### PR TITLE
Add model tag facets to the providers API

### DIFF
--- a/runner/src/coval_bench/api/routers/providers.py
+++ b/runner/src/coval_bench/api/routers/providers.py
@@ -22,14 +22,34 @@ from starlette.requests import Request
 
 from coval_bench.api.deps import capture_api_event, get_posthog
 from coval_bench.api.ratelimit import limiter
-from coval_bench.api.schemas import ModelInfo, ProviderInfo, ProvidersResponse
-from coval_bench.registries import MODEL_REGISTRY, Benchmark, ModelStatus
+from coval_bench.api.schemas import ModelInfo, ModelTagOut, ProviderInfo, ProvidersResponse
+from coval_bench.registries import (
+    MODEL_REGISTRY,
+    TAG_CATEGORIES,
+    Benchmark,
+    ModelStatus,
+    RegisteredModel,
+    TagCategory,
+)
 
 logger = structlog.get_logger("coval_bench.api")
 
 router = APIRouter(tags=["providers"])
 
 _HIDDEN_STATUSES = frozenset({ModelStatus.RETIRED, ModelStatus.PENDING})
+
+
+def _model_tags(m: RegisteredModel) -> list[ModelTagOut]:
+    """Flatten a model's facets: derived columns/attributes plus curated tags."""
+    source = "inference" if m.creator and m.creator != m.provider else "original"
+    return [
+        ModelTagOut(category=TagCategory.TYPE, value=m.benchmark),
+        ModelTagOut(category=TagCategory.HOST, value=m.provider),
+        ModelTagOut(category=TagCategory.LAB, value=m.creator or m.provider),
+        ModelTagOut(category=TagCategory.SOURCE, value=source),
+        ModelTagOut(category=TagCategory.TENANCY, value=m.tenancy),
+        *(ModelTagOut(category=TAG_CATEGORIES[t], value=t) for t in m.tags),
+    ]
 
 
 def _build_provider_map(benchmark: Benchmark) -> dict[str, list[ModelInfo]]:
@@ -43,7 +63,11 @@ def _build_provider_map(benchmark: Benchmark) -> dict[str, list[ModelInfo]]:
     for m in MODEL_REGISTRY:
         if m.benchmark is benchmark:
             result.setdefault(m.provider, []).append(
-                ModelInfo(model=m.model, disabled=m.status in _HIDDEN_STATUSES)
+                ModelInfo(
+                    model=m.model,
+                    disabled=m.status in _HIDDEN_STATUSES,
+                    tags=_model_tags(m),
+                )
             )
     return result
 

--- a/runner/src/coval_bench/api/schemas.py
+++ b/runner/src/coval_bench/api/schemas.py
@@ -17,6 +17,7 @@ from typing import Literal
 from pydantic import BaseModel, ConfigDict, Field
 
 from coval_bench.api.common import BenchmarkLiteral, WindowLiteral
+from coval_bench.registries import TagCategory
 
 
 class RunOut(BaseModel):
@@ -74,7 +75,7 @@ class LeaderboardEntry(BaseModel):
 class ModelTagOut(BaseModel):
     """A faceted filter tag: its category and value (e.g. capability/realtime)."""
 
-    category: str
+    category: TagCategory
     value: str
 
 

--- a/runner/src/coval_bench/api/schemas.py
+++ b/runner/src/coval_bench/api/schemas.py
@@ -71,11 +71,19 @@ class LeaderboardEntry(BaseModel):
     n: int
 
 
+class ModelTagOut(BaseModel):
+    """A faceted filter tag: its category and value (e.g. capability/realtime)."""
+
+    category: str
+    value: str
+
+
 class ModelInfo(BaseModel):
     """A single model entry under a provider, with admin-disabled flag."""
 
     model: str
     disabled: bool = False
+    tags: list[ModelTagOut] = []
 
 
 class ProviderInfo(BaseModel):

--- a/runner/src/coval_bench/registries/__init__.py
+++ b/runner/src/coval_bench/registries/__init__.py
@@ -13,7 +13,12 @@ from coval_bench.registries.metrics import (
     MetricDirection,
     MetricSpec,
 )
