### PR TITLE
Add GCS backend for arena audio clips

### DIFF
--- a/runner/src/coval_bench/api/app.py
+++ b/runner/src/coval_bench/api/app.py
@@ -128,8 +128,8 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     app.include_router(arena.router, prefix="/v1")
 
     # Serve locally-generated arena clips when no external audio host is set
-    # (prod points arena_audio_base_url at the GCS/CDN origin instead).
-    if not resolved.arena_audio_base_url:
+    # (prod sets arena_gcs_bucket for GCS, or arena_audio_base_url for a CDN origin).
+    if not resolved.arena_audio_base_url and not resolved.arena_gcs_bucket:
         clips_dir = resolved.arena_audio_dir / "clips"
         clips_dir.mkdir(parents=True, exist_ok=True)
         app.mount("/clips", StaticFiles(directory=clips_dir), name="clips")

--- a/runner/src/coval_bench/arena/audio_store.py
+++ b/runner/src/coval_bench/arena/audio_store.py
@@ -3,32 +3,96 @@
 
 """Storage for generated arena clips: move a synthesized WAV into durable storage.
 
-Local-dir backend for dev; a GCS backend reimplements just ``store_clip`` later
-(generate key -> upload -> return URL) without touching callers. Keys are random
-and opaque so a served URL never reveals which model produced it (blind voting) —
-identity is recovered from ``arena.battles``, never the filename.
+Local-dir backend for dev; GCS backend for prod, selected by
+``settings.arena_gcs_bucket``. Keys are random and opaque so a served URL never
+reveals which model produced it (blind voting) — identity is recovered from
+``arena.battles``, never the filename.
 """
 
 from __future__ import annotations
 
 import shutil
 import uuid
+from datetime import timedelta
 from pathlib import Path
+from typing import TYPE_CHECKING, Any
 
 from coval_bench.config import Settings
 
+if TYPE_CHECKING:
+    from google.cloud import storage
 
-def store_clip(settings: Settings, src_path: Path) -> str:
-    """Move a synthesized WAV into arena storage under a fresh opaque key; return its URL.
+_SIGNED_URL_TTL = timedelta(days=1)
+
+
+def store_clip(
+    settings: Settings,
+    src_path: Path,
+    *,
+    storage_client: storage.Client | None = None,
+) -> str:
+    """Consume a synthesized WAV into arena storage under a fresh opaque key; return its URL.
 
     The source is a provider's temp WAV (``TTSResult.audio_path``); we own it once
