### PR TITLE
Add pacing-drift methodology marker to timeline chart

### DIFF
--- a/web/components/visualizations/TimelineChart.tsx
+++ b/web/components/visualizations/TimelineChart.tsx
@@ -165,16 +165,19 @@ const TimelineChart: React.FC = () => {
   const modelsWithData = getModelsWithTimelineData(metric);
   const windowedTimelineData = getWindowedTimelineData(metric);
   const activeMetricKey = metric.toLowerCase() as MethodologyMetricKey;
-  // Anchor date-only strings at UTC noon so the marker lands on the intended
-  // calendar day in every inhabited timezone (UTC midnight would shift to the
-  // previous day for the Americas).
+  // With an explicit time (an offset-qualified "HH:MM:SS±hh:mm") pin the marker
+  // to that exact instant; otherwise anchor date-only strings at UTC noon so the
+  // marker lands on the intended calendar day in every inhabited timezone (UTC
+  // midnight would shift to the previous day for the Americas).
   const methodologyMarkers = useMemo(
     () =>
       methodologyChanges
         .filter((c) => !c.metrics || c.metrics.includes(activeMetricKey))
         .map((c) => ({
           change: c,
-          ts: new Date(`${c.date}T12:00:00Z`).getTime(),
+          ts: new Date(
+            c.time ? `${c.date}T${c.time}` : `${c.date}T12:00:00Z`
+          ).getTime(),
         }))
         .filter((m) => m.ts >= windowStart && m.ts <= windowEnd),
     [activeMetricKey, windowStart, windowEnd]

--- a/web/lib/config/methodologyChanges.ts
+++ b/web/lib/config/methodologyChanges.ts
@@ -5,6 +5,7 @@ export type MethodologyMetricKey = "ttfa" | "ttft" | "ttfs" | "wer";
 
 export interface MethodologyChange {
   date: string;
+  time?: string;
   metrics?: MethodologyMetricKey[];
   title: string;
   detail: string;
@@ -38,5 +39,13 @@ export const methodologyChanges: MethodologyChange[] = [
     title: "Gradium finalization made event-driven",
     detail:
       "Gradium STT now waits for an explicit finalization event instead of a fixed timeout, so its time-to-final-segment reflects true engine speed. Gradium TTFS values shift at this point.",
+  },
+  {
+    date: "2026-07-01",
+    time: "14:00:00-07:00",
+    metrics: ["ttft", "ttfs"],
+    title: "STT streaming latency corrected for pacing drift",
+    detail:
+      "Streaming STT audio was fed with a fixed per-chunk sleep, so send-loop drift accumulated and inflated latency. Audio is now paced against an absolute deadline, so latency reflects true engine speed. STT latency drops after this date; values before and after are not comparable.",
   },
 ];


### PR DESCRIPTION
- Adds a methodology-change marker for the July 1 STT pacing-drift fix (#205), which re-based TTFT/TTFS by pacing streaming audio against an absolute deadline instead of a fixed per-chunk sleep;

- Also lets a change pin to an exact instant: methodologyChanges entries gain an optional offset-qualified time field, and the timeline anchors to it when present (this one at 14:00 PT / 21:00 UTC); date-only entries still fall back to UTC noon.

Note: manual entry by design, automating methodology changes is out of scope

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds an exact-time methodology marker for the STT pacing-drift fix. The main changes are:

- Optional `time` support on methodology change entries.
- Exact-instant parsing for timed markers in the timeline chart.
- A July 1 TTFT/TTFS methodology-change entry.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<sub>Reviews (1): Last reviewed commit: ["Add July 1 pacing-drift methodology mark..."](https://github.com/coval-ai/benchmarks/commit/4fa160e000d1ff74cf28509ac6b396bc7e6aa4b0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41739661)</sub>

<!-- /greptile_comment -->