### PR TITLE
Model selector visual updates

### DIFF
--- a/web/components/layout/DashboardHeader.tsx
+++ b/web/components/layout/DashboardHeader.tsx
@@ -36,7 +36,7 @@ const DashboardHeader: React.FC = () => {
         {/* Anchored to the full-width nav (not the centered container) so it
             always lines up with the logo's left margin, like the global nav. */}
         <span className="absolute left-4 top-1/2 hidden -translate-y-1/2 font-mono text-xs uppercase tracking-wider text-text-tertiary sm:inline md:left-6">
-          Benchmarks
+          Voice Model Benchmarks
         </span>
         <div className="relative mx-auto flex h-full max-w-[1400px] items-center justify-center gap-1 px-4 md:px-6">
           {SECTIONS.map((section) => {

--- a/web/components/layout/ModelSidebar.tsx
+++ b/web/components/layout/ModelSidebar.tsx
@@ -10,7 +10,6 @@ import { useDashboard } from "@/contexts/DashboardContext";
 
 const ModelSidebar: React.FC = () => {
   const {
-    sidebarTitle: title,
     normalizeProviderName,
     modelsByProvider,
     selectedModels,
@@ -24,10 +23,6 @@ const ModelSidebar: React.FC = () => {
         {/* Model Selection Content */}
         <div className="space-y-2">
           <div>
-            <div className="text-text-secondary text-xs font-medium mb-3 px-2">
-              {title}
-            </div>
-
             {Object.entries(modelsByProvider).map(([provider, models]) => (
               <div key={provider} className="mt-4 first:mt-0">
                 <div className="text-text-primary pt-1.5 pb-0.5 px-2 text-sm font-bold">

--- a/web/components/layout/ModelSidebar.tsx
+++ b/web/components/layout/ModelSidebar.tsx
@@ -6,7 +6,6 @@
 import React from "react";
 import { normalizeModelName } from "@/lib/utils/formatters";
 import { useDashboard } from "@/contexts/DashboardContext";
-import { useSidebarMenu } from "@/contexts/SidebarMenuContext";
 
 
 const ModelSidebar: React.FC = () => {
@@ -15,45 +14,14 @@ const ModelSidebar: React.FC = () => {
     normalizeProviderName,
     modelsByProvider,
     selectedModels,
-    sidebarCollapsed,
-    toggleSidebar: onToggleSidebar,
     toggleModelSelection: onToggleModelSelection,
   } = useDashboard();
-  const { expandedProviders, toggleProvider: onToggleProvider } =
-    useSidebarMenu();
 
   return (
-    <div
-      className={`hidden lg:flex flex-col fixed left-4 top-28 bottom-4 z-10 bg-surface-secondary backdrop-blur-2xl border border-border-primary rounded-3xl p-3 shadow-2xl transition-all duration-300 ${
-        sidebarCollapsed ? "w-16" : "w-64"
-      }`}
-    >
+    <div className="hidden lg:flex flex-col fixed left-4 top-28 bottom-4 z-10 py-3 w-64">
       {/* Scrollable content area */}
       <div className="flex-1 overflow-y-auto scrollbar-hide">
-      {/* Toggle Button */}
-      <button
-        onClick={onToggleSidebar}
-        className="w-full mb-4 p-2 hover:bg-hover-bg rounded-xl transition-colors flex items-center justify-center"
-        aria-label={sidebarCollapsed ? "Expand sidebar" : "Collapse sidebar"}
-      >
-        <svg
-          className="w-5 h-5"
-          fill="none"
-          stroke="currentColor"
-          viewBox="0 0 24 24"
-        >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth={2}
-            d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2.586a1 1 0 01-.293.707l-6.414 6.414a1 1 0 00-.293.707V17l-4 4v-6.586a1 1 0 00-.293-.707L3.293 7.293A1 1 0 013 6.586V4z"
-          />
-        </svg>
-      </button>
-
-      {/* Model Selection Content */}
-      {!sidebarCollapsed ? (
-        // Expanded state - show full model selection
+        {/* Model Selection Content */}
         <div className="space-y-2">
           <div>
             <div className="text-text-secondary text-xs font-medium mb-3 px-2">
@@ -61,63 +29,43 @@ const ModelSidebar: React.FC = () => {
             </div>
 
             {Object.entries(modelsByProvider).map(([provider, models]) => (
-              <div key={provider}>
-                <button
-                  onClick={() => onToggleProvider(provider)}
-                  className="flex items-center justify-between w-full text-text-secondary hover:text-text-primary py-1.5 px-2 rounded-lg text-xs transition-all duration-300 hover:bg-hover-bg group"
-                >
-                  <span className="font-medium">
-                    {normalizeProviderName(provider)}
-                  </span>
-                  <span
-                    className={`text-xs transition-all duration-300 ${
-                      expandedProviders[provider] ? "rotate-90" : ""
-                    }`}
-                  >
-                    ›
-                  </span>
-                </button>
-                {expandedProviders[provider] && (
-                  <div className="ml-3 space-y-0.5 mt-1 animate-in slide-in-from-top-1 duration-200">
-                    {models.map((model) => (
-                      <button
+              <div key={provider} className="mt-4 first:mt-0">
+                <div className="text-text-primary pt-1.5 pb-0.5 px-2 text-sm font-bold">
+                  {normalizeProviderName(provider)}
+                </div>
+                <div className="space-y-0">
+                  {models.map((model) => {
+                    const checked = selectedModels.includes(model);
+                    return (
+                      <label
                         key={model}
-                        onClick={() => onToggleModelSelection(model)}
-                        aria-label={`${
-                          selectedModels.includes(model)
-                            ? "Deselect"
-                            : "Select"
-                        } ${model} model`}
-                        className={`block text-left py-1.5 px-2 rounded-lg text-xs transition-all duration-300 w-full group ${
-                          selectedModels.includes(model)
-                            ? "bg-selected-bg text-text-primary shadow-md border border-selected-border"
-                            : "text-text-tertiary hover:text-text-secondary hover:bg-hover-bg"
-                        }`}
+                        className="flex items-center gap-2 py-1.5 px-2 rounded-lg text-xs cursor-pointer text-text-tertiary"
                       >
-                        <span className="truncate font-mono text-xs leading-tight">
+                        <input
+                          type="checkbox"
+                          checked={checked}
+                          onChange={() => onToggleModelSelection(model)}
+                          aria-label={`${
+                            checked ? "Deselect" : "Select"
+                          } ${model} model`}
+                          className="h-3.5 w-3.5 shrink-0 rounded accent-text-primary cursor-pointer"
+                        />
+                        <span
+                          className={`truncate text-xs leading-tight ${
+                            checked ? "text-text-primary" : ""
+                          }`}
+                        >
                           {normalizeModelName(model)}
                         </span>
-                      </button>
-                    ))}
-                  </div>
-                )}
+                      </label>
+                    );
+                  })}
+                </div>
               </div>
             ))}
           </div>
         </div>
-      ) : (
-        // Collapsed state - show compact indicators
-        <div className="space-y-3">
-          <div className="text-center">
-            <div className="text-xs text-text-secondary">
-              {selectedModels.length}
-            </div>
-            <div className="text-xs text-text-tertiary">models</div>
-          </div>
-        </div>
-      )}
       </div>
-
     </div>
   );
 };

--- a/web/hooks/useDashboardState.tsx
+++ b/web/hooks/useDashboardState.tsx
@@ -36,7 +36,7 @@ function adaptResult(row: Result): BenchmarkData {
 export function useDashboardState(page: "tts" | "stt") {
   // State declarations
   const [selectedModels, setSelectedModels] = useState<string[]>([]);
-  const [sidebarCollapsed, setSidebarCollapsed] = useState(true);
+  const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
   const [chartRefreshKey] = useState(0);
 
   const benchmarkParam = page === "tts" ? "TTS" : "STT";
@@ -436,9 +436,7 @@ export function useDashboardState(page: "tts" | "stt") {
   const pageSubtitle = page === "tts"
     ? "Compare performance metrics between different Text-to-Speech models for voice agent applications."
     : "Compare performance metrics between different Speech-to-Text models for voice agent applications.";
-  const sidebarTitle = page === "tts"
-    ? "Select TTS Models to Compare"
-    : "Select STT Models to Compare";
+  const sidebarTitle = "Models to Compare";
   const mobileSheetTitle = page === "tts"
     ? "Text-to-Speech Models"
     : "Speech-to-Text Models";


### PR DESCRIPTION
## Summary
Visual cleanup of the model filter sidebar (applies to both TTS and STT pages):

- Align the menu's left margin with the Coval logo
- Use the default sans font for model names (was monospace)
- Bold, slightly larger, darker provider names
- Always show each provider's models — removed the chevrons and expand/collapse functionality
- Tighten the gap between a provider name and its models
- Rename the sidebar header to "Models to Compare"
- Remove the hover state from model rows
- Round the checkbox corners

## Test plan
- [ ] Verify sidebar layout on both /tts and /stt
- [ ] Confirm all providers/models render expanded with no chevrons
- [ ] Confirm checkbox selection still toggles models in the charts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI Improvements**
  * The model selection sidebar is always displayed and no longer collapsible; model choices are shown as checkboxes for simpler selection.
  * Sidebar title is consistently "Models to Compare" across comparison pages and defaults to expanded on load.
  * Secondary header text updated to "Voice Model Benchmarks" for clearer context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->