### PR TITLE
Add S2S benchmark axis and V2V latency metric

### DIFF
--- a/runner/src/coval_bench/api/common.py
+++ b/runner/src/coval_bench/api/common.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 from typing import Literal
 
-BenchmarkLiteral = Literal["STT", "TTS"]
+BenchmarkLiteral = Literal["STT", "TTS", "S2S"]
 WindowLiteral = Literal["24h", "7d", "30d"]
 
 # Fixed interval strings — looked up by Python, never user-interpolated into

--- a/runner/src/coval_bench/api/routers/leaderboard.py
+++ b/runner/src/coval_bench/api/routers/leaderboard.py
@@ -33,7 +33,7 @@ logger = structlog.get_logger("coval_bench.api")
 
 router = APIRouter(tags=["leaderboard"])
 
-MetricLiteral = Literal["WER", "TTFA", "TTFT", "TTFS"]
+MetricLiteral = Literal["WER", "TTFA", "TTFT", "TTFS", "V2V"]
 
 # Valid (metric, benchmark) combinations — lower is better for all.
 _VALID_COMBOS: set[tuple[str, str]] = {
@@ -41,6 +41,7 @@ _VALID_COMBOS: set[tuple[str, str]] = {
     ("TTFT", "STT"),
     ("TTFS", "STT"),
     ("TTFA", "TTS"),
+    ("V2V", "S2S"),
 }
 
 _MV_SQL_TEMPLATE = """

--- a/runner/src/coval_bench/api/routers/leaderboard.py
+++ b/runner/src/coval_bench/api/routers/leaderboard.py
@@ -84,7 +84,7 @@ async def get_leaderboard(
         raise HTTPException(
             400,
             f"metric={metric!r} is not compatible with benchmark={benchmark!r}. "
-            f"Valid combinations: WER+STT, TTFT+STT, TTFS+STT, TTFA+TTS.",
+            f"Valid combinations: WER+STT, TTFT+STT, TTFS+STT, TTFA+TTS, V2V+S2S.",
         )
 
     params: dict[str, Any] = {"metric": metric, "benchmark": benchmark}

--- a/runner/src/coval_bench/api/routers/providers.py
+++ b/runner/src/coval_bench/api/routers/providers.py
@@ -104,10 +104,12 @@ def _build_provider_map(benchmark: Benchmark) -> dict[str, list[ModelInfo]]:
 def _describe() -> ProvidersResponse:
     stt_map = _build_provider_map(Benchmark.STT)
     tts_map = _build_provider_map(Benchmark.TTS)
+    s2s_map = _build_provider_map(Benchmark.S2S)
 
     return ProvidersResponse(
         stt=[ProviderInfo(provider=p, models=m) for p, m in sorted(stt_map.items())],
         tts=[ProviderInfo(provider=p, models=m) for p, m in sorted(tts_map.items())],
+        s2s=[ProviderInfo(provider=p, models=m) for p, m in sorted(s2s_map.items())],
         tag_categories=_tag_categories(),
     )
 

--- a/runner/src/coval_bench/api/routers/results.py
+++ b/runner/src/coval_bench/api/routers/results.py
@@ -53,7 +53,7 @@ router = APIRouter(tags=["results"])
 
 # ``MetricLiteral`` is kept as the type for the legacy ``metric`` param.
 # The canonical FE-facing param is ``metric_type`` (plain ``str``).
-MetricLiteral = Literal["WER", "TTFA", "TTFT", "TTFS", "RTF", "AUDIO_TO_FINAL"]
+MetricLiteral = Literal["WER", "TTFA", "TTFT", "TTFS", "RTF", "AUDIO_TO_FINAL", "V2V"]
 
 # Base SELECT used by all three query paths.
 # S608 false-positive: the interpolated fragment is a fixed constant; user

--- a/runner/src/coval_bench/api/schemas.py
+++ b/runner/src/coval_bench/api/schemas.py
@@ -49,7 +49,7 @@ class ResultOut(BaseModel):
     provider: str
     model: str
     voice: str | None
-    benchmark: Literal["STT", "TTS"]
+    benchmark: Literal["STT", "TTS", "S2S"]
     metric_type: str
     metric_value: float | None
     metric_units: str | None
@@ -110,7 +110,8 @@ class ProvidersResponse(BaseModel):
 
     stt: list[ProviderInfo]
     tts: list[ProviderInfo]
-    # Facet vocabulary in display order, shared across STT and TTS.
+    s2s: list[ProviderInfo]
+    # Facet vocabulary in display order, shared across STT, TTS, and S2S.
     tag_categories: list[TagCategoryOut]
 
 
@@ -184,7 +185,7 @@ class RunsResponse(BaseModel):
 class LeaderboardResponse(BaseModel):
     """Response schema for GET /v1/leaderboard."""
 
-    metric: Literal["WER", "TTFA", "TTFT", "TTFS"]
+    metric: Literal["WER", "TTFA", "TTFT", "TTFS", "V2V"]
     window: Literal["24h", "7d", "30d"]
     entries: list[LeaderboardEntry]
 

--- a/runner/src/coval_bench/db/migrations/versions/20260707_0009_add_s2s_benchmark.py
+++ b/runner/src/coval_bench/db/migrations/versions/20260707_0009_add_s2s_benchmark.py
@@ -1,0 +1,62 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Allow 'S2S' in the benchmark CHECK on results and results_by_bucket.
+
+Both tables were created with an inline, column-level CHECK
+(``benchmark IN ('STT','TTS')``), which Postgres names deterministically
+``<table>_benchmark_check``. Adding the S2S dashboard requires widening both
+to include ``'S2S'``. The per-window matviews (results_24h/7d/30d) derive from
+``results`` and carry no constraint, so they need no change.
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "20260707_0009"
+down_revision = "20260626_0008"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Widen both benchmark CHECKs to include 'S2S'."""
+    op.execute(
+        "ALTER TABLE benchmarks_v2.results DROP CONSTRAINT IF EXISTS results_benchmark_check"
+    )
+    op.execute(
+        "ALTER TABLE benchmarks_v2.results "
+        "ADD CONSTRAINT results_benchmark_check "
+        "CHECK (benchmark IN ('STT','TTS','S2S'))"
+    )
+    op.execute(
+        "ALTER TABLE benchmarks_v2.results_by_bucket "
+        "DROP CONSTRAINT IF EXISTS results_by_bucket_benchmark_check"
+    )
+    op.execute(
+        "ALTER TABLE benchmarks_v2.results_by_bucket "
+        "ADD CONSTRAINT results_by_bucket_benchmark_check "
+        "CHECK (benchmark IN ('STT','TTS','S2S'))"
+    )
+
+
+def downgrade() -> None:
+    """Restore the STT/TTS-only CHECKs (fails if any S2S rows exist)."""
+    op.execute(
+        "ALTER TABLE benchmarks_v2.results DROP CONSTRAINT IF EXISTS results_benchmark_check"
+    )
+    op.execute(
+        "ALTER TABLE benchmarks_v2.results "
+        "ADD CONSTRAINT results_benchmark_check "
+        "CHECK (benchmark IN ('STT','TTS'))"
+    )
+    op.execute(
+        "ALTER TABLE benchmarks_v2.results_by_bucket "
+        "DROP CONSTRAINT IF EXISTS results_by_bucket_benchmark_check"
+    )
+    op.execute(
+        "ALTER TABLE benchmarks_v2.results_by_bucket "
+        "ADD CONSTRAINT results_by_bucket_benchmark_check "
+        "CHECK (benchmark IN ('STT','TTS'))"
+    )

--- a/runner/src/coval_bench/registries/benchmarks.py
+++ b/runner/src/coval_bench/registries/benchmarks.py
@@ -12,3 +12,4 @@ class Benchmark(StrEnum):
 
     STT = "STT"
     TTS = "TTS"
+    S2S = "S2S"

--- a/runner/src/coval_bench/registries/metrics.py
+++ b/runner/src/coval_bench/registries/metrics.py
@@ -26,6 +26,7 @@ class Metric(StrEnum):
     TTFA = "TTFA"
     RTF = "RTF"
     AUDIO_TO_FINAL = "AudioToFinal"
+    V2V = "V2V"
 
 
 class MetricDirection(StrEnum):
@@ -89,6 +90,13 @@ METRIC_SPECS: dict[Metric, MetricSpec] = {
         direction=MetricDirection.LOWER_IS_BETTER,
         decimals=2,
         benchmarks=frozenset({Benchmark.STT}),
+    ),
+    Metric.V2V: MetricSpec(
+        display_name="Voice-to-Voice Latency",
+        units="milliseconds",
+        direction=MetricDirection.LOWER_IS_BETTER,
+        decimals=0,
+        benchmarks=frozenset({Benchmark.S2S}),
     ),
 }
 

