### PR TITLE
Refresh stats matviews at the end of each run

### DIFF
--- a/runner/src/coval_bench/api/common.py
+++ b/runner/src/coval_bench/api/common.py
@@ -15,12 +15,19 @@ BenchmarkLiteral = Literal["STT", "TTS"]
 WindowLiteral = Literal["24h", "7d", "30d"]
 
 # Fixed interval strings — looked up by Python, never user-interpolated into
-# SQL. Note: the leaderboard router keeps its own 7d/30d-only dict because its
-# 24h window is served by the results_24h materialized view, not a live query.
+# SQL. Used by live queries (the aggregates series block).
 WINDOW_INTERVALS: dict[str, str] = {
     "24h": "24 hours",
     "7d": "7 days",
     "30d": "30 days",
+}
+
+# Per-window stats materialized views (schema-qualified). Looked up by Python
+# from the validated WindowLiteral, never user-interpolated into SQL.
+WINDOW_VIEWS: dict[str, str] = {
+    "24h": "benchmarks_v2.results_24h",
+    "7d": "benchmarks_v2.results_7d",
+    "30d": "benchmarks_v2.results_30d",
 }
 
 # Bucket expression for chart timestamps: the run's cron trigger time,

--- a/runner/src/coval_bench/api/routers/aggregates.py
+++ b/runner/src/coval_bench/api/routers/aggregates.py
@@ -8,8 +8,8 @@ Serves the dashboard's chart data as pre-computed aggregates. Two blocks:
 * ``model_stats`` — per (provider, model, metric_type): avg, sample stddev
   (n-1 denominator, coalesced to 0 for n=1), p25/p50/p75/p90/p95/p99
   (percentile_cont), min, max, count. Read from the per-window materialized
-  views (``results_24h``/``results_7d``/``results_30d``), refreshed
-  out-of-band — read-only here.
+  views (``results_24h``/``results_7d``/``results_30d``), refreshed by the
+  runner at the end of each benchmark run — read-only here.
 * ``series`` — per (provider, model, metric_type, scheduled_at bucket): avg and
   count, aggregated live. The bucket falls back to created_at floored to the
   scheduler period for legacy rows, identical to the COALESCE in GET

--- a/runner/src/coval_bench/api/routers/aggregates.py
+++ b/runner/src/coval_bench/api/routers/aggregates.py
@@ -6,11 +6,14 @@
 Serves the dashboard's chart data as pre-computed aggregates. Two blocks:
 
 * ``model_stats`` — per (provider, model, metric_type): avg, sample stddev
-  (n-1 denominator, coalesced to 0 for n=1), p25/p50/p75 (percentile_cont),
-  min, max, count.
+  (n-1 denominator, coalesced to 0 for n=1), p25/p50/p75/p90/p95/p99
+  (percentile_cont), min, max, count. Read from the per-window materialized
+  views (``results_24h``/``results_7d``/``results_30d``), refreshed
+  out-of-band — read-only here.
 * ``series`` — per (provider, model, metric_type, scheduled_at bucket): avg and
-  count. The bucket falls back to created_at floored to the scheduler period
-  for legacy rows, identical to the COALESCE in GET /v1/results.
+  count, aggregated live. The bucket falls back to created_at floored to the
+  scheduler period for legacy rows, identical to the COALESCE in GET
+  /v1/results.
 
 Both blocks gate on result rows with status='success' and a non-null
 metric_value, from parent runs in (succeeded, partial).
@@ -34,6 +37,7 @@ from coval_bench.api.cache import get_or_fill
 from coval_bench.api.common import (
     SCHEDULED_AT_BUCKET_SQL,
     WINDOW_INTERVALS,
+    WINDOW_VIEWS,
     BenchmarkLiteral,
     WindowLiteral,
 )
@@ -53,7 +57,7 @@ logger = structlog.get_logger("coval_bench.api")
 
 router = APIRouter(tags=["results"])
 
