### PR TITLE
Pause Groq Orpheus TTS pending a paid tier

### DIFF
--- a/runner/src/coval_bench/registries/models.py
+++ b/runner/src/coval_bench/registries/models.py
@@ -463,7 +463,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         tags=(_REALTIME, _EMOTION),
         licensing=_OPEN,
         self_hostable=True,
-        status=_ACTIVE,
+        status=_PENDING,
     ),
     # Baseten dedicated endpoints (Qwen3-TTS 1.7B). PENDING for the same reason
     # as the Whisper STT entry above — implemented, hidden, run manually.


### PR DESCRIPTION
## Why

Groq's free `on_demand` tier caps `canopylabs/orpheus-v1-english` at **3,600 tokens/day** (~40 requests). In the last 24h the runner made 436 requests and **all 436 got `429 rate_limit_exceeded`**; only 43 succeeded. Two visible symptoms on the TTS board:

- Sample count `n=43` vs ~482 for every other model.
- Garbage latency (`avg 5.4s`, `p95 25s`, `p50 735ms`): the OpenAI SDK silently retries 429s with backoff *inside* the call we time, so retry-sleep gets counted as TTFA.

The key and code are fine — this is purely the account tier.

## Change

Flip the Groq entry from `ACTIVE` to `PENDING` so it's hidden from the public leaderboard and dropped from the scheduled run, same treatment as the Baseten pending models. Re-activate once the account moves to a paid tier with a workable daily quota.

`ruff`, `ruff format`, `mypy --strict`, and `tests/unit/test_provider_config.py` + `tests/api/test_providers.py` pass.

## Follow-up (not here)

Optional code hardening: construct the Groq `AsyncOpenAI` client with `max_retries=0` so 429s become clean failed rows instead of latency-inflated successes — worth doing regardless of tier.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Hid an unreliable text-to-speech benchmark entry from the run queue and benchmarked list to reduce failed runs and 429 errors.
  * The affected option will remain unavailable until the service quota is sufficient for stable execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR pauses the Groq `canopylabs/orpheus-v1-english` TTS benchmark by flipping its registry status from `_ACTIVE` to `_PENDING`, hiding it from the public leaderboard and scheduled runs until the account is upgraded to a paid tier.

- **One-line change** in `models.py`: `status=_ACTIVE` → `status=_PENDING` for the Groq Orpheus entry, mirroring the same treatment already applied to Baseten pending models.
- The motivation is well-documented: the free on-demand quota (~3,600 tokens/day) is exhausted in ~40 requests, causing 429 errors that inflate latency metrics via silent SDK retries.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a single-field status flip on one registry entry with no logic, schema, or API surface changes.

The change touches exactly one line in a data registry file, toggling a model's status from active to paused. It follows the same established pattern used for other paused models in the same file. There is no new logic, no schema change, and no risk of breaking any other benchmark entries.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| runner/src/coval_bench/registries/models.py | Single-line status change: `_ACTIVE` → `_PENDING` for the Groq Orpheus TTS entry. No logic changes; consistent with existing pattern for paused models. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Scheduled Benchmark Run] --> B{Model Status?}
    B -- ACTIVE --> C[Include in run queue]
    B -- PENDING --> D[Skip / hide from leaderboard]
    C --> E[Groq API call]
    E -- 429 rate_limit_exceeded --> F[SDK silent retry + backoff]
    F --> G[Inflated TTFA latency counted]
    D --> H[No API calls, no bad metrics]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Scheduled Benchmark Run] --> B{Model Status?}
    B -- ACTIVE --> C[Include in run queue]
    B -- PENDING --> D[Skip / hide from leaderboard]
    C --> E[Groq API call]
    E -- 429 rate_limit_exceeded --> F[SDK silent retry + backoff]
    F --> G[Inflated TTFA latency counted]
    D --> H[No API calls, no bad metrics]
```

</a>

<sub>Reviews (3): Last reviewed commit: ["Pause Groq Orpheus TTS pending a paid ti..."](https://github.com/coval-ai/benchmarks/commit/ca8f08b6dc76b0088f90fc4056c8e9ea208046f8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41168884)</sub>

<!-- /greptile_comment -->