### PR TITLE
Speed up the test suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,9 @@ jobs:
       # spun up by pytest-postgresql on the loopback interface.
       - name: pytest
         working-directory: runner
-        run: uv run pytest -q --disable-socket --allow-unix-socket --allow-hosts=127.0.0.1,::1
+        run: >
+          uv run pytest -q --disable-socket --allow-unix-socket --allow-hosts=127.0.0.1,::1
+          --cov=coval_bench --cov-report=term-missing --cov-fail-under=0
 
       # -----------------------------------------------------------------------
       # License scan — fail if any dep carries a copyleft license (GPL/AGPL/SSPL/BUSL).

--- a/runner/alembic.ini
+++ b/runner/alembic.ini
@@ -10,6 +10,7 @@
 script_location = src/coval_bench/db/migrations
 file_template = %%(year)d%%(month).2d%%(day).2d_%%(rev)s_%%(slug)s
 prepend_sys_path = .
+path_separator = os
 
 [loggers]
 keys = root,sqlalchemy,alembic

--- a/runner/pytest.ini
+++ b/runner/pytest.ini
@@ -3,7 +3,8 @@
 
 [pytest]
 asyncio_mode = auto
-addopts = -ra --strict-markers --cov=coval_bench --cov-report=term-missing --cov-fail-under=0
+# Coverage is CI-only (ci.yml).
+addopts = -ra --strict-markers
 markers =
     live: requires live provider API keys (deselect with -m "not live")
     e2e: end-to-end tests requiring full stack

--- a/runner/tests/api/conftest.py
+++ b/runner/tests/api/conftest.py
@@ -3,9 +3,11 @@
 
 """Shared fixtures for the Coval Benchmarks API test suite.
 
-Uses ``pytest-postgresql`` to spin up a real in-process Postgres for each test.
-The FastAPI lifespan is managed by ``asgi_lifespan.LifespanManager`` so that the
-psycopg3 pool is properly opened and closed for each test.
+Uses ``pytest-postgresql`` with a session-scoped in-process Postgres.  The
+schema is loaded into the template database once; each test gets a fresh
+database cloned from it.  The FastAPI lifespan is managed by
+``asgi_lifespan.LifespanManager`` so that the psycopg3 pool is properly opened
+and closed for each test.
 
 Tests use ``httpx.AsyncClient`` with ``ASGITransport`` — no real network calls.
 
@@ -32,6 +34,7 @@ from asgi_lifespan import LifespanManager
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
 from psycopg_pool import AsyncConnectionPool
+from pytest_postgresql import factories
 
 from coval_bench.api.app import create_app
 from coval_bench.config import Settings
@@ -53,16 +56,16 @@ _MV_WINDOWS: dict[str, str] = {
 }
 
 
-async def _apply_schema(dsn: str) -> None:
+def _load_schema(**connect_kwargs: Any) -> None:
     """Create the benchmarks_v2 schema and tables needed by the API tests.
 
-    This mirrors the Alembic migration (20260429_0001_init_schema) without
-    requiring a full Alembic migration run.
+    Runs once against the template database; per-test databases are cloned
+    from it.  Mirrors the Alembic migration (20260429_0001_init_schema)
+    without requiring a full Alembic migration run.
     """
-    aconn = await psycopg.AsyncConnection.connect(dsn, autocommit=True)
-    try:
-        await aconn.execute("CREATE SCHEMA IF NOT EXISTS benchmarks_v2")
-        await aconn.execute("""
+    with psycopg.connect(**connect_kwargs) as conn:
+        conn.execute("CREATE SCHEMA IF NOT EXISTS benchmarks_v2")
+        conn.execute("""
             CREATE TABLE IF NOT EXISTS benchmarks_v2.runs (
                 id             bigserial PRIMARY KEY,
                 started_at     timestamptz NOT NULL DEFAULT now(),
@@ -76,7 +79,7 @@ async def _apply_schema(dsn: str) -> None:
                 error          text
             )
         """)
