### PR TITLE
test: cover methodology marker guardrail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,12 +157,4 @@ jobs:
           BASE_REF: ${{ github.base_ref }}
         run: |
           set -euo pipefail
-          BASE="origin/$BASE_REF"
-          CHANGED=$(git diff --name-only "$BASE"...HEAD)
-          SENSITIVE=$(echo "$CHANGED" | grep -E \
-            'runner/src/coval_bench/metrics/(wer|ttft|ttfa|ttfs)\.py|runner/src/coval_bench/datasets/|docs/methodology\.md' || true)
-          if [ -n "$SENSITIVE" ] && ! echo "$CHANGED" | grep -q 'web/lib/config/methodologyChanges\.ts'; then
-            echo "::warning::Methodology-sensitive files changed but web/lib/config/methodologyChanges.ts was not updated. If this PR changes how a metric is computed or the eval dataset, add a methodology marker so the timeline charts explain the step."
-            echo "Changed methodology-sensitive files:"
-            echo "$SENSITIVE"
-          fi
+          python3 runner/scripts/methodology_marker_check.py --base "origin/$BASE_REF"

--- a/runner/scripts/methodology_marker_check.py
+++ b/runner/scripts/methodology_marker_check.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import shutil
 import subprocess
 import sys
 from collections.abc import Iterable, Sequence
@@ -31,7 +32,7 @@ def is_methodology_sensitive(path: str) -> bool:
 
 
 def missing_methodology_marker(changed_files: Iterable[str]) -> list[str]:
-    files = [normalize_path(path) for path in changed_files if normalize_path(path)]
+    files = [normalized for path in changed_files if (normalized := normalize_path(path))]
     sensitive_files = [path for path in files if is_methodology_sensitive(path)]
 
     if not sensitive_files or METHODOLOGY_MARKER_FILE in files:
@@ -41,12 +42,18 @@ def missing_methodology_marker(changed_files: Iterable[str]) -> list[str]:
 
 
 def list_changed_files(base: str) -> list[str]:
-    result = subprocess.run(  # noqa: S603
-        ["/usr/bin/git", "diff", "--name-only", f"{base}...HEAD"],
-        check=True,
-        stdout=subprocess.PIPE,
-        text=True,
-    )
+    git = shutil.which("git") or "git"
+
+    try:
+        result = subprocess.run(  # noqa: S603,S607
+            [git, "diff", "--name-only", f"{base}...HEAD"],
+            check=True,
+            stdout=subprocess.PIPE,
+            text=True,
+        )
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        return []
+
     return [line for line in result.stdout.splitlines() if line]
 
 

