### PR TITLE
Cale/model tag facet metadata api

### DIFF
--- a/runner/src/coval_bench/api/routers/providers.py
+++ b/runner/src/coval_bench/api/routers/providers.py
@@ -22,14 +22,23 @@ from starlette.requests import Request
 
 from coval_bench.api.deps import capture_api_event, get_posthog
 from coval_bench.api.ratelimit import limiter
-from coval_bench.api.schemas import ModelInfo, ModelTagOut, ProviderInfo, ProvidersResponse
+from coval_bench.api.schemas import (
+    ModelInfo,
+    ModelTagOut,
+    ProviderInfo,
+    ProvidersResponse,
+    TagCategoryOut,
+)
 from coval_bench.registries import (
+    CATEGORY_LABELS,
     MODEL_REGISTRY,
+    PROVIDER_VALUED_CATEGORIES,
     TAG_CATEGORIES,
     Benchmark,
     ModelStatus,
     RegisteredModel,
     TagCategory,
+    tag_value_label,
 )
 
 logger = structlog.get_logger("coval_bench.api")
@@ -39,16 +48,32 @@ router = APIRouter(tags=["providers"])
 _HIDDEN_STATUSES = frozenset({ModelStatus.RETIRED, ModelStatus.PENDING})
 
 
+def _tag(category: TagCategory, value: str) -> ModelTagOut:
+    return ModelTagOut(category=category, value=value, label=tag_value_label(category, value))
+
+
 def _model_tags(m: RegisteredModel) -> list[ModelTagOut]:
     """Flatten a model's facets: derived columns/attributes plus curated tags."""
     source = "inference" if m.creator and m.creator != m.provider else "original"
     return [
-        ModelTagOut(category=TagCategory.TYPE, value=m.benchmark),
-        ModelTagOut(category=TagCategory.HOST, value=m.provider),
-        ModelTagOut(category=TagCategory.LAB, value=m.creator or m.provider),
-        ModelTagOut(category=TagCategory.SOURCE, value=source),
-        ModelTagOut(category=TagCategory.TENANCY, value=m.tenancy),
-        *(ModelTagOut(category=TAG_CATEGORIES[t], value=t) for t in m.tags),
+        _tag(TagCategory.TYPE, m.benchmark),
+        _tag(TagCategory.HOST, m.provider),
+        _tag(TagCategory.LAB, m.creator or m.provider),
+        _tag(TagCategory.SOURCE, source),
+        _tag(TagCategory.TENANCY, m.tenancy),
+        *(_tag(TAG_CATEGORIES[t], t) for t in m.tags),
+    ]
+
+
+def _tag_categories() -> list[TagCategoryOut]:
+    """The facet vocabulary in display order (TagCategory definition order)."""
+    return [
+        TagCategoryOut(
+            category=c,
+            label=CATEGORY_LABELS[c],
+            provider_valued=c in PROVIDER_VALUED_CATEGORIES,
+        )
+        for c in TagCategory
     ]
 
 
@@ -79,6 +104,7 @@ def _describe() -> ProvidersResponse:
     return ProvidersResponse(
         stt=[ProviderInfo(provider=p, models=m) for p, m in sorted(stt_map.items())],
         tts=[ProviderInfo(provider=p, models=m) for p, m in sorted(tts_map.items())],
+        tag_categories=_tag_categories(),
     )
 
 

--- a/runner/src/coval_bench/api/routers/providers.py
+++ b/runner/src/coval_bench/api/routers/providers.py
@@ -49,6 +49,7 @@ _HIDDEN_STATUSES = frozenset({ModelStatus.RETIRED, ModelStatus.PENDING})
 
 
 def _tag(category: TagCategory, value: str) -> ModelTagOut:
+    """Build a facet tag with its display label resolved from the registry."""
     return ModelTagOut(category=category, value=value, label=tag_value_label(category, value))
 
 

--- a/runner/src/coval_bench/api/schemas.py
+++ b/runner/src/coval_bench/api/schemas.py
@@ -73,10 +73,20 @@ class LeaderboardEntry(BaseModel):
 
 
 class ModelTagOut(BaseModel):
