### PR TITLE
Add Cartesia Ink-2 STT provider

### DIFF
--- a/runner/src/coval_bench/providers/stt/__init__.py
+++ b/runner/src/coval_bench/providers/stt/__init__.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 from coval_bench.providers.base import STTProvider
 from coval_bench.providers.stt.assemblyai import AssemblyAIProvider
+from coval_bench.providers.stt.cartesia import CartesiaSTTProvider
 from coval_bench.providers.stt.deepgram import DeepgramProvider
 from coval_bench.providers.stt.elevenlabs import ElevenLabsSTTProvider
 from coval_bench.providers.stt.gradium import GradiumSTTProvider
@@ -34,6 +35,7 @@ except ImportError:
 
 STT_PROVIDERS: dict[str, type[STTProvider]] = {
     "deepgram": DeepgramProvider,
+    "cartesia": CartesiaSTTProvider,
     "assemblyai": AssemblyAIProvider,
     "elevenlabs": ElevenLabsSTTProvider,
     "gradium": GradiumSTTProvider,
@@ -49,6 +51,7 @@ __all__ = [
     "STT_PROVIDERS",
     "GOOGLE_AVAILABLE",
     "DeepgramProvider",
+    "CartesiaSTTProvider",
     "AssemblyAIProvider",
     "ElevenLabsSTTProvider",
     "GradiumSTTProvider",

--- a/runner/src/coval_bench/providers/stt/cartesia.py
+++ b/runner/src/coval_bench/providers/stt/cartesia.py
@@ -1,0 +1,185 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Cartesia Ink real-time STT provider (ink-2).
+
+The auto-finalize endpoint (/stt/turns/websocket, turn.* events) is intentionally
+not used: its model-driven turn segmentation diverges from how every other STT
+provider here is benchmarked (single stream, progressive finals, finalize-on-close).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from typing import Any
+
+import structlog
+import websockets.asyncio.client as ws_client
+from pydantic import SecretStr
+
+from coval_bench.providers.base import STTProvider, TranscriptionResult
+
+logger = structlog.get_logger(__name__)
+
+_VALID_MODELS = ("ink-2",)
+_WS_BASE_URL = "wss://api.cartesia.ai/stt/websocket"
+_CARTESIA_VERSION = "2025-11-04"
+
+
+class CartesiaSTTProvider(STTProvider):
+    """Cartesia Ink streaming STT provider."""
+
+    def __init__(self, api_key: SecretStr, model: str = "ink-2") -> None:
+        if model not in _VALID_MODELS:
+            raise ValueError(f"Invalid Cartesia STT model {model!r}. Valid: {_VALID_MODELS}")
+        self._api_key = api_key
+        self._model = model
+
+    @property
+    def name(self) -> str:
+        return f"cartesia-{self._model}"
+
+    @property
+    def model(self) -> str:
+        return self._model
+
+    def _build_websocket_url(self, sample_rate: int) -> str:
+        return (
+            f"{_WS_BASE_URL}"
+            f"?model={self._model}"
+            f"&encoding=pcm_s16le"
+            f"&sample_rate={sample_rate}"
+            f"&language=en"
+        )
+
+    async def measure_ttft(
+        self,
+        audio_data: bytes,
+        channels: int,
+        sample_width: int,
+        sample_rate: int,
+        realtime_resolution: float = 0.1,
+        audio_duration: float | None = None,
+    ) -> TranscriptionResult:
+        if channels != 1:
+            raise ValueError(
+                f"Cartesia Ink only supports mono audio (channels=1), got channels={channels}"
+            )
+        if sample_width != 2:
+            raise ValueError(
+                f"Cartesia Ink expects 16-bit PCM (sample_width=2), got sample_width={sample_width}"
+            )
+        result = TranscriptionResult(provider=self.name, vad_events_count=0)
+        total_start = time.monotonic()
+
+        try:
+            url = self._build_websocket_url(sample_rate)
+            headers = {
+                "Authorization": f"Bearer {self._api_key.get_secret_value()}",
+                "cartesia-version": _CARTESIA_VERSION,
+            }
+
+            async with ws_client.connect(url, additional_headers=headers) as ws:
+                send_task = asyncio.create_task(
+                    self._send_audio(ws, audio_data, sample_rate, result, realtime_resolution)
+                )
+                recv_task = asyncio.create_task(self._receive(ws, result))
+                outcomes = await asyncio.gather(send_task, recv_task, return_exceptions=True)
+                # gather swallows task exceptions into the result list; surface the
+                # first one so a failed send/recv never reads as a clean run.
+                for outcome in outcomes:
+                    if isinstance(outcome, BaseException) and result.error is None:
+                        result.error = str(outcome)
+
+        except Exception as exc:
+            logger.exception("cartesia stt measure_ttft failed", error=str(exc))
+            result.error = str(exc)
+
+        result.total_time = time.monotonic() - total_start
+        return result
+
+    async def _send_audio(
+        self,
+        ws: Any,
+        audio_data: bytes,
+        sample_rate: int,
+        result: TranscriptionResult,
+        realtime_resolution: float,
+    ) -> None:
+        byte_rate = sample_rate * 2  # 16-bit mono
+        chunk_size = int(byte_rate * realtime_resolution)
+        data = audio_data
+        first_chunk = True
+        try:
+            while data:
+                chunk, data = data[:chunk_size], data[chunk_size:]
+                if first_chunk:
+                    result.audio_start_time = time.monotonic()
+                    first_chunk = False
+                await ws.send(chunk)
+                await asyncio.sleep(realtime_resolution)
+            # Two-phase end: finalize flushes buffered audio; close ends the session.
+            await ws.send("finalize")
+            await ws.send("close")
+        except Exception as exc:
+            logger.exception("cartesia stt send error", error=str(exc))
+            raise
+
+    async def _receive(self, ws: Any, result: TranscriptionResult) -> None:
+        final_segments: list[str] = []
+
+        try:
+            async for raw in ws:
+                if isinstance(raw, bytes):
+                    continue
+
+                msg: dict[str, Any] = json.loads(raw)
+                now = time.monotonic()
+                msg_type: str = msg.get("type", "")
+
+                if msg_type == "error":
+                    result.error = str(msg.get("message") or msg)
+                    break
+                # flush_done acks a finalize; done is the terminal marker. Break on
+                # done explicitly rather than relying on the socket closing.
+                if msg_type == "done":
+                    break
+                if msg_type != "transcript":
+                    continue
+
+                # Keep the raw text: Cartesia deltas carry their own leading spaces,
+                # which are the word separators. Strip only for the empty check + display.
+                text = str(msg.get("text", ""))
+                token = text.strip()
+                if not token:
+                    continue
+
+                # TTFT — first non-empty transcript (partial or final).
+                if result.ttft_seconds is None and result.audio_start_time is not None:
+                    result.ttft_seconds = now - result.audio_start_time
+                    result.first_token_content = token[:30] + "..." if len(token) > 30 else token
+
+                result.partial_transcripts.append(token)
+
+                if msg.get("is_final"):
+                    final_segments.append(text)
+                    if result.audio_start_time is not None:
+                        result.audio_to_final_seconds = now - result.audio_start_time
+
+        except Exception as exc:
+            logger.exception("cartesia stt receive error", error=str(exc))
+            if result.error is None:
+                result.error = str(exc)
+
+        # Per Cartesia docs, join is_final deltas verbatim — they carry their own
+        # spacing; do NOT inject separators between them. Outer strip only, for display.
+        # If no is_final arrived, leave complete_transcript None so the orchestrator
+        # scores WER as failed rather than from a partial fragment.
+        if final_segments:
+            result.complete_transcript = "".join(final_segments).strip() or None
+
+        if result.complete_transcript:
+            result.transcript_length = len(result.complete_transcript)
+            result.word_count = len(result.complete_transcript.split())

--- a/runner/src/coval_bench/runner/config.py
+++ b/runner/src/coval_bench/runner/config.py
@@ -41,6 +41,7 @@ DEFAULT_STT_MATRIX: list[ProviderEntry] = [
     ProviderEntry(provider="speechmatics", model="enhanced", enabled=True),
     ProviderEntry(provider="gradium", model="default", enabled=True),
     ProviderEntry(provider="smallest", model="pulse", enabled=True),
+    ProviderEntry(provider="cartesia", model="ink-2", enabled=True),
     # OFF; disabled=True hides these from the public catalogue.
     ProviderEntry(provider="google", model="short", enabled=False, disabled=True),
     ProviderEntry(provider="google", model="long", enabled=False, disabled=True),

--- a/runner/tests/providers/stt/fixtures/cartesia/events-success.json
+++ b/runner/tests/providers/stt/fixtures/cartesia/events-success.json
@@ -1,0 +1,14 @@
+[
+  { "type": "transcript", "is_final": true, "request_id": "req_test001", "text": "hello", "duration": 0.6 },
+  { "type": "transcript", "is_final": true, "request_id": "req_test001", "text": " world", "duration": 1.2 },
+  {
+    "type": "transcript",
+    "is_final": true,
+    "request_id": "req_test001",
+    "text": " how are you",
+    "duration": 2.4,
+    "words": [{ "word": "how", "start": 1.2, "end": 1.5 }]
+  },
+  { "type": "flush_done", "request_id": "req_test001" },
+  { "type": "done", "request_id": "req_test001" }
+]

--- a/runner/tests/providers/stt/test_cartesia.py
+++ b/runner/tests/providers/stt/test_cartesia.py
@@ -1,0 +1,334 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for coval_bench.providers.stt.cartesia (CartesiaSTTProvider).
+
+All tests use FakeWebSocket — no live network calls are made.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pydantic import SecretStr
+
+from coval_bench.providers.stt.cartesia import CartesiaSTTProvider
+from tests.providers.stt.conftest import FakeWebSocket, load_fixture_events
+
+
+def make_provider() -> CartesiaSTTProvider:
+    return CartesiaSTTProvider(api_key=SecretStr("test-key-cartesia"))
+
+
+def _fake_connect(events: list[Any], sent: list[Any] | None = None) -> Any:
+    ws = FakeWebSocket(events, on_send=(sent.append if sent is not None else None))
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=ws)
+    cm.__aexit__ = AsyncMock(return_value=False)
+    return cm
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cartesia_success(fake_api_key: SecretStr, audio_pcm_bytes: bytes) -> None:
+    events = load_fixture_events("cartesia", "events-success")
+    provider = CartesiaSTTProvider(api_key=fake_api_key)
+
+    with patch(
+        "coval_bench.providers.stt.cartesia.ws_client.connect",
+        return_value=_fake_connect(events),
+    ):
+        result = await provider.measure_ttft(
+            audio_data=audio_pcm_bytes,
+            channels=1,
+            sample_width=2,
+            sample_rate=16000,
+            realtime_resolution=0.5,
+            audio_duration=3.0,
+        )
+
+    assert result.error is None
+    assert result.ttft_seconds is not None
+    assert result.ttft_seconds >= 0
+    assert result.first_token_content is not None
+    assert "hello" in result.first_token_content.lower()
+    assert result.complete_transcript == "hello world how are you"
+
+
+# ---------------------------------------------------------------------------
+# Provider name and model
+# ---------------------------------------------------------------------------
+
+
+def test_provider_name() -> None:
+    assert make_provider().name == "cartesia-ink-2"
+
+
+def test_provider_model() -> None:
+    assert make_provider().model == "ink-2"
+
+
+# ---------------------------------------------------------------------------
+# Invalid model / mono guard
+# ---------------------------------------------------------------------------
+
+
+def test_invalid_model_raises() -> None:
+    with pytest.raises(ValueError, match="Invalid Cartesia STT model"):
+        CartesiaSTTProvider(api_key=SecretStr("k"), model="ink-whisper")
+
+
+@pytest.mark.asyncio
+async def test_stereo_rejected(fake_api_key: SecretStr, audio_pcm_bytes: bytes) -> None:
+    provider = CartesiaSTTProvider(api_key=fake_api_key)
+    with pytest.raises(ValueError, match="mono"):
+        await provider.measure_ttft(
+            audio_data=audio_pcm_bytes,
+            channels=2,
+            sample_width=2,
+            sample_rate=16000,
+        )
+
+
+@pytest.mark.asyncio
+async def test_non_16bit_rejected(fake_api_key: SecretStr, audio_pcm_bytes: bytes) -> None:
+    provider = CartesiaSTTProvider(api_key=fake_api_key)
+    with pytest.raises(ValueError, match="16-bit PCM"):
+        await provider.measure_ttft(
+            audio_data=audio_pcm_bytes,
+            channels=1,
+            sample_width=4,
+            sample_rate=16000,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Control commands: finalize then close are sent after the audio
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_finalize_and_close_sent(fake_api_key: SecretStr, audio_pcm_bytes: bytes) -> None:
+    events = load_fixture_events("cartesia", "events-success")
+    sent: list[Any] = []
+    provider = CartesiaSTTProvider(api_key=fake_api_key)
+
+    with patch(
+        "coval_bench.providers.stt.cartesia.ws_client.connect",
+        return_value=_fake_connect(events, sent=sent),
+    ):
+        await provider.measure_ttft(
+            audio_data=audio_pcm_bytes,
+            channels=1,
+            sample_width=2,
+            sample_rate=16000,
+            realtime_resolution=0.5,
+        )
+
+    text_cmds = [m for m in sent if isinstance(m, str)]
+    assert text_cmds == ["finalize", "close"]
+
+
+# ---------------------------------------------------------------------------
+# Connection URL, auth header, and pinned API version (regression guard for the
+# X-API-Key / wrong-version bug the hermetic suite originally missed)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_connect_url_and_auth(fake_api_key: SecretStr, audio_pcm_bytes: bytes) -> None:
+    events = load_fixture_events("cartesia", "events-success")
+    connect_mock = MagicMock(return_value=_fake_connect(events))
+    provider = CartesiaSTTProvider(api_key=fake_api_key)
+
+    with patch("coval_bench.providers.stt.cartesia.ws_client.connect", connect_mock):
+        await provider.measure_ttft(
+            audio_data=audio_pcm_bytes,
+            channels=1,
+            sample_width=2,
+            sample_rate=16000,
+            realtime_resolution=0.5,
+        )
+
+    url = connect_mock.call_args.args[0]
+    assert url.startswith("wss://api.cartesia.ai/stt/websocket?")
+    for param in ("model=ink-2", "encoding=pcm_s16le", "sample_rate=16000", "language=en"):
+        assert param in url
+    assert "cartesia_version" not in url  # version is a header, not a query param
+
+    headers = connect_mock.call_args.kwargs["additional_headers"]
+    assert headers["Authorization"] == f"Bearer {fake_api_key.get_secret_value()}"
+    assert headers["cartesia-version"] == "2025-11-04"
+
+
+# ---------------------------------------------------------------------------
+# Field-name guard: transcript text lives in "text", not "transcript"
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_reads_text_field_not_transcript(
+    fake_api_key: SecretStr, audio_pcm_bytes: bytes
+) -> None:
+    events: list[Any] = [
+        {"type": "transcript", "is_final": True, "transcript": "wrong field", "request_id": "r"},
+        {"type": "done", "request_id": "r"},
+    ]
+    provider = CartesiaSTTProvider(api_key=fake_api_key)
+
+    with patch(
+        "coval_bench.providers.stt.cartesia.ws_client.connect",
+        return_value=_fake_connect(events),
+    ):
+        result = await provider.measure_ttft(
+            audio_data=audio_pcm_bytes,
+            channels=1,
+            sample_width=2,
+            sample_rate=16000,
+            realtime_resolution=0.5,
+        )
+
+    assert result.complete_transcript is None
+    assert result.ttft_seconds is None
+
+
+# ---------------------------------------------------------------------------
+# Empty stream
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cartesia_empty_stream(fake_api_key: SecretStr, audio_pcm_bytes: bytes) -> None:
+    provider = CartesiaSTTProvider(api_key=fake_api_key)
+
+    with patch(
+        "coval_bench.providers.stt.cartesia.ws_client.connect",
+        return_value=_fake_connect([]),
+    ):
+        result = await provider.measure_ttft(
+            audio_data=audio_pcm_bytes,
+            channels=1,
+            sample_width=2,
+            sample_rate=16000,
+            realtime_resolution=0.5,
+        )
+
+    assert result.complete_transcript is None
+    assert result.ttft_seconds is None
+
+
+# ---------------------------------------------------------------------------
+# WS-close gate: a stream that ends WITHOUT a "done" marker still terminates
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_no_done_marker_terminates(fake_api_key: SecretStr, audio_pcm_bytes: bytes) -> None:
+    events: list[Any] = [
+        {"type": "transcript", "is_final": True, "text": "hello world", "request_id": "r"},
+    ]
+    provider = CartesiaSTTProvider(api_key=fake_api_key)
+
+    with patch(
+        "coval_bench.providers.stt.cartesia.ws_client.connect",
+        return_value=_fake_connect(events),
+    ):
+        result = await provider.measure_ttft(
+            audio_data=audio_pcm_bytes,
+            channels=1,
+            sample_width=2,
+            sample_rate=16000,
+            realtime_resolution=0.5,
+        )
+
+    assert result.complete_transcript == "hello world"
+    assert result.audio_to_final_seconds is not None
+
+
+# ---------------------------------------------------------------------------
+# audio_to_final: set on a final, None when only partials arrive
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_audio_to_final_none_on_partial_only(
+    fake_api_key: SecretStr, audio_pcm_bytes: bytes
+) -> None:
+    events: list[Any] = [
+        {"type": "transcript", "is_final": False, "text": "hello", "request_id": "r"},
+        {"type": "done", "request_id": "r"},
+    ]
+    provider = CartesiaSTTProvider(api_key=fake_api_key)
+
+    with patch(
+        "coval_bench.providers.stt.cartesia.ws_client.connect",
+        return_value=_fake_connect(events),
+    ):
+        result = await provider.measure_ttft(
+            audio_data=audio_pcm_bytes,
+            channels=1,
+            sample_width=2,
+            sample_rate=16000,
+            realtime_resolution=0.5,
+        )
+
+    assert result.audio_to_final_seconds is None
+    assert result.ttft_seconds is not None
+    # No is_final arrived: TTFT is still measured, but the transcript stays
+    # incomplete so the orchestrator does not score WER from a fragment.
+    assert result.complete_transcript is None
+
+
+# ---------------------------------------------------------------------------
+# Error event populates result.error
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_error_event_sets_error(fake_api_key: SecretStr, audio_pcm_bytes: bytes) -> None:
+    events: list[Any] = [
+        {"type": "error", "status_code": 400, "title": "Bad", "message": "boom"},
+    ]
+    provider = CartesiaSTTProvider(api_key=fake_api_key)
+
+    with patch(
+        "coval_bench.providers.stt.cartesia.ws_client.connect",
+        return_value=_fake_connect(events),
+    ):
+        result = await provider.measure_ttft(
+            audio_data=audio_pcm_bytes,
+            channels=1,
+            sample_width=2,
+            sample_rate=16000,
+            realtime_resolution=0.5,
+        )
+
+    assert result.error == "boom"
+    assert result.complete_transcript is None
+
+
+@pytest.mark.asyncio
+async def test_malformed_frame_sets_error(fake_api_key: SecretStr, audio_pcm_bytes: bytes) -> None:
+    """A non-JSON frame must surface as result.error, not a silent clean run."""
+    provider = CartesiaSTTProvider(api_key=fake_api_key)
+
+    with patch(
+        "coval_bench.providers.stt.cartesia.ws_client.connect",
+        return_value=_fake_connect(["not-json{"]),
+    ):
+        result = await provider.measure_ttft(
+            audio_data=audio_pcm_bytes,
+            channels=1,
+            sample_width=2,
+            sample_rate=16000,
+            realtime_resolution=0.5,
+        )
+
+    assert result.error is not None
+    assert result.complete_transcript is None

--- a/web/lib/config/colors.ts
+++ b/web/lib/config/colors.ts
@@ -20,6 +20,9 @@ export const modelColors: Record<string, string> = {
   "sonic-3": "#3498DB",
   "sonic-3.5": "#2563EB",
 
+  // Cartesia STT
+  "ink-2": "#6366F1",
+
   // Rime TTS
   arcana: "#33FF99",
   mistv3: "#0E5C32",

--- a/web/lib/config/models.ts
+++ b/web/lib/config/models.ts
@@ -24,12 +24,14 @@ export const modelDisplayNames: Record<string, string> = {
   scribe_v2_realtime: "Scribe v2 Realtime",
   "gpt-realtime-whisper": "GPT Realtime Whisper",
   "universal-streaming": "Universal Streaming",
+  "ink-2": "Ink 2",
   default: "Default",
   enhanced: "Enhanced"
 };
 
 export const sttProviderNames: Record<string, string> = {
   assemblyai: "AssemblyAI",
+  cartesia: "Cartesia",
   deepgram: "Deepgram",
   elevenlabs: "ElevenLabs",
   gradium: "Gradium",

--- a/web/lib/utils/formatters.ts
+++ b/web/lib/utils/formatters.ts
@@ -107,6 +107,7 @@ export function normalizeModelName(modelKey: string): string {
     scribe_v2_realtime: "Scribe v2 Realtime",
     "gpt-realtime-whisper": "GPT Realtime Whisper",
     "universal-streaming": "Universal Streaming",
+    "ink-2": "Ink 2",
     default: "Default",
     enhanced: "Enhanced"
   };
@@ -146,6 +147,7 @@ function capitalizeProviderSlug(providerName: string): string {
 export function normalizeSTTProviderName(providerName: string): string {
   const mappings: Record<string, string> = {
     assemblyai: "AssemblyAI",
+    cartesia: "Cartesia",
     deepgram: "Deepgram",
     elevenlabs: "ElevenLabs",
     gradium: "Gradium",


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds Cartesia Ink-2 as a new streaming STT provider, including the WebSocket-based provider implementation, hermetic test suite, and frontend label/color registrations.

- **`cartesia.py`**: Implements `CartesiaSTTProvider` using a two-task async pattern (`_send_audio` / `_receive` over a WebSocket), with explicit validation of mono-only and 16-bit-only constraints, and correct exception surfacing via `gather` outcome inspection.
- **Tests**: 334-line hermetic test file covering happy path, validation guards, protocol control commands, field-name correctness, empty stream, and error-event handling — no live network calls.
- **Frontend**: `models.ts`, `colors.ts`, and `formatters.ts` each receive the corresponding `"ink-2"` / `"cartesia"` entries; `config.py` adds the provider to the default benchmark matrix.

<h3>Confidence Score: 5/5</h3>

The change is self-contained and additive — no existing code paths are modified.

The provider correctly validates both the channel and sample-width constraints upfront, surfaces task exceptions through the gather-outcome inspection loop, and assembles the final transcript by joining raw segments verbatim per Cartesia's spacing convention. The hermetic test suite covers all meaningful code paths including error events, malformed frames, control-command sequencing, and URL/auth construction. No pre-existing providers or shared state are touched.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| runner/src/coval_bench/providers/stt/cartesia.py | Core provider: validates mono/16-bit constraints, correctly inspects gather outcomes for exceptions, and assembles final transcript by joining raw segments verbatim. |
| runner/tests/providers/stt/test_cartesia.py | Comprehensive hermetic test suite with 13 scenarios covering happy path, validation guards, control commands, URL/auth, field-name regression, empty stream, partial-only transcripts, error events, and malformed frames. |
| runner/src/coval_bench/runner/config.py | Adds cartesia/ink-2 to the default STT benchmark matrix with enabled=True. |
| runner/src/coval_bench/providers/stt/__init__.py | Registers CartesiaSTTProvider in the STT_PROVIDERS dict and __all__; consistent with existing provider pattern. |
| runner/tests/providers/stt/fixtures/cartesia/events-success.json | Fixture with three is_final transcript events (with leading-space word separators), a flush_done ack, and a done terminal marker — correctly models Cartesia's streaming protocol. |
| web/lib/config/colors.ts | Adds ink-2 color entry in the Cartesia STT section. |
| web/lib/config/models.ts | Adds ink-2 display name and cartesia provider name; consistent with existing entries. |
| web/lib/utils/formatters.ts | Adds ink-2 and cartesia to both the model and provider normalization maps, mirroring models.ts. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Runner
    participant Provider as CartesiaSTTProvider
    participant Send as _send_audio task
    participant Recv as _receive task
    participant WS as Cartesia WS Server

    Runner->>Provider: "measure_ttft(audio, channels=1, sample_width=2)"
    Provider->>WS: "connect (model, encoding, sample_rate, Bearer token)"
    Provider->>Send: create_task(_send_audio)
    Provider->>Recv: create_task(_receive)
    Provider->>Provider: "asyncio.gather(send, recv, return_exceptions=True)"

    loop stream at realtime_resolution rate
        Send->>WS: send PCM chunk
        Send->>Send: asyncio.sleep(realtime_resolution)
    end
    Send->>WS: "send finalize"
    Send->>WS: "send close"

    loop transcript events
        WS-->>Recv: "transcript event (text, is_final)"
        Recv->>Recv: record ttft_seconds on first token
        Recv->>Recv: "append to partial_transcripts or final_segments"
    end
    WS-->>Recv: "done event"
    Recv->>Recv: "join final_segments to complete_transcript"

    Provider->>Provider: inspect outcomes for BaseException
    Provider-->>Runner: "TranscriptionResult(ttft_seconds, complete_transcript)"
```

<sub>Reviews (2): Last reviewed commit: ["Add Cartesia Ink-2 STT provider"](https://github.com/coval-ai/benchmarks/commit/3cb0178369d4abcd6d14198e22d297d0e6715bf3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36566110)</sub>

<!-- /greptile_comment -->