### PR TITLE
Mark methodology changes on benchmark timeline charts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,3 +120,35 @@ jobs:
           push: false
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+  # ---------------------------------------------------------------------------
+  # Methodology marker reminder — advisory only (warns, never blocks).
+  # If a PR changes how a metric is computed (WER normalization, TTFT/TTFA
+  # definitions) or the eval dataset, the timeline charts should get a
+  # methodology marker. Warn when those paths change but the curated marker
+  # file (web/lib/config/methodologyChanges.ts) was not touched.
+  # Provider add/exclude (orchestrator.py) is intentionally NOT watched — it
+  # changes for routine reasons and is left to human judgment.
+  # ---------------------------------------------------------------------------
+  methodology-gate:
+    name: Methodology marker check
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Warn on methodology change without a marker
+        run: |
+          set -euo pipefail
+          BASE="origin/${{ github.base_ref }}"
+          CHANGED=$(git diff --name-only "$BASE"...HEAD)
+          SENSITIVE=$(echo "$CHANGED" | grep -E \
+            'runner/src/coval_bench/metrics/(wer|ttft|ttfa)\.py|runner/src/coval_bench/datasets/|docs/methodology\.md' || true)
+          if [ -n "$SENSITIVE" ] && ! echo "$CHANGED" | grep -q 'web/lib/config/methodologyChanges\.ts'; then
+            echo "::warning::Methodology-sensitive files changed but web/lib/config/methodologyChanges.ts was not updated. If this PR changes how a metric is computed or the eval dataset, add a methodology marker so the timeline charts explain the step."
+            echo "Changed methodology-sensitive files:"
+            echo "$SENSITIVE"
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,19 +134,24 @@ jobs:
     name: Methodology marker check
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    # Advisory only: never let this job block a PR, even on an unexpected error.
+    continue-on-error: true
     steps:
       - name: Checkout
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Warn on methodology change without a marker
+        env:
+          BASE_REF: ${{ github.base_ref }}
         run: |
           set -euo pipefail
-          BASE="origin/${{ github.base_ref }}"
+          BASE="origin/$BASE_REF"
           CHANGED=$(git diff --name-only "$BASE"...HEAD)
           SENSITIVE=$(echo "$CHANGED" | grep -E \
-            'runner/src/coval_bench/metrics/(wer|ttft|ttfa)\.py|runner/src/coval_bench/datasets/|docs/methodology\.md' || true)
+            'runner/src/coval_bench/metrics/(wer|ttft|ttfa|ttfs)\.py|runner/src/coval_bench/datasets/|docs/methodology\.md' || true)
           if [ -n "$SENSITIVE" ] && ! echo "$CHANGED" | grep -q 'web/lib/config/methodologyChanges\.ts'; then
             echo "::warning::Methodology-sensitive files changed but web/lib/config/methodologyChanges.ts was not updated. If this PR changes how a metric is computed or the eval dataset, add a methodology marker so the timeline charts explain the step."
             echo "Changed methodology-sensitive files:"

--- a/web/components/visualizations/TimelineChart.tsx
+++ b/web/components/visualizations/TimelineChart.tsx
@@ -12,11 +12,17 @@ import {
   CartesianGrid,
   ResponsiveContainer,
   Legend,
-  Tooltip
+  Tooltip,
+  ReferenceLine
 } from "recharts";
 import { getModelColor } from "@/lib/utils/colors";
 import { formatDate, formatTime, getLocalTimeZoneAbbr } from "@/lib/utils/formatters";
 import { metricDescriptions } from "@/lib/config/metrics";
+import {
+  methodologyChanges,
+  type MethodologyChange,
+  type MethodologyMetricKey
+} from "@/lib/config/methodologyChanges";
 import CustomTimelineTooltip from "@/components/charts/tooltips/TimelineTooltip";
 import Card from "@/components/shared/Card";
 import SectionHeader from "@/components/shared/SectionHeader";
@@ -53,6 +59,51 @@ const TimelineLegend: React.FC<{ payload?: LegendEntry[] }> = ({ payload }) => (
   </ul>
 );
 
