### PR TITLE
test: add benchmarks ci guardrail selection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
+          ref: ${{ inputs.ref || github.ref }}
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Select guardrails
         id: select
@@ -165,6 +167,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+          persist-credentials: false
 
       - name: Set up Node.js
         uses: actions/setup-node@v6
@@ -202,6 +207,7 @@ jobs:
     steps:
       - name: Check selected guardrails
         env:
+          SELECT_RESULT: ${{ needs.select.result }}
           RUN_RUNNER: ${{ needs.select.outputs.run_runner }}
           RUN_WEB: ${{ needs.select.outputs.run_web }}
           RUNNER_RESULT: ${{ needs.runner-ci.result }}
@@ -210,6 +216,11 @@ jobs:
           set -euo pipefail
 
           failed=0
+
+          if [ "$SELECT_RESULT" != "success" ]; then
+            echo "::error::Guardrail selector failed with result: $SELECT_RESULT"
+            failed=1
+          fi
 
           if [ "$RUN_RUNNER" = "true" ] && [ "$RUNNER_RESULT" != "success" ]; then
             echo "::error::Runner CI was selected but finished with result: $RUNNER_RESULT"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           ref: ${{ inputs.ref || github.ref }}
+          persist-credentials: false
 
       - name: Set up uv
         uses: astral-sh/setup-uv@v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,34 @@ permissions:
   contents: read
 
 jobs:
-  ci:
-    name: Lint / Test / Build
+  select:
+    name: Select CI guardrails
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      run_runner: ${{ steps.select.outputs.run_runner }}
+      run_web: ${{ steps.select.outputs.run_web }}
+      methodology_sensitive: ${{ steps.select.outputs.methodology_sensitive }}
+      methodology_marker: ${{ steps.select.outputs.methodology_marker }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Select guardrails
+        id: select
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          python3 runner/scripts/ci_select.py \
+            --base "origin/$BASE_REF" \
+            --github-output "$GITHUB_OUTPUT"
+
+  runner-ci:
+    name: Runner CI
+    needs: select
+    if: needs.select.outputs.run_runner == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
 
@@ -129,6 +155,78 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+  web-ci:
+    name: Web CI
+    needs: select
+    if: needs.select.outputs.run_web == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+
+      - name: Enable Corepack
+        run: |
+          corepack enable
+          corepack prepare pnpm@10.33.0 --activate
+
+      - name: Install dependencies
+        working-directory: web
+        run: pnpm install --frozen-lockfile
+
+      - name: lint
+        working-directory: web
+        run: pnpm lint
+
+      - name: test
+        working-directory: web
+        run: pnpm test
+
+      - name: build
+        working-directory: web
+        run: pnpm build
+
+  ci:
+    name: Lint / Test / Build
+    needs: [select, runner-ci, web-ci]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Check selected guardrails
+        env:
+          RUN_RUNNER: ${{ needs.select.outputs.run_runner }}
+          RUN_WEB: ${{ needs.select.outputs.run_web }}
+          RUNNER_RESULT: ${{ needs.runner-ci.result }}
+          WEB_RESULT: ${{ needs.web-ci.result }}
+        run: |
+          set -euo pipefail
+
+          failed=0
+
+          if [ "$RUN_RUNNER" = "true" ] && [ "$RUNNER_RESULT" != "success" ]; then
+            echo "::error::Runner CI was selected but finished with result: $RUNNER_RESULT"
+            failed=1
+          fi
+
+          if [ "$RUN_WEB" = "true" ] && [ "$WEB_RESULT" != "success" ]; then
+            echo "::error::Web CI was selected but finished with result: $WEB_RESULT"
+            failed=1
+          fi
+
+          if [ "$RUN_RUNNER" != "true" ] && [ "$RUN_WEB" != "true" ]; then
+            echo "No runner/web guardrail selected for this PR."
+          fi
+
+          exit "$failed"
+
   # ---------------------------------------------------------------------------
   # Methodology marker reminder — advisory only (warns, never blocks).
   # If a PR changes how a metric is computed (WER normalization, TTFT/TTFA
@@ -140,9 +238,10 @@ jobs:
   # ---------------------------------------------------------------------------
   methodology-gate:
     name: Methodology marker check
+    needs: select
+    if: needs.select.outputs.methodology_sensitive == 'true' && needs.select.outputs.methodology_marker != 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    if: github.event_name == 'pull_request'
     # Advisory only: never let this job block a PR, even on an unexpected error.
     continue-on-error: true
     steps:

--- a/runner/scripts/ci_select.py
+++ b/runner/scripts/ci_select.py
@@ -94,8 +94,9 @@ def list_changed_files(base: str) -> list[str]:
             check=True,
             stdout=subprocess.PIPE,
             text=True,
+            timeout=30,
         )
