### PR TITLE
feat(providers): add Gradium STT and TTS

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,8 @@ ASSEMBLYAI_API_KEY=
 SPEECHMATICS_API_KEY=
 HUME_API_KEY=
 RIME_API_KEY=
+GRADIUM_API_KEY=
+GRADIUM_TTS_API_KEY=
 
 # --- Google STT (optional; requires the `google-stt` extra) ---
 # GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json

--- a/runner/src/coval_bench/config.py
+++ b/runner/src/coval_bench/config.py
@@ -53,6 +53,8 @@ class Settings(BaseSettings):
     speechmatics_api_key: SecretStr | None = None
     hume_api_key: SecretStr | None = None
     rime_api_key: SecretStr | None = None
+    gradium_api_key: SecretStr | None = None
+    gradium_tts_api_key: SecretStr | None = None
 
     # Path to a Google service-account JSON file mounted as a Secret-as-volume.
     google_application_credentials: Path | None = None

--- a/runner/src/coval_bench/providers/stt/__init__.py
+++ b/runner/src/coval_bench/providers/stt/__init__.py
@@ -18,6 +18,7 @@ from coval_bench.providers.base import STTProvider
 from coval_bench.providers.stt.assemblyai import AssemblyAIProvider
 from coval_bench.providers.stt.deepgram import DeepgramProvider
 from coval_bench.providers.stt.elevenlabs import ElevenLabsSTTProvider
+from coval_bench.providers.stt.gradium import GradiumSTTProvider
 from coval_bench.providers.stt.speechmatics import SpeechmaticsProvider
 
 # Google is optional — gated on the ``google-stt`` extra
@@ -33,6 +34,7 @@ STT_PROVIDERS: dict[str, type[STTProvider]] = {
     "deepgram": DeepgramProvider,
     "assemblyai": AssemblyAIProvider,
     "elevenlabs": ElevenLabsSTTProvider,
+    "gradium": GradiumSTTProvider,
     "speechmatics": SpeechmaticsProvider,
 }
 
@@ -45,6 +47,7 @@ __all__ = [
     "DeepgramProvider",
     "AssemblyAIProvider",
     "ElevenLabsSTTProvider",
+    "GradiumSTTProvider",
     "SpeechmaticsProvider",
     "GoogleSTTProvider",
 ]

