### PR TITLE
[FD-298] Add hover tooltips explaining TTFS and TTFT on the Latency vs Accuracy chart

### DIFF
--- a/web/components/dashboard/BoxPlotSection.tsx
+++ b/web/components/dashboard/BoxPlotSection.tsx
@@ -9,6 +9,7 @@ import { normalizeModelName } from "@/lib/utils/formatters";
 import BoxPlot from "@/components/charts/d3/BoxPlot";
 import Card from "@/components/shared/Card";
 import SectionHeader from "@/components/shared/SectionHeader";
+import MetricInfo from "@/components/shared/MetricInfo";
 import MetricToggle from "@/components/dashboard/MetricToggle";
 import { useDashboard } from "@/contexts/DashboardContext";
 import { useChartHoverTracking } from "@/hooks/useChartHoverTracking";
@@ -39,7 +40,9 @@ const BoxPlotSection: React.FC = () => {
           label="Latency Variation"
           description={description}
           stat={{
-            label: `Average ${latencyLabel}`,
+            label: (
+              <MetricInfo metric={activeMetric} align="right">{`Average ${latencyLabel}`}</MetricInfo>
+            ),
             value: `${avgLatency.toFixed(0)} ms`,
           }}
         />

--- a/web/components/dashboard/LatencyAccuracySection.tsx
+++ b/web/components/dashboard/LatencyAccuracySection.tsx
@@ -19,6 +19,7 @@ import CustomScatterTooltip from "@/components/charts/tooltips/ScatterTooltip";
 import Card from "@/components/shared/Card";
 import SectionHeader from "@/components/shared/SectionHeader";
 import MetricToggle from "@/components/dashboard/MetricToggle";
+import MetricInfo from "@/components/shared/MetricInfo";
 import { useDashboard } from "@/contexts/DashboardContext";
 import { useThemeColors } from "@/hooks/useThemeColors";
 import { useActiveTab } from "@/hooks/useActiveTab";
@@ -92,7 +93,9 @@ const LatencyAccuracySection: React.FC = () => {
           label="Latency vs Accuracy"
           description={description}
           stat={{
-            label: `Avg ${latencyLabel}`,
+            label: (
+              <MetricInfo metric={metric} align="right">{`Avg ${latencyLabel}`}</MetricInfo>
+            ),
             value: `${avgLatency.toFixed(0)} ms`,
           }}
         />
@@ -102,7 +105,7 @@ const LatencyAccuracySection: React.FC = () => {
         <div className="h-64" onMouseEnter={trackChartHover}>
           <ResponsiveContainer width="100%" height="100%">
             <ScatterChart
-              margin={{ top: 10, right: 8, left: 0, bottom: 20 }}
+              margin={{ top: 10, right: 8, left: 0, bottom: 0 }}
             >
               <CartesianGrid
                 stroke={themeColors.grid}
@@ -118,16 +121,6 @@ const LatencyAccuracySection: React.FC = () => {
                 tickLine={false}
                 tick={{ fill: themeColors.axisText, fontSize: 12 }}
                 tickFormatter={(value) => `${parseFloat((Number(value) / 1000).toFixed(2))}s`}
-                label={{
-                  value: latencyLabel,
-                  position: "insideBottom",
-                  offset: -20,
-                  style: {
-                    textAnchor: "middle",
-                    fill: themeColors.axisText,
-                    fontSize: "14px",
-                  },
-                }}
               />
               <YAxis
                 dataKey="y"
@@ -163,6 +156,12 @@ const LatencyAccuracySection: React.FC = () => {
               ))}
             </ScatterChart>
           </ResponsiveContainer>
+        </div>
+        <div
+          className="mt-1 text-center text-sm"
+          style={{ color: themeColors.axisText }}
+        >
+          <MetricInfo metric={metric}>{latencyLabel}</MetricInfo>
         </div>
       </Card>
     </div>

--- a/web/components/dashboard/MetricToggle.tsx
+++ b/web/components/dashboard/MetricToggle.tsx
@@ -6,6 +6,7 @@
 import React from "react";
 import { useDashboard } from "@/contexts/DashboardContext";
 import { useActiveTab } from "@/hooks/useActiveTab";
+import MetricInfo from "@/components/shared/MetricInfo";
 
 // Shared TTFS / TTFT switch. Reads and writes the single dashboard-wide metric,
 // so every chart that renders it stays in sync. Hidden on TTS (single-metric).
@@ -18,19 +19,20 @@ const MetricToggle: React.FC = () => {
   return (
     <div className="mb-4 inline-flex gap-0.5 rounded-lg bg-gray-100 p-0.5">
       {(["TTFS", "TTFT"] as const).map((m) => (
-        <button
-          key={m}
-          type="button"
-          onClick={() => setSttMetric(m)}
-          className={
-            "rounded-md px-3 py-1 text-xs font-medium transition-colors " +
-            (sttMetric === m
-              ? "bg-white text-text-primary shadow-sm"
-              : "text-gray-500 hover:text-text-primary")
-          }
-        >
-          {m}
-        </button>
+        <MetricInfo key={m} metric={m} align="left">
+          <button
+            type="button"
+            onClick={() => setSttMetric(m)}
+            className={
+              "rounded-md px-3 py-1 text-xs font-medium transition-colors " +
+              (sttMetric === m
+                ? "bg-white text-text-primary shadow-sm"
+                : "text-gray-500 hover:text-text-primary")
+            }
+          >
+            {m}
+          </button>
+        </MetricInfo>
       ))}
     </div>
   );

--- a/web/components/shared/MetricInfo.tsx
+++ b/web/components/shared/MetricInfo.tsx
@@ -1,0 +1,47 @@
+// Copyright 2026 The Coval Benchmarks Authors
+// SPDX-License-Identifier: Apache-2.0
+
+"use client";
+
+import React, { useId } from "react";
+import { metricDescriptions } from "@/lib/config/metrics";
+
+const alignClasses = {
+  left: "left-0",
+  center: "left-1/2 -translate-x-1/2",
+  right: "right-0",
+};
+
+const MetricInfo: React.FC<{
+  metric: string;
+  align?: keyof typeof alignClasses;
+  children: React.ReactNode;
+}> = ({ metric, align = "center", children }) => {
+  const id = useId();
+  const info =
+    metricDescriptions[metric.toLowerCase() as keyof typeof metricDescriptions];
+  if (!info || !("tooltip" in info)) return <>{children}</>;
+  const isElement = React.isValidElement(children);
+  return (
+    <span
+      className="group relative inline-block"
+      tabIndex={isElement ? undefined : 0}
+      aria-describedby={isElement ? undefined : id}
+    >
+      {isElement
+        ? React.cloneElement(children as React.ReactElement<Record<string, unknown>>, {
+            "aria-describedby": id,
+          })
+        : children}
+      <span
+        id={id}
+        role="tooltip"
+        className={`pointer-events-none invisible absolute bottom-full z-50 mb-1.5 w-64 rounded-lg border border-border-secondary bg-surface-tooltip px-3 py-2 text-left text-xs font-normal leading-snug text-[var(--color-text-on-tooltip)] opacity-0 shadow-md transition-opacity group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 group-has-[:focus-visible]:visible group-has-[:focus-visible]:opacity-100 ${alignClasses[align]}`}
+      >
+        <span className="font-semibold">{info.short}.</span> {info.tooltip}
+      </span>
+    </span>
+  );
+};
+
+export default MetricInfo;

--- a/web/components/shared/SectionHeader.tsx
+++ b/web/components/shared/SectionHeader.tsx
@@ -12,7 +12,7 @@ interface SectionHeaderProps {
     detailed: string;
   };
   stat?: {
-    label: string;
+    label: React.ReactNode;
     value: string;
   };
   /** Optional hint shown after the "About this benchmark" link, separated by an interpunct. */

--- a/web/components/visualizations/TimelineChart.tsx
+++ b/web/components/visualizations/TimelineChart.tsx
@@ -26,6 +26,7 @@ import {
 import CustomTimelineTooltip from "@/components/charts/tooltips/TimelineTooltip";
 import Card from "@/components/shared/Card";
 import SectionHeader from "@/components/shared/SectionHeader";
+import MetricInfo from "@/components/shared/MetricInfo";
 import MetricToggle from "@/components/dashboard/MetricToggle";
 import { useActiveTab } from "@/hooks/useActiveTab";
 import { useDashboard } from "@/contexts/DashboardContext";
@@ -314,7 +315,9 @@ const TimelineChart: React.FC = () => {
           }
           description={description}
           stat={{
-            label: `Average ${metricLabel}`,
+            label: (
+              <MetricInfo metric={metric} align="right">{`Average ${metricLabel}`}</MetricInfo>
+            ),
             value: `${avgValue.toFixed(0)} ms`,
           }}
         />

--- a/web/lib/config/metrics.ts
+++ b/web/lib/config/metrics.ts
@@ -9,11 +9,15 @@ export const metricDescriptions = {
   },
   ttft: {
     short: "Time to First Token",
+    tooltip:
+      "Time until the provider returns its first transcript token — how quickly partial results start streaming. Low TTFT with high TTFS points to slow finalization. Lower is better.",
     detailed:
       "We run TTFT measurements on a fixed test case to measure consistency over time. A model that consistently responds within a narrow time range provides better user experience than one with highly variable timing, even if the variable model is sometimes faster. Unpredictable delays can be seen through sudden latency spikes."
   },
   ttfs: {
     short: "Time to Final Segment",
+    tooltip:
+      "Time from end of speech until the final transcript is returned — the delay a voice agent actually waits before it can respond. Lower is better.",
     detailed:
       "TTFS measures how quickly a provider returns the final transcript once speech has ended, anchored at a shared VAD end-of-speech point so every provider is compared from the same instant. It isolates engine finalization speed — the latency a voice agent actually waits on before it can respond — independent of how long the speaker talked."
   },


### PR DESCRIPTION
Fixes FD-298.

## What
<img width="899" height="546" alt="Screenshot 2026-07-07 at 5 17 54 PM" src="https://github.com/user-attachments/assets/3253cc75-aa47-4109-b6cd-cafd7dad7fb7" />


Before (No hover; i lowkey thought that TTFS was Time to First Sound, not Final Segment) 
<img width="907" height="460" alt="Screenshot 2026-07-07 at 5 18 54 PM" src="https://github.com/user-attachments/assets/095060f3-127f-4960-bbb1-8de304c3aafb" />

Adds hover tooltips defining TTFS and TTFT wherever these metrics appear on the STT dashboard.

- Tooltip copy is defined once in `metricDescriptions` (`web/lib/config/metrics.ts`) and rendered through a new shared `MetricInfo` component, so future charts get the tooltip by referencing the metric — no copy duplication.
- Wired to the TTFS/TTFT toggle buttons, the "Avg TTFS" / "Average TTFS" stat headers (Latency vs Accuracy, Latency Variation, Performance Consistency), and the scatter chart's x-axis title (converted from an SVG recharts label to HTML so it can carry the tooltip).
- Accessible: shows on keyboard focus (`:focus-visible`, so a mouse click doesn't pin it open) and is announced via `aria-describedby`.
- Tooltip alignment adapts per edge (left-aligned on the toggle, right-aligned on the stat header) so it never clips outside the card.

Note: copy follows the codebase definition of TTFS (Time to Final Segment, per `runner/src/coval_bench/metrics/ttft.py`), not the ticket's "Time to First Sound" draft, which described a TTS-pipeline metric this chart doesn't measure.

## Testing

- `tsc --noEmit`, `eslint`, and `next build` pass.
- Verified in the dev server: hover shows/hides correctly on toggle, stat, and axis labels; click no longer pins the tooltip; copy switches with the active metric.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds shared metric tooltips across the STT dashboard. The main changes are:

- New `MetricInfo` component backed by `metricDescriptions`.
- TTFS and TTFT tooltip copy in the metric config.
- Tooltip wrappers on toggles, stat labels, and the Latency vs Accuracy axis label.
- HTML rendering for the scatter chart x-axis title.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge after checking the keyboard tooltip behavior.

- The changed metric lookups are guarded and current callers pass known TTFS or TTFT values.
- The main follow-up is the focus selector used for tooltips around focusable children.

web/components/shared/MetricInfo.tsx

<sub>Reviews (1): Last reviewed commit: ["Add hover tooltips explaining TTFS and T..."](https://github.com/coval-ai/benchmarks/commit/5165ff9e99cb5557b3d97a4c2c312cf5d7a59df7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42571473)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->