### PR TITLE
(FD-293) Add drag-to-zoom hint to timeline tooltip 

### DIFF
--- a/web/components/charts/tooltips/TimelineTooltip.tsx
+++ b/web/components/charts/tooltips/TimelineTooltip.tsx
@@ -139,7 +139,7 @@ const CustomTimelineTooltip: React.FC<TimelineTooltipProps> = ({ active, payload
             color: "var(--color-text-on-tooltip-secondary)"
           }}
         >
-          +{validData.length - 1} more · click to pin
+          +{validData.length - 1} more · click to pin · drag to zoom
         </p>
       )}
     </div>


### PR DESCRIPTION
## Summary
The timeline chart supports drag-to-zoom, but nothing in the UI hints at it. This adds the hint to the compact tooltip footer, following the existing convention:

> +16 more · click to pin · drag to zoom

One-line string change in `web/components/charts/tooltips/TimelineTooltip.tsx`.

Fixes FD-293.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a drag-to-zoom hint to the timeline tooltip. The main change is:

- Updates the compact tooltip footer copy to include `drag to zoom`.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<sub>Reviews (1): Last reviewed commit: ["Add drag-to-zoom hint to timeline toolti..."](https://github.com/coval-ai/benchmarks/commit/9223a6b9c6f82c2e6ecb96a07c33c2b1c58aac40) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42564465)</sub>

<!-- /greptile_comment -->