### PR TITLE
Fix card centering with new model selection bar

### DIFF
--- a/web/components/charts/CustomBarChartTick.tsx
+++ b/web/components/charts/CustomBarChartTick.tsx
@@ -5,14 +5,17 @@ import React from "react";
 import { normalizeModelName } from "@/lib/utils/formatters";
 import { useThemeColors } from "@/hooks/useThemeColors";
 
+const modelFontSize = "10px";
+const providerFontSize = "9px";
+const mobileFontSize = "10px";
+
 const CustomBarChartTick: React.FC<{
   x?: number;
   y?: number;
   payload?: { value: string };
   getProviderForModel: (model: string) => string;
   isMobile?: boolean;
-  sidebarCollapsed?: boolean;
-}> = ({ x = 0, y = 0, payload, getProviderForModel, isMobile = false, sidebarCollapsed = true }) => {
+}> = ({ x = 0, y = 0, payload, getProviderForModel, isMobile = false }) => {
   const themeColors = useThemeColors();
 
   if (!payload) return null;
@@ -20,11 +23,6 @@ const CustomBarChartTick: React.FC<{
   const model = payload.value;
   const normalizedModel = normalizeModelName(model);
   const provider = getProviderForModel(model);
-
-  // Adjust font sizes based on sidebar state
-  const modelFontSize = sidebarCollapsed ? "12px" : "10px";
-  const providerFontSize = sidebarCollapsed ? "10px" : "9px";
-  const mobileFontSize = sidebarCollapsed ? "11px" : "10px";
 
   // Mobile: model name + provider, diagonal
   if (isMobile) {

--- a/web/components/charts/d3/ViolinPlot.tsx
+++ b/web/components/charts/d3/ViolinPlot.tsx
@@ -8,6 +8,11 @@ import * as d3 from "d3";
 import { ViolinPlotProps } from "@/types/chart.types";
 import { useThemeColors } from "@/hooks/useThemeColors";
 
+const modelFontSize = "10px";
+const providerFontSize = "9px";
+const axisLabelFontSize = "12px";
+const yAxisTickFontSize = "10px";
+
 const ViolinPlot: React.FC<ViolinPlotProps> = ({
   data,
   width = 800,
@@ -15,8 +20,7 @@ const ViolinPlot: React.FC<ViolinPlotProps> = ({
   getModelColor,
   getProviderForModel,
   normalizeModelName,
-  isMobile = false,
-  sidebarCollapsed = true
+  isMobile = false
 }) => {
   const svgRef = useRef<SVGSVGElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -25,12 +29,6 @@ const ViolinPlot: React.FC<ViolinPlotProps> = ({
     height
   });
   const themeColors = useThemeColors();
-
-  // Define font sizes based on sidebar state
-  const modelFontSize = sidebarCollapsed ? "12px" : "10px";
-  const providerFontSize = sidebarCollapsed ? "10px" : "9px";
-  const axisLabelFontSize = sidebarCollapsed ? "14px" : "12px";
-  const yAxisTickFontSize = sidebarCollapsed ? "12px" : "10px";
 
   // Handle responsive sizing
   useEffect(() => {
@@ -55,7 +53,7 @@ const ViolinPlot: React.FC<ViolinPlotProps> = ({
     handleResize();
     window.addEventListener("resize", handleResize);
 
-    // Also listen for sidebar changes by checking container size periodically
+    // Track container size changes that happen without a window resize
     const resizeObserver = new ResizeObserver(handleResize);
     if (containerRef.current) {
       resizeObserver.observe(containerRef.current);
@@ -464,7 +462,7 @@ const ViolinPlot: React.FC<ViolinPlotProps> = ({
           g.select(".violin-tooltip").remove();
         });
     });
-  }, [data, dimensions, getModelColor, getProviderForModel, normalizeModelName, isMobile, sidebarCollapsed, modelFontSize, providerFontSize, axisLabelFontSize, yAxisTickFontSize, themeColors]);
+  }, [data, dimensions, getModelColor, getProviderForModel, normalizeModelName, isMobile, themeColors]);
 
   if (data.data.length === 0) {
     return (

--- a/web/components/dashboard/AccuracyBarSection.tsx
+++ b/web/components/dashboard/AccuracyBarSection.tsx
@@ -25,7 +25,6 @@ const AccuracyBarSection: React.FC = () => {
     werBarDataWithColors,
     getProviderForModel,
     isMobile,
-    sidebarCollapsed,
     handleWERBarClick,
   } = useDashboard();
 
@@ -42,7 +41,7 @@ const AccuracyBarSection: React.FC = () => {
 
   return (
     <div className="mb-4">
-      <div className="w-[75vw] mx-auto relative z-[2] border border-border-secondary rounded-lg bg-white p-8">
+      <div className="relative z-[2] border border-border-secondary rounded-lg bg-white p-8">
         <SectionHeader
           label="Accuracy by Model"
           description={description}
@@ -67,7 +66,6 @@ const AccuracyBarSection: React.FC = () => {
                   <CustomBarChartTick
                     getProviderForModel={getProviderForModel}
                     isMobile={isMobile}
-                    sidebarCollapsed={sidebarCollapsed}
                   />
                 }
                 height={isMobile ? 100 : 80}

--- a/web/components/dashboard/HeatmapSection.tsx
+++ b/web/components/dashboard/HeatmapSection.tsx
@@ -17,7 +17,7 @@ const HeatmapSection: React.FC = () => {
         className={`heatmap-container ${
           isMobile
             ? ""
-            : "w-[75vw] mx-auto relative z-[2] border border-border-secondary rounded-lg bg-white p-8"
+            : "relative z-[2] border border-border-secondary rounded-lg bg-white p-8"
         }`}
       >
         <div className="flex justify-between items-start mb-4">

--- a/web/components/dashboard/KeyMetrics.tsx
+++ b/web/components/dashboard/KeyMetrics.tsx
@@ -31,7 +31,7 @@ const KeyMetrics: React.FC = () => {
   ];
 
   return (
-    <div className="grid grid-cols-4 gap-4 mb-4 w-[75vw] mx-auto">
+    <div className="grid grid-cols-4 gap-4 mb-4">
       {metrics.map((metric, index) => (
         <div
           key={index}

--- a/web/components/dashboard/LatencyAccuracySection.tsx
+++ b/web/components/dashboard/LatencyAccuracySection.tsx
@@ -49,7 +49,7 @@ const LatencyAccuracySection: React.FC = () => {
 
   return (
     <div className="mb-4">
-      <div className="w-[75vw] mx-auto relative z-[2] border border-border-secondary rounded-lg bg-white p-8">
+      <div className="relative z-[2] border border-border-secondary rounded-lg bg-white p-8">
         <SectionHeader
           label="Latency vs Accuracy"
           description={description}

--- a/web/components/dashboard/PerformanceDeltaSection.tsx
+++ b/web/components/dashboard/PerformanceDeltaSection.tsx
@@ -59,7 +59,7 @@ const PerformanceDeltaSection: React.FC = () => {
 
   return (
     <div className="mb-4">
-      <div className="w-[75vw] mx-auto p-8 relative z-[2] border border-border-secondary rounded-lg bg-white">
+      <div className="p-8 relative z-[2] border border-border-secondary rounded-lg bg-white">
         <SectionHeader
           label="Performance Delta Analysis"
           description={metricDescriptions.performanceGap}

--- a/web/components/dashboard/PerformanceRankings.tsx
+++ b/web/components/dashboard/PerformanceRankings.tsx
@@ -14,7 +14,7 @@ const PerformanceRankings: React.FC = () => {
 
   return (
     <div className="mb-4">
-      <div className="w-[75vw] mx-auto border border-border-secondary rounded-lg bg-white p-8">
+      <div className="border border-border-secondary rounded-lg bg-white p-8">
         <SectionHeader
           label="Performance Rankings"
           description={{

--- a/web/components/dashboard/ViolinSection.tsx
+++ b/web/components/dashboard/ViolinSection.tsx
@@ -17,8 +17,6 @@ const ViolinSection: React.FC = () => {
     getViolinData,
     getProviderForModel,
     isMobile,
-    sidebarCollapsed,
-    chartRefreshKey,
   } = useDashboard();
 
   const violinData = getViolinData();
@@ -41,7 +39,7 @@ const ViolinSection: React.FC = () => {
         className={`${
           isMobile
             ? ""
-            : "w-[75vw] mx-auto relative z-[2] border border-border-secondary rounded-lg bg-white p-8"
+            : "relative z-[2] border border-border-secondary rounded-lg bg-white p-8"
         }`}
       >
         <SectionHeader
@@ -59,8 +57,6 @@ const ViolinSection: React.FC = () => {
           getProviderForModel={getProviderForModel}
           normalizeModelName={normalizeModelName}
           isMobile={isMobile}
-          sidebarCollapsed={sidebarCollapsed}
-          key={`violin-${chartRefreshKey}-${sidebarCollapsed}`}
         />
       </div>
     </div>

--- a/web/components/layout/DashboardLayout.tsx
+++ b/web/components/layout/DashboardLayout.tsx
@@ -11,11 +11,7 @@ import MobileModelSheet from "@/components/layout/MobileModelSheet";
 import ModelSidebar from "@/components/layout/ModelSidebar";
 
 const DashboardLayout: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-  const { sidebarCollapsed, loading } = useDashboard();
-
-  // Offset for the content column so the fixed sidebar doesn't overlap it.
-  // The footer is intentionally left full-width (spanning under the sidebar).
-  const columnOffset = sidebarCollapsed ? "lg:ml-20" : "lg:ml-72";
+  const { loading } = useDashboard();
 
   return (
     <div className="min-h-screen bg-background text-text-primary">
@@ -23,26 +19,26 @@ const DashboardLayout: React.FC<{ children: React.ReactNode }> = ({ children }) 
       <MobileModelSheet />
       <ModelSidebar />
 
-      <div
-        className={`transition-all duration-300 pt-28 p-8 pb-24 lg:pb-8 overflow-x-hidden ${columnOffset} ${
-          sidebarCollapsed ? "lg:w-[calc(100vw-5rem)]" : "lg:w-[calc(100vw-18rem)]"
-        }`}
-      >
-        {loading && (
-          <div className="-mx-8 w-screen flex flex-col items-center justify-center min-h-[70vh] lg:-translate-x-9 bg-background text-text-primary">
-            <div className="w-6 h-6 border-[3px] border-spinner-track border-t-spinner-head rounded-full animate-spin" />
-            <h1 className="mt-6 text-base tracking-tight">
-              Loading benchmarks
-            </h1>
-          </div>
-        )}
+      {/* Below 1440px content fills the space right of the sidebar; from 1440px
+          the gutters go symmetric so content centers with the nav and footer. */}
+      <div className="pt-28 p-8 pb-24 lg:pb-8 overflow-x-hidden lg:ml-52 min-[90rem]:mr-52">
+        <div className="max-w-[1400px] mx-auto">
+          {loading && (
+            <div className="flex flex-col items-center justify-center min-h-[70vh] bg-background text-text-primary">
+              <div className="w-6 h-6 border-[3px] border-spinner-track border-t-spinner-head rounded-full animate-spin" />
+              <h1 className="mt-6 text-base tracking-tight">
+                Loading benchmarks
+              </h1>
+            </div>
+          )}
 
-        {!loading && (
-          <>
-            <div className="mb-16"></div>
-            {children}
-          </>
-        )}
+          {!loading && (
+            <>
+              <div className="mb-16"></div>
+              {children}
+            </>
+          )}
+        </div>
       </div>
 
       {!loading && <DashboardFooter />}

--- a/web/components/layout/ModelSidebar.tsx
+++ b/web/components/layout/ModelSidebar.tsx
@@ -17,7 +17,7 @@ const ModelSidebar: React.FC = () => {
   } = useDashboard();
 
   return (
-    <div className="hidden lg:flex flex-col fixed left-4 top-28 bottom-4 z-10 py-3 w-64">
+    <div className="hidden lg:flex flex-col fixed left-4 top-28 bottom-4 z-10 py-3 w-48">
       {/* Scrollable content area */}
       <div className="flex-1 overflow-y-auto scrollbar-hide">
         {/* Model Selection Content */}

--- a/web/components/visualizations/TimelineChart.tsx
+++ b/web/components/visualizations/TimelineChart.tsx
@@ -65,7 +65,7 @@ const TimelineChart: React.FC = () => {
 
   return (
     <div className="mb-4">
-      <div className="w-[75vw] mx-auto p-8 relative z-[2] border border-border-secondary rounded-lg bg-white">
+      <div className="p-8 relative z-[2] border border-border-secondary rounded-lg bg-white">
         <SectionHeader
           label={
             activeTab === "tts"

--- a/web/hooks/useDashboardState.tsx
+++ b/web/hooks/useDashboardState.tsx
@@ -36,8 +36,6 @@ function adaptResult(row: Result): BenchmarkData {
 export function useDashboardState(page: "tts" | "stt") {
   // State declarations
   const [selectedModels, setSelectedModels] = useState<string[]>([]);
-  const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
-  const [chartRefreshKey] = useState(0);
 
   const benchmarkParam = page === "tts" ? "TTS" : "STT";
 
@@ -153,14 +151,6 @@ export function useDashboardState(page: "tts" | "stt") {
     },
     []
   );
-
-  const toggleSidebar = useCallback(() => {
-    setSidebarCollapsed((prev) => !prev);
-    // Wait for CSS transition to complete (300ms), then trigger resize
-    setTimeout(() => {
-      window.dispatchEvent(new Event("resize"));
-    }, 300);
-  }, []);
 
   // Heatmap scaling for mobile
   useEffect(() => {
@@ -541,13 +531,10 @@ export function useDashboardState(page: "tts" | "stt") {
     modelsByProvider,
 
     // UI state
-    sidebarCollapsed,
     isMobile,
-    chartRefreshKey,
 
     // Actions
     toggleModelSelection,
-    toggleSidebar,
 
     // Timeline
     isDragging,

--- a/web/types/chart.types.ts
+++ b/web/types/chart.types.ts
@@ -25,7 +25,6 @@ export interface ViolinPlotProps {
   getProviderForModel: (model: string) => string;
   normalizeModelName: (model: string) => string;
   isMobile?: boolean;
-  sidebarCollapsed?: boolean;
 }
 
 export interface TooltipProps {


### PR DESCRIPTION
Rob updated the model bar and it pushed the viewport off center. This updates the card centering so that it correctly fills the screen at a variety of widths.

I also used this opportunity to clean up some dead code and do a little FE refactoring.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reduced sidebar width for improved dashboard layout efficiency.
  * Simplified dashboard content layout with fixed margins and max-width constraints.
  * Removed dynamic sidebar offset calculations in favor of fixed layout values.
  * Standardized chart container styling across dashboard sections.
  * Enhanced chart rendering to respond to theme color changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->