### PR TITLE
Remove OpenAI Realtime from TTS benchmark

### DIFF
--- a/runner/src/coval_bench/providers/tts/openai.py
+++ b/runner/src/coval_bench/providers/tts/openai.py
@@ -1,18 +1,13 @@
 # Copyright 2026 The Coval Benchmarks Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""OpenAI TTS provider — supports HTTP streaming and Realtime WebSocket modes."""
+"""OpenAI TTS provider — HTTP streaming synthesis."""
 
 from __future__ import annotations
 
-import base64
-import json
 import time
-from typing import Any
 
 import structlog
-import websockets
-import websockets.exceptions
 from openai import AsyncOpenAI
 
 from coval_bench.config import Settings
@@ -40,16 +35,15 @@ VALID_VOICES = [
 ]
 
 HTTP_MODELS = {"gpt-4o-mini-tts"}
-REALTIME_MODELS = {"gpt-realtime-2025-08-28"}
 SAMPLE_RATE = 24000
 
 _BASE_URL = "https://api.openai.com"
 
 
 class OpenAITTSProvider(TTSProvider):
-    """OpenAI TTS provider supporting HTTP and Realtime WS paths."""
+    """OpenAI TTS provider over the HTTP streaming speech API."""
 
-    _VALID_MODELS = frozenset(HTTP_MODELS | REALTIME_MODELS)
+    _VALID_MODELS = frozenset(HTTP_MODELS)
 
     def __init__(self, settings: Settings, model: str, voice: str) -> None:
         self._model = model
@@ -87,8 +81,7 @@ class OpenAITTSProvider(TTSProvider):
 
         Transport failures propagate to the caller, which runs warmup under
         ``return_exceptions=True`` and logs them. A 401 still warms the
-        socket, so an unauthenticated HEAD is sufficient. The Realtime WS
-        path is unaffected (it opens its own ws connection).
+        socket, so an unauthenticated HEAD is sufficient.
         """
         client = get_shared_client("openai", _BASE_URL)
         t0 = time.monotonic()
@@ -105,8 +98,6 @@ class OpenAITTSProvider(TTSProvider):
         """Synthesize speech and return a TTSResult."""
         if self._model in HTTP_MODELS:
             return await self._synthesize_http(text)
-        if self._model in REALTIME_MODELS:
-            return await self._synthesize_realtime(text)
         return TTSResult(
             provider="openai",
             model=self._model,
@@ -167,70 +158,4 @@ class OpenAITTSProvider(TTSProvider):
             http_version=http_version,
             submit_to_headers_ms=setup_ms,
             connection_reused=reused,
-        )
-
-    async def _synthesize_realtime(self, text: str) -> TTSResult:
-        audio_chunks: list[bytes] = []
-        start: float | None = None
-        first_chunk_at: float | None = None
-
-        ws_url = f"wss://api.openai.com/v1/realtime?model={self._model}"
-        ws_extra_headers = {
-            "Authorization": f"Bearer {self._api_key}",
-            "OpenAI-Beta": "realtime=v1",
-        }
-
-        create_event: dict[str, Any] = {
-            "type": "response.create",
-            "response": {
-                "modalities": ["audio", "text"],
-                "instructions": f"Speak this text exactly as provided: {text}",
-                "voice": self._voice,
-                "output_audio_format": "pcm16",
-            },
-        }
-
-        try:
-            start = time.monotonic()
-            async with websockets.connect(ws_url, additional_headers=ws_extra_headers) as ws:
-                await ws.send(json.dumps(create_event))
-                while True:
-                    try:
-                        raw = await ws.recv()
-                        event: dict[str, Any] = json.loads(raw)
-                        event_type: str = event.get("type", "")
-
-                        if event_type == "response.audio.delta" and "delta" in event:
-                            audio_data = base64.b64decode(event["delta"])
-                            if len(audio_data) > 0:
-                                if first_chunk_at is None:
-                                    first_chunk_at = time.monotonic()
-                                audio_chunks.append(audio_data)
-
-                        if event_type == "response.done":
-                            break
-
-                    except websockets.exceptions.ConnectionClosed:
-                        break
-        except Exception as exc:
-            logger.debug("openai_realtime_error", exc_info=True)
-            return finalize_tts_result(
-                provider="openai",
-                model=self._model,
-                voice=self._voice,
-                pcm=b"",
-                sample_rate=SAMPLE_RATE,
-                audio_synthesis_start=start,
-                first_audio_chunk_at=first_chunk_at,
-                error=str(exc),
-            )
-
-        return finalize_tts_result(
-            provider="openai",
-            model=self._model,
-            voice=self._voice,
-            pcm=b"".join(audio_chunks),
-            sample_rate=SAMPLE_RATE,
-            audio_synthesis_start=start,
-            first_audio_chunk_at=first_chunk_at,
         )

--- a/runner/src/coval_bench/registries/models.py
+++ b/runner/src/coval_bench/registries/models.py
@@ -168,6 +168,10 @@ MODEL_REGISTRY: list[RegisteredModel] = [
     RegisteredModel(
         benchmark=_TTS, provider="soniox", model="tts-rt-v1", voice="Adrian", status=_RETIRED
     ),
+    # gpt-realtime is a speech-to-speech LLM, not a TTS provider: driving it
+    # from a text "instructions" prompt folds LLM inference into TTFA and never
+    # guarantees verbatim speech, so its metrics are incomparable here. Kept
+    # retired (not deleted) so historical rows stay hidden on the site.
     RegisteredModel(
         benchmark=_TTS, provider="openai", model="gpt-realtime-2025-08-28", status=_RETIRED
     ),

--- a/runner/tests/providers/tts/conftest.py
+++ b/runner/tests/providers/tts/conftest.py
@@ -77,7 +77,7 @@ def sample_text() -> str:
 
 
 # ---------------------------------------------------------------------------
-# FakeWebSocket — reusable for OpenAI realtime, and ElevenLabs WS tests
+# FakeWebSocket — reusable across the WebSocket-based TTS provider tests
 # ---------------------------------------------------------------------------
 
 

--- a/runner/tests/providers/tts/test_openai.py
+++ b/runner/tests/providers/tts/test_openai.py
@@ -1,12 +1,10 @@
 # Copyright 2026 The Coval Benchmarks Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Tests for the OpenAI TTS provider (HTTP + Realtime paths)."""
