### PR TITLE
Add AssemblyAI multilingual streaming STT

### DIFF
--- a/runner/src/coval_bench/providers/stt/assemblyai.py
+++ b/runner/src/coval_bench/providers/stt/assemblyai.py
@@ -3,7 +3,7 @@
 
 """AssemblyAI real-time STT provider (v3 streaming API).
 
-Models: universal-streaming, universal-3.5-pro
+Models: universal-streaming, universal-streaming-multilingual, universal-3.5-pro
 Wire protocol: WebSocket, wss://streaming.assemblyai.com/v3/ws
 Auth: Authorization: <key>
 Close: {"type": "Terminate"}
@@ -30,6 +30,7 @@ logger = structlog.get_logger(__name__)
 # would inflate TTFT measurements.
 _SPEECH_MODEL_MAP: dict[str, str] = {
     "universal-streaming": "universal-streaming-english",
+    "universal-streaming-multilingual": "universal-streaming-multilingual",
     "universal-3.5-pro": "universal-3-5-pro",
 }
 _WS_BASE = "wss://streaming.assemblyai.com/v3/ws"

--- a/runner/src/coval_bench/providers/stt/assemblyai.py
+++ b/runner/src/coval_bench/providers/stt/assemblyai.py
@@ -214,8 +214,6 @@ class AssemblyAIProvider(STTProvider):
 
         if complete_turns:
             result.complete_transcript = " ".join(complete_turns).strip() or None
-        elif result.partial_transcripts:
-            result.complete_transcript = result.partial_transcripts[-1].strip() or None
 
         if result.complete_transcript:
             result.transcript_length = len(result.complete_transcript)

--- a/runner/src/coval_bench/registries/models.py
+++ b/runner/src/coval_bench/registries/models.py
@@ -69,6 +69,12 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         benchmark=_STT, provider="assemblyai", model="universal-streaming", status=_ACTIVE
     ),
     RegisteredModel(
+        benchmark=_STT,
+        provider="assemblyai",
+        model="universal-streaming-multilingual",
+        status=_ACTIVE,
+    ),
+    RegisteredModel(
         benchmark=_STT, provider="assemblyai", model="universal-3.5-pro", status=_ACTIVE
     ),
     RegisteredModel(benchmark=_STT, provider="speechmatics", model="default", status=_ACTIVE),

--- a/runner/tests/providers/stt/test_assemblyai.py
+++ b/runner/tests/providers/stt/test_assemblyai.py
@@ -124,6 +124,11 @@ def test_provider_name_universal_3_5_pro() -> None:
     assert p.name == "assemblyai-universal-3.5-pro"
 
 
+def test_provider_name_universal_streaming_multilingual() -> None:
+    p = AssemblyAIProvider(api_key=SecretStr("k"), model="universal-streaming-multilingual")
+    assert p.name == "assemblyai-universal-streaming-multilingual"
+
+
 @pytest.mark.asyncio
 async def test_universal_3_5_pro_url_uses_api_speech_model(
     fake_api_key: SecretStr, monkeypatch: pytest.MonkeyPatch
@@ -149,6 +154,34 @@ async def test_universal_3_5_pro_url_uses_api_speech_model(
 
     url = mock_connect.call_args.args[0]
     assert "speech_model=universal-3-5-pro" in url
+
+
+@pytest.mark.asyncio
+async def test_universal_streaming_multilingual_url_uses_api_speech_model(
+    fake_api_key: SecretStr, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The multilingual model id maps to its speech_model value with no language lock."""
+    monkeypatch.setattr("coval_bench.providers.stt.assemblyai._FINAL_WAIT_S", 0.05)
+    ws = FakeWebSocket([{"type": "Turn", "end_of_turn": True, "transcript": "hola"}])
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=ws)
+    cm.__aexit__ = AsyncMock(return_value=False)
+    provider = AssemblyAIProvider(api_key=fake_api_key, model="universal-streaming-multilingual")
+
+    with patch(
+        "coval_bench.providers.stt.assemblyai.ws_client.connect", return_value=cm
+    ) as mock_connect:
+        await provider.measure_ttft(
+            audio_data=b"\x00" * 640,
+            channels=1,
+            sample_width=2,
+            sample_rate=16000,
+            realtime_resolution=0.01,
+        )
+
+    url = mock_connect.call_args.args[0]
+    assert "speech_model=universal-streaming-multilingual" in url
+    assert "language_code" not in url
 
 
 # ---------------------------------------------------------------------------

