### PR TITLE
[BENCH-210] Remove legacy openain tts-1 models

### DIFF
--- a/docs/methodology.md
+++ b/docs/methodology.md
@@ -40,7 +40,7 @@ Each `(provider, model, voice)` tuple the runner exercises is declared in
 `runner/src/coval_bench/runner/config.py` (`DEFAULT_STT_MATRIX` and
 `DEFAULT_TTS_MATRIX`). Model identifiers are exact provider strings — not
 aliases — wherever the provider exposes a versioned identifier (e.g.
-`nova-3`, `flux-general-en`, `tts-1-hd`, `aura-2-thalia-en`, `mistv3`).
+`nova-3`, `flux-general-en`, `gpt-4o-mini-tts`, `aura-2-thalia-en`, `mistv3`).
 
 **Server-side aliases.** Where a provider resolves a name server-side (e.g.
 Rime `arcana` → Arcana v3), the resolution is documented inline in

--- a/runner/src/coval_bench/__main__.py
+++ b/runner/src/coval_bench/__main__.py
@@ -76,7 +76,7 @@ migrate.add_command(import_legacy_cli, name="import-legacy")
 
 @cli.command(name="tts-smoke")
 @click.option("--provider", required=True, help="TTS provider name (e.g. openai, cartesia).")
