### PR TITLE
Disable Grok STT in the benchmark

### DIFF
--- a/runner/src/coval_bench/runner/config.py
+++ b/runner/src/coval_bench/runner/config.py
@@ -44,7 +44,7 @@ DEFAULT_STT_MATRIX: list[ProviderEntry] = [
     ProviderEntry(provider="speechmatics", model="default", enabled=True),
     ProviderEntry(provider="speechmatics", model="enhanced", enabled=True),
     ProviderEntry(provider="gradium", model="default", enabled=True),
-    ProviderEntry(provider="xai", model="grok-stt", enabled=True),
+    ProviderEntry(provider="xai", model="grok-stt", enabled=False, disabled=True),
     ProviderEntry(provider="smallest", model="pulse", enabled=True),
     ProviderEntry(provider="cartesia", model="ink-2", enabled=True),
     # OFF; disabled=True hides these from the public catalogue.

--- a/runner/tests/api/test_providers.py
+++ b/runner/tests/api/test_providers.py
@@ -54,9 +54,10 @@ async def test_disabled_flag_exposed(client: AsyncClient) -> None:
     nova_3 = next(m for m in deepgram_entry["models"] if m["model"] == "nova-3")
     assert nova_3["disabled"] is False
 
+    # xai grok-stt is disabled in the matrix
     xai_entry = next(e for e in data["stt"] if e["provider"] == "xai")
     grok_stt = next(m for m in xai_entry["models"] if m["model"] == "grok-stt")
-    assert grok_stt["disabled"] is False
+    assert grok_stt["disabled"] is True
 
 
 async def test_response_shape_breaking_change(client: AsyncClient) -> None:


### PR DESCRIPTION
Turns off the xAI Grok STT entry in the runner's STT matrix: `enabled=True` → `enabled=False, disabled=True`.

- Runner stops benchmarking `xai/grok-stt`.
- `/v1/providers` reports it with `disabled=true`, so the dashboard filters its result rows out at runtime (`modelsFromResults.ts`) — no web redeploy needed.

Same pattern already used for the Google and Cartesia STT entries. Takes effect in prod once merged to main (release pipeline rebuilds the API image and rolls Cloud Run).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * The `xai/grok-stt` speech-to-text provider model has been disabled and is no longer available for selection in the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR disables the `xai/grok-stt` STT provider by setting `enabled=False, disabled=True` in the runner matrix, following the same pattern used for Google and Cartesia STT entries. The test suite is updated to assert that `grok-stt` now reports `disabled: true` through the `/v1/providers` endpoint.

- **`config.py`**: Single-line change flips `xai/grok-stt` from `enabled=True` to `enabled=False, disabled=True`, immediately stopping the runner from benchmarking that model and hiding it from the public catalogue.
- **`test_providers.py`**: Updates the `test_disabled_flag_exposed` assertion from `disabled is False` to `disabled is True` to match the new config state.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a one-line config toggle with a matching test update, using the same disable pattern already proven by multiple other entries in the matrix.

The change touches only the provider matrix config and its corresponding test. Both sides of the change are consistent and correct: the runner will stop benchmarking xai/grok-stt, and the /v1/providers endpoint will report it as disabled so the dashboard filters it out. No logic, schema, or API contract is altered.

No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| runner/src/coval_bench/runner/config.py | Disables `xai/grok-stt` by setting `enabled=False, disabled=True`; functionally correct but entry sits above the `# OFF` comment while all other disabled entries are below it. |
| runner/tests/api/test_providers.py | Test assertion flipped from `disabled is False` to `disabled is True`; correctly tracks the config change with a helpful inline comment added. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Runner starts benchmark cycle] --> B{Check ProviderEntry.enabled}
    B -- "enabled=True" --> C[Include in benchmark run]
    B -- "enabled=False" --> D[Skip benchmark execution]
    C --> E[GET /v1/providers]
    D --> E
    E --> F{Check ProviderEntry.disabled}
    F -- "disabled=False" --> G[Expose in public catalogue]
    F -- "disabled=True" --> H[Hide from public catalogue]
    G --> I[Dashboard renders result rows]
    H --> J[modelsFromResults.ts filters rows out]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `runner/src/coval_bench/runner/config.py`, line 47-51 ([link](https://github.com/coval-ai/benchmarks/blob/cef2bd24950658c2752d706e469171324d0534c7/runner/src/coval_bench/runner/config.py#L47-L51)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The disabled `xai/grok-stt` entry is left above the `# OFF; disabled=True hides these from the public catalogue.` comment, whereas the other disabled STT entries (Google models) live below it. Moving it down keeps the convention consistent and makes it easier to spot which providers are live at a glance.

   

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["Update provider catalogue test for disab..."](https://github.com/coval-ai/benchmarks/commit/3e0506e1a4aede05af6f7f0843c075cb58465be5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37016685)</sub>

<!-- /greptile_comment -->