### PR TITLE
Add Azure AI Speech real-time STT provider (BENCH-328)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,3 +36,7 @@ SONIOX_API_KEY=
 # --- Google STT (optional; requires the `google-stt` extra) ---
 # GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json
 # GOOGLE_PROJECT_ID=
+
+# --- Azure AI Speech STT (subscription key + region of the Speech resource) ---
+# AZURE_API_KEY=
+# AZURE_REGION=eastus

--- a/runner/src/coval_bench/__main__.py
+++ b/runner/src/coval_bench/__main__.py
@@ -254,6 +254,8 @@ def stt_smoke(provider: str, model: str, wav: str) -> None:
         kwargs["project_id"] = settings.google_project_id
     elif provider == "baseten":
         kwargs["ws_url"] = settings.baseten_whisper_url
+    elif provider == "azure":
+        kwargs["region"] = settings.azure_region
     instance = provider_cls(**kwargs)
 
     with wave.open(wav, "rb") as w:

--- a/runner/src/coval_bench/config.py
+++ b/runner/src/coval_bench/config.py
@@ -78,6 +78,11 @@ class Settings(BaseSettings):
     inworld_api_key: SecretStr | None = None
     soniox_api_key: SecretStr | None = None
     baseten_api_key: SecretStr | None = None
+    azure_api_key: SecretStr | None = None
+
+    # Azure region hosting the Speech resource (e.g. "eastus"). Determines the
+    # region-scoped WebSocket host; required only when the Azure STT provider runs.
+    azure_region: str | None = None
 
     # Baseten dedicated-endpoint WebSocket URLs. The hostnames embed private,
     # pre-launch model ids, so they live in config (``.env`` locally, Secret

--- a/runner/src/coval_bench/providers/stt/__init__.py
+++ b/runner/src/coval_bench/providers/stt/__init__.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 from coval_bench.providers.base import STTProvider
 from coval_bench.providers.stt.assemblyai import AssemblyAIProvider
+from coval_bench.providers.stt.azure import AzureSTTProvider
 from coval_bench.providers.stt.baseten import BasetenSTTProvider
 from coval_bench.providers.stt.cartesia import CartesiaSTTProvider
 from coval_bench.providers.stt.deepgram import DeepgramProvider
