### PR TITLE
[BENCH-208] Update TTFA metric

### DIFF
--- a/docs/methodology.md
+++ b/docs/methodology.md
@@ -66,7 +66,34 @@ attributed to the pipeline version that produced it.
 A future revision may A/B-test against `whisper_normalizer`. Any such change
 will increment `NORM_VERSION` and ship a separate ADR.
 
-## 4. Library versions
+## 4. Latency metrics (TTFA)
+
+The TTS latency metric is **TTFA (Time-To-First-Audio)**, reported in
+milliseconds. It is *perceived* first-audible latency, the goal being to measure 
+what an enqueue-and-play client actually waits before it hears sound:
+
+    TTFA = (first audio chunk arrival − synthesis start)
+           + leading silence inside the stream before the first audible sample
+
+The arrival term is wall-clock (`time.monotonic`) from the synthesis trigger to
+the first non-empty audio chunk. The leading-silence term is computed from the
+assembled PCM by `runner/src/coval_bench/metrics/ttfa.py`
+(`first_audible_offset_ms`, an RMS-threshold onset detector). Both terms are
+combined in one place — `providers/tts/_common.py:finalize_tts_result` — which
+every provider routes through. The offset is best-effort: if it cannot be
+computed, TTFA degrades to arrival-only and the audio is still kept.
+
+**Methodology change (2026-05).** TTFA previously measured *network arrival
+only* (time to first chunk) and ignored any leading silence a provider
+front-loads into the stream. As of this change it is the perceived value above.
+This shifts every provider's reported TTFA upward by its leading-silence offset
+(near-zero for providers that emit audible audio immediately; several hundred ms
+for those that front-load silence), so numbers recorded before the change are
+**not comparable** with later ones. There is no schema or metric-name change —
+the existing `TTFA` metric simply carries the perceived definition from this
+point forward, distinguished by the `runner_sha` on the run.
+
+## 5. Library versions
 
 The DP edit-distance computation is delegated to `jiwer`. Pinned in
 `runner/uv.lock` (currently `jiwer == 4.0.0`). `numpy` is also locked. Every

--- a/runner/src/coval_bench/providers/tts/_common.py
+++ b/runner/src/coval_bench/providers/tts/_common.py
@@ -1,0 +1,102 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared finalize step for TTS providers: perceived TTFA + WAV output."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import wave
+from pathlib import Path
+
+import structlog
+
+from coval_bench.metrics import compute_ttfa, first_audible_offset_ms
+from coval_bench.providers.base import TTSResult
+
+logger: structlog.BoundLogger = structlog.get_logger(__name__)
+
+# Mono signed 16-bit PCM: 2 bytes per sample.
+_PCM16_FRAME_BYTES = 2
+
+
+def finalize_tts_result(
+    *,
+    provider: str,
+    model: str,
+    voice: str,
+    pcm: bytes,
+    sample_rate: int,
+    audio_synthesis_start: float | None,
+    first_audio_chunk_at: float | None,
+    error: str | None = None,
+) -> TTSResult:
+    """Build a TTSResult with perceived TTFA from assembled PCM and timing.
+
+    Perceived TTFA = (first chunk arrival - synthesis start) + leading silence.
+    ``ttfa_ms`` is ``None`` when no audio arrived (timestamps unset). On the error
+    path, callers pass ``pcm=b""`` so no WAV is written and TTFA falls back to
+    arrival-only (no offset), matching today's behaviour.
+
+    The offset is best-effort: computing it is a latency *metric*, never a reason
+    to discard good audio. A trailing partial sample (a 16-bit frame split across
+    the final stream frame) is dropped, and any failure in offset detection is
+    swallowed and degrades TTFA to arrival-only — the WAV is still written either
+    way.
+    """
+    # Drop a dangling partial sample so neither offset detection (which rejects
+    # frame-misaligned PCM) nor the WAV header chokes on a split final frame.
+    remainder = len(pcm) % _PCM16_FRAME_BYTES
+    if remainder:
+        pcm = pcm[: len(pcm) - remainder]
+
+    ttfa_ms: float | None = None
+    if audio_synthesis_start is not None and first_audio_chunk_at is not None:
+        offset_ms = _safe_offset_ms(pcm, sample_rate, provider, model) if pcm else None
+        ttfa_ms = compute_ttfa(
+            audio_synthesis_start, first_audio_chunk_at, offset_ms if offset_ms is not None else 0.0
+        )
+        logger.debug(
+            "tts_ttfa",
+            provider=provider,
+            model=model,
+            arrival_ms=(first_audio_chunk_at - audio_synthesis_start) * 1000.0,
+            offset_ms=offset_ms,
+            ttfa_ms=ttfa_ms,
+        )
+
+    audio_path = _write_wav(pcm, sample_rate) if pcm else None
+    return TTSResult(
+        provider=provider,
+        model=model,
+        voice=voice,
+        ttfa_ms=ttfa_ms,
+        audio_path=audio_path,
+        error=error,
+    )
+
+
+def _safe_offset_ms(pcm: bytes, sample_rate: int, provider: str, model: str) -> float | None:
+    """Leading-silence offset, swallowing any error to a ``None`` (arrival-only) result.
+
+    The offset is a latency metric, not load-bearing for the audio; a failure here
+    must never propagate out of ``synthesize`` and discard the synthesized WAV.
+    """
+    try:
+        return first_audible_offset_ms(pcm, sample_rate)
+    except Exception:
+        logger.warning("tts_offset_failed", provider=provider, model=model, exc_info=True)
+        return None
+
+
+def _write_wav(pcm: bytes, sample_rate: int) -> Path:
+    """Write assembled mono 16-bit PCM to a temp WAV file."""
+    fd, tmp_name = tempfile.mkstemp(suffix=".wav")
+    os.close(fd)
+    with wave.open(tmp_name, "wb") as wav_file:
+        wav_file.setnchannels(1)
+        wav_file.setsampwidth(2)
+        wav_file.setframerate(sample_rate)
+        wav_file.writeframes(pcm)
+    return Path(tmp_name)

