### PR TITLE
Add Google Chirp STT (chirp_2, chirp_3)

### DIFF
--- a/runner/src/coval_bench/providers/stt/google.py
+++ b/runner/src/coval_bench/providers/stt/google.py
@@ -52,7 +52,7 @@ class GoogleSTTProvider(STTProvider):
     """Google Cloud Speech-to-Text v2 streaming provider.
 
     Install with:  uv sync --extra google-stt
-    Requires:      GOOGLE_APPLICATION_CREDENTIALS pointing to a service-account JSON.
+    Requires:      Application Default Credentials (the runner service account in Cloud Run).
     """
 
     _VALID_MODELS = frozenset({"default", "chirp_2", "chirp_3"})

--- a/runner/src/coval_bench/providers/stt/google.py
+++ b/runner/src/coval_bench/providers/stt/google.py
@@ -7,9 +7,8 @@ This provider is gated on the optional extra ``google-stt``:
 
     uv sync --extra google-stt
 
-Auth: GOOGLE_APPLICATION_CREDENTIALS env var (path to service-account JSON
-      mounted as a Secret-as-volume in Cloud Run).
-Models: chirp_2 (default), chirp_3.
+Auth: Application Default Credentials (the runner-rt service account in Cloud Run).
+Models: chirp_2 (default, us-central1), chirp_3 (us).
 """
 
 from __future__ import annotations
@@ -44,15 +43,9 @@ if TYPE_CHECKING:
 
 _RECOGNIZER_PATTERN = "projects/{project}/locations/{location}/recognizers/_"
 
-# chirp_3 isn't served in us-central1; it streams from global.
-_MODEL_LOCATIONS = {"chirp_3": "global"}
+# chirp_3 isn't served in us-central1; it lives in the us multi-region.
+_MODEL_LOCATIONS = {"chirp_3": "us"}
 _DEFAULT_LOCATION = "us-central1"
-
-
-def _endpoint_for_location(location: str) -> str:
-    if location == "global":
-        return "speech.googleapis.com"
-    return f"{location}-speech.googleapis.com"
 
 
 class GoogleSTTProvider(STTProvider):
@@ -82,13 +75,13 @@ class GoogleSTTProvider(STTProvider):
             raise ValueError(
                 "GoogleSTTProvider requires project_id (set Settings.google_project_id)"
             )
-        # api_key is unused for Google; auth is via GOOGLE_APPLICATION_CREDENTIALS
+        # api_key is unused for Google; auth is via ADC
         _ = api_key
         self._model = model
         self._project_id = project_id
         self._location = _MODEL_LOCATIONS.get(self._get_model_name(), _DEFAULT_LOCATION)
         self._client: Any = SpeechClient(
-            client_options=ClientOptions(api_endpoint=_endpoint_for_location(self._location))
+            client_options=ClientOptions(api_endpoint=f"{self._location}-speech.googleapis.com")
         )
 
     @property

--- a/runner/src/coval_bench/providers/stt/google.py
+++ b/runner/src/coval_bench/providers/stt/google.py
@@ -9,7 +9,7 @@ This provider is gated on the optional extra ``google-stt``:
 
 Auth: GOOGLE_APPLICATION_CREDENTIALS env var (path to service-account JSON
       mounted as a Secret-as-volume in Cloud Run).
-Models: short, long, telephony, chirp_2 (default).
+Models: chirp_2 (default), chirp_3.
 """
 
 from __future__ import annotations
@@ -42,8 +42,17 @@ if TYPE_CHECKING:
     # These type stubs may not be present; used only for static analysis.
     pass
 
-_RECOGNIZER_PATTERN = "projects/{project}/locations/us-central1/recognizers/_"
-_API_ENDPOINT = "us-central1-speech.googleapis.com"
+_RECOGNIZER_PATTERN = "projects/{project}/locations/{location}/recognizers/_"
+
+# chirp_3 isn't served in us-central1; it streams from global.
+_MODEL_LOCATIONS = {"chirp_3": "global"}
+_DEFAULT_LOCATION = "us-central1"
+
+
+def _endpoint_for_location(location: str) -> str:
+    if location == "global":
+        return "speech.googleapis.com"
+    return f"{location}-speech.googleapis.com"
 
 
 class GoogleSTTProvider(STTProvider):
