### PR TITLE
Fix Deepgram Flux never finalizing

### DIFF
--- a/runner/src/coval_bench/providers/stt/deepgram.py
+++ b/runner/src/coval_bench/providers/stt/deepgram.py
@@ -33,6 +33,9 @@ logger = structlog.get_logger(__name__)
 # timeout — the outer per-item timeout still bounds the run.
 _FINAL_WAIT_S = 5.0
 
+# Cap on trailing silence fed to Flux while waiting for EndOfTurn.
+_FLUX_EOT_SILENCE_S = 5.0
+
 
 class DeepgramProvider(STTProvider):
     """Deepgram streaming STT provider."""
@@ -170,10 +173,17 @@ class DeepgramProvider(STTProvider):
             async for chunk, start in paced_chunks(audio_data, chunk_size, byte_rate):
                 result.audio_start_time = start
                 await ws.send(chunk)
-            # nova finalizes on our signal (endpointing disabled): send Finalize, then
-            # wait for the forced final before closing so the close can't race it. Flux
-            # has no Finalize and can't be forced, so it's left on its native EOT.
-            if not self._model.startswith("flux-"):
+            if self._model.startswith("flux-"):
+                # Clear so a mid-clip EndOfTurn can't cut the silence short.
+                final_event.clear()
+                silence = bytes(int(byte_rate * _FLUX_EOT_SILENCE_S))
+                async for chunk, _ in paced_chunks(silence, chunk_size, byte_rate):
+                    if final_event.is_set():
+                        break
+                    await ws.send(chunk)
+            else:
+                # nova finalizes on our signal (endpointing disabled): send Finalize, then
+                # wait for the forced final before closing so the close can't race it.
                 # Clear first: nova can emit an is_final segment mid-stream, which would
                 # leave the latch set and make the wait a no-op.
                 final_event.clear()
@@ -248,6 +258,7 @@ class DeepgramProvider(STTProvider):
                     # EndOfTurn is the confirmed turn-final; Start/Update are partials.
                     if msg.get("event") == "EndOfTurn":
                         last_final_time = now
+                        final_event.set()
                     continue
 
                 transcript = self._extract_transcript(msg)

--- a/runner/tests/providers/stt/conftest.py
+++ b/runner/tests/providers/stt/conftest.py
@@ -125,6 +125,7 @@ _REAL_SLEEP = asyncio.sleep
 _WAIT_PATCHES = (
     "coval_bench.providers.stt.assemblyai._FINAL_WAIT_S",
     "coval_bench.providers.stt.deepgram._FINAL_WAIT_S",
+    "coval_bench.providers.stt.deepgram._FLUX_EOT_SILENCE_S",
     "coval_bench.providers.stt.xai._FINAL_WAIT_S",
     "coval_bench.providers.stt.gradium._FLUSH_WAIT_S",
 )

--- a/runner/tests/providers/stt/test_deepgram.py
+++ b/runner/tests/providers/stt/test_deepgram.py
@@ -8,6 +8,8 @@ All tests use FakeWebSocket — no live network calls are made.
 
 from __future__ import annotations
 
+import asyncio
+import json
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -158,17 +160,19 @@ async def test_nova_sends_finalize_before_close(fake_api_key: SecretStr) -> None
 
 
 @pytest.mark.asyncio
-async def test_flux_does_not_send_finalize(fake_api_key: SecretStr, audio_pcm_bytes: bytes) -> None:
+async def test_flux_does_not_send_finalize(fake_api_key: SecretStr) -> None:
+    """flux: no Finalize; with no EndOfTurn, silence streams to the cap, then close."""
     sent: list[Any] = []
     ws = FakeWebSocket([], on_send=sent.append)
     cm = MagicMock()
     cm.__aenter__ = AsyncMock(return_value=ws)
     cm.__aexit__ = AsyncMock(return_value=False)
     provider = DeepgramProvider(api_key=fake_api_key, model="flux-general-en")
