### PR TITLE
Default time window to 7 days

### DIFF
--- a/web/hooks/useTimeWindow.ts
+++ b/web/hooks/useTimeWindow.ts
@@ -13,7 +13,7 @@ import {
 import type { TimeWindow } from "@/lib/config/timeWindows";
 
 export function useTimeWindow(surface: PostHogSurface, mode?: PostHogMode) {
-  const [timeWindow, setTimeWindow] = useState<TimeWindow>("24h");
+  const [timeWindow, setTimeWindow] = useState<TimeWindow>("7d");
 
   const changeTimeWindow = useCallback(
     (next: TimeWindow) => {


### PR DESCRIPTION
## Summary
- Changes the initial time window from 24h to 7d on both TTS and STT dashboards

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted default time window from 24 hours to 7 days for improved data visibility and analysis context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the default time window in the shared `useTimeWindow` hook from `"24h"` to `"7d"`, affecting the TTS and STT dashboards that consume it.

- The new default `"7d"` is a valid member of the `TimeWindow` union (`"24h" | "7d" | "30d"`), so there are no type safety concerns.
- The change is a single-line update with no side effects on state management, PostHog event tracking, or the `changeTimeWindow` callback logic.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a one-line default value update to a valid, type-checked constant.

The only change is swapping the initial useState value from '24h' to '7d', a value that already exists in the TIME_WINDOWS const tuple and is fully covered by the TimeWindow type. No logic, event tracking, or API contract is altered.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| web/hooks/useTimeWindow.ts | Single-line default state change from "24h" to "7d"; both are valid TimeWindow literals — no issues found. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Default time window to 7d instead of 24h"](https://github.com/coval-ai/benchmarks/commit/c927dded6a323752a31846ce9308c853e224ea86) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37563378)</sub>

<!-- /greptile_comment -->