### PR TITLE
Activate Soniox models in public benchmarks

### DIFF
--- a/runner/src/coval_bench/registries/models.py
+++ b/runner/src/coval_bench/registries/models.py
@@ -67,8 +67,8 @@ MODEL_REGISTRY: list[RegisteredModel] = [
     RegisteredModel(benchmark=_STT, provider="speechmatics", model="default", status=_ACTIVE),
     RegisteredModel(benchmark=_STT, provider="speechmatics", model="enhanced", status=_ACTIVE),
     RegisteredModel(benchmark=_STT, provider="gradium", model="default", status=_ACTIVE),
-    RegisteredModel(benchmark=_STT, provider="soniox", model="stt-rt-v4", status=_RETIRED),
-    RegisteredModel(benchmark=_STT, provider="soniox", model="stt-rt-v5", status=_RETIRED),
+    RegisteredModel(benchmark=_STT, provider="soniox", model="stt-rt-v4", status=_ACTIVE),
+    RegisteredModel(benchmark=_STT, provider="soniox", model="stt-rt-v5", status=_ACTIVE),
     RegisteredModel(benchmark=_STT, provider="xai", model="grok-stt", status=_ACTIVE),
     RegisteredModel(benchmark=_STT, provider="smallest", model="pulse", status=_ACTIVE),
     RegisteredModel(benchmark=_STT, provider="cartesia", model="ink-2", status=_ACTIVE),
@@ -166,7 +166,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         status=_ACTIVE,
     ),
     RegisteredModel(
-        benchmark=_TTS, provider="soniox", model="tts-rt-v1", voice="Adrian", status=_RETIRED
+        benchmark=_TTS, provider="soniox", model="tts-rt-v1", voice="Adrian", status=_ACTIVE
     ),
     RegisteredModel(
         benchmark=_TTS, provider="openai", model="gpt-realtime-2025-08-28", status=_RETIRED


### PR DESCRIPTION
Flip the Soniox STT (stt-rt-v4, stt-rt-v5) and TTS (tts-rt-v1) entries from retired to active in the model registry so they're benchmarked and shown on the site.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Soniox STT models `stt-rt-v4` and `stt-rt-v5` are now available.
  * Soniox TTS model `tts-rt-v1` is now available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR activates three previously retired Soniox entries in the model registry — `stt-rt-v4`, `stt-rt-v5` (STT), and `tts-rt-v1` (TTS) — so the orchestrator will benchmark them and the site will display their results.

- The provider implementations (`SonioxSTTProvider`, `SonioxTTSProvider`) were already fully wired into `STT_PROVIDERS` and `TTS_PROVIDERS`, and the `soniox_api_key` was already present in `Settings`; the only thing this PR changes is the three `status=_RETIRED` → `status=_ACTIVE` flags.
- Both models named in the STT registry (`stt-rt-v4`, `stt-rt-v5`) are already in the provider's `_VALID_MODELS` frozenset, and the TTS voice `\"Adrian\"` is already in `_VALID_VOICES`, so no provider-side validation will reject the newly active entries.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is three status flips in the registry for providers that are already fully implemented, registered, and keyed in config.

All supporting infrastructure (provider classes, STT_PROVIDERS/TTS_PROVIDERS dispatch maps, soniox_api_key in Settings) was already present and active before this PR. Both activated STT model strings match the provider's _VALID_MODELS frozenset exactly, and the TTS voice 'Adrian' is in _VALID_VOICES. The duplicate-key guard at the bottom of models.py runs at import time and would catch any accidental duplicate. There are no schema changes, no new code paths, and no configuration gaps introduced by this change.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| runner/src/coval_bench/registries/models.py | Three Soniox registry entries changed from RETIRED to ACTIVE; provider implementations, API key config, and provider dispatch were already in place. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Registry as MODEL_REGISTRY (models.py)
    participant Orchestrator as run_benchmarks()
    participant STT as STT_PROVIDERS["soniox"] (SonioxSTTProvider)
    participant TTS as TTS_PROVIDERS["soniox"] (SonioxTTSProvider)
    participant SonioxSTTWS as wss://stt-rt.soniox.com
    participant SonioxTTSWS as wss://tts-rt.soniox.com

    Orchestrator->>Registry: "filter entries where status == ACTIVE"
    note over Registry: stt-rt-v4 ACTIVE (was RETIRED), stt-rt-v5 ACTIVE (was RETIRED), tts-rt-v1 ACTIVE (was RETIRED)

    Orchestrator->>STT: "SonioxSTTProvider(api_key, model=stt-rt-v4)"
    STT->>SonioxSTTWS: WebSocket connect + send audio
    SonioxSTTWS-->>STT: token stream TTFT WER RTF
    STT-->>Orchestrator: TranscriptionResult

    Orchestrator->>STT: "SonioxSTTProvider(api_key, model=stt-rt-v5)"
    STT->>SonioxSTTWS: WebSocket connect + send audio
    SonioxSTTWS-->>STT: token stream TTFT WER RTF
    STT-->>Orchestrator: TranscriptionResult

    Orchestrator->>TTS: "SonioxTTSProvider(settings, model=tts-rt-v1, voice=Adrian)"
    TTS->>SonioxTTSWS: WebSocket connect + send text
    SonioxTTSWS-->>TTS: base64 PCM chunks TTFA WER
    TTS-->>Orchestrator: TTSResult

    Orchestrator->>Orchestrator: persist results to DB
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Registry as MODEL_REGISTRY (models.py)
    participant Orchestrator as run_benchmarks()
    participant STT as STT_PROVIDERS["soniox"] (SonioxSTTProvider)
    participant TTS as TTS_PROVIDERS["soniox"] (SonioxTTSProvider)
    participant SonioxSTTWS as wss://stt-rt.soniox.com
    participant SonioxTTSWS as wss://tts-rt.soniox.com

    Orchestrator->>Registry: "filter entries where status == ACTIVE"
    note over Registry: stt-rt-v4 ACTIVE (was RETIRED), stt-rt-v5 ACTIVE (was RETIRED), tts-rt-v1 ACTIVE (was RETIRED)

    Orchestrator->>STT: "SonioxSTTProvider(api_key, model=stt-rt-v4)"
    STT->>SonioxSTTWS: WebSocket connect + send audio
    SonioxSTTWS-->>STT: token stream TTFT WER RTF
    STT-->>Orchestrator: TranscriptionResult

    Orchestrator->>STT: "SonioxSTTProvider(api_key, model=stt-rt-v5)"
    STT->>SonioxSTTWS: WebSocket connect + send audio
    SonioxSTTWS-->>STT: token stream TTFT WER RTF
    STT-->>Orchestrator: TranscriptionResult

    Orchestrator->>TTS: "SonioxTTSProvider(settings, model=tts-rt-v1, voice=Adrian)"
    TTS->>SonioxTTSWS: WebSocket connect + send text
    SonioxTTSWS-->>TTS: base64 PCM chunks TTFA WER
    TTS-->>Orchestrator: TTSResult

    Orchestrator->>Orchestrator: persist results to DB
```

</a>

<sub>Reviews (1): Last reviewed commit: ["Activate Soniox models in public benchma..."](https://github.com/coval-ai/benchmarks/commit/f950a82d6e86021ceb3fa31b09642333e4725189) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37957093)</sub>

<!-- /greptile_comment -->