### PR TITLE
Force STT finalization at end-of-speech for TTFS parity

### DIFF
--- a/runner/src/coval_bench/providers/stt/assemblyai.py
+++ b/runner/src/coval_bench/providers/stt/assemblyai.py
@@ -32,6 +32,10 @@ _SPEECH_MODEL_MAP: dict[str, str] = {
 }
 _WS_BASE = "wss://streaming.assemblyai.com/v3/ws"
 
+# Held high so the semantic end-of-turn model can't auto-finalize mid-utterance
+# before our ForceEndpoint at speech-end (TTFS parity). Tune after a re-run.
+_END_OF_TURN_CONFIDENCE_THRESHOLD = 0.9
+
 
 class AssemblyAIProvider(STTProvider):
     """AssemblyAI v3 streaming STT provider."""
@@ -71,7 +75,10 @@ class AssemblyAIProvider(STTProvider):
 
         try:
             speech_model = _SPEECH_MODEL_MAP[self._model]
-            url = f"{_WS_BASE}?sample_rate={sample_rate}&speech_model={speech_model}"
+            url = (
+                f"{_WS_BASE}?sample_rate={sample_rate}&speech_model={speech_model}"
+                f"&end_of_turn_confidence_threshold={_END_OF_TURN_CONFIDENCE_THRESHOLD}"
+            )
             headers = {"Authorization": self._api_key.get_secret_value()}
             async with ws_client.connect(url, additional_headers=headers) as ws:
                 send_task = asyncio.create_task(
@@ -117,6 +124,8 @@ class AssemblyAIProvider(STTProvider):
                     first_chunk = False
                 await ws.send(chunk)
                 await asyncio.sleep(realtime_resolution)
+            # Force finalization at speech-end (TTFS parity) before terminating.
+            await ws.send(json.dumps({"type": "ForceEndpoint"}))
             await ws.send(json.dumps({"type": "Terminate"}))
         except Exception as exc:
             logger.exception("assemblyai send error", error=str(exc))

--- a/runner/src/coval_bench/providers/stt/deepgram.py
+++ b/runner/src/coval_bench/providers/stt/deepgram.py
@@ -78,6 +78,9 @@ class DeepgramProvider(STTProvider):
             f"&vad_events=true"
             f"&no_delay=true"
             f"&punctuate=true"
+            # Disable native silence endpointing; we force the final at speech-end
+            # via a Finalize message instead (TTFS parity).
+            f"&endpointing=false"
         )
         if self._model != "default":
             url += f"&model={self._model}"
@@ -151,6 +154,10 @@ class DeepgramProvider(STTProvider):
                     first_chunk = False
                 await ws.send(chunk)
                 await asyncio.sleep(realtime_resolution)
+            # nova finalizes on our signal (endpointing disabled); Flux has no
+            # Finalize and can't be forced, so it's left on its native EOT.
+            if not self._model.startswith("flux-"):
+                await ws.send(json.dumps({"type": "Finalize"}))
             await ws.send(json.dumps({"type": "CloseStream"}))
         except Exception as exc:
             logger.exception("deepgram send error", error=str(exc))