@@ -43,6 +44,7 @@ STT_PROVIDERS: dict[str, type[STTProvider]] = {
     "deepgram": DeepgramProvider,
     "cartesia": CartesiaSTTProvider,
     "assemblyai": AssemblyAIProvider,
+    "azure": AzureSTTProvider,
     "baseten": BasetenSTTProvider,
     "elevenlabs": ElevenLabsSTTProvider,
     "gladia": GladiaSTTProvider,
@@ -65,6 +67,7 @@ __all__ = [
     "DeepgramProvider",
     "CartesiaSTTProvider",
     "AssemblyAIProvider",
+    "AzureSTTProvider",
     "BasetenSTTProvider",
     "ElevenLabsSTTProvider",
     "GladiaSTTProvider",

--- a/runner/src/coval_bench/providers/stt/azure.py
+++ b/runner/src/coval_bench/providers/stt/azure.py
@@ -1,0 +1,286 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Microsoft Azure AI Speech real-time STT provider.
+
+Drives the Speech WebSocket protocol directly, not the Speech SDK: the SDK adds
+seconds of event-delivery overhead that would inflate latency vs. other providers.
+
+Endpoint: wss://{region}.stt.speech.microsoft.com/speech/recognition/conversation
+/cognitiveservices/v1. Auth: Ocp-Apim-Subscription-Key header. Client text frames
+are a header block + JSON body; audio frames are a 2-byte big-endian header length,
+header, then payload; an empty payload ends the stream. Conversation mode is
+continuous, so the transcript concatenates every speech.phrase final until turn.end.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import struct
+import time  # monotonic clock — wall-clock can step on NTP sync
+import uuid
+from datetime import UTC, datetime
+from typing import Any
+
+import structlog
+import websockets.asyncio.client as ws_client
+from pydantic import SecretStr
+
+from coval_bench.providers.base import STTProvider, TranscriptionResult
+from coval_bench.providers.stt._pacing import paced_chunks
+from coval_bench.providers.stt._transcript_utils import (
+    add_partial_transcript,
+    set_first_token,
+)
+
+logger = structlog.get_logger(__name__)
+
+# conversation mode keeps recognizing across pauses; interactive stops at the first.
+_WS_PATH = "/speech/recognition/conversation/cognitiveservices/v1"
+_LANGUAGE = "en-US"
+
+_SPEECH_CONFIG = {
+    "context": {
+        "system": {"name": "coval-bench", "version": "1.0"},
+        "os": {"platform": "Linux", "name": "Linux", "version": "1.0"},
+    }
+}
+
+
+class AzureSTTProvider(STTProvider):
+    """Azure AI Speech real-time streaming STT provider (raw WebSocket)."""
+
+    _VALID_MODELS = frozenset({"default"})
+
+    def __init__(
+        self,
+        api_key: SecretStr,
+        model: str = "default",
+        region: str | None = None,
+    ) -> None:
+        if not self._model_supported(model):
+            raise ValueError(f"Invalid Azure model {model!r}. Valid: {sorted(self._VALID_MODELS)}")
+        if region is None:
+            raise ValueError("AzureSTTProvider requires region (set Settings.azure_region)")
+        self._api_key = api_key
+        self._model = model
+        self._region = region
+
+    @property
+    def name(self) -> str:
+        return "azure"
+
+    @property
+    def model(self) -> str:
+        return self._model
+
+    def _build_websocket_url(self) -> str:
+        return (
+            f"wss://{self._region}.stt.speech.microsoft.com{_WS_PATH}"
+            f"?language={_LANGUAGE}&format=detailed"
+        )
+
+    async def measure_ttft(
+        self,
+        audio_data: bytes,
+        channels: int,
+        sample_width: int,
+        sample_rate: int,
+        realtime_resolution: float = 0.1,
+    ) -> TranscriptionResult:
+        result = TranscriptionResult(provider=self.name, vad_events_count=0)
+        total_start = time.monotonic()
+
+        try:
+            url = self._build_websocket_url()
+            request_id = uuid.uuid4().hex
+            headers = {
+                "Ocp-Apim-Subscription-Key": self._api_key.get_secret_value(),
+                "X-ConnectionId": uuid.uuid4().hex,
+            }
+            async with ws_client.connect(url, additional_headers=headers) as ws:
+                await ws.send(_text_message("speech.config", json.dumps(_SPEECH_CONFIG)))
+                send_task = asyncio.create_task(
+                    self._send_audio(
+                        ws,
+                        audio_data,
+                        channels,
+                        sample_width,
+                        sample_rate,
+                        result,
+                        realtime_resolution,
+                        request_id,
+                    )
+                )
+                recv_task = asyncio.create_task(self._receive(ws, result))
+                tasks = (send_task, recv_task)
+                done, pending = await asyncio.wait(tasks, return_when=asyncio.FIRST_EXCEPTION)
+                if any(not task.cancelled() and task.exception() is not None for task in done):
+                    for task in pending:
+                        task.cancel()
+                outcomes = await asyncio.gather(*tasks, return_exceptions=True)
+                if result.error is None and result.audio_to_final_seconds is None:
+                    for outcome in outcomes:
+                        if isinstance(outcome, Exception):
+                            result.error = str(outcome)
+                            break
+
+        except Exception as exc:
+            logger.warning(
+                "azure_measure_ttft_failed", provider="azure", model=self._model, exc_info=exc
+            )
+            result.error = str(exc)
+
+        result.total_time = time.monotonic() - total_start
+        return result
+
+    async def _send_audio(
+        self,
+        ws: Any,
+        audio_data: bytes,
+        channels: int,
+        sample_width: int,
+        sample_rate: int,
+        result: TranscriptionResult,
+        realtime_resolution: float,
+        request_id: str,
+    ) -> None:
+        # Payloads are concatenated server-side, so the RIFF header prefixes the PCM.
+        stream = _wav_header(sample_rate, channels, sample_width) + audio_data
+        byte_rate = sample_width * sample_rate * channels
+        chunk_size = int(byte_rate * realtime_resolution)
+        try:
+            async for chunk, start in paced_chunks(stream, chunk_size, byte_rate):
+                result.audio_start_time = start
+                await ws.send(_audio_message(request_id, chunk))
+            await ws.send(_audio_message(request_id, b""))  # empty payload = end of stream
+        except Exception as exc:
+            logger.warning("azure_send_error", provider="azure", model=self._model, exc_info=exc)
+            raise
+
+    async def _receive(self, ws: Any, result: TranscriptionResult) -> None:
+        final_segments: list[str] = []
+        last_final_time: float | None = None
+
+        try:
+            async for raw in ws:
+                if isinstance(raw, bytes):
+                    continue
+
+                path, body = _parse_message(raw)
+                now = time.monotonic()
+
+                if path == "speech.startdetected":
+                    if result.audio_start_time is not None and result.vad_first_detected is None:
+                        result.vad_first_detected = now - result.audio_start_time
+                        result.vad_first_event_content = str(body)
+                    result.vad_events_count = (result.vad_events_count or 0) + 1
+                    continue
+
+                if path == "speech.hypothesis":
+                    transcript = str(body.get("Text", "")).strip()
+                    if transcript:
+                        set_first_token(result, transcript, now=now)
+                        add_partial_transcript(result, transcript)
+                    continue
+
+                if path == "speech.phrase":
+                    if body.get("RecognitionStatus") != "Success":
+                        continue
+                    transcript = _phrase_text(body)
+                    if not transcript:
+                        continue
+                    set_first_token(result, transcript, now=now)
+                    add_partial_transcript(result, transcript)
+                    final_segments.append(transcript)
+                    last_final_time = now
+                    continue
+
+                if path == "turn.end":
+                    break
+
+        except Exception as exc:
+            logger.warning("azure_receive_error", provider="azure", model=self._model, exc_info=exc)
+            if result.error is None and last_final_time is None:
+                result.error = str(exc)
+
+        if last_final_time is not None and result.audio_start_time is not None:
+            result.audio_to_final_seconds = last_final_time - result.audio_start_time
+
+        # Only finalized phrases are scored; unfinalized hypotheses stay out.
+        if final_segments:
+            result.complete_transcript = " ".join(final_segments).strip() or None
+        if result.complete_transcript:
+            result.transcript_length = len(result.complete_transcript)
+            result.word_count = len(result.complete_transcript.split())
+
+
+# ---------------------------------------------------------------------------
+# Wire-format helpers
+# ---------------------------------------------------------------------------
+
+
+def _timestamp() -> str:
+    now = datetime.now(UTC)
+    return now.strftime("%Y-%m-%dT%H:%M:%S.") + f"{now.microsecond // 1000:03d}Z"
+
+
+def _text_message(path: str, body: str) -> str:
+    header = f"Path:{path}\r\nX-Timestamp:{_timestamp()}\r\nContent-Type:application/json\r\n"
+    return f"{header}\r\n{body}"
+
+
+def _audio_message(request_id: str, payload: bytes) -> bytes:
+    header = (
+        f"Path:audio\r\nX-RequestId:{request_id}\r\n"
+        f"X-Timestamp:{_timestamp()}\r\nContent-Type:audio/x-wav\r\n"
+    ).encode("ascii")
+    return struct.pack(">H", len(header)) + header + payload
+
+
+def _parse_message(raw: str) -> tuple[str, dict[str, Any]]:
+    """Split a server text frame into (lowercased Path, JSON body)."""
+    head, _, body = raw.partition("\r\n\r\n")
+    path = ""
+    for line in head.split("\r\n"):
+        name, _, value = line.partition(":")
+        if name.strip().lower() == "path":
+            path = value.strip().lower()
+            break
+    try:
+        data: dict[str, Any] = json.loads(body) if body.strip() else {}
+    except json.JSONDecodeError:
+        data = {}
+    return path, data
+
+
+def _phrase_text(body: dict[str, Any]) -> str:
+    """Best display text from a speech.phrase body (detailed NBest or simple)."""
+    nbest = body.get("NBest")
+    if isinstance(nbest, list) and nbest:
+        first = nbest[0]
+        if isinstance(first, dict):
+            return str(first.get("Display", "") or first.get("Lexical", "")).strip()
+    return str(body.get("DisplayText", "")).strip()
+
+
+def _wav_header(sample_rate: int, channels: int, sample_width: int) -> bytes:
+    """44-byte PCM WAV header. Sizes are 0: the service streams and ignores them."""
+    byte_rate = sample_rate * channels * sample_width
+    block_align = channels * sample_width
+    return (
+        b"RIFF"
+        + struct.pack("<I", 0)
+        + b"WAVE"
+        + b"fmt "
+        + struct.pack("<I", 16)
+        + struct.pack("<H", 1)  # PCM
+        + struct.pack("<H", channels)
+        + struct.pack("<I", sample_rate)
+        + struct.pack("<I", byte_rate)
+        + struct.pack("<H", block_align)
+        + struct.pack("<H", sample_width * 8)
+        + b"data"
+        + struct.pack("<I", 0)
+    )

--- a/runner/src/coval_bench/providers/stt/azure.py
+++ b/runner/src/coval_bench/providers/stt/azure.py
@@ -63,6 +63,8 @@ class AzureSTTProvider(STTProvider):
             raise ValueError(f"Invalid Azure model {model!r}. Valid: {sorted(self._VALID_MODELS)}")
         if region is None:
             raise ValueError("AzureSTTProvider requires region (set Settings.azure_region)")
+        if api_key is None:
+            raise ValueError("AzureSTTProvider requires api_key (set Settings.azure_api_key)")
         self._api_key = api_key
         self._model = model
         self._region = region
@@ -152,7 +154,8 @@ class AzureSTTProvider(STTProvider):
         chunk_size = int(byte_rate * realtime_resolution)
         try:
             async for chunk, start in paced_chunks(stream, chunk_size, byte_rate):
-                result.audio_start_time = start
+                if result.audio_start_time is None:
+                    result.audio_start_time = start
                 await ws.send(_audio_message(request_id, chunk))
             await ws.send(_audio_message(request_id, b""))  # empty payload = end of stream
         except Exception as exc:

--- a/runner/src/coval_bench/providers/stt/azure.py
+++ b/runner/src/coval_bench/providers/stt/azure.py
@@ -207,16 +207,18 @@ class AzureSTTProvider(STTProvider):
             logger.warning("azure_receive_error", provider="azure", model=self._model, exc_info=exc)
             if result.error is None and last_final_time is None:
                 result.error = str(exc)
+        finally:
+            # In `finally` so a cancellation (BaseException, not caught above) when
+            # send fails still commits any finals already received.
+            if last_final_time is not None and result.audio_start_time is not None:
+                result.audio_to_final_seconds = last_final_time - result.audio_start_time
 
-        if last_final_time is not None and result.audio_start_time is not None:
-            result.audio_to_final_seconds = last_final_time - result.audio_start_time
-
-        # Only finalized phrases are scored; unfinalized hypotheses stay out.
-        if final_segments:
-            result.complete_transcript = " ".join(final_segments).strip() or None
-        if result.complete_transcript:
-            result.transcript_length = len(result.complete_transcript)
-            result.word_count = len(result.complete_transcript.split())
+            # Only finalized phrases are scored; unfinalized hypotheses stay out.
+            if final_segments:
+                result.complete_transcript = " ".join(final_segments).strip() or None
+            if result.complete_transcript:
+                result.transcript_length = len(result.complete_transcript)
+                result.word_count = len(result.complete_transcript.split())
 
 
 # ---------------------------------------------------------------------------

--- a/runner/src/coval_bench/registries/models.py
+++ b/runner/src/coval_bench/registries/models.py
@@ -271,6 +271,15 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         self_hostable=True,
         status=_PENDING,
     ),
+    # Azure AI Speech real-time (raw WebSocket, conversation mode).
+    RegisteredModel(
+        benchmark=_STT,
+        provider="azure",
+        model="default",
+        creator="microsoft",
+        tags=(_REALTIME, _MULTI, _VAD),
+        status=_ACTIVE,
+    ),
     RegisteredModel(
         benchmark=_STT,
         provider="google",

--- a/runner/src/coval_bench/runner/orchestrator.py
+++ b/runner/src/coval_bench/runner/orchestrator.py
@@ -256,6 +256,8 @@ async def _run_stt_item(
             kwargs["project_id"] = settings.google_project_id
         elif entry.provider == "baseten":
             kwargs["ws_url"] = settings.baseten_whisper_url
+        elif entry.provider == "azure":
+            kwargs["region"] = settings.azure_region
         provider = provider_cls(**kwargs)
 
         audio_path: Path = item.path

--- a/runner/tests/providers/stt/test_azure.py
+++ b/runner/tests/providers/stt/test_azure.py
@@ -256,3 +256,8 @@ def test_invalid_model_raises() -> None:
 def test_missing_region_raises() -> None:
     with pytest.raises(ValueError, match="requires region"):
         AzureSTTProvider(api_key=SecretStr("k"))
+
+
+def test_missing_api_key_raises() -> None:
+    with pytest.raises(ValueError, match="requires api_key"):
+        AzureSTTProvider(api_key=None, region=REGION)  # type: ignore[arg-type]

--- a/runner/tests/providers/stt/test_azure.py
+++ b/runner/tests/providers/stt/test_azure.py
@@ -9,14 +9,17 @@ built with the Azure header-block framing (``Path:...\\r\\n...\\r\\n\\r\\n<json>
 
 from __future__ import annotations
 
+import asyncio
 import json
 import struct
+import time
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from pydantic import SecretStr
 
+from coval_bench.providers.base import TranscriptionResult
 from coval_bench.providers.stt.azure import (
     AzureSTTProvider,
     _audio_message,
@@ -165,6 +168,35 @@ async def test_azure_empty_stream(audio_pcm_bytes: bytes) -> None:
     result = await _run(make_provider(), [], audio_pcm_bytes)
     assert result.complete_transcript is None
     assert result.ttft_seconds is None
+
+
+class _CancelAfterEvents:
+    """Async-iterable WS fake that replays events, then raises CancelledError."""
+
+    def __init__(self, events: list[str]) -> None:
+        self._events = list(events)
+
+    def __aiter__(self) -> _CancelAfterEvents:
+        return self
+
+    async def __anext__(self) -> str:
+        if self._events:
+            return self._events.pop(0)
+        raise asyncio.CancelledError
+
+
+@pytest.mark.asyncio
+async def test_azure_receive_commits_finals_on_cancellation() -> None:
+    """A cancellation after a final still commits the transcript (finally block)."""
+    result = TranscriptionResult(provider="azure")
+    result.audio_start_time = time.monotonic()
+    ws = _CancelAfterEvents([_frame("speech.phrase", _phrase("hello world"))])
+
+    with pytest.raises(asyncio.CancelledError):
+        await make_provider()._receive(ws, result)
+
+    assert result.complete_transcript == "hello world"
+    assert result.audio_to_final_seconds is not None
 
 
 # ---------------------------------------------------------------------------

--- a/runner/tests/providers/stt/test_azure.py
+++ b/runner/tests/providers/stt/test_azure.py
@@ -1,0 +1,258 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for coval_bench.providers.stt.azure (AzureSTTProvider).
+
+All tests use FakeWebSocket — no live network calls are made. Server frames are
+built with the Azure header-block framing (``Path:...\\r\\n...\\r\\n\\r\\n<json>``).
+"""
+
+from __future__ import annotations
+
+import json
+import struct
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pydantic import SecretStr
+
+from coval_bench.providers.stt.azure import (
+    AzureSTTProvider,
+    _audio_message,
+    _parse_message,
+    _wav_header,
+)
+from tests.providers.stt.conftest import FakeWebSocket
+
+REGION = "eastus"
+
+
+def make_provider(model: str = "default") -> AzureSTTProvider:
+    return AzureSTTProvider(api_key=SecretStr("test-key-azure"), model=model, region=REGION)
+
+
+def _frame(path: str, body: dict[str, Any] | None = None) -> str:
+    """Frame a server text message the way Azure sends them."""
+    header = f"X-RequestId:req-1\r\nContent-Type:application/json\r\nPath:{path}\r\n"
+    return header + "\r\n" + (json.dumps(body) if body is not None else "")
+
+
+def _phrase(text: str, status: str = "Success") -> dict[str, Any]:
+    return {
+        "RecognitionStatus": status,
+        "Offset": 0,
+        "Duration": 1000,
+        "NBest": [{"Confidence": 0.95, "Lexical": text.lower(), "Display": text}],
+    }
+
+
+def _fake_connect(events: list[Any], on_send: Any = None) -> Any:
+    ws = FakeWebSocket(events, on_send=on_send)
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=ws)
+    cm.__aexit__ = AsyncMock(return_value=False)
+    return cm
+
+
+async def _run(
+    provider: AzureSTTProvider, events: list[Any], audio: bytes, on_send: Any = None
+) -> Any:
+    with patch(
+        "coval_bench.providers.stt.azure.ws_client.connect",
+        return_value=_fake_connect(events, on_send=on_send),
+    ):
+        return await provider.measure_ttft(
+            audio_data=audio,
+            channels=1,
+            sample_width=2,
+            sample_rate=16000,
+            realtime_resolution=0.5,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_azure_success(audio_pcm_bytes: bytes) -> None:
+    events = [
+        _frame("turn.start", {"context": {"serviceTag": "x"}}),
+        _frame("speech.startDetected", {"Offset": 100}),
+        _frame("speech.hypothesis", {"Text": "hello", "Offset": 0, "Duration": 100}),
+        _frame("speech.phrase", _phrase("Hello world")),
+        _frame("speech.endDetected", {"Offset": 900}),
+        _frame("turn.end"),
+    ]
+    result = await _run(make_provider(), events, audio_pcm_bytes)
+
+    assert result.error is None
+    assert result.ttft_seconds is not None and result.ttft_seconds >= 0
+    assert result.first_token_content is not None
+    assert "hello" in result.first_token_content.lower()
+    assert result.complete_transcript == "Hello world"
+    assert result.word_count == 2
+    assert result.audio_to_final_seconds is not None
+    assert result.vad_first_detected is not None
+    assert result.vad_events_count == 1
+
+
+@pytest.mark.asyncio
+async def test_azure_multi_phrase_concatenates(audio_pcm_bytes: bytes) -> None:
+    """Conversation mode emits multiple finals across pauses; all are joined."""
+    events = [
+        _frame("turn.start"),
+        _frame("speech.phrase", _phrase("Hello world")),
+        _frame("speech.phrase", _phrase("how are you")),
+        _frame("turn.end"),
+    ]
+    result = await _run(make_provider(), events, audio_pcm_bytes)
+
+    assert result.complete_transcript == "Hello world how are you"
+    assert result.audio_to_final_seconds is not None
+
+
+@pytest.mark.asyncio
+async def test_azure_simple_format_display_text_fallback(audio_pcm_bytes: bytes) -> None:
+    """A speech.phrase without NBest falls back to the top-level DisplayText."""
+    events = [
+        _frame("turn.start"),
+        _frame(
+            "speech.phrase",
+            {"RecognitionStatus": "Success", "DisplayText": "plain text", "Offset": 0},
+        ),
+        _frame("turn.end"),
+    ]
+    result = await _run(make_provider(), events, audio_pcm_bytes)
+
+    assert result.complete_transcript == "plain text"
+
+
+@pytest.mark.asyncio
+async def test_azure_non_success_phrase_ignored(audio_pcm_bytes: bytes) -> None:
+    """NoMatch / silence-timeout phrases carry no text and must not be scored."""
+    events = [
+        _frame("turn.start"),
+        _frame("speech.phrase", {"RecognitionStatus": "NoMatch"}),
+        _frame("turn.end"),
+    ]
+    result = await _run(make_provider(), events, audio_pcm_bytes)
+
+    assert result.complete_transcript is None
+    assert result.audio_to_final_seconds is None
+
+
+@pytest.mark.asyncio
+async def test_azure_hypothesis_only_leaves_transcript_none(audio_pcm_bytes: bytes) -> None:
+    """An unfinalized hypothesis sets ttft/partials but never the scored transcript."""
+    events = [
+        _frame("turn.start"),
+        _frame("speech.hypothesis", {"Text": "hello"}),
+        _frame("speech.hypothesis", {"Text": "hello world"}),
+        _frame("turn.end"),
+    ]
+    result = await _run(make_provider(), events, audio_pcm_bytes)
+
+    assert result.complete_transcript is None
+    assert result.ttft_seconds is not None
+    assert result.partial_transcripts == ["hello", "hello world"]
+
+
+@pytest.mark.asyncio
+async def test_azure_empty_stream(audio_pcm_bytes: bytes) -> None:
+    result = await _run(make_provider(), [], audio_pcm_bytes)
+    assert result.complete_transcript is None
+    assert result.ttft_seconds is None
+
+
+# ---------------------------------------------------------------------------
+# Wire protocol
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_azure_sends_speech_config_then_ends_with_empty_audio(
+    audio_pcm_bytes: bytes,
+) -> None:
+    sent: list[Any] = []
+    events = [_frame("turn.start"), _frame("speech.phrase", _phrase("hi")), _frame("turn.end")]
+    await _run(make_provider(), events, audio_pcm_bytes, on_send=sent.append)
+
+    # First message is the speech.config text frame.
+    assert isinstance(sent[0], str)
+    assert "Path:speech.config" in sent[0]
+
+    binary = [m for m in sent if isinstance(m, (bytes, bytearray))]
+    assert binary, "expected binary audio frames"
+    # The final audio frame is header-only (empty payload) — the end-of-stream signal.
+    last = binary[-1]
+    header_len = struct.unpack(">H", last[:2])[0]
+    assert len(last) == 2 + header_len
+    assert b"Path:audio" in last[2 : 2 + header_len]
+
+
+@pytest.mark.asyncio
+async def test_azure_url_uses_region_and_conversation_mode(audio_pcm_bytes: bytes) -> None:
+    events = [_frame("turn.end")]
+    with patch(
+        "coval_bench.providers.stt.azure.ws_client.connect",
+        return_value=_fake_connect(events),
+    ) as mock_connect:
+        await make_provider().measure_ttft(audio_pcm_bytes, 1, 2, 16000, 0.5)
+
+    url = mock_connect.call_args.args[0]
+    assert url.startswith(f"wss://{REGION}.stt.speech.microsoft.com/")
+    assert "/recognition/conversation/" in url
+    assert "language=en-US" in url
+    assert "format=detailed" in url
+
+
+def test_audio_message_round_trips() -> None:
+    payload = b"\x01\x02\x03\x04"
+    frame = _audio_message("req-abc", payload)
+    header_len = struct.unpack(">H", frame[:2])[0]
+    header = frame[2 : 2 + header_len].decode("ascii")
+    assert "Path:audio" in header
+    assert "X-RequestId:req-abc" in header
+    assert frame[2 + header_len :] == payload
+
+
+def test_parse_message_extracts_path_and_body() -> None:
+    path, body = _parse_message(_frame("speech.phrase", {"RecognitionStatus": "Success"}))
+    assert path == "speech.phrase"
+    assert body["RecognitionStatus"] == "Success"
+
+    path, body = _parse_message(_frame("turn.end"))
+    assert path == "turn.end"
+    assert body == {}
+
+
+def test_wav_header_is_canonical_pcm() -> None:
+    header = _wav_header(16000, 1, 2)
+    assert len(header) == 44
+    assert header[:4] == b"RIFF"
+    assert header[8:12] == b"WAVE"
+    assert struct.unpack("<I", header[24:28])[0] == 16000  # sample rate
+    assert struct.unpack("<H", header[22:24])[0] == 1  # channels
+    assert struct.unpack("<H", header[34:36])[0] == 16  # bits per sample
+
+
+# ---------------------------------------------------------------------------
+# Provider identity + validation
+# ---------------------------------------------------------------------------
+
+
+def test_provider_name() -> None:
+    assert make_provider().name == "azure"
+
+
+def test_invalid_model_raises() -> None:
+    with pytest.raises(ValueError, match="Invalid Azure model"):
+        AzureSTTProvider(api_key=SecretStr("k"), model="bad-model", region=REGION)
+
+
+def test_missing_region_raises() -> None:
+    with pytest.raises(ValueError, match="requires region"):
+        AzureSTTProvider(api_key=SecretStr("k"))

--- a/web/lib/config/colors.ts
+++ b/web/lib/config/colors.ts
@@ -64,6 +64,9 @@ export const modelColors: Record<string, string> = {
   "stt-rt-v4": "#B8860B",
   "stt-rt-v5": "#9C7400",
 
+  // Azure — azure-blue (#0078D4). Sits between the Google and Cartesia blues.
+  "azure:default": "#0078D4",
+
   // Composite keys for models whose slug is shared across providers
   "speechmatics:default": "#21618C",
   "gradium:default": "#1ABC9C"
@@ -82,5 +85,6 @@ export const providerColors: Record<string, string> = {
   "Inworld AI": "#6366F1",
   xAI: "#EC4899",
   Soniox: "#C9A227",
-  Google: "#4285F4"
+  Google: "#4285F4",
+  Azure: "#0078D4"
 };

--- a/web/lib/utils/formatters.ts
+++ b/web/lib/utils/formatters.ts
@@ -166,6 +166,7 @@ function capitalizeProviderSlug(providerName: string): string {
 export function normalizeSTTProviderName(providerName: string): string {
   const mappings: Record<string, string> = {
     assemblyai: "AssemblyAI",
+    azure: "Azure",
     cartesia: "Cartesia",
     deepgram: "Deepgram",
     elevenlabs: "ElevenLabs",


### PR DESCRIPTION
Drives the Speech recognition WebSocket protocol directly rather than the Speech SDK, and registers azure as an active STT model.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a new Azure AI Speech real-time STT provider that drives the Speech WebSocket protocol directly (bypassing the SDK), plus the associated config, registration, and frontend display entries.

- `azure.py` implements `AzureSTTProvider` with a concurrent send/receive task pair, WAV-header streaming, and a `finally`-guarded commit block that ensures partial transcripts are preserved even on task cancellation.
- `models.py`, `__init__.py`, `config.py`, `orchestrator.py`, and `__main__.py` wire up the new provider end-to-end; `colors.ts` and `formatters.ts` add the frontend display entries.

<h3>Confidence Score: 5/5</h3>

Safe to merge.

The new azure.py provider correctly handles the concurrent send/receive pattern: CancelledError is caught by the finally block, so any finals collected before a cancellation are committed. The audio_start_time is only set once. The asyncio.wait + cancel + gather flow, WAV header construction, and message parsing all look correct. Frontend and config additions are mechanical and low-risk.

No files require special attention.

<sub>Reviews (4): Last reviewed commit: ["Commit Azure STT finals even if receive ..."](https://github.com/coval-ai/benchmarks/commit/3243bd6cfca661e76eacd9f9ff842990d5daf07b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43063111)</sub>

<!-- /greptile_comment -->