### PR TITLE
Show Orpheus TTS on the leaderboard

### DIFF
--- a/runner/src/coval_bench/registries/models.py
+++ b/runner/src/coval_bench/registries/models.py
@@ -203,7 +203,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         provider="groq",
         model="canopylabs/orpheus-v1-english",
         voice="autumn",
-        status=_PENDING,
+        status=_ACTIVE,
     ),
     # gpt-realtime is a speech-to-speech LLM, not a TTS provider: driving it
     # from a text "instructions" prompt folds LLM inference into TTFA and never


### PR DESCRIPTION
Flip the Groq Orpheus entry from pending to active now that it's ready to benchmark.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR activates the Groq-hosted Orpheus TTS model (`canopylabs/orpheus-v1-english`) on the leaderboard by changing its registry status from `PENDING` to `ACTIVE`.

- The single-line change causes the orchestrator to begin benchmarking the entry and the API to surface it as an enabled model on the frontend.
- No logic, schema, or configuration beyond the status flag is touched.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a single status flag flip with no logic, schema, or configuration side-effects.

The only change is moving the Groq Orpheus TTS entry from PENDING to ACTIVE in the model registry. This is a well-understood, isolated operation: the orchestrator will begin scheduling benchmark runs and the API will expose the model on the leaderboard. There is no risk of data corruption, auth changes, or regressions to other models.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| runner/src/coval_bench/registries/models.py | Flips `status` for the Groq Orpheus TTS entry from `_PENDING` to `_ACTIVE`, enabling benchmarking and leaderboard display; all other fields are unchanged. |

<sub>Reviews (2): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/mai..."](https://github.com/coval-ai/benchmarks/commit/ed98fb3c8101aa6e0e83a9dfc82ec908b27cb547) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40586445)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled the Groq `canopylabs/orpheus-v1-english` voice model for benchmarking and display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->