### PR TITLE
ci: pin external GitHub Actions to SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,18 +33,18 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: ${{ inputs.ref || github.ref }}
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           enable-cache: true
           cache-dependency-glob: runner/uv.lock
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.12"
 
@@ -107,10 +107,10 @@ jobs:
       # GHA cache via buildx gha backend.
       # -----------------------------------------------------------------------
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
 
       - name: Docker build — runner image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
         with:
           context: runner
           file: runner/Dockerfile
@@ -120,7 +120,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Docker build — api image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
         with:
           context: runner
           file: runner/Dockerfile.api
@@ -147,7 +147,7 @@ jobs:
     continue-on-error: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -31,15 +31,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
         with:
           languages: python
           build-mode: none   # Python is interpreted — no compile step needed
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
         with:
           category: codeql-python

--- a/.github/workflows/runner-release.yml
+++ b/.github/workflows/runner-release.yml
@@ -50,7 +50,7 @@ jobs:
           echo "deploy_ref=${DISPATCH_REF:-${MANUAL_REF:-main}}" >> "$GITHUB_OUTPUT"
 
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: ${{ steps.input.outputs.deploy_ref }}
           fetch-depth: 0
@@ -108,28 +108,28 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: ${{ needs.context.outputs.deploy_sha }}
           persist-credentials: false
 
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v3
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
         with:
           workload_identity_provider: ${{ secrets.WIF_PROVIDER }}
           service_account: ${{ secrets.WIF_DEPLOY_SA }}
 
       - name: Set up gcloud
-        uses: google-github-actions/setup-gcloud@v3
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3
 
       - name: Configure Docker for Artifact Registry
         run: gcloud auth configure-docker us-east1-docker.pkg.dev --quiet
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
 
       - name: Build and push ${{ matrix.image }} image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
         with:
           context: runner
           file: runner/${{ matrix.dockerfile }}
@@ -230,7 +230,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: ${{ needs.context.outputs.deploy_sha }}
           fetch-depth: 0

--- a/.github/workflows/switchboard.yml
+++ b/.github/workflows/switchboard.yml
@@ -42,7 +42,7 @@ jobs:
 
     steps:
       - name: Checkout benchmarks
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.ref || github.ref }}
           fetch-depth: 0
@@ -65,7 +65,7 @@ jobs:
       - name: Generate token for Switchboard
         id: app_token
         if: env.RELEASE_APP_ID != '' && env.RELEASE_APP_PRIVATE_KEY != ''
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         env:
           RELEASE_APP_ID: ${{ secrets.RELEASE_APP_ID }}
           RELEASE_APP_PRIVATE_KEY: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
@@ -77,7 +77,7 @@ jobs:
 
       - name: Checkout Switchboard
         if: steps.app_token.outputs.token != ''
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           repository: coval-ai/ci-cd-switchboard
           ref: main
@@ -87,7 +87,7 @@ jobs:
 
       - name: Set up Node.js
         if: steps.app_token.outputs.token != ''
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: "22"
 

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -42,28 +42,28 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       # Authenticate to GCP via WIF — no JSON key involved.
       # runner-deploy SA is bound to coval-ai/benchmarks refs/tags/v* by the
       # wif-binding TF module.
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v3
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
         with:
           workload_identity_provider: ${{ secrets.WIF_PROVIDER }}
           service_account: ${{ secrets.WIF_DEPLOY_SA }}
 
       - name: Set up gcloud
-        uses: google-github-actions/setup-gcloud@v3
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3
 
       - name: Configure Docker for Artifact Registry
         run: gcloud auth configure-docker us-east1-docker.pkg.dev --quiet
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
 
       - name: Build and push ${{ matrix.image }} image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
         with:
           context: runner
           file: runner/${{ matrix.dockerfile }}
@@ -88,7 +88,7 @@ jobs:
     steps:
       # Dispatch uses the tag-named image refs so infra deploys the named release.
       - name: Fire repository_dispatch → coval-ai/benchmark-infra
-        uses: peter-evans/repository-dispatch@v4
+        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4
         with:
           token: ${{ secrets.INFRA_DISPATCH_TOKEN }}
           repository: coval-ai/benchmark-infra

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -38,20 +38,20 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       # Authenticate to GCP via WIF so Trivy can pull the private AR image.
       # runner-scanner is a dedicated read-only SA — bound to schedule +
       # workflow_dispatch on coval-ai/benchmarks. Trivy must NOT use
       # runner-deploy (which has artifactregistry.writer).
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v3
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
         with:
           workload_identity_provider: ${{ secrets.WIF_PROVIDER }}
           service_account: ${{ secrets.WIF_SCANNER_SA }}
 
       - name: Set up gcloud
