### PR TITLE
feat(providers/tts): benchmark Hume over WebSocket

### DIFF
--- a/runner/src/coval_bench/providers/tts/hume.py
+++ b/runner/src/coval_bench/providers/tts/hume.py
@@ -2,13 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """Hume TTS provider — WebSocket streaming to Hume Octave TTS API.
-
-Wire protocol (single-utterance benchmark path):
-  connect (api_key in URL, version in URL) -> t0 -> send text msg -> send flush
-  -> recv binary PCM frames -> send close -> WS closes naturally
-
-Auth: api_key query param in WSS URL (Hume WS does not accept headers).
-Audio: raw PCM linear16 at 48 kHz mono (strip_headers=true, format_type=pcm).
+Hume WS does not accept headers
 """
 
 from __future__ import annotations
@@ -98,7 +92,6 @@ class HumeTTSProvider(TTSProvider):
             async with asyncio.timeout(_WS_SESSION_TIMEOUT_S):
                 async with ws_client.connect(url) as ws:
                     # t0: connection established; Hume WS sends no setup message.
-                    # Consistent with Cartesia/Deepgram/Gradium WS group convention.
                     start = time.monotonic()
 
                     await ws.send(
@@ -112,7 +105,6 @@ class HumeTTSProvider(TTSProvider):
                         )
                     )
                     await ws.send(json.dumps({"flush": True}))
-                    # Signal end of input; server sends remaining audio then closes.
                     await ws.send(json.dumps({"close": True}))
 
                     async for raw in ws:

--- a/runner/src/coval_bench/providers/tts/hume.py
+++ b/runner/src/coval_bench/providers/tts/hume.py
@@ -1,55 +1,52 @@
 # Copyright 2026 The Coval Benchmarks Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Hume TTS provider — requires the optional ``hume-tts`` extra.
+"""Hume TTS provider — WebSocket streaming to Hume Octave TTS API.
 
-Install with:
-    pip install "coval-bench[hume-tts]"
+Wire protocol (single-utterance benchmark path):
+  connect (api_key in URL, version in URL) -> t0 -> send text msg -> send flush
+  -> recv binary PCM frames -> send close -> WS closes naturally
 
-If the ``hume`` package is not installed, importing this module raises
-``ImportError``. The ``__init__.py`` registry catches this and sets
-``HUME_AVAILABLE = False``. Tests should use
-``pytest.importorskip("hume")`` to skip automatically when the extra
-is absent.
+Auth: api_key query param in WSS URL (Hume WS does not accept headers).
+Audio: raw PCM linear16 at 48 kHz mono (strip_headers=true, format_type=pcm).
 """
 
 from __future__ import annotations
 
+import asyncio
+import json
 import os
 import tempfile
 import time
+import wave
 from pathlib import Path
+from urllib.parse import urlencode
 
 import structlog
-
-# This import is intentionally left to propagate ImportError if hume is absent.
-from hume import HumeClient
-from hume.tts import (
-    FormatWav,
-    PostedUtterance,
-    PostedUtteranceVoiceWithId,
-)
+import websockets.asyncio.client as ws_client
 
 from coval_bench.config import Settings
 from coval_bench.providers.base import TTSProvider, TTSResult
 
 logger: structlog.BoundLogger = structlog.get_logger(__name__)
 
-SAMPLE_RATE = 24000
+SAMPLE_RATE = 48000
+_WS_BASE = "wss://api.hume.ai/v0/tts/stream/input"
+_WS_SESSION_TIMEOUT_S = 30.0
 
-# Models supported by this provider
 SUPPORTED_MODELS = {"octave-tts", "octave-2"}
+# Maps model name to Hume version query param
+_MODEL_TO_VERSION: dict[str, str] = {"octave-tts": "1", "octave-2": "2"}
 
-# Default voice ID for octave models (Hume AI built-in)
 _DEFAULT_VOICE_ID = "176a55b1-4468-4736-8878-db82729667c1"
 
 
 class HumeTTSProvider(TTSProvider):
