### PR TITLE
[BENCH-185] Audit Deepgram implementation

### DIFF
--- a/runner/src/coval_bench/providers/tts/deepgram.py
+++ b/runner/src/coval_bench/providers/tts/deepgram.py
@@ -74,11 +74,10 @@ class DeepgramTTSProvider(TTSProvider):
                     if msg.get("type") == "Warning":
                         logger.warning("deepgram_ws_warning", description=msg.get("description"))
 
-                await ws.send(json.dumps({"type": "Speak", "text": text}))
-
                 # t0 — synthesis trigger (equivalent to the HTTP POST in the old path).
                 # Matches Cartesia's convention: t0 after connect, before text dispatch.
                 start = time.monotonic()
+                await ws.send(json.dumps({"type": "Speak", "text": text}))
                 await ws.send(json.dumps({"type": "Flush"}))
 
                 async for raw in ws:


### PR DESCRIPTION
Adjust where we begin the timer for TTFA to match how we time other providers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of time-to-first-audio measurements for Deepgram text-to-speech synthesis by adjusting the timing measurement window.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/coval-ai/benchmarks/pull/35?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->