@@ -53,7 +62,7 @@ class GoogleSTTProvider(STTProvider):
     Requires:      GOOGLE_APPLICATION_CREDENTIALS pointing to a service-account JSON.
     """
 
-    _VALID_MODELS = frozenset({"default", "short", "long", "telephony", "chirp_2"})
+    _VALID_MODELS = frozenset({"default", "chirp_2", "chirp_3"})
 
     def __init__(
         self,
@@ -77,7 +86,10 @@ class GoogleSTTProvider(STTProvider):
         _ = api_key
         self._model = model
         self._project_id = project_id
-        self._client: Any = SpeechClient(client_options=ClientOptions(api_endpoint=_API_ENDPOINT))
+        self._location = _MODEL_LOCATIONS.get(self._get_model_name(), _DEFAULT_LOCATION)
+        self._client: Any = SpeechClient(
+            client_options=ClientOptions(api_endpoint=_endpoint_for_location(self._location))
+        )
 
     @property
     def name(self) -> str:
@@ -94,7 +106,7 @@ class GoogleSTTProvider(STTProvider):
         return "chirp_2" if self._model == "default" else self._model
 
     def _get_recognizer_name(self) -> str:
-        return _RECOGNIZER_PATTERN.format(project=self._project_id)
+        return _RECOGNIZER_PATTERN.format(project=self._project_id, location=self._location)
 
     async def measure_ttft(
         self,

--- a/runner/src/coval_bench/registries/models.py
+++ b/runner/src/coval_bench/registries/models.py
@@ -64,7 +64,6 @@ _ACTIVE = ModelStatus.ACTIVE
 _RETIRED = ModelStatus.RETIRED
 _PENDING = ModelStatus.PENDING
 _REALTIME = ModelTag.REALTIME
-_BATCH = ModelTag.BATCH
 _MULTI = ModelTag.MULTILINGUAL
 _VAD = ModelTag.VAD
 _DIAR = ModelTag.DIARIZATION
@@ -273,30 +272,16 @@ MODEL_REGISTRY: list[RegisteredModel] = [
     RegisteredModel(
         benchmark=_STT,
         provider="google",
-        model="short",
-        tags=(_BATCH, _MULTI),
-        status=_RETIRED,
-    ),
-    RegisteredModel(
-        benchmark=_STT,
-        provider="google",
-        model="long",
-        tags=(_BATCH, _MULTI),
-        status=_RETIRED,
-    ),
-    RegisteredModel(
-        benchmark=_STT,
-        provider="google",
-        model="telephony",
-        tags=(_REALTIME, _MULTI, _VAD),
-        status=_RETIRED,
-    ),
-    RegisteredModel(
-        benchmark=_STT,
-        provider="google",
         model="chirp_2",
         tags=(_REALTIME, _MULTI, _VAD),
-        status=_RETIRED,
+        status=_ACTIVE,
+    ),
+    RegisteredModel(
+        benchmark=_STT,
+        provider="google",
+        model="chirp_3",
+        tags=(_REALTIME, _MULTI, _VAD),
+        status=_ACTIVE,
     ),
     #######
     # TTS #

--- a/runner/tests/api/test_providers.py
+++ b/runner/tests/api/test_providers.py
@@ -44,10 +44,11 @@ async def test_disabled_flag_exposed(client: AsyncClient) -> None:
     response = await client.get("/v1/providers")
     data = response.json()
 
-    # google STT models (chirp_2, long, telephony, short) are all disabled in the matrix
+    # google STT chirp models are active — must be disabled=False
     google_entry = next(e for e in data["stt"] if e["provider"] == "google")
-    chirp_2 = next(m for m in google_entry["models"] if m["model"] == "chirp_2")
-    assert chirp_2["disabled"] is True
+    for active in ("chirp_2", "chirp_3"):
+        model = next(m for m in google_entry["models"] if m["model"] == active)
+        assert model["disabled"] is False, f"{active} must be disabled=False"
 
     # deepgram nova-3 is an active model — must be disabled=False
     deepgram_entry = next(e for e in data["stt"] if e["provider"] == "deepgram")

--- a/runner/tests/providers/stt/test_google.py
+++ b/runner/tests/providers/stt/test_google.py
@@ -159,6 +159,11 @@ def test_provider_name_chirp2() -> None:
     assert p.name == "google-chirp_2"
 
 
+def test_provider_name_chirp3() -> None:
+    p = _make_provider("chirp_3")
+    assert p.name == "google-chirp_3"
+
+
 # ---------------------------------------------------------------------------
 # get_model_name mapping
 # ---------------------------------------------------------------------------
@@ -169,9 +174,26 @@ def test_get_model_name_default() -> None:
     assert p._get_model_name() == "chirp_2"
 
 
-def test_get_model_name_long() -> None:
-    p = _make_provider("long")
-    assert p._get_model_name() == "long"
+def test_get_model_name_chirp3() -> None:
+    p = _make_provider("chirp_3")
+    assert p._get_model_name() == "chirp_3"
+
+
+# ---------------------------------------------------------------------------
+# Region routing
+# ---------------------------------------------------------------------------
+
+
+def test_chirp2_uses_us_central1() -> None:
+    p = _make_provider("chirp_2")
+    assert p._location == "us-central1"
+    assert "us-central1" in p._get_recognizer_name()
+
+
+def test_chirp3_uses_global() -> None:
+    p = _make_provider("chirp_3")
+    assert p._location == "global"
+    assert "locations/global/" in p._get_recognizer_name()
 
 
 # ---------------------------------------------------------------------------

--- a/runner/tests/providers/stt/test_google.py
+++ b/runner/tests/providers/stt/test_google.py
@@ -190,10 +190,10 @@ def test_chirp2_uses_us_central1() -> None:
     assert "us-central1" in p._get_recognizer_name()
 
 
-def test_chirp3_uses_global() -> None:
+def test_chirp3_uses_us() -> None:
     p = _make_provider("chirp_3")
-    assert p._location == "global"
-    assert "locations/global/" in p._get_recognizer_name()
+    assert p._location == "us"
+    assert "locations/us/" in p._get_recognizer_name()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Brings Google Speech-to-Text back into the STT benchmark with the current Chirp models.

## Changes
- Reactivate `chirp_2` and add `chirp_3` to the registry (both ACTIVE); drop the retired short/long/telephony rows.
- `_VALID_MODELS` → `{default, chirp_2, chirp_3}`.
- Per-model region routing: `chirp_2` streams from `us-central1` (unchanged), `chirp_3` from the `global` endpoint since it is not served in `us-central1`.
- Tests updated for the active chirp rows and region routing.

## Notes
- No auth change here; credentials come from the runner environment. The infra change that points the runner at the billed prod project (via ADC) is a separate PR.
- End-to-end transcript check for both models is pending that infra apply — the models reach the API but their STT project's billing must be enabled first.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR reactivates Google Speech-to-Text in the STT benchmark by promoting `chirp_2` and adding `chirp_3` to the model registry as `ACTIVE`, and removes the now-retired `short`, `long`, and `telephony` rows. The provider implementation gains per-model region routing so that `chirp_3` targets the `us` multi-region endpoint (`us-speech.googleapis.com`) while `chirp_2` keeps the existing `us-central1` endpoint.

- `_RECOGNIZER_PATTERN` is parameterized with `{location}` and a `_MODEL_LOCATIONS` dict drives which endpoint each model uses at construction time.
- Registry entries for deprecated batch models are removed along with the now-unused `_BATCH` alias.
- Tests cover the new model name, location assignment, and recognizer-name format for both active chirp models.

<h3>Confidence Score: 5/5</h3>

Safe to merge. The changes are focused and correct: location routing is resolved before the SpeechClient is constructed, the us-speech.googleapis.com endpoint and locations/us/recognizers/_ recognizer path for chirp_3 are valid per Google's documentation, and the registry update cleanly removes the retired batch models.

The per-model region routing is implemented correctly — self._model is assigned before _get_model_name() and _MODEL_LOCATIONS lookup, so the endpoint and recognizer name are always consistent. The Google API endpoint and recognizer pattern for the us multi-region are confirmed correct by Google docs. Registry and test changes are in sync with the provider changes.

No files require special attention.

<sub>Reviews (3): Last reviewed commit: ["Fix stale ADC docstring on the STT provi..."](https://github.com/coval-ai/benchmarks/commit/e1234ebdf9cc76650b62abb4e2b86a60cbe9d799) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42851785)</sub>

<!-- /greptile_comment -->