### PR TITLE
Add S2S fetch job, model registry entries, and chart colors

### DIFF
--- a/runner/src/coval_bench/__main__.py
+++ b/runner/src/coval_bench/__main__.py
@@ -20,6 +20,7 @@ import click
 from coval_bench import __version__
 from coval_bench.db.cli import db_check, db_migrate
 from coval_bench.migrations.import_legacy import import_legacy_cli
+from coval_bench.s2s.fetch_v2v import fetch_s2s
 
 # Backstop so a stalled connection can't hang a smoke probe forever. Loose enough
 # for a cold dedicated endpoint (handshake + cold inference); the production paths
@@ -81,6 +82,9 @@ def migrate() -> None:
 
 
 migrate.add_command(import_legacy_cli, name="import-legacy")
+
+# S2S is fetch-only, so a standalone command rather than a `run --kind` value.
+cli.add_command(fetch_s2s, name="fetch-s2s")
 
 
 @cli.command(name="tts-smoke")

--- a/runner/src/coval_bench/config.py
+++ b/runner/src/coval_bench/config.py
@@ -92,6 +92,15 @@ class Settings(BaseSettings):
     # the Google STT provider is enabled (optional `google-stt` extra).
     google_project_id: str | None = None
 
+    # --- Coval API (S2S fetch job) ---
+    # X-API-Key for the Coval API. SecretStr so it never lands in a log.
+    coval_api_key: SecretStr | None = None
+    coval_api_base: str = "https://api.coval.dev/v1"
+    # The S2S latency metric id + per-provider Coval agent ids (opaque, not secret).
+    coval_s2s_latency_metric_id: str | None = None
+    coval_s2s_openai_agent_id: str | None = None
+    coval_s2s_gemini_agent_id: str | None = None
+
     # --- Analytics ---
     posthog_project_token: str = ""
     posthog_host: str = "https://us.i.posthog.com"

--- a/runner/src/coval_bench/db/writer.py
+++ b/runner/src/coval_bench/db/writer.py
@@ -236,18 +236,21 @@ class RunWriter:
             await conn.commit()
 
     async def coval_run_ingested(self, *, provider: str, coval_run_id: str) -> bool:
-        """True if any S2S row already references this Coval run.
+        """True if a succeeded or partial run already holds rows for this Coval run.
 
         S2S rows store ``audio_filename = '<coval_run_id>/<sim_id>'``. Lets the
         fetch job skip a re-pulled run so a retry or stale re-pull doesn't
-        double-write the day's bucket.
+        double-write the day's bucket. Rows from failed runs don't count: they
+        never reach the bucket, so a retry must stay free to re-ingest the run.
         """
         sql = """
             SELECT 1
-            FROM benchmarks_v2.results
-            WHERE provider = %s
-              AND benchmark = 'S2S'
-              AND split_part(audio_filename, '/', 1) = %s
+            FROM benchmarks_v2.results r
+            JOIN benchmarks_v2.runs rn ON rn.id = r.run_id
+            WHERE r.provider = %s
+              AND r.benchmark = 'S2S'
+              AND split_part(r.audio_filename, '/', 1) = %s
+              AND rn.status IN ('succeeded', 'partial')
             LIMIT 1
         """
         async with self._pool.connection() as conn:

--- a/runner/src/coval_bench/db/writer.py
+++ b/runner/src/coval_bench/db/writer.py
@@ -250,9 +250,11 @@ class RunWriter:
               AND split_part(audio_filename, '/', 1) = %s
             LIMIT 1
         """
-        async with self._pool.connection() as conn, conn.cursor() as cur:
-            await cur.execute(sql, (provider, coval_run_id))
-            row = await cur.fetchone()
+        async with self._pool.connection() as conn:
+            async with conn.cursor() as cur:
+                await cur.execute(sql, (provider, coval_run_id))
+                row = await cur.fetchone()
+            await conn.commit()
         return row is not None
 
     async def refresh_stats_matviews(self) -> None:

--- a/runner/src/coval_bench/db/writer.py
+++ b/runner/src/coval_bench/db/writer.py
@@ -235,6 +235,26 @@ class RunWriter:
                 await cur.execute(sql, (status, error, run_id))
             await conn.commit()
 