-        uses: google-github-actions/setup-gcloud@v3
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3
 
       - name: Configure Docker for Artifact Registry
         run: gcloud auth configure-docker us-east1-docker.pkg.dev --quiet
@@ -72,7 +72,7 @@ jobs:
 
       - name: Scan ${{ matrix.image }}:latest with Trivy
         if: steps.image-check.outputs.exists == 'true'
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@cf5c088a69634cd13ccddc735d7926162c31f9a6 # master
         with:
           image-ref: us-east1-docker.pkg.dev/coval-benchmarks-prod/runner/coval-bench-${{ matrix.image }}:latest
           format: sarif
@@ -83,7 +83,7 @@ jobs:
 
       - name: Upload Trivy SARIF to GitHub Security tab
         if: steps.image-check.outputs.exists == 'true'
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
         with:
           sarif_file: trivy-${{ matrix.image }}.sarif
           category: trivy-${{ matrix.image }}

--- a/.github/workflows/web-ci.yml
+++ b/.github/workflows/web-ci.yml
@@ -31,32 +31,32 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: ${{ inputs.ref || github.ref }}
           persist-credentials: false
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
           package_json_file: web/package.json
           run_install: false
 
       - name: Set up Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: "22"
           cache: pnpm
           cache-dependency-path: web/pnpm-lock.yaml
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           enable-cache: true
           cache-dependency-glob: runner/uv.lock
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.12"
 

--- a/.github/workflows/web-release.yml
+++ b/.github/workflows/web-release.yml
@@ -61,7 +61,7 @@ jobs:
         working-directory: .
 
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
           ref: ${{ steps.context.outputs.deploy_ref }}
@@ -81,14 +81,14 @@ jobs:
 
       - name: Set up pnpm
         if: steps.up_to_date.outputs.skip != 'true'
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
           package_json_file: web/package.json
           run_install: false
 
       - name: Set up Node.js
         if: steps.up_to_date.outputs.skip != 'true'
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: "22"
           cache: pnpm


### PR DESCRIPTION
## Summary
- pin external GitHub Actions in benchmarks workflows to immutable commit SHAs
- keep the original tag/branch as a YAML comment for update ergonomics
- leave local reusable workflow calls unchanged

## Why
Mutable action refs like `@v4`, `@v7`, and `@master` can drift underneath CI. Pinning to SHAs makes the exact workflow dependency graph auditable and reproducible.

## Validation
- Resolved each action tag/branch with `git ls-remote`; for annotated tags, used the peeled commit SHA
- Parsed every `.github/workflows/*.{yml,yaml}` file with Ruby YAML
- Verified no external `uses:` refs in `.github/workflows` remain at `@v*`, `@main`, or `@master`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflows to use pinned versions of external tools and dependencies for improved build reliability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces all mutable external GitHub Action refs (`@v4`, `@v7`, `@master`, etc.) across eight CI workflow files with pinned commit SHAs, while preserving the original tag/branch as a YAML comment for readability and future update guidance.

- Every distinct external action (15 unique refs across 8 files) has been replaced with a 40-character SHA, including the highest-risk case: `aquasecurity/trivy-action@master` → an immutable SHA.
- Local reusable workflow calls (`uses: ./.github/workflows/...`) and `./switchboard-src/...` local action references are intentionally left unchanged; the `coval-ai/ci-cd-switchboard` repo is still checked out at `ref: main`, meaning the switchboard plan action's source code remains mutable even though the checkout action itself is now SHA-pinned.

<h3>Confidence Score: 5/5</h3>

Safe to merge — a straightforward hardening change that locks all third-party action refs to immutable SHAs.

All 15 distinct external action references across the eight workflow files have been replaced with full 40-character commit SHAs. The most volatile pre-existing ref (aquasecurity/trivy-action@master) is now pinned. Version comments are present on every pinned line. The only remaining mutable reference is the internal ci-cd-switchboard checkout at ref: main, which was pre-existing and is out of scope for this PR.

