### PR TITLE
Add pending status for new models

### DIFF
--- a/runner/src/coval_bench/api/routers/providers.py
+++ b/runner/src/coval_bench/api/routers/providers.py
@@ -7,8 +7,8 @@ The catalogue is sourced from the model registry
 (``coval_bench.registries.MODEL_REGISTRY``) — the same source of truth the
 orchestrator runs from, so the website can never drift from the runner's
 reality. Every registered model is exposed; ``disabled`` is true for
-``RETIRED`` models so the frontend keeps them off the site even when
-historical result rows exist.
+``RETIRED`` and ``PENDING`` models so the frontend keeps them off the site
+even when historical result rows exist.
 
 No DB hit is made by this endpoint.
 """
@@ -29,6 +29,8 @@ logger = structlog.get_logger("coval_bench.api")
 
 router = APIRouter(tags=["providers"])
 
+_HIDDEN_STATUSES = frozenset({ModelStatus.RETIRED, ModelStatus.PENDING})
+
 
 def _build_provider_map(benchmark: Benchmark) -> dict[str, list[ModelInfo]]:
     """Build an ordered {provider: [ModelInfo, ...]} map from the model registry.
@@ -41,7 +43,7 @@ def _build_provider_map(benchmark: Benchmark) -> dict[str, list[ModelInfo]]:
     for m in MODEL_REGISTRY:
         if m.benchmark is benchmark:
             result.setdefault(m.provider, []).append(
-                ModelInfo(model=m.model, disabled=m.status is ModelStatus.RETIRED)
+                ModelInfo(model=m.model, disabled=m.status in _HIDDEN_STATUSES)
             )
     return result
 

--- a/runner/src/coval_bench/registries/models.py
+++ b/runner/src/coval_bench/registries/models.py
@@ -4,8 +4,8 @@
 
 One entry per model, keyed by ``(benchmark, provider, model)``. The
 orchestrator runs every ``ACTIVE`` entry; the API serves all entries and
