### PR TITLE
Add arena pairing monitoring and tune-scale tools

### DIFF
--- a/runner/src/coval_bench/__main__.py
+++ b/runner/src/coval_bench/__main__.py
@@ -252,5 +252,163 @@ def arena_seed_battles(per_domain: int) -> None:
     )
 
 
+@arena.command(name="cooccurrence")
+@click.option(
+    "--out",
+    default="arena-cooccurrence.html",
+    show_default=True,
+    type=click.Path(dir_okay=False),
+    help="HTML output path.",
+)
+@click.option(
+    "--metric",
+    default="naturalness",
+    show_default=True,
+    help="Board metric used to Elo-order the axis.",
+)
+@click.option(
+    "--domain",
+    default="all",
+    show_default=True,
+    help="Board domain used to Elo-order the axis.",
+)
+def arena_cooccurrence(out: str, metric: str, domain: str) -> None:
+    """Render the who-battled-whom heatmap (admin: reveals model identities)."""
+    from pathlib import Path
+
+    from coval_bench.arena.monitoring import build_cooccurrence, render_cooccurrence
+    from coval_bench.config import get_settings
+    from coval_bench.db.arena_store import ArenaStore
+    from coval_bench.db.conn import lifespan_pool
+
+    async def _run() -> tuple[int, int]:
+        settings = get_settings()
+        async with lifespan_pool(settings) as pool:
+            store = ArenaStore(pool)
+            rows = await store.get_cooccurrence_counts()
+            ratings = await store.get_latest_ratings(metric_name=metric, domain=domain)
+        elos = {key: r.rating_elo for key, r in ratings.items()}
+        cooc = build_cooccurrence(rows, elos)
+        Path(out).write_text(render_cooccurrence(cooc), encoding="utf-8")
+        return cooc.total, len(cooc.labels)
+
+    total, models = asyncio.run(_run())
+    click.echo(
+        json.dumps({"event": "arena_cooccurrence", "out": out, "battles": total, "models": models})
+    )
+
+
+@arena.command(name="convergence")
+@click.option(
+    "--out",
+    default="arena-convergence.html",
+    show_default=True,
+    type=click.Path(dir_okay=False),
+    help="HTML output path.",
+)
+@click.option("--metric", default="naturalness", show_default=True)
+@click.option("--domain", default="all", show_default=True)
+@click.option(
+    "--threshold",
+    default=9.0,
+    show_default=True,
+    type=float,
+    help="CI half-width (Elo) counted as converged.",
+)
+def arena_convergence(out: str, metric: str, domain: str, threshold: float) -> None:
+    """Render CI-vs-votes convergence per model from snapshot history (admin)."""
+    from pathlib import Path
+
+    from coval_bench.arena.monitoring import build_convergence, render_convergence
+    from coval_bench.config import get_settings
+    from coval_bench.db.arena_store import ArenaStore
+    from coval_bench.db.conn import lifespan_pool
+
+    async def _run() -> int:
+        settings = get_settings()
+        async with lifespan_pool(settings) as pool:
+            rows = await ArenaStore(pool).get_snapshot_history(metric_name=metric, domain=domain)
+        conv = build_convergence(rows, threshold=threshold)
+        Path(out).write_text(render_convergence(conv), encoding="utf-8")
+        return len(conv.series)
+
+    models = asyncio.run(_run())
+    click.echo(json.dumps({"event": "arena_convergence", "out": out, "models": models}))
+
+
+@arena.command(name="tune-scale")
+@click.option(
+    "--out",
+    default="tune-scale.html",
+    show_default=True,
+    type=click.Path(dir_okay=False),
+    help="HTML loss-curve output path.",
+)
+@click.option(
+    "--scales",
+    default="50,100,150,200,250",
+    show_default=True,
+    help="Comma-separated candidate SCALE values.",
+)
+@click.option("--battles", default=2000, show_default=True, type=int)
+@click.option("--refit-every", default=100, show_default=True, type=int)
+@click.option("--replications", default=3, show_default=True, type=int)
+@click.option(
+    "--bootstrap-rounds",
+    default=100,
+    show_default=True,
+    type=int,
+    help="Per-refit bootstrap rounds (drives the CI term in pairing).",
+)
+@click.option(
+    "--elo-spread",
+    default=800.0,
+    show_default=True,
+    type=float,
+    help="True top-to-bottom Elo gap of the synthetic roster.",
+)
+@click.option(
+    "--k",
+    default=1.0,
+    show_default=True,
+    type=float,
+    help="Confidently-wrong penalty weight in the loss.",
+)
+@click.option("--seed", default=0, show_default=True, type=int)
+def arena_tune_scale(
+    out: str,
+    scales: str,
+    battles: int,
+    refit_every: int,
+    replications: int,
+    bootstrap_rounds: int,
+    elo_spread: float,
+    k: float,
+    seed: int,
+) -> None:
+    """Offline: simulate battles to pick the pairing SCALE minimizing penalized CE."""
+    from pathlib import Path
+
+    from coval_bench.arena.tune_scale import render_loss_curve, tune_scale
+
+    scale_values = [float(s) for s in scales.split(",") if s.strip()]
+    results = tune_scale(
+        scales=scale_values,
+        n_battles=battles,
+        refit_every=refit_every,
+        replications=replications,
+        bootstrap_rounds=bootstrap_rounds,
+        elo_spread=elo_spread,
+        k=k,
+        seed=seed,
+    )
+    Path(out).write_text(render_loss_curve(results), encoding="utf-8")
+    best = min(results, key=lambda r: r.loss)
+    for r in results:
+        marker = " <-- best" if r is best else ""
+        click.echo(f"SCALE {r.scale:6g}   L {r.loss:.4f}{marker}")
+    click.echo(json.dumps({"event": "arena_tune_scale", "out": out, "best_scale": best.scale}))
+
+
 if __name__ == "__main__":
     cli()

