### PR TITLE
Add AssemblyAI Universal-3 Pro to the STT benchmark

### DIFF
--- a/runner/src/coval_bench/providers/stt/assemblyai.py
+++ b/runner/src/coval_bench/providers/stt/assemblyai.py
@@ -41,7 +41,11 @@ _WS_BASE = "wss://streaming.assemblyai.com/v3/ws"
 # 1.0 = pure VAD silence-latency mode: the model never declares end-of-turn on a
 # semantic guess, only on our ForceEndpoint at speech-end (TTFS parity). A lower
 # value could let a confident short utterance auto-finalize before our signal.
+# universal-3-pro (u3-rt-pro) has no such param — it uses punctuation/silence
+# turn detection (min_turn_silence/max_turn_silence); we keep its defaults and
+# rely on ForceEndpoint, which is supported across all models.
 _END_OF_TURN_CONFIDENCE_THRESHOLD = 1.0
+_NO_EOT_THRESHOLD_MODELS = frozenset({"universal-3-pro"})
 
 # After ForceEndpoint, wait this long for the forced final before sending Terminate,
 # so the close never races the final (the WS close-gate bug class). Falls through on
@@ -87,10 +91,9 @@ class AssemblyAIProvider(STTProvider):
 
         try:
             speech_model = _SPEECH_MODEL_MAP[self._model]
-            url = (
-                f"{_WS_BASE}?sample_rate={sample_rate}&speech_model={speech_model}"
-                f"&end_of_turn_confidence_threshold={_END_OF_TURN_CONFIDENCE_THRESHOLD}"
-            )
+            url = f"{_WS_BASE}?sample_rate={sample_rate}&speech_model={speech_model}"
+            if self._model not in _NO_EOT_THRESHOLD_MODELS:
+                url += f"&end_of_turn_confidence_threshold={_END_OF_TURN_CONFIDENCE_THRESHOLD}"
             headers = {"Authorization": self._api_key.get_secret_value()}
             final_event = asyncio.Event()
             async with ws_client.connect(url, additional_headers=headers) as ws:

--- a/runner/src/coval_bench/providers/stt/assemblyai.py
+++ b/runner/src/coval_bench/providers/stt/assemblyai.py
@@ -3,7 +3,8 @@
 
 """AssemblyAI real-time STT provider (v3 streaming API).
 
-Models: universal-streaming, universal-streaming-multilingual, universal-3.5-pro
+Models: universal-streaming, universal-streaming-multilingual, universal-3-pro,
+universal-3.5-pro
 Wire protocol: WebSocket, wss://streaming.assemblyai.com/v3/ws
 Auth: Authorization: <key>
 Close: {"type": "Terminate"}
@@ -32,6 +33,7 @@ logger = structlog.get_logger(__name__)
 _SPEECH_MODEL_MAP: dict[str, str] = {
     "universal-streaming": "universal-streaming-english",
     "universal-streaming-multilingual": "universal-streaming-multilingual",
+    "universal-3-pro": "u3-rt-pro",
     "universal-3.5-pro": "universal-3-5-pro",
 }
 _WS_BASE = "wss://streaming.assemblyai.com/v3/ws"

--- a/runner/src/coval_bench/registries/models.py
+++ b/runner/src/coval_bench/registries/models.py
@@ -159,6 +159,14 @@ MODEL_REGISTRY: list[RegisteredModel] = [
     RegisteredModel(
         benchmark=_STT,
         provider="assemblyai",
+        model="universal-3-pro",
+        tags=(_REALTIME, _MULTI, _VAD, _DIAR, _CODESW, _KEYTERM),
+        self_hostable=True,
+        status=_ACTIVE,
+    ),
+    RegisteredModel(
+        benchmark=_STT,
+        provider="assemblyai",
         model="universal-3.5-pro",
         tags=(_REALTIME, _MULTI, _VAD, _DIAR, _CODESW, _KEYTERM),
         self_hostable=True,

--- a/runner/tests/providers/stt/test_assemblyai.py
+++ b/runner/tests/providers/stt/test_assemblyai.py
@@ -153,6 +153,7 @@ async def test_universal_3_5_pro_url_uses_api_speech_model(fake_api_key: SecretS
 
     url = mock_connect.call_args.args[0]
     assert "speech_model=universal-3-5-pro" in url
+    assert "end_of_turn_confidence_threshold=1.0" in url
 
 
 @pytest.mark.asyncio
@@ -177,6 +178,9 @@ async def test_universal_3_pro_url_uses_api_speech_model(fake_api_key: SecretStr
 
     url = mock_connect.call_args.args[0]
     assert "speech_model=u3-rt-pro" in url
+    # u3-rt-pro uses punctuation/silence turn detection; the legacy confidence
+    # param does not exist on it and must not be sent.
+    assert "end_of_turn_confidence_threshold" not in url
 
 
 @pytest.mark.asyncio

--- a/runner/tests/providers/stt/test_assemblyai.py
+++ b/runner/tests/providers/stt/test_assemblyai.py
@@ -121,6 +121,11 @@ def test_provider_name_universal_3_5_pro() -> None:
     assert p.name == "assemblyai-universal-3.5-pro"
 
 
+def test_provider_name_universal_3_pro() -> None:
+    p = AssemblyAIProvider(api_key=SecretStr("k"), model="universal-3-pro")
+    assert p.name == "assemblyai-universal-3-pro"
+
+
 def test_provider_name_universal_streaming_multilingual() -> None:
     p = AssemblyAIProvider(api_key=SecretStr("k"), model="universal-streaming-multilingual")
     assert p.name == "assemblyai-universal-streaming-multilingual"
@@ -148,6 +153,30 @@ async def test_universal_3_5_pro_url_uses_api_speech_model(fake_api_key: SecretS
 
     url = mock_connect.call_args.args[0]
     assert "speech_model=universal-3-5-pro" in url
+
+
+@pytest.mark.asyncio
+async def test_universal_3_pro_url_uses_api_speech_model(fake_api_key: SecretStr) -> None:
+    """universal-3-pro maps to the API's u3-rt-pro speech_model value."""
+    ws = FakeWebSocket([{"type": "Turn", "end_of_turn": True, "transcript": "hi"}])
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=ws)
+    cm.__aexit__ = AsyncMock(return_value=False)
+    provider = AssemblyAIProvider(api_key=fake_api_key, model="universal-3-pro")
+
+    with patch(
+        "coval_bench.providers.stt.assemblyai.ws_client.connect", return_value=cm
+    ) as mock_connect:
+        await provider.measure_ttft(
+            audio_data=b"\x00" * 640,
+            channels=1,
+            sample_width=2,
+            sample_rate=16000,
+            realtime_resolution=0.01,
+        )
+
+    url = mock_connect.call_args.args[0]
+    assert "speech_model=u3-rt-pro" in url
 
 
 @pytest.mark.asyncio

