### PR TITLE
Install the google-stt extra in the runner image

### DIFF
--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -30,8 +30,8 @@ ENV UV_COMPILE_BYTECODE=1 \
 # at metadata-validation time when uv builds the editable wheel for this package.
 COPY pyproject.toml uv.lock README.md ./
 
-# Install production dependencies (no dev, no extras) into /app/.venv
-RUN uv sync --frozen --no-dev
+# Install production dependencies (no dev) into /app/.venv
+RUN uv sync --frozen --no-dev --extra google-stt
 
 # Copy source tree + alembic config (db/cli.py reads /app/alembic.ini)
 COPY src/ ./src/


### PR DESCRIPTION
The runner Docker image ran `uv sync --frozen --no-dev`, which skips optional extras — so `google-cloud-speech` was never installed. In prod every chirp task failed at construction with `ImportError: google-cloud-speech is not installed` (seen in the benchmarks-runner logs after the STT provider shipped).

Adds `--extra google-stt` to the runner image build. Confirmed the frozen sync resolves against the existing `uv.lock` (google-cloud-speech is already locked). The API image is untouched — it doesn't instantiate STT providers.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `--extra google-stt` to the runner image's `uv sync` command so that `google-cloud-speech` (declared as an optional dependency under `[project.optional-dependencies]`) is installed in the production venv. Previously, the extra was skipped at build time, causing every Chirp STT task to fail at construction with an `ImportError`.

- The `google-stt` extra is already defined in `pyproject.toml` and locked in `uv.lock`; no lock-file changes are needed.
- The API Dockerfile is unchanged, which is correct since the API image does not instantiate STT providers.

<h3>Confidence Score: 5/5</h3>

Single-line Dockerfile change that adds a declared, already-locked optional dependency to the runner image build. No logic changes, no new packages introduced outside the lock file.

The change is a one-line fix to a well-understood build command. The extra is already defined and locked, so the only behavioral delta is that google-cloud-speech will now be present in the runner venv — exactly what is needed to resolve the production ImportError.

No files require special attention.

<sub>Reviews (1): Last reviewed commit: ["Install the google-stt extra in the runn..."](https://github.com/coval-ai/benchmarks/commit/a55bab91915c429b22aa4ca1edfeb856058c4f6d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42874851)</sub>

<!-- /greptile_comment -->