### PR TITLE
Add Voice Arena database schema

### DIFF
--- a/runner/src/coval_bench/db/migrations/versions/20260615_0007_arena_init_schema.py
+++ b/runner/src/coval_bench/db/migrations/versions/20260615_0007_arena_init_schema.py
@@ -21,8 +21,11 @@ Three tables in the ``arena`` schema, alongside ``benchmarks_v2`` in the same DB
                previously computed rating.
 - ``leaderboard_snapshots``  persisted computed ratings: one row per model per computation run
                (a board = all rows sharing ``computed_at`` + ``metric_name`` +
-               ``methodology_version`` + ``domain``). This is a cache/history of derived data,
-               refreshed from votes — never an input to the rating math.
+               ``methodology_version`` + ``domain``), enforced by a UNIQUE over those four plus
+               ``provider`` + ``model``. ``domain`` is NOT NULL with an ``'all'`` sentinel for the
+               global board, so the UNIQUE dedups global rows too (a nullable ``domain`` would not,
+               since NULLs compare unequal). This is a cache/history of derived data, refreshed
+               from votes — never an input to the rating math.
 
 Notes
 -----
@@ -59,7 +62,8 @@ def upgrade() -> None:
             prompt_text TEXT NOT NULL,
             audio_a_url TEXT NOT NULL,
             audio_b_url TEXT NOT NULL,
-            created_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+            created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+            CHECK (NOT (provider_a = provider_b AND model_a = model_b))
         )
         """
     )
@@ -88,27 +92,23 @@ def upgrade() -> None:
             computed_at         TIMESTAMPTZ NOT NULL DEFAULT now(),
             metric_name         TEXT NOT NULL,
             methodology_version TEXT NOT NULL,
-            domain              TEXT,
+            domain              TEXT NOT NULL DEFAULT 'all',
             provider            TEXT NOT NULL,
             model               TEXT NOT NULL,
             rating_elo          NUMERIC NOT NULL,
             rating_bt           NUMERIC NOT NULL,
             ci_low              NUMERIC,
             ci_high             NUMERIC,
-            ci_half_width       NUMERIC,
-            votes_total         INTEGER NOT NULL,
-            wins                NUMERIC NOT NULL,
-            losses              NUMERIC NOT NULL,
-            ties                NUMERIC NOT NULL,
+            ci_half_width       NUMERIC CHECK (ci_half_width >= 0),
+            votes_total         INTEGER NOT NULL CHECK (votes_total >= 0),
+            wins                NUMERIC NOT NULL CHECK (wins >= 0),
+            losses              NUMERIC NOT NULL CHECK (losses >= 0),
+            ties                NUMERIC NOT NULL CHECK (ties >= 0),
             status              TEXT NOT NULL
-                                CHECK (status IN ('preliminary','usable','established'))
+                                CHECK (status IN ('preliminary','usable','established')),
+            UNIQUE (computed_at, metric_name, methodology_version, domain, provider, model)
         )
         """
-    )
-    op.execute(
-        "CREATE INDEX leaderboard_snapshots_lookup_idx "
-        "ON arena.leaderboard_snapshots "
-        "(computed_at, metric_name, methodology_version, domain)"
     )
 
 

--- a/runner/src/coval_bench/db/migrations/versions/20260615_0007_arena_init_schema.py
+++ b/runner/src/coval_bench/db/migrations/versions/20260615_0007_arena_init_schema.py
@@ -15,7 +15,8 @@ Three tables in the ``arena`` schema, alongside ``benchmarks_v2`` in the same DB
 - ``votes``    raw human judgments (A_WIN/B_WIN/TIE). ``voter_type`` separates internal
                ``labeler`` votes from ``external`` (public) votes; ``UNIQUE (battle_id,
                voter_type, voter_id)`` keeps one current vote per identity (re-label = UPDATE
-               that row, bumping ``updated_at`` so windowed refits see the corrected time).
+               that row; a ``BEFORE UPDATE`` trigger bumps ``updated_at`` so windowed refits
+               see the corrected time even if the writer omits the column).
                Raw votes are the source of truth — Bradley-Terry / Davidson are refit
                from these at any time, for any window; nothing here is ever an input from a
                previously computed rating.
@@ -84,6 +85,25 @@ def upgrade() -> None:
         """
     )
     op.execute("CREATE INDEX votes_battle_id_idx ON arena.votes (battle_id)")
+
+    op.execute(
+        """
+        CREATE FUNCTION arena.set_updated_at() RETURNS trigger AS $$
+        BEGIN
+            NEW.updated_at := now();
+            RETURN NEW;
+        END;
+        $$ LANGUAGE plpgsql
+        """
+    )
+    op.execute(
+        """
+        CREATE TRIGGER votes_set_updated_at
+            BEFORE UPDATE ON arena.votes
+            FOR EACH ROW
+            EXECUTE FUNCTION arena.set_updated_at()
+        """
+    )
 
     op.execute(
         """

