### PR TITLE
Add 7d and 30d windows

### DIFF
--- a/runner/src/coval_bench/api/app.py
+++ b/runner/src/coval_bench/api/app.py
@@ -26,7 +26,7 @@ from posthog import Posthog
 from slowapi.errors import RateLimitExceeded
 from slowapi.middleware import SlowAPIMiddleware
 
-from coval_bench.api.cache import new_response_cache
+from coval_bench.api.cache import new_cache_locks, new_response_cache
 from coval_bench.api.ratelimit import _rate_limit_handler, limiter
 from coval_bench.api.routers import aggregates, health, leaderboard, providers, results, runs
 from coval_bench.config import Settings, get_settings
@@ -97,6 +97,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     )
 
     app.state.response_cache = new_response_cache()
+    app.state.cache_locks = new_cache_locks()
 
     # Rate limiting (ADR-013) — in-memory per-instance; see ratelimit.py for caveat.
     app.state.limiter = limiter

--- a/runner/src/coval_bench/api/cache.py
+++ b/runner/src/coval_bench/api/cache.py
@@ -20,13 +20,19 @@ only ``/v1/results/aggregates`` reads it today.
 from __future__ import annotations
 
 import asyncio
+import time
 from collections import defaultdict
-from typing import Any
+from collections.abc import Awaitable, Callable, Hashable
+from typing import Any, Literal
 
 from cachetools import TTLCache
 
 # 15 min cache for no real reason.
 CACHE_TTL_SECONDS = 900
+# How long one fill failure is shared before the query is retried.
+FAILURE_TTL_SECONDS = 5
+
+CacheStatus = Literal["hit", "coalesced", "miss"]
 
 
 def new_response_cache() -> TTLCache[Any, Any]:
@@ -39,9 +45,40 @@ def new_response_cache() -> TTLCache[Any, Any]:
 
 
 def new_cache_locks() -> defaultdict[Any, asyncio.Lock]:
-    """Per-cache-key locks that coalesce concurrent misses.
-
-    N simultaneous requests for one uncached key run the SQL once; the rest
-    wait on the lock instead of each holding one of the pool's 4 connections.
-    """
+    """Per-cache-key locks backing ``get_or_fill``."""
     return defaultdict(asyncio.Lock)
+
+
+async def get_or_fill[T](
+    cache: TTLCache[Any, Any],
+    locks: defaultdict[Any, asyncio.Lock],
+    key: Hashable,
+    fill: Callable[[], Awaitable[T]],
+) -> tuple[T, CacheStatus]:
+    """Read ``key`` from the cache, running ``fill`` once on a miss.
+
+    Concurrent misses for one key share a single ``fill`` instead of each
+    holding a pool connection ("coalesced"). A fill that raises is re-raised
+    to callers arriving within FAILURE_TTL_SECONDS, so a failing query is
+    not re-run serially by every queued waiter.
+    """
+    lock = locks[key]
+    waited = lock.locked()
+    async with lock:
+        value = cache.get(key)
+        if value is not None:
+            return value, "coalesced" if waited else "hit"
+
+        failure = cache.get((key, "failure"))
+        if failure is not None:
+            failed_at, exc = failure
+            if time.monotonic() - failed_at < FAILURE_TTL_SECONDS:
+                raise exc
+
+        try:
+            value = await fill()
+        except Exception as exc:
+            cache[(key, "failure")] = (time.monotonic(), exc)
+            raise
+        cache[key] = value
+        return value, "miss"

--- a/runner/src/coval_bench/api/cache.py
+++ b/runner/src/coval_bench/api/cache.py
@@ -19,6 +19,8 @@ only ``/v1/results/aggregates`` reads it today.
 
 from __future__ import annotations
 
+import asyncio
+from collections import defaultdict
 from typing import Any
 
 from cachetools import TTLCache
@@ -34,3 +36,12 @@ def new_response_cache() -> TTLCache[Any, Any]:
     window) aggregates param combinations.
     """
     return TTLCache(maxsize=64, ttl=CACHE_TTL_SECONDS)
+
+
+def new_cache_locks() -> defaultdict[Any, asyncio.Lock]:
+    """Per-cache-key locks that coalesce concurrent misses.
+
+    N simultaneous requests for one uncached key run the SQL once; the rest
+    wait on the lock instead of each holding one of the pool's 4 connections.
+    """
+    return defaultdict(asyncio.Lock)

--- a/runner/src/coval_bench/api/common.py
+++ b/runner/src/coval_bench/api/common.py
@@ -9,42 +9,19 @@ on — adding a window or benchmark here updates every endpoint at once.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 from typing import Literal
 
 BenchmarkLiteral = Literal["STT", "TTS"]
 WindowLiteral = Literal["24h", "7d", "30d"]
 
-
-@dataclass(frozen=True)
-class WindowSpec:
-    """Per-window query parameters.
-
-    interval: Postgres interval string. Fixed here — looked up by Python,
-        never user-interpolated into SQL.
-    series_bucket_seconds: Width of the aggregates series buckets; None keeps
-        the scheduler-period buckets (exact scheduled_at).
-    """
-
-    interval: str
-    series_bucket_seconds: int | None
-
-
-WINDOWS: dict[WindowLiteral, WindowSpec] = {
-    "24h": WindowSpec(interval="24 hours", series_bucket_seconds=None),
-    "7d": WindowSpec(interval="7 days", series_bucket_seconds=2 * 3600),
-    "30d": WindowSpec(interval="30 days", series_bucket_seconds=12 * 3600),
-}
-
-# Note: the leaderboard router keeps its own 7d/30d-only dict because its
+# Fixed interval strings — looked up by Python, never user-interpolated into
+# SQL. Note: the leaderboard router keeps its own 7d/30d-only dict because its
 # 24h window is served by the results_24h materialized view, not a live query.
-WINDOW_INTERVALS: dict[str, str] = {w: spec.interval for w, spec in WINDOWS.items()}
-
-
-def floor_epoch_sql(ts_expr: str, param: str) -> str:
-    """SQL expression flooring ``ts_expr`` to ``%(param)s``-second buckets."""
-    return f"to_timestamp(floor(extract(epoch FROM {ts_expr}) / %({param})s) * %({param})s)"
-
+WINDOW_INTERVALS: dict[str, str] = {
+    "24h": "24 hours",
+    "7d": "7 days",
+    "30d": "30 days",
+}
 
 # Bucket expression for chart timestamps: the run's cron trigger time,
 # falling back to created_at floored to the scheduler period for legacy rows.
@@ -52,5 +29,7 @@ def floor_epoch_sql(ts_expr: str, param: str) -> str:
 # Expects ``r`` (results) and ``rn`` (runs) table aliases and a
 # ``schedule_period`` query parameter.
 SCHEDULED_AT_BUCKET_SQL = (
-    "COALESCE(rn.scheduled_at, " + floor_epoch_sql("r.created_at", "schedule_period") + ")"
+    "COALESCE(rn.scheduled_at,"
+    " to_timestamp(floor(extract(epoch FROM r.created_at) / %(schedule_period)s)"
+    " * %(schedule_period)s))"
 )

--- a/runner/src/coval_bench/api/common.py
+++ b/runner/src/coval_bench/api/common.py
@@ -9,19 +9,42 @@ on — adding a window or benchmark here updates every endpoint at once.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Literal
 
 BenchmarkLiteral = Literal["STT", "TTS"]
 WindowLiteral = Literal["24h", "7d", "30d"]
 
-# Fixed interval strings — looked up by Python, never user-interpolated into
-# SQL. Note: the leaderboard router keeps its own 7d/30d-only dict because its
-# 24h window is served by the results_24h materialized view, not a live query.
-WINDOW_INTERVALS: dict[str, str] = {
-    "24h": "24 hours",
-    "7d": "7 days",
-    "30d": "30 days",
+
+@dataclass(frozen=True)
+class WindowSpec:
+    """Per-window query parameters.
+
+    interval: Postgres interval string. Fixed here — looked up by Python,
+        never user-interpolated into SQL.
+    series_bucket_seconds: Width of the aggregates series buckets; None keeps
+        the scheduler-period buckets (exact scheduled_at).
+    """
+
+    interval: str
+    series_bucket_seconds: int | None
+
+
+WINDOWS: dict[WindowLiteral, WindowSpec] = {
+    "24h": WindowSpec(interval="24 hours", series_bucket_seconds=None),
+    "7d": WindowSpec(interval="7 days", series_bucket_seconds=2 * 3600),
+    "30d": WindowSpec(interval="30 days", series_bucket_seconds=12 * 3600),
 }
+
+# Note: the leaderboard router keeps its own 7d/30d-only dict because its
+# 24h window is served by the results_24h materialized view, not a live query.
+WINDOW_INTERVALS: dict[str, str] = {w: spec.interval for w, spec in WINDOWS.items()}
+
+
+def floor_epoch_sql(ts_expr: str, param: str) -> str:
+    """SQL expression flooring ``ts_expr`` to ``%(param)s``-second buckets."""
+    return f"to_timestamp(floor(extract(epoch FROM {ts_expr}) / %({param})s) * %({param})s)"
+
 
 # Bucket expression for chart timestamps: the run's cron trigger time,
 # falling back to created_at floored to the scheduler period for legacy rows.
@@ -29,7 +52,5 @@ WINDOW_INTERVALS: dict[str, str] = {
 # Expects ``r`` (results) and ``rn`` (runs) table aliases and a
 # ``schedule_period`` query parameter.
 SCHEDULED_AT_BUCKET_SQL = (
-    "COALESCE(rn.scheduled_at,"
-    " to_timestamp(floor(extract(epoch FROM r.created_at) / %(schedule_period)s)"
-    " * %(schedule_period)s))"
+    "COALESCE(rn.scheduled_at, " + floor_epoch_sql("r.created_at", "schedule_period") + ")"
 )

--- a/runner/src/coval_bench/api/deps.py
+++ b/runner/src/coval_bench/api/deps.py
@@ -10,6 +10,8 @@ populated during the FastAPI lifespan (see ``app.py``).
 
 from __future__ import annotations
 
+import asyncio
+from collections import defaultdict
 from typing import Any, cast
 
 import structlog
@@ -49,6 +51,11 @@ def get_posthog(request: Request) -> Posthog | None:
 def get_cache(request: Request) -> TTLCache[Any, Any]:
     """Return the per-app response TTL cache from app state."""
     return cast("TTLCache[Any, Any]", request.app.state.response_cache)
+
+
+def get_cache_locks(request: Request) -> defaultdict[Any, asyncio.Lock]:
+    """Return the per-app cache-key locks from app state."""
+    return cast("defaultdict[Any, asyncio.Lock]", request.app.state.cache_locks)
 
 
 def capture_api_event(client: Posthog | None, event: str, properties: dict[str, Any]) -> None:

--- a/runner/src/coval_bench/api/routers/aggregates.py
+++ b/runner/src/coval_bench/api/routers/aggregates.py
@@ -32,11 +32,13 @@ from posthog import Posthog
 from psycopg_pool import AsyncConnectionPool
 from starlette.requests import Request
 
+from coval_bench.api.cache import get_or_fill
 from coval_bench.api.common import (
     SCHEDULED_AT_BUCKET_SQL,
-    WINDOW_INTERVALS,
+    WINDOWS,
     BenchmarkLiteral,
     WindowLiteral,
+    floor_epoch_sql,
 )
 from coval_bench.api.deps import (
     capture_api_event,
@@ -78,17 +80,8 @@ _STATS_SQL = (
     " ORDER BY r.provider, r.model, r.metric_type"
 )
 
-_WINDOW_BUCKET_SECONDS: dict[str, int | None] = {
-    "24h": None,
-    "7d": 2 * 3600,
-    "30d": 12 * 3600,
-}
-
 # Wider windows floor scheduled_at (created_at for legacy rows) to the bucket.
-_COARSE_BUCKET_SQL = (
-    "to_timestamp(floor(extract(epoch FROM COALESCE(rn.scheduled_at, r.created_at))"
-    " / %(bucket_seconds)s) * %(bucket_seconds)s)"
-)
+_COARSE_BUCKET_SQL = floor_epoch_sql("COALESCE(rn.scheduled_at, r.created_at)", "bucket_seconds")
 
 
 def _build_series_sql(bucket_sql: str) -> str:
@@ -125,44 +118,34 @@ async def get_results_aggregates(
         benchmark: One of STT, TTS.
         window: Time window over results.created_at. Defaults to 24h.
     """
