### PR TITLE
Add new assembly ai stt model

### DIFF
--- a/runner/src/coval_bench/providers/stt/assemblyai.py
+++ b/runner/src/coval_bench/providers/stt/assemblyai.py
@@ -3,7 +3,7 @@
 
 """AssemblyAI real-time STT provider (v3 streaming API).
 
-Model: universal-streaming
+Models: universal-streaming, universal-3.5-pro
 Wire protocol: WebSocket, wss://streaming.assemblyai.com/v3/ws
 Auth: Authorization: <key>
 Close: {"type": "Terminate"}
@@ -30,6 +30,7 @@ logger = structlog.get_logger(__name__)
 # would inflate TTFT measurements.
 _SPEECH_MODEL_MAP: dict[str, str] = {
     "universal-streaming": "universal-streaming-english",
+    "universal-3.5-pro": "universal-3-5-pro",
 }
 _WS_BASE = "wss://streaming.assemblyai.com/v3/ws"
 

--- a/runner/src/coval_bench/registries/models.py
+++ b/runner/src/coval_bench/registries/models.py
@@ -68,6 +68,9 @@ MODEL_REGISTRY: list[RegisteredModel] = [
     RegisteredModel(
         benchmark=_STT, provider="assemblyai", model="universal-streaming", status=_ACTIVE
     ),
+    RegisteredModel(
+        benchmark=_STT, provider="assemblyai", model="universal-3.5-pro", status=_ACTIVE
+    ),
     RegisteredModel(benchmark=_STT, provider="speechmatics", model="default", status=_ACTIVE),
     RegisteredModel(benchmark=_STT, provider="speechmatics", model="enhanced", status=_ACTIVE),
     RegisteredModel(benchmark=_STT, provider="gradium", model="default", status=_ACTIVE),

--- a/runner/tests/providers/stt/test_assemblyai.py
+++ b/runner/tests/providers/stt/test_assemblyai.py
@@ -119,6 +119,38 @@ def test_provider_name() -> None:
     assert p.name == "assemblyai-universal-streaming"
 
 
+def test_provider_name_universal_3_5_pro() -> None:
+    p = AssemblyAIProvider(api_key=SecretStr("k"), model="universal-3.5-pro")
+    assert p.name == "assemblyai-universal-3.5-pro"
+
+
+@pytest.mark.asyncio
+async def test_universal_3_5_pro_url_uses_api_speech_model(
+    fake_api_key: SecretStr, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The friendly model id maps to the API's speech_model value on the wire."""
+    monkeypatch.setattr("coval_bench.providers.stt.assemblyai._FINAL_WAIT_S", 0.05)
+    ws = FakeWebSocket([{"type": "Turn", "end_of_turn": True, "transcript": "hi"}])
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=ws)
+    cm.__aexit__ = AsyncMock(return_value=False)
+    provider = AssemblyAIProvider(api_key=fake_api_key, model="universal-3.5-pro")
+
+    with patch(
+        "coval_bench.providers.stt.assemblyai.ws_client.connect", return_value=cm
+    ) as mock_connect:
+        await provider.measure_ttft(
+            audio_data=b"\x00" * 640,
+            channels=1,
+            sample_width=2,
+            sample_rate=16000,
+            realtime_resolution=0.01,
+        )
+
+    url = mock_connect.call_args.args[0]
+    assert "speech_model=universal-3-5-pro" in url
+
+
 # ---------------------------------------------------------------------------
 # Invalid model
 # ---------------------------------------------------------------------------

