### PR TITLE
Add Voice Arena on-demand battle generation

### DIFF
--- a/runner/src/coval_bench/__main__.py
+++ b/runner/src/coval_bench/__main__.py
@@ -215,5 +215,42 @@ def arena_snapshot(metric: str, bootstrap_rounds: int, seed: int, force: bool) -
         click.echo(json.dumps({"event": "arena_snapshot", "metric": metric, "models": written}))
 
 
+@arena.command(name="seed-battles")
+@click.option(
+    "--per-domain",
+    default=1,
+    show_default=True,
+    type=int,
+    help="Demo battles to generate per domain (uses real TTS credits).",
+)
+def arena_seed_battles(per_domain: int) -> None:
+    """Generate real demo battles from example prompts so a labeler can vote."""
+    from coval_bench.arena.prompts import EXAMPLE_PROMPTS
+    from coval_bench.arena.seed import seed_demo_battles
+    from coval_bench.config import get_settings
+    from coval_bench.db.arena_store import ArenaStore
+    from coval_bench.db.conn import lifespan_pool
+    from coval_bench.db.models import Battle
+
+    async def _run() -> list[Battle]:
+        settings = get_settings()
+        async with lifespan_pool(settings) as pool:
+            return await seed_demo_battles(settings, ArenaStore(pool), per_domain=per_domain)
+
+    battles = asyncio.run(_run())
+    attempted = sum(min(per_domain, len(prompts)) for prompts in EXAMPLE_PROMPTS.values())
+    click.echo(
+        json.dumps(
+            {
+                "event": "arena_seed_battles",
+                "attempted": attempted,
+                "created": len(battles),
+                "skipped": attempted - len(battles),
+                "battles": [{"id": str(b.id), "domain": b.domain} for b in battles],
+            }
+        )
+    )
+
+
 if __name__ == "__main__":
     cli()

--- a/runner/src/coval_bench/__main__.py
+++ b/runner/src/coval_bench/__main__.py
@@ -220,7 +220,7 @@ def arena_snapshot(metric: str, bootstrap_rounds: int, seed: int, force: bool) -
     "--per-domain",
     default=1,
     show_default=True,
-    type=int,
+    type=click.IntRange(min=0),
     help="Demo battles to generate per domain (uses real TTS credits).",
 )
 def arena_seed_battles(per_domain: int) -> None:

--- a/runner/src/coval_bench/api/app.py
+++ b/runner/src/coval_bench/api/app.py
@@ -22,6 +22,7 @@ from contextlib import asynccontextmanager
 import structlog
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.staticfiles import StaticFiles
 from posthog import Posthog
 from slowapi.errors import RateLimitExceeded
 from slowapi.middleware import SlowAPIMiddleware
@@ -125,5 +126,12 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     app.include_router(leaderboard.router, prefix="/v1")
     app.include_router(providers.router, prefix="/v1")
     app.include_router(arena.router, prefix="/v1")
+
+    # Serve locally-generated arena clips when no external audio host is set
+    # (prod points arena_audio_base_url at the GCS/CDN origin instead).
+    if not resolved.arena_audio_base_url:
+        clips_dir = resolved.arena_audio_dir / "clips"
+        clips_dir.mkdir(parents=True, exist_ok=True)
+        app.mount("/clips", StaticFiles(directory=clips_dir), name="clips")
 
     return app

