### PR TITLE
Credit the fastest model on the median latency card

### DIFF
--- a/web/hooks/useDashboardState.tsx
+++ b/web/hooks/useDashboardState.tsx
@@ -215,6 +215,24 @@ export function useDashboardState(page: "tts" | "stt") {
     [getMedianLatencyMs, activeMetric]
   );
 
+  // The fastest selected model (lowest p50) for the active latency metric.
+  // Surfaced as the primary card's subtitle so the median headline still
+  // credits a leader, mirroring the lowest-WER pick below.
+  const fastestPrimary = useMemo(() => {
+    let lowestP50 = Infinity;
+    let fastestModel = "";
+    let fastestProvider = "";
+    deferredSelectedModels.forEach((model) => {
+      const stat = getStat(model, activeMetric);
+      if (stat && typeof stat.p50 === "number" && stat.p50 < lowestP50) {
+        lowestP50 = stat.p50;
+        fastestModel = model;
+        fastestProvider = parseModelKey(model).provider;
+      }
+    });
+    return { fastestModel, fastestProvider };
+  }, [getStat, deferredSelectedModels, activeMetric]);
+
   const keyMetrics = useMemo(() => {
     let lowestSecondary = Infinity;
     let lowestWERModel = "";
@@ -298,6 +316,15 @@ export function useDashboardState(page: "tts" | "stt") {
     return {
       label: `Median ${latencyFullLabel}`,
       displayValue: `${medianPrimary.toFixed(0)} ms`,
+      subtitle:
+        selectedModels.length > 1 && fastestPrimary.fastestModel
+          ? {
+              name: normalizeModelName(fastestPrimary.fastestModel),
+              detail: fastestPrimary.fastestProvider
+                ? normalizeProviderName(fastestPrimary.fastestProvider)
+                : undefined,
+            }
+          : undefined,
     };
   })();
 

--- a/web/hooks/useDashboardState.tsx
+++ b/web/hooks/useDashboardState.tsx
@@ -215,9 +215,6 @@ export function useDashboardState(page: "tts" | "stt") {
     [getMedianLatencyMs, activeMetric]
   );
 
-  // The fastest selected model (lowest p50) for the active latency metric.
-  // Surfaced as the primary card's subtitle so the median headline still
-  // credits a leader, mirroring the lowest-WER pick below.
   const fastestPrimary = useMemo(() => {
     let lowestP50 = Infinity;
     let fastestModel = "";
@@ -317,7 +314,7 @@ export function useDashboardState(page: "tts" | "stt") {
       label: `Median ${latencyFullLabel}`,
       displayValue: `${medianPrimary.toFixed(0)} ms`,
       subtitle:
-        selectedModels.length > 1 && fastestPrimary.fastestModel
+        deferredSelectedModels.length > 1 && fastestPrimary.fastestModel
           ? {
               name: normalizeModelName(fastestPrimary.fastestModel),
               detail: fastestPrimary.fastestProvider
@@ -329,10 +326,10 @@ export function useDashboardState(page: "tts" | "stt") {
   })();
 
   const secondaryKeyMetric = {
-    label: `${selectedModels.length > 1 ? "Lowest" : "Average"} Word Error Rate`,
+    label: `${deferredSelectedModels.length > 1 ? "Lowest" : "Average"} Word Error Rate`,
     displayValue: `${avgSecondary.toFixed(1)}%`,
     subtitle:
-      selectedModels.length > 1 && lowestWERModel
+      deferredSelectedModels.length > 1 && lowestWERModel
         ? {
             name: normalizeModelName(lowestWERModel),
             detail: lowestWERProvider


### PR DESCRIPTION
The TTS/STT primary card now names the lowest-p50 model as its subtitle when more than one model is selected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * When comparing multiple models, the dashboard now selects and highlights the fastest primary option based on latency performance (using the active latency metric). The primary card’s subtitle updates to reflect the fastest model/provider selection. If you’re not in a multi-model comparison view, the subtitle behavior remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->