--- a/runner/scripts/methodology_marker_check.py
+++ b/runner/scripts/methodology_marker_check.py
@@ -1,0 +1,89 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from collections.abc import Iterable, Sequence
+
+METHODOLOGY_MARKER_FILE = "web/lib/config/methodologyChanges.ts"
+METHODOLOGY_SENSITIVE_PREFIXES = ("runner/src/coval_bench/datasets/",)
+METHODOLOGY_SENSITIVE_FILES = {
+    "docs/methodology.md",
+    "runner/src/coval_bench/metrics/ttfa.py",
+    "runner/src/coval_bench/metrics/ttfs.py",
+    "runner/src/coval_bench/metrics/ttft.py",
+    "runner/src/coval_bench/metrics/wer.py",
+}
+
+
+def normalize_path(path: str) -> str:
+    return path.replace("\\", "/").removeprefix("./")
+
+
+def is_methodology_sensitive(path: str) -> bool:
+    normalized = normalize_path(path)
+    return normalized in METHODOLOGY_SENSITIVE_FILES or normalized.startswith(
+        METHODOLOGY_SENSITIVE_PREFIXES
+    )
+
+
+def missing_methodology_marker(changed_files: Iterable[str]) -> list[str]:
+    files = [normalize_path(path) for path in changed_files if normalize_path(path)]
+    sensitive_files = [path for path in files if is_methodology_sensitive(path)]
+
+    if not sensitive_files or METHODOLOGY_MARKER_FILE in files:
+        return []
+
+    return sensitive_files
+
+
+def list_changed_files(base: str) -> list[str]:
+    result = subprocess.run(  # noqa: S603
+        ["/usr/bin/git", "diff", "--name-only", f"{base}...HEAD"],
+        check=True,
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    return [line for line in result.stdout.splitlines() if line]
+
+
+def parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Warn when methodology-sensitive changes lack a marker."
+    )
+    parser.add_argument("--base", help="Base git ref to diff against, e.g. origin/main")
+    parser.add_argument(
+        "--changed-file",
+        action="append",
+        default=[],
+        help="Explicit changed file path. Repeatable; bypasses git diff when present.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+    changed_files = args.changed_file or list_changed_files(args.base or "origin/main")
+    missing_marker_files = missing_methodology_marker(changed_files)
+
+    if missing_marker_files:
+        print(
+            "::warning::Methodology-sensitive files changed but "
+            f"{METHODOLOGY_MARKER_FILE} was not updated. If this PR changes how a "
+            "metric is computed or the eval dataset, add a methodology marker so "
+            "the timeline charts explain the step."
+        )
+        print("Changed methodology-sensitive files:")
+        for path in missing_marker_files:
+            print(path)
+    else:
+        print("No methodology marker warning needed.")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/runner/scripts/methodology_marker_check.py
+++ b/runner/scripts/methodology_marker_check.py
@@ -51,8 +51,8 @@ def list_changed_files(base: str) -> list[str]:
             stdout=subprocess.PIPE,
             text=True,
         )
-    except (FileNotFoundError, subprocess.CalledProcessError):
-        return []
+    except (FileNotFoundError, subprocess.CalledProcessError) as error:
+        raise RuntimeError(f"Unable to list changed files against {base}") from error
 
     return [line for line in result.stdout.splitlines() if line]
 

--- a/runner/tests/unit/test_methodology_marker_check.py
+++ b/runner/tests/unit/test_methodology_marker_check.py
@@ -6,6 +6,7 @@ import subprocess
 from pathlib import Path
 from types import ModuleType
 
+import pytest
 from pytest import CaptureFixture, MonkeyPatch
 
 
@@ -57,13 +58,14 @@ def test_provider_orchestrator_changes_do_not_warn() -> None:
     assert missing_methodology_marker(["runner/src/coval_bench/runner/orchestrator.py"]) == []
 
 
-def test_git_diff_failure_does_not_break_advisory_check(monkeypatch: MonkeyPatch) -> None:
+def test_git_diff_failure_surfaces_instead_of_passing_clean(monkeypatch: MonkeyPatch) -> None:
     def raise_git_error(*_args: object, **_kwargs: object) -> None:
         raise subprocess.CalledProcessError(1, ["git", "diff"])
 
     monkeypatch.setattr(methodology_marker_check.subprocess, "run", raise_git_error)
 
-    assert methodology_marker_check.list_changed_files("origin/main") == []
+    with pytest.raises(RuntimeError, match="Unable to list changed files against origin/main"):
+        methodology_marker_check.list_changed_files("origin/main")
 
 
 def test_cli_prints_warning_for_missing_marker(capsys: CaptureFixture[str]) -> None:

--- a/runner/tests/unit/test_methodology_marker_check.py
+++ b/runner/tests/unit/test_methodology_marker_check.py
@@ -2,10 +2,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import importlib.util
+import subprocess
 from pathlib import Path
 from types import ModuleType
 
-from pytest import CaptureFixture
+from pytest import CaptureFixture, MonkeyPatch
 
 
 def load_methodology_marker_check() -> ModuleType:
@@ -54,6 +55,15 @@ def test_marker_satisfies_sensitive_changes() -> None:
 
 def test_provider_orchestrator_changes_do_not_warn() -> None:
     assert missing_methodology_marker(["runner/src/coval_bench/runner/orchestrator.py"]) == []