+    async def coval_run_ingested(self, *, provider: str, coval_run_id: str) -> bool:
+        """True if any S2S row already references this Coval run.
+
+        S2S rows store ``audio_filename = '<coval_run_id>/<sim_id>'``. Lets the
+        fetch job skip a re-pulled run so a retry or stale re-pull doesn't
+        double-write the day's bucket.
+        """
+        sql = """
+            SELECT 1
+            FROM benchmarks_v2.results
+            WHERE provider = %s
+              AND benchmark = 'S2S'
+              AND split_part(audio_filename, '/', 1) = %s
+            LIMIT 1
+        """
+        async with self._pool.connection() as conn, conn.cursor() as cur:
+            await cur.execute(sql, (provider, coval_run_id))
+            row = await cur.fetchone()
+        return row is not None
+
     async def refresh_stats_matviews(self) -> None:
         """Concurrently refresh the per-window stats materialized views.
 

--- a/runner/src/coval_bench/registries/models.py
+++ b/runner/src/coval_bench/registries/models.py
@@ -60,6 +60,7 @@ class RegisteredModel(BaseModel, frozen=True):
 
 _STT = Benchmark.STT
 _TTS = Benchmark.TTS
+_S2S = Benchmark.S2S
 _ACTIVE = ModelStatus.ACTIVE
 _RETIRED = ModelStatus.RETIRED
 _PENDING = ModelStatus.PENDING
@@ -519,6 +520,25 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         model="sonic",
         tags=(_REALTIME, _MULTI),
         status=_RETIRED,
+    ),
+    #######
+    # S2S #
+    #######
+    # S2S realtime models. Numbers are fetched daily from Coval (no local
+    # provider client). PENDING until the first run lands data.
+    RegisteredModel(
+        benchmark=_S2S,
+        provider="openai",
+        model="gpt-realtime",
+        tags=(_REALTIME, _MULTI),
+        status=_PENDING,
+    ),
+    RegisteredModel(
+        benchmark=_S2S,
+        provider="google",
+        model="gemini-live",
+        tags=(_REALTIME, _MULTI),
+        status=_PENDING,
     ),
 ]
 

--- a/runner/src/coval_bench/s2s/__init__.py
+++ b/runner/src/coval_bench/s2s/__init__.py
@@ -1,0 +1,4 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Speech-to-speech (V2V) benchmark support: the daily Coval fetch-and-write job."""

