### PR TITLE
Make Gradium STT finalization wait event-driven

### DIFF
--- a/runner/src/coval_bench/providers/stt/gradium.py
+++ b/runner/src/coval_bench/providers/stt/gradium.py
@@ -15,14 +15,16 @@ Close: {"type":"end_of_stream"}
 Protocol notes:
 - "text" messages carry a word group for the CURRENT segment (no text in "end_text").
 - "end_text" signals the segment is finalised; the text comes from the preceding "text".
-- A flush must be sent after all audio and waited on before end_of_stream, otherwise
-  the model's lookahead buffer (delay_in_frames ≈ 10 × 80 ms) is discarded.
+- A flush must be sent after all audio; wait for the "flushed" ack before
+  end_of_stream, otherwise the model's lookahead buffer
+  (delay_in_frames ≈ 10 × 80 ms) is discarded.
 """
 
 from __future__ import annotations
 
 import asyncio
 import base64
+import contextlib
 import json
 import time
 from typing import Any
@@ -36,6 +38,7 @@ from coval_bench.providers.base import STTProvider, TranscriptionResult
 logger = structlog.get_logger(__name__)
 
 _WS_URL = "wss://api.gradium.ai/api/speech/asr"
+# Cap on waiting for the "flushed" ack before sending end_of_stream.
 _FLUSH_WAIT_S = 2.0
 
 
@@ -78,6 +81,7 @@ class GradiumSTTProvider(STTProvider):
         try:
             headers = {"x-api-key": self._api_key.get_secret_value()}
 
+            final_event = asyncio.Event()
             async with ws_client.connect(_WS_URL, additional_headers=headers) as ws:
                 await ws.send(
                     json.dumps(
@@ -91,9 +95,11 @@ class GradiumSTTProvider(STTProvider):
                 )
 
                 send_task = asyncio.create_task(
-                    self._send_audio(ws, audio_data, sample_rate, result, realtime_resolution)
+                    self._send_audio(
+                        ws, audio_data, sample_rate, result, realtime_resolution, final_event
+                    )
                 )
-                recv_task = asyncio.create_task(self._receive(ws, result))
+                recv_task = asyncio.create_task(self._receive(ws, result, final_event))
                 await asyncio.gather(send_task, recv_task, return_exceptions=True)
 
         except Exception as exc:
@@ -110,6 +116,7 @@ class GradiumSTTProvider(STTProvider):
         sample_rate: int,
         result: TranscriptionResult,
         realtime_resolution: float,
+        final_event: asyncio.Event,
     ) -> None:
         bytes_per_second = sample_rate * 2  # 16-bit mono
         chunk_size = int(bytes_per_second * realtime_resolution)
@@ -120,17 +127,19 @@ class GradiumSTTProvider(STTProvider):
                 b64 = base64.b64encode(chunk).decode("utf-8")
                 await ws.send(json.dumps({"type": "audio", "audio": b64}))
                 await asyncio.sleep(realtime_resolution)
-            # Flush forces the model's lookahead buffer to emit pending results.
-            # Wait long enough for the server to process remaining frames and
-            # send back the final text/end_text messages (~delay_in_frames × 80 ms).
+            # Flush drains the lookahead buffer; wait for the "flushed" ack so
+            # end_of_stream can't cut off pending results.
             await ws.send(json.dumps({"type": "flush", "flush_id": 1}))
-            await asyncio.sleep(_FLUSH_WAIT_S)
+            with contextlib.suppress(TimeoutError):
+                await asyncio.wait_for(final_event.wait(), timeout=_FLUSH_WAIT_S)
             await ws.send(json.dumps({"type": "end_of_stream"}))
         except Exception as exc:
             logger.exception("gradium send error", error=str(exc))
             raise
 
-    async def _receive(self, ws: Any, result: TranscriptionResult) -> None:
+    async def _receive(
+        self, ws: Any, result: TranscriptionResult, final_event: asyncio.Event
+    ) -> None:
         final_parts: list[str] = []
 
         try:
@@ -164,7 +173,11 @@ class GradiumSTTProvider(STTProvider):
                         result.audio_to_final_seconds = now - result.audio_start_time
                     continue
 
-                if msg_type in ("flushed", "ready", "end_text"):
+                if msg_type == "flushed":
+                    final_event.set()
+                    continue
+
+                if msg_type in ("ready", "end_text"):
                     continue
 
                 if msg_type == "end_of_stream":

--- a/runner/tests/providers/stt/test_gradium.py
+++ b/runner/tests/providers/stt/test_gradium.py
@@ -141,7 +141,7 @@ async def test_gradium_closes_on_flushed_ack_not_blind_sleep(
     assert result.error is None
     assert result.complete_transcript == "hello world"
     # Ack releases the wait well before the 30s cap (audio streams ~3s).
-    assert elapsed < 10.0
+    assert elapsed < 5.0
 
 
 # ---------------------------------------------------------------------------

--- a/runner/tests/providers/stt/test_gradium.py
+++ b/runner/tests/providers/stt/test_gradium.py
@@ -11,6 +11,7 @@ each ``text`` message carries an additive word group for the current segment
 
 from __future__ import annotations
 
+import time
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -105,6 +106,42 @@ async def test_gradium_commits_text_without_end_text(
     assert result.error is None
     assert result.complete_transcript == "hello world how are you"
     assert result.word_count == 5
+
+
+@pytest.mark.asyncio
+async def test_gradium_closes_on_flushed_ack_not_blind_sleep(
+    fake_api_key: SecretStr, audio_pcm_bytes: bytes, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The `flushed` ack releases the close wait before the timeout cap.
+
+    The cap is set high, so a prompt return proves the ack unblocked the wait.
+    """
+    monkeypatch.setattr("coval_bench.providers.stt.gradium._FLUSH_WAIT_S", 30.0)
+    events: list[Any] = [
+        {"type": "text", "text": "hello world", "start_s": 0.5, "stream_id": 0},
+        {"type": "flushed", "flush_id": 1},
+        {"type": "end_of_stream"},
+    ]
+    provider = GradiumSTTProvider(api_key=fake_api_key)
+
+    with patch(
+        "coval_bench.providers.stt.gradium.ws_client.connect",
+        return_value=_fake_connect(events),
+    ):
+        start = time.monotonic()
+        result = await provider.measure_ttft(
+            audio_data=audio_pcm_bytes,
+            channels=1,
+            sample_width=2,
+            sample_rate=16000,
+            realtime_resolution=0.5,
+        )
+        elapsed = time.monotonic() - start
+
+    assert result.error is None
+    assert result.complete_transcript == "hello world"
+    # Ack releases the wait well before the 30s cap (audio streams ~3s).
+    assert elapsed < 10.0
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Gradium's STT model was inadvertently calling a 2s sleep on a large portion of responses. This fixes that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed speech-to-text streaming protocol to prevent loss of final transcription results during audio completion
  * Improved system responsiveness by eliminating unnecessary timeout delays

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaces a fixed `asyncio.sleep(_FLUSH_WAIT_S)` after the flush message with an `asyncio.Event`-driven wait that unblocks as soon as the server sends the `"flushed"` ack, falling back to the 2-second cap only if the ack never arrives.

