### PR TITLE
Guard xAI STT against doubled transcript when transcript.done echoes full text

### DIFF
--- a/runner/src/coval_bench/providers/stt/xai.py
+++ b/runner/src/coval_bench/providers/stt/xai.py
@@ -30,21 +30,21 @@ _BASE_WS_URL = "wss://api.x.ai/v1/stt"
 _FINAL_WAIT_S = 5.0
 
 
-def _done_already_finalized(final_segments: list[str], done_transcript: str) -> bool:
-    """True when transcript.done only echoes text already closed by speech_final.
+def _merge_done_with_finals(final_segments: list[str], done_transcript: str) -> list[str]:
+    """Reconcile a non-empty transcript.done with the speech_final segments.
 
     xAI documents transcript.done as the final transcript after audio.done, not
-    strictly the still-unclosed tail, so a session may echo the whole utterance
-    that speech_final partials already finalized. Appending it blindly doubles
-    the transcript (≈100% WER). Treat done as covered when it repeats the last
-    finalized segment or the full joined transcript.
+    strictly the still-unclosed tail. It may therefore arrive as the unclosed
+    tail only, the whole utterance, or the whole utterance plus a trailing tail.
+    When done already contains the joined finalized text as a leading prefix it
+    IS the authoritative full transcript, so use it verbatim — appending would
+    duplicate (≈100% WER). Otherwise treat done as a trailing tail and append.
     """
-    if not final_segments:
-        return False
-    done = " ".join(done_transcript.split())
-    last = " ".join(final_segments[-1].split())
     joined = " ".join(" ".join(final_segments).split())
-    return done in (last, joined)
+    done = " ".join(done_transcript.split())
+    if not joined or done == joined or done.startswith(joined + " "):
+        return [done_transcript]
+    return [*final_segments, done_transcript]
 
 
 class XaiSTTProvider(STTProvider):
@@ -181,8 +181,8 @@ class XaiSTTProvider(STTProvider):
         # partial. The full utterance is the in-order join of speech_final
         # segments. transcript.done is documented only as "final transcript
         # after audio.done" — not guaranteed to be the unclosed tail — so it
-        # may carry the trailing tail OR echo the whole utterance; we append it
-        # only when it isn't already covered (see _done_already_finalized).
+        # may be the tail, the whole utterance, or the whole utterance plus a
+        # tail; _merge_done_with_finals reconciles it without duplicating.
         # is_final=true/speech_final=false events are interim duplicates of the
         # segment and must NOT be joined.
         final_segments: list[str] = []
@@ -218,10 +218,11 @@ class XaiSTTProvider(STTProvider):
                     if done_transcript:
                         set_first_token(result, done_transcript, now=now)
                         add_partial_transcript(result, done_transcript)
-                        if not _done_already_finalized(final_segments, done_transcript):
-                            final_segments.append(done_transcript)
-                            if result.audio_start_time is not None:
-                                last_final_time = now
+                        prev_text = " ".join(" ".join(final_segments).split())
+                        final_segments = _merge_done_with_finals(final_segments, done_transcript)
+                        new_text = " ".join(" ".join(final_segments).split())
+                        if new_text != prev_text and result.audio_start_time is not None:
+                            last_final_time = now
                     break
 
                 if event_type == "error":

--- a/runner/src/coval_bench/providers/stt/xai.py
+++ b/runner/src/coval_bench/providers/stt/xai.py
@@ -30,6 +30,23 @@ _BASE_WS_URL = "wss://api.x.ai/v1/stt"
 _FINAL_WAIT_S = 5.0
 
 
+def _done_already_finalized(final_segments: list[str], done_transcript: str) -> bool:
+    """True when transcript.done only echoes text already closed by speech_final.
+
+    xAI documents transcript.done as the final transcript after audio.done, not
+    strictly the still-unclosed tail, so a session may echo the whole utterance
+    that speech_final partials already finalized. Appending it blindly doubles
+    the transcript (≈100% WER). Treat done as covered when it repeats the last
+    finalized segment or the full joined transcript.
+    """
+    if not final_segments:
+        return False
+    done = " ".join(done_transcript.split())
+    last = " ".join(final_segments[-1].split())
+    joined = " ".join(" ".join(final_segments).split())
+    return done in (last, joined)
+
+
 class XaiSTTProvider(STTProvider):
     """xAI `/v1/stt` realtime WebSocket provider."""
 
@@ -161,11 +178,13 @@ class XaiSTTProvider(STTProvider):
     ) -> None:
         # With endpointing enabled, xAI restarts the transcript at each endpoint:
         # every speech segment is closed exactly once by a speech_final=true
-        # partial, and transcript.done carries only text not yet closed by a
-        # speech_final (empty when the last segment was already closed). The
-        # full utterance is the in-order join of speech_final segments plus any
-        # trailing done text. is_final=true/speech_final=false events are
-        # interim duplicates of the segment and must NOT be joined.
+        # partial. The full utterance is the in-order join of speech_final
+        # segments. transcript.done is documented only as "final transcript
+        # after audio.done" — not guaranteed to be the unclosed tail — so it
+        # may carry the trailing tail OR echo the whole utterance; we append it
+        # only when it isn't already covered (see _done_already_finalized).
+        # is_final=true/speech_final=false events are interim duplicates of the
+        # segment and must NOT be joined.
         final_segments: list[str] = []
         done_transcript: str | None = None
         last_final_time: float | None = None
@@ -199,9 +218,10 @@ class XaiSTTProvider(STTProvider):
                     if done_transcript:
                         set_first_token(result, done_transcript, now=now)
                         add_partial_transcript(result, done_transcript)
-                        final_segments.append(done_transcript)
-                        if result.audio_start_time is not None:
-                            last_final_time = now
+                        if not _done_already_finalized(final_segments, done_transcript):
+                            final_segments.append(done_transcript)
+                            if result.audio_start_time is not None:
+                                last_final_time = now
                     break
 
                 if event_type == "error":

--- a/runner/tests/providers/stt/test_xai.py
+++ b/runner/tests/providers/stt/test_xai.py
@@ -123,6 +123,90 @@ async def test_xai_multi_segment_join_trailing_done(
 
 
 @pytest.mark.asyncio
+async def test_xai_done_echoes_full_transcript_not_duplicated(
+    fake_api_key: SecretStr,
+    audio_pcm_bytes: bytes,
+) -> None:
+    """transcript.done echoing the whole utterance must not double the transcript.
+
+    Regression guard for the incident where xAI's transcript.done carried the
+    full utterance already closed by speech_final partials instead of the
+    unclosed tail. Blindly appending it produced "X X" and ≈100% WER; the dedup
+    in _done_already_finalized must drop the echo so the final text stays single.
+    """
+    events: list[Any] = [
+        {"type": "transcript.created", "id": "xai-session-echo"},
+        {
+            "type": "transcript.partial",
+            "text": "hello world",
+            "is_final": True,
+            "speech_final": True,
+        },
+        {
+            "type": "transcript.partial",
+            "text": "how are you",
+            "is_final": True,
+            "speech_final": True,
+        },
+        {"type": "transcript.done", "text": "hello world how are you"},
+    ]
+    provider = XaiSTTProvider(api_key=fake_api_key, model="grok-stt")
+
+    with patch(
+        "coval_bench.providers.stt.xai.ws_client.connect",
+        return_value=_fake_connect(events),
+    ):
+        result = await provider.measure_ttft(
+            audio_data=audio_pcm_bytes,
+            channels=1,
+            sample_width=2,
+            sample_rate=16000,
+            realtime_resolution=0.5,
+        )
+
+    assert result.error is None
+    assert result.complete_transcript == "hello world how are you"
+    assert result.word_count == 5
+    wer = compute_wer("hello world how are you", result.complete_transcript)
+    assert wer.wer_percentage == pytest.approx(0.0)
+
+
+@pytest.mark.asyncio
+async def test_xai_done_echoes_single_segment_not_duplicated(
+    fake_api_key: SecretStr,
+    audio_pcm_bytes: bytes,
+) -> None:
+    """Single speech_final segment + done repeating that same segment stays single."""
+    events: list[Any] = [
+        {"type": "transcript.created", "id": "xai-session-echo-single"},
+        {
+            "type": "transcript.partial",
+            "text": "hello world how are you",
+            "is_final": True,
+            "speech_final": True,
+        },
+        {"type": "transcript.done", "text": "hello world how are you"},
+    ]
+    provider = XaiSTTProvider(api_key=fake_api_key, model="grok-stt")
+
+    with patch(
+        "coval_bench.providers.stt.xai.ws_client.connect",
+        return_value=_fake_connect(events),
+    ):
+        result = await provider.measure_ttft(
+            audio_data=audio_pcm_bytes,
+            channels=1,
+            sample_width=2,
+            sample_rate=16000,
+            realtime_resolution=0.5,
+        )
+
+    assert result.error is None
+    assert result.complete_transcript == "hello world how are you"
+    assert result.word_count == 5
+
+
+@pytest.mark.asyncio
 async def test_xai_single_speech_final_empty_done(
     fake_api_key: SecretStr,
     audio_pcm_bytes: bytes,

--- a/runner/tests/providers/stt/test_xai.py
+++ b/runner/tests/providers/stt/test_xai.py
@@ -207,6 +207,137 @@ async def test_xai_done_echoes_single_segment_not_duplicated(
 
 
 @pytest.mark.asyncio
+async def test_xai_done_full_transcript_plus_tail_not_duplicated(
+    fake_api_key: SecretStr,
+    audio_pcm_bytes: bytes,
+) -> None:
+    """done carrying the whole utterance plus a new trailing tail must not duplicate.
+
+    transcript.done is the final transcript, so it can repeat the finalized
+    segment AND add new words. Appending it whole would double the prefix
+    ("hello world hello world thanks"); the merge keeps the authoritative done.
+    """
+    events: list[Any] = [
+        {"type": "transcript.created", "id": "xai-session-full-tail"},
+        {
+            "type": "transcript.partial",
+            "text": "hello world",
+            "is_final": True,
+            "speech_final": True,
+        },
+        {"type": "transcript.done", "text": "hello world thanks"},
+    ]
+    provider = XaiSTTProvider(api_key=fake_api_key, model="grok-stt")
+
+    with patch(
+        "coval_bench.providers.stt.xai.ws_client.connect",
+        return_value=_fake_connect(events),
+    ):
+        result = await provider.measure_ttft(
+            audio_data=audio_pcm_bytes,
+            channels=1,
+            sample_width=2,
+            sample_rate=16000,
+            realtime_resolution=0.5,
+        )
+
+    assert result.error is None
+    assert result.complete_transcript == "hello world thanks"
+    assert result.word_count == 3
+
+
+@pytest.mark.asyncio
+async def test_xai_repeated_phrase_tail_is_kept(
+    fake_api_key: SecretStr,
+    audio_pcm_bytes: bytes,
+) -> None:
+    """A genuine repeated-phrase tail in done is appended, not dropped.
+
+    Two speech_final "hello world" segments then done "hello world" is a real
+    third repetition, not an echo (done is not a prefix of the joined text), so
+    it must be kept.
+    """
+    events: list[Any] = [
+        {"type": "transcript.created", "id": "xai-session-repeat"},
+        {
+            "type": "transcript.partial",
+            "text": "hello world",
+            "is_final": True,
+            "speech_final": True,
+        },
+        {
+            "type": "transcript.partial",
+            "text": "hello world",
+            "is_final": True,
+            "speech_final": True,
+        },
+        {"type": "transcript.done", "text": "hello world"},
+    ]
+    provider = XaiSTTProvider(api_key=fake_api_key, model="grok-stt")
+
+    with patch(
+        "coval_bench.providers.stt.xai.ws_client.connect",
+        return_value=_fake_connect(events),
+    ):
+        result = await provider.measure_ttft(
+            audio_data=audio_pcm_bytes,
+            channels=1,
+            sample_width=2,
+            sample_rate=16000,
+            realtime_resolution=0.5,
+        )
+
+    assert result.error is None
+    assert result.complete_transcript == "hello world hello world hello world"
+
+
+@pytest.mark.asyncio
+async def test_xai_interim_cumulative_partials_not_joined(
+    fake_api_key: SecretStr,
+    audio_pcm_bytes: bytes,
+) -> None:
+    """Cumulative is_final/speech_final=false partials drive TTFT but are never joined.
+
+    Guards the prior class of bug where cumulative interim partials were
+    concatenated into the final transcript. Only the speech_final segment is.
+    """
+    events: list[Any] = [
+        {"type": "transcript.created", "id": "xai-session-cumulative"},
+        {"type": "transcript.partial", "text": "hello", "is_final": True, "speech_final": False},
+        {
+            "type": "transcript.partial",
+            "text": "hello world",
+            "is_final": True,
+            "speech_final": False,
+        },
+        {
+            "type": "transcript.partial",
+            "text": "hello world",
+            "is_final": True,
+            "speech_final": True,
+        },
+        {"type": "transcript.done", "text": ""},
+    ]
+    provider = XaiSTTProvider(api_key=fake_api_key, model="grok-stt")
+
+    with patch(
+        "coval_bench.providers.stt.xai.ws_client.connect",
+        return_value=_fake_connect(events),
+    ):
+        result = await provider.measure_ttft(
+            audio_data=audio_pcm_bytes,
+            channels=1,
+            sample_width=2,
+            sample_rate=16000,
+            realtime_resolution=0.5,
+        )
+
+    assert result.error is None
+    assert result.complete_transcript == "hello world"
+    assert result.word_count == 2
+
+
+@pytest.mark.asyncio
 async def test_xai_single_speech_final_empty_done(
     fake_api_key: SecretStr,
     audio_pcm_bytes: bytes,


### PR DESCRIPTION
xAI's `transcript.done` is documented as the final transcript after `audio.done`, not strictly the unclosed tail. Our assembly assumed tail-only and always appended `done` on top of the `speech_final` segments, so when `done` echoed the full utterance (seen Jun 19–22) it produced a doubled transcript (`"X X"`) scoring ~100% WER despite correct transcription.

We now reconcile `done` with the finalized segments: when `done` already contains the joined finalized text as a leading prefix it is the authoritative full transcript and is used verbatim; otherwise it is a trailing tail and is appended. This covers full echo, full-plus-tail, and genuine repeated-phrase tails without duplicating, and keeps the empty/tail-only `done` behavior unchanged.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a doubled-transcript bug in the xAI STT provider caused by `transcript.done` echoing the full utterance instead of only the unclosed tail. The old code always blindly appended `done` to the `speech_final` segments, producing `"X X"` and ~100% WER when the API changed its behavior between June 19–22.

- Introduces `_merge_done_with_finals` to reconcile `done` against already-finalized segments: if `done` equals the normalized joined text or starts with it, `done` is treated as authoritative and returned verbatim; otherwise it is appended as a genuine tail.
- Updates `_receive` to use the new helper and guards `last_final_time` updates behind a content-change check so timing is not falsely advanced by a pure echo.
- Adds five regression tests covering the full-echo, single-segment-echo, full-plus-tail, repeated-phrase-tail, and cumulative-partial scenarios.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the fix is scoped to a single well-tested helper that handles all known transcript.done shapes without affecting the normal tail-append path.

The change is narrowly targeted: a new pure function (_merge_done_with_finals) with clear branching logic, backed by five new regression tests that directly reproduce the incident scenario and the adjacent edge cases. The guard is only invoked when done_transcript is non-empty, so the empty-done and multi-segment paths remain on the original code path.

No files require special attention. One test docstring contains a stale reference to the old function name (_done_already_finalized) but this has no runtime impact.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| runner/src/coval_bench/providers/stt/xai.py | Adds _merge_done_with_finals to guard against duplicated transcripts when transcript.done echoes the full utterance; handles all three documented done shapes (tail-only, full echo, full-plus-tail) correctly |
| runner/tests/providers/stt/test_xai.py | Adds five targeted regression tests covering the echo, single-segment echo, full-plus-tail, repeated-phrase, and cumulative-partial cases; one test docstring contains a stale reference to _done_already_finalized (the old function name) |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[transcript.done received] --> B{done_transcript non-empty?}
    B -- No --> Z[final_segments unchanged]
    B -- Yes --> C[Normalize: joined = speech_final segments joined]
    C --> D{joined empty?}
    D -- Yes --> E[return done_transcript as sole segment]
    D -- No --> F{done == joined?}
    F -- Yes: full echo --> E
    F -- No --> G{done.startswith joined + space?}
    G -- Yes: full utterance plus tail --> E
    G -- No: genuine tail --> H[return final_segments + done_transcript appended]
    E --> I[final_segments = done_transcript]
    H --> I
    I --> J{new_text != prev_text?}
    J -- Yes --> K[update last_final_time]
    J -- No: echo, no new content --> L[last_final_time unchanged]
    K --> M[finalize_transcript with final_segments]
    L --> M
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[transcript.done received] --> B{done_transcript non-empty?}
    B -- No --> Z[final_segments unchanged]
    B -- Yes --> C[Normalize: joined = speech_final segments joined]
    C --> D{joined empty?}
    D -- Yes --> E[return done_transcript as sole segment]
    D -- No --> F{done == joined?}
    F -- Yes: full echo --> E
    F -- No --> G{done.startswith joined + space?}
    G -- Yes: full utterance plus tail --> E
    G -- No: genuine tail --> H[return final_segments + done_transcript appended]
    E --> I[final_segments = done_transcript]
    H --> I
    I --> J{new_text != prev_text?}
    J -- Yes --> K[update last_final_time]
    J -- No: echo, no new content --> L[last_final_time unchanged]
    K --> M[finalize_transcript with final_segments]
    L --> M
```

</a>

<sub>Reviews (2): Last reviewed commit: ["Reconcile xAI transcript.done as authori..."](https://github.com/coval-ai/benchmarks/commit/9b97f795e5a46453e8778a21f4b2de7640d5335a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39143506)</sub>

<!-- /greptile_comment -->