### PR TITLE
Fix STT real-time pacing drift inflating latency

### DIFF
--- a/runner/src/coval_bench/providers/stt/_pacing.py
+++ b/runner/src/coval_bench/providers/stt/_pacing.py
@@ -1,0 +1,70 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Real-time pacing for streaming STT audio sends.
+
+Providers are fed audio at 1x real time so latency metrics reflect provider
+processing rather than feed timing. Each chunk is paced to an absolute deadline
+(``start + cumulative_bytes / byte_rate``), and the final chunk is paced too so
+the end-of-stream signal lands at the true end of the audio.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from collections.abc import AsyncIterator, Iterator
+
+
+def pacing_delay(start: float, sent_bytes: int, byte_rate: int) -> float:
+    """Seconds to wait so ``sent_bytes`` of audio matches real time.
+
+    Non-positive when the send is already behind schedule (no wait needed).
+    """
+    return start + sent_bytes / byte_rate - time.monotonic()
+
+
+async def paced_chunks(
+    audio_data: bytes,
+    chunk_size: int,
+    byte_rate: int,
+    *,
+    start: float | None = None,
+) -> AsyncIterator[tuple[bytes, float]]:
+    """Yield ``(chunk, start)`` pacing each chunk to real time, the last included.
+
+    ``start`` defaults to the monotonic clock at the first chunk; pass it to
+    anchor pacing to a timestamp captured earlier.
+    """
+    chunk_size = max(1, chunk_size)
+    if start is None:
+        start = time.monotonic()
+    sent_bytes = 0
+    for i in range(0, len(audio_data), chunk_size):
+        chunk = audio_data[i : i + chunk_size]
+        yield chunk, start
+        sent_bytes += len(chunk)
+        delay = pacing_delay(start, sent_bytes, byte_rate)
+        if delay > 0:
+            await asyncio.sleep(delay)
+
+
+def paced_chunks_sync(
+    audio_data: bytes,
+    chunk_size: int,
+    byte_rate: int,
+    *,
+    start: float | None = None,
+) -> Iterator[tuple[bytes, float]]:
+    """Synchronous :func:`paced_chunks` for blocking send loops (e.g. gRPC)."""
+    chunk_size = max(1, chunk_size)
+    if start is None:
+        start = time.monotonic()
+    sent_bytes = 0
+    for i in range(0, len(audio_data), chunk_size):
+        chunk = audio_data[i : i + chunk_size]
+        yield chunk, start
+        sent_bytes += len(chunk)
+        delay = pacing_delay(start, sent_bytes, byte_rate)
+        if delay > 0:
+            time.sleep(delay)

--- a/runner/src/coval_bench/providers/stt/assemblyai.py
+++ b/runner/src/coval_bench/providers/stt/assemblyai.py
@@ -140,17 +140,22 @@ class AssemblyAIProvider(STTProvider):
         final_event: asyncio.Event,
     ) -> None:
         byte_rate = sample_width * sample_rate * channels
+        chunk_size = int(byte_rate * realtime_resolution)
         data = audio_data
-        first_chunk = True
+        start: float | None = None
+        chunk_index = 0
         try:
             while data:
-                chunk_size = int(byte_rate * realtime_resolution)
                 chunk, data = data[:chunk_size], data[chunk_size:]
-                if first_chunk:
-                    result.audio_start_time = time.monotonic()
-                    first_chunk = False
+                if start is None:
+                    start = time.monotonic()
+                    result.audio_start_time = start
                 await ws.send(chunk)
-                await asyncio.sleep(realtime_resolution)
+                if data:
+                    delay = start + (chunk_index + 1) * realtime_resolution - time.monotonic()
+                    if delay > 0:
+                        await asyncio.sleep(delay)
+                chunk_index += 1
             # Force finalization at speech-end (TTFS parity), then wait for the final
             # before terminating so the close can't race it. Clear first: the event may
             # already be set by an earlier final, which would make the wait a no-op.

--- a/runner/src/coval_bench/providers/stt/assemblyai.py
+++ b/runner/src/coval_bench/providers/stt/assemblyai.py
@@ -22,6 +22,7 @@ import websockets.asyncio.client as ws_client
 from pydantic import SecretStr
 
 from coval_bench.providers.base import STTProvider, TranscriptionResult
+from coval_bench.providers.stt._pacing import paced_chunks
 
 logger = structlog.get_logger(__name__)
 
@@ -141,20 +142,10 @@ class AssemblyAIProvider(STTProvider):
     ) -> None:
         byte_rate = sample_width * sample_rate * channels
         chunk_size = int(byte_rate * realtime_resolution)
-        data = audio_data
-        start: float | None = None
-        sent_bytes = 0
         try:
-            while data:
-                chunk, data = data[:chunk_size], data[chunk_size:]
-                if start is None:
-                    start = time.monotonic()
-                    result.audio_start_time = start
+            async for chunk, start in paced_chunks(audio_data, chunk_size, byte_rate):
+                result.audio_start_time = start
                 await ws.send(chunk)
-                sent_bytes += len(chunk)
-                delay = start + sent_bytes / byte_rate - time.monotonic()
-                if delay > 0:
-                    await asyncio.sleep(delay)
             # Force finalization at speech-end (TTFS parity), then wait for the final
             # before terminating so the close can't race it. Clear first: the event may
             # already be set by an earlier final, which would make the wait a no-op.

--- a/runner/src/coval_bench/providers/stt/assemblyai.py
+++ b/runner/src/coval_bench/providers/stt/assemblyai.py
@@ -143,7 +143,7 @@ class AssemblyAIProvider(STTProvider):
         chunk_size = int(byte_rate * realtime_resolution)
         data = audio_data
         start: float | None = None
-        chunk_index = 0
+        sent_bytes = 0
         try:
             while data:
                 chunk, data = data[:chunk_size], data[chunk_size:]
@@ -151,11 +151,10 @@ class AssemblyAIProvider(STTProvider):
                     start = time.monotonic()
                     result.audio_start_time = start
                 await ws.send(chunk)
-                if data:
-                    delay = start + (chunk_index + 1) * realtime_resolution - time.monotonic()
-                    if delay > 0:
-                        await asyncio.sleep(delay)
-                chunk_index += 1
+                sent_bytes += len(chunk)
+                delay = start + sent_bytes / byte_rate - time.monotonic()
+                if delay > 0:
+                    await asyncio.sleep(delay)
             # Force finalization at speech-end (TTFS parity), then wait for the final
             # before terminating so the close can't race it. Clear first: the event may
             # already be set by an earlier final, which would make the wait a no-op.

--- a/runner/src/coval_bench/providers/stt/cartesia.py
+++ b/runner/src/coval_bench/providers/stt/cartesia.py
@@ -121,15 +121,20 @@ class CartesiaSTTProvider(STTProvider):
         byte_rate = sample_rate * 2  # 16-bit mono
         chunk_size = int(byte_rate * realtime_resolution)
         data = audio_data
-        first_chunk = True
+        start: float | None = None
+        chunk_index = 0
         try:
             while data:
                 chunk, data = data[:chunk_size], data[chunk_size:]
-                if first_chunk:
-                    result.audio_start_time = time.monotonic()
-                    first_chunk = False
+                if start is None:
+                    start = time.monotonic()
+                    result.audio_start_time = start
                 await ws.send(chunk)
-                await asyncio.sleep(realtime_resolution)
+                if data:
+                    delay = start + (chunk_index + 1) * realtime_resolution - time.monotonic()
+                    if delay > 0:
+                        await asyncio.sleep(delay)
+                chunk_index += 1
             # Two-phase end: finalize flushes buffered audio; close ends the session.
             await ws.send("finalize")
             await ws.send("close")

