### PR TITLE
Anchor methodology markers to their deploy times

### DIFF
--- a/web/lib/config/methodologyChanges.ts
+++ b/web/lib/config/methodologyChanges.ts
@@ -50,13 +50,15 @@ export const methodologyChanges: MethodologyChange[] = [
   },
   {
     date: "2026-07-07",
+    time: "17:33:45-07:00",
     metrics: ["wer"],
     title: "WER normalization switched to the Whisper text normalizer",
     detail:
       "Transcripts were previously normalized with a hand-rolled pipeline that corrupted many number forms (“thirty six” became 3006), putting a WER floor under providers that transcribe numbers as digits. Both reference and hypothesis now go through OpenAI’s Whisper English text normalizer, the standard used for published WER. Affected providers’ WER drops after this date; values before and after are not comparable.",
   },
   {
-    date: "2026-07-07",
+    date: "2026-07-08",
+    time: "09:52:07-07:00",
     metrics: ["wer", "ttft", "ttfs"],
     title: "STT dataset replaced with WildASR fleurs_clean_en",
     detail:


### PR DESCRIPTION
The two most recent methodology-change markers (Whisper normalizer, WildASR stt-v2 dataset) were date-only, so they rendered at noon UTC instead of the moment prod actually switched. This pins each to the runner release that shipped it, so the marker lands on the real discontinuity in the data.

- **Whisper normalizer** (#231): first shipped in the runner release at 2026-07-08 00:33:45 UTC → `date: 2026-07-07`, `time: 17:33:45-07:00`.
- **WildASR stt-v2 dataset** (#235): deployed 2026-07-08 16:52:07 UTC → moved to `date: 2026-07-08`, `time: 09:52:07-07:00` (was dated 07-07 speculatively before the deploy landed).

Data-only change to `methodologyChanges.ts`; times parse to the exact deploy instants and both fall in the default 7d window. Web typecheck passes.

Closes BENCH-377.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR pins methodology-change markers to their deploy instants. The main changes are:

- Adds the Whisper normalizer release time to the existing July 7 marker.
- Moves the WildASR dataset marker to July 8.
- Adds the WildASR deploy time with a timezone offset.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.
- The existing marker consumer already parses optional timezone-qualified times.
- The changed values produce concrete timestamps for chart placement.

<sub>Reviews (1): Last reviewed commit: ["Anchor methodology markers to their depl..."](https://github.com/coval-ai/benchmarks/commit/4c55083bf9712e51a378e27d3c8893a76e295371) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42769859)</sub>

<!-- /greptile_comment -->