-    """Hume TTS provider (optional — requires ``hume-tts`` extra)."""
+    """Hume TTS provider using WebSocket streaming (Octave Speak API)."""
 
-    enabled: bool = False  # Commented out in legacy run_tts.py
+    enabled: bool = False
 
-    def __init__(self, settings: Settings, model: str, voice: str) -> None:
+    def __init__(self, settings: Settings, model: str, voice: str | None) -> None:
         self._model = model
         self._voice = voice
 
@@ -66,17 +63,14 @@ class HumeTTSProvider(TTSProvider):
     def model(self) -> str:
         return self._model
 
-    @staticmethod
-    def _is_audio_chunk(chunk: object) -> bool:
-        return isinstance(chunk, bytes) and len(chunk) > 0
-
     async def synthesize(self, text: str) -> TTSResult:
-        """Synthesize speech via Hume SDK and return a TTSResult."""
+        """Synthesize speech via Hume WebSocket and return a TTSResult."""
+        voice_id = self._voice if self._voice else _DEFAULT_VOICE_ID
         if self._model not in SUPPORTED_MODELS:
             return TTSResult(
                 provider="hume",
                 model=self._model,
-                voice=self._voice,
+                voice=voice_id,
                 ttfa_ms=None,
                 audio_path=None,
                 error=(
@@ -84,72 +78,106 @@ class HumeTTSProvider(TTSProvider):
                 ),
             )
 
+        version = _MODEL_TO_VERSION[self._model]
+
         audio_chunks: list[bytes] = []
         ttfa_ms: float | None = None
 
+        qs = urlencode(
+            {
+                "api_key": self._api_key,
+                "instant_mode": "true",
+                "format_type": "pcm",
+                "strip_headers": "true",
+                "version": version,
+            }
+        )
+        url = f"{_WS_BASE}?{qs}"
+
         try:
-            client = HumeClient(api_key=self._api_key)
+            async with asyncio.timeout(_WS_SESSION_TIMEOUT_S):
+                async with ws_client.connect(url) as ws:
+                    # t0: connection established; Hume WS sends no setup message.
+                    # Consistent with Cartesia/Deepgram/Gradium WS group convention.
+                    start = time.monotonic()
 
