### PR TITLE
Color sidebar provider chips to match chart colors

### DIFF
--- a/web/components/layout/FacetFilter.tsx
+++ b/web/components/layout/FacetFilter.tsx
@@ -5,6 +5,7 @@
 
 import React from "react";
 import { useDashboard } from "@/contexts/DashboardContext";
+import { getReadableTextColor } from "@/lib/utils/colors";
 
 const FacetFilter: React.FC = () => {
   const { facetGroups, toggleFacet, clearFacets, hasActiveFacets } = useDashboard();
@@ -40,28 +41,50 @@ const FacetFilter: React.FC = () => {
             {group.label}
           </div>
           <div className="flex flex-wrap gap-1.5">
-            {group.options.map((option) => (
-              <button
-                key={option.value}
-                type="button"
-                aria-pressed={option.active}
-                onClick={() => toggleFacet(group.category, option.value)}
-                className={`inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-text-tertiary/40 ${
-                  option.active
-                    ? "border-transparent bg-surface-toggle-active text-text-on-toggle-active"
-                    : "border-border-primary text-text-secondary hover:border-text-tertiary/50 hover:text-text-primary"
-                }`}
-              >
-                <span>{option.label}</span>
-                <span
-                  className={
-                    option.active ? "text-text-on-toggle-active/70" : "text-text-tertiary"
+            {group.options.map((option) => {
+              const fill = option.color ?? null;
+              const fg = fill ? getReadableTextColor(fill) : null;
+              return (
+                <button
+                  key={option.value}
+                  type="button"
+                  aria-pressed={option.active}
+                  onClick={() => toggleFacet(group.category, option.value)}
+                  style={
+                    fill
+                      ? {
+                          backgroundColor: fill,
+                          color: fg!,
+                          borderColor: "transparent",
+                          boxShadow: option.active
+                            ? "0 0 0 2px var(--color-surface-primary), 0 0 0 3.5px var(--color-text-primary)"
+                            : undefined,
+                        }
+                      : undefined
                   }
+                  className={`inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-text-tertiary/40 ${
+                    fill
+                      ? ""
+                      : option.active
+                        ? "border-transparent bg-surface-toggle-active text-text-on-toggle-active"
+                        : "border-border-primary text-text-secondary hover:border-text-tertiary/50 hover:text-text-primary"
+                  }`}
                 >
-                  {option.count}
-                </span>
-              </button>
-            ))}
+                  <span>{option.label}</span>
+                  <span
+                    className={
+                      fill
+                        ? "opacity-70"
+                        : option.active
+                          ? "text-text-on-toggle-active/70"
+                          : "text-text-tertiary"
+                    }
+                  >
+                    {option.count}
+                  </span>
+                </button>
+              );
+            })}
           </div>
         </div>
       ))}

--- a/web/lib/utils/colors.ts
+++ b/web/lib/utils/colors.ts
@@ -5,8 +5,8 @@
  * Color utility functions for benchmark visualizations
  */
 
-import { modelColors, providerColors } from '@/lib/config/colors';
-import { parseModelKey } from '@/lib/utils/formatters';
+import { modelColors, providerColors } from '../config/colors';
+import { parseModelKey } from './formatters';
 
 /**
  * Fallback colors for models/providers not in the predefined color maps
@@ -91,4 +91,18 @@ export function getProviderColor(provider: string): string {
 
   const hash = hashCode(provider);
   return fallbackProviderColors[Math.abs(hash) % fallbackProviderColors.length] ?? "#8BC34A";
+}
+
+/**
+ * Pick a light or dark foreground for a solid hex fill so text stays WCAG-AA
+ * legible, using the relative-luminance crossover between black and white.
+ */
+export function getReadableTextColor(hex: string): string {
+  const h = hex.replace("#", "");
+  const channel = (i: number) => {
+    const c = parseInt(h.slice(i, i + 2), 16) / 255;
+    return c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4;
+  };
+  const luminance = 0.2126 * channel(0) + 0.7152 * channel(2) + 0.0722 * channel(4);
+  return luminance > 0.179 ? "#0a0a0a" : "#ffffff";
 }

