### PR TITLE
Add results created_at index

### DIFF
--- a/runner/src/coval_bench/api/routers/results.py
+++ b/runner/src/coval_bench/api/routers/results.py
@@ -18,8 +18,8 @@ Note on window routing:
 * ``window=24h``: queries the live ``benchmarks_v2.results`` table directly with a
   24-hour filter. The ``results_24h`` materialized view is NOT used here because it
   aggregates by (provider, model, benchmark, metric_type) and lacks row-level columns
-  (id, voice, metric_value, etc.) required by ``ResultOut``. The existing index
-  ``results_provider_model_idx`` supports this path.
+  (id, voice, metric_value, etc.) required by ``ResultOut``. The index
+  ``results_benchmark_created_at_idx`` supports this path.
 * ``window=7d|30d``: live table join with interval filter.
 * ``since``/``until``: live table join with explicit timestamp bounds.
 """

--- a/runner/src/coval_bench/db/migrations/versions/20260605_0004_add_results_benchmark_created_at_idx.py
+++ b/runner/src/coval_bench/db/migrations/versions/20260605_0004_add_results_benchmark_created_at_idx.py
@@ -1,0 +1,33 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Add (benchmark, created_at) index on results.
+
+The TTS/STT dashboards (GET /v1/results) and the live 7d/30d leaderboard
+filter results by benchmark plus a created_at window. No existing index
+covers that path — results_provider_model_idx leads with provider/model,
+which those queries don't filter on — so they seq-scan the whole table.
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "20260605_0004"
+down_revision = "20260602_0003"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Add the (benchmark, created_at DESC) index."""
+    op.execute("SET search_path TO benchmarks_v2")
+    op.execute(
+        "CREATE INDEX results_benchmark_created_at_idx ON results (benchmark, created_at DESC)"
+    )
+
+
+def downgrade() -> None:
+    """Drop the index."""
+    op.execute("SET search_path TO benchmarks_v2")
+    op.execute("DROP INDEX IF EXISTS results_benchmark_created_at_idx")

--- a/runner/src/coval_bench/db/migrations/versions/20260605_0004_add_results_benchmark_created_at_idx.py
+++ b/runner/src/coval_bench/db/migrations/versions/20260605_0004_add_results_benchmark_created_at_idx.py
@@ -7,6 +7,12 @@ The TTS/STT dashboards (GET /v1/results) and the live 7d/30d leaderboard
 filter results by benchmark plus a created_at window. No existing index
 covers that path — results_provider_model_idx leads with provider/model,
 which those queries don't filter on — so they seq-scan the whole table.
+
+CONCURRENTLY avoids blocking runner inserts during the build, so it must
+run outside a transaction (autocommit_block). If the build fails it leaves
+an INVALID index; drop it manually before re-running migrate:
+
+    DROP INDEX benchmarks_v2.results_benchmark_created_at_idx;
 """
 
 from __future__ import annotations
@@ -20,14 +26,14 @@ depends_on = None
 
 
 def upgrade() -> None:
-    """Add the (benchmark, created_at DESC) index."""
-    op.execute("SET search_path TO benchmarks_v2")
-    op.execute(
-        "CREATE INDEX results_benchmark_created_at_idx ON results (benchmark, created_at DESC)"
-    )
+    """Add the (benchmark, created_at DESC) index without blocking writes."""
+    with op.get_context().autocommit_block():
+        op.execute(
+            "CREATE INDEX CONCURRENTLY results_benchmark_created_at_idx "
+            "ON benchmarks_v2.results (benchmark, created_at DESC)"
+        )
 
 
 def downgrade() -> None:
     """Drop the index."""
-    op.execute("SET search_path TO benchmarks_v2")
-    op.execute("DROP INDEX IF EXISTS results_benchmark_created_at_idx")
+    op.execute("DROP INDEX IF EXISTS benchmarks_v2.results_benchmark_created_at_idx")


### PR DESCRIPTION
Our db is getting pretty large and we weren't indexing on the main query for STT/TTS pages. Led to some slow down. This fixes a bit of that slowdown.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Corrected internal routing notes to reference the proper index used for 24‑hour window result queries.

* **Infrastructure**
  * Added a non-blocking database index to improve performance of benchmark result and leaderboard queries filtered by creation time.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->