### PR TITLE
[BENCH-186] Audit Rime TTS implementation

### DIFF
--- a/runner/src/coval_bench/providers/tts/rime.py
+++ b/runner/src/coval_bench/providers/tts/rime.py
@@ -22,10 +22,17 @@ from coval_bench.providers.base import TTSProvider, TTSResult
 
 logger: structlog.BoundLogger = structlog.get_logger(__name__)
 
-SAMPLE_RATE = 24000
 _WS_BASE = "wss://users-ws.rime.ai/ws3"
 
 VALID_MODELS = {"arcana", "coda", "mistv3"}
+
+# Native output sample rates per model; requesting each model's native rate
+# avoids server-side upsampling and produces the most faithful benchmark audio.
+_MODEL_SAMPLE_RATES: dict[str, int] = {
+    "arcana": 24000,
+    "coda": 24000,
+    "mistv3": 22050,
+}
 
 
 class RimeTTSProvider(TTSProvider):
@@ -66,13 +73,14 @@ class RimeTTSProvider(TTSProvider):
 
         audio_chunks: list[bytes] = []
         ttfa_ms: float | None = None
+        sample_rate = _MODEL_SAMPLE_RATES[self._model]
 
         qs = urlencode(
             {
                 "modelId": self._model,
                 "speaker": self._voice or "luna",
                 "audioFormat": "pcm",
-                "samplingRate": SAMPLE_RATE,
+                "samplingRate": sample_rate,
                 # segment=never: synthesis fires only on explicit eos, not on sentence
                 "segment": "never",
             }
@@ -121,7 +129,7 @@ class RimeTTSProvider(TTSProvider):
                 error=str(exc),
             )
 
-        audio_path = _write_wav(audio_chunks, SAMPLE_RATE) if audio_chunks else None
+        audio_path = _write_wav(audio_chunks, sample_rate) if audio_chunks else None
         return TTSResult(
             provider="rime",
             model=self._model,

--- a/runner/src/coval_bench/providers/tts/rime.py
+++ b/runner/src/coval_bench/providers/tts/rime.py
@@ -33,6 +33,11 @@ _MODEL_SAMPLE_RATES: dict[str, int] = {
     "coda": 24000,
     "mistv3": 22050,
 }
+if set(_MODEL_SAMPLE_RATES) != VALID_MODELS:
+    raise ValueError(
+        f"VALID_MODELS and _MODEL_SAMPLE_RATES are out of sync: "
+        f"{VALID_MODELS ^ set(_MODEL_SAMPLE_RATES)}"
+    )
 
 
 class RimeTTSProvider(TTSProvider):

--- a/runner/src/coval_bench/providers/tts/rime.py
+++ b/runner/src/coval_bench/providers/tts/rime.py
@@ -33,11 +33,6 @@ _MODEL_SAMPLE_RATES: dict[str, int] = {
     "coda": 24000,
     "mistv3": 22050,
 }
-if set(_MODEL_SAMPLE_RATES) != VALID_MODELS:
-    raise ValueError(
-        f"VALID_MODELS and _MODEL_SAMPLE_RATES are out of sync: "
-        f"{VALID_MODELS ^ set(_MODEL_SAMPLE_RATES)}"
-    )
 
 
 class RimeTTSProvider(TTSProvider):
@@ -78,7 +73,7 @@ class RimeTTSProvider(TTSProvider):
 
         audio_chunks: list[bytes] = []
         ttfa_ms: float | None = None
-        sample_rate = _MODEL_SAMPLE_RATES[self._model]
+        sample_rate = _MODEL_SAMPLE_RATES.get(self._model, 24000)
 
         qs = urlencode(
             {

--- a/runner/tests/providers/tts/test_rime.py
+++ b/runner/tests/providers/tts/test_rime.py
@@ -14,7 +14,7 @@ from urllib.parse import parse_qs, urlparse
 import pytest
 
 from coval_bench.config import Settings
-from coval_bench.providers.tts.rime import SAMPLE_RATE, RimeTTSProvider
+from coval_bench.providers.tts.rime import _MODEL_SAMPLE_RATES, RimeTTSProvider
 
 from .conftest import FakeWebSocket, make_pcm_bytes
 
@@ -119,7 +119,7 @@ async def test_rime_url_shape(fake_settings: Settings) -> None:
     assert parsed.path == "/ws3"
     assert qs["modelId"] == ["coda"]
     assert qs["audioFormat"] == ["pcm"]
-    assert qs["samplingRate"] == [str(SAMPLE_RATE)]
+    assert qs["samplingRate"] == [str(_MODEL_SAMPLE_RATES["coda"])]
     assert qs["segment"] == ["never"]
     assert qs["speaker"] == ["luna"]
 
@@ -144,6 +144,30 @@ async def test_rime_url_model_id(fake_settings: Settings, model: str) -> None:
         await provider.synthesize("test")
 
     assert parse_qs(urlparse(captured["url"]).query)["modelId"] == [model]
+
+
+@pytest.mark.asyncio
+async def test_rime_mistv3_uses_22050(fake_settings: Settings) -> None:
+    """mistv3 requests its native 22050 Hz sample rate, not the coda/arcana 24000."""
+    ws = FakeWebSocket(_ws3_events([make_pcm_bytes(240)]))
+    captured: dict[str, str] = {}
+
+    def _capture(url: str, **_kwargs: object) -> Any:
+        captured["url"] = url
+        return _fake_connect(ws)
+
+    provider = RimeTTSProvider(fake_settings, model="mistv3", voice="luna")
+
+    with patch(
+        "coval_bench.providers.tts.rime.ws_client.connect",
+        side_effect=_capture,
+    ):
+        result = await provider.synthesize("test")
+
+    assert result.error is None
+    assert parse_qs(urlparse(captured["url"]).query)["samplingRate"] == ["22050"]
+    if result.audio_path:
+        result.audio_path.unlink()
 
 
 # ---------------------------------------------------------------------------

--- a/runner/tests/providers/tts/test_rime.py
+++ b/runner/tests/providers/tts/test_rime.py
@@ -165,7 +165,9 @@ async def test_rime_mistv3_uses_22050(fake_settings: Settings) -> None:
         result = await provider.synthesize("test")
 
     assert result.error is None
-    assert parse_qs(urlparse(captured["url"]).query)["samplingRate"] == ["22050"]
+    assert parse_qs(urlparse(captured["url"]).query)["samplingRate"] == [
+        str(_MODEL_SAMPLE_RATES["mistv3"])
+    ]
     if result.audio_path:
         result.audio_path.unlink()
 


### PR DESCRIPTION
mistv3 samples at 22050Hz instead of 24000. Update the sampling rate variable so that there's no upsampling weirdness down the line.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rime text-to-speech now selects and uses each model's native audio sampling rate for WebSocket requests and output files instead of a single fixed rate.

* **Tests**
  * Improved test coverage to validate model-specific sampling rates, including a new async test ensuring a model requests its native rate.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/coval-ai/benchmarks/pull/36?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->