--- a/web/lib/utils/facets.ts
+++ b/web/lib/utils/facets.ts
@@ -4,6 +4,8 @@
 import type { ModelTagOut, ProvidersApiResponse, TagCategoryOut } from "../api/client";
 import type { ModelsByProvider } from "../../types/benchmark.types";
 import { toModelKey } from "./formatters";
+import { providerColors } from "../config/colors";
+import { getModelColor } from "./colors";
 
 /** category -> selected values. Within a category values OR; across categories they AND. */
 export type FacetSelection = Record<string, string[]>;
@@ -13,6 +15,7 @@ export interface FacetOption {
   label: string;
   count: number;
   active: boolean;
+  color?: string;
 }
 
 export interface FacetGroup {
@@ -124,11 +127,20 @@ export function buildFacetGroups(
             matchesSelection(tags, others)
           );
         }).length;
+        const label = provider_valued ? normalizeProvider(value) : valueLabel;
+        let color: string | undefined;
+        if (provider_valued) {
+          const repKey = visibleKeys.find((key) =>
+            (tagIndex.get(key) ?? []).some((t) => t.category === category && t.value === value)
+          );
+          color = providerColors[label] ?? (repKey ? getModelColor(repKey) : undefined);
+        }
         return {
           value,
-          label: provider_valued ? normalizeProvider(value) : valueLabel,
+          label,
           count,
           active: (selected[category] ?? []).includes(value),
+          color,
         };
       })
       .sort((a, b) => a.label.localeCompare(b.label));


### PR DESCRIPTION
## What
<img width="1343" height="761" alt="Screenshot 2026-07-08 at 5 29 50 PM" src="https://github.com/user-attachments/assets/de792549-05b4-4eb3-a92e-4b755de890ea" />

Fill the provider filter chips in the left **Filters** panel (HOST and LAB sections) with each provider's brand color, matching the colors already used for that provider's bars/lines in the charts.

## Why

Brooke's request: "change the chips on the side panel to be the fill of the colors of each provider (eg. 11labs is orange, cartesia is blue etc)". A follow-up caught that Gladia rendered green in the sidebar but orange on the chart — the chips need to stay uniform with the chart.

## How

- **Single source of truth** — chips resolve color from the same maps the charts use (`providerColors` + `getModelColor`), no second copy.
  - Mapped providers → `providerColors` brand anchor.
  - Unmapped providers (Gladia, Mistral, Smallest) → fall back to the plotted model's `getModelColor`, so the chip matches its actual chart line/bar exactly.
- Foreground text/count auto-picks light or dark via a relative-luminance crossover for WCAG-AA contrast.
- Selected chips keep a theme-aware outline (surface-primary gap + text-primary ring); hover/focus, spacing, border-radius, and layout unchanged.
- FEATURES/DEPLOYMENT chips are untouched.
- **No color values in `colors.ts` were changed** — the charts are identical to main. Its two imports were switched from the `@/` alias to relative paths so the module resolves under vitest (a test now exercises it transitively).

## Testing

- `tsc --noEmit` clean
- `eslint` clean on changed files
- `vitest run` — 53/53 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR colors provider facet chips to match the chart palette. The main changes are:

- Adds optional facet color metadata for provider-valued HOST and LAB groups.
- Renders colored chips with readable foreground text.
- Reuses chart color maps from the shared color utilities.
- Switches color utility imports from aliases to relative paths.

<h3>Confidence Score: 4/5</h3>

The provider chip color selection needs a fix before merging.

- Unmapped providers can get a chip color from whichever model is first after filtering.
- Multi-model providers can still show a chip color that does not match the visible chart series exactly.
- The import changes and current hex color handling look safe for the changed code.

web/lib/utils/facets.ts

<sub>Reviews (1): Last reviewed commit: ["Color sidebar provider chips to match ch..."](https://github.com/coval-ai/benchmarks/commit/6e8e642d4f71736a09e7565f858d334dcf559b85) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42887072)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->