### PR TITLE
Add ttl cache

### DIFF
--- a/runner/pyproject.toml
+++ b/runner/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "fastapi>=0.111",
     "uvicorn[standard]>=0.30",
     "slowapi>=0.1.9",
+    "cachetools>=5.3",
     # WebSocket clients (STT providers)
     "websockets>=13,<14",
     # TTS provider SDKs

--- a/runner/src/coval_bench/api/app.py
+++ b/runner/src/coval_bench/api/app.py
@@ -26,6 +26,7 @@ from posthog import Posthog
 from slowapi.errors import RateLimitExceeded
 from slowapi.middleware import SlowAPIMiddleware
 
+from coval_bench.api.cache import new_response_cache
 from coval_bench.api.ratelimit import _rate_limit_handler, limiter
 from coval_bench.api.routers import aggregates, health, leaderboard, providers, results, runs
 from coval_bench.config import Settings, get_settings
@@ -94,6 +95,8 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         allow_headers=["*"],
         max_age=600,
     )
+
+    app.state.response_cache = new_response_cache()
 
     # Rate limiting (ADR-013) — in-memory per-instance; see ratelimit.py for caveat.
     app.state.limiter = limiter

--- a/runner/src/coval_bench/api/cache.py
+++ b/runner/src/coval_bench/api/cache.py
@@ -1,0 +1,35 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""In-process TTL cache for read-only dashboard endpoints.
+
+``/v1/results/aggregates`` and ``/v1/leaderboard`` recompute the same SQL on
+every request even though the underlying results only change when a benchmark
+run finishes (~every 30 min). A short per-process TTL cache lets identical
+requests inside the window skip the DB.
+
+Tradeoffs: lost on restart, not shared across API instances, and the first
+request after expiry still scans raw. A shared/durable cache would be Redis —
+a deliberately larger call deferred for now.
+
+One cache lives per app instance (see ``create_app``); both endpoints share it
+with namespaced tuple keys.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from cachetools import TTLCache
+
+# 15 min cache for no real reason.
+CACHE_TTL_SECONDS = 900
+
+
+def new_response_cache() -> TTLCache[Any, Any]:
+    """Build the per-app response cache.
+
+    ``maxsize`` is ample headroom: the only keys are the few (benchmark,
+    window) and (metric, benchmark, window) param combinations.
+    """
+    return TTLCache(maxsize=64, ttl=CACHE_TTL_SECONDS)

--- a/runner/src/coval_bench/api/deps.py
+++ b/runner/src/coval_bench/api/deps.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 from typing import Any, cast
 
 import structlog
+from cachetools import TTLCache
 from fastapi import HTTPException
 from posthog import Posthog
 from psycopg_pool import AsyncConnectionPool
@@ -43,6 +44,11 @@ def get_settings(request: Request) -> Settings:
 def get_posthog(request: Request) -> Posthog | None:
     """Return the PostHog client from app state, or None if analytics is disabled."""
     return cast("Posthog | None", request.app.state.posthog)
+
+
+def get_cache(request: Request) -> TTLCache[Any, Any]:
+    """Return the per-app response TTL cache from app state."""
+    return cast("TTLCache[Any, Any]", request.app.state.response_cache)
 
 
 def capture_api_event(client: Posthog | None, event: str, properties: dict[str, Any]) -> None:

--- a/runner/src/coval_bench/api/routers/aggregates.py
+++ b/runner/src/coval_bench/api/routers/aggregates.py
@@ -22,6 +22,7 @@ from typing import Any
 
 import psycopg.rows
 import structlog
+from cachetools import TTLCache
 from fastapi import APIRouter, Depends, Query
 from posthog import Posthog
 from psycopg_pool import AsyncConnectionPool
@@ -33,7 +34,13 @@ from coval_bench.api.common import (
     BenchmarkLiteral,
     WindowLiteral,
 )
-from coval_bench.api.deps import capture_api_event, get_pool, get_posthog, get_settings
+from coval_bench.api.deps import (
+    capture_api_event,
+    get_cache,
+    get_pool,
+    get_posthog,
+    get_settings,
+)
 from coval_bench.api.ratelimit import limiter
 from coval_bench.api.schemas import AggregatesResponse, ModelStatEntry, SeriesPoint
 from coval_bench.config import Settings
@@ -88,6 +95,7 @@ async def get_results_aggregates(
     pool: AsyncConnectionPool[Any] = Depends(get_pool),
     settings: Settings = Depends(get_settings),
     posthog_client: Posthog | None = Depends(get_posthog),
+    cache: TTLCache[Any, Any] = Depends(get_cache),
 ) -> AggregatesResponse:
     """Return per-model stats and per-bucket series for one benchmark.
 
@@ -95,36 +103,43 @@ async def get_results_aggregates(
         benchmark: One of STT, TTS.
         window: Time window over results.created_at. Defaults to 24h.
     """
-    params: dict[str, Any] = {
-        "benchmark": benchmark,
-        "interval": WINDOW_INTERVALS[window],
-    }
-    series_params: dict[str, Any] = {
-        **params,
-        "schedule_period": settings.schedule_period_seconds,
-    }
+    cache_key = ("aggregates", benchmark, window)
+    response: AggregatesResponse | None = cache.get(cache_key)
+    cache_hit = response is not None
 
