### PR TITLE
Fix Inworld STT hanging until timeout in prod

### DIFF
--- a/runner/src/coval_bench/providers/stt/_pacing.py
+++ b/runner/src/coval_bench/providers/stt/_pacing.py
@@ -24,26 +24,37 @@ def pacing_delay(start: float, sent_bytes: int, byte_rate: int) -> float:
     return start + sent_bytes / byte_rate - time.monotonic()
 
 
+def _chunk_spans(total: int, chunk_size: int, min_tail_bytes: int) -> list[tuple[int, int]]:
+    spans = [(i, min(i + chunk_size, total)) for i in range(0, total, chunk_size)]
+    if min_tail_bytes and len(spans) >= 2:
+        last_lo, last_hi = spans[-1]
+        if last_hi - last_lo < min_tail_bytes:
+            prev_lo, _ = spans.pop(-2)
+            spans[-1] = (prev_lo, last_hi)
+    return spans
+
+
 async def paced_chunks(
     audio_data: bytes,
     chunk_size: int,
     byte_rate: int,
     *,
     start: float | None = None,
+    min_tail_bytes: int = 0,
 ) -> AsyncIterator[tuple[bytes, float]]:
     """Yield ``(chunk, start)`` pacing each chunk to real time, the last included.
 
     ``start`` defaults to the monotonic clock at the first chunk; pass it to
-    anchor pacing to a timestamp captured earlier.
+    anchor pacing to a timestamp captured earlier. ``min_tail_bytes`` folds a
+    sub-threshold final chunk into its predecessor.
     """
     chunk_size = max(1, chunk_size)
     if start is None:
         start = time.monotonic()
     sent_bytes = 0
-    for i in range(0, len(audio_data), chunk_size):
-        chunk = audio_data[i : i + chunk_size]
-        yield chunk, start
-        sent_bytes += len(chunk)
+    for lo, hi in _chunk_spans(len(audio_data), chunk_size, min_tail_bytes):
+        yield audio_data[lo:hi], start
+        sent_bytes += hi - lo
         delay = pacing_delay(start, sent_bytes, byte_rate)
         if delay > 0:
             await asyncio.sleep(delay)
@@ -55,16 +66,16 @@ def paced_chunks_sync(
     byte_rate: int,
     *,
     start: float | None = None,
+    min_tail_bytes: int = 0,
 ) -> Iterator[tuple[bytes, float]]:
     """Synchronous :func:`paced_chunks` for blocking send loops (e.g. gRPC)."""
     chunk_size = max(1, chunk_size)
     if start is None:
         start = time.monotonic()
     sent_bytes = 0
-    for i in range(0, len(audio_data), chunk_size):
-        chunk = audio_data[i : i + chunk_size]
-        yield chunk, start
-        sent_bytes += len(chunk)
+    for lo, hi in _chunk_spans(len(audio_data), chunk_size, min_tail_bytes):
+        yield audio_data[lo:hi], start
+        sent_bytes += hi - lo
         delay = pacing_delay(start, sent_bytes, byte_rate)
         if delay > 0:
             time.sleep(delay)