-    except (FileNotFoundError, subprocess.CalledProcessError):
+    except (FileNotFoundError, subprocess.CalledProcessError, subprocess.TimeoutExpired):
         return []
 
     return [line for line in result.stdout.splitlines() if line]

--- a/runner/scripts/ci_select.py
+++ b/runner/scripts/ci_select.py
@@ -1,0 +1,133 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from collections.abc import Iterable, Sequence
+from pathlib import Path
+
+RUNNER_PREFIXES = ("runner/",)
+WEB_PREFIXES = ("web/",)
+
+CI_GUARDRAIL_FILES = {
+    ".github/workflows/ci.yml",
+    "runner/scripts/ci_select.py",
+}
+
+RUNNER_GUARDRAIL_FILES = CI_GUARDRAIL_FILES | {
+    "runner/pyproject.toml",
+    "runner/uv.lock",
+}
+
+WEB_GUARDRAIL_FILES = CI_GUARDRAIL_FILES | {
+    "web/package.json",
+    "web/pnpm-lock.yaml",
+    "web/pnpm-workspace.yaml",
+    "web/next.config.ts",
+    "web/eslint.config.mjs",
+    "web/tsconfig.json",
+}
+
+METHODOLOGY_SENSITIVE_PREFIXES = ("runner/src/coval_bench/datasets/",)
+METHODOLOGY_SENSITIVE_FILES = {
+    "docs/methodology.md",
+    "runner/src/coval_bench/metrics/ttfa.py",
+    "runner/src/coval_bench/metrics/ttfs.py",
+    "runner/src/coval_bench/metrics/ttft.py",
+    "runner/src/coval_bench/metrics/wer.py",
+}
+METHODOLOGY_MARKER_FILE = "web/lib/config/methodologyChanges.ts"
+
+
+def normalize_path(path: str) -> str:
+    return path.replace("\\", "/").removeprefix("./")
+
+
+def is_runner_relevant(path: str) -> bool:
+    normalized = normalize_path(path)
+    return normalized.startswith(RUNNER_PREFIXES) or normalized in RUNNER_GUARDRAIL_FILES
+
+
+def is_web_relevant(path: str) -> bool:
+    normalized = normalize_path(path)
+    return normalized.startswith(WEB_PREFIXES) or normalized in WEB_GUARDRAIL_FILES
+
+
+def is_methodology_sensitive(path: str) -> bool:
+    normalized = normalize_path(path)
+    return normalized in METHODOLOGY_SENSITIVE_FILES or normalized.startswith(
+        METHODOLOGY_SENSITIVE_PREFIXES
+    )
+
+
+def classify_changed_files(changed_files: Iterable[str]) -> dict[str, bool]:
+    files = [normalize_path(path) for path in changed_files if normalize_path(path)]
+
+    # Fail open when the diff is unavailable or empty. A selector problem should
+    # cost CI time, not silently skip the only relevant guardrail.
+    if not files:
+        return {
+            "run_runner": True,
+            "run_web": True,
+            "methodology_sensitive": False,
+            "methodology_marker": False,
+        }
+
+    return {
+        "run_runner": any(is_runner_relevant(path) for path in files),
+        "run_web": any(is_web_relevant(path) for path in files),
+        "methodology_sensitive": any(is_methodology_sensitive(path) for path in files),
+        "methodology_marker": METHODOLOGY_MARKER_FILE in files,
+    }
+
+
+def list_changed_files(base: str) -> list[str]:
+    result = subprocess.run(  # noqa: S603
+        ["/usr/bin/git", "diff", "--name-only", f"{base}...HEAD"],
+        check=True,
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    return [line for line in result.stdout.splitlines() if line]
+
+
+def write_github_outputs(outputs: dict[str, bool], output_path: str | None) -> None:
+    if not output_path:
+        return
+
+    lines = [f"{key}={str(value).lower()}" for key, value in outputs.items()]
+    Path(output_path).write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Select benchmarks CI guardrails from changed files."
+    )
+    parser.add_argument("--base", help="Base git ref to diff against, e.g. origin/main")
+    parser.add_argument(
+        "--changed-file",
+        action="append",
+        default=[],
+        help="Explicit changed file path. Repeatable; bypasses git diff when present.",
+    )
+    parser.add_argument("--github-output", help="Path to a GitHub output file.")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+    changed_files = args.changed_file or list_changed_files(args.base or "origin/main")
+    outputs = classify_changed_files(changed_files)
+
+    for key, value in outputs.items():
+        print(f"{key}={str(value).lower()}")
+
+    write_github_outputs(outputs, args.github_output)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/runner/scripts/ci_select.py
+++ b/runner/scripts/ci_select.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import shutil
 import subprocess
 import sys
 from collections.abc import Iterable, Sequence
