### PR TITLE
Feat/http tts comparable ttfa

### DIFF
--- a/docs/methodology.md
+++ b/docs/methodology.md
@@ -100,6 +100,64 @@ The DP edit-distance computation is delegated to `jiwer`. Pinned in
 `uv.lock` change is reviewed against the SPDX license-set policy before
 merge.
 
+## 5. Latency measurement convention
+
+TTFT (STT) and TTFA (TTS) measure model inference time. Pre-t0 deployment
+setup — TCP, TLS, protocol handshake, optional session-setup RTT — is
+excluded for every provider. The rule is applied uniformly across cohorts;
+the magnitude of what each cohort excludes varies by deployment architecture,
+but the rule is the same.
+
+| Cohort | What is excluded from t0 |
+|---|---|
+| WS streaming (Deepgram, AssemblyAI, ElevenLabs Scribe, Speechmatics, Gradium STT, Cartesia, Deepgram aura-2, Rime, Gradium TTS, Hume) | TLS + WS upgrade + optional session-setup RTT (~50–200 ms). Handshake naturally completes inside `measure_ttft` / `synthesize` before t0. |
+| HTTP TTS (ElevenLabs HTTP, OpenAI `tts-1-hd`) | TLS + TCP via a shared `httpx.AsyncClient` pre-warmed once per run (~80–200 ms). |
+
+HTTP-pool warming lives in `runner/src/coval_bench/providers/_http_session.py`.
+Providers opt in by overriding `Provider.warmup()` in `providers/base.py`; the
+orchestrator invokes warmup on every enabled provider class before the
+dataset loop runs and tears down the pool in the run's `finally` block.
+
+### HTTP/2 for the HTTP TTS cohort
+
+The shared pool uses HTTP/2 so that every concurrent request to a host
+multiplexes over a single connection. The connection is opened once by
+`warmup()`, and the dataset loop — run at a concurrency of 8 — reuses it, so
+TCP+TLS is paid once and excluded from every TTFA row rather than just the
+first. `http2=True` and the pool limits are set on `TimedTransport`, not on
+`AsyncClient`: httpx ignores both when a custom transport is supplied. Both
+hosts (`api.openai.com`, `api.elevenlabs.io`) negotiate HTTP/2; under 8-way
+concurrency the pool stays at one socket per host. Requires the `h2` package
+(`httpx[http2]`) — a build without it raises at client construction rather
+than downgrading silently.
+
+The protocol is chosen by TLS ALPN at connect time. It can negotiate HTTP/1.1
+instead — a TLS-terminating proxy or middlebox, an `HTTPS_PROXY` tunnel, or an
+HTTP/1.1-only endpoint. On HTTP/1.1 there is no multiplexing, so concurrent
+requests open additional connections that `warmup()` did not warm, and TTFA
+reabsorbs TCP+TLS for those rows. `warmup()` logs `http_version` and emits a
+`*_prewarm_no_http2` warning on any non-h2 connection, and every HTTP TTS
+result row records the negotiated `http_version`, so HTTP/1.1 rows can be
+filtered out of analysis rather than silently inflating the published TTFA.
+
+**Follow-ups, not yet in this implementation:**
+
+- *NVCF gRPC hosted cohort (Nvidia Nemotron, Magpie).* These providers ship a
+  per-channel warmup probe that excludes TLS + gRPC channel + NVCF GPU
+  dispatch (~500–1000 ms) before t0. The probe uses the same
+  `Provider.warmup()` hook documented above and will be wired in when
+  `nvidia_hosted.py` lands on `main`; the cohort table will gain a third row
+  then.
+- *Connect-time isolation at the transport layer.* `TimedTransport` records
+  `submit-to-headers` time per request, surfaced on each HTTP TTS result row
+  as `submit_to_headers_ms` — small and stable values confirm the pool stayed
+  warm, while a spike flags a row whose connection reconnected mid-run and
+  reabsorbed connect time. It does not isolate TCP + TLS time from server
+  processing time. True per-call isolation would require subclassing
+  `httpcore.AsyncNetworkBackend` (one layer below httpx's transport).
+  Deferred — pool reuse achieves the same end result by construction, and the
+  recorded interval is sufficient to detect and filter pool eviction.
+
 ## Reproducing a result
 
 To reproduce a single `(provider, model, voice, metric)` cell:

--- a/docs/methodology.md
+++ b/docs/methodology.md
@@ -111,7 +111,7 @@ but the rule is the same.
 | Cohort | What is excluded from t0 |
 |---|---|
 | WS streaming (Deepgram, AssemblyAI, ElevenLabs Scribe, Speechmatics, Gradium STT, Cartesia, Deepgram aura-2, Rime, Gradium TTS, Hume) | TLS + WS upgrade + optional session-setup RTT (~50–200 ms). Handshake naturally completes inside `measure_ttft` / `synthesize` before t0. |
-| HTTP TTS (ElevenLabs HTTP, OpenAI `tts-1-hd`) | TLS + TCP via a shared `httpx.AsyncClient` pre-warmed once per run (~80–200 ms). |
+| HTTP TTS (ElevenLabs HTTP, OpenAI `gpt-4o-mini-tts`) | TLS + TCP via a shared `httpx.AsyncClient` pre-warmed once per run (~80–200 ms). |
 
 HTTP-pool warming lives in `runner/src/coval_bench/providers/_http_session.py`.
 Providers opt in by overriding `Provider.warmup()` in `providers/base.py`; the

--- a/runner/pyproject.toml
+++ b/runner/pyproject.toml
@@ -32,7 +32,6 @@ dependencies = [
     # TTS provider SDKs
     "openai>=1.40",
     "cartesia>=2",
-    "elevenlabs>=1.5",
     "aiohttp>=3.9",
     # Dataset
     "google-cloud-storage>=2.18",
@@ -119,10 +118,6 @@ ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
 module = "cartesia.*"
-ignore_missing_imports = true
-
-[[tool.mypy.overrides]]
-module = "elevenlabs.*"
 ignore_missing_imports = true
 
 [[tool.mypy.overrides]]

--- a/runner/src/coval_bench/db/migrations/versions/20260601_0002_add_http_diagnostics.py
+++ b/runner/src/coval_bench/db/migrations/versions/20260601_0002_add_http_diagnostics.py
@@ -1,0 +1,43 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Add http_version and submit_to_headers_ms diagnostics to results.
+
+Revision ID: 20260601_0002
+Revises:     20260429_0001
+Create Date: 2026-06-01
+
+These columns let analysis filter HTTP TTS rows whose TTFA reabsorbed
+connection setup: ``http_version`` distinguishes HTTP/2 from HTTP/1.1
+fallback, and ``submit_to_headers_ms`` flags rows where the warm pool
+reconnected mid-run.
+
+Deferred / out of scope: the ``results_24h`` materialized view is not changed
+to filter on ``http_version``. Contaminated rows are already excluded from
+aggregates because the orchestrator writes them with ``status='failed'`` and
+the view filters ``status='success'``. Adding an explicit per-protocol filter
+to the view (and to dashboard queries) is tracked as a separate follow-up.
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "20260601_0002"
+down_revision = "20260429_0001"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Add the two diagnostic columns to ``results``."""
+    op.execute("SET search_path TO benchmarks_v2")
+    op.execute("ALTER TABLE results ADD COLUMN http_version TEXT")
+    op.execute("ALTER TABLE results ADD COLUMN submit_to_headers_ms DOUBLE PRECISION")
+
+
+def downgrade() -> None:
+    """Drop the two diagnostic columns."""
+    op.execute("SET search_path TO benchmarks_v2")
+    op.execute("ALTER TABLE results DROP COLUMN IF EXISTS submit_to_headers_ms")
+    op.execute("ALTER TABLE results DROP COLUMN IF EXISTS http_version")

--- a/runner/src/coval_bench/db/models.py
+++ b/runner/src/coval_bench/db/models.py
@@ -67,3 +67,5 @@ class Result(BaseModel):
     transcript: str | None = None
     status: ResultStatus
     error: str | None = None
+    http_version: str | None = None
+    submit_to_headers_ms: float | None = None

--- a/runner/src/coval_bench/db/writer.py
+++ b/runner/src/coval_bench/db/writer.py
@@ -96,8 +96,8 @@ class RunWriter:
             INSERT INTO benchmarks_v2.results
                 (run_id, provider, model, voice, benchmark, metric_type,
                  metric_value, metric_units, audio_filename, transcript,
-                 status, error)
-            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                 status, error, http_version, submit_to_headers_ms)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
         """
         params = [
             (
@@ -113,6 +113,8 @@ class RunWriter:
                 r.transcript,
                 r.status,
                 r.error,
+                r.http_version,
+                r.submit_to_headers_ms,
             )
             for r in results
         ]

--- a/runner/src/coval_bench/providers/_http_session.py
+++ b/runner/src/coval_bench/providers/_http_session.py
@@ -1,0 +1,130 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared httpx clients with timed-transport diagnostics.
+
+HTTP providers grab a module-level ``httpx.AsyncClient`` keyed by provider.
+The client uses a long ``keepalive_expiry`` so the pool survives between
+dataset items; once the first request opens a connection, every subsequent
+request on that pool reuses it (no DNS, no TCP, no TLS).
+
+``TimedTransport`` stamps each request with ``__t_submit`` / ``__t_headers``
+in ``request.extensions``. ``submit_to_headers_ms`` reads those stamps so
+providers can record the interval on every result row: a small, stable value
+confirms the pool stayed warm; a spike means the connection reconnected and
+TTFA reabsorbed connect time for that row.
+
+Lifecycle is managed by the orchestrator: ``close_all()`` runs in the
+``finally`` of ``run_benchmarks``.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Final
+
+import httpx
+import structlog
+
+_log = structlog.get_logger(__name__)
+
+_KEEPALIVE_S: Final[float] = 300.0
+_TIMEOUT_S: Final[float] = 30.0
+_MAX_KEEPALIVE_CONNECTIONS: Final[int] = 8
+_MAX_CONNECTIONS: Final[int] = 8
+
+_CLIENTS: dict[str, httpx.AsyncClient] = {}
+
+
+class TimedTransport(httpx.AsyncHTTPTransport):
+    """httpx transport that timestamps each request for warmth diagnostics.
+
+    The interval ``__t_headers - __t_submit`` contains connect time (if the
+    pool was cold) plus server-side processing. After the orchestrator's
+    one-time warmup primes the pool, this interval should be small and
+    stable; large or growing values indicate the pool is reconnecting
+    mid-run.
+    """
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        opened_connection = False
+
+        async def _trace(name: str, info: dict[str, object]) -> None:
+            nonlocal opened_connection
+            if "connect_tcp" in name:
+                opened_connection = True
+
+        request.extensions["trace"] = _trace
+        t_submit = time.monotonic()
+        response = await super().handle_async_request(request)
+        t_headers = time.monotonic()
+        request.extensions["__t_submit"] = t_submit
+        request.extensions["__t_headers"] = t_headers
+        request.extensions["__connection_reused"] = not opened_connection
+        _log.debug(
+            "http_request_timing",
+            host=request.url.host,
+            method=request.method,
+            submit_to_headers_ms=round((t_headers - t_submit) * 1000, 1),
+            connection_reused=not opened_connection,
+        )
+        return response
+
+
+def submit_to_headers_ms(request: httpx.Request) -> float | None:
+    t_submit = request.extensions.get("__t_submit")
+    t_headers = request.extensions.get("__t_headers")
+    if t_submit is None or t_headers is None:
+        return None
+    return round((float(t_headers) - float(t_submit)) * 1000, 1)
+
+
+def connection_reused(request: httpx.Request) -> bool | None:
+    reused = request.extensions.get("__connection_reused")
+    if reused is None:
+        return None
+    return bool(reused)
+
+
+def get_shared_client(provider_key: str, base_url: str) -> httpx.AsyncClient:
+    """Return the module-level ``httpx.AsyncClient`` for *provider_key*.
+
+    Lazy-initialised on first call. Subsequent calls return the same instance
+    so connection-pool state is preserved across providers' lifetimes.
+
+    Raises ``ValueError`` if called again with the same *provider_key* but a
+    different *base_url* — the cached client is pinned to the first host.
+    """
+    existing = _CLIENTS.get(provider_key)
+    if existing is not None:
+        if str(existing.base_url).rstrip("/") != base_url.rstrip("/"):
+            raise ValueError(
+                f"shared client {provider_key!r} already bound to "
+                f"{existing.base_url!r}, cannot rebind to {base_url!r}"
+            )
+        return existing
+
+    _CLIENTS[provider_key] = httpx.AsyncClient(
+        base_url=base_url,
+        transport=TimedTransport(
+            retries=0,
+            http2=True,
+            limits=httpx.Limits(
+                max_connections=_MAX_CONNECTIONS,
+                max_keepalive_connections=_MAX_KEEPALIVE_CONNECTIONS,
+                keepalive_expiry=_KEEPALIVE_S,
+            ),
+        ),
+        timeout=_TIMEOUT_S,
+    )
+    return _CLIENTS[provider_key]
+
+
+async def close_all() -> None:
+    """Close every shared client. Idempotent; safe to call in a finally block."""
+    for key, client in list(_CLIENTS.items()):
+        try:
+            await client.aclose()
+        except Exception as exc:  # noqa: BLE001 — best-effort teardown
+            _log.debug("http_client_close_failed", provider=key, exc_info=exc)
+    _CLIENTS.clear()

--- a/runner/src/coval_bench/providers/base.py
+++ b/runner/src/coval_bench/providers/base.py
@@ -12,7 +12,10 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import ClassVar
+from typing import TYPE_CHECKING, ClassVar
+
+if TYPE_CHECKING:
+    from coval_bench.config import Settings
 
 # ---------------------------------------------------------------------------
 # Shared result types
@@ -63,6 +66,9 @@ class TTSResult:
     ttfa_ms: float | None
     audio_path: Path | None
     error: str | None
+    http_version: str | None = None
+    submit_to_headers_ms: float | None = None
+    connection_reused: bool | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -92,6 +98,17 @@ class Provider(ABC):
     @abstractmethod
     def model(self) -> str:
         """Model identifier used for this provider instance."""
+
+    @classmethod
+    async def warmup(cls, settings: Settings) -> None:
+        """Optional pre-t0 setup, invoked once per run before the dataset loop.
+
+        Default: no-op. Caller handles exceptions
+        (``return_exceptions=True``), so a failed warmup never aborts the
+        run. Implementers document protocol-specific behaviour on the
+        override.
+        """
+        return None
 
 
 class STTProvider(Provider, ABC):

--- a/runner/src/coval_bench/providers/tts/_common.py
+++ b/runner/src/coval_bench/providers/tts/_common.py
@@ -31,6 +31,9 @@ def finalize_tts_result(
     audio_synthesis_start: float | None,
     first_audio_chunk_at: float | None,
     error: str | None = None,
+    http_version: str | None = None,
+    submit_to_headers_ms: float | None = None,
+    connection_reused: bool | None = None,
 ) -> TTSResult:
     """Build a TTSResult with perceived TTFA from assembled PCM and timing.
 
@@ -74,6 +77,9 @@ def finalize_tts_result(
         ttfa_ms=ttfa_ms,
         audio_path=audio_path,
         error=error,
+        http_version=http_version,
+        submit_to_headers_ms=submit_to_headers_ms,
+        connection_reused=connection_reused,
     )
 
 

--- a/runner/src/coval_bench/providers/tts/elevenlabs.py
+++ b/runner/src/coval_bench/providers/tts/elevenlabs.py
@@ -1,19 +1,25 @@
 # Copyright 2026 The Coval Benchmarks Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""ElevenLabs TTS provider — uses the elevenlabs SDK for streaming synthesis."""
+"""ElevenLabs TTS provider — direct REST against a shared httpx pool.
+
+TTFA is measured from the first request byte to the first PCM chunk. The
+shared client is pre-warmed by ``warmup`` before the dataset loop, so the
+measurement excludes TCP+TLS setup.
+"""
 
 from __future__ import annotations
 
-import base64
-import json
 import time
-from io import BytesIO
 
 import structlog
-from elevenlabs import ElevenLabs
 
 from coval_bench.config import Settings
+from coval_bench.providers._http_session import (
+    connection_reused,
+    get_shared_client,
+    submit_to_headers_ms,
+)
 from coval_bench.providers.base import TTSProvider, TTSResult
 from coval_bench.providers.tts._common import finalize_tts_result
 
@@ -21,15 +27,22 @@ logger: structlog.BoundLogger = structlog.get_logger(__name__)
 
 SAMPLE_RATE = 24000
 
+_BASE_URL = "https://api.elevenlabs.io"
+_OUTPUT_FORMAT = "pcm_24000"
+
 
 class ElevenLabsTTSProvider(TTSProvider):
-    """ElevenLabs TTS provider using the official SDK streaming endpoint."""
+    """ElevenLabs TTS provider over the REST streaming endpoint."""
 
     enabled: bool = True
 
     _VALID_MODELS = frozenset({"eleven_flash_v2_5", "eleven_multilingual_v2", "eleven_turbo_v2_5"})
 
     def __init__(self, settings: Settings, model: str, voice: str) -> None:
+        if model not in self._VALID_MODELS:
+            raise ValueError(
+                f"Unsupported ElevenLabs model {model!r}. Valid: {sorted(self._VALID_MODELS)}"
+            )
         self._model = model
         self._voice = voice
 
@@ -46,72 +59,69 @@ class ElevenLabsTTSProvider(TTSProvider):
     def model(self) -> str:
         return self._model
 
-    @staticmethod
-    def _is_audio_chunk(message: object) -> bool:
-        """Return True when *message* carries audio data."""
-        if isinstance(message, bytes) and len(message) > 0:
-            return True
-        if isinstance(message, str):
-            try:
-                data = json.loads(message)
-                return bool(data.get("audio"))
-            except (json.JSONDecodeError, TypeError):
-                return False
-        return False
+    @classmethod
+    async def warmup(cls, settings: Settings) -> None:
+        """Pre-warm the shared httpx connection pool with a HEAD probe.
 
-    @staticmethod
-    def _extract_audio(message: object) -> bytes:
-        """Extract raw PCM bytes from a message."""
-        if isinstance(message, bytes):
-            return message
-        if isinstance(message, str):
-            try:
-                data = json.loads(message)
-                audio_b64 = data.get("audio")
-                if audio_b64:
-                    return base64.b64decode(audio_b64)
-            except (json.JSONDecodeError, TypeError, Exception):  # noqa: BLE001
-                logger.debug("elevenlabs_extract_audio_failed", message=message[:100])
-        return b""
+        Transport failures propagate to the caller, which runs warmup under
+        ``return_exceptions=True`` and logs them. A 401 still warms the
+        socket, so an unauthenticated HEAD is sufficient.
+        """
+        client = get_shared_client("elevenlabs", _BASE_URL)
+        t0 = time.monotonic()
+        response = await client.head("/v1/voices")
+        logger.info(
+            "elevenlabs_prewarm",
+            warmup_ms=round((time.monotonic() - t0) * 1000, 1),
+            http_version=response.http_version,
+        )
+        if response.http_version != "HTTP/2":
+            logger.warning("elevenlabs_prewarm_no_http2", http_version=response.http_version)
 
     async def synthesize(self, text: str) -> TTSResult:
-        """Synthesize speech via ElevenLabs SDK and return a TTSResult."""
-        if not self._model_supported(self._model):
-            return TTSResult(
-                provider="elevenlabs",
-                model=self._model,
-                voice=self._voice,
-                ttfa_ms=None,
-                audio_path=None,
-                error=(
-                    f"Unsupported ElevenLabs model: {self._model}. "
-                    f"Valid models: {sorted(self._VALID_MODELS)}"
-                ),
-            )
+        client = get_shared_client("elevenlabs", _BASE_URL)
+        url = f"/v1/text-to-speech/{self._voice}/stream?output_format={_OUTPUT_FORMAT}"
+        headers = {
+            "xi-api-key": self._api_key,
+            "Content-Type": "application/json",
+            "Accept": "audio/pcm",
+        }
+        payload = {"text": text, "model_id": self._model}
+
+        audio_chunks: list[bytes] = []
+        http_version: str | None = None
+        setup_ms: float | None = None
+        reused: bool | None = None
         start: float | None = None
         first_chunk_at: float | None = None
-        audio_stream = BytesIO()
 
         try:
-            client = ElevenLabs(api_key=self._api_key)
             start = time.monotonic()
-
-            response = client.text_to_speech.stream(
-                voice_id=self._voice,
-                output_format="pcm_24000",
-                text=text,
-                model_id=self._model,
-            )
-
-            for chunk in response:
-                if chunk:
-                    if self._is_audio_chunk(chunk) and first_chunk_at is None:
+            async with client.stream("POST", url, headers=headers, json=payload) as response:
+                http_version = response.http_version
+                setup_ms = submit_to_headers_ms(response.request)
+                reused = connection_reused(response.request)
+                if response.is_error:
+                    body = await response.aread()
+                    detail = body.decode("utf-8", "replace").strip() or response.reason_phrase
+                    return finalize_tts_result(
+                        provider="elevenlabs",
+                        model=self._model,
+                        voice=self._voice,
+                        pcm=b"",
+                        sample_rate=SAMPLE_RATE,
+                        audio_synthesis_start=None,
+                        first_audio_chunk_at=None,
+                        error=f"HTTP {response.status_code}: {detail[:500]}",
+                        http_version=http_version,
+                        submit_to_headers_ms=setup_ms,
+                        connection_reused=reused,
+                    )
+                async for chunk in response.aiter_bytes():
+                    if chunk and first_chunk_at is None:
                         first_chunk_at = time.monotonic()
-                    if isinstance(chunk, bytes):
-                        audio_stream.write(chunk)
-                    else:
-                        audio_stream.write(self._extract_audio(chunk))
-
+                    if chunk:
+                        audio_chunks.append(chunk)
         except Exception as exc:
             logger.debug("elevenlabs_error", exc_info=True)
             return finalize_tts_result(
@@ -123,9 +133,12 @@ class ElevenLabsTTSProvider(TTSProvider):
                 audio_synthesis_start=start,
                 first_audio_chunk_at=first_chunk_at,
                 error=str(exc),
+                http_version=http_version,
+                submit_to_headers_ms=setup_ms,
+                connection_reused=reused,
             )
 
-        audio_data = audio_stream.getvalue()
+        audio_data = b"".join(audio_chunks)
         if not audio_data:
             logger.warning("elevenlabs_no_audio", model=self._model)
 
@@ -137,4 +150,7 @@ class ElevenLabsTTSProvider(TTSProvider):
             sample_rate=SAMPLE_RATE,
             audio_synthesis_start=start,
             first_audio_chunk_at=first_chunk_at,
+            http_version=http_version,
+            submit_to_headers_ms=setup_ms,
+            connection_reused=reused,
         )

--- a/runner/src/coval_bench/providers/tts/openai.py
+++ b/runner/src/coval_bench/providers/tts/openai.py
@@ -16,6 +16,11 @@ import websockets.exceptions
 from openai import AsyncOpenAI
 
 from coval_bench.config import Settings
+from coval_bench.providers._http_session import (
+    connection_reused,
+    get_shared_client,
+    submit_to_headers_ms,
+)
 from coval_bench.providers.base import TTSProvider, TTSResult
 from coval_bench.providers.tts._common import finalize_tts_result
 
@@ -37,6 +42,8 @@ VALID_VOICES = [
 HTTP_MODELS = {"gpt-4o-mini-tts"}
 REALTIME_MODELS = {"gpt-realtime-2025-08-28"}
 SAMPLE_RATE = 24000
+
+_BASE_URL = "https://api.openai.com"
 
 
 class OpenAITTSProvider(TTSProvider):
@@ -63,7 +70,10 @@ class OpenAITTSProvider(TTSProvider):
         if api_key_secret is None:
             raise ValueError("openai_api_key is required in Settings")
         self._api_key = api_key_secret.get_secret_value()
-        self._client = AsyncOpenAI(api_key=self._api_key)
+        self._client = AsyncOpenAI(
+            api_key=self._api_key,
+            http_client=get_shared_client("openai", _BASE_URL),
+        )
 
     @property
     def name(self) -> str:
@@ -72,6 +82,26 @@ class OpenAITTSProvider(TTSProvider):
     @property
     def model(self) -> str:
         return self._model
+
+    @classmethod
+    async def warmup(cls, settings: Settings) -> None:
+        """Pre-warm the shared httpx pool used by the HTTP TTS path.
+
+        Transport failures propagate to the caller, which runs warmup under
+        ``return_exceptions=True`` and logs them. A 401 still warms the
+        socket, so an unauthenticated HEAD is sufficient. The Realtime WS
+        path is unaffected (it opens its own ws connection).
+        """
+        client = get_shared_client("openai", _BASE_URL)
+        t0 = time.monotonic()
+        response = await client.head("/v1/models")
+        logger.info(
+            "openai_prewarm",
+            warmup_ms=round((time.monotonic() - t0) * 1000, 1),
+            http_version=response.http_version,
+        )
+        if response.http_version != "HTTP/2":
+            logger.warning("openai_prewarm_no_http2", http_version=response.http_version)
 
     async def synthesize(self, text: str) -> TTSResult:
         """Synthesize speech and return a TTSResult."""
@@ -90,6 +120,9 @@ class OpenAITTSProvider(TTSProvider):
 
     async def _synthesize_http(self, text: str) -> TTSResult:
         audio_chunks: list[bytes] = []
+        http_version: str | None = None
+        setup_ms: float | None = None
+        reused: bool | None = None
         start: float | None = None
         first_chunk_at: float | None = None
 
@@ -101,6 +134,9 @@ class OpenAITTSProvider(TTSProvider):
                 input=text,
                 response_format="pcm",
             ) as response:
+                http_version = response.http_version
+                setup_ms = submit_to_headers_ms(response.http_response.request)
+                reused = connection_reused(response.http_response.request)
                 async for chunk in response.iter_bytes():
                     if isinstance(chunk, bytes) and len(chunk) > 0:
                         if first_chunk_at is None:
@@ -117,6 +153,9 @@ class OpenAITTSProvider(TTSProvider):
                 audio_synthesis_start=start,
                 first_audio_chunk_at=first_chunk_at,
                 error=str(exc),
+                http_version=http_version,
+                submit_to_headers_ms=setup_ms,
+                connection_reused=reused,
             )
 
         return finalize_tts_result(
@@ -127,6 +166,9 @@ class OpenAITTSProvider(TTSProvider):
             sample_rate=SAMPLE_RATE,
             audio_synthesis_start=start,
             first_audio_chunk_at=first_chunk_at,
+            http_version=http_version,
+            submit_to_headers_ms=setup_ms,
+            connection_reused=reused,
         )
 
     async def _synthesize_realtime(self, text: str) -> TTSResult:

