### PR TITLE
feat(tts): add xAI Grok TTS provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,6 +27,7 @@ HUME_API_KEY=
 RIME_API_KEY=
 GRADIUM_API_KEY=
 GRADIUM_TTS_API_KEY=
+XAI_API_KEY=
 
 # --- Google STT (optional; requires the `google-stt` extra) ---
 # GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json

--- a/runner/src/coval_bench/config.py
+++ b/runner/src/coval_bench/config.py
@@ -60,6 +60,7 @@ class Settings(BaseSettings):
     rime_api_key: SecretStr | None = None
     gradium_api_key: SecretStr | None = None
     gradium_tts_api_key: SecretStr | None = None
+    xai_api_key: SecretStr | None = None
 
     # Path to a Google service-account JSON file mounted as a Secret-as-volume.
     google_application_credentials: Path | None = None

--- a/runner/src/coval_bench/providers/tts/__init__.py
+++ b/runner/src/coval_bench/providers/tts/__init__.py
@@ -21,6 +21,7 @@ from coval_bench.providers.tts.elevenlabs import ElevenLabsTTSProvider
 from coval_bench.providers.tts.gradium import GradiumTTSProvider
 from coval_bench.providers.tts.openai import OpenAITTSProvider
 from coval_bench.providers.tts.rime import RimeTTSProvider
+from coval_bench.providers.tts.xai import XaiTTSProvider
 
 try:
     from coval_bench.providers.tts.hume import HumeTTSProvider
@@ -37,9 +38,10 @@ TTS_PROVIDERS: dict[str, type[TTSProvider]] = {
     "gradium": GradiumTTSProvider,
     "deepgram": DeepgramTTSProvider,
     "rime": RimeTTSProvider,
+    "xai": XaiTTSProvider,
 }
 
 if HumeTTSProvider is not None:
     TTS_PROVIDERS["hume"] = HumeTTSProvider
 
-__all__ = ["TTS_PROVIDERS", "HUME_AVAILABLE", "GradiumTTSProvider"]
+__all__ = ["TTS_PROVIDERS", "HUME_AVAILABLE", "GradiumTTSProvider", "XaiTTSProvider"]

--- a/runner/src/coval_bench/providers/tts/xai.py
+++ b/runner/src/coval_bench/providers/tts/xai.py
@@ -66,7 +66,6 @@ class XaiTTSProvider(TTSProvider):
     async def synthesize(self, text: str) -> TTSResult:
         audio_chunks: list[bytes] = []
         ttfa_ms: float | None = None
-        error: str | None = None
 
         try:
             headers = {"Authorization": f"Bearer {self._api_key}"}
@@ -102,7 +101,14 @@ class XaiTTSProvider(TTSProvider):
 
         except Exception as exc:
             logger.debug("xai_tts_error", exc_info=True)
-            error = str(exc)
+            return TTSResult(
+                provider="xai",
+                model=self._model,
+                voice=self._voice,
+                ttfa_ms=ttfa_ms,
+                audio_path=None,
+                error=str(exc),
+            )
 
         audio_path = _write_wav(audio_chunks, _SAMPLE_RATE) if audio_chunks else None
         return TTSResult(
@@ -111,7 +117,7 @@ class XaiTTSProvider(TTSProvider):
             voice=self._voice,
             ttfa_ms=ttfa_ms,
             audio_path=audio_path,
-            error=error,
+            error=None,
         )
 
 

--- a/runner/src/coval_bench/providers/tts/xai.py
+++ b/runner/src/coval_bench/providers/tts/xai.py
@@ -59,7 +59,8 @@ class XaiTTSProvider(TTSProvider):
             "voice": self._voice,
             "codec": "pcm",
             "sample_rate": _SAMPLE_RATE,
-            "text_normalization": "true",
+            "text_normalization": "false",
+            "optimize_streaming_latency": 2,
         }
         return f"{_BASE_WS_URL}?{urlencode(params)}"
 

