### PR TITLE
Show absolute latency percentiles in the heatmap

### DIFF
--- a/web/components/charts/d3/HeatmapPlot.tsx
+++ b/web/components/charts/d3/HeatmapPlot.tsx
@@ -31,86 +31,46 @@ const HeatmapPlot: React.FC<HeatmapProps> = ({
   });
   const themeColors = useThemeColors();
 
-  // Define metrics based on active tab
   const metrics = useMemo(() => {
-    return activeTab === "tts"
-      ? [
-          {
-            key: "latencyP25" as keyof ModelHeatmapData,
-            label: "P25 Latency",
-            unit: "ms",
-            lowerIsBetter: true
-          },
-          {
-            key: "latencyP50" as keyof ModelHeatmapData,
-            label: "P50 Latency",
-            unit: "ms",
-            lowerIsBetter: true
-          },
-          {
-            key: "latencyP75" as keyof ModelHeatmapData,
-            label: "P75 Latency",
-            unit: "ms",
-            lowerIsBetter: true
-          },
-          {
-            key: "latencyIQR" as keyof ModelHeatmapData,
-            label: "Latency IQR",
-            unit: "ms",
-            lowerIsBetter: true
-          },
-          {
-            key: "avgWER" as keyof ModelHeatmapData,
-            label: "Avg WER",
-            unit: "%",
-            lowerIsBetter: true
-          },
-          {
-            key: "werStdDev" as keyof ModelHeatmapData,
-            label: "WER Std Dev",
-            unit: "%",
-            lowerIsBetter: true
-          }
-        ]
-      : [
-          {
-            key: "latencyP25" as keyof ModelHeatmapData,
-            label: "P25 Delta",
-            unit: "ms",
-            lowerIsBetter: true
-          },
-          {
-            key: "latencyP50" as keyof ModelHeatmapData,
-            label: "P50 Delta",
-            unit: "ms",
-            lowerIsBetter: true
-          },
-          {
-            key: "latencyP75" as keyof ModelHeatmapData,
-            label: "P75 Delta",
-            unit: "ms",
-            lowerIsBetter: true
-          },
-          {
-            key: "latencyIQR" as keyof ModelHeatmapData,
-            label: "Delta IQR",
-            unit: "ms",
-            lowerIsBetter: true
-          },
-          {
-            key: "avgWER" as keyof ModelHeatmapData,
-            label: "Avg WER",
-            unit: "%",
-            lowerIsBetter: true
-          },
-          {
-            key: "werStdDev" as keyof ModelHeatmapData,
-            label: "WER Std Dev",
-            unit: "%",
-            lowerIsBetter: true
-          }
-        ];
-  }, [activeTab]);
+    return [
+      {
+        key: "latencyP25" as keyof ModelHeatmapData,
+        label: "P25 Latency",
+        unit: "ms",
+        lowerIsBetter: true
+      },
+      {
+        key: "latencyP50" as keyof ModelHeatmapData,
+        label: "P50 Latency",
+        unit: "ms",
+        lowerIsBetter: true
+      },
+      {
+        key: "latencyP75" as keyof ModelHeatmapData,
+        label: "P75 Latency",
+        unit: "ms",
+        lowerIsBetter: true
+      },
+      {
+        key: "latencyIQR" as keyof ModelHeatmapData,
+        label: "Latency IQR",
+        unit: "ms",
+        lowerIsBetter: true
+      },
+      {
+        key: "avgWER" as keyof ModelHeatmapData,
+        label: "Avg WER",
+        unit: "%",
+        lowerIsBetter: true
+      },
+      {
+        key: "werStdDev" as keyof ModelHeatmapData,
+        label: "WER Std Dev",
+        unit: "%",
+        lowerIsBetter: true
+      }
+    ];
+  }, []);
 
   // Calculate dynamic height based on data
   const cellHeight = 50;

--- a/web/hooks/useChartData.ts
+++ b/web/hooks/useChartData.ts
@@ -143,13 +143,6 @@ export function useChartData({
     return out;
   }, [series, toDisplayUnits]);
 
