### PR TITLE
Sign arena clip URLs at serve time

### DIFF
--- a/runner/src/coval_bench/api/routers/arena.py
+++ b/runner/src/coval_bench/api/routers/arena.py
@@ -127,10 +127,19 @@ async def get_battle(
     async with pool.connection() as conn:
         conn.row_factory = psycopg.rows.dict_row
         # Placeholder selection: a uniformly random battle. Adaptive pairing will
-        # replace this to surface the most informative matchups.
-        rows = await conn.execute(
-            f"SELECT {_BATTLE_COLS} FROM arena.battles ORDER BY random() LIMIT 1"  # noqa: S608
-        )
+        # replace this to surface the most informative matchups. With GCS-backed
+        # clips, skip battles older than the bucket retention — their audio is gone.
+        if settings.arena_gcs_bucket:
+            rows = await conn.execute(
+                f"SELECT {_BATTLE_COLS} FROM arena.battles "  # noqa: S608
+                "WHERE created_at >= now() - make_interval(days => %(days)s) "
+                "ORDER BY random() LIMIT 1",
+                {"days": settings.arena_clip_retention_days},
+            )
+        else:
+            rows = await conn.execute(
+                f"SELECT {_BATTLE_COLS} FROM arena.battles ORDER BY random() LIMIT 1"  # noqa: S608
+            )
         row = await rows.fetchone()
     if row is None:
         raise HTTPException(404, "no battles available")

--- a/runner/src/coval_bench/api/routers/arena.py
+++ b/runner/src/coval_bench/api/routers/arena.py
@@ -19,6 +19,7 @@ recorded.
 
 from __future__ import annotations
 
+import asyncio
 import hmac
 import uuid
 from typing import Any
@@ -42,6 +43,7 @@ from coval_bench.api.schemas import (
     VoteIn,
     VoteOut,
 )
+from coval_bench.arena.audio_store import clip_url
 from coval_bench.arena.generate import generate_battle
 from coval_bench.arena.pairing import (
     PAIRING_DOMAIN,
@@ -103,11 +105,22 @@ def require_labeler(
         raise HTTPException(404)
 
 
+async def _battle_out(settings: Settings, row: dict[str, Any]) -> BattleOut:
+    """Resolve stored clip keys to fresh playable URLs (off the loop — GCS signing is I/O)."""
+    row = dict(row)
+    row["audio_a_url"], row["audio_b_url"] = await asyncio.gather(
+        asyncio.to_thread(clip_url, settings, row["audio_a_url"]),
+        asyncio.to_thread(clip_url, settings, row["audio_b_url"]),
+    )
+    return BattleOut.model_validate(row)
+
+
 @router.get("/arena/battle", response_model=BattleOut, dependencies=[Depends(require_labeler)])
 @limiter.limit("60/minute")
 async def get_battle(
     request: Request,  # required by slowapi
     pool: AsyncConnectionPool[Any] = Depends(get_pool),
+    settings: Settings = Depends(get_settings),
     posthog_client: Posthog | None = Depends(get_posthog),
 ) -> BattleOut:
     """Return one battle to vote on, chosen at random. 404 if none exist."""
@@ -126,7 +139,7 @@ async def get_battle(
         "arena_battle_served",
         {"$process_person_profile": False},
     )
-    return BattleOut.model_validate(row)
+    return await _battle_out(settings, row)
 
 
 @router.get(
@@ -139,6 +152,7 @@ async def get_battle_by_id(
     request: Request,  # required by slowapi
     battle_id: uuid.UUID,
     pool: AsyncConnectionPool[Any] = Depends(get_pool),
+    settings: Settings = Depends(get_settings),
 ) -> BattleOut:
     """Return a specific battle by id. 404 if not found (422 if id is not a UUID)."""
     async with pool.connection() as conn:
@@ -150,7 +164,7 @@ async def get_battle_by_id(
         row = await rows.fetchone()
     if row is None:
         raise HTTPException(404, f"battle {battle_id} not found")
-    return BattleOut.model_validate(row)
+    return await _battle_out(settings, row)
 
 
 @router.get(
@@ -284,7 +298,7 @@ async def create_battle(
         "arena_battle_generated",
         {"$process_person_profile": False},
     )
-    return BattleOut.model_validate(battle.model_dump())
+    return await _battle_out(settings, battle.model_dump())
 
 
 @router.get("/arena/battle/{battle_id}/reveal", response_model=RevealOut)

--- a/runner/src/coval_bench/api/routers/arena.py
+++ b/runner/src/coval_bench/api/routers/arena.py
@@ -166,10 +166,18 @@ async def get_battle_by_id(
     """Return a specific battle by id. 404 if not found (422 if id is not a UUID)."""
     async with pool.connection() as conn:
         conn.row_factory = psycopg.rows.dict_row
-        rows = await conn.execute(
-            f"SELECT {_BATTLE_COLS} FROM arena.battles WHERE id = %(id)s",  # noqa: S608
-            {"id": battle_id},
-        )
+        if settings.arena_gcs_bucket:
+            rows = await conn.execute(
+                f"SELECT {_BATTLE_COLS} FROM arena.battles "  # noqa: S608
+                "WHERE id = %(id)s "
+                "AND created_at >= now() - make_interval(days => %(days)s)",
+                {"id": battle_id, "days": settings.arena_clip_retention_days},
+            )
+        else:
+            rows = await conn.execute(
+                f"SELECT {_BATTLE_COLS} FROM arena.battles WHERE id = %(id)s",  # noqa: S608
+                {"id": battle_id},
+            )
         row = await rows.fetchone()
     if row is None:
         raise HTTPException(404, f"battle {battle_id} not found")

--- a/runner/src/coval_bench/arena/audio_store.py
+++ b/runner/src/coval_bench/arena/audio_store.py
@@ -1,12 +1,11 @@
 # Copyright 2026 The Coval Benchmarks Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Storage for generated arena clips: move a synthesized WAV into durable storage.
+"""Arena clip storage.
 
-Local-dir backend for dev; GCS backend for prod, selected by
-``settings.arena_gcs_bucket``. Keys are random and opaque so a served URL never
-reveals which model produced it (blind voting) — identity is recovered from
-``arena.battles``, never the filename.
+``store_clip`` stores a WAV under an opaque key and returns the key (kept on the battle
+row); ``clip_url`` turns a key into a playable URL at serve time — a fresh signed URL for
+GCS, so rows never serve stale links. Opaque keys keep voting blind.
 """
 
 from __future__ import annotations
@@ -31,61 +30,67 @@ def store_clip(
     *,
     storage_client: storage.Client | None = None,
 ) -> str:
-    """Consume a synthesized WAV into arena storage under a fresh opaque key; return its URL.
-
-    The source is a provider's temp WAV (``TTSResult.audio_path``); we own it once
-    synthesis returns, so it is consumed — moved locally, or uploaded then deleted.
-    With ``arena_gcs_bucket`` set the clip goes to GCS and a time-limited V4 signed
-    URL is returned (the bucket is private); otherwise it is stored under
-    ``arena_audio_dir`` and a root-relative (or ``arena_audio_base_url``-prefixed) URL
-    is returned.
-    """
+    """Consume a WAV into storage (GCS upload or local move); return its opaque key."""
     key = f"clips/{uuid.uuid4().hex}.wav"
     if settings.arena_gcs_bucket:
-        return _store_clip_gcs(settings.arena_gcs_bucket, key, src_path, storage_client)
+        _upload_gcs(settings.arena_gcs_bucket, key, src_path, storage_client)
+    else:
+        dest = settings.arena_audio_dir / key
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        shutil.move(str(src_path), dest)
+    return key
 
-    dest = settings.arena_audio_dir / key
-    dest.parent.mkdir(parents=True, exist_ok=True)
-    shutil.move(str(src_path), dest)
 
+def clip_url(
+    settings: Settings,
+    key: str,
+    *,
+    storage_client: storage.Client | None = None,
+) -> str:
+    """Build a playable URL for a key at serve time: a fresh signed URL for GCS, else local."""
+    if settings.arena_gcs_bucket:
+        return _signed_url(settings.arena_gcs_bucket, key, storage_client=storage_client)
     base = settings.arena_audio_base_url.rstrip("/")
     return f"{base}/{key}" if base else f"/{key}"
 
 
-def _store_clip_gcs(
+def _upload_gcs(
     bucket_name: str,
     key: str,
     src_path: Path,
     client: storage.Client | None,
-) -> str:
+) -> None:
     if client is None:
         from google.cloud import storage
 
         client = storage.Client()
     blob = client.bucket(bucket_name).blob(key)
     blob.upload_from_filename(str(src_path), content_type="audio/wav")
-    url = _signed_url(blob)
     src_path.unlink(missing_ok=True)
-    return url
 
 
-def _signed_url(blob: storage.Blob) -> str:
-    """V4 signed GET URL signed via the runtime SA's IAM SignBlob (no key file).
-
-    Cloud Run's default credentials carry no private key, so signing is delegated to
-    the IAM API using the SA's own token — this needs ``roles/iam.serviceAccounts.tokenCreator``
-    on the runtime SA.
-    """
+def _signed_url(
+    bucket_name: str,
+    key: str,
+    *,
+    storage_client: storage.Client | None = None,
+) -> str:
+    """Fresh V4 signed GET URL via the SA's IAM SignBlob (no key file; needs tokenCreator)."""
     import google.auth
     import google.auth.transport.requests
+
+    if storage_client is None:
+        from google.cloud import storage
+
+        storage_client = storage.Client()
+    blob = storage_client.bucket(bucket_name).blob(key)
 
     credentials, _ = google.auth.default()
     signer: Any = credentials
     if not hasattr(signer, "service_account_email"):
         raise RuntimeError(
             "Signing arena clip URLs requires service-account credentials with a "
-            "tokenCreator grant; got credentials without a service account. Set "
-            "arena_gcs_bucket only where the runtime SA is configured."
+            "tokenCreator grant; got credentials without a service account."
         )
     signer.refresh(google.auth.transport.requests.Request())
     url: str = blob.generate_signed_url(

--- a/runner/src/coval_bench/config.py
+++ b/runner/src/coval_bench/config.py
@@ -110,6 +110,7 @@ class Settings(BaseSettings):
     arena_audio_dir: Path = Path("arena-audio")
     arena_audio_base_url: str = ""
     arena_gcs_bucket: str = ""
+    # Must match the GCS bucket's object-deletion lifecycle (set in benchmark-infra).
     arena_clip_retention_days: int = 7
     arena_daily_battle_cap: int = 500
 

--- a/runner/src/coval_bench/config.py
+++ b/runner/src/coval_bench/config.py
@@ -110,6 +110,7 @@ class Settings(BaseSettings):
     arena_audio_dir: Path = Path("arena-audio")
     arena_audio_base_url: str = ""
     arena_gcs_bucket: str = ""
+    arena_clip_retention_days: int = 7
     arena_daily_battle_cap: int = 500
 
 

--- a/runner/tests/api/test_arena.py
+++ b/runner/tests/api/test_arena.py
@@ -191,6 +191,26 @@ async def test_get_battle_is_blind(client: AsyncClient, postgresql: Any) -> None
     assert data["domain"] == "support"
 
 
+async def test_get_battle_excludes_expired_clips(
+    client: AsyncClient, app: FastAPI, postgresql: Any
+) -> None:
+    """With GCS storage, a battle older than the clip retention is not served."""
+    await _apply_arena_schema(_make_db_url(postgresql))
+    battle_id = await _insert_battle(postgresql)
+    aconn = await psycopg.AsyncConnection.connect(_make_db_url(postgresql), autocommit=True)
+    try:
+        await aconn.execute(
+            "UPDATE arena.battles SET created_at = now() - interval '8 days' WHERE id = %(id)s",
+            {"id": battle_id},
+        )
+    finally:
+        await aconn.close()
+    app.state.settings = app.state.settings.model_copy(update={"arena_gcs_bucket": "b"})
+
+    response = await client.get("/v1/arena/battle", headers=_LABELER_HEADERS)
+    assert response.status_code == 404
+
+
 async def test_get_battle_by_id(client: AsyncClient, postgresql: Any) -> None:
     """GET /arena/battle/{id} returns the matching battle."""
     await _apply_arena_schema(_make_db_url(postgresql))

--- a/runner/tests/api/test_arena.py
+++ b/runner/tests/api/test_arena.py
@@ -221,6 +221,26 @@ async def test_get_battle_by_id(client: AsyncClient, postgresql: Any) -> None:
     assert response.json()["id"] == battle_id
 
 
+async def test_get_battle_by_id_excludes_expired_clip(
+    client: AsyncClient, app: FastAPI, postgresql: Any
+) -> None:
+    """With GCS storage, fetching a battle whose clip has expired returns 404."""
+    await _apply_arena_schema(_make_db_url(postgresql))
+    battle_id = await _insert_battle(postgresql)
+    aconn = await psycopg.AsyncConnection.connect(_make_db_url(postgresql), autocommit=True)
+    try:
+        await aconn.execute(
+            "UPDATE arena.battles SET created_at = now() - interval '8 days' WHERE id = %(id)s",
+            {"id": battle_id},
+        )
+    finally:
+        await aconn.close()
+    app.state.settings = app.state.settings.model_copy(update={"arena_gcs_bucket": "b"})
+
+    response = await client.get(f"/v1/arena/battle/{battle_id}", headers=_LABELER_HEADERS)
+    assert response.status_code == 404
+
+
 async def test_get_battle_by_id_unknown_returns_404(client: AsyncClient, postgresql: Any) -> None:
     """A well-formed but unknown UUID returns 404."""
     await _apply_arena_schema(_make_db_url(postgresql))

--- a/runner/tests/api/test_arena.py
+++ b/runner/tests/api/test_arena.py
@@ -555,7 +555,7 @@ async def test_create_battle_returns_blind_battle(
     await _apply_arena_schema(_make_db_url(postgresql))
     monkeypatch.setattr("coval_bench.arena.generate.TTS_PROVIDERS", _fake_tts_providers(set()))
     monkeypatch.setattr(
-        "coval_bench.arena.generate.store_clip", lambda settings, src: f"/clips/{src.name}"
+        "coval_bench.arena.generate.store_clip", lambda settings, src: f"clips/{src.name}"
     )
 
     response = await client.post(
@@ -593,7 +593,7 @@ async def test_create_battle_502_when_synthesis_fails(
         "coval_bench.arena.generate.TTS_PROVIDERS", _fake_tts_providers(every_model)
     )
     monkeypatch.setattr(
-        "coval_bench.arena.generate.store_clip", lambda settings, src: "/clips/x.wav"
+        "coval_bench.arena.generate.store_clip", lambda settings, src: "clips/x.wav"
     )
 
     response = await client.post(
@@ -677,7 +677,7 @@ async def test_create_battle_cap_disabled_when_zero(
     app.state.settings = app.state.settings.model_copy(update={"arena_daily_battle_cap": 0})
     monkeypatch.setattr("coval_bench.arena.generate.TTS_PROVIDERS", _fake_tts_providers(set()))
     monkeypatch.setattr(
-        "coval_bench.arena.generate.store_clip", lambda settings, src: f"/clips/{src.name}"
+        "coval_bench.arena.generate.store_clip", lambda settings, src: f"clips/{src.name}"
     )
 
     response = await client.post(

--- a/runner/tests/unit/test_arena_audio_store.py
+++ b/runner/tests/unit/test_arena_audio_store.py
@@ -1,7 +1,7 @@
 # Copyright 2026 The Coval Benchmarks Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Unit tests for arena clip storage (local-dir and GCS backends)."""
+"""Unit tests for arena clip storage: store_clip (key) and clip_url (serve-time URL)."""
 
 from __future__ import annotations
 
@@ -12,7 +12,7 @@ from typing import Any
 
 import pytest
 
-from coval_bench.arena.audio_store import store_clip
+from coval_bench.arena.audio_store import clip_url, store_clip
 from coval_bench.config import Settings
 
 
@@ -22,19 +22,79 @@ def _wav(tmp_path: Path) -> Path:
     return src
 
 
-def test_store_clip_local_root_relative(tmp_path: Path) -> None:
+# --- store_clip: returns an opaque key, consumes the source -----------------
+
+
+def test_store_clip_local_returns_key_and_moves_file(tmp_path: Path) -> None:
     settings = Settings(arena_audio_dir=tmp_path / "store")
-    url = store_clip(settings, _wav(tmp_path))
+    key = store_clip(settings, _wav(tmp_path))
 
-    assert url.startswith("/clips/") and url.endswith(".wav")
-    assert (settings.arena_audio_dir / url.lstrip("/")).is_file()
+    assert key.startswith("clips/") and key.endswith(".wav")
+    assert (settings.arena_audio_dir / key).is_file()
 
 
-def test_store_clip_local_base_url_prefix(tmp_path: Path) -> None:
-    settings = Settings(arena_audio_dir=tmp_path / "store", arena_audio_base_url="https://cdn.x/")
-    url = store_clip(settings, _wav(tmp_path))
+def test_store_clip_gcs_uploads_and_returns_key(tmp_path: Path) -> None:
+    blob = _FakeBlob()
+    client = _FakeClient(blob)
+    src = _wav(tmp_path)
+    settings = Settings(arena_gcs_bucket="coval-benchmarks-arena")
 
-    assert url.startswith("https://cdn.x/clips/")
+    key = store_clip(settings, src, storage_client=client)
+
+    assert key.startswith("clips/") and key.endswith(".wav")
+    assert client.bucket_name == "coval-benchmarks-arena"
+    assert client.bucket_obj.key == key
+    assert blob.uploaded_from == str(src)
+    assert blob.content_type == "audio/wav"
+    assert not src.exists()
+
+
+# --- clip_url: builds a playable URL at serve time --------------------------
+
+
+def test_clip_url_local_root_relative() -> None:
+    settings = Settings()
+    assert clip_url(settings, "clips/abc.wav") == "/clips/abc.wav"
+
+
+def test_clip_url_local_base_url_prefix() -> None:
+    settings = Settings(arena_audio_base_url="https://cdn.x/")
+    assert clip_url(settings, "clips/abc.wav") == "https://cdn.x/clips/abc.wav"
+
+
+def test_clip_url_gcs_signs_fresh(monkeypatch: pytest.MonkeyPatch) -> None:
+    creds = SimpleNamespace(
+        service_account_email="api-rt@proj.iam.gserviceaccount.com",
+        token="tok",  # noqa: S106 — fake credential token for the stubbed signer
+        refresh=lambda _request: None,
+    )
+    monkeypatch.setattr("google.auth.default", lambda: (creds, "proj"))
+    monkeypatch.setattr("google.auth.transport.requests.Request", lambda: object())
+
+    blob = _FakeBlob()
+    client = _FakeClient(blob)
+    settings = Settings(arena_gcs_bucket="coval-benchmarks-arena")
+
+    url = clip_url(settings, "clips/abc.wav", storage_client=client)
+
+    assert url == "https://signed.example/GET"
+    assert client.bucket_name == "coval-benchmarks-arena"
+    assert client.bucket_obj.key == "clips/abc.wav"
+    assert blob.signed_kwargs["version"] == "v4"
+    assert blob.signed_kwargs["expiration"] == timedelta(days=1)
+
+
+def test_clip_url_gcs_rejects_non_service_account_creds(monkeypatch: pytest.MonkeyPatch) -> None:
+    creds = SimpleNamespace(token="tok", refresh=lambda _request: None)  # noqa: S106 — fake user creds
+    monkeypatch.setattr("google.auth.default", lambda: (creds, "proj"))
+
+    settings = Settings(arena_gcs_bucket="coval-benchmarks-arena")
+
+    with pytest.raises(RuntimeError, match="service-account credentials"):
+        clip_url(settings, "clips/abc.wav", storage_client=_FakeClient(_FakeBlob()))
+
+
+# --- fakes ------------------------------------------------------------------
 
 
 class _FakeBlob:
@@ -70,29 +130,3 @@ class _FakeClient:
     def bucket(self, name: str) -> _FakeBucket:
         self.bucket_name = name
         return self.bucket_obj
-
-
-def test_store_clip_gcs_uploads_and_signs(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    creds = SimpleNamespace(
-        service_account_email="api-rt@proj.iam.gserviceaccount.com",
-        token="tok",  # noqa: S106 — fake credential token for the stubbed signer
-        refresh=lambda _request: None,
-    )
-    monkeypatch.setattr("google.auth.default", lambda: (creds, "proj"))
-    monkeypatch.setattr("google.auth.transport.requests.Request", lambda: object())
-
-    blob = _FakeBlob()
-    client = _FakeClient(blob)
-    src = _wav(tmp_path)
-    settings = Settings(arena_gcs_bucket="coval-benchmarks-arena")
-
-    url = store_clip(settings, src, storage_client=client)
-
-    assert url == "https://signed.example/GET"
-    assert client.bucket_name == "coval-benchmarks-arena"
-    assert client.bucket_obj.key is not None and client.bucket_obj.key.startswith("clips/")
-    assert blob.uploaded_from == str(src)
-    assert blob.content_type == "audio/wav"
-    assert blob.signed_kwargs["version"] == "v4"
-    assert blob.signed_kwargs["expiration"] == timedelta(days=1)
-    assert not src.exists()


### PR DESCRIPTION
Stacked on #186 (base `arena/gcs-audio-store`) — retarget to `main` once #186 merges.

Fixes the signed-URL expiry: #186 baked a 24h signed URL into the permanent battle row, but `GET /arena/battle` serves random rows with no recency filter, so a battle served >24h after generation handed out a dead link.

- `store_clip` now returns the opaque **key** (`clips/<uuid>.wav`) — stored on the row, never expires.
- `clip_url(settings, key)` builds the playable URL **at serve time** — a fresh signed URL for GCS, root-relative/CDN for local.
- `arena.py` resolves keys → URLs in all three battle returns via `_battle_out`, off the event loop (`to_thread` + `gather`).

So the URL's clock starts when the voter fetches, not at generation.

Known follow-up (separate): `GET /arena/battle` still selects from all rows including ones older than the bucket's 7-day retention (clip deleted) — needs a recency filter on selection.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Audio clips are now resolved at response time, so battle results include playable audio URLs consistently across endpoints.
  * A configurable clip retention window was added to limit which arena battles can be served.

* **Bug Fixes**
  * Expired battles are now hidden when cloud-backed audio storage is enabled.
  * Battle creation and lookup now return fresh audio links instead of stale stored paths.

* **Tests**
  * Added coverage for expired-battle handling and updated audio storage behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes stale signed-URL expiry by splitting the audio storage layer into two operations: `store_clip` (upload + return opaque key) and `clip_url` (generate fresh signed URL at serve time). A new `_battle_out` helper resolves keys → URLs for all three battle endpoints via `asyncio.to_thread` + `asyncio.gather`.

- `store_clip` now returns the storage key (`clips/<uuid>.wav`) instead of a baked signed URL; the key is what gets written to the DB row.
- `clip_url` is called at response time, generating a fresh 24-hour signed URL for GCS or a root-relative/CDN path for local storage.
- A `arena_clip_retention_days` config knob (default 7) guards both GET endpoints against serving battles whose GCS-backed audio has been lifecycle-deleted.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the core fix (key storage + serve-time signing) is correct and the retention filter is applied consistently across both GET endpoints.

The key/URL split is cleanly implemented, _battle_out correctly offloads blocking GCS calls off the event loop, and the SQL retention guard is parameterized safely. No logic errors were found in the changed paths.

runner/tests/api/test_arena.py — _insert_battle still seeds full URLs (https://example.test/a.wav) rather than opaque keys, so test rows are passed through clip_url as keys and produce mangled paths (/https://…) in local mode. Tests pass only because no existing test asserts on the audio URL values in GET responses.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| runner/src/coval_bench/arena/audio_store.py | Core split of store_clip (returns key) and clip_url (builds URL at serve time); _signed_url still creates a new Client and refreshes credentials on every call. |
| runner/src/coval_bench/api/routers/arena.py | _battle_out helper correctly offloads blocking clip_url calls to threads and parallelizes the two per-battle signing calls; retention filter applied consistently to both GET endpoints when arena_gcs_bucket is set. |
| runner/src/coval_bench/config.py | Adds arena_clip_retention_days int setting (default 7) with a comment tying it to the GCS bucket lifecycle; straightforward and safe. |
| runner/tests/api/test_arena.py | New expiry tests correctly verify 404 for both endpoints; _insert_battle still seeds full URLs rather than opaque keys, so test rows produce mangled paths through clip_url — existing tests pass only because none assert on audio URL values. |
| runner/tests/unit/test_arena_audio_store.py | Unit tests properly separated into store_clip (key assertions) and clip_url (URL assertions) sections; GCS signing test updated to call clip_url directly with a fake client; good coverage. |


<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant API as Arena API
    participant DB as arena.battles
    participant CU as clip_url
    participant IAM as GCS IAM

    Note over API,IAM: POST /arena/battle (create)
    Client->>API: POST /arena/battle
    API->>API: generate_battle store_clip returns key
    API->>DB: "INSERT audio_a_url = clips/uuid.wav"
    API->>CU: clip_url(settings, key)
    CU->>IAM: google.auth.default + refresh
    IAM-->>CU: credentials
    CU->>IAM: "generate_signed_url v4 TTL=1d"
    IAM-->>CU: signed URL
    CU-->>API: signed URL (fresh)
    API-->>Client: BattleOut with fresh signed URL

    Note over API,IAM: GET /arena/battle (serve)
    Client->>API: GET /arena/battle
    API->>DB: "SELECT WHERE created_at >= now()-retention LIMIT 1"
    DB-->>API: "row with audio_a_url = clips/uuid.wav"
    API->>CU: asyncio.gather to_thread clip_url x2
    CU->>IAM: sign clip A and clip B in parallel
    IAM-->>CU: two fresh signed URLs
    CU-->>API: resolved URLs
    API-->>Client: BattleOut with fresh signed URLs
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant API as Arena API
    participant DB as arena.battles
    participant CU as clip_url
    participant IAM as GCS IAM

    Note over API,IAM: POST /arena/battle (create)
    Client->>API: POST /arena/battle
    API->>API: generate_battle store_clip returns key
    API->>DB: "INSERT audio_a_url = clips/uuid.wav"
    API->>CU: clip_url(settings, key)
    CU->>IAM: google.auth.default + refresh
    IAM-->>CU: credentials
    CU->>IAM: "generate_signed_url v4 TTL=1d"
    IAM-->>CU: signed URL
    CU-->>API: signed URL (fresh)
    API-->>Client: BattleOut with fresh signed URL

    Note over API,IAM: GET /arena/battle (serve)
    Client->>API: GET /arena/battle
    API->>DB: "SELECT WHERE created_at >= now()-retention LIMIT 1"
    DB-->>API: "row with audio_a_url = clips/uuid.wav"
    API->>CU: asyncio.gather to_thread clip_url x2
    CU->>IAM: sign clip A and clip B in parallel
    IAM-->>CU: two fresh signed URLs
    CU-->>API: resolved URLs
    API-->>Client: BattleOut with fresh signed URLs
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `runner/tests/api/test_arena.py`, line 96-128 ([link](https://github.com/coval-ai/benchmarks/blob/37675161faea6167e03132a0e4c9de38a8e990fe/runner/tests/api/test_arena.py#L96-L128)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`_insert_battle` uses full URLs — read-path tests don't exercise key→URL resolution**

   `_insert_battle` seeds `audio_a_url`/`audio_b_url` with `"https://example.test/a.wav"`, which are now passed as-is to `clip_url()` by `_battle_out`. In the local (no GCS bucket) test environment `clip_url("https://example.test/a.wav")` returns `"/https://example.test/a.wav"` — a mangled, invalid URL. `test_get_battle_is_blind` and `test_get_battle_by_id` both pass only because neither asserts on the URL values.

   Consider seeding rows with bare keys (`"clips/abc.wav"`) and asserting that the response URL starts with `"/"` (or the expected CDN prefix), the same way `test_create_battle_returns_blind_battle` already checks `startswith("/clips/")`.

2. `runner/src/coval_bench/arena/audio_store.py`, line 88-102 ([link](https://github.com/coval-ai/benchmarks/blob/37675161faea6167e03132a0e4c9de38a8e990fe/runner/src/coval_bench/arena/audio_store.py#L88-L102)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Credentials refreshed unconditionally on every signing call**

   `google.auth.default()` is called and `signer.refresh()` is invoked on every execution of `_signed_url`. Google access tokens are typically valid for one hour; refreshing on each call means every `GET /arena/battle` makes two synchronous HTTP round-trips to the metadata service (one per clip) regardless of whether the current token is still valid.

   A lighter alternative is to check `credentials.valid` before refreshing — or hold credentials in a module-level or app-state cache and only refresh when they're about to expire — bringing the common path down to the one IAM SignBlob call that actually generates the URL.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (5): Last reviewed commit: ["Trigger CI"](https://github.com/coval-ai/benchmarks/commit/573daea3ed70dd925ef0700673e13758930e99f6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40132213)</sub>

<!-- /greptile_comment -->