--- a/runner/src/coval_bench/providers/tts/xai.py
+++ b/runner/src/coval_bench/providers/tts/xai.py
@@ -1,0 +1,127 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""xAI Grok TTS streaming provider."""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import tempfile
+import time
+import wave
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlencode
+
+import structlog
+import websockets.asyncio.client as ws_client
+
+from coval_bench.config import Settings
+from coval_bench.providers.base import TTSProvider, TTSResult
+
+logger: structlog.BoundLogger = structlog.get_logger(__name__)
+
+_VALID_MODELS = ("grok-tts",)
+_VALID_VOICES = ("eve", "ara", "rex", "sal", "leo")
+_BASE_WS_URL = "wss://api.x.ai/v1/tts"
+_SAMPLE_RATE = 24000
+
+
+class XaiTTSProvider(TTSProvider):
+    """xAI Grok TTS provider using WebSocket streaming."""
+
+    def __init__(self, settings: Settings, model: str, voice: str) -> None:
+        if model not in _VALID_MODELS:
+            raise ValueError(f"Invalid xAI TTS model {model!r}. Valid: {_VALID_MODELS}")
+        if voice not in _VALID_VOICES:
+            raise ValueError(f"Invalid xAI TTS voice {voice!r}. Valid: {_VALID_VOICES}")
+        self._model = model
+        self._voice = voice
+
+        api_key_secret = settings.xai_api_key
+        if api_key_secret is None:
+            raise ValueError("xai_api_key is required in Settings")
+        self._api_key = api_key_secret.get_secret_value()
+
+    @property
+    def name(self) -> str:
+        return "xai"
+
+    @property
+    def model(self) -> str:
+        return self._model
+
+    def _build_websocket_url(self) -> str:
+        params: dict[str, str | int] = {
+            "language": "en",
+            "voice": self._voice,
+            "codec": "pcm",
+            "sample_rate": _SAMPLE_RATE,
+            "text_normalization": "true",
+        }
+        return f"{_BASE_WS_URL}?{urlencode(params)}"
+
+    async def synthesize(self, text: str) -> TTSResult:
+        audio_chunks: list[bytes] = []
+        ttfa_ms: float | None = None
+        error: str | None = None
+
+        try:
+            headers = {"Authorization": f"Bearer {self._api_key}"}
+
+            async with ws_client.connect(
+                self._build_websocket_url(),
+                additional_headers=headers,
+            ) as ws:
+                start = time.monotonic()
+                await ws.send(json.dumps({"type": "text.delta", "delta": text}))
+                await ws.send(json.dumps({"type": "text.done"}))
+
+                async for raw in ws:
+                    if isinstance(raw, bytes):
+                        continue
+                    event: dict[str, Any] = json.loads(raw)
+                    event_type = str(event.get("type", ""))
+
+                    if event_type == "audio.delta":
+                        audio_b64 = str(event.get("delta", ""))
+                        if audio_b64:
+                            chunk = base64.b64decode(audio_b64)
+                            if chunk:
+                                if ttfa_ms is None:
+                                    ttfa_ms = (time.monotonic() - start) * 1000
+                                audio_chunks.append(chunk)
+
+                    elif event_type == "audio.done":
+                        break
+
+                    elif event_type == "error":
+                        raise RuntimeError(str(event.get("message", "xAI TTS error")))
+
+        except Exception as exc:
+            logger.debug("xai_tts_error", exc_info=True)
+            error = str(exc)
+
+        audio_path = _write_wav(audio_chunks, _SAMPLE_RATE) if audio_chunks else None
+        return TTSResult(
+            provider="xai",
+            model=self._model,
+            voice=self._voice,
+            ttfa_ms=ttfa_ms,
+            audio_path=audio_path,
+            error=error,
+        )
+
+
+def _write_wav(chunks: list[bytes], sample_rate: int) -> Path:
+    fd, tmp_name = tempfile.mkstemp(suffix=".wav")
+    os.close(fd)
+    audio_data = b"".join(chunks)
+    with wave.open(tmp_name, "wb") as wav_file:
+        wav_file.setnchannels(1)
+        wav_file.setsampwidth(2)
+        wav_file.setframerate(sample_rate)
+        wav_file.writeframes(audio_data)
+    return Path(tmp_name)

--- a/runner/src/coval_bench/providers/tts/xai.py
+++ b/runner/src/coval_bench/providers/tts/xai.py
@@ -47,7 +47,7 @@ class XaiTTSProvider(TTSProvider):
 
     @property
     def name(self) -> str:
-        return "xai"
+        return f"xai-{self._model}"
 
     @property
     def model(self) -> str:

--- a/runner/src/coval_bench/runner/config.py
+++ b/runner/src/coval_bench/runner/config.py
@@ -114,6 +114,7 @@ DEFAULT_TTS_MATRIX: list[ProviderEntry] = [
         voice="176a55b1-4468-4736-8878-db82729667c1",
         enabled=True,
     ),
+    ProviderEntry(provider="xai", model="grok-tts", voice="eve", enabled=True),
     # Placeholder entries with voice=None — never executed by the runner; surfaced only
     # in /v1/providers so the frontend can label them as disabled.
     ProviderEntry(

--- a/runner/tests/providers/tts/conftest.py
+++ b/runner/tests/providers/tts/conftest.py
@@ -57,6 +57,7 @@ def fake_settings(tmp_path: Path) -> Settings:
         hume_api_key="test-hume-key",  # type: ignore[arg-type]
         rime_api_key="test-rime-key",  # type: ignore[arg-type]
         gradium_tts_api_key="test-gradium-tts-key",  # type: ignore[arg-type]
+        xai_api_key="test-xai-key",
     )
 
 

--- a/runner/tests/providers/tts/test_xai.py
+++ b/runner/tests/providers/tts/test_xai.py
@@ -215,5 +215,5 @@ def test_xai_tts_missing_api_key_raises() -> None:
 
 def test_xai_tts_provider_name(fake_settings: Settings) -> None:
     provider = XaiTTSProvider(fake_settings, model="grok-tts", voice="eve")
-    assert provider.name == "xai"
+    assert provider.name == "xai-grok-tts"
     assert provider.model == "grok-tts"

--- a/runner/tests/providers/tts/test_xai.py
+++ b/runner/tests/providers/tts/test_xai.py
@@ -1,0 +1,150 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the xAI Grok WebSocket TTS provider."""
+
+from __future__ import annotations
+
+import base64
+import json
+from unittest.mock import patch
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+
+from coval_bench.config import Settings
+from coval_bench.providers.tts.xai import XaiTTSProvider
+
+from .conftest import FakeWebSocket, make_pcm_bytes
+
+
+def _audio_events(pcm_chunks: list[bytes]) -> list[str]:
+    events: list[str] = []
+    for chunk in pcm_chunks:
+        events.append(
+            json.dumps({"type": "audio.delta", "delta": base64.b64encode(chunk).decode()})
+        )
+    events.append(json.dumps({"type": "audio.done", "trace_id": "test-trace-id"}))
+    return events
+
+
+@pytest.mark.asyncio
+async def test_xai_tts_happy_path(fake_settings: Settings) -> None:
+    ws = FakeWebSocket(_audio_events([make_pcm_bytes(240)]))
+    provider = XaiTTSProvider(fake_settings, model="grok-tts", voice="eve")
+
+    with patch(
+        "coval_bench.providers.tts.xai.ws_client.connect",
+        return_value=ws,
+    ):
+        result = await provider.synthesize("Hello from Grok")
+
+    assert result.error is None, f"Unexpected error: {result.error}"
+    assert result.ttfa_ms is not None
+    assert 0 < result.ttfa_ms < 60_000
+    assert result.audio_path is not None
+    assert result.audio_path.exists()
+    assert result.audio_path.read_bytes()[:4] == b"RIFF"
+    assert result.provider == "xai"
+    assert result.model == "grok-tts"
+    assert result.voice == "eve"
+    result.audio_path.unlink()
+
+
+@pytest.mark.asyncio
+async def test_xai_tts_url_and_auth(fake_settings: Settings) -> None:
+    ws = FakeWebSocket(_audio_events([make_pcm_bytes(240)]))
+    captured: dict[str, object] = {}
+
+    def connect_side_effect(
+        url: str,
+        additional_headers: dict[str, str] | None = None,
+        **_: object,
+    ) -> FakeWebSocket:
+        captured["url"] = url
+        captured["headers"] = dict(additional_headers or {})
+        return ws
+
+    provider = XaiTTSProvider(fake_settings, model="grok-tts", voice="eve")
+
+    with patch(
+        "coval_bench.providers.tts.xai.ws_client.connect",
+        side_effect=connect_side_effect,
+    ):
+        result = await provider.synthesize("Hello")
+
+    assert result.error is None
+    parsed = urlparse(str(captured["url"]))
+    assert parsed.scheme == "wss"
+    assert parsed.netloc == "api.x.ai"
+    assert parsed.path == "/v1/tts"
+    query = parse_qs(parsed.query)
+    assert query.get("language") == ["en"]
+    assert query.get("voice") == ["eve"]
+    assert query.get("codec") == ["pcm"]
+    assert query.get("sample_rate") == ["24000"]
+    assert query.get("text_normalization") == ["true"]
+    headers = captured["headers"]
+    assert isinstance(headers, dict)
+    assert headers.get("Authorization") == "Bearer test-xai-key"
+
+
+@pytest.mark.asyncio
+async def test_xai_tts_sends_text_delta_then_done(fake_settings: Settings) -> None:
+    ws = FakeWebSocket(_audio_events([make_pcm_bytes(240)]))
+    provider = XaiTTSProvider(fake_settings, model="grok-tts", voice="eve")
+
+    with patch(
+        "coval_bench.providers.tts.xai.ws_client.connect",
+        return_value=ws,
+    ):
+        await provider.synthesize("Hello world")
+
+    sent_json = [json.loads(m) for m in ws.sent if isinstance(m, str)]
+    assert sent_json[0] == {"type": "text.delta", "delta": "Hello world"}
+    assert sent_json[1] == {"type": "text.done"}
+
+
+@pytest.mark.asyncio
+async def test_xai_tts_error_event(fake_settings: Settings) -> None:
+    ws = FakeWebSocket([json.dumps({"type": "error", "message": "invalid api key"})])
+    provider = XaiTTSProvider(fake_settings, model="grok-tts", voice="eve")
+
+    with patch(
+        "coval_bench.providers.tts.xai.ws_client.connect",
+        return_value=ws,
+    ):
+        result = await provider.synthesize("Hello")
+
+    assert result.error is not None
+    assert "invalid api key" in result.error
+    assert result.audio_path is None
+    assert result.ttfa_ms is None
+
+
+def test_xai_tts_invalid_model_raises(fake_settings: Settings) -> None:
+    with pytest.raises(ValueError, match="Invalid xAI TTS model"):
+        XaiTTSProvider(fake_settings, model="not-a-model", voice="eve")
+
+
+def test_xai_tts_invalid_voice_raises(fake_settings: Settings) -> None:
+    with pytest.raises(ValueError, match="Invalid xAI TTS voice"):
+        XaiTTSProvider(fake_settings, model="grok-tts", voice="not-a-voice")
+
+
+def test_xai_tts_missing_api_key_raises() -> None:
+    settings = Settings(
+        database_url="postgresql://runner:password@localhost:5432/benchmarks",
+        dataset_bucket="test-bucket",
+        dataset_id="stt-v1",
+        runner_sha="test",
+        log_level="DEBUG",
+    )
+    with pytest.raises(ValueError, match="xai_api_key is required"):
+        XaiTTSProvider(settings, model="grok-tts", voice="eve")
+
+
+def test_xai_tts_provider_name(fake_settings: Settings) -> None:
+    provider = XaiTTSProvider(fake_settings, model="grok-tts", voice="eve")
+    assert provider.name == "xai"
+    assert provider.model == "grok-tts"