-  // Primary latency metric series (TTFT for STT, TTFA for TTS). Also feeds the
-  // STT heatmap deltas and the gap chart.
-  const timelineByModel = useMemo<Record<string, Record<number, number>>>(() => {
-    const primaryMetric = activeTab === "tts" ? "TTFA" : "TTFT";
-    return timelineByMetricModel[primaryMetric] ?? {};
-  }, [timelineByMetricModel, activeTab]);
-
   // Timeline rows for a given metric. Models follow the active tab (STT models
   // for TTFS/TTFT, TTS models for TTFA).
   const getTimelineData = useCallback(
@@ -288,78 +281,27 @@ export function useChartData({
     [scatterByMetricModel, activeTab, selectedTTSModels, selectedSTTModels]
   );
 
-  // STT heatmap: latency deltas relative to the fastest selected model at
-  // each timestamp, percentiled per model. Deltas depend on the selection, so
-  // they are computed here from the per-model series.
-  const modelHeatmapDataMemo = useMemo<ModelHeatmapData[]>(() => {
+  // Heatmap rows: absolute latency percentiles straight from the SQL stats
+  // (like the box plot), plus avg WER.
+  const heatmapDataMemo = useMemo<ModelHeatmapData[]>(() => {
     const selectedModels =
       activeTab === "tts" ? selectedTTSModels : selectedSTTModels;
     const latencyMetric = activeTab === "tts" ? "TTFA" : "TTFT";
 
-    if (selectedModels.length === 0) {
-      return [];
-    }
-
-    // Per-timestamp averages for the selected models.
-    const averagedTimestampGroups: { [key: number]: { [key: string]: number } } = {};
-    selectedModels.forEach((model) => {
-      const tsMap = timelineByModel[model];
-      if (!tsMap) return;
-      Object.entries(tsMap).forEach(([timestamp, avg]) => {
-        const bucket = Number(timestamp);
-        if (!averagedTimestampGroups[bucket]) {
-          averagedTimestampGroups[bucket] = {};
-        }
-        const group = averagedTimestampGroups[bucket];
-        if (group) {
-          group[model] = avg;
-        }
-      });
-    });
-
     const heatmapData: ModelHeatmapData[] = [];
 
     selectedModels.forEach((model) => {
-      const werStat = getStat(model, "WER");
       const latencyStat = getStat(model, latencyMetric);
+      const werStat = getStat(model, "WER");
 
-      // Need both latency and WER data
-      if (!werStat || !latencyStat) return;
+      if (!latencyStat || !werStat) return;
 
-      // Calculate latency deltas relative to fastest at each timestamp
-      const latencyDeltas: number[] = [];
-      Object.values(averagedTimestampGroups).forEach((modelValues) => {
-        const modelVal = modelValues[model];
-        if (modelVal !== undefined) {
-          const allVals = Object.values(modelValues);
-          const fastest = allVals.length > 0 ? Math.min(...allVals) : 0;
-          const delta = modelVal - fastest;
-          latencyDeltas.push(delta);
-        }
-      });
-
-      // Delta percentiles (relative to the selection, so computed here)
-      const sorted = [...latencyDeltas].sort((a, b) => a - b);
-      const n = sorted.length;
-      let p25 = 0, p50 = 0, p75 = 0;
-      if (n > 0) {
-        const getPercentile = (pct: number): number => {
-          const index = (pct / 100) * (n - 1);
-          const lower = Math.floor(index);
-          const upper = Math.ceil(index);
-          if (lower === upper) return sorted[lower] ?? 0;
-          const weight = index - lower;
-          return (sorted[lower] ?? 0) * (1 - weight) + (sorted[upper] ?? 0) * weight;
-        };
-        p25 = getPercentile(25);
-        p50 = getPercentile(50);
-        p75 = getPercentile(75);
-      }
-
+      const p25 = toDisplayUnits(latencyStat.p25);
+      const p75 = toDisplayUnits(latencyStat.p75);
       heatmapData.push({
         model,
         latencyP25: p25,
-        latencyP50: p50,
+        latencyP50: toDisplayUnits(latencyStat.p50),
         latencyP75: p75,
         latencyIQR: p75 - p25,
         avgWER: werStat.avg_value,
@@ -372,54 +314,11 @@ export function useChartData({
         normalizeModelName(a.model).localeCompare(normalizeModelName(b.model)) ||
         a.model.localeCompare(b.model)
     );
-  }, [
-    timelineByModel,
-    activeTab,
-    selectedTTSModels,
-    selectedSTTModels,
-    getStat
-  ]);
+  }, [activeTab, selectedTTSModels, selectedSTTModels, getStat, toDisplayUnits]);
 
-  const getModelHeatmapData = useCallback(
-    (): ModelHeatmapData[] => modelHeatmapDataMemo,
-    [modelHeatmapDataMemo]
-  );
-
-  // TTS heatmap uses absolute percentiles — straight from the SQL stats
-  const ttsHeatmapDataMemo = useMemo<ModelHeatmapData[]>(() => {
-    if (activeTab !== "tts" || selectedTTSModels.length === 0) {
-      return [];
-    }
-
-    const heatmapData: ModelHeatmapData[] = [];
-
-    selectedTTSModels.forEach((model) => {
-      const latencyStat = getStat(model, "TTFA");
-      const werStat = getStat(model, "WER");
-
-      if (!latencyStat || !werStat) return;
-
-      heatmapData.push({
-        model,
-        latencyP25: latencyStat.p25,
-        latencyP50: latencyStat.p50,
-        latencyP75: latencyStat.p75,
-        latencyIQR: latencyStat.p75 - latencyStat.p25,
-        avgWER: werStat.avg_value,
-        werStdDev: werStat.stddev_value
-      });
-    });
-
-    return heatmapData.sort(
-      (a, b) =>
-        normalizeModelName(a.model).localeCompare(normalizeModelName(b.model)) ||
-        a.model.localeCompare(b.model)
-    );
-  }, [activeTab, selectedTTSModels, getStat]);
-
-  const getTTSHeatmapData = useCallback(
-    (): ModelHeatmapData[] => ttsHeatmapDataMemo,
-    [ttsHeatmapDataMemo]
+  const getHeatmapData = useCallback(
+    (): ModelHeatmapData[] => heatmapDataMemo,
+    [heatmapDataMemo]
   );
 
   const werBarDataMemo = useMemo<BarDataPoint[]>(() => {
@@ -543,8 +442,7 @@ export function useChartData({
     getTimelineData,
     getBoxPlotData,
     getScatterData,
-    getModelHeatmapData,
-    getTTSHeatmapData,
+    getHeatmapData,
     getWERBarData,
     getCurrentTimeWindow,
     getTimelineTicks,

--- a/web/hooks/useDashboardState.tsx
+++ b/web/hooks/useDashboardState.tsx
@@ -232,7 +232,6 @@ export function useDashboardState(page: "tts" | "stt") {
   } = keyMetrics;
 
   // Get computed data
-  const heatmapData = chartData.getModelHeatmapData();
   const werBarData = chartData.getWERBarData();
 
   const werBarDataWithColors = useMemo(() => {
@@ -280,9 +279,7 @@ export function useDashboardState(page: "tts" | "stt") {
           "In voice AI applications, transcription accuracy directly impacts the performance of downstream tasks. Even small transcription errors can lead to misinterpretations, frustrating experiences, or incorrect system responses. We evaluate against test audio that includes diverse speakers, accents, and real-world audio conditions. Click a bar to highlight it for comparison.",
       };
 
-  const heatmapDisplayData = page === "tts"
-    ? chartData.getTTSHeatmapData()
-    : heatmapData;
+  const heatmapDisplayData = chartData.getHeatmapData();
 
   // Pre-computed key metrics for display
   const primaryKeyMetric = (() => {


### PR DESCRIPTION
Restore the frontend heatmap change from #100 (lost in revert #103): unify the STT delta and TTS absolute paths into one absolute-percentile heatmap that reads p25/p50/p75 from model_stats, matching the box plot. Backend-independent, with no dependency on the reverted matviews.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Heatmap now displays consistent metrics across all views: latency percentiles (P25/P50/P75), latency IQR, and WER metrics.

* **Bug Fixes**
  * Fixed heatmap column labels that previously varied inconsistently based on active tab selection.

* **Refactor**
  * Simplified heatmap data computation and metric selection logic for improved performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR restores a frontend-only change that was accidentally reverted: the STT heatmap previously showed latency *deltas* relative to the fastest selected model, while the TTS heatmap already used absolute percentiles. Both paths are now unified into a single `heatmapDataMemo` that reads `p25`/`p50`/`p75` directly from `model_stats` — consistent with the box plot — and `toDisplayUnits` is applied to both tabs.

- **`useChartData.ts`**: Removes `timelineByModel`, the delta-computation loop, and the separate `ttsHeatmapDataMemo`; replaces `getModelHeatmapData`/`getTTSHeatmapData` with a single `getHeatmapData` callback that applies `toDisplayUnits` to latency percentiles for both tabs.
- **`HeatmapPlot.tsx`**: Drops the `activeTab`-branched `metrics` definition; the unified metric list is now tab-agnostic, with an empty dep array.
- **`useDashboardState.tsx`**: Removes the conditional ternary that selected between the two old heatmap getters; now calls `chartData.getHeatmapData()` directly.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the change is purely frontend, removes dead code, and aligns the heatmap data path with the already-working box plot path.

The unified data path correctly applies toDisplayUnits to latency percentiles for both tabs (a no-op for TTS since values are already in ms, a x1000 conversion for STT), WER stats are intentionally left unconverted, and the removed timelineByModel computed value was exclusively consumed by the deleted delta logic with no other dependents. No logic regressions or missing side effects were found.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| web/hooks/useChartData.ts | Removes ~80 lines of delta-computation and the separate TTS absolute-percentile path; the new unified heatmapDataMemo correctly applies toDisplayUnits to latency stats for both tabs, matching how the box plot works. |
| web/components/charts/d3/HeatmapPlot.tsx | Metrics array is now static (empty dep array); activeTab is still correctly used for PostHog analytics and the useEffect dependency list. |
| web/hooks/useDashboardState.tsx | Removes the conditional ternary that selected between two heatmap getters; now calls the unified getHeatmapData directly. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Show absolute latency percentiles in the..."](https://github.com/coval-ai/benchmarks/commit/91bc1ef80ad8fc38a21ec346aacc706102e3941b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37109212)</sub>

<!-- /greptile_comment -->