### PR TITLE
Add Voice Arena voting UI

### DIFF
--- a/web/app/arena/components/AudioPlayer.tsx
+++ b/web/app/arena/components/AudioPlayer.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+type Props = {
+  src: string | null; // null until a battle is generated -> the player renders disabled
+  label: string;
+  isActive: boolean; // true when this is the side currently allowed to play
+  onActivate: () => void; // claim single-playback focus
+};
+
+function fmt(t: number): string {
+  if (!Number.isFinite(t)) return "0:00";
+  const m = Math.floor(t / 60);
+  const s = Math.floor(t % 60);
+  return `${m}:${s.toString().padStart(2, "0")}`;
+}
+
+export function AudioPlayer({ src, label, isActive, onActivate }: Props) {
+  const ref = useRef<HTMLAudioElement>(null);
+  const [playing, setPlaying] = useState(false);
+  const [progress, setProgress] = useState(0);
+  const [duration, setDuration] = useState(0);
+  const disabled = !src;
+
+  // Single-playback: when another side claims focus, stop this one.
+  useEffect(() => {
+    if (!isActive && ref.current) {
+      ref.current.pause();
+      ref.current.currentTime = 0;
+    }
+  }, [isActive]);
+
+  // Pause on unmount so audio never outlives the component.
+  useEffect(() => {
+    const el = ref.current;
+    return () => {
+      el?.pause();
+    };
+  }, []);
+
+  const toggle = () => {
+    const el = ref.current;
+    if (!el || disabled) return;
+    if (playing) {
+      el.pause();
+      return;
+    }
+    onActivate();
+    el.currentTime = 0;
+    void el.play();
+  };
+
+  return (
+    <div className="flex items-center justify-between gap-3">
+      {src && (
+        <audio
+          ref={ref}
+          src={src}
+          preload="metadata"
+          onPlay={() => setPlaying(true)}
+          onPause={() => setPlaying(false)}
+          onEnded={() => {
+            setPlaying(false);
+            setProgress(0);
+          }}
+          onLoadedMetadata={(e) => setDuration(e.currentTarget.duration)}
+          onTimeUpdate={(e) =>
+            setProgress(
+              e.currentTarget.duration ? e.currentTarget.currentTime / e.currentTarget.duration : 0,
+            )
+          }
+        />
+      )}
+      <button
+        type="button"
+        onClick={toggle}
+        disabled={disabled}
+        aria-label={disabled ? `${label} — generate to enable` : `${playing ? "Pause" : "Play"} ${label}`}
+        className="shrink-0 rounded-full border border-border-primary bg-surface-primary px-4 py-2 font-mono text-sm text-text-primary hover:bg-hover-bg disabled:cursor-not-allowed disabled:opacity-40"
+      >
+        {playing ? "❚❚" : "▶"}
+      </button>
+      <div className="h-1.5 flex-1 overflow-hidden rounded-full bg-surface-secondary">
+        <div
+          className="h-full rounded-full bg-text-primary"
+          style={{ width: `${Math.round(progress * 100)}%` }}
+        />
+      </div>
+      <span className="shrink-0 font-mono text-xs text-text-tertiary">{src ? fmt(duration) : "—"}</span>
+    </div>
+  );
+}

--- a/web/app/arena/components/AudioPlayer.tsx
+++ b/web/app/arena/components/AudioPlayer.tsx
@@ -47,7 +47,6 @@ export function AudioPlayer({ src, label, isActive, onActivate }: Props) {
       return;
     }
     onActivate();
-    el.currentTime = 0;
     void el.play();
   };
 
