### PR TITLE
Add a provider select-all checkbox to the model sidebar

### DIFF
--- a/web/components/layout/ModelSidebar.tsx
+++ b/web/components/layout/ModelSidebar.tsx
@@ -24,6 +24,7 @@ const ModelSidebar: React.FC = () => {
     modelsByProvider,
     selectedModels,
     toggleModelSelection: onToggleModelSelection,
+    toggleProviderSelection: onToggleProviderSelection,
   } = useDashboard();
 
   const containerRef = React.useRef<HTMLDivElement>(null);
@@ -75,11 +76,61 @@ const ModelSidebar: React.FC = () => {
         {/* Model Selection Content */}
         <div ref={linksRef} className="space-y-2">
           <div>
-            {Object.entries(modelsByProvider).map(([provider, models]) => (
+            {Object.entries(modelsByProvider).map(([provider, models]) => {
+              const selectedCount = models.filter((m) =>
+                selectedModels.includes(m)
+              ).length;
+              const allSelected =
+                models.length > 0 && selectedCount === models.length;
+              const someSelected = selectedCount > 0 && !allSelected;
+              return (
               <div key={provider} className="mt-4 first:mt-0">
-                <div className="text-text-primary pt-1.5 pb-0.5 px-2 text-sm font-bold">
+                <label className="flex items-center gap-2 text-text-primary pt-1.5 pb-0.5 px-2 text-sm font-bold cursor-pointer">
+                  <span className="relative inline-flex h-3.5 w-3.5 shrink-0">
+                    <input
+                      type="checkbox"
+                      checked={allSelected}
+                      ref={(el) => {
+                        if (el) el.indeterminate = someSelected;
+                      }}
+                      onChange={() => onToggleProviderSelection(provider)}
+                      aria-label={`${
+                        allSelected ? "Deselect" : "Select"
+                      } all ${normalizeProviderName(provider)} models`}
+                      className="peer h-3.5 w-3.5 shrink-0 cursor-pointer appearance-none rounded-[3px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-text-tertiary/40 focus-visible:ring-offset-1 focus-visible:ring-offset-background"
+                      style={{
+                        backgroundColor:
+                          allSelected || someSelected
+                            ? "var(--color-text-primary)"
+                            : "#d4d2cc",
+                      }}
+                    />
+                    <svg
+                      aria-hidden
+                      viewBox="0 0 14 14"
+                      fill="none"
+                      stroke="white"
+                      strokeWidth={1.5}
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      className="pointer-events-none absolute inset-0 hidden h-3.5 w-3.5 peer-checked:block"
+                    >
+                      <path d="M3.5 7.5l2.5 2.5 4.5-5" />
+                    </svg>
+                    <svg
+                      aria-hidden
+                      viewBox="0 0 14 14"
+                      fill="none"
+                      stroke="white"
+                      strokeWidth={1.5}
+                      strokeLinecap="round"
+                      className="pointer-events-none absolute inset-0 hidden h-3.5 w-3.5 peer-indeterminate:block"
+                    >
+                      <path d="M3.5 7h7" />
+                    </svg>
+                  </span>
                   {normalizeProviderName(provider)}
-                </div>
+                </label>
                 <div className="space-y-0">
                   {models.map((model) => {
                     const checked = selectedModels.includes(model);
@@ -125,7 +176,8 @@ const ModelSidebar: React.FC = () => {
                   })}
                 </div>
               </div>
-            ))}
+              );
+            })}
           </div>
         </div>
       </div>

--- a/web/hooks/useDashboardState.tsx
+++ b/web/hooks/useDashboardState.tsx
@@ -107,6 +107,31 @@ export function useDashboardState(page: "tts" | "stt") {
     [selectedModels, page]
   );
 
+  // Select all of a provider's models unless they're all already selected.
+  const toggleProviderSelection = useCallback(
+    (provider: string) => {
+      const providerModels = modelsByProvider[provider] ?? [];
+      if (providerModels.length === 0) return;
+      const willBeSelected = !providerModels.every((m) =>
+        selectedModels.includes(m)
+      );
+      const nextSelected = willBeSelected
+        ? [...new Set([...selectedModels, ...providerModels])]
+        : selectedModels.filter((m) => !providerModels.includes(m));
+      capturePostHogEvent(POSTHOG_EVENTS.dashboardModelSelectionChanged, {
+        surface: `${page}_dashboard`,
+        mode: page,
+        action: willBeSelected ? "add" : "remove",
+        provider,
+        selected_model_ids: nextSelected,
+        selected_model_count: nextSelected.length,
+        is_comparison: nextSelected.length >= 2
+      });
+      setSelectedModels(nextSelected);
+    },
+    [selectedModels, modelsByProvider, page]
+  );
+
   // Heatmap scaling for mobile. Skipped while loading (only the skeleton is
   // in the DOM); re-runs when loading completes so the first paint of the
   // heatmap gets scaled without waiting for a resize event.
@@ -383,6 +408,7 @@ export function useDashboardState(page: "tts" | "stt") {
 
     // Actions
     toggleModelSelection,
+    toggleProviderSelection,
     changeTimeWindow,
 
     // Chart data functions


### PR DESCRIPTION
Toggles every model under a provider at once, with an indeterminate state when only some are selected.

Just a hot fix until proper filtering lands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added provider-level bulk selection in the model sidebar, letting you select or clear all models for a provider at once.
  * Provider checkboxes now reflect selection state with checked and indeterminate visuals for clearer feedback.

* **Bug Fixes**
  * Improved selection behavior so provider toggles stay in sync with the currently selected models.
  * Updated accessibility labels to better describe the provider selection state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a select-all checkbox to each provider group in the model sidebar. Clicking the header checkbox selects or deselects all models under that provider at once, with a visually correct indeterminate state when only some of the provider's models are selected.

- **`useDashboardState`**: Adds `toggleProviderSelection`, which computes the next selection by either union-ing or filtering, fires the existing PostHog analytics event, and calls `setSelectedModels` — consistent with the `toggleModelSelection` pattern already in place.
- **`ModelSidebar`**: Converts the plain provider heading into a `<label>` wrapping a custom styled checkbox, uses a ref callback to imperatively set `element.indeterminate`, and renders a checkmark or dash SVG via Tailwind's `peer-checked` / `peer-indeterminate` variants to match the visuals of the existing per-model checkboxes.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the new provider-level checkbox works correctly and the hook logic is well-guarded against empty provider lists and duplicate entries.

The select/deselect logic is correct, the indeterminate state is properly driven through the ref callback, and the Set-based deduplication in the select path prevents duplicates. The only notable pattern is the inline ref function being recreated on every render, which triggers React's cleanup+setup cycle per provider row per selection change — not a bug, but worth tidying up when the provider list grows.

web/components/layout/ModelSidebar.tsx — the inline ref callback for `indeterminate` is the one spot that could benefit from a stable reference if re-render frequency becomes noticeable.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| web/hooks/useDashboardState.tsx | Adds toggleProviderSelection callback; logic is correct, deselect path uses filter + Array.includes (O(n·m) but negligible at this scale), PostHog event fires before setSelectedModels, consistent with toggleModelSelection. |
| web/components/layout/ModelSidebar.tsx | Provider label converted to a clickable checkbox; allSelected/someSelected logic is sound, peer-indeterminate Tailwind variant works correctly in v4, but the ref callback is recreated every render causing redundant cleanup/setup cycles. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([User clicks provider checkbox]) --> B{Compute state}
    B --> C["selectedCount = models ∩ selectedModels"]
    C --> D{allSelected?}
    D -- "selectedCount === models.length" --> E["checked=true\nindeterminate=false\nShow ✓ SVG"]
    D -- "selectedCount === 0" --> F["checked=false\nindeterminate=false\nNo SVG shown"]
    D -- "0 < selectedCount < models.length" --> G["checked=false\nindeterminate=true\nShow — SVG"]
    E --> H["toggleProviderSelection(provider)"]
    F --> H
    G --> H
    H --> I{"providerModels.every(m => selectedModels.includes(m))"}
    I -- "true → willBeSelected=false" --> J["nextSelected = selectedModels.filter(m => not in providerModels)"]
    I -- "false → willBeSelected=true" --> K["nextSelected = Set(selectedModels ∪ providerModels)"]
    J --> L[capturePostHogEvent]
    K --> L
    L --> M[setSelectedModels]
    M --> B
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A([User clicks provider checkbox]) --> B{Compute state}
    B --> C["selectedCount = models ∩ selectedModels"]
    C --> D{allSelected?}
    D -- "selectedCount === models.length" --> E["checked=true\nindeterminate=false\nShow ✓ SVG"]
    D -- "selectedCount === 0" --> F["checked=false\nindeterminate=false\nNo SVG shown"]
    D -- "0 < selectedCount < models.length" --> G["checked=false\nindeterminate=true\nShow — SVG"]
    E --> H["toggleProviderSelection(provider)"]
    F --> H
    G --> H
    H --> I{"providerModels.every(m => selectedModels.includes(m))"}
    I -- "true → willBeSelected=false" --> J["nextSelected = selectedModels.filter(m => not in providerModels)"]
    I -- "false → willBeSelected=true" --> K["nextSelected = Set(selectedModels ∪ providerModels)"]
    J --> L[capturePostHogEvent]
    K --> L
    L --> M[setSelectedModels]
    M --> B
```

</a>

<sub>Reviews (1): Last reviewed commit: ["Add a provider select-all checkbox to th..."](https://github.com/coval-ai/benchmarks/commit/61d880b36817411f662692badfddf170d32806d3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39977510)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->