### PR TITLE
Add soniox stt models

### DIFF
--- a/runner/src/coval_bench/providers/stt/__init__.py
+++ b/runner/src/coval_bench/providers/stt/__init__.py
@@ -22,6 +22,7 @@ from coval_bench.providers.stt.elevenlabs import ElevenLabsSTTProvider
 from coval_bench.providers.stt.gradium import GradiumSTTProvider
 from coval_bench.providers.stt.openai import OpenAISTTProvider
 from coval_bench.providers.stt.smallest import SmallestSTTProvider
+from coval_bench.providers.stt.soniox import SonioxSTTProvider
 from coval_bench.providers.stt.speechmatics import SpeechmaticsProvider
 from coval_bench.providers.stt.xai import XaiSTTProvider
 
@@ -42,6 +43,7 @@ STT_PROVIDERS: dict[str, type[STTProvider]] = {
     "gradium": GradiumSTTProvider,
     "openai": OpenAISTTProvider,
     "smallest": SmallestSTTProvider,
+    "soniox": SonioxSTTProvider,
     "speechmatics": SpeechmaticsProvider,
     "xai": XaiSTTProvider,
 }
@@ -59,6 +61,7 @@ __all__ = [
     "GradiumSTTProvider",
     "OpenAISTTProvider",
     "SmallestSTTProvider",
+    "SonioxSTTProvider",
     "SpeechmaticsProvider",
     "XaiSTTProvider",
     "GoogleSTTProvider",

--- a/runner/src/coval_bench/providers/stt/soniox.py
+++ b/runner/src/coval_bench/providers/stt/soniox.py
@@ -1,25 +1,7 @@
 # Copyright 2026 The Coval Benchmarks Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Soniox real-time STT provider.
-
-Supports models: stt-rt-v4
-Wire protocol: WebSocket, wss://stt-rt.soniox.com/transcribe-websocket
-Auth: in-band — the api_key rides the opening JSON config frame (no header).
-Config: {"api_key":..., "model":"stt-rt-v4", "audio_format":"pcm_s16le",
-         "sample_rate":16000, "num_channels":1, "language_hints":["en"]}
-Audio: raw PCM_16 sent as binary frames.
-End: an empty text frame (`""`) signals end of audio; the server flushes final
-     tokens and sends {"finished": true} before closing. A zero-length binary
-     frame is ignored, so the stream must be ended with the empty string.
-
-Protocol notes:
-- Responses carry a "tokens" array; each token has "text" and "is_final".
-  Final tokens (is_final=True) are committed and never change; non-final tokens
-  are interim and may be superseded by later messages.
-- Token "text" already carries its own spacing, so the transcript is the direct
-  concatenation of final-token text (not a " ".join()).
-"""
+"""Soniox real-time STT provider (WebSocket)."""
 
 from __future__ import annotations
 
@@ -42,7 +24,7 @@ _WS_URL = "wss://stt-rt.soniox.com/transcribe-websocket"
 class SonioxSTTProvider(STTProvider):
     """Soniox streaming STT provider."""
 
-    _VALID_MODELS = frozenset({"stt-rt-v4"})
+    _VALID_MODELS = frozenset({"stt-rt-v4", "stt-rt-v5"})
 
     def __init__(self, api_key: SecretStr | None, model: str = "stt-rt-v4") -> None:
         if not self._model_supported(model):
@@ -79,8 +61,6 @@ class SonioxSTTProvider(STTProvider):
 
         try:
             async with ws_client.connect(_WS_URL) as ws:
-                # Soniox authenticates in-band: the api_key rides the opening config
-                # frame rather than an Authorization header.
                 await ws.send(
                     json.dumps(
                         {
@@ -122,9 +102,8 @@ class SonioxSTTProvider(STTProvider):
             for i in range(0, len(audio_data), chunk_size):
                 await ws.send(audio_data[i : i + chunk_size])
                 await asyncio.sleep(realtime_resolution)
-            # An empty *text* frame signals end of audio; the server then flushes
-            # final tokens and sends {"finished": true}. A zero-length binary frame
-            # is ignored, leaving the stream open until the server's idle timeout.
+            # End-of-audio is an empty *text* frame; a zero-length binary frame is
+            # ignored, so the server never finalizes (stalls to its idle timeout).
             await ws.send("")
         except Exception as exc:
             logger.exception("soniox send error", error=str(exc))
@@ -174,6 +153,7 @@ class SonioxSTTProvider(STTProvider):
             logger.exception("soniox receive error", error=str(exc))
 
         if final_parts:
+            # Soniox tokens carry their own leading spaces — concatenate, don't " ".join.
             result.complete_transcript = "".join(final_parts).strip() or None
 
         if result.complete_transcript:

--- a/runner/src/coval_bench/providers/stt/soniox.py
+++ b/runner/src/coval_bench/providers/stt/soniox.py
@@ -56,6 +56,12 @@ class SonioxSTTProvider(STTProvider):
         if sample_rate != 16000:
             result.error = f"Soniox requires 16 kHz PCM input; got {sample_rate} Hz"
             return result
+        if channels != 1 or sample_width != 2:
+            result.error = (
+                "Soniox requires mono 16-bit PCM input; "
+                f"got channels={channels}, sample_width={sample_width}"
+            )
+            return result
 
         total_start = time.monotonic()
 
@@ -78,7 +84,11 @@ class SonioxSTTProvider(STTProvider):
                     self._send_audio(ws, audio_data, sample_rate, result, realtime_resolution)
                 )
                 recv_task = asyncio.create_task(self._receive(ws, result))
-                await asyncio.gather(send_task, recv_task, return_exceptions=True)
+                outcomes = await asyncio.gather(send_task, recv_task, return_exceptions=True)
+                # Surface a task failure as result.error so it isn't a silent success.
+                for outcome in outcomes:
+                    if isinstance(outcome, Exception) and result.error is None:
+                        result.error = str(outcome)
 
         except Exception as exc:
             logger.exception("soniox measure_ttft failed", error=str(exc))
@@ -151,6 +161,8 @@ class SonioxSTTProvider(STTProvider):
 
         except Exception as exc:
             logger.exception("soniox receive error", error=str(exc))
+            if result.error is None:
+                result.error = str(exc)
 
         if final_parts:
             # Soniox tokens carry their own leading spaces — concatenate, don't " ".join.

--- a/runner/src/coval_bench/providers/stt/soniox.py
+++ b/runner/src/coval_bench/providers/stt/soniox.py
@@ -1,0 +1,181 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Soniox real-time STT provider.
+
+Supports models: stt-rt-v4
+Wire protocol: WebSocket, wss://stt-rt.soniox.com/transcribe-websocket
+Auth: in-band — the api_key rides the opening JSON config frame (no header).
+Config: {"api_key":..., "model":"stt-rt-v4", "audio_format":"pcm_s16le",
+         "sample_rate":16000, "num_channels":1, "language_hints":["en"]}
+Audio: raw PCM_16 sent as binary frames.
+End: an empty text frame (`""`) signals end of audio; the server flushes final
+     tokens and sends {"finished": true} before closing. A zero-length binary
+     frame is ignored, so the stream must be ended with the empty string.
+
+Protocol notes:
+- Responses carry a "tokens" array; each token has "text" and "is_final".
+  Final tokens (is_final=True) are committed and never change; non-final tokens
+  are interim and may be superseded by later messages.
+- Token "text" already carries its own spacing, so the transcript is the direct
+  concatenation of final-token text (not a " ".join()).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from typing import Any
+
+import structlog
+import websockets.asyncio.client as ws_client
+from pydantic import SecretStr
+
+from coval_bench.providers.base import STTProvider, TranscriptionResult
+
+logger = structlog.get_logger(__name__)
+
+_WS_URL = "wss://stt-rt.soniox.com/transcribe-websocket"
+
+
+class SonioxSTTProvider(STTProvider):
+    """Soniox streaming STT provider."""
+
+    _VALID_MODELS = frozenset({"stt-rt-v4"})
+
+    def __init__(self, api_key: SecretStr | None, model: str = "stt-rt-v4") -> None:
+        if not self._model_supported(model):
+            raise ValueError(
+                f"Invalid Soniox STT model {model!r}. Valid: {sorted(self._VALID_MODELS)}"
+            )
+        if api_key is None:
+            raise ValueError("soniox_api_key is required for the Soniox STT provider")
+        self._api_key = api_key
+        self._model = model
+
+    @property
+    def name(self) -> str:
+        return "soniox"
+
+    @property
+    def model(self) -> str:
+        return self._model
+
+    async def measure_ttft(
+        self,
+        audio_data: bytes,
+        channels: int,
+        sample_width: int,
+        sample_rate: int,
+        realtime_resolution: float = 0.1,
+    ) -> TranscriptionResult:
+        result = TranscriptionResult(provider=self.name)
+        if sample_rate != 16000:
+            result.error = f"Soniox requires 16 kHz PCM input; got {sample_rate} Hz"
+            return result
+
+        total_start = time.monotonic()
+
+        try:
+            async with ws_client.connect(_WS_URL) as ws:
+                # Soniox authenticates in-band: the api_key rides the opening config
+                # frame rather than an Authorization header.
+                await ws.send(
+                    json.dumps(
+                        {
+                            "api_key": self._api_key.get_secret_value(),
+                            "model": self._model,
+                            "audio_format": "pcm_s16le",
+                            "sample_rate": sample_rate,
+                            "num_channels": 1,
+                            "language_hints": ["en"],
+                        }
+                    )
+                )
+
+                send_task = asyncio.create_task(
+                    self._send_audio(ws, audio_data, sample_rate, result, realtime_resolution)
+                )
+                recv_task = asyncio.create_task(self._receive(ws, result))
+                await asyncio.gather(send_task, recv_task, return_exceptions=True)
+
+        except Exception as exc:
+            logger.exception("soniox measure_ttft failed", error=str(exc))
+            result.error = str(exc)
+
+        result.total_time = time.monotonic() - total_start
+        return result
+
+    async def _send_audio(
+        self,
+        ws: Any,
+        audio_data: bytes,
+        sample_rate: int,
+        result: TranscriptionResult,
+        realtime_resolution: float,
+    ) -> None:
+        bytes_per_second = sample_rate * 2  # 16-bit mono
+        chunk_size = int(bytes_per_second * realtime_resolution)
+        result.audio_start_time = time.monotonic()
+        try:
+            for i in range(0, len(audio_data), chunk_size):
+                await ws.send(audio_data[i : i + chunk_size])
+                await asyncio.sleep(realtime_resolution)
+            # An empty *text* frame signals end of audio; the server then flushes
+            # final tokens and sends {"finished": true}. A zero-length binary frame
+            # is ignored, leaving the stream open until the server's idle timeout.
+            await ws.send("")
+        except Exception as exc:
+            logger.exception("soniox send error", error=str(exc))
+            raise
+
+    async def _receive(self, ws: Any, result: TranscriptionResult) -> None:
+        final_parts: list[str] = []
+
+        try:
+            async for raw in ws:
+                if isinstance(raw, bytes):
+                    continue
+
+                msg: dict[str, Any] = json.loads(raw)
+                now = time.monotonic()
+
+                if msg.get("error_code") or msg.get("error_message"):
+                    code = msg.get("error_code")
+                    result.error = str(
+                        msg.get("error_message") or f"Soniox STT error (code {code})"
+                    )
+                    logger.error("soniox stt error", msg=msg)
+                    break
+
+                tokens: list[dict[str, Any]] = msg.get("tokens") or []
+                for token in tokens:
+                    text = str(token.get("text", ""))
+                    if not text.strip():
+                        continue
+                    if result.ttft_seconds is None and result.audio_start_time is not None:
+                        result.ttft_seconds = now - result.audio_start_time
+                        snippet = text.strip()
+                        result.first_token_content = (
+                            snippet[:30] + "..." if len(snippet) > 30 else snippet
+                        )
+                    if token.get("is_final"):
+                        final_parts.append(text)
+                        if result.audio_start_time is not None:
+                            result.audio_to_final_seconds = now - result.audio_start_time
+                    else:
+                        result.partial_transcripts.append(text.strip())
+
+                if msg.get("finished"):
+                    break
+
+        except Exception as exc:
+            logger.exception("soniox receive error", error=str(exc))
+
+        if final_parts:
+            result.complete_transcript = "".join(final_parts).strip() or None
+
+        if result.complete_transcript:
+            result.transcript_length = len(result.complete_transcript)
+            result.word_count = len(result.complete_transcript.split())

--- a/runner/src/coval_bench/registries/models.py
+++ b/runner/src/coval_bench/registries/models.py
@@ -67,6 +67,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
     RegisteredModel(benchmark=_STT, provider="speechmatics", model="default", status=_ACTIVE),
     RegisteredModel(benchmark=_STT, provider="speechmatics", model="enhanced", status=_ACTIVE),
     RegisteredModel(benchmark=_STT, provider="gradium", model="default", status=_ACTIVE),
+    RegisteredModel(benchmark=_STT, provider="soniox", model="stt-rt-v4", status=_RETIRED),
     RegisteredModel(benchmark=_STT, provider="xai", model="grok-stt", status=_RETIRED),
     RegisteredModel(benchmark=_STT, provider="smallest", model="pulse", status=_ACTIVE),
     RegisteredModel(benchmark=_STT, provider="cartesia", model="ink-2", status=_ACTIVE),

--- a/runner/src/coval_bench/registries/models.py
+++ b/runner/src/coval_bench/registries/models.py
@@ -68,6 +68,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
     RegisteredModel(benchmark=_STT, provider="speechmatics", model="enhanced", status=_ACTIVE),
     RegisteredModel(benchmark=_STT, provider="gradium", model="default", status=_ACTIVE),
     RegisteredModel(benchmark=_STT, provider="soniox", model="stt-rt-v4", status=_RETIRED),
+    RegisteredModel(benchmark=_STT, provider="soniox", model="stt-rt-v5", status=_RETIRED),
     RegisteredModel(benchmark=_STT, provider="xai", model="grok-stt", status=_RETIRED),
     RegisteredModel(benchmark=_STT, provider="smallest", model="pulse", status=_ACTIVE),
     RegisteredModel(benchmark=_STT, provider="cartesia", model="ink-2", status=_ACTIVE),

--- a/runner/tests/providers/stt/fixtures/soniox/events-error.json
+++ b/runner/tests/providers/stt/fixtures/soniox/events-error.json
@@ -1,0 +1,3 @@
+[
+  {"error_code": 401, "error_type": "unauthorized", "error_message": "Invalid or expired API key"}
+]

--- a/runner/tests/providers/stt/fixtures/soniox/events-success.json
+++ b/runner/tests/providers/stt/fixtures/soniox/events-success.json
@@ -1,0 +1,7 @@
+[
+  {"tokens": [{"text": "hel", "is_final": false}]},
+  {"tokens": [{"text": "hello", "is_final": true}, {"text": " wor", "is_final": false}]},
+  {"tokens": [{"text": " world", "is_final": true}, {"text": " how are", "is_final": false}]},
+  {"tokens": [{"text": " how", "is_final": true}, {"text": " are", "is_final": true}, {"text": " you", "is_final": true}]},
+  {"finished": true}
+]

--- a/runner/tests/providers/stt/test_soniox.py
+++ b/runner/tests/providers/stt/test_soniox.py
@@ -115,6 +115,10 @@ def test_provider_model() -> None:
     assert make_provider().model == "stt-rt-v4"
 
 
+def test_stt_rt_v5_supported() -> None:
+    assert SonioxSTTProvider(api_key=SecretStr("k"), model="stt-rt-v5").model == "stt-rt-v5"
+
+
 # ---------------------------------------------------------------------------
 # Invalid construction
 # ---------------------------------------------------------------------------

--- a/runner/tests/providers/stt/test_soniox.py
+++ b/runner/tests/providers/stt/test_soniox.py
@@ -1,0 +1,202 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for coval_bench.providers.stt.soniox (SonioxSTTProvider).
+
+All tests use FakeWebSocket — no live network calls are made. The event
+fixtures mirror the Soniox real-time wire protocol: each message carries a
+``tokens`` array where ``is_final`` marks committed tokens. Token ``text``
+already carries its own spacing, so the transcript is the direct concatenation
+of final-token text.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pydantic import SecretStr
+
+from coval_bench.metrics.wer import compute_wer
+from coval_bench.providers.stt.soniox import SonioxSTTProvider
+from tests.providers.stt.conftest import FakeWebSocket, load_fixture_events
+
+
+def make_provider() -> SonioxSTTProvider:
+    return SonioxSTTProvider(api_key=SecretStr("test-key-soniox"))
+
+
+def _fake_connect(events: list[Any]) -> Any:
+    ws = FakeWebSocket(events)
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=ws)
+    cm.__aexit__ = AsyncMock(return_value=False)
+    return cm
+
+
+# ---------------------------------------------------------------------------
+# Happy path — final tokens concatenated in order
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_soniox_success(fake_api_key: SecretStr, audio_pcm_bytes: bytes) -> None:
+    events = load_fixture_events("soniox", "events-success")
+    provider = SonioxSTTProvider(api_key=fake_api_key)
+
+    with patch(
+        "coval_bench.providers.stt.soniox.ws_client.connect",
+        return_value=_fake_connect(events),
+    ):
+        result = await provider.measure_ttft(
+            audio_data=audio_pcm_bytes,
+            channels=1,
+            sample_width=2,
+            sample_rate=16000,
+            realtime_resolution=0.5,
+        )
+
+    assert result.error is None
+    assert result.ttft_seconds is not None
+    assert result.ttft_seconds >= 0
+    assert result.first_token_content is not None
+    assert result.complete_transcript == "hello world how are you"
+    assert result.word_count == 5
+    assert result.audio_to_final_seconds is not None
+    wer = compute_wer("hello world how are you", result.complete_transcript)
+    assert wer.wer_percentage == pytest.approx(0.0)
+
+
+@pytest.mark.asyncio
+async def test_soniox_excludes_interim_tokens(
+    fake_api_key: SecretStr, audio_pcm_bytes: bytes
+) -> None:
+    """Only ``is_final`` tokens form the transcript; interim tokens are dropped.
+
+    The interim ("wrong") tokens differ from the committed text, so a leak into
+    the final transcript would change the assertion.
+    """
+    events: list[Any] = [
+        {"tokens": [{"text": "wrong guess", "is_final": False}]},
+        {"tokens": [{"text": "hello", "is_final": True}, {"text": " worng", "is_final": False}]},
+        {"tokens": [{"text": " world", "is_final": True}]},
+        {"finished": True},
+    ]
+    provider = SonioxSTTProvider(api_key=fake_api_key)
+
+    with patch(
+        "coval_bench.providers.stt.soniox.ws_client.connect",
+        return_value=_fake_connect(events),
+    ):
+        result = await provider.measure_ttft(
+            audio_data=audio_pcm_bytes,
+            channels=1,
+            sample_width=2,
+            sample_rate=16000,
+            realtime_resolution=0.5,
+        )
+
+    assert result.error is None
+    assert result.complete_transcript == "hello world"
+    assert result.word_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Provider name and model
+# ---------------------------------------------------------------------------
+
+
+def test_provider_name() -> None:
+    assert make_provider().name == "soniox"
+
+
+def test_provider_model() -> None:
+    assert make_provider().model == "stt-rt-v4"
+
+
+# ---------------------------------------------------------------------------
+# Invalid construction
+# ---------------------------------------------------------------------------
+
+
+def test_invalid_model_raises() -> None:
+    with pytest.raises(ValueError, match="Invalid Soniox STT model"):
+        SonioxSTTProvider(api_key=SecretStr("k"), model="stt-rt-preview")
+
+
+def test_missing_api_key_raises() -> None:
+    with pytest.raises(ValueError, match="soniox_api_key is required"):
+        SonioxSTTProvider(api_key=None)
+
+
+# ---------------------------------------------------------------------------
+# Invalid sample rate
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_soniox_wrong_sample_rate(fake_api_key: SecretStr, audio_pcm_bytes: bytes) -> None:
+    provider = SonioxSTTProvider(api_key=fake_api_key)
+    result = await provider.measure_ttft(
+        audio_data=audio_pcm_bytes,
+        channels=1,
+        sample_width=2,
+        sample_rate=8000,
+    )
+
+    assert result.error is not None
+    assert "16 kHz" in result.error
+    assert result.ttft_seconds is None
+
+
+# ---------------------------------------------------------------------------
+# Failure path — error frame
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_soniox_error_event(fake_api_key: SecretStr, audio_pcm_bytes: bytes) -> None:
+    events = load_fixture_events("soniox", "events-error")
+    provider = SonioxSTTProvider(api_key=fake_api_key)
+
+    with patch(
+        "coval_bench.providers.stt.soniox.ws_client.connect",
+        return_value=_fake_connect(events),
+    ):
+        result = await provider.measure_ttft(
+            audio_data=audio_pcm_bytes,
+            channels=1,
+            sample_width=2,
+            sample_rate=16000,
+            realtime_resolution=0.5,
+        )
+
+    assert result.error is not None
+    assert "Invalid or expired API key" in result.error
+    assert result.complete_transcript is None
+
+
+# ---------------------------------------------------------------------------
+# Failure path — empty stream
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_soniox_empty_stream(fake_api_key: SecretStr, audio_pcm_bytes: bytes) -> None:
+    provider = SonioxSTTProvider(api_key=fake_api_key)
+
+    with patch(
+        "coval_bench.providers.stt.soniox.ws_client.connect",
+        return_value=_fake_connect([]),
+    ):
+        result = await provider.measure_ttft(
+            audio_data=audio_pcm_bytes,
+            channels=1,
+            sample_width=2,
+            sample_rate=16000,
+            realtime_resolution=0.5,
+        )
+
+    assert result.complete_transcript is None
+    assert result.ttft_seconds is None

--- a/runner/tests/providers/stt/test_soniox.py
+++ b/runner/tests/providers/stt/test_soniox.py
@@ -154,6 +154,24 @@ async def test_soniox_wrong_sample_rate(fake_api_key: SecretStr, audio_pcm_bytes
     assert result.ttft_seconds is None
 
 
+@pytest.mark.asyncio
+async def test_soniox_rejects_non_mono_or_non_16bit(
+    fake_api_key: SecretStr, audio_pcm_bytes: bytes
+) -> None:
+    """The config hardcodes mono 16-bit, so non-matching input is rejected upfront."""
+    provider = SonioxSTTProvider(api_key=fake_api_key)
+    result = await provider.measure_ttft(
+        audio_data=audio_pcm_bytes,
+        channels=2,
+        sample_width=2,
+        sample_rate=16000,
+    )
+
+    assert result.error is not None
+    assert "mono 16-bit" in result.error
+    assert result.ttft_seconds is None
+
+
 # ---------------------------------------------------------------------------
 # Failure path — error frame
 # ---------------------------------------------------------------------------
@@ -204,3 +222,61 @@ async def test_soniox_empty_stream(fake_api_key: SecretStr, audio_pcm_bytes: byt
 
     assert result.complete_transcript is None
     assert result.ttft_seconds is None
+
+
+# ---------------------------------------------------------------------------
+# Failure path — websocket transport exceptions
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_soniox_connection_error(fake_api_key: SecretStr, audio_pcm_bytes: bytes) -> None:
+    """A connect failure surfaces as result.error, not a silent empty success."""
+    provider = SonioxSTTProvider(api_key=fake_api_key)
+
+    with patch(
+        "coval_bench.providers.stt.soniox.ws_client.connect",
+        side_effect=OSError("connection refused"),
+    ):
+        result = await provider.measure_ttft(
+            audio_data=audio_pcm_bytes,
+            channels=1,
+            sample_width=2,
+            sample_rate=16000,
+            realtime_resolution=0.5,
+        )
+
+    assert result.error is not None
+    assert "connection refused" in result.error
+    assert result.complete_transcript is None
+    assert result.ttft_seconds is None
+
+
+@pytest.mark.asyncio
+async def test_soniox_surfaces_send_failure(
+    fake_api_key: SecretStr, audio_pcm_bytes: bytes
+) -> None:
+    """A send failure inside the streaming task is surfaced, not swallowed by gather."""
+
+    def _raise_on_audio(msg: object) -> None:
+        if isinstance(msg, (bytes, bytearray)):
+            raise RuntimeError("send boom")
+
+    ws = FakeWebSocket([], on_send=_raise_on_audio)
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=ws)
+    cm.__aexit__ = AsyncMock(return_value=False)
+
+    provider = SonioxSTTProvider(api_key=fake_api_key)
+    with patch("coval_bench.providers.stt.soniox.ws_client.connect", return_value=cm):
+        result = await provider.measure_ttft(
+            audio_data=audio_pcm_bytes,
+            channels=1,
+            sample_width=2,
+            sample_rate=16000,
+            realtime_resolution=0.5,
+        )
+
+    assert result.error is not None
+    assert "send boom" in result.error
+    assert result.complete_transcript is None

--- a/web/lib/config/colors.ts
+++ b/web/lib/config/colors.ts
@@ -48,6 +48,7 @@ export const modelColors: Record<string, string> = {
   // Soniox — gold family. The chart's only gold; sits yellower than the
   // ElevenLabs oranges and dark enough to read on the cream background.
   "tts-rt-v1": "#C9A227",
+  "stt-rt-v4": "#B8860B",
 
   // Composite keys for models whose slug is shared across providers
   "speechmatics:default": "#21618C",

--- a/web/lib/config/colors.ts
+++ b/web/lib/config/colors.ts
@@ -49,6 +49,7 @@ export const modelColors: Record<string, string> = {
   // ElevenLabs oranges and dark enough to read on the cream background.
   "tts-rt-v1": "#C9A227",
   "stt-rt-v4": "#B8860B",
+  "stt-rt-v5": "#9C7400",
 
   // Composite keys for models whose slug is shared across providers
   "speechmatics:default": "#21618C",


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Soniox as a supported real-time speech-to-text provider.
  * Added Soniox models (`stt-rt-v4`, `stt-rt-v5`) to the registry (disabled for active benchmarking).
  * Updated the UI to display Soniox model options with distinct styling.
* **Bug Fixes**
  * Improved validation and error reporting for incorrect audio format/sample rate and API key/protocol/send failures.
* **Tests**
  * Expanded Soniox provider test coverage with success/error event scenarios and fixtures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds Soniox as a new real-time WebSocket STT provider, following the established pattern of `_send_audio` / `_receive` task concurrency used by Speechmatics. The two new models are pre-registered as `_RETIRED` (intentionally disabled for live benchmarking) and Soniox colours are added to the web colour palette.

- **`soniox.py`**: Validates 16 kHz mono 16-bit PCM upfront, streams chunked audio over WebSocket, captures TTFT from the first non-empty token, and surfaces errors from both server error frames and task exceptions via `asyncio.gather(return_exceptions=True)`.
- **Tests**: Comprehensive — covers happy path, interim-only tokens, wrong sample rate, mono/bit-depth rejection, error frame, empty stream, connection failure, and send failure.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the new provider is additive, both models are pre-disabled in the registry, and the tests exercise all meaningful code paths without making live network calls.

The Soniox provider closely follows the established Speechmatics pattern for concurrent send/receive tasks. Upfront validation (sample rate, channels, bit-depth) prevents the known chunk-size limitation from being reached with invalid input. All error paths — transport failures, server error frames, empty streams, and send exceptions — are explicitly tested with FakeWebSocket. The web colour change is trivially safe.

No files require special attention. The known chunk-size limitation in soniox.py is guarded by the upfront validation rejecting any non-mono/non-16-bit input.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| runner/src/coval_bench/providers/stt/soniox.py | New Soniox WebSocket provider; `bytes_per_second` hardcodes 16-bit mono (channels/sample_width unused — already flagged in prior threads) but upfront validation ensures only that combination is accepted, limiting blast radius. |
| runner/tests/providers/stt/test_soniox.py | Thorough unit tests covering success, partial/final token separation, validation failures, transport errors, and send failures via FakeWebSocket; no live network calls. |
| runner/src/coval_bench/registries/models.py | Both Soniox models registered as _RETIRED on day one — intentional per PR (already discussed in prior thread), but worth confirming before activating for benchmarks. |
| runner/src/coval_bench/providers/stt/__init__.py | Clean addition of SonioxSTTProvider to the STT_PROVIDERS registry and __all__ export. |
| web/lib/config/colors.ts | Adds two gold-family colours for stt-rt-v4 and stt-rt-v5 consistent with existing Soniox tts-rt-v1 branding. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant B as Benchmark Runner
    participant S as SonioxSTTProvider
    participant WS as Soniox WebSocket
    B->>S: "measure_ttft(audio_data, channels=1, sample_width=2, sample_rate=16000)"
    S->>S: Validate sample_rate / channels / sample_width
    S->>WS: connect(wss://stt-rt.soniox.com/transcribe-websocket)
    S->>WS: send(config JSON: model, audio_format, sample_rate, language_hints)
    par send_task
        S->>S: "audio_start_time = monotonic()"
        loop chunks at realtime_resolution
            S->>WS: send(PCM chunk)
            S->>S: sleep(realtime_resolution)
        end
        S->>WS: send("") end-of-audio text frame
    and recv_task
        loop until finished or error
            WS-->>S: tokens / error_code / finished
            S->>S: Set ttft_seconds on first non-empty token
            S->>S: Accumulate final_parts on is_final tokens
        end
    end
    S->>S: Resolve task exceptions to result.error
    S->>B: TranscriptionResult(ttft_seconds, complete_transcript)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant B as Benchmark Runner
    participant S as SonioxSTTProvider
    participant WS as Soniox WebSocket
    B->>S: "measure_ttft(audio_data, channels=1, sample_width=2, sample_rate=16000)"
    S->>S: Validate sample_rate / channels / sample_width
    S->>WS: connect(wss://stt-rt.soniox.com/transcribe-websocket)
    S->>WS: send(config JSON: model, audio_format, sample_rate, language_hints)
    par send_task
        S->>S: "audio_start_time = monotonic()"
        loop chunks at realtime_resolution
            S->>WS: send(PCM chunk)
            S->>S: sleep(realtime_resolution)
        end
        S->>WS: send("") end-of-audio text frame
    and recv_task
        loop until finished or error
            WS-->>S: tokens / error_code / finished
            S->>S: Set ttft_seconds on first non-empty token
            S->>S: Accumulate final_parts on is_final tokens
        end
    end
    S->>S: Resolve task exceptions to result.error
    S->>B: TranscriptionResult(ttft_seconds, complete_transcript)
```

</a>

<sub>Reviews (2): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/mai..."](https://github.com/coval-ai/benchmarks/commit/2b887d9488aedc135ca830bee724046b6bd0c021) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37935976)</sub>

<!-- /greptile_comment -->