+
+
+def test_git_diff_failure_does_not_break_advisory_check(monkeypatch: MonkeyPatch) -> None:
+    def raise_git_error(*_args: object, **_kwargs: object) -> None:
+        raise subprocess.CalledProcessError(1, ["git", "diff"])
+
+    monkeypatch.setattr(methodology_marker_check.subprocess, "run", raise_git_error)
+
+    assert methodology_marker_check.list_changed_files("origin/main") == []
 
 
 def test_cli_prints_warning_for_missing_marker(capsys: CaptureFixture[str]) -> None:

--- a/runner/tests/unit/test_methodology_marker_check.py
+++ b/runner/tests/unit/test_methodology_marker_check.py
@@ -1,0 +1,80 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+from pytest import CaptureFixture
+
+
+def load_methodology_marker_check() -> ModuleType:
+    script_path = Path(__file__).parents[2] / "scripts" / "methodology_marker_check.py"
+    spec = importlib.util.spec_from_file_location("methodology_marker_check", script_path)
+    assert spec is not None
+    assert spec.loader is not None
+
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+methodology_marker_check = load_methodology_marker_check()
+missing_methodology_marker = methodology_marker_check.missing_methodology_marker
+main = methodology_marker_check.main
+
+
+def test_metric_change_requires_methodology_marker() -> None:
+    assert missing_methodology_marker(["runner/src/coval_bench/metrics/wer.py"]) == [
+        "runner/src/coval_bench/metrics/wer.py"
+    ]
+
+
+def test_dataset_change_requires_methodology_marker() -> None:
+    assert missing_methodology_marker(["runner/src/coval_bench/datasets/manifest.py"]) == [
+        "runner/src/coval_bench/datasets/manifest.py"
+    ]
+
+
+def test_docs_methodology_change_requires_marker() -> None:
+    assert missing_methodology_marker(["docs/methodology.md"]) == ["docs/methodology.md"]
+
+
+def test_marker_satisfies_sensitive_changes() -> None:
+    assert (
+        missing_methodology_marker(
+            [
+                "runner/src/coval_bench/metrics/ttft.py",
+                "web/lib/config/methodologyChanges.ts",
+            ]
+        )
+        == []
+    )
+
+
+def test_provider_orchestrator_changes_do_not_warn() -> None:
+    assert missing_methodology_marker(["runner/src/coval_bench/runner/orchestrator.py"]) == []
+
+
+def test_cli_prints_warning_for_missing_marker(capsys: CaptureFixture[str]) -> None:
+    assert main(["--changed-file", "runner/src/coval_bench/metrics/ttfa.py"]) == 0
+
+    output = capsys.readouterr().out
+    assert "::warning::Methodology-sensitive files changed" in output
+    assert "runner/src/coval_bench/metrics/ttfa.py" in output
+
+
+def test_cli_prints_noop_message_when_marker_is_present(capsys: CaptureFixture[str]) -> None:
+    assert (
+        main(
+            [
+                "--changed-file",
+                "runner/src/coval_bench/metrics/ttfa.py",
+                "--changed-file",
+                "web/lib/config/methodologyChanges.ts",
+            ]
+        )
+        == 0
+    )
+
+    assert capsys.readouterr().out == "No methodology marker warning needed.\n"


### PR DESCRIPTION
## Summary
- move the methodology-marker advisory selection into a tested Python helper
- cover metric, dataset, docs, marker-present, and provider-orchestrator cases
- keep the CI job advisory-only while replacing shell grep with the helper

