### PR TITLE
[BENCH-176] audit deepgram stt

### DIFF
--- a/runner/src/coval_bench/providers/stt/deepgram.py
+++ b/runner/src/coval_bench/providers/stt/deepgram.py
@@ -237,7 +237,7 @@ class DeepgramProvider(STTProvider):
             result.audio_to_final_seconds = last_final_time - result.audio_start_time
 
         # Build complete transcript
-        if self._model == "flux-general-en":
+        if self._model in ("flux-general-en", "flux-general-multi"):
             result.complete_transcript = flux_latest.strip() or None
         elif final_segments:
             result.complete_transcript = " ".join(final_segments).strip()

--- a/runner/src/coval_bench/providers/stt/deepgram.py
+++ b/runner/src/coval_bench/providers/stt/deepgram.py
@@ -3,8 +3,10 @@
 
 """Deepgram real-time STT provider.
 
-Supports models: default (nova-2), nova-2, nova-3, flux-general-en.
-Wire protocol: WebSocket, wss://api.deepgram.com/v1/listen
+Supports models: default (nova-2), nova-2, nova-3, flux-general-en, flux-general-multi.
+Wire protocols:
+  nova-2 / nova-3 / default: wss://api.deepgram.com/v1/listen (Results events)
+  flux-general-*:            wss://api.deepgram.com/v2/listen  (TurnInfo events)
 Auth: Authorization: Token <key>
 Close: {"type": "CloseStream"}
 """
@@ -58,8 +60,11 @@ class DeepgramProvider(STTProvider):
             # `flux-general-multi` shares the same endpoint as `flux-general-en`;
             # we don't pass a language hint so the multilingual model auto-detects.
             return (
-                "wss://api.preview.deepgram.com/v2/listen"
-                f"?model={self._model}&sample_rate=16000&encoding=linear16"
+                "wss://api.deepgram.com/v2/listen"
+                f"?model={self._model}"
+                f"&sample_rate={sample_rate}"
+                f"&channels={channels}"
+                f"&encoding=linear16"
             )
         url = (
             f"wss://api.deepgram.com/v1/listen"
@@ -69,6 +74,7 @@ class DeepgramProvider(STTProvider):
             f"&interim_results=true"
             f"&vad_events=true"
             f"&no_delay=true"
+            f"&punctuate=true"
         )
         if self._model != "default":
             url += f"&model={self._model}"
@@ -175,7 +181,7 @@ class DeepgramProvider(STTProvider):
                     result.vad_events_count = (result.vad_events_count or 0) + 1
                     continue
 
-                if msg_type in ("SpeechEnded", "Metadata", "Connected"):
+                if msg_type in ("UtteranceEnd", "Metadata", "Connected"):
                     continue
 
                 # flux v2/listen emits TurnInfo (not Results). Each TurnInfo