+interface MarkerLabelProps {
+  viewBox?: { x?: number; y?: number; width?: number; height?: number };
+  change: MethodologyChange;
+  onEnter: (change: MethodologyChange, x: number) => void;
+  onLeave: () => void;
+}
+
+const MethodologyMarkerLabel: React.FC<MarkerLabelProps> = ({
+  viewBox,
+  change,
+  onEnter,
+  onLeave,
+}) => {
+  const cx = viewBox?.x ?? 0;
+  const cy = (viewBox?.y ?? 0) + 9;
+  return (
+    <g
+      transform={`translate(${cx}, ${cy})`}
+      style={{ cursor: "pointer" }}
+      onMouseEnter={() => onEnter(change, cx)}
+      onMouseLeave={onLeave}
+    >
+      <rect
+        x={-13}
+        y={-9}
+        width={26}
+        height={18}
+        rx={5}
+        fill="#f59e0b"
+        stroke="#ffffff"
+        strokeWidth={1.5}
+      />
+      <text
+        textAnchor="middle"
+        y={4}
+        fontSize={12}
+        fontWeight={700}
+        fill="#ffffff"
+      >
+        (!)
+      </text>
+    </g>
+  );
+};
+
 interface TooltipPayloadItem {
   dataKey: string;
   value: number;
@@ -87,11 +138,16 @@ const TimelineChart: React.FC = () => {
   const chartRef = useRef<HTMLDivElement>(null);
   const pinnedRef = useRef<HTMLDivElement>(null);
   const [pinned, setPinned] = useState<PinnedTooltip | null>(null);
+  const [hoveredMarker, setHoveredMarker] = useState<{
+    change: MethodologyChange;
+    x: number;
+  } | null>(null);
 
   // The metric is shared dashboard-wide, so clear any pinned tooltip whenever it
   // changes — whether from this chart's toggle or another section's.
   useEffect(() => {
     setPinned(null);
+    setHoveredMarker(null);
   }, [metric]);
 
   useEffect(() => {
@@ -111,6 +167,12 @@ const TimelineChart: React.FC = () => {
   const modelsWithData = getModelsWithTimelineData(metric);
   const windowedTimelineData = getWindowedTimelineData(metric);
   const currentTimeWindow = getCurrentTimeWindow();
+  const [windowStart, windowEnd] = currentTimeWindow;
+  const activeMetricKey = metric.toLowerCase() as MethodologyMetricKey;
+  const methodologyMarkers = methodologyChanges
+    .filter((c) => !c.metrics || c.metrics.includes(activeMetricKey))
+    .map((c) => ({ change: c, ts: new Date(c.date).getTime() }))
+    .filter((m) => m.ts >= windowStart && m.ts <= windowEnd);
   const tzAbbr = getLocalTimeZoneAbbr();
   const dateScale = dataTimeWindow !== "24h";
   const xAxisLabel = dateScale ? "Date" : tzAbbr ? `Time (${tzAbbr})` : "Time";
@@ -260,6 +322,22 @@ const TimelineChart: React.FC = () => {
                   name={formatChartLabel(model, getProviderForModel(model))}
                 />
               ))}
+              {methodologyMarkers.map((m) => (
+                <ReferenceLine
+                  key={`${m.change.date}-${m.change.title}`}
+                  x={m.ts}
+                  stroke="#f59e0b"
+                  strokeDasharray="4 4"
+                  strokeWidth={1.5}
+                  label={
+                    <MethodologyMarkerLabel
+                      change={m.change}
+                      onEnter={(change, x) => setHoveredMarker({ change, x })}
+                      onLeave={() => setHoveredMarker(null)}
+                    />
+                  }
+                />
+              ))}
             </LineChart>
           </ResponsiveContainer>
           {pinned && (
@@ -285,6 +363,67 @@ const TimelineChart: React.FC = () => {
               />
             </div>
           )}
+          {hoveredMarker &&
+            (() => {
+              const width = chartRef.current?.clientWidth ?? 0;
+              const pad = 120;
+              const left =
+                width > pad * 2
+                  ? Math.min(Math.max(hoveredMarker.x, pad), width - pad)
+                  : hoveredMarker.x;
+              return (
+                <div
+                  style={{
+                    position: "absolute",
+                    left,
+                    top: 26,
+                    transform: "translateX(-50%)",
+                    zIndex: 25,
+                    pointerEvents: "none",
+                    maxWidth: 240,
+                  }}
+                >
+                  <div
+                    style={{
+                      backgroundColor: "var(--color-surface-tooltip)",
+                      border: "1px solid var(--color-border-secondary)",
+                      borderRadius: "8px",
+                      color: "var(--color-text-on-tooltip)",
+                      padding: "12px",
+                    }}
+                  >
+                    <p
+                      style={{
+                        margin: 0,
+                        fontWeight: "bold",
+                        fontSize: "12px",
+                      }}
+                    >
+                      {hoveredMarker.change.title}
+                    </p>
+                    <p
+                      style={{
+                        margin: "4px 0 0",
+                        fontSize: "10px",
+                        color: "var(--color-text-on-tooltip-secondary)",
+                      }}
+                    >
+                      Methodology change ·{" "}
+                      {formatDate(new Date(hoveredMarker.change.date).getTime())}
+                    </p>
+                    <p
+                      style={{
+                        margin: "8px 0 0",
+                        fontSize: "11px",
+                        lineHeight: 1.45,
+                      }}
+                    >
+                      {hoveredMarker.change.detail}
+                    </p>
+                  </div>
+                </div>
+              );
+            })()}
         </div>
       </Card>
     </div>

--- a/web/components/visualizations/TimelineChart.tsx
+++ b/web/components/visualizations/TimelineChart.tsx
@@ -81,6 +81,7 @@ const MethodologyMarkerLabel: React.FC<MarkerLabelProps> = ({
       onMouseEnter={() => onEnter(change, cx)}
       onMouseLeave={onLeave}
     >
+      <rect x={-24} y={-14} width={48} height={42} fill="transparent" />
       <rect
         x={-13}
         y={-9}
@@ -141,14 +142,20 @@ const TimelineChart: React.FC = () => {
   const [hoveredMarker, setHoveredMarker] = useState<{
     change: MethodologyChange;
     x: number;
+    ts: number;
   } | null>(null);
 
+  const currentTimeWindow = getCurrentTimeWindow();
+  const [windowStart, windowEnd] = currentTimeWindow;
+
   // The metric is shared dashboard-wide, so clear any pinned tooltip whenever it
-  // changes — whether from this chart's toggle or another section's.
+  // changes — whether from this chart's toggle or another section's. Also clear
+  // the marker popover when the time window shifts, since a marker may scroll
+  // out of range.
   useEffect(() => {
     setPinned(null);
     setHoveredMarker(null);
-  }, [metric]);
+  }, [metric, windowStart, windowEnd]);
 
   useEffect(() => {
     if (pinned === null) return;
@@ -166,13 +173,21 @@ const TimelineChart: React.FC = () => {
   const themeColors = useThemeColors();
   const modelsWithData = getModelsWithTimelineData(metric);
   const windowedTimelineData = getWindowedTimelineData(metric);
-  const currentTimeWindow = getCurrentTimeWindow();
-  const [windowStart, windowEnd] = currentTimeWindow;
   const activeMetricKey = metric.toLowerCase() as MethodologyMetricKey;
-  const methodologyMarkers = methodologyChanges
-    .filter((c) => !c.metrics || c.metrics.includes(activeMetricKey))
-    .map((c) => ({ change: c, ts: new Date(c.date).getTime() }))
-    .filter((m) => m.ts >= windowStart && m.ts <= windowEnd);
+  // Anchor date-only strings at UTC noon so the marker lands on the intended
+  // calendar day in every inhabited timezone (UTC midnight would shift to the
+  // previous day for the Americas).
+  const methodologyMarkers = useMemo(
+    () =>
+      methodologyChanges
+        .filter((c) => !c.metrics || c.metrics.includes(activeMetricKey))
+        .map((c) => ({
+          change: c,
+          ts: new Date(`${c.date}T12:00:00Z`).getTime(),
+        }))
+        .filter((m) => m.ts >= windowStart && m.ts <= windowEnd),
+    [activeMetricKey, windowStart, windowEnd]
+  );
   const tzAbbr = getLocalTimeZoneAbbr();
   const dateScale = dataTimeWindow !== "24h";
   const xAxisLabel = dateScale ? "Date" : tzAbbr ? `Time (${tzAbbr})` : "Time";
@@ -332,7 +347,9 @@ const TimelineChart: React.FC = () => {
                   label={
                     <MethodologyMarkerLabel
                       change={m.change}
-                      onEnter={(change, x) => setHoveredMarker({ change, x })}
+                      onEnter={(change, x) =>
+                        setHoveredMarker({ change, x, ts: m.ts })
+                      }
                       onLeave={() => setHoveredMarker(null)}
                     />
                   }
@@ -408,8 +425,7 @@ const TimelineChart: React.FC = () => {
                         color: "var(--color-text-on-tooltip-secondary)",
                       }}
                     >
-                      Methodology change ·{" "}
-                      {formatDate(new Date(hoveredMarker.change.date).getTime())}
+                      Methodology change · {formatDate(hoveredMarker.ts)}
                     </p>
                     <p
                       style={{

--- a/web/components/visualizations/TimelineChart.tsx
+++ b/web/components/visualizations/TimelineChart.tsx
@@ -82,24 +82,15 @@ const MethodologyMarkerLabel: React.FC<MarkerLabelProps> = ({
       onMouseLeave={onLeave}
     >
       <rect x={-24} y={-14} width={48} height={42} fill="transparent" />
-      <rect
-        x={-13}
-        y={-9}
-        width={26}
-        height={18}
-        rx={5}
-        fill="#f59e0b"
-        stroke="#ffffff"
-        strokeWidth={1.5}
-      />
+      <circle r={9} fill="#f59e0b" stroke="#ffffff" strokeWidth={1.5} />
       <text
         textAnchor="middle"
         y={4}
-        fontSize={12}
+        fontSize={13}
         fontWeight={700}
         fill="#ffffff"
       >
-        (!)
+        !
       </text>
     </g>
   );

--- a/web/lib/config/methodologyChanges.ts
+++ b/web/lib/config/methodologyChanges.ts
@@ -12,18 +12,11 @@ export interface MethodologyChange {
 
 export const methodologyChanges: MethodologyChange[] = [
   {
-    date: "2026-05-20",
-    metrics: ["ttfa"],
-    title: "TTFA switched to perceived first-audible latency",
-    detail:
-      "TTFA previously measured network arrival only (time to the first audio chunk). It now adds the leading silence a provider front-loads before the first audible sample, so it reflects what a listener actually waits to hear. Every provider's TTFA shifts upward; values before and after are not comparable.",
-  },
-  {
     date: "2026-06-01",
     metrics: ["ttfa"],
-    title: "TTFA methodology updated across all providers",
+    title: "TTFA redefined as perceived first-audible latency",
     detail:
-      "A methodology change applied uniformly to every provider shifted all reported TTFA values upward on this date. Numbers before and after are not directly comparable.",
+      "TTFA previously measured network arrival only (time to the first audio chunk). It now adds the leading silence a provider front-loads before the first audible sample, so it reflects what a listener actually waits to hear. Every provider's TTFA shifts upward; values before and after are not comparable.",
   },
   {
     date: "2026-06-10",

--- a/web/lib/config/methodologyChanges.ts
+++ b/web/lib/config/methodologyChanges.ts
@@ -12,18 +12,25 @@ export interface MethodologyChange {
 
 export const methodologyChanges: MethodologyChange[] = [
   {
+    date: "2026-05-20",
+    metrics: ["ttfa"],
+    title: "TTFA switched to perceived first-audible latency",
+    detail:
+      "TTFA previously measured network arrival only (time to the first audio chunk). It now adds the leading silence a provider front-loads before the first audible sample, so it reflects what a listener actually waits to hear. Every provider's TTFA shifts upward; values before and after are not comparable.",
+  },
+  {
+    date: "2026-06-01",
+    metrics: ["ttfa"],
+    title: "TTFA methodology updated across all providers",
+    detail:
+      "A methodology change applied uniformly to every provider shifted all reported TTFA values upward on this date. Numbers before and after are not directly comparable.",
+  },
+  {
     date: "2026-06-10",
     metrics: ["ttfs"],
     title: "TTFS anchored at end-of-speech",
     detail:
       "Streaming STT finalization is now forced at a shared VAD end-of-speech point, so every provider is timed from the same instant. Steps after this date reflect engine finalization speed, not how long the speaker talked.",
-  },
-  {
-    date: "2026-06-15",
-    metrics: ["ttft"],
-    title: "Grok excluded from TTFT",
-    detail:
-      "Grok has a ~1.1s fixed response floor that is not comparable to other providers' time-to-first-token. It is excluded from TTFT from this date onward.",
   },
   {
     date: "2026-06-15",

--- a/web/lib/config/methodologyChanges.ts
+++ b/web/lib/config/methodologyChanges.ts
@@ -19,6 +19,13 @@ export const methodologyChanges: MethodologyChange[] = [
       "TTFA previously measured network arrival only (time to the first audio chunk). It now adds the leading silence a provider front-loads before the first audible sample, so it reflects what a listener actually waits to hear. Every provider's TTFA shifts upward; values before and after are not comparable.",
   },
   {
+    date: "2026-06-03",
+    metrics: ["ttfa"],
+    title: "TTFA corrected for librosa cold-start",
+    detail:
+      "Early TTFA readings were inflated because the audio library loaded lazily on the first request, adding one-off import latency to the measurement. The library is now warmed before traffic, so TTFA reflects real synthesis latency. Values drop to their corrected level after this date.",
+  },
+  {
     date: "2026-06-10",
     metrics: ["ttfs"],
     title: "TTFS anchored at end-of-speech",

--- a/web/lib/config/methodologyChanges.ts
+++ b/web/lib/config/methodologyChanges.ts
@@ -1,0 +1,35 @@
+// Copyright 2026 The Coval Benchmarks Authors
+// SPDX-License-Identifier: Apache-2.0
+
+export type MethodologyMetricKey = "ttfa" | "ttft" | "ttfs" | "wer";
+
+export interface MethodologyChange {
+  date: string;
+  metrics?: MethodologyMetricKey[];
+  title: string;
+  detail: string;
+}
+
+export const methodologyChanges: MethodologyChange[] = [
+  {
+    date: "2026-06-10",
+    metrics: ["ttfs"],
+    title: "TTFS anchored at end-of-speech",
+    detail:
+      "Streaming STT finalization is now forced at a shared VAD end-of-speech point, so every provider is timed from the same instant. Steps after this date reflect engine finalization speed, not how long the speaker talked.",
+  },
+  {
+    date: "2026-06-15",
+    metrics: ["ttft"],
+    title: "Grok excluded from TTFT",
+    detail:
+      "Grok has a ~1.1s fixed response floor that is not comparable to other providers' time-to-first-token. It is excluded from TTFT from this date onward.",
+  },
+  {
+    date: "2026-06-15",
+    metrics: ["ttfs"],
+    title: "Gradium finalization made event-driven",
+    detail:
+      "Gradium STT now waits for an explicit finalization event instead of a fixed timeout, so its time-to-final-segment reflects true engine speed. Gradium TTFS values shift at this point.",
+  },
+];


### PR DESCRIPTION
Closes BENCH-301.

When a timeline steps up or down, you can't tell if a provider changed or if we changed how we measure. This adds a marker that explains the step.

- A dashed amber line with a **(!)** badge at each methodology change; hover shows the title, date, and detail.
- Markers only show on the metric they affect, and only when the change falls in the visible time range.
- Changes are curated in `web/lib/config/methodologyChanges.ts`. Seeded with the TTFS end-of-speech anchor, Grok TTFT exclusion, and Gradium event-driven finalization (dates from PR merges — worth confirming).
- Adds an advisory CI check that warns when metric or dataset code changes without a matching marker entry. Provider add/exclude is left to human judgment.

No backend changes — markers read a static config file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Timeline charts now display methodology change markers that highlight significant updates to metric definitions. Hovering over any marker reveals the change title, date, and detailed explanation of the impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds amber dashed `ReferenceLine` markers to the timeline charts that appear at the exact x-position of each methodology change, filtered to the active metric and visible time window. Hovering the badge shows a popover with the change title, date, and detail text. A new advisory CI job warns (but never blocks) when metric or dataset files change without a matching entry in the new `methodologyChanges.ts` config.

- `web/lib/config/methodologyChanges.ts` — static registry of 4 methodology events scoped to `ttfa` and `ttfs`; the previous UTC-midnight timezone bug is fixed with `T12:00:00Z` anchoring and the marker list is correctly wrapped in `useMemo`.
- `web/components/visualizations/TimelineChart.tsx` — `MethodologyMarkerLabel` SVG component with an enlarged transparent hit rect and hover callbacks; popover state (`hoveredMarker`) is cleared on metric or time-window change.
- `.github/workflows/ci.yml` — `methodology-gate` job watches metric files (including `ttfs`) and `docs/methodology.md`, emitting a `::warning::` when those paths change without a matching config update.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all previous review findings are addressed and no new defects were introduced.

The UTC-noon anchoring fix, useMemo wrapping, formatDate consistency, and ttfs CI watch pattern were all applied correctly. The remaining open thread (popover hover gap) predates this revision and the expanded transparent hit-rect mitigates it. The only new observation is a content discrepancy between the PR description (mentions a Grok TTFT exclusion entry) and the committed config file (which omits it) — a question for the author rather than a blocker.

web/lib/config/methodologyChanges.ts — worth confirming whether the Grok TTFT exclusion entry was intentionally deferred or accidentally omitted.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| web/lib/config/methodologyChanges.ts | New static config seeding 4 methodology change entries with correct typed fields; all entries have explicit `metrics` arrays scoping them to the right charts. |
| web/components/visualizations/TimelineChart.tsx | Adds dashed amber ReferenceLine markers with hover popovers; UTC-noon anchoring, useMemo, and formatDate fixes from prior review rounds are all applied correctly. |
| .github/workflows/ci.yml | Advisory `methodology-gate` job added; watches the correct metric files (including `ttfs`) and emits a warning without blocking merges; `continue-on-error: true` is appropriate. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[TimelineChart renders] --> B[getCurrentTimeWindow]
    B --> C[windowStart / windowEnd]
    C --> D["useMemo: methodologyMarkers"]
    D --> E["filter: metric matches activeMetricKey"]
    E --> F["map: date + 'T12:00:00Z' → ts"]
    F --> G["filter: windowStart ≤ ts ≤ windowEnd"]
    G --> H{Any markers?}
    H -- No --> I[No ReferenceLine rendered]
    H -- Yes --> J["ReferenceLine x=ts, label=MethodologyMarkerLabel"]
    J --> K[User hovers badge]
    K --> L["onMouseEnter → setHoveredMarker\{change, x, ts\}"]
    L --> M["Absolute popover: title · formatDate(ts) · detail"]
    K --> N[onMouseLeave → setHoveredMarker null]
    N --> O[Popover removed]
    M --> O
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[TimelineChart renders] --> B[getCurrentTimeWindow]
    B --> C[windowStart / windowEnd]
    C --> D["useMemo: methodologyMarkers"]
    D --> E["filter: metric matches activeMetricKey"]
    E --> F["map: date + 'T12:00:00Z' → ts"]
    F --> G["filter: windowStart ≤ ts ≤ windowEnd"]
    G --> H{Any markers?}
    H -- No --> I[No ReferenceLine rendered]
    H -- Yes --> J["ReferenceLine x=ts, label=MethodologyMarkerLabel"]
    J --> K[User hovers badge]
    K --> L["onMouseEnter → setHoveredMarker\{change, x, ts\}"]
    L --> M["Absolute popover: title · formatDate(ts) · detail"]
    K --> N[onMouseLeave → setHoveredMarker null]
    N --> O[Popover removed]
    M --> O
```

</a>

<sub>Reviews (4): Last reviewed commit: ["Add Jun 3 TTFA librosa cold-start correc..."](https://github.com/coval-ai/benchmarks/commit/0b266fb5646e55214966aadb851efdd6145d0851) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38227128)</sub>

<!-- /greptile_comment -->