+"""Tests for the OpenAI TTS provider (HTTP streaming path)."""
 
 from __future__ import annotations
 
-import base64
-import json
 from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -18,7 +16,7 @@ from coval_bench.config import Settings
 from coval_bench.providers import _http_session
 from coval_bench.providers.tts.openai import HTTP_MODELS, VALID_VOICES, OpenAITTSProvider
 
-from .conftest import FakeWebSocket, make_pcm_bytes
+from .conftest import make_pcm_bytes
 
 
 @pytest.fixture(autouse=True)
@@ -37,10 +35,6 @@ def _make_http_provider(
     fake_settings: Settings, model: str = "gpt-4o-mini-tts"
 ) -> OpenAITTSProvider:
     return OpenAITTSProvider(fake_settings, model=model, voice="alloy")
-
-
-def _make_realtime_provider(fake_settings: Settings) -> OpenAITTSProvider:
-    return OpenAITTSProvider(fake_settings, model="gpt-realtime-2025-08-28", voice="alloy")
 
 
 def _make_streaming_response_mock(chunks: list[bytes]) -> MagicMock:
@@ -173,45 +167,6 @@ async def test_openai_unsupported_model(fake_settings: Settings) -> None:
     assert result.error is not None
     assert "Unsupported" in result.error
     assert result.audio_path is None
-
-
-# ---------------------------------------------------------------------------
-# Realtime path — happy path
-# ---------------------------------------------------------------------------
-
-
-def _make_realtime_ws_messages(audio_b64: str) -> list[str]:
-    """Build the sequence of WS messages the realtime API would send."""
-    return [
-        json.dumps({"type": "response.audio.delta", "delta": audio_b64}),
-        json.dumps({"type": "response.done"}),
-    ]
-
-
-@pytest.mark.asyncio
-async def test_openai_realtime_happy_path(fake_settings: Settings) -> None:
-    """Realtime WS synthesize → ttfa set, audio file written."""
-    pcm = make_pcm_bytes(480)
-    audio_b64 = base64.b64encode(pcm).decode()
-    messages = _make_realtime_ws_messages(audio_b64)
-    fake_ws = FakeWebSocket(messages)
-
-    provider = _make_realtime_provider(fake_settings)
-
-    with patch(
-        "coval_bench.providers.tts.openai.websockets.connect",
-        return_value=fake_ws,
-    ):
-        result = await provider.synthesize("Hello realtime")
-
-    assert result.error is None, f"Error: {result.error}"
-    assert result.ttfa_ms is not None
-    assert 0 < result.ttfa_ms < 60_000
-    assert result.audio_path is not None
-    assert result.audio_path.exists()
-    assert result.audio_path.stat().st_size > 0
-
-    result.audio_path.unlink()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
gpt-realtime is a speech-to-speech LLM, not a TTS provider, so its text-prompted TTFA isn't comparable; delete the synthesis path and keep the model retired to hide historical rows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed Realtime WebSocket text-to-speech support from the OpenAI provider; HTTP streaming is now the exclusive available path
  * Simplified model routing for OpenAI TTS

