### PR TITLE
Lock arena reads and generation behind the labeler key

### DIFF
--- a/runner/src/coval_bench/api/routers/arena.py
+++ b/runner/src/coval_bench/api/routers/arena.py
@@ -55,7 +55,7 @@ from coval_bench.db.models import VoteOutcome, VoterType
 
 logger = structlog.get_logger("coval_bench.api")
 
-router = APIRouter(tags=["arena"])
+router = APIRouter(tags=["arena"], include_in_schema=False)
 
 
 # Columns exposed by the (blind) battle endpoints — provider/model are withheld.
@@ -87,7 +87,9 @@ def _is_authenticated_labeler(provided: str | None, settings: Settings) -> bool:
     expected = settings.arena_labeler_key
     if expected is None or provided is None:
         return False
-    return hmac.compare_digest(provided, expected.get_secret_value())
+    return hmac.compare_digest(
+        provided.encode("utf-8"), expected.get_secret_value().encode("utf-8")
+    )
 
 
 def require_labeler(

--- a/runner/src/coval_bench/api/routers/arena.py
+++ b/runner/src/coval_bench/api/routers/arena.py
@@ -82,7 +82,26 @@ _LEADERBOARD_SQL = """
 """
 
 
-@router.get("/arena/battle", response_model=BattleOut)
+def _is_authenticated_labeler(provided: str | None, settings: Settings) -> bool:
+    """True only if a labeler key is configured and the presented key matches it."""
+    expected = settings.arena_labeler_key
+    if expected is None or provided is None:
+        return False
+    return hmac.compare_digest(provided, expected.get_secret_value())
+
+
+def require_labeler(
+    x_labeler_key: str | None = Header(default=None),
+    settings: Settings = Depends(get_settings),
+) -> None:
+    """Gate a route behind the labeler key, raising 404 (not 403) so a locked arena is
+    indistinguishable from a route that does not exist — keeping its existence
+    confidential until launch."""
+    if not _is_authenticated_labeler(x_labeler_key, settings):
+        raise HTTPException(404)
+
+
+@router.get("/arena/battle", response_model=BattleOut, dependencies=[Depends(require_labeler)])
 @limiter.limit("60/minute")
 async def get_battle(
     request: Request,  # required by slowapi
@@ -108,7 +127,11 @@ async def get_battle(
     return BattleOut.model_validate(row)
 
 
-@router.get("/arena/battle/{battle_id}", response_model=BattleOut)
+@router.get(
+    "/arena/battle/{battle_id}",
+    response_model=BattleOut,
+    dependencies=[Depends(require_labeler)],
+)
 @limiter.limit("60/minute")
 async def get_battle_by_id(
     request: Request,  # required by slowapi
@@ -128,7 +151,11 @@ async def get_battle_by_id(
     return BattleOut.model_validate(row)
 
 
-@router.get("/arena/leaderboard", response_model=ArenaLeaderboardResponse)
+@router.get(
+    "/arena/leaderboard",
+    response_model=ArenaLeaderboardResponse,
+    dependencies=[Depends(require_labeler)],
+)
 @limiter.limit("60/minute")
 async def get_arena_leaderboard(
     request: Request,  # required by slowapi
@@ -161,14 +188,6 @@ async def get_arena_leaderboard(
         methodology_version=board[0]["methodology_version"] if board else None,
         entries=entries,
     )
-
-
-def _is_authenticated_labeler(provided: str | None, settings: Settings) -> bool:
-    """True only if a labeler key is configured and the presented key matches it."""
-    expected = settings.arena_labeler_key
-    if expected is None or provided is None:
-        return False
-    return hmac.compare_digest(provided, expected.get_secret_value())
 
 
 @router.post("/arena/vote", response_model=VoteOut, status_code=201)
@@ -205,7 +224,12 @@ async def cast_vote(
     return VoteOut.model_validate(recorded.model_dump())
 
 
-@router.post("/arena/battle", response_model=BattleOut, status_code=201)
+@router.post(
+    "/arena/battle",
+    response_model=BattleOut,
+    status_code=201,
+    dependencies=[Depends(require_labeler)],
+)
 @limiter.limit("60/minute")
 async def create_battle(
     request: Request,  # required by slowapi

--- a/runner/tests/api/test_arena.py
+++ b/runner/tests/api/test_arena.py
@@ -350,11 +350,17 @@ async def test_locked_reads_are_404_without_key(client: AsyncClient, postgresql:
 
 
 async def test_locked_reads_are_404_with_wrong_key(client: AsyncClient, postgresql: Any) -> None:
-    """A non-matching key is treated like no key: 404, never 403 (no existence leak)."""
+    """A non-matching key is treated like no key on every gated route: 404, never 403."""
     await _apply_arena_schema(_make_db_url(postgresql))
+    battle_id = await _insert_battle(postgresql)
     await _insert_snapshot(postgresql)
     wrong = {"X-Labeler-Key": "not-the-key"}
+    assert (await client.get("/v1/arena/battle", headers=wrong)).status_code == 404
+    assert (await client.get(f"/v1/arena/battle/{battle_id}", headers=wrong)).status_code == 404
     assert (await client.get("/v1/arena/leaderboard", headers=wrong)).status_code == 404
+    assert (
+        await client.post("/v1/arena/battle", json={"prompt": "hi"}, headers=wrong)
+    ).status_code == 404
 
 
 async def _count_votes(postgresql: Any, battle_id: str) -> int:

--- a/runner/tests/api/test_arena.py
+++ b/runner/tests/api/test_arena.py
@@ -19,6 +19,8 @@ from coval_bench.arena.pairing import active_tts_models
 from coval_bench.providers.base import TTSResult
 from tests.api.conftest import ARENA_LABELER_KEY, _make_db_url
 
+_LABELER_HEADERS = {"X-Labeler-Key": ARENA_LABELER_KEY}
+
 
 async def _apply_arena_schema(dsn: str) -> None:
     """Create the arena tables read by the endpoints (mirrors migration 20260615_0007)."""
@@ -171,7 +173,7 @@ async def _insert_snapshot(postgresql: Any, **kwargs: Any) -> None:
 async def test_get_battle_404_when_empty(client: AsyncClient, postgresql: Any) -> None:
     """No battles seeded -> 404."""
     await _apply_arena_schema(_make_db_url(postgresql))
-    response = await client.get("/v1/arena/battle")
+    response = await client.get("/v1/arena/battle", headers=_LABELER_HEADERS)
     assert response.status_code == 404
 
 
@@ -180,7 +182,7 @@ async def test_get_battle_is_blind(client: AsyncClient, postgresql: Any) -> None
     await _apply_arena_schema(_make_db_url(postgresql))
     await _insert_battle(postgresql)
 
-    response = await client.get("/v1/arena/battle")
+    response = await client.get("/v1/arena/battle", headers=_LABELER_HEADERS)
     assert response.status_code == 200
     data = response.json()
     assert set(data) == {"id", "prompt_text", "domain", "audio_a_url", "audio_b_url"}
@@ -194,7 +196,7 @@ async def test_get_battle_by_id(client: AsyncClient, postgresql: Any) -> None:
     await _apply_arena_schema(_make_db_url(postgresql))
     battle_id = await _insert_battle(postgresql)
 
-    response = await client.get(f"/v1/arena/battle/{battle_id}")
+    response = await client.get(f"/v1/arena/battle/{battle_id}", headers=_LABELER_HEADERS)
     assert response.status_code == 200
     assert response.json()["id"] == battle_id
 
@@ -202,21 +204,23 @@ async def test_get_battle_by_id(client: AsyncClient, postgresql: Any) -> None:
 async def test_get_battle_by_id_unknown_returns_404(client: AsyncClient, postgresql: Any) -> None:
     """A well-formed but unknown UUID returns 404."""
     await _apply_arena_schema(_make_db_url(postgresql))
-    response = await client.get("/v1/arena/battle/00000000-0000-0000-0000-000000000000")
+    response = await client.get(
+        "/v1/arena/battle/00000000-0000-0000-0000-000000000000", headers=_LABELER_HEADERS
+    )
     assert response.status_code == 404
 
 
 async def test_get_battle_by_id_malformed_returns_422(client: AsyncClient, postgresql: Any) -> None:
     """A non-UUID id is rejected by validation with 422."""
     await _apply_arena_schema(_make_db_url(postgresql))
-    response = await client.get("/v1/arena/battle/not-a-uuid")
+    response = await client.get("/v1/arena/battle/not-a-uuid", headers=_LABELER_HEADERS)
     assert response.status_code == 422
 
 
 async def test_leaderboard_empty_when_no_snapshots(client: AsyncClient, postgresql: Any) -> None:
     """No snapshots -> 200 with empty entries and null computed_at."""
     await _apply_arena_schema(_make_db_url(postgresql))
-    response = await client.get("/v1/arena/leaderboard")
+    response = await client.get("/v1/arena/leaderboard", headers=_LABELER_HEADERS)
     assert response.status_code == 200
     data = response.json()
     assert data["metric"] == "naturalness"
@@ -243,7 +247,7 @@ async def test_leaderboard_returns_latest_board_sorted(
         postgresql, computed_at=latest, provider="elevenlabs", model="v2", rating_elo=1520
     )
 
-    response = await client.get("/v1/arena/leaderboard")
+    response = await client.get("/v1/arena/leaderboard", headers=_LABELER_HEADERS)
     assert response.status_code == 200
     data = response.json()
     entries = data["entries"]
@@ -263,12 +267,14 @@ async def test_leaderboard_domain_filter(client: AsyncClient, postgresql: Any) -
         postgresql, computed_at=computed, domain="support", provider="cartesia", model="sonic-3"
     )
 
-    support = await client.get("/v1/arena/leaderboard", params={"domain": "support"})
+    support = await client.get(
+        "/v1/arena/leaderboard", params={"domain": "support"}, headers=_LABELER_HEADERS
+    )
     assert support.status_code == 200
     assert support.json()["domain"] == "support"
     assert [e["model"] for e in support.json()["entries"]] == ["sonic-3"]
 
-    default = await client.get("/v1/arena/leaderboard")
+    default = await client.get("/v1/arena/leaderboard", headers=_LABELER_HEADERS)
     assert [e["model"] for e in default.json()["entries"]] == ["v2"]
 
 
@@ -292,7 +298,9 @@ async def test_leaderboard_latest_is_scoped_per_metric(
         model="sonic-3",
     )
 
-    response = await client.get("/v1/arena/leaderboard", params={"metric": "clarity"})
+    response = await client.get(
+        "/v1/arena/leaderboard", params={"metric": "clarity"}, headers=_LABELER_HEADERS
+    )
     assert response.status_code == 200
     data = response.json()
     assert data["metric"] == "clarity"
@@ -320,7 +328,7 @@ async def test_leaderboard_does_not_mix_methodology_versions(
         model="sonic-3",
     )
 
-    response = await client.get("/v1/arena/leaderboard")
+    response = await client.get("/v1/arena/leaderboard", headers=_LABELER_HEADERS)
     assert response.status_code == 200
     data = response.json()
     # One board only: the tiebreaker picks davidson-v2, so v1's row is excluded.
@@ -328,7 +336,25 @@ async def test_leaderboard_does_not_mix_methodology_versions(
     assert [e["model"] for e in data["entries"]] == ["sonic-3"]
 
 
-_LABELER_HEADERS = {"X-Labeler-Key": ARENA_LABELER_KEY}
+async def test_locked_reads_are_404_without_key(client: AsyncClient, postgresql: Any) -> None:
+    """Without a labeler key the reads/generate return 404 — indistinguishable from a route
+    that does not exist. Data is present, proving the lock fires before any DB access."""
+    await _apply_arena_schema(_make_db_url(postgresql))
+    battle_id = await _insert_battle(postgresql)
+    await _insert_snapshot(postgresql)
+
+    assert (await client.get("/v1/arena/battle")).status_code == 404
+    assert (await client.get(f"/v1/arena/battle/{battle_id}")).status_code == 404
+    assert (await client.get("/v1/arena/leaderboard")).status_code == 404
+    assert (await client.post("/v1/arena/battle", json={"prompt": "hi"})).status_code == 404
+
+
+async def test_locked_reads_are_404_with_wrong_key(client: AsyncClient, postgresql: Any) -> None:
+    """A non-matching key is treated like no key: 404, never 403 (no existence leak)."""
+    await _apply_arena_schema(_make_db_url(postgresql))
+    await _insert_snapshot(postgresql)
+    wrong = {"X-Labeler-Key": "not-the-key"}
+    assert (await client.get("/v1/arena/leaderboard", headers=wrong)).status_code == 404
 
 
 async def _count_votes(postgresql: Any, battle_id: str) -> int:
@@ -529,6 +555,7 @@ async def test_create_battle_returns_blind_battle(
     response = await client.post(
         "/v1/arena/battle",
         json={"prompt": "Your appointment is confirmed.", "domain": "customer service"},
+        headers=_LABELER_HEADERS,
     )
 
     assert response.status_code == 201
@@ -544,7 +571,9 @@ async def test_create_battle_returns_blind_battle(
 async def test_create_battle_rejects_empty_prompt(client: AsyncClient, postgresql: Any) -> None:
     """A blank prompt is rejected with 422 — no synthesis attempted."""
     await _apply_arena_schema(_make_db_url(postgresql))
-    response = await client.post("/v1/arena/battle", json={"prompt": "   "})
+    response = await client.post(
+        "/v1/arena/battle", json={"prompt": "   "}, headers=_LABELER_HEADERS
+    )
     assert response.status_code == 422
 
 
@@ -561,7 +590,9 @@ async def test_create_battle_502_when_synthesis_fails(
         "coval_bench.arena.generate.store_clip", lambda settings, src: "/clips/x.wav"
     )
 
-    response = await client.post("/v1/arena/battle", json={"prompt": "hello"})
+    response = await client.post(
+        "/v1/arena/battle", json={"prompt": "hello"}, headers=_LABELER_HEADERS
+    )
     assert response.status_code == 502
 
 
@@ -623,7 +654,9 @@ async def test_create_battle_429_when_cap_reached(
 
     monkeypatch.setattr("coval_bench.api.routers.arena.generate_battle", _no_synth)
 
-    response = await client.post("/v1/arena/battle", json={"prompt": "hello"})
+    response = await client.post(
+        "/v1/arena/battle", json={"prompt": "hello"}, headers=_LABELER_HEADERS
+    )
     assert response.status_code == 429
 
 
@@ -641,5 +674,7 @@ async def test_create_battle_cap_disabled_when_zero(
         "coval_bench.arena.generate.store_clip", lambda settings, src: f"/clips/{src.name}"
     )
 
-    response = await client.post("/v1/arena/battle", json={"prompt": "hello"})
+    response = await client.post(
+        "/v1/arena/battle", json={"prompt": "hello"}, headers=_LABELER_HEADERS
+    )
     assert response.status_code == 201

--- a/web/app/api/arena/battle/[id]/reveal/route.ts
+++ b/web/app/api/arena/battle/[id]/reveal/route.ts
@@ -1,9 +1,11 @@
 export const runtime = "nodejs";
 
+import { arenaAccessOk } from "@/lib/arena/guard";
 import { arenaRunnerFetch } from "@/lib/arena/runner";
 import type { Reveal } from "@/lib/arena/types";
 
 export async function GET(_req: Request, { params }: { params: Promise<{ id: string }> }) {
+  if (!(await arenaAccessOk())) return new Response(null, { status: 404 });
   const { id } = await params;
   let res: Response;
   try {

--- a/web/app/api/arena/battle/route.ts
+++ b/web/app/api/arena/battle/route.ts
@@ -1,6 +1,7 @@
 export const runtime = "nodejs";
 export const maxDuration = 60;
 
+import { arenaAccessOk } from "@/lib/arena/guard";
 import { arenaRunnerFetch } from "@/lib/arena/runner";
 import type { BlindBattle } from "@/lib/arena/types";
 
@@ -13,6 +14,7 @@ interface BattleOut {
 }
 
 export async function POST(req: Request) {
+  if (!(await arenaAccessOk())) return new Response(null, { status: 404 });
   let body: { text?: string };
   try {
     body = await req.json();

--- a/web/app/api/arena/leaderboard/route.ts
+++ b/web/app/api/arena/leaderboard/route.ts
@@ -1,8 +1,10 @@
 export const runtime = "nodejs";
 
+import { arenaAccessOk } from "@/lib/arena/guard";
 import { arenaRunnerFetch } from "@/lib/arena/runner";
 
 export async function GET(req: Request) {
+  if (!(await arenaAccessOk())) return new Response(null, { status: 404 });
   const { searchParams } = new URL(req.url);
   const qs = new URLSearchParams({
     metric: searchParams.get("metric") ?? "naturalness",

--- a/web/app/api/arena/leaderboard/route.ts
+++ b/web/app/api/arena/leaderboard/route.ts
@@ -1,0 +1,20 @@
+export const runtime = "nodejs";
+
+import { arenaRunnerFetch } from "@/lib/arena/runner";
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const qs = new URLSearchParams({
+    metric: searchParams.get("metric") ?? "naturalness",
+    domain: searchParams.get("domain") ?? "all",
+  });
+
+  let res: Response;
+  try {
+    res = await arenaRunnerFetch(`/v1/arena/leaderboard?${qs}`);
+  } catch {
+    return Response.json({ error: "Leaderboard unavailable." }, { status: 502 });
+  }
+  if (!res.ok) return Response.json({ error: "Leaderboard unavailable." }, { status: res.status });
+  return Response.json(await res.json());
+}

--- a/web/app/api/arena/vote/route.ts
+++ b/web/app/api/arena/vote/route.ts
@@ -1,5 +1,6 @@
 export const runtime = "nodejs";
 
+import { arenaAccessOk } from "@/lib/arena/guard";
 import { arenaRunnerFetch } from "@/lib/arena/runner";
 import type { VoteResult } from "@/lib/arena/types";
 
@@ -9,6 +10,7 @@ interface VoteOut {
 }
 
 export async function POST(req: Request) {
+  if (!(await arenaAccessOk())) return new Response(null, { status: 404 });
   let body: { battleId?: string; outcome?: string; voterId?: string };
   try {
     body = await req.json();

--- a/web/lib/arena/guard.ts
+++ b/web/lib/arena/guard.ts
@@ -1,0 +1,8 @@
+import { cookies } from "next/headers";
+import { ACCESS_COOKIE_NAME, verifyAccess } from "./access";
+
+export async function arenaAccessOk(): Promise<boolean> {
+  if (process.env.NODE_ENV !== "production") return true;
+  const token = (await cookies()).get(ACCESS_COOKIE_NAME)?.value;
+  return verifyAccess(token) !== null;
+}

--- a/web/lib/arena/leaderboard.ts
+++ b/web/lib/arena/leaderboard.ts
@@ -28,10 +28,8 @@ export interface ArenaLeaderboard {
   entries: ArenaLeaderboardEntry[];
 }
 
-const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
-
 export async function getArenaLeaderboard(signal?: AbortSignal): Promise<ArenaLeaderboard> {
-  const res = await fetch(`${API_BASE}/v1/arena/leaderboard`, {
+  const res = await fetch("/api/arena/leaderboard", {
     headers: { Accept: "application/json" },
     signal,
   });


### PR DESCRIPTION
Gate the four still-open arena endpoints (`leaderboard`, `battle`, `battle/{id}`, generate) behind the labeler key → 404 when missing/wrong. Vote/reveal already gated. Leaderboard page now reads via a new `/api/arena/leaderboard` BFF that injects the key.

Keeps the ratings and the arena's existence confidential — the page was gated, but the runner API was still curl-able. 404 (not 403) hides the route; unauthenticated hits never touch the DB.

Needs `ARENA_LABELER_KEY` on the runner (Cloud Run) and web (Vercel), same value, or BFF→runner 404s.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added query-filtered arena leaderboard support in the web app with consistent backend forwarding and error responses.

* **Bug Fixes**
  * Added access gating for arena actions (reads, voting, and battle creation), returning a hidden **404** when access is missing or invalid.
  * Updated the web client to call the internal leaderboard endpoint rather than constructing an external backend URL.

* **Tests**
  * Expanded arena test coverage for “locked reads” (**404** on missing/incorrect keys) and confirmed battle creation also returns **404** for invalid keys.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR closes the gap where the arena runner API was directly curl-able despite the page being gated. It does so on two layers: a new `require_labeler` FastAPI dependency on the runner raises 404 (not 403) for all four previously-open routes, and a new Next.js BFF route (`/api/arena/leaderboard`) injects the `X-Labeler-Key` server-side so the browser never needs — or has access to — the key.

- **Runner hardening** (`arena.py`): `require_labeler` is applied via `dependencies=[Depends(...)]` to `GET /arena/battle`, `GET /arena/battle/{id}`, `GET /arena/leaderboard`, and `POST /arena/battle`; `hmac.compare_digest` now operates on UTF-8 bytes rather than raw Python `str` objects.
- **Web BFF** (`leaderboard/route.ts`, `guard.ts`): a new server-side leaderboard proxy injects the labeler key; `arenaAccessOk()` provides defense-in-depth cookie verification inside each route handler (middleware already gates the path).
- **Tests** (`test_arena.py`): two new tests assert 404 for all four gated routes with no key and with a wrong key; all existing tests updated to pass the correct header.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the two-layer auth (runner key + web cookie) is correctly wired, the 404-not-403 policy is consistently applied on the four new gates, and the test suite covers both the no-key and wrong-key cases for every gated route.

All four newly gated runner routes use the shared `require_labeler` dependency (constant-time comparison, bytes-safe), the web BFF injects the key server-side so it never leaks to the browser, and existing tests were updated without any gaps. The one note is that `getArenaLeaderboard` now fetches a relative URL and is therefore client-only, but its current call site (a React Query hook) is already client-side, so there is no present defect.

web/lib/arena/leaderboard.ts — the relative fetch URL limits server-side reuse; a comment documents the constraint.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| runner/src/coval_bench/api/routers/arena.py | Adds require_labeler FastAPI dependency (raises 404, not 403) gating get_battle, get_battle_by_id, get_arena_leaderboard, and create_battle; moves _is_authenticated_labeler earlier and correctly encodes both sides to bytes before hmac.compare_digest; cast_vote and reveal_battle retain the pre-existing inline 403 (flagged in a previous review thread). |
| web/lib/arena/guard.ts | New helper that reads the arena_access cookie and calls verifyAccess(); bypasses the check in non-production environments (consistent with middleware.ts behaviour). |
| web/app/api/arena/leaderboard/route.ts | New BFF GET route that gates behind arenaAccessOk(), forwards metric/domain query params to the runner (defaulting to naturalness/all), and injects X-Labeler-Key via arenaRunnerFetch. |
| web/lib/arena/leaderboard.ts | Removes direct NEXT_PUBLIC_API_URL call; fetch now targets the relative path /api/arena/leaderboard. Works correctly in its current client-only context but would throw in any server-side call. |
| runner/tests/api/test_arena.py | Adds _LABELER_HEADERS constant at module scope, updates all existing tests to include the header, and adds two new parameterized tests (no-key and wrong-key) covering all four newly gated endpoints. |
| web/app/api/arena/battle/route.ts | Adds arenaAccessOk() guard at the top of POST handler before any business logic. |
| web/app/api/arena/battle/[id]/reveal/route.ts | Adds arenaAccessOk() guard at the top of GET handler. |
| web/app/api/arena/vote/route.ts | Adds arenaAccessOk() guard at the top of POST handler. |


<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Browser
    participant Middleware as Next.js Middleware
    participant BFF as /api/arena/* (BFF)
    participant Guard as arenaAccessOk()
    participant Runner as Runner (Cloud Run)

    Browser->>Middleware: GET /api/arena/leaderboard (with arena_access cookie)
    Middleware->>Middleware: arenaGate() — verify cookie via verifyAccess()
    alt invalid/missing cookie
        Middleware-->>Browser: 404 (no body)
    end
    Middleware->>BFF: pass through
    BFF->>Guard: arenaAccessOk() [defense-in-depth]
    Guard->>Guard: verifyAccess(cookie) in production
    alt access not ok
        BFF-->>Browser: 404 (no body)
    end
    BFF->>Runner: GET /v1/arena/leaderboard (X-Labeler-Key injected)
    Runner->>Runner: require_labeler dependency — hmac.compare_digest(key)
    alt wrong/missing key
        Runner-->>BFF: 404
        BFF-->>Browser: "404 {error: Leaderboard unavailable.}"
    end
    Runner-->>BFF: 200 leaderboard JSON
    BFF-->>Browser: 200 leaderboard JSON
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Browser
    participant Middleware as Next.js Middleware
    participant BFF as /api/arena/* (BFF)
    participant Guard as arenaAccessOk()
    participant Runner as Runner (Cloud Run)

    Browser->>Middleware: GET /api/arena/leaderboard (with arena_access cookie)
    Middleware->>Middleware: arenaGate() — verify cookie via verifyAccess()
    alt invalid/missing cookie
        Middleware-->>Browser: 404 (no body)
    end
    Middleware->>BFF: pass through
    BFF->>Guard: arenaAccessOk() [defense-in-depth]
    Guard->>Guard: verifyAccess(cookie) in production
    alt access not ok
        BFF-->>Browser: 404 (no body)
    end
    BFF->>Runner: GET /v1/arena/leaderboard (X-Labeler-Key injected)
    Runner->>Runner: require_labeler dependency — hmac.compare_digest(key)
    alt wrong/missing key
        Runner-->>BFF: 404
        BFF-->>Browser: "404 {error: Leaderboard unavailable.}"
    end
    Runner-->>BFF: 200 leaderboard JSON
    BFF-->>Browser: 200 leaderboard JSON
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `runner/src/coval_bench/api/routers/arena.py`, line 193-205 ([link](https://github.com/coval-ai/benchmarks/blob/e94be55f656b1c58cf0e3d1aa88fea65b0293573/runner/src/coval_bench/api/routers/arena.py#L193-L205)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`cast_vote` and `reveal_battle` return 403, leaking route existence**

   Both endpoints read `x_labeler_key` inline and raise `HTTPException(403)`, while the four newly gated routes all raise 404. A caller probing `/v1/arena/vote` or `/v1/arena/battle/{id}/reveal` without a key will receive a 403, confirming these routes exist — undermining the "indistinguishable from a missing route" goal stated in the PR. These were pre-existing but are now inconsistent with the explicit 404 policy. Switching them to `Depends(require_labeler)` would make the whole router uniform.
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["Self-gate arena BFF routes on the access..."](https://github.com/coval-ai/benchmarks/commit/d65c2950de8233597cb3813db7c5412fb88262fc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39912544)</sub>

<!-- /greptile_comment -->