### PR TITLE
Add hidden S2S dashboard page

### DIFF
--- a/web/app/s2s/page.tsx
+++ b/web/app/s2s/page.tsx
@@ -1,0 +1,19 @@
+// Copyright 2026 The Coval Benchmarks Authors
+// SPDX-License-Identifier: Apache-2.0
+
+import { notFound } from "next/navigation";
+import { Suspense } from "react";
+import { S2SDashboard } from "./s2s-dashboard";
+
+export default function Page() {
+  // Gated rollout: /s2s is unreachable until NEXT_PUBLIC_S2S_ENABLED is set.
+  // It is intentionally left out of the nav and Overview until launch.
+  if (process.env.NEXT_PUBLIC_S2S_ENABLED !== "true") {
+    notFound();
+  }
+  return (
+    <Suspense fallback={null}>
+      <S2SDashboard />
+    </Suspense>
+  );
+}

--- a/web/app/s2s/s2s-dashboard.tsx
+++ b/web/app/s2s/s2s-dashboard.tsx
@@ -1,0 +1,39 @@
+// Copyright 2026 The Coval Benchmarks Authors
+// SPDX-License-Identifier: Apache-2.0
+
+"use client";
+
+import dynamic from "next/dynamic";
+import { DashboardProvider } from "@/contexts/DashboardContext";
+import { SidebarMenuProvider } from "@/contexts/SidebarMenuContext";
+import DashboardLayout from "@/components/layout/DashboardLayout";
+import KeyMetrics from "@/components/dashboard/KeyMetrics";
+import { ChartSkeleton } from "@/components/dashboard/DashboardSkeleton";
+
+// S2S has a single metric (V2V latency, no WER). The WER-based sections
+// (AccuracyBarSection, LatencyAccuracySection) are omitted, and the model
+// comparison table (HeatmapSection) is deferred to a later pass — its WER
+// columns would need per-column S2S gating.
+const TimelineChart = dynamic(
+  () => import("@/components/visualizations/TimelineChart"),
+  { ssr: false, loading: () => <ChartSkeleton /> }
+);
+
+const BoxPlotSection = dynamic(
+  () => import("@/components/dashboard/BoxPlotSection"),
+  { ssr: false, loading: () => <ChartSkeleton /> }
+);
+
+export function S2SDashboard() {
+  return (
+    <DashboardProvider page="s2s">
+      <SidebarMenuProvider>
+        <DashboardLayout>
+          <KeyMetrics />
+          <TimelineChart />
+          <BoxPlotSection />
+        </DashboardLayout>
+      </SidebarMenuProvider>
+    </DashboardProvider>
+  );
+}

--- a/web/components/dashboard/AccuracyBarSection.tsx
+++ b/web/components/dashboard/AccuracyBarSection.tsx
@@ -99,6 +99,9 @@ const AccuracyBarSection: React.FC = () => {
     );
   }, [werBarDataWithColors, clickedWERBars, themeColors.label]);
 