-            voice_id = self._voice if self._voice else _DEFAULT_VOICE_ID
-
-            start = time.monotonic()
-
-            response = client.tts.synthesize_file_streaming(
-                utterances=[
-                    PostedUtterance(
-                        text=text,
-                        voice=PostedUtteranceVoiceWithId(
-                            id=voice_id,
-                            provider="HUME_AI",
-                        ),
-                    )
-                ],
-                format=FormatWav(),
-                num_generations=1,
-                instant_mode=True,
-            )
-
-            for chunk in response:
-                if self._is_audio_chunk(chunk):
-                    if ttfa_ms is None:
-                        ttfa_ms = (time.monotonic() - start) * 1000
-                        logger.debug(
-                            "hume_ttfa",
-                            model=self._model,
-                            ttfa_ms=ttfa_ms,
+                    await ws.send(
+                        json.dumps(
+                            {
+                                "text": text,
+                                "voice": {"id": voice_id, "provider": "HUME_AI"},
+                                "speed": 1.0,
+                                "trailing_silence": 0,
+                            }
                         )
-                    audio_chunks.append(chunk)
+                    )
+                    await ws.send(json.dumps({"flush": True}))
+                    # Signal end of input; server sends remaining audio then closes.
+                    await ws.send(json.dumps({"close": True}))
 
-        except Exception as exc:
-            logger.debug("hume_error", exc_info=True)
+                    async for raw in ws:
+                        if isinstance(raw, bytes) and len(raw) > 0:
+                            if ttfa_ms is None:
+                                ttfa_ms = (time.monotonic() - start) * 1000
+                                logger.debug(
+                                    "hume_ttfa",
+                                    model=self._model,
+                                    ttfa_ms=ttfa_ms,
+                                )
+                            audio_chunks.append(raw)
+                        elif isinstance(raw, str):
+                            try:
+                                msg = json.loads(raw)
+                                if msg.get("type") == "error":
+                                    raise RuntimeError(str(msg.get("message", msg)))
+                            except (json.JSONDecodeError, KeyError):
+                                pass
+
+        except TimeoutError:
+            logger.warning(
+                "hume_timeout",
+                model=self._model,
+                timeout_s=_WS_SESSION_TIMEOUT_S,
+            )
             return TTSResult(
                 provider="hume",
                 model=self._model,
-                voice=self._voice,
+                voice=voice_id,
+                ttfa_ms=ttfa_ms,
+                audio_path=None,
+                error=f"Hume WebSocket session timed out after {_WS_SESSION_TIMEOUT_S}s",
+            )
+
+        except Exception as exc:
+            logger.warning("hume_error", exc_info=True)
+            return TTSResult(
+                provider="hume",
+                model=self._model,
+                voice=voice_id,
                 ttfa_ms=ttfa_ms,
                 audio_path=None,
                 error=str(exc),
             )
 
-        audio_path: Path | None = None
-        if audio_chunks:
-            audio_path = _write_raw(audio_chunks)
-
+        audio_path = _write_wav(audio_chunks, SAMPLE_RATE) if audio_chunks else None
         return TTSResult(
             provider="hume",
             model=self._model,
-            voice=self._voice,
+            voice=voice_id,
             ttfa_ms=ttfa_ms,
             audio_path=audio_path,
             error=None,
         )
 
 
-def _write_raw(chunks: list[bytes]) -> Path:
-    """Write Hume audio chunks (already WAV-formatted) to a temp file."""
+def _write_wav(chunks: list[bytes], sample_rate: int) -> Path:
+    """Concatenate raw PCM chunks and write a WAV file."""
     fd, tmp_name = tempfile.mkstemp(suffix=".wav")
     os.close(fd)
-    with open(tmp_name, "wb") as fh:
-        for chunk in chunks:
-            fh.write(chunk)
+    audio_data = b"".join(chunks)
+    with wave.open(tmp_name, "wb") as wav_file:
+        wav_file.setnchannels(1)
+        wav_file.setsampwidth(2)
+        wav_file.setframerate(sample_rate)
+        wav_file.writeframes(audio_data)
     return Path(tmp_name)

--- a/runner/src/coval_bench/runner/config.py
+++ b/runner/src/coval_bench/runner/config.py
@@ -110,11 +110,18 @@ DEFAULT_TTS_MATRIX: list[ProviderEntry] = [
     ProviderEntry(provider="rime", model="arcana", voice="luna", enabled=True),
     ProviderEntry(provider="rime", model="mistv3", voice="luna", enabled=True),
     ProviderEntry(provider="rime", model="mistv2", voice="luna", enabled=False, disabled=True),
-    # Hidden from the public catalogue (`disabled=True`). Never executed.
     ProviderEntry(
-        provider="hume", model="octave-tts", voice="male_01", enabled=False, disabled=True
+        provider="hume",
+        model="octave-tts",
+        voice="176a55b1-4468-4736-8878-db82729667c1",
+        enabled=True,
     ),
-    ProviderEntry(provider="hume", model="octave-2", voice="male_01", enabled=False, disabled=True),
+    ProviderEntry(
+        provider="hume",
+        model="octave-2",
+        voice="176a55b1-4468-4736-8878-db82729667c1",
+        enabled=True,
+    ),
     # Placeholder entries with voice=None — never executed by the runner; surfaced only
     # in /v1/providers so the frontend can label them as disabled.
     ProviderEntry(

--- a/runner/tests/providers/tts/conftest.py
+++ b/runner/tests/providers/tts/conftest.py
@@ -11,6 +11,7 @@ monkeypatched fake SDKs.
 from __future__ import annotations
 
 import wave as _wave
+from collections.abc import Sequence
 from io import BytesIO
 from pathlib import Path
 from typing import Any
@@ -79,7 +80,7 @@ def sample_text() -> str:
 class FakeWebSocket:
     """Minimal async context-manager fake for websockets.connect()."""
 
-    def __init__(self, messages: list[str | bytes]) -> None:
+    def __init__(self, messages: Sequence[str | bytes]) -> None:
         self._messages = list(messages)
         self._idx = 0
         self.sent: list[str | bytes] = []
@@ -99,6 +100,15 @@ class FakeWebSocket:
 
     async def __aexit__(self, *_: object) -> None:
         pass
+
+    def __aiter__(self) -> FakeWebSocket:
+        return self
+
+    async def __anext__(self) -> str | bytes:
+        try:
+            return await self.recv()
+        except StopAsyncIteration:
+            raise StopAsyncIteration from None
 
 
 # ---------------------------------------------------------------------------

--- a/runner/tests/providers/tts/test_hume.py
+++ b/runner/tests/providers/tts/test_hume.py
@@ -1,31 +1,22 @@
 # Copyright 2026 The Coval Benchmarks Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Tests for the Hume TTS provider.
-
-The ``hume`` package is an optional dependency.  Tests in this file are
-skipped automatically when the extra is not installed::
-
-    pytest.importorskip("hume")
-
-To run these tests locally::
-
-    pip install "coval-bench[hume-tts]"
-"""
+"""Tests for the Hume WebSocket TTS provider."""
 
 from __future__ import annotations
 
+import json
+import wave
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
+from urllib.parse import parse_qs, urlparse
 
 import pytest
 
-hume = pytest.importorskip("hume")
-
 from coval_bench.config import Settings  # noqa: E402
-from coval_bench.providers.tts.hume import HumeTTSProvider  # noqa: E402
+from coval_bench.providers.tts.hume import SAMPLE_RATE, HumeTTSProvider  # noqa: E402
 
-from .conftest import make_wav_bytes  # noqa: E402
+from .conftest import FakeWebSocket, make_pcm_bytes  # noqa: E402
 
 # ---------------------------------------------------------------------------
 # Happy path
@@ -34,19 +25,14 @@ from .conftest import make_wav_bytes  # noqa: E402
 
 @pytest.mark.asyncio
 async def test_hume_happy_path(fake_settings: Settings, tmp_path: Path) -> None:
-    """Hume octave-tts synthesize → ttfa set, WAV file written."""
-    wav_chunks = [make_wav_bytes(240)]
+    """Hume octave-tts synthesize sets TTFA and writes WAV output."""
+    pcm_chunks: list[str | bytes] = [make_pcm_bytes(240)]
     provider = HumeTTSProvider(
         fake_settings, model="octave-tts", voice="176a55b1-4468-4736-8878-db82729667c1"
     )
+    ws = FakeWebSocket(pcm_chunks)
 
-    mock_tts = MagicMock()
-    mock_tts.synthesize_file_streaming.return_value = iter(wav_chunks)
-
-    mock_client = MagicMock()
-    mock_client.tts = mock_tts
-
-    with patch("coval_bench.providers.tts.hume.HumeClient", return_value=mock_client):
+    with patch("coval_bench.providers.tts.hume.ws_client.connect", return_value=ws):
         result = await provider.synthesize("Hello from Hume")
 
     assert result.error is None, f"Unexpected error: {result.error}"
@@ -64,20 +50,86 @@ async def test_hume_happy_path(fake_settings: Settings, tmp_path: Path) -> None:
 @pytest.mark.asyncio
 async def test_hume_octave_2_model(fake_settings: Settings) -> None:
     """octave-2 model also succeeds."""
-    wav_chunk = make_wav_bytes(240)
     provider = HumeTTSProvider(fake_settings, model="octave-2", voice="test-voice-id")
+    ws = FakeWebSocket([make_pcm_bytes(240)])
 
-    mock_tts = MagicMock()
-    mock_tts.synthesize_file_streaming.return_value = iter([wav_chunk])
-    mock_client = MagicMock()
-    mock_client.tts = mock_tts
-
-    with patch("coval_bench.providers.tts.hume.HumeClient", return_value=mock_client):
+    with patch("coval_bench.providers.tts.hume.ws_client.connect", return_value=ws):
         result = await provider.synthesize("test octave-2")
 
     assert result.error is None
     if result.audio_path:
         result.audio_path.unlink()
+
+
+# ---------------------------------------------------------------------------
+# Protocol: sent messages and URL shape
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_hume_sends_text_flush_and_close(fake_settings: Settings) -> None:
+    """Provider sends text, flush, then close messages in order."""
+    ws = FakeWebSocket([make_pcm_bytes(240)])
+    provider = HumeTTSProvider(fake_settings, model="octave-tts", voice="test-voice-id")
+
+    with patch("coval_bench.providers.tts.hume.ws_client.connect", return_value=ws):
+        await provider.synthesize("test text")
+
+    assert len(ws.sent) >= 3
+    first = json.loads(ws.sent[0])
+    second = json.loads(ws.sent[1])
+    third = json.loads(ws.sent[2])
+    assert first == {
+        "text": "test text",
+        "voice": {"id": "test-voice-id", "provider": "HUME_AI"},
+        "speed": 1.0,
+        "trailing_silence": 0,
+    }
+    assert second == {"flush": True}
+    assert third == {"close": True}
+
+
+@pytest.mark.asyncio
+async def test_hume_url_shape(fake_settings: Settings) -> None:
+    """WS URL targets Hume input streaming endpoint with PCM params."""
+    ws = FakeWebSocket([make_pcm_bytes(240)])
+    captured: dict[str, str] = {}
+
+    def _capture(url: str, **_kwargs: object) -> FakeWebSocket:
+        captured["url"] = url
+        return ws
+
+    provider = HumeTTSProvider(fake_settings, model="octave-2", voice="test-voice-id")
+
+    with patch("coval_bench.providers.tts.hume.ws_client.connect", side_effect=_capture):
+        await provider.synthesize("url test")
+
+    parsed = urlparse(captured["url"])
+    qs = parse_qs(parsed.query)
+
+    assert parsed.hostname == "api.hume.ai"
+    assert parsed.path == "/v0/tts/stream/input"
+    assert qs["api_key"] == ["test-hume-key"]
+    assert qs["instant_mode"] == ["true"]
+    assert qs["format_type"] == ["pcm"]
+    assert qs["strip_headers"] == ["true"]
+    assert qs["version"] == ["2"]
+
+
+@pytest.mark.asyncio
+async def test_hume_voice_fallback(fake_settings: Settings) -> None:
+    """voice=None falls back to the built-in Hume voice ID in the text message."""
+    ws = FakeWebSocket([make_pcm_bytes(240)])
+    provider = HumeTTSProvider(fake_settings, model="octave-tts", voice="")
+
+    with patch("coval_bench.providers.tts.hume.ws_client.connect", return_value=ws):
+        await provider.synthesize("voice fallback")
+
+    first = json.loads(ws.sent[0])
+    assert first["voice"] == {
+        "id": "176a55b1-4468-4736-8878-db82729667c1",
+        "provider": "HUME_AI",
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -102,11 +154,11 @@ async def test_hume_unsupported_model(fake_settings: Settings) -> None:
 
 @pytest.mark.asyncio
 async def test_hume_sdk_error(fake_settings: Settings) -> None:
-    """SDK exception → result.error populated, audio_path None."""
+    """WebSocket exception populates result.error and leaves audio_path empty."""
     provider = HumeTTSProvider(fake_settings, model="octave-tts", voice="test-voice-id")
 
     with patch(
-        "coval_bench.providers.tts.hume.HumeClient",
+        "coval_bench.providers.tts.hume.ws_client.connect",
         side_effect=RuntimeError("Hume API error"),
     ):
         result = await provider.synthesize("error test")
@@ -120,18 +172,111 @@ async def test_hume_sdk_error(fake_settings: Settings) -> None:
 async def test_hume_empty_response(fake_settings: Settings) -> None:
     """No audio chunks → audio_path is None."""
     provider = HumeTTSProvider(fake_settings, model="octave-tts", voice="test-voice-id")
+    ws = FakeWebSocket([])
 
-    mock_tts = MagicMock()
-    mock_tts.synthesize_file_streaming.return_value = iter([])
-    mock_client = MagicMock()
-    mock_client.tts = mock_tts
-
-    with patch("coval_bench.providers.tts.hume.HumeClient", return_value=mock_client):
+    with patch("coval_bench.providers.tts.hume.ws_client.connect", return_value=ws):
         result = await provider.synthesize("silence")
 
     assert result.error is None
     assert result.audio_path is None
     assert result.ttfa_ms is None
+
+
+# ---------------------------------------------------------------------------
+# TTFA correctness
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_hume_ttfa_set_on_first_chunk_only(fake_settings: Settings) -> None:
+    """ttfa_ms is measured at the first audio chunk and not overwritten."""
+    ws = FakeWebSocket([make_pcm_bytes(240), make_pcm_bytes(240), make_pcm_bytes(240)])
+    provider = HumeTTSProvider(fake_settings, model="octave-tts", voice="test-voice-id")
+    # asyncio.timeout() may call monotonic before t0; pad leading values.
+    clock = iter([0.0, 0.0, 0.0, 0.1, 0.5, 0.9])
+
+    with (
+        patch("coval_bench.providers.tts.hume.ws_client.connect", return_value=ws),
+        patch("coval_bench.providers.tts.hume.time.monotonic", side_effect=clock),
+    ):
+        result = await provider.synthesize("three chunks")
+
+    assert result.error is None
+    assert result.ttfa_ms == pytest.approx(100.0)
+    if result.audio_path:
+        result.audio_path.unlink()
+
+
+@pytest.mark.asyncio
+async def test_hume_empty_chunk_not_counted(fake_settings: Settings) -> None:
+    """Empty binary messages must not set TTFA or write a WAV file."""
+    ws = FakeWebSocket([b""])
+    provider = HumeTTSProvider(fake_settings, model="octave-tts", voice="test-voice-id")
+
+    with patch("coval_bench.providers.tts.hume.ws_client.connect", return_value=ws):
+        result = await provider.synthesize("empty chunk")
+
+    assert result.error is None
+    assert result.audio_path is None
+    assert result.ttfa_ms is None
+
+
+@pytest.mark.asyncio
+async def test_hume_session_timeout(fake_settings: Settings) -> None:
+    """A stalled WebSocket session returns a clear timeout error."""
+    import asyncio
+
+    class StalledWebSocket(FakeWebSocket):
+        def __aiter__(self) -> StalledWebSocket:
+            return self
+
+        async def __anext__(self) -> bytes:
+            await asyncio.sleep(3600)
+            return b""
+
+    provider = HumeTTSProvider(fake_settings, model="octave-tts", voice="test-voice-id")
+    ws = StalledWebSocket([])
+
+    with (
+        patch("coval_bench.providers.tts.hume.ws_client.connect", return_value=ws),
+        patch("coval_bench.providers.tts.hume._WS_SESSION_TIMEOUT_S", 0.05),
+    ):
+        result = await provider.synthesize("stall")
+
+    assert result.error is not None
+    assert "timed out" in result.error.lower()
+    assert result.audio_path is None
+
+
+@pytest.mark.asyncio
+async def test_hume_server_error_event(fake_settings: Settings) -> None:
+    """A server error frame populates result.error."""
+    ws = FakeWebSocket([json.dumps({"type": "error", "message": "rate limit exceeded"})])
+    provider = HumeTTSProvider(fake_settings, model="octave-tts", voice="test-voice-id")
+
+    with patch("coval_bench.providers.tts.hume.ws_client.connect", return_value=ws):
+        result = await provider.synthesize("error frame")
+
+    assert result.error is not None
+    assert "rate limit exceeded" in result.error
+    assert result.audio_path is None
+
+
+@pytest.mark.asyncio
+async def test_hume_write_wav_sample_rate(fake_settings: Settings) -> None:
+    """Hume writes raw PCM chunks as 48 kHz WAV output."""
+    provider = HumeTTSProvider(fake_settings, model="octave-tts", voice="test-voice-id")
+    ws = FakeWebSocket([make_pcm_bytes(240)])
+
+    with patch("coval_bench.providers.tts.hume.ws_client.connect", return_value=ws):
+        result = await provider.synthesize("sample rate")
+
+    assert result.audio_path is not None
+    with wave.open(str(result.audio_path), "rb") as wav_file:
+        assert wav_file.getframerate() == SAMPLE_RATE
+        assert wav_file.getnchannels() == 1
+        assert wav_file.getsampwidth() == 2
+    result.audio_path.unlink()
 
 
 # ---------------------------------------------------------------------------

--- a/web/components/charts/CustomBarChartTick.tsx
+++ b/web/components/charts/CustomBarChartTick.tsx
@@ -17,6 +17,8 @@ const normalizeModelName = (modelName: string): string => {
     "aura-2-thalia-en": "Aura 2",
     arcana: "Arcana",
     mistv3: "Mist v3",
+    "octave-tts": "Octave TTS",
+    "octave-2": "Octave 2",
     // STT
     "nova-2": "Nova 2",
     "nova-3": "Nova 3",

--- a/web/lib/config/colors.ts
+++ b/web/lib/config/colors.ts
@@ -20,6 +20,10 @@ export const modelColors: Record<string, string> = {
   arcana: "#33FF99",
   mistv3: "#0E5C32",
 
+  // Hume TTS
+  "octave-tts": "#7C3AED",
+  "octave-2": "#C026D3",
+
   // Deepgram TTS
   "aura-2-thalia-en": "#FC2D62",
 
@@ -45,5 +49,6 @@ export const providerColors: Record<string, string> = {
   AssemblyAI: "#8E44AD",
   Speechmatics: "#21618C",
   Rime: "#27AE60",
-  Gradium: "#1ABC9C"
+  Gradium: "#1ABC9C",
+  Hume: "#A855F7"
 };

--- a/web/lib/config/models.ts
+++ b/web/lib/config/models.ts
@@ -11,6 +11,8 @@ export const modelDisplayNames: Record<string, string> = {
   "aura-2-thalia-en": "Aura 2",
   arcana: "Arcana",
   mistv3: "Mist v3",
+  "octave-tts": "Octave TTS",
+  "octave-2": "Octave 2",
   // STT
   "nova-2": "Nova 2",
   "nova-3": "Nova 3",

--- a/web/lib/utils/formatters.ts
+++ b/web/lib/utils/formatters.ts
@@ -65,6 +65,8 @@ export function normalizeModelName(modelName: string): string {
     "aura-2-thalia-en": "Aura 2",
     arcana: "Arcana",
     mistv3: "Mist v3",
+    "octave-tts": "Octave TTS",
+    "octave-2": "Octave 2",
     // STT
     "nova-2": "Nova 2",
     "nova-3": "Nova 3",


### PR DESCRIPTION
Replaces Hume SDK file streaming with WebSocket streaming so TTFA is measured apples-to-apples from connection to first audio chunk. Enables Hume Octave models and adds matching website labels/colors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled Hume TTS provider with Octave TTS and Octave 2 models; streaming synthesis now produces playable WAV output and supports voice fallback.
  * Switched TTS streaming to a WebSocket-based delivery for real-time audio.

* **UI Updates**
  * Added "Octave TTS" and "Octave 2" model names and a Hume provider color to the benchmark dashboard.

* **Tests**
  * Added comprehensive tests covering WebSocket streaming, error cases, timeouts, and WAV output verification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/coval-ai/benchmarks/pull/23?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->