### PR TITLE
Add arena rating snapshot job

### DIFF
--- a/runner/src/coval_bench/__main__.py
+++ b/runner/src/coval_bench/__main__.py
@@ -173,6 +173,7 @@ def arena() -> None:
 )
 def arena_snapshot(metric: str, bootstrap_rounds: int, seed: int, force: bool) -> None:
     """Refit Davidson-BT ratings from all votes and persist a leaderboard board."""
+    from coval_bench.arena.rating import ConvergenceError
     from coval_bench.arena.snapshot import run_snapshot
     from coval_bench.config import get_settings
     from coval_bench.db.arena_store import ArenaStore
@@ -190,7 +191,20 @@ def arena_snapshot(metric: str, bootstrap_rounds: int, seed: int, force: bool) -
             )
         return None if result is None else len(result.models)
 
-    written = asyncio.run(_run())
+    try:
+        written = asyncio.run(_run())
+    except ConvergenceError as exc:
+        click.echo(
+            json.dumps(
+                {
+                    "event": "arena_snapshot",
+                    "metric": metric,
+                    "error": "convergence_failed",
+                    "detail": str(exc),
+                }
+            )
+        )
+        sys.exit(1)
     if written is None:
         click.echo(json.dumps({"event": "arena_snapshot", "metric": metric, "skipped": True}))
     else:

--- a/runner/src/coval_bench/__main__.py
+++ b/runner/src/coval_bench/__main__.py
@@ -139,5 +139,63 @@ def tts_smoke(provider: str, model: str, voice: str, text: str) -> None:
     sys.exit(0 if ok else 1)
 
 
+@cli.group()
+def arena() -> None:
+    """Voice Arena maintenance commands."""
+
+
+@arena.command(name="snapshot")
+@click.option(
+    "--metric",
+    default="naturalness",
+    show_default=True,
+    help="Metric to rate (MVP: naturalness).",
+)
+@click.option(
+    "--bootstrap-rounds",
+    default=1000,
+    show_default=True,
+    type=int,
+    help="Bootstrap resamples for the confidence interval (0 disables CIs).",
+)
+@click.option(
+    "--seed",
+    default=0,
+    show_default=True,
+    type=int,
+    help="RNG seed; keeps the bootstrap CI reproducible.",
+)
+@click.option(
+    "--force",
+    is_flag=True,
+    default=False,
+    help="Run even if another snapshot is in progress (bypass the advisory lock).",
+)
+def arena_snapshot(metric: str, bootstrap_rounds: int, seed: int, force: bool) -> None:
+    """Refit Davidson-BT ratings from all votes and persist a leaderboard board."""
+    from coval_bench.arena.snapshot import run_snapshot
+    from coval_bench.config import get_settings
+    from coval_bench.db.arena_store import ArenaStore
+    from coval_bench.db.conn import lifespan_pool
+
+    async def _run() -> int | None:
+        settings = get_settings()
+        async with lifespan_pool(settings) as pool:
+            result = await run_snapshot(
+                ArenaStore(pool),
+                metric_name=metric,
+                bootstrap_rounds=bootstrap_rounds,
+                seed=seed,
+                force=force,
+            )
+        return None if result is None else len(result.models)
+
+    written = asyncio.run(_run())
+    if written is None:
+        click.echo(json.dumps({"event": "arena_snapshot", "metric": metric, "skipped": True}))
+    else:
+        click.echo(json.dumps({"event": "arena_snapshot", "metric": metric, "models": written}))
+
+
 if __name__ == "__main__":
     cli()

