### PR TITLE
Add Voice Arena read endpoints

### DIFF
--- a/runner/src/coval_bench/api/app.py
+++ b/runner/src/coval_bench/api/app.py
@@ -28,7 +28,15 @@ from slowapi.middleware import SlowAPIMiddleware
 
 from coval_bench.api.cache import new_cache_locks, new_response_cache
 from coval_bench.api.ratelimit import _rate_limit_handler, limiter
-from coval_bench.api.routers import aggregates, health, leaderboard, providers, results, runs
+from coval_bench.api.routers import (
+    aggregates,
+    arena,
+    health,
+    leaderboard,
+    providers,
+    results,
+    runs,
+)
 from coval_bench.config import Settings, get_settings
 from coval_bench.db.conn import lifespan_pool
 
@@ -111,5 +119,6 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     app.include_router(aggregates.router, prefix="/v1")
     app.include_router(leaderboard.router, prefix="/v1")
     app.include_router(providers.router, prefix="/v1")
+    app.include_router(arena.router, prefix="/v1")
 
     return app

--- a/runner/src/coval_bench/api/routers/arena.py
+++ b/runner/src/coval_bench/api/routers/arena.py
@@ -20,7 +20,6 @@ recorded.
 from __future__ import annotations
 
 import uuid
-from datetime import datetime
 from typing import Any
 
 import psycopg.rows
@@ -28,52 +27,15 @@ import structlog
 from fastapi import APIRouter, Depends, HTTPException, Query
 from posthog import Posthog
 from psycopg_pool import AsyncConnectionPool
-from pydantic import BaseModel
 from starlette.requests import Request
 
 from coval_bench.api.deps import capture_api_event, get_pool, get_posthog
 from coval_bench.api.ratelimit import limiter
+from coval_bench.api.schemas import ArenaLeaderboardResponse, BattleOut, LeaderboardEntryOut
 
 logger = structlog.get_logger("coval_bench.api")
 
 router = APIRouter(tags=["arena"])
-
-
-class BattleOut(BaseModel):
-    """A battle to vote on. Blind by design: no provider/model identities."""
-
-    id: uuid.UUID
-    prompt_text: str
-    domain: str | None
-    audio_a_url: str
-    audio_b_url: str
-
-
-class LeaderboardEntryOut(BaseModel):
-    """One model's row within an arena leaderboard board."""
-
-    provider: str
-    model: str
-    rating_elo: float
-    rating_bt: float
-    ci_low: float | None
-    ci_high: float | None
-    ci_half_width: float | None
-    votes_total: int
-    wins: float
-    losses: float
-    ties: float
-    status: str
-
-
-class ArenaLeaderboardResponse(BaseModel):
-    """The latest board for a metric/domain, or empty if none computed yet."""
-
-    metric: str
-    domain: str
-    computed_at: datetime | None
-    methodology_version: str | None
-    entries: list[LeaderboardEntryOut]
 
 
 # Columns exposed by the (blind) battle endpoints — provider/model are withheld.
