### PR TITLE
Start Gradium STT playground TTFA clock at ws open

### DIFF
--- a/web/lib/stt/gradium.ts
+++ b/web/lib/stt/gradium.ts
@@ -54,8 +54,6 @@ export function callGradium(
     }, SESSION_TIMEOUT_MS);
 
     ws.on("open", () => {
-      // Unlike the runner, the TTFA clock starts at ws open (handshake included)
-      // so timings are comparable with the other playground adapters.
       t0 = performance.now();
       ws.send(
         JSON.stringify({

--- a/web/lib/stt/gradium.ts
+++ b/web/lib/stt/gradium.ts
@@ -54,6 +54,9 @@ export function callGradium(
     }, SESSION_TIMEOUT_MS);
 
     ws.on("open", () => {
+      // Unlike the runner, the TTFA clock starts at ws open (handshake included)
+      // so timings are comparable with the other playground adapters.
+      t0 = performance.now();
       ws.send(
         JSON.stringify({
           type: "setup",
@@ -75,7 +78,6 @@ export function callGradium(
       if (msg.type === "ready") {
         ready = true;
         clearTimeout(readyTimer);
-        t0 = performance.now();
         for (let i = 0; i < buf.length; i += PCM_CHUNK_BYTES) {
           ws.send(
             JSON.stringify({


### PR DESCRIPTION
The Gradium STT adapter started its TTFA clock after the setup/ready handshake, when it began sending audio. Every other playground STT adapter starts the clock at WebSocket open, so Gradium's TTFA looked flattering next to the other models on the same page.

This moves the t0 assignment to the open handler, matching Speechmatics and both Deepgram variants. A comment notes the deliberate divergence from the runner methodology, since the file header says the adapter mirrors the runner.

Verified with eslint, tsc, and the web vitest suite (32 passing).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted audio timing baseline to start earlier in the connection lifecycle so reported metrics include connection handshake latency, improving timing accuracy for audio events.
  * No changes to public APIs or result formats; this improves measurement precision without altering existing integrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a measurement inconsistency in the Gradium STT playground adapter by moving the TTFA baseline timestamp (`t0`) from the `ready` message handler to the `ws.on("open")` handler, aligning it with Speechmatics and both Deepgram adapters on the same page.

- `t0 = performance.now()` is now captured at WebSocket open, so connection and handshake time are included in the TTFA metric, matching playground convention.
- The existing `t0 > 0` guard on line 99 remains valid since `t0` is only set inside `open`, which still fires before any `text` message can arrive.
- `audioToFinalMs` in `resolveWithTranscript` correctly falls through to `0` in the rare path where the socket closes before opening, because the `close` handler rejects with "connection closed before ready" before that branch is reached.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a one-line move of a timestamp assignment with no functional side effects.

The moved `t0` assignment is the only changed line and it falls in a well-guarded path: it can only be set once (inside `open`), the `t0 > 0` guard on the TTFA calculation is still satisfied by this earlier assignment, and edge cases where the socket closes before reaching `ready` are already handled by the `close` handler's `!ready` rejection branch.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| web/lib/stt/gradium.ts | Moves `t0 = performance.now()` from the `ready` message handler to the `ws.on("open")` handler so the TTFA clock starts at WebSocket connection open, matching all other playground STT adapters. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant C as Client
    participant W as Gradium WS

    Note over C: t0 = performance.now() (NEW position)
    C->>W: WebSocket open
    C->>W: "send { type: "setup", model_name, input_format, json_config }"
    W->>C: "{ type: "ready" }"
    Note over C: (OLD position: t0 was set here)
    C->>W: send audio chunks (base64 PCM)
    C->>W: "send { type: "flush", flush_id: 1 }"
    W->>C: "{ type: "text", text: "..." }"
    Note over C: ttfaMs = performance.now() - t0
    C->>W: "send { type: "end_of_stream" } (after FLUSH_SETTLE_MS)"
    W->>C: "{ type: "end_of_stream" }"
    Note over C: resolve with transcript, ttfaMs, audioToFinalMs
```

<sub>Reviews (2): Last reviewed commit: ["Update gradium.ts"](https://github.com/coval-ai/benchmarks/commit/882e14b8fbe1b6e75d2426d70dd50f3169ead197) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37300448)</sub>

<!-- /greptile_comment -->