### PR TITLE
Retire ElevenLabs eleven_turbo_v2_5

### DIFF
--- a/runner/src/coval_bench/registries/models.py
+++ b/runner/src/coval_bench/registries/models.py
@@ -81,14 +81,14 @@ MODEL_REGISTRY: list[RegisteredModel] = [
     #######
     RegisteredModel(
         benchmark=_TTS,
-        provider="abs",
+        provider="elevenlabs",
         model="eleven_flash_v2_5",
         voice="IKne3meq5aSn9XLyUdCD",
         status=_ACTIVE,
     ),
     RegisteredModel(
         benchmark=_TTS,
-        provider="abs",
+        provider="elevenlabs",
         model="eleven_multilingual_v2",
         voice="IKne3meq5aSn9XLyUdCD",
         status=_ACTIVE,

--- a/runner/src/coval_bench/registries/models.py
+++ b/runner/src/coval_bench/registries/models.py
@@ -81,21 +81,18 @@ MODEL_REGISTRY: list[RegisteredModel] = [
     #######
     RegisteredModel(
         benchmark=_TTS,
-        provider="elevenlabs",
+        provider="abs",
         model="eleven_flash_v2_5",
         voice="IKne3meq5aSn9XLyUdCD",
         status=_ACTIVE,
     ),
     RegisteredModel(
         benchmark=_TTS,
-        provider="elevenlabs",
+        provider="abs",
         model="eleven_multilingual_v2",
         voice="IKne3meq5aSn9XLyUdCD",
         status=_ACTIVE,
     ),
-    # Deprecated by ElevenLabs ("outclassed by Flash models"); the replacement
-    # eleven_flash_v2_5 is already benchmarked above. Retired, not deleted, so
-    # historical rows stay hidden on the site.
     RegisteredModel(
         benchmark=_TTS,
         provider="elevenlabs",

--- a/runner/src/coval_bench/registries/models.py
+++ b/runner/src/coval_bench/registries/models.py
@@ -93,12 +93,15 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         voice="IKne3meq5aSn9XLyUdCD",
         status=_ACTIVE,
     ),
+    # Deprecated by ElevenLabs ("outclassed by Flash models"); the replacement
+    # eleven_flash_v2_5 is already benchmarked above. Retired, not deleted, so
+    # historical rows stay hidden on the site.
     RegisteredModel(
         benchmark=_TTS,
         provider="elevenlabs",
         model="eleven_turbo_v2_5",
         voice="IKne3meq5aSn9XLyUdCD",
-        status=_ACTIVE,
+        status=_RETIRED,
     ),
     RegisteredModel(
         benchmark=_TTS, provider="openai", model="gpt-4o-mini-tts", voice="alloy", status=_ACTIVE


### PR DESCRIPTION
Deprecated by ElevenLabs in favor of eleven_flash_v2_5, which we already benchmark; flip its registry status to retired so it stops benchmarking and stays off the site while historical rows remain hidden.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Retired the elevenlabs/eleven_turbo_v2_5 text-to-speech model and removed it from available options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Retires the `eleven_turbo_v2_5` ElevenLabs TTS model by flipping its registry status from `_ACTIVE` to `_RETIRED`, stopping benchmarks from running against it and hiding historical result rows on the frontend.

- The replacement model `eleven_flash_v2_5` is already present in the registry with `_ACTIVE` status, so coverage is uninterrupted.
- The `RETIRED` semantics are clearly documented in the module docstring and `ModelStatus` enum: the model stops being benchmarked and the site hides it even when historical data exists.

<h3>Confidence Score: 5/5</h3>

This is a minimal, well-scoped registry change — safe to merge as-is.

The change is a single field value update in a data registry. The target model (eleven_turbo_v2_5) is being retired in favour of eleven_flash_v2_5, which is already present and active in the same registry. The RETIRED status is well-defined in both the enum and the module docstring. No logic, API contracts, or other entries are touched.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| runner/src/coval_bench/registries/models.py | Single-line status change from `_ACTIVE` to `_RETIRED` for the `eleven_turbo_v2_5` entry; no structural changes, no logic affected. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[MODEL_REGISTRY] --> B[eleven_flash_v2_5\nstatus: ACTIVE]
    A --> C[eleven_turbo_v2_5\nstatus: RETIRED ← was ACTIVE]
    A --> D[eleven_multilingual_v2\nstatus: ACTIVE]

    B --> E[Orchestrator runs benchmark]
    D --> E
    C --> F[Benchmarks skipped]
    C --> G[Historical rows hidden on site]

    style C fill:#f66,color:#fff
    style B fill:#6a6,color:#fff
    style D fill:#6a6,color:#fff
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[MODEL_REGISTRY] --> B[eleven_flash_v2_5\nstatus: ACTIVE]
    A --> C[eleven_turbo_v2_5\nstatus: RETIRED ← was ACTIVE]
    A --> D[eleven_multilingual_v2\nstatus: ACTIVE]

    B --> E[Orchestrator runs benchmark]
    D --> E
    C --> F[Benchmarks skipped]
    C --> G[Historical rows hidden on site]

    style C fill:#f66,color:#fff
    style B fill:#6a6,color:#fff
    style D fill:#6a6,color:#fff
```

</a>

<sub>Reviews (1): Last reviewed commit: ["Fix accidental abs provider on ElevenLab..."](https://github.com/coval-ai/benchmarks/commit/321f42ab42859d34ffaafc7c23fe35e1dc8d73ca) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37995616)</sub>

<!-- /greptile_comment -->