### PR TITLE
[BENCH-177] Audit elevenlabs stt

### DIFF
--- a/runner/src/coval_bench/providers/stt/elevenlabs.py
+++ b/runner/src/coval_bench/providers/stt/elevenlabs.py
@@ -29,19 +29,19 @@ _VALID_MODELS = ("scribe_v1", "scribe_v2_realtime")
 
 _ERROR_MSG_TYPES = frozenset(
     {
-        "scribe_error",
-        "scribe_auth_error",
-        "scribe_quota_exceeded_error",
-        "scribe_throttled_error",
-        "scribe_unaccepted_terms_error",
-        "scribe_rate_limited_error",
-        "scribe_queue_overflow_error",
-        "scribe_resource_exhausted_error",
-        "scribe_session_time_limit_exceeded_error",
-        "scribe_input_error",
-        "scribe_chunk_size_exceeded_error",
-        "scribe_insufficient_audio_activity_error",
-        "scribe_transcriber_error",
+        "error",
+        "auth_error",
+        "quota_exceeded",
+        "commit_throttled",
+        "rate_limited",
+        "unaccepted_terms",
+        "queue_overflow",
+        "resource_exhausted",
+        "session_time_limit_exceeded",
+        "input_error",
+        "chunk_size_exceeded",
+        "insufficient_audio_activity",
+        "transcriber_error",
     }
 )
 
@@ -64,7 +64,10 @@ class ElevenLabsSTTProvider(STTProvider):
         return self._model
 
     def _build_websocket_url(self) -> str:
-        return f"wss://api.elevenlabs.io/v1/speech-to-text/realtime?model_id={self._model}"
+        return (
+            f"wss://api.elevenlabs.io/v1/speech-to-text/realtime"
+            f"?model_id={self._model}&audio_format=pcm_16000"
+        )
 
     async def measure_ttft(
         self,
@@ -173,6 +176,10 @@ class ElevenLabsSTTProvider(STTProvider):
                         result.partial_transcripts.append(transcript)
 
                 elif msg_type in ("committed_transcript", "committed_transcript_with_timestamps"):
+                    # Both types carry "text" in the same position.
+                    # committed_transcript_with_timestamps arrives when include_timestamps=true,
+                    # but handling it defensively prevents silent data loss if the server ever
+                    # sends it unexpectedly (account setting, API default change, etc.).
                     transcript = msg.get("text", "").strip()
                     if transcript:
                         committed_parts.append(transcript)

--- a/runner/src/coval_bench/providers/stt/elevenlabs.py
+++ b/runner/src/coval_bench/providers/stt/elevenlabs.py
@@ -78,6 +78,8 @@ class ElevenLabsSTTProvider(STTProvider):
         realtime_resolution: float = 0.1,
         audio_duration: float | None = None,
     ) -> TranscriptionResult:
+        if sample_rate != 16000:
+            raise ValueError(f"ElevenLabs requires 16 kHz PCM input; got {sample_rate} Hz")
         result = TranscriptionResult(provider=self.name, vad_events_count=0)
         total_start = time.monotonic()
 

--- a/runner/src/coval_bench/providers/stt/elevenlabs.py
+++ b/runner/src/coval_bench/providers/stt/elevenlabs.py
@@ -42,6 +42,19 @@ _ERROR_MSG_TYPES = frozenset(
         "chunk_size_exceeded",
         "insufficient_audio_activity",
         "transcriber_error",
+        "scribe_error",
+        "scribe_auth_error",
+        "scribe_quota_exceeded_error",
+        "scribe_throttled_error",
+        "scribe_unaccepted_terms_error",
+        "scribe_rate_limited_error",
+        "scribe_queue_overflow_error",
+        "scribe_resource_exhausted_error",
+        "scribe_session_time_limit_exceeded_error",
+        "scribe_input_error",
+        "scribe_chunk_size_exceeded_error",
+        "scribe_insufficient_audio_activity_error",
+        "scribe_transcriber_error",
     }
 )
 