* **Documentation**
  * Updated registry documentation to clarify deprecated model status and data preservation policies

* **Tests**
  * Refocused test coverage on HTTP streaming functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes the `gpt-realtime-2025-08-28` Realtime WebSocket synthesis path from the OpenAI TTS provider, on the grounds that it is a speech-to-speech LLM whose text-prompted TTFA is not comparable to true TTS providers. The model entry is kept in the registry as `_RETIRED` so historical rows remain hidden on the site without being deleted.

- Deletes `_synthesize_realtime`, `REALTIME_MODELS`, and all associated imports (`base64`, `json`, `websockets`) from `openai.py`, narrowing the provider to the HTTP streaming path only.
- Removes the corresponding test (`test_openai_realtime_happy_path`), helper (`_make_realtime_provider`), and now-unused imports from `test_openai.py`; adds a comment in `models.py` explaining the rationale for keeping the entry retired.

<h3>Confidence Score: 5/5</h3>

Safe to merge — removes a dead code path with no impact on active benchmark runs.

The change is a straightforward deletion: the realtime WebSocket synthesis method, its supporting constants, imports, and tests are all removed consistently. The only active OpenAI TTS model (gpt-4o-mini-tts) goes through the HTTP path, which is untouched. The gpt-realtime-2025-08-28 registry entry remains RETIRED, so no historical data is lost and the frontend continues to suppress it. All existing HTTP-path tests still pass.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| runner/src/coval_bench/providers/tts/openai.py | Removes REALTIME_MODELS constant, _synthesize_realtime method, and associated imports; HTTP path is unchanged and all remaining logic is correct. |
| runner/src/coval_bench/registries/models.py | Adds an explanatory comment above the gpt-realtime RETIRED entry; the entry itself is unchanged and the duplicate-key guard still passes. |
| runner/tests/providers/tts/test_openai.py | Realtime test and helper removed cleanly; remaining HTTP tests are intact and cover happy path, error path, warmup, and unsupported model. |
| runner/tests/providers/tts/conftest.py | Only the FakeWebSocket comment is updated; the class itself is unchanged and still used by other WebSocket-based provider tests. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["synthesize(text)"] --> B{model in HTTP_MODELS?}
    B -- Yes --> C["_synthesize_http(text)"]
    B -- No --> D["Return TTSResult with error\n'Unsupported OpenAI model'"]
    C --> E{Exception?}
    E -- No --> F["finalize_tts_result\n(pcm chunks, ttfa, http_version)"]
    E -- Yes --> G["finalize_tts_result\n(empty pcm, error=str(exc))"]

    style D fill:#f9a,stroke:#c66
    style G fill:#f9a,stroke:#c66

    subgraph "REMOVED (this PR)"
        X["_synthesize_realtime(text)\nWebSocket → base64 audio chunks"]
        style X fill:#eee,stroke:#aaa,color:#aaa
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["synthesize(text)"] --> B{model in HTTP_MODELS?}
    B -- Yes --> C["_synthesize_http(text)"]
    B -- No --> D["Return TTSResult with error\n'Unsupported OpenAI model'"]
    C --> E{Exception?}
    E -- No --> F["finalize_tts_result\n(pcm chunks, ttfa, http_version)"]
    E -- Yes --> G["finalize_tts_result\n(empty pcm, error=str(exc))"]

    style D fill:#f9a,stroke:#c66
    style G fill:#f9a,stroke:#c66

    subgraph "REMOVED (this PR)"
        X["_synthesize_realtime(text)\nWebSocket → base64 audio chunks"]
        style X fill:#eee,stroke:#aaa,color:#aaa
    end
```

</a>

<sub>Reviews (1): Last reviewed commit: ["Remove OpenAI Realtime from TTS benchmar..."](https://github.com/coval-ai/benchmarks/commit/21b34e7fbb0ab43ad5cd46735d437fa51af6d803) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37983093)</sub>

<!-- /greptile_comment -->