## Testing
- PYTHONPATH=src /tmp/benchmarks-ci-tools/bin/python -m pytest -q --confcutdir=tests/unit tests/unit/test_methodology_marker_check.py
- /tmp/benchmarks-ci-tools/bin/ruff check runner/scripts/methodology_marker_check.py runner/tests/unit/test_methodology_marker_check.py
- /tmp/benchmarks-ci-tools/bin/ruff format --check runner/scripts/methodology_marker_check.py runner/tests/unit/test_methodology_marker_check.py
- parsed .github/workflows/ci.yml with PyYAML

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved CI methodology validation by moving methodology-sensitive change detection into a dedicated helper script.
* **Tests**
  * Added unit tests covering methodology marker requirements, edge cases, and expected CI advisory output behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR refactors the CI methodology-marker guardrail from an inline shell `grep` block into a tested Python helper (`runner/scripts/methodology_marker_check.py`) and adds comprehensive unit tests. The advisory-only nature of the check (always exits 0, emits a `::warning::` annotation) is preserved.

- `methodology_marker_check.py` encapsulates the sensitive-file detection logic with proper path normalization, `shutil.which` for portable git resolution, and a `--changed-file` override for hermetic testing.
- The test suite covers metric, dataset, docs, marker-present, non-sensitive-file, git-failure, and full CLI output scenarios.
- `.github/workflows/ci.yml` is simplified from 9 lines of shell to a single `python3` invocation.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change replaces shell grep with an equivalent Python helper that is well-covered by unit tests, and the CI step remains advisory-only.

The refactoring is a clean, behavior-preserving extraction of shell logic into a testable Python module. Path normalization is idempotent and correct, git resolution is portable via shutil.which, and the helper always exits 0 to keep the CI job non-blocking. All key branches (sensitive changed, marker present, non-sensitive, git failure) are covered by dedicated tests. No logic regressions or untested critical paths were found.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| runner/scripts/methodology_marker_check.py | New Python helper that detects methodology-sensitive file changes and emits a GitHub Actions warning when the marker file is absent; logic is clean, git binary resolved via shutil.which, always exits 0 for advisory-only CI behavior. |
| runner/tests/unit/test_methodology_marker_check.py | New unit test module covering metric, dataset, docs, marker-present, non-sensitive, git-failure, and CLI output cases; uses importlib.util to load the script without requiring it to be a package. |
| .github/workflows/ci.yml | CI step simplified from 9-line shell grep block to a single python3 invocation; advisory-only behavior preserved since the helper always exits 0. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant CI as CI Job (ci.yml)
    participant Script as methodology_marker_check.py
    participant Git as git diff
    participant GHA as GitHub Actions

    CI->>Script: python3 runner/scripts/methodology_marker_check.py --base origin/$BASE_REF
    Script->>Git: git diff --name-only origin/$BASE_REF...HEAD
    Git-->>Script: list of changed file paths
    Script->>Script: normalize_path() each file
    Script->>Script: is_methodology_sensitive() for each normalized path
    alt sensitive files changed AND marker file absent
        Script->>GHA: print ::warning:: annotation
        Script->>CI: exit 0 (advisory only)
    else no sensitive changes OR marker file present
        Script->>CI: print "No methodology marker warning needed.", exit 0
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant CI as CI Job (ci.yml)
    participant Script as methodology_marker_check.py
    participant Git as git diff
    participant GHA as GitHub Actions

    CI->>Script: python3 runner/scripts/methodology_marker_check.py --base origin/$BASE_REF
    Script->>Git: git diff --name-only origin/$BASE_REF...HEAD
    Git-->>Script: list of changed file paths
    Script->>Script: normalize_path() each file
    Script->>Script: is_methodology_sensitive() for each normalized path
    alt sensitive files changed AND marker file absent
        Script->>GHA: print ::warning:: annotation
        Script->>CI: exit 0 (advisory only)
    else no sensitive changes OR marker file present
        Script->>CI: print "No methodology marker warning needed.", exit 0
    end
```

</a>

<sub>Reviews (3): Last reviewed commit: ["test: surface methodology diff failures"](https://github.com/coval-ai/benchmarks/commit/2fc7acc9e2e6547d822b2e1576f29a3819a84769) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39247518)</sub>

<!-- /greptile_comment -->