### PR TITLE
[BENCH-369] Fix filter sidebar overlapping the footer on fast scroll

### DIFF
--- a/web/components/layout/DashboardLayout.tsx
+++ b/web/components/layout/DashboardLayout.tsx
@@ -51,45 +51,48 @@ const DashboardLayout: React.FC<{ children: React.ReactNode }> = ({ children }) 
   }, [mode]);
 
   return (
-    <div className="relative flex min-h-screen flex-col overflow-hidden bg-background text-text-primary">
+    <div className="relative flex min-h-screen flex-col overflow-x-clip bg-background text-text-primary">
       <DashboardHeader />
       <MobileModelSheet />
-      <ModelSidebar />
 
       {/* Content column — centered on the page (under the centered tabs). The
-          18rem side gutters keep its left edge clear of the fixed sidebar
-          (17rem wide) with a 1rem gap. The footer stays full-width.
-          w-full is load-bearing below lg: mx-auto disables the flex
-          cross-axis stretch, and the column would otherwise size to its
-          content and overflow the viewport. */}
-      <div className="relative z-10 flex-1 transition-all duration-300 pt-20 px-3 py-8 sm:px-8 pb-24 lg:pb-8 overflow-x-hidden w-full mx-auto lg:w-[calc(100vw-36rem)]">
-        <div className="mb-6 flex flex-wrap items-center justify-between gap-3">
-          <h1 className="text-2xl font-bold tracking-tight text-text-primary">
-            {benchmarkTitle}
-          </h1>
-          <TimeWindowToggle
-            value={timeWindow}
-            onChange={changeTimeWindow}
-            className="ml-auto"
-          />
-        </div>
+          sticky sidebar and the spacer are 18rem each so the column stays
+          centered. The footer sits below this row, so it pushes the sticky
+          sidebar up natively. w-full is load-bearing below lg: mx-auto
+          disables the flex cross-axis stretch, and the column would otherwise
+          size to its content and overflow the viewport. */}
+      <div className="relative z-10 flex flex-1">
+        <ModelSidebar />
+        <div className="transition-all duration-300 pt-20 px-3 py-8 sm:px-8 pb-24 lg:pb-8 overflow-x-hidden w-full mx-auto lg:w-[calc(100vw-36rem)]">
+          <div className="mb-6 flex flex-wrap items-center justify-between gap-3">
+            <h1 className="text-2xl font-bold tracking-tight text-text-primary">
+              {benchmarkTitle}
+            </h1>
+            <TimeWindowToggle
+              value={timeWindow}
+              onChange={changeTimeWindow}
+              className="ml-auto"
+            />
+          </div>
 
-        <div
-          className={`transition-opacity duration-200 ${
-            windowDataStale ? "opacity-60" : ""
-          }`}
-        >
-          {loading ? (
-            <DashboardSkeleton />
-          ) : loadError ? (
-            <div className="py-24 text-center text-sm text-text-tertiary">
-              Couldn&rsquo;t load benchmark results. Try another time window or
-              refresh the page.
-            </div>
-          ) : (
-            children
-          )}
+          <div
+            className={`transition-opacity duration-200 ${
+              windowDataStale ? "opacity-60" : ""
+            }`}
+          >
+            {loading ? (
+              <DashboardSkeleton />
+            ) : loadError ? (
+              <div className="py-24 text-center text-sm text-text-tertiary">
+                Couldn&rsquo;t load benchmark results. Try another time window or
+                refresh the page.
+              </div>
+            ) : (
+              children
+            )}
+          </div>
         </div>
+        <div className="hidden lg:block w-72 shrink-0" />
       </div>
 
       {!loading && <DashboardFooter />}

--- a/web/components/layout/ModelSidebar.tsx
+++ b/web/components/layout/ModelSidebar.tsx
@@ -6,68 +6,12 @@
 import React from "react";
 import FacetFilter from "@/components/layout/FacetFilter";
 