--- a/runner/tests/providers/stt/test_elevenlabs.py
+++ b/runner/tests/providers/stt/test_elevenlabs.py
@@ -95,6 +95,23 @@ def test_invalid_model_raises() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Invalid sample rate
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_elevenlabs_wrong_sample_rate(audio_pcm_bytes: bytes) -> None:
+    provider = ElevenLabsSTTProvider(api_key=SecretStr("k"))
+    with pytest.raises(ValueError, match="16 kHz"):
+        await provider.measure_ttft(
+            audio_data=audio_pcm_bytes,
+            channels=1,
+            sample_width=2,
+            sample_rate=8000,
+        )
+
+
+# ---------------------------------------------------------------------------
 # Failure path — error event
 # ---------------------------------------------------------------------------
 

--- a/runner/tests/providers/stt/test_elevenlabs.py
+++ b/runner/tests/providers/stt/test_elevenlabs.py
@@ -117,10 +117,13 @@ async def test_elevenlabs_wrong_sample_rate(audio_pcm_bytes: bytes) -> None:
 
 
 @pytest.mark.asyncio
-async def test_elevenlabs_api_error(fake_api_key: SecretStr, audio_pcm_bytes: bytes) -> None:
+@pytest.mark.parametrize("message_type", ["auth_error", "scribe_auth_error"])
+async def test_elevenlabs_api_error(
+    message_type: str, fake_api_key: SecretStr, audio_pcm_bytes: bytes
+) -> None:
     error_events = [
         {"message_type": "session_started", "session_id": "x", "config": {}},
-        {"message_type": "auth_error", "message": "Invalid API key"},
+        {"message_type": message_type, "message": "Invalid API key"},
     ]
     provider = ElevenLabsSTTProvider(api_key=fake_api_key)
 
@@ -137,7 +140,7 @@ async def test_elevenlabs_api_error(fake_api_key: SecretStr, audio_pcm_bytes: by
         )
 
     assert result.error is not None
-    assert "auth_error" in result.error
+    assert message_type in result.error
     assert result.complete_transcript is None
 
 

--- a/runner/tests/providers/stt/test_elevenlabs.py
+++ b/runner/tests/providers/stt/test_elevenlabs.py
@@ -71,6 +71,7 @@ def test_build_websocket_url() -> None:
     url = p._build_websocket_url()
     assert "elevenlabs.io" in url
     assert "scribe_v2_realtime" in url
+    assert "audio_format=pcm_16000" in url
 
 
 # ---------------------------------------------------------------------------
@@ -102,7 +103,7 @@ def test_invalid_model_raises() -> None:
 async def test_elevenlabs_api_error(fake_api_key: SecretStr, audio_pcm_bytes: bytes) -> None:
     error_events = [
         {"message_type": "session_started", "session_id": "x", "config": {}},
-        {"message_type": "scribe_auth_error", "message": "Invalid API key"},
+        {"message_type": "auth_error", "message": "Invalid API key"},
     ]
     provider = ElevenLabsSTTProvider(api_key=fake_api_key)
 
@@ -119,7 +120,7 @@ async def test_elevenlabs_api_error(fake_api_key: SecretStr, audio_pcm_bytes: by
         )
 
     assert result.error is not None
-    assert "scribe_auth_error" in result.error
+    assert "auth_error" in result.error
     assert result.complete_transcript is None
 
 


### PR DESCRIPTION
- Update error types to match current API.
- Explicitly add audio format. Not a huge issue but this heads off any potential weirdness from a change to the default.
- Add a comment on why we're handling committed_transcript_with_timestamps even if we're not relying on timestamps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated ElevenLabs real-time speech-to-text to recognize new error types for clearer failure messages.
  * WebSocket connections now explicitly specify the required audio format to improve compatibility.
  * Improved transcript commitment handling to reduce risk of silent transcript loss.
  * Calls using non-16 kHz audio now fail fast with a clear error.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/coval-ai/benchmarks/pull/30?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->