--- a/runner/src/coval_bench/providers/stt/cartesia.py
+++ b/runner/src/coval_bench/providers/stt/cartesia.py
@@ -20,6 +20,7 @@ import websockets.asyncio.client as ws_client
 from pydantic import SecretStr
 
 from coval_bench.providers.base import STTProvider, TranscriptionResult
+from coval_bench.providers.stt._pacing import paced_chunks
 
 logger = structlog.get_logger(__name__)
 
@@ -120,20 +121,10 @@ class CartesiaSTTProvider(STTProvider):
     ) -> None:
         byte_rate = sample_rate * 2  # 16-bit mono
         chunk_size = int(byte_rate * realtime_resolution)
-        data = audio_data
-        start: float | None = None
-        sent_bytes = 0
         try:
-            while data:
-                chunk, data = data[:chunk_size], data[chunk_size:]
-                if start is None:
-                    start = time.monotonic()
-                    result.audio_start_time = start
+            async for chunk, start in paced_chunks(audio_data, chunk_size, byte_rate):
+                result.audio_start_time = start
                 await ws.send(chunk)
-                sent_bytes += len(chunk)
-                delay = start + sent_bytes / byte_rate - time.monotonic()
-                if delay > 0:
-                    await asyncio.sleep(delay)
             # Two-phase end: finalize flushes buffered audio; close ends the session.
             await ws.send("finalize")
             await ws.send("close")

--- a/runner/src/coval_bench/providers/stt/cartesia.py
+++ b/runner/src/coval_bench/providers/stt/cartesia.py
@@ -122,7 +122,7 @@ class CartesiaSTTProvider(STTProvider):
         chunk_size = int(byte_rate * realtime_resolution)
         data = audio_data
         start: float | None = None
-        chunk_index = 0
+        sent_bytes = 0
         try:
             while data:
                 chunk, data = data[:chunk_size], data[chunk_size:]
@@ -130,11 +130,10 @@ class CartesiaSTTProvider(STTProvider):
                     start = time.monotonic()
                     result.audio_start_time = start
                 await ws.send(chunk)
-                if data:
-                    delay = start + (chunk_index + 1) * realtime_resolution - time.monotonic()
-                    if delay > 0:
-                        await asyncio.sleep(delay)
-                chunk_index += 1
+                sent_bytes += len(chunk)
+                delay = start + sent_bytes / byte_rate - time.monotonic()
+                if delay > 0:
+                    await asyncio.sleep(delay)
             # Two-phase end: finalize flushes buffered audio; close ends the session.
             await ws.send("finalize")
             await ws.send("close")

--- a/runner/src/coval_bench/providers/stt/deepgram.py
+++ b/runner/src/coval_bench/providers/stt/deepgram.py
@@ -167,7 +167,7 @@ class DeepgramProvider(STTProvider):
         chunk_size = int(byte_rate * realtime_resolution)
         data = audio_data
         start: float | None = None
-        chunk_index = 0
+        sent_bytes = 0
         try:
             while data:
                 chunk, data = data[:chunk_size], data[chunk_size:]
@@ -175,11 +175,10 @@ class DeepgramProvider(STTProvider):
                     start = time.monotonic()
                     result.audio_start_time = start
                 await ws.send(chunk)
-                if data:
-                    delay = start + (chunk_index + 1) * realtime_resolution - time.monotonic()
-                    if delay > 0:
-                        await asyncio.sleep(delay)
-                chunk_index += 1
+                sent_bytes += len(chunk)
+                delay = start + sent_bytes / byte_rate - time.monotonic()
+                if delay > 0:
+                    await asyncio.sleep(delay)
             # nova finalizes on our signal (endpointing disabled): send Finalize, then
             # wait for the forced final before closing so the close can't race it. Flux
             # has no Finalize and can't be forced, so it's left on its native EOT.

--- a/runner/src/coval_bench/providers/stt/deepgram.py
+++ b/runner/src/coval_bench/providers/stt/deepgram.py
@@ -24,6 +24,7 @@ import websockets.asyncio.client as ws_client
 from pydantic import SecretStr
 
 from coval_bench.providers.base import STTProvider, TranscriptionResult
+from coval_bench.providers.stt._pacing import paced_chunks
 
 logger = structlog.get_logger(__name__)
 
@@ -165,20 +166,10 @@ class DeepgramProvider(STTProvider):
     ) -> None:
         byte_rate = sample_width * sample_rate * channels
         chunk_size = int(byte_rate * realtime_resolution)
-        data = audio_data
-        start: float | None = None
-        sent_bytes = 0
         try:
-            while data:
-                chunk, data = data[:chunk_size], data[chunk_size:]
-                if start is None:
-                    start = time.monotonic()
-                    result.audio_start_time = start
+            async for chunk, start in paced_chunks(audio_data, chunk_size, byte_rate):
+                result.audio_start_time = start
                 await ws.send(chunk)
-                sent_bytes += len(chunk)
-                delay = start + sent_bytes / byte_rate - time.monotonic()
-                if delay > 0:
-                    await asyncio.sleep(delay)
             # nova finalizes on our signal (endpointing disabled): send Finalize, then
             # wait for the forced final before closing so the close can't race it. Flux
             # has no Finalize and can't be forced, so it's left on its native EOT.

--- a/runner/src/coval_bench/providers/stt/deepgram.py
+++ b/runner/src/coval_bench/providers/stt/deepgram.py
@@ -164,17 +164,22 @@ class DeepgramProvider(STTProvider):
         final_event: asyncio.Event,
     ) -> None:
         byte_rate = sample_width * sample_rate * channels
+        chunk_size = int(byte_rate * realtime_resolution)
         data = audio_data
-        first_chunk = True
+        start: float | None = None
+        chunk_index = 0
         try:
             while data:
-                chunk_size = int(byte_rate * realtime_resolution)
                 chunk, data = data[:chunk_size], data[chunk_size:]
-                if first_chunk:
-                    result.audio_start_time = time.monotonic()
-                    first_chunk = False
+                if start is None:
+                    start = time.monotonic()
+                    result.audio_start_time = start
                 await ws.send(chunk)
-                await asyncio.sleep(realtime_resolution)
+                if data:
+                    delay = start + (chunk_index + 1) * realtime_resolution - time.monotonic()
+                    if delay > 0:
+                        await asyncio.sleep(delay)
+                chunk_index += 1
             # nova finalizes on our signal (endpointing disabled): send Finalize, then
             # wait for the forced final before closing so the close can't race it. Flux
             # has no Finalize and can't be forced, so it's left on its native EOT.

--- a/runner/src/coval_bench/providers/stt/elevenlabs.py
+++ b/runner/src/coval_bench/providers/stt/elevenlabs.py
@@ -22,6 +22,7 @@ import websockets.asyncio.client as ws_client
 from pydantic import SecretStr
 
 from coval_bench.providers.base import STTProvider, TranscriptionResult
+from coval_bench.providers.stt._pacing import paced_chunks
 
 logger = structlog.get_logger(__name__)
 
@@ -162,20 +163,13 @@ class ElevenLabsSTTProvider(STTProvider):
         # ElevenLabs expects base64-encoded PCM chunks in JSON
         bytes_per_second = sample_rate * 2  # 16-bit mono
         chunk_size = int(bytes_per_second * realtime_resolution)
-        start = time.monotonic()
-        result.audio_start_time = start
-        sent_bytes = 0
         try:
-            for i in range(0, len(audio_data), chunk_size):
-                chunk = audio_data[i : i + chunk_size]
+            async for chunk, start in paced_chunks(audio_data, chunk_size, bytes_per_second):
+                result.audio_start_time = start
                 b64 = base64.b64encode(chunk).decode("utf-8")
                 await ws.send(
                     json.dumps({"message_type": "input_audio_chunk", "audio_base_64": b64})
                 )
