### PR TITLE
Fix deepgram wer

### DIFF
--- a/runner/src/coval_bench/providers/stt/deepgram.py
+++ b/runner/src/coval_bench/providers/stt/deepgram.py
@@ -163,6 +163,7 @@ class DeepgramProvider(STTProvider):
 
     async def _receive(self, ws: Any, result: TranscriptionResult) -> None:
         final_segments: list[str] = []
+        pending_partial: str = ""
         flux_latest: str = ""
         last_final_time: float | None = None
 
@@ -230,15 +231,22 @@ class DeepgramProvider(STTProvider):
 
                 result.partial_transcripts.append(transcript)
 
-                if self._model in ("nova-2", "nova-3"):
-                    if msg.get("speech_final"):
-                        final_segments.append(transcript)
-                        last_final_time = now
+                # Deepgram v1 chunks an utterance into non-overlapping pieces,
+                # each finalized by is_final=true. speech_final=true is only an
+                # endpointing flag riding on the last is_final before a pause —
+                # keying on it drops every is_final-only piece in between. Per
+                # Deepgram's docs the full transcript is the concatenation of
+                # ALL is_final segments, so accumulate on is_final.
+                if msg.get("is_final"):
+                    final_segments.append(transcript)
+                    pending_partial = ""
+                    last_final_time = now
                 else:
-                    # default model — treat is_final as final
-                    if msg.get("is_final"):
-                        final_segments.append(transcript)
-                        last_final_time = now
+                    # Interim for the current (not-yet-finalized) segment. Keep
+                    # the longest so a tail the stream closes before finalizing
+                    # still makes it into the transcript.
+                    if len(transcript) > len(pending_partial):
+                        pending_partial = transcript
 
         except Exception as exc:
             logger.exception("deepgram receive error", error=str(exc))
@@ -249,10 +257,11 @@ class DeepgramProvider(STTProvider):
         # Build complete transcript
         if self._model in ("flux-general-en", "flux-general-multi"):
             result.complete_transcript = flux_latest.strip() or None
-        elif final_segments:
-            result.complete_transcript = " ".join(final_segments).strip()
-        elif result.partial_transcripts:
-            result.complete_transcript = max(result.partial_transcripts, key=len).strip() or None
+        elif final_segments or pending_partial:
+            parts = list(final_segments)
+            if pending_partial:
+                parts.append(pending_partial)
+            result.complete_transcript = " ".join(parts).strip() or None
 
         if result.complete_transcript:
             result.transcript_length = len(result.complete_transcript)

--- a/runner/src/coval_bench/providers/stt/deepgram.py
+++ b/runner/src/coval_bench/providers/stt/deepgram.py
@@ -58,16 +58,15 @@ class DeepgramProvider(STTProvider):
 
     def _build_websocket_url(self, sample_rate: int, channels: int) -> str:
         if self._model.startswith("flux-"):
-            # v2/listen uses a conversational TurnInfo-based protocol — it does
-            # NOT accept interim_results / no_delay (those are v1/listen params)
-            # and rejects the WS upgrade with HTTP 400 if either is present.
-            # `flux-general-multi` shares the same endpoint as `flux-general-en`;
-            # we don't pass a language hint so the multilingual model auto-detects.
+            if channels != 1:
+                raise ValueError(
+                    f"Flux models require mono audio (channels=1), got channels={channels}"
+                )
+            # v2/listen 400s on v1-only query params (channels/interim_results/no_delay).
             return (
                 "wss://api.deepgram.com/v2/listen"
                 f"?model={self._model}"
                 f"&sample_rate={sample_rate}"
-                f"&channels={channels}"
                 f"&encoding=linear16"
             )
         url = (
@@ -164,7 +163,7 @@ class DeepgramProvider(STTProvider):
     async def _receive(self, ws: Any, result: TranscriptionResult) -> None:
         final_segments: list[str] = []
         pending_partial: str = ""
-        flux_latest: str = ""
+        flux_turns: dict[int, str] = {}
         last_final_time: float | None = None
 
         try:
@@ -189,10 +188,8 @@ class DeepgramProvider(STTProvider):
                 if msg_type in ("UtteranceEnd", "Metadata", "Connected"):
                     continue
 
-                # flux v2/listen emits TurnInfo (not Results). Each TurnInfo
-                # carries a rolling top-level "transcript" + "words" array,
-                # NOT the channel.alternatives shape. Handle it inline so we
-                # can mark the latest TurnInfo as the best transcript so far.
+                # Flux transcript is cumulative within a turn and resets per
+                # turn, so key by turn_index and concatenate turns.
                 if msg_type == "TurnInfo":
                     transcript = str(msg.get("transcript", "")).strip()
                     if not transcript:
@@ -214,8 +211,10 @@ class DeepgramProvider(STTProvider):
                             transcript[:30] + "..." if len(transcript) > 30 else transcript
                         )
                     result.partial_transcripts.append(transcript)