--- a/runner/src/coval_bench/arena/_render.py
+++ b/runner/src/coval_bench/arena/_render.py
@@ -1,0 +1,156 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Dependency-free HTML/SVG rendering for the arena monitoring tools.
+
+No matplotlib, no JS, no external assets: a heatmap is a colored ``<table>`` and
+a line chart is hand-built ``<svg>``, so the output is one self-contained file an
+operator can open in any browser. Pure string builders — trivially unit-testable.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+
+# Sequential white -> deep-blue ramp (low count -> high count).
+_RAMP_LOW = (255, 255, 255)
+_RAMP_HIGH = (8, 48, 107)
+# Distinct hues cycled across series in a line chart.
+_SERIES_COLORS = (
+    "#1f77b4",
+    "#d62728",
+    "#2ca02c",
+    "#9467bd",
+    "#ff7f0e",
+    "#17becf",
+    "#8c564b",
+    "#e377c2",
+    "#7f7f7f",
+    "#bcbd22",
+)
+
+
+def _lerp_color(t: float) -> str:
+    """Interpolate the white->blue ramp at ``t`` in [0, 1]; return ``#rrggbb``."""
+    t = max(0.0, min(1.0, t))
+    r, g, b = (round(lo + (hi - lo) * t) for lo, hi in zip(_RAMP_LOW, _RAMP_HIGH, strict=True))
+    return f"#{r:02x}{g:02x}{b:02x}"
+
+
+def document(title: str, *body: str) -> str:
+    """Wrap rendered fragments in a minimal standalone HTML document."""
+    style = (
+        "body{font:13px/1.4 system-ui,sans-serif;margin:24px;color:#111}"
+        "h1{font-size:18px}h2{font-size:14px;margin-top:28px}"
+        "table{border-collapse:collapse}td,th{padding:3px 6px;text-align:center}"
+        "th{font-weight:600;font-size:11px}"
+        ".rowhdr{text-align:right;white-space:nowrap}"
+        ".muted{color:#666}"
+    )
+    return (
+        f"<!doctype html><meta charset=utf-8><title>{_esc(title)}</title>"
+        f"<style>{style}</style><h1>{_esc(title)}</h1>" + "".join(body)
+    )
+
+
+def _esc(s: str) -> str:
+    return s.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+
+
+def heatmap_table(
+    labels: Sequence[str],
+    matrix: Sequence[Sequence[int]],
+    *,
+    caption: str = "",
+) -> str:
+    """Render a symmetric integer matrix as a color-graded ``<table>``.
+
+    Diagonal cells are blanked. Color scales by count against the off-diagonal
+    max, so empty inter-tier blocks (the SCALE-too-small "island" signal) read as
+    white gaps. Zero cells show ``0`` on white — distinguishable from the blanked
+    diagonal, which is intentional: a true zero is a matchup that never happened.
+    """
+    n = len(labels)
+    peak = max(
+        (matrix[i][j] for i in range(n) for j in range(n) if i != j),
+        default=0,
+    )
+    head = "<tr><th></th>" + "".join(f"<th>{_esc(lbl)}</th>" for lbl in labels) + "</tr>"
+    rows = []
+    for i in range(n):
+        cells = [f'<th class="rowhdr">{_esc(labels[i])}</th>']
+        for j in range(n):
+            if i == j:
+                cells.append('<td style="background:#222"></td>')
+                continue
+            count = matrix[i][j]
+            shade = (count / peak) if peak > 0 else 0.0
+            fg = "#fff" if shade > 0.55 else "#111"
+            cells.append(f'<td style="background:{_lerp_color(shade)};color:{fg}">{count}</td>')
+        rows.append("<tr>" + "".join(cells) + "</tr>")
+    cap = f"<p class=muted>{_esc(caption)}</p>" if caption else ""
+    return f"<table>{head}{''.join(rows)}</table>{cap}"
+
+
+def line_chart(
+    series: Mapping[str, Sequence[tuple[float, float]]],
+    *,
+    x_label: str,
+    y_label: str,
+    ref_y: float | None = None,
+    width: int = 720,
+    height: int = 420,
+) -> str:
+    """Hand-build an SVG multi-line chart. ``series`` maps name -> (x, y) points.
+
+    ``ref_y`` draws a dashed horizontal reference (e.g. the +/-9 Elo target). An
+    empty ``series`` (or one with no finite points) renders an explanatory note
+    instead of a degenerate axis.
+    """
+    pts = [(x, y) for s in series.values() for (x, y) in s]
+    if not pts:
+        return f"<p class=muted>no data to plot for {_esc(y_label)}</p>"
+    pad = 48.0
+    xs = [x for x, _ in pts]
+    ys = [y for _, y in pts] + ([ref_y] if ref_y is not None else [])
+    x_min, x_max = min(xs), max(xs)
+    y_min, y_max = min(ys), max(ys)
+    x_span = x_max - x_min or 1.0
+    y_span = y_max - y_min or 1.0
+
+    def px(x: float) -> float:
+        return pad + (x - x_min) / x_span * (width - 2 * pad)
+
+    def py(y: float) -> float:
+        return height - pad - (y - y_min) / y_span * (height - 2 * pad)
+
+    parts = [f'<svg viewBox="0 0 {width} {height}" width="{width}" height="{height}">']
+    parts.append(
+        f'<line x1="{pad}" y1="{height - pad}" x2="{width - pad}" '
+        f'y2="{height - pad}" stroke="#999"/>'
+        f'<line x1="{pad}" y1="{pad}" x2="{pad}" y2="{height - pad}" stroke="#999"/>'
+    )
+    parts.append(
+        f'<text x="{width / 2}" y="{height - 12}" text-anchor="middle" '
+        f'font-size="12">{_esc(x_label)}</text>'
+        f'<text x="14" y="{height / 2}" text-anchor="middle" font-size="12" '
+        f'transform="rotate(-90 14 {height / 2})">{_esc(y_label)}</text>'
+    )
+    if ref_y is not None:
+        ry = py(ref_y)
+        parts.append(
+            f'<line x1="{pad}" y1="{ry}" x2="{width - pad}" y2="{ry}" '
+            f'stroke="#c00" stroke-dasharray="4 3"/>'
+            f'<text x="{width - pad}" y="{ry - 4}" text-anchor="end" '
+            f'font-size="10" fill="#c00">{ref_y:g}</text>'
+        )
+    for idx, (name, points) in enumerate(series.items()):
+        color = _SERIES_COLORS[idx % len(_SERIES_COLORS)]
+        path = " ".join(f"{px(x):.1f},{py(y):.1f}" for x, y in points)
+        parts.append(f'<polyline fill="none" stroke="{color}" points="{path}"/>')
+        parts.append(
+            f'<text x="{width - pad + 6}" y="{12 + idx * 14}" font-size="10" '
+            f'fill="{color}">{_esc(name)}</text>'
+        )
+    parts.append("</svg>")
+    return "".join(parts)

