### PR TITLE
Debug-log successful metric calculations

### DIFF
--- a/runner/src/coval_bench/runner/orchestrator.py
+++ b/runner/src/coval_bench/runner/orchestrator.py
@@ -306,6 +306,13 @@ async def _run_stt_item(
                     error=ttft_error,
                 )
             )
+            if ttft_status is ResultStatus.SUCCESS:
+                logger.debug(
+                    "stt_ttft",
+                    provider=entry.provider,
+                    model=entry.model,
+                    ttft_seconds=ttft_seconds,
+                )
 
         # 2. AudioToFinal
         atf_status, atf_error = _metric_outcome(
@@ -326,6 +333,13 @@ async def _run_stt_item(
                 error=atf_error,
             )
         )
+        if atf_status is ResultStatus.SUCCESS:
+            logger.debug(
+                "stt_audio_to_final",
+                provider=entry.provider,
+                model=entry.model,
+                audio_to_final_seconds=audio_to_final,
+            )
 
         # 2b. TTFS — time-to-final from VAD end-of-speech (primary headline metric). Status
         # tracks ttfs_value (not audio_to_final): a missing offset or a failed calculation
@@ -366,6 +380,13 @@ async def _run_stt_item(
                     error=ttfs_error,
                 )
             )
+            if ttfs_status is ResultStatus.SUCCESS:
+                logger.debug(
+                    "stt_ttfs",
+                    provider=entry.provider,
+                    model=entry.model,
+                    ttfs_seconds=ttfs_value,
+                )
 
         # 3. RTF — derived from AudioToFinal, so its outcome tracks whether a final was
         # produced. A present final with an uncomputable RTF (e.g. zero duration) stays a
@@ -400,6 +421,13 @@ async def _run_stt_item(
                 error=rtf_error,
             )
         )
+        if rtf_status is ResultStatus.SUCCESS and rtf_value is not None:
+            logger.debug(
+                "stt_rtf",
+                provider=entry.provider,
+                model=entry.model,
+                rtf=rtf_value,
+            )
 
         # 4. WER (when ground-truth available; skip when the stream errored so we don't
         # score a transcript salvaged from a failed run)
@@ -420,6 +448,12 @@ async def _run_stt_item(
                         status=ResultStatus.SUCCESS,
                         error=None,
                     )
+                )
+                logger.debug(
+                    "stt_wer",
+                    provider=entry.provider,
+                    model=entry.model,
+                    wer_percentage=wer_result.wer_percentage,
                 )
             except Exception as exc:
                 # compute_wer is deterministic over a transcript we already obtained, so a
@@ -606,6 +640,12 @@ async def _run_tts_item(
                                 status=ResultStatus.SUCCESS,
                                 error=None,
                             )
