### PR TITLE
[BENCH-374] Fix AssemblyAI streaming WER truncation

### DIFF
--- a/runner/src/coval_bench/providers/stt/assemblyai.py
+++ b/runner/src/coval_bench/providers/stt/assemblyai.py
@@ -37,6 +37,8 @@ _SPEECH_MODEL_MAP: dict[str, str] = {
 }
 _WS_BASE = "wss://streaming.assemblyai.com/v3/ws"
 
+_FORCE_ENDPOINT_MODELS = frozenset({"universal-3.5-pro"})
+
 # 1.0 = pure VAD silence-latency mode: the model never declares end-of-turn on a
 # semantic guess, only on our ForceEndpoint at speech-end (TTFS parity). A lower
 # value could let a confident short utterance auto-finalize before our signal.
@@ -97,10 +99,9 @@ class AssemblyAIProvider(STTProvider):
 
         try:
             speech_model = _SPEECH_MODEL_MAP[self._model]
-            url = (
-                f"{_WS_BASE}?sample_rate={sample_rate}&speech_model={speech_model}"
-                f"&end_of_turn_confidence_threshold={_END_OF_TURN_CONFIDENCE_THRESHOLD}"
-            )
+            url = f"{_WS_BASE}?sample_rate={sample_rate}&speech_model={speech_model}"
+            if self._model in _FORCE_ENDPOINT_MODELS:
+                url += f"&end_of_turn_confidence_threshold={_END_OF_TURN_CONFIDENCE_THRESHOLD}"
             extra_params = _MODEL_EXTRA_PARAMS.get(self._model)
             if extra_params:
                 url += "&" + urlencode(extra_params)
@@ -161,13 +162,11 @@ class AssemblyAIProvider(STTProvider):
             async for chunk, start in paced_chunks(audio_data, chunk_size, byte_rate):
                 result.audio_start_time = start
                 await ws.send(chunk)
-            # Force finalization at speech-end (TTFS parity), then wait for the final
-            # before terminating so the close can't race it. Clear first: the event may
-            # already be set by an earlier final, which would make the wait a no-op.
-            final_event.clear()
-            await ws.send(json.dumps({"type": "ForceEndpoint"}))
-            with contextlib.suppress(TimeoutError):
-                await asyncio.wait_for(final_event.wait(), timeout=_FINAL_WAIT_S)
+            if self._model in _FORCE_ENDPOINT_MODELS:
+                final_event.clear()
+                await ws.send(json.dumps({"type": "ForceEndpoint"}))
+                with contextlib.suppress(TimeoutError):
+                    await asyncio.wait_for(final_event.wait(), timeout=_FINAL_WAIT_S)
             await ws.send(json.dumps({"type": "Terminate"}))
         except Exception as exc:
             logger.warning(

--- a/runner/tests/providers/stt/test_assemblyai.py
+++ b/runner/tests/providers/stt/test_assemblyai.py
@@ -76,7 +76,10 @@ def test_websocket_url_contains_required_params() -> None:
 
 
 @pytest.mark.asyncio
-async def test_force_endpoint_sent_before_terminate(fake_api_key: SecretStr) -> None:
+async def test_universal_streaming_terminates_without_force_endpoint(
+    fake_api_key: SecretStr,
+) -> None:
+    """TTFS-excluded models end the session per the vendor's streaming-WER guide."""
     sent: list[Any] = []
     final = {"type": "Turn", "end_of_turn": True, "transcript": "hello world"}
     ws = FakeWebSocket([final], on_send=sent.append)
@@ -97,12 +100,42 @@ async def test_force_endpoint_sent_before_terminate(fake_api_key: SecretStr) -> 
         )
 
     url = mock_connect.call_args.args[0]
+    assert "end_of_turn_confidence_threshold" not in url
+
+    text = [m for m in sent if isinstance(m, str)]
+    assert text == ['{"type": "Terminate"}']
+    assert result.complete_transcript == "hello world"
+
+
+@pytest.mark.asyncio
+async def test_universal_3_5_pro_force_endpoint_before_terminate(
+    fake_api_key: SecretStr,
+) -> None:
+    sent: list[Any] = []
+    final = {"type": "Turn", "end_of_turn": True, "transcript": "hello world"}
+    ws = FakeWebSocket([final], on_send=sent.append)
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=ws)
+    cm.__aexit__ = AsyncMock(return_value=False)
+    provider = AssemblyAIProvider(api_key=fake_api_key, model="universal-3.5-pro")
+
+    with patch(
+        "coval_bench.providers.stt.assemblyai.ws_client.connect", return_value=cm
+    ) as mock_connect:
+        result = await provider.measure_ttft(
+            audio_data=b"\x00" * 640,
+            channels=1,
+            sample_width=2,
+            sample_rate=16000,
+            realtime_resolution=0.01,
+        )
+
+    url = mock_connect.call_args.args[0]
     assert "end_of_turn_confidence_threshold=1.0" in url
 
     text = [m for m in sent if isinstance(m, str)]
     assert '"ForceEndpoint"' in text[-2]
     assert '"Terminate"' in text[-1]
-    # The forced final is captured before the close (gate + response-capture path).
     assert result.audio_to_final_seconds is not None
 
 
@@ -205,6 +238,7 @@ async def test_universal_streaming_multilingual_url_uses_api_speech_model(
     url = mock_connect.call_args.args[0]
     assert "speech_model=universal-streaming-multilingual" in url
     assert "language_code" not in url
+    assert "end_of_turn_confidence_threshold" not in url
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
universal-streaming and universal-streaming-multilingual are TTFS-excluded, but the provider still sent ForceEndpoint at speech end. On these models that final is just an ack: it returns whatever has been processed and drops the in-flight tail, cutting transcripts mid-word. We were paying a WER penalty for a latency parity we no longer report.

These two models now end sessions the way AssemblyAI's own streaming WER evaluation guide does: stream the audio, send Terminate, and keep reading until the Termination message so the server flushes the remaining finals. The end_of_turn_confidence_threshold=1.0 override is also dropped for them so turns can finalize naturally mid-clip. universal-3.5-pro keeps the ForceEndpoint path unchanged since it still reports TTFS and finalizes genuinely.

Verified live against the v3 API on silence-trimmed clips: the old path cut a tail mid-word ("flower fatten sauce") where the new path returns it intact ("flower fattened sauce"), and universal-3.5-pro behavior is unchanged (forced final lands at speech end, complete transcript).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR changes how AssemblyAI streaming sessions are ended for TTFS-excluded models.

- Adds a ForceEndpoint-only model set for `universal-3.5-pro`.
- Removes the end-of-turn confidence override from the two universal streaming models.
- Sends `Terminate` directly for those models and updates tests for the split behavior.

<h3>Confidence Score: 4/5</h3>

The new Terminate-driven AssemblyAI path needs a lifecycle fix before merging.

- The receiver does not treat the `Termination` message as completion.
- The changed non-ForceEndpoint path can wait on websocket close instead of the documented termination ack.
- The removed final wait leaves a conditional path where a flushed final turn can be missed if close wins the race.

runner/src/coval_bench/providers/stt/assemblyai.py

<sub>Reviews (1): Last reviewed commit: ["Fix AssemblyAI streaming WER tail trunca..."](https://github.com/coval-ai/benchmarks/commit/2f1837d6f0141bda2d499aa25efb15511d74c50d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42757365)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->