### PR TITLE
Fix the input-format and language for the Gradium STT setup message.

### DIFF
--- a/runner/src/coval_bench/providers/stt/gradium.py
+++ b/runner/src/coval_bench/providers/stt/gradium.py
@@ -6,7 +6,8 @@
 Supports models: default
 Wire protocol: WebSocket, wss://api.gradium.ai/api/speech/asr
 Auth: x-api-key: <key>
-Setup: {"type":"setup","model_name":"default","input_format":"pcm_16000","json_config":"{\"language\": \"en\"}"}
+Setup: {"type":"setup","model_name":"default","input_format":"pcm_16000",
+        "json_config":"{\"language\": \"en\"}"}
 Audio: {"type":"audio","audio":"<base64-encoded PCM>"}
 Flush: {"type":"flush","flush_id":1}  -- forces buffered results to emit
 Close: {"type":"end_of_stream"}

--- a/runner/src/coval_bench/providers/stt/gradium.py
+++ b/runner/src/coval_bench/providers/stt/gradium.py
@@ -64,6 +64,9 @@ class GradiumSTTProvider(STTProvider):
         realtime_resolution: float = 0.1,
         audio_duration: float | None = None,
     ) -> TranscriptionResult:
+        if sample_rate != 16000:
+            raise ValueError(f"Gradium requires 16 kHz PCM input; got {sample_rate} Hz")
+
         result = TranscriptionResult(provider=self.name, vad_events_count=0)
         total_start = time.monotonic()
 

--- a/runner/src/coval_bench/providers/stt/gradium.py
+++ b/runner/src/coval_bench/providers/stt/gradium.py
@@ -6,7 +6,7 @@
 Supports models: default
 Wire protocol: WebSocket, wss://api.gradium.ai/api/speech/asr
 Auth: x-api-key: <key>
-Setup: {"type":"setup","model_name":"default","input_format":"pcm"}
+Setup: {"type":"setup","model_name":"default","input_format":"pcm_16000","json_config":"{\"language\": \"en\"}"}
 Audio: {"type":"audio","audio":"<base64-encoded PCM>"}
 Flush: {"type":"flush","flush_id":1}  -- forces buffered results to emit
 Close: {"type":"end_of_stream"}
@@ -72,7 +72,14 @@ class GradiumSTTProvider(STTProvider):
 
             async with ws_client.connect(_WS_URL, additional_headers=headers) as ws:
                 await ws.send(
-                    json.dumps({"type": "setup", "model_name": self._model, "input_format": "pcm"})
+                    json.dumps(
+                        {
+                            "type": "setup",
+                            "model_name": self._model,
+                            "input_format": "pcm_16000",
+                            "json_config": json.dumps({"language": "en"}),
+                        }
+                    )
                 )
 
                 send_task = asyncio.create_task(


### PR DESCRIPTION
This PR fixes two issues with the Gradium speech-to-text provider.
- The `pcm` input format expects 24khz pcm audio. However it seems that the benchmarking code uses 16khz so I switched it to `pcm_16000` to get things in line.
- The `language=en` part lets the speech-to-text know about the language which improves its performance.
I've tested it on some sample file and can confirm that we receive the audio at the proper sampling rate on our api after this change.
Let me know if you want me to do any tweaks to this PR (or feel free to do them).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Gradium speech-to-text provider configuration to properly specify PCM 16000 Hz audio format and include language settings in the setup process, ensuring correct audio stream handling and transcription accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->