@@ -105,6 +67,8 @@ async def get_battle(
     """Return one battle to vote on, chosen at random. 404 if none exist."""
     async with pool.connection() as conn:
         conn.row_factory = psycopg.rows.dict_row
+        # Placeholder selection: a uniformly random battle. Adaptive pairing will
+        # replace this to surface the most informative matchups.
         rows = await conn.execute(
             f"SELECT {_BATTLE_COLS} FROM arena.battles ORDER BY random() LIMIT 1"  # noqa: S608
         )

--- a/runner/src/coval_bench/api/routers/arena.py
+++ b/runner/src/coval_bench/api/routers/arena.py
@@ -41,19 +41,24 @@ router = APIRouter(tags=["arena"])
 # Columns exposed by the (blind) battle endpoints — provider/model are withheld.
 _BATTLE_COLS = "id, prompt_text, domain, audio_a_url, audio_b_url"
 
-# Latest board for a (metric, domain): the rows sharing the max computed_at.
+# Latest board for a (metric, domain): the rows of the single most recent
+# (computed_at, methodology_version), so two methodology versions computed at the
+# same timestamp never mix into one board.
 _LEADERBOARD_SQL = """
-    SELECT provider, model, methodology_version, computed_at,
-           rating_elo, rating_bt, ci_low, ci_high, ci_half_width,
-           votes_total, wins, losses, ties, status
-    FROM arena.leaderboard_snapshots
-    WHERE metric_name = %(metric)s
-      AND domain = %(domain)s
-      AND computed_at = (
-          SELECT max(computed_at) FROM arena.leaderboard_snapshots
-          WHERE metric_name = %(metric)s AND domain = %(domain)s
-      )
-    ORDER BY rating_elo DESC
+    WITH latest AS (
+        SELECT computed_at, methodology_version
+        FROM arena.leaderboard_snapshots
+        WHERE metric_name = %(metric)s AND domain = %(domain)s
+        ORDER BY computed_at DESC, methodology_version DESC
+        LIMIT 1
+    )
+    SELECT s.provider, s.model, s.methodology_version, s.computed_at,
+           s.rating_elo, s.rating_bt, s.ci_low, s.ci_high, s.ci_half_width,
+           s.votes_total, s.wins, s.losses, s.ties, s.status
+    FROM arena.leaderboard_snapshots s
+    JOIN latest l USING (computed_at, methodology_version)
+    WHERE s.metric_name = %(metric)s AND s.domain = %(domain)s
+    ORDER BY s.rating_elo DESC
 """
 
 

--- a/runner/src/coval_bench/api/routers/arena.py
+++ b/runner/src/coval_bench/api/routers/arena.py
@@ -1,0 +1,174 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Voice Arena read endpoints.
+
+``GET /v1/arena/battle``       — a battle to vote on (blind: no model identities).
+``GET /v1/arena/battle/{id}``  — a specific battle.
+``GET /v1/arena/leaderboard``  — the latest computed board for a metric/domain.
+
+Reads only. Battles/votes are written elsewhere; leaderboard rows are produced by
+the snapshot job, so the leaderboard is empty until that job has run. Queries hit
+the pool directly, matching the other routers; this module does not depend on the
+arena DB-access layer, so it can land independently.
+
+The battle payload deliberately omits provider/model identities to keep voting
+blind — the A/B -> model mapping stays server-side, used only when a vote is
+recorded.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Any
+
+import psycopg.rows
+import structlog
+from fastapi import APIRouter, Depends, HTTPException, Query
+from posthog import Posthog
+from psycopg_pool import AsyncConnectionPool
+from pydantic import BaseModel
+from starlette.requests import Request
+
+from coval_bench.api.deps import capture_api_event, get_pool, get_posthog
+from coval_bench.api.ratelimit import limiter
+
+logger = structlog.get_logger("coval_bench.api")
+
+router = APIRouter(tags=["arena"])
+
+
+class BattleOut(BaseModel):
+    """A battle to vote on. Blind by design: no provider/model identities."""
+
+    id: uuid.UUID
+    prompt_text: str
+    domain: str | None
+    audio_a_url: str
+    audio_b_url: str
+
+
+class LeaderboardEntryOut(BaseModel):
+    """One model's row within an arena leaderboard board."""
+
+    provider: str
+    model: str
+    rating_elo: float
+    rating_bt: float
+    ci_low: float | None
+    ci_high: float | None
+    ci_half_width: float | None
+    votes_total: int
+    wins: float
+    losses: float
+    ties: float
+    status: str
+
+
+class ArenaLeaderboardResponse(BaseModel):
+    """The latest board for a metric/domain, or empty if none computed yet."""
+
+    metric: str
+    domain: str
+    computed_at: datetime | None
+    methodology_version: str | None
+    entries: list[LeaderboardEntryOut]
+
+
+# Columns exposed by the (blind) battle endpoints — provider/model are withheld.
+_BATTLE_COLS = "id, prompt_text, domain, audio_a_url, audio_b_url"
+
+# Latest board for a (metric, domain): the rows sharing the max computed_at.
+_LEADERBOARD_SQL = """
+    SELECT provider, model, methodology_version, computed_at,
+           rating_elo, rating_bt, ci_low, ci_high, ci_half_width,
+           votes_total, wins, losses, ties, status
+    FROM arena.leaderboard_snapshots
+    WHERE metric_name = %(metric)s
+      AND domain = %(domain)s
+      AND computed_at = (
+          SELECT max(computed_at) FROM arena.leaderboard_snapshots
+          WHERE metric_name = %(metric)s AND domain = %(domain)s
+      )
+    ORDER BY rating_elo DESC
+"""
+
+
+@router.get("/arena/battle", response_model=BattleOut)
+@limiter.limit("60/minute")
+async def get_battle(
+    request: Request,  # required by slowapi
+    pool: AsyncConnectionPool[Any] = Depends(get_pool),
+    posthog_client: Posthog | None = Depends(get_posthog),
+) -> BattleOut:
+    """Return one battle to vote on, chosen at random. 404 if none exist."""
+    async with pool.connection() as conn:
+        conn.row_factory = psycopg.rows.dict_row
+        rows = await conn.execute(
+            f"SELECT {_BATTLE_COLS} FROM arena.battles ORDER BY random() LIMIT 1"  # noqa: S608
+        )
+        row = await rows.fetchone()
+    if row is None:
+        raise HTTPException(404, "no battles available")
+    capture_api_event(
+        posthog_client,
+        "arena_battle_served",
+        {"$process_person_profile": False},
+    )
+    return BattleOut.model_validate(row)
+
+
+@router.get("/arena/battle/{battle_id}", response_model=BattleOut)
+@limiter.limit("60/minute")
+async def get_battle_by_id(
+    request: Request,  # required by slowapi
+    battle_id: uuid.UUID,
+    pool: AsyncConnectionPool[Any] = Depends(get_pool),
+) -> BattleOut:
+    """Return a specific battle by id. 404 if not found (422 if id is not a UUID)."""
+    async with pool.connection() as conn:
+        conn.row_factory = psycopg.rows.dict_row
+        rows = await conn.execute(
+            f"SELECT {_BATTLE_COLS} FROM arena.battles WHERE id = %(id)s",  # noqa: S608
+            {"id": battle_id},
+        )
+        row = await rows.fetchone()
+    if row is None:
+        raise HTTPException(404, f"battle {battle_id} not found")
+    return BattleOut.model_validate(row)
+
+
+@router.get("/arena/leaderboard", response_model=ArenaLeaderboardResponse)
+@limiter.limit("60/minute")
+async def get_arena_leaderboard(
+    request: Request,  # required by slowapi
+    metric: str = Query(default="naturalness"),
+    domain: str = Query(default="all"),
+    pool: AsyncConnectionPool[Any] = Depends(get_pool),
+    posthog_client: Posthog | None = Depends(get_posthog),
+) -> ArenaLeaderboardResponse:
+    """Return the latest computed board for ``metric``/``domain`` (empty if none)."""
+    async with pool.connection() as conn:
+        conn.row_factory = psycopg.rows.dict_row
+        rows = await conn.execute(_LEADERBOARD_SQL, {"metric": metric, "domain": domain})
+        board = await rows.fetchall()
+
+    entries = [LeaderboardEntryOut.model_validate(r) for r in board]
+    capture_api_event(
+        posthog_client,
+        "arena_leaderboard_queried",
+        {
+            "metric": metric,
+            "domain": domain,
+            "entry_count": len(entries),
+            "$process_person_profile": False,
+        },
+    )
+    return ArenaLeaderboardResponse(
+        metric=metric,
+        domain=domain,
+        computed_at=board[0]["computed_at"] if board else None,
+        methodology_version=board[0]["methodology_version"] if board else None,
+        entries=entries,
+    )

--- a/runner/src/coval_bench/api/schemas.py
+++ b/runner/src/coval_bench/api/schemas.py
@@ -10,6 +10,7 @@ added later if needed.
 
 from __future__ import annotations
 
+import uuid
 from datetime import datetime
 from typing import Literal
 
@@ -165,3 +166,40 @@ class LeaderboardResponse(BaseModel):
     metric: Literal["WER", "TTFA", "TTFT", "TTFS"]
     window: Literal["24h", "7d", "30d"]
     entries: list[LeaderboardEntry]
+
+
+class BattleOut(BaseModel):
+    """A battle to vote on. Blind by design: no provider/model identities."""
+
+    id: uuid.UUID
+    prompt_text: str
+    domain: str | None
+    audio_a_url: str
+    audio_b_url: str
+
+
+class LeaderboardEntryOut(BaseModel):
+    """One model's row within an arena leaderboard board."""
+
+    provider: str
+    model: str
+    rating_elo: float
+    rating_bt: float
+    ci_low: float | None
+    ci_high: float | None
+    ci_half_width: float | None
+    votes_total: int
+    wins: float
+    losses: float
+    ties: float
+    status: str
+
+
+class ArenaLeaderboardResponse(BaseModel):
+    """The latest board for a metric/domain, or empty if none computed yet."""
+
+    metric: str
+    domain: str
+    computed_at: datetime | None
+    methodology_version: str | None
+    entries: list[LeaderboardEntryOut]

--- a/runner/tests/api/test_arena.py
+++ b/runner/tests/api/test_arena.py
@@ -264,3 +264,32 @@ async def test_leaderboard_latest_is_scoped_per_metric(
     data = response.json()
     assert data["metric"] == "clarity"
     assert [e["model"] for e in data["entries"]] == ["sonic-3"]
+
+
+async def test_leaderboard_does_not_mix_methodology_versions(
+    client: AsyncClient, postgresql: Any
+) -> None:
+    """Two methodology versions sharing computed_at must not merge into one board."""
+    await _apply_arena_schema(_make_db_url(postgresql))
+    shared = datetime(2026, 6, 18, 12, 0, tzinfo=UTC)
+    await _insert_snapshot(
+        postgresql,
+        computed_at=shared,
+        methodology_version="davidson-v1",
+        provider="elevenlabs",
+        model="v2",
+    )
+    await _insert_snapshot(
+        postgresql,
+        computed_at=shared,
+        methodology_version="davidson-v2",
+        provider="cartesia",
+        model="sonic-3",
+    )
+
+    response = await client.get("/v1/arena/leaderboard")
+    assert response.status_code == 200
+    data = response.json()
+    # One board only: the tiebreaker picks davidson-v2, so v1's row is excluded.
+    assert data["methodology_version"] == "davidson-v2"
+    assert [e["model"] for e in data["entries"]] == ["sonic-3"]

--- a/runner/tests/api/test_arena.py
+++ b/runner/tests/api/test_arena.py
@@ -1,0 +1,266 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the Voice Arena read endpoints (GET /v1/arena/*)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+import psycopg
+from httpx import AsyncClient
+
+from tests.api.conftest import _make_db_url
+
+
+async def _apply_arena_schema(dsn: str) -> None:
+    """Create the arena tables read by the endpoints (mirrors migration 20260615_0007)."""
+    aconn = await psycopg.AsyncConnection.connect(dsn, autocommit=True)
+    try:
+        await aconn.execute("CREATE SCHEMA IF NOT EXISTS arena")
+        await aconn.execute("""
+            CREATE TABLE IF NOT EXISTS arena.battles (
+                id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+                provider_a  TEXT NOT NULL,
+                model_a     TEXT NOT NULL,
+                provider_b  TEXT NOT NULL,
+                model_b     TEXT NOT NULL,
+                domain      TEXT,
+                prompt_text TEXT NOT NULL,
+                audio_a_url TEXT NOT NULL,
+                audio_b_url TEXT NOT NULL,
+                created_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+            )
+        """)
+        await aconn.execute("""
+            CREATE TABLE IF NOT EXISTS arena.leaderboard_snapshots (
+                id                  UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+                computed_at         TIMESTAMPTZ NOT NULL DEFAULT now(),
+                metric_name         TEXT NOT NULL,
+                methodology_version TEXT NOT NULL,
+                domain              TEXT NOT NULL DEFAULT 'all',
+                provider            TEXT NOT NULL,
+                model               TEXT NOT NULL,
+                rating_elo          NUMERIC NOT NULL,
+                rating_bt           NUMERIC NOT NULL,
+                ci_low              NUMERIC,
+                ci_high             NUMERIC,
+                ci_half_width       NUMERIC,
+                votes_total         INTEGER NOT NULL,
+                wins                NUMERIC NOT NULL,
+                losses              NUMERIC NOT NULL,
+                ties                NUMERIC NOT NULL,
+                status              TEXT NOT NULL
+            )
+        """)
+    finally:
+        await aconn.close()
+
+
+async def _insert_battle(postgresql: Any, **kwargs: Any) -> str:
+    """Insert a battle row and return its id as a string."""
+    dsn = _make_db_url(postgresql)
+    aconn = await psycopg.AsyncConnection.connect(dsn, autocommit=True)
+    try:
+        defaults: dict[str, Any] = {
+            "provider_a": "elevenlabs",
+            "model_a": "eleven_multilingual_v2",
+            "provider_b": "cartesia",
+            "model_b": "sonic-3",
+            "domain": "support",
+            "prompt_text": "Tell me about your refund policy.",
+            "audio_a_url": "https://example.test/a.wav",
+            "audio_b_url": "https://example.test/b.wav",
+        }
+        defaults.update(kwargs)
+        row = await aconn.execute(
+            """
+            INSERT INTO arena.battles
+                (provider_a, model_a, provider_b, model_b, domain,
+                 prompt_text, audio_a_url, audio_b_url)
+            VALUES
+                (%(provider_a)s, %(model_a)s, %(provider_b)s, %(model_b)s, %(domain)s,
+                 %(prompt_text)s, %(audio_a_url)s, %(audio_b_url)s)
+            RETURNING id
+            """,
+            defaults,
+        )
+        result = await row.fetchone()
+        assert result is not None
+        return str(result[0])
+    finally:
+        await aconn.close()
+
+
+async def _insert_snapshot(postgresql: Any, **kwargs: Any) -> None:
+    """Insert a leaderboard_snapshots row."""
+    dsn = _make_db_url(postgresql)
+    aconn = await psycopg.AsyncConnection.connect(dsn, autocommit=True)
+    try:
+        defaults: dict[str, Any] = {
+            "computed_at": datetime(2026, 6, 18, 12, 0, tzinfo=UTC),
+            "metric_name": "naturalness",
+            "methodology_version": "davidson-v1",
+            "domain": "all",
+            "provider": "elevenlabs",
+            "model": "eleven_multilingual_v2",
+            "rating_elo": 1500.0,
+            "rating_bt": 0.0,
+            "ci_low": 1450.0,
+            "ci_high": 1550.0,
+            "ci_half_width": 50.0,
+            "votes_total": 10,
+            "wins": 6,
+            "losses": 4,
+            "ties": 0,
+            "status": "usable",
+        }
+        defaults.update(kwargs)
+        await aconn.execute(
+            """
+            INSERT INTO arena.leaderboard_snapshots
+                (computed_at, metric_name, methodology_version, domain, provider, model,
+                 rating_elo, rating_bt, ci_low, ci_high, ci_half_width,
+                 votes_total, wins, losses, ties, status)
+            VALUES
+                (%(computed_at)s, %(metric_name)s, %(methodology_version)s, %(domain)s,
+                 %(provider)s, %(model)s, %(rating_elo)s, %(rating_bt)s, %(ci_low)s,
+                 %(ci_high)s, %(ci_half_width)s, %(votes_total)s, %(wins)s, %(losses)s,
+                 %(ties)s, %(status)s)
+            """,
+            defaults,
+        )
+    finally:
+        await aconn.close()
+
+
+async def test_get_battle_404_when_empty(client: AsyncClient, postgresql: Any) -> None:
+    """No battles seeded -> 404."""
+    await _apply_arena_schema(_make_db_url(postgresql))
+    response = await client.get("/v1/arena/battle")
+    assert response.status_code == 404
+
+
+async def test_get_battle_is_blind(client: AsyncClient, postgresql: Any) -> None:
+    """A served battle exposes only the blind fields, never provider/model identities."""
+    await _apply_arena_schema(_make_db_url(postgresql))
+    await _insert_battle(postgresql)
+
+    response = await client.get("/v1/arena/battle")
+    assert response.status_code == 200
+    data = response.json()
+    assert set(data) == {"id", "prompt_text", "domain", "audio_a_url", "audio_b_url"}
+    assert "provider_a" not in data
+    assert "model_a" not in data
+    assert data["domain"] == "support"
+
+
+async def test_get_battle_by_id(client: AsyncClient, postgresql: Any) -> None:
+    """GET /arena/battle/{id} returns the matching battle."""
+    await _apply_arena_schema(_make_db_url(postgresql))
+    battle_id = await _insert_battle(postgresql)
+
+    response = await client.get(f"/v1/arena/battle/{battle_id}")
+    assert response.status_code == 200
+    assert response.json()["id"] == battle_id
+
+
+async def test_get_battle_by_id_unknown_returns_404(client: AsyncClient, postgresql: Any) -> None:
+    """A well-formed but unknown UUID returns 404."""
+    await _apply_arena_schema(_make_db_url(postgresql))
+    response = await client.get("/v1/arena/battle/00000000-0000-0000-0000-000000000000")
+    assert response.status_code == 404
+
+
+async def test_get_battle_by_id_malformed_returns_422(client: AsyncClient, postgresql: Any) -> None:
+    """A non-UUID id is rejected by validation with 422."""
+    await _apply_arena_schema(_make_db_url(postgresql))
+    response = await client.get("/v1/arena/battle/not-a-uuid")
+    assert response.status_code == 422
+
+
+async def test_leaderboard_empty_when_no_snapshots(client: AsyncClient, postgresql: Any) -> None:
+    """No snapshots -> 200 with empty entries and null computed_at."""
+    await _apply_arena_schema(_make_db_url(postgresql))
+    response = await client.get("/v1/arena/leaderboard")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["metric"] == "naturalness"
+    assert data["domain"] == "all"
+    assert data["entries"] == []
+    assert data["computed_at"] is None
+
+
+async def test_leaderboard_returns_latest_board_sorted(
+    client: AsyncClient, postgresql: Any
+) -> None:
+    """Only the most recent computed_at board is returned, sorted by rating_elo desc."""
+    await _apply_arena_schema(_make_db_url(postgresql))
+    stale = datetime(2026, 6, 17, 12, 0, tzinfo=UTC)
+    latest = datetime(2026, 6, 18, 12, 0, tzinfo=UTC)
+
+    # An older board that must be excluded.
+    await _insert_snapshot(postgresql, computed_at=stale, provider="old", model="m", rating_elo=999)
+    # The latest board: two models, inserted out of rank order.
+    await _insert_snapshot(
+        postgresql, computed_at=latest, provider="cartesia", model="sonic-3", rating_elo=1480
+    )
+    await _insert_snapshot(
+        postgresql, computed_at=latest, provider="elevenlabs", model="v2", rating_elo=1520
+    )
+
+    response = await client.get("/v1/arena/leaderboard")
+    assert response.status_code == 200
+    data = response.json()
+    entries = data["entries"]
+    assert len(entries) == 2
+    assert [e["model"] for e in entries] == ["v2", "sonic-3"]
+    assert data["methodology_version"] == "davidson-v1"
+
+
+async def test_leaderboard_domain_filter(client: AsyncClient, postgresql: Any) -> None:
+    """domain filter returns only that domain's board, excluding the global 'all' board."""
+    await _apply_arena_schema(_make_db_url(postgresql))
+    computed = datetime(2026, 6, 18, 12, 0, tzinfo=UTC)
+    await _insert_snapshot(
+        postgresql, computed_at=computed, domain="all", provider="elevenlabs", model="v2"
+    )
+    await _insert_snapshot(
+        postgresql, computed_at=computed, domain="support", provider="cartesia", model="sonic-3"
+    )
+
+    support = await client.get("/v1/arena/leaderboard", params={"domain": "support"})
+    assert support.status_code == 200
+    assert support.json()["domain"] == "support"
+    assert [e["model"] for e in support.json()["entries"]] == ["sonic-3"]
+
+    default = await client.get("/v1/arena/leaderboard")
+    assert [e["model"] for e in default.json()["entries"]] == ["v2"]
+
+
+async def test_leaderboard_latest_is_scoped_per_metric(
+    client: AsyncClient, postgresql: Any
+) -> None:
+    """The latest board is per metric: a metric computed earlier still returns its own rows."""
+    await _apply_arena_schema(_make_db_url(postgresql))
+    await _insert_snapshot(
+        postgresql,
+        computed_at=datetime(2026, 6, 18, 12, 0, tzinfo=UTC),
+        metric_name="naturalness",
+        provider="elevenlabs",
+        model="v2",
+    )
+    await _insert_snapshot(
+        postgresql,
+        computed_at=datetime(2026, 6, 17, 12, 0, tzinfo=UTC),
+        metric_name="clarity",
+        provider="cartesia",
+        model="sonic-3",
+    )
+
+    response = await client.get("/v1/arena/leaderboard", params={"metric": "clarity"})
+    assert response.status_code == 200
+    data = response.json()
+    assert data["metric"] == "clarity"
+    assert [e["model"] for e in data["entries"]] == ["sonic-3"]


### PR DESCRIPTION
Adds the read-only API for the Voice Arena (layer 4 of the build plan).

## Endpoints
- `GET /v1/arena/battle` returns one battle to vote on
- `GET /v1/arena/battle/{id}` returns a specific battle
- `GET /v1/arena/leaderboard?metric=&domain=` returns the latest computed board

- Battles are served blind: the response omits provider/model identities so voting stays unbiased. The A/B to model mapping stays server-side.
- The leaderboard returns the rows sharing the most recent `computed_at` for the requested metric and domain, sorted by Elo. It is empty until the snapshot job (a later layer) has run.
- Battle selection is a placeholder (uniform random). Adaptive pairing replaces it in a later layer; the endpoint contract does not change.
- Reads the pool directly with raw SQL like the other routers, so this lands independently of the DB access layer PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Arena endpoints enabling blind battle voting and leaderboard queries
  * Blind battles conceal model identities to ensure unbiased voting
  * Leaderboard displays model ratings and performance statistics, filterable by metric and domain
  * Rate limiting applied (60 requests per minute per endpoint)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds three read-only Voice Arena endpoints (`GET /v1/arena/battle`, `GET /v1/arena/battle/{id}`, and `GET /v1/arena/leaderboard`) along with their Pydantic schemas and a thorough test suite. Battles are served blind (provider/model identities stripped), and the leaderboard returns the most recent computed snapshot for a given metric and domain.

- **Blind battle selection** uses a placeholder `ORDER BY random()` (acknowledged in comments) with all model identity columns withheld from the response schema.
- **Leaderboard SQL** uses a CTE to isolate the single most recent `(computed_at, methodology_version)` pair per metric/domain before joining back for the full row set, correctly preventing mixed-version boards.
- **Test coverage** is comprehensive: blindness invariant, 404/422 edge cases, domain/metric scoping, staleness exclusion, and methodology-version tiebreaking are all verified with a real in-process Postgres instance.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all three endpoints use parameterized queries, the blind invariant is enforced at the SQL column-selection layer, and the leaderboard CTE correctly isolates single-version boards.

The core logic is correct: battles are served blind, leaderboard filtering by metric/domain is applied both in the CTE and outer WHERE, and all DB access is parameterized. Two minor observations (lexicographic version tiebreaker and unconstrained metric string) do not affect current correctness.

runner/src/coval_bench/api/routers/arena.py — the methodology_version tiebreaker and metric param type are worth a second look before the leaderboard snapshot job ships.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| runner/src/coval_bench/api/routers/arena.py | New router implementing three blind read endpoints; SQL and parameterization are correct, minor lexicographic tiebreaker and unconstrained metric-param concerns noted. |
| runner/src/coval_bench/api/schemas.py | Adds BattleOut, LeaderboardEntryOut, and ArenaLeaderboardResponse schemas; intentional float wins/losses/ties for fractional scoring as clarified in prior review thread. |
| runner/tests/api/test_arena.py | Comprehensive test coverage: blindness, 404/422 edge cases, domain/metric filtering, latest-board selection, and methodology-version tiebreaker are all exercised. |
| runner/src/coval_bench/api/app.py | Minimal change: imports the arena router and mounts it at /v1; no issues. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant ArenaRouter
    participant PgPool as Postgres Pool
    participant PostHog

    Client->>ArenaRouter: GET /v1/arena/battle
    ArenaRouter->>PgPool: SELECT id, prompt_text, domain, audio_a_url, audio_b_url FROM arena.battles ORDER BY random() LIMIT 1
    PgPool-->>ArenaRouter: row (or None)
    alt No rows
        ArenaRouter-->>Client: 404 no battles available
    else Row found
        ArenaRouter->>PostHog: capture arena_battle_served
        ArenaRouter-->>Client: 200 BattleOut (blind)
    end

    Client->>ArenaRouter: "GET /v1/arena/battle/{id}"
    ArenaRouter->>PgPool: "SELECT ... FROM arena.battles WHERE id = %(id)s"
    PgPool-->>ArenaRouter: row (or None)
    alt Not found
        ArenaRouter-->>Client: 404
    else Found
        ArenaRouter-->>Client: 200 BattleOut (blind)
    end

    Client->>ArenaRouter: "GET /v1/arena/leaderboard?metric=&domain="
    ArenaRouter->>PgPool: CTE picks latest (computed_at, methodology_version), JOIN snapshots WHERE metric/domain match, ORDER BY rating_elo DESC
    PgPool-->>ArenaRouter: board rows
    ArenaRouter->>PostHog: capture arena_leaderboard_queried
    ArenaRouter-->>Client: 200 ArenaLeaderboardResponse
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant ArenaRouter
    participant PgPool as Postgres Pool
    participant PostHog

    Client->>ArenaRouter: GET /v1/arena/battle
    ArenaRouter->>PgPool: SELECT id, prompt_text, domain, audio_a_url, audio_b_url FROM arena.battles ORDER BY random() LIMIT 1
    PgPool-->>ArenaRouter: row (or None)
    alt No rows
        ArenaRouter-->>Client: 404 no battles available
    else Row found
        ArenaRouter->>PostHog: capture arena_battle_served
        ArenaRouter-->>Client: 200 BattleOut (blind)
    end

    Client->>ArenaRouter: "GET /v1/arena/battle/{id}"
    ArenaRouter->>PgPool: "SELECT ... FROM arena.battles WHERE id = %(id)s"
    PgPool-->>ArenaRouter: row (or None)
    alt Not found
        ArenaRouter-->>Client: 404
    else Found
        ArenaRouter-->>Client: 200 BattleOut (blind)
    end

    Client->>ArenaRouter: "GET /v1/arena/leaderboard?metric=&domain="
    ArenaRouter->>PgPool: CTE picks latest (computed_at, methodology_version), JOIN snapshots WHERE metric/domain match, ORDER BY rating_elo DESC
    PgPool-->>ArenaRouter: board rows
    ArenaRouter->>PostHog: capture arena_leaderboard_queried
    ArenaRouter-->>Client: 200 ArenaLeaderboardResponse
```

</a>

<sub>Reviews (2): Last reviewed commit: ["Select a single leaderboard board so met..."](https://github.com/coval-ai/benchmarks/commit/13454e3875709da7c5c1b40a0f808c792151a967) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38702413)</sub>

<!-- /greptile_comment -->