### PR TITLE
Show WER methodology note on the accuracy chart

### DIFF
--- a/web/components/dashboard/AccuracyBarSection.tsx
+++ b/web/components/dashboard/AccuracyBarSection.tsx
@@ -18,6 +18,7 @@ import CustomBarTooltip from "@/components/charts/tooltips/BarTooltip";
 import CustomBarChartTick from "@/components/charts/CustomBarChartTick";
 import Card from "@/components/shared/Card";
 import SectionHeader from "@/components/shared/SectionHeader";
+import MethodologyNote from "@/components/dashboard/MethodologyNote";
 import { useDashboard } from "@/contexts/DashboardContext";
 import { useThemeColors } from "@/hooks/useThemeColors";
 import { useActiveTab } from "@/hooks/useActiveTab";
@@ -69,6 +70,7 @@ const AccuracyBarSection: React.FC = () => {
           hint="Click bar to compare models"
           stat={{ label: "Avg WER", value: `${avgWER.toFixed(1)}%` }}
         />
+        <MethodologyNote metric="wer" />
         <div className="h-96" onMouseEnter={trackChartHover}>
           <ResponsiveContainer width="100%" height="100%">
             <BarChart

--- a/web/components/dashboard/MethodologyNote.tsx
+++ b/web/components/dashboard/MethodologyNote.tsx
@@ -1,0 +1,56 @@
+// Copyright 2026 The Coval Benchmarks Authors
+// SPDX-License-Identifier: Apache-2.0
+
+"use client";
+
+import React from "react";
+import {
+  methodologyChanges,
+  methodologyChangeTs,
+  type MethodologyMetricKey,
+} from "@/lib/config/methodologyChanges";
+import { useDashboard } from "@/contexts/DashboardContext";
+import { formatDate } from "@/lib/utils/formatters";
+
+interface MethodologyNoteProps {
+  metric: MethodologyMetricKey;
+}
+
+/**
+ * Methodology-change note for charts without a time axis. Shown only while the
+ * selected data window spans the change, i.e. while the chart aggregates
+ * non-comparable values.
+ */
+const MethodologyNote: React.FC<MethodologyNoteProps> = ({ metric }) => {
+  const { getCurrentTimeWindow } = useDashboard();
+  const [windowStart, windowEnd] = getCurrentTimeWindow();
+
+  const visibleChanges = methodologyChanges
+    .map((change) => ({ change, ts: methodologyChangeTs(change) }))
+    .filter(
+      ({ change, ts }) =>
+        (!change.metrics || change.metrics.includes(metric)) &&
+        ts >= windowStart &&
+        ts <= windowEnd
+    );
+
+  if (visibleChanges.length === 0) return null;
+
+  return (
+    <div className="mb-4 space-y-2">
+      {visibleChanges.map(({ change, ts }) => (
+        <p
+          key={`${change.date}-${change.title}`}
+          className="border-l-2 border-[#f59e0b] pl-3 text-sm font-light leading-snug text-text-tertiary"
+        >
+          <span className="text-text-secondary">
+            Methodology change · {formatDate(ts)}:
+          </span>{" "}
+          {change.detail}
+        </p>
+      ))}
+    </div>
+  );
+};
+
+export default MethodologyNote;

--- a/web/components/visualizations/TimelineChart.tsx
+++ b/web/components/visualizations/TimelineChart.tsx
@@ -20,6 +20,7 @@ import { formatDate, formatTime, getLocalTimeZoneAbbr } from "@/lib/utils/format
 import { metricDescriptions } from "@/lib/config/metrics";
 import {
   methodologyChanges,
+  methodologyChangeTs,
   type MethodologyChange,
   type MethodologyMetricKey
 } from "@/lib/config/methodologyChanges";
@@ -187,20 +188,11 @@ const TimelineChart: React.FC = () => {
   const modelsWithData = getModelsWithTimelineData(metric);
   const windowedTimelineData = getWindowedTimelineData(metric);
   const activeMetricKey = metric.toLowerCase() as MethodologyMetricKey;
-  // With an explicit time (an offset-qualified "HH:MM:SS±hh:mm") pin the marker
-  // to that exact instant; otherwise anchor date-only strings at UTC noon so the
-  // marker lands on the intended calendar day in every inhabited timezone (UTC
-  // midnight would shift to the previous day for the Americas).
   const methodologyMarkers = useMemo(
     () =>
       methodologyChanges
         .filter((c) => !c.metrics || c.metrics.includes(activeMetricKey))
-        .map((c) => ({
-          change: c,
-          ts: new Date(
-            c.time ? `${c.date}T${c.time}` : `${c.date}T12:00:00Z`
-          ).getTime(),
-        }))
+        .map((c) => ({ change: c, ts: methodologyChangeTs(c) }))
         .filter((m) => m.ts >= windowStart && m.ts <= windowEnd),
     [activeMetricKey, windowStart, windowEnd]
   );

--- a/web/lib/config/methodologyChanges.ts
+++ b/web/lib/config/methodologyChanges.ts
@@ -11,6 +11,16 @@ export interface MethodologyChange {
   detail: string;
 }
 
+// With an explicit time (an offset-qualified "HH:MM:SS±hh:mm") the marker pins
+// to that exact instant; date-only entries anchor at UTC noon so the marker
+// lands on the intended calendar day in every inhabited timezone (UTC midnight
+// would shift to the previous day for the Americas).
+export function methodologyChangeTs(change: MethodologyChange): number {
+  return new Date(
+    change.time ? `${change.date}T${change.time}` : `${change.date}T12:00:00Z`
+  ).getTime();
+}
+
 export const methodologyChanges: MethodologyChange[] = [
   {
     date: "2026-06-01",
@@ -50,6 +60,7 @@ export const methodologyChanges: MethodologyChange[] = [
   },
   {
     date: "2026-07-07",
+    time: "18:00:00-07:00",
     metrics: ["wer"],
     title: "WER normalization switched to the Whisper text normalizer",
     detail:


### PR DESCRIPTION
The whisper_normalizer methodology annotation from #231 never rendered: the latency timeline is the only surface that reads methodologyChanges, and it never displays WER, so a wer-tagged entry showed up nowhere. WER lives on the accuracy bar chart, which has no time axis.

This renders the note on the accuracy card (STT and TTS) while the selected data window spans the change, i.e. exactly while the bars aggregate non-comparable values, using the same gating as the timeline markers. The entry is also pinned to the real step: run 3908, 2026-07-08 01:00 UTC, the first run scored with the new normalizer.

Verified locally against the prod API on a production build: note renders on both dashboards, timeline markers unaffected by the shared-timestamp refactor.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds methodology-change notes to the accuracy chart. The main changes are:

- Adds a reusable `MethodologyNote` component for non-time-axis charts.
- Renders the WER methodology note in the accuracy bar section.
- Extracts methodology timestamp parsing into a shared helper.
- Pins the WER normalizer change to its explicit UTC-equivalent run time.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<sub>Reviews (1): Last reviewed commit: ["Show WER methodology note on the accurac..."](https://github.com/coval-ai/benchmarks/commit/189118cc3aa72ce58b4206516d57e18ab5122910) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42586292)</sub>

<!-- /greptile_comment -->