--- a/runner/tests/providers/tts/test_xai.py
+++ b/runner/tests/providers/tts/test_xai.py
@@ -83,7 +83,8 @@ async def test_xai_tts_url_and_auth(fake_settings: Settings) -> None:
     assert query.get("voice") == ["eve"]
     assert query.get("codec") == ["pcm"]
     assert query.get("sample_rate") == ["24000"]
-    assert query.get("text_normalization") == ["true"]
+    assert query.get("text_normalization") == ["false"]
+    assert query.get("optimize_streaming_latency") == ["2"]
     headers = captured["headers"]
     assert isinstance(headers, dict)
     assert headers.get("Authorization") == "Bearer test-xai-key"

--- a/runner/tests/providers/tts/test_xai.py
+++ b/runner/tests/providers/tts/test_xai.py
@@ -122,6 +122,74 @@ async def test_xai_tts_error_event(fake_settings: Settings) -> None:
     assert result.ttfa_ms is None
 
 
+@pytest.mark.asyncio
+async def test_xai_tts_error_after_partial_audio(fake_settings: Settings) -> None:
+    chunk = make_pcm_bytes(240)
+    events = [
+        json.dumps({"type": "audio.delta", "delta": base64.b64encode(chunk).decode()}),
+        json.dumps({"type": "error", "message": "stream interrupted"}),
+    ]
+    ws = FakeWebSocket(events)
+    provider = XaiTTSProvider(fake_settings, model="grok-tts", voice="eve")
+
+    with patch(
+        "coval_bench.providers.tts.xai.ws_client.connect",
+        return_value=ws,
+    ):
+        result = await provider.synthesize("Hello")
+
+    assert result.error is not None
+    assert "stream interrupted" in result.error
+    assert result.audio_path is None
+    assert result.ttfa_ms is not None
+
+
+@pytest.mark.asyncio
+async def test_xai_tts_ttfa_set_on_first_chunk_only(fake_settings: Settings) -> None:
+    chunks = [make_pcm_bytes(240), make_pcm_bytes(240), make_pcm_bytes(240)]
+    ws = FakeWebSocket(_audio_events(chunks))
+    provider = XaiTTSProvider(fake_settings, model="grok-tts", voice="eve")
+
+    times = iter([0.0, 0.1, 1.0, 2.0])
+
+    with (
+        patch(
+            "coval_bench.providers.tts.xai.time.monotonic",
+            side_effect=lambda: next(times, 10.0),
+        ),
+        patch(
+            "coval_bench.providers.tts.xai.ws_client.connect",
+            return_value=ws,
+        ),
+    ):
+        result = await provider.synthesize("Hello")
+
+    assert result.error is None
+    assert result.ttfa_ms == pytest.approx(100.0)
+    assert result.audio_path is not None
+    result.audio_path.unlink()
+
+
+@pytest.mark.asyncio
+async def test_xai_tts_skips_empty_audio_delta(fake_settings: Settings) -> None:
+    events = [
+        json.dumps({"type": "audio.delta", "delta": ""}),
+        json.dumps({"type": "audio.done", "trace_id": "test"}),
+    ]
+    ws = FakeWebSocket(events)
+    provider = XaiTTSProvider(fake_settings, model="grok-tts", voice="eve")
+
+    with patch(
+        "coval_bench.providers.tts.xai.ws_client.connect",
+        return_value=ws,
+    ):
+        result = await provider.synthesize("Hello")
+
+    assert result.error is None
+    assert result.audio_path is None
+    assert result.ttfa_ms is None
+
+
 def test_xai_tts_invalid_model_raises(fake_settings: Settings) -> None:
     with pytest.raises(ValueError, match="Invalid xAI TTS model"):
         XaiTTSProvider(fake_settings, model="not-a-model", voice="eve")
