### PR TITLE
(BENCH-375) Improve TTFA box plot tooltip: compact hover, click-to-pin details

### DIFF
--- a/web/components/charts/d3/BoxPlot.tsx
+++ b/web/components/charts/d3/BoxPlot.tsx
@@ -6,6 +6,7 @@
 import React, { useState, useEffect, useRef } from "react";
 import * as d3 from "d3";
 import { BoxPlotProps } from "@/types/chart.types";
+import { BoxPlotDataPoint } from "@/types/benchmark.types";
 import { useThemeColors } from "@/hooks/useThemeColors";
 
 // Match the text sizes on the timeline chart above: 14px axis labels, 12px
@@ -31,7 +32,25 @@ const BoxPlot: React.FC<BoxPlotProps> = ({
     width: width || 800,
     height
   });
+  const [tip, setTip] = useState<{
+    point: BoxPlotDataPoint;
+    x: number;
+    yTop: number;
+    pinned: boolean;
+  } | null>(null);
   const themeColors = useThemeColors();
+
+  useEffect(() => {
+    if (!tip?.pinned) return;
+    const onClick = () => setTip(null);
+    const onKey = (e: KeyboardEvent) => e.key === "Escape" && setTip(null);
+    document.addEventListener("click", onClick);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("click", onClick);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [tip]);
 
   // Handle responsive sizing — always fit the card's content box.
   useEffect(() => {
@@ -60,6 +79,8 @@ const BoxPlot: React.FC<BoxPlotProps> = ({
 
   useEffect(() => {
     if (!svgRef.current || data.data.length === 0) return;
+
+    setTip(null);
 
     const margin = { top: 20, right: 8, bottom: 80, left: 40 };
     const chartWidth = dimensions.width - margin.left - margin.right;
@@ -303,7 +324,15 @@ const BoxPlot: React.FC<BoxPlotProps> = ({
         .attr("stroke", color)
         .attr("stroke-width", 1.5);
 
-      // Add interactive hover effects
+      // Hover shows a compact name + median tooltip above the whiskers;
+      // clicking pins that same tooltip and populates it with the full
+      // stats so it never chases the cursor or blocks neighboring boxes.
+      const anchor = {
+        point: modelData,
+        x: margin.left + centerX,
+        yTop: margin.top + yScale(max),
+      };
+
       boxGroup
         .style("cursor", "pointer")
         .on("mouseenter", function () {
@@ -311,120 +340,35 @@ const BoxPlot: React.FC<BoxPlotProps> = ({
             .select("rect")
             .attr("fill-opacity", 0.5);
 
-          const tooltip = g.append("g").attr("class", "box-tooltip");
-
-          const tooltipRect = tooltip
-            .append("rect")
-            .attr("x", 0)
-            .attr("y", -40)
-            .attr("height", 80)
-            .attr("fill", themeColors.tooltipBg)
-            .attr("stroke", color)
-            .attr("stroke-width", 1)
-            .attr("rx", 6)
-            .attr("opacity", 0.95);
-
-          const tooltipLines = [
-            {
-              text: modelData.model,
-              y: -25,
-              size: "12px",
-              weight: "bold",
-              fill: themeColors.tooltipText,
-            },
-            {
-              text: `Count: ${modelData.stats.count}`,
-              y: -8,
-              size: "10px",
-              weight: "normal",
-              fill: themeColors.tooltipSecondary,
-            },
-            {
-              text: `Mean: ${modelData.stats.mean.toFixed(0)}ms`,
-              y: 6,
-              size: "10px",
-              weight: "normal",
-              fill: themeColors.tooltipSecondary,
-            },
-            {
-              text: `Median: ${modelData.quartiles.median.toFixed(0)}ms`,
-              y: 20,
-              size: "10px",
-              weight: "normal",
-              fill: themeColors.tooltipSecondary,
-            },
-            {
-              text: `Std: ${modelData.stats.std.toFixed(0)}ms`,
-              y: 34,
-              size: "10px",
-              weight: "normal",
-              fill: themeColors.tooltipSecondary,
-            },
-          ];
-
-          const tooltipNodes = tooltipLines.map((line) => {
-            const node = tooltip
-              .append("text")
-              .attr("x", 8)
-              .attr("y", line.y)
-              .attr("fill", line.fill)
-              .attr("font-size", line.size)
-              .attr("font-weight", line.weight)
-              .text(line.text);
-            return {
-              node,
-              width: node.node()?.getComputedTextLength() ?? 0,
-              size: line.size,
-            };
-          });
-
-          const tooltipTextWidth = tooltipNodes.reduce(
-            (max, n) => Math.max(max, n.width),
-            0
-          );
-          const tooltipWidth = Math.min(
-            chartWidth,
-            Math.max(140, tooltipTextWidth + 16)
-          );
-          tooltipRect.attr("width", tooltipWidth);
-
-          const innerWidth = tooltipWidth - 16;
-          tooltipNodes.forEach(({ node, width, size }) => {
-            if (width > innerWidth && width > 0) {
-              const baseSize = parseFloat(size);
-              node.attr("font-size", `${baseSize * (innerWidth / width)}px`);
-            }
-          });
-
-          const tooltipX = Math.max(
-            0,
-            Math.min(
-              centerX + 30 + tooltipWidth > chartWidth
-                ? centerX - 30 - tooltipWidth
-                : centerX + 30,
-              chartWidth - tooltipWidth
-            )
-          );
-          tooltip.attr(
-            "transform",
-            `translate(${tooltipX}, ${yScale(median)})`
+          setTip((t) =>
+            t?.pinned && t.point.model === modelData.model
+              ? t
+              : { ...anchor, pinned: false }
           );
         })
         .on("mouseleave", function () {
           d3.select(this)
             .select("rect")
             .attr("fill-opacity", 0.3);
-
-          g.select(".box-tooltip").remove();
+        })
+        .on("click", (event: MouseEvent) => {
+          event.stopPropagation();
+          setTip((t) =>
+            t?.pinned && t.point.model === modelData.model
+              ? null
+              : { ...anchor, pinned: true }
+          );
         });
     });
+
+    svg.on("mouseleave", () => setTip((t) => (t?.pinned ? t : null)));
   }, [data, dimensions, getModelColor, getProviderForModel, normalizeModelName, isMobile, themeColors]);
 
   // The measured container must always render — an early return here would
   // leave the sizing effect's ResizeObserver attached to nothing, freezing
   // dimensions at their initial value once data arrives.
   return (
-    <div ref={containerRef} className="w-full">
+    <div ref={containerRef} className="relative w-full">
       {data.data.length === 0 ? (
         <div className="h-64 flex items-center justify-center text-text-secondary">
           <p>No data available for box plot</p>
@@ -437,6 +381,77 @@ const BoxPlot: React.FC<BoxPlotProps> = ({
           className="overflow-visible"
           style={{ background: "transparent" }}
         />
+      )}
+      {tip && (
+        <div
+          onClick={(e) => e.stopPropagation()}
+          className="absolute z-10 whitespace-nowrap text-xs"
+          style={{
+            left: Math.min(Math.max(tip.x, 90), dimensions.width - 90),
+            top: tip.yTop,
+            transform: "translate(-50%, calc(-100% - 8px))",
+            transition: "left 150ms ease-out, top 150ms ease-out",
+            pointerEvents: tip.pinned ? "auto" : "none",
+            backgroundColor: "var(--color-surface-tooltip)",
+            border: `1px solid ${getModelColor(tip.point.model)}`,
+            borderRadius: "8px",
+            padding: tip.pinned ? "6px 24px 6px 10px" : "6px 10px",
+            boxShadow: "0 2px 8px rgba(10, 10, 10, 0.08)"
+          }}
+        >
+          {tip.pinned && (
+            <button
+              aria-label="Close"
+              onClick={() => setTip(null)}
+              style={{
+                position: "absolute",
+                top: "4px",
+                right: "6px",
+                background: "none",
+                border: "none",
+                padding: 0,
+                cursor: "pointer",
+                lineHeight: 1,
+                color: "var(--color-text-on-tooltip-secondary)"
+              }}
+            >
+              ✕
+            </button>
+          )}
+          <p
+            style={{
+              margin: 0,
+              fontWeight: "bold",
+              color: "var(--color-text-on-tooltip)"
+            }}
+          >
+            {tip.point.model}
+          </p>
+          {(tip.pinned
+            ? [
+                ["Count", `${tip.point.stats.count}`],
+                ["Mean", `${tip.point.stats.mean.toFixed(0)}ms`],
+                ["Median", `${tip.point.quartiles.median.toFixed(0)}ms`],
+                ["Std", `${tip.point.stats.std.toFixed(0)}ms`]
+              ]
+            : [
+                [
+                  "Median",
+                  `${tip.point.quartiles.median.toFixed(0)}ms · click for details`
+                ]
+              ]
+          ).map(([label, value]) => (
+            <p
+              key={label}
+              style={{
+                margin: 0,
+                color: "var(--color-text-on-tooltip-secondary)"
+              }}
+            >
+              {label}: {value}
+            </p>
+          ))}
+        </div>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
After:
<img width="732" height="676" alt="Screenshot 2026-07-08 at 11 01 46 AM" src="https://github.com/user-attachments/assets/f2e3232c-ca1b-4b69-b388-6b64f60c15f2" />

Before:
<img width="736" height="746" alt="Screenshot 2026-07-08 at 11 02 03 AM" src="https://github.com/user-attachments/assets/e035dd26-f156-4d9a-a902-320cdb6ffd34" />


The "Distribution of TTFA values across all runs" box plot showed a large five-line stats panel on hover that overlapped neighboring boxes and obscured the data behind it.

- **Hover** now shows a compact tooltip (model name + median) anchored above the box's top whisker, so it sits in whitespace instead of over adjacent boxes, and is clamped to the plot area.
- **Click** pins that same tooltip in place and populates it with the full breakdown (Count, Mean, Median, Std). It persists until dismissed via outside-click, Esc, the ✕ button, hovering another model, or clicking the same box again.
- The tooltip is a single persistent HTML element (styled with the same design-system tooltip variables as the recharts tooltips), so sweeping across the chart glides it from box to box rather than flashing separate popups; it only disappears when the cursor leaves the chart.

## Testing
- Exercised all paths in the browser preview: hover, glide between boxes, pin, hover-replaces-pin, same-box toggle, outside-click / Esc / ✕ dismissal, and pin surviving cursor leaving the chart.
- `tsc --noEmit` and `eslint` clean.

Closes BENCH-375, BENCH-376

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR changes the box plot tooltip from an SVG hover panel to a React-rendered tooltip. The main changes are:

- Compact hover tooltip with model and median.
- Click-to-pin mode with full stats and close controls.
- Shared tooltip element positioned above the whisker and clamped horizontally.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge after a small tooltip persistence cleanup.

- No blocking issues found in the changed code.
- A pinned tooltip can still be cleared by normal chart redraws such as resize or refreshed data.

web/components/charts/d3/BoxPlot.tsx

<sub>Reviews (1): Last reviewed commit: ["(BENCH-375) Replace box plot hover panel..."](https://github.com/coval-ai/benchmarks/commit/d5b1a92a58495bdb51ed7852888bc2dfb0483046) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42787908)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->