--- a/runner/src/coval_bench/runner/orchestrator.py
+++ b/runner/src/coval_bench/runner/orchestrator.py
@@ -43,6 +43,8 @@ from typing import TYPE_CHECKING, Any, Literal
 import structlog
 from pydantic import BaseModel
 
+from coval_bench.providers._http_session import close_all as _close_http_clients
+from coval_bench.providers.base import Provider
 from coval_bench.runner.config import DEFAULT_STT_MATRIX, DEFAULT_TTS_MATRIX, ProviderEntry
 from coval_bench.runner.retry import with_retry
 
@@ -405,6 +407,17 @@ async def _run_tts_item(
 
         try:
             # 1. TTFA
+            if tts_result.http_version is not None and tts_result.http_version != "HTTP/2":
+                ttfa_failure = (
+                    f"TTFA measured over {tts_result.http_version}; not comparable "
+                    "(no HTTP/2 multiplexing, TTFA reabsorbs TCP+TLS)"
+                )
+            elif tts_result.connection_reused is False:
+                ttfa_failure = (
+                    "TTFA measured over a cold connection; not comparable (TTFA reabsorbs TCP+TLS)"
+                )
+            else:
+                ttfa_failure = None
             results.append(
                 Result(
                     run_id=run_id,
@@ -413,12 +426,14 @@ async def _run_tts_item(
                     voice=entry.voice,
                     benchmark=Benchmark.TTS,
                     metric_type="TTFA",
-                    metric_value=tts_result.ttfa_ms,
+                    metric_value=None if ttfa_failure else tts_result.ttfa_ms,
                     metric_units="milliseconds",
                     audio_filename=audio_path.name if audio_path else None,
                     transcript=transcript,
-                    status=ResultStatus.SUCCESS,
-                    error=None,
+                    status=ResultStatus.FAILED if ttfa_failure else ResultStatus.SUCCESS,
+                    error=_truncate(ttfa_failure) if ttfa_failure else None,
+                    http_version=tts_result.http_version,
+                    submit_to_headers_ms=tts_result.submit_to_headers_ms,
                 )
             )
 
@@ -595,6 +610,40 @@ async def run_benchmarks(
 
         try:
             # ------------------------------------------------------------------
+            # 2b. Provider warmup
+            # Each provider class may override Provider.warmup() to absorb
+            # pre-t0 deployment cold-start cost (HTTP TCP+TLS, gRPC channel
+            # open, NVCF dispatch).  Default is a no-op; only providers that
+            # need it pay the call.  Errors are non-fatal.
+            # ------------------------------------------------------------------
+            stt_providers = _get_stt_providers()
+            tts_providers = _get_tts_providers()
+            provider_classes: set[type[Provider]] = set()
+            if benchmark_kind in ("stt", "both"):
+                for entry in enabled_stt:
+                    cls = stt_providers.get(entry.provider)
+                    if cls is not None:
+                        provider_classes.add(cls)
+            if benchmark_kind in ("tts", "both"):
+                for entry in enabled_tts:
+                    cls = tts_providers.get(entry.provider)
+                    if cls is not None:
+                        provider_classes.add(cls)
+            if provider_classes:
+                ordered_classes = list(provider_classes)
+                warmup_results = await asyncio.gather(
+                    *(cls.warmup(settings=settings) for cls in ordered_classes),
+                    return_exceptions=True,
+                )
+                for cls, res in zip(ordered_classes, warmup_results, strict=False):
+                    if isinstance(res, BaseException):
+                        _log.warning(
+                            "provider_warmup_failed",
+                            provider=cls.__name__,
+                            exc_info=res,
+                        )
+
+            # ------------------------------------------------------------------
             # 3. STT path
             # ------------------------------------------------------------------
             if benchmark_kind in ("stt", "both") and enabled_stt:
@@ -764,3 +813,5 @@ async def run_benchmarks(
         finally:
             with contextlib.suppress(NotImplementedError, ValueError):
                 loop.remove_signal_handler(signal.SIGTERM)
+            with contextlib.suppress(Exception):
+                await _close_http_clients()

--- a/runner/tests/providers/test_http_session.py
+++ b/runner/tests/providers/test_http_session.py
@@ -1,0 +1,175 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the shared httpx client registry."""
+
+from __future__ import annotations
+
+import pytest
+
+from coval_bench.providers import _http_session
+
+
+@pytest.fixture(autouse=True)
+def _reset_clients() -> None:
+    _http_session._CLIENTS.clear()
+    yield
+    _http_session._CLIENTS.clear()
+
+
+# ---------------------------------------------------------------------------
+# get_shared_client — memoization
+# ---------------------------------------------------------------------------
+
+
+def test_get_shared_client_memoizes() -> None:
+    a = _http_session.get_shared_client("foo", "https://example.com")
+    b = _http_session.get_shared_client("foo", "https://example.com")
+    assert a is b
+
+
+def test_get_shared_client_distinct_per_key() -> None:
+    a = _http_session.get_shared_client("foo", "https://example.com")
+    b = _http_session.get_shared_client("bar", "https://example.org")
+    assert a is not b
+    assert {"foo", "bar"} <= set(_http_session._CLIENTS)
+
+
+def test_get_shared_client_rejects_rebind_to_new_base_url() -> None:
+    _http_session.get_shared_client("foo", "https://example.com")
+    with pytest.raises(ValueError, match="already bound"):
+        _http_session.get_shared_client("foo", "https://other.example.com")
+
+
+def test_get_shared_client_uses_timed_transport() -> None:
+    c = _http_session.get_shared_client("foo", "https://example.com")
+    # The default transport wraps the chosen one; httpx exposes it directly.
+    assert isinstance(c._transport, _http_session.TimedTransport)
+
+
+def test_get_shared_client_applies_http2_and_limits() -> None:
+    """http2/limits must live on the transport's pool, not the ignored client args."""
+    pool = _http_session.get_shared_client("foo", "https://example.com")._transport._pool
+    assert pool._http2 is True
+    assert pool._keepalive_expiry == _http_session._KEEPALIVE_S
+    assert pool._max_keepalive_connections == _http_session._MAX_KEEPALIVE_CONNECTIONS
+    assert pool._max_connections == _http_session._MAX_CONNECTIONS
+
+
+# ---------------------------------------------------------------------------
+# submit_to_headers_ms — reads TimedTransport stamps
+# ---------------------------------------------------------------------------
+
+
+def test_submit_to_headers_ms_none_without_stamps() -> None:
+    import httpx
+
+    request = httpx.Request("GET", "https://example.com")
+    assert _http_session.submit_to_headers_ms(request) is None
+
+
+def test_submit_to_headers_ms_computes_interval() -> None:
+    import httpx
+
+    request = httpx.Request("GET", "https://example.com")
+    request.extensions["__t_submit"] = 100.0
+    request.extensions["__t_headers"] = 100.5
+    assert _http_session.submit_to_headers_ms(request) == 500.0
+
+
+# ---------------------------------------------------------------------------
+# TimedTransport — stamps timing and connection-reuse on each request
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_timed_transport_flags_new_connection(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A request that opens a TCP connection is stamped not-reused."""
+    import httpx
+
+    async def fake_super(self: object, request: httpx.Request) -> httpx.Response:
+        trace = request.extensions.get("trace")
+        if trace is not None:
+            await trace("connection.connect_tcp.started", {})
+        return httpx.Response(200, request=request)
+
+    monkeypatch.setattr(httpx.AsyncHTTPTransport, "handle_async_request", fake_super)
+    request = httpx.Request("GET", "https://example.com")
+    await _http_session.TimedTransport().handle_async_request(request)
+
+    assert _http_session.submit_to_headers_ms(request) is not None
+    assert _http_session.connection_reused(request) is False
+
+
+@pytest.mark.asyncio
+async def test_timed_transport_flags_reused_connection(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A request with no connect event reused a pooled connection."""
+    import httpx
+
+    async def fake_super(self: object, request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, request=request)
+
+    monkeypatch.setattr(httpx.AsyncHTTPTransport, "handle_async_request", fake_super)
+    request = httpx.Request("GET", "https://example.com")
+    await _http_session.TimedTransport().handle_async_request(request)
+
+    assert _http_session.connection_reused(request) is True
+
+
+@pytest.mark.asyncio
+async def test_timed_transport_trace_is_async_through_real_httpcore() -> None:
+    """A real request exercises httpcore's async trace path.
+
+    Regression guard: a sync ``trace`` callback raises ``TypeError`` here
+    (httpcore rejects non-coroutine callbacks on the async path); an async one
+    lets the request proceed to a genuine connection error.
+    """
+    import httpx
+
+    transport = _http_session.TimedTransport()
+    request = httpx.Request("GET", "http://127.0.0.1:1/")
+    try:
+        with pytest.raises(httpx.ConnectError):
+            await transport.handle_async_request(request)
+    finally:
+        await transport.aclose()
+
+
+def test_connection_reused_none_without_stamp() -> None:
+    import httpx
+
+    request = httpx.Request("GET", "https://example.com")
+    assert _http_session.connection_reused(request) is None
+
+
+# ---------------------------------------------------------------------------
+# close_all — clears registry and aclose()s each client
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_close_all_clears_registry() -> None:
+    _http_session.get_shared_client("foo", "https://example.com")
+    _http_session.get_shared_client("bar", "https://example.org")
+    assert len(_http_session._CLIENTS) == 2
+
+    await _http_session.close_all()
+    assert _http_session._CLIENTS == {}
+
+
+@pytest.mark.asyncio
+async def test_close_all_is_idempotent() -> None:
+    await _http_session.close_all()  # empty registry
+    await _http_session.close_all()  # second call, still empty
+    assert _http_session._CLIENTS == {}
+
+
+@pytest.mark.asyncio
+async def test_close_all_swallows_per_client_errors() -> None:
+    class _BrokenClient:
+        async def aclose(self) -> None:
+            raise RuntimeError("synthetic close failure")
+
+    _http_session._CLIENTS["broken"] = _BrokenClient()  # type: ignore[assignment]
+    await _http_session.close_all()  # must not raise
+    assert _http_session._CLIENTS == {}

--- a/runner/tests/providers/tts/test_elevenlabs.py
+++ b/runner/tests/providers/tts/test_elevenlabs.py
@@ -6,14 +6,35 @@
 from __future__ import annotations
 
 from pathlib import Path
-from unittest.mock import MagicMock, patch
 
+import httpx
 import pytest
 
 from coval_bench.config import Settings
+from coval_bench.providers import _http_session
 from coval_bench.providers.tts.elevenlabs import ElevenLabsTTSProvider
 
 from .conftest import make_pcm_bytes
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _install_mock(handler: object) -> None:
+    """Register a MockTransport-backed AsyncClient as the shared elevenlabs client."""
+    _http_session._CLIENTS["elevenlabs"] = httpx.AsyncClient(
+        base_url="https://api.elevenlabs.io",
+        transport=httpx.MockTransport(handler),  # type: ignore[arg-type]
+    )
+
+
+@pytest.fixture(autouse=True)
+def reset_clients() -> None:
+    _http_session._CLIENTS.clear()
+    yield
+    _http_session._CLIENTS.clear()
+
 
 # ---------------------------------------------------------------------------
 # Happy path
@@ -21,46 +42,61 @@ from .conftest import make_pcm_bytes
 
 
 @pytest.mark.asyncio
-async def test_elevenlabs_happy_path(fake_settings: Settings, tmp_path: Path) -> None:
-    """ElevenLabs synthesize → ttfa set, WAV file written."""
-    pcm_chunks = [make_pcm_bytes(240), make_pcm_bytes(240)]
+async def test_elevenlabs_happy_path(
+    fake_settings: Settings,
+    tmp_path: Path,
+) -> None:
+    pcm = make_pcm_bytes(480) * 4  # ~80 ms of silence
+    captured: dict[str, object] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        captured["xi_api_key"] = request.headers.get("xi-api-key")
+        captured["body"] = request.read()
+        return httpx.Response(200, content=pcm)
+
+    _install_mock(handler)
 
     provider = ElevenLabsTTSProvider(
         fake_settings,
         model="eleven_flash_v2_5",
         voice="IKne3meq5aSn9XLyUdCD",
     )
+    result = await provider.synthesize("Hello from ElevenLabs")
 
-    mock_sdk = MagicMock()
-    mock_sdk.text_to_speech.stream.return_value = iter(pcm_chunks)
-
-    with patch("coval_bench.providers.tts.elevenlabs.ElevenLabs", return_value=mock_sdk):
-        result = await provider.synthesize("Hello from ElevenLabs")
-
-    assert result.error is None, f"Unexpected error: {result.error}"
-    assert result.ttfa_ms is not None
-    assert 0 < result.ttfa_ms < 60_000
-    assert result.audio_path is not None
-    assert result.audio_path.exists()
+    assert result.error is None, result.error
+    assert result.ttfa_ms is not None and 0 < result.ttfa_ms < 10_000
+    assert result.audio_path is not None and result.audio_path.exists()
     assert result.audio_path.stat().st_size > 0
     assert result.provider == "elevenlabs"
     assert result.model == "eleven_flash_v2_5"
+    assert result.http_version == "HTTP/1.1"
+    assert result.submit_to_headers_ms is None
+
+    url = str(captured["url"])
+    assert "/v1/text-to-speech/IKne3meq5aSn9XLyUdCD/stream" in url
+    assert "output_format=pcm_24000" in url
+    assert captured["xi_api_key"] == "test-elevenlabs-key"
+    body = captured["body"]
+    assert isinstance(body, bytes)
+    assert b"Hello from ElevenLabs" in body
+    assert b"eleven_flash_v2_5" in body
 
     result.audio_path.unlink()
 
 
 @pytest.mark.asyncio
 async def test_elevenlabs_all_models(fake_settings: Settings) -> None:
-    """Supported models all work with monkeypatched SDK."""
-    pcm = make_pcm_bytes()
+    def handler(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=make_pcm_bytes(240))
+
+    _install_mock(handler)
+
     for model in ElevenLabsTTSProvider._VALID_MODELS:
         provider = ElevenLabsTTSProvider(fake_settings, model=model, voice="test-voice")
-        mock_sdk = MagicMock()
-        mock_sdk.text_to_speech.stream.return_value = iter([pcm])
-        with patch("coval_bench.providers.tts.elevenlabs.ElevenLabs", return_value=mock_sdk):
-            result = await provider.synthesize("test")
-        assert result.error is None, f"Model {model}: {result.error}"
-        if result.audio_path:
+        result = await provider.synthesize("test")
+        assert result.error is None, f"{model}: {result.error}"
+        if result.audio_path is not None:
             result.audio_path.unlink()
 
 
@@ -70,31 +106,46 @@ async def test_elevenlabs_all_models(fake_settings: Settings) -> None:
 
 
 @pytest.mark.asyncio
-async def test_elevenlabs_sdk_error(fake_settings: Settings) -> None:
-    """SDK exception → result.error populated, audio_path None."""
-    provider = ElevenLabsTTSProvider(fake_settings, model="eleven_flash_v2_5", voice="test-voice")
+async def test_elevenlabs_http_error(fake_settings: Settings) -> None:
+    def handler(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(429, content=b'{"detail": "rate limit"}')
 
-    with patch(
-        "coval_bench.providers.tts.elevenlabs.ElevenLabs",
-        side_effect=RuntimeError("API rate limit"),
-    ):
-        result = await provider.synthesize("error test")
+    _install_mock(handler)
+
+    provider = ElevenLabsTTSProvider(fake_settings, model="eleven_flash_v2_5", voice="v")
+    result = await provider.synthesize("hi")
 
     assert result.error is not None
-    assert "API rate limit" in result.error
+    assert "429" in result.error
+    assert "rate limit" in result.error
     assert result.audio_path is None
 
 
 @pytest.mark.asyncio
+async def test_elevenlabs_transport_exception(fake_settings: Settings) -> None:
+    def handler(_: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("synthetic network failure")
+
+    _install_mock(handler)
+
+    provider = ElevenLabsTTSProvider(fake_settings, model="eleven_flash_v2_5", voice="v")
+    result = await provider.synthesize("hi")
+
+    assert result.error is not None
+    assert "synthetic network failure" in result.error
+    assert result.audio_path is None
+    assert result.ttfa_ms is None
+
+
+@pytest.mark.asyncio
 async def test_elevenlabs_empty_response(fake_settings: Settings) -> None:
-    """Empty iterator from SDK → audio_path is None, error is None."""
-    provider = ElevenLabsTTSProvider(fake_settings, model="eleven_flash_v2_5", voice="test-voice")
+    def handler(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=b"")
 
-    mock_sdk = MagicMock()
-    mock_sdk.text_to_speech.stream.return_value = iter([])  # nothing
+    _install_mock(handler)
 
-    with patch("coval_bench.providers.tts.elevenlabs.ElevenLabs", return_value=mock_sdk):
-        result = await provider.synthesize("silence")
+    provider = ElevenLabsTTSProvider(fake_settings, model="eleven_flash_v2_5", voice="v")
+    result = await provider.synthesize("silence")
 
     assert result.error is None
     assert result.audio_path is None
@@ -102,75 +153,34 @@ async def test_elevenlabs_empty_response(fake_settings: Settings) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Static method coverage — JSON-encoded audio branch
+# warmup
 # ---------------------------------------------------------------------------
 
 
-def test_elevenlabs_is_audio_chunk_bytes() -> None:
-    """Bytes with content are audio chunks."""
-    assert ElevenLabsTTSProvider._is_audio_chunk(b"\x00\x01") is True
-    assert ElevenLabsTTSProvider._is_audio_chunk(b"") is False
+@pytest.mark.asyncio
+async def test_elevenlabs_warmup_issues_head(fake_settings: Settings) -> None:
+    seen: list[str] = []
 
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(f"{request.method} {request.url.path}")
+        return httpx.Response(401, content=b"unauthorized")
 
-def test_elevenlabs_is_audio_chunk_json_with_audio() -> None:
-    """JSON-encoded message with 'audio' key is an audio chunk."""
-    import base64
-    import json
+    _install_mock(handler)
+    await ElevenLabsTTSProvider.warmup(fake_settings)
 
-    payload = json.dumps({"audio": base64.b64encode(b"\x00\x01").decode()})
-    assert ElevenLabsTTSProvider._is_audio_chunk(payload) is True
-
-
-def test_elevenlabs_is_audio_chunk_json_no_audio() -> None:
-    """JSON without 'audio' key is not an audio chunk."""
-    import json
-
-    payload = json.dumps({"isFinal": True})
-    assert ElevenLabsTTSProvider._is_audio_chunk(payload) is False
-
-
-def test_elevenlabs_is_audio_chunk_invalid_json() -> None:
-    """Non-JSON string is not an audio chunk."""
-    assert ElevenLabsTTSProvider._is_audio_chunk("not json") is False
-
-
-def test_elevenlabs_extract_audio_from_json() -> None:
-    """Extracts base64-encoded audio from JSON message."""
-    import base64
-    import json
-
-    raw = b"\x00\x01\x02"
-    payload = json.dumps({"audio": base64.b64encode(raw).decode()})
-    result = ElevenLabsTTSProvider._extract_audio(payload)
-    assert result == raw
-
-
-def test_elevenlabs_extract_audio_fallback() -> None:
-    """Invalid JSON returns empty bytes."""
-    result = ElevenLabsTTSProvider._extract_audio("invalid json {{{")
-    assert result == b""
+    assert seen == ["HEAD /v1/voices"]
 
 
 @pytest.mark.asyncio
-async def test_elevenlabs_json_audio_chunks(fake_settings: Settings) -> None:
-    """Synthesize with JSON-encoded audio chunk (ElevenLabs WS format)."""
-    import base64
-    import json
+async def test_elevenlabs_warmup_propagates_transport_error(fake_settings: Settings) -> None:
+    """Transport failures propagate so the orchestrator can log them."""
 
-    raw_pcm = make_pcm_bytes(240)
-    json_chunk = json.dumps({"audio": base64.b64encode(raw_pcm).decode()})
+    def handler(_: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("dns blew up")
 
-    provider = ElevenLabsTTSProvider(fake_settings, model="eleven_flash_v2_5", voice="test-voice")
-
-    mock_sdk = MagicMock()
-    mock_sdk.text_to_speech.stream.return_value = iter([json_chunk])
-
-    with patch("coval_bench.providers.tts.elevenlabs.ElevenLabs", return_value=mock_sdk):
-        result = await provider.synthesize("json audio test")
-
-    # The json branch goes through _extract_audio which returns the decoded bytes
-    # audio stream write receives empty string from non-bytes path, ttfa may be None
-    assert result.error is None
+    _install_mock(handler)
+    with pytest.raises(httpx.ConnectError):
+        await ElevenLabsTTSProvider.warmup(fake_settings)
 
 
 # ---------------------------------------------------------------------------
@@ -182,6 +192,11 @@ def test_elevenlabs_name_and_model(fake_settings: Settings) -> None:
     p = ElevenLabsTTSProvider(fake_settings, model="eleven_turbo_v2_5", voice="voice-id")
     assert p.name == "elevenlabs-eleven_turbo_v2_5"
     assert p.model == "eleven_turbo_v2_5"
+
+
+def test_elevenlabs_rejects_unsupported_model(fake_settings: Settings) -> None:
+    with pytest.raises(ValueError, match="Unsupported ElevenLabs model"):
+        ElevenLabsTTSProvider(fake_settings, model="not-a-real-model", voice="v")
 
 
 # ---------------------------------------------------------------------------

--- a/runner/tests/providers/tts/test_openai.py
+++ b/runner/tests/providers/tts/test_openai.py
@@ -11,12 +11,22 @@ from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 import pytest
 
 from coval_bench.config import Settings
+from coval_bench.providers import _http_session
 from coval_bench.providers.tts.openai import HTTP_MODELS, VALID_VOICES, OpenAITTSProvider
 
 from .conftest import FakeWebSocket, make_pcm_bytes
+
+
+@pytest.fixture(autouse=True)
+def _reset_http_clients() -> None:
+    _http_session._CLIENTS.clear()
+    yield
+    _http_session._CLIENTS.clear()
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -42,6 +52,8 @@ def _make_streaming_response_mock(chunks: list[bytes]) -> MagicMock:
 
     mock_resp = MagicMock()
     mock_resp.iter_bytes = _iter_bytes
+    mock_resp.http_version = "HTTP/2"
+    mock_resp.http_response.request.extensions = {"__t_submit": 1.0, "__t_headers": 1.002}
     mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
     mock_resp.__aexit__ = AsyncMock(return_value=False)
 
@@ -81,6 +93,8 @@ async def test_openai_http_happy_path(fake_settings: Settings, tmp_path: Path) -
     assert result.provider == "openai"
     assert result.model == "gpt-4o-mini-tts"
     assert result.voice == "alloy"
+    assert result.http_version == "HTTP/2"
+    assert result.submit_to_headers_ms == 2.0
 
     # Orchestrator owns deletion — provider must NOT auto-delete
     result.audio_path.unlink()
@@ -214,6 +228,50 @@ def test_openai_name_property(fake_settings: Settings) -> None:
 # ---------------------------------------------------------------------------
 # gpt-4o-mini-tts is the only OpenAI HTTP model in production.
 # ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# Shared client injection + warmup
+# ---------------------------------------------------------------------------
+
+
+def test_openai_uses_shared_http_client(fake_settings: Settings) -> None:
+    """Construction registers a pooled httpx client in the shared registry."""
+    OpenAITTSProvider(fake_settings, model="gpt-4o-mini-tts", voice="alloy")
+    assert "openai" in _http_session._CLIENTS
+    assert isinstance(_http_session._CLIENTS["openai"], httpx.AsyncClient)
+
+
+@pytest.mark.asyncio
+async def test_openai_warmup_issues_head(fake_settings: Settings) -> None:
+    """warmup() HEADs /v1/models on the shared client; a 401 does not raise."""
+    seen: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(f"{request.method} {request.url.path}")
+        return httpx.Response(401, content=b"unauthorized")
+
+    _http_session._CLIENTS["openai"] = httpx.AsyncClient(
+        base_url="https://api.openai.com",
+        transport=httpx.MockTransport(handler),
+    )
+    await OpenAITTSProvider.warmup(fake_settings)
+    assert seen == ["HEAD /v1/models"]
+
+
+@pytest.mark.asyncio
+async def test_openai_warmup_propagates_transport_error(fake_settings: Settings) -> None:
+    """Transport failures propagate so the orchestrator can log them."""
+
+    def handler(_: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("dns blew up")
+
+    _http_session._CLIENTS["openai"] = httpx.AsyncClient(
+        base_url="https://api.openai.com",
+        transport=httpx.MockTransport(handler),
+    )
+    with pytest.raises(httpx.ConnectError):
+        await OpenAITTSProvider.warmup(fake_settings)
 
 
 @pytest.mark.asyncio

--- a/runner/tests/unit/test_db_writer.py
+++ b/runner/tests/unit/test_db_writer.py
@@ -138,6 +138,14 @@ def test_migration_up_down(pg_conn: psycopg.Connection[Any]) -> None:
         views = {row[0] for row in cur.fetchall()}
     assert "results_24h" in views
 
+    with pg_conn.cursor() as cur:
+        cur.execute(
+            "SELECT column_name FROM information_schema.columns "
+            "WHERE table_schema = 'benchmarks_v2' AND table_name = 'results'"
+        )
+        columns = {row[0] for row in cur.fetchall()}
+    assert {"http_version", "submit_to_headers_ms"} <= columns
+
     _downgrade_migrations(pg_conn)
 
     with pg_conn.cursor() as cur:
@@ -344,6 +352,55 @@ def test_results_24h_view(pg_conn: psycopg.Connection[Any]) -> None:
     assert abs(float(row["avg_value"]) - 0.3) < 0.001
     # p50 = median = 0.3
     assert abs(float(row["p50"]) - 0.3) < 0.001
+
+
+def test_records_http_diagnostics(pg_conn: psycopg.Connection[Any]) -> None:
+    """http_version and submit_to_headers_ms round-trip through the writer."""
+    _apply_migrations(pg_conn)
+
+    async def _run() -> int:
+        pool = await _make_pool(pg_conn)
+        try:
+            writer = RunWriter(pool)
+            run = await writer.start_run(
+                runner_sha="abc123", dataset_id="tts-v1", dataset_sha256="deadbeef"
+            )
+            assert run.id is not None
+            await writer.record_results(
+                [
+                    Result(
+                        run_id=run.id,
+                        provider="openai",
+                        model="gpt-4o-mini-tts",
+                        voice="alloy",
+                        benchmark=Benchmark.TTS,
+                        metric_type="TTFA",
+                        metric_value=120.0,
+                        metric_units="milliseconds",
+                        status=ResultStatus.SUCCESS,
+                        http_version="HTTP/2",
+                        submit_to_headers_ms=3.4,
+                    )
+                ]
+            )
+            await writer.finish_run(run.id, status=RunStatus.SUCCEEDED)
+            return run.id
+        finally:
+            await pool.close()
+
+    run_id = asyncio.run(_run())
+
+    pg_conn.autocommit = True
+    with pg_conn.cursor() as cur:
+        cur.execute(
+            "SELECT http_version, submit_to_headers_ms "
+            "FROM benchmarks_v2.results WHERE run_id = %s",
+            (run_id,),
+        )
+        row = cur.fetchone()
+    assert row is not None
+    assert row[0] == "HTTP/2"
+    assert abs(float(row[1]) - 3.4) < 0.001
 
 
 def test_check_constraints(pg_conn: psycopg.Connection[Any]) -> None:

--- a/runner/tests/unit/test_orchestrator.py
+++ b/runner/tests/unit/test_orchestrator.py
@@ -146,6 +146,10 @@ async def _orchestrator_env(  # noqa: ANN202
     if tts_providers is None:
         tts_providers = {}
 
+    for cls in (*stt_providers.values(), *tts_providers.values()):
+        if not hasattr(cls, "warmup") or not isinstance(cls.warmup, AsyncMock):
+            cls.warmup = AsyncMock(return_value=None)
+
     stt_dataset = MagicMock()
     stt_dataset.items = stt_items
     tts_dataset = MagicMock()
@@ -504,6 +508,9 @@ async def test_dataset_integrity_failure(settings: Settings) -> None:
     def _fake_get_db_symbols() -> tuple[Any, Any, Any, Any]:
         return _fake_lifespan_pool, MagicMock(return_value=writer), RunStatus, models_mod
 
+    deepgram_cls = MagicMock()
+    deepgram_cls.warmup = AsyncMock(return_value=None)
+
     with (
         patch(
             "coval_bench.runner.orchestrator._get_db_symbols",
@@ -511,7 +518,7 @@ async def test_dataset_integrity_failure(settings: Settings) -> None:
         ),
         patch(
             "coval_bench.runner.orchestrator._get_stt_providers",
-            return_value={"deepgram": MagicMock()},
+            return_value={"deepgram": deepgram_cls},
         ),
         patch(
             "coval_bench.runner.orchestrator._get_tts_providers",
@@ -562,6 +569,7 @@ async def test_audio_file_cleanup(settings: Settings) -> None:
         provider_inst = MagicMock()
         provider_inst.synthesize = AsyncMock(return_value=tts_result)
         provider_cls = MagicMock(return_value=provider_inst)
+        provider_cls.warmup = AsyncMock(return_value=None)
 
         tts_providers = {"elevenlabs": provider_cls}
         tts_item = _make_tts_item("hello world")
@@ -641,6 +649,229 @@ async def test_audio_file_cleanup(settings: Settings) -> None:
         assert summary.success_count >= 1
 
 
+@pytest.mark.asyncio
+async def test_tts_http1_downgrade_fails_ttfa_row(settings: Settings) -> None:
+    """An HTTP/1.1 TTFA row is marked FAILED; WER stays SUCCESS; run is PARTIAL."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        audio_path = Path(tmpdir) / "synth.wav"
+        audio_path.write_bytes(b"\x00" * 512)
+
+        tts_result = TTSResult(
+            provider="elevenlabs",
+            model="eleven_flash_v2_5",
+            voice="IKne3meq5aSn9XLyUdCD",
+            ttfa_ms=120.0,
+            audio_path=audio_path,
+            error=None,
+            http_version="HTTP/1.1",
+            submit_to_headers_ms=210.0,
+        )
+
+        provider_inst = MagicMock()
+        provider_inst.synthesize = AsyncMock(return_value=tts_result)
+        provider_cls = MagicMock(return_value=provider_inst)
+        provider_cls.warmup = AsyncMock(return_value=None)
+
+        tts_providers = {"elevenlabs": provider_cls}
+
+        run = _make_run()
+        writer = _make_stub_writer(run)
+
+        tts_dataset = MagicMock()
+        tts_dataset.items = [_make_tts_item("hello world")]
+
+        def _load(dataset_id: str, *, settings: Any) -> Any:
+            return tts_dataset
+
+        fake_pool = MagicMock()
+
+        @contextlib.asynccontextmanager
+        async def _fake_pool(s: Any) -> AsyncIterator[MagicMock]:
+            yield fake_pool
+
+        models_mod = MagicMock()
+        models_mod.Benchmark = Benchmark
+        models_mod.Result = Result
+        models_mod.ResultStatus = ResultStatus
+        models_mod.RunStatus = RunStatus
+
+        def _fake_get_db_symbols() -> tuple[Any, Any, Any, Any]:
+            return _fake_pool, MagicMock(return_value=writer), RunStatus, models_mod
+
+        compute_wer_real = __import__("coval_bench.metrics", fromlist=["compute_wer"]).compute_wer
+        compute_rtf_real = __import__("coval_bench.metrics", fromlist=["compute_rtf"]).compute_rtf
+
+        from coval_bench.runner.config import DEFAULT_TTS_MATRIX
+
+        matrix_map = {
+            (e.provider, e.model): ProviderEntry(
+                provider=e.provider, model=e.model, voice=e.voice, enabled=False
+            )
+            for e in DEFAULT_TTS_MATRIX
+        }
+        matrix_map[("elevenlabs", "eleven_flash_v2_5")] = ProviderEntry(
+            provider="elevenlabs",
+            model="eleven_flash_v2_5",
+            voice="IKne3meq5aSn9XLyUdCD",
+            enabled=True,
+        )
+        matrix = list(matrix_map.values())
+
+        with (
+            patch(
+                "coval_bench.runner.orchestrator._get_db_symbols",
+                side_effect=_fake_get_db_symbols,
+            ),
+            patch("coval_bench.runner.orchestrator._get_stt_providers", return_value={}),
+            patch(
+                "coval_bench.runner.orchestrator._get_tts_providers",
+                return_value=tts_providers,
+            ),
+            patch("coval_bench.runner.orchestrator._get_load_dataset", return_value=_load),
+            patch(
+                "coval_bench.runner.orchestrator._get_metrics",
+                return_value=(compute_wer_real, compute_rtf_real),
+            ),
+            patch(
+                "coval_bench.runner.orchestrator._transcribe_with_whisper",
+                return_value="hello world",
+            ),
+        ):
+            await run_benchmarks(
+                settings=settings,
+                benchmark_kind="tts",
+                smoke=True,
+                matrix_overrides=matrix,
+            )
+
+        recorded = [r for call in writer.record_results.call_args_list for r in call.args[0]]
+        ttfa_rows = [r for r in recorded if r.metric_type == "TTFA"]
+        wer_rows = [r for r in recorded if r.metric_type == "WER"]
+
+        assert len(ttfa_rows) == 1
+        assert ttfa_rows[0].status == ResultStatus.FAILED
+        assert ttfa_rows[0].metric_value is None
+        assert "HTTP/1.1" in ttfa_rows[0].error
+        assert ttfa_rows[0].http_version == "HTTP/1.1"
+
+        assert len(wer_rows) == 1
+        assert wer_rows[0].status == ResultStatus.SUCCESS
+
+        assert writer.finish_run.call_args.kwargs["status"] == RunStatus.PARTIAL
+
+
+@pytest.mark.asyncio
+async def test_tts_cold_connection_fails_ttfa_row(settings: Settings) -> None:
+    """A warm-h2 row that opened a cold connection is failed, not averaged in."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        audio_path = Path(tmpdir) / "synth.wav"
+        audio_path.write_bytes(b"\x00" * 512)
+
+        tts_result = TTSResult(
+            provider="elevenlabs",
+            model="eleven_flash_v2_5",
+            voice="IKne3meq5aSn9XLyUdCD",
+            ttfa_ms=120.0,
+            audio_path=audio_path,
+            error=None,
+            http_version="HTTP/2",
+            submit_to_headers_ms=190.0,
+            connection_reused=False,
+        )
+
+        provider_inst = MagicMock()
+        provider_inst.synthesize = AsyncMock(return_value=tts_result)
+        provider_cls = MagicMock(return_value=provider_inst)
+        provider_cls.warmup = AsyncMock(return_value=None)
+
+        tts_providers = {"elevenlabs": provider_cls}
+
+        run = _make_run()
+        writer = _make_stub_writer(run)
+
+        tts_dataset = MagicMock()
+        tts_dataset.items = [_make_tts_item("hello world")]
+
+        def _load(dataset_id: str, *, settings: Any) -> Any:
+            return tts_dataset
+
+        fake_pool = MagicMock()
+
+        @contextlib.asynccontextmanager
+        async def _fake_pool(s: Any) -> AsyncIterator[MagicMock]:
+            yield fake_pool
+
+        models_mod = MagicMock()
+        models_mod.Benchmark = Benchmark
+        models_mod.Result = Result
+        models_mod.ResultStatus = ResultStatus
+        models_mod.RunStatus = RunStatus
+
+        def _fake_get_db_symbols() -> tuple[Any, Any, Any, Any]:
+            return _fake_pool, MagicMock(return_value=writer), RunStatus, models_mod
+
+        compute_wer_real = __import__("coval_bench.metrics", fromlist=["compute_wer"]).compute_wer
+        compute_rtf_real = __import__("coval_bench.metrics", fromlist=["compute_rtf"]).compute_rtf
+
+        from coval_bench.runner.config import DEFAULT_TTS_MATRIX
+
+        matrix_map = {
+            (e.provider, e.model): ProviderEntry(
+                provider=e.provider, model=e.model, voice=e.voice, enabled=False
+            )
+            for e in DEFAULT_TTS_MATRIX
+        }
+        matrix_map[("elevenlabs", "eleven_flash_v2_5")] = ProviderEntry(
+            provider="elevenlabs",
+            model="eleven_flash_v2_5",
+            voice="IKne3meq5aSn9XLyUdCD",
+            enabled=True,
+        )
+        matrix = list(matrix_map.values())
+
+        with (
+            patch(
+                "coval_bench.runner.orchestrator._get_db_symbols",
+                side_effect=_fake_get_db_symbols,
+            ),
+            patch("coval_bench.runner.orchestrator._get_stt_providers", return_value={}),
+            patch(
+                "coval_bench.runner.orchestrator._get_tts_providers",
+                return_value=tts_providers,
+            ),
+            patch("coval_bench.runner.orchestrator._get_load_dataset", return_value=_load),
+            patch(
+                "coval_bench.runner.orchestrator._get_metrics",
+                return_value=(compute_wer_real, compute_rtf_real),
+            ),
+            patch(
+                "coval_bench.runner.orchestrator._transcribe_with_whisper",
+                return_value="hello world",
+            ),
+        ):
+            await run_benchmarks(
+                settings=settings,
+                benchmark_kind="tts",
+                smoke=True,
+                matrix_overrides=matrix,
+            )
+
+        recorded = [r for call in writer.record_results.call_args_list for r in call.args[0]]
+        ttfa_rows = [r for r in recorded if r.metric_type == "TTFA"]
+        wer_rows = [r for r in recorded if r.metric_type == "WER"]
+
+        assert len(ttfa_rows) == 1
+        assert ttfa_rows[0].status == ResultStatus.FAILED
+        assert ttfa_rows[0].metric_value is None
+        assert "cold connection" in ttfa_rows[0].error
+        assert ttfa_rows[0].http_version == "HTTP/2"
+
+        assert len(wer_rows) == 1
+        assert wer_rows[0].status == ResultStatus.SUCCESS
+
+        assert writer.finish_run.call_args.kwargs["status"] == RunStatus.PARTIAL
+
+
 # ---------------------------------------------------------------------------
 # 9. test_matrix_overrides
 # ---------------------------------------------------------------------------
@@ -701,6 +932,51 @@ async def test_matrix_overrides(audio_file: Path, settings: Settings) -> None:
     # nova-2 was instantiated and called
     assert "nova-2" in model_instances
     model_instances["nova-2"].measure_ttft.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_warmup_scoped_to_benchmark_kind(audio_file: Path, settings: Settings) -> None:
+    """An stt run warms only stt providers; tts warmup is not invoked."""
+    good = _good_transcription()
+
+    stt_inst = MagicMock()
+    stt_inst.measure_ttft = AsyncMock(return_value=good)
+    stt_cls = MagicMock(return_value=stt_inst)
+    stt_cls.warmup = AsyncMock(return_value=None)
+
+    tts_cls = MagicMock()
+    tts_cls.warmup = AsyncMock(return_value=None)
+
+    matrix = [
+        ProviderEntry(provider="deepgram", model="nova-2", enabled=True),
+        ProviderEntry(
+            provider="elevenlabs",
+            model="eleven_flash_v2_5",
+            voice="IKne3meq5aSn9XLyUdCD",
+            enabled=True,
+        ),
+    ]
+
+    run = _make_run()
+    writer = _make_stub_writer(run)
+
+    async with _orchestrator_env(
+        audio_path=audio_file,
+        stt_items=[_make_dataset_item(audio_file)],
+        stt_providers={"deepgram": stt_cls},
+        tts_providers={"elevenlabs": tts_cls},
+        run=run,
+        writer=writer,
+    ) as _:
+        await run_benchmarks(
+            settings=settings,
+            benchmark_kind="stt",
+            smoke=True,
+            matrix_overrides=matrix,
+        )
+
+    stt_cls.warmup.assert_awaited_once()
+    tts_cls.warmup.assert_not_awaited()
 
 
 # ---------------------------------------------------------------------------

--- a/runner/uv.lock
+++ b/runner/uv.lock
@@ -247,7 +247,6 @@ dependencies = [
     { name = "anyio" },
     { name = "cartesia" },
     { name = "click" },
-    { name = "elevenlabs" },
     { name = "fastapi" },
     { name = "google-cloud-storage" },
     { name = "httpx", extra = ["http2"] },
@@ -298,7 +297,6 @@ requires-dist = [
     { name = "anyio", specifier = ">=4.4" },
     { name = "cartesia", specifier = ">=2" },
     { name = "click", specifier = ">=8.1" },
-    { name = "elevenlabs", specifier = ">=1.5" },
     { name = "fastapi", specifier = ">=0.111" },
     { name = "google-cloud-speech", marker = "extra == 'google-stt'", specifier = ">=2.27" },
     { name = "google-cloud-storage", specifier = ">=2.18" },
@@ -428,23 +426,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
-]
-
-[[package]]
-name = "elevenlabs"
-version = "2.45.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "httpx" },
-    { name = "pydantic" },
-    { name = "pydantic-core" },
-    { name = "requests" },
-    { name = "typing-extensions" },
-    { name = "websockets" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/2c/a3/1696fd5b32e94703ff64b009de49bc5f4909397b5400900e3c5ca10a6499/elevenlabs-2.45.0.tar.gz", hash = "sha256:237eb96508e973393eb273728c562ae1f029764a544ab282acfd5d6d1cb8a043", size = 554966, upload-time = "2026-04-27T09:57:21.439Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/60/2f/e9136e7b049898fcd8ddf1836d687cac0acc5ed76329740942498fe602e0/elevenlabs-2.45.0-py3-none-any.whl", hash = "sha256:19edf75de4da22b340bd96c833c3589a9871015addc1d487b034b4541c71b0ef", size = 1518097, upload-time = "2026-04-27T09:57:19.102Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Align HTTP TTS benchmarking with the WebSocket methodology by reusing a warm HTTP/2 connection and excluding connection setup overhead from TTFA measurements.

changes made:
Apply HTTP/2, connection limits, and 300s keepalive in _http_session.py via TimedTransport.
Maintain a single warm HTTP/2 connection per host.
Add HTTP version logging and HTTP/1.1 fallback warnings in OpenAI and ElevenLabs warmup paths.
Surface warmup failures instead of swallowing them.
Scope warmup to the requested benchmark kind.
Update methodology documentation and add regression tests.

*_prewarm_no_http2 warns when HTTP/2 negotiation fails and the client falls back to HTTP/1.1.
This aligns HTTP benchmarking with the WebSocket cohort methodology.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional provider warmup phase to pre-warm HTTP connections; warmup failures are non-fatal and clients are shut down on completion

* **Documentation**
  * Added latency measurement convention clarifying TTFT/TTFA timing excludes protocol setup

* **Improvements**
  * Shared HTTP client pooling and HTTP diagnostics (version, setup timing, connection reuse) collected and persisted for improved TTS latency reporting

* **Tests**
  * Expanded HTTP, TTS provider, and orchestrator tests to cover pooling, timing stamps, warmup, and TTFA persistence

* **Chores**
  * Removed elevenlabs SDK dependency
<!-- end of auto-generated comment: release notes by coderabbit.ai -->