--- a/runner/src/coval_bench/runner/orchestrator.py
+++ b/runner/src/coval_bench/runner/orchestrator.py
@@ -319,21 +319,25 @@ async def _run_stt_item(
         ttfs_status, ttfs_error = _metric_outcome(
             ttfs_value, item_error or ttfs_calc_error, "TTFS", ResultStatus
         )
-        results.append(
-            Result(
-                run_id=run_id,
-                provider=entry.provider,
-                model=entry.model,
-                benchmark=Benchmark.STT,
-                metric_type="TTFS",
-                metric_value=ttfs_value,
-                metric_units="seconds",
-                audio_filename=audio_path.name,
-                transcript=complete_transcript,
-                status=ttfs_status,
-                error=ttfs_error,
+        # Flux can't finalize on our signal (no Finalize, EOT can't be disabled), so it's
+        # outside the TTFS parity cohort. Other metrics still run; only the TTFS row is omitted.
+        ttfs_excluded = entry.provider == "deepgram" and entry.model.startswith("flux-")
+        if not ttfs_excluded:
+            results.append(
+                Result(
+                    run_id=run_id,
+                    provider=entry.provider,
+                    model=entry.model,
+                    benchmark=Benchmark.STT,
+                    metric_type="TTFS",
+                    metric_value=ttfs_value,
+                    metric_units="seconds",
+                    audio_filename=audio_path.name,
+                    transcript=complete_transcript,
+                    status=ttfs_status,
+                    error=ttfs_error,
+                )
             )
-        )
 
         # 3. RTF — derived from AudioToFinal, so its outcome tracks whether a final was
         # produced. A present final with an uncomputable RTF (e.g. zero duration) stays a

--- a/runner/tests/providers/stt/test_assemblyai.py
+++ b/runner/tests/providers/stt/test_assemblyai.py
@@ -77,6 +77,36 @@ def test_websocket_url_contains_required_params() -> None:
         assert "format_turns" not in api_name
 
 
+@pytest.mark.asyncio
+async def test_force_endpoint_sent_before_terminate(
+    fake_api_key: SecretStr, audio_pcm_bytes: bytes
+) -> None:
+    sent: list[Any] = []
+    ws = FakeWebSocket([], on_send=sent.append)
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=ws)
+    cm.__aexit__ = AsyncMock(return_value=False)
+    provider = AssemblyAIProvider(api_key=fake_api_key)
+
+    with patch(
+        "coval_bench.providers.stt.assemblyai.ws_client.connect", return_value=cm
+    ) as mock_connect:
+        await provider.measure_ttft(
+            audio_data=audio_pcm_bytes,
+            channels=1,
+            sample_width=2,
+            sample_rate=16000,
+            realtime_resolution=0.01,
+        )
+
+    url = mock_connect.call_args.args[0]
+    assert "end_of_turn_confidence_threshold=" in url
+
+    text = [m for m in sent if isinstance(m, str)]
+    assert '"ForceEndpoint"' in text[-2]
+    assert '"Terminate"' in text[-1]
+
+
 # ---------------------------------------------------------------------------
 # Provider name
 # ---------------------------------------------------------------------------

--- a/runner/tests/providers/stt/test_deepgram.py
+++ b/runner/tests/providers/stt/test_deepgram.py
@@ -106,6 +106,8 @@ def test_build_websocket_url_nova3() -> None:
     url = p._build_websocket_url(16000, 1)
     assert "nova-3" in url
     assert "api.deepgram.com" in url
+    # Native silence endpointing disabled; we force the final via Finalize (TTFS parity).
+    assert "endpointing=false" in url
 
 
 def test_build_websocket_url_flux() -> None:
@@ -119,6 +121,56 @@ def test_build_websocket_url_flux() -> None:
     assert "interim_results" not in url
     assert "no_delay" not in url
     assert "channels" not in url
+    # endpointing is a v1-only param and Flux can't be forced anyway.
+    assert "endpointing" not in url
+
+
+@pytest.mark.asyncio
+async def test_nova_sends_finalize_before_close(
+    fake_api_key: SecretStr, audio_pcm_bytes: bytes
+) -> None:
+    sent: list[Any] = []
+    ws = FakeWebSocket([], on_send=sent.append)
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=ws)
+    cm.__aexit__ = AsyncMock(return_value=False)
+    provider = DeepgramProvider(api_key=fake_api_key, model="nova-3")
+
+    with patch("coval_bench.providers.stt.deepgram.ws_client.connect", return_value=cm):
+        await provider.measure_ttft(
+            audio_data=audio_pcm_bytes,
+            channels=1,
+            sample_width=2,
+            sample_rate=16000,
+            realtime_resolution=0.01,
+        )
+
+    text = [m for m in sent if isinstance(m, str)]
+    assert '"Finalize"' in text[-2]
+    assert '"CloseStream"' in text[-1]
+
+
+@pytest.mark.asyncio
+async def test_flux_does_not_send_finalize(fake_api_key: SecretStr, audio_pcm_bytes: bytes) -> None:
+    sent: list[Any] = []
+    ws = FakeWebSocket([], on_send=sent.append)
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=ws)
+    cm.__aexit__ = AsyncMock(return_value=False)
+    provider = DeepgramProvider(api_key=fake_api_key, model="flux-general-en")
+
+    with patch("coval_bench.providers.stt.deepgram.ws_client.connect", return_value=cm):
+        await provider.measure_ttft(
+            audio_data=audio_pcm_bytes,
+            channels=1,
+            sample_width=2,
+            sample_rate=16000,
+            realtime_resolution=0.01,
+        )
+
+    text = [m for m in sent if isinstance(m, str)]
+    assert not any("Finalize" in m for m in text)
+    assert '"CloseStream"' in text[-1]
 
 
 def test_build_websocket_url_flux_rejects_non_mono() -> None:

--- a/runner/tests/unit/test_orchestrator.py
+++ b/runner/tests/unit/test_orchestrator.py
@@ -379,6 +379,44 @@ async def test_full_failure(audio_file: Path, settings: Settings) -> None:
     assert all("always fails" in (r.error or "") for r in rows)
 
 
