### PR TITLE
Fix/overview uses aggregates

### DIFF
--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -4,5 +4,5 @@
 import { redirect } from "next/navigation";
 
 export default function Home() {
-  redirect("/tts");
+  redirect("/overview");
 }

--- a/web/components/overview/OverviewLeaderboards.tsx
+++ b/web/components/overview/OverviewLeaderboards.tsx
@@ -4,56 +4,55 @@
 "use client";
 
 import React, { useMemo } from "react";
-import { useLeaderboardQuery } from "@/lib/api/queries";
+import { useAggregatesQuery } from "@/lib/api/queries";
 import {
   normalizeModelName,
   normalizeSTTProviderName,
   normalizeTTSProviderName,
   toModelKey,
 } from "@/lib/utils/formatters";
-import type { LeaderboardEntry } from "@/lib/api/client";
+import type { ModelStatEntry } from "@/lib/api/client";
 import LeaderboardCard, { type LeaderboardRow } from "./LeaderboardCard";
 
 const TOP_N = 5;
 
-/**
- * Map leaderboard entries (already sorted ascending by avg — lower is better)
- * into display rows, formatting each model's average with `formatValue`.
- */
+// Rank field is chosen to match the /tts and /stt pages exactly, so the
+// overview cards never disagree with the full leaderboards: TTS ranks by p50
+// of TTFA, STT by avg of WER. All are "lower is better".
 function toRows(
-  entries: LeaderboardEntry[] | undefined,
+  stats: ModelStatEntry[] | undefined,
+  metricType: string,
+  rankField: "p50" | "avg_value",
   normalizeProvider: (p: string) => string,
-  formatValue: (avg: number) => string
+  formatValue: (value: number) => string
 ): LeaderboardRow[] {
-  if (!entries) return [];
-  return entries.slice(0, TOP_N).map((entry) => ({
-    key: toModelKey(entry.provider, entry.model),
-    model: normalizeModelName(toModelKey(entry.provider, entry.model)),
-    provider: normalizeProvider(entry.provider),
-    value: formatValue(entry.avg),
-  }));
+  if (!stats) return [];
+  return stats
+    .filter((s) => s.metric_type === metricType)
+    .sort((a, b) => a[rankField] - b[rankField])
+    .slice(0, TOP_N)
+    .map((s) => ({
+      key: toModelKey(s.provider, s.model),
+      model: normalizeModelName(toModelKey(s.provider, s.model)),
+      provider: normalizeProvider(s.provider),
+      value: formatValue(s[rankField]),
+    }));
 }
 
 const OverviewLeaderboards: React.FC = () => {
-  // TTS ranked by Time to First Audio; STT ranked by Word Error Rate.
-  // Both metrics are "lower is better", so rank 1 is the API's first entry.
-  const ttsQuery = useLeaderboardQuery({
-    metric: "TTFA",
-    benchmark: "TTS",
-    window: "24h",
-  });
-  const sttQuery = useLeaderboardQuery({
-    metric: "WER",
-    benchmark: "STT",
-    window: "24h",
-  });
+  // Same endpoint and params the /tts and /stt pages use, so React Query
+  // serves both from one cache entry and the numbers are identical.
+  const ttsQuery = useAggregatesQuery({ benchmark: "TTS", window: "24h" });
+  const sttQuery = useAggregatesQuery({ benchmark: "STT", window: "24h" });
 
   const ttsRows = useMemo(
     () =>
       toRows(
-        ttsQuery.data?.entries,
+        ttsQuery.data?.model_stats,
+        "TTFA",
+        "p50",
         normalizeTTSProviderName,
-        (avg) => `${Math.round(avg)} ms`
+        (value) => `${Math.round(value)} ms`
       ),
     [ttsQuery.data]
   );
@@ -61,9 +60,11 @@ const OverviewLeaderboards: React.FC = () => {
   const sttRows = useMemo(
     () =>
       toRows(
-        sttQuery.data?.entries,
+        sttQuery.data?.model_stats,
+        "WER",
+        "avg_value",
         normalizeSTTProviderName,
-        (avg) => `${avg.toFixed(1)}%`
+        (value) => `${value.toFixed(1)}%`
       ),
     [sttQuery.data]
   );


### PR DESCRIPTION
Overview leaderboards now read the live `/v1/results/aggregates` endpoint instead of the stale `results_24h` materialized view. Also: `/` lands on `/overview`, not`/tts`.

Same endpoint, params, and ranking fields as the pages (TTS by p50 TTFA, STT by avg WER), so they can't drift apart.

Note:
Removes the last caller of `/v1/leaderboard` (it only powered these cards). The endpoint + `results_24h` MV are now orphaned. Deleting them is out of scope for this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Leaderboards completely redesigned to display top-performing models with metrics specifically optimized for TTS and STT use cases. The new interface provides enhanced visibility into model rankings, improved performance data presentation, and streamlined model comparison capabilities to help users make better-informed selection decisions
  * Home page navigation enhanced with improved routing and user experience optimization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->