### PR TITLE
Add arena tune-scale simulation tool

### DIFF
--- a/runner/src/coval_bench/__main__.py
+++ b/runner/src/coval_bench/__main__.py
@@ -252,5 +252,79 @@ def arena_seed_battles(per_domain: int) -> None:
     )
 
 
+@arena.command(name="tune-scale")
+@click.option(
+    "--out",
+    default="tune-scale.html",
+    show_default=True,
+    type=click.Path(dir_okay=False),
+    help="HTML loss-curve output path.",
+)
+@click.option(
+    "--scales",
+    default="50,100,150,200,250",
+    show_default=True,
+    help="Comma-separated candidate SCALE values.",
+)
+@click.option("--battles", default=2000, show_default=True, type=int)
+@click.option("--refit-every", default=100, show_default=True, type=int)
+@click.option("--replications", default=3, show_default=True, type=int)
+@click.option(
+    "--bootstrap-rounds",
+    default=100,
+    show_default=True,
+    type=int,
+    help="Per-refit bootstrap rounds (drives the CI term in pairing).",
+)
+@click.option(
+    "--elo-spread",
+    default=800.0,
+    show_default=True,
+    type=float,
+    help="True top-to-bottom Elo gap of the synthetic roster.",
+)
+@click.option(
+    "--k",
+    default=1.0,
+    show_default=True,
+    type=float,
+    help="Confidently-wrong penalty weight in the loss.",
+)
+@click.option("--seed", default=0, show_default=True, type=int)
+def arena_tune_scale(
+    out: str,
+    scales: str,
+    battles: int,
+    refit_every: int,
+    replications: int,
+    bootstrap_rounds: int,
+    elo_spread: float,
+    k: float,
+    seed: int,
+) -> None:
+    """Offline: simulate battles to pick the pairing SCALE minimizing penalized CE."""
+    from pathlib import Path
+
+    from coval_bench.arena.tune_scale import render_loss_curve, tune_scale
+
+    scale_values = [float(s) for s in scales.split(",") if s.strip()]
+    results = tune_scale(
+        scales=scale_values,
+        n_battles=battles,
+        refit_every=refit_every,
+        replications=replications,
+        bootstrap_rounds=bootstrap_rounds,
+        elo_spread=elo_spread,
+        k=k,
+        seed=seed,
+    )
+    Path(out).write_text(render_loss_curve(results), encoding="utf-8")
+    best = min(results, key=lambda r: r.loss)
+    for r in results:
+        marker = " <-- best" if r is best else ""
+        click.echo(f"SCALE {r.scale:6g}   L {r.loss:.4f}{marker}")
+    click.echo(json.dumps({"event": "arena_tune_scale", "out": out, "best_scale": best.scale}))
+
+
 if __name__ == "__main__":
     cli()

--- a/runner/src/coval_bench/__main__.py
+++ b/runner/src/coval_bench/__main__.py
@@ -266,14 +266,14 @@ def arena_seed_battles(per_domain: int) -> None:
     show_default=True,
     help="Comma-separated candidate SCALE values.",
 )
