### PR TITLE
Add arena battle reveal endpoint

### DIFF
--- a/runner/src/coval_bench/api/routers/arena.py
+++ b/runner/src/coval_bench/api/routers/arena.py
@@ -37,6 +37,8 @@ from coval_bench.api.schemas import (
     BattleCreate,
     BattleOut,
     LeaderboardEntryOut,
+    RevealModelOut,
+    RevealOut,
     VoteIn,
     VoteOut,
 )
@@ -236,3 +238,27 @@ async def create_battle(
         {"$process_person_profile": False},
     )
     return BattleOut.model_validate(battle.model_dump())
+
+
+@router.get("/arena/battle/{battle_id}/reveal", response_model=RevealOut)
+@limiter.limit("60/minute")
+async def reveal_battle(
+    request: Request,  # required by slowapi
+    battle_id: uuid.UUID,
+    x_labeler_key: str | None = Header(default=None),
+    pool: AsyncConnectionPool[Any] = Depends(get_pool),
+    settings: Settings = Depends(get_settings),
+) -> RevealOut:
+    """De-anonymize a battle's two sides. Labeler-only, and only after a vote exists."""
+    if not _is_authenticated_labeler(x_labeler_key, settings):
+        raise HTTPException(403, "reveal is not enabled")
+    store = ArenaStore(pool)
+    battle = await store.get_battle(battle_id)
+    if battle is None:
+        raise HTTPException(404, f"battle {battle_id} not found")
+    if not await store.list_votes(battle_id=battle_id, limit=1):
+        raise HTTPException(409, "battle has not been voted on yet")
+    return RevealOut(
+        a=RevealModelOut(provider=battle.provider_a, model=battle.model_a, label=battle.model_a),
+        b=RevealModelOut(provider=battle.provider_b, model=battle.model_b, label=battle.model_b),
+    )

--- a/runner/src/coval_bench/api/schemas.py
+++ b/runner/src/coval_bench/api/schemas.py
@@ -230,3 +230,18 @@ class VoteOut(BaseModel):
     voter_id: str
     created_at: datetime
     updated_at: datetime
+
+
+class RevealModelOut(BaseModel):
+    """One side of a battle, de-anonymized after a vote."""
+
+    provider: str
+    model: str
+    label: str
+
+
+class RevealOut(BaseModel):
+    """Post-vote reveal of both sides' identities."""
+
+    a: RevealModelOut
+    b: RevealModelOut