--- a/runner/src/coval_bench/arena/snapshot.py
+++ b/runner/src/coval_bench/arena/snapshot.py
@@ -1,0 +1,106 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Rating snapshot job — refit ratings from raw votes and persist one board.
+
+Pure orchestration: reads every battle and vote via :class:`ArenaStore`, feeds
+them to the pure :func:`compute_ratings` engine, and writes the resulting board
+back through the store. No SQL and no rating math live here.
+"""
+
+from __future__ import annotations
+
+from coval_bench.arena.rating import BattleOutcome, RatingResult, compute_ratings
+from coval_bench.db.arena_store import ArenaStore
+from coval_bench.db.models import LeaderboardSnapshot, SnapshotStatus
+
+
+def _model_id(provider: str, model: str) -> str:
+    return f"{provider}/{model}"
+
+
+async def _refit_and_persist(
+    store: ArenaStore,
+    *,
+    metric_name: str,
+    domain: str,
+    bootstrap_rounds: int,
+    seed: int,
+) -> RatingResult:
+    battles = {battle.id: battle for battle in await store.list_battles(limit=None)}
+    votes = await store.list_votes()
+
+    outcomes: list[BattleOutcome] = []
+    id_to_pm: dict[str, tuple[str, str]] = {}
+    for vote in votes:
+        battle = battles.get(vote.battle_id)
+        if battle is None:
+            continue
+        a_id = _model_id(battle.provider_a, battle.model_a)
+        b_id = _model_id(battle.provider_b, battle.model_b)
+        id_to_pm[a_id] = (battle.provider_a, battle.model_a)
+        id_to_pm[b_id] = (battle.provider_b, battle.model_b)
+        outcomes.append(BattleOutcome(model_a=a_id, model_b=b_id, outcome=vote.outcome.value))
+
+    result = compute_ratings(outcomes, bootstrap_rounds=bootstrap_rounds, seed=seed)
+
+    rows = [
+        LeaderboardSnapshot(
+            metric_name=metric_name,
+            methodology_version=result.methodology_version,
+            domain=domain,
+            provider=id_to_pm[entry.model_id][0],
+            model=id_to_pm[entry.model_id][1],
+            rating_elo=entry.rating_elo,
+            rating_bt=entry.rating_bt,
+            ci_low=entry.ci_low,
+            ci_high=entry.ci_high,
+            ci_half_width=entry.ci_half_width,
+            votes_total=entry.votes_total,
+            wins=entry.wins,
+            losses=entry.losses,
+            ties=entry.ties,
+            status=SnapshotStatus(entry.status),
+        )
+        for entry in result.models
+    ]
+    await store.insert_snapshot_board(rows)
+    return result
+
+
+async def run_snapshot(
+    store: ArenaStore,
+    *,
+    metric_name: str = "naturalness",
+    domain: str = "all",
+    bootstrap_rounds: int = 1000,
+    seed: int = 0,
+    force: bool = False,
+) -> RatingResult | None:
+    """Refit the Davidson-BT board from all votes and persist it.
+
+    Holds a non-blocking advisory lock so two runs never compute at once: if
+    another run already holds it, this one returns ``None`` (skipped) rather than
+    queueing. ``force=True`` bypasses the lock for a deliberate manual run.
+    ``seed`` keeps the bootstrap CI reproducible. The result is empty — and
+    nothing is written — when there are no votes; models with no votes never
+    appear and are never persisted.
+    """
+    if force:
+        return await _refit_and_persist(
+            store,
+            metric_name=metric_name,
+            domain=domain,
+            bootstrap_rounds=bootstrap_rounds,
+            seed=seed,
+        )
+    async with store.snapshot_lock() as acquired:
+        if not acquired:
+            return None
+        return await _refit_and_persist(
+            store,
+            metric_name=metric_name,
+            domain=domain,
+            bootstrap_rounds=bootstrap_rounds,
+            seed=seed,
+        )

--- a/runner/src/coval_bench/arena/snapshot.py
+++ b/runner/src/coval_bench/arena/snapshot.py
@@ -27,7 +27,10 @@ async def _refit_and_persist(
     bootstrap_rounds: int,
     seed: int,
 ) -> RatingResult:
-    battles = {battle.id: battle for battle in await store.list_battles(limit=None)}
+    battle_domain = None if domain == "all" else domain
+    battles = {
+        battle.id: battle for battle in await store.list_battles(domain=battle_domain, limit=None)
+    }
     votes = await store.list_votes()
 
     outcomes: list[BattleOutcome] = []

--- a/runner/src/coval_bench/db/arena_store.py
+++ b/runner/src/coval_bench/db/arena_store.py
@@ -10,15 +10,20 @@ are the source of truth; ratings are refit from them elsewhere.
 
 from __future__ import annotations
 
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from uuid import UUID
 
 import psycopg
 import psycopg.rows
 from psycopg_pool import AsyncConnectionPool
 
-from coval_bench.db.models import Battle, Vote, VoteOutcome, VoterType
+from coval_bench.db.models import Battle, LeaderboardSnapshot, Vote, VoteOutcome, VoterType
 
 ArenaPool = AsyncConnectionPool[psycopg.AsyncConnection[psycopg.rows.DictRow]]
+
+_SNAPSHOT_LOCK_ACQUIRE = "SELECT pg_try_advisory_lock(hashtextextended('arena_snapshot', 0))"
+_SNAPSHOT_LOCK_RELEASE = "SELECT pg_advisory_unlock(hashtextextended('arena_snapshot', 0))"
 
 
 class ArenaStore:
@@ -112,28 +117,26 @@ class ArenaStore:
         self,
         *,
         domain: str | None = None,
-        limit: int = 100,
+        limit: int | None = 100,
     ) -> list[Battle]:
-        """Return battles ordered by creation time, optionally filtered by domain."""
-        if domain is None:
-            sql = """
-                SELECT id, provider_a, model_a, provider_b, model_b, domain,
-                       prompt_text, audio_a_url, audio_b_url, created_at
-                FROM arena.battles
-                ORDER BY created_at
-                LIMIT %s
-            """
-            params: tuple[object, ...] = (limit,)
-        else:
-            sql = """
-                SELECT id, provider_a, model_a, provider_b, model_b, domain,
-                       prompt_text, audio_a_url, audio_b_url, created_at
-                FROM arena.battles
-                WHERE domain = %s
-                ORDER BY created_at
-                LIMIT %s
-            """
-            params = (domain, limit)
+        """Return battles ordered by creation time, optionally filtered by domain.
+
+        ``limit`` defaults to 100; pass ``None`` for no cap, which the rating
+        refit needs so it can map every vote back to its battle.
+        """
+        clauses = [
+            "SELECT id, provider_a, model_a, provider_b, model_b, domain,"
+            " prompt_text, audio_a_url, audio_b_url, created_at FROM arena.battles",
+        ]
+        params: list[object] = []
+        if domain is not None:
+            clauses.append("WHERE domain = %s")
+            params.append(domain)
+        clauses.append("ORDER BY created_at")
+        if limit is not None:
+            clauses.append("LIMIT %s")
+            params.append(limit)
+        sql = "\n".join(clauses)
         async with (
             self._pool.connection() as conn,
             conn.cursor(row_factory=psycopg.rows.dict_row) as cur,
@@ -141,6 +144,76 @@ class ArenaStore:
             await cur.execute(sql, params)
             rows = await cur.fetchall()
         return [Battle.model_validate(dict(row)) for row in rows]
+
+    async def insert_snapshot_board(self, rows: list[LeaderboardSnapshot]) -> int:
+        """Persist one leaderboard board atomically; return the row count.
+
+        Every row is inserted in a single transaction with ``computed_at`` left
+        to the DB default, so the whole board shares one timestamp and a reader
+        taking ``max(computed_at)`` never sees a partial board. An empty board
+        (no votes yet) writes nothing.
+        """
+        if not rows:
+            return 0
+        sql = """
+            INSERT INTO arena.leaderboard_snapshots
+                (metric_name, methodology_version, domain, provider, model,
+                 rating_elo, rating_bt, ci_low, ci_high, ci_half_width,
+                 votes_total, wins, losses, ties, status)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+        """
+        async with (
+            self._pool.connection() as conn,
+            conn.transaction(),
+            conn.cursor() as cur,
+        ):
+            for r in rows:
+                await cur.execute(
+                    sql,
+                    (
+                        r.metric_name,
+                        r.methodology_version,
+                        r.domain,
+                        r.provider,
+                        r.model,
+                        r.rating_elo,
+                        r.rating_bt,
+                        r.ci_low,
+                        r.ci_high,
+                        r.ci_half_width,
+                        r.votes_total,
+                        r.wins,
+                        r.losses,
+                        r.ties,
+                        r.status,
+                    ),
+                )
+        return len(rows)
+
+    @asynccontextmanager
+    async def snapshot_lock(self) -> AsyncIterator[bool]:
+        """Hold the global snapshot advisory lock; yield whether it was acquired.
+
+        Non-blocking: ``pg_try_advisory_lock`` returns ``False`` at once if another
+        run already holds the lock, so the caller can skip instead of queueing.
+        The lock is session-scoped — it lives on this one connection and survives
+        commits — so the connection is held open for the whole job and released on
+        exit. Postgres drops it if the connection dies, so a crashed run never
+        wedges the lock.
+        """
+        async with self._pool.connection() as conn:
+            async with conn.cursor(row_factory=psycopg.rows.tuple_row) as cur:
+                await cur.execute(_SNAPSHOT_LOCK_ACQUIRE)
+                row = await cur.fetchone()
+            await conn.commit()
+            acquired = bool(row[0]) if row is not None else False
+            try:
+                yield acquired
+            finally:
+                if acquired:
+                    async with conn.cursor(row_factory=psycopg.rows.tuple_row) as cur:
+                        await cur.execute(_SNAPSHOT_LOCK_RELEASE)
+                    await conn.commit()
 
     async def list_votes(
         self,

--- a/runner/src/coval_bench/db/arena_store.py
+++ b/runner/src/coval_bench/db/arena_store.py
@@ -162,32 +162,32 @@ class ArenaStore:
                  votes_total, wins, losses, ties, status)
             VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
         """