-                sent_bytes += len(chunk)
-                delay = start + sent_bytes / bytes_per_second - time.monotonic()
-                if delay > 0:
-                    await asyncio.sleep(delay)
 
             # Commit / end-of-input signal
             await ws.send(

--- a/runner/src/coval_bench/providers/stt/elevenlabs.py
+++ b/runner/src/coval_bench/providers/stt/elevenlabs.py
@@ -164,17 +164,18 @@ class ElevenLabsSTTProvider(STTProvider):
         chunk_size = int(bytes_per_second * realtime_resolution)
         start = time.monotonic()
         result.audio_start_time = start
+        sent_bytes = 0
         try:
-            for chunk_index, i in enumerate(range(0, len(audio_data), chunk_size)):
+            for i in range(0, len(audio_data), chunk_size):
                 chunk = audio_data[i : i + chunk_size]
                 b64 = base64.b64encode(chunk).decode("utf-8")
                 await ws.send(
                     json.dumps({"message_type": "input_audio_chunk", "audio_base_64": b64})
                 )
-                if i + chunk_size < len(audio_data):
-                    delay = start + (chunk_index + 1) * realtime_resolution - time.monotonic()
-                    if delay > 0:
-                        await asyncio.sleep(delay)
+                sent_bytes += len(chunk)
+                delay = start + sent_bytes / bytes_per_second - time.monotonic()
+                if delay > 0:
+                    await asyncio.sleep(delay)
 
             # Commit / end-of-input signal
             await ws.send(

--- a/runner/src/coval_bench/providers/stt/elevenlabs.py
+++ b/runner/src/coval_bench/providers/stt/elevenlabs.py
@@ -162,15 +162,19 @@ class ElevenLabsSTTProvider(STTProvider):
         # ElevenLabs expects base64-encoded PCM chunks in JSON
         bytes_per_second = sample_rate * 2  # 16-bit mono
         chunk_size = int(bytes_per_second * realtime_resolution)
-        result.audio_start_time = time.monotonic()
+        start = time.monotonic()
+        result.audio_start_time = start
         try:
-            for i in range(0, len(audio_data), chunk_size):
+            for chunk_index, i in enumerate(range(0, len(audio_data), chunk_size)):
                 chunk = audio_data[i : i + chunk_size]
                 b64 = base64.b64encode(chunk).decode("utf-8")
                 await ws.send(
                     json.dumps({"message_type": "input_audio_chunk", "audio_base_64": b64})
                 )
-                await asyncio.sleep(realtime_resolution)
+                if i + chunk_size < len(audio_data):
+                    delay = start + (chunk_index + 1) * realtime_resolution - time.monotonic()
+                    if delay > 0:
+                        await asyncio.sleep(delay)
 
             # Commit / end-of-input signal
             await ws.send(

--- a/runner/src/coval_bench/providers/stt/gladia.py
+++ b/runner/src/coval_bench/providers/stt/gladia.py
@@ -21,6 +21,7 @@ import websockets.asyncio.client as ws_client
 from pydantic import SecretStr
 
 from coval_bench.providers.base import STTProvider, TranscriptionResult
+from coval_bench.providers.stt._pacing import paced_chunks
 from coval_bench.providers.stt._transcript_utils import (
     add_partial_transcript,
     finalize_transcript,
@@ -136,17 +137,10 @@ class GladiaSTTProvider(STTProvider):
     ) -> None:
         byte_rate = sample_width * sample_rate * channels
         chunk_size = int(byte_rate * realtime_resolution)
-        start = time.monotonic()
-        result.audio_start_time = start
-        sent_bytes = 0
         try:
-            for i in range(0, len(audio_data), chunk_size):
-                chunk = audio_data[i : i + chunk_size]
+            async for chunk, start in paced_chunks(audio_data, chunk_size, byte_rate):
+                result.audio_start_time = start
                 await ws.send(chunk)
-                sent_bytes += len(chunk)
-                delay = start + sent_bytes / byte_rate - time.monotonic()
-                if delay > 0:
-                    await asyncio.sleep(delay)
             # Stop streaming; the server flushes pending finals and closes (1000).
             await ws.send(json.dumps({"type": "stop_recording"}))
         except Exception as exc:

--- a/runner/src/coval_bench/providers/stt/gladia.py
+++ b/runner/src/coval_bench/providers/stt/gladia.py
@@ -138,13 +138,15 @@ class GladiaSTTProvider(STTProvider):
         chunk_size = int(byte_rate * realtime_resolution)
         start = time.monotonic()
         result.audio_start_time = start
+        sent_bytes = 0
         try:
-            for chunk_index, i in enumerate(range(0, len(audio_data), chunk_size)):
-                await ws.send(audio_data[i : i + chunk_size])
-                if i + chunk_size < len(audio_data):
-                    delay = start + (chunk_index + 1) * realtime_resolution - time.monotonic()
-                    if delay > 0:
-                        await asyncio.sleep(delay)
+            for i in range(0, len(audio_data), chunk_size):
+                chunk = audio_data[i : i + chunk_size]
+                await ws.send(chunk)
+                sent_bytes += len(chunk)
+                delay = start + sent_bytes / byte_rate - time.monotonic()
+                if delay > 0:
+                    await asyncio.sleep(delay)
             # Stop streaming; the server flushes pending finals and closes (1000).
             await ws.send(json.dumps({"type": "stop_recording"}))
         except Exception as exc:

--- a/runner/src/coval_bench/providers/stt/gladia.py
+++ b/runner/src/coval_bench/providers/stt/gladia.py
@@ -136,11 +136,15 @@ class GladiaSTTProvider(STTProvider):
     ) -> None:
         byte_rate = sample_width * sample_rate * channels
         chunk_size = int(byte_rate * realtime_resolution)
-        result.audio_start_time = time.monotonic()
+        start = time.monotonic()
+        result.audio_start_time = start
         try:
-            for i in range(0, len(audio_data), chunk_size):
+            for chunk_index, i in enumerate(range(0, len(audio_data), chunk_size)):
                 await ws.send(audio_data[i : i + chunk_size])
-                await asyncio.sleep(realtime_resolution)
+                if i + chunk_size < len(audio_data):
+                    delay = start + (chunk_index + 1) * realtime_resolution - time.monotonic()
+                    if delay > 0:
+                        await asyncio.sleep(delay)
             # Stop streaming; the server flushes pending finals and closes (1000).
             await ws.send(json.dumps({"type": "stop_recording"}))
         except Exception as exc:

--- a/runner/src/coval_bench/providers/stt/google.py
+++ b/runner/src/coval_bench/providers/stt/google.py
@@ -136,16 +136,20 @@ class GoogleSTTProvider(STTProvider):
                 )
                 data = audio_data
                 byte_rate = sample_width * sample_rate * channels
-                first_chunk = True
+                chunk_size = int(byte_rate * realtime_resolution)
+                start: float | None = None
+                chunk_index = 0
                 while data:
-                    chunk_size = int(byte_rate * realtime_resolution)
                     chunk, data = data[:chunk_size], data[chunk_size:]
-                    if first_chunk and chunk:
-                        result.audio_start_time = time.monotonic()
-                        first_chunk = False
+                    if start is None and chunk:
+                        start = time.monotonic()
+                        result.audio_start_time = start
                     yield cloud_speech.StreamingRecognizeRequest(audio=chunk)
-                    if chunk:
-                        time.sleep(realtime_resolution)
+                    if start is not None and data:
+                        delay = start + (chunk_index + 1) * realtime_resolution - time.monotonic()
+                        if delay > 0:
+                            time.sleep(delay)
+                    chunk_index += 1
 
             try:
                 responses = self._client.streaming_recognize(requests=_request_iterator())

--- a/runner/src/coval_bench/providers/stt/google.py
+++ b/runner/src/coval_bench/providers/stt/google.py
@@ -138,18 +138,18 @@ class GoogleSTTProvider(STTProvider):
                 byte_rate = sample_width * sample_rate * channels
                 chunk_size = int(byte_rate * realtime_resolution)
                 start: float | None = None
-                chunk_index = 0
+                sent_bytes = 0
                 while data:
                     chunk, data = data[:chunk_size], data[chunk_size:]
                     if start is None and chunk:
                         start = time.monotonic()
                         result.audio_start_time = start
                     yield cloud_speech.StreamingRecognizeRequest(audio=chunk)
-                    if start is not None and data:
-                        delay = start + (chunk_index + 1) * realtime_resolution - time.monotonic()
+                    sent_bytes += len(chunk)
+                    if start is not None:
+                        delay = start + sent_bytes / byte_rate - time.monotonic()
                         if delay > 0:
                             time.sleep(delay)
-                    chunk_index += 1
 
             try:
                 responses = self._client.streaming_recognize(requests=_request_iterator())

--- a/runner/src/coval_bench/providers/stt/google.py
+++ b/runner/src/coval_bench/providers/stt/google.py
@@ -24,6 +24,7 @@ import structlog
 from pydantic import SecretStr
 
 from coval_bench.providers.base import STTProvider, TranscriptionResult
+from coval_bench.providers.stt._pacing import paced_chunks_sync
 
 logger = structlog.get_logger(__name__)
 
@@ -134,22 +135,12 @@ class GoogleSTTProvider(STTProvider):
                     recognizer=self._get_recognizer_name(),
                     streaming_config=streaming_config,
                 )
