### PR TITLE
fix/arena: pass voter_id through the arena reveal so it reveals after voting

### DIFF
--- a/web/app/api/arena/battle/[id]/reveal/route.ts
+++ b/web/app/api/arena/battle/[id]/reveal/route.ts
@@ -4,12 +4,16 @@ import { arenaAccessOk } from "@/lib/arena/guard";
 import { arenaRunnerFetch } from "@/lib/arena/runner";
 import type { Reveal } from "@/lib/arena/types";
 
-export async function GET(_req: Request, { params }: { params: Promise<{ id: string }> }) {
+export async function GET(req: Request, { params }: { params: Promise<{ id: string }> }) {
   if (!(await arenaAccessOk())) return new Response(null, { status: 404 });
   const { id } = await params;
+  const voterId = new URL(req.url).searchParams.get("voterId");
+  if (!voterId) return Response.json({ error: "voterId required." }, { status: 400 });
   let res: Response;
   try {
-    res = await arenaRunnerFetch(`/v1/arena/battle/${encodeURIComponent(id)}/reveal`);
+    res = await arenaRunnerFetch(
+      `/v1/arena/battle/${encodeURIComponent(id)}/reveal?voter_id=${encodeURIComponent(voterId)}`,
+    );
   } catch {
     return Response.json({ error: "Reveal failed." }, { status: 502 });
   }

--- a/web/app/arena/page.tsx
+++ b/web/app/arena/page.tsx
@@ -70,7 +70,7 @@ export default function ArenaPage() {
     try {
       await source.submitVote({ battleId: battle.battleId, outcome, voterId });
       try {
-        setReveal(await source.reveal(battle.battleId));
+        setReveal(await source.reveal(battle.battleId, voterId));
       } catch {
         setReveal(null); // vote is recorded; identities just unavailable
       }

--- a/web/lib/arena/apiSource.ts
+++ b/web/lib/arena/apiSource.ts
@@ -6,7 +6,7 @@ import type { BattleSource, BlindBattle, Reveal, VoteInput, VoteResult } from ".
 // calls:
 //   POST /api/arena/battle              { text }                        -> BlindBattle
 //   POST /api/arena/vote                { battleId, outcome, voterId }  -> VoteResult
-//   GET  /api/arena/battle/{id}/reveal                                  -> Reveal
+//   GET  /api/arena/battle/{id}/reveal?voterId=...                      -> Reveal
 
 // Coarse hang-backstops, not latency SLAs; tune once real backend latency is known.
 const QUICK_TIMEOUT_MS = 5_000; // vote/reveal: quick DB ops
@@ -32,8 +32,9 @@ export class ApiBattleSource implements BattleSource {
     return postJson<VoteResult>("/api/arena/vote", input);
   }
 
-  async reveal(battleId: string): Promise<Reveal> {
-    const res = await fetch(`/api/arena/battle/${encodeURIComponent(battleId)}/reveal`, {
+  async reveal(battleId: string, voterId: string): Promise<Reveal> {
+    const url = `/api/arena/battle/${encodeURIComponent(battleId)}/reveal?voterId=${encodeURIComponent(voterId)}`;
+    const res = await fetch(url, {
       signal: AbortSignal.timeout(QUICK_TIMEOUT_MS),
     });
     if (!res.ok) throw new Error(`reveal -> ${res.status}`);

--- a/web/lib/arena/arena.test.ts
+++ b/web/lib/arena/arena.test.ts
@@ -23,14 +23,14 @@ describe("MockBattleSource", () => {
   it("reveals two distinct models for a created battle", async () => {
     const src = new MockBattleSource();
     const battle = await src.createBattle("hi");
-    const reveal = await src.reveal(battle.battleId);
+    const reveal = await src.reveal(battle.battleId, "t");
     expect(reveal.a.model).toBeTruthy();
     expect(reveal.b.model).toBeTruthy();
     expect(reveal.a.model).not.toBe(reveal.b.model);
   });
 
   it("throws when revealing an unknown battle", async () => {
-    await expect(new MockBattleSource().reveal("does-not-exist")).rejects.toThrow();
+    await expect(new MockBattleSource().reveal("does-not-exist", "t")).rejects.toThrow();
   });
 
   it("echoes the outcome on submitVote", async () => {

--- a/web/lib/arena/mockSource.ts
+++ b/web/lib/arena/mockSource.ts
@@ -80,7 +80,7 @@ export class MockBattleSource implements BattleSource {
     return { battleId: input.battleId, outcome: input.outcome };
   }
 
-  async reveal(battleId: string): Promise<Reveal> {
+  async reveal(battleId: string, _voterId: string): Promise<Reveal> {
     const r = this.assignments.get(battleId);
     if (!r) throw new Error(`mock reveal: unknown battle ${battleId}`);
     return r;

--- a/web/lib/arena/types.ts
+++ b/web/lib/arena/types.ts
@@ -36,5 +36,5 @@ export interface Reveal {
 export interface BattleSource {
   createBattle(text: string): Promise<BlindBattle>;
   submitVote(input: VoteInput): Promise<VoteResult>;
-  reveal(battleId: string): Promise<Reveal>;
+  reveal(battleId: string, voterId: string): Promise<Reveal>;
 }


### PR DESCRIPTION
…vote

The runner reveal endpoint requires a voter_id query param, but the web layers never passed it, so the reveal always failed and the battle stayed blind even after voting. Forward voterId from the page through the BFF route to the runner.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reveal results now require and use your voter ID, so the app can return vote-specific battle details after you vote.
  * The vote flow now automatically requests the updated reveal information right after a successful vote.

* **Bug Fixes**
  * Added validation for reveal requests to return a clear error when the voter ID is missing.
  * Improved request handling for battle reveal responses while keeping existing access checks and error mapping intact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug where the arena reveal endpoint always silently failed after voting because the required `voter_id` query parameter was never forwarded from the page through the BFF to the runner. The fix is propagated consistently through all layers: the `BattleSource` interface, both the API and mock implementations, the BFF route handler, and the page component.

- **BFF route** (`route.ts`): now reads `voterId` from the incoming query string, returns HTTP 400 when absent, and re-maps it to the `voter_id` name expected by the runner.
- **Interface & implementations**: `BattleSource.reveal` gains a required `voterId` parameter, making the missing argument a compile-time error going forward; `ApiBattleSource` encodes and appends it to the fetch URL, `MockBattleSource` accepts and ignores it.
- **Tests**: updated to pass a dummy voter ID; the new 400-guard path in the BFF route is not covered by tests but that is a pre-existing test-infrastructure gap.

<h3>Confidence Score: 5/5</h3>

Safe to merge — a focused, end-to-end bug fix with no risky side effects.

The change is small and surgical: one query-param is threaded through four files. The voter ID is already generated client-side before any user interaction is possible, the empty-string edge case is caught by the 400 guard and handled gracefully in the catch block, and encoding is applied at every boundary. All existing tests pass with the updated signatures.

No files require special attention. The BFF route handler is the most critical new path, and its validation logic is straightforward.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| web/app/api/arena/battle/[id]/reveal/route.ts | BFF route now reads `voterId` from the query string, returns HTTP 400 when absent, and forwards it as `voter_id` to the runner — correctly translating the camelCase client param to the snake_case runner param. |
| web/lib/arena/types.ts | Interface `BattleSource.reveal` updated to require `voterId: string`, making the missing parameter a compile-time enforcement across all implementations. |
| web/lib/arena/apiSource.ts | `ApiBattleSource.reveal` now accepts and encodes `voterId` as a query parameter when calling the BFF route. Change is consistent with the updated interface. |
| web/app/arena/page.tsx | Page-level `castVote` now passes the local `voterId` to `source.reveal()`; the voter ID is already derived from localStorage (with a fallback UUID) and is guaranteed to be set before any user interaction. |
| web/lib/arena/mockSource.ts | Mock implementation accepts the new `_voterId` parameter (appropriately unused) to satisfy the updated interface without affecting mock behavior. |
| web/lib/arena/arena.test.ts | Test cases updated to pass `"t"` as the `voterId` argument to `reveal()`. Coverage is adequate for the mock path; the new 400-validation path in the BFF route is untested but that is an existing test-gap, not a regression. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Page as ArenaPage (client)
    participant BFF as /api/arena/battle/[id]/reveal (BFF route)
    participant Runner as Arena Runner (/v1/arena/...)

    Note over Page: User casts vote
    Page->>BFF: "POST /api/arena/vote { battleId, outcome, voterId }"
    BFF-->>Page: VoteResult

    Note over Page,Runner: Before this PR — reveal always failed
    Page->>BFF: "GET /api/arena/battle/{id}/reveal (no voterId)"
    BFF->>Runner: "GET /v1/arena/battle/{id}/reveal (no voter_id)"
    Runner-->>BFF: 4xx (voter_id required)
    BFF-->>Page: error → battle stays blind

    Note over Page,Runner: After this PR — reveal works
    Page->>BFF: "GET /api/arena/battle/{id}/reveal?voterId={voterId}"
    BFF->>Runner: "GET /v1/arena/battle/{id}/reveal?voter_id={voterId}"
    Runner-->>BFF: "Reveal { a: {model,provider}, b: {model,provider} }"
    BFF-->>Page: Reveal
    Note over Page: Models revealed on cards
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Page as ArenaPage (client)
    participant BFF as /api/arena/battle/[id]/reveal (BFF route)
    participant Runner as Arena Runner (/v1/arena/...)

    Note over Page: User casts vote
    Page->>BFF: "POST /api/arena/vote { battleId, outcome, voterId }"
    BFF-->>Page: VoteResult

    Note over Page,Runner: Before this PR — reveal always failed
    Page->>BFF: "GET /api/arena/battle/{id}/reveal (no voterId)"
    BFF->>Runner: "GET /v1/arena/battle/{id}/reveal (no voter_id)"
    Runner-->>BFF: 4xx (voter_id required)
    BFF-->>Page: error → battle stays blind

    Note over Page,Runner: After this PR — reveal works
    Page->>BFF: "GET /api/arena/battle/{id}/reveal?voterId={voterId}"
    BFF->>Runner: "GET /v1/arena/battle/{id}/reveal?voter_id={voterId}"
    Runner-->>BFF: "Reveal { a: {model,provider}, b: {model,provider} }"
    BFF-->>Page: Reveal
    Note over Page: Models revealed on cards
```

</a>

<sub>Reviews (1): Last reviewed commit: ["Thread voter\_id through the arena reveal..."](https://github.com/coval-ai/benchmarks/commit/80d802de5070078866eff818a02de8a26bff9935) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41145836)</sub>

<!-- /greptile_comment -->