+    audio = b"\x01" * 640
 
     with patch("coval_bench.providers.stt.deepgram.ws_client.connect", return_value=cm):
         await provider.measure_ttft(
-            audio_data=audio_pcm_bytes,
+            audio_data=audio,
             channels=1,
             sample_width=2,
             sample_rate=16000,
@@ -178,6 +182,70 @@ async def test_flux_does_not_send_finalize(fake_api_key: SecretStr, audio_pcm_by
     text = [m for m in sent if isinstance(m, str)]
     assert not any("Finalize" in m for m in text)
     assert '"CloseStream"' in text[-1]
+    assert any(isinstance(m, bytes) and set(m) == {0} for m in sent)
+
+
+class _EndOfTurnOnSilenceWS:
+    """Fake WS that emits EndOfTurn only once trailing silence starts arriving."""
+
+    def __init__(self, audio_len: int) -> None:
+        self.sent: list[Any] = []
+        self._audio_len = audio_len
+        self._bytes_seen = 0
+        self._queue: asyncio.Queue[str | None] = asyncio.Queue()
+
+    async def send(self, msg: Any) -> None:
+        self.sent.append(msg)
+        if isinstance(msg, bytes):
+            before = self._bytes_seen
+            self._bytes_seen += len(msg)
+            if before < self._audio_len <= self._bytes_seen:
+                turn = {"type": "TurnInfo", "event": "Update", "turn_index": 0}
+                self._queue.put_nowait(json.dumps({**turn, "transcript": "hello world"}))
+            elif before >= self._audio_len:
+                turn = {"type": "TurnInfo", "event": "EndOfTurn", "turn_index": 0}
+                self._queue.put_nowait(json.dumps({**turn, "transcript": "hello world"}))
+        elif isinstance(msg, str) and "CloseStream" in msg:
+            self._queue.put_nowait(None)
+
+    def __aiter__(self) -> _EndOfTurnOnSilenceWS:
+        return self
+
+    async def __anext__(self) -> str:
+        item = await self._queue.get()
+        if item is None:
+            raise StopAsyncIteration
+        return item
+
+
+@pytest.mark.asyncio
+async def test_flux_stops_silence_on_end_of_turn(
+    fake_api_key: SecretStr, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """flux: trailing silence stops at EndOfTurn instead of running out the cap."""
+    monkeypatch.setattr("coval_bench.providers.stt.deepgram._FLUX_EOT_SILENCE_S", 5.0)
+    audio = b"\x01" * 640
+    ws = _EndOfTurnOnSilenceWS(audio_len=len(audio))
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=ws)
+    cm.__aexit__ = AsyncMock(return_value=False)
+    provider = DeepgramProvider(api_key=fake_api_key, model="flux-general-en")
+
+    with patch("coval_bench.providers.stt.deepgram.ws_client.connect", return_value=cm):
+        result = await provider.measure_ttft(
+            audio_data=audio,
+            channels=1,
+            sample_width=2,
+            sample_rate=16000,
+            realtime_resolution=0.01,
+        )
+
+    assert result.error is None
+    assert result.audio_to_final_seconds is not None
+    assert result.complete_transcript == "hello world"
+    silence_bytes = sum(len(m) for m in ws.sent if isinstance(m, bytes)) - len(audio)
+    assert 0 < silence_bytes < 16000
+    assert isinstance(ws.sent[-1], str) and "CloseStream" in ws.sent[-1]
 
 
 def test_build_websocket_url_flux_rejects_non_mono() -> None:

--- a/runner/tests/providers/stt/test_deepgram.py
+++ b/runner/tests/providers/stt/test_deepgram.py
@@ -16,6 +16,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from pydantic import SecretStr
 
+from coval_bench.providers.stt import deepgram as deepgram_mod
 from coval_bench.providers.stt.deepgram import DeepgramProvider
 from tests.providers.stt.conftest import FakeWebSocket, load_fixture_events  # noqa: E402
 
@@ -185,12 +186,13 @@ async def test_flux_does_not_send_finalize(fake_api_key: SecretStr) -> None:
     assert any(isinstance(m, bytes) and set(m) == {0} for m in sent)
 
 
-class _EndOfTurnOnSilenceWS:
-    """Fake WS that emits EndOfTurn only once trailing silence starts arriving."""
+class _TurnEventWS:
+    """Fake WS that emits an EndOfTurn keyed to how many audio bytes have arrived."""
 
-    def __init__(self, audio_len: int) -> None:
+    def __init__(self, audio_len: int, eot_after: int) -> None:
         self.sent: list[Any] = []
         self._audio_len = audio_len
+        self._eot_after = eot_after
         self._bytes_seen = 0
         self._queue: asyncio.Queue[str | None] = asyncio.Queue()
 
@@ -202,13 +204,13 @@ class _EndOfTurnOnSilenceWS:
             if before < self._audio_len <= self._bytes_seen:
                 turn = {"type": "TurnInfo", "event": "Update", "turn_index": 0}
                 self._queue.put_nowait(json.dumps({**turn, "transcript": "hello world"}))
-            elif before >= self._audio_len:
+            if before < self._eot_after <= self._bytes_seen:
                 turn = {"type": "TurnInfo", "event": "EndOfTurn", "turn_index": 0}
                 self._queue.put_nowait(json.dumps({**turn, "transcript": "hello world"}))
         elif isinstance(msg, str) and "CloseStream" in msg:
             self._queue.put_nowait(None)
 
-    def __aiter__(self) -> _EndOfTurnOnSilenceWS:
+    def __aiter__(self) -> _TurnEventWS:
         return self
 
     async def __anext__(self) -> str:
@@ -225,7 +227,7 @@ async def test_flux_stops_silence_on_end_of_turn(
     """flux: trailing silence stops at EndOfTurn instead of running out the cap."""
     monkeypatch.setattr("coval_bench.providers.stt.deepgram._FLUX_EOT_SILENCE_S", 5.0)
     audio = b"\x01" * 640
-    ws = _EndOfTurnOnSilenceWS(audio_len=len(audio))
+    ws = _TurnEventWS(audio_len=len(audio), eot_after=len(audio) + 1)
     cm = MagicMock()
     cm.__aenter__ = AsyncMock(return_value=ws)
     cm.__aexit__ = AsyncMock(return_value=False)
@@ -245,6 +247,33 @@ async def test_flux_stops_silence_on_end_of_turn(
     assert result.complete_transcript == "hello world"
     silence_bytes = sum(len(m) for m in ws.sent if isinstance(m, bytes)) - len(audio)
     assert 0 < silence_bytes < 16000
+    assert isinstance(ws.sent[-1], str) and "CloseStream" in ws.sent[-1]
+
+
+@pytest.mark.asyncio
+async def test_flux_mid_clip_end_of_turn_does_not_cut_silence_short(
+    fake_api_key: SecretStr,
+) -> None:
+    """flux: an EndOfTurn during the audio must not skip the trailing silence."""
+    audio = b"\x01" * 640
+    ws = _TurnEventWS(audio_len=len(audio), eot_after=1)
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=ws)
+    cm.__aexit__ = AsyncMock(return_value=False)
+    provider = DeepgramProvider(api_key=fake_api_key, model="flux-general-en")
+
+    with patch("coval_bench.providers.stt.deepgram.ws_client.connect", return_value=cm):
+        result = await provider.measure_ttft(
+            audio_data=audio,
+            channels=1,
+            sample_width=2,
+            sample_rate=16000,
+            realtime_resolution=0.01,
+        )
+
+    silence_bytes = sum(len(m) for m in ws.sent if isinstance(m, bytes)) - len(audio)
+    assert silence_bytes == int(32000 * deepgram_mod._FLUX_EOT_SILENCE_S)
+    assert result.audio_to_final_seconds is not None
     assert isinstance(ws.sent[-1], str) and "CloseStream" in ws.sent[-1]
 
 


### PR DESCRIPTION
Flux only advances turn detection on incoming audio, so stream paced trailing silence after the speech-end-trimmed clip until its native EndOfTurn fires instead of closing immediately.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes Deepgram Flux models never producing a final transcription result. The root cause was twofold: `final_event.set()` was never called on `EndOfTurn` (so the send task had no signal), and Flux only advances its turn-detection model when new audio arrives (so stopping sends immediately left it in a perpetual partial state).

- **`deepgram.py`**: After the speech clip ends, a buffer of zero-byte silence (`_FLUX_EOT_SILENCE_S` seconds, capped) is streamed at real-time pace; the loop breaks early if `EndOfTurn` fires. `final_event.clear()` is called immediately before the silence loop to prevent a mid-clip `EndOfTurn` from skipping it. `final_event.set()` is now correctly called on `EndOfTurn` in `_receive`.
- **`conftest.py`**: `_FLUX_EOT_SILENCE_S` is added to the `_WAIT_PATCHES` tuple so the autouse `_fast_streaming` fixture patches it to 50 ms, keeping test runtime fast.
- **`test_deepgram.py`**: Three new tests cover the no-EndOfTurn silence-to-cap path, early silence termination on EndOfTurn, and the mid-clip EndOfTurn guard — using a new queue-based `_TurnEventWS` fake that emits events keyed to cumulative bytes received.

<h3>Confidence Score: 5/5</h3>

Safe to merge. The change is well-scoped to Flux models, nova behaviour is unchanged, and all three new tests exercise the critical edge cases.

The fix is minimal and targeted: two small additions to _send_audio (silence loop + final_event.clear()) and one line added to _receive (final_event.set() on EndOfTurn). The final_event.clear() before the silence loop is the key guard preventing a mid-clip EndOfTurn from cutting silence short, and the analysis confirms no await point exists between clear() and the first is_set() check in the silence loop — the protection is race-free. Test coverage is thorough and the conftest patch prevents any real-time delays from slipping into the suite.

No files require special attention.

<sub>Reviews (2): Last reviewed commit: ["Cover the mid-clip EndOfTurn path in the..."](https://github.com/coval-ai/benchmarks/commit/32ae89262d4192a13bc138257d6771973937b2b9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41501316)</sub>

<!-- /greptile_comment -->