### PR TITLE
Add TTFS streaming-STT metric

### DIFF
--- a/runner/scripts/precompute_vad_offsets.py
+++ b/runner/scripts/precompute_vad_offsets.py
@@ -1,0 +1,93 @@
+"""Offline: compute per-clip speech-end offsets (ms) for the STT dataset.
+
+Standalone dev tool — NOT part of the runner, NOT under src/ (so it is not
+subject to the mypy --strict gate). Requires silero-vad + soundfile installed
+separately; they are deliberately not runner dependencies:
+
+    uv pip install silero-vad soundfile
+
+Usage:
+    python scripts/precompute_vad_offsets.py \
+        --manifest src/coval_bench/datasets/manifests/stt-v1.json \
+        --audio-dir /path/to/local/16k/wavs \
+        [--write] [--min-silence-ms 300] [--speech-pad-ms 100]
+
+For each clip the manifest references, runs SileroVAD and records
+speech_end_offset_ms = end of the LAST detected speech segment (already
+includes speech-pad as the guard). With --write, patches the field into the
+manifest in place; otherwise prints a review table. Audio bytes are untouched,
+so every clip's sha256 stays the same.
+
+Validation after running: confirm truncated-clip WER == full-clip WER on all
+clips before trusting the offsets.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+SAMPLE_RATE = 16000
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--manifest", type=Path, required=True)
+    parser.add_argument("--audio-dir", type=Path, required=True)
+    parser.add_argument("--min-silence-ms", type=int, default=300)
+    parser.add_argument("--speech-pad-ms", type=int, default=100)
+    parser.add_argument("--write", action="store_true")
+    args = parser.parse_args()
+
+    import numpy as np
+    import soundfile as sf
+    import torch
+    from silero_vad import get_speech_timestamps, load_silero_vad
+
+    model = load_silero_vad()
+    manifest = json.loads(args.manifest.read_text())
+    items = manifest["items"] if isinstance(manifest, dict) else manifest
+
+    rows: list[tuple[str, float | None, float]] = []
+    for item in items:
+        rel = item["path"]
+        wav_path = args.audio_dir / Path(rel).name
+        if not wav_path.exists():
+            rows.append((rel, None, item.get("duration_sec", 0.0)))
+            continue
+
+        wav_np, file_sr = sf.read(str(wav_path), dtype="float32")
+        if wav_np.ndim > 1:
+            wav_np = np.mean(wav_np, axis=1)
+        wav = torch.from_numpy(np.ascontiguousarray(wav_np))
+        ts = get_speech_timestamps(
+            wav,
+            model,
+            sampling_rate=file_sr,
+            min_silence_duration_ms=args.min_silence_ms,
+            speech_pad_ms=args.speech_pad_ms,
+        )
+        duration_ms = float(len(wav)) / file_sr * 1000.0
+        if ts:
+            raw_end_ms = float(ts[-1]["end"]) / file_sr * 1000.0
+            speech_end_ms = round(min(raw_end_ms, duration_ms), 1)  # round after clamp
+        else:
+            speech_end_ms = None  # no speech detected → don't truncate this clip
+        item["speech_end_offset_ms"] = speech_end_ms
+        rows.append((rel, speech_end_ms, duration_ms))
+
+    for rel, end_ms, dur_ms in rows:
+        trailing = "n/a" if end_ms is None else f"{dur_ms - end_ms:7.1f}"
+        end_str = "MISSING/NO-SPEECH" if end_ms is None else f"{end_ms:8.1f}"
+        print(f"{rel:48s}  end_ms={end_str}  clip_ms={dur_ms:8.1f}  trailing_ms={trailing}")
+
+    if args.write:
+        args.manifest.write_text(json.dumps(manifest, indent=2) + "\n")
+        print(f"\nWrote speech_end_offset_ms into {args.manifest}")
+    else:
+        print("\n(dry run — pass --write to patch the manifest)")
+
+
+if __name__ == "__main__":
+    main()

--- a/runner/src/coval_bench/api/routers/leaderboard.py
+++ b/runner/src/coval_bench/api/routers/leaderboard.py
@@ -35,12 +35,13 @@ logger = structlog.get_logger("coval_bench.api")
 
 router = APIRouter(tags=["leaderboard"])
 
-MetricLiteral = Literal["WER", "TTFA", "TTFT"]
+MetricLiteral = Literal["WER", "TTFA", "TTFT", "TTFS"]
 
 # Valid (metric, benchmark) combinations — lower is better for all.
 _VALID_COMBOS: set[tuple[str, str]] = {
     ("WER", "STT"),
     ("TTFT", "STT"),
+    ("TTFS", "STT"),
     ("TTFA", "TTS"),
 }
 
@@ -94,7 +95,7 @@ async def get_leaderboard(
     """Return leaderboard entries sorted ascending by average metric value.
 
     Args:
-        metric: One of WER, TTFA, TTFT.
+        metric: One of WER, TTFA, TTFT, TTFS.
         benchmark: One of STT, TTS.
         window: Time window — 24h uses the materialized view; 7d/30d run live.
 
@@ -108,7 +109,7 @@ async def get_leaderboard(
         raise HTTPException(
             400,
             f"metric={metric!r} is not compatible with benchmark={benchmark!r}. "
-            f"Valid combinations: WER+STT, TTFT+STT, TTFA+TTS.",
+            f"Valid combinations: WER+STT, TTFT+STT, TTFS+STT, TTFA+TTS.",
         )
 
     params: dict[str, Any] = {"metric": metric, "benchmark": benchmark}

--- a/runner/src/coval_bench/api/routers/results.py
+++ b/runner/src/coval_bench/api/routers/results.py
@@ -53,7 +53,7 @@ router = APIRouter(tags=["results"])
 
 # ``MetricLiteral`` is kept as the type for the legacy ``metric`` param.
 # The canonical FE-facing param is ``metric_type`` (plain ``str``).
-MetricLiteral = Literal["WER", "TTFA", "TTFT", "RTF", "AUDIO_TO_FINAL"]
+MetricLiteral = Literal["WER", "TTFA", "TTFT", "TTFS", "RTF", "AUDIO_TO_FINAL"]
 
 # Base SELECT used by all three query paths.
 # S608 false-positive: the interpolated fragment is a fixed constant; user

--- a/runner/src/coval_bench/api/schemas.py
+++ b/runner/src/coval_bench/api/schemas.py
@@ -154,6 +154,6 @@ class RunsResponse(BaseModel):
 class LeaderboardResponse(BaseModel):
     """Response schema for GET /v1/leaderboard."""
 
-    metric: Literal["WER", "TTFA", "TTFT"]
+    metric: Literal["WER", "TTFA", "TTFT", "TTFS"]
     window: Literal["24h", "7d", "30d"]
     entries: list[LeaderboardEntry]

--- a/runner/src/coval_bench/datasets/loader.py
+++ b/runner/src/coval_bench/datasets/loader.py
@@ -97,6 +97,7 @@ class DatasetItem(BaseModel):
     transcript: str  # ground-truth transcript
     duration_sec: float
     sha256: str
+    speech_end_offset_ms: float | None = None  # VAD end-of-speech anchor; None => no truncation
     metadata: dict[str, str] = Field(default_factory=dict)  # speaker_id etc.
 
 
@@ -286,6 +287,7 @@ def load_stt_dataset(
                 transcript=raw_item.transcript,
                 duration_sec=raw_item.duration_sec,
                 sha256=raw_item.sha256,
+                speech_end_offset_ms=raw_item.speech_end_offset_ms,
                 metadata=meta,
             )
         )

