### PR TITLE
Absolutely center main and benchmarks nav links

### DIFF
--- a/web/components/layout/DashboardHeader.tsx
+++ b/web/components/layout/DashboardHeader.tsx
@@ -38,7 +38,7 @@ const DashboardHeader: React.FC = () => {
         <span className="absolute left-4 top-1/2 hidden -translate-y-1/2 font-mono text-xs uppercase tracking-wider text-text-tertiary sm:inline md:left-6">
           Benchmarks
         </span>
-        <div className="relative mx-auto flex h-full max-w-[1400px] items-center justify-center gap-1 px-4 md:px-6">
+        <div className="absolute left-1/2 top-0 flex h-full -translate-x-1/2 items-center gap-1 px-4 md:px-6">
           {SECTIONS.map((section) => {
             const active = pathname === section.href;
             return (

--- a/web/components/layout/GlobalNav.tsx
+++ b/web/components/layout/GlobalNav.tsx
@@ -185,8 +185,9 @@ const GlobalNav: React.FC<{
           />
         </a>
 
-        {/* Desktop nav groups */}
-        <nav className="hidden items-center gap-1 lg:flex">
+        {/* Desktop nav groups — absolutely centered on the viewport, independent
+            of the logo/CTA widths on either side. */}
+        <nav className="absolute left-1/2 top-1/2 hidden -translate-x-1/2 -translate-y-1/2 items-center gap-1 lg:flex">
           {NAV_GROUPS.map((group) => (
             <DesktopGroup key={group.label} group={group} />
           ))}


### PR DESCRIPTION
## What

Center the navigation links on the true page center, independent of the elements flanking them.

- **Global nav** ([GlobalNav.tsx](web/components/layout/GlobalNav.tsx)): the Product/Industries/Pricing/Resources/Company menu was laid out via `justify-between` between the logo (narrow) and the Log In / Get Started CTAs (wide), which pulled it left of center. It's now `absolute left-1/2 -translate-x-1/2`, pulled out of the flex flow — logo stays pinned left, CTAs pinned right, menu sits at the true viewport center.
- **Benchmarks secondary nav** ([DashboardHeader.tsx](web/components/layout/DashboardHeader.tsx)): the tab group (Text-to-Speech / Speech-to-Text / Playground) is now `absolute left-1/2 -translate-x-1/2` so its centering is mathematically independent of the "BENCHMARKS" label.

## Verification

Measured tab/menu group center vs viewport center in headless Chrome — **0px offset** across 1024 → 2200px widths for both navs. Logo and CTAs remain pinned and don't collide with the centered menu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated dashboard header navigation bar positioning to improve visual alignment consistency with the global fixed navigation structure.
  * Enhanced global navigation component layout with improved centering and viewport positioning for better coordination across the navigation hierarchy while maintaining responsive design behaviors on all screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->