@@ -64,7 +65,7 @@ def is_methodology_sensitive(path: str) -> bool:
 
 
 def classify_changed_files(changed_files: Iterable[str]) -> dict[str, bool]:
-    files = [normalize_path(path) for path in changed_files if normalize_path(path)]
+    files = [normalized for path in changed_files if (normalized := normalize_path(path))]
 
     # Fail open when the diff is unavailable or empty. A selector problem should
     # cost CI time, not silently skip the only relevant guardrail.
@@ -85,12 +86,18 @@ def classify_changed_files(changed_files: Iterable[str]) -> dict[str, bool]:
 
 
 def list_changed_files(base: str) -> list[str]:
-    result = subprocess.run(  # noqa: S603
-        ["/usr/bin/git", "diff", "--name-only", f"{base}...HEAD"],
-        check=True,
-        stdout=subprocess.PIPE,
-        text=True,
-    )
+    git = shutil.which("git") or "git"
+
+    try:
+        result = subprocess.run(  # noqa: S603,S607
+            [git, "diff", "--name-only", f"{base}...HEAD"],
+            check=True,
+            stdout=subprocess.PIPE,
+            text=True,
+        )
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        return []
+
     return [line for line in result.stdout.splitlines() if line]
 
 

--- a/runner/tests/unit/test_ci_select.py
+++ b/runner/tests/unit/test_ci_select.py
@@ -1,0 +1,94 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+
+def load_ci_select() -> ModuleType:
+    script_path = Path(__file__).parents[2] / "scripts" / "ci_select.py"
+    spec = importlib.util.spec_from_file_location("ci_select", script_path)
+    assert spec is not None
+    assert spec.loader is not None
+
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+ci_select = load_ci_select()
+classify_changed_files = ci_select.classify_changed_files
+main = ci_select.main
+
+
+def test_runner_changes_select_runner_only() -> None:
+    assert classify_changed_files(["runner/src/coval_bench/metrics/wer.py"]) == {
+        "run_runner": True,
+        "run_web": False,
+        "methodology_marker": False,
+        "methodology_sensitive": True,
+    }
+
+
+def test_web_changes_select_web_only() -> None:
+    assert classify_changed_files(["web/app/page.tsx"]) == {
+        "run_runner": False,
+        "run_web": True,
+        "methodology_marker": False,
+        "methodology_sensitive": False,
+    }
+
+
+def test_ci_guardrail_changes_select_runner_and_web() -> None:
+    assert classify_changed_files([".github/workflows/ci.yml"]) == {
+        "run_runner": True,
+        "run_web": True,
+        "methodology_marker": False,
+        "methodology_sensitive": False,
+    }
+
+
+def test_empty_diff_fails_open_to_runner_and_web() -> None:
+    assert classify_changed_files([]) == {
+        "run_runner": True,
+        "run_web": True,
+        "methodology_marker": False,
+        "methodology_sensitive": False,
+    }
+
+
+def test_dataset_changes_are_methodology_sensitive() -> None:
+    assert classify_changed_files(["runner/src/coval_bench/datasets/manifest.py"]) == {
+        "run_runner": True,
+        "run_web": False,
+        "methodology_marker": False,
+        "methodology_sensitive": True,
+    }
+
+
+def test_methodology_marker_is_tracked_separately() -> None:
+    assert classify_changed_files(["web/lib/config/methodologyChanges.ts"]) == {
+        "run_runner": False,
+        "run_web": True,
+        "methodology_marker": True,
+        "methodology_sensitive": False,
+    }
+
+
+def test_cli_writes_github_outputs(tmp_path: Path) -> None:
+    output_path = tmp_path / "github-output.txt"
+
+    assert (
+        main(
+            [
+                "--changed-file=web/package.json",
+                "--github-output",
+                str(output_path),
+            ]
+        )
+        == 0
+    )
+    assert output_path.read_text(encoding="utf-8") == (
+        "run_runner=false\nrun_web=true\nmethodology_sensitive=false\nmethodology_marker=false\n"
+    )

