### PR TITLE
Add arena pairing monitoring tools

### DIFF
--- a/runner/src/coval_bench/__main__.py
+++ b/runner/src/coval_bench/__main__.py
@@ -252,5 +252,89 @@ def arena_seed_battles(per_domain: int) -> None:
     )
 
 
+@arena.command(name="cooccurrence")
+@click.option(
+    "--out",
+    default="arena-cooccurrence.html",
+    show_default=True,
+    type=click.Path(dir_okay=False),
+    help="HTML output path.",
+)
+@click.option(
+    "--metric",
+    default="naturalness",
+    show_default=True,
+    help="Board metric used to Elo-order the axis.",
+)
+@click.option(
+    "--domain",
+    default="all",
+    show_default=True,
+    help="Board domain used to Elo-order the axis.",
+)
+def arena_cooccurrence(out: str, metric: str, domain: str) -> None:
+    """Render the who-battled-whom heatmap (admin: reveals model identities)."""
+    from pathlib import Path
+
+    from coval_bench.arena.monitoring import build_cooccurrence, render_cooccurrence
+    from coval_bench.config import get_settings
+    from coval_bench.db.arena_store import ArenaStore
+    from coval_bench.db.conn import lifespan_pool
+
+    async def _run() -> tuple[int, int]:
+        settings = get_settings()
+        async with lifespan_pool(settings) as pool:
+            store = ArenaStore(pool)
+            rows = await store.get_cooccurrence_counts()
+            ratings = await store.get_latest_ratings(metric_name=metric, domain=domain)
+        elos = {key: r.rating_elo for key, r in ratings.items()}
+        cooc = build_cooccurrence(rows, elos)
+        Path(out).write_text(render_cooccurrence(cooc), encoding="utf-8")
+        return cooc.total, len(cooc.labels)
+
+    total, models = asyncio.run(_run())
+    click.echo(
+        json.dumps({"event": "arena_cooccurrence", "out": out, "battles": total, "models": models})
+    )
+
+
+@arena.command(name="convergence")
+@click.option(
+    "--out",
+    default="arena-convergence.html",
+    show_default=True,
+    type=click.Path(dir_okay=False),
+    help="HTML output path.",
+)
+@click.option("--metric", default="naturalness", show_default=True)
+@click.option("--domain", default="all", show_default=True)
+@click.option(
+    "--threshold",
+    default=9.0,
+    show_default=True,
+    type=float,
+    help="CI half-width (Elo) counted as converged.",
+)
+def arena_convergence(out: str, metric: str, domain: str, threshold: float) -> None:
+    """Render CI-vs-votes convergence per model from snapshot history (admin)."""
+    from pathlib import Path
+
+    from coval_bench.arena.monitoring import build_convergence, render_convergence
+    from coval_bench.config import get_settings
+    from coval_bench.db.arena_store import ArenaStore
+    from coval_bench.db.conn import lifespan_pool
+
+    async def _run() -> int:
+        settings = get_settings()
+        async with lifespan_pool(settings) as pool:
+            rows = await ArenaStore(pool).get_snapshot_history(metric_name=metric, domain=domain)
+        conv = build_convergence(rows, threshold=threshold)
+        Path(out).write_text(render_convergence(conv), encoding="utf-8")
+        return len(conv.series)
+
+    models = asyncio.run(_run())
+    click.echo(json.dumps({"event": "arena_convergence", "out": out, "models": models}))
+
+
 if __name__ == "__main__":
     cli()

