### PR TITLE
Add PostHog analytics to the API and runner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,4 @@ runner/.uv-cache/
 
 # Playground internal docs (per Loren's PR #26 R4-1 review)
 PLAYGROUND.md
+.env*.local

--- a/runner/pyproject.toml
+++ b/runner/pyproject.toml
@@ -38,6 +38,8 @@ dependencies = [
     # WER
     "jiwer>=3.0",
     "whisper-normalizer>=0.0.10",
+    # Analytics
+    "posthog>=3.0",
 ]
 
 [project.optional-dependencies]
@@ -126,6 +128,10 @@ ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
 module = "aiohttp.*"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "posthog.*"
 ignore_missing_imports = true
 
 [tool.coverage.run]

--- a/runner/src/coval_bench/api/app.py
+++ b/runner/src/coval_bench/api/app.py
@@ -15,12 +15,14 @@ and all five routers.
 
 from __future__ import annotations
 
+import atexit
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 
 import structlog
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from posthog import Posthog
 from slowapi.errors import RateLimitExceeded
 from slowapi.middleware import SlowAPIMiddleware
 
@@ -47,10 +49,21 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     @asynccontextmanager
     async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         logger.info("api_startup", runner_sha=resolved.runner_sha)
+        posthog_client: Posthog | None = None
+        if not resolved.posthog_disabled and resolved.posthog_project_token:
+            posthog_client = Posthog(
+                resolved.posthog_project_token,
+                host=resolved.posthog_host,
+                enable_exception_autocapture=True,
+            )
+            atexit.register(posthog_client.shutdown)
+        app.state.posthog = posthog_client
         async with lifespan_pool(resolved) as pool:
             app.state.pool = pool
             app.state.settings = resolved
             yield