--- a/runner/tests/unit/test_ci_select.py
+++ b/runner/tests/unit/test_ci_select.py
@@ -70,6 +70,15 @@ def test_git_diff_failure_fails_open(monkeypatch: MonkeyPatch) -> None:
     assert ci_select.list_changed_files("origin/main") == []
 
 
+def test_git_diff_timeout_fails_open(monkeypatch: MonkeyPatch) -> None:
+    def raise_git_timeout(*_args: object, **_kwargs: object) -> None:
+        raise subprocess.TimeoutExpired(["git", "diff"], timeout=30)
+
+    monkeypatch.setattr(ci_select.subprocess, "run", raise_git_timeout)
+
+    assert ci_select.list_changed_files("origin/main") == []
+
+
 def test_dataset_changes_are_methodology_sensitive() -> None:
     assert classify_changed_files(["runner/src/coval_bench/datasets/manifest.py"]) == {
         "run_runner": True,

--- a/runner/tests/unit/test_ci_select.py
+++ b/runner/tests/unit/test_ci_select.py
@@ -2,8 +2,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import importlib.util
+import subprocess
 from pathlib import Path
 from types import ModuleType
+
+from pytest import MonkeyPatch
 
 
 def load_ci_select() -> ModuleType:
@@ -56,6 +59,15 @@ def test_empty_diff_fails_open_to_runner_and_web() -> None:
         "methodology_marker": False,
         "methodology_sensitive": False,
     }
+
+
+def test_git_diff_failure_fails_open(monkeypatch: MonkeyPatch) -> None:
+    def raise_git_error(*_args: object, **_kwargs: object) -> None:
+        raise subprocess.CalledProcessError(1, ["git", "diff"])
+
+    monkeypatch.setattr(ci_select.subprocess, "run", raise_git_error)
+
+    assert ci_select.list_changed_files("origin/main") == []
 
 
 def test_dataset_changes_are_methodology_sensitive() -> None:

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -11,7 +11,9 @@ node_modules/
 
 # Generated
 generated/
-lib/api/generated/
+!lib/api/generated/
+lib/api/generated/*
+!lib/api/generated/schema.ts
 
 # TypeScript
 *.tsbuildinfo
@@ -29,5 +31,3 @@ Thumbs.db
 
 # Vercel
 .vercel
-
-

--- a/web/hooks/useDashboardState.tsx
+++ b/web/hooks/useDashboardState.tsx
@@ -21,6 +21,8 @@ import { useAggregatesQuery, useProvidersQuery } from "@/lib/api/queries";
 import { capturePostHogEvent } from "@/lib/posthog/client";
 import { POSTHOG_EVENTS } from "@/lib/posthog/events";
 import { useTimeWindow } from "@/hooks/useTimeWindow";
+import type { ModelStats } from "@/types/benchmark.types";
+import type { SeriesPoint } from "@/lib/api/client";
 
 export function useDashboardState(page: "tts" | "stt") {
   // State declarations
@@ -50,11 +52,11 @@ export function useDashboardState(page: "tts" | "stt") {
   const windowDataStale = aggregatesQuery.isPlaceholderData;
   const loadError = aggregatesQuery.isError;
 
-  const modelStats = useMemo(
+  const modelStats = useMemo<ModelStats[]>(
     () => aggregatesQuery.data?.model_stats ?? [],
     [aggregatesQuery.data]
   );
-  const series = useMemo(
+  const series = useMemo<SeriesPoint[]>(
     () => aggregatesQuery.data?.series ?? [],
     [aggregatesQuery.data]
   );

--- a/web/lib/api/generated/schema.ts
+++ b/web/lib/api/generated/schema.ts
@@ -1,0 +1,107 @@
+/**
+ * This file mirrors the FastAPI OpenAPI contract used by the web client.
+ * Refresh with `pnpm codegen` when API response schemas change.
+ */
+
+export interface paths {
+  "/v1/results/aggregates": {
+    get: {
+      parameters: {
+        query: {
+          benchmark: components["schemas"]["BenchmarkLiteral"];
+          window?: components["schemas"]["WindowLiteral"];
+          schedule_period?: number;
+        };
+      };
+      responses: {
+        200: {
+          content: {
+            "application/json": components["schemas"]["AggregatesResponse"];
+          };
+        };
+      };
+    };
+  };
+}
+
+export interface components {
+  schemas: {
+    AggregatesResponse: {
+      benchmark: components["schemas"]["BenchmarkLiteral"];
+      window: components["schemas"]["WindowLiteral"];
+      model_stats: components["schemas"]["ModelStatEntry"][];
+      series: components["schemas"]["SeriesPoint"][];
+    };
+    BenchmarkLiteral: "STT" | "TTS";
+    LeaderboardEntry: {
+      provider: string;
+      model: string;
+      avg: number;
+      p50: number;
+      p95: number;
+      n: number;
+    };
+    LeaderboardResponse: {
+      metric: "WER" | "TTFA" | "TTFT" | "TTFS";
+      window: components["schemas"]["WindowLiteral"];
+      entries: components["schemas"]["LeaderboardEntry"][];
+    };
+    ModelInfo: {
+      model: string;
+      disabled?: boolean;
+    };
+    ModelStatEntry: {
+      provider: string;
+      model: string;
+      metric_type: string;
+      avg_value: number;
+      stddev_value: number;
+      p25: number;
+      p50: number;
+      p75: number;
+      p90: number;
+      p95: number;
+      p99: number;
+      min_value: number;
+      max_value: number;
+      sample_count: number;
+    };
+    ProviderInfo: {
+      provider: string;
+      models: components["schemas"]["ModelInfo"][];
+      modes?: string[] | null;
+    };
+    ProvidersResponse: {
+      stt: components["schemas"]["ProviderInfo"][];
+      tts: components["schemas"]["ProviderInfo"][];
+    };
+    RunOut: {
+      id: number;
+      started_at: string;
+      finished_at: string | null;
+      status: "RUNNING" | "SUCCEEDED" | "PARTIAL" | "FAILED";
+      runner_sha: string;
+      dataset_id: string;
+      dataset_sha256: string;
+      error: string | null;
+    };
+    RunsResponse: {
+      runs: components["schemas"]["RunOut"][];
+      next_before?: number | null;
+    };
+    SeriesPoint: {
+      provider: string;
+      model: string;
+      metric_type: string;
+      scheduled_at: string;
+      min_value: number;
+      p25: number;
+      p50: number;
+      p75: number;
+      max_value: number;
+      value_sum: number;
+      sample_count: number;
+    };
+    WindowLiteral: "24h" | "7d" | "30d";
+  };
+}

