### PR TITLE
[BENCH-219] Fix silent errors.

### DIFF
--- a/runner/src/coval_bench/runner/orchestrator.py
+++ b/runner/src/coval_bench/runner/orchestrator.py
@@ -85,6 +85,30 @@ def _truncate(msg: str) -> str:
     return msg[:_MAX_ERROR_LEN]
 
 
+def _metric_outcome(
+    metric_value: float | None,
+    item_error: str | None,
+    metric_label: str,
+    result_status: Any,  # noqa: ANN401 — ResultStatus enum, lazy-imported by callers
+) -> tuple[Any, str | None]:
+    """Decide ``(status, error)`` for a single result row.
+
+    A provider that returns without raising can still have failed: it may set
+    ``result.error`` or simply produce no measurement. The orchestrator used to
+    stamp every returned row ``SUCCESS``; this restores honest labelling.
+
+    Rules (in order):
+    * an item-level provider error fails the row and carries the message;
+    * otherwise a missing (``None``) metric fails just this row;
+    * a present metric succeeds.
+    """
+    if item_error:
+        return result_status.FAILED, _truncate(item_error)
+    if metric_value is None:
+        return result_status.FAILED, f"no {metric_label} produced"
+    return result_status.SUCCESS, None
+
+
 async def _transcribe_with_whisper(audio_path: Path, settings: Settings) -> str:
     """Transcribe *audio_path* with OpenAI ``whisper-1`` and return the text.
 
@@ -194,6 +218,8 @@ async def _run_stt_item(
         duration_sec: float = item.duration_sec
         audio_bytes = audio_path.read_bytes()
 
+        transcription_result = None
+        item_error: str | None = None
         try:
             async with asyncio.timeout(_STT_TIMEOUT_S):
                 transcription_result = await with_retry(
@@ -207,7 +233,7 @@ async def _run_stt_item(
                     ),
                 )
         except Exception as exc:
-            err = _truncate(str(exc))
+            item_error = _truncate(str(exc))
             _log.warning(
                 "STT provider call failed",
                 provider=entry.provider,
@@ -215,24 +241,20 @@ async def _run_stt_item(
                 audio=str(audio_path),
                 exc_info=exc,
             )
-            results.append(
-                Result(
-                    run_id=run_id,
-                    provider=entry.provider,
-                    model=entry.model,
-                    benchmark=Benchmark.STT,
-                    metric_type="TTFT",
-                    metric_value=None,
-                    metric_units=None,
-                    audio_filename=audio_path.name,
-                    transcript=None,
-                    status=ResultStatus.FAILED,
-                    error=err,
-                )
-            )
-            return results
+
+        item_error = item_error or (
+            transcription_result.error if transcription_result is not None else None
+        )
+        ttft_seconds = transcription_result.ttft_seconds if transcription_result else None
+        audio_to_final = (
+            transcription_result.audio_to_final_seconds if transcription_result else None
+        )
+        complete_transcript = (
+            transcription_result.complete_transcript if transcription_result else None
+        )
 
         # 1. TTFT
+        ttft_status, ttft_error = _metric_outcome(ttft_seconds, item_error, "TTFT", ResultStatus)
         results.append(
             Result(
                 run_id=run_id,
@@ -240,16 +262,19 @@ async def _run_stt_item(
                 model=entry.model,
                 benchmark=Benchmark.STT,
                 metric_type="TTFT",
-                metric_value=transcription_result.ttft_seconds,
+                metric_value=ttft_seconds,
                 metric_units="seconds",
                 audio_filename=audio_path.name,
-                transcript=transcription_result.complete_transcript,
-                status=ResultStatus.SUCCESS,
-                error=None,
+                transcript=complete_transcript,
+                status=ttft_status,
+                error=ttft_error,
             )
         )
 
         # 2. AudioToFinal
+        atf_status, atf_error = _metric_outcome(
+            audio_to_final, item_error, "AudioToFinal", ResultStatus
+        )
         results.append(
             Result(
                 run_id=run_id,
@@ -257,21 +282,24 @@ async def _run_stt_item(
                 model=entry.model,
                 benchmark=Benchmark.STT,
                 metric_type="AudioToFinal",
-                metric_value=transcription_result.audio_to_final_seconds,
+                metric_value=audio_to_final,
                 metric_units="seconds",
                 audio_filename=audio_path.name,
-                transcript=transcription_result.complete_transcript,
-                status=ResultStatus.SUCCESS,
-                error=None,
+                transcript=complete_transcript,
+                status=atf_status,
+                error=atf_error,
             )
         )
 
-        # 3. RTF — suppress on invalid inputs (e.g. zero duration) rather than failing the row
+        # 3. RTF — derived from AudioToFinal, so its outcome tracks whether a final was
+        # produced. A present final with an uncomputable RTF (e.g. zero duration) stays a
+        # null-valued success rather than a failure, matching the original intent.
         rtf_value: float | None = None
-        if transcription_result.audio_to_final_seconds is not None and duration_sec > 0:
+        if audio_to_final is not None and duration_sec > 0:
             with contextlib.suppress(Exception):
-                rtf_value = compute_rtf(transcription_result.audio_to_final_seconds, duration_sec)
+                rtf_value = compute_rtf(audio_to_final, duration_sec)
 
+        rtf_status, rtf_error = _metric_outcome(audio_to_final, item_error, "RTF", ResultStatus)
         results.append(
             Result(
                 run_id=run_id,
@@ -282,16 +310,17 @@ async def _run_stt_item(
                 metric_value=rtf_value,
                 metric_units="ratio",
                 audio_filename=audio_path.name,
-                transcript=transcription_result.complete_transcript,
-                status=ResultStatus.SUCCESS,
-                error=None,
+                transcript=complete_transcript,
+                status=rtf_status,
+                error=rtf_error,
             )
         )
 
-        # 4. WER (when ground-truth available)
-        if transcript_ref and transcription_result.complete_transcript is not None:
+        # 4. WER (when ground-truth available; skip when the stream errored so we don't
+        # score a transcript salvaged from a failed run)
+        if transcript_ref and complete_transcript is not None and item_error is None:
             try:
-                wer_result = compute_wer(transcript_ref, transcription_result.complete_transcript)
+                wer_result = compute_wer(transcript_ref, complete_transcript)
                 results.append(
                     Result(
                         run_id=run_id,
@@ -302,7 +331,7 @@ async def _run_stt_item(
                         metric_value=wer_result.wer_percentage,
                         metric_units="percent",
                         audio_filename=audio_path.name,
-                        transcript=transcription_result.complete_transcript,
+                        transcript=complete_transcript,
                         status=ResultStatus.SUCCESS,
                         error=None,
                     )
@@ -371,6 +400,8 @@ async def _run_tts_item(
         transcript: str = item.transcript
         provider = provider_cls(settings=settings, model=entry.model, voice=entry.voice)
 
+        tts_result = None
+        item_error: str | None = None
         try:
             async with asyncio.timeout(_TTS_TIMEOUT_S):
                 tts_result = await with_retry(
@@ -378,33 +409,22 @@ async def _run_tts_item(
                 )
             audio_path = tts_result.audio_path
         except Exception as exc:
-            err = _truncate(str(exc))
+            item_error = _truncate(str(exc))
             _log.warning(
                 "TTS provider call failed",
                 provider=entry.provider,
                 model=entry.model,
                 exc_info=exc,
             )
-            results.append(
-                Result(
-                    run_id=run_id,
-                    provider=entry.provider,
-                    model=entry.model,
-                    voice=entry.voice,
-                    benchmark=Benchmark.TTS,
-                    metric_type="TTFA",
-                    metric_value=None,
-                    metric_units=None,
-                    audio_filename=None,
-                    transcript=None,
-                    status=ResultStatus.FAILED,
-                    error=err,
-                )
-            )
-            return results
+
+        # Single failure model: a raised exception OR a provider-reported error fails the
+        # TTFA row (see _metric_outcome) and suppresses WER scoring below.
+        item_error = item_error or (tts_result.error if tts_result is not None else None)
+        ttfa_ms = tts_result.ttfa_ms if tts_result else None
 
         try:
             # 1. TTFA
+            ttfa_status, ttfa_error = _metric_outcome(ttfa_ms, item_error, "TTFA", ResultStatus)
             results.append(
                 Result(
                     run_id=run_id,
@@ -413,17 +433,17 @@ async def _run_tts_item(
                     voice=entry.voice,
                     benchmark=Benchmark.TTS,
                     metric_type="TTFA",
-                    metric_value=tts_result.ttfa_ms,
+                    metric_value=ttfa_ms,
                     metric_units="milliseconds",
                     audio_filename=audio_path.name if audio_path else None,
                     transcript=transcript,
-                    status=ResultStatus.SUCCESS,
-                    error=None,
+                    status=ttfa_status,
+                    error=ttfa_error,
                 )
             )
 
-            # 2. WER via Whisper transcription of synthesized audio
-            if audio_path is not None and audio_path.exists():
+            # 2. WER via Whisper transcription of synthesized audio (skip when synth errored)
+            if item_error is None and audio_path is not None and audio_path.exists():
                 try:
                     whisper_transcript = await _transcribe_with_whisper(audio_path, settings)
                     wer_result = compute_wer(transcript, whisper_transcript)

--- a/runner/tests/unit/test_orchestrator.py
+++ b/runner/tests/unit/test_orchestrator.py
@@ -362,8 +362,14 @@ async def test_full_failure(audio_file: Path, settings: Settings) -> None:
         )
 
     assert summary.status == str(RunStatus.FAILED)
-    assert summary.fail_count == 1
+    # Unified failure model: a raised exception fails every metric row for the item
+    # (TTFT, AudioToFinal, RTF), each carrying the real exception string.
+    assert summary.fail_count == 3
     assert summary.success_count == 0
+    rows = _recorded_rows(writer)
+    assert {r.metric_type for r in rows} == {"TTFT", "AudioToFinal", "RTF"}
+    assert all(r.status == ResultStatus.FAILED for r in rows)
+    assert all("always fails" in (r.error or "") for r in rows)
 
 
 # ---------------------------------------------------------------------------
@@ -952,3 +958,193 @@ async def test_sigterm_finalizes_run_as_partial(audio_file: Path, settings: Sett
     finish_kwargs = writer.finish_run.await_args.kwargs
     assert finish_kwargs["status"] == RunStatus.PARTIAL
     assert "sigterm" in (finish_kwargs.get("error") or "").lower()
+
+
+# ---------------------------------------------------------------------------
+# 14-17. degraded results that return (no raise) are marked FAILED
+# ---------------------------------------------------------------------------
+
+
+def _only_stt_matrix(provider: str, model: str) -> list[ProviderEntry]:
+    """Disable the whole default STT matrix and enable just one provider×model.
+
+    Keeps a degraded-provider test isolated to a single Result set (the default
+    matrix runs deepgram across several models, which would otherwise collide).
+    """
+    from coval_bench.runner.config import DEFAULT_STT_MATRIX
+
+    return [
+        *[
+            ProviderEntry(provider=e.provider, model=e.model, voice=e.voice, enabled=False)
+            for e in DEFAULT_STT_MATRIX
+        ],
+        ProviderEntry(provider=provider, model=model, enabled=True),
+    ]
+
+
+def _recorded_rows(writer: MagicMock) -> list[Result]:
+    """All Result rows handed to writer.record_results across the run."""
+    return [row for call in writer.record_results.await_args_list for row in call.args[0]]
+
+
+@pytest.mark.asyncio
+async def test_stt_empty_result_marked_failed(audio_file: Path, settings: Settings) -> None:
+    """No-raise return with no metrics → TTFT/AudioToFinal/RTF FAILED, no WER row, run FAILED."""
+    empty = TranscriptionResult(provider="deepgram")  # all metrics None, no error, no transcript
+
+    provider_inst = MagicMock()
+    provider_inst.measure_ttft = AsyncMock(return_value=empty)
+    provider_cls = MagicMock(return_value=provider_inst)
+
+    run = _make_run()
+    writer = _make_stub_writer(run)
+
+    async with _orchestrator_env(
+        audio_path=audio_file,
+        stt_items=[_make_dataset_item(audio_file)],
+        stt_providers={"deepgram": provider_cls},
+        run=run,
+        writer=writer,
+    ) as _:
+        summary = await run_benchmarks(
+            settings=settings,
+            benchmark_kind="stt",
+            smoke=True,
+            matrix_overrides=_only_stt_matrix("deepgram", "nova-2"),
+        )
+
+    by_metric = {r.metric_type: r for r in _recorded_rows(writer)}
+    for mt in ("TTFT", "AudioToFinal", "RTF"):
+        assert by_metric[mt].status == ResultStatus.FAILED
+        assert by_metric[mt].error and "produced" in by_metric[mt].error
+    assert "WER" not in by_metric  # no transcript → no WER row
+    assert summary.success_count == 0
+    assert summary.status == str(RunStatus.FAILED)
+
+
+@pytest.mark.asyncio
+async def test_stt_result_error_propagated(audio_file: Path, settings: Settings) -> None:
+    """result.error set → every row FAILED, provider message preserved, WER skipped."""
+    errored = TranscriptionResult(
+        provider="deepgram",
+        ttft_seconds=0.3,  # a measured TTFT is still untrustworthy when the stream errored
+        complete_transcript="partial words",
+        error="websocket closed unexpectedly",
+    )
+
+    provider_inst = MagicMock()
+    provider_inst.measure_ttft = AsyncMock(return_value=errored)
+    provider_cls = MagicMock(return_value=provider_inst)
+
+    run = _make_run()
+    writer = _make_stub_writer(run)
+
+    async with _orchestrator_env(
+        audio_path=audio_file,
+        stt_items=[_make_dataset_item(audio_file)],
+        stt_providers={"deepgram": provider_cls},
+        run=run,
+        writer=writer,
+    ) as _:
+        summary = await run_benchmarks(
+            settings=settings,
+            benchmark_kind="stt",
+            smoke=True,
+            matrix_overrides=_only_stt_matrix("deepgram", "nova-2"),
+        )
+
+    rows = _recorded_rows(writer)
+    assert rows
+    assert all(r.status == ResultStatus.FAILED for r in rows)
+    assert all("websocket closed" in (r.error or "") for r in rows)
+    assert all(r.metric_type != "WER" for r in rows)  # errored stream → no WER scoring
+    assert summary.success_count == 0
+
+
+@pytest.mark.asyncio
+async def test_stt_partial_keeps_real_ttft(audio_file: Path, settings: Settings) -> None:
+    """First token but no final → TTFT success, AudioToFinal/RTF FAILED → run PARTIAL."""
+    partial = TranscriptionResult(
+        provider="deepgram",
+        ttft_seconds=0.42,
+        audio_to_final_seconds=None,
+        complete_transcript=None,
+    )
+
+    provider_inst = MagicMock()
+    provider_inst.measure_ttft = AsyncMock(return_value=partial)
+    provider_cls = MagicMock(return_value=provider_inst)
+
+    run = _make_run()
+    writer = _make_stub_writer(run)
+
+    async with _orchestrator_env(
+        audio_path=audio_file,
+        stt_items=[_make_dataset_item(audio_file)],
+        stt_providers={"deepgram": provider_cls},
+        run=run,
+        writer=writer,
+    ) as _:
+        summary = await run_benchmarks(
+            settings=settings,
+            benchmark_kind="stt",
+            smoke=True,
+            matrix_overrides=_only_stt_matrix("deepgram", "nova-2"),
+        )
+
+    by_metric = {r.metric_type: r for r in _recorded_rows(writer)}
+    assert by_metric["TTFT"].status == ResultStatus.SUCCESS
+    assert by_metric["TTFT"].metric_value == 0.42
+    assert by_metric["AudioToFinal"].status == ResultStatus.FAILED
+    assert by_metric["RTF"].status == ResultStatus.FAILED
+    assert summary.status == str(RunStatus.PARTIAL)
+
+
+@pytest.mark.asyncio
+async def test_tts_empty_ttfa_marked_failed(audio_file: Path, settings: Settings) -> None:
+    """TTS synth returns (no raise) with no ttfa/audio → TTFA FAILED, no WER row, run FAILED."""
+    from coval_bench.runner.config import DEFAULT_TTS_MATRIX
+
+    hume_entry = next(e for e in DEFAULT_TTS_MATRIX if e.provider == "hume")
+    empty_tts = TTSResult(
+        provider="hume",
+        model=hume_entry.model,
+        voice=hume_entry.voice or "v",
+        ttfa_ms=None,
+        audio_path=None,
+        error=None,
+    )
+
+    provider_inst = MagicMock()
+    provider_inst.synthesize = AsyncMock(return_value=empty_tts)
+    provider_cls = MagicMock(return_value=provider_inst)
+
+    # Enable exactly one hume entry; disable the rest of the default TTS matrix.
+    matrix = [
+        ProviderEntry(provider=e.provider, model=e.model, voice=e.voice, enabled=(e is hume_entry))
+        for e in DEFAULT_TTS_MATRIX
+    ]
+
+    run = _make_run()
+    writer = _make_stub_writer(run)
+
+    async with _orchestrator_env(
+        audio_path=audio_file,
+        tts_items=[_make_tts_item("hello world")],
+        tts_providers={"hume": provider_cls},
+        run=run,
+        writer=writer,
+    ) as _:
+        summary = await run_benchmarks(
+            settings=settings,
+            benchmark_kind="tts",
+            smoke=True,
+            matrix_overrides=matrix,
+        )
+
+    by_metric = {r.metric_type: r for r in _recorded_rows(writer)}
+    assert by_metric["TTFA"].status == ResultStatus.FAILED
+    assert by_metric["TTFA"].error and "TTFA" in by_metric["TTFA"].error
+    assert "WER" not in by_metric
+    assert summary.success_count == 0
+    assert summary.status == str(RunStatus.FAILED)


### PR DESCRIPTION
- Errors weren't being properly handled.
- Providers caught errors and passed them to the result object.
- Orchestrator expected errors to be propagated.
- This is a quick fix that checks the result object for an error instead of expecting that error to be propagated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Metrics now fail with clear messages when provider errors or missing values occur; downstream rows (including timing and RTF/TTFA) reflect those failures and affect run status (FAILED/PARTIAL/SUCCESS).
  * WER scoring is emitted only when required upstream data exists (complete transcript or synthesized audio); WER rows are suppressed otherwise.

* **Tests**
  * Added regression tests covering provider exceptions, empty/partial/errored STT/TTS results, WER failures, and related run-status behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->