-    """A faceted filter tag: its category and value (e.g. capability/realtime)."""
+    """A faceted filter tag: its category, raw value, and display label."""
 
     category: TagCategory
     value: str
+    label: str
+
+
+class TagCategoryOut(BaseModel):
+    """A facet category's display metadata. Sent in display order."""
+
+    category: TagCategory
+    label: str
+    # Values are provider/creator ids the client formats, not the per-tag label.
+    provider_valued: bool = False
 
 
 class ModelInfo(BaseModel):
@@ -100,6 +110,8 @@ class ProvidersResponse(BaseModel):
 
     stt: list[ProviderInfo]
     tts: list[ProviderInfo]
+    # Facet vocabulary in display order, shared across STT and TTS.
+    tag_categories: list[TagCategoryOut]
 
 
 class ResultsResponse(BaseModel):

--- a/runner/src/coval_bench/registries/__init__.py
+++ b/runner/src/coval_bench/registries/__init__.py
@@ -19,7 +19,14 @@ from coval_bench.registries.models import (
     RegisteredModel,
     Tenancy,
 )
-from coval_bench.registries.tags import TAG_CATEGORIES, ModelTag, TagCategory
+from coval_bench.registries.tags import (
+    CATEGORY_LABELS,
+    PROVIDER_VALUED_CATEGORIES,
+    TAG_CATEGORIES,
+    ModelTag,
+    TagCategory,
+    tag_value_label,
+)
 
 __all__ = [
     "Benchmark",
@@ -31,7 +38,10 @@ __all__ = [
     "ModelStatus",
     "RegisteredModel",
     "Tenancy",
+    "CATEGORY_LABELS",
+    "PROVIDER_VALUED_CATEGORIES",
     "TAG_CATEGORIES",
     "ModelTag",
     "TagCategory",
+    "tag_value_label",
 ]

--- a/runner/src/coval_bench/registries/tags.py
+++ b/runner/src/coval_bench/registries/tags.py
@@ -64,7 +64,7 @@ if CATEGORY_LABELS.keys() != set(TagCategory):
 PROVIDER_VALUED_CATEGORIES: frozenset[TagCategory] = frozenset({TagCategory.HOST, TagCategory.LAB})
 
 # Value labels that aren't a plain capitalization.
-_VALUE_LABELS: dict[str, str] = {ModelTag.VAD: "VAD"}
+_VALUE_LABELS: dict[str, str] = {ModelTag.VAD.value: "VAD"}
 
 
 def tag_value_label(category: TagCategory, value: str) -> str:

--- a/runner/src/coval_bench/registries/tags.py
+++ b/runner/src/coval_bench/registries/tags.py
@@ -43,3 +43,34 @@ TAG_CATEGORIES: dict[ModelTag, TagCategory] = {
 if TAG_CATEGORIES.keys() != set(ModelTag):
     _missing = ", ".join(sorted(set(ModelTag) - TAG_CATEGORIES.keys()))
     raise RuntimeError(f"TAG_CATEGORIES is missing categories for: {_missing}")
+
+
+# Display label per category.
+CATEGORY_LABELS: dict[TagCategory, str] = {
+    TagCategory.TYPE: "Type",
+    TagCategory.MODE: "Mode",
+    TagCategory.HOST: "Host",
+    TagCategory.LAB: "Lab",
+    TagCategory.FEATURES: "Features",
+    TagCategory.SOURCE: "Source",
+    TagCategory.TENANCY: "Tenancy",
+}
+
+if CATEGORY_LABELS.keys() != set(TagCategory):
+    _missing = ", ".join(sorted(set(TagCategory) - CATEGORY_LABELS.keys()))
+    raise RuntimeError(f"CATEGORY_LABELS is missing labels for: {_missing}")
+
+# Categories whose values are provider/creator ids; the client formats them.
+PROVIDER_VALUED_CATEGORIES: frozenset[TagCategory] = frozenset({TagCategory.HOST, TagCategory.LAB})
+
+# Value labels that aren't a plain capitalization.
+_VALUE_LABELS: dict[str, str] = {ModelTag.VAD: "VAD"}
+
+
+def tag_value_label(category: TagCategory, value: str) -> str:
+    """Display label for a tag value. Provider-valued categories keep the raw id."""
+    if category in PROVIDER_VALUED_CATEGORIES:
+        return value
+    if category is TagCategory.TYPE:
+        return value.upper()
+    return _VALUE_LABELS.get(value, value.capitalize())

--- a/runner/tests/api/test_providers.py
+++ b/runner/tests/api/test_providers.py
@@ -111,6 +111,37 @@ async def test_every_model_carries_derived_facets(client: AsyncClient) -> None:
     assert ("source", "original") in facets
     assert ("tenancy", "shared") in facets
 
+    # Each tag carries a display label: provider-valued categories keep the raw
+    # id, TYPE uppercases, everything else capitalizes.
+    labels = {(t["category"], t["value"]): t["label"] for t in grok_stt["tags"]}
+    assert labels[("type", "STT")] == "STT"
+    assert labels[("host", "xai")] == "xai"
+    assert labels[("source", "original")] == "Original"
+    assert labels[("tenancy", "shared")] == "Shared"
+
+
+async def test_tag_categories_metadata(client: AsyncClient) -> None:
+    """tag_categories ships the full vocabulary in display order with labels."""
+    response = await client.get("/v1/providers")
+    data = response.json()
+
+    categories = data["tag_categories"]
+    assert [c["category"] for c in categories] == [
+        "type",
+        "mode",
+        "host",
+        "lab",
+        "features",
+        "source",
+        "tenancy",
+    ]
+    by_category = {c["category"]: c for c in categories}
+    assert by_category["features"]["label"] == "Features"
+    # Host/lab values are provider ids the frontend formats itself.
+    assert by_category["host"]["provider_valued"] is True
+    assert by_category["lab"]["provider_valued"] is True
+    assert by_category["mode"]["provider_valued"] is False
+
     # groq hosts canopylabs' orpheus, so the creator override drives lab and source.
     groq_entry = next(e for e in data["tts"] if e["provider"] == "groq")
     orpheus = next(m for m in groq_entry["models"] if m["model"] == "canopylabs/orpheus-v1-english")


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Provider listings now include structured tags for each model, plus a full set of available tag categories for richer filtering and display.
  * Model metadata now reflects additional facets such as mode, features, host, lab, source, and tenancy.

* **Bug Fixes**
  * Improved tag labeling and ordering so the UI can present consistent, human-readable facet values.
  * Expanded provider response coverage to include the new tag fields across all listed models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds display metadata to the providers API — a `label` field on each model tag and a new `tag_categories` list in `ProvidersResponse` that ships the full facet vocabulary with human-readable labels and a `provider_valued` flag.

- `ModelTagOut` gains a `label` field, resolved by a new `tag_value_label()` registry function that capitalises simple values, uppercases TYPE, and keeps provider/creator ids raw.
- A new `TagCategoryOut` schema and `_tag_categories()` helper are added, iterating `TagCategory` definition order to produce a deterministic display list.
- Module-load integrity checks ensure `CATEGORY_LABELS` covers every `TagCategory`, mirroring the existing guard on `TAG_CATEGORIES`.

<h3>Confidence Score: 5/5</h3>

The change is additive and safe to merge — no existing fields are removed or altered, and module-load integrity checks guarantee the new label dictionaries are always complete.

All changes are purely additive: a new label field on ModelTagOut, a new TagCategoryOut schema, and a tag_categories list on the response. The tag_value_label logic is simple and fully covered by the new assertions. Two runtime guards (one pre-existing, one new) catch any future enum/label mismatch at startup rather than at request time.

runner/tests/api/test_providers.py — the shape test does not assert the new tag_categories key, and the groq/orpheus derived-facet block is inside test_tag_categories_metadata rather than test_every_model_carries_derived_facets.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| runner/src/coval_bench/registries/tags.py | Adds CATEGORY_LABELS, PROVIDER_VALUED_CATEGORIES, _VALUE_LABELS, and tag_value_label(); module-load integrity check guards CATEGORY_LABELS completeness; logic is straightforward and well-scoped. |
| runner/src/coval_bench/api/routers/providers.py | Adds _tag() helper, refactors _model_tags() to use it, and adds _tag_categories() for the vocabulary endpoint; changes are minimal and correct. |
| runner/src/coval_bench/api/schemas.py | Adds label to ModelTagOut and new TagCategoryOut schema; ProvidersResponse gains tag_categories field; all changes are additive and non-breaking. |
| runner/src/coval_bench/registries/__init__.py | Exports three new symbols (CATEGORY_LABELS, PROVIDER_VALUED_CATEGORIES, tag_value_label) from tags.py; __all__ is kept in sync. |
| runner/tests/api/test_providers.py | New label assertions and test_tag_categories_metadata added; however test_providers_shape doesn't assert the new tag_categories key, and the groq/orpheus derived-facet block was placed inside test_tag_categories_metadata rather than test_every_model_carries_derived_facets. |


<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant Router as GET /v1/providers
    participant Describe as _describe()
    participant TagHelper as _tag_categories()
    participant ModelTags as _model_tags(m)
    participant Registry as tags.py registry

    Client->>Router: GET /v1/providers
    Router->>Describe: _describe()
    Describe->>TagHelper: _tag_categories()
    TagHelper->>Registry: iterate TagCategory enum
    Registry-->>TagHelper: CATEGORY_LABELS[c], PROVIDER_VALUED_CATEGORIES
    TagHelper-->>Describe: list[TagCategoryOut]
    Describe->>ModelTags: _model_tags(m) per model
    ModelTags->>Registry: tag_value_label(category, value)
    Registry-->>ModelTags: label string
    ModelTags-->>Describe: list[ModelTagOut] (with label)
    Describe-->>Router: ProvidersResponse(stt, tts, tag_categories)
    Router-->>Client: JSON response
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant Router as GET /v1/providers
    participant Describe as _describe()
    participant TagHelper as _tag_categories()
    participant ModelTags as _model_tags(m)
    participant Registry as tags.py registry

    Client->>Router: GET /v1/providers
    Router->>Describe: _describe()
    Describe->>TagHelper: _tag_categories()
    TagHelper->>Registry: iterate TagCategory enum
    Registry-->>TagHelper: CATEGORY_LABELS[c], PROVIDER_VALUED_CATEGORIES
    TagHelper-->>Describe: list[TagCategoryOut]
    Describe->>ModelTags: _model_tags(m) per model
    ModelTags->>Registry: tag_value_label(category, value)
    Registry-->>ModelTags: label string
    ModelTags-->>Describe: list[ModelTagOut] (with label)
    Describe-->>Router: ProvidersResponse(stt, tts, tag_categories)
    Router-->>Client: JSON response
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `runner/tests/api/test_providers.py`, line 145-151 ([link](https://github.com/coval-ai/benchmarks/blob/d0ca374a33affb2a572e9cb32ca8617a211464df/runner/tests/api/test_providers.py#L145-L151)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Groq/Orpheus assertions landed in the wrong test function**

   The `# groq hosts canopylabs' orpheus…` block (lines 145–151) was previously the last section of `test_every_model_carries_derived_facets`. Inserting the new `test_tag_categories_metadata` function between the label assertions and the groq block relocated those lines into `test_tag_categories_metadata`. The assertions still pass because `data` is in scope, but they test derived-facet/creator-override behaviour rather than category metadata, so they're now stranded in the wrong test function and will confuse anyone reading either test in isolation.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["Address PR review on facet metadata API"](https://github.com/coval-ai/benchmarks/commit/e96916b17e017db86d2c0cf75d332d62f4bf6853) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40602832)</sub>

<!-- /greptile_comment -->