### PR TITLE
Allow Vercel preview deployment origins in playground API routes

### DIFF
--- a/web/lib/playground/security.ts
+++ b/web/lib/playground/security.ts
@@ -8,7 +8,14 @@ const ALLOWED_ORIGINS = new Set([
 
 export function isAllowedOrigin(origin: string | null): boolean {
   if (!origin) return false;
-  return ALLOWED_ORIGINS.has(origin);
+  if (ALLOWED_ORIGINS.has(origin)) return true;
+  if (process.env.VERCEL_ENV === "preview") {
+    return (
+      origin === `https://${process.env.VERCEL_URL}` ||
+      origin === `https://${process.env.VERCEL_BRANCH_URL}`
+    );
+  }
+  return false;
 }
 
 export const MAX_CONCURRENT_PER_SESSION = Math.max(


### PR DESCRIPTION
The playground origin allowlist only contained localhost and benchmarks.coval.ai, so every preview deployment got 403s on its own API routes. Accept the deployment URL and branch alias when VERCEL_ENV is preview; production still only allows the hardcoded origins.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Preview deployments can now access the playground environment, enabling testing of Vercel preview URLs. The system maintains security by explicitly denying unauthorized origins in non-preview environments while continuing to allow configured local and benchmark origins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR relaxes the playground API origin allowlist for Vercel preview deployments by checking `VERCEL_ENV === "preview"` and accepting the deployment URL (`VERCEL_URL`) and branch alias (`VERCEL_BRANCH_URL`) as trusted origins; production behavior is unchanged.

- The preview-only gate is a reasonable approach — production retains the original strict allowlist.
- Template literals with potentially-undefined env vars produce the literal string `"https://undefined"`, which would be accepted as a valid origin for any request in a preview environment where one of those variables is not set.

<h3>Confidence Score: 3/5</h3>

Safe to merge after fixing the undefined env var guard; the change is well-scoped to preview environments and does not affect production.

The origin check in preview mode interpolates env vars that may not always be set, producing the literal string "https://undefined" as an accepted origin. This is a present defect in the changed path, not a hypothetical one. The rest of the logic is straightforward and the production allowlist is untouched.

web/lib/playground/security.ts — the only changed file; specifically the new preview-environment branch of isAllowedOrigin.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| web/lib/playground/security.ts | Adds Vercel preview-environment origin allowance using VERCEL_URL and VERCEL_BRANCH_URL; template literals may produce "https://undefined" when either env var is unset, bypassing the origin check for that literal string. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Incoming API request] --> B{origin header present?}
    B -- No --> DENY[Return false / 403]
    B -- Yes --> C{origin in ALLOWED_ORIGINS?}
    C -- Yes --> ALLOW[Return true / proceed]
    C -- No --> D{VERCEL_ENV === 'preview'?}
    D -- No --> DENY
    D -- Yes --> E{origin === https://VERCEL_URL?}
    E -- Yes --> ALLOW
    E -- No --> F{origin === https://VERCEL_BRANCH_URL?}
    F -- Yes --> ALLOW
    F -- No --> DENY
    style DENY fill:#f88,stroke:#c00
    style ALLOW fill:#8f8,stroke:#080
```

<sub>Reviews (1): Last reviewed commit: ["Allow Vercel preview deployment origins ..."](https://github.com/coval-ai/benchmarks/commit/c556518eed64fd384d35897a1314d7b06037230f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37032153)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->