### PR TITLE
Strip whitespace from provider keys at load

### DIFF
--- a/runner/src/coval_bench/config.py
+++ b/runner/src/coval_bench/config.py
@@ -12,10 +12,17 @@ from __future__ import annotations
 
 import functools
 from pathlib import Path
-from typing import Literal
+from typing import Annotated, Literal
 
-from pydantic import Field, SecretStr
+from pydantic import BeforeValidator, Field, SecretStr
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+def _strip_whitespace(value: object) -> object:
+    return value.strip() if isinstance(value, str) else value
+
+
+StrippedSecretStr = Annotated[SecretStr, BeforeValidator(_strip_whitespace)]
 
 
 class Settings(BaseSettings):
@@ -60,23 +67,23 @@ class Settings(BaseSettings):
     schedule_period_seconds: int = Field(default=1800, gt=0)
 
     # --- Provider API keys (all optional; loaded from Secret Manager at runtime) ---
-    openai_api_key: SecretStr | None = None
-    elevenlabs_api_key: SecretStr | None = None
-    cartesia_api_key: SecretStr | None = None
-    deepgram_api_key: SecretStr | None = None
-    assemblyai_api_key: SecretStr | None = None
-    speechmatics_api_key: SecretStr | None = None
-    hume_api_key: SecretStr | None = None
-    rime_api_key: SecretStr | None = None
-    gladia_api_key: SecretStr | None = None
-    gradium_api_key: SecretStr | None = None
-    gradium_tts_api_key: SecretStr | None = None
-    xai_api_key: SecretStr | None = None
-    groq_api_key: SecretStr | None = None
-    smallest_api_key: SecretStr | None = None
-    inworld_api_key: SecretStr | None = None
-    soniox_api_key: SecretStr | None = None
-    baseten_api_key: SecretStr | None = None
+    openai_api_key: StrippedSecretStr | None = None
+    elevenlabs_api_key: StrippedSecretStr | None = None
+    cartesia_api_key: StrippedSecretStr | None = None
+    deepgram_api_key: StrippedSecretStr | None = None
+    assemblyai_api_key: StrippedSecretStr | None = None
+    speechmatics_api_key: StrippedSecretStr | None = None
+    hume_api_key: StrippedSecretStr | None = None
+    rime_api_key: StrippedSecretStr | None = None
+    gladia_api_key: StrippedSecretStr | None = None
+    gradium_api_key: StrippedSecretStr | None = None
+    gradium_tts_api_key: StrippedSecretStr | None = None
+    xai_api_key: StrippedSecretStr | None = None
+    groq_api_key: StrippedSecretStr | None = None
+    smallest_api_key: StrippedSecretStr | None = None
+    inworld_api_key: StrippedSecretStr | None = None
+    soniox_api_key: StrippedSecretStr | None = None
+    baseten_api_key: StrippedSecretStr | None = None
 
     # Baseten dedicated-endpoint WebSocket URLs. The hostnames embed private,
     # pre-launch model ids, so they live in config (``.env`` locally, Secret
@@ -113,7 +120,7 @@ class Settings(BaseSettings):
     rate_limit_per_minute: int = 60
 
     # --- Arena ---
-    arena_labeler_key: SecretStr | None = None
+    arena_labeler_key: StrippedSecretStr | None = None
     arena_audio_dir: Path = Path("arena-audio")
     arena_audio_base_url: str = ""
     arena_gcs_bucket: str = ""

--- a/runner/tests/unit/test_config.py
+++ b/runner/tests/unit/test_config.py
@@ -1,0 +1,22 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for Settings loading."""
+
+from __future__ import annotations
+
+import pytest
+
+from coval_bench.config import Settings
+
+
+def test_provider_keys_strip_surrounding_whitespace(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("INWORLD_API_KEY", "abc123\n")
+    monkeypatch.setenv("OPENAI_API_KEY", " sk-test ")
+
+    settings = Settings()
+
+    assert settings.inworld_api_key is not None
+    assert settings.inworld_api_key.get_secret_value() == "abc123"
+    assert settings.openai_api_key is not None
+    assert settings.openai_api_key.get_secret_value() == "sk-test"


### PR DESCRIPTION
A trailing newline in a Secret Manager version took Inworld down in prod; strip keys in Settings so a sloppy secret can't do that again.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Introduces a `StrippedSecretStr` type alias — `Annotated[SecretStr, BeforeValidator(_strip_whitespace)]` — and applies it to all 18 provider API key fields and `arena_labeler_key` in `Settings`, so whitespace in secrets loaded from Secret Manager is silently trimmed before use.

- Adds `_strip_whitespace` as a Pydantic `BeforeValidator` that no-ops on non-strings (safe for `None` optional fields) and strips surrounding whitespace from strings before `SecretStr` wraps them.
- Migrates every `SecretStr | None` field in `Settings` to `StrippedSecretStr | None` in one sweep, ensuring consistent behaviour across all providers.
- Adds a focused unit test via `monkeypatch.setenv` verifying both trailing newline (`"abc123\n"`) and leading/trailing spaces (`" sk-test "`) are stripped on load.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a non-breaking, additive whitespace guard on secret fields that is thoroughly applied and tested.

The validator is minimal and correctly short-circuits for non-string values, so optional None fields are unaffected. Every SecretStr field in Settings has been updated consistently, and the new unit test confirms the expected trimming behaviour for both newline and space variants.

No files require special attention.

<sub>Reviews (2): Last reviewed commit: ["Strip whitespace from provider keys at l..."](https://github.com/coval-ai/benchmarks/commit/2b51a4802fa7db343235ab4d486f1e98290c2968) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41453084)</sub>

<!-- /greptile_comment -->