### PR TITLE
Add Inworld AI STT and enable Inworld TTS

### DIFF
--- a/runner/src/coval_bench/providers/stt/__init__.py
+++ b/runner/src/coval_bench/providers/stt/__init__.py
@@ -21,6 +21,7 @@ from coval_bench.providers.stt.deepgram import DeepgramProvider
 from coval_bench.providers.stt.elevenlabs import ElevenLabsSTTProvider
 from coval_bench.providers.stt.gladia import GladiaSTTProvider
 from coval_bench.providers.stt.gradium import GradiumSTTProvider
+from coval_bench.providers.stt.inworld import InworldSTTProvider
 from coval_bench.providers.stt.openai import OpenAISTTProvider
 from coval_bench.providers.stt.smallest import SmallestSTTProvider
 from coval_bench.providers.stt.soniox import SonioxSTTProvider
@@ -43,6 +44,7 @@ STT_PROVIDERS: dict[str, type[STTProvider]] = {
     "elevenlabs": ElevenLabsSTTProvider,
     "gladia": GladiaSTTProvider,
     "gradium": GradiumSTTProvider,
+    "inworld": InworldSTTProvider,
     "openai": OpenAISTTProvider,
     "smallest": SmallestSTTProvider,
     "soniox": SonioxSTTProvider,
@@ -62,6 +64,7 @@ __all__ = [
     "ElevenLabsSTTProvider",
     "GladiaSTTProvider",
     "GradiumSTTProvider",
+    "InworldSTTProvider",
     "OpenAISTTProvider",
     "SmallestSTTProvider",
     "SonioxSTTProvider",

--- a/runner/src/coval_bench/providers/stt/inworld.py
+++ b/runner/src/coval_bench/providers/stt/inworld.py
@@ -1,0 +1,197 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Inworld AI real-time STT provider (WebSocket bidirectional streaming).
+
+INWORLD_API_KEY is the portal-issued base64 credential; it rides the
+``Authorization: Basic <key>`` header verbatim (re-encoding it fails auth).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import time
+from typing import Any
+
+import structlog
+import websockets.asyncio.client as ws_client
+from pydantic import SecretStr
+
+from coval_bench.providers.base import STTProvider, TranscriptionResult
+
+logger = structlog.get_logger(__name__)
+
+_WS_URL = "wss://api.inworld.ai/stt/v1/transcribe:streamBidirectional"
+
+
+class InworldSTTProvider(STTProvider):
+    """Inworld AI streaming STT provider."""
+
+    _VALID_MODELS = frozenset({"inworld-stt-1"})
+
+    def __init__(self, api_key: SecretStr | None, model: str = "inworld-stt-1") -> None:
+        if not self._model_supported(model):
+            raise ValueError(
+                f"Invalid Inworld STT model {model!r}. Valid: {sorted(self._VALID_MODELS)}"
+            )
+        if api_key is None:
+            raise ValueError("inworld_api_key is required for the Inworld STT provider")
+        self._api_key = api_key
+        self._model = model
+
+    @property
+    def name(self) -> str:
+        return "inworld"
+
+    @property
+    def model(self) -> str:
+        return self._model
+
+    async def measure_ttft(
+        self,
+        audio_data: bytes,
+        channels: int,
+        sample_width: int,
+        sample_rate: int,
+        realtime_resolution: float = 0.1,
+    ) -> TranscriptionResult:
+        result = TranscriptionResult(provider=self.name)
+        if sample_rate != 16000:
+            result.error = f"Inworld requires 16 kHz PCM input; got {sample_rate} Hz"
+            return result
+        if channels != 1 or sample_width != 2:
+            result.error = (
+                "Inworld requires mono 16-bit PCM input; "
+                f"got channels={channels}, sample_width={sample_width}"
+            )
+            return result
+
+        total_start = time.monotonic()
+        headers = {"Authorization": f"Basic {self._api_key.get_secret_value()}"}
+
+        try:
+            async with ws_client.connect(_WS_URL, additional_headers=headers) as ws:
+                # Inworld routes by a "{provider}/{model}" id; we own the inworld/ namespace.
+                await ws.send(
+                    json.dumps(
+                        {
+                            "transcribeConfig": {
+                                "modelId": f"inworld/{self._model}",
+                                "audioEncoding": "LINEAR16",
+                                "sampleRateHertz": sample_rate,
+                                "numberOfChannels": 1,
+                                "language": "en-US",
+                            }
+                        }
+                    )
+                )
+
+                send_task = asyncio.create_task(
+                    self._send_audio(ws, audio_data, sample_rate, result, realtime_resolution)
+                )
+                recv_task = asyncio.create_task(self._receive(ws, result))
+                tasks = (send_task, recv_task)
+                done, pending = await asyncio.wait(tasks, return_when=asyncio.FIRST_EXCEPTION)
+                if any(not task.cancelled() and task.exception() is not None for task in done):
+                    for task in pending:
+                        task.cancel()
+                outcomes = await asyncio.gather(*tasks, return_exceptions=True)
+                if result.error is None and result.audio_to_final_seconds is None:
+                    for outcome in outcomes:
+                        if isinstance(outcome, Exception):
+                            result.error = str(outcome)
+                            break
+
+        except Exception as exc:
+            logger.warning(
+                "inworld_measure_ttft_failed", provider="inworld", model=self._model, exc_info=exc
+            )
+            result.error = str(exc)
+
+        result.total_time = time.monotonic() - total_start
+        return result
+
+    async def _send_audio(
+        self,
+        ws: Any,
+        audio_data: bytes,
+        sample_rate: int,
+        result: TranscriptionResult,
+        realtime_resolution: float,
+    ) -> None:
+        bytes_per_second = sample_rate * 2  # 16-bit mono
+        chunk_size = int(bytes_per_second * realtime_resolution)
+        result.audio_start_time = time.monotonic()
+        try:
+            for i in range(0, len(audio_data), chunk_size):
+                chunk = audio_data[i : i + chunk_size]
+                await ws.send(
+                    json.dumps({"audioChunk": {"content": base64.b64encode(chunk).decode()}})
+                )
+                await asyncio.sleep(realtime_resolution)
+            # endTurn forces finalization; closeStream then flushes the final
+            # transcripts and closes the socket, ending the receive loop.
+            await ws.send(json.dumps({"endTurn": {}}))
+            await ws.send(json.dumps({"closeStream": {}}))
+        except Exception as exc:
+            logger.warning(
+                "inworld_send_error", provider="inworld", model=self._model, exc_info=exc
+            )
+            raise
+
+    async def _receive(self, ws: Any, result: TranscriptionResult) -> None:
+        final_parts: list[str] = []
+
+        try:
+            async for raw in ws:
+                if isinstance(raw, bytes):
+                    continue
+
+                msg: dict[str, Any] = json.loads(raw)
+                now = time.monotonic()
+
+                if msg.get("error"):
+                    result.error = str(msg["error"])
+                    logger.warning(
+                        "inworld_stt_error", provider="inworld", model=self._model, msg=msg
+                    )
+                    break
+
+                transcription = msg.get("result", {}).get("transcription")
+                if not transcription:
+                    continue
+
+                text = str(transcription.get("transcript", ""))
+                if not text.strip():
+                    continue
+
+                if result.ttft_seconds is None and result.audio_start_time is not None:
+                    result.ttft_seconds = now - result.audio_start_time
+                    snippet = text.strip()
+                    result.first_token_content = (
+                        snippet[:30] + "..." if len(snippet) > 30 else snippet
+                    )
+
+                if transcription.get("isFinal"):
+                    final_parts.append(text.strip())
+                    if result.audio_start_time is not None:
+                        result.audio_to_final_seconds = now - result.audio_start_time
+                else:
+                    result.partial_transcripts.append(text.strip())
+
+        except Exception as exc:
+            logger.warning(
+                "inworld_receive_error", provider="inworld", model=self._model, exc_info=exc
+            )
+            if result.error is None and result.audio_to_final_seconds is None:
+                result.error = str(exc)
+
+        if final_parts:
+            # Inworld emits whole-phrase final segments; join with spaces.
+            result.complete_transcript = " ".join(final_parts).strip() or None
+
+        if result.complete_transcript:
+            result.transcript_length = len(result.complete_transcript)
+            result.word_count = len(result.complete_transcript.split())

--- a/runner/src/coval_bench/providers/stt/inworld.py
+++ b/runner/src/coval_bench/providers/stt/inworld.py
@@ -36,7 +36,7 @@ class InworldSTTProvider(STTProvider):
             raise ValueError(
                 f"Invalid Inworld STT model {model!r}. Valid: {sorted(self._VALID_MODELS)}"
             )
-        if api_key is None:
+        if api_key is None or not api_key.get_secret_value().strip():
             raise ValueError("inworld_api_key is required for the Inworld STT provider")
         self._api_key = api_key
         self._model = model
@@ -103,6 +103,10 @@ class InworldSTTProvider(STTProvider):
                         if isinstance(outcome, Exception):
                             result.error = str(outcome)
                             break
+                    else:
+                        result.error = (
+                            "Inworld stream ended before a final transcription was received"
+                        )
 
         except Exception as exc:
             logger.warning(
@@ -126,11 +130,17 @@ class InworldSTTProvider(STTProvider):
         result.audio_start_time = time.monotonic()
         try:
             for i in range(0, len(audio_data), chunk_size):
+                # Stop early if _receive already recorded a protocol/auth error.
+                if result.error is not None:
+                    break
                 chunk = audio_data[i : i + chunk_size]
                 await ws.send(
                     json.dumps({"audioChunk": {"content": base64.b64encode(chunk).decode()}})
                 )
-                await asyncio.sleep(realtime_resolution)
+                # Pace to real time between chunks only — sleeping after the last
+                # one would delay finalization and inflate the latency clocks.
+                if i + chunk_size < len(audio_data):
+                    await asyncio.sleep(realtime_resolution)
             # endTurn forces finalization; closeStream then flushes the final
             # transcripts and closes the socket, ending the receive loop.
             await ws.send(json.dumps({"endTurn": {}}))

--- a/runner/src/coval_bench/registries/models.py
+++ b/runner/src/coval_bench/registries/models.py
@@ -184,6 +184,13 @@ MODEL_REGISTRY: list[RegisteredModel] = [
     ),
     RegisteredModel(
         benchmark=_STT,
+        provider="inworld",
+        model="inworld-stt-1",
+        tags=(_REALTIME, _VAD),
+        status=_ACTIVE,
+    ),
+    RegisteredModel(
+        benchmark=_STT,
         provider="xai",
         model="grok-stt",
         tags=(_REALTIME, _MULTI, _VAD),
@@ -386,7 +393,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         model="inworld-tts-1.5-max",
         voice="Ashley",
         tags=(_REALTIME, _MULTI),
-        status=_PENDING,
+        status=_ACTIVE,
     ),
     RegisteredModel(
         benchmark=_TTS,
@@ -394,7 +401,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         model="inworld-tts-1.5-mini",
         voice="Ashley",
         tags=(_REALTIME, _MULTI),
-        status=_PENDING,
+        status=_ACTIVE,
     ),
     RegisteredModel(
         benchmark=_TTS,

--- a/runner/tests/providers/stt/fixtures/inworld/events-error.json
+++ b/runner/tests/providers/stt/fixtures/inworld/events-error.json
@@ -1,0 +1,3 @@
+[
+  {"error": "Invalid or expired API key"}
+]

--- a/runner/tests/providers/stt/fixtures/inworld/events-success.json
+++ b/runner/tests/providers/stt/fixtures/inworld/events-success.json
@@ -1,0 +1,6 @@
+[
+  {"result": {"transcription": {"transcript": "hello", "isFinal": false}}},
+  {"result": {"transcription": {"transcript": "hello world", "isFinal": true}}},
+  {"result": {"transcription": {"transcript": "how", "isFinal": false}}},
+  {"result": {"transcription": {"transcript": "how are you", "isFinal": true}}}
+]

--- a/runner/tests/providers/stt/test_inworld.py
+++ b/runner/tests/providers/stt/test_inworld.py
@@ -1,0 +1,277 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for coval_bench.providers.stt.inworld (InworldSTTProvider).
+
+All tests use FakeWebSocket — no live network calls are made. The event
+fixtures mirror the Inworld real-time wire protocol: each message nests a
+``result.transcription`` object where ``isFinal`` marks committed segments.
+Final segments are whole phrases, so the transcript joins them with spaces.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pydantic import SecretStr
+
+from coval_bench.metrics.wer import compute_wer
+from coval_bench.providers.stt.inworld import InworldSTTProvider
+from tests.providers.stt.conftest import FakeWebSocket, load_fixture_events
+
+
+def make_provider() -> InworldSTTProvider:
+    return InworldSTTProvider(api_key=SecretStr("test-key-inworld"))
+
+
+def _fake_connect(events: list[Any]) -> Any:
+    ws = FakeWebSocket(events)
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=ws)
+    cm.__aexit__ = AsyncMock(return_value=False)
+    return cm
+
+
+# ---------------------------------------------------------------------------
+# Happy path — final segments joined in order
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_inworld_success(fake_api_key: SecretStr, audio_pcm_bytes: bytes) -> None:
+    events = load_fixture_events("inworld", "events-success")
+    provider = InworldSTTProvider(api_key=fake_api_key)
+
+    with patch(
+        "coval_bench.providers.stt.inworld.ws_client.connect",
+        return_value=_fake_connect(events),
+    ):
+        result = await provider.measure_ttft(
+            audio_data=audio_pcm_bytes,
+            channels=1,
+            sample_width=2,
+            sample_rate=16000,
+            realtime_resolution=0.5,
+        )
+
+    assert result.error is None
+    assert result.ttft_seconds is not None
+    assert result.ttft_seconds >= 0
+    assert result.first_token_content is not None
+    assert result.complete_transcript == "hello world how are you"
+    assert result.word_count == 5
+    assert result.audio_to_final_seconds is not None
+    wer = compute_wer("hello world how are you", result.complete_transcript)
+    assert wer.wer_percentage == pytest.approx(0.0)
+
+
+@pytest.mark.asyncio
+async def test_inworld_excludes_interim_segments(
+    fake_api_key: SecretStr, audio_pcm_bytes: bytes
+) -> None:
+    """Only ``isFinal`` segments form the transcript; interim ones are dropped.
+
+    The interim ("wrong") segments differ from the committed text, so a leak
+    into the final transcript would change the assertion.
+    """
+    events: list[Any] = [
+        {"result": {"transcription": {"transcript": "wrong guess", "isFinal": False}}},
+        {"result": {"transcription": {"transcript": "hello", "isFinal": True}}},
+        {"result": {"transcription": {"transcript": "worng", "isFinal": False}}},
+        {"result": {"transcription": {"transcript": "world", "isFinal": True}}},
+    ]
+    provider = InworldSTTProvider(api_key=fake_api_key)
+
+    with patch(
+        "coval_bench.providers.stt.inworld.ws_client.connect",
+        return_value=_fake_connect(events),
+    ):
+        result = await provider.measure_ttft(
+            audio_data=audio_pcm_bytes,
+            channels=1,
+            sample_width=2,
+            sample_rate=16000,
+            realtime_resolution=0.5,
+        )
+
+    assert result.error is None
+    assert result.complete_transcript == "hello world"
+    assert result.word_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Provider name and model
+# ---------------------------------------------------------------------------
+
+
+def test_provider_name() -> None:
+    assert make_provider().name == "inworld"
+
+
+def test_provider_model() -> None:
+    assert make_provider().model == "inworld-stt-1"
+
+
+# ---------------------------------------------------------------------------
+# Invalid construction
+# ---------------------------------------------------------------------------
+
+
+def test_invalid_model_raises() -> None:
+    with pytest.raises(ValueError, match="Invalid Inworld STT model"):
+        InworldSTTProvider(api_key=SecretStr("k"), model="inworld-stt-preview")
+
+
+def test_missing_api_key_raises() -> None:
+    with pytest.raises(ValueError, match="inworld_api_key is required"):
+        InworldSTTProvider(api_key=None)
+
+
+# ---------------------------------------------------------------------------
+# Invalid sample rate / format
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_inworld_wrong_sample_rate(fake_api_key: SecretStr, audio_pcm_bytes: bytes) -> None:
+    provider = InworldSTTProvider(api_key=fake_api_key)
+    result = await provider.measure_ttft(
+        audio_data=audio_pcm_bytes,
+        channels=1,
+        sample_width=2,
+        sample_rate=8000,
+    )
+
+    assert result.error is not None
+    assert "16 kHz" in result.error
+    assert result.ttft_seconds is None
+
+
+@pytest.mark.asyncio
+async def test_inworld_rejects_non_mono_or_non_16bit(
+    fake_api_key: SecretStr, audio_pcm_bytes: bytes
+) -> None:
+    """The config hardcodes mono 16-bit, so non-matching input is rejected upfront."""
+    provider = InworldSTTProvider(api_key=fake_api_key)
+    result = await provider.measure_ttft(
+        audio_data=audio_pcm_bytes,
+        channels=2,
+        sample_width=2,
+        sample_rate=16000,
+    )
+
+    assert result.error is not None
+    assert "mono 16-bit" in result.error
+    assert result.ttft_seconds is None
+
+
+# ---------------------------------------------------------------------------
+# Failure path — error frame
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_inworld_error_event(fake_api_key: SecretStr, audio_pcm_bytes: bytes) -> None:
+    events = load_fixture_events("inworld", "events-error")
+    provider = InworldSTTProvider(api_key=fake_api_key)
+
+    with patch(
+        "coval_bench.providers.stt.inworld.ws_client.connect",
+        return_value=_fake_connect(events),
+    ):
+        result = await provider.measure_ttft(
+            audio_data=audio_pcm_bytes,
+            channels=1,
+            sample_width=2,
+            sample_rate=16000,
+            realtime_resolution=0.5,
+        )
+
+    assert result.error is not None
+    assert "Invalid or expired API key" in result.error
+    assert result.complete_transcript is None
+
+
+# ---------------------------------------------------------------------------
+# Failure path — empty stream
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_inworld_empty_stream(fake_api_key: SecretStr, audio_pcm_bytes: bytes) -> None:
+    provider = InworldSTTProvider(api_key=fake_api_key)
+
+    with patch(
+        "coval_bench.providers.stt.inworld.ws_client.connect",
+        return_value=_fake_connect([]),
+    ):
+        result = await provider.measure_ttft(
+            audio_data=audio_pcm_bytes,
+            channels=1,
+            sample_width=2,
+            sample_rate=16000,
+            realtime_resolution=0.5,
+        )
+
+    assert result.complete_transcript is None
+    assert result.ttft_seconds is None
+
+
+# ---------------------------------------------------------------------------
+# Failure path — websocket transport exceptions
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_inworld_connection_error(fake_api_key: SecretStr, audio_pcm_bytes: bytes) -> None:
+    """A connect failure surfaces as result.error, not a silent empty success."""
+    provider = InworldSTTProvider(api_key=fake_api_key)
+
+    with patch(
+        "coval_bench.providers.stt.inworld.ws_client.connect",
+        side_effect=OSError("connection refused"),
+    ):
+        result = await provider.measure_ttft(
+            audio_data=audio_pcm_bytes,
+            channels=1,
+            sample_width=2,
+            sample_rate=16000,
+            realtime_resolution=0.5,
+        )
+
+    assert result.error is not None
+    assert "connection refused" in result.error
+    assert result.complete_transcript is None
+    assert result.ttft_seconds is None
+
+
+@pytest.mark.asyncio
+async def test_inworld_surfaces_send_failure(
+    fake_api_key: SecretStr, audio_pcm_bytes: bytes
+) -> None:
+    """A send failure inside the streaming task is surfaced, not swallowed by gather."""
+
+    def _raise_on_audio(msg: object) -> None:
+        if isinstance(msg, str) and "audioChunk" in msg:
+            raise RuntimeError("send boom")
+
+    ws = FakeWebSocket([], on_send=_raise_on_audio)
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=ws)
+    cm.__aexit__ = AsyncMock(return_value=False)
+
+    provider = InworldSTTProvider(api_key=fake_api_key)
+    with patch("coval_bench.providers.stt.inworld.ws_client.connect", return_value=cm):
+        result = await provider.measure_ttft(
+            audio_data=audio_pcm_bytes,
+            channels=1,
+            sample_width=2,
+            sample_rate=16000,
+            realtime_resolution=0.5,
+        )
+
+    assert result.error is not None
+    assert "send boom" in result.error
+    assert result.complete_transcript is None

--- a/runner/tests/providers/stt/test_inworld.py
+++ b/runner/tests/providers/stt/test_inworld.py
@@ -129,6 +129,11 @@ def test_missing_api_key_raises() -> None:
         InworldSTTProvider(api_key=None)
 
 
+def test_blank_api_key_raises() -> None:
+    with pytest.raises(ValueError, match="inworld_api_key is required"):
+        InworldSTTProvider(api_key=SecretStr("   "))
+
+
 # ---------------------------------------------------------------------------
 # Invalid sample rate / format
 # ---------------------------------------------------------------------------
@@ -201,6 +206,7 @@ async def test_inworld_error_event(fake_api_key: SecretStr, audio_pcm_bytes: byt
 
 @pytest.mark.asyncio
 async def test_inworld_empty_stream(fake_api_key: SecretStr, audio_pcm_bytes: bytes) -> None:
+    """A stream that never yields a final transcription is a failure, not an empty success."""
     provider = InworldSTTProvider(api_key=fake_api_key)
 
     with patch(
@@ -217,6 +223,8 @@ async def test_inworld_empty_stream(fake_api_key: SecretStr, audio_pcm_bytes: by
 
     assert result.complete_transcript is None
     assert result.ttft_seconds is None
+    assert result.error is not None
+    assert "before a final transcription" in result.error
 
 
 # ---------------------------------------------------------------------------

--- a/web/lib/config/colors.ts
+++ b/web/lib/config/colors.ts
@@ -35,6 +35,7 @@ export const modelColors: Record<string, string> = {
   // Inworld AI — indigo family (#6366F1).
   "inworld-tts-1.5-mini": "#818CF8",
   "inworld-tts-1.5-max": "#4F46E5",
+  "inworld-stt-1": "#6366F1",
 
   // Deepgram — teal family (#16A085). TTS aura anchors the dark end; STT models
   // span up to light teal. All shades are visibly teal (none near-black).

--- a/web/lib/utils/formatters.ts
+++ b/web/lib/utils/formatters.ts
@@ -123,6 +123,7 @@ export function normalizeModelName(modelKey: string): string {
     "universal-streaming-multilingual": "Universal Streaming Multilingual",
     "universal-3.5-pro": "Universal 3.5 Pro",
     "ink-2": "Ink 2",
+    "inworld-stt-1": "STT 1",
     default: "Default",
     enhanced: "Enhanced"
   };
@@ -166,6 +167,7 @@ export function normalizeSTTProviderName(providerName: string): string {
     deepgram: "Deepgram",
     elevenlabs: "ElevenLabs",
     gradium: "Gradium",
+    inworld: "Inworld AI",
     openai: "OpenAI",
     rime: "Rime",
     speechmatics: "Speechmatics",


### PR DESCRIPTION
Wire up an Inworld streaming STT provider and flip the Inworld STT/TTS models to active in the registry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an additional speech-to-text provider with the **inworld-stt-1** model and enabled it for benchmarking.
  * Introduced bidirectional real-time transcription over WebSocket, including partial and finalized segments plus TTFT/latency metrics.

* **Bug Fixes**
  * Strengthened validation for audio format and credentials, and improved error propagation for websocket/send failures.
  * Ensured only finalized transcriptions are included in the completed transcript.

* **UI/Display**
  * Added display labels and color styling for the new provider/model.

* **Tests**
  * Added fixture-driven and error-path coverage for the new provider.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR wires up a new Inworld AI streaming STT provider over WebSocket and flips both Inworld TTS models from `_PENDING` to `_ACTIVE` in the registry.

- **New `InworldSTTProvider`** (`inworld.py`): bidirectional WebSocket streaming with base64-encoded PCM chunks, explicit `endTurn`/`closeStream` protocol signalling, and the same `asyncio.wait(FIRST_EXCEPTION)` + `asyncio.gather(return_exceptions=True)` concurrency pattern used by the Soniox provider; format validation (16 kHz mono 16-bit) gates the network call.
- **Registry + UI**: `inworld-stt-1` added to the model registry as `_ACTIVE`, colour `#6366F1` added to the indigo family alongside the two TTS entries, and display labels wired in `formatters.ts`.
- **Tests**: fixture-driven happy-path and inline-event tests, plus error-path coverage for protocol errors, empty streams, connection failures, and send-side exceptions — all using `FakeWebSocket` with no live network calls.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the new provider follows the established Soniox concurrency pattern, all error paths are handled, and the registry/UI changes are additive.

The implementation is a clean port of the existing bidirectional-WebSocket pattern with solid test coverage across happy-path, error-frame, empty-stream, and send-failure scenarios. The two minor observations (stray protocol messages on early error exit, and a null-guard on the result key) do not affect correctness given the surrounding return_exceptions=True gather and the except Exception handler.

runner/src/coval_bench/providers/stt/inworld.py — the _send_audio early-exit path and the msg.get('result', {}) null-guard are worth a second look, but neither causes incorrect behaviour today.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| runner/src/coval_bench/providers/stt/inworld.py | Core new provider: bidirectional WS streaming follows the established Soniox concurrency pattern; minor: endTurn/closeStream are sent unconditionally even after an early break on error, and msg.get('result', {}) does not guard against an explicit null value for the 'result' key. |
| runner/tests/providers/stt/test_inworld.py | Good fixture-driven and inline-event test coverage: happy path, interim-segment exclusion, format validation, error frames, empty stream, connection failure, and send-exception surfacing — all via FakeWebSocket. |
| runner/src/coval_bench/registries/models.py | Adds inworld-stt-1 as ACTIVE and flips inworld-tts-1.5-max / inworld-tts-1.5-mini from PENDING to ACTIVE; straightforward registry edits. |
| web/lib/config/colors.ts | Adds #6366F1 for inworld-stt-1, completing the indigo family alongside the two existing TTS colours. |
| web/lib/utils/formatters.ts | Adds 'STT 1' display label for inworld-stt-1 and 'Inworld AI' provider label; consistent with existing naming patterns. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Bench as measure_ttft
    participant Send as _send_audio (task)
    participant Recv as _receive (task)
    participant WS as Inworld WS Server

    Bench->>WS: connect (Authorization: Basic key)
    Bench->>WS: send transcribeConfig (modelId, LINEAR16, 16 kHz)
    Bench->>Send: asyncio.create_task
    Bench->>Recv: asyncio.create_task
    Bench->>Bench: asyncio.wait(FIRST_EXCEPTION)

    loop real-time paced chunks
        Send->>WS: send audioChunk (base64 PCM)
        Send->>Send: asyncio.sleep(realtime_resolution)
    end
    Send->>WS: send endTurn
    Send->>WS: send closeStream

    WS-->>Recv: "result.transcription isFinal=false"
    Note over Recv: record ttft_seconds, append partial

    WS-->>Recv: "result.transcription isFinal=true"
    Note over Recv: append final_parts, update audio_to_final_seconds

    WS-->>Recv: connection closed
    Note over Recv: join final_parts → complete_transcript

    Bench->>Bench: "asyncio.gather(return_exceptions=True)"
    Bench->>Bench: set total_time, return TranscriptionResult
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Bench as measure_ttft
    participant Send as _send_audio (task)
    participant Recv as _receive (task)
    participant WS as Inworld WS Server

    Bench->>WS: connect (Authorization: Basic key)
    Bench->>WS: send transcribeConfig (modelId, LINEAR16, 16 kHz)
    Bench->>Send: asyncio.create_task
    Bench->>Recv: asyncio.create_task
    Bench->>Bench: asyncio.wait(FIRST_EXCEPTION)

    loop real-time paced chunks
        Send->>WS: send audioChunk (base64 PCM)
        Send->>Send: asyncio.sleep(realtime_resolution)
    end
    Send->>WS: send endTurn
    Send->>WS: send closeStream

    WS-->>Recv: "result.transcription isFinal=false"
    Note over Recv: record ttft_seconds, append partial

    WS-->>Recv: "result.transcription isFinal=true"
    Note over Recv: append final_parts, update audio_to_final_seconds

    WS-->>Recv: connection closed
    Note over Recv: join final_parts → complete_transcript

    Bench->>Bench: "asyncio.gather(return_exceptions=True)"
    Bench->>Bench: set total_time, return TranscriptionResult
```

</a>

<sub>Reviews (2): Last reviewed commit: ["Address PR review on Inworld STT provide..."](https://github.com/coval-ai/benchmarks/commit/c723411907c98294cfede1d9aaa08b27ff0ac710) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40644920)</sub>

<!-- /greptile_comment -->