### PR TITLE
Clean up mobile chart layout

### DIFF
--- a/web/components/charts/d3/BoxPlot.tsx
+++ b/web/components/charts/d3/BoxPlot.tsx
@@ -61,9 +61,12 @@ const BoxPlot: React.FC<BoxPlotProps> = ({
   useEffect(() => {
     if (!svgRef.current || data.data.length === 0) return;
 
-    // Left margin matches the recharts plots' 40px YAxis so the plot areas
-    // line up across cards.
-    const margin = { top: 20, right: 8, bottom: 80, left: 40 };
+    // STT hides the y-axis tick labels, so it needs almost no left margin —
+    // reclaim that space for a wider plot. TTS keeps room for the "1.4s" ticks.
+    const showYTicks = !(
+      data.metricType === "NTTFT" || data.metricType === "TTFT"
+    );
+    const margin = { top: 20, right: 8, bottom: 80, left: showYTicks ? 40 : 10 };
     const chartWidth = dimensions.width - margin.left - margin.right;
     const chartHeight = dimensions.height - margin.top - margin.bottom;
 
@@ -116,9 +119,14 @@ const BoxPlot: React.FC<BoxPlotProps> = ({
       .attr("stroke", themeColors.grid)
       .attr("stroke-dasharray", "2 2");
 
-    yAxisGroup.selectAll("text")
-      .attr("fill", themeColors.axisText)
-      .attr("font-size", yAxisTickFontSize);
+    // STT hides the y-axis tick labels (see showYTicks); TTS keeps them styled.
+    if (showYTicks) {
+      yAxisGroup.selectAll("text")
+        .attr("fill", themeColors.axisText)
+        .attr("font-size", yAxisTickFontSize);
+    } else {
+      yAxisGroup.selectAll("text").style("display", "none");
+    }
 
     yAxisGroup.select(".domain").remove();
 

--- a/web/components/dashboard/LatencyAccuracySection.tsx
+++ b/web/components/dashboard/LatencyAccuracySection.tsx
@@ -123,7 +123,7 @@ const LatencyAccuracySection: React.FC = () => {
               <YAxis
                 dataKey="y"
                 type="number"
-                name="WER"
+                name="WER (%)"
                 width={40}
                 domain={[0, yMax]}
                 ticks={yTicks}


### PR DESCRIPTION
## Summary
Mobile chart layout cleanup, rebased onto current `main`.

- **BoxPlot**: hide the y-axis tick labels for STT metrics (`NTTFT`/`TTFT`) and reclaim that left margin (40px → 10px) for a wider plot on narrow screens; TTS keeps its labels.
- **LatencyAccuracySection**: label the WER axis with units (`"WER (%)"`).

## Note on scope
This branch originally carried four commits, but three were already on `main` via other PRs and dropped out cleanly during the rebase:
- "Make chart-card text sizes consistent" — main's `SectionHeader` already uses the same `text-2xl` / `text-[0.9rem]` sizing.
- "Rotate accuracy bar labels to 45°" — already present in main's `CustomBarChartTick`.
- "Retrigger Vercel deploy" — empty no-op, removed.

During the rebase I also kept main's current design decisions where they superseded the old branch: dotted gridlines (`strokeDasharray="2 2"`) across BoxPlot/Timeline/AccuracyBar, and removed a duplicated `TimelineLegend` the rebase would otherwise have introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chart layout by dynamically adjusting axis margins based on data type and visibility requirements.
  * Fixed Y-axis label in latency accuracy charts to correctly display percentage units as "WER (%)".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->