--- a/runner/src/coval_bench/arena/_render.py
+++ b/runner/src/coval_bench/arena/_render.py
@@ -1,0 +1,156 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Dependency-free HTML/SVG rendering for the arena monitoring tools.
+
+No matplotlib, no JS, no external assets: a heatmap is a colored ``<table>`` and
+a line chart is hand-built ``<svg>``, so the output is one self-contained file an
+operator can open in any browser. Pure string builders — trivially unit-testable.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+
+# Sequential white -> deep-blue ramp (low count -> high count).
+_RAMP_LOW = (255, 255, 255)
+_RAMP_HIGH = (8, 48, 107)
+# Distinct hues cycled across series in a line chart.
+_SERIES_COLORS = (
+    "#1f77b4",
+    "#d62728",
+    "#2ca02c",
+    "#9467bd",
+    "#ff7f0e",
+    "#17becf",
+    "#8c564b",
+    "#e377c2",
+    "#7f7f7f",
+    "#bcbd22",
+)
+
+
+def _lerp_color(t: float) -> str:
+    """Interpolate the white->blue ramp at ``t`` in [0, 1]; return ``#rrggbb``."""
+    t = max(0.0, min(1.0, t))
+    r, g, b = (round(lo + (hi - lo) * t) for lo, hi in zip(_RAMP_LOW, _RAMP_HIGH, strict=True))
+    return f"#{r:02x}{g:02x}{b:02x}"
+
+
+def document(title: str, *body: str) -> str:
+    """Wrap rendered fragments in a minimal standalone HTML document."""
+    style = (
+        "body{font:13px/1.4 system-ui,sans-serif;margin:24px;color:#111}"
+        "h1{font-size:18px}h2{font-size:14px;margin-top:28px}"
+        "table{border-collapse:collapse}td,th{padding:3px 6px;text-align:center}"
+        "th{font-weight:600;font-size:11px}"
+        ".rowhdr{text-align:right;white-space:nowrap}"
+        ".muted{color:#666}"
+    )
+    return (
+        f"<!doctype html><meta charset=utf-8><title>{_esc(title)}</title>"
+        f"<style>{style}</style><h1>{_esc(title)}</h1>" + "".join(body)
+    )
+
+
+def _esc(s: str) -> str:
+    return s.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+
+
+def heatmap_table(
+    labels: Sequence[str],
+    matrix: Sequence[Sequence[int]],
+    *,
+    caption: str = "",
+) -> str:
+    """Render a symmetric integer matrix as a color-graded ``<table>``.
+
+    Diagonal cells are blanked. Color scales by count against the off-diagonal
+    max, so empty inter-tier blocks (the SCALE-too-small "island" signal) read as
+    white gaps. Zero cells show ``0`` on white — distinguishable from the blanked
+    diagonal, which is intentional: a true zero is a matchup that never happened.
+    """
+    n = len(labels)
+    peak = max(
+        (matrix[i][j] for i in range(n) for j in range(n) if i != j),
+        default=0,
+    )
+    head = "<tr><th></th>" + "".join(f"<th>{_esc(lbl)}</th>" for lbl in labels) + "</tr>"
+    rows = []
+    for i in range(n):
+        cells = [f'<th class="rowhdr">{_esc(labels[i])}</th>']
+        for j in range(n):
+            if i == j:
+                cells.append('<td style="background:#222"></td>')
+                continue
+            count = matrix[i][j]
+            shade = (count / peak) if peak > 0 else 0.0
+            fg = "#fff" if shade > 0.55 else "#111"
+            cells.append(f'<td style="background:{_lerp_color(shade)};color:{fg}">{count}</td>')
+        rows.append("<tr>" + "".join(cells) + "</tr>")
+    cap = f"<p class=muted>{_esc(caption)}</p>" if caption else ""
+    return f"<table>{head}{''.join(rows)}</table>{cap}"
+
+
+def line_chart(
+    series: Mapping[str, Sequence[tuple[float, float]]],
+    *,
+    x_label: str,
+    y_label: str,
+    ref_y: float | None = None,
+    width: int = 720,
+    height: int = 420,
+) -> str:
+    """Hand-build an SVG multi-line chart. ``series`` maps name -> (x, y) points.
+
+    ``ref_y`` draws a dashed horizontal reference (e.g. the +/-9 Elo target). An
+    empty ``series`` (or one with no finite points) renders an explanatory note
+    instead of a degenerate axis.
+    """
+    pts = [(x, y) for s in series.values() for (x, y) in s]
+    if not pts:
+        return f"<p class=muted>no data to plot for {_esc(y_label)}</p>"
+    pad = 48.0
+    xs = [x for x, _ in pts]
+    ys = [y for _, y in pts] + ([ref_y] if ref_y is not None else [])
+    x_min, x_max = min(xs), max(xs)
+    y_min, y_max = min(ys), max(ys)
+    x_span = x_max - x_min or 1.0
+    y_span = y_max - y_min or 1.0
+
+    def px(x: float) -> float:
+        return pad + (x - x_min) / x_span * (width - 2 * pad)
+
+    def py(y: float) -> float:
+        return height - pad - (y - y_min) / y_span * (height - 2 * pad)
+
+    parts = [f'<svg viewBox="0 0 {width} {height}" width="{width}" height="{height}">']
+    parts.append(
+        f'<line x1="{pad}" y1="{height - pad}" x2="{width - pad}" '
+        f'y2="{height - pad}" stroke="#999"/>'
+        f'<line x1="{pad}" y1="{pad}" x2="{pad}" y2="{height - pad}" stroke="#999"/>'
+    )
+    parts.append(
+        f'<text x="{width / 2}" y="{height - 12}" text-anchor="middle" '
+        f'font-size="12">{_esc(x_label)}</text>'
+        f'<text x="14" y="{height / 2}" text-anchor="middle" font-size="12" '
+        f'transform="rotate(-90 14 {height / 2})">{_esc(y_label)}</text>'
+    )
+    if ref_y is not None:
+        ry = py(ref_y)
+        parts.append(
+            f'<line x1="{pad}" y1="{ry}" x2="{width - pad}" y2="{ry}" '
+            f'stroke="#c00" stroke-dasharray="4 3"/>'
+            f'<text x="{width - pad}" y="{ry - 4}" text-anchor="end" '
+            f'font-size="10" fill="#c00">{ref_y:g}</text>'
+        )
+    for idx, (name, points) in enumerate(series.items()):
+        color = _SERIES_COLORS[idx % len(_SERIES_COLORS)]
+        path = " ".join(f"{px(x):.1f},{py(y):.1f}" for x, y in points)
+        parts.append(f'<polyline fill="none" stroke="{color}" points="{path}"/>')
+        parts.append(
+            f'<text x="{width - pad + 6}" y="{12 + idx * 14}" font-size="10" '
+            f'fill="{color}">{_esc(name)}</text>'
+        )
+    parts.append("</svg>")
+    return "".join(parts)

