### PR TITLE
Log per-item run failures

### DIFF
--- a/runner/src/coval_bench/runner/orchestrator.py
+++ b/runner/src/coval_bench/runner/orchestrator.py
@@ -132,6 +132,31 @@ def _metric_outcome(
     return result_status.SUCCESS, None
 
 
+def _log_item_failures(
+    event: str,
+    results: list[Any],
+    logged_reasons: set[str],
+    result_status: Any,  # noqa: ANN401 — ResultStatus enum, lazy-imported by callers
+    *,
+    provider: str,
+    model: str,
+    item: str | None,
+) -> None:
+    """Emit one per-item warning for FAILED rows nothing else logged.
+
+    A failed item fans out to several FAILED rows, so this logs once, keyed by
+    metric, not per row. *logged_reasons* carries messages already warned at
+    their source (exceptions, metric crashes) so they are not logged twice.
+    """
+    reasons = {
+        r.metric_type: r.error
+        for r in results
+        if r.status is result_status.FAILED and r.error not in logged_reasons
+    }
+    if reasons:
+        logger.warning(event, provider=provider, model=model, item=item, reasons=reasons)
+
+
 async def _transcribe_with_whisper(audio_path: Path, settings: Settings) -> str:
     """Transcribe *audio_path* with OpenAI ``whisper-1`` and return the text.
 
@@ -218,6 +243,8 @@ async def _run_stt_item(
     compute_wer, compute_rtf = _get_metrics()
 
     results: list[Any] = []
+    # Reasons already warned at their source; the per-item summary skips these.
+    logged_reasons: set[str] = set()
 
     async with sem:
         provider_cls = stt_providers.get(entry.provider)
@@ -266,6 +293,7 @@ async def _run_stt_item(
                 )
         except Exception as exc:
             item_error = _truncate(str(exc))
+            logged_reasons.add(item_error)
             logger.warning(
                 "stt_provider_call_failed",
                 provider=entry.provider,
@@ -352,6 +380,7 @@ async def _run_stt_item(
                 ttfs_value = compute_ttfs(audio_to_final, speech_end_offset_ms / 1000.0)
             except Exception as exc:
                 ttfs_calc_error = str(exc)
+                logged_reasons.add(_truncate(ttfs_calc_error))
                 logger.warning(
                     "ttfs_computation_failed",
                     provider=entry.provider,
@@ -459,6 +488,7 @@ async def _run_stt_item(
                 # compute_wer is deterministic over a transcript we already obtained, so a
                 # crash here is a genuine failure — surface it as a FAILED row rather than
                 # silently dropping it and leaving the run marked SUCCEEDED.
+                logged_reasons.add(_truncate(str(exc)))
                 logger.warning(
                     "wer_computation_failed",
                     provider=entry.provider,
@@ -480,6 +510,16 @@ async def _run_stt_item(
                         error=_truncate(str(exc)),
                     )
                 )
+
+    _log_item_failures(
+        "stt_item_failed",
+        results,
+        logged_reasons,
+        ResultStatus,
+        provider=entry.provider,
+        model=entry.model,
+        item=audio_path.name,
+    )
 
     if writer is not None and results:
         try:
@@ -523,6 +563,8 @@ async def _run_tts_item(
 
     results: list[Any] = []
     audio_path: Path | None = None
+    # Reasons already warned at their source; the per-item summary skips these.
+    logged_reasons: set[str] = set()
 
     async with sem:
         provider_cls = tts_providers.get(entry.provider)
@@ -547,6 +589,7 @@ async def _run_tts_item(
             audio_path = tts_result.audio_path
         except Exception as exc:
             item_error = _truncate(str(exc))
+            logged_reasons.add(item_error)
             logger.warning(
                 "tts_provider_call_failed",
                 provider=entry.provider,
@@ -648,6 +691,7 @@ async def _run_tts_item(
                             wer_percentage=wer_result.wer_percentage,
                         )
                     except Exception as exc:
+                        logged_reasons.add(_truncate(str(exc)))
                         logger.warning(
                             "tts_wer_computation_failed",
                             provider=entry.provider,
@@ -681,6 +725,16 @@ async def _run_tts_item(
                         path=str(audio_path),
                         exc_info=exc,
                     )
+
+    _log_item_failures(
+        "tts_item_failed",
+        results,
+        logged_reasons,
+        ResultStatus,
+        provider=entry.provider,
+        model=entry.model,
+        item=item.testcase_id,
+    )
 
     if writer is not None and results:
         try:

--- a/runner/src/coval_bench/runner/orchestrator.py
+++ b/runner/src/coval_bench/runner/orchestrator.py
@@ -151,7 +151,9 @@ def _log_item_failures(
     reasons = {
         r.metric_type: r.error
         for r in results
-        if r.status is result_status.FAILED and r.error not in logged_reasons
+        if r.status is result_status.FAILED
+        and r.error is not None
+        and r.error not in logged_reasons
     }
     if reasons:
         logger.warning(event, provider=provider, model=model, item=item, reasons=reasons)

--- a/runner/tests/unit/test_orchestrator.py
+++ b/runner/tests/unit/test_orchestrator.py
@@ -1997,6 +1997,41 @@ async def test_stt_wer_crash_not_double_logged(audio_file: Path, settings: Setti
 
 
 @pytest.mark.asyncio
+async def test_stt_ttfs_crash_not_double_logged(audio_file: Path, settings: Settings) -> None:
+    """A TTFS compute crash warns at its source; the item summary stays silent."""
+
+    def _raising_ttfs(*_args: Any, **_kwargs: Any) -> Any:
+        raise ValueError("ttfs blew up")
+
+    provider_inst = MagicMock()
+    provider_inst.measure_ttft = AsyncMock(return_value=_good_transcription())
+
+    run = _make_run()
+    writer = _make_stub_writer(run)
+
+    async with _orchestrator_env(
+        audio_path=audio_file,
+        stt_items=[_make_dataset_item(audio_file)],  # speech_end_offset_ms set → TTFS runs
+        stt_providers={"deepgram": MagicMock(return_value=provider_inst)},
+        run=run,
+        writer=writer,
+    ) as _:
+        with (
+            patch("coval_bench.metrics.compute_ttfs", _raising_ttfs),
+            structlog.testing.capture_logs() as captured,
+        ):
+            await run_benchmarks(
+                settings=settings,
+                benchmark_kind="stt",
+                smoke=True,
+                matrix_overrides=_only_stt_matrix("deepgram", "nova-2"),
+            )
+
+    assert _events(captured, "ttfs_computation_failed"), "source warning still emitted"
+    assert not _events(captured, "stt_item_failed"), "crash failure must not be logged twice"
+
+
+@pytest.mark.asyncio
 async def test_tts_transport_gate_logs_item_failure(settings: Settings) -> None:
     """An HTTP/1.1 contamination failure is surfaced in the per-item summary."""
     with tempfile.TemporaryDirectory() as tmpdir:

--- a/runner/tests/unit/test_orchestrator.py
+++ b/runner/tests/unit/test_orchestrator.py
@@ -25,13 +25,14 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import tempfile
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, MutableMapping
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, create_autospec, patch
 
 import pytest
+import structlog
 from posthog import Posthog
 from pydantic import SecretStr
 
@@ -126,6 +127,7 @@ def _make_dataset_item(path: Path, transcript: str = "hello world") -> Any:
 
 def _make_tts_item(transcript: str = "hello world") -> Any:
     item = MagicMock()
+    item.testcase_id = "tts-0001"
     item.transcript = transcript
     return item
 
@@ -1411,6 +1413,11 @@ def _recorded_rows(writer: MagicMock) -> list[Result]:
     return [row for call in writer.record_results.await_args_list for row in call.args[0]]
 
 
+def _events(captured: list[MutableMapping[str, Any]], name: str) -> list[MutableMapping[str, Any]]:
+    """Captured structlog events whose event name matches *name*."""
+    return [e for e in captured if e.get("event") == name]
+
+
 @pytest.mark.asyncio
 async def test_stt_empty_result_marked_failed(audio_file: Path, settings: Settings) -> None:
     """No-raise return with no metrics → TTFT/AudioToFinal/RTF FAILED, no WER row, run FAILED."""
@@ -1839,6 +1846,212 @@ async def test_tts_wer_compute_failure_marked_failed(settings: Settings) -> None
         assert by_metric["WER"].metric_value is None
         assert "wer blew up" in (by_metric["WER"].error or "")
         assert summary.status == str(RunStatus.PARTIAL)
+
+
+# ---------------------------------------------------------------------------
+# 18-22. per-item failure summary logging (silent paths log; no double-log)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_stt_empty_result_logs_item_failure(audio_file: Path, settings: Settings) -> None:
+    """A no-value return surfaces one stt_item_failed line keyed by metric."""
+    empty = TranscriptionResult(provider="deepgram")  # all metrics None, no error
+
+    provider_inst = MagicMock()
+    provider_inst.measure_ttft = AsyncMock(return_value=empty)
+
+    run = _make_run()
+    writer = _make_stub_writer(run)
+
+    async with _orchestrator_env(
+        audio_path=audio_file,
+        stt_items=[_make_dataset_item(audio_file)],
+        stt_providers={"deepgram": MagicMock(return_value=provider_inst)},
+        run=run,
+        writer=writer,
+    ) as _:
+        with structlog.testing.capture_logs() as captured:
+            await run_benchmarks(
+                settings=settings,
+                benchmark_kind="stt",
+                smoke=True,
+                matrix_overrides=_only_stt_matrix("deepgram", "nova-2"),
+            )
+
+    failures = _events(captured, "stt_item_failed")
+    assert len(failures) == 1, "one summary line per failed item, not one per row"
+    event = failures[0]
+    assert event["provider"] == "deepgram"
+    assert event["item"] == "0001.wav"
+    # Every silent FAILED metric is carried with its reason.
+    assert {"TTFT", "AudioToFinal", "RTF"} <= set(event["reasons"])
+    assert all("produced" in reason for reason in event["reasons"].values())
+
+
+@pytest.mark.asyncio
+async def test_stt_provider_error_logs_item_failure(audio_file: Path, settings: Settings) -> None:
+    """A provider-set result.error (no raise) surfaces in the per-item summary."""
+    errored = TranscriptionResult(
+        provider="deepgram",
+        ttft_seconds=0.3,
+        complete_transcript="partial words",
+        error="websocket closed unexpectedly",
+    )
+
+    provider_inst = MagicMock()
+    provider_inst.measure_ttft = AsyncMock(return_value=errored)
+
+    run = _make_run()
+    writer = _make_stub_writer(run)
+
+    async with _orchestrator_env(
+        audio_path=audio_file,
+        stt_items=[_make_dataset_item(audio_file)],
+        stt_providers={"deepgram": MagicMock(return_value=provider_inst)},
+        run=run,
+        writer=writer,
+    ) as _:
+        with structlog.testing.capture_logs() as captured:
+            await run_benchmarks(
+                settings=settings,
+                benchmark_kind="stt",
+                smoke=True,
+                matrix_overrides=_only_stt_matrix("deepgram", "nova-2"),
+            )
+
+    failures = _events(captured, "stt_item_failed")
+    assert len(failures) == 1
+    reasons = failures[0]["reasons"]
+    assert reasons  # the provider message reached the log
+    assert all("websocket closed" in reason for reason in reasons.values())
+
+
+@pytest.mark.asyncio
+async def test_stt_provider_exception_not_double_logged(
+    audio_file: Path, settings: Settings
+) -> None:
+    """A raised provider error warns once at its source — no second item summary."""
+    provider_inst = MagicMock()
+    provider_inst.measure_ttft = AsyncMock(side_effect=RuntimeError("boom"))
+
+    run = _make_run()
+    writer = _make_stub_writer(run)
+
+    async with _orchestrator_env(
+        audio_path=audio_file,
+        stt_items=[_make_dataset_item(audio_file)],
+        stt_providers={"deepgram": MagicMock(return_value=provider_inst)},
+        run=run,
+        writer=writer,
+    ) as _:
+        with structlog.testing.capture_logs() as captured:
+            await run_benchmarks(
+                settings=settings,
+                benchmark_kind="stt",
+                smoke=True,
+                matrix_overrides=_only_stt_matrix("deepgram", "nova-2"),
+            )
+
+    assert _events(captured, "stt_provider_call_failed"), "source warning still emitted"
+    assert not _events(captured, "stt_item_failed"), "exception failure must not be logged twice"
+
+
+@pytest.mark.asyncio
+async def test_stt_wer_crash_not_double_logged(audio_file: Path, settings: Settings) -> None:
+    """A WER compute crash warns at its source; the item summary stays silent."""
+    from coval_bench.metrics import compute_rtf
+
+    def _raising_wer(*_args: Any, **_kwargs: Any) -> Any:
+        raise ValueError("wer blew up")
+
+    provider_inst = MagicMock()
+    provider_inst.measure_ttft = AsyncMock(return_value=_good_transcription())
+
+    run = _make_run()
+    writer = _make_stub_writer(run)
+
+    async with _orchestrator_env(
+        audio_path=audio_file,
+        stt_items=[_make_dataset_item(audio_file)],
+        stt_providers={"deepgram": MagicMock(return_value=provider_inst)},
+        run=run,
+        writer=writer,
+    ) as _:
+        with (
+            patch(
+                "coval_bench.runner.orchestrator._get_metrics",
+                return_value=(_raising_wer, compute_rtf),
+            ),
+            structlog.testing.capture_logs() as captured,
+        ):
+            await run_benchmarks(
+                settings=settings,
+                benchmark_kind="stt",
+                smoke=True,
+                matrix_overrides=_only_stt_matrix("deepgram", "nova-2"),
+            )
+
+    assert _events(captured, "wer_computation_failed"), "source warning still emitted"
+    assert not _events(captured, "stt_item_failed"), "crash failure must not be logged twice"
+
+
+@pytest.mark.asyncio
+async def test_tts_transport_gate_logs_item_failure(settings: Settings) -> None:
+    """An HTTP/1.1 contamination failure is surfaced in the per-item summary."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        audio_path = Path(tmpdir) / "synth.wav"
+        audio_path.write_bytes(b"\x00" * 512)
+
+        hume_entry = _registry_entry(Benchmark.TTS, "hume")
+        tts_result = TTSResult(
+            provider="hume",
+            model=hume_entry.model,
+            voice=hume_entry.voice or "v",
+            ttfa_ms=120.0,
+            audio_path=audio_path,
+            error=None,
+            http_version="HTTP/1.1",
+        )
+
+        provider_inst = MagicMock()
+        provider_inst.synthesize = AsyncMock(return_value=tts_result)
+        provider_cls = MagicMock(return_value=provider_inst)
+
+        matrix = [
+            *_paused_registry(Benchmark.TTS),
+            hume_entry.model_copy(update={"status": ModelStatus.ACTIVE}),
+        ]
+
+        run = _make_run()
+        writer = _make_stub_writer(run)
+
+        async with _orchestrator_env(
+            audio_path=audio_path,
+            tts_items=[_make_tts_item("hello world")],
+            tts_providers={"hume": provider_cls},
+            run=run,
+            writer=writer,
+        ) as _:
+            with (
+                patch(
+                    "coval_bench.runner.orchestrator._transcribe_with_whisper",
+                    return_value="hello world",
+                ),
+                structlog.testing.capture_logs() as captured,
+            ):
+                await run_benchmarks(
+                    settings=settings,
+                    benchmark_kind="tts",
+                    smoke=True,
+                    matrix_overrides=matrix,
+                )
+
+    failures = _events(captured, "tts_item_failed")
+    assert len(failures) == 1
+    event = failures[0]
+    assert event["item"] == "tts-0001"
+    assert "HTTP/1.1" in event["reasons"]["TTFA"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Emit one structured warning per failed STT/TTS item covering the silent FAILED paths (no measurement, provider-set error, transport gate), deduped against the source warnings that already log exceptions and metric crashes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved item-level failure reporting so each failed STT/TTS item emits a single aggregated warning with metric-specific reasons.
  * Reduced duplicate error/warning messages by avoiding repeated reasons already logged from the original failure source.
  * Standardized how warnings are produced for provider errors, transcription/compute issues, and metric computation failures.

* **Tests**
  * Added unit tests for STT and TTS failure logging behavior, including no-double-log “silent path” scenarios and a deterministic TTS item failure assertion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds structured per-item failure logging to the STT and TTS benchmark runners. Instead of silently passing failed items or relying on scattered exception logs, a new `_log_item_failures` helper emits one `stt_item_failed`/`tts_item_failed` warning per failed item, keyed by metric, while a `logged_reasons` set prevents double-logging for exceptions and metric-crash paths that already have their own source-level warnings.

- Adds `_log_item_failures(event, results, logged_reasons, result_status, ...)` that builds a `{metric_type: error}` dict from FAILED rows not already in `logged_reasons`, and fires one structured warning if non-empty.
- In both `_run_stt_item` and `_run_tts_item`, a `logged_reasons: set[str]` is populated at each exception/metric-crash site so those messages are suppressed in the per-item summary.
- Five new unit tests (plus the previously requested TTFS-crash dedup test) cover the silent no-value path, provider-error path, transport-gate path, and the three source-logged crash paths (provider exception, WER crash, TTFS crash).

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changed code paths are purely additive logging with no side effects on benchmark results or DB writes.

The change adds structured warning emission after results are already collected; it cannot affect metric values, result status, or database writes. The dedup logic is internally consistent: every source-warn site truncates with `_truncate` before storing in `logged_reasons`, and `_metric_outcome` also applies `_truncate` before storing in `r.error`, so comparison in `_log_item_failures` is always apples-to-apples. Six new unit tests exercise all new paths including the previously missing TTFS crash dedup case.

No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| runner/src/coval_bench/runner/orchestrator.py | Adds `_log_item_failures` helper and `logged_reasons` dedup sets to both STT and TTS item runners; dedup logic is consistent: all three source-warn sites truncate with `_truncate` before adding to `logged_reasons`, matching what `_metric_outcome` stores in `r.error`. |
| runner/tests/unit/test_orchestrator.py | Adds 6 new tests covering all new logging paths: silent FAILED (no-value), provider-set error, provider exception dedup, WER crash dedup, TTFS crash dedup, and TTS transport-gate. The `_events` helper and `item.testcase_id` fixture fix are clean additions. |


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `runner/src/coval_bench/runner/orchestrator.py`, line 423-433 ([link](https://github.com/coval-ai/benchmarks/blob/0ab4444170e5499d22bbcef36bea9798d5068204/runner/src/coval_bench/runner/orchestrator.py#L423-L433)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The `rtf_computation_failed` warning site is the only source-logged exception path that does not add to `logged_reasons`. This is benign today because `_metric_outcome` for RTF is keyed on `audio_to_final` (not `rtf_value`), so an RTF compute exception yields a SUCCESS row (the "null-valued success" design), which `_log_item_failures` never touches. However the asymmetry is a latent trap: if the RTF failure model is ever aligned with the TTFS/WER pattern (produce a FAILED row), the missing `logged_reasons.add` would cause the RTF crash to be double-logged without any obvious breakage signal.
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["Guard per-item failure log against null ..."](https://github.com/coval-ai/benchmarks/commit/6e809f713aa870edb64e11c081149c31bacd52bb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39958103)</sub>

<!-- /greptile_comment -->