--- a/runner/src/coval_bench/providers/stt/gradium.py
+++ b/runner/src/coval_bench/providers/stt/gradium.py
@@ -1,0 +1,164 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Gradium real-time STT provider.
+
+Supports models: default
+Wire protocol: WebSocket, wss://api.gradium.ai/api/speech/asr
+Auth: x-api-key: <key>
+Setup: {"type":"setup","model_name":"default","input_format":"pcm"}
+Audio: {"type":"audio","audio":"<base64-encoded PCM>"}
+Close: {"type":"end_of_stream"}
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import time
+from typing import Any
+
+import structlog
+import websockets.asyncio.client as ws_client
+from pydantic import SecretStr
+
+from coval_bench.providers.base import STTProvider, TranscriptionResult
+
+logger = structlog.get_logger(__name__)
+
+_VALID_MODELS = ("default",)
+_WS_URL = "wss://api.gradium.ai/api/speech/asr"
+
+
+class GradiumSTTProvider(STTProvider):
+    """Gradium streaming STT provider."""
+
+    def __init__(self, api_key: SecretStr, model: str = "default") -> None:
+        if model not in _VALID_MODELS:
+            raise ValueError(f"Invalid Gradium STT model {model!r}. Valid: {_VALID_MODELS}")
+        self._api_key = api_key
+        self._model = model
+
+    @property
+    def name(self) -> str:
+        return "gradium"
+
+    @property
+    def model(self) -> str:
+        return self._model
+
+    async def measure_ttft(
+        self,
+        audio_data: bytes,
+        channels: int,
+        sample_width: int,
+        sample_rate: int,
+        realtime_resolution: float = 0.1,
+        audio_duration: float | None = None,
+    ) -> TranscriptionResult:
+        result = TranscriptionResult(provider=self.name, vad_events_count=0)
+        total_start = time.monotonic()
+
+        try:
+            headers = {"x-api-key": self._api_key.get_secret_value()}
+
+            async with ws_client.connect(_WS_URL, additional_headers=headers) as ws:
+                await ws.send(
+                    json.dumps({"type": "setup", "model_name": self._model, "input_format": "pcm"})
+                )
+
+                send_task = asyncio.create_task(
+                    self._send_audio(ws, audio_data, sample_rate, result, realtime_resolution)
+                )
+                recv_task = asyncio.create_task(self._receive(ws, result))
+                await asyncio.gather(send_task, recv_task, return_exceptions=True)
+
+        except Exception as exc:
+            logger.exception("gradium measure_ttft failed", error=str(exc))
+            result.error = str(exc)
+
+        result.total_time = time.monotonic() - total_start
+        return result
+
+    async def _send_audio(
+        self,
+        ws: Any,
+        audio_data: bytes,
+        sample_rate: int,
+        result: TranscriptionResult,
+        realtime_resolution: float,
+    ) -> None:
+        bytes_per_second = sample_rate * 2  # 16-bit mono
+        chunk_size = int(bytes_per_second * realtime_resolution)
+        result.audio_start_time = time.monotonic()
+        try:
+            for i in range(0, len(audio_data), chunk_size):
+                chunk = audio_data[i : i + chunk_size]
+                b64 = base64.b64encode(chunk).decode("utf-8")
+                await ws.send(json.dumps({"type": "audio", "audio": b64}))
+                await asyncio.sleep(realtime_resolution)
+            await ws.send(json.dumps({"type": "end_of_stream"}))
+        except Exception as exc:
+            logger.exception("gradium send error", error=str(exc))
+            raise
+
+    async def _receive(self, ws: Any, result: TranscriptionResult) -> None:
+        final_parts: list[str] = []
+
+        try:
+            async for raw in ws:
+                if isinstance(raw, bytes):
+                    continue
+
+                msg: dict[str, Any] = json.loads(raw)
+                now = time.monotonic()
+                msg_type: str = msg.get("type", "")
+
+                if msg_type == "step":
+                    # VAD horizon predictions
+                    result.vad_events_count = (result.vad_events_count or 0) + 1
+                    if result.vad_first_detected is None and result.audio_start_time is not None:
+                        result.vad_first_detected = now - result.audio_start_time
+                        result.vad_first_event_content = str(msg)
+                    continue
+
+                if msg_type == "text":
+                    transcript = str(msg.get("text", "")).strip()
+                    if not transcript:
+                        continue
+                    if result.ttft_seconds is None and result.audio_start_time is not None:
+                        result.ttft_seconds = now - result.audio_start_time
+                        result.first_token_content = (
+                            transcript[:30] + "..." if len(transcript) > 30 else transcript
+                        )
+                    result.partial_transcripts.append(transcript)
+                    continue
+
+                if msg_type == "end_text":
+                    transcript = str(msg.get("text", "")).strip()
+                    if transcript:
+                        final_parts.append(transcript)
+                        if result.audio_start_time is not None:
+                            result.audio_to_final_seconds = now - result.audio_start_time
+                    continue
+
+                if msg_type == "end_of_stream":
+                    break
+
+                if msg_type == "error":
+                    result.error = str(msg.get("message", msg))
+                    logger.error("gradium stt error", msg=msg)
+                    break
+
+        except Exception as exc:
+            logger.exception("gradium receive error", error=str(exc))
+
+        if final_parts:
+            result.complete_transcript = " ".join(final_parts).strip() or None
+        elif result.partial_transcripts:
+            result.complete_transcript = result.partial_transcripts[-1].strip() or None
+
+        if result.complete_transcript:
+            result.transcript_length = len(result.complete_transcript)
+            result.word_count = len(result.complete_transcript.split())

--- a/runner/src/coval_bench/providers/tts/__init__.py
+++ b/runner/src/coval_bench/providers/tts/__init__.py
@@ -18,6 +18,7 @@ from coval_bench.providers.base import TTSProvider
 from coval_bench.providers.tts.cartesia import CartesiaTTSProvider
 from coval_bench.providers.tts.deepgram import DeepgramTTSProvider
 from coval_bench.providers.tts.elevenlabs import ElevenLabsTTSProvider
+from coval_bench.providers.tts.gradium import GradiumTTSProvider
 from coval_bench.providers.tts.openai import OpenAITTSProvider
 from coval_bench.providers.tts.rime import RimeTTSProvider
 
