### PR TITLE
feat(providers/tts): move Rime to /ws3 WebSocket and add coda

### DIFF
--- a/runner/pyproject.toml
+++ b/runner/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "uvicorn[standard]>=0.30",
     "slowapi>=0.1.9",
     # WebSocket clients (STT providers)
-    "websockets>=12,<14",
+    "websockets>=13,<14",
     # TTS provider SDKs
     "openai>=1.40",
     "cartesia>=2",

--- a/runner/src/coval_bench/providers/tts/rime.py
+++ b/runner/src/coval_bench/providers/tts/rime.py
@@ -74,8 +74,6 @@ class RimeTTSProvider(TTSProvider):
                 "audioFormat": "pcm",
                 "samplingRate": SAMPLE_RATE,
                 # segment=never: synthesis fires only on explicit eos, not on sentence
-                # boundary detection. Deterministic trigger; matches Deepgram Flush /
-                # Gradium end_of_stream / Hume flush patterns.
                 "segment": "never",
             }
         )
@@ -84,8 +82,6 @@ class RimeTTSProvider(TTSProvider):
 
         try:
             async with ws_client.connect(url, additional_headers=headers) as ws:
-                # t0 — WS connected; /ws3 sends no server-initiated setup frame.
-                # Consistent with Hume/Cartesia/Gradium: t0 after connect, before text send.
                 start = time.monotonic()
 
                 await ws.send(json.dumps({"text": text}))

--- a/runner/src/coval_bench/providers/tts/rime.py
+++ b/runner/src/coval_bench/providers/tts/rime.py
@@ -1,18 +1,21 @@
 # Copyright 2026 The Coval Benchmarks Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Rime TTS provider — HTTP POST streaming to Rime TTS API."""
+"""Rime TTS provider — WebSocket streaming to Rime /ws3 JSON endpoint."""
 
 from __future__ import annotations
 
+import base64
+import json
 import os
 import tempfile
 import time
 import wave
 from pathlib import Path
+from urllib.parse import urlencode
 
-import aiohttp
 import structlog
+import websockets.asyncio.client as ws_client
 
 from coval_bench.config import Settings
 from coval_bench.providers.base import TTSProvider, TTSResult
@@ -20,15 +23,15 @@ from coval_bench.providers.base import TTSProvider, TTSResult
 logger: structlog.BoundLogger = structlog.get_logger(__name__)
 
 SAMPLE_RATE = 24000
-RIME_TTS_URL = "https://users.rime.ai/v1/rime-tts"
+_WS_BASE = "wss://users-ws.rime.ai/ws3"
 
-VALID_MODELS = {"arcana", "mistv2", "mistv3"}
+VALID_MODELS = {"arcana", "coda", "mistv3"}
 
 
 class RimeTTSProvider(TTSProvider):
-    """Rime TTS provider using HTTP streaming."""
+    """Rime TTS provider using WebSocket /ws3 JSON streaming."""
 
-    enabled: bool = False  # Commented out in legacy run_tts.py
+    enabled: bool = False  # enabled via DEFAULT_TTS_MATRIX entries
 
     def __init__(self, settings: Settings, model: str, voice: str) -> None:
         self._model = model
@@ -47,12 +50,8 @@ class RimeTTSProvider(TTSProvider):
     def model(self) -> str:
         return self._model
 
-    @staticmethod
-    def _is_audio_chunk(chunk: object) -> bool:
-        return isinstance(chunk, bytes) and len(chunk) > 0
-
     async def synthesize(self, text: str) -> TTSResult:
