### PR TITLE
Add Soniox TTS to public benchmarks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,6 +29,7 @@ GRADIUM_API_KEY=
 GRADIUM_TTS_API_KEY=
 XAI_API_KEY=
 SMALLEST_API_KEY=
+SONIOX_API_KEY=
 
 # --- Google STT (optional; requires the `google-stt` extra) ---
 # GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json

--- a/runner/src/coval_bench/config.py
+++ b/runner/src/coval_bench/config.py
@@ -68,6 +68,7 @@ class Settings(BaseSettings):
     gradium_tts_api_key: SecretStr | None = None
     xai_api_key: SecretStr | None = None
     smallest_api_key: SecretStr | None = None
+    soniox_api_key: SecretStr | None = None
 
     # Path to a Google service-account JSON file mounted as a Secret-as-volume.
     google_application_credentials: Path | None = None

--- a/runner/src/coval_bench/providers/tts/__init__.py
+++ b/runner/src/coval_bench/providers/tts/__init__.py
@@ -21,6 +21,7 @@ from coval_bench.providers.tts.elevenlabs import ElevenLabsTTSProvider
 from coval_bench.providers.tts.gradium import GradiumTTSProvider
 from coval_bench.providers.tts.openai import OpenAITTSProvider
 from coval_bench.providers.tts.rime import RimeTTSProvider
+from coval_bench.providers.tts.soniox import SonioxTTSProvider
 from coval_bench.providers.tts.xai import XaiTTSProvider
 
 try:
@@ -39,9 +40,16 @@ TTS_PROVIDERS: dict[str, type[TTSProvider]] = {
     "deepgram": DeepgramTTSProvider,
     "rime": RimeTTSProvider,
     "xai": XaiTTSProvider,
+    "soniox": SonioxTTSProvider,
 }
 
 if HumeTTSProvider is not None:
     TTS_PROVIDERS["hume"] = HumeTTSProvider
 
-__all__ = ["TTS_PROVIDERS", "HUME_AVAILABLE", "GradiumTTSProvider", "XaiTTSProvider"]
+__all__ = [
+    "TTS_PROVIDERS",
+    "HUME_AVAILABLE",
+    "GradiumTTSProvider",
+    "XaiTTSProvider",
+    "SonioxTTSProvider",
+]

--- a/runner/src/coval_bench/providers/tts/soniox.py
+++ b/runner/src/coval_bench/providers/tts/soniox.py
@@ -111,7 +111,10 @@ class SonioxTTSProvider(TTSProvider):
                     event: dict[str, Any] = json.loads(raw)
 
                     if event.get("error_code") or event.get("error_message"):
-                        raise RuntimeError(str(event.get("error_message", "Soniox TTS error")))
+                        message = event.get("error_message") or (
+                            f"Soniox TTS error (code {event.get('error_code')})"
+                        )
+                        raise RuntimeError(str(message))
 
                     audio_b64 = event.get("audio")
                     if audio_b64:

--- a/runner/src/coval_bench/providers/tts/soniox.py
+++ b/runner/src/coval_bench/providers/tts/soniox.py
@@ -1,0 +1,148 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Soniox real-time TTS streaming provider."""
+
+from __future__ import annotations
+
+import base64
+import json
+import time
+from typing import Any
+from uuid import uuid4
+
+import structlog
+import websockets.asyncio.client as ws_client
+
+from coval_bench.config import Settings
+from coval_bench.providers.base import TTSProvider, TTSResult
+from coval_bench.providers.tts._common import finalize_tts_result
+
+logger: structlog.BoundLogger = structlog.get_logger(__name__)
+
+_VALID_MODELS = ("tts-rt-v1",)
+_VALID_VOICES = (
+    "Maya",
+    "Daniel",
+    "Noah",
+    "Nina",
+    "Emma",
+    "Jack",
+    "Adrian",
+    "Claire",
+    "Grace",
+    "Owen",
+    "Mina",
+    "Kenji",
+    "Rafael",
+    "Mateo",
+    "Lucia",
+    "Sofia",
+    "Oliver",
+    "Arthur",
+    "Isla",
+    "Victoria",
+    "Cooper",
+    "Mason",
+    "Ruby",
+    "Elise",
+    "Arjun",
+    "Rohan",
+    "Priya",
+    "Meera",
+)
+_WS_URL = "wss://tts-rt.soniox.com/tts-websocket"
+_SAMPLE_RATE = 24000
+
+
+class SonioxTTSProvider(TTSProvider):
+    """Soniox TTS provider using WebSocket streaming (JSON frames, base64 audio)."""
+
+    def __init__(self, settings: Settings, model: str, voice: str) -> None:
+        if model not in _VALID_MODELS:
+            raise ValueError(f"Invalid Soniox TTS model {model!r}. Valid: {_VALID_MODELS}")
+        if voice not in _VALID_VOICES:
+            raise ValueError(f"Invalid Soniox TTS voice {voice!r}. Valid: {_VALID_VOICES}")
+        self._model = model
+        self._voice = voice
+
+        api_key_secret = settings.soniox_api_key
+        if api_key_secret is None:
+            raise ValueError("soniox_api_key is required in Settings")
+        self._api_key = api_key_secret.get_secret_value()
+
+    @property
+    def name(self) -> str:
+        return f"soniox-{self._model}"
+
+    @property
+    def model(self) -> str:
+        return self._model
+
+    async def synthesize(self, text: str) -> TTSResult:
+        audio_chunks: list[bytes] = []
+        start: float | None = None
+        first_chunk_at: float | None = None
+        stream_id = str(uuid4())
+
+        try:
+            async with ws_client.connect(_WS_URL) as ws:
+                start = time.monotonic()
+                # Soniox authenticates in-band: the api_key rides the opening config
+                # frame rather than an Authorization header.
+                await ws.send(
+                    json.dumps(
+                        {
+                            "api_key": self._api_key,
+                            "model": self._model,
+                            "language": "en",
+                            "voice": self._voice,
+                            "audio_format": "pcm_s16le",
+                            "sample_rate": _SAMPLE_RATE,
+                            "stream_id": stream_id,
+                        }
+                    )
+                )
+                await ws.send(json.dumps({"text": text, "text_end": True, "stream_id": stream_id}))
+
+                async for raw in ws:
+                    if isinstance(raw, bytes):
+                        continue
+                    event: dict[str, Any] = json.loads(raw)
+
+                    if event.get("error_code") or event.get("error_message"):
+                        raise RuntimeError(str(event.get("error_message", "Soniox TTS error")))
+
+                    audio_b64 = event.get("audio")
+                    if audio_b64:
+                        chunk = base64.b64decode(audio_b64)
+                        if chunk:
+                            if first_chunk_at is None:
+                                first_chunk_at = time.monotonic()
+                            audio_chunks.append(chunk)
+
+                    if event.get("terminated"):
+                        break
+
+        except Exception as exc:
+            logger.debug("soniox_tts_error", exc_info=True)
+            return finalize_tts_result(
+                provider="soniox",
+                model=self._model,
+                voice=self._voice,
+                pcm=b"",
+                sample_rate=_SAMPLE_RATE,
+                audio_synthesis_start=start,
+                first_audio_chunk_at=first_chunk_at,
+                error=str(exc),
+            )
+
+        return finalize_tts_result(
+            provider="soniox",
+            model=self._model,
+            voice=self._voice,
+            pcm=b"".join(audio_chunks),
+            sample_rate=_SAMPLE_RATE,
+            audio_synthesis_start=start,
+            first_audio_chunk_at=first_chunk_at,
+        )

--- a/runner/src/coval_bench/registries/models.py
+++ b/runner/src/coval_bench/registries/models.py
@@ -156,7 +156,6 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         status=_ACTIVE,
     ),
     RegisteredModel(benchmark=_TTS, provider="xai", model="grok-tts", voice="eve", status=_ACTIVE),
-    # Smallest AI — Lightning v3.1 Pro, kaitlyn voice (American English).
     RegisteredModel(
         benchmark=_TTS,
         provider="smallest",
@@ -165,7 +164,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         status=_ACTIVE,
     ),
     RegisteredModel(
-        benchmark=_TTS, provider="soniox", model="tts-rt-v1", voice="Adrian", status=_ACTIVE
+        benchmark=_TTS, provider="soniox", model="tts-rt-v1", voice="Adrian", status=_RETIRED
     ),
     RegisteredModel(
         benchmark=_TTS, provider="openai", model="gpt-realtime-2025-08-28", status=_RETIRED

--- a/runner/src/coval_bench/registries/models.py
+++ b/runner/src/coval_bench/registries/models.py
@@ -157,6 +157,9 @@ MODEL_REGISTRY: list[RegisteredModel] = [
     ),
     RegisteredModel(benchmark=_TTS, provider="xai", model="grok-tts", voice="eve", status=_ACTIVE),
     RegisteredModel(
+        benchmark=_TTS, provider="soniox", model="tts-rt-v1", voice="Adrian", status=_ACTIVE
+    ),
+    RegisteredModel(
         benchmark=_TTS, provider="openai", model="gpt-realtime-2025-08-28", status=_RETIRED
     ),
     RegisteredModel(benchmark=_TTS, provider="cartesia", model="sonic", status=_RETIRED),

--- a/runner/tests/providers/tts/conftest.py
+++ b/runner/tests/providers/tts/conftest.py
@@ -58,6 +58,7 @@ def fake_settings(tmp_path: Path) -> Settings:
         rime_api_key="test-rime-key",  # type: ignore[arg-type]
         gradium_tts_api_key="test-gradium-tts-key",  # type: ignore[arg-type]
         xai_api_key="test-xai-key",
+        soniox_api_key="test-soniox-key",  # type: ignore[arg-type]
     )
 
 

--- a/runner/tests/providers/tts/test_soniox.py
+++ b/runner/tests/providers/tts/test_soniox.py
@@ -127,6 +127,23 @@ async def test_soniox_tts_error_event(fake_settings: Settings) -> None:
 
 
 @pytest.mark.asyncio
+async def test_soniox_tts_error_code_without_message(fake_settings: Settings) -> None:
+    ws = FakeWebSocket([json.dumps({"stream_id": "probe", "error_code": 503})])
+    provider = SonioxTTSProvider(fake_settings, model="tts-rt-v1", voice="Adrian")
+
+    with patch(
+        "coval_bench.providers.tts.soniox.ws_client.connect",
+        return_value=ws,
+    ):
+        result = await provider.synthesize("Hello")
+
+    assert result.error is not None
+    assert "503" in result.error
+    assert result.audio_path is None
+    assert result.ttfa_ms is None
+
+
+@pytest.mark.asyncio
 async def test_soniox_tts_error_after_partial_audio(fake_settings: Settings) -> None:
     chunk = make_pcm_bytes(240)
     events = [

--- a/runner/tests/providers/tts/test_soniox.py
+++ b/runner/tests/providers/tts/test_soniox.py
@@ -1,0 +1,223 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the Soniox WebSocket TTS provider."""
+
+from __future__ import annotations
+
+import base64
+import json
+from unittest.mock import patch
+
+import pytest
+
+from coval_bench.config import Settings
+from coval_bench.providers.tts.soniox import _WS_URL, SonioxTTSProvider
+
+from .conftest import FakeWebSocket, make_pcm_bytes
+
+
+def _audio_events(pcm_chunks: list[bytes]) -> list[str]:
+    events: list[str] = []
+    for chunk in pcm_chunks:
+        events.append(json.dumps({"audio": base64.b64encode(chunk).decode(), "stream_id": "probe"}))
+    events.append(json.dumps({"terminated": True, "stream_id": "probe"}))
+    return events
+
+
+@pytest.mark.asyncio
+async def test_soniox_tts_happy_path(fake_settings: Settings) -> None:
+    ws = FakeWebSocket(_audio_events([make_pcm_bytes(240)]))
+    provider = SonioxTTSProvider(fake_settings, model="tts-rt-v1", voice="Adrian")
+
+    with patch(
+        "coval_bench.providers.tts.soniox.ws_client.connect",
+        return_value=ws,
+    ):
+        result = await provider.synthesize("Hello from Soniox")
+
+    assert result.error is None, f"Unexpected error: {result.error}"
+    assert result.ttfa_ms is not None
+    assert 0 < result.ttfa_ms < 60_000
+    assert result.audio_path is not None
+    assert result.audio_path.exists()
+    assert result.audio_path.read_bytes()[:4] == b"RIFF"
+    assert result.provider == "soniox"
+    assert result.model == "tts-rt-v1"
+    assert result.voice == "Adrian"
+    result.audio_path.unlink()
+
+
+@pytest.mark.asyncio
+async def test_soniox_tts_url_and_in_band_auth(fake_settings: Settings) -> None:
+    ws = FakeWebSocket(_audio_events([make_pcm_bytes(240)]))
+    captured: dict[str, object] = {}
+
+    def connect_side_effect(url: str, **kwargs: object) -> FakeWebSocket:
+        captured["url"] = url
+        captured["kwargs"] = kwargs
+        return ws
+
+    provider = SonioxTTSProvider(fake_settings, model="tts-rt-v1", voice="Adrian")
+
+    with patch(
+        "coval_bench.providers.tts.soniox.ws_client.connect",
+        side_effect=connect_side_effect,
+    ):
+        result = await provider.synthesize("Hello")
+
+    assert result.error is None
+    assert captured["url"] == _WS_URL
+    # Soniox authenticates in-band, not via an Authorization header.
+    assert "additional_headers" not in captured["kwargs"]  # type: ignore[operator]
+
+    config = json.loads(ws.sent[0])
+    assert config["api_key"] == "test-soniox-key"
+    assert config["model"] == "tts-rt-v1"
+    assert config["voice"] == "Adrian"
+    assert config["audio_format"] == "pcm_s16le"
+    assert config["sample_rate"] == 24000
+
+
+@pytest.mark.asyncio
+async def test_soniox_tts_sends_config_then_text(fake_settings: Settings) -> None:
+    ws = FakeWebSocket(_audio_events([make_pcm_bytes(240)]))
+    provider = SonioxTTSProvider(fake_settings, model="tts-rt-v1", voice="Adrian")
+
+    with patch(
+        "coval_bench.providers.tts.soniox.ws_client.connect",
+        return_value=ws,
+    ):
+        await provider.synthesize("Hello world")
+
+    sent_json = [json.loads(m) for m in ws.sent if isinstance(m, str)]
+    assert "api_key" in sent_json[0]
+    assert sent_json[1]["text"] == "Hello world"
+    assert sent_json[1]["text_end"] is True
+    # All frames in a synthesis share one stream_id.
+    assert sent_json[0]["stream_id"] == sent_json[1]["stream_id"]
+
+
+@pytest.mark.asyncio
+async def test_soniox_tts_error_event(fake_settings: Settings) -> None:
+    ws = FakeWebSocket(
+        [
+            json.dumps(
+                {
+                    "stream_id": "probe",
+                    "error_code": 400,
+                    "error_type": "invalid_request",
+                    "error_message": "invalid api key",
+                }
+            )
+        ]
+    )
+    provider = SonioxTTSProvider(fake_settings, model="tts-rt-v1", voice="Adrian")
+
+    with patch(
+        "coval_bench.providers.tts.soniox.ws_client.connect",
+        return_value=ws,
+    ):
+        result = await provider.synthesize("Hello")
+
+    assert result.error is not None
+    assert "invalid api key" in result.error
+    assert result.audio_path is None
+    assert result.ttfa_ms is None
+
+
+@pytest.mark.asyncio
+async def test_soniox_tts_error_after_partial_audio(fake_settings: Settings) -> None:
+    chunk = make_pcm_bytes(240)
+    events = [
+        json.dumps({"audio": base64.b64encode(chunk).decode(), "stream_id": "probe"}),
+        json.dumps({"error_code": 500, "error_message": "stream interrupted"}),
+    ]
+    ws = FakeWebSocket(events)
+    provider = SonioxTTSProvider(fake_settings, model="tts-rt-v1", voice="Adrian")
+
+    with patch(
+        "coval_bench.providers.tts.soniox.ws_client.connect",
+        return_value=ws,
+    ):
+        result = await provider.synthesize("Hello")
+
+    assert result.error is not None
+    assert "stream interrupted" in result.error
+    assert result.audio_path is None
+    assert result.ttfa_ms is not None
+
+
+@pytest.mark.asyncio
+async def test_soniox_tts_ttfa_set_on_first_chunk_only(fake_settings: Settings) -> None:
+    chunks = [make_pcm_bytes(240), make_pcm_bytes(240), make_pcm_bytes(240)]
+    ws = FakeWebSocket(_audio_events(chunks))
+    provider = SonioxTTSProvider(fake_settings, model="tts-rt-v1", voice="Adrian")
+
+    times = iter([0.0, 0.1, 1.0, 2.0])
+
+    with (
+        patch(
+            "coval_bench.providers.tts.soniox.time.monotonic",
+            side_effect=lambda: next(times, 10.0),
+        ),
+        patch(
+            "coval_bench.providers.tts.soniox.ws_client.connect",
+            return_value=ws,
+        ),
+    ):
+        result = await provider.synthesize("Hello")
+
+    assert result.error is None
+    assert result.ttfa_ms == pytest.approx(100.0)
+    assert result.audio_path is not None
+    result.audio_path.unlink()
+
+
+@pytest.mark.asyncio
+async def test_soniox_tts_skips_empty_audio(fake_settings: Settings) -> None:
+    events = [
+        json.dumps({"audio": "", "stream_id": "probe"}),
+        json.dumps({"terminated": True, "stream_id": "probe"}),
+    ]
+    ws = FakeWebSocket(events)
+    provider = SonioxTTSProvider(fake_settings, model="tts-rt-v1", voice="Adrian")
+
+    with patch(
+        "coval_bench.providers.tts.soniox.ws_client.connect",
+        return_value=ws,
+    ):
+        result = await provider.synthesize("Hello")
+
+    assert result.error is None
+    assert result.audio_path is None
+    assert result.ttfa_ms is None
+
+
+def test_soniox_tts_invalid_model_raises(fake_settings: Settings) -> None:
+    with pytest.raises(ValueError, match="Invalid Soniox TTS model"):
+        SonioxTTSProvider(fake_settings, model="not-a-model", voice="Adrian")
+
+
+def test_soniox_tts_invalid_voice_raises(fake_settings: Settings) -> None:
+    with pytest.raises(ValueError, match="Invalid Soniox TTS voice"):
+        SonioxTTSProvider(fake_settings, model="tts-rt-v1", voice="not-a-voice")
+
+
+def test_soniox_tts_missing_api_key_raises() -> None:
+    settings = Settings(
+        database_url="postgresql://runner:password@localhost:5432/benchmarks",
+        dataset_bucket="test-bucket",
+        dataset_id="stt-v1",
+        runner_sha="test",
+        log_level="DEBUG",
+        soniox_api_key=None,
+    )
+    with pytest.raises(ValueError, match="soniox_api_key is required"):
+        SonioxTTSProvider(settings, model="tts-rt-v1", voice="Adrian")
+
+
+def test_soniox_tts_provider_name(fake_settings: Settings) -> None:
+    provider = SonioxTTSProvider(fake_settings, model="tts-rt-v1", voice="Adrian")
+    assert provider.name == "soniox-tts-rt-v1"
+    assert provider.model == "tts-rt-v1"