-                data = audio_data
                 byte_rate = sample_width * sample_rate * channels
                 chunk_size = int(byte_rate * realtime_resolution)
-                start: float | None = None
-                sent_bytes = 0
-                while data:
-                    chunk, data = data[:chunk_size], data[chunk_size:]
-                    if start is None and chunk:
-                        start = time.monotonic()
+                for chunk, start in paced_chunks_sync(audio_data, chunk_size, byte_rate):
+                    if result.audio_start_time is None:
                         result.audio_start_time = start
                     yield cloud_speech.StreamingRecognizeRequest(audio=chunk)
-                    sent_bytes += len(chunk)
-                    if start is not None:
-                        delay = start + sent_bytes / byte_rate - time.monotonic()
-                        if delay > 0:
-                            time.sleep(delay)
 
             try:
                 responses = self._client.streaming_recognize(requests=_request_iterator())

--- a/runner/src/coval_bench/providers/stt/gradium.py
+++ b/runner/src/coval_bench/providers/stt/gradium.py
@@ -132,13 +132,17 @@ class GradiumSTTProvider(STTProvider):
     ) -> None:
         bytes_per_second = sample_rate * 2  # 16-bit mono
         chunk_size = int(bytes_per_second * realtime_resolution)
-        result.audio_start_time = time.monotonic()
+        start = time.monotonic()
+        result.audio_start_time = start
         try:
-            for i in range(0, len(audio_data), chunk_size):
+            for chunk_index, i in enumerate(range(0, len(audio_data), chunk_size)):
                 chunk = audio_data[i : i + chunk_size]
                 b64 = base64.b64encode(chunk).decode("utf-8")
                 await ws.send(json.dumps({"type": "audio", "audio": b64}))
-                await asyncio.sleep(realtime_resolution)
+                if i + chunk_size < len(audio_data):
+                    delay = start + (chunk_index + 1) * realtime_resolution - time.monotonic()
+                    if delay > 0:
+                        await asyncio.sleep(delay)
             # Flush drains the lookahead buffer; wait for the "flushed" ack so
             # end_of_stream can't cut off pending results.
             await ws.send(json.dumps({"type": "flush", "flush_id": 1}))

--- a/runner/src/coval_bench/providers/stt/gradium.py
+++ b/runner/src/coval_bench/providers/stt/gradium.py
@@ -134,15 +134,16 @@ class GradiumSTTProvider(STTProvider):
         chunk_size = int(bytes_per_second * realtime_resolution)
         start = time.monotonic()
         result.audio_start_time = start
+        sent_bytes = 0
         try:
-            for chunk_index, i in enumerate(range(0, len(audio_data), chunk_size)):
+            for i in range(0, len(audio_data), chunk_size):
                 chunk = audio_data[i : i + chunk_size]
                 b64 = base64.b64encode(chunk).decode("utf-8")
                 await ws.send(json.dumps({"type": "audio", "audio": b64}))
-                if i + chunk_size < len(audio_data):
-                    delay = start + (chunk_index + 1) * realtime_resolution - time.monotonic()
-                    if delay > 0:
-                        await asyncio.sleep(delay)
+                sent_bytes += len(chunk)
+                delay = start + sent_bytes / bytes_per_second - time.monotonic()
+                if delay > 0:
+                    await asyncio.sleep(delay)
             # Flush drains the lookahead buffer; wait for the "flushed" ack so
             # end_of_stream can't cut off pending results.
             await ws.send(json.dumps({"type": "flush", "flush_id": 1}))

--- a/runner/src/coval_bench/providers/stt/gradium.py
+++ b/runner/src/coval_bench/providers/stt/gradium.py
@@ -34,6 +34,7 @@ import websockets.asyncio.client as ws_client
 from pydantic import SecretStr
 
 from coval_bench.providers.base import STTProvider, TranscriptionResult
+from coval_bench.providers.stt._pacing import paced_chunks
 
 logger = structlog.get_logger(__name__)
 
@@ -132,18 +133,11 @@ class GradiumSTTProvider(STTProvider):
     ) -> None:
         bytes_per_second = sample_rate * 2  # 16-bit mono
         chunk_size = int(bytes_per_second * realtime_resolution)
-        start = time.monotonic()
-        result.audio_start_time = start
-        sent_bytes = 0
         try:
-            for i in range(0, len(audio_data), chunk_size):
-                chunk = audio_data[i : i + chunk_size]
+            async for chunk, start in paced_chunks(audio_data, chunk_size, bytes_per_second):
+                result.audio_start_time = start
                 b64 = base64.b64encode(chunk).decode("utf-8")
                 await ws.send(json.dumps({"type": "audio", "audio": b64}))
-                sent_bytes += len(chunk)
-                delay = start + sent_bytes / bytes_per_second - time.monotonic()
-                if delay > 0:
-                    await asyncio.sleep(delay)
             # Flush drains the lookahead buffer; wait for the "flushed" ack so
             # end_of_stream can't cut off pending results.
             await ws.send(json.dumps({"type": "flush", "flush_id": 1}))

--- a/runner/src/coval_bench/providers/stt/inworld.py
+++ b/runner/src/coval_bench/providers/stt/inworld.py
@@ -129,8 +129,9 @@ class InworldSTTProvider(STTProvider):
         chunk_size = int(bytes_per_second * realtime_resolution)
         start = time.monotonic()
         result.audio_start_time = start
+        sent_bytes = 0
         try:
-            for chunk_index, i in enumerate(range(0, len(audio_data), chunk_size)):
+            for i in range(0, len(audio_data), chunk_size):
                 # Stop early if _receive already recorded a protocol/auth error.
                 if result.error is not None:
                     break
@@ -138,10 +139,10 @@ class InworldSTTProvider(STTProvider):
                 await ws.send(
                     json.dumps({"audioChunk": {"content": base64.b64encode(chunk).decode()}})
                 )
-                if i + chunk_size < len(audio_data):
-                    delay = start + (chunk_index + 1) * realtime_resolution - time.monotonic()
-                    if delay > 0:
-                        await asyncio.sleep(delay)
+                sent_bytes += len(chunk)
+                delay = start + sent_bytes / bytes_per_second - time.monotonic()
+                if delay > 0:
+                    await asyncio.sleep(delay)
             # endTurn forces finalization; closeStream then flushes the final
             # transcripts and closes the socket, ending the receive loop.
             await ws.send(json.dumps({"endTurn": {}}))

