### PR TITLE
Force STT finalization at end-of-speech for TTFS parity

### DIFF
--- a/runner/src/coval_bench/providers/stt/assemblyai.py
+++ b/runner/src/coval_bench/providers/stt/assemblyai.py
@@ -32,6 +32,10 @@ _SPEECH_MODEL_MAP: dict[str, str] = {
 }
 _WS_BASE = "wss://streaming.assemblyai.com/v3/ws"
 
+# Held high so the semantic end-of-turn model can't auto-finalize mid-utterance
+# before our ForceEndpoint at speech-end (TTFS parity). Tune after a re-run.
+_END_OF_TURN_CONFIDENCE_THRESHOLD = 0.9
+
 
 class AssemblyAIProvider(STTProvider):
     """AssemblyAI v3 streaming STT provider."""
@@ -71,7 +75,10 @@ class AssemblyAIProvider(STTProvider):
 
         try:
             speech_model = _SPEECH_MODEL_MAP[self._model]
-            url = f"{_WS_BASE}?sample_rate={sample_rate}&speech_model={speech_model}"
+            url = (
+                f"{_WS_BASE}?sample_rate={sample_rate}&speech_model={speech_model}"
+                f"&end_of_turn_confidence_threshold={_END_OF_TURN_CONFIDENCE_THRESHOLD}"
+            )
             headers = {"Authorization": self._api_key.get_secret_value()}
             async with ws_client.connect(url, additional_headers=headers) as ws:
                 send_task = asyncio.create_task(
@@ -117,6 +124,8 @@ class AssemblyAIProvider(STTProvider):
                     first_chunk = False
                 await ws.send(chunk)
                 await asyncio.sleep(realtime_resolution)
+            # Force finalization at speech-end (TTFS parity) before terminating.
+            await ws.send(json.dumps({"type": "ForceEndpoint"}))
             await ws.send(json.dumps({"type": "Terminate"}))
         except Exception as exc:
             logger.exception("assemblyai send error", error=str(exc))

--- a/runner/src/coval_bench/providers/stt/assemblyai.py
+++ b/runner/src/coval_bench/providers/stt/assemblyai.py
@@ -12,6 +12,7 @@ Close: {"type": "Terminate"}
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 import time  # monotonic clock — wall-clock can step on NTP sync
 from typing import Any
@@ -32,9 +33,15 @@ _SPEECH_MODEL_MAP: dict[str, str] = {
 }
 _WS_BASE = "wss://streaming.assemblyai.com/v3/ws"
 
-# Held high so the semantic end-of-turn model can't auto-finalize mid-utterance
-# before our ForceEndpoint at speech-end (TTFS parity). Tune after a re-run.
-_END_OF_TURN_CONFIDENCE_THRESHOLD = 0.9
+# 1.0 = pure VAD silence-latency mode: the model never declares end-of-turn on a
+# semantic guess, only on our ForceEndpoint at speech-end (TTFS parity). A lower
+# value could let a confident short utterance auto-finalize before our signal.
+_END_OF_TURN_CONFIDENCE_THRESHOLD = 1.0
+
+# After ForceEndpoint, wait this long for the forced final before sending Terminate,
+# so the close never races the final (the WS close-gate bug class). Falls through on
+# timeout — the outer per-item timeout still bounds the run.
+_FINAL_WAIT_S = 5.0
 
 
 class AssemblyAIProvider(STTProvider):
@@ -80,6 +87,7 @@ class AssemblyAIProvider(STTProvider):
                 f"&end_of_turn_confidence_threshold={_END_OF_TURN_CONFIDENCE_THRESHOLD}"
             )
             headers = {"Authorization": self._api_key.get_secret_value()}
+            final_event = asyncio.Event()
             async with ws_client.connect(url, additional_headers=headers) as ws:
                 send_task = asyncio.create_task(
                     self._send_audio(
@@ -90,9 +98,10 @@ class AssemblyAIProvider(STTProvider):
                         sample_rate,
                         result,
                         realtime_resolution,
+                        final_event,
                     )
                 )
-                recv_task = asyncio.create_task(self._receive(ws, result))
+                recv_task = asyncio.create_task(self._receive(ws, result, final_event))
                 await asyncio.gather(send_task, recv_task, return_exceptions=True)
 
         except Exception as exc:
