### PR TITLE
test: use shared switchboard resolver

### DIFF
--- a/.github/workflows/switchboard.yml
+++ b/.github/workflows/switchboard.yml
@@ -64,11 +64,7 @@ jobs:
 
       - name: Generate token for Switchboard
         id: app_token
-        if: env.RELEASE_APP_ID != '' && env.RELEASE_APP_PRIVATE_KEY != ''
         uses: actions/create-github-app-token@v3
-        env:
-          RELEASE_APP_ID: ${{ secrets.RELEASE_APP_ID }}
-          RELEASE_APP_PRIVATE_KEY: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
         with:
           app-id: ${{ secrets.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
@@ -76,7 +72,6 @@ jobs:
           repositories: ci-cd-switchboard
 
       - name: Checkout Switchboard
-        if: steps.app_token.outputs.token != ''
         uses: actions/checkout@v7
         with:
           repository: coval-ai/ci-cd-switchboard
@@ -86,54 +81,18 @@ jobs:
           persist-credentials: false
 
       - name: Set up Node.js
-        if: steps.app_token.outputs.token != ''
         uses: actions/setup-node@v6
         with:
           node-version: "22"
 
       - name: Resolve changed files
         id: changed_files
-        env:
-          GH_TOKEN: ${{ github.token }}
-          GITHUB_TOKEN: ${{ github.token }}
-          MANUAL_CHANGED_FILES_JSON: ${{ github.event.inputs.changed_files_json }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: |
-          set -euo pipefail
-          mkdir -p switchboard
-
-          selector_failed=false
-          fallback_reason=""
-
-          if [ "${{ github.event_name }}" = "merge_group" ]; then
-            selector_failed=true
-            fallback_reason="merge queue changed-file selector unavailable in benchmarks; running conservative full repo check"
-            printf '{"changedFiles":["runner/pyproject.toml","web/package.json",".github/workflows/ci.yml",".github/workflows/web-ci.yml"],"fallbackReason":"%s","selectorMode":"fallback-full"}\n' "$fallback_reason" > switchboard/changed-files.json
-          elif [ "${{ github.event_name }}" = "pull_request" ]; then
-            if gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/files" --paginate \
-              | jq -s 'add | map(.filename) | unique | {changedFiles: ., selectorMode: "file-scoped"}' > switchboard/changed-files.json
-            then
-              :
-            else
-              selector_failed=true
-              fallback_reason="pull request changed-file selector failed"
-              printf '{"changedFiles":["runner/pyproject.toml","web/package.json"],"fallbackReason":"%s","selectorMode":"fallback-full"}\n' "$fallback_reason" > switchboard/changed-files.json
-            fi
-          elif [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            manual_changed_files_json="${MANUAL_CHANGED_FILES_JSON:-[\"runner/pyproject.toml\",\"web/package.json\"]}"
-            if jq -cen --argjson changedFiles "$manual_changed_files_json" '$changedFiles | if type == "array" then {changedFiles: (map(tostring) | unique | sort), selectorMode: "manual"} else error("changed_files_json must be a JSON array") end' > switchboard/changed-files.json; then
-              :
-            else
-              selector_failed=true
-              fallback_reason="manual changed-file input was invalid"
-              printf '{"changedFiles":["runner/pyproject.toml","web/package.json"],"fallbackReason":"%s","selectorMode":"fallback-full"}\n' "$fallback_reason" > switchboard/changed-files.json
-            fi
-          else
-            printf '{"changedFiles":["runner/pyproject.toml","web/package.json"],"selectorMode":"fallback-full"}\n' > switchboard/changed-files.json
-          fi
-
-          echo "selector_failed=$selector_failed" >> "$GITHUB_OUTPUT"
-          echo "fallback_reason=$fallback_reason" >> "$GITHUB_OUTPUT"
+        uses: ./switchboard-src/.github/actions/resolve-changed-files
+        with:
+          manual-changed-files-json: ${{ github.event.inputs.changed_files_json }}
+          default-changed-files-json: '["runner/pyproject.toml","web/package.json"]'
+          pull-request-fallback-json: '["runner/pyproject.toml","web/package.json"]'
+          merge-group-fallback-json: '["runner/pyproject.toml","web/package.json",".github/workflows/ci.yml",".github/workflows/web-ci.yml"]'
 
       - name: Build Switchboard event
         env:
@@ -175,9 +134,7 @@ jobs:
 
       - name: Plan Switchboard checks
         id: switchboard
-        if: steps.app_token.outputs.token != ''
         uses: ./switchboard-src/.github/actions/switchboard-plan
-        continue-on-error: true
         with:
           event: ${{ github.workspace }}/switchboard/event.json
           changed-files: ${{ github.workspace }}/switchboard/changed-files.json
@@ -188,16 +145,10 @@ jobs:
       - name: Resolve selected adapters
         id: adapters
         env:
-          PLAN_OUTCOME: ${{ steps.switchboard.outcome }}
           SELECTED_CHECK_IDS: ${{ steps.switchboard.outputs.selected_check_ids }}
         run: |
           set -euo pipefail
           node <<'NODE' >> "$GITHUB_OUTPUT"
-          if (process.env.PLAN_OUTCOME !== "success") {
-            console.log("run_runner_ci=true")
-            console.log("run_web_ci=true")
-            process.exit(0)
-          }
           const selected = new Set(JSON.parse(process.env.SELECTED_CHECK_IDS || "[]"))
           console.log(`run_runner_ci=${selected.has("benchmarks.runner.ci")}`)
           console.log(`run_web_ci=${selected.has("benchmarks.web.ci")}`)

--- a/.github/workflows/switchboard.yml
+++ b/.github/workflows/switchboard.yml
@@ -64,7 +64,11 @@ jobs:
 
       - name: Generate token for Switchboard
         id: app_token
+        if: env.RELEASE_APP_ID != '' && env.RELEASE_APP_PRIVATE_KEY != ''
         uses: actions/create-github-app-token@v3
+        env:
+          RELEASE_APP_ID: ${{ secrets.RELEASE_APP_ID }}
+          RELEASE_APP_PRIVATE_KEY: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
         with:
           app-id: ${{ secrets.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
@@ -72,6 +76,7 @@ jobs:
           repositories: ci-cd-switchboard
 
       - name: Checkout Switchboard
+        if: steps.app_token.outputs.token != ''
         uses: actions/checkout@v7
         with:
           repository: coval-ai/ci-cd-switchboard
@@ -87,6 +92,7 @@ jobs:
 
       - name: Resolve changed files
         id: changed_files
+        if: steps.app_token.outputs.token != ''
         uses: ./switchboard-src/.github/actions/resolve-changed-files
         with:
           manual-changed-files-json: ${{ github.event.inputs.changed_files_json }}
@@ -94,9 +100,32 @@ jobs:
           pull-request-fallback-json: '["runner/pyproject.toml","web/package.json"]'
           merge-group-fallback-json: '["runner/pyproject.toml","web/package.json",".github/workflows/ci.yml",".github/workflows/web-ci.yml"]'
 
+      - name: Resolve changed files without Switchboard token
+        id: changed_files_fallback
+        if: steps.app_token.outputs.token == ''
+        run: |
+          set -euo pipefail
+          mkdir -p switchboard
+          node <<'NODE'
+          const fs = require("node:fs")
+          const fallbackReason = "Switchboard app token unavailable; running conservative fallback adapters"
+          const changedFiles = [
+            "runner/pyproject.toml",
+            "web/package.json",
+            ".github/workflows/ci.yml",
+            ".github/workflows/web-ci.yml",
+          ]
+          fs.writeFileSync(
+            "switchboard/changed-files.json",
+            `${JSON.stringify({ changedFiles, fallbackReason, selectorMode: "token-unavailable-fallback" }, null, 2)}\n`,
+          )
+          NODE
+          echo "selector_failed=true" >> "$GITHUB_OUTPUT"
+          echo "fallback_reason=Switchboard app token unavailable; running conservative fallback adapters" >> "$GITHUB_OUTPUT"
+
       - name: Build Switchboard event
         env:
-          SELECTOR_FAILED: ${{ steps.changed_files.outputs.selector_failed }}
+          SELECTOR_FAILED: ${{ steps.changed_files.outputs.selector_failed || steps.changed_files_fallback.outputs.selector_failed || 'false' }}
         run: |
           set -euo pipefail
           node <<'NODE'
@@ -134,6 +163,7 @@ jobs:
 
       - name: Plan Switchboard checks
         id: switchboard
+        if: steps.app_token.outputs.token != ''
         uses: ./switchboard-src/.github/actions/switchboard-plan
         with:
           event: ${{ github.workspace }}/switchboard/event.json
@@ -146,9 +176,15 @@ jobs:
         id: adapters
         env:
           SELECTED_CHECK_IDS: ${{ steps.switchboard.outputs.selected_check_ids }}
+          SWITCHBOARD_TOKEN_AVAILABLE: ${{ steps.app_token.outputs.token != '' }}
         run: |
           set -euo pipefail
           node <<'NODE' >> "$GITHUB_OUTPUT"
+          if (process.env.SWITCHBOARD_TOKEN_AVAILABLE !== "true") {
+            console.log("run_runner_ci=true")
+            console.log("run_web_ci=true")
+            process.exit(0)
+          }
           const selected = new Set(JSON.parse(process.env.SELECTED_CHECK_IDS || "[]"))
           console.log(`run_runner_ci=${selected.has("benchmarks.runner.ci")}`)
           console.log(`run_web_ci=${selected.has("benchmarks.web.ci")}`)
@@ -164,7 +200,8 @@ jobs:
             echo "- Selected check ids: ${{ steps.switchboard.outputs.selected_check_ids || '[]' }}"
             echo "- Required gates: ${{ steps.switchboard.outputs.required_gates || '[]' }}"
             echo "- Workflow ownership: ${{ steps.switchboard.outputs.workflow_ownership || '{}' }}"
-            echo "- Selector failed: ${{ steps.changed_files.outputs.selector_failed || 'false' }}"
+            echo "- Selector failed: ${{ steps.changed_files.outputs.selector_failed || steps.changed_files_fallback.outputs.selector_failed || 'false' }}"
+            echo "- Fallback reason: ${{ steps.changed_files.outputs.fallback_reason || steps.changed_files_fallback.outputs.fallback_reason || 'none' }}"
             echo "- Planner outcome: ${{ steps.switchboard.outcome }}"
           } >> "$GITHUB_STEP_SUMMARY"
 


### PR DESCRIPTION
## Summary
- use the shared Switchboard changed-file resolver for PR/MQ/manual planning
- stop treating planner failures as broad selected adapter runs; planner failures now fail the Switchboard gate directly

## Sentinel coverage
- this PR touches `.github/workflows/switchboard.yml`, which is in the benchmarks path rules, so the PR should exercise the shared resolver, planning, selected adapters, and Switchboard Gate

## Tests
- actionlint .github/workflows/switchboard.yml
- git diff --check

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR migrates the inline changed-file resolution logic in the `plan` job to a shared composite action (`resolve-changed-files` from `coval-ai/ci-cd-switchboard`), and removes `continue-on-error: true` from the planner step so that planning failures now propagate directly to the Switchboard Gate instead of silently triggering a broad CI run.

- **Shared resolver**: The three-branch inline shell script (PR / merge_group / workflow_dispatch) is replaced by `./switchboard-src/.github/actions/resolve-changed-files`, with a dedicated token-unavailable fallback step that preserves the conservative full-repo file list.
- **Planner failure semantics**: Removing `continue-on-error: true` from `Plan Switchboard checks` means any planner error now fails the `plan` job; `Resolve selected adapters` shifts from checking `PLAN_OUTCOME` to checking `SWITCHBOARD_TOKEN_AVAILABLE`, which is safe because plan failures cause subsequent steps to be skipped under GitHub Actions' implicit `success()` semantics.

<h3>Confidence Score: 5/5</h3>

The workflow change is safe to merge; the two code paths (token available / token unavailable) are mutually exclusive and both produce switchboard/changed-files.json before Build Switchboard event reads it.

The core logic is internally consistent: removing continue-on-error from the planner and switching Resolve selected adapters to check SWITCHBOARD_TOKEN_AVAILABLE instead of PLAN_OUTCOME is correct because a failing planner step causes GitHub Actions to skip subsequent steps under implicit success() semantics. The remaining open questions around the shared action output contract are observability-level concerns, not functional blockers.

.github/workflows/switchboard.yml — confirm that coval-ai/ci-cd-switchboard/.github/actions/resolve-changed-files writes to switchboard/changed-files.json and exposes selector_failed and fallback_reason step outputs.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/switchboard.yml | Migrates inline changed-file resolution to shared composite action and tightens planner failure behavior; the correctness of the `selector_failed`/`fallback_reason` output contract now depends on the upstream action's interface. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[plan job starts] --> B{RELEASE_APP_ID & PRIVATE_KEY set?}
    B -- yes --> C[Generate app token]
    B -- no --> D[app_token skipped, token empty]
    C --> E{token != empty?}
    D --> E
    E -- yes --> F[Checkout switchboard-src]
    E -- no --> G[Fallback: full repo file list, selector_failed=true]
    F --> H[resolve-changed-files shared composite action]
    H --> I[Build Switchboard event]
    G --> I
    I --> J{token != empty?}
    J -- yes --> K[switchboard-plan, no continue-on-error]
    J -- no --> L[Plan step SKIPPED]
    K -- failure --> M[plan job FAILS]
    K -- success --> N[Resolve selected adapters, use SELECTED_CHECK_IDS]
    L --> O[Resolve selected adapters, run_runner_ci=true, run_web_ci=true]
    N --> P[plan job outputs]
    O --> P
    M --> Q[switchboard_gate FAILS]
    P --> R[runner_ci / web_ci adapters]
    R --> Q
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[plan job starts] --> B{RELEASE_APP_ID & PRIVATE_KEY set?}
    B -- yes --> C[Generate app token]
    B -- no --> D[app_token skipped, token empty]
    C --> E{token != empty?}
    D --> E
    E -- yes --> F[Checkout switchboard-src]
    E -- no --> G[Fallback: full repo file list, selector_failed=true]
    F --> H[resolve-changed-files shared composite action]
    H --> I[Build Switchboard event]
    G --> I
    I --> J{token != empty?}
    J -- yes --> K[switchboard-plan, no continue-on-error]
    J -- no --> L[Plan step SKIPPED]
    K -- failure --> M[plan job FAILS]
    K -- success --> N[Resolve selected adapters, use SELECTED_CHECK_IDS]
    L --> O[Resolve selected adapters, run_runner_ci=true, run_web_ci=true]
    N --> P[plan job outputs]
    O --> P
    M --> Q[switchboard_gate FAILS]
    P --> R[runner_ci / web_ci adapters]
    R --> Q
```

</a>

<sub>Reviews (2): Last reviewed commit: ["test: preserve switchboard token fallbac..."](https://github.com/coval-ai/benchmarks/commit/857fe63333e79e357e475ee2e99cb10d526d0b74) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39734966)</sub>

<!-- /greptile_comment -->