### PR TITLE
Add api route to grab summary statistics

### DIFF
--- a/runner/src/coval_bench/api/app.py
+++ b/runner/src/coval_bench/api/app.py
@@ -10,7 +10,7 @@ Usage::
 
 The factory wires the psycopg3 connection pool lifespan, CORS middleware
 (ADR-015 — configured in-app, not infra), slowapi rate-limiting (ADR-013),
-and all five routers.
+and all routers.
 """
 
 from __future__ import annotations
@@ -27,7 +27,7 @@ from slowapi.errors import RateLimitExceeded
 from slowapi.middleware import SlowAPIMiddleware
 
 from coval_bench.api.ratelimit import _rate_limit_handler, limiter
-from coval_bench.api.routers import health, leaderboard, providers, results, runs
+from coval_bench.api.routers import aggregates, health, leaderboard, providers, results, runs
 from coval_bench.config import Settings, get_settings
 from coval_bench.db.conn import lifespan_pool
 
@@ -104,6 +104,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     app.include_router(health.router)
     app.include_router(runs.router, prefix="/v1")
     app.include_router(results.router, prefix="/v1")
+    app.include_router(aggregates.router, prefix="/v1")
     app.include_router(leaderboard.router, prefix="/v1")
     app.include_router(providers.router, prefix="/v1")
 

--- a/runner/src/coval_bench/api/common.py
+++ b/runner/src/coval_bench/api/common.py
@@ -1,0 +1,35 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared API-layer literals and SQL fragments.
+
+Single home for definitions that multiple routers (and schemas) must agree
+on — adding a window or benchmark here updates every endpoint at once.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+BenchmarkLiteral = Literal["STT", "TTS"]
+WindowLiteral = Literal["24h", "7d", "30d"]
+
+# Fixed interval strings — looked up by Python, never user-interpolated into
+# SQL. Note: the leaderboard router keeps its own 7d/30d-only dict because its
+# 24h window is served by the results_24h materialized view, not a live query.
+WINDOW_INTERVALS: dict[str, str] = {
+    "24h": "24 hours",
+    "7d": "7 days",
+    "30d": "30 days",
+}
+
+# Bucket expression for chart timestamps: the run's cron trigger time,
+# falling back to created_at floored to the scheduler period for legacy rows.
+# Shared by /results and /results/aggregates so both bucket identically.
+# Expects ``r`` (results) and ``rn`` (runs) table aliases and a
+# ``schedule_period`` query parameter.
+SCHEDULED_AT_BUCKET_SQL = (
+    "COALESCE(rn.scheduled_at,"
+    " to_timestamp(floor(extract(epoch FROM r.created_at) / %(schedule_period)s)"
+    " * %(schedule_period)s))"
+)

--- a/runner/src/coval_bench/api/routers/aggregates.py
+++ b/runner/src/coval_bench/api/routers/aggregates.py
@@ -1,0 +1,130 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""GET /v1/results/aggregates — server-side dashboard aggregation.
+
+Serves the dashboard's chart data as pre-computed aggregates. Two blocks:
+
+* ``model_stats`` — per (provider, model, metric_type): avg, sample stddev
+  (n-1 denominator, coalesced to 0 for n=1), p25/p50/p75 (percentile_cont),
+  min, max, count.
+* ``series`` — per (provider, model, metric_type, scheduled_at bucket): avg and
+  count. The bucket falls back to created_at floored to the scheduler period
+  for legacy rows, identical to the COALESCE in GET /v1/results.
+
+Both blocks gate on result rows with status='success' and a non-null
+metric_value, from parent runs in (succeeded, partial).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import psycopg.rows
+import structlog
+from fastapi import APIRouter, Depends, Query
+from posthog import Posthog
+from psycopg_pool import AsyncConnectionPool
+from starlette.requests import Request
+
+from coval_bench.api.common import (
+    SCHEDULED_AT_BUCKET_SQL,
+    WINDOW_INTERVALS,
+    BenchmarkLiteral,
+    WindowLiteral,
+)
+from coval_bench.api.deps import capture_api_event, get_pool, get_posthog, get_settings
+from coval_bench.api.ratelimit import limiter
+from coval_bench.api.schemas import AggregatesResponse, ModelStatEntry, SeriesPoint
+from coval_bench.config import Settings
+
+logger = structlog.get_logger("coval_bench.api")
+
+router = APIRouter(tags=["results"])
+
+# Shared FROM/WHERE for both blocks.
+_FROM_WHERE = (
+    " FROM benchmarks_v2.results r"
+    " JOIN benchmarks_v2.runs rn ON rn.id = r.run_id"
+    " WHERE r.status = 'success'"
+    " AND rn.status IN ('succeeded', 'partial')"
+    " AND r.benchmark = %(benchmark)s"
+    " AND r.metric_value IS NOT NULL"
+    " AND r.created_at >= NOW() - %(interval)s::interval"
+)
+
+_STATS_SQL = (
+    "SELECT r.provider, r.model, r.metric_type,"
+    " AVG(r.metric_value)::float8 AS avg_value,"
+    " COALESCE(STDDEV_SAMP(r.metric_value), 0)::float8 AS stddev_value,"
+    " PERCENTILE_CONT(0.25) WITHIN GROUP (ORDER BY r.metric_value)::float8 AS p25,"
+    " PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY r.metric_value)::float8 AS p50,"
+    " PERCENTILE_CONT(0.75) WITHIN GROUP (ORDER BY r.metric_value)::float8 AS p75,"
+    " MIN(r.metric_value)::float8 AS min_value,"
+    " MAX(r.metric_value)::float8 AS max_value,"
+    " COUNT(*)::int AS sample_count" + _FROM_WHERE + " GROUP BY r.provider, r.model, r.metric_type"
+    " ORDER BY r.provider, r.model, r.metric_type"
+)
+
+# Bucket expression repeated in GROUP BY because a bare ``scheduled_at`` there
+# would resolve to the input column rn.scheduled_at, not the alias.
+_SERIES_SQL = (
+    "SELECT r.provider, r.model, r.metric_type,"
+    f" {SCHEDULED_AT_BUCKET_SQL} AS scheduled_at,"
+    " AVG(r.metric_value)::float8 AS avg_value,"
+    " COUNT(*)::int AS sample_count"
+    + _FROM_WHERE
+    + f" GROUP BY r.provider, r.model, r.metric_type, {SCHEDULED_AT_BUCKET_SQL}"
+    " ORDER BY 4, r.provider, r.model, r.metric_type"
+)
+
+
+@router.get("/results/aggregates", response_model=AggregatesResponse)
+@limiter.limit("60/minute")
+async def get_results_aggregates(
+    request: Request,  # required by slowapi
+    benchmark: BenchmarkLiteral = Query(...),
+    window: WindowLiteral = Query(default="24h"),
+    pool: AsyncConnectionPool[Any] = Depends(get_pool),
+    settings: Settings = Depends(get_settings),
+    posthog_client: Posthog | None = Depends(get_posthog),
+) -> AggregatesResponse:
+    """Return per-model stats and per-bucket series for one benchmark.
+
+    Args:
+        benchmark: One of STT, TTS.
+        window: Time window over results.created_at. Defaults to 24h.
+    """
+    params: dict[str, Any] = {
+        "benchmark": benchmark,
+        "interval": WINDOW_INTERVALS[window],
+    }
+    series_params: dict[str, Any] = {
+        **params,
+        "schedule_period": settings.schedule_period_seconds,
+    }
+
+    async with pool.connection() as conn:
+        conn.row_factory = psycopg.rows.dict_row
+        stat_rows = await (await conn.execute(_STATS_SQL, params)).fetchall()
+        series_rows = await (await conn.execute(_SERIES_SQL, series_params)).fetchall()
+
+    model_stats = [ModelStatEntry.model_validate(r) for r in stat_rows]
+    series = [SeriesPoint.model_validate(r) for r in series_rows]
+    capture_api_event(
+        posthog_client,
+        "results_aggregates_queried",
+        {
+            "benchmark": benchmark,
+            "window": window,
+            "model_stat_count": len(model_stats),
+            "series_point_count": len(series),
+            "$process_person_profile": False,
+        },
+    )
+    return AggregatesResponse(
+        benchmark=benchmark,
+        window=window,
+        model_stats=model_stats,
+        series=series,
+    )

--- a/runner/src/coval_bench/api/routers/leaderboard.py
+++ b/runner/src/coval_bench/api/routers/leaderboard.py
@@ -26,6 +26,7 @@ from posthog import Posthog
 from psycopg_pool import AsyncConnectionPool
 from starlette.requests import Request
 
+from coval_bench.api.common import BenchmarkLiteral, WindowLiteral
 from coval_bench.api.deps import capture_api_event, get_pool, get_posthog
 from coval_bench.api.ratelimit import limiter
 from coval_bench.api.schemas import LeaderboardEntry, LeaderboardResponse
@@ -35,8 +36,6 @@ logger = structlog.get_logger("coval_bench.api")
 router = APIRouter(tags=["leaderboard"])
 
 MetricLiteral = Literal["WER", "TTFA", "TTFT"]
-BenchmarkLiteral = Literal["STT", "TTS"]
-WindowLiteral = Literal["24h", "7d", "30d"]
 
 # Valid (metric, benchmark) combinations — lower is better for all.
 _VALID_COMBOS: set[tuple[str, str]] = {

--- a/runner/src/coval_bench/api/routers/results.py
+++ b/runner/src/coval_bench/api/routers/results.py
@@ -36,10 +36,16 @@ from posthog import Posthog
 from psycopg_pool import AsyncConnectionPool
 from starlette.requests import Request
 
-from coval_bench.api.deps import capture_api_event, get_pool, get_posthog
+from coval_bench.api.common import (
+    SCHEDULED_AT_BUCKET_SQL,
+    WINDOW_INTERVALS,
+    BenchmarkLiteral,
+    WindowLiteral,
+)
+from coval_bench.api.deps import capture_api_event, get_pool, get_posthog, get_settings
 from coval_bench.api.ratelimit import limiter
 from coval_bench.api.schemas import ResultOut, ResultsResponse
-from coval_bench.config import get_settings
+from coval_bench.config import Settings
 
 logger = structlog.get_logger("coval_bench.api")
 
@@ -48,25 +54,15 @@ router = APIRouter(tags=["results"])
 # ``MetricLiteral`` is kept as the type for the legacy ``metric`` param.
 # The canonical FE-facing param is ``metric_type`` (plain ``str``).
 MetricLiteral = Literal["WER", "TTFA", "TTFT", "RTF", "AUDIO_TO_FINAL"]
-BenchmarkLiteral = Literal["STT", "TTS"]
-WindowLiteral = Literal["24h", "7d", "30d"]
-
-# Fixed interval strings — looked up by Python, never user-interpolated into SQL.
-_WINDOW_INTERVALS: dict[str, str] = {
-    "24h": "24 hours",
-    "7d": "7 days",
-    "30d": "30 days",
-}
 
 # Base SELECT used by all three query paths.
+# S608 false-positive: the interpolated fragment is a fixed constant; user
+# values only ever bind through %(param)s placeholders.
 _SELECT = (
-    "SELECT r.id, r.run_id, r.provider, r.model, r.voice, r.benchmark,"
+    "SELECT r.id, r.run_id, r.provider, r.model, r.voice, r.benchmark,"  # noqa: S608
     " r.metric_type, r.metric_value, r.metric_units, r.audio_filename,"
     " r.created_at,"
-    " COALESCE(rn.scheduled_at,"
-    " to_timestamp(floor(extract(epoch FROM r.created_at) / %(schedule_period)s)"
-    " * %(schedule_period)s))"
-    " AS scheduled_at,"
+    f" {SCHEDULED_AT_BUCKET_SQL} AS scheduled_at,"
     " UPPER(rn.status) AS status"
     " FROM benchmarks_v2.results r"
     " JOIN benchmarks_v2.runs rn ON rn.id = r.run_id"
@@ -123,6 +119,7 @@ async def list_results(
         description="Maximum rows to return (1–100000, default 100000).",
     ),
     pool: AsyncConnectionPool[Any] = Depends(get_pool),
+    settings: Settings = Depends(get_settings),
     posthog_client: Posthog | None = Depends(get_posthog),
 ) -> ResultsResponse:
     """Return a newest-first page of successful benchmark results.