@@ -139,6 +207,7 @@ def test_xai_tts_missing_api_key_raises() -> None:
         dataset_id="stt-v1",
         runner_sha="test",
         log_level="DEBUG",
+        xai_api_key=None,
     )
     with pytest.raises(ValueError, match="xai_api_key is required"):
         XaiTTSProvider(settings, model="grok-tts", voice="eve")

--- a/web/lib/config/colors.ts
+++ b/web/lib/config/colors.ts
@@ -26,7 +26,7 @@ export const modelColors: Record<string, string> = {
   "octave-2": "#C026D3",
 
   // xAI TTS
-  "grok-tts": "#1F2937",
+  "grok-tts": "#EC4899",
 
   // Deepgram TTS
   "aura-2-thalia-en": "#FC2D62",
@@ -55,5 +55,5 @@ export const providerColors: Record<string, string> = {
   Rime: "#27AE60",
   Gradium: "#1ABC9C",
   Hume: "#A855F7",
-  xAI: "#111827"
+  xAI: "#EC4899"
 };

--- a/web/lib/config/colors.ts
+++ b/web/lib/config/colors.ts
@@ -25,6 +25,9 @@ export const modelColors: Record<string, string> = {
   "octave-tts": "#7C3AED",
   "octave-2": "#C026D3",
 
+  // xAI TTS
+  "grok-tts": "#1F2937",
+
   // Deepgram TTS
   "aura-2-thalia-en": "#FC2D62",
 
@@ -51,5 +54,6 @@ export const providerColors: Record<string, string> = {
   Speechmatics: "#21618C",
   Rime: "#27AE60",
   Gradium: "#1ABC9C",
-  Hume: "#A855F7"
+  Hume: "#A855F7",
+  xAI: "#111827"
 };

--- a/web/lib/config/models.ts
+++ b/web/lib/config/models.ts
@@ -14,6 +14,7 @@ export const modelDisplayNames: Record<string, string> = {
   "octave-tts": "Octave TTS",
   "octave-2": "Octave 2",
   coda: "Coda",
+  "grok-tts": "Grok TTS",
   // STT
   "nova-2": "Nova 2",
   "nova-3": "Nova 3",
@@ -40,5 +41,6 @@ export const ttsProviderNames: Record<string, string> = {
   gradium: "Gradium",
   hume: "Hume",
   openai: "OpenAI",
-  rime: "Rime"
+  rime: "Rime",
+  xai: "xAI"
 };

--- a/web/lib/utils/formatters.ts
+++ b/web/lib/utils/formatters.ts
@@ -68,6 +68,7 @@ export function normalizeModelName(modelName: string): string {
     "octave-tts": "Octave TTS",
     "octave-2": "Octave 2",
     coda: "Coda",
+    "grok-tts": "Grok TTS",
     // STT
     "nova-2": "Nova 2",
     "nova-3": "Nova 3",
@@ -135,6 +136,7 @@ export function normalizeTTSProviderName(providerName: string): string {
     hume: "Hume",
     openai: "OpenAI",
     rime: "Rime",
+    xai: "xAI",
   };
 
   const lower = providerName.toLowerCase();


### PR DESCRIPTION
## Summary
- Adds xAI Grok TTS provider via WebSocket streaming at `/v1/tts`
- Web display entries for `grok-tts` model + `xAI` provider
- Tests cover happy path, multi-chunk TTFA invariant, partial-audio error safety, empty `audio.delta` handling

## Test plan
- [x] CI green
- [x] Smoke benchmark produces TTFA + WER row for xai/grok-tts
- [x] No regression in existing TTS tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added xAI Grok TTS provider with WebSocket streaming audio synthesis.

* **Tests**
  * Added comprehensive test suite covering streaming, auth, error cases, timing, and validation.

* **Chores**
  * Registered the new TTS provider, added XAI API key to example env, and updated UI display names and colors for provider/model.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->