--- a/runner/src/coval_bench/s2s/fetch_v2v.py
+++ b/runner/src/coval_bench/s2s/fetch_v2v.py
@@ -1,0 +1,275 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Fetch S2S (voice-to-voice) latency from the Coval API and write per-clip rows.
+
+For each provider, find its newest completed Coval run, read the per-clip
+latency values (seconds), convert to milliseconds, and write one results row
+per clip via ``RunWriter``; the existing matviews aggregate. Agent ids, the
+metric id, and the API key are read from the environment, never committed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import importlib.resources
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any, cast
+
+import click
+import httpx
+import structlog
+
+from coval_bench.config import Settings, get_settings
+from coval_bench.db.conn import lifespan_pool
+from coval_bench.db.models import Result, ResultStatus, RunStatus
+from coval_bench.db.writer import RunWriter
+from coval_bench.registries import Metric
+from coval_bench.registries.benchmarks import Benchmark
+
+logger = structlog.get_logger("coval_bench.s2s.fetch_v2v")
+
+# Daily job: floor scheduled_at to the day so a run's clip rows share one bucket.
+DAILY_PERIOD_SECONDS = 86_400
+
+# The dataset the S2S sims run against (matches the packaged manifest name).
+DATASET_ID = "s2s-v1"
+
+
+@dataclass(frozen=True)
+class AgentSpec:
+    """One S2S provider: the Settings attr holding its Coval agent id + display strings."""
+
+    agent_id_attr: str
+    provider: str
+    model: str
+
+
+# Agent ids resolved from Settings; model strings are display labels.
+AGENTS: tuple[AgentSpec, ...] = (
+    AgentSpec(agent_id_attr="coval_s2s_openai_agent_id", provider="openai", model="gpt-realtime"),
+    AgentSpec(agent_id_attr="coval_s2s_gemini_agent_id", provider="google", model="gemini-live"),
+)
+
+
+def _client(settings: Settings) -> httpx.AsyncClient:
+    """Build the Coval API client. The key is used only as a header, never logged."""
+    key = settings.coval_api_key
+    if key is None:
+        raise RuntimeError("coval_api_key is not set (Secret Manager in prod, .env locally)")
+    return httpx.AsyncClient(
+        base_url=settings.coval_api_base,
+        headers={"X-API-Key": key.get_secret_value()},
+        timeout=30.0,
+    )
+
+
+def _dataset_sha256() -> str:
+    """SHA-256 of the packaged S2S manifest."""
+    try:
+        ref = importlib.resources.files("coval_bench.datasets.manifests").joinpath(
+            f"{DATASET_ID}.json"
+        )
+        return hashlib.sha256(ref.read_bytes()).hexdigest()
+    except Exception:
+        return "unknown"
+
+
+async def latest_completed_run_id(client: httpx.AsyncClient, agent_id: str) -> str | None:
+    """Newest completed Coval run for one agent.
+
+    List returns the summary view newest-first; filter by agent_id + status
+    (tags are not filterable).
+    """
+    resp = await client.get(
+        "/runs",
+        params={
+            "filter": f'status="COMPLETED" AND agent_id="{agent_id}"',
+            "order_by": "-create_time",
+            "page_size": 1,
+        },
+    )
+    resp.raise_for_status()
+    runs = cast("list[dict[str, Any]]", resp.json().get("runs", []))
+    return cast("str | None", runs[0]["run_id"]) if runs else None
+
+
+async def per_clip_rows(
+    client: httpx.AsyncClient,
+    *,
+    run_pk: int,
+    coval_run_id: str,
+    metric_id: str,
+    spec: AgentSpec,
+) -> list[Result]:
+    """Map a Coval run's per-clip values to Result rows.
+
+    Values are seconds; convert to ms. A clip with no numeric value becomes a
+    FAILED row, so reliability = success/total.
+    """
+    resp = await client.get(f"/runs/{coval_run_id}")
+    resp.raise_for_status()
+    run = cast("dict[str, Any]", resp.json()["run"])
+    metrics = cast("dict[str, Any]", (run.get("results") or {}).get("metrics") or {})
+    metric = metrics.get(metric_id)
+    if metric is None:
+        logger.warning(
+            "metric_absent", provider=spec.provider, run_id=coval_run_id, metric_id=metric_id
+        )
+        return []
+
+    values = cast("list[dict[str, Any]]", metric.get("values", []))
+    rows: list[Result] = []
+    for i, v in enumerate(values):
+        raw = v.get("value")
+        if isinstance(raw, (int, float)) and not isinstance(raw, bool):
+            metric_value: float | None = round(float(raw) * 1000, 1)
+            status = ResultStatus.SUCCESS
+        else:
+            metric_value = None
+            status = ResultStatus.FAILED
+        sim_id = v.get("simulation_output_id")
+        clip_key = f"{coval_run_id}/{sim_id}" if sim_id else f"{coval_run_id}/{i}"
+        rows.append(
+            Result(
+                run_id=run_pk,
+                provider=spec.provider,
+                model=spec.model,
+                benchmark=Benchmark.S2S,
+                metric_type=Metric.V2V,
+                metric_units="milliseconds",
+                metric_value=metric_value,
+                audio_filename=clip_key,
+                status=status,
+            )
+        )
+
+    logger.info(
+        "fetched_clips",
+        provider=spec.provider,
+        run_id=coval_run_id,
+        clips=len(rows),
+        success=sum(1 for r in rows if r.status is ResultStatus.SUCCESS),
+    )
+    return rows
+
+
+async def _fetch_one_provider(
+    client: httpx.AsyncClient,
+    writer: RunWriter,
+    *,
+    spec: AgentSpec,
+    agent_id: str,
+    metric_id: str,
+    runner_sha: str,
+    scheduled_at: datetime,
+) -> RunStatus:
+    """Fetch one provider's latest run into its own run row; return its status.
+
+    SUCCEEDED = all clips numeric, PARTIAL = some clips failed, FAILED = no
+    clips or all failed. Errors are caught here so one provider can't abort others.
+    Skips (no write) if this Coval run was already ingested, so a retry or a
+    re-pulled stale run doesn't double-count and the last good data stays.
+    """
+    coval_run_id = await latest_completed_run_id(client, agent_id)
+    if coval_run_id is None:
+        logger.warning("no_completed_run", provider=spec.provider, agent_attr=spec.agent_id_attr)
+        return RunStatus.FAILED
+    if await writer.coval_run_ingested(provider=spec.provider, coval_run_id=coval_run_id):
+        logger.info("run_already_ingested", provider=spec.provider, coval_run_id=coval_run_id)
+        return RunStatus.SUCCEEDED
+
+    run = await writer.start_run(
+        runner_sha=runner_sha,
+        dataset_id=DATASET_ID,
+        dataset_sha256=_dataset_sha256(),
+        scheduled_at=scheduled_at,
+    )
+    if run.id is None:  # pragma: no cover -- start_run always returns an id
+        raise RuntimeError("start_run returned a run with no id")
+    run_pk = run.id
+    try:
+        rows = await per_clip_rows(
+            client, run_pk=run_pk, coval_run_id=coval_run_id, metric_id=metric_id, spec=spec
+        )
+        if rows:
+            await writer.record_results(rows)
+        failed = sum(1 for r in rows if r.status is ResultStatus.FAILED)
+        if not rows or failed == len(rows):
+            status = RunStatus.FAILED
+        elif failed:
+            status = RunStatus.PARTIAL
+        else:
+            status = RunStatus.SUCCEEDED
+        await writer.finish_run(run_pk, status=status)
+        if status in (RunStatus.SUCCEEDED, RunStatus.PARTIAL):
+            try:
+                await writer.refresh_bucket(run_pk, period_seconds=DAILY_PERIOD_SECONDS)
+            except Exception:
+                logger.warning("refresh_bucket_failed", provider=spec.provider, exc_info=True)
+        return status
+    except Exception as exc:
+        await writer.finish_run(run_pk, status=RunStatus.FAILED, error=str(exc))
+        logger.warning("provider_fetch_failed", provider=spec.provider, error=str(exc))
+        return RunStatus.FAILED
+
+
+async def fetch_and_write_v2v(settings: Settings | None = None) -> dict[str, RunStatus]:
+    """Fetch each provider's latest run into its own run row; return per-provider status.
+
+    Mirrors the STT/TTS orchestrator: per-provider ``finish_run``, then a best-effort
+    bucket/matview refresh that never fails the job. No cross-run dedup -- a same-day
+    retry re-aggregates the slot, matching the orchestrator's behaviour.
+    """
+    settings = settings or get_settings()
+
+    metric_id = settings.coval_s2s_latency_metric_id
+    if not metric_id:
+        raise RuntimeError("coval_s2s_latency_metric_id is not set")
+
+    epoch = int(datetime.now(tz=UTC).timestamp())
+    scheduled_at = datetime.fromtimestamp(epoch - epoch % DAILY_PERIOD_SECONDS, tz=UTC)
+
+    async with _client(settings) as client, lifespan_pool(settings) as pool:
+        writer = RunWriter(pool)
+        statuses: dict[str, RunStatus] = {}
+        for spec in AGENTS:
+            agent_id = getattr(settings, spec.agent_id_attr)
+            if not agent_id:
+                logger.warning("agent_id_unset", provider=spec.provider, attr=spec.agent_id_attr)
+                continue
+            statuses[spec.provider] = await _fetch_one_provider(
+                client,
+                writer,
+                spec=spec,
+                agent_id=agent_id,
+                metric_id=metric_id,
+                runner_sha=settings.runner_sha,
+                scheduled_at=scheduled_at,
+            )
+
+        if any(s in (RunStatus.SUCCEEDED, RunStatus.PARTIAL) for s in statuses.values()):
+            try:
+                await writer.refresh_stats_matviews()
+            except Exception:
+                logger.warning("refresh_stats_matviews_failed", exc_info=True)
+        logger.info("s2s_fetch_done", statuses={p: str(s) for p, s in statuses.items()})
+        return statuses
+
+
+@click.command(name="fetch-s2s")
+def fetch_s2s() -> None:
+    """Fetch S2S latency from Coval and write per-clip rows (daily Cloud Run Job)."""
+    from coval_bench.logging import configure_logging
+
+    settings = get_settings()
+    configure_logging(level=settings.log_level)
+    statuses = asyncio.run(fetch_and_write_v2v(settings))
+    if not statuses or all(s is RunStatus.FAILED for s in statuses.values()):
+        raise click.ClickException("s2s fetch failed for all providers")
+
+
+if __name__ == "__main__":
+    fetch_s2s()

