### PR TITLE
Remove sunset Cartesia sonic-turbo from provider allowlist

### DIFF
--- a/runner/src/coval_bench/providers/tts/cartesia.py
+++ b/runner/src/coval_bench/providers/tts/cartesia.py
@@ -29,7 +29,7 @@ OUTPUT_FORMAT: dict[str, Any] = {
 class CartesiaTTSProvider(TTSProvider):
     """Cartesia TTS provider using WebSocket streaming (cartesia SDK v2)."""
 
-    _VALID_MODELS = frozenset({"sonic-3", "sonic-3.5", "sonic-turbo"})
+    _VALID_MODELS = frozenset({"sonic-3", "sonic-3.5"})
 
     def __init__(self, settings: Settings, model: str, voice: str) -> None:
         self._model = model

--- a/runner/tests/providers/tts/test_cartesia.py
+++ b/runner/tests/providers/tts/test_cartesia.py
@@ -92,12 +92,6 @@ def test_cartesia_name_and_model(fake_settings: Settings) -> None:
     assert p.model == "sonic-3"
 
 
-def test_cartesia_rejects_sunset_sonic_turbo(fake_settings: Settings) -> None:
-    """Cartesia sunset sonic-turbo on 2026-06-01, so the guard must reject it."""
-    p = CartesiaTTSProvider(fake_settings, model="sonic-turbo", voice="voice-id")
-    assert not p._model_supported("sonic-turbo")
-
-
 def test_cartesia_supports_sonic_3_5(fake_settings: Settings) -> None:
     """sonic-3.5 (the public matrix entry) must pass the model-support guard."""
     p = CartesiaTTSProvider(

--- a/runner/tests/providers/tts/test_cartesia.py
+++ b/runner/tests/providers/tts/test_cartesia.py
@@ -87,9 +87,15 @@ async def test_cartesia_no_audio_chunks(fake_settings: Settings) -> None:
 
 
 def test_cartesia_name_and_model(fake_settings: Settings) -> None:
+    p = CartesiaTTSProvider(fake_settings, model="sonic-3", voice="voice-id")
+    assert p.name == "cartesia-sonic-3"
+    assert p.model == "sonic-3"
+
+
+def test_cartesia_rejects_sunset_sonic_turbo(fake_settings: Settings) -> None:
+    """Cartesia sunset sonic-turbo on 2026-06-01, so the guard must reject it."""
     p = CartesiaTTSProvider(fake_settings, model="sonic-turbo", voice="voice-id")
-    assert p.name == "cartesia-sonic-turbo"
-    assert p.model == "sonic-turbo"
+    assert not p._model_supported("sonic-turbo")
 
 
 def test_cartesia_supports_sonic_3_5(fake_settings: Settings) -> None:


### PR DESCRIPTION
Cartesia sunset sonic-turbo on 2026-06-01; it was never in the run set, so this just drops the stale allowlist entry and points its test at a live model.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed support for the Cartesia “sonic-turbo” model; only “sonic-3” and “sonic-3.5” are now supported. Attempts to use “sonic-turbo” now return an unsupported model error.
  * Updated the Cartesia provider test expectations to align with the supported model set.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removes the sunset `sonic-turbo` model from Cartesia's `_VALID_MODELS` allowlist and updates the property test to use a live model (`sonic-3`). The change is purely a housekeeping cleanup with no behavioral impact on the run set.

- **`cartesia.py`**: `_VALID_MODELS` shrinks from three to two entries (`sonic-3`, `sonic-3.5`); calls with `sonic-turbo` will now return a `TTSResult` with an unsupported-model error instead of proceeding.
- **`test_cartesia.py`**: `test_cartesia_name_and_model` is retargeted from `sonic-turbo` to `sonic-3` so it exercises a live, supported model; all other tests were already using `sonic-3`/`sonic-3.5`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — a one-line allowlist removal with a matching test update, no logic changes.

The diff is minimal and self-contained: one entry dropped from a frozenset and one test redirected to a live model. The unsupported-model code path already existed and is exercised by the broader test suite; there is no new error handling to verify. No callers outside the provider are touched.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| runner/src/coval_bench/providers/tts/cartesia.py | Removes `sonic-turbo` from `_VALID_MODELS`; only `sonic-3` and `sonic-3.5` remain. One-line change with no logic impact. |
| runner/tests/providers/tts/test_cartesia.py | Updates `test_cartesia_name_and_model` to use `sonic-3` instead of the removed `sonic-turbo`. No new test for the rejection path of `sonic-turbo`. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[CartesiaTTSProvider.synthesize] --> B{_model_supported?}
    B -- "sonic-3 ✓\nsonic-3.5 ✓" --> C[Call Cartesia WebSocket API]
    B -- "sonic-turbo ✗\n(removed)" --> D[Return TTSResult with error]
    C --> E[Stream audio chunks]
    E --> F[finalize_tts_result → WAV file]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[CartesiaTTSProvider.synthesize] --> B{_model_supported?}
    B -- "sonic-3 ✓\nsonic-3.5 ✓" --> C[Call Cartesia WebSocket API]
    B -- "sonic-turbo ✗\n(removed)" --> D[Return TTSResult with error]
    C --> E[Stream audio chunks]
    E --> F[finalize_tts_result → WAV file]
```

</a>

<sub>Reviews (1): Last reviewed commit: ["Update test\_cartesia.py"](https://github.com/coval-ai/benchmarks/commit/4f4ae8da15b211814aa0b14e6c432381ed8b7711) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37985940)</sub>

<!-- /greptile_comment -->