--- a/runner/src/coval_bench/datasets/manifest.py
+++ b/runner/src/coval_bench/datasets/manifest.py
@@ -28,6 +28,7 @@ class STTManifestItem(BaseModel):
     speaker_id: str | None = None  # LibriSpeech provenance
     chapter_id: str | None = None
     utterance_id: str | None = None
+    speech_end_offset_ms: float | None = Field(default=None, ge=0)
 
 
 class TTSManifestItem(BaseModel):

--- a/runner/src/coval_bench/datasets/manifests/stt-v1.json
+++ b/runner/src/coval_bench/datasets/manifests/stt-v1.json
@@ -12,7 +12,8 @@
       "duration_sec": 10.435,
       "speaker_id": "1089",
       "chapter_id": "134686",
-      "utterance_id": "1089-134686-0000"
+      "utterance_id": "1089-134686-0000",
+      "speech_end_offset_ms": 10435.0
     },
     {
       "path": "audio/0002.wav",
@@ -21,7 +22,8 @@
       "duration_sec": 3.275,
       "speaker_id": "1089",
       "chapter_id": "134686",
-      "utterance_id": "1089-134686-0001"
+      "utterance_id": "1089-134686-0001",
+      "speech_end_offset_ms": 2980.0
     },
     {
       "path": "audio/0003.wav",
@@ -30,7 +32,8 @@
       "duration_sec": 10.725,
       "speaker_id": "1188",
       "chapter_id": "133604",
-      "utterance_id": "1188-133604-0000"
+      "utterance_id": "1188-133604-0000",
+      "speech_end_offset_ms": 10308.0
     },
     {
       "path": "audio/0004.wav",
@@ -39,7 +42,8 @@
       "duration_sec": 9.04,
       "speaker_id": "1188",
       "chapter_id": "133604",
-      "utterance_id": "1188-133604-0001"
+      "utterance_id": "1188-133604-0001",
+      "speech_end_offset_ms": 8580.0
     },
     {
       "path": "audio/0005.wav",
@@ -48,7 +52,8 @@
       "duration_sec": 8.46,
       "speaker_id": "121",
       "chapter_id": "121726",
-      "utterance_id": "121-121726-0000"
+      "utterance_id": "121-121726-0000",
+      "speech_end_offset_ms": 8100.0
     },
     {
       "path": "audio/0006.wav",
@@ -57,7 +62,8 @@
       "duration_sec": 5.925,
       "speaker_id": "121",
       "chapter_id": "121726",
-      "utterance_id": "121-121726-0001"
+      "utterance_id": "121-121726-0001",
+      "speech_end_offset_ms": 5925.0
     },
     {
       "path": "audio/0007.wav",
@@ -66,7 +72,8 @@
       "duration_sec": 12.435,
       "speaker_id": "1221",
       "chapter_id": "135766",
-      "utterance_id": "1221-135766-0000"
+      "utterance_id": "1221-135766-0000",
+      "speech_end_offset_ms": 12435.0
     },
     {
       "path": "audio/0008.wav",
@@ -75,7 +82,8 @@
       "duration_sec": 4.825,
       "speaker_id": "1221",
       "chapter_id": "135766",
-      "utterance_id": "1221-135766-0002"
+      "utterance_id": "1221-135766-0002",
+      "speech_end_offset_ms": 4825.0
     },
     {
       "path": "audio/0009.wav",
@@ -84,7 +92,8 @@
       "duration_sec": 8.12,
       "speaker_id": "1284",
       "chapter_id": "1180",
-      "utterance_id": "1284-1180-0000"
+      "utterance_id": "1284-1180-0000",
+      "speech_end_offset_ms": 8120.0
     },
     {
       "path": "audio/0010.wav",
@@ -93,7 +102,8 @@
       "duration_sec": 7.755,
       "speaker_id": "1284",
       "chapter_id": "1180",
-      "utterance_id": "1284-1180-0001"
+      "utterance_id": "1284-1180-0001",
+      "speech_end_offset_ms": 7755.0
     },
     {
       "path": "audio/0011.wav",
@@ -102,7 +112,8 @@
       "duration_sec": 13.48,
       "speaker_id": "1320",
       "chapter_id": "122612",
-      "utterance_id": "1320-122612-0000"
+      "utterance_id": "1320-122612-0000",
+      "speech_end_offset_ms": 13092.0
     },
     {
       "path": "audio/0012.wav",
@@ -111,7 +122,8 @@
       "duration_sec": 9.52,
       "speaker_id": "1320",
       "chapter_id": "122612",
-      "utterance_id": "1320-122612-0001"
+      "utterance_id": "1320-122612-0001",
+      "speech_end_offset_ms": 9124.0
     },
     {
       "path": "audio/0013.wav",
@@ -120,7 +132,8 @@
       "duration_sec": 8.94,
       "speaker_id": "1580",
       "chapter_id": "141083",
-      "utterance_id": "1580-141083-0000"
+      "utterance_id": "1580-141083-0000",
+      "speech_end_offset_ms": 8580.0
     },
     {
       "path": "audio/0014.wav",
@@ -129,7 +142,8 @@
       "duration_sec": 10.255,
       "speaker_id": "1580",
       "chapter_id": "141083",
-      "utterance_id": "1580-141083-0001"
+      "utterance_id": "1580-141083-0001",
+      "speech_end_offset_ms": 9924.0
     },
     {
       "path": "audio/0015.wav",
@@ -138,7 +152,8 @@
       "duration_sec": 9.485,
       "speaker_id": "1995",
       "chapter_id": "1826",
-      "utterance_id": "1995-1826-0000"
+      "utterance_id": "1995-1826-0000",
+      "speech_end_offset_ms": 9188.0
     },
     {
       "path": "audio/0016.wav",
@@ -147,7 +162,8 @@
       "duration_sec": 10.17,
       "speaker_id": "1995",
       "chapter_id": "1826",
-      "utterance_id": "1995-1826-0001"
+      "utterance_id": "1995-1826-0001",
+      "speech_end_offset_ms": 10170.0
     },
     {
       "path": "audio/0017.wav",
@@ -156,7 +172,8 @@
       "duration_sec": 8.03,
       "speaker_id": "2094",
       "chapter_id": "142345",
-      "utterance_id": "2094-142345-0001"
+      "utterance_id": "2094-142345-0001",
+      "speech_end_offset_ms": 7684.0
     },
     {
       "path": "audio/0018.wav",
@@ -165,7 +182,8 @@
       "duration_sec": 14.675,
       "speaker_id": "2094",
       "chapter_id": "142345",
-      "utterance_id": "2094-142345-0003"
+      "utterance_id": "2094-142345-0003",
+      "speech_end_offset_ms": 14276.0
     },
     {
       "path": "audio/0019.wav",
@@ -174,7 +192,8 @@
       "duration_sec": 5.08,
       "speaker_id": "2300",
       "chapter_id": "131720",
-      "utterance_id": "2300-131720-0000"
+      "utterance_id": "2300-131720-0000",
+      "speech_end_offset_ms": 5080.0
     },
     {
       "path": "audio/0020.wav",
@@ -183,7 +202,8 @@
       "duration_sec": 14.63,
       "speaker_id": "2300",
       "chapter_id": "131720",
-      "utterance_id": "2300-131720-0001"
+      "utterance_id": "2300-131720-0001",
+      "speech_end_offset_ms": 14308.0
     },
     {
       "path": "audio/0021.wav",
@@ -192,7 +212,8 @@
       "duration_sec": 13.29,
       "speaker_id": "237",
       "chapter_id": "126133",
-      "utterance_id": "237-126133-0000"
+      "utterance_id": "237-126133-0000",
+      "speech_end_offset_ms": 12964.0
     },
     {
       "path": "audio/0022.wav",
@@ -201,7 +222,8 @@
       "duration_sec": 7.04,
       "speaker_id": "260",
       "chapter_id": "123286",
-      "utterance_id": "260-123286-0000"
+      "utterance_id": "260-123286-0000",
+      "speech_end_offset_ms": 7040.0
     },
     {
       "path": "audio/0023.wav",
@@ -210,7 +232,8 @@
       "duration_sec": 6.12,
       "speaker_id": "2830",
       "chapter_id": "3979",
-      "utterance_id": "2830-3979-0000"
+      "utterance_id": "2830-3979-0000",
+      "speech_end_offset_ms": 5796.0
     },
     {
       "path": "audio/0024.wav",
@@ -219,7 +242,8 @@
       "duration_sec": 8.250063,
       "speaker_id": "2961",
       "chapter_id": "960",
-      "utterance_id": "2961-960-0001"
+      "utterance_id": "2961-960-0001",
+      "speech_end_offset_ms": 7972.0
     },
     {
       "path": "audio/0025.wav",
@@ -228,7 +252,8 @@
       "duration_sec": 12.085,
       "speaker_id": "3570",
       "chapter_id": "5694",
-      "utterance_id": "3570-5694-0000"
+      "utterance_id": "3570-5694-0000",
+      "speech_end_offset_ms": 12085.0
     },
     {
       "path": "audio/0026.wav",
@@ -237,7 +262,8 @@
       "duration_sec": 8.23,
       "speaker_id": "3575",
       "chapter_id": "170457",
-      "utterance_id": "3575-170457-0000"
+      "utterance_id": "3575-170457-0000",
+      "speech_end_offset_ms": 7940.0
     },
     {
       "path": "audio/0027.wav",
@@ -246,7 +272,8 @@
       "duration_sec": 11.17,
       "speaker_id": "3729",
       "chapter_id": "6852",
-      "utterance_id": "3729-6852-0000"
+      "utterance_id": "3729-6852-0000",
+      "speech_end_offset_ms": 10948.0
     },
     {
       "path": "audio/0028.wav",
@@ -255,7 +282,8 @@
       "duration_sec": 9.56,
       "speaker_id": "4077",
       "chapter_id": "13751",
-      "utterance_id": "4077-13751-0000"
+      "utterance_id": "4077-13751-0000",
+      "speech_end_offset_ms": 9560.0
     },
     {
       "path": "audio/0029.wav",
@@ -264,7 +292,8 @@
       "duration_sec": 3.495,
       "speaker_id": "4446",
       "chapter_id": "2271",
-      "utterance_id": "4446-2271-0000"
+      "utterance_id": "4446-2271-0000",
+      "speech_end_offset_ms": 3495.0
     },
     {
       "path": "audio/0030.wav",
@@ -273,7 +302,8 @@
       "duration_sec": 2.59,
       "speaker_id": "4507",
       "chapter_id": "16021",
-      "utterance_id": "4507-16021-0000"
+      "utterance_id": "4507-16021-0000",
+      "speech_end_offset_ms": 2244.0
     },
     {
       "path": "audio/0031.wav",
@@ -282,7 +312,8 @@
       "duration_sec": 3.03,
       "speaker_id": "4970",
       "chapter_id": "29093",
-      "utterance_id": "4970-29093-0000"
+      "utterance_id": "4970-29093-0000",
+      "speech_end_offset_ms": 2724.0
     },
     {
       "path": "audio/0032.wav",
@@ -291,7 +322,8 @@
       "duration_sec": 6.645,
       "speaker_id": "4992",
       "chapter_id": "23283",
-      "utterance_id": "4992-23283-0000"
+      "utterance_id": "4992-23283-0000",
+      "speech_end_offset_ms": 6308.0
     },
     {
       "path": "audio/0033.wav",
@@ -300,7 +332,8 @@
       "duration_sec": 4.51,
       "speaker_id": "5105",
       "chapter_id": "28233",
-      "utterance_id": "5105-28233-0000"
+      "utterance_id": "5105-28233-0000",
+      "speech_end_offset_ms": 4260.0
     },
     {
       "path": "audio/0034.wav",
@@ -309,7 +342,8 @@
       "duration_sec": 2.005,
       "speaker_id": "5142",
       "chapter_id": "33396",
-      "utterance_id": "5142-33396-0000"
+      "utterance_id": "5142-33396-0000",
+      "speech_end_offset_ms": 2005.0
     },
     {
       "path": "audio/0035.wav",
@@ -318,7 +352,8 @@
       "duration_sec": 12.44,
       "speaker_id": "5639",
       "chapter_id": "40744",
-      "utterance_id": "5639-40744-0001"
+      "utterance_id": "5639-40744-0001",
+      "speech_end_offset_ms": 12132.0
     },
     {
       "path": "audio/0036.wav",
@@ -327,7 +362,8 @@
       "duration_sec": 2.19,
       "speaker_id": "5683",
       "chapter_id": "32865",
-      "utterance_id": "5683-32865-0000"
+      "utterance_id": "5683-32865-0000",
+      "speech_end_offset_ms": 2190.0
     },
     {
       "path": "audio/0037.wav",
@@ -336,7 +372,8 @@
       "duration_sec": 4.905,
       "speaker_id": "61",
       "chapter_id": "70968",
-      "utterance_id": "61-70968-0000"
+      "utterance_id": "61-70968-0000",
+      "speech_end_offset_ms": 4905.0
     },
     {
       "path": "audio/0038.wav",
@@ -345,7 +382,8 @@
       "duration_sec": 4.07,
       "speaker_id": "672",
       "chapter_id": "122797",
-      "utterance_id": "672-122797-0000"
+      "utterance_id": "672-122797-0000",
+      "speech_end_offset_ms": 3716.0
     },
     {
       "path": "audio/0039.wav",
@@ -354,7 +392,8 @@
       "duration_sec": 11.695,
       "speaker_id": "6829",
       "chapter_id": "68769",
-      "utterance_id": "6829-68769-0000"
+      "utterance_id": "6829-68769-0000",
+      "speech_end_offset_ms": 11695.0
     },
     {
       "path": "audio/0040.wav",
@@ -363,7 +402,8 @@
       "duration_sec": 3.505,
       "speaker_id": "6930",
       "chapter_id": "75918",
-      "utterance_id": "6930-75918-0000"
+      "utterance_id": "6930-75918-0000",
+      "speech_end_offset_ms": 3505.0
     },
     {
       "path": "audio/0041.wav",
@@ -372,7 +412,8 @@
       "duration_sec": 2.44,
       "speaker_id": "7021",
       "chapter_id": "79730",
-      "utterance_id": "7021-79730-0000"
+      "utterance_id": "7021-79730-0000",
+      "speech_end_offset_ms": 2052.0
     },
     {
       "path": "audio/0042.wav",
@@ -381,7 +422,8 @@
       "duration_sec": 2.17,
       "speaker_id": "7127",
       "chapter_id": "75946",
-      "utterance_id": "7127-75946-0001"
+      "utterance_id": "7127-75946-0001",
+      "speech_end_offset_ms": 2170.0
     },
     {
       "path": "audio/0043.wav",
@@ -390,7 +432,8 @@
       "duration_sec": 5.695,
       "speaker_id": "7176",
       "chapter_id": "88083",
-      "utterance_id": "7176-88083-0000"
+      "utterance_id": "7176-88083-0000",
+      "speech_end_offset_ms": 5695.0
     },
     {
       "path": "audio/0044.wav",
@@ -399,7 +442,8 @@
       "duration_sec": 3.285,
       "speaker_id": "7729",
       "chapter_id": "102255",
-      "utterance_id": "7729-102255-0000"
+      "utterance_id": "7729-102255-0000",
+      "speech_end_offset_ms": 3285.0
     },
     {
       "path": "audio/0045.wav",
@@ -408,7 +452,8 @@
       "duration_sec": 13.085,
       "speaker_id": "8224",
       "chapter_id": "274381",
-      "utterance_id": "8224-274381-0003"
+      "utterance_id": "8224-274381-0003",
+      "speech_end_offset_ms": 12836.0
     },
     {
       "path": "audio/0046.wav",
@@ -417,7 +462,8 @@
       "duration_sec": 8.805,
       "speaker_id": "8230",
       "chapter_id": "279154",
-      "utterance_id": "8230-279154-0000"
+      "utterance_id": "8230-279154-0000",
+      "speech_end_offset_ms": 8452.0
     },
     {
       "path": "audio/0047.wav",
@@ -426,7 +472,8 @@
       "duration_sec": 8.745,
       "speaker_id": "8455",
       "chapter_id": "210777",
-      "utterance_id": "8455-210777-0000"
+      "utterance_id": "8455-210777-0000",
+      "speech_end_offset_ms": 8452.0
     },
     {
       "path": "audio/0048.wav",
@@ -435,7 +482,8 @@
       "duration_sec": 4.73,
       "speaker_id": "8463",
       "chapter_id": "287645",
-      "utterance_id": "8463-287645-0000"
+      "utterance_id": "8463-287645-0000",
+      "speech_end_offset_ms": 4730.0
     },
     {
       "path": "audio/0049.wav",
@@ -444,7 +492,8 @@
       "duration_sec": 9.605,
       "speaker_id": "8555",
       "chapter_id": "284447",
-      "utterance_id": "8555-284447-0000"
+      "utterance_id": "8555-284447-0000",
+      "speech_end_offset_ms": 9252.0
     },
     {
       "path": "audio/0050.wav",
@@ -453,7 +502,8 @@
       "duration_sec": 12.62,
       "speaker_id": "908",
       "chapter_id": "157963",
-      "utterance_id": "908-157963-0000"
+      "utterance_id": "908-157963-0000",
+      "speech_end_offset_ms": 12356.0
     }
   ]
 }

