### PR TITLE
Add Conversational Context feature to AssemblyAI universal-3.5-pro

### DIFF
--- a/runner/src/coval_bench/registries/models.py
+++ b/runner/src/coval_bench/registries/models.py
@@ -74,6 +74,7 @@ _KEYTERM = ModelTag.KEYTERM_BIASING
 _CLONE = ModelTag.VOICE_CLONING
 _EMOTION = ModelTag.EMOTION_CONTROL
 _STREAM = ModelTag.STREAMING_INPUT
+_CONVCTX = ModelTag.CONVERSATIONAL_CONTEXT
 _OPEN = Licensing.OPEN_WEIGHT
 
 # Per-benchmark order is the model order /v1/providers returns.
@@ -171,7 +172,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         benchmark=_STT,
         provider="assemblyai",
         model="universal-3.5-pro",
-        tags=(_REALTIME, _MULTI, _VAD, _DIAR, _CODESW, _KEYTERM),
+        tags=(_REALTIME, _MULTI, _VAD, _DIAR, _CODESW, _KEYTERM, _CONVCTX),
         self_hostable=True,
         status=_ACTIVE,
     ),

--- a/runner/src/coval_bench/registries/tags.py
+++ b/runner/src/coval_bench/registries/tags.py
@@ -40,6 +40,7 @@ class ModelTag(StrEnum):
     VOICE_CLONING = "voice-cloning"
     EMOTION_CONTROL = "emotion-control"
     STREAMING_INPUT = "streaming-input"
+    CONVERSATIONAL_CONTEXT = "conversational-context"
 
 
 TAG_CATEGORIES: dict[ModelTag, TagCategory] = {
@@ -54,6 +55,7 @@ TAG_CATEGORIES: dict[ModelTag, TagCategory] = {
     ModelTag.VOICE_CLONING: TagCategory.FEATURES,
     ModelTag.EMOTION_CONTROL: TagCategory.FEATURES,
     ModelTag.STREAMING_INPUT: TagCategory.FEATURES,
+    ModelTag.CONVERSATIONAL_CONTEXT: TagCategory.FEATURES,
 }
 
 if TAG_CATEGORIES.keys() != set(ModelTag):
@@ -89,6 +91,7 @@ _VALUE_LABELS: dict[str, str] = {
     ModelTag.VOICE_CLONING.value: "Voice cloning",
     ModelTag.EMOTION_CONTROL.value: "Emotion control",
     ModelTag.STREAMING_INPUT.value: "Streaming input",
+    ModelTag.CONVERSATIONAL_CONTEXT.value: "Conversational context",
 }
 
 


### PR DESCRIPTION
Surfaces conversational context as a Features chip on AssemblyAI's newest streaming model.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `CONVERSATIONAL_CONTEXT` feature tag to the registry and assigns it to AssemblyAI's `universal-3.5-pro` streaming model.

- A new `ModelTag.CONVERSATIONAL_CONTEXT = "conversational-context"` enum value is introduced in `tags.py`, with a corresponding `TAG_CATEGORIES` entry (`FEATURES`) and a `_VALUE_LABELS` display string ("Conversational context") — all following the existing pattern for every other tag.
- In `models.py`, a `_CONVCTX` shorthand alias is added and appended to the `universal-3.5-pro` tag tuple, matching how all other tags are applied in the registry.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is additive, well-contained, and the built-in completeness guard validates the new tag at module import time.

The change strictly follows the existing pattern for adding a tag: enum value, category mapping, display label, shorthand alias, and model assignment — all in the right places and correctly wired up. The module-level guard (TAG_CATEGORIES.keys() != set(ModelTag)) will raise at import if any step is missed, providing automatic correctness coverage.

No files require special attention.

<sub>Reviews (1): Last reviewed commit: ["Add Conversational Context feature to As..."](https://github.com/coval-ai/benchmarks/commit/0d931f3a6f69e66312a57bf45641f4fc66fed3b1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42839276)</sub>

<!-- /greptile_comment -->