### PR TITLE
Fix/Warm librosa before traffic to fix inflated TTFA

### DIFF
--- a/runner/src/coval_bench/runner/orchestrator.py
+++ b/runner/src/coval_bench/runner/orchestrator.py
@@ -169,6 +169,20 @@ def _get_metrics() -> tuple[Any, Any]:
     return mod.compute_wer, mod.compute_rtf
 
 
+def _warm_audio_metrics() -> None:
+    """Absorb librosa's lazy numba/scipy import before any provider traffic.
+
+    The first ``first_audible_offset_ms`` call pulls in the stack (~18s on one
+    Cloud Run vCPU); mid-phase it freezes the event loop and inflates every
+    in-flight TTFA. Must run before provider warmup so the freeze can't idle
+    out freshly warmed connections, and before the run row exists — the loop
+    can't service SIGTERM during the freeze, so a row would strand at
+    'running'.
+    """
+    mod = importlib.import_module("coval_bench.metrics")
+    mod.first_audible_offset_ms(b"\x00\x00" * 1600, 16000)
+
+
 # ---------------------------------------------------------------------------
 # STT coroutine builder
 # ---------------------------------------------------------------------------
@@ -629,6 +643,15 @@ async def run_benchmarks(
 
     enabled_stt = [e for e in stt_matrix if e.enabled and not e.disabled]
     enabled_tts = [e for e in tts_matrix if e.enabled and not e.disabled]
+
+    # Before the pool opens: the synchronous ~18s freeze must not sit inside
+    # the SIGTERM-finalization window where a run row could strand at
+    # 'running'.  Errors are non-fatal — a broken stack surfaces per-result.
+    if benchmark_kind in ("tts", "both") and enabled_tts:
+        try:
+            _warm_audio_metrics()
+        except Exception as exc:
+            _log.warning("audio_metrics_warmup_failed", exc_info=exc)
 
     # ------------------------------------------------------------------
     # 2. Open DB pool + start run row

--- a/runner/tests/unit/test_orchestrator.py
+++ b/runner/tests/unit/test_orchestrator.py
@@ -1651,3 +1651,155 @@ async def test_tts_wer_compute_failure_marked_failed(settings: Settings) -> None
         assert by_metric["WER"].metric_value is None
         assert "wer blew up" in (by_metric["WER"].error or "")
         assert summary.status == str(RunStatus.PARTIAL)
+
+
+# ---------------------------------------------------------------------------
+# test_audio_metrics_warmed_before_provider_traffic
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_audio_metrics_warmed_before_provider_traffic(settings: Settings) -> None:
+    """librosa warm-up runs before provider warmup and any synthesis.
+
+    The first first_audible_offset_ms call imports the numba/scipy stack and
+    blocks the loop; landing it after provider warmup would idle out the warmed
+    connections, and landing it mid-phase would inflate in-flight TTFA.
+    """
+    order: list[str] = []
+
+    tts_result = TTSResult(
+        provider="elevenlabs",
+        model="eleven_flash_v2_5",
+        voice="IKne3meq5aSn9XLyUdCD",
+        ttfa_ms=120.0,
+        audio_path=None,
+        error=None,
+    )
+
+    async def _synthesize(*args: Any, **kwargs: Any) -> TTSResult:
+        order.append("synthesize")
+        return tts_result
+
+    async def _warmup(*args: Any, **kwargs: Any) -> None:
+        order.append("provider_warmup")
+
+    provider_inst = MagicMock()
+    provider_inst.synthesize = AsyncMock(side_effect=_synthesize)
+    provider_cls = MagicMock(return_value=provider_inst)
+    provider_cls.warmup = AsyncMock(side_effect=_warmup)
+
+    matrix = [
+        ProviderEntry(
+            provider="elevenlabs",
+            model="eleven_flash_v2_5",
+            voice="IKne3meq5aSn9XLyUdCD",
+            enabled=True,
+        )
+    ]
+
+    async with _orchestrator_env(
+        audio_path=Path("/nonexistent"),
+        tts_providers={"elevenlabs": provider_cls},
+    ) as _:
+        with patch(
+            "coval_bench.runner.orchestrator._warm_audio_metrics",
+            side_effect=lambda: order.append("warm"),
+        ) as warm_mock:
+            await run_benchmarks(
+                settings=settings,
+                benchmark_kind="tts",
+                smoke=True,
+                matrix_overrides=matrix,
+            )
+
+    warm_mock.assert_called_once()
+    assert "synthesize" in order
+    assert order[0] == "warm"
+    assert order.index("warm") < order.index("provider_warmup")
+
+
+@pytest.mark.asyncio
+async def test_audio_metrics_warmup_skipped_for_stt_only(
+    audio_file: Path, settings: Settings
+) -> None:
+    """STT-only runs never touch the TTS audio-metric stack."""
+    good = _good_transcription()
+    provider_inst = MagicMock()
+    provider_inst.measure_ttft = AsyncMock(return_value=good)
+    provider_cls = MagicMock(return_value=provider_inst)
+
+    matrix = [ProviderEntry(provider="deepgram", model="nova-2", enabled=True)]
+
+    async with _orchestrator_env(
+        audio_path=audio_file,
+        stt_items=[_make_dataset_item(audio_file)],
+        stt_providers={"deepgram": provider_cls},
+    ) as _:
+        with patch("coval_bench.runner.orchestrator._warm_audio_metrics") as warm_mock:
+            await run_benchmarks(
+                settings=settings,
+                benchmark_kind="stt",
+                smoke=True,
+                matrix_overrides=matrix,
+            )
+
+    warm_mock.assert_not_called()
+
+
+def test_warm_audio_metrics_real_call() -> None:
+    """The unmocked warm-up body runs against the real metrics stack.
+
+    Guards the dummy input against future first_audible_offset_ms validation
+    changes; a stale input would otherwise only surface at run start in prod.
+    """
+    from coval_bench.runner.orchestrator import _warm_audio_metrics
+
+    _warm_audio_metrics()
+
+
+@pytest.mark.asyncio
+async def test_audio_metrics_warmup_failure_non_fatal(settings: Settings) -> None:
+    """A warm-up failure degrades to a warning; the run still executes."""
+    tts_result = TTSResult(
+        provider="elevenlabs",
+        model="eleven_flash_v2_5",
+        voice="IKne3meq5aSn9XLyUdCD",
+        ttfa_ms=120.0,
+        audio_path=None,
+        error=None,
+    )
+
+    provider_inst = MagicMock()
+    provider_inst.synthesize = AsyncMock(return_value=tts_result)
+    provider_cls = MagicMock(return_value=provider_inst)
+    provider_cls.warmup = AsyncMock(return_value=None)
+
+    matrix = [
+        ProviderEntry(
+            provider="elevenlabs",
+            model="eleven_flash_v2_5",
+            voice="IKne3meq5aSn9XLyUdCD",
+            enabled=True,
+        )
+    ]
+
+    async with _orchestrator_env(
+        audio_path=Path("/nonexistent"),
+        tts_providers={"elevenlabs": provider_cls},
+    ) as _:
+        with patch(
+            "coval_bench.runner.orchestrator._warm_audio_metrics",
+            side_effect=ImportError("numba missing"),
+        ) as warm_mock:
+            summary = await run_benchmarks(
+                settings=settings,
+                benchmark_kind="tts",
+                smoke=True,
+                matrix_overrides=matrix,
+            )
+
+    warm_mock.assert_called_once()
+    provider_cls.warmup.assert_awaited_once()
+    provider_inst.synthesize.assert_awaited()
+    assert summary.status != str(RunStatus.FAILED)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Ensure audio-related libraries are loaded before TTS benchmark provider warmup when TTS is enabled and providers exist, improving reliability; failures during this warmup are non-fatal.

* **Tests**
  * Added tests verifying warmup runs before TTS provider traffic, is skipped for STT-only runs, includes an integration-style real-call, and tolerates warmup import failures without failing the run.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->