+        params_seq = [
+            (
+                r.metric_name,
+                r.methodology_version,
+                r.domain,
+                r.provider,
+                r.model,
+                r.rating_elo,
+                r.rating_bt,
+                r.ci_low,
+                r.ci_high,
+                r.ci_half_width,
+                r.votes_total,
+                r.wins,
+                r.losses,
+                r.ties,
+                r.status,
+            )
+            for r in rows
+        ]
         async with (
             self._pool.connection() as conn,
             conn.transaction(),
             conn.cursor() as cur,
         ):
-            for r in rows:
-                await cur.execute(
-                    sql,
-                    (
-                        r.metric_name,
-                        r.methodology_version,
-                        r.domain,
-                        r.provider,
-                        r.model,
-                        r.rating_elo,
-                        r.rating_bt,
-                        r.ci_low,
-                        r.ci_high,
-                        r.ci_half_width,
-                        r.votes_total,
-                        r.wins,
-                        r.losses,
-                        r.ties,
-                        r.status,
-                    ),
-                )
+            await cur.executemany(sql, params_seq)
         return len(rows)
 
     @asynccontextmanager

--- a/runner/src/coval_bench/db/models.py
+++ b/runner/src/coval_bench/db/models.py
@@ -20,10 +20,12 @@ from coval_bench.registries.benchmarks import Benchmark
 __all__ = [
     "Battle",
     "Benchmark",
+    "LeaderboardSnapshot",
     "Result",
     "ResultStatus",
     "Run",
     "RunStatus",
+    "SnapshotStatus",
     "Vote",
     "VoteOutcome",
     "VoterType",
@@ -120,3 +122,37 @@ class Vote(BaseModel):
     voter_id: str
     created_at: datetime | None = None  # set by DB default (now())
     updated_at: datetime | None = None  # maintained by the BEFORE UPDATE trigger
+
+
+class SnapshotStatus(StrEnum):
+    """Confidence tier of a leaderboard rating, gated on the CI half-width."""
+
+    PRELIMINARY = "preliminary"
+    USABLE = "usable"
+    ESTABLISHED = "established"
+
+
+class LeaderboardSnapshot(BaseModel):
+    """Domain model for one ``arena.leaderboard_snapshots`` row — one model in one board.
+
+    A board is every row sharing ``computed_at`` + ``metric_name`` +
+    ``methodology_version`` + ``domain``. ``computed_at`` is left to the DB
+    default so a board written in one transaction shares a single timestamp.
+    """
+
+    computed_at: datetime | None = None  # set by DB default (now())
+    metric_name: str
+    methodology_version: str
+    domain: str = "all"
+    provider: str
+    model: str
+    rating_elo: float
+    rating_bt: float
+    ci_low: float | None = None
+    ci_high: float | None = None
+    ci_half_width: float | None = None
+    votes_total: int
+    wins: float
+    losses: float
+    ties: float
+    status: SnapshotStatus

--- a/runner/tests/unit/test_arena_snapshot.py
+++ b/runner/tests/unit/test_arena_snapshot.py
@@ -109,8 +109,19 @@ def _battle(provider_b: str, model_b: str) -> Battle:
 _VOTES = [VoteOutcome.A_WIN] * 5 + [VoteOutcome.B_WIN, VoteOutcome.TIE]
 
 
-async def _seed_one_battle(store: ArenaStore) -> None:
-    battle = await store.insert_battle(_battle("openai", "gpt-4o-mini-tts"))
+async def _seed_battle(store: ArenaStore, *, domain: str, provider_b: str, model_b: str) -> None:
+    battle = await store.insert_battle(
+        Battle(
+            provider_a="cartesia",
+            model_a="sonic-3.5",
+            provider_b=provider_b,
+            model_b=model_b,
+            domain=domain,
+            prompt_text="hello there",
+            audio_a_url="https://example.test/a.wav",
+            audio_b_url="https://example.test/b.wav",
+        )
+    )
     assert battle.id is not None
     for idx, outcome in enumerate(_VOTES):
         await store.upsert_vote(
@@ -119,6 +130,10 @@ async def _seed_one_battle(store: ArenaStore) -> None:
             voter_type=VoterType.LABELER,
             voter_id=f"labeler-{idx + 1}",
         )
+
+
+async def _seed_one_battle(store: ArenaStore) -> None:
+    await _seed_battle(store, domain="general", provider_b="openai", model_b="gpt-4o-mini-tts")
 
 
 def test_snapshot_persists_one_board(snap_pg: psycopg.Connection[Any]) -> None:
@@ -219,6 +234,44 @@ def test_snapshot_force_runs_despite_held_lock(snap_pg: psycopg.Connection[Any])
             assert forced is not None
             assert len(forced.models) == 2
             assert await _snapshot_row_count(pool) == 2
+        finally:
+            await pool.close()
+
+    asyncio.run(_run())
+
+
+def test_snapshot_scoped_to_domain_excludes_other_domains(snap_pg: psycopg.Connection[Any]) -> None:
+    _apply_migrations(snap_pg)
+
+    async def _run() -> None:
+        pool = await _make_pool(snap_pg)
+        try:
+            await _reset(pool)
+            store = ArenaStore(pool)
+            await _seed_battle(
+                store, domain="general", provider_b="openai", model_b="gpt-4o-mini-tts"
+            )
+            await _seed_battle(store, domain="support", provider_b="deepgram", model_b="aura-2")
+
+            result = await run_snapshot(store, domain="support", bootstrap_rounds=50, seed=0)
+            assert result is not None
+            assert {entry.model_id for entry in result.models} == {
+                "cartesia/sonic-3.5",
+                "deepgram/aura-2",
+            }
+
+            async with (
+                pool.connection() as conn,
+                conn.cursor(row_factory=psycopg.rows.dict_row) as cur,
+            ):
+                await cur.execute("SELECT domain, provider, model FROM arena.leaderboard_snapshots")
+                rows = await cur.fetchall()
+
+            assert {r["domain"] for r in rows} == {"support"}
+            assert {(r["provider"], r["model"]) for r in rows} == {
+                ("cartesia", "sonic-3.5"),
+                ("deepgram", "aura-2"),
+            }
         finally:
             await pool.close()
 

--- a/runner/tests/unit/test_arena_snapshot.py
+++ b/runner/tests/unit/test_arena_snapshot.py
@@ -1,0 +1,225 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for coval_bench.arena.snapshot.
+
+Uses ``pytest-postgresql`` (embedded ``pg_ctl``, no Docker) to spin up a real
+Postgres. No remote DB is ever contacted. A separate session server (random
+port) keeps these independent of the other db tests.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any
+from urllib.parse import quote_plus
+
+import psycopg
+import psycopg.rows
+from alembic import command as alembic_command
+from alembic.config import Config as AlembicConfig
+from psycopg_pool import AsyncConnectionPool
+from pytest_postgresql.factories import postgresql, postgresql_proc
+
+from coval_bench.arena.snapshot import run_snapshot
+from coval_bench.db.arena_store import ArenaStore
+from coval_bench.db.models import Battle, VoteOutcome, VoterType
+
+snap_pg_proc = postgresql_proc(port=None)
+snap_pg = postgresql("snap_pg_proc")
+
+_INI_PATH = Path(__file__).parents[2] / "alembic.ini"
+
+
+def _alembic_cfg(dsn: str) -> AlembicConfig:
+    cfg = AlembicConfig(str(_INI_PATH))
+    cfg.set_main_option(
+        "sqlalchemy.url",
+        dsn.replace("postgresql://", "postgresql+psycopg://"),
+    )
+    return cfg
+
+
+def _async_dsn(conn: psycopg.Connection[Any]) -> str:
+    info = conn.info
+    host = info.host or "localhost"
+    port = info.port or 5432
+    dbname = info.dbname or "test"
+    user = info.user or ""
+    password = info.password or ""
+    if password:
+        return f"postgresql://{quote_plus(user)}:{quote_plus(password)}@{host}:{port}/{dbname}"
+    return f"postgresql://{quote_plus(user)}@{host}:{port}/{dbname}"
+
+
+def _apply_migrations(conn: psycopg.Connection[Any]) -> None:
+    alembic_command.upgrade(_alembic_cfg(_async_dsn(conn)), "head")
+
+
+async def _make_pool(
+    conn: psycopg.Connection[Any],
+) -> AsyncConnectionPool[psycopg.AsyncConnection[psycopg.rows.DictRow]]:
+    pool: AsyncConnectionPool[psycopg.AsyncConnection[psycopg.rows.DictRow]] = AsyncConnectionPool(
+        conninfo=_async_dsn(conn),
+        min_size=1,
+        max_size=4,
+        open=False,
+        kwargs={
+            "autocommit": False,
+            "row_factory": psycopg.rows.dict_row,
+        },
+    )
+    await pool.open()
+    return pool
+
+
+async def _reset(pool: AsyncConnectionPool[Any]) -> None:
+    async with pool.connection() as conn, conn.cursor() as cur:
+        await cur.execute("DELETE FROM arena.leaderboard_snapshots")
+        await cur.execute("DELETE FROM arena.votes")
+        await cur.execute("DELETE FROM arena.battles")
+        await conn.commit()
+
+
+async def _snapshot_row_count(pool: AsyncConnectionPool[Any]) -> int:
+    async with (
+        pool.connection() as conn,
+        conn.cursor(row_factory=psycopg.rows.tuple_row) as cur,
+    ):
+        await cur.execute("SELECT count(*) FROM arena.leaderboard_snapshots")
+        row = await cur.fetchone()
+    assert row is not None
+    return int(row[0])
+
+
+def _battle(provider_b: str, model_b: str) -> Battle:
+    return Battle(
+        provider_a="cartesia",
+        model_a="sonic-3.5",
+        provider_b=provider_b,
+        model_b=model_b,
+        domain="general",
+        prompt_text="hello there",
+        audio_a_url="https://example.test/a.wav",
+        audio_b_url="https://example.test/b.wav",
+    )
+
+
+_VOTES = [VoteOutcome.A_WIN] * 5 + [VoteOutcome.B_WIN, VoteOutcome.TIE]
+
+
+async def _seed_one_battle(store: ArenaStore) -> None:
+    battle = await store.insert_battle(_battle("openai", "gpt-4o-mini-tts"))
+    assert battle.id is not None
+    for idx, outcome in enumerate(_VOTES):
+        await store.upsert_vote(
+            battle_id=battle.id,
+            outcome=outcome,
+            voter_type=VoterType.LABELER,
+            voter_id=f"labeler-{idx + 1}",
+        )
+
+
+def test_snapshot_persists_one_board(snap_pg: psycopg.Connection[Any]) -> None:
+    _apply_migrations(snap_pg)
+
+    async def _run() -> None:
+        pool = await _make_pool(snap_pg)
+        try:
+            await _reset(pool)
+            store = ArenaStore(pool)
+            await _seed_one_battle(store)
+
+            result = await run_snapshot(store, bootstrap_rounds=50, seed=0)
+            assert result is not None
+            assert len(result.models) == 2
+
+            async with (
+                pool.connection() as conn,
+                conn.cursor(row_factory=psycopg.rows.dict_row) as cur,
+            ):
+                await cur.execute(
+                    "SELECT provider, model, metric_name, methodology_version, domain,"
+                    " rating_elo, rating_bt, status, votes_total, computed_at"
+                    " FROM arena.leaderboard_snapshots"
+                )
+                rows = await cur.fetchall()
+
+            assert len(rows) == 2
+            assert {r["metric_name"] for r in rows} == {"naturalness"}
+            assert {r["domain"] for r in rows} == {"all"}
+            assert {r["methodology_version"] for r in rows} == {"davidson-bt-1"}
+            assert len({r["computed_at"] for r in rows}) == 1
+            assert {(r["provider"], r["model"]) for r in rows} == {
+                ("cartesia", "sonic-3.5"),
+                ("openai", "gpt-4o-mini-tts"),
+            }
+            assert sum(r["votes_total"] for r in rows) == 2 * len(_VOTES)
+        finally:
+            await pool.close()
+
+    asyncio.run(_run())
+
+
+def test_snapshot_with_no_votes_writes_nothing(snap_pg: psycopg.Connection[Any]) -> None:
+    _apply_migrations(snap_pg)
+
+    async def _run() -> None:
+        pool = await _make_pool(snap_pg)
+        try:
+            await _reset(pool)
+            store = ArenaStore(pool)
+            result = await run_snapshot(store, bootstrap_rounds=50, seed=0)
+            assert result is not None
+            assert result.models == []
+            assert await _snapshot_row_count(pool) == 0
+        finally:
+            await pool.close()
+
+    asyncio.run(_run())
+
+
+def test_snapshot_skips_when_lock_is_held(snap_pg: psycopg.Connection[Any]) -> None:
+    _apply_migrations(snap_pg)
+
+    async def _run() -> None:
+        pool = await _make_pool(snap_pg)
+        try:
+            await _reset(pool)
+            store = ArenaStore(pool)
+            await _seed_one_battle(store)
+
+            async with store.snapshot_lock() as held:
+                assert held
+                skipped = await run_snapshot(store, bootstrap_rounds=50, seed=0)
+
+            assert skipped is None
+            assert await _snapshot_row_count(pool) == 0
+        finally:
+            await pool.close()
+
+    asyncio.run(_run())
+
+
+def test_snapshot_force_runs_despite_held_lock(snap_pg: psycopg.Connection[Any]) -> None:
+    _apply_migrations(snap_pg)
+
+    async def _run() -> None:
+        pool = await _make_pool(snap_pg)
+        try:
+            await _reset(pool)
+            store = ArenaStore(pool)
+            await _seed_one_battle(store)
+
+            async with store.snapshot_lock() as held:
+                assert held
+                forced = await run_snapshot(store, bootstrap_rounds=50, seed=0, force=True)
+
+            assert forced is not None
+            assert len(forced.models) == 2
+            assert await _snapshot_row_count(pool) == 2
+        finally:
+            await pool.close()
+
+    asyncio.run(_run())


### PR DESCRIPTION
Adds the rating snapshot job (layer 7): refit Davidson-BT ratings from all votes and persist one leaderboard board.


- `coval-bench arena snapshot` reads every vote, runs the rating engine, and writes one board.
- The whole board is written in a single transaction with one `computed_at`, so a reader never sees a partial board.
- A non-blocking advisory lock keeps two runs from computing at once. `--force` bypasses it; a crashed run self-heals when its connection drops.
- Status comes from the engine's CI-half-width classifier. Models with no votes are never written.


- Writes the `all` domain board only. Per-domain boards, retention/pruning, and trigger cadence are follow-ups.
- Read-API files are untouched: math stays in `arena/rating.py`, SQL in `db/arena_store.py`, the job is glue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new `arena snapshot` command to compute and persist leaderboard snapshots with configurable parameters including rating metric, bootstrap resampling rounds, and random seed.
  * Command supports a `--force` flag to bypass snapshot locks when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds the `arena snapshot` CLI command (layer 7 of the rating pipeline) that reads all votes, fits the Davidson-BT leaderboard via `compute_ratings`, and atomically persists one board to `arena.leaderboard_snapshots`. The previously-flagged gaps — uncaught `ConvergenceError` and individual-`execute` inserts in a loop — are both resolved in this diff.

- `run_snapshot` in `snapshot.py` orchestrates the job: battles and votes are fetched, converted to `BattleOutcome` objects, and fed to `compute_ratings`; the resulting rows are bulk-inserted with `executemany` inside a single transaction so `computed_at` is identical for every row in a board.
- A non-blocking `pg_try_advisory_lock` prevents concurrent recomputes; `--force` bypasses the lock; `ConvergenceError` is caught and serialised as structured JSON before a non-zero exit.
- `list_battles` gains an optional `limit=None` path needed by the refit job, and `LeaderboardSnapshot` / `SnapshotStatus` are added to `models.py`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the orchestration logic, advisory lock lifecycle, and atomic board insert are all correct, and the previously-raised gaps are resolved in this diff.

The lock is correctly held on a dedicated connection for the job's full duration and always released in a finally block, executemany inside conn.transaction() guarantees all rows share a single computed_at, ConvergenceError is caught and serialised before exit, and the five integration tests exercise all branching paths including force-override and domain scoping.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| runner/src/coval_bench/arena/snapshot.py | New orchestration module: fetches battles+votes, builds BattleOutcome list, calls compute_ratings, writes board via insert_snapshot_board. Advisory-lock branching is clean; empty-vote case is correctly handled by returning an empty RatingResult without writing anything. |
| runner/src/coval_bench/db/arena_store.py | Adds insert_snapshot_board (executemany in a single transaction), snapshot_lock (session-level pg_try_advisory_lock with proper acquire/release/commit), and refactors list_battles to accept limit=None. SQL is parameterised; lock connection lifetime is correctly scoped to the job. |
| runner/src/coval_bench/__main__.py | Adds arena group and snapshot sub-command. ConvergenceError is caught and serialised as structured JSON before sys.exit(1); skipped and success paths also emit valid JSON — exit contract is consistent across all code paths. |
| runner/src/coval_bench/db/models.py | Adds SnapshotStatus StrEnum and LeaderboardSnapshot Pydantic model matching the arena.leaderboard_snapshots schema; computed_at is left None so the DB default assigns a single transaction timestamp. |
| runner/tests/unit/test_arena_snapshot.py | Integration tests using pytest-postgresql cover: board persistence, no-votes no-write, lock-skip, force-override, and domain-scoped snapshot. Good coverage of the advisory lock paths and atomic timestamp assertion. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant CLI as CLI (arena snapshot)
    participant S as run_snapshot
    participant Store as ArenaStore
    participant DB as PostgreSQL
    participant Eng as compute_ratings

    CLI->>S: run_snapshot(store, metric, domain, force, ...)
    alt "force=False"
        S->>Store: snapshot_lock()
        Store->>DB: pg_try_advisory_lock(arena_snapshot)
        DB-->>Store: acquired (true/false)
        alt not acquired
            S-->>CLI: None - JSON skipped true
        end
    end
    S->>S: _refit_and_persist(...)
    S->>Store: "list_battles(domain, limit=None)"
    Store->>DB: SELECT FROM arena.battles
    DB-->>Store: battles[]
    S->>Store: list_votes()
    Store->>DB: SELECT FROM arena.votes
    DB-->>Store: votes[]
    S->>Eng: compute_ratings(outcomes, bootstrap_rounds, seed)
    Eng-->>S: RatingResult or ConvergenceError
    S->>Store: insert_snapshot_board(rows)
    Store->>DB: BEGIN / executemany INSERT / COMMIT
    DB-->>Store: ok
    S-->>CLI: RatingResult
    CLI->>CLI: JSON event metric models
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant CLI as CLI (arena snapshot)
    participant S as run_snapshot
    participant Store as ArenaStore
    participant DB as PostgreSQL
    participant Eng as compute_ratings

    CLI->>S: run_snapshot(store, metric, domain, force, ...)
    alt "force=False"
        S->>Store: snapshot_lock()
        Store->>DB: pg_try_advisory_lock(arena_snapshot)
        DB-->>Store: acquired (true/false)
        alt not acquired
            S-->>CLI: None - JSON skipped true
        end
    end
    S->>S: _refit_and_persist(...)
    S->>Store: "list_battles(domain, limit=None)"
    Store->>DB: SELECT FROM arena.battles
    DB-->>Store: battles[]
    S->>Store: list_votes()
    Store->>DB: SELECT FROM arena.votes
    DB-->>Store: votes[]
    S->>Eng: compute_ratings(outcomes, bootstrap_rounds, seed)
    Eng-->>S: RatingResult or ConvergenceError
    S->>Store: insert_snapshot_board(rows)
    Store->>DB: BEGIN / executemany INSERT / COMMIT
    DB-->>Store: ok
    S-->>CLI: RatingResult
    CLI->>CLI: JSON event metric models
```

</a>

<sub>Reviews (3): Last reviewed commit: ["Address snapshot job review feedback"](https://github.com/coval-ai/benchmarks/commit/fa362716987292aa38b39e74952f1f21764dbefd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38745125)</sub>

<!-- /greptile_comment -->