### PR TITLE
Add a logging wrapper so gcp picks up logs correctly

### DIFF
--- a/runner/src/coval_bench/logging.py
+++ b/runner/src/coval_bench/logging.py
@@ -14,8 +14,20 @@ import sys
 from typing import Any, Literal
 
 import structlog
+from structlog.typing import EventDict, WrappedLogger
 
 LogLevel = Literal["DEBUG", "INFO", "WARNING", "ERROR"]
+
+
+def add_gcp_severity(_logger: WrappedLogger, _method_name: str, event_dict: EventDict) -> EventDict:
+    """Copy ``level`` into a top-level ``severity`` Cloud Logging can filter on.
+
+    Must run after ``add_log_level``; GCP expects DEBUG/INFO/WARNING/ERROR.
+    """
+    level = event_dict.get("level")
+    if level is not None:
+        event_dict["severity"] = level.upper()
+    return event_dict
 
 
 def configure_logging(
@@ -32,6 +44,7 @@ def configure_logging(
         processors=[
             structlog.contextvars.merge_contextvars,
             structlog.processors.add_log_level,
+            add_gcp_severity,
             structlog.processors.TimeStamper(fmt="iso"),
             structlog.processors.StackInfoRenderer(),
             structlog.processors.format_exc_info,
@@ -78,6 +91,7 @@ def uvicorn_log_config(level: LogLevel = "INFO") -> dict[str, Any]:
                 ],
                 "foreign_pre_chain": [
                     structlog.processors.add_log_level,
+                    add_gcp_severity,
                     structlog.processors.TimeStamper(fmt="iso"),
                     structlog.processors.format_exc_info,
                 ],

--- a/runner/tests/unit/test_logging.py
+++ b/runner/tests/unit/test_logging.py
@@ -47,6 +47,16 @@ def test_configure_logging_emits_json(capsys: pytest.CaptureFixture[str]) -> Non
     assert "timestamp" in record
 
 
+def test_configure_logging_sets_gcp_severity(capsys: pytest.CaptureFixture[str]) -> None:
+    # Cloud Logging filters/alerts on top-level `severity`, not structlog's `level`.
+    configure_logging(level="INFO")
+    structlog.get_logger("test").warning("careful")
+
+    record: dict[str, Any] = json.loads(capsys.readouterr().out.strip())
+    assert record["level"] == "warning"
+    assert record["severity"] == "WARNING"
+
+
 def test_run_failed_event_matches_alert_filter(capsys: pytest.CaptureFixture[str]) -> None:
     # benchmark_run_failure filters on jsonPayload.event="RUN_FAILED" (see
     # benchmark-infra modules/alerting). The key name and value are a prod-alerting
@@ -91,3 +101,4 @@ def test_uvicorn_config_renders_error_log_as_json(
     record: dict[str, Any] = json.loads(lines[0])
     assert record["event"] == "Application startup complete."
     assert record["level"] == "info"
+    assert record["severity"] == "INFO"


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Logs now include GCP Cloud Logging-compatible `severity` field mapping to enable proper log filtering and classification.

* **Tests**
  * Added test coverage verifying `severity` field enrichment for both application and web server logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds an `add_gcp_severity` structlog processor that mirrors structlog's lowercase `level` field into an uppercase `severity` field on every log record. This is necessary because GCP Cloud Logging filters and metric alerts key on `severity`, not `level`. The processor is wired into both the main `configure_logging()` chain and the `uvicorn_log_config()` foreign pre-chain.

- New `add_gcp_severity` processor placed immediately after `structlog.processors.add_log_level` in both processor chains, correctly uppercasing the level string (e.g. `"warning"` → `"WARNING"`).
- Two new test assertions (one new test, one added assertion) verify the field is present and correctly capitalised for both the native structlog and the uvicorn stdlib paths.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a narrow, additive processor insertion with no mutation of existing fields and full test coverage of both paths.

The processor is inserted in the correct position after `add_log_level` in both chains, the `.upper()` call is safe because `add_log_level` always produces a lowercase ASCII string, and the new `severity` field does not interfere with any existing field. Both the native structlog path and the uvicorn stdlib path are covered by tests that parse real JSON output.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| runner/src/coval_bench/logging.py | Adds `add_gcp_severity` processor after `add_log_level` in both structlog and uvicorn processor chains; implementation is correct and well-placed. |
| runner/tests/unit/test_logging.py | Adds a dedicated test for the new `severity` field and extends the uvicorn test — both assertions are correct and exercise the real renderer chain. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["structlog logger call\n(e.g. .warning('msg'))"] --> B["merge_contextvars"]
    B --> C["add_log_level\n→ event_dict['level'] = 'warning'"]
    C --> D["add_gcp_severity NEW\n→ event_dict['severity'] = 'WARNING'"]
    D --> E["TimeStamper\n→ event_dict['timestamp'] = ..."]
    E --> F["StackInfoRenderer / format_exc_info"]
    F --> G["JSONRenderer\n→ stdout JSON"]
    G --> H["GCP Cloud Logging\nfilters on severity=WARNING"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["structlog logger call\n(e.g. .warning('msg'))"] --> B["merge_contextvars"]
    B --> C["add_log_level\n→ event_dict['level'] = 'warning'"]
    C --> D["add_gcp_severity NEW\n→ event_dict['severity'] = 'WARNING'"]
    D --> E["TimeStamper\n→ event_dict['timestamp'] = ..."]
    E --> F["StackInfoRenderer / format_exc_info"]
    F --> G["JSONRenderer\n→ stdout JSON"]
    G --> H["GCP Cloud Logging\nfilters on severity=WARNING"]
```

</a>

<sub>Reviews (1): Last reviewed commit: ["Add a logging wrapper so gcp picks up lo..."](https://github.com/coval-ai/benchmarks/commit/9c16a19de2c4aa69028c8d00beed72a96afe6e56) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39439401)</sub>

<!-- /greptile_comment -->