### PR TITLE
Strengthen STT transcript-assembly test coverage

### DIFF
--- a/runner/src/coval_bench/providers/stt/deepgram.py
+++ b/runner/src/coval_bench/providers/stt/deepgram.py
@@ -84,6 +84,7 @@ class DeepgramProvider(STTProvider):
             f"&vad_events=true"
             f"&no_delay=true"
             f"&punctuate=true"
+            f"&filler_words=true"
             # Disable native silence endpointing; we force the final at speech-end
             # via a Finalize message instead (TTFS parity).
             f"&endpointing=false"

--- a/runner/src/coval_bench/providers/stt/gradium.py
+++ b/runner/src/coval_bench/providers/stt/gradium.py
@@ -36,6 +36,7 @@ from coval_bench.providers.base import STTProvider, TranscriptionResult
 logger = structlog.get_logger(__name__)
 
 _WS_URL = "wss://api.gradium.ai/api/speech/asr"
+_FLUSH_WAIT_S = 2.0
 
 
 class GradiumSTTProvider(STTProvider):
@@ -123,7 +124,7 @@ class GradiumSTTProvider(STTProvider):
             # Wait long enough for the server to process remaining frames and
             # send back the final text/end_text messages (~delay_in_frames × 80 ms).
             await ws.send(json.dumps({"type": "flush", "flush_id": 1}))
-            await asyncio.sleep(2.0)
+            await asyncio.sleep(_FLUSH_WAIT_S)
             await ws.send(json.dumps({"type": "end_of_stream"}))
         except Exception as exc:
             logger.exception("gradium send error", error=str(exc))

--- a/runner/tests/providers/stt/fixtures/elevenlabs/events-multi-committed.json
+++ b/runner/tests/providers/stt/fixtures/elevenlabs/events-multi-committed.json
@@ -1,0 +1,7 @@
+[
+  {"message_type": "session_started", "session_id": "test-session-multi", "config": {"model_id": "scribe_v2_realtime"}},
+  {"message_type": "partial_transcript", "text": "hello", "is_final": false},
+  {"message_type": "committed_transcript", "text": "hello world", "is_final": true},
+  {"message_type": "partial_transcript", "text": "how are", "is_final": false},
+  {"message_type": "committed_transcript", "text": "how are you", "is_final": true}
+]

--- a/runner/tests/providers/stt/fixtures/google/events-multi-final.json
+++ b/runner/tests/providers/stt/fixtures/google/events-multi-final.json
@@ -1,0 +1,26 @@
+[
+  {
+    "results": [
+      {
+        "alternatives": [{"transcript": "hello world", "confidence": 0.95}],
+        "is_final": false
+      }
+    ]
+  },
+  {
+    "results": [
+      {
+        "alternatives": [{"transcript": "hello world", "confidence": 0.96}],
+        "is_final": true
+      }
+    ]
+  },
+  {
+    "results": [
+      {
+        "alternatives": [{"transcript": "how are you", "confidence": 0.96}],
+        "is_final": true
+      }
+    ]
+  }
+]

--- a/runner/tests/providers/stt/fixtures/gradium/events-error.json
+++ b/runner/tests/providers/stt/fixtures/gradium/events-error.json
@@ -1,0 +1,3 @@
+[
+  {"type": "error", "message": "Invalid or expired API key", "code": 1008}
+]

--- a/runner/tests/providers/stt/fixtures/gradium/events-success.json
+++ b/runner/tests/providers/stt/fixtures/gradium/events-success.json
@@ -1,0 +1,9 @@
+[
+  {"type": "step", "vad": [], "step_idx": 1, "step_duration_s": 0.08, "total_duration_s": 0.5},
+  {"type": "text", "text": "hello world", "start_s": 0.5, "stream_id": 0},
+  {"type": "end_text", "stop_s": 1.0, "stream_id": 0},
+  {"type": "text", "text": "how are you", "start_s": 1.2, "stream_id": 0},
+  {"type": "end_text", "stop_s": 1.8, "stream_id": 0},
+  {"type": "flushed", "flush_id": 1},
+  {"type": "end_of_stream"}
+]

--- a/runner/tests/providers/stt/fixtures/smallest/events-success.json
+++ b/runner/tests/providers/stt/fixtures/smallest/events-success.json
@@ -3,6 +3,15 @@
     "type": "transcription",
     "status": "success",
     "session_id": "sess_test001",
