### PR TITLE
Pure-white chart cards + cream nav chrome

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -13,7 +13,7 @@
   --color-surface-elevated: #f5f4f0;
   --color-surface-tooltip: #fdfcf8;
   --color-surface-backdrop: rgba(10, 10, 10, 0.5);
-  --color-surface-overlay: rgba(253, 252, 248, 0.85);
+  --color-surface-overlay: rgba(242, 241, 238, 0.85);
 
   /* Text */
   --color-text-primary: #0a0a0a;

--- a/web/components/dashboard/AccuracyBarSection.tsx
+++ b/web/components/dashboard/AccuracyBarSection.tsx
@@ -37,7 +37,7 @@ const AccuracyBarSection: React.FC = () => {
         <h2 className="text-2xl font-light mb-2">Accuracy by Model</h2>
         <ExpandableDescription description={description} />
       </div>
-      <div className="h-64 border border-border-secondary rounded-lg bg-white p-4">
+      <div className="h-64 relative z-[2] border border-border-secondary rounded-lg bg-white p-4">
         <ResponsiveContainer width="100%" height="100%">
           <BarChart
             data={werBarDataWithColors}

--- a/web/components/dashboard/HeatmapSection.tsx
+++ b/web/components/dashboard/HeatmapSection.tsx
@@ -29,7 +29,7 @@ const HeatmapSection: React.FC = () => {
         className={`heatmap-container ${
           isMobile
             ? ""
-            : "border border-border-secondary rounded-lg bg-white p-4"
+            : "relative z-[2] border border-border-secondary rounded-lg bg-white p-4"
         }`}
       >
         <HeatmapPlot

--- a/web/components/dashboard/LatencyAccuracySection.tsx
+++ b/web/components/dashboard/LatencyAccuracySection.tsx
@@ -49,7 +49,7 @@ const LatencyAccuracySection: React.FC = () => {
         </div>
       </div>
 
-      <div className="h-64 border border-border-secondary rounded-lg bg-white p-4">
+      <div className="h-64 relative z-[2] border border-border-secondary rounded-lg bg-white p-4">
         <ResponsiveContainer width="100%" height="100%">
           <ScatterChart>
             <XAxis

--- a/web/components/dashboard/PerformanceDeltaSection.tsx
+++ b/web/components/dashboard/PerformanceDeltaSection.tsx
@@ -55,7 +55,7 @@ const PerformanceDeltaSection: React.FC = () => {
 
       <div
         ref={chartRef}
-        className="h-96 p-4 border border-border-secondary rounded-lg bg-white"
+        className="h-96 p-4 relative z-[2] border border-border-secondary rounded-lg bg-white"
         onMouseDown={handleMouseDown}
         style={{
           userSelect: "none",

--- a/web/components/dashboard/ViolinSection.tsx
+++ b/web/components/dashboard/ViolinSection.tsx
@@ -33,7 +33,7 @@ const ViolinSection: React.FC = () => {
         className={`${
           isMobile
             ? ""
-            : "border border-border-secondary rounded-lg bg-white p-4"
+            : "relative z-[2] border border-border-secondary rounded-lg bg-white p-4"
         }`}
       >
         <ViolinPlot

--- a/web/components/visualizations/TimelineChart.tsx
+++ b/web/components/visualizations/TimelineChart.tsx
@@ -62,7 +62,7 @@ const TimelineChart: React.FC = () => {
 
       <div
         ref={chartRef}
-        className="h-96 p-4 border border-border-secondary rounded-lg bg-white"
+        className="h-96 p-4 relative z-[2] border border-border-secondary rounded-lg bg-white"
         onMouseDown={handleMouseDown}
         style={{
           userSelect: "none",


### PR DESCRIPTION

<img width="1463" height="890" alt="image" src="https://github.com/user-attachments/assets/6f970f84-00b9-493e-835d-a920bb0e762e" />


## Summary
Two related visual fixes to better match the coval.ai cream branding on the TTS and STT dashboards.

### Pure-white chart cards
The chart cards are `bg-white`, but the global film-grain `.noise-overlay` (`fixed inset-0 z-[1]`, `mix-blend-mode: multiply`) was tinting them against the cream page. Added `relative z-[2]` to each chart card so it paints above the overlay and renders as pure white. `z-[2]` sits above the overlay (`z-[1]`) but well below the sidebar (`z-10`) and nav (`z-50`), so stacking is unchanged. The grain still shows on the cream page background around the cards.

Affected cards (TTS + STT):
- TimelineChart, ViolinSection, LatencyAccuracySection, AccuracyBarSection, HeatmapSection
- PerformanceDeltaSection (STT-only)

### Cream nav chrome
The page body was already `#f2f1ee`, but the header chrome used `--color-surface-overlay: rgba(253, 252, 248, 0.85)` — a near-white tint that painted a visible white strip across the top, unlike coval.ai where the nav blends into the cream. Retuned the token to the cream base `rgba(242, 241, 238, 0.85)`. This affects the top nav, the BENCHMARKS sub-nav bar, and the mobile model sheets — all now blend into the cream page.

## Test plan
- [ ] Load `/tts` and `/stt`: chart cards render pure white against the textured cream background.
- [ ] Top nav and BENCHMARKS sub-nav blend into the cream page (no white strip), matching coval.ai.
- [ ] Mobile model sheet still reads correctly with the cream overlay tint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Updated light theme overlay color for improved visual appearance
  * Enhanced visual layering of dashboard charts to improve depth and clarity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->