--- a/runner/src/coval_bench/providers/stt/_pacing.py
+++ b/runner/src/coval_bench/providers/stt/_pacing.py
@@ -29,8 +29,15 @@ def _chunk_spans(total: int, chunk_size: int, min_tail_bytes: int) -> list[tuple
     if min_tail_bytes and len(spans) >= 2:
         last_lo, last_hi = spans[-1]
         if last_hi - last_lo < min_tail_bytes:
-            prev_lo, _ = spans.pop(-2)
-            spans[-1] = (prev_lo, last_hi)
+            lo = spans[-2][0]
+            mid = lo + (last_hi - lo) // 2
+            del spans[-2:]
+            # Splitting evenly keeps both chunks under chunk_size; fold instead
+            # if a half would still be under the floor.
+            if mid - lo >= min_tail_bytes:
+                spans += [(lo, mid), (mid, last_hi)]
+            else:
+                spans.append((lo, last_hi))
     return spans
 
 
@@ -45,8 +52,8 @@ async def paced_chunks(
     """Yield ``(chunk, start)`` pacing each chunk to real time, the last included.
 
     ``start`` defaults to the monotonic clock at the first chunk; pass it to
-    anchor pacing to a timestamp captured earlier. ``min_tail_bytes`` folds a
-    sub-threshold final chunk into its predecessor.
+    anchor pacing to a timestamp captured earlier. ``min_tail_bytes`` rebalances
+    a sub-threshold final chunk with its predecessor.
     """
     chunk_size = max(1, chunk_size)
     if start is None:

--- a/runner/src/coval_bench/providers/stt/inworld.py
+++ b/runner/src/coval_bench/providers/stt/inworld.py
@@ -145,9 +145,10 @@ class InworldSTTProvider(STTProvider):
             async for chunk, start in paced_chunks(
                 audio_data, chunk_size, bytes_per_second, min_tail_bytes=min_tail_bytes
             ):
-                # Stop early if _receive already recorded a protocol/auth error.
+                # Stop early if _receive already recorded a protocol/auth error;
+                # the server closes the socket on its error path.
                 if result.error is not None:
-                    break
+                    return
                 result.audio_start_time = start
                 await ws.send(
                     json.dumps({"audioChunk": {"content": base64.b64encode(chunk).decode()}})

--- a/runner/src/coval_bench/providers/stt/inworld.py
+++ b/runner/src/coval_bench/providers/stt/inworld.py
@@ -139,11 +139,12 @@ class InworldSTTProvider(STTProvider):
         done_event: asyncio.Event,
     ) -> None:
         bytes_per_second = sample_rate * 2  # 16-bit mono
+        min_chunk_bytes = bytes_per_second * _MIN_CHUNK_MS // 1000
         chunk_size = int(bytes_per_second * realtime_resolution)
-        min_tail_bytes = bytes_per_second * _MIN_CHUNK_MS // 1000
+        chunk_size = min(max(chunk_size, min_chunk_bytes), bytes_per_second)
         try:
             async for chunk, start in paced_chunks(
-                audio_data, chunk_size, bytes_per_second, min_tail_bytes=min_tail_bytes
+                audio_data, chunk_size, bytes_per_second, min_tail_bytes=min_chunk_bytes
             ):
                 # Stop early if _receive already recorded a protocol/auth error;
                 # the server closes the socket on its error path.

--- a/runner/src/coval_bench/providers/stt/inworld.py
+++ b/runner/src/coval_bench/providers/stt/inworld.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import contextlib
 import json
 import time
 from typing import Any
@@ -25,6 +26,12 @@ from coval_bench.providers.stt._pacing import paced_chunks
 logger = structlog.get_logger(__name__)
 
 _WS_URL = "wss://api.inworld.ai/stt/v1/transcribe:streamBidirectional"
+
+# Inworld rejects chunks outside 20-1000 ms with "invalid audio chunk duration".
+_MIN_CHUNK_MS = 20
+
+# The server never closes after closeStream; the sender closes client-side.
+_FINAL_WAIT_S = 5.0
 
 
 class InworldSTTProvider(STTProvider):
@@ -89,10 +96,13 @@ class InworldSTTProvider(STTProvider):
                     )
                 )
 
+                final_event = asyncio.Event()
                 send_task = asyncio.create_task(
-                    self._send_audio(ws, audio_data, sample_rate, result, realtime_resolution)
+                    self._send_audio(
+                        ws, audio_data, sample_rate, result, realtime_resolution, final_event
+                    )
                 )
-                recv_task = asyncio.create_task(self._receive(ws, result))
+                recv_task = asyncio.create_task(self._receive(ws, result, final_event))
                 tasks = (send_task, recv_task)
                 done, pending = await asyncio.wait(tasks, return_when=asyncio.FIRST_EXCEPTION)
                 if any(not task.cancelled() and task.exception() is not None for task in done):
