### PR TITLE
Cale/bench 342 model tag filter UI

### DIFF
--- a/web/components/layout/FacetFilter.tsx
+++ b/web/components/layout/FacetFilter.tsx
@@ -1,0 +1,64 @@
+// Copyright 2026 The Coval Benchmarks Authors
+// SPDX-License-Identifier: Apache-2.0
+
+"use client";
+
+import React from "react";
+import { useDashboard } from "@/contexts/DashboardContext";
+
+const FacetFilter: React.FC = () => {
+  const { facetGroups, toggleFacet, clearFacets, hasActiveFacets } = useDashboard();
+
+  if (facetGroups.length === 0) return null;
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between px-2">
+        <span className="text-sm font-bold text-text-primary">Filters</span>
+        {hasActiveFacets && (
+          <button
+            type="button"
+            onClick={clearFacets}
+            className="text-xs text-text-tertiary transition-colors hover:text-text-primary"
+          >
+            Clear
+          </button>
+        )}
+      </div>
+
+      {facetGroups.map((group) => (
+        <div key={group.category} className="px-2">
+          <div className="mb-1.5 text-[11px] font-semibold uppercase tracking-wide text-text-tertiary">
+            {group.label}
+          </div>
+          <div className="flex flex-wrap gap-1.5">
+            {group.options.map((option) => (
+              <button
+                key={option.value}
+                type="button"
+                aria-pressed={option.active}
+                onClick={() => toggleFacet(group.category, option.value)}
+                className={`inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-text-tertiary/40 ${
+                  option.active
+                    ? "border-transparent bg-surface-toggle-active text-text-on-toggle-active"
+                    : "border-border-primary text-text-secondary hover:border-text-tertiary/50 hover:text-text-primary"
+                }`}
+              >
+                <span>{option.label}</span>
+                <span
+                  className={
+                    option.active ? "text-text-on-toggle-active/70" : "text-text-tertiary"
+                  }
+                >
+                  {option.count}
+                </span>
+              </button>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default FacetFilter;

--- a/web/components/layout/FacetFilter.tsx
+++ b/web/components/layout/FacetFilter.tsx
@@ -27,8 +27,16 @@ const FacetFilter: React.FC = () => {
       </div>
 
       {facetGroups.map((group) => (
-        <div key={group.category} className="px-2">
-          <div className="mb-1.5 text-[11px] font-semibold uppercase tracking-wide text-text-tertiary">
+        <div
+          key={group.category}
+          role="group"
+          aria-labelledby={`facet-${group.category}`}
+          className="px-2"
+        >
+          <div
+            id={`facet-${group.category}`}
+            className="mb-1.5 text-[11px] font-semibold uppercase tracking-wide text-text-tertiary"
+          >
             {group.label}
           </div>
           <div className="flex flex-wrap gap-1.5">

--- a/web/components/layout/MobileModelSheet.tsx
+++ b/web/components/layout/MobileModelSheet.tsx
@@ -4,25 +4,15 @@
 "use client";
 
 import React from "react";
-import { normalizeModelName } from "@/lib/utils/formatters";
 import { useDashboard } from "@/contexts/DashboardContext";
 import { useSidebarMenu } from "@/contexts/SidebarMenuContext";
-import { getModelColor } from "@/lib/utils/colors";
 import FacetFilter from "@/components/layout/FacetFilter";
 
 const MobileModelSheet: React.FC = () => {
+  const { mobileSheetTitle: title } = useDashboard();
   const {
-    mobileSheetTitle: title,
-    normalizeProviderName,
-    modelsByProvider,
-    selectedModels,
-    toggleModelSelection: onToggleModelSelection,
-  } = useDashboard();
-  const {
-    expandedProviders,
     mobileSheetOpen,
     setMobileSheetOpen: onSetMobileSheetOpen,
-    toggleProvider: onToggleProvider,
   } = useSidebarMenu();
 
   return (
@@ -56,55 +46,7 @@ const MobileModelSheet: React.FC = () => {
             {title}
           </div>
 
-          {/* Model Selection */}
-          <div className="space-y-2">
-            <FacetFilter />
-            {Object.entries(modelsByProvider).map(([provider, models]) => (
-              <div key={provider}>
-                <button
-                  onClick={() => onToggleProvider(provider)}
-                  className="flex items-center justify-between w-full text-text-secondary hover:text-text-primary py-1.5 px-2 rounded-lg text-xs transition-all duration-300 hover:bg-hover-bg group"
-                >
-                  <span className="font-medium">
-                    {normalizeProviderName(provider)}
-                  </span>
-                  <span
-                    className={`text-xs transition-all duration-300 ${
-                      expandedProviders[provider] ? "rotate-90" : ""
-                    }`}
-                  >
-                    ›
-                  </span>
-                </button>
-                {expandedProviders[provider] && (
-                  <div className="ml-3 space-y-1 mt-2">
-                    {models.map((model) => {
-                      const selected = selectedModels.includes(model);
-                      return (
-                        <button
-                          key={model}
-                          onClick={() => onToggleModelSelection(model)}
-                          className={`flex items-center gap-2 text-left py-2 px-3 rounded-lg text-sm transition-all duration-300 w-full ${
-                            selected
-                              ? "bg-selected-bg text-text-primary shadow-md border border-selected-border"
-                              : "text-text-tertiary hover:text-text-secondary hover:bg-hover-bg"
-                          }`}
-                        >
-                          <span
-                            className="shrink-0 h-2.5 w-2.5 rounded-full"
-                            style={{ backgroundColor: getModelColor(model) }}
-                          />
-                          <span className="text-sm">
-                            {normalizeModelName(model)}
-                          </span>
-                        </button>
-                      );
-                    })}
-                  </div>
-                )}
-              </div>
-            ))}
-          </div>
+          <FacetFilter />
         </div>
       </div>
 
@@ -115,7 +57,7 @@ const MobileModelSheet: React.FC = () => {
           onClick={() => onSetMobileSheetOpen(true)}
         >
           <div className="flex items-center space-x-2 text-text-secondary text-sm">
-            <span>{selectedModels.length} selected</span>
+            <span>Filters</span>
             <div className="w-6 h-0.5 bg-text-tertiary rounded-full"></div>
           </div>
         </div>

--- a/web/components/layout/MobileModelSheet.tsx
+++ b/web/components/layout/MobileModelSheet.tsx
@@ -8,6 +8,7 @@ import { normalizeModelName } from "@/lib/utils/formatters";
 import { useDashboard } from "@/contexts/DashboardContext";
 import { useSidebarMenu } from "@/contexts/SidebarMenuContext";
 import { getModelColor } from "@/lib/utils/colors";
+import FacetFilter from "@/components/layout/FacetFilter";
 
 const MobileModelSheet: React.FC = () => {
   const {
@@ -57,6 +58,7 @@ const MobileModelSheet: React.FC = () => {
 
           {/* Model Selection */}
           <div className="space-y-2">
+            <FacetFilter />
             {Object.entries(modelsByProvider).map(([provider, models]) => (
               <div key={provider}>
                 <button

--- a/web/components/layout/MobileModelSheet.tsx
+++ b/web/components/layout/MobileModelSheet.tsx
@@ -9,7 +9,7 @@ import { useSidebarMenu } from "@/contexts/SidebarMenuContext";
 import FacetFilter from "@/components/layout/FacetFilter";
 
 const MobileModelSheet: React.FC = () => {
-  const { mobileSheetTitle: title } = useDashboard();
+  const { mobileSheetTitle: title, hasActiveFacets } = useDashboard();
   const {
     mobileSheetOpen,
     setMobileSheetOpen: onSetMobileSheetOpen,
@@ -58,6 +58,12 @@ const MobileModelSheet: React.FC = () => {
         >
           <div className="flex items-center space-x-2 text-text-secondary text-sm">
             <span>Filters</span>
+            {hasActiveFacets && (
+              <span
+                className="h-2 w-2 rounded-full bg-surface-toggle-active"
+                aria-label="Filters active"
+              />
+            )}
             <div className="w-6 h-0.5 bg-text-tertiary rounded-full"></div>
           </div>
         </div>

--- a/web/components/layout/ModelSidebar.tsx
+++ b/web/components/layout/ModelSidebar.tsx
@@ -4,9 +4,6 @@
 "use client";
 
 import React from "react";
-import { normalizeModelName } from "@/lib/utils/formatters";
-import { useDashboard } from "@/contexts/DashboardContext";
-import { getModelColor } from "@/lib/utils/colors";
 import FacetFilter from "@/components/layout/FacetFilter";
 
 // Keep the links pinned in place until the footer is about to collide with the
@@ -20,14 +17,6 @@ const SIDEBAR_BOTTOM_GAP = 16;
 const LINKS_GAP = 24;
 
 const ModelSidebar: React.FC = () => {
-  const {
-    normalizeProviderName,
-    modelsByProvider,
-    selectedModels,
-    toggleModelSelection: onToggleModelSelection,
-    toggleProviderSelection: onToggleProviderSelection,
-  } = useDashboard();
-
   const containerRef = React.useRef<HTMLDivElement>(null);
   const linksRef = React.useRef<HTMLDivElement>(null);
   const pushUpRef = React.useRef(0);
@@ -72,115 +61,9 @@ const ModelSidebar: React.FC = () => {
       ref={containerRef}
       className="hidden lg:flex flex-col fixed left-4 top-20 bottom-4 z-10 py-3 w-64"
     >
-      {/* Scrollable content area */}
       <div className="flex-1 overflow-y-auto scrollbar-hide">
-        {/* Model Selection Content */}
-        <div ref={linksRef} className="space-y-2">
+        <div ref={linksRef}>
           <FacetFilter />
-          <div>
-            {Object.entries(modelsByProvider).map(([provider, models]) => {
-              const selectedCount = models.filter((m) =>
-                selectedModels.includes(m)
-              ).length;
-              const allSelected =
-                models.length > 0 && selectedCount === models.length;
-              const someSelected = selectedCount > 0 && !allSelected;
-              return (
-              <div key={provider} className="mt-4 first:mt-0">
-                <label className="flex items-center gap-2 text-text-primary pt-1.5 pb-0.5 px-2 text-sm font-bold cursor-pointer">
-                  <span className="relative inline-flex h-3.5 w-3.5 shrink-0">
-                    <input
-                      type="checkbox"
-                      checked={allSelected}
-                      ref={(el) => {
-                        if (el) el.indeterminate = someSelected;
-                      }}
-                      onChange={() => onToggleProviderSelection(provider)}
-                      aria-label={`${
-                        allSelected ? "Deselect" : "Select"
-                      } all ${normalizeProviderName(provider)} models`}
-                      className="peer h-3.5 w-3.5 shrink-0 cursor-pointer appearance-none rounded-[3px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-text-tertiary/40 focus-visible:ring-offset-1 focus-visible:ring-offset-background"
-                      style={{
-                        backgroundColor:
-                          allSelected || someSelected
-                            ? "var(--color-text-primary)"
-                            : "#d4d2cc",
-                      }}
-                    />
-                    <svg
-                      aria-hidden
-                      viewBox="0 0 14 14"
-                      fill="none"
-                      stroke="white"
-                      strokeWidth={1.5}
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      className="pointer-events-none absolute inset-0 hidden h-3.5 w-3.5 peer-checked:block"
-                    >
-                      <path d="M3.5 7.5l2.5 2.5 4.5-5" />
-                    </svg>
-                    <svg
-                      aria-hidden
-                      viewBox="0 0 14 14"
-                      fill="none"
-                      stroke="white"
-                      strokeWidth={1.5}
-                      strokeLinecap="round"
-                      className="pointer-events-none absolute inset-0 hidden h-3.5 w-3.5 peer-indeterminate:block"
-                    >
-                      <path d="M3.5 7h7" />
-                    </svg>
-                  </span>
-                  {normalizeProviderName(provider)}
-                </label>
-                <div className="space-y-0">
-                  {models.map((model) => {
-                    const checked = selectedModels.includes(model);
-                    const modelColor = getModelColor(model);
-                    return (
-                      <label
-                        key={model}
-                        className="flex items-center gap-2 py-1.5 px-2 rounded-lg text-xs cursor-pointer text-text-tertiary"
-                      >
-                        <span className="relative inline-flex h-3.5 w-3.5 shrink-0">
-                          <input
-                            type="checkbox"
-                            checked={checked}
-                            onChange={() => onToggleModelSelection(model)}
-                            aria-label={`${
-                              checked ? "Deselect" : "Select"
-                            } ${model} model`}
-                            className="peer h-3.5 w-3.5 shrink-0 cursor-pointer appearance-none rounded-[3px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-text-tertiary/40 focus-visible:ring-offset-1 focus-visible:ring-offset-background"
-                            style={{ backgroundColor: checked ? modelColor : "#d4d2cc" }}
-                          />
-                          <svg
-                            aria-hidden
-                            viewBox="0 0 14 14"
-                            fill="none"
-                            stroke="white"
-                            strokeWidth={1.5}
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                            className="pointer-events-none absolute inset-0 hidden h-3.5 w-3.5 peer-checked:block"
-                          >
-                            <path d="M3.5 7.5l2.5 2.5 4.5-5" />
-                          </svg>
-                        </span>
-                        <span
-                          className={`truncate text-xs leading-tight ${
-                            checked ? "text-text-primary" : ""
-                          }`}
-                        >
-                          {normalizeModelName(model)}
-                        </span>
-                      </label>
-                    );
-                  })}
-                </div>
-              </div>
-              );
-            })}
-          </div>
         </div>
       </div>
     </div>

--- a/web/components/layout/ModelSidebar.tsx
+++ b/web/components/layout/ModelSidebar.tsx
@@ -7,6 +7,7 @@ import React from "react";
 import { normalizeModelName } from "@/lib/utils/formatters";
 import { useDashboard } from "@/contexts/DashboardContext";
 import { getModelColor } from "@/lib/utils/colors";
+import FacetFilter from "@/components/layout/FacetFilter";
 
 // Keep the links pinned in place until the footer is about to collide with the
 // actual bottom of the link list, then push the sidebar up so the filters slide
@@ -75,6 +76,7 @@ const ModelSidebar: React.FC = () => {
       <div className="flex-1 overflow-y-auto scrollbar-hide">
         {/* Model Selection Content */}
         <div ref={linksRef} className="space-y-2">
+          <FacetFilter />
           <div>
             {Object.entries(modelsByProvider).map(([provider, models]) => {
               const selectedCount = models.filter((m) =>

--- a/web/contexts/SidebarMenuContext.tsx
+++ b/web/contexts/SidebarMenuContext.tsx
@@ -5,7 +5,6 @@
 
 import React, { createContext, useContext } from "react";
 import { useSidebarMenuState } from "@/hooks/useSidebarMenuState";
-import { useDashboard } from "@/contexts/DashboardContext";
 
 type SidebarMenuContextType = ReturnType<typeof useSidebarMenuState>;
 
@@ -16,8 +15,7 @@ export function SidebarMenuProvider({
 }: {
   children: React.ReactNode;
 }) {
-  const { modelsByProvider } = useDashboard();
-  const value = useSidebarMenuState(modelsByProvider);
+  const value = useSidebarMenuState();
   return (
     <SidebarMenuContext.Provider value={value}>
       {children}

--- a/web/hooks/useDashboardState.tsx
+++ b/web/hooks/useDashboardState.tsx
@@ -15,6 +15,13 @@ import { useMobileDetection } from "@/hooks/useMobileDetection";
 import { useBarInteraction } from "@/hooks/useBarInteraction";
 import { latencyToMs, normalizeModelName, normalizeSTTProviderName, normalizeTTSProviderName, parseModelKey, toModelKey } from "@/lib/utils/formatters";
 import { buildModelsByProvider, pruneSelection } from "@/lib/utils/modelsFromResults";
+import {
+  buildFacetGroups,
+  buildTagIndex,
+  filterModelsByFacets,
+  toggleFacetValue,
+  type FacetSelection,
+} from "@/lib/utils/facets";
 import { getModelColor } from "@/lib/utils/colors";
 import { metricDescriptions } from "@/lib/config/metrics";
 import { useAggregatesQuery, useProvidersQuery } from "@/lib/api/queries";
@@ -61,10 +68,29 @@ export function useDashboardState(page: "tts" | "stt") {
     [aggregatesQuery.data]
   );
 
-  const modelsByProvider = useMemo(
+  // Full catalogue (minus disabled) drives the facet options; the facet
+  // selection then narrows it to what the sidebar and charts actually show.
+  const allModelsByProvider = useMemo(
     () => buildModelsByProvider(modelStats, benchmarkParam, providersQuery.data),
     [providersQuery.data, modelStats, benchmarkParam]
   );
+  const tagIndex = useMemo(
+    () => buildTagIndex(benchmarkParam, providersQuery.data),
+    [benchmarkParam, providersQuery.data]
+  );
+  const [selectedFacets, setSelectedFacets] = useState<FacetSelection>({});
+  const modelsByProvider = useMemo(
+    () => filterModelsByFacets(allModelsByProvider, tagIndex, selectedFacets),
+    [allModelsByProvider, tagIndex, selectedFacets]
+  );
+  const hasActiveFacets = useMemo(
+    () => Object.values(selectedFacets).some((v) => v.length > 0),
+    [selectedFacets]
+  );
+  const toggleFacet = useCallback((category: string, value: string) => {
+    setSelectedFacets((prev) => toggleFacetValue(prev, category, value));
+  }, []);
+  const clearFacets = useCallback(() => setSelectedFacets({}), []);
 
   const loading = aggregatesQuery.isLoading || providersQuery.isLoading;
 
@@ -312,6 +338,11 @@ export function useDashboardState(page: "tts" | "stt") {
     ? normalizeSTTProviderName
     : normalizeTTSProviderName;
 
+  const facetGroups = useMemo(
+    () => buildFacetGroups(allModelsByProvider, tagIndex, selectedFacets, normalizeProviderName),
+    [allModelsByProvider, tagIndex, selectedFacets, normalizeProviderName]
+  );
+
   const boxPlotDescription = {
     short: `Distribution of ${latencyLabel} values across all runs`,
     detailed:
@@ -399,6 +430,12 @@ export function useDashboardState(page: "tts" | "stt") {
     // Model state
     selectedModels,
     modelsByProvider,
+
+    // Faceted filters
+    facetGroups,
+    toggleFacet,
+    clearFacets,
+    hasActiveFacets,
 
     // UI state
     isMobile,

--- a/web/hooks/useDashboardState.tsx
+++ b/web/hooks/useDashboardState.tsx
@@ -20,10 +20,13 @@ import {
   buildTagIndex,
   filterModelsByFacets,
   getTagCategories,
+  hasAnySelection,
   restrictToModelKeys,
   toggleFacetValue,
   type FacetSelection,
 } from "@/lib/utils/facets";
+import { capturePostHogEvent } from "@/lib/posthog/client";
+import { POSTHOG_EVENTS } from "@/lib/posthog/events";
 import { getModelColor } from "@/lib/utils/colors";
 import { metricDescriptions } from "@/lib/config/metrics";
 import { useAggregatesQuery, useProvidersQuery } from "@/lib/api/queries";
@@ -92,13 +95,34 @@ export function useDashboardState(page: "tts" | "stt") {
     [dataBackedByProvider, tagIndex, selectedFacets]
   );
   const hasActiveFacets = useMemo(
-    () => Object.values(selectedFacets).some((v) => v.length > 0),
+    () => hasAnySelection(selectedFacets),
     [selectedFacets]
   );
-  const toggleFacet = useCallback((category: string, value: string) => {
-    setSelectedFacets((prev) => toggleFacetValue(prev, category, value));
-  }, []);
-  const clearFacets = useCallback(() => setSelectedFacets({}), []);
+  const toggleFacet = useCallback(
+    (category: string, value: string) => {
+      const removing = (selectedFacets[category] ?? []).includes(value);
+      const next = toggleFacetValue(selectedFacets, category, value);
+      setSelectedFacets(next);
+      capturePostHogEvent(POSTHOG_EVENTS.dashboardFacetChanged, {
+        surface: `${page}_dashboard`,
+        mode: page,
+        action: removing ? "remove" : "add",
+        category,
+        value,
+        active_facet_count: Object.values(next).reduce((n, v) => n + v.length, 0),
+      });
+    },
+    [selectedFacets, page]
+  );
+  const clearFacets = useCallback(() => {
+    if (!hasAnySelection(selectedFacets)) return;
+    setSelectedFacets({});
+    capturePostHogEvent(POSTHOG_EVENTS.dashboardFacetChanged, {
+      surface: `${page}_dashboard`,
+      mode: page,
+      action: "clear",
+    });
+  }, [selectedFacets, page]);
 
   // The facet filter is the only selector now, and its universe is already the
   // data-backed models, so everything still visible after filtering is plotted.

--- a/web/hooks/useDashboardState.tsx
+++ b/web/hooks/useDashboardState.tsx
@@ -19,6 +19,7 @@ import {
   buildFacetGroups,
   buildTagIndex,
   filterModelsByFacets,
+  getTagCategories,
   toggleFacetValue,
   type FacetSelection,
 } from "@/lib/utils/facets";
@@ -72,6 +73,10 @@ export function useDashboardState(page: "tts" | "stt") {
   const tagIndex = useMemo(
     () => buildTagIndex(benchmarkParam, providersQuery.data),
     [benchmarkParam, providersQuery.data]
+  );
+  const tagCategories = useMemo(
+    () => getTagCategories(providersQuery.data),
+    [providersQuery.data]
   );
   const [selectedFacets, setSelectedFacets] = useState<FacetSelection>({});
   const modelsByProvider = useMemo(
@@ -275,8 +280,15 @@ export function useDashboardState(page: "tts" | "stt") {
     : normalizeTTSProviderName;
 
   const facetGroups = useMemo(
-    () => buildFacetGroups(allModelsByProvider, tagIndex, selectedFacets, normalizeProviderName),
-    [allModelsByProvider, tagIndex, selectedFacets, normalizeProviderName]
+    () =>
+      buildFacetGroups(
+        allModelsByProvider,
+        tagIndex,
+        selectedFacets,
+        tagCategories,
+        normalizeProviderName
+      ),
+    [allModelsByProvider, tagIndex, selectedFacets, tagCategories, normalizeProviderName]
   );
 
   const boxPlotDescription = {

--- a/web/hooks/useDashboardState.tsx
+++ b/web/hooks/useDashboardState.tsx
@@ -20,6 +20,7 @@ import {
   buildTagIndex,
   filterModelsByFacets,
   getTagCategories,
+  restrictToModelKeys,
   toggleFacetValue,
   type FacetSelection,
 } from "@/lib/utils/facets";
@@ -64,8 +65,6 @@ export function useDashboardState(page: "tts" | "stt") {
     [aggregatesQuery.data]
   );
 
-  // Full catalogue (minus disabled) drives the facet options; the facet
-  // selection then narrows it to what the sidebar and charts actually show.
   const allModelsByProvider = useMemo(
     () => buildModelsByProvider(modelStats, benchmarkParam, providersQuery.data),
     [providersQuery.data, modelStats, benchmarkParam]
@@ -78,10 +77,19 @@ export function useDashboardState(page: "tts" | "stt") {
     () => getTagCategories(providersQuery.data),
     [providersQuery.data]
   );
+
+  // Facets are driven only by models that actually have data to plot. A
+  // catalogue model without stats (e.g. a batch-only or not-yet-benchmarked
+  // model) would otherwise surface a chip that counts 1 but charts nothing.
+  const dataBackedByProvider = useMemo(() => {
+    const withData = new Set(modelStats.map((s) => toModelKey(s.provider, s.model)));
+    return restrictToModelKeys(allModelsByProvider, withData);
+  }, [allModelsByProvider, modelStats]);
+
   const [selectedFacets, setSelectedFacets] = useState<FacetSelection>({});
   const modelsByProvider = useMemo(
-    () => filterModelsByFacets(allModelsByProvider, tagIndex, selectedFacets),
-    [allModelsByProvider, tagIndex, selectedFacets]
+    () => filterModelsByFacets(dataBackedByProvider, tagIndex, selectedFacets),
+    [dataBackedByProvider, tagIndex, selectedFacets]
   );
   const hasActiveFacets = useMemo(
     () => Object.values(selectedFacets).some((v) => v.length > 0),
@@ -92,15 +100,12 @@ export function useDashboardState(page: "tts" | "stt") {
   }, []);
   const clearFacets = useCallback(() => setSelectedFacets({}), []);
 
-  // The facet filter is the only selector now: every visible model that has
-  // data is plotted. Catalogue-only models (no stats) are left out — nothing
-  // to chart — and clearing a facet brings its models straight back.
-  const selectedModels = useMemo(() => {
-    const visible = new Set(Object.values(modelsByProvider).flat());
-    return [...new Set(modelStats.map((s) => toModelKey(s.provider, s.model)))].filter((key) =>
-      visible.has(key)
-    );
-  }, [modelsByProvider, modelStats]);
+  // The facet filter is the only selector now, and its universe is already the
+  // data-backed models, so everything still visible after filtering is plotted.
+  const selectedModels = useMemo(
+    () => Object.values(modelsByProvider).flat(),
+    [modelsByProvider]
+  );
 
   const loading = aggregatesQuery.isLoading || providersQuery.isLoading;
 
@@ -282,13 +287,13 @@ export function useDashboardState(page: "tts" | "stt") {
   const facetGroups = useMemo(
     () =>
       buildFacetGroups(
-        allModelsByProvider,
+        dataBackedByProvider,
         tagIndex,
         selectedFacets,
         tagCategories,
         normalizeProviderName
       ),
-    [allModelsByProvider, tagIndex, selectedFacets, tagCategories, normalizeProviderName]
+    [dataBackedByProvider, tagIndex, selectedFacets, tagCategories, normalizeProviderName]
   );
 
   const boxPlotDescription = {

--- a/web/hooks/useDashboardState.tsx
+++ b/web/hooks/useDashboardState.tsx
@@ -302,35 +302,30 @@ export function useDashboardState(page: "tts" | "stt") {
   );
 
   // Pre-computed key metrics for display
-  const primaryKeyMetric = (() => {
-    const multiple = deferredSelectedModels.length > 1;
-    return {
-      label: `Lowest Median ${activeMetric}`,
-      displayValue: `${fastestPrimary.fastestMs.toFixed(0)} ms`,
-      subtitle:
-        multiple && fastestPrimary.fastestModel
-          ? {
-              name: normalizeModelName(fastestPrimary.fastestModel),
-              detail: fastestPrimary.fastestProvider
-                ? normalizeProviderName(fastestPrimary.fastestProvider)
-                : undefined,
-            }
-          : undefined,
-    };
-  })();
+  const primaryKeyMetric = {
+    label: `Lowest Median ${activeMetric}`,
+    displayValue: `${fastestPrimary.fastestMs.toFixed(0)} ms`,
+    subtitle: fastestPrimary.fastestModel
+      ? {
+          name: normalizeModelName(fastestPrimary.fastestModel),
+          detail: fastestPrimary.fastestProvider
+            ? normalizeProviderName(fastestPrimary.fastestProvider)
+            : undefined,
+        }
+      : undefined,
+  };
 
   const secondaryKeyMetric = {
     label: `${deferredSelectedModels.length > 1 ? "Lowest" : "Average"} Word Error Rate`,
     displayValue: `${avgSecondary.toFixed(1)}%`,
-    subtitle:
-      deferredSelectedModels.length > 1 && lowestWERModel
-        ? {
-            name: normalizeModelName(lowestWERModel),
-            detail: lowestWERProvider
-              ? normalizeProviderName(lowestWERProvider)
-              : undefined,
-          }
-        : undefined,
+    subtitle: lowestWERModel
+      ? {
+          name: normalizeModelName(lowestWERModel),
+          detail: lowestWERProvider
+            ? normalizeProviderName(lowestWERProvider)
+            : undefined,
+        }
+      : undefined,
   };
 
   return {

--- a/web/hooks/useDashboardState.tsx
+++ b/web/hooks/useDashboardState.tsx
@@ -14,7 +14,7 @@ import { useChartData } from "@/hooks/useChartData";
 import { useMobileDetection } from "@/hooks/useMobileDetection";
 import { useBarInteraction } from "@/hooks/useBarInteraction";
 import { latencyToMs, normalizeModelName, normalizeSTTProviderName, normalizeTTSProviderName, parseModelKey, toModelKey } from "@/lib/utils/formatters";
-import { buildModelsByProvider, pruneSelection } from "@/lib/utils/modelsFromResults";
+import { buildModelsByProvider } from "@/lib/utils/modelsFromResults";
 import {
   buildFacetGroups,
   buildTagIndex,
@@ -25,16 +25,11 @@ import {
 import { getModelColor } from "@/lib/utils/colors";
 import { metricDescriptions } from "@/lib/config/metrics";
 import { useAggregatesQuery, useProvidersQuery } from "@/lib/api/queries";
-import { capturePostHogEvent } from "@/lib/posthog/client";
-import { POSTHOG_EVENTS } from "@/lib/posthog/events";
 import { useTimeWindow } from "@/hooks/useTimeWindow";
 import type { ModelStats } from "@/types/benchmark.types";
 import type { SeriesPoint } from "@/lib/api/client";
 
 export function useDashboardState(page: "tts" | "stt") {
-  // State declarations
-  const [selectedModels, setSelectedModels] = useState<string[]>([]);
-
   // STT shows a TTFS / TTFT toggle that drives every latency surface (headline,
   // timeline, box plot, scatter, heatmap) in sync. TTS is single-metric (TTFA),
   // so the toggle is hidden there and the metric stays TTFA.
@@ -92,6 +87,16 @@ export function useDashboardState(page: "tts" | "stt") {
   }, []);
   const clearFacets = useCallback(() => setSelectedFacets({}), []);
 
+  // The facet filter is the only selector now: every visible model that has
+  // data is plotted. Catalogue-only models (no stats) are left out — nothing
+  // to chart — and clearing a facet brings its models straight back.
+  const selectedModels = useMemo(() => {
+    const visible = new Set(Object.values(modelsByProvider).flat());
+    return [...new Set(modelStats.map((s) => toModelKey(s.provider, s.model)))].filter((key) =>
+      visible.has(key)
+    );
+  }, [modelsByProvider, modelStats]);
+
   const loading = aggregatesQuery.isLoading || providersQuery.isLoading;
 
   const isMobile = useMobileDetection();
@@ -111,52 +116,6 @@ export function useDashboardState(page: "tts" | "stt") {
     modelsByProvider,
     timeWindow: dataTimeWindow,
   });
-
-  // Event handlers
-  const toggleModelSelection = useCallback(
-    (model: string) => {
-      const willBeSelected = !selectedModels.includes(model);
-      const nextSelected = willBeSelected
-        ? [...selectedModels, model]
-        : selectedModels.filter((m) => m !== model);
-      capturePostHogEvent(POSTHOG_EVENTS.dashboardModelSelectionChanged, {
-        surface: `${page}_dashboard`,
-        mode: page,
-        action: willBeSelected ? "add" : "remove",
-        model_id: model,
-        selected_model_ids: nextSelected,
-        selected_model_count: nextSelected.length,
-        is_comparison: nextSelected.length >= 2
-      });
-      setSelectedModels(nextSelected);
-    },
-    [selectedModels, page]
-  );
-
-  // Select all of a provider's models unless they're all already selected.
-  const toggleProviderSelection = useCallback(
-    (provider: string) => {
-      const providerModels = modelsByProvider[provider] ?? [];
-      if (providerModels.length === 0) return;
-      const willBeSelected = !providerModels.every((m) =>
-        selectedModels.includes(m)
-      );
-      const nextSelected = willBeSelected
-        ? [...new Set([...selectedModels, ...providerModels])]
-        : selectedModels.filter((m) => !providerModels.includes(m));
-      capturePostHogEvent(POSTHOG_EVENTS.dashboardModelSelectionChanged, {
-        surface: `${page}_dashboard`,
-        mode: page,
-        action: willBeSelected ? "add" : "remove",
-        provider,
-        selected_model_ids: nextSelected,
-        selected_model_count: nextSelected.length,
-        is_comparison: nextSelected.length >= 2
-      });
-      setSelectedModels(nextSelected);
-    },
-    [selectedModels, modelsByProvider, page]
-  );
 
   // Heatmap scaling for mobile. Skipped while loading (only the skeleton is
   // in the DOM); re-runs when loading completes so the first paint of the
@@ -215,29 +174,6 @@ export function useDashboardState(page: "tts" | "stt") {
     window.addEventListener("resize", scaleHeatmapForMobile);
     return () => window.removeEventListener("resize", scaleHeatmapForMobile);
   }, [page, loading]);
-
-  // Auto-select models that have aggregate stats once they load. Catalogue-only
-  // models (in modelsByProvider but absent from modelStats) stay unselected —
-  // they have nothing to plot.
-  useEffect(() => {
-    if (modelStats.length === 0 || selectedModels.length > 0) return;
-    const visible = new Set(Object.values(modelsByProvider).flat());
-    const withStats = [
-      ...new Set(modelStats.map((s) => toModelKey(s.provider, s.model))),
-    ].filter((key) => visible.has(key));
-    if (withStats.length > 0) setSelectedModels(withStats);
-  }, [modelStats, modelsByProvider, selectedModels.length]);
-
-  // Keep the selection a subset of the visible models. Once provider metadata
-  // loads, a model that results alone had surfaced may be filtered out of
-  // modelsByProvider; drop it so it stops being plotted while absent from the
-  // sidebar. Removal-only, so it never fights a manual selection.
-  useEffect(() => {
-    setSelectedModels((prev) => {
-      const next = pruneSelection(prev, modelsByProvider);
-      return next.length === prev.length ? prev : next;
-    });
-  }, [modelsByProvider]);
 
   // Calculate metrics
   const { getStat, getHeatmapData } = chartData;
@@ -444,8 +380,6 @@ export function useDashboardState(page: "tts" | "stt") {
     windowDataStale,
 
     // Actions
-    toggleModelSelection,
-    toggleProviderSelection,
     changeTimeWindow,
 
     // Chart data functions

--- a/web/hooks/useSidebarMenuState.ts
+++ b/web/hooks/useSidebarMenuState.ts
@@ -3,43 +3,9 @@
 
 "use client";
 
-import { useState, useEffect, useCallback, useMemo, useRef } from "react";
-import type { ModelsByProvider } from "@/types/benchmark.types";
+import { useState } from "react";
 
-export function useSidebarMenuState(modelsByProvider: ModelsByProvider) {
-  const [expandedProviders, setExpandedProviders] = useState<{
-    [key: string]: boolean;
-  }>({});
+export function useSidebarMenuState() {
   const [mobileSheetOpen, setMobileSheetOpen] = useState(false);
-
-  // Expand every provider group once, the first time models arrive.
-  const hasExpandedRef = useRef(false);
-  useEffect(() => {
-    if (hasExpandedRef.current) return;
-    const providers = Object.keys(modelsByProvider);
-    if (providers.length === 0) return;
-    const expanded: Record<string, boolean> = {};
-    providers.forEach((provider) => {
-      expanded[provider] = true;
-    });
-    setExpandedProviders(expanded);
-    hasExpandedRef.current = true;
-  }, [modelsByProvider]);
-
-  const toggleProvider = useCallback((provider: string) => {
-    setExpandedProviders((prev) => ({
-      ...prev,
-      [provider]: !prev[provider],
-    }));
-  }, []);
-
-  return useMemo(
-    () => ({
-      expandedProviders,
-      mobileSheetOpen,
-      setMobileSheetOpen,
-      toggleProvider,
-    }),
-    [expandedProviders, mobileSheetOpen, toggleProvider]
-  );
+  return { mobileSheetOpen, setMobileSheetOpen };
 }

--- a/web/lib/api/client.ts
+++ b/web/lib/api/client.ts
@@ -48,6 +48,8 @@ async function request<T>(path: string, init?: Parameters<typeof fetch>[1]): Pro
 export type ProvidersApiResponse = components["schemas"]["ProvidersResponse"];
 export type ProviderInfo = components["schemas"]["ProviderInfo"];
 export type ModelInfo = components["schemas"]["ModelInfo"];
+export type ModelTagOut = components["schemas"]["ModelTagOut"];
+export type TagCategoryOut = components["schemas"]["TagCategoryOut"];
 export type LeaderboardApiResponse = components["schemas"]["LeaderboardResponse"];
 export type LeaderboardEntry = components["schemas"]["LeaderboardEntry"];
 export type RunRow = components["schemas"]["RunOut"];

--- a/web/lib/api/client.ts
+++ b/web/lib/api/client.ts
@@ -48,7 +48,6 @@ async function request<T>(path: string, init?: Parameters<typeof fetch>[1]): Pro
 export type ProvidersApiResponse = components["schemas"]["ProvidersResponse"];
 export type ProviderInfo = components["schemas"]["ProviderInfo"];
 export type ModelInfo = components["schemas"]["ModelInfo"];
-export type ModelTagOut = components["schemas"]["ModelTagOut"];
 export type LeaderboardApiResponse = components["schemas"]["LeaderboardResponse"];
 export type LeaderboardEntry = components["schemas"]["LeaderboardEntry"];
 export type RunRow = components["schemas"]["RunOut"];

--- a/web/lib/api/client.ts
+++ b/web/lib/api/client.ts
@@ -48,6 +48,7 @@ async function request<T>(path: string, init?: Parameters<typeof fetch>[1]): Pro
 export type ProvidersApiResponse = components["schemas"]["ProvidersResponse"];
 export type ProviderInfo = components["schemas"]["ProviderInfo"];
 export type ModelInfo = components["schemas"]["ModelInfo"];
+export type ModelTagOut = components["schemas"]["ModelTagOut"];
 export type LeaderboardApiResponse = components["schemas"]["LeaderboardResponse"];
 export type LeaderboardEntry = components["schemas"]["LeaderboardEntry"];
 export type RunRow = components["schemas"]["RunOut"];

--- a/web/lib/api/generated/schema.ts
+++ b/web/lib/api/generated/schema.ts
@@ -49,11 +49,6 @@ export interface components {
     ModelInfo: {
       model: string;
       disabled?: boolean;
-      tags?: components["schemas"]["ModelTagOut"][];
-    };
-    ModelTagOut: {
-      category: string;
-      value: string;
     };
     ModelStatEntry: {
       provider: string;

--- a/web/lib/api/generated/schema.ts
+++ b/web/lib/api/generated/schema.ts
@@ -49,6 +49,7 @@ export interface components {
     ModelInfo: {
       model: string;
       disabled?: boolean;
+      tags?: components["schemas"]["ModelTagOut"][];
     };
     ModelStatEntry: {
       provider: string;
@@ -66,6 +67,11 @@ export interface components {
       max_value: number;
       sample_count: number;
     };
+    ModelTagOut: {
+      category: components["schemas"]["TagCategory"];
+      value: string;
+      label: string;
+    };
     ProviderInfo: {
       provider: string;
       models: components["schemas"]["ModelInfo"][];
@@ -74,6 +80,7 @@ export interface components {
     ProvidersResponse: {
       stt: components["schemas"]["ProviderInfo"][];
       tts: components["schemas"]["ProviderInfo"][];
+      tag_categories: components["schemas"]["TagCategoryOut"][];
     };
     RunOut: {
       id: number;
@@ -101,6 +108,12 @@ export interface components {
       max_value: number;
       value_sum: number;
       sample_count: number;
+    };
+    TagCategory: "type" | "mode" | "host" | "lab" | "features" | "source" | "tenancy";
+    TagCategoryOut: {
+      category: components["schemas"]["TagCategory"];
+      label: string;
+      provider_valued?: boolean;
     };
     WindowLiteral: "24h" | "7d" | "30d";
   };

--- a/web/lib/api/generated/schema.ts
+++ b/web/lib/api/generated/schema.ts
@@ -49,6 +49,11 @@ export interface components {
     ModelInfo: {
       model: string;
       disabled?: boolean;
+      tags?: components["schemas"]["ModelTagOut"][];
+    };
+    ModelTagOut: {
+      category: string;
+      value: string;
     };
     ModelStatEntry: {
       provider: string;

--- a/web/lib/posthog/events.ts
+++ b/web/lib/posthog/events.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 export const POSTHOG_EVENTS = {
+  dashboardFacetChanged: "dashboard_facet_changed",
   playgroundModelSelectionChanged: "playground_model_selection_changed",
   playgroundTtsBenchmarkPressed: "playground_tts_benchmark_pressed",
   playgroundSttRecordPressed: "playground_stt_record_pressed",

--- a/web/lib/posthog/events.ts
+++ b/web/lib/posthog/events.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 export const POSTHOG_EVENTS = {
-  dashboardModelSelectionChanged: "dashboard_model_selection_changed",
   playgroundModelSelectionChanged: "playground_model_selection_changed",
   playgroundTtsBenchmarkPressed: "playground_tts_benchmark_pressed",
   playgroundSttRecordPressed: "playground_stt_record_pressed",
@@ -26,7 +25,6 @@ export type PostHogSurface =
   | "playground"
   | "overview";
 export type PostHogMode = "tts" | "stt";
-export type SelectionAction = "add" | "remove";
 export type DashboardChartId =
   | "timeline"
   | "scatter"

--- a/web/lib/utils/facets.test.ts
+++ b/web/lib/utils/facets.test.ts
@@ -9,6 +9,7 @@ import {
   buildTagIndex,
   filterModelsByFacets,
   getTagCategories,
+  restrictToModelKeys,
   toggleFacetValue,
 } from "./facets";
 
@@ -113,6 +114,26 @@ describe("buildFacetGroups", () => {
     const groups = buildFacetGroups(ALL, index(), {}, cats(), (s) => s.toUpperCase());
     const host = groups.find((g) => g.category === "host")!;
     expect(host.options.map((o) => o.label)).toEqual(["CARTESIA", "DEEPGRAM", "OPENAI"]);
+  });
+});
+
+describe("restrictToModelKeys", () => {
+  it("drops models without data and prunes emptied providers", () => {
+    // openai:gpt-4o-transcribe has no data → openai drops entirely; a chip
+    // built over the result can't count a model that would chart nothing.
+    const withData = new Set(["deepgram:nova-2", "cartesia:ink-2"]);
+    expect(restrictToModelKeys(ALL, withData)).toEqual({
+      deepgram: ["deepgram:nova-2"],
+      cartesia: ["cartesia:ink-2"],
+    });
+  });
+
+  it("hides a category once its only data-backed value collapses to one", () => {
+    // Only deepgram models have data → host has a single value → not a facet.
+    const withData = new Set(["deepgram:nova-2", "deepgram:flux-general-en"]);
+    const universe = restrictToModelKeys(ALL, withData);
+    const groups = buildFacetGroups(universe, index(), {}, cats(), (s) => s);
+    expect(groups.map((g) => g.category)).not.toContain("host");
   });
 });
 

--- a/web/lib/utils/facets.test.ts
+++ b/web/lib/utils/facets.test.ts
@@ -2,56 +2,55 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, expect, it } from "vitest";
-import type { ProvidersApiResponse } from "../api/client";
+import type { ProvidersApiResponse, TagCategoryOut } from "../api/client";
 import type { ModelsByProvider } from "../../types/benchmark.types";
 import {
   buildFacetGroups,
   buildTagIndex,
   filterModelsByFacets,
+  getTagCategories,
   toggleFacetValue,
 } from "./facets";
 
 // Four STT models: every mode is realtime (single-value → not a facet); host
-// and features vary, so those are the real facets. Cast because `tags` is read
-// defensively in facets.ts and isn't part of the generated ModelInfo type.
-function tag(category: string, value: string) {
-  return { category, value };
+// and features vary, so those are the real facets. Each tag carries the label
+// the API supplies; host is provider-valued so its label is the raw id.
+function tag(category: string, value: string, label: string) {
+  return { category, value, label };
 }
+const TYPE = tag("type", "STT", "STT");
+const REALTIME = tag("mode", "realtime", "Realtime");
+const MULTI = tag("features", "multilingual", "Multilingual");
+const VAD = tag("features", "vad", "VAD");
+const host = (id: string) => tag("host", id, id);
+
+const TAG_CATEGORIES: TagCategoryOut[] = [
+  { category: "type", label: "Type", provider_valued: false },
+  { category: "mode", label: "Mode", provider_valued: false },
+  { category: "host", label: "Host", provider_valued: true },
+  { category: "features", label: "Features", provider_valued: false },
+];
+
 const PROVIDERS = {
   stt: [
     {
       provider: "deepgram",
       models: [
-        {
-          model: "nova-2",
-          tags: [tag("type", "STT"), tag("host", "deepgram"), tag("mode", "realtime"), tag("features", "multilingual"), tag("features", "vad")],
-        },
-        {
-          model: "flux-general-en",
-          tags: [tag("type", "STT"), tag("host", "deepgram"), tag("mode", "realtime"), tag("features", "vad")],
-        },
+        { model: "nova-2", tags: [TYPE, host("deepgram"), REALTIME, MULTI, VAD] },
+        { model: "flux-general-en", tags: [TYPE, host("deepgram"), REALTIME, VAD] },
       ],
     },
     {
       provider: "openai",
-      models: [
-        {
-          model: "gpt-4o-transcribe",
-          tags: [tag("type", "STT"), tag("host", "openai"), tag("mode", "realtime"), tag("features", "multilingual"), tag("features", "vad")],
-        },
-      ],
+      models: [{ model: "gpt-4o-transcribe", tags: [TYPE, host("openai"), REALTIME, MULTI, VAD] }],
     },
     {
       provider: "cartesia",
-      models: [
-        {
-          model: "ink-2",
-          tags: [tag("type", "STT"), tag("host", "cartesia"), tag("mode", "realtime"), tag("features", "vad")],
-        },
-      ],
+      models: [{ model: "ink-2", tags: [TYPE, host("cartesia"), REALTIME, VAD] }],
     },
   ],
   tts: [],
+  tag_categories: TAG_CATEGORIES,
 } as unknown as ProvidersApiResponse;
 
 const ALL: ModelsByProvider = {
@@ -61,6 +60,7 @@ const ALL: ModelsByProvider = {
 };
 
 const index = () => buildTagIndex("STT", PROVIDERS);
+const cats = () => getTagCategories(PROVIDERS);
 
 describe("filterModelsByFacets", () => {
   it("returns everything when nothing is selected", () => {
@@ -88,25 +88,31 @@ describe("filterModelsByFacets", () => {
 describe("buildFacetGroups", () => {
   const id = (s: string) => s;
 
-  it("drops single-value categories (type, mode) and keeps host + features", () => {
-    const groups = buildFacetGroups(ALL, index(), {}, id);
+  it("drops single-value categories (type, mode) and keeps host + features in API order", () => {
+    const groups = buildFacetGroups(ALL, index(), {}, cats(), id);
     expect(groups.map((g) => g.category)).toEqual(["host", "features"]);
   });
 
   it("counts honor the other categories' selection", () => {
-    const groups = buildFacetGroups(ALL, index(), { features: ["multilingual"] }, id);
+    const groups = buildFacetGroups(ALL, index(), { features: ["multilingual"] }, cats(), id);
     const host = groups.find((g) => g.category === "host")!;
     const byValue = Object.fromEntries(host.options.map((o) => [o.value, o.count]));
     // Among multilingual models, deepgram has 1 (nova-2), openai 1, cartesia 0.
     expect(byValue).toEqual({ deepgram: 1, openai: 1, cartesia: 0 });
   });
 
-  it("labels VAD specially and marks active options", () => {
-    const groups = buildFacetGroups(ALL, index(), { features: ["vad"] }, id);
+  it("uses the API-supplied label and marks active options", () => {
+    const groups = buildFacetGroups(ALL, index(), { features: ["vad"] }, cats(), id);
     const features = groups.find((g) => g.category === "features")!;
     const vad = features.options.find((o) => o.value === "vad")!;
     expect(vad.label).toBe("VAD");
     expect(vad.active).toBe(true);
+  });
+
+  it("renders provider-valued categories through normalizeProvider", () => {
+    const groups = buildFacetGroups(ALL, index(), {}, cats(), (s) => s.toUpperCase());
+    const host = groups.find((g) => g.category === "host")!;
+    expect(host.options.map((o) => o.label)).toEqual(["CARTESIA", "DEEPGRAM", "OPENAI"]);
   });
 });
 

--- a/web/lib/utils/facets.test.ts
+++ b/web/lib/utils/facets.test.ts
@@ -1,0 +1,118 @@
+// Copyright 2026 The Coval Benchmarks Authors
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+import type { ProvidersApiResponse } from "../api/client";
+import type { ModelsByProvider } from "../../types/benchmark.types";
+import {
+  buildFacetGroups,
+  buildTagIndex,
+  filterModelsByFacets,
+  toggleFacetValue,
+} from "./facets";
+
+// Four STT models: every mode is realtime (single-value → not a facet); host
+// and features vary, so those are the real facets.
+function tag(category: string, value: string) {
+  return { category, value };
+}
+const PROVIDERS: ProvidersApiResponse = {
+  stt: [
+    {
+      provider: "deepgram",
+      models: [
+        {
+          model: "nova-2",
+          tags: [tag("type", "STT"), tag("host", "deepgram"), tag("mode", "realtime"), tag("features", "multilingual"), tag("features", "vad")],
+        },
+        {
+          model: "flux-general-en",
+          tags: [tag("type", "STT"), tag("host", "deepgram"), tag("mode", "realtime"), tag("features", "vad")],
+        },
+      ],
+    },
+    {
+      provider: "openai",
+      models: [
+        {
+          model: "gpt-4o-transcribe",
+          tags: [tag("type", "STT"), tag("host", "openai"), tag("mode", "realtime"), tag("features", "multilingual"), tag("features", "vad")],
+        },
+      ],
+    },
+    {
+      provider: "cartesia",
+      models: [
+        {
+          model: "ink-2",
+          tags: [tag("type", "STT"), tag("host", "cartesia"), tag("mode", "realtime"), tag("features", "vad")],
+        },
+      ],
+    },
+  ],
+  tts: [],
+};
+
+const ALL: ModelsByProvider = {
+  deepgram: ["deepgram:nova-2", "deepgram:flux-general-en"],
+  openai: ["openai:gpt-4o-transcribe"],
+  cartesia: ["cartesia:ink-2"],
+};
+
+const index = () => buildTagIndex("STT", PROVIDERS);
+
+describe("filterModelsByFacets", () => {
+  it("returns everything when nothing is selected", () => {
+    expect(filterModelsByFacets(ALL, index(), {})).toEqual(ALL);
+  });
+
+  it("ORs values within a category", () => {
+    const out = filterModelsByFacets(ALL, index(), { host: ["deepgram", "openai"] });
+    expect(out.deepgram).toHaveLength(2);
+    expect(out.openai).toHaveLength(1);
+    expect(out.cartesia).toBeUndefined();
+  });
+
+  it("ANDs across categories", () => {
+    const out = filterModelsByFacets(ALL, index(), {
+      host: ["deepgram", "openai"],
+      features: ["multilingual"],
+    });
+    // flux-general-en is deepgram but not multilingual → dropped.
+    expect(out.deepgram).toEqual(["deepgram:nova-2"]);
+    expect(out.openai).toEqual(["openai:gpt-4o-transcribe"]);
+  });
+});
+
+describe("buildFacetGroups", () => {
+  const id = (s: string) => s;
+
+  it("drops single-value categories (type, mode) and keeps host + features", () => {
+    const groups = buildFacetGroups(ALL, index(), {}, id);
+    expect(groups.map((g) => g.category)).toEqual(["host", "features"]);
+  });
+
+  it("counts honor the other categories' selection", () => {
+    const groups = buildFacetGroups(ALL, index(), { features: ["multilingual"] }, id);
+    const host = groups.find((g) => g.category === "host")!;
+    const byValue = Object.fromEntries(host.options.map((o) => [o.value, o.count]));
+    // Among multilingual models, deepgram has 1 (nova-2), openai 1, cartesia 0.
+    expect(byValue).toEqual({ deepgram: 1, openai: 1, cartesia: 0 });
+  });
+
+  it("labels VAD specially and marks active options", () => {
+    const groups = buildFacetGroups(ALL, index(), { features: ["vad"] }, id);
+    const features = groups.find((g) => g.category === "features")!;
+    const vad = features.options.find((o) => o.value === "vad")!;
+    expect(vad.label).toBe("VAD");
+    expect(vad.active).toBe(true);
+  });
+});
+
+describe("toggleFacetValue", () => {
+  it("adds, then removes and prunes the empty category", () => {
+    const added = toggleFacetValue({}, "host", "openai");
+    expect(added).toEqual({ host: ["openai"] });
+    expect(toggleFacetValue(added, "host", "openai")).toEqual({});
+  });
+});

--- a/web/lib/utils/facets.test.ts
+++ b/web/lib/utils/facets.test.ts
@@ -12,11 +12,12 @@ import {
 } from "./facets";
 
 // Four STT models: every mode is realtime (single-value → not a facet); host
-// and features vary, so those are the real facets.
+// and features vary, so those are the real facets. Cast because `tags` is read
+// defensively in facets.ts and isn't part of the generated ModelInfo type.
 function tag(category: string, value: string) {
   return { category, value };
 }
-const PROVIDERS: ProvidersApiResponse = {
+const PROVIDERS = {
   stt: [
     {
       provider: "deepgram",
@@ -51,7 +52,7 @@ const PROVIDERS: ProvidersApiResponse = {
     },
   ],
   tts: [],
-};
+} as unknown as ProvidersApiResponse;
 
 const ALL: ModelsByProvider = {
   deepgram: ["deepgram:nova-2", "deepgram:flux-general-en"],

--- a/web/lib/utils/facets.ts
+++ b/web/lib/utils/facets.ts
@@ -1,17 +1,9 @@
 // Copyright 2026 The Coval Benchmarks Authors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { ProvidersApiResponse } from "../api/client";
+import type { ModelTagOut, ProvidersApiResponse, TagCategoryOut } from "../api/client";
 import type { ModelsByProvider } from "../../types/benchmark.types";
 import { toModelKey } from "./formatters";
-
-// Defined locally, not from the generated schema, so the build never depends on
-// the API having shipped `tags` yet — codegen rebuilds ModelInfo from the live
-// API, and the frontend reads tags defensively (absent -> no facets).
-export interface ModelTag {
-  category: string;
-  value: string;
-}
 
 /** category -> selected values. Within a category values OR; across categories they AND. */
 export type FacetSelection = Record<string, string[]>;
@@ -29,50 +21,30 @@ export interface FacetGroup {
   options: FacetOption[];
 }
 
-// Display order and labels for the tag categories the API emits.
-const CATEGORY_ORDER = ["type", "mode", "host", "lab", "features", "source", "tenancy"];
-const CATEGORY_LABELS: Record<string, string> = {
-  type: "Type",
-  mode: "Mode",
-  host: "Host",
-  lab: "Lab",
-  features: "Features",
-  source: "Source",
-  tenancy: "Tenancy",
-};
-// Values whose nice form isn't just a capitalization.
-const VALUE_LABELS: Record<string, string> = { vad: "VAD" };
+/** The facet vocabulary (categories, labels, order) — sourced entirely from the API. */
+export function getTagCategories(providers?: ProvidersApiResponse): TagCategoryOut[] {
+  return providers?.tag_categories ?? [];
+}
 
 /** Map every catalogue model's composite key to its tags. */
 export function buildTagIndex(
   benchmark: "STT" | "TTS",
   providers?: ProvidersApiResponse
-): Map<string, ModelTag[]> {
-  const index = new Map<string, ModelTag[]>();
+): Map<string, ModelTagOut[]> {
+  const index = new Map<string, ModelTagOut[]>();
   if (!providers) return index;
   const catalogue = benchmark === "STT" ? providers.stt : providers.tts;
   for (const providerInfo of catalogue) {
     for (const modelInfo of providerInfo.models) {
-      const tags = (modelInfo as { tags?: ModelTag[] }).tags ?? [];
-      index.set(toModelKey(providerInfo.provider, modelInfo.model), tags);
+      index.set(toModelKey(providerInfo.provider, modelInfo.model), modelInfo.tags ?? []);
     }
   }
   return index;
 }
 
-function facetValueLabel(
-  category: string,
-  value: string,
-  normalizeProvider: (name: string) => string
-): string {
-  if (category === "host" || category === "lab") return normalizeProvider(value);
-  if (category === "type") return value.toUpperCase();
-  return VALUE_LABELS[value] ?? value.charAt(0).toUpperCase() + value.slice(1);
-}
-
 // A model passes when, for every category with a selection, it carries at least
 // one of the selected values in that category (OR within, AND across).
-function matchesSelection(tags: ModelTag[], selected: FacetSelection): boolean {
+function matchesSelection(tags: ModelTagOut[], selected: FacetSelection): boolean {
   for (const [category, values] of Object.entries(selected)) {
     if (values.length === 0) continue;
     const hit = tags.some((t) => t.category === category && values.includes(t.value));
@@ -87,7 +59,7 @@ const hasAnySelection = (selected: FacetSelection): boolean =>
 /** Narrow modelsByProvider to the models passing the current facet selection. */
 export function filterModelsByFacets(
   modelsByProvider: ModelsByProvider,
-  tagIndex: Map<string, ModelTag[]>,
+  tagIndex: Map<string, ModelTagOut[]>,
   selected: FacetSelection
 ): ModelsByProvider {
   if (!hasAnySelection(selected)) return modelsByProvider;
@@ -100,32 +72,33 @@ export function filterModelsByFacets(
 }
 
 /**
- * Build the chip groups. A category is shown only when it has at least two
- * distinct values across the visible models — a single-value facet can't filter
- * anything. Each option's count is the number of models that would remain if it
- * were selected, honoring the other categories' current selection.
+ * Build the chip groups, in the API's category order. A category is shown only
+ * when the visible models hold at least two distinct values for it. Each
+ * option's count is how many models would remain if it were selected, honoring
+ * the other categories' selection.
  */
 export function buildFacetGroups(
   modelsByProvider: ModelsByProvider,
-  tagIndex: Map<string, ModelTag[]>,
+  tagIndex: Map<string, ModelTagOut[]>,
   selected: FacetSelection,
+  tagCategories: TagCategoryOut[],
   normalizeProvider: (name: string) => string
 ): FacetGroup[] {
   const visibleKeys = Object.values(modelsByProvider).flat();
   const groups: FacetGroup[] = [];
 
-  for (const category of CATEGORY_ORDER) {
-    const values = new Set<string>();
+  for (const { category, label, provider_valued } of tagCategories) {
+    const valueLabels = new Map<string, string>();
     for (const key of visibleKeys) {
       for (const tag of tagIndex.get(key) ?? []) {
-        if (tag.category === category) values.add(tag.value);
+        if (tag.category === category) valueLabels.set(tag.value, tag.label);
       }
     }
-    if (values.size < 2) continue;
+    if (valueLabels.size < 2) continue;
 
     const others: FacetSelection = { ...selected, [category]: [] };
-    const options: FacetOption[] = [...values]
-      .map((value) => {
+    const options: FacetOption[] = [...valueLabels.entries()]
+      .map(([value, valueLabel]) => {
         const count = visibleKeys.filter((key) => {
           const tags = tagIndex.get(key) ?? [];
           return (
@@ -135,14 +108,14 @@ export function buildFacetGroups(
         }).length;
         return {
           value,
-          label: facetValueLabel(category, value, normalizeProvider),
+          label: provider_valued ? normalizeProvider(value) : valueLabel,
           count,
           active: (selected[category] ?? []).includes(value),
         };
       })
       .sort((a, b) => a.label.localeCompare(b.label));
 
-    groups.push({ category, label: CATEGORY_LABELS[category] ?? category, options });
+    groups.push({ category, label, options });
   }
 
   return groups;

--- a/web/lib/utils/facets.ts
+++ b/web/lib/utils/facets.ts
@@ -53,7 +53,8 @@ function matchesSelection(tags: ModelTagOut[], selected: FacetSelection): boolea
   return true;
 }
 
-const hasAnySelection = (selected: FacetSelection): boolean =>
+/** True when any category has at least one selected value. */
+export const hasAnySelection = (selected: FacetSelection): boolean =>
   Object.values(selected).some((v) => v.length > 0);
 
 /**

--- a/web/lib/utils/facets.ts
+++ b/web/lib/utils/facets.ts
@@ -1,0 +1,155 @@
+// Copyright 2026 The Coval Benchmarks Authors
+// SPDX-License-Identifier: Apache-2.0
+
+import type { ModelTagOut, ProvidersApiResponse } from "../api/client";
+import type { ModelsByProvider } from "../../types/benchmark.types";
+import { toModelKey } from "./formatters";
+
+/** category -> selected values. Within a category values OR; across categories they AND. */
+export type FacetSelection = Record<string, string[]>;
+
+export interface FacetOption {
+  value: string;
+  label: string;
+  count: number;
+  active: boolean;
+}
+
+export interface FacetGroup {
+  category: string;
+  label: string;
+  options: FacetOption[];
+}
+
+// Display order and labels for the tag categories the API emits.
+const CATEGORY_ORDER = ["type", "mode", "host", "lab", "features", "source", "tenancy"];
+const CATEGORY_LABELS: Record<string, string> = {
+  type: "Type",
+  mode: "Mode",
+  host: "Host",
+  lab: "Lab",
+  features: "Features",
+  source: "Source",
+  tenancy: "Tenancy",
+};
+// Values whose nice form isn't just a capitalization.
+const VALUE_LABELS: Record<string, string> = { vad: "VAD" };
+
+/** Map every catalogue model's composite key to its tags. */
+export function buildTagIndex(
+  benchmark: "STT" | "TTS",
+  providers?: ProvidersApiResponse
+): Map<string, ModelTagOut[]> {
+  const index = new Map<string, ModelTagOut[]>();
+  if (!providers) return index;
+  const catalogue = benchmark === "STT" ? providers.stt : providers.tts;
+  for (const providerInfo of catalogue) {
+    for (const modelInfo of providerInfo.models) {
+      index.set(toModelKey(providerInfo.provider, modelInfo.model), modelInfo.tags ?? []);
+    }
+  }
+  return index;
+}
+
+function facetValueLabel(
+  category: string,
+  value: string,
+  normalizeProvider: (name: string) => string
+): string {
+  if (category === "host" || category === "lab") return normalizeProvider(value);
+  if (category === "type") return value.toUpperCase();
+  return VALUE_LABELS[value] ?? value.charAt(0).toUpperCase() + value.slice(1);
+}
+
+// A model passes when, for every category with a selection, it carries at least
+// one of the selected values in that category (OR within, AND across).
+function matchesSelection(tags: ModelTagOut[], selected: FacetSelection): boolean {
+  for (const [category, values] of Object.entries(selected)) {
+    if (values.length === 0) continue;
+    const hit = tags.some((t) => t.category === category && values.includes(t.value));
+    if (!hit) return false;
+  }
+  return true;
+}
+
+const hasAnySelection = (selected: FacetSelection): boolean =>
+  Object.values(selected).some((v) => v.length > 0);
+
+/** Narrow modelsByProvider to the models passing the current facet selection. */
+export function filterModelsByFacets(
+  modelsByProvider: ModelsByProvider,
+  tagIndex: Map<string, ModelTagOut[]>,
+  selected: FacetSelection
+): ModelsByProvider {
+  if (!hasAnySelection(selected)) return modelsByProvider;
+  const out: ModelsByProvider = {};
+  for (const [provider, keys] of Object.entries(modelsByProvider)) {
+    const kept = keys.filter((key) => matchesSelection(tagIndex.get(key) ?? [], selected));
+    if (kept.length > 0) out[provider] = kept;
+  }
+  return out;
+}
+
+/**
+ * Build the chip groups. A category is shown only when it has at least two
+ * distinct values across the visible models — a single-value facet can't filter
+ * anything. Each option's count is the number of models that would remain if it
+ * were selected, honoring the other categories' current selection.
+ */
+export function buildFacetGroups(
+  modelsByProvider: ModelsByProvider,
+  tagIndex: Map<string, ModelTagOut[]>,
+  selected: FacetSelection,
+  normalizeProvider: (name: string) => string
+): FacetGroup[] {
+  const visibleKeys = Object.values(modelsByProvider).flat();
+  const groups: FacetGroup[] = [];
+
+  for (const category of CATEGORY_ORDER) {
+    const values = new Set<string>();
+    for (const key of visibleKeys) {
+      for (const tag of tagIndex.get(key) ?? []) {
+        if (tag.category === category) values.add(tag.value);
+      }
+    }
+    if (values.size < 2) continue;
+
+    const others: FacetSelection = { ...selected, [category]: [] };
+    const options: FacetOption[] = [...values]
+      .map((value) => {
+        const count = visibleKeys.filter((key) => {
+          const tags = tagIndex.get(key) ?? [];
+          return (
+            tags.some((t) => t.category === category && t.value === value) &&
+            matchesSelection(tags, others)
+          );
+        }).length;
+        return {
+          value,
+          label: facetValueLabel(category, value, normalizeProvider),
+          count,
+          active: (selected[category] ?? []).includes(value),
+        };
+      })
+      .sort((a, b) => a.label.localeCompare(b.label));
+
+    groups.push({ category, label: CATEGORY_LABELS[category] ?? category, options });
+  }
+
+  return groups;
+}
+
+export function toggleFacetValue(
+  selected: FacetSelection,
+  category: string,
+  value: string
+): FacetSelection {
+  const current = selected[category] ?? [];
+  const next = current.includes(value)
+    ? current.filter((v) => v !== value)
+    : [...current, value];
+  const out = { ...selected };
+  if (next.length > 0) out[category] = next;
+  else delete out[category];
+  return out;
+}

--- a/web/lib/utils/facets.ts
+++ b/web/lib/utils/facets.ts
@@ -1,9 +1,17 @@
 // Copyright 2026 The Coval Benchmarks Authors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { ModelTagOut, ProvidersApiResponse } from "../api/client";
+import type { ProvidersApiResponse } from "../api/client";
 import type { ModelsByProvider } from "../../types/benchmark.types";
 import { toModelKey } from "./formatters";
+
+// Defined locally, not from the generated schema, so the build never depends on
+// the API having shipped `tags` yet — codegen rebuilds ModelInfo from the live
+// API, and the frontend reads tags defensively (absent -> no facets).
+export interface ModelTag {
+  category: string;
+  value: string;
+}
 
 /** category -> selected values. Within a category values OR; across categories they AND. */
 export type FacetSelection = Record<string, string[]>;
@@ -39,13 +47,14 @@ const VALUE_LABELS: Record<string, string> = { vad: "VAD" };
 export function buildTagIndex(
   benchmark: "STT" | "TTS",
   providers?: ProvidersApiResponse
-): Map<string, ModelTagOut[]> {
-  const index = new Map<string, ModelTagOut[]>();
+): Map<string, ModelTag[]> {
+  const index = new Map<string, ModelTag[]>();
   if (!providers) return index;
   const catalogue = benchmark === "STT" ? providers.stt : providers.tts;
   for (const providerInfo of catalogue) {
     for (const modelInfo of providerInfo.models) {
-      index.set(toModelKey(providerInfo.provider, modelInfo.model), modelInfo.tags ?? []);
+      const tags = (modelInfo as { tags?: ModelTag[] }).tags ?? [];
+      index.set(toModelKey(providerInfo.provider, modelInfo.model), tags);
     }
   }
   return index;
@@ -63,7 +72,7 @@ function facetValueLabel(
 
 // A model passes when, for every category with a selection, it carries at least
 // one of the selected values in that category (OR within, AND across).
-function matchesSelection(tags: ModelTagOut[], selected: FacetSelection): boolean {
+function matchesSelection(tags: ModelTag[], selected: FacetSelection): boolean {
   for (const [category, values] of Object.entries(selected)) {
     if (values.length === 0) continue;
     const hit = tags.some((t) => t.category === category && values.includes(t.value));
@@ -78,7 +87,7 @@ const hasAnySelection = (selected: FacetSelection): boolean =>
 /** Narrow modelsByProvider to the models passing the current facet selection. */
 export function filterModelsByFacets(
   modelsByProvider: ModelsByProvider,
-  tagIndex: Map<string, ModelTagOut[]>,
+  tagIndex: Map<string, ModelTag[]>,
   selected: FacetSelection
 ): ModelsByProvider {
   if (!hasAnySelection(selected)) return modelsByProvider;
@@ -98,7 +107,7 @@ export function filterModelsByFacets(
  */
 export function buildFacetGroups(
   modelsByProvider: ModelsByProvider,
-  tagIndex: Map<string, ModelTagOut[]>,
+  tagIndex: Map<string, ModelTag[]>,
   selected: FacetSelection,
   normalizeProvider: (name: string) => string
 ): FacetGroup[] {

--- a/web/lib/utils/facets.ts
+++ b/web/lib/utils/facets.ts
@@ -56,6 +56,23 @@ function matchesSelection(tags: ModelTagOut[], selected: FacetSelection): boolea
 const hasAnySelection = (selected: FacetSelection): boolean =>
   Object.values(selected).some((v) => v.length > 0);
 
+/**
+ * Keep only the models whose composite key is in `keys`. Used to restrict the
+ * facet universe to models that actually have data to plot, so a chip can never
+ * count (or filter to) a catalogue-only model that would show nothing.
+ */
+export function restrictToModelKeys(
+  modelsByProvider: ModelsByProvider,
+  keys: Set<string>
+): ModelsByProvider {
+  const out: ModelsByProvider = {};
+  for (const [provider, modelKeys] of Object.entries(modelsByProvider)) {
+    const kept = modelKeys.filter((key) => keys.has(key));
+    if (kept.length > 0) out[provider] = kept;
+  }
+  return out;
+}
+
 /** Narrow modelsByProvider to the models passing the current facet selection. */
 export function filterModelsByFacets(
   modelsByProvider: ModelsByProvider,

--- a/web/lib/utils/modelsFromResults.test.ts
+++ b/web/lib/utils/modelsFromResults.test.ts
@@ -3,7 +3,7 @@
 
 import { describe, expect, it } from "vitest";
 import type { ProviderModelRef } from "./modelsFromResults";
-import { buildModelsByProvider, pruneSelection } from "./modelsFromResults";
+import { buildModelsByProvider } from "./modelsFromResults";
 
 function entry(provider: string, model: string): ProviderModelRef {
   return { provider, model };
@@ -127,29 +127,5 @@ describe("buildModelsByProvider", () => {
       "STT"
     );
     expect(out.deepgram).toEqual(["deepgram:nova-2"]);
-  });
-});
-
-describe("pruneSelection", () => {
-  it("removes selected keys no longer present in modelsByProvider", () => {
-    const result = pruneSelection(
-      ["speechmatics:default", "google:short", "deepgram:nova-2"],
-      {
-        speechmatics: ["speechmatics:default"],
-        deepgram: ["deepgram:nova-2"]
-      }
-    );
-    expect(result).toEqual(["speechmatics:default", "deepgram:nova-2"]);
-  });
-
-  it("keeps the selection intact when every key is still valid", () => {
-    const selected = ["deepgram:nova-2", "deepgram:nova-3"];
-    expect(
-      pruneSelection(selected, { deepgram: ["deepgram:nova-2", "deepgram:nova-3"] })
-    ).toEqual(selected);
-  });
-
-  it("returns empty when modelsByProvider is empty", () => {
-    expect(pruneSelection(["deepgram:nova-2"], {})).toEqual([]);
   });
 });

--- a/web/lib/utils/modelsFromResults.ts
+++ b/web/lib/utils/modelsFromResults.ts
@@ -77,18 +77,3 @@ export function buildModelsByProvider(
 
   return modelsByProvider;
 }
-
-/**
- * Drop any selected composite key that is no longer present in
- * `modelsByProvider`. Removal-only: it never adds or reorders, so it cannot
- * override a manual selection or re-introduce a model — it only reconciles the
- * selection after provider metadata filters a model out (e.g. a disabled model
- * that results alone had surfaced before the catalogue loaded).
- */
-export function pruneSelection(
-  selected: readonly string[],
-  modelsByProvider: ModelsByProvider
-): string[] {
-  const valid = new Set(Object.values(modelsByProvider).flat());
-  return selected.filter((key) => valid.has(key));
-}


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a faceted filter experience to model browsing in both the sidebar and mobile model sheet, using grouped filter chips derived from API tag metadata.
  * Filter options now show counts, reflect active selections, and provide a “Clear” action when filters are active.
* **Bug Fixes**
  * Updated model results to consistently reflect the active facet selections, replacing prior manual model/provider selection behavior.
* **Tests**
  * Added a new test suite covering facet filtering, grouping, counting, normalization, and toggle behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the per-model checkbox sidebar with a faceted filter UI driven by tag metadata from the API. Facet groups (host, features, etc.) are built server-side, chip counts reflect cross-category filtering, and all PostHog instrumentation has been updated to the new `dashboard_facet_changed` event.

- `facets.ts` introduces the full facet pipeline (`buildTagIndex`, `filterModelsByFacets`, `buildFacetGroups`, `toggleFacetValue`) with OR-within / AND-across semantics and a companion test suite covering grouping, count honoring, provider normalization, and toggle behavior.
- `useDashboardState` migrates from explicit `selectedModels` state to a derived value: `modelsByProvider` after facet filtering, so all data-backed models are visible by default and only those matching active chips are plotted.
- The old `pruneSelection` effect and provider-expand state in `useSidebarMenuState` are cleanly removed.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the facet pipeline is well-tested, the OR-within/AND-across logic is sound, and the migration from explicit selection to derived state is clean.

The core filtering logic is covered by a thorough test suite, the derived-selection model simplifies state management without introducing correctness gaps, and the two findings are limited to UX polish (clickable zero-count chips) and an accessibility nit (duplicate IDs) in the new component.

web/components/layout/FacetFilter.tsx — zero-count chips and duplicate IDs are both isolated here and straightforward to fix before or after merge.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| web/lib/utils/facets.ts | New facet utility: buildTagIndex, filterModelsByFacets, buildFacetGroups, toggleFacetValue — well-structured with clear OR-within/AND-across semantics and tested |
| web/hooks/useDashboardState.tsx | Replaces manual model-checkbox selection with facet state; selectedModels is now fully derived from filtered universe; analytics wired up with dashboardFacetChanged events |
| web/components/layout/FacetFilter.tsx | New chip-based filter component; zero-count options render as fully clickable buttons with no disabled state, which can lead to a dead-end empty result set |
| web/components/layout/ModelSidebar.tsx | Provider checkbox tree replaced with FacetFilter; both ModelSidebar and MobileModelSheet render FacetFilter simultaneously, creating duplicate DOM IDs for aria-labelledby targets |
| web/lib/utils/facets.test.ts | Comprehensive test coverage for OR-within/AND-across filtering, count computation honoring cross-category selection, provider normalization, and toggle semantics |
| web/hooks/useSidebarMenuState.ts | Reduced to a single mobileSheetOpen boolean after provider-expand logic was removed; correct simplification |
| web/lib/api/generated/schema.ts | Added ModelTagOut, TagCategoryOut, TagCategory schema types matching the new API surface; ProvidersResponse extended with tag_categories array |
| web/lib/posthog/events.ts | Renamed dashboardModelSelectionChanged → dashboardFacetChanged and removed SelectionAction type; breaking change for any existing analytics dashboards on the old event |
| web/lib/utils/modelsFromResults.ts | pruneSelection helper removed since the selection is now entirely derived from facet state; clean deletion |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[providersQuery.data] --> B[buildTagIndex\nbenchmark + providers]
    A --> C[getTagCategories\nfrom tag_categories]
    A --> D[buildModelsByProvider\nallModelsByProvider]
    E[modelStats] --> F[restrictToModelKeys\ndataBackedByProvider]
    D --> F

    F --> G[filterModelsByFacets\nmodelsByProvider]
    B --> G
    H[selectedFacets state] --> G

    G --> I[selectedModels\nflat derived list]
    I --> J[Charts / KeyMetrics\ndeferredSelectedModels]

    F --> K[buildFacetGroups\nfacetGroups]
    B --> K
    H --> K
    C --> K

    K --> L[FacetFilter UI\nchip groups + counts]
    L -->|toggleFacet| H
    L -->|clearFacets| H
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[providersQuery.data] --> B[buildTagIndex\nbenchmark + providers]
    A --> C[getTagCategories\nfrom tag_categories]
    A --> D[buildModelsByProvider\nallModelsByProvider]
    E[modelStats] --> F[restrictToModelKeys\ndataBackedByProvider]
    D --> F

    F --> G[filterModelsByFacets\nmodelsByProvider]
    B --> G
    H[selectedFacets state] --> G

    G --> I[selectedModels\nflat derived list]
    I --> J[Charts / KeyMetrics\ndeferredSelectedModels]

    F --> K[buildFacetGroups\nfacetGroups]
    B --> K
    H --> K
    C --> K

    K --> L[FacetFilter UI\nchip groups + counts]
    L -->|toggleFacet| H
    L -->|clearFacets| H
```

</a>

<sub>Reviews (3): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/mai..."](https://github.com/coval-ai/benchmarks/commit/fe024eb51699eb65133091705546c111ef101388) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40607226)</sub>

<!-- /greptile_comment -->