### PR TITLE
fix: exclude TTFT for finalize-only STT models

### DIFF
--- a/runner/src/coval_bench/providers/stt/openai.py
+++ b/runner/src/coval_bench/providers/stt/openai.py
@@ -7,13 +7,16 @@ Benchmarks the realtime transcription models — ``gpt-realtime-whisper``,
 ``gpt-4o-transcribe``, and ``gpt-4o-mini-transcribe`` — over a single websocket
 transcription session.
 
-Streaming is single-pass manual-commit for every model: deltas stream in real time
-(TTFT stays comparable to native streaming ASR), but the final transcript requires an
-explicit ``input_audio_buffer.commit`` after all audio is sent, so AudioToFinal carries
-an extra post-audio round-trip and is not directly comparable to auto-finalizing
-streaming providers. ``gpt-realtime-whisper`` additionally rejects
-``turn_detection: server_vad`` outright, so manual-commit is the only option there
-(verified 2026-06).
+Every model runs single-pass manual-commit: audio streams in, then an explicit
+``input_audio_buffer.commit`` finalizes the buffer, so AudioToFinal carries an extra
+post-audio round-trip versus auto-finalizing streaming providers.
+
+Streaming differs by model. ``gpt-realtime-whisper`` emits partial deltas in real time, so
+its TTFT is comparable to streaming ASR; it also rejects ``turn_detection: server_vad``
+outright, leaving manual-commit the only option (verified 2026-06). ``gpt-4o-transcribe``
+and ``gpt-4o-mini-transcribe`` only transcribe a finalized segment — no partials
+mid-utterance, even with server VAD — so their TTFT is excluded upstream (see
+``_TTFT_NOT_COMPARABLE``).
 """
 
 from __future__ import annotations

--- a/runner/src/coval_bench/runner/orchestrator.py
+++ b/runner/src/coval_bench/runner/orchestrator.py
@@ -69,6 +69,17 @@ _TTS_TIMEOUT_S = 60
 _MAX_ERROR_LEN = 4000  # truncate error messages stored in DB (Postgres text is unbounded
 # but huge stack traces choke log pipelines)
 
+# STT models whose first token can't precede end-of-speech, so TTFT reflects a buffering
+# gate, not engine speed — omit it and rely on TTFS. xai/grok-stt gates on min audio; the
+# openai transcribe models finalize per-segment (no partials mid-utterance, even with VAD).
+_TTFT_NOT_COMPARABLE: frozenset[tuple[str, str]] = frozenset(
+    {
+        ("xai", "grok-stt"),
+        ("openai", "gpt-4o-transcribe"),
+        ("openai", "gpt-4o-mini-transcribe"),
+    }
+)
+
 
 # ---------------------------------------------------------------------------
 # Public result type
@@ -274,13 +285,11 @@ async def _run_stt_item(
             transcription_result.complete_transcript if transcription_result else None
         )
 
-        # 1. TTFT — time-to-first-partial from first audio. For xAI Grok this reflects
-        # its min-audio gate, not engine speed, so it misrepresents the provider; TTFS
-        # (re-anchored at end-of-speech) is the fair metric. Omit TTFT for xAI; the rest run.
+        # 1. TTFT — time-to-first-partial from first audio.
         ttft_status, ttft_error = _metric_outcome(
             ttft_seconds, item_error, Metric.TTFT, ResultStatus
         )
-        ttft_excluded = entry.provider == "xai"
+        ttft_excluded = (entry.provider, entry.model) in _TTFT_NOT_COMPARABLE
         if not ttft_excluded:
             results.append(
                 Result(

--- a/runner/tests/unit/test_orchestrator.py
+++ b/runner/tests/unit/test_orchestrator.py
@@ -484,17 +484,28 @@ async def test_flux_excluded_from_ttfs(audio_file: Path, settings: Settings) -> 
 
 
 @pytest.mark.asyncio
-async def test_xai_excluded_from_ttft(audio_file: Path, settings: Settings) -> None:
-    """xAI Grok's TTFT is a fixed min-audio-gate artifact, not engine speed → no TTFT row.
+@pytest.mark.parametrize(
+    ("provider_name", "model"),
+    [
+        ("xai", "grok-stt"),
+        ("openai", "gpt-4o-transcribe"),
+        ("openai", "gpt-4o-mini-transcribe"),
+    ],
+)
+async def test_non_streaming_models_excluded_from_ttft(
+    provider_name: str, model: str, audio_file: Path, settings: Settings
+) -> None:
+    """Models that can't emit a token before end-of-speech get no TTFT row.
 
-    The fair latency metric (TTFS) and the other metrics still run.
+    xAI Grok (min-audio gate) and the OpenAI transcribe models (finalize-only, no
+    mid-utterance partials) report TTFS instead; the other metrics still run.
     """
     provider = MagicMock()
     provider.measure_ttft = AsyncMock(return_value=_good_transcription())
