### PR TITLE
fix(providers/stt): correct xAI WER measurement

### DIFF
--- a/runner/src/coval_bench/providers/stt/xai.py
+++ b/runner/src/coval_bench/providers/stt/xai.py
@@ -54,7 +54,7 @@ class XaiSTTProvider(STTProvider):
             "interim_results": "true",
             "endpointing": 200,
             "language": "en",
-            "filler_words": "false",
+            "filler_words": "true",
             "diarize": "false",
         }
         return f"{_BASE_WS_URL}?{urlencode(params)}"

--- a/runner/src/coval_bench/providers/stt/xai.py
+++ b/runner/src/coval_bench/providers/stt/xai.py
@@ -159,8 +159,14 @@ class XaiSTTProvider(STTProvider):
     async def _receive(
         self, ws: Any, result: TranscriptionResult, final_event: asyncio.Event
     ) -> None:
-        # xAI is_final=True partials are cumulative restarts, not segments to join.
-        last_final_text: str | None = None
+        # With endpointing enabled, xAI restarts the transcript at each endpoint:
+        # every speech segment is closed exactly once by a speech_final=true
+        # partial, and transcript.done carries only text not yet closed by a
+        # speech_final (empty when the last segment was already closed). The
+        # full utterance is the in-order join of speech_final segments plus any
+        # trailing done text. is_final=true/speech_final=false events are
+        # interim duplicates of the segment and must NOT be joined.
+        final_segments: list[str] = []
         done_transcript: str | None = None
         last_final_time: float | None = None
         done_received = False
@@ -181,8 +187,8 @@ class XaiSTTProvider(STTProvider):
 
                     set_first_token(result, transcript, now=now)
                     add_partial_transcript(result, transcript)
-                    if event.get("is_final"):
-                        last_final_text = transcript
+                    if event.get("speech_final"):
+                        final_segments.append(transcript)
                         if result.audio_start_time is not None:
                             last_final_time = now
                     continue
@@ -193,6 +199,7 @@ class XaiSTTProvider(STTProvider):
                     if done_transcript:
                         set_first_token(result, done_transcript, now=now)
                         add_partial_transcript(result, done_transcript)
+                        final_segments.append(done_transcript)
                     if result.audio_start_time is not None:
                         last_final_time = now
                     break
@@ -217,7 +224,6 @@ class XaiSTTProvider(STTProvider):
 
         finalize_transcript(
             result,
-            # transcript.done text is authoritative when present; otherwise use the last is_final.
-            explicit_transcript=done_transcript or last_final_text,
+            final_segments=final_segments,
             partial_fallback="longest",
         )


### PR DESCRIPTION
Fixes xAI STT transcript assembly so WER is scored on the full utterance.

With `endpointing` enabled, xAI closes each speech segment exactly once with a `speech_final=true` partial; `transcript.done` carries only text not yet closed (often empty). The provider previously used the `done` text (falling back to the last `is_final` partial), so utterances with mid-speech pauses were scored on their final segment only.

**Updated logic:** the hypothesis is the in-order join of `speech_final=true` segments, plus trailing non-empty `transcript.done` text. `is_final=true / speech_final=false` events are interim duplicates of an open segment and are excluded. Unchanged: error when the stream ends without `transcript.done`, longest-partial fallback, TTFT logic.

Filler words are included in the truth transcripts and xAI defaults to filler_words=false so enabling filler words to match the eval expected format.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes transcript assembly for multi-segment xAI utterances by collecting `speech_final=true` partials in order and joining them, replacing the old strategy of using only the last `is_final=true` partial or `transcript.done` text, which caused 5/50 utterances to be scored against only their final endpoint segment.

- **Core fix** (`_receive`): `last_final_text` replaced with `final_segments: list[str]`; only `speech_final=true` events and non-empty `transcript.done` text are collected, then passed to the existing `finalize_transcript(final_segments=...)` helper for space-joined assembly.
- **Undocumented API change**: `filler_words` is silently flipped from `"false"` to `"true"` in `_build_websocket_url`, which alters transcription output independently of the assembly fix and is not discussed in the PR description or validation numbers.
- **Test coverage gap**: The multi-segment join path (two or more `speech_final=true` events before an empty `done`) is the root cause of the bug but has no corresponding fixture in the test suite.

<h3>Confidence Score: 4/5</h3>

Safe to merge once the filler_words change is confirmed intentional and documented; the assembly fix itself is correct and well-reasoned.

The transcript assembly change is logically sound and matches the described xAI protocol. However, filler_words is quietly flipped from false to true with no explanation — this modifies the raw API output that feeds directly into WER computation. If reference transcripts omit filler words, every filler token becomes an insertion error, and the before/after WER numbers conflate the assembly fix with this change.

runner/src/coval_bench/providers/stt/xai.py — specifically the filler_words parameter change on line 57.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| runner/src/coval_bench/providers/stt/xai.py | Core transcript assembly rewritten to join speech_final=true segments; also silently flips filler_words from "false" to "true", an undocumented behavioral change that can inflate WER on runs where reference transcripts omit filler words. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant A as Audio Sender
    participant WS as xAI WebSocket
    participant R as _receive()
    participant FS as final_segments[]

    A->>WS: audio chunks (streaming)
    WS-->>R: transcript.created
    WS-->>R: "transcript.partial (is_final=false, speech_final=false)"
    Note over R: set_first_token / add_partial
    WS-->>R: "transcript.partial (is_final=true, speech_final=false)"
    Note over R: interim duplicate - skip
    WS-->>R: "transcript.partial (is_final=true, speech_final=true) [seg 1]"
    R->>FS: append(segment 1)
    WS-->>R: "transcript.partial (is_final=true, speech_final=true) [seg 2]"
    R->>FS: append(segment 2)
    WS-->>R: "transcript.partial (is_final=true, speech_final=true) [seg 3]"
    R->>FS: append(segment 3)
    A->>WS: audio.done
    WS-->>R: "transcript.done (text=empty)"
    R->>R: "finalize_transcript(final_segments=[seg1, seg2, seg3])"
```

<sub>Reviews (2): Last reviewed commit: ["fix(providers/stt): enable filler\_words ..."](https://github.com/coval-ai/benchmarks/commit/a9c86c72cb7a1d3b9d1899b4ed9d5715a392a6af) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36910103)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->