### PR TITLE
Fix invalid core-js placeholder in pnpm-workspace.yaml

### DIFF
--- a/web/pnpm-workspace.yaml
+++ b/web/pnpm-workspace.yaml
@@ -1,5 +1,5 @@
 allowBuilds:
-  core-js: set this to true or false
+  core-js: false
   esbuild: true
   sharp: true
   unrs-resolver: true


### PR DESCRIPTION
## Summary
`web/pnpm-workspace.yaml` shipped with a leftover placeholder for the `allowBuilds.core-js` entry — the literal string `set this to true or false` instead of a boolean (flagged by CodeRabbit on #67).

Set it to `false`: `core-js` only emits a cosmetic postinstall banner and needs no build script, consistent with how the other entries are explicit booleans.

```diff
 allowBuilds:
-  core-js: set this to true or false
+  core-js: false
   esbuild: true
   sharp: true
   unrs-resolver: true
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workspace build configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->