### PR TITLE
Gate arena TTS providers on mounted API keys

### DIFF
--- a/.github/workflows/check-arena-keys.yml
+++ b/.github/workflows/check-arena-keys.yml
@@ -1,0 +1,72 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Cross-repo parity gate: when a PR changes the TTS provider registry, every
+# arena-eligible provider's API key must be mounted on the benchmarks-api Cloud
+# Run service in coval-ai/benchmark-infra. Path-filtered so it only runs on
+# provider-addition PRs — never on unrelated branches or already-merged work.
+name: Arena key parity
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "runner/src/coval_bench/registries/models.py"
+      - "runner/src/coval_bench/registries/provider_keys.py"
+      - "runner/src/coval_bench/providers/tts/**"
+
+permissions:
+  contents: read
+
+jobs:
+  parity:
+    name: Arena provider keys mounted in infra
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-dependency-glob: runner/uv.lock
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        working-directory: runner
+        run: uv sync --frozen --dev
+
+      - name: Fetch infra Cloud Run service module
+        id: fetch_infra
+        env:
+          GH_TOKEN: ${{ secrets.INFRA_DISPATCH_TOKEN }}
+        run: |
+          set -uo pipefail
+          # Warn-and-pass only for PLUMBING failures (token absent, infra unreadable):
+          # these mean "couldn't verify", not "key unmounted". A real parity miss is
+          # decided by the next step, which still fails hard.
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "::warning::skipping arena key parity — INFRA_DISPATCH_TOKEN unavailable (e.g. fork PR); could not verify, not a parity failure."
+            echo "verified=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if ! gh api repos/coval-ai/benchmark-infra/contents/modules/cloud_run_service/main.tf \
+               -H "Accept: application/vnd.github.raw" > infra_cloud_run_service.tf; then
+            echo "::warning::skipping arena key parity — could not read benchmark-infra (token scope/expiry or infra perms); could not verify, not a parity failure."
+            echo "verified=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "verified=true" >> "$GITHUB_OUTPUT"
+
+      - name: Check arena provider key parity
+        if: steps.fetch_infra.outputs.verified == 'true'
+        working-directory: runner
+        run: uv run --with 'python-hcl2==8.1.2' python scripts/check_arena_keys.py ../infra_cloud_run_service.tf

--- a/runner/scripts/check_arena_keys.py
+++ b/runner/scripts/check_arena_keys.py
@@ -1,0 +1,87 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+"""Assert every arena-eligible TTS provider's API key is mounted on benchmarks-api.
+
+Reads the ``coval-ai/benchmark-infra`` Cloud Run service module (passed as a
+path; the CI workflow fetches it) and structurally extracts the env-var names it
+mounts from Secret Manager. Fails if any provider the arena would synthesize
+lacks its key on the service — the cross-repo parity gate.
+
+Usage: python scripts/check_arena_keys.py <path-to-cloud_run_service/main.tf>
+"""
+
+from __future__ import annotations
+
+import sys
+
+import hcl2
+
+from coval_bench.arena.pairing import active_tts_models
+from coval_bench.registries.provider_keys import PROVIDER_ENV
+
+
+def _has_secret_ref(node: object) -> bool:
+    if isinstance(node, dict):
+        if "secret_key_ref" in node:
+            return True
+        return any(_has_secret_ref(v) for v in node.values())
+    if isinstance(node, list):
+        return any(_has_secret_ref(item) for item in node)
+    return False
+
+
+def _secret_backed_env_names(node: object) -> set[str]:
+    """Env-var names bound to a Secret Manager secret, found anywhere in the tree."""
+    found: set[str] = set()
+    if isinstance(node, dict):
+        name = node.get("name")
+        if isinstance(name, str) and _has_secret_ref(node.get("value_source")):
+            # python-hcl2 preserves literal quotes on string values, e.g. '"OPENAI_API_KEY"'.
+            found.add(name.strip('"'))
+        for value in node.values():
+            found |= _secret_backed_env_names(value)
+    elif isinstance(node, list):
+        for item in node:
+            found |= _secret_backed_env_names(item)
+    return found
+
+
+def main(tf_path: str) -> int:
+    with open(tf_path) as fp:
+        tree = hcl2.load(fp)
+    mounted = _secret_backed_env_names(tree)
+
+    required: set[str] = set()
+    unmapped: set[str] = set()
+    for m in active_tts_models():
+        env_var = PROVIDER_ENV.get(m.provider)
+        if env_var is None:
+            unmapped.add(m.provider)
+        else:
+            required.add(env_var)
+
+    if unmapped:
+        print(f"ERROR: no PROVIDER_ENV entry for arena providers: {sorted(unmapped)}")
+        return 1
+
+    if not required:
+        print("ERROR: arena roster is empty — no ACTIVE, arena_enabled TTS providers to verify.")
+        return 1
+
+    missing = sorted(required - mounted)
+    if missing:
+        print(
+            f"ERROR: arena-eligible but NOT mounted on benchmarks-api: {missing}\n"
+            "Mount them in coval-ai/benchmark-infra "
+            "(modules/cloud_run_service/main.tf env{} block + "
+            "envs/prod/cloud_run_service.tf secret_ids + the secret_manager secret), "
+            "then re-run this check."
+        )
+        return 1
+
+    print(f"OK: all {len(required)} arena provider keys are mounted on benchmarks-api")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1]))

