### PR TITLE
[BENCH-389] Add finger zoom crop to timeline chart

### DIFF
--- a/web/components/visualizations/TimelineChart.tsx
+++ b/web/components/visualizations/TimelineChart.tsx
@@ -467,13 +467,13 @@ const TimelineChart: React.FC = () => {
 
         <div
           ref={chartRef}
-          className="relative h-96 cursor-crosshair select-none"
+          className="relative h-96 cursor-crosshair select-none touch-pan-y"
           onMouseEnter={trackChartHover}
           onDoubleClick={() => {
             if (Date.now() - dragEndAtRef.current > 400) setZoom(null);
           }}
           onPointerDown={(e) => {
-            if (e.pointerType !== "mouse" || e.button !== 0) return;
+            if (e.button !== 0) return;
             const box = plotBox();
             const rect = chartRef.current?.getBoundingClientRect();
             if (!box || !rect) return;
@@ -487,6 +487,7 @@ const TimelineChart: React.FC = () => {
             )
               return;
             dragRef.current = { x, y, armX: false, armY: false };
+            if (e.pointerType !== "mouse") setDragging(true);
           }}
           onPointerMove={(e) => {
             const start = dragRef.current;

--- a/web/components/visualizations/TimelineChart.tsx
+++ b/web/components/visualizations/TimelineChart.tsx
@@ -504,7 +504,9 @@ const TimelineChart: React.FC = () => {
               box.top + box.height
             );
             start.armX = start.armX || Math.abs(x - start.x) > 12;
-            start.armY = start.armY || Math.abs(y - start.y) > 12;
+            start.armY =
+              start.armY ||
+              (e.pointerType === "mouse" && Math.abs(y - start.y) > 12);
             if (!start.armX && !start.armY) {
               el.style.display = "none";
               return;


### PR DESCRIPTION
Makes the timeline chart's existing drag-to-crop-zoom work with a finger on mobile. Reuses the current pointer drag/zoom pipeline — no new components or gesture logic.

## Changes
- Accept touch/pen pointers in the drag handler (was mouse-only).
- `touch-action: pan-y` — a horizontal finger drag crops the time range; vertical stays page scroll.
- Suppress the hover tooltip for the duration of a touch gesture. On the cramped mobile plot it otherwise pops up right under the finger and covers most of the chart.

3 lines changed in `TimelineChart.tsx`.

## Behavior
- **Drag** = zoom crop · **tap** = pin values · **vertical swipe** = page scroll.
- Desktop mouse behavior is unchanged.

## Testing
Verified in a mobile viewport (375×812):
- Touch drag crops the time window (e.g. Jul 3–Jul 9 → Jul 3–Jul 7); "Reset zoom" appears; no console errors.
- Mid-drag shows only the dashed selection band — no tooltip under the finger.
- Mouse hover tooltip still works.

## Not included
- Plot height on mobile is squeezed by the 17-model legend (~96px) — cramped for any gesture, but a layout change beyond this fix (parent BENCH-388).
- No on-screen hint for the gesture on touch (the hover tooltip that carried "drag to zoom" is now suppressed on touch).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extends the timeline chart's existing drag-to-crop-zoom to work with touch and pen inputs on mobile by making three targeted changes to `TimelineChart.tsx`.

- Removes the `pointerType === \"mouse\"` guard on `onPointerDown` so touch and pen events enter the drag pipeline, and adds `touch-action: pan-y` so vertical finger swipes are handed off to the browser for page scroll.
- Eagerly sets `dragging = true` on the first touch `pointerdown` (before any movement threshold is crossed) so the hover tooltip is immediately hidden under the finger; mouse behavior is unchanged.
- Disables `armY` arming for non-mouse pointers so a touch drag only ever crops the time axis (no accidental Y-range zoom), consistent with `pan-y` handing vertical scrolls to the browser.

<h3>Confidence Score: 5/5</h3>

Minimal, targeted change that correctly reuses the existing pointer-event pipeline for touch/pen without introducing new gesture logic or state.

The three changed lines are internally consistent and covered by the pre-existing onPointerCancel handler at line 567.

No files require special attention.

<sub>Reviews (2): Last reviewed commit: ["Keep vertical touch drags as page scroll"](https://github.com/coval-ai/benchmarks/commit/51f05e6a9d0d240b0757e17d11b24e296316352a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43079774)</sub>

<!-- /greptile_comment -->