--- a/runner/tests/providers/stt/test_assemblyai.py
+++ b/runner/tests/providers/stt/test_assemblyai.py
@@ -270,9 +270,10 @@ async def test_assemblyai_audio_to_final_populated(
 
 @pytest.mark.asyncio
 async def test_assemblyai_audio_to_final_none_when_no_end_of_turn(
-    fake_api_key: SecretStr, audio_pcm_bytes: bytes
+    fake_api_key: SecretStr, audio_pcm_bytes: bytes, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """audio_to_final_seconds is None when no end_of_turn event arrives."""
+    monkeypatch.setattr("coval_bench.providers.stt.assemblyai._FINAL_WAIT_S", 0.05)
     events: list[Any] = [
         {"type": "Begin", "id": "test-session", "expires_at": 9999999999},
         {
@@ -301,7 +302,7 @@ async def test_assemblyai_audio_to_final_none_when_no_end_of_turn(
 
 @pytest.mark.asyncio
 async def test_assemblyai_partial_only_leaves_complete_transcript_none(
-    fake_api_key: SecretStr, audio_pcm_bytes: bytes
+    fake_api_key: SecretStr, audio_pcm_bytes: bytes, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """No end_of_turn=true final means no scorable transcript.
 
@@ -310,6 +311,7 @@ async def test_assemblyai_partial_only_leaves_complete_transcript_none(
     still captured (ttft, partial_transcripts) — they just stay out of the
     transcript WER reads.
     """
+    monkeypatch.setattr("coval_bench.providers.stt.assemblyai._FINAL_WAIT_S", 0.05)
     events: list[Any] = [
         {"type": "Begin", "id": "test-session", "expires_at": 9999999999},
         {"type": "Turn", "transcript": "hello", "end_of_turn": False},

--- a/runner/tests/providers/stt/test_assemblyai.py
+++ b/runner/tests/providers/stt/test_assemblyai.py
@@ -300,6 +300,41 @@ async def test_assemblyai_audio_to_final_none_when_no_end_of_turn(
 
 
 @pytest.mark.asyncio
+async def test_assemblyai_partial_only_leaves_complete_transcript_none(
+    fake_api_key: SecretStr, audio_pcm_bytes: bytes
+) -> None:
+    """No end_of_turn=true final means no scorable transcript.
+
+    The orchestrator scores WER on any non-null complete_transcript, so an
+    unfinalized partial hypothesis must not be promoted to it. Partials are
+    still captured (ttft, partial_transcripts) — they just stay out of the
+    transcript WER reads.
+    """
+    events: list[Any] = [
+        {"type": "Begin", "id": "test-session", "expires_at": 9999999999},
+        {"type": "Turn", "transcript": "hello", "end_of_turn": False},
+        {"type": "Turn", "transcript": "hello world", "end_of_turn": False},
+    ]
+    provider = AssemblyAIProvider(api_key=fake_api_key)
+
+    with patch(
+        "coval_bench.providers.stt.assemblyai.ws_client.connect",
+        return_value=_fake_connect(events),
+    ):
+        result = await provider.measure_ttft(
+            audio_data=audio_pcm_bytes,
+            channels=1,
+            sample_width=2,
+            sample_rate=16000,
+            realtime_resolution=0.5,
+        )
+
+    assert result.complete_transcript is None
+    assert result.ttft_seconds is not None
+    assert result.partial_transcripts == ["hello", "hello world"]
+
+
+@pytest.mark.asyncio
 async def test_assemblyai_audio_to_final_uses_last_end_of_turn(
     fake_api_key: SecretStr, audio_pcm_bytes: bytes
 ) -> None:

--- a/web/lib/config/colors.ts
+++ b/web/lib/config/colors.ts
@@ -46,6 +46,7 @@ export const modelColors: Record<string, string> = {
 
   // AssemblyAI — amethyst family (#8E44AD).
   "universal-streaming": "#8E44AD",
+  "universal-streaming-multilingual": "#A569BD",
   "universal-3.5-pro": "#6C3483",
 
   // Speechmatics — navy family (#21618C).

--- a/web/lib/utils/formatters.ts
+++ b/web/lib/utils/formatters.ts
@@ -120,6 +120,7 @@ export function normalizeModelName(modelKey: string): string {
     "gpt-4o-transcribe": "GPT-4o Transcribe",
     "gpt-4o-mini-transcribe": "GPT-4o mini Transcribe",
     "universal-streaming": "Universal Streaming",
+    "universal-streaming-multilingual": "Universal Streaming Multilingual",
     "universal-3.5-pro": "Universal 3.5 Pro",
     "ink-2": "Ink 2",
     default: "Default",


### PR DESCRIPTION
Registers universal-streaming-multilingual as an active STT model with its leaderboard display name and color.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the new AssemblyAI speech model, **Universal Streaming Multilingual**.
  * The model is now shown in the app with a dedicated display name and color.

* **Bug Fixes**
  * Updated model configuration so requests use the correct API speech model identifier.
  * Improved transcript handling so `complete_transcript` is populated only when final segments are available.

* **Tests**
  * Added/updated tests for model name mapping, streaming URL parameters, and “partials only” behavior, including deterministic no-final timing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds the `universal-streaming-multilingual` model to the AssemblyAI STT provider, registers it with an active status, and assigns it a display name and leaderboard color. It also fixes a transcript assembly bug where partial-only transcripts were incorrectly promoted to `complete_transcript` (used for WER scoring).

- **New model registration**: `universal-streaming-multilingual` is added to `_SPEECH_MODEL_MAP` (mapping to itself as the API value), the model registry, the color config, and the display name formatter — all in parallel, consistent with how other models are wired.
- **Bug fix in `_receive`**: Removes the `elif result.partial_transcripts` fallback that set `complete_transcript` from the last partial; `complete_transcript` is now only populated when at least one `end_of_turn=True` turn is received, preventing un-finalized hypotheses from being scored as WER references.
- **Test coverage**: Three new tests cover the provider name, the WebSocket URL speech model mapping, and the partial-only transcript behavior.

<h3>Confidence Score: 5/5</h3>

Safe to merge — changes are additive model registration with a targeted bug fix backed by new tests.

All five touched files make narrow, consistent changes: the new model slot is wired identically to its siblings, the partial-transcript fallback removal is intentional and validated by a dedicated test, and no existing behaviour for other models is altered.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| runner/src/coval_bench/providers/stt/assemblyai.py | Adds universal-streaming-multilingual to _SPEECH_MODEL_MAP and removes the partial-transcript fallback for complete_transcript; both changes are correct and well-tested. |
| runner/src/coval_bench/registries/models.py | Registers universal-streaming-multilingual as an active STT model; straightforward insertion consistent with existing entries. |
| runner/tests/providers/stt/test_assemblyai.py | Adds three targeted tests: provider name, URL speech_model param, and partial-only transcript staying None; also adds _FINAL_WAIT_S monkeypatch to the no-end-of-turn test to avoid a 5-second wait. |
| web/lib/config/colors.ts | Adds a lighter amethyst shade (#A569BD) for the new model, fitting within the established AssemblyAI color family. |
| web/lib/utils/formatters.ts | Adds "Universal Streaming Multilingual" display name mapping for the new model key. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Caller
    participant AssemblyAIProvider
    participant WebSocket as AssemblyAI WS

    Caller->>AssemblyAIProvider: "measure_ttft(audio_data, model="universal-streaming-multilingual")"
    AssemblyAIProvider->>AssemblyAIProvider: "speech_model = _SPEECH_MODEL_MAP["universal-streaming-multilingual"]"
    AssemblyAIProvider->>WebSocket: "connect(?sample_rate=16000&speech_model=universal-streaming-multilingual&...)"
    WebSocket-->>AssemblyAIProvider: Begin
    loop Audio chunks
        AssemblyAIProvider->>WebSocket: send(PCM chunk)
        WebSocket-->>AssemblyAIProvider: "Turn(end_of_turn=false) → partial_transcripts[]"
    end
    AssemblyAIProvider->>WebSocket: ForceEndpoint
    WebSocket-->>AssemblyAIProvider: "Turn(end_of_turn=true) → complete_turns[]"
    AssemblyAIProvider->>WebSocket: Terminate
    WebSocket-->>AssemblyAIProvider: Termination
    AssemblyAIProvider->>AssemblyAIProvider: "complete_transcript = join(complete_turns) [no partial fallback]"
    AssemblyAIProvider-->>Caller: TranscriptionResult
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Caller
    participant AssemblyAIProvider
    participant WebSocket as AssemblyAI WS

    Caller->>AssemblyAIProvider: "measure_ttft(audio_data, model="universal-streaming-multilingual")"
    AssemblyAIProvider->>AssemblyAIProvider: "speech_model = _SPEECH_MODEL_MAP["universal-streaming-multilingual"]"
    AssemblyAIProvider->>WebSocket: "connect(?sample_rate=16000&speech_model=universal-streaming-multilingual&...)"
    WebSocket-->>AssemblyAIProvider: Begin
    loop Audio chunks
        AssemblyAIProvider->>WebSocket: send(PCM chunk)
        WebSocket-->>AssemblyAIProvider: "Turn(end_of_turn=false) → partial_transcripts[]"
    end
    AssemblyAIProvider->>WebSocket: ForceEndpoint
    WebSocket-->>AssemblyAIProvider: "Turn(end_of_turn=true) → complete_turns[]"
    AssemblyAIProvider->>WebSocket: Terminate
    WebSocket-->>AssemblyAIProvider: Termination
    AssemblyAIProvider->>AssemblyAIProvider: "complete_transcript = join(complete_turns) [no partial fallback]"
    AssemblyAIProvider-->>Caller: TranscriptionResult
```

</a>

<sub>Reviews (3): Last reviewed commit: ["Speed up AssemblyAI no-final STT tests"](https://github.com/coval-ai/benchmarks/commit/7ab85a8386fccb35f105864e4e1216d88faabebe) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39974581)</sub>

<!-- /greptile_comment -->