-                    flux_latest = transcript
-                    last_final_time = now
+                    flux_turns[int(msg.get("turn_index", 0))] = transcript
+                    # EndOfTurn is the confirmed turn-final; Start/Update are partials.
+                    if msg.get("event") == "EndOfTurn":
+                        last_final_time = now
                     continue
 
                 transcript = self._extract_transcript(msg)
@@ -231,20 +230,14 @@ class DeepgramProvider(STTProvider):
 
                 result.partial_transcripts.append(transcript)
 
-                # Deepgram v1 chunks an utterance into non-overlapping pieces,
-                # each finalized by is_final=true. speech_final=true is only an
-                # endpointing flag riding on the last is_final before a pause —
-                # keying on it drops every is_final-only piece in between. Per
-                # Deepgram's docs the full transcript is the concatenation of
-                # ALL is_final segments, so accumulate on is_final.
+                # Full transcript is the concatenation of ALL is_final segments;
+                # speech_final alone drops the is_final-only pieces between pauses.
                 if msg.get("is_final"):
                     final_segments.append(transcript)
                     pending_partial = ""
                     last_final_time = now
                 else:
-                    # Interim for the current (not-yet-finalized) segment. Keep
-                    # the longest so a tail the stream closes before finalizing
-                    # still makes it into the transcript.
+                    # Keep the longest interim as the not-yet-finalized tail.
                     if len(transcript) > len(pending_partial):
                         pending_partial = transcript
 
@@ -256,7 +249,8 @@ class DeepgramProvider(STTProvider):
 
         # Build complete transcript
         if self._model in ("flux-general-en", "flux-general-multi"):
-            result.complete_transcript = flux_latest.strip() or None
+            joined = " ".join(flux_turns[i] for i in sorted(flux_turns)).strip()
+            result.complete_transcript = joined or None
         elif final_segments or pending_partial:
             parts = list(final_segments)
             if pending_partial:

--- a/runner/tests/providers/stt/fixtures/deepgram/events-flux-success.json
+++ b/runner/tests/providers/stt/fixtures/deepgram/events-flux-success.json
@@ -32,5 +32,23 @@
     ],
     "end_of_turn_confidence": 0.92,
     "sequence_id": 2
+  },
+  {
+    "type": "TurnInfo",
+    "request_id": "test-flux-request-001",
+    "event": "EndOfTurn",
+    "turn_index": 0,
+    "audio_window_start": 0.0,
+    "audio_window_end": 1.8,
+    "transcript": "hello world how are you",
+    "words": [
+      {"word": "hello", "punctuated_word": "Hello", "start": 0.1, "end": 0.4, "confidence": 0.97},
+      {"word": "world", "punctuated_word": "world", "start": 0.5, "end": 0.8, "confidence": 0.93},
+      {"word": "how", "punctuated_word": "how", "start": 1.0, "end": 1.2, "confidence": 0.95},
+      {"word": "are", "punctuated_word": "are", "start": 1.3, "end": 1.5, "confidence": 0.95},
+      {"word": "you", "punctuated_word": "you", "start": 1.6, "end": 1.8, "confidence": 0.95}
+    ],
+    "end_of_turn_confidence": 0.95,
+    "sequence_id": 3
   }
 ]