--- a/runner/src/coval_bench/providers/stt/inworld.py
+++ b/runner/src/coval_bench/providers/stt/inworld.py
@@ -20,6 +20,7 @@ import websockets.asyncio.client as ws_client
 from pydantic import SecretStr
 
 from coval_bench.providers.base import STTProvider, TranscriptionResult
+from coval_bench.providers.stt._pacing import paced_chunks
 
 logger = structlog.get_logger(__name__)
 
@@ -127,22 +128,15 @@ class InworldSTTProvider(STTProvider):
     ) -> None:
         bytes_per_second = sample_rate * 2  # 16-bit mono
         chunk_size = int(bytes_per_second * realtime_resolution)
-        start = time.monotonic()
-        result.audio_start_time = start
-        sent_bytes = 0
         try:
-            for i in range(0, len(audio_data), chunk_size):
+            async for chunk, start in paced_chunks(audio_data, chunk_size, bytes_per_second):
                 # Stop early if _receive already recorded a protocol/auth error.
                 if result.error is not None:
                     break
-                chunk = audio_data[i : i + chunk_size]
+                result.audio_start_time = start
                 await ws.send(
                     json.dumps({"audioChunk": {"content": base64.b64encode(chunk).decode()}})
                 )
-                sent_bytes += len(chunk)
-                delay = start + sent_bytes / bytes_per_second - time.monotonic()
-                if delay > 0:
-                    await asyncio.sleep(delay)
             # endTurn forces finalization; closeStream then flushes the final
             # transcripts and closes the socket, ending the receive loop.
             await ws.send(json.dumps({"endTurn": {}}))

--- a/runner/src/coval_bench/providers/stt/inworld.py
+++ b/runner/src/coval_bench/providers/stt/inworld.py
@@ -127,9 +127,10 @@ class InworldSTTProvider(STTProvider):
     ) -> None:
         bytes_per_second = sample_rate * 2  # 16-bit mono
         chunk_size = int(bytes_per_second * realtime_resolution)
-        result.audio_start_time = time.monotonic()
+        start = time.monotonic()
+        result.audio_start_time = start
         try:
-            for i in range(0, len(audio_data), chunk_size):
+            for chunk_index, i in enumerate(range(0, len(audio_data), chunk_size)):
                 # Stop early if _receive already recorded a protocol/auth error.
                 if result.error is not None:
                     break
@@ -137,10 +138,10 @@ class InworldSTTProvider(STTProvider):
                 await ws.send(
                     json.dumps({"audioChunk": {"content": base64.b64encode(chunk).decode()}})
                 )
-                # Pace to real time between chunks only — sleeping after the last
-                # one would delay finalization and inflate the latency clocks.
                 if i + chunk_size < len(audio_data):
-                    await asyncio.sleep(realtime_resolution)
+                    delay = start + (chunk_index + 1) * realtime_resolution - time.monotonic()
+                    if delay > 0:
+                        await asyncio.sleep(delay)
             # endTurn forces finalization; closeStream then flushes the final
             # transcripts and closes the socket, ending the receive loop.
             await ws.send(json.dumps({"endTurn": {}}))

--- a/runner/src/coval_bench/providers/stt/openai.py
+++ b/runner/src/coval_bench/providers/stt/openai.py
@@ -36,6 +36,7 @@ from pydantic import SecretStr
 from scipy import signal
 
 from coval_bench.providers.base import STTProvider, TranscriptionResult
+from coval_bench.providers.stt._pacing import paced_chunks
 from coval_bench.providers.stt._transcript_utils import (
     add_partial_transcript,
     finalize_transcript,
@@ -199,14 +200,9 @@ class OpenAISTTProvider(STTProvider):
     ) -> None:
         bytes_per_second = _INPUT_SAMPLE_RATE * 2
         chunk_size = max(int(bytes_per_second * realtime_resolution), 2)
-        start: float | None = None
-        sent_bytes = 0
         try:
-            for offset in range(0, len(audio_data), chunk_size):
-                chunk = audio_data[offset : offset + chunk_size]
-                if start is None and chunk:
-                    start = time.monotonic()
-                    result.audio_start_time = start
+            async for chunk, start in paced_chunks(audio_data, chunk_size, bytes_per_second):
+                result.audio_start_time = start
                 await ws.send(
                     json.dumps(
                         {
@@ -215,11 +211,6 @@ class OpenAISTTProvider(STTProvider):
                         }
                     )
                 )
-                sent_bytes += len(chunk)
-                if start is not None:
-                    delay = start + sent_bytes / bytes_per_second - time.monotonic()
-                    if delay > 0:
-                        await asyncio.sleep(delay)
             await ws.send(json.dumps({"type": "input_audio_buffer.commit"}))
         except Exception as exc:
             logger.warning("openai_send_error", provider="openai", model=self._model, exc_info=exc)

--- a/runner/src/coval_bench/providers/stt/openai.py
+++ b/runner/src/coval_bench/providers/stt/openai.py
@@ -200,8 +200,9 @@ class OpenAISTTProvider(STTProvider):
         bytes_per_second = _INPUT_SAMPLE_RATE * 2
         chunk_size = max(int(bytes_per_second * realtime_resolution), 2)
         start: float | None = None
+        sent_bytes = 0
         try:
-            for chunk_index, offset in enumerate(range(0, len(audio_data), chunk_size)):
+            for offset in range(0, len(audio_data), chunk_size):
                 chunk = audio_data[offset : offset + chunk_size]
                 if start is None and chunk:
                     start = time.monotonic()
@@ -214,8 +215,9 @@ class OpenAISTTProvider(STTProvider):
                         }
                     )
                 )
-                if start is not None and offset + chunk_size < len(audio_data):
-                    delay = start + (chunk_index + 1) * realtime_resolution - time.monotonic()
+                sent_bytes += len(chunk)
+                if start is not None:
+                    delay = start + sent_bytes / bytes_per_second - time.monotonic()
                     if delay > 0:
                         await asyncio.sleep(delay)
             await ws.send(json.dumps({"type": "input_audio_buffer.commit"}))

--- a/runner/src/coval_bench/providers/stt/openai.py
+++ b/runner/src/coval_bench/providers/stt/openai.py
@@ -199,13 +199,13 @@ class OpenAISTTProvider(STTProvider):
     ) -> None:
         bytes_per_second = _INPUT_SAMPLE_RATE * 2
         chunk_size = max(int(bytes_per_second * realtime_resolution), 2)
-        first_chunk = True
+        start: float | None = None
         try:
-            for start in range(0, len(audio_data), chunk_size):
-                chunk = audio_data[start : start + chunk_size]
-                if first_chunk and chunk:
-                    result.audio_start_time = time.monotonic()
-                    first_chunk = False
+            for chunk_index, offset in enumerate(range(0, len(audio_data), chunk_size)):
+                chunk = audio_data[offset : offset + chunk_size]
+                if start is None and chunk:
+                    start = time.monotonic()
+                    result.audio_start_time = start
                 await ws.send(
                     json.dumps(
                         {
@@ -214,7 +214,10 @@ class OpenAISTTProvider(STTProvider):
                         }
                     )
                 )
-                await asyncio.sleep(realtime_resolution)
+                if start is not None and offset + chunk_size < len(audio_data):
+                    delay = start + (chunk_index + 1) * realtime_resolution - time.monotonic()
+                    if delay > 0:
+                        await asyncio.sleep(delay)
             await ws.send(json.dumps({"type": "input_audio_buffer.commit"}))
         except Exception as exc:
             logger.warning("openai_send_error", provider="openai", model=self._model, exc_info=exc)

--- a/runner/src/coval_bench/providers/stt/smallest.py
+++ b/runner/src/coval_bench/providers/stt/smallest.py
@@ -23,6 +23,7 @@ import websockets.asyncio.client as ws_client
 from pydantic import SecretStr
 
 from coval_bench.providers.base import STTProvider, TranscriptionResult
