### PR TITLE
Fix box plot x-axis labels overflowing when filters narrow the chart (BENCH-382)

### DIFF
--- a/web/components/charts/d3/BoxPlot.tsx
+++ b/web/components/charts/d3/BoxPlot.tsx
@@ -167,7 +167,10 @@ const BoxPlot: React.FC<BoxPlotProps> = ({
         const xPosition = (xScale(model) ?? 0) + xScale.bandwidth() / 2;
         const yPosition = chartHeight + 15; // Base position
 
-        const maxCharsPerLine = 8;
+        const maxCharsPerLine = Math.max(
+          8,
+          Math.floor(labelMaxWidth / (modelFontSize * 0.66))
+        );
         const modelWords = normalizedModel.split(/[-_\s]/);
         const modelLines: string[] = [];
         let currentLine = "";


### PR DESCRIPTION
## Summary
Before:
<img width="2396" height="1410" alt="image" src="https://github.com/user-attachments/assets/f3d20d63-605b-48c3-8dc9-be36555969c2" />
After:

<img width="953" height="620" alt="Screenshot 2026-07-08 at 3 00 18 PM" src="https://github.com/user-attachments/assets/b56f0480-bf8f-4913-a244-e84b88474193" />

On the Latency Variation view (TTFS/TTFT), filtering down to one or a few models caused long model names to overflow the bottom margin and collide with the "Ranked by P50 latency" caption — e.g. LAB → Mistral rendered "Voxtral Mini Transcribe Realtime 2602" as five stacked lines, with the "2602" fragment overwriting the caption.

## Root cause
`BoxPlot.tsx` wrapped x-axis labels at a hardcoded `maxCharsPerLine = 8` regardless of column width. With few models each band is very wide, so the name would fit on one line — but the fixed wrap still stacked it 5 lines deep, past the 80px bottom margin. The existing measure-and-scale guard only handles width overflow, not height.

## Fix
Derive the wrap threshold from the per-column width already computed as `labelMaxWidth`, keeping 8 chars as the floor:

```ts
const maxCharsPerLine = Math.max(8, Math.floor(labelMaxWidth / (modelFontSize * 0.66)));
```

Wide bands (filtered views) now render the name on a single line; narrow bands (full unfiltered view) hit the floor and behave exactly as before. The existing width-based scale-down still applies as a safety net.

## Verification
- LAB → Mistral on TTFS: label renders on one line, provider beneath, clear of the caption (label bottom y≈454, caption y≈477)
- Same confirmed on the TTFT tab
- Unfiltered 22-model view renders identically to main — no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a visual overflow bug in `BoxPlot.tsx` where long model names produced too many wrapped lines and overflowed the 80px bottom margin when few models were shown. The fix replaces a hardcoded `maxCharsPerLine = 8` with a dynamic value derived from the available per-column pixel width, keeping 8 as a floor so the full-model-list view is unaffected.

- `maxCharsPerLine` now grows with `labelMaxWidth` (which tracks `xScale.step()`), so wide bands in filtered views produce fewer wrapped lines rather than always forcing 8-char wraps.
- The existing rendered-text-width scale-down guard at line 220–223 is unchanged and continues to act as a safety net against actual pixel overflow.
- The `0.66` character-width approximation is reasonable (common typographic heuristic) but is undocumented inline.

<h3>Confidence Score: 5/5</h3>

Safe to merge — it's a one-line arithmetic change that only affects how a character-count threshold is computed for x-axis label wrapping.

The change is minimal and self-contained: it replaces a hardcoded constant with a formula that gracefully degrades back to the same constant via Math.max. The existing width-based scale guard is preserved, no data or state is modified, and the full-model-list path is demonstrably unchanged. The only observation is an undocumented magic number.

No files require special attention.

<sub>Reviews (1): Last reviewed commit: ["Wrap box plot x-axis labels by available..."](https://github.com/coval-ai/benchmarks/commit/2d4add7ba44bc671bc3e7b7c789595c80fd537f6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42856740)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->