### PR TITLE
 (FD-294) Add share button on charts with deep link to the specific chart

### DIFF
--- a/web/components/shared/SectionHeader.tsx
+++ b/web/components/shared/SectionHeader.tsx
@@ -38,14 +38,27 @@ const SectionHeader: React.FC<SectionHeaderProps> = ({
   useEffect(() => {
     if (window.location.hash !== `#${anchorId}`) return;
     window.scrollTo(0, 0);
-    const t = setTimeout(
-      () =>
-        document
-          .getElementById(anchorId)
-          ?.scrollIntoView({ behavior: "smooth" }),
-      300
-    );
-    return () => clearTimeout(t);
+    let stop = false;
+    const cancel = () => {
+      stop = true;
+    };
+    window.addEventListener("wheel", cancel, { passive: true });
+    window.addEventListener("touchstart", cancel, { passive: true });
+    const t0 = performance.now();
+    const step = (now: number) => {
+      if (stop || now - t0 > 2500) return;
+      const delta =
+        (document.getElementById(anchorId)?.getBoundingClientRect().top ?? 96) -
+        96;
+      if (Math.abs(delta) > 0.5) window.scrollTo(0, window.scrollY + delta * 0.15);
+      requestAnimationFrame(step);
+    };
+    requestAnimationFrame(step);
+    return () => {
+      stop = true;
+      window.removeEventListener("wheel", cancel);
+      window.removeEventListener("touchstart", cancel);
+    };
   }, [anchorId]);
 
   const copyLink = () => {
@@ -70,8 +83,8 @@ const SectionHeader: React.FC<SectionHeaderProps> = ({
             type="button"
             onClick={copyLink}
             aria-label="Copy link to this chart"
-            title="Copy link to this chart"
-            className="text-text-tertiary hover:text-text-primary transition-colors"
+            title="Copy link"
+            className="flex h-7 w-7 items-center justify-center rounded-lg border border-border-secondary bg-white text-text-secondary transition-colors hover:bg-surface-toggle-inactive hover:text-text-primary"
           >
             {copied ? <Check size={14} /> : <Link2 size={14} />}
           </button>

--- a/web/components/shared/SectionHeader.tsx
+++ b/web/components/shared/SectionHeader.tsx
@@ -3,7 +3,10 @@
 
 "use client";
 
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
+import { Check, Link2 } from "lucide-react";
+import { capturePostHogEvent } from "@/lib/posthog/client";
+import { POSTHOG_EVENTS } from "@/lib/posthog/events";
 
 interface SectionHeaderProps {
   label: string;
@@ -29,12 +32,49 @@ const SectionHeader: React.FC<SectionHeaderProps> = ({
   expandable = true,
 }) => {
   const [showDetails, setShowDetails] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const anchorId = label.toLowerCase().replace(/[^a-z0-9]+/g, "-");
+
+  useEffect(() => {
+    if (window.location.hash !== `#${anchorId}`) return;
+    window.scrollTo(0, 0);
+    const t = setTimeout(
+      () =>
+        document
+          .getElementById(anchorId)
+          ?.scrollIntoView({ behavior: "smooth" }),
+      300
+    );
+    return () => clearTimeout(t);
+  }, [anchorId]);
+
+  const copyLink = () => {
+    navigator.clipboard.writeText(
+      `${window.location.origin}${window.location.pathname}#${anchorId}`
+    );
+    window.history.replaceState(null, "", `#${anchorId}`);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+    capturePostHogEvent(POSTHOG_EVENTS.dashboardChartShared, {
+      chart: anchorId,
+      path: window.location.pathname,
+    });
+  };
 
   return (
-    <div className="flex justify-between items-start gap-8 mb-4">
+    <div id={anchorId} className="flex justify-between items-start gap-8 mb-4 scroll-mt-24">
       <div className="w-3/4 min-w-0">
-        <h2 className="text-[0.9rem] font-light text-text-secondary mb-2">
+        <h2 className="flex items-center gap-2 text-[0.9rem] font-light text-text-secondary mb-2">
           {label}
+          <button
+            type="button"
+            onClick={copyLink}
+            aria-label="Copy link to this chart"
+            title="Copy link to this chart"
+            className="text-text-tertiary hover:text-text-primary transition-colors"
+          >
+            {copied ? <Check size={14} /> : <Link2 size={14} />}
+          </button>
         </h2>
         <p className="text-2xl font-medium text-text-primary mb-1">
           {description.short}

--- a/web/lib/posthog/events.ts
+++ b/web/lib/posthog/events.ts
@@ -17,7 +17,8 @@ export const POSTHOG_EVENTS = {
   playgroundExamplePromptUsed: "playground_example_prompt_used",
   playgroundModeSwitched: "playground_mode_switched",
   playgroundResultPlayed: "playground_result_played",
-  dashboardTimeWindowChanged: "dashboard_time_window_changed"
+  dashboardTimeWindowChanged: "dashboard_time_window_changed",
+  dashboardChartShared: "dashboard_chart_shared"
 } as const;
 
 export type PostHogSurface =


### PR DESCRIPTION
## Summary

Adds a copy-link button to every chart on the STT and TTS dashboards that deep-links to that exact chart, not just the page (FD-294).
<img width="364" height="122" alt="Screenshot 2026-07-07 at 4 57 40 PM" src="https://github.com/user-attachments/assets/5892b16b-962c-4be1-8a57-880955a7a059" />

- Each `SectionHeader` derives an anchor id from its label (e.g. `/stt#accuracy-by-model`) and renders a small bubble button next to the label that copies the URL and swaps to a checkmark for 2s.
- Opening a deep link lands at the top of the page, then quickly scrolls the chart into view. Because chart sections are lazy-loaded (`ssr: false`), a brief rAF loop keeps the chart pinned through late layout shifts and cancels the moment the user scrolls.
- New `dashboard_chart_shared` PostHog event with chart id and path.

Frontend-only: hash fragments never reach the server, so no route or backend changes were needed. All five charts on both `/stt` and `/tts` get the button automatically since they share `SectionHeader`.

Note: anchor ids derive from section labels, so renaming a label breaks previously shared links to that chart.

## Test plan

- [x] Buttons render on all 5 chart sections on `/stt` and `/tts`
- [x] Click copies `origin + path + #anchor`, updates the URL hash, and shows checkmark feedback
- [x] Opening a deep link in a fresh session scrolls to the chart and stays pinned at 96px below the fixed header through late chart/data loads (verified by sampling position over 3.5s)
- [x] Manual scroll during the animation cancels the auto-scroll
- [x] `tsc --noEmit` and `eslint --max-warnings 0` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds shareable chart links to dashboard section headers. The main changes are:

- Label-based section IDs for chart deep links.
- A copy-link button with temporary success feedback.
- A short scroll loop for opening links to lazy-loaded charts.
- A new `dashboard_chart_shared` PostHog event.

<h3>Confidence Score: 5/5</h3>

The changed flow looks mergeable after a small clipboard cleanup.

- Current chart labels appear compatible with the generated IDs.
- The share button can show success when the clipboard write fails.
- The analytics event addition is straightforward.

web/components/shared/SectionHeader.tsx

<sub>Reviews (1): Last reviewed commit: ["Speed up deep-link scroll and style copy..."](https://github.com/coval-ai/benchmarks/commit/bec668657fa575bf5cf650b36e60d6bd07f8aa3c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42568483)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->