-@click.option("--model", required=True, help="Model ID for the provider (e.g. tts-1-hd).")
+@click.option("--model", required=True, help="Model ID for the provider (e.g. gpt-4o-mini-tts).")
 @click.option("--voice", required=True, help="Voice ID for the provider.")
 @click.option(
     "--text",

--- a/runner/src/coval_bench/providers/tts/openai.py
+++ b/runner/src/coval_bench/providers/tts/openai.py
@@ -37,7 +37,7 @@ VALID_VOICES = [
     "cedar",
 ]
 
-HTTP_MODELS = {"gpt-4o-mini-tts", "tts-1", "tts-1-hd"}
+HTTP_MODELS = {"gpt-4o-mini-tts"}
 REALTIME_MODELS = {"gpt-realtime-2025-08-28"}
 SAMPLE_RATE = 24000
 

--- a/runner/src/coval_bench/runner/config.py
+++ b/runner/src/coval_bench/runner/config.py
@@ -72,9 +72,11 @@ DEFAULT_TTS_MATRIX: list[ProviderEntry] = [
         enabled=True,
     ),
     # OpenAI HTTP models.
-    ProviderEntry(provider="openai", model="tts-1-hd", voice="alloy", enabled=True),
-    ProviderEntry(provider="openai", model="tts-1", voice="alloy", enabled=True),
     ProviderEntry(provider="openai", model="gpt-4o-mini-tts", voice="alloy", enabled=True),
+    # Legacy OpenAI HTTP models — retired 2026-05-31; kept disabled (hidden from the
+    # public catalogue) per the matrix convention for superseded models.
+    ProviderEntry(provider="openai", model="tts-1-hd", voice="alloy", enabled=False, disabled=True),
+    ProviderEntry(provider="openai", model="tts-1", voice="alloy", enabled=False, disabled=True),
     # Cartesia — re-activated 2026-04-30: sonic-3 (flagship).
     ProviderEntry(
         provider="cartesia",

--- a/runner/tests/api/test_providers.py
+++ b/runner/tests/api/test_providers.py
@@ -66,7 +66,7 @@ async def test_response_shape_breaking_change(client: AsyncClient) -> None:
     )
 
     openai_entry = next(e for e in data["tts"] if e["provider"] == "openai")
-    for active in ("tts-1-hd", "tts-1", "gpt-4o-mini-tts"):
+    for active in ("gpt-4o-mini-tts",):
         entry = next(m for m in openai_entry["models"] if m["model"] == active)
         assert entry["disabled"] is False, f"{active} must be disabled=False"
 
@@ -83,6 +83,12 @@ async def test_inactive_tts_models_marked_disabled(client: AsyncClient) -> None:
     rime_entry = next(e for e in data["tts"] if e["provider"] == "rime")
     mistv2 = next(m for m in rime_entry["models"] if m["model"] == "mistv2")
     assert mistv2["disabled"] is True
+
+    # OpenAI legacy HTTP models (tts-1, tts-1-hd) are retired but kept disabled.
+    openai_entry = next(e for e in data["tts"] if e["provider"] == "openai")
+    for legacy in ("tts-1", "tts-1-hd"):
+        model = next(m for m in openai_entry["models"] if m["model"] == legacy)
+        assert model["disabled"] is True, f"{legacy} must be disabled=True"
 
 
 async def test_providers_no_db_connection(app: FastAPI, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/runner/tests/api/test_results.py
+++ b/runner/tests/api/test_results.py
@@ -21,7 +21,12 @@ async def test_filters_compose(client: AsyncClient, postgresql: Any) -> None:
     await _insert_result(postgresql, run_id, provider="deepgram", model="nova-3", metric_type="WER")
     # Non-matching rows
     await _insert_result(
-        postgresql, run_id, provider="openai", model="tts-1", metric_type="TTFA", benchmark="TTS"
+        postgresql,
+        run_id,
+        provider="openai",
+        model="gpt-4o-mini-tts",
+        metric_type="TTFA",
+        benchmark="TTS",
     )
     await _insert_result(postgresql, run_id, provider="deepgram", model="nova-2", metric_type="WER")
 

--- a/runner/tests/providers/tts/test_openai.py
+++ b/runner/tests/providers/tts/test_openai.py
@@ -23,7 +23,9 @@ from .conftest import FakeWebSocket, make_pcm_bytes
 # ---------------------------------------------------------------------------
 
 
-def _make_http_provider(fake_settings: Settings, model: str = "tts-1") -> OpenAITTSProvider:
+def _make_http_provider(
+    fake_settings: Settings, model: str = "gpt-4o-mini-tts"
+) -> OpenAITTSProvider:
     return OpenAITTSProvider(fake_settings, model=model, voice="alloy")
 
 
@@ -77,7 +79,7 @@ async def test_openai_http_happy_path(fake_settings: Settings, tmp_path: Path) -
     assert result.audio_path.exists()
     assert result.audio_path.stat().st_size > 0
     assert result.provider == "openai"
-    assert result.model == "tts-1"
+    assert result.model == "gpt-4o-mini-tts"
     assert result.voice == "alloy"
 
     # Orchestrator owns deletion — provider must NOT auto-delete
@@ -105,14 +107,14 @@ async def test_openai_http_all_http_models(fake_settings: Settings) -> None:
 
 def test_openai_unknown_voice_falls_back_to_alloy(fake_settings: Settings) -> None:
     """Unknown voice is replaced by 'alloy' at construction time."""
-    provider = OpenAITTSProvider(fake_settings, model="tts-1", voice="invalid_voice")
+    provider = OpenAITTSProvider(fake_settings, model="gpt-4o-mini-tts", voice="invalid_voice")
     assert provider._voice == "alloy"
 
 
 def test_openai_valid_voices_accepted(fake_settings: Settings) -> None:
     """All documented voices are accepted without fallback."""
     for voice in VALID_VOICES:
-        p = OpenAITTSProvider(fake_settings, model="tts-1", voice=voice)
+        p = OpenAITTSProvider(fake_settings, model="gpt-4o-mini-tts", voice=voice)
         assert p._voice == voice
 
 
@@ -204,21 +206,21 @@ async def test_openai_realtime_happy_path(fake_settings: Settings) -> None:
 
 
 def test_openai_name_property(fake_settings: Settings) -> None:
-    p = OpenAITTSProvider(fake_settings, model="tts-1-hd", voice="echo")
-    assert p.name == "openai-tts-1-hd"
-    assert p.model == "tts-1-hd"
+    p = OpenAITTSProvider(fake_settings, model="gpt-4o-mini-tts", voice="echo")
+    assert p.name == "openai-gpt-4o-mini-tts"
+    assert p.model == "gpt-4o-mini-tts"
 
 
 # ---------------------------------------------------------------------------
-# Re-activated 2026-04-30: tts-1-hd is the only OpenAI HTTP model in production.
+# gpt-4o-mini-tts is the only OpenAI HTTP model in production.
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_synthesize_tts_1_hd_streams_pcm(fake_settings: Settings) -> None:
-    """tts-1-hd streams PCM chunks → ttfa set, valid WAV with .wav magic bytes."""
+async def test_synthesize_gpt_4o_mini_tts_streams_pcm(fake_settings: Settings) -> None:
+    """gpt-4o-mini-tts streams PCM chunks → ttfa set, valid WAV with .wav magic bytes."""
     pcm = make_pcm_bytes(480)
-    provider = _make_http_provider(fake_settings, model="tts-1-hd")
+    provider = _make_http_provider(fake_settings, model="gpt-4o-mini-tts")
 
     mock_client = _make_streaming_response_mock([pcm, pcm])
     with patch.object(provider, "_client", mock_client):
@@ -227,7 +229,7 @@ async def test_synthesize_tts_1_hd_streams_pcm(fake_settings: Settings) -> None:
     assert result.error is None
     assert result.ttfa_ms is not None
     assert result.provider == "openai"
-    assert result.model == "tts-1-hd"
+    assert result.model == "gpt-4o-mini-tts"
     assert result.voice == "alloy"
     assert result.audio_path is not None
     assert result.audio_path.exists()

--- a/runner/tests/runner/test_tts_smoke_cli.py
+++ b/runner/tests/runner/test_tts_smoke_cli.py
@@ -53,7 +53,7 @@ def _ok_provider() -> MagicMock:
     instance.synthesize = AsyncMock(
         return_value=TTSResult(
             provider="openai",
-            model="tts-1-hd",
+            model="gpt-4o-mini-tts",
             voice="alloy",
             ttfa_ms=412.3,
             audio_path=audio_path,
@@ -70,7 +70,7 @@ def _err_provider() -> MagicMock:
     instance.synthesize = AsyncMock(
         return_value=TTSResult(
             provider="openai",
-            model="tts-1-hd",
+            model="gpt-4o-mini-tts",
             voice="alloy",
             ttfa_ms=None,
             audio_path=None,
@@ -94,7 +94,7 @@ def test_tts_smoke_success(monkeypatch: pytest.MonkeyPatch) -> None:
             "--provider",
             "openai",
             "--model",
-            "tts-1-hd",
+            "gpt-4o-mini-tts",
             "--voice",
             "alloy",
             "--text",
@@ -106,7 +106,7 @@ def test_tts_smoke_success(monkeypatch: pytest.MonkeyPatch) -> None:
     payload = json.loads(line)
     assert payload["event"] == "tts_smoke"
     assert payload["provider"] == "openai"
-    assert payload["model"] == "tts-1-hd"
+    assert payload["model"] == "gpt-4o-mini-tts"
     assert payload["voice"] == "alloy"
     assert payload["ttfa_ms"] == 412.3
     assert payload["error"] is None
@@ -128,7 +128,7 @@ def test_tts_smoke_provider_error(monkeypatch: pytest.MonkeyPatch) -> None:
             "--provider",
             "openai",
             "--model",
-            "tts-1-hd",
+            "gpt-4o-mini-tts",
             "--voice",
             "alloy",
         ],
@@ -153,7 +153,7 @@ def test_tts_smoke_unknown_provider(monkeypatch: pytest.MonkeyPatch) -> None:
             "--provider",
             "definitely-not-real",
             "--model",
-            "tts-1-hd",
+            "gpt-4o-mini-tts",
             "--voice",
             "alloy",
         ],

--- a/web/components/charts/CustomBarChartTick.tsx
+++ b/web/components/charts/CustomBarChartTick.tsx
@@ -9,7 +9,7 @@ const normalizeModelName = (modelName: string): string => {
   // Mapping mirrors the backend's enabled provider matrix (runner/config.py).
   const modelMappings: Record<string, string> = {
     // TTS
-    "tts-1-hd": "TTS 1 HD",
+    "gpt-4o-mini-tts": "GPT-4o mini TTS",
     eleven_multilingual_v2: "Multilingual v2",
     eleven_flash_v2_5: "Flash v2.5",
     eleven_turbo_v2_5: "Turbo v2.5",

--- a/web/lib/config/colors.ts
+++ b/web/lib/config/colors.ts
@@ -3,7 +3,7 @@
 
 export const modelColors: Record<string, string> = {
   // OpenAI TTS
-  "tts-1-hd": "#943126",
+  "gpt-4o-mini-tts": "#943126",
 
   // ElevenLabs TTS
   eleven_multilingual_v2: "#FFD633",

--- a/web/lib/config/models.ts
+++ b/web/lib/config/models.ts
@@ -3,7 +3,7 @@
 
 export const modelDisplayNames: Record<string, string> = {
   // TTS
-  "tts-1-hd": "TTS 1 HD",
+  "gpt-4o-mini-tts": "GPT-4o mini TTS",
   eleven_multilingual_v2: "Multilingual v2",
   eleven_flash_v2_5: "Flash v2.5",
   eleven_turbo_v2_5: "Turbo v2.5",

--- a/web/lib/utils/formatters.ts
+++ b/web/lib/utils/formatters.ts
@@ -57,7 +57,7 @@ export function normalizeModelName(modelName: string): string {
   // Mapping mirrors the backend's enabled provider matrix (runner/config.py).
   const modelMappings: Record<string, string> = {
     // TTS
-    "tts-1-hd": "TTS 1 HD",
+    "gpt-4o-mini-tts": "GPT-4o mini TTS",
     eleven_multilingual_v2: "Multilingual v2",
     eleven_flash_v2_5: "Flash v2.5",
     eleven_turbo_v2_5: "Turbo v2.5",


### PR DESCRIPTION
- Toched 12 files to do this. Might be time for some TLC. :)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * OpenAI TTS: primary model switched to gpt-4o-mini-tts; legacy HTTP TTS models retired/disabled and hidden from active lists
  * CLI help, docs, and API responses updated to show current model set
  * Web UI labels and color mapping updated to reflect the new TTS model name
<!-- end of auto-generated comment: release notes by coderabbit.ai -->