### PR TITLE
Make WER chart comparison functional and responsive (BENCH-380)

### DIFF
--- a/web/components/charts/CustomBarChartTick.tsx
+++ b/web/components/charts/CustomBarChartTick.tsx
@@ -13,17 +13,38 @@ const mobileFontSize = "12px";
 const CustomBarChartTick: React.FC<{
   x?: number;
   y?: number;
+  width?: number;
+  visibleTicksCount?: number;
   payload?: { value: string };
   getProviderForModel: (model: string) => string;
   isMobile?: boolean;
-}> = ({ x = 0, y = 0, payload, getProviderForModel, isMobile = false }) => {
+}> = ({
+  x = 0,
+  y = 0,
+  width = 0,
+  visibleTicksCount = 1,
+  payload,
+  getProviderForModel,
+  isMobile = false,
+}) => {
   const themeColors = useThemeColors();
 
   if (!payload) return null;
 
   const model = payload.value;
-  const normalizedModel = normalizeModelName(model);
+  const fullName = normalizeModelName(model);
   const provider = getProviderForModel(model);
+
+  // Labels sit on a 45° diagonal, so adjacent labels are slot·sin(45°) apart
+  // perpendicular to the text. Two 12px lines need ~40px of slot; below that
+  // the provider line collides with the neighbour's model line, so drop it
+  // and shorten the name (the tooltip and <title> still carry the full info).
+  const slot = visibleTicksCount > 0 ? width / visibleTicksCount : width;
+  const showProvider = slot >= 40;
+  const maxChars = !showProvider ? 12 : isMobile ? 14 : 18;
+  const normalizedModel =
+    fullName.length > maxChars ? `${fullName.slice(0, maxChars - 1)}…` : fullName;
+  const showTitle = !showProvider || normalizedModel !== fullName;
 
   // Render every label on a single 45° diagonal so they don't collide when many
   // models are shown: model name (bold) on the first line, provider below it,
@@ -42,18 +63,21 @@ const CustomBarChartTick: React.FC<{
           fontSize={fontSize}
           fontWeight="bold"
         >
+          {showTitle && <title>{`${provider} ${fullName}`}</title>}
           {normalizedModel}
         </text>
-        <text
-          x={0}
-          y={0}
-          dy={28}
-          textAnchor="end"
-          fill={themeColors.axisText}
-          fontSize={providerFontSize}
-        >
-          {provider}
-        </text>
+        {showProvider && (
+          <text
+            x={0}
+            y={0}
+            dy={28}
+            textAnchor="end"
+            fill={themeColors.axisText}
+            fontSize={providerFontSize}
+          >
+            {provider}
+          </text>
+        )}
       </g>
     </g>
   );

--- a/web/components/dashboard/AccuracyBarSection.tsx
+++ b/web/components/dashboard/AccuracyBarSection.tsx
@@ -3,7 +3,7 @@
 
 "use client";
 
-import React, { useMemo } from "react";
+import React, { useCallback, useMemo } from "react";
 import {
   BarChart,
   Bar,
@@ -70,7 +70,7 @@ const AccuracyBarSection: React.FC = () => {
   // Bar-top value labels are ~28px wide, so on narrow charts they collide.
   // When a bar is too thin, keep the label only on selected bars; the axis
   // and tooltip still carry the values for the rest.
-  const barLabel = ({
+  const barLabel = useCallback(({
     x = 0,
     y = 0,
     width = 0,
@@ -97,7 +97,7 @@ const AccuracyBarSection: React.FC = () => {
         {`${Number(value).toFixed(1)}%`}
       </text>
     );
-  };
+  }, [werBarDataWithColors, clickedWERBars, themeColors.label]);
 
   return (
     <div className="mb-4">
@@ -145,7 +145,7 @@ const AccuracyBarSection: React.FC = () => {
             <button
               type="button"
               onClick={clearWERBars}
-              className="px-1 text-xs text-text-tertiary transition-colors hover:text-text-primary"
+              className="px-1 text-xs text-text-tertiary transition-colors hover:text-text-primary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-text-tertiary/40"
             >
               Clear
             </button>

--- a/web/components/dashboard/AccuracyBarSection.tsx
+++ b/web/components/dashboard/AccuracyBarSection.tsx
@@ -15,6 +15,7 @@ import {
   Cell,
 } from "recharts";
 import CustomBarTooltip from "@/components/charts/tooltips/BarTooltip";
+import { normalizeModelName } from "@/lib/utils/formatters";
 import CustomBarChartTick from "@/components/charts/CustomBarChartTick";
 import Card from "@/components/shared/Card";
 import SectionHeader from "@/components/shared/SectionHeader";
@@ -31,7 +32,10 @@ const AccuracyBarSection: React.FC = () => {
     werBarDataWithColors,
     getProviderForModel,
     isMobile,
+    clickedWERBars,
     handleWERBarClick,
+    clearWERBars,
+    hasActiveFacets,
   } = useDashboard();
 
   const themeColors = useThemeColors();
@@ -51,14 +55,49 @@ const AccuracyBarSection: React.FC = () => {
     handleWERBarClick(data);
   };
 
+  const selectedBars = useMemo(
+    () => werBarDataWithColors.filter((item) => clickedWERBars.has(item.model)),
+    [werBarDataWithColors, clickedWERBars]
+  );
+
   const avgWER = useMemo(() => {
-    if (werBarDataWithColors.length === 0) return 0;
-    const sum = werBarDataWithColors.reduce(
-      (acc, item) => acc + (item.averageWER ?? 0),
-      0
+    const source = selectedBars.length > 0 ? selectedBars : werBarDataWithColors;
+    if (source.length === 0) return 0;
+    const sum = source.reduce((acc, item) => acc + (item.averageWER ?? 0), 0);
+    return sum / source.length;
+  }, [selectedBars, werBarDataWithColors]);
+
+  // Bar-top value labels are ~28px wide, so on narrow charts they collide.
+  // When a bar is too thin, keep the label only on selected bars; the axis
+  // and tooltip still carry the values for the rest.
+  const barLabel = ({
+    x = 0,
+    y = 0,
+    width = 0,
+    value,
+    index = 0,
+  }: {
+    x?: number;
+    y?: number;
+    width?: number;
+    value?: number;
+    index?: number;
+  }) => {
+    const entry = werBarDataWithColors[index];
+    if (width < 28 && !(entry && clickedWERBars.has(entry.model))) return <g />;
+    return (
+      <text
+        x={x + width / 2}
+        y={y - 8}
+        textAnchor="middle"
+        fill={themeColors.label}
+        fillOpacity={entry?.fillOpacity}
+        fontSize={12}
+      >
+        {`${Number(value).toFixed(1)}%`}
+      </text>
     );
-    return sum / werBarDataWithColors.length;
-  }, [werBarDataWithColors]);
+  };
 
   return (
     <div className="mb-4">
@@ -67,8 +106,51 @@ const AccuracyBarSection: React.FC = () => {
           label="Accuracy by Model"
           description={description}
           hint="Click bar to compare models"
-          stat={{ label: "Avg WER", value: `${avgWER.toFixed(1)}%` }}
+          stat={{
+            label:
+              selectedBars.length > 0
+                ? `Avg WER (${selectedBars.length} selected)`
+                : hasActiveFacets
+                  ? `Avg WER (${werBarDataWithColors.length} filtered)`
+                  : "Avg WER (all models)",
+            value:
+              werBarDataWithColors.length === 0 ? "—" : `${avgWER.toFixed(1)}%`,
+          }}
         />
+        {selectedBars.length > 0 && (
+          <div className="mb-3 flex flex-wrap items-center gap-1.5">
+            {selectedBars.map((item) => (
+              <span
+                key={item.model}
+                className="inline-flex items-center gap-1.5 rounded-full border border-border-primary px-2.5 py-1 text-xs text-text-secondary"
+              >
+                <span
+                  className="h-2 w-2 rounded-full"
+                  style={{ backgroundColor: item.fill }}
+                />
+                {normalizeModelName(item.model)}
+                <span className="tabular-nums font-medium text-text-primary">
+                  {item.averageWER.toFixed(1)}%
+                </span>
+                <button
+                  type="button"
+                  aria-label={`Deselect ${normalizeModelName(item.model)}`}
+                  onClick={() => handleWERBarClickTracked(item)}
+                  className="text-text-tertiary transition-colors hover:text-text-primary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-text-tertiary/40"
+                >
+                  ✕
+                </button>
+              </span>
+            ))}
+            <button
+              type="button"
+              onClick={clearWERBars}
+              className="px-1 text-xs text-text-tertiary transition-colors hover:text-text-primary"
+            >
+              Clear
+            </button>
+          </div>
+        )}
         <div className="h-96" onMouseEnter={trackChartHover}>
           <ResponsiveContainer width="100%" height="100%">
             <BarChart
@@ -99,11 +181,19 @@ const AccuracyBarSection: React.FC = () => {
                 interval={0}
               />
               <YAxis
-                width={40}
+                width={52}
                 axisLine={false}
                 tickLine={false}
                 tick={{ fill: themeColors.axisText, fontSize: 12 }}
                 tickFormatter={(value) => `${value}%`}
+                label={{
+                  value: "WER % · lower is better",
+                  angle: -90,
+                  position: "insideLeft",
+                  fill: themeColors.axisText,
+                  fontSize: 12,
+                  style: { textAnchor: "middle" },
+                }}
               />
               <Tooltip content={<CustomBarTooltip getProviderForModel={getProviderForModel} />} cursor={false} />
               <Bar
@@ -111,18 +201,27 @@ const AccuracyBarSection: React.FC = () => {
                 radius={[4, 4, 0, 0]}
                 isAnimationActive={false}
                 onClick={handleWERBarClickTracked}
-                label={{
-                  position: "top",
-                  fill: themeColors.label,
-                  fontSize: 12,
-                  formatter: (value: number) => `${value.toFixed(1)}%`,
-                }}
+                label={barLabel}
                 style={{
                   cursor: "pointer",
                 }}
               >
                 {werBarDataWithColors.map((entry) => (
-                  <Cell key={`wer-cell-${entry.model}`} fill={entry.fill} fillOpacity={entry.fillOpacity} />
+                  <Cell
+                    key={`wer-cell-${entry.model}`}
+                    fill={entry.fill}
+                    fillOpacity={entry.fillOpacity}
+                    role="button"
+                    tabIndex={0}
+                    aria-label={`${normalizeModelName(entry.model)}: ${entry.averageWER.toFixed(1)}% WER${clickedWERBars.has(entry.model) ? ", selected" : ""}`}
+                    onKeyDown={(e: React.KeyboardEvent) => {
+                      if (e.key === "Enter" || e.key === " ") {
+                        e.preventDefault();
+                        handleWERBarClickTracked(entry);
+                      }
+                    }}
+                    onMouseDown={(e: React.MouseEvent) => e.preventDefault()}
+                  />
                 ))}
               </Bar>
             </BarChart>

--- a/web/hooks/useBarInteraction.ts
+++ b/web/hooks/useBarInteraction.ts
@@ -29,8 +29,11 @@ export const useBarInteraction = () => {
     });
   }, []);
 
+  const clearWERBars = useCallback(() => setClickedWERBars(new Set()), []);
+
   return {
     clickedWERBars,
-    handleWERBarClick
+    handleWERBarClick,
+    clearWERBars
   };
 };

--- a/web/hooks/useDashboardState.tsx
+++ b/web/hooks/useDashboardState.tsx
@@ -133,7 +133,7 @@ export function useDashboardState(page: "tts" | "stt") {
   const loading = aggregatesQuery.isLoading || providersQuery.isLoading;
 
   const isMobile = useMobileDetection();
-  const { clickedWERBars, handleWERBarClick } =
+  const { clickedWERBars, handleWERBarClick, clearWERBars } =
     useBarInteraction();
 
   const deferredSelectedModels = useDeferredValue(selectedModels);
@@ -224,7 +224,7 @@ export function useDashboardState(page: "tts" | "stt") {
   const werBarData = chartData.getWERBarData();
 
   const werBarDataWithColors = useMemo(() => {
-    const hasSelection = clickedWERBars.size > 0;
+    const hasSelection = werBarData.some((item) => clickedWERBars.has(item.model));
     return werBarData.map((item) => ({
       ...item,
       fill: getModelColor(item.model),
@@ -375,6 +375,8 @@ export function useDashboardState(page: "tts" | "stt") {
     werBarDataWithColors,
 
     // Bar interaction
+    clickedWERBars,
     handleWERBarClick,
+    clearWERBars,
   };
 }


### PR DESCRIPTION
## Problem
After
<img width="951" height="567" alt="Screenshot 2026-07-08 at 2 22 50 PM" src="https://github.com/user-attachments/assets/f4e1331a-b4f2-4bed-a230-45c9edee6115" />
Before )Avg WER doesnt change).
<img width="903" height="548" alt="Screenshot 2026-07-08 at 2 23 39 PM" src="https://github.com/user-attachments/assets/fcc0ea80-4b8f-4a72-bd9f-05f3881d4817" />

Also changed half page view:

<img width="700" height="555" alt="Screenshot 2026-07-08 at 2 24 00 PM" src="https://github.com/user-attachments/assets/c7afa81b-5bc8-4cb4-bfd4-a0d4190f30a2" />

AFter: 
<img width="704" height="548" alt="Screenshot 2026-07-08 at 2 27 00 PM" src="https://github.com/user-attachments/assets/52622f14-87df-48ff-90de-cb229ed58fc9" />

<img width="705" height="506" alt="Screenshot 2026-07-08 at 2 27 09 PM" src="https://github.com/user-attachments/assets/ede3ace8-062e-4472-b75c-bd6e92dac0a8" />

The "Accuracy by Model" chart said "Click bar to compare models," but selecting bars had no visible effect — the Avg WER readout never changed, and the stat claimed "all models" even when provider filters were narrowing the chart. At half-window widths, the angled model labels and bar-top % values overlapped into unreadable text.

## Changes

**Selection is real.** Clicking a bar toggles it (keyboard too: Tab + Enter/Space). Selected bars stay at full opacity while the rest dim, and each selected model shows as a dismissable pill (color dot, name, WER, ✕) with a Clear action, matching the facet-chip styling.

**Avg WER responds.** The readout averages the selected models and labels itself `Avg WER (N selected)`. With no selection it shows `(N filtered)` when facet filters are active, or `(all models)` otherwise.

**Legibility at narrow widths.** Axis ticks now use the real per-bar slot width from Recharts: below ~40px they drop the provider line and truncate the model name (full "Provider Model" stays available via SVG title and the tooltip). Bar-top % labels hide on bars thinner than 28px unless that bar is selected, so nothing collides in split-screen views.

**Context.** Y-axis is labeled "WER % · lower is better"; bars were already sorted ascending. Distortion-condition data (background noise, etc.) intentionally stays out of this chart — it will arrive as a side selector; current data is clean-audio only.

## Testing

- `pnpm typecheck`, `pnpm lint`, `pnpm test` (53/53) all pass
- Verified in the browser: select/deselect/clear, keyboard selection, avg recompute (2.4+3.1+3.6 → 3.0%), facet-filtered label (OpenAI → "3 filtered, 2.8%"), tooltip clamped in-bounds, and label behavior at ~730px and ~1300px chart widths

🤖 Generated with [Claude Code](https://claude.com/claude-code)