### PR TITLE
[BENCH-183] Use stream endpoint for ElevenLabs TTS TTFA

### DIFF
--- a/runner/src/coval_bench/providers/tts/elevenlabs.py
+++ b/runner/src/coval_bench/providers/tts/elevenlabs.py
@@ -91,7 +91,7 @@ class ElevenLabsTTSProvider(TTSProvider):
             client = ElevenLabs(api_key=self._api_key)
             start = time.monotonic()
 
-            response = client.text_to_speech.convert(
+            response = client.text_to_speech.stream(
                 voice_id=self._voice,
                 output_format="pcm_24000",
                 text=text,

--- a/runner/tests/providers/tts/test_elevenlabs.py
+++ b/runner/tests/providers/tts/test_elevenlabs.py
@@ -32,7 +32,7 @@ async def test_elevenlabs_happy_path(fake_settings: Settings, tmp_path: Path) ->
     )
 
     mock_sdk = MagicMock()
-    mock_sdk.text_to_speech.convert.return_value = iter(pcm_chunks)
+    mock_sdk.text_to_speech.stream.return_value = iter(pcm_chunks)
 
     with patch("coval_bench.providers.tts.elevenlabs.ElevenLabs", return_value=mock_sdk):
         result = await provider.synthesize("Hello from ElevenLabs")
@@ -58,7 +58,7 @@ async def test_elevenlabs_all_models(fake_settings: Settings) -> None:
     for model in SUPPORTED_MODELS:
         provider = ElevenLabsTTSProvider(fake_settings, model=model, voice="test-voice")
         mock_sdk = MagicMock()
-        mock_sdk.text_to_speech.convert.return_value = iter([pcm])
+        mock_sdk.text_to_speech.stream.return_value = iter([pcm])
         with patch("coval_bench.providers.tts.elevenlabs.ElevenLabs", return_value=mock_sdk):
             result = await provider.synthesize("test")
         assert result.error is None, f"Model {model}: {result.error}"
@@ -93,7 +93,7 @@ async def test_elevenlabs_empty_response(fake_settings: Settings) -> None:
     provider = ElevenLabsTTSProvider(fake_settings, model="eleven_flash_v2_5", voice="test-voice")
 
     mock_sdk = MagicMock()
-    mock_sdk.text_to_speech.convert.return_value = iter([])  # nothing
+    mock_sdk.text_to_speech.stream.return_value = iter([])  # nothing
 
     with patch("coval_bench.providers.tts.elevenlabs.ElevenLabs", return_value=mock_sdk):
         result = await provider.synthesize("silence")
@@ -165,7 +165,7 @@ async def test_elevenlabs_json_audio_chunks(fake_settings: Settings) -> None:
     provider = ElevenLabsTTSProvider(fake_settings, model="eleven_flash_v2_5", voice="test-voice")
 
     mock_sdk = MagicMock()
-    mock_sdk.text_to_speech.convert.return_value = iter([json_chunk])
+    mock_sdk.text_to_speech.stream.return_value = iter([json_chunk])
 
     with patch("coval_bench.providers.tts.elevenlabs.ElevenLabs", return_value=mock_sdk):
         result = await provider.synthesize("json audio test")


### PR DESCRIPTION
Switch `text_to_speech.convert` to `text_to_speech.stream` so TTFA is measured correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * ElevenLabs text-to-speech provider now uses streaming synthesis, improving audio delivery responsiveness and reducing time-to-first-audio while maintaining output quality and behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/coval-ai/benchmarks/pull/34?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->