### PR TITLE
Add TTFS/TTFT toggle to latency-vs-accuracy chart

### DIFF
--- a/web/components/charts/tooltips/ScatterTooltip.tsx
+++ b/web/components/charts/tooltips/ScatterTooltip.tsx
@@ -7,9 +7,10 @@ import { TooltipProps } from "@/types/chart.types";
 
 interface ScatterTooltipProps extends TooltipProps {
   activeTab: "tts" | "stt";
+  metric: string;
 }
 
-const CustomScatterTooltip: React.FC<ScatterTooltipProps> = ({ active, payload, activeTab }) => {
+const CustomScatterTooltip: React.FC<ScatterTooltipProps> = ({ active, payload, activeTab, metric }) => {
   if (active && payload && payload.length > 0) {
     const point = payload[0]?.payload;
     if (!point) return null;
@@ -27,9 +28,7 @@ const CustomScatterTooltip: React.FC<ScatterTooltipProps> = ({ active, payload, 
           style={{ margin: 0, fontWeight: "bold" }}
         >{`Model: ${normalizeModelName(point.model)}`}</p>
         <p style={{ margin: 0 }}>{`Provider: ${activeTab === "stt" ? normalizeSTTProviderName(point.provider) : normalizeTTSProviderName(point.provider)}`}</p>
-        <p style={{ margin: 0 }}>{`Avg ${
-          activeTab === "tts" ? "TTFA" : "TTFT"
-        }: ${point.x.toFixed(0)}ms`}</p>
+        <p style={{ margin: 0 }}>{`Avg ${metric}: ${point.x.toFixed(0)}ms`}</p>
         <p style={{ margin: 0 }}>{`Avg WER: ${point.y.toFixed(1)}%`}</p>
         <p style={{ margin: 0 }}>{`Samples: ${point.count}`}</p>
       </div>

--- a/web/components/dashboard/LatencyAccuracySection.tsx
+++ b/web/components/dashboard/LatencyAccuracySection.tsx
@@ -3,7 +3,7 @@
 
 "use client";
 
-import React, { useMemo } from "react";
+import React, { useMemo, useState } from "react";
 import {
   ScatterChart,
   Scatter,
@@ -24,11 +24,22 @@ import { useActiveTab } from "@/hooks/useActiveTab";
 import { useChartHoverTracking } from "@/hooks/useChartHoverTracking";
 
 const LatencyAccuracySection: React.FC = () => {
-  const { latencyLabel, selectedModels, scatterData } = useDashboard();
+  const { selectedModels, getScatterData } = useDashboard();
 
   const activeTab = useActiveTab();
   const themeColors = useThemeColors();
   const trackChartHover = useChartHoverTracking("scatter");
+
+  // STT shows a TTFS / TTFT toggle; TTS is single-metric (TTFA). Defaulting to
+  // TTFT for now; flip back to "TTFS" once enough TTFS data has accumulated.
+  const [metric, setMetric] = useState<string>(
+    activeTab === "stt" ? "TTFT" : "TTFA"
+  );
+  const latencyLabel = metric;
+  const scatterData = useMemo(
+    () => getScatterData(metric),
+    [getScatterData, metric]
+  );
 
   const description = {
     short: `Average ${latencyLabel} and WER per model`,
@@ -90,6 +101,26 @@ const LatencyAccuracySection: React.FC = () => {
           }}
         />
 
+        {activeTab === "stt" && (
+          <div className="mb-4 inline-flex gap-0.5 rounded-lg bg-gray-100 p-0.5">
+            {(["TTFS", "TTFT"] as const).map((m) => (
+              <button
+                key={m}
+                type="button"
+                onClick={() => setMetric(m)}
+                className={
+                  "rounded-md px-3 py-1 text-xs font-medium transition-colors " +
+                  (metric === m
+                    ? "bg-white text-text-primary shadow-sm"
+                    : "text-gray-500 hover:text-text-primary")
+                }
+              >
+                {m}
+              </button>
+            ))}
+          </div>
+        )}
+
         <div className="h-64" onMouseEnter={trackChartHover}>
           <ResponsiveContainer width="100%" height="100%">
             <ScatterChart
@@ -132,7 +163,7 @@ const LatencyAccuracySection: React.FC = () => {
                 tick={{ fill: themeColors.axisText, fontSize: 12 }}
                 tickFormatter={(value) => `${value}%`}
               />
-              <Tooltip content={<CustomScatterTooltip activeTab={activeTab} />} />
+              <Tooltip content={<CustomScatterTooltip activeTab={activeTab} metric={metric} />} />
               {selectedModels.map((model: string) => (
                 <Scatter
                   key={model}

--- a/web/components/visualizations/TimelineChart.tsx
+++ b/web/components/visualizations/TimelineChart.tsx
@@ -64,9 +64,10 @@ const TimelineChart: React.FC = () => {
   } = useDashboard();
   const trackChartHover = useChartHoverTracking("timeline");
 
-  // STT shows a TTFS (default) / TTFT toggle; TTS is single-metric (TTFA).
+  // STT shows a TTFS / TTFT toggle; TTS is single-metric (TTFA). Defaulting to
+  // TTFT for now; flip back to "TTFS" once enough TTFS data has accumulated.
   const [metric, setMetric] = useState<string>(
-    activeTab === "stt" ? "TTFS" : "TTFA"
+    activeTab === "stt" ? "TTFT" : "TTFA"
   );
 
   const themeColors = useThemeColors();

--- a/web/hooks/useChartData.ts
+++ b/web/hooks/useChartData.ts
@@ -239,19 +239,26 @@ export function useChartData({
     [boxPlotDataMemo]
   );
 
-  // One (avg latency, avg WER) point per model. The averages are independent
-  // per metric — not restricted to runs that produced both.
-  const scatterByModel = useMemo<Record<string, ScatterDataPoint>>(() => {
-    const xMetric = activeTab === "tts" ? "TTFA" : "TTFT";
-
-    const byModel: Record<string, ScatterDataPoint> = {};
+  // Per-metric, per-model scatter point (avg latency, avg WER) built in one
+  // pass, indexed by metric_type so any latency metric can read its own points.
+  // Averages are independent per metric — not restricted to runs producing both.
+  const scatterByMetricModel = useMemo<
+    Record<string, Record<string, ScatterDataPoint>>
+  >(() => {
+    const out: Record<string, Record<string, ScatterDataPoint>> = {};
     modelStats.forEach((stat) => {
-      if (stat.metric_type !== xMetric) return;
-
+      // Only latency metrics belong on the scatter's x-axis; skip WER/RTF/etc.
+      if (
+        stat.metric_type !== "TTFS" &&
+        stat.metric_type !== "TTFT" &&
+        stat.metric_type !== "TTFA"
+      ) {
+        return;
+      }
       const modelKey = toModelKey(stat.provider, stat.model);
       const werStat = getStat(modelKey, "WER");
       if (!werStat) return;
-
+      const byModel = (out[stat.metric_type] ??= {});
       byModel[modelKey] = {
         x: toDisplayUnits(stat.avg_value),
         y: werStat.avg_value,
@@ -264,26 +271,19 @@ export function useChartData({
         count: stat.sample_count
       };
     });
-    return byModel;
+    return out;
   }, [modelStats, activeTab, getStat, toDisplayUnits]);
 
-  const scatterDataMemo = useMemo<ScatterDataPoint[]>(() => {
-    const selectedModels =
-      activeTab === "tts" ? selectedTTSModels : selectedSTTModels;
-
-    const points: ScatterDataPoint[] = [];
-    selectedModels.forEach((model) => {
-      const point = scatterByModel[model];
-      if (point) {
-        points.push(point);
-      }
-    });
-    return points;
-  }, [scatterByModel, activeTab, selectedTTSModels, selectedSTTModels]);
-
   const getScatterData = useCallback(
-    (): ScatterDataPoint[] => scatterDataMemo,
-    [scatterDataMemo]
+    (metric: string): ScatterDataPoint[] => {
+      const selectedModels =
+        activeTab === "tts" ? selectedTTSModels : selectedSTTModels;
+      const byModel = scatterByMetricModel[metric] ?? {};
+      return selectedModels
+        .map((model) => byModel[model])
+        .filter((point): point is ScatterDataPoint => point !== undefined);
+    },
+    [scatterByMetricModel, activeTab, selectedTTSModels, selectedSTTModels]
   );
 
   // STT heatmap: latency deltas relative to the fastest selected model at

--- a/web/hooks/useDashboardState.tsx
+++ b/web/hooks/useDashboardState.tsx
@@ -220,7 +220,6 @@ export function useDashboardState(page: "tts" | "stt") {
   } = keyMetrics;
 
   // Get computed data
-  const scatterData = chartData.getScatterData();
   const heatmapData = chartData.getModelHeatmapData();
   const werBarData = chartData.getWERBarData();
 
@@ -351,7 +350,7 @@ export function useDashboardState(page: "tts" | "stt") {
     getBoxPlotData: chartData.getBoxPlotData,
 
     // Computed chart data
-    scatterData,
+    getScatterData: chartData.getScatterData,
     heatmapDisplayData,
     werBarDataWithColors,
 


### PR DESCRIPTION
Adds a TTFS/TTFT toggle to the latency-vs-accuracy scatter, matching the timeline toggle. Also defaults both STT latency charts (timeline + scatter) to **TTFT for now** — TTFS has no data until #85 deploys and runs accumulate, so TTFT avoids an empty chart on load. Flip the defaults back to `"TTFS"` in ~a day (one-liner each, marked by a comment).

- `getScatterData` is parameterized by metric (one-pass `scatterByMetricModel` + thin getter, same shape as the timeline)
- The chart derives its x-axis and labels from the selected metric; STT-only, TTS stays TTFA
- No Pareto frontier — matches the current chart
- 2nd commit defaults the **timeline** toggle to TTFT too (it lives on `main` from #85, so it rides here rather than a separate PR)

Builds on the TTFS metric (#85, merged).
