### PR TITLE
Fix logging setup

### DIFF
--- a/runner/src/coval_bench/__main__.py
+++ b/runner/src/coval_bench/__main__.py
@@ -26,6 +26,10 @@ from coval_bench.migrations.import_legacy import import_legacy_cli
 @click.version_option(version=__version__, prog_name="coval-bench")
 def cli() -> None:
     """Coval voice-AI benchmarks runner."""
+    from coval_bench.config import get_settings
+    from coval_bench.logging import configure_logging
+
+    configure_logging(level=get_settings().log_level)
 
 
 @cli.command(name="run")

--- a/runner/src/coval_bench/api/app.py
+++ b/runner/src/coval_bench/api/app.py
@@ -31,6 +31,7 @@ from coval_bench.api.ratelimit import _rate_limit_handler, limiter
 from coval_bench.api.routers import aggregates, health, leaderboard, providers, results, runs
 from coval_bench.config import Settings, get_settings
 from coval_bench.db.conn import lifespan_pool
+from coval_bench.logging import configure_logging
 
 logger = structlog.get_logger("coval_bench.api")
 
@@ -49,6 +50,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
 
     @asynccontextmanager
     async def lifespan(app: FastAPI) -> AsyncIterator[None]:
+        configure_logging(level=resolved.log_level)
         logger.info("api_startup", runner_sha=resolved.runner_sha)
         posthog_client: Posthog | None = None
         if not resolved.posthog_disabled and resolved.posthog_project_token:

--- a/runner/src/coval_bench/api/app.py
+++ b/runner/src/coval_bench/api/app.py
@@ -28,6 +28,7 @@ from slowapi.middleware import SlowAPIMiddleware
 
 from coval_bench.api.cache import new_cache_locks, new_response_cache
 from coval_bench.api.ratelimit import _rate_limit_handler, limiter
+from coval_bench.api.request_logging import RequestLoggingMiddleware
 from coval_bench.api.routers import aggregates, health, leaderboard, providers, results, runs
 from coval_bench.config import Settings, get_settings
 from coval_bench.db.conn import lifespan_pool
@@ -105,6 +106,8 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     app.state.limiter = limiter
     app.add_exception_handler(RateLimitExceeded, _rate_limit_handler)  # type: ignore[arg-type]
     app.add_middleware(SlowAPIMiddleware)
+
+    app.add_middleware(RequestLoggingMiddleware)
 
     # Routers
     app.include_router(health.router)

--- a/runner/src/coval_bench/api/main.py
+++ b/runner/src/coval_bench/api/main.py
@@ -3,13 +3,14 @@
 
 """Uvicorn entrypoint for the Coval Benchmarks API.
 
-Production startup::
+Production startup (see ``Dockerfile.api``)::
 
     uvicorn coval_bench.api.main:app --host 0.0.0.0 --port 8080
 
-Or via the CLI (see ``__main__.py`` for the entry point)::
-
-    coval-bench serve
+Importing this module configures logging as a side effect, so JSON output is in
+effect no matter how uvicorn is launched: uvicorn always imports the app *after*
+installing its own (default) logging, so our ``dictConfig`` below wins. This
+avoids tying the logging setup to a particular CMD form.
 
 The ``app`` module-level object is required so that uvicorn can import it as
 ``coval_bench.api.main:app``.
@@ -17,9 +18,16 @@ The ``app`` module-level object is required so that uvicorn can import it as
 
 from __future__ import annotations
 
+import logging.config
 import os
 
 from coval_bench.api.app import create_app
+from coval_bench.config import get_settings
+from coval_bench.logging import configure_logging, uvicorn_log_config
+
+_log_level = get_settings().log_level
+configure_logging(level=_log_level)
+logging.config.dictConfig(uvicorn_log_config(_log_level))
 
 app = create_app()
 
@@ -30,5 +38,5 @@ if __name__ == "__main__":
         "coval_bench.api.main:app",
         host="0.0.0.0",  # noqa: S104
         port=int(os.environ.get("PORT", "8080")),
-        log_level="info",
+        log_level=_log_level.lower(),
     )

--- a/runner/src/coval_bench/api/main.py
+++ b/runner/src/coval_bench/api/main.py
@@ -39,4 +39,6 @@ if __name__ == "__main__":
         host="0.0.0.0",  # noqa: S104
         port=int(os.environ.get("PORT", "8080")),
         log_level=_log_level.lower(),
+        log_config=uvicorn_log_config(_log_level),
+        access_log=False,
     )

--- a/runner/src/coval_bench/api/request_logging.py
+++ b/runner/src/coval_bench/api/request_logging.py
@@ -17,6 +17,7 @@ echoed back in the ``X-Request-ID`` response header.
 
 from __future__ import annotations
 
+import re
 import time
 import uuid
 from collections.abc import Iterable
@@ -27,6 +28,7 @@ from starlette.types import ASGIApp, Message, Receive, Scope, Send
 _log = structlog.get_logger("coval_bench.api.access")
 
 _TRACE_HEADER = b"x-cloud-trace-context"
+_TRACE_ID_RE = re.compile(r"[0-9a-f]{32}", re.IGNORECASE)
 
 _QUIET_PATHS = frozenset({"/healthz", "/readyz"})
 
@@ -92,7 +94,7 @@ def _request_id(scope: Scope) -> str:
     for key, value in headers:
         if key == _TRACE_HEADER:
             trace = value.decode("latin-1").split("/", 1)[0]
-            if trace:
+            if _TRACE_ID_RE.fullmatch(trace):
                 return trace
             break
     return uuid.uuid4().hex

--- a/runner/src/coval_bench/api/request_logging.py
+++ b/runner/src/coval_bench/api/request_logging.py
@@ -1,0 +1,97 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Per-request logging for the API.
+
+A pure-ASGI middleware that binds a ``request_id`` to structlog's contextvars
+for the duration of each request — so every log line emitted while handling it
+carries the id — and emits one canonical ``http_request`` line per request with
+the method, path, status, and duration. It is pure ASGI rather than
+``BaseHTTPMiddleware`` on purpose: the latter runs the endpoint in a separate
+context, so contextvars bound in it would not reach the route handler.
+
+Cloud Run's ``X-Cloud-Trace-Context`` trace id is used as the id when present so
+logs line up with Cloud Trace; otherwise a random id is generated. The id is
+echoed back in the ``X-Request-ID`` response header.
+"""
+
+from __future__ import annotations
+
+import time
+import uuid
+from collections.abc import Iterable
+
+import structlog
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+_log = structlog.get_logger("coval_bench.api.access")
+
+_TRACE_HEADER = b"x-cloud-trace-context"
+
+_QUIET_PATHS = frozenset({"/healthz", "/readyz"})
+
+
+class RequestLoggingMiddleware:
+    """Bind a per-request ``request_id`` and log one line per request."""
+
+    def __init__(self, app: ASGIApp, *, quiet_paths: frozenset[str] = _QUIET_PATHS) -> None:
+        self.app = app
+        self.quiet_paths = quiet_paths
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        request_id = _request_id(scope)
+        method: str = scope["method"]
+        path: str = scope["path"]
+        status = 500
+
+        async def send_wrapper(message: Message) -> None:
+            nonlocal status
+            if message["type"] == "http.response.start":
+                status = message["status"]
+                message.setdefault("headers", []).append(
+                    (b"x-request-id", request_id.encode("latin-1"))
+                )
+            await send(message)
+
+        structlog.contextvars.clear_contextvars()
+        structlog.contextvars.bind_contextvars(request_id=request_id)
+        start = time.perf_counter()
+        try:
+            await self.app(scope, receive, send_wrapper)
+        except Exception:
+            _log.error(
+                "http_request",
+                method=method,
+                path=path,
+                status=500,
+                duration_ms=round((time.perf_counter() - start) * 1000, 1),
+            )
+            raise
+        else:
+            if not (path in self.quiet_paths and status < 400):
+                emit = _log.error if status >= 500 else _log.warning if status >= 400 else _log.info
+                emit(
+                    "http_request",
+                    method=method,
+                    path=path,
+                    status=status,
+                    duration_ms=round((time.perf_counter() - start) * 1000, 1),
+                )
+        finally:
+            structlog.contextvars.clear_contextvars()
+
+
+def _request_id(scope: Scope) -> str:
+    """Return the Cloud Trace id from the request headers, or a random id."""
+    headers: Iterable[tuple[bytes, bytes]] = scope["headers"]
+    for key, value in headers:
+        if key == _TRACE_HEADER:
+            trace = value.decode("latin-1").split("/", 1)[0]
+            if trace:
+                return trace
+            break
+    return uuid.uuid4().hex