-    synthesis returns, so it is moved, not copied. The URL prepends
-    ``arena_audio_base_url`` when set, else is root-relative for the web layer.
+    synthesis returns, so it is consumed — moved locally, or uploaded then deleted.
+    With ``arena_gcs_bucket`` set the clip goes to GCS and a time-limited V4 signed
+    URL is returned (the bucket is private); otherwise it is stored under
+    ``arena_audio_dir`` and a root-relative (or ``arena_audio_base_url``-prefixed) URL
+    is returned.
     """
     key = f"clips/{uuid.uuid4().hex}.wav"
+    if settings.arena_gcs_bucket:
+        return _store_clip_gcs(settings.arena_gcs_bucket, key, src_path, storage_client)
+
     dest = settings.arena_audio_dir / key
     dest.parent.mkdir(parents=True, exist_ok=True)
     shutil.move(str(src_path), dest)
 
     base = settings.arena_audio_base_url.rstrip("/")
     return f"{base}/{key}" if base else f"/{key}"
+
+
+def _store_clip_gcs(
+    bucket_name: str,
+    key: str,
+    src_path: Path,
+    client: storage.Client | None,
+) -> str:
+    if client is None:
+        from google.cloud import storage
+
+        client = storage.Client()
+    blob = client.bucket(bucket_name).blob(key)
+    blob.upload_from_filename(str(src_path), content_type="audio/wav")
+    url = _signed_url(blob)
+    src_path.unlink(missing_ok=True)
+    return url
+
+
+def _signed_url(blob: storage.Blob) -> str:
+    """V4 signed GET URL signed via the runtime SA's IAM SignBlob (no key file).
+
+    Cloud Run's default credentials carry no private key, so signing is delegated to
+    the IAM API using the SA's own token — this needs ``roles/iam.serviceAccounts.tokenCreator``
+    on the runtime SA.
+    """
+    import google.auth
+    import google.auth.transport.requests
+
+    credentials, _ = google.auth.default()
+    signer: Any = credentials
+    if not hasattr(signer, "service_account_email"):
+        raise RuntimeError(
+            "Signing arena clip URLs requires service-account credentials with a "
+            "tokenCreator grant; got credentials without a service account. Set "
+            "arena_gcs_bucket only where the runtime SA is configured."
+        )
+    signer.refresh(google.auth.transport.requests.Request())
+    url: str = blob.generate_signed_url(
+        version="v4",
+        expiration=_SIGNED_URL_TTL,
+        method="GET",
+        service_account_email=signer.service_account_email,
+        access_token=signer.token,
+    )
+    return url

--- a/runner/src/coval_bench/arena/generate.py
+++ b/runner/src/coval_bench/arena/generate.py
@@ -67,6 +67,15 @@ async def generate_battle(
         )
         return None
 
+    try:
+        audio_a_url, audio_b_url = await asyncio.gather(
+            asyncio.to_thread(store_clip, settings, path_a),
+            asyncio.to_thread(store_clip, settings, path_b),
+        )
+    except Exception:
+        path_a.unlink(missing_ok=True)
+        path_b.unlink(missing_ok=True)
+        raise
     battle = Battle(
         provider_a=model_a.provider,
         model_a=model_a.model,
@@ -74,8 +83,8 @@ async def generate_battle(
         model_b=model_b.model,
         domain=domain,
         prompt_text=prompt,
-        audio_a_url=store_clip(settings, path_a),
-        audio_b_url=store_clip(settings, path_b),
+        audio_a_url=audio_a_url,
+        audio_b_url=audio_b_url,
     )
     inserted = await store.insert_battle(battle)
     logger.info(

--- a/runner/src/coval_bench/config.py
+++ b/runner/src/coval_bench/config.py
@@ -109,6 +109,7 @@ class Settings(BaseSettings):
     arena_labeler_key: SecretStr | None = None
     arena_audio_dir: Path = Path("arena-audio")
     arena_audio_base_url: str = ""
+    arena_gcs_bucket: str = ""
     arena_daily_battle_cap: int = 500
 
 

--- a/runner/tests/unit/test_arena_audio_store.py
+++ b/runner/tests/unit/test_arena_audio_store.py
@@ -1,0 +1,98 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for arena clip storage (local-dir and GCS backends)."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from coval_bench.arena.audio_store import store_clip
+from coval_bench.config import Settings
+
+
+def _wav(tmp_path: Path) -> Path:
+    src = tmp_path / "src.wav"
+    src.write_bytes(b"RIFFsynth")
+    return src
+
+
+def test_store_clip_local_root_relative(tmp_path: Path) -> None:
+    settings = Settings(arena_audio_dir=tmp_path / "store")
+    url = store_clip(settings, _wav(tmp_path))
+
+    assert url.startswith("/clips/") and url.endswith(".wav")
+    assert (settings.arena_audio_dir / url.lstrip("/")).is_file()
+
+
+def test_store_clip_local_base_url_prefix(tmp_path: Path) -> None:
+    settings = Settings(arena_audio_dir=tmp_path / "store", arena_audio_base_url="https://cdn.x/")
+    url = store_clip(settings, _wav(tmp_path))
+
+    assert url.startswith("https://cdn.x/clips/")
+
+
+class _FakeBlob:
+    def __init__(self) -> None:
+        self.uploaded_from: str | None = None
+        self.content_type: str | None = None
+        self.signed_kwargs: dict[str, Any] = {}
+
+    def upload_from_filename(self, filename: str, *, content_type: str) -> None:
+        self.uploaded_from = filename
+        self.content_type = content_type
+
+    def generate_signed_url(self, **kwargs: Any) -> str:
+        self.signed_kwargs = kwargs
+        return f"https://signed.example/{kwargs['method']}"
+
+
+class _FakeBucket:
+    def __init__(self, blob: _FakeBlob) -> None:
+        self._blob = blob
+        self.key: str | None = None
+
+    def blob(self, key: str) -> _FakeBlob:
+        self.key = key
+        return self._blob
+
+
+class _FakeClient:
+    def __init__(self, blob: _FakeBlob) -> None:
+        self.bucket_obj = _FakeBucket(blob)
+        self.bucket_name: str | None = None
+
+    def bucket(self, name: str) -> _FakeBucket:
+        self.bucket_name = name
+        return self.bucket_obj
+
+
+def test_store_clip_gcs_uploads_and_signs(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    creds = SimpleNamespace(
+        service_account_email="api-rt@proj.iam.gserviceaccount.com",
+        token="tok",  # noqa: S106 — fake credential token for the stubbed signer
+        refresh=lambda _request: None,
+    )
+    monkeypatch.setattr("google.auth.default", lambda: (creds, "proj"))
+    monkeypatch.setattr("google.auth.transport.requests.Request", lambda: object())
+
+    blob = _FakeBlob()
+    client = _FakeClient(blob)
+    src = _wav(tmp_path)
+    settings = Settings(arena_gcs_bucket="coval-benchmarks-arena")
+
+    url = store_clip(settings, src, storage_client=client)
+
+    assert url == "https://signed.example/GET"
+    assert client.bucket_name == "coval-benchmarks-arena"
+    assert client.bucket_obj.key is not None and client.bucket_obj.key.startswith("clips/")
+    assert blob.uploaded_from == str(src)
+    assert blob.content_type == "audio/wav"
+    assert blob.signed_kwargs["version"] == "v4"
+    assert blob.signed_kwargs["expiration"] == timedelta(days=1)
+    assert not src.exists()


### PR DESCRIPTION
GCS backend for arena clips, selected by `arena_gcs_bucket` (env `ARENA_GCS_BUCKET`):
- **unset (default):** unchanged — local-dir move + `/clips` mount.
- **set:** upload to GCS under an opaque `clips/<uuid>.wav` key, delete temp WAV, return a 1-day V4 signed URL; local `/clips` mount skipped.

Private bucket → signed URLs. Signing via the runtime SA's IAM SignBlob (no key file), needs `roles/iam.serviceAccountTokenCreator` (infra PR #19). Opaque keys keep voting blind.

Inert until `ARENA_GCS_BUCKET` is set on Cloud Run; callers untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Audio clips can now be stored and served from local storage or a cloud-backed bucket based on configuration.
  * Clip URL generation works consistently across storage modes.
* **Bug Fixes**
  * Local clip mounting is now only enabled when cloud audio hosting is not configured.
  * Improved cloud upload handling by generating signed links and removing the original source after upload.
* **Tests**
  * Added unit coverage for both local and cloud-backed clip storage paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a GCS backend for arena audio clips, selected by the new `arena_gcs_bucket` / `ARENA_GCS_BUCKET` setting. When unset, the existing local-dir move and `/clips` static mount are unchanged.

- `audio_store.py` gains `_store_clip_gcs` and `_signed_url`: uploads a temp WAV to GCS under an opaque `clips/<uuid>.wav` key, generates a 1-day V4 signed URL via IAM SignBlob (no key file needed; uses the runtime SA's access token), then deletes the local temp file.
- `generate.py` upgrades `store_clip` calls to run in parallel via `asyncio.gather` with a cleanup block that unlinks temp WAVs on failure.
- `app.py` now skips the `/clips` static mount when either `arena_gcs_bucket` or `arena_audio_base_url` is set.

<h3>Confidence Score: 5/5</h3>

The change is inert until ARENA_GCS_BUCKET is set; callers are untouched and the local path is unchanged.

The GCS path correctly sequences upload → sign → delete, and the credential-type guard raises a clear error on misconfigured environments. The two findings are a documentation typo in an IAM role name and a resource-hygiene note about orphaned GCS blobs on rare partial failures — neither affects correctness of the happy path.

No files require special attention; audio_store.py and generate.py are the core of the change and both read cleanly.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| runner/src/coval_bench/arena/audio_store.py | New GCS backend: uploads WAV, signs a 1-day V4 URL via IAM SignBlob, deletes local temp after successful signing. Minor docstring typo in IAM role name. |
| runner/src/coval_bench/arena/generate.py | Parallel store_clip calls with asyncio.gather; cleanup on failure leaves orphaned GCS blobs if one side succeeds before the other raises. |
| runner/src/coval_bench/config.py | Adds arena_gcs_bucket: str = '' setting, populated by ARENA_GCS_BUCKET env var; inert when unset. |
| runner/src/coval_bench/api/app.py | Static /clips mount is now skipped when either arena_gcs_bucket or arena_audio_base_url is set, correctly handling the new GCS mode. |
| runner/tests/unit/test_arena_audio_store.py | New unit tests cover local-dir (root-relative and base-URL-prefixed) and GCS paths with a hand-rolled fake client; verifies upload, signing kwargs, and temp-file deletion. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant C as Caller (POST /arena/battle)
    participant G as generate_battle()
    participant S as store_clip()
    participant GCS as Google Cloud Storage
    participant IAM as IAM SignBlob API
    participant DB as arena.battles

    C->>G: generate_battle(settings, store, prompt)
    G->>G: asyncio.gather(_synthesize A, _synthesize B)
    G->>G: asyncio.gather(store_clip A, store_clip B)

    alt arena_gcs_bucket set
        S->>GCS: "upload_from_filename(wav, content_type=audio/wav)"
        S->>IAM: credentials.refresh() + generate_signed_url(v4, 1d)
        IAM-->>S: signed URL
        S->>S: src_path.unlink()
        S-->>G: "https://storage.googleapis.com/…?X-Goog-Signature=…"
    else local dir
        S->>S: shutil.move(src, arena_audio_dir/clips/uuid.wav)
        S-->>G: /clips/uuid.wav (or base_url prefix)
    end

    G->>DB: insert_battle(audio_a_url, audio_b_url)
    DB-->>G: Battle row
    G-->>C: Battle
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant C as Caller (POST /arena/battle)
    participant G as generate_battle()
    participant S as store_clip()
    participant GCS as Google Cloud Storage
    participant IAM as IAM SignBlob API
    participant DB as arena.battles

    C->>G: generate_battle(settings, store, prompt)
    G->>G: asyncio.gather(_synthesize A, _synthesize B)
    G->>G: asyncio.gather(store_clip A, store_clip B)

    alt arena_gcs_bucket set
        S->>GCS: "upload_from_filename(wav, content_type=audio/wav)"
        S->>IAM: credentials.refresh() + generate_signed_url(v4, 1d)
        IAM-->>S: signed URL
        S->>S: src_path.unlink()
        S-->>G: "https://storage.googleapis.com/…?X-Goog-Signature=…"
    else local dir
        S->>S: shutil.move(src, arena_audio_dir/clips/uuid.wav)
        S-->>G: /clips/uuid.wav (or base_url prefix)
    end

    G->>DB: insert_battle(audio_a_url, audio_b_url)
    DB-->>G: Battle row
    G-->>C: Battle
```

</a>

<sub>Reviews (5): Last reviewed commit: ["Add GCS backend for arena audio clips"](https://github.com/coval-ai/benchmarks/commit/64a89882da0985641a41e1e9e8117682c67ea448) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39957763)</sub>

<!-- /greptile_comment -->