@@ -125,11 +135,15 @@ class InworldSTTProvider(STTProvider):
         sample_rate: int,
         result: TranscriptionResult,
         realtime_resolution: float,
+        final_event: asyncio.Event,
     ) -> None:
         bytes_per_second = sample_rate * 2  # 16-bit mono
         chunk_size = int(bytes_per_second * realtime_resolution)
+        min_tail_bytes = bytes_per_second * _MIN_CHUNK_MS // 1000
         try:
-            async for chunk, start in paced_chunks(audio_data, chunk_size, bytes_per_second):
+            async for chunk, start in paced_chunks(
+                audio_data, chunk_size, bytes_per_second, min_tail_bytes=min_tail_bytes
+            ):
                 # Stop early if _receive already recorded a protocol/auth error.
                 if result.error is not None:
                     break
@@ -137,17 +151,21 @@ class InworldSTTProvider(STTProvider):
                 await ws.send(
                     json.dumps({"audioChunk": {"content": base64.b64encode(chunk).decode()}})
                 )
-            # endTurn forces finalization; closeStream then flushes the final
-            # transcripts and closes the socket, ending the receive loop.
+            final_event.clear()
             await ws.send(json.dumps({"endTurn": {}}))
             await ws.send(json.dumps({"closeStream": {}}))
+            with contextlib.suppress(TimeoutError):
+                await asyncio.wait_for(final_event.wait(), timeout=_FINAL_WAIT_S)
+            await ws.close()
         except Exception as exc:
             logger.warning(
                 "inworld_send_error", provider="inworld", model=self._model, exc_info=exc
             )
             raise
 
-    async def _receive(self, ws: Any, result: TranscriptionResult) -> None:
+    async def _receive(
+        self, ws: Any, result: TranscriptionResult, final_event: asyncio.Event
+    ) -> None:
         final_parts: list[str] = []
 
         try:
@@ -184,6 +202,7 @@ class InworldSTTProvider(STTProvider):
                     final_parts.append(text.strip())
                     if result.audio_start_time is not None:
                         result.audio_to_final_seconds = now - result.audio_start_time
+                    final_event.set()
                 else:
                     result.partial_transcripts.append(text.strip())
 

--- a/runner/src/coval_bench/providers/stt/inworld.py
+++ b/runner/src/coval_bench/providers/stt/inworld.py
@@ -30,8 +30,9 @@ _WS_URL = "wss://api.inworld.ai/stt/v1/transcribe:streamBidirectional"
 # Inworld rejects chunks outside 20-1000 ms with "invalid audio chunk duration".
 _MIN_CHUNK_MS = 20
 
-# The server never closes after closeStream; the sender closes client-side.
-_FINAL_WAIT_S = 5.0
+# The server never closes after closeStream; the sender closes client-side once
+# the trailing usage frame (sent after all finals) arrives, or after this wait.
+_CLOSE_WAIT_S = 5.0
 
 
 class InworldSTTProvider(STTProvider):
@@ -96,13 +97,13 @@ class InworldSTTProvider(STTProvider):
                     )
                 )
 
-                final_event = asyncio.Event()
+                done_event = asyncio.Event()
                 send_task = asyncio.create_task(
                     self._send_audio(
-                        ws, audio_data, sample_rate, result, realtime_resolution, final_event
+                        ws, audio_data, sample_rate, result, realtime_resolution, done_event
                     )
                 )
-                recv_task = asyncio.create_task(self._receive(ws, result, final_event))
+                recv_task = asyncio.create_task(self._receive(ws, result, done_event))
                 tasks = (send_task, recv_task)
                 done, pending = await asyncio.wait(tasks, return_when=asyncio.FIRST_EXCEPTION)
                 if any(not task.cancelled() and task.exception() is not None for task in done):
@@ -135,7 +136,7 @@ class InworldSTTProvider(STTProvider):
         sample_rate: int,
         result: TranscriptionResult,
         realtime_resolution: float,
