### PR TITLE
Per window stats matviews

### DIFF
--- a/runner/src/coval_bench/api/common.py
+++ b/runner/src/coval_bench/api/common.py
@@ -15,12 +15,19 @@ BenchmarkLiteral = Literal["STT", "TTS"]
 WindowLiteral = Literal["24h", "7d", "30d"]
 
 # Fixed interval strings — looked up by Python, never user-interpolated into
-# SQL. Note: the leaderboard router keeps its own 7d/30d-only dict because its
-# 24h window is served by the results_24h materialized view, not a live query.
+# SQL. Used by live queries (the aggregates series block).
 WINDOW_INTERVALS: dict[str, str] = {
     "24h": "24 hours",
     "7d": "7 days",
     "30d": "30 days",
+}
+
+# Per-window stats materialized views (schema-qualified). Looked up by Python
+# from the validated WindowLiteral, never user-interpolated into SQL.
+WINDOW_VIEWS: dict[str, str] = {
+    "24h": "benchmarks_v2.results_24h",
+    "7d": "benchmarks_v2.results_7d",
+    "30d": "benchmarks_v2.results_30d",
 }
 
 # Bucket expression for chart timestamps: the run's cron trigger time,

--- a/runner/src/coval_bench/api/routers/aggregates.py
+++ b/runner/src/coval_bench/api/routers/aggregates.py
@@ -6,11 +6,14 @@
 Serves the dashboard's chart data as pre-computed aggregates. Two blocks:
 
 * ``model_stats`` — per (provider, model, metric_type): avg, sample stddev
-  (n-1 denominator, coalesced to 0 for n=1), p25/p50/p75 (percentile_cont),
-  min, max, count.
+  (n-1 denominator, coalesced to 0 for n=1), p25/p50/p75/p90/p95/p99
+  (percentile_cont), min, max, count. Read from the per-window materialized
+  views (``results_24h``/``results_7d``/``results_30d``), refreshed
+  out-of-band — read-only here.
 * ``series`` — per (provider, model, metric_type, scheduled_at bucket): avg and
-  count. The bucket falls back to created_at floored to the scheduler period
-  for legacy rows, identical to the COALESCE in GET /v1/results.
+  count, aggregated live. The bucket falls back to created_at floored to the
+  scheduler period for legacy rows, identical to the COALESCE in GET
+  /v1/results.
 
 Both blocks gate on result rows with status='success' and a non-null
 metric_value, from parent runs in (succeeded, partial).
@@ -34,6 +37,7 @@ from coval_bench.api.cache import get_or_fill
 from coval_bench.api.common import (
     SCHEDULED_AT_BUCKET_SQL,
     WINDOW_INTERVALS,
+    WINDOW_VIEWS,
     BenchmarkLiteral,
     WindowLiteral,
 )
@@ -53,7 +57,7 @@ logger = structlog.get_logger("coval_bench.api")
 
 router = APIRouter(tags=["results"])
 