+                        )
+                        logger.debug(
+                            "tts_wer",
+                            provider=entry.provider,
+                            model=entry.model,
+                            wer_percentage=wer_result.wer_percentage,
                         )
                     except Exception as exc:
                         logger.warning(


### PR DESCRIPTION
Only TTFA emitted a debug line on success (the `tts_ttfa` line in the TTS provider's finalize step); every other metric was silent on the success path even though they all warn on failure. This makes the success path symmetric: each metric now emits a debug line reporting its value when recorded, parallel to `tts_ttfa`.

New debug events, each with `provider`, `model`, and the value in its stored units:

| Metric | Event | Value field |
|---|---|---|
| STT TTFT | `stt_ttft` | `ttft_seconds` |
| STT AudioToFinal | `stt_audio_to_final` | `audio_to_final_seconds` |
| STT TTFS | `stt_ttfs` | `ttfs_seconds` |
| STT RTF | `stt_rtf` | `rtf` |
| STT WER | `stt_wer` | `wer_percentage` |
| TTS WER | `tts_wer` | `wer_percentage` |

TTFA is unchanged.

**Open question (settled):** the debug fires only when a value is actually recorded as SUCCESS, not on every computation attempt. This keeps the logs symmetric and clean — success gets one debug line, failure keeps its existing warning, with no overlap and no debug line announcing a value later discarded for transport contamination. RTF additionally requires a non-null value, since it can be a null-valued SUCCESS (final present but ratio uncomputable).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added more detailed debug logging for successful speech benchmark measurements, including key metric values and provider/model context.
  * Improved visibility into successful text-to-speech evaluation results in logs, helping with troubleshooting and analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes the success-path logging symmetric: every metric that emits a `logger.warning` on failure now also emits a `logger.debug` on success. Six new debug events are added to `orchestrator.py`, each fired only after the corresponding `Result` is appended with `ResultStatus.SUCCESS`.

- **STT metrics (TTFT, AudioToFinal, TTFS, RTF, WER):** debug logs are correctly placed after `results.append()`, inside their existing exclusion guards where applicable; the RTF log adds an extra `rtf_value is not None` guard to handle the null-valued SUCCESS case documented in the code.
- **TTS WER:** debug log follows the same try-block pattern as STT WER, firing only when `compute_wer` succeeds; it omits `voice`, which is a key TTS dimension included on the `Result` object and worth adding for log completeness (see comment).

<h3>Confidence Score: 4/5</h3>

Safe to merge — the changes are additive debug logs only, with no logic, data, or control-flow modifications.

All six debug calls are correctly positioned after results.append() and gated on SUCCESS, so they add no side effects to the existing metric-recording logic. The only gap is tts_wer omitting voice, which would make voice-level TTS WER regressions harder to trace in structured logs but has no runtime impact.

No files require special attention; the single changed file is straightforward and low-risk.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| runner/src/coval_bench/runner/orchestrator.py | Adds 6 new structured debug log lines on the success path for STT and TTS metrics (TTFT, AudioToFinal, TTFS, RTF, STT WER, TTS WER). Each log is correctly gated after results.append() and on SUCCESS status; the RTF log has an additional null guard for the null-valued SUCCESS case. The tts_wer log omits voice, which is a key TTS discriminator, though this is consistent with the pre-existing tts_ttfa pattern. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Metric Computed] --> B{Status == SUCCESS?}
    B -- No --> W[Existing warning log]
    B -- Yes --> C{Metric type?}

    C --> D[TTFT / TTFS\n+ excluded check]
    C --> E[AudioToFinal / RTF]
    C --> F[STT WER]
    C --> G[TTS WER]

    D --> D1{not excluded?}
    D1 -- No --> Skip[No result / no debug]
    D1 -- Yes --> D2[results.append]
    D2 --> D3[logger.debug stt_ttft / stt_ttfs]

    E --> E1[results.append]
    E1 --> E2{RTF? Also check\nrtf_value != None}
    E2 -- Yes --> E3[logger.debug stt_audio_to_final\nor stt_rtf]
    E2 -- No --> Skip2[No debug for null RTF]

    F --> F1[compute_wer\ntry block]
    F1 -- exception --> F2[warning + FAILED row]
    F1 -- success --> F3[results.append SUCCESS]
    F3 --> F4[logger.debug stt_wer]

    G --> G1[compute_wer\ntry block]
    G1 -- exception --> G2[warning + FAILED row]
    G1 -- success --> G3[results.append SUCCESS]
    G3 --> G4[logger.debug tts_wer]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Metric Computed] --> B{Status == SUCCESS?}
    B -- No --> W[Existing warning log]
    B -- Yes --> C{Metric type?}

    C --> D[TTFT / TTFS\n+ excluded check]
    C --> E[AudioToFinal / RTF]
    C --> F[STT WER]
    C --> G[TTS WER]

    D --> D1{not excluded?}
    D1 -- No --> Skip[No result / no debug]
    D1 -- Yes --> D2[results.append]
    D2 --> D3[logger.debug stt_ttft / stt_ttfs]

    E --> E1[results.append]
    E1 --> E2{RTF? Also check\nrtf_value != None}
    E2 -- Yes --> E3[logger.debug stt_audio_to_final\nor stt_rtf]
    E2 -- No --> Skip2[No debug for null RTF]

    F --> F1[compute_wer\ntry block]
    F1 -- exception --> F2[warning + FAILED row]
    F1 -- success --> F3[results.append SUCCESS]
    F3 --> F4[logger.debug stt_wer]

    G --> G1[compute_wer\ntry block]
    G1 -- exception --> G2[warning + FAILED row]
    G1 -- success --> G3[results.append SUCCESS]
    G3 --> G4[logger.debug tts_wer]
```

</a>

<sub>Reviews (1): Last reviewed commit: ["Debug-log successful metric calculations"](https://github.com/coval-ai/benchmarks/commit/3601958e7164ea65611eb7a61925ec8f5d5d0ce5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39947787)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->