--- a/web/lib/config/colors.ts
+++ b/web/lib/config/colors.ts
@@ -44,6 +44,11 @@ export const modelColors: Record<string, string> = {
   // Speechmatics — navy family (#21618C).
   enhanced: "#2E86C1",
   default: "#21618C",
+
+  // Soniox — gold family. The chart's only gold; sits yellower than the
+  // ElevenLabs oranges and dark enough to read on the cream background.
+  "tts-rt-v1": "#C9A227",
+
   // Composite keys for models whose slug is shared across providers
   "speechmatics:default": "#21618C",
   "gradium:default": "#1ABC9C"
@@ -59,5 +64,6 @@ export const providerColors: Record<string, string> = {
   Rime: "#27AE60",
   Gradium: "#1ABC9C",
   Hume: "#A855F7",
-  xAI: "#EC4899"
+  xAI: "#EC4899",
+  Soniox: "#C9A227"
 };


### PR DESCRIPTION
Add a new WebSocket TTS provider for Soniox's real-time model (tts-rt-v1).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Soniox as a real-time, streaming text-to-speech provider.
  * Added optional `SONIOX_API_KEY` configuration support.

* **Model Availability**
  * Registered the `tts-rt-v1` model with the `Adrian` voice (marked as retired/disabled).

* **UI**
  * Updated model/provider color mappings to include Soniox (`tts-rt-v1`).

* **Tests**
  * Added end-to-end async coverage for Soniox WebSocket TTS, including happy-path output, message sequencing, first-audio timing, metadata, and multiple error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds Soniox as a new real-time WebSocket TTS provider (`tts-rt-v1`) using in-band API key authentication with JSON frames and base64-encoded PCM audio. The implementation, tests, config wiring, and color mappings are all well-structured and consistent with existing peer providers.

- **`soniox.py`**: New `SonioxTTSProvider` follows the established WebSocket streaming pattern (connect → send config frame → send text frame → collect audio chunks → `finalize_tts_result`), with correct TTFA timing and error handling.
- **`test_soniox.py`**: Thorough offline coverage via `FakeWebSocket` — happy path, sequencing, TTFA isolation, error events (with and without message), partial audio + error, empty audio, and constructor validation.
- **`models.py`**: The Soniox entry is registered with `status=_RETIRED`, which means the orchestrator will skip it and the frontend will hide it — at odds with the PR's stated goal of adding it to public benchmarks.

<h3>Confidence Score: 4/5</h3>

Safe to merge with one fix: the Soniox model registry entry must not be RETIRED if the provider is intended to run in benchmarks.

The provider implementation and tests are solid. The only substantive problem is in models.py — the new Soniox entry is registered as RETIRED, so the orchestrator will never schedule it and the site will never display it. Everything else (connection logic, timing, error handling, config, color mappings) is correct and consistent with existing providers.

runner/src/coval_bench/registries/models.py — the Soniox model status needs to be reconsidered before this PR achieves its stated goal.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| runner/src/coval_bench/registries/models.py | Soniox added as status=RETIRED — the orchestrator will never run it and the frontend will not show it, which contradicts the PR goal. |
| runner/src/coval_bench/providers/tts/soniox.py | New WebSocket TTS provider; protocol, timing, and error handling are correct; log level is debug (vs warning in peer providers) per previous thread note. |
| runner/tests/providers/tts/test_soniox.py | Comprehensive offline tests covering happy path, sequencing, TTFA timing, error events, empty audio, and invalid construction — all using FakeWebSocket. |
| runner/tests/providers/tts/conftest.py | Adds soniox_api_key to fake_settings fixture; no issues. |
| runner/src/coval_bench/providers/tts/__init__.py | Registers SonioxTTSProvider in TTS_PROVIDERS and __all__; straightforward. |
| runner/src/coval_bench/config.py | Adds optional soniox_api_key SecretStr field; consistent with peer providers. |
| web/lib/config/colors.ts | Adds gold color mapping for tts-rt-v1 model and Soniox provider; consistent with existing pattern. |
| .env.example | Adds SONIOX_API_KEY placeholder; no issues. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant O as Orchestrator
    participant P as SonioxTTSProvider
    participant WS as Soniox WebSocket

    O->>P: synthesize(text)
    P->>WS: connect (wss://tts-rt.soniox.com/tts-websocket)
    note right of P: start = time.monotonic()
    P->>WS: send config frame with api_key
    P->>WS: send text frame
    loop Audio frames
        WS-->>P: JSON with base64 PCM
        note right of P: first_chunk_at set once
        P->>P: decode and append chunk
    end
    WS-->>P: terminated event
    P->>P: finalize_tts_result
    P-->>O: TTSResult
```

<sub>Reviews (4): Last reviewed commit: ["Hide Soniox TTS until partnership lands"](https://github.com/coval-ai/benchmarks/commit/2da105c8a48ded62404cf9c97d1aaa66909ed19d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37698197)</sub>

<!-- /greptile_comment -->