### PR TITLE
Add arena voting BFF routes

### DIFF
--- a/web/.env.example
+++ b/web/.env.example
@@ -38,6 +38,12 @@ ARENA_ACCESS_TOKEN=
 # HMAC key for the access cookie. 32+ random bytes, base64. Generate with:
 #   node -e "console.log(require('crypto').randomBytes(32).toString('base64'))"
 ARENA_SESSION_SECRET=
+# Runner base URL the BFF proxies to (e.g. http://localhost:8000). Server-side only.
+ARENA_API_URL=
+# Injected as X-Labeler-Key; must equal the runner's ARENA_LABELER_KEY.
+ARENA_LABELER_KEY=
+# Flip the voting UI off the mock onto the BFF.
+NEXT_PUBLIC_ARENA_SOURCE=api
 
 # PostHog analytics (optional — leave unset to disable capture)
 NEXT_PUBLIC_POSTHOG_TOKEN=

--- a/web/.env.example
+++ b/web/.env.example
@@ -42,8 +42,8 @@ ARENA_SESSION_SECRET=
 ARENA_API_URL=
 # Injected as X-Labeler-Key; must equal the runner's ARENA_LABELER_KEY.
 ARENA_LABELER_KEY=
-# Flip the voting UI off the mock onto the BFF.
-NEXT_PUBLIC_ARENA_SOURCE=api
+# Set to "api" to flip the voting UI off the mock onto the BFF. Empty/unset = mock.
+NEXT_PUBLIC_ARENA_SOURCE=
 
 # PostHog analytics (optional — leave unset to disable capture)
 NEXT_PUBLIC_POSTHOG_TOKEN=

--- a/web/app/api/arena/battle/[id]/reveal/route.ts
+++ b/web/app/api/arena/battle/[id]/reveal/route.ts
@@ -1,0 +1,11 @@
+export const runtime = "nodejs";
+
+import { arenaRunnerFetch } from "@/lib/arena/runner";
+import type { Reveal } from "@/lib/arena/types";
+
+export async function GET(_req: Request, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const res = await arenaRunnerFetch(`/v1/arena/battle/${encodeURIComponent(id)}/reveal`);
+  if (!res.ok) return Response.json({ error: "Reveal failed." }, { status: res.status });
+  return Response.json((await res.json()) as Reveal);
+}

--- a/web/app/api/arena/battle/[id]/reveal/route.ts
+++ b/web/app/api/arena/battle/[id]/reveal/route.ts
@@ -5,7 +5,12 @@ import type { Reveal } from "@/lib/arena/types";
 
 export async function GET(_req: Request, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
-  const res = await arenaRunnerFetch(`/v1/arena/battle/${encodeURIComponent(id)}/reveal`);
+  let res: Response;
+  try {
+    res = await arenaRunnerFetch(`/v1/arena/battle/${encodeURIComponent(id)}/reveal`);
+  } catch {
+    return Response.json({ error: "Reveal failed." }, { status: 502 });
+  }
   if (!res.ok) return Response.json({ error: "Reveal failed." }, { status: res.status });
   return Response.json((await res.json()) as Reveal);
 }

--- a/web/app/api/arena/battle/route.ts
+++ b/web/app/api/arena/battle/route.ts
@@ -1,0 +1,36 @@
+export const runtime = "nodejs";
+export const maxDuration = 60;
+
+import { arenaRunnerFetch } from "@/lib/arena/runner";
+import type { BlindBattle } from "@/lib/arena/types";
+
+interface BattleOut {
+  id: string;
+  prompt_text: string;
+  domain: string | null;
+  audio_a_url: string;
+  audio_b_url: string;
+}
+
+export async function POST(req: Request) {
+  let body: { text?: string };
+  try {
+    body = await req.json();
+  } catch {
+    return Response.json({ error: "Invalid JSON." }, { status: 400 });
+  }
+  const text = body.text?.trim();
+  if (!text) return Response.json({ error: "Prompt is empty." }, { status: 400 });
+
+  const res = await arenaRunnerFetch("/v1/arena/battle", { prompt: text });
+  if (!res.ok) return Response.json({ error: "Battle generation failed." }, { status: res.status });
+
+  const b = (await res.json()) as BattleOut;
+  const battle: BlindBattle = {
+    battleId: b.id,
+    prompt: b.prompt_text,
+    audioA: b.audio_a_url,
+    audioB: b.audio_b_url,
+  };
+  return Response.json(battle, { status: 201 });
+}