-marks ``RETIRED`` ones disabled so the frontend keeps them off the site
-even when historical result rows exist for them.
+marks ``RETIRED`` and ``PENDING`` ones disabled so the frontend keeps them
+off the site even when historical result rows exist for them.
 """
 
 from __future__ import annotations
@@ -25,6 +25,7 @@ class ModelStatus(StrEnum):
     ACTIVE = "active"  # benchmarked and shown
     PAUSED = "paused"  # shown, not currently benchmarked
     RETIRED = "retired"  # not benchmarked, hidden even if old data exists
+    PENDING = "pending"  # implemented but waiting on credits; hidden like retired
 
 
 class RegisteredModel(BaseModel, frozen=True):
@@ -43,6 +44,7 @@ _STT = Benchmark.STT
 _TTS = Benchmark.TTS
 _ACTIVE = ModelStatus.ACTIVE
 _RETIRED = ModelStatus.RETIRED
+_PENDING = ModelStatus.PENDING
 
 # Per-benchmark order is the model order /v1/providers returns.
 MODEL_REGISTRY: list[RegisteredModel] = [
@@ -74,7 +76,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
     RegisteredModel(benchmark=_STT, provider="speechmatics", model="default", status=_ACTIVE),
     RegisteredModel(benchmark=_STT, provider="speechmatics", model="enhanced", status=_ACTIVE),
     RegisteredModel(benchmark=_STT, provider="gradium", model="default", status=_ACTIVE),
-    RegisteredModel(benchmark=_STT, provider="gladia", model="solaria-1", status=_RETIRED),
+    RegisteredModel(benchmark=_STT, provider="gladia", model="solaria-1", status=_PENDING),
     RegisteredModel(benchmark=_STT, provider="soniox", model="stt-rt-v4", status=_ACTIVE),
     RegisteredModel(benchmark=_STT, provider="soniox", model="stt-rt-v5", status=_ACTIVE),
     RegisteredModel(benchmark=_STT, provider="xai", model="grok-stt", status=_ACTIVE),
@@ -178,14 +180,14 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         provider="inworld",
         model="inworld-tts-1.5-max",
         voice="Ashley",
-        status=_RETIRED,
+        status=_PENDING,
     ),
     RegisteredModel(
         benchmark=_TTS,
         provider="inworld",
         model="inworld-tts-1.5-mini",
         voice="Ashley",
-        status=_RETIRED,
+        status=_PENDING,
     ),
     RegisteredModel(
         benchmark=_TTS, provider="soniox", model="tts-rt-v1", voice="Adrian", status=_ACTIVE
@@ -195,7 +197,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         provider="groq",
         model="canopylabs/orpheus-v1-english",
         voice="autumn",
-        status=_RETIRED,
+        status=_PENDING,
     ),
     # gpt-realtime is a speech-to-speech LLM, not a TTS provider: driving it
     # from a text "instructions" prompt folds LLM inference into TTFA and never


### PR DESCRIPTION
- Makes it easy to add a model that we don't yet have credits for.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new model status, **Pending**, alongside existing statuses.
* **Bug Fixes**
  * Models marked as **Pending** or **Retired** are now hidden from the provider/model list.
  * Updated several model entries to reflect their current visibility status in the catalog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a `PENDING` status for models that are implemented but awaiting API credits, keeping them hidden on the frontend identically to `RETIRED` while distinguishing their intent in the registry. Four models (`gladia/solaria-1`, `inworld/inworld-tts-1.5-max`, `inworld/inworld-tts-1.5-mini`, `groq/canopylabs/orpheus-v1-english`) are migrated from `RETIRED` to `PENDING`.

- Adds `ModelStatus.PENDING` to the `StrEnum` with a clear inline comment, alongside a `_PENDING` shorthand alias consistent with `_ACTIVE` and `_RETIRED`.
- Introduces `_HIDDEN_STATUSES = frozenset({ModelStatus.RETIRED, ModelStatus.PENDING})` in the router, replacing the single-enum identity check with an `in`-membership check — correctly handled since the orchestrator and arena pairing already exclude non-`ACTIVE` models with no changes needed there.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is narrow, additive, and the new status slot behaves correctly at every consumer.

The new PENDING status is fully consistent with how RETIRED is already handled: the orchestrator and arena pairing both filter exclusively on ACTIVE, so no new exclusion logic is needed there. The router's _HIDDEN_STATUSES frozenset correctly gates the disabled flag for the frontend. The four model migrations from RETIRED to PENDING produce identical observable behavior (hidden, not benchmarked) while accurately reflecting their real state.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| runner/src/coval_bench/registries/models.py | Adds PENDING to ModelStatus enum with a clear comment; adds _PENDING alias; migrates 4 models (gladia STT, inworld TTS x2, groq TTS) from RETIRED to PENDING. The duplicate-key guard at module load still validates correctly. |
| runner/src/coval_bench/api/routers/providers.py | Introduces _HIDDEN_STATUSES frozenset and replaces the single-enum identity check with an in-membership check. Docstring updated to match. Logic is correct and robust. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[GET /v1/providers] --> B[_build_provider_map]
    B --> C{for each model in MODEL_REGISTRY}
    C --> D{m.status in _HIDDEN_STATUSES?}
    D -- "RETIRED or PENDING" --> E["ModelInfo(disabled=True)"]
    D -- "ACTIVE or PAUSED" --> F["ModelInfo(disabled=False)"]
    E --> G[Included in response - frontend hides it]
    F --> H[Included in response - frontend shows it]
    G --> I[ProvidersResponse]
    H --> I

    subgraph Orchestrator
        J{e.status is ACTIVE?}
        J -- Yes --> K[Benchmarked and run]
        J -- No --> L[Skipped — PAUSED / RETIRED / PENDING]
    end

    style E fill:#f9c,stroke:#a00
    style G fill:#f9c,stroke:#a00
    style K fill:#cfc,stroke:#060
    style L fill:#eee,stroke:#999
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[GET /v1/providers] --> B[_build_provider_map]
    B --> C{for each model in MODEL_REGISTRY}
    C --> D{m.status in _HIDDEN_STATUSES?}
    D -- "RETIRED or PENDING" --> E["ModelInfo(disabled=True)"]
    D -- "ACTIVE or PAUSED" --> F["ModelInfo(disabled=False)"]
    E --> G[Included in response - frontend hides it]
    F --> H[Included in response - frontend shows it]
    G --> I[ProvidersResponse]
    H --> I

    subgraph Orchestrator
        J{e.status is ACTIVE?}
        J -- Yes --> K[Benchmarked and run]
        J -- No --> L[Skipped — PAUSED / RETIRED / PENDING]
    end

    style E fill:#f9c,stroke:#a00
    style G fill:#f9c,stroke:#a00
    style K fill:#cfc,stroke:#060
    style L fill:#eee,stroke:#999
```

</a>

<sub>Reviews (1): Last reviewed commit: ["Add pending status for new models"](https://github.com/coval-ai/benchmarks/commit/d4fbd0fd4479783f6f1f5414308d1f976cdcfd08) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40184263)</sub>

<!-- /greptile_comment -->