--- a/web/package.json
+++ b/web/package.json
@@ -51,11 +51,5 @@
     "tsx": "^4.21.0",
     "typescript": "^5",
     "vitest": "^4.1.5"
-  },
-  "pnpm": {
-    "overrides": {
-      "postcss@<8.5.10": ">=8.5.10",
-      "vite": "8.0.16"
-    }
   }
 }

--- a/web/pnpm-workspace.yaml
+++ b/web/pnpm-workspace.yaml
@@ -6,3 +6,4 @@ allowBuilds:
 
 overrides:
   "postcss@<8.5.10": ">=8.5.10"
+  vite: 8.0.16


### PR DESCRIPTION
## Summary
- add a path-aware CI selector for runner/web guardrails
- split runner and web CI while preserving the existing final `Lint / Test / Build` check name
- add web lint/test/build to PR CI and fix the existing web build blockers it exposed
- track the generated API schema snapshot needed for deterministic web builds

## Testing
- PYTHONPATH=src /tmp/benchmarks-ci-tools/bin/python -m pytest -q --confcutdir=tests/unit tests/unit/test_ci_select.py
- /tmp/benchmarks-ci-tools/bin/ruff check scripts/ci_select.py tests/unit/test_ci_select.py
- /tmp/benchmarks-ci-tools/bin/ruff format --check scripts/ci_select.py tests/unit/test_ci_select.py
- pnpm install --frozen-lockfile
- pnpm lint
- pnpm test
- pnpm build
- parsed .github/workflows/ci.yml with PyYAML

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved CI workflow by selecting which guardrails to run based on changed files, gating runner and web checks accordingly.
  * Adjusted methodology gating to run only for specific methodology-related change signals.
  * Updated web dependency/pinning configuration and .gitignore rules for generated API outputs.
* **New Features**
  * Added a “changed files” CI selector utility that outputs guardrail flags for the workflow.
* **Tests**
  * Added unit tests covering selection logic, empty-diff behavior, and CI output formatting.
* **Style**
  * Strengthened TypeScript typing for dashboard chart data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a path-aware CI guardrail selector that routes each PR through only the runner, web, or both CI pipelines based on which files changed, while preserving the existing required `Lint / Test / Build` check name via a new gate job. It also commits the generated API schema snapshot needed for deterministic web builds and fixes pre-existing web lint/type errors.

