### PR TITLE
Cale/add baseten models

### DIFF
--- a/runner/src/coval_bench/__main__.py
+++ b/runner/src/coval_bench/__main__.py
@@ -143,6 +143,118 @@ def tts_smoke(provider: str, model: str, voice: str, text: str) -> None:
     sys.exit(0 if ok else 1)
 
 
+@cli.command(name="probe")
+@click.option(
+    "--only",
+    "selectors",
+    multiple=True,
+    required=True,
+    help="provider/model to probe (repeatable), e.g. baseten/whisper-large-v3. "
+    "Runs regardless of registry status.",
+)
+@click.option("--samples", default=20, show_default=True, type=int, help="Dataset items per model.")
+@click.option(
+    "--concurrency",
+    default=1,
+    show_default=True,
+    type=int,
+    help="Concurrent items; keep at 1 for a single pinned replica.",
+)
+def probe(selectors: tuple[str, ...], samples: int, concurrency: int) -> None:
+    """Run dataset samples through selected models WITHOUT persisting (logs only).
+
+    For private latency checks of PENDING models from the production (in-region)
+    environment: writes nothing to the DB or public API, emits per-metric
+    aggregates as a single JSON line to stdout. Exits 2 if a selector matches no
+    registered model.
+    """
+    from coval_bench.config import get_settings
+    from coval_bench.registries import MODEL_REGISTRY
+    from coval_bench.runner.probe import run_probe
+
+    models = [m for m in MODEL_REGISTRY if f"{m.provider}/{m.model}" in set(selectors)]
+    matched = {f"{m.provider}/{m.model}" for m in models}
+    missing = sorted(set(selectors) - matched)
+    if missing:
+        known = sorted({f"{m.provider}/{m.model}" for m in MODEL_REGISTRY})
+        click.echo(f"Unknown model(s): {missing}. Known: {known}", err=True)
+        sys.exit(2)
+
+    settings = get_settings()
+    results = asyncio.run(
+        run_probe(settings=settings, models=models, sample_size=samples, concurrency=concurrency)
+    )
+    click.echo(json.dumps({"event": "probe_results", "samples": samples, "results": results}))
+
+
+@cli.command(name="stt-smoke")
+@click.option("--provider", required=True, help="STT provider name (e.g. deepgram, baseten).")
+@click.option("--model", required=True, help="Model ID for the provider (e.g. nova-3).")
+@click.option(
+    "--wav",
+    required=True,
+    type=click.Path(exists=True, dir_okay=False),
+    help="16 kHz mono PCM16 WAV to transcribe.",
+)
+def stt_smoke(provider: str, model: str, wav: str) -> None:
+    """Probe a single (provider, model) against the real STT upstream.
+
+    Streams *wav* in real time and emits a single-line JSON to stdout with the
+    timing measurements. Exits 0 on success, 1 on provider error, 2 if
+    *provider* is not registered. Does NOT write to the database.
+    """
+    import wave
+    from typing import Any
+
+    from coval_bench.config import get_settings
+    from coval_bench.providers.stt import STT_PROVIDERS
+
+    registry: dict[str, Any] = dict(STT_PROVIDERS)
+    provider_cls = registry.get(provider)
+    if provider_cls is None:
+        click.echo(
+            f"Unknown STT provider: {provider!r}. Known: {sorted(registry.keys())}",
+            err=True,
+        )
+        sys.exit(2)
+
+    settings = get_settings()
+    kwargs: dict[str, Any] = {
+        "api_key": getattr(settings, f"{provider}_api_key", None),
+        "model": model,
+    }
+    if provider == "google":
+        kwargs["project_id"] = settings.google_project_id
+    elif provider == "baseten":
+        kwargs["ws_url"] = settings.baseten_whisper_url
+    instance = provider_cls(**kwargs)
+
+    with wave.open(wav, "rb") as w:
+        if w.getframerate() != 16000 or w.getnchannels() != 1 or w.getsampwidth() != 2:
+            click.echo("WAV must be 16 kHz, mono, 16-bit PCM", err=True)
+            sys.exit(1)
+        pcm = w.readframes(w.getnframes())
+
+    result = asyncio.run(instance.measure_ttft(pcm, 1, 2, 16000, 0.1))
+    ok = result.error is None and result.complete_transcript is not None
+
+    click.echo(
+        json.dumps(
+            {
+                "event": "stt_smoke",
+                "provider": provider,
+                "model": model,
+                "ttft_seconds": result.ttft_seconds,
+                "audio_to_final_seconds": result.audio_to_final_seconds,
+                "transcript": result.complete_transcript,
+                "error": result.error,
+                "ok": ok,
+            }
+        )
+    )
+    sys.exit(0 if ok else 1)
+
+
 @cli.group()
 def arena() -> None:
     """Voice Arena maintenance commands."""

--- a/runner/src/coval_bench/__main__.py
+++ b/runner/src/coval_bench/__main__.py
@@ -21,6 +21,11 @@ from coval_bench import __version__
 from coval_bench.db.cli import db_check, db_migrate
 from coval_bench.migrations.import_legacy import import_legacy_cli
 
+# Backstop so a stalled connection can't hang a smoke probe forever. Loose enough
+# for a cold dedicated endpoint (handshake + cold inference); the production paths
+# use the orchestrator's tighter per-call timeouts instead.
+_SMOKE_TIMEOUT_S = 120
+
 
 @click.group()
 @click.version_option(version=__version__, prog_name="coval-bench")
@@ -111,7 +116,25 @@ def tts_smoke(provider: str, model: str, voice: str, text: str) -> None:
 
     settings = get_settings()
     instance = provider_cls(settings=settings, model=model, voice=voice)
-    result = asyncio.run(instance.synthesize(text))
+    try:
+        result = asyncio.run(asyncio.wait_for(instance.synthesize(text), timeout=_SMOKE_TIMEOUT_S))
+    except TimeoutError:
+        click.echo(
+            json.dumps(
+                {
+                    "event": "tts_smoke",
+                    "provider": provider,
+                    "model": model,
+                    "voice": voice,
+                    "ttfa_ms": None,
+                    "audio_path": None,
+                    "audio_bytes": None,
+                    "error": f"timed out after {_SMOKE_TIMEOUT_S}s",
+                    "ok": False,
+                }
+            )
+        )
+        sys.exit(1)
 
     audio_path_str: str | None = str(result.audio_path) if result.audio_path else None
     audio_bytes: int | None = None
@@ -235,7 +258,26 @@ def stt_smoke(provider: str, model: str, wav: str) -> None:
             sys.exit(1)
         pcm = w.readframes(w.getnframes())
 
-    result = asyncio.run(instance.measure_ttft(pcm, 1, 2, 16000, 0.1))
+    try:
+        result = asyncio.run(
+            asyncio.wait_for(instance.measure_ttft(pcm, 1, 2, 16000, 0.1), timeout=_SMOKE_TIMEOUT_S)
+        )
+    except TimeoutError:
+        click.echo(
+            json.dumps(
+                {
+                    "event": "stt_smoke",
+                    "provider": provider,
+                    "model": model,
+                    "ttft_seconds": None,
+                    "audio_to_final_seconds": None,
+                    "transcript": None,
+                    "error": f"timed out after {_SMOKE_TIMEOUT_S}s",
+                    "ok": False,
+                }
+            )
+        )
+        sys.exit(1)
     ok = result.error is None and result.complete_transcript is not None
 
     click.echo(

--- a/runner/src/coval_bench/__main__.py
+++ b/runner/src/coval_bench/__main__.py
@@ -278,7 +278,7 @@ def stt_smoke(provider: str, model: str, wav: str) -> None:
             )
         )
         sys.exit(1)
