### PR TITLE
Normalize Soniox display names

### DIFF
--- a/web/lib/utils/formatters.ts
+++ b/web/lib/utils/formatters.ts
@@ -109,6 +109,7 @@ export function normalizeModelName(modelKey: string): string {
     "grok-tts": "Grok TTS",
     "inworld-tts-1.5-max": "TTS 1.5 Max",
     "inworld-tts-1.5-mini": "TTS 1.5 Mini",
+    "tts-rt-v1": "TTS RT v1",
     // STT
     "nova-2": "Nova 2",
     "nova-3": "Nova 3",
@@ -124,6 +125,8 @@ export function normalizeModelName(modelKey: string): string {
     "universal-3-pro": "Universal 3 Pro",
     "universal-3.5-pro": "Universal 3.5 Pro",
     "ink-2": "Ink 2",
+    "stt-rt-v4": "STT RT v4",
+    "stt-rt-v5": "STT RT v5",
     "inworld-stt-1": "STT 1",
     default: "Default",
     enhanced: "Enhanced"
@@ -171,6 +174,7 @@ export function normalizeSTTProviderName(providerName: string): string {
     inworld: "Inworld AI",
     openai: "OpenAI",
     rime: "Rime",
+    soniox: "Soniox",
     speechmatics: "Speechmatics",
     xai: "xAI"
   };
@@ -189,6 +193,7 @@ export function normalizeTTSProviderName(providerName: string): string {
     inworld: "Inworld AI",
     openai: "OpenAI",
     rime: "Rime",
+    soniox: "Soniox",
     xai: "xAI",
   };
 


### PR DESCRIPTION
Formats Soniox models and provider up to the set naming convention (STT RT v4/v5, TTS RT v1, Soniox).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR normalizes Soniox display names in the formatter utilities.

- Adds Soniox STT and TTS model labels.
- Adds Soniox provider labels for STT and TTS formatters.

<h3>Confidence Score: 4/5</h3>

The formatter change looks mergeable after covering the composite Soniox TTS provider value.

- The changed mappings are isolated to display formatting.
- A TTS provider value can still bypass the new `soniox` mapping and render with generic title-casing.
- No security-sensitive behavior is changed.

web/lib/utils/formatters.ts

<sub>Reviews (1): Last reviewed commit: ["Normalize Soniox provider and model disp..."](https://github.com/coval-ai/benchmarks/commit/94ee330a7cb7ff4d1242c427bc8e740409617c68) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42181182)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->