-        """Synthesize speech via Rime HTTP and return a TTSResult."""
+        """Synthesize speech via Rime /ws3 WebSocket and return a TTSResult."""
         if self._model not in VALID_MODELS:
             return TTSResult(
                 provider="rime",
@@ -68,37 +67,37 @@ class RimeTTSProvider(TTSProvider):
         audio_chunks: list[bytes] = []
         ttfa_ms: float | None = None
 
-        payload = {
-            "speaker": self._voice or "luna",
-            "text": text,
-            "modelId": self._model,
-            "repetition_penalty": 1.5,
-            "temperature": 0.5,
-            "top_p": 1,
-            "samplingRate": SAMPLE_RATE,
-            "max_tokens": 1200,
-        }
-
-        headers = {
-            "Accept": "audio/pcm",
-            "Authorization": f"Bearer {self._api_key}",
-            "Content-Type": "application/json",
-        }
+        qs = urlencode(
+            {
+                "modelId": self._model,
+                "speaker": self._voice or "luna",
+                "audioFormat": "pcm",
+                "samplingRate": SAMPLE_RATE,
+                # segment=never: synthesis fires only on explicit eos, not on sentence
+                # boundary detection. Deterministic trigger; matches Deepgram Flush /
+                # Gradium end_of_stream / Hume flush patterns.
+                "segment": "never",
+            }
+        )
+        url = f"{_WS_BASE}?{qs}"
+        headers = {"Authorization": f"Bearer {self._api_key}"}
 
         try:
-            async with aiohttp.ClientSession() as session:
+            async with ws_client.connect(url, additional_headers=headers) as ws:
+                # t0 — WS connected; /ws3 sends no server-initiated setup frame.
+                # Consistent with Hume/Cartesia/Gradium: t0 after connect, before text send.
                 start = time.monotonic()
-                async with session.post(
-                    RIME_TTS_URL,
-                    json=payload,
-                    headers=headers,
-                ) as response:
-                    if response.status != 200:
-                        error_text = await response.text()
-                        raise ValueError(f"Rime HTTP error {response.status}: {error_text}")
 
-                    async for chunk in response.content.iter_any():
-                        if self._is_audio_chunk(chunk):
+                await ws.send(json.dumps({"text": text}))
+                await ws.send(json.dumps({"operation": "eos"}))
+
+                async for raw in ws:
+                    msg = json.loads(raw)
+                    msg_type = msg.get("type", "")
+
+                    if msg_type == "chunk":
+                        audio_bytes = base64.b64decode(msg["data"])
+                        if audio_bytes:
                             if ttfa_ms is None:
                                 ttfa_ms = (time.monotonic() - start) * 1000
                                 logger.debug(
@@ -106,10 +105,17 @@ class RimeTTSProvider(TTSProvider):
                                     model=self._model,
                                     ttfa_ms=ttfa_ms,
                                 )
-                            audio_chunks.append(chunk)
+                            audio_chunks.append(audio_bytes)
+
+                    elif msg_type == "done":
+                        break
+
+                    elif msg_type == "error":
+                        raise RuntimeError(msg.get("message", "rime /ws3 error"))
+                    # "timestamps" events are silently dropped — not needed for benchmark.
 
         except Exception as exc:
-            logger.debug("rime_error", exc_info=True)
+            logger.warning("rime_error", exc_info=True)
             return TTSResult(
                 provider="rime",
                 model=self._model,
@@ -131,7 +137,7 @@ class RimeTTSProvider(TTSProvider):
 
 
 def _write_wav(chunks: list[bytes], sample_rate: int) -> Path:
-    """Concatenate PCM chunks and write a WAV file to a temp location."""
+    """Concatenate raw PCM chunks and write a WAV file to a temp location."""
     fd, tmp_name = tempfile.mkstemp(suffix=".wav")
     os.close(fd)
     audio_data = b"".join(chunks)

--- a/runner/src/coval_bench/runner/config.py
+++ b/runner/src/coval_bench/runner/config.py
@@ -105,8 +105,9 @@ DEFAULT_TTS_MATRIX: list[ProviderEntry] = [
         voice="YTpq7expH9539ERJ",
         enabled=True,
     ),
-    # Rime — re-activated 2026-04-30: arcana (resolves to Arcana v3 server-side
-    # per Rime docs — same model ID promoted in place) + mistv3.
+    # Rime — all three on /ws3 WebSocket (rewired 2026-05-19).
+    # "arcana" resolves server-side to Arcana v3; "coda" to May 2026 flagship.
+    ProviderEntry(provider="rime", model="coda", voice="luna", enabled=True),
     ProviderEntry(provider="rime", model="arcana", voice="luna", enabled=True),
     ProviderEntry(provider="rime", model="mistv3", voice="luna", enabled=True),
     ProviderEntry(provider="rime", model="mistv2", voice="luna", enabled=False, disabled=True),

--- a/runner/tests/providers/tts/conftest.py
+++ b/runner/tests/providers/tts/conftest.py
@@ -94,11 +94,31 @@ class FakeWebSocket:
             return msg
         raise StopAsyncIteration
 
+    def __aiter__(self) -> _AsyncFakeWebSocketIter:
+        return _AsyncFakeWebSocketIter(self)
+
     async def __aenter__(self) -> FakeWebSocket:
         return self
 
     async def __aexit__(self, *_: object) -> None:
         pass
+
+
+class _AsyncFakeWebSocketIter:
+    """Async iterator over remaining FakeWebSocket messages (shares recv() index)."""
+
+    def __init__(self, ws: FakeWebSocket) -> None:
+        self._ws = ws
+
+    def __aiter__(self) -> _AsyncFakeWebSocketIter:
+        return self
+
+    async def __anext__(self) -> str | bytes:
+        if self._ws._idx >= len(self._ws._messages):
+            raise StopAsyncIteration
+        msg = self._ws._messages[self._ws._idx]
+        self._ws._idx += 1
+        return msg
 
 
 # ---------------------------------------------------------------------------

--- a/runner/tests/providers/tts/test_rime.py
+++ b/runner/tests/providers/tts/test_rime.py
@@ -1,155 +1,243 @@
 # Copyright 2026 The Coval Benchmarks Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Tests for the Rime TTS provider."""
+"""Tests for the Rime TTS provider — WebSocket /ws3 JSON endpoint."""
 
 from __future__ import annotations
 
-from pathlib import Path
-from unittest.mock import patch
+import base64
+import json
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+from urllib.parse import parse_qs, urlparse
 
 import pytest
 
 from coval_bench.config import Settings
-from coval_bench.providers.tts.rime import RimeTTSProvider
+from coval_bench.providers.tts.rime import SAMPLE_RATE, RimeTTSProvider
 
-from .conftest import FakeAiohttpResponse, FakeAiohttpSession, make_pcm_bytes
+from .conftest import FakeWebSocket, make_pcm_bytes
 
 # ---------------------------------------------------------------------------
-# Happy path
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _fake_connect(ws: FakeWebSocket) -> Any:
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=ws)
+    cm.__aexit__ = AsyncMock(return_value=False)
+    return cm
+
+
+def _ws3_events(pcm_chunks: list[bytes]) -> list[str]:
+    """Build a /ws3 event stream: chunk messages followed by done."""
+    events = [
+        json.dumps({"type": "chunk", "data": base64.b64encode(c).decode()}) for c in pcm_chunks
+    ]
+    events.append(json.dumps({"type": "done"}))
+    return events
+
+
+# ---------------------------------------------------------------------------
+# Happy path — all three valid models
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_rime_happy_path(fake_settings: Settings, tmp_path: Path) -> None:
-    """Rime HTTP streaming → ttfa set, WAV written."""
+@pytest.mark.parametrize("model", ["arcana", "mistv3", "coda"])
+async def test_rime_happy_path(fake_settings: Settings, model: str) -> None:
+    """All valid models: ttfa set, WAV written with RIFF header."""
     chunks = [make_pcm_bytes(240), make_pcm_bytes(240)]
-    provider = RimeTTSProvider(fake_settings, model="arcana", voice="luna")
+    ws = FakeWebSocket(_ws3_events(chunks))
+    provider = RimeTTSProvider(fake_settings, model=model, voice="luna")
 
-    fake_resp = FakeAiohttpResponse(chunks, status=200)
-    fake_sess = FakeAiohttpSession(fake_resp)
-
-    with patch("coval_bench.providers.tts.rime.aiohttp.ClientSession", return_value=fake_sess):
+    with patch(
+        "coval_bench.providers.tts.rime.ws_client.connect",
+        return_value=_fake_connect(ws),
+    ):
         result = await provider.synthesize("Hello from Rime")
 
     assert result.error is None, f"Unexpected error: {result.error}"
     assert result.ttfa_ms is not None
     assert 0 < result.ttfa_ms < 60_000
+    assert result.provider == "rime"
+    assert result.model == model
+    assert result.voice == "luna"
     assert result.audio_path is not None
     assert result.audio_path.exists()
-    assert result.audio_path.stat().st_size > 0
-    assert result.provider == "rime"
-    assert result.model == "arcana"
-    assert result.voice == "luna"
-
+    assert result.audio_path.read_bytes()[:4] == b"RIFF"
     result.audio_path.unlink()
 
 
-@pytest.mark.asyncio
-async def test_rime_mistv2_model(fake_settings: Settings) -> None:
-    """mistv2 model also synthesizes successfully."""
-    chunks = [make_pcm_bytes(240)]
-    provider = RimeTTSProvider(fake_settings, model="mistv2", voice="luna")
-
-    fake_resp = FakeAiohttpResponse(chunks, status=200)
-    fake_sess = FakeAiohttpSession(fake_resp)
-
-    with patch("coval_bench.providers.tts.rime.aiohttp.ClientSession", return_value=fake_sess):
-        result = await provider.synthesize("mistv2 test")
-
-    assert result.error is None
-    if result.audio_path:
-        result.audio_path.unlink()
-
-
 # ---------------------------------------------------------------------------
-# Bad model raises error immediately
+# Protocol: sent messages and URL shape
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_rime_invalid_model(fake_settings: Settings) -> None:
-    """Unsupported model returns error result without calling network."""
-    provider = RimeTTSProvider(fake_settings, model="unknown-model", voice="luna")
-    result = await provider.synthesize("test")
-    assert result.error is not None
-    assert "Unsupported" in result.error
-    assert result.audio_path is None
-    assert result.ttfa_ms is None
-
-
-@pytest.mark.asyncio
-async def test_invalid_model_returns_error(fake_settings: Settings) -> None:
-    """mistv3 is now a valid model; mistv4 is rejected without a network call."""
-    # mistv3 is valid as of 2026-04-30 — must NOT be rejected by VALID_MODELS.
-    valid = RimeTTSProvider(fake_settings, model="mistv3", voice="luna")
-    fake_resp = FakeAiohttpResponse([make_pcm_bytes(240)], status=200)
-    fake_sess = FakeAiohttpSession(fake_resp)
-    with patch("coval_bench.providers.tts.rime.aiohttp.ClientSession", return_value=fake_sess):
-        ok = await valid.synthesize("ok")
-    assert ok.error is None
-    if ok.audio_path:
-        ok.audio_path.unlink()
-
-    # An unknown model is still rejected pre-flight without hitting the network.
-    bad = RimeTTSProvider(fake_settings, model="mistv4", voice="luna")
-    bad_result = await bad.synthesize("test")
-    assert bad_result.error is not None
-    assert "Unsupported" in bad_result.error
-    assert "mistv3" in bad_result.error
-    assert bad_result.audio_path is None
-
-
-# ---------------------------------------------------------------------------
-# Error path — HTTP errors
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.asyncio
-async def test_rime_http_error(fake_settings: Settings) -> None:
-    """Non-200 response → result.error populated."""
-    provider = RimeTTSProvider(fake_settings, model="arcana", voice="luna")
-
-    fake_resp = FakeAiohttpResponse([], status=429, text_body="Too Many Requests")
-    fake_sess = FakeAiohttpSession(fake_resp)
-
-    with patch("coval_bench.providers.tts.rime.aiohttp.ClientSession", return_value=fake_sess):
-        result = await provider.synthesize("error test")
-
-    assert result.error is not None
-    assert "429" in result.error
-    assert result.audio_path is None
-
-
-@pytest.mark.asyncio
-async def test_rime_network_exception(fake_settings: Settings) -> None:
-    """Network exception → result.error populated, audio_path None."""
-    provider = RimeTTSProvider(fake_settings, model="arcana", voice="luna")
+async def test_rime_sends_text_and_eos(fake_settings: Settings) -> None:
+    """Provider sends {"text": …} then {"operation": "eos"} — in that order."""
+    ws = FakeWebSocket(_ws3_events([make_pcm_bytes(240)]))
+    provider = RimeTTSProvider(fake_settings, model="coda", voice="luna")
 
     with patch(
-        "coval_bench.providers.tts.rime.aiohttp.ClientSession",
-        side_effect=RuntimeError("connection reset"),
+        "coval_bench.providers.tts.rime.ws_client.connect",
+        return_value=_fake_connect(ws),
+    ):
+        await provider.synthesize("test text")
+
+    assert len(ws.sent) >= 2
+    first = json.loads(ws.sent[0])
+    second = json.loads(ws.sent[1])
+    assert first == {"text": "test text"}
+    assert second == {"operation": "eos"}
+
+
+@pytest.mark.asyncio
+async def test_rime_url_shape(fake_settings: Settings) -> None:
+    """WS URL must target users-ws.rime.ai /ws3 with correct query params."""
+    ws = FakeWebSocket(_ws3_events([make_pcm_bytes(240)]))
+    captured: dict[str, str] = {}
+
+    def _capture(url: str, **_kwargs: object) -> Any:
+        captured["url"] = url
+        return _fake_connect(ws)
+
+    provider = RimeTTSProvider(fake_settings, model="coda", voice="luna")
+
+    with patch(
+        "coval_bench.providers.tts.rime.ws_client.connect",
+        side_effect=_capture,
+    ):
+        await provider.synthesize("url test")
+
+    parsed = urlparse(captured["url"])
+    qs = parse_qs(parsed.query)
+
+    assert parsed.hostname == "users-ws.rime.ai"
+    assert parsed.path == "/ws3"
+    assert qs["modelId"] == ["coda"]
+    assert qs["audioFormat"] == ["pcm"]
+    assert qs["samplingRate"] == [str(SAMPLE_RATE)]
+    assert qs["segment"] == ["never"]
+    assert qs["speaker"] == ["luna"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("model", ["arcana", "mistv3"])
+async def test_rime_url_model_id(fake_settings: Settings, model: str) -> None:
+    """modelId in the URL matches the requested model for arcana and mistv3."""
+    ws = FakeWebSocket(_ws3_events([make_pcm_bytes(240)]))
+    captured: dict[str, str] = {}
+
+    def _capture(url: str, **_kwargs: object) -> Any:
+        captured["url"] = url
+        return _fake_connect(ws)
+
+    provider = RimeTTSProvider(fake_settings, model=model, voice="luna")
+
+    with patch(
+        "coval_bench.providers.tts.rime.ws_client.connect",
+        side_effect=_capture,
+    ):
+        await provider.synthesize("test")
+
+    assert parse_qs(urlparse(captured["url"]).query)["modelId"] == [model]
+
+
+# ---------------------------------------------------------------------------
+# Protocol: timestamps event is silently ignored
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_rime_timestamps_ignored(fake_settings: Settings) -> None:
+    """Interleaved timestamps events don't interrupt audio assembly."""
+    pcm = make_pcm_bytes(240)
+    timestamps_event = json.dumps(
+        {
+            "type": "timestamps",
+            "word_timestamps": {
+                "words": ["Hello"],
+                "start": [0.0],
+                "end": [0.36],
+            },
+        }
+    )
+    events = [
+        json.dumps({"type": "chunk", "data": base64.b64encode(pcm).decode()}),
+        timestamps_event,
+        json.dumps({"type": "chunk", "data": base64.b64encode(pcm).decode()}),
+        json.dumps({"type": "done"}),
+    ]
+    ws = FakeWebSocket(events)
+    provider = RimeTTSProvider(fake_settings, model="coda", voice="luna")
+
+    with patch(
+        "coval_bench.providers.tts.rime.ws_client.connect",
+        return_value=_fake_connect(ws),
+    ):
+        result = await provider.synthesize("Hello")
+
+    assert result.error is None
+    assert result.ttfa_ms is not None
+    assert result.audio_path is not None
+    # Both PCM chunks assembled: 2 × 240 frames × 2 bytes = 960 bytes of PCM
+    data = result.audio_path.read_bytes()
+    assert len(data) > 960
+    result.audio_path.unlink()
+
+
+# ---------------------------------------------------------------------------
+# Error paths
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_rime_server_error_event(fake_settings: Settings) -> None:
+    """{"type":"error"} frame from server → result.error populated."""
+    events = [json.dumps({"type": "error", "message": "rate limit exceeded"})]
+    ws = FakeWebSocket(events)
+    provider = RimeTTSProvider(fake_settings, model="coda", voice="luna")
+
+    with patch(
+        "coval_bench.providers.tts.rime.ws_client.connect",
+        return_value=_fake_connect(ws),
     ):
         result = await provider.synthesize("error test")
 
     assert result.error is not None
+    assert "rate limit exceeded" in result.error
     assert result.audio_path is None
 
 
-# ---------------------------------------------------------------------------
-# No audio chunks
-# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_rime_connect_failure(fake_settings: Settings) -> None:
+    """WebSocket connect OSError → result.error populated, audio_path None."""
+    provider = RimeTTSProvider(fake_settings, model="coda", voice="luna")
+
+    with patch(
+        "coval_bench.providers.tts.rime.ws_client.connect",
+        side_effect=OSError("connection refused"),
+    ):
+        result = await provider.synthesize("error test")
+
+    assert result.error is not None
+    assert "refused" in result.error.lower()
+    assert result.audio_path is None
 
 
 @pytest.mark.asyncio
 async def test_rime_empty_response(fake_settings: Settings) -> None:
-    """Empty body → audio_path None, error None."""
-    provider = RimeTTSProvider(fake_settings, model="arcana", voice="luna")
+    """done with no chunks → audio_path None, ttfa_ms None, no error."""
+    ws = FakeWebSocket([json.dumps({"type": "done"})])
+    provider = RimeTTSProvider(fake_settings, model="coda", voice="luna")
 
-    fake_resp = FakeAiohttpResponse([], status=200)
-    fake_sess = FakeAiohttpSession(fake_resp)
-
-    with patch("coval_bench.providers.tts.rime.aiohttp.ClientSession", return_value=fake_sess):
+    with patch(
+        "coval_bench.providers.tts.rime.ws_client.connect",
+        return_value=_fake_connect(ws),
+    ):
         result = await provider.synthesize("silent test")
 
     assert result.error is None
@@ -158,68 +246,130 @@ async def test_rime_empty_response(fake_settings: Settings) -> None:
 
 
 # ---------------------------------------------------------------------------
+# TTFA correctness
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_rime_ttfa_set_on_first_chunk_only(fake_settings: Settings) -> None:
+    """ttfa_ms is measured at the first chunk and not overwritten by later chunks."""
+    chunks = [make_pcm_bytes(240), make_pcm_bytes(240), make_pcm_bytes(240)]
+    ws = FakeWebSocket(_ws3_events(chunks))
+    provider = RimeTTSProvider(fake_settings, model="coda", voice="luna")
+
+    # clock: start=0.0, chunk-1=0.1s, chunk-2=0.5s, chunk-3=0.9s.
+    # If the `if ttfa_ms is None` guard is removed, chunks 2 and 3 overwrite to
+    # 500 ms and 900 ms respectively, and the assertion below fails.
+    clock = iter([0.0, 0.1, 0.5, 0.9])
+
+    with (
+        patch("coval_bench.providers.tts.rime.ws_client.connect", return_value=_fake_connect(ws)),
+        patch("coval_bench.providers.tts.rime.time.monotonic", side_effect=clock),
+    ):
+        result = await provider.synthesize("three chunks")
+
+    assert result.error is None
+    assert result.ttfa_ms == pytest.approx(100.0)
+    if result.audio_path:
+        result.audio_path.unlink()
+
+
+@pytest.mark.asyncio
+async def test_rime_auth_header(fake_settings: Settings) -> None:
+    """Bearer token is passed in additional_headers when opening the WS connection."""
+    ws = FakeWebSocket(_ws3_events([make_pcm_bytes(240)]))
+    captured: dict[str, str] = {}
+
+    def _capture(url: str, additional_headers: dict[str, str] | None = None, **_kw: object) -> Any:
+        if additional_headers:
+            captured.update(additional_headers)
+        return _fake_connect(ws)
+
+    provider = RimeTTSProvider(fake_settings, model="coda", voice="luna")
+
+    with patch("coval_bench.providers.tts.rime.ws_client.connect", side_effect=_capture):
+        await provider.synthesize("auth test")
+
+    assert captured.get("Authorization") == "Bearer test-rime-key"
+
+
+@pytest.mark.asyncio
+async def test_rime_empty_chunk_not_counted(fake_settings: Settings) -> None:
+    """A chunk event whose base64 data decodes to empty bytes must not set ttfa_ms or audio."""
+    events = [
+        json.dumps({"type": "chunk", "data": base64.b64encode(b"").decode()}),
+        json.dumps({"type": "done"}),
+    ]
+    ws = FakeWebSocket(events)
+    provider = RimeTTSProvider(fake_settings, model="coda", voice="luna")
+
+    with patch("coval_bench.providers.tts.rime.ws_client.connect", return_value=_fake_connect(ws)):
+        result = await provider.synthesize("test")
+
+    assert result.error is None
+    # If the `if audio_bytes:` guard is removed, audio_chunks = [b""] is truthy
+    # so _write_wav is called and ttfa_ms is set — both assertions below would fail.
+    assert result.ttfa_ms is None
+    assert result.audio_path is None
+
+
+# ---------------------------------------------------------------------------
+# Model validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_rime_invalid_model(fake_settings: Settings) -> None:
+    """Unknown model returns error result without opening a WS connection."""
+    provider = RimeTTSProvider(fake_settings, model="mistv4", voice="luna")
+    result = await provider.synthesize("test")
+    assert result.error is not None
+    assert "Unsupported" in result.error
+    assert result.audio_path is None
+    assert result.ttfa_ms is None
+
+
+# ---------------------------------------------------------------------------
+# Voice fallback
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_rime_voice_fallback(fake_settings: Settings) -> None:
+    """voice=None falls back to 'luna' in the WS query string."""
+    ws = FakeWebSocket(_ws3_events([make_pcm_bytes(240)]))
+    captured: dict[str, str] = {}
+
+    def _capture(url: str, **_kwargs: object) -> Any:
+        captured["url"] = url
+        return _fake_connect(ws)
+
+    provider = RimeTTSProvider(fake_settings, model="coda", voice=None)
+
+    with patch(
+        "coval_bench.providers.tts.rime.ws_client.connect",
+        side_effect=_capture,
+    ):
+        await provider.synthesize("test")
+
+    assert parse_qs(urlparse(captured["url"]).query)["speaker"] == ["luna"]
+
+
+# ---------------------------------------------------------------------------
 # Properties
 # ---------------------------------------------------------------------------
 
 
-def test_rime_name_and_model(fake_settings: Settings) -> None:
-    p = RimeTTSProvider(fake_settings, model="arcana", voice="luna")
-    assert p.name == "rime-arcana"
-    assert p.model == "arcana"
+@pytest.mark.parametrize("model", ["arcana", "mistv3", "coda"])
+def test_rime_name_and_model(fake_settings: Settings, model: str) -> None:
+    p = RimeTTSProvider(fake_settings, model=model, voice="luna")
+    assert p.name == f"rime-{model}"
+    assert p.model == model
 
 
 # ---------------------------------------------------------------------------
 # Missing API key
 # ---------------------------------------------------------------------------
-
-
-# ---------------------------------------------------------------------------
-# Re-activated 2026-04-30: arcana (resolves to Arcana v3 server-side) + mistv3.
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.asyncio
-async def test_synthesize_arcana_http(fake_settings: Settings) -> None:
-    """arcana streams PCM via HTTP → ttfa set, valid WAV with .wav magic bytes."""
-    chunks = [make_pcm_bytes(240), make_pcm_bytes(240)]
-    provider = RimeTTSProvider(fake_settings, model="arcana", voice="luna")
-
-    fake_resp = FakeAiohttpResponse(chunks, status=200)
-    fake_sess = FakeAiohttpSession(fake_resp)
-    with patch("coval_bench.providers.tts.rime.aiohttp.ClientSession", return_value=fake_sess):
-        result = await provider.synthesize("Hello world")
-
-    assert result.error is None
-    assert result.ttfa_ms is not None
-    assert result.provider == "rime"
-    assert result.model == "arcana"
-    assert result.voice == "luna"
-    assert result.audio_path is not None
-    assert result.audio_path.exists()
-    assert result.audio_path.read_bytes()[:4] == b"RIFF"
-    result.audio_path.unlink()
-
-
-@pytest.mark.asyncio
-async def test_synthesize_mistv3_http(fake_settings: Settings) -> None:
-    """mistv3 streams PCM via HTTP → ttfa set, valid WAV with .wav magic bytes."""
-    chunks = [make_pcm_bytes(240), make_pcm_bytes(240)]
-    provider = RimeTTSProvider(fake_settings, model="mistv3", voice="luna")
-
-    fake_resp = FakeAiohttpResponse(chunks, status=200)
-    fake_sess = FakeAiohttpSession(fake_resp)
-    with patch("coval_bench.providers.tts.rime.aiohttp.ClientSession", return_value=fake_sess):
-        result = await provider.synthesize("Hello world")
-
-    assert result.error is None
-    assert result.ttfa_ms is not None
-    assert result.provider == "rime"
-    assert result.model == "mistv3"
-    assert result.voice == "luna"
-    assert result.audio_path is not None
-    assert result.audio_path.exists()
-    assert result.audio_path.read_bytes()[:4] == b"RIFF"
-    result.audio_path.unlink()
 
 
 def test_rime_missing_api_key() -> None:
@@ -231,4 +381,4 @@ def test_rime_missing_api_key() -> None:
         rime_api_key=None,
     )
     with pytest.raises(ValueError, match="rime_api_key"):
-        RimeTTSProvider(settings_no_key, model="arcana", voice="luna")
+        RimeTTSProvider(settings_no_key, model="coda", voice="luna")

--- a/runner/uv.lock
+++ b/runner/uv.lock
@@ -315,7 +315,7 @@ requires-dist = [
     { name = "soundfile", specifier = ">=0.12" },
     { name = "structlog", specifier = ">=24" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.30" },
-    { name = "websockets", specifier = ">=12,<14" },
+    { name = "websockets", specifier = ">=13,<14" },
     { name = "whisper-normalizer", specifier = ">=0.0.10" },
 ]
 provides-extras = ["google-stt", "hume-tts"]
@@ -636,9 +636,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ef/32/f2ce6d4cac3e55bc6173f92dbe627e782e1850f89d986c3606feb63aafa7/greenlet-3.5.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:db2910d3c809444e0a20147361f343fe2798e106af8d9d8506f5305302655a9f", size = 286228, upload-time = "2026-04-27T12:20:34.421Z" },
     { url = "https://files.pythonhosted.org/packages/b7/aa/caed9e5adf742315fc7be2a84196373aab4816e540e38ba0d76cb7584d68/greenlet-3.5.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3ec9ea74e7268ace7f9aab1b1a4e730193fc661b39a993cd91c606c32d4a3628", size = 601775, upload-time = "2026-04-27T12:52:41.045Z" },
     { url = "https://files.pythonhosted.org/packages/c7/af/90ae08497400a941595d12774447f752d3dfe0fbb012e35b76bc5c0ff37e/greenlet-3.5.0-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:54d243512da35485fc7a6bf3c178fdda6327a9d6506fcdd62b1abd1e41b2927b", size = 614436, upload-time = "2026-04-27T12:59:41.595Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/e9/4eeadf8cb3403ac274245ba75f07844abc7fa5f6787583fc9156ba741e0f/greenlet-3.5.0-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:41353ec2ecedf7aa8f682753a41919f8718031a6edac46b8d3dc7ed9e1ceb136", size = 620610, upload-time = "2026-04-27T13:02:39.194Z" },
     { url = "https://files.pythonhosted.org/packages/2b/e0/2e13df68f367e2f9960616927d60857dd7e56aaadd59a47c644216b2f920/greenlet-3.5.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9d280a7f5c331622c69f97eb167f33577ff2d1df282c41cd15907fc0a3ca198c", size = 611388, upload-time = "2026-04-27T12:25:28.008Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/ef/f913b3c0eb7d26d86a2401c5e1546c9d46b657efee724b06f6f4ac5d8824/greenlet-3.5.0-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:58c1c374fe2b3d852f9b6b11a7dff4c85404e51b9a596fd9e89cf904eb09866d", size = 422775, upload-time = "2026-04-27T13:05:14.261Z" },
     { url = "https://files.pythonhosted.org/packages/82/f7/393c64055132ac0d488ef6be549253b7e6274194863967ddc0bc8f5b87b8/greenlet-3.5.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:1eb67d5adefb5bd2e182d42678a328979a209e4e82eb93575708185d31d1f588", size = 1570768, upload-time = "2026-04-27T12:53:28.099Z" },
     { url = "https://files.pythonhosted.org/packages/b8/4b/eaf7735253522cf56d1b74d672a58f54fc114702ceaf05def59aae72f6e1/greenlet-3.5.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2628d6c86f6cb0cb45e0c3c54058bbec559f57eaae699447748cb3928150577e", size = 1635983, upload-time = "2026-04-27T12:25:26.903Z" },
     { url = "https://files.pythonhosted.org/packages/4c/fe/4fb3a0805bd5165da5ebf858da7cc01cce8061674106d2cf5bdab32cbfde/greenlet-3.5.0-cp312-cp312-win_amd64.whl", hash = "sha256:d4d9f0624c775f2dfc56ba54d515a8c771044346852a918b405914f6b19d7fd8", size = 238840, upload-time = "2026-04-27T12:23:54.806Z" },

--- a/web/components/charts/CustomBarChartTick.tsx
+++ b/web/components/charts/CustomBarChartTick.tsx
@@ -17,6 +17,7 @@ const normalizeModelName = (modelName: string): string => {
     "aura-2-thalia-en": "Aura 2",
     arcana: "Arcana",
     mistv3: "Mist v3",
+    coda: "Coda",
     // STT
     "nova-2": "Nova 2",
     "nova-3": "Nova 3",

--- a/web/hooks/useChartData.ts
+++ b/web/hooks/useChartData.ts
@@ -331,7 +331,10 @@ export function useChartData({
           y: yData.metric_value ?? 0,
           model: xData.model,
           benchmark: xData.benchmark,
-          provider: xData.provider
+          provider:
+            activeTab === "stt"
+              ? normalizeSTTProviderName(xData.provider)
+              : normalizeTTSProviderName(xData.provider)
         });
       }
     });
