### PR TITLE
Add y-axis to STT boxplot

### DIFF
--- a/web/components/charts/d3/BoxPlot.tsx
+++ b/web/components/charts/d3/BoxPlot.tsx
@@ -61,14 +61,7 @@ const BoxPlot: React.FC<BoxPlotProps> = ({
   useEffect(() => {
     if (!svgRef.current || data.data.length === 0) return;
 
-    // STT hides the y-axis tick labels, so it needs almost no left margin —
-    // reclaim that space for a wider plot. TTS keeps room for the "1.4s" ticks.
-    const showYTicks = !(
-      data.metricType === "NTTFT" ||
-      data.metricType === "TTFT" ||
-      data.metricType === "TTFS"
-    );
-    const margin = { top: 20, right: 8, bottom: 80, left: showYTicks ? 40 : 10 };
+    const margin = { top: 20, right: 8, bottom: 80, left: 40 };
     const chartWidth = dimensions.width - margin.left - margin.right;
     const chartHeight = dimensions.height - margin.top - margin.bottom;
 
@@ -121,14 +114,9 @@ const BoxPlot: React.FC<BoxPlotProps> = ({
       .attr("stroke", themeColors.grid)
       .attr("stroke-dasharray", "2 2");
 
-    // STT hides the y-axis tick labels (see showYTicks); TTS keeps them styled.
-    if (showYTicks) {
-      yAxisGroup.selectAll("text")
-        .attr("fill", themeColors.axisText)
-        .attr("font-size", yAxisTickFontSize);
-    } else {
-      yAxisGroup.selectAll("text").style("display", "none");
-    }
+    yAxisGroup.selectAll("text")
+      .attr("fill", themeColors.axisText)
+      .attr("font-size", yAxisTickFontSize);
 
     yAxisGroup.select(".domain").remove();
 


### PR DESCRIPTION
- Standardizes the STT boxplot with the TTS one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved BoxPlot component's y-axis rendering by streamlining the layout logic and standardizing how axis labels are displayed across different chart configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes the conditional logic that hid y-axis tick labels for STT metric types (NTTFT, TTFT, TTFS) and reclaims a smaller left margin for those charts. All box plots now share a uniform 40px left margin and always render y-axis tick labels, matching the existing TTS chart behavior.

- Deletes `showYTicks` flag and its conditional margin (10px vs 40px), replacing both with a single constant `margin` object.
- Removes the `if (showYTicks) … else hide text` branch in the y-axis styling block, so tick labels are always styled and visible.

<h3>Confidence Score: 5/5</h3>

Straightforward removal of a display-only conditional; no data logic or API contracts are touched.

The change deletes two small, self-contained branches — a boolean flag that toggled y-axis visibility and a paired margin conditional — and replaces them with the single values that were already used for the TTS path. There is no altered data flow, no changed props contract, and no side effects beyond the visual appearance of STT charts now showing y-axis labels.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| web/components/charts/d3/BoxPlot.tsx | Removes the STT-specific y-axis hiding logic and conditional left margin; all chart types now use a uniform 40px left margin and always show y-axis tick labels. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[useEffect triggered] --> B{data.data.length === 0?}
    B -- Yes --> C[Return early]
    B -- No --> D[Set uniform margin left: 40px for all types]
    D --> E[Build xScale / yScale]
    E --> F[Render y-axis with gridlines]
    F --> G[Style tick labels fill + font-size — always shown]
    G --> H[Remove domain line]
    H --> I[Render x-axis labels]
    I --> J[Render box plots per model]
    J --> K[Attach hover tooltip]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[useEffect triggered] --> B{data.data.length === 0?}
    B -- Yes --> C[Return early]
    B -- No --> D[Set uniform margin left: 40px for all types]
    D --> E[Build xScale / yScale]
    E --> F[Render y-axis with gridlines]
    F --> G[Style tick labels fill + font-size — always shown]
    G --> H[Remove domain line]
    H --> I[Render x-axis labels]
    I --> J[Render box plots per model]
    J --> K[Attach hover tooltip]
```

</a>

<sub>Reviews (1): Last reviewed commit: ["Add y-axis to STT boxplot"](https://github.com/coval-ai/benchmarks/commit/501efdaad9a4d97db92d116c1a85f6727c1eabe5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39339976)</sub>

<!-- /greptile_comment -->