### PR TITLE
Tag models with capability, licensing, and deployment facets

### DIFF
--- a/runner/src/coval_bench/api/routers/providers.py
+++ b/runner/src/coval_bench/api/routers/providers.py
@@ -56,12 +56,15 @@ def _tag(category: TagCategory, value: str) -> ModelTagOut:
 def _model_tags(m: RegisteredModel) -> list[ModelTagOut]:
     """Flatten a model's facets: derived columns/attributes plus curated tags."""
     source = "inference" if m.creator and m.creator != m.provider else "original"
+    deployment = "self-hostable" if m.self_hostable else "cloud"
     return [
         _tag(TagCategory.TYPE, m.benchmark),
         _tag(TagCategory.HOST, m.provider),
         _tag(TagCategory.LAB, m.creator or m.provider),
         _tag(TagCategory.SOURCE, source),
         _tag(TagCategory.TENANCY, m.tenancy),
+        _tag(TagCategory.LICENSING, m.licensing),
+        _tag(TagCategory.DEPLOYMENT, deployment),
         *(_tag(TAG_CATEGORIES[t], t) for t in m.tags),
     ]
 

--- a/runner/src/coval_bench/registries/__init__.py
+++ b/runner/src/coval_bench/registries/__init__.py
@@ -15,6 +15,7 @@ from coval_bench.registries.metrics import (
 )
 from coval_bench.registries.models import (
     MODEL_REGISTRY,
+    Licensing,
     ModelStatus,
     RegisteredModel,
     Tenancy,
@@ -35,6 +36,7 @@ __all__ = [
     "Metric",
     "MetricDirection",
     "MetricSpec",
+    "Licensing",
     "ModelStatus",
     "RegisteredModel",
     "Tenancy",

--- a/runner/src/coval_bench/registries/models.py
+++ b/runner/src/coval_bench/registries/models.py
@@ -423,6 +423,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         self_hostable=True,
         status=_ACTIVE,
     ),
+    # Inworld offers on-prem for Max only, so mini is not self_hostable.
     RegisteredModel(
         benchmark=_TTS,
         provider="inworld",

--- a/runner/src/coval_bench/registries/models.py
+++ b/runner/src/coval_bench/registries/models.py
@@ -35,6 +35,13 @@ class Tenancy(StrEnum):
     DEDICATED = "dedicated"
 
 
+class Licensing(StrEnum):
+    """Whether the model's weights are openly available."""
+
+    PROPRIETARY = "proprietary"
+    OPEN_WEIGHT = "open-weight"
+
+
 class RegisteredModel(BaseModel, frozen=True):
     """A single benchmarked model: identity, display metadata, run config."""
 
@@ -45,6 +52,8 @@ class RegisteredModel(BaseModel, frozen=True):
     creator: str | None = None  # who makes the model; None means same as provider
     tags: tuple[ModelTag, ...] = ()
     tenancy: Tenancy = Tenancy.SHARED
+    licensing: Licensing = Licensing.PROPRIETARY
+    self_hostable: bool = False  # can run in the customer's own infra
     status: ModelStatus
 
 
@@ -57,6 +66,14 @@ _REALTIME = ModelTag.REALTIME
 _BATCH = ModelTag.BATCH
 _MULTI = ModelTag.MULTILINGUAL
 _VAD = ModelTag.VAD
+_DIAR = ModelTag.DIARIZATION
+_TRANS = ModelTag.TRANSLATION
+_CODESW = ModelTag.CODE_SWITCHING
+_KEYTERM = ModelTag.KEYTERM_BIASING
+_CLONE = ModelTag.VOICE_CLONING
+_EMOTION = ModelTag.EMOTION_CONTROL
+_STREAM = ModelTag.STREAMING_INPUT
+_OPEN = Licensing.OPEN_WEIGHT
 
 # Per-benchmark order is the model order /v1/providers returns.
 MODEL_REGISTRY: list[RegisteredModel] = [
@@ -67,35 +84,39 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         benchmark=_STT,
         provider="deepgram",
         model="nova-2",
-        tags=(_REALTIME, _MULTI, _VAD),
+        tags=(_REALTIME, _MULTI, _VAD, _DIAR, _CODESW, _KEYTERM),
+        self_hostable=True,
         status=_ACTIVE,
     ),
     RegisteredModel(
         benchmark=_STT,
         provider="deepgram",
         model="nova-3",
-        tags=(_REALTIME, _MULTI, _VAD),
+        tags=(_REALTIME, _MULTI, _VAD, _DIAR, _CODESW, _KEYTERM),
+        self_hostable=True,
         status=_ACTIVE,
     ),
     RegisteredModel(
         benchmark=_STT,
         provider="deepgram",
         model="flux-general-en",
-        tags=(_REALTIME, _VAD),
+        tags=(_REALTIME, _VAD, _KEYTERM),
+        self_hostable=True,
         status=_ACTIVE,
     ),
     RegisteredModel(
         benchmark=_STT,
         provider="deepgram",
         model="flux-general-multi",
-        tags=(_REALTIME, _MULTI, _VAD),
+        tags=(_REALTIME, _MULTI, _VAD, _CODESW, _KEYTERM),
+        self_hostable=True,
         status=_ACTIVE,
     ),
     RegisteredModel(
         benchmark=_STT,
         provider="elevenlabs",
         model="scribe_v2_realtime",
-        tags=(_REALTIME, _MULTI, _VAD),
+        tags=(_REALTIME, _MULTI, _VAD, _CODESW, _KEYTERM),
         status=_ACTIVE,
     ),
     RegisteredModel(
@@ -109,49 +130,54 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         benchmark=_STT,
         provider="openai",
         model="gpt-4o-transcribe",
-        tags=(_REALTIME, _MULTI, _VAD),
+        tags=(_REALTIME, _MULTI, _VAD, _KEYTERM),
         status=_ACTIVE,
     ),
     RegisteredModel(
         benchmark=_STT,
         provider="openai",
         model="gpt-4o-mini-transcribe",
-        tags=(_REALTIME, _MULTI, _VAD),
+        tags=(_REALTIME, _MULTI, _VAD, _KEYTERM),
         status=_ACTIVE,
     ),
     RegisteredModel(
         benchmark=_STT,
         provider="assemblyai",
         model="universal-streaming",
-        tags=(_REALTIME, _VAD),
+        tags=(_REALTIME, _VAD, _DIAR, _KEYTERM),
+        self_hostable=True,
         status=_ACTIVE,
     ),
     RegisteredModel(
         benchmark=_STT,
         provider="assemblyai",
         model="universal-streaming-multilingual",
-        tags=(_REALTIME, _MULTI, _VAD),
+        tags=(_REALTIME, _MULTI, _VAD, _DIAR, _CODESW, _KEYTERM),
+        self_hostable=True,
         status=_ACTIVE,
     ),
     RegisteredModel(
         benchmark=_STT,
         provider="assemblyai",
         model="universal-3.5-pro",
-        tags=(_REALTIME, _MULTI, _VAD),
+        tags=(_REALTIME, _MULTI, _VAD, _DIAR, _CODESW, _KEYTERM),
+        self_hostable=True,
         status=_ACTIVE,
     ),
     RegisteredModel(
         benchmark=_STT,
         provider="speechmatics",
         model="default",
-        tags=(_REALTIME, _MULTI, _VAD),
+        tags=(_REALTIME, _MULTI, _VAD, _DIAR, _TRANS, _CODESW, _KEYTERM),
+        self_hostable=True,
         status=_ACTIVE,
     ),
     RegisteredModel(
         benchmark=_STT,
         provider="speechmatics",
         model="enhanced",
-        tags=(_REALTIME, _MULTI, _VAD),
+        tags=(_REALTIME, _MULTI, _VAD, _DIAR, _TRANS, _CODESW, _KEYTERM),
+        self_hostable=True,
         status=_ACTIVE,
     ),
     RegisteredModel(
@@ -165,42 +191,42 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         benchmark=_STT,
         provider="gladia",
         model="solaria-1",
-        tags=(_REALTIME, _MULTI, _VAD),
+        tags=(_REALTIME, _MULTI, _VAD, _DIAR, _TRANS, _CODESW, _KEYTERM),
         status=_ACTIVE,
     ),
     RegisteredModel(
         benchmark=_STT,
         provider="soniox",
         model="stt-rt-v4",
-        tags=(_REALTIME, _MULTI, _VAD),
+        tags=(_REALTIME, _MULTI, _VAD, _DIAR, _TRANS, _CODESW, _KEYTERM),
         status=_ACTIVE,
     ),
     RegisteredModel(
         benchmark=_STT,
         provider="soniox",
         model="stt-rt-v5",
-        tags=(_REALTIME, _MULTI, _VAD),
+        tags=(_REALTIME, _MULTI, _VAD, _DIAR, _TRANS, _CODESW, _KEYTERM),
         status=_ACTIVE,
     ),
     RegisteredModel(
         benchmark=_STT,
         provider="inworld",
         model="inworld-stt-1",
-        tags=(_REALTIME, _VAD),
+        tags=(_REALTIME, _MULTI, _VAD, _KEYTERM),
         status=_ACTIVE,
     ),
     RegisteredModel(
         benchmark=_STT,
         provider="xai",
         model="grok-stt",
-        tags=(_REALTIME, _MULTI, _VAD),
+        tags=(_REALTIME, _MULTI, _VAD, _DIAR, _CODESW),
         status=_ACTIVE,
     ),
     RegisteredModel(
         benchmark=_STT,
         provider="smallest",
         model="pulse",
-        tags=(_REALTIME, _MULTI, _VAD),
+        tags=(_REALTIME, _MULTI, _VAD, _DIAR, _CODESW),
         status=_ACTIVE,
     ),
     RegisteredModel(
@@ -246,7 +272,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         provider="elevenlabs",
         model="eleven_flash_v2_5",
         voice="IKne3meq5aSn9XLyUdCD",
-        tags=(_REALTIME, _MULTI),
+        tags=(_REALTIME, _MULTI, _CLONE, _STREAM),
         status=_ACTIVE,
     ),
     RegisteredModel(
@@ -254,7 +280,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         provider="elevenlabs",
         model="eleven_multilingual_v2",
         voice="IKne3meq5aSn9XLyUdCD",
-        tags=(_REALTIME, _MULTI),
+        tags=(_REALTIME, _MULTI, _CLONE, _STREAM),
         status=_ACTIVE,
     ),
     RegisteredModel(
@@ -270,7 +296,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         provider="openai",
         model="gpt-4o-mini-tts",
         voice="alloy",
-        tags=(_REALTIME, _MULTI),
+        tags=(_REALTIME, _MULTI, _EMOTION),
         status=_ACTIVE,
     ),
     RegisteredModel(
@@ -294,7 +320,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         provider="cartesia",
         model="sonic-3",
         voice="f786b574-daa5-4673-aa0c-cbe3e8534c02",
-        tags=(_REALTIME, _MULTI),
+        tags=(_REALTIME, _MULTI, _CLONE, _EMOTION, _STREAM),
         status=_ACTIVE,
     ),
     RegisteredModel(
@@ -302,7 +328,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         provider="cartesia",
         model="sonic-3.5",
         voice="db6b0ed5-d5d3-463d-ae85-518a07d3c2b4",
-        tags=(_REALTIME, _MULTI),
+        tags=(_REALTIME, _MULTI, _CLONE, _EMOTION, _STREAM),
         status=_ACTIVE,
     ),
     RegisteredModel(
@@ -310,7 +336,8 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         provider="deepgram",
         model="aura-2-thalia-en",
         voice="aura-2-thalia-en",
-        tags=(_REALTIME,),
+        tags=(_REALTIME, _STREAM),
+        self_hostable=True,
         status=_ACTIVE,
     ),
     RegisteredModel(
@@ -318,7 +345,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         provider="gradium",
         model="default",
         voice="YTpq7expH9539ERJ",
-        tags=(_REALTIME, _MULTI),
+        tags=(_REALTIME, _MULTI, _CLONE, _STREAM),
         status=_ACTIVE,
     ),
     # Rime — all three on /ws3 WebSocket.
@@ -328,7 +355,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         provider="rime",
         model="coda",
         voice="luna",
-        tags=(_REALTIME, _MULTI),
+        tags=(_REALTIME, _MULTI, _STREAM),
         status=_ACTIVE,
     ),
     RegisteredModel(
@@ -336,7 +363,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         provider="rime",
         model="arcana",
         voice="luna",
-        tags=(_REALTIME, _MULTI),
+        tags=(_REALTIME, _MULTI, _EMOTION, _STREAM),
         status=_ACTIVE,
     ),
     RegisteredModel(
@@ -344,7 +371,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         provider="rime",
         model="mistv3",
         voice="luna",
-        tags=(_REALTIME, _MULTI),
+        tags=(_REALTIME, _MULTI, _STREAM),
         status=_ACTIVE,
     ),
     RegisteredModel(
@@ -360,7 +387,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         provider="hume",
         model="octave-tts",
         voice="176a55b1-4468-4736-8878-db82729667c1",
-        tags=(_REALTIME, _MULTI),
+        tags=(_REALTIME, _MULTI, _CLONE, _EMOTION, _STREAM),
         status=_ACTIVE,
     ),
     RegisteredModel(
@@ -368,7 +395,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         provider="hume",
         model="octave-2",
         voice="176a55b1-4468-4736-8878-db82729667c1",
-        tags=(_REALTIME, _MULTI),
+        tags=(_REALTIME, _MULTI, _CLONE, _STREAM),
         status=_ACTIVE,
     ),
     RegisteredModel(
@@ -376,7 +403,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         provider="xai",
         model="grok-tts",
         voice="eve",
-        tags=(_REALTIME, _MULTI),
+        tags=(_REALTIME, _MULTI, _CLONE, _EMOTION, _STREAM),
         status=_ACTIVE,
     ),
     RegisteredModel(
@@ -384,7 +411,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         provider="smallest",
         model="lightning_v3.1_pro",
         voice="kaitlyn",
-        tags=(_REALTIME,),
+        tags=(_REALTIME, _MULTI, _CLONE, _STREAM),
         status=_ACTIVE,
     ),
     RegisteredModel(
@@ -392,7 +419,8 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         provider="inworld",
         model="inworld-tts-1.5-max",
         voice="Ashley",
-        tags=(_REALTIME, _MULTI),
+        tags=(_REALTIME, _MULTI, _CLONE, _EMOTION, _STREAM),
+        self_hostable=True,
         status=_ACTIVE,
     ),
     RegisteredModel(
@@ -400,7 +428,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         provider="inworld",
         model="inworld-tts-1.5-mini",
         voice="Ashley",
-        tags=(_REALTIME, _MULTI),
+        tags=(_REALTIME, _MULTI, _CLONE, _EMOTION, _STREAM),
         status=_ACTIVE,
     ),
     RegisteredModel(
@@ -408,7 +436,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         provider="soniox",
         model="tts-rt-v1",
         voice="Adrian",
-        tags=(_REALTIME, _MULTI),
+        tags=(_REALTIME, _MULTI, _STREAM),
         status=_ACTIVE,
     ),
     RegisteredModel(
@@ -417,7 +445,9 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         model="canopylabs/orpheus-v1-english",
         voice="autumn",
         creator="canopylabs",
-        tags=(_BATCH,),
+        tags=(_BATCH, _EMOTION),
+        licensing=_OPEN,
+        self_hostable=True,
         status=_ACTIVE,
     ),
     # gpt-realtime is a speech-to-speech LLM, not a TTS provider: driving it

--- a/runner/src/coval_bench/registries/tags.py
+++ b/runner/src/coval_bench/registries/tags.py
@@ -84,6 +84,7 @@ PROVIDER_VALUED_CATEGORIES: frozenset[TagCategory] = frozenset({TagCategory.HOST
 # Value labels that aren't a plain capitalization.
 _VALUE_LABELS: dict[str, str] = {
     ModelTag.VAD.value: "VAD",
+    ModelTag.CODE_SWITCHING.value: "Code switching",
     ModelTag.KEYTERM_BIASING.value: "Keyterm biasing",
     ModelTag.VOICE_CLONING.value: "Voice cloning",
     ModelTag.EMOTION_CONTROL.value: "Emotion control",

--- a/runner/src/coval_bench/registries/tags.py
+++ b/runner/src/coval_bench/registries/tags.py
@@ -10,9 +10,9 @@ from enum import StrEnum
 class TagCategory(StrEnum):
     """Faceted leaderboard filters. Within a facet tags OR; across facets they AND.
 
-    TYPE/HOST/LAB are derived from registry columns and SOURCE/TENANCY from model
-    attributes, all at the API boundary; only MODE and FEATURES draw their values
-    from ``ModelTag``.
+    TYPE/HOST/LAB are derived from registry columns and SOURCE/TENANCY/LICENSING/
+    DEPLOYMENT from model attributes, all at the API boundary; only MODE and
+    FEATURES draw their values from ``ModelTag``.
     """
 
     TYPE = "type"
@@ -22,6 +22,8 @@ class TagCategory(StrEnum):
     FEATURES = "features"
     SOURCE = "source"
     TENANCY = "tenancy"
+    LICENSING = "licensing"
+    DEPLOYMENT = "deployment"
 
 
 class ModelTag(StrEnum):
@@ -31,6 +33,13 @@ class ModelTag(StrEnum):
     BATCH = "batch"
     MULTILINGUAL = "multilingual"
     VAD = "vad"
+    DIARIZATION = "diarization"
+    TRANSLATION = "translation"
+    CODE_SWITCHING = "code-switching"
+    KEYTERM_BIASING = "keyterm-biasing"
+    VOICE_CLONING = "voice-cloning"
+    EMOTION_CONTROL = "emotion-control"
+    STREAMING_INPUT = "streaming-input"
 
 
 TAG_CATEGORIES: dict[ModelTag, TagCategory] = {
@@ -38,6 +47,13 @@ TAG_CATEGORIES: dict[ModelTag, TagCategory] = {
     ModelTag.BATCH: TagCategory.MODE,
     ModelTag.MULTILINGUAL: TagCategory.FEATURES,
     ModelTag.VAD: TagCategory.FEATURES,
+    ModelTag.DIARIZATION: TagCategory.FEATURES,
+    ModelTag.TRANSLATION: TagCategory.FEATURES,
+    ModelTag.CODE_SWITCHING: TagCategory.FEATURES,
+    ModelTag.KEYTERM_BIASING: TagCategory.FEATURES,
+    ModelTag.VOICE_CLONING: TagCategory.FEATURES,
+    ModelTag.EMOTION_CONTROL: TagCategory.FEATURES,
+    ModelTag.STREAMING_INPUT: TagCategory.FEATURES,
 }
 
 if TAG_CATEGORIES.keys() != set(ModelTag):
@@ -54,6 +70,8 @@ CATEGORY_LABELS: dict[TagCategory, str] = {
     TagCategory.FEATURES: "Features",
     TagCategory.SOURCE: "Source",
     TagCategory.TENANCY: "Tenancy",
+    TagCategory.LICENSING: "Licensing",
+    TagCategory.DEPLOYMENT: "Deployment",
 }
 
 if CATEGORY_LABELS.keys() != set(TagCategory):
@@ -64,7 +82,13 @@ if CATEGORY_LABELS.keys() != set(TagCategory):
 PROVIDER_VALUED_CATEGORIES: frozenset[TagCategory] = frozenset({TagCategory.HOST, TagCategory.LAB})
 
 # Value labels that aren't a plain capitalization.
-_VALUE_LABELS: dict[str, str] = {ModelTag.VAD.value: "VAD"}
+_VALUE_LABELS: dict[str, str] = {
+    ModelTag.VAD.value: "VAD",
+    ModelTag.KEYTERM_BIASING.value: "Keyterm biasing",
+    ModelTag.VOICE_CLONING.value: "Voice cloning",
+    ModelTag.EMOTION_CONTROL.value: "Emotion control",
+    ModelTag.STREAMING_INPUT.value: "Streaming input",
+}
 
 
 def tag_value_label(category: TagCategory, value: str) -> str:

--- a/runner/tests/api/test_providers.py
+++ b/runner/tests/api/test_providers.py
@@ -110,6 +110,8 @@ async def test_every_model_carries_derived_facets(client: AsyncClient) -> None:
     assert ("lab", "xai") in facets
     assert ("source", "original") in facets
     assert ("tenancy", "shared") in facets
+    assert ("licensing", "proprietary") in facets
+    assert ("deployment", "cloud") in facets
 
     # Each tag carries a display label: provider-valued categories keep the raw
     # id, TYPE uppercases, everything else capitalizes.
@@ -118,6 +120,28 @@ async def test_every_model_carries_derived_facets(client: AsyncClient) -> None:
     assert labels[("host", "xai")] == "xai"
     assert labels[("source", "original")] == "Original"
     assert labels[("tenancy", "shared")] == "Shared"
+
+
+async def test_capability_and_licensing_facets(client: AsyncClient) -> None:
+    """Curated capability tags, open-weight licensing, and self-hostable deployment surface."""
+    response = await client.get("/v1/providers")
+    data = response.json()
+
+    sm = next(e for e in data["stt"] if e["provider"] == "speechmatics")
+    default = next(m for m in sm["models"] if m["model"] == "default")
+    sm_facets = {(t["category"], t["value"]) for t in default["tags"]}
+    assert ("features", "diarization") in sm_facets
+    assert ("features", "translation") in sm_facets
+    assert ("deployment", "self-hostable") in sm_facets
+
+    groq = next(e for e in data["tts"] if e["provider"] == "groq")
+    orpheus = next(m for m in groq["models"] if m["model"] == "canopylabs/orpheus-v1-english")
+    orpheus_facets = {(t["category"], t["value"]) for t in orpheus["tags"]}
+    labels = {(t["category"], t["value"]): t["label"] for t in orpheus["tags"]}
+    assert ("licensing", "open-weight") in orpheus_facets
+    assert ("features", "emotion-control") in orpheus_facets
+    assert labels[("licensing", "open-weight")] == "Open-weight"
+    assert labels[("features", "emotion-control")] == "Emotion control"
 
 
 async def test_tag_categories_metadata(client: AsyncClient) -> None:
@@ -134,6 +158,8 @@ async def test_tag_categories_metadata(client: AsyncClient) -> None:
         "features",
         "source",
         "tenancy",
+        "licensing",
+        "deployment",
     ]
     by_category = {c["category"]: c for c in categories}
     assert by_category["features"]["label"] == "Features"

--- a/runner/tests/unit/test_provider_config.py
+++ b/runner/tests/unit/test_provider_config.py
@@ -8,6 +8,7 @@ from coval_bench.registries import (
     MODEL_REGISTRY,
     TAG_CATEGORIES,
     Benchmark,
+    Licensing,
     ModelStatus,
     ModelTag,
     RegisteredModel,
@@ -32,6 +33,8 @@ def test_registered_model_defaults() -> None:
     assert m.creator is None
     assert m.tags == ()
     assert m.tenancy is Tenancy.SHARED
+    assert m.licensing is Licensing.PROPRIETARY
+    assert m.self_hostable is False
 
 
 def test_every_model_has_exactly_one_mode() -> None:


### PR DESCRIPTION
Adds STT/TTS capability tags (diarization, translation, voice cloning, etc.), licensing and deployment categories, and the missing multilingual tags on inworld-stt-1 and lightning_v3.1_pro.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added new provider facets for **licensing** and **deployment** (hosting mode), improving filtering and discovery.
  * Expanded supported capability facets with richer feature tags (e.g., code-switching, translation, diarization-related features), with improved display labeling.

* **Bug Fixes**
  * Improved provider catalog tagging so models now expose more complete and consistent facet information.

* **Tests**
  * Updated and added test coverage to validate the new facet categories, derived values, and display ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR enriches the model registry with three new dimensions — STT/TTS capability feature tags (diarization, translation, code-switching, keyterm biasing, voice cloning, emotion control, streaming input), a `Licensing` enum (`proprietary` / `open-weight`), and a `self_hostable` boolean that drives a new `deployment` facet. All three are surfaced as faceted leaderboard filters through the existing `_model_tags` pipeline.

- **New tags vocabulary** (`tags.py`): seven `ModelTag` entries, two `TagCategory` entries, matching `TAG_CATEGORIES` / `CATEGORY_LABELS` / `_VALUE_LABELS` entries, guarded by the existing exhaustiveness checks at import time.
- **Registry data** (`models.py`): `RegisteredModel` gains `licensing` (default `PROPRIETARY`) and `self_hostable` (default `False`); all STT and TTS entries are annotated with the appropriate capability, licensing, and deployment values. The inworld-tts-1.5-mini / max self-hosting asymmetry is documented with an inline comment.
- **API layer** (`providers.py`): two lines added to `_model_tags`; tests extended to assert the new facets surface on representative models (speechmatics `default`, Orpheus).

<h3>Confidence Score: 5/5</h3>

All changes are additive data and vocabulary additions with no mutations to existing behavior; import-time exhaustiveness guards confirm the new entries are complete.

The diff is purely additive: new enum values, two new model fields with safe defaults, and updated tag lists on existing entries. The import-time guards in tags.py would raise at startup if any ModelTag or TagCategory were left out of their respective mapping dicts, so omissions are caught before deployment. Previously flagged issues (code-switching label and inworld-tts asymmetry) are both addressed. Tests cover the new facets end-to-end.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| runner/src/coval_bench/registries/tags.py | Adds LICENSING and DEPLOYMENT TagCategory values, 7 new ModelTag entries, their TAG_CATEGORIES mappings, CATEGORY_LABELS, and _VALUE_LABELS entries. Exhaustiveness guards at module level catch any omissions at import time. |
| runner/src/coval_bench/registries/models.py | Introduces Licensing enum and two new RegisteredModel fields (licensing, self_hostable). Applies capability, licensing, and self-hostable tags across STT/TTS model entries, including a clarifying comment for the inworld-tts-1.5-mini asymmetry. |
| runner/src/coval_bench/api/routers/providers.py | _model_tags now emits LICENSING and DEPLOYMENT facet tags derived from the model's new attributes; straightforward two-line addition with no logic changes elsewhere. |
| runner/src/coval_bench/registries/__init__.py | Exports the new Licensing enum from the package's public API; change is minimal and correct. |
| runner/tests/api/test_providers.py | Adds test_capability_and_licensing_facets covering diarization/translation on speechmatics and open-weight/emotion-control on orpheus, plus extends derived-facet and tag-categories order tests for the two new categories. |
| runner/tests/unit/test_provider_config.py | Extends test_registered_model_defaults to assert the new licensing and self_hostable fields default correctly; minimal, targeted addition. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    RM[RegisteredModel\n+licensing: Licensing\n+self_hostable: bool] -->|read by| MT["_model_tags()"]
    MT -->|emits| LIC["_tag(LICENSING, m.licensing)\n'proprietary' | 'open-weight'"]
    MT -->|emits| DEP["_tag(DEPLOYMENT, deployment)\n'cloud' | 'self-hostable'"]
    MT -->|emits| CAP["_tag(FEATURES, t)\nfor t in m.tags"]
    LIC -->|label via| TVL["tag_value_label()\n_VALUE_LABELS or .capitalize()"]
    DEP -->|label via| TVL
    CAP -->|label via| TVL
    TVL -->|returns| OUT["ModelTagOut\n{category, value, label}"]
    OUT -->|included in| RESP["/v1/providers response"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    RM[RegisteredModel\n+licensing: Licensing\n+self_hostable: bool] -->|read by| MT["_model_tags()"]
    MT -->|emits| LIC["_tag(LICENSING, m.licensing)\n'proprietary' | 'open-weight'"]
    MT -->|emits| DEP["_tag(DEPLOYMENT, deployment)\n'cloud' | 'self-hostable'"]
    MT -->|emits| CAP["_tag(FEATURES, t)\nfor t in m.tags"]
    LIC -->|label via| TVL["tag_value_label()\n_VALUE_LABELS or .capitalize()"]
    DEP -->|label via| TVL
    CAP -->|label via| TVL
    TVL -->|returns| OUT["ModelTagOut\n{category, value, label}"]
    OUT -->|included in| RESP["/v1/providers response"]
```

</a>

<sub>Reviews (2): Last reviewed commit: ["Address PR review on capability tags"](https://github.com/coval-ai/benchmarks/commit/bb91a03c536d193ceca5970a59eea1f92a50737c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40680675)</sub>

<!-- /greptile_comment -->