### PR TITLE
Rename Gradium playground labels to Gradium TTS and Gradium STT

### DIFF
--- a/web/app/playground/components/playground-draft/ModelPill.tsx
+++ b/web/app/playground/components/playground-draft/ModelPill.tsx
@@ -21,8 +21,6 @@ export function ModelPill({
   onToggle,
   fullWidth = false
 }: ModelPillProps) {
-  // Drop the provider tag when the label already names the provider
-  // (e.g. "Gradium TTS · Gradium", "Speechmatics+ · Speechmatics").
   const showProvider =
     providerLabel && !label.toLowerCase().includes(providerLabel.toLowerCase());
 

--- a/web/app/playground/components/playground-draft/ModelPill.tsx
+++ b/web/app/playground/components/playground-draft/ModelPill.tsx
@@ -21,6 +21,11 @@ export function ModelPill({
   onToggle,
   fullWidth = false
 }: ModelPillProps) {
+  // Drop the provider tag when the label already names the provider
+  // (e.g. "Gradium TTS · Gradium", "Speechmatics+ · Speechmatics").
+  const showProvider =
+    providerLabel && !label.toLowerCase().includes(providerLabel.toLowerCase());
+
   const className = [
     fullWidth
       ? "flex w-full max-w-full min-w-0 items-center justify-between gap-2 rounded-xl border px-3 py-2 text-xs font-medium transition-colors"
@@ -43,7 +48,7 @@ export function ModelPill({
         <span className="size-1.5 shrink-0 rounded-full" style={dotStyle} aria-hidden />
         <span className="min-w-0 truncate">{label}</span>
       </span>
-      {providerLabel ? (
+      {showProvider ? (
         <span className="shrink-0 text-[10px] font-medium uppercase tracking-wide text-text-tertiary dark:text-zinc-500">
           {providerLabel}
         </span>
@@ -54,7 +59,7 @@ export function ModelPill({
       <span className="size-1.5 shrink-0 rounded-full" style={dotStyle} aria-hidden />
       <span className="min-w-0 truncate">
         {label}
-        {providerLabel ? (
+        {showProvider ? (
           <span className="font-normal text-text-tertiary dark:text-zinc-500"> · {providerLabel}</span>
         ) : null}
       </span>

--- a/web/lib/playground/providers.ts
+++ b/web/lib/playground/providers.ts
@@ -102,7 +102,7 @@ export const ttsModels: TtsModelConfig[] = [
   {
     id: "gradium:default:emma",
     provider: "gradium",
-    label: "Default",
+    label: "Gradium TTS",
     model: "default",
     voice: "YTpq7expH9539ERJ",
     enabled: true
@@ -169,7 +169,7 @@ export const sttModels: SttModelConfig[] = [
   {
     id: "gradium:default",
     provider: "gradium",
-    label: "Gradium",
+    label: "Gradium STT",
     model: "default",
     sampleRate: 16_000,
     enabled: true


### PR DESCRIPTION
Renames the Gradium playground allowlist labels so the modality is explicit: the TTS entry "Default" becomes "Gradium TTS" and the STT entry "Gradium" becomes "Gradium STT".

Since the model pills render the provider name next to the label, the new labels would read "Gradium TTS · Gradium". ModelPill now suppresses the provider tag when the label already contains the provider name, which also cleans up the existing "Speechmatics · Speechmatics" and "AssemblyAI · AssemblyAI" pills.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Eliminated redundant provider label display when the provider name is already included in the model label.
* **Updates**
  * Updated Gradium TTS and Gradium STT model display labels for improved clarity in the playground interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR renames the Gradium playground model labels to be modality-explicit ("Default" → "Gradium TTS", "Gradium" → "Gradium STT") and updates `ModelPill` to suppress the provider tag when the label already contains the provider name, eliminating redundant displays like "Speechmatics · Speechmatics" and "AssemblyAI · AssemblyAI".

- **`providers.ts`**: Two label-only renames; the stable `id` and `model` fields are untouched, so no server-side behaviour changes.
- **`ModelPill.tsx`**: New `showProvider` flag uses a case-insensitive `includes` check against `providerLabel`; works correctly for all current provider display names (`"Gradium"`, `"AssemblyAI"`, `"Speechmatics"`).

<h3>Confidence Score: 5/5</h3>

Safe to merge — only display labels and UI suppression logic are touched, with no impact on model IDs, API calls, or server-side behaviour.

Both changes are purely presentational. The label renames in providers.ts affect only the UI copy; the stable id and model fields used for API routing are unchanged. The showProvider guard in ModelPill.tsx is a straightforward case-insensitive substring check that behaves correctly for every current provider display name.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| web/app/playground/components/playground-draft/ModelPill.tsx | Adds showProvider guard that hides the provider tag when the label already contains the provider name; logic is correct for all existing labels including Gradium, AssemblyAI, and Speechmatics. |
| web/lib/playground/providers.ts | Renames Gradium TTS label "Default" → "Gradium TTS" and Gradium STT label "Gradium" → "Gradium STT"; labels are purely display-only and no other file references them by value. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([ModelPill renders]) --> B{providerLabel provided?}
    B -- No --> D[Show label only]
    B -- Yes --> C{label contains providerLabel?}
    C -- Yes - already in label --> D
    C -- No - no redundancy --> E[Show label and provider tag]
```

<sub>Reviews (2): Last reviewed commit: ["Update ModelPill.tsx"](https://github.com/coval-ai/benchmarks/commit/7e0920a318e8357105a12cf19230e4a17e4eeca7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37300584)</sub>

<!-- /greptile_comment -->