@@ -172,7 +169,7 @@ async def list_results(
     conditions: list[str] = ["r.status = 'success'"]
     params: dict[str, Any] = {
         "limit": limit,
-        "schedule_period": get_settings().schedule_period_seconds,
+        "schedule_period": settings.schedule_period_seconds,
     }
 
     if provider is not None:
@@ -195,7 +192,7 @@ async def list_results(
     # -- Time window / since-until conditions
     if window is not None:
         # Use a fixed-string interval from the lookup dict — never user-interpolated.
-        interval_str = _WINDOW_INTERVALS[window]
+        interval_str = WINDOW_INTERVALS[window]
         conditions.append(f"r.created_at >= NOW() - INTERVAL '{interval_str}'")  # noqa: S608
     else:
         # Path C: explicit since/until bounds (window is None when either is set)

--- a/runner/src/coval_bench/api/schemas.py
+++ b/runner/src/coval_bench/api/schemas.py
@@ -15,6 +15,8 @@ from typing import Literal
 
 from pydantic import BaseModel, ConfigDict
 
+from coval_bench.api.common import BenchmarkLiteral, WindowLiteral
+
 
 class RunOut(BaseModel):
     """API response schema for a benchmark run row."""
@@ -94,6 +96,52 @@ class ResultsResponse(BaseModel):
     """Response schema for GET /v1/results."""
 
     results: list[ResultOut]
+
+
+class ModelStatEntry(BaseModel):
+    """Per-(provider, model, metric_type) aggregate stats.
+
+    Lets us compute the stats server-side and just send the summaries.
+    """
+
+    provider: str
+    model: str
+    metric_type: str
+    avg_value: float
+    stddev_value: float
+    p25: float
+    p50: float
+    p75: float
+    min_value: float
+    max_value: float
+    sample_count: int
+
+
+class SeriesPoint(BaseModel):
+    """Per-(provider, model, metric_type) average for one scheduled_at bucket.
+
+    Used in all the timeline charts.
+    """
+
+    provider: str
+    model: str
+    metric_type: str
+    scheduled_at: datetime
+    avg_value: float
+    sample_count: int
+
+
+class AggregatesResponse(BaseModel):
+    """Response schema for GET /v1/results/aggregates.
+
+    Wraps and returns all our ModelStatEntry and SeriesPoint data for a time
+    window.
+    """
+
+    benchmark: BenchmarkLiteral
+    window: WindowLiteral
+    model_stats: list[ModelStatEntry]
+    series: list[SeriesPoint]
 
 
 class RunsResponse(BaseModel):

--- a/runner/tests/api/test_aggregates.py
+++ b/runner/tests/api/test_aggregates.py
@@ -1,0 +1,170 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for GET /v1/results/aggregates."""
+
+from __future__ import annotations
+
+import datetime as dt
+from datetime import datetime, timedelta
+from typing import Any
+
+import pytest
+from httpx import AsyncClient
+
+from tests.api.conftest import _insert_result, _insert_run
+
+
+async def test_empty_db_returns_empty_blocks(client: AsyncClient) -> None:
+    response = await client.get("/v1/results/aggregates", params={"benchmark": "STT"})
+    assert response.status_code == 200
+    body = response.json()
+    assert body["benchmark"] == "STT"
+    assert body["window"] == "24h"
+    assert body["model_stats"] == []
+    assert body["series"] == []
+
+
+async def test_benchmark_required(client: AsyncClient) -> None:
+    response = await client.get("/v1/results/aggregates")
+    assert response.status_code == 422
+
+
+async def test_model_stats_math(client: AsyncClient, postgresql: Any) -> None:
+    """avg / percentiles / stddev / min / max / count match known values."""
+    run_id = await _insert_run(postgresql)
+    for value in (1.0, 2.0, 3.0, 4.0):
+        await _insert_result(postgresql, run_id, metric_type="WER", metric_value=value)
+
+    response = await client.get("/v1/results/aggregates", params={"benchmark": "STT"})
+    assert response.status_code == 200
+    stats = response.json()["model_stats"]
+    assert len(stats) == 1
+    s = stats[0]
+    assert s["provider"] == "deepgram"
+    assert s["model"] == "nova-3"
+    assert s["metric_type"] == "WER"
+    assert s["avg_value"] == pytest.approx(2.5)
+    # percentile_cont linear interpolation
+    assert s["p25"] == pytest.approx(1.75)
+    assert s["p50"] == pytest.approx(2.5)
+    assert s["p75"] == pytest.approx(3.25)
+    # sample stddev of 1..4 = sqrt(5/3)
+    assert s["stddev_value"] == pytest.approx(1.2909944, rel=1e-6)
+    assert s["min_value"] == pytest.approx(1.0)
+    assert s["max_value"] == pytest.approx(4.0)
+    assert s["sample_count"] == 4
+
+
+async def test_single_sample_stddev_is_zero(client: AsyncClient, postgresql: Any) -> None:
+    """STDDEV_SAMP is NULL for n=1 — must be coalesced to 0 like the client did."""
+    run_id = await _insert_run(postgresql)
+    await _insert_result(postgresql, run_id, metric_value=3.5)
+
+    response = await client.get("/v1/results/aggregates", params={"benchmark": "STT"})
+    s = response.json()["model_stats"][0]
+    assert s["stddev_value"] == 0
+    assert s["sample_count"] == 1
+
+
+async def test_excludes_failed_null_and_other_benchmark(
+    client: AsyncClient, postgresql: Any
+) -> None:
+    """Failed rows, failed parent runs, null metric values, and the other
+    benchmark are all excluded from aggregation."""
+    run_id = await _insert_run(postgresql)
+    await _insert_result(postgresql, run_id, metric_value=1.0)
+    # Excluded: failed result row
+    await _insert_result(postgresql, run_id, metric_value=100.0, status="failed")
+    # Excluded: null metric_value
+    await _insert_result(postgresql, run_id, metric_value=None)
+    # Excluded: other benchmark
+    await _insert_result(
+        postgresql, run_id, metric_value=100.0, benchmark="TTS", metric_type="TTFA"
+    )
+    # Excluded: failed parent run
+    failed_run = await _insert_run(postgresql, status="failed")
+    await _insert_result(postgresql, failed_run, metric_value=100.0)
+
+    response = await client.get("/v1/results/aggregates", params={"benchmark": "STT"})
+    stats = response.json()["model_stats"]
+    assert len(stats) == 1
+    assert stats[0]["avg_value"] == pytest.approx(1.0)
+    assert stats[0]["sample_count"] == 1
+
+
+async def test_partial_runs_included(client: AsyncClient, postgresql: Any) -> None:
+    run_id = await _insert_run(postgresql, status="partial")
+    await _insert_result(postgresql, run_id, metric_value=2.0)
+
+    response = await client.get("/v1/results/aggregates", params={"benchmark": "STT"})
+    assert response.json()["model_stats"][0]["sample_count"] == 1
+
+
+async def test_series_buckets_by_scheduled_at(client: AsyncClient, postgresql: Any) -> None:
+    """Results from one run share its scheduled_at bucket; values average."""
+    scheduled = datetime(2026, 6, 5, 12, 0, 0, tzinfo=dt.UTC)
+    run_id = await _insert_run(postgresql, scheduled_at=scheduled)
+    await _insert_result(postgresql, run_id, metric_value=1.0)
+    await _insert_result(postgresql, run_id, metric_value=3.0)
+
+    response = await client.get("/v1/results/aggregates", params={"benchmark": "STT"})
+    series = response.json()["series"]
+    assert len(series) == 1
+    point = series[0]
+    assert datetime.fromisoformat(point["scheduled_at"]) == scheduled
+    assert point["avg_value"] == pytest.approx(2.0)
+    assert point["sample_count"] == 2
+
+
+async def test_series_legacy_rows_floor_created_at(client: AsyncClient, postgresql: Any) -> None:
+    """Runs without scheduled_at fall back to created_at floored to the
+    schedule period (1800s default), same as GET /v1/results."""
+    run_id = await _insert_run(postgresql, scheduled_at=None)
+    created = datetime.now(dt.UTC) - timedelta(minutes=10)
+    await _insert_result(postgresql, run_id, created_at=created, metric_value=1.0)
+
+    response = await client.get("/v1/results/aggregates", params={"benchmark": "STT"})
+    series = response.json()["series"]
+    assert len(series) == 1
+    bucket = datetime.fromisoformat(series[0]["scheduled_at"])
+    expected_epoch = created.timestamp() // 1800 * 1800
+    assert bucket.timestamp() == pytest.approx(expected_epoch)
+
+
+async def test_window_excludes_old_rows(client: AsyncClient, postgresql: Any) -> None:
+    run_id = await _insert_run(postgresql)
+    old = datetime.now(dt.UTC) - timedelta(days=10)
+    await _insert_result(postgresql, run_id, created_at=old, metric_value=1.0)
+
+    response_24h = await client.get("/v1/results/aggregates", params={"benchmark": "STT"})
+    assert response_24h.json()["model_stats"] == []
+
+    response_30d = await client.get(
+        "/v1/results/aggregates", params={"benchmark": "STT", "window": "30d"}
+    )
+    assert response_30d.json()["model_stats"][0]["sample_count"] == 1
+
+
+async def test_models_grouped_separately(client: AsyncClient, postgresql: Any) -> None:
+    """Distinct (provider, model, metric_type) groups stay separate and sorted."""
+    run_id = await _insert_run(postgresql)
+    await _insert_result(postgresql, run_id, provider="deepgram", model="nova-3", metric_value=1.0)
+    await _insert_result(postgresql, run_id, provider="assemblyai", model="best", metric_value=2.0)
+    await _insert_result(
+        postgresql,
+        run_id,
+        provider="deepgram",
+        model="nova-3",
+        metric_type="TTFT",
+        metric_value=0.5,
+    )
+
+    response = await client.get("/v1/results/aggregates", params={"benchmark": "STT"})
+    stats = response.json()["model_stats"]
+    keys = [(s["provider"], s["model"], s["metric_type"]) for s in stats]
+    assert keys == [
+        ("assemblyai", "best", "WER"),
+        ("deepgram", "nova-3", "TTFT"),
+        ("deepgram", "nova-3", "WER"),
+    ]

--- a/runner/tests/api/test_results.py
+++ b/runner/tests/api/test_results.py
@@ -10,6 +10,7 @@ from datetime import datetime, timedelta
 from typing import Any
 
 import pytest
+from fastapi import FastAPI
 from httpx import AsyncClient
 
 from coval_bench.config import Settings
@@ -328,27 +329,26 @@ async def test_limit_zero_rejected(client: AsyncClient) -> None:
     assert response.status_code == 422
 
 
-def _patch_period(monkeypatch: pytest.MonkeyPatch, seconds: int) -> None:
-    """Force the results endpoint to read a specific schedule_period_seconds.
+def _patch_period(app: FastAPI, monkeypatch: pytest.MonkeyPatch, seconds: int) -> None:
+    """Force the endpoint to read a specific schedule_period_seconds.
 
-    Patches the module-level ``get_settings`` reference rather than the shared
-    ``lru_cache``, so nothing leaks into other tests and monkeypatch reverts it.
+    The handler reads Settings from ``app.state`` via ``Depends(get_settings)``,
+    so patch the state object; monkeypatch reverts it after the test.
     """
     monkeypatch.setattr(
-        "coval_bench.api.routers.results.get_settings",
-        lambda: Settings(schedule_period_seconds=seconds),
+        app.state, "settings", Settings(schedule_period_seconds=seconds), raising=False
     )
 
 
 async def test_scheduled_at_fallback_uses_configured_period(
-    client: AsyncClient, postgresql: Any, monkeypatch: pytest.MonkeyPatch
+    app: FastAPI, client: AsyncClient, postgresql: Any, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """NULL scheduled_at falls back to created_at floored to the configured period.
 
     With a 900s period, a created_at at :20 past the hour floors to :15 (900s grid),
     not :00 (the old hardcoded 1800s grid) — proving the fallback tracks config.
     """
-    _patch_period(monkeypatch, 900)
+    _patch_period(app, monkeypatch, 900)
     run_id = await _insert_run(postgresql)  # scheduled_at left NULL
     created = (_now() - timedelta(hours=1)).replace(minute=20, second=0, microsecond=0)
     await _insert_result(postgresql, run_id, created_at=created)
@@ -363,14 +363,14 @@ async def test_scheduled_at_fallback_uses_configured_period(
 
 
 async def test_scheduled_at_uses_stamped_value(
-    client: AsyncClient, postgresql: Any, monkeypatch: pytest.MonkeyPatch
+    app: FastAPI, client: AsyncClient, postgresql: Any, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """A stamped scheduled_at is returned verbatim — COALESCE never hits the fallback.
 
     The stored value (:00) is returned unchanged even though the created_at-based
     fallback under a 900s period would yield a different bucket (:15).
     """
-    _patch_period(monkeypatch, 900)
+    _patch_period(app, monkeypatch, 900)
     stamped = (_now() - timedelta(hours=1)).replace(minute=0, second=0, microsecond=0)
     run_id = await _insert_run(postgresql, scheduled_at=stamped)
     created = (_now() - timedelta(hours=1)).replace(minute=20, second=0, microsecond=0)


### PR DESCRIPTION
Backend of #76. Gotta push this first as Vercel grabs routes from prod.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `/v1/results/aggregates` endpoint to retrieve pre-computed benchmark result statistics and time-series data, including per-model summary stats (averages, percentiles, standard deviation, min/max) and bucketed series points with configurable time windows.

* **Tests**
  * Added comprehensive test coverage for the new aggregates endpoint, including validation of summary statistics, time-series bucketing, and filtering logic.

* **Refactor**
  * Consolidated shared API constants and type definitions into a common module for consistency across endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->