### PR TITLE
Activate Gladia Solaria-1 on the STT leaderboard

### DIFF
--- a/runner/src/coval_bench/registries/models.py
+++ b/runner/src/coval_bench/registries/models.py
@@ -166,7 +166,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         provider="gladia",
         model="solaria-1",
         tags=(_REALTIME, _MULTI, _VAD),
-        status=_PENDING,
+        status=_ACTIVE,
     ),
     RegisteredModel(
         benchmark=_STT,


### PR DESCRIPTION
Flips `gladia/solaria-1` from `PENDING` to `ACTIVE` in the model registry so the orchestrator benchmarks it and the site shows it.

The runner provider (`providers/stt/gladia.py`), config (`gladia_api_key`), and `.env.example` already support Gladia — it was only held in `PENDING` waiting on credits. Depends on the prod `GLADIA_API_KEY` secret being provisioned first (separate benchmark-infra PR).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR activates `gladia/solaria-1` for the STT leaderboard by flipping its registry status from `PENDING` to `ACTIVE`. The provider implementation, config wiring, and `.env.example` were already in place; this change is the single gate that enables the orchestrator to schedule runs and the site to display results.

- Changes `status=_PENDING` → `status=_ACTIVE` for the `gladia/solaria-1` entry in `MODEL_REGISTRY`, which is the only change in the diff.
- The orchestrator resolves the provider key dynamically via `getattr(settings, \"gladia_api_key\", None)`, so if the API key secret has not yet been provisioned the Gladia tasks will raise a `ValueError` at provider instantiation, be caught by the `return_exceptions=True` gather, and log a warning — other providers are unaffected.

<h3>Confidence Score: 5/5</h3>

Safe to merge — this is a single-field registry change with no new logic.

The only change is flipping one status field. The provider implementation, config mapping, and env example have all been in the codebase for some time. If the API key secret is not yet in place, the orchestrator's return_exceptions=True gather silently absorbs the init-time ValueError, logs a warning, and leaves other providers unaffected — no crashes, no data corruption.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| runner/src/coval_bench/registries/models.py | Single-line status change from PENDING to ACTIVE for gladia/solaria-1; provider, config, and .env.example are already wired up. |

<sub>Reviews (1): Last reviewed commit: ["Activate Gladia Solaria-1 on the STT lea..."](https://github.com/coval-ai/benchmarks/commit/0380679fc7e06d63070b09e6488147a1ff17e480) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40652090)</sub>

<!-- /greptile_comment -->