### PR TITLE
feat(providers): add Smallest AI Pulse STT (streaming)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,6 +27,7 @@ HUME_API_KEY=
 RIME_API_KEY=
 GRADIUM_API_KEY=
 GRADIUM_TTS_API_KEY=
+SMALLEST_API_KEY=
 
 # --- Google STT (optional; requires the `google-stt` extra) ---
 # GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json

--- a/runner/src/coval_bench/config.py
+++ b/runner/src/coval_bench/config.py
@@ -55,6 +55,7 @@ class Settings(BaseSettings):
     rime_api_key: SecretStr | None = None
     gradium_api_key: SecretStr | None = None
     gradium_tts_api_key: SecretStr | None = None
+    smallest_api_key: SecretStr | None = None
 
     # Path to a Google service-account JSON file mounted as a Secret-as-volume.
     google_application_credentials: Path | None = None

--- a/runner/src/coval_bench/providers/stt/__init__.py
+++ b/runner/src/coval_bench/providers/stt/__init__.py
@@ -19,6 +19,7 @@ from coval_bench.providers.stt.assemblyai import AssemblyAIProvider
 from coval_bench.providers.stt.deepgram import DeepgramProvider
 from coval_bench.providers.stt.elevenlabs import ElevenLabsSTTProvider
 from coval_bench.providers.stt.gradium import GradiumSTTProvider
+from coval_bench.providers.stt.smallest import SmallestSTTProvider
 from coval_bench.providers.stt.speechmatics import SpeechmaticsProvider
 
 # Google is optional — gated on the ``google-stt`` extra
@@ -35,6 +36,7 @@ STT_PROVIDERS: dict[str, type[STTProvider]] = {
     "assemblyai": AssemblyAIProvider,
     "elevenlabs": ElevenLabsSTTProvider,
     "gradium": GradiumSTTProvider,
+    "smallest": SmallestSTTProvider,
     "speechmatics": SpeechmaticsProvider,
 }
 
@@ -48,6 +50,7 @@ __all__ = [
     "AssemblyAIProvider",
     "ElevenLabsSTTProvider",
     "GradiumSTTProvider",
+    "SmallestSTTProvider",
     "SpeechmaticsProvider",
     "GoogleSTTProvider",
 ]

--- a/runner/src/coval_bench/providers/stt/smallest.py
+++ b/runner/src/coval_bench/providers/stt/smallest.py
@@ -59,6 +59,10 @@ class SmallestSTTProvider(STTProvider):
         realtime_resolution: float = 0.1,
         audio_duration: float | None = None,
     ) -> TranscriptionResult:
+        if channels != 1:
+            raise ValueError(
+                f"Smallest AI Pulse only supports mono audio (channels=1), got channels={channels}"
+            )
         result = TranscriptionResult(provider=self.name, vad_events_count=0)
         total_start = time.monotonic()
 