-    ok = result.error is None and result.complete_transcript is not None
+    ok = result.error is None and bool(result.complete_transcript)
 
     click.echo(
         json.dumps(

--- a/runner/src/coval_bench/config.py
+++ b/runner/src/coval_bench/config.py
@@ -76,6 +76,13 @@ class Settings(BaseSettings):
     smallest_api_key: SecretStr | None = None
     inworld_api_key: SecretStr | None = None
     soniox_api_key: SecretStr | None = None
+    baseten_api_key: SecretStr | None = None
+
+    # Baseten dedicated-endpoint WebSocket URLs. The hostnames embed private,
+    # pre-launch model ids, so they live in config (``.env`` locally, Secret
+    # Manager in prod) rather than hardcoded in the provider modules.
+    baseten_whisper_url: str | None = None  # STT (Whisper Large V3)
+    baseten_qwen_url: str | None = None  # TTS (Qwen3-TTS)
 
     # Path to a Google service-account JSON file mounted as a Secret-as-volume.
     google_application_credentials: Path | None = None

--- a/runner/src/coval_bench/providers/stt/__init__.py
+++ b/runner/src/coval_bench/providers/stt/__init__.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 from coval_bench.providers.base import STTProvider
 from coval_bench.providers.stt.assemblyai import AssemblyAIProvider
+from coval_bench.providers.stt.baseten import BasetenSTTProvider
 from coval_bench.providers.stt.cartesia import CartesiaSTTProvider
 from coval_bench.providers.stt.deepgram import DeepgramProvider
 from coval_bench.providers.stt.elevenlabs import ElevenLabsSTTProvider
@@ -41,6 +42,7 @@ STT_PROVIDERS: dict[str, type[STTProvider]] = {
     "deepgram": DeepgramProvider,
     "cartesia": CartesiaSTTProvider,
     "assemblyai": AssemblyAIProvider,
+    "baseten": BasetenSTTProvider,
     "elevenlabs": ElevenLabsSTTProvider,
     "gladia": GladiaSTTProvider,
     "gradium": GradiumSTTProvider,
@@ -61,6 +63,7 @@ __all__ = [
     "DeepgramProvider",
     "CartesiaSTTProvider",
     "AssemblyAIProvider",
+    "BasetenSTTProvider",
     "ElevenLabsSTTProvider",
     "GladiaSTTProvider",
     "GradiumSTTProvider",

--- a/runner/src/coval_bench/providers/stt/baseten.py
+++ b/runner/src/coval_bench/providers/stt/baseten.py
@@ -1,0 +1,215 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Baseten dedicated-endpoint STT provider (Whisper Large V3 over WebSocket).
+
+The server runs a Silero VAD that consumes audio in fixed 512-sample frames
+(32 ms @ 16 kHz). Raw PCM must be sent as binary frames of exactly 512 samples
+(1024 bytes); other frame sizes are not processed correctly. The endpoint URL
+embeds a private model id, so it is injected from settings rather than hardcoded.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from typing import Any
+
+import structlog
+import websockets.asyncio.client as ws_client
+from pydantic import SecretStr
+
+from coval_bench.providers.base import STTProvider, TranscriptionResult
+from coval_bench.providers.stt._pacing import paced_chunks
+
+logger = structlog.get_logger(__name__)
+
+# Silero VAD frame: 512 samples * 2 bytes = 1024 bytes; other sizes are rejected.
+_FRAME_SAMPLES = 512
+_FRAME_BYTES = _FRAME_SAMPLES * 2
+_BYTE_RATE = 16000 * 2  # 16 kHz mono 16-bit
+_MAX_WS_SIZE = 16 * 1024 * 1024
+# Cold replicas exceed the 10 s websockets default for the handshake.
+_OPEN_TIMEOUT_S = 45
+
+
+class BasetenSTTProvider(STTProvider):
+    """Baseten streaming STT provider (Whisper Large V3)."""
+
+    _VALID_MODELS = frozenset({"whisper-large-v3"})
+
+    def __init__(
+        self,
+        api_key: SecretStr | None,
+        model: str = "whisper-large-v3",
+        ws_url: str | None = None,
+    ) -> None:
+        if not self._model_supported(model):
+            raise ValueError(
+                f"Invalid Baseten STT model {model!r}. Valid: {sorted(self._VALID_MODELS)}"
+            )
+        if api_key is None or not api_key.get_secret_value().strip():
+            raise ValueError("baseten_api_key is required for the Baseten STT provider")
+        if not ws_url:
+            raise ValueError("baseten_whisper_url is required for the Baseten STT provider")
+        self._api_key = api_key
+        self._model = model
+        self._ws_url = ws_url
+
+    @property
+    def name(self) -> str:
+        return "baseten"
+
+    @property
+    def model(self) -> str:
+        return self._model
+
+    async def measure_ttft(
+        self,
+        audio_data: bytes,
+        channels: int,
+        sample_width: int,
+        sample_rate: int,
+        realtime_resolution: float = 0.1,
+    ) -> TranscriptionResult:
+        result = TranscriptionResult(provider=self.name)
+        if sample_rate != 16000:
+            result.error = f"Baseten requires 16 kHz PCM input; got {sample_rate} Hz"
+            return result
+        if channels != 1 or sample_width != 2:
+            result.error = (
+                "Baseten requires mono 16-bit PCM input; "
+                f"got channels={channels}, sample_width={sample_width}"
+            )
+            return result
+
+        total_start = time.monotonic()
+        headers = {"Authorization": f"Api-Key {self._api_key.get_secret_value()}"}
+
+        try:
+            async with ws_client.connect(
+                self._ws_url,
+                additional_headers=headers,
+                max_size=_MAX_WS_SIZE,
+                open_timeout=_OPEN_TIMEOUT_S,
+            ) as ws:
+                # First message configures the stream: partials at a 300 ms cadence.
+                await ws.send(
+                    json.dumps(
+                        {
+                            "streaming_params": {
+                                "enable_partial_transcripts": True,
+                                "partial_transcript_interval_s": 0.3,
+                            }
+                        }
+                    )
+                )
+
+                send_task = asyncio.create_task(self._send_audio(ws, audio_data, result))
+                recv_task = asyncio.create_task(self._receive(ws, result))
+                tasks = (send_task, recv_task)
+                done, pending = await asyncio.wait(tasks, return_when=asyncio.FIRST_EXCEPTION)
+                if any(not task.cancelled() and task.exception() is not None for task in done):
+                    for task in pending:
+                        task.cancel()
+                outcomes = await asyncio.gather(*tasks, return_exceptions=True)
+                if result.error is None and result.audio_to_final_seconds is None:
+                    for outcome in outcomes:
+                        if isinstance(outcome, Exception):
+                            result.error = str(outcome)
+                            break
+                    else:
+                        result.error = (
+                            "Baseten stream ended before a final transcription was received"
+                        )
+
+        except Exception as exc:
+            logger.warning(
+                "baseten_measure_ttft_failed", provider="baseten", model=self._model, exc_info=exc
+            )
+            result.error = str(exc)
+
+        result.total_time = time.monotonic() - total_start
+        return result
+
+    async def _send_audio(
+        self,
+        ws: Any,
+        audio_data: bytes,
+        result: TranscriptionResult,
+    ) -> None:
+        try:
+            async for chunk, start in paced_chunks(audio_data, _FRAME_BYTES, _BYTE_RATE):
+                # Stop early if _receive already recorded a protocol/auth error.
+                if result.error is not None:
+                    break
+                result.audio_start_time = start
+                frame = chunk
+                if len(frame) < _FRAME_BYTES:  # pad the final short frame to 512 samples
+                    frame += b"\x00" * (_FRAME_BYTES - len(frame))
+                await ws.send(frame)
+            # Signal end of audio so the server flushes the final transcript.
+            await ws.send(json.dumps({"type": "end_audio"}))
+        except Exception as exc:
+            logger.warning(
+                "baseten_send_error", provider="baseten", model=self._model, exc_info=exc
+            )
+            raise
+
+    async def _receive(self, ws: Any, result: TranscriptionResult) -> None:
+        # Per-segment finals accumulate in arrival order (Whisper + Silero VAD).
+        final_parts: list[str] = []
+
+        try:
+            async for raw in ws:
+                if isinstance(raw, (bytes, bytearray)):
+                    continue  # STT replies are JSON; ignore any binary frames
+
+                msg: dict[str, Any] = json.loads(raw)
+                now = time.monotonic()
+
+                msg_type = msg.get("type")
+                if msg_type == "end_audio":
+                    # Sent twice: "acknowledged" (pre-transcripts) then "finished"
+                    # (true end). Stop only on "finished"; the session never closes.
+                    if msg.get("body", {}).get("status") == "finished":
+                        break
+                    continue
+                if msg_type == "error":
+                    result.error = str(msg.get("message") or msg)
+                    logger.warning(
+                        "baseten_stt_error", provider="baseten", model=self._model, msg=msg
+                    )
+                    break
+                if msg_type != "transcription":
+                    continue
+
+                text = " ".join(str(seg.get("text", "")) for seg in msg.get("segments", [])).strip()
+                if not text:
+                    continue
+
+                if result.ttft_seconds is None and result.audio_start_time is not None:
+                    result.ttft_seconds = now - result.audio_start_time
+                    result.first_token_content = text[:30] + "..." if len(text) > 30 else text
+
+                if msg.get("is_final"):
+                    final_parts.append(text)
+                    if result.audio_start_time is not None:
+                        result.audio_to_final_seconds = now - result.audio_start_time
+                else:
+                    result.partial_transcripts.append(text)
+
+        except Exception as exc:
+            logger.warning(
+                "baseten_receive_error", provider="baseten", model=self._model, exc_info=exc
+            )
+            if result.error is None and result.audio_to_final_seconds is None:
+                result.error = str(exc)
+
+        if final_parts:
+            result.complete_transcript = " ".join(final_parts).strip() or None
+
+        if result.complete_transcript:
+            result.transcript_length = len(result.complete_transcript)
+            result.word_count = len(result.complete_transcript.split())

--- a/runner/src/coval_bench/providers/tts/__init__.py
+++ b/runner/src/coval_bench/providers/tts/__init__.py
@@ -15,6 +15,7 @@ Usage::
 from __future__ import annotations
 
 from coval_bench.providers.base import TTSProvider
+from coval_bench.providers.tts.baseten import BasetenTTSProvider
 from coval_bench.providers.tts.cartesia import CartesiaTTSProvider
 from coval_bench.providers.tts.deepgram import DeepgramTTSProvider
 from coval_bench.providers.tts.elevenlabs import ElevenLabsTTSProvider
@@ -47,6 +48,7 @@ TTS_PROVIDERS: dict[str, type[TTSProvider]] = {
     "xai": XaiTTSProvider,
     "groq": GroqTTSProvider,
     "soniox": SonioxTTSProvider,
+    "baseten": BasetenTTSProvider,
 }
 
 if HumeTTSProvider is not None:
@@ -55,6 +57,7 @@ if HumeTTSProvider is not None:
 __all__ = [
     "TTS_PROVIDERS",
     "HUME_AVAILABLE",
+    "BasetenTTSProvider",
     "GradiumTTSProvider",
     "SmallestTTSProvider",
     "XaiTTSProvider",

--- a/runner/src/coval_bench/providers/tts/baseten.py
+++ b/runner/src/coval_bench/providers/tts/baseten.py
@@ -1,0 +1,129 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Baseten dedicated-endpoint TTS provider (Qwen3-TTS over WebSocket).
+
+Protocol: send a JSON ``session.config``, then ``input.text`` and ``input.done``;
+the server streams back 24 kHz mono PCM16 as binary frames interleaved with JSON
+status messages, finishing with ``session.done``. The endpoint URL embeds a
+private model id, so it is read from settings rather than hardcoded.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from typing import Any
+
+import structlog
+import websockets.asyncio.client as ws_client
+
+from coval_bench.config import Settings
+from coval_bench.providers.base import TTSProvider, TTSResult
+from coval_bench.providers.tts._common import finalize_tts_result
+
+logger: structlog.BoundLogger = structlog.get_logger(__name__)
+
+_VALID_MODELS = ("qwen3-tts-1.7b",)
+_VALID_VOICES = ("lisa", "jim")
+_SAMPLE_RATE = 24000
+_MAX_WS_SIZE = 16 * 1024 * 1024
+# Cold replicas exceed the 10 s websockets default for the handshake.
+_OPEN_TIMEOUT_S = 45
+
+
+class BasetenTTSProvider(TTSProvider):
+    """Baseten TTS provider using WebSocket streaming (Qwen3-TTS)."""
+
+    def __init__(self, settings: Settings, model: str, voice: str) -> None:
+        if model not in _VALID_MODELS:
+            raise ValueError(f"Invalid Baseten TTS model {model!r}. Valid: {_VALID_MODELS}")
+        if voice not in _VALID_VOICES:
+            raise ValueError(f"Invalid Baseten TTS voice {voice!r}. Valid: {_VALID_VOICES}")
+        self._model = model
+        self._voice = voice
+
+        api_key_secret = settings.baseten_api_key
+        if api_key_secret is None or not api_key_secret.get_secret_value().strip():
+            raise ValueError("baseten_api_key is required in Settings")
+        self._api_key = api_key_secret.get_secret_value()
+
+        if not settings.baseten_qwen_url:
+            raise ValueError("baseten_qwen_url is required in Settings")
+        self._ws_url = settings.baseten_qwen_url
+
+    @property
+    def name(self) -> str:
+        return f"baseten-{self._model}"
+
+    @property
+    def model(self) -> str:
+        return self._model
+
+    async def synthesize(self, text: str) -> TTSResult:
+        audio_chunks: list[bytes] = []
+        start: float | None = None
+        first_chunk_at: float | None = None
+        headers = {"Authorization": f"Api-Key {self._api_key}"}
+
+        try:
+            async with ws_client.connect(
+                self._ws_url,
+                additional_headers=headers,
+                max_size=_MAX_WS_SIZE,
+                open_timeout=_OPEN_TIMEOUT_S,
+            ) as ws:
+                # Clock starts post-handshake so TTFA excludes connect (cohort parity).
+                start = time.monotonic()
+                # x_vector_only_mode reuses the cached speaker embedding (fast path).
+                await ws.send(
+                    json.dumps(
+                        {
+                            "type": "session.config",
+                            "task_type": "Base",
+                            "response_format": "pcm",
+                            "stream_audio": True,
+                            "speed": 1.0,
+                            "split_granularity": "sentence",
+                            "voice": self._voice,
+                            "x_vector_only_mode": True,
+                        }
+                    )
+                )
+                await ws.send(json.dumps({"type": "input.text", "text": text}))
+                await ws.send(json.dumps({"type": "input.done"}))
+
+                async for message in ws:
+                    if isinstance(message, (bytes, bytearray)):
+                        if first_chunk_at is None:
+                            first_chunk_at = time.monotonic()
+                        audio_chunks.append(bytes(message))
+                        continue
+                    data: dict[str, Any] = json.loads(message)
+                    if data.get("type") == "session.done":
+                        break
+                    if data.get("type") == "error":
+                        raise RuntimeError(str(data.get("message", data)))
+
+        except Exception as exc:
+            logger.warning("baseten_tts_error", provider="baseten", model=self._model, exc_info=exc)
+            return finalize_tts_result(
+                provider="baseten",
+                model=self._model,
+                voice=self._voice,
+                pcm=b"",
+                sample_rate=_SAMPLE_RATE,
+                audio_synthesis_start=start,
+                first_audio_chunk_at=first_chunk_at,
+                error=str(exc),
+            )
+
+        return finalize_tts_result(
+            provider="baseten",
+            model=self._model,
+            voice=self._voice,
+            pcm=b"".join(audio_chunks),
+            sample_rate=_SAMPLE_RATE,
+            audio_synthesis_start=start,
+            first_audio_chunk_at=first_chunk_at,
+        )

--- a/runner/src/coval_bench/registries/models.py
+++ b/runner/src/coval_bench/registries/models.py
@@ -236,6 +236,20 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         tags=(_REALTIME, _VAD),
         status=_ACTIVE,
     ),
+    # Baseten dedicated endpoints (Whisper Large V3). PENDING: implemented and
+    # hidden while Baseten tunes the setup — kept off the scheduled runner and
+    # the public site, run manually during the daily test window.
+    RegisteredModel(
+        benchmark=_STT,
+        provider="baseten",
+        model="whisper-large-v3",
+        creator="openai",
+        tags=(_REALTIME, _MULTI, _VAD),
+        tenancy=Tenancy.DEDICATED,
+        licensing=_OPEN,
+        self_hostable=True,
+        status=_PENDING,
+    ),
     RegisteredModel(
         benchmark=_STT,
         provider="google",
@@ -450,6 +464,20 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         licensing=_OPEN,
         self_hostable=True,
         status=_ACTIVE,
+    ),
+    # Baseten dedicated endpoints (Qwen3-TTS 1.7B). PENDING for the same reason
+    # as the Whisper STT entry above — implemented, hidden, run manually.
+    RegisteredModel(
+        benchmark=_TTS,
+        provider="baseten",
+        model="qwen3-tts-1.7b",
+        voice="lisa",
+        creator="alibaba",
+        tags=(_REALTIME, _MULTI, _STREAM),
+        tenancy=Tenancy.DEDICATED,
+        licensing=_OPEN,
+        self_hostable=True,
+        status=_PENDING,
     ),
     # gpt-realtime is a speech-to-speech LLM, not a TTS provider: driving it
     # from a text "instructions" prompt folds LLM inference into TTFA and never

--- a/runner/src/coval_bench/runner/orchestrator.py
+++ b/runner/src/coval_bench/runner/orchestrator.py
@@ -263,6 +263,8 @@ async def _run_stt_item(
         kwargs: dict[str, Any] = {"api_key": api_key, "model": entry.model}
         if entry.provider == "google":
             kwargs["project_id"] = settings.google_project_id
+        elif entry.provider == "baseten":
+            kwargs["ws_url"] = settings.baseten_whisper_url
         provider = provider_cls(**kwargs)
 
         audio_path: Path = item.path

--- a/runner/src/coval_bench/runner/probe.py
+++ b/runner/src/coval_bench/runner/probe.py
@@ -1,0 +1,146 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Non-persisting benchmark probe.
+
+Runs dataset samples through the real per-item pipeline (``_run_stt_item`` /
+``_run_tts_item``) with ``writer=None``, so it measures the same metrics as a
+production run without writing to the database. Used for private latency checks
+of ``PENDING`` models.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import random
+import statistics
+from collections.abc import Awaitable, Callable
+from typing import TYPE_CHECKING, Any
+
+import structlog
+
+from coval_bench.datasets.loader import load_stt_dataset, load_tts_dataset
+from coval_bench.db.models import ResultStatus
+from coval_bench.registries import METRIC_SPECS, Benchmark, Metric
+from coval_bench.runner.orchestrator import _run_stt_item, _run_tts_item
+
+if TYPE_CHECKING:
+    from coval_bench.config import Settings
+    from coval_bench.registries import RegisteredModel
+
+logger = structlog.get_logger("coval_bench.probe")
+
+_STT_METRICS = (Metric.TTFS, Metric.TTFT, Metric.AUDIO_TO_FINAL, Metric.RTF, Metric.WER)
+_TTS_METRICS = (Metric.TTFA, Metric.WER)
+# Fixed seed so repeated probes draw the same sample for run-to-run comparability.
+_SEED = 0
+
+
+def _pct(values: list[float], q: float) -> float | None:
+    s = sorted(values)
+    if not s:
+        return None
+    k = max(0, min(len(s) - 1, round(q * (len(s) - 1))))
+    return s[k]
+
+
+def _aggregate(rows: list[Any], metrics: tuple[Metric, ...]) -> dict[str, dict[str, Any]]:
+    """Summarise Result rows per metric: counts plus mean/median/p90/min/max."""
+    out: dict[str, dict[str, Any]] = {}
+    for metric in metrics:
+        sel = [r for r in rows if r.metric_type == metric]
+        ok = [
+            r.metric_value
+            for r in sel
+            if r.status == ResultStatus.SUCCESS and r.metric_value is not None
+        ]
+        stat: dict[str, Any] = {"n_ok": len(ok), "n": len(sel), "unit": METRIC_SPECS[metric].units}
+        if ok:
+            stat.update(
+                mean=statistics.mean(ok),
+                median=statistics.median(ok),
+                p90=_pct(ok, 0.9),
+                min=min(ok),
+                max=max(ok),
+            )
+        out[metric.value] = stat
+    return out
+
+
+async def _run_model(
+    *,
+    entry: RegisteredModel,
+    items: list[Any],
+    runner: Callable[..., Awaitable[list[Any]]],
+    metrics: tuple[Metric, ...],
+    sem: asyncio.Semaphore,
+    settings: Settings,
+) -> dict[str, Any]:
+    tasks = [
+        runner(entry=entry, item=item, run_id=0, sem=sem, settings=settings, writer=None)
+        for item in items
+    ]
+    rows: list[Any] = []
+    for batch in await asyncio.gather(*tasks, return_exceptions=True):
+        if isinstance(batch, list):
+            rows.extend(batch)
+        else:
+            logger.warning("probe_item_raised", provider=entry.provider, model=entry.model)
+    return {
+        "benchmark": entry.benchmark.value,
+        "n_items": len(items),
+        "metrics": _aggregate(rows, metrics),
+    }
+
+
+async def run_probe(
+    *,
+    settings: Settings,
+    models: list[RegisteredModel],
+    sample_size: int,
+    concurrency: int = 1,
+) -> dict[str, dict[str, Any]]:
+    """Probe *models* over *sample_size* dataset items each; return aggregates.
+
+    Concurrency defaults to 1; keep it there for a single pinned replica so the
+    latency numbers are not inflated by self-contention.
+    """
+    sem = asyncio.Semaphore(concurrency)
+    results: dict[str, dict[str, Any]] = {}
+
+    stt_models = [m for m in models if m.benchmark is Benchmark.STT]
+    tts_models = [m for m in models if m.benchmark is Benchmark.TTS]
+
+    if stt_models:
+        ds = load_stt_dataset(
+            "stt-v1",
+            settings=settings,
+            sample_size=sample_size,
+            rng=random.Random(_SEED),  # noqa: S311
+        )
+        for entry in stt_models:
+            results[f"{entry.provider}/{entry.model}"] = await _run_model(
+                entry=entry,
+                items=list(ds.items),
+                runner=_run_stt_item,
+                metrics=_STT_METRICS,
+                sem=sem,
+                settings=settings,
+            )
+    if tts_models:
+        ds_tts = load_tts_dataset(
+            "tts-v1",
+            settings=settings,
+            sample_size=sample_size,
+            rng=random.Random(_SEED),  # noqa: S311
+        )
+        for entry in tts_models:
+            results[f"{entry.provider}/{entry.model}"] = await _run_model(
+                entry=entry,
+                items=list(ds_tts.items),
+                runner=_run_tts_item,
+                metrics=_TTS_METRICS,
+                sem=sem,
+                settings=settings,
+            )
+    return results

--- a/runner/src/coval_bench/runner/probe.py
+++ b/runner/src/coval_bench/runner/probe.py
@@ -85,7 +85,12 @@ async def _run_model(
         if isinstance(batch, list):
             rows.extend(batch)
         else:
-            logger.warning("probe_item_raised", provider=entry.provider, model=entry.model)
+            logger.warning(
+                "probe_item_raised",
+                provider=entry.provider,
+                model=entry.model,
+                exc_info=batch,
+            )
     return {
         "benchmark": entry.benchmark.value,
         "n_items": len(items),

--- a/runner/tests/providers/stt/test_baseten.py
+++ b/runner/tests/providers/stt/test_baseten.py
@@ -1,0 +1,197 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for coval_bench.providers.stt.baseten (BasetenSTTProvider).
+
+All tests use FakeWebSocket — no live network calls. The fixtures mirror the
+Baseten Whisper wire protocol: ``transcription`` messages carry ``segments`` and
+an ``is_final`` flag, two ``end_audio`` messages bracket the stream
+(``acknowledged`` then ``finished``), and the receiver stops only on
+``finished``. A small PCM buffer keeps the real-time 512-sample pacing fast.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pydantic import SecretStr
+
+from coval_bench.metrics.wer import compute_wer
+from coval_bench.providers.stt.baseten import BasetenSTTProvider
+from tests.providers.stt.conftest import FakeWebSocket
+
+_WS_URL = "wss://model-test.api.baseten.co/environments/production/websocket"
+
+# A few frames of PCM — enough to exercise framing/padding without the 3 s
+# fixture's real-time pacing dominating the test runtime.
+_SMALL_PCM = b"\x01\x02" * 1100  # 2200 bytes -> two 512-sample frames (last padded)
+
+
+def make_provider(api_key: SecretStr | None = None) -> BasetenSTTProvider:
+    return BasetenSTTProvider(api_key=api_key or SecretStr("test-key"), ws_url=_WS_URL)
+
+
+def _fake_connect(events: list[Any]) -> Any:
+    ws = FakeWebSocket(events)
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=ws)
+    cm.__aexit__ = AsyncMock(return_value=False)
+    return cm
+
+
+@pytest.mark.asyncio
+async def test_baseten_success(fake_api_key: SecretStr) -> None:
+    events: list[Any] = [
+        {"type": "transcription", "segments": [{"text": "hello"}], "is_final": False},
+        {"type": "end_audio", "body": {"status": "acknowledged"}},
+        {"type": "transcription", "segments": [{"text": "hello world"}], "is_final": True},
+        {"type": "end_audio", "body": {"status": "finished"}},
+    ]
+    provider = BasetenSTTProvider(api_key=fake_api_key, ws_url=_WS_URL)
+
+    with patch(
+        "coval_bench.providers.stt.baseten.ws_client.connect",
+        return_value=_fake_connect(events),
+    ):
+        result = await provider.measure_ttft(_SMALL_PCM, 1, 2, 16000, 0.1)
+
+    assert result.error is None
+    assert result.ttft_seconds is not None and result.ttft_seconds >= 0
+    assert result.first_token_content is not None
+    assert result.complete_transcript == "hello world"
+    assert result.word_count == 2
+    assert result.audio_to_final_seconds is not None
+    assert result.partial_transcripts == ["hello"]
+    wer = compute_wer("hello world", result.complete_transcript)
+    assert wer.wer_percentage == pytest.approx(0.0)
+
+
+@pytest.mark.asyncio
+async def test_baseten_accumulates_multi_segment_finals(fake_api_key: SecretStr) -> None:
+    """Multiple final messages (one per VAD segment) concatenate in order."""
+    events: list[Any] = [
+        {"type": "transcription", "segments": [{"text": "hello"}], "is_final": True},
+        {"type": "transcription", "segments": [{"text": "world"}], "is_final": True},
+        {"type": "end_audio", "body": {"status": "finished"}},
+    ]
+    provider = BasetenSTTProvider(api_key=fake_api_key, ws_url=_WS_URL)
+
+    with patch(
+        "coval_bench.providers.stt.baseten.ws_client.connect",
+        return_value=_fake_connect(events),
+    ):
+        result = await provider.measure_ttft(_SMALL_PCM, 1, 2, 16000, 0.1)
+
+    assert result.error is None
+    assert result.complete_transcript == "hello world"
+    assert result.word_count == 2
+
+
+@pytest.mark.asyncio
+async def test_baseten_ignores_acknowledged_end_audio(fake_api_key: SecretStr) -> None:
+    """The 'acknowledged' end_audio must not stop the receive loop early."""
+    events: list[Any] = [
+        {"type": "end_audio", "body": {"status": "acknowledged"}},
+        {"type": "transcription", "segments": [{"text": "after ack"}], "is_final": True},
+        {"type": "end_audio", "body": {"status": "finished"}},
+    ]
+    provider = BasetenSTTProvider(api_key=fake_api_key, ws_url=_WS_URL)
+
+    with patch(
+        "coval_bench.providers.stt.baseten.ws_client.connect",
+        return_value=_fake_connect(events),
+    ):
+        result = await provider.measure_ttft(_SMALL_PCM, 1, 2, 16000, 0.1)
+
+    assert result.error is None
+    assert result.complete_transcript == "after ack"
+
+
+def test_provider_name() -> None:
+    assert make_provider().name == "baseten"
+
+
+def test_provider_model() -> None:
+    assert make_provider().model == "whisper-large-v3"
+
+
+def test_invalid_model_raises() -> None:
+    with pytest.raises(ValueError, match="Invalid Baseten STT model"):
+        BasetenSTTProvider(api_key=SecretStr("k"), model="whisper-tiny", ws_url=_WS_URL)
+
+
+def test_missing_api_key_raises() -> None:
+    with pytest.raises(ValueError, match="baseten_api_key is required"):
+        BasetenSTTProvider(api_key=None, ws_url=_WS_URL)
+
+
+def test_missing_ws_url_raises() -> None:
+    with pytest.raises(ValueError, match="baseten_whisper_url is required"):
+        BasetenSTTProvider(api_key=SecretStr("k"), ws_url=None)
+
+
+@pytest.mark.asyncio
+async def test_baseten_wrong_sample_rate(fake_api_key: SecretStr) -> None:
+    provider = BasetenSTTProvider(api_key=fake_api_key, ws_url=_WS_URL)
+    result = await provider.measure_ttft(_SMALL_PCM, 1, 2, 8000)
+    assert result.error is not None
+    assert "16 kHz" in result.error
+    assert result.ttft_seconds is None
+
+
+@pytest.mark.asyncio
+async def test_baseten_rejects_non_mono(fake_api_key: SecretStr) -> None:
+    provider = BasetenSTTProvider(api_key=fake_api_key, ws_url=_WS_URL)
+    result = await provider.measure_ttft(_SMALL_PCM, 2, 2, 16000)
+    assert result.error is not None
+    assert "mono 16-bit" in result.error
+    assert result.ttft_seconds is None
+
+
+@pytest.mark.asyncio
+async def test_baseten_error_event(fake_api_key: SecretStr) -> None:
+    events: list[Any] = [{"type": "error", "message": "Invalid or expired API key"}]
+    provider = BasetenSTTProvider(api_key=fake_api_key, ws_url=_WS_URL)
+
+    with patch(
+        "coval_bench.providers.stt.baseten.ws_client.connect",
+        return_value=_fake_connect(events),
+    ):
+        result = await provider.measure_ttft(_SMALL_PCM, 1, 2, 16000, 0.1)
+
+    assert result.error is not None
+    assert "Invalid or expired API key" in result.error
+    assert result.complete_transcript is None
+
+
+@pytest.mark.asyncio
+async def test_baseten_stream_ends_without_final(fake_api_key: SecretStr) -> None:
+    """A stream that closes with no final transcript surfaces an error, not a silent pass."""
+    provider = BasetenSTTProvider(api_key=fake_api_key, ws_url=_WS_URL)
+
+    with patch(
+        "coval_bench.providers.stt.baseten.ws_client.connect",
+        return_value=_fake_connect([]),
+    ):
+        result = await provider.measure_ttft(_SMALL_PCM, 1, 2, 16000, 0.1)
+
+    assert result.error is not None
+    assert "before a final transcription" in result.error
+    assert result.complete_transcript is None
+
+
+@pytest.mark.asyncio
+async def test_baseten_connection_error(fake_api_key: SecretStr) -> None:
+    provider = BasetenSTTProvider(api_key=fake_api_key, ws_url=_WS_URL)
+
+    with patch(
+        "coval_bench.providers.stt.baseten.ws_client.connect",
+        side_effect=OSError("connection refused"),
+    ):
+        result = await provider.measure_ttft(_SMALL_PCM, 1, 2, 16000, 0.1)
+
+    assert result.error is not None
+    assert "connection refused" in result.error
+    assert result.complete_transcript is None

--- a/runner/tests/providers/tts/test_baseten.py
+++ b/runner/tests/providers/tts/test_baseten.py
@@ -86,6 +86,8 @@ async def test_baseten_tts_url_and_header_auth(baseten_settings: Settings) -> No
     assert captured["url"] == _WS_URL
     headers = captured["kwargs"]["additional_headers"]  # type: ignore[index]
     assert headers["Authorization"] == "Api-Key test-baseten-key"
+    if result.audio_path is not None:
+        result.audio_path.unlink()
 
 
 @pytest.mark.asyncio
@@ -94,7 +96,7 @@ async def test_baseten_tts_sends_config_text_done(baseten_settings: Settings) ->
     provider = BasetenTTSProvider(baseten_settings, model="qwen3-tts-1.7b", voice="jim")
 
     with patch("coval_bench.providers.tts.baseten.ws_client.connect", return_value=ws):
-        await provider.synthesize("Hello world")
+        result = await provider.synthesize("Hello world")
 
     sent = [json.loads(m) for m in ws.sent if isinstance(m, str)]
     assert sent[0]["type"] == "session.config"
@@ -103,6 +105,8 @@ async def test_baseten_tts_sends_config_text_done(baseten_settings: Settings) ->
     assert sent[0]["stream_audio"] is True
     assert sent[1] == {"type": "input.text", "text": "Hello world"}
     assert sent[2] == {"type": "input.done"}
+    if result.audio_path is not None:
+        result.audio_path.unlink()
 
 
 @pytest.mark.asyncio

--- a/runner/tests/providers/tts/test_baseten.py
+++ b/runner/tests/providers/tts/test_baseten.py
@@ -1,0 +1,168 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the Baseten WebSocket TTS provider (Qwen3-TTS)."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import pytest
+from pydantic import SecretStr
+
+from coval_bench.config import Settings
+from coval_bench.providers.tts.baseten import BasetenTTSProvider
+
+from .conftest import FakeWebSocket, make_pcm_bytes
+
+_WS_URL = "wss://model-test.api.baseten.co/environments/production/websocket"
+
+
+def _settings(**overrides: object) -> Settings:
+    base: dict[str, object] = {
+        "database_url": "postgresql://runner:password@localhost:5432/benchmarks",
+        "dataset_bucket": "test-bucket",
+        "dataset_id": "stt-v1",
+        "runner_sha": "test",
+        "log_level": "DEBUG",
+        "baseten_api_key": SecretStr("test-baseten-key"),
+        "baseten_qwen_url": _WS_URL,
+    }
+    base.update(overrides)
+    return Settings(**base)  # type: ignore[arg-type]
+
+
+def _done_events(pcm_chunks: list[bytes]) -> list[bytes | str]:
+    events: list[bytes | str] = list(pcm_chunks)
+    events.append(json.dumps({"type": "session.done"}))
+    return events
+
+
+@pytest.fixture()
+def baseten_settings() -> Settings:
+    return _settings()
+
+
+@pytest.mark.asyncio
+async def test_baseten_tts_happy_path(baseten_settings: Settings) -> None:
+    ws = FakeWebSocket(_done_events([make_pcm_bytes(240)]))
+    provider = BasetenTTSProvider(baseten_settings, model="qwen3-tts-1.7b", voice="lisa")
+
+    with patch("coval_bench.providers.tts.baseten.ws_client.connect", return_value=ws):
+        result = await provider.synthesize("Hello from Baseten")
+
+    assert result.error is None, f"Unexpected error: {result.error}"
+    assert result.ttfa_ms is not None
+    assert 0 < result.ttfa_ms < 60_000
+    assert result.audio_path is not None
+    assert result.audio_path.exists()
+    assert result.audio_path.read_bytes()[:4] == b"RIFF"
+    assert result.provider == "baseten"
+    assert result.model == "qwen3-tts-1.7b"
+    assert result.voice == "lisa"
+    result.audio_path.unlink()
+
+
+@pytest.mark.asyncio
+async def test_baseten_tts_url_and_header_auth(baseten_settings: Settings) -> None:
+    ws = FakeWebSocket(_done_events([make_pcm_bytes(240)]))
+    captured: dict[str, object] = {}
+
+    def connect_side_effect(url: str, **kwargs: object) -> FakeWebSocket:
+        captured["url"] = url
+        captured["kwargs"] = kwargs
+        return ws
+
+    provider = BasetenTTSProvider(baseten_settings, model="qwen3-tts-1.7b", voice="lisa")
+
+    with patch(
+        "coval_bench.providers.tts.baseten.ws_client.connect",
+        side_effect=connect_side_effect,
+    ):
+        result = await provider.synthesize("Hello")
+
+    assert result.error is None
+    assert captured["url"] == _WS_URL
+    headers = captured["kwargs"]["additional_headers"]  # type: ignore[index]
+    assert headers["Authorization"] == "Api-Key test-baseten-key"
+
+
+@pytest.mark.asyncio
+async def test_baseten_tts_sends_config_text_done(baseten_settings: Settings) -> None:
+    ws = FakeWebSocket(_done_events([make_pcm_bytes(240)]))
+    provider = BasetenTTSProvider(baseten_settings, model="qwen3-tts-1.7b", voice="jim")
+
+    with patch("coval_bench.providers.tts.baseten.ws_client.connect", return_value=ws):
+        await provider.synthesize("Hello world")
+
+    sent = [json.loads(m) for m in ws.sent if isinstance(m, str)]
+    assert sent[0]["type"] == "session.config"
+    assert sent[0]["voice"] == "jim"
+    assert sent[0]["response_format"] == "pcm"
+    assert sent[0]["stream_audio"] is True
+    assert sent[1] == {"type": "input.text", "text": "Hello world"}
+    assert sent[2] == {"type": "input.done"}
+
+
+@pytest.mark.asyncio
+async def test_baseten_tts_error_event(baseten_settings: Settings) -> None:
+    ws = FakeWebSocket([json.dumps({"type": "error", "message": "bad request"})])
+    provider = BasetenTTSProvider(baseten_settings, model="qwen3-tts-1.7b", voice="lisa")
+
+    with patch("coval_bench.providers.tts.baseten.ws_client.connect", return_value=ws):
+        result = await provider.synthesize("Hello")
+
+    assert result.error is not None
+    assert "bad request" in result.error
+    assert result.audio_path is None
+    assert result.ttfa_ms is None
+
+
+@pytest.mark.asyncio
+async def test_baseten_tts_ttfa_on_first_chunk(baseten_settings: Settings) -> None:
+    chunks = [make_pcm_bytes(240), make_pcm_bytes(240), make_pcm_bytes(240)]
+    ws = FakeWebSocket(_done_events(chunks))
+    provider = BasetenTTSProvider(baseten_settings, model="qwen3-tts-1.7b", voice="lisa")
+
+    times = iter([0.0, 0.1, 1.0, 2.0])
+
+    with (
+        patch(
+            "coval_bench.providers.tts.baseten.time.monotonic",
+            side_effect=lambda: next(times, 10.0),
+        ),
+        patch("coval_bench.providers.tts.baseten.ws_client.connect", return_value=ws),
+    ):
+        result = await provider.synthesize("Hello")
+
+    assert result.error is None
+    assert result.ttfa_ms == pytest.approx(100.0)
+    assert result.audio_path is not None
+    result.audio_path.unlink()
+
+
+def test_baseten_tts_invalid_model_raises(baseten_settings: Settings) -> None:
+    with pytest.raises(ValueError, match="Invalid Baseten TTS model"):
+        BasetenTTSProvider(baseten_settings, model="not-a-model", voice="lisa")
+
+
+def test_baseten_tts_invalid_voice_raises(baseten_settings: Settings) -> None:
+    with pytest.raises(ValueError, match="Invalid Baseten TTS voice"):
+        BasetenTTSProvider(baseten_settings, model="qwen3-tts-1.7b", voice="not-a-voice")
+
+
+def test_baseten_tts_missing_api_key_raises() -> None:
+    with pytest.raises(ValueError, match="baseten_api_key is required"):
+        BasetenTTSProvider(_settings(baseten_api_key=None), model="qwen3-tts-1.7b", voice="lisa")
+
+
+def test_baseten_tts_missing_url_raises() -> None:
+    with pytest.raises(ValueError, match="baseten_qwen_url is required"):
+        BasetenTTSProvider(_settings(baseten_qwen_url=None), model="qwen3-tts-1.7b", voice="lisa")
+
+
+def test_baseten_tts_provider_name(baseten_settings: Settings) -> None:
+    provider = BasetenTTSProvider(baseten_settings, model="qwen3-tts-1.7b", voice="lisa")
+    assert provider.name == "baseten-qwen3-tts-1.7b"
+    assert provider.model == "qwen3-tts-1.7b"

--- a/runner/tests/runner/test_probe.py
+++ b/runner/tests/runner/test_probe.py
@@ -1,0 +1,82 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the non-persisting probe (coval_bench.runner.probe).
+
+Dataset loading and the per-item runners are monkeypatched, so no network or DB
+is touched — the focus is the aggregation and that ``writer=None`` is propagated.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from coval_bench.db.models import ResultStatus
+from coval_bench.registries import Benchmark, Metric
+from coval_bench.runner import probe as probe_mod
+
+
+def _row(metric: Metric, value: float | None, status: ResultStatus = ResultStatus.SUCCESS) -> Any:
+    return SimpleNamespace(metric_type=metric, metric_value=value, status=status)
+
+
+def test_pct_and_aggregate() -> None:
+    rows = [_row(Metric.TTFS, v) for v in (0.2, 0.4, 0.6, 0.8, 1.0)]
+    rows.append(_row(Metric.TTFS, None, ResultStatus.FAILED))  # excluded from stats
+    agg = probe_mod._aggregate(rows, (Metric.TTFS,))
+    s = agg["TTFS"]
+    assert s["n"] == 6
+    assert s["n_ok"] == 5
+    assert s["unit"] == "seconds"
+    assert s["mean"] == pytest.approx(0.6)
+    assert s["median"] == pytest.approx(0.6)
+    assert s["min"] == 0.2
+    assert s["max"] == 1.0
+
+
+def test_aggregate_no_successes_omits_stats() -> None:
+    rows = [_row(Metric.TTFA, None, ResultStatus.FAILED)]
+    agg = probe_mod._aggregate(rows, (Metric.TTFA,))
+    assert agg["TTFA"] == {"n_ok": 0, "n": 1, "unit": "milliseconds"}
+
+
+@pytest.mark.asyncio
+async def test_run_probe_no_persist(monkeypatch: pytest.MonkeyPatch) -> None:
+    """run_probe routes each model through the right runner with writer=None."""
+    captured: dict[str, Any] = {}
+
+    fake_ds = SimpleNamespace(items=[object(), object(), object()])
+    monkeypatch.setattr(probe_mod, "load_stt_dataset", lambda *a, **k: fake_ds)
+    monkeypatch.setattr(probe_mod, "load_tts_dataset", lambda *a, **k: fake_ds)
+
+    async def fake_stt(*, writer: Any, **_: Any) -> list[Any]:
+        captured["stt_writer"] = writer
+        return [_row(Metric.TTFS, 0.5), _row(Metric.WER, 0.0)]
+
+    async def fake_tts(*, writer: Any, **_: Any) -> list[Any]:
+        captured["tts_writer"] = writer
+        return [_row(Metric.TTFA, 300.0)]
+
+    monkeypatch.setattr(probe_mod, "_run_stt_item", fake_stt)
+    monkeypatch.setattr(probe_mod, "_run_tts_item", fake_tts)
+
+    models = [
+        SimpleNamespace(benchmark=Benchmark.STT, provider="baseten", model="whisper-large-v3"),
+        SimpleNamespace(benchmark=Benchmark.TTS, provider="baseten", model="qwen3-tts-1.7b"),
+    ]
+    results = await probe_mod.run_probe(
+        settings=SimpleNamespace(), models=models, sample_size=3, concurrency=1
+    )
+
+    assert captured["stt_writer"] is None
+    assert captured["tts_writer"] is None
+    stt = results["baseten/whisper-large-v3"]
+    assert stt["benchmark"] == "STT"
+    assert stt["n_items"] == 3
+    assert stt["metrics"]["TTFS"]["n_ok"] == 3
+    assert stt["metrics"]["TTFS"]["median"] == pytest.approx(0.5)
+    tts = results["baseten/qwen3-tts-1.7b"]
+    assert tts["metrics"]["TTFA"]["mean"] == pytest.approx(300.0)

--- a/runner/tests/runner/test_probe.py
+++ b/runner/tests/runner/test_probe.py
@@ -10,12 +10,13 @@ is touched — the focus is the aggregation and that ``writer=None`` is propagat
 from __future__ import annotations
 
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, cast
 
 import pytest
 
+from coval_bench.config import Settings
 from coval_bench.db.models import ResultStatus
-from coval_bench.registries import Benchmark, Metric
+from coval_bench.registries import Benchmark, Metric, ModelStatus, RegisteredModel
 from coval_bench.runner import probe as probe_mod
 
 
@@ -64,11 +65,22 @@ async def test_run_probe_no_persist(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(probe_mod, "_run_tts_item", fake_tts)
 
     models = [
-        SimpleNamespace(benchmark=Benchmark.STT, provider="baseten", model="whisper-large-v3"),
-        SimpleNamespace(benchmark=Benchmark.TTS, provider="baseten", model="qwen3-tts-1.7b"),
+        RegisteredModel(
+            benchmark=Benchmark.STT,
+            provider="baseten",
+            model="whisper-large-v3",
+            status=ModelStatus.PENDING,
+        ),
+        RegisteredModel(
+            benchmark=Benchmark.TTS,
+            provider="baseten",
+            model="qwen3-tts-1.7b",
+            status=ModelStatus.PENDING,
+        ),
     ]
+    # settings is forwarded to the patched runners (which ignore it); cast a stub.
     results = await probe_mod.run_probe(
-        settings=SimpleNamespace(), models=models, sample_size=3, concurrency=1
+        settings=cast(Settings, SimpleNamespace()), models=models, sample_size=3, concurrency=1
     )
 
     assert captured["stt_writer"] is None


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a benchmark probe command that runs selected STT/TTS models and returns aggregated JSON results.
  * Added an `stt-smoke` command that validates WAV format, streams speech-to-text, and outputs JSON timing/transcript results.
  * Added Baseten-backed streaming STT/TTS provider support and registered Baseten STT/TTS models.

* **Bug Fixes**
  * Updated `tts-smoke` to enforce a 120s timeout and emit a failure JSON event with a non-zero exit code.

* **Tests**
  * Added mocked async test coverage for Baseten STT/TTS and for probe aggregation/non-persist execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds Baseten dedicated-endpoint providers for STT (Whisper Large V3 over WebSocket) and TTS (Qwen3-TTS via WebSocket), registers them as `PENDING` models, wires them into the orchestrator, and adds a new `probe` CLI command for non-persisting latency checks plus an `stt-smoke` command and a timeout guard on `tts-smoke`.

- **Baseten STT/TTS providers** (`providers/stt/baseten.py`, `providers/tts/baseten.py`): both implement the respective WebSocket streaming protocols with proper error handling, auth headers, and cold-start open-timeout settings; a pre-existing flagged issue with `audio_start_time` being overwritten on every sent chunk (rather than set once at stream start) affects TTFT and `audio_to_final` accuracy.
- **Probe runner** (`runner/probe.py`): non-persisting benchmark runner that reuses `_run_stt_item`/`_run_tts_item` with `writer=None`, aggregates metrics (mean/median/p90/min/max), and is exposed via a new `probe` CLI command.
- **CLI additions** (`__main__.py`): `stt-smoke` validates WAV format before streaming, both smoke commands gain 120 s timeouts with structured JSON failure output; provider-init errors (e.g. missing env vars) still surface as raw tracebacks rather than clean exit-code-1 JSON.

<h3>Confidence Score: 4/5</h3>

Safe to merge for PENDING/internal use; the existing unresolved bug in `_send_audio` causes TTFT and audio-to-final measurements to be anchored to the last sent audio frame rather than the first, so the STT metrics collected during probe runs will be systematically inaccurate until fixed.

The STT provider's `audio_start_time` is overwritten on every chunk, meaning all latency measurements (`ttft_seconds`, `audio_to_final_seconds`) are computed relative to the most recently sent frame rather than the beginning of the audio stream. Since these metrics drive the benchmark's TTFS computation in the orchestrator, any probe or production run with this provider will produce misleadingly low latency numbers.

runner/src/coval_bench/providers/stt/baseten.py — specifically `_send_audio` and the `audio_start_time` assignment inside the per-chunk loop.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| runner/src/coval_bench/providers/stt/baseten.py | New Baseten STT WebSocket provider; contains the flagged P1 where `audio_start_time` is overwritten on every chunk instead of being set once at stream start, causing systematically wrong TTFT and audio_to_final metrics. |
| runner/src/coval_bench/providers/tts/baseten.py | New Baseten TTS WebSocket provider; synthesize logic and error handling look solid; `name` property returns a compound string inconsistent with every other provider (flagged separately). |
| runner/src/coval_bench/runner/probe.py | New non-persisting probe runner; aggregation logic and result-key scheme are clean for the single-voice-per-model registry entries added here; all items are gathered concurrently with semaphore control. |
| runner/src/coval_bench/__main__.py | Adds `stt-smoke`, `probe`, and timeout handling for `tts-smoke`; provider-init errors in both smoke commands still surface as raw tracebacks (flagged separately); probe command has no top-level timeout, relying on per-item orchestrator timeouts. |
| runner/src/coval_bench/runner/orchestrator.py | Adds `baseten` branch to the STT provider kwargs in `_run_stt_item`; minimal and consistent with the existing `google` branch pattern. |
| runner/src/coval_bench/config.py | Adds `baseten_api_key`, `baseten_whisper_url`, and `baseten_qwen_url` to Settings; all nullable to maintain backward compatibility. |
| runner/src/coval_bench/registries/models.py | Registers Baseten STT (whisper-large-v3) and TTS (qwen3-tts-1.7b) models as PENDING with DEDICATED tenancy; correct attributes and consistent with other registry entries. |
| runner/tests/providers/stt/test_baseten.py | Good test coverage for STT provider: happy path, multi-segment finals, acknowledged vs. finished end_audio, error event, wrong sample rate, connection failure, and stream-ends-without-final. |
| runner/tests/providers/tts/test_baseten.py | Comprehensive TTS test suite; validates wire protocol order, TTFA timing, auth headers, error events, and init validation guards. |
| runner/tests/runner/test_probe.py | Probe tests verify `writer=None` propagation and `_aggregate` correctness including edge case of all-failed rows; uses monkeypatching so no live I/O. |


<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant CLI as CLI (stt-smoke / probe)
    participant Provider as BasetenSTTProvider
    participant WS as Baseten WebSocket
    participant Send as _send_audio task
    participant Recv as _receive task

    CLI->>Provider: measure_ttft(pcm, 1, 2, 16000)
    Provider->>WS: connect(ws_url, Authorization header)
    Provider->>WS: send streaming_params config (JSON)
    Provider->>Send: asyncio.create_task(_send_audio)
    Provider->>Recv: asyncio.create_task(_receive)
    Provider->>Provider: asyncio.wait(FIRST_EXCEPTION)

    loop paced 512-sample frames
        Send->>Send: "result.audio_start_time = frame_start (overwritten each frame)"
        Send->>WS: send binary PCM frame
    end
    Send->>WS: send end_audio JSON

    WS-->>Recv: "transcription is_final=false"
    Recv->>Recv: "ttft = now - result.audio_start_time"
    WS-->>Recv: "end_audio status=acknowledged"
    Note over Recv: continue (not finished yet)
    WS-->>Recv: "transcription is_final=true"
    Recv->>Recv: "audio_to_final = now - result.audio_start_time"
    WS-->>Recv: "end_audio status=finished"
    Recv->>Recv: break loop

    Provider->>Provider: asyncio.gather(send_task, recv_task)
    Provider-->>CLI: TranscriptionResult(ttft, audio_to_final, transcript)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant CLI as CLI (stt-smoke / probe)
    participant Provider as BasetenSTTProvider
    participant WS as Baseten WebSocket
    participant Send as _send_audio task
    participant Recv as _receive task

    CLI->>Provider: measure_ttft(pcm, 1, 2, 16000)
    Provider->>WS: connect(ws_url, Authorization header)
    Provider->>WS: send streaming_params config (JSON)
    Provider->>Send: asyncio.create_task(_send_audio)
    Provider->>Recv: asyncio.create_task(_receive)
    Provider->>Provider: asyncio.wait(FIRST_EXCEPTION)

    loop paced 512-sample frames
        Send->>Send: "result.audio_start_time = frame_start (overwritten each frame)"
        Send->>WS: send binary PCM frame
    end
    Send->>WS: send end_audio JSON

    WS-->>Recv: "transcription is_final=false"
    Recv->>Recv: "ttft = now - result.audio_start_time"
    WS-->>Recv: "end_audio status=acknowledged"
    Note over Recv: continue (not finished yet)
    WS-->>Recv: "transcription is_final=true"
    Recv->>Recv: "audio_to_final = now - result.audio_start_time"
    WS-->>Recv: "end_audio status=finished"
    Recv->>Recv: break loop

    Provider->>Provider: asyncio.gather(send_task, recv_task)
    Provider-->>CLI: TranscriptionResult(ttft, audio_to_final, transcript)
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (3)</h3></summary>

1. `runner/src/coval_bench/__main__.py`, line 93 ([link](https://github.com/coval-ai/benchmarks/blob/6518f35d9e0d0dc337029fbfc72e7360a4f3ec18/runner/src/coval_bench/__main__.py#L93)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Provider init errors surface as unhandled tracebacks**

   The docstring contracts exit code 1 for provider errors and exit code 2 for unknown providers, but `provider_cls(**kwargs)` is not wrapped in a try/except. If `baseten_whisper_url` or `baseten_api_key` is absent from the environment, `BasetenSTTProvider.__init__` raises `ValueError`, which propagates as an uncaught exception (messy traceback) rather than a clean `click.echo(..., err=True)` + `sys.exit(1)` sequence.

2. `runner/src/coval_bench/providers/tts/baseten.py`, line 481-482 ([link](https://github.com/coval-ai/benchmarks/blob/6518f35d9e0d0dc337029fbfc72e7360a4f3ec18/runner/src/coval_bench/providers/tts/baseten.py#L481-L482)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`name` property returns a compound string unlike every other provider**

   The STT counterpart returns `"baseten"`, every other provider in the codebase returns a flat provider name, but this property returns `"baseten-qwen3-tts-1.7b"`. The `finalize_tts_result` call hardcodes `provider="baseten"` so the DB record is unaffected, but any logging or display code that reads `provider.name` will see an inconsistent value. Consider aligning with the STT provider and returning `"baseten"`.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

3. `runner/src/coval_bench/providers/stt/baseten.py`, line 367-374 ([link](https://github.com/coval-ai/benchmarks/blob/36d8b8147737fd233a530a25be1db2373baf2d9a/runner/src/coval_bench/providers/stt/baseten.py#L367-L374)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **`audio_start_time` overwritten on every chunk — TTFT and `audio_to_final` measured from last sent frame, not from audio start**

   `result.audio_start_time` is reassigned on each loop iteration in `_send_audio`, so by the time a transcription message arrives in `_receive`, it holds the timestamp of the most recently sent 512-sample frame rather than the timestamp of the first frame. This means `ttft_seconds` measures "latency from last audio frame before first token" (roughly server processing latency per frame) and `audio_to_final_seconds` measures "time from last sent chunk to final transcript." The latter is used by the orchestrator to compute TTFS via `compute_ttfs(audio_to_final, speech_end_offset_ms / 1000.0)`, so if `audio_to_final` is not anchored to the start of the audio stream (as it is for every other STT provider), the TTFS value will be systematically lower than the true figure and incomparable to the rest of the cohort.
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (5): Last reviewed commit: ["Require non-empty transcript for stt-smo..."](https://github.com/coval-ai/benchmarks/commit/6ce3ef33c82c4d3b9f5c1d427120362b1780dea4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40973198)</sub>

<!-- /greptile_comment -->