### PR TITLE
Fix overlapping tooltips on TTFS/TTFT methodology markers (BENCH-379)

### DIFF
--- a/web/components/visualizations/TimelineChart.tsx
+++ b/web/components/visualizations/TimelineChart.tsx
@@ -546,8 +546,8 @@ const TimelineChart: React.FC = () => {
                     compact
                   />
                 }
-                active={pinned || dragging ? false : undefined}
-                cursor={!dragging}
+                active={pinned || dragging || hoveredMarker ? false : undefined}
+                cursor={!dragging && !hoveredMarker}
               />
               {modelsWithData.length > 1 && (
                 <Legend content={<TimelineLegend />} />
@@ -638,60 +638,22 @@ const TimelineChart: React.FC = () => {
           {hoveredMarker &&
             (() => {
               const width = chartRef.current?.clientWidth ?? 0;
-              const pad = 120;
+              const pad = 132;
               const left =
                 width > pad * 2
                   ? Math.min(Math.max(hoveredMarker.x, pad), width - pad)
                   : hoveredMarker.x;
               return (
                 <div
-                  style={{
-                    position: "absolute",
-                    left,
-                    top: 26,
-                    transform: "translateX(-50%)",
-                    zIndex: 25,
-                    pointerEvents: "none",
-                    maxWidth: 240,
-                  }}
+                  role="tooltip"
+                  className="pointer-events-none absolute z-30 w-64 -translate-x-1/2 rounded-lg border border-border-secondary bg-surface-tooltip px-3 py-2 text-left text-xs font-normal leading-snug text-[var(--color-text-on-tooltip)] shadow-md"
+                  style={{ left, top: 26 }}
                 >
-                  <div
-                    style={{
-                      backgroundColor: "var(--color-surface-tooltip)",
-                      border: "1px solid var(--color-border-secondary)",
-                      borderRadius: "8px",
-                      color: "var(--color-text-on-tooltip)",
-                      padding: "12px",
-                    }}
-                  >
-                    <p
-                      style={{
-                        margin: 0,
-                        fontWeight: "bold",
-                        fontSize: "12px",
-                      }}
-                    >
-                      {hoveredMarker.change.title}
-                    </p>
-                    <p
-                      style={{
-                        margin: "4px 0 0",
-                        fontSize: "10px",
-                        color: "var(--color-text-on-tooltip-secondary)",
-                      }}
-                    >
-                      Methodology change · {formatDate(hoveredMarker.ts)}
-                    </p>
-                    <p
-                      style={{
-                        margin: "8px 0 0",
-                        fontSize: "11px",
-                        lineHeight: 1.45,
-                      }}
-                    >
-                      {hoveredMarker.change.detail}
-                    </p>
-                  </div>
+                  <p className="font-semibold">{hoveredMarker.change.title}</p>
+                  <p className="mt-0.5 text-[10px] text-[var(--color-text-on-tooltip-secondary)]">
+                    Methodology change · {formatDate(hoveredMarker.ts)}
+                  </p>
+                  <p className="mt-1.5">{hoveredMarker.change.detail}</p>
                 </div>
               );
             })()}


### PR DESCRIPTION
## Summary
- Hovering a methodology-change reference line on the Performance Consistency chart rendered two stacked tooltips: the recharts data tooltip stayed active underneath the annotation popover, leaving both unreadable. The data tooltip is now suppressed while a marker is hovered, reusing the same `active`/`cursor` suppression the pinned and dragging states already use — only one tooltip surface shows at a time.
- Rebuilt the annotation popover with the shared design-system tooltip classes (same recipe as `MetricInfo`: `bg-surface-tooltip`, `border-border-secondary`, `rounded-lg`, tooltip text tokens) instead of ~50 lines of bespoke inline styles, so it inherits app theming. Net −38 lines.
- Edge clamp is sized to the popover's fixed `w-64` width so it can never overflow the chart container, including the far-right Jul 8 marker.

## Test plan
- [x] Hovered right-edge (Jul 8) and left-edge markers on TTFS: single readable tooltip, measured fully inside chart bounds, recharts tooltip hidden
- [x] Same verified on the TTFT tab
- [x] Normal data tooltip, pin-on-click, and drag-to-zoom unaffected (props identical to main when no marker is hovered)
- [x] `tsc --noEmit` and `eslint . --max-warnings 0` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a double-tooltip bug on the Performance Consistency chart by suppressing the recharts data tooltip while a methodology-change marker is hovered, then refactors the marker popover to use design-system Tailwind classes instead of inline styles.

- Adds `hoveredMarker` to the `active={false}` guard on `<Tooltip>` (consistent with the existing `pinned` and `dragging` patterns) and sets `cursor={false}` to also hide the crosshair, so only the annotation popover is visible during a marker hover.
- Replaces ~50 lines of bespoke `style={{}}` on the annotation popover with design-system tokens (`bg-surface-tooltip`, `border-border-secondary`, `text-[var(--color-text-on-tooltip)]`, etc.), reduces nesting by one `<div>`, and adds `role="tooltip"` for accessibility.
- Bumps the edge-clamp `pad` from 120 to 132, correctly covering half of the new fixed `w-64` (256 px) tooltip width with a 4 px margin.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is narrow and self-contained, touches only the marker-hover rendering path, and leaves all other chart interactions (data tooltip, pin-on-click, drag-to-zoom) unaffected.

The tooltip-suppression fix follows an identical pattern already in the file for `pinned` and `dragging` states, and the popover refactor is a mechanical style-to-class translation with no behavioral change beyond the fixed width (256 px vs. max-width 240 px). The edge-clamp arithmetic is correct for the new width. No logic, state, or data-flow is changed outside the hovered-marker branch.

No files require special attention.

<sub>Reviews (1): Last reviewed commit: ["Fix overlapping tooltips on TTFS/TTFT me..."](https://github.com/coval-ai/benchmarks/commit/458ecc6e9996383aa0908e32eb9e31adbca5d266) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42816246)</sub>

<!-- /greptile_comment -->