@@ -111,6 +120,7 @@ class AssemblyAIProvider(STTProvider):
         sample_rate: int,
         result: TranscriptionResult,
         realtime_resolution: float,
+        final_event: asyncio.Event,
     ) -> None:
         byte_rate = sample_width * sample_rate * channels
         data = audio_data
@@ -124,14 +134,19 @@ class AssemblyAIProvider(STTProvider):
                     first_chunk = False
                 await ws.send(chunk)
                 await asyncio.sleep(realtime_resolution)
-            # Force finalization at speech-end (TTFS parity) before terminating.
+            # Force finalization at speech-end (TTFS parity), then wait for the final
+            # before terminating so the close can't race it.
             await ws.send(json.dumps({"type": "ForceEndpoint"}))
+            with contextlib.suppress(TimeoutError):
+                await asyncio.wait_for(final_event.wait(), timeout=_FINAL_WAIT_S)
             await ws.send(json.dumps({"type": "Terminate"}))
         except Exception as exc:
             logger.exception("assemblyai send error", error=str(exc))
             raise
 
-    async def _receive(self, ws: Any, result: TranscriptionResult) -> None:
+    async def _receive(
+        self, ws: Any, result: TranscriptionResult, final_event: asyncio.Event
+    ) -> None:
         complete_turns: list[str] = []
         last_final_time: float | None = None
 
@@ -161,6 +176,7 @@ class AssemblyAIProvider(STTProvider):
                 if msg_type == "Turn" and msg.get("end_of_turn") and transcript:
                     complete_turns.append(transcript)
                     last_final_time = now
+                    final_event.set()
 
         except Exception as exc:
             logger.exception("assemblyai receive error", error=str(exc))

--- a/runner/src/coval_bench/providers/stt/assemblyai.py
+++ b/runner/src/coval_bench/providers/stt/assemblyai.py
@@ -135,7 +135,9 @@ class AssemblyAIProvider(STTProvider):
                 await ws.send(chunk)
                 await asyncio.sleep(realtime_resolution)
             # Force finalization at speech-end (TTFS parity), then wait for the final
-            # before terminating so the close can't race it.
+            # before terminating so the close can't race it. Clear first: the event may
+            # already be set by an earlier final, which would make the wait a no-op.
+            final_event.clear()
             await ws.send(json.dumps({"type": "ForceEndpoint"}))
             with contextlib.suppress(TimeoutError):
                 await asyncio.wait_for(final_event.wait(), timeout=_FINAL_WAIT_S)

--- a/runner/src/coval_bench/providers/stt/deepgram.py
+++ b/runner/src/coval_bench/providers/stt/deepgram.py
@@ -14,6 +14,7 @@ Close: {"type": "CloseStream"}
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 import time  # monotonic clock — wall-clock can step on NTP sync
 from typing import Any
@@ -25,6 +26,11 @@ from pydantic import SecretStr
 from coval_bench.providers.base import STTProvider, TranscriptionResult
 
 logger = structlog.get_logger(__name__)
+
+# After Finalize, wait this long for the forced final before sending CloseStream,
+# so the close can't race the final (the WS close-gate bug class). Falls through on
+# timeout — the outer per-item timeout still bounds the run.
+_FINAL_WAIT_S = 5.0
 
 
 class DeepgramProvider(STTProvider):
@@ -106,6 +112,7 @@ class DeepgramProvider(STTProvider):
             url = self._build_websocket_url(sample_rate, channels)
             headers = {"Authorization": f"Token {self._api_key.get_secret_value()}"}
 
+            final_event = asyncio.Event()
             async with ws_client.connect(url, additional_headers=headers) as ws:
                 send_task = asyncio.create_task(
                     self._send_audio(
@@ -116,9 +123,10 @@ class DeepgramProvider(STTProvider):
                         sample_rate,
                         result,
                         realtime_resolution,
+                        final_event,
                     )
                 )
-                recv_task = asyncio.create_task(self._receive(ws, result))
+                recv_task = asyncio.create_task(self._receive(ws, result, final_event))
                 await asyncio.gather(send_task, recv_task, return_exceptions=True)
 
         except Exception as exc:
@@ -141,6 +149,7 @@ class DeepgramProvider(STTProvider):
         sample_rate: int,
         result: TranscriptionResult,
         realtime_resolution: float,
+        final_event: asyncio.Event,
     ) -> None:
         byte_rate = sample_width * sample_rate * channels
         data = audio_data