-        final_event: asyncio.Event,
+        done_event: asyncio.Event,
     ) -> None:
         bytes_per_second = sample_rate * 2  # 16-bit mono
         chunk_size = int(bytes_per_second * realtime_resolution)
@@ -151,11 +152,10 @@ class InworldSTTProvider(STTProvider):
                 await ws.send(
                     json.dumps({"audioChunk": {"content": base64.b64encode(chunk).decode()}})
                 )
-            final_event.clear()
             await ws.send(json.dumps({"endTurn": {}}))
             await ws.send(json.dumps({"closeStream": {}}))
             with contextlib.suppress(TimeoutError):
-                await asyncio.wait_for(final_event.wait(), timeout=_FINAL_WAIT_S)
+                await asyncio.wait_for(done_event.wait(), timeout=_CLOSE_WAIT_S)
             await ws.close()
         except Exception as exc:
             logger.warning(
@@ -164,7 +164,7 @@ class InworldSTTProvider(STTProvider):
             raise
 
     async def _receive(
-        self, ws: Any, result: TranscriptionResult, final_event: asyncio.Event
+        self, ws: Any, result: TranscriptionResult, done_event: asyncio.Event
     ) -> None:
         final_parts: list[str] = []
 
@@ -181,6 +181,9 @@ class InworldSTTProvider(STTProvider):
                     logger.warning(
                         "inworld_stt_error", provider="inworld", model=self._model, msg=msg
                     )
+                    break
+
+                if "usage" in msg:
                     break
 
                 transcription = msg.get("result", {}).get("transcription")
@@ -202,7 +205,6 @@ class InworldSTTProvider(STTProvider):
                     final_parts.append(text.strip())
                     if result.audio_start_time is not None:
                         result.audio_to_final_seconds = now - result.audio_start_time
-                    final_event.set()
                 else:
                     result.partial_transcripts.append(text.strip())
 
@@ -212,6 +214,8 @@ class InworldSTTProvider(STTProvider):
             )
             if result.error is None and result.audio_to_final_seconds is None:
                 result.error = str(exc)
+
+        done_event.set()
 
         if final_parts:
             # Inworld emits whole-phrase final segments; join with spaces.

--- a/runner/tests/providers/stt/conftest.py
+++ b/runner/tests/providers/stt/conftest.py
@@ -55,27 +55,32 @@ class FakeWebSocket:
     """Async context-manager WebSocket fake that replays JSON events from a list.
 
     Each entry in *events* is either a ``dict`` (serialised to JSON) or a
-    ``str`` (sent verbatim).  ``bytes`` entries are forwarded as-is.
+    ``str`` (sent verbatim).  ``bytes`` entries are forwarded as-is. With
+    ``server_closes=False`` the receive iterator blocks until the client closes,
+    modelling a server (e.g. Inworld) that keeps the socket open.
     """
 
     def __init__(
         self,
         events: list[dict[str, Any] | str | bytes],
         on_send: Callable[[Any], None] | None = None,
+        *,
+        server_closes: bool = True,
     ) -> None:
         self._events: list[dict[str, Any] | str | bytes] = list(events)
         self._on_send = on_send
-        self._closed = False
+        self._server_closes = server_closes
+        self._closed = asyncio.Event()
         self._sent: list[Any] = []
 
     async def __aenter__(self) -> FakeWebSocket:
         return self
 
     async def __aexit__(self, *exc: object) -> None:
-        self._closed = True
+        self._closed.set()
 
     async def close(self) -> None:
-        self._closed = True
+        self._closed.set()
         self._events.clear()
 
     async def send(self, msg: bytes | str) -> None:
@@ -92,21 +97,30 @@ class FakeWebSocket:
         return evt
 
     def __aiter__(self) -> AsyncFakeWebSocketIter:
-        return AsyncFakeWebSocketIter(self._events)
+        return AsyncFakeWebSocketIter(self._events, self._closed, self._server_closes)
 
 
 class AsyncFakeWebSocketIter:
     """Async iterator over the remaining events list."""
 
