### PR TITLE
Add POST /arena/vote write endpoint

### DIFF
--- a/runner/src/coval_bench/api/routers/arena.py
+++ b/runner/src/coval_bench/api/routers/arena.py
@@ -1,16 +1,16 @@
 # Copyright 2026 The Coval Benchmarks Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Voice Arena read endpoints.
+"""Voice Arena endpoints.
 
-``GET /v1/arena/battle``       — a battle to vote on (blind: no model identities).
-``GET /v1/arena/battle/{id}``  — a specific battle.
-``GET /v1/arena/leaderboard``  — the latest computed board for a metric/domain.
+``GET  /v1/arena/battle``       — a battle to vote on (blind: no model identities).
+``GET  /v1/arena/battle/{id}``  — a specific battle.
+``GET  /v1/arena/leaderboard``  — the latest computed board for a metric/domain.
+``POST /v1/arena/vote``         — record a labeler's vote (labeler-only at MVP).
 
-Reads only. Battles/votes are written elsewhere; leaderboard rows are produced by
-the snapshot job, so the leaderboard is empty until that job has run. Queries hit
-the pool directly, matching the other routers; this module does not depend on the
-arena DB-access layer, so it can land independently.
+Reads hit the pool directly; the write path uses the arena DB-access layer
+(``ArenaStore``). Leaderboard rows are produced by the snapshot job, so the
+leaderboard is empty until that job has run.
 
 The battle payload deliberately omits provider/model identities to keep voting
 blind — the A/B -> model mapping stays server-side, used only when a vote is
@@ -19,19 +19,29 @@ recorded.
 
 from __future__ import annotations
 
+import hmac
 import uuid
 from typing import Any
 
 import psycopg.rows
 import structlog
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, Header, HTTPException, Query
 from posthog import Posthog
 from psycopg_pool import AsyncConnectionPool
 from starlette.requests import Request
 
-from coval_bench.api.deps import capture_api_event, get_pool, get_posthog
+from coval_bench.api.deps import capture_api_event, get_pool, get_posthog, get_settings
 from coval_bench.api.ratelimit import limiter
-from coval_bench.api.schemas import ArenaLeaderboardResponse, BattleOut, LeaderboardEntryOut
+from coval_bench.api.schemas import (
+    ArenaLeaderboardResponse,
+    BattleOut,
+    LeaderboardEntryOut,
+    VoteIn,
+    VoteOut,
+)
+from coval_bench.config import Settings
+from coval_bench.db.arena_store import ArenaStore
+from coval_bench.db.models import VoteOutcome, VoterType
 
 logger = structlog.get_logger("coval_bench.api")
 
@@ -141,3 +151,45 @@ async def get_arena_leaderboard(
         methodology_version=board[0]["methodology_version"] if board else None,
         entries=entries,
     )
+
+
+def _is_authenticated_labeler(provided: str | None, settings: Settings) -> bool:
+    """True only if a labeler key is configured and the presented key matches it."""
+    expected = settings.arena_labeler_key
+    if expected is None or provided is None:
+        return False
+    return hmac.compare_digest(provided, expected.get_secret_value())
+
+
+@router.post("/arena/vote", response_model=VoteOut, status_code=201)
+@limiter.limit("60/minute")
+async def cast_vote(
+    request: Request,  # required by slowapi
+    vote: VoteIn,
+    x_labeler_key: str | None = Header(default=None),
+    pool: AsyncConnectionPool[Any] = Depends(get_pool),
+    settings: Settings = Depends(get_settings),
+    posthog_client: Posthog | None = Depends(get_posthog),
+) -> VoteOut:
+    """Record a labeler's vote on a battle (labeler-only at MVP; others get 403)."""
+    if not _is_authenticated_labeler(x_labeler_key, settings):
+        raise HTTPException(403, "external voting is not enabled")
+    store = ArenaStore(pool)
+    if await store.get_battle(vote.battle_id) is None:
+        raise HTTPException(404, f"battle {vote.battle_id} not found")
+    recorded = await store.upsert_vote(
+        battle_id=vote.battle_id,
+        outcome=VoteOutcome(vote.outcome),
+        voter_type=VoterType.LABELER,
+        voter_id=vote.voter_id,
+    )
+    capture_api_event(
+        posthog_client,
+        "arena_vote_cast",
+        {
+            "outcome": vote.outcome,
+            "voter_type": VoterType.LABELER.value,
+            "$process_person_profile": False,
+        },
+    )
+    return VoteOut.model_validate(recorded.model_dump())

