### PR TITLE
ci: run benchmarks web Vercel release from repo root

### DIFF
--- a/.github/workflows/web-release.yml
+++ b/.github/workflows/web-release.yml
@@ -116,8 +116,9 @@ jobs:
             echo "::error::NEXT_PUBLIC_API_URL is required for benchmarks web codegen."
             exit 1
           fi
-          pnpm codegen
+          (cd web && pnpm codegen)
           npx vercel build --prod --token="$VERCEL_TOKEN"
+        working-directory: .
 
       - name: Deploy and promote
         if: steps.up_to_date.outputs.skip != 'true'
@@ -130,6 +131,7 @@ jobs:
           deployment_url="$(npx vercel deploy --prebuilt --prod --skip-domain --scope="$VERCEL_TEAM_SCOPE" --token="$VERCEL_TOKEN")"
           echo "deployment_url=${deployment_url}" >> "$GITHUB_OUTPUT"
           npx vercel promote "$deployment_url" --scope="$VERCEL_TEAM_SCOPE" --token="$VERCEL_TOKEN" --yes
+        working-directory: .
 
       - name: Fast-forward production-web marker
         if: steps.up_to_date.outputs.skip != 'true'


### PR DESCRIPTION
## Summary\n- run Vercel pull/build/deploy from the repo root for benchmarks web releases\n- keep codegen in web/ after loading production env\n- fixes Vercel rootDirectory=web resolving as web/web when the release job cwd is already web\n\n## Test plan\n- parsed .github/workflows/web-release.yml as YAML

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a Vercel deployment path-doubling bug where the workflow's default `working-directory: web` combined with Vercel's project-level `rootDirectory=web` caused resolution to `web/web/` during build and deploy. The fix moves the `vercel pull`, `vercel build`, and `vercel deploy` steps to run from the repo root, while adapting codegen to run via `(cd web && pnpm codegen)` so it still executes in the correct subdirectory after the production env is loaded.

- `working-directory: .` is added to the **Build Vercel artifact** and **Deploy and promote** steps, overriding the job-level default of `working-directory: web`.
- Codegen is changed from a bare `pnpm codegen` (in `web/`) to `(cd web && pnpm codegen)` so it runs in the right directory; exported env vars from `set -a; source ...` propagate into the subshell correctly.

<h3>Confidence Score: 5/5</h3>

The change is a targeted, well-scoped fix to a real deployment path issue with no functional regressions introduced.

The three modified steps are internally consistent: vercel pull, env sourcing, vercel build, and vercel deploy --prebuilt all now operate from the same repo-root working directory, eliminating the path doubling. The subshell correctly inherits exported env vars, and the pnpm install step is unchanged.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/web-release.yml | Adds working-directory: . to the build and deploy steps and changes pnpm codegen to (cd web && pnpm codegen) to fix a Vercel rootDirectory path-doubling issue; logic is consistent and subshell env propagation is correct. |

</details>

<sub>Reviews (1): Last reviewed commit: ["ci: run benchmarks web Vercel release fr..."](https://github.com/coval-ai/benchmarks/commit/747710e93ae9a972ebb216ab0c0471fd6589ca33) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38567521)</sub>

<!-- /greptile_comment -->