--- a/runner/tests/unit/test_metric_registry.py
+++ b/runner/tests/unit/test_metric_registry.py
@@ -21,6 +21,7 @@ def test_metric_values_match_stored_strings() -> None:
         "TTFA",
         "RTF",
         "AudioToFinal",
+        "V2V",
     }
 
 
@@ -33,6 +34,7 @@ def test_units_match_stored_strings() -> None:
         Metric.TTFA: "milliseconds",
         Metric.RTF: "ratio",
         Metric.AUDIO_TO_FINAL: "seconds",
+        Metric.V2V: "milliseconds",
     }
     assert {m: spec.units for m, spec in METRIC_SPECS.items()} == expected
 

--- a/web/lib/config/metrics.ts
+++ b/web/lib/config/metrics.ts
@@ -21,5 +21,10 @@ export const metricDescriptions = {
     short: "Word Error Rate (%)",
     detailed:
       "Ensuring accurate speech output is fundamental to user trust and comprehension in voice AI systems. We recognize that even minor pronunciation errors can undermine the entire conversation experience and our evaluation captures how faithfully text-to-speech systems pronounce complex terminology, proper nouns, and domain-specific vocabulary that matter most to your users. Click a bar to highlight it for comparison."
+  },
+  v2v: {
+    short: "Voice-to-Voice Latency",
+    detailed:
+      "V2V latency measures the time from the end of the user's speech (the end of the last transcribed word) to the first frame of the agent's audio response, measured directly from the conversation audio on native single-turn interactions. Because it is derived from the recorded audio rather than internal events, it reflects the full response time a caller actually experiences — including any pipeline overhead — which makes it a fair cross-model comparison of conversational responsiveness."
   }
 };