-    stt_providers = {"xai": MagicMock(return_value=provider)}
+    stt_providers = {provider_name: MagicMock(return_value=provider)}
     matrix = [
         *_paused_registry(Benchmark.STT),
-        _stt_entry("xai", "grok-stt"),
+        _stt_entry(provider_name, model),
     ]
 
     run = _make_run()


### PR DESCRIPTION
gpt-4o-transcribe and gpt-4o-mini-transcribe emit no partials before end-of-speech, so TTFT reflected clip length rather than engine speed; route them through the same exclusion as xAI Grok and report TTFS instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified benchmark semantics for OpenAI STT models, detailing streaming behavior and measurement constraints.

* **Bug Fixes**
  * Improved accuracy of time-to-first-token (TTFT) measurement filtering using expanded provider and model validation lists.

* **Tests**
  * Enhanced test coverage for TTFT exclusion across multiple model types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extends the existing TTFT exclusion (previously xAI-provider-wide) to also cover `gpt-4o-transcribe` and `gpt-4o-mini-transcribe`, which emit no streaming partials before end-of-speech — making their measured TTFT a function of audio clip length rather than engine latency. The exclusion list is refactored from a provider-level string check to a fine-grained `(provider, model)` tuple set.

- **`orchestrator.py`**: Introduces `_TTFT_NOT_COMPARABLE` (a `frozenset` of `(provider, model)` pairs) and replaces the broad `entry.provider == "xai"` guard with a tuple-based lookup, correctly scoping the xAI exclusion to `grok-stt` while adding both OpenAI transcribe models.
- **`openai.py`**: Updates the module docstring to clearly distinguish `gpt-realtime-whisper` (streams partials → TTFT valid) from the two transcribe models (finalize-only → TTFT excluded).
- **`test_orchestrator.py`**: Converts the single xAI test into a parametrized case covering all three excluded models, asserting that `TTFT` is absent and `TTFS` is present in the recorded results.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is surgical, well-tested, and the existing xAI exclusion scope is unchanged in practice (only one xAI STT model exists in the registry).

The refactor from a provider-string check to a typed frozenset of (provider, model) tuples is straightforward. The two newly excluded models genuinely don't emit partials before end-of-speech, so dropping their TTFT rows is the correct fix. The parametrized test covers all three excluded entries and validates both the absence of TTFT and the presence of TTFS. No functional code in the provider itself was changed.

No files require special attention. The only files changed are the orchestrator exclusion guard, the OpenAI provider module docstring, and the corresponding test.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| runner/src/coval_bench/runner/orchestrator.py | Replaces broad provider-string exclusion with a typed frozenset of (provider, model) tuples; logic is correct and the new check precisely matches the three models that lack mid-utterance partials. |
| runner/src/coval_bench/providers/stt/openai.py | Doc-only change; updated module docstring now accurately describes the per-model streaming behaviour and cross-references _TTFT_NOT_COMPARABLE. No functional code changed. |
| runner/tests/unit/test_orchestrator.py | Test correctly parametrized over all three excluded (provider, model) pairs; asserts TTFT absent and TTFS present for each case. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[STT benchmark item runs] --> B[measure_ttft returns TranscriptionResult]
    B --> C{entry.provider, entry.model\nin _TTFT_NOT_COMPARABLE?}
    C -- Yes\ngrok-stt / gpt-4o-transcribe\ngpt-4o-mini-transcribe --> D[ttft_excluded = True\nSkip TTFT row]
    C -- No\ngpt-realtime-whisper\nand all other models --> E[ttft_excluded = False\nAppend TTFT Result row]
    D --> F[Append AudioToFinal row]
    E --> F
    F --> G{audio_to_final present\n& speech_end_offset known?}
    G -- Yes --> H[compute_ttfs\nAppend TTFS row]
    G -- No --> I[TTFS row: error / missing]
    H --> J[Append RTF & WER rows]
    I --> J
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[STT benchmark item runs] --> B[measure_ttft returns TranscriptionResult]
    B --> C{entry.provider, entry.model\nin _TTFT_NOT_COMPARABLE?}
    C -- Yes\ngrok-stt / gpt-4o-transcribe\ngpt-4o-mini-transcribe --> D[ttft_excluded = True\nSkip TTFT row]
    C -- No\ngpt-realtime-whisper\nand all other models --> E[ttft_excluded = False\nAppend TTFT Result row]
    D --> F[Append AudioToFinal row]
    E --> F
    F --> G{audio_to_final present\n& speech_end_offset known?}
    G -- Yes --> H[compute_ttfs\nAppend TTFS row]
    G -- No --> I[TTFS row: error / missing]
    H --> J[Append RTF & WER rows]
    I --> J
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix: exclude TTFT for finalize-only STT ..."](https://github.com/coval-ai/benchmarks/commit/3abee94d0078f05e2ab1cdcf768a99e14125783b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38261551)</sub>

<!-- /greptile_comment -->