--- a/runner/src/coval_bench/s2s/fetch_v2v.py
+++ b/runner/src/coval_bench/s2s/fetch_v2v.py
@@ -216,7 +216,12 @@ async def _fetch_one_provider(
         return status
     except Exception as exc:
         if run_pk is not None:
-            await writer.finish_run(run_pk, status=RunStatus.FAILED, error=str(exc))
+            try:
+                await writer.finish_run(run_pk, status=RunStatus.FAILED, error=str(exc))
+            except Exception:
+                logger.warning(
+                    "finish_run_failed", provider=spec.provider, run_id=run_pk, exc_info=True
+                )
         logger.warning("provider_fetch_failed", provider=spec.provider, error=str(exc))
         return RunStatus.FAILED
 

--- a/runner/src/coval_bench/s2s/fetch_v2v.py
+++ b/runner/src/coval_bench/s2s/fetch_v2v.py
@@ -74,6 +74,7 @@ def _dataset_sha256() -> str:
         )
         return hashlib.sha256(ref.read_bytes()).hexdigest()
     except Exception:
+        logger.warning("dataset_sha256_failed", dataset_id=DATASET_ID, exc_info=True)
         return "unknown"
 
 
@@ -173,24 +174,27 @@ async def _fetch_one_provider(
     Skips (no write) if this Coval run was already ingested, so a retry or a
     re-pulled stale run doesn't double-count and the last good data stays.
     """
-    coval_run_id = await latest_completed_run_id(client, agent_id)
-    if coval_run_id is None:
-        logger.warning("no_completed_run", provider=spec.provider, agent_attr=spec.agent_id_attr)
-        return RunStatus.FAILED
-    if await writer.coval_run_ingested(provider=spec.provider, coval_run_id=coval_run_id):
-        logger.info("run_already_ingested", provider=spec.provider, coval_run_id=coval_run_id)
-        return RunStatus.SUCCEEDED
-
-    run = await writer.start_run(
-        runner_sha=runner_sha,
-        dataset_id=DATASET_ID,
-        dataset_sha256=_dataset_sha256(),
-        scheduled_at=scheduled_at,
-    )
-    if run.id is None:  # pragma: no cover -- start_run always returns an id
-        raise RuntimeError("start_run returned a run with no id")
-    run_pk = run.id
+    run_pk: int | None = None
     try:
+        coval_run_id = await latest_completed_run_id(client, agent_id)
+        if coval_run_id is None:
+            logger.warning(
+                "no_completed_run", provider=spec.provider, agent_attr=spec.agent_id_attr
+            )
+            return RunStatus.FAILED
+        if await writer.coval_run_ingested(provider=spec.provider, coval_run_id=coval_run_id):
+            logger.info("run_already_ingested", provider=spec.provider, coval_run_id=coval_run_id)
+            return RunStatus.SUCCEEDED
+
+        run = await writer.start_run(
+            runner_sha=runner_sha,
+            dataset_id=DATASET_ID,
+            dataset_sha256=_dataset_sha256(),
+            scheduled_at=scheduled_at,
+        )
+        if run.id is None:  # pragma: no cover -- start_run always returns an id
+            raise RuntimeError("start_run returned a run with no id")
+        run_pk = run.id
         rows = await per_clip_rows(
             client, run_pk=run_pk, coval_run_id=coval_run_id, metric_id=metric_id, spec=spec
         )
@@ -211,7 +215,8 @@ async def _fetch_one_provider(
                 logger.warning("refresh_bucket_failed", provider=spec.provider, exc_info=True)
         return status
     except Exception as exc:
-        await writer.finish_run(run_pk, status=RunStatus.FAILED, error=str(exc))
+        if run_pk is not None:
+            await writer.finish_run(run_pk, status=RunStatus.FAILED, error=str(exc))
         logger.warning("provider_fetch_failed", provider=spec.provider, error=str(exc))
         return RunStatus.FAILED
 

--- a/runner/tests/unit/test_s2s_fetch.py
+++ b/runner/tests/unit/test_s2s_fetch.py
@@ -1,0 +1,205 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the S2S V2V fetch job."""
+
+from __future__ import annotations
+
+import contextlib
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+
+from coval_bench.config import Settings
+from coval_bench.db.models import ResultStatus, Run, RunStatus
+from coval_bench.s2s import fetch_v2v
+from coval_bench.s2s.fetch_v2v import AgentSpec
+
+SPEC = AgentSpec(agent_id_attr="coval_s2s_openai_agent_id", provider="openai", model="gpt-realtime")
+SLOT = datetime(2026, 7, 7, tzinfo=UTC)
+_LIST_ONE: dict[str, Any] = {"runs": [{"run_id": "R1", "status": "COMPLETED"}]}
+
+
+def _fake_client(
+    list_json: dict[str, Any],
+    run_json: dict[str, Any],
+    captured: list[httpx.Request] | None = None,
+) -> httpx.AsyncClient:
+    """AsyncClient that answers /runs (list) and /runs/{id} (get) from fixtures."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if captured is not None:
+            captured.append(request)
+        if request.url.path.endswith("/runs"):
+            return httpx.Response(200, json=list_json)
+        return httpx.Response(200, json=run_json)
+
+    return httpx.AsyncClient(base_url="https://api.test/v1", transport=httpx.MockTransport(handler))
+
+
+def _run_json(values: list[dict[str, Any]], metric_id: str = "MID") -> dict[str, Any]:
+    return {"run": {"results": {"metrics": {metric_id: {"values": values}}}}}
+
+
+def _stub_writer() -> MagicMock:
+    writer = MagicMock()
+    writer.start_run = AsyncMock(
+        return_value=Run(
+            id=1,
+            runner_sha="test",
+            dataset_id="s2s-v1",
+            dataset_sha256="x",
+            status=RunStatus.RUNNING,
+        )
+    )
+    writer.coval_run_ingested = AsyncMock(return_value=False)
+    writer.record_results = AsyncMock()
+    writer.finish_run = AsyncMock()
+    writer.refresh_bucket = AsyncMock()
+    writer.refresh_stats_matviews = AsyncMock()
+    return writer
+
+
+@pytest.mark.asyncio
+async def test_per_clip_rows_maps_values() -> None:
+    values = [
+        {"simulation_output_id": "s1", "value": 0.842},
+        {"simulation_output_id": "s2", "value": None},
+        {"value": 0.5},  # missing sim id -> index fallback in the clip key
+    ]
+    async with _fake_client(_LIST_ONE, _run_json(values)) as client:
+        rows = await fetch_v2v.per_clip_rows(
+            client, run_pk=1, coval_run_id="R1", metric_id="MID", spec=SPEC
+        )
+    assert [r.metric_value for r in rows] == [842.0, None, 500.0]
+    assert [r.status for r in rows] == [
+        ResultStatus.SUCCESS,
+        ResultStatus.FAILED,
+        ResultStatus.SUCCESS,
+    ]
+    assert [r.audio_filename for r in rows] == ["R1/s1", "R1/s2", "R1/2"]
+    assert all(r.benchmark == "S2S" and r.metric_type == "V2V" for r in rows)
+
+
+@pytest.mark.asyncio
+async def test_latest_completed_run_id() -> None:
+    captured: list[httpx.Request] = []
+    async with _fake_client(_LIST_ONE, {}, captured) as client:
+        assert await fetch_v2v.latest_completed_run_id(client, "a1") == "R1"
+    filter_expr = captured[0].url.params["filter"]
+    assert 'status="COMPLETED"' in filter_expr
+    assert 'agent_id="a1"' in filter_expr
+
+    async with _fake_client({"runs": []}, {}) as client:
+        assert await fetch_v2v.latest_completed_run_id(client, "a1") is None
+
+
+@pytest.mark.asyncio
+async def test_fetch_one_provider_succeeded() -> None:
+    writer = _stub_writer()
+    values = [{"simulation_output_id": f"s{i}", "value": 0.5} for i in range(3)]
+    async with _fake_client(_LIST_ONE, _run_json(values)) as client:
+        status = await fetch_v2v._fetch_one_provider(
+            client,
+            writer,
+            spec=SPEC,
+            agent_id="a1",
+            metric_id="MID",
+            runner_sha="test",
+            scheduled_at=SLOT,
+        )
+    assert status is RunStatus.SUCCEEDED
+    writer.record_results.assert_awaited_once()
+    writer.refresh_bucket.assert_awaited_once()
+    assert writer.finish_run.await_args.kwargs["status"] is RunStatus.SUCCEEDED
+
+
+@pytest.mark.asyncio
+async def test_fetch_one_provider_partial() -> None:
+    writer = _stub_writer()
+    values = [
+        {"simulation_output_id": "s1", "value": 0.5},
+        {"simulation_output_id": "s2", "value": None},
+    ]
+    async with _fake_client(_LIST_ONE, _run_json(values)) as client:
+        status = await fetch_v2v._fetch_one_provider(
+            client,
+            writer,
+            spec=SPEC,
+            agent_id="a1",
+            metric_id="MID",
+            runner_sha="test",
+            scheduled_at=SLOT,
+        )
+    assert status is RunStatus.PARTIAL
+
+
+@pytest.mark.asyncio
+async def test_fetch_one_provider_no_run_failed() -> None:
+    writer = _stub_writer()
+    async with _fake_client({"runs": []}, {}) as client:
+        status = await fetch_v2v._fetch_one_provider(
+            client,
+            writer,
+            spec=SPEC,
+            agent_id="a1",
+            metric_id="MID",
+            runner_sha="test",
+            scheduled_at=SLOT,
+        )
+    assert status is RunStatus.FAILED
+    writer.record_results.assert_not_awaited()
+    writer.refresh_bucket.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_fetch_one_provider_skips_already_ingested_run() -> None:
+    writer = _stub_writer()
+    writer.coval_run_ingested = AsyncMock(return_value=True)  # run already in the DB
+    async with _fake_client(_LIST_ONE, _run_json([])) as client:
+        status = await fetch_v2v._fetch_one_provider(
+            client,
+            writer,
+            spec=SPEC,
+            agent_id="a1",
+            metric_id="MID",
+            runner_sha="test",
+            scheduled_at=SLOT,
+        )
+    assert status is RunStatus.SUCCEEDED  # no-op: last good data left in place
+    writer.start_run.assert_not_awaited()
+    writer.record_results.assert_not_awaited()
+    writer.refresh_bucket.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_fetch_and_write_v2v_per_provider(monkeypatch: pytest.MonkeyPatch) -> None:
+    # gemini agent id left unset (None) -> that provider is skipped.
+    monkeypatch.delenv("COVAL_S2S_GEMINI_AGENT_ID", raising=False)
+    settings = Settings(
+        runner_sha="test",
+        coval_s2s_latency_metric_id="MID",
+        coval_s2s_openai_agent_id="a1",
+    )
+
+    writer = _stub_writer()
+    values = [{"simulation_output_id": f"s{i}", "value": 0.5} for i in range(2)]
+    client = _fake_client(_LIST_ONE, _run_json(values))
+
+    @contextlib.asynccontextmanager
+    async def _fake_pool(_settings: Any) -> AsyncIterator[MagicMock]:
+        yield MagicMock()
+
+    monkeypatch.setattr(fetch_v2v, "_client", lambda _s: client)
+    monkeypatch.setattr(fetch_v2v, "lifespan_pool", _fake_pool)
+    monkeypatch.setattr(fetch_v2v, "RunWriter", lambda _pool: writer)
+
+    statuses = await fetch_v2v.fetch_and_write_v2v(settings)
+
+    # only openai runs (gemini unset), and it fully succeeds.
+    assert statuses == {"openai": RunStatus.SUCCEEDED}
+    writer.refresh_stats_matviews.assert_awaited_once()

--- a/runner/tests/unit/test_s2s_fetch.py
+++ b/runner/tests/unit/test_s2s_fetch.py
@@ -66,7 +66,7 @@ def _stub_writer() -> MagicMock:
 
 @pytest.mark.asyncio
 async def test_per_clip_rows_maps_values() -> None:
-    values = [
+    values: list[dict[str, Any]] = [
         {"simulation_output_id": "s1", "value": 0.842},
         {"simulation_output_id": "s2", "value": None},
         {"value": 0.5},  # missing sim id -> index fallback in the clip key
@@ -121,7 +121,7 @@ async def test_fetch_one_provider_succeeded() -> None:
 @pytest.mark.asyncio
 async def test_fetch_one_provider_partial() -> None:
     writer = _stub_writer()
-    values = [
+    values: list[dict[str, Any]] = [
         {"simulation_output_id": "s1", "value": 0.5},
         {"simulation_output_id": "s2", "value": None},
     ]

--- a/web/lib/config/colors.ts
+++ b/web/lib/config/colors.ts
@@ -2,11 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 export const modelColors: Record<string, string> = {
-  // OpenAI — red family (#E74C3C). Both TTS and STT use the same red range.
+  // OpenAI — red family (#E74C3C). TTS, STT, and S2S all use the same red range.
   "gpt-4o-mini-tts": "#C0392B",
   "gpt-realtime-whisper": "#E74C3C",
   "gpt-4o-transcribe": "#CD6155",
   "gpt-4o-mini-transcribe": "#922B21",
+  "gpt-realtime": "#EC7063", // S2S
+
+  // Google — blue family (#4285F4). Gemini realtime (S2S).
+  "gemini-live": "#4285F4",
 
   // ElevenLabs — orange family (#F39C12). TTS + STT scribe all span light→dark orange.
   eleven_multilingual_v2: "#F5B041",
@@ -77,5 +81,6 @@ export const providerColors: Record<string, string> = {
   Hume: "#A855F7",
   "Inworld AI": "#6366F1",
   xAI: "#EC4899",
-  Soniox: "#C9A227"
+  Soniox: "#C9A227",
+  Google: "#4285F4"
 };


### PR DESCRIPTION
Stacks on #225 (the S2S benchmark axis + V2V metric) — merge that first.

Adds the daily Coval fetch-and-write job (`coval_bench/s2s/fetch_v2v.py`) that pulls each provider's newest completed run, reads the 50 per-clip V2V latency values, converts seconds to milliseconds once, and writes one result row per clip through the existing RunWriter so the matviews aggregate it exactly like STT/TTS. Registers the two realtime models (`openai/gpt-realtime`, `google/gemini-live`) in the model registry as pending so they stay hidden until the first run lands data, exposes the job as `coval-bench fetch-s2s` (fetch-only, so a standalone command rather than a `run --kind` value), adds the Coval API key/base to settings, and gives the two models chart colors.

Verified against the live Coval API: List filters by an AIP-160 string (`agent_id` + `status`), not query params, and tags aren't filterable. Nothing runs against Coval yet — blocked on the org, agents, and metric id, and there's no prod visibility (no `/s2s` route, models pending).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds the S2S Coval fetch path and registers the first realtime S2S models. The main changes are:

- New `fetch-s2s` CLI command for daily Coval V2V ingestion.
- Coval API settings for the fetch job.
- S2S model registry entries for OpenAI realtime and Gemini Live.
- Per-clip V2V fetch, result writing, and bucket refresh logic.
- Unit coverage for the new fetch flow.
- Chart colors for the new S2S models and Google provider.

<h3>Confidence Score: 4/5</h3>

This is close, but the retry repair path should be fixed before merging.

- A retry can skip `refresh_bucket()` when raw rows already exist.
- That can leave the daily S2S chart bucket empty or stale after a prior best-effort refresh failure.

runner/src/coval_bench/s2s/fetch_v2v.py

<sub>Reviews (10): Last reviewed commit: ["Annotate heterogeneous test fixtures for..."](https://github.com/coval-ai/benchmarks/commit/621a91872937ae544d367a4e9f651c2332077382) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42548594)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->