### PR TITLE
fix: timeline tooltip: scrollable, pinnable, with all models reachable

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -192,3 +192,20 @@ body {
     rgba(0, 0, 0, 1) 60%
   );
 }
+
+.tooltip-scroll {
+  scrollbar-width: thin;
+  scrollbar-color: var(--color-text-tertiary) var(--color-border-secondary);
+}
+.tooltip-scroll::-webkit-scrollbar {
+  width: 10px;
+}
+.tooltip-scroll::-webkit-scrollbar-track {
+  background: var(--color-border-secondary);
+  border-radius: 5px;
+}
+.tooltip-scroll::-webkit-scrollbar-thumb {
+  background-color: var(--color-text-tertiary);
+  border-radius: 5px;
+  border: 2px solid var(--color-border-secondary);
+}

--- a/web/components/charts/tooltips/TimelineTooltip.tsx
+++ b/web/components/charts/tooltips/TimelineTooltip.tsx
@@ -45,7 +45,10 @@ const CustomTimelineTooltip: React.FC<TimelineTooltipProps> = ({ active, payload
           ? `${formatDate(Number(label))} ${formatTimeWithSeconds(Number(label))}`
           : formatTimeWithSeconds(Number(label))}
       </p>
-      <div style={{ fontSize: "11px" }}>
+      <div
+        className="tooltip-scroll"
+        style={{ fontSize: "11px", maxHeight: "300px", overflowY: "scroll", paddingRight: "8px" }}
+      >
         {validData.map((item, index) => {
           // Extract model name from dataKey (remove '_value' suffix)
           const modelName = item.dataKey.replace(/_value$/, "");

--- a/web/components/visualizations/TimelineChart.tsx
+++ b/web/components/visualizations/TimelineChart.tsx
@@ -71,6 +71,7 @@ const TimelineChart: React.FC = () => {
   const [metric, setMetric] = useState<string>(
     activeTab === "stt" ? "TTFT" : "TTFA"
   );
+  const [pinnedLabel, setPinnedLabel] = useState<string | null>(null);
 
   const themeColors = useThemeColors();
   const modelsWithData = getModelsWithTimelineData(metric);
@@ -160,6 +161,11 @@ const TimelineChart: React.FC = () => {
             <LineChart
               data={windowedTimelineData}
               margin={{ top: 5, right: 8, left: 0, bottom: 5 }}
+              onClick={(state) => {
+                const lbl = state?.activeLabel;
+                if (lbl == null) return;
+                setPinnedLabel((cur) => (cur === lbl ? null : lbl));
+              }}
             >
               <CartesianGrid
                 vertical={false}
@@ -205,6 +211,9 @@ const TimelineChart: React.FC = () => {
                     showDate={dateScale}
                   />
                 }
+                trigger="click"
+                active={pinnedLabel !== null}
+                wrapperStyle={{ pointerEvents: "auto" }}
               />
               {modelsWithData.length > 1 && (
                 <Legend content={<TimelineLegend />} />

--- a/web/components/visualizations/TimelineChart.tsx
+++ b/web/components/visualizations/TimelineChart.tsx
@@ -52,6 +52,21 @@ const TimelineLegend: React.FC<{ payload?: LegendEntry[] }> = ({ payload }) => (
   </ul>
 );
 
+interface TooltipPayloadItem {
+  dataKey: string;
+  value: number;
+  name: string;
+  color: string;
+}
+
+interface PinnedTooltip {
+  label: string;
+  payload: TooltipPayloadItem[];
+  x: number;
+  y: number;
+  flip: boolean;
+}
+
 const TimelineChart: React.FC = () => {
   const activeTab = useActiveTab();
   const {
@@ -71,19 +86,19 @@ const TimelineChart: React.FC = () => {
   const [metric, setMetric] = useState<string>(
     activeTab === "stt" ? "TTFT" : "TTFA"
   );
-  const [pinnedLabel, setPinnedLabel] = useState<string | null>(null);
   const chartRef = useRef<HTMLDivElement>(null);
+  const [pinned, setPinned] = useState<PinnedTooltip | null>(null);
 
   useEffect(() => {
-    if (pinnedLabel === null) return;
+    if (pinned === null) return;
     const onDocMouseDown = (e: MouseEvent) => {
       if (chartRef.current && !chartRef.current.contains(e.target as Node)) {
-        setPinnedLabel(null);
+        setPinned(null);
       }
     };
     document.addEventListener("mousedown", onDocMouseDown);
     return () => document.removeEventListener("mousedown", onDocMouseDown);
-  }, [pinnedLabel]);
+  }, [pinned]);
 
   const themeColors = useThemeColors();
   const modelsWithData = getModelsWithTimelineData(metric);
@@ -168,15 +183,27 @@ const TimelineChart: React.FC = () => {
           </div>
         )}
 
-        <div ref={chartRef} className="h-96" onMouseEnter={trackChartHover}>
+        <div ref={chartRef} className="relative h-96" onMouseEnter={trackChartHover}>
           <ResponsiveContainer width="100%" height="100%">
             <LineChart
               data={windowedTimelineData}
               margin={{ top: 5, right: 8, left: 0, bottom: 5 }}
               onClick={(state) => {
                 const lbl = state?.activeLabel;
-                if (lbl == null) return;
-                setPinnedLabel((cur) => (cur === lbl ? null : lbl));
+                const coord = state?.activeCoordinate;
+                if (lbl == null || !coord) return;
+                setPinned((cur) => {
+                  if (cur && cur.label === lbl) return null;
+                  const width = chartRef.current?.clientWidth ?? 0;
+                  const x = coord.x ?? 0;
+                  return {
+                    label: lbl,
+                    payload: (state.activePayload ?? []) as TooltipPayloadItem[],
+                    x,
+                    y: coord.y ?? 0,
+                    flip: width > 0 && x > width / 2,
+                  };
+                });
               }}
             >
               <CartesianGrid
@@ -223,9 +250,7 @@ const TimelineChart: React.FC = () => {
                     showDate={dateScale}
                   />
                 }
-                trigger="click"
-                active={pinnedLabel !== null}
-                wrapperStyle={{ pointerEvents: "auto" }}
+                active={pinned ? false : undefined}
               />
               {modelsWithData.length > 1 && (
                 <Legend content={<TimelineLegend />} />
@@ -249,6 +274,28 @@ const TimelineChart: React.FC = () => {
               ))}
             </LineChart>
           </ResponsiveContainer>
+          {pinned && (
+            <div
+              style={{
+                position: "absolute",
+                left: pinned.x,
+                top: pinned.y,
+                transform: pinned.flip
+                  ? "translate(calc(-100% - 12px), -50%)"
+                  : "translate(12px, -50%)",
+                pointerEvents: "auto",
+                zIndex: 20,
+              }}
+            >
+              <CustomTimelineTooltip
+                active
+                payload={pinned.payload}
+                label={pinned.label}
+                getProviderForModel={getProviderForModel}
+                showDate={dateScale}
+              />
+            </div>
+          )}
         </div>
       </Card>
     </div>

--- a/web/components/visualizations/TimelineChart.tsx
+++ b/web/components/visualizations/TimelineChart.tsx
@@ -3,7 +3,7 @@
 
 "use client";
 
-import React, { useMemo, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import {
   LineChart,
   Line,
@@ -72,6 +72,18 @@ const TimelineChart: React.FC = () => {
     activeTab === "stt" ? "TTFT" : "TTFA"
   );
   const [pinnedLabel, setPinnedLabel] = useState<string | null>(null);
+  const chartRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (pinnedLabel === null) return;
+    const onDocMouseDown = (e: MouseEvent) => {
+      if (chartRef.current && !chartRef.current.contains(e.target as Node)) {
+        setPinnedLabel(null);
+      }
+    };
+    document.addEventListener("mousedown", onDocMouseDown);
+    return () => document.removeEventListener("mousedown", onDocMouseDown);
+  }, [pinnedLabel]);
 
   const themeColors = useThemeColors();
   const modelsWithData = getModelsWithTimelineData(metric);
@@ -156,7 +168,7 @@ const TimelineChart: React.FC = () => {
           </div>
         )}
 
-        <div className="h-96" onMouseEnter={trackChartHover}>
+        <div ref={chartRef} className="h-96" onMouseEnter={trackChartHover}>
           <ResponsiveContainer width="100%" height="100%">
             <LineChart
               data={windowedTimelineData}

--- a/web/components/visualizations/TimelineChart.tsx
+++ b/web/components/visualizations/TimelineChart.tsx
@@ -87,14 +87,17 @@ const TimelineChart: React.FC = () => {
     activeTab === "stt" ? "TTFT" : "TTFA"
   );
   const chartRef = useRef<HTMLDivElement>(null);
+  const pinnedRef = useRef<HTMLDivElement>(null);
   const [pinned, setPinned] = useState<PinnedTooltip | null>(null);
 
   useEffect(() => {
     if (pinned === null) return;
     const onDocMouseDown = (e: MouseEvent) => {
-      if (chartRef.current && !chartRef.current.contains(e.target as Node)) {
-        setPinned(null);
-      }
+      const target = e.target as Node;
+      if (pinnedRef.current?.contains(target)) return;
+      const surface = chartRef.current?.querySelector(".recharts-surface");
+      if (surface?.contains(target)) return;
+      setPinned(null);
     };
     document.addEventListener("mousedown", onDocMouseDown);
     return () => document.removeEventListener("mousedown", onDocMouseDown);
@@ -276,6 +279,7 @@ const TimelineChart: React.FC = () => {
           </ResponsiveContainer>
           {pinned && (
             <div
+              ref={pinnedRef}
               style={{
                 position: "absolute",
                 left: pinned.x,

--- a/web/components/visualizations/TimelineChart.tsx
+++ b/web/components/visualizations/TimelineChart.tsx
@@ -172,7 +172,10 @@ const TimelineChart: React.FC = () => {
               <button
                 key={m}
                 type="button"
-                onClick={() => setMetric(m)}
+                onClick={() => {
+                  setMetric(m);
+                  setPinned(null);
+                }}
                 className={
                   "rounded-md px-3 py-1 text-xs font-medium transition-colors " +
                   (metric === m
@@ -194,16 +197,27 @@ const TimelineChart: React.FC = () => {
               onClick={(state) => {
                 const lbl = state?.activeLabel;
                 const coord = state?.activeCoordinate;
-                if (lbl == null || !coord) return;
+                const payload = (state?.activePayload ?? []) as TooltipPayloadItem[];
+                const hasRows = payload.some(
+                  (item) => typeof item?.value === "number" && item.value > 0
+                );
+                if (lbl == null || !coord || !hasRows) return;
                 setPinned((cur) => {
                   if (cur && cur.label === lbl) return null;
                   const width = chartRef.current?.clientWidth ?? 0;
+                  const height = chartRef.current?.clientHeight ?? 0;
                   const x = coord.x ?? 0;
+                  const rawY = coord.y ?? 0;
+                  const pad = 130;
+                  const y =
+                    height > pad * 2
+                      ? Math.min(Math.max(rawY, pad), height - pad)
+                      : rawY;
                   return {
                     label: lbl,
-                    payload: (state.activePayload ?? []) as TooltipPayloadItem[],
+                    payload,
                     x,
-                    y: coord.y ?? 0,
+                    y,
                     flip: width > 0 && x > width / 2,
                   };
                 });


### PR DESCRIPTION
On the dashboard timeline charts (STT + TTS), the hover tooltip couldn't show all models with many providers the list overflowed the chart box and the bottom entries were pushed out of view. The tooltip rendered every model with no usable scroll (a recharts hover tooltip follows the cursor and is `pointer-events: none`, so a plain scrollbar isn't grabbable).

fixed: Kept the lightweight hover preview and added a click-to-pin tooltip you can actually scroll.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now pin timeline chart tooltips by clicking on specific data points. Pinned tooltips remain visible while exploring chart data and automatically dismiss when clicking outside the chart.

* **Style**
  * Scrollbar styling within tooltips has been enhanced for improved visual presentation and readability when displaying extensive data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR solves the tooltip overflow problem on the STT/TTS timeline charts by keeping the lightweight hover preview and layering a click-to-pin tooltip on top that has `pointer-events: auto`, allowing real scrolling through a long model list.

- **Pinnable tooltip**: clicking a data point pins an absolute-positioned `CustomTimelineTooltip` overlay with vertical clamping (`pad = 130`) to keep it inside the chart area; clicking the same point or anywhere outside the chart dismisses it.
- **Hover suppression**: `active={pinned ? false : undefined}` correctly hides the recharts hover tooltip while a pin is active, preventing two tooltips from stacking.
- **Scrollbar polish**: `.tooltip-scroll` CSS class in `globals.css` styles the native scrollbar using CSS custom properties so it respects the app's theme tokens.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is additive UI logic with no data-layer impact.

The pin/unpin state machine is straightforward, the dismiss listener is correctly scoped to `pinned !== null` with a proper cleanup, and the vertical-clamping fix keeps the tooltip inside the chart bounds. No data mutations, no new network calls, and the hover tooltip is cleanly suppressed while a pin is active.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| web/components/visualizations/TimelineChart.tsx | Core change: adds click-to-pin logic with `PinnedTooltip` state, a `mousedown` dismiss listener, and an absolute-positioned interactive tooltip overlay; metric toggle also clears the pin. |
| web/components/charts/tooltips/TimelineTooltip.tsx | Wraps model list in a scrollable `div` with `maxHeight: 300px`, `overflowY: scroll`, and the new `tooltip-scroll` CSS class; no logic changes. |
| web/app/globals.css | Adds `.tooltip-scroll` scrollbar styling rules using CSS custom properties for color theming; clean, self-contained addition. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant U as User
    participant LC as LineChart (recharts)
    participant TC as TimelineChart state
    participant PT as Pinned Tooltip (DOM)
    participant Doc as document

    U->>LC: hover over data point
    LC-->>TC: Tooltip content rendered (pointer-events:none)
    Note over TC: active={pinned ? false : undefined} suppresses hover tooltip when pinned

    U->>LC: click data point
    LC->>TC: onClick(state) → activeLabel, activeCoordinate, activePayload
    TC->>TC: "setPinned({label, payload, x, y, flip})"
    TC->>PT: render absolute-positioned tooltip (pointerEvents: auto)
    TC->>Doc: addEventListener(mousedown, onDocMouseDown)

    U->>PT: scroll inside pinned tooltip
    Note over PT: pointerEvents:auto allows native scroll

    U->>LC: click same data point
    LC->>TC: "onClick → cur.label === lbl → return null"
    TC->>TC: setPinned(null) — unpin
    TC->>Doc: removeEventListener (effect cleanup)

    U->>Doc: mousedown outside chart
    Doc->>TC: onDocMouseDown fired
    TC->>TC: target not in pinnedRef or recharts-surface
    TC->>TC: setPinned(null) — dismiss
```

<sub>Reviews (3): Last reviewed commit: ["Harden pinned timeline tooltip: clear on..."](https://github.com/coval-ai/benchmarks/commit/22119f7cb0eb8da0f4308e4b0ddd29fefec0ae64) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37098621)</sub>

<!-- /greptile_comment -->