### PR TITLE
Log successful requests at debug instead of info

### DIFF
--- a/runner/src/coval_bench/api/request_logging.py
+++ b/runner/src/coval_bench/api/request_logging.py
@@ -81,7 +81,7 @@ class RequestLoggingMiddleware:
                     if status >= 500
                     else logger.warning
                     if status >= 400
-                    else logger.info
+                    else logger.debug
                 )
                 emit(
                     "http_request",


### PR DESCRIPTION
Routine sub-400 access lines now surface only when debugging; 4xx and 5xx still log at warning and error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reduced logging noise for successful requests by lowering non-error request logs from info to debug.
  * Error and warning logs for failed requests remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR reduces log verbosity for successful HTTP requests by changing the emit level for sub-400 responses from `info` to `debug` in the ASGI request-logging middleware; 4xx and 5xx responses continue to log at `warning` and `error` respectively.

- The single-line change is in the ternary `emit` selector inside `RequestLoggingMiddleware.__call__`; all other branches (exception path, warning, error) are untouched.
- The existing `quiet_paths` suppression for `/healthz` and `/readyz` still works as intended: those endpoints are completely silenced even when debug logging is enabled, preventing health-check noise at any log level.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is narrowly scoped and does not touch any logic that affects request handling, error propagation, or status-code routing.

The only line changed is the fallback branch of the emit ternary, moving successful access logs from info to debug. The 4xx warning path and 5xx error path are identical to before, the exception handler still logs at error with a traceback, and quiet_paths suppression is unaffected. There is no behavioural change in request processing itself.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| runner/src/coval_bench/api/request_logging.py | Single-line change: downgrade successful (sub-400) access log from `info` to `debug`; error/warning paths unchanged; `quiet_paths` suppression still works correctly for health-check endpoints. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Incoming HTTP Request] --> B{scope type == http?}
    B -- No --> C[Pass-through to app]
    B -- Yes --> D[Bind request_id to contextvars]
    D --> E[Dispatch to inner app]
    E --> F{Exception raised?}
    F -- Yes --> G[logger.error with exc_info=True]
    G --> H[Re-raise exception]
    F -- No --> I{quiet path AND status < 400?}
    I -- Yes --> J[Suppress log entirely]
    I -- No --> K{status >= 500?}
    K -- Yes --> L[logger.error]
    K -- No --> M{status >= 400?}
    M -- Yes --> N[logger.warning]
    M -- No --> O["logger.debug (was logger.info)"]
    L --> P[Clear contextvars]
    N --> P
    O --> P
    J --> P
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Incoming HTTP Request] --> B{scope type == http?}
    B -- No --> C[Pass-through to app]
    B -- Yes --> D[Bind request_id to contextvars]
    D --> E[Dispatch to inner app]
    E --> F{Exception raised?}
    F -- Yes --> G[logger.error with exc_info=True]
    G --> H[Re-raise exception]
    F -- No --> I{quiet path AND status < 400?}
    I -- Yes --> J[Suppress log entirely]
    I -- No --> K{status >= 500?}
    K -- Yes --> L[logger.error]
    K -- No --> M{status >= 400?}
    M -- Yes --> N[logger.warning]
    M -- No --> O["logger.debug (was logger.info)"]
    L --> P[Clear contextvars]
    N --> P
    O --> P
    J --> P
```

</a>

<sub>Reviews (1): Last reviewed commit: ["Log successful requests at debug instead..."](https://github.com/coval-ai/benchmarks/commit/4a1858a355cde35a16af69f87b2fcf7cf0243247) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39953062)</sub>

<!-- /greptile_comment -->