+
+    async def fill() -> AggregatesResponse:
+        spec = WINDOWS[window]
+        params: dict[str, Any] = {"benchmark": benchmark, "interval": spec.interval}
+        if spec.series_bucket_seconds is None:
+            series_sql = _SERIES_SQL
+            series_params: dict[str, Any] = {
+                **params,
+                "schedule_period": settings.schedule_period_seconds,
+            }
+        else:
+            series_sql = _COARSE_SERIES_SQL
+            series_params = {**params, "bucket_seconds": spec.series_bucket_seconds}
+
+        async with pool.connection() as conn:
+            conn.row_factory = psycopg.rows.dict_row
+            stat_rows = await (await conn.execute(_STATS_SQL, params)).fetchall()
+            series_rows = await (await conn.execute(series_sql, series_params)).fetchall()
+
+        return AggregatesResponse(
+            benchmark=benchmark,
+            window=window,
+            model_stats=[ModelStatEntry.model_validate(r) for r in stat_rows],
+            series=[SeriesPoint.model_validate(r) for r in series_rows],
+        )
+
     cache_key = ("aggregates", benchmark, window)
-    response: AggregatesResponse | None = cache.get(cache_key)
-    cache_hit = response is not None
-
-    if response is None:
-        # Concurrent misses for one key run the SQL once; see new_cache_locks.
-        async with cache_locks[cache_key]:
-            response = cache.get(cache_key)
-            cache_hit = response is not None
-
-            if response is None:
-                params: dict[str, Any] = {
-                    "benchmark": benchmark,
-                    "interval": WINDOW_INTERVALS[window],
-                }
-                bucket_seconds = _WINDOW_BUCKET_SECONDS[window]
-                if bucket_seconds is None:
-                    series_sql = _SERIES_SQL
-                    series_params: dict[str, Any] = {
-                        **params,
-                        "schedule_period": settings.schedule_period_seconds,
-                    }
-                else:
-                    series_sql = _COARSE_SERIES_SQL
-                    series_params = {**params, "bucket_seconds": bucket_seconds}
-
-                async with pool.connection() as conn:
-                    conn.row_factory = psycopg.rows.dict_row
-                    stat_rows = await (await conn.execute(_STATS_SQL, params)).fetchall()
-                    series_rows = await (await conn.execute(series_sql, series_params)).fetchall()
-
-                response = AggregatesResponse(
-                    benchmark=benchmark,
-                    window=window,
-                    model_stats=[ModelStatEntry.model_validate(r) for r in stat_rows],
-                    series=[SeriesPoint.model_validate(r) for r in series_rows],
-                )
-                cache[cache_key] = response
+    response, cache_status = await get_or_fill(cache, cache_locks, cache_key, fill)
 
     capture_api_event(
         posthog_client,
@@ -172,7 +155,8 @@ async def get_results_aggregates(
             "window": window,
             "model_stat_count": len(response.model_stats),
             "series_point_count": len(response.series),
-            "cache_hit": cache_hit,
+            "cache_hit": cache_status != "miss",
+            "cache_status": cache_status,
             "$process_person_profile": False,
         },
     )

--- a/runner/src/coval_bench/api/routers/aggregates.py
+++ b/runner/src/coval_bench/api/routers/aggregates.py
@@ -20,6 +20,8 @@ metric_value, from parent runs in (succeeded, partial).
 
 from __future__ import annotations
 
+import asyncio
+from collections import defaultdict
 from typing import Any
 
 import psycopg.rows