--- a/runner/src/coval_bench/arena/monitoring.py
+++ b/runner/src/coval_bench/arena/monitoring.py
@@ -1,0 +1,205 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Admin monitoring views over real arena vote data.
+
+Two read-only diagnostics that tell us whether ``SCALE`` (the pairing volume
+knob) is set sanely in production:
+
+* **co-occurrence matrix** — who battled whom. Empty inter-tier blocks mean the
+  battle graph has fragmented into islands (SCALE too small), which makes the
+  Bradley-Terry fit's cross-tier Elo meaningless.
+* **convergence** — CI half-width vs votes per model from snapshot history. Too
+  many votes to reach the +/-9 Elo target means SCALE is too large (votes wasted
+  on foregone-conclusion matchups).
+
+Both reveal model identities, so these are operator/CLI tools, never the public
+web surface. Pure functions take already-fetched rows; the CLI does the I/O.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import datetime
+
+from coval_bench.arena import _render
+
+# Per-model CI half-width (Elo) we treat as "converged" for time-to-threshold.
+# The established target band is +/-4..9 Elo; 9 is the loose end of that band.
+DEFAULT_CONVERGED_CI = 9.0
+
+ModelKey = tuple[str, str]  # (provider, model)
+
+
+def _label(key: ModelKey) -> str:
+    return f"{key[0]}/{key[1]}"
+
+
+# ---------------------------------------------------------------------------
+# Co-occurrence
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Cooccurrence:
+    """A symmetric who-battled-whom matrix over an ordered model axis."""
+
+    labels: list[str]
+    matrix: list[list[int]]
+    total: int
+
+
+def build_cooccurrence(
+    rows: Sequence[tuple[str, str, str, str, int]],
+    ratings: Mapping[ModelKey, float],
+) -> Cooccurrence:
+    """Fold per-direction battle counts into a symmetric matrix.
+
+    ``rows`` are ``(provider_a, model_a, provider_b, model_b, count)`` straight
+    from ``GROUP BY``. Because ``generate_battle`` randomizes which model lands in
+    slot A vs B, the same matchup appears as both ``(X, Y)`` and ``(Y, X)``; we
+    fold them together (``sorted`` pair key) so one matchup is one cell — not
+    counting this would halve every cell and fake the island signal.
+
+    Axis is ordered by ``rating_elo`` descending so tiers are visually adjacent
+    and inter-tier gaps stand out. Rated models with zero battles still appear
+    (a full empty row is itself a signal); models seen only in battles but absent
+    from ``ratings`` are appended in sorted order.
+    """
+    pair_counts: dict[tuple[ModelKey, ModelKey], int] = {}
+    seen: set[ModelKey] = set()
+    for prov_a, model_a, prov_b, model_b, count in rows:
+        a: ModelKey = (prov_a, model_a)
+        b: ModelKey = (prov_b, model_b)
+        seen.update((a, b))
+        key = (a, b) if a <= b else (b, a)
+        pair_counts[key] = pair_counts.get(key, 0) + count
+
+    rated = sorted(ratings, key=lambda k: (-ratings[k], k))
+    extra = sorted(seen - set(ratings))
+    axis = rated + extra
+    index = {key: i for i, key in enumerate(axis)}
+
+    n = len(axis)
+    matrix = [[0] * n for _ in range(n)]
+    total = 0
+    for (a, b), count in pair_counts.items():
+        i, j = index[a], index[b]
+        matrix[i][j] = count
+        matrix[j][i] = count
+        total += count
+    return Cooccurrence(labels=[_label(k) for k in axis], matrix=matrix, total=total)
+
+
+def _empty_inter_pairs(cooc: Cooccurrence, top_n: int = 8) -> list[tuple[str, str]]:
+    """Widest-separated model pairs that have never battled — island candidates.
+
+    "Widest-separated" is approximated by axis distance: the axis is rating-
+    ordered, so a zero cell far from the diagonal is a top-vs-bottom matchup that
+    never happened — exactly what fragments the graph.
+    """
+    n = len(cooc.labels)
+    gaps = [
+        (abs(i - j), cooc.labels[i], cooc.labels[j])
+        for i in range(n)
+        for j in range(i + 1, n)
+        if cooc.matrix[i][j] == 0
+    ]
+    gaps.sort(reverse=True)
+    return [(a, b) for _, a, b in gaps[:top_n]]
+
+
+def render_cooccurrence(cooc: Cooccurrence) -> str:
+    """Full standalone HTML document for the co-occurrence matrix."""
+    empties = _empty_inter_pairs(cooc)
+    note = (
+        "Empty cells far from the diagonal are wide-gap matchups that never "
+        "happened — if there are blocks of them, SCALE is too small (islands)."
+    )
+    empty_list = (
+        "<h2>Widest never-played matchups</h2><ul>"
+        + "".join(f"<li>{_render._esc(a)} &times; {_render._esc(b)}</li>" for a, b in empties)
+        + "</ul>"
+        if empties
+        else "<p class=muted>Every adjacent-or-wider matchup has at least one battle.</p>"
+    )
+    table = _render.heatmap_table(
+        cooc.labels,
+        cooc.matrix,
+        caption=f"{cooc.total} battles · axis ordered by Elo (strongest first). {note}",
+    )
+    return _render.document("Arena co-occurrence", table, empty_list)
+
+
+# ---------------------------------------------------------------------------
+# Convergence
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Convergence:
+    """Per-model CI-vs-votes trajectories plus time-to-threshold."""
+
+    # model label -> ordered (votes_total, ci_half_width) points
+    series: dict[str, list[tuple[float, float]]]
+    # model label -> votes at first crossing of the converged-CI threshold (or None)
+    time_to_threshold: dict[str, int | None]
+    threshold: float
+
+
+def build_convergence(
+    rows: Sequence[tuple[datetime, str, str, int, float | None]],
+    *,
+    threshold: float = DEFAULT_CONVERGED_CI,
+) -> Convergence:
+    """Group snapshot history into per-model trajectories.
+
+    ``rows`` are ``(computed_at, provider, model, votes_total, ci_half_width)``
+    across every board. Points are ordered by ``computed_at``. Snapshots with a
+    null ``ci_half_width`` (bootstrap produced none) are dropped from the line but
+    still considered "not yet converged". ``time_to_threshold`` is the votes_total
+    at the first snapshot whose CI is at or below ``threshold``.
+    """
+    by_model: dict[str, list[tuple[datetime, int, float]]] = {}
+    for computed_at, prov, model, votes, ci in rows:
+        if ci is None:
+            continue
+        by_model.setdefault(_label((prov, model)), []).append((computed_at, votes, ci))
+
+    series: dict[str, list[tuple[float, float]]] = {}
+    ttt: dict[str, int | None] = {}
+    for label, points in by_model.items():
+        points.sort(key=lambda p: p[0])
+        # time-to-threshold is the *first chronological* crossing...
+        crossed = next((votes for _, votes, ci in points if ci <= threshold), None)
+        ttt[label] = crossed
+        # ...but the plotted line is ordered by votes so the x-axis is monotonic
+        # even if a snapshot's votes_total is ever out of step with its timestamp.
+        series[label] = [(float(votes), ci) for _, votes, ci in sorted(points, key=lambda p: p[1])]
+    return Convergence(series=series, time_to_threshold=ttt, threshold=threshold)
+
+
+def render_convergence(conv: Convergence) -> str:
+    """Full standalone HTML document for the convergence view."""
+    chart = _render.line_chart(
+        conv.series,
+        x_label="votes_total",
+        y_label="ci_half_width (Elo)",
+        ref_y=conv.threshold,
+    )
+
+    def _row(label: str) -> str:
+        votes = conv.time_to_threshold[label]
+        cell = "not reached" if votes is None else str(votes)
+        return f"<tr><th class=rowhdr>{_render._esc(label)}</th><td>{cell}</td></tr>"
+
+    table = (
+        f"<h2>Votes to reach +/-{conv.threshold:g} Elo</h2>"
+        "<table><tr><th></th><th>votes</th></tr>"
+        + "".join(_row(label) for label in sorted(conv.time_to_threshold))
+        + "</table>"
+        "<p class=muted>&gt;5,000 votes to converge ⇒ SCALE too large "
+        "(votes wasted on blowouts).</p>"
+    )
+    return _render.document("Arena convergence", chart, table)

