### PR TITLE
Remove ElevenLabs scribe_v1 from STT model allowlist

### DIFF
--- a/runner/src/coval_bench/providers/stt/elevenlabs.py
+++ b/runner/src/coval_bench/providers/stt/elevenlabs.py
@@ -60,7 +60,7 @@ _ERROR_MSG_TYPES = frozenset(
 class ElevenLabsSTTProvider(STTProvider):
     """ElevenLabs real-time STT provider."""
 
-    _VALID_MODELS = frozenset({"scribe_v1", "scribe_v2_realtime"})
+    _VALID_MODELS = frozenset({"scribe_v2_realtime"})
 
     def __init__(self, api_key: SecretStr, model: str = "scribe_v2_realtime") -> None:
         if not self._model_supported(model):


### PR DESCRIPTION
ElevenLabs deprecates scribe_v1 on 2026-07-09; drop it from the provider's valid-models set.