### PR TITLE
Default model comparison table to p95 latency

### DIFF
--- a/web/components/dashboard/ModelComparisonTable.tsx
+++ b/web/components/dashboard/ModelComparisonTable.tsx
@@ -28,6 +28,9 @@ const PERCENTILES: { key: LatencyPercentile; hint?: string }[] = [
   { key: "p100", hint: "slowest run" }
 ];
 
+// p95: the tail latency real-time voice users actually feel.
+const DEFAULT_PERCENTILE_IDX = 5;
+
 const COLUMNS: {
   key: ColumnKey;
   label: string;
@@ -43,12 +46,12 @@ const ModelComparisonTable: React.FC<ModelComparisonTableProps> = ({
   getProviderForModel
 }) => {
   const activeTab = useActiveTab();
-  const [percentileIdx, setPercentileIdx] = useState(2);
+  const [percentileIdx, setPercentileIdx] = useState(DEFAULT_PERCENTILE_IDX);
   const [sort, setSort] = useState<{ key: ColumnKey; direction: "asc" | "desc" }>(
     { key: "latency", direction: "asc" }
   );
 
-  const percentile = (PERCENTILES[percentileIdx] ?? PERCENTILES[2])!;
+  const percentile = (PERCENTILES[percentileIdx] ?? PERCENTILES[DEFAULT_PERCENTILE_IDX])!;
 
   // One pass per (data, percentile, sort) change: pull the selected latency
   // percentile, precompute the relative bar fractions, sort, and note the best


### PR DESCRIPTION
The table now opens on p95, the tail latency real-time voice users feel, instead of median.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR changes the default latency view in the model comparison table.

- Adds a named default percentile index for `p95`.
- Initializes the percentile slider to `p95` instead of median latency.
- Uses the same `p95` default when the selected percentile is missing.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<sub>Reviews (1): Last reviewed commit: ["Default model comparison table to p95 la..."](https://github.com/coval-ai/benchmarks/commit/15fac325086fef19be7786f05ab5023774794996) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42781597)</sub>

<!-- /greptile_comment -->