--- a/runner/src/coval_bench/db/migrations/versions/20260615_0007_arena_init_schema.py
+++ b/runner/src/coval_bench/db/migrations/versions/20260615_0007_arena_init_schema.py
@@ -1,0 +1,115 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Voice Arena lean schema: arena.battles, arena.votes, arena.leaderboard_snapshots.
+
+Revision ID: 20260615_0007
+Revises:     20260611_0006
+Create Date: 2026-06-15
+
+Three tables in the ``arena`` schema, alongside ``benchmarks_v2`` in the same DB:
+
+- ``battles``  raw matchups. Model identity is stored as text (provider + model) using the
+               same keys as ``benchmarks_v2.results``, so arena rows can join to benchmark
+               metrics without a shared id. Domain and prompt text are inlined.
+- ``votes``    raw human judgments (A_WIN/B_WIN/TIE). ``voter_type`` separates internal
+               ``labeler`` votes from ``external`` (public) votes; ``UNIQUE (battle_id,
+               voter_type, voter_id)`` keeps one current vote per identity (re-label = UPDATE
+               that row). Raw votes are the source of truth — Bradley-Terry / Davidson are refit
+               from these at any time, for any window; nothing here is ever an input from a
+               previously computed rating.
+- ``leaderboard_snapshots``  persisted computed ratings: one row per model per computation run
+               (a board = all rows sharing ``computed_at`` + ``metric_name`` +
+               ``methodology_version`` + ``domain``). This is a cache/history of derived data,
+               refreshed from votes — never an input to the rating math.
+
+Notes
+-----
+DB roles (``runner``, ``api``) and GRANTs are managed by Terraform. Alembic does NOT create or
+alter roles; the roles must be granted USAGE on ``arena`` and privileges on its tables in
+Terraform before the API can read or write here.
+
+Primary keys are UUID defaulted with ``gen_random_uuid()`` (core since Postgres 13).
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "20260615_0007"
+down_revision = "20260611_0006"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Create the arena schema and its three tables."""
+    op.execute("CREATE SCHEMA IF NOT EXISTS arena")
+    op.execute("SET search_path TO arena")
+
+    op.execute(
+        """
+        CREATE TABLE battles (
+            id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+            provider_a  TEXT NOT NULL,
+            model_a     TEXT NOT NULL,
+            provider_b  TEXT NOT NULL,
+            model_b     TEXT NOT NULL,
+            domain      TEXT,
+            prompt_text TEXT NOT NULL,
+            audio_a_url TEXT NOT NULL,
+            audio_b_url TEXT NOT NULL,
+            created_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+        )
+        """
+    )
+    op.execute("CREATE INDEX battles_domain_idx ON battles (domain)")
+
+    op.execute(
+        """
+        CREATE TABLE votes (
+            id         UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+            battle_id  UUID NOT NULL REFERENCES battles(id),
+            outcome    TEXT NOT NULL CHECK (outcome IN ('A_WIN','B_WIN','TIE')),
+            voter_type TEXT NOT NULL CHECK (voter_type IN ('labeler','external')),
+            voter_id   TEXT NOT NULL,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+            UNIQUE (battle_id, voter_type, voter_id)
+        )
+        """
+    )
+    op.execute("CREATE INDEX votes_battle_id_idx ON votes (battle_id)")
+
+    op.execute(
+        """
+        CREATE TABLE leaderboard_snapshots (
+            id                  UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+            computed_at         TIMESTAMPTZ NOT NULL DEFAULT now(),
+            metric_name         TEXT NOT NULL,
+            methodology_version TEXT NOT NULL,
+            domain              TEXT,
+            provider            TEXT NOT NULL,
+            model               TEXT NOT NULL,
+            rating_elo          NUMERIC NOT NULL,
+            rating_bt           NUMERIC NOT NULL,
+            ci_low              NUMERIC,
+            ci_high             NUMERIC,
+            ci_half_width       NUMERIC,
+            votes_total         INTEGER NOT NULL,
+            wins                NUMERIC NOT NULL,
+            losses              NUMERIC NOT NULL,
+            ties                INTEGER NOT NULL,
+            status              TEXT NOT NULL
+                                CHECK (status IN ('preliminary','usable','established'))
+        )
+        """
+    )
+    op.execute(
+        "CREATE INDEX leaderboard_snapshots_lookup_idx "
+        "ON leaderboard_snapshots (metric_name, computed_at)"
+    )
+
+
+def downgrade() -> None:
+    """Drop the entire arena schema and everything in it."""
+    op.execute("DROP SCHEMA IF EXISTS arena CASCADE")

--- a/runner/src/coval_bench/db/migrations/versions/20260615_0007_arena_init_schema.py
+++ b/runner/src/coval_bench/db/migrations/versions/20260615_0007_arena_init_schema.py
@@ -15,7 +15,8 @@ Three tables in the ``arena`` schema, alongside ``benchmarks_v2`` in the same DB
 - ``votes``    raw human judgments (A_WIN/B_WIN/TIE). ``voter_type`` separates internal
                ``labeler`` votes from ``external`` (public) votes; ``UNIQUE (battle_id,
                voter_type, voter_id)`` keeps one current vote per identity (re-label = UPDATE
-               that row). Raw votes are the source of truth — Bradley-Terry / Davidson are refit
+               that row, bumping ``updated_at`` so windowed refits see the corrected time).
+               Raw votes are the source of truth — Bradley-Terry / Davidson are refit
                from these at any time, for any window; nothing here is ever an input from a
                previously computed rating.
 - ``leaderboard_snapshots``  persisted computed ratings: one row per model per computation run
@@ -45,11 +46,10 @@ depends_on = None
 def upgrade() -> None:
     """Create the arena schema and its three tables."""
     op.execute("CREATE SCHEMA IF NOT EXISTS arena")
-    op.execute("SET search_path TO arena")
 
     op.execute(
         """
