### PR TITLE
Add Voice Arena rating engine (Davidson-BT)

### DIFF
--- a/runner/src/coval_bench/arena/__init__.py
+++ b/runner/src/coval_bench/arena/__init__.py
@@ -1,0 +1,21 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+"""Voice Arena rating engine and supporting pure functions."""
+
+from coval_bench.arena.rating import (
+    METHODOLOGY_VERSION,
+    BattleOutcome,
+    ModelRating,
+    RatingResult,
+    classify_status,
+    compute_ratings,
+)
+
+__all__ = [
+    "METHODOLOGY_VERSION",
+    "BattleOutcome",
+    "ModelRating",
+    "RatingResult",
+    "classify_status",
+    "compute_ratings",
+]

--- a/runner/src/coval_bench/arena/rating.py
+++ b/runner/src/coval_bench/arena/rating.py
@@ -160,6 +160,8 @@ def _aggregate(outcomes: Sequence[BattleOutcome]) -> _Aggregate:
     # Map an unordered pair (lo, hi) -> [wins_lo_over_hi, wins_hi_over_lo, ties].
     pairs: dict[tuple[int, int], list[float]] = {}
     for o in outcomes:
+        if o.model_a == o.model_b:
+            continue
         a, b = index[o.model_a], index[o.model_b]
         lo, hi = (a, b) if a < b else (b, a)
         cell = pairs.setdefault((lo, hi), [0.0, 0.0, 0.0])