--- a/runner/src/coval_bench/arena/tune_scale.py
+++ b/runner/src/coval_bench/arena/tune_scale.py
@@ -1,0 +1,240 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Offline simulation to tune the pairing ``SCALE`` constant.
+
+NOT in the live pairing path — a research tool. We invent ground-truth model
+strengths, then for each candidate ``SCALE`` run a prequential ("predict then
+observe") simulation: at every step the *current* fitted leaderboard predicts the
+next battle's outcome, we score that prediction, then we reveal the true outcome
+and fold it into the data. A SCALE that picks more informative matchups converges
+the fit faster, so its predictions are sharper sooner and its cumulative loss is
+lower.
+
+Loss is penalized cumulative cross-entropy::
+
+    L = sum_i ( CE_i + K * max(0, CE_i - ln2) )
+    CE_i = -ln(p)   p = predicted prob the fit assigned to the ACTUAL winner
+
+``ln2`` is the coin-flip baseline; the K-term punishes confidently-wrong calls
+(CE > ln2) extra. K=1 here (a confidently-wrong call costs ~2x a correct one).
+
+The generative and predictive probabilities use the exact Davidson form that
+``rating.compute_ratings`` fits, so "truth" and "model" never silently disagree.
+Only *decisive* battles enter the loss, scored by the conditional win
+probability p_i/(p_i+p_j); that is what keeps ln2 the true coin-flip baseline
+(see DECISIONS note in the review summary).
+"""
+
+from __future__ import annotations
+
+import math
+import random
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+from coval_bench.arena.pairing import SCALE, active_tts_models, select_pair
+from coval_bench.arena.rating import (
+    _ELO_SCALE,
+    BattleOutcome,
+    ConvergenceError,
+    compute_ratings,
+)
+from coval_bench.db.models import PairingRating
+from coval_bench.registries.models import RegisteredModel
+
+_EPS = 1e-12
+
+DEFAULT_SCALES = (50.0, 100.0, 150.0, 200.0, 250.0)
+
+
+@dataclass(frozen=True)
+class ScaleResult:
+    """Mean penalized loss for one candidate SCALE across replications."""
+
+    scale: float
+    loss: float  # mean over replications of L / n_decisive (per-battle, comparable)
+    decisive: float  # mean count of decisive (loss-scored) battles
+
+
+def _davidson(theta_i: float, theta_j: float, nu: float) -> tuple[float, float, float]:
+    """Davidson (p_a_win, p_b_win, p_tie) — identical to the fitted likelihood."""
+    ei = math.exp(theta_i)
+    ej = math.exp(theta_j)
+    eij = math.exp((theta_i + theta_j) / 2.0)
+    denom = ei + ej + nu * eij
+    return ei / denom, ej / denom, nu * eij / denom
+
+
+def _penalized_ce(p_winner: float, k: float) -> float:
+    """Penalized CE for one decisive battle: ``CE + k*(CE-ln2)`` when ``CE > ln2``.
+
+    ``p_winner`` is the conditional win prob ``p_i/(p_i+p_j)``, so ``p=0.5`` is the
+    ``ln2`` coin-flip baseline; the K-term only bites confidently-wrong calls.
+    """
+    ce = -math.log(max(p_winner, _EPS))
+    return ce + k * max(0.0, ce - math.log(2.0))
+
+
+def _model_id(m: RegisteredModel) -> str:
+    return f"{m.provider}|{m.model}"
+
+
+def _true_strengths(
+    roster: Sequence[RegisteredModel], *, elo_spread: float, rng: random.Random
+) -> dict[str, float]:
+    """Assign each model a fixed true theta, evenly spread then shuffled.
+
+    Even spacing (not random draws) guarantees a real tier structure to detect;
+    the spread is given in Elo for interpretability and converted with the same
+    constant ``_elo`` uses, so ``elo_spread`` is the true top-to-bottom gap.
+    """
+    n = len(roster)
+    theta_spread = elo_spread / _ELO_SCALE
+    grid = [(-0.5 + i / (n - 1)) * theta_spread for i in range(n)] if n > 1 else [0.0]
+    rng.shuffle(grid)
+    return {_model_id(m): theta for m, theta in zip(roster, grid, strict=True)}
+
+
+def _sample_outcome(p_a: float, p_b: float, rng: random.Random) -> str:
+    r = rng.random()
+    if r < p_a:
+        return "A_WIN"
+    if r < p_a + p_b:
+        return "B_WIN"
+    return "TIE"
+
+
+def _simulate_once(
+    roster: Sequence[RegisteredModel],
+    true_theta: dict[str, float],
+    *,
+    scale: float,
+    n_battles: int,
+    refit_every: int,
+    bootstrap_rounds: int,
+    true_nu: float,
+    k: float,
+    rng: random.Random,
+    fit_seed: int,
+) -> tuple[float, int]:
+    """Run one prequential pass; return (total penalized loss, decisive count)."""
+    outcomes: list[BattleOutcome] = []
+    ratings: dict[tuple[str, str], PairingRating] = {}  # empty -> uniform pairing
+    theta_fit: dict[str, float] = {}
+    nu_fit = 1.0
+    loss = 0.0
+    decisive = 0
+
+    for step in range(n_battles):
+        a, b = select_pair(roster, ratings, scale=scale, rng=rng)
+        id_a, id_b = _model_id(a), _model_id(b)
+
+        # Reveal the true outcome.
+        pa_t, pb_t, _ = _davidson(true_theta[id_a], true_theta[id_b], true_nu)
+        outcome = _sample_outcome(pa_t, pb_t, rng)
+        outcomes.append(BattleOutcome(model_a=id_a, model_b=id_b, outcome=outcome))
+
+        # Score the *prediction made before* observing — only decisive battles,
+        # using the conditional win prob so ln2 is the exact coin-flip baseline.
+        if outcome != "TIE" and id_a in theta_fit and id_b in theta_fit:
+            pa, pb, _ = _davidson(theta_fit[id_a], theta_fit[id_b], nu_fit)
+            denom = pa + pb
+            p_winner = (pa if outcome == "A_WIN" else pb) / denom if denom > 0 else 0.5
+            loss += _penalized_ce(p_winner, k)
+            decisive += 1
+
+        if (step + 1) % refit_every == 0:
+            try:
+                result = compute_ratings(outcomes, bootstrap_rounds=bootstrap_rounds, seed=fit_seed)
+            except ConvergenceError:
+                continue  # keep the previous fit; data still too sparse/disconnected
+            theta_fit = {mr.model_id: mr.rating_bt for mr in result.models}
+            nu_fit = result.tie_param
+            ratings = {}
+            for mr in result.models:
+                provider, model = mr.model_id.split("|", 1)
+                ratings[provider, model] = PairingRating(
+                    rating_elo=mr.rating_elo, ci_half_width=mr.ci_half_width
+                )
+    return loss, decisive
+
+
+def tune_scale(
+    *,
+    scales: Sequence[float] = DEFAULT_SCALES,
+    n_battles: int = 2000,
+    refit_every: int = 100,
+    replications: int = 3,
+    bootstrap_rounds: int = 100,
+    elo_spread: float = 800.0,
+    true_nu: float = 1.0,
+    k: float = 1.0,
+    seed: int = 0,
+) -> list[ScaleResult]:
+    """Sweep candidate SCALEs; return per-SCALE mean per-battle penalized loss.
+
+    The same true strengths are reused across all SCALEs within a replication
+    (paired comparison: SCALE is the only thing that varies), and a fresh truth
+    is drawn per replication. Loss is normalized by decisive count so SCALEs that
+    happen to produce different tie rates stay comparable.
+    """
+    roster = active_tts_models()
+    if len(roster) < 2:
+        raise ValueError("need at least two active TTS models to simulate")
+
+    results: list[ScaleResult] = []
+    for scale in scales:
+        per_rep_loss: list[float] = []
+        per_rep_decisive: list[int] = []
+        for rep in range(replications):
+            # Truth depends only on (seed, rep) — identical across scales.
+            truth_rng = random.Random(seed * 1000 + rep)  # noqa: S311
+            true_theta = _true_strengths(roster, elo_spread=elo_spread, rng=truth_rng)
+            # Sim stream RNG is independent of scale-ordering in the sweep.
+            sim_rng = random.Random(seed * 1000 + rep + 7919)  # noqa: S311
+            loss, decisive = _simulate_once(
+                roster,
+                true_theta,
+                scale=scale,
+                n_battles=n_battles,
+                refit_every=refit_every,
+                bootstrap_rounds=bootstrap_rounds,
+                true_nu=true_nu,
+                k=k,
+                rng=sim_rng,
+                fit_seed=seed * 1000 + rep,
+            )
+            per_rep_loss.append(loss / decisive if decisive else math.inf)
+            per_rep_decisive.append(decisive)
+        results.append(
+            ScaleResult(
+                scale=scale,
+                loss=sum(per_rep_loss) / len(per_rep_loss),
+                decisive=sum(per_rep_decisive) / len(per_rep_decisive),
+            )
+        )
+    return results
+
+
+def render_loss_curve(results: Sequence[ScaleResult]) -> str:
+    """Standalone HTML: loss-vs-SCALE curve plus the winning SCALE."""
+    from coval_bench.arena import _render
+
+    best = min(results, key=lambda r: r.loss)
+    # Order by SCALE so the x-axis is monotonic regardless of the order --scales
+    # was given in; min() above is order-independent so `best` is unaffected.
+    ordered = sorted(results, key=lambda r: r.scale)
+    series = {"penalized CE / battle": [(r.scale, r.loss) for r in ordered]}
+    chart = _render.line_chart(series, x_label="SCALE (Elo)", y_label="mean penalized CE / battle")
+    rows = "".join(
+        f"<tr><th class=rowhdr>{r.scale:g}</th><td>{r.loss:.4f}</td>"
+        f"<td>{'&larr; best' if r is best else ''}</td></tr>"
+        for r in ordered
+    )
+    table = (
+        "<h2>Sweep</h2><table><tr><th>SCALE</th><th>loss</th><th></th></tr>"
+        f"{rows}</table><p>Recommended SCALE: <b>{best.scale:g}</b> "
+        f"(committed default is {SCALE:g}).</p>"
+    )
+    return _render.document("Arena tune-scale", chart, table)

--- a/runner/src/coval_bench/db/arena_store.py
+++ b/runner/src/coval_bench/db/arena_store.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
+from datetime import datetime
 from uuid import UUID
 
 import psycopg
@@ -254,6 +255,67 @@ class ArenaStore:
             )
             for row in rows
         }
+
+    async def get_cooccurrence_counts(
+        self,
+    ) -> list[tuple[str, str, str, str, int]]:
+        """Per-direction battle counts: ``(prov_a, model_a, prov_b, model_b, n)``.
+
+        Raw ``GROUP BY`` over battles — direction is NOT folded here (the A/B slot
+        is randomized at generation), so the caller symmetrizes. Cheap enough to
+        run live on every admin load (~105 groups for a 15-model roster).
+        """
+        sql = """
+            SELECT provider_a, model_a, provider_b, model_b, COUNT(*) AS n
+            FROM arena.battles
+            GROUP BY provider_a, model_a, provider_b, model_b
+        """
+        async with (
+            self._pool.connection() as conn,
+            conn.cursor(row_factory=psycopg.rows.dict_row) as cur,
+        ):
+            await cur.execute(sql)
+            rows = await cur.fetchall()
+        return [
+            (row["provider_a"], row["model_a"], row["provider_b"], row["model_b"], int(row["n"]))
+            for row in rows
+        ]
+
+    async def get_snapshot_history(
+        self,
+        *,
+        metric_name: str,
+        domain: str,
+    ) -> list[tuple[datetime, str, str, int, float | None]]:
+        """All snapshot points for a board, oldest first.
+
+        ``(computed_at, provider, model, votes_total, ci_half_width)`` across every
+        board version for this metric/domain — the convergence view's raw input.
+        ``ci_half_width`` may be null (bootstrap produced none); the caller drops
+        those points from the line.
+        """
+        sql = """
+            SELECT computed_at, provider, model, votes_total, ci_half_width
+            FROM arena.leaderboard_snapshots
+            WHERE metric_name = %(metric)s AND domain = %(domain)s
+            ORDER BY computed_at
+        """
+        async with (
+            self._pool.connection() as conn,
+            conn.cursor(row_factory=psycopg.rows.dict_row) as cur,
+        ):
+            await cur.execute(sql, {"metric": metric_name, "domain": domain})
+            rows = await cur.fetchall()
+        return [
+            (
+                row["computed_at"],
+                row["provider"],
+                row["model"],
+                int(row["votes_total"]),
+                None if row["ci_half_width"] is None else float(row["ci_half_width"]),
+            )
+            for row in rows
+        ]
 
     @asynccontextmanager
     async def snapshot_lock(self) -> AsyncIterator[bool]:

--- a/runner/tests/unit/test_arena_monitoring.py
+++ b/runner/tests/unit/test_arena_monitoring.py
@@ -1,0 +1,125 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the arena monitoring views (co-occurrence + convergence)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+from coval_bench.arena.monitoring import (
+    _empty_inter_pairs,
+    build_convergence,
+    build_cooccurrence,
+    render_convergence,
+    render_cooccurrence,
+)
+
+_DT1 = datetime(2026, 1, 1)
+_DT2 = _DT1 + timedelta(days=1)
+
+
+# --- co-occurrence ---------------------------------------------------------
+
+
+def test_cooccurrence_folds_ab_direction() -> None:
+    rows = [("p", "a", "p", "b", 3), ("p", "b", "p", "a", 2)]
+    ratings = {("p", "a"): 1600.0, ("p", "b"): 1500.0}
+    cooc = build_cooccurrence(rows, ratings)
+    # (a,b) and (b,a) collapse to one symmetric cell holding the full count.
+    assert cooc.matrix[0][1] == 5
+    assert cooc.matrix[1][0] == 5
+    assert cooc.total == 5
+
+
+def test_cooccurrence_axis_ordered_by_elo_desc() -> None:
+    rows: list[tuple[str, str, str, str, int]] = []
+    ratings = {("p", "low"): 1400.0, ("p", "high"): 1600.0, ("p", "mid"): 1500.0}
+    cooc = build_cooccurrence(rows, ratings)
+    assert cooc.labels == ["p/high", "p/mid", "p/low"]
+
+
+def test_cooccurrence_elo_ties_break_deterministically() -> None:
+    # Equal Elo, inserted b-before-a; tie-break is the (provider, model) key asc.
+    ratings = {("p", "b"): 1500.0, ("p", "a"): 1500.0}
+    cooc = build_cooccurrence([], ratings)
+    assert cooc.labels == ["p/a", "p/b"]
+
+
+def test_cooccurrence_rated_model_with_no_battles_is_an_empty_row() -> None:
+    rows = [("p", "a", "p", "b", 4)]
+    ratings = {("p", "a"): 1600.0, ("p", "b"): 1500.0, ("p", "c"): 1400.0}
+    cooc = build_cooccurrence(rows, ratings)
+    c = cooc.labels.index("p/c")
+    assert all(cooc.matrix[c][j] == 0 for j in range(len(cooc.labels)))
+
+
+def test_cooccurrence_unrated_model_appended_after_rated() -> None:
+    rows = [("p", "a", "x", "z", 1)]
+    ratings = {("p", "a"): 1600.0}
+    cooc = build_cooccurrence(rows, ratings)
+    assert cooc.labels == ["p/a", "x/z"]
+
+
+def test_render_cooccurrence_renders_full_grid() -> None:
+    rows = [("p", "a", "p", "b", 1)]
+    ratings = {("p", "a"): 1600.0, ("p", "b"): 1500.0}
+    html = render_cooccurrence(build_cooccurrence(rows, ratings))
+    assert "<table>" in html
+    assert html.count("<td") == 4  # n*n cells for a 2-model axis (incl. diagonal)
+    assert ">1<" in html  # the folded battle count is rendered in its cell
+
+
+def test_empty_inter_pairs_ranks_widest_gap_first() -> None:
+    # 4 models, only the adjacent a-b pair has battled; every other pair is empty.
+    rows = [("p", "a", "p", "b", 1)]
+    ratings = {("p", "a"): 1600.0, ("p", "b"): 1500.0, ("p", "c"): 1400.0, ("p", "d"): 1300.0}
+    cooc = build_cooccurrence(rows, ratings)
+    empties = _empty_inter_pairs(cooc)
+    # a (rank 0) vs d (rank 3) is the widest never-played matchup -> the island
+    # signal -> must surface first.
+    assert empties[0] == ("p/a", "p/d")
+    assert ("p/a", "p/b") not in empties  # that pair *has* a battle
+
+
+# --- convergence -----------------------------------------------------------
+
+
+def test_convergence_time_to_threshold_is_first_crossing() -> None:
+    rows = [
+        (_DT1, "p", "a", 10, 50.0),
+        (_DT2, "p", "a", 40, 8.0),
+    ]
+    conv = build_convergence(rows, threshold=9.0)
+    assert conv.time_to_threshold["p/a"] == 40
+
+
+def test_convergence_drops_null_ci_points() -> None:
+    rows: list[tuple[datetime, str, str, int, float | None]] = [
+        (_DT1, "p", "b", 10, None),
+    ]
+    conv = build_convergence(rows)
+    assert "p/b" not in conv.series
+    assert "p/b" not in conv.time_to_threshold
+
+
+def test_convergence_never_reached_is_none() -> None:
+    rows = [(_DT1, "p", "a", 10, 50.0), (_DT2, "p", "a", 40, 20.0)]
+    conv = build_convergence(rows, threshold=9.0)
+    assert conv.time_to_threshold["p/a"] is None
+
+
+def test_convergence_line_is_ordered_by_votes_not_time() -> None:
+    # Pathological: votes decrease over time. The plotted line must still go
+    # left-to-right on the votes axis.
+    rows = [(_DT1, "p", "a", 40, 30.0), (_DT2, "p", "a", 10, 8.0)]
+    conv = build_convergence(rows, threshold=9.0)
+    xs = [x for x, _ in conv.series["p/a"]]
+    assert xs == sorted(xs)
+    # ...while time-to-threshold stays chronological (the DT2 snapshot).
+    assert conv.time_to_threshold["p/a"] == 10
+
+
+def test_render_convergence_renders_without_data() -> None:
+    conv = build_convergence([])
+    assert "<h1>" in render_convergence(conv)

--- a/runner/tests/unit/test_arena_tune_scale.py
+++ b/runner/tests/unit/test_arena_tune_scale.py
@@ -1,0 +1,96 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the offline tune-scale simulation."""
+
+from __future__ import annotations
+
+import math
+import random
+from collections import Counter
+
+from coval_bench.arena.pairing import active_tts_models
+from coval_bench.arena.rating import _ELO_SCALE
+from coval_bench.arena.tune_scale import (
+    _davidson,
+    _penalized_ce,
+    _sample_outcome,
+    _true_strengths,
+    tune_scale,
+)
+
+# Fast sim knobs so the suite stays quick while still exercising refit + pairing.
+_FAST = {
+    "scales": (100.0, 200.0),
+    "n_battles": 120,
+    "refit_every": 40,
+    "replications": 1,
+    "bootstrap_rounds": 10,
+}
+
+
+def test_penalized_ce_at_coin_flip_is_ln2_with_no_penalty() -> None:
+    # p=0.5 -> CE = ln2 exactly, and the K-term must not fire.
+    assert math.isclose(_penalized_ce(0.5, k=1.0), math.log(2.0))
+
+
+def test_penalized_ce_below_baseline_is_unpenalized() -> None:
+    # Confident-and-right (p=0.9 > 0.5) -> CE < ln2 -> no penalty added.
+    assert math.isclose(_penalized_ce(0.9, k=1.0), -math.log(0.9))
+
+
+def test_penalized_ce_penalizes_confidently_wrong() -> None:
+    # p=0.1 < 0.5 -> CE = -ln(0.1) > ln2 -> add k*(CE - ln2).
+    ce = -math.log(0.1)
+    assert math.isclose(_penalized_ce(0.1, k=1.0), ce + (ce - math.log(2.0)))
+    # Larger K bites harder on the same wrong call.
+    assert _penalized_ce(0.1, k=5.0) > _penalized_ce(0.1, k=1.0)
+
+
+def test_penalized_ce_is_monotonic_in_confidence() -> None:
+    assert _penalized_ce(0.9, k=1.0) < _penalized_ce(0.5, k=1.0) < _penalized_ce(0.1, k=1.0)
+
+
+def test_davidson_probs_sum_to_one() -> None:
+    pa, pb, ptie = _davidson(0.4, -0.2, 1.0)
+    assert math.isclose(pa + pb + ptie, 1.0, rel_tol=1e-12)
+
+
+def test_davidson_stronger_model_wins_more() -> None:
+    pa, pb, _ = _davidson(1.0, -1.0, 1.0)
+    assert pa > pb
+
+
+def test_davidson_is_symmetric_under_swap() -> None:
+    pa, pb, ptie = _davidson(0.7, 0.1, 1.5)
+    pb2, pa2, ptie2 = _davidson(0.1, 0.7, 1.5)
+    assert math.isclose(pa, pa2) and math.isclose(pb, pb2)
+    assert math.isclose(ptie, ptie2)
+
+
+def test_true_strengths_span_the_requested_elo_spread() -> None:
+    roster = active_tts_models()
+    theta = _true_strengths(roster, elo_spread=800.0, rng=random.Random(0))
+    elo_range = (max(theta.values()) - min(theta.values())) * _ELO_SCALE
+    assert math.isclose(elo_range, 800.0, rel_tol=1e-9)
+
+
+def test_sample_outcome_follows_the_probabilities() -> None:
+    rng = random.Random(0)
+    counts = Counter(_sample_outcome(0.7, 0.2, rng) for _ in range(20_000))
+    assert math.isclose(counts["A_WIN"] / 20_000, 0.7, abs_tol=0.02)
+    assert math.isclose(counts["B_WIN"] / 20_000, 0.2, abs_tol=0.02)
+    assert math.isclose(counts["TIE"] / 20_000, 0.1, abs_tol=0.02)
+
+
+def test_tune_scale_is_deterministic_for_a_seed() -> None:
+    a = tune_scale(seed=0, **_FAST)
+    b = tune_scale(seed=0, **_FAST)
+    assert [(r.scale, r.loss) for r in a] == [(r.scale, r.loss) for r in b]
+
+
+def test_tune_scale_returns_one_finite_result_per_scale() -> None:
+    results = tune_scale(seed=0, **_FAST)
+    assert [r.scale for r in results] == [100.0, 200.0]
+    assert all(math.isfinite(r.loss) for r in results)
+    assert all(r.decisive > 0 for r in results)


### PR DESCRIPTION
## Summary

Three admin/offline `arena` CLI tools for sanity-checking the pairing `SCALE`
constant (added in #166). Operator tools only: local HTML output, no web surface,
no auth.

- **`arena cooccurrence`** renders a who-battled-whom heatmap. Folds the
  randomized A/B slot into one symmetric cell and orders the axis by Elo, so empty
  inter-tier blocks (the "island" signal that `SCALE` is too small) stand out.
- **`arena convergence`** plots per-model CI half-width vs `votes_total` from
  snapshot history, with a +/-9 Elo line and votes-to-threshold per model. Flags
  when `SCALE` is too large (votes wasted on blowouts).
- **`arena tune-scale`** runs an offline simulation (not in the live path) that
  sweeps `SCALE` in {50..250} and picks the value minimizing penalized
  cross-entropy loss. Terminal table plus HTML loss curve.

## Design notes

- tune-scale reuses the exact Davidson model `rating.compute_ratings` fits, so
  simulated truth and the fitted model never disagree; `SCALE` is the only thing
  that varies.
- Loss scores only decisive battles via the conditional win probability
  `p_i/(p_i+p_j)`, keeping `ln2` the exact coin-flip baseline. Penalty term
  `K*max(0, CE-ln2)` with `K=1`.
- Pure builders/renderers (no I/O), so the logic is unit-tested directly; the CLI
  does the DB calls and file writes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new arena diagnostics for co-occurrence and convergence, with HTML visualizations and JSON output from the CLI.
  * Added an offline scale-tuning report that compares candidate values and highlights the best result.
  * Introduced reusable chart and table rendering for standalone HTML reports.

* **Bug Fixes**
  * Improved arena reporting to better handle missing data, unrated models, and empty result sets.
  * Added coverage to ensure charts and tuning results stay consistent and deterministic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->