@@ -154,10 +163,13 @@ class DeepgramProvider(STTProvider):
                     first_chunk = False
                 await ws.send(chunk)
                 await asyncio.sleep(realtime_resolution)
-            # nova finalizes on our signal (endpointing disabled); Flux has no
-            # Finalize and can't be forced, so it's left on its native EOT.
+            # nova finalizes on our signal (endpointing disabled): send Finalize, then
+            # wait for the forced final before closing so the close can't race it. Flux
+            # has no Finalize and can't be forced, so it's left on its native EOT.
             if not self._model.startswith("flux-"):
                 await ws.send(json.dumps({"type": "Finalize"}))
+                with contextlib.suppress(TimeoutError):
+                    await asyncio.wait_for(final_event.wait(), timeout=_FINAL_WAIT_S)
             await ws.send(json.dumps({"type": "CloseStream"}))
         except Exception as exc:
             logger.exception("deepgram send error", error=str(exc))
@@ -167,7 +179,9 @@ class DeepgramProvider(STTProvider):
     # Receive helpers
     # ------------------------------------------------------------------
 
-    async def _receive(self, ws: Any, result: TranscriptionResult) -> None:
+    async def _receive(
+        self, ws: Any, result: TranscriptionResult, final_event: asyncio.Event
+    ) -> None:
         final_segments: list[str] = []
         pending_partial: str = ""
         flux_turns: dict[int, str] = {}
@@ -243,6 +257,7 @@ class DeepgramProvider(STTProvider):
                     final_segments.append(transcript)
                     pending_partial = ""
                     last_final_time = now
+                    final_event.set()
                 else:
                     # Keep the longest interim as the not-yet-finalized tail.
                     if len(transcript) > len(pending_partial):

--- a/runner/src/coval_bench/providers/stt/deepgram.py
+++ b/runner/src/coval_bench/providers/stt/deepgram.py
@@ -167,6 +167,9 @@ class DeepgramProvider(STTProvider):
             # wait for the forced final before closing so the close can't race it. Flux
             # has no Finalize and can't be forced, so it's left on its native EOT.
             if not self._model.startswith("flux-"):
+                # Clear first: nova can emit an is_final segment mid-stream, which would
+                # leave the latch set and make the wait a no-op.
+                final_event.clear()
                 await ws.send(json.dumps({"type": "Finalize"}))
                 with contextlib.suppress(TimeoutError):
                     await asyncio.wait_for(final_event.wait(), timeout=_FINAL_WAIT_S)

--- a/runner/src/coval_bench/providers/stt/deepgram.py
+++ b/runner/src/coval_bench/providers/stt/deepgram.py
@@ -78,6 +78,9 @@ class DeepgramProvider(STTProvider):
             f"&vad_events=true"
             f"&no_delay=true"
             f"&punctuate=true"
+            # Disable native silence endpointing; we force the final at speech-end
+            # via a Finalize message instead (TTFS parity).
+            f"&endpointing=false"
         )
         if self._model != "default":
             url += f"&model={self._model}"
@@ -151,6 +154,10 @@ class DeepgramProvider(STTProvider):
                     first_chunk = False
                 await ws.send(chunk)
                 await asyncio.sleep(realtime_resolution)
+            # nova finalizes on our signal (endpointing disabled); Flux has no
+            # Finalize and can't be forced, so it's left on its native EOT.
+            if not self._model.startswith("flux-"):
+                await ws.send(json.dumps({"type": "Finalize"}))
             await ws.send(json.dumps({"type": "CloseStream"}))
         except Exception as exc:
             logger.exception("deepgram send error", error=str(exc))

