### PR TITLE
Rank STT by TTFS instead of WER

### DIFF
--- a/web/components/overview/OverviewLeaderboards.tsx
+++ b/web/components/overview/OverviewLeaderboards.tsx
@@ -19,9 +19,6 @@ import LeaderboardCard, { type LeaderboardRow } from "./LeaderboardCard";
 
 const TOP_N = 5;
 
-// Rank field is chosen to match the /tts and /stt pages exactly, so the
-// overview cards never disagree with the full leaderboards: TTS ranks by p50
-// of TTFA, STT by avg of WER. All are "lower is better".
 function toRows(
   stats: ModelStatEntry[] | undefined,
   metricType: string,
@@ -68,10 +65,10 @@ const OverviewLeaderboards: React.FC = () => {
     () =>
       toRows(
         sttQuery.data?.model_stats,
-        "WER",
-        "avg_value",
+        "TTFS",
+        "p50",
         normalizeSTTProviderName,
-        (value) => `${value.toFixed(1)}%`
+        (value) => `${Math.round(value * 1000)} ms`
       ),
     [sttQuery.data]
   );
@@ -94,7 +91,7 @@ const OverviewLeaderboards: React.FC = () => {
         />
         <LeaderboardCard
           title="Speech-to-Text"
-          metricLabel="Word Error Rate"
+          metricLabel="Time to Final Segment"
           windowLabel={windowBadge(sttQuery.data?.window ?? timeWindow)}
           rows={sttRows}
           href="/stt"


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Speech-to-Text leaderboard to use the **TTFS** metric and rank by **p50**, resulting in more relevant ordering.
  * Changed the displayed leaderboard value from **Word Error Rate** to a rounded **time-to-final-segment** duration (shown in milliseconds).
  * Renamed the Speech-to-Text card metric to **“Time to Final Segment”** and limited the leaderboard to the **top 5** entries for a cleaner overview.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the Speech-to-Text overview leaderboard card to rank and display by TTFS (Time to Final Segment) at the p50 latency percentile instead of average WER, aligning the overview card with the metric the full `/stt` dashboard surfaces by default.

- **Metric swap**: `metric_type` changes from `"WER"` / `avg_value` to `"TTFS"` / `p50`, matching how the full STT dashboard ranks models.
- **Unit conversion**: Values are formatted as `Math.round(value * 1000) ms`, correctly converting TTFS from seconds (the API storage unit, per `latencyToMs()` in `formatters.ts`) to whole milliseconds — consistent with the TTS card's display format.
- **Label update**: The column header changes from "Word Error Rate" to "Time to Final Segment" to reflect the new metric.

<h3>Confidence Score: 5/5</h3>

Safe to merge — a focused metric swap with correct unit handling.

The change is small and self-contained: metric type, rank field, and format function are all updated together. The ×1000 conversion is consistent with `latencyToMs()` in `formatters.ts`, which documents that STT latency values are stored in seconds. The new `p50` ranking field matches what the full `/stt` dashboard uses, so the overview card and full leaderboard stay aligned.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| web/components/overview/OverviewLeaderboards.tsx | Switches STT leaderboard card from WER/avg_value to TTFS/p50; unit conversion (×1000) is correct per latencyToMs(); label updated to match. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[sttQuery.data?.model_stats] --> B[filter: metric_type === 'TTFS']
    B --> C[sort ascending by p50]
    C --> D[slice top 5]
    D --> E["format: Math.round(value × 1000) ms"]
    E --> F[LeaderboardCard\nmetricLabel='Time to Final Segment']
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[sttQuery.data?.model_stats] --> B[filter: metric_type === 'TTFS']
    B --> C[sort ascending by p50]
    C --> D[slice top 5]
    D --> E["format: Math.round(value × 1000) ms"]
    E --> F[LeaderboardCard\nmetricLabel='Time to Final Segment']
```

</a>

<sub>Reviews (2): Last reviewed commit: ["Rank STT by TTFS instead of WER"](https://github.com/coval-ai/benchmarks/commit/90c11369bcf4aa49aba274c19247d0175fbb663b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39881108)</sub>

<!-- /greptile_comment -->