### PR TITLE
Fix our provider logging

### DIFF
--- a/runner/src/coval_bench/api/request_logging.py
+++ b/runner/src/coval_bench/api/request_logging.py
@@ -25,7 +25,7 @@ from collections.abc import Iterable
 import structlog
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
-_log = structlog.get_logger("coval_bench.api.access")
+logger = structlog.get_logger("coval_bench.api.access")
 
 _TRACE_HEADER = b"x-cloud-trace-context"
 _TRACE_ID_RE = re.compile(r"[0-9a-f]{32}", re.IGNORECASE)
@@ -65,7 +65,7 @@ class RequestLoggingMiddleware:
         try:
             await self.app(scope, receive, send_wrapper)
         except Exception:
-            _log.error(
+            logger.error(
                 "http_request",
                 method=method,
                 path=path,
@@ -76,7 +76,13 @@ class RequestLoggingMiddleware:
             raise
         else:
             if not (path in self.quiet_paths and status < 400):
-                emit = _log.error if status >= 500 else _log.warning if status >= 400 else _log.info
+                emit = (
+                    logger.error
+                    if status >= 500
+                    else logger.warning
+                    if status >= 400
+                    else logger.info
+                )
                 emit(
                     "http_request",
                     method=method,

--- a/runner/src/coval_bench/providers/_http_session.py
+++ b/runner/src/coval_bench/providers/_http_session.py
@@ -26,7 +26,7 @@ from typing import Final
 import httpx
 import structlog
 
-_log = structlog.get_logger(__name__)
+logger = structlog.get_logger(__name__)
 
 _KEEPALIVE_S: Final[float] = 300.0
 _TIMEOUT_S: Final[float] = 30.0
@@ -61,7 +61,7 @@ class TimedTransport(httpx.AsyncHTTPTransport):
         request.extensions["__t_submit"] = t_submit
         request.extensions["__t_headers"] = t_headers
         request.extensions["__connection_reused"] = not opened_connection
-        _log.debug(
+        logger.debug(
             "http_request_timing",
             host=request.url.host,
             method=request.method,
@@ -126,5 +126,5 @@ async def close_all() -> None:
         try:
             await client.aclose()
         except Exception as exc:  # noqa: BLE001 — best-effort teardown
-            _log.debug("http_client_close_failed", provider=key, exc_info=exc)
+            logger.warning("http_client_close_failed", provider=key, exc_info=exc)
     _CLIENTS.clear()

--- a/runner/src/coval_bench/providers/stt/assemblyai.py
+++ b/runner/src/coval_bench/providers/stt/assemblyai.py
@@ -102,10 +102,20 @@ class AssemblyAIProvider(STTProvider):
                     )
                 )
                 recv_task = asyncio.create_task(self._receive(ws, result, final_event))
-                await asyncio.gather(send_task, recv_task, return_exceptions=True)
+                outcomes = await asyncio.gather(send_task, recv_task, return_exceptions=True)
+                if result.error is None and result.audio_to_final_seconds is None:
+                    for outcome in outcomes:
+                        if isinstance(outcome, Exception):
+                            result.error = str(outcome)
+                            break
 
         except Exception as exc:
-            logger.exception("assemblyai_measure_ttft_failed", error=str(exc))
+            logger.warning(
+                "assemblyai_measure_ttft_failed",
+                provider="assemblyai",
+                model=self._model,
+                exc_info=exc,
+            )
             result.error = str(exc)
 
         result.total_time = time.monotonic() - total_start
@@ -143,7 +153,9 @@ class AssemblyAIProvider(STTProvider):
                 await asyncio.wait_for(final_event.wait(), timeout=_FINAL_WAIT_S)
             await ws.send(json.dumps({"type": "Terminate"}))
         except Exception as exc:
-            logger.exception("assemblyai_send_error", error=str(exc))
+            logger.warning(
+                "assemblyai_send_error", provider="assemblyai", model=self._model, exc_info=exc
+            )
             raise
 
     async def _receive(
@@ -181,7 +193,14 @@ class AssemblyAIProvider(STTProvider):
                     final_event.set()
 
         except Exception as exc:
-            logger.exception("assemblyai_receive_error", error=str(exc))
+            logger.warning(
+                "assemblyai_receive_error",
+                provider="assemblyai",
+                model=self._model,
+                exc_info=exc,
+            )
+            if result.error is None and last_final_time is None:
+                result.error = str(exc)
 
         if last_final_time is not None and result.audio_start_time is not None:
             result.audio_to_final_seconds = last_final_time - result.audio_start_time

--- a/runner/src/coval_bench/providers/stt/assemblyai.py
+++ b/runner/src/coval_bench/providers/stt/assemblyai.py
@@ -102,7 +102,12 @@ class AssemblyAIProvider(STTProvider):
                     )
                 )
                 recv_task = asyncio.create_task(self._receive(ws, result, final_event))
-                outcomes = await asyncio.gather(send_task, recv_task, return_exceptions=True)
+                tasks = (send_task, recv_task)
+                done, pending = await asyncio.wait(tasks, return_when=asyncio.FIRST_EXCEPTION)
+                if any(not task.cancelled() and task.exception() is not None for task in done):
+                    for task in pending:
+                        task.cancel()
+                outcomes = await asyncio.gather(*tasks, return_exceptions=True)
                 if result.error is None and result.audio_to_final_seconds is None:
                     for outcome in outcomes:
                         if isinstance(outcome, Exception):

--- a/runner/src/coval_bench/providers/stt/cartesia.py
+++ b/runner/src/coval_bench/providers/stt/cartesia.py
@@ -86,7 +86,12 @@ class CartesiaSTTProvider(STTProvider):
                     self._send_audio(ws, audio_data, sample_rate, result, realtime_resolution)
                 )
                 recv_task = asyncio.create_task(self._receive(ws, result))
-                outcomes = await asyncio.gather(send_task, recv_task, return_exceptions=True)
+                tasks = (send_task, recv_task)
+                done, pending = await asyncio.wait(tasks, return_when=asyncio.FIRST_EXCEPTION)
+                if any(not task.cancelled() and task.exception() is not None for task in done):
+                    for task in pending:
+                        task.cancel()
+                outcomes = await asyncio.gather(*tasks, return_exceptions=True)
                 if result.error is None and result.audio_to_final_seconds is None:
                     for outcome in outcomes:
                         if isinstance(outcome, Exception):

--- a/runner/src/coval_bench/providers/stt/cartesia.py
+++ b/runner/src/coval_bench/providers/stt/cartesia.py
@@ -87,14 +87,19 @@ class CartesiaSTTProvider(STTProvider):
                 )
                 recv_task = asyncio.create_task(self._receive(ws, result))
                 outcomes = await asyncio.gather(send_task, recv_task, return_exceptions=True)
-                # gather swallows task exceptions into the result list; surface the
-                # first one so a failed send/recv never reads as a clean run.
-                for outcome in outcomes:
-                    if isinstance(outcome, BaseException) and result.error is None:
-                        result.error = str(outcome)
+                if result.error is None and result.audio_to_final_seconds is None:
+                    for outcome in outcomes:
+                        if isinstance(outcome, Exception):
+                            result.error = str(outcome)
+                            break
 
         except Exception as exc:
-            logger.exception("cartesia_stt_measure_ttft_failed", error=str(exc))
+            logger.warning(
+                "cartesia_stt_measure_ttft_failed",
+                provider="cartesia",
+                model=self._model,
+                exc_info=exc,
+            )
             result.error = str(exc)
 
         result.total_time = time.monotonic() - total_start