--- a/runner/src/coval_bench/providers/tts/cartesia.py
+++ b/runner/src/coval_bench/providers/tts/cartesia.py
@@ -5,11 +5,7 @@
 
 from __future__ import annotations
 
-import os
-import tempfile
 import time
-import wave
-from pathlib import Path
 from typing import Any
 
 import structlog
@@ -18,6 +14,7 @@ from cartesia.types import VoiceSpecifierParam
 
 from coval_bench.config import Settings
 from coval_bench.providers.base import TTSProvider, TTSResult
+from coval_bench.providers.tts._common import finalize_tts_result
 
 logger: structlog.BoundLogger = structlog.get_logger(__name__)
 
@@ -54,7 +51,8 @@ class CartesiaTTSProvider(TTSProvider):
     async def synthesize(self, text: str) -> TTSResult:
         """Synthesize speech via Cartesia WebSocket and return a TTSResult."""
         audio_chunks: list[bytes] = []
-        ttfa_ms: float | None = None
+        start: float | None = None
+        first_chunk_at: float | None = None
         voice_spec: VoiceSpecifierParam = {"id": self._voice, "mode": "id"}
 
         try:
@@ -73,7 +71,7 @@ class CartesiaTTSProvider(TTSProvider):
                 # send() — ctx.send() does NOT inherit them from conn.context().
                 # Omitting output_format causes the SDK to substitute its own
                 # default (pcm_f32le / 44100 Hz), which mismatches the WAV header
-                # written by _write_wav (pcm_s16le / 24000 Hz) and produces
+                # written at finalize (pcm_s16le / 24000 Hz) and produces
                 # corrupt audio → Whisper hallucination → WER > 100%.
                 # Omitting language causes sonic-3 to auto-detect and intermittently
                 # synthesize non-English audio → WER = 100%.
@@ -91,47 +89,31 @@ class CartesiaTTSProvider(TTSProvider):
                     if event_type == "chunk":
                         audio: bytes | None = getattr(event, "audio", None)
                         if audio and len(audio) > 0:
-                            if ttfa_ms is None:
-                                ttfa_ms = (time.monotonic() - start) * 1000
-                                logger.debug(
-                                    "cartesia_ttfa",
-                                    model=self._model,
-                                    ttfa_ms=ttfa_ms,
-                                )
+                            if first_chunk_at is None:
+                                first_chunk_at = time.monotonic()
                             audio_chunks.append(audio)
                     elif event_type == "done":
                         break
 
         except Exception as exc:
             logger.debug("cartesia_error", exc_info=True)
