### PR TITLE
fix(smallest-tts): pass language="en" to prevent auto-detect flakiness

### DIFF
--- a/runner/src/coval_bench/providers/tts/smallest.py
+++ b/runner/src/coval_bench/providers/tts/smallest.py
@@ -4,7 +4,7 @@
 """Smallest AI Lightning TTS provider — WebSocket streaming.
 
 Wire protocol:
-  connect → send JSON(text, voice_id, model, sample_rate)
+  connect → send JSON(text, voice_id, model, sample_rate, language)
   → recv JSON chunks: {"status": "chunk", "data": {"audio": "<base64-pcm>"}}
   → recv JSON done:   {"status": "complete", "done": true}
 
@@ -70,6 +70,8 @@ class SmallestTTSProvider(TTSProvider):
                 "voice_id": self._voice,
                 "model": self._model,
                 "sample_rate": SAMPLE_RATE,
+                # Explicit language prevents auto-detect flakiness on English-only models.
+                "language": "en",
             }
         )
 

--- a/runner/tests/providers/tts/test_smallest.py
+++ b/runner/tests/providers/tts/test_smallest.py
@@ -65,6 +65,7 @@ async def test_smallest_happy_path(fake_settings: Settings, tmp_path: Path) -> N
     assert payload["voice_id"] == "kaitlyn"
     assert payload["model"] == "lightning_v3.1_pro"
     assert payload["sample_rate"] == 24000
+    assert payload["language"] == "en"
 
     result.audio_path.unlink()
 


### PR DESCRIPTION
## Summary

- Adds `"language": "en"` to the WebSocket payload sent by `SmallestTTSProvider`
- Lightning v3.1 Pro is English-only; without an explicit language field the server auto-detects on every request, which can produce intermittent degraded output
- Mirrors the same fix already applied to the `cartesia`, `soniox`, and `xai` providers
- Updates `test_smallest_happy_path` to assert `payload["language"] == "en"`

## Test plan

- [ ] `test_smallest_happy_path` asserts `language == "en"` in the outgoing payload

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Smallest AI text-to-speech provider to properly send language parameters to the service.

* **Tests**
  * Updated tests to verify language parameters are correctly included in service requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR pins `language: "en"` in the WebSocket payload sent by `SmallestTTSProvider`, preventing the Smallest AI server from running per-request language auto-detection on an English-only model. The wire-protocol docstring and happy-path test are updated to match.

- `smallest.py`: adds `"language": "en"` to the `json.dumps` payload alongside an explanatory inline comment; updates the docstring to include `language` in the wire-protocol spec.
- `test_smallest.py`: adds `assert payload["language"] == "en"` to `test_smallest_happy_path`, closing the assertion gap for the new field.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a one-field addition to a JSON payload with a matching test assertion, no logic is restructured.

The language field is hardcoded to `"en"`, which is appropriate given that `lightning_v3.1_pro` is English-only and the `_VALID_MODELS` frozenset currently allows only that model. The test covers the new field, the docstring is updated, and the fix is consistent with the treatment of other providers in the repo. No existing behavior is altered beyond eliminating the server-side auto-detect path.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| runner/src/coval_bench/providers/tts/smallest.py | Adds `"language": "en"` to the WebSocket payload; updates the wire-protocol docstring. Change is minimal, correctly placed, and consistent with the stated fix. |
| runner/tests/providers/tts/test_smallest.py | Adds the corresponding assertion for `language == "en"` in the happy-path test. Other test cases remain unaffected. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client as SmallestTTSProvider
    participant WS as wss://api.smallest.ai/waves/v1/tts/live

    Client->>WS: "connect (Authorization: Bearer <key>)"
    Client->>WS: "send JSON {text, voice_id, model, sample_rate, language: "en"}"
    loop audio chunks
        WS-->>Client: "{"status": "chunk", "data": {"audio": "<base64-pcm>"}}"
    end
    WS-->>Client: "{"status": "complete", "done": true}"
    Client->>Client: finalize_tts_result(pcm, sample_rate, ...)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client as SmallestTTSProvider
    participant WS as wss://api.smallest.ai/waves/v1/tts/live

    Client->>WS: "connect (Authorization: Bearer <key>)"
    Client->>WS: "send JSON {text, voice_id, model, sample_rate, language: "en"}"
    loop audio chunks
        WS-->>Client: "{"status": "chunk", "data": {"audio": "<base64-pcm>"}}"
    end
    WS-->>Client: "{"status": "complete", "done": true}"
    Client->>Client: finalize_tts_result(pcm, sample_rate, ...)
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(smallest-tts): pass language=&quot;en&quot; to..."](https://github.com/coval-ai/benchmarks/commit/df6799153b63fc078f9c22c581170dc53a683c2d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37831306)</sub>

<!-- /greptile_comment -->