### PR TITLE
[BENCH-143] Bucket benchmark chart timestamps to 30 min

### DIFF
--- a/web/components/charts/tooltips/GapTooltip.tsx
+++ b/web/components/charts/tooltips/GapTooltip.tsx
@@ -4,7 +4,7 @@
 import React from "react";
 import { BenchmarkData } from "@/types/benchmark.types";
 import { formatTimeWithSeconds } from "@/lib/utils/formatters";
-import { to15MinuteBucket } from "@/lib/utils/time";
+import { to30MinuteBucket } from "@/lib/utils/time";
 
 interface GapTooltipProps {
   active?: boolean;
@@ -68,7 +68,7 @@ const CustomGapTooltip: React.FC<GapTooltipProps> = ({ active, payload, label, g
               (d) =>
                 d.model === modelName &&
                 d.metric_type === "TTFT" &&
-                to15MinuteBucket(new Date(d.timestamp).getTime()) === labelTimestamp
+                to30MinuteBucket(new Date(d.timestamp).getTime()) === labelTimestamp
             )
             .sort(
               (a, b) =>

--- a/web/hooks/useChartData.ts
+++ b/web/hooks/useChartData.ts
@@ -23,7 +23,7 @@ import {
 } from "@/lib/utils/statistics";
 import { normalizeModelName, normalizeSTTProviderName, normalizeTTSProviderName } from "@/lib/utils/formatters";
 import { TWENTY_FOUR_HOURS_MS } from "@/lib/config/constants";
-import { to15MinuteBucket } from "@/lib/utils/time";
+import { to30MinuteBucket } from "@/lib/utils/time";
 
 // Parent-run statuses that should contribute to chart aggregates. Mirrors the
 // filter used in `lib/aggregates.ts` — keep in sync. The result-row status is
@@ -128,7 +128,7 @@ export function useChartData({
           INCLUDED_STATUSES.has(item.status)
       )
       .map((item) => ({
-        timestamp: to15MinuteBucket(new Date(item.timestamp).getTime()),
+        timestamp: to30MinuteBucket(new Date(item.timestamp).getTime()),
         value:
           activeTab === "tts"
             ? item.metric_value ?? 0
@@ -363,7 +363,7 @@ export function useChartData({
           item.metric_value !== undefined
       )
       .map((item) => ({
-        timestamp: to15MinuteBucket(new Date(item.timestamp).getTime()),
+        timestamp: to30MinuteBucket(new Date(item.timestamp).getTime()),
         value: (item.metric_value as number) * 1000,
         model: item.model,
         benchmark: item.benchmark
@@ -456,7 +456,7 @@ export function useChartData({
       if (!INCLUDED_STATUSES.has(item.status)) return;
       if (item.metric_value === null || item.metric_value === undefined) return;
 
-      const timestamp = to15MinuteBucket(new Date(item.timestamp).getTime());
+      const timestamp = to30MinuteBucket(new Date(item.timestamp).getTime());
       if (!timestampGroups[timestamp]) {
         timestampGroups[timestamp] = {};
       }

--- a/web/lib/config/constants.ts
+++ b/web/lib/config/constants.ts
@@ -3,4 +3,4 @@
 
 export const THREE_HOURS_MS = 3 * 60 * 60 * 1000;
 export const TWENTY_FOUR_HOURS_MS = 24 * 60 * 60 * 1000;
-export const FIFTEEN_MINUTES_MS = 15 * 60 * 1000;
+export const THIRTY_MINUTES_MS = 30 * 60 * 1000;

--- a/web/lib/utils/time.ts
+++ b/web/lib/utils/time.ts
@@ -1,11 +1,12 @@
 // Copyright 2026 The Coval Benchmarks Authors
 // SPDX-License-Identifier: Apache-2.0
 
-import { FIFTEEN_MINUTES_MS } from "@/lib/config/constants";
+import { THIRTY_MINUTES_MS } from "@/lib/config/constants";
 
 /**
- * Normalize a timestamp to the start of its 15-minute bucket.
+ * Normalize a timestamp to the start of its 30-minute bucket.
+ * Matches the every-30-minute cron cadence so completion-time stays in the trigger bucket.
  */
-export function to15MinuteBucket(timestamp: number): number {
-  return Math.floor(timestamp / FIFTEEN_MINUTES_MS) * FIFTEEN_MINUTES_MS;
+export function to30MinuteBucket(timestamp: number): number {
+  return Math.floor(timestamp / THIRTY_MINUTES_MS) * THIRTY_MINUTES_MS;
 }


### PR DESCRIPTION
## Summary
- Widens the chart's client-side timestamp bucket from 15 min → 30 min to match the `*/30` cron cadence.
- Fixes the spurious `:45` (or `:15`) ticks that appeared for 1-2 slower providers per run, caused by completion-time crossing the 15-min boundary of the trigger time.
- Renames `to15MinuteBucket` → `to30MinuteBucket` and `FIFTEEN_MINUTES_MS` → `THIRTY_MINUTES_MS` so the name matches the behavior.

## Why this is safe
Cloud Run Job timeout is 20 min (`benchmark-infra/modules/cloud_run_job/variables.tf:61`), which is < 30 min, so completion-time always lands in the same 30-min bucket as the trigger.

## Followup
[BENCH-142](https://linear.app/coval/issue/BENCH-142) — proper fix is to tag rows with `scheduled_at` at write time so the frontend doesn't need to bucket at all (removes the implicit "duration < bucket size" invariant).

## Test plan
- [ ] `cd web && npx tsc --noEmit` clean (verified locally)
- [ ] Lint / Test / Build CI passes
- [ ] Vercel preview: confirm the chart shows ticks only at `:00` and `:30` for the last 24h, including the 9:45 AM PDT window where extra ticks were observed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated time-based data bucketing from 15-minute to 30-minute intervals across all charts and tooltips.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->