### PR TITLE
Add category based filtering

### DIFF
--- a/runner/src/coval_bench/api/routers/providers.py
+++ b/runner/src/coval_bench/api/routers/providers.py
@@ -22,14 +22,34 @@ from starlette.requests import Request
 
 from coval_bench.api.deps import capture_api_event, get_posthog
 from coval_bench.api.ratelimit import limiter
-from coval_bench.api.schemas import ModelInfo, ProviderInfo, ProvidersResponse
-from coval_bench.registries import MODEL_REGISTRY, Benchmark, ModelStatus
+from coval_bench.api.schemas import ModelInfo, ModelTagOut, ProviderInfo, ProvidersResponse
+from coval_bench.registries import (
+    MODEL_REGISTRY,
+    TAG_CATEGORIES,
+    Benchmark,
+    ModelStatus,
+    RegisteredModel,
+    TagCategory,
+)
 
 logger = structlog.get_logger("coval_bench.api")
 
 router = APIRouter(tags=["providers"])
 
 _HIDDEN_STATUSES = frozenset({ModelStatus.RETIRED, ModelStatus.PENDING})
+
+
+def _model_tags(m: RegisteredModel) -> list[ModelTagOut]:
+    """Flatten a model's facets: derived columns/attributes plus curated tags."""
+    source = "inference" if m.creator and m.creator != m.provider else "original"
+    return [
+        ModelTagOut(category=TagCategory.TYPE, value=m.benchmark),
+        ModelTagOut(category=TagCategory.HOST, value=m.provider),
+        ModelTagOut(category=TagCategory.LAB, value=m.creator or m.provider),
+        ModelTagOut(category=TagCategory.SOURCE, value=source),
+        ModelTagOut(category=TagCategory.TENANCY, value=m.tenancy),
+        *(ModelTagOut(category=TAG_CATEGORIES[t], value=t) for t in m.tags),
+    ]
 
 
 def _build_provider_map(benchmark: Benchmark) -> dict[str, list[ModelInfo]]:
@@ -43,7 +63,11 @@ def _build_provider_map(benchmark: Benchmark) -> dict[str, list[ModelInfo]]:
     for m in MODEL_REGISTRY:
         if m.benchmark is benchmark:
             result.setdefault(m.provider, []).append(
-                ModelInfo(model=m.model, disabled=m.status in _HIDDEN_STATUSES)
+                ModelInfo(
+                    model=m.model,
+                    disabled=m.status in _HIDDEN_STATUSES,
+                    tags=_model_tags(m),
+                )
             )
     return result
 

--- a/runner/src/coval_bench/api/schemas.py
+++ b/runner/src/coval_bench/api/schemas.py
@@ -71,11 +71,19 @@ class LeaderboardEntry(BaseModel):
     n: int
 
 
+class ModelTagOut(BaseModel):
+    """A faceted filter tag: its category and value (e.g. capability/realtime)."""
+
+    category: str
+    value: str
+
+
 class ModelInfo(BaseModel):
     """A single model entry under a provider, with admin-disabled flag."""
 
     model: str
     disabled: bool = False
+    tags: list[ModelTagOut] = []
 
 
 class ProviderInfo(BaseModel):

--- a/runner/src/coval_bench/registries/__init__.py
+++ b/runner/src/coval_bench/registries/__init__.py
@@ -13,7 +13,12 @@ from coval_bench.registries.metrics import (
     MetricDirection,
     MetricSpec,
 )