@@ -313,7 +315,7 @@ def _bootstrap(
     ci_high = np.full(n, np.nan, dtype=np.float64)
     for k in range(n):
         vals = np.array(samples[k], dtype=np.float64)
-        if vals.size == 0:
+        if vals.size < 2:
             continue
         ci_low[k] = float(np.percentile(vals, 2.5))
         ci_high[k] = float(np.percentile(vals, 97.5))
@@ -360,7 +362,20 @@ def compute_ratings(
     Returns one :class:`ModelRating` per model seen, sorted by Elo descending.
     ``bootstrap_rounds`` controls CI precision/cost; ``seed`` makes the bootstrap
     reproducible; ``reg`` is the L2 ridge on theta.
+
+    Limitation — disconnected comparison graph: if some models never share a
+    direct or transitive matchup, their relative Elo is not identified by the
+    data. The ridge keeps the fit finite and converging, but pins each component
+    near 0, so cross-component ordering is arbitrary; ranks within a connected
+    component stay valid, and the wide bootstrap CIs on poorly-connected models
+    flag the low confidence. The intended remedy is upstream adaptive pairing
+    (steer new battles to bridge components), not a hard failure here.
     """
+    if bootstrap_rounds < 0:
+        raise ValueError("bootstrap_rounds must be >= 0")
+    if not math.isfinite(reg) or reg < 0.0:
+        raise ValueError("reg must be finite and >= 0")
+
     agg = _aggregate(outcomes)
     n = len(agg.models)
     if n == 0:

--- a/runner/src/coval_bench/arena/rating.py
+++ b/runner/src/coval_bench/arena/rating.py
@@ -1,0 +1,409 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+"""Voice Arena rating engine.
+
+Pure functions: vote outcomes in, ratings out. No DB, no I/O. The only input is
+a sequence of head-to-head battle outcomes (the shape of ``arena.votes`` joined
+to ``arena.battles``); the output maps one-to-one onto ``arena.leaderboard_snapshots``.
+
+Model
+-----
+Davidson (1970) extension of Bradley-Terry to allow ties. Each model has a
+log-strength ``theta``; one shared tie parameter ``nu >= 0`` controls how often a
+comparison ends in a draw. For a battle between ``i`` and ``j``::
+
+    D            = exp(theta_i) + exp(theta_j) + nu * exp((theta_i + theta_j) / 2)
+    P(i wins)    = exp(theta_i) / D
+    P(j wins)    = exp(theta_j) / D
+    P(tie)       = nu * exp((theta_i + theta_j) / 2) / D
+
+``nu = 0`` collapses exactly to plain Bradley-Terry (ties impossible).
+
+Fitting
+-------
+Maximum likelihood via L-BFGS-B with an analytic gradient. The score statistic
+``wins + 0.5 * ties`` is sufficient for ``theta``; the *log-likelihood* gradient
+is ``observed - expected`` of that score. The objective adds a small L2 ridge
+(`reg`), so the fitted optimum satisfies ``observed - expected = 2 * reg * theta``
+(a slight shrink toward 0), not exactly zero. The ridge also pins the otherwise
+shift-invariant scale, tames separation (a model that wins or loses everything),
+keeps bootstrap refits finite, and makes the objective strictly convex (unique
+optimum). A fit that still fails to converge raises ``ConvergenceError`` rather
+than return a non-MLE point.
+
+Elo
+---
+``elo = 1500 + (400 / ln 10) * theta`` — the standard Bradley-Terry-to-Elo map, so
+a 400-point gap means a 10:1 odds favourite (ties aside). Elo is a display rescale
+of ``theta`` (``rating_bt``) and carries no information ``theta`` does not.
+
+Confidence
+----------
+Percentile bootstrap over battles: resample battles with replacement, refit, and
+take the 2.5/97.5 Elo percentiles. The CI half-width comes from the same draws.
+More votes -> tighter interval. A resample whose fit fails to converge is skipped.
+
+Assumptions
+-----------
+Ratings assume a *connected* comparison graph: each model must be linked to the
+rest through a chain of battles, or cross-cluster strengths are undefined and the
+ridge silently pins them. Connectivity is maintained upstream by adaptive pairing
+(plan §10); a defensive connected-components guard in this engine is a follow-up.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Literal
+
+import numpy as np
+import numpy.typing as npt
+from pydantic import BaseModel, Field
+from scipy.optimize import minimize
+
+logger = logging.getLogger(__name__)
+
+
+class ConvergenceError(RuntimeError):
+    """Raised when the Davidson MLE optimizer fails to reach the optimum.
+
+    The fitted theta/nu are only the maximum-likelihood estimate when the solver
+    converges (gradient ~ 0). On failure the returned point is an arbitrary spot
+    on the likelihood surface, so we refuse it rather than publish wrong ratings.
+    """
+
+
+# Bump on any behavioural change to the rating math (model, Elo map, bootstrap,
+# status thresholds). Persisted on leaderboard snapshots so a stored rating can
+# be tied back to the method that produced it.
+METHODOLOGY_VERSION: Literal["davidson-bt-1"] = "davidson-bt-1"
+
+# Standard Bradley-Terry -> Elo scale: a difference of 400 Elo == 10:1 win odds.
+_ELO_BASE = 1500.0
+_ELO_SCALE = 400.0 / math.log(10.0)
+
+# nu is optimized on the log scale (eta = log nu) and bounded so that a tie-free
+# dataset floors out near zero instead of running eta to -inf, and a tie-heavy
+# one cannot blow up. These bounds never bind on realistic data.
+_NU_MIN = 1e-3
+_NU_MAX = 30.0
+
+Outcome = Literal["A_WIN", "B_WIN", "TIE"]
+Status = Literal["preliminary", "usable", "established"]
+
+
+class BattleOutcome(BaseModel):
+    """One settled battle: model A vs model B, and who won.
+
+    ``A_WIN``/``B_WIN``/``TIE`` is stored raw and never collapsed, matching
+    ``arena.votes.outcome``. ``model_a``/``model_b`` are opaque model ids.
+    """
+
+    model_a: str
+    model_b: str
+    outcome: Outcome
+
+
+class ModelRating(BaseModel):
+    """Rating for one model — the shape of an ``arena.leaderboard_snapshots`` row."""
+
+    model_id: str
+    rating_bt: float
+    rating_elo: float
+    # None when no CI is available (e.g. bootstrap_rounds=0, or the model never
+    # appeared in a resample) — never NaN, which is invalid JSON and a silent
+    # poison value in a NUMERIC column.
+    ci_low: float | None
+    ci_high: float | None
+    ci_half_width: float | None = Field(default=None, ge=0)
+    votes_total: int = Field(ge=0)
+    wins: float = Field(ge=0)
+    losses: float = Field(ge=0)
+    ties: float = Field(ge=0)
+    status: Status
+
+
+class RatingResult(BaseModel):
+    """Full leaderboard fit: the tie parameter plus one entry per model."""
+
+    methodology_version: Literal["davidson-bt-1"] = METHODOLOGY_VERSION
+    tie_param: float
+    models: list[ModelRating]
+
+
+# ---------------------------------------------------------------------------
+# Aggregation
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _Aggregate:
+    """Sufficient statistics: unique models plus per-pair win/tie counts."""
+
+    models: list[str]
+    # Parallel arrays over unordered pairs (i < j):
+    idx_i: npt.NDArray[np.int64]
+    idx_j: npt.NDArray[np.int64]
+    wins_ij: npt.NDArray[np.float64]  # times model i beat model j
+    wins_ji: npt.NDArray[np.float64]  # times model j beat model i
+    ties: npt.NDArray[np.float64]  # draws between i and j
+
+
+def _aggregate(outcomes: Sequence[BattleOutcome]) -> _Aggregate:
+    """Collapse raw battles into per-pair win/tie counts."""
+    models = sorted({o.model_a for o in outcomes} | {o.model_b for o in outcomes})
+    index = {m: k for k, m in enumerate(models)}
+
+    # Map an unordered pair (lo, hi) -> [wins_lo_over_hi, wins_hi_over_lo, ties].
+    pairs: dict[tuple[int, int], list[float]] = {}
+    for o in outcomes:
+        a, b = index[o.model_a], index[o.model_b]
+        lo, hi = (a, b) if a < b else (b, a)
+        cell = pairs.setdefault((lo, hi), [0.0, 0.0, 0.0])
+        if o.outcome == "TIE":
+            cell[2] += 1.0
+        else:
+            winner = a if o.outcome == "A_WIN" else b
+            cell[0 if winner == lo else 1] += 1.0
+
+    keys = list(pairs.keys())
+    idx_i = np.array([k[0] for k in keys], dtype=np.int64)
+    idx_j = np.array([k[1] for k in keys], dtype=np.int64)
+    wins_ij = np.array([pairs[k][0] for k in keys], dtype=np.float64)
+    wins_ji = np.array([pairs[k][1] for k in keys], dtype=np.float64)
+    ties = np.array([pairs[k][2] for k in keys], dtype=np.float64)
+    return _Aggregate(
+        models=models,
+        idx_i=idx_i,
+        idx_j=idx_j,
+        wins_ij=wins_ij,
+        wins_ji=wins_ji,
+        ties=ties,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Davidson maximum-likelihood fit
+# ---------------------------------------------------------------------------
+
+
+def _fit(agg: _Aggregate, reg: float) -> tuple[npt.NDArray[np.float64], float]:
+    """Fit Davidson theta (centered, mean 0) and tie parameter nu by MLE."""
+    n = len(agg.models)
+    if n == 0:
+        return np.zeros(0, dtype=np.float64), _NU_MIN
+
+    i, j = agg.idx_i, agg.idx_j
+    w_ij, w_ji, tie = agg.wins_ij, agg.wins_ji, agg.ties
+    n_pair = w_ij + w_ji + tie
+
+    def neg_ll_grad(x: npt.NDArray[np.float64]) -> tuple[float, npt.NDArray[np.float64]]:
+        theta = x[:n]
+        nu = math.exp(x[n])
+        ti, tj = theta[i], theta[j]
+        ei, ej = np.exp(ti), np.exp(tj)
+        eij = np.exp((ti + tj) / 2.0)
+        denom = ei + ej + nu * eij
+        log_d = np.log(denom)
+
+        ll = float(
+            np.sum(
+                w_ij * (ti - log_d)
+                + w_ji * (tj - log_d)
+                + tie * (math.log(nu) + (ti + tj) / 2.0 - log_d)
+            )
+        )
+        nll = -ll + reg * float(np.sum(theta * theta))
+
+        p_i = ei / denom
+        p_j = ej / denom
+        p_tie = (nu * eij) / denom
+        # d(LL)/d(theta) = observed - expected of the score (wins + 0.5 * ties).
+        obs_i = w_ij + 0.5 * tie
+        obs_j = w_ji + 0.5 * tie
+        exp_i = n_pair * (p_i + 0.5 * p_tie)
+        exp_j = n_pair * (p_j + 0.5 * p_tie)
+        grad_theta = np.zeros(n, dtype=np.float64)
+        np.add.at(grad_theta, i, -(obs_i - exp_i))
+        np.add.at(grad_theta, j, -(obs_j - exp_j))
+        grad_theta += 2.0 * reg * theta
+        # d(LL)/d(eta) = observed ties - expected ties (chain rule on nu = e^eta).
+        grad_eta = -float(np.sum(tie - n_pair * p_tie))
+
+        grad = np.empty(n + 1, dtype=np.float64)
+        grad[:n] = grad_theta
+        grad[n] = grad_eta
+        return nll, grad
+
+    x0 = np.zeros(n + 1, dtype=np.float64)  # theta = 0, eta = 0 (nu = 1)
+    bounds = [(None, None)] * n + [(math.log(_NU_MIN), math.log(_NU_MAX))]
+    res = minimize(neg_ll_grad, x0, jac=True, method="L-BFGS-B", bounds=bounds)
+    if not res.success:
+        # The ridge makes the objective strictly convex, so a healthy fit
+        # converges easily; failure signals degenerate data (e.g. a disconnected
+        # comparison graph), and res.x is not the MLE.
+        raise ConvergenceError(
+            f"Davidson MLE did not converge: {res.message!r} ({n} models, {len(agg.idx_i)} pairs)"
+        )
+
+    x_opt = np.asarray(res.x, dtype=np.float64)
+    theta = x_opt[:n]
+    theta = theta - float(np.mean(theta))  # recenter: theta is shift-invariant
+    nu = float(math.exp(x_opt[n]))
+    return theta, nu
+
+
+def _elo(theta: npt.NDArray[np.float64]) -> npt.NDArray[np.float64]:
+    """Map centered log-strengths to the Elo scale."""
+    return _ELO_BASE + _ELO_SCALE * theta
+
+
+# ---------------------------------------------------------------------------
+# Bootstrap confidence intervals
+# ---------------------------------------------------------------------------
+
+
+def _bootstrap(
+    outcomes: Sequence[BattleOutcome],
+    models: list[str],
+    *,
+    rounds: int,
+    reg: float,
+    rng: np.random.Generator,
+) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]:
+    """Return (ci_low, ci_high) Elo arrays aligned to ``models``.
+
+    Resamples battles with replacement, refits, and aligns each replicate's Elo
+    back to the canonical model order. Models absent from a replicate contribute
+    no sample for that round (dropped, not imputed). A resample whose fit fails to
+    converge is skipped (a few dropped replicates barely move the percentiles).
+    """
+    n = len(models)
+    index = {m: k for k, m in enumerate(models)}
+    arr = list(outcomes)
+    n_battles = len(arr)
+    # samples[k] collects every replicate Elo seen for model k.
+    samples: list[list[float]] = [[] for _ in range(n)]
+
+    failures = 0
+    for _ in range(rounds):
+        picks = rng.integers(0, n_battles, size=n_battles)
+        resampled = [arr[p] for p in picks]
+        agg = _aggregate(resampled)
+        try:
+            theta, _ = _fit(agg, reg)
+        except ConvergenceError:
+            failures += 1
+            continue
+        elo = _elo(theta)
+        for local_k, model_id in enumerate(agg.models):
+            samples[index[model_id]].append(float(elo[local_k]))
+
+    if failures:
+        logger.warning(
+            "bootstrap: %d/%d resamples failed to converge and were skipped",
+            failures,
+            rounds,
+        )
+
+    ci_low = np.full(n, np.nan, dtype=np.float64)
+    ci_high = np.full(n, np.nan, dtype=np.float64)
+    for k in range(n):
+        vals = np.array(samples[k], dtype=np.float64)
+        if vals.size == 0:
+            continue
+        ci_low[k] = float(np.percentile(vals, 2.5))
+        ci_high[k] = float(np.percentile(vals, 97.5))
+    return ci_low, ci_high
+
+
+# ---------------------------------------------------------------------------
+# Status classifier
+# ---------------------------------------------------------------------------
+
+# Provisional confidence tiers (methodology doc not yet on this branch). Driven
+# by the bootstrap CI half-width in Elo points. ``preliminary`` is the floor: a
+# model with no CI or a wide one reads as preliminary, not better. Tune once the
+# methodology §7 thresholds land.
+_CI_ESTABLISHED = 30.0
+_CI_USABLE = 60.0
+
+
+def classify_status(ci_half_width: float | None) -> Status:
+    """Bucket a model into a confidence tier from its bootstrap CI half-width."""
+    if ci_half_width is None or math.isnan(ci_half_width):
+        return "preliminary"
+    if ci_half_width <= _CI_ESTABLISHED:
+        return "established"
+    if ci_half_width <= _CI_USABLE:
+        return "usable"
+    return "preliminary"
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def compute_ratings(
+    outcomes: Sequence[BattleOutcome],
+    *,
+    bootstrap_rounds: int = 1000,
+    seed: int = 0,
+    reg: float = 0.1,
+) -> RatingResult:
+    """Fit the Davidson-BT leaderboard from raw battle outcomes.
+
+    Returns one :class:`ModelRating` per model seen, sorted by Elo descending.
+    ``bootstrap_rounds`` controls CI precision/cost; ``seed`` makes the bootstrap
+    reproducible; ``reg`` is the L2 ridge on theta.
+    """
+    agg = _aggregate(outcomes)
+    n = len(agg.models)
+    if n == 0:
+        return RatingResult(tie_param=0.0, models=[])
+
+    theta, nu = _fit(agg, reg)
+    elo = _elo(theta)
+
+    rng = np.random.default_rng(seed)
+    ci_low, ci_high = _bootstrap(outcomes, agg.models, rounds=bootstrap_rounds, reg=reg, rng=rng)
+
+    # Per-model win/loss/tie tallies from the per-pair counts.
+    wins = np.zeros(n, dtype=np.float64)
+    losses = np.zeros(n, dtype=np.float64)
+    ties = np.zeros(n, dtype=np.float64)
+    np.add.at(wins, agg.idx_i, agg.wins_ij)
+    np.add.at(wins, agg.idx_j, agg.wins_ji)
+    np.add.at(losses, agg.idx_i, agg.wins_ji)
+    np.add.at(losses, agg.idx_j, agg.wins_ij)
+    np.add.at(ties, agg.idx_i, agg.ties)
+    np.add.at(ties, agg.idx_j, agg.ties)
+
+    entries: list[ModelRating] = []
+    for k, model_id in enumerate(agg.models):
+        votes_total = int(round(wins[k] + losses[k] + ties[k]))
+        low = None if math.isnan(ci_low[k]) else float(ci_low[k])
+        high = None if math.isnan(ci_high[k]) else float(ci_high[k])
+        half_width = (high - low) / 2.0 if low is not None and high is not None else None
+        entries.append(
+            ModelRating(
+                model_id=model_id,
+                rating_bt=float(theta[k]),
+                rating_elo=float(elo[k]),
+                ci_low=low,
+                ci_high=high,
+                ci_half_width=half_width,
+                votes_total=votes_total,
+                wins=float(wins[k]),
+                losses=float(losses[k]),
+                ties=float(ties[k]),
+                status=classify_status(half_width),
+            )
+        )
+
+    entries.sort(key=lambda e: e.rating_elo, reverse=True)
+    return RatingResult(tie_param=nu, models=entries)

--- a/runner/tests/unit/test_arena_rating.py
+++ b/runner/tests/unit/test_arena_rating.py
@@ -222,3 +222,40 @@ def test_bootstrap_skips_nonconverged(monkeypatch: pytest.MonkeyPatch) -> None:
     low, high = rating._bootstrap(outcomes, ["A", "B"], rounds=5, reg=0.1, rng=rng)
     assert np.all(np.isnan(low))
     assert np.all(np.isnan(high))
+
+
+def test_self_battle_is_ignored() -> None:
+    # A self-battle (model_a == model_b) carries no comparison signal and must
+    # not corrupt the per-pair tallies or shift the ratings.
+    real = [BattleOutcome(model_a="A", model_b="B", outcome="A_WIN") for _ in range(5)]
+    polluted = real + [BattleOutcome(model_a="A", model_b="A", outcome="A_WIN") for _ in range(3)]
+
+    clean = {m.model_id: m for m in compute_ratings(real, bootstrap_rounds=0, seed=1).models}
+    mixed = {m.model_id: m for m in compute_ratings(polluted, bootstrap_rounds=0, seed=1).models}
+
+    assert mixed["A"].wins == clean["A"].wins == 5.0
+    assert mixed["A"].votes_total == clean["A"].votes_total == 5
+    assert mixed["A"].rating_elo == pytest.approx(clean["A"].rating_elo)
+
+
+def test_single_bootstrap_sample_gives_no_ci() -> None:
+    # With one bootstrap round each model has at most one resample Elo. A lone
+    # sample is not a usable interval, so CI must be None and the status the
+    # preliminary floor -- not a false zero-width "established".
+    outcomes = [BattleOutcome(model_a="A", model_b="B", outcome="A_WIN") for _ in range(10)]
+    result = compute_ratings(outcomes, bootstrap_rounds=1, seed=1)
+    for m in result.models:
+        assert m.ci_low is None
+        assert m.ci_high is None
+        assert m.ci_half_width is None
+        assert m.status == "preliminary"
+
+
+def test_invalid_inputs_raise() -> None:
+    outcomes = [BattleOutcome(model_a="A", model_b="B", outcome="A_WIN")]
+    with pytest.raises(ValueError):
+        compute_ratings(outcomes, bootstrap_rounds=-1, seed=1)
+    with pytest.raises(ValueError):
+        compute_ratings(outcomes, reg=-0.1, seed=1)
+    with pytest.raises(ValueError):
+        compute_ratings(outcomes, reg=float("inf"), seed=1)

--- a/runner/tests/unit/test_arena_rating.py
+++ b/runner/tests/unit/test_arena_rating.py
@@ -1,0 +1,224 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the Davidson-BT arena rating engine.
+
+Done-criteria from the implementation plan (layer #3):
+  * synthetic data recovers a known ranking,
+  * confidence intervals shrink as vote count grows,
+  * adding ties moves the tie parameter.
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+from coval_bench.arena import rating
+from coval_bench.arena.rating import (
+    BattleOutcome,
+    classify_status,
+    compute_ratings,
+)
+
+
+def _simulate(
+    true_theta: dict[str, float],
+    *,
+    nu: float,
+    battles_per_pair: int,
+    seed: int,
+) -> list[BattleOutcome]:
+    """Round-robin battles drawn from the Davidson model at known theta/nu."""
+    rng = np.random.default_rng(seed)
+    models = list(true_theta)
+    outcomes: list[BattleOutcome] = []
+    for a_idx in range(len(models)):
+        for b_idx in range(a_idx + 1, len(models)):
+            a, b = models[a_idx], models[b_idx]
+            ti, tj = true_theta[a], true_theta[b]
+            ei, ej = math.exp(ti), math.exp(tj)
+            eij = math.exp((ti + tj) / 2.0)
+            denom = ei + ej + nu * eij
+            probs = [ei / denom, ej / denom, nu * eij / denom]
+            draws = rng.choice(3, size=battles_per_pair, p=probs)
+            for d in draws:
+                outcome = ("A_WIN", "B_WIN", "TIE")[int(d)]
+                outcomes.append(BattleOutcome(model_a=a, model_b=b, outcome=outcome))
+    return outcomes
+
+
+# ---------------------------------------------------------------------------
+# 1. Recover a known ranking
+# ---------------------------------------------------------------------------
+
+
+def test_recovers_known_ranking() -> None:
+    true_theta = {"m0": 1.2, "m1": 0.6, "m2": 0.0, "m3": -0.6, "m4": -1.2}
+    outcomes = _simulate(true_theta, nu=0.3, battles_per_pair=400, seed=7)
+
+    result = compute_ratings(outcomes, bootstrap_rounds=100, seed=1)
+
+    recovered_order = [m.model_id for m in result.models]  # sorted by Elo desc
+    expected_order = sorted(true_theta, key=lambda m: true_theta[m], reverse=True)
+    assert recovered_order == expected_order
+
+    # Elo should be monotonic in true strength and centered on the 1500 base.
+    elo = {m.model_id: m.rating_elo for m in result.models}
+    assert elo["m0"] > elo["m2"] > elo["m4"]
+    mean_elo = sum(elo.values()) / len(elo)
+    assert abs(mean_elo - 1500.0) < 1.0
+
+
+# ---------------------------------------------------------------------------
+# 2. CIs shrink with N
+# ---------------------------------------------------------------------------
+
+
+def test_ci_shrinks_with_more_votes() -> None:
+    true_theta = {"m0": 0.8, "m1": 0.0, "m2": -0.8}
+
+    small = compute_ratings(
+        _simulate(true_theta, nu=0.3, battles_per_pair=30, seed=3),
+        bootstrap_rounds=200,
+        seed=1,
+    )
+    large = compute_ratings(
+        _simulate(true_theta, nu=0.3, battles_per_pair=600, seed=3),
+        bootstrap_rounds=200,
+        seed=1,
+    )
+
+    small_hw = {m.model_id: m.ci_half_width for m in small.models}
+    large_hw = {m.model_id: m.ci_half_width for m in large.models}
+    for model_id in true_theta:
+        assert large_hw[model_id] < small_hw[model_id]
+
+
+# ---------------------------------------------------------------------------
+# 3. Ties move the tie parameter
+# ---------------------------------------------------------------------------
+
+
+def test_ties_move_tie_parameter() -> None:
+    true_theta = {"m0": 0.5, "m1": 0.0, "m2": -0.5}
+
+    few_ties = compute_ratings(
+        _simulate(true_theta, nu=0.05, battles_per_pair=300, seed=5),
+        bootstrap_rounds=1,
+        seed=1,
+    )
+    many_ties = compute_ratings(
+        _simulate(true_theta, nu=3.0, battles_per_pair=300, seed=5),
+        bootstrap_rounds=1,
+        seed=1,
+    )
+
+    assert many_ties.tie_param > few_ties.tie_param
+    # The tie-heavy fit should also report many more ties than the clean one.
+    assert sum(m.ties for m in many_ties.models) > sum(m.ties for m in few_ties.models)
+
+
+# ---------------------------------------------------------------------------
+# Edge cases and unit-level checks
+# ---------------------------------------------------------------------------
+
+
+def test_empty_input() -> None:
+    result = compute_ratings([], bootstrap_rounds=10, seed=1)
+    assert result.models == []
+    assert result.tie_param == 0.0
+
+
+def test_separation_stays_finite() -> None:
+    # A beats B every time -> MLE wants infinite theta; ridge must keep it finite.
+    outcomes = [BattleOutcome(model_a="A", model_b="B", outcome="A_WIN") for _ in range(50)]
+    result = compute_ratings(outcomes, bootstrap_rounds=20, seed=1)
+    by_id = {m.model_id: m for m in result.models}
+    assert by_id["A"].rating_elo > by_id["B"].rating_elo
+    assert all(math.isfinite(m.rating_elo) for m in result.models)
+    assert by_id["A"].wins == 50.0
+    assert by_id["B"].losses == 50.0
+
+
+def test_win_loss_tie_tallies() -> None:
+    outcomes = [
+        BattleOutcome(model_a="A", model_b="B", outcome="A_WIN"),
+        BattleOutcome(model_a="A", model_b="B", outcome="B_WIN"),
+        BattleOutcome(model_a="B", model_b="A", outcome="B_WIN"),  # model_b (A) wins again
+        BattleOutcome(model_a="A", model_b="B", outcome="TIE"),
+    ]
+    result = compute_ratings(outcomes, bootstrap_rounds=10, seed=1)
+    by_id = {m.model_id: m for m in result.models}
+    assert by_id["A"].wins == 2.0
+    assert by_id["A"].losses == 1.0
+    assert by_id["A"].ties == 1
+    assert by_id["A"].votes_total == 4
+    assert by_id["B"].wins == 1.0
+    assert by_id["B"].losses == 2.0
+
+
+def test_classify_status() -> None:
+    assert classify_status(None) == "preliminary"  # no CI -> floor
+    assert classify_status(float("nan")) == "preliminary"
+    assert classify_status(10.0) == "established"
+    assert classify_status(30.0) == "established"  # boundary inclusive
+    assert classify_status(45.0) == "usable"
+    assert classify_status(60.0) == "usable"  # boundary inclusive
+    assert classify_status(200.0) == "preliminary"  # CI too wide -> floor
+
+
+def test_ci_is_well_formed() -> None:
+    # Only the geometrically guaranteed properties are asserted. The point
+    # estimate is NOT guaranteed to sit inside the bootstrap percentile band
+    # (the MLE and the bootstrap distribution are distinct objects), so we do
+    # not assert ci_low <= rating_elo <= ci_high.
+    true_theta = {"m0": 0.7, "m1": 0.0, "m2": -0.7}
+    result = compute_ratings(
+        _simulate(true_theta, nu=0.3, battles_per_pair=200, seed=9),
+        bootstrap_rounds=200,
+        seed=1,
+    )
+    for m in result.models:
+        assert m.ci_low is not None and m.ci_high is not None
+        assert m.ci_low <= m.ci_high
+        assert m.ci_half_width is not None and m.ci_half_width >= 0.0
+
+
+def test_no_ci_when_bootstrap_disabled() -> None:
+    # bootstrap_rounds=0 -> no resamples -> CI fields are None, never NaN.
+    outcomes = [BattleOutcome(model_a="A", model_b="B", outcome="A_WIN") for _ in range(10)]
+    result = compute_ratings(outcomes, bootstrap_rounds=0, seed=1)
+    for m in result.models:
+        assert m.ci_low is None
+        assert m.ci_high is None
+        assert m.ci_half_width is None
+        assert m.status == "preliminary"
+
+
+def test_main_fit_nonconvergence_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    # If the optimizer reports failure, the main fit must refuse, not return junk.
+    class _FailRes:
+        success = False
+        message = "iteration limit"
+        x = np.zeros(3, dtype=np.float64)  # 2 models + eta
+
+    monkeypatch.setattr(rating, "minimize", lambda *a, **k: _FailRes())
+    outcomes = [BattleOutcome(model_a="A", model_b="B", outcome="A_WIN")]
+    with pytest.raises(rating.ConvergenceError):
+        compute_ratings(outcomes, bootstrap_rounds=0, seed=1)
+
+
+def test_bootstrap_skips_nonconverged(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A resample that fails to converge is skipped, not fatal: _bootstrap returns
+    # NaN (which compute_ratings later renders as None), without raising.
+    def _always_fail(*_a: object, **_k: object) -> object:
+        raise rating.ConvergenceError("forced")
+
+    monkeypatch.setattr(rating, "_fit", _always_fail)
+    rng = np.random.default_rng(0)
+    outcomes = [BattleOutcome(model_a="A", model_b="B", outcome="A_WIN")]
+    low, high = rating._bootstrap(outcomes, ["A", "B"], rounds=5, reg=0.1, rng=rng)
+    assert np.all(np.isnan(low))
+    assert np.all(np.isnan(high))


### PR DESCRIPTION
Rating engine for arena layer #3, stacked on the schema PR (#119).

Pure functions, no DB/IO: A_WIN/B_WIN/TIE outcomes in, one rating row per model out (matching arena.leaderboard_snapshots).

- Davidson Bradley-Terry fit (model strengths theta + shared tie parameter nu) by MLE, with a hand-derived gradient and a small ridge to keep separation/refits finite. nu=0 collapses to plain Bradley-Terry.
- Elo = 1500 + 400/ln10 * theta (display rescale of theta; rating_bt holds the raw strength).
- 95% CIs via seeded percentile bootstrap; CI fields are null (not NaN) when unavailable.
- Status (preliminary / usable / established) from CI half-width.
- Refuses a non-converged fit and skips non-converged bootstrap resamples.

Tests cover the three done-criteria (recovers a known ranking, CIs shrink with votes, ties move nu) plus the convergence and null-CI paths.

Follow-ups (not this PR): calibrate `reg` and pin/decouple the status thresholds once methodology lands, per-domain tie rate (far future).

Merge after #119.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced an arena rating engine that processes model battle outcomes and generates rankings with statistical confidence intervals and status classifications.

* **Tests**
  * Added comprehensive unit and integration tests for the rating engine, verifying ranking accuracy, confidence interval shrinkage, tie handling, and bootstrap robustness across edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds the Davidson Bradley-Terry rating engine for the Voice Arena leaderboard layer. Pure-function implementation: battle outcomes in, one `ModelRating` row per model out, matching the `arena.leaderboard_snapshots` schema from #119.

- MLE fit via L-BFGS-B with an analytic gradient, L2 ridge for strict convexity, and a hard `ConvergenceError` guard so a non-converged optimizer never produces ratings.
- Percentile bootstrap CIs with NaN→`None` conversion (no silent poison values in the schema), and a `classify_status` tier based on CI half-width.
- All three done-criteria tests pass; convergence-guard and CI-assertion regressions from the prior review round are correctly addressed.

<h3>Confidence Score: 5/5</h3>

Safe to merge; this is a pure-function module with no DB/IO and a well-guarded optimizer path.

All three blocking concerns from the previous round (optimizer convergence check, NaN to None schema correctness, and the CI containment assertion) are fully addressed. The two remaining observations are methodological trade-offs explicitly acknowledged in the PR description and docstrings.

No files require special attention; rating.py is the only complex file and its core MLE and bootstrap paths are well-tested.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| runner/src/coval_bench/arena/rating.py | Core Davidson-BT engine: MLE fit with convergence guard, percentile bootstrap CIs, and NaN to None conversion all correctly implemented; bootstrap recentering bias when models drop from resamples is a subtle methodological edge case worth noting. |
| runner/tests/unit/test_arena_rating.py | Comprehensive tests covering all done-criteria and edge cases; convergence-guard and CI-assertion regressions from prior review round are correctly addressed. |
| runner/src/coval_bench/arena/__init__.py | Thin re-export shim; all public symbols correctly listed in __all__. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["compute_ratings(outcomes)"] --> B["_aggregate(outcomes)\nper-pair win/tie counts"]
    B --> C{n == 0?}
    C -- yes --> D["RatingResult(models=[])"]
    C -- no --> E["_fit(agg, reg)\nL-BFGS-B MLE"]
    E --> F{res.success?}
    F -- no --> G["raise ConvergenceError"]
    F -- yes --> H["recenter theta\nnu = exp(eta)"]
    H --> I["_elo(theta)\n1500 + scale * theta"]
    I --> J["_bootstrap(outcomes, models)\nresample battles x rounds"]
    J --> K{replicate converges?}
    K -- no --> L["skip replicate\nlog warning"]
    K -- yes --> M["collect Elo\nper model"]
    L --> N{more rounds?}
    M --> N
    N -- yes --> J
    N -- no --> O["percentile 2.5/97.5\n(need >= 2 samples)"]
    O --> P["nan to None\ncompute half_width"]
    P --> Q["classify_status\npreliminary/usable/established"]
    Q --> R["sort by Elo desc\nRatingResult"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["compute_ratings(outcomes)"] --> B["_aggregate(outcomes)\nper-pair win/tie counts"]
    B --> C{n == 0?}
    C -- yes --> D["RatingResult(models=[])"]
    C -- no --> E["_fit(agg, reg)\nL-BFGS-B MLE"]
    E --> F{res.success?}
    F -- no --> G["raise ConvergenceError"]
    F -- yes --> H["recenter theta\nnu = exp(eta)"]
    H --> I["_elo(theta)\n1500 + scale * theta"]
    I --> J["_bootstrap(outcomes, models)\nresample battles x rounds"]
    J --> K{replicate converges?}
    K -- no --> L["skip replicate\nlog warning"]
    K -- yes --> M["collect Elo\nper model"]
    L --> N{more rounds?}
    M --> N
    N -- yes --> J
    N -- no --> O["percentile 2.5/97.5\n(need >= 2 samples)"]
    O --> P["nan to None\ncompute half_width"]
    P --> Q["classify_status\npreliminary/usable/established"]
    Q --> R["sort by Elo desc\nRatingResult"]
```

</a>

<sub>Reviews (3): Last reviewed commit: ["Add regression tests for rating engine h..."](https://github.com/coval-ai/benchmarks/commit/821673ea5c1db557a0884135d18c53d05578c279) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38182836)</sub>

<!-- /greptile_comment -->