### PR TITLE
Cut log noise from httpx and the run summary

### DIFF
--- a/runner/src/coval_bench/__main__.py
+++ b/runner/src/coval_bench/__main__.py
@@ -56,7 +56,7 @@ def run(kind: str, smoke: bool) -> None:
     summary: RunSummary = asyncio.run(
         run_benchmarks(settings=settings, benchmark_kind=kind, smoke=smoke)  # type: ignore[arg-type]
     )
-    click.echo(summary.model_dump_json(indent=2))
+    click.echo(summary.model_dump_json())
     if summary.status == str(RunStatus.FAILED):
         raise click.ClickException("run failed")
 

--- a/runner/src/coval_bench/logging.py
+++ b/runner/src/coval_bench/logging.py
@@ -66,6 +66,9 @@ def configure_logging(
         level=log_level,
     )
 
+    for noisy in ("httpx", "httpcore"):
+        logging.getLogger(noisy).setLevel(max(log_level, logging.WARNING))
+
 
 def uvicorn_log_config(level: LogLevel = "INFO") -> dict[str, Any]:
     """Return a uvicorn ``log_config`` that renders uvicorn's logs as JSON.

--- a/runner/src/coval_bench/providers/stt/gladia.py
+++ b/runner/src/coval_bench/providers/stt/gladia.py
@@ -93,7 +93,9 @@ class GladiaSTTProvider(STTProvider):
                     result.error = str(send_outcome[0])
 
         except Exception as exc:
-            logger.exception("gladia_measure_ttft_failed", error=str(exc))
+            logger.warning(
+                "gladia_measure_ttft_failed", provider="gladia", model=self._model, exc_info=exc
+            )
             result.error = str(exc)
 
         result.total_time = time.monotonic() - total_start
@@ -142,7 +144,7 @@ class GladiaSTTProvider(STTProvider):
             # Stop streaming; the server flushes pending finals and closes (1000).
             await ws.send(json.dumps({"type": "stop_recording"}))
         except Exception as exc:
-            logger.exception("gladia_send_error", error=str(exc))
+            logger.warning("gladia_send_error", provider="gladia", model=self._model, exc_info=exc)
             raise
 
     async def _receive(self, ws: Any, result: TranscriptionResult) -> None:
@@ -159,7 +161,9 @@ class GladiaSTTProvider(STTProvider):
 
                 if msg_type == "error":
                     result.error = str(msg.get("message") or msg.get("error") or msg)
-                    logger.error("gladia_stt_error", msg=msg)
+                    logger.warning(
+                        "gladia_stt_error", provider="gladia", model=self._model, msg=msg
+                    )
                     break
 
                 if msg_type != "transcript":
@@ -179,7 +183,9 @@ class GladiaSTTProvider(STTProvider):
                         result.audio_to_final_seconds = now - result.audio_start_time
 
         except Exception as exc:
-            logger.exception("gladia_receive_error", error=str(exc))
+            logger.warning(
+                "gladia_receive_error", provider="gladia", model=self._model, exc_info=exc
+            )
             if result.error is None:
                 result.error = str(exc)
 


### PR DESCRIPTION
Silence httpx per-request INFO lines, emit the run summary as single-line JSON, and align Gladia STT failures to WARNING.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved logging behavior so low-severity messages from network libraries no longer clutter output when quieter log levels are selected.
  * Updated error reporting to use more consistent warning-level log entries with richer context for speech-to-text failures.

* **Style**
  * Changed run command JSON output to compact formatting, reducing unnecessary whitespace in stdout while keeping the same content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR reduces log noise by silencing `httpx`/`httpcore` per-request INFO lines, compacting the run summary to single-line JSON, and downgrading all Gladia STT failure logs from ERROR/exception to WARNING with added `provider` and `model` context fields.

- `logging.py` pins the `httpx` and `httpcore` stdlib loggers to `max(log_level, WARNING)` immediately after `basicConfig`, ensuring they stay quiet even when the root level is DEBUG or INFO.
- `gladia.py` converts four `logger.exception` / `logger.error` call sites to `logger.warning(..., exc_info=exc)`; tracebacks are preserved via structlog's `format_exc_info` processor, and contextual fields are added uniformly.
- `__main__.py` drops `indent=2` from `model_dump_json()` so the run summary is one compact line, consistent with the rest of the CLI's JSON output.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the changes are contained to logging configuration and do not touch business logic or data paths.

The httpx silencing and compact-JSON changes are straightforward and correct. The one thing worth a second look is that all four Gladia exception handlers now emit WARNING regardless of cause — a transient transcript error and a complete auth/network failure look identical in the logs, which could make production incidents harder to detect if monitoring is keyed on ERROR events.

runner/src/coval_bench/providers/stt/gladia.py — verify that the uniform WARNING level for all Gladia failure paths aligns with your alerting thresholds.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| runner/src/coval_bench/__main__.py | Drops `indent=2` from `model_dump_json()` so the run summary is emitted as compact single-line JSON; no logic change. |
| runner/src/coval_bench/logging.py | Pins `httpx` and `httpcore` stdlib loggers to at least WARNING after `basicConfig`, correctly using `max(log_level, logging.WARNING)` so stricter root levels are respected. |
| runner/src/coval_bench/providers/stt/gladia.py | Replaces all four `logger.exception` / `logger.error` calls with `logger.warning(..., exc_info=exc)` and adds `provider`/`model` context; traceback is preserved but all failures are now uniformly WARNING. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[configure_logging called] --> B[structlog.configure - JSON pipeline]
    B --> C[logging.basicConfig - root handler at log_level]
    C --> D["for httpx, httpcore:\nsetLevel(max(log_level, WARNING))"]
    D --> E[httpx/httpcore silenced >= WARNING]

    F[GladiaSTTProvider.measure_ttft] --> G{Exception?}
    G -- yes --> H["logger.warning(gladia_measure_ttft_failed)"]
    H --> I[result.error = str exc]

    F --> J[_send_audio]
    J --> K{Exception?}
    K -- yes --> L["logger.warning(gladia_send_error)"]
    L --> M[raise - captured by gather]

    F --> N[_receive]
    N --> O{msg_type == error?}
    O -- yes --> P["logger.warning(gladia_stt_error)"]
    N --> Q{Exception?}
    Q -- yes --> R["logger.warning(gladia_receive_error)"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[configure_logging called] --> B[structlog.configure - JSON pipeline]
    B --> C[logging.basicConfig - root handler at log_level]
    C --> D["for httpx, httpcore:\nsetLevel(max(log_level, WARNING))"]
    D --> E[httpx/httpcore silenced >= WARNING]

    F[GladiaSTTProvider.measure_ttft] --> G{Exception?}
    G -- yes --> H["logger.warning(gladia_measure_ttft_failed)"]
    H --> I[result.error = str exc]

    F --> J[_send_audio]
    J --> K{Exception?}
    K -- yes --> L["logger.warning(gladia_send_error)"]
    L --> M[raise - captured by gather]

    F --> N[_receive]
    N --> O{msg_type == error?}
    O -- yes --> P["logger.warning(gladia_stt_error)"]
    N --> Q{Exception?}
    Q -- yes --> R["logger.warning(gladia_receive_error)"]
```

</a>

<sub>Reviews (1): Last reviewed commit: ["Cut log noise from httpx and the run sum..."](https://github.com/coval-ai/benchmarks/commit/629fde6604827a17da0cf8f9edecba22dcff6bde) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40178493)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->