@@ -124,7 +129,9 @@ class CartesiaSTTProvider(STTProvider):
             await ws.send("finalize")
             await ws.send("close")
         except Exception as exc:
-            logger.exception("cartesia_stt_send_error", error=str(exc))
+            logger.warning(
+                "cartesia_stt_send_error", provider="cartesia", model=self._model, exc_info=exc
+            )
             raise
 
     async def _receive(self, ws: Any, result: TranscriptionResult) -> None:
@@ -169,8 +176,13 @@ class CartesiaSTTProvider(STTProvider):
                         result.audio_to_final_seconds = now - result.audio_start_time
 
         except Exception as exc:
-            logger.exception("cartesia_stt_receive_error", error=str(exc))
-            if result.error is None:
+            logger.warning(
+                "cartesia_stt_receive_error",
+                provider="cartesia",
+                model=self._model,
+                exc_info=exc,
+            )
+            if result.error is None and result.audio_to_final_seconds is None:
                 result.error = str(exc)
 
         # Per Cartesia docs, join is_final deltas verbatim — they carry their own

--- a/runner/src/coval_bench/providers/stt/deepgram.py
+++ b/runner/src/coval_bench/providers/stt/deepgram.py
@@ -127,7 +127,12 @@ class DeepgramProvider(STTProvider):
                     )
                 )
                 recv_task = asyncio.create_task(self._receive(ws, result, final_event))
-                outcomes = await asyncio.gather(send_task, recv_task, return_exceptions=True)
+                tasks = (send_task, recv_task)
+                done, pending = await asyncio.wait(tasks, return_when=asyncio.FIRST_EXCEPTION)
+                if any(not task.cancelled() and task.exception() is not None for task in done):
+                    for task in pending:
+                        task.cancel()
+                outcomes = await asyncio.gather(*tasks, return_exceptions=True)
                 if result.error is None and result.audio_to_final_seconds is None:
                     for outcome in outcomes:
                         if isinstance(outcome, Exception):

--- a/runner/src/coval_bench/providers/stt/deepgram.py
+++ b/runner/src/coval_bench/providers/stt/deepgram.py
@@ -127,10 +127,17 @@ class DeepgramProvider(STTProvider):
                     )
                 )
                 recv_task = asyncio.create_task(self._receive(ws, result, final_event))
-                await asyncio.gather(send_task, recv_task, return_exceptions=True)
+                outcomes = await asyncio.gather(send_task, recv_task, return_exceptions=True)
+                if result.error is None and result.audio_to_final_seconds is None:
+                    for outcome in outcomes:
+                        if isinstance(outcome, Exception):
+                            result.error = str(outcome)
+                            break
 
         except Exception as exc:
-            logger.exception("deepgram_measure_ttft_failed", error=str(exc))
+            logger.warning(
+                "deepgram_measure_ttft_failed", provider="deepgram", model=self._model, exc_info=exc
+            )
             result.error = str(exc)
 
         result.total_time = time.monotonic() - total_start
@@ -175,7 +182,9 @@ class DeepgramProvider(STTProvider):
                     await asyncio.wait_for(final_event.wait(), timeout=_FINAL_WAIT_S)
             await ws.send(json.dumps({"type": "CloseStream"}))
         except Exception as exc:
-            logger.exception("deepgram_send_error", error=str(exc))
+            logger.warning(
+                "deepgram_send_error", provider="deepgram", model=self._model, exc_info=exc
+            )
             raise
 
     # ------------------------------------------------------------------
@@ -267,7 +276,11 @@ class DeepgramProvider(STTProvider):
                         pending_partial = transcript
 
         except Exception as exc:
-            logger.exception("deepgram_receive_error", error=str(exc))
+            logger.warning(
+                "deepgram_receive_error", provider="deepgram", model=self._model, exc_info=exc
+            )
+            if result.error is None and last_final_time is None:
+                result.error = str(exc)
 
         if last_final_time is not None and result.audio_start_time is not None:
             result.audio_to_final_seconds = last_final_time - result.audio_start_time

--- a/runner/src/coval_bench/providers/stt/elevenlabs.py
+++ b/runner/src/coval_bench/providers/stt/elevenlabs.py
@@ -127,7 +127,12 @@ class ElevenLabsSTTProvider(STTProvider):
                     self._send_audio(ws, audio_data, sample_rate, result, realtime_resolution)
                 )
                 recv_task = asyncio.create_task(self._receive(ws, result))
-                outcomes = await asyncio.gather(send_task, recv_task, return_exceptions=True)
+                tasks = (send_task, recv_task)
+                done, pending = await asyncio.wait(tasks, return_when=asyncio.FIRST_EXCEPTION)
+                if any(not task.cancelled() and task.exception() is not None for task in done):
+                    for task in pending:
+                        task.cancel()
+                outcomes = await asyncio.gather(*tasks, return_exceptions=True)
                 if result.error is None and result.audio_to_final_seconds is None:
                     for outcome in outcomes:
                         if isinstance(outcome, Exception):

--- a/runner/src/coval_bench/providers/stt/elevenlabs.py
+++ b/runner/src/coval_bench/providers/stt/elevenlabs.py
@@ -115,17 +115,32 @@ class ElevenLabsSTTProvider(STTProvider):
                 except TimeoutError:
                     logger.warning("elevenlabs_session_started_timeout")
                 except Exception as exc:
-                    logger.exception("elevenlabs_session_started_error", error=str(exc))
+                    logger.warning(
+                        "elevenlabs_session_started_error",
+                        provider="elevenlabs",
+                        model=self._model,
+                        exc_info=exc,
+                    )
                     raise
 
                 send_task = asyncio.create_task(
                     self._send_audio(ws, audio_data, sample_rate, result, realtime_resolution)
                 )
                 recv_task = asyncio.create_task(self._receive(ws, result))
-                await asyncio.gather(send_task, recv_task, return_exceptions=True)
+                outcomes = await asyncio.gather(send_task, recv_task, return_exceptions=True)
+                if result.error is None and result.audio_to_final_seconds is None:
+                    for outcome in outcomes:
+                        if isinstance(outcome, Exception):
+                            result.error = str(outcome)
+                            break
 
         except Exception as exc:
-            logger.exception("elevenlabs_measure_ttft_failed", error=str(exc))
+            logger.warning(
+                "elevenlabs_measure_ttft_failed",
+                provider="elevenlabs",
+                model=self._model,
+                exc_info=exc,
+            )
             result.error = str(exc)
 
         result.total_time = time.monotonic() - total_start
@@ -159,7 +174,9 @@ class ElevenLabsSTTProvider(STTProvider):
                 )
             )
         except Exception as exc:
-            logger.exception("elevenlabs_send_error", error=str(exc))
+            logger.warning(
+                "elevenlabs_send_error", provider="elevenlabs", model=self._model, exc_info=exc
+            )
             raise
 
     async def _receive(self, ws: Any, result: TranscriptionResult) -> None:
@@ -177,8 +194,10 @@ class ElevenLabsSTTProvider(STTProvider):
                 if msg_type in _ERROR_MSG_TYPES:
                     error_text = msg.get("message", msg.get("error", "Unknown error"))
                     result.error = f"{msg_type}: {error_text}"
