### PR TITLE
fix(cartesia): WER issue

### DIFF
--- a/runner/src/coval_bench/providers/tts/cartesia.py
+++ b/runner/src/coval_bench/providers/tts/cartesia.py
@@ -69,15 +69,19 @@ class CartesiaTTSProvider(TTSProvider):
                 )
 
                 start = time.monotonic()
-                # `language` MUST be passed on every send() — Cartesia v2 contexts
-                # don't propagate it from the conn.context(...) call. Without this
-                # explicit hint, sonic-3 falls back to multilingual auto-detect
-                # and intermittently hallucinates non-English output (CJK/Arabic/
-                # emoji transcripts), producing WER=100% rows in the benchmark.
+                # Both `output_format` and `language` MUST be passed on every
+                # send() — ctx.send() does NOT inherit them from conn.context().
+                # Omitting output_format causes the SDK to substitute its own
+                # default (pcm_f32le / 44100 Hz), which mismatches the WAV header
+                # written by _write_wav (pcm_s16le / 24000 Hz) and produces
+                # corrupt audio → Whisper hallucination → WER > 100%.
+                # Omitting language causes sonic-3 to auto-detect and intermittently
+                # synthesize non-English audio → WER = 100%.
                 await ctx.send(
                     model_id=self._model,
                     transcript=text,
                     voice=voice_spec,
+                    output_format=OUTPUT_FORMAT,
                     language="en",
                     continue_=False,
                 )

--- a/runner/tests/providers/tts/test_cartesia.py
+++ b/runner/tests/providers/tts/test_cartesia.py
@@ -160,6 +160,42 @@ async def test_cartesia_send_includes_language_en(fake_settings: Settings) -> No
         result.audio_path.unlink()
 
 
+@pytest.mark.asyncio
+async def test_cartesia_send_includes_output_format(fake_settings: Settings) -> None:
+    """Regression: ctx.send() must include output_format matching OUTPUT_FORMAT.
+
+    The Cartesia SDK AsyncWebSocketContext.send() does NOT inherit output_format
+    from conn.context() — ctx._output_format is only used by push(), not send().
+    When output_format is omitted from send(), the SDK substitutes its own default
+    (pcm_f32le / 44100 Hz). _write_wav then stamps the WAV header as pcm_s16le /
+    24000 Hz, producing a corrupt file. Whisper hallucinating on corrupt audio
+    causes WER > 100% in the benchmark.
+    """
+    from coval_bench.providers.tts.cartesia import OUTPUT_FORMAT
+
+    chunks = [make_pcm_bytes(240)]
+    provider = CartesiaTTSProvider(
+        fake_settings, model="sonic-3", voice="f786b574-daa5-4673-aa0c-cbe3e8534c02"
+    )
+    fake_client = make_fake_cartesia_client(chunks)
+
+    with patch("coval_bench.providers.tts.cartesia.AsyncCartesia", return_value=fake_client):
+        result = await provider.synthesize("Hello world")
+
+    assert result.error is None
+    fake_conn = fake_client._fake_conn
+    assert fake_conn.last_context is not None, "conn.context(...) was never called"
+    send_kwargs = fake_conn.last_context.send_kwargs
+    assert send_kwargs is not None, "ctx.send(...) was never called"
+    assert send_kwargs.get("output_format") == OUTPUT_FORMAT, (
+        f"ctx.send must pass output_format=OUTPUT_FORMAT (pcm_s16le/24000) to prevent "
+        f"SDK default (pcm_f32le/44100) corrupting the WAV file, got {send_kwargs!r}"
+    )
+
+    if result.audio_path is not None:
+        result.audio_path.unlink()
+
+
 def test_cartesia_missing_api_key() -> None:
     settings_no_key = Settings(
         database_url="postgresql://runner:password@localhost:5432/benchmarks",  # type: ignore[arg-type]


### PR DESCRIPTION
The Cartesia SDK does not propagate output_format from conn.context() to ctx.send(). When omitted, ctx.send() substitutes its own default (pcm_f32le / 44100 Hz), which mismatches the WAV header written downstream (pcm_s16le / 24000 Hz), producing corrupt audio. Whisper then hallucinated on the corrupt file, causing WER > 100% for sonic-3.

Fix: pass output_format=OUTPUT_FORMAT explicitly on every ctx.send() call, alongside the existing language="en" which has the same propagation issue.

Adds a regression test that asserts both fields are present in ctx.send() kwargs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed Cartesia Text-to-Speech audio streaming to eliminate corrupted audio files and prevent unintended language detection switching. This ensures proper audio output format is consistently applied during voice synthesis operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/coval-ai/benchmarks/pull/20?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->