### PR TITLE
Add View results button to reopen playground metrics

### DIFF
--- a/web/app/playground/components/playground-draft/STTPlaygroundPanel.tsx
+++ b/web/app/playground/components/playground-draft/STTPlaygroundPanel.tsx
@@ -684,6 +684,16 @@ export function STTPlaygroundPanel({
             Hold Enter to record, release to stop (when focus isn&apos;t in a control) · Ranking by first recognized word after upload (not live TTFT)
           </p>
         </div>
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+        {phase === "complete" && leaderRows.length > 0 ? (
+          <button
+            type="button"
+            onClick={() => setLeaderOpen(true)}
+            className="inline-flex items-center justify-center gap-2 self-stretch rounded-full border border-border-primary px-5 py-2.5 text-sm font-medium text-text-primary transition-colors hover:bg-hover-bg sm:self-auto"
+          >
+            View results
+          </button>
+        ) : null}
         <button
           type="button"
           onClick={handleRecord}
@@ -720,6 +730,7 @@ export function STTPlaygroundPanel({
                 ? "New take"
                 : "Record"}
         </button>
+        </div>
       </div>
 
       {leaderOpen && leaderRows.length > 0 && portalRoot

--- a/web/app/playground/components/playground-draft/STTPlaygroundPanel.tsx
+++ b/web/app/playground/components/playground-draft/STTPlaygroundPanel.tsx
@@ -685,51 +685,51 @@ export function STTPlaygroundPanel({
           </p>
         </div>
         <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
-        {phase === "complete" && leaderRows.length > 0 ? (
+          {phase === "complete" && leaderRows.length > 0 ? (
+            <button
+              type="button"
+              onClick={() => setLeaderOpen(true)}
+              className="inline-flex items-center justify-center gap-2 self-stretch rounded-full border border-border-primary px-5 py-2.5 text-sm font-medium text-text-primary transition-colors hover:bg-hover-bg focus-visible:ring-2 focus-visible:ring-text-tertiary/30 sm:self-auto"
+            >
+              View results
+            </button>
+          ) : null}
           <button
             type="button"
-            onClick={() => setLeaderOpen(true)}
-            className="inline-flex items-center justify-center gap-2 self-stretch rounded-full border border-border-primary px-5 py-2.5 text-sm font-medium text-text-primary transition-colors hover:bg-hover-bg sm:self-auto"
+            onClick={handleRecord}
+            disabled={
+              ((phase === "idle" || phase === "complete" || phase === "error") &&
+                !canStartOrRetakeRecording) ||
+              phase === "submitting"
+            }
+            title={
+              (phase === "idle" || phase === "complete") && !canStartOrRetakeRecording
+                ? "Turn on at least one model to record a comparison."
+                : "Hold Enter to record, release to stop when focus is outside buttons and fields"
+            }
+            className={`inline-flex items-center justify-center gap-2 self-stretch rounded-full border px-5 py-2.5 text-sm font-medium transition-colors sm:self-auto ${
+              ((phase === "idle" || phase === "complete" || phase === "error") &&
+                !canStartOrRetakeRecording) ||
+              phase === "submitting"
+                ? "cursor-not-allowed border-border-primary text-text-tertiary opacity-60"
+                : "border-border-primary text-text-primary hover:bg-hover-bg"
+            }`}
           >
-            View results
+            {phase === "recording" ? (
+              <span className="relative flex size-2.5 shrink-0 items-center justify-center">
+                <span className="absolute size-2.5 animate-pulse rounded-full bg-red-500" />
+              </span>
+            ) : (
+              <Mic className="size-4 shrink-0 text-text-secondary" aria-hidden />
+            )}
+            {phase === "recording"
+              ? "Stop"
+              : phase === "submitting"
+                ? "Transcribing…"
+                : phase === "complete"
+                  ? "New take"
+                  : "Record"}
           </button>
-        ) : null}
-        <button
-          type="button"
-          onClick={handleRecord}
-          disabled={
-            ((phase === "idle" || phase === "complete" || phase === "error") &&
-              !canStartOrRetakeRecording) ||
-            phase === "submitting"
-          }
-          title={
-            (phase === "idle" || phase === "complete") && !canStartOrRetakeRecording
-              ? "Turn on at least one model to record a comparison."
-              : "Hold Enter to record, release to stop when focus is outside buttons and fields"
-          }
-          className={`inline-flex items-center justify-center gap-2 self-stretch rounded-full border px-5 py-2.5 text-sm font-medium transition-colors sm:self-auto ${
-            ((phase === "idle" || phase === "complete" || phase === "error") &&
-              !canStartOrRetakeRecording) ||
-            phase === "submitting"
-              ? "cursor-not-allowed border-border-primary text-text-tertiary opacity-60"
-              : "border-border-primary text-text-primary hover:bg-hover-bg"
-          }`}
-        >
-          {phase === "recording" ? (
-            <span className="relative flex size-2.5 shrink-0 items-center justify-center">
-              <span className="absolute size-2.5 animate-pulse rounded-full bg-red-500" />
-            </span>
-          ) : (
-            <Mic className="size-4 shrink-0 text-text-secondary" aria-hidden />
-          )}
-          {phase === "recording"
-            ? "Stop"
-            : phase === "submitting"
-              ? "Transcribing…"
-              : phase === "complete"
-                ? "New take"
-                : "Record"}
-        </button>
         </div>
       </div>
 

--- a/web/app/playground/components/playground-draft/TTSPlaygroundPanel.tsx
+++ b/web/app/playground/components/playground-draft/TTSPlaygroundPanel.tsx
@@ -410,6 +410,16 @@ export function TTSPlaygroundPanel({
             ))}
           </div>
         </div>
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+        {rows.length > 0 && !hasInFlight ? (
+          <button
+            type="button"
+            onClick={() => setBenchmarkOpen(true)}
+            className="inline-flex items-center justify-center gap-2 self-stretch rounded-full border border-border-primary px-5 py-2.5 text-sm font-medium text-text-primary transition-colors hover:bg-hover-bg sm:self-auto"
+          >
+            View results
+          </button>
+        ) : null}
         <button
           type="button"
           disabled={!canBenchmark || hasInFlight}
@@ -424,6 +434,7 @@ export function TTSPlaygroundPanel({
           <Play className="size-4 shrink-0" aria-hidden />
           Benchmark
         </button>
+        </div>
       </div>
 
       {benchmarkOpen && portalRoot

--- a/web/app/playground/components/playground-draft/TTSPlaygroundPanel.tsx
+++ b/web/app/playground/components/playground-draft/TTSPlaygroundPanel.tsx
@@ -411,29 +411,29 @@ export function TTSPlaygroundPanel({
           </div>
         </div>
         <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
-        {rows.length > 0 && !hasInFlight ? (
+          {rows.length > 0 && !hasInFlight ? (
+            <button
+              type="button"
+              onClick={() => setBenchmarkOpen(true)}
+              className="inline-flex items-center justify-center gap-2 self-stretch rounded-full border border-border-primary px-5 py-2.5 text-sm font-medium text-text-primary transition-colors hover:bg-hover-bg focus-visible:ring-2 focus-visible:ring-text-tertiary/30 sm:self-auto"
+            >
+              View results
+            </button>
+          ) : null}
           <button
             type="button"
-            onClick={() => setBenchmarkOpen(true)}
-            className="inline-flex items-center justify-center gap-2 self-stretch rounded-full border border-border-primary px-5 py-2.5 text-sm font-medium text-text-primary transition-colors hover:bg-hover-bg sm:self-auto"
+            disabled={!canBenchmark || hasInFlight}
+            onClick={handleBenchmarkButtonClick}
+            title={
+              canBenchmark
+                ? "Enter runs benchmark when focus is outside fields, or ⌘/Ctrl+Enter from the text box"
+                : undefined
+            }
+            className="inline-flex items-center justify-center gap-2 self-stretch rounded-full border border-border-primary px-5 py-2.5 text-sm font-medium text-text-primary transition-colors hover:bg-hover-bg disabled:cursor-not-allowed disabled:opacity-40 sm:self-auto"
           >
-            View results
+            <Play className="size-4 shrink-0" aria-hidden />
+            Benchmark
           </button>
-        ) : null}
-        <button
-          type="button"
-          disabled={!canBenchmark || hasInFlight}
-          onClick={handleBenchmarkButtonClick}
-          title={
-            canBenchmark
-              ? "Enter runs benchmark when focus is outside fields, or ⌘/Ctrl+Enter from the text box"
-              : undefined
-          }
-          className="inline-flex items-center justify-center gap-2 self-stretch rounded-full border border-border-primary px-5 py-2.5 text-sm font-medium text-text-primary transition-colors hover:bg-hover-bg disabled:cursor-not-allowed disabled:opacity-40 sm:self-auto"
-        >
-          <Play className="size-4 shrink-0" aria-hidden />
-          Benchmark
-        </button>
         </div>
       </div>
 

--- a/web/app/playground/components/playground-draft/TTSPlaygroundPanel.tsx
+++ b/web/app/playground/components/playground-draft/TTSPlaygroundPanel.tsx
@@ -411,7 +411,7 @@ export function TTSPlaygroundPanel({
           </div>
         </div>
         <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
-          {rows.length > 0 && !hasInFlight ? (
+          {Object.keys(generationRows).length > 0 && !hasInFlight ? (
             <button
               type="button"
               onClick={() => setBenchmarkOpen(true)}


### PR DESCRIPTION
## Summary
- The playground showed metrics in a modal that could never be reopened once closed, even though the results stayed in state. Both panels now show a **View results** button next to the record/benchmark button whenever a completed run has rows, which reopens the modal.
- STT gates on `phase === "complete" && leaderRows.length > 0`; TTS gates on `rows.length > 0 && !hasInFlight`. Styling matches the adjacent pill buttons.

## Testing
- `tsc --noEmit`: no errors in the touched files (pre-existing codegen-schema errors elsewhere are unrelated)
- `eslint` clean on both files
- `pnpm test`: 32/32 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * STT playground footer now shows a "View results" button when benchmarking is complete and results exist; opens the leaderboard overlay.
  * TTS playground footer now shows a "View results" button when benchmark results exist and no request is in progress; opens the benchmark results overlay.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a "View results" button next to the existing record/benchmark button in both the STT and TTS playground panels, allowing users to reopen the results modal after dismissing it. Previously, once the results modal was closed there was no way to get it back without running a new benchmark.

- **STT**: wraps the record button in a flex container and conditionally renders \"View results\" when `phase === \"complete\" && leaderRows.length > 0`, calling `setLeaderOpen(true)` on click.
- **TTS**: uses `Object.keys(generationRows).length > 0 && !hasInFlight` as the gate (note: the PR description mentions `rows.length > 0` but the actual code correctly uses the raw `generationRows` object, which captures error-only runs as well), calling `setBenchmarkOpen(true)` on click.

<h3>Confidence Score: 5/5</h3>

Small, focused UI addition with no changes to data fetching, state initialisation, or modal close logic.

Both buttons only set an already-existing boolean state to true, reusing the exact same modal portal that auto-opens today. The gating conditions are conservative and consistent with the surrounding conditional renders. No new side effects are introduced.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| web/app/playground/components/playground-draft/STTPlaygroundPanel.tsx | Wraps the record button in a flex container and adds a conditional "View results" button gated on `phase === "complete" && leaderRows.length > 0`. Logic is consistent with the existing leaderboard portal condition. |
| web/app/playground/components/playground-draft/TTSPlaygroundPanel.tsx | Wraps the benchmark button in a flex container and adds a conditional "View results" button gated on `Object.keys(generationRows).length > 0 && !hasInFlight`. Using the raw `generationRows` (not the filtered `rows` memo) means error-only runs also get the reopen affordance. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph STT["STT Playground"]
        S1{phase === complete AND leaderRows.length > 0?}
        S1 -->|Yes| S2[Show 'View results' button]
        S1 -->|No| S3[Hide button]
        S2 -->|Click| S4[setLeaderOpen true → modal reopens]
    end

    subgraph TTS["TTS Playground"]
        T1{Object.keys generationRows .length > 0 AND NOT hasInFlight?}
        T1 -->|Yes| T2[Show 'View results' button]
        T1 -->|No| T3[Hide button]
        T2 -->|Click| T4[setBenchmarkOpen true → modal reopens]
    end
```

<sub>Reviews (3): Last reviewed commit: ["Show TTS View results button after all-f..."](https://github.com/coval-ai/benchmarks/commit/619d0e7f32fa24a64a05c9c4d3d47f335930f85e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36815160)</sub>

<!-- /greptile_comment -->