### PR TITLE
Default STT metric to TTFS and sync the toggle across all latency charts

### DIFF
--- a/web/components/charts/d3/BoxPlot.tsx
+++ b/web/components/charts/d3/BoxPlot.tsx
@@ -64,7 +64,9 @@ const BoxPlot: React.FC<BoxPlotProps> = ({
     // STT hides the y-axis tick labels, so it needs almost no left margin —
     // reclaim that space for a wider plot. TTS keeps room for the "1.4s" ticks.
     const showYTicks = !(
-      data.metricType === "NTTFT" || data.metricType === "TTFT"
+      data.metricType === "NTTFT" ||
+      data.metricType === "TTFT" ||
+      data.metricType === "TTFS"
     );
     const margin = { top: 20, right: 8, bottom: 80, left: showYTicks ? 40 : 10 };
     const chartWidth = dimensions.width - margin.left - margin.right;

--- a/web/components/dashboard/BoxPlotSection.tsx
+++ b/web/components/dashboard/BoxPlotSection.tsx
@@ -25,7 +25,10 @@ const BoxPlotSection: React.FC = () => {
   } = useDashboard();
   const trackChartHover = useChartHoverTracking("box_plot");
 
-  const boxPlotData = getBoxPlotData(activeMetric);
+  const boxPlotData = useMemo(
+    () => getBoxPlotData(activeMetric),
+    [getBoxPlotData, activeMetric]
+  );
   // Median across the selected models' per-model medians.
   const medianLatency = useMemo(
     () => median(boxPlotData.data.map((modelData) => modelData.quartiles.median)),

--- a/web/components/dashboard/BoxPlotSection.tsx
+++ b/web/components/dashboard/BoxPlotSection.tsx
@@ -10,6 +10,7 @@ import { median } from "@/lib/utils/median";
 import BoxPlot from "@/components/charts/d3/BoxPlot";
 import Card from "@/components/shared/Card";
 import SectionHeader from "@/components/shared/SectionHeader";
+import MetricToggle from "@/components/dashboard/MetricToggle";
 import { useDashboard } from "@/contexts/DashboardContext";
 import { useChartHoverTracking } from "@/hooks/useChartHoverTracking";
 
@@ -20,10 +21,11 @@ const BoxPlotSection: React.FC = () => {
     getBoxPlotData,
     getProviderForModel,
     isMobile,
+    activeMetric,
   } = useDashboard();
   const trackChartHover = useChartHoverTracking("box_plot");
 
-  const boxPlotData = getBoxPlotData();
+  const boxPlotData = getBoxPlotData(activeMetric);
   // Median across the selected models' per-model medians.
   const medianLatency = useMemo(
     () => median(boxPlotData.data.map((modelData) => modelData.quartiles.median)),
@@ -41,6 +43,8 @@ const BoxPlotSection: React.FC = () => {
             value: `${medianLatency.toFixed(0)} ms`,
           }}
         />
+
+        <MetricToggle />
 
         <BoxPlot
           data={boxPlotData}

--- a/web/components/dashboard/HeatmapSection.tsx
+++ b/web/components/dashboard/HeatmapSection.tsx
@@ -7,6 +7,7 @@ import React from "react";
 import HeatmapPlot from "@/components/charts/d3/HeatmapPlot";
 import Card from "@/components/shared/Card";
 import SectionHeader from "@/components/shared/SectionHeader";
+import MetricToggle from "@/components/dashboard/MetricToggle";
 import { useDashboard } from "@/contexts/DashboardContext";
 import { useChartHoverTracking } from "@/hooks/useChartHoverTracking";
 
@@ -26,6 +27,8 @@ const HeatmapSection: React.FC = () => {
           }}
           expandable={false}
         />
+
+        <MetricToggle />
 
         {/* The mobile scale transform (useDashboardState) targets
             .heatmap-container, so only the plot lives inside it — keeping the

--- a/web/components/dashboard/LatencyAccuracySection.tsx
+++ b/web/components/dashboard/LatencyAccuracySection.tsx
@@ -3,7 +3,7 @@
 
 "use client";
 
-import React, { useMemo, useState } from "react";
+import React, { useMemo } from "react";
 import {
   ScatterChart,
   Scatter,
@@ -18,23 +18,19 @@ import { getModelColor } from "@/lib/utils/colors";
 import CustomScatterTooltip from "@/components/charts/tooltips/ScatterTooltip";
 import Card from "@/components/shared/Card";
 import SectionHeader from "@/components/shared/SectionHeader";
+import MetricToggle from "@/components/dashboard/MetricToggle";
 import { useDashboard } from "@/contexts/DashboardContext";
 import { useThemeColors } from "@/hooks/useThemeColors";
 import { useActiveTab } from "@/hooks/useActiveTab";
 import { useChartHoverTracking } from "@/hooks/useChartHoverTracking";
 
 const LatencyAccuracySection: React.FC = () => {
-  const { selectedModels, getScatterData } = useDashboard();
+  const { selectedModels, getScatterData, activeMetric: metric } = useDashboard();
 
   const activeTab = useActiveTab();
   const themeColors = useThemeColors();
   const trackChartHover = useChartHoverTracking("scatter");
 
-  // STT shows a TTFS / TTFT toggle; TTS is single-metric (TTFA). Defaulting to
-  // TTFT for now; flip back to "TTFS" once enough TTFS data has accumulated.
-  const [metric, setMetric] = useState<string>(
-    activeTab === "stt" ? "TTFT" : "TTFA"
-  );
   const latencyLabel = metric;
   const scatterData = useMemo(
     () => getScatterData(metric),
@@ -101,25 +97,7 @@ const LatencyAccuracySection: React.FC = () => {
           }}
         />
 
-        {activeTab === "stt" && (
-          <div className="mb-4 inline-flex gap-0.5 rounded-lg bg-gray-100 p-0.5">
-            {(["TTFS", "TTFT"] as const).map((m) => (
-              <button
-                key={m}
-                type="button"
-                onClick={() => setMetric(m)}
-                className={
-                  "rounded-md px-3 py-1 text-xs font-medium transition-colors " +
-                  (metric === m
-                    ? "bg-white text-text-primary shadow-sm"
-                    : "text-gray-500 hover:text-text-primary")
-                }
-              >
-                {m}
-              </button>
-            ))}
-          </div>
-        )}
+        <MetricToggle />
 
         <div className="h-64" onMouseEnter={trackChartHover}>
           <ResponsiveContainer width="100%" height="100%">

--- a/web/components/dashboard/MetricToggle.tsx
+++ b/web/components/dashboard/MetricToggle.tsx
@@ -1,0 +1,42 @@
+// Copyright 2026 The Coval Benchmarks Authors
+// SPDX-License-Identifier: Apache-2.0
+
+"use client";
+
+import React from "react";
+import { useDashboard } from "@/contexts/DashboardContext";
+import { useActiveTab } from "@/hooks/useActiveTab";
+
+// Shared TTFS / TTFT switch. Reads and writes the single dashboard-wide metric,
+// so every chart that renders it stays in sync. Hidden on TTS (single-metric).
+const MetricToggle: React.FC<{ onChange?: () => void }> = ({ onChange }) => {
+  const activeTab = useActiveTab();
+  const { sttMetric, setSttMetric } = useDashboard();
+
+  if (activeTab !== "stt") return null;
+
+  return (
+    <div className="mb-4 inline-flex gap-0.5 rounded-lg bg-gray-100 p-0.5">
+      {(["TTFS", "TTFT"] as const).map((m) => (
+        <button
+          key={m}
+          type="button"
+          onClick={() => {
+            setSttMetric(m);
+            onChange?.();
+          }}
+          className={
+            "rounded-md px-3 py-1 text-xs font-medium transition-colors " +
+            (sttMetric === m
+              ? "bg-white text-text-primary shadow-sm"
+              : "text-gray-500 hover:text-text-primary")
+          }
+        >
+          {m}
+        </button>
+      ))}
+    </div>
+  );
+};
+
+export default MetricToggle;

--- a/web/components/dashboard/MetricToggle.tsx
+++ b/web/components/dashboard/MetricToggle.tsx
@@ -9,7 +9,7 @@ import { useActiveTab } from "@/hooks/useActiveTab";
 
 // Shared TTFS / TTFT switch. Reads and writes the single dashboard-wide metric,
 // so every chart that renders it stays in sync. Hidden on TTS (single-metric).
-const MetricToggle: React.FC<{ onChange?: () => void }> = ({ onChange }) => {
+const MetricToggle: React.FC = () => {
   const activeTab = useActiveTab();
   const { sttMetric, setSttMetric } = useDashboard();
 
@@ -21,10 +21,7 @@ const MetricToggle: React.FC<{ onChange?: () => void }> = ({ onChange }) => {
         <button
           key={m}
           type="button"
-          onClick={() => {
-            setSttMetric(m);
-            onChange?.();
-          }}
+          onClick={() => setSttMetric(m)}
           className={
             "rounded-md px-3 py-1 text-xs font-medium transition-colors " +
             (sttMetric === m

--- a/web/components/visualizations/TimelineChart.tsx
+++ b/web/components/visualizations/TimelineChart.tsx
@@ -20,6 +20,7 @@ import { metricDescriptions } from "@/lib/config/metrics";
 import CustomTimelineTooltip from "@/components/charts/tooltips/TimelineTooltip";
 import Card from "@/components/shared/Card";
 import SectionHeader from "@/components/shared/SectionHeader";
+import MetricToggle from "@/components/dashboard/MetricToggle";
 import { useActiveTab } from "@/hooks/useActiveTab";
 import { useDashboard } from "@/contexts/DashboardContext";
 import { useThemeColors } from "@/hooks/useThemeColors";
@@ -78,15 +79,11 @@ const TimelineChart: React.FC = () => {
     formatChartLabel,
     getProviderForModel,
     getMedianLatencyMs,
+    activeMetric: metric,
     dataTimeWindow,
   } = useDashboard();
   const trackChartHover = useChartHoverTracking("timeline");
 
-  // STT shows a TTFS / TTFT toggle; TTS is single-metric (TTFA). Defaulting to
-  // TTFT for now; flip back to "TTFS" once enough TTFS data has accumulated.
-  const [metric, setMetric] = useState<string>(
-    activeTab === "stt" ? "TTFT" : "TTFA"
-  );
   const chartRef = useRef<HTMLDivElement>(null);
   const pinnedRef = useRef<HTMLDivElement>(null);
   const [pinned, setPinned] = useState<PinnedTooltip | null>(null);
@@ -156,28 +153,7 @@ const TimelineChart: React.FC = () => {
           }}
         />
 
-        {activeTab === "stt" && (
-          <div className="mb-4 inline-flex gap-0.5 rounded-lg bg-gray-100 p-0.5">
-            {(["TTFS", "TTFT"] as const).map((m) => (
-              <button
-                key={m}
-                type="button"
-                onClick={() => {
-                  setMetric(m);
-                  setPinned(null);
-                }}
-                className={
-                  "rounded-md px-3 py-1 text-xs font-medium transition-colors " +
-                  (metric === m
-                    ? "bg-white text-text-primary shadow-sm"
-                    : "text-gray-500 hover:text-text-primary")
-                }
-              >
-                {m}
-              </button>
-            ))}
-          </div>
-        )}
+        <MetricToggle onChange={() => setPinned(null)} />
 
         <div ref={chartRef} className="relative h-96" onMouseEnter={trackChartHover}>
           <ResponsiveContainer width="100%" height="100%">

--- a/web/components/visualizations/TimelineChart.tsx
+++ b/web/components/visualizations/TimelineChart.tsx
@@ -88,6 +88,12 @@ const TimelineChart: React.FC = () => {
   const pinnedRef = useRef<HTMLDivElement>(null);
   const [pinned, setPinned] = useState<PinnedTooltip | null>(null);
 
+  // The metric is shared dashboard-wide, so clear any pinned tooltip whenever it
+  // changes — whether from this chart's toggle or another section's.
+  useEffect(() => {
+    setPinned(null);
+  }, [metric]);
+
   useEffect(() => {
     if (pinned === null) return;
     const onDocMouseDown = (e: MouseEvent) => {
@@ -153,7 +159,7 @@ const TimelineChart: React.FC = () => {
           }}
         />
 
-        <MetricToggle onChange={() => setPinned(null)} />
+        <MetricToggle />
 
         <div ref={chartRef} className="relative h-96" onMouseEnter={trackChartHover}>
           <ResponsiveContainer width="100%" height="100%">

--- a/web/hooks/useChartData.ts
+++ b/web/hooks/useChartData.ts
@@ -160,20 +160,29 @@ export function useChartData({
     ]
   );
 
-  // Per-model box-plot pieces from the SQL stats: box = p25..p75, whiskers
-  // clamped to 1.5x IQR beyond the box (against the true data extremes).
-  const boxByModel = useMemo<Record<string, BoxPlotDataPoint>>(() => {
-    const primaryMetric = activeTab === "tts" ? "TTFA" : "TTFT";
-
-    const byModel: Record<string, BoxPlotDataPoint> = {};
+  // Per-metric, per-model box-plot pieces from the SQL stats, built in one pass
+  // and indexed by metric_type so any latency metric can read its own pieces:
+  // box = p25..p75, whiskers clamped to 1.5x IQR beyond the box (against the
+  // true data extremes).
+  const boxByMetricModel = useMemo<
+    Record<string, Record<string, BoxPlotDataPoint>>
+  >(() => {
+    const out: Record<string, Record<string, BoxPlotDataPoint>> = {};
     modelStats.forEach((stat) => {
-      if (stat.metric_type !== primaryMetric) return;
+      if (
+        stat.metric_type !== "TTFS" &&
+        stat.metric_type !== "TTFT" &&
+        stat.metric_type !== "TTFA"
+      ) {
+        return;
+      }
 
       const q1 = toDisplayUnits(stat.p25);
       const median = toDisplayUnits(stat.p50);
       const q3 = toDisplayUnits(stat.p75);
       const iqr = q3 - q1;
 
+      const byModel = (out[stat.metric_type] ??= {});
       byModel[toModelKey(stat.provider, stat.model)] = {
         model: toModelKey(stat.provider, stat.model),
         provider: stat.provider,
@@ -192,46 +201,44 @@ export function useChartData({
       };
     });
 
-    return byModel;
-  }, [modelStats, activeTab, toDisplayUnits]);
+    return out;
+  }, [modelStats, toDisplayUnits]);
 
-  // Box plot data: the selected models' pieces, sorted by median, with the
-  // pooled axis bounds.
-  const boxPlotDataMemo = useMemo<BoxPlotData>(() => {
-    const selectedModels =
-      activeTab === "tts" ? selectedTTSModels : selectedSTTModels;
-    const primaryMetric = activeTab === "tts" ? "TTFA" : "TTFT";
-
-    const data: BoxPlotDataPoint[] = [];
-    let globalMin = Infinity;
-    let globalMax = -Infinity;
-
-    selectedModels.forEach((model) => {
-      const entry = boxByModel[model];
-      if (!entry) return;
-      data.push(entry);
-      globalMin = Math.min(globalMin, entry.quartiles.min);
-      globalMax = Math.max(globalMax, entry.quartiles.max);
-    });
-
-    if (data.length === 0) {
-      globalMin = 0;
-      globalMax = 0;
-    }
-
-    data.sort((a, b) => a.quartiles.median - b.quartiles.median);
-
-    return {
-      data,
-      globalMin,
-      globalMax,
-      metricType: primaryMetric
-    };
-  }, [boxByModel, activeTab, selectedTTSModels, selectedSTTModels]);
-
+  // Box plot data for a given metric: the selected models' pieces, sorted by
+  // median, with the pooled axis bounds.
   const getBoxPlotData = useCallback(
-    (): BoxPlotData => boxPlotDataMemo,
-    [boxPlotDataMemo]
+    (metric: string): BoxPlotData => {
+      const selectedModels =
+        activeTab === "tts" ? selectedTTSModels : selectedSTTModels;
+      const byModel = boxByMetricModel[metric] ?? {};
+
+      const data: BoxPlotDataPoint[] = [];
+      let globalMin = Infinity;
+      let globalMax = -Infinity;
+
+      selectedModels.forEach((model) => {
+        const entry = byModel[model];
+        if (!entry) return;
+        data.push(entry);
+        globalMin = Math.min(globalMin, entry.quartiles.min);
+        globalMax = Math.max(globalMax, entry.quartiles.max);
+      });
+
+      if (data.length === 0) {
+        globalMin = 0;
+        globalMax = 0;
+      }
+
+      data.sort((a, b) => a.quartiles.median - b.quartiles.median);
+
+      return {
+        data,
+        globalMin,
+        globalMax,
+        metricType: metric
+      };
+    },
+    [boxByMetricModel, activeTab, selectedTTSModels, selectedSTTModels]
   );
 
   // Per-metric, per-model scatter point (avg latency, avg WER) built in one
@@ -281,44 +288,42 @@ export function useChartData({
     [scatterByMetricModel, activeTab, selectedTTSModels, selectedSTTModels]
   );
 
-  // Heatmap rows: absolute latency percentiles straight from the SQL stats
-  // (like the box plot), plus avg WER.
-  const heatmapDataMemo = useMemo<ModelHeatmapData[]>(() => {
-    const selectedModels =
-      activeTab === "tts" ? selectedTTSModels : selectedSTTModels;
-    const latencyMetric = activeTab === "tts" ? "TTFA" : "TTFT";
-
-    const heatmapData: ModelHeatmapData[] = [];
-
-    selectedModels.forEach((model) => {
-      const latencyStat = getStat(model, latencyMetric);
-      const werStat = getStat(model, "WER");
-
-      if (!latencyStat || !werStat) return;
-
-      const p25 = toDisplayUnits(latencyStat.p25);
-      const p75 = toDisplayUnits(latencyStat.p75);
-      heatmapData.push({
-        model,
-        latencyP25: p25,
-        latencyP50: toDisplayUnits(latencyStat.p50),
-        latencyP75: p75,
-        latencyIQR: p75 - p25,
-        avgWER: werStat.avg_value,
-        werStdDev: werStat.stddev_value
-      });
-    });
-
-    return heatmapData.sort(
-      (a, b) =>
-        normalizeModelName(a.model).localeCompare(normalizeModelName(b.model)) ||
-        a.model.localeCompare(b.model)
-    );
-  }, [activeTab, selectedTTSModels, selectedSTTModels, getStat, toDisplayUnits]);
-
+  // Heatmap rows for a given latency metric: absolute latency percentiles
+  // straight from the SQL stats (like the box plot), plus avg WER.
   const getHeatmapData = useCallback(
-    (): ModelHeatmapData[] => heatmapDataMemo,
-    [heatmapDataMemo]
+    (metric: string): ModelHeatmapData[] => {
+      const selectedModels =
+        activeTab === "tts" ? selectedTTSModels : selectedSTTModels;
+
+      const heatmapData: ModelHeatmapData[] = [];
+
+      selectedModels.forEach((model) => {
+        const latencyStat = getStat(model, metric);
+        const werStat = getStat(model, "WER");
+
+        if (!latencyStat || !werStat) return;
+
+        const p25 = toDisplayUnits(latencyStat.p25);
+        const p75 = toDisplayUnits(latencyStat.p75);
+        heatmapData.push({
+          model,
+          latencyP25: p25,
+          latencyP50: toDisplayUnits(latencyStat.p50),
+          latencyP75: p75,
+          latencyIQR: p75 - p25,
+          avgWER: werStat.avg_value,
+          werStdDev: werStat.stddev_value
+        });
+      });
+
+      return heatmapData.sort(
+        (a, b) =>
+          normalizeModelName(a.model).localeCompare(
+            normalizeModelName(b.model)
+          ) || a.model.localeCompare(b.model)
+      );
+    },
+    [activeTab, selectedTTSModels, selectedSTTModels, getStat, toDisplayUnits]
   );
 
   const werBarDataMemo = useMemo<BarDataPoint[]>(() => {

--- a/web/hooks/useDashboardState.tsx
+++ b/web/hooks/useDashboardState.tsx
@@ -187,7 +187,7 @@ export function useDashboardState(page: "tts" | "stt") {
   }, [modelsByProvider]);
 
   // Calculate metrics
-  const { getStat } = chartData;
+  const { getStat, getHeatmapData } = chartData;
 
   // Median latency (in display units) across the selected models' per-model
   // medians for the given metric. This is the single canonical headline number,
@@ -285,13 +285,17 @@ export function useDashboardState(page: "tts" | "stt") {
           "In voice AI applications, transcription accuracy directly impacts the performance of downstream tasks. Even small transcription errors can lead to misinterpretations, frustrating experiences, or incorrect system responses. We evaluate against test audio that includes diverse speakers, accents, and real-world audio conditions. Click a bar to highlight it for comparison.",
       };
 
-  const heatmapDisplayData = chartData.getHeatmapData(activeMetric);
+  const heatmapDisplayData = useMemo(
+    () => getHeatmapData(activeMetric),
+    [getHeatmapData, activeMetric]
+  );
 
   // Pre-computed key metrics for display
   const primaryKeyMetric = (() => {
     const latencyFullLabel =
-      metricDescriptions[activeMetric.toLowerCase() as keyof typeof metricDescriptions]
-        .short;
+      metricDescriptions[
+        activeMetric.toLowerCase() as keyof typeof metricDescriptions
+      ]?.short ?? activeMetric;
     return {
       label: `Median ${latencyFullLabel}`,
       displayValue: `${medianPrimary.toFixed(0)} ms`,

--- a/web/hooks/useDashboardState.tsx
+++ b/web/hooks/useDashboardState.tsx
@@ -25,6 +25,12 @@ import { useTimeWindow } from "@/hooks/useTimeWindow";
 export function useDashboardState(page: "tts" | "stt") {
   // State declarations
   const [selectedModels, setSelectedModels] = useState<string[]>([]);
+
+  // STT shows a TTFS / TTFT toggle that drives every latency surface (headline,
+  // timeline, box plot, scatter, heatmap) in sync. TTS is single-metric (TTFA),
+  // so the toggle is hidden there and the metric stays TTFA.
+  const [sttMetric, setSttMetric] = useState<"TTFS" | "TTFT">("TTFS");
+  const activeMetric = page === "tts" ? "TTFA" : sttMetric;
   const { timeWindow, changeTimeWindow } = useTimeWindow(
     `${page}_dashboard`,
     page
@@ -203,10 +209,9 @@ export function useDashboardState(page: "tts" | "stt") {
 
   // Headline numbers: the median latency across selected models, and the
   // lowest average WER (with one model selected, that model's own value).
-  const primaryMetric = page === "tts" ? "TTFA" : "TTFT";
   const medianPrimary = useMemo(
-    () => getMedianLatencyMs(primaryMetric),
-    [getMedianLatencyMs, primaryMetric]
+    () => getMedianLatencyMs(activeMetric),
+    [getMedianLatencyMs, activeMetric]
   );
 
   const keyMetrics = useMemo(() => {
@@ -247,7 +252,7 @@ export function useDashboardState(page: "tts" | "stt") {
   }, [werBarData, clickedWERBars]);
 
   // Derived display values
-  const latencyLabel = page === "tts" ? "TTFA" : "TTFT";
+  const latencyLabel = activeMetric;
   const pageTitle = page === "tts" ? "Text to Speech Model Comparisons" : "Speech to Text Model Comparisons";
   const pageSubtitle = page === "tts"
     ? "Compare performance metrics between different Text-to-Speech models for voice agent applications."
@@ -280,12 +285,13 @@ export function useDashboardState(page: "tts" | "stt") {
           "In voice AI applications, transcription accuracy directly impacts the performance of downstream tasks. Even small transcription errors can lead to misinterpretations, frustrating experiences, or incorrect system responses. We evaluate against test audio that includes diverse speakers, accents, and real-world audio conditions. Click a bar to highlight it for comparison.",
       };
 
-  const heatmapDisplayData = chartData.getHeatmapData();
+  const heatmapDisplayData = chartData.getHeatmapData(activeMetric);
 
   // Pre-computed key metrics for display
   const primaryKeyMetric = (() => {
     const latencyFullLabel =
-      page === "tts" ? "Time to First Audio" : "Time to First Token";
+      metricDescriptions[activeMetric.toLowerCase() as keyof typeof metricDescriptions]
+        .short;
     return {
       label: `Median ${latencyFullLabel}`,
       displayValue: `${medianPrimary.toFixed(0)} ms`,
@@ -321,6 +327,11 @@ export function useDashboardState(page: "tts" | "stt") {
     // Section descriptions
     boxPlotDescription,
     werDescription,
+
+    // Metric toggle (STT: TTFS/TTFT; TTS: always TTFA)
+    sttMetric,
+    setSttMetric,
+    activeMetric,
 
     // Key metrics
     primaryKeyMetric,


### PR DESCRIPTION
Makes TTFS the default metric on the STT dashboard and ties the TTFS/TTFT switch to one shared state so the whole page moves together.

Toggling on any chart now updates the summary headline, timeline, box plot (Latency Variation), latency vs accuracy scatter, and heatmap at the same time. The box plot and heatmap previously hardcoded TTFT and now follow the toggle. The WER bar chart is left alone since it is not a latency metric. TTS is unaffected and stays on TTFA with no toggle.

No backend or data changes. All TTFS values were already present in the stats payload.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced unified metric toggle control for STT metrics (TTFS/TTFT) across dashboard sections
  * Charts and visualizations now dynamically update based on the selected metric

* **UI/UX Improvements**
  * Consolidated metric selection into a consistent toggle control across box plots, heatmaps, latency/accuracy, and timeline charts
  * Metric selection synchronized dashboard-wide for improved user experience

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes TTFS the default STT metric and unifies the TTFS/TTFT toggle into a single shared piece of state (`sttMetric` / `activeMetric`) so that every latency surface — the summary headline, timeline, box plot, scatter plot, and heatmap — moves together when the toggle is clicked on any chart.

- **`useDashboardState`**: adds `sttMetric` state (default `\"TTFS\"`) and derives `activeMetric` from it; threads `activeMetric` through headline, heatmap memoisation, and box plot calls.
- **`useChartData`**: re-indexes box-plot and heatmap data by metric type up front (`boxByMetricModel`), and converts `getBoxPlotData`/`getHeatmapData` from memoised values to `useCallback`s that accept a metric argument, enabling on-demand lookup without extra passes.
- **`MetricToggle`**: new shared component that reads/writes `sttMetric` from the dashboard context and renders `null` on TTS, replacing four copies of the inline toggle buttons.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is purely frontend state consolidation with no backend or data-schema impact.

All five latency surfaces now read from a single reactive activeMetric value derived from sttMetric. The memoisation is applied correctly at each consumer, the getBoxPlotData/getHeatmapData callbacks have accurate dependency arrays, TTS remains unaffected because activeMetric is hardcoded to TTFA when page === tts, and MetricToggle guards against appearing on the TTS tab.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| web/hooks/useDashboardState.tsx | Introduces sttMetric state and derives activeMetric; threads it through headline, heatmap, and box plot correctly with proper useMemo wrappers. |
| web/hooks/useChartData.ts | Re-indexes box-plot data by metric type and converts getBoxPlotData/getHeatmapData to metric-parameterised useCallbacks; dependencies look correct. |
| web/components/dashboard/MetricToggle.tsx | New shared toggle component; correctly reads sttMetric/setSttMetric from context and returns null on non-stt tabs. |
| web/components/visualizations/TimelineChart.tsx | Removes local metric state; uses a useEffect to clear the pinned tooltip whenever the shared metric changes — a clean replacement for the inline setPinned(null) on the old button click. |
| web/components/charts/d3/BoxPlot.tsx | Adds TTFS to the condition that suppresses y-axis tick labels, consistent with existing TTFT/NTTFT treatment. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    Toggle["MetricToggle\n(TTFS / TTFT button)"]
    State["useDashboardState\nsttMetric state\nactiveMetric = page=tts ? TTFA : sttMetric"]
    Toggle -->|setSttMetric| State

    State -->|activeMetric| Headline["Summary Headline\nprimaryKeyMetric"]
    State -->|activeMetric| BoxPlot["BoxPlotSection\nuseMemo getBoxPlotData(activeMetric)"]
    State -->|activeMetric| Heatmap["HeatmapSection\nuseMemo getHeatmapData(activeMetric)"]
    State -->|activeMetric| Scatter["LatencyAccuracySection\nuseMemo getScatterData(metric)"]
    State -->|activeMetric| Timeline["TimelineChart\nuseEffect clears pinned on change"]

    WER["WERBarSection\n(unaffected - not a latency metric)"]
    TTS["TTS page\nactiveMetric always TTFA\nMetricToggle returns null"]
```

<sub>Reviews (2): Last reviewed commit: ["Memoize box plot and heatmap data; clear..."](https://github.com/coval-ai/benchmarks/commit/dd05f2aa8941f59ebf7be718bb1678303d68780f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37306394)</sub>

<!-- /greptile_comment -->