### PR TITLE
Make model select/deselect responsive

### DIFF
--- a/web/components/dashboard/AccuracyBarSection.tsx
+++ b/web/components/dashboard/AccuracyBarSection.tsx
@@ -112,6 +112,7 @@ const AccuracyBarSection: React.FC = () => {
                 stroke={themeColors.barStroke}
                 strokeWidth={1}
                 radius={[4, 4, 0, 0]}
+                isAnimationActive={false}
                 onClick={handleWERBarClickTracked}
                 label={{
                   position: "top",

--- a/web/components/dashboard/LatencyAccuracySection.tsx
+++ b/web/components/dashboard/LatencyAccuracySection.tsx
@@ -147,6 +147,7 @@ const LatencyAccuracySection: React.FC = () => {
                   )}
                   fill={getModelColor(model)}
                   name={model}
+                  isAnimationActive={false}
                   shape={(props: { cx?: number; cy?: number; fill?: string }) => (
                     <circle
                       cx={props.cx}

--- a/web/components/dashboard/ViolinSection.tsx
+++ b/web/components/dashboard/ViolinSection.tsx
@@ -6,6 +6,7 @@
 import React, { useMemo } from "react";
 import { getModelColor } from "@/lib/utils/colors";
 import { normalizeModelName } from "@/lib/utils/formatters";
+import { median } from "@/lib/utils/median";
 import ViolinPlot from "@/components/charts/d3/ViolinPlot";
 import SectionHeader from "@/components/shared/SectionHeader";
 import { useDashboard } from "@/contexts/DashboardContext";
@@ -25,14 +26,11 @@ const ViolinSection: React.FC = () => {
   const medianLatency = useMemo(() => {
     const values: number[] = [];
     for (const modelData of violinData.data) {
-      values.push(...modelData.values);
+      for (const value of modelData.values) {
+        values.push(value);
+      }
     }
-    if (values.length === 0) return 0;
-    values.sort((a, b) => a - b);
-    const mid = Math.floor(values.length / 2);
-    return values.length % 2 === 0
-      ? ((values[mid - 1] ?? 0) + (values[mid] ?? 0)) / 2
-      : (values[mid] ?? 0);
+    return median(values);
   }, [violinData]);
 
   return (

--- a/web/components/visualizations/TimelineChart.tsx
+++ b/web/components/visualizations/TimelineChart.tsx
@@ -162,6 +162,7 @@ const TimelineChart: React.FC = () => {
                   stroke={getModelColor(model)}
                   strokeWidth={modelsWithData.length === 1 ? 3 : 2}
                   dot={false}
+                  isAnimationActive={false}
                   activeDot={{
                     r: modelsWithData.length === 1 ? 7 : 6,
                     fill: getModelColor(model)

--- a/web/hooks/useChartData.ts
+++ b/web/hooks/useChartData.ts
@@ -120,70 +120,86 @@ export function useChartData({
 
   // Memoized result so repeated callers (getFullTimeRange, getWindowedTimelineData,
   // useTimelineWindow) share a single computation per (rawData, tab, selection).
+  // Per-model timeline series (timestamp → averaged value) — the heavy pass,
+  // computed once per dataset so selection only merges precomputed series.
+  const timelineByModel = useMemo<Record<string, Record<number, number>>>(() => {
+    const primaryMetric = activeTab === "tts" ? "TTFA" : "TTFT";
+
+    const acc: Record<
+      string,
+      { [key: number]: { total: number; count: number } }
+    > = {};
+
+    rawData.forEach((item) => {
+      if (item.metric_type !== primaryMetric) return;
+      if (!INCLUDED_STATUSES.has(item.status)) return;
+
+      const modelKey = toModelKey(item.provider, item.model);
+      const timestamp = new Date(item.scheduled_at).getTime();
+      const value =
+        activeTab === "tts"
+          ? item.metric_value ?? 0
+          : (item.metric_value ?? 0) * 1000;
+
+      if (!acc[modelKey]) {
+        acc[modelKey] = {};
+      }
+      const modelAcc = acc[modelKey];
+      if (!modelAcc[timestamp]) {
+        modelAcc[timestamp] = { total: 0, count: 0 };
+      }
+      const bucket = modelAcc[timestamp];
+      if (bucket) {
+        bucket.total += value;
+        bucket.count += 1;
+      }
+    });
+
+    const byModel: Record<string, Record<number, number>> = {};
+    Object.entries(acc).forEach(([model, tsMap]) => {
+      const series: Record<number, number> = {};
+      Object.entries(tsMap).forEach(([timestamp, stats]) => {
+        series[Number(timestamp)] = stats.total / stats.count;
+      });
+      byModel[model] = series;
+    });
+
+    return byModel;
+  }, [rawData, activeTab]);
+
+  // Timeline rows: merge the selected models' precomputed series into one row
+  // per timestamp (ascending), each with a `${model}_value` column.
   const timelineData = useMemo<TimelineDataPoint[]>(() => {
     const selectedModels =
       activeTab === "tts" ? selectedTTSModels : selectedSTTModels;
-    const primaryMetric = activeTab === "tts" ? "TTFA" : "TTFT";
 
     if (selectedModels.length === 0) {
       return [];
     }
 
-    const selectedModelKeys = new Set(selectedModels);
-    const points = rawData
-      .filter(
-        (item) =>
-          selectedModelKeys.has(toModelKey(item.provider, item.model)) &&
-          item.metric_type === primaryMetric &&
-          INCLUDED_STATUSES.has(item.status)
-      )
-      .map((item) => ({
-        timestamp: new Date(item.scheduled_at).getTime(),
-        value:
-          activeTab === "tts"
-            ? item.metric_value ?? 0
-            : (item.metric_value ?? 0) * 1000,
-        modelKey: toModelKey(item.provider, item.model),
-        benchmark: item.benchmark
-      }))
-      .sort((a, b) => a.timestamp - b.timestamp);
-
-    const timestampGroups: { [key: number]: TimelineDataPoint } = {};
-    const modelValueAccumulator: { [key: number]: { [key: string]: { total: number; count: number } } } = {};
-
-    points.forEach((item) => {
-      if (!timestampGroups[item.timestamp]) {
-        timestampGroups[item.timestamp] = {
-          timestamp: item.timestamp,
-          timestampLabel: new Date(item.timestamp).toISOString()
-        };
-        modelValueAccumulator[item.timestamp] = {};
-      }
-      const bucketAcc = modelValueAccumulator[item.timestamp];
-      if (bucketAcc) {
-        if (!bucketAcc[item.modelKey]) {
-          bucketAcc[item.modelKey] = { total: 0, count: 0 };
-        }
-        const modelAcc = bucketAcc[item.modelKey];
-        if (modelAcc) {
-          modelAcc.total += item.value;
-          modelAcc.count += 1;
-        }
+    const timestampSet = new Set<number>();
+    selectedModels.forEach((model) => {
+      const tsMap = timelineByModel[model];
+      if (tsMap) {
+        Object.keys(tsMap).forEach((ts) => timestampSet.add(Number(ts)));
       }
     });
+    const timestamps = [...timestampSet].sort((a, b) => a - b);
 
-    Object.entries(modelValueAccumulator).forEach(([bucketTimestamp, bucketModelStats]) => {
-      const bucket = Number(bucketTimestamp);
-      Object.entries(bucketModelStats).forEach(([model, stats]) => {
-        const group = timestampGroups[bucket];
-        if (group) {
-          group[`${model}_value`] = stats.total / stats.count;
+    return timestamps.map((timestamp) => {
+      const row: TimelineDataPoint = {
+        timestamp,
+        timestampLabel: new Date(timestamp).toISOString()
+      };
+      selectedModels.forEach((model) => {
+        const value = timelineByModel[model]?.[timestamp];
+        if (value !== undefined) {
+          row[`${model}_value`] = value;
         }
       });
+      return row;
     });
-
-    return Object.values(timestampGroups);
-  }, [rawData, activeTab, selectedTTSModels, selectedSTTModels]);
+  }, [timelineByModel, activeTab, selectedTTSModels, selectedSTTModels]);
 
   const getTimelineData = useCallback(
     (): TimelineDataPoint[] => timelineData,

--- a/web/hooks/useChartData.ts
+++ b/web/hooks/useChartData.ts
@@ -190,7 +190,53 @@ export function useChartData({
     [timelineData]
   );
 
-  // Violin plots need raw values for KDE — cannot use pre-aggregated stats
+  // Per-model violin pieces (values, KDE, quartiles, stats) — the heavy work.
+  // Computed once per dataset (independent of selection) so toggling a model
+  // only reassembles the precomputed pieces instead of re-scanning rawData.
+  const violinByModel = useMemo<Record<string, ViolinDataPoint>>(() => {
+    const primaryMetric = activeTab === "tts" ? "TTFA" : "TTFT";
+    const modelGroups: { [key: string]: BenchmarkData[] } = {};
+
+    rawData.forEach((item) => {
+      if (item.metric_type !== primaryMetric) return;
+      if (!INCLUDED_STATUSES.has(item.status)) return;
+      if (item.metric_value === null || item.metric_value === undefined) return;
+
+      const itemKey = toModelKey(item.provider, item.model);
+      if (!modelGroups[itemKey]) {
+        modelGroups[itemKey] = [];
+      }
+      const modelGroup = modelGroups[itemKey];
+      if (modelGroup) {
+        modelGroup.push(item);
+      }
+    });
+
+    const byModel: Record<string, ViolinDataPoint> = {};
+    Object.entries(modelGroups).forEach(([model, items]) => {
+      const values = items.map((item) =>
+        activeTab === "tts"
+          ? item.metric_value ?? 0
+          : (item.metric_value ?? 0) * 1000
+      );
+
+      if (values.length === 0) return;
+
+      byModel[model] = {
+        model,
+        provider: items[0]?.provider ?? "Unknown",
+        values,
+        density: calculateKernelDensity(values),
+        quartiles: calculateQuartiles(values),
+        stats: calculateStats(values)
+      };
+    });
+
+    return byModel;
+  }, [rawData, activeTab]);
+
+  // Violin plot data: gather the selected models' precomputed pieces and
+  // recompute only the pooled summary (axis bounds, whisker cap, outliers).
   const violinDataMemo = useMemo<ViolinPlotData>(() => {
     const selectedModels =
       activeTab === "tts" ? selectedTTSModels : selectedSTTModels;
@@ -205,55 +251,16 @@ export function useChartData({
       };
     }
 
-    const selectedModelKeys = new Set(selectedModels);
-    const modelGroups: { [key: string]: BenchmarkData[] } = {};
-
-    rawData.forEach((item) => {
-      const itemKey = toModelKey(item.provider, item.model);
-      if (!selectedModelKeys.has(itemKey)) return;
-      if (item.metric_type !== primaryMetric) return;
-      if (!INCLUDED_STATUSES.has(item.status)) return;
-      if (item.metric_value === null || item.metric_value === undefined) return;
-
-      if (!modelGroups[itemKey]) {
-        modelGroups[itemKey] = [];
-      }
-      const modelGroup = modelGroups[itemKey];
-      if (modelGroup) {
-        modelGroup.push(item);
-      }
-    });
-
     const violinData: ViolinDataPoint[] = [];
     let globalMin = Infinity;
     let globalMax = -Infinity;
 
-    Object.entries(modelGroups).forEach(([model, items]) => {
-      const values = items.map((item) =>
-        activeTab === "tts"
-          ? item.metric_value ?? 0
-          : (item.metric_value ?? 0) * 1000
-      );
-
-      if (values.length === 0) return;
-
-      const quartiles = calculateQuartiles(values);
-      const stats = calculateStats(values);
-      const density = calculateKernelDensity(values);
-
-      globalMin = Math.min(globalMin, ...values);
-      globalMax = Math.max(globalMax, ...values);
-
-      const provider = items[0]?.provider ?? "Unknown";
-
-      violinData.push({
-        model,
-        provider,
-        values,
-        density,
-        quartiles,
-        stats
-      });
+    selectedModels.forEach((model) => {
+      const entry = violinByModel[model];
+      if (!entry) return;
+      violinData.push(entry);
+      globalMin = Math.min(globalMin, ...entry.values);
+      globalMax = Math.max(globalMax, ...entry.values);
     });
 
     if (violinData.length === 0) {
@@ -279,7 +286,7 @@ export function useChartData({
       maxUpperWhisker = 0;
     }
 
-    const sortedViolinData = violinData.sort(
+    const sortedViolinData = [...violinData].sort(
       (a, b) => a.quartiles.median - b.quartiles.median
     );
 
@@ -292,7 +299,7 @@ export function useChartData({
       cappedAt: maxUpperWhisker,
       metricType: primaryMetric
     };
-  }, [rawData, activeTab, selectedTTSModels, selectedSTTModels]);
+  }, [violinByModel, activeTab, selectedTTSModels, selectedSTTModels]);
 
   const getViolinData = useCallback(
     (): ViolinPlotData => violinDataMemo,

--- a/web/hooks/useChartData.ts
+++ b/web/hooks/useChartData.ts
@@ -419,6 +419,51 @@ export function useChartData({
   // ─── Functions using SQL-aggregated modelStats ───
 
   // STT heatmap still needs raw data for per-timestamp delta calculation
+  // Per-model latency series (timestamp → averaged value) for the STT model
+  // heatmap — the heavy scan, computed once per dataset.
+  const heatmapAvgByModel = useMemo<Record<string, Record<number, number>>>(() => {
+    const latencyMetric = activeTab === "tts" ? "TTFA" : "TTFT";
+    const acc: Record<
+      string,
+      { [key: number]: { total: number; count: number } }
+    > = {};
+
+    rawData.forEach((item) => {
+      if (item.metric_type !== latencyMetric) return;
+      if (!INCLUDED_STATUSES.has(item.status)) return;
+      if (item.metric_value === null || item.metric_value === undefined) return;
+
+      const itemKey = toModelKey(item.provider, item.model);
+      const timestamp = new Date(item.scheduled_at).getTime();
+      const latencyValue =
+        activeTab === "tts" ? item.metric_value : item.metric_value * 1000;
+
+      if (!acc[itemKey]) {
+        acc[itemKey] = {};
+      }
+      const modelAcc = acc[itemKey];
+      if (!modelAcc[timestamp]) {
+        modelAcc[timestamp] = { total: 0, count: 0 };
+      }
+      const bucket = modelAcc[timestamp];
+      if (bucket) {
+        bucket.total += latencyValue;
+        bucket.count += 1;
+      }
+    });
+
+    const byModel: Record<string, Record<number, number>> = {};
+    Object.entries(acc).forEach(([model, tsMap]) => {
+      const series: Record<number, number> = {};
+      Object.entries(tsMap).forEach(([timestamp, stats]) => {
+        series[Number(timestamp)] = stats.total / stats.count;
+      });
+      byModel[model] = series;
+    });
+
+    return byModel;
+  }, [rawData, activeTab]);
+
   const modelHeatmapDataMemo = useMemo<ModelHeatmapData[]>(() => {
     const selectedModels =
       activeTab === "tts" ? selectedTTSModels : selectedSTTModels;
@@ -428,47 +473,21 @@ export function useChartData({
       return [];
     }
 
-    // Delta calculation requires raw per-timestamp data
-    // Group latency data by timestamp across all selected models
-    const timestampGroups: {
-      [key: number]: { [key: string]: { total: number; count: number } };
-    } = {};
-
-    const selectedModelKeys = new Set(selectedModels);
-    rawData.forEach((item) => {
-      const itemKey = toModelKey(item.provider, item.model);
-      if (!selectedModelKeys.has(itemKey)) return;
-      if (item.metric_type !== latencyMetric) return;
-      if (!INCLUDED_STATUSES.has(item.status)) return;
-      if (item.metric_value === null || item.metric_value === undefined) return;
-
-      const timestamp = new Date(item.scheduled_at).getTime();
-      if (!timestampGroups[timestamp]) {
-        timestampGroups[timestamp] = {};
-      }
-      const latencyValue =
-        activeTab === "tts" ? item.metric_value : item.metric_value * 1000;
-      const bucket = timestampGroups[timestamp];
-      if (bucket) {
-        if (!bucket[itemKey]) {
-          bucket[itemKey] = { total: 0, count: 0 };
-        }
-        const modelAcc = bucket[itemKey];
-        if (modelAcc) {
-          modelAcc.total += latencyValue;
-          modelAcc.count += 1;
-        }
-      }
-    });
-
+    // Rebuild per-timestamp averages for the selected models from the
+    // precomputed per-model series (deltas are relative to the fastest
+    // selected model, so this part stays selection-dependent).
     const averagedTimestampGroups: { [key: number]: { [key: string]: number } } = {};
-    Object.entries(timestampGroups).forEach(([bucketTimestamp, perModelStats]) => {
-      const bucket = Number(bucketTimestamp);
-      averagedTimestampGroups[bucket] = {};
-      Object.entries(perModelStats).forEach(([model, stats]) => {
-        const avg = averagedTimestampGroups[bucket];
-        if (avg) {
-          avg[model] = stats.total / stats.count;
+    selectedModels.forEach((model) => {
+      const tsMap = heatmapAvgByModel[model];
+      if (!tsMap) return;
+      Object.entries(tsMap).forEach(([timestamp, avg]) => {
+        const bucket = Number(timestamp);
+        if (!averagedTimestampGroups[bucket]) {
+          averagedTimestampGroups[bucket] = {};
+        }
+        const group = averagedTimestampGroups[bucket];
+        if (group) {
+          group[model] = avg;
         }
       });
     });
@@ -529,7 +548,7 @@ export function useChartData({
         a.model.localeCompare(b.model)
     );
   }, [
-    rawData,
+    heatmapAvgByModel,
     activeTab,
     selectedTTSModels,
     selectedSTTModels,

--- a/web/hooks/useChartData.ts
+++ b/web/hooks/useChartData.ts
@@ -324,23 +324,15 @@ export function useChartData({
 
   // Pair latency with WER per run, then average per model — pairing restricts
   // the average to runs that produced both metrics
-  const scatterDataMemo = useMemo<ScatterDataPoint[]>(() => {
-    const selectedModels =
-      activeTab === "tts" ? selectedTTSModels : selectedSTTModels;
+  const scatterByModel = useMemo<Record<string, ScatterDataPoint>>(() => {
     const xMetric = activeTab === "tts" ? "TTFA" : "TTFT";
     const yMetric = "WER";
-
-    if (selectedModels.length === 0) {
-      return [];
-    }
 
     const benchmarkGroups: {
       [key: string]: { [key: string]: BenchmarkData[] };
     } = {};
 
-    const selectedModelKeys = new Set(selectedModels);
     rawData.forEach((item) => {
-      if (!selectedModelKeys.has(toModelKey(item.provider, item.model))) return;
       if (item.metric_type !== xMetric && item.metric_type !== yMetric) return;
       if (!INCLUDED_STATUSES.has(item.status)) return;
       if (item.metric_value === null || item.metric_value === undefined) return;
@@ -401,15 +393,33 @@ export function useChartData({
       }
     });
 
-    return Object.entries(modelAggregates).map(([model, agg]) => ({
-      x: agg.xSum / agg.count,
-      y: agg.ySum / agg.count,
-      model,
-      benchmark: agg.benchmark,
-      provider: agg.provider,
-      count: agg.count
-    }));
-  }, [rawData, activeTab, selectedTTSModels, selectedSTTModels]);
+    const byModel: Record<string, ScatterDataPoint> = {};
+    Object.entries(modelAggregates).forEach(([model, agg]) => {
+      byModel[model] = {
+        x: agg.xSum / agg.count,
+        y: agg.ySum / agg.count,
+        model,
+        benchmark: agg.benchmark,
+        provider: agg.provider,
+        count: agg.count
+      };
+    });
+    return byModel;
+  }, [rawData, activeTab]);
+
+  const scatterDataMemo = useMemo<ScatterDataPoint[]>(() => {
+    const selectedModels =
+      activeTab === "tts" ? selectedTTSModels : selectedSTTModels;
+
+    const points: ScatterDataPoint[] = [];
+    selectedModels.forEach((model) => {
+      const point = scatterByModel[model];
+      if (point) {
+        points.push(point);
+      }
+    });
+    return points;
+  }, [scatterByModel, activeTab, selectedTTSModels, selectedSTTModels]);
 
   const getScatterData = useCallback(
     (): ScatterDataPoint[] => scatterDataMemo,

--- a/web/hooks/useDashboardState.tsx
+++ b/web/hooks/useDashboardState.tsx
@@ -3,13 +3,21 @@
 
 "use client";
 
-import { useState, useEffect, useMemo, useCallback, useRef } from "react";
+import {
+  useState,
+  useEffect,
+  useMemo,
+  useCallback,
+  useRef,
+  useDeferredValue,
+} from "react";
 import type { BenchmarkData } from "@/types/benchmark.types";
 import { TWENTY_FOUR_HOURS_MS } from "@/lib/config/constants";
 import { useChartData } from "@/hooks/useChartData";
 import { useMobileDetection } from "@/hooks/useMobileDetection";
 import { useBarInteraction } from "@/hooks/useBarInteraction";
 import { useTimelineWindow } from "@/hooks/useTimelineWindow";
+import { median } from "@/lib/utils/median";
 import { normalizeModelName, normalizeSTTProviderName, normalizeTTSProviderName, parseModelKey } from "@/lib/utils/formatters";
 import { buildModelsByProviderFromResults, pruneSelection } from "@/lib/utils/modelsFromResults";
 import { metricDescriptions } from "@/lib/config/metrics";
@@ -116,13 +124,15 @@ export function useDashboardState(page: "tts" | "stt") {
     hasAnchoredRef.current = true;
   }, [rawData.length, latestTimestamp]);
 
+  const deferredSelectedModels = useDeferredValue(selectedModels);
+
   // useChartData hook - pass page as activeTab internally
   const chartData = useChartData({
     activeTab: page,
     rawData,
     modelStats,
-    selectedTTSModels: page === "tts" ? selectedModels : [],
-    selectedSTTModels: page === "stt" ? selectedModels : [],
+    selectedTTSModels: page === "tts" ? deferredSelectedModels : [],
+    selectedSTTModels: page === "stt" ? deferredSelectedModels : [],
     timelineWindowEnd: timelineWindowEndTemp,
     modelsByProvider: page === "tts" ? ttsModelsByProvider : sttModelsByProvider,
   });
@@ -232,188 +242,211 @@ export function useDashboardState(page: "tts" | "stt") {
   }, [modelsByProvider]);
 
   // Calculate metrics
-  const currentData = chartData.getCurrentData();
-  const primaryMetric = page === "tts" ? "TTFA" : "TTFT";
-  const secondaryMetric = "WER";
+  const { getCurrentData, getStat } = chartData;
 
-  const primaryData = currentData.filter(
-    (item) => item.metric_type === primaryMetric
-  );
-  const secondaryData = currentData.filter(
-    (item) => item.metric_type === secondaryMetric
-  );
+  const keyMetrics = useMemo(() => {
+    const currentData = getCurrentData();
+    const primaryMetric = page === "tts" ? "TTFA" : "TTFT";
+    const secondaryMetric = "WER";
 
-  let avgPrimary = 0;
-  let avgSecondary = 0;
-  let fastestLatencyModel = "";
-  let lowestWERModel = "";
-  let fastestLatencyProvider = "";
-  let lowestWERProvider = "";
-
-  if (selectedModels.length === 0) {
-    avgPrimary = 0;
-    avgSecondary = 0;
-  } else if (page === "stt") {
-    let fastestPrimary = Infinity;
-    selectedModels.forEach((model) => {
-      const stat = chartData.getStat(model, primaryMetric);
-      if (!stat || stat.p50 >= fastestPrimary) return;
-      fastestPrimary = stat.p50;
-      fastestLatencyModel = model;
-      fastestLatencyProvider = parseModelKey(model).provider;
-    });
-    // TTFT is stored in seconds; display in ms like TTFA
-    avgPrimary = fastestPrimary !== Infinity ? fastestPrimary * 1000 : 0;
-
-    const sttSecondaryData = currentData.filter(
+    const primaryData = currentData.filter(
+      (item) => item.metric_type === primaryMetric
+    );
+    const secondaryData = currentData.filter(
       (item) => item.metric_type === secondaryMetric
     );
-    if (selectedModels.length === 1) {
-      if (sttSecondaryData.length > 0) {
-        avgSecondary =
-          sttSecondaryData.reduce(
-            (sum, item) => sum + (item.metric_value ?? 0),
-            0
-          ) / sttSecondaryData.length;
+
+    const groupByModel = (rows: BenchmarkData[]) => {
+      const map = new Map<string, BenchmarkData[]>();
+      for (const item of rows) {
+        const key = `${item.model}\x00${item.provider}`;
+        const arr = map.get(key);
+        if (arr) arr.push(item);
+        else map.set(key, [item]);
       }
-    } else {
-      const modelMetrics: {
-        [key: string]: { avgSecondary: number; provider: string };
-      } = {};
+      return map;
+    };
+    const primaryByModel = groupByModel(primaryData);
+    const secondaryByModel = groupByModel(secondaryData);
 
-      selectedModels.forEach((model) => {
-        const { model: modelSlug, provider: modelProvider } = parseModelKey(model);
-        const modelSecondaryData = sttSecondaryData.filter(
-          (item) => item.model === modelSlug && item.provider === modelProvider
-        );
+    let avgPrimary = 0;
+    let avgSecondary = 0;
+    let fastestLatencyModel = "";
+    let lowestWERModel = "";
+    let fastestLatencyProvider = "";
+    let lowestWERProvider = "";
 
-        let modelAvgSecondary = Infinity;
-        if (modelSecondaryData.length > 0) {
-          modelAvgSecondary =
-            modelSecondaryData.reduce(
+    if (deferredSelectedModels.length === 0) {
+      avgPrimary = 0;
+      avgSecondary = 0;
+    } else if (page === "stt") {
+      let fastestPrimary = Infinity;
+      deferredSelectedModels.forEach((model) => {
+        const stat = getStat(model, primaryMetric);
+        if (!stat || stat.p50 >= fastestPrimary) return;
+        fastestPrimary = stat.p50;
+        fastestLatencyModel = model;
+        fastestLatencyProvider = parseModelKey(model).provider;
+      });
+      // TTFT is stored in seconds; display in ms like TTFA
+      avgPrimary = fastestPrimary !== Infinity ? fastestPrimary * 1000 : 0;
+
+      if (deferredSelectedModels.length === 1) {
+        if (secondaryData.length > 0) {
+          avgSecondary =
+            secondaryData.reduce(
               (sum, item) => sum + (item.metric_value ?? 0),
               0
-            ) / modelSecondaryData.length;
+            ) / secondaryData.length;
         }
+      } else {
+        const modelMetrics: {
+          [key: string]: { avgSecondary: number; provider: string };
+        } = {};
 
-        const provider = modelSecondaryData[0]?.provider ?? "Unknown";
-        modelMetrics[model] = {
-          avgSecondary: modelAvgSecondary,
-          provider: provider,
-        };
-      });
+        deferredSelectedModels.forEach((model) => {
+          const { model: modelSlug, provider: modelProvider } =
+            parseModelKey(model);
+          const modelSecondaryData =
+            secondaryByModel.get(`${modelSlug}\x00${modelProvider}`) ?? [];
 
-      let lowestSecondary = Infinity;
-      Object.entries(modelMetrics).forEach(([model, metrics]) => {
-        if (
-          metrics.avgSecondary < lowestSecondary &&
-          metrics.avgSecondary !== Infinity
-        ) {
-          lowestSecondary = metrics.avgSecondary;
-          lowestWERModel = model;
-          lowestWERProvider = metrics.provider;
-        }
-      });
+          let modelAvgSecondary = Infinity;
+          if (modelSecondaryData.length > 0) {
+            modelAvgSecondary =
+              modelSecondaryData.reduce(
+                (sum, item) => sum + (item.metric_value ?? 0),
+                0
+              ) / modelSecondaryData.length;
+          }
 
-      avgSecondary = lowestSecondary !== Infinity ? lowestSecondary : 0;
-    }
-  } else {
-    // TTS logic
-    if (selectedModels.length === 1) {
-      if (primaryData.length > 0) {
-        const primaryValues = primaryData.map((item) => item.metric_value ?? 0);
-        const sortedPrimary = primaryValues.sort((a, b) => a - b);
-        const medianIndex = Math.floor(sortedPrimary.length / 2);
-        avgPrimary =
-          sortedPrimary.length % 2 === 0
-            ? ((sortedPrimary[medianIndex - 1] ?? 0) + (sortedPrimary[medianIndex] ?? 0)) / 2
-            : (sortedPrimary[medianIndex] ?? 0);
-      }
+          const provider = modelSecondaryData[0]?.provider ?? "Unknown";
+          modelMetrics[model] = {
+            avgSecondary: modelAvgSecondary,
+            provider: provider,
+          };
+        });
 
-      if (secondaryData.length > 0) {
-        avgSecondary =
-          secondaryData.reduce(
-            (sum, item) => sum + (item.metric_value ?? 0),
-            0
-          ) / secondaryData.length;
+        let lowestSecondary = Infinity;
+        Object.entries(modelMetrics).forEach(([model, metrics]) => {
+          if (
+            metrics.avgSecondary < lowestSecondary &&
+            metrics.avgSecondary !== Infinity
+          ) {
+            lowestSecondary = metrics.avgSecondary;
+            lowestWERModel = model;
+            lowestWERProvider = metrics.provider;
+          }
+        });
+
+        avgSecondary = lowestSecondary !== Infinity ? lowestSecondary : 0;
       }
     } else {
-      const modelMetrics: {
-        [key: string]: {
-          medianPrimary: number;
-          avgSecondary: number;
-          provider: string;
-        };
-      } = {};
-
-      selectedModels.forEach((model) => {
-        const { model: modelSlug, provider: modelProvider } = parseModelKey(model);
-        const modelPrimaryData = primaryData.filter(
-          (item) => item.model === modelSlug && item.provider === modelProvider
-        );
-        const modelSecondaryData = secondaryData.filter(
-          (item) => item.model === modelSlug && item.provider === modelProvider
-        );
-
-        let modelMedianPrimary = Infinity;
-        let modelAvgSecondary = Infinity;
-
-        if (modelPrimaryData.length > 0) {
-          const primaryValues = modelPrimaryData.map(
+      // TTS logic
+      if (deferredSelectedModels.length === 1) {
+        if (primaryData.length > 0) {
+          const primaryValues = primaryData.map(
             (item) => item.metric_value ?? 0
           );
-          const sortedPrimary = primaryValues.sort((a, b) => a - b);
-          const medianIndex = Math.floor(sortedPrimary.length / 2);
-          modelMedianPrimary =
-            sortedPrimary.length % 2 === 0
-              ? ((sortedPrimary[medianIndex - 1] ?? 0) + (sortedPrimary[medianIndex] ?? 0)) / 2
-              : (sortedPrimary[medianIndex] ?? 0);
+          avgPrimary = median(primaryValues);
         }
 
-        if (modelSecondaryData.length > 0) {
-          modelAvgSecondary =
-            modelSecondaryData.reduce(
+        if (secondaryData.length > 0) {
+          avgSecondary =
+            secondaryData.reduce(
               (sum, item) => sum + (item.metric_value ?? 0),
               0
-            ) / modelSecondaryData.length;
+            ) / secondaryData.length;
         }
+      } else {
+        const modelMetrics: {
+          [key: string]: {
+            medianPrimary: number;
+            avgSecondary: number;
+            provider: string;
+          };
+        } = {};
 
-        const provider =
-          (modelPrimaryData[0] ?? modelSecondaryData[0])?.provider ?? "Unknown";
+        deferredSelectedModels.forEach((model) => {
+          const { model: modelSlug, provider: modelProvider } =
+            parseModelKey(model);
+          const mapKey = `${modelSlug}\x00${modelProvider}`;
+          const modelPrimaryData = primaryByModel.get(mapKey) ?? [];
+          const modelSecondaryData = secondaryByModel.get(mapKey) ?? [];
 
-        modelMetrics[model] = {
-          medianPrimary: modelMedianPrimary,
-          avgSecondary: modelAvgSecondary,
-          provider: provider,
-        };
-      });
+          let modelMedianPrimary = Infinity;
+          let modelAvgSecondary = Infinity;
 
-      let fastestPrimary = Infinity;
-      let lowestSecondary = Infinity;
+          if (modelPrimaryData.length > 0) {
+            const primaryValues = modelPrimaryData.map(
+              (item) => item.metric_value ?? 0
+            );
+            modelMedianPrimary = median(primaryValues);
+          }
 
-      Object.entries(modelMetrics).forEach(([model, metrics]) => {
-        if (
-          metrics.medianPrimary < fastestPrimary &&
-          metrics.medianPrimary !== Infinity
-        ) {
-          fastestPrimary = metrics.medianPrimary;
-          fastestLatencyModel = model;
-          fastestLatencyProvider = normalizeTTSProviderName(metrics.provider);
-        }
-        if (
-          metrics.avgSecondary < lowestSecondary &&
-          metrics.avgSecondary !== Infinity
-        ) {
-          lowestSecondary = metrics.avgSecondary;
-          lowestWERModel = model;
-          lowestWERProvider = normalizeTTSProviderName(metrics.provider);
-        }
-      });
+          if (modelSecondaryData.length > 0) {
+            modelAvgSecondary =
+              modelSecondaryData.reduce(
+                (sum, item) => sum + (item.metric_value ?? 0),
+                0
+              ) / modelSecondaryData.length;
+          }
 
-      avgPrimary = fastestPrimary !== Infinity ? fastestPrimary : 0;
-      avgSecondary = lowestSecondary !== Infinity ? lowestSecondary : 0;
+          const provider =
+            (modelPrimaryData[0] ?? modelSecondaryData[0])?.provider ??
+            "Unknown";
+
+          modelMetrics[model] = {
+            medianPrimary: modelMedianPrimary,
+            avgSecondary: modelAvgSecondary,
+            provider: provider,
+          };
+        });
+
+        let fastestPrimary = Infinity;
+        let lowestSecondary = Infinity;
+
+        Object.entries(modelMetrics).forEach(([model, metrics]) => {
+          if (
+            metrics.medianPrimary < fastestPrimary &&
+            metrics.medianPrimary !== Infinity
+          ) {
+            fastestPrimary = metrics.medianPrimary;
+            fastestLatencyModel = model;
+            fastestLatencyProvider = normalizeTTSProviderName(metrics.provider);
+          }
+          if (
+            metrics.avgSecondary < lowestSecondary &&
+            metrics.avgSecondary !== Infinity
+          ) {
+            lowestSecondary = metrics.avgSecondary;
+            lowestWERModel = model;
+            lowestWERProvider = normalizeTTSProviderName(metrics.provider);
+          }
+        });
+
+        avgPrimary = fastestPrimary !== Infinity ? fastestPrimary : 0;
+        avgSecondary = lowestSecondary !== Infinity ? lowestSecondary : 0;
+      }
     }
-  }
+
+    return {
+      avgPrimary,
+      avgSecondary,
+      fastestLatencyModel,
+      lowestWERModel,
+      fastestLatencyProvider,
+      lowestWERProvider,
+    };
+  }, [getCurrentData, getStat, deferredSelectedModels, page]);
+
+  const {
+    avgPrimary,
+    avgSecondary,
+    fastestLatencyModel,
+    lowestWERModel,
+    fastestLatencyProvider,
+    lowestWERProvider,
+  } = keyMetrics;
 
   // Get computed data
   const scatterData = chartData.getScatterData();

--- a/web/lib/utils/median.ts
+++ b/web/lib/utils/median.ts
@@ -1,0 +1,38 @@
+// Copyright 2026 The Coval Benchmarks Authors
+// SPDX-License-Identifier: Apache-2.0
+
+function selectKth(arr: number[], k: number): number {
+  let lo = 0;
+  let hi = arr.length - 1;
+  while (lo < hi) {
+    const mid = (lo + hi) >> 1;
+    const a = arr[lo]!;
+    const b = arr[mid]!;
+    const c = arr[hi]!;
+    const pivot =
+      a < b ? (b < c ? b : a < c ? c : a) : a < c ? a : b < c ? c : b;
+    let i = lo - 1;
+    let j = hi + 1;
+    for (;;) {
+      do i++;
+      while (arr[i]! < pivot);
+      do j--;
+      while (arr[j]! > pivot);
+      if (i >= j) break;
+      const tmp = arr[i]!;
+      arr[i] = arr[j]!;
+      arr[j] = tmp;
+    }
+    if (k <= j) hi = j;
+    else lo = j + 1;
+  }
+  return arr[k]!;
+}
+
+export function median(values: number[]): number {
+  const n = values.length;
+  if (n === 0) return 0;
+  const mid = n >> 1;
+  if (n % 2 === 1) return selectKth(values.slice(), mid);
+  return (selectKth(values.slice(), mid - 1) + selectKth(values.slice(), mid)) / 2;
+}


### PR DESCRIPTION
Toggling a model re-computed every selected model's chart data on every click, so it got slower as data grew. Now each model's series is built once on load, and a toggle only touches the clicked model — the cost stays flat as we add providers, models, and history.

- Per-model precompute for scatter/timeline/violin/heatmap
- Key-metrics memoized + grouped in one pass (was re-filtering per model every render)
- Charts read a deferred selection — checkbox responds instantly
- Chart animations off; quickselect instead of full-sort median

Same numbers shown, just computed cheaply. Page-load work is a separate follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Refactored chart data pipeline to precompute model aggregates, improving responsiveness when selecting and switching between models and analysis tabs.
  * Deferred model selection updates to reduce UI rendering overhead during rapid interactions.
  * Disabled animations on bar, scatter, and timeline charts for faster visual updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->