### PR TITLE
Add series rollup table (results_by_bucket)

### DIFF
--- a/runner/src/coval_bench/api/routers/aggregates.py
+++ b/runner/src/coval_bench/api/routers/aggregates.py
@@ -10,13 +10,12 @@ Serves the dashboard's chart data as pre-computed aggregates. Two blocks:
   (percentile_cont), min, max, count. Read from the per-window materialized
   views (``results_24h``/``results_7d``/``results_30d``), refreshed by the
   runner at the end of each benchmark run — read-only here.
-* ``series`` — per (provider, model, metric_type, scheduled_at bucket): avg and
-  count, aggregated live. The bucket falls back to created_at floored to the
-  scheduler period for legacy rows, identical to the COALESCE in GET
-  /v1/results.
+* ``series`` — per (provider, model, metric_type, bucket_at) distribution
+  (min/p25/p50/p75/max/value_sum/count), read from the ``results_by_bucket``
+  rollup table, filled by the orchestrator's end-of-run hook.
 
-Both blocks gate on result rows with status='success' and a non-null
-metric_value, from parent runs in (succeeded, partial).
+Both blocks are pre-aggregated from rows with status='success' and a non-null
+metric_value, from parent runs in (succeeded, partial) — read-only here.
 """
 
 from __future__ import annotations
@@ -35,7 +34,6 @@ from starlette.requests import Request
 
 from coval_bench.api.cache import get_or_fill
 from coval_bench.api.common import (
-    SCHEDULED_AT_BUCKET_SQL,
     WINDOW_INTERVALS,
     WINDOW_VIEWS,
     BenchmarkLiteral,
@@ -47,26 +45,13 @@ from coval_bench.api.deps import (
     get_cache_locks,
     get_pool,
     get_posthog,
-    get_settings,
 )
 from coval_bench.api.ratelimit import limiter
 from coval_bench.api.schemas import AggregatesResponse, ModelStatEntry, SeriesPoint
-from coval_bench.config import Settings
 
 logger = structlog.get_logger("coval_bench.api")
 
 router = APIRouter(tags=["results"])
-
-# Live FROM/WHERE for the series block.
-_FROM_WHERE = (
-    " FROM benchmarks_v2.results r"
-    " JOIN benchmarks_v2.runs rn ON rn.id = r.run_id"
-    " WHERE r.status = 'success'"
-    " AND rn.status IN ('succeeded', 'partial')"
-    " AND r.benchmark = %(benchmark)s"
-    " AND r.metric_value IS NOT NULL"
-    " AND r.created_at >= NOW() - %(interval)s::interval"
-)
 
 _STATS_SQL_TEMPLATE = (
     "SELECT provider, model, metric_type,"
@@ -77,16 +62,13 @@ _STATS_SQL_TEMPLATE = (
     " ORDER BY provider, model, metric_type"
 )
 
-# Bucket expression repeated in GROUP BY because a bare ``scheduled_at`` there
-# would resolve to the input column rn.scheduled_at, not the alias.
 _SERIES_SQL = (
-    "SELECT r.provider, r.model, r.metric_type,"
-    f" {SCHEDULED_AT_BUCKET_SQL} AS scheduled_at,"
-    " AVG(r.metric_value)::float8 AS avg_value,"
-    " COUNT(*)::int AS sample_count"
-    + _FROM_WHERE
-    + f" GROUP BY r.provider, r.model, r.metric_type, {SCHEDULED_AT_BUCKET_SQL}"
-    " ORDER BY 4, r.provider, r.model, r.metric_type"
+    "SELECT provider, model, metric_type, bucket_at AS scheduled_at,"
+    " min_value, p25, p50, p75, max_value, value_sum, sample_count"
+    " FROM benchmarks_v2.results_by_bucket"
+    " WHERE benchmark = %(benchmark)s"
+    " AND bucket_at >= NOW() - %(interval)s::interval"
+    " ORDER BY bucket_at, provider, model, metric_type"
 )
 
 
@@ -97,7 +79,6 @@ async def get_results_aggregates(
     benchmark: BenchmarkLiteral = Query(...),
     window: WindowLiteral = Query(default="24h"),
     pool: AsyncConnectionPool[Any] = Depends(get_pool),
-    settings: Settings = Depends(get_settings),
     posthog_client: Posthog | None = Depends(get_posthog),
     cache: TTLCache[Any, Any] = Depends(get_cache),
     cache_locks: defaultdict[Any, asyncio.Lock] = Depends(get_cache_locks),
@@ -106,7 +87,8 @@ async def get_results_aggregates(
 
     Args:
         benchmark: One of STT, TTS.
-        window: Time window over results.created_at. Defaults to 24h.
+        window: Time window — stats over results.created_at, series over
+            bucket_at. Defaults to 24h.
     """
 
     async def fill() -> AggregatesResponse:
@@ -114,7 +96,6 @@ async def get_results_aggregates(
         series_params: dict[str, Any] = {
             "benchmark": benchmark,
             "interval": WINDOW_INTERVALS[window],
-            "schedule_period": settings.schedule_period_seconds,
         }
 
         async with pool.connection() as conn:

--- a/runner/src/coval_bench/api/schemas.py
+++ b/runner/src/coval_bench/api/schemas.py
@@ -121,16 +121,21 @@ class ModelStatEntry(BaseModel):
 
 
 class SeriesPoint(BaseModel):
-    """Per-(provider, model, metric_type) average for one scheduled_at bucket.
+    """Per-(provider, model, metric_type) distribution for one scheduled_at bucket.
 
-    Used in all the timeline charts.
+    Latency timelines render p50; WER renders value_sum / sample_count.
     """
 
     provider: str
     model: str
     metric_type: str
     scheduled_at: datetime
-    avg_value: float
+    min_value: float
+    p25: float
+    p50: float
+    p75: float
+    max_value: float
+    value_sum: float
     sample_count: int
 
 

--- a/runner/src/coval_bench/db/migrations/versions/20260611_0006_results_by_bucket.py
+++ b/runner/src/coval_bench/db/migrations/versions/20260611_0006_results_by_bucket.py
@@ -1,0 +1,102 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Series rollup table: results_by_bucket.
+
+One row per (provider, model, benchmark, metric_type, bucket_at):
+min/p25/p50/p75/max/value_sum/sample_count. ``bucket_at`` is the run's cron
+trigger time, falling back to ``created_at`` floored to the scheduler period
+for legacy rows. The aggregates series block reads this table; the
+orchestrator's end-of-run hook (``RunWriter.refresh_bucket``) keeps it
+current. This migration creates the table and backfills it from existing
+results.
+
+Migrations deploy separately from images, so rerun the backfill (truncate +
+the ``upgrade`` insert-select) once the new image is live. Same recovery if
+the table ever drifts from ``results``.
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "20260611_0006"
+down_revision = "20260611_0005"
+branch_labels = None
+depends_on = None
+
+# Settings.schedule_period_seconds default; only used for legacy rows with a
+# null scheduled_at.
+_SCHEDULE_PERIOD_SECONDS = 1800
+
+# S608 false-positive: only the integer constant above is interpolated.
+_BACKFILL_SQL = f"""
+    INSERT INTO benchmarks_v2.results_by_bucket
+        (provider, model, benchmark, metric_type, bucket_at,
+         min_value, p25, p50, p75, max_value, value_sum, sample_count)
+    SELECT provider, model, benchmark, metric_type, bucket_at,
+           min_value, pct[1], pct[2], pct[3], max_value, value_sum, sample_count
+    FROM (
+        SELECT r.provider, r.model, r.benchmark, r.metric_type,
+               COALESCE(
+                   rn.scheduled_at,
+                   to_timestamp(
+                       floor(extract(epoch FROM r.created_at) / {_SCHEDULE_PERIOD_SECONDS})
+                       * {_SCHEDULE_PERIOD_SECONDS}
+                   )
+               ) AS bucket_at,
+               MIN(r.metric_value)::float8 AS min_value,
+               (PERCENTILE_CONT(ARRAY[0.25, 0.5, 0.75])
+                   WITHIN GROUP (ORDER BY r.metric_value))::float8[] AS pct,
+               MAX(r.metric_value)::float8 AS max_value,
+               SUM(r.metric_value)::float8 AS value_sum,
+               COUNT(*)::int AS sample_count
+        FROM benchmarks_v2.results r
+        JOIN benchmarks_v2.runs rn ON rn.id = r.run_id
+        WHERE r.status = 'success'
+          AND rn.status IN ('succeeded', 'partial')
+          AND r.metric_value IS NOT NULL
+        GROUP BY r.provider, r.model, r.benchmark, r.metric_type,
+                 COALESCE(
+                     rn.scheduled_at,
+                     to_timestamp(
+                         floor(extract(epoch FROM r.created_at) / {_SCHEDULE_PERIOD_SECONDS})
+                         * {_SCHEDULE_PERIOD_SECONDS}
+                     )
+                 )
+    ) agg
+"""  # noqa: S608
+
+
+def upgrade() -> None:
+    """Create results_by_bucket and backfill it from all of results."""
+    op.execute(
+        """
+        CREATE TABLE benchmarks_v2.results_by_bucket (
+            provider      TEXT NOT NULL,
+            model         TEXT NOT NULL,
+            benchmark     TEXT NOT NULL CHECK (benchmark IN ('STT','TTS')),
+            metric_type   TEXT NOT NULL,
+            bucket_at     TIMESTAMPTZ NOT NULL,
+            min_value     DOUBLE PRECISION NOT NULL,
+            p25           DOUBLE PRECISION NOT NULL,
+            p50           DOUBLE PRECISION NOT NULL,
+            p75           DOUBLE PRECISION NOT NULL,
+            max_value     DOUBLE PRECISION NOT NULL,
+            value_sum     DOUBLE PRECISION NOT NULL,
+            sample_count  INTEGER NOT NULL,
+            PRIMARY KEY (provider, model, benchmark, metric_type, bucket_at)
+        )
+        """
+    )
+    # Serves the series read: benchmark equality + bucket_at range.
+    op.execute(
+        "CREATE INDEX results_by_bucket_series_idx "
+        "ON benchmarks_v2.results_by_bucket (benchmark, bucket_at)"
+    )
+    op.execute(_BACKFILL_SQL)
+
+
+def downgrade() -> None:
+    """Drop the rollup table."""
+    op.execute("DROP TABLE IF EXISTS benchmarks_v2.results_by_bucket")

--- a/runner/src/coval_bench/db/writer.py
+++ b/runner/src/coval_bench/db/writer.py
@@ -141,6 +141,70 @@ class RunWriter:
                 await cur.executemany(sql, params)
             await conn.commit()
 
+    async def refresh_bucket(self, run_id: int, *, period_seconds: int) -> None:
+        """Recompute the series rollup bucket for this run's scheduled_at slot.
+
+        Delete-then-insert the whole bucket from raw result rows in one
+        transaction. Recomputing the full bucket (not just this run's rows)
+        keeps it correct when runs share a slot, and makes the call idempotent.
+        Runs without a ``scheduled_at`` are skipped — the migration backfill
+        owns those.
+        """
+        async with self._pool.connection() as conn:
+            async with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+                await cur.execute(
+                    "SELECT scheduled_at FROM benchmarks_v2.runs WHERE id = %s",
+                    (run_id,),
+                )
+                row = await cur.fetchone()
+                bucket_at = row["scheduled_at"] if row is not None else None
+                if bucket_at is None:
+                    return
+
+                # Two statements on purpose: a data-modifying CTE
+                # (WITH deleted AS (DELETE ...) INSERT) collides on the primary
+                # key — the INSERT cannot see the CTE's deletes.
+                params = {"bucket": bucket_at, "period": period_seconds}
+                await cur.execute(
+                    "DELETE FROM benchmarks_v2.results_by_bucket WHERE bucket_at = %(bucket)s",
+                    params,
+                )
+                # Bucket membership: scheduled_at matches exactly, or a legacy
+                # null-scheduled row whose created_at falls in
+                # [bucket_at, bucket_at + period).
+                await cur.execute(
+                    """
+                    INSERT INTO benchmarks_v2.results_by_bucket
+                        (provider, model, benchmark, metric_type, bucket_at,
+                         min_value, p25, p50, p75, max_value, value_sum, sample_count)
+                    SELECT r.provider, r.model, r.benchmark, r.metric_type, %(bucket)s,
+                           MIN(r.metric_value)::float8,
+                           PERCENTILE_CONT(0.25) WITHIN GROUP (ORDER BY r.metric_value)::float8,
+                           PERCENTILE_CONT(0.5)  WITHIN GROUP (ORDER BY r.metric_value)::float8,
+                           PERCENTILE_CONT(0.75) WITHIN GROUP (ORDER BY r.metric_value)::float8,
+                           MAX(r.metric_value)::float8,
+                           SUM(r.metric_value)::float8,
+                           COUNT(*)::int
+                    FROM benchmarks_v2.results r
+                    JOIN benchmarks_v2.runs rn ON rn.id = r.run_id
+                    WHERE r.status = 'success'
+                      AND rn.status IN ('succeeded', 'partial')
+                      AND r.metric_value IS NOT NULL
+                      AND (
+                          rn.scheduled_at = %(bucket)s
+                          OR (
+                              rn.scheduled_at IS NULL
+                              AND r.created_at >= %(bucket)s
+                              AND r.created_at < %(bucket)s
+                                  + (%(period)s::double precision) * INTERVAL '1 second'
+                          )
+                      )
+                    GROUP BY r.provider, r.model, r.benchmark, r.metric_type
+                    """,
+                    params,
+                )
+            await conn.commit()
+
     async def finish_run(
         self,
         run_id: int,

--- a/runner/src/coval_bench/db/writer.py
+++ b/runner/src/coval_bench/db/writer.py
@@ -145,10 +145,10 @@ class RunWriter:
         """Recompute the series rollup bucket for this run's scheduled_at slot.
 
         Delete-then-insert the whole bucket from raw result rows in one
-        transaction. Recomputing the full bucket (not just this run's rows)
-        keeps it correct when runs share a slot, and makes the call idempotent.
-        Runs without a ``scheduled_at`` are skipped — the migration backfill
-        owns those.
+        transaction, serialized per bucket by an advisory lock. Recomputing
+        the full bucket (not just this run's rows) keeps it correct when runs
+        share a slot, and makes the call idempotent. Runs without a
+        ``scheduled_at`` are skipped — the migration backfill owns those.
         """
         async with self._pool.connection() as conn:
             async with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
@@ -161,10 +161,20 @@ class RunWriter:
                 if bucket_at is None:
                     return
 
+                # Serializes concurrent refreshes of one bucket. An empty
+                # bucket gives DELETE nothing to lock, so two refreshes can
+                # interleave such that the staler recompute commits and the
+                # fresher one aborts on the primary key, dropping a run from
+                # the slot. Released on commit/abort.
+                params = {"bucket": bucket_at, "period": period_seconds}
+                await cur.execute(
+                    "SELECT pg_advisory_xact_lock(hashtextextended('results_by_bucket',"
+                    " extract(epoch FROM %(bucket)s::timestamptz)::bigint))",
+                    params,
+                )
                 # Two statements on purpose: a data-modifying CTE
                 # (WITH deleted AS (DELETE ...) INSERT) collides on the primary
                 # key — the INSERT cannot see the CTE's deletes.
-                params = {"bucket": bucket_at, "period": period_seconds}
                 await cur.execute(
                     "DELETE FROM benchmarks_v2.results_by_bucket WHERE bucket_at = %(bucket)s",
                     params,

--- a/runner/src/coval_bench/runner/orchestrator.py
+++ b/runner/src/coval_bench/runner/orchestrator.py
@@ -648,16 +648,29 @@ def _emit_posthog(client: Posthog | None, event: str, properties: dict[str, Any]
         _log.warning("posthog_emit_failed", event_name=event, exc_info=True)
 
 
+# Transient-failure retry for the end-of-run bucket refresh.
+_BUCKET_REFRESH_ATTEMPTS = 3
+_BUCKET_REFRESH_RETRY_DELAY_S = 0.5
+
+
 async def _refresh_series_bucket(writer: Any, run_id: int, settings: Settings) -> None:  # noqa: ANN401 — RunWriter, lazy-imported by the caller
     """Best-effort refresh of the run's series rollup bucket; never raises.
 
-    A failure leaves only this bucket stale (later runs fill their own
-    buckets, not this one) — not worth failing the run.
+    Transient failures are retried. A final failure leaves only this bucket
+    stale (a run sharing the slot recomputes it; the migration backfill is
+    the manual repair) — not worth failing the run.
     """
-    try:
-        await writer.refresh_bucket(run_id, period_seconds=settings.schedule_period_seconds)
-    except Exception:
-        _log.warning("series_bucket_refresh_failed", run_id=run_id, exc_info=True)
+    for attempt in range(1, _BUCKET_REFRESH_ATTEMPTS + 1):
+        try:
+            await writer.refresh_bucket(run_id, period_seconds=settings.schedule_period_seconds)
+        except Exception:
+            if attempt == _BUCKET_REFRESH_ATTEMPTS:
+                _log.warning("series_bucket_refresh_failed", run_id=run_id, exc_info=True)
+                return
+            _log.info("series_bucket_refresh_retry", run_id=run_id, attempt=attempt)
+            await asyncio.sleep(_BUCKET_REFRESH_RETRY_DELAY_S)
+        else:
+            return
 
 
 async def run_benchmarks(

--- a/runner/src/coval_bench/runner/orchestrator.py
+++ b/runner/src/coval_bench/runner/orchestrator.py
@@ -648,6 +648,18 @@ def _emit_posthog(client: Posthog | None, event: str, properties: dict[str, Any]
         _log.warning("posthog_emit_failed", event_name=event, exc_info=True)
 
 
+async def _refresh_series_bucket(writer: Any, run_id: int, settings: Settings) -> None:  # noqa: ANN401 — RunWriter, lazy-imported by the caller
+    """Best-effort refresh of the run's series rollup bucket; never raises.
+
+    A failure leaves only this bucket stale (later runs fill their own
+    buckets, not this one) — not worth failing the run.
+    """
+    try:
+        await writer.refresh_bucket(run_id, period_seconds=settings.schedule_period_seconds)
+    except Exception:
+        _log.warning("series_bucket_refresh_failed", run_id=run_id, exc_info=True)
+
+
 async def run_benchmarks(
     *,
     settings: Settings,
@@ -896,6 +908,9 @@ async def run_benchmarks(
                     exc_info=refresh_exc,
                 )
 
+            if final_status in (RunStatus.SUCCEEDED, RunStatus.PARTIAL):
+                await _refresh_series_bucket(writer, run_id, settings)
+
             finished_at = datetime.now(tz=UTC)
             summary = RunSummary(
                 run_id=run_id,
@@ -959,6 +974,9 @@ async def run_benchmarks(
                     run_id=run_id,
                     exc_info=write_exc,
                 )
+            else:
+                # Run row is PARTIAL, so its bucket qualifies.
+                await asyncio.shield(_refresh_series_bucket(writer, run_id, settings))
             finished_at = datetime.now(tz=UTC)
             sigterm_duration_s = (finished_at - started_at).total_seconds()
             _log.warning(

--- a/runner/tests/api/conftest.py
+++ b/runner/tests/api/conftest.py
@@ -121,6 +121,24 @@ async def _apply_schema(dsn: str) -> None:
                     GROUP BY r.provider, r.model, r.benchmark, r.metric_type
                 ) stats
             """)  # noqa: S608
+        # Series rollup table (mirrors migration 20260611_0006).
+        await aconn.execute("""
+            CREATE TABLE IF NOT EXISTS benchmarks_v2.results_by_bucket (
+                provider      text NOT NULL,
+                model         text NOT NULL,
+                benchmark     text NOT NULL CHECK (benchmark IN ('STT','TTS')),
+                metric_type   text NOT NULL,
+                bucket_at     timestamptz NOT NULL,
+                min_value     double precision NOT NULL,
+                p25           double precision NOT NULL,
+                p50           double precision NOT NULL,
+                p75           double precision NOT NULL,
+                max_value     double precision NOT NULL,
+                value_sum     double precision NOT NULL,
+                sample_count  integer NOT NULL,
+                PRIMARY KEY (provider, model, benchmark, metric_type, bucket_at)
+            )
+        """)
     finally:
         await aconn.close()
 
@@ -310,5 +328,44 @@ async def _refresh_mv(postgresql: Any) -> None:
     try:
         for name in _MV_WINDOWS:
             await aconn.execute(f"REFRESH MATERIALIZED VIEW benchmarks_v2.{name}")
+    finally:
+        await aconn.close()
+
+
+# Scheduler period for the legacy created_at bucket fallback (matches
+# migration 20260611_0006).
+_BUCKET_PERIOD_SECONDS = 1800
+
+
+async def _fill_buckets(postgresql: Any) -> None:
+    """Truncate and recompute results_by_bucket from all results (mirrors the backfill)."""
+    dsn = _make_db_url(postgresql)
+    aconn = await psycopg.AsyncConnection.connect(dsn, autocommit=True)
+    bucket_sql = (
+        "COALESCE(rn.scheduled_at, to_timestamp("
+        f"floor(extract(epoch FROM r.created_at) / {_BUCKET_PERIOD_SECONDS})"
+        f" * {_BUCKET_PERIOD_SECONDS}))"
+    )
+    try:
+        await aconn.execute("TRUNCATE benchmarks_v2.results_by_bucket")
+        await aconn.execute(f"""
+            INSERT INTO benchmarks_v2.results_by_bucket
+                (provider, model, benchmark, metric_type, bucket_at,
+                 min_value, p25, p50, p75, max_value, value_sum, sample_count)
+            SELECT r.provider, r.model, r.benchmark, r.metric_type, {bucket_sql},
+                   MIN(r.metric_value)::float8,
+                   PERCENTILE_CONT(0.25) WITHIN GROUP (ORDER BY r.metric_value)::float8,
+                   PERCENTILE_CONT(0.5)  WITHIN GROUP (ORDER BY r.metric_value)::float8,
+                   PERCENTILE_CONT(0.75) WITHIN GROUP (ORDER BY r.metric_value)::float8,
+                   MAX(r.metric_value)::float8,
+                   SUM(r.metric_value)::float8,
+                   COUNT(*)::int
+            FROM benchmarks_v2.results r
+            JOIN benchmarks_v2.runs rn ON rn.id = r.run_id
+            WHERE r.status = 'success'
+              AND rn.status IN ('succeeded', 'partial')
+              AND r.metric_value IS NOT NULL
+            GROUP BY r.provider, r.model, r.benchmark, r.metric_type, {bucket_sql}
+        """)  # noqa: S608
     finally:
         await aconn.close()

--- a/runner/tests/api/test_aggregates.py
+++ b/runner/tests/api/test_aggregates.py
@@ -16,7 +16,7 @@ from fastapi import FastAPI
 from httpx import AsyncClient
 
 from coval_bench.api.common import WINDOW_INTERVALS, WINDOW_VIEWS, WindowLiteral
-from tests.api.conftest import _insert_result, _insert_run, _refresh_mv
+from tests.api.conftest import _fill_buckets, _insert_result, _insert_run, _refresh_mv
 
 
 def test_intervals_cover_every_window() -> None:
@@ -120,34 +120,45 @@ async def test_partial_runs_included(client: AsyncClient, postgresql: Any) -> No
 
 
 async def test_series_buckets_by_scheduled_at(client: AsyncClient, postgresql: Any) -> None:
-    """Results from one run share its scheduled_at bucket; values average."""
-    scheduled = datetime(2026, 6, 5, 12, 0, 0, tzinfo=dt.UTC)
+    """Results from one run share its scheduled_at bucket; the rollup holds
+    the bucket distribution."""
+    scheduled = datetime.now(dt.UTC).replace(microsecond=0) - timedelta(hours=1)
     run_id = await _insert_run(postgresql, scheduled_at=scheduled)
     await _insert_result(postgresql, run_id, metric_value=1.0)
     await _insert_result(postgresql, run_id, metric_value=3.0)
+    await _fill_buckets(postgresql)
 
     response = await client.get("/v1/results/aggregates", params={"benchmark": "STT"})
     series = response.json()["series"]
     assert len(series) == 1
     point = series[0]
     assert datetime.fromisoformat(point["scheduled_at"]) == scheduled
-    assert point["avg_value"] == pytest.approx(2.0)
+    assert point["min_value"] == pytest.approx(1.0)
+    assert point["p25"] == pytest.approx(1.5)
+    assert point["p50"] == pytest.approx(2.0)
+    assert point["p75"] == pytest.approx(2.5)
+    assert point["max_value"] == pytest.approx(3.0)
+    assert point["value_sum"] == pytest.approx(4.0)
     assert point["sample_count"] == 2
 
 
 async def test_series_legacy_rows_floor_created_at(client: AsyncClient, postgresql: Any) -> None:
-    """Runs without scheduled_at fall back to created_at floored to the
-    schedule period (1800s default), same as GET /v1/results."""
+    """Runs without scheduled_at bucket on created_at floored to the schedule
+    period (1800s default)."""
     run_id = await _insert_run(postgresql, scheduled_at=None)
     created = datetime.now(dt.UTC) - timedelta(minutes=10)
     await _insert_result(postgresql, run_id, created_at=created, metric_value=1.0)
+    await _fill_buckets(postgresql)
 
     response = await client.get("/v1/results/aggregates", params={"benchmark": "STT"})
     series = response.json()["series"]
     assert len(series) == 1
-    bucket = datetime.fromisoformat(series[0]["scheduled_at"])
+    point = series[0]
+    bucket = datetime.fromisoformat(point["scheduled_at"])
     expected_epoch = created.timestamp() // 1800 * 1800
     assert bucket.timestamp() == pytest.approx(expected_epoch)
+    assert point["value_sum"] == pytest.approx(1.0)
+    assert point["sample_count"] == 1
 
 
 async def test_window_excludes_old_rows(client: AsyncClient, postgresql: Any) -> None:

--- a/runner/tests/unit/test_db_writer.py
+++ b/runner/tests/unit/test_db_writer.py
@@ -15,6 +15,7 @@ needs them via a helper ``_apply_migrations`` that calls Alembic directly.
 from __future__ import annotations
 
 import asyncio
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
@@ -132,6 +133,7 @@ def test_migration_up_down(pg_conn: psycopg.Connection[Any]) -> None:
         tables = {row[0] for row in cur.fetchall()}
     assert "runs" in tables
     assert "results" in tables
+    assert "results_by_bucket" in tables
 
     with pg_conn.cursor() as cur:
         cur.execute("SELECT matviewname FROM pg_matviews WHERE schemaname = 'benchmarks_v2'")
@@ -155,6 +157,51 @@ def test_migration_up_down(pg_conn: psycopg.Connection[Any]) -> None:
         )
         schemas = cur.fetchall()
     assert schemas == []
+
+
+def test_migration_backfills_existing_results(pg_conn: psycopg.Connection[Any]) -> None:
+    """Upgrade to 0005, seed results, upgrade to head — the 0006 backfill
+    fills the bucket."""
+    cfg = _alembic_cfg(_async_dsn(pg_conn))
+    alembic_command.upgrade(cfg, "20260611_0005")
+
+    pg_conn.autocommit = True
+    with pg_conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO benchmarks_v2.runs "
+            "(runner_sha, dataset_id, dataset_sha256, status, scheduled_at) "
+            "VALUES ('s', 'd', 'h', 'succeeded', now() - interval '1 hour') RETURNING id"
+        )
+        seed = cur.fetchone()
+        assert seed is not None
+        run_id = seed[0]
+        for value in (1.0, 3.0):
+            cur.execute(
+                "INSERT INTO benchmarks_v2.results "
+                "(run_id, provider, model, benchmark, metric_type, metric_value, "
+                " metric_units, status) "
+                "VALUES (%s, 'openai', 'whisper-1', 'STT', 'WER', %s, 'ratio', 'success')",
+                (run_id, value),
+            )
+
+    # Same as `coval-bench db migrate`.
+    alembic_command.upgrade(cfg, "head")
+
+    with pg_conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            "SELECT min_value, p50, max_value, value_sum, sample_count "
+            "FROM benchmarks_v2.results_by_bucket "
+            "WHERE provider = 'openai' AND model = 'whisper-1' AND metric_type = 'WER'"
+        )
+        rows = cur.fetchall()
+
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["sample_count"] == 2
+    assert float(row["value_sum"]) == pytest.approx(4.0)
+    assert float(row["min_value"]) == pytest.approx(1.0)
+    assert float(row["max_value"]) == pytest.approx(3.0)
+    assert float(row["p50"]) == pytest.approx(2.0)
 
 
 def test_run_lifecycle(pg_conn: psycopg.Connection[Any]) -> None:
@@ -560,6 +607,112 @@ def test_record_results_batch_rollback_on_failure(pg_conn: psycopg.Connection[An
         row = cur.fetchone()
     assert row is not None
     # Nothing committed — the batch rolled back
+    assert row[0] == 0
+
+
+def _wer_result(run_id: int, value: float) -> Result:
+    return Result(
+        run_id=run_id,
+        provider="openai",
+        model="whisper-1",
+        benchmark=Benchmark.STT,
+        metric_type="WER",
+        metric_value=value,
+        metric_units="ratio",
+        status=ResultStatus.SUCCESS,
+    )
+
+
+def test_refresh_bucket(pg_conn: psycopg.Connection[Any]) -> None:
+    """refresh_bucket fills the run's rollup bucket, is idempotent, and
+    recomputes the whole bucket from raw rows when runs share a scheduled_at."""
+    _apply_migrations(pg_conn)
+    scheduled = datetime.now(UTC).replace(microsecond=0) - timedelta(hours=1)
+
+    async def _run() -> None:
+        pool = await _make_pool(pg_conn)
+        try:
+            writer = RunWriter(pool)
+            run = await writer.start_run(
+                runner_sha="abc123",
+                dataset_id="stt-v1",
+                dataset_sha256="deadbeef",
+                scheduled_at=scheduled,
+            )
+            assert run.id is not None
+            await writer.record_results([_wer_result(run.id, 1.0), _wer_result(run.id, 3.0)])
+            await writer.finish_run(run.id, status=RunStatus.SUCCEEDED)
+            await writer.refresh_bucket(run.id, period_seconds=1800)
+            # Twice — idempotent.
+            await writer.refresh_bucket(run.id, period_seconds=1800)
+
+            # Second run in the same bucket — refresh recomputes over both
+            # runs' rows.
+            run2 = await writer.start_run(
+                runner_sha="abc123",
+                dataset_id="stt-v1",
+                dataset_sha256="deadbeef",
+                scheduled_at=scheduled,
+            )
+            assert run2.id is not None
+            await writer.record_results([_wer_result(run2.id, 5.0)])
+            await writer.finish_run(run2.id, status=RunStatus.SUCCEEDED)
+            await writer.refresh_bucket(run2.id, period_seconds=1800)
+        finally:
+            await pool.close()
+
+    asyncio.run(_run())
+
+    pg_conn.autocommit = True
+    with pg_conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            "SELECT bucket_at, min_value, p50, max_value, value_sum, sample_count "
+            "FROM benchmarks_v2.results_by_bucket "
+            "WHERE provider = 'openai' AND model = 'whisper-1' AND metric_type = 'WER'"
+        )
+        rows = cur.fetchall()
+
+    # One bucket spanning all three samples.
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["bucket_at"] == scheduled
+    assert row["sample_count"] == 3
+    assert float(row["value_sum"]) == pytest.approx(9.0)
+    assert float(row["min_value"]) == pytest.approx(1.0)
+    assert float(row["max_value"]) == pytest.approx(5.0)
+    assert float(row["p50"]) == pytest.approx(3.0)
+
+
+def test_refresh_bucket_excludes_failed_run(pg_conn: psycopg.Connection[Any]) -> None:
+    """A failed run never seeds a bucket — the recompute drops failed parent
+    runs."""
+    _apply_migrations(pg_conn)
+    scheduled = datetime.now(UTC).replace(microsecond=0) - timedelta(hours=1)
+
+    async def _run() -> None:
+        pool = await _make_pool(pg_conn)
+        try:
+            writer = RunWriter(pool)
+            run = await writer.start_run(
+                runner_sha="abc123",
+                dataset_id="stt-v1",
+                dataset_sha256="deadbeef",
+                scheduled_at=scheduled,
+            )
+            assert run.id is not None
+            await writer.record_results([_wer_result(run.id, 1.0)])
+            await writer.finish_run(run.id, status=RunStatus.FAILED)
+            await writer.refresh_bucket(run.id, period_seconds=1800)
+        finally:
+            await pool.close()
+
+    asyncio.run(_run())
+
+    pg_conn.autocommit = True
+    with pg_conn.cursor() as cur:
+        cur.execute("SELECT count(*) FROM benchmarks_v2.results_by_bucket")
+        row = cur.fetchone()
+    assert row is not None
     assert row[0] == 0
 
 

--- a/runner/tests/unit/test_orchestrator.py
+++ b/runner/tests/unit/test_orchestrator.py
@@ -147,6 +147,7 @@ def _make_stub_writer(run: Run) -> MagicMock:
     writer.record_results = AsyncMock()
     writer.finish_run = AsyncMock()
     writer.refresh_stats_matviews = AsyncMock()
+    writer.refresh_bucket = AsyncMock()
     return writer
 
 
@@ -314,6 +315,9 @@ async def test_smoke_run_stt(audio_file: Path, settings: Settings) -> None:
     assert writer.record_results.await_count >= 2
     writer.finish_run.assert_awaited_once_with(1, status=RunStatus.SUCCEEDED, error=None)
     writer.refresh_stats_matviews.assert_awaited_once_with()
+    writer.refresh_bucket.assert_awaited_once_with(
+        1, period_seconds=settings.schedule_period_seconds
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -361,6 +365,9 @@ async def test_partial_run(audio_file: Path, settings: Settings) -> None:
     assert summary.fail_count >= 1
     assert summary.success_count >= 1
     writer.finish_run.assert_awaited_once_with(1, status=RunStatus.PARTIAL, error=None)
+    writer.refresh_bucket.assert_awaited_once_with(
+        1, period_seconds=settings.schedule_period_seconds
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -408,6 +415,7 @@ async def test_full_failure(audio_file: Path, settings: Settings) -> None:
     assert {r.metric_type for r in rows} == {"TTFT", "AudioToFinal", "RTF", "TTFS"}
     assert all(r.status == ResultStatus.FAILED for r in rows)
     assert all("always fails" in (r.error or "") for r in rows)
+    writer.refresh_bucket.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -1209,6 +1217,9 @@ async def test_sigterm_finalizes_run_as_partial(audio_file: Path, settings: Sett
     finish_kwargs = writer.finish_run.await_args.kwargs
     assert finish_kwargs["status"] == RunStatus.PARTIAL
     assert "sigterm" in (finish_kwargs.get("error") or "").lower()
+    writer.refresh_bucket.assert_awaited_once_with(
+        run.id, period_seconds=settings.schedule_period_seconds
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/runner/tests/unit/test_orchestrator.py
+++ b/runner/tests/unit/test_orchestrator.py
@@ -419,6 +419,38 @@ async def test_full_failure(audio_file: Path, settings: Settings) -> None:
 
 
 @pytest.mark.asyncio
+async def test_refresh_series_bucket_retries_transient_failure(
+    settings: Settings, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A transient refresh failure is retried; success stops the loop."""
+    from coval_bench.runner import orchestrator
+
+    monkeypatch.setattr(orchestrator, "_BUCKET_REFRESH_RETRY_DELAY_S", 0.0)
+    writer = MagicMock()
+    writer.refresh_bucket = AsyncMock(side_effect=[RuntimeError("blip"), None])
+
+    await orchestrator._refresh_series_bucket(writer, 1, settings)
+
+    assert writer.refresh_bucket.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_refresh_series_bucket_never_raises(
+    settings: Settings, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Exhausting all attempts logs and returns instead of raising."""
+    from coval_bench.runner import orchestrator
+
+    monkeypatch.setattr(orchestrator, "_BUCKET_REFRESH_RETRY_DELAY_S", 0.0)
+    writer = MagicMock()
+    writer.refresh_bucket = AsyncMock(side_effect=RuntimeError("db down"))
+
+    await orchestrator._refresh_series_bucket(writer, 1, settings)
+
+    assert writer.refresh_bucket.await_count == 3
+
+
+@pytest.mark.asyncio
 async def test_flux_excluded_from_ttfs(audio_file: Path, settings: Settings) -> None:
     """Deepgram Flux is outside the TTFS parity cohort → no TTFS row, other metrics stay."""
     provider = MagicMock()

--- a/web/hooks/useChartData.ts
+++ b/web/hooks/useChartData.ts
@@ -148,8 +148,9 @@ export function useChartData({
         p.metric_type === "WER"
           ? p.value_sum !== undefined
             ? p.value_sum / p.sample_count
-            : (p.avg_value ?? 0)
-          : (p.p50 ?? p.avg_value ?? 0);
+            : p.avg_value
+          : (p.p50 ?? p.avg_value);
+      if (value === undefined) return;
       modelSeries[new Date(point.scheduled_at).getTime()] =
         toDisplayUnits(value);
     });

--- a/web/hooks/useChartData.ts
+++ b/web/hooks/useChartData.ts
@@ -128,6 +128,9 @@ export function useChartData({
 
   // Per-metric, per-model timeline series (scheduled_at bucket → value) built in
   // one pass. Latency metrics plot the bucket median (p50); WER the average.
+  // The generated SeriesPoint type follows the deployed API, which may still be
+  // the pre-rollup shape (avg_value only) — fall back to it so web and API can
+  // deploy in either order. Drop the fallback once the rollup API is live.
   const timelineByMetricModel = useMemo<
     Record<string, Record<string, Record<number, number>>>
   >(() => {
@@ -136,10 +139,17 @@ export function useChartData({
       const byModel = (out[point.metric_type] ??= {});
       const modelKey = toModelKey(point.provider, point.model);
       const modelSeries = (byModel[modelKey] ??= {});
+      const p = point as SeriesPoint & {
+        avg_value?: number;
+        value_sum?: number;
+        p50?: number;
+      };
       const value =
-        point.metric_type === "WER"
-          ? point.value_sum / point.sample_count
-          : point.p50;
+        p.metric_type === "WER"
+          ? p.value_sum !== undefined
+            ? p.value_sum / p.sample_count
+            : (p.avg_value ?? 0)
+          : (p.p50 ?? p.avg_value ?? 0);
       modelSeries[new Date(point.scheduled_at).getTime()] =
         toDisplayUnits(value);
     });

--- a/web/hooks/useChartData.ts
+++ b/web/hooks/useChartData.ts
@@ -126,8 +126,8 @@ export function useChartData({
     []
   );
 
-  // Per-metric, per-model timeline series (scheduled_at bucket → avg) built in
-  // one pass. Indexed by metric_type so any metric can read its own series.
+  // Per-metric, per-model timeline series (scheduled_at bucket → value) built in
+  // one pass. Latency metrics plot the bucket median (p50); WER the average.
   const timelineByMetricModel = useMemo<
     Record<string, Record<string, Record<number, number>>>
   >(() => {
@@ -136,9 +136,12 @@ export function useChartData({
       const byModel = (out[point.metric_type] ??= {});
       const modelKey = toModelKey(point.provider, point.model);
       const modelSeries = (byModel[modelKey] ??= {});
-      modelSeries[new Date(point.scheduled_at).getTime()] = toDisplayUnits(
-        point.avg_value
-      );
+      const value =
+        point.metric_type === "WER"
+          ? point.value_sum / point.sample_count
+          : point.p50;
+      modelSeries[new Date(point.scheduled_at).getTime()] =
+        toDisplayUnits(value);
     });
     return out;
   }, [series, toDisplayUnits]);


### PR DESCRIPTION
The timeline series still ran the live query over raw results on every cache miss (a 500k+ row scan on 30d). This adds a `results_by_bucket` rollup keyed `(provider, model, benchmark, metric_type, bucket_at)` holding min/p25/p50/p75/max/value_sum/sample_count, and serves the aggregates series block from it as an index range read over `(benchmark, bucket_at)`. No runs join, no GROUP BY over raw rows, and one table serves every window.

The orchestrator's end-of-run hook fills a run's bucket next to the existing matview refresh: delete-then-insert recomputed from raw rows, so re-runs sharing a slot and double-fired hooks converge to the same state. Failed runs are skipped. The migration creates the table and backfills it from existing results.

Latency timelines now plot the bucket median (p50); WER plots value_sum / sample_count.

Deploy notes:
- Prod migration is manual: `coval-bench db migrate` after the image bump.
- Migrations deploy separately from images, so rerun the backfill (truncate + the migration insert-select) once the new runner image is live to cover the gap.

Tests: migration up/down + backfill over pre-existing rows, refresh_bucket idempotency and shared-slot recompute, failed-run exclusion, orchestrator hook firing on succeeded/partial/SIGTERM-partial and not on failure, and the reshaped series assertions in the aggregates API tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Aggregates endpoint now returns pre-aggregated per-bucket series with full distribution fields (min, p25, p50, p75, max), bucketed value sums and sample counts; schema updated accordingly.

* **Improvements**
  * Endpoint reads precomputed rollups for faster, consistent series results.
  * Timeline charts use medians for latency-like metrics and weighted means for WER.
  * Series rollups are refreshed after successful/partial runs (including SIGTERM-partial) to improve freshness.

* **Database Migration**
  * Adds a rollup table to store per-bucket aggregates for series reads.

* **Tests**
  * Expanded tests to cover migration backfill, rollup refresh behavior, and updated series assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the live `GROUP BY` query over 500k+ raw rows in the aggregates `series` block with a pre-aggregated `results_by_bucket` rollup table, keyed on `(provider, model, benchmark, metric_type, bucket_at)` and holding full distribution columns (min/p25/p50/p75/max/value_sum/sample_count). The orchestrator's end-of-run hook populates it via a delete-then-recompute-in-one-transaction approach serialised per bucket with a PostgreSQL advisory lock, making simultaneous refreshes idempotent.

- **New rollup table + migration**: `results_by_bucket` is created with a primary key and a `(benchmark, bucket_at)` index; the migration backfills the table from all existing results, and the `downgrade` path cleanly drops the table.
- **Writer & orchestrator hook**: `RunWriter.refresh_bucket` runs a transaction-scoped advisory lock → DELETE → INSERT from raw rows for the entire time-bucket, and `_refresh_series_bucket` wraps it with a 3-attempt retry. The orchestrator calls it after `SUCCEEDED`/`PARTIAL` runs (including SIGTERM-partial), skipping `FAILED` runs.
- **Frontend**: `useChartData` is updated to serve p50 for latency metrics and `value_sum / sample_count` for WER, with a forward-compatible fallback to `avg_value` for pre-rollup API responses.

<h3>Confidence Score: 5/5</h3>

Safe to merge. The rollup table write path is correctly transactional, advisory-locked per bucket, and idempotent; the API read path is a straightforward index-range scan.

The delete-then-recompute strategy is sound: the advisory lock serialises concurrent refreshes, DELETE and INSERT share a single transaction so readers never see a partially-refreshed bucket, and the retry wrapper prevents transient errors from failing the run. Tests cover migration, idempotency, shared-slot recompute, failed-run exclusion, and orchestrator hook firing.

No files require special attention beyond the already-flagged test gaps in runner/tests/api/test_aggregates.py and runner/tests/api/conftest.py.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| runner/src/coval_bench/db/writer.py | Adds refresh_bucket with advisory lock, DELETE + INSERT in one transaction. Early-return on NULL scheduled_at is safe. |
| runner/src/coval_bench/runner/orchestrator.py | Adds _refresh_series_bucket with 3-attempt retry, wired into normal and SIGTERM-partial end-of-run paths. |
| runner/src/coval_bench/db/migrations/versions/20260611_0006_results_by_bucket.py | Creates results_by_bucket with correct PK and index, backfills from raw rows. Only integer constant interpolated in SQL. |
| runner/src/coval_bench/api/routers/aggregates.py | Replaces live GROUP-BY with indexed range read from results_by_bucket. Cache-key structure unchanged. |
| runner/tests/api/test_aggregates.py | Updates series assertions to check full distribution shape. Window filter not exercised in test_window_excludes_old_rows. |
| runner/tests/api/conftest.py | Adds results_by_bucket DDL and _fill_buckets helper. TRUNCATE + INSERT are two separate autocommit ops (not atomic). |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `runner/tests/api/test_aggregates.py`, line 164-176 ([link](https://github.com/coval-ai/benchmarks/blob/a98620253089d91273c4f3b44a5e5d80f8878668/runner/tests/api/test_aggregates.py#L164-L176)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Series time-window filter is not exercised after the rollup change**

   `test_window_excludes_old_rows` doesn't call `_fill_buckets`, so `results_by_bucket` is empty and the `series` block is vacuously `[]` for every window. No test inserts a row with a `bucket_at` that falls outside the 24h window and then asserts it is absent from `series` (but present in the 30d window). The `_SERIES_SQL` filter `bucket_at >= NOW() - %(interval)s::interval` is the key correctness predicate for the new path, so it's worth a dedicated assertion alongside the existing `model_stats` check.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["Serialize bucket refreshes and retry tra..."](https://github.com/coval-ai/benchmarks/commit/d9fc91a1ae68ad93b38523490e7bccde55513f66) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37300243)</sub>

<!-- /greptile_comment -->