switchboard.yml is worth a follow-up: the ci-cd-switchboard repo is still fetched at ref: main, so the switchboard-plan action's source code can change without a diff in this repo.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/ci.yml | Pins 5 action refs (checkout, setup-uv, setup-python, setup-buildx-action, build-push-action×2) to SHAs; methodology-gate job also updated. No issues found. |
| .github/workflows/codeql.yml | Pins 3 action refs (checkout, codeql-action/init, codeql-action/analyze) to SHAs; init and analyze share the same SHA as expected for a monorepo action package. |
| .github/workflows/trivy.yml | Pins 5 action refs including the critical aquasecurity/trivy-action@master → SHA; codeql-action/upload-sarif also pinned. All changes are correct. |
| .github/workflows/switchboard.yml | Pins 4 action refs (checkout×2, create-github-app-token, setup-node); however, the ci-cd-switchboard repo is still checked out at ref: main, so the switchboard-plan action source remains mutable. |
| .github/workflows/tag.yml | Pins 5 action refs (checkout, google-github-actions/auth, setup-gcloud, setup-buildx-action, build-push-action, peter-evans/repository-dispatch). No issues. |
| .github/workflows/runner-release.yml | Pins 6 action uses across 4 jobs (checkout×3, google-github-actions/auth, setup-gcloud, setup-buildx-action, build-push-action). No issues. |
| .github/workflows/web-ci.yml | Pins 5 action refs (checkout, pnpm/action-setup, setup-node, setup-uv, setup-python). No issues. |
| .github/workflows/web-release.yml | Pins 3 action refs (checkout, pnpm/action-setup, setup-node). No issues. |

</details>



<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[External Action ref] --> B{Ref type}
    B -->|mutable tag e.g. @v4 @master| C[❌ Before: Floats with tag updates]
    B -->|immutable SHA e.g. @abc1234| D[✅ After: Locked to exact commit]

    subgraph "Actions Pinned in this PR"
        E["actions/checkout (v6)"]
        F["astral-sh/setup-uv (v7)"]
        G["actions/setup-python (v6)"]
        H["docker/setup-buildx-action (v4)"]
        I["docker/build-push-action (v7)"]
        J["github/codeql-action/* (v4)"]
        K["google-github-actions/auth (v3)"]
        L["google-github-actions/setup-gcloud (v3)"]
        M["aquasecurity/trivy-action (master→SHA)"]
        N["peter-evans/repository-dispatch (v4)"]
        O["actions/create-github-app-token (v3)"]
        P["pnpm/action-setup (v4)"]
        Q["actions/setup-node (v5)"]
    end

    subgraph "Still Mutable"
        R["coval-ai/ci-cd-switchboard ref: main\n(checked out, then used as local action)"]
    end

    D --> E & F & G & H & I & J & K & L & M & N & O & P & Q
    C -.->|unchanged| R
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[External Action ref] --> B{Ref type}
    B -->|mutable tag e.g. @v4 @master| C[❌ Before: Floats with tag updates]
    B -->|immutable SHA e.g. @abc1234| D[✅ After: Locked to exact commit]

    subgraph "Actions Pinned in this PR"
        E["actions/checkout (v6)"]
        F["astral-sh/setup-uv (v7)"]
        G["actions/setup-python (v6)"]
        H["docker/setup-buildx-action (v4)"]
        I["docker/build-push-action (v7)"]
        J["github/codeql-action/* (v4)"]
        K["google-github-actions/auth (v3)"]
        L["google-github-actions/setup-gcloud (v3)"]
        M["aquasecurity/trivy-action (master→SHA)"]
        N["peter-evans/repository-dispatch (v4)"]
        O["actions/create-github-app-token (v3)"]
        P["pnpm/action-setup (v4)"]
        Q["actions/setup-node (v5)"]
    end

    subgraph "Still Mutable"
        R["coval-ai/ci-cd-switchboard ref: main\n(checked out, then used as local action)"]
    end

    D --> E & F & G & H & I & J & K & L & M & N & O & P & Q
    C -.->|unchanged| R
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `.github/workflows/switchboard.yml`, line 82-86 ([link](https://github.com/coval-ai/benchmarks/blob/957c8c7fbdddfdbe18d734a799623a0abba648e9/.github/workflows/switchboard.yml#L82-L86)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Mutable branch reference for executed switchboard source**

   The `actions/checkout` action is now SHA-pinned (supply chain for the checkout mechanism is fixed), but the *content* fetched — the `coval-ai/ci-cd-switchboard` repo at `ref: main` — is still a floating branch. The local action `./switchboard-src/.github/actions/switchboard-plan` (line 179) runs code directly from that mutable ref. If `main` on the internal switchboard repo advances (or is force-pushed), the next CI run will execute the new version without any diff visible in this repo. Pinning to a specific commit SHA or tag here would close the gap, e.g. `ref: <commit-sha> # main`.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["ci: pin external GitHub Actions to SHAs"](https://github.com/coval-ai/benchmarks/commit/957c8c7fbdddfdbe18d734a799623a0abba648e9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38821157)</sub>

<!-- /greptile_comment -->