### PR TITLE
[BENCH-334] Add drag-to-zoom and Y-axis scaling to the latency timeline

### DIFF
--- a/web/components/charts/tooltips/TimelineTooltip.tsx
+++ b/web/components/charts/tooltips/TimelineTooltip.tsx
@@ -31,7 +31,17 @@ const CustomTimelineTooltip: React.FC<TimelineTooltipProps> = ({ active, payload
 
   if (validData.length === 0) return null;
 
-  const rows = compact ? validData.slice(0, 1) : validData;
+  const inRange = (value: number) =>
+    !highlightRange ||
+    (value >= highlightRange[0] && value <= highlightRange[1]);
+
+  // Compact hover shows one row: the fastest model that's actually in view,
+  // so a Y-zoom past the global leader still surfaces a visible model.
+  const rows = compact
+    ? [validData.find((item) => inRange(item.value)) ?? validData[0]].filter(
+        (item): item is (typeof validData)[number] => item != null
+      )
+    : validData;
 
   return (
     <div
@@ -63,10 +73,7 @@ const CustomTimelineTooltip: React.FC<TimelineTooltipProps> = ({ active, payload
           // Extract model name from dataKey (remove '_value' suffix)
           const modelName = item.dataKey.replace(/_value$/, "");
           const provider = getProviderForModel(modelName);
-          const inView =
-            !highlightRange ||
-            (item.value >= highlightRange[0] &&
-              item.value <= highlightRange[1]);
+          const inView = inRange(item.value);
 
           return (
             <div

--- a/web/components/charts/tooltips/TimelineTooltip.tsx
+++ b/web/components/charts/tooltips/TimelineTooltip.tsx
@@ -15,9 +15,13 @@ interface TimelineTooltipProps {
   label?: string | number;
   getProviderForModel: (model: string) => string;
   showDate?: boolean;
+  /** Visible Y range when zoomed; models outside it (clipped off-chart) dim. */
+  highlightRange?: [number, number];
+  /** Hover mode: only the fastest model plus a pin hint, so the chart stays visible. */
+  compact?: boolean;
 }
 
-const CustomTimelineTooltip: React.FC<TimelineTooltipProps> = ({ active, payload, label, getProviderForModel, showDate }) => {
+const CustomTimelineTooltip: React.FC<TimelineTooltipProps> = ({ active, payload, label, getProviderForModel, showDate, highlightRange, compact }) => {
   if (!active || !payload || payload.length === 0) return null;
 
   // Filter out null/undefined values and sort by value (fastest to slowest)
@@ -27,6 +31,8 @@ const CustomTimelineTooltip: React.FC<TimelineTooltipProps> = ({ active, payload
 
   if (validData.length === 0) return null;
 
+  const rows = compact ? validData.slice(0, 1) : validData;
+
   return (
     <div
       style={{
@@ -35,7 +41,7 @@ const CustomTimelineTooltip: React.FC<TimelineTooltipProps> = ({ active, payload
         borderRadius: "8px",
         color: "var(--color-text-on-tooltip)",
         padding: "12px",
-        minWidth: "250px"
+        minWidth: compact ? "180px" : "250px"
       }}
     >
       <p
@@ -47,12 +53,20 @@ const CustomTimelineTooltip: React.FC<TimelineTooltipProps> = ({ active, payload
       </p>
       <div
         className="tooltip-scroll"
-        style={{ fontSize: "11px", maxHeight: "300px", overflowY: "scroll", paddingRight: "8px" }}
+        style={
+          compact
+            ? { fontSize: "11px" }
+            : { fontSize: "11px", maxHeight: "300px", overflowY: "scroll", paddingRight: "8px" }
+        }
       >
-        {validData.map((item, index) => {
+        {rows.map((item, index) => {
           // Extract model name from dataKey (remove '_value' suffix)
           const modelName = item.dataKey.replace(/_value$/, "");
           const provider = getProviderForModel(modelName);
+          const inView =
+            !highlightRange ||
+            (item.value >= highlightRange[0] &&
+              item.value <= highlightRange[1]);
 
           return (
             <div
@@ -61,7 +75,8 @@ const CustomTimelineTooltip: React.FC<TimelineTooltipProps> = ({ active, payload
                 margin: "6px 0",
                 display: "flex",
                 alignItems: "center",
-                justifyContent: "space-between"
+                justifyContent: "space-between",
+                opacity: inView ? 1 : 0.35
               }}
             >
               <div style={{ display: "flex", alignItems: "center", flex: 1 }}>
@@ -109,6 +124,17 @@ const CustomTimelineTooltip: React.FC<TimelineTooltipProps> = ({ active, payload
           );
         })}
       </div>
+      {compact && validData.length > 1 && (
+        <p
+          style={{
+            margin: "8px 0 0",
+            fontSize: "10px",
+            color: "var(--color-text-on-tooltip-secondary)"
+          }}
+        >
+          +{validData.length - 1} more · click to pin
+        </p>
+      )}
     </div>
   );
 };

--- a/web/components/visualizations/TimelineChart.tsx
+++ b/web/components/visualizations/TimelineChart.tsx
@@ -111,6 +111,8 @@ interface PinnedTooltip {
   flip: boolean;
 }
 
+const Y_MAX_PRESETS = [500, 1000, 1500, 2000, 3000, 5000];
+
 const TimelineChart: React.FC = () => {
   const activeTab = useActiveTab();
   const {
@@ -128,8 +130,22 @@ const TimelineChart: React.FC = () => {
   const trackChartHover = useChartHoverTracking("timeline");
 
   const chartRef = useRef<HTMLDivElement>(null);
+  const chartInstRef = useRef<React.ElementRef<typeof LineChart>>(null);
   const pinnedRef = useRef<HTMLDivElement>(null);
   const [pinned, setPinned] = useState<PinnedTooltip | null>(null);
+  const [zoom, setZoom] = useState<{
+    x?: [number, number];
+    y?: [number, number];
+  } | null>(null);
+  const boxRef = useRef<HTMLDivElement>(null);
+  const dragRef = useRef<{
+    x: number;
+    y: number;
+    armX: boolean;
+    armY: boolean;
+  } | null>(null);
+  const dragEndAtRef = useRef(0);
+  const [dragging, setDragging] = useState(false);
   const [hoveredMarker, setHoveredMarker] = useState<{
     change: MethodologyChange;
     x: number;
@@ -139,14 +155,19 @@ const TimelineChart: React.FC = () => {
   const currentTimeWindow = getCurrentTimeWindow();
   const [windowStart, windowEnd] = currentTimeWindow;
 
-  // The metric is shared dashboard-wide, so clear any pinned tooltip whenever it
-  // changes — whether from this chart's toggle or another section's. Also clear
-  // the marker popover when the time window shifts, since a marker may scroll
-  // out of range.
+  // The metric and time window are shared dashboard-wide, so drop the zoom and
+  // the marker popover whenever either shifts — the zoomed region may no longer
+  // exist in the new data.
+  useEffect(() => {
+    setHoveredMarker(null);
+    setZoom(null);
+  }, [metric, windowStart, windowEnd]);
+
+  // The pin is anchored in pixel space, so a zoom change (drag, Y-max select,
+  // reset) moves the ground under it — drop it rather than mislabel a point.
   useEffect(() => {
     setPinned(null);
-    setHoveredMarker(null);
-  }, [metric, windowStart, windowEnd]);
+  }, [zoom, metric, windowStart, windowEnd]);
 
   useEffect(() => {
     if (pinned === null) return;
@@ -183,8 +204,21 @@ const TimelineChart: React.FC = () => {
     [activeMetricKey, windowStart, windowEnd]
   );
   const tzAbbr = getLocalTimeZoneAbbr();
+  const zoomX = zoom?.x;
+  const xDomain = zoomX ?? currentTimeWindow;
+  const zoomTicks = useMemo(
+    () =>
+      zoomX &&
+      Array.from(
+        { length: 6 },
+        (_, i) => zoomX[0] + ((zoomX[1] - zoomX[0]) * i) / 5
+      ),
+    [zoomX]
+  );
   const dateScale = dataTimeWindow !== "24h";
-  const xAxisLabel = dateScale ? "Date" : tzAbbr ? `Time (${tzAbbr})` : "Time";
+  const dateTicks =
+    dateScale && !(zoomX && zoomX[1] - zoomX[0] <= 48 * 60 * 60 * 1000);
+  const xAxisLabel = dateTicks ? "Date" : tzAbbr ? `Time (${tzAbbr})` : "Time";
 
   const metricLabel = metric;
   const description =
@@ -200,6 +234,8 @@ const TimelineChart: React.FC = () => {
   const yAxisMax = useMemo(() => {
     let max = 0;
     for (const point of getTimelineData(metric)) {
+      if (zoomX && (point.timestamp < zoomX[0] || point.timestamp > zoomX[1]))
+        continue;
       const record = point as Record<string, number>;
       for (const model of modelsWithData) {
         const value = record[`${model}_value`];
@@ -209,9 +245,63 @@ const TimelineChart: React.FC = () => {
       }
     }
     if (max === 0) return "dataMax" as const;
-    const step = 500;
+    const step = max > 2000 ? 500 : max > 500 ? 250 : 50;
     return Math.ceil(max / step) * step;
-  }, [getTimelineData, metric, modelsWithData]);
+  }, [getTimelineData, metric, modelsWithData, zoomX]);
+
+  const yDomain: [number, number | "dataMax"] = zoom?.y ?? [0, yAxisMax];
+  const ySpan =
+    typeof yDomain[1] === "number" ? yDomain[1] - yDomain[0] : null;
+
+  // Ticks land on a tidy step sized to the zoomed span; finer steps need a
+  // second decimal to stay distinguishable.
+  let yTicks: number[] | undefined;
+  let yTickDecimals = 1;
+  if (ySpan !== null && ySpan > 0) {
+    const step =
+      [50, 100, 200, 250, 500, 1000, 2000].find((s) => ySpan / s <= 6) ?? 2500;
+    yTicks = [];
+    for (
+      let t = Math.ceil(yDomain[0] / step) * step;
+      t <= yDomain[0] + ySpan + 1;
+      t += step
+    ) {
+      yTicks.push(t);
+    }
+    yTickDecimals = step < 500 ? 2 : 1;
+  }
+
+  const yMaxSelectValue = !zoom?.y
+    ? "auto"
+    : zoom.y[0] === 0 && Y_MAX_PRESETS.includes(zoom.y[1])
+      ? String(zoom.y[1])
+      : "custom";
+
+  // Plot-area box in container pixels, read off the chart instance (recharts
+  // keeps it in state; mouse-event payloads omit it).
+  const plotBox = () => {
+    const offset = chartInstRef.current?.state.offset;
+    if (!offset?.width || !offset.height) return null;
+    return {
+      left: offset.left ?? 0,
+      top: offset.top ?? 0,
+      width: offset.width,
+      height: offset.height,
+    };
+  };
+
+  const endDrag = () => {
+    dragRef.current = null;
+    setDragging(false);
+    if (boxRef.current) boxRef.current.style.display = "none";
+  };
+
+  // Whether a data value sits inside the visible (possibly zoomed) Y range.
+  // Recharts doesn't clip active dots, so out-of-view dots must not render.
+  const inYView = (v?: number) =>
+    v != null &&
+    (typeof yDomain[1] !== "number" ||
+      (v >= yDomain[0] && v <= yDomain[1]));
 
   return (
     <div className="mb-4">
@@ -229,14 +319,147 @@ const TimelineChart: React.FC = () => {
           }}
         />
 
-        <MetricToggle />
+        <div className="flex items-start justify-between gap-2">
+          <MetricToggle />
+          <div className="mb-4 ml-auto flex items-center gap-2">
+            {zoom && (
+              <button
+                type="button"
+                onClick={() => setZoom(null)}
+                className="rounded-md bg-surface-toggle-inactive px-3 py-1 text-xs font-medium text-text-secondary transition-colors hover:text-text-primary"
+              >
+                Reset zoom
+              </button>
+            )}
+            <label className="flex items-center gap-1.5 text-xs font-medium text-text-secondary">
+              Y max
+              <select
+                value={yMaxSelectValue}
+                onChange={(e) => {
+                  const v = e.target.value;
+                  if (v === "custom") return;
+                  setZoom((z) =>
+                    v === "auto"
+                      ? z?.x
+                        ? { x: z.x }
+                        : null
+                      : { x: z?.x, y: [0, Number(v)] }
+                  );
+                }}
+                className="rounded-md bg-surface-toggle-inactive px-2 py-1 text-xs font-medium text-text-primary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-text-tertiary/40"
+              >
+                <option value="auto">Auto</option>
+                {Y_MAX_PRESETS.map((v) => (
+                  <option key={v} value={v}>{`${v / 1000}s`}</option>
+                ))}
+                {yMaxSelectValue === "custom" && (
+                  <option value="custom">Custom</option>
+                )}
+              </select>
+            </label>
+          </div>
+        </div>
 
-        <div ref={chartRef} className="relative h-96" onMouseEnter={trackChartHover}>
+        <div
+          ref={chartRef}
+          className="relative h-96 cursor-crosshair select-none"
+          onMouseEnter={trackChartHover}
+          onDoubleClick={() => {
+            if (Date.now() - dragEndAtRef.current > 400) setZoom(null);
+          }}
+          onPointerDown={(e) => {
+            if (e.pointerType !== "mouse" || e.button !== 0) return;
+            const box = plotBox();
+            const rect = chartRef.current?.getBoundingClientRect();
+            if (!box || !rect) return;
+            const x = e.clientX - rect.left;
+            const y = e.clientY - rect.top;
+            if (
+              x < box.left ||
+              x > box.left + box.width ||
+              y < box.top ||
+              y > box.top + box.height
+            )
+              return;
+            dragRef.current = { x, y, armX: false, armY: false };
+          }}
+          onPointerMove={(e) => {
+            const start = dragRef.current;
+            const box = plotBox();
+            const rect = chartRef.current?.getBoundingClientRect();
+            const el = boxRef.current;
+            if (!start || !box || !rect || !el) return;
+            const x = Math.min(
+              Math.max(e.clientX - rect.left, box.left),
+              box.left + box.width
+            );
+            const y = Math.min(
+              Math.max(e.clientY - rect.top, box.top),
+              box.top + box.height
+            );
+            start.armX = start.armX || Math.abs(x - start.x) > 12;
+            start.armY = start.armY || Math.abs(y - start.y) > 12;
+            if (!start.armX && !start.armY) {
+              el.style.display = "none";
+              return;
+            }
+            // Capture only once a real drag is in progress — capturing on
+            // pointerdown would swallow the click recharts needs for pinning.
+            chartRef.current?.setPointerCapture(e.pointerId);
+            if (!dragging) setDragging(true);
+            el.style.display = "block";
+            el.style.left = `${start.armX ? Math.min(start.x, x) : box.left}px`;
+            el.style.width = `${start.armX ? Math.abs(x - start.x) : box.width}px`;
+            el.style.top = `${start.armY ? Math.min(start.y, y) : box.top}px`;
+            el.style.height = `${start.armY ? Math.abs(y - start.y) : box.height}px`;
+          }}
+          onPointerUp={(e) => {
+            const start = dragRef.current;
+            const box = plotBox();
+            const rect = chartRef.current?.getBoundingClientRect();
+            endDrag();
+            if (!start || !box || !rect || (!start.armX && !start.armY)) return;
+            dragEndAtRef.current = Date.now();
+            const x = Math.min(
+              Math.max(e.clientX - rect.left, box.left),
+              box.left + box.width
+            );
+            const y = Math.min(
+              Math.max(e.clientY - rect.top, box.top),
+              box.top + box.height
+            );
+            const applyX = start.armX && Math.abs(x - start.x) > 8;
+            const applyY = start.armY && Math.abs(y - start.y) > 8;
+            const hi = yDomain[1];
+            let yRange = zoom?.y;
+            if (applyY && typeof hi === "number") {
+              const toY = (py: number) =>
+                hi - ((py - box.top) / box.height) * (hi - yDomain[0]);
+              yRange = [
+                Math.max(0, toY(Math.max(start.y, y))),
+                toY(Math.min(start.y, y)),
+              ];
+            }
+            if (!applyX && yRange === zoom?.y) return;
+            const toX = (px: number) =>
+              xDomain[0] +
+              ((px - box.left) / box.width) * (xDomain[1] - xDomain[0]);
+            setZoom({
+              x: applyX
+                ? [toX(Math.min(start.x, x)), toX(Math.max(start.x, x))]
+                : zoom?.x,
+              y: yRange,
+            });
+          }}
+          onPointerCancel={endDrag}
+        >
           <ResponsiveContainer width="100%" height="100%">
             <LineChart
+              ref={chartInstRef}
               data={windowedTimelineData}
               margin={{ top: 5, right: 8, left: 0, bottom: 5 }}
               onClick={(state) => {
+                if (Date.now() - dragEndAtRef.current < 300) return;
                 const lbl = state?.activeLabel;
                 const coord = state?.activeCoordinate;
                 const payload = (state?.activePayload ?? []) as TooltipPayloadItem[];
@@ -245,7 +468,7 @@ const TimelineChart: React.FC = () => {
                 );
                 if (lbl == null || !coord || !hasRows) return;
                 setPinned((cur) => {
-                  if (cur && cur.label === lbl) return null;
+                  if (cur) return null;
                   const width = chartRef.current?.clientWidth ?? 0;
                   const height = chartRef.current?.clientHeight ?? 0;
                   const x = coord.x ?? 0;
@@ -274,14 +497,14 @@ const TimelineChart: React.FC = () => {
                 dataKey="timestamp"
                 type="number"
                 scale="time"
-                domain={currentTimeWindow}
-                ticks={getTimelineTicks()}
-                allowDataOverflow={false}
+                domain={xDomain}
+                ticks={zoomTicks ?? getTimelineTicks()}
+                allowDataOverflow
                 axisLine={false}
                 tickLine={false}
                 tick={{ fill: themeColors.axisText, fontSize: 12 }}
                 tickFormatter={(value) =>
-                  dateScale ? formatDate(value) : formatTime(value)
+                  dateTicks ? formatDate(value) : formatTime(value)
                 }
                 label={{
                   value: xAxisLabel,
@@ -299,17 +522,24 @@ const TimelineChart: React.FC = () => {
                 axisLine={false}
                 tickLine={false}
                 tick={{ fill: themeColors.axisText, fontSize: 12 }}
-                domain={[0, yAxisMax]}
-                tickFormatter={(value) => `${(value / 1000).toFixed(1)}s`}
+                domain={yDomain}
+                ticks={yTicks}
+                allowDataOverflow
+                tickFormatter={(value) =>
+                  `${(value / 1000).toFixed(yTickDecimals)}s`
+                }
               />
               <Tooltip
                 content={
                   <CustomTimelineTooltip
                     getProviderForModel={getProviderForModel}
                     showDate={dateScale}
+                    highlightRange={zoom?.y}
+                    compact
                   />
                 }
-                active={pinned ? false : undefined}
+                active={pinned || dragging ? false : undefined}
+                cursor={!dragging}
               />
               {modelsWithData.length > 1 && (
                 <Legend content={<TimelineLegend />} />
@@ -323,10 +553,21 @@ const TimelineChart: React.FC = () => {
                   strokeWidth={modelsWithData.length === 1 ? 3 : 2}
                   dot={false}
                   isAnimationActive={false}
-                  activeDot={{
-                    r: modelsWithData.length === 1 ? 7 : 6,
-                    fill: getModelColor(model)
-                  }}
+                  activeDot={
+                    dragging
+                      ? false
+                      : (props: { cx?: number; cy?: number; value?: number }) =>
+                          inYView(props.value) ? (
+                            <circle
+                              cx={props.cx}
+                              cy={props.cy}
+                              r={modelsWithData.length === 1 ? 7 : 6}
+                              fill={getModelColor(model)}
+                            />
+                          ) : (
+                            <g />
+                          )
+                  }
                   connectNulls={false}
                   name={formatChartLabel(model, getProviderForModel(model))}
                 />
@@ -351,26 +592,38 @@ const TimelineChart: React.FC = () => {
               ))}
             </LineChart>
           </ResponsiveContainer>
+          <div
+            ref={boxRef}
+            className="pointer-events-none absolute z-10 hidden rounded-sm border border-dashed border-text-secondary/50 bg-text-secondary/10"
+          />
           {pinned && (
             <div
               ref={pinnedRef}
+              className="absolute z-20 cursor-auto shadow-lg"
               style={{
-                position: "absolute",
                 left: pinned.x,
                 top: pinned.y,
                 transform: pinned.flip
                   ? "translate(calc(-100% - 12px), -50%)"
                   : "translate(12px, -50%)",
-                pointerEvents: "auto",
-                zIndex: 20,
               }}
+              onPointerDown={(e) => e.stopPropagation()}
             >
+              <button
+                type="button"
+                aria-label="Close pinned stats"
+                onClick={() => setPinned(null)}
+                className="absolute right-2 top-2 z-10 flex h-5 w-5 items-center justify-center rounded-full bg-surface-toggle-inactive text-xs leading-none text-text-secondary hover:text-text-primary"
+              >
+                ×
+              </button>
               <CustomTimelineTooltip
                 active
                 payload={pinned.payload}
                 label={pinned.label}
                 getProviderForModel={getProviderForModel}
                 showDate={dateScale}
+                highlightRange={zoom?.y}
               />
             </div>
           )}

--- a/web/components/visualizations/TimelineChart.tsx
+++ b/web/components/visualizations/TimelineChart.tsx
@@ -430,14 +430,19 @@ const TimelineChart: React.FC = () => {
             );
             const applyX = start.armX && Math.abs(x - start.x) > 8;
             const applyY = start.armY && Math.abs(y - start.y) > 8;
-            const hi = yDomain[1];
+            // Invert pixels through recharts' own y-scale so this works even
+            // on the automatic domain, where yDomain[1] is still "dataMax".
+            const yScale = (
+              chartInstRef.current?.state.yAxisMap &&
+              (Object.values(chartInstRef.current.state.yAxisMap)[0] as {
+                scale?: { invert?: (n: number) => number };
+              })
+            )?.scale;
             let yRange = zoom?.y;
-            if (applyY && typeof hi === "number") {
-              const toY = (py: number) =>
-                hi - ((py - box.top) / box.height) * (hi - yDomain[0]);
+            if (applyY && yScale?.invert) {
               yRange = [
-                Math.max(0, toY(Math.max(start.y, y))),
-                toY(Math.min(start.y, y)),
+                Math.max(0, yScale.invert(Math.max(start.y, y))),
+                yScale.invert(Math.min(start.y, y)),
               ];
             }
             if (!applyX && yRange === zoom?.y) return;


### PR DESCRIPTION
## Problem

On the TTFA timeline, a single latency outlier (e.g. the ~3.7s Hume Octave 2 spike) pins the Y axis to 4s, compressing every other model into the 0–1s band where their lines are indistinguishable. The interesting data is effectively lost.
<img width="941" height="448" alt="Screenshot 2026-07-07 at 2 26 10 PM" src="https://github.com/user-attachments/assets/36a5a919-608d-403a-bd39-bc69b6630cc2" />

## What this adds

A zoom + inspect layer on the timeline chart (`TimelineChart.tsx`), reusing the existing recharts/theme/tooltip stack:

- **Drag to zoom.** Drag any region of the plot to zoom into it. Per-axis "arming" (movement > 12px) decides intent: a horizontal sweep zooms time only, a flat wide sweep over a latency band zooms Y only, a box zooms both. Arming is sticky for the gesture, so moving the mouse back past the start point shrinks the selection through zero instead of snapping to a giant box.
- **Smooth selection.** The selection rectangle is a plain div updated imperatively during the drag, so the 17-series chart re-renders only twice per gesture (hide tooltip on start, apply zoom on release). `setPointerCapture` keeps the drag tracking even when the cursor leaves the plot.
- **Y-max control.** A "Y max" preset selector (0.5s–5s) plus a Reset zoom button; double-click also resets. Tidy tick steps and decimals adapt to the zoomed span.
- **Clean dots.** recharts doesn't clip active dots to the plot area, so out-of-view dots used to paint over the legend/card — they now stop rendering when outside the visible Y range.
- **Pin vs. hover tooltip.** Hover shows a compact card (timestamp + fastest model + "click to pin") so the lines stay visible; clicking a timestamp pins the full scrollable ranking in place. Both dim models that fall outside the zoomed Y range, so the highlighted set matches the dots drawn on the chart.

## Scope / safety

- **Frontend only.** No backend, API, auth, env, or deployment changes.
- Two files touched: `TimelineChart.tsx` and the shared `TimelineTooltip.tsx` (additive `highlightRange` + `compact` props).
- `pnpm typecheck`, `pnpm lint` (0 warnings), `pnpm test` (53 passing), and `pnpm build` all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds zoom and inspection controls to the latency timeline. The main changes are:

- Drag selection for X-axis, Y-axis, or box zoom.
- Y max presets with reset and double-click reset behavior.
- Compact hover tooltips and pinned full ranking tooltips.
- Range-aware tooltip dimming and active-dot clipping.

<h3>Confidence Score: 4/5</h3>

This is close, but the pinned tooltip interaction should be fixed before merging.

- Clicking a different timestamp while a tooltip is pinned still closes the card instead of moving it.
- The Y-axis drag path now uses the chart scale, so the auto-domain zoom case appears addressed.

web/components/visualizations/TimelineChart.tsx

<sub>Reviews (3): Last reviewed commit: ["Show the fastest in-range model in the c..."](https://github.com/coval-ai/benchmarks/commit/a5380dbe5a200dd6884cd1c3b561b6b68954ff22) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42521736)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->