### PR TITLE
Handle empty xAI transcripts and exclude Grok from TTFT

### DIFF
--- a/runner/src/coval_bench/providers/stt/xai.py
+++ b/runner/src/coval_bench/providers/stt/xai.py
@@ -200,8 +200,8 @@ class XaiSTTProvider(STTProvider):
                         set_first_token(result, done_transcript, now=now)
                         add_partial_transcript(result, done_transcript)
                         final_segments.append(done_transcript)
-                    if result.audio_start_time is not None:
-                        last_final_time = now
+                        if result.audio_start_time is not None:
+                            last_final_time = now
                     break
 
                 if event_type == "error":
@@ -219,11 +219,19 @@ class XaiSTTProvider(STTProvider):
                 result.error = "xAI stream ended before transcript.done"
             return
 
-        if last_final_time is not None and result.audio_start_time is not None:
-            result.audio_to_final_seconds = last_final_time - result.audio_start_time
-
         finalize_transcript(
             result,
             final_segments=final_segments,
             partial_fallback="longest",
         )
+
+        # An empty transcript.done that closed no speech_final segment means the
+        # session produced nothing (degraded/dead session) — fail it so the row is
+        # retryable, instead of stamping a spurious final from the empty terminal.
+        if result.complete_transcript is None:
+            if result.error is None:
+                result.error = "xAI returned an empty transcript"
+            return
+
+        if last_final_time is not None and result.audio_start_time is not None:
+            result.audio_to_final_seconds = last_final_time - result.audio_start_time

--- a/runner/src/coval_bench/registries/models.py
+++ b/runner/src/coval_bench/registries/models.py
@@ -67,7 +67,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
     RegisteredModel(benchmark=_STT, provider="speechmatics", model="default", status=_ACTIVE),
     RegisteredModel(benchmark=_STT, provider="speechmatics", model="enhanced", status=_ACTIVE),
     RegisteredModel(benchmark=_STT, provider="gradium", model="default", status=_ACTIVE),
-    RegisteredModel(benchmark=_STT, provider="xai", model="grok-stt", status=_RETIRED),
+    RegisteredModel(benchmark=_STT, provider="xai", model="grok-stt", status=_ACTIVE),
     RegisteredModel(benchmark=_STT, provider="smallest", model="pulse", status=_ACTIVE),
     RegisteredModel(benchmark=_STT, provider="cartesia", model="ink-2", status=_ACTIVE),
     RegisteredModel(benchmark=_STT, provider="google", model="short", status=_RETIRED),

--- a/runner/src/coval_bench/runner/orchestrator.py
+++ b/runner/src/coval_bench/runner/orchestrator.py
@@ -274,25 +274,29 @@ async def _run_stt_item(
             transcription_result.complete_transcript if transcription_result else None
         )
 
-        # 1. TTFT
+        # 1. TTFT — time-to-first-partial from first audio. For xAI Grok this reflects
+        # its min-audio gate, not engine speed, so it misrepresents the provider; TTFS
+        # (re-anchored at end-of-speech) is the fair metric. Omit TTFT for xAI; the rest run.
         ttft_status, ttft_error = _metric_outcome(
             ttft_seconds, item_error, Metric.TTFT, ResultStatus
         )