--- a/runner/tests/providers/stt/test_deepgram.py
+++ b/runner/tests/providers/stt/test_deepgram.py
@@ -386,8 +386,7 @@ async def test_deepgram_flux_success(fake_api_key: SecretStr, audio_pcm_bytes: b
     assert result.ttft_seconds >= 0
     assert result.first_token_content is not None
     assert "hello" in result.first_token_content.lower()
-    assert result.complete_transcript is not None
-    assert "hello" in result.complete_transcript.lower()
+    assert result.complete_transcript == "hello world how are you"
     assert result.audio_to_final_seconds is not None
     assert result.audio_to_final_seconds >= 0
 

--- a/runner/tests/providers/stt/test_deepgram.py
+++ b/runner/tests/providers/stt/test_deepgram.py
@@ -365,9 +365,7 @@ async def test_deepgram_default_audio_to_final(
 
 @pytest.mark.asyncio
 async def test_deepgram_flux_success(fake_api_key: SecretStr, audio_pcm_bytes: bytes) -> None:
-    """flux-general-en: TTFT and audio_to_final_seconds are populated using the
-    standard channel.alternatives response shape (same wire format as nova-* but
-    on the preview endpoint)."""
+    """flux-general-en: TTFT and audio_to_final_seconds are populated from TurnInfo messages."""
     events = load_fixture_events("deepgram", "events-flux-success")
     provider = DeepgramProvider(api_key=fake_api_key, model="flux-general-en")
 

--- a/runner/tests/providers/stt/test_deepgram.py
+++ b/runner/tests/providers/stt/test_deepgram.py
@@ -411,3 +411,34 @@ async def test_deepgram_flux_audio_to_final_none_when_no_transcript(
         )
 
     assert result.audio_to_final_seconds is None
+
+
+# ---------------------------------------------------------------------------
+# Happy path — flux-general-multi
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_deepgram_flux_multi_success(fake_api_key: SecretStr, audio_pcm_bytes: bytes) -> None:
+    """flux-general-multi: TTFT and complete_transcript are populated from TurnInfo messages."""
+    events = load_fixture_events("deepgram", "events-flux-success")
+    provider = DeepgramProvider(api_key=fake_api_key, model="flux-general-multi")
+
+    with patch(
+        "coval_bench.providers.stt.deepgram.ws_client.connect",
+        return_value=_fake_connect(events),
+    ):
+        result = await provider.measure_ttft(
+            audio_data=audio_pcm_bytes,
+            channels=1,
+            sample_width=2,
+            sample_rate=16000,
+            realtime_resolution=0.5,
+        )
+
+    assert result.error is None
+    assert result.ttft_seconds is not None
+    assert result.ttft_seconds >= 0
+    assert result.complete_transcript == "hello world how are you"
+    assert result.audio_to_final_seconds is not None
+    assert result.audio_to_final_seconds >= 0

--- a/runner/tests/providers/stt/test_deepgram.py
+++ b/runner/tests/providers/stt/test_deepgram.py
@@ -111,9 +111,10 @@ def test_build_websocket_url_nova3() -> None:
 def test_build_websocket_url_flux() -> None:
     p = make_provider("flux-general-en")
     url = p._build_websocket_url(16000, 1)
-    assert "/v2/listen" in url
-    assert "preview.deepgram.com" in url
+    assert url.startswith("wss://api.deepgram.com/v2/listen")
+    assert "preview" not in url
     assert "flux-general-en" in url
+    assert "channels=1" in url
     # v2/listen rejects interim_results / no_delay as unknown query params and
     # closes the WS upgrade with HTTP 400 — both must be absent.
     assert "interim_results" not in url
@@ -123,8 +124,10 @@ def test_build_websocket_url_flux() -> None:
 def test_build_websocket_url_flux_multi() -> None:
     p = make_provider("flux-general-multi")
     url = p._build_websocket_url(16000, 1)
-    assert "/v2/listen" in url
+    assert url.startswith("wss://api.deepgram.com/v2/listen")
+    assert "preview" not in url
     assert "model=flux-general-multi" in url
+    assert "channels=1" in url
     # No language hint — multilingual model auto-detects.
     assert "language=" not in url
     assert "interim_results" not in url


### PR DESCRIPTION
A few things came up:
1. `flux-general-multi` was using the wrong path when processing the transcript. Updated it.
2. Flux was hitting a preview endpoint instead of the production url.
3. Added `punctuate=true` for nova models. Should make WER comparisons fairer.
4. We were assuming a `SpeechEnded` event but it was really an `UtteranceEnd` event.

Also updated the tests a bit. Big one was adding happy path test to `flux-general-multi`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Deepgram speech-to-text now selects the correct protocol per model variant and produces more accurate, complete transcripts for flux and nova model families.
  * Message handling and transcript completion logic refined for more reliable real-time speech results.

* **Tests**
  * Test coverage tightened with stricter URL validation and exact transcript assertions, plus a new multi-stream happy-path scenario.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/coval-ai/benchmarks/pull/28?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->