+    "transcript": "hello",
+    "is_final": false,
+    "is_last": false,
+    "language": "en"
+  },
+  {
+    "type": "transcription",
+    "status": "success",
+    "session_id": "sess_test001",
     "transcript": "hello world",
     "is_final": false,
     "is_last": false,
@@ -12,7 +21,7 @@
     "type": "transcription",
     "status": "success",
     "session_id": "sess_test001",
-    "transcript": "hello world how are you",
+    "transcript": "hello world",
     "is_final": true,
     "is_last": false,
     "language": "en"
@@ -21,7 +30,25 @@
     "type": "transcription",
     "status": "success",
     "session_id": "sess_test001",
-    "transcript": "hello world how are you",
+    "transcript": "how are",
+    "is_final": false,
+    "is_last": false,
+    "language": "en"
+  },
+  {
+    "type": "transcription",
+    "status": "success",
+    "session_id": "sess_test001",
+    "transcript": "how are you",
+    "is_final": true,
+    "is_last": false,
+    "language": "en"
+  },
+  {
+    "type": "transcription",
+    "status": "success",
+    "session_id": "sess_test001",
+    "transcript": "",
     "is_final": true,
     "is_last": true,
     "language": "en"

--- a/runner/tests/providers/stt/fixtures/xai/events-multi-segment-trailing-done.json
+++ b/runner/tests/providers/stt/fixtures/xai/events-multi-segment-trailing-done.json
@@ -1,0 +1,24 @@
+[
+  {"type": "transcript.created", "id": "xai-session-trailing"},
+  {
+    "type": "transcript.partial",
+    "text": "hello world",
+    "is_final": true,
+    "speech_final": true,
+    "start": 0.0,
+    "duration": 1.0
+  },
+  {
+    "type": "transcript.partial",
+    "text": "how are you",
+    "is_final": true,
+    "speech_final": true,
+    "start": 1.2,
+    "duration": 2.5
+  },
+  {
+    "type": "transcript.done",
+    "text": "thanks",
+    "duration": 3.0
+  }
+]

--- a/runner/tests/providers/stt/fixtures/xai/events-multi-segment.json
+++ b/runner/tests/providers/stt/fixtures/xai/events-multi-segment.json
@@ -1,0 +1,32 @@
+[
+  {"type": "transcript.created", "id": "xai-session-multi"},
+  {
+    "type": "transcript.partial",
+    "text": "hello",
+    "is_final": false,
+    "speech_final": false,
+    "start": 0.0,
+    "duration": 0.5
+  },
+  {
+    "type": "transcript.partial",
+    "text": "hello world",
+    "is_final": true,
+    "speech_final": true,
+    "start": 0.0,
+    "duration": 1.0
+  },
+  {
+    "type": "transcript.partial",
+    "text": "how are you",
+    "is_final": true,
+    "speech_final": true,
+    "start": 1.2,
+    "duration": 2.5
+  },
+  {
+    "type": "transcript.done",
+    "text": "",
+    "duration": 3.0
+  }
+]

--- a/runner/tests/providers/stt/test_assemblyai.py
+++ b/runner/tests/providers/stt/test_assemblyai.py
@@ -57,8 +57,7 @@ async def test_assemblyai_success(fake_api_key: SecretStr, audio_pcm_bytes: byte
     assert result.ttft_seconds >= 0
     assert result.first_token_content is not None
     assert "hello" in result.first_token_content.lower()
-    assert result.complete_transcript is not None
-    assert "hello world how are you" in result.complete_transcript
+    assert result.complete_transcript == "hello world how are you"
 
 
 # ---------------------------------------------------------------------------
@@ -289,7 +288,5 @@ async def test_assemblyai_multi_turn_complete_transcript(
             realtime_resolution=0.5,
         )
 
-    assert result.complete_transcript is not None
-    # Both turns should appear in the complete transcript
-    assert "hello world" in result.complete_transcript
-    assert "how are you" in result.complete_transcript
+    assert result.complete_transcript == "hello world how are you"
+    assert result.word_count == 5

--- a/runner/tests/providers/stt/test_deepgram.py
+++ b/runner/tests/providers/stt/test_deepgram.py
@@ -107,6 +107,7 @@ def test_build_websocket_url_nova3() -> None:
     assert "api.deepgram.com" in url
     # Native silence endpointing disabled; we force the final via Finalize (TTFS parity).
     assert "endpointing=false" in url
+    assert "filler_words=true" in url
 
 
 def test_build_websocket_url_flux() -> None:
@@ -122,6 +123,8 @@ def test_build_websocket_url_flux() -> None:
     assert "channels" not in url
     # endpointing is a v1-only param and Flux can't be forced anyway.
     assert "endpointing" not in url
+    # filler_words is a v1-only param; Flux 400s on it.
+    assert "filler_words" not in url
 
 
 @pytest.mark.asyncio

--- a/runner/tests/providers/stt/test_elevenlabs.py
+++ b/runner/tests/providers/stt/test_elevenlabs.py
@@ -56,8 +56,32 @@ async def test_elevenlabs_success(fake_api_key: SecretStr, audio_pcm_bytes: byte
     assert result.ttft_seconds is not None
     assert result.ttft_seconds >= 0
     assert result.first_token_content is not None
-    assert result.complete_transcript is not None
-    assert "hello world how are you" in result.complete_transcript
+    assert result.complete_transcript == "hello world how are you"
+
+
+@pytest.mark.asyncio
+async def test_elevenlabs_joins_multiple_committed(
+    fake_api_key: SecretStr, audio_pcm_bytes: bytes
+) -> None:
+    """Two distinct committed_transcript segments are joined in order."""
+    events = load_fixture_events("elevenlabs", "events-multi-committed")
+    provider = ElevenLabsSTTProvider(api_key=fake_api_key)
+
+    with patch(
+        "coval_bench.providers.stt.elevenlabs.ws_client.connect",
+        return_value=_fake_connect(events),
+    ):
+        result = await provider.measure_ttft(
+            audio_data=audio_pcm_bytes,
+            channels=1,
+            sample_width=2,
+            sample_rate=16000,
+            realtime_resolution=0.5,
+        )
+
+    assert result.error is None
+    assert result.complete_transcript == "hello world how are you"
+    assert result.word_count == 5
 
 
 # ---------------------------------------------------------------------------

--- a/runner/tests/providers/stt/test_google.py
+++ b/runner/tests/providers/stt/test_google.py
@@ -37,9 +37,9 @@ FIXTURES_DIR = Path(__file__).parent / "fixtures" / "google"
 # ---------------------------------------------------------------------------
 
 
-def _load_fixture_responses() -> list[Any]:
-    """Load google/events-success.json and convert to SimpleNamespace objects."""
-    raw: list[dict[str, Any]] = json.loads((FIXTURES_DIR / "events-success.json").read_text())
+def _load_fixture_responses(scenario: str = "events-success") -> list[Any]:
+    """Load google/<scenario>.json and convert to SimpleNamespace objects."""
+    raw: list[dict[str, Any]] = json.loads((FIXTURES_DIR / f"{scenario}.json").read_text())
     responses = []
     for item in raw:
         results = []
@@ -104,8 +104,44 @@ async def test_google_success(audio_pcm_bytes: bytes) -> None:
 
     assert result.error is None
     assert result.ttft_seconds is not None
-    assert result.complete_transcript is not None
-    assert "hello world" in result.complete_transcript
+    assert result.complete_transcript == "hello world how are you"
+
+
+@pytest.mark.asyncio
+async def test_google_joins_multiple_finals(audio_pcm_bytes: bytes) -> None:
+    """Two distinct is_final results are joined in order, not just the last one."""
+    responses = _load_fixture_responses("events-multi-final")
+
+    mock_client = MagicMock()
+
+    def _fake_recognize(requests: Any) -> Any:
+        list(requests)
+        return iter(responses)
+
+    mock_client.streaming_recognize.side_effect = _fake_recognize
+
+    with patch(
+        "coval_bench.providers.stt.google.SpeechClient",
+        return_value=mock_client,
+    ):
+        provider = GoogleSTTProvider(
+            api_key=SecretStr("unused"), model="default", project_id="test-project"
+        )
+
+    provider._client = mock_client
+
+    with patch("coval_bench.providers.stt.google.time.sleep"):
+        result = await provider.measure_ttft(
+            audio_data=audio_pcm_bytes,
+            channels=1,
+            sample_width=2,
+            sample_rate=16000,
+            realtime_resolution=0.5,
+        )
+
+    assert result.error is None
+    assert result.complete_transcript == "hello world how are you"
+    assert result.word_count == 5
 
 
 # ---------------------------------------------------------------------------

--- a/runner/tests/providers/stt/test_gradium.py
+++ b/runner/tests/providers/stt/test_gradium.py
@@ -34,6 +34,11 @@ def _fake_connect(events: list[Any]) -> Any:
     return cm
 
 
+@pytest.fixture(autouse=True)
+def _fast_flush_wait(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("coval_bench.providers.stt.gradium._FLUSH_WAIT_S", 0.05)
+
+
 # ---------------------------------------------------------------------------
 # Happy path — additive word groups joined in order
 # ---------------------------------------------------------------------------

--- a/runner/tests/providers/stt/test_gradium.py
+++ b/runner/tests/providers/stt/test_gradium.py
@@ -72,6 +72,41 @@ async def test_gradium_success(fake_api_key: SecretStr, audio_pcm_bytes: bytes) 
     assert wer.wer_percentage == pytest.approx(0.0)
 
 
+@pytest.mark.asyncio
+async def test_gradium_commits_text_without_end_text(
+    fake_api_key: SecretStr, audio_pcm_bytes: bytes
+) -> None:
+    """Each `text` word group is committed on arrival; `end_text` is not required.
+
+    Pins the finalization contract: dropping every `end_text` from the stream
+    leaves the assembled transcript unchanged, documenting that the provider
+    commits on `text` rather than waiting for `end_text`.
+    """
+    events: list[Any] = [
+        {"type": "text", "text": "hello world", "start_s": 0.5, "stream_id": 0},
+        {"type": "text", "text": "how are you", "start_s": 1.2, "stream_id": 0},
+        {"type": "flushed", "flush_id": 1},
+        {"type": "end_of_stream"},
+    ]
+    provider = GradiumSTTProvider(api_key=fake_api_key)
+
+    with patch(
+        "coval_bench.providers.stt.gradium.ws_client.connect",
+        return_value=_fake_connect(events),
+    ):
+        result = await provider.measure_ttft(
+            audio_data=audio_pcm_bytes,
+            channels=1,
+            sample_width=2,
+            sample_rate=16000,
+            realtime_resolution=0.5,
+        )
+
+    assert result.error is None
+    assert result.complete_transcript == "hello world how are you"
+    assert result.word_count == 5
+
+
 # ---------------------------------------------------------------------------
 # Provider name and model
 # ---------------------------------------------------------------------------

--- a/runner/tests/providers/stt/test_gradium.py
+++ b/runner/tests/providers/stt/test_gradium.py
@@ -1,0 +1,162 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for coval_bench.providers.stt.gradium (GradiumSTTProvider).
+
+All tests use FakeWebSocket — no live network calls are made. The event
+fixtures mirror the real Gradium wire protocol captured on a live socket:
+each ``text`` message carries an additive word group for the current segment
+(not a cumulative snapshot), so the full transcript is the in-order join.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pydantic import SecretStr
+
+from coval_bench.metrics.wer import compute_wer
+from coval_bench.providers.stt.gradium import GradiumSTTProvider
+from tests.providers.stt.conftest import FakeWebSocket, load_fixture_events
+
+
+def make_provider() -> GradiumSTTProvider:
+    return GradiumSTTProvider(api_key=SecretStr("test-key-gradium"))
+
+
+def _fake_connect(events: list[Any]) -> Any:
+    ws = FakeWebSocket(events)
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=ws)
+    cm.__aexit__ = AsyncMock(return_value=False)
+    return cm
+
+
+# ---------------------------------------------------------------------------
+# Happy path — additive word groups joined in order
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_gradium_success(fake_api_key: SecretStr, audio_pcm_bytes: bytes) -> None:
+    events = load_fixture_events("gradium", "events-success")
+    provider = GradiumSTTProvider(api_key=fake_api_key)
+
+    with patch(
+        "coval_bench.providers.stt.gradium.ws_client.connect",
+        return_value=_fake_connect(events),
+    ):
+        result = await provider.measure_ttft(
+            audio_data=audio_pcm_bytes,
+            channels=1,
+            sample_width=2,
+            sample_rate=16000,
+            realtime_resolution=0.5,
+        )
+
+    assert result.error is None
+    assert result.ttft_seconds is not None
+    assert result.ttft_seconds >= 0
+    assert result.first_token_content is not None
+    assert result.complete_transcript == "hello world how are you"
+    assert result.word_count == 5
+    assert result.audio_to_final_seconds is not None
+    wer = compute_wer("hello world how are you", result.complete_transcript)
+    assert wer.wer_percentage == pytest.approx(0.0)
+
+
+# ---------------------------------------------------------------------------
+# Provider name and model
+# ---------------------------------------------------------------------------
+
+
+def test_provider_name() -> None:
+    assert make_provider().name == "gradium"
+
+
+def test_provider_model() -> None:
+    assert make_provider().model == "default"
+
+
+# ---------------------------------------------------------------------------
+# Invalid model
+# ---------------------------------------------------------------------------
+
+
+def test_invalid_model_raises() -> None:
+    with pytest.raises(ValueError, match="Invalid Gradium STT model"):
+        GradiumSTTProvider(api_key=SecretStr("k"), model="bad-model")
+
+
+# ---------------------------------------------------------------------------
+# Invalid sample rate
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_gradium_wrong_sample_rate(fake_api_key: SecretStr, audio_pcm_bytes: bytes) -> None:
+    provider = GradiumSTTProvider(api_key=fake_api_key)
+    result = await provider.measure_ttft(
+        audio_data=audio_pcm_bytes,
+        channels=1,
+        sample_width=2,
+        sample_rate=8000,
+    )
+
+    assert result.error is not None
+    assert "16 kHz" in result.error
+    assert result.ttft_seconds is None
+
+
+# ---------------------------------------------------------------------------
+# Failure path — error event
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_gradium_error_event(fake_api_key: SecretStr, audio_pcm_bytes: bytes) -> None:
+    events = load_fixture_events("gradium", "events-error")
+    provider = GradiumSTTProvider(api_key=fake_api_key)
+
+    with patch(
+        "coval_bench.providers.stt.gradium.ws_client.connect",
+        return_value=_fake_connect(events),
+    ):
+        result = await provider.measure_ttft(
+            audio_data=audio_pcm_bytes,
+            channels=1,
+            sample_width=2,
+            sample_rate=16000,
+            realtime_resolution=0.5,
+        )
+
+    assert result.error is not None
+    assert "Invalid or expired API key" in result.error
+    assert result.complete_transcript is None
+
+
+# ---------------------------------------------------------------------------
+# Failure path — empty stream
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_gradium_empty_stream(fake_api_key: SecretStr, audio_pcm_bytes: bytes) -> None:
+    provider = GradiumSTTProvider(api_key=fake_api_key)
+
+    with patch(
+        "coval_bench.providers.stt.gradium.ws_client.connect",
+        return_value=_fake_connect([]),
+    ):
+        result = await provider.measure_ttft(
+            audio_data=audio_pcm_bytes,
+            channels=1,
+            sample_width=2,
+            sample_rate=16000,
+            realtime_resolution=0.5,
+        )
+
+    assert result.complete_transcript is None
+    assert result.ttft_seconds is None

--- a/runner/tests/providers/stt/test_smallest.py
+++ b/runner/tests/providers/stt/test_smallest.py
@@ -58,8 +58,8 @@ async def test_smallest_success(fake_api_key: SecretStr, audio_pcm_bytes: bytes)
     assert result.ttft_seconds >= 0
     assert result.first_token_content is not None
     assert "hello" in result.first_token_content.lower()
-    assert result.complete_transcript is not None
-    assert "hello world how are you" in result.complete_transcript
+    assert result.complete_transcript == "hello world how are you"
+    assert result.word_count == 5
 
 
 # ---------------------------------------------------------------------------

--- a/runner/tests/providers/stt/test_speechmatics.py
+++ b/runner/tests/providers/stt/test_speechmatics.py
@@ -56,9 +56,8 @@ async def test_speechmatics_success(fake_api_key: SecretStr, audio_pcm_bytes: by
     assert result.ttft_seconds is not None
     assert result.ttft_seconds >= 0
     assert result.first_token_content is not None
-    assert result.complete_transcript is not None
-    # Final transcripts: "hello world" + "how are you"
-    assert "hello" in result.complete_transcript.lower()
+    assert result.complete_transcript == "hello world how are you"
+    assert result.word_count == 5
 
 
 # ---------------------------------------------------------------------------
@@ -84,7 +83,7 @@ async def test_speechmatics_enhanced(fake_api_key: SecretStr, audio_pcm_bytes: b
         )
 
     assert result.error is None
-    assert result.complete_transcript is not None
+    assert result.complete_transcript == "hello world how are you"
 
 
 # ---------------------------------------------------------------------------

--- a/runner/tests/providers/stt/test_xai.py
+++ b/runner/tests/providers/stt/test_xai.py
@@ -64,11 +64,70 @@ async def test_xai_grok_stt_success(fake_api_key: SecretStr, audio_pcm_bytes: by
 
 
 @pytest.mark.asyncio
-async def test_xai_cumulative_is_final_without_done_text(
+async def test_xai_multi_segment_join_empty_done(
     fake_api_key: SecretStr,
     audio_pcm_bytes: bytes,
 ) -> None:
-    """is_final partials are cumulative; empty transcript.done uses last is_final only."""
+    """Two distinct speech_final segments + empty done are joined in order.
+
+    Regression guard for the pre-fix bug that scored only the last segment: a
+    paused utterance closes each segment with its own speech_final=true partial,
+    and the trailing transcript.done is empty.
+    """
+    events = load_fixture_events("xai", "events-multi-segment")
+    provider = XaiSTTProvider(api_key=fake_api_key, model="grok-stt")
+
+    with patch(
+        "coval_bench.providers.stt.xai.ws_client.connect",
+        return_value=_fake_connect(events),
+    ):
+        result = await provider.measure_ttft(
+            audio_data=audio_pcm_bytes,
+            channels=1,
+            sample_width=2,
+            sample_rate=16000,
+            realtime_resolution=0.5,
+        )
+
+    assert result.error is None
+    assert result.complete_transcript == "hello world how are you"
+    assert result.word_count == 5
+    wer = compute_wer("hello world how are you", result.complete_transcript)
+    assert wer.wer_percentage == pytest.approx(0.0)
+
+
+@pytest.mark.asyncio
+async def test_xai_multi_segment_join_trailing_done(
+    fake_api_key: SecretStr,
+    audio_pcm_bytes: bytes,
+) -> None:
+    """Speech_final segments plus trailing non-empty transcript.done are all joined."""
+    events = load_fixture_events("xai", "events-multi-segment-trailing-done")
+    provider = XaiSTTProvider(api_key=fake_api_key, model="grok-stt")
+
+    with patch(
+        "coval_bench.providers.stt.xai.ws_client.connect",
+        return_value=_fake_connect(events),
+    ):
+        result = await provider.measure_ttft(
+            audio_data=audio_pcm_bytes,
+            channels=1,
+            sample_width=2,
+            sample_rate=16000,
+            realtime_resolution=0.5,
+        )
+
+    assert result.error is None
+    assert result.complete_transcript == "hello world how are you thanks"
+    assert result.word_count == 6
+
+
+@pytest.mark.asyncio
+async def test_xai_single_speech_final_empty_done(
+    fake_api_key: SecretStr,
+    audio_pcm_bytes: bytes,
+) -> None:
+    """A single speech_final segment closes the utterance; empty done adds nothing."""
     events = load_fixture_events("xai", "events-success-empty-done")
     provider = XaiSTTProvider(api_key=fake_api_key, model="grok-stt")
 
@@ -155,6 +214,7 @@ async def test_xai_websocket_connect_setup(fake_api_key: SecretStr, audio_pcm_by
     assert query.get("interim_results") == ["true"]
     assert query.get("endpointing") == ["200"]
     assert query.get("language") == ["en"]
+    assert query.get("filler_words") == ["true"]
     auth = captured["additional_headers"].get("Authorization")
     assert auth == f"Bearer {fake_api_key.get_secret_value()}"
 


### PR DESCRIPTION
Each STT provider now has a multi-segment fixture plus exact-equality assertions, so a drop-last or duplication regression in transcript assembly fails the test instead of slipping past a substring check.

- xAI: regression fixtures locking the PR #94 multi-segment join (empty and trailing `transcript.done`)
- Gradium: first test suite + fixtures, based on the real captured wire protocol (additive word groups)
- Smallest: fixture rewritten to match the real protocol (disjoint finals + empty terminal); the old fixture modeled an impossible duplicate
- Speechmatics / AssemblyAI / ElevenLabs / Google: substring assertions tightened to exact equality; multi-segment fixtures added where missing
- Deepgram: enable `filler_words=true` (nova only) for filler-word parity with the other providers

Verified: 115 passed, 1 skipped (Google extra not installed locally); ruff + mypy --strict clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced Deepgram support with optimized configuration for nova-2/nova-3 models.

* **Bug Fixes**
  * Improved multi-segment transcript handling across ElevenLabs, Google, and XAI providers.
  * Enhanced word count accuracy tracking for transcripts.
  * Strengthened error handling and validation for STT operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR strengthens STT transcript-assembly test coverage by tightening assertions from substring checks to exact equality and adding multi-segment fixture tests for every provider. It also addresses a previous review comment by extracting the hardcoded `2.0`-second sleep in the Gradium provider into a patchable `_FLUSH_WAIT_S` constant, and adds `filler_words=true` to the Deepgram v1 URL for nova model parity.

- **Test tightening**: Assertions across AssemblyAI, ElevenLabs, Google, Speechmatics, Smallest, and xAI are upgraded from `\"substring\" in result` to `result == \"exact string\"`, with new multi-segment fixtures verifying that drop-last and duplication regressions in transcript assembly fail the test.
- **New Gradium test suite**: Full first test suite for `GradiumSTTProvider` with `autouse` `_fast_flush_wait` fixture patching `_FLUSH_WAIT_S` to `0.05` to eliminate slow wall-clock sleeps in CI.
- **Deepgram `filler_words`**: `filler_words=true` added to the v1/listen URL (nova-2/nova-3/default models only); Flux URL explicitly excluded with a corresponding test assertion.

<h3>Confidence Score: 5/5</h3>

Safe to merge. All changes are test coverage improvements or small, well-guarded production tweaks with corresponding test assertions.

The only production code changes are extracting a constant in gradium.py (no logic change) and appending filler_words=true to Deepgram's v1/listen URL for nova models. Both are additive and low-risk. The Flux URL path is explicitly excluded and covered by a new test assertion. All new and updated tests tighten existing assertions to exact equality and add regression guards for multi-segment assembly.

No files require special attention. The deepgram.py URL change is the only production behaviour delta and it is covered directly by test_build_websocket_url_nova3 and test_build_websocket_url_flux.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| runner/src/coval_bench/providers/stt/deepgram.py | Adds filler_words=true to the v1/listen query string for nova models; Flux path is unaffected. One-liner production change, guarded by new URL-builder assertions in test_deepgram.py. |
| runner/src/coval_bench/providers/stt/gradium.py | Extracts hardcoded asyncio.sleep(2.0) into module-level _FLUSH_WAIT_S = 2.0 constant, making it patchable in tests. No logic change; addresses the previous review thread about slow CI tests. |
| runner/tests/providers/stt/test_gradium.py | New test file for GradiumSTTProvider: happy path, no-end_text variant, wrong sample rate, error event, and empty stream. autouse _fast_flush_wait fixture patches _FLUSH_WAIT_S to 0.05 s, keeping CI fast. |
| runner/tests/providers/stt/test_xai.py | Renames the old cumulative-is_final test and adds two new multi-segment regression guards: empty trailing transcript.done and non-empty trailing transcript.done. Existing test_xai_websocket_connect_setup gains a filler_words assertion. |
| runner/tests/providers/stt/test_google.py | Strengthens existing assertion to exact equality and adds test_google_joins_multiple_finals using a new three-result fixture (one non-final + two finals), verifying both finals are joined and the non-final is dropped. |
| runner/tests/providers/stt/test_elevenlabs.py | Tightens the success-path assertion and adds test_elevenlabs_joins_multiple_committed using a two-committed-segment fixture, asserting exact transcript and word count. |
| runner/tests/providers/stt/fixtures/smallest/events-success.json | Rewrites the fixture to model the real protocol: disjoint finals (hello world, how are you) instead of a duplicate cumulative string, with an empty terminal is_last=true event. |
| runner/tests/providers/stt/fixtures/xai/events-multi-segment.json | New fixture: partial → speech_final hello world → speech_final how are you → empty transcript.done, modelling two distinct pause-separated segments with a trailing empty done. |
| runner/tests/providers/stt/fixtures/xai/events-multi-segment-trailing-done.json | New fixture: two speech_final segments plus a non-empty transcript.done carrying thanks, used to verify all three contributions are joined. |

</details>

<sub>Reviews (3): Last reviewed commit: ["Pin Gradium finalization: text commits w..."](https://github.com/coval-ai/benchmarks/commit/1351222ef734438b359bdb74241bbeec8d2b6036) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37073739)</sub>

<!-- /greptile_comment -->