### PR TITLE
Cap daily arena battle generation

### DIFF
--- a/runner/src/coval_bench/api/routers/arena.py
+++ b/runner/src/coval_bench/api/routers/arena.py
@@ -217,17 +217,30 @@ async def create_battle(
     """Generate a battle from a prompt: pick two models, synthesize, persist (blind).
 
     Pairing weights informative matchups from the latest ratings, falling back to
-    uniform at cold start. Returns 502 if either side fails to synthesize (no
-    battle is written).
+    uniform at cold start. Returns 502 if either side fails to synthesize (no battle
+    is written). Guarded by a global daily cap (``arena_daily_battle_cap``, ``<= 0``
+    disables), checked before synthesis so a tripped cap spends nothing (429). Known
+    limits: it counts successful battles only (a failed one still costs ~2 calls,
+    uncounted but logged), and the non-transactional check may overshoot slightly
+    under concurrency (no data is overwritten).
     """
+    store = ArenaStore(pool)
     prompt = body.prompt.strip()
     if not prompt:
         raise HTTPException(422, "prompt must not be empty")
 
+    cap = settings.arena_daily_battle_cap
+    if cap > 0 and await store.count_battles_today() >= cap:
+        capture_api_event(
+            posthog_client,
+            "arena_battle_cap_reached",
+            {"$process_person_profile": False},
+        )
+        raise HTTPException(429, "daily generation limit reached")
+
     models = active_tts_models()
     if len(models) < 2:
         raise HTTPException(503, "not enough active TTS models to form a battle")
-    store = ArenaStore(pool)
     ratings = await store.get_latest_ratings(metric_name=PAIRING_METRIC, domain=PAIRING_DOMAIN)
     pair = select_pair(models, ratings)
     battle = await generate_battle(

--- a/runner/src/coval_bench/config.py
+++ b/runner/src/coval_bench/config.py
@@ -108,6 +108,7 @@ class Settings(BaseSettings):
     arena_labeler_key: SecretStr | None = None
     arena_audio_dir: Path = Path("arena-audio")
     arena_audio_base_url: str = ""
+    arena_daily_battle_cap: int = 500
 
 
 @functools.lru_cache(maxsize=1)

--- a/runner/src/coval_bench/db/arena_store.py
+++ b/runner/src/coval_bench/db/arena_store.py
@@ -104,6 +104,25 @@ class ArenaStore:
             await conn.commit()
         return Vote.model_validate(dict(row))
 
+    async def count_battles_today(self) -> int:
+        """Count battles created since the start of the current UTC day.
+
+        Backs the global daily generation cap. Uses the DB clock (``now()``),
+        matching the ``created_at DEFAULT now()`` on the table, so the count and
+        the rows it counts share one clock. The window resets at 00:00 UTC.
+        """
+        sql = (
+            "SELECT count(*) FROM arena.battles "
+            "WHERE created_at >= date_trunc('day', now() AT TIME ZONE 'UTC') AT TIME ZONE 'UTC'"
+        )
+        async with (
+            self._pool.connection() as conn,
+            conn.cursor(row_factory=psycopg.rows.tuple_row) as cur,
+        ):
+            await cur.execute(sql)
+            row = await cur.fetchone()
+        return int(row[0]) if row is not None else 0
+
     async def get_battle(self, battle_id: UUID) -> Battle | None:
         """Return the battle with this id, or ``None`` if it does not exist."""
         sql = """

--- a/runner/src/coval_bench/db/arena_store.py
+++ b/runner/src/coval_bench/db/arena_store.py
@@ -112,8 +112,7 @@ class ArenaStore:
         the rows it counts share one clock. The window resets at 00:00 UTC.
         """
         sql = (
-            "SELECT count(*) FROM arena.battles "
-            "WHERE created_at >= date_trunc('day', now() AT TIME ZONE 'UTC') AT TIME ZONE 'UTC'"
+            "SELECT count(*) FROM arena.battles WHERE created_at >= date_trunc('day', now(), 'UTC')"
         )
         async with (
             self._pool.connection() as conn,

--- a/runner/tests/api/test_arena.py
+++ b/runner/tests/api/test_arena.py
@@ -12,6 +12,7 @@ from typing import Any
 
 import psycopg
 import pytest
+from fastapi import FastAPI
 from httpx import AsyncClient
 
 from coval_bench.arena.pairing import active_tts_models
@@ -606,3 +607,39 @@ async def test_reveal_after_vote_returns_identities(client: AsyncClient, postgre
     assert data["a"]["model"] == "eleven_multilingual_v2"
     assert data["b"]["provider"] == "cartesia"
     assert data["b"]["model"] == "sonic-3"
+
+
+async def test_create_battle_429_when_cap_reached(
+    client: AsyncClient, app: FastAPI, postgresql: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """At/over the daily cap -> 429, and synthesis is never attempted."""
+    await _apply_arena_schema(_make_db_url(postgresql))
+    await _insert_battle(postgresql)  # one battle already today
+
+    app.state.settings = app.state.settings.model_copy(update={"arena_daily_battle_cap": 1})
+
+    async def _no_synth(*args: Any, **kwargs: Any) -> None:
+        raise AssertionError("generate_battle must not run once the cap is reached")
+
+    monkeypatch.setattr("coval_bench.api.routers.arena.generate_battle", _no_synth)
+
+    response = await client.post("/v1/arena/battle", json={"prompt": "hello"})
+    assert response.status_code == 429
+
+
+async def test_create_battle_cap_disabled_when_zero(
+    client: AsyncClient, app: FastAPI, postgresql: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A cap of 0 disables the limit: generation proceeds even with battles present."""
+    await _apply_arena_schema(_make_db_url(postgresql))
+    await _insert_battle(postgresql)
+    await _insert_battle(postgresql)
+
+    app.state.settings = app.state.settings.model_copy(update={"arena_daily_battle_cap": 0})
+    monkeypatch.setattr("coval_bench.arena.generate.TTS_PROVIDERS", _fake_tts_providers(set()))
+    monkeypatch.setattr(
+        "coval_bench.arena.generate.store_clip", lambda settings, src: f"/clips/{src.name}"
+    )
+
+    response = await client.post("/v1/arena/battle", json={"prompt": "hello"})
+    assert response.status_code == 201

--- a/runner/tests/unit/test_arena_store.py
+++ b/runner/tests/unit/test_arena_store.py
@@ -189,6 +189,23 @@ def test_insert_and_read_battle(arena_pg: psycopg.Connection[Any]) -> None:
     asyncio.run(_run())
 
 
+def test_count_battles_today(arena_pg: psycopg.Connection[Any]) -> None:
+    _apply_migrations(arena_pg)
+
+    async def _run() -> None:
+        pool = await _make_pool(arena_pg)
+        try:
+            store = ArenaStore(pool)
+            assert await store.count_battles_today() == 0
+            await store.insert_battle(_make_battle())
+            await store.insert_battle(_make_battle())
+            assert await store.count_battles_today() == 2
+        finally:
+            await pool.close()
+
+    asyncio.run(_run())
+
+
 def test_upsert_vote_dedup_updates_in_place(arena_pg: psycopg.Connection[Any]) -> None:
     _apply_migrations(arena_pg)
 


### PR DESCRIPTION
Add a global daily limit on POST /arena/battle, checked before synthesis so a tripped cap makes no paid TTS calls (429). Configurable via ARENA_DAILY_BATTLE_CAP (<= 0 disables); counts successful battles for the day.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a global daily cap on POST `/arena/battle` by checking a DB count before synthesis, so hitting the limit costs nothing in TTS API calls (returns 429). The cap is configurable via `ARENA_DAILY_BATTLE_CAP` (default 500; `<= 0` disables), counts only persisted (successful) battles, and deliberately allows minor overshoot under concurrency.

- **`arena_store.py`**: Adds `count_battles_today()` using `date_trunc('day', now(), 'UTC')` to anchor to the DB clock, consistent with `created_at DEFAULT now()`.
- **`arena.py`**: Enforces the cap after prompt validation but before model selection/synthesis; fires a PostHog event on cap hit; moves `ArenaStore` instantiation to the top of the handler.
- **Tests**: Two integration tests (429 at cap, 201 with cap disabled) and a unit test for `count_battles_today()`.

<h3>Confidence Score: 5/5</h3>

Safe to merge. The cap check is correctly gated before any TTS call, reads a fresh count on every request, and the acknowledged race-window overshoot cannot corrupt data.

The change is narrow and well-contained: one new DB read method, one early-return guard, one config field, and matching tests. The DB query uses the same clock source as the column default, settings are correctly threaded through the existing app-state dependency, and both the enforced-cap and disabled-cap code paths are covered by integration tests against a real embedded Postgres.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| runner/src/coval_bench/api/routers/arena.py | Adds cap guard (429) before synthesis; moves ArenaStore instantiation earlier; cap check correctly uses settings from app.state via get_settings dependency. |
| runner/src/coval_bench/db/arena_store.py | Adds count_battles_today() using date_trunc three-arg form; consistent with table's DEFAULT now(); defensive row-is-None guard is harmless. |
| runner/src/coval_bench/config.py | Adds arena_daily_battle_cap: int = 500 field; straightforward settings change. |
| runner/tests/api/test_arena.py | Two new integration tests: cap=1 with existing battle gives 429 without invoking synthesis; cap=0 allows full 201 path via existing fake-TTS helpers. |
| runner/tests/unit/test_arena_store.py | Adds unit test for count_battles_today() using a real embedded Postgres; verifies 0→2 after two inserts. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant C as Client
    participant R as POST /arena/battle
    participant DB as arena.battles (DB)
    participant TTS as TTS Providers

    C->>R: "POST /arena/battle {prompt}"
    R->>R: Validate prompt (422 if empty)
    alt "cap > 0"
        R->>DB: count_battles_today()
        DB-->>R: count
        alt "count >= cap"
            R-->>C: 429 daily generation limit reached
        end
    end
    R->>R: "active_tts_models() (503 if < 2)"
    R->>TTS: synthesize audio (pair A + B)
    TTS-->>R: audio clips
    R->>DB: insert battle row
    DB-->>R: battle record
    R-->>C: 201 BattleOut
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant C as Client
    participant R as POST /arena/battle
    participant DB as arena.battles (DB)
    participant TTS as TTS Providers

    C->>R: "POST /arena/battle {prompt}"
    R->>R: Validate prompt (422 if empty)
    alt "cap > 0"
        R->>DB: count_battles_today()
        DB-->>R: count
        alt "count >= cap"
            R-->>C: 429 daily generation limit reached
        end
    end
    R->>R: "active_tts_models() (503 if < 2)"
    R->>TTS: synthesize audio (pair A + B)
    TTS-->>R: audio clips
    R->>DB: insert battle row
    DB-->>R: battle record
    R-->>C: 201 BattleOut
```

</a>

<sub>Reviews (3): Last reviewed commit: ["Use 3-arg date\_trunc for the daily-count..."](https://github.com/coval-ai/benchmarks/commit/bbfdb3ca05b8ed24f3e022e05780a00350ed0eee) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39427698)</sub>

<!-- /greptile_comment -->