-    def __init__(self, events: list[dict[str, Any] | str | bytes]) -> None:
+    def __init__(
+        self,
+        events: list[dict[str, Any] | str | bytes],
+        closed: asyncio.Event,
+        server_closes: bool,
+    ) -> None:
         self._events = events
+        self._closed = closed
+        self._server_closes = server_closes
 
     def __aiter__(self) -> AsyncFakeWebSocketIter:
         return self
 
     async def __anext__(self) -> str | bytes:
-        if not self._events:
-            raise StopAsyncIteration
+        while not self._events:
+            if self._server_closes or self._closed.is_set():
+                raise StopAsyncIteration
+            await self._closed.wait()
         evt = self._events.pop(0)
         if isinstance(evt, dict):
             return json.dumps(evt)
@@ -128,6 +142,7 @@ _WAIT_PATCHES = (
     "coval_bench.providers.stt.deepgram._FLUX_EOT_SILENCE_S",
     "coval_bench.providers.stt.xai._FINAL_WAIT_S",
     "coval_bench.providers.stt.gradium._FLUSH_WAIT_S",
+    "coval_bench.providers.stt.inworld._FINAL_WAIT_S",
 )
 
 

--- a/runner/tests/providers/stt/conftest.py
+++ b/runner/tests/providers/stt/conftest.py
@@ -142,7 +142,7 @@ _WAIT_PATCHES = (
     "coval_bench.providers.stt.deepgram._FLUX_EOT_SILENCE_S",
     "coval_bench.providers.stt.xai._FINAL_WAIT_S",
     "coval_bench.providers.stt.gradium._FLUSH_WAIT_S",
-    "coval_bench.providers.stt.inworld._FINAL_WAIT_S",
+    "coval_bench.providers.stt.inworld._CLOSE_WAIT_S",
 )
 
 

--- a/runner/tests/providers/stt/fixtures/inworld/events-success.json
+++ b/runner/tests/providers/stt/fixtures/inworld/events-success.json
@@ -2,5 +2,6 @@
   {"result": {"transcription": {"transcript": "hello", "isFinal": false}}},
   {"result": {"transcription": {"transcript": "hello world", "isFinal": true}}},
   {"result": {"transcription": {"transcript": "how", "isFinal": false}}},
-  {"result": {"transcription": {"transcript": "how are you", "isFinal": true}}}
+  {"result": {"transcription": {"transcript": "how are you", "isFinal": true}}},
+  {"usage": {"durationSeconds": 3}}
 ]

--- a/runner/tests/providers/stt/test_inworld.py
+++ b/runner/tests/providers/stt/test_inworld.py
@@ -11,6 +11,8 @@ Final segments are whole phrases, so the transcript joins them with spaces.
 
 from __future__ import annotations
 
+import base64
+import json
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -27,7 +29,7 @@ def make_provider() -> InworldSTTProvider:
 
 
 def _fake_connect(events: list[Any]) -> Any:
-    ws = FakeWebSocket(events)
+    ws = FakeWebSocket(events, server_closes=False)
     cm = MagicMock()
     cm.__aenter__ = AsyncMock(return_value=ws)
     cm.__aexit__ = AsyncMock(return_value=False)