--- a/runner/src/coval_bench/api/schemas.py
+++ b/runner/src/coval_bench/api/schemas.py
@@ -203,3 +203,23 @@ class ArenaLeaderboardResponse(BaseModel):
     computed_at: datetime | None
     methodology_version: str | None
     entries: list[LeaderboardEntryOut]
+
+
+class VoteIn(BaseModel):
+    """Request body for POST /arena/vote (voter_type is set server-side, never sent)."""
+
+    battle_id: uuid.UUID
+    outcome: Literal["A_WIN", "B_WIN", "TIE"]
+    voter_id: str
+
+
+class VoteOut(BaseModel):
+    """A recorded arena vote (the row as persisted)."""
+
+    id: uuid.UUID
+    battle_id: uuid.UUID
+    outcome: str
+    voter_type: str
+    voter_id: str
+    created_at: datetime
+    updated_at: datetime

--- a/runner/src/coval_bench/config.py
+++ b/runner/src/coval_bench/config.py
@@ -103,6 +103,9 @@ class Settings(BaseSettings):
     cors_origin_regex: str | None = r"^https://benchmarks-[a-z0-9-]+-covalai\.vercel\.app$"
     rate_limit_per_minute: int = 60
 
+    # --- Arena ---
+    arena_labeler_key: SecretStr | None = None
+
 
 @functools.lru_cache(maxsize=1)
 def get_settings() -> Settings:

--- a/runner/tests/api/conftest.py
+++ b/runner/tests/api/conftest.py
@@ -36,6 +36,8 @@ from psycopg_pool import AsyncConnectionPool
 from coval_bench.api.app import create_app
 from coval_bench.config import Settings
 
+ARENA_LABELER_KEY = "test-labeler-key"
+
 
 def _make_db_url(postgresql: Any) -> str:
     """Build a postgresql:// URL from the pytest-postgresql fixture."""
@@ -158,6 +160,7 @@ async def app(postgresql: Any, monkeypatch: pytest.MonkeyPatch) -> AsyncIterator
     monkeypatch.setenv("DATASET_ID", "librispeech-test-clean-50")
     monkeypatch.setenv("RUNNER_SHA", "test-sha")
     monkeypatch.setenv("POSTHOG_DISABLED", "true")
+    monkeypatch.setenv("ARENA_LABELER_KEY", ARENA_LABELER_KEY)
 
     settings = Settings()
 

--- a/runner/tests/api/test_arena.py
+++ b/runner/tests/api/test_arena.py
@@ -1,7 +1,7 @@
 # Copyright 2026 The Coval Benchmarks Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Tests for the Voice Arena read endpoints (GET /v1/arena/*)."""