-from coval_bench.registries.models import MODEL_REGISTRY, ModelStatus, RegisteredModel
+from coval_bench.registries.models import (
+    MODEL_REGISTRY,
+    ModelStatus,
+    RegisteredModel,
+    Tenancy,
+)
 from coval_bench.registries.tags import TAG_CATEGORIES, ModelTag, TagCategory
 
 __all__ = [
@@ -25,6 +30,7 @@ __all__ = [
     "MetricSpec",
     "ModelStatus",
     "RegisteredModel",
+    "Tenancy",
     "TAG_CATEGORIES",
     "ModelTag",
     "TagCategory",

--- a/runner/src/coval_bench/registries/models.py
+++ b/runner/src/coval_bench/registries/models.py
@@ -53,53 +53,184 @@ _TTS = Benchmark.TTS
 _ACTIVE = ModelStatus.ACTIVE
 _RETIRED = ModelStatus.RETIRED
 _PENDING = ModelStatus.PENDING
+_REALTIME = ModelTag.REALTIME
+_BATCH = ModelTag.BATCH
+_MULTI = ModelTag.MULTILINGUAL
+_VAD = ModelTag.VAD
 
 # Per-benchmark order is the model order /v1/providers returns.
 MODEL_REGISTRY: list[RegisteredModel] = [
     #######
     # STT #
     #######
-    RegisteredModel(benchmark=_STT, provider="deepgram", model="nova-2", status=_ACTIVE),
-    RegisteredModel(benchmark=_STT, provider="deepgram", model="nova-3", status=_ACTIVE),
-    RegisteredModel(benchmark=_STT, provider="deepgram", model="flux-general-en", status=_ACTIVE),
     RegisteredModel(
-        benchmark=_STT, provider="deepgram", model="flux-general-multi", status=_ACTIVE
+        benchmark=_STT,
+        provider="deepgram",
+        model="nova-2",
+        tags=(_REALTIME, _MULTI, _VAD),
+        status=_ACTIVE,
     ),
     RegisteredModel(
-        benchmark=_STT, provider="elevenlabs", model="scribe_v2_realtime", status=_ACTIVE
+        benchmark=_STT,
+        provider="deepgram",
+        model="nova-3",
+        tags=(_REALTIME, _MULTI, _VAD),
+        status=_ACTIVE,
     ),
     RegisteredModel(
-        benchmark=_STT, provider="openai", model="gpt-realtime-whisper", status=_ACTIVE
+        benchmark=_STT,
+        provider="deepgram",
+        model="flux-general-en",
+        tags=(_REALTIME, _VAD),
+        status=_ACTIVE,
     ),
-    RegisteredModel(benchmark=_STT, provider="openai", model="gpt-4o-transcribe", status=_ACTIVE),
     RegisteredModel(
-        benchmark=_STT, provider="openai", model="gpt-4o-mini-transcribe", status=_ACTIVE
+        benchmark=_STT,
+        provider="deepgram",
+        model="flux-general-multi",
+        tags=(_REALTIME, _MULTI, _VAD),
+        status=_ACTIVE,
     ),
     RegisteredModel(
-        benchmark=_STT, provider="assemblyai", model="universal-streaming", status=_ACTIVE
+        benchmark=_STT,
+        provider="elevenlabs",
+        model="scribe_v2_realtime",
+        tags=(_REALTIME, _MULTI, _VAD),
+        status=_ACTIVE,
+    ),
+    RegisteredModel(
+        benchmark=_STT,
+        provider="openai",
+        model="gpt-realtime-whisper",
+        tags=(_REALTIME, _MULTI),
+        status=_ACTIVE,
+    ),
+    RegisteredModel(
+        benchmark=_STT,
+        provider="openai",
+        model="gpt-4o-transcribe",
+        tags=(_REALTIME, _MULTI, _VAD),
+        status=_ACTIVE,
+    ),
+    RegisteredModel(
+        benchmark=_STT,
+        provider="openai",
+        model="gpt-4o-mini-transcribe",
+        tags=(_REALTIME, _MULTI, _VAD),
+        status=_ACTIVE,
+    ),
+    RegisteredModel(
+        benchmark=_STT,
+        provider="assemblyai",
+        model="universal-streaming",
+        tags=(_REALTIME, _VAD),
+        status=_ACTIVE,
     ),
     RegisteredModel(
         benchmark=_STT,
         provider="assemblyai",
         model="universal-streaming-multilingual",
+        tags=(_REALTIME, _MULTI, _VAD),
         status=_ACTIVE,
     ),
     RegisteredModel(
-        benchmark=_STT, provider="assemblyai", model="universal-3.5-pro", status=_ACTIVE
+        benchmark=_STT,
+        provider="assemblyai",
+        model="universal-3.5-pro",
+        tags=(_REALTIME, _MULTI, _VAD),
+        status=_ACTIVE,
     ),
-    RegisteredModel(benchmark=_STT, provider="speechmatics", model="default", status=_ACTIVE),
-    RegisteredModel(benchmark=_STT, provider="speechmatics", model="enhanced", status=_ACTIVE),
-    RegisteredModel(benchmark=_STT, provider="gradium", model="default", status=_ACTIVE),
-    RegisteredModel(benchmark=_STT, provider="gladia", model="solaria-1", status=_PENDING),
-    RegisteredModel(benchmark=_STT, provider="soniox", model="stt-rt-v4", status=_ACTIVE),
-    RegisteredModel(benchmark=_STT, provider="soniox", model="stt-rt-v5", status=_ACTIVE),
-    RegisteredModel(benchmark=_STT, provider="xai", model="grok-stt", status=_ACTIVE),
-    RegisteredModel(benchmark=_STT, provider="smallest", model="pulse", status=_ACTIVE),
-    RegisteredModel(benchmark=_STT, provider="cartesia", model="ink-2", status=_ACTIVE),
-    RegisteredModel(benchmark=_STT, provider="google", model="short", status=_RETIRED),
-    RegisteredModel(benchmark=_STT, provider="google", model="long", status=_RETIRED),
-    RegisteredModel(benchmark=_STT, provider="google", model="telephony", status=_RETIRED),
-    RegisteredModel(benchmark=_STT, provider="google", model="chirp_2", status=_RETIRED),
+    RegisteredModel(
+        benchmark=_STT,
+        provider="speechmatics",
+        model="default",
+        tags=(_REALTIME, _MULTI, _VAD),
+        status=_ACTIVE,
+    ),
+    RegisteredModel(
+        benchmark=_STT,
+        provider="speechmatics",
+        model="enhanced",
+        tags=(_REALTIME, _MULTI, _VAD),
+        status=_ACTIVE,
+    ),
+    RegisteredModel(
+        benchmark=_STT,
+        provider="gradium",
+        model="default",
+        tags=(_REALTIME, _MULTI, _VAD),
+        status=_ACTIVE,
+    ),
+    RegisteredModel(
+        benchmark=_STT,
+        provider="gladia",
+        model="solaria-1",
+        tags=(_REALTIME, _MULTI, _VAD),
+        status=_PENDING,
+    ),
+    RegisteredModel(
+        benchmark=_STT,
+        provider="soniox",
+        model="stt-rt-v4",
+        tags=(_REALTIME, _MULTI, _VAD),
+        status=_ACTIVE,
+    ),
+    RegisteredModel(
+        benchmark=_STT,
+        provider="soniox",
+        model="stt-rt-v5",
+        tags=(_REALTIME, _MULTI, _VAD),
+        status=_ACTIVE,
+    ),
+    RegisteredModel(
+        benchmark=_STT,
+        provider="xai",
+        model="grok-stt",
+        tags=(_REALTIME, _MULTI, _VAD),
+        status=_ACTIVE,
+    ),
+    RegisteredModel(
+        benchmark=_STT,
+        provider="smallest",
+        model="pulse",
+        tags=(_REALTIME, _MULTI, _VAD),
+        status=_ACTIVE,
+    ),
+    RegisteredModel(
+        benchmark=_STT,
+        provider="cartesia",
+        model="ink-2",
+        tags=(_REALTIME, _VAD),
+        status=_ACTIVE,
+    ),
+    RegisteredModel(
+        benchmark=_STT,
+        provider="google",
+        model="short",
+        tags=(_BATCH, _MULTI),
+        status=_RETIRED,
+    ),
+    RegisteredModel(
+        benchmark=_STT,
+        provider="google",
+        model="long",
+        tags=(_BATCH, _MULTI),
+        status=_RETIRED,
+    ),
+    RegisteredModel(
+        benchmark=_STT,
+        provider="google",
+        model="telephony",
+        tags=(_REALTIME, _MULTI, _VAD),
+        status=_RETIRED,
+    ),
+    RegisteredModel(
+        benchmark=_STT,
+        provider="google",
+        model="chirp_2",
+        tags=(_REALTIME, _MULTI, _VAD),
+        status=_RETIRED,
+    ),
     #######
     # TTS #
     #######
@@ -108,6 +239,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         provider="elevenlabs",
         model="eleven_flash_v2_5",
         voice="IKne3meq5aSn9XLyUdCD",
+        tags=(_REALTIME, _MULTI),
         status=_ACTIVE,
     ),
     RegisteredModel(
@@ -115,6 +247,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         provider="elevenlabs",
         model="eleven_multilingual_v2",
         voice="IKne3meq5aSn9XLyUdCD",
+        tags=(_REALTIME, _MULTI),
         status=_ACTIVE,
     ),
     RegisteredModel(
@@ -122,22 +255,39 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         provider="elevenlabs",
         model="eleven_turbo_v2_5",
         voice="IKne3meq5aSn9XLyUdCD",
+        tags=(_REALTIME, _MULTI),
         status=_RETIRED,
     ),
     RegisteredModel(
-        benchmark=_TTS, provider="openai", model="gpt-4o-mini-tts", voice="alloy", status=_ACTIVE
+        benchmark=_TTS,
+        provider="openai",
+        model="gpt-4o-mini-tts",
+        voice="alloy",
+        tags=(_REALTIME, _MULTI),
+        status=_ACTIVE,
     ),
     RegisteredModel(
-        benchmark=_TTS, provider="openai", model="tts-1-hd", voice="alloy", status=_RETIRED
+        benchmark=_TTS,
+        provider="openai",
+        model="tts-1-hd",
+        voice="alloy",
+        tags=(_REALTIME, _MULTI),
+        status=_RETIRED,
     ),
     RegisteredModel(
-        benchmark=_TTS, provider="openai", model="tts-1", voice="alloy", status=_RETIRED
+        benchmark=_TTS,
+        provider="openai",
+        model="tts-1",
+        voice="alloy",
+        tags=(_REALTIME, _MULTI),
+        status=_RETIRED,
     ),
     RegisteredModel(
         benchmark=_TTS,
         provider="cartesia",
         model="sonic-3",
         voice="f786b574-daa5-4673-aa0c-cbe3e8534c02",
+        tags=(_REALTIME, _MULTI),
         status=_ACTIVE,
     ),
     RegisteredModel(
@@ -145,6 +295,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         provider="cartesia",
         model="sonic-3.5",
         voice="db6b0ed5-d5d3-463d-ae85-518a07d3c2b4",
+        tags=(_REALTIME, _MULTI),
         status=_ACTIVE,
     ),
     RegisteredModel(
@@ -152,6 +303,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         provider="deepgram",
         model="aura-2-thalia-en",
         voice="aura-2-thalia-en",
+        tags=(_REALTIME,),
         status=_ACTIVE,
     ),
     RegisteredModel(
@@ -159,19 +311,49 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         provider="gradium",
         model="default",
         voice="YTpq7expH9539ERJ",
+        tags=(_REALTIME, _MULTI),
         status=_ACTIVE,
     ),
     # Rime — all three on /ws3 WebSocket.
     # "arcana" resolves server-side to Arcana v3; "coda" to May 2026 flagship.
-    RegisteredModel(benchmark=_TTS, provider="rime", model="coda", voice="luna", status=_ACTIVE),
-    RegisteredModel(benchmark=_TTS, provider="rime", model="arcana", voice="luna", status=_ACTIVE),
-    RegisteredModel(benchmark=_TTS, provider="rime", model="mistv3", voice="luna", status=_ACTIVE),
-    RegisteredModel(benchmark=_TTS, provider="rime", model="mistv2", voice="luna", status=_RETIRED),
+    RegisteredModel(
+        benchmark=_TTS,
+        provider="rime",
+        model="coda",
+        voice="luna",
+        tags=(_REALTIME, _MULTI),
+        status=_ACTIVE,
+    ),
+    RegisteredModel(
+        benchmark=_TTS,
+        provider="rime",
+        model="arcana",
+        voice="luna",
+        tags=(_REALTIME, _MULTI),
+        status=_ACTIVE,
+    ),
+    RegisteredModel(
+        benchmark=_TTS,
+        provider="rime",
+        model="mistv3",
+        voice="luna",
+        tags=(_REALTIME, _MULTI),
+        status=_ACTIVE,
+    ),
+    RegisteredModel(
+        benchmark=_TTS,
+        provider="rime",
+        model="mistv2",
+        voice="luna",
+        tags=(_REALTIME, _MULTI),
+        status=_RETIRED,
+    ),
     RegisteredModel(
         benchmark=_TTS,
         provider="hume",
         model="octave-tts",
         voice="176a55b1-4468-4736-8878-db82729667c1",
+        tags=(_REALTIME, _MULTI),
         status=_ACTIVE,
     ),
     RegisteredModel(
@@ -179,14 +361,23 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         provider="hume",
         model="octave-2",
         voice="176a55b1-4468-4736-8878-db82729667c1",
+        tags=(_REALTIME, _MULTI),
         status=_ACTIVE,
     ),
-    RegisteredModel(benchmark=_TTS, provider="xai", model="grok-tts", voice="eve", status=_ACTIVE),
+    RegisteredModel(
+        benchmark=_TTS,
+        provider="xai",
+        model="grok-tts",
+        voice="eve",
+        tags=(_REALTIME, _MULTI),
+        status=_ACTIVE,
+    ),
     RegisteredModel(
         benchmark=_TTS,
         provider="smallest",
         model="lightning_v3.1_pro",
         voice="kaitlyn",
+        tags=(_REALTIME,),
         status=_ACTIVE,
     ),
     RegisteredModel(
@@ -194,6 +385,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         provider="inworld",
         model="inworld-tts-1.5-max",
         voice="Ashley",
+        tags=(_REALTIME, _MULTI),
         status=_PENDING,
     ),
     RegisteredModel(
@@ -201,16 +393,24 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         provider="inworld",
         model="inworld-tts-1.5-mini",
         voice="Ashley",
+        tags=(_REALTIME, _MULTI),
         status=_PENDING,
     ),
     RegisteredModel(
-        benchmark=_TTS, provider="soniox", model="tts-rt-v1", voice="Adrian", status=_ACTIVE
+        benchmark=_TTS,
+        provider="soniox",
+        model="tts-rt-v1",
+        voice="Adrian",
+        tags=(_REALTIME, _MULTI),
+        status=_ACTIVE,
     ),
     RegisteredModel(
         benchmark=_TTS,
         provider="groq",
         model="canopylabs/orpheus-v1-english",
         voice="autumn",
+        creator="canopylabs",
+        tags=(_BATCH,),
         status=_PENDING,
     ),
     # gpt-realtime is a speech-to-speech LLM, not a TTS provider: driving it
@@ -218,9 +418,19 @@ MODEL_REGISTRY: list[RegisteredModel] = [
     # guarantees verbatim speech, so its metrics are incomparable here. Kept
     # retired (not deleted) so historical rows stay hidden on the site.
     RegisteredModel(
-        benchmark=_TTS, provider="openai", model="gpt-realtime-2025-08-28", status=_RETIRED
+        benchmark=_TTS,
+        provider="openai",
+        model="gpt-realtime-2025-08-28",
+        tags=(_REALTIME, _MULTI),
+        status=_RETIRED,
     ),
-    RegisteredModel(benchmark=_TTS, provider="cartesia", model="sonic", status=_RETIRED),
+    RegisteredModel(
+        benchmark=_TTS,
+        provider="cartesia",
+        model="sonic",
+        tags=(_REALTIME, _MULTI),
+        status=_RETIRED,
+    ),
 ]
 
 _key_counts = Counter((m.benchmark, m.provider, m.model) for m in MODEL_REGISTRY)

--- a/runner/src/coval_bench/registries/models.py
+++ b/runner/src/coval_bench/registries/models.py
@@ -28,6 +28,13 @@ class ModelStatus(StrEnum):
     PENDING = "pending"  # implemented but waiting on credits; hidden like retired
 
 
+class Tenancy(StrEnum):
+    """Whether the served model runs on shared or dedicated infrastructure."""
+
+    SHARED = "shared"
+    DEDICATED = "dedicated"
+
+
 class RegisteredModel(BaseModel, frozen=True):
     """A single benchmarked model: identity, display metadata, run config."""
 
@@ -37,6 +44,7 @@ class RegisteredModel(BaseModel, frozen=True):
     voice: str | None = None  # TTS only
     creator: str | None = None  # who makes the model; None means same as provider
     tags: tuple[ModelTag, ...] = ()
+    tenancy: Tenancy = Tenancy.SHARED
     status: ModelStatus
 
 

--- a/runner/src/coval_bench/registries/tags.py
+++ b/runner/src/coval_bench/registries/tags.py
@@ -8,19 +8,38 @@ from enum import StrEnum
 
 
 class TagCategory(StrEnum):
-    """Grouping for model tags, used to organize leaderboard filters."""
+    """Faceted leaderboard filters. Within a facet tags OR; across facets they AND.
 
-    CAPABILITY = "capability"
+    TYPE/HOST/LAB are derived from registry columns and SOURCE/TENANCY from model
+    attributes, all at the API boundary; only MODE and FEATURES draw their values
+    from ``ModelTag``.
+    """
+
+    TYPE = "type"
+    MODE = "mode"
+    HOST = "host"
+    LAB = "lab"
+    FEATURES = "features"
+    SOURCE = "source"
+    TENANCY = "tenancy"
 
 
 class ModelTag(StrEnum):
-    """Filterable/sortable model attributes surfaced on the leaderboard."""
+    """Curated model attributes surfaced as MODE and FEATURES filter chips."""
 
     REALTIME = "realtime"
+    BATCH = "batch"
+    BIDIRECTIONAL = "bidirectional"
+    MULTILINGUAL = "multilingual"
+    VAD = "vad"
 
 
 TAG_CATEGORIES: dict[ModelTag, TagCategory] = {
-    ModelTag.REALTIME: TagCategory.CAPABILITY,
+    ModelTag.REALTIME: TagCategory.MODE,
+    ModelTag.BATCH: TagCategory.MODE,
+    ModelTag.BIDIRECTIONAL: TagCategory.MODE,
+    ModelTag.MULTILINGUAL: TagCategory.FEATURES,
+    ModelTag.VAD: TagCategory.FEATURES,
 }
 
 if TAG_CATEGORIES.keys() != set(ModelTag):

--- a/runner/src/coval_bench/registries/tags.py
+++ b/runner/src/coval_bench/registries/tags.py
@@ -29,7 +29,6 @@ class ModelTag(StrEnum):
 
     REALTIME = "realtime"
     BATCH = "batch"
-    BIDIRECTIONAL = "bidirectional"
     MULTILINGUAL = "multilingual"
     VAD = "vad"
 
@@ -37,7 +36,6 @@ class ModelTag(StrEnum):
 TAG_CATEGORIES: dict[ModelTag, TagCategory] = {
     ModelTag.REALTIME: TagCategory.MODE,
     ModelTag.BATCH: TagCategory.MODE,
-    ModelTag.BIDIRECTIONAL: TagCategory.MODE,
     ModelTag.MULTILINGUAL: TagCategory.FEATURES,
     ModelTag.VAD: TagCategory.FEATURES,
 }

--- a/runner/tests/api/test_providers.py
+++ b/runner/tests/api/test_providers.py
@@ -111,6 +111,14 @@ async def test_every_model_carries_derived_facets(client: AsyncClient) -> None:
     assert ("source", "original") in facets
     assert ("tenancy", "shared") in facets
 
+    # groq hosts canopylabs' orpheus, so the creator override drives lab and source.
+    groq_entry = next(e for e in data["tts"] if e["provider"] == "groq")
+    orpheus = next(m for m in groq_entry["models"] if m["model"] == "canopylabs/orpheus-v1-english")
+    orpheus_facets = {(t["category"], t["value"]) for t in orpheus["tags"]}
+    assert ("host", "groq") in orpheus_facets
+    assert ("lab", "canopylabs") in orpheus_facets
+    assert ("source", "inference") in orpheus_facets
+
 
 async def test_providers_no_db_connection(app: FastAPI, monkeypatch: pytest.MonkeyPatch) -> None:
     """The /v1/providers endpoint never acquires a DB connection.

--- a/runner/tests/api/test_providers.py
+++ b/runner/tests/api/test_providers.py
@@ -61,13 +61,13 @@ async def test_disabled_flag_exposed(client: AsyncClient) -> None:
 
 
 async def test_response_shape_breaking_change(client: AsyncClient) -> None:
-    """models is a list[ModelInfo] (dict with 'model' + 'disabled'), not a list[str]."""
+    """models is a list[ModelInfo] (dict with 'model', 'disabled', 'tags'), not a list[str]."""
     response = await client.get("/v1/providers")
     data = response.json()
     first_model = data["stt"][0]["models"][0]
     assert isinstance(first_model, dict), "models must be dicts, not strings"
-    assert set(first_model.keys()) == {"model", "disabled"}, (
-        f"ModelInfo must have exactly 'model' and 'disabled' keys, got {set(first_model.keys())}"
+    assert set(first_model.keys()) == {"model", "disabled", "tags"}, (
+        f"ModelInfo keys must be model/disabled/tags, got {set(first_model.keys())}"
     )
 
     openai_entry = next(e for e in data["tts"] if e["provider"] == "openai")
@@ -94,6 +94,22 @@ async def test_inactive_tts_models_marked_disabled(client: AsyncClient) -> None:
     for legacy in ("tts-1", "tts-1-hd"):
         model = next(m for m in openai_entry["models"] if m["model"] == legacy)
         assert model["disabled"] is True, f"{legacy} must be disabled=True"
+
+
+async def test_every_model_carries_derived_facets(client: AsyncClient) -> None:
+    """Each model emits type/host/lab/source/tenancy facets derived from the registry."""
+    response = await client.get("/v1/providers")
+    data = response.json()
+
+    xai_entry = next(e for e in data["stt"] if e["provider"] == "xai")
+    grok_stt = next(m for m in xai_entry["models"] if m["model"] == "grok-stt")
+    facets = {(t["category"], t["value"]) for t in grok_stt["tags"]}
+    assert ("type", "STT") in facets
+    assert ("host", "xai") in facets
+    # lab defaults to the host when no creator override is set; source is then original.
+    assert ("lab", "xai") in facets
+    assert ("source", "original") in facets
+    assert ("tenancy", "shared") in facets
 
 
 async def test_providers_no_db_connection(app: FastAPI, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/runner/tests/unit/test_provider_config.py
+++ b/runner/tests/unit/test_provider_config.py
@@ -11,6 +11,7 @@ from coval_bench.registries import (
     ModelStatus,
     ModelTag,
     RegisteredModel,
+    Tenancy,
 )
 
 
@@ -30,6 +31,7 @@ def test_registered_model_defaults() -> None:
     assert m.voice is None
     assert m.creator is None
     assert m.tags == ()
+    assert m.tenancy is Tenancy.SHARED
 
 
 def test_models_untagged_for_now() -> None:

--- a/runner/tests/unit/test_provider_config.py
+++ b/runner/tests/unit/test_provider_config.py
@@ -34,11 +34,10 @@ def test_registered_model_defaults() -> None:
     assert m.tenancy is Tenancy.SHARED
 
 
-def test_models_untagged_for_now() -> None:
-    # Scaffolding only — no registered model carries tags or a creator override yet.
+def test_every_model_has_exactly_one_mode() -> None:
+    modes = {ModelTag.REALTIME, ModelTag.BATCH}
     for m in MODEL_REGISTRY:
-        assert m.creator is None
-        assert m.tags == ()
+        assert len(set(m.tags) & modes) == 1, f"{m.provider}/{m.model} needs one mode tag"
 
 
 def test_active_tts_models_have_voices() -> None:


### PR DESCRIPTION
Expands the model tag taxonomy and surfaces it on `GET /v1/providers` so the website can offer faceted filtering.

## Tags
Seven facet categories: Type, Mode, Host, Lab, Features, Source, Tenancy.

- **Mode** and **Features** are curated `ModelTag` values (realtime/batch; multilingual/vad).
- **Type**, **Host**, **Lab** are derived at the API boundary from existing registry columns.
- **Source** is derived from whether the host differs from the lab (original vs inference).
- **Tenancy** is a new explicit field on `RegisteredModel`, defaulting to `shared`.

Every model is tagged, and `/v1/providers` now emits a flat `tags` list per model so the site can't drift from the runner's reality. No DB changes, no migration.

## Notes
- Tenancy defaults to `shared` everywhere and wants a follow-up audit to mark dedicated deployments.
- Among enabled models only Host/Lab/Features currently vary; Mode/Source/Tenancy populate once batch/inference/dedicated models go active.
- The frontend filter UI is on its own branch and is decoupled, so it ships independently of this.

Checks: ruff, ruff format --check, mypy --strict, and the provider/registry tests all pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `/v1/providers` model responses now include structured `tags` to support faceted filtering (type, mode, host, lab, source, features, and tenancy).
  * Models are now categorized with tenancy (shared vs dedicated) and standardized mode/feature tagging for more consistent browsing.

* **Bug Fixes**
  * Model listings now consistently return the updated response shape including the new tag data.

* **Tests**
  * Updated and added API/unit coverage to enforce the presence and correctness of derived facet tags across registered models.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Expands the model tag taxonomy from a single `CAPABILITY` category to seven facets (Type, Mode, Host, Lab, Features, Source, Tenancy) and surfaces them on `GET /v1/providers` as a flat `tags` list per model. A new `Tenancy` field is added to `RegisteredModel` (defaulting to `shared`), all registry entries gain explicit mode tags, and the `creator` field is now used for the first time (groq/orpheus) to drive the SOURCE and LAB facets.

- `_model_tags()` in `providers.py` derives five facets from registry columns and stitches in the curated `ModelTag`-based mode/features tags via the `TAG_CATEGORIES` lookup, ensuring the frontend filter tags are always in sync with the runner registry.
- The module-level exhaustiveness guard in `tags.py` (`TAG_CATEGORIES.keys() != set(ModelTag)`) prevents new `ModelTag` values from silently going unrouted; a companion unit test (`test_every_model_has_exactly_one_mode`) enforces that every registry entry carries exactly one MODE tag.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is purely additive: new tags are appended to the existing ModelInfo shape, no DB touches, and the registry-level invariants are enforced at both module-load time and in a dedicated unit test.

The core logic in _model_tags is simple and directly tested. The TAG_CATEGORIES exhaustiveness guard fires at import time, so a missing mapping is a hard startup failure rather than a silent data gap. All registry entries were audited to carry exactly one mode tag, enforced by the new unit test. The only gap is that the integration test doesn't round-trip mode/features facets through the serialization layer, but that path is trivial and structurally identical to the derived facets that are asserted.

runner/tests/api/test_providers.py — the new integration test stops short of asserting mode and features tags flow through correctly.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| runner/src/coval_bench/registries/tags.py | Replaces single CAPABILITY category with seven typed facets; adds BATCH/MULTILINGUAL/VAD tags; exhaustiveness guard at module load time keeps TAG_CATEGORIES in sync with ModelTag. |
| runner/src/coval_bench/api/routers/providers.py | Adds _model_tags() helper that derives five column-based facets and stitches in curated ModelTag facets; passes result through ModelInfo.tags on every registry entry. |
| runner/src/coval_bench/api/schemas.py | Adds ModelTagOut(category, value) schema and extends ModelInfo with a tags list; clean, backward-compatible additive change. |
| runner/src/coval_bench/registries/models.py | Adds Tenancy enum and tenancy field (default SHARED) to RegisteredModel; backfills all registry entries with explicit mode/features tags; first use of creator field (groq/orpheus). |
| runner/tests/unit/test_provider_config.py | Replaces blanket 'no tags yet' scaffolding test with a meaningful mode-count invariant; adds tenancy default assertion. |
| runner/tests/api/test_providers.py | Adds test_every_model_carries_derived_facets covering type/host/lab/source/tenancy and the inference-source path via groq/orpheus; mode and features facet values are not asserted in the integration test. |
| runner/src/coval_bench/registries/__init__.py | Re-exports Tenancy from the models submodule; straightforward housekeeping. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    RM[RegisteredModel] --> MT[_model_tags]

    MT --> T1["TYPE = m.benchmark\n('STT' or 'TTS')"]
    MT --> T2["HOST = m.provider"]
    MT --> T3["LAB = m.creator ?? m.provider"]
    MT --> T4{m.creator set\nand != provider?}
    T4 -->|Yes| S1["SOURCE = 'inference'"]
    T4 -->|No| S2["SOURCE = 'original'"]
    MT --> T5["TENANCY = m.tenancy\n(default: 'shared')"]
    MT --> T6["m.tags → TAG_CATEGORIES lookup"]

    T6 --> M1["REALTIME/BATCH → MODE facet"]
    T6 --> M2["MULTILINGUAL/VAD → FEATURES facet"]

    T1 & T2 & T3 & S1 & S2 & T5 & M1 & M2 --> OUT["list[ModelTagOut]\n(flat tags on ModelInfo)"]

    OUT --> API["GET /v1/providers response"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    RM[RegisteredModel] --> MT[_model_tags]

    MT --> T1["TYPE = m.benchmark\n('STT' or 'TTS')"]
    MT --> T2["HOST = m.provider"]
    MT --> T3["LAB = m.creator ?? m.provider"]
    MT --> T4{m.creator set\nand != provider?}
    T4 -->|Yes| S1["SOURCE = 'inference'"]
    T4 -->|No| S2["SOURCE = 'original'"]
    MT --> T5["TENANCY = m.tenancy\n(default: 'shared')"]
    MT --> T6["m.tags → TAG_CATEGORIES lookup"]

    T6 --> M1["REALTIME/BATCH → MODE facet"]
    T6 --> M2["MULTILINGUAL/VAD → FEATURES facet"]

    T1 & T2 & T3 & S1 & S2 & T5 & M1 & M2 --> OUT["list[ModelTagOut]\n(flat tags on ModelInfo)"]

    OUT --> API["GET /v1/providers response"]
```

</a>

<sub>Reviews (2): Last reviewed commit: ["Address PR review on model tag facets"](https://github.com/coval-ai/benchmarks/commit/66e34d945935a7a61e9b3fd056808fb4cb289d58) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40372967)</sub>

<!-- /greptile_comment -->