### PR TITLE
Add standardized dataset builder framework

### DIFF
--- a/runner/pyproject.toml
+++ b/runner/pyproject.toml
@@ -46,6 +46,7 @@ dependencies = [
 [project.optional-dependencies]
 google-stt = ["google-cloud-speech>=2.27"]
 hume-tts = ["hume>=0.7"]
+hf-parquet = ["pyarrow>=17"]  # build-time only: parquet fallback for unconverted HF datasets
 
 [project.scripts]
 coval-bench = "coval_bench.__main__:cli"
@@ -110,6 +111,10 @@ ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
 module = "scipy.*"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "pyarrow.*"
 ignore_missing_imports = true
 
 [[tool.mypy.overrides]]

--- a/runner/pyproject.toml
+++ b/runner/pyproject.toml
@@ -49,6 +49,7 @@ hume-tts = ["hume>=0.7"]
 
 [project.scripts]
 coval-bench = "coval_bench.__main__:cli"
+coval-build-dataset = "coval_bench.datasets.scripts.build:build"
 
 [dependency-groups]
 dev = [

--- a/runner/src/coval_bench/datasets/scripts/build.py
+++ b/runner/src/coval_bench/datasets/scripts/build.py
@@ -15,6 +15,8 @@ from __future__ import annotations
 
 import importlib.util
 import logging
+import re
+import shutil
 import sys
 from collections.abc import Callable
 from pathlib import Path
@@ -45,8 +47,18 @@ def _configure_logging() -> None:
 
 
 def _meta_dim(col: str) -> Callable[[Clip], object]:
-    """A balance-dimension accessor for meta column *col* (None when absent/empty)."""
-    return lambda clip: clip.meta.get(col) or None
+    """Balance-dimension accessor for meta column *col*.
+
+    Only genuinely missing/blank values count as untagged (``None``). ``False`` and
+    ``0`` are real values and are kept, so balancing on a boolean/numeric column
+    doesn't silently drop every ``False``/``0`` clip.
+    """
+
+    def dim(clip: Clip) -> object:
+        value = clip.meta.get(col)
+        return None if value is None or value == "" else value
+
+    return dim
 
 
 def _load_adapter_spec(name: str) -> DatasetSpec | None:
@@ -130,6 +142,8 @@ def _hf_spec(
     handwritten adapter only when neither can resolve it.
     """
     ds_id = dataset_id or f"{hf_path.split('/')[-1].lower()}-v1"
+    if not re.fullmatch(r"[A-Za-z0-9._-]+", ds_id):
+        raise click.UsageError(f"invalid dataset id {ds_id!r}: use letters, digits, '.', '_', '-'")
     download, parse, fetch = _resolve_hooks(
         hf_path, ds_id, config=config, split=split, audio_col=audio_col, text_col=text_col
     )
@@ -177,6 +191,12 @@ def _hf_spec(
     default=False,
     help="Overwrite existing GCS objects / manifest (off by default — v1 freeze).",
 )
+@click.option(
+    "--keep-cache/--no-keep-cache",
+    default=False,
+    show_default=True,
+    help="Keep the downloaded source after building; default deletes it to reclaim disk.",
+)
 def build(
     dataset: str | None,
     hf_path: str | None,
@@ -192,37 +212,45 @@ def build(
     dry_run: bool,
     bucket: str,
     overwrite: bool,
+    keep_cache: bool,
 ) -> None:
     """Build a dataset through the standardized framework and write its manifest."""
     _configure_logging()
-    if hf_path:
-        spec = _hf_spec(
-            hf_path,
-            config=config,
-            split=split,
-            audio_col=audio_col,
-            text_col=text_col,
-            balance_cols=balance_cols,
-            num=num,
-            dur_min=dur_min,
-            dur_max=dur_max,
-            dataset_id=dataset_id,
-        )
-    elif dataset and dataset in _SPECS:
-        spec = _SPECS[dataset]
-    elif dataset and (adapter := _load_adapter_spec(dataset)) is not None:
-        spec = adapter
-    else:
-        raise click.UsageError(
-            f"pass --hf <path>, a registered dataset {sorted(_SPECS)}, or a scaffolded adapter name"
-        )
-    run_build(
-        spec,
-        bucket=bucket,
-        dry_run=dry_run,
-        overwrite=overwrite,
-        cache_root=_CACHE_ROOT / spec.cache_name,
-    )
+    try:
+        if hf_path:
+            spec = _hf_spec(
+                hf_path,
+                config=config,
+                split=split,
+                audio_col=audio_col,
+                text_col=text_col,
+                balance_cols=balance_cols,
+                num=num,
+                dur_min=dur_min,
+                dur_max=dur_max,
+                dataset_id=dataset_id,
+            )
+        elif dataset and dataset in _SPECS:
+            spec = _SPECS[dataset]
+        elif dataset and (adapter := _load_adapter_spec(dataset)) is not None:
+            spec = adapter
+        else:
+            raise click.UsageError(
+                f"pass --hf <path>, a registered dataset {sorted(_SPECS)}, or an adapter name"
+            )
+        cache_root = _CACHE_ROOT / spec.cache_name
+        try:
+            run_build(
+                spec, bucket=bucket, dry_run=dry_run, overwrite=overwrite, cache_root=cache_root
+            )
+        finally:
+            if not keep_cache:
+                shutil.rmtree(cache_root, ignore_errors=True)  # reclaim the downloaded gigabytes
+    except hf_source.HFNetworkError as exc:
+        raise click.ClickException(
+            f"Network error: {exc}\nCheck your connection and re-run:\n"
+            f"  coval-build-dataset {' '.join(sys.argv[1:])}"
+        ) from exc
 
 
 if __name__ == "__main__":

--- a/runner/src/coval_bench/datasets/scripts/build.py
+++ b/runner/src/coval_bench/datasets/scripts/build.py
@@ -243,6 +243,12 @@ def build(
             run_build(
                 spec, bucket=bucket, dry_run=dry_run, overwrite=overwrite, cache_root=cache_root
             )
+        except (hf_source.HFUnsupported, hf_source.HFAmbiguous) as exc:
+            # The parquet source detects columns / duration inside parse(), i.e. during
+            # run_build; scaffold a handwritten adapter just as the resolve path does.
+            if hf_path:
+                _scaffold_and_exit(hf_path, spec.dataset_id, str(exc))
+            raise
         finally:
             if not keep_cache:
                 shutil.rmtree(cache_root, ignore_errors=True)  # reclaim the downloaded gigabytes

--- a/runner/src/coval_bench/datasets/scripts/build.py
+++ b/runner/src/coval_bench/datasets/scripts/build.py
@@ -62,6 +62,54 @@ def _load_adapter_spec(name: str) -> DatasetSpec | None:
     return cast(DatasetSpec, module.SPEC)
 
 
+_HookTriple = tuple[
+    Callable[[Path], Path], Callable[[Path], list[Clip]], Callable[[list[Clip]], None] | None
+]
+
+
+def _scaffold_and_exit(hf_path: str, ds_id: str, reason: str) -> None:
+    """Write a starter adapter and abort with instructions (unresolvable dataset)."""
+    _ADAPTERS_DIR.mkdir(parents=True, exist_ok=True)
+    dest = _ADAPTERS_DIR / f"{ds_id}.py"
+    hf_source.scaffold_adapter(hf_path, dest, detected=reason)
+    raise click.UsageError(
+        f"{reason}\nScaffolded {dest} — complete it, then run: coval-build-dataset {ds_id}"
+    )
+
+
+def _resolve_hooks(
+    hf_path: str,
+    ds_id: str,
+    *,
+    config: str | None,
+    split: str | None,
+    audio_col: str | None,
+    text_col: str | None,
+) -> _HookTriple:
+    """(download, parse, fetch) via the REST API, falling back to repo parquet."""
+    try:
+        config, splits = hf_source.resolve_splits(hf_path, config=config, split=split)
+        acol, tcol, dcol = hf_source.detect_columns(
+            hf_path, config, splits[0], audio_col=audio_col, text_col=text_col
+        )
+        return hf_source.make_source(hf_path, config, splits, acol, tcol, dcol)
+    except hf_source.HFNeedsChoice as exc:
+        raise click.UsageError(str(exc)) from exc
+    except hf_source.HFUnsupported as rest_exc:
+        # REST can't serve it — try reading the repo's parquet directly.
+        if config is None:
+            _scaffold_and_exit(
+                hf_path, ds_id, f"{rest_exc} (pass --config to read parquet directly)"
+            )
+        try:
+            return hf_source.make_parquet_source(hf_path, config, audio_col, text_col)  # type: ignore[arg-type]
+        except (hf_source.HFUnsupported, hf_source.HFAmbiguous) as pq_exc:
+            _scaffold_and_exit(hf_path, ds_id, f"REST: {rest_exc}; parquet: {pq_exc}")
+    except hf_source.HFAmbiguous as exc:
+        _scaffold_and_exit(hf_path, ds_id, str(exc))
+    raise AssertionError("unreachable")  # _scaffold_and_exit always raises
+
+
 def _hf_spec(
     hf_path: str,
     *,
@@ -75,24 +123,15 @@ def _hf_spec(
     dur_max: float,
     dataset_id: str | None,
 ) -> DatasetSpec:
-    """Resolve *hf_path* into a DatasetSpec; scaffold an adapter if it can't be read."""
+    """Resolve *hf_path* into a DatasetSpec.
+
+    Tries the datasets-server REST API first; if it can't serve the dataset
+    (unconverted), falls back to reading the repo's parquet directly. Scaffolds a
+    handwritten adapter only when neither can resolve it.
+    """
     ds_id = dataset_id or f"{hf_path.split('/')[-1].lower()}-v1"
-    try:
-        config, splits = hf_source.resolve_splits(hf_path, config=config, split=split)
-        audio_col, text_col, duration_col = hf_source.detect_columns(
-            hf_path, config, splits[0], audio_col=audio_col, text_col=text_col
-        )
-    except hf_source.HFNeedsChoice as exc:
-        raise click.UsageError(str(exc)) from exc
-    except (hf_source.HFUnsupported, hf_source.HFAmbiguous) as exc:
-        _ADAPTERS_DIR.mkdir(parents=True, exist_ok=True)
-        dest = _ADAPTERS_DIR / f"{ds_id}.py"
-        hf_source.scaffold_adapter(hf_path, dest, detected=str(exc))
-        raise click.UsageError(
-            f"{exc}\nScaffolded {dest} — complete it, then run: coval-build-dataset {ds_id}"
-        ) from exc
-    download, parse, fetch = hf_source.make_source(
-        hf_path, config, splits, audio_col, text_col, duration_col
+    download, parse, fetch = _resolve_hooks(
+        hf_path, ds_id, config=config, split=split, audio_col=audio_col, text_col=text_col
     )
     return DatasetSpec(
         dataset_id=ds_id,

--- a/runner/src/coval_bench/datasets/scripts/build.py
+++ b/runner/src/coval_bench/datasets/scripts/build.py
@@ -1,0 +1,190 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+"""CLI for the standardized dataset builder.
+
+Two ways to build:
+- ``coval-build-dataset <name>`` — a registered dataset (``_SPECS``) or a scaffolded
+  adapter file in ``adapters/``.
+- ``coval-build-dataset --hf <path>`` — any Hugging Face audio dataset, read live via
+  ``hf_source`` (auto-detects columns; ``--audio-col``/``--text-col`` override, and
+  ``--balance <col>`` picks the balance dimension). If it can't resolve the dataset it
+  scaffolds a starter adapter to complete by hand.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import logging
+import sys
+from collections.abc import Callable
+from pathlib import Path
+from typing import cast
+
+import click
+import structlog
+
+from coval_bench.datasets.scripts import hf_source
+from coval_bench.datasets.scripts.framework import Clip, DatasetSpec, run_build
+from coval_bench.datasets.scripts.s2s_v1 import S2S_V1
+
+_SPECS: dict[str, DatasetSpec] = {S2S_V1.dataset_id: S2S_V1}
+_CACHE_ROOT = Path.home() / ".cache" / "coval-bench"
+_ADAPTERS_DIR = Path(__file__).parent / "adapters"
+
+
+def _configure_logging() -> None:
+    structlog.configure(
+        processors=[
+            structlog.processors.add_log_level,
+            structlog.processors.TimeStamper(fmt="%H:%M:%S"),
+            structlog.dev.ConsoleRenderer(),
+        ],
+        wrapper_class=structlog.make_filtering_bound_logger(logging.INFO),
+        logger_factory=structlog.PrintLoggerFactory(file=sys.stderr),
+    )
+
+
+def _meta_dim(col: str) -> Callable[[Clip], object]:
+    """A balance-dimension accessor for meta column *col* (None when absent/empty)."""
+    return lambda clip: clip.meta.get(col) or None
+
+
+def _load_adapter_spec(name: str) -> DatasetSpec | None:
+    """Load ``SPEC`` from a scaffolded handwritten adapter ``adapters/<name>.py``."""
+    path = _ADAPTERS_DIR / f"{name}.py"
+    if not path.exists():
+        return None
+    module_spec = importlib.util.spec_from_file_location(f"_adapter_{name}", path)
+    if module_spec is None or module_spec.loader is None:
+        return None
+    module = importlib.util.module_from_spec(module_spec)
+    module_spec.loader.exec_module(module)
+    return cast(DatasetSpec, module.SPEC)
+
+
+def _hf_spec(
+    hf_path: str,
+    *,
+    config: str | None,
+    split: str | None,
+    audio_col: str | None,
+    text_col: str | None,
+    balance_cols: tuple[str, ...],
+    num: int,
+    dur_min: float,
+    dur_max: float,
+    dataset_id: str | None,
+) -> DatasetSpec:
+    """Resolve *hf_path* into a DatasetSpec; scaffold an adapter if it can't be read."""
+    ds_id = dataset_id or f"{hf_path.split('/')[-1].lower()}-v1"
+    try:
+        config, splits = hf_source.resolve_splits(hf_path, config=config, split=split)
+        audio_col, text_col, duration_col = hf_source.detect_columns(
+            hf_path, config, splits[0], audio_col=audio_col, text_col=text_col
+        )
+    except hf_source.HFNeedsChoice as exc:
+        raise click.UsageError(str(exc)) from exc
+    except (hf_source.HFUnsupported, hf_source.HFAmbiguous) as exc:
+        _ADAPTERS_DIR.mkdir(parents=True, exist_ok=True)
+        dest = _ADAPTERS_DIR / f"{ds_id}.py"
+        hf_source.scaffold_adapter(hf_path, dest, detected=str(exc))
+        raise click.UsageError(
+            f"{exc}\nScaffolded {dest} — complete it, then run: coval-build-dataset {ds_id}"
+        ) from exc
+    download, parse, fetch = hf_source.make_source(
+        hf_path, config, splits, audio_col, text_col, duration_col
+    )
+    return DatasetSpec(
+        dataset_id=ds_id,
+        cache_name=ds_id,
+        download=download,
+        parse=parse,
+        dur_min=dur_min,
+        dur_max=dur_max,
+        min_words=3,
+        num=num,
+        dedup_key=lambda clip: clip.audio_path.name,
+        balance_dims=tuple(_meta_dim(col) for col in balance_cols),
+        license="see-source",
+        source=hf_path,
+        needs_vad_offset=False,
+        fetch=fetch,
+    )
+
+
+@click.command()
+@click.argument("dataset", required=False)
+@click.option("--hf", "hf_path", default=None, help="HF dataset path, e.g. bosonai/WildASR.")
+@click.option("--config", default=None, help="HF config (required if the dataset has several).")
+@click.option(
+    "--split", default=None, help="HF split (default: test if standard, else all facets)."
+)
+@click.option("--audio-col", default=None, help="Override the audio column.")
+@click.option("--text-col", default=None, help="Override the transcript column.")
+@click.option("--balance", "balance_cols", multiple=True, help="Meta column(s) to balance across.")
+@click.option("--num", type=int, default=50, show_default=True, help="Number of clips.")
+@click.option("--dur-min", type=float, default=2.0, show_default=True, help="Min clip seconds.")
+@click.option("--dur-max", type=float, default=10.0, show_default=True, help="Max clip seconds.")
+@click.option("--dataset-id", default=None, help="Manifest id (default derived from --hf).")
+@click.option(
+    "--dry-run", is_flag=True, default=False, help="Build + print manifest; no GCS writes."
+)
+@click.option(
+    "--bucket", default="coval-benchmarks-datasets", show_default=True, help="Target GCS bucket."
+)
+@click.option(
+    "--overwrite",
+    is_flag=True,
+    default=False,
+    help="Overwrite existing GCS objects / manifest (off by default — v1 freeze).",
+)
+def build(
+    dataset: str | None,
+    hf_path: str | None,
+    config: str | None,
+    split: str | None,
+    audio_col: str | None,
+    text_col: str | None,
+    balance_cols: tuple[str, ...],
+    num: int,
+    dur_min: float,
+    dur_max: float,
+    dataset_id: str | None,
+    dry_run: bool,
+    bucket: str,
+    overwrite: bool,
+) -> None:
+    """Build a dataset through the standardized framework and write its manifest."""
+    _configure_logging()
+    if hf_path:
+        spec = _hf_spec(
+            hf_path,
+            config=config,
+            split=split,
+            audio_col=audio_col,
+            text_col=text_col,
+            balance_cols=balance_cols,
+            num=num,
+            dur_min=dur_min,
+            dur_max=dur_max,
+            dataset_id=dataset_id,
+        )
+    elif dataset and dataset in _SPECS:
+        spec = _SPECS[dataset]
+    elif dataset and (adapter := _load_adapter_spec(dataset)) is not None:
+        spec = adapter
+    else:
+        raise click.UsageError(
+            f"pass --hf <path>, a registered dataset {sorted(_SPECS)}, or a scaffolded adapter name"
+        )
+    run_build(
+        spec,
+        bucket=bucket,
+        dry_run=dry_run,
+        overwrite=overwrite,
+        cache_root=_CACHE_ROOT / spec.cache_name,
+    )
+
+
+if __name__ == "__main__":
+    build()

--- a/runner/src/coval_bench/datasets/scripts/framework.py
+++ b/runner/src/coval_bench/datasets/scripts/framework.py
@@ -1,0 +1,286 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+"""Standardized dataset build/clean framework.
+
+Every dataset is built through the same shared flow (see
+``docs/standardized-dataset-cleaning.md``):
+
+    download + extract → parse → clean → select/balance → transcode + hash →
+    annotate (SileroVAD end-of-speech, a separate tool) → render manifest → upload
+
+A dataset is a :class:`DatasetSpec` — config plus a couple of hooks (``download``,
+``parse``); everything else is shared here. Adding a dataset = fill a spec + write
+one ``parse``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.resources as impres
+import json
+import tempfile
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import soundfile as sf
+import structlog
+
+if TYPE_CHECKING:
+    import google.cloud.storage as _gcs_storage
+
+logger = structlog.get_logger(__name__)
+
+_TARGET_SR = 16_000
+_BUCKET_DEFAULT = "coval-benchmarks-datasets"
+_TAG_WARN = 0.95  # per-dim coverage below this → warn + flag (still builds)
+_TAG_FLOOR = 0.50  # per-dim coverage below this → abort (metadata too sparse)
+
+
+@dataclass
+class Clip:
+    """One candidate clip, shared across datasets.
+
+    ``audio_path``/``transcript``/``meta``/``duration_sec`` come from ``parse``;
+    ``filename``/``wav_path``/``sha256`` are filled during transcode. ``meta`` holds
+    per-dataset provenance (speaker_id, scenario, gender, …) emitted into the manifest
+    item; keys starting with ``_`` are build-internal and are NOT emitted.
+    """
+
+    audio_path: Path
+    transcript: str
+    meta: dict[str, object]
+    duration_sec: float = 0.0
+    filename: str = ""
+    wav_path: Path = field(default_factory=Path)
+    sha256: str = ""
+
+
+@dataclass
+class DatasetSpec:
+    """Config + hooks for one dataset's build."""
+
+    dataset_id: str  # "s2s-v1" → prefix "s2s-v1/audio" + manifest "s2s-v1.json"
+    cache_name: str  # subdir under ~/.cache/coval-bench for this dataset's source
+    download: Callable[[Path], Path]  # download + extract → source dir
+    parse: Callable[[Path], list[Clip]]  # source dir → clips (duration + meta set)
+    dur_min: float  # clean: keep clips within [dur_min, dur_max]
+    dur_max: float
+    min_words: int  # clean: minimum transcript word count
+    num: int  # final clip count
+    dedup_key: Callable[[Clip], object]  # keep one clip per key
+    balance_dims: Sequence[Callable[[Clip], object]]  # sample even across these (None = untagged)
+    license: str
+    source: str
+    needs_vad_offset: bool  # run precompute_vad_offsets.py after the build?
+    fetch: Callable[[list[Clip]], None] | None = None  # pull audio for selected clips only
+
+
+# --- shared build helpers ---------------------------------------------------
+
+
+def _hash_file(path: Path) -> str:
+    """SHA256 hex digest of *path*."""
+    h = hashlib.sha256()
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(65536), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _clean(clips: list[Clip], *, dur_min: float, dur_max: float, min_words: int) -> list[Clip]:
+    """Clean: drop clips with no transcript, under the word floor, or outside the band."""
+    return [
+        c
+        for c in clips
+        if c.transcript.strip()
+        and len(c.transcript.split()) >= min_words
+        and dur_min <= c.duration_sec <= dur_max
+    ]
+
+
+def balanced_sample(
+    clips: list[Clip],
+    *,
+    num: int,
+    dedup_key: Callable[[Clip], object],
+    balance_dims: Sequence[Callable[[Clip], object]],
+    tag_warn: float = _TAG_WARN,
+    tag_floor: float = _TAG_FLOOR,
+) -> list[Clip]:
+    """Select: dedup, exclude clips untagged on any balance dim, then stratified
+    round-robin to *num* so the balance dimensions are evenly represented.
+
+    Each dim returns a value or ``None`` (untagged/unexpected). Per-dim coverage is
+    logged; below *tag_warn* it warns, below *tag_floor* it aborts. Untagged clips
+    are excluded and flagged — never silently defaulted. Deterministic.
+    """
+    seen: set[object] = set()
+    dedup: list[Clip] = []
+    for clip in sorted(clips, key=lambda c: str(dedup_key(c))):
+        key = dedup_key(clip)
+        if key not in seen:
+            seen.add(key)
+            dedup.append(clip)
+    if not dedup:
+        raise ValueError("balanced_sample: no clips to sample from")
+
+    # Coverage per balance dim: health check, not a gate on balancing.
+    for i, dim in enumerate(balance_dims):
+        coverage = sum(1 for c in dedup if dim(c) is not None) / len(dedup)
+        logger.info("balance_dim_coverage", dim=i, coverage=round(coverage, 3))
+        if coverage < tag_floor:
+            raise ValueError(
+                f"balance dim {i} coverage {coverage:.3f} below floor {tag_floor} "
+                "— source metadata too sparse to balance"
+            )
+        if coverage < tag_warn:
+            logger.warning("balance_dim_low_coverage", dim=i, coverage=round(coverage, 3))
+
+    # Always exclude clips untagged on any balance dim; flag them.
+    pool = [c for c in dedup if all(dim(c) is not None for dim in balance_dims)]
+    if len(pool) < len(dedup):
+        logger.warning("balance_excluded_untagged", count=len(dedup) - len(pool))
+
+    # Stratify by the cross-product of dim values; round-robin to num.
+    strata: dict[tuple[object, ...], list[Clip]] = {}
+    for clip in pool:
+        strata.setdefault(tuple(dim(clip) for dim in balance_dims), []).append(clip)
+    for group in strata.values():
+        group.sort(key=lambda c: str(dedup_key(c)))
+
+    keys = sorted(strata, key=lambda k: tuple(str(v) for v in k))
+    selected: list[Clip] = []
+    cursor = 0
+    while len(selected) < num and any(strata[k] for k in keys):
+        key = keys[cursor % len(keys)]
+        if strata[key]:
+            selected.append(strata[key].pop(0))
+        cursor += 1
+    if len(selected) < num:
+        raise ValueError(f"balanced_sample: {len(selected)} clips after balancing, need {num}")
+    return selected
+
+
+def _transcode_and_hash(clips: list[Clip], work_dir: Path) -> None:
+    """Transcode each clip to 16 kHz mono PCM_16 WAV; fill filename/wav_path/sha256.
+
+    Reads float32, downmixes multi-channel to mono, and resamples off-rate sources
+    to 16 kHz so any dataset's audio normalizes identically.
+    """
+    for index, clip in enumerate(clips, start=1):
+        clip.filename = f"{index:04d}.wav"
+        clip.wav_path = work_dir / clip.filename
+        data, samplerate = sf.read(str(clip.audio_path), dtype="float32", always_2d=False)
+        if data.ndim > 1:
+            data = data.mean(axis=1)
+        if samplerate != _TARGET_SR:
+            from scipy.signal import resample_poly
+
+            data = resample_poly(data, _TARGET_SR, samplerate)
+        sf.write(str(clip.wav_path), data, _TARGET_SR, subtype="PCM_16")
+        clip.sha256 = _hash_file(clip.wav_path)
+
+
+def _render_manifest(spec: DatasetSpec, clips: list[Clip]) -> str:
+    """Render the manifest JSON (shared schema + per-dataset ``meta``)."""
+    manifest = {
+        "_license": spec.license,
+        "id": spec.dataset_id,
+        "version": "1.0.0",
+        "license": spec.license,
+        "source": spec.source,
+        "items": [
+            {
+                "path": f"audio/{c.filename}",
+                "sha256": c.sha256,
+                "transcript": c.transcript,
+                "duration_sec": round(c.duration_sec, 6),
+                "speech_end_offset_ms": None,
+                **{k: v for k, v in c.meta.items() if not k.startswith("_")},
+            }
+            for c in clips
+        ],
+    }
+    return json.dumps(manifest, indent=2, ensure_ascii=False) + "\n"
+
+
+def _gcs_client() -> _gcs_storage.Client:
+    import google.cloud.storage as storage
+
+    return storage.Client()
+
+
+def _upload_clips(
+    clips: Sequence[Clip],
+    bucket_name: str,
+    *,
+    prefix: str,
+    overwrite: bool,
+    client: _gcs_storage.Client | None = None,
+) -> None:
+    """Upload each WAV to gs://<bucket>/<prefix>/, then re-download + verify SHA256."""
+    if client is None:
+        client = _gcs_client()
+    bucket = client.bucket(bucket_name)
+    for clip in clips:
+        blob_name = f"{prefix}/{clip.filename}"
+        blob = bucket.blob(blob_name)
+        if overwrite:
+            blob.upload_from_filename(str(clip.wav_path), content_type="audio/wav")
+        else:
+            blob.upload_from_filename(
+                str(clip.wav_path), content_type="audio/wav", if_generation_match=0
+            )
+        with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as tmp:
+            tmp_path = Path(tmp.name)
+        try:
+            blob.download_to_filename(str(tmp_path))
+            if _hash_file(tmp_path) != clip.sha256:
+                raise RuntimeError(f"upload integrity failure for {blob_name}")
+        finally:
+            tmp_path.unlink(missing_ok=True)
+
+
+def _write_manifest(json_text: str, dataset_id: str) -> Path:
+    """Write the manifest to the packaged ``<dataset_id>.json``."""
+    pkg = impres.files("coval_bench.datasets.manifests")
+    dest = Path(str(pkg.joinpath(f"{dataset_id}.json")))
+    dest.write_text(json_text, encoding="utf-8")
+    return dest
+
+
+def run_build(
+    spec: DatasetSpec,
+    *,
+    bucket: str = _BUCKET_DEFAULT,
+    dry_run: bool,
+    overwrite: bool,
+    cache_root: Path,
+) -> None:
+    """Run the shared build for *spec* (see docs/standardized-dataset-cleaning.md).
+
+    ``speech_end_offset_ms`` (SileroVAD) is left null here and filled by
+    ``scripts/precompute_vad_offsets.py`` afterward when ``spec.needs_vad_offset``.
+    """
+    source = spec.download(cache_root)  # download + extract
+    clips = spec.parse(source)  # parse → clips
+    clips = _clean(clips, dur_min=spec.dur_min, dur_max=spec.dur_max, min_words=spec.min_words)
+    selected = balanced_sample(  # dedup + exclude untagged + balance
+        clips,
+        num=spec.num,
+        dedup_key=spec.dedup_key,
+        balance_dims=spec.balance_dims,
+    )
+    if spec.fetch is not None:
+        spec.fetch(selected)  # fetch audio for the selected clips only
+    with tempfile.TemporaryDirectory(prefix="coval-bench-build-") as work_dir:
+        _transcode_and_hash(selected, Path(work_dir))  # transcode + hash
+        manifest_json = _render_manifest(spec, selected)  # render manifest
+        if dry_run:
+            print(manifest_json, end="")  # noqa: T201 (dry-run: emit manifest for inspection)
+            return
+        _upload_clips(selected, bucket, prefix=f"{spec.dataset_id}/audio", overwrite=overwrite)
+    _write_manifest(manifest_json, spec.dataset_id)
+    # annotate: run precompute_vad_offsets.py if spec.needs_vad_offset

--- a/runner/src/coval_bench/datasets/scripts/framework.py
+++ b/runner/src/coval_bench/datasets/scripts/framework.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import hashlib
 import importlib.resources as impres
 import json
+import re
 import tempfile
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
@@ -36,6 +37,11 @@ _TARGET_SR = 16_000
 _BUCKET_DEFAULT = "coval-benchmarks-datasets"
 _TAG_WARN = 0.95  # per-dim coverage below this → warn + flag (still builds)
 _TAG_FLOOR = 0.50  # per-dim coverage below this → abort (metadata too sparse)
+# Framework owns these manifest fields; a same-named dataset meta column must not
+# overwrite them (path/sha256 are assigned here, duration/vad-offset are computed).
+_RESERVED_ITEM_KEYS = frozenset(
+    {"path", "sha256", "transcript", "duration_sec", "speech_end_offset_ms"}
+)
 
 
 @dataclass
@@ -183,6 +189,15 @@ def _transcode_and_hash(clips: list[Clip], work_dir: Path) -> None:
         clip.sha256 = _hash_file(clip.wav_path)
 
 
+def _public_meta(meta: dict[str, object]) -> dict[str, object]:
+    """Meta emitted into a manifest item: drop build-internal (_) and reserved keys.
+
+    Reserved keys are framework-owned; keeping a dataset's same-named column out of
+    the spread stops it silently overwriting the computed path/sha256/duration/etc.
+    """
+    return {k: v for k, v in meta.items() if not k.startswith("_") and k not in _RESERVED_ITEM_KEYS}
+
+
 def _render_manifest(spec: DatasetSpec, clips: list[Clip]) -> str:
     """Render the manifest JSON (shared schema + per-dataset ``meta``)."""
     manifest = {
@@ -198,7 +213,7 @@ def _render_manifest(spec: DatasetSpec, clips: list[Clip]) -> str:
                 "transcript": c.transcript,
                 "duration_sec": round(c.duration_sec, 6),
                 "speech_end_offset_ms": None,
-                **{k: v for k, v in c.meta.items() if not k.startswith("_")},
+                **_public_meta(c.meta),
             }
             for c in clips
         ],
@@ -238,6 +253,7 @@ def _upload_clips(
         try:
             blob.download_to_filename(str(tmp_path))
             if _hash_file(tmp_path) != clip.sha256:
+                blob.delete()  # remove the corrupt object so a re-run isn't blocked
                 raise RuntimeError(f"upload integrity failure for {blob_name}")
         finally:
             tmp_path.unlink(missing_ok=True)
@@ -245,6 +261,8 @@ def _upload_clips(
 
 def _write_manifest(json_text: str, dataset_id: str) -> Path:
     """Write the manifest to the packaged ``<dataset_id>.json``."""
+    if not re.fullmatch(r"[A-Za-z0-9._-]+", dataset_id):
+        raise ValueError(f"invalid dataset_id {dataset_id!r}: use letters, digits, '.', '_', '-'")
     pkg = impres.files("coval_bench.datasets.manifests")
     dest = Path(str(pkg.joinpath(f"{dataset_id}.json")))
     dest.write_text(json_text, encoding="utf-8")

--- a/runner/src/coval_bench/datasets/scripts/hf_source.py
+++ b/runner/src/coval_bench/datasets/scripts/hf_source.py
@@ -1,0 +1,314 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+"""Turn a Hugging Face dataset path into builder ``Clip``s.
+
+A source for the shared builder: it converts a dataset into ``Clip``s so the shared
+build (clean → balance → transcode → manifest) is written once, never per dataset.
+Other sources plug in the same way.
+
+Reading:
+    Uses the Hugging Face datasets-server REST API — rows come back as JSON with a
+    downloadable audio URL — so there is no parquet reader / ``datasets`` dependency
+    (``urllib`` + ``json`` only). Build-time module; the runtime loader never imports it.
+
+Cost control (metadata-first):
+    When the dataset has a duration column, only row *metadata* (transcript,
+    duration, audio URL) is paged to run clean + balance; audio is downloaded for
+    the *selected* clips alone — the whole dataset's audio is never pulled. With no
+    duration column, it falls back to downloading all audio and reading each file's
+    duration from its header.
+
+Resolution outcomes (what can go wrong picking a dataset apart):
+    HFNeedsChoice  — readable, but you must pick a config/split.
+    HFAmbiguous    — readable, but you must name the audio/transcript column.
+    HFUnsupported  — not readable at all (gated / not converted).
+    The CLI turns the last two into a scaffolded handwritten adapter.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import soundfile as sf
+import structlog
+
+from coval_bench.datasets.scripts.framework import Clip
+
+logger = structlog.get_logger(__name__)
+
+_SERVER = "https://datasets-server.huggingface.co"
+_PAGE = 100  # datasets-server hard cap on rows per /rows request
+_STANDARD_SPLITS = frozenset({"train", "validation", "valid", "dev", "test"})
+_TEXT_PRIORITY = ("transcript", "transcription", "text", "sentence", "normalized_text")
+_DURATION_COLS = ("duration", "length", "duration_sec")
+_UA = {"User-Agent": "coval-bench/build-dataset"}
+_RETRIES = 6  # transient (429 / 5xx / timeout) attempts before giving up
+_PAGE_PAUSE = 0.3  # seconds between pages, to stay under the rate limit
+_SCAN_CAP_PER_SPLIT = 100  # cap rows scanned per split — full-split paging trips HF rate limits
+
+
+class HFUnsupported(Exception):
+    """datasets-server can't serve rows (gated / not converted / no splits / API error)."""
+
+
+class HFNeedsChoice(Exception):
+    """Readable, but the caller must pick a config/split (more than one available)."""
+
+
+class HFAmbiguous(Exception):
+    """Readable, but can't pin exactly one audio + one transcript column."""
+
+
+def _api_get(endpoint: str, **params: object) -> Any:  # noqa: ANN401 (JSON payload is dynamic)
+    url = f"{_SERVER}/{endpoint}?{urllib.parse.urlencode(params)}"
+    last: Exception | None = None
+    for attempt in range(_RETRIES):
+        req = urllib.request.Request(url, headers=_UA)  # noqa: S310 (audited: hardcoded https HF URL)
+        wait = 2 * (attempt + 1)
+        try:
+            with urllib.request.urlopen(req, timeout=60) as resp:  # noqa: S310
+                return json.loads(resp.read())
+        except urllib.error.HTTPError as exc:
+            if exc.code != 429 and exc.code < 500:  # 4xx (not rate-limit) = permanent
+                raise HFUnsupported(f"{endpoint}: HTTP {exc.code}") from exc
+            last = exc  # 429 rate-limit / 5xx = transient
+            retry_after = exc.headers.get("Retry-After")
+            if retry_after and retry_after.isdigit():
+                wait = int(retry_after)
+        except OSError as exc:  # URLError, timeouts, connection resets — transient
+            last = exc
+        if attempt < _RETRIES - 1:
+            time.sleep(wait)
+    raise HFUnsupported(f"datasets-server unavailable for {endpoint}: {last}")
+
+
+def _fetch_file(src: str, dest: Path) -> None:
+    req = urllib.request.Request(src, headers=_UA)  # noqa: S310 (audited: HF cached-assets URL)
+    with urllib.request.urlopen(req, timeout=120) as resp, dest.open("wb") as out:  # noqa: S310
+        out.write(resp.read())
+
+
+def resolve_splits(hf_path: str, *, config: str | None, split: str | None) -> tuple[str, list[str]]:
+    """Pick ``(config, [splits])`` for *hf_path*.
+
+    Algorithm (no silent first-pick):
+    - >1 config and none given → :class:`HFNeedsChoice` (caller must ``--config``).
+    - standard partitions (train/validation/test) → use ``test`` (benchmarks are
+      held-out); if no ``test``, the first standard split.
+    - non-standard split names are *facets* (e.g. robustness conditions) → use ALL.
+    - an explicit *split* always wins.
+    """
+    pairs = [
+        (s["config"], s["split"]) for s in _api_get("splits", dataset=hf_path).get("splits", [])
+    ]
+    if not pairs:
+        raise HFUnsupported(f"{hf_path}: datasets-server lists no splits")
+    configs = sorted({c for c, _ in pairs})
+    if config is None:
+        if len(configs) > 1:
+            raise HFNeedsChoice(f"{hf_path}: {len(configs)} configs {configs} — pass --config")
+        config = configs[0]
+    elif config not in configs:
+        raise HFNeedsChoice(f"{hf_path}: config '{config}' not in {configs}")
+    cfg_splits = [sp for c, sp in pairs if c == config]
+    if split is not None:
+        if split not in cfg_splits:
+            raise HFNeedsChoice(f"{hf_path}: split '{split}' not in {cfg_splits}")
+        return config, [split]
+    standard = [sp for sp in cfg_splits if sp in _STANDARD_SPLITS]
+    if standard:
+        return config, ["test" if "test" in cfg_splits else standard[0]]
+    return config, cfg_splits
+
+
+def detect_columns(
+    hf_path: str, config: str, split: str, *, audio_col: str | None, text_col: str | None
+) -> tuple[str, str, str | None]:
+    """Return ``(audio_col, transcript_col, duration_col | None)``, honoring overrides.
+
+    Auto: audio = the single ``Audio``-typed column; transcript = the first string
+    column in :data:`_TEXT_PRIORITY` (or the sole string column). Raises
+    :class:`HFAmbiguous` when it can't pin exactly one of each.
+    """
+    feats = _api_get("rows", dataset=hf_path, config=config, split=split, offset=0, length=1).get(
+        "features", []
+    )
+    names = {f["name"] for f in feats}
+    audios = [f["name"] for f in feats if f["type"].get("_type") == "Audio"]
+    strings = [f["name"] for f in feats if f["type"].get("dtype") == "string"]
+    audio = audio_col or (audios[0] if len(audios) == 1 else None)
+    text = text_col or next((n for n in _TEXT_PRIORITY if n in strings), None)
+    if text is None and text_col is None and len(strings) == 1:
+        text = strings[0]
+    if audio is None or text is None or audio not in names or text not in names:
+        raise HFAmbiguous(
+            f"{hf_path}: audio={audios} strings={strings} — use --audio-col/--text-col"
+        )
+    duration = next((c for c in _DURATION_COLS if c in names), None)
+    return audio, text, duration
+
+
+def make_source(
+    hf_path: str,
+    config: str,
+    splits: list[str],
+    audio_col: str,
+    text_col: str,
+    duration_col: str | None,
+) -> tuple[
+    Callable[[Path], Path], Callable[[Path], list[Clip]], Callable[[list[Clip]], None] | None
+]:
+    """Build the ``(download, parse, fetch)`` framework hooks for this HF dataset.
+
+    Metadata-first when *duration_col* is set (download indexes metadata only, fetch
+    grabs audio for the selected clips); otherwise bulk (download grabs all audio,
+    duration is read from each file, no fetch).
+    """
+
+    def _scan_split(
+        split: str, audio_dir: Path, rows: list[dict[str, object]], *, with_audio: bool
+    ) -> None:
+        offset = 0
+        got = 0
+        while True:
+            page = _api_get(
+                "rows", dataset=hf_path, config=config, split=split, offset=offset, length=_PAGE
+            )
+            batch = page.get("rows", [])
+            if not batch:
+                break
+            for entry in batch:
+                got += 1
+                row = entry["row"]
+                cell = row[audio_col]
+                src = (cell[0] if isinstance(cell, list) else cell)["src"]
+                name = f"{split}-{entry['row_idx']}.wav"
+                if with_audio and not (audio_dir / name).exists():
+                    _fetch_file(src, audio_dir / name)
+                meta = {
+                    k: v
+                    for k, v in row.items()
+                    if k not in (audio_col, text_col) and isinstance(v, (str, int, float, bool))
+                }
+                meta["_split"] = split
+                meta["_audio_src"] = src
+                rows.append(
+                    {
+                        "audio": name,
+                        "transcript": str(row[text_col] or ""),
+                        "duration": float(row[duration_col]) if duration_col else 0.0,
+                        "meta": meta,
+                    }
+                )
+            offset += _PAGE
+            total = int(page.get("num_rows_total", 0))
+            if got >= _SCAN_CAP_PER_SPLIT and got < total:
+                logger.info("hf_scan_capped", split=split, scanned=got, total=total)
+                break
+            if offset >= total:
+                break
+            time.sleep(_PAGE_PAUSE)  # stay polite under the rate limit
+
+    def _index(cache_root: Path, *, with_audio: bool) -> Path:
+        audio_dir = cache_root / "audio"
+        audio_dir.mkdir(parents=True, exist_ok=True)
+        rows: list[dict[str, object]] = []
+        for split in splits:
+            try:
+                _scan_split(split, audio_dir, rows, with_audio=with_audio)
+            except HFUnsupported as exc:  # one upstream-broken split shouldn't abort the build
+                logger.warning("hf_split_skipped", split=split, error=str(exc))
+        if not rows:
+            raise HFUnsupported(f"{hf_path}: no rows loaded from any split")
+        (cache_root / "index.jsonl").write_text(
+            "\n".join(json.dumps(r) for r in rows) + "\n", encoding="utf-8"
+        )
+        return cache_root
+
+    def download(cache_root: Path) -> Path:  # index metadata (+ audio only in bulk mode)
+        return _index(cache_root, with_audio=duration_col is None)
+
+    def parse(source: Path) -> list[Clip]:  # index → clips
+        audio_dir = source / "audio"
+        clips: list[Clip] = []
+        for line in (source / "index.jsonl").read_text(encoding="utf-8").splitlines():
+            if not line.strip():
+                continue
+            record: Any = json.loads(line)
+            path = audio_dir / str(record["audio"])
+            # duration: use the dataset's duration column if it has one; otherwise
+            # read it from the (bulk-downloaded) file header.
+            if duration_col:
+                duration = float(record["duration"])
+            else:
+                duration = float(sf.info(str(path)).duration)
+            clips.append(
+                Clip(
+                    audio_path=path,
+                    transcript=str(record["transcript"]),
+                    duration_sec=duration,
+                    meta=record["meta"],
+                )
+            )
+        return clips
+
+    def fetch(selected: list[Clip]) -> None:  # download audio for the selected clips only
+        for clip in selected:
+            if not clip.audio_path.exists():
+                _fetch_file(str(clip.meta["_audio_src"]), clip.audio_path)
+
+    return download, parse, (None if duration_col is None else fetch)
+
+
+def scaffold_adapter(hf_path: str, dest: Path, *, detected: str) -> None:
+    """Write a starter handwritten adapter (like SLURP) to complete by hand."""
+    slug = hf_path.split("/")[-1].lower()
+    dest.write_text(
+        f'''# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+"""Handwritten adapter for {hf_path} — auto-ingest could not resolve it.
+
+Reason: {detected}
+Fill in download()/parse(), then run:  coval-build-dataset {slug}
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from coval_bench.datasets.scripts.framework import Clip, DatasetSpec
+
+
+def download(cache_root: Path) -> Path:
+    raise NotImplementedError  # TODO: fetch the source into cache_root, return it
+
+
+def parse(source: Path) -> list[Clip]:
+    raise NotImplementedError  # TODO: source -> Clips (audio_path, transcript, duration_sec, meta)
+
+
+SPEC = DatasetSpec(
+    dataset_id="{slug}",
+    cache_name="{slug}",
+    download=download,
+    parse=parse,
+    dur_min=2.0,
+    dur_max=10.0,
+    min_words=3,
+    num=50,
+    dedup_key=lambda clip: clip.audio_path.name,
+    balance_dims=(),  # TODO: add balance columns if wanted
+    license="TODO",
+    source="{hf_path}",
+    needs_vad_offset=False,
+)
+''',
+        encoding="utf-8",
+    )

--- a/runner/src/coval_bench/datasets/scripts/hf_source.py
+++ b/runner/src/coval_bench/datasets/scripts/hf_source.py
@@ -55,7 +55,11 @@ _SCAN_CAP_PER_SPLIT = 100  # cap rows scanned per split — full-split paging tr
 
 
 class HFUnsupported(Exception):
-    """datasets-server can't serve rows (gated / not converted / no splits / API error)."""
+    """datasets-server can't serve this dataset (gated / not converted / no rows)."""
+
+
+class HFNetworkError(Exception):
+    """A transient connection failure (timeout / reset / DNS) — safe to just retry."""
 
 
 class HFNeedsChoice(Exception):
@@ -86,13 +90,33 @@ def _api_get(endpoint: str, **params: object) -> Any:  # noqa: ANN401 (JSON payl
             last = exc
         if attempt < _RETRIES - 1:
             time.sleep(wait)
-    raise HFUnsupported(f"datasets-server unavailable for {endpoint}: {last}")
+    # HTTP status exhausted → dataset-level (may be unconverted → parquet fallback);
+    # a bare connection error → network problem the caller should just retry.
+    if isinstance(last, urllib.error.HTTPError):
+        raise HFUnsupported(f"datasets-server error for {endpoint}: HTTP {last.code}")
+    raise HFNetworkError(f"datasets-server unreachable for {endpoint}: {last}")
 
 
 def _fetch_file(src: str, dest: Path) -> None:
+    """Stream *src* to *dest* atomically (chunked, so a huge file isn't held in RAM)."""
+    tmp = dest.with_suffix(dest.suffix + ".part")
     req = urllib.request.Request(src, headers=_UA)  # noqa: S310 (audited: HF cached-assets URL)
-    with urllib.request.urlopen(req, timeout=120) as resp, dest.open("wb") as out:  # noqa: S310
-        out.write(resp.read())
+    try:
+        with urllib.request.urlopen(req, timeout=120) as resp, tmp.open("wb") as out:  # noqa: S310
+            while chunk := resp.read(1 << 20):  # 1 MiB
+                out.write(chunk)
+    except OSError as exc:
+        tmp.unlink(missing_ok=True)  # never leave a partial file behind
+        raise HFNetworkError(f"download failed for {src}: {exc}") from exc
+    tmp.replace(dest)
+
+
+def _as_duration(value: object) -> float:
+    """Coerce a duration cell to float; null/blank/non-numeric → 0.0 (then _clean drops it)."""
+    try:
+        return float(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return 0.0
 
 
 def resolve_splits(hf_path: str, *, config: str | None, split: str | None) -> tuple[str, list[str]]:
@@ -203,7 +227,7 @@ def make_source(
                     {
                         "audio": name,
                         "transcript": str(row[text_col] or ""),
-                        "duration": float(row[duration_col]) if duration_col else 0.0,
+                        "duration": _as_duration(row.get(duration_col)) if duration_col else 0.0,
                         "meta": meta,
                     }
                 )
@@ -279,8 +303,13 @@ _HF_RESOLVE = "https://huggingface.co/datasets/{repo}/resolve/main/{path}"
 def _list_parquet_files(hf_path: str, config: str) -> list[str]:
     """Repo-relative parquet paths that belong to *config* (e.g. data/<config>/*.parquet)."""
     req = urllib.request.Request(f"{_HF_API}/{hf_path}", headers=_UA)  # noqa: S310 (audited: HF API)
-    with urllib.request.urlopen(req, timeout=60) as resp:  # noqa: S310
-        data = json.loads(resp.read())
+    try:
+        with urllib.request.urlopen(req, timeout=60) as resp:  # noqa: S310
+            data = json.loads(resp.read())
+    except urllib.error.HTTPError as exc:
+        raise HFUnsupported(f"{hf_path}: repo listing HTTP {exc.code}") from exc
+    except OSError as exc:
+        raise HFNetworkError(f"{hf_path}: repo listing unreachable: {exc}") from exc
     files = [str(s["rfilename"]) for s in data.get("siblings", [])]
     return sorted(f for f in files if f.endswith(".parquet") and f"/{config}/" in f)
 
@@ -369,7 +398,7 @@ def make_parquet_source(
                     Clip(
                         audio_path=audio_dir / f"{local.stem}-{i}.wav",
                         transcript=str(row[t] or ""),
-                        duration_sec=float(row[d]),
+                        duration_sec=_as_duration(row[d]),
                         meta=meta,
                     )
                 )
@@ -393,8 +422,12 @@ def make_parquet_source(
 
 
 def scaffold_adapter(hf_path: str, dest: Path, *, detected: str) -> None:
-    """Write a starter handwritten adapter (like SLURP) to complete by hand."""
-    slug = hf_path.split("/")[-1].lower()
+    """Write a starter handwritten adapter (like SLURP) to complete by hand.
+
+    The dataset id/slug is taken from *dest* (the file the CLI created) so the run
+    instruction and ``SPEC.dataset_id`` match the file name exactly.
+    """
+    slug = dest.stem
     dest.write_text(
         f'''# Copyright 2026 The Coval Benchmarks Authors
 # SPDX-License-Identifier: Apache-2.0

--- a/runner/src/coval_bench/datasets/scripts/hf_source.py
+++ b/runner/src/coval_bench/datasets/scripts/hf_source.py
@@ -412,6 +412,10 @@ def make_parquet_source(
             by_file.setdefault(str(clip.meta["_pq"]), []).append(clip)
         audio = detected["audio"]
         for pq_file, clips in by_file.items():
+            # NOTE (deferred): this materializes the whole audio column per shard, so a
+            # sparse fetch from a huge single-row-group file peaks at that file's size in
+            # RAM. Acceptable for now — cache is deleted after the build and most shards
+            # have many row groups. Proper fix = read only the selected rows' row groups.
             column = pq.read_table(pq_file, columns=[audio])[audio].to_pylist()
             for clip in clips:
                 cell = column[int(clip.meta["_row"])]  # type: ignore[call-overload]

--- a/runner/src/coval_bench/datasets/scripts/hf_source.py
+++ b/runner/src/coval_bench/datasets/scripts/hf_source.py
@@ -267,6 +267,131 @@ def make_source(
     return download, parse, (None if duration_col is None else fetch)
 
 
+# --- parquet fallback: read the repo's parquet directly when the REST API can't ---
+# Used when datasets-server is unavailable (unconverted dataset). Needs pyarrow
+# (optional dep, build-time). Downloads the config's shard(s); metadata columns are
+# read cheaply and audio bytes are extracted for the selected clips only.
+
+_HF_API = "https://huggingface.co/api/datasets"
+_HF_RESOLVE = "https://huggingface.co/datasets/{repo}/resolve/main/{path}"
+
+
+def _list_parquet_files(hf_path: str, config: str) -> list[str]:
+    """Repo-relative parquet paths that belong to *config* (e.g. data/<config>/*.parquet)."""
+    req = urllib.request.Request(f"{_HF_API}/{hf_path}", headers=_UA)  # noqa: S310 (audited: HF API)
+    with urllib.request.urlopen(req, timeout=60) as resp:  # noqa: S310
+        data = json.loads(resp.read())
+    files = [str(s["rfilename"]) for s in data.get("siblings", [])]
+    return sorted(f for f in files if f.endswith(".parquet") and f"/{config}/" in f)
+
+
+def _detect_parquet_columns(
+    schema: Any,  # noqa: ANN401 (pyarrow schema)
+    audio_col: str | None,
+    text_col: str | None,
+) -> tuple[str, str, str | None]:
+    """Pick (audio, transcript, duration|None) from a parquet schema; raise HFAmbiguous."""
+    import pyarrow as pa
+
+    names = list(schema.names)
+    audios = [
+        f.name for f in schema if pa.types.is_struct(f.type) and "bytes" in [c.name for c in f.type]
+    ]
+    strings = [f.name for f in schema if pa.types.is_string(f.type)]
+    audio = audio_col or (audios[0] if len(audios) == 1 else None)
+    text = text_col or next((n for n in _TEXT_PRIORITY if n in strings), None)
+    if text is None and text_col is None and len(strings) == 1:
+        text = strings[0]
+    if audio is None or text is None:
+        raise HFAmbiguous(f"parquet audio={audios} strings={strings} — use --audio-col/--text-col")
+    duration = next((c for c in _DURATION_COLS if c in names), None)
+    return audio, text, duration
+
+
+def make_parquet_source(
+    hf_path: str,
+    config: str,
+    audio_col: str | None,
+    text_col: str | None,
+) -> tuple[Callable[[Path], Path], Callable[[Path], list[Clip]], Callable[[list[Clip]], None]]:
+    """Build (download, parse, fetch) hooks that read the repo's parquet directly.
+
+    ``download`` pulls the config's shard(s); ``parse`` reads only metadata columns
+    (transcript, duration, meta) — cheap — and requires a duration column so clean
+    can run without decoding audio; ``fetch`` extracts audio bytes for the selected
+    clips. Raises :class:`HFUnsupported` if pyarrow is missing or no shard exists.
+    """
+    try:
+        import pyarrow  # noqa: F401
+    except ImportError as exc:
+        raise HFUnsupported("parquet fallback needs pyarrow (pip install pyarrow)") from exc
+    files = _list_parquet_files(hf_path, config)
+    if not files:
+        raise HFUnsupported(f"{hf_path}: no parquet files for config '{config}'")
+    detected: dict[str, str | None] = {}
+
+    def _local(cache_root: Path, rel: str) -> Path:
+        return cache_root / "parquet" / rel.replace("/", "__")
+
+    def download(cache_root: Path) -> Path:
+        (cache_root / "parquet").mkdir(parents=True, exist_ok=True)
+        for rel in files:
+            dest = _local(cache_root, rel)
+            if not dest.exists():
+                logger.info("hf_parquet_download", file=rel)
+                _fetch_file(_HF_RESOLVE.format(repo=hf_path, path=rel), dest)
+        return cache_root
+
+    def parse(source: Path) -> list[Clip]:
+        import pyarrow.parquet as pq
+
+        audio_dir = source / "audio"
+        audio_dir.mkdir(parents=True, exist_ok=True)
+        clips: list[Clip] = []
+        for rel in files:
+            local = _local(source, rel)
+            a, t, d = _detect_parquet_columns(pq.read_schema(local), audio_col, text_col)
+            if d is None:
+                raise HFUnsupported(
+                    f"{hf_path}: parquet has no duration column — can't clean without audio"
+                )
+            detected.update(audio=a, text=t, duration=d)
+            keep = [t, d, *(c for c in pq.read_schema(local).names if c not in (a, t, d))]
+            for i, row in enumerate(pq.read_table(local, columns=keep).to_pylist()):
+                meta: dict[str, object] = {
+                    str(k): v
+                    for k, v in row.items()
+                    if k not in (t, d) and isinstance(v, (str, int, float, bool))
+                }
+                meta["_pq"] = str(local)
+                meta["_row"] = i
+                clips.append(
+                    Clip(
+                        audio_path=audio_dir / f"{local.stem}-{i}.wav",
+                        transcript=str(row[t] or ""),
+                        duration_sec=float(row[d]),
+                        meta=meta,
+                    )
+                )
+        return clips
+
+    def fetch(selected: list[Clip]) -> None:
+        import pyarrow.parquet as pq
+
+        by_file: dict[str, list[Clip]] = {}
+        for clip in selected:
+            by_file.setdefault(str(clip.meta["_pq"]), []).append(clip)
+        audio = detected["audio"]
+        for pq_file, clips in by_file.items():
+            column = pq.read_table(pq_file, columns=[audio])[audio].to_pylist()
+            for clip in clips:
+                cell = column[int(clip.meta["_row"])]  # type: ignore[call-overload]
+                data = cell["bytes"] if isinstance(cell, dict) else cell
+                clip.audio_path.write_bytes(data)
+
+    return download, parse, fetch
+
+
 def scaffold_adapter(hf_path: str, dest: Path, *, detected: str) -> None:
     """Write a starter handwritten adapter (like SLURP) to complete by hand."""
     slug = hf_path.split("/")[-1].lower()

--- a/runner/src/coval_bench/datasets/scripts/s2s_v1.py
+++ b/runner/src/coval_bench/datasets/scripts/s2s_v1.py
@@ -1,0 +1,160 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+"""s2s-v1 dataset adapter — builds the SLURP query-eliciting clip set via the framework.
+
+Provides SLURP's ``download``/``parse`` plus balance config for the :class:`DatasetSpec`;
+the shared build flow lives in ``framework.py``. Cleaning (duration band + min words)
+is handled generically by the framework, so there is no backfill here — selection
+picks only from already-clean clips.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import tarfile
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+import soundfile as sf
+
+from coval_bench.datasets.scripts.framework import Clip, DatasetSpec
+
+_META_BASE = "https://raw.githubusercontent.com/pswietojanski/slurp/master/dataset/slurp"
+_AUDIO_URL = "https://zenodo.org/record/4274930/files/slurp_real.tar.gz"
+_SPLITS = ("train", "devel", "test")  # real splits only — excludes train_synthetic
+_NUM = 50
+_CHUNK = 1024 * 1024
+_QUERY_RE = re.compile(  # query intents only — clips must elicit a spoken reply
+    r"query|qa_|factoid|definition|recommend|currency|stock|maths|convert|traffic|joke|quirky"
+)
+
+
+def download_slurp(cache_root: Path) -> Path:
+    """Download SLURP metadata (GitHub) + audio (Zenodo) into *cache_root*; return it."""
+    meta = cache_root / "metadata"
+    meta.mkdir(parents=True, exist_ok=True)
+    for name in (*(f"{s}.jsonl" for s in _SPLITS), "metadata.json"):
+        dest = meta / name
+        if dest.exists():
+            continue
+        req = urllib.request.Request(  # noqa: S310 (audited: hardcoded https SLURP URL)
+            f"{_META_BASE}/{name}", headers={"User-Agent": "coval-bench/build-dataset"}
+        )
+        with urllib.request.urlopen(req) as response:  # noqa: S310
+            dest.write_bytes(response.read())
+
+    audio_dir = cache_root / "slurp_real"
+    if audio_dir.exists():
+        return cache_root
+    tar_path = cache_root / "slurp_real.tar.gz"
+    if not tar_path.exists():
+        req = urllib.request.Request(  # noqa: S310 (audited: hardcoded https Zenodo URL)
+            _AUDIO_URL, headers={"User-Agent": "coval-bench/build-dataset"}
+        )
+        with urllib.request.urlopen(req) as response, tar_path.open("wb") as out:  # noqa: S310
+            while chunk := response.read(_CHUNK):
+                out.write(chunk)
+    with tarfile.open(tar_path, "r:gz") as tf:
+        tf.extractall(cache_root)  # noqa: S202
+    return cache_root
+
+
+def _usrid_map(meta_dir: Path) -> dict[str, str]:
+    """Map ``{audio_filename: usrid}`` from SLURP ``metadata.json``."""
+    raw: Any = json.loads((meta_dir / "metadata.json").read_text(encoding="utf-8"))
+    out: dict[str, str] = {}
+    for entry in raw.values():
+        for filename, rec in (entry.get("recordings") or {}).items():
+            usrid = rec.get("usrid")
+            if isinstance(usrid, str):
+                out[str(filename)] = usrid
+    return out
+
+
+def parse_slurp(source: Path) -> list[Clip]:
+    """Parse SLURP jsonl → Clips. Applies the mandatory per-dataset filters.
+
+    Mandatory (drop if failing): headset recording, ``status=correct``, non-empty
+    transcript, and a query/question-eliciting intent (V2V needs a spoken reply).
+    gender/native are recorded as-is — untagged → ``"UNK"``/``None`` — and left for
+    the framework's ``balanced_sample`` to exclude/balance; scenario is metadata only.
+    """
+    meta_dir = source / "metadata"
+    audio_dir = source / "slurp_real"
+    usrid_map = _usrid_map(meta_dir)
+    clips: list[Clip] = []
+    for split in _SPLITS:
+        for line in (meta_dir / f"{split}.jsonl").read_text(encoding="utf-8").splitlines():
+            if not line.strip():
+                continue
+            record: Any = json.loads(line)
+            sentence = str(record.get("sentence") or "").strip()
+            intent = str(record.get("intent") or "")
+            if not sentence or not _QUERY_RE.search(intent):
+                continue
+            scenario = str(record.get("scenario") or "").strip()
+            for rec in record.get("recordings") or []:
+                filename = str(rec.get("file") or "")
+                if "-headset" not in filename or rec.get("status") != "correct":
+                    continue
+                usrid = usrid_map.get(filename, "")
+                gender = usrid[0] if usrid[:1] in ("F", "M") else "UNK"
+                second = usrid[1:2]
+                native = True if second == "E" else False if second == "O" else None
+                flac = audio_dir / filename
+                duration = float(sf.info(str(flac)).duration) if flac.exists() else 0.0
+                clips.append(
+                    Clip(
+                        audio_path=flac,
+                        transcript=sentence,
+                        duration_sec=duration,
+                        meta={
+                            "scenario": scenario,
+                            "intent": intent,
+                            "speaker_id": usrid,
+                            "gender": gender,
+                            "native": native,
+                            "slurp_id": int(record["slurp_id"]),
+                            "slurp_file": filename,
+                        },
+                    )
+                )
+    return clips
+
+
+def _slurp_id(clip: Clip) -> object:
+    """Dedup key — one clip per SLURP prompt."""
+    return clip.meta["slurp_id"]
+
+
+def _gender(clip: Clip) -> object:
+    """Balance value for gender; None if untagged."""
+    g = clip.meta["gender"]
+    return g if g in ("F", "M") else None
+
+
+def _native(clip: Clip) -> object:
+    """Balance value for native (True/False); None if untagged."""
+    return clip.meta["native"]
+
+
+S2S_V1 = DatasetSpec(
+    dataset_id="s2s-v1",
+    cache_name="slurp",
+    download=download_slurp,
+    parse=parse_slurp,
+    dur_min=2.0,
+    dur_max=10.0,
+    min_words=3,
+    num=_NUM,
+    dedup_key=_slurp_id,
+    balance_dims=(_gender, _native),  # scenario is metadata only, not balanced
+    needs_vad_offset=True,
+    license="CC-BY-NC-4.0",
+    source=(
+        "SLURP (Bastianelli et al., EMNLP 2020); audio via Zenodo 4274930; "
+        "headset, status=correct, query-eliciting intents"
+    ),
+)

--- a/runner/src/coval_bench/datasets/scripts/s2s_v1.py
+++ b/runner/src/coval_bench/datasets/scripts/s2s_v1.py
@@ -42,7 +42,8 @@ def download_slurp(cache_root: Path) -> Path:
         req = urllib.request.Request(  # noqa: S310 (audited: hardcoded https SLURP URL)
             f"{_META_BASE}/{name}", headers={"User-Agent": "coval-bench/build-dataset"}
         )
-        with urllib.request.urlopen(req) as response:  # noqa: S310
+        # timeout = idle/stall limit (not a total deadline); a slow large transfer is fine.
+        with urllib.request.urlopen(req, timeout=120) as response:  # noqa: S310
             dest.write_bytes(response.read())
 
     audio_dir = cache_root / "slurp_real"
@@ -53,11 +54,22 @@ def download_slurp(cache_root: Path) -> Path:
         req = urllib.request.Request(  # noqa: S310 (audited: hardcoded https Zenodo URL)
             _AUDIO_URL, headers={"User-Agent": "coval-bench/build-dataset"}
         )
-        with urllib.request.urlopen(req) as response, tar_path.open("wb") as out:  # noqa: S310
-            while chunk := response.read(_CHUNK):
-                out.write(chunk)
+        # Download to a .part file and rename on success so an interrupted run never
+        # leaves a truncated archive that the tar_path.exists() check would trust.
+        part = tar_path.with_suffix(".tar.gz.part")
+        try:
+            with (
+                urllib.request.urlopen(req, timeout=120) as response,  # noqa: S310
+                part.open("wb") as out,
+            ):
+                while chunk := response.read(_CHUNK):
+                    out.write(chunk)
+        except OSError:
+            part.unlink(missing_ok=True)
+            raise
+        part.replace(tar_path)
     with tarfile.open(tar_path, "r:gz") as tf:
-        tf.extractall(cache_root)  # noqa: S202
+        tf.extractall(cache_root, filter="data")  # noqa: S202 (filter blocks path traversal)
     return cache_root
 
 

--- a/runner/src/coval_bench/datasets/scripts/s2s_v1.py
+++ b/runner/src/coval_bench/datasets/scripts/s2s_v1.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import json
 import re
+import shutil
 import tarfile
 import urllib.request
 from pathlib import Path
@@ -68,8 +69,18 @@ def download_slurp(cache_root: Path) -> Path:
             part.unlink(missing_ok=True)
             raise
         part.replace(tar_path)
+    # Extract into a staging dir and rename on success, so a failed extraction never
+    # leaves a partial slurp_real/ that the audio_dir.exists() check above would trust.
+    staging = cache_root / "slurp_real.extracting"
+    if staging.exists():
+        shutil.rmtree(staging)
+    staging.mkdir(parents=True)
     with tarfile.open(tar_path, "r:gz") as tf:
-        tf.extractall(cache_root, filter="data")  # noqa: S202 (filter blocks path traversal)
+        tf.extractall(staging, filter="data")  # noqa: S202 (filter blocks path traversal)
+    extracted = staging / "slurp_real"
+    (extracted if extracted.exists() else staging).replace(audio_dir)
+    if staging.exists():
+        shutil.rmtree(staging, ignore_errors=True)
     return cache_root
 
 

--- a/runner/tests/unit/test_framework.py
+++ b/runner/tests/unit/test_framework.py
@@ -14,7 +14,13 @@ from typing import cast
 
 import pytest
 
-from coval_bench.datasets.scripts.framework import Clip, _clean, balanced_sample
+from coval_bench.datasets.scripts.framework import (
+    Clip,
+    _clean,
+    _public_meta,
+    _write_manifest,
+    balanced_sample,
+)
 
 
 def _clip(
@@ -110,3 +116,20 @@ def test_clean_filters_duration_band_and_word_floor() -> None:
     ]
     out = _clean(clips, dur_min=2.0, dur_max=10.0, min_words=3)
     assert [_sid(c) for c in out] == [2]
+
+
+def test_public_meta_drops_internal_and_reserved_keys() -> None:
+    """Reserved manifest keys and _-prefixed internals never reach a manifest item."""
+    meta = {
+        "gender": "F",
+        "sha256": "attacker",  # reserved — must be dropped
+        "duration_sec": 999,  # reserved — must be dropped
+        "_row": 3,  # build-internal — must be dropped
+    }
+    assert _public_meta(meta) == {"gender": "F"}
+
+
+def test_write_manifest_rejects_path_escape() -> None:
+    """A dataset_id with path separators can't redirect the manifest write."""
+    with pytest.raises(ValueError, match="invalid dataset_id"):
+        _write_manifest("{}", "../evil")

--- a/runner/tests/unit/test_framework.py
+++ b/runner/tests/unit/test_framework.py
@@ -1,0 +1,112 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the standardized dataset build framework (framework.py).
+
+Pure: no network, no GCS, no real audio. Focus on the generic balanced_sample
+selector — the shared "balancing" logic every dataset relies on.
+"""
+
+from __future__ import annotations
+
+import collections
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+from coval_bench.datasets.scripts.framework import Clip, _clean, balanced_sample
+
+
+def _clip(
+    sid: int,
+    gender: str,
+    native: bool | None,
+    *,
+    dur: float = 3.0,
+    transcript: str = "what time is it now",
+) -> Clip:
+    return Clip(
+        audio_path=Path(f"/fake/{sid}.flac"),
+        transcript=transcript,
+        meta={"slurp_id": sid, "gender": gender, "native": native},
+        duration_sec=dur,
+    )
+
+
+def _sid(clip: Clip) -> int:
+    return cast(int, clip.meta["slurp_id"])
+
+
+def _gender(clip: Clip) -> str | None:
+    g = clip.meta["gender"]
+    return g if isinstance(g, str) and g in ("F", "M") else None
+
+
+def _native(clip: Clip) -> bool | None:
+    return cast("bool | None", clip.meta["native"])
+
+
+def test_balanced_sample_dedups_by_key() -> None:
+    """Duplicate dedup keys collapse to a single clip."""
+    clips = [_clip(1, "F", True), _clip(1, "M", False), _clip(2, "M", False)]
+    out = balanced_sample(clips, num=2, dedup_key=_sid, balance_dims=[])
+    assert sorted(_sid(c) for c in out) == [1, 2]
+
+
+def test_balanced_sample_excludes_untagged() -> None:
+    """Clips untagged on a balance dim never enter the result."""
+    clips = [_clip(i, "F", True) for i in range(10)] + [_clip(100, "UNK", None)]
+    out = balanced_sample(clips, num=5, dedup_key=_sid, balance_dims=[_gender, _native])
+    assert all(_gender(c) is not None and _native(c) is not None for c in out)
+    assert 100 not in [_sid(c) for c in out]
+
+
+def test_balanced_sample_stratified_balance() -> None:
+    """Even round-robin over the dim cross-product balances each dimension."""
+    clips: list[Clip] = []
+    sid = 0
+    for gender in ("F", "M"):
+        for native in (True, False):
+            for _ in range(20):
+                clips.append(_clip(sid, gender, native))
+                sid += 1
+    out = balanced_sample(clips, num=40, dedup_key=_sid, balance_dims=[_gender, _native])
+    genders = collections.Counter(_gender(c) for c in out)
+    natives = collections.Counter(_native(c) for c in out)
+    assert genders["F"] == genders["M"] == 20
+    assert natives[True] == natives[False] == 20
+
+
+def test_balanced_sample_aborts_below_floor() -> None:
+    """A balance dim below the coverage floor aborts the build."""
+    clips = [_clip(i, "F", True) for i in range(4)] + [
+        _clip(100 + i, "UNK", True) for i in range(6)
+    ]
+    with pytest.raises(ValueError, match="below floor"):
+        balanced_sample(clips, num=2, dedup_key=_sid, balance_dims=[_gender])
+
+
+def test_balanced_sample_raises_if_insufficient() -> None:
+    """Too few tagged clips to reach num aborts rather than under-filling."""
+    clips = [_clip(i, "F", True) for i in range(3)]
+    with pytest.raises(ValueError, match="need"):
+        balanced_sample(clips, num=10, dedup_key=_sid, balance_dims=[_gender])
+
+
+def test_balanced_sample_deterministic() -> None:
+    """Result is independent of input order."""
+    clips = [_clip(i, "F" if i % 2 else "M", i % 3 == 0) for i in range(60)]
+    forward = balanced_sample(clips, num=10, dedup_key=_sid, balance_dims=[_gender])
+    reverse = balanced_sample(list(reversed(clips)), num=10, dedup_key=_sid, balance_dims=[_gender])
+    assert [_sid(c) for c in forward] == [_sid(c) for c in reverse]
+
+
+def test_clean_filters_duration_band_and_word_floor() -> None:
+    """_clean drops clips outside the duration band or under the word floor."""
+    clips = [
+        _clip(1, "F", True, dur=1.0),  # too short
+        _clip(2, "F", True, dur=3.0),  # kept
+        _clip(3, "F", True, dur=3.0, transcript="hi"),  # too few words
+    ]
+    out = _clean(clips, dur_min=2.0, dur_max=10.0, min_words=3)
+    assert [_sid(c) for c in out] == [2]

--- a/runner/tests/unit/test_hf_source.py
+++ b/runner/tests/unit/test_hf_source.py
@@ -1,0 +1,34 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for hf_source + build helpers (pure: no network)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from coval_bench.datasets.scripts.build import _meta_dim
+from coval_bench.datasets.scripts.framework import Clip
+from coval_bench.datasets.scripts.hf_source import _as_duration
+
+
+def _clip(meta: dict[str, object]) -> Clip:
+    return Clip(audio_path=Path("/x.wav"), transcript="hi there now", meta=meta)
+
+
+def test_as_duration_coerces_null_and_junk() -> None:
+    """Null / blank / non-numeric duration cells become 0.0 instead of crashing."""
+    assert _as_duration(3.5) == 3.5
+    assert _as_duration("2.0") == 2.0
+    assert _as_duration(None) == 0.0
+    assert _as_duration("") == 0.0
+    assert _as_duration("n/a") == 0.0
+
+
+def test_meta_dim_keeps_false_and_zero() -> None:
+    """Balancing on a boolean/numeric column keeps False/0 (only missing → untagged)."""
+    native = _meta_dim("native")
+    assert native(_clip({"native": False})) is False
+    assert native(_clip({"native": True})) is True
+    assert _meta_dim("count")(_clip({"count": 0})) == 0
+    assert native(_clip({})) is None
+    assert native(_clip({"native": ""})) is None

--- a/runner/uv.lock
+++ b/runner/uv.lock
@@ -306,6 +306,9 @@ dependencies = [
 google-stt = [
     { name = "google-cloud-speech" },
 ]
+hf-parquet = [
+    { name = "pyarrow" },
+]
 hume-tts = [
     { name = "hume" },
 ]
@@ -345,6 +348,7 @@ requires-dist = [
     { name = "openai", specifier = ">=1.40" },
     { name = "posthog", specifier = ">=3.0" },
     { name = "psycopg", extras = ["binary", "pool"], specifier = ">=3.2" },
+    { name = "pyarrow", marker = "extra == 'hf-parquet'", specifier = ">=17" },
     { name = "pydantic", specifier = ">=2.7" },
     { name = "pydantic-settings", specifier = ">=2.14.2" },
     { name = "scipy", specifier = ">=1.11" },
@@ -355,7 +359,7 @@ requires-dist = [
     { name = "websockets", specifier = ">=13,<14" },
     { name = "whisper-normalizer", specifier = ">=0.0.10" },
 ]
-provides-extras = ["google-stt", "hume-tts"]
+provides-extras = ["google-stt", "hume-tts", "hf-parquet"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1239,6 +1243,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/90/82/7a23d26039827ecd4ebe93905651029ddd307c5182ad59296dfb6f67b528/psycopg_pool-3.3.1.tar.gz", hash = "sha256:b10b10b7a175d5cc1592147dc5b7eec8a9e0834eb3ed2c4a92c858e2f51eb63c", size = 31661, upload-time = "2026-05-01T23:31:59.809Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/37/ed/89c2c620af0e1660354cd8aabf9f5b21f911597ce22acb37c805d6c86bc8/psycopg_pool-3.3.1-py3-none-any.whl", hash = "sha256:2af5b432941c4c9ad5c87b3fa410aec910ec8f7c122855897983a06c45f2e4b5", size = 40023, upload-time = "2026-05-01T23:31:53.136Z" },
+]
+
+[[package]]
+name = "pyarrow"
+version = "24.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/91/13/13e1069b351bdc3881266e11147ffccf687505dbb0ea74036237f5d454a5/pyarrow-24.0.0.tar.gz", hash = "sha256:85fe721a14dd823aca09127acbb06c3ca723efbd436c004f16bca601b04dcc83", size = 1180261, upload-time = "2026-04-21T10:51:25.837Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b4/a9/9686d9f07837f91f775e8932659192e02c74f9d8920524b480b85212cc68/pyarrow-24.0.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:6233c9ed9ab9d1db47de57d9753256d9dcffbf42db341576099f0fd9f6bf4810", size = 34981559, upload-time = "2026-04-21T10:47:22.17Z" },
+    { url = "https://files.pythonhosted.org/packages/80/b6/0ddf0e9b6ead3474ab087ae598c76b031fc45532bf6a63f3a553440fb258/pyarrow-24.0.0-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:f7616236ec1bc2b15bfdec22a71ab38851c86f8f05ff64f379e1278cf20c634a", size = 36663654, upload-time = "2026-04-21T10:47:28.315Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/3b/926382efe8ce27ba729071d3566ade6dfb86bdf112f366000196b2f5780a/pyarrow-24.0.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:1617043b99bd33e5318ae18eb2919af09c71322ef1ca46566cdafc6e6712fb66", size = 45679394, upload-time = "2026-04-21T10:47:34.821Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/7a/829f7d9dfd37c207206081d6dad474d81dde29952401f07f2ba507814818/pyarrow-24.0.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:6165461f55ef6314f026de6638d661188e3455d3ec49834556a0ebbdbace18bb", size = 48863122, upload-time = "2026-04-21T10:47:42.056Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/e8/f88ce625fe8babaae64e8db2d417c7653adb3019b08aae85c5ed787dc816/pyarrow-24.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3b13dedfe76a0ad2d1d859b0811b53827a4e9d93a0bcb05cf59333ab4980cc7e", size = 49376032, upload-time = "2026-04-21T10:47:48.967Z" },
+    { url = "https://files.pythonhosted.org/packages/36/7a/82c363caa145fff88fb475da50d3bf52bb024f61917be5424c3392eaf878/pyarrow-24.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:25ea65d868eb04015cd18e6df2fbe98f07e5bda2abefabcb88fce39a947716f6", size = 51929490, upload-time = "2026-04-21T10:47:55.981Z" },
+    { url = "https://files.pythonhosted.org/packages/66/1c/e3e72c8014ad2743ca64a701652c733cc5cbcee15c0463a32a8c55518d9e/pyarrow-24.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:295f0a7f2e242dabd513737cf076007dc5b2d59237e3eca37b05c0c6446f3826", size = 27355660, upload-time = "2026-04-21T10:48:01.718Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
One shared pipeline for building benchmark datasets — clean, balance, transcode, hash, manifest, upload — where only the per-dataset source (download + parse) is written each time.

`balanced_sample` is the core: dedup, per-dimension tag-coverage checks (warn <0.95, abort <0.50), exclude untagged clips rather than default them, then a stratified round-robin so each balance dimension is even.

A generic Hugging Face source builds a manifest from just a dataset path — resolve splits, auto-detect columns, metadata-first paging, and scaffold a handwritten adapter when a dataset can't be read. SLURP `s2s-v1` is the first adapter; `coval-build-dataset` is the CLI.

Experimental. Follow-ups: parquet fallback for unconverted datasets, cache-management flags, stt-v1 migration.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a shared pipeline for building benchmark datasets — `framework.py` owns the clean → balance → transcode → hash → manifest → upload flow; per-dataset adapters provide only `download` + `parse` hooks. The first concrete adapter is SLURP/`s2s-v1`; `hf_source.py` adds a generic HF REST path (with a parquet fallback); `coval-build-dataset` is the CLI entry point.

- `balanced_sample` deduplicates, enforces per-dimension tag-coverage floors, excludes untagged clips, and does stratified round-robin; the tests cover all the documented edge cases.
- The metadata-first HF path pages only transcript/duration via the datasets-server API and downloads audio only for the selected clips, keeping bandwidth proportional to `num` rather than total dataset size.
- Path-traversal guards for `dataset_id` in both `_hf_spec` and `_write_manifest` prevent the manifest from being redirected outside the package directory.

<h3>Confidence Score: 5/5</h3>

The pipeline is well-structured and the critical paths (path-traversal validation, atomic file writes, chunked downloads, tag-floor abort) are all correctly implemented. No correctness bugs were found.

All findings are minor quality issues — a missing NoReturn annotation that forces a type: ignore suppression, a template-string that produces invalid Python when the dataset path contains a quote, and an unhandled OSError in the SLURP metadata downloader that bypasses the clean error-message path. None of these affect the build output or data integrity for normal inputs.

No files require special attention before merging; the scaffold_adapter template in hf_source.py and the download_slurp error handling in s2s_v1.py are the two spots worth a quick follow-up.

<sub>Reviews (3): Last reviewed commit: ["Harden parquet fallback and SLURP extrac..."](https://github.com/coval-ai/benchmarks/commit/5943f24c5dd3aef57321e133cc5c9cffbebe2926) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41517030)</sub>

<!-- /greptile_comment -->