### PR TITLE
Fix mobile heatmap white space below map

### DIFF
--- a/web/hooks/useDashboardState.tsx
+++ b/web/hooks/useDashboardState.tsx
@@ -108,15 +108,21 @@ export function useDashboardState(page: "tts" | "stt") {
             // Reset any prior scaling so measurements reflect natural layout
             heatmapContainer.style.transform = "";
             heatmapContainer.style.width = "";
+            heatmapContainer.style.height = "";
             const availableWidth =
               heatmapContainer.getBoundingClientRect().width;
             const heatmapWidth = heatmapSvg.getBoundingClientRect().width;
+            const heatmapHeight = heatmapSvg.getBoundingClientRect().height;
             const scaleFactor = availableWidth / heatmapWidth;
 
             if (scaleFactor < 1) {
               heatmapContainer.style.transform = `scale(${scaleFactor})`;
               heatmapContainer.style.transformOrigin = "top left";
               heatmapContainer.style.width = `${100 / scaleFactor}%`;
+              // A scaled element keeps its natural layout height, leaving
+              // white space below. Collapse the layout box to the scaled
+              // height so standard card padding applies beneath the map.
+              heatmapContainer.style.height = `${heatmapHeight * scaleFactor}px`;
             }
           }
         }, 100);
@@ -128,6 +134,7 @@ export function useDashboardState(page: "tts" | "stt") {
           heatmapContainer.style.transform = "";
           heatmapContainer.style.transformOrigin = "";
           heatmapContainer.style.width = "";
+          heatmapContainer.style.height = "";
         }
       }
     };


### PR DESCRIPTION
## Summary
On mobile, the heatmap card showed a large block of white space below the map before the standard card padding.

## Cause
The mobile scale transform (`transform: scale()` with `transform-origin: top left`) shrinks the heatmap visually, but a CSS-scaled element keeps its full **natural** layout height. That leftover `height × (1 − scaleFactor)` was the white space — card padding was applied below it.

## Fix
Capture the SVG's natural height before scaling and set the container's layout height to `heatmapHeight × scaleFactor` when a scale is applied, collapsing the layout box to match the visually-scaled map. The height is also reset in the pre-measure reset and the desktop branch so resizing back up restores natural height.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed mobile heatmap scaling to properly reset and recalculate container dimensions during scale transforms.
  * Resolved desktop heatmap height reset issues.

* **Style**
  * Improved WER bar visuals with enhanced opacity for non-selected bars.
  * Refined WER bar description text for clarity.

* **New Features**
  * Extended timeline data access in dashboard state management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->