### PR TITLE
Mark groq model retired

### DIFF
--- a/runner/src/coval_bench/registries/models.py
+++ b/runner/src/coval_bench/registries/models.py
@@ -191,7 +191,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         provider="groq",
         model="canopylabs/orpheus-v1-english",
         voice="autumn",
-        status=_ACTIVE,
+        status=_RETIRED,
     ),
     # gpt-realtime is a speech-to-speech LLM, not a TTS provider: driving it
     # from a text "instructions" prompt folds LLM inference into TTFA and never


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed an unavailable text-to-speech option from active use so it no longer appears as a runnable/serving choice.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR retires the Groq TTS model `canopylabs/orpheus-v1-english` by flipping its `status` from `_ACTIVE` to `_RETIRED` in the model registry. Per the module docstring, `RETIRED` models are not benchmarked and are hidden on the frontend even when historical result rows exist.

- The single-line change correctly uses the pre-defined `_RETIRED` alias (`ModelStatus.RETIRED`) and follows the established pattern used by other retired entries (e.g., inworld models, `gpt-realtime`).
- No other metadata (benchmark, provider, model id, voice) was altered, which is the expected approach for preserving historical data traceability.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a single status field flip on a known Groq TTS model, using an existing constant with no side-effects beyond stopping benchmarks and hiding the entry on the frontend.

The change is a one-line, in-place metadata update in an append-only registry. The _RETIRED constant is already defined and used by multiple other entries; the duplicate-key guard at module load would catch any accidental structural mistake. No logic, schema, or runtime behavior is affected beyond what the module docstring explicitly documents for retired entries.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| runner/src/coval_bench/registries/models.py | One-line status change for the Groq TTS model from ACTIVE to RETIRED; follows the established retirement pattern used throughout the registry. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["MODEL_REGISTRY entry\ngroq / canopylabs/orpheus-v1-english"] --> B{status}
    B -- "Before PR\n_ACTIVE" --> C["Orchestrator runs benchmark\nSite shows results"]
    B -- "After PR\n_RETIRED" --> D["Orchestrator skips model\nAPI marks disabled\nFrontend hides entry\n(historical rows preserved)"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["MODEL_REGISTRY entry\ngroq / canopylabs/orpheus-v1-english"] --> B{status}
    B -- "Before PR\n_ACTIVE" --> C["Orchestrator runs benchmark\nSite shows results"]
    B -- "After PR\n_RETIRED" --> D["Orchestrator skips model\nAPI marks disabled\nFrontend hides entry\n(historical rows preserved)"]
```

</a>

<sub>Reviews (1): Last reviewed commit: ["Mark groq model retired"](https://github.com/coval-ai/benchmarks/commit/0234544f4e046d66687c7e1def0bde2b1386aec6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39858025)</sub>

<!-- /greptile_comment -->