### PR TITLE
Fix dashboard model name collisions

### DIFF
--- a/web/components/charts/CustomBarChartTick.tsx
+++ b/web/components/charts/CustomBarChartTick.tsx
@@ -2,12 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React from "react";
-import {
-  normalizeModelName,
-  normalizeSTTProviderName,
-  normalizeTTSProviderName,
-} from "@/lib/utils/formatters";
-import { useActiveTab } from "@/hooks/useActiveTab";
+import { normalizeModelName } from "@/lib/utils/formatters";
 import { useThemeColors } from "@/hooks/useThemeColors";
 
 const CustomBarChartTick: React.FC<{
@@ -19,17 +14,12 @@ const CustomBarChartTick: React.FC<{
   sidebarCollapsed?: boolean;
 }> = ({ x = 0, y = 0, payload, getProviderForModel, isMobile = false, sidebarCollapsed = true }) => {
   const themeColors = useThemeColors();
-  const activeTab = useActiveTab();
 
   if (!payload) return null;
 
   const model = payload.value;
   const normalizedModel = normalizeModelName(model);
-  const providerRaw = getProviderForModel(model);
-  const provider =
-    activeTab === "stt"
-      ? normalizeSTTProviderName(providerRaw)
-      : normalizeTTSProviderName(providerRaw);
+  const provider = getProviderForModel(model);
 
   // Adjust font sizes based on sidebar state
   const modelFontSize = sidebarCollapsed ? "12px" : "10px";

--- a/web/components/charts/CustomBarChartTick.tsx
+++ b/web/components/charts/CustomBarChartTick.tsx
@@ -2,47 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React from "react";
+import {
+  normalizeModelName,
+  normalizeSTTProviderName,
+  normalizeTTSProviderName,
+} from "@/lib/utils/formatters";
+import { useActiveTab } from "@/hooks/useActiveTab";
 import { useThemeColors } from "@/hooks/useThemeColors";
-
-// Helper function to normalize model names
-const normalizeModelName = (modelName: string): string => {
-  // Mapping mirrors the backend's enabled provider matrix (runner/config.py).
-  const modelMappings: Record<string, string> = {
-    // TTS
-    "gpt-4o-mini-tts": "GPT-4o mini TTS",
-    eleven_multilingual_v2: "Multilingual v2",
-    eleven_flash_v2_5: "Flash v2.5",
-    eleven_turbo_v2_5: "Turbo v2.5",
-    "sonic-3": "Sonic 3",
-    "aura-2-thalia-en": "Aura 2",
-    arcana: "Arcana",
-    mistv3: "Mist v3",
-    "octave-tts": "Octave TTS",
-    "octave-2": "Octave 2",
-    coda: "Coda",
-    // STT
-    "nova-2": "Nova 2",
-    "nova-3": "Nova 3",
-    "flux-general-en": "Flux",
-    "flux-general-multi": "Flux Multilingual",
-    scribe_v2_realtime: "Scribe v2",
-    "universal-streaming": "Universal Streaming",
-    default: "Default",
-    enhanced: "Enhanced"
-  };
-
-  // Return mapped name if it exists
-  if (modelMappings[modelName]) {
-    return modelMappings[modelName];
-  }
-
-  // Fallback: automatic normalization for unmapped models
-  return modelName
-    .replace(/-/g, " ") // Replace hyphens with spaces
-    .split(" ") // Split into words
-    .map((word) => word.charAt(0).toUpperCase() + word.slice(1)) // Capitalize
-    .join(" "); // Join back together
-};
 
 const CustomBarChartTick: React.FC<{
   x?: number;
@@ -53,12 +19,17 @@ const CustomBarChartTick: React.FC<{
   sidebarCollapsed?: boolean;
 }> = ({ x = 0, y = 0, payload, getProviderForModel, isMobile = false, sidebarCollapsed = true }) => {
   const themeColors = useThemeColors();
+  const activeTab = useActiveTab();
 
   if (!payload) return null;
 
   const model = payload.value;
   const normalizedModel = normalizeModelName(model);
-  const provider = getProviderForModel(model);
+  const providerRaw = getProviderForModel(model);
+  const provider =
+    activeTab === "stt"
+      ? normalizeSTTProviderName(providerRaw)
+      : normalizeTTSProviderName(providerRaw);
 
   // Adjust font sizes based on sidebar state
   const modelFontSize = sidebarCollapsed ? "12px" : "10px";

--- a/web/components/charts/CustomBarChartTick.tsx
+++ b/web/components/charts/CustomBarChartTick.tsx
@@ -26,22 +26,34 @@ const CustomBarChartTick: React.FC<{
   const providerFontSize = sidebarCollapsed ? "10px" : "9px";
   const mobileFontSize = sidebarCollapsed ? "11px" : "10px";
 
-  // Mobile: Show only model name, diagonal
+  // Mobile: model name + provider, diagonal
   if (isMobile) {
     return (
       <g transform={`translate(${x},${y})`}>
-        <text
-          x={0}
-          y={0}
-          dy={16}
-          textAnchor="end"
-          fill={themeColors.label}
-          fontSize={mobileFontSize}
-          fontWeight="bold"
-          transform="rotate(-45)"
-        >
-          {normalizedModel}
-        </text>
+        <g transform="rotate(-45)">
+          <text
+            x={0}
+            y={0}
+            dy={14}
+            textAnchor="end"
+            fill={themeColors.label}
+            fontSize={mobileFontSize}
+            fontWeight="bold"
+          >
+            {normalizedModel}
+          </text>
+          <text
+            x={0}
+            y={0}
+            dy={26}
+            textAnchor="end"
+            fill={themeColors.label}
+            fontSize={providerFontSize}
+            opacity={0.8}
+          >
+            {provider}
+          </text>
+        </g>
       </g>
     );
   }

--- a/web/components/charts/d3/HeatmapPlot.tsx
+++ b/web/components/charts/d3/HeatmapPlot.tsx
@@ -7,6 +7,7 @@ import React, { useState, useEffect, useRef, useMemo, useCallback } from "react"
 import * as d3 from "d3";
 import { HeatmapProps, SortConfig } from "@/types/chart.types";
 import { ModelHeatmapData } from "@/types/benchmark.types";
+import { normalizeModelName } from "@/lib/utils/formatters";
 import { useActiveTab } from "@/hooks/useActiveTab";
 import { useThemeColors } from "@/hooks/useThemeColors";
 
@@ -382,7 +383,7 @@ const HeatmapPlot: React.FC<HeatmapProps> = ({
           .attr("dominant-baseline", "middle")
           .attr("fill", themeColors.label)
           .attr("font-size", "10px")
-          .text(model.model);
+          .text(normalizeModelName(model.model));
       } else {
         // Desktop: Single line as before
         const labelText = formatChartLabel(model.model, provider);

--- a/web/components/charts/tooltips/BarTooltip.tsx
+++ b/web/components/charts/tooltips/BarTooltip.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React from "react";
+import { normalizeModelName } from "@/lib/utils/formatters";
 import { CustomBarTooltipProps } from "@/types/chart.types";
 
 const CustomBarTooltip: React.FC<CustomBarTooltipProps> = ({
@@ -22,7 +23,7 @@ const CustomBarTooltip: React.FC<CustomBarTooltipProps> = ({
       >
         <p
           style={{ margin: 0, fontWeight: "bold", color: "var(--color-text-on-tooltip)" }}
-        >{`Model: ${label}`}</p>
+        >{`Model: ${normalizeModelName(label ?? "")}`}</p>
         <p style={{ margin: 0, color: "var(--color-text-on-tooltip)" }}>{`Average WER: ${Number(
           value
         ).toFixed(1)}%`}</p>

--- a/web/components/charts/tooltips/BarTooltip.tsx
+++ b/web/components/charts/tooltips/BarTooltip.tsx
@@ -8,10 +8,16 @@ import { CustomBarTooltipProps } from "@/types/chart.types";
 const CustomBarTooltip: React.FC<CustomBarTooltipProps> = ({
   active,
   payload,
-  label
+  label,
+  getProviderForModel
 }) => {
   if (active && payload && payload.length > 0) {
     const value = payload[0]?.value;
+    const modelKey = label ?? "";
+    const provider = getProviderForModel?.(modelKey);
+    const modelLabel = provider
+      ? `${provider} ${normalizeModelName(modelKey)}`
+      : normalizeModelName(modelKey);
     return (
       <div
         style={{
@@ -23,7 +29,7 @@ const CustomBarTooltip: React.FC<CustomBarTooltipProps> = ({
       >
         <p
           style={{ margin: 0, fontWeight: "bold", color: "var(--color-text-on-tooltip)" }}
-        >{`Model: ${normalizeModelName(label ?? "")}`}</p>
+        >{`Model: ${modelLabel}`}</p>
         <p style={{ margin: 0, color: "var(--color-text-on-tooltip)" }}>{`Average WER: ${Number(
           value
         ).toFixed(1)}%`}</p>

--- a/web/components/charts/tooltips/GapTooltip.tsx
+++ b/web/components/charts/tooltips/GapTooltip.tsx
@@ -2,9 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React from "react";
-import { BenchmarkData } from "@/types/benchmark.types";
-import { formatTimeWithSeconds } from "@/lib/utils/formatters";
-import { to15MinuteBucket } from "@/lib/utils/time";
+import { normalizeModelName, formatTimeWithSeconds } from "@/lib/utils/formatters";
 
 interface GapTooltipProps {
   active?: boolean;
@@ -16,20 +14,16 @@ interface GapTooltipProps {
   }>;
   label?: string | number;
   getProviderForModel: (model: string) => string;
-  rawData: BenchmarkData[];
 }
 
-const CustomGapTooltip: React.FC<GapTooltipProps> = ({ active, payload, label, getProviderForModel, rawData }) => {
+const CustomGapTooltip: React.FC<GapTooltipProps> = ({ active, payload, label, getProviderForModel }) => {
   if (!active || !payload || payload.length === 0) return null;
 
-  // Filter out null/undefined values and sort by gap (smallest gap = best performance)
   const validData = payload
     .filter((item) => item.value != null)
     .sort((a, b) => a.value - b.value);
 
   if (validData.length === 0) return null;
-
-  const labelTimestamp = Number(label);
 
   return (
     <div
@@ -39,41 +33,17 @@ const CustomGapTooltip: React.FC<GapTooltipProps> = ({ active, payload, label, g
         borderRadius: "8px",
         color: "var(--color-text-on-tooltip)",
         padding: "12px",
-        minWidth: "400px",
-        maxWidth: "600px"
+        minWidth: "250px"
       }}
     >
-      <div style={{ display: "flex", alignItems: "center", marginBottom: "8px" }}>
-        <p
-          style={{ margin: "0", fontWeight: "bold", fontSize: "12px", marginRight: "12px" }}
-        >
-          First Token
-        </p>
-        <p
-          style={{ margin: "0", fontWeight: "bold", fontSize: "12px" }}
-        >
-          {formatTimeWithSeconds(Number(label))}
-        </p>
-      </div>
+      <p style={{ margin: "0 0 8px 0", fontWeight: "bold", fontSize: "12px" }}>
+        {formatTimeWithSeconds(Number(label))}
+      </p>
       <div style={{ fontSize: "11px" }}>
         {validData.map((item, index) => {
-          // Extract model name from dataKey (remove '_gap' suffix)
           const modelName = item.dataKey.replace("_gap", "");
           const provider = getProviderForModel(modelName);
           const gapMs = item.value;
-
-          // Get transcript from rawData for this model/timestamp
-          const transcript = rawData
-            .filter(
-              (d) =>
-                d.model === modelName &&
-                d.metric_type === "TTFT" &&
-                to15MinuteBucket(new Date(d.timestamp).getTime()) === labelTimestamp
-            )
-            .sort(
-              (a, b) =>
-                new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime()
-            )[0]?.transcript ?? "";
 
           return (
             <div
@@ -85,7 +55,7 @@ const CustomGapTooltip: React.FC<GapTooltipProps> = ({ active, payload, label, g
                 justifyContent: "space-between"
               }}
             >
-              <div style={{ display: "flex", alignItems: "center", flex: "0 0 auto" }}>
+              <div style={{ display: "flex", alignItems: "center", flex: 1 }}>
                 <div
                   style={{
                     width: "8px",
@@ -96,14 +66,14 @@ const CustomGapTooltip: React.FC<GapTooltipProps> = ({ active, payload, label, g
                     flexShrink: 0
                   }}
                 />
-                <div>
+                <div style={{ flex: 1 }}>
                   <div
                     style={{
                       color: index === 0 ? "#10B981" : "var(--color-text-on-tooltip)",
                       fontWeight: index === 0 ? "bold" : "normal"
                     }}
                   >
-                    #{index + 1} {modelName}
+                    #{index + 1} {normalizeModelName(modelName)}
                   </div>
                   <div
                     style={{
@@ -116,30 +86,16 @@ const CustomGapTooltip: React.FC<GapTooltipProps> = ({ active, payload, label, g
                   </div>
                 </div>
               </div>
-
-              <div style={{ display: "flex", alignItems: "center", flex: "1 1 auto", justifyContent: "space-between", marginLeft: "12px" }}>
-                <span
-                  style={{
-                    color: "var(--color-text-on-tooltip-secondary)",
-                    fontWeight: index === 0 ? "bold" : "normal",
-                    flexShrink: 0
-                  }}
-                >
-                  {index === 0 ? "FASTEST" : `+${(gapMs / 1000).toFixed(3)}s`}
-                </span>
-
-                <span
-                  style={{
-                    color: "var(--color-text-on-tooltip-secondary)",
-                    fontWeight: index === 0 ? "bold" : "normal",
-                    marginLeft: "12px",
-                    textAlign: "right",
-                    flex: "1 1 auto"
-                  }}
-                >
-                  {transcript}
-                </span>
-              </div>
+              <span
+                style={{
+                  color: "var(--color-text-on-tooltip-secondary)",
+                  marginLeft: "12px",
+                  fontWeight: index === 0 ? "bold" : "normal",
+                  flexShrink: 0
+                }}
+              >
+                {index === 0 ? "FASTEST" : `+${gapMs.toFixed(0)}ms`}
+              </span>
             </div>
           );
         })}

--- a/web/components/charts/tooltips/GapTooltip.tsx
+++ b/web/components/charts/tooltips/GapTooltip.tsx
@@ -41,7 +41,7 @@ const CustomGapTooltip: React.FC<GapTooltipProps> = ({ active, payload, label, g
       </p>
       <div style={{ fontSize: "11px" }}>
         {validData.map((item, index) => {
-          const modelName = item.dataKey.replace("_gap", "");
+          const modelName = item.dataKey.replace(/_gap$/, "");
           const provider = getProviderForModel(modelName);
           const gapMs = item.value;
 

--- a/web/components/charts/tooltips/ScatterTooltip.tsx
+++ b/web/components/charts/tooltips/ScatterTooltip.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React from "react";
+import { normalizeModelName, normalizeSTTProviderName, normalizeTTSProviderName } from "@/lib/utils/formatters";
 import { TooltipProps } from "@/types/chart.types";
 
 interface ScatterTooltipProps extends TooltipProps {
@@ -24,8 +25,8 @@ const CustomScatterTooltip: React.FC<ScatterTooltipProps> = ({ active, payload, 
       >
         <p
           style={{ margin: 0, fontWeight: "bold" }}
-        >{`Model: ${point.model}`}</p>
-        <p style={{ margin: 0 }}>{`Provider: ${point.provider}`}</p>
+        >{`Model: ${normalizeModelName(point.model)}`}</p>
+        <p style={{ margin: 0 }}>{`Provider: ${activeTab === "stt" ? normalizeSTTProviderName(point.provider) : normalizeTTSProviderName(point.provider)}`}</p>
         <p style={{ margin: 0 }}>{`${
           activeTab === "tts" ? "TTFA" : "TTFT"
         }: ${point.x.toFixed(0)}ms`}</p>

--- a/web/components/charts/tooltips/TimelineTooltip.tsx
+++ b/web/components/charts/tooltips/TimelineTooltip.tsx
@@ -45,7 +45,7 @@ const CustomTimelineTooltip: React.FC<TimelineTooltipProps> = ({ active, payload
       <div style={{ fontSize: "11px" }}>
         {validData.map((item, index) => {
           // Extract model name from dataKey (remove '_value' suffix)
-          const modelName = item.dataKey.replace("_value", "");
+          const modelName = item.dataKey.replace(/_value$/, "");
           const provider = getProviderForModel(modelName);
 
           return (

--- a/web/components/dashboard/AccuracyBarSection.tsx
+++ b/web/components/dashboard/AccuracyBarSection.tsx
@@ -78,7 +78,7 @@ const AccuracyBarSection: React.FC = () => {
                 },
               }}
             />
-            <Tooltip content={<CustomBarTooltip />} cursor={false} />
+            <Tooltip content={<CustomBarTooltip getProviderForModel={getProviderForModel} />} cursor={false} />
             <Bar
               dataKey="averageWER"
               stroke={themeColors.barStroke}

--- a/web/components/dashboard/LatencyAccuracySection.tsx
+++ b/web/components/dashboard/LatencyAccuracySection.tsx
@@ -51,7 +51,7 @@ const LatencyAccuracySection: React.FC = () => {
 
       <div className="h-64">
         <ResponsiveContainer width="100%" height="100%">
-          <ScatterChart data={scatterData}>
+          <ScatterChart>
             <XAxis
               dataKey="x"
               type="number"
@@ -74,6 +74,7 @@ const LatencyAccuracySection: React.FC = () => {
             />
             <YAxis
               dataKey="y"
+              type="number"
               name="WER (%)"
               domain={[0, "dataMax"]}
               axisLine={false}
@@ -95,10 +96,9 @@ const LatencyAccuracySection: React.FC = () => {
             {selectedModels.map((model: string) => (
               <Scatter
                 key={model}
-                dataKey="y"
                 data={scatterData.filter(
                   (item: ScatterDataPoint) =>
-                    item.model === model && item.x <= scatterP99X
+                    item.model === model && item.x <= (scatterP99X || Infinity)
                 )}
                 fill={getModelColor(model)}
                 name={model}

--- a/web/components/dashboard/PerformanceDeltaSection.tsx
+++ b/web/components/dashboard/PerformanceDeltaSection.tsx
@@ -24,7 +24,7 @@ import { useThemeColors } from "@/hooks/useThemeColors";
 
 const PerformanceDeltaSection: React.FC = () => {
   const {
-    selectedModels,
+    getModelsWithGapData,
     isDragging,
     handleMouseDown,
     getWindowedGapData,
@@ -32,9 +32,9 @@ const PerformanceDeltaSection: React.FC = () => {
     getTimelineTicks,
     formatChartLabel,
     getProviderForModel,
-    rawData,
   } = useDashboard();
   const chartRef = useRef<HTMLDivElement>(null);
+  const modelsWithData = getModelsWithGapData();
 
   const themeColors = useThemeColors();
   const tzAbbr = getLocalTimeZoneAbbr();
@@ -94,7 +94,7 @@ const PerformanceDeltaSection: React.FC = () => {
               tickFormatter={(value) =>
                 value === 0
                   ? "FASTEST"
-                  : `+${(value / 1000).toFixed(3)}s`
+                  : `+${value.toFixed(0)}ms`
               }
               label={{
                 value: "Performance Gap (ms)",
@@ -111,11 +111,10 @@ const PerformanceDeltaSection: React.FC = () => {
               content={
                 <CustomGapTooltip
                   getProviderForModel={getProviderForModel}
-                  rawData={rawData}
                 />
               }
             />
-            {selectedModels.length > 1 && (
+            {modelsWithData.length > 1 && (
               <Legend
                 wrapperStyle={{
                   color: themeColors.axisText,
@@ -137,16 +136,16 @@ const PerformanceDeltaSection: React.FC = () => {
               }}
             />
 
-            {selectedModels.map((model) => (
+            {modelsWithData.map((model) => (
               <Line
                 key={model}
                 type="monotone"
                 dataKey={`${model}_gap`}
                 stroke={getModelColor(model)}
-                strokeWidth={selectedModels.length === 1 ? 3 : 2}
+                strokeWidth={modelsWithData.length === 1 ? 3 : 2}
                 dot={false}
                 activeDot={{
-                  r: selectedModels.length === 1 ? 7 : 6,
+                  r: modelsWithData.length === 1 ? 7 : 6,
                   fill: getModelColor(model),
                 }}
                 connectNulls={false}

--- a/web/components/visualizations/TimelineChart.tsx
+++ b/web/components/visualizations/TimelineChart.tsx
@@ -25,7 +25,7 @@ import { useThemeColors } from "@/hooks/useThemeColors";
 const TimelineChart: React.FC = () => {
   const activeTab = useActiveTab();
   const {
-    selectedModels,
+    getModelsWithTimelineData,
     getWindowedTimelineData,
     getCurrentTimeWindow,
     getTimelineTicks,
@@ -37,6 +37,7 @@ const TimelineChart: React.FC = () => {
   const chartRef = useRef<HTMLDivElement>(null);
 
   const themeColors = useThemeColors();
+  const modelsWithData = getModelsWithTimelineData();
   const windowedTimelineData = getWindowedTimelineData();
   const currentTimeWindow = getCurrentTimeWindow();
   const tzAbbr = getLocalTimeZoneAbbr();
@@ -110,22 +111,22 @@ const TimelineChart: React.FC = () => {
               }}
             />
             <Tooltip content={<CustomTimelineTooltip getProviderForModel={getProviderForModel} />} />
-            {selectedModels.length > 1 && (
+            {modelsWithData.length > 1 && (
               <Legend
                 wrapperStyle={{ color: themeColors.axisText, paddingTop: "20px" }}
                 iconType="line"
               />
             )}
-            {selectedModels.map((model) => (
+            {modelsWithData.map((model) => (
               <Line
                 key={model}
                 type="monotone"
                 dataKey={`${model}_value`}
                 stroke={getModelColor(model)}
-                strokeWidth={selectedModels.length === 1 ? 3 : 2}
+                strokeWidth={modelsWithData.length === 1 ? 3 : 2}
                 dot={false}
                 activeDot={{
-                  r: selectedModels.length === 1 ? 7 : 6,
+                  r: modelsWithData.length === 1 ? 7 : 6,
                   fill: getModelColor(model)
                 }}
                 connectNulls={false}

--- a/web/hooks/useChartData.ts
+++ b/web/hooks/useChartData.ts
@@ -21,7 +21,7 @@ import {
   calculateStats,
   calculateKernelDensity
 } from "@/lib/utils/statistics";
-import { normalizeModelName, normalizeSTTProviderName, normalizeTTSProviderName } from "@/lib/utils/formatters";
+import { normalizeModelName, normalizeSTTProviderName, normalizeTTSProviderName, toModelKey, parseModelKey } from "@/lib/utils/formatters";
 import { TWENTY_FOUR_HOURS_MS } from "@/lib/config/constants";
 import { to15MinuteBucket } from "@/lib/utils/time";
 
@@ -50,11 +50,16 @@ export function useChartData({
   timelineWindowEnd,
   modelsByProvider
 }: UseChartDataParams) {
-  // Helper: find a stat row for a given model and metric
+  // Helper: find a stat row for a given model key and metric.
+  // Accepts composite "provider:model" keys or bare model slugs.
   const getStat = useCallback(
-    (model: string, metricType: string): ModelStats | undefined => {
+    (modelKey: string, metricType: string): ModelStats | undefined => {
+      const { provider, model } = parseModelKey(modelKey);
       return modelStats.find(
-        (s) => s.model === model && s.metric_type === metricType
+        (s) =>
+          s.model === model &&
+          (provider === "" || s.provider === provider) &&
+          s.metric_type === metricType
       );
     },
     [modelStats]
@@ -68,23 +73,28 @@ export function useChartData({
     []
   );
 
-  // Helper function to get provider for a model
+  // Helper function to get provider for a model.
+  // Accepts composite "provider:model" keys — extracts the provider directly.
   const getProviderForModel = useCallback(
-    (model: string): string => {
-      // Try modelStats first (cheaper), then fall back to rawData, then providers config
+    (modelKey: string): string => {
+      const { provider, model } = parseModelKey(modelKey);
+      if (provider) {
+        return activeTab === "stt"
+          ? normalizeSTTProviderName(provider)
+          : normalizeTTSProviderName(provider);
+      }
+      // Fallback for bare slugs: search modelStats, then rawData, then providers config
       const stat = modelStats.find((s) => s.model === model);
       const rawFromData = stat?.provider ?? rawData.find((d) => d.model === model)?.provider;
-
-      // Fall back to providers config when no run data exists yet
-      const rawProvider = rawFromData ?? Object.entries(modelsByProvider).find(
-        ([, models]) => models.includes(model)
-      )?.[0] ?? "Unknown";
-
-      if (activeTab === "stt") {
-        return normalizeSTTProviderName(rawProvider);
-      }
-
-      return normalizeTTSProviderName(rawProvider);
+      const rawProvider =
+        rawFromData ??
+        Object.entries(modelsByProvider).find(([, models]) =>
+          models.includes(modelKey)
+        )?.[0] ??
+        "Unknown";
+      return activeTab === "stt"
+        ? normalizeSTTProviderName(rawProvider)
+        : normalizeTTSProviderName(rawProvider);
     },
     [modelStats, rawData, activeTab, modelsByProvider]
   );
@@ -100,9 +110,10 @@ export function useChartData({
       return [];
     }
 
+    const selectedModelKeys = new Set(selectedModels);
     return rawData.filter(
       (item) =>
-        selectedModels.includes(item.model) &&
+        selectedModelKeys.has(toModelKey(item.provider, item.model)) &&
         metricTypes.includes(item.metric_type) &&
         item.metric_value !== null &&
         item.metric_value !== undefined
@@ -120,10 +131,11 @@ export function useChartData({
       return [];
     }
 
+    const selectedModelKeys = new Set(selectedModels);
     const points = rawData
       .filter(
         (item) =>
-          selectedModels.includes(item.model) &&
+          selectedModelKeys.has(toModelKey(item.provider, item.model)) &&
           item.metric_type === primaryMetric &&
           INCLUDED_STATUSES.has(item.status)
       )
@@ -133,7 +145,7 @@ export function useChartData({
           activeTab === "tts"
             ? item.metric_value ?? 0
             : (item.metric_value ?? 0) * 1000,
-        model: item.model,
+        modelKey: toModelKey(item.provider, item.model),
         benchmark: item.benchmark
       }))
       .sort((a, b) => a.timestamp - b.timestamp);
@@ -151,10 +163,10 @@ export function useChartData({
       }
       const bucketAcc = modelValueAccumulator[item.timestamp];
       if (bucketAcc) {
-        if (!bucketAcc[item.model]) {
-          bucketAcc[item.model] = { total: 0, count: 0 };
+        if (!bucketAcc[item.modelKey]) {
+          bucketAcc[item.modelKey] = { total: 0, count: 0 };
         }
-        const modelAcc = bucketAcc[item.model];
+        const modelAcc = bucketAcc[item.modelKey];
         if (modelAcc) {
           modelAcc.total += item.value;
           modelAcc.count += 1;
@@ -195,19 +207,20 @@ export function useChartData({
       };
     }
 
+    const selectedModelKeys = new Set(selectedModels);
     const modelGroups: { [key: string]: BenchmarkData[] } = {};
 
     rawData.forEach((item) => {
-      if (!selectedModels.includes(item.model)) return;
+      const itemKey = toModelKey(item.provider, item.model);
+      if (!selectedModelKeys.has(itemKey)) return;
       if (item.metric_type !== primaryMetric) return;
       if (!INCLUDED_STATUSES.has(item.status)) return;
       if (item.metric_value === null || item.metric_value === undefined) return;
 
-      if (!modelGroups[item.model]) {
-        modelGroups[item.model] = [];
+      if (!modelGroups[itemKey]) {
+        modelGroups[itemKey] = [];
       }
-      // noUncheckedIndexedAccess: guard after the initialization above
-      const modelGroup = modelGroups[item.model];
+      const modelGroup = modelGroups[itemKey];
       if (modelGroup) {
         modelGroup.push(item);
       }
@@ -298,18 +311,18 @@ export function useChartData({
       [key: string]: { [key: string]: BenchmarkData[] };
     } = {};
 
+    const selectedModelKeys = new Set(selectedModels);
     rawData.forEach((item) => {
-      if (!selectedModels.includes(item.model)) return;
+      if (!selectedModelKeys.has(toModelKey(item.provider, item.model))) return;
       if (item.metric_type !== xMetric && item.metric_type !== yMetric) return;
 
-      const key = `${item.benchmark}_${item.model}_${item.timestamp}`;
+      const key = `${item.benchmark}_${item.provider}_${item.model}_${item.timestamp}`;
       if (!benchmarkGroups[key]) {
         benchmarkGroups[key] = {};
       }
       if (!benchmarkGroups[key][item.metric_type]) {
         benchmarkGroups[key][item.metric_type] = [];
       }
-      // noUncheckedIndexedAccess: guard after initialization
       const metricGroup = benchmarkGroups[key][item.metric_type];
       if (metricGroup) {
         metricGroup.push(item);
@@ -329,7 +342,7 @@ export function useChartData({
               ? xData.metric_value ?? 0
               : (xData.metric_value ?? 0) * 1000,
           y: yData.metric_value ?? 0,
-          model: xData.model,
+          model: toModelKey(xData.provider, xData.model),
           benchmark: xData.benchmark,
           provider:
             activeTab === "stt"
@@ -356,10 +369,11 @@ export function useChartData({
 
     const primaryMetric = "TTFT";
 
+    const selectedSTTModelKeys = new Set(selectedSTTModels);
     const ttftData = rawData
       .filter(
         (item) =>
-          selectedSTTModels.includes(item.model) &&
+          selectedSTTModelKeys.has(toModelKey(item.provider, item.model)) &&
           item.metric_type === primaryMetric &&
           INCLUDED_STATUSES.has(item.status) &&
           item.metric_value !== null &&
@@ -368,7 +382,7 @@ export function useChartData({
       .map((item) => ({
         timestamp: to15MinuteBucket(new Date(item.timestamp).getTime()),
         value: (item.metric_value as number) * 1000,
-        model: item.model,
+        model: toModelKey(item.provider, item.model),
         benchmark: item.benchmark
       }))
       .sort((a, b) => a.timestamp - b.timestamp);
@@ -453,8 +467,10 @@ export function useChartData({
       [key: number]: { [key: string]: { total: number; count: number } };
     } = {};
 
+    const selectedModelKeys = new Set(selectedModels);
     rawData.forEach((item) => {
-      if (!selectedModels.includes(item.model)) return;
+      const itemKey = toModelKey(item.provider, item.model);
+      if (!selectedModelKeys.has(itemKey)) return;
       if (item.metric_type !== latencyMetric) return;
       if (!INCLUDED_STATUSES.has(item.status)) return;
       if (item.metric_value === null || item.metric_value === undefined) return;
@@ -467,10 +483,10 @@ export function useChartData({
         activeTab === "tts" ? item.metric_value : item.metric_value * 1000;
       const bucket = timestampGroups[timestamp];
       if (bucket) {
-        if (!bucket[item.model]) {
-          bucket[item.model] = { total: 0, count: 0 };
+        if (!bucket[itemKey]) {
+          bucket[itemKey] = { total: 0, count: 0 };
         }
-        const modelAcc = bucket[item.model];
+        const modelAcc = bucket[itemKey];
         if (modelAcc) {
           modelAcc.total += latencyValue;
           modelAcc.count += 1;
@@ -495,7 +511,6 @@ export function useChartData({
     selectedModels.forEach((model) => {
       const werStat = getStat(model, "WER");
       const latencyStat = getStat(model, latencyMetric);
-      const rtfStat = getStat(model, "RTF");
 
       // Need both latency and WER data
       if (!werStat || !latencyStat) return;
@@ -537,8 +552,7 @@ export function useChartData({
         latencyP75: p75,
         latencyIQR: p75 - p25,
         avgWER: werStat.avg_value,
-        werStdDev: werStat.stddev_value,
-        avgRTF: rtfStat?.avg_value ?? 0
+        werStdDev: werStat.stddev_value
       });
     });
 
@@ -562,7 +576,6 @@ export function useChartData({
     selectedTTSModels.forEach((model) => {
       const latencyStat = getStat(model, "TTFA");
       const werStat = getStat(model, "WER");
-      const rtfStat = getStat(model, "RTF");
 
       if (!latencyStat || !werStat) return;
 
@@ -573,8 +586,7 @@ export function useChartData({
         latencyP75: latencyStat.p75,
         latencyIQR: latencyStat.p75 - latencyStat.p25,
         avgWER: werStat.avg_value,
-        werStdDev: werStat.stddev_value,
-        avgRTF: rtfStat?.avg_value ?? 0
+        werStdDev: werStat.stddev_value
       });
     });
 
@@ -665,6 +677,38 @@ export function useChartData({
     );
   }, [getCurrentTimeWindow, getGapData]);
 
+  /** Models that have at least one plotted point in the current timeline window. */
+  const getModelsWithTimelineData = useCallback((): string[] => {
+    const selectedModels =
+      activeTab === "tts" ? selectedTTSModels : selectedSTTModels;
+    const windowed = getWindowedTimelineData();
+    return selectedModels.filter((model) =>
+      windowed.some(
+        (point) =>
+          point[`${model}_value`] !== undefined &&
+          point[`${model}_value`] !== null
+      )
+    );
+  }, [
+    activeTab,
+    selectedTTSModels,
+    selectedSTTModels,
+    getWindowedTimelineData,
+  ]);
+
+  /** Models that have at least one gap point in the current performance-delta window. */
+  const getModelsWithGapData = useCallback((): string[] => {
+    const selectedModels =
+      activeTab === "tts" ? selectedTTSModels : selectedSTTModels;
+    const windowed = getWindowedGapData();
+    return selectedModels.filter((model) =>
+      windowed.some(
+        (point) =>
+          point[`${model}_gap`] !== undefined && point[`${model}_gap`] !== null
+      )
+    );
+  }, [activeTab, selectedTTSModels, selectedSTTModels, getWindowedGapData]);
+
   const getSTTRankingData = useCallback(() => {
     if (activeTab !== "stt" || selectedSTTModels.length === 0) {
       return [];
@@ -719,6 +763,8 @@ export function useChartData({
     getTimelineTicks,
     getWindowedTimelineData,
     getWindowedGapData,
+    getModelsWithTimelineData,
+    getModelsWithGapData,
     getSTTRankingData
   };
 }

--- a/web/hooks/useChartData.ts
+++ b/web/hooks/useChartData.ts
@@ -556,7 +556,11 @@ export function useChartData({
       });
     });
 
-    return heatmapData.sort((a, b) => a.model.localeCompare(b.model));
+    return heatmapData.sort(
+      (a, b) =>
+        normalizeModelName(a.model).localeCompare(normalizeModelName(b.model)) ||
+        a.model.localeCompare(b.model)
+    );
   }, [
     rawData,
     activeTab,
@@ -590,7 +594,11 @@ export function useChartData({
       });
     });
 
-    return heatmapData.sort((a, b) => a.model.localeCompare(b.model));
+    return heatmapData.sort(
+      (a, b) =>
+        normalizeModelName(a.model).localeCompare(normalizeModelName(b.model)) ||
+        a.model.localeCompare(b.model)
+    );
   }, [activeTab, selectedTTSModels, getStat]);
 
   const getWERBarData = useCallback((): BarDataPoint[] => {

--- a/web/hooks/useChartData.ts
+++ b/web/hooks/useChartData.ts
@@ -689,7 +689,10 @@ export function useChartData({
   const getModelsWithTimelineData = useCallback((): string[] => {
     const selectedModels =
       activeTab === "tts" ? selectedTTSModels : selectedSTTModels;
-    const windowed = getWindowedTimelineData();
+    const [windowStart, windowEnd] = getCurrentTimeWindow();
+    const windowed = getTimelineData().filter(
+      (point) => point.timestamp >= windowStart && point.timestamp <= windowEnd
+    );
     return selectedModels.filter((model) =>
       windowed.some(
         (point) =>
@@ -701,21 +704,25 @@ export function useChartData({
     activeTab,
     selectedTTSModels,
     selectedSTTModels,
-    getWindowedTimelineData,
+    getCurrentTimeWindow,
+    getTimelineData,
   ]);
 
   /** Models that have at least one gap point in the current performance-delta window. */
   const getModelsWithGapData = useCallback((): string[] => {
     const selectedModels =
       activeTab === "tts" ? selectedTTSModels : selectedSTTModels;
-    const windowed = getWindowedGapData();
+    const [windowStart, windowEnd] = getCurrentTimeWindow();
+    const windowed = getGapData().filter(
+      (point) => point.timestamp >= windowStart && point.timestamp <= windowEnd
+    );
     return selectedModels.filter((model) =>
       windowed.some(
         (point) =>
           point[`${model}_gap`] !== undefined && point[`${model}_gap`] !== null
       )
     );
-  }, [activeTab, selectedTTSModels, selectedSTTModels, getWindowedGapData]);
+  }, [activeTab, selectedTTSModels, selectedSTTModels, getCurrentTimeWindow, getGapData]);
 
   const getSTTRankingData = useCallback(() => {
     if (activeTab !== "stt" || selectedSTTModels.length === 0) {

--- a/web/hooks/useDashboardState.tsx
+++ b/web/hooks/useDashboardState.tsx
@@ -4,13 +4,14 @@
 "use client";
 
 import { useState, useEffect, useMemo, useCallback, useRef } from "react";
-import type { BenchmarkData, ModelsByProvider } from "@/types/benchmark.types";
+import type { BenchmarkData } from "@/types/benchmark.types";
 import { TWENTY_FOUR_HOURS_MS } from "@/lib/config/constants";
 import { useChartData } from "@/hooks/useChartData";
 import { useMobileDetection } from "@/hooks/useMobileDetection";
 import { useBarInteraction } from "@/hooks/useBarInteraction";
 import { useTimelineWindow } from "@/hooks/useTimelineWindow";
-import { normalizeModelName, normalizeSTTProviderName, normalizeTTSProviderName } from "@/lib/utils/formatters";
+import { normalizeModelName, normalizeSTTProviderName, normalizeTTSProviderName, parseModelKey } from "@/lib/utils/formatters";
+import { buildModelsByProviderFromResults } from "@/lib/utils/modelsFromResults";
 import { metricDescriptions } from "@/lib/config/metrics";
 import { useResultsQuery, useProvidersQuery } from "@/lib/api/queries";
 import { computeModelStats, type Result } from "@/lib/aggregates";
@@ -64,20 +65,21 @@ export function useDashboardState(page: "tts" | "stt") {
     [resultRows]
   );
 
-  const { ttsModelsByProvider, sttModelsByProvider } = useMemo(() => {
-    const tts: ModelsByProvider = {};
-    const stt: ModelsByProvider = {};
-    const providers = providersQuery.data;
-    if (providers) {
-      for (const p of providers.tts) {
-        tts[p.provider] = p.models.filter((m) => !m.disabled).map((m) => m.model);
-      }
-      for (const p of providers.stt) {
-        stt[p.provider] = p.models.filter((m) => !m.disabled).map((m) => m.model);
-      }
-    }
-    return { ttsModelsByProvider: tts, sttModelsByProvider: stt };
-  }, [providersQuery.data]);
+  const { ttsModelsByProvider, sttModelsByProvider } = useMemo(
+    () => ({
+      ttsModelsByProvider: buildModelsByProviderFromResults(
+        resultRows,
+        "TTS",
+        providersQuery.data
+      ),
+      sttModelsByProvider: buildModelsByProviderFromResults(
+        resultRows,
+        "STT",
+        providersQuery.data
+      ),
+    }),
+    [providersQuery.data, resultRows]
+  );
 
   const loading = resultsQuery.isLoading || providersQuery.isLoading;
 
@@ -222,7 +224,7 @@ export function useDashboardState(page: "tts" | "stt") {
       Object.keys(modelsByProvider).length > 0 &&
       selectedModels.length === 0
     ) {
-      const allModels = Object.values(modelsByProvider).flat();
+      const allModels: string[] = Object.values(modelsByProvider).flat();
       setSelectedModels(allModels);
 
       const expanded: Record<string, boolean> = {};
@@ -262,7 +264,7 @@ export function useDashboardState(page: "tts" | "stt") {
       const fastestModel = rankingData[0];
       if (fastestModel) {
         fastestLatencyModel = fastestModel.model;
-        fastestLatencyProvider = fastestModel.provider;
+        fastestLatencyProvider = normalizeSTTProviderName(fastestModel.provider);
       }
     }
 
@@ -283,8 +285,9 @@ export function useDashboardState(page: "tts" | "stt") {
       } = {};
 
       selectedModels.forEach((model) => {
+        const { model: modelSlug, provider: modelProvider } = parseModelKey(model);
         const modelSecondaryData = sttSecondaryData.filter(
-          (item) => item.model === model
+          (item) => item.model === modelSlug && item.provider === modelProvider
         );
 
         let modelAvgSecondary = Infinity;
@@ -347,11 +350,12 @@ export function useDashboardState(page: "tts" | "stt") {
       } = {};
 
       selectedModels.forEach((model) => {
+        const { model: modelSlug, provider: modelProvider } = parseModelKey(model);
         const modelPrimaryData = primaryData.filter(
-          (item) => item.model === model
+          (item) => item.model === modelSlug && item.provider === modelProvider
         );
         const modelSecondaryData = secondaryData.filter(
-          (item) => item.model === model
+          (item) => item.model === modelSlug && item.provider === modelProvider
         );
 
         let modelMedianPrimary = Infinity;
@@ -397,7 +401,7 @@ export function useDashboardState(page: "tts" | "stt") {
         ) {
           fastestPrimary = metrics.medianPrimary;
           fastestLatencyModel = model;
-          fastestLatencyProvider = metrics.provider;
+          fastestLatencyProvider = normalizeTTSProviderName(metrics.provider);
         }
         if (
           metrics.avgSecondary < lowestSecondary &&
@@ -405,7 +409,7 @@ export function useDashboardState(page: "tts" | "stt") {
         ) {
           lowestSecondary = metrics.avgSecondary;
           lowestWERModel = model;
-          lowestWERProvider = metrics.provider;
+          lowestWERProvider = normalizeTTSProviderName(metrics.provider);
         }
       });
 
@@ -560,6 +564,8 @@ export function useDashboardState(page: "tts" | "stt") {
     getCurrentTimeWindow: chartData.getCurrentTimeWindow,
     getTimelineTicks: chartData.getTimelineTicks,
     getWindowedGapData: chartData.getWindowedGapData,
+    getModelsWithTimelineData: chartData.getModelsWithTimelineData,
+    getModelsWithGapData: chartData.getModelsWithGapData,
     getViolinData: chartData.getViolinData,
     getSTTRankingData: chartData.getSTTRankingData,
 

--- a/web/hooks/useDashboardState.tsx
+++ b/web/hooks/useDashboardState.tsx
@@ -11,7 +11,7 @@ import { useMobileDetection } from "@/hooks/useMobileDetection";
 import { useBarInteraction } from "@/hooks/useBarInteraction";
 import { useTimelineWindow } from "@/hooks/useTimelineWindow";
 import { normalizeModelName, normalizeSTTProviderName, normalizeTTSProviderName, parseModelKey } from "@/lib/utils/formatters";
-import { buildModelsByProviderFromResults } from "@/lib/utils/modelsFromResults";
+import { buildModelsByProviderFromResults, pruneSelection } from "@/lib/utils/modelsFromResults";
 import { metricDescriptions } from "@/lib/config/metrics";
 import { useResultsQuery, useProvidersQuery } from "@/lib/api/queries";
 import { computeModelStats, type Result } from "@/lib/aggregates";
@@ -234,6 +234,17 @@ export function useDashboardState(page: "tts" | "stt") {
       setExpandedProviders(expanded);
     }
   }, [modelsByProvider, selectedModels.length]);
+
+  // Keep the selection a subset of the visible models. Once provider metadata
+  // loads, a model that results alone had surfaced may be filtered out of
+  // modelsByProvider; drop it so it stops being plotted while absent from the
+  // sidebar. Removal-only, so it never fights a manual selection.
+  useEffect(() => {
+    setSelectedModels((prev) => {
+      const next = pruneSelection(prev, modelsByProvider);
+      return next.length === prev.length ? prev : next;
+    });
+  }, [modelsByProvider]);
 
   // Calculate metrics
   const currentData = chartData.getCurrentData();

--- a/web/lib/config/colors.ts
+++ b/web/lib/config/colors.ts
@@ -40,11 +40,12 @@ export const modelColors: Record<string, string> = {
   // AssemblyAI STT
   "universal-streaming": "#E74C3C",
 
-  // Speechmatics STT — composite keys so `default` does not collide with other vendors
+  // Speechmatics STT
   enhanced: "#3498DB",
   default: "#21618C",
-  "speechmatics-default": "#21618C",
-  "speechmatics-enhanced": "#3498DB"
+  // Composite keys for models whose slug is shared across providers
+  "speechmatics:default": "#21618C",
+  "gradium:default": "#1ABC9C"
 };
 
 export const providerColors: Record<string, string> = {

--- a/web/lib/config/metrics.ts
+++ b/web/lib/config/metrics.ts
@@ -22,11 +22,6 @@ export const metricDescriptions = {
     detailed:
       "Ensuring accurate speech output is fundamental to user trust and comprehension in voice AI systems. We recognize that even minor pronunciation errors can undermine the entire conversation experience and our evaluation captures how faithfully text-to-speech systems pronounces complex terminology, proper nouns, and domain-specific vocabulary that matter most to your users."
   },
-  rtf: {
-    short: "Real-time factor",
-    detailed:
-      "RTF measures how fast a speech-to-text model processes audio relative to real-time. RTF = processing time / audio duration. Values < 1.0 mean faster than real-time, > 1.0 mean slower than real-time. Higher values are better for batch processing, while values close to 1.0 are ideal for real-time applications."
-  },
   performanceGap: {
     short: "Time to First Token",
     detailed:

--- a/web/lib/utils/colors.ts
+++ b/web/lib/utils/colors.ts
@@ -6,6 +6,7 @@
  */
 
 import { modelColors, providerColors } from '@/lib/config/colors';
+import { parseModelKey } from '@/lib/utils/formatters';
 
 /**
  * Fallback colors for models/providers not in the predefined color maps
@@ -65,16 +66,16 @@ function hashCode(str: string): number {
 }
 
 /**
- * Get color for a model, using predefined colors or generating a consistent fallback
- * @param model - Model name
- * @returns Hex color code
+ * Get color for a model. Accepts both bare slugs ("default") and composite
+ * "provider:model" keys ("speechmatics:default"). Composite keys are tried
+ * first so that same-slug models across different providers can have distinct
+ * colors; the hash fallback uses the full key for uniqueness.
  */
-export function getModelColor(model: string): string {
-  if (modelColors[model]) {
-    return modelColors[model];
-  }
-
-  const hash = hashCode(model);
+export function getModelColor(modelKey: string): string {
+  if (modelColors[modelKey]) return modelColors[modelKey];
+  const { model } = parseModelKey(modelKey);
+  if (modelColors[model]) return modelColors[model];
+  const hash = hashCode(modelKey);
   return fallbackModelColors[Math.abs(hash) % fallbackModelColors.length] ?? "#E74C3C";
 }
 

--- a/web/lib/utils/formatters.ts
+++ b/web/lib/utils/formatters.ts
@@ -49,12 +49,33 @@ export function getLocalTimeZoneAbbr(): string {
 }
 
 /**
- * Normalize model name for display
- * @param modelName - Raw model name from API
+ * Build a composite model key from provider and model slug.
+ * Used throughout the frontend to uniquely identify a (provider, model) pair,
+ * since multiple providers can share the same model slug (e.g. "default").
+ */
+export function toModelKey(provider: string, model: string): string {
+  return `${provider}:${model}`;
+}
+
+/**
+ * Parse a composite model key back into its provider and model slug parts.
+ * Returns the key unchanged as `model` when no colon separator is found.
+ */
+export function parseModelKey(key: string): { provider: string; model: string } {
+  const idx = key.indexOf(":");
+  if (idx === -1) return { provider: "", model: key };
+  return { provider: key.slice(0, idx), model: key.slice(idx + 1) };
+}
+
+/**
+ * Normalize model name for display.
+ * Accepts both bare slugs ("default") and composite keys ("speechmatics:default").
+ * @param modelKey - Model slug or composite "provider:model" key
  * @returns Formatted model name for display
  */
-export function normalizeModelName(modelName: string): string {
-  // Mapping mirrors the backend's enabled provider matrix (runner/config.py).
+export function normalizeModelName(modelKey: string): string {
+  const { model } = parseModelKey(modelKey);
+  // Display labels only — sidebar/chart membership comes from result rows, not this map.
   const modelMappings: Record<string, string> = {
     // TTS
     "gpt-4o-mini-tts": "GPT-4o mini TTS",
@@ -80,13 +101,12 @@ export function normalizeModelName(modelName: string): string {
     enhanced: "Enhanced"
   };
 
-  // Return mapped name if it exists
-  if (modelMappings[modelName]) {
-    return modelMappings[modelName];
+  if (modelMappings[model]) {
+    return modelMappings[model];
   }
 
   // Fallback: automatic normalization for unmapped models
-  return modelName
+  return model
     .replace(/-/g, " ") // Replace hyphens with spaces
     .replace(/_/g, " ") // Replace underscores with spaces
     .replace(/\bv(\d+)/g, "v$1") // Keep version format (v2, v3)
@@ -119,8 +139,8 @@ export function normalizeSTTProviderName(providerName: string): string {
     deepgram: "Deepgram",
     elevenlabs: "ElevenLabs",
     gradium: "Gradium",
-    speechmatics: "Speechmatics",
     rime: "Rime",
+    speechmatics: "Speechmatics"
   };
 
   const lower = providerName.toLowerCase();

--- a/web/lib/utils/modelsFromResults.test.ts
+++ b/web/lib/utils/modelsFromResults.test.ts
@@ -1,0 +1,129 @@
+// Copyright 2026 The Coval Benchmarks Authors
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+import type { Result } from "../aggregates";
+import { buildModelsByProviderFromResults } from "./modelsFromResults";
+
+function row(
+  provider: string,
+  model: string,
+  benchmark: "STT" | "TTS" = "STT"
+): Result {
+  return {
+    id: 1,
+    provider,
+    model,
+    benchmark,
+    metric_type: "TTFT",
+    metric_value: 0.5,
+    metric_units: "seconds",
+    status: "SUCCEEDED",
+    created_at: "2026-05-18T12:00:00Z",
+    run_id: 1,
+    audio_filename: "a.wav",
+    transcript: null,
+    error: null,
+    voice: null,
+  } as Result;
+}
+
+describe("buildModelsByProviderFromResults", () => {
+  it("includes providers/models present in result rows when no catalogue is available", () => {
+    const out = buildModelsByProviderFromResults(
+      [
+        row("deepgram", "nova-2"),
+        row("xai", "grok-stt"),
+      ],
+      "STT"
+    );
+    expect(out.deepgram).toEqual(["deepgram:nova-2"]);
+    expect(out.xai).toEqual(["xai:grok-stt"]);
+    expect(out.openai).toBeUndefined();
+  });
+
+  it("starts from enabled catalogue models so an empty benchmark page still has choices", () => {
+    const catalogue = {
+      tts: [],
+      stt: [
+        {
+          provider: "deepgram",
+          models: [
+            { model: "nova-2", disabled: false },
+            { model: "flux-general-multi", disabled: false },
+          ],
+        },
+      ],
+    };
+    const out = buildModelsByProviderFromResults(
+      [row("deepgram", "nova-2")],
+      "STT",
+      catalogue as never
+    );
+    expect(out.deepgram).toEqual([
+      "deepgram:nova-2",
+      "deepgram:flux-general-multi",
+    ]);
+  });
+
+  it("works when catalogue is undefined", () => {
+    const out = buildModelsByProviderFromResults([row("hume", "octave-2", "TTS")], "TTS");
+    expect(out.hume).toEqual(["hume:octave-2"]);
+  });
+
+  it("does not include disabled catalogue models or disabled result rows", () => {
+    const catalogue = {
+      tts: [],
+      stt: [
+        {
+          provider: "openai",
+          models: [
+            { model: "gpt-realtime-whisper", disabled: false },
+            { model: "legacy-whisper", disabled: true },
+          ],
+        },
+      ],
+    };
+
+    const out = buildModelsByProviderFromResults(
+      [
+        row("openai", "gpt-realtime-whisper"),
+        row("openai", "legacy-whisper"),
+      ],
+      "STT",
+      catalogue as never
+    );
+
+    expect(out.openai).toEqual(["openai:gpt-realtime-whisper"]);
+  });
+
+  it("adds result-backed TTS models alongside catalogue models", () => {
+    const catalogue = {
+      stt: [],
+      tts: [
+        {
+          provider: "openai",
+          models: [{ model: "tts-1-hd", disabled: false }],
+        },
+        {
+          provider: "elevenlabs",
+          models: [{ model: "eleven_flash_v2_5", disabled: false }],
+        },
+      ],
+    };
+
+    const out = buildModelsByProviderFromResults(
+      [
+        row("openai", "tts-1-hd", "TTS"),
+        row("hume", "octave-tts", "TTS"),
+        row("hume", "octave-2", "TTS"),
+      ],
+      "TTS",
+      catalogue as never
+    );
+
+    expect(out.openai).toEqual(["openai:tts-1-hd"]);
+    expect(out.elevenlabs).toEqual(["elevenlabs:eleven_flash_v2_5"]);
+    expect(out.hume).toEqual(["hume:octave-tts", "hume:octave-2"]);
+  });
+});

--- a/web/lib/utils/modelsFromResults.test.ts
+++ b/web/lib/utils/modelsFromResults.test.ts
@@ -42,6 +42,15 @@ describe("buildModelsByProviderFromResults", () => {
     expect(out.openai).toBeUndefined();
   });
 
+  it("keeps same-slug models from different providers distinct", () => {
+    const out = buildModelsByProviderFromResults(
+      [row("speechmatics", "default"), row("gradium", "default")],
+      "STT"
+    );
+    expect(out.speechmatics).toEqual(["speechmatics:default"]);
+    expect(out.gradium).toEqual(["gradium:default"]);
+  });
+
   it("starts from enabled catalogue models so an empty benchmark page still has choices", () => {
     const catalogue = {
       tts: [],

--- a/web/lib/utils/modelsFromResults.test.ts
+++ b/web/lib/utils/modelsFromResults.test.ts
@@ -3,7 +3,7 @@
 
 import { describe, expect, it } from "vitest";
 import type { Result } from "../aggregates";
-import { buildModelsByProviderFromResults } from "./modelsFromResults";
+import { buildModelsByProviderFromResults, pruneSelection } from "./modelsFromResults";
 
 function row(
   provider: string,
@@ -125,5 +125,29 @@ describe("buildModelsByProviderFromResults", () => {
     expect(out.openai).toEqual(["openai:tts-1-hd"]);
     expect(out.elevenlabs).toEqual(["elevenlabs:eleven_flash_v2_5"]);
     expect(out.hume).toEqual(["hume:octave-tts", "hume:octave-2"]);
+  });
+});
+
+describe("pruneSelection", () => {
+  it("removes selected keys no longer present in modelsByProvider", () => {
+    const result = pruneSelection(
+      ["speechmatics:default", "google:short", "deepgram:nova-2"],
+      {
+        speechmatics: ["speechmatics:default"],
+        deepgram: ["deepgram:nova-2"]
+      }
+    );
+    expect(result).toEqual(["speechmatics:default", "deepgram:nova-2"]);
+  });
+
+  it("keeps the selection intact when every key is still valid", () => {
+    const selected = ["deepgram:nova-2", "deepgram:nova-3"];
+    expect(
+      pruneSelection(selected, { deepgram: ["deepgram:nova-2", "deepgram:nova-3"] })
+    ).toEqual(selected);
+  });
+
+  it("returns empty when modelsByProvider is empty", () => {
+    expect(pruneSelection(["deepgram:nova-2"], {})).toEqual([]);
   });
 });

--- a/web/lib/utils/modelsFromResults.ts
+++ b/web/lib/utils/modelsFromResults.ts
@@ -1,0 +1,70 @@
+// Copyright 2026 The Coval Benchmarks Authors
+// SPDX-License-Identifier: Apache-2.0
+
+import type { ProvidersApiResponse } from "../api/client";
+import type { Result } from "../aggregates";
+import type { ModelsByProvider } from "../../types/benchmark.types";
+import { toModelKey } from "./formatters";
+
+function modelIsEnabled(
+  providers: ProvidersApiResponse | undefined,
+  benchmark: "STT" | "TTS",
+  provider: string,
+  model: string
+): boolean {
+  if (!providers) return true;
+
+  const catalogue = benchmark === "STT" ? providers.stt : providers.tts;
+  const providerInfo = catalogue.find((item) => item.provider === provider);
+  if (!providerInfo) return true;
+
+  const modelInfo = providerInfo.models.find((item) => item.model === model);
+  return modelInfo?.disabled !== true;
+}
+
+function addModel(
+  modelsByProvider: ModelsByProvider,
+  provider: string,
+  model: string
+): void {
+  const key = toModelKey(provider, model);
+  const models = modelsByProvider[provider] ?? [];
+  if (!models.includes(key)) {
+    models.push(key);
+    modelsByProvider[provider] = models;
+  }
+}
+
+function buildModelsByProviderFromCatalogue(
+  benchmark: "STT" | "TTS",
+  providers?: ProvidersApiResponse
+): ModelsByProvider {
+  const modelsByProvider: ModelsByProvider = {};
+  if (!providers) return modelsByProvider;
+
+  const catalogue = benchmark === "STT" ? providers.stt : providers.tts;
+  for (const providerInfo of catalogue) {
+    for (const modelInfo of providerInfo.models) {
+      if (modelInfo.disabled) continue;
+      addModel(modelsByProvider, providerInfo.provider, modelInfo.model);
+    }
+  }
+
+  return modelsByProvider;
+}
+
+export function buildModelsByProviderFromResults(
+  rows: readonly Result[],
+  benchmark: "STT" | "TTS",
+  providers?: ProvidersApiResponse
+): ModelsByProvider {
+  const modelsByProvider = buildModelsByProviderFromCatalogue(benchmark, providers);
+
+  for (const row of rows) {
+    if (row.benchmark !== benchmark) continue;
+    if (!modelIsEnabled(providers, benchmark, row.provider, row.model)) continue;
+    addModel(modelsByProvider, row.provider, row.model);
+  }
+
+  return modelsByProvider;
+}

--- a/web/lib/utils/modelsFromResults.ts
+++ b/web/lib/utils/modelsFromResults.ts
@@ -68,3 +68,18 @@ export function buildModelsByProviderFromResults(
 
   return modelsByProvider;
 }
+
+/**
+ * Drop any selected composite key that is no longer present in
+ * `modelsByProvider`. Removal-only: it never adds or reorders, so it cannot
+ * override a manual selection or re-introduce a model — it only reconciles the
+ * selection after provider metadata filters a model out (e.g. a disabled model
+ * that results alone had surfaced before the catalogue loaded).
+ */
+export function pruneSelection(
+  selected: readonly string[],
+  modelsByProvider: ModelsByProvider
+): string[] {
+  const valid = new Set(Object.values(modelsByProvider).flat());
+  return selected.filter((key) => valid.has(key));
+}

--- a/web/next-env.d.ts
+++ b/web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/web/next-env.d.ts
+++ b/web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/web/types/benchmark.types.ts
+++ b/web/types/benchmark.types.ts
@@ -43,7 +43,6 @@ export interface ModelHeatmapData {
   latencyIQR: number;
   avgWER: number;
   werStdDev: number;
-  avgRTF: number; // Will be 0 for TTS models
 }
 
 export interface ScatterDataResult {

--- a/web/types/chart.types.ts
+++ b/web/types/chart.types.ts
@@ -44,4 +44,5 @@ export interface CustomBarTooltipProps {
     value: number;
   }>;
   label?: string;
+  getProviderForModel?: (model: string) => string;
 }


### PR DESCRIPTION
Models that share a slug — Speechmatics and Gradium both expose `default` — were colliding in the dashboard, so one provider's series overwrote the other's. This keys charts and stats by `provider:model` so same-named models stay distinct, builds the sidebar list from actual results, and only plots models with data in the active window.

Commits:
- Composite `provider:model` keys across charts, stats, colors, and sidebar
- Normalize the provider name once in the chart axis tick (no behavior change)
- Sort heatmap rows by display name instead of the internal key

Known follow-ups (out of scope): latency-only models with no WER are dropped from WER-gated charts; catalogue models with no results can show as empty selections.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model name normalization and display consistency across all charts and tooltips.
  * Fixed model filtering logic to properly handle composite provider-model identifiers.
  * Corrected timeline data aggregation to accurately reflect selected models in current windows.

* **Refactor**
  * Simplified tooltip displays by removing unnecessary benchmark transcript data dependency.
  * Integrated provider information directly into tooltips for better model identification.
  * Updated performance metrics to use millisecond-based gap calculations instead of seconds.

* **Chores**
  * Removed Real-Time Factor (RTF) metric from performance comparisons.
  * Added support for Time-to-First-Token performance gap metric.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->