--- a/runner/src/coval_bench/arena/_render.py
+++ b/runner/src/coval_bench/arena/_render.py
@@ -124,7 +124,11 @@ def line_chart(
     def py(y: float) -> float:
         return height - pad - (y - y_min) / y_span * (height - 2 * pad)
 
-    parts = [f'<svg viewBox="0 0 {width} {height}" width="{width}" height="{height}">']
+    # Legend grows rightward from the plot edge; widen the canvas so long names
+    # are not clipped at the viewBox (~6px/char at font 10).
+    label_px = max((len(name) for name in series), default=0) * 6
+    canvas_w = width - pad + 12 + label_px
+    parts = [f'<svg viewBox="0 0 {canvas_w:g} {height}" width="{canvas_w:g}" height="{height}">']
     parts.append(
         f'<line x1="{pad}" y1="{height - pad}" x2="{width - pad}" '
         f'y2="{height - pad}" stroke="#999"/>'

--- a/runner/src/coval_bench/arena/monitoring.py
+++ b/runner/src/coval_bench/arena/monitoring.py
@@ -24,10 +24,14 @@ from dataclasses import dataclass
 from datetime import datetime
 
 from coval_bench.arena import _render
+from coval_bench.arena.rating import Status, classify_status
 
 # Per-model CI half-width (Elo) we treat as "converged" for time-to-threshold.
 # The established target band is +/-4..9 Elo; 9 is the loose end of that band.
 DEFAULT_CONVERGED_CI = 9.0
+# Cold-start vote floor: a tight CI on fewer votes is a small-sample artifact,
+# not convergence (adaptive-pairing plan: ~100-300 votes/model).
+DEFAULT_MIN_VOTES = 100
 
 ModelKey = tuple[str, str]  # (provider, model)
 
@@ -141,43 +145,63 @@ def render_cooccurrence(cooc: Cooccurrence) -> str:
 class Convergence:
     """Per-model CI-vs-votes trajectories plus time-to-threshold."""
 
-    # model label -> ordered (votes_total, ci_half_width) points
+    # model label -> ordered (votes_total, ci_half_width) points (null CI omitted)
     series: dict[str, list[tuple[float, float]]]
-    # model label -> votes at first crossing of the converged-CI threshold (or None)
+    # model label -> votes at first snapshot meeting BOTH bars (or None)
     time_to_threshold: dict[str, int | None]
+    # model label -> current confidence tier from its latest CI half-width
+    status: dict[str, Status]
     threshold: float
+    min_votes: int
 
 
 def build_convergence(
     rows: Sequence[tuple[datetime, str, str, int, float | None]],
     *,
     threshold: float = DEFAULT_CONVERGED_CI,
+    min_votes: int = DEFAULT_MIN_VOTES,
 ) -> Convergence:
-    """Group snapshot history into per-model trajectories.
+    """Group snapshot history ``(computed_at, provider, model, votes_total,
+    ci_half_width)`` into per-model trajectories.
 
-    ``rows`` are ``(computed_at, provider, model, votes_total, ci_half_width)``
-    across every board. Points are ordered by ``computed_at``. Snapshots with a
-    null ``ci_half_width`` (bootstrap produced none) are dropped from the line but
-    still considered "not yet converged". ``time_to_threshold`` is the votes_total
-    at the first snapshot whose CI is at or below ``threshold``.
+    Every model appears in ``time_to_threshold`` and ``status`` even if its CI is
+    always null; only null points drop from the plotted ``series``. Converged =
+    first snapshot with CI <= ``threshold`` Elo AND votes >= ``min_votes`` (the
+    floor blocks tiny-sample false positives). ``status`` is ``classify_status``
+    on the latest CI.
     """
-    by_model: dict[str, list[tuple[datetime, int, float]]] = {}
+    by_model: dict[str, list[tuple[datetime, int, float | None]]] = {}
     for computed_at, prov, model, votes, ci in rows:
-        if ci is None:
-            continue
         by_model.setdefault(_label((prov, model)), []).append((computed_at, votes, ci))
 
     series: dict[str, list[tuple[float, float]]] = {}
     ttt: dict[str, int | None] = {}
+    status: dict[str, Status] = {}
     for label, points in by_model.items():
         points.sort(key=lambda p: p[0])
-        # time-to-threshold is the *first chronological* crossing...
-        crossed = next((votes for _, votes, ci in points if ci <= threshold), None)
+        # first chronological snapshot clearing both bars
+        crossed = next(
+            (
+                votes
+                for _, votes, ci in points
+                if ci is not None and ci <= threshold and votes >= min_votes
+            ),
+            None,
+        )
         ttt[label] = crossed
-        # ...but the plotted line is ordered by votes so the x-axis is monotonic
-        # even if a snapshot's votes_total is ever out of step with its timestamp.
-        series[label] = [(float(votes), ci) for _, votes, ci in sorted(points, key=lambda p: p[1])]
-    return Convergence(series=series, time_to_threshold=ttt, threshold=threshold)
+        # latest CI drives the tier (None -> preliminary)
+        status[label] = classify_status(points[-1][2])
+        # drop null points; order by votes for a monotonic x-axis
+        pts = [(float(votes), ci) for _, votes, ci in points if ci is not None]
+        if pts:
+            series[label] = sorted(pts, key=lambda p: p[0])
+    return Convergence(
+        series=series,
+        time_to_threshold=ttt,
+        status=status,
+        threshold=threshold,
+        min_votes=min_votes,
+    )
 
 
 def render_convergence(conv: Convergence) -> str:
@@ -192,11 +216,14 @@ def render_convergence(conv: Convergence) -> str:
     def _row(label: str) -> str:
         votes = conv.time_to_threshold[label]
         cell = "not reached" if votes is None else str(votes)
-        return f"<tr><th class=rowhdr>{_render._esc(label)}</th><td>{cell}</td></tr>"
+        return (
+            f"<tr><th class=rowhdr>{_render._esc(label)}</th>"
+            f"<td>{conv.status[label]}</td><td>{cell}</td></tr>"
+        )
 
     table = (
-        f"<h2>Votes to reach +/-{conv.threshold:g} Elo</h2>"
-        "<table><tr><th></th><th>votes</th></tr>"
+        f"<h2>Convergence (target +/-{conv.threshold:g} Elo, min {conv.min_votes} votes)</h2>"
+        "<table><tr><th></th><th>tier</th><th>votes to converge</th></tr>"
         + "".join(_row(label) for label in sorted(conv.time_to_threshold))
         + "</table>"
         "<p class=muted>&gt;5,000 votes to converge ⇒ SCALE too large "

--- a/runner/src/coval_bench/arena/monitoring.py
+++ b/runner/src/coval_bench/arena/monitoring.py
@@ -1,0 +1,205 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Admin monitoring views over real arena vote data.
+
+Two read-only diagnostics that tell us whether ``SCALE`` (the pairing volume
+knob) is set sanely in production:
+
+* **co-occurrence matrix** — who battled whom. Empty inter-tier blocks mean the
+  battle graph has fragmented into islands (SCALE too small), which makes the
+  Bradley-Terry fit's cross-tier Elo meaningless.
+* **convergence** — CI half-width vs votes per model from snapshot history. Too
+  many votes to reach the +/-9 Elo target means SCALE is too large (votes wasted
+  on foregone-conclusion matchups).
+
+Both reveal model identities, so these are operator/CLI tools, never the public
+web surface. Pure functions take already-fetched rows; the CLI does the I/O.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import datetime
+
+from coval_bench.arena import _render
+
+# Per-model CI half-width (Elo) we treat as "converged" for time-to-threshold.
+# The established target band is +/-4..9 Elo; 9 is the loose end of that band.
+DEFAULT_CONVERGED_CI = 9.0
+
+ModelKey = tuple[str, str]  # (provider, model)
+
+
+def _label(key: ModelKey) -> str:
+    return f"{key[0]}/{key[1]}"
+
+
+# ---------------------------------------------------------------------------
+# Co-occurrence
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Cooccurrence:
+    """A symmetric who-battled-whom matrix over an ordered model axis."""
+
+    labels: list[str]
+    matrix: list[list[int]]
+    total: int
+
+
+def build_cooccurrence(
+    rows: Sequence[tuple[str, str, str, str, int]],
+    ratings: Mapping[ModelKey, float],
+) -> Cooccurrence:
+    """Fold per-direction battle counts into a symmetric matrix.
+
+    ``rows`` are ``(provider_a, model_a, provider_b, model_b, count)`` straight
+    from ``GROUP BY``. Because ``generate_battle`` randomizes which model lands in
+    slot A vs B, the same matchup appears as both ``(X, Y)`` and ``(Y, X)``; we
+    fold them together (``sorted`` pair key) so one matchup is one cell — not
+    counting this would halve every cell and fake the island signal.
+
+    Axis is ordered by ``rating_elo`` descending so tiers are visually adjacent
+    and inter-tier gaps stand out. Rated models with zero battles still appear
+    (a full empty row is itself a signal); models seen only in battles but absent
+    from ``ratings`` are appended in sorted order.
+    """
+    pair_counts: dict[tuple[ModelKey, ModelKey], int] = {}
+    seen: set[ModelKey] = set()
+    for prov_a, model_a, prov_b, model_b, count in rows:
+        a: ModelKey = (prov_a, model_a)
+        b: ModelKey = (prov_b, model_b)
+        seen.update((a, b))
+        key = (a, b) if a <= b else (b, a)
+        pair_counts[key] = pair_counts.get(key, 0) + count
+
+    rated = sorted(ratings, key=lambda k: (-ratings[k], k))
+    extra = sorted(seen - set(ratings))
+    axis = rated + extra
+    index = {key: i for i, key in enumerate(axis)}
+
+    n = len(axis)
+    matrix = [[0] * n for _ in range(n)]
+    total = 0
+    for (a, b), count in pair_counts.items():
+        i, j = index[a], index[b]
+        matrix[i][j] = count
+        matrix[j][i] = count
+        total += count
+    return Cooccurrence(labels=[_label(k) for k in axis], matrix=matrix, total=total)
+
+
+def _empty_inter_pairs(cooc: Cooccurrence, top_n: int = 8) -> list[tuple[str, str]]:
+    """Widest-separated model pairs that have never battled — island candidates.
+
+    "Widest-separated" is approximated by axis distance: the axis is rating-
+    ordered, so a zero cell far from the diagonal is a top-vs-bottom matchup that
+    never happened — exactly what fragments the graph.
+    """
+    n = len(cooc.labels)
+    gaps = [
+        (abs(i - j), cooc.labels[i], cooc.labels[j])
+        for i in range(n)
+        for j in range(i + 1, n)
+        if cooc.matrix[i][j] == 0
+    ]
+    gaps.sort(reverse=True)
+    return [(a, b) for _, a, b in gaps[:top_n]]
+
+
+def render_cooccurrence(cooc: Cooccurrence) -> str:
+    """Full standalone HTML document for the co-occurrence matrix."""
+    empties = _empty_inter_pairs(cooc)
+    note = (
+        "Empty cells far from the diagonal are wide-gap matchups that never "
+        "happened — if there are blocks of them, SCALE is too small (islands)."
+    )
+    empty_list = (
+        "<h2>Widest never-played matchups</h2><ul>"
+        + "".join(f"<li>{_render._esc(a)} &times; {_render._esc(b)}</li>" for a, b in empties)
+        + "</ul>"
+        if empties
+        else "<p class=muted>Every adjacent-or-wider matchup has at least one battle.</p>"
+    )
+    table = _render.heatmap_table(
+        cooc.labels,
+        cooc.matrix,
+        caption=f"{cooc.total} battles · axis ordered by Elo (strongest first). {note}",
+    )
+    return _render.document("Arena co-occurrence", table, empty_list)
+
+
+# ---------------------------------------------------------------------------
+# Convergence
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Convergence:
+    """Per-model CI-vs-votes trajectories plus time-to-threshold."""
+
+    # model label -> ordered (votes_total, ci_half_width) points
+    series: dict[str, list[tuple[float, float]]]
+    # model label -> votes at first crossing of the converged-CI threshold (or None)
+    time_to_threshold: dict[str, int | None]
+    threshold: float
+
+
+def build_convergence(
+    rows: Sequence[tuple[datetime, str, str, int, float | None]],
+    *,
+    threshold: float = DEFAULT_CONVERGED_CI,
+) -> Convergence:
+    """Group snapshot history into per-model trajectories.
+
+    ``rows`` are ``(computed_at, provider, model, votes_total, ci_half_width)``
+    across every board. Points are ordered by ``computed_at``. Snapshots with a
+    null ``ci_half_width`` (bootstrap produced none) are dropped from the line but
+    still considered "not yet converged". ``time_to_threshold`` is the votes_total
+    at the first snapshot whose CI is at or below ``threshold``.
+    """
+    by_model: dict[str, list[tuple[datetime, int, float]]] = {}
+    for computed_at, prov, model, votes, ci in rows:
+        if ci is None:
+            continue
+        by_model.setdefault(_label((prov, model)), []).append((computed_at, votes, ci))
+
+    series: dict[str, list[tuple[float, float]]] = {}
+    ttt: dict[str, int | None] = {}
+    for label, points in by_model.items():
+        points.sort(key=lambda p: p[0])
+        # time-to-threshold is the *first chronological* crossing...
+        crossed = next((votes for _, votes, ci in points if ci <= threshold), None)
+        ttt[label] = crossed
+        # ...but the plotted line is ordered by votes so the x-axis is monotonic
+        # even if a snapshot's votes_total is ever out of step with its timestamp.
+        series[label] = [(float(votes), ci) for _, votes, ci in sorted(points, key=lambda p: p[1])]
+    return Convergence(series=series, time_to_threshold=ttt, threshold=threshold)
+
+
+def render_convergence(conv: Convergence) -> str:
+    """Full standalone HTML document for the convergence view."""
+    chart = _render.line_chart(
+        conv.series,
+        x_label="votes_total",
+        y_label="ci_half_width (Elo)",
+        ref_y=conv.threshold,
+    )
+
+    def _row(label: str) -> str:
+        votes = conv.time_to_threshold[label]
+        cell = "not reached" if votes is None else str(votes)
+        return f"<tr><th class=rowhdr>{_render._esc(label)}</th><td>{cell}</td></tr>"
+
+    table = (
+        f"<h2>Votes to reach +/-{conv.threshold:g} Elo</h2>"
+        "<table><tr><th></th><th>votes</th></tr>"
+        + "".join(_row(label) for label in sorted(conv.time_to_threshold))
+        + "</table>"
+        "<p class=muted>&gt;5,000 votes to converge ⇒ SCALE too large "
+        "(votes wasted on blowouts).</p>"
+    )
+    return _render.document("Arena convergence", chart, table)

--- a/runner/src/coval_bench/db/arena_store.py
+++ b/runner/src/coval_bench/db/arena_store.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
+from datetime import datetime
 from uuid import UUID
 
 import psycopg
@@ -254,6 +255,67 @@ class ArenaStore:
             )
             for row in rows
         }
+
+    async def get_cooccurrence_counts(
+        self,
+    ) -> list[tuple[str, str, str, str, int]]:
+        """Per-direction battle counts: ``(prov_a, model_a, prov_b, model_b, n)``.
+
+        Raw ``GROUP BY`` over battles — direction is NOT folded here (the A/B slot
+        is randomized at generation), so the caller symmetrizes. Cheap enough to
+        run live on every admin load (~105 groups for a 15-model roster).
+        """
+        sql = """
+            SELECT provider_a, model_a, provider_b, model_b, COUNT(*) AS n
+            FROM arena.battles
+            GROUP BY provider_a, model_a, provider_b, model_b
+        """
+        async with (
+            self._pool.connection() as conn,
+            conn.cursor(row_factory=psycopg.rows.dict_row) as cur,
+        ):
+            await cur.execute(sql)
+            rows = await cur.fetchall()
+        return [
+            (row["provider_a"], row["model_a"], row["provider_b"], row["model_b"], int(row["n"]))
+            for row in rows
+        ]
+
+    async def get_snapshot_history(
+        self,
+        *,
+        metric_name: str,
+        domain: str,
+    ) -> list[tuple[datetime, str, str, int, float | None]]:
+        """All snapshot points for a board, oldest first.
+
+        ``(computed_at, provider, model, votes_total, ci_half_width)`` across every
+        board version for this metric/domain — the convergence view's raw input.
+        ``ci_half_width`` may be null (bootstrap produced none); the caller drops
+        those points from the line.
+        """
+        sql = """
+            SELECT computed_at, provider, model, votes_total, ci_half_width
+            FROM arena.leaderboard_snapshots
+            WHERE metric_name = %(metric)s AND domain = %(domain)s
+            ORDER BY computed_at
+        """
+        async with (
+            self._pool.connection() as conn,
+            conn.cursor(row_factory=psycopg.rows.dict_row) as cur,
+        ):
+            await cur.execute(sql, {"metric": metric_name, "domain": domain})
+            rows = await cur.fetchall()
+        return [
+            (
+                row["computed_at"],
+                row["provider"],
+                row["model"],
+                int(row["votes_total"]),
+                None if row["ci_half_width"] is None else float(row["ci_half_width"]),
+            )
+            for row in rows
+        ]
 
     @asynccontextmanager
     async def snapshot_lock(self) -> AsyncIterator[bool]:

--- a/runner/tests/unit/test_arena_monitoring.py
+++ b/runner/tests/unit/test_arena_monitoring.py
@@ -1,0 +1,125 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the arena monitoring views (co-occurrence + convergence)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+from coval_bench.arena.monitoring import (
+    _empty_inter_pairs,
+    build_convergence,
+    build_cooccurrence,
+    render_convergence,
+    render_cooccurrence,
+)
+
+_DT1 = datetime(2026, 1, 1)
+_DT2 = _DT1 + timedelta(days=1)
+
+
+# --- co-occurrence ---------------------------------------------------------
+
+
+def test_cooccurrence_folds_ab_direction() -> None:
+    rows = [("p", "a", "p", "b", 3), ("p", "b", "p", "a", 2)]
+    ratings = {("p", "a"): 1600.0, ("p", "b"): 1500.0}
+    cooc = build_cooccurrence(rows, ratings)
+    # (a,b) and (b,a) collapse to one symmetric cell holding the full count.
+    assert cooc.matrix[0][1] == 5
+    assert cooc.matrix[1][0] == 5
+    assert cooc.total == 5
+
+
+def test_cooccurrence_axis_ordered_by_elo_desc() -> None:
+    rows: list[tuple[str, str, str, str, int]] = []
+    ratings = {("p", "low"): 1400.0, ("p", "high"): 1600.0, ("p", "mid"): 1500.0}
+    cooc = build_cooccurrence(rows, ratings)
+    assert cooc.labels == ["p/high", "p/mid", "p/low"]
+
+
+def test_cooccurrence_elo_ties_break_deterministically() -> None:
+    # Equal Elo, inserted b-before-a; tie-break is the (provider, model) key asc.
+    ratings = {("p", "b"): 1500.0, ("p", "a"): 1500.0}
+    cooc = build_cooccurrence([], ratings)
+    assert cooc.labels == ["p/a", "p/b"]
+
+
+def test_cooccurrence_rated_model_with_no_battles_is_an_empty_row() -> None:
+    rows = [("p", "a", "p", "b", 4)]
+    ratings = {("p", "a"): 1600.0, ("p", "b"): 1500.0, ("p", "c"): 1400.0}
+    cooc = build_cooccurrence(rows, ratings)
+    c = cooc.labels.index("p/c")
+    assert all(cooc.matrix[c][j] == 0 for j in range(len(cooc.labels)))
+
+
+def test_cooccurrence_unrated_model_appended_after_rated() -> None:
+    rows = [("p", "a", "x", "z", 1)]
+    ratings = {("p", "a"): 1600.0}
+    cooc = build_cooccurrence(rows, ratings)
+    assert cooc.labels == ["p/a", "x/z"]
+
+
+def test_render_cooccurrence_renders_full_grid() -> None:
+    rows = [("p", "a", "p", "b", 1)]
+    ratings = {("p", "a"): 1600.0, ("p", "b"): 1500.0}
+    html = render_cooccurrence(build_cooccurrence(rows, ratings))
+    assert "<table>" in html
+    assert html.count("<td") == 4  # n*n cells for a 2-model axis (incl. diagonal)
+    assert ">1<" in html  # the folded battle count is rendered in its cell
+
+
+def test_empty_inter_pairs_ranks_widest_gap_first() -> None:
+    # 4 models, only the adjacent a-b pair has battled; every other pair is empty.
+    rows = [("p", "a", "p", "b", 1)]
+    ratings = {("p", "a"): 1600.0, ("p", "b"): 1500.0, ("p", "c"): 1400.0, ("p", "d"): 1300.0}
+    cooc = build_cooccurrence(rows, ratings)
+    empties = _empty_inter_pairs(cooc)
+    # a (rank 0) vs d (rank 3) is the widest never-played matchup -> the island
+    # signal -> must surface first.
+    assert empties[0] == ("p/a", "p/d")
+    assert ("p/a", "p/b") not in empties  # that pair *has* a battle
+
+
+# --- convergence -----------------------------------------------------------
+
+
+def test_convergence_time_to_threshold_is_first_crossing() -> None:
+    rows = [
+        (_DT1, "p", "a", 10, 50.0),
+        (_DT2, "p", "a", 40, 8.0),
+    ]
+    conv = build_convergence(rows, threshold=9.0)
+    assert conv.time_to_threshold["p/a"] == 40
+
+
+def test_convergence_drops_null_ci_points() -> None:
+    rows: list[tuple[datetime, str, str, int, float | None]] = [
+        (_DT1, "p", "b", 10, None),
+    ]
+    conv = build_convergence(rows)
+    assert "p/b" not in conv.series
+    assert "p/b" not in conv.time_to_threshold
+
+
+def test_convergence_never_reached_is_none() -> None:
+    rows = [(_DT1, "p", "a", 10, 50.0), (_DT2, "p", "a", 40, 20.0)]
+    conv = build_convergence(rows, threshold=9.0)
+    assert conv.time_to_threshold["p/a"] is None
+
+
+def test_convergence_line_is_ordered_by_votes_not_time() -> None:
+    # Pathological: votes decrease over time. The plotted line must still go
+    # left-to-right on the votes axis.
+    rows = [(_DT1, "p", "a", 40, 30.0), (_DT2, "p", "a", 10, 8.0)]
+    conv = build_convergence(rows, threshold=9.0)
+    xs = [x for x, _ in conv.series["p/a"]]
+    assert xs == sorted(xs)
+    # ...while time-to-threshold stays chronological (the DT2 snapshot).
+    assert conv.time_to_threshold["p/a"] == 10
+
+
+def test_render_convergence_renders_without_data() -> None:
+    conv = build_convergence([])
+    assert "<h1>" in render_convergence(conv)

--- a/runner/tests/unit/test_arena_monitoring.py
+++ b/runner/tests/unit/test_arena_monitoring.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta
 
+from coval_bench.arena._render import line_chart
 from coval_bench.arena.monitoring import (
     _empty_inter_pairs,
     build_convergence,
@@ -87,20 +88,35 @@ def test_empty_inter_pairs_ranks_widest_gap_first() -> None:
 
 def test_convergence_time_to_threshold_is_first_crossing() -> None:
     rows = [
-        (_DT1, "p", "a", 10, 50.0),
-        (_DT2, "p", "a", 40, 8.0),
+        (_DT1, "p", "a", 110, 50.0),
+        (_DT2, "p", "a", 140, 8.0),
     ]
     conv = build_convergence(rows, threshold=9.0)
-    assert conv.time_to_threshold["p/a"] == 40
+    assert conv.time_to_threshold["p/a"] == 140
 
 
-def test_convergence_drops_null_ci_points() -> None:
+def test_convergence_keeps_null_ci_model_off_the_line() -> None:
     rows: list[tuple[datetime, str, str, int, float | None]] = [
         (_DT1, "p", "b", 10, None),
     ]
     conv = build_convergence(rows)
+    # null points never plot, but the model stays visible in the table.
     assert "p/b" not in conv.series
-    assert "p/b" not in conv.time_to_threshold
+    assert conv.time_to_threshold["p/b"] is None
+    assert conv.status["p/b"] == "preliminary"
+
+
+def test_convergence_vote_floor_blocks_tiny_sample() -> None:
+    # A tight CI on too few votes is a small-sample artifact, not convergence.
+    rows = [(_DT1, "p", "a", 20, 5.0), (_DT2, "p", "a", 120, 5.0)]
+    conv = build_convergence(rows, threshold=9.0, min_votes=100)
+    assert conv.time_to_threshold["p/a"] == 120
+
+
+def test_convergence_status_is_latest_ci_tier() -> None:
+    rows = [(_DT1, "p", "a", 50, 80.0), (_DT2, "p", "a", 200, 20.0)]
+    conv = build_convergence(rows)
+    assert conv.status["p/a"] == "established"
 
 
 def test_convergence_never_reached_is_none() -> None:
@@ -112,14 +128,30 @@ def test_convergence_never_reached_is_none() -> None:
 def test_convergence_line_is_ordered_by_votes_not_time() -> None:
     # Pathological: votes decrease over time. The plotted line must still go
     # left-to-right on the votes axis.
-    rows = [(_DT1, "p", "a", 40, 30.0), (_DT2, "p", "a", 10, 8.0)]
+    rows = [(_DT1, "p", "a", 140, 30.0), (_DT2, "p", "a", 110, 8.0)]
     conv = build_convergence(rows, threshold=9.0)
     xs = [x for x, _ in conv.series["p/a"]]
     assert xs == sorted(xs)
     # ...while time-to-threshold stays chronological (the DT2 snapshot).
-    assert conv.time_to_threshold["p/a"] == 10
+    assert conv.time_to_threshold["p/a"] == 110
 
 
 def test_render_convergence_renders_without_data() -> None:
     conv = build_convergence([])
     assert "<h1>" in render_convergence(conv)
+
+
+def test_line_chart_widens_canvas_for_long_legend_labels() -> None:
+    # Regression: legend text must fit inside the viewBox, not clip at the edge.
+    short = line_chart({"a": [(0.0, 0.0)]}, x_label="x", y_label="y")
+    long = line_chart(
+        {"anthropic/claude-opus-4-some-very-long-name": [(0.0, 0.0)]},
+        x_label="x",
+        y_label="y",
+    )
+    assert _viewbox_width(long) > _viewbox_width(short)
+
+
+def _viewbox_width(svg: str) -> float:
+    inner = svg.split('viewBox="0 0 ', 1)[1]
+    return float(inner.split(" ", 1)[0])


### PR DESCRIPTION
## Summary

Two admin/offline `arena` CLI tools for sanity-checking the pairing `SCALE`
constant (added in #166). Operator tools only: local HTML output, no web surface,
no auth.

- **`arena cooccurrence`** renders a who-battled-whom heatmap. Folds the
  randomized A/B slot into one symmetric cell and orders the axis by Elo, so empty
  inter-tier blocks (the "island" signal that `SCALE` is too small) stand out.
- **`arena convergence`** plots per-model CI half-width vs `votes_total` from
  snapshot history, with a +/-9 Elo line and votes-to-threshold per model. Flags
  when `SCALE` is too large (votes wasted on blowouts).

Pure builders/renderers (no I/O), so the logic is unit-tested directly; the CLI
does the DB calls and file writes. Rendering is dependency-free (HTML table +
hand-built SVG, no JS or matplotlib).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds two admin-only CLI tools — `arena cooccurrence` (heatmap of who battled whom, Elo-ordered) and `arena convergence` (CI-vs-votes trajectories from snapshot history) — to help operators sanity-check the pairing `SCALE` constant. Both tools are pure-function builders backed by two new read-only DB queries and rendered to self-contained HTML with hand-built SVG; no web surface, no auth, no external dependencies.

- `monitoring.py` introduces `build_cooccurrence` (folds randomised A/B direction into a symmetric matrix, appends unrated models in sorted order) and `build_convergence` (groups snapshot history by model, computes time-to-threshold with a cold-start vote floor, and exposes the trajectory for charting).
- `_render.py` provides a dependency-free `heatmap_table` and `line_chart` (including a canvas-widening fix so long legend labels are not clipped at the SVG viewBox edge).
- `arena_store.py` adds `get_cooccurrence_counts` and `get_snapshot_history`, both using parameterised queries that follow the existing module patterns.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all new code is read-only admin tooling with no web surface, the DB queries are parameterised, and the pure-function builders are well unit-tested.

Both CLI commands only read data and write a local HTML file. The builder logic is deterministic and fully covered by unit tests, including edge cases like all-null CI, vote-floor blocking, and reversed-vote-order series. No changes to shared application paths.

No files require special attention; the minor suggestions are limited to monitoring.py (hardcoded hint), _render.py (legend height guard), and __main__.py (log completeness).

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| runner/src/coval_bench/arena/monitoring.py | New module — implements build_cooccurrence and build_convergence pure builders plus their HTML renderers; logic is sound and well-tested. |
| runner/src/coval_bench/arena/_render.py | New dependency-free HTML/SVG rendering module; canvas-widening fix for long legend labels is present and regression-tested. |
| runner/src/coval_bench/db/arena_store.py | Two new read-only DB methods (get_cooccurrence_counts, get_snapshot_history); both use parameterised queries and follow existing patterns. |
| runner/src/coval_bench/__main__.py | Two new CLI commands (arena cooccurrence, arena convergence) wiring DB calls to pure builders and writing HTML output; no logic in the CLI layer itself. |
| runner/tests/unit/test_arena_monitoring.py | Good unit-test coverage: folding, axis ordering, empty rows, vote-floor, status tier, votes-vs-time ordering, canvas-widening regression; all exercised directly on pure functions. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Operator as Operator (CLI)
    participant CMD as arena cooccurrence / convergence
    participant Store as ArenaStore
    participant DB as PostgreSQL (arena schema)
    participant Builder as build_cooccurrence / build_convergence
    participant Render as _render (heatmap_table / line_chart)
    participant File as HTML output file

    Operator->>CMD: arena cooccurrence --out file.html
    CMD->>Store: get_cooccurrence_counts()
    Store->>DB: "SELECT provider_a,model_a,... COUNT(*) FROM arena.battles GROUP BY ..."
    DB-->>Store: [(prov_a, model_a, prov_b, model_b, n), ...]
    CMD->>Store: get_latest_ratings(metric, domain)
    Store->>DB: SELECT ... FROM arena.leaderboard_snapshots (latest per model)
    DB-->>Store: "{ModelKey: PairingRating}"
    CMD->>Builder: build_cooccurrence(rows, elos)
    Builder-->>CMD: Cooccurrence(labels, matrix, total)
    CMD->>Render: render_cooccurrence(cooc)
    Render-->>CMD: HTML string
    CMD->>File: write_text(html)
    CMD->>Operator: "JSON log {event, out, battles, models}"

    Operator->>CMD: arena convergence --out file.html
    CMD->>Store: get_snapshot_history(metric, domain)
    Store->>DB: SELECT computed_at,provider,model,votes_total,ci_half_width FROM arena.leaderboard_snapshots ORDER BY computed_at
    DB-->>Store: [(datetime, prov, model, votes, ci), ...]
    CMD->>Builder: build_convergence(rows, threshold)
    Builder-->>CMD: Convergence(series, time_to_threshold, status, ...)
    CMD->>Render: render_convergence(conv)
    Render-->>CMD: HTML string
    CMD->>File: write_text(html)
    CMD->>Operator: "JSON log {event, out, models}"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Operator as Operator (CLI)
    participant CMD as arena cooccurrence / convergence
    participant Store as ArenaStore
    participant DB as PostgreSQL (arena schema)
    participant Builder as build_cooccurrence / build_convergence
    participant Render as _render (heatmap_table / line_chart)
    participant File as HTML output file

    Operator->>CMD: arena cooccurrence --out file.html
    CMD->>Store: get_cooccurrence_counts()
    Store->>DB: "SELECT provider_a,model_a,... COUNT(*) FROM arena.battles GROUP BY ..."
    DB-->>Store: [(prov_a, model_a, prov_b, model_b, n), ...]
    CMD->>Store: get_latest_ratings(metric, domain)
    Store->>DB: SELECT ... FROM arena.leaderboard_snapshots (latest per model)
    DB-->>Store: "{ModelKey: PairingRating}"
    CMD->>Builder: build_cooccurrence(rows, elos)
    Builder-->>CMD: Cooccurrence(labels, matrix, total)
    CMD->>Render: render_cooccurrence(cooc)
    Render-->>CMD: HTML string
    CMD->>File: write_text(html)
    CMD->>Operator: "JSON log {event, out, battles, models}"

    Operator->>CMD: arena convergence --out file.html
    CMD->>Store: get_snapshot_history(metric, domain)
    Store->>DB: SELECT computed_at,provider,model,votes_total,ci_half_width FROM arena.leaderboard_snapshots ORDER BY computed_at
    DB-->>Store: [(datetime, prov, model, votes, ci), ...]
    CMD->>Builder: build_convergence(rows, threshold)
    Builder-->>CMD: Convergence(series, time_to_threshold, status, ...)
    CMD->>Render: render_convergence(conv)
    Render-->>CMD: HTML string
    CMD->>File: write_text(html)
    CMD->>Operator: "JSON log {event, out, models}"
```

</a>

<sub>Reviews (2): Last reviewed commit: ["Keep all models in convergence view and ..."](https://github.com/coval-ai/benchmarks/commit/98cc39c01a0a4275459982d950cf99fc3d2a6def) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39607171)</sub>

<!-- /greptile_comment -->