@@ -33,6 +34,7 @@ TTS_PROVIDERS: dict[str, type[TTSProvider]] = {
     "openai": OpenAITTSProvider,
     "cartesia": CartesiaTTSProvider,
     "elevenlabs": ElevenLabsTTSProvider,
+    "gradium": GradiumTTSProvider,
     "deepgram": DeepgramTTSProvider,
     "rime": RimeTTSProvider,
 }
@@ -40,4 +42,4 @@ TTS_PROVIDERS: dict[str, type[TTSProvider]] = {
 if HumeTTSProvider is not None:
     TTS_PROVIDERS["hume"] = HumeTTSProvider
 
-__all__ = ["TTS_PROVIDERS", "HUME_AVAILABLE"]
+__all__ = ["TTS_PROVIDERS", "HUME_AVAILABLE", "GradiumTTSProvider"]

--- a/runner/src/coval_bench/providers/tts/gradium.py
+++ b/runner/src/coval_bench/providers/tts/gradium.py
@@ -1,0 +1,146 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Gradium TTS provider — WebSocket streaming.
+
+Wire protocol: WebSocket, wss://api.gradium.ai/api/speech/tts
+Auth: x-api-key: <key>
+Setup: {"type":"setup","voice_id":"...","model_name":"default","output_format":"pcm"}
+Text:  {"type":"text","text":"..."}
+Close: {"type":"end_of_stream"}
+Audio: server sends {"type":"audio","audio":"<base64 PCM>"} chunks
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import os
+import tempfile
+import time
+import wave
+from pathlib import Path
+from typing import Any
+
+import structlog
+import websockets.asyncio.client as ws_client
+
+from coval_bench.config import Settings
+from coval_bench.providers.base import TTSProvider, TTSResult
+
+logger: structlog.BoundLogger = structlog.get_logger(__name__)
+
+_VALID_MODELS = ("default",)
+_WS_URL = "wss://api.gradium.ai/api/speech/tts"
+_SAMPLE_RATE = 24000
+
+class GradiumTTSProvider(TTSProvider):
+    """Gradium TTS provider using WebSocket streaming."""
+
+    def __init__(self, settings: Settings, model: str, voice: str) -> None:
+        if model not in _VALID_MODELS:
+            raise ValueError(f"Invalid Gradium TTS model {model!r}. Valid: {_VALID_MODELS}")
+        self._model = model
+        self._voice = voice
+
+        api_key_secret = settings.gradium_tts_api_key
+        if api_key_secret is None:
+            raise ValueError("gradium_tts_api_key is required in Settings")
+        self._api_key = api_key_secret.get_secret_value()
+
+    @property
+    def name(self) -> str:
+        return "gradium"
+
+    @property
+    def model(self) -> str:
+        return self._model
+
+    async def synthesize(self, text: str) -> TTSResult:
+        audio_chunks: list[bytes] = []
+        ttfa_ms: float | None = None
+
+        try:
+            headers = {"x-api-key": self._api_key}
+
+            async with ws_client.connect(_WS_URL, additional_headers=headers) as ws:
+                await ws.send(
+                    json.dumps(
+                        {
+                            "type": "setup",
+                            "voice_id": self._voice,
+                            "model_name": self._model,
+                            "output_format": "pcm",
+                        }
+                    )
+                )
+
+                # Wait for ready
+                raw = await asyncio.wait_for(ws.recv(), timeout=5.0)
+                msg: dict[str, Any] = json.loads(raw)
+                if msg.get("type") != "ready":
+                    logger.warning("gradium unexpected first message", msg=msg)
+
+                start = time.monotonic()
+                await ws.send(json.dumps({"type": "text", "text": text}))
+                await ws.send(json.dumps({"type": "end_of_stream"}))
+
+                async for raw in ws:
+                    if isinstance(raw, bytes):
+                        continue
+                    msg = json.loads(raw)
+                    msg_type: str = msg.get("type", "")
+
+                    if msg_type == "audio":
+                        audio_b64: str = msg.get("audio", "")
+                        if audio_b64:
+                            chunk = base64.b64decode(audio_b64)
+                            if chunk:
+                                if ttfa_ms is None:
+                                    ttfa_ms = (time.monotonic() - start) * 1000
+                                    logger.debug(
+                                        "gradium_ttfa",
+                                        model=self._model,
+                                        ttfa_ms=ttfa_ms,
+                                    )
+                                audio_chunks.append(chunk)
+
+                    elif msg_type == "end_of_stream":
+                        break
+
+                    elif msg_type == "error":
+                        raise RuntimeError(str(msg.get("message", msg)))
+
+        except Exception as exc:
+            logger.debug("gradium_tts_error", exc_info=True)
+            return TTSResult(
+                provider="gradium",
+                model=self._model,
+                voice=self._voice,
+                ttfa_ms=ttfa_ms,
+                audio_path=None,
+                error=str(exc),
+            )
+
+        audio_path = _write_wav(audio_chunks, _SAMPLE_RATE) if audio_chunks else None
+        return TTSResult(
+            provider="gradium",
+            model=self._model,
+            voice=self._voice,
+            ttfa_ms=ttfa_ms,
+            audio_path=audio_path,
+            error=None,
+        )
+
+
+def _write_wav(chunks: list[bytes], sample_rate: int) -> Path:
+    fd, tmp_name = tempfile.mkstemp(suffix=".wav")
+    os.close(fd)
+    audio_data = b"".join(chunks)
+    with wave.open(tmp_name, "wb") as wav_file:
+        wav_file.setnchannels(1)
+        wav_file.setsampwidth(2)
+        wav_file.setframerate(sample_rate)
+        wav_file.writeframes(audio_data)
+    return Path(tmp_name)

--- a/runner/src/coval_bench/providers/tts/gradium.py
+++ b/runner/src/coval_bench/providers/tts/gradium.py
@@ -35,6 +35,7 @@ _VALID_MODELS = ("default",)
 _WS_URL = "wss://api.gradium.ai/api/speech/tts"
 _SAMPLE_RATE = 24000
 
+
 class GradiumTTSProvider(TTSProvider):
     """Gradium TTS provider using WebSocket streaming."""
 

--- a/runner/src/coval_bench/runner/config.py
+++ b/runner/src/coval_bench/runner/config.py
@@ -38,6 +38,7 @@ DEFAULT_STT_MATRIX: list[ProviderEntry] = [
     ProviderEntry(provider="assemblyai", model="universal-streaming", enabled=True),
     ProviderEntry(provider="speechmatics", model="default", enabled=True),
     ProviderEntry(provider="speechmatics", model="enhanced", enabled=True),
+    ProviderEntry(provider="gradium", model="default", enabled=True),
     # OFF; disabled=True hides these from the public catalogue.
     ProviderEntry(provider="google", model="short", enabled=False, disabled=True),
     ProviderEntry(provider="google", model="long", enabled=False, disabled=True),
@@ -95,6 +96,13 @@ DEFAULT_TTS_MATRIX: list[ProviderEntry] = [
         provider="deepgram",
         model="aura-2-thalia-en",
         voice="aura-2-thalia-en",
+        enabled=True,
+    ),
+    # Gradium — added 2026-05-03: WebSocket streaming, Emma voice (American English).
+    ProviderEntry(
+        provider="gradium",
+        model="default",
+        voice="YTpq7expH9539ERJ",
         enabled=True,
     ),
     # Rime — re-activated 2026-04-30: arcana (resolves to Arcana v3 server-side


### PR DESCRIPTION
Adds Gradium as a new provider for both STT and TTS benchmarks.

- **STT**: WebSocket (`wss://api.gradium.ai/api/speech/asr`), `x-api-key` auth, model `default`, enabled in matrix
- **TTS**: WebSocket (`wss://api.gradium.ai/api/speech/tts`), `x-api-key` auth, model `default`, Emma voice (`YTpq7expH9539ERJ`), enabled in matrix

Keys stored locally in `.env` and in GCP Secret Manager (`benchmarks-gradium-stt-api-key`, `benchmarks-gradium-tts-api-key`). Infra wiring in companion PR: coval-ai/benchmark-infra.

Docs: https://docs.gradium.ai/guides/speech-to-text-overview · https://docs.gradium.ai/guides/text-to-speech-overview

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Gradium as a new speech-to-text provider for real-time transcription.
  * Added Gradium as a new text-to-speech provider for voice synthesis.

* **Chores**
  * Added optional Gradium API key entries to the example environment configuration.
  * Enabled Gradium in the default STT and TTS provider configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->