-        results.append(
-            Result(
-                run_id=run_id,
-                provider=entry.provider,
-                model=entry.model,
-                benchmark=Benchmark.STT,
-                metric_type=Metric.TTFT,
-                metric_value=ttft_seconds,
-                metric_units=METRIC_SPECS[Metric.TTFT].units,
-                audio_filename=audio_path.name,
-                transcript=complete_transcript,
-                status=ttft_status,
-                error=ttft_error,
+        ttft_excluded = entry.provider == "xai"
+        if not ttft_excluded:
+            results.append(
+                Result(
+                    run_id=run_id,
+                    provider=entry.provider,
+                    model=entry.model,
+                    benchmark=Benchmark.STT,
+                    metric_type=Metric.TTFT,
+                    metric_value=ttft_seconds,
+                    metric_units=METRIC_SPECS[Metric.TTFT].units,
+                    audio_filename=audio_path.name,
+                    transcript=complete_transcript,
+                    status=ttft_status,
+                    error=ttft_error,
+                )
             )
-        )
 
         # 2. AudioToFinal
         atf_status, atf_error = _metric_outcome(

--- a/runner/tests/api/test_providers.py
+++ b/runner/tests/api/test_providers.py
@@ -54,10 +54,10 @@ async def test_disabled_flag_exposed(client: AsyncClient) -> None:
     nova_3 = next(m for m in deepgram_entry["models"] if m["model"] == "nova-3")
     assert nova_3["disabled"] is False
 
-    # xai grok-stt is disabled in the matrix
+    # xai grok-stt is an active model — must be disabled=False
     xai_entry = next(e for e in data["stt"] if e["provider"] == "xai")
     grok_stt = next(m for m in xai_entry["models"] if m["model"] == "grok-stt")
-    assert grok_stt["disabled"] is True
+    assert grok_stt["disabled"] is False
 
 
 async def test_response_shape_breaking_change(client: AsyncClient) -> None:

--- a/runner/tests/providers/stt/fixtures/xai/events-empty-session.json
+++ b/runner/tests/providers/stt/fixtures/xai/events-empty-session.json
@@ -1,0 +1,4 @@
+[
+  {"type": "transcript.created", "id": "xai-session-empty"},
+  {"type": "transcript.done", "text": "", "duration": 3.0}
+]

--- a/runner/tests/providers/stt/test_xai.py
+++ b/runner/tests/providers/stt/test_xai.py
@@ -150,6 +150,35 @@ async def test_xai_single_speech_final_empty_done(
 
 
 @pytest.mark.asyncio
+async def test_xai_empty_session_errors(fake_api_key: SecretStr, audio_pcm_bytes: bytes) -> None:
+    """A session with no partials and an empty transcript.done is an error.
+
+    Models a degraded/dead session (handshake ok, ASR backend emits nothing). It
+    must fail — not stamp a spurious audio_to_final from the empty terminal event.
+    """
+    events = load_fixture_events("xai", "events-empty-session")
+    provider = XaiSTTProvider(api_key=fake_api_key, model="grok-stt")
+
+    with patch(
+        "coval_bench.providers.stt.xai.ws_client.connect",
+        return_value=_fake_connect(events),
+    ):
+        result = await provider.measure_ttft(
+            audio_data=audio_pcm_bytes,
+            channels=1,
+            sample_width=2,
+            sample_rate=16000,
+            realtime_resolution=0.5,
+        )
+
+    assert result.error is not None
+    assert "empty transcript" in result.error
+    assert result.complete_transcript is None
+    assert result.ttft_seconds is None
+    assert result.audio_to_final_seconds is None
+
+
+@pytest.mark.asyncio
 async def test_xai_missing_terminal_errors(fake_api_key: SecretStr, audio_pcm_bytes: bytes) -> None:
     """Stream ends on a chunk is_final with no transcript.done: error, no final metrics."""
     events: list[Any] = [

--- a/runner/tests/unit/test_orchestrator.py
+++ b/runner/tests/unit/test_orchestrator.py
@@ -483,6 +483,42 @@ async def test_flux_excluded_from_ttfs(audio_file: Path, settings: Settings) -> 
     assert metric_types == {"TTFT", "AudioToFinal", "RTF", "WER"}
 
 
+@pytest.mark.asyncio
+async def test_xai_excluded_from_ttft(audio_file: Path, settings: Settings) -> None:
+    """xAI Grok's TTFT is a fixed min-audio-gate artifact, not engine speed → no TTFT row.
+
+    The fair latency metric (TTFS) and the other metrics still run.
+    """
+    provider = MagicMock()
+    provider.measure_ttft = AsyncMock(return_value=_good_transcription())
+    stt_providers = {"xai": MagicMock(return_value=provider)}
+    matrix = [
+        *_paused_registry(Benchmark.STT),
+        _stt_entry("xai", "grok-stt"),
+    ]
+
+    run = _make_run()
+    writer = _make_stub_writer(run)
+
+    async with _orchestrator_env(
+        audio_path=audio_file,
+        stt_items=[_make_dataset_item(audio_file)],
+        stt_providers=stt_providers,
+        run=run,
+        writer=writer,
+    ) as _:
+        await run_benchmarks(
+            settings=settings,
+            benchmark_kind="stt",
+            smoke=True,
+            matrix_overrides=matrix,
+        )
+
+    metric_types = {r.metric_type for r in _recorded_rows(writer)}
+    assert "TTFT" not in metric_types
+    assert metric_types == {"AudioToFinal", "RTF", "TTFS", "WER"}
+
+
 # ---------------------------------------------------------------------------
 # 4. test_retry_succeeds_on_third_attempt
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
An empty `transcript.done` no longer stamps a finalization time: the session is failed (and so retryable) instead of recording a spurious ~5s TTFS/AudioToFinal success.

Grok's TTFT is a fixed min-audio floor (measured ~1.1s, stdev 0.05s, uncorrelated with clip length), not engine speed, so it is omitted the way Flux is excluded from TTFS. Grok ranks on TTFS and WER.

Tests: `test_xai_empty_session_errors` (+ fixture) and `test_xai_excluded_from_ttft`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * xAI STT provider now properly detects empty transcript sessions and returns an error message instead of proceeding with invalid metrics.
  * xAI STT provider excluded from Time-To-First-Token (TTFT) metric reporting.

* **Tests**
  * Added test coverage for empty transcript session handling.
  * Added validation for xAI TTFT exclusion from metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two related issues with the xAI (`grok-stt`) provider: an empty `transcript.done` no longer stamps a spurious `audio_to_final_seconds`, and TTFT is excluded from the metrics table because Grok's min-audio gate produces a measurement that is an artifact of buffering, not engine speed. The model registry is also updated from `_RETIRED` to `_ACTIVE`.

- **xai.py**: The `last_final_time` assignment is moved inside the `if done_transcript:` block so it only updates on non-empty terminal events; after `finalize_transcript`, a new early-return guard checks `complete_transcript is None` and sets an error instead of recording `audio_to_final_seconds` for a dead session.
- **orchestrator.py**: A `ttft_excluded = entry.provider == "xai"` guard skips appending the TTFT `Result` row, mirroring the existing Flux/TTFS exclusion pattern.
- **Tests**: `test_xai_empty_session_errors` (with fixture) and `test_xai_excluded_from_ttft` provide direct coverage of both new behaviors.

<h3>Confidence Score: 5/5</h3>

Safe to merge — both changes are narrowly scoped, well-tested, and do not alter logic for any provider other than xAI.

The empty-session guard is a straightforward early-return after finalize_transcript, and the TTFT exclusion mirrors the established Flux/TTFS pattern. New tests cover both paths directly, and the registry promotion is consistent with the companion test update in test_providers.py.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| runner/src/coval_bench/providers/stt/xai.py | Indentation fix moves last_final_time stamp inside the non-empty done-text branch; new guard after finalize_transcript returns early with an error when complete_transcript is None, preventing spurious audio_to_final on empty sessions. |
| runner/src/coval_bench/runner/orchestrator.py | Adds ttft_excluded = entry.provider == 'xai' guard to skip appending the TTFT Result row for xAI, consistent with the Flux/TTFS exclusion pattern. |
| runner/src/coval_bench/registries/models.py | grok-stt status promoted from _RETIRED to _ACTIVE; the companion test in test_providers.py is updated to assert disabled=False. |
| runner/tests/providers/stt/test_xai.py | New test_xai_empty_session_errors verifies error is set and no timing metrics are recorded when the session produces no speech. |
| runner/tests/unit/test_orchestrator.py | New test_xai_excluded_from_ttft confirms TTFT row is absent while AudioToFinal, RTF, TTFS, and WER are still emitted for the xAI provider. |
| runner/tests/providers/stt/fixtures/xai/events-empty-session.json | New fixture with transcript.created + transcript.done with empty text, sufficient to exercise the dead-session error path. |
| runner/tests/api/test_providers.py | Assertion updated to expect disabled=False for grok-stt following its _RETIRED → _ACTIVE promotion. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[transcript.done received] --> B{done_transcript non-empty?}
    B -- Yes --> C[set_first_token / add_partial / append to final_segments]
    C --> D[last_final_time = now]
    D --> E[break]
    B -- No --> E

    E --> F[finalize_transcript]
    F --> G{complete_transcript is None?}
    G -- Yes --> H[result.error = 'xAI returned an empty transcript']
    H --> I[return — no timing metrics stamped]
    G -- No --> J{last_final_time AND audio_start_time set?}
    J -- Yes --> K[audio_to_final_seconds = last_final_time - audio_start_time]
    J -- No --> L[audio_to_final_seconds stays None]

    subgraph Orchestrator
        M[entry.provider == 'xai'?] -- Yes --> N[skip TTFT Result row]
        M -- No --> O[append TTFT Result row]
    end
```

<sub>Reviews (3): Last reviewed commit: ["Enable Grok STT in the model registry"](https://github.com/coval-ai/benchmarks/commit/2a4fa7f130466000a8796fc0e5c9b093c5deb7f8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37728444)</sub>

<!-- /greptile_comment -->