--- a/web/lib/posthog/events.ts
+++ b/web/lib/posthog/events.ts
@@ -23,9 +23,10 @@ export const POSTHOG_EVENTS = {
 export type PostHogSurface =
   | "tts_dashboard"
   | "stt_dashboard"
+  | "s2s_dashboard"
   | "playground"
   | "overview";
-export type PostHogMode = "tts" | "stt";
+export type PostHogMode = "tts" | "stt" | "s2s";
 export type DashboardChartId =
   | "timeline"
   | "scatter"


### PR DESCRIPTION
Registers the S2S benchmark and V2V (voice-to-voice latency) metric across the registry and the results, leaderboard, and providers APIs, and adds a migration widening the benchmark CHECK constraints on results and results_by_bucket to allow 'S2S'.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds S2S benchmark support and a V2V latency metric. The main changes are:

- Adds `S2S` and `V2V` to backend registry, API, and response schemas.
- Allows `V2V+S2S` in leaderboard validation.
- Adds a migration to widen benchmark checks for stored results.
- Adds frontend metric copy and PostHog type values for S2S.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<sub>Reviews (3): Last reviewed commit: ["List V2V+S2S in the leaderboard combo er..."](https://github.com/coval-ai/benchmarks/commit/78988cbda5d90feec1a08c786f178b98ef2da97b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42531758)</sub>

<!-- /greptile_comment -->