--- a/runner/tests/api/test_arena.py
+++ b/runner/tests/api/test_arena.py
@@ -562,3 +562,47 @@ async def test_create_battle_502_when_synthesis_fails(
 
     response = await client.post("/v1/arena/battle", json={"prompt": "hello"})
     assert response.status_code == 502
+
+
+async def test_reveal_without_labeler_key_is_403(client: AsyncClient, postgresql: Any) -> None:
+    """No labeler key -> 403, identities never returned."""
+    await _apply_arena_schema(_make_db_url(postgresql))
+    battle_id = await _insert_battle(postgresql)
+    response = await client.get(f"/v1/arena/battle/{battle_id}/reveal")
+    assert response.status_code == 403
+
+
+async def test_reveal_before_vote_is_409(client: AsyncClient, postgresql: Any) -> None:
+    """A battle with no vote yet cannot be revealed."""
+    await _apply_arena_schema(_make_db_url(postgresql))
+    battle_id = await _insert_battle(postgresql)
+    response = await client.get(f"/v1/arena/battle/{battle_id}/reveal", headers=_LABELER_HEADERS)
+    assert response.status_code == 409
+
+
+async def test_reveal_unknown_battle_is_404(client: AsyncClient, postgresql: Any) -> None:
+    """A well-formed but unknown battle id returns 404."""
+    await _apply_arena_schema(_make_db_url(postgresql))
+    response = await client.get(
+        "/v1/arena/battle/00000000-0000-0000-0000-000000000000/reveal",
+        headers=_LABELER_HEADERS,
+    )
+    assert response.status_code == 404
+
+
+async def test_reveal_after_vote_returns_identities(client: AsyncClient, postgresql: Any) -> None:
+    """Once a vote exists, reveal returns both sides' provider/model."""
+    await _apply_arena_schema(_make_db_url(postgresql))
+    battle_id = await _insert_battle(postgresql)
+    await client.post(
+        "/v1/arena/vote",
+        json={"battle_id": battle_id, "outcome": "A_WIN", "voter_id": "ann-1"},
+        headers=_LABELER_HEADERS,
+    )
+    response = await client.get(f"/v1/arena/battle/{battle_id}/reveal", headers=_LABELER_HEADERS)
+    assert response.status_code == 200
+    data = response.json()
+    assert data["a"]["provider"] == "elevenlabs"
+    assert data["a"]["model"] == "eleven_multilingual_v2"
+    assert data["b"]["provider"] == "cartesia"
+    assert data["b"]["model"] == "sonic-3"


### PR DESCRIPTION
Adds `GET /arena/battle/{id}/reveal` so the voting page can show which models were behind A/B after a vote.

- Labeler-only (`X-Labeler-Key`), same as voting.
- Returns 409 until the battle has a vote, so identities never leak before voting.
- Reuses the existing `get_battle` query — no new DB work.

Pairs with the web BFF PR (the proxy route that calls this).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a reveal endpoint for authenticated users to view the provider and model identities involved in a battle after votes have been recorded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `GET /v1/arena/battle/{id}/reveal`, a labeler-only endpoint that returns the provider and model identities for both sides of a battle once a vote has been cast.

- The auth guard (`X-Labeler-Key`), 404 for unknown battles, and 409 until a vote exists are all correctly enforced, keeping model identities server-side until after a vote is recorded.
- `RevealModelOut` exposes a `label` field that the endpoint always populates with the same value as `model` — the field's purpose is undocumented and appears to be either an unfinished display-name feature or unnecessary schema weight.
- Four new tests cover the main status-code paths; a wrong-key 403 test (present for the vote endpoint) is absent for reveal.

<h3>Confidence Score: 4/5</h3>

The endpoint is safe to merge — auth, not-found, and pre-vote guards all work correctly and the new route does not conflict with existing ones.

The core logic is solid and the critical identity-leak guard (409 until a vote exists) is correctly placed. The only notable concern is the `label` field in `RevealModelOut`, which is always set to the same value as `model`, leaving it unclear whether it represents an unfinished display-name feature or dead schema weight that will be forwarded to the BFF without purpose.

runner/src/coval_bench/api/routers/arena.py and runner/src/coval_bench/api/schemas.py — specifically the intent behind the `label` field in `RevealModelOut`.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| runner/src/coval_bench/api/routers/arena.py | Adds the GET /arena/battle/{id}/reveal endpoint with correct auth, 404, and 409 guards. The `label` field in the response is always set to the same value as `model`, suggesting an incomplete or unneeded field. Module docstring is not updated to list the new route. |
| runner/src/coval_bench/api/schemas.py | Adds RevealModelOut and RevealOut schemas. RevealModelOut includes a `label` field that is always populated with the same value as `model` at the call site — the field's purpose is unclear without further documentation. |
| runner/tests/api/test_arena.py | Four new tests cover 403 (no key), 404 (unknown battle), 409 (no vote), and 200 (success) cases. Missing a test for an incorrect (non-matching) key, which exists for the vote endpoint. |

</details>



<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant BFF as Web BFF
    participant API as /v1/arena/battle/{id}/reveal
    participant DB as ArenaStore (PostgreSQL)

    BFF->>API: "GET /v1/arena/battle/{id}/reveal"
    API->>API: _is_authenticated_labeler()
    alt Key missing or wrong
        API-->>BFF: 403 Forbidden
    end
    API->>DB: store.get_battle(battle_id)
    alt Battle not found
        DB-->>API: None
        API-->>BFF: 404 Not Found
    end
    DB-->>API: Battle (provider_a, model_a, provider_b, model_b)
    API->>DB: "store.list_votes(battle_id, limit=1)"
    alt No votes yet
        DB-->>API: []
        API-->>BFF: 409 Conflict
    end
    DB-->>API: [Vote]
    API-->>BFF: "200 OK {a: {provider, model, label}, b: {provider, model, label}}"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant BFF as Web BFF
    participant API as /v1/arena/battle/{id}/reveal
    participant DB as ArenaStore (PostgreSQL)

    BFF->>API: "GET /v1/arena/battle/{id}/reveal"
    API->>API: _is_authenticated_labeler()
    alt Key missing or wrong
        API-->>BFF: 403 Forbidden
    end
    API->>DB: store.get_battle(battle_id)
    alt Battle not found
        DB-->>API: None
        API-->>BFF: 404 Not Found
    end
    DB-->>API: Battle (provider_a, model_a, provider_b, model_b)
    API->>DB: "store.list_votes(battle_id, limit=1)"
    alt No votes yet
        DB-->>API: []
        API-->>BFF: 409 Conflict
    end
    DB-->>API: [Vote]
    API-->>BFF: "200 OK {a: {provider, model, label}, b: {provider, model, label}}"
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `runner/src/coval_bench/api/routers/arena.py`, line 6-9 ([link](https://github.com/coval-ai/benchmarks/blob/59684a48f22341b74885e856b1401db7f7283f5b/runner/src/coval_bench/api/routers/arena.py#L6-L9)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The module docstring lists all arena endpoints but doesn't include the new reveal route, which will cause the header comment to drift from the actual API surface.

   

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!


2. `runner/tests/api/test_arena.py`, line 567-609 ([link](https://github.com/coval-ai/benchmarks/blob/59684a48f22341b74885e856b1401db7f7283f5b/runner/tests/api/test_arena.py#L567-L609)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **No test for a wrong (non-matching) labeler key**

   The vote endpoint has `test_vote_with_wrong_key_is_403` to cover the case where a key is supplied but incorrect. The reveal tests only cover the missing-key case. The `_is_authenticated_labeler` check for reveal is identical, so the behaviour is the same, but the gap means a future refactor that accidentally removes the timing-safe comparison would go undetected for reveal while still being caught for vote.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["Add arena battle reveal endpoint"](https://github.com/coval-ai/benchmarks/commit/59684a48f22341b74885e856b1401db7f7283f5b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39427566)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->