### PR TITLE
Show median TTFA on the summary card and timeline headline

### DIFF
--- a/web/components/visualizations/TimelineChart.tsx
+++ b/web/components/visualizations/TimelineChart.tsx
@@ -77,6 +77,7 @@ const TimelineChart: React.FC = () => {
     getTimelineTicks,
     formatChartLabel,
     getProviderForModel,
+    getMedianLatencyMs,
     dataTimeWindow,
   } = useDashboard();
   const trackChartHover = useChartHoverTracking("timeline");
@@ -115,21 +116,10 @@ const TimelineChart: React.FC = () => {
   const description =
     metricDescriptions[metric.toLowerCase() as keyof typeof metricDescriptions];
 
-  const avgValue = useMemo(() => {
-    let sum = 0;
-    let count = 0;
-    for (const point of windowedTimelineData) {
-      const record = point as Record<string, number>;
-      for (const model of modelsWithData) {
-        const value = record[`${model}_value`];
-        if (typeof value === "number" && !Number.isNaN(value)) {
-          sum += value;
-          count += 1;
-        }
-      }
-    }
-    return count > 0 ? sum / count : 0;
-  }, [windowedTimelineData, modelsWithData]);
+  // Headline number: the median latency across selected models — the same
+  // canonical statistic the summary card and box plot report, so all three
+  // surfaces agree.
+  const medianValue = getMedianLatencyMs(metric);
 
   // Fix the Y axis to the max across the full dataset (not just the visible
   // window) so the scale stays consistent while panning. Rounded up to a clean
@@ -161,8 +151,8 @@ const TimelineChart: React.FC = () => {
           }
           description={description}
           stat={{
-            label: `Avg ${metricLabel}`,
-            value: `${avgValue.toFixed(0)} ms`,
+            label: `Median ${metricLabel}`,
+            value: `${medianValue.toFixed(0)} ms`,
           }}
         />
 

--- a/web/hooks/useDashboardState.tsx
+++ b/web/hooks/useDashboardState.tsx
@@ -15,6 +15,7 @@ import { useMobileDetection } from "@/hooks/useMobileDetection";
 import { useBarInteraction } from "@/hooks/useBarInteraction";
 import { latencyToMs, normalizeModelName, normalizeSTTProviderName, normalizeTTSProviderName, parseModelKey, toModelKey } from "@/lib/utils/formatters";
 import { buildModelsByProvider, pruneSelection } from "@/lib/utils/modelsFromResults";
+import { median } from "@/lib/utils/median";
 import { metricDescriptions } from "@/lib/config/metrics";
 import { useAggregatesQuery, useProvidersQuery } from "@/lib/api/queries";
 import { capturePostHogEvent } from "@/lib/posthog/client";
@@ -182,27 +183,38 @@ export function useDashboardState(page: "tts" | "stt") {
   // Calculate metrics
   const { getStat } = chartData;
 
-  // Headline numbers: among the selected models, the lowest median latency
-  // and the lowest average WER (with one model selected, that model's own
-  // median/average).
-  const keyMetrics = useMemo(() => {
-    const primaryMetric = page === "tts" ? "TTFA" : "TTFT";
+  // Median latency (in display units) across the selected models' per-model
+  // medians for the given metric. This is the single canonical headline number,
+  // shared by the summary card, the box plot, and the timeline so every surface
+  // reports the same statistic. Median commutes with the linear ms conversion,
+  // so this equals the box plot's median(per-model medians).
+  const getMedianLatencyMs = useCallback(
+    (metric: string) => {
+      const p50s: number[] = [];
+      deferredSelectedModels.forEach((model) => {
+        const stat = getStat(model, metric);
+        if (stat && typeof stat.p50 === "number") p50s.push(stat.p50);
+      });
+      if (p50s.length === 0) return 0;
+      return latencyToMs(median(p50s), page);
+    },
+    [getStat, deferredSelectedModels, page]
+  );
 
-    let fastestPrimary = Infinity;
+  // Headline numbers: the median latency across selected models, and the
+  // lowest average WER (with one model selected, that model's own value).
+  const primaryMetric = page === "tts" ? "TTFA" : "TTFT";
+  const medianPrimary = useMemo(
+    () => getMedianLatencyMs(primaryMetric),
+    [getMedianLatencyMs, primaryMetric]
+  );
+
+  const keyMetrics = useMemo(() => {
     let lowestSecondary = Infinity;
-    let fastestLatencyModel = "";
     let lowestWERModel = "";
-    let fastestLatencyProvider = "";
     let lowestWERProvider = "";
 
     deferredSelectedModels.forEach((model) => {
-      const latencyStat = getStat(model, primaryMetric);
-      if (latencyStat && latencyStat.p50 < fastestPrimary) {
-        fastestPrimary = latencyStat.p50;
-        fastestLatencyModel = model;
-        fastestLatencyProvider = parseModelKey(model).provider;
-      }
-
       const werStat = getStat(model, "WER");
       if (werStat && werStat.avg_value < lowestSecondary) {
         lowestSecondary = werStat.avg_value;
@@ -212,24 +224,13 @@ export function useDashboardState(page: "tts" | "stt") {
     });
 
     return {
-      avgPrimary:
-        fastestPrimary !== Infinity ? latencyToMs(fastestPrimary, page) : 0,
       avgSecondary: lowestSecondary !== Infinity ? lowestSecondary : 0,
-      fastestLatencyModel,
       lowestWERModel,
-      fastestLatencyProvider,
       lowestWERProvider,
     };
-  }, [getStat, deferredSelectedModels, page]);
+  }, [getStat, deferredSelectedModels]);
 
-  const {
-    avgPrimary,
-    avgSecondary,
-    fastestLatencyModel,
-    lowestWERModel,
-    fastestLatencyProvider,
-    lowestWERProvider,
-  } = keyMetrics;
+  const { avgSecondary, lowestWERModel, lowestWERProvider } = keyMetrics;
 
   // Get computed data
   const werBarData = chartData.getWERBarData();
@@ -285,19 +286,9 @@ export function useDashboardState(page: "tts" | "stt") {
   const primaryKeyMetric = (() => {
     const latencyFullLabel =
       page === "tts" ? "Time to First Audio" : "Time to First Token";
-    const label = `${selectedModels.length > 1 ? "Fastest" : "Median"} ${latencyFullLabel}`;
     return {
-      label,
-      displayValue: `${avgPrimary.toFixed(0)} ms`,
-      subtitle:
-        selectedModels.length > 1 && fastestLatencyModel
-          ? {
-              name: normalizeModelName(fastestLatencyModel),
-              detail: fastestLatencyProvider
-                ? normalizeProviderName(fastestLatencyProvider)
-                : undefined,
-            }
-          : undefined,
+      label: `Median ${latencyFullLabel}`,
+      displayValue: `${medianPrimary.toFixed(0)} ms`,
     };
   })();
 
@@ -334,6 +325,7 @@ export function useDashboardState(page: "tts" | "stt") {
     // Key metrics
     primaryKeyMetric,
     secondaryKeyMetric,
+    getMedianLatencyMs,
 
     // Data loading
     loading,


### PR DESCRIPTION
The summary card showed the fastest model's median and the timeline showed an average, while the box plot and overview already used the median  three statistics for one metric read as a bug (BENCH-273). Both now report the same median TTFA across the selected models, so every latency headline on the page agrees.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated latency metric calculations to display median-based values across all selected models instead of average or fastest values. This provides more statistically representative performance data throughout dashboard visualizations and statistics displays. The change enhances accuracy and reliability of performance comparisons across all TTS and STT model combinations on the platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR unifies the latency headline across all dashboard surfaces (summary card, timeline, box plot) by replacing the previous "fastest model's median" and "average over windowed data" calculations with a single `getMedianLatencyMs` helper that computes the median of per-model p50s.

- **`useDashboardState.tsx`**: Adds `getMedianLatencyMs` as a `useCallback`, removes the "fastest model" tracking from `keyMetrics`, and computes `medianPrimary` via `useMemo` for the summary card.
- **`TimelineChart.tsx`**: Drops the per-point average loop and calls `getMedianLatencyMs(metric)` for the headline stat, updating the label from "Avg" to "Median".

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a straightforward unification of a headline statistic with no new data paths or side effects.

The logic change is well-contained: `getMedianLatencyMs` is a pure computation over already-fetched data, `medianPrimary` in the hook is correctly memoized, and the `median` utility guards against empty arrays. No data fetching, persistence, or auth logic is touched.

No files require special attention. The only note is that `medianValue` in `TimelineChart.tsx` could be wrapped in `useMemo` for consistency with the hook's pattern, but this does not affect correctness.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| web/components/visualizations/TimelineChart.tsx | Replaces the average-over-windowed-data calculation with a call to `getMedianLatencyMs(metric)` and updates the headline label from "Avg" to "Median". `medianValue` is called directly in the render body rather than inside `useMemo`. |
| web/hooks/useDashboardState.tsx | Introduces `getMedianLatencyMs` as a `useCallback` computing the median of per-model p50s, replaces "fastest model" logic in `keyMetrics` with `medianPrimary` (correctly `useMemo`-wrapped), and exposes the callback for consumption in `TimelineChart`. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[deferredSelectedModels] --> B[getMedianLatencyMs - useCallback]
    B --> C{for each model}
    C --> D[getStat model metric .p50]
    D --> E[collect p50s array]
    E --> F[median of p50s]
    F --> G[latencyToMs linear conversion]
    G --> H[medianPrimary - useMemo]
    G --> I[medianValue in TimelineChart]
    H --> J[Summary Card Median TTFA/TTFT]
    I --> K[Timeline Headline Median metric]
    G -.->|same statistic| L[Box Plot p50 per model]
    J & K & L --> M[All three surfaces agree]
```

<sub>Reviews (2): Last reviewed commit: ["Show median TTFA on the summary card and..."](https://github.com/coval-ai/benchmarks/commit/0e133ff963d5e81f7b2ce58791f3a22baf9ebe4b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37271830)</sub>

<!-- /greptile_comment -->