+from coval_bench.providers.stt._pacing import paced_chunks
 
 logger = structlog.get_logger(__name__)
 
@@ -106,20 +107,10 @@ class SmallestSTTProvider(STTProvider):
     ) -> None:
         byte_rate = sample_rate * 2  # 16-bit mono
         chunk_size = int(byte_rate * realtime_resolution)
-        data = audio_data
-        start: float | None = None
-        sent_bytes = 0
         try:
-            while data:
-                chunk, data = data[:chunk_size], data[chunk_size:]
-                if start is None:
-                    start = time.monotonic()
-                    result.audio_start_time = start
+            async for chunk, start in paced_chunks(audio_data, chunk_size, byte_rate):
+                result.audio_start_time = start
                 await ws.send(chunk)
-                sent_bytes += len(chunk)
-                delay = start + sent_bytes / byte_rate - time.monotonic()
-                if delay > 0:
-                    await asyncio.sleep(delay)
             await ws.send(json.dumps({"type": "close_stream"}))
         except Exception as exc:
             logger.warning(

--- a/runner/src/coval_bench/providers/stt/smallest.py
+++ b/runner/src/coval_bench/providers/stt/smallest.py
@@ -108,7 +108,7 @@ class SmallestSTTProvider(STTProvider):
         chunk_size = int(byte_rate * realtime_resolution)
         data = audio_data
         start: float | None = None
-        chunk_index = 0
+        sent_bytes = 0
         try:
             while data:
                 chunk, data = data[:chunk_size], data[chunk_size:]
@@ -116,11 +116,10 @@ class SmallestSTTProvider(STTProvider):
                     start = time.monotonic()
                     result.audio_start_time = start
                 await ws.send(chunk)
-                if data:
-                    delay = start + (chunk_index + 1) * realtime_resolution - time.monotonic()
-                    if delay > 0:
-                        await asyncio.sleep(delay)
-                chunk_index += 1
+                sent_bytes += len(chunk)
+                delay = start + sent_bytes / byte_rate - time.monotonic()
+                if delay > 0:
+                    await asyncio.sleep(delay)
             await ws.send(json.dumps({"type": "close_stream"}))
         except Exception as exc:
             logger.warning(

--- a/runner/src/coval_bench/providers/stt/smallest.py
+++ b/runner/src/coval_bench/providers/stt/smallest.py
@@ -107,15 +107,20 @@ class SmallestSTTProvider(STTProvider):
         byte_rate = sample_rate * 2  # 16-bit mono
         chunk_size = int(byte_rate * realtime_resolution)
         data = audio_data
-        first_chunk = True
+        start: float | None = None
+        chunk_index = 0
         try:
             while data:
                 chunk, data = data[:chunk_size], data[chunk_size:]
-                if first_chunk:
-                    result.audio_start_time = time.monotonic()
-                    first_chunk = False
+                if start is None:
+                    start = time.monotonic()
+                    result.audio_start_time = start
                 await ws.send(chunk)
-                await asyncio.sleep(realtime_resolution)
+                if data:
+                    delay = start + (chunk_index + 1) * realtime_resolution - time.monotonic()
+                    if delay > 0:
+                        await asyncio.sleep(delay)
+                chunk_index += 1
             await ws.send(json.dumps({"type": "close_stream"}))
         except Exception as exc:
             logger.warning(

--- a/runner/src/coval_bench/providers/stt/soniox.py
+++ b/runner/src/coval_bench/providers/stt/soniox.py
@@ -117,13 +117,15 @@ class SonioxSTTProvider(STTProvider):
         chunk_size = int(bytes_per_second * realtime_resolution)
         start = time.monotonic()
         result.audio_start_time = start
+        sent_bytes = 0
         try:
-            for chunk_index, i in enumerate(range(0, len(audio_data), chunk_size)):
-                await ws.send(audio_data[i : i + chunk_size])
-                if i + chunk_size < len(audio_data):
-                    delay = start + (chunk_index + 1) * realtime_resolution - time.monotonic()
-                    if delay > 0:
-                        await asyncio.sleep(delay)
+            for i in range(0, len(audio_data), chunk_size):
+                chunk = audio_data[i : i + chunk_size]
+                await ws.send(chunk)
+                sent_bytes += len(chunk)
+                delay = start + sent_bytes / bytes_per_second - time.monotonic()
+                if delay > 0:
+                    await asyncio.sleep(delay)
             # End-of-audio is an empty *text* frame; a zero-length binary frame is
             # ignored, so the server never finalizes (stalls to its idle timeout).
             await ws.send("")

--- a/runner/src/coval_bench/providers/stt/soniox.py
+++ b/runner/src/coval_bench/providers/stt/soniox.py
@@ -15,6 +15,7 @@ import websockets.asyncio.client as ws_client
 from pydantic import SecretStr
 
 from coval_bench.providers.base import STTProvider, TranscriptionResult
+from coval_bench.providers.stt._pacing import paced_chunks
 
 logger = structlog.get_logger(__name__)
 
@@ -115,17 +116,10 @@ class SonioxSTTProvider(STTProvider):
     ) -> None:
         bytes_per_second = sample_rate * 2  # 16-bit mono
         chunk_size = int(bytes_per_second * realtime_resolution)
-        start = time.monotonic()
-        result.audio_start_time = start
-        sent_bytes = 0
         try:
-            for i in range(0, len(audio_data), chunk_size):
-                chunk = audio_data[i : i + chunk_size]
+            async for chunk, start in paced_chunks(audio_data, chunk_size, bytes_per_second):
+                result.audio_start_time = start
                 await ws.send(chunk)
-                sent_bytes += len(chunk)
-                delay = start + sent_bytes / bytes_per_second - time.monotonic()
-                if delay > 0:
-                    await asyncio.sleep(delay)
             # End-of-audio is an empty *text* frame; a zero-length binary frame is
             # ignored, so the server never finalizes (stalls to its idle timeout).
             await ws.send("")

--- a/runner/src/coval_bench/providers/stt/soniox.py
+++ b/runner/src/coval_bench/providers/stt/soniox.py
@@ -115,11 +115,15 @@ class SonioxSTTProvider(STTProvider):
     ) -> None:
         bytes_per_second = sample_rate * 2  # 16-bit mono
         chunk_size = int(bytes_per_second * realtime_resolution)
-        result.audio_start_time = time.monotonic()
+        start = time.monotonic()
+        result.audio_start_time = start
         try:
-            for i in range(0, len(audio_data), chunk_size):
+            for chunk_index, i in enumerate(range(0, len(audio_data), chunk_size)):
                 await ws.send(audio_data[i : i + chunk_size])
-                await asyncio.sleep(realtime_resolution)
+                if i + chunk_size < len(audio_data):
+                    delay = start + (chunk_index + 1) * realtime_resolution - time.monotonic()
+                    if delay > 0:
+                        await asyncio.sleep(delay)
             # End-of-audio is an empty *text* frame; a zero-length binary frame is
             # ignored, so the server never finalizes (stalls to its idle timeout).
             await ws.send("")

--- a/runner/src/coval_bench/providers/stt/speechmatics.py
+++ b/runner/src/coval_bench/providers/stt/speechmatics.py
@@ -155,15 +155,16 @@ class SpeechmaticsProvider(STTProvider):
         start = result.audio_start_time or time.monotonic()
         data = audio_data
         seq_no = 0
+        sent_bytes = 0
         try:
             while data:
                 chunk, data = data[:chunk_size], data[chunk_size:]
                 await ws.send(chunk)
                 seq_no += 1
-                if data:
-                    delay = start + seq_no * realtime_resolution - time.monotonic()
-                    if delay > 0:
-                        await asyncio.sleep(delay)
+                sent_bytes += len(chunk)
+                delay = start + sent_bytes / byte_rate - time.monotonic()
+                if delay > 0:
+                    await asyncio.sleep(delay)
             await ws.send(json.dumps({"message": "EndOfStream", "last_seq_no": seq_no}))
         except Exception as exc:
             logger.warning(

--- a/runner/src/coval_bench/providers/stt/speechmatics.py
+++ b/runner/src/coval_bench/providers/stt/speechmatics.py
@@ -151,15 +151,19 @@ class SpeechmaticsProvider(STTProvider):
         realtime_resolution: float,
     ) -> None:
         byte_rate = sample_width * sample_rate * channels
+        chunk_size = int(byte_rate * realtime_resolution)
+        start = result.audio_start_time or time.monotonic()
         data = audio_data
         seq_no = 0
         try:
             while data:
-                chunk_size = int(byte_rate * realtime_resolution)
                 chunk, data = data[:chunk_size], data[chunk_size:]
                 await ws.send(chunk)
                 seq_no += 1
-                await asyncio.sleep(realtime_resolution)
+                if data:
+                    delay = start + seq_no * realtime_resolution - time.monotonic()
+                    if delay > 0:
+                        await asyncio.sleep(delay)
             await ws.send(json.dumps({"message": "EndOfStream", "last_seq_no": seq_no}))
         except Exception as exc:
             logger.warning(

--- a/runner/src/coval_bench/providers/stt/speechmatics.py
+++ b/runner/src/coval_bench/providers/stt/speechmatics.py
@@ -22,6 +22,7 @@ import websockets.asyncio.client as ws_client
 from pydantic import SecretStr
 
 from coval_bench.providers.base import STTProvider, TranscriptionResult
+from coval_bench.providers.stt._pacing import paced_chunks
 
 logger = structlog.get_logger(__name__)
 
@@ -152,19 +153,13 @@ class SpeechmaticsProvider(STTProvider):
     ) -> None:
         byte_rate = sample_width * sample_rate * channels
         chunk_size = int(byte_rate * realtime_resolution)
-        start = result.audio_start_time or time.monotonic()
-        data = audio_data
         seq_no = 0
-        sent_bytes = 0
         try:
-            while data:
-                chunk, data = data[:chunk_size], data[chunk_size:]
+            async for chunk, _ in paced_chunks(
+                audio_data, chunk_size, byte_rate, start=result.audio_start_time
+            ):
                 await ws.send(chunk)
                 seq_no += 1
-                sent_bytes += len(chunk)
-                delay = start + sent_bytes / byte_rate - time.monotonic()
-                if delay > 0:
-                    await asyncio.sleep(delay)
             await ws.send(json.dumps({"message": "EndOfStream", "last_seq_no": seq_no}))
         except Exception as exc:
             logger.warning(

--- a/runner/src/coval_bench/providers/stt/xai.py
+++ b/runner/src/coval_bench/providers/stt/xai.py
@@ -160,15 +160,18 @@ class XaiSTTProvider(STTProvider):
     ) -> None:
         frame_bytes = 2
         chunk_size = max(frame_bytes, int(sample_rate * frame_bytes * realtime_resolution))
-        first_chunk = True
+        start: float | None = None
 
-        for start in range(0, len(audio_data), chunk_size):
-            chunk = audio_data[start : start + chunk_size]
-            if first_chunk and chunk:
-                result.audio_start_time = time.monotonic()
-                first_chunk = False
+        for chunk_index, offset in enumerate(range(0, len(audio_data), chunk_size)):
+            chunk = audio_data[offset : offset + chunk_size]
+            if start is None and chunk:
+                start = time.monotonic()
+                result.audio_start_time = start
             await ws.send(chunk)
-            await asyncio.sleep(realtime_resolution)
+            if start is not None and offset + chunk_size < len(audio_data):
+                delay = start + (chunk_index + 1) * realtime_resolution - time.monotonic()
+                if delay > 0:
+                    await asyncio.sleep(delay)
 
         await ws.send(json.dumps({"type": "audio.done"}))
         with contextlib.suppress(TimeoutError):

--- a/runner/src/coval_bench/providers/stt/xai.py
+++ b/runner/src/coval_bench/providers/stt/xai.py
@@ -17,6 +17,7 @@ import websockets.asyncio.client as ws_client
 from pydantic import SecretStr
 
 from coval_bench.providers.base import STTProvider, TranscriptionResult
+from coval_bench.providers.stt._pacing import paced_chunks
 from coval_bench.providers.stt._transcript_utils import (
     add_partial_transcript,
     finalize_transcript,
@@ -161,20 +162,10 @@ class XaiSTTProvider(STTProvider):
         frame_bytes = 2
         byte_rate = sample_rate * frame_bytes
         chunk_size = max(frame_bytes, int(byte_rate * realtime_resolution))
-        start: float | None = None
-        sent_bytes = 0
 
-        for offset in range(0, len(audio_data), chunk_size):
-            chunk = audio_data[offset : offset + chunk_size]
-            if start is None and chunk:
-                start = time.monotonic()
-                result.audio_start_time = start
+        async for chunk, start in paced_chunks(audio_data, chunk_size, byte_rate):
+            result.audio_start_time = start
             await ws.send(chunk)
-            sent_bytes += len(chunk)
-            if start is not None:
-                delay = start + sent_bytes / byte_rate - time.monotonic()
-                if delay > 0:
-                    await asyncio.sleep(delay)
 
         await ws.send(json.dumps({"type": "audio.done"}))
         with contextlib.suppress(TimeoutError):

--- a/runner/src/coval_bench/providers/stt/xai.py
+++ b/runner/src/coval_bench/providers/stt/xai.py
@@ -159,17 +159,20 @@ class XaiSTTProvider(STTProvider):
         final_event: asyncio.Event,
     ) -> None:
         frame_bytes = 2
-        chunk_size = max(frame_bytes, int(sample_rate * frame_bytes * realtime_resolution))
+        byte_rate = sample_rate * frame_bytes
+        chunk_size = max(frame_bytes, int(byte_rate * realtime_resolution))
         start: float | None = None
+        sent_bytes = 0
 
-        for chunk_index, offset in enumerate(range(0, len(audio_data), chunk_size)):
+        for offset in range(0, len(audio_data), chunk_size):
             chunk = audio_data[offset : offset + chunk_size]
             if start is None and chunk:
                 start = time.monotonic()
                 result.audio_start_time = start
             await ws.send(chunk)
-            if start is not None and offset + chunk_size < len(audio_data):
-                delay = start + (chunk_index + 1) * realtime_resolution - time.monotonic()
+            sent_bytes += len(chunk)
+            if start is not None:
+                delay = start + sent_bytes / byte_rate - time.monotonic()
                 if delay > 0:
                     await asyncio.sleep(delay)
 

--- a/runner/tests/providers/stt/test_pacing.py
+++ b/runner/tests/providers/stt/test_pacing.py
@@ -1,0 +1,90 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for coval_bench.providers.stt._pacing.
+
+The clock and sleep are patched so the schedule is asserted deterministically
+without real waiting. The key invariant: every chunk is paced, including the
+last, so the end-of-stream signal lands at the true end of the audio.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+
+import pytest
+
+from coval_bench.providers.stt import _pacing
+
+_BYTE_RATE = 32000  # 16 kHz * 2 bytes, mono
+
+
+def test_pacing_delay_positive_when_ahead(monkeypatch: pytest.MonkeyPatch) -> None:
+    # 16000 bytes at 32000 B/s == 0.5 s of audio; deadline start+0.5, now == start.
+    monkeypatch.setattr(time, "monotonic", lambda: 10.0)
+    assert _pacing.pacing_delay(10.0, 16000, _BYTE_RATE) == pytest.approx(0.5)
+
+
+def test_pacing_delay_nonpositive_when_behind(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(time, "monotonic", lambda: 100.0)
+    assert _pacing.pacing_delay(10.0, 16000, _BYTE_RATE) < 0
+
+
+async def test_paces_every_chunk_including_last(monkeypatch: pytest.MonkeyPatch) -> None:
+    sleeps: list[float] = []
+
+    async def fake_sleep(delay: float) -> None:
+        sleeps.append(delay)
+
+    monkeypatch.setattr(time, "monotonic", lambda: 1000.0)
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+
+    audio = b"\x00" * 1000
+    yielded = [pair async for pair in _pacing.paced_chunks(audio, 300, _BYTE_RATE)]
+    chunks = [chunk for chunk, _ in yielded]
+
+    # Chunks tile the whole clip, last one short.
+    assert b"".join(chunks) == audio
+    assert [len(c) for c in chunks] == [300, 300, 300, 100]
+    # Every chunk is paced — the last included (skip-last would give 3).
+    assert len(sleeps) == len(chunks) == 4
+    # The final deadline targets the true audio duration (1000 bytes).
+    assert sleeps[-1] == pytest.approx(1000 / _BYTE_RATE)
+    assert yielded[-1][1] == 1000.0
+
+
+async def test_chunk_size_floored_to_one(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_sleep(delay: float) -> None:
+        pass
+
+    monkeypatch.setattr(time, "monotonic", lambda: 0.0)
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+
+    # chunk_size 0 would hang a naive loop; the helper floors it to 1.
+    chunks = [chunk async for chunk, _ in _pacing.paced_chunks(b"abc", 0, _BYTE_RATE)]
+    assert b"".join(chunks) == b"abc"
+    assert [len(c) for c in chunks] == [1, 1, 1]
+
+
+async def test_respects_start_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_sleep(delay: float) -> None:
+        pass
+
+    monkeypatch.setattr(time, "monotonic", lambda: 5.0)
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+
+    starts = [s async for _, s in _pacing.paced_chunks(b"abcd", 2, _BYTE_RATE, start=42.0)]
+    assert starts == [42.0, 42.0]
+
+
+def test_sync_paces_every_chunk_including_last(monkeypatch: pytest.MonkeyPatch) -> None:
+    sleeps: list[float] = []
+
+    monkeypatch.setattr(time, "monotonic", lambda: 0.0)
+    monkeypatch.setattr(time, "sleep", lambda delay: sleeps.append(delay))
+
+    chunks = [chunk for chunk, _ in _pacing.paced_chunks_sync(b"\x00" * 500, 200, _BYTE_RATE)]
+    assert [len(c) for c in chunks] == [200, 200, 100]
+    assert len(sleeps) == len(chunks) == 3
+    assert sleeps[-1] == pytest.approx(500 / _BYTE_RATE)


### PR DESCRIPTION
Pace streaming STT audio against an absolute deadline instead of a fixed per-chunk sleep, so accumulated drift no longer leaks into TTFS/TTFT/RTF.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved real-time audio streaming consistency across speech-to-text integrations by standardizing chunk pacing and timing.
  * Reduced timing drift and removed redundant per-chunk waits, helping transcriptions start and progress more smoothly.
  * Ensured audio start timestamps align per chunk for more accurate streaming behavior.
* **Tests**
  * Added coverage for the shared pacing logic (async and sync), including edge cases like minimal chunk sizes and correct sleep timing through the final chunk.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces per-chunk fixed `asyncio.sleep(realtime_resolution)` delays across all 13 STT providers with an absolute-deadline pacing helper (`_pacing.py`), so accumulated scheduling jitter no longer inflates TTFS/TTFT/RTF metrics.

- Introduces `paced_chunks` (async) and `paced_chunks_sync` (sync/gRPC) in `_pacing.py`, each computing the sleep target as `start + sent_bytes / byte_rate - now` — a monotonic-clock deadline that self-corrects for drift on every chunk, including the final one.
- All 13 provider send loops are migrated to the new helper, removing per-loop first-chunk bookkeeping and eliminating the `O(n_chunks * realtime_resolution)` over-delay that accumulated in the old pattern.
- Dedicated unit tests patch the clock and sleep primitives for deterministic verification that every chunk — including the last — is paced, and that the final deadline lands at exactly the true audio duration.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a well-contained algorithmic improvement to timing logic with no functional regressions.

All 13 provider send loops are migrated uniformly to a single, well-tested helper. The new absolute-deadline approach is strictly more correct than the old fixed-sleep pattern, edge cases (zero chunk_size, custom start anchor, empty audio) are covered by tests, and the synchronous gRPC path (Google) and pre-anchored path (Speechmatics) each handle their special requirements correctly. No data paths, error handling, or EOS signalling were broken in the migration.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| runner/src/coval_bench/providers/stt/_pacing.py | New pacing helper module; clean absolute-deadline logic with correct edge-case handling (chunk_size floored to 1, optional start anchor). |
| runner/tests/providers/stt/test_pacing.py | Thorough deterministic tests cover positive/negative delay, every-chunk pacing (async and sync), chunk_size floor, and start-override; asyncio_mode=auto in pytest.ini ensures async tests actually run. |
| runner/src/coval_bench/providers/stt/speechmatics.py | Correctly passes the pre-captured result.audio_start_time as the pacing anchor so the send task stays synchronised with the conceptual stream start set in measure_ttft. |
| runner/src/coval_bench/providers/stt/google.py | Uses paced_chunks_sync correctly inside the gRPC request iterator; guards audio_start_time with an is-None check to handle the zero-audio edge case. |
| runner/src/coval_bench/providers/stt/xai.py | Migrated correctly; the send loop had no try/except in the original either, consistent with the updated version. |
| runner/src/coval_bench/providers/stt/assemblyai.py | Clean migration; result.audio_start_time is set to the constant pacing start on each chunk (harmless redundancy since start never changes within a call). |
| runner/src/coval_bench/providers/stt/deepgram.py | Straightforward migration matching the assemblyai pattern; no issues. |
| runner/src/coval_bench/providers/stt/inworld.py | Old code deliberately skipped sleep after the last chunk; new code paces the last chunk to the true audio-end deadline — intentional design change consistent with the PR goal. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant P as Provider (_send_audio)
    participant PC as paced_chunks
    participant C as Clock (monotonic)
    participant WS as WebSocket / gRPC

    P->>PC: paced_chunks(audio, chunk_size, byte_rate)
    PC->>C: "start = time.monotonic()"
    loop for each chunk i
        PC-->>P: yield (chunk, start)
        P->>WS: ws.send(chunk)
        PC->>C: "now = time.monotonic()"
        PC->>PC: "delay = start + sent_bytes/byte_rate - now"
        alt "delay > 0"
            PC->>PC: asyncio.sleep(delay)
        end
    end
    Note over PC: Last chunk paced to true audio end
    P->>WS: send EOS / EndOfStream / audio.done
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant P as Provider (_send_audio)
    participant PC as paced_chunks
    participant C as Clock (monotonic)
    participant WS as WebSocket / gRPC

    P->>PC: paced_chunks(audio, chunk_size, byte_rate)
    PC->>C: "start = time.monotonic()"
    loop for each chunk i
        PC-->>P: yield (chunk, start)
        P->>WS: ws.send(chunk)
        PC->>C: "now = time.monotonic()"
        PC->>PC: "delay = start + sent_bytes/byte_rate - now"
        alt "delay > 0"
            PC->>PC: asyncio.sleep(delay)
        end
    end
    Note over PC: Last chunk paced to true audio end
    P->>WS: send EOS / EndOfStream / audio.done
```

</a>

<sub>Reviews (3): Last reviewed commit: ["Extract STT real-time pacing into a shar..."](https://github.com/coval-ai/benchmarks/commit/0c4999fb66048ba6551ab37d494426b8c2c726f5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40939352)</sub>

<!-- /greptile_comment -->