### PR TITLE
Cale/bench 368 drop the assemblyai ttfs methodology annotation

### DIFF
--- a/runner/src/coval_bench/api/routers/aggregates.py
+++ b/runner/src/coval_bench/api/routers/aggregates.py
@@ -104,8 +104,6 @@ async def get_results_aggregates(
             stat_rows = await (await conn.execute(stats_sql, {"benchmark": benchmark})).fetchall()
             series_rows = await (await conn.execute(_SERIES_SQL, series_params)).fetchall()
 
-        # Hide rows for models excluded from a metric (historical rows predate
-        # the orchestrator's write-side skip).
         return AggregatesResponse(
             benchmark=benchmark,
             window=window,

--- a/runner/src/coval_bench/api/routers/aggregates.py
+++ b/runner/src/coval_bench/api/routers/aggregates.py
@@ -48,6 +48,7 @@ from coval_bench.api.deps import (
 )
 from coval_bench.api.ratelimit import limiter
 from coval_bench.api.schemas import AggregatesResponse, ModelStatEntry, SeriesPoint
+from coval_bench.registries import is_metric_excluded
 
 logger = structlog.get_logger("coval_bench.api")
 
@@ -103,11 +104,21 @@ async def get_results_aggregates(
             stat_rows = await (await conn.execute(stats_sql, {"benchmark": benchmark})).fetchall()
             series_rows = await (await conn.execute(_SERIES_SQL, series_params)).fetchall()
 
+        # Hide rows for models excluded from a metric (historical rows predate
+        # the orchestrator's write-side skip).
         return AggregatesResponse(
             benchmark=benchmark,
             window=window,
-            model_stats=[ModelStatEntry.model_validate(r) for r in stat_rows],
-            series=[SeriesPoint.model_validate(r) for r in series_rows],
+            model_stats=[
+                ModelStatEntry.model_validate(r)
+                for r in stat_rows
+                if not is_metric_excluded(r["provider"], r["model"], r["metric_type"])
+            ],
+            series=[
+                SeriesPoint.model_validate(r)
+                for r in series_rows
+                if not is_metric_excluded(r["provider"], r["model"], r["metric_type"])
+            ],
         )
 
     cache_key = ("aggregates", benchmark, window)

--- a/runner/src/coval_bench/api/routers/leaderboard.py
+++ b/runner/src/coval_bench/api/routers/leaderboard.py
@@ -95,8 +95,6 @@ async def get_leaderboard(
         rows = await conn.execute(sql, params)
         entry_rows = await rows.fetchall()
 
-    # Hide rows for models excluded from a metric (historical rows predate
-    # the orchestrator's write-side skip).
     entries = [
         LeaderboardEntry.model_validate(r)
         for r in entry_rows

--- a/runner/src/coval_bench/api/routers/leaderboard.py
+++ b/runner/src/coval_bench/api/routers/leaderboard.py
@@ -28,6 +28,7 @@ from coval_bench.api.common import WINDOW_VIEWS, BenchmarkLiteral, WindowLiteral
 from coval_bench.api.deps import capture_api_event, get_pool, get_posthog
 from coval_bench.api.ratelimit import limiter
 from coval_bench.api.schemas import LeaderboardEntry, LeaderboardResponse
+from coval_bench.registries import is_metric_excluded
 
 logger = structlog.get_logger("coval_bench.api")
 
@@ -94,7 +95,13 @@ async def get_leaderboard(
         rows = await conn.execute(sql, params)
         entry_rows = await rows.fetchall()
 
-    entries = [LeaderboardEntry.model_validate(r) for r in entry_rows]
+    # Hide rows for models excluded from a metric (historical rows predate
+    # the orchestrator's write-side skip).
+    entries = [
+        LeaderboardEntry.model_validate(r)
+        for r in entry_rows
+        if not is_metric_excluded(r["provider"], r["model"], metric)
+    ]
     capture_api_event(
         posthog_client,
         "leaderboard_queried",

--- a/runner/src/coval_bench/providers/stt/openai.py
+++ b/runner/src/coval_bench/providers/stt/openai.py
@@ -16,7 +16,7 @@ its TTFT is comparable to streaming ASR; it also rejects ``turn_detection: serve
 outright, leaving manual-commit the only option (verified 2026-06). ``gpt-4o-transcribe``
 and ``gpt-4o-mini-transcribe`` only transcribe a finalized segment — no partials
 mid-utterance, even with server VAD — so their TTFT is excluded upstream (see
-``_TTFT_NOT_COMPARABLE``).
+``METRIC_EXCLUSIONS`` in the metrics registry).
 """
 
 from __future__ import annotations

--- a/runner/src/coval_bench/registries/__init__.py
+++ b/runner/src/coval_bench/registries/__init__.py
@@ -8,10 +8,12 @@ and the orchestrator without pulling in metric-computation dependencies.
 
 from coval_bench.registries.benchmarks import Benchmark
 from coval_bench.registries.metrics import (
+    METRIC_EXCLUSIONS,
     METRIC_SPECS,
     Metric,
     MetricDirection,
     MetricSpec,
+    is_metric_excluded,
 )
 from coval_bench.registries.models import (
     MODEL_REGISTRY,
@@ -31,6 +33,7 @@ from coval_bench.registries.tags import (
 
 __all__ = [
     "Benchmark",
+    "METRIC_EXCLUSIONS",
     "METRIC_SPECS",
     "MODEL_REGISTRY",
     "Metric",
@@ -45,5 +48,6 @@ __all__ = [
     "TAG_CATEGORIES",
     "ModelTag",
     "TagCategory",
+    "is_metric_excluded",
     "tag_value_label",
 ]

--- a/runner/src/coval_bench/registries/metrics.py
+++ b/runner/src/coval_bench/registries/metrics.py
@@ -95,3 +95,47 @@ METRIC_SPECS: dict[Metric, MetricSpec] = {
 if METRIC_SPECS.keys() != set(Metric):
     _missing = ", ".join(sorted(set(Metric) - METRIC_SPECS.keys()))
     raise RuntimeError(f"METRIC_SPECS is missing specs for: {_missing}")
+
+
+# (provider, model) pairs whose metric is not comparable with the rest of the
+# cohort. The orchestrator skips writing these rows; the API hides any
+# historical rows from aggregate views.
+#
+# TTFT: first token can't precede end-of-speech, so TTFT reflects a buffering
+# gate, not engine speed. xai/grok-stt gates on min audio; the openai
+# transcribe models finalize per-segment (no partials mid-utterance).
+#
+# TTFS: the model doesn't finalize on our end-of-speech signal, so TTFS
+# reflects a network round-trip, not finalization. Flux has no client
+# finalize; AssemblyAI universal-streaming acks ForceEndpoint without
+# flushing the tail.
+METRIC_EXCLUSIONS: dict[Metric, frozenset[tuple[str, str]]] = {
+    Metric.TTFT: frozenset(
+        {
+            ("xai", "grok-stt"),
+            ("openai", "gpt-4o-transcribe"),
+            ("openai", "gpt-4o-mini-transcribe"),
+        }
+    ),
+    Metric.TTFS: frozenset(
+        {
+            ("deepgram", "flux-general-en"),
+            ("deepgram", "flux-general-multi"),
+            ("assemblyai", "universal-streaming"),
+            ("assemblyai", "universal-streaming-multilingual"),
+        }
+    ),
+}
+
+
+def is_metric_excluded(provider: str, model: str, metric: str) -> bool:
+    """True if this (provider, model) pair is excluded from ``metric``.
+
+    Accepts the metric as a plain string (as stored in
+    ``results.metric_type``); unknown metric strings are never excluded.
+    """
+    try:
+        pairs = METRIC_EXCLUSIONS.get(Metric(metric))
+    except ValueError:
+        return False
+    return pairs is not None and (provider, model) in pairs

--- a/runner/src/coval_bench/registries/metrics.py
+++ b/runner/src/coval_bench/registries/metrics.py
@@ -97,18 +97,10 @@ if METRIC_SPECS.keys() != set(Metric):
     raise RuntimeError(f"METRIC_SPECS is missing specs for: {_missing}")
 
 
-# (provider, model) pairs whose metric is not comparable with the rest of the
-# cohort. The orchestrator skips writing these rows; the API hides any
-# historical rows from aggregate views.
-#
-# TTFT: first token can't precede end-of-speech, so TTFT reflects a buffering
-# gate, not engine speed. xai/grok-stt gates on min audio; the openai
-# transcribe models finalize per-segment (no partials mid-utterance).
-#
-# TTFS: the model doesn't finalize on our end-of-speech signal, so TTFS
-# reflects a network round-trip, not finalization. Flux has no client
-# finalize; AssemblyAI universal-streaming acks ForceEndpoint without
-# flushing the tail.
+# (provider, model) pairs whose metric is not comparable with the cohort:
+# TTFT gated by buffering rather than engine speed, TTFS acked without
+# finalizing. The orchestrator skips writing these rows; the API hides
+# historical ones.
 METRIC_EXCLUSIONS: dict[Metric, frozenset[tuple[str, str]]] = {
     Metric.TTFT: frozenset(
         {
@@ -129,11 +121,7 @@ METRIC_EXCLUSIONS: dict[Metric, frozenset[tuple[str, str]]] = {
 
 
 def is_metric_excluded(provider: str, model: str, metric: str) -> bool:
-    """True if this (provider, model) pair is excluded from ``metric``.
-
-    Accepts the metric as a plain string (as stored in
-    ``results.metric_type``); unknown metric strings are never excluded.
-    """
+    """True if this (provider, model) pair is excluded from ``metric``."""
     try:
         pairs = METRIC_EXCLUSIONS.get(Metric(metric))
     except ValueError:

--- a/runner/src/coval_bench/runner/orchestrator.py
+++ b/runner/src/coval_bench/runner/orchestrator.py
@@ -49,6 +49,7 @@ from pydantic import BaseModel
 from coval_bench.providers._http_session import close_all as _close_http_clients
 from coval_bench.providers.base import Provider
 from coval_bench.registries import (
+    METRIC_EXCLUSIONS,
     METRIC_SPECS,
     MODEL_REGISTRY,
     Benchmark,
@@ -68,29 +69,6 @@ _STT_TIMEOUT_S = 45
 _TTS_TIMEOUT_S = 60
 _MAX_ERROR_LEN = 4000  # truncate error messages stored in DB (Postgres text is unbounded
 # but huge stack traces choke log pipelines)
-
-# STT models whose first token can't precede end-of-speech, so TTFT reflects a buffering
-# gate, not engine speed — omit it and rely on TTFS. xai/grok-stt gates on min audio; the
-# openai transcribe models finalize per-segment (no partials mid-utterance, even with VAD).
-_TTFT_NOT_COMPARABLE: frozenset[tuple[str, str]] = frozenset(
-    {
-        ("xai", "grok-stt"),
-        ("openai", "gpt-4o-transcribe"),
-        ("openai", "gpt-4o-mini-transcribe"),
-    }
-)
-
-# STT models that don't finalize on our end-of-speech signal, so TTFS reflects a network
-# round-trip, not finalization — omit it. Flux has no client finalize; AssemblyAI
-# universal-streaming acks ForceEndpoint without flushing the tail.
-_TTFS_NOT_COMPARABLE: frozenset[tuple[str, str]] = frozenset(
-    {
-        ("deepgram", "flux-general-en"),
-        ("deepgram", "flux-general-multi"),
-        ("assemblyai", "universal-streaming"),
-        ("assemblyai", "universal-streaming-multilingual"),
-    }
-)
 
 
 # ---------------------------------------------------------------------------
@@ -333,7 +311,7 @@ async def _run_stt_item(
         ttft_status, ttft_error = _metric_outcome(
             ttft_seconds, item_error, Metric.TTFT, ResultStatus
         )
-        ttft_excluded = (entry.provider, entry.model) in _TTFT_NOT_COMPARABLE
+        ttft_excluded = (entry.provider, entry.model) in METRIC_EXCLUSIONS[Metric.TTFT]
         if not ttft_excluded:
             results.append(
                 Result(
@@ -406,7 +384,7 @@ async def _run_stt_item(
         ttfs_status, ttfs_error = _metric_outcome(
             ttfs_value, item_error or ttfs_calc_error, Metric.TTFS, ResultStatus
         )
-        ttfs_excluded = (entry.provider, entry.model) in _TTFS_NOT_COMPARABLE
+        ttfs_excluded = (entry.provider, entry.model) in METRIC_EXCLUSIONS[Metric.TTFS]
         if not ttfs_excluded:
             results.append(
                 Result(

--- a/runner/tests/api/test_aggregates.py
+++ b/runner/tests/api/test_aggregates.py
@@ -298,3 +298,35 @@ async def test_models_grouped_separately(client: AsyncClient, postgresql: Any) -
         ("deepgram", "nova-3", "TTFT"),
         ("deepgram", "nova-3", "WER"),
     ]
+
+
+async def test_excluded_metric_rows_hidden(client: AsyncClient, postgresql: Any) -> None:
+    """METRIC_EXCLUSIONS pairs are hidden from stats and series for the excluded
+    metric only — other metrics for the same model still show."""
+    run_id = await _insert_run(postgresql)
+    await _insert_result(
+        postgresql,
+        run_id,
+        provider="assemblyai",
+        model="universal-streaming",
+        metric_type="TTFS",
+        metric_value=0.4,
+    )
+    await _insert_result(
+        postgresql,
+        run_id,
+        provider="assemblyai",
+        model="universal-streaming",
+        metric_type="WER",
+        metric_value=5.0,
+    )
+    await _refresh_mv(postgresql)
+    await _fill_buckets(postgresql)
+
+    response = await client.get("/v1/results/aggregates", params={"benchmark": "STT"})
+    assert response.status_code == 200
+    body = response.json()
+    stat_keys = [(s["provider"], s["model"], s["metric_type"]) for s in body["model_stats"]]
+    assert stat_keys == [("assemblyai", "universal-streaming", "WER")]
+    series_keys = {(p["provider"], p["model"], p["metric_type"]) for p in body["series"]}
+    assert series_keys == {("assemblyai", "universal-streaming", "WER")}

--- a/runner/tests/api/test_leaderboard.py
+++ b/runner/tests/api/test_leaderboard.py
@@ -123,3 +123,34 @@ async def test_30d_window(client: AsyncClient, postgresql: Any) -> None:
     )
     assert response.status_code == 200
     assert len(response.json()["entries"]) == 1
+
+
+async def test_excluded_metric_rows_hidden(client: AsyncClient, postgresql: Any) -> None:
+    """Historical rows for METRIC_EXCLUSIONS pairs are hidden from the leaderboard."""
+    run_id = await _insert_run(postgresql)
+    await _insert_result(
+        postgresql,
+        run_id,
+        provider="assemblyai",
+        model="universal-streaming",
+        metric_type="TTFS",
+        metric_value=0.4,
+        benchmark="STT",
+    )
+    await _insert_result(
+        postgresql,
+        run_id,
+        provider="deepgram",
+        model="nova-3",
+        metric_type="TTFS",
+        metric_value=0.6,
+        benchmark="STT",
+    )
+    await _refresh_mv(postgresql)
+
+    response = await client.get(
+        "/v1/leaderboard", params={"metric": "TTFS", "benchmark": "STT", "window": "24h"}
+    )
+    assert response.status_code == 200
+    entries = response.json()["entries"]
+    assert [(e["provider"], e["model"]) for e in entries] == [("deepgram", "nova-3")]

--- a/web/lib/config/methodologyChanges.ts
+++ b/web/lib/config/methodologyChanges.ts
@@ -48,11 +48,4 @@ export const methodologyChanges: MethodologyChange[] = [
     detail:
       "Streaming STT audio was fed with a fixed per-chunk sleep, so send-loop drift accumulated and inflated latency. Audio is now paced against an absolute deadline, so latency reflects true engine speed. STT latency drops after this date; values before and after are not comparable.",
   },
-  {
-    date: "2026-07-07",
-    metrics: ["ttfs"],
-    title: "AssemblyAI universal-streaming models no longer report TTFS",
-    detail:
-      "universal-streaming and universal-streaming-multilingual acknowledge the end-of-speech signal without finalizing: the reply arrives in one network round-trip and can omit the last words of the clip. Their TTFS measured connectivity rather than finalization speed, so it is no longer reported, matching how Deepgram Flux is handled. The pro models and all other metrics are unaffected.",
-  },
 ];


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR centralizes non-comparable metric exclusions and hides affected historical rows. The main changes are:

- Adds shared metric exclusions in the metrics registry.
- Reuses the shared exclusions in the STT orchestrator.
- Filters excluded rows from aggregates and leaderboard API responses.
- Adds API coverage for hidden AssemblyAI TTFS rows.
- Removes the matching frontend methodology annotation.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge after a small cache-staleness cleanup.

- The orchestrator behavior matches the previous local exclusion sets.
- The new API filters hide the intended historical rows.
- Aggregates caching can briefly keep old exclusion results if the shared list changes inside a running process.

runner/src/coval_bench/api/routers/aggregates.py

<sub>Reviews (1): Last reviewed commit: ["Trim comments in the metric exclusion ch..."](https://github.com/coval-ai/benchmarks/commit/f82fc651d8f1f7e3ce8137091584165b25f545e0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42540481)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->