-// Keep the links pinned in place until the footer is about to collide with the
-// actual bottom of the link list, then push the sidebar up so the filters slide
-// up under the top nav — as if the footer were pushing them off-screen. We
-// measure where the links really end (not the full-height container) so a short
-// list doesn't get pushed early by the empty space beneath it. The cap keeps a
-// long, scrolling list from being shoved before it reaches the viewport floor.
-const SIDEBAR_BOTTOM_GAP = 16;
-// Gap left between the links and the footer so the links never touch it.
-const LINKS_GAP = 24;
-
-const ModelSidebar: React.FC = () => {
-  const containerRef = React.useRef<HTMLDivElement>(null);
-  const linksRef = React.useRef<HTMLDivElement>(null);
-  const pushUpRef = React.useRef(0);
-
-  React.useEffect(() => {
-    // Drive the transform straight on the DOM node so it tracks the scroll in
-    // the same frame — going through React state would lag a frame behind.
-    const update = () => {
-      const container = containerRef.current;
-      if (!container) return;
-      const footer = document.querySelector("footer");
-      const links = linksRef.current;
-      if (!footer || !links) {
-        pushUpRef.current = 0;
-        container.style.transform = "translateY(0px)";
-        return;
-      }
-      const footerTop = footer.getBoundingClientRect().top;
-      // Bottom of the links in their un-pushed position: subtract out the
-      // transform we're currently applying so the reference point stays stable.
-      const naturalLinksBottom =
-        links.getBoundingClientRect().bottom + pushUpRef.current;
-      const maxBottom = window.innerHeight - SIDEBAR_BOTTOM_GAP;
-      const linksBottom = Math.min(naturalLinksBottom, maxBottom);
-
-      const next = Math.max(0, linksBottom + LINKS_GAP - footerTop);
-      pushUpRef.current = next;
-      container.style.transform = `translateY(-${next}px)`;
-    };
-
-    update();
-    window.addEventListener("scroll", update, { passive: true });
-    window.addEventListener("resize", update);
-    return () => {
-      window.removeEventListener("scroll", update);
-      window.removeEventListener("resize", update);
-    };
-  }, []);
-
-  return (
-    <div
-      ref={containerRef}
-      className="hidden lg:flex flex-col fixed left-4 top-20 bottom-4 z-10 py-3 w-64"
-    >
-      <div className="flex-1 overflow-y-auto scrollbar-hide">
-        <div ref={linksRef}>
-          <FacetFilter />
-        </div>
-      </div>
+const ModelSidebar: React.FC = () => (
+  <div className="hidden lg:block w-72 shrink-0">
+    <div className="sticky top-20 max-h-[calc(100vh-6rem)] overflow-y-auto scrollbar-hide px-4 py-3">
+      <FacetFilter />
     </div>
-  );
-};
+  </div>
+);
 
 export default ModelSidebar;


### PR DESCRIPTION

<img width="1512" height="982" alt="Screenshot 2026-07-07 at 3 20 03 PM" src="https://github.com/user-attachments/assets/7ffbd0a6-1418-4c6a-865d-5d48688e315b" />

<img width="1512" height="982" alt="Screenshot 2026-07-07 at 3 36 17 PM" src="https://github.com/user-attachments/assets/e3a2c3df-b245-46c3-a4f0-b05686e078f5" />


## Problem
On the TTS/STT dashboards, scrolling quickly to the bottom made the filter chips (Deployment, Features, etc.) float into the footer. The sidebar was `position: fixed` and dodged the footer with a scroll-event-driven `translateY` — on fast/momentum scrolls the page moves on the compositor thread while the JS handler lags behind, so the correction arrives frames late (or never lands cleanly).

## Fix
Delete the scroll-sync effect entirely and put the sidebar in the content flow with `position: sticky`, so the footer pushes it up natively with zero JS:

- `ModelSidebar` becomes a plain sticky column inside the content row.
- `DashboardLayout` wraps sidebar + content in a flex row with a matching 18rem right spacer, keeping the content column centered exactly as before.
- Root `overflow-hidden` → `overflow-x-clip`, since `overflow-hidden` creates a scroll container that would break `sticky`; `clip` keeps the same horizontal clipping without one.

Net −53 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)