-            return TTSResult(
+            return finalize_tts_result(
                 provider="cartesia",
                 model=self._model,
                 voice=self._voice,
-                ttfa_ms=ttfa_ms,
-                audio_path=None,
+                pcm=b"",
+                sample_rate=SAMPLE_RATE,
+                audio_synthesis_start=start,
+                first_audio_chunk_at=first_chunk_at,
                 error=str(exc),
             )
 
-        audio_path = _write_wav(audio_chunks, SAMPLE_RATE) if audio_chunks else None
-        return TTSResult(
+        return finalize_tts_result(
             provider="cartesia",
             model=self._model,
             voice=self._voice,
-            ttfa_ms=ttfa_ms,
-            audio_path=audio_path,
-            error=None,
+            pcm=b"".join(audio_chunks),
+            sample_rate=SAMPLE_RATE,
+            audio_synthesis_start=start,
+            first_audio_chunk_at=first_chunk_at,
         )
-
-
-def _write_wav(chunks: list[bytes], sample_rate: int) -> Path:
-    """Concatenate PCM chunks and write a WAV file to a temp location."""
-    fd, tmp_name = tempfile.mkstemp(suffix=".wav")
-    os.close(fd)
-    audio_data = b"".join(chunks)
-    with wave.open(tmp_name, "wb") as wav_file:
-        wav_file.setnchannels(1)
-        wav_file.setsampwidth(2)
-        wav_file.setframerate(sample_rate)
-        wav_file.writeframes(audio_data)
-    return Path(tmp_name)

--- a/runner/src/coval_bench/providers/tts/deepgram.py
+++ b/runner/src/coval_bench/providers/tts/deepgram.py
@@ -14,11 +14,7 @@ from __future__ import annotations
 
 import asyncio
 import json
-import os
-import tempfile
 import time
-import wave
-from pathlib import Path
 from urllib.parse import urlencode
 
 import structlog
@@ -26,6 +22,7 @@ import websockets.asyncio.client as ws_client
 
 from coval_bench.config import Settings
 from coval_bench.providers.base import TTSProvider, TTSResult
+from coval_bench.providers.tts._common import finalize_tts_result
 
 logger: structlog.BoundLogger = structlog.get_logger(__name__)
 
@@ -58,7 +55,8 @@ class DeepgramTTSProvider(TTSProvider):
     async def synthesize(self, text: str) -> TTSResult:
         """Synthesize speech via Deepgram WebSocket and return a TTSResult."""
         audio_chunks: list[bytes] = []
-        ttfa_ms: float | None = None
+        start: float | None = None
+        first_chunk_at: float | None = None
 
         qs = urlencode({"encoding": "linear16", "sample_rate": SAMPLE_RATE, "model": self._model})
         url = f"{_DEEPGRAM_TTS_WS_BASE}?{qs}"
@@ -82,13 +80,8 @@ class DeepgramTTSProvider(TTSProvider):
 
                 async for raw in ws:
                     if isinstance(raw, bytes):
-                        if ttfa_ms is None:
-                            ttfa_ms = (time.monotonic() - start) * 1000
-                            logger.debug(
-                                "deepgram_ttfa",
-                                model=self._model,
-                                ttfa_ms=ttfa_ms,
-                            )
+                        if first_chunk_at is None:
+                            first_chunk_at = time.monotonic()
                         audio_chunks.append(raw)
                         continue
 
@@ -101,34 +94,23 @@ class DeepgramTTSProvider(TTSProvider):
 
         except Exception as exc:
             logger.debug("deepgram_error", exc_info=True)
-            return TTSResult(
+            return finalize_tts_result(
                 provider="deepgram",
                 model=self._model,
                 voice=self._voice,
-                ttfa_ms=ttfa_ms,
-                audio_path=None,
+                pcm=b"",
+                sample_rate=SAMPLE_RATE,
+                audio_synthesis_start=start,
+                first_audio_chunk_at=first_chunk_at,
                 error=str(exc),
             )
 
-        audio_path = _write_wav(audio_chunks, SAMPLE_RATE) if audio_chunks else None
-        return TTSResult(
+        return finalize_tts_result(
             provider="deepgram",
             model=self._model,
             voice=self._voice,
-            ttfa_ms=ttfa_ms,
-            audio_path=audio_path,
-            error=None,
+            pcm=b"".join(audio_chunks),
+            sample_rate=SAMPLE_RATE,
+            audio_synthesis_start=start,
+            first_audio_chunk_at=first_chunk_at,
         )
-
-
-def _write_wav(chunks: list[bytes], sample_rate: int) -> Path:
-    """Concatenate PCM chunks and write a WAV file to a temp location."""
-    fd, tmp_name = tempfile.mkstemp(suffix=".wav")
-    os.close(fd)
-    audio_data = b"".join(chunks)
-    with wave.open(tmp_name, "wb") as wav_file:
-        wav_file.setnchannels(1)
-        wav_file.setsampwidth(2)
-        wav_file.setframerate(sample_rate)
-        wav_file.writeframes(audio_data)
-    return Path(tmp_name)

--- a/runner/src/coval_bench/providers/tts/elevenlabs.py
+++ b/runner/src/coval_bench/providers/tts/elevenlabs.py
@@ -7,18 +7,15 @@ from __future__ import annotations
 
 import base64
 import json
-import os
-import tempfile
 import time
-import wave
 from io import BytesIO
-from pathlib import Path
 
 import structlog
 from elevenlabs import ElevenLabs
 
 from coval_bench.config import Settings
 from coval_bench.providers.base import TTSProvider, TTSResult
+from coval_bench.providers.tts._common import finalize_tts_result
 
 logger: structlog.BoundLogger = structlog.get_logger(__name__)
 
@@ -84,7 +81,8 @@ class ElevenLabsTTSProvider(TTSProvider):
 
     async def synthesize(self, text: str) -> TTSResult:
         """Synthesize speech via ElevenLabs SDK and return a TTSResult."""
-        ttfa_ms: float | None = None
+        start: float | None = None
+        first_chunk_at: float | None = None
         audio_stream = BytesIO()
 
         try:
@@ -100,13 +98,8 @@ class ElevenLabsTTSProvider(TTSProvider):
 
             for chunk in response:
                 if chunk:
-                    if self._is_audio_chunk(chunk) and ttfa_ms is None:
-                        ttfa_ms = (time.monotonic() - start) * 1000
-                        logger.debug(
-                            "elevenlabs_ttfa",
-                            model=self._model,
-                            ttfa_ms=ttfa_ms,
-                        )
+                    if self._is_audio_chunk(chunk) and first_chunk_at is None:
+                        first_chunk_at = time.monotonic()
                     if isinstance(chunk, bytes):
                         audio_stream.write(chunk)
                     else:
@@ -114,39 +107,27 @@ class ElevenLabsTTSProvider(TTSProvider):
 
         except Exception as exc:
             logger.debug("elevenlabs_error", exc_info=True)
-            return TTSResult(
+            return finalize_tts_result(
                 provider="elevenlabs",
                 model=self._model,
                 voice=self._voice,
-                ttfa_ms=ttfa_ms,
-                audio_path=None,
+                pcm=b"",
+                sample_rate=SAMPLE_RATE,
+                audio_synthesis_start=start,
+                first_audio_chunk_at=first_chunk_at,
                 error=str(exc),
             )
 
         audio_data = audio_stream.getvalue()
-        audio_path: Path | None = None
-        if audio_data:
-            audio_path = _write_wav_from_data(audio_data, SAMPLE_RATE)
-        else:
+        if not audio_data:
             logger.warning("elevenlabs_no_audio", model=self._model)
 
-        return TTSResult(
+        return finalize_tts_result(
             provider="elevenlabs",
             model=self._model,
             voice=self._voice,
-            ttfa_ms=ttfa_ms,
-            audio_path=audio_path,
-            error=None,
+            pcm=audio_data,
+            sample_rate=SAMPLE_RATE,
+            audio_synthesis_start=start,
+            first_audio_chunk_at=first_chunk_at,
         )
-
-
-def _write_wav_from_data(audio_data: bytes, sample_rate: int) -> Path:
-    """Write raw PCM data as a WAV file and return the path."""
-    fd, tmp_name = tempfile.mkstemp(suffix=".wav")
-    os.close(fd)
-    with wave.open(tmp_name, "wb") as wav_file:
-        wav_file.setnchannels(1)
-        wav_file.setsampwidth(2)
-        wav_file.setframerate(sample_rate)
-        wav_file.writeframes(audio_data)
-    return Path(tmp_name)

--- a/runner/src/coval_bench/providers/tts/gradium.py
+++ b/runner/src/coval_bench/providers/tts/gradium.py
@@ -16,11 +16,7 @@ from __future__ import annotations
 import asyncio
 import base64
 import json
-import os
-import tempfile
 import time
-import wave
-from pathlib import Path
 from typing import Any
 
 import structlog
@@ -28,6 +24,7 @@ import websockets.asyncio.client as ws_client
 
 from coval_bench.config import Settings
 from coval_bench.providers.base import TTSProvider, TTSResult
+from coval_bench.providers.tts._common import finalize_tts_result
 
 logger: structlog.BoundLogger = structlog.get_logger(__name__)
 
@@ -60,7 +57,8 @@ class GradiumTTSProvider(TTSProvider):
 
     async def synthesize(self, text: str) -> TTSResult:
         audio_chunks: list[bytes] = []
-        ttfa_ms: float | None = None
+        start: float | None = None
+        first_chunk_at: float | None = None
 
         try:
             headers = {"x-api-key": self._api_key}
@@ -98,13 +96,8 @@ class GradiumTTSProvider(TTSProvider):
                         if audio_b64:
                             chunk = base64.b64decode(audio_b64)
                             if chunk:
-                                if ttfa_ms is None:
-                                    ttfa_ms = (time.monotonic() - start) * 1000
-                                    logger.debug(
-                                        "gradium_ttfa",
-                                        model=self._model,
-                                        ttfa_ms=ttfa_ms,
-                                    )
+                                if first_chunk_at is None:
+                                    first_chunk_at = time.monotonic()
                                 audio_chunks.append(chunk)
 
                     elif msg_type == "end_of_stream":
@@ -115,33 +108,23 @@ class GradiumTTSProvider(TTSProvider):
 
         except Exception as exc:
             logger.debug("gradium_tts_error", exc_info=True)
-            return TTSResult(
+            return finalize_tts_result(
                 provider="gradium",
                 model=self._model,
                 voice=self._voice,
-                ttfa_ms=ttfa_ms,
-                audio_path=None,
+                pcm=b"",
+                sample_rate=_SAMPLE_RATE,
+                audio_synthesis_start=start,
+                first_audio_chunk_at=first_chunk_at,
                 error=str(exc),
             )
 
-        audio_path = _write_wav(audio_chunks, _SAMPLE_RATE) if audio_chunks else None
-        return TTSResult(
+        return finalize_tts_result(
             provider="gradium",
             model=self._model,
             voice=self._voice,
-            ttfa_ms=ttfa_ms,
-            audio_path=audio_path,
-            error=None,
+            pcm=b"".join(audio_chunks),
+            sample_rate=_SAMPLE_RATE,
+            audio_synthesis_start=start,
+            first_audio_chunk_at=first_chunk_at,
         )
-
-
-def _write_wav(chunks: list[bytes], sample_rate: int) -> Path:
-    fd, tmp_name = tempfile.mkstemp(suffix=".wav")
-    os.close(fd)
-    audio_data = b"".join(chunks)
-    with wave.open(tmp_name, "wb") as wav_file:
-        wav_file.setnchannels(1)
-        wav_file.setsampwidth(2)
-        wav_file.setframerate(sample_rate)
-        wav_file.writeframes(audio_data)
-    return Path(tmp_name)

--- a/runner/src/coval_bench/providers/tts/hume.py
+++ b/runner/src/coval_bench/providers/tts/hume.py
@@ -9,11 +9,7 @@ from __future__ import annotations
 
 import asyncio
 import json
-import os
-import tempfile
 import time
-import wave
-from pathlib import Path
 from urllib.parse import urlencode
 
 import structlog
@@ -21,6 +17,7 @@ import websockets.asyncio.client as ws_client
 
 from coval_bench.config import Settings
 from coval_bench.providers.base import TTSProvider, TTSResult
+from coval_bench.providers.tts._common import finalize_tts_result
 
 logger: structlog.BoundLogger = structlog.get_logger(__name__)
 
@@ -75,7 +72,8 @@ class HumeTTSProvider(TTSProvider):
         version = _MODEL_TO_VERSION[self._model]
 
         audio_chunks: list[bytes] = []
-        ttfa_ms: float | None = None
+        start: float | None = None
+        first_chunk_at: float | None = None
 
         qs = urlencode(
             {
@@ -109,13 +107,8 @@ class HumeTTSProvider(TTSProvider):
 
                     async for raw in ws:
                         if isinstance(raw, bytes) and len(raw) > 0:
-                            if ttfa_ms is None:
-                                ttfa_ms = (time.monotonic() - start) * 1000
-                                logger.debug(
-                                    "hume_ttfa",
-                                    model=self._model,
-                                    ttfa_ms=ttfa_ms,
-                                )
+                            if first_chunk_at is None:
+                                first_chunk_at = time.monotonic()
                             audio_chunks.append(raw)
                         elif isinstance(raw, str):
                             try:
@@ -131,45 +124,36 @@ class HumeTTSProvider(TTSProvider):
                 model=self._model,
                 timeout_s=_WS_SESSION_TIMEOUT_S,
             )
-            return TTSResult(
+            return finalize_tts_result(
                 provider="hume",
                 model=self._model,
                 voice=voice_id,
-                ttfa_ms=ttfa_ms,
-                audio_path=None,
+                pcm=b"",
+                sample_rate=SAMPLE_RATE,
+                audio_synthesis_start=start,
+                first_audio_chunk_at=first_chunk_at,
                 error=f"Hume WebSocket session timed out after {_WS_SESSION_TIMEOUT_S}s",
             )
 
         except Exception as exc:
             logger.warning("hume_error", exc_info=True)
-            return TTSResult(
+            return finalize_tts_result(
                 provider="hume",
                 model=self._model,
                 voice=voice_id,
-                ttfa_ms=ttfa_ms,
-                audio_path=None,
+                pcm=b"",
+                sample_rate=SAMPLE_RATE,
+                audio_synthesis_start=start,
+                first_audio_chunk_at=first_chunk_at,
                 error=str(exc),
             )
 
-        audio_path = _write_wav(audio_chunks, SAMPLE_RATE) if audio_chunks else None
-        return TTSResult(
+        return finalize_tts_result(
             provider="hume",
             model=self._model,
             voice=voice_id,
-            ttfa_ms=ttfa_ms,
-            audio_path=audio_path,
-            error=None,
+            pcm=b"".join(audio_chunks),
+            sample_rate=SAMPLE_RATE,
+            audio_synthesis_start=start,
+            first_audio_chunk_at=first_chunk_at,
         )
-
-
-def _write_wav(chunks: list[bytes], sample_rate: int) -> Path:
-    """Concatenate raw PCM chunks and write a WAV file."""
-    fd, tmp_name = tempfile.mkstemp(suffix=".wav")
-    os.close(fd)
-    audio_data = b"".join(chunks)
-    with wave.open(tmp_name, "wb") as wav_file:
-        wav_file.setnchannels(1)
-        wav_file.setsampwidth(2)
-        wav_file.setframerate(sample_rate)
-        wav_file.writeframes(audio_data)
-    return Path(tmp_name)

--- a/runner/src/coval_bench/providers/tts/openai.py
+++ b/runner/src/coval_bench/providers/tts/openai.py
@@ -7,11 +7,7 @@ from __future__ import annotations
 
 import base64
 import json
-import os
-import tempfile
 import time
-import wave
-from pathlib import Path
 from typing import Any
 
 import structlog
@@ -21,6 +17,7 @@ from openai import AsyncOpenAI
 
 from coval_bench.config import Settings
 from coval_bench.providers.base import TTSProvider, TTSResult
+from coval_bench.providers.tts._common import finalize_tts_result
 
 logger: structlog.BoundLogger = structlog.get_logger(__name__)
 
@@ -91,7 +88,8 @@ class OpenAITTSProvider(TTSProvider):
 
     async def _synthesize_http(self, text: str) -> TTSResult:
         audio_chunks: list[bytes] = []
-        ttfa_ms: float | None = None
+        start: float | None = None
+        first_chunk_at: float | None = None
 
         try:
             start = time.monotonic()
@@ -103,38 +101,36 @@ class OpenAITTSProvider(TTSProvider):
             ) as response:
                 async for chunk in response.iter_bytes():
                     if isinstance(chunk, bytes) and len(chunk) > 0:
-                        if ttfa_ms is None:
-                            ttfa_ms = (time.monotonic() - start) * 1000
-                            logger.debug(
-                                "openai_http_ttfa",
-                                model=self._model,
-                                ttfa_ms=ttfa_ms,
-                            )
+                        if first_chunk_at is None:
+                            first_chunk_at = time.monotonic()
                         audio_chunks.append(chunk)
         except Exception as exc:
             logger.debug("openai_http_error", exc_info=True)
-            return TTSResult(
+            return finalize_tts_result(
                 provider="openai",
                 model=self._model,
                 voice=self._voice,
-                ttfa_ms=ttfa_ms,
-                audio_path=None,
+                pcm=b"",
+                sample_rate=SAMPLE_RATE,
+                audio_synthesis_start=start,
+                first_audio_chunk_at=first_chunk_at,
                 error=str(exc),
             )
 
-        audio_path = _write_wav(audio_chunks, SAMPLE_RATE) if audio_chunks else None
-        return TTSResult(
+        return finalize_tts_result(
             provider="openai",
             model=self._model,
             voice=self._voice,
-            ttfa_ms=ttfa_ms,
-            audio_path=audio_path,
-            error=None,
+            pcm=b"".join(audio_chunks),
+            sample_rate=SAMPLE_RATE,
+            audio_synthesis_start=start,
+            first_audio_chunk_at=first_chunk_at,
         )
 
     async def _synthesize_realtime(self, text: str) -> TTSResult:
         audio_chunks: list[bytes] = []
-        ttfa_ms: float | None = None
+        start: float | None = None
+        first_chunk_at: float | None = None
 
         ws_url = f"wss://api.openai.com/v1/realtime?model={self._model}"
         ws_extra_headers = {
@@ -165,13 +161,8 @@ class OpenAITTSProvider(TTSProvider):
                         if event_type == "response.audio.delta" and "delta" in event:
                             audio_data = base64.b64decode(event["delta"])
                             if len(audio_data) > 0:
-                                if ttfa_ms is None:
-                                    ttfa_ms = (time.monotonic() - start) * 1000
-                                    logger.debug(
-                                        "openai_realtime_ttfa",
-                                        model=self._model,
-                                        ttfa_ms=ttfa_ms,
-                                    )
+                                if first_chunk_at is None:
+                                    first_chunk_at = time.monotonic()
                                 audio_chunks.append(audio_data)
 
                         if event_type == "response.done":
@@ -181,34 +172,23 @@ class OpenAITTSProvider(TTSProvider):
                         break
         except Exception as exc:
             logger.debug("openai_realtime_error", exc_info=True)
-            return TTSResult(
+            return finalize_tts_result(
                 provider="openai",
                 model=self._model,
                 voice=self._voice,
-                ttfa_ms=ttfa_ms,
-                audio_path=None,
+                pcm=b"",
+                sample_rate=SAMPLE_RATE,
+                audio_synthesis_start=start,
+                first_audio_chunk_at=first_chunk_at,
                 error=str(exc),
             )
 
-        audio_path = _write_wav(audio_chunks, SAMPLE_RATE) if audio_chunks else None
-        return TTSResult(
+        return finalize_tts_result(
             provider="openai",
             model=self._model,
             voice=self._voice,
-            ttfa_ms=ttfa_ms,
-            audio_path=audio_path,
-            error=None,
+            pcm=b"".join(audio_chunks),
+            sample_rate=SAMPLE_RATE,
+            audio_synthesis_start=start,
+            first_audio_chunk_at=first_chunk_at,
         )
-
-
-def _write_wav(chunks: list[bytes], sample_rate: int) -> Path:
-    """Concatenate PCM chunks and write a WAV file to a temp location."""
-    fd, tmp_name = tempfile.mkstemp(suffix=".wav")
-    os.close(fd)
-    audio_data = b"".join(chunks)
-    with wave.open(tmp_name, "wb") as wav_file:
-        wav_file.setnchannels(1)
-        wav_file.setsampwidth(2)
-        wav_file.setframerate(sample_rate)
-        wav_file.writeframes(audio_data)
-    return Path(tmp_name)

--- a/runner/src/coval_bench/providers/tts/rime.py
+++ b/runner/src/coval_bench/providers/tts/rime.py
@@ -7,11 +7,7 @@ from __future__ import annotations
 
 import base64
 import json
-import os
-import tempfile
 import time
-import wave
-from pathlib import Path
 from urllib.parse import urlencode
 
 import structlog
@@ -19,6 +15,7 @@ import websockets.asyncio.client as ws_client
 
 from coval_bench.config import Settings
 from coval_bench.providers.base import TTSProvider, TTSResult
+from coval_bench.providers.tts._common import finalize_tts_result
 
 logger: structlog.BoundLogger = structlog.get_logger(__name__)
 
@@ -72,7 +69,8 @@ class RimeTTSProvider(TTSProvider):
             )
 
         audio_chunks: list[bytes] = []
-        ttfa_ms: float | None = None
+        start: float | None = None
+        first_chunk_at: float | None = None
         sample_rate = _MODEL_SAMPLE_RATES.get(self._model, 24000)
 
         qs = urlencode(
@@ -102,13 +100,8 @@ class RimeTTSProvider(TTSProvider):
                     if msg_type == "chunk":
                         audio_bytes = base64.b64decode(msg["data"])
                         if audio_bytes:
-                            if ttfa_ms is None:
-                                ttfa_ms = (time.monotonic() - start) * 1000
-                                logger.debug(
-                                    "rime_ttfa",
-                                    model=self._model,
-                                    ttfa_ms=ttfa_ms,
-                                )
+                            if first_chunk_at is None:
+                                first_chunk_at = time.monotonic()
                             audio_chunks.append(audio_bytes)
 
                     elif msg_type == "done":
@@ -120,34 +113,23 @@ class RimeTTSProvider(TTSProvider):
 
         except Exception as exc:
             logger.warning("rime_error", exc_info=True)
-            return TTSResult(
+            return finalize_tts_result(
                 provider="rime",
                 model=self._model,
                 voice=self._voice,
-                ttfa_ms=ttfa_ms,
-                audio_path=None,
+                pcm=b"",
+                sample_rate=sample_rate,
+                audio_synthesis_start=start,
+                first_audio_chunk_at=first_chunk_at,
                 error=str(exc),
             )
 
-        audio_path = _write_wav(audio_chunks, sample_rate) if audio_chunks else None
-        return TTSResult(
+        return finalize_tts_result(
             provider="rime",
             model=self._model,
             voice=self._voice,
-            ttfa_ms=ttfa_ms,
-            audio_path=audio_path,
-            error=None,
+            pcm=b"".join(audio_chunks),
+            sample_rate=sample_rate,
+            audio_synthesis_start=start,
+            first_audio_chunk_at=first_chunk_at,
         )
-
-
-def _write_wav(chunks: list[bytes], sample_rate: int) -> Path:
-    """Concatenate raw PCM chunks and write a WAV file to a temp location."""
-    fd, tmp_name = tempfile.mkstemp(suffix=".wav")
-    os.close(fd)
-    audio_data = b"".join(chunks)
-    with wave.open(tmp_name, "wb") as wav_file:
-        wav_file.setnchannels(1)
-        wav_file.setsampwidth(2)
-        wav_file.setframerate(sample_rate)
-        wav_file.writeframes(audio_data)
-    return Path(tmp_name)

--- a/runner/src/coval_bench/providers/tts/xai.py
+++ b/runner/src/coval_bench/providers/tts/xai.py
@@ -7,11 +7,7 @@ from __future__ import annotations
 
 import base64
 import json
-import os
-import tempfile
 import time
-import wave
-from pathlib import Path
 from typing import Any
 from urllib.parse import urlencode
 
@@ -20,6 +16,7 @@ import websockets.asyncio.client as ws_client
 
 from coval_bench.config import Settings
 from coval_bench.providers.base import TTSProvider, TTSResult
+from coval_bench.providers.tts._common import finalize_tts_result
 
 logger: structlog.BoundLogger = structlog.get_logger(__name__)
 
@@ -66,7 +63,8 @@ class XaiTTSProvider(TTSProvider):
 
     async def synthesize(self, text: str) -> TTSResult:
         audio_chunks: list[bytes] = []
-        ttfa_ms: float | None = None
+        start: float | None = None
+        first_chunk_at: float | None = None
 
         try:
             headers = {"Authorization": f"Bearer {self._api_key}"}
@@ -90,8 +88,8 @@ class XaiTTSProvider(TTSProvider):
                         if audio_b64:
                             chunk = base64.b64decode(audio_b64)
                             if chunk:
-                                if ttfa_ms is None:
-                                    ttfa_ms = (time.monotonic() - start) * 1000
+                                if first_chunk_at is None:
+                                    first_chunk_at = time.monotonic()
                                 audio_chunks.append(chunk)
 
                     elif event_type == "audio.done":
@@ -102,33 +100,23 @@ class XaiTTSProvider(TTSProvider):
 
         except Exception as exc:
             logger.debug("xai_tts_error", exc_info=True)
-            return TTSResult(
+            return finalize_tts_result(
                 provider="xai",
                 model=self._model,
                 voice=self._voice,
-                ttfa_ms=ttfa_ms,
-                audio_path=None,
+                pcm=b"",
+                sample_rate=_SAMPLE_RATE,
+                audio_synthesis_start=start,
+                first_audio_chunk_at=first_chunk_at,
                 error=str(exc),
             )
 
-        audio_path = _write_wav(audio_chunks, _SAMPLE_RATE) if audio_chunks else None
-        return TTSResult(
+        return finalize_tts_result(
             provider="xai",
             model=self._model,
             voice=self._voice,
-            ttfa_ms=ttfa_ms,
-            audio_path=audio_path,
-            error=None,
+            pcm=b"".join(audio_chunks),
+            sample_rate=_SAMPLE_RATE,
+            audio_synthesis_start=start,
+            first_audio_chunk_at=first_chunk_at,
         )
-
-
-def _write_wav(chunks: list[bytes], sample_rate: int) -> Path:
-    fd, tmp_name = tempfile.mkstemp(suffix=".wav")
-    os.close(fd)
-    audio_data = b"".join(chunks)
-    with wave.open(tmp_name, "wb") as wav_file:
-        wav_file.setnchannels(1)
-        wav_file.setsampwidth(2)
-        wav_file.setframerate(sample_rate)
-        wav_file.writeframes(audio_data)
-    return Path(tmp_name)

--- a/runner/tests/providers/tts/test_cartesia.py
+++ b/runner/tests/providers/tts/test_cartesia.py
@@ -167,8 +167,8 @@ async def test_cartesia_send_includes_output_format(fake_settings: Settings) -> 
     The Cartesia SDK AsyncWebSocketContext.send() does NOT inherit output_format
     from conn.context() — ctx._output_format is only used by push(), not send().
     When output_format is omitted from send(), the SDK substitutes its own default
-    (pcm_f32le / 44100 Hz). _write_wav then stamps the WAV header as pcm_s16le /
-    24000 Hz, producing a corrupt file. Whisper hallucinating on corrupt audio
+    (pcm_f32le / 44100 Hz). The finalize step then stamps the WAV header as
+    pcm_s16le / 24000 Hz, producing a corrupt file. Whisper hallucinating on corrupt audio
     causes WER > 100% in the benchmark.
     """
     from coval_bench.providers.tts.cartesia import OUTPUT_FORMAT

--- a/runner/tests/providers/tts/test_rime.py
+++ b/runner/tests/providers/tts/test_rime.py
@@ -333,8 +333,8 @@ async def test_rime_empty_chunk_not_counted(fake_settings: Settings) -> None:
         result = await provider.synthesize("test")
 
     assert result.error is None
-    # If the `if audio_bytes:` guard is removed, audio_chunks = [b""] is truthy
-    # so _write_wav is called and ttfa_ms is set — both assertions below would fail.
+    # If the `if audio_bytes:` guard is removed, first_chunk_at gets stamped on the
+    # empty chunk, so ttfa_ms is computed (non-None) — the assertion below would fail.
     assert result.ttfa_ms is None
     assert result.audio_path is None
 

--- a/runner/tests/unit/test_tts_common.py
+++ b/runner/tests/unit/test_tts_common.py
@@ -1,0 +1,178 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the shared TTS finalize helper (perceived TTFA + WAV output)."""
+
+from __future__ import annotations
+
+import math
+import wave
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+
+from coval_bench.providers.tts._common import finalize_tts_result
+
+
+def _silence_pcm(duration_ms: float, sample_rate: int) -> bytes:
+    """Return *duration_ms* of pure silence as int16 PCM bytes."""
+    n = round(duration_ms / 1000.0 * sample_rate)
+    return np.zeros(n, dtype="<i2").tobytes()
+
+
+def _tone_pcm(
+    duration_ms: float, sample_rate: int, amplitude: float = 0.3, freq: float = 220.0
+) -> bytes:
+    """Return a *duration_ms* sine tone as int16 PCM bytes (amplitude in [0, 1])."""
+    n = round(duration_ms / 1000.0 * sample_rate)
+    t = np.arange(n) / sample_rate
+    wave_arr = amplitude * np.sin(2.0 * math.pi * freq * t)
+    return (wave_arr * 32767.0).astype("<i2").tobytes()
+
+
+def test_finalize_adds_leading_silence_offset() -> None:
+    """Silence-then-tone PCM → ttfa = arrival + offset, strictly greater than arrival."""
+    sr = 24000
+    lead_ms = 200.0
+    pcm = _silence_pcm(lead_ms, sr) + _tone_pcm(300, sr)
+    arrival_ms = 500.0
+
+    result = finalize_tts_result(
+        provider="test",
+        model="m",
+        voice="v",
+        pcm=pcm,
+        sample_rate=sr,
+        audio_synthesis_start=1000.0,
+        first_audio_chunk_at=1000.0 + arrival_ms / 1000.0,
+    )
+
+    assert result.ttfa_ms is not None
+    assert result.ttfa_ms > arrival_ms
+    assert result.ttfa_ms == pytest.approx(arrival_ms + lead_ms, abs=12.0)
+
+    assert result.audio_path is not None
+    assert result.audio_path.exists()
+    with wave.open(str(result.audio_path), "rb") as wav_file:
+        assert wav_file.getframerate() == sr
+        assert wav_file.getnchannels() == 1
+        assert wav_file.getsampwidth() == 2
+    result.audio_path.unlink()
+
+
+def test_finalize_immediate_tone_offset_near_zero() -> None:
+    """Immediate-tone PCM → ttfa ≈ arrival (offset ≈ 0)."""
+    sr = 24000
+    arrival_ms = 300.0
+    pcm = _tone_pcm(300, sr)
+
+    result = finalize_tts_result(
+        provider="test",
+        model="m",
+        voice="v",
+        pcm=pcm,
+        sample_rate=sr,
+        audio_synthesis_start=2.0,
+        first_audio_chunk_at=2.0 + arrival_ms / 1000.0,
+    )
+
+    assert result.ttfa_ms is not None
+    assert result.ttfa_ms == pytest.approx(arrival_ms, abs=10.0)
+    assert result.audio_path is not None
+    result.audio_path.unlink()
+
+
+def test_finalize_error_path_arrival_only() -> None:
+    """Error path (empty pcm, timestamps set) → ttfa = arrival only, no WAV."""
+    arrival_ms = 420.0
+    result = finalize_tts_result(
+        provider="test",
+        model="m",
+        voice="v",
+        pcm=b"",
+        sample_rate=24000,
+        audio_synthesis_start=10.0,
+        first_audio_chunk_at=10.0 + arrival_ms / 1000.0,
+        error="boom",
+    )
+
+    assert result.ttfa_ms == pytest.approx(arrival_ms)
+    assert result.audio_path is None
+    assert result.error == "boom"
+
+
+def test_finalize_odd_length_pcm_still_writes_wav() -> None:
+    """A dangling partial sample (split final frame) is dropped, not fatal.
+
+    Regression: offset detection rejects frame-misaligned PCM. The finalize step
+    must align it, still detect the leading-silence offset, and write the WAV.
+    """
+    sr = 24000
+    lead_ms = 200.0
+    pcm = _silence_pcm(lead_ms, sr) + _tone_pcm(300, sr) + b"\x07"  # stray odd byte
+
+    result = finalize_tts_result(
+        provider="test",
+        model="m",
+        voice="v",
+        pcm=pcm,
+        sample_rate=sr,
+        audio_synthesis_start=1.0,
+        first_audio_chunk_at=1.5,
+    )
+
+    assert result.ttfa_ms is not None
+    assert result.ttfa_ms == pytest.approx(500.0 + lead_ms, abs=12.0)
+    assert result.audio_path is not None
+    assert result.audio_path.exists()
+    with wave.open(str(result.audio_path), "rb") as wav_file:
+        # The dangling byte was dropped → frame count is a whole number of samples.
+        assert wav_file.getnframes() == (len(pcm) - 1) // 2
+    result.audio_path.unlink()
+
+
+def test_finalize_offset_failure_falls_back_and_writes_wav() -> None:
+    """If offset detection raises, TTFA degrades to arrival-only and the WAV still writes.
+
+    A latency-metric failure must never discard good synthesized audio.
+    """
+    sr = 24000
+    pcm = _tone_pcm(300, sr)
+    arrival_ms = 250.0
+
+    with patch(
+        "coval_bench.providers.tts._common.first_audible_offset_ms",
+        side_effect=RuntimeError("librosa boom"),
+    ):
+        result = finalize_tts_result(
+            provider="test",
+            model="m",
+            voice="v",
+            pcm=pcm,
+            sample_rate=sr,
+            audio_synthesis_start=10.0,
+            first_audio_chunk_at=10.0 + arrival_ms / 1000.0,
+        )
+
+    assert result.ttfa_ms == pytest.approx(arrival_ms)  # arrival only, offset dropped
+    assert result.error is None
+    assert result.audio_path is not None
+    assert result.audio_path.exists()
+    result.audio_path.unlink()
+
+
+def test_finalize_no_audio_returns_none() -> None:
+    """No audio (first_audio_chunk_at unset) → ttfa None, no WAV."""
+    result = finalize_tts_result(
+        provider="test",
+        model="m",
+        voice="v",
+        pcm=b"",
+        sample_rate=24000,
+        audio_synthesis_start=10.0,
+        first_audio_chunk_at=None,
+    )
+
+    assert result.ttfa_ms is None
+    assert result.audio_path is None
+    assert result.error is None


### PR DESCRIPTION
Digging into our metrics I noticed that we were seeing incredibly small variation in the TTFA (Time to First Audio) metric for some models, as low as std=10ms. Low variance is good but this picked my curiosity. I dug into how we measure TTFA and found that it was a simple difference between a T_0 representing when we send the transcript and a T_end when we receive the first chunk of audio file back. But the audio files we received back had significant differences in when the speech actually started. A provider could inadvertently inflate the TTFA metric by sending back a silent chunk of audio immediately after receiving the request.

This change adjusts how we compute TTFA. Before we computed time between sending the transcript and receiving the first audio. Now, we retain that but also process the audio to the time between the start of the audio and when the volume raises above a certain threshold (not exactly but an easy way to think about it). So our new TTFA is:

Time between sending the transcript and receiving the audio + time between audio start and audible speech

Also in this PR:
- Abstracted the wav file creation into a helper function. This was duplicated across every class so no significant functional change to the audio output.

This will lead to a slight inflation of provider latency compared to before. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added TTFA methodology clarifying TTFA now measures perceived first‑audible latency (pre/post-change values not comparable) and updated section numbering.

* **Refactor**
  * Unified TTS output handling across providers to standardize timing capture, audio file creation behavior, and error handling (removes per-provider WAV-temp flows).

* **Tests**
  * Added unit tests for TTS finalization and TTFA calculations, plus minor test comment/docstring updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->