### PR TITLE
Stop normal metric edge cases from flipping benchmark runs to partial

### DIFF
--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -63,10 +63,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /app
 
+# The nonroot user has no home (--no-create-home), so the dataset loader's default
+# ~/.cache is unwritable. Point XDG_CACHE_HOME at /tmp so the primary cache path
+# resolves instead of falling back with a warning on every run.
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
     PYTHONPATH=/app/src \
-    PATH="/app/.venv/bin:$PATH"
+    PATH="/app/.venv/bin:$PATH" \
+    XDG_CACHE_HOME=/tmp
 
 COPY --from=build --chown=65532:65532 /app /app
 

--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -63,9 +63,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /app
 
-# The nonroot user has no home (--no-create-home), so the dataset loader's default
-# ~/.cache is unwritable. Point XDG_CACHE_HOME at /tmp so the primary cache path
-# resolves instead of falling back with a warning on every run.
+# XDG_CACHE_HOME: nonroot has no home (--no-create-home), so the dataset cache lands in /tmp.
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
     PYTHONPATH=/app/src \

--- a/runner/src/coval_bench/metrics/ttft.py
+++ b/runner/src/coval_bench/metrics/ttft.py
@@ -40,13 +40,16 @@ def compute_ttfs(audio_to_final_seconds: float, speech_end_offset_seconds: float
         audio_to_final_seconds: Wall-clock seconds from audio send to final transcript.
         speech_end_offset_seconds: VAD end-of-speech offset for the clip.
 
-    Returns:
-        Elapsed time in seconds (float).
+    A provider whose endpointing fires before the shared anchor produces a
+    final ahead of it, which would make the raw difference negative. Such a
+    provider finalized at or before end-of-speech, so its finalization latency
+    is clamped to the metric floor of ``0.0`` rather than treated as an error.
 
-    Raises:
-        ValueError: If the result would be negative.
+    Args:
+        audio_to_final_seconds: Wall-clock seconds from audio send to final transcript.
+        speech_end_offset_seconds: VAD end-of-speech offset for the clip.
+
+    Returns:
+        Elapsed time in seconds (float), never negative.
     """
-    ttfs = audio_to_final_seconds - speech_end_offset_seconds
-    if ttfs < 0:
-        raise ValueError("ttfs must be >= 0 (speech_end_offset exceeds audio_to_final)")
-    return ttfs
+    return max(0.0, audio_to_final_seconds - speech_end_offset_seconds)

--- a/runner/src/coval_bench/metrics/ttft.py
+++ b/runner/src/coval_bench/metrics/ttft.py
@@ -40,16 +40,7 @@ def compute_ttfs(audio_to_final_seconds: float, speech_end_offset_seconds: float
         audio_to_final_seconds: Wall-clock seconds from audio send to final transcript.
         speech_end_offset_seconds: VAD end-of-speech offset for the clip.
 
-    A provider whose endpointing fires before the shared anchor produces a
-    final ahead of it, which would make the raw difference negative. Such a
-    provider finalized at or before end-of-speech, so its finalization latency
-    is clamped to the metric floor of ``0.0`` rather than treated as an error.
-
-    Args:
-        audio_to_final_seconds: Wall-clock seconds from audio send to final transcript.
-        speech_end_offset_seconds: VAD end-of-speech offset for the clip.
-
     Returns:
-        Elapsed time in seconds (float), never negative.
+        Elapsed time in seconds, clamped at 0.0 for finals ahead of the anchor.
     """
     return max(0.0, audio_to_final_seconds - speech_end_offset_seconds)

--- a/runner/src/coval_bench/runner/orchestrator.py
+++ b/runner/src/coval_bench/runner/orchestrator.py
@@ -369,9 +369,8 @@ async def _run_stt_item(
                 audio_to_final_seconds=audio_to_final,
             )
 
-        # 2b. TTFS — time-to-final from VAD end-of-speech (primary headline metric). Status
-        # tracks ttfs_value (not audio_to_final): a missing offset fails the row. An early
-        # final (ahead of the shared anchor) clamps to 0; only an unexpected calc crash surfaces.
+        # 2b. TTFS — time-to-final from VAD end-of-speech (primary headline metric). A missing
+        # offset fails the row; an early final (ahead of the anchor) clamps to 0 in compute_ttfs.
         ttfs_value: float | None = None
         ttfs_calc_error: str | None = None
         if audio_to_final is not None and isinstance(speech_end_offset_ms, (int, float)):
@@ -607,11 +606,9 @@ async def _run_tts_item(
             )
             ttfa_value = ttfa_ms
 
-            # Transport-contamination gate: a measurement taken over HTTP/1.1 or a cold socket
-            # is not comparable to the warm-pool cohort, so its value is dropped. It stays a
-            # null-valued success (excluded from aggregation, reason kept in error) rather than a
-            # failure, so an occasional cold connection does not drag the run to PARTIAL. Override
-            # only a would-be SUCCESS — a real provider error or empty result keeps its message.
+            # Transport-contamination gate: a measurement over HTTP/1.1 or a cold socket is not
+            # comparable to the warm-pool cohort, so its value is dropped to a null-valued success
+            # (excluded from aggregation, not a failure). Override only a would-be SUCCESS.
             if ttfa_status is ResultStatus.SUCCESS and tts_result is not None:
                 if tts_result.http_version is not None and tts_result.http_version != "HTTP/2":
                     ttfa_error = _truncate(

--- a/runner/src/coval_bench/runner/orchestrator.py
+++ b/runner/src/coval_bench/runner/orchestrator.py
@@ -370,8 +370,8 @@ async def _run_stt_item(
             )
 
         # 2b. TTFS — time-to-final from VAD end-of-speech (primary headline metric). Status
-        # tracks ttfs_value (not audio_to_final): a missing offset or a failed calculation
-        # fails the row instead of passing as a null-valued success, and calc errors surface.
+        # tracks ttfs_value (not audio_to_final): a missing offset fails the row. An early
+        # final (ahead of the shared anchor) clamps to 0; only an unexpected calc crash surfaces.
         ttfs_value: float | None = None
         ttfs_calc_error: str | None = None
         if audio_to_final is not None and isinstance(speech_end_offset_ms, (int, float)):
@@ -607,19 +607,19 @@ async def _run_tts_item(
             )
             ttfa_value = ttfa_ms
 
-            # Transport-contamination gate: a clean measurement taken over HTTP/1.1 or a cold
-            # socket is not comparable to the WebSocket cohort. Override only a would-be
-            # SUCCESS — a real provider error or empty result keeps its own message.
+            # Transport-contamination gate: a measurement taken over HTTP/1.1 or a cold socket
+            # is not comparable to the warm-pool cohort, so its value is dropped. It stays a
+            # null-valued success (excluded from aggregation, reason kept in error) rather than a
+            # failure, so an occasional cold connection does not drag the run to PARTIAL. Override
+            # only a would-be SUCCESS — a real provider error or empty result keeps its message.
             if ttfa_status is ResultStatus.SUCCESS and tts_result is not None:
                 if tts_result.http_version is not None and tts_result.http_version != "HTTP/2":
-                    ttfa_status = ResultStatus.FAILED
                     ttfa_error = _truncate(
                         f"TTFA measured over {tts_result.http_version}; not comparable "
                         "(no HTTP/2 multiplexing, TTFA reabsorbs TCP+TLS)"
                     )
                     ttfa_value = None
                 elif tts_result.connection_reused is False:
-                    ttfa_status = ResultStatus.FAILED
                     ttfa_error = _truncate(
                         "TTFA measured over a cold connection; not comparable "
                         "(TTFA reabsorbs TCP+TLS)"

--- a/runner/tests/unit/test_orchestrator.py
+++ b/runner/tests/unit/test_orchestrator.py
@@ -825,8 +825,9 @@ async def test_audio_file_cleanup(settings: Settings) -> None:
 
 
 @pytest.mark.asyncio
-async def test_tts_http1_downgrade_fails_ttfa_row(settings: Settings) -> None:
-    """An HTTP/1.1 TTFA row is marked FAILED; WER stays SUCCESS; run is PARTIAL."""
+async def test_tts_http1_downgrade_nulls_ttfa_row(settings: Settings) -> None:
+    """An HTTP/1.1 TTFA row is a null-valued success (excluded, not a failure); WER stays
+    SUCCESS; run stays SUCCEEDED rather than being dragged to PARTIAL."""
     with tempfile.TemporaryDirectory() as tmpdir:
         audio_path = Path(tmpdir) / "synth.wav"
         audio_path.write_bytes(b"\x00" * 512)
@@ -913,7 +914,7 @@ async def test_tts_http1_downgrade_fails_ttfa_row(settings: Settings) -> None:
         wer_rows = [r for r in recorded if r.metric_type == "WER"]
 
         assert len(ttfa_rows) == 1
-        assert ttfa_rows[0].status == ResultStatus.FAILED
+        assert ttfa_rows[0].status == ResultStatus.SUCCESS
         assert ttfa_rows[0].metric_value is None
         assert "HTTP/1.1" in ttfa_rows[0].error
         assert ttfa_rows[0].http_version == "HTTP/1.1"
@@ -921,12 +922,13 @@ async def test_tts_http1_downgrade_fails_ttfa_row(settings: Settings) -> None:
         assert len(wer_rows) == 1
         assert wer_rows[0].status == ResultStatus.SUCCESS
 
-        assert writer.finish_run.call_args.kwargs["status"] == RunStatus.PARTIAL
+        assert writer.finish_run.call_args.kwargs["status"] == RunStatus.SUCCEEDED
 
 
 @pytest.mark.asyncio
-async def test_tts_cold_connection_fails_ttfa_row(settings: Settings) -> None:
-    """A warm-h2 row that opened a cold connection is failed, not averaged in."""
+async def test_tts_cold_connection_nulls_ttfa_row(settings: Settings) -> None:
+    """A warm-h2 row that opened a cold connection is a null-valued success: kept out of
+    the average (null metric_value) but not a failure that drags the run to PARTIAL."""
     with tempfile.TemporaryDirectory() as tmpdir:
         audio_path = Path(tmpdir) / "synth.wav"
         audio_path.write_bytes(b"\x00" * 512)
@@ -1014,7 +1016,7 @@ async def test_tts_cold_connection_fails_ttfa_row(settings: Settings) -> None:
         wer_rows = [r for r in recorded if r.metric_type == "WER"]
 
         assert len(ttfa_rows) == 1
-        assert ttfa_rows[0].status == ResultStatus.FAILED
+        assert ttfa_rows[0].status == ResultStatus.SUCCESS
         assert ttfa_rows[0].metric_value is None
         assert "cold connection" in ttfa_rows[0].error
         assert ttfa_rows[0].http_version == "HTTP/2"
@@ -1022,7 +1024,7 @@ async def test_tts_cold_connection_fails_ttfa_row(settings: Settings) -> None:
         assert len(wer_rows) == 1
         assert wer_rows[0].status == ResultStatus.SUCCESS
 
-        assert writer.finish_run.call_args.kwargs["status"] == RunStatus.PARTIAL
+        assert writer.finish_run.call_args.kwargs["status"] == RunStatus.SUCCEEDED
 
 
 # ---------------------------------------------------------------------------
@@ -1602,6 +1604,34 @@ async def test_stt_ttfs_status_tracks_value(audio_file: Path, settings: Settings
 
 
 @pytest.mark.asyncio
+async def test_stt_ttfs_early_final_clamps_to_zero(audio_file: Path, settings: Settings) -> None:
+    """A provider that finalizes before the end-of-speech anchor yields a 0.0-valued TTFS
+    success, not a failure that would drag the run to PARTIAL."""
+    early_item = _make_dataset_item(audio_file)
+    early_item.speech_end_offset_ms = 2000.0  # exceeds audio_to_final (0.85 s) → early final
+    provider_inst = MagicMock()
+    provider_inst.measure_ttft = AsyncMock(return_value=_good_transcription())
+    run = _make_run()
+    writer = _make_stub_writer(run)
+    async with _orchestrator_env(
+        audio_path=audio_file,
+        stt_items=[early_item],
+        stt_providers={"deepgram": MagicMock(return_value=provider_inst)},
+        run=run,
+        writer=writer,
+    ) as _:
+        await run_benchmarks(
+            settings=settings,
+            benchmark_kind="stt",
+            smoke=True,
+            matrix_overrides=_only_stt_matrix("deepgram", "nova-2"),
+        )
+    ttfs = {r.metric_type: r for r in _recorded_rows(writer)}["TTFS"]
+    assert ttfs.status == ResultStatus.SUCCESS
+    assert ttfs.metric_value == pytest.approx(0.0)
+
+
+@pytest.mark.asyncio
 async def test_tts_empty_ttfa_marked_failed(audio_file: Path, settings: Settings) -> None:
     """TTS synth returns (no raise) with no ttfa/audio → TTFA FAILED, no WER row, run FAILED."""
     hume_entry = _registry_entry(Benchmark.TTS, "hume")
@@ -2052,8 +2082,8 @@ async def test_stt_ttfs_crash_not_double_logged(audio_file: Path, settings: Sett
 
 
 @pytest.mark.asyncio
-async def test_tts_transport_gate_logs_item_failure(settings: Settings) -> None:
-    """An HTTP/1.1 contamination failure is surfaced in the per-item summary."""
+async def test_tts_transport_gate_nulls_without_failing(settings: Settings) -> None:
+    """An HTTP/1.1 contaminated TTFA is a null-valued success, not a logged item failure."""
     with tempfile.TemporaryDirectory() as tmpdir:
         audio_path = Path(tmpdir) / "synth.wav"
         audio_path.write_bytes(b"\x00" * 512)
@@ -2102,11 +2132,12 @@ async def test_tts_transport_gate_logs_item_failure(settings: Settings) -> None:
                     matrix_overrides=matrix,
                 )
 
-    failures = _events(captured, "tts_item_failed")
-    assert len(failures) == 1
-    event = failures[0]
-    assert event["item"] == "tts-0001"
-    assert "HTTP/1.1" in event["reasons"]["TTFA"]
+    assert _events(captured, "tts_item_failed") == []
+
+    ttfa = {r.metric_type: r for r in _recorded_rows(writer)}["TTFA"]
+    assert ttfa.status == ResultStatus.SUCCESS
+    assert ttfa.metric_value is None
+    assert "HTTP/1.1" in (ttfa.error or "")
 
 
 # ---------------------------------------------------------------------------

--- a/runner/tests/unit/test_orchestrator.py
+++ b/runner/tests/unit/test_orchestrator.py
@@ -826,8 +826,7 @@ async def test_audio_file_cleanup(settings: Settings) -> None:
 
 @pytest.mark.asyncio
 async def test_tts_http1_downgrade_nulls_ttfa_row(settings: Settings) -> None:
-    """An HTTP/1.1 TTFA row is a null-valued success (excluded, not a failure); WER stays
-    SUCCESS; run stays SUCCEEDED rather than being dragged to PARTIAL."""
+    """HTTP/1.1 TTFA is a null-valued success; WER stays SUCCESS; run stays SUCCEEDED."""
     with tempfile.TemporaryDirectory() as tmpdir:
         audio_path = Path(tmpdir) / "synth.wav"
         audio_path.write_bytes(b"\x00" * 512)
@@ -927,8 +926,7 @@ async def test_tts_http1_downgrade_nulls_ttfa_row(settings: Settings) -> None:
 
 @pytest.mark.asyncio
 async def test_tts_cold_connection_nulls_ttfa_row(settings: Settings) -> None:
-    """A warm-h2 row that opened a cold connection is a null-valued success: kept out of
-    the average (null metric_value) but not a failure that drags the run to PARTIAL."""
+    """A cold-connection TTFA is a null-valued success, not a PARTIAL-forcing failure."""
     with tempfile.TemporaryDirectory() as tmpdir:
         audio_path = Path(tmpdir) / "synth.wav"
         audio_path.write_bytes(b"\x00" * 512)
@@ -1605,10 +1603,9 @@ async def test_stt_ttfs_status_tracks_value(audio_file: Path, settings: Settings
 
 @pytest.mark.asyncio
 async def test_stt_ttfs_early_final_clamps_to_zero(audio_file: Path, settings: Settings) -> None:
-    """A provider that finalizes before the end-of-speech anchor yields a 0.0-valued TTFS
-    success, not a failure that would drag the run to PARTIAL."""
+    """A final ahead of the end-of-speech anchor yields a 0.0-valued TTFS success, not a failure."""
     early_item = _make_dataset_item(audio_file)
-    early_item.speech_end_offset_ms = 2000.0  # exceeds audio_to_final (0.85 s) → early final
+    early_item.speech_end_offset_ms = 2000.0  # exceeds audio_to_final (0.85 s)
     provider_inst = MagicMock()
     provider_inst.measure_ttft = AsyncMock(return_value=_good_transcription())
     run = _make_run()

--- a/runner/tests/unit/test_ttft.py
+++ b/runner/tests/unit/test_ttft.py
@@ -60,9 +60,10 @@ def test_ttfs_zero() -> None:
     assert compute_ttfs(5.0, 5.0) == pytest.approx(0.0)
 
 
-def test_ttfs_raises_on_negative() -> None:
-    with pytest.raises(ValueError, match="ttfs must be >= 0"):
-        compute_ttfs(4.9, 5.0)
+def test_ttfs_clamps_early_final_to_zero() -> None:
+    """A final ahead of the end-of-speech anchor clamps to the 0.0 floor, not an error."""
+    assert compute_ttfs(4.9, 5.0) == pytest.approx(0.0)
+    assert compute_ttfs(3.0, 5.0) == pytest.approx(0.0)
 
 
 def test_ttfs_returns_float() -> None:


### PR DESCRIPTION
Clamp early-final TTFS to 0, record non-comparable (cold/non-HTTP2) TTFA as a null-valued success, and give the runner a writable cache dir so runs stop going partial or warning on benign edges.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR addresses three distinct edge cases that were incorrectly flipping benchmark runs to `PARTIAL`: an early STT final clamping to 0 instead of raising, contaminated TTFA rows being marked `FAILED` instead of null-valued `SUCCESS`, and the cache directory being unwritable for the nonroot container user.

- **TTFS clamping** (`ttft.py`): `compute_ttfs` now returns `max(0.0, ...)` rather than raising `ValueError` when the final arrives ahead of the speech-end anchor; the `0.0` propagates as a valid `SUCCESS` row instead of a caught exception that nulls the value and can chain to a `PARTIAL` run.
- **TTFA contamination gate** (`orchestrator.py`): HTTP/1.1 and cold-socket TTFA measurements no longer flip `ttfa_status` to `FAILED`; they remain `SUCCESS` with `metric_value=None` (excluded from aggregation) so a WER-only success still finishes the run as `SUCCEEDED`.
- **Docker cache dir** (`Dockerfile`): `XDG_CACHE_HOME=/tmp` routes dataset cache writes to `/tmp`, which is always writable by the nonroot uid `65532`.

<h3>Confidence Score: 5/5</h3>

Safe to merge. All three changes are well-scoped, well-tested, and address genuine false-positive failures rather than altering measurement semantics.

The TTFS clamp, TTFA null-valued-success conversion, and cache-dir fix are each minimal and independently correct. The `_metric_outcome` identity check (`is None`) handles 0.0 correctly, the transport-contamination gate correctly preserves `ttfa_status=SUCCESS` while nulling the value, and the run-level aggregation (`status == FAILED` counts) is unaffected. Tests cover all three paths including the new early-final case.

No files require special attention.

<sub>Reviews (3): Last reviewed commit: ["Trim verbose comments and docstrings fro..."](https://github.com/coval-ai/benchmarks/commit/695a599f2b7a175f3bdc472df527b61d4263c699) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42863703)</sub>

<!-- /greptile_comment -->