### PR TITLE
New checkbox design + dashboard cleanup

### DIFF
--- a/web/app/stt/stt-dashboard.tsx
+++ b/web/app/stt/stt-dashboard.tsx
@@ -8,31 +8,34 @@ import { DashboardProvider } from "@/contexts/DashboardContext";
 import { SidebarMenuProvider } from "@/contexts/SidebarMenuContext";
 import DashboardLayout from "@/components/layout/DashboardLayout";
 import KeyMetrics from "@/components/dashboard/KeyMetrics";
+import { ChartSkeleton } from "@/components/dashboard/DashboardSkeleton";
 
-// Lazy-load heavy chart components — D3 and Recharts do not support SSR
+// Lazy-load heavy chart components — D3 and Recharts do not support SSR.
+// Each renders a chart-sized skeleton while its chunk loads so the page keeps
+// its full height and the footer never flashes up into view during the gap.
 const TimelineChart = dynamic(
   () => import("@/components/visualizations/TimelineChart"),
-  { ssr: false }
+  { ssr: false, loading: () => <ChartSkeleton /> }
 );
 
 const BoxPlotSection = dynamic(
   () => import("@/components/dashboard/BoxPlotSection"),
-  { ssr: false }
+  { ssr: false, loading: () => <ChartSkeleton /> }
 );
 
 const LatencyAccuracySection = dynamic(
   () => import("@/components/dashboard/LatencyAccuracySection"),
-  { ssr: false }
+  { ssr: false, loading: () => <ChartSkeleton /> }
 );
 
 const AccuracyBarSection = dynamic(
   () => import("@/components/dashboard/AccuracyBarSection"),
-  { ssr: false }
+  { ssr: false, loading: () => <ChartSkeleton /> }
 );
 
 const HeatmapSection = dynamic(
   () => import("@/components/dashboard/HeatmapSection"),
-  { ssr: false }
+  { ssr: false, loading: () => <ChartSkeleton /> }
 );
 
 export function STTDashboard() {

--- a/web/app/tts/tts-dashboard.tsx
+++ b/web/app/tts/tts-dashboard.tsx
@@ -8,31 +8,34 @@ import { DashboardProvider } from "@/contexts/DashboardContext";
 import { SidebarMenuProvider } from "@/contexts/SidebarMenuContext";
 import DashboardLayout from "@/components/layout/DashboardLayout";
 import KeyMetrics from "@/components/dashboard/KeyMetrics";
+import { ChartSkeleton } from "@/components/dashboard/DashboardSkeleton";
 
-// Lazy-load heavy chart components — D3 and Recharts do not support SSR
+// Lazy-load heavy chart components — D3 and Recharts do not support SSR.
+// Each renders a chart-sized skeleton while its chunk loads so the page keeps
+// its full height and the footer never flashes up into view during the gap.
 const TimelineChart = dynamic(
   () => import("@/components/visualizations/TimelineChart"),
-  { ssr: false }
+  { ssr: false, loading: () => <ChartSkeleton /> }
 );
 
 const BoxPlotSection = dynamic(
   () => import("@/components/dashboard/BoxPlotSection"),
-  { ssr: false }
+  { ssr: false, loading: () => <ChartSkeleton /> }
 );
 
 const LatencyAccuracySection = dynamic(
   () => import("@/components/dashboard/LatencyAccuracySection"),
-  { ssr: false }
+  { ssr: false, loading: () => <ChartSkeleton /> }
 );
 
 const AccuracyBarSection = dynamic(
   () => import("@/components/dashboard/AccuracyBarSection"),
-  { ssr: false }
+  { ssr: false, loading: () => <ChartSkeleton /> }
 );
 
 const HeatmapSection = dynamic(
   () => import("@/components/dashboard/HeatmapSection"),
-  { ssr: false }
+  { ssr: false, loading: () => <ChartSkeleton /> }
 );
 
 export function TTSDashboard() {

--- a/web/components/dashboard/DashboardSkeleton.tsx
+++ b/web/components/dashboard/DashboardSkeleton.tsx
@@ -39,7 +39,7 @@ const MetricSkeleton: React.FC = () => (
 // Mirrors the first chart card (TimelineChart). The wrapper (shared Card)
 // and SectionHeader structure match, and the h-96 chart area is reproduced
 // verbatim so the overall card height equals the loaded chart.
-const ChartSkeleton: React.FC = () => (
+export const ChartSkeleton: React.FC = () => (
   <div className="mb-4">
     <Card>
       {/* SectionHeader mirror */}
@@ -74,16 +74,23 @@ const ChartSkeleton: React.FC = () => (
   </div>
 );
 
-// Loading placeholder for the dashboard: the four key-metric cards plus the
-// first chart card, each matching the height of its loaded counterpart.
+// Loading placeholder for the dashboard: mirrors the full page so every
+// skeleton card is on screen at once — the two key-metric cards (matching
+// KeyMetrics) plus one chart card per chart section (TimelineChart, BoxPlot,
+// AccuracyBar, LatencyAccuracy, Heatmap). Each matches its loaded counterpart's
+// height, so nothing pops in after the top of the page has rendered.
+const CHART_SECTION_COUNT = 5;
+
 const DashboardSkeleton: React.FC = () => (
   <>
-    <div className="grid grid-cols-2 lg:grid-cols-4 gap-[0.8rem] mb-[0.8rem] w-full">
-      {["a", "b", "c", "d"].map((k) => (
+    <div className="grid grid-cols-2 gap-[0.8rem] mb-[0.8rem] w-full">
+      {["a", "b"].map((k) => (
         <MetricSkeleton key={k} />
       ))}
     </div>
-    <ChartSkeleton />
+    {Array.from({ length: CHART_SECTION_COUNT }, (_, i) => (
+      <ChartSkeleton key={i} />
+    ))}
   </>
 );
 

--- a/web/components/dashboard/KeyMetrics.tsx
+++ b/web/components/dashboard/KeyMetrics.tsx
@@ -20,19 +20,12 @@ const KeyMetrics: React.FC = () => {
   const {
     primaryKeyMetric: primary,
     secondaryKeyMetric: secondary,
-    modelsComparedMetric,
-    providersMetric,
   } = useDashboard();
 
-  const metrics: KeyMetricData[] = [
-    primary,
-    secondary,
-    modelsComparedMetric,
-    providersMetric,
-  ];
+  const metrics: KeyMetricData[] = [primary, secondary];
 
   return (
-    <div className="grid grid-cols-2 lg:grid-cols-4 gap-[0.8rem] mb-[0.8rem] w-full">
+    <div className="grid grid-cols-2 gap-[0.8rem] mb-[0.8rem] w-full">
       {metrics.map((metric, index) => (
         <Card key={index} className="text-left min-w-0" padding="p-5 lg:p-8">
 

--- a/web/components/layout/DashboardLayout.tsx
+++ b/web/components/layout/DashboardLayout.tsx
@@ -43,7 +43,7 @@ const DashboardLayout: React.FC<{ children: React.ReactNode }> = ({ children }) 
   }, [mode]);
 
   return (
-    <div className="relative min-h-screen overflow-hidden bg-background text-text-primary">
+    <div className="relative flex min-h-screen flex-col overflow-hidden bg-background text-text-primary">
       <DashboardHeader />
       <MobileModelSheet />
       <ModelSidebar />
@@ -51,7 +51,7 @@ const DashboardLayout: React.FC<{ children: React.ReactNode }> = ({ children }) 
       {/* Content column — centered on the page (under the centered tabs). The
           18rem side gutters keep its left edge clear of the fixed sidebar
           (17rem wide) with a 1rem gap. The footer stays full-width. */}
-      <div className="relative z-10 transition-all duration-300 pt-20 px-3 py-8 sm:px-8 pb-24 lg:pb-8 overflow-x-hidden mx-auto lg:w-[calc(100vw-36rem)]">
+      <div className="relative z-10 flex-1 transition-all duration-300 pt-20 px-3 py-8 sm:px-8 pb-24 lg:pb-8 overflow-x-hidden mx-auto lg:w-[calc(100vw-36rem)]">
         <h1 className="mb-6 text-2xl font-bold tracking-tight text-text-primary">
           {benchmarkTitle}
         </h1>

--- a/web/components/layout/ModelSidebar.tsx
+++ b/web/components/layout/ModelSidebar.tsx
@@ -95,14 +95,14 @@ const ModelSidebar: React.FC = () => {
                             aria-label={`${
                               checked ? "Deselect" : "Select"
                             } ${model} model`}
-                            className="peer h-3.5 w-3.5 shrink-0 cursor-pointer appearance-none rounded-[3px] border border-text-tertiary bg-transparent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-text-tertiary/40 focus-visible:ring-offset-1 focus-visible:ring-offset-background"
+                            className="peer h-3.5 w-3.5 shrink-0 cursor-pointer appearance-none rounded-[3px] bg-[#d4d2cc] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-text-tertiary/40 focus-visible:ring-offset-1 focus-visible:ring-offset-background"
                           />
                           <svg
                             aria-hidden
                             viewBox="0 0 14 14"
                             fill="none"
                             stroke="currentColor"
-                            strokeWidth={2}
+                            strokeWidth={1.5}
                             strokeLinecap="round"
                             strokeLinejoin="round"
                             className="pointer-events-none absolute inset-0 hidden h-3.5 w-3.5 text-text-primary peer-checked:block"

--- a/web/hooks/useDashboardState.tsx
+++ b/web/hooks/useDashboardState.tsx
@@ -307,18 +307,6 @@ export function useDashboardState(page: "tts" | "stt") {
         : undefined,
   };
 
-  const modelsComparedMetric = {
-    label: "Models Compared",
-    displayValue: `${selectedModels.length}`,
-  };
-
-  const providersMetric = {
-    label: "Providers",
-    displayValue: `${
-      new Set(selectedModels.map((model) => parseModelKey(model).provider)).size
-    }`,
-  };
-
   return {
     // Page identity
     latencyLabel,
@@ -338,8 +326,6 @@ export function useDashboardState(page: "tts" | "stt") {
     // Key metrics
     primaryKeyMetric,
     secondaryKeyMetric,
-    modelsComparedMetric,
-    providersMetric,
 
     // Data loading
     loading,


### PR DESCRIPTION
## Summary
- Redesign leaderboard model-selection checkboxes: remove border, use a darker filled background (`#d4d2cc`) for the unchecked shape, and narrow the checkmark stroke
- Fix loading flicker
- Remove provider and model stat cards
- Related dashboard skeleton / layout tweaks

## Test plan
- [ ] Verify checkboxes render correctly (unchecked filled square, checkmark when selected) on TTS/STT dashboards
- [ ] Confirm no loading flicker
- [ ] Confirm stat cards are removed as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)