- **`gradium.py`**: `final_event` is created in `measure_ttft` and threaded into both `_send_audio` and `_receive`; `_receive` calls `final_event.set()` on the `\"flushed\"` message, and `_send_audio` replaces the blind sleep with `asyncio.wait_for(final_event.wait(), timeout=_FLUSH_WAIT_S)` wrapped in `contextlib.suppress(TimeoutError)`.
- **`test_gradium.py`**: New test patches the timeout cap to 30 s and asserts the provider returns in under 5 s, proving the ack—not the timer—drives the unblock.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a targeted, well-tested improvement to the flush wait mechanism with no behavioural regressions.

The refactor is small and self-contained: one new asyncio.Event, two updated call sites, and a clear fallback if the ack never arrives. The project pins Python >= 3.12, so TimeoutError is the canonical alias for asyncio.TimeoutError and contextlib.suppress(TimeoutError) works correctly. The new test directly exercises the event-driven path under a 30-second artificial cap and confirms the provider returns in the expected audio-streaming window, not at the cap.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| runner/src/coval_bench/providers/stt/gradium.py | Replaces blind asyncio.sleep(_FLUSH_WAIT_S) with event-driven asyncio.wait_for(final_event.wait(), ...) guarded by contextlib.suppress(TimeoutError); the flush ack sets the event and unblocks immediately, with the 2-second cap as a fallback. |
| runner/tests/providers/stt/test_gradium.py | Adds test_gradium_closes_on_flushed_ack_not_blind_sleep which patches _FLUSH_WAIT_S to 30 s and asserts elapsed < 5 s, proving the flushed ack releases the wait well before the cap. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Tighten Gradium finalization test bound ..."](https://github.com/coval-ai/benchmarks/commit/b3b15fd65f6cda738a00c99eeca1798da19ab537) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37680083)</sub>

<!-- /greptile_comment -->