### PR TITLE
ci: pass Vercel org id during web release deploy

### DIFF
--- a/.github/workflows/web-release.yml
+++ b/.github/workflows/web-release.yml
@@ -123,6 +123,7 @@ jobs:
         if: steps.up_to_date.outputs.skip != 'true'
         id: vercel
         env:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
         run: |
           set -euo pipefail


### PR DESCRIPTION
## Summary\n- pass VERCEL_ORG_ID to the benchmarks web Vercel deploy/promote step\n- fixes release jobs that set VERCEL_PROJECT_ID but not the paired org id\n\n## Test plan\n- parsed .github/workflows/web-release.yml as YAML

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved deployment configuration to ensure proper organization setup during release deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The "Deploy and promote" step in the web release workflow was missing `VERCEL_ORG_ID` even though the immediately preceding "Build Vercel artifact" step already passed it. This caused the Vercel CLI to fail org resolution at deploy/promote time despite `VERCEL_PROJECT_ID` being set at the job level.

- `VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}` is now added to the "Deploy and promote" step's `env` block, mirroring what was already present in the build step.
- No other logic is changed; `VERCEL_PROJECT_ID` continues to be inherited from the top-level `env`, and `--scope` flags remain unchanged.

<h3>Confidence Score: 5/5</h3>

Minimal, targeted one-line addition that aligns the deploy step's env block with the build step that precedes it.

The change adds exactly the missing env var that was already used in the prior step and is required by the Vercel CLI to resolve org context at deploy time. Both the build and deploy steps now have a consistent env block, and no other logic is touched.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/web-release.yml | Adds VERCEL_ORG_ID to the "Deploy and promote" step's env block to match the env already present in the preceding "Build Vercel artifact" step, fixing org-resolution failures during release deploys. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant GH as GitHub Actions
    participant V as Vercel CLI

    GH->>V: vercel pull (Build step) VERCEL_ORG_ID, VERCEL_TOKEN, VERCEL_PROJECT_ID
    V-->>GH: .vercel config + env pulled

    GH->>GH: pnpm codegen + vercel build --prod

    GH->>V: vercel deploy --prebuilt --prod (before PR) missing VERCEL_ORG_ID
    V-->>GH: org resolution failure

    GH->>V: vercel deploy --prebuilt --prod (after PR) VERCEL_ORG_ID added
    V-->>GH: deployment_url

    GH->>V: vercel promote deployment_url
    V-->>GH: production promoted
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant GH as GitHub Actions
    participant V as Vercel CLI

    GH->>V: vercel pull (Build step) VERCEL_ORG_ID, VERCEL_TOKEN, VERCEL_PROJECT_ID
    V-->>GH: .vercel config + env pulled

    GH->>GH: pnpm codegen + vercel build --prod

    GH->>V: vercel deploy --prebuilt --prod (before PR) missing VERCEL_ORG_ID
    V-->>GH: org resolution failure

    GH->>V: vercel deploy --prebuilt --prod (after PR) VERCEL_ORG_ID added
    V-->>GH: deployment_url

    GH->>V: vercel promote deployment_url
    V-->>GH: production promoted
```

</a>

<sub>Reviews (1): Last reviewed commit: ["ci: pass Vercel org id during web releas..."](https://github.com/coval-ai/benchmarks/commit/4dd24f57f6a19377fab76ffed052d567cc95891b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38566040)</sub>

<!-- /greptile_comment -->