-@click.option("--battles", default=2000, show_default=True, type=int)
-@click.option("--refit-every", default=100, show_default=True, type=int)
-@click.option("--replications", default=3, show_default=True, type=int)
+@click.option("--battles", default=2000, show_default=True, type=click.IntRange(min=1))
+@click.option("--refit-every", default=100, show_default=True, type=click.IntRange(min=1))
+@click.option("--replications", default=3, show_default=True, type=click.IntRange(min=1))
 @click.option(
     "--bootstrap-rounds",
     default=100,
     show_default=True,
-    type=int,
+    type=click.IntRange(min=0),
     help="Per-refit bootstrap rounds (drives the CI term in pairing).",
 )
 @click.option(
@@ -307,7 +307,12 @@ def arena_tune_scale(
 
     from coval_bench.arena.tune_scale import render_loss_curve, tune_scale
 
-    scale_values = [float(s) for s in scales.split(",") if s.strip()]
+    try:
+        scale_values = [float(s) for s in scales.split(",") if s.strip()]
+    except ValueError as exc:
+        raise click.BadParameter(f"--scales must be comma-separated numbers: {exc}") from exc
+    if not scale_values:
+        raise click.BadParameter("--scales must contain at least one value")
     results = tune_scale(
         scales=scale_values,
         n_battles=battles,

--- a/runner/src/coval_bench/arena/tune_scale.py
+++ b/runner/src/coval_bench/arena/tune_scale.py
@@ -1,0 +1,237 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Offline simulation to tune the pairing ``SCALE`` constant.
+
+NOT in the live pairing path — a research tool. We invent ground-truth model
+strengths, then for each candidate ``SCALE`` run a prequential ("predict then
+observe") simulation: at every step the *current* fitted leaderboard predicts the
+next battle's outcome, we score that prediction, then we reveal the true outcome
+and fold it into the data. A SCALE that picks more informative matchups converges
+the fit faster, so its predictions are sharper sooner and its cumulative loss is
+lower.
+
+Loss is penalized cumulative cross-entropy::
+
+    L = sum_i ( CE_i + K * max(0, CE_i - ln2) )
+    CE_i = -ln(p)   p = predicted prob the fit assigned to the ACTUAL winner
+
+``ln2`` is the coin-flip baseline; the K-term punishes confidently-wrong calls
+(CE > ln2) extra. K=1 here (a confidently-wrong call costs ~2x a correct one).
+
+The generative and predictive probabilities use the exact Davidson form that
+``rating.compute_ratings`` fits, so "truth" and "model" never silently disagree.
+Only *decisive* battles enter the loss, scored by the conditional win
+probability p_i/(p_i+p_j); that is what keeps ln2 the true coin-flip baseline
+(see DECISIONS note in the review summary).
+"""
+
+from __future__ import annotations
+
+import math
+import random
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+from coval_bench.arena.pairing import SCALE, active_tts_models, select_pair
+from coval_bench.arena.rating import (
+    _ELO_SCALE,
+    BattleOutcome,
+    ConvergenceError,
+    compute_ratings,
+)
+from coval_bench.db.models import PairingRating
+from coval_bench.registries.models import RegisteredModel
+
+_EPS = 1e-12
+
+DEFAULT_SCALES = (50.0, 100.0, 150.0, 200.0, 250.0)
+
+
+@dataclass(frozen=True)
+class ScaleResult:
+    """Mean penalized loss for one candidate SCALE across replications."""
+
+    scale: float
+    loss: float  # mean over replications of L / n_decisive (per-battle, comparable)
+    decisive: float  # mean count of decisive (loss-scored) battles
+
+
+def _davidson(theta_i: float, theta_j: float, nu: float) -> tuple[float, float, float]:
+    """Davidson (p_a_win, p_b_win, p_tie) — identical to the fitted likelihood."""
+    ei = math.exp(theta_i)
+    ej = math.exp(theta_j)
+    eij = math.exp((theta_i + theta_j) / 2.0)
+    denom = ei + ej + nu * eij
+    return ei / denom, ej / denom, nu * eij / denom
+
+
+def _penalized_ce(p_winner: float, k: float) -> float:
+    """Penalized CE for one decisive battle: ``CE + k*(CE-ln2)`` when ``CE > ln2``.
+
+    ``p_winner`` is the conditional win prob ``p_i/(p_i+p_j)``, so ``p=0.5`` is the
+    ``ln2`` coin-flip baseline; the K-term only bites confidently-wrong calls.
+    """
+    ce = -math.log(max(p_winner, _EPS))
+    return ce + k * max(0.0, ce - math.log(2.0))
+
+
+def _model_id(m: RegisteredModel) -> str:
+    return f"{m.provider}|{m.model}"
+
+
+def _true_strengths(
+    roster: Sequence[RegisteredModel], *, elo_spread: float, rng: random.Random
+) -> dict[str, float]:
+    """Assign each model a fixed true theta, evenly spread then shuffled.
+
+    Even spacing (not random draws) guarantees a real tier structure to detect;
+    the spread is given in Elo for interpretability and converted with the same
+    constant ``_elo`` uses, so ``elo_spread`` is the true top-to-bottom gap.
+    """
+    n = len(roster)
+    theta_spread = elo_spread / _ELO_SCALE
+    grid = [(-0.5 + i / (n - 1)) * theta_spread for i in range(n)] if n > 1 else [0.0]
+    rng.shuffle(grid)
+    return {_model_id(m): theta for m, theta in zip(roster, grid, strict=True)}
+
+
+def _sample_outcome(p_a: float, p_b: float, rng: random.Random) -> str:
+    r = rng.random()
+    if r < p_a:
+        return "A_WIN"
+    if r < p_a + p_b:
+        return "B_WIN"
+    return "TIE"
+
+
+def _simulate_once(
+    roster: Sequence[RegisteredModel],
+    true_theta: dict[str, float],
+    *,
+    scale: float,
+    n_battles: int,
+    refit_every: int,
+    bootstrap_rounds: int,
+    true_nu: float,
+    k: float,
+    rng: random.Random,
+    fit_seed: int,
+) -> tuple[float, int]:
+    """Run one prequential pass; return (total penalized loss, decisive count)."""
+    outcomes: list[BattleOutcome] = []
+    ratings: dict[tuple[str, str], PairingRating] = {}  # empty -> uniform pairing
+    theta_fit: dict[str, float] = {}
+    nu_fit = 1.0
+    loss = 0.0
+    decisive = 0
+
+    for step in range(n_battles):
+        a, b = select_pair(roster, ratings, scale=scale, rng=rng)
+        id_a, id_b = _model_id(a), _model_id(b)
+
+        # Reveal the true outcome.
+        pa_t, pb_t, _ = _davidson(true_theta[id_a], true_theta[id_b], true_nu)
+        outcome = _sample_outcome(pa_t, pb_t, rng)
+        outcomes.append(BattleOutcome(model_a=id_a, model_b=id_b, outcome=outcome))
+
+        # Score the *prediction made before* observing — only decisive battles,
+        # using the conditional win prob so ln2 is the exact coin-flip baseline.
+        if outcome != "TIE" and id_a in theta_fit and id_b in theta_fit:
+            pa, pb, _ = _davidson(theta_fit[id_a], theta_fit[id_b], nu_fit)
+            denom = pa + pb
+            p_winner = (pa if outcome == "A_WIN" else pb) / denom if denom > 0 else 0.5
+            loss += _penalized_ce(p_winner, k)
+            decisive += 1
+
+        if (step + 1) % refit_every == 0:
+            try:
+                result = compute_ratings(outcomes, bootstrap_rounds=bootstrap_rounds, seed=fit_seed)
+            except ConvergenceError:
+                continue  # keep the previous fit; data still too sparse/disconnected
+            theta_fit = {mr.model_id: mr.rating_bt for mr in result.models}
+            nu_fit = result.tie_param
+            ratings = {}
+            for mr in result.models:
+                provider, model = mr.model_id.split("|", 1)
+                ratings[provider, model] = PairingRating(
+                    rating_elo=mr.rating_elo, ci_half_width=mr.ci_half_width
+                )
+    return loss, decisive
+
+
+def tune_scale(
+    *,
+    scales: Sequence[float] = DEFAULT_SCALES,
+    n_battles: int = 2000,
+    refit_every: int = 100,
+    replications: int = 3,
+    bootstrap_rounds: int = 100,
+    elo_spread: float = 800.0,
+    true_nu: float = 1.0,
+    k: float = 1.0,
+    seed: int = 0,
+) -> list[ScaleResult]:
+    """Sweep candidate SCALEs; return per-SCALE mean per-battle penalized loss.
+
+    The same true strengths are reused across all SCALEs within a replication
+    (paired comparison: SCALE is the only thing that varies), and a fresh truth
+    is drawn per replication. Loss is normalized by decisive count so SCALEs that
+    happen to produce different tie rates stay comparable.
+    """
+    roster = active_tts_models()
+    if len(roster) < 2:
+        raise ValueError("need at least two active TTS models to simulate")
+
+    results: list[ScaleResult] = []
+    for scale in scales:
+        per_rep_loss: list[float] = []
+        per_rep_decisive: list[int] = []
+        for rep in range(replications):
+            # Three streams from (seed, rep): identical across scales (paired
+            # comparison), distinct from each other. truth/sim share an engine so
+            # are seeded by name; fit_seed feeds numpy (a different engine).
+            truth_rng = random.Random(f"{seed}:{rep}:truth")  # noqa: S311
+            true_theta = _true_strengths(roster, elo_spread=elo_spread, rng=truth_rng)
+            sim_rng = random.Random(f"{seed}:{rep}:sim")  # noqa: S311
+            loss, decisive = _simulate_once(
+                roster,
+                true_theta,
+                scale=scale,
+                n_battles=n_battles,
+                refit_every=refit_every,
+                bootstrap_rounds=bootstrap_rounds,
+                true_nu=true_nu,
+                k=k,
+                rng=sim_rng,
+                fit_seed=seed * 1000 + rep,
+            )
+            per_rep_loss.append(loss / decisive if decisive else math.inf)
+            per_rep_decisive.append(decisive)
+        results.append(
+            ScaleResult(
+                scale=scale,
+                loss=sum(per_rep_loss) / len(per_rep_loss),
+                decisive=sum(per_rep_decisive) / len(per_rep_decisive),
+            )
+        )
+    return results
+
+
+def render_loss_curve(results: Sequence[ScaleResult]) -> str:
+    """Self-contained HTML table of the SCALE sweep (no chart, no shared helper)."""
+    best = min(results, key=lambda r: r.loss)
+    ordered = sorted(results, key=lambda r: r.scale)
+    rows = "".join(
+        f'<tr><th style="text-align:right">{r.scale:g}</th><td>{r.loss:.4f}</td>'
+        f"<td>{'&larr; best' if r is best else ''}</td></tr>"
+        for r in ordered
+    )
+    style = "body{font:13px/1.4 system-ui,sans-serif;margin:24px}td,th{padding:3px 8px}"
+    return (
+        "<!doctype html><meta charset=utf-8><title>Arena tune-scale</title>"
+        f"<style>{style}</style><h1>Arena tune-scale</h1>"
+        "<table><tr><th>SCALE</th><th>loss</th><th></th></tr>"
+        f"{rows}</table><p>Recommended SCALE: <b>{best.scale:g}</b> "
+        f"(committed default is {SCALE:g}).</p>"
+    )

--- a/runner/src/coval_bench/arena/tune_scale.py
+++ b/runner/src/coval_bench/arena/tune_scale.py
@@ -135,10 +135,11 @@ def _simulate_once(
         outcome = _sample_outcome(pa_t, pb_t, rng)
         outcomes.append(BattleOutcome(model_a=id_a, model_b=id_b, outcome=outcome))
 
-        # Score the *prediction made before* observing — only decisive battles,
-        # using the conditional win prob so ln2 is the exact coin-flip baseline.
-        if outcome != "TIE" and id_a in theta_fit and id_b in theta_fit:
-            pa, pb, _ = _davidson(theta_fit[id_a], theta_fit[id_b], nu_fit)
+        # Score every decisive battle by conditional win prob (ln2 = coin flip).
+        # Models not yet fitted use the neutral prior theta=0 (scores at ln2)
+        # instead of being dropped, so the loss covers the full run.
+        if outcome != "TIE":
+            pa, pb, _ = _davidson(theta_fit.get(id_a, 0.0), theta_fit.get(id_b, 0.0), nu_fit)
             denom = pa + pb
             p_winner = (pa if outcome == "A_WIN" else pb) / denom if denom > 0 else 0.5
             loss += _penalized_ce(p_winner, k)
@@ -179,6 +180,16 @@ def tune_scale(
     is drawn per replication. Loss is normalized by decisive count so SCALEs that
     happen to produce different tie rates stay comparable.
     """
+    if not scales:
+        raise ValueError("scales must contain at least one value")
+    if n_battles <= 0:
+        raise ValueError("n_battles must be > 0")
+    if refit_every <= 0:
+        raise ValueError("refit_every must be > 0")
+    if replications <= 0:
+        raise ValueError("replications must be > 0")
+    if bootstrap_rounds < 0:
+        raise ValueError("bootstrap_rounds must be >= 0")
     roster = active_tts_models()
     if len(roster) < 2:
         raise ValueError("need at least two active TTS models to simulate")

--- a/runner/tests/unit/test_arena_tune_scale.py
+++ b/runner/tests/unit/test_arena_tune_scale.py
@@ -9,6 +9,8 @@ import math
 import random
 from collections import Counter
 
+import pytest
+
 from coval_bench.arena.pairing import active_tts_models
 from coval_bench.arena.rating import _ELO_SCALE
 from coval_bench.arena.tune_scale import (
@@ -98,3 +100,33 @@ def test_tune_scale_returns_one_finite_result_per_scale() -> None:
     assert [r.scale for r in results] == [100.0, 200.0]
     assert all(math.isfinite(r.loss) for r in results)
     assert all(r.decisive > 0 for r in results)
+
+
+def test_short_run_with_no_refit_is_still_finite() -> None:
+    # n_battles < refit_every -> the fit never runs, so every battle is scored
+    # against the neutral prior. Loss must stay finite (not collapse to inf).
+    results = tune_scale(
+        scales=(150.0,),
+        n_battles=20,
+        refit_every=100,
+        replications=1,
+        bootstrap_rounds=0,
+        seed=0,
+    )
+    assert math.isfinite(results[0].loss)
+    assert results[0].decisive > 0
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"scales": ()},
+        {"n_battles": 0},
+        {"refit_every": 0},
+        {"replications": 0},
+        {"bootstrap_rounds": -1},
+    ],
+)
+def test_tune_scale_rejects_invalid_params(kwargs: dict[str, object]) -> None:
+    with pytest.raises(ValueError):
+        tune_scale(**kwargs)  # type: ignore[arg-type]

--- a/runner/tests/unit/test_arena_tune_scale.py
+++ b/runner/tests/unit/test_arena_tune_scale.py
@@ -1,0 +1,100 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the offline tune-scale simulation."""
+
+from __future__ import annotations
+
+import math
+import random
+from collections import Counter
+
+from coval_bench.arena.pairing import active_tts_models
+from coval_bench.arena.rating import _ELO_SCALE
+from coval_bench.arena.tune_scale import (
+    ScaleResult,
+    _davidson,
+    _penalized_ce,
+    _sample_outcome,
+    _true_strengths,
+    tune_scale,
+)
+
+
+def _fast(seed: int) -> list[ScaleResult]:
+    """tune_scale with fast knobs: quick but still exercises refit + pairing."""
+    return tune_scale(
+        scales=(100.0, 200.0),
+        n_battles=120,
+        refit_every=40,
+        replications=1,
+        bootstrap_rounds=10,
+        seed=seed,
+    )
+
+
+def test_penalized_ce_at_coin_flip_is_ln2_with_no_penalty() -> None:
+    # p=0.5 -> CE = ln2 exactly, and the K-term must not fire.
+    assert math.isclose(_penalized_ce(0.5, k=1.0), math.log(2.0))
+
+
+def test_penalized_ce_below_baseline_is_unpenalized() -> None:
+    # Confident-and-right (p=0.9 > 0.5) -> CE < ln2 -> no penalty added.
+    assert math.isclose(_penalized_ce(0.9, k=1.0), -math.log(0.9))
+
+
+def test_penalized_ce_penalizes_confidently_wrong() -> None:
+    # p=0.1 < 0.5 -> CE = -ln(0.1) > ln2 -> add k*(CE - ln2).
+    ce = -math.log(0.1)
+    assert math.isclose(_penalized_ce(0.1, k=1.0), ce + (ce - math.log(2.0)))
+    # Larger K bites harder on the same wrong call.
+    assert _penalized_ce(0.1, k=5.0) > _penalized_ce(0.1, k=1.0)
+
+
+def test_penalized_ce_is_monotonic_in_confidence() -> None:
+    assert _penalized_ce(0.9, k=1.0) < _penalized_ce(0.5, k=1.0) < _penalized_ce(0.1, k=1.0)
+
+
+def test_davidson_probs_sum_to_one() -> None:
+    pa, pb, ptie = _davidson(0.4, -0.2, 1.0)
+    assert math.isclose(pa + pb + ptie, 1.0, rel_tol=1e-12)
+
+
+def test_davidson_stronger_model_wins_more() -> None:
+    pa, pb, _ = _davidson(1.0, -1.0, 1.0)
+    assert pa > pb
+
+
+def test_davidson_is_symmetric_under_swap() -> None:
+    pa, pb, ptie = _davidson(0.7, 0.1, 1.5)
+    pb2, pa2, ptie2 = _davidson(0.1, 0.7, 1.5)
+    assert math.isclose(pa, pa2) and math.isclose(pb, pb2)
+    assert math.isclose(ptie, ptie2)
+
+
+def test_true_strengths_span_the_requested_elo_spread() -> None:
+    roster = active_tts_models()
+    theta = _true_strengths(roster, elo_spread=800.0, rng=random.Random(0))
+    elo_range = (max(theta.values()) - min(theta.values())) * _ELO_SCALE
+    assert math.isclose(elo_range, 800.0, rel_tol=1e-9)
+
+
+def test_sample_outcome_follows_the_probabilities() -> None:
+    rng = random.Random(0)
+    counts = Counter(_sample_outcome(0.7, 0.2, rng) for _ in range(20_000))
+    assert math.isclose(counts["A_WIN"] / 20_000, 0.7, abs_tol=0.02)
+    assert math.isclose(counts["B_WIN"] / 20_000, 0.2, abs_tol=0.02)
+    assert math.isclose(counts["TIE"] / 20_000, 0.1, abs_tol=0.02)
+
+
+def test_tune_scale_is_deterministic_for_a_seed() -> None:
+    a = _fast(seed=0)
+    b = _fast(seed=0)
+    assert [(r.scale, r.loss) for r in a] == [(r.scale, r.loss) for r in b]
+
+
+def test_tune_scale_returns_one_finite_result_per_scale() -> None:
+    results = _fast(seed=0)
+    assert [r.scale for r in results] == [100.0, 200.0]
+    assert all(math.isfinite(r.loss) for r in results)
+    assert all(r.decisive > 0 for r in results)


### PR DESCRIPTION
## Summary

`arena tune-scale`: an offline tool (not in the live pairing path) that sweeps the
pairing `SCALE` constant over a candidate range and picks the value minimizing
penalized cross-entropy loss. Terminal table plus a dependency-free HTML loss
curve.

It runs a prequential ("predict then observe") simulation over synthetic model
strengths: at each step the current fitted leaderboard predicts the next battle,
that prediction is scored, then the true outcome is revealed and folded in. A
`SCALE` that picks more informative matchups converges the fit faster, so its
cumulative loss is lower.

## Design notes

- Reuses the exact Davidson model `rating.compute_ratings` fits (predicting from
  `rating_bt`/`tie_param`), so simulated truth and the fitted model never disagree;
  `SCALE` is the only thing that varies.
- Loss scores only decisive battles via the conditional win probability
  `p_i/(p_i+p_j)`, keeping `ln2` the exact coin-flip baseline. Penalty term
  `K*max(0, CE-ln2)` with `K=1`.

## Notes

- Stacked on #173 (the monitoring tools PR), which carries the shared
  `arena/_render.py` helper. Retarget to `main` once that merges.
- Split out of #172.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an `arena tune-scale` CLI subcommand to evaluate multiple pairing SCALE candidates using offline prequential simulations.
  * Generates a shareable HTML loss-curve report and prints each candidate loss, highlighting the recommended best SCALE; also outputs a final JSON line with the results.
* **Bug Fixes**
  * Improved determinism and repeatability of tuning runs via fixed, seeded randomness.
* **Tests**
  * Added unit tests covering the tuning pipeline, loss behavior, probability calculations, parameter validation, and edge cases (e.g., short runs without refits).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds an offline `arena tune-scale` research command that sweeps a set of candidate `SCALE` values over a prequential simulation and picks the one with the lowest penalized cross-entropy loss, writing a self-contained HTML table and printing a terminal summary. Previously-flagged input-validation gaps (empty `--scales`, zero replications/refits, and PRNG seed collisions) are all resolved in this version.

- `tune_scale.py` implements the Davidson-model simulation loop: for each `(scale, replication)` pair a fresh truth is generated, the current fitted leaderboard predicts each decisive battle, the loss is accumulated, and the model is periodically refit via `compute_ratings` — keeping truth and model in full agreement.
- The CLI command (`arena tune-scale`) parses and validates all options, delegates to `tune_scale`/`render_loss_curve`, and emits a structured JSON log line with the recommended scale.
- The test file covers mathematical invariants (`_davidson`, `_penalized_ce`), statistical correctness of `_sample_outcome`, determinism under fixed seeds, and parametrized rejection of invalid inputs.

<h3>Confidence Score: 5/5</h3>

Safe to merge — this is a standalone offline research tool with no live-path changes, and all previously identified input-validation gaps have been addressed.

The simulation logic is mathematically consistent (Davidson truth and model use identical forms), the seeding strategy correctly isolates the three random streams, all parameter bounds are enforced before any work starts, and the test suite covers both mathematical invariants and invalid-input rejection.

No files require special attention; the one minor gap (per-value scale validation) is in tune_scale.py lines 183–185.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| runner/src/coval_bench/arena/tune_scale.py | New offline simulation module: prequential sweep of SCALE values using Davidson model and penalized CE loss. Validation guards, deterministic seeding, and paired-comparison design are all correctly implemented. |
| runner/src/coval_bench/__main__.py | Adds the `arena tune-scale` Click command with proper bounds enforcement on all numeric options and a clear `BadParameter` guard for empty or malformed `--scales` input. |
| runner/tests/unit/test_arena_tune_scale.py | Comprehensive unit tests covering mathematical properties, statistical correctness, determinism, edge cases (no-refit run), and validation of bad parameter rejection. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant CLI as arena tune-scale (CLI)
    participant TS as tune_scale()
    participant S as _simulate_once()
    participant P as select_pair()
    participant D as _davidson()
    participant R as compute_ratings()

    CLI->>TS: scales, n_battles, replications, seed
    loop for each scale
        loop for each replication
            TS->>S: "roster, true_theta, scale, rng=sim_rng"
            loop for each battle step
                S->>P: roster, ratings, scale, rng
                P-->>S: (model_a, model_b)
                S->>D: true_theta[a], true_theta[b], true_nu
                D-->>S: (pa_t, pb_t, p_tie)
                S->>S: _sample_outcome → outcome
                Note over S: if decisive: score with _penalized_ce
                alt every refit_every steps
                    S->>R: outcomes, bootstrap_rounds, fit_seed
                    R-->>S: fitted theta, nu, CI
                    S->>S: update ratings for next pairing
                end
            end
            S-->>TS: (total_loss, decisive_count)
        end
        TS->>TS: mean loss / decisive across reps → ScaleResult
    end
    TS-->>CLI: list[ScaleResult]
    CLI->>CLI: render_loss_curve → HTML
    CLI->>CLI: print table + JSON log line
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant CLI as arena tune-scale (CLI)
    participant TS as tune_scale()
    participant S as _simulate_once()
    participant P as select_pair()
    participant D as _davidson()
    participant R as compute_ratings()

    CLI->>TS: scales, n_battles, replications, seed
    loop for each scale
        loop for each replication
            TS->>S: "roster, true_theta, scale, rng=sim_rng"
            loop for each battle step
                S->>P: roster, ratings, scale, rng
                P-->>S: (model_a, model_b)
                S->>D: true_theta[a], true_theta[b], true_nu
                D-->>S: (pa_t, pb_t, p_tie)
                S->>S: _sample_outcome → outcome
                Note over S: if decisive: score with _penalized_ce
                alt every refit_every steps
                    S->>R: outcomes, bootstrap_rounds, fit_seed
                    R-->>S: fitted theta, nu, CI
                    S->>S: update ratings for next pairing
                end
            end
            S-->>TS: (total_loss, decisive_count)
        end
        TS->>TS: mean loss / decisive across reps → ScaleResult
    end
    TS-->>CLI: list[ScaleResult]
    CLI->>CLI: render_loss_curve → HTML
    CLI->>CLI: print table + JSON log line
```

</a>

<sub>Reviews (4): Last reviewed commit: ["Merge main into arena/tune-scale"](https://github.com/coval-ai/benchmarks/commit/eef5e9ea8a5b0eefcfa55e26b2b8d5fe47a4e6bd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39607224)</sub>

<!-- /greptile_comment -->