### PR TITLE
[BENCH-392] Touch: horizontal drag scrubs tooltip, diagonal crops

### DIFF
--- a/web/components/visualizations/TimelineChart.tsx
+++ b/web/components/visualizations/TimelineChart.tsx
@@ -511,8 +511,8 @@ const TimelineChart: React.FC = () => {
               Math.max(e.clientY - rect.top, box.top),
               box.top + box.height
             );
-            const dx = Math.abs(x - start.x);
-            const dy = Math.abs(y - start.y);
+            const dx = Math.abs(e.clientX - rect.left - start.x);
+            const dy = Math.abs(e.clientY - rect.top - start.y);
             if (e.pointerType === "mouse") {
               start.armX = start.armX || dx > 12;
               start.armY = start.armY || dy > 12;

--- a/web/components/visualizations/TimelineChart.tsx
+++ b/web/components/visualizations/TimelineChart.tsx
@@ -496,7 +496,6 @@ const TimelineChart: React.FC = () => {
             )
               return;
             dragRef.current = { x, y, armX: false, armY: false };
-            if (e.pointerType !== "mouse") setDragging(true);
           }}
           onPointerMove={(e) => {
             const start = dragRef.current;
@@ -512,10 +511,15 @@ const TimelineChart: React.FC = () => {
               Math.max(e.clientY - rect.top, box.top),
               box.top + box.height
             );
-            start.armX = start.armX || Math.abs(x - start.x) > 12;
-            start.armY =
-              start.armY ||
-              (e.pointerType === "mouse" && Math.abs(y - start.y) > 12);
+            const dx = Math.abs(x - start.x);
+            const dy = Math.abs(y - start.y);
+            if (e.pointerType === "mouse") {
+              start.armX = start.armX || dx > 12;
+              start.armY = start.armY || dy > 12;
+            } else if (dx > 12 && dy > 20) {
+              start.armX = true;
+              start.armY = true;
+            }
             if (!start.armX && !start.armY) {
               el.style.display = "none";
               return;


### PR DESCRIPTION
Refines the mobile touch gesture on the timeline chart so it feels natural: a horizontal finger drag scrubs the tooltip along the timeline, and the crop/zoom selection only engages on a deliberate diagonal.

> Stacked on #253 (BENCH-389). Until that merges, the diff here includes its commits; I'll rebase onto `main` once #253 lands so this shows only the diagonal change.

## Gesture model (touch)
- **Horizontal drag** → tooltip scrubs the timeline, no crop (stays unarmed so recharts owns the tooltip).
- **Diagonal drag** → crop selection — engages only on `dx > 12 && dy > 20`, then zooms the X/Y rectangle.
- **Vertical / near-vertical** → page scroll (never arms, even if the browser doesn't claim the gesture).
- Stopped suppressing the tooltip on touch-down so the scrub is visible.
- **Mouse behavior is unchanged.**

## Testing
Verified in a 375×812 viewport:

| Gesture | Result |
|---|---|
| Horizontal touch | no pointer capture → scrub, no zoom |
| Diagonal touch | captures → 2-D crop (e.g. X Jul 3–Jul 6, Y ~2–3s), no console errors |
| Vertical touch | no capture → scroll |
| Near-vertical touch (dx ≤ 12) | no capture → scroll |
| Mouse horizontal / vertical | captures → crop (unchanged) |

## Note
The diagonal threshold (`dx > 12 && dy > 20`) is the tuning knob if starting a crop feels too finicky or too twitchy on a real device.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR refines touch gesture handling on the `TimelineChart` by splitting the interaction model: horizontal touch drag now lets recharts render the scrub tooltip (no capture, no `dragging` state), while a deliberate diagonal gesture (`dx > 12 && dy > 20`) arms the 2-D crop box. Mouse behavior is unchanged.

- Removed `setDragging(true)` from `onPointerDown` for non-mouse pointers, deferring it to `onPointerMove` only when the crop arms — this keeps `dragging` false during horizontal scrub so recharts owns the tooltip.
- Replaced the clamped `x`/`y` coordinates in the arm threshold check with raw `e.clientX - rect.left` / `e.clientY - rect.top`, fixing the edge-proximity dead-zone noted in the previous review thread.

<h3>Confidence Score: 5/5</h3>

The change is narrowly scoped to touch gesture classification in a single component; mouse behavior and all downstream zoom/crop logic are untouched.

The two-line deletion and the rewrite of the arm check are both logically consistent with the stated gesture model. Using raw coordinates for the threshold resolves the edge-proximity dead-zone from the prior review. State transitions (dragging, capture, endDrag) are clean across all gesture paths.

No files require special attention.

<sub>Reviews (2): Last reviewed commit: ["Measure diagonal threshold from raw poin..."](https://github.com/coval-ai/benchmarks/commit/20b343fcecafdc125a56add4b80c91adca780656) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43099182)</sub>

<!-- /greptile_comment -->