### PR TITLE
Group model chart colors by provider color family

### DIFF
--- a/web/components/dashboard/AccuracyBarSection.tsx
+++ b/web/components/dashboard/AccuracyBarSection.tsx
@@ -122,7 +122,7 @@ const AccuracyBarSection: React.FC = () => {
                 }}
               >
                 {werBarDataWithColors.map((entry) => (
-                  <Cell key={`wer-cell-${entry.model}`} fill={entry.fill} />
+                  <Cell key={`wer-cell-${entry.model}`} fill={entry.fill} fillOpacity={entry.fillOpacity} />
                 ))}
               </Bar>
             </BarChart>

--- a/web/components/layout/MobileModelSheet.tsx
+++ b/web/components/layout/MobileModelSheet.tsx
@@ -7,6 +7,7 @@ import React from "react";
 import { normalizeModelName } from "@/lib/utils/formatters";
 import { useDashboard } from "@/contexts/DashboardContext";
 import { useSidebarMenu } from "@/contexts/SidebarMenuContext";
+import { getModelColor } from "@/lib/utils/colors";
 
 const MobileModelSheet: React.FC = () => {
   const {
@@ -75,21 +76,28 @@ const MobileModelSheet: React.FC = () => {
                 </button>
                 {expandedProviders[provider] && (
                   <div className="ml-3 space-y-1 mt-2">
-                    {models.map((model) => (
-                      <button
-                        key={model}
-                        onClick={() => onToggleModelSelection(model)}
-                        className={`block text-left py-2 px-3 rounded-lg text-sm transition-all duration-300 w-full ${
-                          selectedModels.includes(model)
-                            ? "bg-selected-bg text-text-primary shadow-md border border-selected-border"
-                            : "text-text-tertiary hover:text-text-secondary hover:bg-hover-bg"
-                        }`}
-                      >
-                        <span className="text-sm">
-                          {normalizeModelName(model)}
-                        </span>
-                      </button>
-                    ))}
+                    {models.map((model) => {
+                      const selected = selectedModels.includes(model);
+                      return (
+                        <button
+                          key={model}
+                          onClick={() => onToggleModelSelection(model)}
+                          className={`flex items-center gap-2 text-left py-2 px-3 rounded-lg text-sm transition-all duration-300 w-full ${
+                            selected
+                              ? "bg-selected-bg text-text-primary shadow-md border border-selected-border"
+                              : "text-text-tertiary hover:text-text-secondary hover:bg-hover-bg"
+                          }`}
+                        >
+                          <span
+                            className="shrink-0 h-2.5 w-2.5 rounded-full"
+                            style={{ backgroundColor: getModelColor(model) }}
+                          />
+                          <span className="text-sm">
+                            {normalizeModelName(model)}
+                          </span>
+                        </button>
+                      );
+                    })}
                   </div>
                 )}
               </div>

--- a/web/components/layout/ModelSidebar.tsx
+++ b/web/components/layout/ModelSidebar.tsx
@@ -6,6 +6,7 @@
 import React from "react";
 import { normalizeModelName } from "@/lib/utils/formatters";
 import { useDashboard } from "@/contexts/DashboardContext";
+import { getModelColor } from "@/lib/utils/colors";
 
 // Keep the links pinned in place until the footer is about to collide with the
 // actual bottom of the link list, then push the sidebar up so the filters slide
@@ -82,6 +83,7 @@ const ModelSidebar: React.FC = () => {
                 <div className="space-y-0">
                   {models.map((model) => {
                     const checked = selectedModels.includes(model);
+                    const modelColor = getModelColor(model);
                     return (
                       <label
                         key={model}
@@ -95,17 +97,18 @@ const ModelSidebar: React.FC = () => {
                             aria-label={`${
                               checked ? "Deselect" : "Select"
                             } ${model} model`}
-                            className="peer h-3.5 w-3.5 shrink-0 cursor-pointer appearance-none rounded-[3px] bg-[#d4d2cc] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-text-tertiary/40 focus-visible:ring-offset-1 focus-visible:ring-offset-background"
+                            className="peer h-3.5 w-3.5 shrink-0 cursor-pointer appearance-none rounded-[3px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-text-tertiary/40 focus-visible:ring-offset-1 focus-visible:ring-offset-background"
+                            style={{ backgroundColor: checked ? modelColor : "#d4d2cc" }}
                           />
                           <svg
                             aria-hidden
                             viewBox="0 0 14 14"
                             fill="none"
-                            stroke="currentColor"
+                            stroke="white"
                             strokeWidth={1.5}
                             strokeLinecap="round"
                             strokeLinejoin="round"
-                            className="pointer-events-none absolute inset-0 hidden h-3.5 w-3.5 text-text-primary peer-checked:block"
+                            className="pointer-events-none absolute inset-0 hidden h-3.5 w-3.5 peer-checked:block"
                           >
                             <path d="M3.5 7.5l2.5 2.5 4.5-5" />
                           </svg>

--- a/web/components/visualizations/TimelineChart.tsx
+++ b/web/components/visualizations/TimelineChart.tsx
@@ -33,10 +33,9 @@ interface LegendEntry {
 }
 
 // Custom legend: names are rendered in black (recharts colors them per-series
-// by default), and the items lay out in a grid that grows from two columns on
-// mobile to more columns on larger screens.
+// by default), and the items are stacked vertically.
 const TimelineLegend: React.FC<{ payload?: LegendEntry[] }> = ({ payload }) => (
-  <ul className="grid grid-cols-2 gap-x-4 gap-y-1.5 px-2 pt-5 sm:grid-cols-3 sm:gap-x-6 sm:gap-y-2 lg:grid-cols-4">
+  <ul className="flex flex-col gap-y-1.5 px-2 pt-5">
     {payload?.map((entry) => (
       <li
         key={entry.dataKey ?? entry.value}

--- a/web/components/visualizations/TimelineChart.tsx
+++ b/web/components/visualizations/TimelineChart.tsx
@@ -33,13 +33,14 @@ interface LegendEntry {
 }
 
 // Custom legend: names are rendered in black (recharts colors them per-series
-// by default), and the items are stacked vertically.
+// by default), and items fill top-to-bottom within each column so the list
+// reads alphabetically down each column rather than across rows.
 const TimelineLegend: React.FC<{ payload?: LegendEntry[] }> = ({ payload }) => (
-  <ul className="flex flex-col gap-y-1.5 px-2 pt-5">
+  <ul className="columns-2 gap-x-4 px-2 pt-5 sm:columns-3 sm:gap-x-6 lg:columns-4">
     {payload?.map((entry) => (
       <li
         key={entry.dataKey ?? entry.value}
-        className="flex items-start gap-1.5 text-xs leading-tight text-text-primary"
+        className="mb-1.5 flex items-start gap-1.5 text-xs leading-tight text-text-primary break-inside-avoid"
       >
         <span
           className="mt-0.5 inline-block w-3 h-3 shrink-0 rounded-[2px]"

--- a/web/hooks/useDashboardState.tsx
+++ b/web/hooks/useDashboardState.tsx
@@ -15,6 +15,7 @@ import { useMobileDetection } from "@/hooks/useMobileDetection";
 import { useBarInteraction } from "@/hooks/useBarInteraction";
 import { latencyToMs, normalizeModelName, normalizeSTTProviderName, normalizeTTSProviderName, parseModelKey, toModelKey } from "@/lib/utils/formatters";
 import { buildModelsByProvider, pruneSelection } from "@/lib/utils/modelsFromResults";
+import { getModelColor } from "@/lib/utils/colors";
 import { median } from "@/lib/utils/median";
 import { metricDescriptions } from "@/lib/config/metrics";
 import { useAggregatesQuery, useProvidersQuery } from "@/lib/api/queries";
@@ -241,13 +242,11 @@ export function useDashboardState(page: "tts" | "stt") {
   const werBarData = chartData.getWERBarData();
 
   const werBarDataWithColors = useMemo(() => {
+    const hasSelection = clickedWERBars.size > 0;
     return werBarData.map((item) => ({
       ...item,
-      // Default bars are an opaque, light tint of the selected-state orange
-      // (#FF851B). Opaque so the chart gridlines don't show through them.
-      fill: clickedWERBars.has(item.model)
-        ? "#FF851B"
-        : "#FFE5CC",
+      fill: getModelColor(item.model),
+      fillOpacity: hasSelection && !clickedWERBars.has(item.model) ? 0.25 : 1,
     }));
   }, [werBarData, clickedWERBars]);
 

--- a/web/lib/config/colors.ts
+++ b/web/lib/config/colors.ts
@@ -2,56 +2,56 @@
 // SPDX-License-Identifier: Apache-2.0
 
 export const modelColors: Record<string, string> = {
-  // OpenAI TTS
-  "gpt-4o-mini-tts": "#943126",
+  // OpenAI TTS — red family (#E74C3C)
+  "gpt-4o-mini-tts": "#C0392B",
 
-  // ElevenLabs TTS
-  eleven_multilingual_v2: "#FFD633",
+  // OpenAI STT — red family (#E74C3C)
+  "gpt-realtime-whisper": "#F1948A",
+
+  // ElevenLabs TTS — orange family (#F39C12)
+  eleven_multilingual_v2: "#F5B041",
   eleven_flash_v2_5: "#F39C12",
-  eleven_turbo_v2_5: "#B7950B",
+  eleven_turbo_v2_5: "#CA6F1E",
 
-  // ElevenLabs STT
-  scribe_v2_realtime: "#E67E22",
+  // ElevenLabs STT — orange family (#F39C12)
+  scribe_v2_realtime: "#935116",
 
-  // xAI STT
-  "grok-stt": "#EC4899",
+  // xAI TTS — pink family (#EC4899)
+  "grok-tts": "#F472B6",
 
-  // OpenAI STT
-  "gpt-realtime-whisper": "#10A37F",
+  // xAI STT — pink family (#EC4899)
+  "grok-stt": "#BE185D",
 
-  // Cartesia TTS
-  "sonic-3": "#3498DB",
-  "sonic-3.5": "#2563EB",
+  // Cartesia TTS — blue family (#3498DB)
+  "sonic-3": "#85C1E9",
+  "sonic-3.5": "#3498DB",
 
-  // Cartesia STT
-  "ink-2": "#6366F1",
+  // Cartesia STT — blue family (#3498DB)
+  "ink-2": "#1A5276",
 
-  // Rime TTS
-  arcana: "#33FF99",
-  mistv3: "#0E5C32",
-  coda: "#1DE9B6",
+  // Rime TTS — green family (#27AE60)
+  arcana: "#82E0AA",
+  coda: "#27AE60",
+  mistv3: "#1A7A40",
 
-  // Hume TTS
+  // Hume TTS — violet family (#A855F7)
+  "octave-2": "#C084FC",
   "octave-tts": "#7C3AED",
-  "octave-2": "#C026D3",
 
-  // xAI TTS
-  "grok-tts": "#EC4899",
+  // Deepgram TTS — teal family (#16A085)
+  "aura-2-thalia-en": "#0A4F48",
 
-  // Deepgram TTS
-  "aura-2-thalia-en": "#FC2D62",
+  // Deepgram STT — teal family (#16A085)
+  "nova-3": "#52C5AE",
+  "nova-2": "#26AD94",
+  "flux-general-multi": "#16A085",
+  "flux-general-en": "#0D7065",
 
-  // Deepgram STT
-  "nova-2": "#F39C12",
-  "nova-3": "#FFD633",
-  "flux-general-en": "#FFFF66",
-  "flux-general-multi": "#FFB347",
+  // AssemblyAI STT — amethyst family (#8E44AD)
+  "universal-streaming": "#8E44AD",
 
-  // AssemblyAI STT
-  "universal-streaming": "#E74C3C",
-
-  // Speechmatics STT
-  enhanced: "#3498DB",
+  // Speechmatics STT — navy family (#21618C)
+  enhanced: "#2E86C1",
   default: "#21618C",
   // Composite keys for models whose slug is shared across providers
   "speechmatics:default": "#21618C",

--- a/web/lib/config/colors.ts
+++ b/web/lib/config/colors.ts
@@ -2,55 +2,46 @@
 // SPDX-License-Identifier: Apache-2.0
 
 export const modelColors: Record<string, string> = {
-  // OpenAI TTS — red family (#E74C3C)
+  // OpenAI — red family (#E74C3C). Both TTS and STT use the same red range.
   "gpt-4o-mini-tts": "#C0392B",
+  "gpt-realtime-whisper": "#E74C3C",
 
-  // OpenAI STT — red family (#E74C3C)
-  "gpt-realtime-whisper": "#F1948A",
-
-  // ElevenLabs TTS — orange family (#F39C12)
+  // ElevenLabs — orange family (#F39C12). TTS + STT scribe all span light→dark orange.
   eleven_multilingual_v2: "#F5B041",
   eleven_flash_v2_5: "#F39C12",
-  eleven_turbo_v2_5: "#CA6F1E",
+  eleven_turbo_v2_5: "#E67E22",
+  scribe_v2_realtime: "#CA6F1E",
 
-  // ElevenLabs STT — orange family (#F39C12)
-  scribe_v2_realtime: "#935116",
-
-  // xAI TTS — pink family (#EC4899)
+  // xAI — pink family (#EC4899).
   "grok-tts": "#F472B6",
-
-  // xAI STT — pink family (#EC4899)
   "grok-stt": "#BE185D",
 
-  // Cartesia TTS — blue family (#3498DB)
+  // Cartesia — blue family (#3498DB).
   "sonic-3": "#85C1E9",
   "sonic-3.5": "#3498DB",
-
-  // Cartesia STT — blue family (#3498DB)
   "ink-2": "#1A5276",
 
-  // Rime TTS — green family (#27AE60)
+  // Rime — green family (#27AE60).
   arcana: "#82E0AA",
   coda: "#27AE60",
   mistv3: "#1A7A40",
 
-  // Hume TTS — violet family (#A855F7)
+  // Hume — violet family (#A855F7).
   "octave-2": "#C084FC",
   "octave-tts": "#7C3AED",
 
-  // Deepgram TTS — teal family (#16A085)
-  "aura-2-thalia-en": "#0A4F48",
+  // Deepgram — teal family (#16A085). TTS aura anchors the dark end; STT models
+  // span up to light teal. All shades are visibly teal (none near-black).
+  "aura-2-thalia-en": "#0C6654",
+  "nova-2": "#0E8A76",
+  "flux-general-en": "#16A085",
+  "flux-general-multi": "#1EC4A3",
+  "nova-3": "#45D4B5",
 
-  // Deepgram STT — teal family (#16A085)
-  "nova-3": "#52C5AE",
-  "nova-2": "#26AD94",
-  "flux-general-multi": "#16A085",
-  "flux-general-en": "#0D7065",
-
-  // AssemblyAI STT — amethyst family (#8E44AD)
+  // AssemblyAI — amethyst family (#8E44AD).
   "universal-streaming": "#8E44AD",
 
-  // Speechmatics STT — navy family (#21618C)
+  // Speechmatics — navy family (#21618C).
   enhanced: "#2E86C1",
   default: "#21618C",
   // Composite keys for models whose slug is shared across providers


### PR DESCRIPTION
## Summary
- Each provider's models now use shades of the same hue as their provider anchor color
- Makes it immediately obvious which models belong to the same provider on any chart
- Examples: all ElevenLabs models are orange shades, all Deepgram models are teal shades, all Cartesia models are blue shades

## Providers updated
| Provider | Color family | Notable fix |
|---|---|---|
| ElevenLabs | Orange | TTS + STT scribe all in orange range |
| OpenAI | Red | STT `gpt-realtime-whisper` was green, now light red |
| Cartesia | Blue | STT `ink-2` was indigo/purple, now dark blue |
| Deepgram | Teal | TTS was red, STT models were yellow/orange — all now teal |
| AssemblyAI | Amethyst | Was red, now matches provider purple |
| xAI | Pink | TTS and STT now light/dark shades of same pink |
| Rime | Green | Neon/teal mix replaced with clean green gradient |
| Hume | Violet | Consistent violet shades |
| Speechmatics | Navy | Light/dark navy shades |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Style / UI**
  * Refreshed the visual color palette for AI model identifiers with updated color assignments across multiple providers.
  * Improved model color display in both the mobile provider-expanded list and the model sidebar, including more consistent colored selection indicators.
  * Updated WER bar coloring to use model-specific colors and adjusted transparency for unselected bars.
  * Refreshed the timeline legend layout to use a multi-column presentation for better readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR refactors the model color palette so every provider's models use shades of the same hue, making provider affiliation immediately visible on any chart. It also ships three UI improvements: per-model color dots in the mobile sheet, model-colored checkboxes in the sidebar, and a column-flow legend layout.

- **`colors.ts`**: Each provider is anchored to a named color family (red for OpenAI, orange for ElevenLabs, teal for Deepgram, etc.) and all of its models are assigned lighter/darker shades within that family.
- **`useDashboardState.tsx` + `AccuracyBarSection.tsx`**: WER bar chart bars now carry their own model color, and non-selected bars fade to 25% opacity when a bar is clicked, replacing the previous static orange/light-orange binary.
- **`MobileModelSheet.tsx` / `ModelSidebar.tsx`**: Colored indicators added to the model lists so the chart legend and the filter UI stay visually in sync.

<h3>Confidence Score: 5/5</h3>

Pure color palette refactor with additive UI improvements; no logic paths, data transformations, or API contracts are affected.

Every changed file is limited to visual presentation: color constant updates, new colored indicators in the sidebar/mobile sheet, a legend layout tweak, and a switch from a static orange bar color to per-model colors with opacity dimming. None of the changes touch data fetching, state mutations, routing, or auth. The fillOpacity wiring is straightforward recharts SVG prop passthrough and is correctly gated on clickedWERBars.size > 0.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| web/lib/config/colors.ts | Color palette refactored to group model colors by provider family; each provider's models now use consistent hue shades. gradium:default remains unchanged. |
| web/hooks/useDashboardState.tsx | WER bar chart now uses per-model colors via getModelColor and dims non-selected bars to 25% opacity when a selection exists, replacing the static orange/light-orange pair. |
| web/components/dashboard/AccuracyBarSection.tsx | One-line change: passes the new fillOpacity property from werBarDataWithColors through to the recharts Cell component. |
| web/components/layout/MobileModelSheet.tsx | Adds a small colored dot (matching the model's chart color) next to each model name in the mobile provider-expanded list. |
| web/components/layout/ModelSidebar.tsx | Checkbox background now shows the model's color when checked (via inline style) and reverts to gray when unchecked; checkmark stroke changed from currentColor to white for legibility. |
| web/components/visualizations/TimelineChart.tsx | Legend layout switched from CSS grid (row-first) to CSS columns (column-first) so entries read top-to-bottom within each column; break-inside-avoid prevents items from splitting across columns. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["colors.ts\n(modelColors / providerColors)"] --> B["getModelColor(modelKey)\nlib/utils/colors.ts"]
    B --> C["TimelineChart\n(line series colors)"]
    B --> D["useDashboardState\nwerBarDataWithColors\n(fill + fillOpacity)"]
    B --> E["ModelSidebar\ncheckbox background color"]
    B --> F["MobileModelSheet\ncolored dot indicator"]
    D --> G["AccuracyBarSection\nCell fill + fillOpacity"]
```

<sub>Reviews (6): Last reviewed commit: ["Color WER bars by model color instead of..."](https://github.com/coval-ai/benchmarks/commit/54cc08e95f413d92d125ed6ea8161ab2d1ab2be0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37421981)</sub>

<!-- /greptile_comment -->