@@ -39,6 +41,7 @@ from coval_bench.api.common import (
 from coval_bench.api.deps import (
     capture_api_event,
     get_cache,
+    get_cache_locks,
     get_pool,
     get_posthog,
     get_settings,
@@ -81,8 +84,7 @@ _WINDOW_BUCKET_SECONDS: dict[str, int | None] = {
     "30d": 12 * 3600,
 }
 
-# Fixed-width bucket for the wider windows: scheduled_at (or created_at for
-# legacy rows) floored to the bucket width.
+# Wider windows floor scheduled_at (created_at for legacy rows) to the bucket.
 _COARSE_BUCKET_SQL = (
     "to_timestamp(floor(extract(epoch FROM COALESCE(rn.scheduled_at, r.created_at))"
     " / %(bucket_seconds)s) * %(bucket_seconds)s)"
@@ -115,6 +117,7 @@ async def get_results_aggregates(
     settings: Settings = Depends(get_settings),
     posthog_client: Posthog | None = Depends(get_posthog),
     cache: TTLCache[Any, Any] = Depends(get_cache),
+    cache_locks: defaultdict[Any, asyncio.Lock] = Depends(get_cache_locks),
 ) -> AggregatesResponse:
     """Return per-model stats and per-bucket series for one benchmark.
 
@@ -127,33 +130,39 @@ async def get_results_aggregates(
     cache_hit = response is not None
 
     if response is None:
-        params: dict[str, Any] = {
-            "benchmark": benchmark,
-            "interval": WINDOW_INTERVALS[window],
-        }
-        bucket_seconds = _WINDOW_BUCKET_SECONDS[window]
-        if bucket_seconds is None:
-            series_sql = _SERIES_SQL
-            series_params: dict[str, Any] = {
-                **params,
-                "schedule_period": settings.schedule_period_seconds,
-            }
-        else:
-            series_sql = _COARSE_SERIES_SQL
-            series_params = {**params, "bucket_seconds": bucket_seconds}
+        # Concurrent misses for one key run the SQL once; see new_cache_locks.
+        async with cache_locks[cache_key]:
+            response = cache.get(cache_key)
+            cache_hit = response is not None
 
-        async with pool.connection() as conn:
-            conn.row_factory = psycopg.rows.dict_row
-            stat_rows = await (await conn.execute(_STATS_SQL, params)).fetchall()
-            series_rows = await (await conn.execute(series_sql, series_params)).fetchall()
+            if response is None:
+                params: dict[str, Any] = {
+                    "benchmark": benchmark,
+                    "interval": WINDOW_INTERVALS[window],
+                }
+                bucket_seconds = _WINDOW_BUCKET_SECONDS[window]
+                if bucket_seconds is None:
+                    series_sql = _SERIES_SQL
+                    series_params: dict[str, Any] = {
+                        **params,
+                        "schedule_period": settings.schedule_period_seconds,
+                    }
+                else:
+                    series_sql = _COARSE_SERIES_SQL
+                    series_params = {**params, "bucket_seconds": bucket_seconds}
 
-        response = AggregatesResponse(
-            benchmark=benchmark,
-            window=window,
-            model_stats=[ModelStatEntry.model_validate(r) for r in stat_rows],
-            series=[SeriesPoint.model_validate(r) for r in series_rows],
-        )
-        cache[cache_key] = response
+                async with pool.connection() as conn:
+                    conn.row_factory = psycopg.rows.dict_row
+                    stat_rows = await (await conn.execute(_STATS_SQL, params)).fetchall()
+                    series_rows = await (await conn.execute(series_sql, series_params)).fetchall()
+
+                response = AggregatesResponse(
+                    benchmark=benchmark,
+                    window=window,
+                    model_stats=[ModelStatEntry.model_validate(r) for r in stat_rows],
+                    series=[SeriesPoint.model_validate(r) for r in series_rows],
+                )
+                cache[cache_key] = response
 
     capture_api_event(
         posthog_client,

--- a/runner/src/coval_bench/api/routers/aggregates.py
+++ b/runner/src/coval_bench/api/routers/aggregates.py
@@ -8,11 +8,9 @@ Serves the dashboard's chart data as pre-computed aggregates. Two blocks:
 * ``model_stats`` — per (provider, model, metric_type): avg, sample stddev
   (n-1 denominator, coalesced to 0 for n=1), p25/p50/p75 (percentile_cont),
   min, max, count.
-* ``series`` — per (provider, model, metric_type, time bucket): avg and count.
-  At 24h the bucket is the run's scheduled_at, falling back to created_at
-  floored to the scheduler period for legacy rows, identical to the COALESCE
-  in GET /v1/results. The wider windows use fixed buckets (7d: 2h, 30d: 12h)
-  so the series payload stays near its 24h size.
+* ``series`` — per (provider, model, metric_type, scheduled_at bucket): avg and
+  count. The bucket falls back to created_at floored to the scheduler period
+  for legacy rows, identical to the COALESCE in GET /v1/results.
 
 Both blocks gate on result rows with status='success' and a non-null
 metric_value, from parent runs in (succeeded, partial).
@@ -35,10 +33,9 @@ from starlette.requests import Request
 from coval_bench.api.cache import get_or_fill
 from coval_bench.api.common import (
     SCHEDULED_AT_BUCKET_SQL,
-    WINDOWS,
+    WINDOW_INTERVALS,
     BenchmarkLiteral,
     WindowLiteral,
-    floor_epoch_sql,
 )
 from coval_bench.api.deps import (
     capture_api_event,
@@ -80,24 +77,17 @@ _STATS_SQL = (
     " ORDER BY r.provider, r.model, r.metric_type"
 )
 
-# Wider windows floor scheduled_at (created_at for legacy rows) to the bucket.
-_COARSE_BUCKET_SQL = floor_epoch_sql("COALESCE(rn.scheduled_at, r.created_at)", "bucket_seconds")
-
-
-def _build_series_sql(bucket_sql: str) -> str:
-    return (
-        "SELECT r.provider, r.model, r.metric_type,"
-        f" {bucket_sql} AS scheduled_at,"
-        " AVG(r.metric_value)::float8 AS avg_value,"
-        " COUNT(*)::int AS sample_count"
-        + _FROM_WHERE
-        + f" GROUP BY r.provider, r.model, r.metric_type, {bucket_sql}"
-        " ORDER BY 4, r.provider, r.model, r.metric_type"
-    )
-
-
-_SERIES_SQL = _build_series_sql(SCHEDULED_AT_BUCKET_SQL)
-_COARSE_SERIES_SQL = _build_series_sql(_COARSE_BUCKET_SQL)
+# Bucket expression repeated in GROUP BY because a bare ``scheduled_at`` there
+# would resolve to the input column rn.scheduled_at, not the alias.
+_SERIES_SQL = (
+    "SELECT r.provider, r.model, r.metric_type,"
+    f" {SCHEDULED_AT_BUCKET_SQL} AS scheduled_at,"
+    " AVG(r.metric_value)::float8 AS avg_value,"
+    " COUNT(*)::int AS sample_count"
+    + _FROM_WHERE
+    + f" GROUP BY r.provider, r.model, r.metric_type, {SCHEDULED_AT_BUCKET_SQL}"
+    " ORDER BY 4, r.provider, r.model, r.metric_type"
+)
 
 
 @router.get("/results/aggregates", response_model=AggregatesResponse)
@@ -120,22 +110,19 @@ async def get_results_aggregates(
     """
 
     async def fill() -> AggregatesResponse:
-        spec = WINDOWS[window]
-        params: dict[str, Any] = {"benchmark": benchmark, "interval": spec.interval}
-        if spec.series_bucket_seconds is None:
-            series_sql = _SERIES_SQL
-            series_params: dict[str, Any] = {
-                **params,
-                "schedule_period": settings.schedule_period_seconds,
-            }
-        else:
-            series_sql = _COARSE_SERIES_SQL
-            series_params = {**params, "bucket_seconds": spec.series_bucket_seconds}
+        params: dict[str, Any] = {
+            "benchmark": benchmark,
+            "interval": WINDOW_INTERVALS[window],
+        }
+        series_params: dict[str, Any] = {
+            **params,
+            "schedule_period": settings.schedule_period_seconds,
+        }
 
         async with pool.connection() as conn:
             conn.row_factory = psycopg.rows.dict_row
             stat_rows = await (await conn.execute(_STATS_SQL, params)).fetchall()
-            series_rows = await (await conn.execute(series_sql, series_params)).fetchall()
+            series_rows = await (await conn.execute(_SERIES_SQL, series_params)).fetchall()
 
         return AggregatesResponse(
             benchmark=benchmark,

--- a/runner/src/coval_bench/api/routers/aggregates.py
+++ b/runner/src/coval_bench/api/routers/aggregates.py
@@ -8,9 +8,11 @@ Serves the dashboard's chart data as pre-computed aggregates. Two blocks:
 * ``model_stats`` — per (provider, model, metric_type): avg, sample stddev
   (n-1 denominator, coalesced to 0 for n=1), p25/p50/p75 (percentile_cont),
   min, max, count.
-* ``series`` — per (provider, model, metric_type, scheduled_at bucket): avg and
-  count. The bucket falls back to created_at floored to the scheduler period
-  for legacy rows, identical to the COALESCE in GET /v1/results.
+* ``series`` — per (provider, model, metric_type, time bucket): avg and count.
+  At 24h the bucket is the run's scheduled_at, falling back to created_at
+  floored to the scheduler period for legacy rows, identical to the COALESCE
+  in GET /v1/results. The wider windows use fixed buckets (7d: 2h, 30d: 12h)
+  so the series payload stays near its 24h size.
 
 Both blocks gate on result rows with status='success' and a non-null
 metric_value, from parent runs in (succeeded, partial).
@@ -73,17 +75,34 @@ _STATS_SQL = (
     " ORDER BY r.provider, r.model, r.metric_type"
 )
 
-# Bucket expression repeated in GROUP BY because a bare ``scheduled_at`` there
-# would resolve to the input column rn.scheduled_at, not the alias.
-_SERIES_SQL = (
-    "SELECT r.provider, r.model, r.metric_type,"
-    f" {SCHEDULED_AT_BUCKET_SQL} AS scheduled_at,"
-    " AVG(r.metric_value)::float8 AS avg_value,"
-    " COUNT(*)::int AS sample_count"
-    + _FROM_WHERE
-    + f" GROUP BY r.provider, r.model, r.metric_type, {SCHEDULED_AT_BUCKET_SQL}"
-    " ORDER BY 4, r.provider, r.model, r.metric_type"
+_WINDOW_BUCKET_SECONDS: dict[str, int | None] = {
+    "24h": None,
+    "7d": 2 * 3600,
+    "30d": 12 * 3600,
+}
+
+# Fixed-width bucket for the wider windows: scheduled_at (or created_at for
+# legacy rows) floored to the bucket width.
+_COARSE_BUCKET_SQL = (
+    "to_timestamp(floor(extract(epoch FROM COALESCE(rn.scheduled_at, r.created_at))"
+    " / %(bucket_seconds)s) * %(bucket_seconds)s)"
 )
+
+
+def _build_series_sql(bucket_sql: str) -> str:
+    return (
+        "SELECT r.provider, r.model, r.metric_type,"
+        f" {bucket_sql} AS scheduled_at,"
+        " AVG(r.metric_value)::float8 AS avg_value,"
+        " COUNT(*)::int AS sample_count"
+        + _FROM_WHERE
+        + f" GROUP BY r.provider, r.model, r.metric_type, {bucket_sql}"
+        " ORDER BY 4, r.provider, r.model, r.metric_type"
+    )
+
+
+_SERIES_SQL = _build_series_sql(SCHEDULED_AT_BUCKET_SQL)
+_COARSE_SERIES_SQL = _build_series_sql(_COARSE_BUCKET_SQL)
 
 
 @router.get("/results/aggregates", response_model=AggregatesResponse)
@@ -112,15 +131,21 @@ async def get_results_aggregates(
             "benchmark": benchmark,
             "interval": WINDOW_INTERVALS[window],
         }
-        series_params: dict[str, Any] = {
-            **params,
-            "schedule_period": settings.schedule_period_seconds,
-        }
+        bucket_seconds = _WINDOW_BUCKET_SECONDS[window]
+        if bucket_seconds is None:
+            series_sql = _SERIES_SQL
+            series_params: dict[str, Any] = {
+                **params,
+                "schedule_period": settings.schedule_period_seconds,
+            }
+        else:
+            series_sql = _COARSE_SERIES_SQL
+            series_params = {**params, "bucket_seconds": bucket_seconds}
 
         async with pool.connection() as conn:
             conn.row_factory = psycopg.rows.dict_row
             stat_rows = await (await conn.execute(_STATS_SQL, params)).fetchall()
-            series_rows = await (await conn.execute(_SERIES_SQL, series_params)).fetchall()
+            series_rows = await (await conn.execute(series_sql, series_params)).fetchall()
 
         response = AggregatesResponse(
             benchmark=benchmark,

--- a/runner/tests/api/test_aggregates.py
+++ b/runner/tests/api/test_aggregates.py
@@ -132,6 +132,62 @@ async def test_series_legacy_rows_floor_created_at(client: AsyncClient, postgres
     assert bucket.timestamp() == pytest.approx(expected_epoch)
 
 
+async def test_series_7d_coarsens_to_2h_buckets(client: AsyncClient, postgresql: Any) -> None:
+    """On the 7d window, runs 30 minutes apart collapse into one 2h bucket
+    floored to a 2h boundary; their values average."""
+    base = datetime.now(dt.UTC) - timedelta(days=3)
+    base = base.replace(minute=0, second=0, microsecond=0)
+    for offset, value in ((timedelta(0), 1.0), (timedelta(minutes=30), 3.0)):
+        run_id = await _insert_run(postgresql, scheduled_at=base + offset)
+        await _insert_result(postgresql, run_id, created_at=base + offset, metric_value=value)
+
+    response = await client.get(
+        "/v1/results/aggregates", params={"benchmark": "STT", "window": "7d"}
+    )
+    series = response.json()["series"]
+    assert len(series) == 1
+    point = series[0]
+    bucket = datetime.fromisoformat(point["scheduled_at"])
+    assert bucket.timestamp() == base.timestamp() // 7200 * 7200
+    assert point["avg_value"] == pytest.approx(2.0)
+    assert point["sample_count"] == 2
+
+
+async def test_series_30d_coarsens_to_12h_buckets(client: AsyncClient, postgresql: Any) -> None:
+    """On the 30d window, runs 11 hours apart share a 12h bucket while a run
+    in the next 12h block lands in its own."""
+    day = (datetime.now(dt.UTC) - timedelta(days=10)).replace(
+        hour=0, minute=0, second=0, microsecond=0
+    )
+    for offset in (timedelta(hours=0), timedelta(hours=11), timedelta(hours=13)):
+        run_id = await _insert_run(postgresql, scheduled_at=day + offset)
+        await _insert_result(postgresql, run_id, created_at=day + offset, metric_value=1.0)
+
+    response = await client.get(
+        "/v1/results/aggregates", params={"benchmark": "STT", "window": "30d"}
+    )
+    series = response.json()["series"]
+    assert [p["sample_count"] for p in series] == [2, 1]
+
+
+async def test_series_coarse_legacy_rows_use_created_at(
+    client: AsyncClient, postgresql: Any
+) -> None:
+    """Runs without scheduled_at floor created_at to the coarse bucket width
+    on the wider windows."""
+    run_id = await _insert_run(postgresql, scheduled_at=None)
+    created = datetime.now(dt.UTC) - timedelta(days=3)
+    await _insert_result(postgresql, run_id, created_at=created, metric_value=1.0)
+
+    response = await client.get(
+        "/v1/results/aggregates", params={"benchmark": "STT", "window": "7d"}
+    )
+    series = response.json()["series"]
+    assert len(series) == 1
+    bucket = datetime.fromisoformat(series[0]["scheduled_at"])
+    assert bucket.timestamp() == created.timestamp() // 7200 * 7200
+
+
 async def test_window_excludes_old_rows(client: AsyncClient, postgresql: Any) -> None:
     run_id = await _insert_run(postgresql)
     old = datetime.now(dt.UTC) - timedelta(days=10)

--- a/runner/tests/api/test_aggregates.py
+++ b/runner/tests/api/test_aggregates.py
@@ -15,17 +15,14 @@ import pytest
 from fastapi import FastAPI
 from httpx import AsyncClient
 
-from coval_bench.api.common import WINDOW_INTERVALS, WindowLiteral
-from coval_bench.api.routers.aggregates import _WINDOW_BUCKET_SECONDS
+from coval_bench.api.common import WINDOWS, WindowLiteral
 from tests.api.conftest import _insert_result, _insert_run
 
 
-def test_window_dicts_cover_every_window() -> None:
-    """Every WindowLiteral value must have an interval and a bucket entry —
-    a window added to one map but not the others 500s after validation."""
-    windows = set(get_args(WindowLiteral))
-    assert set(WINDOW_INTERVALS) == windows
-    assert set(_WINDOW_BUCKET_SECONDS) == windows
+def test_windows_table_covers_every_window() -> None:
+    """Every WindowLiteral value must have a WINDOWS entry — a window added
+    to the literal but not the table 500s after validation."""
+    assert set(WINDOWS) == set(get_args(WindowLiteral))
 
 
 async def test_empty_db_returns_empty_blocks(client: AsyncClient) -> None:
@@ -280,6 +277,33 @@ async def test_concurrent_misses_coalesce(
     bodies = [r.json() for r in responses]
     assert all(b == bodies[0] for b in bodies)
     assert bodies[0]["model_stats"][0]["sample_count"] == 1
+    assert acquisitions == 1
+
+
+async def test_failed_fill_shared_not_retried(client: AsyncClient, app: FastAPI) -> None:
+    """A failing query is re-raised to requests inside the failure window
+    instead of each one re-running it against the pool."""
+    from coval_bench.api import deps
+
+    acquisitions = 0
+
+    class FailingPool:
+        @asynccontextmanager
+        async def connection(self) -> Any:
+            nonlocal acquisitions
+            acquisitions += 1
+            raise RuntimeError("db down")
+            yield  # noqa: B901 — unreachable; makes this an async generator
+
+    app.dependency_overrides[deps.get_pool] = FailingPool
+    try:
+        with pytest.raises(RuntimeError, match="db down"):
+            await client.get("/v1/results/aggregates", params={"benchmark": "STT"})
+        with pytest.raises(RuntimeError, match="db down"):
+            await client.get("/v1/results/aggregates", params={"benchmark": "STT"})
+    finally:
+        app.dependency_overrides.clear()
+
     assert acquisitions == 1
 
 

--- a/runner/tests/api/test_aggregates.py
+++ b/runner/tests/api/test_aggregates.py
@@ -15,14 +15,14 @@ import pytest
 from fastapi import FastAPI
 from httpx import AsyncClient
 
-from coval_bench.api.common import WINDOWS, WindowLiteral
+from coval_bench.api.common import WINDOW_INTERVALS, WindowLiteral
 from tests.api.conftest import _insert_result, _insert_run
 
 
-def test_windows_table_covers_every_window() -> None:
-    """Every WindowLiteral value must have a WINDOWS entry — a window added
-    to the literal but not the table 500s after validation."""
-    assert set(WINDOWS) == set(get_args(WindowLiteral))
+def test_intervals_cover_every_window() -> None:
+    """Every WindowLiteral value must have an interval — a window added to
+    the literal but not the dict 500s after validation."""
+    assert set(WINDOW_INTERVALS) == set(get_args(WindowLiteral))
 
 
 async def test_empty_db_returns_empty_blocks(client: AsyncClient) -> None:
@@ -140,62 +140,6 @@ async def test_series_legacy_rows_floor_created_at(client: AsyncClient, postgres
     bucket = datetime.fromisoformat(series[0]["scheduled_at"])
     expected_epoch = created.timestamp() // 1800 * 1800
     assert bucket.timestamp() == pytest.approx(expected_epoch)
-
-
-async def test_series_7d_coarsens_to_2h_buckets(client: AsyncClient, postgresql: Any) -> None:
-    """On the 7d window, runs 30 minutes apart collapse into one 2h bucket
-    floored to a 2h boundary; their values average."""
-    base = datetime.now(dt.UTC) - timedelta(days=3)
-    base = base.replace(minute=0, second=0, microsecond=0)
-    for offset, value in ((timedelta(0), 1.0), (timedelta(minutes=30), 3.0)):
-        run_id = await _insert_run(postgresql, scheduled_at=base + offset)
-        await _insert_result(postgresql, run_id, created_at=base + offset, metric_value=value)
-
-    response = await client.get(
-        "/v1/results/aggregates", params={"benchmark": "STT", "window": "7d"}
-    )
-    series = response.json()["series"]
-    assert len(series) == 1
-    point = series[0]
-    bucket = datetime.fromisoformat(point["scheduled_at"])
-    assert bucket.timestamp() == base.timestamp() // 7200 * 7200
-    assert point["avg_value"] == pytest.approx(2.0)
-    assert point["sample_count"] == 2
-
-
-async def test_series_30d_coarsens_to_12h_buckets(client: AsyncClient, postgresql: Any) -> None:
-    """On the 30d window, runs 11 hours apart share a 12h bucket while a run
-    in the next 12h block lands in its own."""
-    day = (datetime.now(dt.UTC) - timedelta(days=10)).replace(
-        hour=0, minute=0, second=0, microsecond=0
-    )
-    for offset in (timedelta(hours=0), timedelta(hours=11), timedelta(hours=13)):
-        run_id = await _insert_run(postgresql, scheduled_at=day + offset)
-        await _insert_result(postgresql, run_id, created_at=day + offset, metric_value=1.0)
-
-    response = await client.get(
-        "/v1/results/aggregates", params={"benchmark": "STT", "window": "30d"}
-    )
-    series = response.json()["series"]
-    assert [p["sample_count"] for p in series] == [2, 1]
-
-
-async def test_series_coarse_legacy_rows_use_created_at(
-    client: AsyncClient, postgresql: Any
-) -> None:
-    """Runs without scheduled_at floor created_at to the coarse bucket width
-    on the wider windows."""
-    run_id = await _insert_run(postgresql, scheduled_at=None)
-    created = datetime.now(dt.UTC) - timedelta(days=3)
-    await _insert_result(postgresql, run_id, created_at=created, metric_value=1.0)
-
-    response = await client.get(
-        "/v1/results/aggregates", params={"benchmark": "STT", "window": "7d"}
-    )
-    series = response.json()["series"]
-    assert len(series) == 1
-    bucket = datetime.fromisoformat(series[0]["scheduled_at"])
-    assert bucket.timestamp() == created.timestamp() // 7200 * 7200
 
 
 async def test_window_excludes_old_rows(client: AsyncClient, postgresql: Any) -> None:

--- a/runner/tests/api/test_aggregates.py
+++ b/runner/tests/api/test_aggregates.py
@@ -5,14 +5,27 @@
 
 from __future__ import annotations
 
+import asyncio
 import datetime as dt
+from contextlib import asynccontextmanager
 from datetime import datetime, timedelta
-from typing import Any
+from typing import Any, get_args
 
 import pytest
+from fastapi import FastAPI
 from httpx import AsyncClient
 
+from coval_bench.api.common import WINDOW_INTERVALS, WindowLiteral
+from coval_bench.api.routers.aggregates import _WINDOW_BUCKET_SECONDS
 from tests.api.conftest import _insert_result, _insert_run
+
+
+def test_window_dicts_cover_every_window() -> None:
+    """Every WindowLiteral value must have an interval and a bucket entry —
+    a window added to one map but not the others 500s after validation."""
+    windows = set(get_args(WindowLiteral))
+    assert set(WINDOW_INTERVALS) == windows
+    assert set(_WINDOW_BUCKET_SECONDS) == windows
 
 
 async def test_empty_db_returns_empty_blocks(client: AsyncClient) -> None:
@@ -229,6 +242,45 @@ async def test_cache_keyed_by_params(client: AsyncClient, postgresql: Any) -> No
     r_30d = await client.get("/v1/results/aggregates", params={"benchmark": "STT", "window": "30d"})
     assert r_24h.json()["model_stats"] == []
     assert r_30d.json()["model_stats"][0]["sample_count"] == 1
+
+
+async def test_concurrent_misses_coalesce(
+    client: AsyncClient, app: FastAPI, postgresql: Any
+) -> None:
+    """Simultaneous uncached requests for one key acquire a pool connection
+    once; the rest wait on the per-key lock and read the warmed cache."""
+    from coval_bench.api import deps
+
+    run_id = await _insert_run(postgresql)
+    await _insert_result(postgresql, run_id, metric_value=1.0)
+
+    acquisitions = 0
+    real_pool = app.state.pool
+
+    class CountingPool:
+        @asynccontextmanager
+        async def connection(self) -> Any:
+            nonlocal acquisitions
+            acquisitions += 1
+            # Hold the connection long enough that every gathered request
+            # passes the unlocked cache check before the first one fills it.
+            await asyncio.sleep(0.2)
+            async with real_pool.connection() as conn:
+                yield conn
+
+    app.dependency_overrides[deps.get_pool] = CountingPool
+    try:
+        responses = await asyncio.gather(
+            *(client.get("/v1/results/aggregates", params={"benchmark": "STT"}) for _ in range(5))
+        )
+    finally:
+        app.dependency_overrides.clear()
+
+    assert all(r.status_code == 200 for r in responses)
+    bodies = [r.json() for r in responses]
+    assert all(b == bodies[0] for b in bodies)
+    assert bodies[0]["model_stats"][0]["sample_count"] == 1
+    assert acquisitions == 1
 
 
 async def test_models_grouped_separately(client: AsyncClient, postgresql: Any) -> None:

--- a/web/components/charts/tooltips/TimelineTooltip.tsx
+++ b/web/components/charts/tooltips/TimelineTooltip.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React from "react";
-import { formatTimeWithSeconds, normalizeModelName } from "@/lib/utils/formatters";
+import { formatDate, formatTimeWithSeconds, normalizeModelName } from "@/lib/utils/formatters";
 
 interface TimelineTooltipProps {
   active?: boolean;
@@ -14,9 +14,11 @@ interface TimelineTooltipProps {
   }>;
   label?: string | number;
   getProviderForModel: (model: string) => string;
+  /** Prefix the timestamp with its date — for windows longer than a day. */
+  showDate?: boolean;
 }
 
-const CustomTimelineTooltip: React.FC<TimelineTooltipProps> = ({ active, payload, label, getProviderForModel }) => {
+const CustomTimelineTooltip: React.FC<TimelineTooltipProps> = ({ active, payload, label, getProviderForModel, showDate }) => {
   if (!active || !payload || payload.length === 0) return null;
 
   // Filter out null/undefined values and sort by value (fastest to slowest)
@@ -40,7 +42,9 @@ const CustomTimelineTooltip: React.FC<TimelineTooltipProps> = ({ active, payload
       <p
         style={{ margin: "0 0 8px 0", fontWeight: "bold", fontSize: "12px" }}
       >
-        {formatTimeWithSeconds(Number(label))}
+        {showDate
+          ? `${formatDate(Number(label))} ${formatTimeWithSeconds(Number(label))}`
+          : formatTimeWithSeconds(Number(label))}
       </p>
       <div style={{ fontSize: "11px" }}>
         {validData.map((item, index) => {

--- a/web/components/charts/tooltips/TimelineTooltip.tsx
+++ b/web/components/charts/tooltips/TimelineTooltip.tsx
@@ -14,7 +14,6 @@ interface TimelineTooltipProps {
   }>;
   label?: string | number;
   getProviderForModel: (model: string) => string;
-  /** Prefix the timestamp with its date — for windows longer than a day. */
   showDate?: boolean;
 }
 

--- a/web/components/layout/DashboardLayout.tsx
+++ b/web/components/layout/DashboardLayout.tsx
@@ -16,8 +16,14 @@ import DashboardSkeleton from "@/components/dashboard/DashboardSkeleton";
 import TimeWindowToggle from "@/components/shared/TimeWindowToggle";
 
 const DashboardLayout: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-  const { loading, benchmarkTitle, timeWindow, changeTimeWindow, windowDataStale } =
-    useDashboard();
+  const {
+    loading,
+    loadError,
+    benchmarkTitle,
+    timeWindow,
+    changeTimeWindow,
+    windowDataStale,
+  } = useDashboard();
   const mode = useActiveTab();
   const firedDepthsRef = useRef<Set<number>>(new Set());
 
@@ -73,7 +79,16 @@ const DashboardLayout: React.FC<{ children: React.ReactNode }> = ({ children }) 
             windowDataStale ? "opacity-60" : ""
           }`}
         >
-          {loading ? <DashboardSkeleton /> : children}
+          {loading ? (
+            <DashboardSkeleton />
+          ) : loadError ? (
+            <div className="py-24 text-center text-sm text-text-tertiary">
+              Couldn&rsquo;t load benchmark results. Try another time window or
+              refresh the page.
+            </div>
+          ) : (
+            children
+          )}
         </div>
       </div>
 

--- a/web/components/layout/DashboardLayout.tsx
+++ b/web/components/layout/DashboardLayout.tsx
@@ -13,9 +13,10 @@ import DashboardFooter from "@/components/dashboard/DashboardFooter";
 import MobileModelSheet from "@/components/layout/MobileModelSheet";
 import ModelSidebar from "@/components/layout/ModelSidebar";
 import DashboardSkeleton from "@/components/dashboard/DashboardSkeleton";
+import TimeWindowToggle from "@/components/shared/TimeWindowToggle";
 
 const DashboardLayout: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-  const { loading, benchmarkTitle } = useDashboard();
+  const { loading, benchmarkTitle, timeWindow, changeTimeWindow } = useDashboard();
   const mode = useActiveTab();
   const firedDepthsRef = useRef<Set<number>>(new Set());
 
@@ -52,9 +53,16 @@ const DashboardLayout: React.FC<{ children: React.ReactNode }> = ({ children }) 
           18rem side gutters keep its left edge clear of the fixed sidebar
           (17rem wide) with a 1rem gap. The footer stays full-width. */}
       <div className="relative z-10 flex-1 transition-all duration-300 pt-20 px-3 py-8 sm:px-8 pb-24 lg:pb-8 overflow-x-hidden mx-auto lg:w-[calc(100vw-36rem)]">
-        <h1 className="mb-6 text-2xl font-bold tracking-tight text-text-primary">
-          {benchmarkTitle}
-        </h1>
+        <div className="mb-6 flex flex-wrap items-center justify-between gap-3">
+          <h1 className="text-2xl font-bold tracking-tight text-text-primary">
+            {benchmarkTitle}
+          </h1>
+          <TimeWindowToggle
+            value={timeWindow}
+            onChange={changeTimeWindow}
+            className="ml-auto"
+          />
+        </div>
 
         {loading ? <DashboardSkeleton /> : children}
       </div>

--- a/web/components/layout/DashboardLayout.tsx
+++ b/web/components/layout/DashboardLayout.tsx
@@ -16,7 +16,8 @@ import DashboardSkeleton from "@/components/dashboard/DashboardSkeleton";
 import TimeWindowToggle from "@/components/shared/TimeWindowToggle";
 
 const DashboardLayout: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-  const { loading, benchmarkTitle, timeWindow, changeTimeWindow } = useDashboard();
+  const { loading, benchmarkTitle, timeWindow, changeTimeWindow, windowDataStale } =
+    useDashboard();
   const mode = useActiveTab();
   const firedDepthsRef = useRef<Set<number>>(new Set());
 
@@ -51,8 +52,11 @@ const DashboardLayout: React.FC<{ children: React.ReactNode }> = ({ children }) 
 
       {/* Content column — centered on the page (under the centered tabs). The
           18rem side gutters keep its left edge clear of the fixed sidebar
-          (17rem wide) with a 1rem gap. The footer stays full-width. */}
-      <div className="relative z-10 flex-1 transition-all duration-300 pt-20 px-3 py-8 sm:px-8 pb-24 lg:pb-8 overflow-x-hidden mx-auto lg:w-[calc(100vw-36rem)]">
+          (17rem wide) with a 1rem gap. The footer stays full-width.
+          w-full is load-bearing below lg: mx-auto disables the flex
+          cross-axis stretch, and the column would otherwise size to its
+          content and overflow the viewport. */}
+      <div className="relative z-10 flex-1 transition-all duration-300 pt-20 px-3 py-8 sm:px-8 pb-24 lg:pb-8 overflow-x-hidden w-full mx-auto lg:w-[calc(100vw-36rem)]">
         <div className="mb-6 flex flex-wrap items-center justify-between gap-3">
           <h1 className="text-2xl font-bold tracking-tight text-text-primary">
             {benchmarkTitle}
@@ -64,7 +68,13 @@ const DashboardLayout: React.FC<{ children: React.ReactNode }> = ({ children }) 
           />
         </div>
 
-        {loading ? <DashboardSkeleton /> : children}
+        <div
+          className={`transition-opacity duration-200 ${
+            windowDataStale ? "opacity-60" : ""
+          }`}
+        >
+          {loading ? <DashboardSkeleton /> : children}
+        </div>
       </div>
 
       {!loading && <DashboardFooter />}

--- a/web/components/overview/LeaderboardCard.tsx
+++ b/web/components/overview/LeaderboardCard.tsx
@@ -21,12 +21,13 @@ interface LeaderboardCardProps {
   title: string;
   /** Right-aligned metric column header, e.g. "TTFA" / "WER". */
   metricLabel: string;
-  /** Time-range badge in the header, e.g. "Last 24h". */
+  /** Time-range badge in the header, e.g. "Last 1d". */
   windowLabel: string;
   rows: LeaderboardRow[];
   /** Link to the full dashboard for this benchmark. */
   href: string;
   loading?: boolean;
+  stale?: boolean;
   error?: boolean;
 }
 
@@ -37,10 +38,16 @@ const LeaderboardCard: React.FC<LeaderboardCardProps> = ({
   rows,
   href,
   loading = false,
+  stale = false,
   error = false,
 }) => {
   return (
-    <Card padding="p-6 md:p-8" className="flex flex-col">
+    <Card
+      padding="p-6 md:p-8"
+      className={`flex flex-col transition-opacity duration-200 ${
+        stale ? "opacity-60" : ""
+      }`}
+    >
       <div className="mb-3 flex items-baseline justify-between gap-3">
         <h2 className="text-lg font-medium text-text-primary md:text-xl">{title}</h2>
         <span className="text-xs font-light tracking-wider text-text-secondary">

--- a/web/components/overview/LeaderboardCard.tsx
+++ b/web/components/overview/LeaderboardCard.tsx
@@ -21,6 +21,8 @@ interface LeaderboardCardProps {
   title: string;
   /** Right-aligned metric column header, e.g. "TTFA" / "WER". */
   metricLabel: string;
+  /** Time-range badge in the header, e.g. "Last 24h". */
+  windowLabel: string;
   rows: LeaderboardRow[];
   /** Link to the full dashboard for this benchmark. */
   href: string;
@@ -31,6 +33,7 @@ interface LeaderboardCardProps {
 const LeaderboardCard: React.FC<LeaderboardCardProps> = ({
   title,
   metricLabel,
+  windowLabel,
   rows,
   href,
   loading = false,
@@ -41,7 +44,7 @@ const LeaderboardCard: React.FC<LeaderboardCardProps> = ({
       <div className="mb-3 flex items-baseline justify-between gap-3">
         <h2 className="text-lg font-medium text-text-primary md:text-xl">{title}</h2>
         <span className="text-xs font-light tracking-wider text-text-secondary">
-          Last 24h
+          {windowLabel}
         </span>
       </div>
 

--- a/web/components/overview/OverviewLeaderboards.tsx
+++ b/web/components/overview/OverviewLeaderboards.tsx
@@ -3,7 +3,7 @@
 
 "use client";
 
-import React, { useCallback, useMemo, useState } from "react";
+import React, { useMemo } from "react";
 import { useAggregatesQuery } from "@/lib/api/queries";
 import {
   normalizeModelName,
@@ -12,11 +12,9 @@ import {
   toModelKey,
 } from "@/lib/utils/formatters";
 import type { ModelStatEntry } from "@/lib/api/client";
-import { capturePostHogEvent } from "@/lib/posthog/client";
-import { POSTHOG_EVENTS } from "@/lib/posthog/events";
-import TimeWindowToggle, {
-  type TimeWindow,
-} from "@/components/shared/TimeWindowToggle";
+import { useTimeWindow } from "@/hooks/useTimeWindow";
+import { WINDOW_LABELS, type TimeWindow } from "@/lib/config/timeWindows";
+import TimeWindowToggle from "@/components/shared/TimeWindowToggle";
 import LeaderboardCard, { type LeaderboardRow } from "./LeaderboardCard";
 
 const TOP_N = 5;
@@ -44,27 +42,10 @@ function toRows(
     }));
 }
 
-const WINDOW_BADGES: Record<TimeWindow, string> = {
-  "24h": "Last 1d",
-  "7d": "Last 7d",
-  "30d": "Last 30d",
-};
+const windowBadge = (window: TimeWindow): string => `Last ${WINDOW_LABELS[window]}`;
 
 const OverviewLeaderboards: React.FC = () => {
-  const [timeWindow, setTimeWindow] = useState<TimeWindow>("24h");
-
-  const changeTimeWindow = useCallback(
-    (next: TimeWindow) => {
-      if (next === timeWindow) return;
-      capturePostHogEvent(POSTHOG_EVENTS.dashboardTimeWindowChanged, {
-        surface: "overview",
-        from: timeWindow,
-        to: next
-      });
-      setTimeWindow(next);
-    },
-    [timeWindow]
-  );
+  const { timeWindow, changeTimeWindow } = useTimeWindow("overview");
 
   // Same endpoint and params the /tts and /stt pages use, so React Query
   // serves both from one cache entry and the numbers are identical.
@@ -104,19 +85,21 @@ const OverviewLeaderboards: React.FC = () => {
         <LeaderboardCard
           title="Text-to-Speech"
           metricLabel="Time to First Audio"
-          windowLabel={WINDOW_BADGES[timeWindow]}
+          windowLabel={windowBadge(ttsQuery.data?.window ?? timeWindow)}
           rows={ttsRows}
           href="/tts"
           loading={ttsQuery.isLoading}
+          stale={ttsQuery.isPlaceholderData}
           error={ttsQuery.isError}
         />
         <LeaderboardCard
           title="Speech-to-Text"
           metricLabel="Word Error Rate"
-          windowLabel={WINDOW_BADGES[timeWindow]}
+          windowLabel={windowBadge(sttQuery.data?.window ?? timeWindow)}
           rows={sttRows}
           href="/stt"
           loading={sttQuery.isLoading}
+          stale={sttQuery.isPlaceholderData}
           error={sttQuery.isError}
         />
       </div>

--- a/web/components/overview/OverviewLeaderboards.tsx
+++ b/web/components/overview/OverviewLeaderboards.tsx
@@ -3,7 +3,7 @@
 
 "use client";
 
-import React, { useMemo } from "react";
+import React, { useCallback, useMemo, useState } from "react";
 import { useAggregatesQuery } from "@/lib/api/queries";
 import {
   normalizeModelName,
@@ -12,6 +12,11 @@ import {
   toModelKey,
 } from "@/lib/utils/formatters";
 import type { ModelStatEntry } from "@/lib/api/client";
+import { capturePostHogEvent } from "@/lib/posthog/client";
+import { POSTHOG_EVENTS } from "@/lib/posthog/events";
+import TimeWindowToggle, {
+  type TimeWindow,
+} from "@/components/shared/TimeWindowToggle";
 import LeaderboardCard, { type LeaderboardRow } from "./LeaderboardCard";
 
 const TOP_N = 5;
@@ -39,11 +44,32 @@ function toRows(
     }));
 }
 
+const WINDOW_BADGES: Record<TimeWindow, string> = {
+  "24h": "Last 1d",
+  "7d": "Last 7d",
+  "30d": "Last 30d",
+};
+
 const OverviewLeaderboards: React.FC = () => {
+  const [timeWindow, setTimeWindow] = useState<TimeWindow>("24h");
+
+  const changeTimeWindow = useCallback(
+    (next: TimeWindow) => {
+      if (next === timeWindow) return;
+      capturePostHogEvent(POSTHOG_EVENTS.dashboardTimeWindowChanged, {
+        surface: "overview",
+        from: timeWindow,
+        to: next
+      });
+      setTimeWindow(next);
+    },
+    [timeWindow]
+  );
+
   // Same endpoint and params the /tts and /stt pages use, so React Query
   // serves both from one cache entry and the numbers are identical.
-  const ttsQuery = useAggregatesQuery({ benchmark: "TTS", window: "24h" });
-  const sttQuery = useAggregatesQuery({ benchmark: "STT", window: "24h" });
+  const ttsQuery = useAggregatesQuery({ benchmark: "TTS", window: timeWindow });
+  const sttQuery = useAggregatesQuery({ benchmark: "STT", window: timeWindow });
 
   const ttsRows = useMemo(
     () =>
@@ -70,23 +96,30 @@ const OverviewLeaderboards: React.FC = () => {
   );
 
   return (
-    <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
-      <LeaderboardCard
-        title="Text-to-Speech"
-        metricLabel="Time to First Audio"
-        rows={ttsRows}
-        href="/tts"
-        loading={ttsQuery.isLoading}
-        error={ttsQuery.isError}
-      />
-      <LeaderboardCard
-        title="Speech-to-Text"
-        metricLabel="Word Error Rate"
-        rows={sttRows}
-        href="/stt"
-        loading={sttQuery.isLoading}
-        error={sttQuery.isError}
-      />
+    <div>
+      <div className="mb-3 flex justify-end">
+        <TimeWindowToggle value={timeWindow} onChange={changeTimeWindow} />
+      </div>
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+        <LeaderboardCard
+          title="Text-to-Speech"
+          metricLabel="Time to First Audio"
+          windowLabel={WINDOW_BADGES[timeWindow]}
+          rows={ttsRows}
+          href="/tts"
+          loading={ttsQuery.isLoading}
+          error={ttsQuery.isError}
+        />
+        <LeaderboardCard
+          title="Speech-to-Text"
+          metricLabel="Word Error Rate"
+          windowLabel={WINDOW_BADGES[timeWindow]}
+          rows={sttRows}
+          href="/stt"
+          loading={sttQuery.isLoading}
+          error={sttQuery.isError}
+        />
+      </div>
     </div>
   );
 };

--- a/web/components/overview/OverviewLeaderboards.tsx
+++ b/web/components/overview/OverviewLeaderboards.tsx
@@ -47,8 +47,8 @@ const windowBadge = (window: TimeWindow): string => `Last ${WINDOW_LABELS[window
 const OverviewLeaderboards: React.FC = () => {
   const { timeWindow, changeTimeWindow } = useTimeWindow("overview");
 
-  // Same endpoint and params the /tts and /stt pages use, so React Query
-  // serves both from one cache entry and the numbers are identical.
+  // Params match what /tts and /stt send, so React Query shares a cache
+  // entry with the dashboards whenever the selected windows coincide.
   const ttsQuery = useAggregatesQuery({ benchmark: "TTS", window: timeWindow });
   const sttQuery = useAggregatesQuery({ benchmark: "STT", window: timeWindow });
 

--- a/web/components/shared/TimeWindowToggle.tsx
+++ b/web/components/shared/TimeWindowToggle.tsx
@@ -4,17 +4,11 @@
 "use client";
 
 import React from "react";
-
-export const TIME_WINDOWS = ["24h", "7d", "30d"] as const;
-export type TimeWindow = (typeof TIME_WINDOWS)[number];
-
-// Values mirror the API's window literals; 24h displays as "1d" so the
-// options read uniformly (1d / 7d / 30d).
-const WINDOW_LABELS: Record<TimeWindow, string> = {
-  "24h": "1d",
-  "7d": "7d",
-  "30d": "30d",
-};
+import {
+  TIME_WINDOWS,
+  WINDOW_LABELS,
+  type TimeWindow,
+} from "@/lib/config/timeWindows";
 
 interface TimeWindowToggleProps {
   value: TimeWindow;
@@ -27,8 +21,7 @@ const TimeWindowToggle: React.FC<TimeWindowToggleProps> = ({
   onChange,
   className = "",
 }) => {
-  // Radiogroup keyboard contract: the group is one Tab stop (roving
-  // tabIndex) and arrow keys move the selection.
+  // Radiogroup contract: one Tab stop, arrows move the selection.
   const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
     let step: number;
     if (event.key === "ArrowRight" || event.key === "ArrowDown") {

--- a/web/components/visualizations/TimelineChart.tsx
+++ b/web/components/visualizations/TimelineChart.tsx
@@ -28,6 +28,7 @@ import { useChartHoverTracking } from "@/hooks/useChartHoverTracking";
 interface LegendEntry {
   value: string;
   color?: string;
+  dataKey?: string;
 }
 
 // Custom legend: names are rendered in black (recharts colors them per-series
@@ -37,7 +38,7 @@ const TimelineLegend: React.FC<{ payload?: LegendEntry[] }> = ({ payload }) => (
   <ul className="grid grid-cols-2 gap-x-4 gap-y-1.5 px-2 pt-5 sm:grid-cols-3 sm:gap-x-6 sm:gap-y-2 lg:grid-cols-4">
     {payload?.map((entry) => (
       <li
-        key={entry.value}
+        key={entry.dataKey ?? entry.value}
         className="flex items-start gap-1.5 text-xs leading-tight text-text-primary"
       >
         <span
@@ -61,7 +62,7 @@ const TimelineChart: React.FC = () => {
     getTimelineTicks,
     formatChartLabel,
     getProviderForModel,
-    timeWindow,
+    dataTimeWindow,
   } = useDashboard();
   const trackChartHover = useChartHoverTracking("timeline");
 
@@ -70,8 +71,7 @@ const TimelineChart: React.FC = () => {
   const windowedTimelineData = getWindowedTimelineData();
   const currentTimeWindow = getCurrentTimeWindow();
   const tzAbbr = getLocalTimeZoneAbbr();
-  // 24h ticks are times of day; the wider windows tick on dates.
-  const dateScale = timeWindow !== "24h";
+  const dateScale = dataTimeWindow !== "24h";
   const xAxisLabel = dateScale ? "Date" : tzAbbr ? `Time (${tzAbbr})` : "Time";
 
   const metricLabel = activeTab === "tts" ? "TTFA" : "TTFT";

--- a/web/components/visualizations/TimelineChart.tsx
+++ b/web/components/visualizations/TimelineChart.tsx
@@ -15,7 +15,7 @@ import {
   Tooltip
 } from "recharts";
 import { getModelColor } from "@/lib/utils/colors";
-import { formatTime, getLocalTimeZoneAbbr } from "@/lib/utils/formatters";
+import { formatDate, formatTime, getLocalTimeZoneAbbr } from "@/lib/utils/formatters";
 import { metricDescriptions } from "@/lib/config/metrics";
 import CustomTimelineTooltip from "@/components/charts/tooltips/TimelineTooltip";
 import Card from "@/components/shared/Card";
@@ -35,9 +35,9 @@ interface LegendEntry {
 // mobile to more columns on larger screens.
 const TimelineLegend: React.FC<{ payload?: LegendEntry[] }> = ({ payload }) => (
   <ul className="grid grid-cols-2 gap-x-4 gap-y-1.5 px-2 pt-5 sm:grid-cols-3 sm:gap-x-6 sm:gap-y-2 lg:grid-cols-4">
-    {payload?.map((entry, index) => (
+    {payload?.map((entry) => (
       <li
-        key={`${entry.value}-${index}`}
+        key={entry.value}
         className="flex items-start gap-1.5 text-xs leading-tight text-text-primary"
       >
         <span
@@ -61,6 +61,7 @@ const TimelineChart: React.FC = () => {
     getTimelineTicks,
     formatChartLabel,
     getProviderForModel,
+    timeWindow,
   } = useDashboard();
   const trackChartHover = useChartHoverTracking("timeline");
 
@@ -69,7 +70,9 @@ const TimelineChart: React.FC = () => {
   const windowedTimelineData = getWindowedTimelineData();
   const currentTimeWindow = getCurrentTimeWindow();
   const tzAbbr = getLocalTimeZoneAbbr();
-  const xAxisLabel = tzAbbr ? `Time (${tzAbbr})` : "Time";
+  // 24h ticks are times of day; the wider windows tick on dates.
+  const dateScale = timeWindow !== "24h";
+  const xAxisLabel = dateScale ? "Date" : tzAbbr ? `Time (${tzAbbr})` : "Time";
 
   const metricLabel = activeTab === "tts" ? "TTFA" : "TTFT";
   const description =
@@ -147,7 +150,9 @@ const TimelineChart: React.FC = () => {
                 axisLine={false}
                 tickLine={false}
                 tick={{ fill: themeColors.axisText, fontSize: 12 }}
-                tickFormatter={(value) => formatTime(value)}
+                tickFormatter={(value) =>
+                  dateScale ? formatDate(value) : formatTime(value)
+                }
                 label={{
                   value: xAxisLabel,
                   position: "insideBottom",
@@ -167,7 +172,14 @@ const TimelineChart: React.FC = () => {
                 domain={[0, yAxisMax]}
                 tickFormatter={(value) => `${(value / 1000).toFixed(1)}s`}
               />
-              <Tooltip content={<CustomTimelineTooltip getProviderForModel={getProviderForModel} />} />
+              <Tooltip
+                content={
+                  <CustomTimelineTooltip
+                    getProviderForModel={getProviderForModel}
+                    showDate={dateScale}
+                  />
+                }
+              />
               {modelsWithData.length > 1 && (
                 <Legend content={<TimelineLegend />} />
               )}

--- a/web/hooks/useChartData.ts
+++ b/web/hooks/useChartData.ts
@@ -16,14 +16,7 @@ import type {
 } from "@/types/benchmark.types";
 import type { SeriesPoint } from "@/lib/api/client";
 import { latencyToMs, normalizeModelName, normalizeSTTProviderName, normalizeTTSProviderName, toModelKey, parseModelKey } from "@/lib/utils/formatters";
-import { TWENTY_FOUR_HOURS_MS } from "@/lib/config/constants";
-import type { TimeWindow } from "@/components/shared/TimeWindowToggle";
-
-const WINDOW_MS: Record<TimeWindow, number> = {
-  "24h": TWENTY_FOUR_HOURS_MS,
-  "7d": 7 * TWENTY_FOUR_HOURS_MS,
-  "30d": 30 * TWENTY_FOUR_HOURS_MS
-};
+import { WINDOW_MS, type TimeWindow } from "@/lib/config/timeWindows";
 
 interface UseChartDataParams {
   activeTab: "tts" | "stt";
@@ -459,11 +452,9 @@ export function useChartData({
     return [windowStart, timelineWindowEnd];
   }, [timelineWindowEnd, timeWindow]);
 
-  // Pinned tick positions for the X axis. Letting Recharts auto-pick ticks
-  // gives uneven spacing. 24h ticks every 4 hours snapped to whole-hour
-  // boundaries; the wider windows tick at local midnights (daily for 7d,
-  // every 5 days for 30d) so date labels sit on day starts in the viewer's
-  // timezone. All land at 6-8 ticks per window.
+  // Pinned ticks — Recharts' auto-picked ticks space unevenly. Wider windows
+  // tick at local midnights so date labels sit on day starts in the viewer's
+  // timezone.
   const getTimelineTicks = useCallback((): number[] => {
     const [windowStart, windowEnd] = getCurrentTimeWindow();
     if (timeWindow === "24h") {

--- a/web/hooks/useChartData.ts
+++ b/web/hooks/useChartData.ts
@@ -17,6 +17,13 @@ import type {
 import type { SeriesPoint } from "@/lib/api/client";
 import { latencyToMs, normalizeModelName, normalizeSTTProviderName, normalizeTTSProviderName, toModelKey, parseModelKey } from "@/lib/utils/formatters";
 import { TWENTY_FOUR_HOURS_MS } from "@/lib/config/constants";
+import type { TimeWindow } from "@/components/shared/TimeWindowToggle";
+
+const WINDOW_MS: Record<TimeWindow, number> = {
+  "24h": TWENTY_FOUR_HOURS_MS,
+  "7d": 7 * TWENTY_FOUR_HOURS_MS,
+  "30d": 30 * TWENTY_FOUR_HOURS_MS
+};
 
 interface UseChartDataParams {
   activeTab: "tts" | "stt";
@@ -25,6 +32,7 @@ interface UseChartDataParams {
   selectedTTSModels: string[];
   selectedSTTModels: string[];
   modelsByProvider: ModelsByProvider;
+  timeWindow: TimeWindow;
 }
 
 export function useChartData({
@@ -33,7 +41,8 @@ export function useChartData({
   series,
   selectedTTSModels,
   selectedSTTModels,
-  modelsByProvider
+  modelsByProvider,
+  timeWindow
 }: UseChartDataParams) {
   const toDisplayUnits = useCallback(
     (value: number): number => latencyToMs(value, activeTab),
@@ -446,24 +455,40 @@ export function useChartData({
   }, [series]);
 
   const getCurrentTimeWindow = useCallback((): [number, number] => {
-    const windowStart = timelineWindowEnd - TWENTY_FOUR_HOURS_MS;
+    const windowStart = timelineWindowEnd - WINDOW_MS[timeWindow];
     return [windowStart, timelineWindowEnd];
-  }, [timelineWindowEnd]);
+  }, [timelineWindowEnd, timeWindow]);
 
   // Pinned tick positions for the X axis. Letting Recharts auto-pick ticks
-  // gives uneven spacing. Six ticks (every 4 hours, snapped to whole-hour
-  // boundaries inside the window) stays readable without crowding.
+  // gives uneven spacing. 24h ticks every 4 hours snapped to whole-hour
+  // boundaries; the wider windows tick at local midnights (daily for 7d,
+  // every 5 days for 30d) so date labels sit on day starts in the viewer's
+  // timezone. All land at 6-8 ticks per window.
   const getTimelineTicks = useCallback((): number[] => {
     const [windowStart, windowEnd] = getCurrentTimeWindow();
-    const FOUR_HOURS_MS = 4 * 60 * 60 * 1000;
-    const firstTick =
-      Math.ceil(windowStart / FOUR_HOURS_MS) * FOUR_HOURS_MS;
+    if (timeWindow === "24h") {
+      const FOUR_HOURS_MS = 4 * 60 * 60 * 1000;
+      const firstTick =
+        Math.ceil(windowStart / FOUR_HOURS_MS) * FOUR_HOURS_MS;
+      const ticks: number[] = [];
+      for (let t = firstTick; t <= windowEnd; t += FOUR_HOURS_MS) {
+        ticks.push(t);
+      }
+      return ticks;
+    }
+    const stepDays = timeWindow === "7d" ? 1 : 5;
+    const cursor = new Date(windowStart);
+    cursor.setHours(0, 0, 0, 0);
+    if (cursor.getTime() < windowStart) {
+      cursor.setDate(cursor.getDate() + 1);
+    }
     const ticks: number[] = [];
-    for (let t = firstTick; t <= windowEnd; t += FOUR_HOURS_MS) {
-      ticks.push(t);
+    while (cursor.getTime() <= windowEnd) {
+      ticks.push(cursor.getTime());
+      cursor.setDate(cursor.getDate() + stepDays);
     }
     return ticks;
-  }, [getCurrentTimeWindow]);
+  }, [getCurrentTimeWindow, timeWindow]);
 
   const getWindowedTimelineData = useCallback((): TimelineDataPoint[] => {
     const [windowStart, windowEnd] = getCurrentTimeWindow();

--- a/web/hooks/useDashboardState.tsx
+++ b/web/hooks/useDashboardState.tsx
@@ -19,12 +19,15 @@ import { metricDescriptions } from "@/lib/config/metrics";
 import { useAggregatesQuery, useProvidersQuery } from "@/lib/api/queries";
 import { capturePostHogEvent } from "@/lib/posthog/client";
 import { POSTHOG_EVENTS } from "@/lib/posthog/events";
-import type { TimeWindow } from "@/components/shared/TimeWindowToggle";
+import { useTimeWindow } from "@/hooks/useTimeWindow";
 
 export function useDashboardState(page: "tts" | "stt") {
   // State declarations
   const [selectedModels, setSelectedModels] = useState<string[]>([]);
-  const [timeWindow, setTimeWindow] = useState<TimeWindow>("24h");
+  const { timeWindow, changeTimeWindow } = useTimeWindow(
+    `${page}_dashboard`,
+    page
+  );
 
   const benchmarkParam = page === "tts" ? "TTS" : "STT";
 
@@ -33,6 +36,11 @@ export function useDashboardState(page: "tts" | "stt") {
     window: timeWindow,
   });
   const providersQuery = useProvidersQuery();
+
+  // The charts keep showing the prior window's data while a new one loads,
+  // so window-derived rendering must follow the data, not the toggle.
+  const dataTimeWindow = aggregatesQuery.data?.window ?? timeWindow;
+  const windowDataStale = aggregatesQuery.isPlaceholderData;
 
   const modelStats = useMemo(
     () => aggregatesQuery.data?.model_stats ?? [],
@@ -65,7 +73,7 @@ export function useDashboardState(page: "tts" | "stt") {
     selectedTTSModels: page === "tts" ? deferredSelectedModels : [],
     selectedSTTModels: page === "stt" ? deferredSelectedModels : [],
     modelsByProvider,
-    timeWindow,
+    timeWindow: dataTimeWindow,
   });
 
   // Event handlers
@@ -87,20 +95,6 @@ export function useDashboardState(page: "tts" | "stt") {
       setSelectedModels(nextSelected);
     },
     [selectedModels, page]
-  );
-
-  const changeTimeWindow = useCallback(
-    (next: TimeWindow) => {
-      if (next === timeWindow) return;
-      capturePostHogEvent(POSTHOG_EVENTS.dashboardTimeWindowChanged, {
-        surface: `${page}_dashboard`,
-        mode: page,
-        from: timeWindow,
-        to: next
-      });
-      setTimeWindow(next);
-    },
-    [timeWindow, page]
   );
 
   // Heatmap scaling for mobile. Skipped while loading (only the skeleton is
@@ -354,6 +348,8 @@ export function useDashboardState(page: "tts" | "stt") {
     // UI state
     isMobile,
     timeWindow,
+    dataTimeWindow,
+    windowDataStale,
 
     // Actions
     toggleModelSelection,

--- a/web/hooks/useDashboardState.tsx
+++ b/web/hooks/useDashboardState.tsx
@@ -41,6 +41,7 @@ export function useDashboardState(page: "tts" | "stt") {
   // so window-derived rendering must follow the data, not the toggle.
   const dataTimeWindow = aggregatesQuery.data?.window ?? timeWindow;
   const windowDataStale = aggregatesQuery.isPlaceholderData;
+  const loadError = aggregatesQuery.isError;
 
   const modelStats = useMemo(
     () => aggregatesQuery.data?.model_stats ?? [],
@@ -340,6 +341,7 @@ export function useDashboardState(page: "tts" | "stt") {
 
     // Data loading
     loading,
+    loadError,
 
     // Model state
     selectedModels,

--- a/web/hooks/useDashboardState.tsx
+++ b/web/hooks/useDashboardState.tsx
@@ -19,16 +19,18 @@ import { metricDescriptions } from "@/lib/config/metrics";
 import { useAggregatesQuery, useProvidersQuery } from "@/lib/api/queries";
 import { capturePostHogEvent } from "@/lib/posthog/client";
 import { POSTHOG_EVENTS } from "@/lib/posthog/events";
+import type { TimeWindow } from "@/components/shared/TimeWindowToggle";
 
 export function useDashboardState(page: "tts" | "stt") {
   // State declarations
   const [selectedModels, setSelectedModels] = useState<string[]>([]);
+  const [timeWindow, setTimeWindow] = useState<TimeWindow>("24h");
 
   const benchmarkParam = page === "tts" ? "TTS" : "STT";
 
   const aggregatesQuery = useAggregatesQuery({
     benchmark: benchmarkParam,
-    window: "24h",
+    window: timeWindow,
   });
   const providersQuery = useProvidersQuery();
 
@@ -63,6 +65,7 @@ export function useDashboardState(page: "tts" | "stt") {
     selectedTTSModels: page === "tts" ? deferredSelectedModels : [],
     selectedSTTModels: page === "stt" ? deferredSelectedModels : [],
     modelsByProvider,
+    timeWindow,
   });
 
   // Event handlers
@@ -84,6 +87,20 @@ export function useDashboardState(page: "tts" | "stt") {
       setSelectedModels(nextSelected);
     },
     [selectedModels, page]
+  );
+
+  const changeTimeWindow = useCallback(
+    (next: TimeWindow) => {
+      if (next === timeWindow) return;
+      capturePostHogEvent(POSTHOG_EVENTS.dashboardTimeWindowChanged, {
+        surface: `${page}_dashboard`,
+        mode: page,
+        from: timeWindow,
+        to: next
+      });
+      setTimeWindow(next);
+    },
+    [timeWindow, page]
   );
 
   // Heatmap scaling for mobile. Skipped while loading (only the skeleton is
@@ -336,9 +353,11 @@ export function useDashboardState(page: "tts" | "stt") {
 
     // UI state
     isMobile,
+    timeWindow,
 
     // Actions
     toggleModelSelection,
+    changeTimeWindow,
 
     // Chart data functions
     formatChartLabel: chartData.formatChartLabel,

--- a/web/hooks/useTimeWindow.ts
+++ b/web/hooks/useTimeWindow.ts
@@ -1,0 +1,29 @@
+// Copyright 2026 The Coval Benchmarks Authors
+// SPDX-License-Identifier: Apache-2.0
+
+"use client";
+
+import { useCallback, useState } from "react";
+import { capturePostHogEvent } from "@/lib/posthog/client";
+import { POSTHOG_EVENTS, type PostHogMode } from "@/lib/posthog/events";
+import type { TimeWindow } from "@/lib/config/timeWindows";
+
+export function useTimeWindow(surface: string, mode?: PostHogMode) {
+  const [timeWindow, setTimeWindow] = useState<TimeWindow>("24h");
+
+  const changeTimeWindow = useCallback(
+    (next: TimeWindow) => {
+      if (next === timeWindow) return;
+      capturePostHogEvent(POSTHOG_EVENTS.dashboardTimeWindowChanged, {
+        surface,
+        ...(mode ? { mode } : {}),
+        from: timeWindow,
+        to: next
+      });
+      setTimeWindow(next);
+    },
+    [timeWindow, surface, mode]
+  );
+
+  return { timeWindow, changeTimeWindow };
+}

--- a/web/hooks/useTimeWindow.ts
+++ b/web/hooks/useTimeWindow.ts
@@ -5,10 +5,14 @@
 
 import { useCallback, useState } from "react";
 import { capturePostHogEvent } from "@/lib/posthog/client";
-import { POSTHOG_EVENTS, type PostHogMode } from "@/lib/posthog/events";
+import {
+  POSTHOG_EVENTS,
+  type PostHogMode,
+  type PostHogSurface,
+} from "@/lib/posthog/events";
 import type { TimeWindow } from "@/lib/config/timeWindows";
 
-export function useTimeWindow(surface: string, mode?: PostHogMode) {
+export function useTimeWindow(surface: PostHogSurface, mode?: PostHogMode) {
   const [timeWindow, setTimeWindow] = useState<TimeWindow>("24h");
 
   const changeTimeWindow = useCallback(

--- a/web/lib/api/queries.ts
+++ b/web/lib/api/queries.ts
@@ -3,7 +3,7 @@
 
 "use client";
 
-import { useQuery } from "@tanstack/react-query";
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import {
   getAggregates,
   getProviders,
@@ -29,6 +29,9 @@ export function useAggregatesQuery(params: AggregatesQueryParams) {
     queryKey: ["aggregates", params],
     queryFn: ({ signal }: { signal: AbortSignal }) =>
       getAggregates(params, { signal } satisfies FetchOptions),
+    // Keep showing the previous window's data while a new window loads so
+    // toggling doesn't flash the page back to the skeleton.
+    placeholderData: keepPreviousData,
   });
 }
 

--- a/web/lib/api/queries.ts
+++ b/web/lib/api/queries.ts
@@ -29,8 +29,7 @@ export function useAggregatesQuery(params: AggregatesQueryParams) {
     queryKey: ["aggregates", params],
     queryFn: ({ signal }: { signal: AbortSignal }) =>
       getAggregates(params, { signal } satisfies FetchOptions),
-    // Keep showing the previous window's data while a new window loads so
-    // toggling doesn't flash the page back to the skeleton.
+    // Toggling windows keeps the prior data up instead of flashing the skeleton.
     placeholderData: keepPreviousData,
   });
 }

--- a/web/lib/config/constants.ts
+++ b/web/lib/config/constants.ts
@@ -1,5 +1,0 @@
-// Copyright 2026 The Coval Benchmarks Authors
-// SPDX-License-Identifier: Apache-2.0
-
-export const THREE_HOURS_MS = 3 * 60 * 60 * 1000;
-export const TWENTY_FOUR_HOURS_MS = 24 * 60 * 60 * 1000;

--- a/web/lib/config/timeWindows.ts
+++ b/web/lib/config/timeWindows.ts
@@ -1,7 +1,7 @@
 // Copyright 2026 The Coval Benchmarks Authors
 // SPDX-License-Identifier: Apache-2.0
 
-import { TWENTY_FOUR_HOURS_MS } from "@/lib/config/constants";
+const DAY_MS = 24 * 60 * 60 * 1000;
 
 export const TIME_WINDOWS = ["24h", "7d", "30d"] as const;
 export type TimeWindow = (typeof TIME_WINDOWS)[number];
@@ -14,7 +14,7 @@ export const WINDOW_LABELS: Record<TimeWindow, string> = {
 };
 
 export const WINDOW_MS: Record<TimeWindow, number> = {
-  "24h": TWENTY_FOUR_HOURS_MS,
-  "7d": 7 * TWENTY_FOUR_HOURS_MS,
-  "30d": 30 * TWENTY_FOUR_HOURS_MS,
+  "24h": DAY_MS,
+  "7d": 7 * DAY_MS,
+  "30d": 30 * DAY_MS,
 };

--- a/web/lib/config/timeWindows.ts
+++ b/web/lib/config/timeWindows.ts
@@ -1,0 +1,20 @@
+// Copyright 2026 The Coval Benchmarks Authors
+// SPDX-License-Identifier: Apache-2.0
+
+import { TWENTY_FOUR_HOURS_MS } from "@/lib/config/constants";
+
+export const TIME_WINDOWS = ["24h", "7d", "30d"] as const;
+export type TimeWindow = (typeof TIME_WINDOWS)[number];
+
+// Values mirror the API's window literals; "1d" is display-only.
+export const WINDOW_LABELS: Record<TimeWindow, string> = {
+  "24h": "1d",
+  "7d": "7d",
+  "30d": "30d",
+};
+
+export const WINDOW_MS: Record<TimeWindow, number> = {
+  "24h": TWENTY_FOUR_HOURS_MS,
+  "7d": 7 * TWENTY_FOUR_HOURS_MS,
+  "30d": 30 * TWENTY_FOUR_HOURS_MS,
+};

--- a/web/lib/posthog/events.ts
+++ b/web/lib/posthog/events.ts
@@ -20,7 +20,11 @@ export const POSTHOG_EVENTS = {
   dashboardTimeWindowChanged: "dashboard_time_window_changed"
 } as const;
 
-export type PostHogSurface = "tts_dashboard" | "stt_dashboard" | "playground";
+export type PostHogSurface =
+  | "tts_dashboard"
+  | "stt_dashboard"
+  | "playground"
+  | "overview";
 export type PostHogMode = "tts" | "stt";
 export type SelectionAction = "add" | "remove";
 export type DashboardChartId =

--- a/web/lib/posthog/events.ts
+++ b/web/lib/posthog/events.ts
@@ -16,7 +16,8 @@ export const POSTHOG_EVENTS = {
   sttTranscriptBrowsed: "stt_transcript_browsed",
   playgroundExamplePromptUsed: "playground_example_prompt_used",
   playgroundModeSwitched: "playground_mode_switched",
-  playgroundResultPlayed: "playground_result_played"
+  playgroundResultPlayed: "playground_result_played",
+  dashboardTimeWindowChanged: "dashboard_time_window_changed"
 } as const;
 
 export type PostHogSurface = "tts_dashboard" | "stt_dashboard" | "playground";

--- a/web/lib/utils/formatters.ts
+++ b/web/lib/utils/formatters.ts
@@ -20,6 +20,14 @@ export function formatTime(timestamp: number): string {
   });
 }
 
+/** Short month-day label (e.g. "Jun 5") for date-scale axis ticks. */
+export function formatDate(timestamp: number): string {
+  return new Date(timestamp).toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric"
+  });
+}
+
 /**
  * Same as {@link formatTime} but includes seconds — used in tooltips where
  * the user is hovering a specific data point and wants higher precision.


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added time window selection (24h, 7d, 30d) to dashboard and overview pages.
  * Charts now display dates alongside times for longer time periods.

* **Improvements**
  * Optimized concurrent requests to reduce backend load via request coalescing.
  * Smoother data transitions when changing time windows; previous data remains visible during loads.
  * Added visual indicators for stale data during window updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extends the dashboard and overview leaderboard with selectable 7d and 30d time windows alongside the existing 24h view. A new `useTimeWindow` hook manages selection state and PostHog telemetry; `keepPreviousData` keeps the prior window's data visible while the new one loads; the backend gains a `get_or_fill` helper that coalesces concurrent cache misses onto a single DB query.

- **Backend**: `get_or_fill` in `cache.py` serialises concurrent misses for one cache key via a per-key `asyncio.Lock`, stores fill failures for `FAILURE_TTL_SECONDS` so waiters don't each retry the DB, and a new `cache_locks` app-state object wires it through FastAPI DI.
- **Frontend**: `timeWindows.ts` centralises window constants (`TIME_WINDOWS`, `WINDOW_LABELS`, `WINDOW_MS`); `useAggregatesQuery` gains `placeholderData: keepPreviousData`; chart ticks and tooltip labels switch between time- and date-scale based on the active window; the deleted `constants.ts` has no remaining consumers.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the changes are well-scoped, the asyncio lock coalescing is correct for the single-threaded event loop, and the frontend staleness handling follows the data window rather than the toggle.

The cache coalescing logic in get_or_fill correctly relies on asyncio's cooperative scheduling: there are no await points between lock.locked() and async with lock, so the waited flag is reliable. Failure caching uses monotonic time independently of the TTLCache TTL, avoiding stale re-raises. Frontend rendering follows dataTimeWindow rather than the in-flight toggle value, keeping chart axes consistent with the displayed data during transitions. All new behaviour is covered by targeted tests.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| runner/src/coval_bench/api/cache.py | Adds get_or_fill with asyncio-safe lock-coalescing and short-lived failure caching; logic is correct for the single-threaded event loop model. |
| runner/src/coval_bench/api/routers/aggregates.py | Refactors cache read/write into get_or_fill; adds cache_status field to PostHog event; clean migration. |
| runner/tests/api/test_aggregates.py | Adds three new tests: window-interval coverage, concurrent miss coalescing, and failure-sharing; all correctly rely on ASGITransport raise_app_exceptions=True default. |
| web/hooks/useDashboardState.tsx | Integrates useTimeWindow; chart data correctly follows dataTimeWindow (the data's reported window) rather than the toggle state during transitions. |
| web/lib/api/queries.ts | Adds keepPreviousData to useAggregatesQuery so window switches show stale data instead of a loading skeleton. |
| web/hooks/useChartData.ts | getTimelineTicks and getCurrentTimeWindow now use WINDOW_MS[timeWindow]; 7d/30d tick generation uses local-midnight alignment; logic is correct. |
| web/components/layout/DashboardLayout.tsx | Adds TimeWindowToggle to header; adds opacity-60 dimming during stale window transitions; adds error state display. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant R1 as Request 1
    participant R2 as Request 2..5
    participant GoF as get_or_fill
    participant Lock as asyncio.Lock[key]
    participant Cache as TTLCache
    participant DB as Postgres Pool

    R1->>GoF: fill(aggregates, benchmark, window)
    GoF->>Lock: lock.locked() False
    GoF->>Lock: acquire immediate
    GoF->>Cache: get(key) None miss
    GoF->>DB: await fill pool.connection
    Note over R2,Lock: concurrent requests arrive during fill
    R2->>GoF: fill(aggregates, benchmark, window)
    GoF->>Lock: "lock.locked() True waited=True"
    GoF->>Lock: await acquire suspend
    DB-->>GoF: result
    GoF->>Cache: "cache[key] = result"
    GoF-->>R1: result miss
    Lock-->>R2: acquired
    GoF->>Cache: get(key) result hit
    GoF-->>R2: result coalesced

    Note over GoF,Cache: On fill failure path
    GoF->>Cache: "cache[(key,failure)] = monotonic exc"
    GoF-->>R1: raise exc
    Lock-->>R2: acquired
    GoF->>Cache: get failure within FAILURE_TTL
    GoF-->>R2: raise cached exc no DB call
```

<sub>Reviews (3): Last reviewed commit: ["Get rid of the bucket aggregating"](https://github.com/coval-ai/benchmarks/commit/9c1ec7a75e4ad57f06c0acc45b86811202dbb02e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36578195)</sub>

<!-- /greptile_comment -->