### PR TITLE
ci: add explicit benchmarks web typecheck

### DIFF
--- a/.github/workflows/web-ci.yml
+++ b/.github/workflows/web-ci.yml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
   web:
-    name: Codegen / Lint / Test / Build
+    name: Codegen / Lint / Typecheck / Test / Build
     runs-on: ubuntu-latest
     timeout-minutes: 25
 
@@ -93,6 +93,9 @@ jobs:
 
       - name: Lint
         run: pnpm lint
+
+      - name: Typecheck
+        run: pnpm typecheck
 
       - name: Test
         run: pnpm test

--- a/web/package.json
+++ b/web/package.json
@@ -11,6 +11,7 @@
     "start": "next start",
     "lint": "eslint . --max-warnings 0",
     "lint:fix": "eslint . --fix",
+    "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "codegen": "tsx scripts/codegen.ts"
   },


### PR DESCRIPTION
## Summary
- add a first-class `pnpm typecheck` script for the benchmarks web app
- run it in the reusable web CI adapter after OpenAPI codegen and before tests/build

## Validation
- parsed `.github/workflows/web-ci.yml`
- `pnpm --dir web install --frozen-lockfile`
- `uv --directory runner sync --frozen --dev`
- generated local OpenAPI schema from `coval_bench.api.app.create_app()`
- `NEXT_PUBLIC_API_URL=http://localhost:8000 pnpm codegen`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test` (32 passed)
- `pnpm build`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds an explicit `pnpm typecheck` script (`tsc --noEmit`) to the benchmarks web app and wires it into the reusable CI workflow as a dedicated step between Lint and Test, with the job name updated to match.

- **`web/package.json`**: New `typecheck` script using `tsc --noEmit`, placed between `lint:fix` and `test` in the scripts block.
- **`.github/workflows/web-ci.yml`**: New "Typecheck" step inserted after Lint and before Test; job `name` updated from `Codegen / Lint / Test / Build` to `Codegen / Lint / Typecheck / Test / Build`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is additive CI hardening with no risk to application code or existing workflow steps.

Both changes are purely additive: a new tsc --noEmit script and the corresponding CI step inserted at the right point in the pipeline (after codegen generates types, before test and build). The job name was also correctly updated. No application logic is touched.

No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/web-ci.yml | Adds a Typecheck step (pnpm typecheck) between Lint and Test; updates job name. Step ordering and placement are correct — codegen runs first so generated types are available for tsc. |
| web/package.json | Adds the typecheck script (tsc --noEmit). Command is idiomatic for Next.js/TypeScript projects; typescript is already in devDependencies. |

</details>



<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant GH as GitHub Actions
    participant Node as Node.js (pnpm)
    participant UV as uv / Python
    participant TSC as tsc

    GH->>Node: pnpm install --frozen-lockfile
    GH->>UV: uv sync --frozen --dev
    UV->>UV: Serve OpenAPI schema on :8000
    GH->>Node: "pnpm codegen (NEXT_PUBLIC_API_URL=http://localhost:8000)"
    Note over Node: Generates TypeScript types from OpenAPI
    GH->>Node: pnpm lint
    GH->>TSC: pnpm typecheck (tsc --noEmit)
    Note over TSC: NEW — type-checks generated + app code
    GH->>Node: pnpm test
    GH->>Node: pnpm build
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant GH as GitHub Actions
    participant Node as Node.js (pnpm)
    participant UV as uv / Python
    participant TSC as tsc

    GH->>Node: pnpm install --frozen-lockfile
    GH->>UV: uv sync --frozen --dev
    UV->>UV: Serve OpenAPI schema on :8000
    GH->>Node: "pnpm codegen (NEXT_PUBLIC_API_URL=http://localhost:8000)"
    Note over Node: Generates TypeScript types from OpenAPI
    GH->>Node: pnpm lint
    GH->>TSC: pnpm typecheck (tsc --noEmit)
    Note over TSC: NEW — type-checks generated + app code
    GH->>Node: pnpm test
    GH->>Node: pnpm build
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `.github/workflows/web-ci.yml`, line 24 ([link](https://github.com/coval-ai/benchmarks/blob/b24968b8ca67e6adc80e93eca71aafdc862343ca/.github/workflows/web-ci.yml#L24)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The job `name` field still lists the old four phases and doesn't reflect the newly added Typecheck step, which can be confusing when reading workflow run summaries on GitHub.

   

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["ci: add explicit benchmarks web typechec..."](https://github.com/coval-ai/benchmarks/commit/d82ff76ecc702cabdc28ab8c4da6ea09939f7ad8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38587933)</sub>

<!-- /greptile_comment -->