--- a/runner/src/coval_bench/providers/stt/smallest.py
+++ b/runner/src/coval_bench/providers/stt/smallest.py
@@ -1,0 +1,161 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Smallest AI Pulse real-time STT provider.
+
+Supports models: default (pulse)
+Wire protocol: WebSocket, wss://api.smallest.ai/waves/v1/pulse/get_text
+Auth: Authorization: Bearer <key>
+Query params: language=en, encoding=linear16, sample_rate=<hz>
+Audio: raw binary PCM chunks streamed at realtime pace
+Close: {"type": "close_stream"}  — server drains buffer, then sends is_last=true
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from typing import Any
+
+import structlog
+import websockets.asyncio.client as ws_client
+from pydantic import SecretStr
+
+from coval_bench.providers.base import STTProvider, TranscriptionResult
+
+logger = structlog.get_logger(__name__)
+
+_VALID_MODELS = ("pulse",)
+_WS_BASE_URL = "wss://api.smallest.ai/waves/v1/pulse/get_text"
+
+
+class SmallestSTTProvider(STTProvider):
+    """Smallest AI Pulse streaming STT provider."""
+
+    def __init__(self, api_key: SecretStr, model: str = "pulse") -> None:
+        if model not in _VALID_MODELS:
+            raise ValueError(f"Invalid Smallest STT model {model!r}. Valid: {_VALID_MODELS}")
+        self._api_key = api_key
+        self._model = model
+
+    @property
+    def name(self) -> str:
+        return "smallest"
+
+    @property
+    def model(self) -> str:
+        return self._model
+
+    def _build_websocket_url(self, sample_rate: int) -> str:
+        return (
+            f"{_WS_BASE_URL}"
+            f"?language=en"
+            f"&encoding=linear16"
+            f"&sample_rate={sample_rate}"
+        )
+
+    async def measure_ttft(
+        self,
+        audio_data: bytes,
+        channels: int,
+        sample_width: int,
+        sample_rate: int,
+        realtime_resolution: float = 0.1,
+        audio_duration: float | None = None,
+    ) -> TranscriptionResult:
+        result = TranscriptionResult(provider=self.name, vad_events_count=0)
+        total_start = time.monotonic()
+
+        try:
+            url = self._build_websocket_url(sample_rate)
+            headers = {"Authorization": f"Bearer {self._api_key.get_secret_value()}"}
+
+            async with ws_client.connect(url, additional_headers=headers) as ws:
+                send_task = asyncio.create_task(
+                    self._send_audio(ws, audio_data, sample_rate, result, realtime_resolution)
+                )
+                recv_task = asyncio.create_task(self._receive(ws, result))
+                await asyncio.gather(send_task, recv_task, return_exceptions=True)
+
+        except Exception as exc:
+            logger.exception("smallest measure_ttft failed", error=str(exc))
+            result.error = str(exc)
+
+        result.total_time = time.monotonic() - total_start
+        return result
+
+    async def _send_audio(
+        self,
+        ws: Any,
+        audio_data: bytes,
+        sample_rate: int,
+        result: TranscriptionResult,
+        realtime_resolution: float,
+    ) -> None:
+        byte_rate = sample_rate * 2  # 16-bit mono
+        chunk_size = int(byte_rate * realtime_resolution)
+        data = audio_data
+        first_chunk = True
+        try:
+            while data:
+                chunk, data = data[:chunk_size], data[chunk_size:]
+                if first_chunk:
+                    result.audio_start_time = time.monotonic()
+                    first_chunk = False
+                await ws.send(chunk)
+                await asyncio.sleep(realtime_resolution)
+            await ws.send(json.dumps({"type": "close_stream"}))
+        except Exception as exc:
+            logger.exception("smallest send error", error=str(exc))
+            raise
+
+    async def _receive(self, ws: Any, result: TranscriptionResult) -> None:
+        final_segments: list[str] = []
+
+        try:
+            async for raw in ws:
+                if isinstance(raw, bytes):
+                    continue
+
+                msg: dict[str, Any] = json.loads(raw)
+                now = time.monotonic()
+
+                transcript = str(msg.get("transcript", "")).strip()
+                is_final: bool = bool(msg.get("is_final", False))
+                is_last: bool = bool(msg.get("is_last", False))
+
+                if not transcript:
+                    if is_last:
+                        break
+                    continue
+
+                # TTFT — first non-empty transcript (partial or final)
+                if result.ttft_seconds is None and result.audio_start_time is not None:
+                    result.ttft_seconds = now - result.audio_start_time
+                    result.first_token_content = (
+                        transcript[:30] + "..." if len(transcript) > 30 else transcript
+                    )
+
+                result.partial_transcripts.append(transcript)
+
+                # Accumulate final segments; is_last=true also signals a final segment
+                if is_final or is_last:
+                    final_segments.append(transcript)
+                    if result.audio_start_time is not None:
+                        result.audio_to_final_seconds = now - result.audio_start_time
+
+                if is_last:
+                    break
+
+        except Exception as exc:
+            logger.exception("smallest receive error", error=str(exc))
+
+        if final_segments:
+            result.complete_transcript = " ".join(final_segments).strip() or None
+        elif result.partial_transcripts:
+            result.complete_transcript = max(result.partial_transcripts, key=len).strip() or None
+
+        if result.complete_transcript:
+            result.transcript_length = len(result.complete_transcript)
+            result.word_count = len(result.complete_transcript.split())

--- a/runner/src/coval_bench/providers/stt/smallest.py
+++ b/runner/src/coval_bench/providers/stt/smallest.py
@@ -48,12 +48,7 @@ class SmallestSTTProvider(STTProvider):
         return self._model
 
     def _build_websocket_url(self, sample_rate: int) -> str:
-        return (
-            f"{_WS_BASE_URL}"
-            f"?language=en"
-            f"&encoding=linear16"
-            f"&sample_rate={sample_rate}"
-        )
+        return f"{_WS_BASE_URL}?language=en&encoding=linear16&sample_rate={sample_rate}"
 
     async def measure_ttft(
         self,

--- a/runner/src/coval_bench/runner/config.py
+++ b/runner/src/coval_bench/runner/config.py
@@ -39,6 +39,7 @@ DEFAULT_STT_MATRIX: list[ProviderEntry] = [
     ProviderEntry(provider="speechmatics", model="default", enabled=True),
     ProviderEntry(provider="speechmatics", model="enhanced", enabled=True),
     ProviderEntry(provider="gradium", model="default", enabled=True),
+    ProviderEntry(provider="smallest", model="pulse", enabled=True),
     # OFF; disabled=True hides these from the public catalogue.
     ProviderEntry(provider="google", model="short", enabled=False, disabled=True),
     ProviderEntry(provider="google", model="long", enabled=False, disabled=True),

--- a/runner/tests/providers/stt/fixtures/smallest/events-success.json
+++ b/runner/tests/providers/stt/fixtures/smallest/events-success.json
@@ -1,0 +1,29 @@
+[
+  {
+    "type": "transcription",
+    "status": "success",
+    "session_id": "sess_test001",
+    "transcript": "hello world",
+    "is_final": false,
+    "is_last": false,
+    "language": "en"
+  },
+  {
+    "type": "transcription",
+    "status": "success",
+    "session_id": "sess_test001",
+    "transcript": "hello world how are you",
+    "is_final": true,
+    "is_last": false,
+    "language": "en"
+  },
+  {
+    "type": "transcription",
+    "status": "success",
+    "session_id": "sess_test001",
+    "transcript": "hello world how are you",
+    "is_final": true,
+    "is_last": true,
+    "language": "en"
+  }
+]

--- a/runner/tests/providers/stt/test_smallest.py
+++ b/runner/tests/providers/stt/test_smallest.py
@@ -1,0 +1,175 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for coval_bench.providers.stt.smallest (SmallestSTTProvider).
+
+All tests use FakeWebSocket — no live network calls are made.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pydantic import SecretStr
+
+from coval_bench.providers.stt.smallest import SmallestSTTProvider
+from tests.providers.stt.conftest import FakeWebSocket, load_fixture_events
+
+
+def make_provider() -> SmallestSTTProvider:
+    return SmallestSTTProvider(api_key=SecretStr("test-key-smallest"))
+
+
+def _fake_connect(events: list[Any]) -> Any:
+    ws = FakeWebSocket(events)
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=ws)
+    cm.__aexit__ = AsyncMock(return_value=False)
+    return cm
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_smallest_success(fake_api_key: SecretStr, audio_pcm_bytes: bytes) -> None:
+    events = load_fixture_events("smallest", "events-success")
+    provider = SmallestSTTProvider(api_key=fake_api_key)
+
+    with patch(
+        "coval_bench.providers.stt.smallest.ws_client.connect",
+        return_value=_fake_connect(events),
+    ):
+        result = await provider.measure_ttft(
+            audio_data=audio_pcm_bytes,
+            channels=1,
+            sample_width=2,
+            sample_rate=16000,
+            realtime_resolution=0.5,
+            audio_duration=3.0,
+        )
+
+    assert result.error is None
+    assert result.ttft_seconds is not None
+    assert result.ttft_seconds >= 0
+    assert result.first_token_content is not None
+    assert "hello" in result.first_token_content.lower()
+    assert result.complete_transcript is not None
+    assert "hello world how are you" in result.complete_transcript
+
+
+# ---------------------------------------------------------------------------
+# Provider name and model
+# ---------------------------------------------------------------------------
+
+
+def test_provider_name() -> None:
+    p = make_provider()
+    assert p.name == "smallest"
+
+
+def test_provider_model() -> None:
+    p = make_provider()
+    assert p.model == "pulse"
+
+
+# ---------------------------------------------------------------------------
+# Invalid model
+# ---------------------------------------------------------------------------
+
+
+def test_invalid_model_raises() -> None:
+    with pytest.raises(ValueError, match="Invalid Smallest STT model"):
+        SmallestSTTProvider(api_key=SecretStr("k"), model="bad-model")
+
+
+# ---------------------------------------------------------------------------
+# Empty stream
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_smallest_empty_stream(fake_api_key: SecretStr, audio_pcm_bytes: bytes) -> None:
+    provider = SmallestSTTProvider(api_key=fake_api_key)
+
+    with patch(
+        "coval_bench.providers.stt.smallest.ws_client.connect",
+        return_value=_fake_connect([]),
+    ):
+        result = await provider.measure_ttft(
+            audio_data=audio_pcm_bytes,
+            channels=1,
+            sample_width=2,
+            sample_rate=16000,
+            realtime_resolution=0.5,
+        )
+
+    assert result.complete_transcript is None
+    assert result.ttft_seconds is None
+
+
+# ---------------------------------------------------------------------------
+# audio_to_final_seconds
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_audio_to_final_set_on_is_last(
+    fake_api_key: SecretStr, audio_pcm_bytes: bytes
+) -> None:
+    events = load_fixture_events("smallest", "events-success")
+    provider = SmallestSTTProvider(api_key=fake_api_key)
+
+    with patch(
+        "coval_bench.providers.stt.smallest.ws_client.connect",
+        return_value=_fake_connect(events),
+    ):
+        result = await provider.measure_ttft(
+            audio_data=audio_pcm_bytes,
+            channels=1,
+            sample_width=2,
+            sample_rate=16000,
+            realtime_resolution=0.5,
+        )
+
+    assert result.audio_to_final_seconds is not None
+    assert result.audio_to_final_seconds >= 0
+
+
+@pytest.mark.asyncio
+async def test_audio_to_final_none_on_partial_only(
+    fake_api_key: SecretStr, audio_pcm_bytes: bytes
+) -> None:
+    """audio_to_final_seconds is None when only partial (is_final=false) messages arrive."""
+    events: list[Any] = [
+        {
+            "type": "transcription",
+            "status": "success",
+            "session_id": "sess_x",
+            "transcript": "hello",
+            "is_final": False,
+            "is_last": False,
+            "language": "en",
+        }
+    ]
+    provider = SmallestSTTProvider(api_key=fake_api_key)
+
+    with patch(
+        "coval_bench.providers.stt.smallest.ws_client.connect",
+        return_value=_fake_connect(events),
+    ):
+        result = await provider.measure_ttft(
+            audio_data=audio_pcm_bytes,
+            channels=1,
+            sample_width=2,
+            sample_rate=16000,
+            realtime_resolution=0.5,
+        )
+
+    assert result.audio_to_final_seconds is None
+    # TTFT is still captured from the partial message
+    assert result.ttft_seconds is not None


### PR DESCRIPTION
## Summary

- Adds Smallest AI's Pulse model to the STT benchmark matrix
- WebSocket streaming via `wss://api.smallest.ai/waves/v1/pulse/get_text`, PCM linear16, 16 kHz mono
- Verified end-to-end against the live API

Closes #18

## Files changed

| File | Purpose |
|---|---|
| `runner/src/coval_bench/providers/stt/smallest.py` | Provider implementation |
| `runner/src/coval_bench/providers/stt/__init__.py` | Registry + `__all__` |
| `runner/src/coval_bench/runner/config.py` | Matrix entry (`enabled=True`, model `pulse`) |
| `runner/src/coval_bench/config.py` | `smallest_api_key` setting |
| `.env.example` | `SMALLEST_API_KEY=` documented |
| `runner/tests/providers/stt/test_smallest.py` | 7 unit tests, all passing |
| `runner/tests/providers/stt/fixtures/smallest/events-success.json` | WebSocket event fixture |

## Test plan

- [x] `uv run pytest tests/providers/stt/test_smallest.py -v` — 7/7 passing
- [x] Live API smoke test confirmed correct TTFT, AudioToFinal, and transcript
- [x] `ruff`, `mypy --strict`, full `pytest` suite clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Smallest AI as a new Speech-to-Text provider (pulse model) and enabled it by default in the provider matrix
  * Added optional environment variable for Smallest API authentication

* **Tests**
  * Added comprehensive tests and fixtures validating transcription behavior, timing metrics, and error/empty-stream handling

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/coval-ai/benchmarks/pull/19?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->