### PR TITLE
Sample a random dataset subset per benchmark run

### DIFF
--- a/docs/methodology.md
+++ b/docs/methodology.md
@@ -17,6 +17,15 @@ download.
 **TTS benchmark.** A 30-prompt set of short text inputs. Source and selection
 rule are documented in `runner/src/coval_bench/datasets/manifests/tts-v1.json`.
 
+**Per-run sampling.** Each scheduled run draws a random sample of
+`dataset_sample_size` items (default 10) from each manifest before any provider
+is called; the STT and TTS pools are sampled independently. The sample is drawn
+once at the start of the run and shared across every model, so all models are
+scored on the identical subset within a run (parity); the draw is independent
+across runs, so the full manifest is covered over time. The manifests still
+carry the complete 50 / 30 items — sampling only controls how many run each
+cycle. Set `DATASET_SAMPLE_SIZE` ≥ the manifest size to run everything.
+
 **SHA pinning.** Every audio file referenced by `stt-v1.json` carries a
 `sha256` field. The runner verifies the SHA after fetching from GCS and raises
 `DatasetIntegrityError` on mismatch (see `runner/src/coval_bench/datasets/loader.py`).

--- a/runner/src/coval_bench/config.py
+++ b/runner/src/coval_bench/config.py
@@ -45,6 +45,10 @@ class Settings(BaseSettings):
     dataset_bucket: str = "coval-benchmarks-datasets"
     dataset_id: str = "stt-v1"
 
+    # Items drawn at random per run from each manifest, shared across all
+    # models for parity. Set >= manifest size to run everything.
+    dataset_sample_size: int = 10
+
     # --- Runner ---
     runner_sha: str = "dev"
     log_level: Literal["DEBUG", "INFO", "WARNING", "ERROR"] = "INFO"

--- a/runner/src/coval_bench/datasets/loader.py
+++ b/runner/src/coval_bench/datasets/loader.py
@@ -38,6 +38,7 @@ from __future__ import annotations
 import hashlib
 import logging
 import os
+import random
 from importlib.resources import files
 from pathlib import Path
 
@@ -153,6 +154,14 @@ def _default_cache_dir() -> Path:
         return fallback
 
 