- **CI selector** (`runner/scripts/ci_select.py`): classifies changed files, fails open on empty diff or git errors, and writes `run_runner`/`run_web`/methodology flags to `$GITHUB_OUTPUT`.
- **Workflow restructure** (`.github/workflows/ci.yml`): adds `select → runner-ci / web-ci → ci` gate topology; the `ci` gate checks `select`'s own result before evaluating guardrail outcomes, addressing the silent-pass gap.
- **Web fixes**: `schema.ts` committed for deterministic builds, `useMemo` generics tightened, and `pnpm.overrides` consolidated into `pnpm-workspace.yaml`.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the gate logic is well-reasoned, fail-open is intentional and tested, and the only findings are minor style inconsistencies.

The core selector logic is simple and well-covered by unit tests. The CI gate correctly checks select's own result before evaluating guardrail outcomes. The only issues found are a checkout action version inconsistency between new and existing jobs, and a stale header comment — neither affects runtime behaviour.

.github/workflows/ci.yml — checkout action version mismatch between the two new jobs (v6) and the two pre-existing jobs (v7) is worth aligning before the next version bump.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/ci.yml | Adds `select`, `runner-ci`, `web-ci`, and updated `ci` gate jobs; minor checkout version inconsistency (v6 vs v7) across new vs old jobs, and a stale header comment referencing switchboard.yml. |
| runner/scripts/ci_select.py | New path-aware guardrail selector script; fail-open on empty diff or git errors; clean argument parsing and GitHub output writing. |
| runner/tests/unit/test_ci_select.py | Good unit test coverage for path classification, fail-open cases, git error/timeout, and CLI output writing. |
| web/.gitignore | Correctly uses the negation-then-glob pattern to track only schema.ts within the otherwise-ignored lib/api/generated/ directory. |
| web/hooks/useDashboardState.tsx | Adds explicit generic type parameters to two `useMemo` calls; straightforward type-narrowing fix. |
| web/lib/api/generated/schema.ts | Committed generated OpenAPI schema snapshot; provides a stable contract reference for deterministic web builds. |
| web/package.json | Removes the `pnpm.overrides` block from package.json; overrides are now consolidated in pnpm-workspace.yaml (the correct location). |
| web/pnpm-workspace.yaml | Adds `vite: 8.0.16` override alongside the pre-existing postcss override; consolidates workspace-level dependency pinning. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[PR / workflow_dispatch / workflow_call] --> B[select job\nci_select.py --base origin/BASE_REF]

    B -->|run_runner == true| C[runner-ci\nruff · mypy · pytest · pip-licenses · gitleaks · docker build]
    B -->|run_web == true| D[web-ci\npnpm lint · test · build]
    B -->|run_runner == false| E[runner-ci SKIPPED]
    B -->|run_web == false| F[web-ci SKIPPED]
    B -->|methodology_sensitive == true & methodology_marker != true| G[methodology-gate\nadvisory warning only]

    C --> H{ci gate\nLint / Test / Build}
    D --> H
    E --> H
    F --> H

    H -->|select failed| I[fail]
    H -->|runner selected but failed| I
    H -->|web selected but failed| I
    H -->|all selected jobs passed or none selected| J[pass]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[PR / workflow_dispatch / workflow_call] --> B[select job\nci_select.py --base origin/BASE_REF]

    B -->|run_runner == true| C[runner-ci\nruff · mypy · pytest · pip-licenses · gitleaks · docker build]
    B -->|run_web == true| D[web-ci\npnpm lint · test · build]
    B -->|run_runner == false| E[runner-ci SKIPPED]
    B -->|run_web == false| F[web-ci SKIPPED]
    B -->|methodology_sensitive == true & methodology_marker != true| G[methodology-gate\nadvisory warning only]

    C --> H{ci gate\nLint / Test / Build}
    D --> H
    E --> H
    F --> H

    H -->|select failed| I[fail]
    H -->|runner selected but failed| I
    H -->|web selected but failed| I
    H -->|all selected jobs passed or none selected| J[pass]
```

</a>

<sub>Reviews (3): Last reviewed commit: ["ci: disable benchmark checkout credentia..."](https://github.com/coval-ai/benchmarks/commit/f16cb2e2e5ff26d1c0a88f4f86501c20b7d9b91d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39247152)</sub>

<!-- /greptile_comment -->