--- a/runner/src/coval_bench/arena/pairing.py
+++ b/runner/src/coval_bench/arena/pairing.py
@@ -31,9 +31,11 @@ PAIRING_DOMAIN = "all"
 
 
 def active_tts_models() -> list[RegisteredModel]:
-    """The arena roster: every ACTIVE TTS model in the registry."""
+    """The arena roster: every ACTIVE, arena-enabled TTS model in the registry."""
     return [
-        m for m in MODEL_REGISTRY if m.benchmark is Benchmark.TTS and m.status is ModelStatus.ACTIVE
+        m
+        for m in MODEL_REGISTRY
+        if m.benchmark is Benchmark.TTS and m.status is ModelStatus.ACTIVE and m.arena_enabled
     ]
 
 

--- a/runner/src/coval_bench/registries/models.py
+++ b/runner/src/coval_bench/registries/models.py
@@ -55,6 +55,7 @@ class RegisteredModel(BaseModel, frozen=True):
     licensing: Licensing = Licensing.PROPRIETARY
     self_hostable: bool = False  # can run in the customer's own infra
     status: ModelStatus
+    arena_enabled: bool = True  # in the arena roster? independent of dashboard `status`
 
 
 _STT = Benchmark.STT
@@ -436,6 +437,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         tags=(_REALTIME, _MULTI, _CLONE, _EMOTION, _STREAM),
         self_hostable=True,
         status=_ACTIVE,
+        arena_enabled=False,
     ),
     RegisteredModel(
         benchmark=_TTS,
@@ -445,6 +447,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         tags=(_REALTIME, _MULTI, _CLONE, _EMOTION, _STREAM),
         self_hostable=True,
         status=_ACTIVE,
+        arena_enabled=False,
     ),
     RegisteredModel(
         benchmark=_TTS,
@@ -464,6 +467,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         licensing=_OPEN,
         self_hostable=True,
         status=_PENDING,
+        arena_enabled=False,
     ),
     # Baseten dedicated endpoints (Qwen3-TTS 1.7B). PENDING for the same reason
     # as the Whisper STT entry above — implemented, hidden, run manually.

--- a/runner/src/coval_bench/registries/provider_keys.py
+++ b/runner/src/coval_bench/registries/provider_keys.py
@@ -1,0 +1,35 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+"""Canonical provider → API-key environment variable map.
+
+The single place that ties each TTS provider to the environment variable that
+must hold its API key, so provider naming lives in exactly one auditable spot.
+Consumed by the cross-repo CI parity check (``scripts/check_arena_keys.py``),
+which asserts every arena-eligible provider's key is actually mounted on the
+benchmarks-api Cloud Run service in the ``coval-ai/benchmark-infra`` repo.
+
+Names must match the runner's ``Settings`` fields case-insensitively (e.g.
+``OPENAI_API_KEY`` ↔ ``settings.openai_api_key``) and the ``name`` of the
+secret-backed ``env`` blocks mounted in infra. The ``gradium`` entry is the one
+deliberate exception: the TTS client reads ``gradium_tts_api_key`` (there is a
+separate ``gradium_api_key`` for the STT provider), so it maps to
+``GRADIUM_TTS_API_KEY``.
+"""
+
+from __future__ import annotations
+
+PROVIDER_ENV: dict[str, str] = {
+    "openai": "OPENAI_API_KEY",
+    "cartesia": "CARTESIA_API_KEY",
+    "elevenlabs": "ELEVENLABS_API_KEY",
+    "deepgram": "DEEPGRAM_API_KEY",
+    "gradium": "GRADIUM_TTS_API_KEY",
+    "rime": "RIME_API_KEY",
+    "hume": "HUME_API_KEY",
+    "xai": "XAI_API_KEY",
+    "smallest": "SMALLEST_API_KEY",
+    "soniox": "SONIOX_API_KEY",
+    "inworld": "INWORLD_API_KEY",
+    "groq": "GROQ_API_KEY",
+    "baseten": "BASETEN_API_KEY",
+}