--- a/runner/src/coval_bench/api/request_logging.py
+++ b/runner/src/coval_bench/api/request_logging.py
@@ -69,6 +69,7 @@ class RequestLoggingMiddleware:
                 path=path,
                 status=500,
                 duration_ms=round((time.perf_counter() - start) * 1000, 1),
+                exc_info=True,
             )
             raise
         else:

--- a/runner/src/coval_bench/api/request_logging.py
+++ b/runner/src/coval_bench/api/request_logging.py
@@ -67,7 +67,7 @@ class RequestLoggingMiddleware:
                 "http_request",
                 method=method,
                 path=path,
-                status=500,
+                status=status,
                 duration_ms=round((time.perf_counter() - start) * 1000, 1),
                 exc_info=True,
             )

--- a/runner/src/coval_bench/datasets/loader.py
+++ b/runner/src/coval_bench/datasets/loader.py
@@ -36,13 +36,13 @@ loader falls back to ``/tmp/coval-bench``.
 from __future__ import annotations
 
 import hashlib
-import logging
 import os
 import random
 from importlib.resources import files
 from pathlib import Path
 
 import google.cloud.storage as storage
+import structlog
 from pydantic import BaseModel, Field
 
 from coval_bench.config import Settings
@@ -52,7 +52,7 @@ from coval_bench.datasets.manifest import (
     TTSManifestItem,
 )
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 __all__ = [
     "Dataset",
@@ -147,9 +147,9 @@ def _default_cache_dir() -> Path:
         fallback = Path(tempfile.gettempdir()) / "coval-bench"  # noqa: S108
         fallback.mkdir(parents=True, exist_ok=True)
         logger.warning(
-            "Default cache dir %s is not writable; falling back to %s",
-            candidate,
-            fallback,
+            "default cache dir not writable; using fallback",
+            candidate=str(candidate),
+            fallback=str(fallback),
         )
         return fallback
 
@@ -219,13 +219,13 @@ def _fetch_and_verify(
     # Cache hit check
     if local_path.exists():
         if _sha256_file(local_path) == item.sha256:
-            logger.debug("Cache hit for %s", item.path)
+            logger.debug("cache hit", path=str(item.path))
             return local_path
-        logger.warning("Cached file %s has wrong hash — re-downloading", local_path)
+        logger.warning("cached file hash mismatch; re-downloading", path=str(local_path))
 
     # Download
     gcs_object = f"{dataset_id}/{item.path}"
-    logger.info("Fetching gs://%s/%s", bucket, gcs_object)
+    logger.info("fetching dataset object", bucket=bucket, object=gcs_object)
     _fetch_blob(client, bucket, gcs_object, local_path)
 
     # Post-download integrity check

--- a/runner/src/coval_bench/datasets/loader.py
+++ b/runner/src/coval_bench/datasets/loader.py
@@ -147,7 +147,7 @@ def _default_cache_dir() -> Path:
         fallback = Path(tempfile.gettempdir()) / "coval-bench"  # noqa: S108
         fallback.mkdir(parents=True, exist_ok=True)
         logger.warning(
-            "default cache dir not writable; using fallback",
+            "cache_dir_not_writable",
             candidate=str(candidate),
             fallback=str(fallback),
         )
@@ -219,13 +219,13 @@ def _fetch_and_verify(
     # Cache hit check
     if local_path.exists():
         if _sha256_file(local_path) == item.sha256:
-            logger.debug("cache hit", path=str(item.path))
+            logger.debug("cache_hit", path=str(item.path))
             return local_path
-        logger.warning("cached file hash mismatch; re-downloading", path=str(local_path))
+        logger.warning("cached_file_hash_mismatch", path=str(local_path))
 
     # Download
     gcs_object = f"{dataset_id}/{item.path}"
-    logger.info("fetching dataset object", bucket=bucket, object=gcs_object)
+    logger.info("fetching_dataset_object", bucket=bucket, object=gcs_object)
     _fetch_blob(client, bucket, gcs_object, local_path)
 
     # Post-download integrity check

--- a/runner/src/coval_bench/datasets/scripts/build_dataset.py
+++ b/runner/src/coval_bench/datasets/scripts/build_dataset.py
@@ -60,6 +60,7 @@ from __future__ import annotations
 import hashlib
 import importlib.resources as _impres
 import json
+import logging
 import sys
 import tarfile
 import tempfile
@@ -675,6 +676,7 @@ def cli() -> None:
             structlog.processors.TimeStamper(fmt="%H:%M:%S"),
             structlog.dev.ConsoleRenderer(),
         ],
+        wrapper_class=structlog.make_filtering_bound_logger(logging.INFO),
         logger_factory=structlog.PrintLoggerFactory(file=sys.stderr),
     )
 

--- a/runner/src/coval_bench/datasets/scripts/build_dataset.py
+++ b/runner/src/coval_bench/datasets/scripts/build_dataset.py
@@ -60,7 +60,7 @@ from __future__ import annotations
 import hashlib
 import importlib.resources as _impres
 import json
-import logging
+import sys
 import tarfile
 import tempfile
 import urllib.request
@@ -70,11 +70,12 @@ from typing import TYPE_CHECKING
 
 import click
 import soundfile as sf
+import structlog
 
 if TYPE_CHECKING:
     import google.cloud.storage as _gcs_storage
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -144,10 +145,10 @@ def _download_archive(cache_root: Path) -> Path:
     dest = cache_root / _ARCHIVE_NAME
 
     if dest.exists() and dest.stat().st_size == _EXPECTED_SIZE_BYTES:
-        logger.info("Archive already cached at %s (%d bytes)", dest, dest.stat().st_size)
+        logger.info("archive already cached", dest=str(dest), size_bytes=dest.stat().st_size)
         return dest
 
-    logger.info("Downloading %s → %s", _OPENSLR_URL, dest)
+    logger.info("downloading archive", url=_OPENSLR_URL, dest=str(dest))
     req = urllib.request.Request(  # noqa: S310 (audited: hardcoded https OpenSLR URL)
         _OPENSLR_URL,
         headers={"User-Agent": "coval-bench/build-dataset"},
@@ -162,10 +163,10 @@ def _download_archive(cache_root: Path) -> Path:
             out.write(chunk)
             downloaded += len(chunk)
             if downloaded - last_logged >= _LOG_EVERY_BYTES:
-                logger.info("Downloaded %d MB …", downloaded // (1024 * 1024))
+                logger.info("download progress", downloaded_mb=downloaded // (1024 * 1024))
                 last_logged = downloaded
 
-    logger.info("Download complete: %d bytes written to %s", downloaded, dest)
+    logger.info("download complete", size_bytes=downloaded, dest=str(dest))
     return dest
 
 
@@ -176,13 +177,13 @@ def _extract_archive(archive_path: Path, cache_root: Path) -> Path:
     """
     extract_dir = cache_root / _EXTRACT_DIR_NAME
     if extract_dir.exists():
-        logger.info("Archive already extracted at %s", extract_dir)
+        logger.info("archive already extracted", extract_dir=str(extract_dir))
         return extract_dir
 
-    logger.info("Extracting %s → %s", archive_path, cache_root)
+    logger.info("extracting archive", archive=str(archive_path), dest=str(cache_root))
     with tarfile.open(archive_path, "r:gz") as tf:
         tf.extractall(path=cache_root)  # noqa: S202
-    logger.info("Extraction complete")
+    logger.info("extraction complete")
     return extract_dir
 
 
@@ -218,7 +219,7 @@ def _parse_trans_txt(
             continue
         if " " not in line:
             # Malformed — no space between utterance_id and transcript
-            logger.warning("Skipping malformed trans.txt line: %r", line)
+            logger.warning("skipping malformed trans.txt line", line=line)
             continue
         utt_id, transcript = line.split(" ", 1)
         flac_path = audio_dir / f"{utt_id}.flac"
@@ -265,13 +266,13 @@ def _enumerate_utterances(librispeech_dir: Path) -> list[_Utterance]:
                 )
                 for utt in batch:
                     if not utt.flac_path.exists():
-                        logger.warning("FLAC not found (skipping): %s", utt.flac_path)
+                        logger.warning("flac not found; skipping", path=str(utt.flac_path))
                         continue
                     info = sf.info(str(utt.flac_path))
                     utt.duration_sec = info.frames / info.samplerate
                 utterances.extend(batch)
 
-    logger.info("Enumerated %d utterances total", len(utterances))
+    logger.info("enumerated utterances", count=len(utterances))
     return utterances
 
 
@@ -363,11 +364,10 @@ def _transcode_to_wav(src_flac: Path, dest_wav: Path) -> None:
     data, samplerate = sf.read(str(src_flac), dtype="int16", always_2d=False)
     if samplerate != _TARGET_SR:
         logger.warning(
-            "Unexpected sample rate %d Hz for %s; expected 16000. "
-            "Audio written as-is at %d Hz — add resampling if needed.",
-            samplerate,
-            src_flac.name,
-            samplerate,
+            "unexpected sample rate; writing as-is (add resampling if needed)",
+            sample_rate=samplerate,
+            expected_rate=_TARGET_SR,
+            file=src_flac.name,
         )
     sf.write(str(dest_wav), data, _TARGET_SR, subtype="PCM_16")
 
@@ -393,12 +393,12 @@ def _build_items(selected: list[_Utterance], work_dir: Path) -> list[_BuiltItem]
             )
         )
         logger.info(
-            "[%d/%d] %s  sha256=%s…  %.2f s",
-            idx,
-            _NUM_UTTERANCES,
-            filename,
-            sha256[:16],
-            utt.duration_sec,
+            "built item",
+            index=idx,
+            total=_NUM_UTTERANCES,
+            filename=filename,
+            sha256=sha256[:16],
+            duration_sec=round(utt.duration_sec, 2),
         )
     return items
 
@@ -440,7 +440,7 @@ def _upload_items(
         blob = bucket.blob(blob_name)
         blob.content_type = "audio/wav"
 
-        logger.info("Uploading gs://%s/%s …", bucket_name, blob_name)
+        logger.info("uploading blob", bucket=bucket_name, blob=blob_name)
 
         if overwrite:
             blob.upload_from_filename(str(item.wav_path), content_type="audio/wav")
@@ -466,7 +466,7 @@ def _upload_items(
             raise RuntimeError(
                 f"Upload integrity failure for {blob_name}: expected={item.sha256} got={actual}"
             )
-        logger.info("Verified %s ✓", blob_name)
+        logger.info("verified blob", blob=blob_name)
 
 
 # ---------------------------------------------------------------------------
@@ -531,7 +531,7 @@ def _parse_speaker_genders(librispeech_dir: Path) -> dict[str, str]:
     """
     speakers_txt = librispeech_dir / "SPEAKERS.TXT"
     if not speakers_txt.exists():
-        logger.warning("SPEAKERS.TXT not found at %s; gender counts unavailable", speakers_txt)
+        logger.warning("speakers.txt not found; gender counts unavailable", path=str(speakers_txt))
         return {}
     genders: dict[str, str] = {}
     for line in speakers_txt.read_text(encoding="utf-8").splitlines():
@@ -669,10 +669,13 @@ def _build_stt_v1(
 @click.group()
 def cli() -> None:
     """Coval dataset builder — download, transcode, hash, upload."""
-    logging.basicConfig(
-        level=logging.INFO,
-        format="%(asctime)s %(levelname)s %(name)s  %(message)s",
-        datefmt="%H:%M:%S",
+    structlog.configure(
+        processors=[
+            structlog.processors.add_log_level,
+            structlog.processors.TimeStamper(fmt="%H:%M:%S"),
+            structlog.dev.ConsoleRenderer(),
+        ],
+        logger_factory=structlog.PrintLoggerFactory(file=sys.stderr),
     )
 
 

--- a/runner/src/coval_bench/datasets/scripts/build_dataset.py
+++ b/runner/src/coval_bench/datasets/scripts/build_dataset.py
@@ -145,10 +145,10 @@ def _download_archive(cache_root: Path) -> Path:
     dest = cache_root / _ARCHIVE_NAME
 
     if dest.exists() and dest.stat().st_size == _EXPECTED_SIZE_BYTES:
-        logger.info("archive already cached", dest=str(dest), size_bytes=dest.stat().st_size)
+        logger.info("archive_already_cached", dest=str(dest), size_bytes=dest.stat().st_size)
         return dest
 
-    logger.info("downloading archive", url=_OPENSLR_URL, dest=str(dest))
+    logger.info("downloading_archive", url=_OPENSLR_URL, dest=str(dest))
     req = urllib.request.Request(  # noqa: S310 (audited: hardcoded https OpenSLR URL)
         _OPENSLR_URL,
         headers={"User-Agent": "coval-bench/build-dataset"},
@@ -163,10 +163,10 @@ def _download_archive(cache_root: Path) -> Path:
             out.write(chunk)
             downloaded += len(chunk)
             if downloaded - last_logged >= _LOG_EVERY_BYTES:
-                logger.info("download progress", downloaded_mb=downloaded // (1024 * 1024))
+                logger.info("download_progress", downloaded_mb=downloaded // (1024 * 1024))
                 last_logged = downloaded
 
-    logger.info("download complete", size_bytes=downloaded, dest=str(dest))
+    logger.info("download_complete", size_bytes=downloaded, dest=str(dest))
     return dest
 
 
@@ -177,13 +177,13 @@ def _extract_archive(archive_path: Path, cache_root: Path) -> Path:
     """
     extract_dir = cache_root / _EXTRACT_DIR_NAME
     if extract_dir.exists():
-        logger.info("archive already extracted", extract_dir=str(extract_dir))
+        logger.info("archive_already_extracted", extract_dir=str(extract_dir))
         return extract_dir
 
-    logger.info("extracting archive", archive=str(archive_path), dest=str(cache_root))
+    logger.info("extracting_archive", archive=str(archive_path), dest=str(cache_root))
     with tarfile.open(archive_path, "r:gz") as tf:
         tf.extractall(path=cache_root)  # noqa: S202
-    logger.info("extraction complete")
+    logger.info("extraction_complete")
     return extract_dir
 
 
@@ -219,7 +219,7 @@ def _parse_trans_txt(
             continue
         if " " not in line:
             # Malformed — no space between utterance_id and transcript
-            logger.warning("skipping malformed trans.txt line", line=line)
+            logger.warning("malformed_trans_txt_line", line=line)
             continue
         utt_id, transcript = line.split(" ", 1)
         flac_path = audio_dir / f"{utt_id}.flac"
@@ -266,13 +266,13 @@ def _enumerate_utterances(librispeech_dir: Path) -> list[_Utterance]:
                 )
                 for utt in batch:
                     if not utt.flac_path.exists():
-                        logger.warning("flac not found; skipping", path=str(utt.flac_path))
+                        logger.warning("flac_not_found", path=str(utt.flac_path))
                         continue
                     info = sf.info(str(utt.flac_path))
                     utt.duration_sec = info.frames / info.samplerate
                 utterances.extend(batch)
 
-    logger.info("enumerated utterances", count=len(utterances))
+    logger.info("enumerated_utterances", count=len(utterances))
     return utterances
 
 
@@ -364,7 +364,7 @@ def _transcode_to_wav(src_flac: Path, dest_wav: Path) -> None:
     data, samplerate = sf.read(str(src_flac), dtype="int16", always_2d=False)
     if samplerate != _TARGET_SR:
         logger.warning(
-            "unexpected sample rate; writing as-is (add resampling if needed)",
+            "unexpected_sample_rate",
             sample_rate=samplerate,
             expected_rate=_TARGET_SR,
             file=src_flac.name,
@@ -393,7 +393,7 @@ def _build_items(selected: list[_Utterance], work_dir: Path) -> list[_BuiltItem]
             )
         )
         logger.info(
-            "built item",
+            "built_item",
             index=idx,
             total=_NUM_UTTERANCES,
             filename=filename,
@@ -440,7 +440,7 @@ def _upload_items(
         blob = bucket.blob(blob_name)
         blob.content_type = "audio/wav"
 
-        logger.info("uploading blob", bucket=bucket_name, blob=blob_name)
+        logger.info("uploading_blob", bucket=bucket_name, blob=blob_name)
 
         if overwrite:
             blob.upload_from_filename(str(item.wav_path), content_type="audio/wav")
@@ -466,7 +466,7 @@ def _upload_items(
             raise RuntimeError(
                 f"Upload integrity failure for {blob_name}: expected={item.sha256} got={actual}"
             )
-        logger.info("verified blob", blob=blob_name)
+        logger.info("verified_blob", blob=blob_name)
 
 
 # ---------------------------------------------------------------------------
@@ -531,7 +531,7 @@ def _parse_speaker_genders(librispeech_dir: Path) -> dict[str, str]:
     """
     speakers_txt = librispeech_dir / "SPEAKERS.TXT"
     if not speakers_txt.exists():
-        logger.warning("speakers.txt not found; gender counts unavailable", path=str(speakers_txt))
+        logger.warning("speakers_txt_not_found", path=str(speakers_txt))
         return {}
     genders: dict[str, str] = {}
     for line in speakers_txt.read_text(encoding="utf-8").splitlines():

--- a/runner/src/coval_bench/datasets/scripts/build_dataset.py
+++ b/runner/src/coval_bench/datasets/scripts/build_dataset.py
@@ -271,7 +271,7 @@ def _enumerate_utterances(librispeech_dir: Path) -> list[_Utterance]:
                         continue
                     info = sf.info(str(utt.flac_path))
                     utt.duration_sec = info.frames / info.samplerate
-                utterances.extend(batch)
+                    utterances.append(utt)
 
     logger.info("enumerated_utterances", count=len(utterances))
     return utterances

--- a/runner/src/coval_bench/logging.py
+++ b/runner/src/coval_bench/logging.py
@@ -11,13 +11,15 @@ from __future__ import annotations
 
 import logging
 import sys
-from typing import Literal
+from typing import Any, Literal
 
 import structlog
 
+LogLevel = Literal["DEBUG", "INFO", "WARNING", "ERROR"]
+
 
 def configure_logging(
-    level: Literal["DEBUG", "INFO", "WARNING", "ERROR"] = "INFO",
+    level: LogLevel = "INFO",
 ) -> None:
     """Configure structlog for JSON output to stdout.
 
@@ -41,11 +43,56 @@ def configure_logging(
         cache_logger_on_first_use=True,
     )
 
-    # Route third-party stdlib loggers (uvicorn, google-cloud, ...) to stdout at
+    # Route third-party stdlib loggers (google-cloud, httpx, ...) to stdout at
     # the same level. These emit plain text, not JSON — only loggers obtained via
-    # structlog.get_logger() go through the JSON pipeline above.
+    # structlog.get_logger() go through the JSON pipeline above. uvicorn's own
+    # loggers are handled separately by uvicorn_log_config().
     logging.basicConfig(
         format="%(message)s",
         stream=sys.stdout,
         level=log_level,
     )
+
+
+def uvicorn_log_config(level: LogLevel = "INFO") -> dict[str, Any]:
+    """Return a uvicorn ``log_config`` that renders uvicorn's logs as JSON.
+
+    Pass to ``uvicorn.run(log_config=...)`` so uvicorn's startup and error logs
+    match the structlog JSON the app emits on stdout, instead of uvicorn's default
+    plain colored text. ``uvicorn.access`` is given no handler: the
+    ``RequestLoggingMiddleware`` emits the canonical per-request line, so uvicorn's
+    duplicate access log is suppressed (also pass ``access_log=False``).
+
+    Args:
+        level: The minimum log level for uvicorn's loggers.
+    """
+    return {
+        "version": 1,
+        "disable_existing_loggers": False,
+        "formatters": {
+            "json": {
+                "()": structlog.stdlib.ProcessorFormatter,
+                "processors": [
+                    structlog.stdlib.ProcessorFormatter.remove_processors_meta,
+                    structlog.processors.JSONRenderer(),
+                ],
+                "foreign_pre_chain": [
+                    structlog.processors.add_log_level,
+                    structlog.processors.TimeStamper(fmt="iso"),
+                    structlog.processors.format_exc_info,
+                ],
+            },
+        },
+        "handlers": {
+            "default": {
+                "class": "logging.StreamHandler",
+                "formatter": "json",
+                "stream": "ext://sys.stdout",
+            },
+        },
+        "loggers": {
+            "uvicorn": {"handlers": ["default"], "level": level, "propagate": False},
+            "uvicorn.error": {"handlers": ["default"], "level": level, "propagate": False},
+            "uvicorn.access": {"handlers": [], "level": level, "propagate": False},
+        },
+    }

--- a/runner/src/coval_bench/logging.py
+++ b/runner/src/coval_bench/logging.py
@@ -29,8 +29,7 @@ def configure_logging(
     structlog.configure(
         processors=[
             structlog.contextvars.merge_contextvars,
-            structlog.stdlib.add_log_level,
-            structlog.stdlib.add_logger_name,
+            structlog.processors.add_log_level,
             structlog.processors.TimeStamper(fmt="iso"),
             structlog.processors.StackInfoRenderer(),
             structlog.processors.format_exc_info,
@@ -42,8 +41,9 @@ def configure_logging(
         cache_logger_on_first_use=True,
     )
 
-    # Also configure stdlib logging so that third-party libraries that use
-    # `logging.getLogger(...)` produce JSON output through structlog.
+    # Route third-party stdlib loggers (uvicorn, google-cloud, ...) to stdout at
+    # the same level. These emit plain text, not JSON — only loggers obtained via
+    # structlog.get_logger() go through the JSON pipeline above.
     logging.basicConfig(
         format="%(message)s",
         stream=sys.stdout,

--- a/runner/src/coval_bench/providers/stt/assemblyai.py
+++ b/runner/src/coval_bench/providers/stt/assemblyai.py
@@ -105,7 +105,7 @@ class AssemblyAIProvider(STTProvider):
                 await asyncio.gather(send_task, recv_task, return_exceptions=True)
 
         except Exception as exc:
-            logger.exception("assemblyai measure_ttft failed", error=str(exc))
+            logger.exception("assemblyai_measure_ttft_failed", error=str(exc))
             result.error = str(exc)
 
         result.total_time = time.monotonic() - total_start
@@ -143,7 +143,7 @@ class AssemblyAIProvider(STTProvider):
                 await asyncio.wait_for(final_event.wait(), timeout=_FINAL_WAIT_S)
             await ws.send(json.dumps({"type": "Terminate"}))
         except Exception as exc:
-            logger.exception("assemblyai send error", error=str(exc))
+            logger.exception("assemblyai_send_error", error=str(exc))
             raise
 
     async def _receive(
@@ -181,7 +181,7 @@ class AssemblyAIProvider(STTProvider):
                     final_event.set()
 
         except Exception as exc:
-            logger.exception("assemblyai receive error", error=str(exc))
+            logger.exception("assemblyai_receive_error", error=str(exc))
 
         if last_final_time is not None and result.audio_start_time is not None:
             result.audio_to_final_seconds = last_final_time - result.audio_start_time

--- a/runner/src/coval_bench/providers/stt/cartesia.py
+++ b/runner/src/coval_bench/providers/stt/cartesia.py
@@ -94,7 +94,7 @@ class CartesiaSTTProvider(STTProvider):
                         result.error = str(outcome)
 
         except Exception as exc:
-            logger.exception("cartesia stt measure_ttft failed", error=str(exc))
+            logger.exception("cartesia_stt_measure_ttft_failed", error=str(exc))
             result.error = str(exc)
 
         result.total_time = time.monotonic() - total_start
@@ -124,7 +124,7 @@ class CartesiaSTTProvider(STTProvider):
             await ws.send("finalize")
             await ws.send("close")
         except Exception as exc:
-            logger.exception("cartesia stt send error", error=str(exc))
+            logger.exception("cartesia_stt_send_error", error=str(exc))
             raise
 
     async def _receive(self, ws: Any, result: TranscriptionResult) -> None:
@@ -169,7 +169,7 @@ class CartesiaSTTProvider(STTProvider):
                         result.audio_to_final_seconds = now - result.audio_start_time
 
         except Exception as exc:
-            logger.exception("cartesia stt receive error", error=str(exc))
+            logger.exception("cartesia_stt_receive_error", error=str(exc))
             if result.error is None:
                 result.error = str(exc)
 

--- a/runner/src/coval_bench/providers/stt/deepgram.py
+++ b/runner/src/coval_bench/providers/stt/deepgram.py
@@ -130,7 +130,7 @@ class DeepgramProvider(STTProvider):
                 await asyncio.gather(send_task, recv_task, return_exceptions=True)
 
         except Exception as exc:
-            logger.exception("deepgram measure_ttft failed", error=str(exc))
+            logger.exception("deepgram_measure_ttft_failed", error=str(exc))
             result.error = str(exc)
 
         result.total_time = time.monotonic() - total_start
@@ -175,7 +175,7 @@ class DeepgramProvider(STTProvider):
                     await asyncio.wait_for(final_event.wait(), timeout=_FINAL_WAIT_S)
             await ws.send(json.dumps({"type": "CloseStream"}))
         except Exception as exc:
-            logger.exception("deepgram send error", error=str(exc))
+            logger.exception("deepgram_send_error", error=str(exc))
             raise
 
     # ------------------------------------------------------------------
@@ -267,7 +267,7 @@ class DeepgramProvider(STTProvider):
                         pending_partial = transcript
 
         except Exception as exc:
-            logger.exception("deepgram receive error", error=str(exc))
+            logger.exception("deepgram_receive_error", error=str(exc))
 
         if last_final_time is not None and result.audio_start_time is not None:
             result.audio_to_final_seconds = last_final_time - result.audio_start_time

--- a/runner/src/coval_bench/providers/stt/elevenlabs.py
+++ b/runner/src/coval_bench/providers/stt/elevenlabs.py
@@ -109,13 +109,13 @@ class ElevenLabsSTTProvider(STTProvider):
                     session_data: dict[str, Any] = json.loads(raw_session)
                     if session_data.get("message_type") != "session_started":
                         logger.warning(
-                            "unexpected first message from elevenlabs",
+                            "elevenlabs_unexpected_first_message",
                             msg=session_data,
                         )
                 except TimeoutError:
-                    logger.warning("timeout waiting for elevenlabs session_started")
+                    logger.warning("elevenlabs_session_started_timeout")
                 except Exception as exc:
-                    logger.exception("error reading elevenlabs session_started", error=str(exc))
+                    logger.exception("elevenlabs_session_started_error", error=str(exc))
                     raise
 
                 send_task = asyncio.create_task(
@@ -125,7 +125,7 @@ class ElevenLabsSTTProvider(STTProvider):
                 await asyncio.gather(send_task, recv_task, return_exceptions=True)
 
         except Exception as exc:
-            logger.exception("elevenlabs measure_ttft failed", error=str(exc))
+            logger.exception("elevenlabs_measure_ttft_failed", error=str(exc))
             result.error = str(exc)
 
         result.total_time = time.monotonic() - total_start
@@ -159,7 +159,7 @@ class ElevenLabsSTTProvider(STTProvider):
                 )
             )
         except Exception as exc:
-            logger.exception("elevenlabs send error", error=str(exc))
+            logger.exception("elevenlabs_send_error", error=str(exc))
             raise
 
     async def _receive(self, ws: Any, result: TranscriptionResult) -> None:
@@ -178,7 +178,7 @@ class ElevenLabsSTTProvider(STTProvider):
                     error_text = msg.get("message", msg.get("error", "Unknown error"))
                     result.error = f"{msg_type}: {error_text}"
                     logger.error(
-                        "elevenlabs api error",
+                        "elevenlabs_api_error",
                         msg_type=msg_type,
                         error=error_text,
                     )
@@ -204,7 +204,7 @@ class ElevenLabsSTTProvider(STTProvider):
                             result.audio_to_final_seconds = now - result.audio_start_time
 
         except Exception as exc:
-            logger.exception("elevenlabs receive error", error=str(exc))
+            logger.exception("elevenlabs_receive_error", error=str(exc))
 
         if committed_parts:
             result.complete_transcript = " ".join(committed_parts).strip() or None

--- a/runner/src/coval_bench/providers/stt/google.py
+++ b/runner/src/coval_bench/providers/stt/google.py
@@ -173,7 +173,7 @@ class GoogleSTTProvider(STTProvider):
                         if saw_final:
                             last_final_time = now
             except Exception as exc:
-                logger.exception("google streaming_recognize failed", error=str(exc))
+                logger.exception("google_streaming_recognize_failed", error=str(exc))
                 raise
 
             if last_final_time is not None and result.audio_start_time is not None:
@@ -191,7 +191,7 @@ class GoogleSTTProvider(STTProvider):
             with concurrent.futures.ThreadPoolExecutor() as executor:
                 await loop.run_in_executor(executor, _run_sync)
         except Exception as exc:
-            logger.exception("google measure_ttft failed", error=str(exc))
+            logger.exception("google_measure_ttft_failed", error=str(exc))
             result.error = str(exc)
 
         result.total_time = time.monotonic() - total_start

--- a/runner/src/coval_bench/providers/stt/gradium.py
+++ b/runner/src/coval_bench/providers/stt/gradium.py
@@ -103,7 +103,7 @@ class GradiumSTTProvider(STTProvider):
                 await asyncio.gather(send_task, recv_task, return_exceptions=True)
 
         except Exception as exc:
-            logger.exception("gradium measure_ttft failed", error=str(exc))
+            logger.exception("gradium_measure_ttft_failed", error=str(exc))
             result.error = str(exc)
 
         result.total_time = time.monotonic() - total_start
@@ -134,7 +134,7 @@ class GradiumSTTProvider(STTProvider):
                 await asyncio.wait_for(final_event.wait(), timeout=_FLUSH_WAIT_S)
             await ws.send(json.dumps({"type": "end_of_stream"}))
         except Exception as exc:
-            logger.exception("gradium send error", error=str(exc))
+            logger.exception("gradium_send_error", error=str(exc))
             raise
 
     async def _receive(
@@ -185,11 +185,11 @@ class GradiumSTTProvider(STTProvider):
 
                 if msg_type == "error":
                     result.error = str(msg.get("message", msg))
-                    logger.error("gradium stt error", msg=msg)
+                    logger.error("gradium_stt_error", msg=msg)
                     break
 
         except Exception as exc:
-            logger.exception("gradium receive error", error=str(exc))
+            logger.exception("gradium_receive_error", error=str(exc))
 
         if final_parts:
             result.complete_transcript = " ".join(final_parts).strip() or None

--- a/runner/src/coval_bench/providers/stt/openai.py
+++ b/runner/src/coval_bench/providers/stt/openai.py
@@ -133,7 +133,7 @@ class OpenAISTTProvider(STTProvider):
                     await asyncio.gather(*tasks, return_exceptions=True)
 
         except Exception as exc:
-            logger.exception("openai measure_ttft failed", error=str(exc))
+            logger.exception("openai_measure_ttft_failed", error=str(exc))
             if result.error is None:
                 result.error = str(exc)
 
@@ -215,7 +215,7 @@ class OpenAISTTProvider(STTProvider):
                 await asyncio.sleep(realtime_resolution)
             await ws.send(json.dumps({"type": "input_audio_buffer.commit"}))
         except Exception as exc:
-            logger.exception("openai send error", error=str(exc))
+            logger.exception("openai_send_error", error=str(exc))
             raise
 
     async def _receive(self, ws: Any, result: TranscriptionResult) -> None:
@@ -265,7 +265,7 @@ class OpenAISTTProvider(STTProvider):
         except _TranscriptionAborted:
             raise
         except Exception as exc:
-            logger.exception("openai receive error", error=str(exc))
+            logger.exception("openai_receive_error", error=str(exc))
             if result.error is None:
                 result.error = str(exc)
 

--- a/runner/src/coval_bench/providers/stt/smallest.py
+++ b/runner/src/coval_bench/providers/stt/smallest.py
@@ -78,7 +78,7 @@ class SmallestSTTProvider(STTProvider):
                 await asyncio.gather(send_task, recv_task, return_exceptions=True)
 
         except Exception as exc:
-            logger.exception("smallest measure_ttft failed", error=str(exc))
+            logger.exception("smallest_measure_ttft_failed", error=str(exc))
             result.error = str(exc)
 
         result.total_time = time.monotonic() - total_start
@@ -106,7 +106,7 @@ class SmallestSTTProvider(STTProvider):
                 await asyncio.sleep(realtime_resolution)
             await ws.send(json.dumps({"type": "close_stream"}))
         except Exception as exc:
-            logger.exception("smallest send error", error=str(exc))
+            logger.exception("smallest_send_error", error=str(exc))
             raise
 
     async def _receive(self, ws: Any, result: TranscriptionResult) -> None:
@@ -148,7 +148,7 @@ class SmallestSTTProvider(STTProvider):
                     break
 
         except Exception as exc:
-            logger.exception("smallest receive error", error=str(exc))
+            logger.exception("smallest_receive_error", error=str(exc))
 
         if final_segments:
             result.complete_transcript = " ".join(final_segments).strip() or None

--- a/runner/src/coval_bench/providers/stt/soniox.py
+++ b/runner/src/coval_bench/providers/stt/soniox.py
@@ -91,7 +91,7 @@ class SonioxSTTProvider(STTProvider):
                         result.error = str(outcome)
 
         except Exception as exc:
-            logger.exception("soniox measure_ttft failed", error=str(exc))
+            logger.exception("soniox_measure_ttft_failed", error=str(exc))
             result.error = str(exc)
 
         result.total_time = time.monotonic() - total_start
@@ -116,7 +116,7 @@ class SonioxSTTProvider(STTProvider):
             # ignored, so the server never finalizes (stalls to its idle timeout).
             await ws.send("")
         except Exception as exc:
-            logger.exception("soniox send error", error=str(exc))
+            logger.exception("soniox_send_error", error=str(exc))
             raise
 
     async def _receive(self, ws: Any, result: TranscriptionResult) -> None:
@@ -135,7 +135,7 @@ class SonioxSTTProvider(STTProvider):
                     result.error = str(
                         msg.get("error_message") or f"Soniox STT error (code {code})"
                     )
-                    logger.error("soniox stt error", msg=msg)
+                    logger.error("soniox_stt_error", msg=msg)
                     break
 
                 tokens: list[dict[str, Any]] = msg.get("tokens") or []
@@ -160,7 +160,7 @@ class SonioxSTTProvider(STTProvider):
                     break
 
         except Exception as exc:
-            logger.exception("soniox receive error", error=str(exc))
+            logger.exception("soniox_receive_error", error=str(exc))
             if result.error is None:
                 result.error = str(exc)
 

--- a/runner/src/coval_bench/providers/stt/speechmatics.py
+++ b/runner/src/coval_bench/providers/stt/speechmatics.py
@@ -109,7 +109,7 @@ class SpeechmaticsProvider(STTProvider):
                 await asyncio.gather(send_task, recv_task, return_exceptions=True)
 
         except Exception as exc:
-            logger.exception("speechmatics measure_ttft failed", error=str(exc))
+            logger.exception("speechmatics_measure_ttft_failed", error=str(exc))
             result.error = str(exc)
 
         result.total_time = time.monotonic() - total_start
@@ -147,7 +147,7 @@ class SpeechmaticsProvider(STTProvider):
                 await asyncio.sleep(realtime_resolution)
             await ws.send(json.dumps({"message": "EndOfStream", "last_seq_no": seq_no}))
         except Exception as exc:
-            logger.exception("speechmatics send error", error=str(exc))
+            logger.exception("speechmatics_send_error", error=str(exc))
             raise
 
     async def _receive(self, ws: Any, result: TranscriptionResult) -> None:
@@ -187,7 +187,7 @@ class SpeechmaticsProvider(STTProvider):
                     last_final_time = now
 
         except Exception as exc:
-            logger.exception("speechmatics receive error", error=str(exc))
+            logger.exception("speechmatics_receive_error", error=str(exc))
 
         if last_final_time is not None and result.audio_start_time is not None:
             result.audio_to_final_seconds = last_final_time - result.audio_start_time

--- a/runner/src/coval_bench/providers/stt/xai.py
+++ b/runner/src/coval_bench/providers/stt/xai.py
@@ -104,7 +104,7 @@ class XaiSTTProvider(STTProvider):
                         raise task_result
 
         except Exception as exc:
-            logger.exception("xai measure_ttft failed", error=str(exc))
+            logger.exception("xai_measure_ttft_failed", error=str(exc))
             result.error = result.error or str(exc)
 
         result.total_time = time.monotonic() - total_start
@@ -208,7 +208,7 @@ class XaiSTTProvider(STTProvider):
                     result.error = str(event.get("message", "xAI error"))
                     break
         except Exception as exc:
-            logger.exception("xai receive error", error=str(exc))
+            logger.exception("xai_receive_error", error=str(exc))
             if result.error is None:
                 result.error = str(exc)
         finally:

--- a/runner/src/coval_bench/providers/tts/gradium.py
+++ b/runner/src/coval_bench/providers/tts/gradium.py
@@ -82,7 +82,7 @@ class GradiumTTSProvider(TTSProvider):
                 raw = await asyncio.wait_for(ws.recv(), timeout=5.0)
                 msg: dict[str, Any] = json.loads(raw)
                 if msg.get("type") != "ready":
-                    logger.warning("gradium unexpected first message", msg=msg)
+                    logger.warning("gradium_unexpected_first_message", msg=msg)
 
                 start = time.monotonic()
                 await ws.send(json.dumps({"type": "text", "text": text}))

--- a/runner/src/coval_bench/runner/orchestrator.py
+++ b/runner/src/coval_bench/runner/orchestrator.py
@@ -678,9 +678,9 @@ async def _refresh_series_bucket(writer: Any, run_id: int, settings: Settings) -
             await writer.refresh_bucket(run_id, period_seconds=settings.schedule_period_seconds)
         except Exception:
             if attempt == _BUCKET_REFRESH_ATTEMPTS:
-                _log.warning("series_bucket_refresh_failed", run_id=run_id, exc_info=True)
+                _log.warning("series_bucket_refresh_failed", exc_info=True)
                 return
-            _log.info("series_bucket_refresh_retry", run_id=run_id, attempt=attempt)
+            _log.info("series_bucket_refresh_retry", attempt=attempt)
             await asyncio.sleep(_BUCKET_REFRESH_RETRY_DELAY_S)
         else:
             return
@@ -710,6 +710,8 @@ async def run_benchmarks(
             The run row is updated to ``FAILED`` before re-raising so the Cloud
             Run Job exits non-zero and the log-based metric fires.
     """
+    structlog.contextvars.clear_contextvars()
+
     lifespan_pool, RunWriter, RunStatus, models_mod = _get_db_symbols()
     Result = models_mod.Result
     ResultStatus = models_mod.ResultStatus
@@ -781,9 +783,10 @@ async def run_benchmarks(
         assert run_id is not None  # noqa: S101 — DB always returns an id after INSERT
         started_at = run.started_at or datetime.now(tz=UTC)
 
+        structlog.contextvars.bind_contextvars(run_id=run_id)
+
         _log.info(
             "benchmark run started",
-            run_id=run_id,
             benchmark_kind=benchmark_kind,
             smoke=smoke,
             runner_sha=settings.runner_sha,
@@ -805,7 +808,7 @@ async def run_benchmarks(
             if sigterm_received:
                 return
             sigterm_received = True
-            _log.warning("SIGTERM received — finalizing run as partial", run_id=run_id)
+            _log.warning("SIGTERM received — finalizing run as partial")
             if main_task is not None:
                 main_task.cancel()
 
@@ -857,7 +860,7 @@ async def run_benchmarks(
                     sample_size=None if smoke else settings.dataset_sample_size,
                 )
                 items = stt_dataset.items[:1] if smoke else stt_dataset.items
-                _log.info("stt dataset sampled", run_id=run_id, item_count=len(items))
+                _log.info("stt dataset sampled", item_count=len(items))
 
                 stt_tasks = [
                     _run_stt_item(
@@ -889,7 +892,7 @@ async def run_benchmarks(
                     sample_size=None if smoke else settings.dataset_sample_size,
                 )
                 tts_items = tts_dataset.items[:1] if smoke else tts_dataset.items
-                _log.info("tts dataset sampled", run_id=run_id, item_count=len(tts_items))
+                _log.info("tts dataset sampled", item_count=len(tts_items))
 
                 tts_tasks = [
                     _run_tts_item(
@@ -940,7 +943,6 @@ async def run_benchmarks(
             except Exception as refresh_exc:
                 _log.error(
                     "failed to refresh stats matviews",
-                    run_id=run_id,
                     exc_info=refresh_exc,
                 )
 
@@ -961,7 +963,6 @@ async def run_benchmarks(
             duration_s = (finished_at - started_at).total_seconds()
             _log.info(
                 "benchmark run finished",
-                run_id=run_id,
                 status=str(final_status),
                 total_results=total_results,
                 success_count=success_count,
@@ -1007,7 +1008,6 @@ async def run_benchmarks(
             except Exception as write_exc:
                 _log.error(
                     "failed to update run row after SIGTERM",
-                    run_id=run_id,
                     exc_info=write_exc,
                 )
             else:
@@ -1017,7 +1017,6 @@ async def run_benchmarks(
             sigterm_duration_s = (finished_at - started_at).total_seconds()
             _log.warning(
                 "benchmark run finished early due to SIGTERM",
-                run_id=run_id,
                 status=str(RunStatus.PARTIAL),
                 total_results=total_results,
                 success_count=success_count,
@@ -1058,7 +1057,6 @@ async def run_benchmarks(
             # structlog uses the first positional arg as the ``event`` key.
             _log.error(
                 "RUN_FAILED",
-                run_id=run_id,
                 error=err_msg,
                 exc_info=exc,
             )
@@ -1067,7 +1065,6 @@ async def run_benchmarks(
             except Exception as write_exc:
                 _log.error(
                     "failed to update run row after RUN_FAILED",
-                    run_id=run_id,
                     exc_info=write_exc,
                 )
             _emit_posthog(

--- a/runner/src/coval_bench/runner/orchestrator.py
+++ b/runner/src/coval_bench/runner/orchestrator.py
@@ -223,7 +223,7 @@ async def _run_stt_item(
         provider_cls = stt_providers.get(entry.provider)
         if provider_cls is None:
             _log.warning(
-                "unknown STT provider — skipping",
+                "unknown_stt_provider",
                 provider=entry.provider,
                 model=entry.model,
             )
@@ -267,7 +267,7 @@ async def _run_stt_item(
         except Exception as exc:
             item_error = _truncate(str(exc))
             _log.warning(
-                "STT provider call failed",
+                "stt_provider_call_failed",
                 provider=entry.provider,
                 model=entry.model,
                 audio=str(audio_path),
@@ -413,7 +413,7 @@ async def _run_stt_item(
                 # crash here is a genuine failure — surface it as a FAILED row rather than
                 # silently dropping it and leaving the run marked SUCCEEDED.
                 _log.warning(
-                    "WER computation failed",
+                    "wer_computation_failed",
                     provider=entry.provider,
                     model=entry.model,
                     exc_info=exc,
@@ -439,7 +439,7 @@ async def _run_stt_item(
             await writer.record_results(results)
         except Exception as exc:
             _log.warning(
-                "STT result persist failed",
+                "stt_result_persist_failed",
                 provider=entry.provider,
                 model=entry.model,
                 exc_info=exc,
@@ -481,7 +481,7 @@ async def _run_tts_item(
         provider_cls = tts_providers.get(entry.provider)
         if provider_cls is None:
             _log.warning(
-                "unknown TTS provider — skipping",
+                "unknown_tts_provider",
                 provider=entry.provider,
                 model=entry.model,
             )
@@ -501,7 +501,7 @@ async def _run_tts_item(
         except Exception as exc:
             item_error = _truncate(str(exc))
             _log.warning(
-                "TTS provider call failed",
+                "tts_provider_call_failed",
                 provider=entry.provider,
                 model=entry.model,
                 exc_info=exc,
@@ -567,7 +567,7 @@ async def _run_tts_item(
                     whisper_transcript = await _transcribe_with_whisper(audio_path, settings)
                 except Exception as exc:
                     _log.warning(
-                        "TTS WER transcription failed",
+                        "tts_wer_transcription_failed",
                         provider=entry.provider,
                         model=entry.model,
                         exc_info=exc,
@@ -596,7 +596,7 @@ async def _run_tts_item(
                         )
                     except Exception as exc:
                         _log.warning(
-                            "TTS WER computation failed",
+                            "tts_wer_computation_failed",
                             provider=entry.provider,
                             model=entry.model,
                             exc_info=exc,
@@ -624,7 +624,7 @@ async def _run_tts_item(
                     audio_path.unlink()
                 except OSError as exc:
                     _log.warning(
-                        "failed to delete TTS audio file",
+                        "tts_audio_file_delete_failed",
                         path=str(audio_path),
                         exc_info=exc,
                     )
@@ -634,7 +634,7 @@ async def _run_tts_item(
             await writer.record_results(results)
         except Exception as exc:
             _log.warning(
-                "TTS result persist failed",
+                "tts_result_persist_failed",
                 provider=entry.provider,
                 model=entry.model,
                 exc_info=exc,
@@ -786,7 +786,7 @@ async def run_benchmarks(
         structlog.contextvars.bind_contextvars(run_id=run_id)
 
         _log.info(
-            "benchmark run started",
+            "benchmark_run_started",
             benchmark_kind=benchmark_kind,
             smoke=smoke,
             runner_sha=settings.runner_sha,
@@ -808,7 +808,7 @@ async def run_benchmarks(
             if sigterm_received:
                 return
             sigterm_received = True
-            _log.warning("SIGTERM received — finalizing run as partial")
+            _log.warning("sigterm_received")
             if main_task is not None:
                 main_task.cancel()
 
@@ -860,7 +860,7 @@ async def run_benchmarks(
                     sample_size=None if smoke else settings.dataset_sample_size,
                 )
                 items = stt_dataset.items[:1] if smoke else stt_dataset.items
-                _log.info("stt dataset sampled", item_count=len(items))
+                _log.info("stt_dataset_sampled", item_count=len(items))
 
                 stt_tasks = [
                     _run_stt_item(
@@ -878,7 +878,7 @@ async def run_benchmarks(
                 stt_batch = await asyncio.gather(*stt_tasks, return_exceptions=True)
                 for batch_result in stt_batch:
                     if isinstance(batch_result, BaseException):
-                        _log.warning("STT task raised unexpectedly", exc_info=batch_result)
+                        _log.warning("stt_task_raised", exc_info=batch_result)
                     else:
                         all_results.extend(batch_result)
 
@@ -892,7 +892,7 @@ async def run_benchmarks(
                     sample_size=None if smoke else settings.dataset_sample_size,
                 )
                 tts_items = tts_dataset.items[:1] if smoke else tts_dataset.items
-                _log.info("tts dataset sampled", item_count=len(tts_items))
+                _log.info("tts_dataset_sampled", item_count=len(tts_items))
 
                 tts_tasks = [
                     _run_tts_item(
@@ -910,7 +910,7 @@ async def run_benchmarks(
                 tts_batch = await asyncio.gather(*tts_tasks, return_exceptions=True)
                 for batch_result in tts_batch:
                     if isinstance(batch_result, BaseException):
-                        _log.warning("TTS task raised unexpectedly", exc_info=batch_result)
+                        _log.warning("tts_task_raised", exc_info=batch_result)
                     else:
                         all_results.extend(batch_result)
 
@@ -942,7 +942,7 @@ async def run_benchmarks(
                 await writer.refresh_stats_matviews()
             except Exception as refresh_exc:
                 _log.error(
-                    "failed to refresh stats matviews",
+                    "stats_matviews_refresh_failed",
                     exc_info=refresh_exc,
                 )
 
@@ -962,7 +962,7 @@ async def run_benchmarks(
 
             duration_s = (finished_at - started_at).total_seconds()
             _log.info(
-                "benchmark run finished",
+                "benchmark_run_finished",
                 status=str(final_status),
                 total_results=total_results,
                 success_count=success_count,
@@ -1007,7 +1007,7 @@ async def run_benchmarks(
                 )
             except Exception as write_exc:
                 _log.error(
-                    "failed to update run row after SIGTERM",
+                    "run_row_update_failed_after_sigterm",
                     exc_info=write_exc,
                 )
             else:
@@ -1016,7 +1016,7 @@ async def run_benchmarks(
             finished_at = datetime.now(tz=UTC)
             sigterm_duration_s = (finished_at - started_at).total_seconds()
             _log.warning(
-                "benchmark run finished early due to SIGTERM",
+                "benchmark_run_finished_early_sigterm",
                 status=str(RunStatus.PARTIAL),
                 total_results=total_results,
                 success_count=success_count,
@@ -1064,7 +1064,7 @@ async def run_benchmarks(
                 await writer.finish_run(run_id, status=RunStatus.FAILED, error=err_msg)
             except Exception as write_exc:
                 _log.error(
-                    "failed to update run row after RUN_FAILED",
+                    "run_row_update_failed_after_failure",
                     exc_info=write_exc,
                 )
             _emit_posthog(

--- a/runner/src/coval_bench/runner/retry.py
+++ b/runner/src/coval_bench/runner/retry.py
@@ -65,7 +65,7 @@ async def with_retry[T](
             last_exc = exc
             if attempt + 1 >= max_attempts:
                 _log.error(
-                    "retry exhausted",
+                    "retry_exhausted",
                     attempt=attempt + 1,
                     max_attempts=max_attempts,
                     exc_info=exc,
@@ -75,7 +75,7 @@ async def with_retry[T](
             # Full jitter — non-cryptographic, used only for backoff scheduling
             delay = random.uniform(0, cap)  # noqa: S311
             _log.warning(
-                "provider call failed — retrying",
+                "provider_call_retry",
                 attempt=attempt + 1,
                 max_attempts=max_attempts,
                 delay_s=round(delay, 3),

--- a/runner/tests/unit/test_logging.py
+++ b/runner/tests/unit/test_logging.py
@@ -25,9 +25,15 @@ from coval_bench.logging import configure_logging, uvicorn_log_config
 
 @pytest.fixture(autouse=True)
 def _reset_structlog() -> Iterator[None]:
-    """Restore structlog defaults after each test — configure_logging is global."""
+    """Restore structlog and stdlib logging defaults after each test — both are global."""
     yield
     structlog.reset_defaults()
+    for name in ("", "uvicorn", "uvicorn.error", "uvicorn.access"):
+        lg = logging.getLogger(name)
+        lg.handlers.clear()
+        lg.setLevel(logging.NOTSET)
+        if name:
+            lg.propagate = True
 
 
 def test_configure_logging_emits_json(capsys: pytest.CaptureFixture[str]) -> None:

--- a/runner/tests/unit/test_logging.py
+++ b/runner/tests/unit/test_logging.py
@@ -1,0 +1,87 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for coval_bench.logging.
+
+These lock the two things that bit us before: the JSON output format, and the
+``event="RUN_FAILED"`` field that the ``benchmark_run_failure`` Cloud Logging
+metric filters on. Output is captured from stdout and parsed as JSON rather than
+via ``structlog.testing.capture_logs`` so the real renderer chain is exercised.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import logging.config
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+import structlog
+
+from coval_bench.logging import configure_logging, uvicorn_log_config
+
+
+@pytest.fixture(autouse=True)
+def _reset_structlog() -> Iterator[None]:
+    """Restore structlog defaults after each test — configure_logging is global."""
+    yield
+    structlog.reset_defaults()
+
+
+def test_configure_logging_emits_json(capsys: pytest.CaptureFixture[str]) -> None:
+    configure_logging(level="INFO")
+    structlog.get_logger("test").info("hello", run_id=7)
+
+    record: dict[str, Any] = json.loads(capsys.readouterr().out.strip())
+    assert record["event"] == "hello"
+    assert record["level"] == "info"
+    assert record["run_id"] == 7
+    assert "timestamp" in record
+
+
+def test_run_failed_event_matches_alert_filter(capsys: pytest.CaptureFixture[str]) -> None:
+    # benchmark_run_failure filters on jsonPayload.event="RUN_FAILED" (see
+    # benchmark-infra modules/alerting). The key name and value are a prod-alerting
+    # contract — a rename here silently breaks the alert, so pin it.
+    configure_logging(level="INFO")
+    structlog.get_logger("coval_bench.runner").error("RUN_FAILED", error="boom")
+
+    record: dict[str, Any] = json.loads(capsys.readouterr().out.strip())
+    assert record["event"] == "RUN_FAILED"
+    assert record["level"] == "error"
+
+
+def test_level_filtering_drops_below_threshold(capsys: pytest.CaptureFixture[str]) -> None:
+    configure_logging(level="WARNING")
+    log = structlog.get_logger("test")
+    log.info("dropped")
+    log.warning("kept")
+
+    out = capsys.readouterr().out
+    assert "dropped" not in out
+    assert json.loads(out.strip())["event"] == "kept"
+
+
+def test_uvicorn_config_silences_access_log() -> None:
+    logging.config.dictConfig(uvicorn_log_config("INFO"))
+
+    access = logging.getLogger("uvicorn.access")
+    assert access.handlers == []
+    assert access.propagate is False
+
+
+def test_uvicorn_config_renders_error_log_as_json(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    logging.config.dictConfig(uvicorn_log_config("INFO"))
+
+    logging.getLogger("uvicorn.error").info("Application startup complete.")
+    logging.getLogger("uvicorn.access").info('127.0.0.1 - "GET / HTTP/1.1" 200')
+
+    lines = [line for line in capsys.readouterr().out.splitlines() if line]
+    assert len(lines) == 1  # access log produced nothing
+    record: dict[str, Any] = json.loads(lines[0])
+    assert record["event"] == "Application startup complete."
+    assert record["level"] == "info"


### PR DESCRIPTION
Our logging hasn't been working. This is just a blanket fix of everything I could find wrong with the goal of us not having to worry about it going forward.

Best way to review this PR is to go on a commit by commit basis. Otherwise it'll feel like a ton of different things.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Application startup now configures consistent machine-readable JSON logging and honors the selected log level.
  * Added per-request logging with unique request IDs (sent back via response headers) and captured request duration and final status.
  * Aligned startup/error and access logging with the same JSON format for clearer operations output.
* **Bug Fixes**
  * Request logging now records the final HTTP response status accurately and consistently.
* **Tests**
  * Added unit coverage for JSON log fields, log-level filtering, and silencing of duplicate access logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR overhauls logging across the benchmarks runner and API: it introduces `configure_logging()` for structured JSON output via structlog, adds a pure-ASGI `RequestLoggingMiddleware` that injects per-request IDs and emits one canonical access-log line per request, and aligns uvicorn's own startup/error logs into the same JSON format via `uvicorn_log_config()`. Event names in providers, retry, and dataset loader are migrated from free-form strings to snake_case tokens for structured querying.

- **`logging.py`**: new `configure_logging()` (structlog JSON pipeline) and `uvicorn_log_config()` (stdlib `dictConfig` dict that wires uvicorn's loggers through `ProcessorFormatter`); `uvicorn.access` is intentionally given no handler since the middleware replaces it.
- **`api/request_logging.py`**: pure-ASGI middleware binding a Cloud-Trace-compatible `request_id` to contextvars and logging one `http_request` line per request with method, path, status, and duration; added as the outermost `add_middleware` call so it wraps the entire stack.
- **Provider / runner files**: event strings normalised to `snake_case` tokens (`assemblyai_measure_ttft_failed`, `retry_exhausted`, etc.) and stdlib `logging.getLogger` calls migrated to `structlog.get_logger`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the logging changes are additive, the ASGI middleware is a well-contained wrapper, and no business logic is altered.

All changed files touch logging setup or event-string normalisation only. The structlog processor chain, uvicorn dictConfig, and request-logging middleware are correctly implemented and covered by the new unit tests. No data paths, DB writes, or auth flows are affected.

No files require special attention; the double-dictConfig note in main.py is a minor clarity issue, not a correctness problem.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| runner/src/coval_bench/logging.py | New module: configure_logging() and uvicorn_log_config() — structlog pipeline and uvicorn ProcessorFormatter dict config are correct; processor order is consistent with structlog docs. |
| runner/src/coval_bench/api/request_logging.py | Pure-ASGI middleware correctly captures final HTTP status via send_wrapper, injects X-Request-ID, and clears contextvars before/after each request. |
| runner/src/coval_bench/api/main.py | Module-level configure_logging + dictConfig(uvicorn_log_config) wins over uvicorn's default setup; __main__ block additionally passes log_config to uvicorn.run(), causing dictConfig to be applied twice — harmless but redundant. |
| runner/src/coval_bench/api/app.py | RequestLoggingMiddleware added as outermost middleware; configure_logging called in lifespan as defensive fallback — redundant with main.py module-level call but harmless. |
| runner/tests/unit/test_logging.py | Good coverage: exercises the real renderer chain via stdout capture, pins the RUN_FAILED event name as a prod-alerting contract, and verifies uvicorn.access is silenced. |

</details>



<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant ServerErrorMiddleware
    participant RequestLoggingMiddleware
    participant SlowAPIMiddleware
    participant RouteHandler

    Client->>ServerErrorMiddleware: HTTP request
    ServerErrorMiddleware->>RequestLoggingMiddleware: forward
    Note over RequestLoggingMiddleware: clear_contextvars()<br/>bind request_id<br/>start timer
    RequestLoggingMiddleware->>SlowAPIMiddleware: forward (send_wrapper)
    SlowAPIMiddleware->>RouteHandler: forward
    RouteHandler-->>SlowAPIMiddleware: http.response.start (status)
    SlowAPIMiddleware-->>RequestLoggingMiddleware: http.response.start
    Note over RequestLoggingMiddleware: capture status<br/>inject X-Request-ID header
    RequestLoggingMiddleware-->>ServerErrorMiddleware: http.response.start
    ServerErrorMiddleware-->>Client: response
    Note over RequestLoggingMiddleware: log http_request<br/>(method, path, status, duration_ms)<br/>clear_contextvars()
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant ServerErrorMiddleware
    participant RequestLoggingMiddleware
    participant SlowAPIMiddleware
    participant RouteHandler

    Client->>ServerErrorMiddleware: HTTP request
    ServerErrorMiddleware->>RequestLoggingMiddleware: forward
    Note over RequestLoggingMiddleware: clear_contextvars()<br/>bind request_id<br/>start timer
    RequestLoggingMiddleware->>SlowAPIMiddleware: forward (send_wrapper)
    SlowAPIMiddleware->>RouteHandler: forward
    RouteHandler-->>SlowAPIMiddleware: http.response.start (status)
    SlowAPIMiddleware-->>RequestLoggingMiddleware: http.response.start
    Note over RequestLoggingMiddleware: capture status<br/>inject X-Request-ID header
    RequestLoggingMiddleware-->>ServerErrorMiddleware: http.response.start
    ServerErrorMiddleware-->>Client: response
    Note over RequestLoggingMiddleware: log http_request<br/>(method, path, status, duration_ms)<br/>clear_contextvars()
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `runner/src/coval_bench/datasets/scripts/build_dataset.py`, line 422-430 ([link](https://github.com/coval-ai/benchmarks/blob/fc317d5983d4df926c98f4a396d1326ec5cf138f/runner/src/coval_bench/datasets/scripts/build_dataset.py#L422-L430)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Custom structlog config omits level filtering, emitting all log levels including DEBUG**

   Unlike `configure_logging()` which sets `wrapper_class=structlog.make_filtering_bound_logger(log_level)`, this custom config does not set a `wrapper_class`. With structlog's default `BoundLogger` over `PrintLoggerFactory`, there is no level-based filtering — DEBUG messages will be printed to stderr even when only INFO and above are desired. Adding `wrapper_class=structlog.make_filtering_bound_logger(logging.INFO)` (after `import logging`) would match the behaviour of the main config.
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/mai..."](https://github.com/coval-ai/benchmarks/commit/aa8c0a74d8c0dd603727c5b8f28953dad8c1312e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38742676)</sub>

<!-- /greptile_comment -->