--- a/runner/tests/providers/stt/test_deepgram.py
+++ b/runner/tests/providers/stt/test_deepgram.py
@@ -445,3 +445,97 @@ async def test_deepgram_flux_multi_success(fake_api_key: SecretStr, audio_pcm_by
     assert result.complete_transcript == "hello world how are you"
     assert result.audio_to_final_seconds is not None
     assert result.audio_to_final_seconds >= 0
+
+
+# ---------------------------------------------------------------------------
+# Transcript assembly — keep ALL is_final segments, not just speech_final
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_deepgram_keeps_isfinal_only_segments(
+    fake_api_key: SecretStr, audio_pcm_bytes: bytes
+) -> None:
+    """nova-3: an is_final segment without speech_final must not be dropped.
+
+    Deepgram chunks long utterances into multiple is_final pieces, with
+    speech_final only on the last one before a pause. Keying assembly on
+    speech_final dropped the in-between pieces; we accumulate on is_final.
+    """
+    events: list[Any] = [
+        {"type": "Connected", "session_id": "test-isfinal"},
+        {
+            "type": "Results",
+            "is_final": True,
+            "speech_final": False,  # finalized piece, but not an endpoint
+            "channel": {"alternatives": [{"transcript": "the quick brown fox"}]},
+        },
+        {
+            "type": "Results",
+            "is_final": True,
+            "speech_final": True,  # endpoint — only this survived before the fix
+            "channel": {"alternatives": [{"transcript": "jumps over the lazy dog"}]},
+        },
+    ]
+    provider = DeepgramProvider(api_key=fake_api_key, model="nova-3")
+
+    with patch(
+        "coval_bench.providers.stt.deepgram.ws_client.connect",
+        return_value=_fake_connect(events),
+    ):
+        result = await provider.measure_ttft(
+            audio_data=audio_pcm_bytes,
+            channels=1,
+            sample_width=2,
+            sample_rate=16000,
+            realtime_resolution=0.5,
+        )
+
+    assert result.complete_transcript == "the quick brown fox jumps over the lazy dog"
+
+
+@pytest.mark.asyncio
+async def test_deepgram_includes_unfinalized_tail(
+    fake_api_key: SecretStr, audio_pcm_bytes: bytes
+) -> None:
+    """nova-3: a tail the stream closes before finalizing is still included.
+
+    After the last is_final, interim results keep arriving but never finalize.
+    The longest such interim is appended so the trailing words aren't lost.
+    """
+    events: list[Any] = [
+        {"type": "Connected", "session_id": "test-tail"},
+        {
+            "type": "Results",
+            "is_final": True,
+            "speech_final": True,
+            "channel": {"alternatives": [{"transcript": "first sentence"}]},
+        },
+        {
+            "type": "Results",
+            "is_final": False,
+            "speech_final": False,
+            "channel": {"alternatives": [{"transcript": "second"}]},
+        },
+        {
+            "type": "Results",
+            "is_final": False,
+            "speech_final": False,
+            "channel": {"alternatives": [{"transcript": "second sentence tail"}]},
+        },
+    ]
+    provider = DeepgramProvider(api_key=fake_api_key, model="nova-3")
+
+    with patch(
+        "coval_bench.providers.stt.deepgram.ws_client.connect",
+        return_value=_fake_connect(events),
+    ):
+        result = await provider.measure_ttft(
+            audio_data=audio_pcm_bytes,
+            channels=1,
+            sample_width=2,
+            sample_rate=16000,
+            realtime_resolution=0.5,
+        )
+
+    assert result.complete_transcript == "first sentence second sentence tail"

--- a/runner/tests/providers/stt/test_deepgram.py
+++ b/runner/tests/providers/stt/test_deepgram.py
@@ -114,11 +114,17 @@ def test_build_websocket_url_flux() -> None:
     assert url.startswith("wss://api.deepgram.com/v2/listen")
     assert "preview" not in url
     assert "flux-general-en" in url
-    assert "channels=1" in url
-    # v2/listen rejects interim_results / no_delay as unknown query params and
-    # closes the WS upgrade with HTTP 400 — both must be absent.
+    # v2/listen rejects v1-only query params as unknown and closes the WS upgrade
+    # with HTTP 400 — interim_results, no_delay AND channels must all be absent.
     assert "interim_results" not in url
     assert "no_delay" not in url
+    assert "channels" not in url
+
+
+def test_build_websocket_url_flux_rejects_non_mono() -> None:
+    p = make_provider("flux-general-en")
+    with pytest.raises(ValueError, match="Flux models require mono audio"):
+        p._build_websocket_url(16000, 2)
 
 
 def test_build_websocket_url_flux_multi() -> None:
@@ -127,11 +133,11 @@ def test_build_websocket_url_flux_multi() -> None:
     assert url.startswith("wss://api.deepgram.com/v2/listen")
     assert "preview" not in url
     assert "model=flux-general-multi" in url
-    assert "channels=1" in url
     # No language hint — multilingual model auto-detects.
     assert "language=" not in url
     assert "interim_results" not in url
     assert "no_delay" not in url
+    assert "channels" not in url
 
 
 # ---------------------------------------------------------------------------
@@ -392,6 +398,41 @@ async def test_deepgram_flux_success(fake_api_key: SecretStr, audio_pcm_bytes: b
     assert result.complete_transcript == "hello world how are you"
     assert result.audio_to_final_seconds is not None
     assert result.audio_to_final_seconds >= 0
+
+
+@pytest.mark.asyncio
+async def test_deepgram_flux_concatenates_multiple_turns(
+    fake_api_key: SecretStr, audio_pcm_bytes: bytes
+) -> None:
+    """flux: turns are concatenated by turn_index, not collapsed to the last turn.
+
+    The single-turn happy-path fixture can't distinguish concatenation from
+    last-turn-wins. This drives two turns (delivered out of order) so a revert to
+    keeping only the latest turn — or a switch that drops turn ordering — fails.
+    """
+    events = [
+        {"type": "Connected", "session_id": "test-flux-multi"},
+        {"type": "TurnInfo", "event": "StartOfTurn", "turn_index": 1, "transcript": "how"},
+        {"type": "TurnInfo", "event": "EndOfTurn", "turn_index": 1, "transcript": "how are you"},
+        {"type": "TurnInfo", "event": "StartOfTurn", "turn_index": 0, "transcript": "hello"},
+        {"type": "TurnInfo", "event": "EndOfTurn", "turn_index": 0, "transcript": "hello world"},
+    ]
+    provider = DeepgramProvider(api_key=fake_api_key, model="flux-general-en")
+
+    with patch(
+        "coval_bench.providers.stt.deepgram.ws_client.connect",
+        return_value=_fake_connect(events),
+    ):
+        result = await provider.measure_ttft(
+            audio_data=audio_pcm_bytes,
+            channels=1,
+            sample_width=2,
+            sample_rate=16000,
+            realtime_resolution=0.5,
+        )
+
+    # Ordered by turn_index regardless of arrival order; both turns present.
+    assert result.complete_transcript == "hello world how are you"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Switched Deepgram websocket usage to the v2 listen endpoint; removed incompatible query parameters and added a runtime check that Flux models require mono audio.
  * Revised streaming transcript assembly to store and order per-turn finals correctly and to preserve trailing interim text when the stream ends.

* **Tests**
  * Added tests covering Flux URL validation (mono), multi-turn final concatenation, is_final handling, and inclusion of unfinalized trailing transcripts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->