-        CREATE TABLE battles (
+        CREATE TABLE arena.battles (
             id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
             provider_a  TEXT NOT NULL,
             model_a     TEXT NOT NULL,
@@ -63,26 +63,27 @@ def upgrade() -> None:
         )
         """
     )
-    op.execute("CREATE INDEX battles_domain_idx ON battles (domain)")
+    op.execute("CREATE INDEX battles_domain_idx ON arena.battles (domain)")
 
     op.execute(
         """
-        CREATE TABLE votes (
+        CREATE TABLE arena.votes (
             id         UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-            battle_id  UUID NOT NULL REFERENCES battles(id),
+            battle_id  UUID NOT NULL REFERENCES arena.battles(id),
             outcome    TEXT NOT NULL CHECK (outcome IN ('A_WIN','B_WIN','TIE')),
             voter_type TEXT NOT NULL CHECK (voter_type IN ('labeler','external')),
             voter_id   TEXT NOT NULL,
             created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+            updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
             UNIQUE (battle_id, voter_type, voter_id)
         )
         """
     )
-    op.execute("CREATE INDEX votes_battle_id_idx ON votes (battle_id)")
+    op.execute("CREATE INDEX votes_battle_id_idx ON arena.votes (battle_id)")
 
     op.execute(
         """
-        CREATE TABLE leaderboard_snapshots (
+        CREATE TABLE arena.leaderboard_snapshots (
             id                  UUID PRIMARY KEY DEFAULT gen_random_uuid(),
             computed_at         TIMESTAMPTZ NOT NULL DEFAULT now(),
             metric_name         TEXT NOT NULL,
@@ -98,7 +99,7 @@ def upgrade() -> None:
             votes_total         INTEGER NOT NULL,
             wins                NUMERIC NOT NULL,
             losses              NUMERIC NOT NULL,
-            ties                INTEGER NOT NULL,
+            ties                NUMERIC NOT NULL,
             status              TEXT NOT NULL
                                 CHECK (status IN ('preliminary','usable','established'))
         )
@@ -106,7 +107,8 @@ def upgrade() -> None:
     )
     op.execute(
         "CREATE INDEX leaderboard_snapshots_lookup_idx "
-        "ON leaderboard_snapshots (metric_name, computed_at)"
+        "ON arena.leaderboard_snapshots "
+        "(computed_at, metric_name, methodology_version, domain)"
     )
 
 


### PR DESCRIPTION
First piece of Voice Arena — just the database tables, nothing wired up yet.

Adds an `arena` schema (next to `benchmarks_v2`, same DB) with three tables:

- `battles` — a matchup: prompt, the two models, their audio. Model names are text keys matching `benchmarks_v2.results`, so they can be joined later. A model can't battle itself.
- `votes` — one judgment per row (A_WIN/B_WIN/TIE), labeler vs external. `UNIQUE (battle_id, voter_type, voter_id)` is the double-vote backstop; `updated_at` lets a labeler re-label (upsert) without breaking windowed refits, while external votes stay insert-once.
- `leaderboard_snapshots` — computed Elo / Bradley-Terry ratings over time. `UNIQUE (computed_at, metric_name, methodology_version, domain, provider, model)` enforces one row per model per board; `domain` is `NOT NULL DEFAULT 'all'` so the global board dedups too.

Additive only: no grants, no `benchmarks_v2` changes, nothing reads/writes these yet. The `arena` DB user + grants live in Terraform, landing separately.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Introduces the `arena` schema alongside `benchmarks_v2`, adding three tables (`battles`, `votes`, `leaderboard_snapshots`) for the Voice Arena feature. The migration is additive-only and well-documented; prior review rounds addressed the missing UNIQUE constraint on snapshots, the absent `updated_at` trigger, and type-uniformity for win/loss/tie columns.

- `arena.battles` stores raw matchups with a CHECK that prevents a model from facing itself; `arena.votes` records human judgments with a BEFORE UPDATE trigger that auto-maintains `updated_at`; `arena.leaderboard_snapshots` caches computed Elo/BT ratings with a 6-column UNIQUE constraint.
- The `leaderboard_snapshots` board-grouping relies on `computed_at TIMESTAMPTZ DEFAULT now()` as a shared key across rows, but `now()` returns the transaction start time — multi-transaction snapshot writes will silently assign different timestamps to rows in the same conceptual run, fragmenting the board and defeating the UNIQUE deduplication guarantee.

<h3>Confidence Score: 3/5</h3>

The migration is additive and won't touch existing tables, but the board-grouping design in leaderboard_snapshots has a structural flaw that should be resolved before any snapshot writer is built against it.

The snapshot table's deduplication guarantee — enforced by a UNIQUE constraint that includes computed_at — breaks as soon as a writer inserts rows across multiple transactions. Each transaction gets a different timestamp from DEFAULT now(), making rows that belong to the same computation run appear as separate boards. Fixing the schema now (before any writer is implemented) is straightforward; waiting until writers exist makes it a much more disruptive change.

runner/src/coval_bench/db/migrations/versions/20260615_0007_arena_init_schema.py — specifically the leaderboard_snapshots table definition and its UNIQUE constraint.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| runner/src/coval_bench/db/migrations/versions/20260615_0007_arena_init_schema.py | Adds arena schema with battles, votes, and leaderboard_snapshots tables. Previous-round fixes are in place (UNIQUE on snapshots, updated_at trigger, uniform NUMERIC types). One remaining structural issue: the board-grouping key for leaderboard_snapshots relies on DEFAULT now() timestamps which produce different values across transactions, potentially fragmenting a single computation run into multiple boards and undermining the UNIQUE deduplication guarantee. |

</details>

<h3>Entity Relationship Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
erDiagram
    BATTLES {
        UUID id PK
        TEXT provider_a
        TEXT model_a
        TEXT provider_b
        TEXT model_b
        TEXT domain
        TEXT prompt_text
        TEXT audio_a_url
        TEXT audio_b_url
        TIMESTAMPTZ created_at
    }

    VOTES {
        UUID id PK
        UUID battle_id FK
        TEXT outcome
        TEXT voter_type
        TEXT voter_id
        TIMESTAMPTZ created_at
        TIMESTAMPTZ updated_at
    }

    LEADERBOARD_SNAPSHOTS {
        UUID id PK
        TIMESTAMPTZ computed_at
        TEXT metric_name
        TEXT methodology_version
        TEXT domain
        TEXT provider
        TEXT model
        NUMERIC rating_elo
        NUMERIC rating_bt
        NUMERIC ci_low
        NUMERIC ci_high
        NUMERIC ci_half_width
        INTEGER votes_total
        NUMERIC wins
        NUMERIC losses
        NUMERIC ties
        TEXT status
    }

    BATTLES ||--o{ VOTES : "has"
    BATTLES }o--o{ LEADERBOARD_SNAPSHOTS : "informs (via refit)"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
erDiagram
    BATTLES {
        UUID id PK
        TEXT provider_a
        TEXT model_a
        TEXT provider_b
        TEXT model_b
        TEXT domain
        TEXT prompt_text
        TEXT audio_a_url
        TEXT audio_b_url
        TIMESTAMPTZ created_at
    }

    VOTES {
        UUID id PK
        UUID battle_id FK
        TEXT outcome
        TEXT voter_type
        TEXT voter_id
        TIMESTAMPTZ created_at
        TIMESTAMPTZ updated_at
    }

    LEADERBOARD_SNAPSHOTS {
        UUID id PK
        TIMESTAMPTZ computed_at
        TEXT metric_name
        TEXT methodology_version
        TEXT domain
        TEXT provider
        TEXT model
        NUMERIC rating_elo
        NUMERIC rating_bt
        NUMERIC ci_low
        NUMERIC ci_high
        NUMERIC ci_half_width
        INTEGER votes_total
        NUMERIC wins
        NUMERIC losses
        NUMERIC ties
        TEXT status
    }

    BATTLES ||--o{ VOTES : "has"
    BATTLES }o--o{ LEADERBOARD_SNAPSHOTS : "informs (via refit)"
```

</a>

<sub>Reviews (4): Last reviewed commit: ["Auto-bump arena.votes.updated\_at via tri..."](https://github.com/coval-ai/benchmarks/commit/636994793ce3cb70a23e1059d52296a3633adaf5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37771834)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->