### PR TITLE
[BENCH-386] Align benchmarks UI with Coval brand guide + fix mobile

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -8,63 +8,64 @@
 /* coval.ai cream palette — single light theme. */
 :root {
   /* Surfaces */
-  --color-surface-primary: #fdfcf8;
+  --color-surface-primary: #f9faf8;
   --color-surface-secondary: #f2f1ee;
   --color-surface-elevated: #f5f4f0;
-  --color-surface-tooltip: #fdfcf8;
-  --color-surface-backdrop: rgba(10, 10, 10, 0.5);
+  --color-surface-tooltip: #f9faf8;
+  --color-surface-backdrop: rgba(15, 12, 10, 0.5);
   --color-surface-overlay: rgba(242, 241, 238, 0.85);
 
   /* Text */
-  --color-text-primary: #0a0a0a;
+  --color-text-primary: #0f0c0a;
   --color-text-secondary: #515151;
-  --color-text-tertiary: #8a8780;
-  --color-text-on-tooltip: #0a0a0a;
+  --color-text-tertiary: #7f7a76;
+  --color-text-on-tooltip: #0f0c0a;
   --color-text-on-tooltip-secondary: #515151;
 
   /* Borders */
-  --color-border-primary: #dddbd4;
+  --color-border-primary: #dbdbd3;
   --color-border-secondary: #e8e6e0;
 
   /* Charts */
-  --color-chart-grid: #dddbd4;
+  --color-chart-grid: #dbdbd3;
   --color-chart-axis-text: #515151;
-  --color-chart-label: #0a0a0a;
-  --color-chart-median: #0a0a0a;
-  --color-chart-box-fill: rgba(10, 10, 10, 0.08);
+  --color-chart-label: #0f0c0a;
+  --color-chart-median: #0f0c0a;
+  --color-chart-box-fill: rgba(15, 12, 10, 0.08);
   --color-chart-bar-stroke: #c8c6c2;
 
   /* Interactive */
-  --color-hover-bg: rgba(10, 10, 10, 0.05);
-  --color-selected-bg: rgba(10, 10, 10, 0.08);
-  --color-selected-border: rgba(10, 10, 10, 0.15);
+  --color-hover-bg: rgba(15, 12, 10, 0.05);
+  --color-selected-bg: rgba(15, 12, 10, 0.08);
+  --color-selected-border: rgba(15, 12, 10, 0.15);
 
   /* Toggle */
-  --color-surface-toggle-active: #0a0a0a;
-  --color-text-on-toggle-active: #fdfcf8;
+  --color-surface-toggle-active: #0f0c0a;
+  --color-text-on-toggle-active: #f9faf8;
   --color-surface-toggle-inactive: #e8e6e0;
   --color-text-on-toggle-inactive: #515151;
 
   /* Spinner */
-  --color-spinner-track: rgba(10, 10, 10, 0.15);
-  --color-spinner-head: #0a0a0a;
+  --color-spinner-track: rgba(15, 12, 10, 0.15);
+  --color-spinner-head: #0f0c0a;
 
   /* Screen glow */
-  --color-screen-glow: rgba(10, 10, 10, 0.15);
+  --color-screen-glow: rgba(15, 12, 10, 0.15);
 
-  /* Brand accents (coval.ai) */
-  --color-accent-rust: #c0401e;
-  --color-accent-teal: #5cb8bf;
-  --color-accent-terracotta: #c06a60;
-  --color-accent-pink: #e8789a;
-  --color-accent-orange: #efa875;
-  --color-accent-sage: #b5c4a8;
-  --color-accent-blue: #a8b8c8;
-  --color-accent-lavender: #a8a0c0;
+  /* Brand accents — anchored on the Coval palette's blue/green/red-orange/purple
+     families, tuned to mid-tones that stay legible on the light surface. */
+  --color-accent-rust: #b23a2e;
+  --color-accent-teal: #1f937c;
+  --color-accent-terracotta: #c15c3c;
+  --color-accent-pink: #b14a72;
+  --color-accent-orange: #d68a66;
+  --color-accent-sage: #5e8a2e;
+  --color-accent-blue: #2f6db0;
+  --color-accent-lavender: #6e51a6;
 
   /* Base */
   --background: #f2f1ee;
-  --foreground: #0a0a0a;
+  --foreground: #0f0c0a;
 
   /* Film grain (coval.ai). Tiled fractal-noise SVG; layered via overlays. */
   --noise-bg: url("data:image/svg+xml;utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='256' height='256'%3E%3Cfilter id='n' color-interpolation-filters='sRGB'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.75' numOctaves='5' seed='23' stitchTiles='stitch'/%3E%3CfeColorMatrix values='1 0 0 0 0 0 1 0 0 0 0 0 1 0 0 0 0 0 3 0'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");

--- a/web/app/playground/components/playground-draft/ModelPill.tsx
+++ b/web/app/playground/components/playground-draft/ModelPill.tsx
@@ -28,7 +28,7 @@ export function ModelPill({
     fullWidth
       ? "flex w-full max-w-full min-w-0 items-center justify-between gap-2 rounded-xl border px-3 py-2 text-xs font-medium transition-colors"
       : "inline-flex max-w-full min-w-0 items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs font-medium transition-colors",
-    selected ? "bg-surface-primary text-text-primary" : "bg-transparent text-zinc-500 dark:text-zinc-500",
+    selected ? "bg-surface-primary text-text-primary" : "bg-transparent text-text-tertiary",
     disabled ? "cursor-not-allowed opacity-50" : ""
   ].join(" ");
 

--- a/web/app/playground/components/playground-draft/STTPlaygroundPanel.tsx
+++ b/web/app/playground/components/playground-draft/STTPlaygroundPanel.tsx
@@ -717,7 +717,7 @@ export function STTPlaygroundPanel({
           >
             {phase === "recording" ? (
               <span className="relative flex size-2.5 shrink-0 items-center justify-center">
-                <span className="absolute size-2.5 animate-pulse rounded-full bg-red-500" />
+                <span className="absolute size-2.5 animate-pulse rounded-full bg-accent-rust" />
               </span>
             ) : (
               <Mic className="size-4 shrink-0 text-text-secondary" aria-hidden />
@@ -799,7 +799,7 @@ export function STTPlaygroundPanel({
                         {row.pending ? (
                           <p className="text-right text-xs text-text-tertiary">Transcribing…</p>
                         ) : row.error ? (
-                          <p className="max-w-[12rem] text-right text-xs text-red-400">{row.error}</p>
+                          <p className="max-w-[12rem] text-right text-xs text-accent-rust">{row.error}</p>
                         ) : (
                           visibleMetricKeys.map((k) => renderMetricCell(k, row))
                         )}

--- a/web/components/dashboard/DashboardSkeleton.tsx
+++ b/web/components/dashboard/DashboardSkeleton.tsx
@@ -43,8 +43,8 @@ export const ChartSkeleton: React.FC = () => (
   <div className="mb-4">
     <Card>
       {/* SectionHeader mirror */}
-      <div className="flex justify-between items-start gap-8 mb-4">
-        <div className="w-3/4 min-w-0">
+      <div className="flex flex-col sm:flex-row sm:justify-between sm:items-start gap-3 sm:gap-8 mb-4">
+        <div className="w-full sm:w-3/4 min-w-0">
           <div className="text-[0.72rem] font-light text-text-secondary mb-2">
             <Bar className="h-[0.7em] w-28" />
           </div>
@@ -56,11 +56,11 @@ export const ChartSkeleton: React.FC = () => (
             <Bar className="mt-1 h-[0.7em] w-2/3" />
           </div>
         </div>
-        <div className="text-right min-w-0">
+        <div className="text-left sm:text-right min-w-0">
           <div className="text-[0.72rem] font-light text-text-secondary mb-2">
             <Bar className="h-[0.7em] w-16" />
           </div>
-          <div className="font-mono text-[2.4rem] font-bold break-words">
+          <div className="font-mono text-3xl sm:text-[2.4rem] font-bold break-words">
             <Bar className="h-[0.7em] w-24" />
           </div>
         </div>

--- a/web/components/dashboard/ModelComparisonTable.tsx
+++ b/web/components/dashboard/ModelComparisonTable.tsx
@@ -125,7 +125,7 @@ const ModelComparisonTable: React.FC<ModelComparisonTableProps> = ({
   const bar = (fraction: number) => (
     <div className="mt-1.5 h-1 w-full min-w-16 rounded-full bg-surface-secondary">
       <div
-        className="h-full rounded-full bg-accent-teal"
+        className="h-full rounded-full bg-accent-blue"
         style={{ width: `${Math.max(2, fraction * 100)}%` }}
       />
     </div>
@@ -157,7 +157,7 @@ const ModelComparisonTable: React.FC<ModelComparisonTableProps> = ({
           step={1}
           value={percentileIdx}
           onChange={(e) => onPercentileChange(Number(e.target.value))}
-          className="w-44 accent-accent-teal"
+          className="w-44 accent-accent-blue"
           aria-valuetext={percentile.key}
         />
         <span className="tabular-nums font-medium text-text-primary">

--- a/web/components/shared/SectionHeader.tsx
+++ b/web/components/shared/SectionHeader.tsx
@@ -129,7 +129,7 @@ const SectionHeader: React.FC<SectionHeaderProps> = ({
       },
       annotate: exportAnnotate,
       legend: Array.from(
-        card.querySelectorAll(".recharts-legend-wrapper li")
+        card.querySelectorAll(".recharts-legend-wrapper li, [data-chart-legend] li")
       ).map((li) => ({
         label: li.textContent?.trim() ?? "",
         color: li.querySelector("span")?.style.backgroundColor ?? "#0f0c0a",

--- a/web/components/shared/SectionHeader.tsx
+++ b/web/components/shared/SectionHeader.tsx
@@ -132,7 +132,7 @@ const SectionHeader: React.FC<SectionHeaderProps> = ({
         card.querySelectorAll(".recharts-legend-wrapper li")
       ).map((li) => ({
         label: li.textContent?.trim() ?? "",
-        color: li.querySelector("span")?.style.backgroundColor ?? "#0a0a0a",
+        color: li.querySelector("span")?.style.backgroundColor ?? "#0f0c0a",
         dimmed: li.hasAttribute("data-dimmed"),
       })),
     }).catch(() => false);
@@ -147,8 +147,8 @@ const SectionHeader: React.FC<SectionHeaderProps> = ({
   };
 
   return (
-    <div id={anchorId} className="flex justify-between items-start gap-8 mb-4 scroll-mt-24">
-      <div className="w-3/4 min-w-0">
+    <div id={anchorId} className="flex flex-col sm:flex-row sm:justify-between sm:items-start gap-3 sm:gap-8 mb-4 scroll-mt-24">
+      <div className="w-full sm:w-3/4 min-w-0">
         <h2 className="flex items-center gap-2 text-[0.9rem] font-light text-text-secondary mb-2">
           {label}
           <button
@@ -212,7 +212,7 @@ const SectionHeader: React.FC<SectionHeaderProps> = ({
         )}
       </div>
       {stat && (
-        <div className="text-right min-w-0">
+        <div className="text-left sm:text-right min-w-0">
           <div
             data-stat-label
             className="text-[0.9rem] font-light text-text-secondary mb-2"

--- a/web/components/visualizations/TimelineChart.tsx
+++ b/web/components/visualizations/TimelineChart.tsx
@@ -11,7 +11,6 @@ import {
   YAxis,
   CartesianGrid,
   ResponsiveContainer,
-  Legend,
   Tooltip,
   ReferenceLine
 } from "recharts";
@@ -395,6 +394,16 @@ const TimelineChart: React.FC = () => {
     (typeof yDomain[1] !== "number" ||
       (v >= yDomain[0] && v <= yDomain[1]));
 
+  // The legend is rendered as a sibling BELOW the chart (not a recharts
+  // <Legend>), so the plot keeps the full card height instead of being
+  // squeezed — a 20-series legend inside the chart left only ~40px to plot on
+  // mobile. Build the payload the custom legend expects from the plotted models.
+  const legendPayload: LegendEntry[] = modelsWithData.map((model) => ({
+    value: formatChartLabel(model, getProviderForModel(model)),
+    color: getModelColor(model),
+    dataKey: `${model}_value`,
+  }));
+
   return (
     <div className="mb-4">
       <Card padding="p-5 lg:p-8">
@@ -651,11 +660,6 @@ const TimelineChart: React.FC = () => {
                 active={pinned || dragging || hoveredMarker ? false : undefined}
                 cursor={!dragging && !hoveredMarker}
               />
-              {modelsWithData.length > 1 && (
-                <Legend
-                  content={<TimelineLegend dimmedKeys={dimmedLegendKeys} />}
-                />
-              )}
               {modelsWithData.map((model) => (
                 <Line
                   key={model}
@@ -762,6 +766,14 @@ const TimelineChart: React.FC = () => {
               );
             })()}
         </div>
+        {modelsWithData.length > 1 && (
+          <div data-chart-legend>
+            <TimelineLegend
+              payload={legendPayload}
+              dimmedKeys={dimmedLegendKeys}
+            />
+          </div>
+        )}
       </Card>
     </div>
   );

--- a/web/hooks/useThemeColors.ts
+++ b/web/hooks/useThemeColors.ts
@@ -20,16 +20,16 @@ export interface ThemeColors {
 // Single light theme tuned for the coval.ai cream palette. These mirror the
 // chart-* CSS variables in globals.css (charts read them via JS, not CSS).
 const colors: ThemeColors = {
-  grid: "#dddbd4",
+  grid: "#dbdbd3",
   axisText: "#515151",
-  label: "#0a0a0a",
-  median: "#0a0a0a",
-  boxFill: "rgba(10, 10, 10, 0.08)",
+  label: "#0f0c0a",
+  median: "#0f0c0a",
+  boxFill: "rgba(15, 12, 10, 0.08)",
   barStroke: "#c8c6c2",
-  tooltipBg: "#fdfcf8",
-  tooltipText: "#0a0a0a",
+  tooltipBg: "#f9faf8",
+  tooltipText: "#0f0c0a",
   tooltipSecondary: "#515151",
-  textPrimary: "#0a0a0a",
+  textPrimary: "#0f0c0a",
   textSecondary: "#515151",
 };
 

--- a/web/lib/config/colors.ts
+++ b/web/lib/config/colors.ts
@@ -1,95 +1,112 @@
 // Copyright 2026 The Coval Benchmarks Authors
 // SPDX-License-Identifier: Apache-2.0
 
-// Series colors are drawn from the Coval brand families (blue / green /
-// red-orange / purple), expanded into legible mid-tones for the light surface
-// and validated for colorblind separation. Each vendor owns a hue family; its
-// models step through shades of that family. Where a modality packs more
-// vendors than the four families allow, two vendors share a family but sit in
-// opposite shade ranges (legend, tooltips, and export labels disambiguate).
+// Series colors are a soft, pastel-leaning categorical palette drawn in the
+// spirit of the Coval brand families (blue / green / red-orange / purple),
+// extended with on-vibe intermediate hues (teal, amber, indigo, rose, sky,
+// lime) so the ~16 vendors stay distinguishable. Values are placed in OKLCH at
+// the softest lightness that still clears the dataviz validator's categorical
+// band (L 0.43–0.77, chroma ≥ 0.10) so they read as gentle pastels while
+// surviving as thin line strokes on the near-white surface. Each vendor owns a
+// hue family; its models step through shades of that family. Where a modality
+// packs more vendors than hues, two vendors share a family but sit in opposite
+// shade ranges (legend, tooltips, and export labels disambiguate). Generated
+// from OKLCH anchors — see the brand guide color families.
 
 export const modelColors: Record<string, string> = {
-  // OpenAI — red family. TTS, STT, and S2S span the red range.
-  "gpt-4o-mini-tts": "#93342a",
-  "gpt-realtime-whisper": "#b23a2e",
-  "gpt-4o-transcribe": "#cf6357",
-  "gpt-4o-mini-transcribe": "#7e271f",
-  "gpt-realtime": "#c04d40", // S2S
+  // OpenAI — rose. TTS, STT, and S2S span the rose range.
+  "gpt-4o-mini-tts": "#de6d9b",
+  "gpt-4o-transcribe": "#f782b1",
+  "gpt-4o-mini-transcribe": "#d1608f",
+  "gpt-realtime-whisper": "#b24574",
+  "gpt-realtime": "#c35483", // S2S
 
-  // Google — blue family. Gemini realtime (S2S).
-  "gemini-live": "#3f7fbf",
+  // Google — sky (light blue). Chirp STT + Gemini realtime.
+  chirp_2: "#53b0de",
+  chirp_3: "#1d85b0",
 
-  // ElevenLabs — red-orange family. TTS + STT scribe span light→dark orange.
-  eleven_multilingual_v2: "#d68a66",
-  eleven_flash_v2_5: "#c15c3c",
-  eleven_turbo_v2_5: "#a54c31",
-  scribe_v2_realtime: "#8f3f26",
+  // ElevenLabs — peach (red-orange). TTS + STT scribe span light→dark peach.
+  eleven_multilingual_v2: "#fb9167",
+  eleven_flash_v2_5: "#d87248",
+  eleven_turbo_v2_5: "#bd592f",
+  scribe_v2_realtime: "#e67e54",
 
-  // xAI — magenta (purple family).
-  "grok-tts": "#cb7397",
-  "grok-stt": "#7e3251",
+  // xAI — purple.
+  "grok-tts": "#c890ea",
+  "grok-stt": "#844da2",
 
-  // Cartesia — blue family (TTS).
-  "sonic-3": "#5b92cd",
-  "sonic-3.5": "#2f6db0",
-  "ink-2": "#1e4b7e",
+  // Cartesia — blue (TTS sonic + STT ink).
+  "sonic-3": "#80b3fe",
+  "sonic-3.5": "#5e93e1",
+  "ink-2": "#3b6eb9",
 
-  // Rime — green family.
-  arcana: "#85ac56",
-  coda: "#5e8a2e",
-  mistv3: "#43631f",
+  // Rime — green, dark range (separates from Gradium in TTS).
+  arcana: "#55a14e",
+  coda: "#3c8836",
+  mistv3: "#22701c",
 
-  // Hume — purple family (TTS). Sits in the light/mid purple range so it stays
-  // clear of Inworld's dark purples when both appear.
-  "octave-2": "#9376c4",
-  "octave-tts": "#6e51a6",
+  // Hume — sky (TTS). Sits alongside Google, which is STT-only, so they never
+  // co-occur in one chart.
+  "octave-2": "#59b7e4",
+  "octave-tts": "#268bb6",
 
-  // Inworld AI — purple family, dark range (separates from Hume in TTS and
-  // AssemblyAI in STT).
-  "inworld-tts-1.5-mini": "#5a417f",
-  "inworld-tts-1.5-max": "#4b356f",
-  "inworld-stt-1": "#3c2b5c",
+  // Inworld AI — indigo.
+  "inworld-tts-1.5-mini": "#a9a5ff",
+  "inworld-tts-1.5-max": "#8b85de",
+  "inworld-stt-1": "#736dc3",
 
-  // Deepgram — green family, teal end. Aura anchors the dark end; STT models
-  // span up to light teal.
-  "aura-2-thalia-en": "#136452",
-  "nova-2": "#17705c",
-  "flux-general-en": "#1f937c",
-  "flux-general-multi": "#2ca386",
-  "nova-3": "#46b39a",
+  // Deepgram — teal. Aura anchors TTS; STT models span light→dark teal.
+  "aura-2-thalia-en": "#29b69e",
+  "nova-2": "#49cdb4",
+  "nova-3": "#1db098",
+  "flux-general-en": "#039580",
+  "flux-general-multi": "#007b69",
 
-  // AssemblyAI — purple family (STT), light/mid range.
-  "universal-streaming": "#8168b8",
-  "universal-streaming-multilingual": "#9376c4",
-  "universal-3.5-pro": "#6e51a6",
+  // AssemblyAI — purple (STT), light range (separates from xAI's dark grok-stt).
+  "universal-streaming-multilingual": "#d299f5",
+  "universal-3.5-pro": "#bf86e0",
+  "universal-3-pro": "#a871c9",
+  "universal-streaming": "#965fb6",
 
-  // Speechmatics — blue family (STT).
-  enhanced: "#3f7fbf",
-  default: "#24598f",
+  // Speechmatics — peach, dark range (STT; separates from ElevenLabs scribe).
+  enhanced: "#c35f36",
+  default: "#a24112",
 
-  // Soniox — gold (red-orange family, yellow end). Reads distinctly warmer than
-  // the ElevenLabs oranges and dark enough for the light surface.
-  "tts-rt-v1": "#c0a03f",
-  "stt-rt-v4": "#9e7b1c",
-  "stt-rt-v5": "#6f5611",
+  // Soniox — lime (green-gold).
+  "tts-rt-v1": "#9db030",
+  "stt-rt-v4": "#859704",
+  "stt-rt-v5": "#697800",
+
+  // Smallest — amber.
+  "lightning_v3.1_pro": "#d7a03d",
+  pulse: "#b07b05",
+
+  // Gladia — blue, mid (STT; sits between Cartesia's light sonic and dark ink).
+  "solaria-1": "#6a9fee",
+
+  // Mistral — amber, dark (STT; separates from Smallest's pulse).
+  "voxtral-mini-transcribe-realtime-2602": "#835a01",
 
   // Composite keys for models whose slug is shared across providers
-  "speechmatics:default": "#24598f",
-  "gradium:default": "#2ca386"
+  "speechmatics:default": "#a24112",
+  "gradium:default": "#74c16c"
 };
 
 export const providerColors: Record<string, string> = {
-  OpenAI: "#b23a2e",
-  ElevenLabs: "#c15c3c",
-  Cartesia: "#2f6db0",
-  Deepgram: "#1f937c",
-  AssemblyAI: "#6e51a6",
-  Speechmatics: "#24598f",
-  Rime: "#5e8a2e",
-  Gradium: "#2ca386",
-  Hume: "#8168b8",
-  "Inworld AI": "#4b356f",
-  xAI: "#b14a72",
-  Soniox: "#9e7b1c",
-  Google: "#3f7fbf"
+  OpenAI: "#d1608f",
+  ElevenLabs: "#e67e54",
+  Cartesia: "#5e93e1",
+  Deepgram: "#1db098",
+  AssemblyAI: "#bf86e0",
+  Speechmatics: "#c35f36",
+  Rime: "#3c8836",
+  Gradium: "#74c16c",
+  Hume: "#59b7e4",
+  "Inworld AI": "#8b85de",
+  xAI: "#c890ea",
+  Soniox: "#859704",
+  Google: "#53b0de",
+  Gladia: "#6a9fee",
+  Mistral: "#835a01",
+  Smallest: "#d7a03d"
 };

--- a/web/lib/config/colors.ts
+++ b/web/lib/config/colors.ts
@@ -1,86 +1,95 @@
 // Copyright 2026 The Coval Benchmarks Authors
 // SPDX-License-Identifier: Apache-2.0
 
+// Series colors are drawn from the Coval brand families (blue / green /
+// red-orange / purple), expanded into legible mid-tones for the light surface
+// and validated for colorblind separation. Each vendor owns a hue family; its
+// models step through shades of that family. Where a modality packs more
+// vendors than the four families allow, two vendors share a family but sit in
+// opposite shade ranges (legend, tooltips, and export labels disambiguate).
+
 export const modelColors: Record<string, string> = {
-  // OpenAI — red family (#E74C3C). TTS, STT, and S2S all use the same red range.
-  "gpt-4o-mini-tts": "#C0392B",
-  "gpt-realtime-whisper": "#E74C3C",
-  "gpt-4o-transcribe": "#CD6155",
-  "gpt-4o-mini-transcribe": "#922B21",
-  "gpt-realtime": "#EC7063", // S2S
+  // OpenAI — red family. TTS, STT, and S2S span the red range.
+  "gpt-4o-mini-tts": "#93342a",
+  "gpt-realtime-whisper": "#b23a2e",
+  "gpt-4o-transcribe": "#cf6357",
+  "gpt-4o-mini-transcribe": "#7e271f",
+  "gpt-realtime": "#c04d40", // S2S
 
-  // Google — blue family (#4285F4). Gemini realtime (S2S).
-  "gemini-live": "#4285F4",
+  // Google — blue family. Gemini realtime (S2S).
+  "gemini-live": "#3f7fbf",
 
-  // ElevenLabs — orange family (#F39C12). TTS + STT scribe all span light→dark orange.
-  eleven_multilingual_v2: "#F5B041",
-  eleven_flash_v2_5: "#F39C12",
-  eleven_turbo_v2_5: "#E67E22",
-  scribe_v2_realtime: "#CA6F1E",
+  // ElevenLabs — red-orange family. TTS + STT scribe span light→dark orange.
+  eleven_multilingual_v2: "#d68a66",
+  eleven_flash_v2_5: "#c15c3c",
+  eleven_turbo_v2_5: "#a54c31",
+  scribe_v2_realtime: "#8f3f26",
 
-  // xAI — pink family (#EC4899).
-  "grok-tts": "#F472B6",
-  "grok-stt": "#BE185D",
+  // xAI — magenta (purple family).
+  "grok-tts": "#cb7397",
+  "grok-stt": "#7e3251",
 
-  // Cartesia — blue family (#3498DB).
-  "sonic-3": "#85C1E9",
-  "sonic-3.5": "#3498DB",
-  "ink-2": "#1A5276",
+  // Cartesia — blue family (TTS).
+  "sonic-3": "#5b92cd",
+  "sonic-3.5": "#2f6db0",
+  "ink-2": "#1e4b7e",
 
-  // Rime — green family (#27AE60).
-  arcana: "#82E0AA",
-  coda: "#27AE60",
-  mistv3: "#1A7A40",
+  // Rime — green family.
+  arcana: "#85ac56",
+  coda: "#5e8a2e",
+  mistv3: "#43631f",
 
-  // Hume — violet family (#A855F7).
-  "octave-2": "#C084FC",
-  "octave-tts": "#7C3AED",
+  // Hume — purple family (TTS). Sits in the light/mid purple range so it stays
+  // clear of Inworld's dark purples when both appear.
+  "octave-2": "#9376c4",
+  "octave-tts": "#6e51a6",
 
-  // Inworld AI — indigo family (#6366F1).
-  "inworld-tts-1.5-mini": "#818CF8",
-  "inworld-tts-1.5-max": "#4F46E5",
-  "inworld-stt-1": "#6366F1",
+  // Inworld AI — purple family, dark range (separates from Hume in TTS and
+  // AssemblyAI in STT).
+  "inworld-tts-1.5-mini": "#5a417f",
+  "inworld-tts-1.5-max": "#4b356f",
+  "inworld-stt-1": "#3c2b5c",
 
-  // Deepgram — teal family (#16A085). TTS aura anchors the dark end; STT models
-  // span up to light teal. All shades are visibly teal (none near-black).
-  "aura-2-thalia-en": "#0C6654",
-  "nova-2": "#0E8A76",
-  "flux-general-en": "#16A085",
-  "flux-general-multi": "#1EC4A3",
-  "nova-3": "#45D4B5",
+  // Deepgram — green family, teal end. Aura anchors the dark end; STT models
+  // span up to light teal.
+  "aura-2-thalia-en": "#136452",
+  "nova-2": "#17705c",
+  "flux-general-en": "#1f937c",
+  "flux-general-multi": "#2ca386",
+  "nova-3": "#46b39a",
 
-  // AssemblyAI — amethyst family (#8E44AD).
-  "universal-streaming": "#8E44AD",
-  "universal-streaming-multilingual": "#A569BD",
-  "universal-3.5-pro": "#6C3483",
+  // AssemblyAI — purple family (STT), light/mid range.
+  "universal-streaming": "#8168b8",
+  "universal-streaming-multilingual": "#9376c4",
+  "universal-3.5-pro": "#6e51a6",
 
-  // Speechmatics — navy family (#21618C).
-  enhanced: "#2E86C1",
-  default: "#21618C",
+  // Speechmatics — blue family (STT).
+  enhanced: "#3f7fbf",
+  default: "#24598f",
 
-  // Soniox — gold family. The chart's only gold; sits yellower than the
-  // ElevenLabs oranges and dark enough to read on the cream background.
-  "tts-rt-v1": "#C9A227",
-  "stt-rt-v4": "#B8860B",
-  "stt-rt-v5": "#9C7400",
+  // Soniox — gold (red-orange family, yellow end). Reads distinctly warmer than
+  // the ElevenLabs oranges and dark enough for the light surface.
+  "tts-rt-v1": "#c0a03f",
+  "stt-rt-v4": "#9e7b1c",
+  "stt-rt-v5": "#6f5611",
 
   // Composite keys for models whose slug is shared across providers
-  "speechmatics:default": "#21618C",
-  "gradium:default": "#1ABC9C"
+  "speechmatics:default": "#24598f",
+  "gradium:default": "#2ca386"
 };
 
 export const providerColors: Record<string, string> = {
-  OpenAI: "#E74C3C",
-  ElevenLabs: "#F39C12",
-  Cartesia: "#3498DB",
-  Deepgram: "#16A085",
-  AssemblyAI: "#8E44AD",
-  Speechmatics: "#21618C",
-  Rime: "#27AE60",
-  Gradium: "#1ABC9C",
-  Hume: "#A855F7",
-  "Inworld AI": "#6366F1",
-  xAI: "#EC4899",
-  Soniox: "#C9A227",
-  Google: "#4285F4"
+  OpenAI: "#b23a2e",
+  ElevenLabs: "#c15c3c",
+  Cartesia: "#2f6db0",
+  Deepgram: "#1f937c",
+  AssemblyAI: "#6e51a6",
+  Speechmatics: "#24598f",
+  Rime: "#5e8a2e",
+  Gradium: "#2ca386",
+  Hume: "#8168b8",
+  "Inworld AI": "#4b356f",
+  xAI: "#b14a72",
+  Soniox: "#9e7b1c",
+  Google: "#3f7fbf"
 };

--- a/web/lib/utils/chartExport.ts
+++ b/web/lib/utils/chartExport.ts
@@ -90,6 +90,33 @@ function legendRows(
   return rows;
 }
 
+/** Height of one wrapped title line (600 20px). */
+const TITLE_LINE_HEIGHT = 28;
+
+// Greedily wrap `text` into lines that fit `maxWidth` under the caller's current
+// ctx.font. A single word wider than maxWidth stays on its own line (it can't be
+// broken), so callers keep some headroom. Falls back to the whole string.
+function wrapText(
+  ctx: CanvasRenderingContext2D,
+  text: string,
+  maxWidth: number
+): string[] {
+  const words = text.split(/\s+/).filter(Boolean);
+  const lines: string[] = [];
+  let line = "";
+  for (const word of words) {
+    const candidate = line ? `${line} ${word}` : word;
+    if (line && ctx.measureText(candidate).width > maxWidth) {
+      lines.push(line);
+      line = word;
+    } else {
+      line = candidate;
+    }
+  }
+  if (line) lines.push(line);
+  return lines.length ? lines : [text];
+}
+
 const SVG_NS = "http://www.w3.org/2000/svg";
 
 // Label text takes its dot's color so stacked labels stay attributable, but
@@ -177,7 +204,18 @@ export function labelScatterDots(
         clone.appendChild(leader);
       }
     }
-    const [x, y, anchor] = placement ?? candidates[0]!;
+    // Last-resort fallback: no collision-free slot exists, so accept overlap
+    // but keep the label horizontally in-bounds (never clipped at the edge).
+    // Prefer the side with room; else clamp a centered label into the canvas.
+    let fallback: [number, number, string];
+    if (cx + 10 + w <= width - 2) fallback = [cx + 10, cy + 4, "start"];
+    else if (cx - 10 - w >= 2) fallback = [cx - 10, cy + 4, "end"];
+    else if (w >= width - 4)
+      // Label is wider than the plot itself; anchor at the left edge so at least
+      // its start is readable rather than clipping both ends.
+      fallback = [2, cy + 4, "start"];
+    else fallback = [Math.min(Math.max(cx, 2 + w / 2), width - 2 - w / 2), cy + 4, "middle"];
+    const [x, y, anchor] = placement ?? fallback;
     boxes.push(box(x, y, anchor));
     const text = document.createElementNS(SVG_NS, "text");
     text.setAttribute("x", `${x}`);
@@ -243,23 +281,27 @@ export async function downloadChartPNG(
   const measure = canvas.getContext("2d");
   if (!measure) return false;
   const rows = legendRows(measure, header.legend ?? [], width);
-  const titleTextBlock = (header.label ? 20 : 0) + (header.title ? 30 : 0);
-  // On a narrow (mobile) export the left title and right-aligned stat collide,
-  // so stack the stat under the title when they don't fit side by side.
-  let statFitsBeside = true;
+  // Measure the headline stat first so we know how much width it claims.
+  let statW = 0;
   if (header.stat) {
-    measure.font = `600 20px ${FONT}`;
-    const titleW = header.title ? measure.measureText(header.title).width : 0;
     measure.font = `13px ${FONT}`;
-    const leftW = Math.max(
-      titleW,
-      header.label ? measure.measureText(header.label).width : 0
-    );
     const statLabelW = measure.measureText(header.stat.label).width;
     measure.font = `700 24px ui-monospace, SFMono-Regular, Menlo, monospace`;
-    const statW = Math.max(statLabelW, measure.measureText(header.stat.value).width);
-    statFitsBeside = leftW + 16 + statW <= width;
+    statW = Math.max(statLabelW, measure.measureText(header.stat.value).width);
   }
+  // On a narrow (mobile) export the left title and right-aligned stat collide,
+  // so stack the stat under the title when a legible title strip (≥140px) can't
+  // sit beside it. Either way the title WRAPS into the width actually available,
+  // so a long multi-word title wraps instead of running off the canvas edge.
+  const statFitsBeside = header.stat ? statW + 16 + 140 <= width : false;
+  const availableTitleWidth =
+    width - (header.stat && statFitsBeside ? statW + 16 : 0);
+  measure.font = `600 20px ${FONT}`;
+  const titleLines = header.title
+    ? wrapText(measure, header.title, availableTitleWidth)
+    : [];
+  const titleTextBlock =
+    (header.label ? 20 : 0) + titleLines.length * TITLE_LINE_HEIGHT;
   const titleBlock = header.stat
     ? statFitsBeside
       ? Math.max(titleTextBlock, 50)
@@ -300,11 +342,13 @@ export async function downloadChartPNG(
     ctx.fillText(header.label, MARGIN, y + 13);
     y += 20;
   }
-  if (header.title) {
+  if (titleLines.length) {
     ctx.font = `600 20px ${FONT}`;
     ctx.fillStyle = "#0f0c0a";
-    ctx.fillText(header.title, MARGIN, y + 20);
-    y += 30;
+    for (const line of titleLines) {
+      ctx.fillText(line, MARGIN, y + 20);
+      y += TITLE_LINE_HEIGHT;
+    }
   }
   if (header.stat && !statFitsBeside) {
     ctx.font = `13px ${FONT}`;

--- a/web/lib/utils/chartExport.ts
+++ b/web/lib/utils/chartExport.ts
@@ -243,10 +243,28 @@ export async function downloadChartPNG(
   const measure = canvas.getContext("2d");
   if (!measure) return false;
   const rows = legendRows(measure, header.legend ?? [], width);
-  const titleBlock = Math.max(
-    (header.label ? 20 : 0) + (header.title ? 30 : 0),
-    header.stat ? 50 : 0
-  );
+  const titleTextBlock = (header.label ? 20 : 0) + (header.title ? 30 : 0);
+  // On a narrow (mobile) export the left title and right-aligned stat collide,
+  // so stack the stat under the title when they don't fit side by side.
+  let statFitsBeside = true;
+  if (header.stat) {
+    measure.font = `600 20px ${FONT}`;
+    const titleW = header.title ? measure.measureText(header.title).width : 0;
+    measure.font = `13px ${FONT}`;
+    const leftW = Math.max(
+      titleW,
+      header.label ? measure.measureText(header.label).width : 0
+    );
+    const statLabelW = measure.measureText(header.stat.label).width;
+    measure.font = `700 24px ui-monospace, SFMono-Regular, Menlo, monospace`;
+    const statW = Math.max(statLabelW, measure.measureText(header.stat.value).width);
+    statFitsBeside = leftW + 16 + statW <= width;
+  }
+  const titleBlock = header.stat
+    ? statFitsBeside
+      ? Math.max(titleTextBlock, 50)
+      : titleTextBlock + 50
+    : titleTextBlock;
   const headerBlock =
     titleBlock +
     rows.length * LEGEND_ROW_HEIGHT +
@@ -260,19 +278,19 @@ export async function downloadChartPNG(
   const ctx = canvas.getContext("2d");
   if (!ctx) return false;
   ctx.scale(2, 2);
-  ctx.fillStyle = "#ffffff";
+  ctx.fillStyle = "#f9faf8";
   ctx.fillRect(0, 0, totalWidth, totalHeight);
-  ctx.strokeStyle = "#dddbd4";
+  ctx.strokeStyle = "#dbdbd3";
   ctx.lineWidth = 1;
   ctx.strokeRect(0.5, 0.5, totalWidth - 1, totalHeight - 1);
   let y = MARGIN;
-  if (header.stat) {
+  if (header.stat && statFitsBeside) {
     ctx.textAlign = "right";
     ctx.font = `13px ${FONT}`;
     ctx.fillStyle = "#515151";
     ctx.fillText(header.stat.label, totalWidth - MARGIN, y + 13);
     ctx.font = `700 24px ui-monospace, SFMono-Regular, Menlo, monospace`;
-    ctx.fillStyle = "#0a0a0a";
+    ctx.fillStyle = "#0f0c0a";
     ctx.fillText(header.stat.value, totalWidth - MARGIN, y + 44);
     ctx.textAlign = "left";
   }
@@ -284,9 +302,18 @@ export async function downloadChartPNG(
   }
   if (header.title) {
     ctx.font = `600 20px ${FONT}`;
-    ctx.fillStyle = "#0a0a0a";
+    ctx.fillStyle = "#0f0c0a";
     ctx.fillText(header.title, MARGIN, y + 20);
     y += 30;
+  }
+  if (header.stat && !statFitsBeside) {
+    ctx.font = `13px ${FONT}`;
+    ctx.fillStyle = "#515151";
+    ctx.fillText(header.stat.label, MARGIN, y + 13);
+    ctx.font = `700 24px ui-monospace, SFMono-Regular, Menlo, monospace`;
+    ctx.fillStyle = "#0f0c0a";
+    ctx.fillText(header.stat.value, MARGIN, y + 40);
+    y += 50;
   }
   y = MARGIN + titleBlock;
   ctx.font = `12px ${FONT}`;
@@ -295,7 +322,7 @@ export async function downloadChartPNG(
       ctx.globalAlpha = item.dimmed ? 0.35 : 1;
       ctx.fillStyle = item.color;
       ctx.fillRect(MARGIN + item.x, y + 5, 12, 12);
-      ctx.fillStyle = "#0a0a0a";
+      ctx.fillStyle = "#0f0c0a";
       ctx.fillText(item.label, MARGIN + item.x + 18, y + 15);
     }
     y += LEGEND_ROW_HEIGHT;

--- a/web/lib/utils/colors.ts
+++ b/web/lib/utils/colors.ts
@@ -82,6 +82,17 @@ function shiftLightness(hex: string, amt: number): string {
   return `#${ch(0)}${ch(2)}${ch(4)}`;
 }
 
+// Bare slugs that appear under more than one provider (via "provider:model"
+// composite keys in modelColors), e.g. "default" for both Speechmatics and
+// Gradium. For these the bare-slug entry belongs to one specific provider, so a
+// composite key for a DIFFERENT provider must not borrow it — it should fall
+// through to that provider's hue family instead.
+const sharedSlugs = new Set(
+  Object.keys(modelColors)
+    .filter((key) => key.includes(":"))
+    .map((key) => key.slice(key.indexOf(":") + 1))
+);
+
 /**
  * Get color for a model. Accepts both bare slugs ("default") and composite
  * "provider:model" keys ("speechmatics:default"). Composite keys are tried
@@ -97,7 +108,10 @@ function shiftLightness(hex: string, amt: number): string {
 export function getModelColor(modelKey: string): string {
   if (modelColors[modelKey]) return modelColors[modelKey];
   const { provider, model } = parseModelKey(modelKey);
-  if (modelColors[model]) return modelColors[model];
+  // Skip the bare-slug entry for a composite key whose slug is shared across
+  // providers — it belongs to another provider; use the hue family below.
+  if (modelColors[model] && !(provider && sharedSlugs.has(model)))
+    return modelColors[model];
 
   if (provider) {
     const base = providerColors[providerDisplayFromId(provider)];

--- a/web/lib/utils/colors.ts
+++ b/web/lib/utils/colors.ts
@@ -9,45 +9,23 @@ import { modelColors, providerColors } from '../config/colors';
 import { parseModelKey } from './formatters';
 
 /**
- * Fallback colors for models/providers not in the predefined color maps
+ * Fallback colors for models/providers not in the predefined color maps.
+ * The 10 validated pastel-leaning categorical anchors (blue, amber, purple,
+ * teal, peach, indigo, green, rose, sky, lime), in a fixed order chosen for
+ * adjacent colorblind separation. Used only when a model/provider isn't in the
+ * predefined maps.
  */
-const fallbackModelColors = [
-  "#2f6db0",
-  "#1f937c",
-  "#c15c3c",
-  "#6e51a6",
-  "#5e8a2e",
-  "#b14a72",
-  "#9e7b1c",
-  "#b23a2e",
-  "#5b92cd",
-  "#46b39a",
-  "#d68a66",
-  "#9376c4",
-  "#85ac56",
-  "#cb7397",
-  "#c0a03f",
-  "#cf6357",
-  "#1e4b7e",
-  "#136452"
-];
-
-/**
- * Fallback colors for providers not in the predefined color map
- */
-const fallbackProviderColors = [
-  "#2f6db0",
-  "#1f937c",
-  "#c15c3c",
-  "#6e51a6",
-  "#5e8a2e",
-  "#b14a72",
-  "#9e7b1c",
-  "#b23a2e",
-  "#5b92cd",
-  "#46b39a",
-  "#d68a66",
-  "#9376c4"
+const fallbackColors = [
+  "#70a6f5",
+  "#dea645",
+  "#c289e4",
+  "#3cc3ab",
+  "#f78e64",
+  "#9792ec",
+  "#77c46f",
+  "#ec79a8",
+  "#59b7e4",
+  "#a9bd40"
 ];
 
 /**
@@ -65,18 +43,73 @@ function hashCode(str: string): number {
   return hash;
 }
 
+// Raw provider ids whose display name isn't a plain title-case of the slug.
+// Everything else title-cases ("google" → "Google", "smallest" → "Smallest").
+const PROVIDER_ID_ALIASES: Record<string, string> = {
+  assemblyai: "AssemblyAI",
+  elevenlabs: "ElevenLabs",
+  openai: "OpenAI",
+  xai: "xAI",
+  inworld: "Inworld AI",
+};
+
+/** Map a raw provider id (from a "provider:model" key) to its providerColors key. */
+function providerDisplayFromId(id: string): string {
+  const lower = id.toLowerCase();
+  if (PROVIDER_ID_ALIASES[lower]) return PROVIDER_ID_ALIASES[lower];
+  return lower
+    .split(/[-_\s]+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+/**
+ * Shift an sRGB hex toward white (amt > 0) or black (amt < 0) by |amt|, keeping
+ * hue. Used to give a provider's unmapped models slightly different shades so
+ * siblings stay distinguishable without leaving the family.
+ */
+function shiftLightness(hex: string, amt: number): string {
+  const h = hex.replace("#", "");
+  const target = amt >= 0 ? 255 : 0;
+  const t = Math.abs(amt);
+  const ch = (i: number) => {
+    const c = parseInt(h.slice(i, i + 2), 16);
+    return Math.round(c + (target - c) * t)
+      .toString(16)
+      .padStart(2, "0");
+  };
+  return `#${ch(0)}${ch(2)}${ch(4)}`;
+}
+
 /**
  * Get color for a model. Accepts both bare slugs ("default") and composite
  * "provider:model" keys ("speechmatics:default"). Composite keys are tried
  * first so that same-slug models across different providers can have distinct
- * colors; the hash fallback uses the full key for uniqueness.
+ * colors.
+ *
+ * When a model isn't in the explicit map it inherits its PROVIDER's hue family
+ * (with a small deterministic shade offset per model) rather than a random hash
+ * color. This keeps a provider's models visually together — a newly added model
+ * lands in the right family automatically, no per-model entry required. Only a
+ * model whose provider is also unknown falls through to the neutral hash ramp.
  */
 export function getModelColor(modelKey: string): string {
   if (modelColors[modelKey]) return modelColors[modelKey];
-  const { model } = parseModelKey(modelKey);
+  const { provider, model } = parseModelKey(modelKey);
   if (modelColors[model]) return modelColors[model];
+
+  if (provider) {
+    const base = providerColors[providerDisplayFromId(provider)];
+    if (base) {
+      // Deterministic per-model shade within the family: lighten/darken/keep.
+      const step = ((Math.abs(hashCode(model)) % 3) - 1) * 0.16; // -0.16 | 0 | +0.16
+      return step === 0 ? base : shiftLightness(base, step);
+    }
+  }
+
   const hash = hashCode(modelKey);
-  return fallbackModelColors[Math.abs(hash) % fallbackModelColors.length] ?? "#2f6db0";
+  return fallbackColors[Math.abs(hash) % fallbackColors.length] ?? "#70a6f5";
 }
 
 /**
@@ -90,7 +123,7 @@ export function getProviderColor(provider: string): string {
   }
 
   const hash = hashCode(provider);
-  return fallbackProviderColors[Math.abs(hash) % fallbackProviderColors.length] ?? "#2f6db0";
+  return fallbackColors[Math.abs(hash) % fallbackColors.length] ?? "#70a6f5";
 }
 
 /**

--- a/web/lib/utils/colors.ts
+++ b/web/lib/utils/colors.ts
@@ -12,42 +12,42 @@ import { parseModelKey } from './formatters';
  * Fallback colors for models/providers not in the predefined color maps
  */
 const fallbackModelColors = [
-  "#E74C3C",
-  "#F39C12",
-  "#3498DB",
-  "#2ECC71",
-  "#9B59B6",
-  "#E67E22",
-  "#1ABC9C",
-  "#95A5A6",
-  "#34495E",
-  "#E91E63",
-  "#FF9800",
-  "#4CAF50",
-  "#673AB7",
-  "#FF5722",
-  "#607D8B",
-  "#795548",
-  "#009688",
-  "#FFC107"
+  "#2f6db0",
+  "#1f937c",
+  "#c15c3c",
+  "#6e51a6",
+  "#5e8a2e",
+  "#b14a72",
+  "#9e7b1c",
+  "#b23a2e",
+  "#5b92cd",
+  "#46b39a",
+  "#d68a66",
+  "#9376c4",
+  "#85ac56",
+  "#cb7397",
+  "#c0a03f",
+  "#cf6357",
+  "#1e4b7e",
+  "#136452"
 ];
 
 /**
  * Fallback colors for providers not in the predefined color map
  */
 const fallbackProviderColors = [
-  "#8BC34A",
-  "#CDDC39",
-  "#FFEB3B",
-  "#FF4081",
-  "#7C4DFF",
-  "#448AFF",
-  "#40E0D0",
-  "#DA70D6",
-  "#98FB98",
-  "#F0E68C",
-  "#DDA0DD",
-  "#87CEEB"
+  "#2f6db0",
+  "#1f937c",
+  "#c15c3c",
+  "#6e51a6",
+  "#5e8a2e",
+  "#b14a72",
+  "#9e7b1c",
+  "#b23a2e",
+  "#5b92cd",
+  "#46b39a",
+  "#d68a66",
+  "#9376c4"
 ];
 
 /**
@@ -76,7 +76,7 @@ export function getModelColor(modelKey: string): string {
   const { model } = parseModelKey(modelKey);
   if (modelColors[model]) return modelColors[model];
   const hash = hashCode(modelKey);
-  return fallbackModelColors[Math.abs(hash) % fallbackModelColors.length] ?? "#E74C3C";
+  return fallbackModelColors[Math.abs(hash) % fallbackModelColors.length] ?? "#2f6db0";
 }
 
 /**
@@ -90,7 +90,7 @@ export function getProviderColor(provider: string): string {
   }
 
   const hash = hashCode(provider);
-  return fallbackProviderColors[Math.abs(hash) % fallbackProviderColors.length] ?? "#8BC34A";
+  return fallbackProviderColors[Math.abs(hash) % fallbackProviderColors.length] ?? "#2f6db0";
 }
 
 /**
@@ -104,5 +104,5 @@ export function getReadableTextColor(hex: string): string {
     return c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4;
   };
   const luminance = 0.2126 * channel(0) + 0.7152 * channel(2) + 0.0722 * channel(4);
-  return luminance > 0.179 ? "#0a0a0a" : "#ffffff";
+  return luminance > 0.179 ? "#0f0c0a" : "#ffffff";
 }

--- a/web/lib/utils/facets.ts
+++ b/web/lib/utils/facets.ts
@@ -130,13 +130,18 @@ export function buildFacetGroups(
         const label = provider_valued ? normalizeProvider(value) : valueLabel;
         let color: string | undefined;
         if (provider_valued) {
-          const repKey = visibleKeys.find((key) =>
-            (tagIndex.get(key) ?? []).some((t) => t.category === category && t.value === value)
-          );
           // Chip follows the chart: derive the host chip from the color of one
           // of its visible models so the sidebar can never drift from the
-          // series colors. providerColors is only a fallback when no model of
-          // the host is currently visible.
+          // series colors. Match the same predicate as `count` (including the
+          // other active facets) so the representative model is one that's
+          // actually visible. providerColors is only a fallback when none is.
+          const repKey = visibleKeys.find((key) => {
+            const tags = tagIndex.get(key) ?? [];
+            return (
+              tags.some((t) => t.category === category && t.value === value) &&
+              matchesSelection(tags, others)
+            );
+          });
           color = (repKey ? getModelColor(repKey) : undefined) ?? providerColors[label];
         }
         return {

--- a/web/lib/utils/facets.ts
+++ b/web/lib/utils/facets.ts
@@ -133,7 +133,11 @@ export function buildFacetGroups(
           const repKey = visibleKeys.find((key) =>
             (tagIndex.get(key) ?? []).some((t) => t.category === category && t.value === value)
           );
-          color = providerColors[label] ?? (repKey ? getModelColor(repKey) : undefined);
+          // Chip follows the chart: derive the host chip from the color of one
+          // of its visible models so the sidebar can never drift from the
+          // series colors. providerColors is only a fallback when no model of
+          // the host is currently visible.
+          color = (repKey ? getModelColor(repKey) : undefined) ?? providerColors[label];
         }
         return {
           value,


### PR DESCRIPTION
Rebrands the benchmarks web app to the [Coval brand guidelines](https://brand-woad-rho.vercel.app/) and fixes mobile layout issues in chart section headers and PNG exports. Frontend-only; no backend/API/auth/env/deploy changes.

<img width="957" height="656" alt="Screenshot 2026-07-09 at 10 13 56 AM" src="https://github.com/user-attachments/assets/06e1f317-bbf4-4ae6-ab8c-908caf60c69d" />

Before
<img width="1486" height="775" alt="Screenshot 2026-07-08 at 9 35 58 PM" src="https://github.com/user-attachments/assets/af1cfa3a-8c1c-4542-af79-48ae18f78ed1" />

## Color
- **Neutrals** snapped to exact brand hex — White `#f9faf8`, Paper `#dbdbd3`, Graphite `#7f7a76`, Ink `#0f0c0a` — across `globals.css`, `useThemeColors`, and the PNG-export chrome. (They were already a near-identical warm "cream"; this makes them exact.)
- **Accent tokens** re-anchored on the brand blue / green / red-orange / purple families.
- **Chart series** (`config/colors.ts` + fallbacks) remapped onto a brand-anchored categorical palette, keeping the app's **vendor = hue family, model = shade** structure. The brand defines only 4 hue families but a modality shows ~10 vendors, so each family is expanded into legible mid-tones — **8 hue anchors, validated for colorblind separation** (worst adjacent ΔE 15.8) on the light surface. Where a modality overloads a family, the two vendors sit in opposite shade ranges (legend / tooltip / export labels disambiguate).
- Model-comparison score bar + slider moved off green (reads as "positive") to neutral brand blue.

Fonts were already on-brand (PP Mori + Geist Mono) — no type changes.

## Mobile
- `SectionHeader` stacks the title + download buttons above the stat below the `sm` breakpoint, instead of cramming a fixed `w-3/4` column against a right-aligned stat — was squishing/overflowing.
- PNG export stacks the stat under the title when they don't fit side by side, fixing the header overlap on narrow mobile exports.

## Playground
- Swapped the last non-token light-mode colors onto brand tokens (unselected pill text → graphite, recording dot + STT error → `accent-rust`). It otherwise already inherits the rebranded tokens and shared `getModelColor`/`getProviderColor`.

## Verification
- `pnpm lint` (0 warnings), `pnpm typecheck`, `pnpm test` (53 passing) all green.
- Verified live on `localhost:3001`: overview / TTS dashboards, mobile section headers, a real mobile PNG export (header no longer overlaps), and the playground.

## Known minor (not addressed here)
- Far-right scatter labels can clip (`Multilingual v2` → `Mul`) at very narrow PNG export widths — pre-existing, not a regression. Can fold edge labels inward in a follow-up if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR rebrands the benchmarks web app to match Coval's exact brand hex tokens and fixes two mobile layout issues. All changes are frontend-only with no API, auth, env, or data-layer impact.

- **Color tokens**: All neutral and accent CSS variables in `globals.css`, `useThemeColors`, and canvas drawing code in `chartExport.ts` are snapped to exact brand hex values (e.g. `#fdfcf8` → `#f9faf8`, `#0a0a0a` → `#0f0c0a`). Vendor chart series colors are remapped onto a brand-anchored categorical palette in `config/colors.ts`, and the fallback ramp in `colors.ts` is consolidated to a single brand-aligned array shared by both model and provider lookups.
- **Mobile layout**: `SectionHeader` and its skeleton mirror now use `flex-col sm:flex-row` to stack the title block above the stat on narrow viewports instead of cramming both into a fixed-width row. `chartExport.ts` applies the same stacking logic to PNG exports by measuring the stat width and wrapping the title into available space.
- **Timeline legend**: The recharts `<Legend>` is removed from inside the chart and re-rendered as a sibling element below it (wrapped in `[data-chart-legend]`), preventing a large multi-series legend from consuming the plot area on mobile. The export selector in `SectionHeader` is extended to find legend items under either selector.

<h3>Confidence Score: 5/5</h3>

Safe to merge — pure frontend restyling and mobile layout fixes with no backend, API, or data-layer changes.

Every change is confined to color token values, Tailwind layout classes, and canvas drawing logic. The brand hex updates are consistent across all three layers they touch (CSS variables, the JS useThemeColors mirror, and the canvas export). The mobile stacking logic in both the live component and the PNG export is correctly height-accounted. The timeline legend externalization correctly wraps the component with a data-chart-legend attribute so the existing export query-selector picks it up. No regressions to data flow, routing, or API contracts are possible from these changes.

No files require special attention.

<sub>Reviews (4): Last reviewed commit: ["Address review: shared-slug color fallba..."](https://github.com/coval-ai/benchmarks/commit/6b0aa25ae2202c29c8747867e595cb27c3982863) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42922907)</sub>

<!-- /greptile_comment -->