--- a/runner/tests/unit/test_arena_pairing.py
+++ b/runner/tests/unit/test_arena_pairing.py
@@ -11,9 +11,11 @@ from collections import Counter
 import pytest
 
 from coval_bench.arena.pairing import active_tts_models, select_pair
+from coval_bench.config import Settings
 from coval_bench.db.models import PairingRating
 from coval_bench.registries.benchmarks import Benchmark
 from coval_bench.registries.models import ModelStatus, RegisteredModel
+from coval_bench.registries.provider_keys import PROVIDER_ENV
 
 
 def _model(name: str) -> RegisteredModel:
@@ -138,3 +140,21 @@ def test_active_tts_models_are_tts_and_active() -> None:
     roster = active_tts_models()
     assert len(roster) >= 2
     assert all(m.benchmark is Benchmark.TTS and m.status is ModelStatus.ACTIVE for m in roster)
+
+
+def test_active_tts_models_excludes_arena_disabled() -> None:
+    assert all(m.arena_enabled for m in active_tts_models())
+
+
+def test_provider_env_covers_arena_providers() -> None:
+    # Only providers the arena can actually synthesize with (ACTIVE + arena_enabled),
+    # matching active_tts_models() and the parity script — not every non-retired one.
+    providers = {m.provider for m in active_tts_models()}
+    missing = providers - PROVIDER_ENV.keys()
+    assert not missing, f"arena providers with no PROVIDER_ENV entry: {sorted(missing)}"
+
+
+def test_provider_env_names_match_settings_fields() -> None:
+    fields = Settings.model_fields
+    bad = {env for env in PROVIDER_ENV.values() if env.lower() not in fields}
+    assert not bad, f"PROVIDER_ENV names with no Settings field: {sorted(bad)}"


### PR DESCRIPTION
A new TTS provider can be marked arena-active in this repo without its API key being mounted on benchmarks-api in benchmark-infra — today that only surfaces as a failed live battle. This catches the gap at PR time.

An `arena_enabled` flag on `RegisteredModel` decouples arena membership from dashboard `status` (default `True`, so every active TTS model is in the arena unless explicitly opted out — inworld and groq are opted out here). A single `PROVIDER_ENV` map is the source of truth for provider→key naming, guarded by tests that fail if an arena provider has no entry or a name drifts from `Settings`. A path-filtered workflow runs only when the TTS provider registry changes: it reads what benchmark-infra mounts on the Cloud Run service and fails the PR if an arena-eligible provider's key isn't there, naming exactly where to add it.

There is deliberately no runtime credential filter. A missing key still surfaces as a 502 on the live battle path (unchanged behavior) — the CI check is the mitigation, catching the missing mount at PR time rather than in a live battle. It's a visible signal on provider PRs today, not a required merge gate; making it hard-block would need a ruleset change.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds an `arena_enabled` flag to `RegisteredModel` to decouple arena membership from dashboard `status`, introduces `PROVIDER_ENV` as the single source of truth for provider → API-key name mapping, and wires a new path-filtered CI workflow that cross-checks the arena roster against what the benchmark-infra Cloud Run service actually mounts.

- `active_tts_models()` is narrowed to require `arena_enabled=True`, three `ACTIVE` models that lack mounted keys are explicitly opted out, and a new `provider_keys.py` module maps every provider to its expected env-var name.
- `check_arena_keys.py` parses the infra Terraform file (fetched via `gh api`) and fails if any arena-eligible provider's key is absent; the workflow degrades gracefully to a warning (not an error) when the infra token is unavailable so fork PRs are not hard-blocked.
- Unit tests guard against `PROVIDER_ENV` drift from both the active roster and `Settings` field names.

<h3>Confidence Score: 4/5</h3>

Safe to merge with awareness that the seed path and runtime filtering gaps noted in earlier review threads remain open.

The structural changes are well-contained and the new tests provide good coverage of the registry/key-map invariants. The two issues flagged in earlier review rounds — seed_demo_battles calling select_pair without first checking that the roster has at least two models, and active_tts_models having no runtime key-based filtering despite the PR description promising it — are still unresolved in the current code, and both affect live arena paths when keys are missing.

runner/src/coval_bench/arena/seed.py and runner/src/coval_bench/arena/pairing.py carry the open issues from the earlier review; the new files (provider_keys.py, check_arena_keys.py, the workflow) look correct.

<sub>Reviews (5): Last reviewed commit: ["Gate arena TTS providers on mounted API ..."](https://github.com/coval-ai/benchmarks/commit/1030d6263b0b286c23b8b5c6b4f89b42e0a7c9ff) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41200956)</sub>

<!-- /greptile_comment -->