-                    logger.error(
+                    logger.warning(
                         "elevenlabs_api_error",
+                        provider="elevenlabs",
+                        model=self._model,
                         msg_type=msg_type,
                         error=error_text,
                     )
@@ -204,7 +223,14 @@ class ElevenLabsSTTProvider(STTProvider):
                             result.audio_to_final_seconds = now - result.audio_start_time
 
         except Exception as exc:
-            logger.exception("elevenlabs_receive_error", error=str(exc))
+            logger.warning(
+                "elevenlabs_receive_error",
+                provider="elevenlabs",
+                model=self._model,
+                exc_info=exc,
+            )
+            if result.error is None and result.audio_to_final_seconds is None:
+                result.error = str(exc)
 
         if committed_parts:
             result.complete_transcript = " ".join(committed_parts).strip() or None

--- a/runner/src/coval_bench/providers/stt/google.py
+++ b/runner/src/coval_bench/providers/stt/google.py
@@ -173,7 +173,12 @@ class GoogleSTTProvider(STTProvider):
                         if saw_final:
                             last_final_time = now
             except Exception as exc:
-                logger.exception("google_streaming_recognize_failed", error=str(exc))
+                logger.warning(
+                    "google_streaming_recognize_failed",
+                    provider="google",
+                    model=self._model,
+                    exc_info=exc,
+                )
                 raise
 
             if last_final_time is not None and result.audio_start_time is not None:
@@ -191,7 +196,9 @@ class GoogleSTTProvider(STTProvider):
             with concurrent.futures.ThreadPoolExecutor() as executor:
                 await loop.run_in_executor(executor, _run_sync)
         except Exception as exc:
-            logger.exception("google_measure_ttft_failed", error=str(exc))
+            logger.warning(
+                "google_measure_ttft_failed", provider="google", model=self._model, exc_info=exc
+            )
             result.error = str(exc)
 
         result.total_time = time.monotonic() - total_start

--- a/runner/src/coval_bench/providers/stt/gradium.py
+++ b/runner/src/coval_bench/providers/stt/gradium.py
@@ -100,7 +100,12 @@ class GradiumSTTProvider(STTProvider):
                     )
                 )
                 recv_task = asyncio.create_task(self._receive(ws, result, final_event))
-                outcomes = await asyncio.gather(send_task, recv_task, return_exceptions=True)
+                tasks = (send_task, recv_task)
+                done, pending = await asyncio.wait(tasks, return_when=asyncio.FIRST_EXCEPTION)
+                if any(not task.cancelled() and task.exception() is not None for task in done):
+                    for task in pending:
+                        task.cancel()
+                outcomes = await asyncio.gather(*tasks, return_exceptions=True)
                 if result.error is None and result.audio_to_final_seconds is None:
                     for outcome in outcomes:
                         if isinstance(outcome, Exception):

--- a/runner/src/coval_bench/providers/stt/gradium.py
+++ b/runner/src/coval_bench/providers/stt/gradium.py
@@ -100,10 +100,17 @@ class GradiumSTTProvider(STTProvider):
                     )
                 )
                 recv_task = asyncio.create_task(self._receive(ws, result, final_event))
-                await asyncio.gather(send_task, recv_task, return_exceptions=True)
+                outcomes = await asyncio.gather(send_task, recv_task, return_exceptions=True)
+                if result.error is None and result.audio_to_final_seconds is None:
+                    for outcome in outcomes:
+                        if isinstance(outcome, Exception):
+                            result.error = str(outcome)
+                            break
 
         except Exception as exc:
-            logger.exception("gradium_measure_ttft_failed", error=str(exc))
+            logger.warning(
+                "gradium_measure_ttft_failed", provider="gradium", model=self._model, exc_info=exc
+            )
             result.error = str(exc)
 
         result.total_time = time.monotonic() - total_start
@@ -134,7 +141,9 @@ class GradiumSTTProvider(STTProvider):
                 await asyncio.wait_for(final_event.wait(), timeout=_FLUSH_WAIT_S)
             await ws.send(json.dumps({"type": "end_of_stream"}))
         except Exception as exc:
-            logger.exception("gradium_send_error", error=str(exc))
+            logger.warning(
+                "gradium_send_error", provider="gradium", model=self._model, exc_info=exc
+            )
             raise
 
     async def _receive(
@@ -185,11 +194,17 @@ class GradiumSTTProvider(STTProvider):
 
                 if msg_type == "error":
                     result.error = str(msg.get("message", msg))
-                    logger.error("gradium_stt_error", msg=msg)
+                    logger.warning(
+                        "gradium_stt_error", provider="gradium", model=self._model, msg=msg
+                    )
                     break
 
         except Exception as exc:
-            logger.exception("gradium_receive_error", error=str(exc))
+            logger.warning(
+                "gradium_receive_error", provider="gradium", model=self._model, exc_info=exc
+            )
+            if result.error is None and result.audio_to_final_seconds is None:
+                result.error = str(exc)
 
         if final_parts:
             result.complete_transcript = " ".join(final_parts).strip() or None

--- a/runner/src/coval_bench/providers/stt/openai.py
+++ b/runner/src/coval_bench/providers/stt/openai.py
@@ -133,7 +133,9 @@ class OpenAISTTProvider(STTProvider):
                     await asyncio.gather(*tasks, return_exceptions=True)
 
         except Exception as exc:
-            logger.exception("openai_measure_ttft_failed", error=str(exc))
+            logger.warning(
+                "openai_measure_ttft_failed", provider="openai", model=self._model, exc_info=exc
+            )
             if result.error is None:
                 result.error = str(exc)
 
@@ -215,7 +217,7 @@ class OpenAISTTProvider(STTProvider):
                 await asyncio.sleep(realtime_resolution)
             await ws.send(json.dumps({"type": "input_audio_buffer.commit"}))
         except Exception as exc:
-            logger.exception("openai_send_error", error=str(exc))
+            logger.warning("openai_send_error", provider="openai", model=self._model, exc_info=exc)
             raise
 
     async def _receive(self, ws: Any, result: TranscriptionResult) -> None:
@@ -265,7 +267,9 @@ class OpenAISTTProvider(STTProvider):
         except _TranscriptionAborted:
             raise
         except Exception as exc:
-            logger.exception("openai_receive_error", error=str(exc))
+            logger.warning(
+                "openai_receive_error", provider="openai", model=self._model, exc_info=exc
+            )
             if result.error is None:
                 result.error = str(exc)
 

--- a/runner/src/coval_bench/providers/stt/smallest.py
+++ b/runner/src/coval_bench/providers/stt/smallest.py
@@ -75,10 +75,17 @@ class SmallestSTTProvider(STTProvider):
                     self._send_audio(ws, audio_data, sample_rate, result, realtime_resolution)
                 )
                 recv_task = asyncio.create_task(self._receive(ws, result))
-                await asyncio.gather(send_task, recv_task, return_exceptions=True)
+                outcomes = await asyncio.gather(send_task, recv_task, return_exceptions=True)
+                if result.error is None and result.audio_to_final_seconds is None:
+                    for outcome in outcomes:
+                        if isinstance(outcome, Exception):
+                            result.error = str(outcome)
+                            break
 
         except Exception as exc:
-            logger.exception("smallest_measure_ttft_failed", error=str(exc))
+            logger.warning(
+                "smallest_measure_ttft_failed", provider="smallest", model=self._model, exc_info=exc
+            )
             result.error = str(exc)
 
         result.total_time = time.monotonic() - total_start
@@ -106,7 +113,9 @@ class SmallestSTTProvider(STTProvider):
                 await asyncio.sleep(realtime_resolution)
             await ws.send(json.dumps({"type": "close_stream"}))
         except Exception as exc:
-            logger.exception("smallest_send_error", error=str(exc))
+            logger.warning(
+                "smallest_send_error", provider="smallest", model=self._model, exc_info=exc
+            )
             raise
 
     async def _receive(self, ws: Any, result: TranscriptionResult) -> None:
@@ -148,7 +157,11 @@ class SmallestSTTProvider(STTProvider):
                     break
 
         except Exception as exc:
-            logger.exception("smallest_receive_error", error=str(exc))
+            logger.warning(
+                "smallest_receive_error", provider="smallest", model=self._model, exc_info=exc
+            )
+            if result.error is None and result.audio_to_final_seconds is None:
+                result.error = str(exc)
 
         if final_segments:
             result.complete_transcript = " ".join(final_segments).strip() or None

--- a/runner/src/coval_bench/providers/stt/smallest.py
+++ b/runner/src/coval_bench/providers/stt/smallest.py
@@ -75,7 +75,12 @@ class SmallestSTTProvider(STTProvider):
                     self._send_audio(ws, audio_data, sample_rate, result, realtime_resolution)
                 )
                 recv_task = asyncio.create_task(self._receive(ws, result))
-                outcomes = await asyncio.gather(send_task, recv_task, return_exceptions=True)
+                tasks = (send_task, recv_task)
+                done, pending = await asyncio.wait(tasks, return_when=asyncio.FIRST_EXCEPTION)
+                if any(not task.cancelled() and task.exception() is not None for task in done):
+                    for task in pending:
+                        task.cancel()
+                outcomes = await asyncio.gather(*tasks, return_exceptions=True)
                 if result.error is None and result.audio_to_final_seconds is None:
                     for outcome in outcomes:
                         if isinstance(outcome, Exception):

--- a/runner/src/coval_bench/providers/stt/soniox.py
+++ b/runner/src/coval_bench/providers/stt/soniox.py
@@ -84,7 +84,12 @@ class SonioxSTTProvider(STTProvider):
                     self._send_audio(ws, audio_data, sample_rate, result, realtime_resolution)
                 )
                 recv_task = asyncio.create_task(self._receive(ws, result))
-                outcomes = await asyncio.gather(send_task, recv_task, return_exceptions=True)
+                tasks = (send_task, recv_task)
+                done, pending = await asyncio.wait(tasks, return_when=asyncio.FIRST_EXCEPTION)
+                if any(not task.cancelled() and task.exception() is not None for task in done):
+                    for task in pending:
+                        task.cancel()
+                outcomes = await asyncio.gather(*tasks, return_exceptions=True)
                 if result.error is None and result.audio_to_final_seconds is None:
                     for outcome in outcomes:
                         if isinstance(outcome, Exception):

--- a/runner/src/coval_bench/providers/stt/soniox.py
+++ b/runner/src/coval_bench/providers/stt/soniox.py
@@ -85,13 +85,16 @@ class SonioxSTTProvider(STTProvider):
                 )
                 recv_task = asyncio.create_task(self._receive(ws, result))
                 outcomes = await asyncio.gather(send_task, recv_task, return_exceptions=True)
-                # Surface a task failure as result.error so it isn't a silent success.
-                for outcome in outcomes:
-                    if isinstance(outcome, Exception) and result.error is None:
-                        result.error = str(outcome)
+                if result.error is None and result.audio_to_final_seconds is None:
+                    for outcome in outcomes:
+                        if isinstance(outcome, Exception):
+                            result.error = str(outcome)
+                            break
 
         except Exception as exc:
-            logger.exception("soniox_measure_ttft_failed", error=str(exc))
+            logger.warning(
+                "soniox_measure_ttft_failed", provider="soniox", model=self._model, exc_info=exc
+            )
             result.error = str(exc)
 
         result.total_time = time.monotonic() - total_start
@@ -116,7 +119,7 @@ class SonioxSTTProvider(STTProvider):
             # ignored, so the server never finalizes (stalls to its idle timeout).
             await ws.send("")
         except Exception as exc:
-            logger.exception("soniox_send_error", error=str(exc))
+            logger.warning("soniox_send_error", provider="soniox", model=self._model, exc_info=exc)
             raise
 
     async def _receive(self, ws: Any, result: TranscriptionResult) -> None:
@@ -135,7 +138,9 @@ class SonioxSTTProvider(STTProvider):
                     result.error = str(
                         msg.get("error_message") or f"Soniox STT error (code {code})"
                     )
-                    logger.error("soniox_stt_error", msg=msg)
+                    logger.warning(
+                        "soniox_stt_error", provider="soniox", model=self._model, msg=msg
+                    )
                     break
 
                 tokens: list[dict[str, Any]] = msg.get("tokens") or []
@@ -160,8 +165,10 @@ class SonioxSTTProvider(STTProvider):
                     break
 
         except Exception as exc:
-            logger.exception("soniox_receive_error", error=str(exc))
-            if result.error is None:
+            logger.warning(
+                "soniox_receive_error", provider="soniox", model=self._model, exc_info=exc
+            )
+            if result.error is None and result.audio_to_final_seconds is None:
                 result.error = str(exc)
 
         if final_parts:

--- a/runner/src/coval_bench/providers/stt/speechmatics.py
+++ b/runner/src/coval_bench/providers/stt/speechmatics.py
@@ -106,7 +106,12 @@ class SpeechmaticsProvider(STTProvider):
                     )
                 )
                 recv_task = asyncio.create_task(self._receive(ws, result))
-                outcomes = await asyncio.gather(send_task, recv_task, return_exceptions=True)
+                tasks = (send_task, recv_task)
+                done, pending = await asyncio.wait(tasks, return_when=asyncio.FIRST_EXCEPTION)
+                if any(not task.cancelled() and task.exception() is not None for task in done):
+                    for task in pending:
+                        task.cancel()
+                outcomes = await asyncio.gather(*tasks, return_exceptions=True)
                 if result.error is None and result.audio_to_final_seconds is None:
                     for outcome in outcomes:
                         if isinstance(outcome, Exception):

--- a/runner/src/coval_bench/providers/stt/speechmatics.py
+++ b/runner/src/coval_bench/providers/stt/speechmatics.py
@@ -106,10 +106,20 @@ class SpeechmaticsProvider(STTProvider):
                     )
                 )
                 recv_task = asyncio.create_task(self._receive(ws, result))
-                await asyncio.gather(send_task, recv_task, return_exceptions=True)
+                outcomes = await asyncio.gather(send_task, recv_task, return_exceptions=True)
+                if result.error is None and result.audio_to_final_seconds is None:
+                    for outcome in outcomes:
+                        if isinstance(outcome, Exception):
+                            result.error = str(outcome)
+                            break
 
         except Exception as exc:
-            logger.exception("speechmatics_measure_ttft_failed", error=str(exc))
+            logger.warning(
+                "speechmatics_measure_ttft_failed",
+                provider="speechmatics",
+                model=self._model,
+                exc_info=exc,
+            )
             result.error = str(exc)
 
         result.total_time = time.monotonic() - total_start
@@ -147,7 +157,9 @@ class SpeechmaticsProvider(STTProvider):
                 await asyncio.sleep(realtime_resolution)
             await ws.send(json.dumps({"message": "EndOfStream", "last_seq_no": seq_no}))
         except Exception as exc:
-            logger.exception("speechmatics_send_error", error=str(exc))
+            logger.warning(
+                "speechmatics_send_error", provider="speechmatics", model=self._model, exc_info=exc
+            )
             raise
 
     async def _receive(self, ws: Any, result: TranscriptionResult) -> None:
@@ -187,7 +199,14 @@ class SpeechmaticsProvider(STTProvider):
                     last_final_time = now
 
         except Exception as exc:
-            logger.exception("speechmatics_receive_error", error=str(exc))
+            logger.warning(
+                "speechmatics_receive_error",
+                provider="speechmatics",
+                model=self._model,
+                exc_info=exc,
+            )
+            if result.error is None and last_final_time is None:
+                result.error = str(exc)
 
         if last_final_time is not None and result.audio_start_time is not None:
             result.audio_to_final_seconds = last_final_time - result.audio_start_time

--- a/runner/src/coval_bench/providers/stt/xai.py
+++ b/runner/src/coval_bench/providers/stt/xai.py
@@ -121,7 +121,9 @@ class XaiSTTProvider(STTProvider):
                         raise task_result
 
         except Exception as exc:
-            logger.exception("xai_measure_ttft_failed", error=str(exc))
+            logger.warning(
+                "xai_measure_ttft_failed", provider="xai", model=self._model, exc_info=exc
+            )
             result.error = result.error or str(exc)
 
         result.total_time = time.monotonic() - total_start
@@ -229,7 +231,7 @@ class XaiSTTProvider(STTProvider):
                     result.error = str(event.get("message", "xAI error"))
                     break
         except Exception as exc:
-            logger.exception("xai_receive_error", error=str(exc))
+            logger.warning("xai_receive_error", provider="xai", model=self._model, exc_info=exc)
             if result.error is None:
                 result.error = str(exc)
         finally:

--- a/runner/src/coval_bench/providers/tts/_common.py
+++ b/runner/src/coval_bench/providers/tts/_common.py
@@ -91,8 +91,8 @@ def _safe_offset_ms(pcm: bytes, sample_rate: int, provider: str, model: str) -> 
     """
     try:
         return first_audible_offset_ms(pcm, sample_rate)
-    except Exception:
-        logger.warning("tts_offset_failed", provider=provider, model=model, exc_info=True)
+    except Exception as exc:
+        logger.warning("tts_offset_failed", provider=provider, model=model, exc_info=exc)
         return None
 
 

--- a/runner/src/coval_bench/providers/tts/cartesia.py
+++ b/runner/src/coval_bench/providers/tts/cartesia.py
@@ -108,7 +108,7 @@ class CartesiaTTSProvider(TTSProvider):
                         break
 
         except Exception as exc:
-            logger.debug("cartesia_error", exc_info=True)
+            logger.warning("cartesia_error", provider="cartesia", model=self._model, exc_info=exc)
             return finalize_tts_result(
                 provider="cartesia",
                 model=self._model,

--- a/runner/src/coval_bench/providers/tts/deepgram.py
+++ b/runner/src/coval_bench/providers/tts/deepgram.py
@@ -105,7 +105,7 @@ class DeepgramTTSProvider(TTSProvider):
                         logger.warning("deepgram_ws_warning", description=msg.get("description"))
 
         except Exception as exc:
-            logger.debug("deepgram_error", exc_info=True)
+            logger.warning("deepgram_error", provider="deepgram", model=self._model, exc_info=exc)
             return finalize_tts_result(
                 provider="deepgram",
                 model=self._model,

--- a/runner/src/coval_bench/providers/tts/elevenlabs.py
+++ b/runner/src/coval_bench/providers/tts/elevenlabs.py
@@ -121,7 +121,9 @@ class ElevenLabsTTSProvider(TTSProvider):
                     if chunk:
                         audio_chunks.append(chunk)
         except Exception as exc:
-            logger.debug("elevenlabs_error", exc_info=True)
+            logger.warning(
+                "elevenlabs_error", provider="elevenlabs", model=self._model, exc_info=exc
+            )
             return finalize_tts_result(
                 provider="elevenlabs",
                 model=self._model,

--- a/runner/src/coval_bench/providers/tts/gradium.py
+++ b/runner/src/coval_bench/providers/tts/gradium.py
@@ -110,7 +110,7 @@ class GradiumTTSProvider(TTSProvider):
                         raise RuntimeError(str(msg.get("message", msg)))
 
         except Exception as exc:
-            logger.debug("gradium_tts_error", exc_info=True)
+            logger.warning("gradium_tts_error", provider="gradium", model=self._model, exc_info=exc)
             return finalize_tts_result(
                 provider="gradium",
                 model=self._model,

--- a/runner/src/coval_bench/providers/tts/groq.py
+++ b/runner/src/coval_bench/providers/tts/groq.py
@@ -126,7 +126,7 @@ class GroqTTSProvider(TTSProvider):
                             first_chunk_at = time.monotonic()
                         audio_chunks.append(chunk)
         except Exception as exc:
-            logger.debug("groq_http_error", exc_info=True)
+            logger.warning("groq_http_error", provider="groq", model=self._model, exc_info=exc)
             return finalize_tts_result(
                 provider="groq",
                 model=self._model,

--- a/runner/src/coval_bench/providers/tts/hume.py
+++ b/runner/src/coval_bench/providers/tts/hume.py
@@ -121,6 +121,7 @@ class HumeTTSProvider(TTSProvider):
         except TimeoutError:
             logger.warning(
                 "hume_timeout",
+                provider="hume",
                 model=self._model,
                 timeout_s=_WS_SESSION_TIMEOUT_S,
             )
@@ -136,7 +137,7 @@ class HumeTTSProvider(TTSProvider):
             )
 
         except Exception as exc:
-            logger.warning("hume_error", exc_info=True)
+            logger.warning("hume_error", provider="hume", model=self._model, exc_info=exc)
             return finalize_tts_result(
                 provider="hume",
                 model=self._model,

--- a/runner/src/coval_bench/providers/tts/inworld.py
+++ b/runner/src/coval_bench/providers/tts/inworld.py
@@ -130,7 +130,7 @@ class InworldTTSProvider(TTSProvider):
                         break
 
         except Exception as exc:
-            logger.warning("inworld_error", exc_info=True)
+            logger.warning("inworld_error", provider="inworld", model=self._model, exc_info=exc)
             # The credential rides in the URL query, so scrub it from any
             # exception that echoes the URI before it lands in a stored result.
             return finalize_tts_result(

--- a/runner/src/coval_bench/providers/tts/inworld.py
+++ b/runner/src/coval_bench/providers/tts/inworld.py
@@ -130,9 +130,11 @@ class InworldTTSProvider(TTSProvider):
                         break
 
         except Exception as exc:
-            logger.warning("inworld_error", provider="inworld", model=self._model, exc_info=exc)
-            # The credential rides in the URL query, so scrub it from any
-            # exception that echoes the URI before it lands in a stored result.
+            # Credential rides in the URL query; scrub it before the exception
+            # reaches logs or the stored result. No exc_info — the rendered
+            # traceback would echo the unredacted URI.
+            scrubbed = str(exc).replace(auth_param, "***")
+            logger.warning("inworld_error", provider="inworld", model=self._model, error=scrubbed)
             return finalize_tts_result(
                 provider="inworld",
                 model=self._model,
@@ -141,7 +143,7 @@ class InworldTTSProvider(TTSProvider):
                 sample_rate=SAMPLE_RATE,
                 audio_synthesis_start=start,
                 first_audio_chunk_at=first_chunk_at,
-                error=str(exc).replace(auth_param, "***"),
+                error=scrubbed,
             )
 
         return finalize_tts_result(

--- a/runner/src/coval_bench/providers/tts/openai.py
+++ b/runner/src/coval_bench/providers/tts/openai.py
@@ -132,7 +132,7 @@ class OpenAITTSProvider(TTSProvider):
                             first_chunk_at = time.monotonic()
                         audio_chunks.append(chunk)
         except Exception as exc:
-            logger.debug("openai_http_error", exc_info=True)
+            logger.warning("openai_http_error", provider="openai", model=self._model, exc_info=exc)
             return finalize_tts_result(
                 provider="openai",
                 model=self._model,

--- a/runner/src/coval_bench/providers/tts/rime.py
+++ b/runner/src/coval_bench/providers/tts/rime.py
@@ -109,7 +109,7 @@ class RimeTTSProvider(TTSProvider):
                     # "timestamps" events are silently dropped — not needed for benchmark.
 
         except Exception as exc:
-            logger.warning("rime_error", exc_info=True)
+            logger.warning("rime_error", provider="rime", model=self._model, exc_info=exc)
             return finalize_tts_result(
                 provider="rime",
                 model=self._model,

--- a/runner/src/coval_bench/providers/tts/smallest.py
+++ b/runner/src/coval_bench/providers/tts/smallest.py
@@ -102,7 +102,7 @@ class SmallestTTSProvider(TTSProvider):
                         break
 
         except Exception as exc:
-            logger.warning("smallest_error", exc_info=True)
+            logger.warning("smallest_error", provider="smallest", model=self._model, exc_info=exc)
             return finalize_tts_result(
                 provider="smallest",
                 model=self._model,

--- a/runner/src/coval_bench/providers/tts/soniox.py
+++ b/runner/src/coval_bench/providers/tts/soniox.py
@@ -128,7 +128,7 @@ class SonioxTTSProvider(TTSProvider):
                         break
 
         except Exception as exc:
-            logger.debug("soniox_tts_error", exc_info=True)
+            logger.warning("soniox_tts_error", provider="soniox", model=self._model, exc_info=exc)
             return finalize_tts_result(
                 provider="soniox",
                 model=self._model,

--- a/runner/src/coval_bench/providers/tts/xai.py
+++ b/runner/src/coval_bench/providers/tts/xai.py
@@ -99,7 +99,7 @@ class XaiTTSProvider(TTSProvider):
                         raise RuntimeError(str(event.get("message", "xAI TTS error")))
 
         except Exception as exc:
-            logger.debug("xai_tts_error", exc_info=True)
+            logger.warning("xai_tts_error", provider="xai", model=self._model, exc_info=exc)
             return finalize_tts_result(
                 provider="xai",
                 model=self._model,

--- a/runner/src/coval_bench/runner/orchestrator.py
+++ b/runner/src/coval_bench/runner/orchestrator.py
@@ -61,7 +61,7 @@ from coval_bench.runner.retry import with_retry
 if TYPE_CHECKING:
     from coval_bench.config import Settings
 
-_log = structlog.get_logger("coval_bench.runner")
+logger = structlog.get_logger("coval_bench.runner")
 
 _CONCURRENCY_CAP = 8
 _STT_TIMEOUT_S = 45
@@ -222,7 +222,7 @@ async def _run_stt_item(
     async with sem:
         provider_cls = stt_providers.get(entry.provider)
         if provider_cls is None:
-            _log.warning(
+            logger.warning(
                 "unknown_stt_provider",
                 provider=entry.provider,
                 model=entry.model,
@@ -266,7 +266,7 @@ async def _run_stt_item(
                 )
         except Exception as exc:
             item_error = _truncate(str(exc))
-            _log.warning(
+            logger.warning(
                 "stt_provider_call_failed",
                 provider=entry.provider,
                 model=entry.model,
@@ -338,6 +338,12 @@ async def _run_stt_item(
                 ttfs_value = compute_ttfs(audio_to_final, speech_end_offset_ms / 1000.0)
             except Exception as exc:
                 ttfs_calc_error = str(exc)
+                logger.warning(
+                    "ttfs_computation_failed",
+                    provider=entry.provider,
+                    model=entry.model,
+                    exc_info=exc,
+                )
         ttfs_status, ttfs_error = _metric_outcome(
             ttfs_value, item_error or ttfs_calc_error, Metric.TTFS, ResultStatus
         )
@@ -366,8 +372,15 @@ async def _run_stt_item(
         # null-valued success rather than a failure, matching the original intent.
         rtf_value: float | None = None
         if audio_to_final is not None and duration_sec > 0:
-            with contextlib.suppress(Exception):
+            try:
                 rtf_value = compute_rtf(audio_to_final, duration_sec)
+            except Exception as exc:
+                logger.warning(
+                    "rtf_computation_failed",
+                    provider=entry.provider,
+                    model=entry.model,
+                    exc_info=exc,
+                )
 
         rtf_status, rtf_error = _metric_outcome(
             audio_to_final, item_error, Metric.RTF, ResultStatus
@@ -412,7 +425,7 @@ async def _run_stt_item(
                 # compute_wer is deterministic over a transcript we already obtained, so a
                 # crash here is a genuine failure — surface it as a FAILED row rather than
                 # silently dropping it and leaving the run marked SUCCEEDED.
-                _log.warning(
+                logger.warning(
                     "wer_computation_failed",
                     provider=entry.provider,
                     model=entry.model,
@@ -438,7 +451,7 @@ async def _run_stt_item(
         try:
             await writer.record_results(results)
         except Exception as exc:
-            _log.warning(
+            logger.warning(
                 "stt_result_persist_failed",
                 provider=entry.provider,
                 model=entry.model,
@@ -480,7 +493,7 @@ async def _run_tts_item(
     async with sem:
         provider_cls = tts_providers.get(entry.provider)
         if provider_cls is None:
-            _log.warning(
+            logger.warning(
                 "unknown_tts_provider",
                 provider=entry.provider,
                 model=entry.model,
@@ -500,7 +513,7 @@ async def _run_tts_item(
             audio_path = tts_result.audio_path
         except Exception as exc:
             item_error = _truncate(str(exc))
-            _log.warning(
+            logger.warning(
                 "tts_provider_call_failed",
                 provider=entry.provider,
                 model=entry.model,
@@ -566,7 +579,7 @@ async def _run_tts_item(
                 try:
                     whisper_transcript = await _transcribe_with_whisper(audio_path, settings)
                 except Exception as exc:
-                    _log.warning(
+                    logger.warning(
                         "tts_wer_transcription_failed",
                         provider=entry.provider,
                         model=entry.model,
@@ -595,7 +608,7 @@ async def _run_tts_item(
                             )
                         )
                     except Exception as exc:
-                        _log.warning(
+                        logger.warning(
                             "tts_wer_computation_failed",
                             provider=entry.provider,
                             model=entry.model,
@@ -623,7 +636,7 @@ async def _run_tts_item(
                 try:
                     audio_path.unlink()
                 except OSError as exc:
-                    _log.warning(
+                    logger.warning(
                         "tts_audio_file_delete_failed",
                         path=str(audio_path),
                         exc_info=exc,
@@ -633,7 +646,7 @@ async def _run_tts_item(
         try:
             await writer.record_results(results)
         except Exception as exc:
-            _log.warning(
+            logger.warning(
                 "tts_result_persist_failed",
                 provider=entry.provider,
                 model=entry.model,
@@ -658,7 +671,7 @@ def _emit_posthog(client: Posthog | None, event: str, properties: dict[str, Any]
         )
         client.flush()  # type: ignore[no-untyped-call]
     except Exception:
-        _log.warning("posthog_emit_failed", event_name=event, exc_info=True)
+        logger.warning("posthog_emit_failed", event_name=event, exc_info=True)
 
 
 # Transient-failure retry for the end-of-run bucket refresh.
@@ -678,9 +691,9 @@ async def _refresh_series_bucket(writer: Any, run_id: int, settings: Settings) -
             await writer.refresh_bucket(run_id, period_seconds=settings.schedule_period_seconds)
         except Exception:
             if attempt == _BUCKET_REFRESH_ATTEMPTS:
-                _log.warning("series_bucket_refresh_failed", exc_info=True)
+                logger.warning("series_bucket_refresh_failed", exc_info=True)
                 return
-            _log.info("series_bucket_refresh_retry", attempt=attempt)
+            logger.info("series_bucket_refresh_retry", attempt=attempt)
             await asyncio.sleep(_BUCKET_REFRESH_RETRY_DELAY_S)
         else:
             return
@@ -727,7 +740,7 @@ async def run_benchmarks(
             )
             atexit.register(posthog_client.shutdown)
         except Exception:
-            _log.warning("posthog_init_failed", exc_info=True)
+            logger.warning("posthog_init_failed", exc_info=True)
             posthog_client = None
 
     # ------------------------------------------------------------------
@@ -785,7 +798,7 @@ async def run_benchmarks(
 
         structlog.contextvars.bind_contextvars(run_id=run_id)
 
-        _log.info(
+        logger.info(
             "benchmark_run_started",
             benchmark_kind=benchmark_kind,
             smoke=smoke,
@@ -808,7 +821,7 @@ async def run_benchmarks(
             if sigterm_received:
                 return
             sigterm_received = True
-            _log.warning("sigterm_received")
+            logger.warning("sigterm_received")
             if main_task is not None:
                 main_task.cancel()
 
@@ -844,7 +857,7 @@ async def run_benchmarks(
                 )
                 for cls, res in zip(ordered_classes, warmup_results, strict=False):
                     if isinstance(res, BaseException):
-                        _log.warning(
+                        logger.warning(
                             "provider_warmup_failed",
                             provider=cls.__name__,
                             exc_info=res,
@@ -860,8 +873,9 @@ async def run_benchmarks(
                     sample_size=None if smoke else settings.dataset_sample_size,
                 )
                 items = stt_dataset.items[:1] if smoke else stt_dataset.items
-                _log.info("stt_dataset_sampled", item_count=len(items))
+                logger.info("stt_dataset_sampled", item_count=len(items))
 
+                stt_pairs = [(entry, item) for item in items for entry in enabled_stt]
                 stt_tasks = [
                     _run_stt_item(
                         entry=entry,
@@ -871,14 +885,18 @@ async def run_benchmarks(
                         settings=settings,
                         writer=writer,
                     )
-                    for item in items
-                    for entry in enabled_stt
+                    for entry, item in stt_pairs
                 ]
 
                 stt_batch = await asyncio.gather(*stt_tasks, return_exceptions=True)
-                for batch_result in stt_batch:
+                for (entry, _item), batch_result in zip(stt_pairs, stt_batch, strict=True):
                     if isinstance(batch_result, BaseException):
-                        _log.warning("stt_task_raised", exc_info=batch_result)
+                        logger.warning(
+                            "stt_task_raised",
+                            provider=entry.provider,
+                            model=entry.model,
+                            exc_info=batch_result,
+                        )
                     else:
                         all_results.extend(batch_result)
 
@@ -892,8 +910,9 @@ async def run_benchmarks(
                     sample_size=None if smoke else settings.dataset_sample_size,
                 )
                 tts_items = tts_dataset.items[:1] if smoke else tts_dataset.items
-                _log.info("tts_dataset_sampled", item_count=len(tts_items))
+                logger.info("tts_dataset_sampled", item_count=len(tts_items))
 
+                tts_pairs = [(entry, item) for item in tts_items for entry in enabled_tts]
                 tts_tasks = [
                     _run_tts_item(
                         entry=entry,
@@ -903,14 +922,18 @@ async def run_benchmarks(
                         settings=settings,
                         writer=writer,
                     )
-                    for item in tts_items
-                    for entry in enabled_tts
+                    for entry, item in tts_pairs
                 ]
 
                 tts_batch = await asyncio.gather(*tts_tasks, return_exceptions=True)
-                for batch_result in tts_batch:
+                for (entry, _item), batch_result in zip(tts_pairs, tts_batch, strict=True):
                     if isinstance(batch_result, BaseException):
-                        _log.warning("tts_task_raised", exc_info=batch_result)
+                        logger.warning(
+                            "tts_task_raised",
+                            provider=entry.provider,
+                            model=entry.model,
+                            exc_info=batch_result,
+                        )
                     else:
                         all_results.extend(batch_result)
 
@@ -941,7 +964,7 @@ async def run_benchmarks(
             try:
                 await writer.refresh_stats_matviews()
             except Exception as refresh_exc:
-                _log.error(
+                logger.error(
                     "stats_matviews_refresh_failed",
                     exc_info=refresh_exc,
                 )
@@ -961,7 +984,7 @@ async def run_benchmarks(
             )
 
             duration_s = (finished_at - started_at).total_seconds()
-            _log.info(
+            logger.info(
                 "benchmark_run_finished",
                 status=str(final_status),
                 total_results=total_results,
@@ -1006,7 +1029,7 @@ async def run_benchmarks(
                     )
                 )
             except Exception as write_exc:
-                _log.error(
+                logger.error(
                     "run_row_update_failed_after_sigterm",
                     exc_info=write_exc,
                 )
@@ -1015,7 +1038,7 @@ async def run_benchmarks(
                 await asyncio.shield(_refresh_series_bucket(writer, run_id, settings))
             finished_at = datetime.now(tz=UTC)
             sigterm_duration_s = (finished_at - started_at).total_seconds()
-            _log.warning(
+            logger.warning(
                 "benchmark_run_finished_early_sigterm",
                 status=str(RunStatus.PARTIAL),
                 total_results=total_results,
@@ -1055,7 +1078,7 @@ async def run_benchmarks(
             # The literal event="RUN_FAILED" in this log line triggers the
             # Cloud Logging log-based metric (see ARCHITECTURE.md § Logging + Alerting).
             # structlog uses the first positional arg as the ``event`` key.
-            _log.error(
+            logger.error(
                 "RUN_FAILED",
                 error=err_msg,
                 exc_info=exc,
@@ -1063,7 +1086,7 @@ async def run_benchmarks(
             try:
                 await writer.finish_run(run_id, status=RunStatus.FAILED, error=err_msg)
             except Exception as write_exc:
-                _log.error(
+                logger.error(
                     "run_row_update_failed_after_failure",
                     exc_info=write_exc,
                 )

--- a/runner/src/coval_bench/runner/retry.py
+++ b/runner/src/coval_bench/runner/retry.py
@@ -22,7 +22,7 @@ from collections.abc import Awaitable, Callable
 
 import structlog
 
-_log = structlog.get_logger("coval_bench.runner")
+logger = structlog.get_logger("coval_bench.runner")
 
 _DEFAULT_RETRY_ON: tuple[type[BaseException], ...] = (
     TimeoutError,  # asyncio.TimeoutError is an alias for builtin TimeoutError (Python 3.11+)
@@ -64,7 +64,7 @@ async def with_retry[T](
         except retry_on as exc:
             last_exc = exc
             if attempt + 1 >= max_attempts:
-                _log.error(
+                logger.error(
                     "retry_exhausted",
                     attempt=attempt + 1,
                     max_attempts=max_attempts,
@@ -74,7 +74,7 @@ async def with_retry[T](
             cap = min(base_delay_s * (2**attempt), max_delay_s)
             # Full jitter — non-cryptographic, used only for backoff scheduling
             delay = random.uniform(0, cap)  # noqa: S311
-            _log.warning(
+            logger.warning(
                 "provider_call_retry",
                 attempt=attempt + 1,
                 max_attempts=max_attempts,


### PR DESCRIPTION
- Failures upgraded from debug to warning.
- All metrics log a warning on failure.
- Some code-cosmetic changes to make everything easier to read/navigate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling across speech-to-text and text-to-speech benchmarks, reducing missed failures during streaming and request processing.
  * Made benchmark results more reliable when concurrent tasks fail, especially for partial or timed-out runs.
  * Enhanced failure reporting with clearer contextual logs, helping surface provider/model-specific issues.
  * Tightened run-time handling for orchestration and retry flows so failures are captured more consistently without changing successful behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves observability across all STT and TTS providers by promoting silent failures to logged warnings and adding `provider`/`model` context to every error log. It also fixes a class of silent result corruption where exceptions raised inside `asyncio.gather` sub-tasks were never surfaced as `result.error`.

- **Logging upgrades**: All `logger.debug`/`logger.exception` calls at error sites are promoted to `logger.warning` with structured `provider`, `model`, and `exc_info` fields, making provider-specific failures visible in production logs without changing the control flow.
- **Async task error propagation**: Eight STT providers replace a bare `asyncio.gather(return_exceptions=True)` with a `asyncio.wait(FIRST_EXCEPTION)` → cancel pending → `gather` pattern; `_receive` methods now also set `result.error` directly so a sub-task exception that was previously silently swallowed is recorded in the result row.
- **Orchestrator improvements**: `stt_pairs`/`tts_pairs` intermediate lists let batch-failure warnings carry `provider` and `model`; `contextlib.suppress` on RTF computation is replaced with a logged `try/except`; `strict=True` on `zip` acts as an assertion that task count matches pair count.

<h3>Confidence Score: 5/5</h3>

Safe to merge — changes are logging-level promotions, cosmetic renames, and bug fixes for silent error swallowing, with no behavior changes on the success path.

Every success path is unchanged. The new async pattern (wait → cancel → gather) correctly handles both the normal-completion and first-exception cases and has no race conditions. Error-path changes only add log output and populate previously-null result.error fields, which prevents phantom null-valued result rows in the benchmark output.

No files require special attention. The inworld.py credential-scrubbing refactor is correct (auth_param is always in scope), and the orchestrator pairs/zip(strict=True) refactor preserves task ordering.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| runner/src/coval_bench/runner/orchestrator.py | Renames _log→logger, introduces stt_pairs/tts_pairs to carry provider/model context into batch-failure logs, adds explicit warnings for ttfs/rtf computation failures, and converts a contextlib.suppress to a logged try/except for RTF. All logic is preserved; strict=True on zip is a correct correctness guarantee. |
| runner/src/coval_bench/providers/stt/assemblyai.py | Replaces bare asyncio.gather with wait+cancel+gather pattern for early task cancellation on failure; adds result.error capture in _receive; upgrades exception→warning logging with provider/model context. Net improvement in error visibility. |
| runner/src/coval_bench/providers/stt/cartesia.py | Adopts the same wait+cancel+gather pattern; tightens the receive-error guard to also check audio_to_final_seconds; downgrades exception→warning logging. Prior review thread noted BaseException→Exception regression in outcome check. |
| runner/src/coval_bench/providers/tts/inworld.py | Extracts auth-param scrubbing into a shared scrubbed variable used for both the warning and the result.error field; correctly omits exc_info to prevent the URL from leaking through the traceback. auth_param is always in scope (assigned before the try block). |
| runner/src/coval_bench/runner/retry.py | Variable rename _log→logger only; logging levels and arguments are unchanged. |
| runner/src/coval_bench/providers/_http_session.py | Renames _log→logger; promotes http_client_close_failed from debug to warning so teardown errors are surfaced. |
| runner/src/coval_bench/providers/stt/deepgram.py | Adds wait+cancel+gather pattern and result.error assignment in _receive (previously deepgram _receive exceptions were logged but never surfaced as result.error, causing silent failures to appear clean). |
| runner/src/coval_bench/providers/stt/elevenlabs.py | Same wait+cancel+gather pattern; adds result.error capture in _receive; downgrades logger.error→warning for API-level error messages and exception handlers. |
| runner/src/coval_bench/api/request_logging.py | Renames _log→logger; reformats the conditional log-level selection as a multi-line ternary for readability. No logic changes. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant O as orchestrator
    participant P as STT Provider (_measure_ttft)
    participant S as send_task
    participant R as recv_task

    O->>P: await _run_stt_item()
    P->>S: asyncio.create_task(_send_audio)
    P->>R: asyncio.create_task(_receive)
    P->>P: asyncio.wait(FIRST_EXCEPTION)

    alt No exception — both complete normally
        S-->>P: done (no exc)
        R-->>P: done (no exc)
        P->>P: gather() → outcomes [None, None]
        P->>O: result (audio_to_final_seconds set)
    else send_task raises
        S-->>P: done (exception)
        P->>R: task.cancel()
        P->>P: gather() → [exc, CancelledError]
        P->>P: "result.error = str(exc)"
        P->>P: "logger.warning(..., exc_info=exc)"
        P->>O: result (error set)
    else recv_task raises
        R-->>P: done (exception)
        P->>P: "result.error = str(exc) in _receive except"
        P->>S: task.cancel()
        P->>P: gather() → [CancelledError, exc]
        P->>P: outer check skipped (result.error already set)
        P->>O: result (error set)
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant O as orchestrator
    participant P as STT Provider (_measure_ttft)
    participant S as send_task
    participant R as recv_task

    O->>P: await _run_stt_item()
    P->>S: asyncio.create_task(_send_audio)
    P->>R: asyncio.create_task(_receive)
    P->>P: asyncio.wait(FIRST_EXCEPTION)

    alt No exception — both complete normally
        S-->>P: done (no exc)
        R-->>P: done (no exc)
        P->>P: gather() → outcomes [None, None]
        P->>O: result (audio_to_final_seconds set)
    else send_task raises
        S-->>P: done (exception)
        P->>R: task.cancel()
        P->>P: gather() → [exc, CancelledError]
        P->>P: "result.error = str(exc)"
        P->>P: "logger.warning(..., exc_info=exc)"
        P->>O: result (error set)
    else recv_task raises
        R-->>P: done (exception)
        P->>P: "result.error = str(exc) in _receive except"
        P->>S: task.cancel()
        P->>P: gather() → [CancelledError, exc]
        P->>P: outer check skipped (result.error already set)
        P->>O: result (error set)
    end
```

</a>

<sub>Reviews (2): Last reviewed commit: ["Websocket fail fast addition"](https://github.com/coval-ai/benchmarks/commit/e0f4c3bbd7873c17552c1978a96ced06bba576fa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39916077)</sub>

<!-- /greptile_comment -->