+  // WER-based: never rendered on S2S (no WER metric).
+  if (mode === "s2s") return null;
+
   return (
     <div className="mb-4">
       <Card padding="p-5 lg:p-8">

--- a/web/components/dashboard/KeyMetrics.tsx
+++ b/web/components/dashboard/KeyMetrics.tsx
@@ -22,10 +22,13 @@ const KeyMetrics: React.FC = () => {
     secondaryKeyMetric: secondary,
   } = useDashboard();
 
-  const metrics: KeyMetricData[] = [primary, secondary];
+  // S2S has no secondary (WER) tile, so it renders a single full-width tile.
+  const metrics: KeyMetricData[] = secondary ? [primary, secondary] : [primary];
 
   return (
-    <div className="grid grid-cols-2 gap-[0.8rem] mb-[0.8rem] w-full">
+    <div
+      className={`grid ${metrics.length > 1 ? "grid-cols-2" : "grid-cols-1"} gap-[0.8rem] mb-[0.8rem] w-full`}
+    >
       {metrics.map((metric) => (
         <Card key={metric.label} className="text-left min-w-0" padding="p-5 lg:p-8">
 

--- a/web/components/dashboard/LatencyAccuracySection.tsx
+++ b/web/components/dashboard/LatencyAccuracySection.tsx
@@ -86,6 +86,9 @@ const LatencyAccuracySection: React.FC = () => {
     return { xMax: max, xTicks: ticks };
   }, [scatterData]);
 
+  // WER-based: never rendered on S2S (no WER metric).
+  if (activeTab === "s2s") return null;
+
   return (
     <div className="mb-4">
       <Card padding="p-5 lg:p-8">

--- a/web/contexts/DashboardContext.tsx
+++ b/web/contexts/DashboardContext.tsx
@@ -14,7 +14,7 @@ export function DashboardProvider({
   page,
   children,
 }: {
-  page: "tts" | "stt";
+  page: "tts" | "stt" | "s2s";
   children: React.ReactNode;
 }) {
   const state = useDashboardState(page);

--- a/web/hooks/useActiveTab.ts
+++ b/web/hooks/useActiveTab.ts
@@ -5,7 +5,9 @@
 
 import { usePathname } from "next/navigation";
 
-export function useActiveTab(): "tts" | "stt" {
+export function useActiveTab(): "tts" | "stt" | "s2s" {
   const pathname = usePathname();
-  return pathname === "/stt" ? "stt" : "tts";
+  if (pathname === "/stt") return "stt";
+  if (pathname === "/s2s") return "s2s";
+  return "tts";
 }

--- a/web/hooks/useChartData.ts
+++ b/web/hooks/useChartData.ts
@@ -15,15 +15,21 @@ import type {
   BarDataPoint
 } from "@/types/benchmark.types";
 import type { SeriesPoint } from "@/lib/api/client";
-import { latencyToMs, normalizeModelName, normalizeSTTProviderName, normalizeTTSProviderName, toModelKey, parseModelKey } from "@/lib/utils/formatters";
+import { latencyToMs, normalizeModelName, normalizeProviderNameForTab, toModelKey, parseModelKey } from "@/lib/utils/formatters";
 import { WINDOW_MS, type TimeWindow } from "@/lib/config/timeWindows";
 
+// Latency metrics share every chart's number machinery (box plot, scatter,
+// comparison table). Membership gates the builders so a new one (V2V for S2S)
+// is never silently skipped.
+const LATENCY_METRICS: readonly string[] = ["TTFS", "TTFT", "TTFA", "V2V"];
+
 interface UseChartDataParams {
-  activeTab: "tts" | "stt";
+  activeTab: "tts" | "stt" | "s2s";
   modelStats: ModelStats[];
   series: SeriesPoint[];
   selectedTTSModels: string[];
   selectedSTTModels: string[];
+  selectedS2SModels: string[];
   modelsByProvider: ModelsByProvider;
   timeWindow: TimeWindow;
 }
@@ -34,9 +40,18 @@ export function useChartData({
   series,
   selectedTTSModels,
   selectedSTTModels,
+  selectedS2SModels,
   modelsByProvider,
   timeWindow
 }: UseChartDataParams) {
+  // The active tab's selected models, resolved once so the builders below don't
+  // each re-derive the tab→list mapping.
+  const selectedModels =
+    activeTab === "tts"
+      ? selectedTTSModels
+      : activeTab === "s2s"
+        ? selectedS2SModels
+        : selectedSTTModels;
   const toDisplayUnits = useCallback(
     (value: number): number => latencyToMs(value, activeTab),
     [activeTab]
@@ -71,9 +86,7 @@ export function useChartData({
     (modelKey: string): string => {
       const { provider, model } = parseModelKey(modelKey);
       if (provider) {
-        return activeTab === "stt"
-          ? normalizeSTTProviderName(provider)
-          : normalizeTTSProviderName(provider);
+        return normalizeProviderNameForTab(provider, activeTab);
       }
       // Fallback for bare slugs: search modelStats, then providers config
       const rawProvider =
@@ -82,9 +95,7 @@ export function useChartData({
           models.includes(modelKey)
         )?.[0] ??
         "Unknown";
-      return activeTab === "stt"
-        ? normalizeSTTProviderName(rawProvider)
-        : normalizeTTSProviderName(rawProvider);
+      return normalizeProviderNameForTab(rawProvider, activeTab);
     },
     [modelStats, activeTab, modelsByProvider]
   );
@@ -161,17 +172,12 @@ export function useChartData({
   // for TTFS/TTFT, TTS models for TTFA).
   const getTimelineData = useCallback(
     (metric: string): TimelineDataPoint[] => {
-      const models =
-        activeTab === "tts" ? selectedTTSModels : selectedSTTModels;
-      return buildTimelineRows(timelineByMetricModel[metric] ?? {}, models);
+      return buildTimelineRows(
+        timelineByMetricModel[metric] ?? {},
+        selectedModels
+      );
     },
-    [
-      buildTimelineRows,
-      timelineByMetricModel,
-      activeTab,
-      selectedTTSModels,
-      selectedSTTModels
-    ]
+    [buildTimelineRows, timelineByMetricModel, selectedModels]
   );
 
   // Per-metric, per-model box-plot pieces from the SQL stats, built in one pass
@@ -183,11 +189,7 @@ export function useChartData({
   >(() => {
     const out: Record<string, Record<string, BoxPlotDataPoint>> = {};
     modelStats.forEach((stat) => {
-      if (
-        stat.metric_type !== "TTFS" &&
-        stat.metric_type !== "TTFT" &&
-        stat.metric_type !== "TTFA"
-      ) {
+      if (!LATENCY_METRICS.includes(stat.metric_type)) {
         return;
       }
 
@@ -222,8 +224,6 @@ export function useChartData({
   // median, with the pooled axis bounds.
   const getBoxPlotData = useCallback(
     (metric: string): BoxPlotData => {
-      const selectedModels =
-        activeTab === "tts" ? selectedTTSModels : selectedSTTModels;
       const byModel = boxByMetricModel[metric] ?? {};
 
       const data: BoxPlotDataPoint[] = [];
@@ -252,7 +252,7 @@ export function useChartData({
         metricType: metric
       };
     },
-    [boxByMetricModel, activeTab, selectedTTSModels, selectedSTTModels]
+    [boxByMetricModel, selectedModels]
   );
 
   // Per-metric, per-model scatter point (avg latency, avg WER) built in one
@@ -264,11 +264,7 @@ export function useChartData({
     const out: Record<string, Record<string, ScatterDataPoint>> = {};
     modelStats.forEach((stat) => {
       // Only latency metrics belong on the scatter's x-axis; skip WER/RTF/etc.
-      if (
-        stat.metric_type !== "TTFS" &&
-        stat.metric_type !== "TTFT" &&
-        stat.metric_type !== "TTFA"
-      ) {
+      if (!LATENCY_METRICS.includes(stat.metric_type)) {
         return;
       }
       const modelKey = toModelKey(stat.provider, stat.model);
@@ -280,10 +276,7 @@ export function useChartData({
         y: werStat.avg_value,
         model: modelKey,
         benchmark: activeTab === "tts" ? "TTS" : "STT",
-        provider:
-          activeTab === "stt"
-            ? normalizeSTTProviderName(stat.provider)
-            : normalizeTTSProviderName(stat.provider),
+        provider: normalizeProviderNameForTab(stat.provider, activeTab),
         count: stat.sample_count
       };
     });
@@ -292,23 +285,18 @@ export function useChartData({
 
   const getScatterData = useCallback(
     (metric: string): ScatterDataPoint[] => {
-      const selectedModels =
-        activeTab === "tts" ? selectedTTSModels : selectedSTTModels;
       const byModel = scatterByMetricModel[metric] ?? {};
       return selectedModels
         .map((model) => byModel[model])
         .filter((point): point is ScatterDataPoint => point !== undefined);
     },
-    [scatterByMetricModel, activeTab, selectedTTSModels, selectedSTTModels]
+    [scatterByMetricModel, selectedModels]
   );
 
   // Comparison rows for a given latency metric: the full latency percentile
   // ladder straight from the SQL stats, plus avg WER and sample counts.
   const getHeatmapData = useCallback(
     (metric: string): ModelHeatmapData[] => {
-      const selectedModels =
-        activeTab === "tts" ? selectedTTSModels : selectedSTTModels;
-
       const heatmapData: ModelHeatmapData[] = [];
 
       selectedModels.forEach((model) => {
@@ -363,13 +351,10 @@ export function useChartData({
           ) || a.model.localeCompare(b.model)
       );
     },
-    [activeTab, selectedTTSModels, selectedSTTModels, getStat, toDisplayUnits]
+    [selectedModels, getStat, toDisplayUnits]
   );
 
   const werBarDataMemo = useMemo<BarDataPoint[]>(() => {
-    const selectedModels =
-      activeTab === "tts" ? selectedTTSModels : selectedSTTModels;
-
     if (selectedModels.length === 0) {
       return [];
     }
@@ -387,7 +372,7 @@ export function useChartData({
       })
       .filter((item): item is BarDataPoint => item !== null)
       .sort((a, b) => a.averageWER - b.averageWER);
-  }, [activeTab, selectedTTSModels, selectedSTTModels, getStat]);
+  }, [selectedModels, getStat]);
 
   const getWERBarData = useCallback(
     (): BarDataPoint[] => werBarDataMemo,
@@ -457,8 +442,6 @@ export function useChartData({
   /** Models that have at least one plotted point in the current timeline window. */
   const getModelsWithTimelineData = useCallback(
     (metric: string): string[] => {
-      const selectedModels =
-        activeTab === "tts" ? selectedTTSModels : selectedSTTModels;
       const [windowStart, windowEnd] = getCurrentTimeWindow();
       const windowed = getTimelineData(metric).filter(
         (point) => point.timestamp >= windowStart && point.timestamp <= windowEnd
@@ -471,13 +454,7 @@ export function useChartData({
         )
       );
     },
-    [
-      activeTab,
-      selectedTTSModels,
-      selectedSTTModels,
-      getCurrentTimeWindow,
-      getTimelineData
-    ]
+    [selectedModels, getCurrentTimeWindow, getTimelineData]
   );
 
   return {

--- a/web/hooks/useDashboardState.tsx
+++ b/web/hooks/useDashboardState.tsx
@@ -12,7 +12,7 @@ import {
 import { useChartData } from "@/hooks/useChartData";
 import { useMobileDetection } from "@/hooks/useMobileDetection";
 import { useBarInteraction } from "@/hooks/useBarInteraction";
-import { latencyToMs, normalizeModelName, normalizeSTTProviderName, normalizeTTSProviderName, parseModelKey, toModelKey } from "@/lib/utils/formatters";
+import { latencyToMs, normalizeModelName, normalizeProviderNameForTab, parseModelKey, toModelKey } from "@/lib/utils/formatters";
 import { buildModelsByProvider } from "@/lib/utils/modelsFromResults";
 import {
   buildFacetGroups,
@@ -33,18 +33,20 @@ import { useTimeWindow } from "@/hooks/useTimeWindow";
 import type { ModelStats } from "@/types/benchmark.types";
 import type { SeriesPoint } from "@/lib/api/client";
 
-export function useDashboardState(page: "tts" | "stt") {
+export function useDashboardState(page: "tts" | "stt" | "s2s") {
   // STT shows a TTFS / TTFT toggle that drives every latency surface (headline,
   // timeline, box plot, scatter, heatmap) in sync. TTS is single-metric (TTFA),
   // so the toggle is hidden there and the metric stays TTFA.
   const [sttMetric, setSttMetric] = useState<"TTFS" | "TTFT">("TTFS");
-  const activeMetric = page === "tts" ? "TTFA" : sttMetric;
+  const activeMetric =
+    page === "s2s" ? "V2V" : page === "tts" ? "TTFA" : sttMetric;
   const { timeWindow, changeTimeWindow } = useTimeWindow(
     `${page}_dashboard`,
     page
   );
 
-  const benchmarkParam = page === "tts" ? "TTS" : "STT";
+  const benchmarkParam =
+    page === "s2s" ? "S2S" : page === "tts" ? "TTS" : "STT";
 
   const aggregatesQuery = useAggregatesQuery({
     benchmark: benchmarkParam,
@@ -146,6 +148,7 @@ export function useDashboardState(page: "tts" | "stt") {
     series,
     selectedTTSModels: page === "tts" ? deferredSelectedModels : [],
     selectedSTTModels: page === "stt" ? deferredSelectedModels : [],
+    selectedS2SModels: page === "s2s" ? deferredSelectedModels : [],
     modelsByProvider,
     timeWindow: dataTimeWindow,
   });
@@ -234,20 +237,17 @@ export function useDashboardState(page: "tts" | "stt") {
 
   // Derived display values
   const latencyLabel = activeMetric;
-  const pageTitle = page === "tts" ? "Text to Speech Model Comparisons" : "Speech to Text Model Comparisons";
-  const pageSubtitle = page === "tts"
-    ? "Compare performance metrics between different Text-to-Speech models for voice agent applications."
-    : "Compare performance metrics between different Speech-to-Text models for voice agent applications.";
+  const modalityName = { stt: "Speech-to-Text", tts: "Text-to-Speech", s2s: "Speech-to-Speech" }[page];
+  const modalitySpaced = { stt: "Speech to Text", tts: "Text to Speech", s2s: "Speech to Speech" }[page];
+  const pageTitle = `${modalitySpaced} Model Comparisons`;
+  const pageSubtitle = `Compare performance metrics between different ${modalityName} models for voice agent applications.`;
   const sidebarTitle = "Models to Compare";
-  const benchmarkTitle = page === "tts"
-    ? "Text to Speech Voice AI Benchmarks"
-    : "Speech to Text Voice AI Benchmarks";
-  const mobileSheetTitle = page === "tts"
-    ? "Text-to-Speech Models"
-    : "Speech-to-Text Models";
-  const normalizeProviderName = page === "stt"
-    ? normalizeSTTProviderName
-    : normalizeTTSProviderName;
+  const benchmarkTitle = `${modalitySpaced} Voice AI Benchmarks`;
+  const mobileSheetTitle = `${modalityName} Models`;
+  const normalizeProviderName = useCallback(
+    (providerName: string) => normalizeProviderNameForTab(providerName, page),
+    [page]
+  );
 
   const facetGroups = useMemo(
     () =>
@@ -297,18 +297,22 @@ export function useDashboardState(page: "tts" | "stt") {
       : undefined,
   };
 
-  const secondaryKeyMetric = {
-    label: `${deferredSelectedModels.length > 1 ? "Lowest" : "Average"} Word Error Rate`,
-    displayValue: `${avgSecondary.toFixed(1)}%`,
-    subtitle: lowestWERModel
-      ? {
-          name: normalizeModelName(lowestWERModel),
-          detail: lowestWERProvider
-            ? normalizeProviderName(lowestWERProvider)
+  // S2S has no WER, so it renders a single KeyMetric tile (no secondary).
+  const secondaryKeyMetric =
+    page === "s2s"
+      ? undefined
+      : {
+          label: `${deferredSelectedModels.length > 1 ? "Lowest" : "Average"} Word Error Rate`,
+          displayValue: `${avgSecondary.toFixed(1)}%`,
+          subtitle: lowestWERModel
+            ? {
+                name: normalizeModelName(lowestWERModel),
+                detail: lowestWERProvider
+                  ? normalizeProviderName(lowestWERProvider)
+                  : undefined,
+              }
             : undefined,
-        }
-      : undefined,
-  };
+        };
 
   return {
     // Page identity

--- a/web/lib/api/generated/schema.ts
+++ b/web/lib/api/generated/schema.ts
@@ -1,120 +1,727 @@
-/**
- * This file mirrors the FastAPI OpenAPI contract used by the web client.
- * Refresh with `pnpm codegen` when API response schemas change.
- */
-
 export interface paths {
-  "/v1/results/aggregates": {
-    get: {
-      parameters: {
-        query: {
-          benchmark: components["schemas"]["BenchmarkLiteral"];
-          window?: components["schemas"]["WindowLiteral"];
-          schedule_period?: number;
+    "/healthz": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
         };
-      };
-      responses: {
-        200: {
-          content: {
-            "application/json": components["schemas"]["AggregatesResponse"];
-          };
-        };
-      };
+        /**
+         * Healthz
+         * @description Liveness probe — always returns 200.
+         */
+        get: operations["healthz_healthz_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-  };
+    "/readyz": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Readyz
+         * @description Readiness probe — returns 200 if DB is reachable, 503 otherwise.
+         *
+         *     Never raises an exception — DB unreachable is the expected failure mode
+         *     during Cloud Run startup.
+         */
+        get: operations["readyz_readyz_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/runs": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Runs
+         * @description Return a newest-first page of benchmark runs.
+         *
+         *     Args:
+         *         limit: Maximum number of runs to return (1–200, default 50).
+         *         before: Cursor — ``id`` of the last run on the previous page.
+         *
+         *     Returns:
+         *         ``{"runs": [...], "next_before": int | None}`` where ``next_before``
+         *         is the smallest ``id`` in this page when there are exactly ``limit``
+         *         rows, else ``None``.
+         */
+        get: operations["list_runs_v1_runs_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/results": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Results
+         * @description Return a newest-first page of successful benchmark results.
+         *
+         *     All optional filters are ANDed together.
+         *
+         *     **Result-row vs run-level status distinction:**
+         *     ``include_failed`` controls whether results from *failed runs* are included.
+         *     The result-row ``status='success'`` filter is always applied — there is no
+         *     way to opt in to failed result rows in this phase.
+         *
+         *     **``metric`` param is deprecated** — use ``metric_type`` for new code.
+         *     Both are accepted; if both are provided and equal the request succeeds.
+         *     If they differ a 400 is returned.
+         *
+         *     **``window`` and ``since``/``until`` are mutually exclusive.** Providing both
+         *     returns 400.
+         */
+        get: operations["list_results_v1_results_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/results/aggregates": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Results Aggregates
+         * @description Return per-model stats and per-bucket series for one benchmark.
+         *
+         *     Args:
+         *         benchmark: One of STT, TTS.
+         *         window: Time window — stats over results.created_at, series over
+         *             bucket_at. Defaults to 24h.
+         */
+        get: operations["get_results_aggregates_v1_results_aggregates_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/leaderboard": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Leaderboard
+         * @description Return leaderboard entries sorted ascending by average metric value.
+         *
+         *     Args:
+         *         metric: One of WER, TTFA, TTFT, TTFS.
+         *         benchmark: One of STT, TTS.
+         *         window: Time window — each is served by its materialized view.
+         *
+         *     Returns:
+         *         ``{"metric": ..., "window": ..., "entries": [LeaderboardEntry, ...]}``
+         *
+         *     Raises:
+         *         400: If the metric/benchmark combination is incompatible.
+         */
+        get: operations["get_leaderboard_v1_leaderboard_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/providers": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Providers
+         * @description Return the catalogue of benchmarked providers and models.
+         *
+         *     Sourced from the model registry (all entries, not just actively run ones).
+         *     Each model includes a ``disabled`` flag that the frontend can use to
+         *     hide or grey out models that are known but not actively benchmarked.
+         */
+        get: operations["get_providers_v1_providers_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
-
+export type webhooks = Record<string, never>;
 export interface components {
-  schemas: {
-    AggregatesResponse: {
-      benchmark: components["schemas"]["BenchmarkLiteral"];
-      window: components["schemas"]["WindowLiteral"];
-      model_stats: components["schemas"]["ModelStatEntry"][];
-      series: components["schemas"]["SeriesPoint"][];
+    schemas: {
+        /**
+         * AggregatesResponse
+         * @description Response schema for GET /v1/results/aggregates.
+         *
+         *     Wraps and returns all our ModelStatEntry and SeriesPoint data for a time
+         *     window.
+         */
+        AggregatesResponse: {
+            /**
+             * Benchmark
+             * @enum {string}
+             */
+            benchmark: "STT" | "TTS" | "S2S";
+            /**
+             * Window
+             * @enum {string}
+             */
+            window: "24h" | "7d" | "30d";
+            /** Model Stats */
+            model_stats: components["schemas"]["ModelStatEntry"][];
+            /** Series */
+            series: components["schemas"]["SeriesPoint"][];
+        };
+        /** HTTPValidationError */
+        HTTPValidationError: {
+            /** Detail */
+            detail?: components["schemas"]["ValidationError"][];
+        };
+        /**
+         * LeaderboardEntry
+         * @description A single entry in the leaderboard response.
+         */
+        LeaderboardEntry: {
+            /** Provider */
+            provider: string;
+            /** Model */
+            model: string;
+            /** Avg */
+            avg: number;
+            /** P50 */
+            p50: number;
+            /** P95 */
+            p95: number;
+            /** N */
+            n: number;
+        };
+        /**
+         * LeaderboardResponse
+         * @description Response schema for GET /v1/leaderboard.
+         */
+        LeaderboardResponse: {
+            /**
+             * Metric
+             * @enum {string}
+             */
+            metric: "WER" | "TTFA" | "TTFT" | "TTFS" | "V2V";
+            /**
+             * Window
+             * @enum {string}
+             */
+            window: "24h" | "7d" | "30d";
+            /** Entries */
+            entries: components["schemas"]["LeaderboardEntry"][];
+        };
+        /**
+         * ModelInfo
+         * @description A single model entry under a provider, with admin-disabled flag.
+         */
+        ModelInfo: {
+            /** Model */
+            model: string;
+            /**
+             * Disabled
+             * @default false
+             */
+            disabled: boolean;
+            /**
+             * Tags
+             * @default []
+             */
+            tags: components["schemas"]["ModelTagOut"][];
+        };
+        /**
+         * ModelStatEntry
+         * @description Per-(provider, model, metric_type) aggregate stats.
+         *
+         *     Lets us compute the stats server-side and just send the summaries.
+         */
+        ModelStatEntry: {
+            /** Provider */
+            provider: string;
+            /** Model */
+            model: string;
+            /** Metric Type */
+            metric_type: string;
+            /** Avg Value */
+            avg_value: number;
+            /** Stddev Value */
+            stddev_value: number;
+            /** P25 */
+            p25: number;
+            /** P50 */
+            p50: number;
+            /** P75 */
+            p75: number;
+            /** P90 */
+            p90: number;
+            /** P95 */
+            p95: number;
+            /** P99 */
+            p99: number;
+            /** Min Value */
+            min_value: number;
+            /** Max Value */
+            max_value: number;
+            /** Sample Count */
+            sample_count: number;
+        };
+        /**
+         * ModelTagOut
+         * @description A faceted filter tag: its category, raw value, and display label.
+         */
+        ModelTagOut: {
+            category: components["schemas"]["TagCategory"];
+            /** Value */
+            value: string;
+            /** Label */
+            label: string;
+        };
+        /**
+         * ProviderInfo
+         * @description Information about a single provider's models.
+         */
+        ProviderInfo: {
+            /** Provider */
+            provider: string;
+            /** Models */
+            models: components["schemas"]["ModelInfo"][];
+            /** Modes */
+            modes?: string[] | null;
+        };
+        /**
+         * ProvidersResponse
+         * @description Response schema for GET /v1/providers.
+         */
+        ProvidersResponse: {
+            /** Stt */
+            stt: components["schemas"]["ProviderInfo"][];
+            /** Tts */
+            tts: components["schemas"]["ProviderInfo"][];
+            /** S2S */
+            s2s: components["schemas"]["ProviderInfo"][];
+            /** Tag Categories */
+            tag_categories: components["schemas"]["TagCategoryOut"][];
+        };
+        /**
+         * ResultOut
+         * @description API response schema for a single benchmark result row.
+         *
+         *     ``status`` is sourced from the *parent run*, not from the result row's own
+         *     ``status`` column (which is always ``'success'`` because we filter on it).
+         *     The parent-run status is denormalized here at the API boundary via SQL JOIN
+         *     so the frontend does not need a second round-trip.
+         */
+        ResultOut: {
+            /** Id */
+            id: number;
+            /** Run Id */
+            run_id: number;
+            /** Provider */
+            provider: string;
+            /** Model */
+            model: string;
+            /** Voice */
+            voice: string | null;
+            /**
+             * Benchmark
+             * @enum {string}
+             */
+            benchmark: "STT" | "TTS" | "S2S";
+            /** Metric Type */
+            metric_type: string;
+            /** Metric Value */
+            metric_value: number | null;
+            /** Metric Units */
+            metric_units: string | null;
+            /** Audio Filename */
+            audio_filename: string | null;
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at: string;
+            /**
+             * Scheduled At
+             * Format: date-time
+             */
+            scheduled_at: string;
+            /**
+             * Status
+             * @enum {string}
+             */
+            status: "RUNNING" | "SUCCEEDED" | "PARTIAL" | "FAILED";
+        };
+        /**
+         * ResultsResponse
+         * @description Response schema for GET /v1/results.
+         */
+        ResultsResponse: {
+            /** Results */
+            results: components["schemas"]["ResultOut"][];
+        };
+        /**
+         * RunOut
+         * @description API response schema for a benchmark run row.
+         */
+        RunOut: {
+            /** Id */
+            id: number;
+            /**
+             * Started At
+             * Format: date-time
+             */
+            started_at: string;
+            /** Finished At */
+            finished_at: string | null;
+            /**
+             * Status
+             * @enum {string}
+             */
+            status: "RUNNING" | "SUCCEEDED" | "PARTIAL" | "FAILED";
+            /** Runner Sha */
+            runner_sha: string;
+            /** Dataset Id */
+            dataset_id: string;
+            /** Dataset Sha256 */
+            dataset_sha256: string;
+            /** Error */
+            error: string | null;
+        };
+        /**
+         * RunsResponse
+         * @description Response schema for GET /v1/runs.
+         */
+        RunsResponse: {
+            /** Runs */
+            runs: components["schemas"]["RunOut"][];
+            /** Next Before */
+            next_before?: number | null;
+        };
+        /**
+         * SeriesPoint
+         * @description Per-(provider, model, metric_type) distribution for one scheduled_at bucket.
+         *
+         *     Latency timelines render p50; WER renders value_sum / sample_count.
+         */
+        SeriesPoint: {
+            /** Provider */
+            provider: string;
+            /** Model */
+            model: string;
+            /** Metric Type */
+            metric_type: string;
+            /**
+             * Scheduled At
+             * Format: date-time
+             */
+            scheduled_at: string;
+            /** Min Value */
+            min_value: number;
+            /** P25 */
+            p25: number;
+            /** P50 */
+            p50: number;
+            /** P75 */
+            p75: number;
+            /** Max Value */
+            max_value: number;
+            /** Value Sum */
+            value_sum: number;
+            /** Sample Count */
+            sample_count: number;
+        };
+        /**
+         * TagCategory
+         * @description Faceted leaderboard filters. Within a facet tags OR; across facets they AND.
+         *
+         *     TYPE/HOST/LAB are derived from registry columns and SOURCE/TENANCY/LICENSING/
+         *     DEPLOYMENT from model attributes, all at the API boundary; only MODE and
+         *     FEATURES draw their values from ``ModelTag``.
+         * @enum {string}
+         */
+        TagCategory: "type" | "mode" | "host" | "lab" | "features" | "source" | "tenancy" | "licensing" | "deployment";
+        /**
+         * TagCategoryOut
+         * @description A facet category's display metadata. Sent in display order.
+         */
+        TagCategoryOut: {
+            category: components["schemas"]["TagCategory"];
+            /** Label */
+            label: string;
+            /**
+             * Provider Valued
+             * @default false
+             */
+            provider_valued: boolean;
+        };
+        /** ValidationError */
+        ValidationError: {
+            /** Location */
+            loc: (string | number)[];
+            /** Message */
+            msg: string;
+            /** Error Type */
+            type: string;
+            /** Input */
+            input?: unknown;
+            /** Context */
+            ctx?: Record<string, never>;
+        };
     };
-    BenchmarkLiteral: "STT" | "TTS";
-    LeaderboardEntry: {
-      provider: string;
-      model: string;
-      avg: number;
-      p50: number;
-      p95: number;
-      n: number;
+    responses: never;
+    parameters: never;
+    requestBodies: never;
+    headers: never;
+    pathItems: never;
+}
+export type $defs = Record<string, never>;
+export interface operations {
+    healthz_healthz_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: string;
+                    };
+                };
+            };
+        };
     };
-    LeaderboardResponse: {
-      metric: "WER" | "TTFA" | "TTFT" | "TTFS";
-      window: components["schemas"]["WindowLiteral"];
-      entries: components["schemas"]["LeaderboardEntry"][];
+    readyz_readyz_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+        };
     };
-    ModelInfo: {
-      model: string;
-      disabled?: boolean;
-      tags?: components["schemas"]["ModelTagOut"][];
+    list_runs_v1_runs_get: {
+        parameters: {
+            query?: {
+                limit?: number;
+                before?: number | null;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RunsResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
     };
-    ModelStatEntry: {
-      provider: string;
-      model: string;
-      metric_type: string;
-      avg_value: number;
-      stddev_value: number;
-      p25: number;
-      p50: number;
-      p75: number;
-      p90: number;
-      p95: number;
-      p99: number;
-      min_value: number;
-      max_value: number;
-      sample_count: number;
+    list_results_v1_results_get: {
+        parameters: {
+            query?: {
+                provider?: string | null;
+                model?: string | null;
+                /** @description Deprecated alias for metric_type. Kept for backward compatibility with legacy callers. Use metric_type for new integrations. If both are provided and equal, the request succeeds. If they differ, a 400 is returned. */
+                metric?: ("WER" | "TTFA" | "TTFT" | "TTFS" | "RTF" | "AUDIO_TO_FINAL" | "V2V") | null;
+                /** @description Filter on metric_type (e.g. WER, TTFA, TTFT, RTF). Canonical FE-facing name. */
+                metric_type?: string | null;
+                benchmark?: ("STT" | "TTS" | "S2S") | null;
+                /** @description Time window for results. One of '24h', '7d', '30d'. Defaults to '7d' when neither window nor since/until are supplied. Mutually exclusive with since/until. */
+                window?: ("24h" | "7d" | "30d") | null;
+                /** @description Lower bound on created_at (ISO 8601). Mutually exclusive with window. */
+                since?: string | null;
+                /** @description Upper bound on created_at (ISO 8601). May be combined with since. */
+                until?: string | null;
+                /** @description If false (default), only returns results whose parent run is SUCCEEDED or PARTIAL. If true, results from FAILED and RUNNING parent runs are also included. The result row's own status='success' filter is always applied regardless. */
+                include_failed?: boolean;
+                /** @description Maximum rows to return (1–100000, default 100000). */
+                limit?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ResultsResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
     };
-    ModelTagOut: {
-      category: components["schemas"]["TagCategory"];
-      value: string;
-      label: string;
+    get_results_aggregates_v1_results_aggregates_get: {
+        parameters: {
+            query: {
+                benchmark: "STT" | "TTS" | "S2S";
+                window?: "24h" | "7d" | "30d";
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AggregatesResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
     };
-    ProviderInfo: {
-      provider: string;
-      models: components["schemas"]["ModelInfo"][];
-      modes?: string[] | null;
+    get_leaderboard_v1_leaderboard_get: {
+        parameters: {
+            query: {
+                metric: "WER" | "TTFA" | "TTFT" | "TTFS" | "V2V";
+                benchmark: "STT" | "TTS" | "S2S";
+                window?: "24h" | "7d" | "30d";
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["LeaderboardResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
     };
-    ProvidersResponse: {
-      stt: components["schemas"]["ProviderInfo"][];
-      tts: components["schemas"]["ProviderInfo"][];
-      tag_categories: components["schemas"]["TagCategoryOut"][];
+    get_providers_v1_providers_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProvidersResponse"];
+                };
+            };
+        };
     };
-    RunOut: {
-      id: number;
-      started_at: string;
-      finished_at: string | null;
-      status: "RUNNING" | "SUCCEEDED" | "PARTIAL" | "FAILED";
-      runner_sha: string;
-      dataset_id: string;
-      dataset_sha256: string;
-      error: string | null;
-    };
-    RunsResponse: {
-      runs: components["schemas"]["RunOut"][];
-      next_before?: number | null;
-    };
-    SeriesPoint: {
-      provider: string;
-      model: string;
-      metric_type: string;
-      scheduled_at: string;
-      min_value: number;
-      p25: number;
-      p50: number;
-      p75: number;
-      max_value: number;
-      value_sum: number;
-      sample_count: number;
-    };
-    TagCategory: "type" | "mode" | "host" | "lab" | "features" | "source" | "tenancy";
-    TagCategoryOut: {
-      category: components["schemas"]["TagCategory"];
-      label: string;
-      provider_valued?: boolean;
-    };
-    WindowLiteral: "24h" | "7d" | "30d";
-  };
 }

--- a/web/lib/api/generated/schema.ts
+++ b/web/lib/api/generated/schema.ts
@@ -1,727 +1,121 @@
+/**
+ * This file mirrors the FastAPI OpenAPI contract used by the web client.
+ * Refresh with `pnpm codegen` when API response schemas change.
+ */
+
 export interface paths {
-    "/healthz": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+  "/v1/results/aggregates": {
+    get: {
+      parameters: {
+        query: {
+          benchmark: components["schemas"]["BenchmarkLiteral"];
+          window?: components["schemas"]["WindowLiteral"];
+          schedule_period?: number;
         };
-        /**
-         * Healthz
-         * @description Liveness probe — always returns 200.
-         */
-        get: operations["healthz_healthz_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/readyz": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+      };
+      responses: {
+        200: {
+          content: {
+            "application/json": components["schemas"]["AggregatesResponse"];
+          };
         };
-        /**
-         * Readyz
-         * @description Readiness probe — returns 200 if DB is reachable, 503 otherwise.
-         *
-         *     Never raises an exception — DB unreachable is the expected failure mode
-         *     during Cloud Run startup.
-         */
-        get: operations["readyz_readyz_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+      };
     };
-    "/v1/runs": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * List Runs
-         * @description Return a newest-first page of benchmark runs.
-         *
-         *     Args:
-         *         limit: Maximum number of runs to return (1–200, default 50).
-         *         before: Cursor — ``id`` of the last run on the previous page.
-         *
-         *     Returns:
-         *         ``{"runs": [...], "next_before": int | None}`` where ``next_before``
-         *         is the smallest ``id`` in this page when there are exactly ``limit``
-         *         rows, else ``None``.
-         */
-        get: operations["list_runs_v1_runs_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/results": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * List Results
-         * @description Return a newest-first page of successful benchmark results.
-         *
-         *     All optional filters are ANDed together.
-         *
-         *     **Result-row vs run-level status distinction:**
-         *     ``include_failed`` controls whether results from *failed runs* are included.
-         *     The result-row ``status='success'`` filter is always applied — there is no
-         *     way to opt in to failed result rows in this phase.
-         *
-         *     **``metric`` param is deprecated** — use ``metric_type`` for new code.
-         *     Both are accepted; if both are provided and equal the request succeeds.
-         *     If they differ a 400 is returned.
-         *
-         *     **``window`` and ``since``/``until`` are mutually exclusive.** Providing both
-         *     returns 400.
-         */
-        get: operations["list_results_v1_results_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/results/aggregates": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Results Aggregates
-         * @description Return per-model stats and per-bucket series for one benchmark.
-         *
-         *     Args:
-         *         benchmark: One of STT, TTS.
-         *         window: Time window — stats over results.created_at, series over
-         *             bucket_at. Defaults to 24h.
-         */
-        get: operations["get_results_aggregates_v1_results_aggregates_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/leaderboard": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Leaderboard
-         * @description Return leaderboard entries sorted ascending by average metric value.
-         *
-         *     Args:
-         *         metric: One of WER, TTFA, TTFT, TTFS.
-         *         benchmark: One of STT, TTS.
-         *         window: Time window — each is served by its materialized view.
-         *
-         *     Returns:
-         *         ``{"metric": ..., "window": ..., "entries": [LeaderboardEntry, ...]}``
-         *
-         *     Raises:
-         *         400: If the metric/benchmark combination is incompatible.
-         */
-        get: operations["get_leaderboard_v1_leaderboard_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/providers": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Providers
-         * @description Return the catalogue of benchmarked providers and models.
-         *
-         *     Sourced from the model registry (all entries, not just actively run ones).
-         *     Each model includes a ``disabled`` flag that the frontend can use to
-         *     hide or grey out models that are known but not actively benchmarked.
-         */
-        get: operations["get_providers_v1_providers_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
+  };
 }
-export type webhooks = Record<string, never>;
+
 export interface components {
-    schemas: {
-        /**
-         * AggregatesResponse
-         * @description Response schema for GET /v1/results/aggregates.
-         *
-         *     Wraps and returns all our ModelStatEntry and SeriesPoint data for a time
-         *     window.
-         */
-        AggregatesResponse: {
-            /**
-             * Benchmark
-             * @enum {string}
-             */
-            benchmark: "STT" | "TTS" | "S2S";
-            /**
-             * Window
-             * @enum {string}
-             */
-            window: "24h" | "7d" | "30d";
-            /** Model Stats */
-            model_stats: components["schemas"]["ModelStatEntry"][];
-            /** Series */
-            series: components["schemas"]["SeriesPoint"][];
-        };
-        /** HTTPValidationError */
-        HTTPValidationError: {
-            /** Detail */
-            detail?: components["schemas"]["ValidationError"][];
-        };
-        /**
-         * LeaderboardEntry
-         * @description A single entry in the leaderboard response.
-         */
-        LeaderboardEntry: {
-            /** Provider */
-            provider: string;
-            /** Model */
-            model: string;
-            /** Avg */
-            avg: number;
-            /** P50 */
-            p50: number;
-            /** P95 */
-            p95: number;
-            /** N */
-            n: number;
-        };
-        /**
-         * LeaderboardResponse
-         * @description Response schema for GET /v1/leaderboard.
-         */
-        LeaderboardResponse: {
-            /**
-             * Metric
-             * @enum {string}
-             */
-            metric: "WER" | "TTFA" | "TTFT" | "TTFS" | "V2V";
-            /**
-             * Window
-             * @enum {string}
-             */
-            window: "24h" | "7d" | "30d";
-            /** Entries */
-            entries: components["schemas"]["LeaderboardEntry"][];
-        };
-        /**
-         * ModelInfo
-         * @description A single model entry under a provider, with admin-disabled flag.
-         */
-        ModelInfo: {
-            /** Model */
-            model: string;
-            /**
-             * Disabled
-             * @default false
-             */
-            disabled: boolean;
-            /**
-             * Tags
-             * @default []
-             */
-            tags: components["schemas"]["ModelTagOut"][];
-        };
-        /**
-         * ModelStatEntry
-         * @description Per-(provider, model, metric_type) aggregate stats.
-         *
-         *     Lets us compute the stats server-side and just send the summaries.
-         */
-        ModelStatEntry: {
-            /** Provider */
-            provider: string;
-            /** Model */
-            model: string;
-            /** Metric Type */
-            metric_type: string;
-            /** Avg Value */
-            avg_value: number;
-            /** Stddev Value */
-            stddev_value: number;
-            /** P25 */
-            p25: number;
-            /** P50 */
-            p50: number;
-            /** P75 */
-            p75: number;
-            /** P90 */
-            p90: number;
-            /** P95 */
-            p95: number;
-            /** P99 */
-            p99: number;
-            /** Min Value */
-            min_value: number;
-            /** Max Value */
-            max_value: number;
-            /** Sample Count */
-            sample_count: number;
-        };
-        /**
-         * ModelTagOut
-         * @description A faceted filter tag: its category, raw value, and display label.
-         */
-        ModelTagOut: {
-            category: components["schemas"]["TagCategory"];
-            /** Value */
-            value: string;
-            /** Label */
-            label: string;
-        };
-        /**
-         * ProviderInfo
-         * @description Information about a single provider's models.
-         */
-        ProviderInfo: {
-            /** Provider */
-            provider: string;
-            /** Models */
-            models: components["schemas"]["ModelInfo"][];
-            /** Modes */
-            modes?: string[] | null;
-        };
-        /**
-         * ProvidersResponse
-         * @description Response schema for GET /v1/providers.
-         */
-        ProvidersResponse: {
-            /** Stt */
-            stt: components["schemas"]["ProviderInfo"][];
-            /** Tts */
-            tts: components["schemas"]["ProviderInfo"][];
-            /** S2S */
-            s2s: components["schemas"]["ProviderInfo"][];
-            /** Tag Categories */
-            tag_categories: components["schemas"]["TagCategoryOut"][];
-        };
-        /**
-         * ResultOut
-         * @description API response schema for a single benchmark result row.
-         *
-         *     ``status`` is sourced from the *parent run*, not from the result row's own
-         *     ``status`` column (which is always ``'success'`` because we filter on it).
-         *     The parent-run status is denormalized here at the API boundary via SQL JOIN
-         *     so the frontend does not need a second round-trip.
-         */
-        ResultOut: {
-            /** Id */
-            id: number;
-            /** Run Id */
-            run_id: number;
-            /** Provider */
-            provider: string;
-            /** Model */
-            model: string;
-            /** Voice */
-            voice: string | null;
-            /**
-             * Benchmark
-             * @enum {string}
-             */
-            benchmark: "STT" | "TTS" | "S2S";
-            /** Metric Type */
-            metric_type: string;
-            /** Metric Value */
-            metric_value: number | null;
-            /** Metric Units */
-            metric_units: string | null;
-            /** Audio Filename */
-            audio_filename: string | null;
-            /**
-             * Created At
-             * Format: date-time
-             */
-            created_at: string;
-            /**
-             * Scheduled At
-             * Format: date-time
-             */
-            scheduled_at: string;
-            /**
-             * Status
-             * @enum {string}
-             */
-            status: "RUNNING" | "SUCCEEDED" | "PARTIAL" | "FAILED";
-        };
-        /**
-         * ResultsResponse
-         * @description Response schema for GET /v1/results.
-         */
-        ResultsResponse: {
-            /** Results */
-            results: components["schemas"]["ResultOut"][];
-        };
-        /**
-         * RunOut
-         * @description API response schema for a benchmark run row.
-         */
-        RunOut: {
-            /** Id */
-            id: number;
-            /**
-             * Started At
-             * Format: date-time
-             */
-            started_at: string;
-            /** Finished At */
-            finished_at: string | null;
-            /**
-             * Status
-             * @enum {string}
-             */
-            status: "RUNNING" | "SUCCEEDED" | "PARTIAL" | "FAILED";
-            /** Runner Sha */
-            runner_sha: string;
-            /** Dataset Id */
-            dataset_id: string;
-            /** Dataset Sha256 */
-            dataset_sha256: string;
-            /** Error */
-            error: string | null;
-        };
-        /**
-         * RunsResponse
-         * @description Response schema for GET /v1/runs.
-         */
-        RunsResponse: {
-            /** Runs */
-            runs: components["schemas"]["RunOut"][];
-            /** Next Before */
-            next_before?: number | null;
-        };
-        /**
-         * SeriesPoint
-         * @description Per-(provider, model, metric_type) distribution for one scheduled_at bucket.
-         *
-         *     Latency timelines render p50; WER renders value_sum / sample_count.
-         */
-        SeriesPoint: {
-            /** Provider */
-            provider: string;
-            /** Model */
-            model: string;
-            /** Metric Type */
-            metric_type: string;
-            /**
-             * Scheduled At
-             * Format: date-time
-             */
-            scheduled_at: string;
-            /** Min Value */
-            min_value: number;
-            /** P25 */
-            p25: number;
-            /** P50 */
-            p50: number;
-            /** P75 */
-            p75: number;
-            /** Max Value */
-            max_value: number;
-            /** Value Sum */
-            value_sum: number;
-            /** Sample Count */
-            sample_count: number;
-        };
-        /**
-         * TagCategory
-         * @description Faceted leaderboard filters. Within a facet tags OR; across facets they AND.
-         *
-         *     TYPE/HOST/LAB are derived from registry columns and SOURCE/TENANCY/LICENSING/
-         *     DEPLOYMENT from model attributes, all at the API boundary; only MODE and
-         *     FEATURES draw their values from ``ModelTag``.
-         * @enum {string}
-         */
-        TagCategory: "type" | "mode" | "host" | "lab" | "features" | "source" | "tenancy" | "licensing" | "deployment";
-        /**
-         * TagCategoryOut
-         * @description A facet category's display metadata. Sent in display order.
-         */
-        TagCategoryOut: {
-            category: components["schemas"]["TagCategory"];
-            /** Label */
-            label: string;
-            /**
-             * Provider Valued
-             * @default false
-             */
-            provider_valued: boolean;
-        };
-        /** ValidationError */
-        ValidationError: {
-            /** Location */
-            loc: (string | number)[];
-            /** Message */
-            msg: string;
-            /** Error Type */
-            type: string;
-            /** Input */
-            input?: unknown;
-            /** Context */
-            ctx?: Record<string, never>;
-        };
+  schemas: {
+    AggregatesResponse: {
+      benchmark: components["schemas"]["BenchmarkLiteral"];
+      window: components["schemas"]["WindowLiteral"];
+      model_stats: components["schemas"]["ModelStatEntry"][];
+      series: components["schemas"]["SeriesPoint"][];
     };
-    responses: never;
-    parameters: never;
-    requestBodies: never;
-    headers: never;
-    pathItems: never;
-}
-export type $defs = Record<string, never>;
-export interface operations {
-    healthz_healthz_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        [key: string]: string;
-                    };
-                };
-            };
-        };
+    BenchmarkLiteral: "STT" | "TTS" | "S2S";
+    LeaderboardEntry: {
+      provider: string;
+      model: string;
+      avg: number;
+      p50: number;
+      p95: number;
+      n: number;
     };
-    readyz_readyz_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-        };
+    LeaderboardResponse: {
+      metric: "WER" | "TTFA" | "TTFT" | "TTFS" | "V2V";
+      window: components["schemas"]["WindowLiteral"];
+      entries: components["schemas"]["LeaderboardEntry"][];
     };
-    list_runs_v1_runs_get: {
-        parameters: {
-            query?: {
-                limit?: number;
-                before?: number | null;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["RunsResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
+    ModelInfo: {
+      model: string;
+      disabled?: boolean;
+      tags?: components["schemas"]["ModelTagOut"][];
     };
-    list_results_v1_results_get: {
-        parameters: {
-            query?: {
-                provider?: string | null;
-                model?: string | null;
-                /** @description Deprecated alias for metric_type. Kept for backward compatibility with legacy callers. Use metric_type for new integrations. If both are provided and equal, the request succeeds. If they differ, a 400 is returned. */
-                metric?: ("WER" | "TTFA" | "TTFT" | "TTFS" | "RTF" | "AUDIO_TO_FINAL" | "V2V") | null;
-                /** @description Filter on metric_type (e.g. WER, TTFA, TTFT, RTF). Canonical FE-facing name. */
-                metric_type?: string | null;
-                benchmark?: ("STT" | "TTS" | "S2S") | null;
-                /** @description Time window for results. One of '24h', '7d', '30d'. Defaults to '7d' when neither window nor since/until are supplied. Mutually exclusive with since/until. */
-                window?: ("24h" | "7d" | "30d") | null;
-                /** @description Lower bound on created_at (ISO 8601). Mutually exclusive with window. */
-                since?: string | null;
-                /** @description Upper bound on created_at (ISO 8601). May be combined with since. */
-                until?: string | null;
-                /** @description If false (default), only returns results whose parent run is SUCCEEDED or PARTIAL. If true, results from FAILED and RUNNING parent runs are also included. The result row's own status='success' filter is always applied regardless. */
-                include_failed?: boolean;
-                /** @description Maximum rows to return (1–100000, default 100000). */
-                limit?: number;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ResultsResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
+    ModelStatEntry: {
+      provider: string;
+      model: string;
+      metric_type: string;
+      avg_value: number;
+      stddev_value: number;
+      p25: number;
+      p50: number;
+      p75: number;
+      p90: number;
+      p95: number;
+      p99: number;
+      min_value: number;
+      max_value: number;
+      sample_count: number;
     };
-    get_results_aggregates_v1_results_aggregates_get: {
-        parameters: {
-            query: {
-                benchmark: "STT" | "TTS" | "S2S";
-                window?: "24h" | "7d" | "30d";
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["AggregatesResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
+    ModelTagOut: {
+      category: components["schemas"]["TagCategory"];
+      value: string;
+      label: string;
     };
-    get_leaderboard_v1_leaderboard_get: {
-        parameters: {
-            query: {
-                metric: "WER" | "TTFA" | "TTFT" | "TTFS" | "V2V";
-                benchmark: "STT" | "TTS" | "S2S";
-                window?: "24h" | "7d" | "30d";
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["LeaderboardResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
+    ProviderInfo: {
+      provider: string;
+      models: components["schemas"]["ModelInfo"][];
+      modes?: string[] | null;
     };
-    get_providers_v1_providers_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProvidersResponse"];
-                };
-            };
-        };
+    ProvidersResponse: {
+      stt: components["schemas"]["ProviderInfo"][];
+      tts: components["schemas"]["ProviderInfo"][];
+      s2s: components["schemas"]["ProviderInfo"][];
+      tag_categories: components["schemas"]["TagCategoryOut"][];
     };
+    RunOut: {
+      id: number;
+      started_at: string;
+      finished_at: string | null;
+      status: "RUNNING" | "SUCCEEDED" | "PARTIAL" | "FAILED";
+      runner_sha: string;
+      dataset_id: string;
+      dataset_sha256: string;
+      error: string | null;
+    };
+    RunsResponse: {
+      runs: components["schemas"]["RunOut"][];
+      next_before?: number | null;
+    };
+    SeriesPoint: {
+      provider: string;
+      model: string;
+      metric_type: string;
+      scheduled_at: string;
+      min_value: number;
+      p25: number;
+      p50: number;
+      p75: number;
+      max_value: number;
+      value_sum: number;
+      sample_count: number;
+    };
+    TagCategory: "type" | "mode" | "host" | "lab" | "features" | "source" | "tenancy";
+    TagCategoryOut: {
+      category: components["schemas"]["TagCategory"];
+      label: string;
+      provider_valued?: boolean;
+    };
+    WindowLiteral: "24h" | "7d" | "30d";
+  };
 }

--- a/web/lib/utils/facets.ts
+++ b/web/lib/utils/facets.ts
@@ -28,12 +28,17 @@ export function getTagCategories(providers?: ProvidersApiResponse): TagCategoryO
 
 /** Map every catalogue model's composite key to its tags. */
 export function buildTagIndex(
-  benchmark: "STT" | "TTS",
+  benchmark: "STT" | "TTS" | "S2S",
   providers?: ProvidersApiResponse
 ): Map<string, ModelTagOut[]> {
   const index = new Map<string, ModelTagOut[]>();
   if (!providers) return index;
-  const catalogue = benchmark === "STT" ? providers.stt : providers.tts;
+  const catalogue =
+    benchmark === "STT"
+      ? providers.stt
+      : benchmark === "S2S"
+        ? providers.s2s
+        : providers.tts;
   for (const providerInfo of catalogue) {
     for (const modelInfo of providerInfo.models) {
       index.set(toModelKey(providerInfo.provider, modelInfo.model), modelInfo.tags ?? []);

--- a/web/lib/utils/facets.ts
+++ b/web/lib/utils/facets.ts
@@ -34,11 +34,11 @@ export function buildTagIndex(
   const index = new Map<string, ModelTagOut[]>();
   if (!providers) return index;
   const catalogue =
-    benchmark === "STT"
+    (benchmark === "STT"
       ? providers.stt
       : benchmark === "S2S"
         ? providers.s2s
-        : providers.tts;
+        : providers.tts) ?? [];
   for (const providerInfo of catalogue) {
     for (const modelInfo of providerInfo.models) {
       index.set(toModelKey(providerInfo.provider, modelInfo.model), modelInfo.tags ?? []);

--- a/web/lib/utils/formatters.ts
+++ b/web/lib/utils/formatters.ts
@@ -193,7 +193,8 @@ export function normalizeS2SProviderName(providerName: string): string {
     xai: "xAI",
   };
 
-  return mappings[providerName] ?? capitalizeProviderSlug(providerName);
+  const lower = providerName.toLowerCase();
+  return mappings[lower] ?? capitalizeProviderSlug(providerName);
 }
 
 /** Pick the provider-name normalizer that matches the active dashboard tab. */

--- a/web/lib/utils/formatters.ts
+++ b/web/lib/utils/formatters.ts
@@ -60,7 +60,7 @@ export function getLocalTimeZoneAbbr(): string {
  * Convert a latency metric value to display milliseconds.
  * STT latency metrics (TTFT) are stored in seconds; TTS (TTFA) already in ms.
  */
-export function latencyToMs(value: number, benchmark: "tts" | "stt"): number {
+export function latencyToMs(value: number, benchmark: "tts" | "stt" | "s2s"): number {
   return benchmark === "stt" ? value * 1000 : value;
 }
 
@@ -127,6 +127,10 @@ export function normalizeModelName(modelKey: string): string {
     "stt-rt-v4": "STT RT v4",
     "stt-rt-v5": "STT RT v5",
     "inworld-stt-1": "STT 1",
+    // S2S
+    "gpt-realtime": "GPT Realtime 2",
+    "gemini-live": "Gemini 3.1 Flash Live (Preview)",
+    "grok-realtime": "Grok Realtime",
     default: "Default",
     enhanced: "Enhanced"
   };
@@ -180,6 +184,26 @@ export function normalizeSTTProviderName(providerName: string): string {
 
   const lower = providerName.toLowerCase();
   return mappings[lower] ?? capitalizeProviderSlug(providerName);
+}
+
+export function normalizeS2SProviderName(providerName: string): string {
+  const mappings: Record<string, string> = {
+    google: "Google",
+    openai: "OpenAI",
+    xai: "xAI",
+  };
+
+  return mappings[providerName] ?? capitalizeProviderSlug(providerName);
+}
+
+/** Pick the provider-name normalizer that matches the active dashboard tab. */
+export function normalizeProviderNameForTab(
+  providerName: string,
+  tab: "tts" | "stt" | "s2s"
+): string {
+  if (tab === "stt") return normalizeSTTProviderName(providerName);
+  if (tab === "s2s") return normalizeS2SProviderName(providerName);
+  return normalizeTTSProviderName(providerName);
 }
 
 export function normalizeTTSProviderName(providerName: string): string {

--- a/web/lib/utils/modelsFromResults.test.ts
+++ b/web/lib/utils/modelsFromResults.test.ts
@@ -56,6 +56,24 @@ describe("buildModelsByProvider", () => {
     ]);
   });
 
+  it("reads the s2s catalogue for the S2S benchmark", () => {
+    const catalogue = {
+      stt: [],
+      tts: [],
+      s2s: [
+        { provider: "openai", models: [{ model: "gpt-realtime", disabled: false }] },
+        { provider: "google", models: [{ model: "gemini-live", disabled: false }] },
+      ],
+    };
+    const out = buildModelsByProvider(
+      [entry("openai", "gpt-realtime")],
+      "S2S",
+      catalogue as never
+    );
+    expect(out.openai).toEqual(["openai:gpt-realtime"]);
+    expect(out.google).toEqual(["google:gemini-live"]);
+  });
+
   it("works when catalogue is undefined", () => {
     const out = buildModelsByProvider([entry("hume", "octave-2")], "TTS");
     expect(out.hume).toEqual(["hume:octave-2"]);

--- a/web/lib/utils/modelsFromResults.ts
+++ b/web/lib/utils/modelsFromResults.ts
@@ -20,11 +20,11 @@ function modelIsEnabled(
   if (!providers) return true;
 
   const catalogue =
-    benchmark === "STT"
+    (benchmark === "STT"
       ? providers.stt
       : benchmark === "S2S"
         ? providers.s2s
-        : providers.tts;
+        : providers.tts) ?? [];
   const providerInfo = catalogue.find((item) => item.provider === provider);
   if (!providerInfo) return true;
 
@@ -53,11 +53,11 @@ function buildModelsByProviderFromCatalogue(
   if (!providers) return modelsByProvider;
 
   const catalogue =
-    benchmark === "STT"
+    (benchmark === "STT"
       ? providers.stt
       : benchmark === "S2S"
         ? providers.s2s
-        : providers.tts;
+        : providers.tts) ?? [];
   for (const providerInfo of catalogue) {
     for (const modelInfo of providerInfo.models) {
       if (modelInfo.disabled) continue;

--- a/web/lib/utils/modelsFromResults.ts
+++ b/web/lib/utils/modelsFromResults.ts
@@ -13,13 +13,18 @@ export interface ProviderModelRef {
 
 function modelIsEnabled(
   providers: ProvidersApiResponse | undefined,
-  benchmark: "STT" | "TTS",
+  benchmark: "STT" | "TTS" | "S2S",
   provider: string,
   model: string
 ): boolean {
   if (!providers) return true;
 
-  const catalogue = benchmark === "STT" ? providers.stt : providers.tts;
+  const catalogue =
+    benchmark === "STT"
+      ? providers.stt
+      : benchmark === "S2S"
+        ? providers.s2s
+        : providers.tts;
   const providerInfo = catalogue.find((item) => item.provider === provider);
   if (!providerInfo) return true;
 
@@ -41,13 +46,18 @@ function addModel(
 }
 
 function buildModelsByProviderFromCatalogue(
-  benchmark: "STT" | "TTS",
+  benchmark: "STT" | "TTS" | "S2S",
   providers?: ProvidersApiResponse
 ): ModelsByProvider {
   const modelsByProvider: ModelsByProvider = {};
   if (!providers) return modelsByProvider;
 
-  const catalogue = benchmark === "STT" ? providers.stt : providers.tts;
+  const catalogue =
+    benchmark === "STT"
+      ? providers.stt
+      : benchmark === "S2S"
+        ? providers.s2s
+        : providers.tts;
   for (const providerInfo of catalogue) {
     for (const modelInfo of providerInfo.models) {
       if (modelInfo.disabled) continue;
@@ -65,7 +75,7 @@ function buildModelsByProviderFromCatalogue(
  */
 export function buildModelsByProvider(
   entries: readonly ProviderModelRef[],
-  benchmark: "STT" | "TTS",
+  benchmark: "STT" | "TTS" | "S2S",
   providers?: ProvidersApiResponse
 ): ModelsByProvider {
   const modelsByProvider = buildModelsByProviderFromCatalogue(benchmark, providers);


### PR DESCRIPTION
S2S launch FE prep  PR:

Gate a new /s2s dashboard behind NEXT_PUBLIC_S2S_ENABLED (404 until set) and thread S2S through the shared dashboard hooks: V2V latency as the single metric, no WER (accuracy charts omitted), a single KeyMetric tile, and S2S provider/model display names. The model comparison table is deferred , its WER columns need per-column S2S gating. STT and TTS are unchanged.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR gates a new `/s2s` (Speech-to-Speech) dashboard behind `NEXT_PUBLIC_S2S_ENABLED`, threading S2S through the shared dashboard hooks with V2V as the single latency metric and no WER.

- Adds `web/app/s2s/page.tsx` and `s2s-dashboard.tsx`: server-side 404 gate with `notFound()`, a clean dashboard layout that renders `KeyMetrics`, `TimelineChart`, and `BoxPlotSection` while omitting all WER-based sections.
- Extends `useDashboardState`, `useChartData`, `modelsFromResults`, `facets`, `formatters`, and the generated schema to handle the `"s2s"` / `"S2S"` / `"V2V"` variants; all catalogue lookups fall back to `?? []` so old API payloads missing `s2s` don't crash.
- `KeyMetrics` now renders a single full-width tile when `secondaryKeyMetric` is `undefined` (S2S), and both `AccuracyBarSection` and `LatencyAccuracySection` return `null` on the S2S path.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the S2S path is completely hidden behind a build-time flag and only introduces additive changes to existing shared hooks.

All three catalogue lookups guard against a missing `s2s` field with `?? []`, the WER-based sections correctly short-circuit on the S2S path, and the V2V metric is registered in `LATENCY_METRICS` so it participates in all chart builders. The one inaccuracy found — the scatter point `benchmark` field defaulting to "STT" for S2S — is inert at runtime because S2S models have no WER stat and the scatter section is hidden for S2S.

No files require special attention. The latent scatter `benchmark` label in `useChartData.ts` is worth fixing before the scatter chart is enabled for S2S.

<sub>Reviews (4): Last reviewed commit: ["Keep schema.ts as the curated mirror plu..."](https://github.com/coval-ai/benchmarks/commit/6edcf8d955e41b6bae5062004de58c68ddd60794) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42891595)</sub>

<!-- /greptile_comment -->