### PR TITLE
Adaptive pairing

### DIFF
--- a/runner/src/coval_bench/api/routers/arena.py
+++ b/runner/src/coval_bench/api/routers/arena.py
@@ -41,7 +41,12 @@ from coval_bench.api.schemas import (
     VoteOut,
 )
 from coval_bench.arena.generate import generate_battle
-from coval_bench.arena.pairing import active_tts_models, select_pair
+from coval_bench.arena.pairing import (
+    PAIRING_DOMAIN,
+    PAIRING_METRIC,
+    active_tts_models,
+    select_pair,
+)
 from coval_bench.config import Settings
 from coval_bench.db.arena_store import ArenaStore
 from coval_bench.db.models import VoteOutcome, VoterType
@@ -209,8 +214,9 @@ async def create_battle(
 ) -> BattleOut:
     """Generate a battle from a prompt: pick two models, synthesize, persist (blind).
 
-    Pairing is uniform random here; adaptive pairing lands in a later PR. Returns
-    502 if either side fails to synthesize (no battle is written).
+    Pairing weights informative matchups from the latest ratings, falling back to
+    uniform at cold start. Returns 502 if either side fails to synthesize (no
+    battle is written).
     """
     prompt = body.prompt.strip()
     if not prompt:
@@ -219,10 +225,12 @@ async def create_battle(
     models = active_tts_models()
     if len(models) < 2:
         raise HTTPException(503, "not enough active TTS models to form a battle")
-    pair = select_pair(models)
+    store = ArenaStore(pool)
+    ratings = await store.get_latest_ratings(metric_name=PAIRING_METRIC, domain=PAIRING_DOMAIN)
+    pair = select_pair(models, ratings)
     battle = await generate_battle(
         settings,
-        ArenaStore(pool),
+        store,
         prompt=prompt,
         domain=body.domain,
         pair=pair,

--- a/runner/src/coval_bench/arena/pairing.py
+++ b/runner/src/coval_bench/arena/pairing.py
@@ -3,19 +3,31 @@
 
 """Model pairing for arena battles.
 
-Uniform-random selection (cold-start strategy): pick two distinct models for an
-incoming prompt. A later adaptive strategy will weight by rating uncertainty and
-closeness (CI reduction); this function is the seam it slots into — the caller
-stays the same, only the selection changes.
+Picks which two of the roster render an incoming prompt. Weights informative
+matchups: near-ties (most signal per vote) and under-measured models (widest CI).
+Falls back to uniform random at cold start, before any ratings exist.
 """
 
 from __future__ import annotations
 
+import itertools
+import math
 import random
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 
+from coval_bench.db.models import PairingRating
 from coval_bench.registries.benchmarks import Benchmark
 from coval_bench.registries.models import MODEL_REGISTRY, ModelStatus, RegisteredModel
+
+# Volume knob (Elo points): the rating gap at which a matchup's sampling priority
+# decays by 1/e. Tuned offline and committed — deliberately a constant, never an
+# env var, so the value running in prod is always the value in source.
+SCALE = 150.0
+
+# Which leaderboard board pairing reads ratings from. A single global board for
+# now; per-domain boards can replace these once a domain has enough votes.
+PAIRING_METRIC = "naturalness"
+PAIRING_DOMAIN = "all"
 
 
 def active_tts_models() -> list[RegisteredModel]:
@@ -27,17 +39,52 @@ def active_tts_models() -> list[RegisteredModel]:
 
 def select_pair(
     models: Sequence[RegisteredModel],
+    ratings: Mapping[tuple[str, str], PairingRating],
     *,
+    scale: float = SCALE,
     rng: random.Random | None = None,
 ) -> tuple[RegisteredModel, RegisteredModel]:
-    """Pick two distinct models to battle, uniformly at random.
+    """Pick two distinct models to battle, weighting informative matchups.
 
-    ``rng`` is injectable for deterministic tests. Raises if fewer than two
-    models are available. ``random.sample`` guarantees the two are distinct, so a
-    self-battle is impossible.
+    ``score(i, j) = exp(-gap / scale) * (ci_i + ci_j)`` with ``gap = |elo_i -
+    elo_j|``. A pair is *sampled* in proportion to its score (not argmax) so the
+    battle graph stays connected; the ``exp`` term favors near-ties, the CI term
+    favors under-measured models. A model absent from ``ratings`` is treated as
+    max uncertainty at the mean rating, so new models are auto-prioritized.
+
+    Falls back to uniform random when ``ratings`` is empty (cold start) or when
+    every model is fully converged (all weights zero). ``rng`` is injectable for
+    deterministic tests; ``random.sample``/``choices`` keep the two distinct.
     """
     if len(models) < 2:
         raise ValueError("need at least two models to form a battle")
     picker = rng if rng is not None else random.Random()  # noqa: S311
-    first, second = picker.sample(list(models), 2)
+    pool = list(models)
+
+    if not ratings:
+        first, second = picker.sample(pool, 2)
+        return first, second
+
+    mean_elo = sum(r.rating_elo for r in ratings.values()) / len(ratings)
+    max_ci = max(
+        (r.ci_half_width for r in ratings.values() if r.ci_half_width is not None),
+        default=1.0,
+    )
+
+    def elo(m: RegisteredModel) -> float:
+        r = ratings.get((m.provider, m.model))
+        return r.rating_elo if r is not None else mean_elo
+
+    def ci(m: RegisteredModel) -> float:
+        r = ratings.get((m.provider, m.model))
+        if r is None or r.ci_half_width is None:
+            return max_ci
+        return r.ci_half_width
+
+    pairs = list(itertools.combinations(pool, 2))
+    weights = [math.exp(-abs(elo(a) - elo(b)) / scale) * (ci(a) + ci(b)) for a, b in pairs]
+    if sum(weights) <= 0.0:
+        first, second = picker.sample(pool, 2)
+        return first, second
+    first, second = picker.choices(pairs, weights=weights, k=1)[0]
     return first, second

--- a/runner/src/coval_bench/arena/pairing.py
+++ b/runner/src/coval_bench/arena/pairing.py
@@ -52,24 +52,36 @@ def select_pair(
     favors under-measured models. A model absent from ``ratings`` is treated as
     max uncertainty at the mean rating, so new models are auto-prioritized.
 
-    Falls back to uniform random when ``ratings`` is empty (cold start) or when
-    every model is fully converged (all weights zero). ``rng`` is injectable for
-    deterministic tests; ``random.sample``/``choices`` keep the two distinct.
+    Placeholders (mean rating, max CI) are taken only over active-roster models
+    that are rated, so a stale board still carrying paused/retired models does not
+    skew them. The max-CI placeholder is floored at 1.0 so a brand-new model stays
+    prioritized even when every rated model has fully converged.
+
+    Falls back to uniform random when no active model is rated yet (cold start) or
+    when every model is fully converged (all weights zero). ``rng`` is injectable
+    for deterministic tests; ``random.sample``/``choices`` keep the two distinct.
     """
     if len(models) < 2:
         raise ValueError("need at least two models to form a battle")
+    if not math.isfinite(scale) or scale <= 0.0:
+        raise ValueError("scale must be a positive finite number")
     picker = rng if rng is not None else random.Random()  # noqa: S311
     pool = list(models)
 
-    if not ratings:
+    def _uniform() -> tuple[RegisteredModel, RegisteredModel]:
         first, second = picker.sample(pool, 2)
         return first, second
 
-    mean_elo = sum(r.rating_elo for r in ratings.values()) / len(ratings)
+    rated = [r for m in pool if (r := ratings.get((m.provider, m.model))) is not None]
+    if not rated:
+        return _uniform()
+
+    mean_elo = sum(r.rating_elo for r in rated) / len(rated)
     max_ci = max(
-        (r.ci_half_width for r in ratings.values() if r.ci_half_width is not None),
+        (r.ci_half_width for r in rated if r.ci_half_width is not None),
         default=1.0,
     )
+    max_ci = max(max_ci, 1.0)
 
     def elo(m: RegisteredModel) -> float:
         r = ratings.get((m.provider, m.model))
@@ -84,7 +96,6 @@ def select_pair(
     pairs = list(itertools.combinations(pool, 2))
     weights = [math.exp(-abs(elo(a) - elo(b)) / scale) * (ci(a) + ci(b)) for a, b in pairs]
     if sum(weights) <= 0.0:
-        first, second = picker.sample(pool, 2)
-        return first, second
+        return _uniform()
     first, second = picker.choices(pairs, weights=weights, k=1)[0]
     return first, second

--- a/runner/src/coval_bench/arena/rating.py
+++ b/runner/src/coval_bench/arena/rating.py
@@ -78,8 +78,10 @@ class ConvergenceError(RuntimeError):
 
 # Bump on any behavioural change to the rating math (model, Elo map, bootstrap,
 # status thresholds). Persisted on leaderboard snapshots so a stored rating can
-# be tied back to the method that produced it.
-METHODOLOGY_VERSION: Literal["davidson-bt-1"] = "davidson-bt-1"
+# be tied back to the method that produced it. The numeric suffix is zero-padded
+# so its lexicographic order (used as the leaderboard tiebreaker on equal
+# timestamps) still matches numeric order past version 9.
+METHODOLOGY_VERSION: Literal["davidson-bt-001"] = "davidson-bt-001"
 
 # Standard Bradley-Terry -> Elo scale: a difference of 400 Elo == 10:1 win odds.
 _ELO_BASE = 1500.0
@@ -129,7 +131,7 @@ class ModelRating(BaseModel):
 class RatingResult(BaseModel):
     """Full leaderboard fit: the tie parameter plus one entry per model."""
 
-    methodology_version: Literal["davidson-bt-1"] = METHODOLOGY_VERSION
+    methodology_version: Literal["davidson-bt-001"] = METHODOLOGY_VERSION
     tie_param: float
     models: list[ModelRating]
 

--- a/runner/src/coval_bench/arena/seed.py
+++ b/runner/src/coval_bench/arena/seed.py
@@ -42,7 +42,7 @@ async def seed_demo_battles(
 
     for domain, prompts in EXAMPLE_PROMPTS.items():
         for prompt in prompts[:per_domain]:
-            pair = select_pair(models, rng=picker)
+            pair = select_pair(models, {}, rng=picker)
             battle = await generate_battle(
                 settings,
                 store,

--- a/runner/src/coval_bench/db/arena_store.py
+++ b/runner/src/coval_bench/db/arena_store.py
@@ -18,7 +18,14 @@ import psycopg
 import psycopg.rows
 from psycopg_pool import AsyncConnectionPool
 
-from coval_bench.db.models import Battle, LeaderboardSnapshot, Vote, VoteOutcome, VoterType
+from coval_bench.db.models import (
+    Battle,
+    LeaderboardSnapshot,
+    PairingRating,
+    Vote,
+    VoteOutcome,
+    VoterType,
+)
 
 ArenaPool = AsyncConnectionPool[psycopg.AsyncConnection[psycopg.rows.DictRow]]
 
@@ -189,6 +196,46 @@ class ArenaStore:
         ):
             await cur.executemany(sql, params_seq)
         return len(rows)
+
+    async def get_latest_ratings(
+        self,
+        *,
+        metric_name: str,
+        domain: str,
+    ) -> dict[tuple[str, str], PairingRating]:
+        """Return the latest board's ratings keyed by ``(provider, model)``.
+
+        Reads the single most recent ``(computed_at, methodology_version)`` board
+        for this metric/domain, so two methodology versions never mix. Empty until
+        the snapshot job has produced a board — the cold-start signal the pairing
+        heuristic falls back to uniform on.
+        """
+        sql = """
+            WITH latest AS (
+                SELECT computed_at, methodology_version
+                FROM arena.leaderboard_snapshots
+                WHERE metric_name = %(metric)s AND domain = %(domain)s
+                ORDER BY computed_at DESC, methodology_version DESC
+                LIMIT 1
+            )
+            SELECT s.provider, s.model, s.rating_elo, s.ci_half_width
+            FROM arena.leaderboard_snapshots s
+            JOIN latest l USING (computed_at, methodology_version)
+            WHERE s.metric_name = %(metric)s AND s.domain = %(domain)s
+        """
+        async with (
+            self._pool.connection() as conn,
+            conn.cursor(row_factory=psycopg.rows.dict_row) as cur,
+        ):
+            await cur.execute(sql, {"metric": metric_name, "domain": domain})
+            rows = await cur.fetchall()
+        return {
+            (row["provider"], row["model"]): PairingRating(
+                rating_elo=row["rating_elo"],
+                ci_half_width=row["ci_half_width"],
+            )
+            for row in rows
+        }
 
     @asynccontextmanager
     async def snapshot_lock(self) -> AsyncIterator[bool]:

--- a/runner/src/coval_bench/db/models.py
+++ b/runner/src/coval_bench/db/models.py
@@ -21,6 +21,7 @@ __all__ = [
     "Battle",
     "Benchmark",
     "LeaderboardSnapshot",
+    "PairingRating",
     "Result",
     "ResultStatus",
     "Run",
@@ -156,3 +157,10 @@ class LeaderboardSnapshot(BaseModel):
     losses: float
     ties: float
     status: SnapshotStatus
+
+
+class PairingRating(BaseModel):
+    """Minimal rating view the pairing heuristic needs from a leaderboard board."""
+
+    rating_elo: float
+    ci_half_width: float | None = None

--- a/runner/tests/unit/test_arena_pairing.py
+++ b/runner/tests/unit/test_arena_pairing.py
@@ -102,11 +102,36 @@ def test_new_model_absent_from_ratings_is_reachable() -> None:
 
 def test_all_converged_falls_back_to_uniform() -> None:
     # every model fully converged (ci=0) → weights sum to 0 → uniform fallback.
+    # Same seed must reproduce the cold-start pick, proving the fallback branch ran.
     ratings = {
         _key(m): _rating(e, 0.0) for m, e in zip(_MODELS, [1000.0, 1100.0, 1200.0], strict=True)
     }
-    first, second = select_pair(_MODELS, ratings, rng=random.Random(3))
-    assert first is not second
+    assert select_pair(_MODELS, ratings, rng=random.Random(3)) == select_pair(
+        _MODELS, {}, rng=random.Random(3)
+    )
+
+
+def test_new_model_prioritized_even_when_known_models_converged() -> None:
+    # a, b fully converged (ci=0); c is absent. The max-CI floor keeps c the only
+    # model with weight, so every selected pair must include it.
+    ratings = {_key(_MODELS[0]): _rating(1000.0, 0.0), _key(_MODELS[1]): _rating(1000.0, 0.0)}
+    pairs = [select_pair(_MODELS, ratings, rng=random.Random(i)) for i in range(50)]
+    assert all("c" in (a.model, b.model) for a, b in pairs)
+
+
+def test_no_active_model_rated_falls_back_to_uniform() -> None:
+    # Board holds only a retired model absent from the active pool → no signal →
+    # uniform, matching the cold-start pick for the same seed.
+    ratings = {("retired", "old"): _rating(1500.0, 40.0)}
+    assert select_pair(_MODELS, ratings, rng=random.Random(1)) == select_pair(
+        _MODELS, {}, rng=random.Random(1)
+    )
+
+
+def test_select_pair_rejects_non_positive_scale() -> None:
+    ratings = {_key(m): _rating(1000.0, 30.0) for m in _MODELS}
+    with pytest.raises(ValueError, match="scale must be"):
+        select_pair(_MODELS, ratings, scale=0.0)
 
 
 def test_active_tts_models_are_tts_and_active() -> None:

--- a/runner/tests/unit/test_arena_pairing.py
+++ b/runner/tests/unit/test_arena_pairing.py
@@ -1,15 +1,17 @@
 # Copyright 2026 The Coval Benchmarks Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Unit tests for arena model pairing (uniform strategy)."""
+"""Unit tests for arena model pairing (adaptive + cold-start strategies)."""
 
 from __future__ import annotations
 
 import random
+from collections import Counter
 
 import pytest
 
 from coval_bench.arena.pairing import active_tts_models, select_pair
+from coval_bench.db.models import PairingRating
 from coval_bench.registries.benchmarks import Benchmark
 from coval_bench.registries.models import ModelStatus, RegisteredModel
 
@@ -24,11 +26,19 @@ def _model(name: str) -> RegisteredModel:
     )
 
 
+def _rating(elo: float, ci: float | None) -> PairingRating:
+    return PairingRating(rating_elo=elo, ci_half_width=ci)
+
+
+def _key(m: RegisteredModel) -> tuple[str, str]:
+    return (m.provider, m.model)
+
+
 _MODELS = [_model("a"), _model("b"), _model("c")]
 
 
 def test_select_pair_returns_two_distinct() -> None:
-    first, second = select_pair(_MODELS, rng=random.Random(1))
+    first, second = select_pair(_MODELS, {}, rng=random.Random(1))
     assert first in _MODELS
     assert second in _MODELS
     assert first is not second
@@ -36,11 +46,67 @@ def test_select_pair_returns_two_distinct() -> None:
 
 def test_select_pair_requires_two_models() -> None:
     with pytest.raises(ValueError, match="at least two"):
-        select_pair(_MODELS[:1])
+        select_pair(_MODELS[:1], {})
 
 
-def test_select_pair_is_deterministic_with_seed() -> None:
-    assert select_pair(_MODELS, rng=random.Random(7)) == select_pair(_MODELS, rng=random.Random(7))
+def test_cold_start_is_deterministic_with_seed() -> None:
+    assert select_pair(_MODELS, {}, rng=random.Random(7)) == select_pair(
+        _MODELS, {}, rng=random.Random(7)
+    )
+
+
+def test_adaptive_is_deterministic_with_seed() -> None:
+    ratings = {
+        _key(m): _rating(e, 30.0) for m, e in zip(_MODELS, [1000.0, 1100.0, 1200.0], strict=True)
+    }
+    assert select_pair(_MODELS, ratings, rng=random.Random(7)) == select_pair(
+        _MODELS, ratings, rng=random.Random(7)
+    )
+
+
+def test_close_pair_outscores_blowout() -> None:
+    # a~b are near-ties, c is a far outlier; the near-tie should dominate draws.
+    ratings = {
+        _key(m): _rating(e, 50.0) for m, e in zip(_MODELS, [1000.0, 1005.0, 1400.0], strict=True)
+    }
+    counts: Counter[frozenset[str]] = Counter(
+        frozenset((a.model, b.model))
+        for a, b in (select_pair(_MODELS, ratings, rng=random.Random(i)) for i in range(500))
+    )
+    assert counts[frozenset(("a", "b"))] > counts[frozenset(("a", "c"))]
+
+
+def test_high_ci_model_oversampled_at_equal_gap() -> None:
+    # equal ratings, but c is far more uncertain → it should appear more often.
+    ratings = {
+        _key(m): _rating(1000.0, ci) for m, ci in zip(_MODELS, [10.0, 10.0, 200.0], strict=True)
+    }
+    counts: Counter[str] = Counter(
+        m.model
+        for pair in (select_pair(_MODELS, ratings, rng=random.Random(i)) for i in range(500))
+        for m in pair
+    )
+    assert counts["c"] > counts["a"]
+
+
+def test_new_model_absent_from_ratings_is_reachable() -> None:
+    # c has no rating → treated as max uncertainty, so it must still get sampled.
+    ratings = {_key(_MODELS[0]): _rating(1000.0, 20.0), _key(_MODELS[1]): _rating(1010.0, 20.0)}
+    seen = {
+        m.model
+        for pair in (select_pair(_MODELS, ratings, rng=random.Random(i)) for i in range(200))
+        for m in pair
+    }
+    assert "c" in seen
+
+
+def test_all_converged_falls_back_to_uniform() -> None:
+    # every model fully converged (ci=0) → weights sum to 0 → uniform fallback.
+    ratings = {
+        _key(m): _rating(e, 0.0) for m, e in zip(_MODELS, [1000.0, 1100.0, 1200.0], strict=True)
+    }
+    first, second = select_pair(_MODELS, ratings, rng=random.Random(3))
+    assert first is not second
 
 
 def test_active_tts_models_are_tts_and_active() -> None:

--- a/runner/tests/unit/test_arena_snapshot.py
+++ b/runner/tests/unit/test_arena_snapshot.py
@@ -164,7 +164,7 @@ def test_snapshot_persists_one_board(snap_pg: psycopg.Connection[Any]) -> None:
             assert len(rows) == 2
             assert {r["metric_name"] for r in rows} == {"naturalness"}
             assert {r["domain"] for r in rows} == {"all"}
-            assert {r["methodology_version"] for r in rows} == {"davidson-bt-1"}
+            assert {r["methodology_version"] for r in rows} == {"davidson-bt-001"}
             assert len({r["computed_at"] for r in rows}) == 1
             assert {(r["provider"], r["model"]) for r in rows} == {
                 ("cartesia", "sonic-3.5"),

--- a/runner/tests/unit/test_arena_store.py
+++ b/runner/tests/unit/test_arena_store.py
@@ -25,7 +25,13 @@ from psycopg_pool import AsyncConnectionPool
 from pytest_postgresql.factories import postgresql, postgresql_proc
 
 from coval_bench.db.arena_store import ArenaStore
-from coval_bench.db.models import Battle, VoteOutcome, VoterType
+from coval_bench.db.models import (
+    Battle,
+    LeaderboardSnapshot,
+    SnapshotStatus,
+    VoteOutcome,
+    VoterType,
+)
 
 # Separate embedded server (random free port) so we don't collide with the
 # db-writer tests' ``pg_proc`` fixture.
@@ -88,6 +94,81 @@ def _make_battle(*, provider_b: str = "elevenlabs", model_b: str = "flash") -> B
         audio_a_url="https://example.test/a.wav",
         audio_b_url="https://example.test/b.wav",
     )
+
+
+def _snapshot(
+    provider: str,
+    model: str,
+    rating_elo: float,
+    *,
+    metric_name: str = "naturalness",
+    domain: str = "all",
+) -> LeaderboardSnapshot:
+    return LeaderboardSnapshot(
+        metric_name=metric_name,
+        methodology_version="davidson-bt-1",
+        domain=domain,
+        provider=provider,
+        model=model,
+        rating_elo=rating_elo,
+        rating_bt=0.0,
+        ci_half_width=25.0,
+        votes_total=100,
+        wins=50.0,
+        losses=45.0,
+        ties=5.0,
+        status=SnapshotStatus.USABLE,
+    )
+
+
+def test_get_latest_ratings_returns_only_latest_board(
+    arena_pg: psycopg.Connection[Any],
+) -> None:
+    _apply_migrations(arena_pg)
+
+    async def _run() -> None:
+        pool = await _make_pool(arena_pg)
+        try:
+            store = ArenaStore(pool)
+            # Older board, then a newer one (distinct computed_at via now()).
+            await store.insert_snapshot_board([_snapshot("cartesia", "sonic-3.5", 1000.0)])
+            await asyncio.sleep(0.05)
+            await store.insert_snapshot_board(
+                [
+                    _snapshot("cartesia", "sonic-3.5", 1200.0),
+                    _snapshot("openai", "gpt-4o-mini-tts", 1100.0),
+                ]
+            )
+            # A different metric must not leak into the naturalness board.
+            await store.insert_snapshot_board(
+                [_snapshot("cartesia", "sonic-3.5", 999.0, metric_name="other")]
+            )
+
+            ratings = await store.get_latest_ratings(metric_name="naturalness", domain="all")
+            assert set(ratings) == {("cartesia", "sonic-3.5"), ("openai", "gpt-4o-mini-tts")}
+            assert ratings[("cartesia", "sonic-3.5")].rating_elo == 1200.0
+            assert ratings[("cartesia", "sonic-3.5")].ci_half_width == 25.0
+        finally:
+            await pool.close()
+
+    asyncio.run(_run())
+
+
+def test_get_latest_ratings_empty_before_any_snapshot(
+    arena_pg: psycopg.Connection[Any],
+) -> None:
+    _apply_migrations(arena_pg)
+
+    async def _run() -> None:
+        pool = await _make_pool(arena_pg)
+        try:
+            store = ArenaStore(pool)
+            ratings = await store.get_latest_ratings(metric_name="naturalness", domain="all")
+            assert ratings == {}
+        finally:
+            await pool.close()
+
+    asyncio.run(_run())
 
 
 def test_insert_and_read_battle(arena_pg: psycopg.Connection[Any]) -> None:


### PR DESCRIPTION
Adaptive arena pairing: samples a model pair in proportion to `exp(-gap/SCALE) * (ci_i + ci_j)`, favoring near-ties and under-measured models. Falls back to uniform at cold start. Replaces uniform selection so we reach rating precision with fewer votes.


- `ArenaStore.get_latest_ratings()` reads the latest naturalness board (single-board CTE, no metric mixing).
- `select_pair(models, ratings)` is adaptive; a model absent from ratings is treated as max uncertainty.
- `SCALE`, `PAIRING_METRIC`, `PAIRING_DOMAIN` are module constants. Route passes ratings in; seed stays uniform.

## Follow-ups
- Per-domain pairing deferred until a domain has enough votes (every model `ci <= 60` Elo).
- Monitoring (co-occurrence, convergence) and `tune-scale` sim are later PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Battle pairings now adapt based on latest model ratings for more balanced and meaningful matchups
  * Models with similar skill levels are preferentially paired together, and under-measured models receive priority for evaluation
  * System gracefully handles cold-start scenarios with uniform random pairing fallback when ratings are unavailable

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces uniform model pairing with an adaptive heuristic that weights each candidate pair by `exp(-gap/SCALE) * (ci_i + ci_j)`, favouring near-ties and under-measured models, with a uniform fallback for cold start. It also bumps `METHODOLOGY_VERSION` to `"davidson-bt-001"` (zero-padded) to fix lexicographic tiebreaking in the leaderboard CTE.

- **Adaptive pairing logic** (`pairing.py`): `select_pair` now accepts a `ratings` mapping; unrated models receive a `max_ci` placeholder (floored at 1.0) and `mean_elo` computed only from active-roster models, so stale board entries don't bias either value.
- **New DB helper** (`arena_store.py`): `get_latest_ratings` uses a single-board CTE (same `computed_at` + `methodology_version`) to prevent mixing boards across methodology upgrades.
- **Version bump** (`rating.py`): `METHODOLOGY_VERSION` becomes `"davidson-bt-001"`, making its lexicographic DESC order safe through at least version 999.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the adaptive pairing logic is well-guarded with cold-start and all-converged fallbacks, and the methodology version bump is backward-compatible.

All three concerns raised in earlier review rounds have been addressed: the max_ci floor prevents new-model deprioritization when known models converge, mean_elo is restricted to active-roster models only, and the version string is now zero-padded to make lexicographic ordering correct. The one remaining inconsistency — the test helper still hardcodes the old version string — does not affect production behaviour or test correctness today.

runner/tests/unit/test_arena_store.py — the _snapshot() helper should use the new "davidson-bt-001" version string to keep tests consistent with production data.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| runner/src/coval_bench/arena/pairing.py | Replaces uniform sampling with an adaptive score(i,j)=exp(-gap/SCALE)*(ci_i+ci_j) heuristic; includes cold-start/all-converged fallbacks, max_ci floor (1.0), and mean-Elo placeholder restricted to active roster models. |
| runner/src/coval_bench/db/arena_store.py | Adds get_latest_ratings() — a single-board CTE query (no metric mixing) returning ratings keyed by (provider, model); named-param style differs from rest of the file but is valid psycopg. |
| runner/src/coval_bench/arena/rating.py | Bumps METHODOLOGY_VERSION to "davidson-bt-001" (zero-padded) so lexicographic DESC order matches numeric order past version 9; Literal type annotation updated to match. |
| runner/tests/unit/test_arena_pairing.py | Comprehensive test suite for adaptive pairing: determinism, near-tie preference, CI oversampling, cold-start fallback, max-CI floor, and invalid-scale guard; all cases well-structured. |
| runner/tests/unit/test_arena_store.py | Adds two tests for get_latest_ratings; _snapshot() helper hardcodes the old "davidson-bt-1" version string rather than the updated "davidson-bt-001", so the zero-padded ordering fix is not exercised by these tests. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant Router as arena.py (create_battle)
    participant Store as ArenaStore
    participant DB as PostgreSQL
    participant Pairing as select_pair()
    participant Gen as generate_battle()

    Client->>Router: POST /arena/battle
    Router->>Store: "get_latest_ratings(metric="naturalness", domain="all")"
    Store->>DB: CTE — latest (computed_at, methodology_version) board
    DB-->>Store: "rows [{provider, model, rating_elo, ci_half_width}]"
    Store-->>Router: dict[(provider,model)] → PairingRating

    alt ratings is empty (cold start)
        Router->>Pairing: "select_pair(models, {})"
        Pairing-->>Router: uniform random pair
    else ratings available
        Router->>Pairing: select_pair(models, ratings)
        Note over Pairing: score(i,j)=exp(-gap/SCALE)*(ci_i+ci_j), unrated → mean_elo, max_ci (≥1.0)
        alt "all weights == 0 (fully converged)"
            Pairing-->>Router: uniform random pair
        else
            Pairing-->>Router: weighted-sampled pair
        end
    end

    Router->>Gen: generate_battle(pair, prompt, ...)
    Gen->>Store: insert_battle(...)
    Store->>DB: INSERT INTO arena.battles
    DB-->>Store: battle row
    Gen-->>Router: Battle
    Router-->>Client: 201 BattleOut
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant Router as arena.py (create_battle)
    participant Store as ArenaStore
    participant DB as PostgreSQL
    participant Pairing as select_pair()
    participant Gen as generate_battle()

    Client->>Router: POST /arena/battle
    Router->>Store: "get_latest_ratings(metric="naturalness", domain="all")"
    Store->>DB: CTE — latest (computed_at, methodology_version) board
    DB-->>Store: "rows [{provider, model, rating_elo, ci_half_width}]"
    Store-->>Router: dict[(provider,model)] → PairingRating

    alt ratings is empty (cold start)
        Router->>Pairing: "select_pair(models, {})"
        Pairing-->>Router: uniform random pair
    else ratings available
        Router->>Pairing: select_pair(models, ratings)
        Note over Pairing: score(i,j)=exp(-gap/SCALE)*(ci_i+ci_j), unrated → mean_elo, max_ci (≥1.0)
        alt "all weights == 0 (fully converged)"
            Pairing-->>Router: uniform random pair
        else
            Pairing-->>Router: weighted-sampled pair
        end
    end

    Router->>Gen: generate_battle(pair, prompt, ...)
    Gen->>Store: insert_battle(...)
    Store->>DB: INSERT INTO arena.battles
    DB-->>Store: battle row
    Gen-->>Router: Battle
    Router-->>Client: 201 BattleOut
```

</a>

<sub>Reviews (3): Last reviewed commit: ["Harden pairing inputs and version orderi..."](https://github.com/coval-ai/benchmarks/commit/242704d04673296329702560167d917e37133ea7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39405576)</sub>

<!-- /greptile_comment -->