### PR TITLE
[BENCH-178] Audit assembly ai stt

### DIFF
--- a/runner/src/coval_bench/providers/stt/assemblyai.py
+++ b/runner/src/coval_bench/providers/stt/assemblyai.py
@@ -24,18 +24,23 @@ from coval_bench.providers.base import STTProvider, TranscriptionResult
 
 logger = structlog.get_logger(__name__)
 
-_VALID_MODELS = ("universal-streaming",)
-# speech_model is required by the API; format_turns is omitted (default=false) because
-# the formatting pass adds significant latency that would inflate TTFT measurements.
-_WS_URL = "wss://streaming.assemblyai.com/v3/ws?sample_rate=16000&speech_model=universal-streaming-english"
+# Maps user-facing model names to the speech_model value required by the API.
+# format_turns is omitted (default=false) — the formatting pass adds latency that
+# would inflate TTFT measurements.
+_SPEECH_MODEL_MAP: dict[str, str] = {
+    "universal-streaming": "universal-streaming-english",
+}
+_WS_BASE = "wss://streaming.assemblyai.com/v3/ws"
 
 
 class AssemblyAIProvider(STTProvider):
     """AssemblyAI v3 streaming STT provider."""
 
     def __init__(self, api_key: SecretStr, model: str = "universal-streaming") -> None:
-        if model not in _VALID_MODELS:
-            raise ValueError(f"Invalid AssemblyAI model {model!r}. Valid: {_VALID_MODELS}")
+        if model not in _SPEECH_MODEL_MAP:
+            raise ValueError(
+                f"Invalid AssemblyAI model {model!r}. Valid: {tuple(_SPEECH_MODEL_MAP)}"
+            )
         self._api_key = api_key
         self._model = model
 
@@ -63,8 +68,10 @@ class AssemblyAIProvider(STTProvider):
         total_start = time.monotonic()
 
         try:
+            speech_model = _SPEECH_MODEL_MAP[self._model]
+            url = f"{_WS_BASE}?sample_rate={sample_rate}&speech_model={speech_model}"
             headers = {"Authorization": self._api_key.get_secret_value()}
-            async with ws_client.connect(_WS_URL, additional_headers=headers) as ws:
+            async with ws_client.connect(url, additional_headers=headers) as ws:
                 send_task = asyncio.create_task(
                     self._send_audio(
                         ws,

--- a/runner/src/coval_bench/providers/stt/assemblyai.py
+++ b/runner/src/coval_bench/providers/stt/assemblyai.py
@@ -25,7 +25,9 @@ from coval_bench.providers.base import STTProvider, TranscriptionResult
 logger = structlog.get_logger(__name__)
 
 _VALID_MODELS = ("universal-streaming",)
-_WS_URL = "wss://streaming.assemblyai.com/v3/ws?sample_rate=16000&format_turns=true"
+# speech_model is required by the API; format_turns is omitted (default=false) because
+# the formatting pass adds significant latency that would inflate TTFT measurements.
+_WS_URL = "wss://streaming.assemblyai.com/v3/ws?sample_rate=16000&speech_model=universal-streaming-english"
 
 
 class AssemblyAIProvider(STTProvider):
@@ -124,11 +126,13 @@ class AssemblyAIProvider(STTProvider):
                 now = time.monotonic()
                 msg_type: str = msg.get("type", "")
 
-                if msg_type == "Begin":
+                if msg_type in ("Begin", "Termination"):
                     continue
 
                 transcript = self._extract_transcript(msg)
                 if transcript:
+                    # TTFT fires on the first Turn regardless of end_of_turn. We want
+                    # time-to-first-word, not time-to-first-completed-sentence.
                     if result.ttft_seconds is None and result.audio_start_time is not None:
                         result.ttft_seconds = now - result.audio_start_time
                         result.first_token_content = (

--- a/runner/tests/providers/stt/test_assemblyai.py
+++ b/runner/tests/providers/stt/test_assemblyai.py
@@ -68,11 +68,13 @@ async def test_assemblyai_success(fake_api_key: SecretStr, audio_pcm_bytes: byte
 
 
 def test_websocket_url_contains_required_params() -> None:
-    from coval_bench.providers.stt.assemblyai import _WS_URL
+    from coval_bench.providers.stt.assemblyai import _SPEECH_MODEL_MAP, _WS_BASE
 
-    assert "speech_model=" in _WS_URL
-    assert "format_turns" not in _WS_URL
-    assert "streaming.assemblyai.com/v3/ws" in _WS_URL
+    assert "streaming.assemblyai.com/v3/ws" in _WS_BASE
+    # Every mapped speech_model value must be a non-empty API string
+    for user_name, api_name in _SPEECH_MODEL_MAP.items():
+        assert api_name, f"model {user_name!r} maps to an empty speech_model"
+        assert "format_turns" not in api_name
 
 
 # ---------------------------------------------------------------------------

--- a/runner/tests/providers/stt/test_assemblyai.py
+++ b/runner/tests/providers/stt/test_assemblyai.py
@@ -63,6 +63,19 @@ async def test_assemblyai_success(fake_api_key: SecretStr, audio_pcm_bytes: byte
 
 
 # ---------------------------------------------------------------------------
+# URL sanity
+# ---------------------------------------------------------------------------
+
+
+def test_websocket_url_contains_required_params() -> None:
+    from coval_bench.providers.stt.assemblyai import _WS_URL
+
+    assert "speech_model=" in _WS_URL
+    assert "format_turns" not in _WS_URL
+    assert "streaming.assemblyai.com/v3/ws" in _WS_URL
+
+
+# ---------------------------------------------------------------------------
 # Provider name
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
- Dropped format_turns. Docs expressely call out that it increases latency. Unfair when we're testing TTFT (Time to First Token).
- Add `speech_model=universal-streaming-english`. Required and we didn't have it.
- Add `Termination` to ignore list. Previously would have been extracted as a transcript.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved AssemblyAI speech-to-text streaming: more robust message handling and more accurate time-to-first-transcript behavior, yielding more reliable live transcription.

* **Tests**
  * Added a sanity check to validate the speech-to-text provider endpoint and model mappings are configured as expected.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/coval-ai/benchmarks/pull/29?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->