--- a/web/app/api/arena/battle/route.ts
+++ b/web/app/api/arena/battle/route.ts
@@ -22,7 +22,12 @@ export async function POST(req: Request) {
   const text = body.text?.trim();
   if (!text) return Response.json({ error: "Prompt is empty." }, { status: 400 });
 
-  const res = await arenaRunnerFetch("/v1/arena/battle", { prompt: text });
+  let res: Response;
+  try {
+    res = await arenaRunnerFetch("/v1/arena/battle", { prompt: text });
+  } catch {
+    return Response.json({ error: "Battle generation failed." }, { status: 502 });
+  }
   if (!res.ok) return Response.json({ error: "Battle generation failed." }, { status: res.status });
 
   const b = (await res.json()) as BattleOut;

--- a/web/app/api/arena/vote/route.ts
+++ b/web/app/api/arena/vote/route.ts
@@ -20,11 +20,16 @@ export async function POST(req: Request) {
     return Response.json({ error: "battleId, outcome, voterId required." }, { status: 400 });
   }
 
-  const res = await arenaRunnerFetch("/v1/arena/vote", {
-    battle_id: battleId,
-    outcome,
-    voter_id: voterId,
-  });
+  let res: Response;
+  try {
+    res = await arenaRunnerFetch("/v1/arena/vote", {
+      battle_id: battleId,
+      outcome,
+      voter_id: voterId,
+    });
+  } catch {
+    return Response.json({ error: "Vote failed." }, { status: 502 });
+  }
   if (!res.ok) return Response.json({ error: "Vote failed." }, { status: res.status });
 
   const v = (await res.json()) as VoteOut;

--- a/web/app/api/arena/vote/route.ts
+++ b/web/app/api/arena/vote/route.ts
@@ -1,0 +1,33 @@
+export const runtime = "nodejs";
+
+import { arenaRunnerFetch } from "@/lib/arena/runner";
+import type { VoteResult } from "@/lib/arena/types";
+
+interface VoteOut {
+  battle_id: string;
+  outcome: string;
+}
+
+export async function POST(req: Request) {
+  let body: { battleId?: string; outcome?: string; voterId?: string };
+  try {
+    body = await req.json();
+  } catch {
+    return Response.json({ error: "Invalid JSON." }, { status: 400 });
+  }
+  const { battleId, outcome, voterId } = body;
+  if (!battleId || !outcome || !voterId) {
+    return Response.json({ error: "battleId, outcome, voterId required." }, { status: 400 });
+  }
+
+  const res = await arenaRunnerFetch("/v1/arena/vote", {
+    battle_id: battleId,
+    outcome,
+    voter_id: voterId,
+  });
+  if (!res.ok) return Response.json({ error: "Vote failed." }, { status: res.status });
+
+  const v = (await res.json()) as VoteOut;
+  const result: VoteResult = { battleId: v.battle_id, outcome: v.outcome as VoteResult["outcome"] };
+  return Response.json(result, { status: 201 });
+}

--- a/web/lib/arena/apiSource.ts
+++ b/web/lib/arena/apiSource.ts
@@ -2,9 +2,8 @@ import type { BattleSource, BlindBattle, Reveal, VoteInput, VoteResult } from ".
 
 // Real battle source: talks to same-origin Next.js API proxy routes under /api/arena/*,
 // which inject the server-only X-Labeler-Key and proxy to the runner. Inert until
-// NEXT_PUBLIC_ARENA_SOURCE=api is set (the factory defaults to the mock). The BFF routes and
-// the runner endpoints they call are not built yet — this adapter defines the contract they
-// must satisfy:
+// NEXT_PUBLIC_ARENA_SOURCE=api is set (the factory defaults to the mock). The BFF routes it
+// calls:
 //   POST /api/arena/battle              { text }                        -> BlindBattle
 //   POST /api/arena/vote                { battleId, outcome, voterId }  -> VoteResult
 //   GET  /api/arena/battle/{id}/reveal                                  -> Reveal

--- a/web/lib/arena/runner.ts
+++ b/web/lib/arena/runner.ts
@@ -1,0 +1,12 @@
+const BASE = process.env.ARENA_API_URL ?? "";
+const KEY = process.env.ARENA_LABELER_KEY ?? "";
+
+export async function arenaRunnerFetch(path: string, body?: unknown): Promise<Response> {
+  if (!BASE) throw new Error("ARENA_API_URL is not configured");
+  const headers = new Headers({ "X-Labeler-Key": KEY });
+  if (body === undefined) {
+    return fetch(`${BASE}${path}`, { method: "GET", headers });
+  }
+  headers.set("Content-Type", "application/json");
+  return fetch(`${BASE}${path}`, { method: "POST", headers, body: JSON.stringify(body) });
+}

--- a/web/lib/arena/runner.ts
+++ b/web/lib/arena/runner.ts
@@ -3,6 +3,7 @@ const KEY = process.env.ARENA_LABELER_KEY ?? "";
 
 export async function arenaRunnerFetch(path: string, body?: unknown): Promise<Response> {
   if (!BASE) throw new Error("ARENA_API_URL is not configured");
+  if (!KEY) throw new Error("ARENA_LABELER_KEY is not configured");
   const headers = new Headers({ "X-Labeler-Key": KEY });
   if (body === undefined) {
     return fetch(`${BASE}${path}`, { method: "GET", headers });

--- a/web/middleware.ts
+++ b/web/middleware.ts
@@ -76,10 +76,11 @@ function playgroundSession(req: NextRequest): NextResponse {
 }
 
 export function middleware(req: NextRequest): NextResponse {
+  if (req.nextUrl.pathname.startsWith("/api/arena")) return arenaGate(req);
   if (req.nextUrl.pathname.startsWith("/arena")) return arenaGate(req);
   return playgroundSession(req);
 }
 
 export const config = {
-  matcher: ["/playground", "/arena", "/arena/:path*"],
+  matcher: ["/playground", "/arena", "/arena/:path*", "/api/arena/:path*"],
 };


### PR DESCRIPTION
Wires the voting UI to the runner so it works against the real backend instead of the mock.

- Same-origin `/api/arena` proxy routes (battle, vote, reveal) that inject the server-only labeler key and map runner field names to the UI shape.
- Gates `/api/arena/*` behind the access cookie, so the endpoints stay hidden (404) in prod alongside the page.
- Flip on with `NEXT_PUBLIC_ARENA_SOURCE=api`; see `.env.example` for the two server vars.

Reveal works once #168 lands; until then the UI just falls back to blind.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR wires the arena voting UI to a real backend by adding three same-origin BFF proxy routes (`/api/arena/battle`, `/api/arena/vote`, `/api/arena/battle/{id}/reveal`) that inject the server-only `X-Labeler-Key`, translate field names between the runner's snake_case API and the UI's camelCase types, and gate everything behind the existing arena access cookie via middleware.

- **`runner.ts`** is the outbound fetch helper: it fast-fails on missing env vars and sets the auth header, cleanly addressing the concerns from the previous review thread.
- **`middleware.ts`** extends the existing `arenaGate` to cover `/api/arena/:path*` with a single new line and matcher entry, keeping the access-control logic centralised and consistent with the page routes.
- **`vote/route.ts`** correctly validates that all three required fields are present, but does not check that `outcome` is one of the three allowed values before forwarding to the runner, and neither the vote nor reveal routes pass an abort signal to the runner fetch — meaning a client that times out can still trigger a write that completes after the client has given up.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the BFF routes are well-structured and the gating logic is correct. Two quality gaps in vote/route.ts (missing outcome allowlist and no server-side abort signal) are worth closing but do not block functionality.

The gating, field mapping, error handling, and env-var fast-fail are all implemented correctly. The two gaps in vote/route.ts are improvements rather than defects that would cause incorrect behavior in the happy path.

web/app/api/arena/vote/route.ts — missing outcome validation and abort signal on the runner fetch

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| web/lib/arena/runner.ts | New helper that wraps outbound runner fetches with fast-fail guards for both env vars and injects X-Labeler-Key; clean and self-contained |
| web/app/api/arena/battle/route.ts | BFF POST handler that validates input, calls runner, and maps snake_case response to BlindBattle; exception handling is correct |
| web/app/api/arena/vote/route.ts | BFF POST handler for voting; missing runtime validation that outcome is one of the allowed Outcome values before forwarding to runner; no abort signal on runner fetch means client-cancelled requests continue running server-side |
| web/app/api/arena/battle/[id]/reveal/route.ts | BFF GET handler for reveal; straightforward proxy with correct encodeURIComponent on the dynamic segment |
| web/middleware.ts | Adds /api/arena to arenaGate check and matcher; gating logic is correct and consistent with existing arena page protection |
| web/lib/arena/apiSource.ts | Comment updated to reflect BFF routes are now implemented; no functional changes |
| web/.env.example | Adds ARENA_API_URL, ARENA_LABELER_KEY, and NEXT_PUBLIC_ARENA_SOURCE with clear comments; well-documented |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Browser
    participant Middleware
    participant BFF as Next.js BFF /api/arena/*
    participant Runner as Arena Runner

    Browser->>Middleware: "GET/POST /api/arena/*"
    Middleware->>Middleware: arenaGate() — check access cookie
    alt Not authenticated (prod)
        Middleware-->>Browser: 404
    else Authenticated / local dev
        Middleware-->>Browser: next()
        Browser->>BFF: "POST /api/arena/battle { text }"
        BFF->>Runner: "POST /v1/arena/battle { prompt } + X-Labeler-Key"
        Runner-->>BFF: "{ id, prompt_text, audio_a_url, audio_b_url }"
        BFF-->>Browser: "201 BlindBattle { battleId, prompt, audioA, audioB }"

        Browser->>BFF: "POST /api/arena/vote { battleId, outcome, voterId }"
        BFF->>Runner: "POST /v1/arena/vote { battle_id, outcome, voter_id } + X-Labeler-Key"
        Runner-->>BFF: "{ battle_id, outcome }"
        BFF-->>Browser: "201 VoteResult { battleId, outcome }"

        Browser->>BFF: "GET /api/arena/battle/{id}/reveal"
        BFF->>Runner: "GET /v1/arena/battle/{id}/reveal + X-Labeler-Key"
        Runner-->>BFF: "Reveal { a, b }"
        BFF-->>Browser: "200 Reveal { a, b }"
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Browser
    participant Middleware
    participant BFF as Next.js BFF /api/arena/*
    participant Runner as Arena Runner

    Browser->>Middleware: "GET/POST /api/arena/*"
    Middleware->>Middleware: arenaGate() — check access cookie
    alt Not authenticated (prod)
        Middleware-->>Browser: 404
    else Authenticated / local dev
        Middleware-->>Browser: next()
        Browser->>BFF: "POST /api/arena/battle { text }"
        BFF->>Runner: "POST /v1/arena/battle { prompt } + X-Labeler-Key"
        Runner-->>BFF: "{ id, prompt_text, audio_a_url, audio_b_url }"
        BFF-->>Browser: "201 BlindBattle { battleId, prompt, audioA, audioB }"

        Browser->>BFF: "POST /api/arena/vote { battleId, outcome, voterId }"
        BFF->>Runner: "POST /v1/arena/vote { battle_id, outcome, voter_id } + X-Labeler-Key"
        Runner-->>BFF: "{ battle_id, outcome }"
        BFF-->>Browser: "201 VoteResult { battleId, outcome }"

        Browser->>BFF: "GET /api/arena/battle/{id}/reveal"
        BFF->>Runner: "GET /v1/arena/battle/{id}/reveal + X-Labeler-Key"
        Runner-->>BFF: "Reveal { a, b }"
        BFF-->>Browser: "200 Reveal { a, b }"
    end
```

</a>

<sub>Reviews (2): Last reviewed commit: ["Match .env.example to mock default; drop..."](https://github.com/coval-ai/benchmarks/commit/93250f6246a34cca49df6e430724434962c149e0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39427731)</sub>

<!-- /greptile_comment -->