-        await aconn.execute("""
+        conn.execute("""
             CREATE TABLE IF NOT EXISTS benchmarks_v2.results (
                 id             bigserial PRIMARY KEY,
                 run_id         bigint NOT NULL
@@ -98,7 +101,7 @@ async def _apply_schema(dsn: str) -> None:
         # Per-window stats materialized views (model_stats + leaderboard).
         # S608 false-positive: name and interval come from the _MV_WINDOWS constant.
         for name, interval in _MV_WINDOWS.items():
-            await aconn.execute(f"""
+            conn.execute(f"""
                 CREATE MATERIALIZED VIEW IF NOT EXISTS benchmarks_v2.{name} AS
                 SELECT provider, model, benchmark, metric_type,
                        avg_value, stddev_value, min_value,
@@ -124,7 +127,7 @@ async def _apply_schema(dsn: str) -> None:
                 ) stats
             """)  # noqa: S608
         # Series rollup table (mirrors migration 20260611_0006).
-        await aconn.execute("""
+        conn.execute("""
             CREATE TABLE IF NOT EXISTS benchmarks_v2.results_by_bucket (
                 provider      text NOT NULL,
                 model         text NOT NULL,
@@ -141,8 +144,10 @@ async def _apply_schema(dsn: str) -> None:
                 PRIMARY KEY (provider, model, benchmark, metric_type, bucket_at)
             )
         """)
-    finally:
-        await aconn.close()
+
+
+postgresql_proc = factories.postgresql_proc(load=[_load_schema])
+postgresql = factories.postgresql("postgresql_proc")
 
 
 @pytest_asyncio.fixture
@@ -153,7 +158,6 @@ async def app(postgresql: Any, monkeypatch: pytest.MonkeyPatch) -> AsyncIterator
     ensure tests are fully isolated.
     """
     dsn = _make_db_url(postgresql)
-    await _apply_schema(dsn)
 
     monkeypatch.setenv("DATABASE_URL", dsn)
     monkeypatch.setenv("DATASET_BUCKET", "test-bucket")

--- a/runner/tests/providers/stt/conftest.py
+++ b/runner/tests/providers/stt/conftest.py
@@ -29,6 +29,7 @@ used with ``--disable-socket --allow-unix-socket`` in CI to enforce this.
 
 from __future__ import annotations
 
+import asyncio
 import json
 from collections.abc import Callable
 from pathlib import Path
@@ -117,6 +118,28 @@ class AsyncFakeWebSocketIter:
 # ---------------------------------------------------------------------------
 # Pytest fixtures
 # ---------------------------------------------------------------------------
+
+_REAL_SLEEP = asyncio.sleep
+
+# Final/flush waits the FakeWebSocket never releases.
+_WAIT_PATCHES = (
+    "coval_bench.providers.stt.assemblyai._FINAL_WAIT_S",
+    "coval_bench.providers.stt.deepgram._FINAL_WAIT_S",
+    "coval_bench.providers.stt.xai._FINAL_WAIT_S",
+    "coval_bench.providers.stt.gradium._FLUSH_WAIT_S",
+)
+
+
+@pytest.fixture(autouse=True)
+def _fast_streaming(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Zero out pacing sleeps and final-event waits; sleeps still yield to the loop."""
+
+    async def _instant(_delay: float, result: Any = None) -> Any:
+        return await _REAL_SLEEP(0, result)
+
+    monkeypatch.setattr(asyncio, "sleep", _instant)
+    for target in _WAIT_PATCHES:
+        monkeypatch.setattr(target, 0.05)
 
 
 @pytest.fixture

--- a/runner/tests/providers/stt/test_assemblyai.py
+++ b/runner/tests/providers/stt/test_assemblyai.py
@@ -76,10 +76,7 @@ def test_websocket_url_contains_required_params() -> None:
 
 
 @pytest.mark.asyncio
-async def test_force_endpoint_sent_before_terminate(
-    fake_api_key: SecretStr, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    monkeypatch.setattr("coval_bench.providers.stt.assemblyai._FINAL_WAIT_S", 0.05)
+async def test_force_endpoint_sent_before_terminate(fake_api_key: SecretStr) -> None:
     sent: list[Any] = []
     final = {"type": "Turn", "end_of_turn": True, "transcript": "hello world"}
     ws = FakeWebSocket([final], on_send=sent.append)
@@ -130,11 +127,8 @@ def test_provider_name_universal_streaming_multilingual() -> None:
 
 
 @pytest.mark.asyncio
-async def test_universal_3_5_pro_url_uses_api_speech_model(
-    fake_api_key: SecretStr, monkeypatch: pytest.MonkeyPatch
-) -> None:
+async def test_universal_3_5_pro_url_uses_api_speech_model(fake_api_key: SecretStr) -> None:
     """The friendly model id maps to the API's speech_model value on the wire."""
-    monkeypatch.setattr("coval_bench.providers.stt.assemblyai._FINAL_WAIT_S", 0.05)
     ws = FakeWebSocket([{"type": "Turn", "end_of_turn": True, "transcript": "hi"}])
     cm = MagicMock()
     cm.__aenter__ = AsyncMock(return_value=ws)
@@ -158,10 +152,9 @@ async def test_universal_3_5_pro_url_uses_api_speech_model(
 
 @pytest.mark.asyncio
 async def test_universal_streaming_multilingual_url_uses_api_speech_model(
-    fake_api_key: SecretStr, monkeypatch: pytest.MonkeyPatch
+    fake_api_key: SecretStr,
 ) -> None:
     """The multilingual model id maps to its speech_model value with no language lock."""
-    monkeypatch.setattr("coval_bench.providers.stt.assemblyai._FINAL_WAIT_S", 0.05)
     ws = FakeWebSocket([{"type": "Turn", "end_of_turn": True, "transcript": "hola"}])
     cm = MagicMock()
     cm.__aenter__ = AsyncMock(return_value=ws)
@@ -270,10 +263,9 @@ async def test_assemblyai_audio_to_final_populated(
 
 @pytest.mark.asyncio
 async def test_assemblyai_audio_to_final_none_when_no_end_of_turn(
-    fake_api_key: SecretStr, audio_pcm_bytes: bytes, monkeypatch: pytest.MonkeyPatch
+    fake_api_key: SecretStr, audio_pcm_bytes: bytes
 ) -> None:
     """audio_to_final_seconds is None when no end_of_turn event arrives."""
-    monkeypatch.setattr("coval_bench.providers.stt.assemblyai._FINAL_WAIT_S", 0.05)
     events: list[Any] = [
         {"type": "Begin", "id": "test-session", "expires_at": 9999999999},
         {
@@ -302,7 +294,7 @@ async def test_assemblyai_audio_to_final_none_when_no_end_of_turn(
 
 @pytest.mark.asyncio
 async def test_assemblyai_partial_only_leaves_complete_transcript_none(
-    fake_api_key: SecretStr, audio_pcm_bytes: bytes, monkeypatch: pytest.MonkeyPatch
+    fake_api_key: SecretStr, audio_pcm_bytes: bytes
 ) -> None:
     """No end_of_turn=true final means no scorable transcript.
 
@@ -311,7 +303,6 @@ async def test_assemblyai_partial_only_leaves_complete_transcript_none(
     still captured (ttft, partial_transcripts) — they just stay out of the
     transcript WER reads.
     """
-    monkeypatch.setattr("coval_bench.providers.stt.assemblyai._FINAL_WAIT_S", 0.05)
     events: list[Any] = [
         {"type": "Begin", "id": "test-session", "expires_at": 9999999999},
         {"type": "Turn", "transcript": "hello", "end_of_turn": False},

--- a/runner/tests/providers/stt/test_deepgram.py
+++ b/runner/tests/providers/stt/test_deepgram.py
@@ -128,10 +128,7 @@ def test_build_websocket_url_flux() -> None:
 
 
 @pytest.mark.asyncio
-async def test_nova_sends_finalize_before_close(
-    fake_api_key: SecretStr, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    monkeypatch.setattr("coval_bench.providers.stt.deepgram._FINAL_WAIT_S", 0.05)
+async def test_nova_sends_finalize_before_close(fake_api_key: SecretStr) -> None:
     sent: list[Any] = []
     final = {
         "type": "Results",

--- a/runner/tests/providers/stt/test_gladia.py
+++ b/runner/tests/providers/stt/test_gladia.py
@@ -11,7 +11,6 @@ in-order join of every final.
 
 from __future__ import annotations
 
-from asyncio import sleep as _real_sleep
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -48,16 +47,6 @@ def _fake_http_client(response: httpx.Response) -> Any:
 
 def _init_ok() -> httpx.Response:
     return httpx.Response(200, json={"id": "test-session", "url": _WS_URL})
-
-
-@pytest.fixture(autouse=True)
-def _no_realtime_sleep(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Drop the real-time pacing sleep so streaming tests run instantly."""
-
-    async def _noop(_seconds: float) -> None:
-        return None
-
-    monkeypatch.setattr("coval_bench.providers.stt.gladia.asyncio.sleep", _noop)
 
 
 # ---------------------------------------------------------------------------
@@ -222,11 +211,9 @@ async def test_gladia_error_event(fake_api_key: SecretStr, audio_pcm_bytes: byte
 
 @pytest.mark.asyncio
 async def test_gladia_cancels_sender_when_receiver_errors(
-    fake_api_key: SecretStr, audio_pcm_bytes: bytes, monkeypatch: pytest.MonkeyPatch
+    fake_api_key: SecretStr, audio_pcm_bytes: bytes
 ) -> None:
     """A receiver error cancels the still-streaming sender instead of draining it."""
-    # Real yielding sleep (overriding the autouse no-op) so the sender is mid-stream.
-    monkeypatch.setattr("coval_bench.providers.stt.gladia.asyncio.sleep", lambda _s: _real_sleep(0))
     sent: list[Any] = []
     ws = FakeWebSocket(load_fixture_events("gladia", "events-error"), on_send=sent.append)
     cm = MagicMock()

--- a/runner/tests/providers/stt/test_gradium.py
+++ b/runner/tests/providers/stt/test_gradium.py
@@ -140,7 +140,7 @@ async def test_gradium_closes_on_flushed_ack_not_blind_sleep(
 
     assert result.error is None
     assert result.complete_transcript == "hello world"
-    # Ack releases the wait well before the 30s cap (audio streams ~3s).
+    # Ack releases the wait well before the 30s cap.
     assert elapsed < 5.0
 
 

--- a/runner/tests/unit/conftest.py
+++ b/runner/tests/unit/conftest.py
@@ -1,0 +1,10 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared fixtures for unit tests."""
+
+from pytest_postgresql.factories import postgresql_proc
+
+# One embedded Postgres server (random free port) for all DB-backed unit
+# tests; each client fixture still gets a clean per-test database.
+pg_proc = postgresql_proc(port=None)

--- a/runner/tests/unit/test_arena_snapshot.py
+++ b/runner/tests/unit/test_arena_snapshot.py
@@ -4,8 +4,7 @@
 """Tests for coval_bench.arena.snapshot.
 
 Uses ``pytest-postgresql`` (embedded ``pg_ctl``, no Docker) to spin up a real
-Postgres. No remote DB is ever contacted. A separate session server (random
-port) keeps these independent of the other db tests.
+Postgres. No remote DB is ever contacted.
 """
 
 from __future__ import annotations
@@ -20,14 +19,13 @@ import psycopg.rows
 from alembic import command as alembic_command
 from alembic.config import Config as AlembicConfig
 from psycopg_pool import AsyncConnectionPool
-from pytest_postgresql.factories import postgresql, postgresql_proc
+from pytest_postgresql.factories import postgresql
 
 from coval_bench.arena.snapshot import run_snapshot
 from coval_bench.db.arena_store import ArenaStore
 from coval_bench.db.models import Battle, VoteOutcome, VoterType
 
-snap_pg_proc = postgresql_proc(port=None)
-snap_pg = postgresql("snap_pg_proc")
+snap_pg = postgresql("pg_proc")  # shared server from conftest, own per-test DB
 
 _INI_PATH = Path(__file__).parents[2] / "alembic.ini"
 

--- a/runner/tests/unit/test_arena_store.py
+++ b/runner/tests/unit/test_arena_store.py
@@ -4,8 +4,7 @@
 """Tests for coval_bench.db.arena_store.
 
 Uses ``pytest-postgresql`` (embedded ``pg_ctl``, no Docker) to spin up a real
-Postgres. No remote DB is ever contacted. A separate session server (random
-port) keeps these independent of the db-writer tests.
+Postgres. No remote DB is ever contacted.
 """
 
 from __future__ import annotations
@@ -22,7 +21,7 @@ import pytest
 from alembic import command as alembic_command
 from alembic.config import Config as AlembicConfig
 from psycopg_pool import AsyncConnectionPool
-from pytest_postgresql.factories import postgresql, postgresql_proc
+from pytest_postgresql.factories import postgresql
 
 from coval_bench.db.arena_store import ArenaStore
 from coval_bench.db.models import (
@@ -33,10 +32,7 @@ from coval_bench.db.models import (
     VoterType,
 )
 
-# Separate embedded server (random free port) so we don't collide with the
-# db-writer tests' ``pg_proc`` fixture.
-arena_pg_proc = postgresql_proc(port=None)
-arena_pg = postgresql("arena_pg_proc")
+arena_pg = postgresql("pg_proc")  # shared server from conftest, own per-test DB
 
 _INI_PATH = Path(__file__).parents[2] / "alembic.ini"
 

--- a/runner/tests/unit/test_db_writer.py
+++ b/runner/tests/unit/test_db_writer.py
@@ -26,17 +26,16 @@ import pytest
 from alembic import command as alembic_command
 from alembic.config import Config as AlembicConfig
 from psycopg_pool import AsyncConnectionPool
-from pytest_postgresql.factories import postgresql, postgresql_proc
+from pytest_postgresql.factories import postgresql
 
 from coval_bench.db.conn import get_pool
 from coval_bench.db.models import Benchmark, Result, ResultStatus, Run, RunStatus
 from coval_bench.db.writer import RunWriter
 
 # ---------------------------------------------------------------------------
-# pytest-postgresql fixtures
+# pytest-postgresql fixtures — server shared via conftest ``pg_proc``
 # ---------------------------------------------------------------------------
 
-pg_proc = postgresql_proc()  # session-scoped Postgres server
 pg_conn = postgresql("pg_proc")  # function-scoped clean DB per test
 
 


### PR DESCRIPTION
Strip real-time waits from the STT provider tests, share one embedded Postgres across DB-backed tests, and move coverage to CI only, taking the suite from ~5.5 minutes to ~16 seconds.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR speeds up the test suite from ~5.5 minutes to ~16 seconds by eliminating three sources of real-time delay: replacing per-test async schema setup in the API tests with a single template-database load, collapsing three separate embedded Postgres server instances in the unit tests into one shared session-scoped server, and centralising all provider sleep/wait patches into a single `autouse` fixture so every STT test runs with instant sleeps and 50 ms `wait_for` timeouts. Coverage collection is moved from `pytest.ini` (always-on) to the CI workflow only, removing that overhead from local runs.

- **STT tests**: new `_fast_streaming` autouse fixture in `stt/conftest.py` globally patches `asyncio.sleep` to `asyncio.sleep(0)` and sets `_FINAL_WAIT_S`/`_FLUSH_WAIT_S` constants to `0.05 s`; all per-test `monkeypatch` calls in `test_assemblyai.py`, `test_deepgram.py`, and `test_gladia.py` are removed. The yielding behaviour that `test_gladia_cancels_sender_when_receiver_errors` relied on is preserved because `_instant` still calls `_REAL_SLEEP(0)`.
- **DB-backed tests**: `tests/api/conftest.py` switches from `_apply_schema(dsn)` (per-test async) to `_load_schema(**connect_kwargs)` (sync, once per session via `postgresql_proc(load=[…])`); `tests/unit/conftest.py` introduces a single `pg_proc` shared by `test_db_writer`, `test_arena_store`, and `test_arena_snapshot`.
- **CI/local split**: `--cov` flags removed from `pytest.ini` and added to the `ci.yml` pytest step, so local runs no longer pay the coverage-instrumentation overhead.

<h3>Confidence Score: 4/5</h3>

Safe to merge; all changes are test-infrastructure only with no production code touched.

The core logic — template-DB loading, shared `pg_proc`, and centralised sleep patching — is sound and the key behavioural invariants are preserved. The `_fast_streaming` fixture patches `asyncio.sleep` on the global `asyncio` module object rather than scoping the patch to individual provider modules, which is a broader side-effect than the old per-module patches. It works correctly today because tests are sequential and `monkeypatch` restores the original, but if a future helper coroutine relies on a real inter-loop delay it will be silently bypassed. The `_WAIT_PATCHES` string-path list also has no early validation, so a renamed constant would surface as a fixture-setup failure across every STT test rather than a targeted import error. Both points are maintenance concerns rather than present failures.

`runner/tests/providers/stt/conftest.py` — the new autouse fixture and `_WAIT_PATCHES` tuple warrant a second look; all other files are straightforward cleanups.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| runner/tests/providers/stt/conftest.py | Introduces `_fast_streaming` autouse fixture that patches `asyncio.sleep` at the global module level and sets `_FINAL_WAIT_S`/`_FLUSH_WAIT_S` constants to 0.05 s for all STT tests. Centralises per-test sleep patches; global patch scope is broader than the old per-module patches but functionally correct for sequential test execution. |
| runner/tests/api/conftest.py | Converts per-test async schema setup (`_apply_schema` called per test) to a sync `_load_schema` called once via `postgresql_proc(load=[...])` against the template DB; each test database is cloned from the template. Removes `await _apply_schema(dsn)` from the `app` fixture. Correct and safe. |
| runner/tests/unit/conftest.py | New file introducing a single session-scoped `pg_proc` shared by all unit test files, replacing three separate server instances. Clean and minimal. |
| runner/tests/providers/stt/test_gladia.py | Removes the per-file `_no_realtime_sleep` autouse fixture and the per-test sleep override in `test_gladia_cancels_sender_when_receiver_errors`. The new global `_fast_streaming` (which calls `_REAL_SLEEP(0)`) preserves the yielding behavior the cancellation test relied on. |
| .github/workflows/ci.yml | Adds `--cov=coval_bench --cov-report=term-missing --cov-fail-under=0` to the CI pytest invocation, matching what was removed from `pytest.ini`. Coverage is now only collected in CI. |
| runner/pytest.ini | Removes the coverage flags from `addopts` so local test runs no longer pay the `pytest-cov` overhead. Adds a comment explaining the intent. |

<sub>Reviews (1): Last reviewed commit: ["Speed up the test suite"](https://github.com/coval-ai/benchmarks/commit/7c1706022264d863ba24c0aa4c3b58ba5847477a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41199955)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->