### PR TITLE
fix(providers/tts): move Deepgram TTS to WebSocket 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,15 @@ coverage.xml
 .DS_Store
 Thumbs.db
 .vercel
+node_modules
+
+# Local knowledge base (never commit)
+insights.md
+
+# Local-only markdown (never commit — use a .local.md suffix)
+**/*.local.md
+
+# Package manager / toolchain caches (local)
+.pnpm-store/
+.uv-cache/
+runner/.uv-cache/

--- a/runner/src/coval_bench/config.py
+++ b/runner/src/coval_bench/config.py
@@ -14,7 +14,7 @@ import functools
 from pathlib import Path
 from typing import Literal
 
-from pydantic import SecretStr
+from pydantic import Field, SecretStr
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -34,7 +34,12 @@ class Settings(BaseSettings):
     # Pydantic's `PostgresDsn` rejects (empty host). psycopg / SQLAlchemy
     # validate the URL at connect time, so the Pydantic-side check would only
     # block the legitimate prod form without catching anything new.
-    database_url: str
+    #
+    # Default placeholder lets provider-only CLIs (e.g. ``coval-bench tts-smoke``) run
+    # without DATABASE_URL. Set DATABASE_URL for ``run``, migrate, API, and Docker Compose.
+    database_url: str = Field(
+        default="postgresql://unused:unused@127.0.0.1:5432/unused",
+    )
 
     # --- Dataset ---
     dataset_bucket: str = "coval-benchmarks-datasets"

--- a/runner/src/coval_bench/providers/tts/deepgram.py
+++ b/runner/src/coval_bench/providers/tts/deepgram.py
@@ -1,18 +1,28 @@
 # Copyright 2026 The Coval Benchmarks Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Deepgram TTS provider — HTTP POST streaming to Deepgram Speak API."""
+"""Deepgram TTS provider — WebSocket streaming to Deepgram Speak API.
+
+Wire protocol (single-utterance benchmark path):
+  connect → recv Metadata → send Speak(text) → send Flush
+  → recv binary PCM frames until Flushed → close
+
+Rate limit: 20 Flush messages per 60 seconds per API key.
+"""
 
 from __future__ import annotations
 
+import asyncio
+import json
 import os
 import tempfile
 import time
 import wave
 from pathlib import Path
+from urllib.parse import urlencode
 
-import aiohttp
 import structlog
+import websockets.asyncio.client as ws_client
 
 from coval_bench.config import Settings
 from coval_bench.providers.base import TTSProvider, TTSResult
@@ -20,11 +30,11 @@ from coval_bench.providers.base import TTSProvider, TTSResult
 logger: structlog.BoundLogger = structlog.get_logger(__name__)
 
 SAMPLE_RATE = 24000
-DEEPGRAM_TTS_URL = "https://api.deepgram.com/v1/speak"
+_DEEPGRAM_TTS_WS_BASE = "wss://api.deepgram.com/v1/speak"
 
 
 class DeepgramTTSProvider(TTSProvider):
-    """Deepgram TTS provider using HTTP streaming (Speak API)."""
+    """Deepgram TTS provider using WebSocket streaming (Speak API)."""
 
     enabled: bool = True
 
@@ -45,53 +55,50 @@ class DeepgramTTSProvider(TTSProvider):
     def model(self) -> str:
         return self._model
 
-    @staticmethod
-    def _is_audio_chunk(chunk: object) -> bool:
-        if isinstance(chunk, bytes) and len(chunk) > 0:
-            return True
-        return bool(hasattr(chunk, "audio") and getattr(chunk, "audio", None)) or bool(
-            hasattr(chunk, "data") and getattr(chunk, "data", None)
-        )
-
     async def synthesize(self, text: str) -> TTSResult:
-        """Synthesize speech via Deepgram HTTP and return a TTSResult."""
+        """Synthesize speech via Deepgram WebSocket and return a TTSResult."""
         audio_chunks: list[bytes] = []
         ttfa_ms: float | None = None
 
-        headers = {
-            "Authorization": f"Token {self._api_key}",
-            "Content-Type": "application/json",
-        }
-        params = {
-            "model": self._model,
-            "encoding": "linear16",
-            "sample_rate": str(SAMPLE_RATE),
-        }
-        payload = {"text": text}
+        qs = urlencode({"encoding": "linear16", "sample_rate": SAMPLE_RATE, "model": self._model})
+        url = f"{_DEEPGRAM_TTS_WS_BASE}?{qs}"
+        headers = {"Authorization": f"Token {self._api_key}"}
 
         try:
-            async with aiohttp.ClientSession() as session:
-                start = time.monotonic()
-                async with session.post(
-                    DEEPGRAM_TTS_URL,
-                    headers=headers,
-                    params=params,
-                    json=payload,
-                ) as response:
-                    if response.status != 200:
-                        error_text = await response.text()
-                        raise ValueError(f"Deepgram HTTP error {response.status}: {error_text}")
+            async with ws_client.connect(url, additional_headers=headers) as ws:
+                # Drain the server-initiated Metadata frame before starting the clock.
+                # Connection is fully established; t0 starts before Flush (synthesis trigger).
+                raw = await asyncio.wait_for(ws.recv(), timeout=5.0)
+                if isinstance(raw, str):
+                    msg = json.loads(raw)
+                    if msg.get("type") == "Warning":
+                        logger.warning("deepgram_ws_warning", description=msg.get("description"))
 
-                    async for chunk in response.content.iter_any():
-                        if self._is_audio_chunk(chunk):
-                            if ttfa_ms is None:
-                                ttfa_ms = (time.monotonic() - start) * 1000
-                                logger.debug(
-                                    "deepgram_ttfa",
-                                    model=self._model,
-                                    ttfa_ms=ttfa_ms,
-                                )
-                            audio_chunks.append(chunk)
+                await ws.send(json.dumps({"type": "Speak", "text": text}))
+
+                # t0 — synthesis trigger (equivalent to the HTTP POST in the old path).
+                # Matches Cartesia's convention: t0 after connect, before text dispatch.
+                start = time.monotonic()
+                await ws.send(json.dumps({"type": "Flush"}))
+
+                async for raw in ws:
+                    if isinstance(raw, bytes):
+                        if ttfa_ms is None:
+                            ttfa_ms = (time.monotonic() - start) * 1000
+                            logger.debug(
+                                "deepgram_ttfa",
+                                model=self._model,
+                                ttfa_ms=ttfa_ms,
+                            )
+                        audio_chunks.append(raw)
+                        continue
+
+                    msg = json.loads(raw)
+                    msg_type = msg.get("type", "")
+                    if msg_type == "Flushed":
+                        break
+                    if msg_type == "Warning":
+                        logger.warning("deepgram_ws_warning", description=msg.get("description"))
 
         except Exception as exc:
             logger.debug("deepgram_error", exc_info=True)

--- a/runner/tests/providers/tts/test_deepgram.py
+++ b/runner/tests/providers/tts/test_deepgram.py
@@ -1,37 +1,47 @@
 # Copyright 2026 The Coval Benchmarks Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Tests for the Deepgram TTS provider."""
+"""Tests for the Deepgram TTS provider — WebSocket Speak API via ``ws_client.connect``."""
 
 from __future__ import annotations
 
-from pathlib import Path
-from unittest.mock import patch
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+from urllib.parse import urlparse
 
 import pytest
 
 from coval_bench.config import Settings
-from coval_bench.providers.tts.deepgram import DeepgramTTSProvider
+from coval_bench.providers.tts.deepgram import SAMPLE_RATE, DeepgramTTSProvider
+from tests.providers.stt.conftest import FakeWebSocket
+from tests.providers.tts.conftest import make_pcm_bytes
 
-from .conftest import FakeAiohttpResponse, FakeAiohttpSession, make_pcm_bytes
 
-# ---------------------------------------------------------------------------
-# Happy path
-# ---------------------------------------------------------------------------
+def _fake_connect(ws: FakeWebSocket) -> Any:
+    """Return an async context manager that yields *ws* (matches ``websockets.connect``)."""
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=ws)
+    cm.__aexit__ = AsyncMock(return_value=False)
+    return cm
+
+
+def _speak_fixture_events(pcm_chunks: list[bytes]) -> list[Any]:
+    """Event stream: Metadata (first ``recv``) then PCM + Flushed for ``async for ws``."""
+    return [{"type": "Metadata"}, *pcm_chunks, {"type": "Flushed"}]
 
 
 @pytest.mark.asyncio
-async def test_deepgram_happy_path(fake_settings: Settings, tmp_path: Path) -> None:
-    """Deepgram HTTP streaming → ttfa set, WAV written."""
+async def test_deepgram_happy_path(fake_settings: Settings) -> None:
     chunks = [make_pcm_bytes(240), make_pcm_bytes(240)]
+    ws = FakeWebSocket(_speak_fixture_events(chunks))
     provider = DeepgramTTSProvider(
         fake_settings, model="aura-2-thalia-en", voice="aura-2-thalia-en"
     )
 
-    fake_resp = FakeAiohttpResponse(chunks, status=200)
-    fake_sess = FakeAiohttpSession(fake_resp)
-
-    with patch("coval_bench.providers.tts.deepgram.aiohttp.ClientSession", return_value=fake_sess):
+    with patch(
+        "coval_bench.providers.tts.deepgram.ws_client.connect",
+        return_value=_fake_connect(ws),
+    ):
         result = await provider.synthesize("Hello from Deepgram")
 
     assert result.error is None, f"Unexpected error: {result.error}"
@@ -43,75 +53,87 @@ async def test_deepgram_happy_path(fake_settings: Settings, tmp_path: Path) -> N
     assert result.provider == "deepgram"
     assert result.model == "aura-2-thalia-en"
 
+    sent_strs = [s.decode() if isinstance(s, bytes) else s for s in ws._sent]
+    assert any('"type": "Speak"' in s for s in sent_strs)
+    assert any('"type": "Flush"' in s for s in sent_strs)
+
     result.audio_path.unlink()
 
 
-# ---------------------------------------------------------------------------
-# Error path — HTTP error status
-# ---------------------------------------------------------------------------
-
-
 @pytest.mark.asyncio
-async def test_deepgram_http_error_status(fake_settings: Settings) -> None:
-    """Non-200 response → result.error populated, audio_path None."""
+async def test_deepgram_connect_refused(fake_settings: Settings) -> None:
+    """WebSocket connect failure → result.error populated, audio_path None."""
+
+    def _boom(*_a: object, **_k: object) -> None:
+        raise OSError("connection refused")
+
     provider = DeepgramTTSProvider(
         fake_settings, model="aura-2-thalia-en", voice="aura-2-thalia-en"
     )
 
-    fake_resp = FakeAiohttpResponse([], status=403, text_body="Forbidden")
-    fake_sess = FakeAiohttpSession(fake_resp)
-
-    with patch("coval_bench.providers.tts.deepgram.aiohttp.ClientSession", return_value=fake_sess):
+    with patch("coval_bench.providers.tts.deepgram.ws_client.connect", side_effect=_boom):
         result = await provider.synthesize("error test")
 
     assert result.error is not None
-    assert "403" in result.error
+    assert "refused" in result.error.lower()
     assert result.audio_path is None
 
 
 @pytest.mark.asyncio
 async def test_deepgram_network_error(fake_settings: Settings) -> None:
-    """Network exception → result.error populated, audio_path None."""
+    """Unexpected exception during the WS session → result.error set."""
+
     provider = DeepgramTTSProvider(
         fake_settings, model="aura-2-thalia-en", voice="aura-2-thalia-en"
     )
 
-    with patch(
-        "coval_bench.providers.tts.deepgram.aiohttp.ClientSession",
-        side_effect=RuntimeError("network error"),
-    ):
+    class _BadWs:
+        async def __aenter__(self) -> _BadWs:
+            return self
+
+        async def __aexit__(self, *_: object) -> None:
+            pass
+
+        async def recv(self) -> str:
+            raise RuntimeError("recv failed")
+
+        async def send(self, _data: str | bytes) -> None:
+            pass
+
+        def __aiter__(self) -> _BadWs:
+            return self
+
+        async def __anext__(self) -> bytes:
+            raise StopAsyncIteration
+
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=_BadWs())
+    cm.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("coval_bench.providers.tts.deepgram.ws_client.connect", return_value=cm):
         result = await provider.synthesize("error test")
 
     assert result.error is not None
     assert result.audio_path is None
 
 
-# ---------------------------------------------------------------------------
-# Empty audio
-# ---------------------------------------------------------------------------
-
-
 @pytest.mark.asyncio
 async def test_deepgram_no_audio_chunks(fake_settings: Settings) -> None:
-    """Empty response body → audio_path None, no error."""
+    """Metadata + Flushed only (no binary PCM) → audio_path None, ttfa_ms None."""
+    ws = FakeWebSocket(_speak_fixture_events([]))
     provider = DeepgramTTSProvider(
         fake_settings, model="aura-2-thalia-en", voice="aura-2-thalia-en"
     )
 
-    fake_resp = FakeAiohttpResponse([], status=200)
-    fake_sess = FakeAiohttpSession(fake_resp)
-
-    with patch("coval_bench.providers.tts.deepgram.aiohttp.ClientSession", return_value=fake_sess):
+    with patch(
+        "coval_bench.providers.tts.deepgram.ws_client.connect",
+        return_value=_fake_connect(ws),
+    ):
         result = await provider.synthesize("silent test")
 
     assert result.error is None
     assert result.audio_path is None
     assert result.ttfa_ms is None
-
-
-# ---------------------------------------------------------------------------
-# Properties
-# ---------------------------------------------------------------------------
 
 
 def test_deepgram_name_and_model(fake_settings: Settings) -> None:
@@ -120,30 +142,61 @@ def test_deepgram_name_and_model(fake_settings: Settings) -> None:
     assert p.model == "aura-2-thalia-en"
 
 
-# ---------------------------------------------------------------------------
-# Missing API key
-# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_deepgram_warning_then_pcm(fake_settings: Settings) -> None:
+    """First ``recv()`` may be a Warning JSON frame; handler logs and continues."""
 
+    pcm = make_pcm_bytes(120)
+    # Single recv consumes Warning; async iter gets pcm + Flushed from shared queue.
+    events: list[Any] = [
+        {"type": "Warning", "description": "test warning", "code": "WARN_TEST"},
+        pcm,
+        {"type": "Flushed"},
+    ]
+    ws = FakeWebSocket(events)
+    provider = DeepgramTTSProvider(
+        fake_settings, model="aura-2-thalia-en", voice="aura-2-thalia-en"
+    )
 
-# ---------------------------------------------------------------------------
-# Re-activated 2026-04-30: aura-2-thalia-en (Deepgram production voice).
-# ---------------------------------------------------------------------------
+    with patch(
+        "coval_bench.providers.tts.deepgram.ws_client.connect",
+        return_value=_fake_connect(ws),
+    ):
+        result = await provider.synthesize("Hi")
+
+    assert result.error is None
+    assert result.ttfa_ms is not None
+    assert result.audio_path is not None
+    assert result.audio_path.stat().st_size > 0
+    result.audio_path.unlink()
 
 
 @pytest.mark.asyncio
-async def test_synthesize_aura_2_thalia_en_http(fake_settings: Settings) -> None:
-    """aura-2-thalia-en HTTP streaming → ttfa set, valid WAV with .wav magic bytes."""
-    chunks = [make_pcm_bytes(240), make_pcm_bytes(240), make_pcm_bytes(240)]
+async def test_synthesize_wav_contains_riff(fake_settings: Settings) -> None:
+    chunks = [
+        make_pcm_bytes(240),
+        make_pcm_bytes(240),
+        make_pcm_bytes(240),
+    ]
+    ws = FakeWebSocket(_speak_fixture_events(chunks))
     provider = DeepgramTTSProvider(
         fake_settings,
         model="aura-2-thalia-en",
         voice="aura-2-thalia-en",
     )
 
-    fake_resp = FakeAiohttpResponse(chunks, status=200)
-    fake_sess = FakeAiohttpSession(fake_resp)
-    with patch("coval_bench.providers.tts.deepgram.aiohttp.ClientSession", return_value=fake_sess):
+    captured: dict[str, str] = {}
+
+    def _capture(url: str, **_kwargs: object) -> Any:
+        captured["url"] = url
+        return _fake_connect(ws)
+
+    with patch("coval_bench.providers.tts.deepgram.ws_client.connect", side_effect=_capture):
         result = await provider.synthesize("Hello world")
+
+    assert urlparse(captured["url"]).hostname == "api.deepgram.com"
+    assert f"sample_rate={SAMPLE_RATE}" in captured["url"]
+    assert "encoding=linear16" in captured["url"]
 
     assert result.error is None
     assert result.ttfa_ms is not None
@@ -158,7 +211,6 @@ async def test_synthesize_aura_2_thalia_en_http(fake_settings: Settings) -> None
 
 def test_deepgram_missing_api_key() -> None:
     settings_no_key = Settings(
-        database_url="postgresql://runner:password@localhost:5432/benchmarks",  # type: ignore[arg-type]
         dataset_bucket="test-bucket",
         dataset_id="stt-v1",
         runner_sha="test",


### PR DESCRIPTION
Switch Deepgram TTS from HTTP chunked streaming to the Speak WebSocket flow (Speak + Flush), align TTFA timing with other WS providers, and refresh unit tests.