+        if posthog_client is not None:
+            posthog_client.flush()  # type: ignore[no-untyped-call]
         logger.info("api_shutdown")
 
     app = FastAPI(

--- a/runner/src/coval_bench/api/app.py
+++ b/runner/src/coval_bench/api/app.py
@@ -51,19 +51,29 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         logger.info("api_startup", runner_sha=resolved.runner_sha)
         posthog_client: Posthog | None = None
         if not resolved.posthog_disabled and resolved.posthog_project_token:
-            posthog_client = Posthog(
-                resolved.posthog_project_token,
-                host=resolved.posthog_host,
-                enable_exception_autocapture=True,
-            )
-            atexit.register(posthog_client.shutdown)
+            try:
+                posthog_client = Posthog(
+                    resolved.posthog_project_token,
+                    host=resolved.posthog_host,
+                    enable_exception_autocapture=True,
+                )
+                atexit.register(posthog_client.shutdown)
+            except Exception:
+                logger.warning("posthog_init_failed", exc_info=True)
+                posthog_client = None
         app.state.posthog = posthog_client
-        async with lifespan_pool(resolved) as pool:
-            app.state.pool = pool
-            app.state.settings = resolved
-            yield
-        if posthog_client is not None:
-            posthog_client.flush()  # type: ignore[no-untyped-call]
+        try:
+            async with lifespan_pool(resolved) as pool:
+                app.state.pool = pool
+                app.state.settings = resolved
+                yield
+        finally:
+            if posthog_client is not None:
+                try:
+                    posthog_client.shutdown()  # type: ignore[no-untyped-call]
+                except Exception:
+                    logger.warning("posthog_shutdown_failed", exc_info=True)
+                atexit.unregister(posthog_client.shutdown)
         logger.info("api_shutdown")
 
     app = FastAPI(

--- a/runner/src/coval_bench/api/deps.py
+++ b/runner/src/coval_bench/api/deps.py
@@ -50,6 +50,6 @@ def capture_api_event(client: Posthog | None, event: str, properties: dict[str, 
     if client is None:
         return
     try:
-        client.capture("coval-bench-api", event, properties=properties)
+        client.capture(event, distinct_id="coval-bench-api", properties=properties)
     except Exception:
         logger.warning("posthog_capture_failed", event_name=event, exc_info=True)

--- a/runner/src/coval_bench/api/deps.py
+++ b/runner/src/coval_bench/api/deps.py
@@ -10,9 +10,10 @@ populated during the FastAPI lifespan (see ``app.py``).
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, cast
 
 from fastapi import HTTPException
+from posthog import Posthog
 from psycopg_pool import AsyncConnectionPool
 from starlette.requests import Request
 
@@ -34,3 +35,8 @@ def get_settings(request: Request) -> Settings:
     """Return the Settings instance from app state."""
     settings: Settings = request.app.state.settings
     return settings
+
+
+def get_posthog(request: Request) -> Posthog | None:
+    """Return the PostHog client from app state, or None if analytics is disabled."""
+    return cast("Posthog | None", request.app.state.posthog)

--- a/runner/src/coval_bench/api/deps.py
+++ b/runner/src/coval_bench/api/deps.py
@@ -12,12 +12,15 @@ from __future__ import annotations
 
 from typing import Any, cast
 
+import structlog
 from fastapi import HTTPException
 from posthog import Posthog
 from psycopg_pool import AsyncConnectionPool
 from starlette.requests import Request
 
 from coval_bench.config import Settings
+
+logger = structlog.get_logger("coval_bench.api")
 
 
 async def get_pool(request: Request) -> AsyncConnectionPool[Any]:
@@ -40,3 +43,13 @@ def get_settings(request: Request) -> Settings:
 def get_posthog(request: Request) -> Posthog | None:
     """Return the PostHog client from app state, or None if analytics is disabled."""
     return cast("Posthog | None", request.app.state.posthog)
+
+
+def capture_api_event(client: Posthog | None, event: str, properties: dict[str, Any]) -> None:
+    """Best-effort PostHog capture for API routes; never fails the request."""
+    if client is None:
+        return
+    try:
+        client.capture("coval-bench-api", event, properties=properties)
+    except Exception:
+        logger.warning("posthog_capture_failed", event_name=event, exc_info=True)

--- a/runner/src/coval_bench/api/deps.py
+++ b/runner/src/coval_bench/api/deps.py
@@ -50,6 +50,8 @@ def capture_api_event(client: Posthog | None, event: str, properties: dict[str, 
     if client is None:
         return
     try:
-        client.capture(event, distinct_id="coval-bench-api", properties=properties)
+        client.capture(
+            event, distinct_id="coval-bench-api", properties=properties, disable_geoip=True
+        )
     except Exception:
         logger.warning("posthog_capture_failed", event_name=event, exc_info=True)

--- a/runner/src/coval_bench/api/routers/leaderboard.py
+++ b/runner/src/coval_bench/api/routers/leaderboard.py
@@ -26,7 +26,7 @@ from posthog import Posthog
 from psycopg_pool import AsyncConnectionPool
 from starlette.requests import Request
 
-from coval_bench.api.deps import get_pool, get_posthog
+from coval_bench.api.deps import capture_api_event, get_pool, get_posthog
 from coval_bench.api.ratelimit import limiter
 from coval_bench.api.schemas import LeaderboardEntry, LeaderboardResponse
 
@@ -126,16 +126,15 @@ async def get_leaderboard(
         entry_rows = await rows.fetchall()
 
     entries = [LeaderboardEntry.model_validate(r) for r in entry_rows]
-    if posthog_client is not None:
-        posthog_client.capture(
-            "coval-bench-api",
-            "leaderboard queried",
-            properties={
-                "metric": metric,
-                "benchmark": benchmark,
-                "window": window,
-                "entry_count": len(entries),
-                "$process_person_profile": False,
-            },
-        )
+    capture_api_event(
+        posthog_client,
+        "leaderboard queried",
+        {
+            "metric": metric,
+            "benchmark": benchmark,
+            "window": window,
+            "entry_count": len(entries),
+            "$process_person_profile": False,
+        },
+    )
     return LeaderboardResponse(metric=metric, window=window, entries=entries)

--- a/runner/src/coval_bench/api/routers/leaderboard.py
+++ b/runner/src/coval_bench/api/routers/leaderboard.py
@@ -22,10 +22,11 @@ from typing import Any, Literal
 import psycopg.rows
 import structlog
 from fastapi import APIRouter, Depends, HTTPException, Query
+from posthog import Posthog
 from psycopg_pool import AsyncConnectionPool
 from starlette.requests import Request
 
-from coval_bench.api.deps import get_pool
+from coval_bench.api.deps import get_pool, get_posthog
 from coval_bench.api.ratelimit import limiter
 from coval_bench.api.schemas import LeaderboardEntry, LeaderboardResponse
 
@@ -89,6 +90,7 @@ async def get_leaderboard(
     benchmark: BenchmarkLiteral = Query(...),
     window: WindowLiteral = Query(default="24h"),
     pool: AsyncConnectionPool[Any] = Depends(get_pool),
+    posthog_client: Posthog | None = Depends(get_posthog),
 ) -> LeaderboardResponse:
     """Return leaderboard entries sorted ascending by average metric value.
 
@@ -124,4 +126,16 @@ async def get_leaderboard(
         entry_rows = await rows.fetchall()
 
     entries = [LeaderboardEntry.model_validate(r) for r in entry_rows]
+    if posthog_client is not None:
+        posthog_client.capture(
+            "coval-bench-api",
+            "leaderboard queried",
+            properties={
+                "metric": metric,
+                "benchmark": benchmark,
+                "window": window,
+                "entry_count": len(entries),
+                "$process_person_profile": False,
+            },
+        )
     return LeaderboardResponse(metric=metric, window=window, entries=entries)

--- a/runner/src/coval_bench/api/routers/leaderboard.py
+++ b/runner/src/coval_bench/api/routers/leaderboard.py
@@ -128,7 +128,7 @@ async def get_leaderboard(
     entries = [LeaderboardEntry.model_validate(r) for r in entry_rows]
     capture_api_event(
         posthog_client,
-        "leaderboard queried",
+        "leaderboard_queried",
         {
             "metric": metric,
             "benchmark": benchmark,

--- a/runner/src/coval_bench/api/routers/providers.py
+++ b/runner/src/coval_bench/api/routers/providers.py
@@ -17,9 +17,11 @@ No DB hit is made by this endpoint.
 from __future__ import annotations
 
 import structlog
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
+from posthog import Posthog
 from starlette.requests import Request
 
+from coval_bench.api.deps import get_posthog
 from coval_bench.api.ratelimit import limiter
 from coval_bench.api.schemas import ModelInfo, ProviderInfo, ProvidersResponse
 from coval_bench.runner.config import DEFAULT_STT_MATRIX, DEFAULT_TTS_MATRIX, ProviderEntry
@@ -79,11 +81,25 @@ def _describe() -> ProvidersResponse:
 
 @router.get("/providers", response_model=ProvidersResponse)
 @limiter.limit("60/minute")
-async def get_providers(request: Request) -> ProvidersResponse:
+async def get_providers(
+    request: Request,
+    posthog_client: Posthog | None = Depends(get_posthog),
+) -> ProvidersResponse:
     """Return the catalogue of benchmarked providers and models.
 
     Sourced from the full runner matrix (all entries, not just enabled ones).
     Each model includes a ``disabled`` flag that the frontend can use to
     hide or grey out models that are known but not actively benchmarked.
     """
-    return _describe()
+    response = _describe()
+    if posthog_client is not None:
+        posthog_client.capture(
+            "coval-bench-api",
+            "providers listed",
+            properties={
+                "stt_provider_count": len(response.stt),
+                "tts_provider_count": len(response.tts),
+                "$process_person_profile": False,
+            },
+        )
+    return response

--- a/runner/src/coval_bench/api/routers/providers.py
+++ b/runner/src/coval_bench/api/routers/providers.py
@@ -94,7 +94,7 @@ async def get_providers(
     response = _describe()
     capture_api_event(
         posthog_client,
-        "providers listed",
+        "providers_listed",
         {
             "stt_provider_count": len(response.stt),
             "tts_provider_count": len(response.tts),

--- a/runner/src/coval_bench/api/routers/providers.py
+++ b/runner/src/coval_bench/api/routers/providers.py
@@ -21,7 +21,7 @@ from fastapi import APIRouter, Depends
 from posthog import Posthog
 from starlette.requests import Request
 
-from coval_bench.api.deps import get_posthog
+from coval_bench.api.deps import capture_api_event, get_posthog
 from coval_bench.api.ratelimit import limiter
 from coval_bench.api.schemas import ModelInfo, ProviderInfo, ProvidersResponse
 from coval_bench.runner.config import DEFAULT_STT_MATRIX, DEFAULT_TTS_MATRIX, ProviderEntry
@@ -92,14 +92,13 @@ async def get_providers(
     hide or grey out models that are known but not actively benchmarked.
     """
     response = _describe()
-    if posthog_client is not None:
-        posthog_client.capture(
-            "coval-bench-api",
-            "providers listed",
-            properties={
-                "stt_provider_count": len(response.stt),
-                "tts_provider_count": len(response.tts),
-                "$process_person_profile": False,
-            },
-        )
+    capture_api_event(
+        posthog_client,
+        "providers listed",
+        {
+            "stt_provider_count": len(response.stt),
+            "tts_provider_count": len(response.tts),
+            "$process_person_profile": False,
+        },
+    )
     return response

--- a/runner/src/coval_bench/api/routers/results.py
+++ b/runner/src/coval_bench/api/routers/results.py
@@ -220,7 +220,7 @@ async def list_results(
     results = [ResultOut.model_validate(r) for r in result_rows]
     capture_api_event(
         posthog_client,
-        "results queried",
+        "results_queried",
         {
             "provider": provider,
             "benchmark": benchmark,

--- a/runner/src/coval_bench/api/routers/results.py
+++ b/runner/src/coval_bench/api/routers/results.py
@@ -36,7 +36,7 @@ from posthog import Posthog
 from psycopg_pool import AsyncConnectionPool
 from starlette.requests import Request
 
-from coval_bench.api.deps import get_pool, get_posthog
+from coval_bench.api.deps import capture_api_event, get_pool, get_posthog
 from coval_bench.api.ratelimit import limiter
 from coval_bench.api.schemas import ResultOut, ResultsResponse
 from coval_bench.config import get_settings
@@ -218,21 +218,20 @@ async def list_results(
         result_rows = await rows.fetchall()
 
     results = [ResultOut.model_validate(r) for r in result_rows]
-    if posthog_client is not None:
-        posthog_client.capture(
-            "coval-bench-api",
-            "results queried",
-            properties={
-                "provider": provider,
-                "benchmark": benchmark,
-                "metric_type": resolved_metric,
-                "window": window,
-                "has_since_filter": since is not None,
-                "has_until_filter": until is not None,
-                "include_failed": include_failed,
-                "result_count": len(results),
-                "limit": limit,
-                "$process_person_profile": False,
-            },
-        )
+    capture_api_event(
+        posthog_client,
+        "results queried",
+        {
+            "provider": provider,
+            "benchmark": benchmark,
+            "metric_type": resolved_metric,
+            "window": window,
+            "has_since_filter": since is not None,
+            "has_until_filter": until is not None,
+            "include_failed": include_failed,
+            "result_count": len(results),
+            "limit": limit,
+            "$process_person_profile": False,
+        },
+    )
     return ResultsResponse(results=results)

--- a/runner/src/coval_bench/api/routers/results.py
+++ b/runner/src/coval_bench/api/routers/results.py
@@ -32,10 +32,11 @@ from typing import Any, Literal
 import psycopg.rows
 import structlog
 from fastapi import APIRouter, Depends, HTTPException, Query
+from posthog import Posthog
 from psycopg_pool import AsyncConnectionPool
 from starlette.requests import Request
 
-from coval_bench.api.deps import get_pool
+from coval_bench.api.deps import get_pool, get_posthog
 from coval_bench.api.ratelimit import limiter
 from coval_bench.api.schemas import ResultOut, ResultsResponse
 from coval_bench.config import get_settings
@@ -122,6 +123,7 @@ async def list_results(
         description="Maximum rows to return (1–100000, default 100000).",
     ),
     pool: AsyncConnectionPool[Any] = Depends(get_pool),
+    posthog_client: Posthog | None = Depends(get_posthog),
 ) -> ResultsResponse:
     """Return a newest-first page of successful benchmark results.
 
@@ -216,4 +218,21 @@ async def list_results(
         result_rows = await rows.fetchall()
 
     results = [ResultOut.model_validate(r) for r in result_rows]
+    if posthog_client is not None:
+        posthog_client.capture(
+            "coval-bench-api",
+            "results queried",
+            properties={
+                "provider": provider,
+                "benchmark": benchmark,
+                "metric_type": resolved_metric,
+                "window": window,
+                "has_since_filter": since is not None,
+                "has_until_filter": until is not None,
+                "include_failed": include_failed,
+                "result_count": len(results),
+                "limit": limit,
+                "$process_person_profile": False,
+            },
+        )
     return ResultsResponse(results=results)

--- a/runner/src/coval_bench/api/routers/runs.py
+++ b/runner/src/coval_bench/api/routers/runs.py
@@ -18,7 +18,7 @@ from posthog import Posthog
 from psycopg_pool import AsyncConnectionPool
 from starlette.requests import Request
 
-from coval_bench.api.deps import get_pool, get_posthog
+from coval_bench.api.deps import capture_api_event, get_pool, get_posthog
 from coval_bench.api.ratelimit import limiter
 from coval_bench.api.schemas import RunOut, RunsResponse
 
@@ -65,15 +65,14 @@ async def list_runs(
     next_before: int | None = None
     if len(runs) == limit:
         next_before = min(r.id for r in runs)
-    if posthog_client is not None:
-        posthog_client.capture(
-            "coval-bench-api",
-            "runs listed",
-            properties={
-                "limit": limit,
-                "has_cursor": before is not None,
-                "run_count": len(runs),
-                "$process_person_profile": False,
-            },
-        )
+    capture_api_event(
+        posthog_client,
+        "runs listed",
+        {
+            "limit": limit,
+            "has_cursor": before is not None,
+            "run_count": len(runs),
+            "$process_person_profile": False,
+        },
+    )
     return RunsResponse(runs=runs, next_before=next_before)

--- a/runner/src/coval_bench/api/routers/runs.py
+++ b/runner/src/coval_bench/api/routers/runs.py
@@ -14,10 +14,11 @@ from typing import Any
 import psycopg.rows
 import structlog
 from fastapi import APIRouter, Depends, Query
+from posthog import Posthog
 from psycopg_pool import AsyncConnectionPool
 from starlette.requests import Request
 
-from coval_bench.api.deps import get_pool
+from coval_bench.api.deps import get_pool, get_posthog
 from coval_bench.api.ratelimit import limiter
 from coval_bench.api.schemas import RunOut, RunsResponse
 
@@ -42,6 +43,7 @@ async def list_runs(
     limit: int = Query(default=50, ge=1, le=200),
     before: int | None = Query(default=None),
     pool: AsyncConnectionPool[Any] = Depends(get_pool),
+    posthog_client: Posthog | None = Depends(get_posthog),
 ) -> RunsResponse:
     """Return a newest-first page of benchmark runs.
 
@@ -63,4 +65,15 @@ async def list_runs(
     next_before: int | None = None
     if len(runs) == limit:
         next_before = min(r.id for r in runs)
+    if posthog_client is not None:
+        posthog_client.capture(
+            "coval-bench-api",
+            "runs listed",
+            properties={
+                "limit": limit,
+                "has_cursor": before is not None,
+                "run_count": len(runs),
+                "$process_person_profile": False,
+            },
+        )
     return RunsResponse(runs=runs, next_before=next_before)

--- a/runner/src/coval_bench/api/routers/runs.py
+++ b/runner/src/coval_bench/api/routers/runs.py
@@ -67,7 +67,7 @@ async def list_runs(
         next_before = min(r.id for r in runs)
     capture_api_event(
         posthog_client,
-        "runs listed",
+        "runs_listed",
         {
             "limit": limit,
             "has_cursor": before is not None,

--- a/runner/src/coval_bench/config.py
+++ b/runner/src/coval_bench/config.py
@@ -76,6 +76,11 @@ class Settings(BaseSettings):
     # the Google STT provider is enabled (optional `google-stt` extra).
     google_project_id: str | None = None
 
+    # --- Analytics ---
+    posthog_project_token: str = ""
+    posthog_host: str = "https://us.i.posthog.com"
+    posthog_disabled: bool = False
+
     # --- API ---
     cors_origins: list[str] = [
         "https://benchmarks.coval.ai",

--- a/runner/src/coval_bench/runner/orchestrator.py
+++ b/runner/src/coval_bench/runner/orchestrator.py
@@ -578,6 +578,17 @@ async def _run_tts_item(
 # ---------------------------------------------------------------------------
 
 
+def _emit_posthog(client: Posthog | None, event: str, properties: dict[str, Any]) -> None:
+    """Best-effort run-event capture + flush; never raises into the run outcome."""
+    if client is None:
+        return
+    try:
+        client.capture("coval-bench-runner", event, properties=properties)
+        client.flush()  # type: ignore[no-untyped-call]
+    except Exception:
+        _log.warning("posthog_emit_failed", event_name=event, exc_info=True)
+
+
 async def run_benchmarks(
     *,
     settings: Settings,
@@ -609,12 +620,16 @@ async def run_benchmarks(
 
     posthog_client: Posthog | None = None
     if not settings.posthog_disabled and settings.posthog_project_token:
-        posthog_client = Posthog(
-            settings.posthog_project_token,
-            host=settings.posthog_host,
-            enable_exception_autocapture=True,
-        )
-        atexit.register(posthog_client.shutdown)
+        try:
+            posthog_client = Posthog(
+                settings.posthog_project_token,
+                host=settings.posthog_host,
+                enable_exception_autocapture=True,
+            )
+            atexit.register(posthog_client.shutdown)
+        except Exception:
+            _log.warning("posthog_init_failed", exc_info=True)
+            posthog_client = None
 
     # ------------------------------------------------------------------
     # 1. Resolve + filter provider matrix
@@ -835,22 +850,20 @@ async def run_benchmarks(
                 fail_count=fail_count,
                 duration_s=duration_s,
             )
-            if posthog_client is not None:
-                posthog_client.capture(
-                    "coval-bench-runner",
-                    "benchmark run completed",
-                    properties={
-                        "status": str(final_status),
-                        "total_results": total_results,
-                        "success_count": success_count,
-                        "fail_count": fail_count,
-                        "duration_s": duration_s,
-                        "benchmark_kind": benchmark_kind,
-                        "smoke": smoke,
-                        "$process_person_profile": False,
-                    },
-                )
-                posthog_client.flush()  # type: ignore[no-untyped-call]
+            _emit_posthog(
+                posthog_client,
+                "benchmark run completed",
+                {
+                    "status": str(final_status),
+                    "total_results": total_results,
+                    "success_count": success_count,
+                    "fail_count": fail_count,
+                    "duration_s": duration_s,
+                    "benchmark_kind": benchmark_kind,
+                    "smoke": smoke,
+                    "$process_person_profile": False,
+                },
+            )
             return summary
 
         except asyncio.CancelledError:
@@ -890,23 +903,21 @@ async def run_benchmarks(
                 fail_count=fail_count,
                 duration_s=sigterm_duration_s,
             )
-            if posthog_client is not None:
-                posthog_client.capture(
-                    "coval-bench-runner",
-                    "benchmark run completed",
-                    properties={
-                        "status": str(RunStatus.PARTIAL),
-                        "total_results": total_results,
-                        "success_count": success_count,
-                        "fail_count": fail_count,
-                        "duration_s": sigterm_duration_s,
-                        "benchmark_kind": benchmark_kind,
-                        "smoke": smoke,
-                        "sigterm": True,
-                        "$process_person_profile": False,
-                    },
-                )
-                posthog_client.flush()  # type: ignore[no-untyped-call]
+            _emit_posthog(
+                posthog_client,
+                "benchmark run completed",
+                {
+                    "status": str(RunStatus.PARTIAL),
+                    "total_results": total_results,
+                    "success_count": success_count,
+                    "fail_count": fail_count,
+                    "duration_s": sigterm_duration_s,
+                    "benchmark_kind": benchmark_kind,
+                    "smoke": smoke,
+                    "sigterm": True,
+                    "$process_person_profile": False,
+                },
+            )
             return RunSummary(
                 run_id=run_id,
                 started_at=started_at,
@@ -938,17 +949,15 @@ async def run_benchmarks(
                     run_id=run_id,
                     exc_info=write_exc,
                 )
-            if posthog_client is not None:
-                posthog_client.capture(
-                    "coval-bench-runner",
-                    "benchmark run failed",
-                    properties={
-                        "benchmark_kind": benchmark_kind,
-                        "smoke": smoke,
-                        "$process_person_profile": False,
-                    },
-                )
-                posthog_client.flush()  # type: ignore[no-untyped-call]
+            _emit_posthog(
+                posthog_client,
+                "benchmark run failed",
+                {
+                    "benchmark_kind": benchmark_kind,
+                    "smoke": smoke,
+                    "$process_person_profile": False,
+                },
+            )
             raise
 
         finally:

--- a/runner/src/coval_bench/runner/orchestrator.py
+++ b/runner/src/coval_bench/runner/orchestrator.py
@@ -583,7 +583,7 @@ def _emit_posthog(client: Posthog | None, event: str, properties: dict[str, Any]
     if client is None:
         return
     try:
-        client.capture("coval-bench-runner", event, properties=properties)
+        client.capture(event, distinct_id="coval-bench-runner", properties=properties)
         client.flush()  # type: ignore[no-untyped-call]
     except Exception:
         _log.warning("posthog_emit_failed", event_name=event, exc_info=True)
@@ -965,3 +965,7 @@ async def run_benchmarks(
                 loop.remove_signal_handler(signal.SIGTERM)
             with contextlib.suppress(Exception):
                 await _close_http_clients()
+            if posthog_client is not None:
+                with contextlib.suppress(Exception):
+                    posthog_client.shutdown()  # type: ignore[no-untyped-call]
+                atexit.unregister(posthog_client.shutdown)

--- a/runner/src/coval_bench/runner/orchestrator.py
+++ b/runner/src/coval_bench/runner/orchestrator.py
@@ -852,7 +852,7 @@ async def run_benchmarks(
             )
             _emit_posthog(
                 posthog_client,
-                "benchmark run completed",
+                "benchmark_run_completed",
                 {
                     "status": str(final_status),
                     "total_results": total_results,
@@ -905,7 +905,7 @@ async def run_benchmarks(
             )
             _emit_posthog(
                 posthog_client,
-                "benchmark run completed",
+                "benchmark_run_completed",
                 {
                     "status": str(RunStatus.PARTIAL),
                     "total_results": total_results,
@@ -951,7 +951,7 @@ async def run_benchmarks(
                 )
             _emit_posthog(
                 posthog_client,
-                "benchmark run failed",
+                "benchmark_run_failed",
                 {
                     "benchmark_kind": benchmark_kind,
                     "smoke": smoke,

--- a/runner/src/coval_bench/runner/orchestrator.py
+++ b/runner/src/coval_bench/runner/orchestrator.py
@@ -32,6 +32,7 @@ Design notes
 from __future__ import annotations
 
 import asyncio
+import atexit
 import contextlib
 import hashlib
 import importlib
@@ -41,6 +42,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 
 import structlog
+from posthog import Posthog
 from pydantic import BaseModel
 
 from coval_bench.providers._http_session import close_all as _close_http_clients
@@ -605,6 +607,15 @@ async def run_benchmarks(
     ResultStatus = models_mod.ResultStatus
     load_dataset = _get_load_dataset()
 
+    posthog_client: Posthog | None = None
+    if not settings.posthog_disabled and settings.posthog_project_token:
+        posthog_client = Posthog(
+            settings.posthog_project_token,
+            host=settings.posthog_host,
+            enable_exception_autocapture=True,
+        )
+        atexit.register(posthog_client.shutdown)
+
     # ------------------------------------------------------------------
     # 1. Resolve + filter provider matrix
     # ------------------------------------------------------------------
@@ -814,6 +825,7 @@ async def run_benchmarks(
                 fail_count=fail_count,
             )
 
+            duration_s = (finished_at - started_at).total_seconds()
             _log.info(
                 "benchmark run finished",
                 run_id=run_id,
@@ -821,8 +833,24 @@ async def run_benchmarks(
                 total_results=total_results,
                 success_count=success_count,
                 fail_count=fail_count,
-                duration_s=(finished_at - started_at).total_seconds(),
+                duration_s=duration_s,
             )
+            if posthog_client is not None:
+                posthog_client.capture(
+                    "coval-bench-runner",
+                    "benchmark run completed",
+                    properties={
+                        "status": str(final_status),
+                        "total_results": total_results,
+                        "success_count": success_count,
+                        "fail_count": fail_count,
+                        "duration_s": duration_s,
+                        "benchmark_kind": benchmark_kind,
+                        "smoke": smoke,
+                        "$process_person_profile": False,
+                    },
+                )
+                posthog_client.flush()  # type: ignore[no-untyped-call]
             return summary
 
         except asyncio.CancelledError:
@@ -852,6 +880,7 @@ async def run_benchmarks(
                     exc_info=write_exc,
                 )
             finished_at = datetime.now(tz=UTC)
+            sigterm_duration_s = (finished_at - started_at).total_seconds()
             _log.warning(
                 "benchmark run finished early due to SIGTERM",
                 run_id=run_id,
@@ -859,8 +888,25 @@ async def run_benchmarks(
                 total_results=total_results,
                 success_count=success_count,
                 fail_count=fail_count,
-                duration_s=(finished_at - started_at).total_seconds(),
+                duration_s=sigterm_duration_s,
             )
+            if posthog_client is not None:
+                posthog_client.capture(
+                    "coval-bench-runner",
+                    "benchmark run completed",
+                    properties={
+                        "status": str(RunStatus.PARTIAL),
+                        "total_results": total_results,
+                        "success_count": success_count,
+                        "fail_count": fail_count,
+                        "duration_s": sigterm_duration_s,
+                        "benchmark_kind": benchmark_kind,
+                        "smoke": smoke,
+                        "sigterm": True,
+                        "$process_person_profile": False,
+                    },
+                )
+                posthog_client.flush()  # type: ignore[no-untyped-call]
             return RunSummary(
                 run_id=run_id,
                 started_at=started_at,
@@ -892,6 +938,17 @@ async def run_benchmarks(
                     run_id=run_id,
                     exc_info=write_exc,
                 )
+            if posthog_client is not None:
+                posthog_client.capture(
+                    "coval-bench-runner",
+                    "benchmark run failed",
+                    properties={
+                        "benchmark_kind": benchmark_kind,
+                        "smoke": smoke,
+                        "$process_person_profile": False,
+                    },
+                )
+                posthog_client.flush()  # type: ignore[no-untyped-call]
             raise
 
         finally:

--- a/runner/src/coval_bench/runner/orchestrator.py
+++ b/runner/src/coval_bench/runner/orchestrator.py
@@ -583,7 +583,9 @@ def _emit_posthog(client: Posthog | None, event: str, properties: dict[str, Any]
     if client is None:
         return
     try:
-        client.capture(event, distinct_id="coval-bench-runner", properties=properties)
+        client.capture(
+            event, distinct_id="coval-bench-runner", properties=properties, disable_geoip=True
+        )
         client.flush()  # type: ignore[no-untyped-call]
     except Exception:
         _log.warning("posthog_emit_failed", event_name=event, exc_info=True)

--- a/runner/tests/api/conftest.py
+++ b/runner/tests/api/conftest.py
@@ -18,10 +18,11 @@ pool per test instead of reusing the singleton.
 
 from __future__ import annotations
 
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Awaitable, Callable
 from contextlib import asynccontextmanager
 from datetime import datetime
 from typing import Any
+from unittest.mock import MagicMock
 
 import psycopg
 import psycopg.rows
@@ -115,6 +116,7 @@ async def app(postgresql: Any, monkeypatch: pytest.MonkeyPatch) -> AsyncIterator
     monkeypatch.setenv("DATASET_BUCKET", "test-bucket")
     monkeypatch.setenv("DATASET_ID", "librispeech-test-clean-50")
     monkeypatch.setenv("RUNNER_SHA", "test-sha")
+    monkeypatch.setenv("POSTHOG_DISABLED", "true")
 
     settings = Settings()
 
@@ -142,6 +144,33 @@ async def app(postgresql: Any, monkeypatch: pytest.MonkeyPatch) -> AsyncIterator
     test_app = create_app(settings)
     async with LifespanManager(test_app):
         yield test_app
+
+
+@pytest.fixture
+def app_factory(
+    monkeypatch: pytest.MonkeyPatch,
+) -> Callable[[dict[str, str] | None], Awaitable[FastAPI]]:
+    """Build an app with a stubbed pool so lifespan and analytics wiring can be
+    tested without spinning up Postgres. The caller drives the lifespan.
+    """
+
+    async def _factory(extra_env: dict[str, str] | None = None) -> FastAPI:
+        monkeypatch.setenv("DATABASE_URL", "postgresql://runner:password@localhost:5432/benchmarks")
+        monkeypatch.setenv("DATASET_BUCKET", "test-bucket")
+        monkeypatch.setenv("DATASET_ID", "stt-v1")
+        monkeypatch.setenv("RUNNER_SHA", "test-sha")
+        monkeypatch.setenv("POSTHOG_DISABLED", "true")
+        for key, value in (extra_env or {}).items():
+            monkeypatch.setenv(key, value)
+
+        @asynccontextmanager
+        async def stub_lifespan_pool(s: Settings) -> AsyncIterator[MagicMock]:
+            yield MagicMock()
+
+        monkeypatch.setattr("coval_bench.api.app.lifespan_pool", stub_lifespan_pool)
+        return create_app(Settings())
+
+    return _factory
 
 
 @pytest_asyncio.fixture

--- a/runner/tests/api/test_posthog.py
+++ b/runner/tests/api/test_posthog.py
@@ -1,41 +1,102 @@
 # Copyright 2026 The Coval Benchmarks Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Verify the API emits PostHog events when analytics is configured.
+"""PostHog wiring for the API: lifespan client creation, the real get_posthog
+dependency, and each router's event name and payload.
 
 Uses ``dependency_overrides`` plus ``unittest.mock`` so no extra test
 dependencies are needed and no real PostHog network calls are made. The
-``/providers`` route exercises the shared ``get_posthog`` wiring that every
-router uses.
+lifespan tests stub the DB pool, so they do not spin up Postgres.
 """
 
 from __future__ import annotations
 
+from collections.abc import Awaitable, Callable
 from unittest.mock import MagicMock
 
+import pytest
+from asgi_lifespan import LifespanManager
 from fastapi import FastAPI
-from httpx import AsyncClient
+from httpx import ASGITransport, AsyncClient
 
 from coval_bench.api.deps import get_posthog
 
+AppFactory = Callable[[dict[str, str] | None], Awaitable[FastAPI]]
 
-async def test_providers_captures_event(app: FastAPI, client: AsyncClient) -> None:
-    """An overridden PostHog client receives a 'providers listed' event."""
+
+async def test_lifespan_builds_client_and_route_captures(
+    app_factory: AppFactory, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Token set: lifespan builds the client, stores it on app.state, the real
+    get_posthog returns it, the route captures, and shutdown flushes."""
+    fake = MagicMock()
+    monkeypatch.setattr("coval_bench.api.app.Posthog", lambda *args, **kwargs: fake)
+    app = await app_factory({"POSTHOG_PROJECT_TOKEN": "phc_test", "POSTHOG_DISABLED": "false"})
+
+    async with LifespanManager(app):
+        assert app.state.posthog is fake
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            response = await client.get("/v1/providers")
+        assert response.status_code == 200
+        fake.capture.assert_called()
+    fake.flush.assert_called()
+
+
+async def test_disabled_builds_no_client(
+    app_factory: AppFactory, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Analytics disabled: no client is constructed and the route still succeeds."""
+    sentinel = MagicMock()
+    monkeypatch.setattr("coval_bench.api.app.Posthog", sentinel)
+    app = await app_factory(None)
+
+    async with LifespanManager(app):
+        assert app.state.posthog is None
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            response = await client.get("/v1/providers")
+        assert response.status_code == 200
+    sentinel.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("path", "params", "event", "required_keys"),
+    [
+        ("/v1/providers", {}, "providers listed", {"stt_provider_count", "tts_provider_count"}),
+        ("/v1/runs", {}, "runs listed", {"limit", "run_count"}),
+        (
+            "/v1/results",
+            {"benchmark": "STT"},
+            "results queried",
+            {"benchmark", "result_count", "limit"},
+        ),
+        (
+            "/v1/leaderboard",
+            {"metric": "WER", "benchmark": "STT"},
+            "leaderboard queried",
+            {"metric", "window", "entry_count"},
+        ),
+    ],
+)
+async def test_router_emits_event_with_payload(
+    app: FastAPI,
+    client: AsyncClient,
+    path: str,
+    params: dict[str, str],
+    event: str,
+    required_keys: set[str],
+) -> None:
+    """Each router emits its named event with the expected property keys and the
+    $process_person_profile guard set to False."""
     fake = MagicMock()
     app.dependency_overrides[get_posthog] = lambda: fake
     try:
-        response = await client.get("/v1/providers")
+        response = await client.get(path, params=params)
     finally:
         app.dependency_overrides.pop(get_posthog, None)
 
     assert response.status_code == 200
     fake.capture.assert_called_once()
-    distinct_id, event = fake.capture.call_args.args[:2]
-    assert distinct_id == "coval-bench-api"
-    assert event == "providers listed"
-
-
-async def test_no_capture_when_analytics_disabled(client: AsyncClient) -> None:
-    """With PostHog unconfigured, the route still succeeds and emits nothing."""
-    response = await client.get("/v1/providers")
-    assert response.status_code == 200
+    assert fake.capture.call_args.args[1] == event
+    properties = fake.capture.call_args.kwargs["properties"]
+    assert required_keys <= set(properties.keys())
+    assert properties["$process_person_profile"] is False

--- a/runner/tests/api/test_posthog.py
+++ b/runner/tests/api/test_posthog.py
@@ -1,0 +1,41 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Verify the API emits PostHog events when analytics is configured.
+
+Uses ``dependency_overrides`` plus ``unittest.mock`` so no extra test
+dependencies are needed and no real PostHog network calls are made. The
+``/providers`` route exercises the shared ``get_posthog`` wiring that every
+router uses.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from fastapi import FastAPI
+from httpx import AsyncClient
+
+from coval_bench.api.deps import get_posthog
+
+
+async def test_providers_captures_event(app: FastAPI, client: AsyncClient) -> None:
+    """An overridden PostHog client receives a 'providers listed' event."""
+    fake = MagicMock()
+    app.dependency_overrides[get_posthog] = lambda: fake
+    try:
+        response = await client.get("/v1/providers")
+    finally:
+        app.dependency_overrides.pop(get_posthog, None)
+
+    assert response.status_code == 200
+    fake.capture.assert_called_once()
+    distinct_id, event = fake.capture.call_args.args[:2]
+    assert distinct_id == "coval-bench-api"
+    assert event == "providers listed"
+
+
+async def test_no_capture_when_analytics_disabled(client: AsyncClient) -> None:
+    """With PostHog unconfigured, the route still succeeds and emits nothing."""
+    response = await client.get("/v1/providers")
+    assert response.status_code == 200

--- a/runner/tests/api/test_posthog.py
+++ b/runner/tests/api/test_posthog.py
@@ -62,18 +62,18 @@ async def test_disabled_builds_no_client(
 @pytest.mark.parametrize(
     ("path", "params", "event", "required_keys"),
     [
-        ("/v1/providers", {}, "providers listed", {"stt_provider_count", "tts_provider_count"}),
-        ("/v1/runs", {}, "runs listed", {"limit", "run_count"}),
+        ("/v1/providers", {}, "providers_listed", {"stt_provider_count", "tts_provider_count"}),
+        ("/v1/runs", {}, "runs_listed", {"limit", "run_count"}),
         (
             "/v1/results",
             {"benchmark": "STT"},
-            "results queried",
+            "results_queried",
             {"benchmark", "result_count", "limit"},
         ),
         (
             "/v1/leaderboard",
             {"metric": "WER", "benchmark": "STT"},
-            "leaderboard queried",
+            "leaderboard_queried",
             {"metric", "window", "entry_count"},
         ),
     ],

--- a/runner/tests/api/test_posthog.py
+++ b/runner/tests/api/test_posthog.py
@@ -99,6 +99,7 @@ async def test_router_emits_event_with_payload(
     fake.capture.assert_called_once()
     assert fake.capture.call_args.args[0] == event
     assert fake.capture.call_args.kwargs["distinct_id"] == "coval-bench-api"
+    assert fake.capture.call_args.kwargs["disable_geoip"] is True
     properties = fake.capture.call_args.kwargs["properties"]
     assert required_keys <= set(properties.keys())
     assert properties["$process_person_profile"] is False

--- a/runner/tests/api/test_posthog.py
+++ b/runner/tests/api/test_posthog.py
@@ -12,12 +12,13 @@ lifespan tests stub the DB pool, so they do not spin up Postgres.
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, create_autospec
 
 import pytest
 from asgi_lifespan import LifespanManager
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
+from posthog import Posthog
 
 from coval_bench.api.deps import get_posthog
 
@@ -29,7 +30,7 @@ async def test_lifespan_builds_client_and_route_captures(
 ) -> None:
     """Token set: lifespan builds the client, stores it on app.state, the real
     get_posthog returns it, the route captures, and shutdown flushes."""
-    fake = MagicMock()
+    fake = create_autospec(Posthog, instance=True)
     monkeypatch.setattr("coval_bench.api.app.Posthog", lambda *args, **kwargs: fake)
     app = await app_factory({"POSTHOG_PROJECT_TOKEN": "phc_test", "POSTHOG_DISABLED": "false"})
 
@@ -87,7 +88,7 @@ async def test_router_emits_event_with_payload(
 ) -> None:
     """Each router emits its named event with the expected property keys and the
     $process_person_profile guard set to False."""
-    fake = MagicMock()
+    fake = create_autospec(Posthog, instance=True)
     app.dependency_overrides[get_posthog] = lambda: fake
     try:
         response = await client.get(path, params=params)
@@ -96,7 +97,8 @@ async def test_router_emits_event_with_payload(
 
     assert response.status_code == 200
     fake.capture.assert_called_once()
-    assert fake.capture.call_args.args[1] == event
+    assert fake.capture.call_args.args[0] == event
+    assert fake.capture.call_args.kwargs["distinct_id"] == "coval-bench-api"
     properties = fake.capture.call_args.kwargs["properties"]
     assert required_keys <= set(properties.keys())
     assert properties["$process_person_profile"] is False
@@ -104,7 +106,7 @@ async def test_router_emits_event_with_payload(
 
 async def test_capture_failure_does_not_break_endpoint(app: FastAPI, client: AsyncClient) -> None:
     """A raising PostHog client is swallowed; the route still returns 200."""
-    fake = MagicMock()
+    fake = create_autospec(Posthog, instance=True)
     fake.capture.side_effect = RuntimeError("posthog down")
     app.dependency_overrides[get_posthog] = lambda: fake
     try:

--- a/runner/tests/api/test_posthog.py
+++ b/runner/tests/api/test_posthog.py
@@ -39,7 +39,7 @@ async def test_lifespan_builds_client_and_route_captures(
             response = await client.get("/v1/providers")
         assert response.status_code == 200
         fake.capture.assert_called()
-    fake.flush.assert_called()
+    fake.shutdown.assert_called()
 
 
 async def test_disabled_builds_no_client(
@@ -100,3 +100,17 @@ async def test_router_emits_event_with_payload(
     properties = fake.capture.call_args.kwargs["properties"]
     assert required_keys <= set(properties.keys())
     assert properties["$process_person_profile"] is False
+
+
+async def test_capture_failure_does_not_break_endpoint(app: FastAPI, client: AsyncClient) -> None:
+    """A raising PostHog client is swallowed; the route still returns 200."""
+    fake = MagicMock()
+    fake.capture.side_effect = RuntimeError("posthog down")
+    app.dependency_overrides[get_posthog] = lambda: fake
+    try:
+        response = await client.get("/v1/providers")
+    finally:
+        app.dependency_overrides.pop(get_posthog, None)
+
+    assert response.status_code == 200
+    fake.capture.assert_called_once()

--- a/runner/tests/unit/test_orchestrator.py
+++ b/runner/tests/unit/test_orchestrator.py
@@ -29,9 +29,10 @@ from collections.abc import AsyncIterator
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, create_autospec, patch
 
 import pytest
+from posthog import Posthog
 from pydantic import SecretStr
 
 from coval_bench.config import Settings
@@ -1662,7 +1663,7 @@ async def test_tts_wer_compute_failure_marked_failed(settings: Settings) -> None
 @pytest.mark.asyncio
 async def test_posthog_completed_event(audio_file: Path, settings: Settings) -> None:
     """A successful run emits 'benchmark run completed' and flushes."""
-    fake = MagicMock()
+    fake = create_autospec(Posthog, instance=True)
     settings = settings.model_copy(
         update={"posthog_project_token": "phc_test", "posthog_disabled": False}
     )
@@ -1692,7 +1693,8 @@ async def test_posthog_completed_event(audio_file: Path, settings: Settings) -> 
 
     assert summary.status == str(RunStatus.SUCCEEDED)
     fake.capture.assert_called_once()
-    assert fake.capture.call_args.args[1] == "benchmark run completed"
+    assert fake.capture.call_args.args[0] == "benchmark run completed"
+    assert fake.capture.call_args.kwargs["distinct_id"] == "coval-bench-runner"
     properties = fake.capture.call_args.kwargs["properties"]
     assert properties["status"] == str(RunStatus.SUCCEEDED)
     assert properties["$process_person_profile"] is False
@@ -1702,7 +1704,7 @@ async def test_posthog_completed_event(audio_file: Path, settings: Settings) -> 
 @pytest.mark.asyncio
 async def test_posthog_failed_event(settings: Settings) -> None:
     """An unrecoverable run error emits 'benchmark run failed', flushes, re-raises."""
-    fake = MagicMock()
+    fake = create_autospec(Posthog, instance=True)
     settings = settings.model_copy(
         update={"posthog_project_token": "phc_test", "posthog_disabled": False}
     )
@@ -1757,7 +1759,7 @@ async def test_posthog_failed_event(settings: Settings) -> None:
         )
 
     fake.capture.assert_called_once()
-    assert fake.capture.call_args.args[1] == "benchmark run failed"
+    assert fake.capture.call_args.args[0] == "benchmark run failed"
     assert fake.capture.call_args.kwargs["properties"]["$process_person_profile"] is False
     fake.flush.assert_called_once()
 
@@ -1767,7 +1769,7 @@ async def test_posthog_capture_failure_does_not_fail_run(
     audio_file: Path, settings: Settings
 ) -> None:
     """A raising PostHog client must not flip a successful run to FAILED."""
-    fake = MagicMock()
+    fake = create_autospec(Posthog, instance=True)
     fake.capture.side_effect = RuntimeError("posthog down")
     settings = settings.model_copy(
         update={"posthog_project_token": "phc_test", "posthog_disabled": False}

--- a/runner/tests/unit/test_orchestrator.py
+++ b/runner/tests/unit/test_orchestrator.py
@@ -1693,7 +1693,7 @@ async def test_posthog_completed_event(audio_file: Path, settings: Settings) -> 
 
     assert summary.status == str(RunStatus.SUCCEEDED)
     fake.capture.assert_called_once()
-    assert fake.capture.call_args.args[0] == "benchmark run completed"
+    assert fake.capture.call_args.args[0] == "benchmark_run_completed"
     assert fake.capture.call_args.kwargs["distinct_id"] == "coval-bench-runner"
     properties = fake.capture.call_args.kwargs["properties"]
     assert properties["status"] == str(RunStatus.SUCCEEDED)
@@ -1759,7 +1759,7 @@ async def test_posthog_failed_event(settings: Settings) -> None:
         )
 
     fake.capture.assert_called_once()
-    assert fake.capture.call_args.args[0] == "benchmark run failed"
+    assert fake.capture.call_args.args[0] == "benchmark_run_failed"
     assert fake.capture.call_args.kwargs["properties"]["$process_person_profile"] is False
     fake.flush.assert_called_once()
 

--- a/runner/tests/unit/test_orchestrator.py
+++ b/runner/tests/unit/test_orchestrator.py
@@ -53,6 +53,7 @@ _TEST_SETTINGS = Settings(
     log_level="DEBUG",
     openai_api_key=SecretStr("sk-test"),
     deepgram_api_key=SecretStr("dg-test"),
+    posthog_disabled=True,
 )
 
 
@@ -1651,3 +1652,111 @@ async def test_tts_wer_compute_failure_marked_failed(settings: Settings) -> None
         assert by_metric["WER"].metric_value is None
         assert "wer blew up" in (by_metric["WER"].error or "")
         assert summary.status == str(RunStatus.PARTIAL)
+
+
+# ---------------------------------------------------------------------------
+# 11. PostHog run events
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_posthog_completed_event(audio_file: Path, settings: Settings) -> None:
+    """A successful run emits 'benchmark run completed' and flushes."""
+    fake = MagicMock()
+    settings = settings.model_copy(
+        update={"posthog_project_token": "phc_test", "posthog_disabled": False}
+    )
+
+    provider = MagicMock()
+    provider.measure_ttft = AsyncMock(return_value=_good_transcription())
+    provider_cls = MagicMock(return_value=provider)
+    matrix = [ProviderEntry(provider="deepgram", model="nova-2", enabled=True)]
+
+    run = _make_run()
+    writer = _make_stub_writer(run)
+
+    with patch("coval_bench.runner.orchestrator.Posthog", lambda *a, **k: fake):
+        async with _orchestrator_env(
+            audio_path=audio_file,
+            stt_items=[_make_dataset_item(audio_file)],
+            stt_providers={"deepgram": provider_cls},
+            run=run,
+            writer=writer,
+        ):
+            summary = await run_benchmarks(
+                settings=settings,
+                benchmark_kind="stt",
+                smoke=True,
+                matrix_overrides=matrix,
+            )
+
+    assert summary.status == str(RunStatus.SUCCEEDED)
+    fake.capture.assert_called_once()
+    assert fake.capture.call_args.args[1] == "benchmark run completed"
+    properties = fake.capture.call_args.kwargs["properties"]
+    assert properties["status"] == str(RunStatus.SUCCEEDED)
+    assert properties["$process_person_profile"] is False
+    fake.flush.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_posthog_failed_event(settings: Settings) -> None:
+    """An unrecoverable run error emits 'benchmark run failed', flushes, re-raises."""
+    fake = MagicMock()
+    settings = settings.model_copy(
+        update={"posthog_project_token": "phc_test", "posthog_disabled": False}
+    )
+
+    class _DatasetIntegrityError(Exception):
+        pass
+
+    def _bad_load(dataset_id: str, *, settings: Any) -> Any:
+        raise _DatasetIntegrityError("hash mismatch")
+
+    deepgram_cls = MagicMock()
+    deepgram_cls.warmup = AsyncMock(return_value=None)
+    run = _make_run()
+    writer = _make_stub_writer(run)
+    fake_pool = MagicMock()
+
+    @contextlib.asynccontextmanager
+    async def _fake_lifespan_pool(s: Any) -> AsyncIterator[MagicMock]:
+        yield fake_pool
+
+    models_mod = MagicMock()
+    models_mod.Benchmark = Benchmark
+    models_mod.Result = Result
+    models_mod.ResultStatus = ResultStatus
+    models_mod.RunStatus = RunStatus
+
+    def _fake_get_db_symbols() -> tuple[Any, Any, Any, Any]:
+        return _fake_lifespan_pool, MagicMock(return_value=writer), RunStatus, models_mod
+
+    with (
+        patch("coval_bench.runner.orchestrator.Posthog", lambda *a, **k: fake),
+        patch(
+            "coval_bench.runner.orchestrator._get_db_symbols",
+            side_effect=_fake_get_db_symbols,
+        ),
+        patch(
+            "coval_bench.runner.orchestrator._get_stt_providers",
+            return_value={"deepgram": deepgram_cls},
+        ),
+        patch("coval_bench.runner.orchestrator._get_tts_providers", return_value={}),
+        patch("coval_bench.runner.orchestrator._get_load_dataset", return_value=_bad_load),
+        patch(
+            "coval_bench.runner.orchestrator._get_metrics",
+            return_value=(MagicMock(), MagicMock()),
+        ),
+        pytest.raises(_DatasetIntegrityError),
+    ):
+        await run_benchmarks(
+            settings=settings,
+            benchmark_kind="stt",
+            matrix_overrides=[ProviderEntry(provider="deepgram", model="nova-2", enabled=True)],
+        )
+
+    fake.capture.assert_called_once()
+    assert fake.capture.call_args.args[1] == "benchmark run failed"
+    assert fake.capture.call_args.kwargs["properties"]["$process_person_profile"] is False
+    fake.flush.assert_called_once()

--- a/runner/tests/unit/test_orchestrator.py
+++ b/runner/tests/unit/test_orchestrator.py
@@ -1760,3 +1760,41 @@ async def test_posthog_failed_event(settings: Settings) -> None:
     assert fake.capture.call_args.args[1] == "benchmark run failed"
     assert fake.capture.call_args.kwargs["properties"]["$process_person_profile"] is False
     fake.flush.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_posthog_capture_failure_does_not_fail_run(
+    audio_file: Path, settings: Settings
+) -> None:
+    """A raising PostHog client must not flip a successful run to FAILED."""
+    fake = MagicMock()
+    fake.capture.side_effect = RuntimeError("posthog down")
+    settings = settings.model_copy(
+        update={"posthog_project_token": "phc_test", "posthog_disabled": False}
+    )
+
+    provider = MagicMock()
+    provider.measure_ttft = AsyncMock(return_value=_good_transcription())
+    provider_cls = MagicMock(return_value=provider)
+    matrix = [ProviderEntry(provider="deepgram", model="nova-2", enabled=True)]
+
+    run = _make_run()
+    writer = _make_stub_writer(run)
+
+    with patch("coval_bench.runner.orchestrator.Posthog", lambda *a, **k: fake):
+        async with _orchestrator_env(
+            audio_path=audio_file,
+            stt_items=[_make_dataset_item(audio_file)],
+            stt_providers={"deepgram": provider_cls},
+            run=run,
+            writer=writer,
+        ):
+            summary = await run_benchmarks(
+                settings=settings,
+                benchmark_kind="stt",
+                smoke=True,
+                matrix_overrides=matrix,
+            )
+
+    assert summary.status == str(RunStatus.SUCCEEDED)
+    fake.capture.assert_called_once()

--- a/runner/uv.lock
+++ b/runner/uv.lock
@@ -160,6 +160,15 @@ wheels = [
 ]
 
 [[package]]
+name = "backoff"
+version = "2.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/d7/5bbeb12c44d7c4f2fb5b56abce497eb5ed9f34d85701de869acedd602619/backoff-2.2.1.tar.gz", hash = "sha256:03f829f5bb1923180821643f8753b0502c3b682293992485b0eef2807afa5cba", size = 17001, upload-time = "2022-10-05T19:19:32.061Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/73/b6e24bd22e6720ca8ee9a85a0c4a2971af8497d8f3193fa05390cbd46e09/backoff-2.2.1-py3-none-any.whl", hash = "sha256:63579f9a0628e06278f7e47b7d7d5b6ce20dc65c5e96a6f3ca99a6adca0396e8", size = 15148, upload-time = "2022-10-05T19:19:30.546Z" },
+]
+
+[[package]]
 name = "cartesia"
 version = "3.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -270,6 +279,7 @@ dependencies = [
     { name = "jiwer" },
     { name = "numpy" },
     { name = "openai" },
+    { name = "posthog" },
     { name = "psycopg", extra = ["binary", "pool"] },
     { name = "pydantic" },
     { name = "pydantic-settings" },
@@ -322,6 +332,7 @@ requires-dist = [
     { name = "jiwer", specifier = ">=3.0" },
     { name = "numpy", specifier = ">=1.26" },
     { name = "openai", specifier = ">=1.40" },
+    { name = "posthog", specifier = ">=3.0" },
     { name = "psycopg", extras = ["binary", "pool"], specifier = ">=3.2" },
     { name = "pydantic", specifier = ">=2.7" },
     { name = "pydantic-settings", specifier = ">=2.4" },
@@ -1070,6 +1081,21 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/88/a0/80a64e8cc096c7a9d0f546a28994af849b4775afc5e4ee44bf2739a55115/port_for-1.0.0.tar.gz", hash = "sha256:404d161b1b2c82e2f6b31d8646396b4847d02bf5ee10068c92b7263657a14582", size = 21681, upload-time = "2025-09-30T10:22:51.149Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/70/2c/b1faca65b9728b4ac43f0bee4bb9e7294bd0a62cc2ee59fd59403bf575f6/port_for-1.0.0-py3-none-any.whl", hash = "sha256:35a848b98cf4cc075fe80dc49ae5c3a78e3ca345a23bd39bf5252277b4eef5c2", size = 17544, upload-time = "2025-09-30T10:22:49.878Z" },
+]
+
+[[package]]
+name = "posthog"
+version = "7.17.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "backoff" },
+    { name = "distro" },
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5d/53/9abb7c2ec8acfcafd488a379f5937d248bf290f9fe8c0a2edc023063b7e9/posthog-7.17.0.tar.gz", hash = "sha256:25bcd488a2b2359b0ae969ffcba75ecb5fd0287ad3f32fffe645659d543dbf17", size = 229049, upload-time = "2026-06-03T15:14:41.202Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/fe/49358d2a9ebde6538ace96785e5b59c4df302ab0b72fef6010625cb77c06/posthog-7.17.0-py3-none-any.whl", hash = "sha256:b2735701effba2f8f4ccf58b0b49fbaaf7d4d0544fb6d6b7547cd7ccde5d4f43", size = 267430, upload-time = "2026-06-03T15:14:39.432Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Server-side PostHog analytics, the backend half of #62 (which is browser-only).

- API routers capture one event per query: leaderboard, providers, results, runs.
- Orchestrator captures run completed, failed, and SIGTERM events.
- Gated on `POSTHOG_PROJECT_TOKEN`; off when unset.

## Testing

`unittest.mock` + `dependency_overrides`, no new deps, no network:

- Lifespan builds the client, the real `get_posthog` returns it, shutdown flushes.
- Every API event name and payload, including the `$process_person_profile` guard.
- Orchestrator completed and failed events.
- Tests disable PostHog by default, so they never use a local `.env` token.

SIGTERM event untested by design (needs a flaky mid-run `CancelledError`).

Gate green: ruff, ruff format --check, mypy --strict src.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added analytics tracking for API endpoints and benchmark runs; events emitted for provider lists, runs, results queries, and leaderboard access.

* **Configuration**
  * New analytics settings: project token, host URL, and disable toggle (configurable via environment variables).

* **Tests**
  * Added end-to-end and unit tests covering analytics initialization, per-route event emission, and tolerant failure behavior.

* **Chores**
  * .gitignore updated to exclude local environment variants (.env*.local).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->