### PR TITLE
Drop the AssemblyAI TTFS methodology annotation

### DIFF
--- a/web/lib/config/methodologyChanges.ts
+++ b/web/lib/config/methodologyChanges.ts
@@ -48,11 +48,4 @@ export const methodologyChanges: MethodologyChange[] = [
     detail:
       "Streaming STT audio was fed with a fixed per-chunk sleep, so send-loop drift accumulated and inflated latency. Audio is now paced against an absolute deadline, so latency reflects true engine speed. STT latency drops after this date; values before and after are not comparable.",
   },
-  {
-    date: "2026-07-07",
-    metrics: ["ttfs"],
-    title: "AssemblyAI universal-streaming models no longer report TTFS",
-    detail:
-      "universal-streaming and universal-streaming-multilingual acknowledge the end-of-speech signal without finalizing: the reply arrives in one network round-trip and can omit the last words of the clip. Their TTFS measured connectivity rather than finalization speed, so it is no longer reported, matching how Deepgram Flux is handled. The pro models and all other metrics are unaffected.",
-  },
 ];


### PR DESCRIPTION
The universal-streaming TTFS exclusion is minor housekeeping, not a methodology shift worth flagging on the timeline, so remove the note while leaving the exclusion itself in place.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes one timeline note for the AssemblyAI TTFS exclusion. The main changes are:

- Removed the `2026-07-07` methodology annotation for AssemblyAI universal-streaming TTFS.
- Left the methodology change list and other TTFS annotations unchanged.
- Did not change the underlying TTFS exclusion behavior.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.
- The diff only removes explanatory chart metadata for an exclusion that remains implemented elsewhere.

<sub>Reviews (1): Last reviewed commit: ["Drop the AssemblyAI TTFS methodology ann..."](https://github.com/coval-ai/benchmarks/commit/3f73f8150c855d4fdf79f4c9da89f08e3ad03246) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42468662)</sub>

<!-- /greptile_comment -->