### PR TITLE
ci: stop running legacy runner CI directly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,8 @@
 # Copyright 2026 The Coval Benchmarks Authors
 # SPDX-License-Identifier: Apache-2.0
 #
-# PR gate: lint + type-check + tests + secret scan + docker build (no push)
-# Triggers on every pull_request targeting main.
+# Reusable runner/API CI adapter: lint + type-check + tests + secret scan +
+# docker build (no push). PR/MQ selection is owned by switchboard.yml.
 
 name: CI
 
@@ -21,9 +21,6 @@ on:
         required: false
         type: string
         default: main
-  pull_request:
-    branches:
-      - main
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- remove the direct `pull_request` trigger from `.github/workflows/ci.yml`
- keep the workflow as the reusable runner/API CI adapter for Switchboard and manual dispatch
- leave CodeQL, Trivy, tag release, and production release workflows unchanged because they are not represented by the PR/MQ adapters

## Why
Switchboard now owns PR/MQ selection for benchmarks runner/API and calls this workflow as `Benchmarks Runner CI Adapter`. The old direct trigger produced duplicate checks (`Lint / Test / Build` and `Methodology marker check`) alongside the adapter checks.

## Validation
- Parsed every `.github/workflows/*.yml` file with Ruby YAML

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes the direct `pull_request` trigger from `.github/workflows/ci.yml`, leaving it callable only via `workflow_call` (from `switchboard.yml`) and `workflow_dispatch`. The intent is to eliminate duplicate CI check runs now that Switchboard owns PR/MQ selection.

- The main `ci` job is unaffected: Switchboard already calls it as the \"Benchmarks Runner CI Adapter\" with the correct ref.
- The `methodology-gate` job has `if: github.event_name == 'pull_request'` and will never execute after this change — when invoked via `workflow_call` or `workflow_dispatch`, `github.event_name` is never `pull_request`, so this advisory check is silently disabled for all PRs going forward.

<h3>Confidence Score: 3/5</h3>

The main CI job will continue to run correctly via Switchboard, but the methodology-gate advisory check is now permanently dead and will never warn on methodology-sensitive file changes.

Removing the `pull_request` trigger achieves the stated goal of eliminating duplicate checks, and the `ci` job itself is unaffected. However, the `methodology-gate` job's guard condition (`github.event_name == 'pull_request'`) is now permanently false — the check is silently disabled for all future PRs with no indication in the workflow output. This is a real behavioral regression that was not called out in the PR description or addressed with an alternative trigger.

`.github/workflows/ci.yml` — specifically the `methodology-gate` job and its event-name guard on line 145.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/ci.yml | Removes the `pull_request` trigger and updates the header comment; however, the `methodology-gate` job's `if: github.event_name == 'pull_request'` guard is now permanently false, silently disabling that advisory check for all future PRs. |

</details>



<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant PR as Pull Request / Merge Group
    participant SW as switchboard.yml
    participant CI as ci.yml (after PR)
    participant MG as methodology-gate job

    PR->>SW: pull_request / merge_group event
    SW->>SW: Plan checks (Switchboard)
    SW->>CI: "workflow_call (github.event_name = workflow_call)"
    CI->>CI: Lint / Test / Build (runs OK)
    CI-->>MG: "if: github.event_name == pull_request → false"
    Note over MG: methodology-gate never runs
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant PR as Pull Request / Merge Group
    participant SW as switchboard.yml
    participant CI as ci.yml (after PR)
    participant MG as methodology-gate job

    PR->>SW: pull_request / merge_group event
    SW->>SW: Plan checks (Switchboard)
    SW->>CI: "workflow_call (github.event_name = workflow_call)"
    CI->>CI: Lint / Test / Build (runs OK)
    CI-->>MG: "if: github.event_name == pull_request → false"
    Note over MG: methodology-gate never runs
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `.github/workflows/ci.yml`, line 145 ([link](https://github.com/coval-ai/benchmarks/blob/a9c7150897a66cf0c0b723a86c80b5fe8c0bc285/.github/workflows/ci.yml#L145)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **`methodology-gate` is now permanently skipped**

   The job guard `if: github.event_name == 'pull_request'` will never be true once the `pull_request` trigger is removed. When Switchboard calls this workflow via `workflow_call`, `github.event_name` is `workflow_call`; for manual runs it is `workflow_dispatch`. Neither satisfies the condition, so `methodology-gate` is silently dead code and methodology-sensitive file changes will no longer produce any warning on PRs. The PR description notes other workflows are intentionally untouched, but this job's trigger dependency was missed.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["ci: stop running legacy benchmarks runne..."](https://github.com/coval-ai/benchmarks/commit/a9c7150897a66cf0c0b723a86c80b5fe8c0bc285) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38594138)</sub>

<!-- /greptile_comment -->