### PR TITLE
Add Cartesia Sonic 3.5 to the TTS benchmark

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ runner/.uv-cache/
 # Playground internal docs (per Loren's PR #26 R4-1 review)
 PLAYGROUND.md
 .env*.local
+
+# Internal benchmarking doc — never commit (also matches global *-benchmarking.md)
+docs/providers/cartesia-sonic-3.5-benchmarking.md

--- a/runner/src/coval_bench/runner/config.py
+++ b/runner/src/coval_bench/runner/config.py
@@ -86,6 +86,13 @@ DEFAULT_TTS_MATRIX: list[ProviderEntry] = [
         voice="f786b574-daa5-4673-aa0c-cbe3e8534c02",
         enabled=True,
     ),
+    # Cartesia — sonic-3.5 (cleared for public benchmarking 2026-06-08).
+    ProviderEntry(
+        provider="cartesia",
+        model="sonic-3.5",
+        voice="db6b0ed5-d5d3-463d-ae85-518a07d3c2b4",
+        enabled=True,
+    ),
     # Deepgram — re-activated 2026-04-30: aura-2-thalia-en.
     ProviderEntry(
         provider="deepgram",

--- a/runner/tests/providers/tts/test_cartesia.py
+++ b/runner/tests/providers/tts/test_cartesia.py
@@ -92,6 +92,15 @@ def test_cartesia_name_and_model(fake_settings: Settings) -> None:
     assert p.model == "sonic-turbo"
 
 
+def test_cartesia_supports_sonic_3_5(fake_settings: Settings) -> None:
+    """sonic-3.5 (the public matrix entry) must pass the model-support guard."""
+    p = CartesiaTTSProvider(
+        fake_settings, model="sonic-3.5", voice="db6b0ed5-d5d3-463d-ae85-518a07d3c2b4"
+    )
+    assert p.name == "cartesia-sonic-3.5"
+    assert p._model_supported("sonic-3.5")
+
+
 # ---------------------------------------------------------------------------
 # Missing API key
 # ---------------------------------------------------------------------------

--- a/web/lib/config/colors.ts
+++ b/web/lib/config/colors.ts
@@ -18,6 +18,7 @@ export const modelColors: Record<string, string> = {
 
   // Cartesia TTS
   "sonic-3": "#3498DB",
+  "sonic-3.5": "#2563EB",
 
   // Rime TTS
   arcana: "#33FF99",

--- a/web/lib/config/models.ts
+++ b/web/lib/config/models.ts
@@ -8,6 +8,7 @@ export const modelDisplayNames: Record<string, string> = {
   eleven_flash_v2_5: "Flash v2.5",
   eleven_turbo_v2_5: "Turbo v2.5",
   "sonic-3": "Sonic 3",
+  "sonic-3.5": "Sonic 3.5",
   "aura-2-thalia-en": "Aura 2",
   arcana: "Arcana",
   mistv3: "Mist v3",

--- a/web/lib/utils/formatters.ts
+++ b/web/lib/utils/formatters.ts
@@ -91,6 +91,7 @@ export function normalizeModelName(modelKey: string): string {
     eleven_flash_v2_5: "Flash v2.5",
     eleven_turbo_v2_5: "Turbo v2.5",
     "sonic-3": "Sonic 3",
+    "sonic-3.5": "Sonic 3.5",
     "aura-2-thalia-en": "Aura 2",
     arcana: "Arcana",
     mistv3: "Mist v3",


### PR DESCRIPTION
Adds Sonic 3.5 as an enabled TTS matrix entry, plus its frontend label  and chart color. Handled by the existing CartesiaTTSProvider

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Cartesia Sonic 3.5 TTS model with complete configuration, including visual styling and display name mapping.

* **Tests**
  * Added test coverage validating support for the new model.

* **Chores**
  * Updated .gitignore to exclude internal benchmarking documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->