### PR TITLE
Add assemblyai u3-rt-pro stt

### DIFF
--- a/runner/src/coval_bench/providers/stt/assemblyai.py
+++ b/runner/src/coval_bench/providers/stt/assemblyai.py
@@ -3,7 +3,7 @@
 
 """AssemblyAI real-time STT provider (v3 streaming API).
 
-Model: universal-streaming
+Models: universal-streaming, u3-rt-pro
 Wire protocol: WebSocket, wss://streaming.assemblyai.com/v3/ws
 Auth: Authorization: <key>
 Close: {"type": "Terminate"}
@@ -25,11 +25,11 @@ from coval_bench.providers.base import STTProvider, TranscriptionResult
 
 logger = structlog.get_logger(__name__)
 
-# Maps user-facing model names to the speech_model value required by the API.
-# format_turns is omitted (default=false) — the formatting pass adds latency that
-# would inflate TTFT measurements.
+# Maps user-facing model names to the API speech_model. Pinned explicitly so
+# universal-streaming can't silently fall back to the u3-rt-pro server default.
 _SPEECH_MODEL_MAP: dict[str, str] = {
     "universal-streaming": "universal-streaming-english",
+    "u3-rt-pro": "u3-rt-pro",
 }
 _WS_BASE = "wss://streaming.assemblyai.com/v3/ws"
 

--- a/runner/src/coval_bench/registries/models.py
+++ b/runner/src/coval_bench/registries/models.py
@@ -68,6 +68,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
     RegisteredModel(
         benchmark=_STT, provider="assemblyai", model="universal-streaming", status=_ACTIVE
     ),
+    RegisteredModel(benchmark=_STT, provider="assemblyai", model="u3-rt-pro", status=_ACTIVE),
     RegisteredModel(benchmark=_STT, provider="speechmatics", model="default", status=_ACTIVE),
     RegisteredModel(benchmark=_STT, provider="speechmatics", model="enhanced", status=_ACTIVE),
     RegisteredModel(benchmark=_STT, provider="gradium", model="default", status=_ACTIVE),

--- a/runner/tests/providers/stt/test_assemblyai.py
+++ b/runner/tests/providers/stt/test_assemblyai.py
@@ -76,6 +76,41 @@ def test_websocket_url_contains_required_params() -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("model", "expected_speech_model"),
+    [
+        # u3-rt-pro is the server default; keep universal-streaming pinned to English.
+        ("universal-streaming", "universal-streaming-english"),
+        ("u3-rt-pro", "u3-rt-pro"),
+    ],
+)
+async def test_url_pins_speech_model(
+    fake_api_key: SecretStr, model: str, expected_speech_model: str
+) -> None:
+    provider = AssemblyAIProvider(api_key=fake_api_key, model=model)
+
+    with patch(
+        "coval_bench.providers.stt.assemblyai.ws_client.connect",
+        return_value=_fake_connect([]),
+    ) as mock_connect:
+        await provider.measure_ttft(
+            audio_data=b"\x00" * 640,
+            channels=1,
+            sample_width=2,
+            sample_rate=16000,
+            realtime_resolution=0.5,
+        )
+
+    url = mock_connect.call_args.args[0]
+    assert f"speech_model={expected_speech_model}" in url
+
+
+def test_provider_name_u3_rt_pro() -> None:
+    provider = AssemblyAIProvider(api_key=SecretStr("k"), model="u3-rt-pro")
+    assert provider.name == "assemblyai-u3-rt-pro"
+
+
+@pytest.mark.asyncio
 async def test_force_endpoint_sent_before_terminate(
     fake_api_key: SecretStr, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/web/lib/config/colors.ts
+++ b/web/lib/config/colors.ts
@@ -46,6 +46,7 @@ export const modelColors: Record<string, string> = {
 
   // AssemblyAI — amethyst family (#8E44AD).
   "universal-streaming": "#8E44AD",
+  "u3-rt-pro": "#6C3483",
 
   // Speechmatics — navy family (#21618C).
   enhanced: "#2E86C1",

--- a/web/lib/utils/formatters.ts
+++ b/web/lib/utils/formatters.ts
@@ -120,6 +120,7 @@ export function normalizeModelName(modelKey: string): string {
     "gpt-4o-transcribe": "GPT-4o Transcribe",
     "gpt-4o-mini-transcribe": "GPT-4o mini Transcribe",
     "universal-streaming": "Universal Streaming",
+    "u3-rt-pro": "Universal-3 Pro",
     "ink-2": "Ink 2",
     default: "Default",
     enhanced: "Enhanced"


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the `u3-rt-pro` AssemblyAI streaming model.
  * Updated model display names and color mapping so the new model appears consistently in the UI.
  
* **Bug Fixes**
  * Improved streaming connection behavior to use the correct model-specific settings for supported AssemblyAI models.
  
* **Tests**
  * Added coverage for model selection and connection URL handling for the new model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR wires up AssemblyAI's `u3-rt-pro` model end-to-end: it extends the Python provider's speech-model map, registers the model, and adds the matching frontend colour and display label.

- **Provider (`assemblyai.py`)**: adds `"u3-rt-pro" → "u3-rt-pro"` to `_SPEECH_MODEL_MAP` and updates the module docstring; the comment now explains that the map also prevents `universal-streaming` from silently falling back to the new server default.
- **Registry (`models.py`)**: registers `assemblyai/u3-rt-pro` as `_ACTIVE`, in line with the existing `universal-streaming` entry.
- **Tests**: adds a parametrized `test_url_pins_speech_model` covering both AssemblyAI models and a `test_provider_name_u3_rt_pro` name check.
- **Frontend**: `colors.ts` gets a darker amethyst shade (`#6C3483`) and `formatters.ts` maps the slug to "Universal-3 Pro".

<h3>Confidence Score: 4/5</h3>

Safe to merge — all changes are additive and the new model follows the exact same connection and message-handling path as the existing one.

The implementation is minimal and consistent with the existing universal-streaming model. The only imperfection is the new parametrized test omitting the _FINAL_WAIT_S monkeypatch, which makes the test suite noticeably slower but does not affect correctness.

runner/tests/providers/stt/test_assemblyai.py — the new test_url_pins_speech_model test would benefit from a _FINAL_WAIT_S monkeypatch to avoid a ~11s slowdown.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| runner/src/coval_bench/providers/stt/assemblyai.py | Adds "u3-rt-pro" → "u3-rt-pro" to _SPEECH_MODEL_MAP; updates module docstring. No behavioral changes to shared connection, send, or receive logic. |
| runner/src/coval_bench/registries/models.py | Adds one RegisteredModel entry for assemblyai/u3-rt-pro with _ACTIVE status, consistent with the existing universal-streaming entry. |
| runner/tests/providers/stt/test_assemblyai.py | Adds test_url_pins_speech_model (parametrized over both models) and test_provider_name_u3_rt_pro. The new parametrized test omits the _FINAL_WAIT_S monkeypatch used elsewhere, causing a ~11s slowdown on empty-stream cases. |
| web/lib/config/colors.ts | Adds "u3-rt-pro": "#6C3483" in the AssemblyAI amethyst block — darker shade of the existing universal-streaming colour, visually consistent. |
| web/lib/utils/formatters.ts | Adds "u3-rt-pro": "Universal-3 Pro" to normalizeModelName. Clean, no side-effects. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Bench as Benchmark Runner
    participant Prov as AssemblyAIProvider
    participant WS as AssemblyAI WSS v3

    Bench->>Prov: "measure_ttft(audio, model="u3-rt-pro")"
    Prov->>Prov: lookup _SPEECH_MODEL_MAP["u3-rt-pro"] → "u3-rt-pro"
    Prov->>WS: "connect(wss://...?speech_model=u3-rt-pro&end_of_turn_confidence_threshold=1.0)"
    WS-->>Prov: "{"type":"Begin"}"
    loop stream audio chunks
        Prov->>WS: send(PCM bytes)
        WS-->>Prov: "{"type":"Turn", "end_of_turn":false, "transcript":"..."}"
        Note right of Prov: TTFT recorded on first Turn
    end
    Prov->>WS: "send({"type":"ForceEndpoint"})"
    WS-->>Prov: "{"type":"Turn", "end_of_turn":true, "transcript":"..."}"
    Note right of Prov: audio_to_final recorded
    Prov->>WS: "send({"type":"Terminate"})"
    WS-->>Prov: "{"type":"Termination"}"
    Prov-->>Bench: TranscriptionResult(ttft_seconds, complete_transcript)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Bench as Benchmark Runner
    participant Prov as AssemblyAIProvider
    participant WS as AssemblyAI WSS v3

    Bench->>Prov: "measure_ttft(audio, model="u3-rt-pro")"
    Prov->>Prov: lookup _SPEECH_MODEL_MAP["u3-rt-pro"] → "u3-rt-pro"
    Prov->>WS: "connect(wss://...?speech_model=u3-rt-pro&end_of_turn_confidence_threshold=1.0)"
    WS-->>Prov: "{"type":"Begin"}"
    loop stream audio chunks
        Prov->>WS: send(PCM bytes)
        WS-->>Prov: "{"type":"Turn", "end_of_turn":false, "transcript":"..."}"
        Note right of Prov: TTFT recorded on first Turn
    end
    Prov->>WS: "send({"type":"ForceEndpoint"})"
    WS-->>Prov: "{"type":"Turn", "end_of_turn":true, "transcript":"..."}"
    Note right of Prov: audio_to_final recorded
    Prov->>WS: "send({"type":"Terminate"})"
    WS-->>Prov: "{"type":"Termination"}"
    Prov-->>Bench: TranscriptionResult(ttft_seconds, complete_transcript)
```

</a>

<sub>Reviews (1): Last reviewed commit: ["Add assemblyai u3-rt-pro stt"](https://github.com/coval-ai/benchmarks/commit/dd6fee8a2d3309bcc0316d276119c64a126d0765) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39940652)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->