+"""Tests for the Voice Arena endpoints (GET /v1/arena/*, POST /v1/arena/vote)."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ from typing import Any
 import psycopg
 from httpx import AsyncClient
 
-from tests.api.conftest import _make_db_url
+from tests.api.conftest import ARENA_LABELER_KEY, _make_db_url
 
 
 async def _apply_arena_schema(dsn: str) -> None:
@@ -32,6 +32,33 @@ async def _apply_arena_schema(dsn: str) -> None:
                 audio_b_url TEXT NOT NULL,
                 created_at  TIMESTAMPTZ NOT NULL DEFAULT now()
             )
+        """)
+        await aconn.execute("""
+            CREATE TABLE IF NOT EXISTS arena.votes (
+                id         UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+                battle_id  UUID NOT NULL REFERENCES arena.battles(id),
+                outcome    TEXT NOT NULL CHECK (outcome IN ('A_WIN','B_WIN','TIE')),
+                voter_type TEXT NOT NULL CHECK (voter_type IN ('labeler','external')),
+                voter_id   TEXT NOT NULL,
+                created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+                updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+                UNIQUE (battle_id, voter_type, voter_id)
+            )
+        """)
+        await aconn.execute("""
+            CREATE OR REPLACE FUNCTION arena.set_updated_at() RETURNS trigger AS $$
+            BEGIN
+                NEW.updated_at := now();
+                RETURN NEW;
+            END;
+            $$ LANGUAGE plpgsql
+        """)
+        await aconn.execute("DROP TRIGGER IF EXISTS votes_set_updated_at ON arena.votes")
+        await aconn.execute("""
+            CREATE TRIGGER votes_set_updated_at
+                BEFORE UPDATE ON arena.votes
+                FOR EACH ROW
+                EXECUTE FUNCTION arena.set_updated_at()
         """)
         await aconn.execute("""
             CREATE TABLE IF NOT EXISTS arena.leaderboard_snapshots (
@@ -293,3 +320,157 @@ async def test_leaderboard_does_not_mix_methodology_versions(
     # One board only: the tiebreaker picks davidson-v2, so v1's row is excluded.
     assert data["methodology_version"] == "davidson-v2"
     assert [e["model"] for e in data["entries"]] == ["sonic-3"]
+
+
+_LABELER_HEADERS = {"X-Labeler-Key": ARENA_LABELER_KEY}
+
+
+async def _count_votes(postgresql: Any, battle_id: str) -> int:
+    """Return the number of vote rows for a battle."""
+    dsn = _make_db_url(postgresql)
+    aconn = await psycopg.AsyncConnection.connect(dsn, autocommit=True)
+    try:
+        row = await aconn.execute(
+            "SELECT count(*) FROM arena.votes WHERE battle_id = %s", (battle_id,)
+        )
+        result = await row.fetchone()
+        assert result is not None
+        return int(result[0])
+    finally:
+        await aconn.close()
+
+
+async def test_vote_without_labeler_key_is_403(client: AsyncClient, postgresql: Any) -> None:
+    """No labeler key -> 403 (external voting is not enabled)."""
+    await _apply_arena_schema(_make_db_url(postgresql))
+    battle_id = await _insert_battle(postgresql)
+    response = await client.post(
+        "/v1/arena/vote",
+        json={"battle_id": battle_id, "outcome": "A_WIN", "voter_id": "ann-1"},
+    )
+    assert response.status_code == 403
+    assert await _count_votes(postgresql, battle_id) == 0
+
+
+async def test_vote_with_wrong_key_is_403(client: AsyncClient, postgresql: Any) -> None:
+    """A non-matching labeler key -> 403."""
+    await _apply_arena_schema(_make_db_url(postgresql))
+    battle_id = await _insert_battle(postgresql)
+    response = await client.post(
+        "/v1/arena/vote",
+        json={"battle_id": battle_id, "outcome": "A_WIN", "voter_id": "ann-1"},
+        headers={"X-Labeler-Key": "not-the-key"},
+    )
+    assert response.status_code == 403
+
+
+async def test_vote_records_a_labeler_vote(client: AsyncClient, postgresql: Any) -> None:
+    """A valid labeler key persists the vote and stamps voter_type='labeler'."""
+    await _apply_arena_schema(_make_db_url(postgresql))
+    battle_id = await _insert_battle(postgresql)
+    response = await client.post(
+        "/v1/arena/vote",
+        json={"battle_id": battle_id, "outcome": "A_WIN", "voter_id": "ann-1"},
+        headers=_LABELER_HEADERS,
+    )
+    assert response.status_code == 201
+    data = response.json()
+    assert data["battle_id"] == battle_id
+    assert data["outcome"] == "A_WIN"
+    assert data["voter_type"] == "labeler"
+    assert data["voter_id"] == "ann-1"
+    assert await _count_votes(postgresql, battle_id) == 1
+
+
+async def test_vote_body_cannot_override_voter_type(client: AsyncClient, postgresql: Any) -> None:
+    """A voter_type smuggled into the body is ignored; the server always pins 'labeler'."""
+    await _apply_arena_schema(_make_db_url(postgresql))
+    battle_id = await _insert_battle(postgresql)
+    response = await client.post(
+        "/v1/arena/vote",
+        json={
+            "battle_id": battle_id,
+            "outcome": "A_WIN",
+            "voter_id": "ann-1",
+            "voter_type": "external",
+        },
+        headers=_LABELER_HEADERS,
+    )
+    assert response.status_code == 201
+    assert response.json()["voter_type"] == "labeler"
+
+
+async def test_revote_updates_existing_row(client: AsyncClient, postgresql: Any) -> None:
+    """The same voter re-voting a battle updates their row, never adds a second."""
+    await _apply_arena_schema(_make_db_url(postgresql))
+    battle_id = await _insert_battle(postgresql)
+    first = await client.post(
+        "/v1/arena/vote",
+        json={"battle_id": battle_id, "outcome": "A_WIN", "voter_id": "ann-1"},
+        headers=_LABELER_HEADERS,
+    )
+    second = await client.post(
+        "/v1/arena/vote",
+        json={"battle_id": battle_id, "outcome": "B_WIN", "voter_id": "ann-1"},
+        headers=_LABELER_HEADERS,
+    )
+    assert first.status_code == 201
+    assert second.status_code == 201
+    # Same row (dedup), outcome overwritten.
+    assert second.json()["id"] == first.json()["id"]
+    assert second.json()["outcome"] == "B_WIN"
+    assert await _count_votes(postgresql, battle_id) == 1
+
+
+async def test_distinct_voters_create_separate_rows(client: AsyncClient, postgresql: Any) -> None:
+    """Dedup is per-identity, not per-battle: two voter_ids on one battle keep both rows."""
+    await _apply_arena_schema(_make_db_url(postgresql))
+    battle_id = await _insert_battle(postgresql)
+    for voter_id in ("ann-1", "ann-2"):
+        response = await client.post(
+            "/v1/arena/vote",
+            json={"battle_id": battle_id, "outcome": "A_WIN", "voter_id": voter_id},
+            headers=_LABELER_HEADERS,
+        )
+        assert response.status_code == 201
+    assert await _count_votes(postgresql, battle_id) == 2
+
+
+async def test_empty_voter_id_is_accepted(client: AsyncClient, postgresql: Any) -> None:
+    """Pins current MVP behavior: voter_id is not validated, so an empty string is accepted."""
+    await _apply_arena_schema(_make_db_url(postgresql))
+    battle_id = await _insert_battle(postgresql)
+    response = await client.post(
+        "/v1/arena/vote",
+        json={"battle_id": battle_id, "outcome": "A_WIN", "voter_id": ""},
+        headers=_LABELER_HEADERS,
+    )
+    assert response.status_code == 201
+    assert response.json()["voter_id"] == ""
+
+
+async def test_vote_on_unknown_battle_is_404(client: AsyncClient, postgresql: Any) -> None:
+    """A valid key but a battle id that does not exist -> 404."""
+    await _apply_arena_schema(_make_db_url(postgresql))
+    response = await client.post(
+        "/v1/arena/vote",
+        json={
+            "battle_id": "00000000-0000-0000-0000-000000000000",
+            "outcome": "A_WIN",
+            "voter_id": "ann-1",
+        },
+        headers=_LABELER_HEADERS,
+    )
+    assert response.status_code == 404
+
+
+async def test_vote_with_invalid_outcome_is_422(client: AsyncClient, postgresql: Any) -> None:
+    """An outcome outside the allowed set fails request validation with 422."""
+    await _apply_arena_schema(_make_db_url(postgresql))
+    battle_id = await _insert_battle(postgresql)
+    response = await client.post(
+        "/v1/arena/vote",
+        json={"battle_id": battle_id, "outcome": "MAYBE", "voter_id": "ann-1"},
+        headers=_LABELER_HEADERS,
+    )
+    assert response.status_code == 422


### PR DESCRIPTION
Stacks on the merged read endpoints (#147) to complete the arena vote loop's write side.

## What
`POST /v1/arena/vote` records a vote on a battle.

- **Labeler-gated** via an `X-Labeler-Key` header (constant-time compare against `ARENA_LABELER_KEY`). A valid key votes as `labeler`; missing/invalid key → **403** ("external voting is not enabled"). Fail-closed: if no key is configured, all votes are rejected.
- **`voter_type` is pinned server-side**, never read from the body — a caller cannot claim to be a trusted labeler.
- **Dedup via `ArenaStore.upsert_vote`**: `ON CONFLICT (battle_id, voter_type, voter_id) DO UPDATE` keeps one current vote per identity (re-vote updates the row; the `BEFORE UPDATE` trigger bumps `updated_at`).
- Unknown battle → 404; invalid `outcome` → 422; `60/minute` rate limit, matching the read endpoints.
- PostHog `arena_vote_cast` carries only `{outcome, voter_type}` — no identifiers, consistent with the other arena events.

## Scope (MVP, labeler-only)
- Public `external` voting is intentionally **not** enabled yet — it needs a stable per-voter identity (session) for the dedup to be meaningful, plus its own rate strategy. Deferred to the voting-UI PR.
- `voter_id` is not validated; acceptable while the only caller is the trusted internal labeling tool.

## Note
`ARENA_LABELER_KEY` must be set as a runner secret (Cloud Run / Secret Manager) before this works in a deployed env, or every vote returns 403.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Labelers can now cast and update votes on arena battles through an authenticated endpoint using a labeler key
  * Votes are deduplicated and tracked with timestamps for audit purposes

* **Tests**
  * Comprehensive test coverage added for voting functionality, authorization, and validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR completes the arena vote write path by adding `POST /v1/arena/vote`, gated behind an `X-Labeler-Key` header verified with a constant-time compare and defaulting to 403 when unconfigured. Dedup is handled via an `ON CONFLICT DO UPDATE` upsert, and `voter_type` is pinned server-side so callers can never self-promote to labeler.

- **Auth** (`_is_authenticated_labeler`): uses `hmac.compare_digest` against a `SecretStr`; the same 403 message is returned for a missing or wrong key, leaking no information about which condition was triggered.
- **Write path**: `ArenaStore.upsert_vote` performs a single `INSERT … ON CONFLICT DO UPDATE RETURNING`, with the battle-existence pre-check handled by a separate `get_battle` query; the PostHog event carries only `{outcome, voter_type}` with no voter identifiers.
- **Tests**: 9 integration tests cover all documented paths — auth failures, happy path, identity-injection guard, dedup/re-vote, multi-voter rows, empty `voter_id`, unknown battle, and invalid outcome.

<h3>Confidence Score: 4/5</h3>

The write path is well-structured and the auth logic is correct; the two minor concerns do not affect normal operation.

The auth guard, dedup logic, and test coverage are solid. The two flagged items — a TOCTOU window between the battle existence check and the upsert, and duplicate outcome definitions across VoteIn and VoteOutcome — are both benign under current usage (battles are not deleted, the two sets are identical), but either could surface as a 500 in a future change rather than a clean 404 or 422.

runner/src/coval_bench/api/routers/arena.py around the two-query battle check and the VoteOutcome conversion; runner/src/coval_bench/api/schemas.py for the loose str types in VoteOut.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| runner/src/coval_bench/api/routers/arena.py | Adds POST /v1/arena/vote with labeler-key auth (hmac.compare_digest, fail-closed), server-side voter_type pinning, and upsert-based dedup; two minor concerns: TOCTOU between the get_battle check and upsert_vote, and duplicate outcome definitions between VoteIn and VoteOutcome. |
| runner/src/coval_bench/api/schemas.py | Adds VoteIn and VoteOut Pydantic schemas; VoteOut uses plain str for outcome/voter_type rather than Literal types, losing the precision already established in VoteIn and the DB CHECK constraint. |
| runner/src/coval_bench/config.py | Adds arena_labeler_key: SecretStr | None = None to Settings; correctly defaults to None so the endpoint fails closed when unset. |
| runner/tests/api/conftest.py | Adds ARENA_LABELER_KEY constant and injects it via monkeypatch for the app fixture; straightforward test scaffolding. |
| runner/tests/api/test_arena.py | Adds 9 focused vote-endpoint tests covering auth failures, happy path, voter_type injection guard, dedup, multi-voter, empty voter_id, unknown battle, and invalid outcome; schema setup includes the votes table, trigger function, and FK constraint. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant C as Client
    participant R as POST /v1/arena/vote
    participant Auth as _is_authenticated_labeler
    participant Store as ArenaStore
    participant DB as PostgreSQL

    C->>R: "POST /v1/arena/vote {battle_id, outcome, voter_id} X-Labeler-Key"
    R->>Auth: check(x_labeler_key, settings)
    Auth-->>R: hmac.compare_digest result
    alt key missing or invalid
        R-->>C: 403 external voting is not enabled
    else key valid
        R->>Store: get_battle(battle_id)
        Store->>DB: "SELECT arena.battles WHERE id = ?"
        DB-->>Store: row or None
        alt battle not found
            R-->>C: 404 battle not found
        else battle exists
            R->>Store: upsert_vote(battle_id, outcome, LABELER, voter_id)
            Store->>DB: INSERT ON CONFLICT DO UPDATE RETURNING
            DB-->>Store: Vote row
            Store-->>R: Vote model
            R->>R: capture_api_event arena_vote_cast
            R-->>C: 201 VoteOut
        end
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant C as Client
    participant R as POST /v1/arena/vote
    participant Auth as _is_authenticated_labeler
    participant Store as ArenaStore
    participant DB as PostgreSQL

    C->>R: "POST /v1/arena/vote {battle_id, outcome, voter_id} X-Labeler-Key"
    R->>Auth: check(x_labeler_key, settings)
    Auth-->>R: hmac.compare_digest result
    alt key missing or invalid
        R-->>C: 403 external voting is not enabled
    else key valid
        R->>Store: get_battle(battle_id)
        Store->>DB: "SELECT arena.battles WHERE id = ?"
        DB-->>Store: row or None
        alt battle not found
            R-->>C: 404 battle not found
        else battle exists
            R->>Store: upsert_vote(battle_id, outcome, LABELER, voter_id)
            Store->>DB: INSERT ON CONFLICT DO UPDATE RETURNING
            DB-->>Store: Vote row
            Store-->>R: Vote model
            R->>R: capture_api_event arena_vote_cast
            R-->>C: 201 VoteOut
        end
    end
```

</a>

<sub>Reviews (1): Last reviewed commit: ["Add POST /arena/vote write endpoint"](https://github.com/coval-ai/benchmarks/commit/579592bc099bfb16cee4427bcf71accfd136fb4e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38755990)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->