### PR TITLE
Add a TimeWindowToggle component

### DIFF
--- a/web/components/shared/TimeWindowToggle.tsx
+++ b/web/components/shared/TimeWindowToggle.tsx
@@ -1,0 +1,82 @@
+// Copyright 2026 The Coval Benchmarks Authors
+// SPDX-License-Identifier: Apache-2.0
+
+"use client";
+
+import React from "react";
+
+export const TIME_WINDOWS = ["24h", "7d", "30d"] as const;
+export type TimeWindow = (typeof TIME_WINDOWS)[number];
+
+// Values mirror the API's window literals; 24h displays as "1d" so the
+// options read uniformly (1d / 7d / 30d).
+const WINDOW_LABELS: Record<TimeWindow, string> = {
+  "24h": "1d",
+  "7d": "7d",
+  "30d": "30d",
+};
+
+interface TimeWindowToggleProps {
+  value: TimeWindow;
+  onChange: (window: TimeWindow) => void;
+  className?: string;
+}
+
+const TimeWindowToggle: React.FC<TimeWindowToggleProps> = ({
+  value,
+  onChange,
+  className = "",
+}) => {
+  // Radiogroup keyboard contract: the group is one Tab stop (roving
+  // tabIndex) and arrow keys move the selection.
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    let step: number;
+    if (event.key === "ArrowRight" || event.key === "ArrowDown") {
+      step = 1;
+    } else if (event.key === "ArrowLeft" || event.key === "ArrowUp") {
+      step = -1;
+    } else {
+      return;
+    }
+    event.preventDefault();
+    const currentIndex = TIME_WINDOWS.indexOf(value);
+    const nextIndex =
+      (currentIndex + step + TIME_WINDOWS.length) % TIME_WINDOWS.length;
+    onChange(TIME_WINDOWS[nextIndex] ?? value);
+    const radios =
+      event.currentTarget.querySelectorAll<HTMLButtonElement>("button");
+    radios[nextIndex]?.focus();
+  };
+
+  return (
+    <div
+      role="radiogroup"
+      aria-label="Time window"
+      onKeyDown={handleKeyDown}
+      className={`inline-flex h-8 items-center gap-0.5 rounded-md bg-surface-toggle-inactive p-[3px] ${className}`}
+    >
+      {TIME_WINDOWS.map((timeWindow) => {
+        const active = timeWindow === value;
+        return (
+          <button
+            key={timeWindow}
+            type="button"
+            role="radio"
+            aria-checked={active}
+            tabIndex={active ? 0 : -1}
+            onClick={() => onChange(timeWindow)}
+            className={`inline-flex items-center justify-center self-stretch rounded-sm px-3 text-sm font-medium transition-colors duration-150 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-text-tertiary/40 focus-visible:ring-offset-1 ${
+              active
+                ? "bg-surface-primary text-text-primary shadow-sm"
+                : "text-text-secondary hover:text-text-primary"
+            }`}
+          >
+            {WINDOW_LABELS[timeWindow]}
+          </button>
+        );
+      })}
+    </div>
+  );
+};
+
+export default TimeWindowToggle;


### PR DESCRIPTION
Not wired up to anything yet. Just tryna keep the PRs small and easy to review.

It's a toggle. Not much else to say.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a time-window toggle letting users switch between 1d, 7d, and 30d views.
  * Toggle uses an accessible radio-style button group with proper ARIA states, keyboard Arrow-key navigation, focus management, and clear active selection feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a new `TimeWindowToggle` component — a segmented control for selecting between three time periods (`24h`/`7d`/`30d`, displayed as `1d`/`7d`/`30d`). It is not yet wired up to any consumer.

- The component is a fully controlled React element with correct `radiogroup`/`radio` ARIA semantics, roving `tabIndex` keyboard navigation, and wrap-around arrow-key handling.
- The `24h → 1d` display label mapping is documented inline, keeping the API value and the rendered label distinct without any magic.

<h3>Confidence Score: 5/5</h3>

Safe to merge — this is a self-contained, unwired UI component with no side effects on the rest of the codebase.

The change adds a single new component that is not yet connected to any consumer. The ARIA roles, keyboard navigation, and controlled-component contract are all implemented correctly. No existing behavior is affected.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| web/components/shared/TimeWindowToggle.tsx | New controlled segmented-control component with correct radiogroup/radio ARIA roles, roving tabIndex keyboard navigation, and wrap-around arrow-key handling. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User presses arrow key] --> B{Key direction?}
    B -->|ArrowRight or ArrowDown| C[step = plus 1]
    B -->|ArrowLeft or ArrowUp| D[step = minus 1]
    B -->|Other key| E[return - no-op]
    C --> F[preventDefault]
    D --> F
    F --> G[Compute currentIndex from value]
    G --> H[Compute nextIndex with wrap-around modulo]
    H --> I[Call onChange with next TimeWindow]
    I --> J[Focus button at nextIndex via querySelectorAll]

    subgraph Render
        K[TIME_WINDOWS.map] --> L{timeWindow === value?}
        L -->|Yes| M[tabIndex=0 aria-checked=true active styles]
        L -->|No| N[tabIndex=-1 aria-checked=false inactive styles]
    end
```

<sub>Reviews (2): Last reviewed commit: ["Add a TimeWindowToggle component"](https://github.com/coval-ai/benchmarks/commit/0e6493e7bfed05c8b75921c8435635e89fdff6e3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36524236)</sub>

<!-- /greptile_comment -->