### PR TITLE
[BENCH-207] Add first_audible_offset_ms

### DIFF
--- a/runner/src/coval_bench/metrics/__init__.py
+++ b/runner/src/coval_bench/metrics/__init__.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """Public API for coval_bench metrics (WER, TTFA, TTFT, RTF)."""
 
-from coval_bench.metrics.ttfa import compute_ttfa
+from coval_bench.metrics.ttfa import compute_ttfa, first_audible_offset_ms
 from coval_bench.metrics.ttft import compute_audio_to_final, compute_rtf, compute_ttft
 from coval_bench.metrics.wer import WERResult, WordError, compute_wer, normalize_text
 
@@ -12,6 +12,7 @@ __all__ = [
     "compute_wer",
     "normalize_text",
     "compute_ttfa",
+    "first_audible_offset_ms",
     "compute_ttft",
     "compute_audio_to_final",
     "compute_rtf",

--- a/runner/src/coval_bench/metrics/ttfa.py
+++ b/runner/src/coval_bench/metrics/ttfa.py
@@ -1,29 +1,86 @@
 # Copyright 2026 The Coval Benchmarks Authors
 # SPDX-License-Identifier: Apache-2.0
-"""Time-To-First-Audio (TTFA) metric for TTS providers."""
+"""Time-To-First-Audio (TTFA) metric for TTS providers.
+
+Perceived TTFA is the wall-clock time until the first audio chunk arrives plus
+the leading silence inside the stream before the first audible sample, which is
+what an enqueue-and-play client actually experiences.
+"""
 
 from __future__ import annotations
 
+import librosa
+import numpy as np
 
-def compute_ttfa(audio_synthesis_start: float, first_audio_chunk_at: float) -> float:
-    """Return time-to-first-audio in **milliseconds**.
+# Loudness threshold and framing calibrated against recorded output from every
+# enabled provider. The threshold is an RMS level on normalized float audio
+# (range [-1, 1]); 0.01 sits above the worst leading noise floor and below
+# every voiced onset. Frame/hop are time-based so the window is a true 10 ms
+# regardless of sample rate (providers range 22.05k-48k).
+_AUDIBLE_RMS_THRESHOLD = 0.01
+_FRAME_SECONDS = 0.010
+_HOP_SECONDS = 0.001
 
-    Both arguments must be ``time.monotonic()`` readings captured by the
-    orchestrator around the TTS request.
+# Signed 16-bit PCM: 2 bytes per sample, full-scale 2**15 to normalize to [-1, 1].
+_PCM16_BYTES = 2
+_PCM16_FULL_SCALE = 32768.0
 
-    Args:
-        audio_synthesis_start: Monotonic timestamp immediately before the TTS
-            request is issued.
-        first_audio_chunk_at: Monotonic timestamp when the first audio chunk
-            is received from the provider.
 
-    Returns:
-        Elapsed time in milliseconds (float).
+def first_audible_offset_ms(
+    pcm: bytes,
+    sample_rate: int,
+) -> float | None:
+    """Offset in milliseconds from the start of *pcm* to the first audible sample.
 
-    Raises:
-        ValueError: If *first_audio_chunk_at* is earlier than
-            *audio_synthesis_start*.
+    *pcm* is assembled raw mono PCM (no WAV header), signed little-endian 16-bit,
+    interpreted at its native *sample_rate* (no resampling). Returns ``None``
+    when there is no audible audio (empty, pure silence, or sub-threshold).
+    """
+    if sample_rate <= 0:
+        raise ValueError("sample_rate must be > 0")
+
+    if not pcm:
+        return None
+    if len(pcm) % _PCM16_BYTES != 0:
+        raise ValueError("pcm length is not a whole number of frames")
+
+    samples = np.frombuffer(pcm, dtype="<i2").astype(np.float32) / _PCM16_FULL_SCALE
+    if samples.size == 0:
+        return None
+
+    frame_length = max(1, round(_FRAME_SECONDS * sample_rate))
+    hop_length = max(1, round(_HOP_SECONDS * sample_rate))
+
+    # Per-frame RMS with each frame's mean removed, so a (silent) DC offset
+    # doesn't read as energy and trip the threshold. Edge-pad rather than
+    # zero-pad: a zero-pad would make a constant DC start look like a step,
+    # which has real energy and would falsely read as audible at t=0.
+    pad = frame_length // 2
+    padded = np.pad(samples, pad, mode="edge")
+    frames = librosa.util.frame(padded, frame_length=frame_length, hop_length=hop_length)
+    rms = np.sqrt(np.mean((frames - frames.mean(axis=0, keepdims=True)) ** 2, axis=0))
+
+    audible_frames = np.where(rms > _AUDIBLE_RMS_THRESHOLD)[0]
+    if audible_frames.size == 0:
+        return None
+
+    return (float(audible_frames[0]) * hop_length / sample_rate) * 1000.0
+
+
+def compute_ttfa(
+    audio_synthesis_start: float,
+    first_audio_chunk_at: float,
+    leading_silence_offset_ms: float = 0.0,
+) -> float:
+    """Return perceived time-to-first-audio in milliseconds.
+
+    Perceived TTFA = (first chunk arrival - synthesis start) +
+    *leading_silence_offset_ms*. The timestamps are ``time.monotonic()``
+    readings; the offset is the output of :func:`first_audible_offset_ms`.
     """
     if first_audio_chunk_at < audio_synthesis_start:
         raise ValueError("first_audio_chunk_at must be >= audio_synthesis_start")
-    return (first_audio_chunk_at - audio_synthesis_start) * 1000.0
+    if leading_silence_offset_ms < 0:
+        raise ValueError("leading_silence_offset_ms must be >= 0")
+    arrival_ms = (first_audio_chunk_at - audio_synthesis_start) * 1000.0
+    return arrival_ms + leading_silence_offset_ms

--- a/runner/tests/unit/test_ttfa.py
+++ b/runner/tests/unit/test_ttfa.py
@@ -4,9 +4,31 @@
 
 from __future__ import annotations
 
+import math
+
+import numpy as np
 import pytest
 
-from coval_bench.metrics.ttfa import compute_ttfa
+from coval_bench.metrics.ttfa import compute_ttfa, first_audible_offset_ms
+
+
+def _silence_pcm(duration_ms: float, sample_rate: int, amplitude: float = 0.0) -> bytes:
+    """Return *duration_ms* of (optionally low-noise) silence as int16 PCM bytes."""
+    n = round(duration_ms / 1000.0 * sample_rate)
+    if amplitude == 0.0:
+        return np.zeros(n, dtype="<i2").tobytes()
+    noise = (np.full(n, amplitude) * 32767.0).astype("<i2")
+    return noise.tobytes()
+
+
+def _tone_pcm(
+    duration_ms: float, sample_rate: int, amplitude: float = 0.3, freq: float = 220.0
+) -> bytes:
+    """Return a *duration_ms* sine tone as int16 PCM bytes (amplitude in [0, 1])."""
+    n = round(duration_ms / 1000.0 * sample_rate)
+    t = np.arange(n) / sample_rate
+    wave = amplitude * np.sin(2.0 * math.pi * freq * t)
+    return (wave * 32767.0).astype("<i2").tobytes()
 
 
 def test_ttfa_basic() -> None:
@@ -47,3 +69,76 @@ def test_ttfa_raises_strictly_negative_delta() -> None:
 def test_ttfa_returns_float() -> None:
     result = compute_ttfa(10.0, 11.0)
     assert isinstance(result, float)
+
+
+def test_ttfa_adds_leading_silence_offset() -> None:
+    """Perceived TTFA = chunk-arrival latency + leading-silence offset."""
+    assert compute_ttfa(1000.0, 1000.5, 50.0) == pytest.approx(550.0)
+
+
+def test_ttfa_raises_on_negative_offset() -> None:
+    with pytest.raises(ValueError, match="leading_silence_offset_ms must be >= 0"):
+        compute_ttfa(1.0, 2.0, -1.0)
+
+
+# --- first_audible_offset_ms ------------------------------------------------
+
+
+def test_offset_pure_silence_returns_none() -> None:
+    """All-zero PCM has no audible sample."""
+    assert first_audible_offset_ms(_silence_pcm(500, 24000), 24000) is None
+
+
+def test_offset_sub_threshold_tone_returns_none() -> None:
+    """A tone too quiet to be audible (below threshold) is not detected."""
+    quiet = _tone_pcm(500, 24000, amplitude=0.005)
+    assert first_audible_offset_ms(quiet, 24000) is None
+
+
+@pytest.mark.parametrize("amplitude", [0.025, 0.05, 0.1, 0.3])
+def test_offset_ignores_pure_dc(amplitude: float) -> None:
+    """A constant DC bias well above the raw threshold is inaudible → None."""
+    # Raw RMS equals the amplitude (> threshold) but the AC energy is zero, so
+    # no audible sample should be reported regardless of how large the bias is.
+    assert first_audible_offset_ms(_silence_pcm(300, 24000, amplitude=amplitude), 24000) is None
+
+
+def test_offset_ignores_dc_before_tone() -> None:
+    """Leading DC bias is skipped; the offset lands on the real tone onset."""
+    sr = 24000
+    pcm = _silence_pcm(100, sr, amplitude=0.05) + _tone_pcm(300, sr)
+    offset = first_audible_offset_ms(pcm, sr)
+    assert offset is not None
+    assert offset == pytest.approx(100.0, abs=12.0)
+
+
+def test_offset_empty_returns_none() -> None:
+    assert first_audible_offset_ms(b"", 24000) is None
+
+
+def test_offset_immediate_tone_near_zero() -> None:
+    """A tone from the first sample is detected at ~0 ms."""
+    offset = first_audible_offset_ms(_tone_pcm(300, 24000), 24000)
+    assert offset is not None
+    assert offset == pytest.approx(0.0, abs=10.0)
+
+
+@pytest.mark.parametrize("sample_rate", [22050, 24000, 48000])
+def test_offset_silence_then_tone_at_known_offset(sample_rate: int) -> None:
+    """Detected offset matches the leading-silence duration within a frame."""
+    lead_ms = 200.0
+    pcm = _silence_pcm(lead_ms, sample_rate) + _tone_pcm(300, sample_rate)
+    offset = first_audible_offset_ms(pcm, sample_rate)
+    assert offset is not None
+    assert offset == pytest.approx(lead_ms, abs=12.0)
+
+
+def test_offset_rejects_bad_sample_rate() -> None:
+    with pytest.raises(ValueError, match="sample_rate must be > 0"):
+        first_audible_offset_ms(_tone_pcm(100, 24000), 0)
+
+
+def test_offset_rejects_misaligned_pcm() -> None:
+    """An odd-length (non-frame-aligned) buffer gets a clear error, not a numpy one."""
+    with pytest.raises(ValueError, match="whole number of frames"):
+        first_audible_offset_ms(b"\x00\x01\x02", 24000)


### PR DESCRIPTION
- Add helper function that calculates time to first audible segment of an audio file.
- Update compute_ttfa to include time to first audible segment. Prevents providers from gaming the metric by sending inaudable segments while their model is processing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Audible onset detection added to identify when audio becomes perceptible
  * TTFA metric extended to account for leading-silence offsets with validation

* **Tests**
  * Comprehensive unit coverage for audible onset detection and TTFA enhancements, including validation of offsets, sample-rate checks, and edge-case silence/DC handling

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/coval-ai/benchmarks/pull/39?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->