### PR TITLE
ci: typecheck runner tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
       # -----------------------------------------------------------------------
       - name: mypy strict
         working-directory: runner
-        run: uv run mypy --strict src
+        run: uv run mypy --strict src tests
 
       # -----------------------------------------------------------------------
       # Tests

--- a/runner/src/coval_bench/datasets/loader.py
+++ b/runner/src/coval_bench/datasets/loader.py
@@ -42,7 +42,7 @@ import random
 from importlib.resources import files
 from pathlib import Path
 
-from google.cloud import storage
+import google.cloud.storage as storage
 from pydantic import BaseModel, Field
 
 from coval_bench.config import Settings

--- a/runner/src/coval_bench/datasets/scripts/build_dataset.py
+++ b/runner/src/coval_bench/datasets/scripts/build_dataset.py
@@ -72,7 +72,7 @@ import click
 import soundfile as sf
 
 if TYPE_CHECKING:
-    from google.cloud import storage as _gcs_storage
+    import google.cloud.storage as _gcs_storage
 
 logger = logging.getLogger(__name__)
 
@@ -410,7 +410,7 @@ def _build_items(selected: list[_Utterance], work_dir: Path) -> list[_BuiltItem]
 
 def _gcs_client() -> _gcs_storage.Client:
     """Create a GCS client using ADC (no service-account key file)."""
-    from google.cloud import storage
+    import google.cloud.storage as storage
 
     return storage.Client()
 

--- a/runner/src/coval_bench/providers/tts/rime.py
+++ b/runner/src/coval_bench/providers/tts/rime.py
@@ -33,9 +33,9 @@ class RimeTTSProvider(TTSProvider):
 
     _VALID_MODELS = frozenset({"arcana", "coda", "mistv3"})
 
-    def __init__(self, settings: Settings, model: str, voice: str) -> None:
+    def __init__(self, settings: Settings, model: str, voice: str | None) -> None:
         self._model = model
-        self._voice = voice
+        self._voice = voice or "luna"
 
         api_key_secret = settings.rime_api_key
         if api_key_secret is None:

--- a/runner/tests/api/test_providers.py
+++ b/runner/tests/api/test_providers.py
@@ -103,7 +103,7 @@ async def test_providers_no_db_connection(app: FastAPI, monkeypatch: pytest.Monk
     endpoint still returns 200.
     """
     original_pool = app.state.pool
-    app.state.pool = None  # type: ignore[assignment]
+    app.state.pool = None
     try:
         async with AsyncClient(
             transport=ASGITransport(app=app),

--- a/runner/tests/conftest.py
+++ b/runner/tests/conftest.py
@@ -20,7 +20,7 @@ def override_settings(
     receives the test settings rather than reading real env vars.
     """
     test_settings = Settings(
-        database_url="postgresql://runner:password@localhost:5432/benchmarks",  # type: ignore[arg-type]
+        database_url="postgresql://runner:password@localhost:5432/benchmarks",
         dataset_bucket="test-bucket",
         dataset_id="stt-v1",
         runner_sha="test",

--- a/runner/tests/providers/stt/conftest.py
+++ b/runner/tests/providers/stt/conftest.py
@@ -32,7 +32,7 @@ from __future__ import annotations
 import json
 from collections.abc import Callable
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import pytest
 from pydantic import SecretStr
@@ -130,10 +130,10 @@ def audio_pcm_bytes() -> bytes:
     import soundfile as sf
 
     data, _sr = sf.read(str(AUDIO_FIXTURE), dtype="int16", always_2d=False)
-    return data.tobytes()  # type: ignore[return-value]
+    return bytes(data.tobytes())
 
 
 def load_fixture_events(provider: str, scenario: str = "events-success") -> list[Any]:
     """Load JSON event list from ``fixtures/<provider>/<scenario>.json``."""
     path = FIXTURES_DIR / provider / f"{scenario}.json"
-    return json.loads(path.read_text())  # type: ignore[return-value]
+    return cast(list[Any], json.loads(path.read_text()))

--- a/runner/tests/providers/test_http_session.py
+++ b/runner/tests/providers/test_http_session.py
@@ -5,13 +5,16 @@
 
 from __future__ import annotations
 
+from collections.abc import Generator
+from typing import Any, cast
+
 import pytest
 
 from coval_bench.providers import _http_session
 
 
 @pytest.fixture(autouse=True)
-def _reset_clients() -> None:
+def _reset_clients() -> Generator[None, None, None]:
     _http_session._CLIENTS.clear()
     yield
     _http_session._CLIENTS.clear()
@@ -49,7 +52,8 @@ def test_get_shared_client_uses_timed_transport() -> None:
 
 def test_get_shared_client_applies_http2_and_limits() -> None:
     """http2/limits must live on the transport's pool, not the ignored client args."""
-    pool = _http_session.get_shared_client("foo", "https://example.com")._transport._pool
+    transport = cast(Any, _http_session.get_shared_client("foo", "https://example.com")._transport)
+    pool = transport._pool
     assert pool._http2 is True
     assert pool._keepalive_expiry == _http_session._KEEPALIVE_S
     assert pool._max_keepalive_connections == _http_session._MAX_KEEPALIVE_CONNECTIONS
@@ -170,6 +174,6 @@ async def test_close_all_swallows_per_client_errors() -> None:
         async def aclose(self) -> None:
             raise RuntimeError("synthetic close failure")
 
-    _http_session._CLIENTS["broken"] = _BrokenClient()  # type: ignore[assignment]
+    _http_session._CLIENTS["broken"] = cast(Any, _BrokenClient())
     await _http_session.close_all()  # must not raise
     assert _http_session._CLIENTS == {}

--- a/runner/tests/providers/tts/conftest.py
+++ b/runner/tests/providers/tts/conftest.py
@@ -11,13 +11,14 @@ monkeypatched fake SDKs.
 from __future__ import annotations
 
 import wave as _wave
-from collections.abc import Sequence
+from collections.abc import AsyncIterator, Sequence
 from io import BytesIO
 from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from pydantic import SecretStr
 
 from coval_bench.config import Settings
 
@@ -45,22 +46,22 @@ def vcr_config() -> dict[str, Any]:
 def fake_settings(tmp_path: Path) -> Settings:
     """Settings instance with placeholder API keys suitable for offline tests."""
     return Settings(
-        database_url="postgresql://runner:password@localhost:5432/benchmarks",  # type: ignore[arg-type]
+        database_url="postgresql://runner:password@localhost:5432/benchmarks",
         dataset_bucket="test-bucket",
         dataset_id="stt-v1",
         runner_sha="test",
         log_level="DEBUG",
-        openai_api_key="sk-test-openai",  # type: ignore[arg-type]
-        cartesia_api_key="test-cartesia-key",  # type: ignore[arg-type]
-        elevenlabs_api_key="test-elevenlabs-key",  # type: ignore[arg-type]
-        deepgram_api_key="test-deepgram-key",  # type: ignore[arg-type]
-        hume_api_key="test-hume-key",  # type: ignore[arg-type]
-        rime_api_key="test-rime-key",  # type: ignore[arg-type]
-        gradium_tts_api_key="test-gradium-tts-key",  # type: ignore[arg-type]
-        xai_api_key="test-xai-key",
-        smallest_api_key="test-smallest-key",  # type: ignore[arg-type]
-        inworld_api_key="test-inworld-key",
-        soniox_api_key="test-soniox-key",  # type: ignore[arg-type]
+        openai_api_key=SecretStr("sk-test-openai"),
+        cartesia_api_key=SecretStr("test-cartesia-key"),
+        elevenlabs_api_key=SecretStr("test-elevenlabs-key"),
+        deepgram_api_key=SecretStr("test-deepgram-key"),
+        hume_api_key=SecretStr("test-hume-key"),
+        rime_api_key=SecretStr("test-rime-key"),
+        gradium_tts_api_key=SecretStr("test-gradium-tts-key"),
+        xai_api_key=SecretStr("test-xai-key"),
+        smallest_api_key=SecretStr("test-smallest-key"),
+        inworld_api_key=SecretStr("test-inworld-key"),
+        soniox_api_key=SecretStr("test-soniox-key"),
     )
 
 
@@ -100,7 +101,7 @@ class FakeWebSocket:
             return msg
         raise StopAsyncIteration
 
-    def __aiter__(self) -> _AsyncFakeWebSocketIter:
+    def __aiter__(self) -> AsyncIterator[str | bytes]:
         return _AsyncFakeWebSocketIter(self)
 
     async def __aenter__(self) -> FakeWebSocket:

--- a/runner/tests/providers/tts/test_cartesia.py
+++ b/runner/tests/providers/tts/test_cartesia.py
@@ -207,7 +207,7 @@ async def test_cartesia_send_includes_output_format(fake_settings: Settings) -> 
 
 def test_cartesia_missing_api_key() -> None:
     settings_no_key = Settings(
-        database_url="postgresql://runner:password@localhost:5432/benchmarks",  # type: ignore[arg-type]
+        database_url="postgresql://runner:password@localhost:5432/benchmarks",
         dataset_bucket="test-bucket",
         dataset_id="stt-v1",
         runner_sha="test",

--- a/runner/tests/providers/tts/test_elevenlabs.py
+++ b/runner/tests/providers/tts/test_elevenlabs.py
@@ -5,7 +5,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Generator
 from pathlib import Path
+from typing import Any
 
 import httpx
 import pytest
@@ -21,16 +23,16 @@ from .conftest import make_pcm_bytes
 # ---------------------------------------------------------------------------
 
 
-def _install_mock(handler: object) -> None:
+def _install_mock(handler: Any) -> None:
     """Register a MockTransport-backed AsyncClient as the shared elevenlabs client."""
     _http_session._CLIENTS["elevenlabs"] = httpx.AsyncClient(
         base_url="https://api.elevenlabs.io",
-        transport=httpx.MockTransport(handler),  # type: ignore[arg-type]
+        transport=httpx.MockTransport(handler),
     )
 
 
 @pytest.fixture(autouse=True)
-def reset_clients() -> None:
+def reset_clients() -> Generator[None, None, None]:
     _http_session._CLIENTS.clear()
     yield
     _http_session._CLIENTS.clear()
@@ -206,7 +208,7 @@ def test_elevenlabs_rejects_unsupported_model(fake_settings: Settings) -> None:
 
 def test_elevenlabs_missing_api_key() -> None:
     settings_no_key = Settings(
-        database_url="postgresql://runner:password@localhost:5432/benchmarks",  # type: ignore[arg-type]
+        database_url="postgresql://runner:password@localhost:5432/benchmarks",
         dataset_bucket="test-bucket",
         dataset_id="stt-v1",
         runner_sha="test",

--- a/runner/tests/providers/tts/test_gradium.py
+++ b/runner/tests/providers/tts/test_gradium.py
@@ -244,7 +244,7 @@ def test_gradium_name_and_model(fake_settings: Settings) -> None:
 
 def test_gradium_missing_api_key() -> None:
     settings_no_key = Settings(
-        database_url="postgresql://runner:password@localhost:5432/benchmarks",  # type: ignore[arg-type]
+        database_url="postgresql://runner:password@localhost:5432/benchmarks",
         dataset_bucket="test-bucket",
         dataset_id="stt-v1",
         runner_sha="test",

--- a/runner/tests/providers/tts/test_hume.py
+++ b/runner/tests/providers/tts/test_hume.py
@@ -297,7 +297,7 @@ def test_hume_name_and_model(fake_settings: Settings) -> None:
 
 def test_hume_missing_api_key() -> None:
     settings_no_key = Settings(
-        database_url="postgresql://runner:password@localhost:5432/benchmarks",  # type: ignore[arg-type]
+        database_url="postgresql://runner:password@localhost:5432/benchmarks",
         dataset_bucket="test-bucket",
         dataset_id="stt-v1",
         runner_sha="test",

--- a/runner/tests/providers/tts/test_openai.py
+++ b/runner/tests/providers/tts/test_openai.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Generator
 from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -20,7 +21,7 @@ from .conftest import make_pcm_bytes
 
 
 @pytest.fixture(autouse=True)
-def _reset_http_clients() -> None:
+def _reset_http_clients() -> Generator[None, None, None]:
     _http_session._CLIENTS.clear()
     yield
     _http_session._CLIENTS.clear()

--- a/runner/tests/providers/tts/test_rime.py
+++ b/runner/tests/providers/tts/test_rime.py
@@ -400,7 +400,7 @@ def test_rime_name_and_model(fake_settings: Settings, model: str) -> None:
 
 def test_rime_missing_api_key() -> None:
     settings_no_key = Settings(
-        database_url="postgresql://runner:password@localhost:5432/benchmarks",  # type: ignore[arg-type]
+        database_url="postgresql://runner:password@localhost:5432/benchmarks",
         dataset_bucket="test-bucket",
         dataset_id="stt-v1",
         runner_sha="test",

--- a/runner/tests/providers/tts/test_smallest.py
+++ b/runner/tests/providers/tts/test_smallest.py
@@ -160,7 +160,7 @@ def test_smallest_rejects_unsupported_model(fake_settings: Settings) -> None:
 
 def test_smallest_missing_api_key() -> None:
     settings_no_key = Settings(
-        database_url="postgresql://runner:password@localhost:5432/benchmarks",  # type: ignore[arg-type]
+        database_url="postgresql://runner:password@localhost:5432/benchmarks",
         dataset_bucket="test-bucket",
         dataset_id="stt-v1",
         runner_sha="test",

--- a/runner/tests/unit/test_dataset_loader.py
+++ b/runner/tests/unit/test_dataset_loader.py
@@ -67,7 +67,7 @@ BAD_HASH_MANIFEST_PATH = FIXTURES_DIR / "manifest-bad-hash.json"
 @pytest.fixture()
 def test_settings() -> Settings:
     return Settings(
-        database_url="postgresql://runner:password@localhost:5432/benchmarks",  # type: ignore[arg-type]
+        database_url="postgresql://runner:password@localhost:5432/benchmarks",
         dataset_bucket="test-bucket",
         dataset_id="stt-v1",
     )

--- a/runner/tests/unit/test_db_writer.py
+++ b/runner/tests/unit/test_db_writer.py
@@ -83,9 +83,11 @@ def _downgrade_migrations(conn: psycopg.Connection[Any]) -> None:
     alembic_command.downgrade(cfg, "base")
 
 
-async def _make_pool(conn: psycopg.Connection[Any]) -> AsyncConnectionPool:  # type: ignore[type-arg]
+async def _make_pool(
+    conn: psycopg.Connection[Any],
+) -> AsyncConnectionPool[psycopg.AsyncConnection[psycopg.rows.DictRow]]:
     """Create and open a psycopg3 async pool for the test database."""
-    pool: AsyncConnectionPool = AsyncConnectionPool(  # type: ignore[type-arg]
+    pool: AsyncConnectionPool[psycopg.AsyncConnection[psycopg.rows.DictRow]] = AsyncConnectionPool(
         conninfo=_async_dsn(conn),
         min_size=1,
         max_size=4,
@@ -589,7 +591,7 @@ def test_record_results_batch_rollback_on_failure(pg_conn: psycopg.Connection[An
                 status=ResultStatus.SUCCESS,  # will be overridden in raw SQL below
             )
             # Inject an invalid benchmark value to trigger CheckViolation
-            bad = bad.model_copy(update={"benchmark": "INVALID"})  # type: ignore[arg-type]
+            bad = bad.model_copy(update={"benchmark": "INVALID"})
             with pytest.raises(psycopg.errors.CheckViolation):
                 await writer.record_results([good, bad])
             return run.id

--- a/runner/tests/unit/test_orchestrator.py
+++ b/runner/tests/unit/test_orchestrator.py
@@ -47,7 +47,7 @@ from coval_bench.runner.retry import with_retry
 # ---------------------------------------------------------------------------
 
 _TEST_SETTINGS = Settings(
-    database_url="postgresql://runner:password@localhost:5432/benchmarks",  # type: ignore[arg-type]
+    database_url="postgresql://runner:password@localhost:5432/benchmarks",
     dataset_bucket="test-bucket",
     dataset_id="stt-v1",
     runner_sha="test-sha",
@@ -1440,7 +1440,8 @@ async def test_stt_empty_result_marked_failed(audio_file: Path, settings: Settin
     by_metric = {r.metric_type: r for r in _recorded_rows(writer)}
     for mt in ("TTFT", "AudioToFinal", "RTF"):
         assert by_metric[mt].status == ResultStatus.FAILED
-        assert by_metric[mt].error and "produced" in by_metric[mt].error
+        error = by_metric[mt].error
+        assert error is not None and "produced" in error
     assert "WER" not in by_metric  # no transcript → no WER row
     assert summary.success_count == 0
     assert summary.status == str(RunStatus.FAILED)


### PR DESCRIPTION
## Summary
- extend runner/API CI mypy from `src` to `src tests`
- clean up test typing issues: stale ignores, fixture generator return types, fake client casts, and typed JSON/audio fixture helpers
- normalize `RimeTTSProvider`'s `voice` annotation to match its existing `None` -> `luna` fallback behavior

## Validation
- parsed `.github/workflows/ci.yml`
- `uv sync --frozen --dev`
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy --strict src tests`
- `uv run pytest -q` (582 passed, 1 skipped)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extends the runner's mypy strict check from `src` to `src tests`, then cleans up all typing issues the expanded check surfaced. No behavioral changes are intended except for `RimeTTSProvider`, which now officially accepts `voice=None` and falls back to `"luna"` in its constructor.

- **CI**: `uv run mypy --strict src tests` now covers the full test tree, preventing future type regressions in test code.
- **Source fixes**: GCS imports are rewritten to `import google.cloud.storage as storage` for mypy strict compatibility; `RimeTTSProvider.__init__` widens `voice` to `str | None` with a `or "luna"` default.
- **Test fixes**: Stale `type: ignore` suppressions removed across 12+ test files, fixture generators typed as `Generator[None, None, None]`, fake client assignments replaced with `cast(Any, ...)`, and `SecretStr(...)` wrappers added to `Settings` constructors.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes are typing housekeeping and the only behavioral change is the officially documented None→luna fallback in RimeTTSProvider.

The diff is entirely type annotation cleanup: removing stale ignores, adding SecretStr wrappers, correcting generator return types, and widening the rime voice parameter. The single behavioral change (voice=None → "luna") was already the implicit runtime behavior before this PR. No logic paths were restructured.

runner/src/coval_bench/providers/tts/rime.py has a minor dead-code fragment (the `or "luna"` guard in synthesize() is now unreachable after the constructor change).

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/ci.yml | Extends mypy strict type checking from `src` to `src tests`, ensuring tests are now covered by the same strict typing rules. |
| runner/src/coval_bench/providers/tts/rime.py | Widens `voice` parameter to `str | None` and applies `or "luna"` fallback in `__init__`; a redundant `or "luna"` guard in `synthesize()` is now dead code but harmless. |
| runner/src/coval_bench/datasets/loader.py | Switches GCS import from `from google.cloud import storage` to `import google.cloud.storage as storage` for mypy strict compatibility; functionally identical. |
| runner/src/coval_bench/datasets/scripts/build_dataset.py | Same GCS import style fix as loader.py, applied in both the TYPE_CHECKING guard and the runtime `_gcs_client()` function. |
| runner/tests/providers/tts/conftest.py | Replaces bare string literals passed to `Settings` with explicit `SecretStr(...)` wrappers (eliminating the `type: ignore[arg-type]` suppressions) and corrects `FakeWebSocket.__aiter__` return type to `AsyncIterator[str | bytes]`. |
| runner/tests/providers/test_http_session.py | Fixes fixture generator return type, uses `cast(Any, ...)` to access private transport internals and inject a `_BrokenClient`, removing stale `type: ignore` suppressions. |
| runner/tests/unit/test_db_writer.py | Fully parameterises `AsyncConnectionPool` generic with the correct connection and row types, removing two `type: ignore[type-arg]` suppressions; also refines a null-assertion pattern. |
| runner/tests/providers/stt/conftest.py | Wraps `json.loads` return with `cast(list[Any], ...)` and wraps numpy `tobytes()` result with `bytes()` to satisfy mypy, replacing stale `type: ignore` comments. |
| runner/tests/unit/test_orchestrator.py | Removes a stale `type: ignore[arg-type]` on `database_url` and refines an assertion to use explicit `is not None` pattern for mypy strict compatibility. |

</details>



<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[RimeTTSProvider.__init__ voice str or None] --> B{voice is None?}
    B -- Yes --> C[self._voice = luna]
    B -- No --> D[self._voice = voice]
    C --> E[synthesize: speaker = self._voice always a str]
    D --> E
    E --> F[WebSocket /ws3 request]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[RimeTTSProvider.__init__ voice str or None] --> B{voice is None?}
    B -- Yes --> C[self._voice = luna]
    B -- No --> D[self._voice = voice]
    C --> E[synthesize: speaker = self._voice always a str]
    D --> E
    E --> F[WebSocket /ws3 request]
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `runner/src/coval_bench/providers/tts/rime.py`, line 76-77 ([link](https://github.com/coval-ai/benchmarks/blob/ca7e065bc5af1ec4f696b2ce716db12262804ccd/runner/src/coval_bench/providers/tts/rime.py#L76-L77)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> After `__init__` assigns `self._voice = voice or "luna"`, `self._voice` is always a non-empty `str`. The `or "luna"` guard in `synthesize()` can never trigger and is dead code left over from before the annotation was widened.

   

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["ci: typecheck runner tests"](https://github.com/coval-ai/benchmarks/commit/ca7e065bc5af1ec4f696b2ce716db12262804ccd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38589241)</sub>

<!-- /greptile_comment -->