-    async with pool.connection() as conn:
-        conn.row_factory = psycopg.rows.dict_row
-        stat_rows = await (await conn.execute(_STATS_SQL, params)).fetchall()
-        series_rows = await (await conn.execute(_SERIES_SQL, series_params)).fetchall()
+    if response is None:
+        params: dict[str, Any] = {
+            "benchmark": benchmark,
+            "interval": WINDOW_INTERVALS[window],
+        }
+        series_params: dict[str, Any] = {
+            **params,
+            "schedule_period": settings.schedule_period_seconds,
+        }
 
-    model_stats = [ModelStatEntry.model_validate(r) for r in stat_rows]
-    series = [SeriesPoint.model_validate(r) for r in series_rows]
+        async with pool.connection() as conn:
+            conn.row_factory = psycopg.rows.dict_row
+            stat_rows = await (await conn.execute(_STATS_SQL, params)).fetchall()
+            series_rows = await (await conn.execute(_SERIES_SQL, series_params)).fetchall()
+
+        response = AggregatesResponse(
+            benchmark=benchmark,
+            window=window,
+            model_stats=[ModelStatEntry.model_validate(r) for r in stat_rows],
+            series=[SeriesPoint.model_validate(r) for r in series_rows],
+        )
+        cache[cache_key] = response
+
     capture_api_event(
         posthog_client,
         "results_aggregates_queried",
         {
             "benchmark": benchmark,
             "window": window,
-            "model_stat_count": len(model_stats),
-            "series_point_count": len(series),
+            "model_stat_count": len(response.model_stats),
+            "series_point_count": len(response.series),
+            "cache_hit": cache_hit,
             "$process_person_profile": False,
         },
     )
-    return AggregatesResponse(
-        benchmark=benchmark,
-        window=window,
-        model_stats=model_stats,
-        series=series,
-    )
+    return response

--- a/runner/tests/api/test_aggregates.py
+++ b/runner/tests/api/test_aggregates.py
@@ -146,6 +146,35 @@ async def test_window_excludes_old_rows(client: AsyncClient, postgresql: Any) ->
     assert response_30d.json()["model_stats"][0]["sample_count"] == 1
 
 
+async def test_cache_serves_stale_within_ttl(client: AsyncClient, postgresql: Any) -> None:
+    """A second identical request is served from cache, not re-queried."""
+    run_id = await _insert_run(postgresql)
+    await _insert_result(postgresql, run_id, metric_value=1.0)
+
+    first = await client.get("/v1/results/aggregates", params={"benchmark": "STT"})
+    assert first.json()["model_stats"][0]["sample_count"] == 1
+
+    # Out-of-band insert that a fresh query would pick up.
+    await _insert_result(postgresql, run_id, metric_value=3.0)
+
+    second = await client.get("/v1/results/aggregates", params={"benchmark": "STT"})
+    # Unchanged — served from the cached response, DB not re-scanned.
+    assert second.json() == first.json()
+
+
+async def test_cache_keyed_by_params(client: AsyncClient, postgresql: Any) -> None:
+    """Different params are computed independently, not cross-served."""
+    run_id = await _insert_run(postgresql)
+    old = datetime.now(dt.UTC) - timedelta(days=10)
+    await _insert_result(postgresql, run_id, created_at=old, metric_value=1.0)
+
+    # 24h excludes the 10-day-old row; 30d includes it. Distinct cache keys.
+    r_24h = await client.get("/v1/results/aggregates", params={"benchmark": "STT"})
+    r_30d = await client.get("/v1/results/aggregates", params={"benchmark": "STT", "window": "30d"})
+    assert r_24h.json()["model_stats"] == []
+    assert r_30d.json()["model_stats"][0]["sample_count"] == 1
+
+
 async def test_models_grouped_separately(client: AsyncClient, postgresql: Any) -> None:
     """Distinct (provider, model, metric_type) groups stay separate and sorted."""
     run_id = await _insert_run(postgresql)

--- a/runner/uv.lock
+++ b/runner/uv.lock
@@ -169,6 +169,15 @@ wheels = [
 ]
 
 [[package]]
+name = "cachetools"
+version = "7.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f4/8b/0d3945a13955303b81272f759a0331e54c5c793da455e6f5706b89d2639c/cachetools-7.1.4.tar.gz", hash = "sha256:437f55a4e0c1b01a4f3077cc470e6991d47430970e36fbcb77e2be0df4fc1cd6", size = 40085, upload-time = "2026-05-21T22:40:43.376Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8c/7b/1fc1c09cc0756cf25861a3be10565915953876da48bb228fb9a672b20a42/cachetools-7.1.4-py3-none-any.whl", hash = "sha256:323dc4127934744db5b54eb4924482d7edafbf9554e820d1531c2e08c0e4ef54", size = 16761, upload-time = "2026-05-21T22:40:41.845Z" },
+]
+
+[[package]]
 name = "cartesia"
 version = "3.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -271,6 +280,7 @@ dependencies = [
     { name = "aiohttp" },
     { name = "alembic" },
     { name = "anyio" },
+    { name = "cachetools" },
     { name = "cartesia" },
     { name = "click" },
     { name = "fastapi" },
@@ -322,6 +332,7 @@ requires-dist = [
     { name = "aiohttp", specifier = ">=3.14.0" },
     { name = "alembic", specifier = ">=1.13" },
     { name = "anyio", specifier = ">=4.4" },
+    { name = "cachetools", specifier = ">=5.3" },
     { name = "cartesia", specifier = ">=2" },
     { name = "click", specifier = ">=8.1" },
     { name = "fastapi", specifier = ">=0.111" },


### PR DESCRIPTION
- Adds a TTL cache to the aggregation query. Simple fix to speed up load times. 
- Cache expires after 15 mins so we're never that far behind live.