+def _sample_items[T](items: list[T], sample_size: int | None, rng: random.Random | None) -> list[T]:
+    """Return a random subset of *items*, or *items* unchanged if it already fits."""
+    if sample_size is None or sample_size >= len(items):
+        return items
+    sampler = rng if rng is not None else random.Random()  # noqa: S311
+    return sampler.sample(items, sample_size)
+
+
 def _load_manifest(dataset_id: str) -> Manifest:
     """Load and validate the packaged manifest for *dataset_id*."""
     manifest_text = (
@@ -238,6 +247,8 @@ def load_stt_dataset(
     settings: Settings,
     cache_dir: Path | None = None,
     storage_client: storage.Client | None = None,
+    sample_size: int | None = None,
+    rng: random.Random | None = None,
 ) -> Dataset:
     """Load an STT dataset from the packaged manifest + GCS.
 
@@ -251,6 +262,10 @@ def load_stt_dataset(
         Override the local file cache directory.
     storage_client:
         Injectable GCS client (for tests; production passes ``None``).
+    sample_size:
+        Draw this many items at random (before fetch); ``None`` uses all.
+    rng:
+        Random source; a fresh one is used when ``None``.
 
     Returns
     -------
@@ -262,7 +277,7 @@ def load_stt_dataset(
     client = storage_client if storage_client is not None else _make_storage_client(settings)
 
     items: list[DatasetItem] = []
-    for raw_item in manifest.items:
+    for raw_item in _sample_items(list(manifest.items), sample_size, rng):
         if not isinstance(raw_item, STTManifestItem):
             raise TypeError(
                 f"Dataset '{dataset_id}' contains non-STT items; use load_tts_dataset instead."
@@ -301,6 +316,8 @@ def load_tts_dataset(
     settings: Settings,  # noqa: ARG001 – kept for uniform call signature
     cache_dir: Path | None = None,  # noqa: ARG001 – no files to cache for TTS
     storage_client: storage.Client | None = None,  # noqa: ARG001 – no GCS needed
+    sample_size: int | None = None,
+    rng: random.Random | None = None,
 ) -> TTSDataset:
     """Load a TTS dataset (text prompts only; no GCS fetch required).
 
@@ -314,6 +331,10 @@ def load_tts_dataset(
         Accepted for call-signature symmetry; not used for TTS.
     storage_client:
         Accepted for call-signature symmetry; not used for TTS.
+    sample_size:
+        Draw this many prompts at random; ``None`` uses all.
+    rng:
+        Random source; a fresh one is used when ``None``.
 
     Returns
     -------
@@ -323,7 +344,7 @@ def load_tts_dataset(
     manifest = _load_manifest(dataset_id)
 
     tts_items: list[TTSDatasetItem] = []
-    for raw_item in manifest.items:
+    for raw_item in _sample_items(list(manifest.items), sample_size, rng):
         if not isinstance(raw_item, TTSManifestItem):
             raise TypeError(
                 f"Dataset '{dataset_id}' contains non-TTS items; use load_stt_dataset instead."
@@ -344,6 +365,8 @@ def load_dataset(
     settings: Settings,
     cache_dir: Path | None = None,
     storage_client: storage.Client | None = None,
+    sample_size: int | None = None,
+    rng: random.Random | None = None,
 ) -> Dataset | TTSDataset:
     """Dispatcher: load STT or TTS dataset based on manifest content.
 
@@ -357,10 +380,14 @@ def load_dataset(
             settings=settings,
             cache_dir=cache_dir,
             storage_client=storage_client,
+            sample_size=sample_size,
+            rng=rng,
         )
     return load_tts_dataset(
         dataset_id,
         settings=settings,
         cache_dir=cache_dir,
         storage_client=storage_client,
+        sample_size=sample_size,
+        rng=rng,
     )

--- a/runner/src/coval_bench/runner/orchestrator.py
+++ b/runner/src/coval_bench/runner/orchestrator.py
@@ -842,8 +842,13 @@ async def run_benchmarks(
             # 3. STT path
             # ------------------------------------------------------------------
             if benchmark_kind in ("stt", "both") and enabled_stt:
-                stt_dataset = load_dataset("stt-v1", settings=settings)
+                stt_dataset = load_dataset(
+                    "stt-v1",
+                    settings=settings,
+                    sample_size=None if smoke else settings.dataset_sample_size,
+                )
                 items = stt_dataset.items[:1] if smoke else stt_dataset.items
+                _log.info("stt dataset sampled", run_id=run_id, item_count=len(items))
 
                 stt_tasks = [
                     _run_stt_item(
@@ -869,8 +874,13 @@ async def run_benchmarks(
             # 4. TTS path
             # ------------------------------------------------------------------
             if benchmark_kind in ("tts", "both") and enabled_tts:
-                tts_dataset = load_dataset("tts-v1", settings=settings)
+                tts_dataset = load_dataset(
+                    "tts-v1",
+                    settings=settings,
+                    sample_size=None if smoke else settings.dataset_sample_size,
+                )
                 tts_items = tts_dataset.items[:1] if smoke else tts_dataset.items
+                _log.info("tts dataset sampled", run_id=run_id, item_count=len(tts_items))
 
                 tts_tasks = [
                     _run_tts_item(

--- a/runner/tests/unit/test_dataset_loader.py
+++ b/runner/tests/unit/test_dataset_loader.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import random
 import shutil
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -43,7 +44,7 @@ from coval_bench.datasets.loader import (
     load_stt_dataset,
     load_tts_dataset,
 )
-from coval_bench.datasets.manifest import Manifest
+from coval_bench.datasets.manifest import Manifest, STTManifestItem, TTSManifestItem
 
 # ---------------------------------------------------------------------------
 # Fixtures directory helpers
@@ -518,3 +519,154 @@ def test_default_cache_dir_xdg(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) 
     result = _default_cache_dir()
     assert result == tmp_path / "coval-bench"
     assert result.is_dir()
+
+
+# ---------------------------------------------------------------------------
+# Random sampling (sample_size / rng)
+# ---------------------------------------------------------------------------
+
+
+def _always_fixture_client() -> MagicMock:
+    """Fake GCS client whose download always writes the fixture WAV."""
+
+    def make_blob(name: str) -> MagicMock:
+        blob = MagicMock()
+        blob.name = name
+        blob.download_to_filename.side_effect = lambda dest, **_k: shutil.copy(
+            str(FIXTURE_WAV), dest
+        )
+        return blob
+
+    bucket_mock = MagicMock()
+    bucket_mock.blob.side_effect = make_blob
+    client_mock = MagicMock()
+    client_mock.bucket.return_value = bucket_mock
+    return client_mock
+
+
+def _stt_manifest(n: int) -> Manifest:
+    """An n-item STT manifest; every item points at a distinct verified path."""
+    return Manifest(
+        id="stt-v1",
+        version="1.0.0",
+        license="CC-BY-4.0",
+        source="test",
+        items=[
+            STTManifestItem(
+                path=f"audio/{i:04d}.wav",
+                sha256=FIXTURE_SHA256,
+                transcript=f"utterance {i}",
+                duration_sec=1.0,
+            )
+            for i in range(n)
+        ],
+    )
+
+
+def _tts_manifest(n: int) -> Manifest:
+    return Manifest(
+        id="tts-v1",
+        version="1.0.0",
+        license="proprietary",
+        source="test",
+        items=[TTSManifestItem(testcase_id=f"TC{i:03d}", transcript=f"line {i}") for i in range(n)],
+    )
+
+
+def test_stt_sample_size_limits_and_fetches_only_sample(
+    test_settings: Settings, tmp_path: Path
+) -> None:
+    """sample_size caps the item count and only the sampled files are fetched."""
+    client = _always_fixture_client()
+
+    with patch("coval_bench.datasets.loader._load_manifest", return_value=_stt_manifest(10)):
+        dataset = load_stt_dataset(
+            "stt-v1",
+            settings=test_settings,
+            cache_dir=tmp_path,
+            storage_client=client,
+            sample_size=3,
+            rng=random.Random(0),
+        )
+
+    assert len(dataset.items) == 3
+    assert client.bucket.return_value.blob.call_count == 3  # only the sample is fetched
+
+
+def test_stt_sample_is_reproducible_with_seed(test_settings: Settings, tmp_path: Path) -> None:
+    """Same seed → identical selection, so every model in a run sees one subset."""
+    manifest = _stt_manifest(12)
+
+    def _load(seed: int, cache: Path) -> list[str]:
+        with patch("coval_bench.datasets.loader._load_manifest", return_value=manifest):
+            ds = load_stt_dataset(
+                "stt-v1",
+                settings=test_settings,
+                cache_dir=cache,
+                storage_client=_always_fixture_client(),
+                sample_size=4,
+                rng=random.Random(seed),
+            )
+        return [item.transcript for item in ds.items]
+
+    assert _load(123, tmp_path / "a") == _load(123, tmp_path / "b")
+
+
+def test_stt_sample_size_none_uses_full_manifest(test_settings: Settings, tmp_path: Path) -> None:
+    """Default (sample_size=None) loads the whole manifest — back-compat."""
+    with patch("coval_bench.datasets.loader._load_manifest", return_value=_stt_manifest(5)):
+        dataset = load_stt_dataset(
+            "stt-v1",
+            settings=test_settings,
+            cache_dir=tmp_path,
+            storage_client=_always_fixture_client(),
+        )
+    assert len(dataset.items) == 5
+
+
+def test_stt_sample_size_exceeding_manifest_returns_all(
+    test_settings: Settings, tmp_path: Path
+) -> None:
+    """A sample_size larger than the manifest just returns every item."""
+    with patch("coval_bench.datasets.loader._load_manifest", return_value=_stt_manifest(5)):
+        dataset = load_stt_dataset(
+            "stt-v1",
+            settings=test_settings,
+            cache_dir=tmp_path,
+            storage_client=_always_fixture_client(),
+            sample_size=100,
+            rng=random.Random(0),
+        )
+    assert len(dataset.items) == 5
+
+
+def test_tts_sample_size_limits_and_reproducible(test_settings: Settings) -> None:
+    """TTS sampling caps the prompt count and is reproducible under a fixed seed."""
+    manifest = _tts_manifest(8)
+
+    with patch("coval_bench.datasets.loader._load_manifest", return_value=manifest):
+        first = load_tts_dataset(
+            "tts-v1", settings=test_settings, sample_size=3, rng=random.Random(7)
+        )
+        second = load_tts_dataset(
+            "tts-v1", settings=test_settings, sample_size=3, rng=random.Random(7)
+        )
+        full = load_tts_dataset("tts-v1", settings=test_settings)
+
+    assert len(first.items) == 3
+    assert [i.testcase_id for i in first.items] == [i.testcase_id for i in second.items]
+    assert len(full.items) == 8
+
+
+def test_load_dataset_dispatcher_threads_sample_size(test_settings: Settings) -> None:
+    """The load_dataset dispatcher forwards sample_size/rng to the TTS loader."""
+    from coval_bench.datasets.loader import load_dataset
+
+    with patch("coval_bench.datasets.loader._load_manifest", return_value=_tts_manifest(6)):
+        result = load_dataset(
+            "tts-v1",
+            settings=test_settings,
+            sample_size=2,
+            rng=random.Random(1),
+        )
+    assert len(result.items) == 2

--- a/runner/tests/unit/test_orchestrator.py
+++ b/runner/tests/unit/test_orchestrator.py
@@ -195,7 +195,7 @@ async def _orchestrator_env(  # noqa: ANN202
     tts_dataset = MagicMock()
     tts_dataset.items = tts_items
 
-    def _load_dataset(dataset_id: str, *, settings: Any) -> Any:
+    def _load_dataset(dataset_id: str, *, settings: Any, sample_size: int | None = None) -> Any:
         return stt_dataset if dataset_id == "stt-v1" else tts_dataset
 
     fake_pool = MagicMock()
@@ -636,7 +636,7 @@ async def test_dataset_integrity_failure(settings: Settings) -> None:
     class DatasetIntegrityError(Exception):
         pass
 
-    def _bad_load(dataset_id: str, *, settings: Any) -> Any:
+    def _bad_load(dataset_id: str, *, settings: Any, sample_size: int | None = None) -> Any:
         raise DatasetIntegrityError("hash mismatch: expected abc actual def")
 
     run = _make_run()
@@ -729,7 +729,7 @@ async def test_audio_file_cleanup(settings: Settings) -> None:
         tts_dataset = MagicMock()
         tts_dataset.items = [tts_item]
 
-        def _load(dataset_id: str, *, settings: Any) -> Any:
+        def _load(dataset_id: str, *, settings: Any, sample_size: int | None = None) -> Any:
             return tts_dataset
 
         fake_pool = MagicMock()
@@ -822,7 +822,7 @@ async def test_tts_http1_downgrade_fails_ttfa_row(settings: Settings) -> None:
         tts_dataset = MagicMock()
         tts_dataset.items = [_make_tts_item("hello world")]
 
-        def _load(dataset_id: str, *, settings: Any) -> Any:
+        def _load(dataset_id: str, *, settings: Any, sample_size: int | None = None) -> Any:
             return tts_dataset
 
         fake_pool = MagicMock()
@@ -923,7 +923,7 @@ async def test_tts_cold_connection_fails_ttfa_row(settings: Settings) -> None:
         tts_dataset = MagicMock()
         tts_dataset.items = [_make_tts_item("hello world")]
 
-        def _load(dataset_id: str, *, settings: Any) -> Any:
+        def _load(dataset_id: str, *, settings: Any, sample_size: int | None = None) -> Any:
             return tts_dataset
 
         fake_pool = MagicMock()
@@ -1125,6 +1125,93 @@ async def test_disabled_providers_skipped(audio_file: Path, settings: Settings) 
 
     disabled_cls.assert_not_called()
     provider_cls.assert_called()
+
+
+# ---------------------------------------------------------------------------
+# 11b. dataset sampling — one shared sample per run (parity), smoke opts out
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_samples_dataset_once_with_configured_size(
+    audio_file: Path, settings: Settings
+) -> None:
+    """A real run loads the dataset once with dataset_sample_size — one shared sample."""
+    provider = MagicMock()
+    provider.measure_ttft = AsyncMock(return_value=_good_transcription())
+    matrix = [
+        _stt_entry("deepgram", "nova-2"),
+        _stt_entry("elevenlabs", "scribe_v2_realtime"),
+    ]
+    sized = settings.model_copy(update={"dataset_sample_size": 7})
+
+    items = [_make_dataset_item(audio_file, f"item {i}") for i in range(7)]
+    captured: list[int | None] = []
+
+    stt_dataset = MagicMock()
+    stt_dataset.items = items
+
+    def _load(dataset_id: str, *, settings: Any, sample_size: int | None = None) -> Any:
+        captured.append(sample_size)
+        return stt_dataset
+
+    run = _make_run()
+    writer = _make_stub_writer(run)
+
+    async with _orchestrator_env(
+        audio_path=audio_file,
+        stt_items=items,
+        stt_providers={
+            "deepgram": MagicMock(return_value=provider),
+            "elevenlabs": MagicMock(return_value=provider),
+        },
+        run=run,
+        writer=writer,
+    ):
+        with patch("coval_bench.runner.orchestrator._get_load_dataset", return_value=_load):
+            await run_benchmarks(
+                settings=sized,
+                benchmark_kind="stt",
+                smoke=False,
+                matrix_overrides=matrix,
+            )
+
+    assert captured == [7]
+
+
+@pytest.mark.asyncio
+async def test_smoke_run_skips_sampling(audio_file: Path, settings: Settings) -> None:
+    """Smoke mode bypasses sampling (sample_size=None) so local dev is deterministic."""
+    provider = MagicMock()
+    provider.measure_ttft = AsyncMock(return_value=_good_transcription())
+    captured: list[int | None] = []
+
+    stt_dataset = MagicMock()
+    stt_dataset.items = [_make_dataset_item(audio_file, "only")]
+
+    def _load(dataset_id: str, *, settings: Any, sample_size: int | None = None) -> Any:
+        captured.append(sample_size)
+        return stt_dataset
+
+    run = _make_run()
+    writer = _make_stub_writer(run)
+
+    async with _orchestrator_env(
+        audio_path=audio_file,
+        stt_items=stt_dataset.items,
+        stt_providers={"deepgram": MagicMock(return_value=provider)},
+        run=run,
+        writer=writer,
+    ):
+        with patch("coval_bench.runner.orchestrator._get_load_dataset", return_value=_load):
+            await run_benchmarks(
+                settings=settings,
+                benchmark_kind="stt",
+                smoke=True,
+                matrix_overrides=[_stt_entry("deepgram", "nova-2")],
+            )
+
+    assert captured == [None]
 
 
 # ---------------------------------------------------------------------------
@@ -1799,7 +1886,7 @@ async def test_posthog_failed_event(settings: Settings) -> None:
     class _DatasetIntegrityError(Exception):
         pass
 
-    def _bad_load(dataset_id: str, *, settings: Any) -> Any:
+    def _bad_load(dataset_id: str, *, settings: Any, sample_size: int | None = None) -> Any:
         raise _DatasetIntegrityError("hash mismatch")
 
     deepgram_cls = MagicMock()


### PR DESCRIPTION
I went a bit crazy adding models and now it takes longer than 30min to benchmark all our models. That's an issue as we run our benchmarks every 30min. 

This is a hot patch that runs our benchmarks on a subset of 10 samples for each benchmark. This should free up a ton of time as normally we run 30 samples for TTS and 50 samples for STT.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable dataset sampling with `dataset_sample_size` setting (default: 10 items per run). Samples are drawn once per run and shared across all models for consistency. Smoke runs bypass sampling.

* **Documentation**
  * Added explanation of per-run sampling behavior and manifest handling.

* **Tests**
  * Added comprehensive test coverage for dataset sampling functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->