@@ -99,6 +101,61 @@ async def test_inworld_excludes_interim_segments(
     assert result.error is None
     assert result.complete_transcript == "hello world"
     assert result.word_count == 2
+
+
+@pytest.mark.asyncio
+async def test_inworld_completes_when_server_keeps_stream_open(
+    fake_api_key: SecretStr, audio_pcm_bytes: bytes
+) -> None:
+    events: list[Any] = [
+        {"result": {"transcription": {"transcript": "hello world", "isFinal": False}}},
+        {"result": {"transcription": {"transcript": "hello world", "isFinal": True}}},
+        {"usage": {"durationSeconds": 3}},
+    ]
+    provider = InworldSTTProvider(api_key=fake_api_key)
+
+    with patch(
+        "coval_bench.providers.stt.inworld.ws_client.connect",
+        return_value=_fake_connect(events),
+    ):
+        result = await provider.measure_ttft(
+            audio_data=audio_pcm_bytes,
+            channels=1,
+            sample_width=2,
+            sample_rate=16000,
+            realtime_resolution=0.5,
+        )
+
+    assert result.error is None
+    assert result.complete_transcript == "hello world"
+    assert result.audio_to_final_seconds is not None
+
+
+@pytest.mark.asyncio
+async def test_inworld_merges_sub_20ms_tail_chunk(fake_api_key: SecretStr) -> None:
+    audio = b"\x00" * (16000 * 2 + 320)  # two 16000 B chunks + a 320 B (10 ms) tail
+    ws = FakeWebSocket([], server_closes=False)
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=ws)
+    cm.__aexit__ = AsyncMock(return_value=False)
+
+    provider = InworldSTTProvider(api_key=fake_api_key)
+    with patch("coval_bench.providers.stt.inworld.ws_client.connect", return_value=cm):
+        await provider.measure_ttft(
+            audio_data=audio,
+            channels=1,
+            sample_width=2,
+            sample_rate=16000,
+            realtime_resolution=0.5,
+        )
+
+    chunk_byte_lengths = [
+        len(base64.b64decode(json.loads(msg)["audioChunk"]["content"]))
+        for msg in ws._sent
+        if isinstance(msg, str) and "audioChunk" in msg
+    ]
+    assert chunk_byte_lengths == [16000, 16320]
+    assert min(chunk_byte_lengths) >= 640
 
 
 # ---------------------------------------------------------------------------