--- a/web/lib/config/colors.ts
+++ b/web/lib/config/colors.ts
@@ -46,6 +46,7 @@ export const modelColors: Record<string, string> = {
 
   // AssemblyAI — amethyst family (#8E44AD).
   "universal-streaming": "#8E44AD",
+  "universal-3.5-pro": "#6C3483",
 
   // Speechmatics — navy family (#21618C).
   enhanced: "#2E86C1",

--- a/web/lib/utils/formatters.ts
+++ b/web/lib/utils/formatters.ts
@@ -120,6 +120,7 @@ export function normalizeModelName(modelKey: string): string {
     "gpt-4o-transcribe": "GPT-4o Transcribe",
     "gpt-4o-mini-transcribe": "GPT-4o mini Transcribe",
     "universal-streaming": "Universal Streaming",
+    "universal-3.5-pro": "Universal 3.5 Pro",
     "ink-2": "Ink 2",
     default: "Default",
     enhanced: "Enhanced"


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the `universal-3.5-pro` speech model.
  * The model now appears in the benchmark model list, with matching display formatting and color styling.

* **Bug Fixes**
  * Improved model handling so requests for `universal-3.5-pro` use the correct backend model value.
  * Added coverage to verify the model name and connection settings are generated correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds AssemblyAI's `universal-3.5-pro` model to the STT benchmark suite, wiring it through the existing v3 streaming WebSocket provider with the API-side identifier `universal-3-5-pro`. All five touch points — provider map, model registry, tests, color config, and display-name formatter — are updated consistently.

- **Provider layer** (`assemblyai.py`): one entry added to `_SPEECH_MODEL_MAP`; the model is auto-picked up by `_VALID_MODELS = frozenset(_SPEECH_MODEL_MAP)`, so validation requires no separate change.
- **Tests** (`test_assemblyai.py`): two new tests verify the provider name and that the correct `speech_model` query param is sent on the wire; the happy-path audio processing path is already covered by `test_assemblyai_success` since the code path is model-agnostic beyond the URL.
- **Web** (`colors.ts`, `formatters.ts`): a darker amethyst shade (`#6C3483`) and the display label `"Universal 3.5 Pro"` are added in line with existing AssemblyAI color-family and naming conventions.

<h3>Confidence Score: 5/5</h3>

Straightforward model registration across all five required layers with no logic changes; safe to merge.

The change is a clean additive registration: one map entry, one registry entry, two focused tests, and two frontend constants. The user-facing key "universal-3.5-pro" correctly maps to the API value "universal-3-5-pro", which is confirmed as a valid speech_model for the AssemblyAI v3 streaming endpoint. No existing behaviour is touched.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| runner/src/coval_bench/providers/stt/assemblyai.py | Adds "universal-3.5-pro" → "universal-3-5-pro" to the speech model map; no logic changes, just a one-line registry addition. |
| runner/src/coval_bench/registries/models.py | Registers the new assemblyai "universal-3.5-pro" model as ACTIVE in the model registry; change is consistent with existing entries. |
| runner/tests/providers/stt/test_assemblyai.py | Adds two focused tests: provider name check and URL speech_model param check for the new model; coverage is adequate given the logic is identical to universal-streaming. |
| web/lib/config/colors.ts | Adds a darker amethyst color (#6C3483) for "universal-3.5-pro", consistent with the existing AssemblyAI color family convention. |
| web/lib/utils/formatters.ts | Adds display name "Universal 3.5 Pro" for the new model slug; correctly placed in the STT section of the model mappings. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Orchestrator
    participant AssemblyAIProvider
    participant WS as wss://streaming.assemblyai.com/v3/ws

    Orchestrator->>AssemblyAIProvider: "measure_ttft(audio_data, model="universal-3.5-pro")"
    AssemblyAIProvider->>AssemblyAIProvider: lookup _SPEECH_MODEL_MAP["universal-3.5-pro"]
    Note right of AssemblyAIProvider: → "universal-3-5-pro"
    AssemblyAIProvider->>WS: "connect(?speech_model=universal-3-5-pro&end_of_turn_confidence_threshold=1.0)"

    par send_task
        AssemblyAIProvider->>WS: send(audio_chunk) × N
        AssemblyAIProvider->>WS: send(ForceEndpoint)
        AssemblyAIProvider->>WS: wait for final_event (≤5s)
        AssemblyAIProvider->>WS: send(Terminate)
    and recv_task
        WS-->>AssemblyAIProvider: Begin
        WS-->>AssemblyAIProvider: "Turn {transcript, end_of_turn:false} → record TTFT"
        WS-->>AssemblyAIProvider: "Turn {transcript, end_of_turn:true} → set final_event"
        WS-->>AssemblyAIProvider: Termination
    end

    AssemblyAIProvider-->>Orchestrator: TranscriptionResult(ttft_seconds, complete_transcript)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Orchestrator
    participant AssemblyAIProvider
    participant WS as wss://streaming.assemblyai.com/v3/ws

    Orchestrator->>AssemblyAIProvider: "measure_ttft(audio_data, model="universal-3.5-pro")"
    AssemblyAIProvider->>AssemblyAIProvider: lookup _SPEECH_MODEL_MAP["universal-3.5-pro"]
    Note right of AssemblyAIProvider: → "universal-3-5-pro"
    AssemblyAIProvider->>WS: "connect(?speech_model=universal-3-5-pro&end_of_turn_confidence_threshold=1.0)"

    par send_task
        AssemblyAIProvider->>WS: send(audio_chunk) × N
        AssemblyAIProvider->>WS: send(ForceEndpoint)
        AssemblyAIProvider->>WS: wait for final_event (≤5s)
        AssemblyAIProvider->>WS: send(Terminate)
    and recv_task
        WS-->>AssemblyAIProvider: Begin
        WS-->>AssemblyAIProvider: "Turn {transcript, end_of_turn:false} → record TTFT"
        WS-->>AssemblyAIProvider: "Turn {transcript, end_of_turn:true} → set final_event"
        WS-->>AssemblyAIProvider: Termination
    end

    AssemblyAIProvider-->>Orchestrator: TranscriptionResult(ttft_seconds, complete_transcript)
```

</a>

<sub>Reviews (1): Last reviewed commit: ["Add new assembly ai stt model"](https://github.com/coval-ai/benchmarks/commit/6e59be53f70ef497f800c7bbf7f5eebcefd1521f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39670716)</sub>

<!-- /greptile_comment -->