--- a/runner/src/coval_bench/runner/orchestrator.py
+++ b/runner/src/coval_bench/runner/orchestrator.py
@@ -319,21 +319,25 @@ async def _run_stt_item(
         ttfs_status, ttfs_error = _metric_outcome(
             ttfs_value, item_error or ttfs_calc_error, "TTFS", ResultStatus
         )
-        results.append(
-            Result(
-                run_id=run_id,
-                provider=entry.provider,
-                model=entry.model,
-                benchmark=Benchmark.STT,
-                metric_type="TTFS",
-                metric_value=ttfs_value,
-                metric_units="seconds",
-                audio_filename=audio_path.name,
-                transcript=complete_transcript,
-                status=ttfs_status,
-                error=ttfs_error,
+        # Flux can't finalize on our signal (no Finalize, EOT can't be disabled), so it's
+        # outside the TTFS parity cohort. Other metrics still run; only the TTFS row is omitted.
+        ttfs_excluded = entry.provider == "deepgram" and entry.model.startswith("flux-")
+        if not ttfs_excluded:
+            results.append(
+                Result(
+                    run_id=run_id,
+                    provider=entry.provider,
+                    model=entry.model,
+                    benchmark=Benchmark.STT,
+                    metric_type="TTFS",
+                    metric_value=ttfs_value,
+                    metric_units="seconds",
+                    audio_filename=audio_path.name,
+                    transcript=complete_transcript,
+                    status=ttfs_status,
+                    error=ttfs_error,
+                )
             )
-        )
 
         # 3. RTF — derived from AudioToFinal, so its outcome tracks whether a final was
         # produced. A present final with an uncomputable RTF (e.g. zero duration) stays a

--- a/runner/tests/providers/stt/test_assemblyai.py
+++ b/runner/tests/providers/stt/test_assemblyai.py
@@ -78,11 +78,10 @@ def test_websocket_url_contains_required_params() -> None:
 
 
 @pytest.mark.asyncio
-async def test_force_endpoint_sent_before_terminate(
-    fake_api_key: SecretStr, audio_pcm_bytes: bytes
-) -> None:
+async def test_force_endpoint_sent_before_terminate(fake_api_key: SecretStr) -> None:
     sent: list[Any] = []
-    ws = FakeWebSocket([], on_send=sent.append)
+    final = {"type": "Turn", "end_of_turn": True, "transcript": "hello world"}
+    ws = FakeWebSocket([final], on_send=sent.append)
     cm = MagicMock()
     cm.__aenter__ = AsyncMock(return_value=ws)
     cm.__aexit__ = AsyncMock(return_value=False)
@@ -91,8 +90,8 @@ async def test_force_endpoint_sent_before_terminate(
     with patch(
         "coval_bench.providers.stt.assemblyai.ws_client.connect", return_value=cm
     ) as mock_connect:
-        await provider.measure_ttft(
-            audio_data=audio_pcm_bytes,
+        result = await provider.measure_ttft(
+            audio_data=b"\x00" * 640,
             channels=1,
             sample_width=2,
             sample_rate=16000,
@@ -100,11 +99,13 @@ async def test_force_endpoint_sent_before_terminate(
         )
 
     url = mock_connect.call_args.args[0]
-    assert "end_of_turn_confidence_threshold=" in url
+    assert "end_of_turn_confidence_threshold=1.0" in url
 
     text = [m for m in sent if isinstance(m, str)]
     assert '"ForceEndpoint"' in text[-2]
     assert '"Terminate"' in text[-1]
+    # The forced final is captured before the close (gate + response-capture path).
+    assert result.audio_to_final_seconds is not None
 
 
 # ---------------------------------------------------------------------------

--- a/runner/tests/providers/stt/test_assemblyai.py
+++ b/runner/tests/providers/stt/test_assemblyai.py
@@ -78,7 +78,10 @@ def test_websocket_url_contains_required_params() -> None:
 
 
 @pytest.mark.asyncio
-async def test_force_endpoint_sent_before_terminate(fake_api_key: SecretStr) -> None:
+async def test_force_endpoint_sent_before_terminate(
+    fake_api_key: SecretStr, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr("coval_bench.providers.stt.assemblyai._FINAL_WAIT_S", 0.05)
     sent: list[Any] = []
     final = {"type": "Turn", "end_of_turn": True, "transcript": "hello world"}
     ws = FakeWebSocket([final], on_send=sent.append)

--- a/runner/tests/providers/stt/test_assemblyai.py
+++ b/runner/tests/providers/stt/test_assemblyai.py
@@ -77,6 +77,36 @@ def test_websocket_url_contains_required_params() -> None:
         assert "format_turns" not in api_name
 
 
+@pytest.mark.asyncio
+async def test_force_endpoint_sent_before_terminate(
+    fake_api_key: SecretStr, audio_pcm_bytes: bytes
+) -> None:
+    sent: list[Any] = []
+    ws = FakeWebSocket([], on_send=sent.append)
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=ws)
+    cm.__aexit__ = AsyncMock(return_value=False)
+    provider = AssemblyAIProvider(api_key=fake_api_key)
+
+    with patch(
+        "coval_bench.providers.stt.assemblyai.ws_client.connect", return_value=cm
+    ) as mock_connect:
+        await provider.measure_ttft(
+            audio_data=audio_pcm_bytes,
+            channels=1,
+            sample_width=2,
+            sample_rate=16000,
+            realtime_resolution=0.01,
+        )
+
+    url = mock_connect.call_args.args[0]
+    assert "end_of_turn_confidence_threshold=" in url
+
+    text = [m for m in sent if isinstance(m, str)]
+    assert '"ForceEndpoint"' in text[-2]
+    assert '"Terminate"' in text[-1]
+
+
 # ---------------------------------------------------------------------------
 # Provider name
 # ---------------------------------------------------------------------------

--- a/runner/tests/providers/stt/test_deepgram.py
+++ b/runner/tests/providers/stt/test_deepgram.py
@@ -126,19 +126,22 @@ def test_build_websocket_url_flux() -> None:
 
 
 @pytest.mark.asyncio
-async def test_nova_sends_finalize_before_close(
-    fake_api_key: SecretStr, audio_pcm_bytes: bytes
-) -> None:
+async def test_nova_sends_finalize_before_close(fake_api_key: SecretStr) -> None:
     sent: list[Any] = []
-    ws = FakeWebSocket([], on_send=sent.append)
+    final = {
+        "type": "Results",
+        "is_final": True,
+        "channel": {"alternatives": [{"transcript": "hello"}]},
+    }
+    ws = FakeWebSocket([final], on_send=sent.append)
     cm = MagicMock()
     cm.__aenter__ = AsyncMock(return_value=ws)
     cm.__aexit__ = AsyncMock(return_value=False)
     provider = DeepgramProvider(api_key=fake_api_key, model="nova-3")
 
     with patch("coval_bench.providers.stt.deepgram.ws_client.connect", return_value=cm):
-        await provider.measure_ttft(
-            audio_data=audio_pcm_bytes,
+        result = await provider.measure_ttft(
+            audio_data=b"\x00" * 640,
             channels=1,
             sample_width=2,
             sample_rate=16000,
@@ -148,6 +151,8 @@ async def test_nova_sends_finalize_before_close(
     text = [m for m in sent if isinstance(m, str)]
     assert '"Finalize"' in text[-2]
     assert '"CloseStream"' in text[-1]
+    # The forced final is captured before the close (gate + response-capture path).
+    assert result.audio_to_final_seconds is not None
 
 
 @pytest.mark.asyncio

--- a/runner/tests/providers/stt/test_deepgram.py
+++ b/runner/tests/providers/stt/test_deepgram.py
@@ -106,6 +106,8 @@ def test_build_websocket_url_nova3() -> None:
     url = p._build_websocket_url(16000, 1)
     assert "nova-3" in url
     assert "api.deepgram.com" in url
+    # Native silence endpointing disabled; we force the final via Finalize (TTFS parity).
+    assert "endpointing=false" in url
 
 
 def test_build_websocket_url_flux() -> None:
@@ -119,6 +121,56 @@ def test_build_websocket_url_flux() -> None:
     assert "interim_results" not in url
     assert "no_delay" not in url
     assert "channels" not in url
+    # endpointing is a v1-only param and Flux can't be forced anyway.
+    assert "endpointing" not in url
+
+
+@pytest.mark.asyncio
+async def test_nova_sends_finalize_before_close(
+    fake_api_key: SecretStr, audio_pcm_bytes: bytes
+) -> None:
+    sent: list[Any] = []
+    ws = FakeWebSocket([], on_send=sent.append)
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=ws)
+    cm.__aexit__ = AsyncMock(return_value=False)
+    provider = DeepgramProvider(api_key=fake_api_key, model="nova-3")
+
+    with patch("coval_bench.providers.stt.deepgram.ws_client.connect", return_value=cm):
+        await provider.measure_ttft(
+            audio_data=audio_pcm_bytes,
+            channels=1,
+            sample_width=2,
+            sample_rate=16000,
+            realtime_resolution=0.01,
+        )
+
+    text = [m for m in sent if isinstance(m, str)]
+    assert '"Finalize"' in text[-2]
+    assert '"CloseStream"' in text[-1]
+
+
+@pytest.mark.asyncio
+async def test_flux_does_not_send_finalize(fake_api_key: SecretStr, audio_pcm_bytes: bytes) -> None:
+    sent: list[Any] = []
+    ws = FakeWebSocket([], on_send=sent.append)
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=ws)
+    cm.__aexit__ = AsyncMock(return_value=False)
+    provider = DeepgramProvider(api_key=fake_api_key, model="flux-general-en")
+
+    with patch("coval_bench.providers.stt.deepgram.ws_client.connect", return_value=cm):
+        await provider.measure_ttft(
+            audio_data=audio_pcm_bytes,
+            channels=1,
+            sample_width=2,
+            sample_rate=16000,
+            realtime_resolution=0.01,
+        )
+
+    text = [m for m in sent if isinstance(m, str)]
+    assert not any("Finalize" in m for m in text)
+    assert '"CloseStream"' in text[-1]
 
 
 def test_build_websocket_url_flux_rejects_non_mono() -> None:

--- a/runner/tests/providers/stt/test_deepgram.py
+++ b/runner/tests/providers/stt/test_deepgram.py
@@ -126,7 +126,10 @@ def test_build_websocket_url_flux() -> None:
 
 
 @pytest.mark.asyncio
-async def test_nova_sends_finalize_before_close(fake_api_key: SecretStr) -> None:
+async def test_nova_sends_finalize_before_close(
+    fake_api_key: SecretStr, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr("coval_bench.providers.stt.deepgram._FINAL_WAIT_S", 0.05)
     sent: list[Any] = []
     final = {
         "type": "Results",

--- a/runner/tests/unit/test_orchestrator.py
+++ b/runner/tests/unit/test_orchestrator.py
@@ -379,6 +379,44 @@ async def test_full_failure(audio_file: Path, settings: Settings) -> None:
     assert all("always fails" in (r.error or "") for r in rows)
 
 
+@pytest.mark.asyncio
+async def test_flux_excluded_from_ttfs(audio_file: Path, settings: Settings) -> None:
+    """Deepgram Flux is outside the TTFS parity cohort → no TTFS row, other metrics stay."""
+    from coval_bench.runner.config import DEFAULT_STT_MATRIX
+
+    provider = MagicMock()
+    provider.measure_ttft = AsyncMock(return_value=_good_transcription())
+    stt_providers = {"deepgram": MagicMock(return_value=provider)}
+    matrix = [
+        *[
+            ProviderEntry(provider=e.provider, model=e.model, voice=e.voice, enabled=False)
+            for e in DEFAULT_STT_MATRIX
+        ],
+        ProviderEntry(provider="deepgram", model="flux-general-en", enabled=True),
+    ]
+
+    run = _make_run()
+    writer = _make_stub_writer(run)
+
+    async with _orchestrator_env(
+        audio_path=audio_file,
+        stt_items=[_make_dataset_item(audio_file)],
+        stt_providers=stt_providers,
+        run=run,
+        writer=writer,
+    ) as _:
+        await run_benchmarks(
+            settings=settings,
+            benchmark_kind="stt",
+            smoke=True,
+            matrix_overrides=matrix,
+        )
+
+    metric_types = {r.metric_type for r in _recorded_rows(writer)}
+    assert "TTFS" not in metric_types
+    assert metric_types == {"TTFT", "AudioToFinal", "RTF", "WER"}
+
+
 # ---------------------------------------------------------------------------
 # 4. test_retry_succeeds_on_third_attempt
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
AssemblyAI sends ForceEndpoint before Terminate (with a high end_of_turn_confidence_threshold), and nova disables native endpointing and sends Finalize before CloseStream, so both finalize on the shared VAD end-of-speech signal rather than their own turn decision. Flux can't be forced, so it's excluded from the TTFS cohort and emits no TTFS row.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved speech-to-text streaming reliability with deterministic close semantics and more accurate timing measurements
  * Enhanced end-of-turn detection and turn finalization handling across providers
  * Optimized metrics calculations for specific model variants

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds deterministic end-of-speech finalization for AssemblyAI and Deepgram nova models, ensuring both providers emit their final transcript on the VAD end-of-speech signal (ForceEndpoint / Finalize) rather than their own latency-variable turn decisions, aligning them in the TTFS parity cohort. Deepgram Flux is explicitly excluded from the TTFS metric because it offers no way to disable or override its native end-of-turn detection.

- **AssemblyAI**: URL now includes `end_of_turn_confidence_threshold=1.0` (disables semantic auto-finalization), `_send_audio` sends `ForceEndpoint` then waits up to `_FINAL_WAIT_S` for the `Turn(end_of_turn=True)` response before sending `Terminate`, preventing the WS-close race on the final.
- **Deepgram nova**: `endpointing=false` is added to the v1/listen URL for all non-Flux models, `_send_audio` sends `Finalize` then waits for the forced `is_final` before sending `CloseStream`; Flux skips the Finalize block entirely and the orchestrator omits its TTFS row.
- New `asyncio.Event` gate mechanism shared between `_send_audio` and `_receive` in both providers replaces the previous fire-and-forget close pattern.

<h3>Confidence Score: 5/5</h3>

Safe to merge. The gate mechanism is well-designed, the Flux exclusion is clearly scoped, and the tests cover the critical message-ordering invariants.

The changes add a deterministic close sequence to two providers and a targeted TTFS exclusion in the orchestrator. All three code paths are exercised by new tests, the asyncio.Event gate is correctly initialised and cleared before each forced-final cycle, and no existing metric rows or test assertions are broken. The concerns already noted in the PR thread (server FIFO assumption, FakeWebSocket timing in new tests, and the flux- prefix duplication) are the ceiling on confidence, but none represents a definite defect in the changed paths.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| runner/src/coval_bench/providers/stt/assemblyai.py | Adds ForceEndpoint + asyncio.Event gate before Terminate; end_of_turn_confidence_threshold=1.0 in URL disables semantic auto-finalization; logic is sound, gate clear-before-send pattern is correct for cooperative asyncio. |
| runner/src/coval_bench/providers/stt/deepgram.py | Adds endpointing=false to all non-Flux v1/listen URLs and a Finalize + asyncio.Event gate before CloseStream; Flux send path unchanged; final_event.set() only in the is_final branch, not in TurnInfo/Flux path — correctly aligned with how _send_audio uses the gate. |
| runner/src/coval_bench/runner/orchestrator.py | Adds Flux TTFS exclusion guard; ttfs_value is still computed (no harm) but the Result row is not appended; existing TTFT/AudioToFinal/RTF/WER rows are unaffected. |
| runner/tests/providers/stt/test_assemblyai.py | New test verifies ForceEndpoint precedes Terminate, URL contains threshold param, and audio_to_final_seconds is set; coverage of the gate mechanism is present but the test's final event fires before ForceEndpoint (FakeWebSocket timing), so it primarily validates message ordering rather than end-to-end gate behavior. |
| runner/tests/providers/stt/test_deepgram.py | New tests cover nova Finalize-before-CloseStream ordering, Flux no-Finalize invariant, and endpointing=false in URLs; similar FakeWebSocket timing caveats as AssemblyAI test; endpointing=false is not asserted for default/nova-2 URL (only nova-3). |
| runner/tests/unit/test_orchestrator.py | New test_flux_excluded_from_ttfs correctly validates that TTFS row is absent and TTFT/AudioToFinal/RTF/WER remain; fixture setup with transcript reference ensures WER assertion is sound. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant SA as _send_audio
    participant WS as WebSocket
    participant SRV as Provider Server
    participant RCV as _receive

    Note over SA,RCV: Shared asyncio.Event: final_event

    SA->>WS: audio chunks 1..N
    WS->>SRV: audio chunks
    SRV-->>WS: partial and is_final responses
    WS-->>RCV: messages
    RCV->>RCV: updates last_final_time

    SA->>SA: final_event.clear()
    SA->>WS: ForceEndpoint or Finalize
    WS->>SRV: ForceEndpoint or Finalize
    SRV-->>WS: "Turn(end_of_turn=True) or is_final"
    WS-->>RCV: forced final
    RCV->>RCV: "last_final_time = now"
    RCV->>RCV: final_event.set()

    SA->>SA: "wait_for(final_event, timeout=5s)"
    SA->>WS: Terminate or CloseStream
    WS->>SRV: close

    Note over RCV: audio_to_final_seconds computed from last_final_time
```

<sub>Reviews (3): Last reviewed commit: ["Reset the final-wait event before forcin..."](https://github.com/coval-ai/benchmarks/commit/afc26cb92bef1e1cf37b157f2e35308281f3751a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36601570)</sub>

<!-- /greptile_comment -->