### PR TITLE
ci: use workflow token for production markers

### DIFF
--- a/.github/workflows/runner-release.yml
+++ b/.github/workflows/runner-release.yml
@@ -229,19 +229,11 @@ jobs:
       contents: write
 
     steps:
-      - name: Generate GitHub App token
-        id: app_token
-        uses: actions/create-github-app-token@v3
-        with:
-          app-id: ${{ secrets.RELEASE_APP_ID }}
-          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
-
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
           ref: ${{ needs.context.outputs.deploy_sha }}
           fetch-depth: 0
-          token: ${{ steps.app_token.outputs.token }}
 
       - name: Fast-forward production-runner
         run: |

--- a/.github/workflows/web-release.yml
+++ b/.github/workflows/web-release.yml
@@ -60,19 +60,11 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
         working-directory: .
 
-      - name: Generate GitHub App token
-        id: app_token
-        uses: actions/create-github-app-token@v3
-        with:
-          app-id: ${{ secrets.RELEASE_APP_ID }}
-          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
-
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ steps.context.outputs.deploy_ref }}
-          token: ${{ steps.app_token.outputs.token }}
 
       - name: Skip if production-web already matches
         id: up_to_date


### PR DESCRIPTION
## Summary
- remove the release GitHub App token requirement from benchmarks web production release
- remove the same token requirement from the runner/API production marker step
- use the workflow's built-in contents:write token for marker branch pushes

## Validation
- actionlint .github/workflows/web-release.yml .github/workflows/runner-release.yml

This unblocks marker branch creation in repos where RELEASE_APP_ID / RELEASE_APP_PRIVATE_KEY are intentionally not configured.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes the dependency on the `RELEASE_APP_ID` / `RELEASE_APP_PRIVATE_KEY` GitHub App secrets from the production marker steps in both the runner and web release workflows, replacing the App-generated token with the built-in `GITHUB_TOKEN` (which already has `contents: write` granted at the workflow/job level).

- Drops the `actions/create-github-app-token` step and the explicit `token:` parameter from `actions/checkout` in both `promote_marker` (runner) and `promote` (web) jobs — the credential stored by `actions/checkout`'s default `persist-credentials: true` is now used for the subsequent `git push`.
- No other workflows in the repository listen on `production-runner` or `production-web` branches, so the behavioral difference that `GITHUB_TOKEN` pushes do not trigger `on: push` events has no current impact.
- Whether `GITHUB_TOKEN` can push to these branches depends on whether they carry branch protection rules; if they do, the repository settings must allow GitHub Actions to bypass those rules.

<h3>Confidence Score: 4/5</h3>

Safe to merge if the production marker branches are unprotected or the repo already permits GitHub Actions to push to them; worth confirming branch protection configuration before landing.

The change is a clean removal of two symmetric App-token steps, the necessary contents:write permission is already in place, and no other workflows in the repo react to pushes on these marker branches. The one open question is whether production-runner / production-web carry branch protection rules that the GitHub App token was previously bypassing — if so, the push step will start failing with the workflow token too.

Both workflow files are straightforward; the only thing worth double-checking is the branch protection configuration for the production-runner and production-web branches in the repository settings.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/runner-release.yml | Removes GitHub App token generation from the promote_marker job; the job already carries contents:write and checkout defaults persist-credentials to true, so git push uses GITHUB_TOKEN directly. |
| .github/workflows/web-release.yml | Removes GitHub App token generation from the promote job; workflow-level contents:write and default persist-credentials allow the git push to production-web to proceed with GITHUB_TOKEN. |

</details>



<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant WF as Workflow (GITHUB_TOKEN)
    participant GH as GitHub API
    participant Repo as Repository

    Note over WF: Before: App token required
    WF->>GH: actions/create-github-app-token (RELEASE_APP_ID + RELEASE_APP_PRIVATE_KEY)
    GH-->>WF: App token
    WF->>Repo: checkout (token: app_token)
    WF->>Repo: "git push HEAD:refs/heads/production-*"

    Note over WF: After: Workflow token only
    WF->>Repo: checkout (implicit GITHUB_TOKEN, persist-credentials: true)
    WF->>Repo: "git push HEAD:refs/heads/production-*"
    Note over WF,Repo: contents:write permission granted at workflow/job level
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant WF as Workflow (GITHUB_TOKEN)
    participant GH as GitHub API
    participant Repo as Repository

    Note over WF: Before: App token required
    WF->>GH: actions/create-github-app-token (RELEASE_APP_ID + RELEASE_APP_PRIVATE_KEY)
    GH-->>WF: App token
    WF->>Repo: checkout (token: app_token)
    WF->>Repo: "git push HEAD:refs/heads/production-*"

    Note over WF: After: Workflow token only
    WF->>Repo: checkout (implicit GITHUB_TOKEN, persist-credentials: true)
    WF->>Repo: "git push HEAD:refs/heads/production-*"
    Note over WF,Repo: contents:write permission granted at workflow/job level
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `.github/workflows/runner-release.yml`, line 238-241 ([link](https://github.com/coval-ai/benchmarks/blob/8650003edc5e7d76792fae77ea71083cf96739a9/.github/workflows/runner-release.yml#L238-L241)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **GITHUB_TOKEN cannot bypass branch protection rules**

   If `production-runner` (or `production-web` in the web workflow) is a protected branch, this `git push` will fail with a 403 unless the repository settings explicitly allow GitHub Actions to bypass those protections. A GitHub App token used previously could be configured to bypass protections via the app's installation permissions. If these marker branches are unprotected, this is fine as-is; but if branch protection was part of why the App token was originally introduced, the push will still fail — just with a different error than "missing secrets".

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["ci: use workflow token for production ma..."](https://github.com/coval-ai/benchmarks/commit/8650003edc5e7d76792fae77ea71083cf96739a9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38563795)</sub>

<!-- /greptile_comment -->