### PR TITLE
Add mobile nav, fix card layout on mobile, minor text updates

### DIFF
--- a/web/app/overview/overview-page-client.tsx
+++ b/web/app/overview/overview-page-client.tsx
@@ -27,17 +27,17 @@ export function OverviewPageClient() {
       />
       <DashboardHeader />
 
-      <main className="relative z-10 mx-auto flex min-h-[90vh] w-full max-w-5xl flex-1 flex-col px-6 pb-10 pt-[84px] md:pt-[96px]">
+      <main className="relative z-10 mx-auto flex min-h-[90vh] w-full max-w-5xl flex-1 flex-col px-4 sm:px-6 pb-10 pt-[84px] md:pt-[96px]">
         <h1 className="mx-auto max-w-xl text-balance text-center text-2xl font-medium leading-tight tracking-tight text-text-primary sm:text-3xl md:text-4xl">
-          Voice AI Benchmarks in real world conditions.
+          Voice AI benchmarks in real world conditions.
         </h1>
 
-        <p className="mx-auto mt-3 max-w-md text-pretty text-center text-sm leading-relaxed text-text-secondary md:text-base">
+        <p className="mx-auto mt-3 max-w-md text-pretty text-center text-base leading-snug text-text-secondary">
           Measuring the accuracy, latency, and quality of text-to-speech and
           speech-to-text models.
         </p>
 
-        <div className="mt-8">
+        <div className="mt-6 md:mt-8">
           <OverviewLeaderboards />
         </div>
       </main>

--- a/web/components/dashboard/DashboardFooter.tsx
+++ b/web/components/dashboard/DashboardFooter.tsx
@@ -34,7 +34,7 @@ const DashboardFooter: React.FC = () => {
         {/* .footer-bottom */}
         <div className="flex flex-col items-start gap-3">
           <span className="font-sans text-lg font-medium tracking-wide text-[#f2f1ee]">
-            Voice Model Benchmarks
+            Voice AI Benchmarks
           </span>
 
           <nav

--- a/web/components/dashboard/DashboardSkeleton.tsx
+++ b/web/components/dashboard/DashboardSkeleton.tsx
@@ -19,11 +19,11 @@ const Bar: React.FC<{ className?: string }> = ({ className = "" }) => (
 // font sizes), so the card height equals the loaded card. The metric grid uses
 // the default `align-items: stretch`, so all four match the tallest card.
 const MetricSkeleton: React.FC = () => (
-  <div className="text-left border border-border-secondary rounded-lg bg-white p-8 min-w-0">
+  <div className="text-left border border-border-secondary rounded-lg bg-white p-5 lg:p-8 min-w-0">
     <div className="text-[0.9rem] font-light text-text-secondary mb-2">
       <Bar className="h-[0.7em] w-24" />
     </div>
-    <div className="font-mono text-5xl font-bold mb-4 break-words leading-tight">
+    <div className="font-mono text-3xl sm:text-4xl lg:text-5xl font-bold mb-4 break-words leading-tight">
       <Bar className="h-[0.7em] w-32" />
     </div>
     <div className="text-text-secondary flex items-baseline gap-2">
@@ -76,7 +76,7 @@ const ChartSkeleton: React.FC = () => (
 // first chart card, each matching the height of its loaded counterpart.
 const DashboardSkeleton: React.FC = () => (
   <>
-    <div className="grid grid-cols-4 gap-4 mb-4 w-full">
+    <div className="grid grid-cols-2 lg:grid-cols-4 gap-[0.8rem] mb-[0.8rem] w-full">
       {["a", "b", "c", "d"].map((k) => (
         <MetricSkeleton key={k} />
       ))}

--- a/web/components/dashboard/KeyMetrics.tsx
+++ b/web/components/dashboard/KeyMetrics.tsx
@@ -31,16 +31,16 @@ const KeyMetrics: React.FC = () => {
   ];
 
   return (
-    <div className="grid grid-cols-4 gap-4 mb-4 w-full">
+    <div className="grid grid-cols-2 lg:grid-cols-4 gap-[0.8rem] mb-[0.8rem] w-full">
       {metrics.map((metric, index) => (
         <div
           key={index}
-          className="text-left border border-border-secondary rounded-lg bg-white p-8 min-w-0"
+          className="text-left border border-border-secondary rounded-lg bg-white p-5 lg:p-8 min-w-0"
         >
           <div className="text-[0.9rem] font-light text-text-secondary mb-2">
             {metric.label}
           </div>
-          <div className="font-mono text-5xl font-bold mb-4 break-words leading-tight">
+          <div className="font-mono text-3xl sm:text-4xl lg:text-5xl font-bold mb-4 break-words leading-tight">
             {metric.displayValue}
           </div>
           {metric.subtitle && (

--- a/web/components/layout/DashboardHeader.tsx
+++ b/web/components/layout/DashboardHeader.tsx
@@ -145,6 +145,7 @@ const DashboardHeader: React.FC = () => {
               key={section.href}
               href={section.href}
               aria-current={active ? "page" : undefined}
+              tabIndex={menuOpen ? undefined : -1}
               onClick={() => setMenuOpen(false)}
               className={`flex items-center rounded-xl px-4 py-4 text-2xl tracking-wide transition-colors ${
                 active
@@ -160,6 +161,7 @@ const DashboardHeader: React.FC = () => {
           href="https://github.com/coval-ai/benchmarks"
           target="_blank"
           rel="noopener noreferrer"
+          tabIndex={menuOpen ? undefined : -1}
           onClick={() => setMenuOpen(false)}
           className="mt-auto flex items-center gap-3 rounded-xl px-4 py-4 text-2xl tracking-wide text-text-secondary transition-colors hover:bg-hover-bg hover:text-text-primary"
         >

--- a/web/components/layout/DashboardHeader.tsx
+++ b/web/components/layout/DashboardHeader.tsx
@@ -16,8 +16,21 @@ const SECTIONS = [
   { href: "/playground", label: "Playground", short: "Playground" }
 ];
 
+// GitHub mark, reused in the desktop header and the mobile menu.
+const GithubIcon: React.FC = () => (
+  <svg viewBox="0 0 16 16" width={20} height={20} aria-hidden fill="currentColor">
+    <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z" />
+  </svg>
+);
+
 const DashboardHeader: React.FC = () => {
   const pathname = usePathname();
+  const [menuOpen, setMenuOpen] = React.useState(false);
+
+  // Close the mobile menu whenever the route changes.
+  React.useEffect(() => {
+    setMenuOpen(false);
+  }, [pathname]);
 
   return (
     <header className="fixed inset-x-0 top-0 z-50 h-[60px] border-b border-border-primary bg-white">
@@ -26,10 +39,10 @@ const DashboardHeader: React.FC = () => {
         <div className="flex flex-col justify-center leading-none">
           <Link
             href="/"
-            aria-label="Voice Model Benchmarks"
+            aria-label="Voice AI Benchmarks"
             className="font-sans text-lg font-medium tracking-wide text-text-primary transition-opacity hover:opacity-80"
           >
-            Voice Model Benchmarks
+            Voice AI Benchmarks
           </Link>
           <a
             href="https://www.coval.ai"
@@ -53,7 +66,7 @@ const DashboardHeader: React.FC = () => {
         {/* Section tabs — centered on the page, independent of the brand width */}
         <nav
           aria-label="Benchmark sections"
-          className="absolute left-1/2 top-0 flex h-full -translate-x-1/2 items-center gap-1"
+          className="absolute left-1/2 top-0 hidden h-full -translate-x-1/2 items-center gap-1 md:flex"
         >
           {SECTIONS.map((section) => {
             const active = pathname === section.href;
@@ -81,25 +94,79 @@ const DashboardHeader: React.FC = () => {
           })}
         </nav>
 
-        {/* GitHub — links to the public repo */}
+        {/* GitHub — links to the public repo (desktop only) */}
         <a
           href="https://github.com/coval-ai/benchmarks"
           target="_blank"
           rel="noopener noreferrer"
           aria-label="View source on GitHub"
-          className="ml-auto flex items-center text-text-secondary transition-colors hover:text-text-primary"
+          className="ml-auto hidden items-center text-text-secondary transition-colors hover:text-text-primary md:flex"
         >
-          <svg
-            viewBox="0 0 16 16"
-            width={20}
-            height={20}
-            aria-hidden
-            fill="currentColor"
-          >
-            <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z" />
-          </svg>
+          <GithubIcon />
         </a>
+
+        {/* Hamburger — opens the mobile menu (two-bar icon, mobile only) */}
+        <button
+          type="button"
+          onClick={() => setMenuOpen((open) => !open)}
+          aria-label={menuOpen ? "Close menu" : "Open menu"}
+          aria-expanded={menuOpen}
+          aria-controls="mobile-menu"
+          className="ml-auto flex h-10 w-10 flex-col items-center justify-center gap-1.5 text-text-primary md:hidden"
+        >
+          <span
+            className={`h-0.5 w-6 bg-current transition-transform duration-300 ease-out ${
+              menuOpen ? "translate-y-1 rotate-45" : ""
+            }`}
+          />
+          <span
+            className={`h-0.5 w-6 bg-current transition-transform duration-300 ease-out ${
+              menuOpen ? "-translate-y-1 -rotate-45" : ""
+            }`}
+          />
+        </button>
       </div>
+
+      {/* Mobile menu — fullscreen overlay with all global items (mobile only) */}
+      <nav
+        id="mobile-menu"
+        aria-label="Global navigation"
+        aria-hidden={!menuOpen}
+        className={`fixed inset-x-0 top-[60px] bottom-0 flex flex-col gap-2 bg-white px-4 py-6 transition-all duration-300 ease-out md:hidden ${
+          menuOpen
+            ? "translate-y-0 opacity-100 pointer-events-auto"
+            : "-translate-y-2 opacity-0 pointer-events-none"
+        }`}
+      >
+        {SECTIONS.map((section) => {
+          const active = pathname === section.href;
+          return (
+            <Link
+              key={section.href}
+              href={section.href}
+              aria-current={active ? "page" : undefined}
+              onClick={() => setMenuOpen(false)}
+              className={`flex items-center rounded-xl px-4 py-4 text-2xl tracking-wide transition-colors ${
+                active
+                  ? "bg-selected-bg font-medium text-text-primary"
+                  : "text-text-secondary hover:bg-hover-bg hover:text-text-primary"
+              }`}
+            >
+              {section.label}
+            </Link>
+          );
+        })}
+        <a
+          href="https://github.com/coval-ai/benchmarks"
+          target="_blank"
+          rel="noopener noreferrer"
+          onClick={() => setMenuOpen(false)}
+          className="mt-auto flex items-center gap-3 rounded-xl px-4 py-4 text-2xl tracking-wide text-text-secondary transition-colors hover:bg-hover-bg hover:text-text-primary"
+        >
+          <GithubIcon />
+          GitHub
+        </a>
+      </nav>
     </header>
   );
 };

--- a/web/components/layout/DashboardLayout.tsx
+++ b/web/components/layout/DashboardLayout.tsx
@@ -51,7 +51,7 @@ const DashboardLayout: React.FC<{ children: React.ReactNode }> = ({ children }) 
       {/* Content column — centered on the page (under the centered tabs). The
           18rem side gutters keep its left edge clear of the fixed sidebar
           (17rem wide) with a 1rem gap. The footer stays full-width. */}
-      <div className="relative z-10 transition-all duration-300 pt-20 p-8 pb-24 lg:pb-8 overflow-x-hidden mx-auto lg:w-[calc(100vw-36rem)]">
+      <div className="relative z-10 transition-all duration-300 pt-20 px-4 py-8 sm:px-8 pb-24 lg:pb-8 overflow-x-hidden mx-auto lg:w-[calc(100vw-36rem)]">
         <h1 className="mb-6 text-2xl font-bold tracking-tight text-text-primary">
           {benchmarkTitle}
         </h1>

--- a/web/components/overview/OverviewLeaderboards.tsx
+++ b/web/components/overview/OverviewLeaderboards.tsx
@@ -71,7 +71,7 @@ const OverviewLeaderboards: React.FC = () => {
   return (
     <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
       <LeaderboardCard
-        title="Text-to-Speech Leaderboard"
+        title="Text-to-Speech"
         metricLabel="Time to First Audio"
         rows={ttsRows}
         href="/tts"
@@ -79,7 +79,7 @@ const OverviewLeaderboards: React.FC = () => {
         error={ttsQuery.isError}
       />
       <LeaderboardCard
-        title="Speech-to-Text Leaderboard"
+        title="Speech-to-Text"
         metricLabel="Word Error Rate"
         rows={sttRows}
         href="/stt"

--- a/web/hooks/useDashboardState.tsx
+++ b/web/hooks/useDashboardState.tsx
@@ -437,8 +437,8 @@ export function useDashboardState(page: "tts" | "stt") {
     : "Compare performance metrics between different Speech-to-Text models for voice agent applications.";
   const sidebarTitle = "Models to Compare";
   const benchmarkTitle = page === "tts"
-    ? "Text to Speech Voice Model Benchmarks"
-    : "Speech to Text Voice Model Benchmarks";
+    ? "Text to Speech Voice AI Benchmarks"
+    : "Speech to Text Voice AI Benchmarks";
   const mobileSheetTitle = page === "tts"
     ? "Text-to-Speech Models"
     : "Speech-to-Text Models";

--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -5,6 +5,11 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   reactStrictMode: true,
+  // Allow loading dev resources when the dev server is opened from another device
+  // on the LAN (e.g. testing the mobile nav on a phone via the network IP).
+  // Without this, Next 16 blocks /_next/* dev resources cross-origin, so the page
+  // renders via SSR but never hydrates and interactive controls appear dead.
+  allowedDevOrigins: ["192.168.86.185"],
   // Dashboard pages fetch benchmark data directly from NEXT_PUBLIC_API_URL (FastAPI).
   // No rewrites needed — FastAPI allows CORS from the browser.
   // Playground routes go through Next.js route handlers (web/app/api/**) so provider

--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -3,13 +3,20 @@
 
 import type { NextConfig } from "next";
 
+// Hostnames allowed to load dev resources when the dev server is opened from
+// another device on the LAN (e.g. testing the mobile nav on a phone via the
+// network IP). Set NEXT_ALLOWED_DEV_ORIGINS to a comma-separated list of
+// hostnames (no scheme or port), e.g. "192.168.86.185,my-laptop.local".
+const allowedDevOrigins = (process.env.NEXT_ALLOWED_DEV_ORIGINS ?? "")
+  .split(",")
+  .map((origin) => origin.trim())
+  .filter(Boolean);
+
 const nextConfig: NextConfig = {
   reactStrictMode: true,
-  // Allow loading dev resources when the dev server is opened from another device
-  // on the LAN (e.g. testing the mobile nav on a phone via the network IP).
   // Without this, Next 16 blocks /_next/* dev resources cross-origin, so the page
   // renders via SSR but never hydrates and interactive controls appear dead.
-  allowedDevOrigins: ["192.168.86.185"],
+  allowedDevOrigins,
   // Dashboard pages fetch benchmark data directly from NEXT_PUBLIC_API_URL (FastAPI).
   // No rewrites needed — FastAPI allows CORS from the browser.
   // Playground routes go through Next.js route handlers (web/app/api/**) so provider

--- a/web/pnpm-workspace.yaml
+++ b/web/pnpm-workspace.yaml
@@ -1,5 +1,5 @@
 allowBuilds:
-  core-js: set this to true or false
+  core-js: false
   esbuild: true
   sharp: true
   unrs-resolver: true


### PR DESCRIPTION
## Summary
- Add a mobile navigation menu to the dashboard header
- Fix card layout on mobile (responsive padding/spacing on the overview page)
- Minor text/copy updates on the overview page (title casing, card titles, body text)
- Includes the prior fix for the invalid core-js placeholder in `pnpm-workspace.yaml`

## Changes
- `DashboardHeader.tsx` — mobile nav
- `overview-page-client.tsx`, `OverviewLeaderboards.tsx` — responsive layout + copy tweaks
- `DashboardLayout.tsx`, `DashboardFooter.tsx`, `DashboardSkeleton.tsx`, `KeyMetrics.tsx`, `useDashboardState.tsx` — supporting layout adjustments
- `next.config.ts`, `pnpm-workspace.yaml` — config

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added mobile hamburger navigation menu with fullscreen overlay for easier navigation on small screens.

* **Updates**
  * Rebranded "Voice Model Benchmarks" to "Voice AI Benchmarks" across the dashboard.
  * Simplified leaderboard card titles by removing redundant "Leaderboard" suffix.
  * Improved responsive layout and spacing across the dashboard for better mobile experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->