-# Shared FROM/WHERE for both blocks.
+# Live FROM/WHERE for the series block.
 _FROM_WHERE = (
     " FROM benchmarks_v2.results r"
     " JOIN benchmarks_v2.runs rn ON rn.id = r.run_id"
@@ -64,17 +68,13 @@ _FROM_WHERE = (
     " AND r.created_at >= NOW() - %(interval)s::interval"
 )
 
-_STATS_SQL = (
-    "SELECT r.provider, r.model, r.metric_type,"
-    " AVG(r.metric_value)::float8 AS avg_value,"
-    " COALESCE(STDDEV_SAMP(r.metric_value), 0)::float8 AS stddev_value,"
-    " PERCENTILE_CONT(0.25) WITHIN GROUP (ORDER BY r.metric_value)::float8 AS p25,"
-    " PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY r.metric_value)::float8 AS p50,"
-    " PERCENTILE_CONT(0.75) WITHIN GROUP (ORDER BY r.metric_value)::float8 AS p75,"
-    " MIN(r.metric_value)::float8 AS min_value,"
-    " MAX(r.metric_value)::float8 AS max_value,"
-    " COUNT(*)::int AS sample_count" + _FROM_WHERE + " GROUP BY r.provider, r.model, r.metric_type"
-    " ORDER BY r.provider, r.model, r.metric_type"
+_STATS_SQL_TEMPLATE = (
+    "SELECT provider, model, metric_type,"
+    " avg_value, stddev_value, p25, p50, p75, p90, p95, p99,"
+    " min_value, max_value, sample_count"
+    " FROM {view}"
+    " WHERE benchmark = %(benchmark)s"
+    " ORDER BY provider, model, metric_type"
 )
 
 # Bucket expression repeated in GROUP BY because a bare ``scheduled_at`` there
@@ -110,18 +110,16 @@ async def get_results_aggregates(
     """
 
     async def fill() -> AggregatesResponse:
-        params: dict[str, Any] = {
+        stats_sql = _STATS_SQL_TEMPLATE.format(view=WINDOW_VIEWS[window])
+        series_params: dict[str, Any] = {
             "benchmark": benchmark,
             "interval": WINDOW_INTERVALS[window],
-        }
-        series_params: dict[str, Any] = {
-            **params,
             "schedule_period": settings.schedule_period_seconds,
         }
 
         async with pool.connection() as conn:
             conn.row_factory = psycopg.rows.dict_row
-            stat_rows = await (await conn.execute(_STATS_SQL, params)).fetchall()
+            stat_rows = await (await conn.execute(stats_sql, {"benchmark": benchmark})).fetchall()
             series_rows = await (await conn.execute(_SERIES_SQL, series_params)).fetchall()
 
         return AggregatesResponse(

--- a/runner/src/coval_bench/api/routers/leaderboard.py
+++ b/runner/src/coval_bench/api/routers/leaderboard.py
@@ -8,11 +8,9 @@ Metric/benchmark compatibility:
 - TTFT + STT
 - TTFA + TTS
 
-``window=24h`` queries the materialized view ``benchmarks_v2.results_24h``
-(refreshed by a Cloud Scheduler cron — read-only here).
-
-``window=7d`` / ``window=30d`` run a live aggregation query against the
-``results`` table directly.
+Every window queries its materialized view (``benchmarks_v2.results_24h``/
+``results_7d``/``results_30d``), refreshed by a Cloud Scheduler cron —
+read-only here.
 """
 
 from __future__ import annotations
@@ -26,7 +24,7 @@ from posthog import Posthog
 from psycopg_pool import AsyncConnectionPool
 from starlette.requests import Request
 
-from coval_bench.api.common import BenchmarkLiteral, WindowLiteral
+from coval_bench.api.common import WINDOW_VIEWS, BenchmarkLiteral, WindowLiteral
 from coval_bench.api.deps import capture_api_event, get_pool, get_posthog
 from coval_bench.api.ratelimit import limiter
 from coval_bench.api.schemas import LeaderboardEntry, LeaderboardResponse
@@ -45,37 +43,13 @@ _VALID_COMBOS: set[tuple[str, str]] = {
     ("TTFA", "TTS"),
 }
 
-# Interval strings for live aggregation
-_WINDOW_INTERVALS: dict[str, str] = {
-    "7d": "7 days",
-    "30d": "30 days",
-}
-
-# SQL for live aggregation (7d / 30d)
-_LIVE_SQL = """
-    SELECT provider, model,
-           AVG(metric_value)::float8 AS avg,
-           PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY metric_value)::float8 AS p50,
-           PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY metric_value)::float8 AS p95,
-           COUNT(*)::int AS n
-    FROM benchmarks_v2.results
-    WHERE status = 'success'
-      AND metric_type = %(metric)s
-      AND benchmark = %(benchmark)s
-      AND created_at >= NOW() - %(interval)s::interval
-    GROUP BY provider, model
-    ORDER BY avg ASC
-"""
-
-# SQL for materialized view (24h).
-# Note: the MV stores ``avg_value`` (not ``avg``) — aliased here for LeaderboardEntry.
-_MV_SQL = """
+_MV_SQL_TEMPLATE = """
     SELECT provider, model,
            avg_value AS avg,
            p50,
            p95,
-           n::int AS n
-    FROM benchmarks_v2.results_24h
+           sample_count AS n
+    FROM {view}
     WHERE metric_type = %(metric)s
       AND benchmark = %(benchmark)s
     ORDER BY avg_value ASC
@@ -97,7 +71,7 @@ async def get_leaderboard(
     Args:
         metric: One of WER, TTFA, TTFT, TTFS.
         benchmark: One of STT, TTS.
-        window: Time window — 24h uses the materialized view; 7d/30d run live.
+        window: Time window — each is served by its materialized view.
 
     Returns:
         ``{"metric": ..., "window": ..., "entries": [LeaderboardEntry, ...]}``
@@ -113,12 +87,7 @@ async def get_leaderboard(
         )
 
     params: dict[str, Any] = {"metric": metric, "benchmark": benchmark}
-
-    if window == "24h":
-        sql = _MV_SQL
-    else:
-        sql = _LIVE_SQL
-        params["interval"] = _WINDOW_INTERVALS[window]
+    sql = _MV_SQL_TEMPLATE.format(view=WINDOW_VIEWS[window])
 
     async with pool.connection() as conn:
         conn.row_factory = psycopg.rows.dict_row

--- a/runner/src/coval_bench/api/routers/leaderboard.py
+++ b/runner/src/coval_bench/api/routers/leaderboard.py
@@ -9,8 +9,8 @@ Metric/benchmark compatibility:
 - TTFA + TTS
 
 Every window queries its materialized view (``benchmarks_v2.results_24h``/
-``results_7d``/``results_30d``), refreshed by a Cloud Scheduler cron —
-read-only here.
+``results_7d``/``results_30d``), refreshed by the runner at the end of each
+benchmark run — read-only here.
 """
 
 from __future__ import annotations

--- a/runner/src/coval_bench/api/schemas.py
+++ b/runner/src/coval_bench/api/schemas.py
@@ -112,6 +112,9 @@ class ModelStatEntry(BaseModel):
     p25: float
     p50: float
     p75: float
+    p90: float
+    p95: float
+    p99: float
     min_value: float
     max_value: float
     sample_count: int

--- a/runner/src/coval_bench/db/migrations/env.py
+++ b/runner/src/coval_bench/db/migrations/env.py
@@ -15,8 +15,9 @@ Notes
 -----
 - DB roles and GRANTs are managed by Terraform, not Alembic.
 - The per-window materialized views (``results_24h``/``results_7d``/
-  ``results_30d``) are refreshed by a Cloud Scheduler cron; Alembic only
-  creates the initial definitions.
+  ``results_30d``) are refreshed by the runner at the end of each benchmark
+  run (REFRESH MATERIALIZED VIEW CONCURRENTLY); Alembic only creates the
+  initial definitions.
 - ``alembic_version`` is stored in the public schema (default) so that
   Alembic can create it before ``benchmarks_v2`` is created.
 - We connect via psycopg3 sync connection + SQLAlchemy ``create_engine``

--- a/runner/src/coval_bench/db/migrations/env.py
+++ b/runner/src/coval_bench/db/migrations/env.py
@@ -14,8 +14,9 @@ connection (Cloud SQL Auth Proxy).
 Notes
 -----
 - DB roles and GRANTs are managed by Terraform, not Alembic.
-- The ``results_24h`` materialized view is refreshed by a Cloud Scheduler
-  cron; Alembic only creates the initial definition.
+- The per-window materialized views (``results_24h``/``results_7d``/
+  ``results_30d``) are refreshed by a Cloud Scheduler cron; Alembic only
+  creates the initial definitions.
 - ``alembic_version`` is stored in the public schema (default) so that
   Alembic can create it before ``benchmarks_v2`` is created.
 - We connect via psycopg3 sync connection + SQLAlchemy ``create_engine``

--- a/runner/src/coval_bench/db/migrations/versions/20260429_0001_init_schema.py
+++ b/runner/src/coval_bench/db/migrations/versions/20260429_0001_init_schema.py
@@ -13,9 +13,9 @@ DB roles (``runner``, ``api``) and GRANTs are managed by Terraform.
 Alembic does NOT create or alter roles.
 
 The ``results_24h`` materialized view is populated immediately but will be
-empty until results are inserted.  Refresh is handled out-of-band by a
-Cloud Scheduler cron via ``REFRESH MATERIALIZED VIEW CONCURRENTLY
-results_24h``. That cron is out of scope for this migration.
+empty until results are inserted.  Refresh is handled by the runner at the
+end of each benchmark run via ``REFRESH MATERIALIZED VIEW CONCURRENTLY``;
+that refresh is out of scope for this migration.
 """
 
 from __future__ import annotations

--- a/runner/src/coval_bench/db/migrations/versions/20260611_0005_per_window_stats_matviews.py
+++ b/runner/src/coval_bench/db/migrations/versions/20260611_0005_per_window_stats_matviews.py
@@ -13,9 +13,9 @@ endpoint applied live.
 results_24h is dropped and recreated in this shape (it previously held only
 avg/p50/p95/n and did not gate on the parent run). Each view gets a unique
 index on the group key so it can be refreshed with REFRESH MATERIALIZED VIEW
-CONCURRENTLY. Refresh remains out-of-band (Cloud Scheduler cron); this
-migration only creates the views, so they hold data as of migration time
-until the first refresh.
+CONCURRENTLY. The runner refreshes them at the end of each benchmark run; this
+migration only creates the views, so they hold data as of migration time until
+the first post-migration run refreshes them.
 """
 
 from __future__ import annotations

--- a/runner/src/coval_bench/db/migrations/versions/20260611_0005_per_window_stats_matviews.py
+++ b/runner/src/coval_bench/db/migrations/versions/20260611_0005_per_window_stats_matviews.py
@@ -1,0 +1,98 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Per-window stats materialized views: results_24h, results_7d, results_30d.
+
+One view per dashboard window, all sharing a wide stats shape per
+(provider, model, benchmark, metric_type): avg, sample stddev, min,
+p25/p50/p75/p90/p95/p99 (a single PERCENTILE_CONT over an array, so one
+sort), max, count. Rows gate on result status='success', a non-null metric_value,
+and a parent run in (succeeded, partial) — the same filters the aggregates
+endpoint applied live.
+
+results_24h is dropped and recreated in this shape (it previously held only
+avg/p50/p95/n and did not gate on the parent run). Each view gets a unique
+index on the group key so it can be refreshed with REFRESH MATERIALIZED VIEW
+CONCURRENTLY. Refresh remains out-of-band (Cloud Scheduler cron); this
+migration only creates the views, so they hold data as of migration time
+until the first refresh.
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "20260611_0005"
+down_revision = "20260605_0004"
+branch_labels = None
+depends_on = None
+
+_WINDOWS: dict[str, str] = {
+    "results_24h": "24 hours",
+    "results_7d": "7 days",
+    "results_30d": "30 days",
+}
+
+
+def _view_sql(name: str, interval: str) -> str:
+    # S608 false-positive: name and interval come from the _WINDOWS constant.
+    return f"""
+        CREATE MATERIALIZED VIEW benchmarks_v2.{name} AS
+        SELECT provider, model, benchmark, metric_type,
+               avg_value, stddev_value, min_value,
+               pct[1] AS p25, pct[2] AS p50, pct[3] AS p75,
+               pct[4] AS p90, pct[5] AS p95, pct[6] AS p99,
+               max_value, sample_count
+        FROM (
+            SELECT r.provider, r.model, r.benchmark, r.metric_type,
+                   AVG(r.metric_value)::float8 AS avg_value,
+                   COALESCE(STDDEV_SAMP(r.metric_value), 0)::float8 AS stddev_value,
+                   MIN(r.metric_value)::float8 AS min_value,
+                   PERCENTILE_CONT(ARRAY[0.25, 0.5, 0.75, 0.9, 0.95, 0.99])
+                       WITHIN GROUP (ORDER BY r.metric_value)::float8[] AS pct,
+                   MAX(r.metric_value)::float8 AS max_value,
+                   COUNT(*)::int AS sample_count
+            FROM benchmarks_v2.results r
+            JOIN benchmarks_v2.runs rn ON rn.id = r.run_id
+            WHERE r.status = 'success'
+              AND rn.status IN ('succeeded', 'partial')
+              AND r.metric_value IS NOT NULL
+              AND r.created_at >= now() - INTERVAL '{interval}'
+            GROUP BY r.provider, r.model, r.benchmark, r.metric_type
+        ) stats
+    """  # noqa: S608
+
+
+def upgrade() -> None:
+    """Recreate results_24h in the wide shape and add results_7d/results_30d."""
+    op.execute("DROP MATERIALIZED VIEW IF EXISTS benchmarks_v2.results_24h")
+    for name, interval in _WINDOWS.items():
+        op.execute(_view_sql(name, interval))
+        op.execute(
+            f"CREATE UNIQUE INDEX {name}_group_key "
+            f"ON benchmarks_v2.{name} (provider, model, benchmark, metric_type)"
+        )
+
+
+def downgrade() -> None:
+    """Drop the per-window views and restore the original results_24h."""
+    for name in _WINDOWS:
+        op.execute(f"DROP MATERIALIZED VIEW IF EXISTS benchmarks_v2.{name}")
+    op.execute(
+        """
+        CREATE MATERIALIZED VIEW benchmarks_v2.results_24h AS
+        SELECT provider, model, benchmark, metric_type,
+               avg(metric_value)                                        AS avg_value,
+               percentile_cont(0.5)  WITHIN GROUP (ORDER BY metric_value) AS p50,
+               percentile_cont(0.95) WITHIN GROUP (ORDER BY metric_value) AS p95,
+               count(*)                                                 AS n
+        FROM benchmarks_v2.results
+        WHERE status = 'success'
+          AND created_at >= now() - INTERVAL '24 hours'
+        GROUP BY provider, model, benchmark, metric_type
+        """
+    )
+    op.execute(
+        "CREATE INDEX results_24h_lookup_idx "
+        "ON benchmarks_v2.results_24h (benchmark, metric_type, avg_value)"
+    )

--- a/runner/src/coval_bench/db/writer.py
+++ b/runner/src/coval_bench/db/writer.py
@@ -29,6 +29,8 @@ from psycopg_pool import AsyncConnectionPool
 from coval_bench.db.models import Result, Run, RunStatus
 from coval_bench.registries import Metric
 
+STATS_MATVIEWS: tuple[str, ...] = ("results_24h", "results_7d", "results_30d")
+
 
 class RunWriter:
     """Per-run persistence helper.
@@ -157,4 +159,18 @@ class RunWriter:
         async with self._pool.connection() as conn:
             async with conn.cursor() as cur:
                 await cur.execute(sql, (status, error, run_id))
+            await conn.commit()
+
+    async def refresh_stats_matviews(self) -> None:
+        """Concurrently refresh the per-window stats materialized views.
+
+        ``CONCURRENTLY`` relies on each view's unique group-key index and does
+        not block API reads. Raises on error like the rest of ``RunWriter``.
+        """
+        async with self._pool.connection() as conn:
+            async with conn.cursor() as cur:
+                for view in STATS_MATVIEWS:
+                    await cur.execute(  # noqa: S608 — view names are constants
+                        f"REFRESH MATERIALIZED VIEW CONCURRENTLY benchmarks_v2.{view}"
+                    )
             await conn.commit()

--- a/runner/src/coval_bench/runner/orchestrator.py
+++ b/runner/src/coval_bench/runner/orchestrator.py
@@ -885,6 +885,17 @@ async def run_benchmarks(
 
             await writer.finish_run(run_id, status=final_status, error=None)
 
+            # Refresh after finish_run: the view query only counts runs already
+            # marked succeeded/partial. A failed refresh must not fail the run.
+            try:
+                await writer.refresh_stats_matviews()
+            except Exception as refresh_exc:
+                _log.error(
+                    "failed to refresh stats matviews",
+                    run_id=run_id,
+                    exc_info=refresh_exc,
+                )
+
             finished_at = datetime.now(tz=UTC)
             summary = RunSummary(
                 run_id=run_id,

--- a/runner/tests/api/conftest.py
+++ b/runner/tests/api/conftest.py
@@ -43,6 +43,14 @@ def _make_db_url(postgresql: Any) -> str:
     return f"postgresql://{info.user}:{info.password or ''}@{info.host}:{info.port}/{info.dbname}"
 
 
+# Mirrors the per-window matview migration (20260611_0005).
+_MV_WINDOWS: dict[str, str] = {
+    "results_24h": "24 hours",
+    "results_7d": "7 days",
+    "results_30d": "30 days",
+}
+
+
 async def _apply_schema(dsn: str) -> None:
     """Create the benchmarks_v2 schema and tables needed by the API tests.
 
@@ -85,19 +93,34 @@ async def _apply_schema(dsn: str) -> None:
                 created_at     timestamptz NOT NULL DEFAULT now()
             )
         """)
-        # Materialized view for 24h leaderboard
-        await aconn.execute("""
-            CREATE MATERIALIZED VIEW IF NOT EXISTS benchmarks_v2.results_24h AS
-            SELECT provider, model, benchmark, metric_type,
-                   AVG(metric_value)::float8 AS avg_value,
-                   PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY metric_value)::float8 AS p50,
-                   PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY metric_value)::float8 AS p95,
-                   COUNT(*) AS n
-            FROM benchmarks_v2.results
-            WHERE status = 'success'
-              AND created_at >= NOW() - INTERVAL '24 hours'
-            GROUP BY provider, model, benchmark, metric_type
-        """)
+        # Per-window stats materialized views (model_stats + leaderboard).
+        # S608 false-positive: name and interval come from the _MV_WINDOWS constant.
+        for name, interval in _MV_WINDOWS.items():
+            await aconn.execute(f"""
+                CREATE MATERIALIZED VIEW IF NOT EXISTS benchmarks_v2.{name} AS
+                SELECT provider, model, benchmark, metric_type,
+                       avg_value, stddev_value, min_value,
+                       pct[1] AS p25, pct[2] AS p50, pct[3] AS p75,
+                       pct[4] AS p90, pct[5] AS p95, pct[6] AS p99,
+                       max_value, sample_count
+                FROM (
+                    SELECT r.provider, r.model, r.benchmark, r.metric_type,
+                           AVG(r.metric_value)::float8 AS avg_value,
+                           COALESCE(STDDEV_SAMP(r.metric_value), 0)::float8 AS stddev_value,
+                           MIN(r.metric_value)::float8 AS min_value,
+                           PERCENTILE_CONT(ARRAY[0.25, 0.5, 0.75, 0.9, 0.95, 0.99])
+                               WITHIN GROUP (ORDER BY r.metric_value)::float8[] AS pct,
+                           MAX(r.metric_value)::float8 AS max_value,
+                           COUNT(*)::int AS sample_count
+                    FROM benchmarks_v2.results r
+                    JOIN benchmarks_v2.runs rn ON rn.id = r.run_id
+                    WHERE r.status = 'success'
+                      AND rn.status IN ('succeeded', 'partial')
+                      AND r.metric_value IS NOT NULL
+                      AND r.created_at >= now() - INTERVAL '{interval}'
+                    GROUP BY r.provider, r.model, r.benchmark, r.metric_type
+                ) stats
+            """)  # noqa: S608
     finally:
         await aconn.close()
 
@@ -281,10 +304,11 @@ async def _insert_result(
 
 
 async def _refresh_mv(postgresql: Any) -> None:
-    """Refresh the results_24h materialized view."""
+    """Refresh all per-window stats materialized views."""
     dsn = _make_db_url(postgresql)
     aconn = await psycopg.AsyncConnection.connect(dsn, autocommit=True)
     try:
-        await aconn.execute("REFRESH MATERIALIZED VIEW benchmarks_v2.results_24h")
+        for name in _MV_WINDOWS:
+            await aconn.execute(f"REFRESH MATERIALIZED VIEW benchmarks_v2.{name}")
     finally:
         await aconn.close()

--- a/runner/tests/api/test_aggregates.py
+++ b/runner/tests/api/test_aggregates.py
@@ -15,14 +15,15 @@ import pytest
 from fastapi import FastAPI
 from httpx import AsyncClient
 
-from coval_bench.api.common import WINDOW_INTERVALS, WindowLiteral
-from tests.api.conftest import _insert_result, _insert_run
+from coval_bench.api.common import WINDOW_INTERVALS, WINDOW_VIEWS, WindowLiteral
+from tests.api.conftest import _insert_result, _insert_run, _refresh_mv
 
 
 def test_intervals_cover_every_window() -> None:
-    """Every WindowLiteral value must have an interval — a window added to
-    the literal but not the dict 500s after validation."""
+    """Every WindowLiteral value must have an interval and a view — a window
+    added to the literal but not the dicts 500s after validation."""
     assert set(WINDOW_INTERVALS) == set(get_args(WindowLiteral))
+    assert set(WINDOW_VIEWS) == set(get_args(WindowLiteral))
 
 
 async def test_empty_db_returns_empty_blocks(client: AsyncClient) -> None:
@@ -45,6 +46,7 @@ async def test_model_stats_math(client: AsyncClient, postgresql: Any) -> None:
     run_id = await _insert_run(postgresql)
     for value in (1.0, 2.0, 3.0, 4.0):
         await _insert_result(postgresql, run_id, metric_type="WER", metric_value=value)
+    await _refresh_mv(postgresql)
 
     response = await client.get("/v1/results/aggregates", params={"benchmark": "STT"})
     assert response.status_code == 200
@@ -59,6 +61,9 @@ async def test_model_stats_math(client: AsyncClient, postgresql: Any) -> None:
     assert s["p25"] == pytest.approx(1.75)
     assert s["p50"] == pytest.approx(2.5)
     assert s["p75"] == pytest.approx(3.25)
+    assert s["p90"] == pytest.approx(3.7)
+    assert s["p95"] == pytest.approx(3.85)
+    assert s["p99"] == pytest.approx(3.97)
     # sample stddev of 1..4 = sqrt(5/3)
     assert s["stddev_value"] == pytest.approx(1.2909944, rel=1e-6)
     assert s["min_value"] == pytest.approx(1.0)
@@ -70,6 +75,7 @@ async def test_single_sample_stddev_is_zero(client: AsyncClient, postgresql: Any
     """STDDEV_SAMP is NULL for n=1 — must be coalesced to 0 like the client did."""
     run_id = await _insert_run(postgresql)
     await _insert_result(postgresql, run_id, metric_value=3.5)
+    await _refresh_mv(postgresql)
 
     response = await client.get("/v1/results/aggregates", params={"benchmark": "STT"})
     s = response.json()["model_stats"][0]
@@ -95,6 +101,7 @@ async def test_excludes_failed_null_and_other_benchmark(
     # Excluded: failed parent run
     failed_run = await _insert_run(postgresql, status="failed")
     await _insert_result(postgresql, failed_run, metric_value=100.0)
+    await _refresh_mv(postgresql)
 
     response = await client.get("/v1/results/aggregates", params={"benchmark": "STT"})
     stats = response.json()["model_stats"]
@@ -106,6 +113,7 @@ async def test_excludes_failed_null_and_other_benchmark(
 async def test_partial_runs_included(client: AsyncClient, postgresql: Any) -> None:
     run_id = await _insert_run(postgresql, status="partial")
     await _insert_result(postgresql, run_id, metric_value=2.0)
+    await _refresh_mv(postgresql)
 
     response = await client.get("/v1/results/aggregates", params={"benchmark": "STT"})
     assert response.json()["model_stats"][0]["sample_count"] == 1
@@ -146,6 +154,7 @@ async def test_window_excludes_old_rows(client: AsyncClient, postgresql: Any) ->
     run_id = await _insert_run(postgresql)
     old = datetime.now(dt.UTC) - timedelta(days=10)
     await _insert_result(postgresql, run_id, created_at=old, metric_value=1.0)
+    await _refresh_mv(postgresql)
 
     response_24h = await client.get("/v1/results/aggregates", params={"benchmark": "STT"})
     assert response_24h.json()["model_stats"] == []
@@ -160,12 +169,14 @@ async def test_cache_serves_stale_within_ttl(client: AsyncClient, postgresql: An
     """A second identical request is served from cache, not re-queried."""
     run_id = await _insert_run(postgresql)
     await _insert_result(postgresql, run_id, metric_value=1.0)
+    await _refresh_mv(postgresql)
 
     first = await client.get("/v1/results/aggregates", params={"benchmark": "STT"})
     assert first.json()["model_stats"][0]["sample_count"] == 1
 
-    # Out-of-band insert that a fresh query would pick up.
+    # Out-of-band insert + refresh that a fresh query would pick up.
     await _insert_result(postgresql, run_id, metric_value=3.0)
+    await _refresh_mv(postgresql)
 
     second = await client.get("/v1/results/aggregates", params={"benchmark": "STT"})
     # Unchanged — served from the cached response, DB not re-scanned.
@@ -177,6 +188,7 @@ async def test_cache_keyed_by_params(client: AsyncClient, postgresql: Any) -> No
     run_id = await _insert_run(postgresql)
     old = datetime.now(dt.UTC) - timedelta(days=10)
     await _insert_result(postgresql, run_id, created_at=old, metric_value=1.0)
+    await _refresh_mv(postgresql)
 
     # 24h excludes the 10-day-old row; 30d includes it. Distinct cache keys.
     r_24h = await client.get("/v1/results/aggregates", params={"benchmark": "STT"})
@@ -194,6 +206,7 @@ async def test_concurrent_misses_coalesce(
 
     run_id = await _insert_run(postgresql)
     await _insert_result(postgresql, run_id, metric_value=1.0)
+    await _refresh_mv(postgresql)
 
     acquisitions = 0
     real_pool = app.state.pool
@@ -264,6 +277,7 @@ async def test_models_grouped_separately(client: AsyncClient, postgresql: Any) -
         metric_type="TTFT",
         metric_value=0.5,
     )
+    await _refresh_mv(postgresql)
 
     response = await client.get("/v1/results/aggregates", params={"benchmark": "STT"})
     stats = response.json()["model_stats"]

--- a/runner/tests/api/test_leaderboard.py
+++ b/runner/tests/api/test_leaderboard.py
@@ -62,8 +62,8 @@ async def test_ttfa_stt_incompatible(client: AsyncClient) -> None:
     assert response.status_code == 400
 
 
-async def test_ttft_stt_7d_live_aggregation(client: AsyncClient, postgresql: Any) -> None:
-    """window=7d runs live aggregation for TTFT+STT."""
+async def test_ttft_stt_7d_window(client: AsyncClient, postgresql: Any) -> None:
+    """window=7d serves TTFT+STT from the results_7d view."""
     run_id = await _insert_run(postgresql)
     await _insert_result(
         postgresql,
@@ -75,6 +75,7 @@ async def test_ttft_stt_7d_live_aggregation(client: AsyncClient, postgresql: Any
         metric_units="ms",
         benchmark="STT",
     )
+    await _refresh_mv(postgresql)
 
     response = await client.get(
         "/v1/leaderboard",
@@ -103,8 +104,8 @@ async def test_missing_metric_returns_422(client: AsyncClient) -> None:
     assert response.status_code == 422
 
 
-async def test_30d_window_live_aggregation(client: AsyncClient, postgresql: Any) -> None:
-    """window=30d runs live aggregation."""
+async def test_30d_window(client: AsyncClient, postgresql: Any) -> None:
+    """window=30d serves from the results_30d view."""
     run_id = await _insert_run(postgresql)
     await _insert_result(
         postgresql,
@@ -115,6 +116,7 @@ async def test_30d_window_live_aggregation(client: AsyncClient, postgresql: Any)
         metric_value=6.0,
         benchmark="STT",
     )
+    await _refresh_mv(postgresql)
     response = await client.get(
         "/v1/leaderboard",
         params={"metric": "WER", "benchmark": "STT", "window": "30d"},

--- a/runner/tests/unit/test_db_writer.py
+++ b/runner/tests/unit/test_db_writer.py
@@ -354,6 +354,54 @@ def test_results_24h_view(pg_conn: psycopg.Connection[Any]) -> None:
     assert abs(float(row["p50"]) - 0.3) < 0.001
 
 
+def test_refresh_stats_matviews(pg_conn: psycopg.Connection[Any]) -> None:
+    """finish_run → refresh_stats_matviews populates all three per-window views."""
+    _apply_migrations(pg_conn)
+
+    async def _run() -> None:
+        pool = await _make_pool(pg_conn)
+        try:
+            writer = RunWriter(pool)
+            run = await writer.start_run(
+                runner_sha="abc123", dataset_id="stt-v1", dataset_sha256="deadbeef"
+            )
+            assert run.id is not None
+            results = [
+                Result(
+                    run_id=run.id,
+                    provider="openai",
+                    model="whisper-1",
+                    benchmark=Benchmark.STT,
+                    metric_type="WER",
+                    metric_value=float(i) * 0.1,
+                    metric_units="ratio",
+                    status=ResultStatus.SUCCESS,
+                )
+                for i in range(1, 6)
+            ]
+            await writer.record_results(results)
+            await writer.finish_run(run.id, status=RunStatus.SUCCEEDED)
+            await writer.refresh_stats_matviews()
+        finally:
+            await pool.close()
+
+    asyncio.run(_run())
+
+    pg_conn.autocommit = True
+    for view in ("results_24h", "results_7d", "results_30d"):
+        with pg_conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+            cur.execute(
+                f"SELECT avg_value, p50, sample_count FROM benchmarks_v2.{view} "  # noqa: S608
+                "WHERE provider = 'openai' AND model = 'whisper-1' AND metric_type = 'WER'"
+            )
+            row = cur.fetchone()
+        assert row is not None, f"{view} was not refreshed"
+        assert row["sample_count"] == 5
+        # avg of [0.1..0.5] = 0.3; p50 = 0.3
+        assert abs(float(row["avg_value"]) - 0.3) < 0.001
+        assert abs(float(row["p50"]) - 0.3) < 0.001
+
+
 def test_records_http_diagnostics(pg_conn: psycopg.Connection[Any]) -> None:
     """http_version and submit_to_headers_ms round-trip through the writer."""
     _apply_migrations(pg_conn)

--- a/runner/tests/unit/test_db_writer.py
+++ b/runner/tests/unit/test_db_writer.py
@@ -340,14 +340,14 @@ def test_results_24h_view(pg_conn: psycopg.Connection[Any]) -> None:
 
     with pg_conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
         cur.execute(
-            "SELECT avg_value, p50, p95, n "
+            "SELECT avg_value, p50, p95, sample_count "
             "FROM benchmarks_v2.results_24h "
             "WHERE provider = 'openai' AND model = 'whisper-1' AND metric_type = 'WER'"
         )
         row = cur.fetchone()
 
     assert row is not None
-    assert row["n"] == 5
+    assert row["sample_count"] == 5
     # avg of [0.1, 0.2, 0.3, 0.4, 0.5] = 0.3
     assert abs(float(row["avg_value"]) - 0.3) < 0.001
     # p50 = median = 0.3

--- a/runner/tests/unit/test_orchestrator.py
+++ b/runner/tests/unit/test_orchestrator.py
@@ -146,6 +146,7 @@ def _make_stub_writer(run: Run) -> MagicMock:
     writer.start_run = AsyncMock(return_value=run)
     writer.record_results = AsyncMock()
     writer.finish_run = AsyncMock()
+    writer.refresh_stats_matviews = AsyncMock()
     return writer
 
 
@@ -312,6 +313,7 @@ async def test_smoke_run_stt(audio_file: Path, settings: Settings) -> None:
     # both deepgram and elevenlabs each fire multiple times via the same mock.
     assert writer.record_results.await_count >= 2
     writer.finish_run.assert_awaited_once_with(1, status=RunStatus.SUCCEEDED, error=None)
+    writer.refresh_stats_matviews.assert_awaited_once_with()
 
 
 # ---------------------------------------------------------------------------

--- a/web/components/charts/d3/HeatmapPlot.tsx
+++ b/web/components/charts/d3/HeatmapPlot.tsx
@@ -31,86 +31,46 @@ const HeatmapPlot: React.FC<HeatmapProps> = ({
   });
   const themeColors = useThemeColors();
 
-  // Define metrics based on active tab
   const metrics = useMemo(() => {
-    return activeTab === "tts"
-      ? [
-          {
-            key: "latencyP25" as keyof ModelHeatmapData,
-            label: "P25 Latency",
-            unit: "ms",
-            lowerIsBetter: true
-          },
-          {
-            key: "latencyP50" as keyof ModelHeatmapData,
-            label: "P50 Latency",
-            unit: "ms",
-            lowerIsBetter: true
-          },
-          {
-            key: "latencyP75" as keyof ModelHeatmapData,
-            label: "P75 Latency",
-            unit: "ms",
-            lowerIsBetter: true
-          },
-          {
-            key: "latencyIQR" as keyof ModelHeatmapData,
-            label: "Latency IQR",
-            unit: "ms",
-            lowerIsBetter: true
-          },
-          {
-            key: "avgWER" as keyof ModelHeatmapData,
-            label: "Avg WER",
-            unit: "%",
-            lowerIsBetter: true
-          },
-          {
-            key: "werStdDev" as keyof ModelHeatmapData,
-            label: "WER Std Dev",
-            unit: "%",
-            lowerIsBetter: true
-          }
-        ]
-      : [
-          {
-            key: "latencyP25" as keyof ModelHeatmapData,
-            label: "P25 Delta",
-            unit: "ms",
-            lowerIsBetter: true
-          },
-          {
-            key: "latencyP50" as keyof ModelHeatmapData,
-            label: "P50 Delta",
-            unit: "ms",
-            lowerIsBetter: true
-          },
-          {
-            key: "latencyP75" as keyof ModelHeatmapData,
-            label: "P75 Delta",
-            unit: "ms",
-            lowerIsBetter: true
-          },
-          {
-            key: "latencyIQR" as keyof ModelHeatmapData,
-            label: "Delta IQR",
-            unit: "ms",
-            lowerIsBetter: true
-          },
-          {
-            key: "avgWER" as keyof ModelHeatmapData,
-            label: "Avg WER",
-            unit: "%",
-            lowerIsBetter: true
-          },
-          {
-            key: "werStdDev" as keyof ModelHeatmapData,
-            label: "WER Std Dev",
-            unit: "%",
-            lowerIsBetter: true
-          }
-        ];
-  }, [activeTab]);
+    return [
+      {
+        key: "latencyP25" as keyof ModelHeatmapData,
+        label: "P25 Latency",
+        unit: "ms",
+        lowerIsBetter: true
+      },
+      {
+        key: "latencyP50" as keyof ModelHeatmapData,
+        label: "P50 Latency",
+        unit: "ms",
+        lowerIsBetter: true
+      },
+      {
+        key: "latencyP75" as keyof ModelHeatmapData,
+        label: "P75 Latency",
+        unit: "ms",
+        lowerIsBetter: true
+      },
+      {
+        key: "latencyIQR" as keyof ModelHeatmapData,
+        label: "Latency IQR",
+        unit: "ms",
+        lowerIsBetter: true
+      },
+      {
+        key: "avgWER" as keyof ModelHeatmapData,
+        label: "Avg WER",
+        unit: "%",
+        lowerIsBetter: true
+      },
+      {
+        key: "werStdDev" as keyof ModelHeatmapData,
+        label: "WER Std Dev",
+        unit: "%",
+        lowerIsBetter: true
+      }
+    ];
+  }, []);
 
   // Calculate dynamic height based on data
   const cellHeight = 50;

--- a/web/hooks/useChartData.ts
+++ b/web/hooks/useChartData.ts
@@ -143,13 +143,6 @@ export function useChartData({
     return out;
   }, [series, toDisplayUnits]);
 
-  // Primary latency metric series (TTFT for STT, TTFA for TTS). Also feeds the
-  // STT heatmap deltas and the gap chart.
-  const timelineByModel = useMemo<Record<string, Record<number, number>>>(() => {
-    const primaryMetric = activeTab === "tts" ? "TTFA" : "TTFT";
-    return timelineByMetricModel[primaryMetric] ?? {};
-  }, [timelineByMetricModel, activeTab]);
-
   // Timeline rows for a given metric. Models follow the active tab (STT models
   // for TTFS/TTFT, TTS models for TTFA).
   const getTimelineData = useCallback(
@@ -288,78 +281,27 @@ export function useChartData({
     [scatterByMetricModel, activeTab, selectedTTSModels, selectedSTTModels]
   );
 
-  // STT heatmap: latency deltas relative to the fastest selected model at
-  // each timestamp, percentiled per model. Deltas depend on the selection, so
-  // they are computed here from the per-model series.
-  const modelHeatmapDataMemo = useMemo<ModelHeatmapData[]>(() => {
+  // Heatmap rows: absolute latency percentiles straight from the SQL stats
+  // (like the box plot), plus avg WER.
+  const heatmapDataMemo = useMemo<ModelHeatmapData[]>(() => {
     const selectedModels =
       activeTab === "tts" ? selectedTTSModels : selectedSTTModels;
     const latencyMetric = activeTab === "tts" ? "TTFA" : "TTFT";
 
-    if (selectedModels.length === 0) {
-      return [];
-    }
-
-    // Per-timestamp averages for the selected models.
-    const averagedTimestampGroups: { [key: number]: { [key: string]: number } } = {};
-    selectedModels.forEach((model) => {
-      const tsMap = timelineByModel[model];
-      if (!tsMap) return;
-      Object.entries(tsMap).forEach(([timestamp, avg]) => {
-        const bucket = Number(timestamp);
-        if (!averagedTimestampGroups[bucket]) {
-          averagedTimestampGroups[bucket] = {};
-        }
-        const group = averagedTimestampGroups[bucket];
-        if (group) {
-          group[model] = avg;
-        }
-      });
-    });
-
     const heatmapData: ModelHeatmapData[] = [];
 
     selectedModels.forEach((model) => {
-      const werStat = getStat(model, "WER");
       const latencyStat = getStat(model, latencyMetric);
+      const werStat = getStat(model, "WER");
 
-      // Need both latency and WER data
-      if (!werStat || !latencyStat) return;
+      if (!latencyStat || !werStat) return;
 
-      // Calculate latency deltas relative to fastest at each timestamp
-      const latencyDeltas: number[] = [];
-      Object.values(averagedTimestampGroups).forEach((modelValues) => {
-        const modelVal = modelValues[model];
-        if (modelVal !== undefined) {
-          const allVals = Object.values(modelValues);
-          const fastest = allVals.length > 0 ? Math.min(...allVals) : 0;
-          const delta = modelVal - fastest;
-          latencyDeltas.push(delta);
-        }
-      });
-
-      // Delta percentiles (relative to the selection, so computed here)
-      const sorted = [...latencyDeltas].sort((a, b) => a - b);
-      const n = sorted.length;
-      let p25 = 0, p50 = 0, p75 = 0;
-      if (n > 0) {
-        const getPercentile = (pct: number): number => {
-          const index = (pct / 100) * (n - 1);
-          const lower = Math.floor(index);
-          const upper = Math.ceil(index);
-          if (lower === upper) return sorted[lower] ?? 0;
-          const weight = index - lower;
-          return (sorted[lower] ?? 0) * (1 - weight) + (sorted[upper] ?? 0) * weight;
-        };
-        p25 = getPercentile(25);
-        p50 = getPercentile(50);
-        p75 = getPercentile(75);
-      }
-
+      const p25 = toDisplayUnits(latencyStat.p25);
+      const p75 = toDisplayUnits(latencyStat.p75);
       heatmapData.push({
         model,
         latencyP25: p25,
-        latencyP50: p50,
+        latencyP50: toDisplayUnits(latencyStat.p50),
         latencyP75: p75,
         latencyIQR: p75 - p25,
         avgWER: werStat.avg_value,
@@ -372,54 +314,11 @@ export function useChartData({
         normalizeModelName(a.model).localeCompare(normalizeModelName(b.model)) ||
         a.model.localeCompare(b.model)
     );
-  }, [
-    timelineByModel,
-    activeTab,
-    selectedTTSModels,
-    selectedSTTModels,
-    getStat
-  ]);
+  }, [activeTab, selectedTTSModels, selectedSTTModels, getStat, toDisplayUnits]);
 
-  const getModelHeatmapData = useCallback(
-    (): ModelHeatmapData[] => modelHeatmapDataMemo,
-    [modelHeatmapDataMemo]
-  );
-
-  // TTS heatmap uses absolute percentiles — straight from the SQL stats
-  const ttsHeatmapDataMemo = useMemo<ModelHeatmapData[]>(() => {
-    if (activeTab !== "tts" || selectedTTSModels.length === 0) {
-      return [];
-    }
-
-    const heatmapData: ModelHeatmapData[] = [];
-
-    selectedTTSModels.forEach((model) => {
-      const latencyStat = getStat(model, "TTFA");
-      const werStat = getStat(model, "WER");
-
-      if (!latencyStat || !werStat) return;
-
-      heatmapData.push({
-        model,
-        latencyP25: latencyStat.p25,
-        latencyP50: latencyStat.p50,
-        latencyP75: latencyStat.p75,
-        latencyIQR: latencyStat.p75 - latencyStat.p25,
-        avgWER: werStat.avg_value,
-        werStdDev: werStat.stddev_value
-      });
-    });
-
-    return heatmapData.sort(
-      (a, b) =>
-        normalizeModelName(a.model).localeCompare(normalizeModelName(b.model)) ||
-        a.model.localeCompare(b.model)
-    );
-  }, [activeTab, selectedTTSModels, getStat]);
-
-  const getTTSHeatmapData = useCallback(
-    (): ModelHeatmapData[] => ttsHeatmapDataMemo,
-    [ttsHeatmapDataMemo]
+  const getHeatmapData = useCallback(
+    (): ModelHeatmapData[] => heatmapDataMemo,
+    [heatmapDataMemo]
   );
 
   const werBarDataMemo = useMemo<BarDataPoint[]>(() => {
@@ -543,8 +442,7 @@ export function useChartData({
     getTimelineData,
     getBoxPlotData,
     getScatterData,
-    getModelHeatmapData,
-    getTTSHeatmapData,
+    getHeatmapData,
     getWERBarData,
     getCurrentTimeWindow,
     getTimelineTicks,

--- a/web/hooks/useDashboardState.tsx
+++ b/web/hooks/useDashboardState.tsx
@@ -232,7 +232,6 @@ export function useDashboardState(page: "tts" | "stt") {
   } = keyMetrics;
 
   // Get computed data
-  const heatmapData = chartData.getModelHeatmapData();
   const werBarData = chartData.getWERBarData();
 
   const werBarDataWithColors = useMemo(() => {
@@ -280,9 +279,7 @@ export function useDashboardState(page: "tts" | "stt") {
           "In voice AI applications, transcription accuracy directly impacts the performance of downstream tasks. Even small transcription errors can lead to misinterpretations, frustrating experiences, or incorrect system responses. We evaluate against test audio that includes diverse speakers, accents, and real-world audio conditions. Click a bar to highlight it for comparison.",
       };
 
-  const heatmapDisplayData = page === "tts"
-    ? chartData.getTTSHeatmapData()
-    : heatmapData;
+  const heatmapDisplayData = chartData.getHeatmapData();
 
   // Pre-computed key metrics for display
   const primaryKeyMetric = (() => {


### PR DESCRIPTION
The leaderboard and the aggregates model_stats block read entirely from results_24h/7d/30d, and nothing refreshed them. Refresh all three CONCURRENTLY from the orchestrator's finish path, after the run row is marked succeeded/partial so its results are visible to the view query. A failed refresh logs loudly but does not fail the run; the views just stay one cycle stale.

Update the stale Cloud Scheduler cron wording in the migration env.py, leaderboard, aggregates, and migration docstrings to describe the runner-side refresh.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dashboard aggregate data (24h, 7d, 30d) and leaderboard stats now use pre-computed per-window aggregates and are automatically refreshed at the end of each benchmark run, providing consistent, up-to-date, read-only results.

* **Documentation**
  * Clarified docs to state that per-window aggregate views are refreshed by the runner at benchmark completion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR wires matview refreshes into the orchestrator's finish path (after `finish_run` marks the run succeeded/partial) and consolidates the leaderboard and aggregates endpoints to read exclusively from the three materialized views (`results_24h/7d/30d`). A new migration recreates `results_24h` in a wider shape (adding p90/p95/p99 percentiles) and adds `results_7d`/`results_30d`; corresponding docs, tests, and the frontend heatmap are updated.

- **Backend**: `refresh_stats_matviews` issues `REFRESH MATERIALIZED VIEW CONCURRENTLY` for all three views; both API routers now read purely from the views instead of mixing live queries for 7d/30d.
- **Migration**: Drops and recreates `results_24h`, creates `results_7d`/`results_30d`, each with a unique group-key index required for `CONCURRENTLY` refresh.
- **Frontend**: Unifies STT and TTS heatmap paths into a single absolute-percentile calculation, removing the previous delta-based STT variant.

<h3>Confidence Score: 4/5</h3>

The core new feature — runner-side matview refresh — does not work in production due to the connection pool's autocommit=False setting, which causes every REFRESH MATERIALIZED VIEW CONCURRENTLY call to raise inside an implicit transaction block. The orchestrator's exception handler silently swallows the error, so the views stay permanently stale. This issue was raised in the previous review thread and has not been addressed in the current diff.

The unresolved transaction-block issue in refresh_stats_matviews means the PR's primary deliverable (keeping matviews current after each run) will silently fail on every run in production. Everything else in the PR — the migration, the API query consolidation, the schema additions, and the frontend unification — is clean and correct. The defect is isolated to writer.py:refresh_stats_matviews and its callers, and a one-line fix (await conn.set_autocommit(True)) is all that is needed.

runner/src/coval_bench/db/writer.py — the refresh_stats_matviews method and the new unit test for it both need autocommit=True on the connection before issuing the REFRESH statement.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| runner/src/coval_bench/db/writer.py | Adds refresh_stats_matviews using REFRESH MATERIALIZED VIEW CONCURRENTLY inside a psycopg3 connection pool configured with autocommit=False — this will always raise in production (flagged in previous thread, still unresolved). |
| runner/src/coval_bench/runner/orchestrator.py | Correctly calls refresh_stats_matviews after finish_run with a try/except guard so a refresh failure doesn't abort the run; SIGTERM path is a known gap already flagged. |
| runner/src/coval_bench/db/migrations/versions/20260611_0005_per_window_stats_matviews.py | Creates results_24h/7d/30d with wide stats shape and unique group-key indexes for CONCURRENTLY refresh; downgrade correctly restores the original results_24h non-unique index. |
| runner/src/coval_bench/api/routers/aggregates.py | Switches model_stats block from live aggregation to a parameterized matview template query; safe since view name comes from validated WINDOW_VIEWS constant. |
| runner/src/coval_bench/api/routers/leaderboard.py | Removes the 24h-vs-live branching; all windows now use _MV_SQL_TEMPLATE with the schema-qualified view name; column aliases (avg_value→avg, sample_count→n) correctly match LeaderboardEntry schema. |
| runner/tests/unit/test_db_writer.py | Adds test_refresh_stats_matviews which exercises the full migration + writer path; will fail in CI because the pool uses autocommit=False — same root cause as the previous-thread finding. |
| runner/tests/unit/test_orchestrator.py | Adds refresh_stats_matviews mock and asserts it in the smoke-run case; partial/failed cases still don't assert the call (noted in previous thread). |
| web/hooks/useChartData.ts | Unifies STT and TTS heatmap into a single absolute-percentile path; toDisplayUnits is a no-op for TTS (TTS latency already in ms) so the TTS output is unchanged. |
| web/hooks/useDashboardState.tsx | Removes the page-conditional heatmap selection in favour of the unified getHeatmapData call. |
| web/components/charts/d3/HeatmapPlot.tsx | Removes the tab-dependent metrics array; both STT and TTS now show absolute P25/P50/P75 latency labels, which is correct given the shift from delta to absolute data. |
| runner/tests/api/conftest.py | Correctly creates all three matviews in tests (without unique indexes, using plain REFRESH in _refresh_mv with autocommit=True) matching the new view shape. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Orch as Orchestrator
    participant Writer as RunWriter
    participant DB as PostgreSQL

    Orch->>Writer: "finish_run(run_id, status=succeeded/partial)"
    Writer->>DB: "UPDATE runs SET status=succeeded/partial"
    DB-->>Writer: OK
    Writer-->>Orch: OK

    Orch->>Writer: refresh_stats_matviews()
    Writer->>DB: REFRESH MATERIALIZED VIEW CONCURRENTLY results_24h
    Writer->>DB: REFRESH MATERIALIZED VIEW CONCURRENTLY results_7d
    Writer->>DB: REFRESH MATERIALIZED VIEW CONCURRENTLY results_30d
    DB-->>Writer: OK (views now current)
    Writer-->>Orch: OK

    Note over Orch: Failed refresh is caught and logged — run is not failed

    participant API as API (leaderboard/aggregates)
    API->>DB: "SELECT from benchmarks_v2.results_24h WHERE benchmark=..."
    DB-->>API: Fresh rows (post-refresh)
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `runner/src/coval_bench/runner/orchestrator.py`, line 940-996 ([link](https://github.com/coval-ai/benchmarks/blob/e813923836a874431c01f2298bb0ca45288ac0a2/runner/src/coval_bench/runner/orchestrator.py#L940-L996)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **SIGTERM path marks run PARTIAL but never refreshes matviews**

   The SIGTERM handler (lines 948–955) calls `finish_run` with `RunStatus.PARTIAL`, so results from that run become visible to the view query filter (`rn.status IN ('succeeded', 'partial')`). However `refresh_stats_matviews` is only called from the normal finish path; SIGTERM-interrupted runs with PARTIAL results will leave the three views one cycle stale until the next successful run triggers a refresh.

   Whether the added `asyncio.shield` complexity is worth guarding here is a judgment call, but the asymmetry is worth making explicit in a comment if it's intentional.

2. `runner/tests/unit/test_orchestrator.py`, line 360-364 ([link](https://github.com/coval-ai/benchmarks/blob/e813923836a874431c01f2298bb0ca45288ac0a2/runner/tests/unit/test_orchestrator.py#L360-L364)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`refresh_stats_matviews` not asserted in `test_partial_run` or `test_full_failure`**

   `test_smoke_run_stt` gains an assertion that `refresh_stats_matviews` was awaited, but the partial and full-failure cases do not. The normal finish path calls `refresh_stats_matviews` regardless of `final_status`, so `test_partial_run` silently skips verifying the new behaviour. Adding `writer.refresh_stats_matviews.assert_awaited_once_with()` to both tests would pin the contract and catch regressions.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["Refresh stats matviews at the end of eac..."](https://github.com/coval-ai/benchmarks/commit/04cc09d7a3f2b40950f7670b58ed6b7e9f514bfb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37101440)</sub>

<!-- /greptile_comment -->