--- a/web/lib/config/colors.ts
+++ b/web/lib/config/colors.ts
@@ -48,6 +48,7 @@ export const modelColors: Record<string, string> = {
   // AssemblyAI — amethyst family (#8E44AD).
   "universal-streaming": "#8E44AD",
   "universal-streaming-multilingual": "#A569BD",
+  "universal-3-pro": "#7D3C98",
   "universal-3.5-pro": "#6C3483",
 
   // Speechmatics — navy family (#21618C).

--- a/web/lib/utils/formatters.ts
+++ b/web/lib/utils/formatters.ts
@@ -121,6 +121,7 @@ export function normalizeModelName(modelKey: string): string {
     "gpt-4o-mini-transcribe": "GPT-4o mini Transcribe",
     "universal-streaming": "Universal Streaming",
     "universal-streaming-multilingual": "Universal Streaming Multilingual",
+    "universal-3-pro": "Universal 3 Pro",
     "universal-3.5-pro": "Universal 3.5 Pro",
     "ink-2": "Ink 2",
     "inworld-stt-1": "STT 1",


### PR DESCRIPTION
Maps universal-3-pro to the u3-rt-pro streaming speech model and registers it active alongside the existing Universal models.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds AssemblyAI's `universal-3-pro` model to the STT benchmark by mapping it to the `u3-rt-pro` streaming API endpoint and registering it as an active model.

- Adds `"universal-3-pro": "u3-rt-pro"` to `_SPEECH_MODEL_MAP` and introduces `_NO_EOT_THRESHOLD_MODELS` to suppress the `end_of_turn_confidence_threshold` query param that `u3-rt-pro` does not support, with a matching URL-construction guard in `measure_ttft`.
- Registers `universal-3-pro` in the model registry with the same capability tags as `universal-3.5-pro`, and adds display name and color entries in the web layer.

<h3>Confidence Score: 5/5</h3>

This PR is safe to merge; all changes are additive and isolated to the new model entry.

The change is narrow and well-contained: a new model mapping, a conditional URL parameter guard, matching registry/color/formatter entries, and dedicated tests that verify both the correct speech_model value and the absence of the unsupported confidence-threshold param. No existing paths are altered beyond the additional assertion on the 3.5-pro test.

No files require special attention.

<sub>Reviews (2): Last reviewed commit: ["Skip the legacy end-of-turn threshold fo..."](https://github.com/coval-ai/benchmarks/commit/ef7acbc4b78de4d72d53e02e38e16166ca80ee85) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41431043)</sub>

<!-- /greptile_comment -->