### PR TITLE
Add Voice Arena leaderboard page (internal-gated)

### DIFF
--- a/web/app/arena/leaderboard/arena-leaderboard.tsx
+++ b/web/app/arena/leaderboard/arena-leaderboard.tsx
@@ -1,0 +1,91 @@
+// Copyright 2026 The Coval Benchmarks Authors
+// SPDX-License-Identifier: Apache-2.0
+
+"use client";
+
+import DashboardHeader from "@/components/layout/DashboardHeader";
+import DashboardFooter from "@/components/dashboard/DashboardFooter";
+import {
+  normalizeModelName,
+  normalizeTTSProviderName,
+  toModelKey,
+} from "@/lib/utils/formatters";
+import { useArenaLeaderboardQuery, type ArenaLeaderboardEntry } from "@/lib/arena/leaderboard";
+
+function eloLabel(entry: ArenaLeaderboardEntry): string {
+  const elo = Math.round(entry.rating_elo);
+  if (entry.ci_half_width == null) return `${elo}`;
+  return `${elo} ± ${Math.round(entry.ci_half_width)}`;
+}
+
+export function ArenaLeaderboardPage() {
+  const { data, isLoading, isError } = useArenaLeaderboardQuery();
+  const entries = data?.entries ?? [];
+  const isEmpty = !isLoading && !isError && entries.length === 0;
+
+  return (
+    <div className="relative flex min-h-screen flex-col bg-background text-text-primary">
+      <DashboardHeader />
+      <main className="relative z-10 mx-auto w-full max-w-3xl flex-1 px-4 pb-10 pt-[84px] sm:px-6 md:pt-[96px]">
+        <h1 className="text-2xl font-medium tracking-tight sm:text-3xl">Voice Arena leaderboard</h1>
+        <p className="mt-2 text-sm text-text-secondary">
+          Models ranked by Elo rating from blind A/B votes.
+        </p>
+
+        {isLoading && <p className="mt-8 text-sm text-text-tertiary">Loading…</p>}
+        {isError && (
+          <p className="mt-8 text-sm text-text-tertiary">
+            Couldn’t load the leaderboard. Try again.
+          </p>
+        )}
+        {isEmpty && (
+          <p className="mt-8 text-sm text-text-tertiary">No ratings yet. Vote to populate.</p>
+        )}
+
+        {entries.length > 0 && (
+          <div className="mt-6 overflow-x-auto">
+            <table className="w-full border-collapse text-sm">
+              <thead>
+                <tr className="border-b border-border-primary text-left text-text-tertiary">
+                  <th className="py-2 pr-4 font-medium">#</th>
+                  <th className="py-2 pr-4 font-medium">Model</th>
+                  <th className="py-2 pr-4 font-medium">Provider</th>
+                  <th className="py-2 pr-4 text-right font-medium">Elo</th>
+                </tr>
+              </thead>
+              <tbody>
+                {entries.map((entry, i) => {
+                  const preliminary = entry.status === "preliminary";
+                  return (
+                    <tr
+                      key={`${entry.provider}/${entry.model}`}
+                      className={`border-b border-border-secondary ${
+                        preliminary ? "text-text-tertiary" : "text-text-primary"
+                      }`}
+                    >
+                      <td className="py-2.5 pr-4 tabular-nums">{i + 1}</td>
+                      <td className="py-2.5 pr-4">
+                        {normalizeModelName(toModelKey(entry.provider, entry.model))}
+                      </td>
+                      <td className="py-2.5 pr-4 text-text-secondary">
+                        {normalizeTTSProviderName(entry.provider)}
+                      </td>
+                      <td className="py-2.5 pr-4 text-right tabular-nums">
+                        {preliminary ? (
+                          <span className="text-text-tertiary">collecting…</span>
+                        ) : (
+                          eloLabel(entry)
+                        )}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </main>
+      <DashboardFooter />
+    </div>
+  );
+}

--- a/web/app/arena/leaderboard/page.tsx
+++ b/web/app/arena/leaderboard/page.tsx
@@ -1,0 +1,13 @@
+// Copyright 2026 The Coval Benchmarks Authors
+// SPDX-License-Identifier: Apache-2.0
+
+import { Suspense } from "react";
+import { ArenaLeaderboardPage } from "./arena-leaderboard";
+
+export default function Page() {
+  return (
+    <Suspense fallback={null}>
+      <ArenaLeaderboardPage />
+    </Suspense>
+  );
+}

--- a/web/lib/arena/leaderboard.ts
+++ b/web/lib/arena/leaderboard.ts
@@ -1,0 +1,47 @@
+// Copyright 2026 The Coval Benchmarks Authors
+// SPDX-License-Identifier: Apache-2.0
+
+import { useQuery } from "@tanstack/react-query";
+
+export type ArenaStatus = "preliminary" | "usable" | "established";
+
+export interface ArenaLeaderboardEntry {
+  provider: string;
+  model: string;
+  rating_elo: number;
+  rating_bt: number;
+  ci_low: number | null;
+  ci_high: number | null;
+  ci_half_width: number | null;
+  votes_total: number;
+  wins: number;
+  losses: number;
+  ties: number;
+  status: ArenaStatus;
+}
+
+export interface ArenaLeaderboard {
+  metric: string;
+  domain: string;
+  computed_at: string | null;
+  methodology_version: string | null;
+  entries: ArenaLeaderboardEntry[];
+}
+
+const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
+
+export async function getArenaLeaderboard(signal?: AbortSignal): Promise<ArenaLeaderboard> {
+  const res = await fetch(`${API_BASE}/v1/arena/leaderboard`, {
+    headers: { Accept: "application/json" },
+    signal,
+  });
+  if (!res.ok) throw new Error(`arena leaderboard -> ${res.status}`);
+  return (await res.json()) as ArenaLeaderboard;
+}
+
+export function useArenaLeaderboardQuery() {
+  return useQuery({
+    queryKey: ["arena", "leaderboard"],
+    queryFn: ({ signal }: { signal: AbortSignal }) => getArenaLeaderboard(signal),
+  });
+}


### PR DESCRIPTION
Adds the internal Voice Arena leaderboard at /arena/leaderboard.

Elo-ranked board. CI shown as 1512 ± 48. Preliminary rows are grayed out as "collecting...". Friendly empty state when there are no ratings yet.

Gated behind the server-only ARENA_ENABLED flag (404s when unset), so it stays off public prod and is only reachable where the flag is set.

Response type is hand-written in web/lib/arena/leaderboard.ts to keep the stale codegen schema.ts out of the diff.

Confidentiality is handled in a follow-up PRs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new arena leaderboard page with loading, error, and empty states.
  * Displayed leaderboard entries in a responsive table with model name, provider, and Elo details.
  * Showed preliminary entries as “collecting…” and included confidence intervals when available.
  * Enabled leaderboard data fetching from the app’s API with seamless loading on page open.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds the internal Voice Arena leaderboard at `/arena/leaderboard`, showing Elo-ranked model entries with confidence intervals and a "collecting…" placeholder for preliminary rows. The page is correctly gated by the existing `arenaGate` middleware that already covers `/arena/:path*`, and TanStack Query is properly wired through the global `ApiProviders`.

- `web/lib/arena/leaderboard.ts` — hand-written types, a fetch helper, and a `useArenaLeaderboardQuery` hook; no `"use client"` directive (avoids blocking server-side use of the types).
- `web/app/arena/leaderboard/arena-leaderboard.tsx` — client component that renders the table; rank numbers are based on array index position rather than an explicit sort of `rating_elo`.
- `web/app/arena/leaderboard/page.tsx` — thin server wrapper with a `Suspense` boundary; the middleware gate is in `web/middleware.ts` and covers this route.

<h3>Confidence Score: 4/5</h3>

Safe to merge for internal use; the leaderboard table may display wrong rank numbers if the API response is not Elo-sorted.

The rank column uses the array index of each entry rather than sorting entries by rating_elo on the client. If the API response order ever differs from Elo descending — by insertion time, alphabetically, or after a backend refactor — the displayed ranks silently misrepresent standings.

web/app/arena/leaderboard/arena-leaderboard.tsx — the rank rendering loop at line 57.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| web/app/arena/leaderboard/arena-leaderboard.tsx | Client component for the leaderboard table; rank column uses array index position rather than sorting entries by rating_elo, so it silently shows wrong ranks if the API response order changes. |
| web/app/arena/leaderboard/page.tsx | Thin server component wrapper; gating is handled by the existing arenaGate middleware that already covers /arena/:path*, so the page is correctly protected. |
| web/lib/arena/leaderboard.ts | Type definitions, fetch helper, and TanStack Query hook; QueryClientProvider is correctly set up in ApiProviders, type definitions are clean. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Browser
    participant Middleware as Next.js Middleware (arenaGate)
    participant Page as /arena/leaderboard (Server Component)
    participant Client as ArenaLeaderboardPage (Client Component)
    participant API as NEXT_PUBLIC_API_URL /v1/arena/leaderboard

    Browser->>Middleware: GET /arena/leaderboard
    Middleware-->>Browser: 404 (no token/cookie)
    Note over Middleware: or
    Middleware->>Page: pass (valid access cookie)
    Page-->>Browser: HTML shell + Suspense fallback
    Browser->>Client: hydrate
    Client->>API: fetch /v1/arena/leaderboard
    API-->>Client: ArenaLeaderboard JSON
    Client-->>Browser: render ranked table
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Browser
    participant Middleware as Next.js Middleware (arenaGate)
    participant Page as /arena/leaderboard (Server Component)
    participant Client as ArenaLeaderboardPage (Client Component)
    participant API as NEXT_PUBLIC_API_URL /v1/arena/leaderboard

    Browser->>Middleware: GET /arena/leaderboard
    Middleware-->>Browser: 404 (no token/cookie)
    Note over Middleware: or
    Middleware->>Page: pass (valid access cookie)
    Page-->>Browser: HTML shell + Suspense fallback
    Browser->>Client: hydrate
    Client->>API: fetch /v1/arena/leaderboard
    API-->>Client: ArenaLeaderboard JSON
    Client-->>Browser: render ranked table
```

</a>

<sub>Reviews (2): Last reviewed commit: ["Add Voice Arena leaderboard page"](https://github.com/coval-ai/benchmarks/commit/08fa0dc818eff76433aafff4176d96395f1a044d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39636575)</sub>

<!-- /greptile_comment -->