--- a/runner/src/coval_bench/metrics/__init__.py
+++ b/runner/src/coval_bench/metrics/__init__.py
@@ -1,6 +1,6 @@
 # Copyright 2026 The Coval Benchmarks Authors
 # SPDX-License-Identifier: Apache-2.0
-"""Public API for coval_bench metrics (WER, TTFA, TTFT, RTF)."""
+"""Public API for coval_bench metrics """
 
 from coval_bench.metrics.ttfa import compute_ttfa, first_audible_offset_ms
 from coval_bench.metrics.ttft import (

--- a/runner/src/coval_bench/metrics/__init__.py
+++ b/runner/src/coval_bench/metrics/__init__.py
@@ -3,7 +3,12 @@
 """Public API for coval_bench metrics (WER, TTFA, TTFT, RTF)."""
 
 from coval_bench.metrics.ttfa import compute_ttfa, first_audible_offset_ms
-from coval_bench.metrics.ttft import compute_audio_to_final, compute_rtf, compute_ttft
+from coval_bench.metrics.ttft import (
+    compute_audio_to_final,
+    compute_rtf,
+    compute_ttfs,
+    compute_ttft,
+)
 from coval_bench.metrics.wer import WERResult, WordError, compute_wer, normalize_text
 
 __all__ = [
@@ -16,4 +21,5 @@ __all__ = [
     "compute_ttft",
     "compute_audio_to_final",
     "compute_rtf",
+    "compute_ttfs",
 ]

--- a/runner/src/coval_bench/metrics/__init__.py
+++ b/runner/src/coval_bench/metrics/__init__.py
@@ -1,6 +1,6 @@
 # Copyright 2026 The Coval Benchmarks Authors
 # SPDX-License-Identifier: Apache-2.0
-"""Public API for coval_bench metrics """
+"""Public API for coval_bench metrics."""
 
 from coval_bench.metrics.ttfa import compute_ttfa, first_audible_offset_ms
 from coval_bench.metrics.ttft import (

--- a/runner/src/coval_bench/metrics/ttft.py
+++ b/runner/src/coval_bench/metrics/ttft.py
@@ -66,3 +66,28 @@ def compute_rtf(audio_to_final_seconds: float, audio_duration_seconds: float) ->
     if audio_duration_seconds <= 0:
         raise ValueError("audio_duration_seconds must be > 0")
     return audio_to_final_seconds / audio_duration_seconds
+
+
+def compute_ttfs(audio_to_final_seconds: float, speech_end_offset_seconds: float) -> float:
+    """Return Time-To-Final-Segment (TTFS) in **seconds**.
+
+    TTFS is latency from VAD-detected end-of-speech to the final transcript:
+    ``audio_to_final_seconds - speech_end_offset_seconds``. The offset is the
+    precomputed, shared end-of-speech anchor for the clip (same for every
+    provider), so TTFS isolates finalization speed given a client end-of-speech
+    signal.
+
+    Args:
+        audio_to_final_seconds: Output of :func:`compute_audio_to_final`.
+        speech_end_offset_seconds: VAD end-of-speech offset for the clip.
+
+    Returns:
+        Elapsed time in seconds (float).
+
+    Raises:
+        ValueError: If the result would be negative.
+    """
+    ttfs = audio_to_final_seconds - speech_end_offset_seconds
+    if ttfs < 0:
+        raise ValueError("ttfs must be >= 0 (speech_end_offset exceeds audio_to_final)")
+    return ttfs

--- a/runner/src/coval_bench/runner/orchestrator.py
+++ b/runner/src/coval_bench/runner/orchestrator.py
@@ -222,6 +222,16 @@ async def _run_stt_item(
         duration_sec: float = item.duration_sec
         audio_bytes = audio_path.read_bytes()
 
+        speech_end_offset_ms = item.speech_end_offset_ms
+        if isinstance(speech_end_offset_ms, (int, float)):
+            trailing_ms = max(0.0, duration_sec * 1000.0 - speech_end_offset_ms)
+            tail_bytes = int(round(trailing_ms / 1000.0 * 16000)) * 2
+            if 0 < tail_bytes < len(audio_bytes):
+                audio_bytes = audio_bytes[: len(audio_bytes) - tail_bytes]
+                # Audio now ends at speech-end; reflect the trimmed length so RTF and the
+                # provider duration hint match what was actually sent.
+                duration_sec = speech_end_offset_ms / 1000.0
+
         transcription_result = None
         item_error: str | None = None
         try:
@@ -292,6 +302,36 @@ async def _run_stt_item(
                 transcript=complete_transcript,
                 status=atf_status,
                 error=atf_error,
+            )
+        )
+
+        # 2b. TTFS — time-to-final from VAD end-of-speech (primary headline metric). Status
+        # tracks ttfs_value (not audio_to_final): a missing offset or a failed calculation
+        # fails the row instead of passing as a null-valued success, and calc errors surface.
+        ttfs_value: float | None = None
+        ttfs_calc_error: str | None = None
+        if audio_to_final is not None and isinstance(speech_end_offset_ms, (int, float)):
+            try:
+                compute_ttfs = importlib.import_module("coval_bench.metrics").compute_ttfs
+                ttfs_value = compute_ttfs(audio_to_final, speech_end_offset_ms / 1000.0)
+            except Exception as exc:
+                ttfs_calc_error = str(exc)
+        ttfs_status, ttfs_error = _metric_outcome(
+            ttfs_value, item_error or ttfs_calc_error, "TTFS", ResultStatus
+        )
+        results.append(
+            Result(
+                run_id=run_id,
+                provider=entry.provider,
+                model=entry.model,
+                benchmark=Benchmark.STT,
+                metric_type="TTFS",
+                metric_value=ttfs_value,
+                metric_units="seconds",
+                audio_filename=audio_path.name,
+                transcript=complete_transcript,
+                status=ttfs_status,
+                error=ttfs_error,
             )
         )
 

--- a/runner/tests/unit/test_orchestrator.py
+++ b/runner/tests/unit/test_orchestrator.py
@@ -83,6 +83,7 @@ def _make_dataset_item(path: Path, transcript: str = "hello world") -> Any:
     item.transcript = transcript
     item.duration_sec = 1.0
     item.sha256 = "abc"
+    item.speech_end_offset_ms = 100.0
     item.metadata = {}
     return item
 
@@ -369,11 +370,11 @@ async def test_full_failure(audio_file: Path, settings: Settings) -> None:
 
     assert summary.status == str(RunStatus.FAILED)
     # Unified failure model: a raised exception fails every metric row for the item
-    # (TTFT, AudioToFinal, RTF), each carrying the real exception string.
-    assert summary.fail_count == 3
+    # (TTFT, AudioToFinal, RTF, TTFS), each carrying the real exception string.
+    assert summary.fail_count == 4
     assert summary.success_count == 0
     rows = _recorded_rows(writer)
-    assert {r.metric_type for r in rows} == {"TTFT", "AudioToFinal", "RTF"}
+    assert {r.metric_type for r in rows} == {"TTFT", "AudioToFinal", "RTF", "TTFS"}
     assert all(r.status == ResultStatus.FAILED for r in rows)
     assert all("always fails" in (r.error or "") for r in rows)
 
@@ -1376,6 +1377,55 @@ async def test_stt_partial_keeps_real_ttft(audio_file: Path, settings: Settings)
     assert by_metric["AudioToFinal"].status == ResultStatus.FAILED
     assert by_metric["RTF"].status == ResultStatus.FAILED
     assert summary.status == str(RunStatus.PARTIAL)
+
+
+@pytest.mark.asyncio
+async def test_stt_ttfs_status_tracks_value(audio_file: Path, settings: Settings) -> None:
+    """TTFS succeeds with audio_to_final − offset when an offset is pinned, and fails
+    (never a null-valued success) when the offset is missing."""
+    provider_inst = MagicMock()
+    provider_inst.measure_ttft = AsyncMock(return_value=_good_transcription())
+    run = _make_run()
+    writer = _make_stub_writer(run)
+    async with _orchestrator_env(
+        audio_path=audio_file,
+        stt_items=[_make_dataset_item(audio_file)],  # speech_end_offset_ms = 100.0
+        stt_providers={"deepgram": MagicMock(return_value=provider_inst)},
+        run=run,
+        writer=writer,
+    ) as _:
+        await run_benchmarks(
+            settings=settings,
+            benchmark_kind="stt",
+            smoke=True,
+            matrix_overrides=_only_stt_matrix("deepgram", "nova-2"),
+        )
+    by_metric = {r.metric_type: r for r in _recorded_rows(writer)}
+    assert by_metric["TTFS"].status == ResultStatus.SUCCESS
+    assert by_metric["TTFS"].metric_value == pytest.approx(0.85 - 0.1)
+
+    item_no_offset = _make_dataset_item(audio_file)
+    item_no_offset.speech_end_offset_ms = None
+    provider_inst2 = MagicMock()
+    provider_inst2.measure_ttft = AsyncMock(return_value=_good_transcription())
+    run2 = _make_run()
+    writer2 = _make_stub_writer(run2)
+    async with _orchestrator_env(
+        audio_path=audio_file,
+        stt_items=[item_no_offset],
+        stt_providers={"deepgram": MagicMock(return_value=provider_inst2)},
+        run=run2,
+        writer=writer2,
+    ) as _:
+        await run_benchmarks(
+            settings=settings,
+            benchmark_kind="stt",
+            smoke=True,
+            matrix_overrides=_only_stt_matrix("deepgram", "nova-2"),
+        )
+    by_metric2 = {r.metric_type: r for r in _recorded_rows(writer2)}
+    assert by_metric2["TTFS"].metric_value is None
+    assert by_metric2["TTFS"].status == ResultStatus.FAILED
 
 
 @pytest.mark.asyncio

--- a/runner/tests/unit/test_ttft.py
+++ b/runner/tests/unit/test_ttft.py
@@ -9,6 +9,7 @@ import pytest
 from coval_bench.metrics.ttft import (
     compute_audio_to_final,
     compute_rtf,
+    compute_ttfs,
     compute_ttft,
 )
 
@@ -104,3 +105,26 @@ def test_rtf_negative_duration_raises() -> None:
 
 def test_rtf_returns_float() -> None:
     assert isinstance(compute_rtf(1.0, 2.0), float)
+
+
+# ---------------------------------------------------------------------------
+# compute_ttfs
+# ---------------------------------------------------------------------------
+
+
+def test_ttfs_basic() -> None:
+    """audio_to_final 5.3 s, speech-end at 5.0 s → 0.3 s finalization."""
+    assert compute_ttfs(5.3, 5.0) == pytest.approx(0.3)
+
+
+def test_ttfs_zero() -> None:
+    assert compute_ttfs(5.0, 5.0) == pytest.approx(0.0)
+
+
+def test_ttfs_raises_on_negative() -> None:
+    with pytest.raises(ValueError, match="ttfs must be >= 0"):
+        compute_ttfs(4.9, 5.0)
+
+
+def test_ttfs_returns_float() -> None:
+    assert isinstance(compute_ttfs(2.0, 1.0), float)

--- a/web/components/visualizations/TimelineChart.tsx
+++ b/web/components/visualizations/TimelineChart.tsx
@@ -3,7 +3,7 @@
 
 "use client";
 
-import React, { useMemo } from "react";
+import React, { useMemo, useState } from "react";
 import {
   LineChart,
   Line,
@@ -64,16 +64,21 @@ const TimelineChart: React.FC = () => {
   } = useDashboard();
   const trackChartHover = useChartHoverTracking("timeline");
 
+  // STT shows a TTFS (default) / TTFT toggle; TTS is single-metric (TTFA).
+  const [metric, setMetric] = useState<string>(
+    activeTab === "stt" ? "TTFS" : "TTFA"
+  );
+
   const themeColors = useThemeColors();
-  const modelsWithData = getModelsWithTimelineData();
-  const windowedTimelineData = getWindowedTimelineData();
+  const modelsWithData = getModelsWithTimelineData(metric);
+  const windowedTimelineData = getWindowedTimelineData(metric);
   const currentTimeWindow = getCurrentTimeWindow();
   const tzAbbr = getLocalTimeZoneAbbr();
   const xAxisLabel = tzAbbr ? `Time (${tzAbbr})` : "Time";
 
-  const metricLabel = activeTab === "tts" ? "TTFA" : "TTFT";
+  const metricLabel = metric;
   const description =
-    metricDescriptions[activeTab === "tts" ? "ttfa" : "ttft"];
+    metricDescriptions[metric.toLowerCase() as keyof typeof metricDescriptions];
 
   const avgValue = useMemo(() => {
     let sum = 0;
@@ -96,7 +101,7 @@ const TimelineChart: React.FC = () => {
   // 0.5s step so the gridlines land on tidy values.
   const yAxisMax = useMemo(() => {
     let max = 0;
-    for (const point of getTimelineData()) {
+    for (const point of getTimelineData(metric)) {
       const record = point as Record<string, number>;
       for (const model of modelsWithData) {
         const value = record[`${model}_value`];
@@ -108,7 +113,7 @@ const TimelineChart: React.FC = () => {
     if (max === 0) return "dataMax" as const;
     const step = 500;
     return Math.ceil(max / step) * step;
-  }, [getTimelineData, modelsWithData]);
+  }, [getTimelineData, metric, modelsWithData]);
 
   return (
     <div className="mb-4">
@@ -125,6 +130,26 @@ const TimelineChart: React.FC = () => {
             value: `${avgValue.toFixed(0)} ms`,
           }}
         />
+
+        {activeTab === "stt" && (
+          <div className="mb-4 inline-flex gap-0.5 rounded-lg bg-gray-100 p-0.5">
+            {(["TTFS", "TTFT"] as const).map((m) => (
+              <button
+                key={m}
+                type="button"
+                onClick={() => setMetric(m)}
+                className={
+                  "rounded-md px-3 py-1 text-xs font-medium transition-colors " +
+                  (metric === m
+                    ? "bg-white text-text-primary shadow-sm"
+                    : "text-gray-500 hover:text-text-primary")
+                }
+              >
+                {m}
+              </button>
+            ))}
+          </div>
+        )}
 
         <div className="h-96" onMouseEnter={trackChartHover}>
           <ResponsiveContainer width="100%" height="100%">

--- a/web/hooks/useChartData.ts
+++ b/web/hooks/useChartData.ts
@@ -87,63 +87,82 @@ export function useChartData({
     [modelStats, activeTab, modelsByProvider]
   );
 
-  // Per-model timeline series (scheduled_at bucket → avg) for the primary
-  // latency metric. Feeds the timeline chart and the STT heatmap deltas.
-  const timelineByModel = useMemo<Record<string, Record<number, number>>>(() => {
-    const primaryMetric = activeTab === "tts" ? "TTFA" : "TTFT";
-
-    const byModel: Record<string, Record<number, number>> = {};
-    series.forEach((point) => {
-      if (point.metric_type !== primaryMetric) return;
-
-      const modelKey = toModelKey(point.provider, point.model);
-      const timestamp = new Date(point.scheduled_at).getTime();
-      if (!byModel[modelKey]) {
-        byModel[modelKey] = {};
+  // Merge a per-model series map into one row per timestamp (ascending), each
+  // with a `${model}_value` column. Shared by every metric's timeline.
+  const buildTimelineRows = useCallback(
+    (
+      byModel: Record<string, Record<number, number>>,
+      models: string[]
+    ): TimelineDataPoint[] => {
+      if (models.length === 0) {
+        return [];
       }
-      byModel[modelKey][timestamp] = toDisplayUnits(point.avg_value);
-    });
 
-    return byModel;
-  }, [series, activeTab, toDisplayUnits]);
-
-  // Timeline rows: merge the selected models' series into one row per
-  // timestamp (ascending), each with a `${model}_value` column.
-  const timelineData = useMemo<TimelineDataPoint[]>(() => {
-    const selectedModels =
-      activeTab === "tts" ? selectedTTSModels : selectedSTTModels;
-
-    if (selectedModels.length === 0) {
-      return [];
-    }
-
-    const timestampSet = new Set<number>();
-    selectedModels.forEach((model) => {
-      const tsMap = timelineByModel[model];
-      if (tsMap) {
-        Object.keys(tsMap).forEach((ts) => timestampSet.add(Number(ts)));
-      }
-    });
-    const timestamps = [...timestampSet].sort((a, b) => a - b);
-
-    return timestamps.map((timestamp) => {
-      const row: TimelineDataPoint = {
-        timestamp,
-        timestampLabel: new Date(timestamp).toISOString()
-      };
-      selectedModels.forEach((model) => {
-        const value = timelineByModel[model]?.[timestamp];
-        if (value !== undefined) {
-          row[`${model}_value`] = value;
+      const timestampSet = new Set<number>();
+      models.forEach((model) => {
+        const tsMap = byModel[model];
+        if (tsMap) {
+          Object.keys(tsMap).forEach((ts) => timestampSet.add(Number(ts)));
         }
       });
-      return row;
-    });
-  }, [timelineByModel, activeTab, selectedTTSModels, selectedSTTModels]);
+      const timestamps = [...timestampSet].sort((a, b) => a - b);
 
+      return timestamps.map((timestamp) => {
+        const row: TimelineDataPoint = {
+          timestamp,
+          timestampLabel: new Date(timestamp).toISOString()
+        };
+        models.forEach((model) => {
+          const value = byModel[model]?.[timestamp];
+          if (value !== undefined) {
+            row[`${model}_value`] = value;
+          }
+        });
+        return row;
+      });
+    },
+    []
+  );
+
+  // Per-metric, per-model timeline series (scheduled_at bucket → avg) built in
+  // one pass. Indexed by metric_type so any metric can read its own series.
+  const timelineByMetricModel = useMemo<
+    Record<string, Record<string, Record<number, number>>>
+  >(() => {
+    const out: Record<string, Record<string, Record<number, number>>> = {};
+    series.forEach((point) => {
+      const byModel = (out[point.metric_type] ??= {});
+      const modelKey = toModelKey(point.provider, point.model);
+      const modelSeries = (byModel[modelKey] ??= {});
+      modelSeries[new Date(point.scheduled_at).getTime()] = toDisplayUnits(
+        point.avg_value
+      );
+    });
+    return out;
+  }, [series, toDisplayUnits]);
+
+  // Primary latency metric series (TTFT for STT, TTFA for TTS). Also feeds the
+  // STT heatmap deltas and the gap chart.
+  const timelineByModel = useMemo<Record<string, Record<number, number>>>(() => {
+    const primaryMetric = activeTab === "tts" ? "TTFA" : "TTFT";
+    return timelineByMetricModel[primaryMetric] ?? {};
+  }, [timelineByMetricModel, activeTab]);
+
+  // Timeline rows for a given metric. Models follow the active tab (STT models
+  // for TTFS/TTFT, TTS models for TTFA).
   const getTimelineData = useCallback(
-    (): TimelineDataPoint[] => timelineData,
-    [timelineData]
+    (metric: string): TimelineDataPoint[] => {
+      const models =
+        activeTab === "tts" ? selectedTTSModels : selectedSTTModels;
+      return buildTimelineRows(timelineByMetricModel[metric] ?? {}, models);
+    },
+    [
+      buildTimelineRows,
+      timelineByMetricModel,
+      activeTab,
+      selectedTTSModels,
+      selectedSTTModels
+    ]
   );
 
   // Per-model box-plot pieces from the SQL stats: box = p25..p75, whiskers
@@ -465,35 +484,41 @@ export function useChartData({
     return ticks;
   }, [getCurrentTimeWindow]);
 
-  const getWindowedTimelineData = useCallback((): TimelineDataPoint[] => {
-    const [windowStart, windowEnd] = getCurrentTimeWindow();
-    return getTimelineData().filter(
-      (item) => item.timestamp >= windowStart && item.timestamp <= windowEnd
-    );
-  }, [getCurrentTimeWindow, getTimelineData]);
+  const getWindowedTimelineData = useCallback(
+    (metric: string): TimelineDataPoint[] => {
+      const [windowStart, windowEnd] = getCurrentTimeWindow();
+      return getTimelineData(metric).filter(
+        (item) => item.timestamp >= windowStart && item.timestamp <= windowEnd
+      );
+    },
+    [getCurrentTimeWindow, getTimelineData]
+  );
 
   /** Models that have at least one plotted point in the current timeline window. */
-  const getModelsWithTimelineData = useCallback((): string[] => {
-    const selectedModels =
-      activeTab === "tts" ? selectedTTSModels : selectedSTTModels;
-    const [windowStart, windowEnd] = getCurrentTimeWindow();
-    const windowed = getTimelineData().filter(
-      (point) => point.timestamp >= windowStart && point.timestamp <= windowEnd
-    );
-    return selectedModels.filter((model) =>
-      windowed.some(
-        (point) =>
-          point[`${model}_value`] !== undefined &&
-          point[`${model}_value`] !== null
-      )
-    );
-  }, [
-    activeTab,
-    selectedTTSModels,
-    selectedSTTModels,
-    getCurrentTimeWindow,
-    getTimelineData,
-  ]);
+  const getModelsWithTimelineData = useCallback(
+    (metric: string): string[] => {
+      const selectedModels =
+        activeTab === "tts" ? selectedTTSModels : selectedSTTModels;
+      const [windowStart, windowEnd] = getCurrentTimeWindow();
+      const windowed = getTimelineData(metric).filter(
+        (point) => point.timestamp >= windowStart && point.timestamp <= windowEnd
+      );
+      return selectedModels.filter((model) =>
+        windowed.some(
+          (point) =>
+            point[`${model}_value`] !== undefined &&
+            point[`${model}_value`] !== null
+        )
+      );
+    },
+    [
+      activeTab,
+      selectedTTSModels,
+      selectedSTTModels,
+      getCurrentTimeWindow,
+      getTimelineData
+    ]
+  );
 
   return {
     formatChartLabel,

--- a/web/lib/config/metrics.ts
+++ b/web/lib/config/metrics.ts
@@ -12,6 +12,11 @@ export const metricDescriptions = {
     detailed:
       "We run TTFT measurements on a fixed test case to measure consistency over time. A model that consistently responds within a narrow time range provides better user experience than one with highly variable timing, even if the variable model is sometimes faster. Unpredictable delays can be seen through sudden latency spikes."
   },
+  ttfs: {
+    short: "Time to Final Segment",
+    detailed:
+      "TTFS measures how quickly a provider returns the final transcript once speech has ended, anchored at a shared VAD end-of-speech point so every provider is compared from the same instant. It isolates engine finalization speed — the latency a voice agent actually waits on before it can respond — independent of how long the speaker talked."
+  },
   wer: {
     short: "Word Error Rate (%)",
     detailed:


### PR DESCRIPTION
Adds TTFS — time from end-of-speech to the final transcript, anchored at a shared VAD offset pinned per clip. Measuring from speech end keeps latency comparable across providers and clip lengths.

- Runner trims trailing silence and emits a TTFS row (a missing offset or failed calc fails the row, not a silent null)
- Served by the results + leaderboard APIs
- STT timeline gets a TTFS/TTFT toggle, default TTFS

Follow-ups (separate PRs): Flux/AssemblyAI endpointing parity, and a TTFS toggle on the latency-vs-accuracy chart.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added TTFS (Time to Final Segment) metric to the leaderboard, accessible alongside existing latency metrics.
  * Introduced metric selector in timeline chart allowing users to toggle between TTFS and TTFT for STT benchmarks.
  * Added VAD offset preprocessing capability for audio dataset preparation.

* **Updates**
  * Extended leaderboard and results API endpoints to support the new TTFS metric option.
  * Updated STT manifest schema to include optional speech end-offset timestamps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Introduces TTFS (Time to Final Segment) as a new STT latency metric anchored at a shared per-clip VAD end-of-speech offset, enabling provider comparisons that are independent of clip length and speaker pace.

- Runner trims trailing silence from each clip using the precomputed `speech_end_offset_ms` before dispatch, then emits a TTFS result row; a missing offset or negative result fails the row (never a silent null).
- Backend: `compute_ttfs` in `metrics/ttft.py`, manifest schema extended, leaderboard and results APIs updated with TTFS as a valid metric.
- Frontend: `useChartData` refactored to index timeline series per-metric; `TimelineChart` gains a TTFS/TTFT toggle for the STT tab, defaulting to TTFS.

<h3>Confidence Score: 4/5</h3>

Safe to merge after fixing the tab-switch metric state in TimelineChart — the runner, metric, and API changes are correct.

The backend additions (trimming, TTFS computation, manifest, APIs) are clean and well-tested. The frontend refactor in useChartData is solid. The one concrete defect is in TimelineChart: metric state is initialized from activeTab only once at mount, so switching between STT and TTS leaves the chart querying the wrong metric — blank chart for TTS if the user navigated from STT, and an un-highlighted toggle for STT if navigating from TTS with no way to recover without a page reload.

web/components/visualizations/TimelineChart.tsx — the metric/activeTab sync needs a useEffect before this ships.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| web/components/visualizations/TimelineChart.tsx | Adds TTFS/TTFT metric toggle for the STT tab; metric state initialized from activeTab but never resynced on tab change, causing blank charts when switching between tabs. |
| runner/src/coval_bench/runner/orchestrator.py | Adds trailing-silence trimming and TTFS metric row; hardcoded PCM format constants (16000/2) duplicate values already in the measure_ttft call but no logic errors found. |
| runner/src/coval_bench/metrics/ttft.py | Adds compute_ttfs; correctly computes audio_to_final minus speech_end_offset and raises ValueError on negative results. |
| web/hooks/useChartData.ts | Refactors timeline data from a single primary-metric series to a per-metric index (timelineByMetricModel); getTimelineData, getWindowedTimelineData, and getModelsWithTimelineData now accept a metric argument cleanly. |
| runner/scripts/precompute_vad_offsets.py | New offline tool that runs SileroVAD over clips and patches speech_end_offset_ms into the manifest; correctly handles missing audio and clips with no detected speech. |
| runner/src/coval_bench/datasets/manifest.py | Adds optional speech_end_offset_ms field (ge=0) to STTManifestItem; backward-compatible with existing manifest entries that omit the field. |
| runner/src/coval_bench/api/routers/leaderboard.py | Extends MetricLiteral and _VALID_COMBOS to include TTFS+STT; minimal, consistent change. |
| runner/tests/unit/test_orchestrator.py | Adds test_stt_ttfs_status_tracks_value covering the happy path and the missing-offset failure path; existing test updated to expect 4 metric rows instead of 3. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant M as Manifest (stt-v1.json)
    participant O as Orchestrator
    participant P as STT Provider
    participant DB as Database
    participant FE as TimelineChart

    M->>O: DatasetItem (speech_end_offset_ms)
    O->>O: trim trailing silence
    O->>P: measure_ttft(trimmed_audio_bytes)
    P-->>O: TranscriptionResult (audio_to_final_seconds)
    O->>O: compute_ttfs(audio_to_final, offset/1000)
    O->>DB: "Result(metric_type=TTFS, metric_value)"
    DB-->>FE: "series data (metric_type = TTFS or TTFT or TTFA)"
    FE->>FE: timelineByMetricModel[metric]
    FE->>FE: TTFS/TTFT toggle (STT tab only)
```

<sub>Reviews (4): Last reviewed commit: ["Fix typo in docstring for metrics module"](https://github.com/coval-ai/benchmarks/commit/cd892cb406c27e304fb8d574d8fa90667f5f87cf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36566048)</sub>

<!-- /greptile_comment -->