--- a/runner/src/coval_bench/api/routers/arena.py
+++ b/runner/src/coval_bench/api/routers/arena.py
@@ -216,7 +216,10 @@ async def create_battle(
     if not prompt:
         raise HTTPException(422, "prompt must not be empty")
 
-    pair = select_pair(active_tts_models())
+    models = active_tts_models()
+    if len(models) < 2:
+        raise HTTPException(503, "not enough active TTS models to form a battle")
+    pair = select_pair(models)
     battle = await generate_battle(
         settings,
         ArenaStore(pool),

--- a/runner/src/coval_bench/api/routers/arena.py
+++ b/runner/src/coval_bench/api/routers/arena.py
@@ -34,11 +34,14 @@ from coval_bench.api.deps import capture_api_event, get_pool, get_posthog, get_s
 from coval_bench.api.ratelimit import limiter
 from coval_bench.api.schemas import (
     ArenaLeaderboardResponse,
+    BattleCreate,
     BattleOut,
     LeaderboardEntryOut,
     VoteIn,
     VoteOut,
 )
+from coval_bench.arena.generate import generate_battle
+from coval_bench.arena.pairing import active_tts_models, select_pair
 from coval_bench.config import Settings
 from coval_bench.db.arena_store import ArenaStore
 from coval_bench.db.models import VoteOutcome, VoterType
@@ -193,3 +196,40 @@ async def cast_vote(
         },
     )
     return VoteOut.model_validate(recorded.model_dump())
+
+
+@router.post("/arena/battle", response_model=BattleOut, status_code=201)
+@limiter.limit("60/minute")
+async def create_battle(
+    request: Request,  # required by slowapi
+    body: BattleCreate,
+    pool: AsyncConnectionPool[Any] = Depends(get_pool),
+    settings: Settings = Depends(get_settings),
+    posthog_client: Posthog | None = Depends(get_posthog),
+) -> BattleOut:
+    """Generate a battle from a prompt: pick two models, synthesize, persist (blind).
+
+    Pairing is uniform random here; adaptive pairing lands in a later PR. Returns
+    502 if either side fails to synthesize (no battle is written).
+    """
+    prompt = body.prompt.strip()
+    if not prompt:
+        raise HTTPException(422, "prompt must not be empty")
+
+    pair = select_pair(active_tts_models())
+    battle = await generate_battle(
+        settings,
+        ArenaStore(pool),
+        prompt=prompt,
+        domain=body.domain,
+        pair=pair,
+    )
+    if battle is None:
+        raise HTTPException(502, "audio synthesis failed for one or both models")
+
+    capture_api_event(
+        posthog_client,
+        "arena_battle_generated",
+        {"$process_person_profile": False},
+    )
+    return BattleOut.model_validate(battle.model_dump())

--- a/runner/src/coval_bench/api/schemas.py
+++ b/runner/src/coval_bench/api/schemas.py
@@ -178,6 +178,13 @@ class BattleOut(BaseModel):
     audio_b_url: str
 
 
+class BattleCreate(BaseModel):
+    """Request to generate a new battle from a user prompt."""
+
+    prompt: str
+    domain: str | None = None
+
+
 class LeaderboardEntryOut(BaseModel):
     """One model's row within an arena leaderboard board."""
 

--- a/runner/src/coval_bench/api/schemas.py
+++ b/runner/src/coval_bench/api/schemas.py
@@ -14,7 +14,7 @@ import uuid
 from datetime import datetime
 from typing import Literal
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 from coval_bench.api.common import BenchmarkLiteral, WindowLiteral
 
@@ -181,7 +181,7 @@ class BattleOut(BaseModel):
 class BattleCreate(BaseModel):
     """Request to generate a new battle from a user prompt."""
 
-    prompt: str
+    prompt: str = Field(..., max_length=500)
     domain: str | None = None
 
 

--- a/runner/src/coval_bench/arena/audio_store.py
+++ b/runner/src/coval_bench/arena/audio_store.py
@@ -1,0 +1,34 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Storage for generated arena clips: move a synthesized WAV into durable storage.
+
+Local-dir backend for dev; a GCS backend reimplements just ``store_clip`` later
+(generate key -> upload -> return URL) without touching callers. Keys are random
+and opaque so a served URL never reveals which model produced it (blind voting) —
+identity is recovered from ``arena.battles``, never the filename.
+"""
+
+from __future__ import annotations
+
+import shutil
+import uuid
+from pathlib import Path
+
+from coval_bench.config import Settings
+
+
+def store_clip(settings: Settings, src_path: Path) -> str:
+    """Move a synthesized WAV into arena storage under a fresh opaque key; return its URL.
+
+    The source is a provider's temp WAV (``TTSResult.audio_path``); we own it once
+    synthesis returns, so it is moved, not copied. The URL prepends
+    ``arena_audio_base_url`` when set, else is root-relative for the web layer.
+    """
+    key = f"clips/{uuid.uuid4().hex}.wav"
+    dest = settings.arena_audio_dir / key
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    shutil.move(str(src_path), dest)
+
+    base = settings.arena_audio_base_url.rstrip("/")
+    return f"{base}/{key}" if base else f"/{key}"

--- a/runner/src/coval_bench/arena/generate.py
+++ b/runner/src/coval_bench/arena/generate.py
@@ -28,6 +28,8 @@ from coval_bench.registries.models import RegisteredModel
 
 logger: structlog.BoundLogger = structlog.get_logger(__name__)
 
+_SYNTH_TIMEOUT_S = 60.0
+
 
 async def generate_battle(
     settings: Settings,
@@ -95,7 +97,17 @@ async def _synthesize(settings: Settings, model: RegisteredModel, prompt: str) -
 
     try:
         provider = provider_cls(settings=settings, model=model.model, voice=model.voice)
-        result: TTSResult = await provider.synthesize(prompt)
+        result: TTSResult = await asyncio.wait_for(
+            provider.synthesize(prompt), timeout=_SYNTH_TIMEOUT_S
+        )
+    except TimeoutError:
+        logger.warning(
+            "arena_synthesis_timeout",
+            provider=model.provider,
+            model=model.model,
+            timeout_s=_SYNTH_TIMEOUT_S,
+        )
+        return None
     except Exception as exc:
         logger.warning(
             "arena_synthesis_exception",

--- a/runner/src/coval_bench/arena/generate.py
+++ b/runner/src/coval_bench/arena/generate.py
@@ -93,8 +93,17 @@ async def _synthesize(settings: Settings, model: RegisteredModel, prompt: str) -
         logger.warning("arena_missing_voice", provider=model.provider, model=model.model)
         return None
 
-    provider = provider_cls(settings=settings, model=model.model, voice=model.voice)
-    result: TTSResult = await provider.synthesize(prompt)
+    try:
+        provider = provider_cls(settings=settings, model=model.model, voice=model.voice)
+        result: TTSResult = await provider.synthesize(prompt)
+    except Exception as exc:
+        logger.warning(
+            "arena_synthesis_exception",
+            provider=model.provider,
+            model=model.model,
+            error=str(exc),
+        )
+        return None
     if result.error is not None or result.audio_path is None:
         logger.warning(
             "arena_synthesis_failed",

--- a/runner/src/coval_bench/arena/generate.py
+++ b/runner/src/coval_bench/arena/generate.py
@@ -54,6 +54,9 @@ async def generate_battle(
         _synthesize(settings, model_b, prompt),
     )
     if path_a is None or path_b is None:
+        for path in (path_a, path_b):
+            if path is not None:
+                path.unlink(missing_ok=True)
         logger.warning(
             "arena_battle_generation_failed",
             domain=domain,
@@ -116,7 +119,7 @@ async def _synthesize(settings: Settings, model: RegisteredModel, prompt: str) -
             error=str(exc),
         )
         return None
-    if result.error is not None or result.audio_path is None:
+    if result.error is not None or result.audio_path is None or not result.audio_path.is_file():
         logger.warning(
             "arena_synthesis_failed",
             provider=model.provider,

--- a/runner/src/coval_bench/arena/generate.py
+++ b/runner/src/coval_bench/arena/generate.py
@@ -1,0 +1,107 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""On-demand battle generation: synthesize a model pair on a prompt, persist a battle.
+
+Both sides speak the same prompt (fairness). Which model lands as A vs B is
+randomized to avoid position bias in voting. Synthesis runs concurrently to keep
+the request fast. A battle is persisted only if both sides succeed — the
+``audio_*_url`` columns are NOT NULL, so a half-synthesized battle is never stored.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import random
+from pathlib import Path
+from typing import Any
+
+import structlog
+
+from coval_bench.arena.audio_store import store_clip
+from coval_bench.config import Settings
+from coval_bench.db.arena_store import ArenaStore
+from coval_bench.db.models import Battle
+from coval_bench.providers.base import TTSResult
+from coval_bench.providers.tts import TTS_PROVIDERS
+from coval_bench.registries.models import RegisteredModel
+
+logger: structlog.BoundLogger = structlog.get_logger(__name__)
+
+
+async def generate_battle(
+    settings: Settings,
+    store: ArenaStore,
+    *,
+    prompt: str,
+    domain: str | None,
+    pair: tuple[RegisteredModel, RegisteredModel],
+    rng: random.Random | None = None,
+) -> Battle | None:
+    """Synthesize both sides of *pair* on *prompt*, store the clips, persist a battle.
+
+    Returns the inserted ``Battle``, or ``None`` if either synthesis fails (no row
+    is written). ``rng`` is injectable so the A/B assignment is deterministic in tests.
+    """
+    picker = rng if rng is not None else random.Random()  # noqa: S311
+    first, second = pair
+    model_a, model_b = (first, second) if picker.random() < 0.5 else (second, first)
+
+    path_a, path_b = await asyncio.gather(
+        _synthesize(settings, model_a, prompt),
+        _synthesize(settings, model_b, prompt),
+    )
+    if path_a is None or path_b is None:
+        logger.warning(
+            "arena_battle_generation_failed",
+            domain=domain,
+            model_a=f"{model_a.provider}:{model_a.model}",
+            model_b=f"{model_b.provider}:{model_b.model}",
+            failed_a=path_a is None,
+            failed_b=path_b is None,
+        )
+        return None
+
+    battle = Battle(
+        provider_a=model_a.provider,
+        model_a=model_a.model,
+        provider_b=model_b.provider,
+        model_b=model_b.model,
+        domain=domain,
+        prompt_text=prompt,
+        audio_a_url=store_clip(settings, path_a),
+        audio_b_url=store_clip(settings, path_b),
+    )
+    inserted = await store.insert_battle(battle)
+    logger.info(
+        "arena_battle_created",
+        battle_id=str(inserted.id),
+        domain=domain,
+        model_a=f"{model_a.provider}:{model_a.model}",
+        model_b=f"{model_b.provider}:{model_b.model}",
+    )
+    return inserted
+
+
+async def _synthesize(settings: Settings, model: RegisteredModel, prompt: str) -> Path | None:
+    """Synthesize one side; return its WAV path, or ``None`` on any failure."""
+    provider_cls: Any = TTS_PROVIDERS.get(model.provider)
+    if provider_cls is None:
+        logger.warning("arena_unknown_provider", provider=model.provider, model=model.model)
+        return None
+    if model.voice is None:
+        logger.warning("arena_missing_voice", provider=model.provider, model=model.model)
+        return None
+
+    provider = provider_cls(settings=settings, model=model.model, voice=model.voice)
+    result: TTSResult = await provider.synthesize(prompt)
+    if result.error is not None or result.audio_path is None:
+        logger.warning(
+            "arena_synthesis_failed",
+            provider=model.provider,
+            model=model.model,
+            reason="provider_error" if result.error is not None else "no_audio",
+            error=result.error,
+        )
+        return None
+    return result.audio_path

--- a/runner/src/coval_bench/arena/pairing.py
+++ b/runner/src/coval_bench/arena/pairing.py
@@ -1,0 +1,43 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Model pairing for arena battles.
+
+Uniform-random selection (cold-start strategy): pick two distinct models for an
+incoming prompt. A later adaptive strategy will weight by rating uncertainty and
+closeness (CI reduction); this function is the seam it slots into — the caller
+stays the same, only the selection changes.
+"""
+
+from __future__ import annotations
+
+import random
+from collections.abc import Sequence
+
+from coval_bench.registries.benchmarks import Benchmark
+from coval_bench.registries.models import MODEL_REGISTRY, ModelStatus, RegisteredModel
+
+
+def active_tts_models() -> list[RegisteredModel]:
+    """The arena roster: every ACTIVE TTS model in the registry."""
+    return [
+        m for m in MODEL_REGISTRY if m.benchmark is Benchmark.TTS and m.status is ModelStatus.ACTIVE
+    ]
+
+
+def select_pair(
+    models: Sequence[RegisteredModel],
+    *,
+    rng: random.Random | None = None,
+) -> tuple[RegisteredModel, RegisteredModel]:
+    """Pick two distinct models to battle, uniformly at random.
+
+    ``rng`` is injectable for deterministic tests. Raises if fewer than two
+    models are available. ``random.sample`` guarantees the two are distinct, so a
+    self-battle is impossible.
+    """
+    if len(models) < 2:
+        raise ValueError("need at least two models to form a battle")
+    picker = rng if rng is not None else random.Random()  # noqa: S311
+    first, second = picker.sample(list(models), 2)
+    return first, second

--- a/runner/src/coval_bench/arena/prompts.py
+++ b/runner/src/coval_bench/arena/prompts.py
@@ -1,0 +1,29 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Example prompts per domain for seeding demo battles.
+
+The arena's real prompts are user-written; these are a small fixture so a labeler
+has battles to vote on before any user prompts arrive. Keys are the launch domains
+and are stored verbatim as a battle's ``domain``.
+"""
+
+from __future__ import annotations
+
+EXAMPLE_PROMPTS: dict[str, list[str]] = {
+    "customer service": [
+        "Thanks for holding — I've found your order and it'll ship today.",
+        "I'm sorry for the trouble; let me refund that charge right now.",
+        "Your appointment is confirmed for Tuesday at nine in the morning.",
+    ],
+    "insurance": [
+        "Your claim has been approved and payment will arrive within five business days.",
+        "This policy covers water damage but excludes flooding from natural disasters.",
+        "To file a claim, I'll need your policy number and the date of the incident.",
+    ],
+    "healthcare": [
+        "Your test results came back normal, so no follow-up is needed.",
+        "Please take this medication twice daily with food.",
+        "The doctor will see you now; the visit usually takes about fifteen minutes.",
+    ],
+}

--- a/runner/src/coval_bench/arena/seed.py
+++ b/runner/src/coval_bench/arena/seed.py
@@ -1,0 +1,59 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Seed a few demo battles from the example prompts.
+
+A dev fixture so a labeler has battles to vote on before real user prompts arrive.
+Each call generates ``per_domain`` battles per domain, using uniform pairing and
+real synthesis (so it needs the TTS provider keys, like the benchmark runner).
+"""
+
+from __future__ import annotations
+
+import random
+
+import structlog
+
+from coval_bench.arena.generate import generate_battle
+from coval_bench.arena.pairing import active_tts_models, select_pair
+from coval_bench.arena.prompts import EXAMPLE_PROMPTS
+from coval_bench.config import Settings
+from coval_bench.db.arena_store import ArenaStore
+from coval_bench.db.models import Battle
+
+logger: structlog.BoundLogger = structlog.get_logger(__name__)
+
+
+async def seed_demo_battles(
+    settings: Settings,
+    store: ArenaStore,
+    *,
+    per_domain: int = 1,
+    rng: random.Random | None = None,
+) -> list[Battle]:
+    """Generate up to ``per_domain`` demo battles for each example domain.
+
+    Returns the battles that were created. A side whose synthesis fails is skipped
+    (logged), never inserted — so the result may be shorter than requested.
+    """
+    picker = rng if rng is not None else random.Random()  # noqa: S311
+    models = active_tts_models()
+    created: list[Battle] = []
+
+    for domain, prompts in EXAMPLE_PROMPTS.items():
+        for prompt in prompts[:per_domain]:
+            pair = select_pair(models, rng=picker)
+            battle = await generate_battle(
+                settings,
+                store,
+                prompt=prompt,
+                domain=domain,
+                pair=pair,
+                rng=picker,
+            )
+            if battle is None:
+                logger.warning("arena_seed_skipped", domain=domain, prompt=prompt)
+                continue
+            created.append(battle)
+
+    return created

--- a/runner/src/coval_bench/config.py
+++ b/runner/src/coval_bench/config.py
@@ -105,6 +105,8 @@ class Settings(BaseSettings):
 
     # --- Arena ---
     arena_labeler_key: SecretStr | None = None
+    arena_audio_dir: Path = Path("arena-audio")
+    arena_audio_base_url: str = ""
 
 
 @functools.lru_cache(maxsize=1)

--- a/runner/tests/api/test_arena.py
+++ b/runner/tests/api/test_arena.py
@@ -1,16 +1,20 @@
 # Copyright 2026 The Coval Benchmarks Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Tests for the Voice Arena endpoints (GET /v1/arena/*, POST /v1/arena/vote)."""
+"""Tests for the Voice Arena endpoints (GET/POST /v1/arena/*)."""
 
 from __future__ import annotations
 
 from datetime import UTC, datetime
+from pathlib import Path
 from typing import Any
 
 import psycopg
+import pytest
 from httpx import AsyncClient
 
+from coval_bench.arena.pairing import active_tts_models
+from coval_bench.providers.base import TTSResult
 from tests.api.conftest import ARENA_LABELER_KEY, _make_db_url
 
 
@@ -474,3 +478,84 @@ async def test_vote_with_invalid_outcome_is_422(client: AsyncClient, postgresql:
         headers=_LABELER_HEADERS,
     )
     assert response.status_code == 422
+
+
+def _fake_tts_providers(fail_models: set[str]) -> dict[str, type]:
+    """A fake TTS_PROVIDERS map: every roster provider returns a stub WAV path.
+
+    Models named in *fail_models* return an error instead, to drive the failure path.
+    """
+
+    class _FakeTTS:
+        def __init__(self, settings: Any, model: str, voice: str) -> None:
+            self.model = model
+
+        async def synthesize(self, text: str) -> TTSResult:
+            if self.model in fail_models:
+                return TTSResult(
+                    provider="fake",
+                    model=self.model,
+                    voice="v",
+                    ttfa_ms=None,
+                    audio_path=None,
+                    error="boom",
+                )
+            return TTSResult(
+                provider="fake",
+                model=self.model,
+                voice="v",
+                ttfa_ms=1.0,
+                audio_path=Path(f"{self.model}.wav"),
+                error=None,
+            )
+
+    return {m.provider: _FakeTTS for m in active_tts_models()}
+
+
+async def test_create_battle_returns_blind_battle(
+    client: AsyncClient, postgresql: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """POST /arena/battle synthesizes a pair and returns a blind battle (201)."""
+    await _apply_arena_schema(_make_db_url(postgresql))
+    monkeypatch.setattr("coval_bench.arena.generate.TTS_PROVIDERS", _fake_tts_providers(set()))
+    monkeypatch.setattr(
+        "coval_bench.arena.generate.store_clip", lambda settings, src: f"/clips/{src.name}"
+    )
+
+    response = await client.post(
+        "/v1/arena/battle",
+        json={"prompt": "Your appointment is confirmed.", "domain": "customer service"},
+    )
+
+    assert response.status_code == 201
+    data = response.json()
+    assert set(data) == {"id", "prompt_text", "domain", "audio_a_url", "audio_b_url"}
+    assert "provider_a" not in data
+    assert "model_a" not in data
+    assert data["prompt_text"] == "Your appointment is confirmed."
+    assert data["domain"] == "customer service"
+    assert data["audio_a_url"].startswith("/clips/")
+
+
+async def test_create_battle_rejects_empty_prompt(client: AsyncClient, postgresql: Any) -> None:
+    """A blank prompt is rejected with 422 — no synthesis attempted."""
+    await _apply_arena_schema(_make_db_url(postgresql))
+    response = await client.post("/v1/arena/battle", json={"prompt": "   "})
+    assert response.status_code == 422
+
+
+async def test_create_battle_502_when_synthesis_fails(
+    client: AsyncClient, postgresql: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """If synthesis fails, no battle is persisted and the endpoint returns 502."""
+    await _apply_arena_schema(_make_db_url(postgresql))
+    every_model = {m.model for m in active_tts_models()}
+    monkeypatch.setattr(
+        "coval_bench.arena.generate.TTS_PROVIDERS", _fake_tts_providers(every_model)
+    )
+    monkeypatch.setattr(
+        "coval_bench.arena.generate.store_clip", lambda settings, src: "/clips/x.wav"
+    )
+
+    response = await client.post("/v1/arena/battle", json={"prompt": "hello"})
+    assert response.status_code == 502

--- a/runner/tests/api/test_arena.py
+++ b/runner/tests/api/test_arena.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import tempfile
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -500,12 +501,14 @@ def _fake_tts_providers(fail_models: set[str]) -> dict[str, type]:
                     audio_path=None,
                     error="boom",
                 )
+            with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as handle:
+                path = Path(handle.name)
             return TTSResult(
                 provider="fake",
                 model=self.model,
                 voice="v",
                 ttfa_ms=1.0,
-                audio_path=Path(f"{self.model}.wav"),
+                audio_path=path,
                 error=None,
             )
 

--- a/runner/tests/unit/test_arena_generate.py
+++ b/runner/tests/unit/test_arena_generate.py
@@ -1,0 +1,130 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for on-demand battle generation (stubbed TTS — no real upstream calls)."""
+
+from __future__ import annotations
+
+import random
+import wave
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+
+from coval_bench.arena import generate as generate_module
+from coval_bench.arena.generate import generate_battle
+from coval_bench.config import Settings
+from coval_bench.db.models import Battle
+from coval_bench.providers.base import TTSResult
+from coval_bench.registries.benchmarks import Benchmark
+from coval_bench.registries.models import ModelStatus, RegisteredModel
+
+
+def _model(provider: str, model: str) -> RegisteredModel:
+    return RegisteredModel(
+        benchmark=Benchmark.TTS,
+        provider=provider,
+        model=model,
+        voice="v",
+        status=ModelStatus.ACTIVE,
+    )
+
+
+def _write_wav(path: Path) -> None:
+    with wave.open(str(path), "wb") as handle:
+        handle.setnchannels(1)
+        handle.setsampwidth(2)
+        handle.setframerate(24000)
+        handle.writeframes(b"\x00\x00" * 100)
+
+
+def _fake_provider_cls(tmp_path: Path, fail_models: set[str]) -> type:
+    """A stub TTS provider: writes a tiny WAV, or returns an error for *fail_models*."""
+
+    class _FakeProvider:
+        def __init__(self, settings: Settings, model: str, voice: str) -> None:
+            self.model = model
+
+        async def synthesize(self, text: str) -> TTSResult:
+            if self.model in fail_models:
+                return TTSResult(
+                    provider="fake",
+                    model=self.model,
+                    voice="v",
+                    ttfa_ms=None,
+                    audio_path=None,
+                    error="synth boom",
+                )
+            path = tmp_path / f"{self.model}-{uuid4().hex}.wav"
+            _write_wav(path)
+            return TTSResult(
+                provider="fake",
+                model=self.model,
+                voice="v",
+                ttfa_ms=12.0,
+                audio_path=path,
+                error=None,
+            )
+
+    return _FakeProvider
+
+
+class _FakeStore:
+    """Minimal ArenaStore stand-in: records inserts and assigns an id."""
+
+    def __init__(self) -> None:
+        self.inserted: list[Battle] = []
+
+    async def insert_battle(self, battle: Battle) -> Battle:
+        stored = battle.model_copy(update={"id": uuid4()})
+        self.inserted.append(stored)
+        return stored
+
+
+async def test_generate_battle_success(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    models = (_model("provider-a", "model-a"), _model("provider-b", "model-b"))
+    provider = _fake_provider_cls(tmp_path, fail_models=set())
+    monkeypatch.setattr(generate_module, "TTS_PROVIDERS", {m.provider: provider for m in models})
+    settings = Settings(arena_audio_dir=tmp_path / "store")
+    store = _FakeStore()
+
+    prompt = "Your test results came back normal, so no follow-up is needed."
+    battle = await generate_battle(
+        settings,
+        store,  # type: ignore[arg-type]
+        prompt=prompt,
+        domain="healthcare",
+        pair=models,
+        rng=random.Random(0),
+    )
+
+    assert battle is not None
+    assert battle.id is not None
+    assert battle.domain == "healthcare"
+    assert battle.prompt_text == prompt
+    assert {battle.model_a, battle.model_b} == {"model-a", "model-b"}
+    for url in (battle.audio_a_url, battle.audio_b_url):
+        assert (settings.arena_audio_dir / url.lstrip("/")).is_file()
+
+
+async def test_generate_battle_skips_when_a_side_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    models = (_model("provider-a", "model-a"), _model("provider-b", "model-b"))
+    provider = _fake_provider_cls(tmp_path, fail_models={"model-b"})
+    monkeypatch.setattr(generate_module, "TTS_PROVIDERS", {m.provider: provider for m in models})
+    settings = Settings(arena_audio_dir=tmp_path / "store")
+    store = _FakeStore()
+
+    battle = await generate_battle(
+        settings,
+        store,  # type: ignore[arg-type]
+        prompt="Your claim has been approved and payment will arrive within five business days.",
+        domain="insurance",
+        pair=models,
+        rng=random.Random(0),
+    )
+
+    assert battle is None
+    assert store.inserted == []

--- a/runner/tests/unit/test_arena_pairing.py
+++ b/runner/tests/unit/test_arena_pairing.py
@@ -1,0 +1,49 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for arena model pairing (uniform strategy)."""
+
+from __future__ import annotations
+
+import random
+
+import pytest
+
+from coval_bench.arena.pairing import active_tts_models, select_pair
+from coval_bench.registries.benchmarks import Benchmark
+from coval_bench.registries.models import ModelStatus, RegisteredModel
+
+
+def _model(name: str) -> RegisteredModel:
+    return RegisteredModel(
+        benchmark=Benchmark.TTS,
+        provider=name,
+        model=name,
+        voice="v",
+        status=ModelStatus.ACTIVE,
+    )
+
+
+_MODELS = [_model("a"), _model("b"), _model("c")]
+
+
+def test_select_pair_returns_two_distinct() -> None:
+    first, second = select_pair(_MODELS, rng=random.Random(1))
+    assert first in _MODELS
+    assert second in _MODELS
+    assert first is not second
+
+
+def test_select_pair_requires_two_models() -> None:
+    with pytest.raises(ValueError, match="at least two"):
+        select_pair(_MODELS[:1])
+
+
+def test_select_pair_is_deterministic_with_seed() -> None:
+    assert select_pair(_MODELS, rng=random.Random(7)) == select_pair(_MODELS, rng=random.Random(7))
+
+
+def test_active_tts_models_are_tts_and_active() -> None:
+    roster = active_tts_models()
+    assert len(roster) >= 2
+    assert all(m.benchmark is Benchmark.TTS and m.status is ModelStatus.ACTIVE for m in roster)


### PR DESCRIPTION
Adds on-demand battle generation for the Voice Arena. `POST /arena/battle` takes a prompt, picks two models, synthesizes both with the existing TTS providers, stores the clips, and persists a blinded battle to vote on.

- **Pairing** is uniform-random for now; adaptive pairing is a follow-up PR.
- **Audio** reuses the providers' existing WAV output. Clips go to local-dir storage under opaque keys (a GCS backend swaps in later); battle responses stay blind — no model identities leak.
- **`arena seed-battles`** CLI generates a few demo battles from example prompts (customer service / insurance / healthcare) so a labeler can start voting.

Stacked on the snapshot-job branch. No changes to rating, snapshot, vote, or benchmark code.

Tests cover pairing, generation (stubbed TTS — no real calls or credits), and the endpoint (happy path, blinding, empty-prompt 422, synthesis-failure 502). `ruff`, `ruff format`, and `mypy --strict` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added API endpoint to create voice battles from user prompts.
  * Added CLI command to seed demo battles using example prompts across launch domains.
  * Implemented blind battle mode where competing models remain hidden during voting.
  * Added audio synthesis and persistent storage system for battle content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds on-demand battle generation for the Voice Arena: a new `POST /arena/battle` endpoint accepts a prompt, picks two models via uniform-random pairing, runs concurrent TTS synthesis, stores the resulting WAV clips under opaque keys, and persists a blind battle row. A new `arena seed-battles` CLI command pre-populates battles from example prompts across three launch domains.

- `generate.py` + `audio_store.py`: concurrent synthesis via `asyncio.gather`, full exception handling in `_synthesize`, WAV cleanup on partial failure, and opaque UUID keys to keep voting blind.
- `pairing.py` + `seed.py`: uniform-random pair selection with injectable RNG; `seed_demo_battles` is missing the `len(models) < 2` guard that the API endpoint has, which would surface as an unhandled `ValueError` from the CLI if the registry is misconfigured.
- `app.py`: conditionally mounts `StaticFiles` at `/clips` for local dev; the key prefix in `store_clip` aligns correctly with the mount path.

<h3>Confidence Score: 5/5</h3>

Safe to merge; all previously raised concerns are either resolved or acknowledged with a clear follow-up plan.

The core generation path is solid: exceptions from TTS providers are fully caught inside `_synthesize`, concurrent synthesis is correctly guarded, and the blind schema correctly excludes model identity. The only new finding is a missing pre-flight check in the CLI seed helper that the API endpoint already has — it would only surface as an unhandled exception if the model registry is misconfigured, which the existing test suite guards against.

runner/src/coval_bench/arena/seed.py — missing len < 2 guard before the pairing loop.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| runner/src/coval_bench/arena/generate.py | Core battle generation: concurrent synthesis with proper exception handling, cleanup of orphaned WAV on partial failure, and blind A/B assignment via injectable RNG. Clean and well-structured. |
| runner/src/coval_bench/api/routers/arena.py | Adds POST /arena/battle; endpoint is unauthenticated while cast_vote requires X-Labeler-Key — flagged in a prior thread and acknowledged. |
| runner/src/coval_bench/arena/audio_store.py | Thin local-dir storage: moves provider temp WAV to opaque UUID key, returns root-relative or base-URL-prefixed URL. Static-files mount in app.py aligns correctly with the key prefix. |
| runner/src/coval_bench/arena/pairing.py | Uniform-random pair selection with injectable RNG; raises ValueError on < 2 models. API endpoint guards against this; seed.py does not (minor inconsistency). |
| runner/src/coval_bench/arena/seed.py | CLI seeding helper calls select_pair without a len < 2 guard, unlike the API endpoint; would surface as an unhandled ValueError rather than a clean error message. |
| runner/src/coval_bench/api/app.py | Mounts StaticFiles at /clips when arena_audio_base_url is unset; directory created at startup to avoid Starlette startup errors. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant C as Client
    participant R as POST /arena/battle
    participant P as pairing.py
    participant G as generate.py
    participant TTS as TTS Provider (×2)
    participant AS as audio_store.py
    participant DB as ArenaStore / DB

    C->>R: "POST /arena/battle {prompt, domain}"
    R->>P: active_tts_models()
    P-->>R: [model list]
    R->>P: select_pair(models)
    P-->>R: (model_a, model_b)
    R->>G: generate_battle(settings, store, prompt, domain, pair)
    par Concurrent synthesis
        G->>TTS: synthesize(prompt) [model_a]
        TTS-->>G: "TTSResult (path_a | None)"
    and
        G->>TTS: synthesize(prompt) [model_b]
        TTS-->>G: "TTSResult (path_b | None)"
    end
    alt Either side fails
        G-->>R: None
        R-->>C: 502
    else Both succeed
        G->>AS: store_clip(settings, path_a)
        AS-->>G: audio_a_url
        G->>AS: store_clip(settings, path_b)
        AS-->>G: audio_b_url
        G->>DB: insert_battle(battle)
        DB-->>G: Battle (with id)
        G-->>R: Battle
        R-->>C: 201 BattleOut (blind)
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant C as Client
    participant R as POST /arena/battle
    participant P as pairing.py
    participant G as generate.py
    participant TTS as TTS Provider (×2)
    participant AS as audio_store.py
    participant DB as ArenaStore / DB

    C->>R: "POST /arena/battle {prompt, domain}"
    R->>P: active_tts_models()
    P-->>R: [model list]
    R->>P: select_pair(models)
    P-->>R: (model_a, model_b)
    R->>G: generate_battle(settings, store, prompt, domain, pair)
    par Concurrent synthesis
        G->>TTS: synthesize(prompt) [model_a]
        TTS-->>G: "TTSResult (path_a | None)"
    and
        G->>TTS: synthesize(prompt) [model_b]
        TTS-->>G: "TTSResult (path_b | None)"
    end
    alt Either side fails
        G-->>R: None
        R-->>C: 502
    else Both succeed
        G->>AS: store_clip(settings, path_a)
        AS-->>G: audio_a_url
        G->>AS: store_clip(settings, path_b)
        AS-->>G: audio_b_url
        G->>DB: insert_battle(battle)
        DB-->>G: Battle (with id)
        G-->>R: Battle
        R-->>C: 201 BattleOut (blind)
    end
```

</a>

<sub>Reviews (4): Last reviewed commit: ["Require synthesized audio to exist and c..."](https://github.com/coval-ai/benchmarks/commit/50581252d1b1db4b1cb40a72878bf4bae94618b1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39189642)</sub>

<!-- /greptile_comment -->