### PR TITLE
Arena vote integrity: one vote per person + per-voter reveal

### DIFF
--- a/runner/src/coval_bench/api/routers/arena.py
+++ b/runner/src/coval_bench/api/routers/arena.py
@@ -292,19 +292,20 @@ async def create_battle(
 async def reveal_battle(
     request: Request,  # required by slowapi
     battle_id: uuid.UUID,
+    voter_id: str = Query(...),
     x_labeler_key: str | None = Header(default=None),
     pool: AsyncConnectionPool[Any] = Depends(get_pool),
     settings: Settings = Depends(get_settings),
 ) -> RevealOut:
-    """De-anonymize a battle's two sides. Labeler-only, and only after a vote exists."""
+    """De-anonymize a battle's two sides. Labeler-only, and only after this voter has voted."""
     if not _is_authenticated_labeler(x_labeler_key, settings):
         raise HTTPException(403, "reveal is not enabled")
     store = ArenaStore(pool)
     battle = await store.get_battle(battle_id)
     if battle is None:
         raise HTTPException(404, f"battle {battle_id} not found")
-    if not await store.list_votes(battle_id=battle_id, limit=1):
-        raise HTTPException(409, "battle has not been voted on yet")
+    if not await store.has_voted(battle_id=battle_id, voter_id=voter_id):
+        raise HTTPException(409, "you have not voted on this battle yet")
     return RevealOut(
         a=RevealModelOut(provider=battle.provider_a, model=battle.model_a, label=battle.model_a),
         b=RevealModelOut(provider=battle.provider_b, model=battle.model_b, label=battle.model_b),

--- a/runner/src/coval_bench/db/arena_store.py
+++ b/runner/src/coval_bench/db/arena_store.py
@@ -93,7 +93,7 @@ class ArenaStore:
             INSERT INTO arena.votes (battle_id, outcome, voter_type, voter_id)
             VALUES (%s, %s, %s, %s)
             ON CONFLICT (battle_id, voter_id)
-            DO UPDATE SET outcome = EXCLUDED.outcome
+            DO UPDATE SET outcome = EXCLUDED.outcome, voter_type = EXCLUDED.voter_type
             RETURNING id, battle_id, outcome, voter_type, voter_id,
                       created_at, updated_at
         """

--- a/runner/src/coval_bench/db/arena_store.py
+++ b/runner/src/coval_bench/db/arena_store.py
@@ -84,14 +84,15 @@ class ArenaStore:
     ) -> Vote:
         """Record a vote, or update the existing one for this identity.
 
-        The schema enforces one vote per ``(battle_id, voter_type, voter_id)``;
-        ``ON CONFLICT DO UPDATE`` turns a re-vote into an update of that row
-        (the ``BEFORE UPDATE`` trigger refreshes ``updated_at``).
+        The schema enforces one vote per ``(battle_id, voter_id)`` (one identity, one
+        current vote per battle, regardless of voter_type); ``ON CONFLICT DO UPDATE``
+        turns a re-vote into an update of that row (the ``BEFORE UPDATE`` trigger
+        refreshes ``updated_at``).
         """
         sql = """
             INSERT INTO arena.votes (battle_id, outcome, voter_type, voter_id)
             VALUES (%s, %s, %s, %s)
-            ON CONFLICT (battle_id, voter_type, voter_id)
+            ON CONFLICT (battle_id, voter_id)
             DO UPDATE SET outcome = EXCLUDED.outcome
             RETURNING id, battle_id, outcome, voter_type, voter_id,
                       created_at, updated_at
@@ -374,3 +375,13 @@ class ArenaStore:
             await cur.execute(sql, params)
             rows = await cur.fetchall()
         return [Vote.model_validate(dict(row)) for row in rows]
+
+    async def has_voted(self, *, battle_id: UUID, voter_id: str) -> bool:
+        """True if this voter already has a vote on this battle."""
+        sql = "SELECT 1 FROM arena.votes WHERE battle_id = %s AND voter_id = %s LIMIT 1"
+        async with (
+            self._pool.connection() as conn,
+            conn.cursor(row_factory=psycopg.rows.tuple_row) as cur,
+        ):
+            await cur.execute(sql, (battle_id, voter_id))
+            return await cur.fetchone() is not None

--- a/runner/src/coval_bench/db/migrations/versions/20260626_0008_arena_vote_dedup_per_person.py
+++ b/runner/src/coval_bench/db/migrations/versions/20260626_0008_arena_vote_dedup_per_person.py
@@ -20,6 +20,17 @@ depends_on = None
 
 def upgrade() -> None:
     op.execute("ALTER TABLE arena.votes DROP CONSTRAINT votes_battle_id_voter_type_voter_id_key")
+    # Collapse any pre-existing cross-type duplicates (same battle+voter, different
+    # voter_type) to the most recent row so the new unique constraint can be added.
+    op.execute(
+        """
+        DELETE FROM arena.votes v
+        USING arena.votes w
+        WHERE v.battle_id = w.battle_id
+          AND v.voter_id = w.voter_id
+          AND (v.updated_at, v.id) < (w.updated_at, w.id)
+        """
+    )
     op.execute(
         "ALTER TABLE arena.votes "
         "ADD CONSTRAINT votes_battle_id_voter_id_key UNIQUE (battle_id, voter_id)"

--- a/runner/src/coval_bench/db/migrations/versions/20260626_0008_arena_vote_dedup_per_person.py
+++ b/runner/src/coval_bench/db/migrations/versions/20260626_0008_arena_vote_dedup_per_person.py
@@ -1,0 +1,35 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Arena votes: dedup per identity, not per (identity, voter_type).
+
+Replace ``UNIQUE (battle_id, voter_type, voter_id)`` with ``UNIQUE (battle_id, voter_id)`` so
+one identity has at most one current vote per battle regardless of voter_type (a re-vote
+stays an UPDATE via ``ON CONFLICT``).
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "20260626_0008"
+down_revision = "20260615_0007"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE arena.votes DROP CONSTRAINT votes_battle_id_voter_type_voter_id_key")
+    op.execute(
+        "ALTER TABLE arena.votes "
+        "ADD CONSTRAINT votes_battle_id_voter_id_key UNIQUE (battle_id, voter_id)"
+    )
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE arena.votes DROP CONSTRAINT votes_battle_id_voter_id_key")
+    op.execute(
+        "ALTER TABLE arena.votes "
+        "ADD CONSTRAINT votes_battle_id_voter_type_voter_id_key "
+        "UNIQUE (battle_id, voter_type, voter_id)"
+    )

--- a/runner/tests/api/test_arena.py
+++ b/runner/tests/api/test_arena.py
@@ -50,7 +50,7 @@ async def _apply_arena_schema(dsn: str) -> None:
                 voter_id   TEXT NOT NULL,
                 created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
                 updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
-                UNIQUE (battle_id, voter_type, voter_id)
+                UNIQUE (battle_id, voter_id)
             )
         """)
         await aconn.execute("""
@@ -606,7 +606,7 @@ async def test_reveal_without_labeler_key_is_403(client: AsyncClient, postgresql
     """No labeler key -> 403, identities never returned."""
     await _apply_arena_schema(_make_db_url(postgresql))
     battle_id = await _insert_battle(postgresql)
-    response = await client.get(f"/v1/arena/battle/{battle_id}/reveal")
+    response = await client.get(f"/v1/arena/battle/{battle_id}/reveal?voter_id=ann-1")
     assert response.status_code == 403
 
 
@@ -614,7 +614,9 @@ async def test_reveal_before_vote_is_409(client: AsyncClient, postgresql: Any) -
     """A battle with no vote yet cannot be revealed."""
     await _apply_arena_schema(_make_db_url(postgresql))
     battle_id = await _insert_battle(postgresql)
-    response = await client.get(f"/v1/arena/battle/{battle_id}/reveal", headers=_LABELER_HEADERS)
+    response = await client.get(
+        f"/v1/arena/battle/{battle_id}/reveal?voter_id=ann-1", headers=_LABELER_HEADERS
+    )
     assert response.status_code == 409
 
 
@@ -622,14 +624,14 @@ async def test_reveal_unknown_battle_is_404(client: AsyncClient, postgresql: Any
     """A well-formed but unknown battle id returns 404."""
     await _apply_arena_schema(_make_db_url(postgresql))
     response = await client.get(
-        "/v1/arena/battle/00000000-0000-0000-0000-000000000000/reveal",
+        "/v1/arena/battle/00000000-0000-0000-0000-000000000000/reveal?voter_id=ann-1",
         headers=_LABELER_HEADERS,
     )
     assert response.status_code == 404
 
 
 async def test_reveal_after_vote_returns_identities(client: AsyncClient, postgresql: Any) -> None:
-    """Once a vote exists, reveal returns both sides' provider/model."""
+    """Once this voter has voted, reveal returns both sides' provider/model."""
     await _apply_arena_schema(_make_db_url(postgresql))
     battle_id = await _insert_battle(postgresql)
     await client.post(
@@ -637,13 +639,32 @@ async def test_reveal_after_vote_returns_identities(client: AsyncClient, postgre
         json={"battle_id": battle_id, "outcome": "A_WIN", "voter_id": "ann-1"},
         headers=_LABELER_HEADERS,
     )
-    response = await client.get(f"/v1/arena/battle/{battle_id}/reveal", headers=_LABELER_HEADERS)
+    response = await client.get(
+        f"/v1/arena/battle/{battle_id}/reveal?voter_id=ann-1", headers=_LABELER_HEADERS
+    )
     assert response.status_code == 200
     data = response.json()
     assert data["a"]["provider"] == "elevenlabs"
     assert data["a"]["model"] == "eleven_multilingual_v2"
     assert data["b"]["provider"] == "cartesia"
     assert data["b"]["model"] == "sonic-3"
+
+
+async def test_reveal_requires_the_requesting_voters_own_vote(
+    client: AsyncClient, postgresql: Any
+) -> None:
+    """A labeler who has not voted on this battle cannot reveal it, even if others have."""
+    await _apply_arena_schema(_make_db_url(postgresql))
+    battle_id = await _insert_battle(postgresql)
+    await client.post(
+        "/v1/arena/vote",
+        json={"battle_id": battle_id, "outcome": "A_WIN", "voter_id": "ann-1"},
+        headers=_LABELER_HEADERS,
+    )
+    response = await client.get(
+        f"/v1/arena/battle/{battle_id}/reveal?voter_id=ann-2", headers=_LABELER_HEADERS
+    )
+    assert response.status_code == 409
 
 
 async def test_create_battle_429_when_cap_reached(


### PR DESCRIPTION
Two per-voter correctness fixes for the arena, surfaced in #190 review. Independent of the GCS work (#186/#190).

Votes now dedup on `(battle_id, voter_id)` instead of `(battle_id, voter_type, voter_id)` (migration `0008` + matching `ON CONFLICT`), so one identity has one current vote per battle regardless of type; re-voting stays an UPDATE, and `voter_type` is kept so cohorts are still query-filterable.

Reveal now requires the requesting voter's own vote: `reveal_battle` takes `voter_id` and gates on a new `ArenaStore.has_voted(...)` instead of "any vote exists" — so a labeler can't unmask a battle off someone else's vote.

Out of scope (follow-ups): web BFF reveal route must pass `?voter_id=`; `voter_id` is caller-supplied (good-faith gate for trusted internal labelers, real enforcement needs per-voter auth); vote-endpoint recency filtering intentionally omitted.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR tightens arena vote integrity with two focused changes: the unique constraint on `arena.votes` is narrowed from `(battle_id, voter_type, voter_id)` to `(battle_id, voter_id)` so one identity can only hold one current vote per battle, and the `reveal_battle` endpoint now gates on the requesting voter's own vote rather than any vote existing on the battle.

- **Migration `0008`**: drops the old three-column constraint, runs a tiebreaker `DELETE` to collapse any pre-existing cross-type duplicate rows (keeping the most-recently-updated one), then adds the new two-column constraint. Both previously flagged issues — unsafe migration ordering and stale `voter_type` on re-vote — are now addressed; the `ON CONFLICT` clause also sets `voter_type = EXCLUDED.voter_type`.
- **`has_voted` + reveal gate**: a new `ArenaStore.has_voted(battle_id, voter_id)` method drives the 409 check, replacing the old "any vote exists" guard; tests cover the cross-voter blocking scenario explicitly.

<h3>Confidence Score: 5/5</h3>

Safe to merge — both previously flagged defects are fully corrected and all changed paths are covered by updated tests.

The migration now correctly deduplicates cross-type duplicate rows before adding the new constraint, removing the earlier unsafe ordering. The upsert also keeps voter_type in sync on re-vote. The reveal gate is tightened to the requesting voter's own record, with a new test confirming cross-voter blocking. No outstanding correctness issues in the changed code.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| runner/src/coval_bench/db/migrations/versions/20260626_0008_arena_vote_dedup_per_person.py | Adds migration 0008: drops old three-column unique constraint, deduplicates any cross-type duplicate rows via a tiebreaker DELETE, then adds new two-column constraint. Both the unsafe ordering and missing dedup issues from the prior review are resolved. Downgrade path is also safe. |
| runner/src/coval_bench/db/arena_store.py | ON CONFLICT clause updated to also set voter_type = EXCLUDED.voter_type (fixes previously flagged stale voter_type issue). New has_voted method provides a clean, parameterized lookup used by the reveal gate. |
| runner/src/coval_bench/api/routers/arena.py | reveal_battle now requires voter_id query param and delegates the reveal gate to has_voted; the old "any vote exists" check is replaced. The voter_id is caller-supplied (acknowledged intentional design for trusted internal labelers). |
| runner/tests/api/test_arena.py | All reveal tests updated to pass voter_id; new test test_reveal_requires_the_requesting_voters_own_vote covers the cross-voter blocking scenario; schema fixture updated to match new unique constraint. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant reveal_battle
    participant ArenaStore
    participant DB as arena.votes

    Client->>reveal_battle: "GET /reveal?voter_id=ann-1\n+ X-Labeler-Key"
    reveal_battle->>reveal_battle: _is_authenticated_labeler()
    alt not authenticated
        reveal_battle-->>Client: 403 Forbidden
    end
    reveal_battle->>ArenaStore: get_battle(battle_id)
    ArenaStore->>DB: "SELECT * FROM arena.battles WHERE id=?"
    DB-->>ArenaStore: battle row (or None)
    alt battle not found
        reveal_battle-->>Client: 404 Not Found
    end
    reveal_battle->>ArenaStore: "has_voted(battle_id, voter_id=ann-1)"
    ArenaStore->>DB: "SELECT 1 FROM arena.votes WHERE battle_id=? AND voter_id=ann-1"
    DB-->>ArenaStore: row (or None)
    alt voter has NOT voted
        reveal_battle-->>Client: 409 you have not voted on this battle yet
    end
    reveal_battle-->>Client: "200 RevealOut (provider/model for A & B)"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant reveal_battle
    participant ArenaStore
    participant DB as arena.votes

    Client->>reveal_battle: "GET /reveal?voter_id=ann-1\n+ X-Labeler-Key"
    reveal_battle->>reveal_battle: _is_authenticated_labeler()
    alt not authenticated
        reveal_battle-->>Client: 403 Forbidden
    end
    reveal_battle->>ArenaStore: get_battle(battle_id)
    ArenaStore->>DB: "SELECT * FROM arena.battles WHERE id=?"
    DB-->>ArenaStore: battle row (or None)
    alt battle not found
        reveal_battle-->>Client: 404 Not Found
    end
    reveal_battle->>ArenaStore: "has_voted(battle_id, voter_id=ann-1)"
    ArenaStore->>DB: "SELECT 1 FROM arena.votes WHERE battle_id=? AND voter_id=ann-1"
    DB-->>ArenaStore: row (or None)
    alt voter has NOT voted
        reveal_battle-->>Client: 409 you have not voted on this battle yet
    end
    reveal_battle-->>Client: "200 RevealOut (provider/model for A & B)"
```

</a>

<sub>Reviews (2): Last reviewed commit: ["Harden vote dedup migration and revote"](https://github.com/coval-ai/benchmarks/commit/f7fdcc8c345c5f85a0915b9e674d6bf168591db1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40155938)</sub>

<!-- /greptile_comment -->