@@ -265,7 +322,7 @@ async def test_inworld_surfaces_send_failure(
         if isinstance(msg, str) and "audioChunk" in msg:
             raise RuntimeError("send boom")
 
-    ws = FakeWebSocket([], on_send=_raise_on_audio)
+    ws = FakeWebSocket([], on_send=_raise_on_audio, server_closes=False)
     cm = MagicMock()
     cm.__aenter__ = AsyncMock(return_value=ws)
     cm.__aexit__ = AsyncMock(return_value=False)

--- a/runner/tests/providers/stt/test_inworld.py
+++ b/runner/tests/providers/stt/test_inworld.py
@@ -133,6 +133,35 @@ async def test_inworld_completes_when_server_keeps_stream_open(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("resolution", [0.005, 2.0])
+async def test_inworld_clamps_chunk_duration(fake_api_key: SecretStr, resolution: float) -> None:
+    audio = b"\x00" * 64000
+    ws = FakeWebSocket([], server_closes=False)
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=ws)
+    cm.__aexit__ = AsyncMock(return_value=False)
+
+    provider = InworldSTTProvider(api_key=fake_api_key)
+    with patch("coval_bench.providers.stt.inworld.ws_client.connect", return_value=cm):
+        await provider.measure_ttft(
+            audio_data=audio,
+            channels=1,
+            sample_width=2,
+            sample_rate=16000,
+            realtime_resolution=resolution,
+        )
+
+    chunk_byte_lengths = [
+        len(base64.b64decode(json.loads(msg)["audioChunk"]["content"]))
+        for msg in ws._sent
+        if isinstance(msg, str) and "audioChunk" in msg
+    ]
+    assert sum(chunk_byte_lengths) == len(audio)
+    # 20-1000 ms at 16 kHz mono PCM.
+    assert all(640 <= n <= 32000 for n in chunk_byte_lengths)
+
+
+@pytest.mark.asyncio
 async def test_inworld_rebalances_sub_20ms_tail_chunk(fake_api_key: SecretStr) -> None:
     audio = b"\x00" * (16000 * 2 + 320)  # two 16000 B chunks + a 320 B (10 ms) tail
     ws = FakeWebSocket([], server_closes=False)

--- a/runner/tests/providers/stt/test_inworld.py
+++ b/runner/tests/providers/stt/test_inworld.py
@@ -110,6 +110,7 @@ async def test_inworld_completes_when_server_keeps_stream_open(
     events: list[Any] = [
         {"result": {"transcription": {"transcript": "hello world", "isFinal": False}}},
         {"result": {"transcription": {"transcript": "hello world", "isFinal": True}}},
+        {"result": {"transcription": {"transcript": "how are you", "isFinal": True}}},
         {"usage": {"durationSeconds": 3}},
     ]
     provider = InworldSTTProvider(api_key=fake_api_key)
@@ -127,12 +128,12 @@ async def test_inworld_completes_when_server_keeps_stream_open(
         )
 
     assert result.error is None
-    assert result.complete_transcript == "hello world"
+    assert result.complete_transcript == "hello world how are you"
     assert result.audio_to_final_seconds is not None
 
 
 @pytest.mark.asyncio
-async def test_inworld_merges_sub_20ms_tail_chunk(fake_api_key: SecretStr) -> None:
+async def test_inworld_rebalances_sub_20ms_tail_chunk(fake_api_key: SecretStr) -> None:
     audio = b"\x00" * (16000 * 2 + 320)  # two 16000 B chunks + a 320 B (10 ms) tail
     ws = FakeWebSocket([], server_closes=False)
     cm = MagicMock()
@@ -154,7 +155,7 @@ async def test_inworld_merges_sub_20ms_tail_chunk(fake_api_key: SecretStr) -> No
         for msg in ws._sent
         if isinstance(msg, str) and "audioChunk" in msg
     ]
-    assert chunk_byte_lengths == [16000, 16320]
+    assert chunk_byte_lengths == [16000, 8160, 8160]
     assert min(chunk_byte_lengths) >= 640
 
 

--- a/runner/tests/providers/stt/test_pacing.py
+++ b/runner/tests/providers/stt/test_pacing.py
@@ -54,6 +54,53 @@ async def test_paces_every_chunk_including_last(monkeypatch: pytest.MonkeyPatch)
     assert yielded[-1][1] == 1000.0
 
 
+async def test_min_tail_bytes_merges_short_final(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_sleep(delay: float) -> None:
+        pass
+
+    monkeypatch.setattr(time, "monotonic", lambda: 0.0)
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+
+    audio = b"\x00" * 1000
+    chunks = [c async for c, _ in _pacing.paced_chunks(audio, 300, _BYTE_RATE, min_tail_bytes=150)]
+    assert b"".join(chunks) == audio
+    assert [len(c) for c in chunks] == [300, 300, 400]
+
+
+async def test_min_tail_bytes_leaves_adequate_tail(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_sleep(delay: float) -> None:
+        pass
+
+    monkeypatch.setattr(time, "monotonic", lambda: 0.0)
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+
+    audio = b"\x00" * 1000
+    chunks = [c async for c, _ in _pacing.paced_chunks(audio, 300, _BYTE_RATE, min_tail_bytes=100)]
+    assert [len(c) for c in chunks] == [300, 300, 300, 100]
+
+
+async def test_min_tail_bytes_single_chunk_untouched(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_sleep(delay: float) -> None:
+        pass
+
+    monkeypatch.setattr(time, "monotonic", lambda: 0.0)
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+
+    audio = b"\x00" * 50
+    chunks = [c async for c, _ in _pacing.paced_chunks(audio, 300, _BYTE_RATE, min_tail_bytes=150)]
+    assert [len(c) for c in chunks] == [50]
+
+
+def test_sync_min_tail_bytes_merges_short_final(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(time, "monotonic", lambda: 0.0)
+    monkeypatch.setattr(time, "sleep", lambda delay: None)
+
+    chunks = [
+        c for c, _ in _pacing.paced_chunks_sync(b"\x00" * 500, 200, _BYTE_RATE, min_tail_bytes=150)
+    ]
+    assert [len(c) for c in chunks] == [200, 300]
+
+
 async def test_chunk_size_floored_to_one(monkeypatch: pytest.MonkeyPatch) -> None:
     async def fake_sleep(delay: float) -> None:
         pass

--- a/runner/tests/providers/stt/test_pacing.py
+++ b/runner/tests/providers/stt/test_pacing.py
@@ -54,7 +54,7 @@ async def test_paces_every_chunk_including_last(monkeypatch: pytest.MonkeyPatch)
     assert yielded[-1][1] == 1000.0
 
 
-async def test_min_tail_bytes_merges_short_final(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_min_tail_bytes_rebalances_short_tail(monkeypatch: pytest.MonkeyPatch) -> None:
     async def fake_sleep(delay: float) -> None:
         pass
 
@@ -63,6 +63,22 @@ async def test_min_tail_bytes_merges_short_final(monkeypatch: pytest.MonkeyPatch
 
     audio = b"\x00" * 1000
     chunks = [c async for c, _ in _pacing.paced_chunks(audio, 300, _BYTE_RATE, min_tail_bytes=150)]
+    assert b"".join(chunks) == audio
+    # The last two chunks split evenly, so no chunk ever exceeds chunk_size.
+    assert [len(c) for c in chunks] == [300, 300, 200, 200]
+
+
+async def test_min_tail_bytes_folds_when_halves_too_small(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake_sleep(delay: float) -> None:
+        pass
+
+    monkeypatch.setattr(time, "monotonic", lambda: 0.0)
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+
+    audio = b"\x00" * 1000
+    chunks = [c async for c, _ in _pacing.paced_chunks(audio, 300, _BYTE_RATE, min_tail_bytes=250)]
     assert b"".join(chunks) == audio
     assert [len(c) for c in chunks] == [300, 300, 400]
 
@@ -91,14 +107,14 @@ async def test_min_tail_bytes_single_chunk_untouched(monkeypatch: pytest.MonkeyP
     assert [len(c) for c in chunks] == [50]
 
 
-def test_sync_min_tail_bytes_merges_short_final(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_sync_min_tail_bytes_rebalances_short_tail(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(time, "monotonic", lambda: 0.0)
     monkeypatch.setattr(time, "sleep", lambda delay: None)
 
     chunks = [
-        c for c, _ in _pacing.paced_chunks_sync(b"\x00" * 500, 200, _BYTE_RATE, min_tail_bytes=150)
+        c for c, _ in _pacing.paced_chunks_sync(b"\x00" * 500, 200, _BYTE_RATE, min_tail_bytes=120)
     ]
-    assert [len(c) for c in chunks] == [200, 300]
+    assert [len(c) for c in chunks] == [200, 150, 150]
 
 
 async def test_chunk_size_floored_to_one(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/runner/tests/providers/stt/test_xai.py
+++ b/runner/tests/providers/stt/test_xai.py
@@ -492,7 +492,7 @@ async def test_xai_force_finalize_closes_socket(
 
     assert result.error is None
     assert result.audio_to_final_seconds is not None
-    assert captured["ws"]._closed is True
+    assert captured["ws"]._closed.is_set()
 
 
 def test_xai_provider_name() -> None:


### PR DESCRIPTION
The server keeps the socket open after closeStream, so close client-side once the post-endTurn final arrives, and merge sub-20ms tail chunks that Inworld rejects.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes Inworld STT streaming behavior in production. The main changes are:

- Client-side websocket close after the final Inworld completion signal.
- Audio chunk clamping to Inworld's accepted duration range.
- Tail-chunk rebalancing for very short final audio chunks.
- Test websocket updates for servers that keep streams open.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<sub>Reviews (4): Last reviewed commit: ["Clamp Inworld chunk duration to protocol..."](https://github.com/coval-ai/benchmarks/commit/fb733dd1fe2950b051b31ebb65b1bc64a58a9ec8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42519523)</sub>

<!-- /greptile_comment -->