-# Shared FROM/WHERE for both blocks.
+# Live FROM/WHERE for the series block.
 _FROM_WHERE = (
     " FROM benchmarks_v2.results r"
     " JOIN benchmarks_v2.runs rn ON rn.id = r.run_id"
@@ -64,17 +68,13 @@ _FROM_WHERE = (
     " AND r.created_at >= NOW() - %(interval)s::interval"
 )
 
-_STATS_SQL = (
-    "SELECT r.provider, r.model, r.metric_type,"
-    " AVG(r.metric_value)::float8 AS avg_value,"
-    " COALESCE(STDDEV_SAMP(r.metric_value), 0)::float8 AS stddev_value,"
-    " PERCENTILE_CONT(0.25) WITHIN GROUP (ORDER BY r.metric_value)::float8 AS p25,"
-    " PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY r.metric_value)::float8 AS p50,"
-    " PERCENTILE_CONT(0.75) WITHIN GROUP (ORDER BY r.metric_value)::float8 AS p75,"
-    " MIN(r.metric_value)::float8 AS min_value,"
-    " MAX(r.metric_value)::float8 AS max_value,"
-    " COUNT(*)::int AS sample_count" + _FROM_WHERE + " GROUP BY r.provider, r.model, r.metric_type"
-    " ORDER BY r.provider, r.model, r.metric_type"
+_STATS_SQL_TEMPLATE = (
+    "SELECT provider, model, metric_type,"
+    " avg_value, stddev_value, p25, p50, p75, p90, p95, p99,"
+    " min_value, max_value, sample_count"
+    " FROM {view}"
+    " WHERE benchmark = %(benchmark)s"
+    " ORDER BY provider, model, metric_type"
 )
 
 # Bucket expression repeated in GROUP BY because a bare ``scheduled_at`` there
@@ -110,18 +110,16 @@ async def get_results_aggregates(
     """
 
     async def fill() -> AggregatesResponse:
-        params: dict[str, Any] = {
+        stats_sql = _STATS_SQL_TEMPLATE.format(view=WINDOW_VIEWS[window])
+        series_params: dict[str, Any] = {
             "benchmark": benchmark,
             "interval": WINDOW_INTERVALS[window],
-        }
-        series_params: dict[str, Any] = {
-            **params,
             "schedule_period": settings.schedule_period_seconds,
         }
 
         async with pool.connection() as conn:
             conn.row_factory = psycopg.rows.dict_row
-            stat_rows = await (await conn.execute(_STATS_SQL, params)).fetchall()
+            stat_rows = await (await conn.execute(stats_sql, {"benchmark": benchmark})).fetchall()
             series_rows = await (await conn.execute(_SERIES_SQL, series_params)).fetchall()
 
         return AggregatesResponse(

--- a/runner/src/coval_bench/api/routers/leaderboard.py
+++ b/runner/src/coval_bench/api/routers/leaderboard.py
@@ -8,11 +8,9 @@ Metric/benchmark compatibility:
 - TTFT + STT
 - TTFA + TTS
 
-``window=24h`` queries the materialized view ``benchmarks_v2.results_24h``
-(refreshed by a Cloud Scheduler cron — read-only here).
-
-``window=7d`` / ``window=30d`` run a live aggregation query against the
-``results`` table directly.
+Every window queries its materialized view (``benchmarks_v2.results_24h``/
+``results_7d``/``results_30d``), refreshed by a Cloud Scheduler cron —
+read-only here.
 """
 
 from __future__ import annotations
@@ -26,7 +24,7 @@ from posthog import Posthog
 from psycopg_pool import AsyncConnectionPool
 from starlette.requests import Request
 
-from coval_bench.api.common import BenchmarkLiteral, WindowLiteral
+from coval_bench.api.common import WINDOW_VIEWS, BenchmarkLiteral, WindowLiteral
 from coval_bench.api.deps import capture_api_event, get_pool, get_posthog
 from coval_bench.api.ratelimit import limiter
 from coval_bench.api.schemas import LeaderboardEntry, LeaderboardResponse
@@ -45,37 +43,16 @@ _VALID_COMBOS: set[tuple[str, str]] = {
     ("TTFA", "TTS"),
 }
 
-# Interval strings for live aggregation
-_WINDOW_INTERVALS: dict[str, str] = {
-    "7d": "7 days",
-    "30d": "30 days",
-}
-
-# SQL for live aggregation (7d / 30d)
-_LIVE_SQL = """
-    SELECT provider, model,
-           AVG(metric_value)::float8 AS avg,
-           PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY metric_value)::float8 AS p50,
-           PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY metric_value)::float8 AS p95,
-           COUNT(*)::int AS n
-    FROM benchmarks_v2.results
-    WHERE status = 'success'
-      AND metric_type = %(metric)s
-      AND benchmark = %(benchmark)s
-      AND created_at >= NOW() - %(interval)s::interval
-    GROUP BY provider, model
-    ORDER BY avg ASC
-"""
-
-# SQL for materialized view (24h).
-# Note: the MV stores ``avg_value`` (not ``avg``) — aliased here for LeaderboardEntry.
-_MV_SQL = """
+# View name comes from WINDOW_VIEWS keyed by the validated window literal —
+# never from user input. The views store ``avg_value``/``sample_count`` —
+# aliased here for LeaderboardEntry.
+_MV_SQL_TEMPLATE = """
     SELECT provider, model,
            avg_value AS avg,
            p50,
            p95,
-           n::int AS n
-    FROM benchmarks_v2.results_24h
+           sample_count AS n
+    FROM {view}
     WHERE metric_type = %(metric)s
       AND benchmark = %(benchmark)s
     ORDER BY avg_value ASC
@@ -97,7 +74,7 @@ async def get_leaderboard(
     Args:
         metric: One of WER, TTFA, TTFT, TTFS.
         benchmark: One of STT, TTS.
-        window: Time window — 24h uses the materialized view; 7d/30d run live.
+        window: Time window — each is served by its materialized view.
 
     Returns:
         ``{"metric": ..., "window": ..., "entries": [LeaderboardEntry, ...]}``
@@ -113,12 +90,7 @@ async def get_leaderboard(
         )
 
     params: dict[str, Any] = {"metric": metric, "benchmark": benchmark}
-
-    if window == "24h":
-        sql = _MV_SQL
-    else:
-        sql = _LIVE_SQL
-        params["interval"] = _WINDOW_INTERVALS[window]
+    sql = _MV_SQL_TEMPLATE.format(view=WINDOW_VIEWS[window])
 
     async with pool.connection() as conn:
         conn.row_factory = psycopg.rows.dict_row

--- a/runner/src/coval_bench/api/routers/leaderboard.py
+++ b/runner/src/coval_bench/api/routers/leaderboard.py
@@ -43,9 +43,6 @@ _VALID_COMBOS: set[tuple[str, str]] = {
     ("TTFA", "TTS"),
 }
 
-# View name comes from WINDOW_VIEWS keyed by the validated window literal —
-# never from user input. The views store ``avg_value``/``sample_count`` —
-# aliased here for LeaderboardEntry.
 _MV_SQL_TEMPLATE = """
     SELECT provider, model,
            avg_value AS avg,

--- a/runner/src/coval_bench/api/schemas.py
+++ b/runner/src/coval_bench/api/schemas.py
@@ -112,6 +112,9 @@ class ModelStatEntry(BaseModel):
     p25: float
     p50: float
     p75: float
+    p90: float
+    p95: float
+    p99: float
     min_value: float
     max_value: float
     sample_count: int

--- a/runner/src/coval_bench/db/migrations/env.py
+++ b/runner/src/coval_bench/db/migrations/env.py
@@ -14,8 +14,9 @@ connection (Cloud SQL Auth Proxy).
 Notes
 -----
 - DB roles and GRANTs are managed by Terraform, not Alembic.
-- The ``results_24h`` materialized view is refreshed by a Cloud Scheduler
-  cron; Alembic only creates the initial definition.
+- The per-window materialized views (``results_24h``/``results_7d``/
+  ``results_30d``) are refreshed by a Cloud Scheduler cron; Alembic only
+  creates the initial definitions.
 - ``alembic_version`` is stored in the public schema (default) so that
   Alembic can create it before ``benchmarks_v2`` is created.
 - We connect via psycopg3 sync connection + SQLAlchemy ``create_engine``

--- a/runner/src/coval_bench/db/migrations/versions/20260611_0005_per_window_stats_matviews.py
+++ b/runner/src/coval_bench/db/migrations/versions/20260611_0005_per_window_stats_matviews.py
@@ -1,0 +1,98 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Per-window stats materialized views: results_24h, results_7d, results_30d.
+
+One view per dashboard window, all sharing a wide stats shape per
+(provider, model, benchmark, metric_type): avg, sample stddev, min,
+p25/p50/p75/p90/p95/p99 (a single PERCENTILE_CONT over an array, so one
+sort), max, count. Rows gate on result status='success', a non-null metric_value,
+and a parent run in (succeeded, partial) — the same filters the aggregates
+endpoint applied live.
+
+results_24h is dropped and recreated in this shape (it previously held only
+avg/p50/p95/n and did not gate on the parent run). Each view gets a unique
+index on the group key so it can be refreshed with REFRESH MATERIALIZED VIEW
+CONCURRENTLY. Refresh remains out-of-band (Cloud Scheduler cron); this
+migration only creates the views, so they hold data as of migration time
+until the first refresh.
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "20260611_0005"
+down_revision = "20260605_0004"
+branch_labels = None
+depends_on = None
+
+_WINDOWS: dict[str, str] = {
+    "results_24h": "24 hours",
+    "results_7d": "7 days",
+    "results_30d": "30 days",
+}
+
+
+def _view_sql(name: str, interval: str) -> str:
+    # S608 false-positive: name and interval come from the _WINDOWS constant.
+    return f"""
+        CREATE MATERIALIZED VIEW benchmarks_v2.{name} AS
+        SELECT provider, model, benchmark, metric_type,
+               avg_value, stddev_value, min_value,
+               pct[1] AS p25, pct[2] AS p50, pct[3] AS p75,
+               pct[4] AS p90, pct[5] AS p95, pct[6] AS p99,
+               max_value, sample_count
+        FROM (
+            SELECT r.provider, r.model, r.benchmark, r.metric_type,
+                   AVG(r.metric_value)::float8 AS avg_value,
+                   COALESCE(STDDEV_SAMP(r.metric_value), 0)::float8 AS stddev_value,
+                   MIN(r.metric_value)::float8 AS min_value,
+                   PERCENTILE_CONT(ARRAY[0.25, 0.5, 0.75, 0.9, 0.95, 0.99])
+                       WITHIN GROUP (ORDER BY r.metric_value)::float8[] AS pct,
+                   MAX(r.metric_value)::float8 AS max_value,
+                   COUNT(*)::int AS sample_count
+            FROM benchmarks_v2.results r
+            JOIN benchmarks_v2.runs rn ON rn.id = r.run_id
+            WHERE r.status = 'success'
+              AND rn.status IN ('succeeded', 'partial')
+              AND r.metric_value IS NOT NULL
+              AND r.created_at >= now() - INTERVAL '{interval}'
+            GROUP BY r.provider, r.model, r.benchmark, r.metric_type
+        ) stats
+    """  # noqa: S608
+
+
+def upgrade() -> None:
+    """Recreate results_24h in the wide shape and add results_7d/results_30d."""
+    op.execute("DROP MATERIALIZED VIEW IF EXISTS benchmarks_v2.results_24h")
+    for name, interval in _WINDOWS.items():
+        op.execute(_view_sql(name, interval))
+        op.execute(
+            f"CREATE UNIQUE INDEX {name}_group_key "
+            f"ON benchmarks_v2.{name} (provider, model, benchmark, metric_type)"
+        )
+
+
+def downgrade() -> None:
+    """Drop the per-window views and restore the original results_24h."""
+    for name in _WINDOWS:
+        op.execute(f"DROP MATERIALIZED VIEW IF EXISTS benchmarks_v2.{name}")
+    op.execute(
+        """
+        CREATE MATERIALIZED VIEW benchmarks_v2.results_24h AS
+        SELECT provider, model, benchmark, metric_type,
+               avg(metric_value)                                        AS avg_value,
+               percentile_cont(0.5)  WITHIN GROUP (ORDER BY metric_value) AS p50,
+               percentile_cont(0.95) WITHIN GROUP (ORDER BY metric_value) AS p95,
+               count(*)                                                 AS n
+        FROM benchmarks_v2.results
+        WHERE status = 'success'
+          AND created_at >= now() - INTERVAL '24 hours'
+        GROUP BY provider, model, benchmark, metric_type
+        """
+    )
+    op.execute(
+        "CREATE INDEX results_24h_lookup_idx "
+        "ON benchmarks_v2.results_24h (benchmark, metric_type, avg_value)"
+    )

--- a/runner/tests/api/conftest.py
+++ b/runner/tests/api/conftest.py
@@ -43,6 +43,14 @@ def _make_db_url(postgresql: Any) -> str:
     return f"postgresql://{info.user}:{info.password or ''}@{info.host}:{info.port}/{info.dbname}"
 
 
+# Mirrors the per-window matview migration (20260611_0005).
+_MV_WINDOWS: dict[str, str] = {
+    "results_24h": "24 hours",
+    "results_7d": "7 days",
+    "results_30d": "30 days",
+}
+
+
 async def _apply_schema(dsn: str) -> None:
     """Create the benchmarks_v2 schema and tables needed by the API tests.
 
@@ -85,19 +93,34 @@ async def _apply_schema(dsn: str) -> None:
                 created_at     timestamptz NOT NULL DEFAULT now()
             )
         """)
-        # Materialized view for 24h leaderboard
-        await aconn.execute("""
-            CREATE MATERIALIZED VIEW IF NOT EXISTS benchmarks_v2.results_24h AS
-            SELECT provider, model, benchmark, metric_type,
-                   AVG(metric_value)::float8 AS avg_value,
-                   PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY metric_value)::float8 AS p50,
-                   PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY metric_value)::float8 AS p95,
-                   COUNT(*) AS n
-            FROM benchmarks_v2.results
-            WHERE status = 'success'
-              AND created_at >= NOW() - INTERVAL '24 hours'
-            GROUP BY provider, model, benchmark, metric_type
-        """)
+        # Per-window stats materialized views (model_stats + leaderboard).
+        # S608 false-positive: name and interval come from the _MV_WINDOWS constant.
+        for name, interval in _MV_WINDOWS.items():
+            await aconn.execute(f"""
+                CREATE MATERIALIZED VIEW IF NOT EXISTS benchmarks_v2.{name} AS
+                SELECT provider, model, benchmark, metric_type,
+                       avg_value, stddev_value, min_value,
+                       pct[1] AS p25, pct[2] AS p50, pct[3] AS p75,
+                       pct[4] AS p90, pct[5] AS p95, pct[6] AS p99,
+                       max_value, sample_count
+                FROM (
+                    SELECT r.provider, r.model, r.benchmark, r.metric_type,
+                           AVG(r.metric_value)::float8 AS avg_value,
+                           COALESCE(STDDEV_SAMP(r.metric_value), 0)::float8 AS stddev_value,
+                           MIN(r.metric_value)::float8 AS min_value,
+                           PERCENTILE_CONT(ARRAY[0.25, 0.5, 0.75, 0.9, 0.95, 0.99])
+                               WITHIN GROUP (ORDER BY r.metric_value)::float8[] AS pct,
+                           MAX(r.metric_value)::float8 AS max_value,
+                           COUNT(*)::int AS sample_count
+                    FROM benchmarks_v2.results r
+                    JOIN benchmarks_v2.runs rn ON rn.id = r.run_id
+                    WHERE r.status = 'success'
+                      AND rn.status IN ('succeeded', 'partial')
+                      AND r.metric_value IS NOT NULL
+                      AND r.created_at >= now() - INTERVAL '{interval}'
+                    GROUP BY r.provider, r.model, r.benchmark, r.metric_type
+                ) stats
+            """)  # noqa: S608
     finally:
         await aconn.close()
 
@@ -281,10 +304,11 @@ async def _insert_result(
 
 
 async def _refresh_mv(postgresql: Any) -> None:
-    """Refresh the results_24h materialized view."""
+    """Refresh all per-window stats materialized views."""
     dsn = _make_db_url(postgresql)
     aconn = await psycopg.AsyncConnection.connect(dsn, autocommit=True)
     try:
-        await aconn.execute("REFRESH MATERIALIZED VIEW benchmarks_v2.results_24h")
+        for name in _MV_WINDOWS:
+            await aconn.execute(f"REFRESH MATERIALIZED VIEW benchmarks_v2.{name}")
     finally:
         await aconn.close()

--- a/runner/tests/api/test_aggregates.py
+++ b/runner/tests/api/test_aggregates.py
@@ -15,14 +15,15 @@ import pytest
 from fastapi import FastAPI
 from httpx import AsyncClient
 
-from coval_bench.api.common import WINDOW_INTERVALS, WindowLiteral
-from tests.api.conftest import _insert_result, _insert_run
+from coval_bench.api.common import WINDOW_INTERVALS, WINDOW_VIEWS, WindowLiteral
+from tests.api.conftest import _insert_result, _insert_run, _refresh_mv
 
 
 def test_intervals_cover_every_window() -> None:
-    """Every WindowLiteral value must have an interval — a window added to
-    the literal but not the dict 500s after validation."""
+    """Every WindowLiteral value must have an interval and a view — a window
+    added to the literal but not the dicts 500s after validation."""
     assert set(WINDOW_INTERVALS) == set(get_args(WindowLiteral))
+    assert set(WINDOW_VIEWS) == set(get_args(WindowLiteral))
 
 
 async def test_empty_db_returns_empty_blocks(client: AsyncClient) -> None:
@@ -45,6 +46,7 @@ async def test_model_stats_math(client: AsyncClient, postgresql: Any) -> None:
     run_id = await _insert_run(postgresql)
     for value in (1.0, 2.0, 3.0, 4.0):
         await _insert_result(postgresql, run_id, metric_type="WER", metric_value=value)
+    await _refresh_mv(postgresql)
 
     response = await client.get("/v1/results/aggregates", params={"benchmark": "STT"})
     assert response.status_code == 200
@@ -59,6 +61,9 @@ async def test_model_stats_math(client: AsyncClient, postgresql: Any) -> None:
     assert s["p25"] == pytest.approx(1.75)
     assert s["p50"] == pytest.approx(2.5)
     assert s["p75"] == pytest.approx(3.25)
+    assert s["p90"] == pytest.approx(3.7)
+    assert s["p95"] == pytest.approx(3.85)
+    assert s["p99"] == pytest.approx(3.97)
     # sample stddev of 1..4 = sqrt(5/3)
     assert s["stddev_value"] == pytest.approx(1.2909944, rel=1e-6)
     assert s["min_value"] == pytest.approx(1.0)
@@ -70,6 +75,7 @@ async def test_single_sample_stddev_is_zero(client: AsyncClient, postgresql: Any
     """STDDEV_SAMP is NULL for n=1 — must be coalesced to 0 like the client did."""
     run_id = await _insert_run(postgresql)
     await _insert_result(postgresql, run_id, metric_value=3.5)
+    await _refresh_mv(postgresql)
 
     response = await client.get("/v1/results/aggregates", params={"benchmark": "STT"})
     s = response.json()["model_stats"][0]
@@ -95,6 +101,7 @@ async def test_excludes_failed_null_and_other_benchmark(
     # Excluded: failed parent run
     failed_run = await _insert_run(postgresql, status="failed")
     await _insert_result(postgresql, failed_run, metric_value=100.0)
+    await _refresh_mv(postgresql)
 
     response = await client.get("/v1/results/aggregates", params={"benchmark": "STT"})
     stats = response.json()["model_stats"]
@@ -106,6 +113,7 @@ async def test_excludes_failed_null_and_other_benchmark(
 async def test_partial_runs_included(client: AsyncClient, postgresql: Any) -> None:
     run_id = await _insert_run(postgresql, status="partial")
     await _insert_result(postgresql, run_id, metric_value=2.0)
+    await _refresh_mv(postgresql)
 
     response = await client.get("/v1/results/aggregates", params={"benchmark": "STT"})
     assert response.json()["model_stats"][0]["sample_count"] == 1
@@ -146,6 +154,7 @@ async def test_window_excludes_old_rows(client: AsyncClient, postgresql: Any) ->
     run_id = await _insert_run(postgresql)
     old = datetime.now(dt.UTC) - timedelta(days=10)
     await _insert_result(postgresql, run_id, created_at=old, metric_value=1.0)
+    await _refresh_mv(postgresql)
 
     response_24h = await client.get("/v1/results/aggregates", params={"benchmark": "STT"})
     assert response_24h.json()["model_stats"] == []
@@ -160,12 +169,14 @@ async def test_cache_serves_stale_within_ttl(client: AsyncClient, postgresql: An
     """A second identical request is served from cache, not re-queried."""
     run_id = await _insert_run(postgresql)
     await _insert_result(postgresql, run_id, metric_value=1.0)
+    await _refresh_mv(postgresql)
 
     first = await client.get("/v1/results/aggregates", params={"benchmark": "STT"})
     assert first.json()["model_stats"][0]["sample_count"] == 1
 
-    # Out-of-band insert that a fresh query would pick up.
+    # Out-of-band insert + refresh that a fresh query would pick up.
     await _insert_result(postgresql, run_id, metric_value=3.0)
+    await _refresh_mv(postgresql)
 
     second = await client.get("/v1/results/aggregates", params={"benchmark": "STT"})
     # Unchanged — served from the cached response, DB not re-scanned.
@@ -177,6 +188,7 @@ async def test_cache_keyed_by_params(client: AsyncClient, postgresql: Any) -> No
     run_id = await _insert_run(postgresql)
     old = datetime.now(dt.UTC) - timedelta(days=10)
     await _insert_result(postgresql, run_id, created_at=old, metric_value=1.0)
+    await _refresh_mv(postgresql)
 
     # 24h excludes the 10-day-old row; 30d includes it. Distinct cache keys.
     r_24h = await client.get("/v1/results/aggregates", params={"benchmark": "STT"})
@@ -194,6 +206,7 @@ async def test_concurrent_misses_coalesce(
 
     run_id = await _insert_run(postgresql)
     await _insert_result(postgresql, run_id, metric_value=1.0)
+    await _refresh_mv(postgresql)
 
     acquisitions = 0
     real_pool = app.state.pool
@@ -264,6 +277,7 @@ async def test_models_grouped_separately(client: AsyncClient, postgresql: Any) -
         metric_type="TTFT",
         metric_value=0.5,
     )
+    await _refresh_mv(postgresql)
 
     response = await client.get("/v1/results/aggregates", params={"benchmark": "STT"})
     stats = response.json()["model_stats"]

--- a/runner/tests/api/test_leaderboard.py
+++ b/runner/tests/api/test_leaderboard.py
@@ -62,8 +62,8 @@ async def test_ttfa_stt_incompatible(client: AsyncClient) -> None:
     assert response.status_code == 400
 
 
-async def test_ttft_stt_7d_live_aggregation(client: AsyncClient, postgresql: Any) -> None:
-    """window=7d runs live aggregation for TTFT+STT."""
+async def test_ttft_stt_7d_window(client: AsyncClient, postgresql: Any) -> None:
+    """window=7d serves TTFT+STT from the results_7d view."""
     run_id = await _insert_run(postgresql)
     await _insert_result(
         postgresql,
@@ -75,6 +75,7 @@ async def test_ttft_stt_7d_live_aggregation(client: AsyncClient, postgresql: Any
         metric_units="ms",
         benchmark="STT",
     )
+    await _refresh_mv(postgresql)
 
     response = await client.get(
         "/v1/leaderboard",
@@ -103,8 +104,8 @@ async def test_missing_metric_returns_422(client: AsyncClient) -> None:
     assert response.status_code == 422
 
 
-async def test_30d_window_live_aggregation(client: AsyncClient, postgresql: Any) -> None:
-    """window=30d runs live aggregation."""
+async def test_30d_window(client: AsyncClient, postgresql: Any) -> None:
+    """window=30d serves from the results_30d view."""
     run_id = await _insert_run(postgresql)
     await _insert_result(
         postgresql,
@@ -115,6 +116,7 @@ async def test_30d_window_live_aggregation(client: AsyncClient, postgresql: Any)
         metric_value=6.0,
         benchmark="STT",
     )
+    await _refresh_mv(postgresql)
     response = await client.get(
         "/v1/leaderboard",
         params={"metric": "WER", "benchmark": "STT", "window": "30d"},

--- a/runner/tests/unit/test_db_writer.py
+++ b/runner/tests/unit/test_db_writer.py
@@ -340,14 +340,14 @@ def test_results_24h_view(pg_conn: psycopg.Connection[Any]) -> None:
 
     with pg_conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
         cur.execute(
-            "SELECT avg_value, p50, p95, n "
+            "SELECT avg_value, p50, p95, sample_count "
             "FROM benchmarks_v2.results_24h "
             "WHERE provider = 'openai' AND model = 'whisper-1' AND metric_type = 'WER'"
         )
         row = cur.fetchone()
 
     assert row is not None
-    assert row["n"] == 5
+    assert row["sample_count"] == 5
     # avg of [0.1, 0.2, 0.3, 0.4, 0.5] = 0.3
     assert abs(float(row["avg_value"]) - 0.3) < 0.001
     # p50 = median = 0.3

--- a/web/components/charts/d3/HeatmapPlot.tsx
+++ b/web/components/charts/d3/HeatmapPlot.tsx
@@ -31,86 +31,46 @@ const HeatmapPlot: React.FC<HeatmapProps> = ({
   });
   const themeColors = useThemeColors();
 
-  // Define metrics based on active tab
   const metrics = useMemo(() => {
-    return activeTab === "tts"
-      ? [
-          {
-            key: "latencyP25" as keyof ModelHeatmapData,
-            label: "P25 Latency",
-            unit: "ms",
-            lowerIsBetter: true
-          },
-          {
-            key: "latencyP50" as keyof ModelHeatmapData,
-            label: "P50 Latency",
-            unit: "ms",
-            lowerIsBetter: true
-          },
-          {
-            key: "latencyP75" as keyof ModelHeatmapData,
-            label: "P75 Latency",
-            unit: "ms",
-            lowerIsBetter: true
-          },
-          {
-            key: "latencyIQR" as keyof ModelHeatmapData,
-            label: "Latency IQR",
-            unit: "ms",
-            lowerIsBetter: true
-          },
-          {
-            key: "avgWER" as keyof ModelHeatmapData,
-            label: "Avg WER",
-            unit: "%",
-            lowerIsBetter: true
-          },
-          {
-            key: "werStdDev" as keyof ModelHeatmapData,
-            label: "WER Std Dev",
-            unit: "%",
-            lowerIsBetter: true
-          }
-        ]
-      : [
-          {
-            key: "latencyP25" as keyof ModelHeatmapData,
-            label: "P25 Delta",
-            unit: "ms",
-            lowerIsBetter: true
-          },
-          {
-            key: "latencyP50" as keyof ModelHeatmapData,
-            label: "P50 Delta",
-            unit: "ms",
-            lowerIsBetter: true
-          },
-          {
-            key: "latencyP75" as keyof ModelHeatmapData,
-            label: "P75 Delta",
-            unit: "ms",
-            lowerIsBetter: true
-          },
-          {
-            key: "latencyIQR" as keyof ModelHeatmapData,
-            label: "Delta IQR",
-            unit: "ms",
-            lowerIsBetter: true
-          },
-          {
-            key: "avgWER" as keyof ModelHeatmapData,
-            label: "Avg WER",
-            unit: "%",
-            lowerIsBetter: true
-          },
-          {
-            key: "werStdDev" as keyof ModelHeatmapData,
-            label: "WER Std Dev",
-            unit: "%",
-            lowerIsBetter: true
-          }
-        ];
-  }, [activeTab]);
+    return [
+      {
+        key: "latencyP25" as keyof ModelHeatmapData,
+        label: "P25 Latency",
+        unit: "ms",
+        lowerIsBetter: true
+      },
+      {
+        key: "latencyP50" as keyof ModelHeatmapData,
+        label: "P50 Latency",
+        unit: "ms",
+        lowerIsBetter: true
+      },
+      {
+        key: "latencyP75" as keyof ModelHeatmapData,
+        label: "P75 Latency",
+        unit: "ms",
+        lowerIsBetter: true
+      },
+      {
+        key: "latencyIQR" as keyof ModelHeatmapData,
+        label: "Latency IQR",
+        unit: "ms",
+        lowerIsBetter: true
+      },
+      {
+        key: "avgWER" as keyof ModelHeatmapData,
+        label: "Avg WER",
+        unit: "%",
+        lowerIsBetter: true
+      },
+      {
+        key: "werStdDev" as keyof ModelHeatmapData,
+        label: "WER Std Dev",
+        unit: "%",
+        lowerIsBetter: true
+      }
+    ];
+  }, []);
 
   // Calculate dynamic height based on data
   const cellHeight = 50;

--- a/web/hooks/useChartData.ts
+++ b/web/hooks/useChartData.ts
@@ -143,13 +143,6 @@ export function useChartData({
     return out;
   }, [series, toDisplayUnits]);
 
-  // Primary latency metric series (TTFT for STT, TTFA for TTS). Also feeds the
-  // STT heatmap deltas and the gap chart.
-  const timelineByModel = useMemo<Record<string, Record<number, number>>>(() => {
-    const primaryMetric = activeTab === "tts" ? "TTFA" : "TTFT";
-    return timelineByMetricModel[primaryMetric] ?? {};
-  }, [timelineByMetricModel, activeTab]);
-
   // Timeline rows for a given metric. Models follow the active tab (STT models
   // for TTFS/TTFT, TTS models for TTFA).
   const getTimelineData = useCallback(
@@ -288,78 +281,27 @@ export function useChartData({
     [scatterByMetricModel, activeTab, selectedTTSModels, selectedSTTModels]
   );
 
-  // STT heatmap: latency deltas relative to the fastest selected model at
-  // each timestamp, percentiled per model. Deltas depend on the selection, so
-  // they are computed here from the per-model series.
-  const modelHeatmapDataMemo = useMemo<ModelHeatmapData[]>(() => {
+  // Heatmap rows: absolute latency percentiles straight from the SQL stats
+  // (like the box plot), plus avg WER.
+  const heatmapDataMemo = useMemo<ModelHeatmapData[]>(() => {
     const selectedModels =
       activeTab === "tts" ? selectedTTSModels : selectedSTTModels;
     const latencyMetric = activeTab === "tts" ? "TTFA" : "TTFT";
 
-    if (selectedModels.length === 0) {
-      return [];
-    }
-
-    // Per-timestamp averages for the selected models.
-    const averagedTimestampGroups: { [key: number]: { [key: string]: number } } = {};
-    selectedModels.forEach((model) => {
-      const tsMap = timelineByModel[model];
-      if (!tsMap) return;
-      Object.entries(tsMap).forEach(([timestamp, avg]) => {
-        const bucket = Number(timestamp);
-        if (!averagedTimestampGroups[bucket]) {
-          averagedTimestampGroups[bucket] = {};
-        }
-        const group = averagedTimestampGroups[bucket];
-        if (group) {
-          group[model] = avg;
-        }
-      });
-    });
-
     const heatmapData: ModelHeatmapData[] = [];
 
     selectedModels.forEach((model) => {
-      const werStat = getStat(model, "WER");
       const latencyStat = getStat(model, latencyMetric);
+      const werStat = getStat(model, "WER");
 
-      // Need both latency and WER data
-      if (!werStat || !latencyStat) return;
+      if (!latencyStat || !werStat) return;
 
-      // Calculate latency deltas relative to fastest at each timestamp
-      const latencyDeltas: number[] = [];
-      Object.values(averagedTimestampGroups).forEach((modelValues) => {
-        const modelVal = modelValues[model];
-        if (modelVal !== undefined) {
-          const allVals = Object.values(modelValues);
-          const fastest = allVals.length > 0 ? Math.min(...allVals) : 0;
-          const delta = modelVal - fastest;
-          latencyDeltas.push(delta);
-        }
-      });
-
-      // Delta percentiles (relative to the selection, so computed here)
-      const sorted = [...latencyDeltas].sort((a, b) => a - b);
-      const n = sorted.length;
-      let p25 = 0, p50 = 0, p75 = 0;
-      if (n > 0) {
-        const getPercentile = (pct: number): number => {
-          const index = (pct / 100) * (n - 1);
-          const lower = Math.floor(index);
-          const upper = Math.ceil(index);
-          if (lower === upper) return sorted[lower] ?? 0;
-          const weight = index - lower;
-          return (sorted[lower] ?? 0) * (1 - weight) + (sorted[upper] ?? 0) * weight;
-        };
-        p25 = getPercentile(25);
-        p50 = getPercentile(50);
-        p75 = getPercentile(75);
-      }
-
+      const p25 = toDisplayUnits(latencyStat.p25);
+      const p75 = toDisplayUnits(latencyStat.p75);
       heatmapData.push({
         model,
         latencyP25: p25,
-        latencyP50: p50,
+        latencyP50: toDisplayUnits(latencyStat.p50),
         latencyP75: p75,
         latencyIQR: p75 - p25,
         avgWER: werStat.avg_value,
@@ -372,54 +314,11 @@ export function useChartData({
         normalizeModelName(a.model).localeCompare(normalizeModelName(b.model)) ||
         a.model.localeCompare(b.model)
     );
-  }, [
-    timelineByModel,
-    activeTab,
-    selectedTTSModels,
-    selectedSTTModels,
-    getStat
-  ]);
+  }, [activeTab, selectedTTSModels, selectedSTTModels, getStat, toDisplayUnits]);
 
-  const getModelHeatmapData = useCallback(
-    (): ModelHeatmapData[] => modelHeatmapDataMemo,
-    [modelHeatmapDataMemo]
-  );
-
-  // TTS heatmap uses absolute percentiles — straight from the SQL stats
-  const ttsHeatmapDataMemo = useMemo<ModelHeatmapData[]>(() => {
-    if (activeTab !== "tts" || selectedTTSModels.length === 0) {
-      return [];
-    }
-
-    const heatmapData: ModelHeatmapData[] = [];
-
-    selectedTTSModels.forEach((model) => {
-      const latencyStat = getStat(model, "TTFA");
-      const werStat = getStat(model, "WER");
-
-      if (!latencyStat || !werStat) return;
-
-      heatmapData.push({
-        model,
-        latencyP25: latencyStat.p25,
-        latencyP50: latencyStat.p50,
-        latencyP75: latencyStat.p75,
-        latencyIQR: latencyStat.p75 - latencyStat.p25,
-        avgWER: werStat.avg_value,
-        werStdDev: werStat.stddev_value
-      });
-    });
-
-    return heatmapData.sort(
-      (a, b) =>
-        normalizeModelName(a.model).localeCompare(normalizeModelName(b.model)) ||
-        a.model.localeCompare(b.model)
-    );
-  }, [activeTab, selectedTTSModels, getStat]);
-
-  const getTTSHeatmapData = useCallback(
-    (): ModelHeatmapData[] => ttsHeatmapDataMemo,
-    [ttsHeatmapDataMemo]
+  const getHeatmapData = useCallback(
+    (): ModelHeatmapData[] => heatmapDataMemo,
+    [heatmapDataMemo]
   );
 
   const werBarDataMemo = useMemo<BarDataPoint[]>(() => {
@@ -543,8 +442,7 @@ export function useChartData({
     getTimelineData,
     getBoxPlotData,
     getScatterData,
-    getModelHeatmapData,
-    getTTSHeatmapData,
+    getHeatmapData,
     getWERBarData,
     getCurrentTimeWindow,
     getTimelineTicks,

--- a/web/hooks/useDashboardState.tsx
+++ b/web/hooks/useDashboardState.tsx
@@ -232,7 +232,6 @@ export function useDashboardState(page: "tts" | "stt") {
   } = keyMetrics;
 
   // Get computed data
-  const heatmapData = chartData.getModelHeatmapData();
   const werBarData = chartData.getWERBarData();
 
   const werBarDataWithColors = useMemo(() => {
@@ -280,9 +279,7 @@ export function useDashboardState(page: "tts" | "stt") {
           "In voice AI applications, transcription accuracy directly impacts the performance of downstream tasks. Even small transcription errors can lead to misinterpretations, frustrating experiences, or incorrect system responses. We evaluate against test audio that includes diverse speakers, accents, and real-world audio conditions. Click a bar to highlight it for comparison.",
       };
 
-  const heatmapDisplayData = page === "tts"
-    ? chartData.getTTSHeatmapData()
-    : heatmapData;
+  const heatmapDisplayData = chartData.getHeatmapData();
 
   // Pre-computed key metrics for display
   const primaryKeyMetric = (() => {


### PR DESCRIPTION
This adds materialized views to speed up data loading.
- Before: Every request for aggregated stats combed through the entire db and built the result in realtime.
- After: Adds three tables to the db that can be updated when new data hits. They just store all the stats for our predefined windows, making lookup blazingly fast.

Note: This doesn't address the timeline view lag, just the stats aggregated over a window.
Note: This does nothing for now. A separate PR to the infra repo will create a hook to update this whenever new benchmarks land. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended aggregate statistics now include additional percentiles: p90, p95, and p99.
  * Leaderboard and aggregates endpoints now support multiple time windows: 24h, 7d, and 30d.

* **Refactor**
  * Heatmap visualization updated to display absolute latency percentiles and inter-quartile ranges instead of comparative deltas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces live aggregation queries in the `/results/aggregates` and `/leaderboard` endpoints with reads from three new PostgreSQL materialized views (`results_24h`, `results_7d`, `results_30d`), each pre-computing wide per-model stats (avg, stddev, p25–p99, min, max, count) for their respective time window. The frontend heatmap is simplified by unifying the separate STT-delta and TTS-absolute paths into a single absolute-percentile implementation.

- **Backend**: Alembic migration drops the old `results_24h` and creates all three views with unique indexes (enabling `CONCURRENTLY` refresh); `WINDOW_VIEWS` dict and `_STATS_SQL_TEMPLATE`/`_MV_SQL_TEMPLATE` string templates safely inject view names from validated Python constants; the `series` block in aggregates remains a live query.
- **Frontend**: `useChartData` removes the delta-relative-to-fastest STT heatmap computation and the separate `ttsHeatmapDataMemo`, replacing both with a single `heatmapDataMemo` that reads absolute percentiles via `toDisplayUnits()` for both tabs; `HeatmapPlot` metric labels are now tab-independent.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the core view-lookup and SQL template logic is correct and the view name interpolation is properly guarded by validated Python constants.

The migration, API routing changes, schema additions, and test updates are all consistent with each other. The main items to be aware of are the downgrade path leaving a non-unique index (which would prevent CONCURRENTLY refresh if the cron is updated before a rollback) and the test conftest duplicating the migration SQL rather than sharing it. Neither blocks a forward deployment, but both could cause pain in a rollback or future migration scenario.

runner/tests/api/conftest.py (duplicated migration SQL) and the downgrade block in 20260611_0005_per_window_stats_matviews.py (non-unique index after rollback).

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| runner/src/coval_bench/db/migrations/versions/20260611_0005_per_window_stats_matviews.py | New migration creates three materialized views (results_24h/7d/30d) with unique indexes for CONCURRENTLY refresh; downgrade recreates results_24h without a unique index, which could break cron-based CONCURRENTLY refresh after a rollback. |
| runner/src/coval_bench/api/routers/aggregates.py | model_stats block now reads from the validated-key matview template instead of a live aggregation; view name interpolation is safe because window is constrained by WindowLiteral and WINDOW_VIEWS is a hardcoded dict. |
| runner/src/coval_bench/api/routers/leaderboard.py | All three windows now serve from their respective matviews via a single SQL template; live aggregation path removed; view name interpolation is safe. |
| runner/src/coval_bench/api/common.py | Adds WINDOW_VIEWS dict mapping validated WindowLiteral keys to schema-qualified view names; comment clarification on WINDOW_INTERVALS usage. |
| runner/src/coval_bench/api/schemas.py | ModelStatEntry gains p90, p95, p99 fields to match the wider matview shape; no schema compatibility issues. |
| runner/tests/api/conftest.py | Test schema setup now creates all three matviews by duplicating the migration SQL inline; duplication creates a maintenance risk if the migration SQL changes without updating the conftest. |
| runner/tests/api/test_aggregates.py | Tests correctly call _refresh_mv before asserting on model_stats; new p90/p95/p99 assertions added with correct expected values. |
| web/hooks/useChartData.ts | Unifies STT and TTS heatmap paths into a single memo using absolute percentiles with toDisplayUnits(); removes the delta-relative-to-fastest STT computation and the separate ttsHeatmapDataMemo; TTS heatmap now applies toDisplayUnits() where the old code did not. |
| web/hooks/useDashboardState.tsx | Removes the page-conditional heatmap dispatch; now calls the single getHeatmapData() for both pages. |
| web/components/charts/d3/HeatmapPlot.tsx | metrics array is now static (no tab-conditional Delta vs Latency labels); dependency on activeTab removed from the useMemo; always shows absolute latency percentile labels. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant API
    participant MatView as Materialized View<br/>(results_24h/7d/30d)
    participant ResultsDB as results / runs tables
    participant Cron as Cloud Scheduler Cron

    Client->>API: "GET /v1/results/aggregates?window=24h"
    API->>MatView: "SELECT provider, model, … FROM results_24h WHERE benchmark=…"
    MatView-->>API: model_stats rows (pre-aggregated)
    API->>ResultsDB: SELECT … FROM results JOIN runs … (live series query)
    ResultsDB-->>API: series rows
    API-->>Client: "{model_stats, series}"

    Client->>API: "GET /v1/leaderboard?window=7d"
    API->>MatView: "SELECT … FROM results_7d WHERE metric_type=… AND benchmark=…"
    MatView-->>API: leaderboard entries
    API-->>Client: "{entries}"

    Cron->>MatView: REFRESH MATERIALIZED VIEW CONCURRENTLY results_24h
    Cron->>MatView: REFRESH MATERIALIZED VIEW CONCURRENTLY results_7d
    Cron->>MatView: REFRESH MATERIALIZED VIEW CONCURRENTLY results_30d
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (3)</h3></summary>

1. `runner/tests/api/conftest.py`, line 380-405 ([link](https://github.com/coval-ai/benchmarks/blob/8e849cdfebbf06ec33e84737990dbd4fdb2fe8ee/runner/tests/api/conftest.py#L380-L405)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Test schema duplicates migration SQL verbatim**

   The materialized-view DDL in `conftest.py` (`_apply_schema`) is an exact copy of the SQL from `20260611_0005_per_window_stats_matviews.py`. Both the migration and the test fixture will now need to be updated in lock-step for any future change to the view shape (e.g. adding a column, changing the `runs` JOIN condition). If the migration is updated without updating the conftest, tests will silently exercise a view definition that no longer matches production, masking real regressions.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!


2. `runner/src/coval_bench/db/migrations/versions/20260611_0005_per_window_stats_matviews.py`, line 320-341 ([link](https://github.com/coval-ai/benchmarks/blob/8e849cdfebbf06ec33e84737990dbd4fdb2fe8ee/runner/src/coval_bench/db/migrations/versions/20260611_0005_per_window_stats_matviews.py#L320-L341)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Downgrade recreates `results_24h` without a unique index**

   The `upgrade()` path creates each view with a `UNIQUE INDEX` (`{name}_group_key`) that allows `REFRESH MATERIALIZED VIEW CONCURRENTLY`. The `downgrade()` path restores `results_24h` with only the original non-unique `results_24h_lookup_idx`. If the companion infra PR updates the Cloud Scheduler cron to use `CONCURRENTLY` refresh for all three views (which the unique indexes are there to support), a rollback will leave the cron unable to refresh `results_24h` until a unique index is added manually.

   Consider adding a unique index on `(provider, model, benchmark, metric_type)` in the downgrade path, or documenting that the cron must be changed back to a non-concurrent refresh before running the downgrade.


3. `web/hooks/useChartData.ts`, line 299-309 ([link](https://github.com/coval-ai/benchmarks/blob/8e849cdfebbf06ec33e84737990dbd4fdb2fe8ee/web/hooks/useChartData.ts#L299-L309)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **TTS heatmap now applies `toDisplayUnits()` — behaviour change**

   The old `ttsHeatmapDataMemo` used raw `latencyStat.p25/p50/p75` values without calling `toDisplayUnits()`. The unified `heatmapDataMemo` now applies `toDisplayUnits(latencyStat.pXX)` for both tabs. All other TTS charts (box plot, scatter) already go through `toDisplayUnits`, so this is almost certainly correcting a pre-existing inconsistency. Worth explicitly verifying that the TTS latency values stored in the database are not already in display units — if they are, the heatmap will now show doubled/scaled values compared to what was shown before this PR.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["Show absolute latency percentiles in the..."](https://github.com/coval-ai/benchmarks/commit/8e849cdfebbf06ec33e84737990dbd4fdb2fe8ee) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37080209)</sub>

<!-- /greptile_comment -->