### PR TITLE
Add Download Image (PNG) and Download Data (CSV) buttons to benchmark charts (BENCH-384)

### DIFF
--- a/web/components/charts/tooltips/TimelineTooltip.tsx
+++ b/web/components/charts/tooltips/TimelineTooltip.tsx
@@ -35,13 +35,21 @@ const CustomTimelineTooltip: React.FC<TimelineTooltipProps> = ({ active, payload
     !highlightRange ||
     (value >= highlightRange[0] && value <= highlightRange[1]);
 
+  // Ranks come from the overall speed order; in-view models then float above
+  // the dimmed ones so the visible series always read first.
+  const ranked = validData.map((item, index) => ({
+    ...item,
+    rank: index + 1,
+    inView: inRange(item.value),
+  }));
+
   // Compact hover shows one row: the fastest model that's actually in view,
   // so a Y-zoom past the global leader still surfaces a visible model.
   const rows = compact
-    ? [validData.find((item) => inRange(item.value)) ?? validData[0]].filter(
-        (item): item is (typeof validData)[number] => item != null
+    ? [ranked.find((item) => item.inView) ?? ranked[0]].filter(
+        (item): item is (typeof ranked)[number] => item != null
       )
-    : validData;
+    : [...ranked].sort((a, b) => Number(b.inView) - Number(a.inView));
 
   return (
     <div
@@ -69,11 +77,10 @@ const CustomTimelineTooltip: React.FC<TimelineTooltipProps> = ({ active, payload
             : { fontSize: "11px", maxHeight: "300px", overflowY: "scroll", paddingRight: "8px" }
         }
       >
-        {rows.map((item, index) => {
+        {rows.map((item) => {
           // Extract model name from dataKey (remove '_value' suffix)
           const modelName = item.dataKey.replace(/_value$/, "");
           const provider = getProviderForModel(modelName);
-          const inView = inRange(item.value);
 
           return (
             <div
@@ -83,7 +90,7 @@ const CustomTimelineTooltip: React.FC<TimelineTooltipProps> = ({ active, payload
                 display: "flex",
                 alignItems: "center",
                 justifyContent: "space-between",
-                opacity: inView ? 1 : 0.35
+                opacity: item.inView ? 1 : 0.35
               }}
             >
               <div style={{ display: "flex", alignItems: "center", flex: 1 }}>
@@ -100,11 +107,11 @@ const CustomTimelineTooltip: React.FC<TimelineTooltipProps> = ({ active, payload
                 <div style={{ flex: 1 }}>
                   <div
                     style={{
-                      color: index === 0 ? "#10B981" : "var(--color-text-on-tooltip)",
-                      fontWeight: index === 0 ? "bold" : "normal"
+                      color: item.rank === 1 ? "#10B981" : "var(--color-text-on-tooltip)",
+                      fontWeight: item.rank === 1 ? "bold" : "normal"
                     }}
                   >
-                    #{index + 1} {normalizeModelName(modelName)}
+                    #{item.rank} {normalizeModelName(modelName)}
                   </div>
                   <div
                     style={{
@@ -121,7 +128,7 @@ const CustomTimelineTooltip: React.FC<TimelineTooltipProps> = ({ active, payload
                 style={{
                   color: "var(--color-text-on-tooltip-secondary)",
                   marginLeft: "12px",
-                  fontWeight: index === 0 ? "bold" : "normal",
+                  fontWeight: item.rank === 1 ? "bold" : "normal",
                   flexShrink: 0
                 }}
               >

--- a/web/components/charts/tooltips/TimelineTooltip.tsx
+++ b/web/components/charts/tooltips/TimelineTooltip.tsx
@@ -15,13 +15,18 @@ interface TimelineTooltipProps {
   label?: string | number;
   getProviderForModel: (model: string) => string;
   showDate?: boolean;
-  /** Visible Y range when zoomed; models outside it (clipped off-chart) dim. */
-  highlightRange?: [number, number];
+  /**
+   * dataKeys whose line is fully clipped out of the current zoom crop. A model
+   * counts as "in view" if any part of its curve is visible in the crop — not
+   * just its value at the hovered timestamp — so the tooltip surfaces the
+   * series the viewer can actually see, matching the legend.
+   */
+  dimmedKeys?: Set<string>;
   /** Hover mode: only the fastest model plus a pin hint, so the chart stays visible. */
   compact?: boolean;
 }
 
-const CustomTimelineTooltip: React.FC<TimelineTooltipProps> = ({ active, payload, label, getProviderForModel, showDate, highlightRange, compact }) => {
+const CustomTimelineTooltip: React.FC<TimelineTooltipProps> = ({ active, payload, label, getProviderForModel, showDate, dimmedKeys, compact }) => {
   if (!active || !payload || payload.length === 0) return null;
 
   // Filter out null/undefined values and sort by value (fastest to slowest)
@@ -31,20 +36,16 @@ const CustomTimelineTooltip: React.FC<TimelineTooltipProps> = ({ active, payload
 
   if (validData.length === 0) return null;
 
-  const inRange = (value: number) =>
-    !highlightRange ||
-    (value >= highlightRange[0] && value <= highlightRange[1]);
-
   // Ranks come from the overall speed order; in-view models then float above
   // the dimmed ones so the visible series always read first.
   const ranked = validData.map((item, index) => ({
     ...item,
     rank: index + 1,
-    inView: inRange(item.value),
+    inView: !dimmedKeys?.has(item.dataKey),
   }));
 
-  // Compact hover shows one row: the fastest model that's actually in view,
-  // so a Y-zoom past the global leader still surfaces a visible model.
+  // Compact hover shows one row: the fastest model whose line is in the crop,
+  // so a zoom past the global leader still surfaces a visible series.
   const rows = compact
     ? [ranked.find((item) => item.inView) ?? ranked[0]].filter(
         (item): item is (typeof ranked)[number] => item != null

--- a/web/components/charts/tooltips/TimelineTooltip.tsx
+++ b/web/components/charts/tooltips/TimelineTooltip.tsx
@@ -51,6 +51,10 @@ const CustomTimelineTooltip: React.FC<TimelineTooltipProps> = ({ active, payload
       )
     : [...ranked].sort((a, b) => Number(b.inView) - Number(a.inView));
 
+  // Emphasize the first row shown — the fastest in-view model — rather than the
+  // global #1, which a Y-zoom can push into the dimmed group at the bottom.
+  const leaderKey = rows[0]?.dataKey;
+
   return (
     <div
       style={{
@@ -81,6 +85,7 @@ const CustomTimelineTooltip: React.FC<TimelineTooltipProps> = ({ active, payload
           // Extract model name from dataKey (remove '_value' suffix)
           const modelName = item.dataKey.replace(/_value$/, "");
           const provider = getProviderForModel(modelName);
+          const isLeader = item.dataKey === leaderKey;
 
           return (
             <div
@@ -107,8 +112,8 @@ const CustomTimelineTooltip: React.FC<TimelineTooltipProps> = ({ active, payload
                 <div style={{ flex: 1 }}>
                   <div
                     style={{
-                      color: item.rank === 1 ? "#10B981" : "var(--color-text-on-tooltip)",
-                      fontWeight: item.rank === 1 ? "bold" : "normal"
+                      color: isLeader ? "#10B981" : "var(--color-text-on-tooltip)",
+                      fontWeight: isLeader ? "bold" : "normal"
                     }}
                   >
                     #{item.rank} {normalizeModelName(modelName)}
@@ -128,7 +133,7 @@ const CustomTimelineTooltip: React.FC<TimelineTooltipProps> = ({ active, payload
                 style={{
                   color: "var(--color-text-on-tooltip-secondary)",
                   marginLeft: "12px",
-                  fontWeight: item.rank === 1 ? "bold" : "normal",
+                  fontWeight: isLeader ? "bold" : "normal",
                   flexShrink: 0
                 }}
               >

--- a/web/components/dashboard/AccuracyBarSection.tsx
+++ b/web/components/dashboard/AccuracyBarSection.tsx
@@ -106,6 +106,14 @@ const AccuracyBarSection: React.FC = () => {
           label="Accuracy by Model"
           description={description}
           hint="Click bar to compare models"
+          exportXLabel="Model"
+          exportRows={() =>
+            werBarDataWithColors.map(({ model, averageWER }) => ({
+              model,
+              provider: getProviderForModel(model),
+              avg_wer_percent: averageWER,
+            }))
+          }
           stat={{
             label:
               selectedBars.length > 0

--- a/web/components/dashboard/BoxPlotSection.tsx
+++ b/web/components/dashboard/BoxPlotSection.tsx
@@ -39,6 +39,20 @@ const BoxPlotSection: React.FC = () => {
         <SectionHeader
           label="Latency Variation"
           description={description}
+          exportRows={() =>
+            boxPlotData.data.map(({ model, provider, quartiles, stats }) => ({
+              model,
+              provider,
+              metric: activeMetric,
+              whisker_low_ms: quartiles.min,
+              q1_ms: quartiles.q1,
+              median_ms: quartiles.median,
+              q3_ms: quartiles.q3,
+              whisker_high_ms: quartiles.max,
+              mean_ms: stats.mean,
+              runs: stats.count,
+            }))
+          }
           stat={{
             label: (
               <MetricInfo metric={activeMetric} align="right">{`Average ${latencyLabel}`}</MetricInfo>

--- a/web/components/dashboard/BoxPlotSection.tsx
+++ b/web/components/dashboard/BoxPlotSection.tsx
@@ -40,9 +40,9 @@ const BoxPlotSection: React.FC = () => {
           label="Latency Variation"
           description={description}
           exportRows={() =>
-            boxPlotData.data.map(({ model, provider, quartiles, stats }) => ({
+            boxPlotData.data.map(({ model, quartiles, stats }) => ({
               model,
-              provider,
+              provider: getProviderForModel(model),
               metric: activeMetric,
               whisker_low_ms: quartiles.min,
               q1_ms: quartiles.q1,

--- a/web/components/dashboard/HeatmapSection.tsx
+++ b/web/components/dashboard/HeatmapSection.tsx
@@ -3,8 +3,11 @@
 
 "use client";
 
-import React from "react";
-import ModelComparisonTable from "@/components/dashboard/ModelComparisonTable";
+import React, { useState } from "react";
+import ModelComparisonTable, {
+  DEFAULT_PERCENTILE_IDX,
+  PERCENTILES,
+} from "@/components/dashboard/ModelComparisonTable";
 import Card from "@/components/shared/Card";
 import SectionHeader from "@/components/shared/SectionHeader";
 import MetricToggle from "@/components/dashboard/MetricToggle";
@@ -12,8 +15,14 @@ import { useDashboard } from "@/contexts/DashboardContext";
 import { useChartHoverTracking } from "@/hooks/useChartHoverTracking";
 
 const HeatmapSection: React.FC = () => {
-  const { heatmapDisplayData: data, getProviderForModel } = useDashboard();
+  const {
+    heatmapDisplayData: data,
+    getProviderForModel,
+    activeMetric,
+  } = useDashboard();
   const trackChartHover = useChartHoverTracking("heatmap");
+  const [percentileIdx, setPercentileIdx] = useState(DEFAULT_PERCENTILE_IDX);
+  const percentile = (PERCENTILES[percentileIdx] ?? PERCENTILES[DEFAULT_PERCENTILE_IDX])!.key;
 
   return (
     <div className="mb-4">
@@ -26,11 +35,28 @@ const HeatmapSection: React.FC = () => {
               "Latency percentiles come straight from the measured runs — drag the slider to move from the fastest run (p0) through the median to the slowest (p100). Click a column to sort.",
           }}
           expandable={false}
+          exportRows={() =>
+            data.map(({ model, latency, avgWER, werStdDev, sampleCount }) => ({
+              model,
+              provider: getProviderForModel(model),
+              metric: activeMetric,
+              [`latency_${percentile}_ms`]: latency[percentile],
+              avg_wer_percent: avgWER,
+              wer_std_dev: werStdDev,
+              runs: sampleCount,
+            }))
+          }
+          exportImage={false}
         />
 
         <MetricToggle />
 
-        <ModelComparisonTable data={data} getProviderForModel={getProviderForModel} />
+        <ModelComparisonTable
+          data={data}
+          getProviderForModel={getProviderForModel}
+          percentileIdx={percentileIdx}
+          onPercentileChange={setPercentileIdx}
+        />
       </Card>
     </div>
   );

--- a/web/components/dashboard/LatencyAccuracySection.tsx
+++ b/web/components/dashboard/LatencyAccuracySection.tsx
@@ -15,6 +15,8 @@ import {
 } from "recharts";
 import type { ScatterDataPoint } from "@/types/benchmark.types";
 import { getModelColor } from "@/lib/utils/colors";
+import { normalizeModelName } from "@/lib/utils/formatters";
+import { labelScatterDots } from "@/lib/utils/chartExport";
 import CustomScatterTooltip from "@/components/charts/tooltips/ScatterTooltip";
 import Card from "@/components/shared/Card";
 import SectionHeader from "@/components/shared/SectionHeader";
@@ -92,6 +94,39 @@ const LatencyAccuracySection: React.FC = () => {
         <SectionHeader
           label="Latency vs Accuracy"
           description={description}
+          exportXLabel={`Average ${latencyLabel}`}
+          exportAnnotate={(clone) => {
+            const nameCounts = new Map<string, number>();
+            for (const { model } of scatterData) {
+              const name = normalizeModelName(model);
+              nameCounts.set(name, (nameCounts.get(name) ?? 0) + 1);
+            }
+            labelScatterDots(
+              clone,
+              scatterData.map(({ model, provider, x, y }) => {
+                const name = normalizeModelName(model);
+                return {
+                  x,
+                  y,
+                  color: getModelColor(model),
+                  label:
+                    (nameCounts.get(name) ?? 0) > 1
+                      ? `${name} (${provider})`
+                      : name,
+                };
+              })
+            );
+          }}
+          exportRows={() =>
+            scatterData.map(({ model, provider, benchmark, x, y, count }) => ({
+              model,
+              provider,
+              benchmark,
+              [`avg_${metric}_ms`]: x,
+              avg_wer_percent: y,
+              runs: count,
+            }))
+          }
           stat={{
             label: (
               <MetricInfo metric={metric} align="right">{`Avg ${latencyLabel}`}</MetricInfo>

--- a/web/components/dashboard/ModelComparisonTable.tsx
+++ b/web/components/dashboard/ModelComparisonTable.tsx
@@ -13,11 +13,13 @@ import { POSTHOG_EVENTS } from "@/lib/posthog/events";
 interface ModelComparisonTableProps {
   data: ModelHeatmapData[];
   getProviderForModel: (model: string) => string;
+  percentileIdx: number;
+  onPercentileChange: (idx: number) => void;
 }
 
 type ColumnKey = "latency" | "avgWER" | "sampleCount";
 
-const PERCENTILES: { key: LatencyPercentile; hint?: string }[] = [
+export const PERCENTILES: { key: LatencyPercentile; hint?: string }[] = [
   { key: "p0", hint: "fastest run" },
   { key: "p25" },
   { key: "p50", hint: "median" },
@@ -29,7 +31,7 @@ const PERCENTILES: { key: LatencyPercentile; hint?: string }[] = [
 ];
 
 // p95: the tail latency real-time voice users actually feel.
-const DEFAULT_PERCENTILE_IDX = 5;
+export const DEFAULT_PERCENTILE_IDX = 5;
 
 const COLUMNS: {
   key: ColumnKey;
@@ -43,10 +45,11 @@ const COLUMNS: {
 
 const ModelComparisonTable: React.FC<ModelComparisonTableProps> = ({
   data,
-  getProviderForModel
+  getProviderForModel,
+  percentileIdx,
+  onPercentileChange
 }) => {
   const activeTab = useActiveTab();
-  const [percentileIdx, setPercentileIdx] = useState(DEFAULT_PERCENTILE_IDX);
   const [sort, setSort] = useState<{ key: ColumnKey; direction: "asc" | "desc" }>(
     { key: "latency", direction: "asc" }
   );
@@ -153,7 +156,7 @@ const ModelComparisonTable: React.FC<ModelComparisonTableProps> = ({
           max={PERCENTILES.length - 1}
           step={1}
           value={percentileIdx}
-          onChange={(e) => setPercentileIdx(Number(e.target.value))}
+          onChange={(e) => onPercentileChange(Number(e.target.value))}
           className="w-44 accent-accent-teal"
           aria-valuetext={percentile.key}
         />

--- a/web/components/shared/SectionHeader.tsx
+++ b/web/components/shared/SectionHeader.tsx
@@ -4,9 +4,13 @@
 "use client";
 
 import React, { useEffect, useState } from "react";
-import { Check, Link2 } from "lucide-react";
+import { Check, ImageDown, Link2, Table } from "lucide-react";
+import { downloadCSV, downloadChartPNG } from "@/lib/utils/chartExport";
 import { capturePostHogEvent } from "@/lib/posthog/client";
 import { POSTHOG_EVENTS } from "@/lib/posthog/events";
+
+const iconButtonClass =
+  "flex h-7 w-7 items-center justify-center rounded-lg border border-border-secondary bg-white text-text-secondary transition-colors hover:bg-surface-toggle-inactive hover:text-text-primary";
 
 interface SectionHeaderProps {
   label: string;
@@ -22,6 +26,14 @@ interface SectionHeaderProps {
   hint?: string;
   /** When false, the detailed text shows inline instead of behind a toggle. */
   expandable?: boolean;
+  /** Rows for the Download Data (CSV) button; must reflect the active filters. */
+  exportRows?: () => Record<string, unknown>[];
+  /** Set false for sections without a chart SVG to hide Download Image. */
+  exportImage?: boolean;
+  /** X-axis title drawn under the exported PNG when the SVG lacks one. */
+  exportXLabel?: string;
+  /** Mutates the exported SVG clone, e.g. to label scatter dots by name. */
+  exportAnnotate?: (clone: SVGSVGElement) => void;
 }
 
 const SectionHeader: React.FC<SectionHeaderProps> = ({
@@ -30,6 +42,10 @@ const SectionHeader: React.FC<SectionHeaderProps> = ({
   stat,
   hint,
   expandable = true,
+  exportRows,
+  exportImage = true,
+  exportXLabel,
+  exportAnnotate,
 }) => {
   const [showDetails, setShowDetails] = useState(false);
   const [copied, setCopied] = useState(false);
@@ -61,6 +77,13 @@ const SectionHeader: React.FC<SectionHeaderProps> = ({
     };
   }, [anchorId]);
 
+  const trackShare = (format: "link" | "png" | "csv") =>
+    capturePostHogEvent(POSTHOG_EVENTS.dashboardChartShared, {
+      chart: anchorId,
+      path: window.location.pathname,
+      format,
+    });
+
   const copyLink = () => {
     navigator.clipboard.writeText(
       `${window.location.origin}${window.location.pathname}#${anchorId}`
@@ -68,10 +91,53 @@ const SectionHeader: React.FC<SectionHeaderProps> = ({
     window.history.replaceState(null, "", `#${anchorId}`);
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);
-    capturePostHogEvent(POSTHOG_EVENTS.dashboardChartShared, {
-      chart: anchorId,
-      path: window.location.pathname,
-    });
+    trackShare("link");
+  };
+
+  const downloadImage = () => {
+    const root = document.getElementById(anchorId);
+    const card = root?.parentElement;
+    const svg =
+      card &&
+      Array.from(card.querySelectorAll("svg")).sort(
+        (a, b) => b.clientWidth * b.clientHeight - a.clientWidth * a.clientHeight
+      )[0];
+    // The stat label can be a ReactNode (MetricInfo), so its text comes from
+    // the DOM — minus the hidden tooltip MetricInfo keeps mounted.
+    const statLabel = root?.querySelector("[data-stat-label]")?.cloneNode(true);
+    if (statLabel instanceof HTMLElement) {
+      statLabel
+        .querySelectorAll('[role="tooltip"]')
+        .forEach((el) => el.remove());
+    }
+    if (card && svg)
+      downloadChartPNG(svg, `${anchorId}.png`, {
+        label,
+        title: description.short,
+        xLabel: exportXLabel,
+        stat: stat && {
+          label:
+            statLabel instanceof HTMLElement
+              ? (statLabel.textContent?.trim() ?? "")
+              : "",
+          value: stat.value,
+        },
+        annotate: exportAnnotate,
+        legend: Array.from(
+          card.querySelectorAll(".recharts-legend-wrapper li")
+        ).map((li) => ({
+          label: li.textContent?.trim() ?? "",
+          color:
+            li.querySelector("span")?.style.backgroundColor ?? "#0a0a0a",
+          dimmed: li.hasAttribute("data-dimmed"),
+        })),
+      });
+    trackShare("png");
+  };
+
+  const downloadData = () => {
+    downloadCSV(exportRows?.() ?? [], `${anchorId}.csv`);
+    trackShare("csv");
   };
 
   return (
@@ -84,10 +150,32 @@ const SectionHeader: React.FC<SectionHeaderProps> = ({
             onClick={copyLink}
             aria-label="Copy link to this chart"
             title="Copy link"
-            className="flex h-7 w-7 items-center justify-center rounded-lg border border-border-secondary bg-white text-text-secondary transition-colors hover:bg-surface-toggle-inactive hover:text-text-primary"
+            className={iconButtonClass}
           >
             {copied ? <Check size={14} /> : <Link2 size={14} />}
           </button>
+          {exportRows && exportImage && (
+            <button
+              type="button"
+              onClick={downloadImage}
+              aria-label="Download chart as image"
+              title="Download image"
+              className={iconButtonClass}
+            >
+              <ImageDown size={14} />
+            </button>
+          )}
+          {exportRows && (
+            <button
+              type="button"
+              onClick={downloadData}
+              aria-label="Download chart data"
+              title="Download data"
+              className={iconButtonClass}
+            >
+              <Table size={14} />
+            </button>
+          )}
         </h2>
         <p className="text-2xl font-medium text-text-primary mb-1">
           {description.short}
@@ -119,7 +207,10 @@ const SectionHeader: React.FC<SectionHeaderProps> = ({
       </div>
       {stat && (
         <div className="text-right min-w-0">
-          <div className="text-[0.9rem] font-light text-text-secondary mb-2">
+          <div
+            data-stat-label
+            className="text-[0.9rem] font-light text-text-secondary mb-2"
+          >
             {stat.label}
           </div>
           <div className="font-mono text-3xl sm:text-[2.4rem] font-bold break-words">{stat.value}</div>

--- a/web/components/shared/SectionHeader.tsx
+++ b/web/components/shared/SectionHeader.tsx
@@ -94,14 +94,20 @@ const SectionHeader: React.FC<SectionHeaderProps> = ({
     trackShare("link");
   };
 
-  const downloadImage = () => {
+  const downloadImage = async () => {
     const root = document.getElementById(anchorId);
     const card = root?.parentElement;
+    // The chart is the largest SVG in the card; icon SVGs and a chart still
+    // sizing to zero during layout are excluded so we never export those.
     const svg =
       card &&
-      Array.from(card.querySelectorAll("svg")).sort(
-        (a, b) => b.clientWidth * b.clientHeight - a.clientWidth * a.clientHeight
-      )[0];
+      Array.from(card.querySelectorAll("svg"))
+        .filter((el) => el.clientWidth > 100 && el.clientHeight > 100)
+        .sort(
+          (a, b) =>
+            b.clientWidth * b.clientHeight - a.clientWidth * a.clientHeight
+        )[0];
+    if (!svg) return;
     // The stat label can be a ReactNode (MetricInfo), so its text comes from
     // the DOM — minus the hidden tooltip MetricInfo keeps mounted.
     const statLabel = root?.querySelector("[data-stat-label]")?.cloneNode(true);
@@ -110,33 +116,33 @@ const SectionHeader: React.FC<SectionHeaderProps> = ({
         .querySelectorAll('[role="tooltip"]')
         .forEach((el) => el.remove());
     }
-    if (card && svg)
-      downloadChartPNG(svg, `${anchorId}.png`, {
-        label,
-        title: description.short,
-        xLabel: exportXLabel,
-        stat: stat && {
-          label:
-            statLabel instanceof HTMLElement
-              ? (statLabel.textContent?.trim() ?? "")
-              : "",
-          value: stat.value,
-        },
-        annotate: exportAnnotate,
-        legend: Array.from(
-          card.querySelectorAll(".recharts-legend-wrapper li")
-        ).map((li) => ({
-          label: li.textContent?.trim() ?? "",
-          color:
-            li.querySelector("span")?.style.backgroundColor ?? "#0a0a0a",
-          dimmed: li.hasAttribute("data-dimmed"),
-        })),
-      });
-    trackShare("png");
+    const ok = await downloadChartPNG(svg, `${anchorId}.png`, {
+      label,
+      title: description.short,
+      xLabel: exportXLabel,
+      stat: stat && {
+        label:
+          statLabel instanceof HTMLElement
+            ? (statLabel.textContent?.trim() ?? "")
+            : "",
+        value: stat.value,
+      },
+      annotate: exportAnnotate,
+      legend: Array.from(
+        card.querySelectorAll(".recharts-legend-wrapper li")
+      ).map((li) => ({
+        label: li.textContent?.trim() ?? "",
+        color: li.querySelector("span")?.style.backgroundColor ?? "#0a0a0a",
+        dimmed: li.hasAttribute("data-dimmed"),
+      })),
+    }).catch(() => false);
+    if (ok) trackShare("png");
   };
 
   const downloadData = () => {
-    downloadCSV(exportRows?.() ?? [], `${anchorId}.csv`);
+    const rows = exportRows?.() ?? [];
+    if (rows.length === 0) return;
+    downloadCSV(rows, `${anchorId}.csv`);
     trackShare("csv");
   };
 
@@ -157,7 +163,7 @@ const SectionHeader: React.FC<SectionHeaderProps> = ({
           {exportRows && exportImage && (
             <button
               type="button"
-              onClick={downloadImage}
+              onClick={() => void downloadImage()}
               aria-label="Download chart as image"
               title="Download image"
               className={iconButtonClass}

--- a/web/components/visualizations/TimelineChart.tsx
+++ b/web/components/visualizations/TimelineChart.tsx
@@ -127,6 +127,44 @@ interface PinnedTooltip {
 
 const Y_MAX_PRESETS = [500, 1000, 1500, 2000, 3000, 5000];
 
+// Liang–Barsky: does the segment (x0,y0)->(x1,y1) touch the axis-aligned
+// rectangle [xMin,xMax]x[yMin,yMax]? Used to tell whether any part of a series
+// line falls inside the zoom crop, so the legend dims only fully-clipped ones.
+function segmentIntersectsRect(
+  x0: number,
+  y0: number,
+  x1: number,
+  y1: number,
+  xMin: number,
+  yMin: number,
+  xMax: number,
+  yMax: number
+): boolean {
+  let t0 = 0;
+  let t1 = 1;
+  const dx = x1 - x0;
+  const dy = y1 - y0;
+  const clip = (p: number, q: number): boolean => {
+    if (p === 0) return q >= 0; // parallel to this edge; inside iff q >= 0
+    const r = q / p;
+    if (p < 0) {
+      if (r > t1) return false;
+      if (r > t0) t0 = r;
+    } else {
+      if (r < t0) return false;
+      if (r < t1) t1 = r;
+    }
+    return true;
+  };
+  return (
+    clip(-dx, x0 - xMin) &&
+    clip(dx, xMax - x0) &&
+    clip(-dy, y0 - yMin) &&
+    clip(dy, yMax - y0) &&
+    t0 <= t1
+  );
+}
+
 const TimelineChart: React.FC = () => {
   const activeTab = useActiveTab();
   const {
@@ -221,46 +259,44 @@ const TimelineChart: React.FC = () => {
   const zoomX = zoom?.x;
   const zoomY = zoom?.y;
 
-  // A series dims when the current crop clips it fully off-chart — mirroring
-  // the tooltip's highlight behavior. A line is visible not only when a point
-  // lands inside the Y range but also when a segment between two consecutive
-  // points crosses it (e.g. a spike whose peak sits above the crop).
+  // A series dims only when the crop clips it fully off-chart. Recharts clips
+  // the polyline to the X and Y domain together, so a series is visible if any
+  // segment between consecutive points passes through the crop rectangle —
+  // even when both endpoints sit outside it (e.g. a spike crossing the top, or
+  // a line entering only at the left/right edge). Test each segment against the
+  // rectangle with Liang–Barsky rather than checking points in isolation.
   const dimmedLegendKeys = useMemo(() => {
     const dimmed = new Set<string>();
     if (!zoomY) return dimmed;
+    const [xLo, xHi] = zoomX ?? [windowStart, windowEnd];
+    const [yLo, yHi] = zoomY;
     for (const model of modelsWithData) {
-      let prev: number | null = null;
+      const key = `${model}_value`;
+      let prevT: number | null = null;
+      let prevV = 0;
       let visible = false;
       for (const point of windowedTimelineData) {
-        if (
-          zoomX &&
-          (point.timestamp < zoomX[0] || point.timestamp > zoomX[1])
-        ) {
-          prev = null;
-          continue;
-        }
-        const value = (point as Record<string, number | undefined>)[
-          `${model}_value`
-        ];
+        const value = (point as Record<string, number | undefined>)[key];
         if (typeof value !== "number" || Number.isNaN(value)) {
-          prev = null;
+          prevT = null;
           continue;
         }
+        const t = point.timestamp;
         if (
-          prev === null
-            ? value >= zoomY[0] && value <= zoomY[1]
-            : Math.min(prev, value) <= zoomY[1] &&
-              Math.max(prev, value) >= zoomY[0]
+          prevT === null
+            ? t >= xLo && t <= xHi && value >= yLo && value <= yHi
+            : segmentIntersectsRect(prevT, prevV, t, value, xLo, yLo, xHi, yHi)
         ) {
           visible = true;
           break;
         }
-        prev = value;
+        prevT = t;
+        prevV = value;
       }
-      if (!visible) dimmed.add(`${model}_value`);
+      if (!visible) dimmed.add(key);
     }
     return dimmed;
-  }, [zoomY, zoomX, windowedTimelineData, modelsWithData]);
+  }, [zoomY, zoomX, windowStart, windowEnd, windowedTimelineData, modelsWithData]);
   const xDomain = zoomX ?? currentTimeWindow;
   const zoomTicks = useMemo(
     () =>
@@ -608,7 +644,7 @@ const TimelineChart: React.FC = () => {
                   <CustomTimelineTooltip
                     getProviderForModel={getProviderForModel}
                     showDate={dateScale}
-                    highlightRange={zoom?.y}
+                    dimmedKeys={dimmedLegendKeys}
                     compact
                   />
                 }
@@ -699,7 +735,7 @@ const TimelineChart: React.FC = () => {
                 label={pinned.label}
                 getProviderForModel={getProviderForModel}
                 showDate={dateScale}
-                highlightRange={zoom?.y}
+                dimmedKeys={dimmedLegendKeys}
               />
             </div>
           )}

--- a/web/components/visualizations/TimelineChart.tsx
+++ b/web/components/visualizations/TimelineChart.tsx
@@ -42,21 +42,34 @@ interface LegendEntry {
 // Custom legend: names are rendered in black (recharts colors them per-series
 // by default), and items fill top-to-bottom within each column so the list
 // reads alphabetically down each column rather than across rows.
-const TimelineLegend: React.FC<{ payload?: LegendEntry[] }> = ({ payload }) => (
+const TimelineLegend: React.FC<{
+  payload?: LegendEntry[];
+  dimmedKeys?: Set<string>;
+}> = ({ payload, dimmedKeys }) => (
   <ul className="columns-2 gap-x-4 px-2 pt-5 sm:columns-3 sm:gap-x-6 lg:columns-4">
-    {payload?.map((entry) => (
-      <li
-        key={entry.dataKey ?? entry.value}
-        className="mb-1.5 flex items-start gap-1.5 text-xs leading-tight text-text-primary break-inside-avoid"
-      >
-        <span
-          className="mt-0.5 inline-block w-3 h-3 shrink-0 rounded-[2px]"
-          style={{ backgroundColor: entry.color }}
-          aria-hidden="true"
-        />
-        <span>{entry.value}</span>
-      </li>
-    ))}
+    {[...(payload ?? [])]
+      .sort(
+        (a, b) =>
+          Number(dimmedKeys?.has(a.dataKey ?? "") ?? 0) -
+          Number(dimmedKeys?.has(b.dataKey ?? "") ?? 0)
+      )
+      .map((entry) => {
+        const dimmed = dimmedKeys?.has(entry.dataKey ?? "");
+        return (
+          <li
+            key={entry.dataKey ?? entry.value}
+            data-dimmed={dimmed || undefined}
+            className={`mb-1.5 flex items-start gap-1.5 text-xs leading-tight text-text-primary break-inside-avoid${dimmed ? " opacity-35" : ""}`}
+          >
+            <span
+              className="mt-0.5 inline-block w-3 h-3 shrink-0 rounded-[2px]"
+              style={{ backgroundColor: entry.color }}
+              aria-hidden="true"
+            />
+            <span>{entry.value}</span>
+          </li>
+        );
+      })}
   </ul>
 );
 
@@ -206,6 +219,48 @@ const TimelineChart: React.FC = () => {
   );
   const tzAbbr = getLocalTimeZoneAbbr();
   const zoomX = zoom?.x;
+  const zoomY = zoom?.y;
+
+  // A series dims when the current crop clips it fully off-chart — mirroring
+  // the tooltip's highlight behavior. A line is visible not only when a point
+  // lands inside the Y range but also when a segment between two consecutive
+  // points crosses it (e.g. a spike whose peak sits above the crop).
+  const dimmedLegendKeys = useMemo(() => {
+    const dimmed = new Set<string>();
+    if (!zoomY) return dimmed;
+    for (const model of modelsWithData) {
+      let prev: number | null = null;
+      let visible = false;
+      for (const point of windowedTimelineData) {
+        if (
+          zoomX &&
+          (point.timestamp < zoomX[0] || point.timestamp > zoomX[1])
+        ) {
+          prev = null;
+          continue;
+        }
+        const value = (point as Record<string, number | undefined>)[
+          `${model}_value`
+        ];
+        if (typeof value !== "number" || Number.isNaN(value)) {
+          prev = null;
+          continue;
+        }
+        if (
+          prev === null
+            ? value >= zoomY[0] && value <= zoomY[1]
+            : Math.min(prev, value) <= zoomY[1] &&
+              Math.max(prev, value) >= zoomY[0]
+        ) {
+          visible = true;
+          break;
+        }
+        prev = value;
+      }
+      if (!visible) dimmed.add(`${model}_value`);
+    }
+    return dimmed;
+  }, [zoomY, zoomX, windowedTimelineData, modelsWithData]);
   const xDomain = zoomX ?? currentTimeWindow;
   const zoomTicks = useMemo(
     () =>
@@ -314,6 +369,17 @@ const TimelineChart: React.FC = () => {
               : "Performance Consistency"
           }
           description={description}
+          exportRows={() =>
+            windowedTimelineData.map((point) => ({
+              time: point.timestampLabel,
+              ...Object.fromEntries(
+                modelsWithData.map((model) => [
+                  `${model}_${metric}_ms`,
+                  point[`${model}_value`],
+                ])
+              ),
+            }))
+          }
           stat={{
             label: (
               <MetricInfo metric={metric} align="right">{`Average ${metricLabel}`}</MetricInfo>
@@ -550,7 +616,9 @@ const TimelineChart: React.FC = () => {
                 cursor={!dragging && !hoveredMarker}
               />
               {modelsWithData.length > 1 && (
-                <Legend content={<TimelineLegend />} />
+                <Legend
+                  content={<TimelineLegend dimmedKeys={dimmedLegendKeys} />}
+                />
               )}
               {modelsWithData.map((model) => (
                 <Line

--- a/web/lib/utils/chartExport.ts
+++ b/web/lib/utils/chartExport.ts
@@ -3,12 +3,12 @@
 
 const triggerDownload = (href: string, filename: string) => {
   const a = document.createElement("a");
+const triggerDownload = (href: string, filename: string) => {
+  const a = document.createElement("a");
   a.href = href;
   a.download = filename;
   a.click();
-  // Browsers may read the blob URL after the click returns; revoking in the
-  // same tick can abort the download.
-  window.setTimeout(() => URL.revokeObjectURL(href), 1000);
+  window.setTimeout(() => URL.revokeObjectURL(href), 0);
 };
 
 const loadImage = (src: string) =>

--- a/web/lib/utils/chartExport.ts
+++ b/web/lib/utils/chartExport.ts
@@ -3,11 +3,11 @@
 
 const triggerDownload = (href: string, filename: string) => {
   const a = document.createElement("a");
-const triggerDownload = (href: string, filename: string) => {
-  const a = document.createElement("a");
   a.href = href;
   a.download = filename;
   a.click();
+  // Browsers may read the blob URL after click() returns; revoking in the same
+  // tick can abort the download, so defer it.
   window.setTimeout(() => URL.revokeObjectURL(href), 0);
 };
 

--- a/web/lib/utils/chartExport.ts
+++ b/web/lib/utils/chartExport.ts
@@ -6,7 +6,9 @@ const triggerDownload = (href: string, filename: string) => {
   a.href = href;
   a.download = filename;
   a.click();
-  URL.revokeObjectURL(href);
+  // Browsers may read the blob URL after the click returns; revoking in the
+  // same tick can abort the download.
+  window.setTimeout(() => URL.revokeObjectURL(href), 1000);
 };
 
 const loadImage = (src: string) =>
@@ -188,13 +190,16 @@ export function labelScatterDots(
     text.textContent = point.label;
     clone.appendChild(text);
   });
+  // Record how far down the labels reached so the export crop keeps them.
+  const bottom = boxes.reduce((max, b) => Math.max(max, b.y2), 0);
+  clone.setAttribute("data-annotation-bottom", `${bottom}`);
 }
 
 export async function downloadChartPNG(
   svg: SVGSVGElement,
   filename: string,
   header: ChartPNGHeader = {}
-) {
+): Promise<boolean> {
   const svgRect = svg.getBoundingClientRect();
   const { width, height } = svgRect;
   // The rendered SVG often reserves empty space below its content (e.g. room
@@ -206,23 +211,37 @@ export async function downloadChartPNG(
   svg.querySelectorAll("text").forEach((text) => {
     textBottom = Math.max(textBottom, text.getBoundingClientRect().bottom);
   });
-  const contentHeight =
-    textBottom > svgRect.top
-      ? Math.min(height, Math.max(1, textBottom - svgRect.top + 6))
-      : height;
   const clone = svg.cloneNode(true) as SVGSVGElement;
   clone.setAttribute("width", `${width}`);
   clone.setAttribute("height", `${height}`);
   header.annotate?.(clone);
-  const chart = await loadImage(
-    `data:image/svg+xml;charset=utf-8,${encodeURIComponent(new XMLSerializer().serializeToString(clone))}`
+  // Annotations may land below the chart's own text (labelScatterDots records
+  // how far down it drew); they must survive the crop too.
+  const annotationBottom =
+    Number(clone.getAttribute("data-annotation-bottom") ?? 0) + 4;
+  const contentHeight = Math.min(
+    height,
+    Math.max(
+      1,
+      textBottom > svgRect.top ? textBottom - svgRect.top + 6 : height,
+      annotationBottom
+    )
   );
-  const logo = await loadImage("/coval-logo.svg");
+  let chart: HTMLImageElement;
+  let logo: HTMLImageElement;
+  try {
+    chart = await loadImage(
+      `data:image/svg+xml;charset=utf-8,${encodeURIComponent(new XMLSerializer().serializeToString(clone))}`
+    );
+    logo = await loadImage("/coval-logo.svg");
+  } catch {
+    return false;
+  }
   const logoWidth = 72;
   const logoHeight = (logo.height / logo.width) * logoWidth;
   const canvas = document.createElement("canvas");
   const measure = canvas.getContext("2d");
-  if (!measure) return;
+  if (!measure) return false;
   const rows = legendRows(measure, header.legend ?? [], width);
   const titleBlock = Math.max(
     (header.label ? 20 : 0) + (header.title ? 30 : 0),
@@ -239,7 +258,7 @@ export async function downloadChartPNG(
   canvas.width = totalWidth * 2;
   canvas.height = totalHeight * 2;
   const ctx = canvas.getContext("2d");
-  if (!ctx) return;
+  if (!ctx) return false;
   ctx.scale(2, 2);
   ctx.fillStyle = "#ffffff";
   ctx.fillRect(0, 0, totalWidth, totalHeight);
@@ -312,4 +331,5 @@ export async function downloadChartPNG(
   canvas.toBlob((blob) => {
     if (blob) triggerDownload(URL.createObjectURL(blob), filename);
   });
+  return true;
 }

--- a/web/lib/utils/chartExport.ts
+++ b/web/lib/utils/chartExport.ts
@@ -1,0 +1,315 @@
+// Copyright 2026 The Coval Benchmarks Authors
+// SPDX-License-Identifier: Apache-2.0
+
+const triggerDownload = (href: string, filename: string) => {
+  const a = document.createElement("a");
+  a.href = href;
+  a.download = filename;
+  a.click();
+  URL.revokeObjectURL(href);
+};
+
+const loadImage = (src: string) =>
+  new Promise<HTMLImageElement>((resolve, reject) => {
+    const img = new Image();
+    img.onload = () => resolve(img);
+    img.onerror = reject;
+    img.src = src;
+  });
+
+export function downloadCSV(
+  rows: Record<string, unknown>[],
+  filename: string
+) {
+  const [first] = rows;
+  if (!first) return;
+  const headers = Object.keys(first);
+  const escape = (value: unknown) => {
+    const s = String(value ?? "");
+    return /[",\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
+  };
+  const csv = [
+    headers.join(","),
+    ...rows.map((row) => headers.map((h) => escape(row[h])).join(",")),
+  ].join("\n");
+  triggerDownload(
+    URL.createObjectURL(new Blob([csv], { type: "text/csv" })),
+    filename
+  );
+}
+
+export interface LegendItem {
+  label: string;
+  color: string;
+  /** Grayed out in the export, e.g. a series clipped off-chart by the zoom. */
+  dimmed?: boolean;
+}
+
+export interface ChartPNGHeader {
+  label?: string;
+  title?: string;
+  legend?: LegendItem[];
+  /** Centered x-axis title drawn under the chart, for SVGs without one. */
+  xLabel?: string;
+  /** Headline stat drawn top-right, e.g. "Avg WER (all models)" / "3.6%". */
+  stat?: { label: string; value: string };
+  /** Mutates the cloned SVG before rasterizing, e.g. to label scatter dots. */
+  annotate?: (clone: SVGSVGElement) => void;
+}
+
+const FONT = "ui-sans-serif, system-ui, sans-serif";
+/** Outer margin between the canvas edge and every piece of content. */
+const MARGIN = 24;
+const LEGEND_ROW_HEIGHT = 20;
+
+// Lay the legend out in wrapped rows of "swatch + label" items sized with
+// canvas text metrics, so the header height is known before the canvas is
+// created (resizing a canvas would wipe its state).
+function legendRows(
+  ctx: CanvasRenderingContext2D,
+  legend: LegendItem[],
+  maxWidth: number
+) {
+  ctx.font = `12px ${FONT}`;
+  const rows: (LegendItem & { x: number })[][] = [];
+  let row: (LegendItem & { x: number })[] = [];
+  let x = 0;
+  for (const entry of legend) {
+    const itemWidth = 18 + ctx.measureText(entry.label).width + 18;
+    if (row.length > 0 && x + itemWidth > maxWidth) {
+      rows.push(row);
+      row = [];
+      x = 0;
+    }
+    row.push({ ...entry, x });
+    x += itemWidth;
+  }
+  if (row.length > 0) rows.push(row);
+  return rows;
+}
+
+const SVG_NS = "http://www.w3.org/2000/svg";
+
+// Label text takes its dot's color so stacked labels stay attributable, but
+// light series colors get darkened to keep the text readable on white.
+const labelColor = (hex?: string) => {
+  if (!hex || !/^#[0-9a-f]{6}$/i.test(hex)) return "#3d3d3d";
+  const n = parseInt(hex.slice(1), 16);
+  let [r, g, b] = [n >> 16, (n >> 8) & 255, n & 255];
+  if ((0.299 * r + 0.587 * g + 0.114 * b) / 255 > 0.6) {
+    [r, g, b] = [r, g, b].map((c) => Math.round(c * 0.65)) as [
+      number,
+      number,
+      number,
+    ];
+  }
+  return `#${((r << 16) | (g << 8) | b).toString(16).padStart(6, "0")}`;
+};
+
+/**
+ * Names each scatter dot in the export clone. Dots pair with data points by
+ * identical (x, then y) ordering — cy is inverted in pixels. Labels avoid the
+ * dots and each other; one squeezed out of a cluster drops below it with a
+ * leader line back to its dot.
+ */
+export function labelScatterDots(
+  clone: SVGSVGElement,
+  points: { x: number; y: number; label: string; color?: string }[]
+) {
+  const pos = (el: Element, attr: string) => Number(el.getAttribute(attr));
+  const circles = Array.from(clone.querySelectorAll('circle[r="6"]')).sort(
+    (a, b) => pos(a, "cx") - pos(b, "cx") || pos(a, "cy") - pos(b, "cy")
+  );
+  const sorted = [...points].sort((a, b) => a.x - b.x || b.y - a.y);
+  const width = Number(clone.getAttribute("width"));
+  const height = Number(clone.getAttribute("height"));
+  type Box = { x1: number; y1: number; x2: number; y2: number };
+  const boxes: Box[] = circles.map((c) => ({
+    x1: pos(c, "cx") - 8,
+    y1: pos(c, "cy") - 8,
+    x2: pos(c, "cx") + 8,
+    y2: pos(c, "cy") + 8,
+  }));
+  const blocked = (box: Box) =>
+    box.x1 < 2 ||
+    box.x2 > width - 2 ||
+    box.y1 < 2 ||
+    box.y2 > height - 14 ||
+    boxes.some(
+      (b) => box.x1 < b.x2 && box.x2 > b.x1 && box.y1 < b.y2 && box.y2 > b.y1
+    );
+  circles.forEach((circle, index) => {
+    const point = sorted[index];
+    if (!point) return;
+    const cx = pos(circle, "cx");
+    const cy = pos(circle, "cy");
+    const w = point.label.length * 6;
+    const box = (x: number, y: number, anchor: string): Box => {
+      const x1 = anchor === "start" ? x : anchor === "end" ? x - w : x - w / 2;
+      return { x1, y1: y - 11, x2: x1 + w, y2: y + 3 };
+    };
+    const candidates: [number, number, string][] = [
+      [cx + 10, cy + 4, "start"],
+      [cx - 10, cy + 4, "end"],
+      [cx, cy - 11, "middle"],
+      [cx, cy + 18, "middle"],
+      [cx + 10, cy - 7, "start"],
+      [cx + 10, cy + 15, "start"],
+      [cx - 10, cy - 7, "end"],
+      [cx - 10, cy + 15, "end"],
+    ];
+    let placement = candidates.find(([x, y, a]) => !blocked(box(x, y, a)));
+    if (!placement) {
+      for (let step = 2; step < 10 && !placement; step++) {
+        const y = cy + 5 + step * 13;
+        if (!blocked(box(cx, y, "middle"))) placement = [cx, y, "middle"];
+      }
+      if (placement) {
+        const leader = document.createElementNS(SVG_NS, "line");
+        leader.setAttribute("x1", `${cx}`);
+        leader.setAttribute("y1", `${cy + 7}`);
+        leader.setAttribute("x2", `${cx}`);
+        leader.setAttribute("y2", `${placement[1] - 9}`);
+        leader.setAttribute("stroke", "#c8c6c2");
+        leader.setAttribute("stroke-width", "1");
+        clone.appendChild(leader);
+      }
+    }
+    const [x, y, anchor] = placement ?? candidates[0]!;
+    boxes.push(box(x, y, anchor));
+    const text = document.createElementNS(SVG_NS, "text");
+    text.setAttribute("x", `${x}`);
+    text.setAttribute("y", `${y}`);
+    if (anchor !== "start") text.setAttribute("text-anchor", anchor);
+    text.setAttribute("font-size", "11");
+    text.setAttribute("font-family", FONT);
+    text.setAttribute("font-weight", "500");
+    text.setAttribute("fill", labelColor(point.color));
+    text.textContent = point.label;
+    clone.appendChild(text);
+  });
+}
+
+export async function downloadChartPNG(
+  svg: SVGSVGElement,
+  filename: string,
+  header: ChartPNGHeader = {}
+) {
+  const svgRect = svg.getBoundingClientRect();
+  const { width, height } = svgRect;
+  // The rendered SVG often reserves empty space below its content (e.g. room
+  // recharts keeps for its HTML legend); crop it so the image ends where the
+  // chart does. The bound comes from text elements (axis ticks/titles are the
+  // lowest visible content) — getBBox would count series paths that a zoom
+  // clips out of view and extend far past the plot.
+  let textBottom = 0;
+  svg.querySelectorAll("text").forEach((text) => {
+    textBottom = Math.max(textBottom, text.getBoundingClientRect().bottom);
+  });
+  const contentHeight =
+    textBottom > svgRect.top
+      ? Math.min(height, Math.max(1, textBottom - svgRect.top + 6))
+      : height;
+  const clone = svg.cloneNode(true) as SVGSVGElement;
+  clone.setAttribute("width", `${width}`);
+  clone.setAttribute("height", `${height}`);
+  header.annotate?.(clone);
+  const chart = await loadImage(
+    `data:image/svg+xml;charset=utf-8,${encodeURIComponent(new XMLSerializer().serializeToString(clone))}`
+  );
+  const logo = await loadImage("/coval-logo.svg");
+  const logoWidth = 72;
+  const logoHeight = (logo.height / logo.width) * logoWidth;
+  const canvas = document.createElement("canvas");
+  const measure = canvas.getContext("2d");
+  if (!measure) return;
+  const rows = legendRows(measure, header.legend ?? [], width);
+  const titleBlock = Math.max(
+    (header.label ? 20 : 0) + (header.title ? 30 : 0),
+    header.stat ? 50 : 0
+  );
+  const headerBlock =
+    titleBlock +
+    rows.length * LEGEND_ROW_HEIGHT +
+    (titleBlock > 0 || rows.length > 0 ? 12 : 0);
+  // The bottom strip carries the optional x-axis title and the watermark.
+  const bottomBlock = Math.max(header.xLabel ? 24 : 0, logoHeight + 10);
+  const totalWidth = width + 2 * MARGIN;
+  const totalHeight = MARGIN + headerBlock + contentHeight + bottomBlock + MARGIN / 2;
+  canvas.width = totalWidth * 2;
+  canvas.height = totalHeight * 2;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) return;
+  ctx.scale(2, 2);
+  ctx.fillStyle = "#ffffff";
+  ctx.fillRect(0, 0, totalWidth, totalHeight);
+  ctx.strokeStyle = "#dddbd4";
+  ctx.lineWidth = 1;
+  ctx.strokeRect(0.5, 0.5, totalWidth - 1, totalHeight - 1);
+  let y = MARGIN;
+  if (header.stat) {
+    ctx.textAlign = "right";
+    ctx.font = `13px ${FONT}`;
+    ctx.fillStyle = "#515151";
+    ctx.fillText(header.stat.label, totalWidth - MARGIN, y + 13);
+    ctx.font = `700 24px ui-monospace, SFMono-Regular, Menlo, monospace`;
+    ctx.fillStyle = "#0a0a0a";
+    ctx.fillText(header.stat.value, totalWidth - MARGIN, y + 44);
+    ctx.textAlign = "left";
+  }
+  if (header.label) {
+    ctx.font = `13px ${FONT}`;
+    ctx.fillStyle = "#515151";
+    ctx.fillText(header.label, MARGIN, y + 13);
+    y += 20;
+  }
+  if (header.title) {
+    ctx.font = `600 20px ${FONT}`;
+    ctx.fillStyle = "#0a0a0a";
+    ctx.fillText(header.title, MARGIN, y + 20);
+    y += 30;
+  }
+  y = MARGIN + titleBlock;
+  ctx.font = `12px ${FONT}`;
+  for (const row of rows) {
+    for (const item of row) {
+      ctx.globalAlpha = item.dimmed ? 0.35 : 1;
+      ctx.fillStyle = item.color;
+      ctx.fillRect(MARGIN + item.x, y + 5, 12, 12);
+      ctx.fillStyle = "#0a0a0a";
+      ctx.fillText(item.label, MARGIN + item.x + 18, y + 15);
+    }
+    y += LEGEND_ROW_HEIGHT;
+  }
+  ctx.globalAlpha = 1;
+  const chartY = MARGIN + headerBlock;
+  ctx.drawImage(
+    chart,
+    0,
+    0,
+    width,
+    contentHeight,
+    MARGIN,
+    chartY,
+    width,
+    contentHeight
+  );
+  if (header.xLabel) {
+    ctx.font = `12px ${FONT}`;
+    ctx.fillStyle = "#515151";
+    ctx.textAlign = "center";
+    ctx.fillText(header.xLabel, totalWidth / 2, chartY + contentHeight + 16);
+    ctx.textAlign = "left";
+  }
+  ctx.globalAlpha = 0.45;
+  ctx.drawImage(
+    logo,
+    totalWidth - MARGIN - logoWidth,
+    totalHeight - logoHeight - 8,
+    logoWidth,
+    logoHeight
+  );
+  canvas.toBlob((blob) => {
+    if (blob) triggerDownload(URL.createObjectURL(blob), filename);
+  });
+}


### PR DESCRIPTION
## Summary
<img width="731" height="544" alt="Screenshot 2026-07-08 at 4 55 11 PM" src="https://github.com/user-attachments/assets/86a98160-9e48-4cc3-85de-24bd5c9eef57" />
Add PNG and CSV buttons.
Example:

<img width="1565" height="751" alt="latency-vs-accuracy (13)" src="https://github.com/user-attachments/assets/3eb65b76-ab1e-4974-8dfc-44b084879701" />



Adds two export actions next to the existing **Copy Link** icon on every benchmark chart section, matching its button styling and `title` tooltip pattern ("Download image", "Download data"). Wired on: Timeline, Latency Variation (box plot), Accuracy by Model (WER bar), Latency vs Accuracy (scatter), and Model Comparison (CSV only — it's a table, no chart SVG).

### Download Image (PNG)

Mirrors exactly what's on screen, rendered at 2x with the Coval logo watermark bottom-right (~45% opacity):

- Header with section label, title, and the headline stat (e.g. "Avg WER (3 filtered) · 2.8%")
- Legend included; when the chart is drag-zoomed, series cropped fully off-chart dim in the legend and in-view series sort to the top — same behavior as the pinned tooltip (visibility counts segment *crossings*, so a spike passing through the crop stays lit)
- Bar-selection fading is preserved so excluded bars read as excluded
- Scatter chart gets per-dot name labels instead of a legend: collision-aware placement around each dot, dot-colored text (light colors darkened), leader lines if a cluster squeezes a label out; provider is appended only for ambiguous names ("Default (gradium)")
- Charts whose SVG lacks an x-axis title get one drawn in ("Model", "Average TTFS/TTFA")
- Hairline border, symmetric margins, trailing SVG whitespace cropped (measured from rendered text, robust under zoom)

### Download Data (CSV)

Always the **full data** for the current time window and facet filters — never reduced by a drag-zoom crop (crops are for screenshots, not data). Follows real data selectors:

- Model Comparison: exports the latency column for the **selected percentile slider** value and the active TTFS/TTFT metric (slider state lifted from `ModelComparisonTable` to `HeatmapSection`)
- Consistent proper-case provider names across all files for easy joins
- Box plot columns renamed to be honest about what they are (`whisker_low_ms`…`whisker_high_ms` are 1.5×IQR-clamped); dropped the raw-runs `std` that could exceed the trimmed min→max range

### Misc

- Timeline tooltip: in-view models now sort above dimmed ones while keeping their speed ranks
- `dashboard_chart_shared` PostHog event gains a `format: link | png | csv` property

## Test plan

- `pnpm typecheck`, `pnpm lint`, `pnpm test` (53/53) pass
- Manually exercised in the browser: PNG + CSV on all five sections, facet-filtered CSV matches on-screen models, D3 box plot rasterizes correctly, zoomed-timeline PNG dims/sorts legend correctly, scatter label placement simulated against real export data (18 models, zero overlaps)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds chart export actions to the benchmark dashboard. The main changes are:

- PNG and CSV buttons in chart section headers.
- Export helpers for CSV generation and chart PNG rendering.
- Timeline legend and tooltip dimming based on zoomed chart visibility.
- CSV exports for timeline, bar, box plot, scatter, and model comparison views.
- Lifted model-comparison percentile state so exported data matches the selected slider value.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<sub>Reviews (4): Last reviewed commit: ["Fix build break and zoom-crop visibility..."](https://github.com/coval-ai/benchmarks/commit/501ae7b4d4638e35eb422844c09d6543e6ec51e1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42880838)</sub>

<!-- /greptile_comment -->