@@ -63,6 +62,7 @@ export function AudioPlayer({ src, label, isActive, onActivate }: Props) {
           onEnded={() => {
             setPlaying(false);
             setProgress(0);
+            if (ref.current) ref.current.currentTime = 0; // rearm for replay from the start
           }}
           onLoadedMetadata={(e) => setDuration(e.currentTarget.duration)}
           onTimeUpdate={(e) =>

--- a/web/app/arena/components/AudioPlayer.tsx
+++ b/web/app/arena/components/AudioPlayer.tsx
@@ -23,12 +23,10 @@ export function AudioPlayer({ src, label, isActive, onActivate }: Props) {
   const [duration, setDuration] = useState(0);
   const disabled = !src;
 
-  // Single-playback: when another side claims focus, stop this one.
+  // Single-playback: when another side claims focus, pause this one (keep its
+  // position so play resumes rather than restarts).
   useEffect(() => {
-    if (!isActive && ref.current) {
-      ref.current.pause();
-      ref.current.currentTime = 0;
-    }
+    if (!isActive) ref.current?.pause();
   }, [isActive]);
 
   // Pause on unmount so audio never outlives the component.

--- a/web/app/arena/page.tsx
+++ b/web/app/arena/page.tsx
@@ -1,0 +1,275 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { getBattleSource } from "@/lib/arena/source";
+import type { BlindBattle, Outcome, Reveal, RevealedModel } from "@/lib/arena/types";
+import { AudioPlayer } from "./components/AudioPlayer";
+
+const MIN_CHARS = 3;
+const MAX_CHARS = 500;
+const EXAMPLES = [
+  "Thanks for calling — I can help you with that refund right away.",
+  "The northern lights danced across the sky in ribbons of green and violet.",
+  "Honestly? I'd grab the earlier train. Traffic downtown is brutal today.",
+];
+
+export default function ArenaPage() {
+  const source = getBattleSource();
+  const voterId = useVoterId();
+
+  const [step, setStep] = useState<1 | 2 | 4>(1);
+  const [text, setText] = useState("");
+  const [battle, setBattle] = useState<BlindBattle | null>(null);
+  const [vote, setVote] = useState<Outcome | null>(null);
+  const [reveal, setReveal] = useState<Reveal | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [active, setActive] = useState<"a" | "b" | null>(null);
+  const newBattleRef = useRef<HTMLButtonElement>(null);
+  const runToken = useRef(0);
+
+  useEffect(() => {
+    if (step === 4) newBattleRef.current?.focus();
+  }, [step]);
+
+  const reset = useCallback(() => {
+    runToken.current += 1; // invalidate any in-flight createBattle
+    setStep(1);
+    setText("");
+    setBattle(null);
+    setVote(null);
+    setReveal(null);
+    setError(null);
+    setActive(null);
+  }, []);
+
+  const generate = async () => {
+    const trimmed = text.trim();
+    if (trimmed.length < MIN_CHARS || loading) return;
+    const token = ++runToken.current;
+    setLoading(true);
+    setError(null);
+    try {
+      const b = await source.createBattle(trimmed);
+      if (token !== runToken.current) return; // a newer action superseded this one
+      setBattle(b);
+      setStep(2);
+    } catch {
+      if (token === runToken.current) setError("Couldn't generate audio. Please try again.");
+    } finally {
+      if (token === runToken.current) setLoading(false);
+    }
+  };
+
+  const castVote = async (outcome: Outcome) => {
+    if (!battle || vote || submitting) return;
+    setSubmitting(true);
+    setVote(outcome);
+    setActive(null); // stop both players
+    try {
+      await source.submitVote({ battleId: battle.battleId, outcome, voterId });
+      try {
+        setReveal(await source.reveal(battle.battleId));
+      } catch {
+        setReveal(null); // vote is recorded; identities just unavailable
+      }
+      setStep(4);
+    } catch {
+      setVote(null); // let them retry
+      setError("Couldn't record your vote. Please try again.");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <main className="min-h-screen bg-surface-primary px-6 pb-24 pt-32 text-text-primary">
+      <div className="mx-auto flex max-w-[760px] flex-col gap-8">
+        <h1 className="text-center font-sans text-2xl">Which voice sounds more natural?</h1>
+
+        <div
+          key={battle?.battleId ?? "pending"}
+          className="grid grid-cols-[1fr_44px_1fr] items-stretch"
+        >
+          <BattleCard
+            side="a"
+            blindTitle="Model A"
+            revealed={step === 4 && reveal ? reveal.a : null}
+            picked={step === 4 ? vote : null}
+            isActive={active === "a"}
+            src={battle?.audioA ?? null}
+            onActivate={() => setActive("a")}
+          />
+          <div className="flex items-center justify-center font-mono text-xs text-text-tertiary">
+            VS
+          </div>
+          <BattleCard
+            side="b"
+            blindTitle="Model B"
+            revealed={step === 4 && reveal ? reveal.b : null}
+            picked={step === 4 ? vote : null}
+            isActive={active === "b"}
+            src={battle?.audioB ?? null}
+            onActivate={() => setActive("b")}
+          />
+        </div>
+
+        {step === 1 && (
+          <section className="flex flex-col gap-3">
+            <textarea
+              value={text}
+              maxLength={MAX_CHARS}
+              onChange={(e) => setText(e.target.value)}
+              placeholder="Describe a scenario or write text to synthesize…"
+              rows={4}
+              className="w-full resize-none rounded-xl border border-border-primary bg-surface-elevated p-4 font-sans text-base leading-relaxed outline-none focus:border-selected-border"
+            />
+            <div className="flex items-center justify-between text-sm text-text-tertiary">
+              <button
+                type="button"
+                onClick={() => setText(EXAMPLES[Math.floor(Math.random() * EXAMPLES.length)] ?? "")}
+                className="font-sans underline underline-offset-2 hover:text-text-secondary"
+              >
+                Use an example
+              </button>
+              <span className="font-mono">
+                {text.length}/{MAX_CHARS}
+              </span>
+            </div>
+            <button
+              type="button"
+              onClick={generate}
+              disabled={text.trim().length < MIN_CHARS || loading}
+              className="self-start rounded-full bg-surface-toggle-active px-6 py-2.5 font-mono text-sm text-text-on-toggle-active disabled:opacity-40"
+            >
+              {loading ? "Generating…" : "Generate speech"}
+            </button>
+            {error && <p className="font-sans text-sm text-accent-rust">{error}</p>}
+          </section>
+        )}
+
+        {battle && step !== 4 && (
+          <section className="flex flex-col gap-3">
+            <div className="grid grid-cols-[1fr_0.7fr_1fr] gap-3">
+              <VoteButton label="Model A" onClick={() => castVote("A_WIN")} disabled={submitting} />
+              <VoteButton label="Tie" onClick={() => castVote("TIE")} disabled={submitting} />
+              <VoteButton label="Model B" onClick={() => castVote("B_WIN")} disabled={submitting} />
+            </div>
+            {error && <p className="text-center font-sans text-sm text-accent-rust">{error}</p>}
+          </section>
+        )}
+
+        {step === 4 && (
+          <div className="flex flex-col items-center gap-4" aria-live="polite">
+            <p className="font-mono text-sm text-text-secondary">✓ Battle recorded</p>
+            <div className="flex gap-3">
+              <button
+                ref={newBattleRef}
+                type="button"
+                onClick={reset}
+                className="rounded-full bg-surface-toggle-active px-6 py-2.5 font-mono text-sm text-text-on-toggle-active"
+              >
+                New battle
+              </button>
+              <a
+                href="/arena/leaderboard"
+                className="rounded-full border border-border-primary px-6 py-2.5 font-mono text-sm text-text-secondary hover:bg-hover-bg"
+              >
+                View leaderboard
+              </a>
+            </div>
+          </div>
+        )}
+      </div>
+    </main>
+  );
+}
+
+function useVoterId(): string {
+  const [id, setId] = useState("");
+  useEffect(() => {
+    let existing = localStorage.getItem("arena_voter_id");
+    if (!existing) {
+      existing = crypto.randomUUID();
+      localStorage.setItem("arena_voter_id", existing);
+    }
+    setId(existing);
+  }, []);
+  return id;
+}
+
+function BattleCard({
+  side,
+  blindTitle,
+  revealed,
+  picked,
+  isActive,
+  src,
+  onActivate,
+}: {
+  side: "a" | "b";
+  blindTitle: string;
+  revealed: RevealedModel | null;
+  picked: Outcome | null;
+  isActive: boolean;
+  src: string | null;
+  onActivate: () => void;
+}) {
+  const won = picked === (side === "a" ? "A_WIN" : "B_WIN");
+  const tie = picked === "TIE";
+  const highlighted = won || tie;
+  return (
+    <div
+      className={`flex flex-col gap-4 rounded-xl border bg-surface-elevated p-5 ${
+        highlighted ? "border-selected-border bg-selected-bg" : "border-border-primary"
+      }`}
+    >
+      <div className="flex items-start justify-between gap-2">
+        <span className="flex items-center gap-2">
+          <span className="mt-1 h-2 w-2 shrink-0 self-start rounded-full bg-text-tertiary" />
+          {revealed ? (
+            <span className="flex flex-col leading-tight">
+              <span className="font-sans text-sm text-text-primary">{revealed.model}</span>
+              <span className="font-mono text-xs text-text-tertiary">{revealed.provider}</span>
+            </span>
+          ) : (
+            <span className="font-sans text-sm">{blindTitle}</span>
+          )}
+        </span>
+        {picked !== null && (
+          <span className="shrink-0 font-mono text-xs text-text-secondary">
+            {won ? "YOUR PICK" : tie ? "TIE" : ""}
+          </span>
+        )}
+      </div>
+      <AudioPlayer
+        src={src}
+        label={`Model ${side.toUpperCase()}`}
+        isActive={isActive}
+        onActivate={onActivate}
+      />
+    </div>
+  );
+}
+
+function VoteButton({
+  label,
+  onClick,
+  disabled,
+}: {
+  label: string;
+  onClick: () => void;
+  disabled: boolean;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      className="rounded-xl border border-border-primary bg-surface-elevated py-3 font-mono text-sm hover:border-selected-border hover:bg-selected-bg disabled:opacity-40"
+    >
+      {label}
+    </button>
+  );
+}

--- a/web/app/arena/page.tsx
+++ b/web/app/arena/page.tsx
@@ -187,16 +187,16 @@ export default function ArenaPage() {
 }
 
 function useVoterId(): string {
-  const [id, setId] = useState("");
-  useEffect(() => {
+  const ref = useRef<string | null>(null);
+  if (ref.current === null && typeof window !== "undefined") {
     let existing = localStorage.getItem("arena_voter_id");
     if (!existing) {
       existing = crypto.randomUUID();
       localStorage.setItem("arena_voter_id", existing);
     }
-    setId(existing);
-  }, []);
-  return id;
+    ref.current = existing;
+  }
+  return ref.current ?? "";
 }
 
 function BattleCard({

--- a/web/app/arena/page.tsx
+++ b/web/app/arena/page.tsx
@@ -186,15 +186,30 @@ export default function ArenaPage() {
   );
 }
 
+function makeVoterId(): string {
+  try {
+    return crypto.randomUUID();
+  } catch {
+    return `anon-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+  }
+}
+
 function useVoterId(): string {
   const ref = useRef<string | null>(null);
   if (ref.current === null && typeof window !== "undefined") {
-    let existing = localStorage.getItem("arena_voter_id");
-    if (!existing) {
-      existing = crypto.randomUUID();
-      localStorage.setItem("arena_voter_id", existing);
+    try {
+      const stored = localStorage.getItem("arena_voter_id");
+      if (stored) {
+        ref.current = stored;
+      } else {
+        const fresh = makeVoterId();
+        localStorage.setItem("arena_voter_id", fresh);
+        ref.current = fresh;
+      }
+    } catch {
+      // Storage blocked (private mode, sandboxed iframe, etc.): ephemeral id.
+      ref.current = makeVoterId();
     }
-    ref.current = existing;
   }
   return ref.current ?? "";
 }

--- a/web/lib/arena/apiSource.ts
+++ b/web/lib/arena/apiSource.ts
@@ -1,0 +1,36 @@
+import type { BattleSource, BlindBattle, Reveal, VoteInput, VoteResult } from "./types";
+
+// Real battle source: talks to same-origin Next.js API proxy routes under /api/arena/*,
+// which inject the server-only X-Labeler-Key and proxy to the runner. Inert until
+// NEXT_PUBLIC_ARENA_SOURCE=api is set (the factory defaults to the mock). The BFF routes and
+// the runner endpoints they call are not built yet — this adapter defines the contract they
+// must satisfy:
+//   POST /api/arena/battle              { text }                        -> BlindBattle
+//   POST /api/arena/vote                { battleId, outcome, voterId }  -> VoteResult
+//   GET  /api/arena/battle/{id}/reveal                                  -> Reveal
+
+async function postJson<T>(url: string, body: unknown): Promise<T> {
+  const res = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) throw new Error(`${url} -> ${res.status}`);
+  return (await res.json()) as T;
+}
+
+export class ApiBattleSource implements BattleSource {
+  createBattle(text: string): Promise<BlindBattle> {
+    return postJson<BlindBattle>("/api/arena/battle", { text });
+  }
+
+  submitVote(input: VoteInput): Promise<VoteResult> {
+    return postJson<VoteResult>("/api/arena/vote", input);
+  }
+
+  async reveal(battleId: string): Promise<Reveal> {
+    const res = await fetch(`/api/arena/battle/${encodeURIComponent(battleId)}/reveal`);
+    if (!res.ok) throw new Error(`reveal -> ${res.status}`);
+    return (await res.json()) as Reveal;
+  }
+}

--- a/web/lib/arena/apiSource.ts
+++ b/web/lib/arena/apiSource.ts
@@ -9,11 +9,16 @@ import type { BattleSource, BlindBattle, Reveal, VoteInput, VoteResult } from ".
 //   POST /api/arena/vote                { battleId, outcome, voterId }  -> VoteResult
 //   GET  /api/arena/battle/{id}/reveal                                  -> Reveal
 
-async function postJson<T>(url: string, body: unknown): Promise<T> {
+// Coarse hang-backstops, not latency SLAs; tune once real backend latency is known.
+const QUICK_TIMEOUT_MS = 5_000; // vote/reveal: quick DB ops
+const SYNTH_TIMEOUT_MS = 30_000; // createBattle: on-demand TTS synthesis of two clips
+
+async function postJson<T>(url: string, body: unknown, timeoutMs = QUICK_TIMEOUT_MS): Promise<T> {
   const res = await fetch(url, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(body),
+    signal: AbortSignal.timeout(timeoutMs),
   });
   if (!res.ok) throw new Error(`${url} -> ${res.status}`);
   return (await res.json()) as T;
@@ -21,7 +26,7 @@ async function postJson<T>(url: string, body: unknown): Promise<T> {
 
 export class ApiBattleSource implements BattleSource {
   createBattle(text: string): Promise<BlindBattle> {
-    return postJson<BlindBattle>("/api/arena/battle", { text });
+    return postJson<BlindBattle>("/api/arena/battle", { text }, SYNTH_TIMEOUT_MS);
   }
 
   submitVote(input: VoteInput): Promise<VoteResult> {
@@ -29,7 +34,9 @@ export class ApiBattleSource implements BattleSource {
   }
 
   async reveal(battleId: string): Promise<Reveal> {
-    const res = await fetch(`/api/arena/battle/${encodeURIComponent(battleId)}/reveal`);
+    const res = await fetch(`/api/arena/battle/${encodeURIComponent(battleId)}/reveal`, {
+      signal: AbortSignal.timeout(QUICK_TIMEOUT_MS),
+    });
     if (!res.ok) throw new Error(`reveal -> ${res.status}`);
     return (await res.json()) as Reveal;
   }

--- a/web/lib/arena/arena.test.ts
+++ b/web/lib/arena/arena.test.ts
@@ -1,0 +1,50 @@
+// Copyright 2026 The Coval Benchmarks Authors
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+import { MockBattleSource } from "./mockSource";
+import { getBattleSource } from "./source";
+
+describe("MockBattleSource", () => {
+  it("creates a blind battle: prompt echoed, two distinct playable audio sources", async () => {
+    const battle = await new MockBattleSource().createBattle("hello world");
+    expect(battle.battleId).toBeTruthy();
+    expect(battle.prompt).toBe("hello world");
+    expect(battle.audioA).toMatch(/^data:audio\/wav;base64,/);
+    expect(battle.audioB).toMatch(/^data:audio\/wav;base64,/);
+    expect(battle.audioA).not.toBe(battle.audioB);
+  });
+
+  it("does not leak any model identity in the blind battle payload", async () => {
+    const battle = await new MockBattleSource().createBattle("hi");
+    expect(Object.keys(battle).sort()).toEqual(["audioA", "audioB", "battleId", "prompt"]);
+  });
+
+  it("reveals two distinct models for a created battle", async () => {
+    const src = new MockBattleSource();
+    const battle = await src.createBattle("hi");
+    const reveal = await src.reveal(battle.battleId);
+    expect(reveal.a.model).toBeTruthy();
+    expect(reveal.b.model).toBeTruthy();
+    expect(reveal.a.model).not.toBe(reveal.b.model);
+  });
+
+  it("throws when revealing an unknown battle", async () => {
+    await expect(new MockBattleSource().reveal("does-not-exist")).rejects.toThrow();
+  });
+
+  it("echoes the outcome on submitVote", async () => {
+    const src = new MockBattleSource();
+    const battle = await src.createBattle("hi");
+    const res = await src.submitVote({ battleId: battle.battleId, outcome: "A_WIN", voterId: "t" });
+    expect(res).toEqual({ battleId: battle.battleId, outcome: "A_WIN" });
+  });
+});
+
+describe("getBattleSource", () => {
+  it("defaults to the mock and returns a singleton", () => {
+    const first = getBattleSource();
+    expect(first).toBeInstanceOf(MockBattleSource);
+    expect(getBattleSource()).toBe(first);
+  });
+});

--- a/web/lib/arena/arena.test.ts
+++ b/web/lib/arena/arena.test.ts
@@ -39,6 +39,13 @@ describe("MockBattleSource", () => {
     const res = await src.submitVote({ battleId: battle.battleId, outcome: "A_WIN", voterId: "t" });
     expect(res).toEqual({ battleId: battle.battleId, outcome: "A_WIN" });
   });
+
+  it("rejects a vote for an unknown battle (mirrors the backend)", async () => {
+    const src = new MockBattleSource();
+    await expect(
+      src.submitVote({ battleId: "does-not-exist", outcome: "A_WIN", voterId: "t" }),
+    ).rejects.toThrow();
+  });
 });
 
 describe("getBattleSource", () => {

--- a/web/lib/arena/mockSource.ts
+++ b/web/lib/arena/mockSource.ts
@@ -74,6 +74,9 @@ export class MockBattleSource implements BattleSource {
 
   async submitVote(input: VoteInput): Promise<VoteResult> {
     await delay(200);
+    if (!this.assignments.has(input.battleId)) {
+      throw new Error(`mock vote: unknown battle ${input.battleId}`);
+    }
     return { battleId: input.battleId, outcome: input.outcome };
   }
 

--- a/web/lib/arena/mockSource.ts
+++ b/web/lib/arena/mockSource.ts
@@ -1,0 +1,83 @@
+import { getEnabledTtsModels } from "../playground/providers";
+import type { BattleSource, BlindBattle, Reveal, RevealedModel, VoteInput, VoteResult } from "./types";
+
+// Self-contained mock: no network, no backend. Generates two distinct audible tones as
+// WAV data URIs so the real <audio> player works exactly as in production, picks two
+// random models for the blind A/B, and remembers the assignment in-memory for the reveal.
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function base64FromBuffer(buf: ArrayBuffer): string {
+  const bytes = new Uint8Array(buf);
+  let binary = "";
+  const chunk = 0x8000;
+  for (let i = 0; i < bytes.length; i += chunk) {
+    binary += String.fromCharCode(...bytes.subarray(i, i + chunk));
+  }
+  return btoa(binary);
+}
+
+function toneDataUri(freq: number, seconds = 1.8): string {
+  const sampleRate = 8000;
+  const n = Math.floor(sampleRate * seconds);
+  const dataSize = n * 2;
+  const view = new DataView(new ArrayBuffer(44 + dataSize));
+  const writeStr = (off: number, s: string) => {
+    for (let i = 0; i < s.length; i++) view.setUint8(off + i, s.charCodeAt(i));
+  };
+  writeStr(0, "RIFF");
+  view.setUint32(4, 36 + dataSize, true);
+  writeStr(8, "WAVE");
+  writeStr(12, "fmt ");
+  view.setUint32(16, 16, true);
+  view.setUint16(20, 1, true);
+  view.setUint16(22, 1, true);
+  view.setUint32(24, sampleRate, true);
+  view.setUint32(28, sampleRate * 2, true);
+  view.setUint16(32, 2, true);
+  view.setUint16(34, 16, true);
+  writeStr(36, "data");
+  view.setUint32(40, dataSize, true);
+  const amp = 0.25 * 32767;
+  for (let i = 0; i < n; i++) {
+    const env = Math.min(1, i / 400, (n - i) / 400); // fade edges to avoid clicks
+    view.setInt16(44 + i * 2, Math.sin((2 * Math.PI * freq * i) / sampleRate) * amp * env, true);
+  }
+  return `data:audio/wav;base64,${base64FromBuffer(view.buffer)}`;
+}
+
+function toRevealed(m: { provider: string; model: string; label: string }): RevealedModel {
+  return { provider: m.provider, model: m.model, label: m.label };
+}
+
+export class MockBattleSource implements BattleSource {
+  private assignments = new Map<string, Reveal>();
+  private counter = 0;
+
+  async createBattle(text: string): Promise<BlindBattle> {
+    await delay(600); // exercise the loading state
+    const [a, b] = [...getEnabledTtsModels()].sort(() => Math.random() - 0.5);
+    if (!a || !b) throw new Error("arena mock: need at least 2 enabled TTS models");
+    const battleId = `mock-${++this.counter}-${Math.random().toString(36).slice(2, 8)}`;
+    this.assignments.set(battleId, { a: toRevealed(a), b: toRevealed(b) });
+    return {
+      battleId,
+      prompt: text,
+      audioA: toneDataUri(220), // A3
+      audioB: toneDataUri(330), // E4 — clearly distinct from A
+    };
+  }
+
+  async submitVote(input: VoteInput): Promise<VoteResult> {
+    await delay(200);
+    return { battleId: input.battleId, outcome: input.outcome };
+  }
+
+  async reveal(battleId: string): Promise<Reveal> {
+    const r = this.assignments.get(battleId);
+    if (!r) throw new Error(`mock reveal: unknown battle ${battleId}`);
+    return r;
+  }
+}

--- a/web/lib/arena/mockSource.ts
+++ b/web/lib/arena/mockSource.ts
@@ -58,7 +58,9 @@ export class MockBattleSource implements BattleSource {
 
   async createBattle(text: string): Promise<BlindBattle> {
     await delay(600); // exercise the loading state
-    const [a, b] = [...getEnabledTtsModels()].sort(() => Math.random() - 0.5);
+    const pool = [...getEnabledTtsModels()];
+    const a = pool.splice(Math.floor(Math.random() * pool.length), 1)[0];
+    const b = pool.splice(Math.floor(Math.random() * pool.length), 1)[0];
     if (!a || !b) throw new Error("arena mock: need at least 2 enabled TTS models");
     const battleId = `mock-${++this.counter}-${Math.random().toString(36).slice(2, 8)}`;
     this.assignments.set(battleId, { a: toRevealed(a), b: toRevealed(b) });

--- a/web/lib/arena/source.ts
+++ b/web/lib/arena/source.ts
@@ -1,0 +1,17 @@
+import { ApiBattleSource } from "./apiSource";
+import { MockBattleSource } from "./mockSource";
+import type { BattleSource } from "./types";
+
+// The UI imports ONLY this. Flip NEXT_PUBLIC_ARENA_SOURCE=api to go live; default is the
+// self-contained mock (no backend required). Singleton so the mock's in-memory battle
+// assignments survive across calls within a session (needed for reveal()).
+let instance: BattleSource | null = null;
+
+export function getBattleSource(): BattleSource {
+  if (instance) return instance;
+  instance =
+    process.env.NEXT_PUBLIC_ARENA_SOURCE === "api" ? new ApiBattleSource() : new MockBattleSource();
+  return instance;
+}
+
+export type { BattleSource, BlindBattle, Outcome, Reveal, VoteInput, VoteResult } from "./types";

--- a/web/lib/arena/types.ts
+++ b/web/lib/arena/types.ts
@@ -1,0 +1,40 @@
+export type Outcome = "A_WIN" | "B_WIN" | "TIE";
+
+// What the UI renders during the blind phase — never any model identity.
+export interface BlindBattle {
+  battleId: string;
+  prompt: string;
+  audioA: string; // playable by an <audio> element (real URL, or data URI in the mock)
+  audioB: string;
+}
+
+export interface VoteInput {
+  battleId: string;
+  outcome: Outcome;
+  voterId: string;
+}
+
+export interface VoteResult {
+  battleId: string;
+  outcome: Outcome;
+}
+
+// Returned only after the vote lands — de-anonymizes the two cards.
+export interface RevealedModel {
+  provider: string;
+  model: string;
+  label: string;
+}
+
+export interface Reveal {
+  a: RevealedModel;
+  b: RevealedModel;
+}
+
+// The single seam the UI depends on. Swap the implementation (mock <-> api) and the
+// whole battle page keeps working unchanged. See ./README.md.
+export interface BattleSource {
+  createBattle(text: string): Promise<BlindBattle>;
+  submitVote(input: VoteInput): Promise<VoteResult>;
+  reveal(battleId: string): Promise<Reveal>;
+}


### PR DESCRIPTION
Blind A/B voting page at `/arena`: write a prompt, generate two voices, listen, vote (Model A / Tie / Model B), then reveal each side's provider and model. Cards stay neutral so identity never leaks before the vote.

Runs on the mock battle-source, so no backend is needed. Votes are not persisted yet; wiring the real API (`/api/arena/*` proxy routes + `NEXT_PUBLIC_ARENA_SOURCE=api`) is a follow-up.

Access: `/arena` is gated by the cookie middleware in #160. Merge #160 first so the page is not yet publicly visible.

Out of scope: the arena leaderboard. The "View leaderboard" button is a placeholder for that future page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Launched an Arena multi-step experience to generate blind speech from a text prompt, listen to two audio options, and cast a vote (Model A, Model B, or Tie).
  * Added an Audio Player with play/pause controls, progress bar, duration display, and smooth switching behavior between active players.
  * Added post-vote reveal to show the corresponding model/provider identities (with the UI handling reveal failures gracefully).
  * Persisted a consistent voter identity across arena sessions for each device.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds the Voice Arena `/arena` page: users enter a prompt, two TTS models synthesise audio clips (behind randomised A/B labels), the user listens and votes, then the identities are revealed. The full flow is driven by a `BattleSource` seam with a self-contained mock (WAV tone data-URIs, in-memory reveal map) and a stubbed `ApiBattleSource` ready for when the backend routes land.

- **Arena page (`page.tsx`)**: run-token cancellation prevents stale `createBattle` responses from landing; `castVote` uses nested try/catch so a failed `reveal` never rolls back a successfully recorded vote; `useVoterId` uses a `useRef`-based lazy initialiser to read `localStorage` synchronously on the first render, avoiding an empty-string race window.
- **AudioPlayer**: single-playback focus via `isActive` prop, pause-on-unmount cleanup, and `onEnded` rewind to rearm for replay — previously flagged bugs in all three areas have been addressed in this version.
- **Mock source**: uses random-splice selection (uniform distribution) instead of the previously flagged biased `sort(() => Math.random() - 0.5)` shuffle.

<h3>Confidence Score: 5/5</h3>

Safe to merge behind the cookie gate from #160 — all previously flagged bugs are resolved and no new blocking issues were found.

The three issues raised in prior review rounds (currentTime rewind on every play, biased shuffle, and empty voterId on first render) are all cleanly addressed. The only remaining notes are that the audio player's time display is static total duration rather than a live elapsed counter, and that RevealedModel.label is defined and populated by the mock but never rendered in the reveal card — neither affects correctness or data integrity.

No files require special attention. The RevealedModel.label field in types.ts and mockSource.ts is worth a second look when the real API source is wired up, to confirm whether the backend sends a friendly label and whether BattleCard should render it.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| web/app/arena/page.tsx | Main arena page: implements 3-step flow (prompt → listen → vote), run-token cancellation for stale battles, useRef-based voterId init, and nested try/catch for vote+reveal. Logic is sound with no blocking issues. |
| web/app/arena/components/AudioPlayer.tsx | Audio player with single-playback focus, pause-on-unmount cleanup, and onEnded rearm. Previously flagged currentTime=0 bug is resolved. Duration display is static (total only, no elapsed counter). |
| web/lib/arena/mockSource.ts | Self-contained mock using WAV data URIs and random-splice model selection (uniform, not sort-based). In-memory assignment map enables reveal. toRevealed() populates the label field which BattleCard never renders. |
| web/lib/arena/source.ts | Module-level singleton factory switching between mock and API source via NEXT_PUBLIC_ARENA_SOURCE. Straightforward and correct. |
| web/lib/arena/apiSource.ts | BFF proxy adapter with AbortSignal.timeout hang-backstops, encodeURIComponent for the reveal path param, and differentiated timeout budgets for synthesis vs DB ops. Inert until NEXT_PUBLIC_ARENA_SOURCE=api. |
| web/lib/arena/types.ts | Clean type definitions for the arena seam. RevealedModel includes a label field that is unused in the UI reveal screen. |
| web/lib/arena/arena.test.ts | Six unit tests covering blind payload shape, model distinctness, reveal, unknown-battle error paths, and singleton factory. Good coverage of the mock contract. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant U as User
    participant P as ArenaPage
    participant S as BattleSource (mock/api)
    participant A as AudioPlayer (A & B)

    U->>P: "Enter text & click Generate speech"
    P->>S: createBattle(text)
    S-->>P: "BlindBattle { battleId, audioA, audioB }"
    P->>A: "render with src=audioA / src=audioB"
    P-->>U: Show vote buttons (step 2)

    U->>A: Click play (player A)
    A->>A: onActivate() setActive(a)
    A->>A: el.play()
    Note over A: Player B auto-pauses via isActive effect

    U->>P: Click Model A vote button
    P->>S: "submitVote({ battleId, outcome: A_WIN, voterId })"
    S-->>P: VoteResult
    P->>S: reveal(battleId)
    S-->>P: "Reveal { a: RevealedModel, b: RevealedModel }"
    P-->>U: Show revealed models + Battle recorded (step 4)

    U->>P: Click New battle
    P->>P: reset() step 1, battle null
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant U as User
    participant P as ArenaPage
    participant S as BattleSource (mock/api)
    participant A as AudioPlayer (A & B)

    U->>P: "Enter text & click Generate speech"
    P->>S: createBattle(text)
    S-->>P: "BlindBattle { battleId, audioA, audioB }"
    P->>A: "render with src=audioA / src=audioB"
    P-->>U: Show vote buttons (step 2)

    U->>A: Click play (player A)
    A->>A: onActivate() setActive(a)
    A->>A: el.play()
    Note over A: Player B auto-pauses via isActive effect

    U->>P: Click Model A vote button
    P->>S: "submitVote({ battleId, outcome: A_WIN, voterId })"
    S-->>P: VoteResult
    P->>S: reveal(battleId)
    S-->>P: "Reveal { a: RevealedModel, b: RevealedModel }"
    P-->>U: Show revealed models + Battle recorded (step 4)

    U->>P: Click New battle
    P->>P: reset() step 1, battle null
```

</a>

<sub>Reviews (3): Last reviewed commit: ["Address CodeRabbit review on voting UI"](https://github.com/coval-ai/benchmarks/commit/94a00173d935fe02ca54906d766a5342e71678dc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39185234)</sub>

<!-- /greptile_comment -->