+@pytest.mark.asyncio
+async def test_flux_excluded_from_ttfs(audio_file: Path, settings: Settings) -> None:
+    """Deepgram Flux is outside the TTFS parity cohort → no TTFS row, other metrics stay."""
+    from coval_bench.runner.config import DEFAULT_STT_MATRIX
+
+    provider = MagicMock()
+    provider.measure_ttft = AsyncMock(return_value=_good_transcription())
+    stt_providers = {"deepgram": MagicMock(return_value=provider)}
+    matrix = [
+        *[
+            ProviderEntry(provider=e.provider, model=e.model, voice=e.voice, enabled=False)
+            for e in DEFAULT_STT_MATRIX
+        ],
+        ProviderEntry(provider="deepgram", model="flux-general-en", enabled=True),
+    ]
+
+    run = _make_run()
+    writer = _make_stub_writer(run)
+
+    async with _orchestrator_env(
+        audio_path=audio_file,
+        stt_items=[_make_dataset_item(audio_file)],
+        stt_providers=stt_providers,
+        run=run,
+        writer=writer,
+    ) as _:
+        await run_benchmarks(
+            settings=settings,
+            benchmark_kind="stt",
+            smoke=True,
+            matrix_overrides=matrix,
+        )
+
+    metric_types = {r.metric_type for r in _recorded_rows(writer)}
+    assert "TTFS" not in metric_types
+    assert metric_types == {"TTFT", "AudioToFinal", "RTF", "WER"}
+
+
 # ---------------------------------------------------------------------------
 # 4. test_retry_succeeds_on_third_attempt
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
TTFS is only apples-to-apples if every model finalizes on the same end-of-speech signal. Silence-based models are already handled by trimming, but semantic-turn models decide their own turn end, so we force them onto our signal:

- **AssemblyAI** — send `ForceEndpoint` at speech-end (with a high confidence threshold so it doesn't fire early).
- **Deepgram nova** — turn off native endpointing, send `Finalize`.

Flux can't be forced, so it's left out of TTFS (still shows on TTFT/WER/etc.).

No DB changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes three coordinated changes to the STT pipeline: it adjusts the AssemblyAI and Deepgram providers to finalize transcripts on an explicit signal rather than waiting for native silence endpointing (improving TTFS measurement parity), and excludes Deepgram Flux models from TTFS collection since they cannot be forced to finalize.

- **AssemblyAI**: raises `end_of_turn_confidence_threshold` to 0.9 (to suppress auto-finalization mid-utterance) and sends `ForceEndpoint` immediately before `Terminate` so that AudioToFinal is anchored to the speech-end signal.
- **Deepgram (nova)**: disables native endpointing (`endpointing=false`) and sends a `Finalize` message after the last audio chunk; Flux models are left on native EOT and their TTFS row is skipped entirely in the orchestrator.
- **Tests**: new async tests verify `ForceEndpoint`/`Finalize` ordering, URL parameter presence, and that `"TTFS"` is absent from Flux run results while all other metrics remain.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changed code paths have new tests and the provider/orchestrator exclusion logic is internally consistent.

The WebSocket finalization changes (ForceEndpoint, Finalize) are straightforward protocol additions with no shared state, and the Flux TTFS exclusion predicate (startswith('flux-')) matches at both the provider and orchestrator layers. New tests verify message ordering, URL params, and missing TTFS rows. No behavioural regressions are apparent in the non-Flux path.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| runner/src/coval_bench/providers/stt/assemblyai.py | Adds end_of_turn_confidence_threshold URL param and ForceEndpoint before Terminate; logic is correct and well-commented. |
| runner/src/coval_bench/providers/stt/deepgram.py | Adds endpointing=false for v1/listen models and sends Finalize before CloseStream for non-flux models; flux branch unchanged. |
| runner/src/coval_bench/runner/orchestrator.py | Skips TTFS result row for deepgram flux-* models; exclusion predicate is consistent with provider-level behavior. |
| runner/tests/providers/stt/test_assemblyai.py | New async test verifies ForceEndpoint ordering and confidence-threshold URL param; covers the changed send path. |
| runner/tests/providers/stt/test_deepgram.py | New async tests verify Finalize sent for nova, not sent for flux, and URL endpointing params; flux-general-multi not independently tested but code path is identical. |
| runner/tests/unit/test_orchestrator.py | New test confirms TTFS row is absent and all other metrics present for a flux-general-en run. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant O as Orchestrator
    participant P as Provider (_send_audio)
    participant WS as WebSocket (API)
    participant R as Provider (_receive)

    O->>P: measure_ttft(audio_data)
    par send + receive tasks
        loop audio chunks
            P->>WS: send(chunk)
        end
        alt AssemblyAI
            P->>WS: send(ForceEndpoint)
            P->>WS: send(Terminate)
        else "Deepgram nova-*"
            P->>WS: send(Finalize)
            P->>WS: send(CloseStream)
        else "Deepgram flux-*"
            P->>WS: send(CloseStream)
        end
        WS-->>R: transcript events (TTFT captured)
        WS-->>R: final event (AudioToFinal captured)
    end
    P-->>O: TranscriptionResult

    O->>O: compute TTFS from AudioToFinal + speech_end_offset
    alt "provider=deepgram AND model starts with flux-"
        O->>O: "skip TTFS row (ttfs_excluded=True)"
    else all other providers
        O->>O: append TTFS Result row
    end
```

<sub>Reviews (3): Last reviewed commit: ["Force STT finalization at end-of-speech ..."](https://github.com/coval-ai/benchmarks/commit/03f014ec14c72d2e7c12111144c3fc3d99b942ce) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36588649)</sub>

<!-- /greptile_comment -->