-from coval_bench.registries.models import MODEL_REGISTRY, ModelStatus, RegisteredModel
+from coval_bench.registries.models import (
+    MODEL_REGISTRY,
+    ModelStatus,
+    RegisteredModel,
+    Tenancy,
+)
 from coval_bench.registries.tags import TAG_CATEGORIES, ModelTag, TagCategory
 
 __all__ = [
@@ -25,6 +30,7 @@ __all__ = [
     "MetricSpec",
     "ModelStatus",
     "RegisteredModel",
+    "Tenancy",
     "TAG_CATEGORIES",
     "ModelTag",
     "TagCategory",

--- a/runner/src/coval_bench/registries/models.py
+++ b/runner/src/coval_bench/registries/models.py
@@ -53,53 +53,184 @@ _TTS = Benchmark.TTS
 _ACTIVE = ModelStatus.ACTIVE
 _RETIRED = ModelStatus.RETIRED
 _PENDING = ModelStatus.PENDING
+_REALTIME = ModelTag.REALTIME
+_BATCH = ModelTag.BATCH
+_MULTI = ModelTag.MULTILINGUAL
+_VAD = ModelTag.VAD
 
 # Per-benchmark order is the model order /v1/providers returns.
 MODEL_REGISTRY: list[RegisteredModel] = [
     #######
     # STT #
     #######
-    RegisteredModel(benchmark=_STT, provider="deepgram", model="nova-2", status=_ACTIVE),
-    RegisteredModel(benchmark=_STT, provider="deepgram", model="nova-3", status=_ACTIVE),
-    RegisteredModel(benchmark=_STT, provider="deepgram", model="flux-general-en", status=_ACTIVE),
     RegisteredModel(
-        benchmark=_STT, provider="deepgram", model="flux-general-multi", status=_ACTIVE
+        benchmark=_STT,
+        provider="deepgram",
+        model="nova-2",
+        tags=(_REALTIME, _MULTI, _VAD),
+        status=_ACTIVE,
     ),
     RegisteredModel(
-        benchmark=_STT, provider="elevenlabs", model="scribe_v2_realtime", status=_ACTIVE
+        benchmark=_STT,
+        provider="deepgram",
+        model="nova-3",
+        tags=(_REALTIME, _MULTI, _VAD),
+        status=_ACTIVE,
     ),
     RegisteredModel(
-        benchmark=_STT, provider="openai", model="gpt-realtime-whisper", status=_ACTIVE
+        benchmark=_STT,
+        provider="deepgram",
+        model="flux-general-en",
+        tags=(_REALTIME, _VAD),
+        status=_ACTIVE,
     ),
-    RegisteredModel(benchmark=_STT, provider="openai", model="gpt-4o-transcribe", status=_ACTIVE),
     RegisteredModel(
-        benchmark=_STT, provider="openai", model="gpt-4o-mini-transcribe", status=_ACTIVE
+        benchmark=_STT,
+        provider="deepgram",
+        model="flux-general-multi",
+        tags=(_REALTIME, _MULTI, _VAD),
+        status=_ACTIVE,
     ),
     RegisteredModel(
-        benchmark=_STT, provider="assemblyai", model="universal-streaming", status=_ACTIVE
+        benchmark=_STT,
+        provider="elevenlabs",
+        model="scribe_v2_realtime",
+        tags=(_REALTIME, _MULTI, _VAD),
+        status=_ACTIVE,
+    ),
+    RegisteredModel(
+        benchmark=_STT,
+        provider="openai",
+        model="gpt-realtime-whisper",
+        tags=(_REALTIME, _MULTI),
+        status=_ACTIVE,
+    ),
+    RegisteredModel(
+        benchmark=_STT,
+        provider="openai",
+        model="gpt-4o-transcribe",
+        tags=(_REALTIME, _MULTI, _VAD),
+        status=_ACTIVE,
+    ),
+    RegisteredModel(
+        benchmark=_STT,
+        provider="openai",
+        model="gpt-4o-mini-transcribe",
+        tags=(_REALTIME, _MULTI, _VAD),
+        status=_ACTIVE,
+    ),
+    RegisteredModel(
+        benchmark=_STT,
+        provider="assemblyai",
+        model="universal-streaming",
+        tags=(_REALTIME, _VAD),
+        status=_ACTIVE,
     ),
     RegisteredModel(
         benchmark=_STT,
         provider="assemblyai",
         model="universal-streaming-multilingual",
+        tags=(_REALTIME, _MULTI, _VAD),
         status=_ACTIVE,
     ),
     RegisteredModel(
-        benchmark=_STT, provider="assemblyai", model="universal-3.5-pro", status=_ACTIVE
+        benchmark=_STT,
+        provider="assemblyai",
+        model="universal-3.5-pro",
+        tags=(_REALTIME, _MULTI, _VAD),
+        status=_ACTIVE,
     ),
-    RegisteredModel(benchmark=_STT, provider="speechmatics", model="default", status=_ACTIVE),
-    RegisteredModel(benchmark=_STT, provider="speechmatics", model="enhanced", status=_ACTIVE),
-    RegisteredModel(benchmark=_STT, provider="gradium", model="default", status=_ACTIVE),
-    RegisteredModel(benchmark=_STT, provider="gladia", model="solaria-1", status=_PENDING),
-    RegisteredModel(benchmark=_STT, provider="soniox", model="stt-rt-v4", status=_ACTIVE),
-    RegisteredModel(benchmark=_STT, provider="soniox", model="stt-rt-v5", status=_ACTIVE),
-    RegisteredModel(benchmark=_STT, provider="xai", model="grok-stt", status=_ACTIVE),
-    RegisteredModel(benchmark=_STT, provider="smallest", model="pulse", status=_ACTIVE),
-    RegisteredModel(benchmark=_STT, provider="cartesia", model="ink-2", status=_ACTIVE),
-    RegisteredModel(benchmark=_STT, provider="google", model="short", status=_RETIRED),
-    RegisteredModel(benchmark=_STT, provider="google", model="long", status=_RETIRED),
-    RegisteredModel(benchmark=_STT, provider="google", model="telephony", status=_RETIRED),
-    RegisteredModel(benchmark=_STT, provider="google", model="chirp_2", status=_RETIRED),
+    RegisteredModel(
+        benchmark=_STT,
+        provider="speechmatics",
+        model="default",
+        tags=(_REALTIME, _MULTI, _VAD),
+        status=_ACTIVE,
+    ),
+    RegisteredModel(
+        benchmark=_STT,
+        provider="speechmatics",
+        model="enhanced",
+        tags=(_REALTIME, _MULTI, _VAD),
+        status=_ACTIVE,
+    ),
+    RegisteredModel(
+        benchmark=_STT,
+        provider="gradium",
+        model="default",
+        tags=(_REALTIME, _MULTI, _VAD),
+        status=_ACTIVE,
+    ),
+    RegisteredModel(
+        benchmark=_STT,
+        provider="gladia",
+        model="solaria-1",
+        tags=(_REALTIME, _MULTI, _VAD),
+        status=_PENDING,
+    ),
+    RegisteredModel(
+        benchmark=_STT,
+        provider="soniox",
+        model="stt-rt-v4",
+        tags=(_REALTIME, _MULTI, _VAD),
+        status=_ACTIVE,
+    ),
+    RegisteredModel(
+        benchmark=_STT,
+        provider="soniox",
+        model="stt-rt-v5",
+        tags=(_REALTIME, _MULTI, _VAD),
+        status=_ACTIVE,
+    ),
+    RegisteredModel(
+        benchmark=_STT,
+        provider="xai",
+        model="grok-stt",
+        tags=(_REALTIME, _MULTI, _VAD),
+        status=_ACTIVE,
+    ),
+    RegisteredModel(
+        benchmark=_STT,
+        provider="smallest",
+        model="pulse",
+        tags=(_REALTIME, _MULTI, _VAD),
+        status=_ACTIVE,
+    ),
+    RegisteredModel(
+        benchmark=_STT,
+        provider="cartesia",
+        model="ink-2",
+        tags=(_REALTIME, _VAD),
+        status=_ACTIVE,
+    ),
+    RegisteredModel(
+        benchmark=_STT,
+        provider="google",
+        model="short",
+        tags=(_BATCH, _MULTI),
+        status=_RETIRED,
+    ),
+    RegisteredModel(
+        benchmark=_STT,
+        provider="google",
+        model="long",
+        tags=(_BATCH, _MULTI),
+        status=_RETIRED,
+    ),
+    RegisteredModel(
+        benchmark=_STT,
+        provider="google",
+        model="telephony",
+        tags=(_REALTIME, _MULTI, _VAD),
+        status=_RETIRED,
+    ),
+    RegisteredModel(
+        benchmark=_STT,
+        provider="google",
+        model="chirp_2",
+        tags=(_REALTIME, _MULTI, _VAD),
+        status=_RETIRED,
+    ),
     #######
     # TTS #
     #######
@@ -108,6 +239,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         provider="elevenlabs",
         model="eleven_flash_v2_5",
         voice="IKne3meq5aSn9XLyUdCD",
+        tags=(_REALTIME, _MULTI),
         status=_ACTIVE,
     ),
     RegisteredModel(
@@ -115,6 +247,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         provider="elevenlabs",
         model="eleven_multilingual_v2",
         voice="IKne3meq5aSn9XLyUdCD",
+        tags=(_REALTIME, _MULTI),
         status=_ACTIVE,
     ),
     RegisteredModel(
@@ -122,22 +255,39 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         provider="elevenlabs",
         model="eleven_turbo_v2_5",
         voice="IKne3meq5aSn9XLyUdCD",
+        tags=(_REALTIME, _MULTI),
         status=_RETIRED,
     ),
     RegisteredModel(
-        benchmark=_TTS, provider="openai", model="gpt-4o-mini-tts", voice="alloy", status=_ACTIVE
+        benchmark=_TTS,
+        provider="openai",
+        model="gpt-4o-mini-tts",
+        voice="alloy",
+        tags=(_REALTIME, _MULTI),
+        status=_ACTIVE,
     ),
     RegisteredModel(
-        benchmark=_TTS, provider="openai", model="tts-1-hd", voice="alloy", status=_RETIRED
+        benchmark=_TTS,
+        provider="openai",
+        model="tts-1-hd",
+        voice="alloy",
+        tags=(_REALTIME, _MULTI),
+        status=_RETIRED,
     ),
     RegisteredModel(
-        benchmark=_TTS, provider="openai", model="tts-1", voice="alloy", status=_RETIRED
+        benchmark=_TTS,
+        provider="openai",
+        model="tts-1",
+        voice="alloy",
+        tags=(_REALTIME, _MULTI),
+        status=_RETIRED,
     ),
     RegisteredModel(
         benchmark=_TTS,
         provider="cartesia",
         model="sonic-3",
         voice="f786b574-daa5-4673-aa0c-cbe3e8534c02",
+        tags=(_REALTIME, _MULTI),
         status=_ACTIVE,
     ),
     RegisteredModel(
@@ -145,6 +295,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         provider="cartesia",
         model="sonic-3.5",
         voice="db6b0ed5-d5d3-463d-ae85-518a07d3c2b4",
+        tags=(_REALTIME, _MULTI),
         status=_ACTIVE,
     ),
     RegisteredModel(
@@ -152,6 +303,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         provider="deepgram",
         model="aura-2-thalia-en",
         voice="aura-2-thalia-en",
+        tags=(_REALTIME,),
         status=_ACTIVE,
     ),
     RegisteredModel(
@@ -159,19 +311,49 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         provider="gradium",
         model="default",
         voice="YTpq7expH9539ERJ",
+        tags=(_REALTIME, _MULTI),
         status=_ACTIVE,
     ),
     # Rime — all three on /ws3 WebSocket.
     # "arcana" resolves server-side to Arcana v3; "coda" to May 2026 flagship.
-    RegisteredModel(benchmark=_TTS, provider="rime", model="coda", voice="luna", status=_ACTIVE),
-    RegisteredModel(benchmark=_TTS, provider="rime", model="arcana", voice="luna", status=_ACTIVE),
-    RegisteredModel(benchmark=_TTS, provider="rime", model="mistv3", voice="luna", status=_ACTIVE),
-    RegisteredModel(benchmark=_TTS, provider="rime", model="mistv2", voice="luna", status=_RETIRED),
+    RegisteredModel(
+        benchmark=_TTS,
+        provider="rime",
+        model="coda",
+        voice="luna",
+        tags=(_REALTIME, _MULTI),
+        status=_ACTIVE,
+    ),
+    RegisteredModel(
+        benchmark=_TTS,
+        provider="rime",
+        model="arcana",
+        voice="luna",
+        tags=(_REALTIME, _MULTI),
+        status=_ACTIVE,
+    ),
+    RegisteredModel(
+        benchmark=_TTS,
+        provider="rime",
+        model="mistv3",
+        voice="luna",
+        tags=(_REALTIME, _MULTI),
+        status=_ACTIVE,
+    ),
+    RegisteredModel(
+        benchmark=_TTS,
+        provider="rime",
+        model="mistv2",
+        voice="luna",
+        tags=(_REALTIME, _MULTI),
+        status=_RETIRED,
+    ),
     RegisteredModel(
         benchmark=_TTS,
         provider="hume",
         model="octave-tts",
         voice="176a55b1-4468-4736-8878-db82729667c1",
+        tags=(_REALTIME, _MULTI),
         status=_ACTIVE,
     ),
     RegisteredModel(
@@ -179,14 +361,23 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         provider="hume",
         model="octave-2",
         voice="176a55b1-4468-4736-8878-db82729667c1",
+        tags=(_REALTIME, _MULTI),
         status=_ACTIVE,
     ),
-    RegisteredModel(benchmark=_TTS, provider="xai", model="grok-tts", voice="eve", status=_ACTIVE),
+    RegisteredModel(
+        benchmark=_TTS,
+        provider="xai",
+        model="grok-tts",
+        voice="eve",
+        tags=(_REALTIME, _MULTI),
+        status=_ACTIVE,
+    ),
     RegisteredModel(
         benchmark=_TTS,
         provider="smallest",
         model="lightning_v3.1_pro",
         voice="kaitlyn",
+        tags=(_REALTIME,),
         status=_ACTIVE,
     ),
     RegisteredModel(
@@ -194,6 +385,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         provider="inworld",
         model="inworld-tts-1.5-max",
         voice="Ashley",
+        tags=(_REALTIME, _MULTI),
         status=_PENDING,
     ),
     RegisteredModel(
@@ -201,16 +393,24 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         provider="inworld",
         model="inworld-tts-1.5-mini",
         voice="Ashley",
+        tags=(_REALTIME, _MULTI),
         status=_PENDING,
     ),
     RegisteredModel(
-        benchmark=_TTS, provider="soniox", model="tts-rt-v1", voice="Adrian", status=_ACTIVE
+        benchmark=_TTS,
+        provider="soniox",
+        model="tts-rt-v1",
+        voice="Adrian",
+        tags=(_REALTIME, _MULTI),
+        status=_ACTIVE,
     ),
     RegisteredModel(
         benchmark=_TTS,
         provider="groq",
         model="canopylabs/orpheus-v1-english",
         voice="autumn",
+        creator="canopylabs",
+        tags=(_BATCH,),
         status=_PENDING,
     ),
     # gpt-realtime is a speech-to-speech LLM, not a TTS provider: driving it
@@ -218,9 +418,19 @@ MODEL_REGISTRY: list[RegisteredModel] = [
     # guarantees verbatim speech, so its metrics are incomparable here. Kept
     # retired (not deleted) so historical rows stay hidden on the site.
     RegisteredModel(
-        benchmark=_TTS, provider="openai", model="gpt-realtime-2025-08-28", status=_RETIRED
+        benchmark=_TTS,
+        provider="openai",
+        model="gpt-realtime-2025-08-28",
+        tags=(_REALTIME, _MULTI),
+        status=_RETIRED,
     ),
-    RegisteredModel(benchmark=_TTS, provider="cartesia", model="sonic", status=_RETIRED),
+    RegisteredModel(
+        benchmark=_TTS,
+        provider="cartesia",
+        model="sonic",
+        tags=(_REALTIME, _MULTI),
+        status=_RETIRED,
+    ),
 ]
 
 _key_counts = Counter((m.benchmark, m.provider, m.model) for m in MODEL_REGISTRY)

--- a/runner/src/coval_bench/registries/models.py
+++ b/runner/src/coval_bench/registries/models.py
@@ -28,6 +28,13 @@ class ModelStatus(StrEnum):
     PENDING = "pending"  # implemented but waiting on credits; hidden like retired
 
 
+class Tenancy(StrEnum):
+    """Whether the served model runs on shared or dedicated infrastructure."""
+
+    SHARED = "shared"
+    DEDICATED = "dedicated"
+
+
 class RegisteredModel(BaseModel, frozen=True):
     """A single benchmarked model: identity, display metadata, run config."""
 
@@ -37,6 +44,7 @@ class RegisteredModel(BaseModel, frozen=True):
     voice: str | None = None  # TTS only
     creator: str | None = None  # who makes the model; None means same as provider
     tags: tuple[ModelTag, ...] = ()
+    tenancy: Tenancy = Tenancy.SHARED
     status: ModelStatus
 
 

--- a/runner/src/coval_bench/registries/tags.py
+++ b/runner/src/coval_bench/registries/tags.py
@@ -8,19 +8,38 @@ from enum import StrEnum
 
 
 class TagCategory(StrEnum):
-    """Grouping for model tags, used to organize leaderboard filters."""
+    """Faceted leaderboard filters. Within a facet tags OR; across facets they AND.
 
-    CAPABILITY = "capability"
+    TYPE/HOST/LAB are derived from registry columns and SOURCE/TENANCY from model
+    attributes, all at the API boundary; only MODE and FEATURES draw their values
+    from ``ModelTag``.
+    """
+
+    TYPE = "type"
+    MODE = "mode"
+    HOST = "host"
+    LAB = "lab"
+    FEATURES = "features"
+    SOURCE = "source"
+    TENANCY = "tenancy"
 
 
 class ModelTag(StrEnum):
-    """Filterable/sortable model attributes surfaced on the leaderboard."""
+    """Curated model attributes surfaced as MODE and FEATURES filter chips."""
 
     REALTIME = "realtime"
+    BATCH = "batch"
+    BIDIRECTIONAL = "bidirectional"
+    MULTILINGUAL = "multilingual"
+    VAD = "vad"
 
 
 TAG_CATEGORIES: dict[ModelTag, TagCategory] = {
-    ModelTag.REALTIME: TagCategory.CAPABILITY,
+    ModelTag.REALTIME: TagCategory.MODE,
+    ModelTag.BATCH: TagCategory.MODE,
+    ModelTag.BIDIRECTIONAL: TagCategory.MODE,
+    ModelTag.MULTILINGUAL: TagCategory.FEATURES,
+    ModelTag.VAD: TagCategory.FEATURES,
 }
 
 if TAG_CATEGORIES.keys() != set(ModelTag):

--- a/runner/tests/api/test_providers.py
+++ b/runner/tests/api/test_providers.py
@@ -61,13 +61,13 @@ async def test_disabled_flag_exposed(client: AsyncClient) -> None:
 
 
 async def test_response_shape_breaking_change(client: AsyncClient) -> None:
-    """models is a list[ModelInfo] (dict with 'model' + 'disabled'), not a list[str]."""
+    """models is a list[ModelInfo] (dict with 'model', 'disabled', 'tags'), not a list[str]."""
     response = await client.get("/v1/providers")
     data = response.json()
     first_model = data["stt"][0]["models"][0]
     assert isinstance(first_model, dict), "models must be dicts, not strings"
-    assert set(first_model.keys()) == {"model", "disabled"}, (
-        f"ModelInfo must have exactly 'model' and 'disabled' keys, got {set(first_model.keys())}"
+    assert set(first_model.keys()) == {"model", "disabled", "tags"}, (
+        f"ModelInfo keys must be model/disabled/tags, got {set(first_model.keys())}"
     )
 
     openai_entry = next(e for e in data["tts"] if e["provider"] == "openai")
@@ -94,6 +94,22 @@ async def test_inactive_tts_models_marked_disabled(client: AsyncClient) -> None:
     for legacy in ("tts-1", "tts-1-hd"):
         model = next(m for m in openai_entry["models"] if m["model"] == legacy)
         assert model["disabled"] is True, f"{legacy} must be disabled=True"
+
+
+async def test_every_model_carries_derived_facets(client: AsyncClient) -> None:
+    """Each model emits type/host/lab/source/tenancy facets derived from the registry."""
+    response = await client.get("/v1/providers")
+    data = response.json()
+
+    xai_entry = next(e for e in data["stt"] if e["provider"] == "xai")
+    grok_stt = next(m for m in xai_entry["models"] if m["model"] == "grok-stt")
+    facets = {(t["category"], t["value"]) for t in grok_stt["tags"]}
+    assert ("type", "STT") in facets
+    assert ("host", "xai") in facets
+    # lab defaults to the host when no creator override is set; source is then original.
+    assert ("lab", "xai") in facets
+    assert ("source", "original") in facets
+    assert ("tenancy", "shared") in facets
 
 
 async def test_providers_no_db_connection(app: FastAPI, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/runner/tests/unit/test_provider_config.py
+++ b/runner/tests/unit/test_provider_config.py
@@ -11,6 +11,7 @@ from coval_bench.registries import (
     ModelStatus,
     ModelTag,
     RegisteredModel,
+    Tenancy,
 )
 
 
@@ -30,6 +31,7 @@ def test_registered_model_defaults() -> None:
     assert m.voice is None
     assert m.creator is None
     assert m.tags == ()
+    assert m.tenancy is Tenancy.SHARED
 
 
 def test_models_untagged_for_now() -> None:

--- a/runner/tests/unit/test_provider_config.py
+++ b/runner/tests/unit/test_provider_config.py
@@ -34,11 +34,10 @@ def test_registered_model_defaults() -> None:
     assert m.tenancy is Tenancy.SHARED
 
 
-def test_models_untagged_for_now() -> None:
-    # Scaffolding only — no registered model carries tags or a creator override yet.
+def test_every_model_has_exactly_one_mode() -> None:
+    modes = {ModelTag.REALTIME, ModelTag.BATCH}
     for m in MODEL_REGISTRY:
-        assert m.creator is None
-        assert m.tags == ()
+        assert len(set(m.tags) & modes) == 1, f"{m.provider}/{m.model} needs one mode tag"
 
 
 def test_active_tts_models_have_voices() -> None:

--- a/web/components/layout/FacetFilter.tsx
+++ b/web/components/layout/FacetFilter.tsx
@@ -1,0 +1,64 @@
+// Copyright 2026 The Coval Benchmarks Authors
+// SPDX-License-Identifier: Apache-2.0
+
+"use client";
+
+import React from "react";
+import { useDashboard } from "@/contexts/DashboardContext";
+
+const FacetFilter: React.FC = () => {
+  const { facetGroups, toggleFacet, clearFacets, hasActiveFacets } = useDashboard();
+
+  if (facetGroups.length === 0) return null;
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between px-2">
+        <span className="text-sm font-bold text-text-primary">Filters</span>
+        {hasActiveFacets && (
+          <button
+            type="button"
+            onClick={clearFacets}
+            className="text-xs text-text-tertiary transition-colors hover:text-text-primary"
+          >
+            Clear
+          </button>
+        )}
+      </div>
+
+      {facetGroups.map((group) => (
+        <div key={group.category} className="px-2">
+          <div className="mb-1.5 text-[11px] font-semibold uppercase tracking-wide text-text-tertiary">
+            {group.label}
+          </div>
+          <div className="flex flex-wrap gap-1.5">
+            {group.options.map((option) => (
+              <button
+                key={option.value}
+                type="button"
+                aria-pressed={option.active}
+                onClick={() => toggleFacet(group.category, option.value)}
+                className={`inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-text-tertiary/40 ${
+                  option.active
+                    ? "border-transparent bg-surface-toggle-active text-text-on-toggle-active"
+                    : "border-border-primary text-text-secondary hover:border-text-tertiary/50 hover:text-text-primary"
+                }`}
+              >
+                <span>{option.label}</span>
+                <span
+                  className={
+                    option.active ? "text-text-on-toggle-active/70" : "text-text-tertiary"
+                  }
+                >
+                  {option.count}
+                </span>
+              </button>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default FacetFilter;

--- a/web/components/layout/MobileModelSheet.tsx
+++ b/web/components/layout/MobileModelSheet.tsx
@@ -8,6 +8,7 @@ import { normalizeModelName } from "@/lib/utils/formatters";
 import { useDashboard } from "@/contexts/DashboardContext";
 import { useSidebarMenu } from "@/contexts/SidebarMenuContext";
 import { getModelColor } from "@/lib/utils/colors";
+import FacetFilter from "@/components/layout/FacetFilter";
 
 const MobileModelSheet: React.FC = () => {
   const {
@@ -57,6 +58,7 @@ const MobileModelSheet: React.FC = () => {
 
           {/* Model Selection */}
           <div className="space-y-2">
+            <FacetFilter />
             {Object.entries(modelsByProvider).map(([provider, models]) => (
               <div key={provider}>
                 <button

--- a/web/components/layout/ModelSidebar.tsx
+++ b/web/components/layout/ModelSidebar.tsx
@@ -7,6 +7,7 @@ import React from "react";
 import { normalizeModelName } from "@/lib/utils/formatters";
 import { useDashboard } from "@/contexts/DashboardContext";
 import { getModelColor } from "@/lib/utils/colors";
+import FacetFilter from "@/components/layout/FacetFilter";
 
 // Keep the links pinned in place until the footer is about to collide with the
 // actual bottom of the link list, then push the sidebar up so the filters slide
@@ -75,6 +76,7 @@ const ModelSidebar: React.FC = () => {
       <div className="flex-1 overflow-y-auto scrollbar-hide">
         {/* Model Selection Content */}
         <div ref={linksRef} className="space-y-2">
+          <FacetFilter />
           <div>
             {Object.entries(modelsByProvider).map(([provider, models]) => {
               const selectedCount = models.filter((m) =>

--- a/web/hooks/useDashboardState.tsx
+++ b/web/hooks/useDashboardState.tsx
@@ -15,6 +15,13 @@ import { useMobileDetection } from "@/hooks/useMobileDetection";
 import { useBarInteraction } from "@/hooks/useBarInteraction";
 import { latencyToMs, normalizeModelName, normalizeSTTProviderName, normalizeTTSProviderName, parseModelKey, toModelKey } from "@/lib/utils/formatters";
 import { buildModelsByProvider, pruneSelection } from "@/lib/utils/modelsFromResults";
+import {
+  buildFacetGroups,
+  buildTagIndex,
+  filterModelsByFacets,
+  toggleFacetValue,
+  type FacetSelection,
+} from "@/lib/utils/facets";
 import { getModelColor } from "@/lib/utils/colors";
 import { metricDescriptions } from "@/lib/config/metrics";
 import { useAggregatesQuery, useProvidersQuery } from "@/lib/api/queries";
@@ -61,10 +68,29 @@ export function useDashboardState(page: "tts" | "stt") {
     [aggregatesQuery.data]
   );
 
-  const modelsByProvider = useMemo(
+  // Full catalogue (minus disabled) drives the facet options; the facet
+  // selection then narrows it to what the sidebar and charts actually show.
+  const allModelsByProvider = useMemo(
     () => buildModelsByProvider(modelStats, benchmarkParam, providersQuery.data),
     [providersQuery.data, modelStats, benchmarkParam]
   );
+  const tagIndex = useMemo(
+    () => buildTagIndex(benchmarkParam, providersQuery.data),
+    [benchmarkParam, providersQuery.data]
+  );
+  const [selectedFacets, setSelectedFacets] = useState<FacetSelection>({});
+  const modelsByProvider = useMemo(
+    () => filterModelsByFacets(allModelsByProvider, tagIndex, selectedFacets),
+    [allModelsByProvider, tagIndex, selectedFacets]
+  );
+  const hasActiveFacets = useMemo(
+    () => Object.values(selectedFacets).some((v) => v.length > 0),
+    [selectedFacets]
+  );
+  const toggleFacet = useCallback((category: string, value: string) => {
+    setSelectedFacets((prev) => toggleFacetValue(prev, category, value));
+  }, []);
+  const clearFacets = useCallback(() => setSelectedFacets({}), []);
 
   const loading = aggregatesQuery.isLoading || providersQuery.isLoading;
 
@@ -312,6 +338,11 @@ export function useDashboardState(page: "tts" | "stt") {
     ? normalizeSTTProviderName
     : normalizeTTSProviderName;
 
+  const facetGroups = useMemo(
+    () => buildFacetGroups(allModelsByProvider, tagIndex, selectedFacets, normalizeProviderName),
+    [allModelsByProvider, tagIndex, selectedFacets, normalizeProviderName]
+  );
+
   const boxPlotDescription = {
     short: `Distribution of ${latencyLabel} values across all runs`,
     detailed:
@@ -399,6 +430,12 @@ export function useDashboardState(page: "tts" | "stt") {
     // Model state
     selectedModels,
     modelsByProvider,
+
+    // Faceted filters
+    facetGroups,
+    toggleFacet,
+    clearFacets,
+    hasActiveFacets,
 
     // UI state
     isMobile,

--- a/web/lib/api/client.ts
+++ b/web/lib/api/client.ts
@@ -48,6 +48,7 @@ async function request<T>(path: string, init?: Parameters<typeof fetch>[1]): Pro
 export type ProvidersApiResponse = components["schemas"]["ProvidersResponse"];
 export type ProviderInfo = components["schemas"]["ProviderInfo"];
 export type ModelInfo = components["schemas"]["ModelInfo"];
+export type ModelTagOut = components["schemas"]["ModelTagOut"];
 export type LeaderboardApiResponse = components["schemas"]["LeaderboardResponse"];
 export type LeaderboardEntry = components["schemas"]["LeaderboardEntry"];
 export type RunRow = components["schemas"]["RunOut"];

--- a/web/lib/api/generated/schema.ts
+++ b/web/lib/api/generated/schema.ts
@@ -49,6 +49,11 @@ export interface components {
     ModelInfo: {
       model: string;
       disabled?: boolean;
+      tags?: components["schemas"]["ModelTagOut"][];
+    };
+    ModelTagOut: {
+      category: string;
+      value: string;
     };
     ModelStatEntry: {
       provider: string;

--- a/web/lib/utils/facets.test.ts
+++ b/web/lib/utils/facets.test.ts
@@ -1,0 +1,118 @@
+// Copyright 2026 The Coval Benchmarks Authors
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+import type { ProvidersApiResponse } from "../api/client";
+import type { ModelsByProvider } from "../../types/benchmark.types";
+import {
+  buildFacetGroups,
+  buildTagIndex,
+  filterModelsByFacets,
+  toggleFacetValue,
+} from "./facets";
+
+// Four STT models: every mode is realtime (single-value → not a facet); host
+// and features vary, so those are the real facets.
+function tag(category: string, value: string) {
+  return { category, value };
+}
+const PROVIDERS: ProvidersApiResponse = {
+  stt: [
+    {
+      provider: "deepgram",
+      models: [
+        {
+          model: "nova-2",
+          tags: [tag("type", "STT"), tag("host", "deepgram"), tag("mode", "realtime"), tag("features", "multilingual"), tag("features", "vad")],
+        },
+        {
+          model: "flux-general-en",
+          tags: [tag("type", "STT"), tag("host", "deepgram"), tag("mode", "realtime"), tag("features", "vad")],
+        },
+      ],
+    },
+    {
+      provider: "openai",
+      models: [
+        {
+          model: "gpt-4o-transcribe",
+          tags: [tag("type", "STT"), tag("host", "openai"), tag("mode", "realtime"), tag("features", "multilingual"), tag("features", "vad")],
+        },
+      ],
+    },
+    {
+      provider: "cartesia",
+      models: [
+        {
+          model: "ink-2",
+          tags: [tag("type", "STT"), tag("host", "cartesia"), tag("mode", "realtime"), tag("features", "vad")],
+        },
+      ],
+    },
+  ],
+  tts: [],
+};
+
+const ALL: ModelsByProvider = {
+  deepgram: ["deepgram:nova-2", "deepgram:flux-general-en"],
+  openai: ["openai:gpt-4o-transcribe"],
+  cartesia: ["cartesia:ink-2"],
+};
+
+const index = () => buildTagIndex("STT", PROVIDERS);
+
+describe("filterModelsByFacets", () => {
+  it("returns everything when nothing is selected", () => {
+    expect(filterModelsByFacets(ALL, index(), {})).toEqual(ALL);
+  });
+
+  it("ORs values within a category", () => {
+    const out = filterModelsByFacets(ALL, index(), { host: ["deepgram", "openai"] });
+    expect(out.deepgram).toHaveLength(2);
+    expect(out.openai).toHaveLength(1);
+    expect(out.cartesia).toBeUndefined();
+  });
+
+  it("ANDs across categories", () => {
+    const out = filterModelsByFacets(ALL, index(), {
+      host: ["deepgram", "openai"],
+      features: ["multilingual"],
+    });
+    // flux-general-en is deepgram but not multilingual → dropped.
+    expect(out.deepgram).toEqual(["deepgram:nova-2"]);
+    expect(out.openai).toEqual(["openai:gpt-4o-transcribe"]);
+  });
+});
+
+describe("buildFacetGroups", () => {
+  const id = (s: string) => s;
+
+  it("drops single-value categories (type, mode) and keeps host + features", () => {
+    const groups = buildFacetGroups(ALL, index(), {}, id);
+    expect(groups.map((g) => g.category)).toEqual(["host", "features"]);
+  });
+
+  it("counts honor the other categories' selection", () => {
+    const groups = buildFacetGroups(ALL, index(), { features: ["multilingual"] }, id);
+    const host = groups.find((g) => g.category === "host")!;
+    const byValue = Object.fromEntries(host.options.map((o) => [o.value, o.count]));
+    // Among multilingual models, deepgram has 1 (nova-2), openai 1, cartesia 0.
+    expect(byValue).toEqual({ deepgram: 1, openai: 1, cartesia: 0 });
+  });
+
+  it("labels VAD specially and marks active options", () => {
+    const groups = buildFacetGroups(ALL, index(), { features: ["vad"] }, id);
+    const features = groups.find((g) => g.category === "features")!;
+    const vad = features.options.find((o) => o.value === "vad")!;
+    expect(vad.label).toBe("VAD");
+    expect(vad.active).toBe(true);
+  });
+});
+
+describe("toggleFacetValue", () => {
+  it("adds, then removes and prunes the empty category", () => {
+    const added = toggleFacetValue({}, "host", "openai");
+    expect(added).toEqual({ host: ["openai"] });
+    expect(toggleFacetValue(added, "host", "openai")).toEqual({});
+  });
+});

--- a/web/lib/utils/facets.ts
+++ b/web/lib/utils/facets.ts
@@ -1,0 +1,155 @@
+// Copyright 2026 The Coval Benchmarks Authors
+// SPDX-License-Identifier: Apache-2.0
+
+import type { ModelTagOut, ProvidersApiResponse } from "../api/client";
+import type { ModelsByProvider } from "../../types/benchmark.types";
+import { toModelKey } from "./formatters";
+
+/** category -> selected values. Within a category values OR; across categories they AND. */
+export type FacetSelection = Record<string, string[]>;
+
+export interface FacetOption {
+  value: string;
+  label: string;
+  count: number;
+  active: boolean;
+}
+
+export interface FacetGroup {
+  category: string;
+  label: string;
+  options: FacetOption[];
+}
+
+// Display order and labels for the tag categories the API emits.
+const CATEGORY_ORDER = ["type", "mode", "host", "lab", "features", "source", "tenancy"];
+const CATEGORY_LABELS: Record<string, string> = {
+  type: "Type",
+  mode: "Mode",
+  host: "Host",
+  lab: "Lab",
+  features: "Features",
+  source: "Source",
+  tenancy: "Tenancy",
+};
+// Values whose nice form isn't just a capitalization.
+const VALUE_LABELS: Record<string, string> = { vad: "VAD" };
+
+/** Map every catalogue model's composite key to its tags. */
+export function buildTagIndex(
+  benchmark: "STT" | "TTS",
+  providers?: ProvidersApiResponse
+): Map<string, ModelTagOut[]> {
+  const index = new Map<string, ModelTagOut[]>();
+  if (!providers) return index;
+  const catalogue = benchmark === "STT" ? providers.stt : providers.tts;
+  for (const providerInfo of catalogue) {
+    for (const modelInfo of providerInfo.models) {
+      index.set(toModelKey(providerInfo.provider, modelInfo.model), modelInfo.tags ?? []);
+    }
+  }
+  return index;
+}
+
+function facetValueLabel(
+  category: string,
+  value: string,
+  normalizeProvider: (name: string) => string
+): string {
+  if (category === "host" || category === "lab") return normalizeProvider(value);
+  if (category === "type") return value.toUpperCase();
+  return VALUE_LABELS[value] ?? value.charAt(0).toUpperCase() + value.slice(1);
+}
+
+// A model passes when, for every category with a selection, it carries at least
+// one of the selected values in that category (OR within, AND across).
+function matchesSelection(tags: ModelTagOut[], selected: FacetSelection): boolean {
+  for (const [category, values] of Object.entries(selected)) {
+    if (values.length === 0) continue;
+    const hit = tags.some((t) => t.category === category && values.includes(t.value));
+    if (!hit) return false;
+  }
+  return true;
+}
+
+const hasAnySelection = (selected: FacetSelection): boolean =>
+  Object.values(selected).some((v) => v.length > 0);
+
+/** Narrow modelsByProvider to the models passing the current facet selection. */
+export function filterModelsByFacets(
+  modelsByProvider: ModelsByProvider,
+  tagIndex: Map<string, ModelTagOut[]>,
+  selected: FacetSelection
+): ModelsByProvider {
+  if (!hasAnySelection(selected)) return modelsByProvider;
+  const out: ModelsByProvider = {};
+  for (const [provider, keys] of Object.entries(modelsByProvider)) {
+    const kept = keys.filter((key) => matchesSelection(tagIndex.get(key) ?? [], selected));
+    if (kept.length > 0) out[provider] = kept;
+  }
+  return out;
+}
+
+/**
+ * Build the chip groups. A category is shown only when it has at least two
+ * distinct values across the visible models — a single-value facet can't filter
+ * anything. Each option's count is the number of models that would remain if it
+ * were selected, honoring the other categories' current selection.
+ */
+export function buildFacetGroups(
+  modelsByProvider: ModelsByProvider,
+  tagIndex: Map<string, ModelTagOut[]>,
+  selected: FacetSelection,
+  normalizeProvider: (name: string) => string
+): FacetGroup[] {
+  const visibleKeys = Object.values(modelsByProvider).flat();
+  const groups: FacetGroup[] = [];
+
+  for (const category of CATEGORY_ORDER) {
+    const values = new Set<string>();
+    for (const key of visibleKeys) {
+      for (const tag of tagIndex.get(key) ?? []) {
+        if (tag.category === category) values.add(tag.value);
+      }
+    }
+    if (values.size < 2) continue;
+
+    const others: FacetSelection = { ...selected, [category]: [] };
+    const options: FacetOption[] = [...values]
+      .map((value) => {
+        const count = visibleKeys.filter((key) => {
+          const tags = tagIndex.get(key) ?? [];
+          return (
+            tags.some((t) => t.category === category && t.value === value) &&
+            matchesSelection(tags, others)
+          );
+        }).length;
+        return {
+          value,
+          label: facetValueLabel(category, value, normalizeProvider),
+          count,
+          active: (selected[category] ?? []).includes(value),
+        };
+      })
+      .sort((a, b) => a.label.localeCompare(b.label));
+
+    groups.push({ category, label: CATEGORY_LABELS[category] ?? category, options });
+  }
+
+  return groups;
+}
+
+export function toggleFacetValue(
+  selected: FacetSelection,
+  category: string,
+  value: string
+): FacetSelection {
+  const current = selected[category] ?? [];
+  const next = current.includes(value)
+    ? current.filter((v) => v !== value)
+    : [...current, value];
+  const out = { ...selected };
+  if (next.length > 0) out[category] = next;
+  else delete out[category];
+  return out;
+}


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added facet-based filters for model browsing, with selectable categories, counts, and a clear-all action.
  * Model listings and mobile selection views now include the new filter controls.
  * Model details now surface structured tags such as type, mode, source, and tenancy.

* **Bug Fixes**
  * Improved model catalogue filtering so selections combine correctly across categories while allowing multiple values within a category.
  * Ensured model entries consistently include the expected metadata fields in responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds category-based faceted filtering to the model leaderboard. Tags (`type`, `mode`, `host`, `lab`, `features`, `source`, `tenancy`) are derived from each model's registry metadata at the API boundary and returned alongside `ModelInfo`; the frontend indexes those tags and drives chip-group filters that AND across categories and OR within them.

- **Backend**: New `Tenancy` enum, `_model_tags()` helper in `providers.py`, and `ModelTagOut` schema are added; all registry models are annotated with `REALTIME`/`BATCH`/`MULTILINGUAL`/`VAD` tags.
- **Frontend**: `facets.ts` implements `buildTagIndex`, `filterModelsByFacets`, and `buildFacetGroups`; `useDashboardState` wires the facet state into `modelsByProvider`; `FacetFilter` renders the chip UI in both sidebar and mobile sheet.

<h3>Confidence Score: 4/5</h3>

The filtering logic, API contract, and state wiring are all correct; the main concern is a UX defect where Host and Lab filter groups appear with identical chips because no active model has a distinct creator.

The backend is solid — tag derivation is correct, TAG_CATEGORIES completeness is enforced at import time, and the schema change is backward-compatible. The frontend AND-across/OR-within logic is well-implemented and pruneSelection correctly handles selection cleanup when facets narrow the model set. The issue is that the lab category produces an identical filter group to host for every currently active model, which users would see immediately as two side-by-side filter sections with the same chips. The test fixture also does not include lab tags, so this scenario is not caught by the test suite.

web/lib/utils/facets.ts (CATEGORY_ORDER includes lab which mirrors host for all active models) and web/lib/utils/facets.test.ts (fixture omits lab tags, preventing the duplicate-group scenario from being caught).

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| runner/src/coval_bench/api/routers/providers.py | Adds _model_tags() to flatten registry columns + curated tags into ModelTagOut; injects tags into ModelInfo. TAG_CATEGORIES completeness is enforced at import time, so no KeyError risk. |
| runner/src/coval_bench/registries/tags.py | Expands TagCategory and ModelTag enums; TAG_CATEGORIES completeness guard prevents silent misses at import time. |
| runner/src/coval_bench/registries/models.py | Adds Tenancy enum and tenancy field to RegisteredModel; backfills all registry entries with mode/feature tags. |
| web/lib/utils/facets.ts | Core faceting logic. AND-across/OR-within is correct; counts apply cross-facet context correctly. Lab facet will duplicate host for all currently active models. |
| web/lib/utils/facets.test.ts | Tests cover OR-within, AND-across, count correctness, and toggleFacetValue. Fixture omits lab/source/tenancy tags so the duplicate host+lab scenario is not exercised. |
| web/hooks/useDashboardState.tsx | Cleanly integrates facet state; pruneSelection effect correctly deselects models that fall outside the active filter. |
| web/components/layout/FacetFilter.tsx | New chip-group component; uses aria-pressed for accessibility, shows Clear only when a facet is active. |
| runner/tests/api/test_providers.py | Updated breaking-change test; adds test_every_model_carries_derived_facets covering type/host/lab/source/tenancy derivation. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Registry as Model Registry
    participant API as /v1/providers API
    participant Client as Frontend Client
    participant TagIndex as buildTagIndex
    participant FacetGroups as buildFacetGroups
    participant Filter as filterModelsByFacets
    participant UI as FacetFilter / Sidebar

    Registry->>API: RegisteredModel (provider, creator, tags, tenancy, benchmark)
    API->>API: _model_tags() → TYPE, HOST, LAB, SOURCE, TENANCY + ModelTag chips
    API-->>Client: "ProvidersResponse with models[{ model, disabled, tags[] }]"
    Client->>TagIndex: buildTagIndex(benchmark, providers)
    TagIndex-->>Client: Map modelKey to ModelTagOut[]
    Client->>FacetGroups: buildFacetGroups(allModelsByProvider, tagIndex, selectedFacets)
    FacetGroups-->>UI: FacetGroup[] with category, label, options
    UI->>Client: toggleFacet(category, value) sets selectedFacets
    Client->>Filter: filterModelsByFacets(allModelsByProvider, tagIndex, selectedFacets)
    Filter-->>Client: modelsByProvider narrowed
    Client->>UI: pruneSelection(selectedModels, modelsByProvider)
    UI-->>UI: charts and sidebar update to filtered set
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Registry as Model Registry
    participant API as /v1/providers API
    participant Client as Frontend Client
    participant TagIndex as buildTagIndex
    participant FacetGroups as buildFacetGroups
    participant Filter as filterModelsByFacets
    participant UI as FacetFilter / Sidebar

    Registry->>API: RegisteredModel (provider, creator, tags, tenancy, benchmark)
    API->>API: _model_tags() → TYPE, HOST, LAB, SOURCE, TENANCY + ModelTag chips
    API-->>Client: "ProvidersResponse with models[{ model, disabled, tags[] }]"
    Client->>TagIndex: buildTagIndex(benchmark, providers)
    TagIndex-->>Client: Map modelKey to ModelTagOut[]
    Client->>FacetGroups: buildFacetGroups(allModelsByProvider, tagIndex, selectedFacets)
    FacetGroups-->>UI: FacetGroup[] with category, label, options
    UI->>Client: toggleFacet(category, value) sets selectedFacets
    Client->>Filter: filterModelsByFacets(allModelsByProvider, tagIndex, selectedFacets)
    Filter-->>Client: modelsByProvider narrowed
    Client->>UI: pruneSelection(selectedModels, modelsByProvider)
    UI-->>UI: charts and sidebar update to filtered set
```

</a>

<sub>Reviews (1): Last reviewed commit: ["Frontend tagging redesign"](https://github.com/coval-ai/benchmarks/commit/45a71b65359134cbe513f62a9ea1c7b505f3d729) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40227555)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->