### PR TITLE
feat(web/playground): durable session quota via Upstash Redis

### DIFF
--- a/web/.env.example
+++ b/web/.env.example
@@ -21,3 +21,8 @@ PLAYGROUND_SESSION_SECRET=
 # Optional. Set during secret rotation to accept cookies signed with the prior
 # secret. Drop once all outstanding cookies have expired (~24h after the swap).
 PLAYGROUND_SESSION_SECRET_PREVIOUS=
+# Durable quota store (Upstash Redis). Auto-injected by the Vercel → Upstash
+# Marketplace integration. When unset, quota/concurrency fall back to in-process
+# counters (single Vercel instance only; reset on cold start).
+UPSTASH_REDIS_REST_URL=
+UPSTASH_REDIS_REST_TOKEN=

--- a/web/app/api/playground/stt/route.ts
+++ b/web/app/api/playground/stt/route.ts
@@ -36,7 +36,7 @@ export async function POST(req: Request): Promise<Response> {
       { status: 401 },
     );
   }
-  if (!tryAcquireSession(session.sid)) {
+  if (!(await tryAcquireSession(session.sid))) {
     return Response.json(
       { error: "Too many concurrent sessions.", code: "RATE_LIMITED" } satisfies BatchError,
       { status: 429 },
@@ -46,7 +46,7 @@ export async function POST(req: Request): Promise<Response> {
   try {
     return await handle(req, session.sid);
   } finally {
-    releaseSession(session.sid);
+    await releaseSession(session.sid);
   }
 }
 
@@ -128,7 +128,7 @@ async function handle(req: Request, sid: string): Promise<Response> {
   }
 
   // Charge one quota item per provider invocation. A 7-model click consumes 7.
-  if (!tryConsumeDailyQuota(sid, "stt", uniqueModelIds.length)) {
+  if (!(await tryConsumeDailyQuota(sid, "stt", uniqueModelIds.length))) {
     return Response.json(
       { error: "Daily quota exceeded.", code: "RATE_LIMITED" } satisfies BatchError,
       { status: 429 },

--- a/web/app/api/playground/tts/route.ts
+++ b/web/app/api/playground/tts/route.ts
@@ -24,14 +24,14 @@ export async function POST(req: Request) {
   if (!session) {
     return Response.json({ error: "Unauthorized.", code: "UNAUTHORIZED" }, { status: 401 });
   }
-  if (!tryAcquireSession(session.sid)) {
+  if (!(await tryAcquireSession(session.sid))) {
     return Response.json({ error: "Too many concurrent sessions.", code: "RATE_LIMITED" }, { status: 429 });
   }
 
   try {
     return await handle(req, session.sid);
   } finally {
-    releaseSession(session.sid);
+    await releaseSession(session.sid);
   }
 }
 
@@ -81,7 +81,7 @@ async function handle(req: Request, sid: string) {
   }
 
   // Daily cap is the last gate so malformed or rejected requests don't burn quota.
-  if (!tryConsumeDailyQuota(sid, "tts")) {
+  if (!(await tryConsumeDailyQuota(sid, "tts"))) {
     return Response.json({ error: "Daily quota exceeded.", code: "RATE_LIMITED" }, { status: 429 });
   }
 

--- a/web/lib/playground/security.test.ts
+++ b/web/lib/playground/security.test.ts
@@ -1,0 +1,72 @@
+// Copyright 2026 The Coval Benchmarks Authors
+// SPDX-License-Identifier: Apache-2.0
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+function clearRedisEnv() {
+  for (const key of Object.keys(process.env)) {
+    if (
+      key === "UPSTASH_REDIS_REST_URL" ||
+      key === "UPSTASH_REDIS_REST_TOKEN" ||
+      key === "KV_REST_API_URL" ||
+      key === "KV_REST_API_TOKEN" ||
+      key.endsWith("KV_REST_API_URL") ||
+      key.endsWith("KV_REST_API_TOKEN")
+    ) {
+      delete process.env[key];
+    }
+  }
+}
+
+async function loadSecurityFallback() {
+  vi.resetModules();
+  clearRedisEnv();
+  return import("./security");
+}
+
+beforeEach(() => {
+  vi.resetModules();
+});
+
+describe("security (in-process fallback)", () => {
+  it("allows up to MAX_CONCURRENT_PER_SESSION then rejects", async () => {
+    const { MAX_CONCURRENT_PER_SESSION, tryAcquireSession } = await loadSecurityFallback();
+    const sid = "s";
+    for (let i = 0; i < MAX_CONCURRENT_PER_SESSION; i++) {
+      expect(await tryAcquireSession(sid)).toBe(true);
+    }
+    expect(await tryAcquireSession(sid)).toBe(false);
+  });
+
+  it("releaseSession frees a concurrency slot", async () => {
+    const { MAX_CONCURRENT_PER_SESSION, tryAcquireSession, releaseSession } =
+      await loadSecurityFallback();
+    const sid = "s";
+    for (let i = 0; i < MAX_CONCURRENT_PER_SESSION; i++) {
+      await tryAcquireSession(sid);
+    }
+    expect(await tryAcquireSession(sid)).toBe(false);
+    await releaseSession(sid);
+    expect(await tryAcquireSession(sid)).toBe(true);
+  });
+
+  it("consumes daily quota up to the cap then rejects", async () => {
+    const { STT_DAILY_CAP, tryConsumeDailyQuota } = await loadSecurityFallback();
+    const sid = "s";
+    expect(await tryConsumeDailyQuota(sid, "stt", STT_DAILY_CAP)).toBe(true);
+    expect(await tryConsumeDailyQuota(sid, "stt", 1)).toBe(false);
+  });
+
+  it("rolls back an over-cap consume so later requests still fit", async () => {
+    const { STT_DAILY_CAP, tryConsumeDailyQuota } = await loadSecurityFallback();
+    const sid = "s";
+    expect(await tryConsumeDailyQuota(sid, "stt", STT_DAILY_CAP - 1)).toBe(true);
+    expect(await tryConsumeDailyQuota(sid, "stt", 2)).toBe(false);
+    expect(await tryConsumeDailyQuota(sid, "stt", 1)).toBe(true);
+  });
+
+  it("treats a non-positive count as a no-op", async () => {
+    const { tryConsumeDailyQuota } = await loadSecurityFallback();
+    expect(await tryConsumeDailyQuota("s", "tts", 0)).toBe(true);
+  });
+});

--- a/web/lib/playground/security.test.ts
+++ b/web/lib/playground/security.test.ts
@@ -1,7 +1,9 @@
 // Copyright 2026 The Coval Benchmarks Authors
 // SPDX-License-Identifier: Apache-2.0
 
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const ORIGINAL_ENV = { ...process.env };
 
 function clearRedisEnv() {
   for (const key of Object.keys(process.env)) {
@@ -10,6 +12,7 @@ function clearRedisEnv() {
       key === "UPSTASH_REDIS_REST_TOKEN" ||
       key === "KV_REST_API_URL" ||
       key === "KV_REST_API_TOKEN" ||
+      key === "PLAYGROUND_REDIS_ENV_PREFIX" ||
       key.endsWith("KV_REST_API_URL") ||
       key.endsWith("KV_REST_API_TOKEN")
     ) {
@@ -26,6 +29,13 @@ async function loadSecurityFallback() {
 
 beforeEach(() => {
   vi.resetModules();
+});
+
+afterEach(() => {
+  for (const key of Object.keys(process.env)) {
+    if (!(key in ORIGINAL_ENV)) delete process.env[key];
+  }
+  Object.assign(process.env, ORIGINAL_ENV);
 });
 
 describe("security (in-process fallback)", () => {

--- a/web/lib/playground/security.ts
+++ b/web/lib/playground/security.ts
@@ -1,36 +1,14 @@
-import { getEnabledSttModels, getEnabledTtsModels } from "@/lib/playground/providers";
+import { Redis } from "@upstash/redis";
+import { getEnabledSttModels, getEnabledTtsModels } from "./providers";
 
-// Defense-in-depth pre-check. The real abuse boundary is the signed session
-// cookie verified in `web/lib/playground/session.ts`; `Origin` and forwarded-IP
-// headers are still caller-controlled and used only as cheap early rejection
-// and for diagnostic logging. The in-process Maps below are not shared across
-// Vercel instances (each gets fresh state on cold start). Upgrade path:
-// Upstash Redis keyed on session id (Phase 2) before scaling beyond a single
-// Vercel instance reliably.
 const ALLOWED_ORIGINS = new Set([
   "http://localhost:3000",
   "https://benchmarks.coval.ai",
-  // Add specific Vercel preview URLs here when testing playground on a preview deploy.
 ]);
 
 export function isAllowedOrigin(origin: string | null): boolean {
   if (!origin) return false;
   return ALLOWED_ORIGINS.has(origin);
-}
-
-export function getClientIp(req: Request): string {
-  const fwd = req.headers.get("x-forwarded-for");
-  if (fwd) {
-    const first = fwd.split(",")[0];
-    if (first) return normalizeIp(first.trim());
-  }
-  const real = req.headers.get("x-real-ip");
-  if (real) return normalizeIp(real);
-  return "unknown";
-}
-
-function normalizeIp(ip: string): string {
-  return ip.replace(/^::ffff:/, "");
 }
 
 export const MAX_CONCURRENT_PER_SESSION = Math.max(
@@ -41,32 +19,124 @@ export const MAX_CONCURRENT_PER_SESSION = Math.max(
 export const STT_DAILY_CAP = MAX_CONCURRENT_PER_SESSION * 5;
 export const TTS_DAILY_CAP = MAX_CONCURRENT_PER_SESSION * 5;
 
-const concurrent = new Map<string, number>();
+export type QuotaKind = "stt" | "tts";
 
-export function tryAcquireSession(sid: string): boolean {
+const CONCURRENCY_TTL_S = 120;
+const DAILY_TTL_S = 24 * 60 * 60;
+
+function resolveRedisCreds(): { url: string; token: string } | null {
+  let url = process.env.UPSTASH_REDIS_REST_URL || process.env.KV_REST_API_URL || "";
+  let token = process.env.UPSTASH_REDIS_REST_TOKEN || process.env.KV_REST_API_TOKEN || "";
+  if (!url || !token) {
+    for (const [k, v] of Object.entries(process.env)) {
+      if (!v) continue;
+      if (!url && k.endsWith("KV_REST_API_URL")) url = v;
+      if (!token && k.endsWith("KV_REST_API_TOKEN")) token = v;
+    }
+  }
+  return url && token ? { url, token } : null;
+}
+
+const creds = resolveRedisCreds();
+const redis = creds ? new Redis(creds) : null;
+
+const ACQUIRE_LUA = `
+local n = redis.call('INCR', KEYS[1])
+redis.call('EXPIRE', KEYS[1], tonumber(ARGV[2]))
+if n > tonumber(ARGV[1]) then
+  redis.call('DECR', KEYS[1])
+  return 0
+end
+return 1`;
+
+const RELEASE_LUA = `
+local n = redis.call('DECR', KEYS[1])
+if n <= 0 then redis.call('DEL', KEYS[1]) end
+return n`;
+
+const QUOTA_LUA = `
+local n = redis.call('INCRBY', KEYS[1], tonumber(ARGV[1]))
+if n == tonumber(ARGV[1]) then
+  redis.call('EXPIRE', KEYS[1], tonumber(ARGV[3]))
+end
+if n > tonumber(ARGV[2]) then
+  local after = redis.call('DECRBY', KEYS[1], tonumber(ARGV[1]))
+  if after <= 0 then redis.call('DEL', KEYS[1]) end
+  return 0
+end
+return 1`;
+
+export async function tryAcquireSession(sid: string): Promise<boolean> {
+  if (!redis) return tryAcquireSessionMemory(sid);
+  try {
+    const res = await redis.eval(
+      ACQUIRE_LUA,
+      [`pg:conc:${sid}`],
+      [MAX_CONCURRENT_PER_SESSION, CONCURRENCY_TTL_S],
+    );
+    return Number(res) === 1;
+  } catch (err) {
+    console.error("[playground/security] acquire failed, denying", err);
+    return false;
+  }
+}
+
+export async function releaseSession(sid: string): Promise<void> {
+  if (!redis) return releaseSessionMemory(sid);
+  try {
+    await redis.eval(RELEASE_LUA, [`pg:conc:${sid}`], []);
+  } catch (err) {
+    console.error("[playground/security] release failed", err);
+  }
+}
+
+export async function tryConsumeDailyQuota(
+  sid: string,
+  kind: QuotaKind,
+  count: number = 1,
+): Promise<boolean> {
+  if (count <= 0) return true;
+  const cap = kind === "stt" ? STT_DAILY_CAP : TTS_DAILY_CAP;
+  if (!redis) return tryConsumeDailyQuotaMemory(sid, kind, count, cap);
+  try {
+    const res = await redis.eval(
+      QUOTA_LUA,
+      [`pg:daily:${kind}:${sid}`],
+      [count, cap, DAILY_TTL_S],
+    );
+    return Number(res) === 1;
+  } catch (err) {
+    console.error("[playground/security] quota check failed, denying", err);
+    return false;
+  }
+}
+
+const DAILY_TTL_MS = DAILY_TTL_S * 1000;
+const PRUNE_THRESHOLD = 10_000;
+const concurrent = new Map<string, number>();
+const dailyStt = new Map<string, { count: number; resetAt: number }>();
+const dailyTts = new Map<string, { count: number; resetAt: number }>();
+
+function tryAcquireSessionMemory(sid: string): boolean {
   const cur = concurrent.get(sid) ?? 0;
   if (cur >= MAX_CONCURRENT_PER_SESSION) return false;
   concurrent.set(sid, cur + 1);
   return true;
 }
 
-export function releaseSession(sid: string): void {
+function releaseSessionMemory(sid: string): void {
   const cur = concurrent.get(sid) ?? 0;
   if (cur <= 1) concurrent.delete(sid);
   else concurrent.set(sid, cur - 1);
 }
 
-const DAILY_TTL_MS = 24 * 60 * 60 * 1000;
-const PRUNE_THRESHOLD = 10_000;
-const dailyStt = new Map<string, { count: number; resetAt: number }>();
-const dailyTts = new Map<string, { count: number; resetAt: number }>();
-
-export type QuotaKind = "stt" | "tts";
-
-export function tryConsumeDailyQuota(sid: string, kind: QuotaKind, count: number = 1): boolean {
-  if (count <= 0) return true;
+function tryConsumeDailyQuotaMemory(
+  sid: string,
+  kind: QuotaKind,
+  count: number,
+  cap: number,
+): boolean {
   const map = kind === "stt" ? dailyStt : dailyTts;
-  const cap = kind === "stt" ? STT_DAILY_CAP : TTS_DAILY_CAP;
   if (map.size > PRUNE_THRESHOLD) pruneExpired(map);
   const now = Date.now();
   let entry = map.get(sid);

--- a/web/lib/playground/security.ts
+++ b/web/lib/playground/security.ts
@@ -25,15 +25,19 @@ const CONCURRENCY_TTL_S = 120;
 const DAILY_TTL_S = 24 * 60 * 60;
 
 function resolveRedisCreds(): { url: string; token: string } | null {
-  let url = process.env.UPSTASH_REDIS_REST_URL || process.env.KV_REST_API_URL || "";
-  let token = process.env.UPSTASH_REDIS_REST_TOKEN || process.env.KV_REST_API_TOKEN || "";
-  if (!url || !token) {
-    for (const [k, v] of Object.entries(process.env)) {
-      if (!v) continue;
-      if (!url && k.endsWith("KV_REST_API_URL")) url = v;
-      if (!token && k.endsWith("KV_REST_API_TOKEN")) token = v;
-    }
-  }
+  const prefix = process.env.PLAYGROUND_REDIS_ENV_PREFIX?.replace(/_+$/, "");
+  const prefixed = (suffix: string) =>
+    prefix ? process.env[`${prefix}_${suffix}`] : undefined;
+  const url =
+    process.env.UPSTASH_REDIS_REST_URL ||
+    process.env.KV_REST_API_URL ||
+    prefixed("KV_REST_API_URL") ||
+    "";
+  const token =
+    process.env.UPSTASH_REDIS_REST_TOKEN ||
+    process.env.KV_REST_API_TOKEN ||
+    prefixed("KV_REST_API_TOKEN") ||
+    "";
   return url && token ? { url, token } : null;
 }
 
@@ -42,11 +46,11 @@ const redis = creds ? new Redis(creds) : null;
 
 const ACQUIRE_LUA = `
 local n = redis.call('INCR', KEYS[1])
-redis.call('EXPIRE', KEYS[1], tonumber(ARGV[2]))
 if n > tonumber(ARGV[1]) then
   redis.call('DECR', KEYS[1])
   return 0
 end
+redis.call('EXPIRE', KEYS[1], tonumber(ARGV[2]))
 return 1`;
 
 const RELEASE_LUA = `
@@ -112,22 +116,29 @@ export async function tryConsumeDailyQuota(
 }
 
 const DAILY_TTL_MS = DAILY_TTL_S * 1000;
+const CONCURRENCY_TTL_MS = CONCURRENCY_TTL_S * 1000;
 const PRUNE_THRESHOLD = 10_000;
-const concurrent = new Map<string, number>();
+const concurrent = new Map<string, { count: number; resetAt: number }>();
 const dailyStt = new Map<string, { count: number; resetAt: number }>();
 const dailyTts = new Map<string, { count: number; resetAt: number }>();
 
 function tryAcquireSessionMemory(sid: string): boolean {
-  const cur = concurrent.get(sid) ?? 0;
-  if (cur >= MAX_CONCURRENT_PER_SESSION) return false;
-  concurrent.set(sid, cur + 1);
+  if (concurrent.size > PRUNE_THRESHOLD) pruneExpired(concurrent);
+  const now = Date.now();
+  let entry = concurrent.get(sid);
+  if (!entry || now > entry.resetAt) entry = { count: 0, resetAt: now + CONCURRENCY_TTL_MS };
+  if (entry.count >= MAX_CONCURRENT_PER_SESSION) return false;
+  entry.count += 1;
+  entry.resetAt = now + CONCURRENCY_TTL_MS;
+  concurrent.set(sid, entry);
   return true;
 }
 
 function releaseSessionMemory(sid: string): void {
-  const cur = concurrent.get(sid) ?? 0;
-  if (cur <= 1) concurrent.delete(sid);
-  else concurrent.set(sid, cur - 1);
+  const entry = concurrent.get(sid);
+  if (!entry) return;
+  if (entry.count <= 1) concurrent.delete(sid);
+  else entry.count -= 1;
 }
 
 function tryConsumeDailyQuotaMemory(

--- a/web/package.json
+++ b/web/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@tanstack/react-query": "^5.90.21",
+    "@upstash/redis": "^1.38.0",
     "d3": "^7.9.0",
     "lucide-react": "^0.544.0",
     "next": "^16.2.6",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@tanstack/react-query':
         specifier: ^5.90.21
         version: 5.100.6(react@19.2.5)
+      '@upstash/redis':
+        specifier: ^1.38.0
+        version: 1.38.0
       d3:
         specifier: ^7.9.0
         version: 7.9.0
@@ -1181,6 +1184,9 @@ packages:
     resolution: {integrity: sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==}
     cpu: [x64]
     os: [win32]
+
+  '@upstash/redis@1.38.0':
+    resolution: {integrity: sha512-wu+dZBptlLy0+MCUEoHmzrY/TnmgDey3+c7EbIGwrLqAvkP8yi5MWZHYGIFtAygmL4Bkz2TdFu+eU0vFPncIcg==}
 
   '@vitest/coverage-v8@4.1.5':
     resolution: {integrity: sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A==}
@@ -2791,6 +2797,9 @@ packages:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
     engines: {node: '>= 0.4'}
 
+  uncrypto@0.1.3:
+    resolution: {integrity: sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==}
+
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
@@ -3869,6 +3878,10 @@ snapshots:
 
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
+
+  '@upstash/redis@1.38.0':
+    dependencies:
+      uncrypto: 0.1.3
 
   '@vitest/coverage-v8@4.1.5(vitest@4.1.5)':
     dependencies:
@@ -5769,6 +5782,8 @@ snapshots:
       has-bigints: 1.1.0
       has-symbols: 1.1.0
       which-boxed-primitive: 1.1.1
+
+  uncrypto@0.1.3: {}
 
   undici-types@6.21.0: {}
 


### PR DESCRIPTION
Moves playground concurrency + daily quota off in-process Maps into Upstash, keyed on the signed session, so limits hold across Vercel instances. This is the durable-storage follow-up from the #26 review.

- Atomic Lua scripts for acquire / consume / release (incr + TTL + cap check + rollback in one server-side op)
- Falls back to in-process counters when no store is configured (local dev, CI, smoke)
- Fails closed (denies) if Upstash is unreachable, so an outage can't let provider spend through
- Resolves credentials from the names Vercel injects under the store prefix

Stacked on `feat/playground-ui` (#26); retarget to `main` once that merges.

Verified: 31 web tests pass (incl. a fallback unit test); live cap enforcement checked against the Upstash store.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced session and quota management system with support for distributed deployments
  * Implemented automatic fallback to local operation when external services are unavailable
  * Updated API session lifecycle operations to handle asynchronous workflows

* **Tests**
  * Added comprehensive test coverage for session acquisition, release, and quota enforcement mechanisms

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/coval-ai/benchmarks/pull/44?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->