@@ -343,7 +346,7 @@ export function useChartData({
     const outlierCount = xValues.filter((val) => val > p99X).length;
 
     return { points: scatterPoints, p99X, outlierCount };
-  }, [rawData, activeTab, selectedTTSModels, selectedSTTModels]);
+  }, [rawData, activeTab, selectedTTSModels, selectedSTTModels, getProviderForModel]);
 
   // Gap data needs per-timestamp comparisons — cannot use pre-aggregated stats
   const getGapData = useCallback((): TimelineDataPoint[] => {

--- a/web/hooks/useDashboardState.tsx
+++ b/web/hooks/useDashboardState.tsx
@@ -476,7 +476,7 @@ export function useDashboardState(page: "tts" | "stt") {
         label,
         displayValue: normalizeModelName(fastestLatencyModel),
         subtitle: fastestLatencyProvider
-          ? { detail: fastestLatencyProvider }
+          ? { detail: normalizeProviderName(fastestLatencyProvider) }
           : undefined,
       };
     }
@@ -487,7 +487,9 @@ export function useDashboardState(page: "tts" | "stt") {
         selectedModels.length > 1 && fastestLatencyModel
           ? {
               name: normalizeModelName(fastestLatencyModel),
-              detail: fastestLatencyProvider,
+              detail: fastestLatencyProvider
+                ? normalizeProviderName(fastestLatencyProvider)
+                : undefined,
             }
           : undefined,
     };
@@ -500,7 +502,9 @@ export function useDashboardState(page: "tts" | "stt") {
       selectedModels.length > 1 && lowestWERModel
         ? {
             name: normalizeModelName(lowestWERModel),
-            detail: normalizeSTTProviderName(lowestWERProvider),
+            detail: lowestWERProvider
+              ? normalizeProviderName(lowestWERProvider)
+              : undefined,
           }
         : undefined,
   };

--- a/web/lib/config/colors.ts
+++ b/web/lib/config/colors.ts
@@ -19,6 +19,7 @@ export const modelColors: Record<string, string> = {
   // Rime TTS
   arcana: "#33FF99",
   mistv3: "#0E5C32",
+  coda: "#1DE9B6",
 
   // Deepgram TTS
   "aura-2-thalia-en": "#FC2D62",

--- a/web/lib/config/models.ts
+++ b/web/lib/config/models.ts
@@ -11,6 +11,7 @@ export const modelDisplayNames: Record<string, string> = {
   "aura-2-thalia-en": "Aura 2",
   arcana: "Arcana",
   mistv3: "Mist v3",
+  coda: "Coda",
   // STT
   "nova-2": "Nova 2",
   "nova-3": "Nova 3",

--- a/web/lib/utils/formatters.ts
+++ b/web/lib/utils/formatters.ts
@@ -65,6 +65,7 @@ export function normalizeModelName(modelName: string): string {
     "aura-2-thalia-en": "Aura 2",
     arcana: "Arcana",
     mistv3: "Mist v3",
+    coda: "Coda",
     // STT
     "nova-2": "Nova 2",
     "nova-3": "Nova 3",
@@ -93,6 +94,17 @@ export function normalizeModelName(modelName: string): string {
     });
 }
 
+/** Display fallback for provider slugs not in the explicit maps below. */
+function capitalizeProviderSlug(providerName: string): string {
+  const trimmed = providerName.trim();
+  if (!trimmed) return trimmed;
+  return trimmed
+    .split(/[-_\s]+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1).toLowerCase())
+    .join(" ");
+}
+
 /**
  * Normalize STT provider name for display
  * @param providerName - Raw provider name from API
@@ -104,11 +116,12 @@ export function normalizeSTTProviderName(providerName: string): string {
     deepgram: "Deepgram",
     elevenlabs: "ElevenLabs",
     gradium: "Gradium",
-    speechmatics: "Speechmatics"
+    speechmatics: "Speechmatics",
+    rime: "Rime",
   };
 
   const lower = providerName.toLowerCase();
-  return mappings[lower] ?? providerName;
+  return mappings[lower] ?? capitalizeProviderSlug(providerName);
 }
 
 export function normalizeTTSProviderName(providerName: string): string {
@@ -119,9 +132,9 @@ export function normalizeTTSProviderName(providerName: string): string {
     gradium: "Gradium",
     hume: "Hume",
     openai: "OpenAI",
-    rime: "Rime"
+    rime: "Rime",
   };
 
   const lower = providerName.toLowerCase();
-  return mappings[lower] ?? providerName;
+  return mappings[lower] ?? capitalizeProviderSlug(providerName);
 }


### PR DESCRIPTION
1) Switch Rime from HTTP /v1/rime-tts to wss://users-ws.rime.ai/ws3 with segment=never and eos; TTFA clock starts after connect. Enable coda in matrix; add web labels and fix TTS provider display. 

2) Historical Rime TTFA on the dashboard is not comparable to pre-merge points (new protocol; handshake excluded from clock). Expect mistv3 to look much faster vs legacy HTTP measurements.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rime TTS now uses the new WebSocket streaming endpoint and defaults to the Coda model/voice.

* **Bug Fixes**
  * Improved handling of interleaved protocol events so audio assembly and timing (TTFA) are more reliable.
  * Scatter chart provider assignment fixed for accurate model attribution.

* **Chores**
  * Added Coda to color and display-name configs for charts and UI.

* **Tests**
  * Updated TTS tests to exercise the WebSocket protocol and related edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/coval-ai/benchmarks/pull/22?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->