### PR TITLE
Add Rev AI streaming STT provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,6 +32,7 @@ MISTRAL_API_KEY=
 XAI_API_KEY=
 SMALLEST_API_KEY=
 SONIOX_API_KEY=
+REVAI_API_KEY=
 
 # --- Google STT (optional; requires the `google-stt` extra) ---
 # GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json

--- a/runner/src/coval_bench/config.py
+++ b/runner/src/coval_bench/config.py
@@ -77,6 +77,7 @@ class Settings(BaseSettings):
     smallest_api_key: SecretStr | None = None
     inworld_api_key: SecretStr | None = None
     soniox_api_key: SecretStr | None = None
+    revai_api_key: SecretStr | None = None
     baseten_api_key: SecretStr | None = None
     azure_api_key: SecretStr | None = None
 

--- a/runner/src/coval_bench/providers/stt/__init__.py
+++ b/runner/src/coval_bench/providers/stt/__init__.py
@@ -26,6 +26,7 @@ from coval_bench.providers.stt.gradium import GradiumSTTProvider
 from coval_bench.providers.stt.inworld import InworldSTTProvider
 from coval_bench.providers.stt.mistral import MistralSTTProvider
 from coval_bench.providers.stt.openai import OpenAISTTProvider
+from coval_bench.providers.stt.revai import RevAISTTProvider
 from coval_bench.providers.stt.smallest import SmallestSTTProvider
 from coval_bench.providers.stt.soniox import SonioxSTTProvider
 from coval_bench.providers.stt.speechmatics import SpeechmaticsProvider
@@ -52,6 +53,7 @@ STT_PROVIDERS: dict[str, type[STTProvider]] = {
     "inworld": InworldSTTProvider,
     "mistral": MistralSTTProvider,
     "openai": OpenAISTTProvider,
+    "revai": RevAISTTProvider,
     "smallest": SmallestSTTProvider,
     "soniox": SonioxSTTProvider,
     "speechmatics": SpeechmaticsProvider,
@@ -75,6 +77,7 @@ __all__ = [
     "InworldSTTProvider",
     "MistralSTTProvider",
     "OpenAISTTProvider",
+    "RevAISTTProvider",
     "SmallestSTTProvider",
     "SonioxSTTProvider",
     "SpeechmaticsProvider",

--- a/runner/src/coval_bench/providers/stt/revai.py
+++ b/runner/src/coval_bench/providers/stt/revai.py
@@ -1,0 +1,237 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Rev AI real-time streaming STT provider (Reverb model).
+
+Wire protocol: WebSocket, wss://api.rev.ai/speechtotext/v1/stream
+Auth: ``access_token`` query parameter.
+Audio in: raw binary PCM frames.
+Close: an ``"EOS"`` text frame; the server flushes the last final and closes.
+Server messages (serialised JSON, keyed by ``type``):
+  connected -> handshake ack, no transcript
+  partial   -> best-guess hypothesis, ``elements: [{type: "text", value}]``
+  final     -> committed segment, ``elements: [{type: "text"|"punct", value, ...}]``
+
+``transcriber=machine_v2`` pins the Reverb ASR model rather than whatever
+default is in effect for the account (see docs.rev.ai/api/streaming).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time  # monotonic clock — wall-clock can step on NTP sync
+from typing import Any
+from urllib.parse import urlencode
+
+import structlog
+import websockets.asyncio.client as ws_client
+from pydantic import SecretStr
+
+from coval_bench.providers.base import STTProvider, TranscriptionResult
+from coval_bench.providers.stt._pacing import paced_chunks
+from coval_bench.providers.stt._transcript_utils import (
+    add_partial_transcript,
+    finalize_transcript,
+    set_first_token,
+)
+
+logger = structlog.get_logger(__name__)
+
+_WS_BASE = "wss://api.rev.ai/speechtotext/v1/stream"
+
+# machine_v2 forces the Reverb ASR model on the streaming endpoint.
+_TRANSCRIBER_FOR_MODEL: dict[str, str] = {"reverb": "machine_v2"}
+
+# End-of-audio sentinel: a text frame the server consumes to end the session.
+_EOS = "EOS"
+
+# Rev AI has no force-finalize control: EOS both finalizes and closes, and it
+# discards the un-endpointed tail. So after speech we feed trailing silence to
+# let Reverb's endpointer fire on the last segment, breaking early once that
+# final lands. Cap bounds the wait when the tail already finalized mid-stream.
+_EOT_SILENCE_S = 2.0
+
+
+class RevAISTTProvider(STTProvider):
+    """Rev AI streaming STT provider."""
+
+    _VALID_MODELS = frozenset(_TRANSCRIBER_FOR_MODEL)
+
+    def __init__(self, api_key: SecretStr | None, model: str = "reverb") -> None:
+        if not self._model_supported(model):
+            raise ValueError(f"Invalid Rev AI model {model!r}. Valid: {sorted(self._VALID_MODELS)}")
+        if api_key is None:
+            raise ValueError("revai_api_key is required for the Rev AI STT provider")
+        self._api_key = api_key
+        self._model = model
+
+    @property
+    def name(self) -> str:
+        return "revai"
+
+    @property
+    def model(self) -> str:
+        return self._model
+
+    def _build_websocket_url(self, sample_rate: int) -> str:
+        params = {
+            "access_token": self._api_key.get_secret_value(),
+            "content_type": (
+                f"audio/x-raw;layout=interleaved;rate={sample_rate};format=S16LE;channels=1"
+            ),
+            "language": "en",
+            "transcriber": _TRANSCRIBER_FOR_MODEL[self._model],
+        }
+        return f"{_WS_BASE}?{urlencode(params)}"
+
+    async def measure_ttft(
+        self,
+        audio_data: bytes,
+        channels: int,
+        sample_width: int,
+        sample_rate: int,
+        realtime_resolution: float = 0.1,
+    ) -> TranscriptionResult:
+        result = TranscriptionResult(provider=self.name)
+        if channels != 1 or sample_width != 2:
+            result.error = (
+                "Rev AI requires mono 16-bit PCM input; "
+                f"got channels={channels}, sample_width={sample_width}"
+            )
+            return result
+
+        total_start = time.monotonic()
+
+        try:
+            url = self._build_websocket_url(sample_rate)
+            final_event = asyncio.Event()
+            async with ws_client.connect(url) as ws:
+                send_task = asyncio.create_task(
+                    self._send_audio(
+                        ws,
+                        audio_data,
+                        channels,
+                        sample_width,
+                        sample_rate,
+                        result,
+                        realtime_resolution,
+                        final_event,
+                    )
+                )
+                recv_task = asyncio.create_task(self._receive(ws, result, final_event))
+                tasks = (send_task, recv_task)
+                done, pending = await asyncio.wait(tasks, return_when=asyncio.FIRST_EXCEPTION)
+                if any(not task.cancelled() and task.exception() is not None for task in done):
+                    for task in pending:
+                        task.cancel()
+                outcomes = await asyncio.gather(*tasks, return_exceptions=True)
+                if result.error is None and result.audio_to_final_seconds is None:
+                    for outcome in outcomes:
+                        if isinstance(outcome, Exception):
+                            result.error = str(outcome)
+                            break
+
+        except Exception as exc:
+            logger.warning(
+                "revai_measure_ttft_failed", provider="revai", model=self._model, exc_info=exc
+            )
+            result.error = str(exc)
+
+        result.total_time = time.monotonic() - total_start
+        return result
+
+    async def _send_audio(
+        self,
+        ws: Any,
+        audio_data: bytes,
+        channels: int,
+        sample_width: int,
+        sample_rate: int,
+        result: TranscriptionResult,
+        realtime_resolution: float,
+        final_event: asyncio.Event,
+    ) -> None:
+        byte_rate = sample_width * sample_rate * channels
+        chunk_size = int(byte_rate * realtime_resolution)
+        try:
+            async for chunk, start in paced_chunks(audio_data, chunk_size, byte_rate):
+                result.audio_start_time = start
+                await ws.send(chunk)
+            # Feed trailing silence so Reverb endpoints the last segment, stopping as
+            # soon as that final lands. Clear first: a mid-stream final would otherwise
+            # leave the latch set and skip the drain. Silence chunks must not touch
+            # audio_start_time — audio_to_final is measured from the first speech chunk.
+            final_event.clear()
+            silence = bytes(int(byte_rate * _EOT_SILENCE_S))
+            async for chunk, _ in paced_chunks(silence, chunk_size, byte_rate):
+                if final_event.is_set():
+                    break
+                await ws.send(chunk)
+            # EOS is a text frame; a zero-length binary frame would be ignored and the
+            # server would stall to its idle timeout without flushing the final.
+            await ws.send(_EOS)
+        except Exception as exc:
+            logger.warning("revai_send_error", provider="revai", model=self._model, exc_info=exc)
+            raise
+
+    async def _receive(
+        self, ws: Any, result: TranscriptionResult, final_event: asyncio.Event
+    ) -> None:
+        final_segments: list[str] = []
+        # Longest partial of the current (not-yet-finalized) segment. Rev AI resets
+        # partials per segment after each final, so a partial left standing when EOS
+        # closes the socket is the un-finalized tail — recover it or its words are lost.
+        pending_partial: str = ""
+        last_final_time: float | None = None
+
+        try:
+            async for raw in ws:
+                if isinstance(raw, bytes):
+                    continue
+
+                msg: dict[str, Any] = json.loads(raw)
+                now = time.monotonic()
+                msg_type: str = msg.get("type", "")
+
+                if msg_type == "connected":
+                    continue
+
+                transcript = self._elements_to_text(msg.get("elements", []))
+                if not transcript:
+                    continue
+
+                # TTFT is time-to-first-word: fire on the first partial, not the first final.
+                set_first_token(result, transcript, now=now)
+                add_partial_transcript(result, transcript)
+
+                if msg_type == "final":
+                    final_segments.append(transcript)
+                    pending_partial = ""
+                    last_final_time = now
+                    final_event.set()
+                elif len(transcript) > len(pending_partial):
+                    pending_partial = transcript
+
+        except Exception as exc:
+            logger.warning("revai_receive_error", provider="revai", model=self._model, exc_info=exc)
+            if result.error is None and last_final_time is None:
+                result.error = str(exc)
+
+        if last_final_time is not None and result.audio_start_time is not None:
+            result.audio_to_final_seconds = last_final_time - result.audio_start_time
+
+        segments = final_segments + ([pending_partial] if pending_partial else [])
+        finalize_transcript(result, final_segments=segments)
+
+    @staticmethod
+    def _elements_to_text(elements: list[dict[str, Any]]) -> str:
+        """Join the spoken-word (``text``) elements; ``punct`` is dropped for WER parity."""
+        parts = [
+            str(el.get("value", "")).strip()
+            for el in elements
+            if isinstance(el, dict)
+            and el.get("type") == "text"
+            and str(el.get("value", "")).strip()
+        ]
+        return " ".join(parts)

--- a/runner/src/coval_bench/providers/stt/revai.py
+++ b/runner/src/coval_bench/providers/stt/revai.py
@@ -198,7 +198,9 @@ class RevAISTTProvider(STTProvider):
                     pending_partial = ""
                     last_final_time = now
                     final_event.set()
-                elif len(transcript) > len(pending_partial):
+                else:
+                    # Partials are cumulative per segment, so keep the latest — a
+                    # downward revision must win over a stale, longer earlier guess.
                     pending_partial = transcript
 
         except Exception as exc:

--- a/runner/src/coval_bench/providers/stt/revai.py
+++ b/runner/src/coval_bench/providers/stt/revai.py
@@ -39,17 +39,11 @@ from coval_bench.providers.stt._transcript_utils import (
 logger = structlog.get_logger(__name__)
 
 _WS_BASE = "wss://api.rev.ai/speechtotext/v1/stream"
-
-# machine_v2 forces the Reverb ASR model on the streaming endpoint.
 _TRANSCRIBER_FOR_MODEL: dict[str, str] = {"reverb": "machine_v2"}
-
-# End-of-audio sentinel: a text frame the server consumes to end the session.
 _EOS = "EOS"
 
-# Rev AI has no force-finalize control: EOS both finalizes and closes, and it
-# discards the un-endpointed tail. So after speech we feed trailing silence to
-# let Reverb's endpointer fire on the last segment, breaking early once that
-# final lands. Cap bounds the wait when the tail already finalized mid-stream.
+# Rev has no force-finalize: EOS discards the un-endpointed tail, so we feed
+# trailing silence to make Reverb endpoint the last segment (cap; breaks early).
 _EOT_SILENCE_S = 2.0
 
 
@@ -158,18 +152,14 @@ class RevAISTTProvider(STTProvider):
             async for chunk, start in paced_chunks(audio_data, chunk_size, byte_rate):
                 result.audio_start_time = start
                 await ws.send(chunk)
-            # Feed trailing silence so Reverb endpoints the last segment, stopping as
-            # soon as that final lands. Clear first: a mid-stream final would otherwise
-            # leave the latch set and skip the drain. Silence chunks must not touch
-            # audio_start_time — audio_to_final is measured from the first speech chunk.
+            # Clear first: a mid-stream final would leave the latch set and skip the
+            # drain. Silence never sets audio_start_time (audio_to_final is from speech).
             final_event.clear()
             silence = bytes(int(byte_rate * _EOT_SILENCE_S))
             async for chunk, _ in paced_chunks(silence, chunk_size, byte_rate):
                 if final_event.is_set():
                     break
                 await ws.send(chunk)
-            # EOS is a text frame; a zero-length binary frame would be ignored and the
-            # server would stall to its idle timeout without flushing the final.
             await ws.send(_EOS)
         except Exception as exc:
             logger.warning("revai_send_error", provider="revai", model=self._model, exc_info=exc)
@@ -179,9 +169,7 @@ class RevAISTTProvider(STTProvider):
         self, ws: Any, result: TranscriptionResult, final_event: asyncio.Event
     ) -> None:
         final_segments: list[str] = []
-        # Longest partial of the current (not-yet-finalized) segment. Rev AI resets
-        # partials per segment after each final, so a partial left standing when EOS
-        # closes the socket is the un-finalized tail — recover it or its words are lost.
+        # A partial left standing at close is the un-finalized tail; recover it.
         pending_partial: str = ""
         last_final_time: float | None = None
 

--- a/runner/src/coval_bench/registries/metrics.py
+++ b/runner/src/coval_bench/registries/metrics.py
@@ -123,6 +123,10 @@ METRIC_EXCLUSIONS: dict[Metric, frozenset[tuple[str, str]]] = {
             ("deepgram", "flux-general-multi"),
             ("assemblyai", "universal-streaming"),
             ("assemblyai", "universal-streaming-multilingual"),
+            # Rev AI has no force-finalize; the tail final only lands after Reverb's
+            # endpointer fires on trailing silence, so TTFS bundles endpoint-detection
+            # latency and isn't comparable to force-endpoint providers.
+            ("revai", "reverb"),
         }
     ),
 }

--- a/runner/src/coval_bench/registries/models.py
+++ b/runner/src/coval_bench/registries/models.py
@@ -294,6 +294,19 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         tags=(_REALTIME, _MULTI, _VAD),
         status=_ACTIVE,
     ),
+    # Rev AI streaming (Reverb ASR, transcriber=machine_v2). PENDING: implemented
+    # and hidden until an API key is provisioned in benchmark-infra. Reverb weights
+    # are openly released (github.com/revdotcom/reverb), hence open-weight.
+    RegisteredModel(
+        benchmark=_STT,
+        provider="revai",
+        model="reverb",
+        creator="rev",
+        tags=(_REALTIME, _MULTI, _VAD, _KEYTERM),
+        licensing=_OPEN,
+        self_hostable=True,
+        status=_PENDING,
+    ),
     #######
     # TTS #
     #######

--- a/runner/tests/providers/stt/conftest.py
+++ b/runner/tests/providers/stt/conftest.py
@@ -140,6 +140,7 @@ _WAIT_PATCHES = (
     "coval_bench.providers.stt.assemblyai._FINAL_WAIT_S",
     "coval_bench.providers.stt.deepgram._FINAL_WAIT_S",
     "coval_bench.providers.stt.deepgram._FLUX_EOT_SILENCE_S",
+    "coval_bench.providers.stt.revai._EOT_SILENCE_S",
     "coval_bench.providers.stt.xai._FINAL_WAIT_S",
     "coval_bench.providers.stt.gradium._FLUSH_WAIT_S",
     "coval_bench.providers.stt.inworld._CLOSE_WAIT_S",

--- a/runner/tests/providers/stt/fixtures/revai/events-success.json
+++ b/runner/tests/providers/stt/fixtures/revai/events-success.json
@@ -1,0 +1,8 @@
+[
+  {"type": "connected", "id": "test-session"},
+  {"type": "partial", "ts": 0.0, "end_ts": 0.5, "elements": [{"type": "text", "value": "hel"}]},
+  {"type": "partial", "ts": 0.0, "end_ts": 0.8, "elements": [{"type": "text", "value": "hello"}]},
+  {"type": "final", "ts": 0.0, "end_ts": 1.2, "elements": [{"type": "text", "value": "hello", "ts": 0.0, "end_ts": 0.6, "confidence": 0.99}, {"type": "punct", "value": ",", "confidence": 1.0}, {"type": "text", "value": "world", "ts": 0.7, "end_ts": 1.2, "confidence": 0.98}]},
+  {"type": "partial", "ts": 1.3, "end_ts": 2.0, "elements": [{"type": "text", "value": "how are"}]},
+  {"type": "final", "ts": 1.3, "end_ts": 2.6, "elements": [{"type": "text", "value": "how", "ts": 1.3, "end_ts": 1.6, "confidence": 0.97}, {"type": "text", "value": "are", "ts": 1.7, "end_ts": 2.0, "confidence": 0.97}, {"type": "text", "value": "you", "ts": 2.1, "end_ts": 2.5, "confidence": 0.96}, {"type": "punct", "value": ".", "confidence": 1.0}]}
+]

--- a/runner/tests/providers/stt/test_revai.py
+++ b/runner/tests/providers/stt/test_revai.py
@@ -128,6 +128,38 @@ async def test_revai_excludes_partials_from_transcript(
 
 
 @pytest.mark.asyncio
+async def test_revai_tail_partial_uses_latest_not_longest(
+    fake_api_key: SecretStr, audio_pcm_bytes: bytes
+) -> None:
+    """A downward-revised trailing partial (no final) recovers the latest guess.
+
+    Rev's partials are cumulative per segment, so a walked-back hypothesis
+    ("hello world foo" -> "hello world") must win over the stale longer one.
+    """
+    events: list[Any] = [
+        {"type": "connected"},
+        {"type": "partial", "elements": [{"type": "text", "value": "hello world foo"}]},
+        {"type": "partial", "elements": [{"type": "text", "value": "hello world"}]},
+    ]
+    provider = RevAISTTProvider(api_key=fake_api_key)
+
+    with patch(
+        "coval_bench.providers.stt.revai.ws_client.connect",
+        return_value=_fake_connect(events),
+    ):
+        result = await provider.measure_ttft(
+            audio_data=audio_pcm_bytes,
+            channels=1,
+            sample_width=2,
+            sample_rate=16000,
+            realtime_resolution=0.5,
+        )
+
+    assert result.error is None
+    assert result.complete_transcript == "hello world"
+
+
+@pytest.mark.asyncio
 async def test_revai_sends_eos_sentinel(fake_api_key: SecretStr, audio_pcm_bytes: bytes) -> None:
     """End-of-audio is signalled with an ``EOS`` text frame after the PCM chunks."""
     ws = FakeWebSocket([{"type": "connected"}])

--- a/runner/tests/providers/stt/test_revai.py
+++ b/runner/tests/providers/stt/test_revai.py
@@ -1,0 +1,274 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for coval_bench.providers.stt.revai (RevAISTTProvider).
+
+All tests use FakeWebSocket — no live network calls. The event fixtures mirror
+the Rev AI streaming wire protocol: a ``connected`` handshake, then ``partial``
+and ``final`` messages carrying an ``elements`` array of ``text``/``punct``
+items. The transcript is the concatenation of the ``text`` elements from every
+``final`` message; ``punct`` elements are dropped for WER parity.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pydantic import SecretStr
+
+from coval_bench.metrics.wer import compute_wer
+from coval_bench.providers.stt.revai import RevAISTTProvider
+from tests.providers.stt.conftest import FakeWebSocket, load_fixture_events
+
+
+def make_provider() -> RevAISTTProvider:
+    return RevAISTTProvider(api_key=SecretStr("test-key-revai"))
+
+
+def _fake_connect(events: list[Any]) -> Any:
+    ws = FakeWebSocket(events)
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=ws)
+    cm.__aexit__ = AsyncMock(return_value=False)
+    return cm
+
+
+# ---------------------------------------------------------------------------
+# Happy path — final text elements concatenated, punct dropped
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_revai_success(fake_api_key: SecretStr, audio_pcm_bytes: bytes) -> None:
+    events = load_fixture_events("revai", "events-success")
+    provider = RevAISTTProvider(api_key=fake_api_key)
+
+    with patch(
+        "coval_bench.providers.stt.revai.ws_client.connect",
+        return_value=_fake_connect(events),
+    ):
+        result = await provider.measure_ttft(
+            audio_data=audio_pcm_bytes,
+            channels=1,
+            sample_width=2,
+            sample_rate=16000,
+            realtime_resolution=0.5,
+        )
+
+    assert result.error is None
+    assert result.ttft_seconds is not None
+    assert result.ttft_seconds >= 0
+    assert result.first_token_content is not None
+    assert result.complete_transcript == "hello world how are you"
+    assert result.word_count == 5
+    assert result.audio_to_final_seconds is not None
+    wer = compute_wer("hello world how are you", result.complete_transcript)
+    assert wer.wer_percentage == pytest.approx(0.0)
+
+
+@pytest.mark.asyncio
+async def test_revai_ttft_fires_on_first_partial(
+    fake_api_key: SecretStr, audio_pcm_bytes: bytes
+) -> None:
+    """TTFT is time-to-first-word: it must fire on a partial, before any final."""
+    events: list[Any] = [
+        {"type": "connected"},
+        {"type": "partial", "elements": [{"type": "text", "value": "hello"}]},
+        {"type": "final", "elements": [{"type": "text", "value": "hello world"}]},
+    ]
+    provider = RevAISTTProvider(api_key=fake_api_key)
+
+    with patch(
+        "coval_bench.providers.stt.revai.ws_client.connect",
+        return_value=_fake_connect(events),
+    ):
+        result = await provider.measure_ttft(
+            audio_data=audio_pcm_bytes,
+            channels=1,
+            sample_width=2,
+            sample_rate=16000,
+            realtime_resolution=0.5,
+        )
+
+    assert result.error is None
+    assert result.first_token_content == "hello"  # noqa: S105 - transcript fixture text
+
+
+@pytest.mark.asyncio
+async def test_revai_excludes_partials_from_transcript(
+    fake_api_key: SecretStr, audio_pcm_bytes: bytes
+) -> None:
+    """Only ``final`` messages form the transcript; partials are dropped."""
+    events: list[Any] = [
+        {"type": "connected"},
+        {"type": "partial", "elements": [{"type": "text", "value": "wrong guess"}]},
+        {"type": "final", "elements": [{"type": "text", "value": "hello"}]},
+        {"type": "partial", "elements": [{"type": "text", "value": "worng"}]},
+        {"type": "final", "elements": [{"type": "text", "value": "world"}]},
+    ]
+    provider = RevAISTTProvider(api_key=fake_api_key)
+
+    with patch(
+        "coval_bench.providers.stt.revai.ws_client.connect",
+        return_value=_fake_connect(events),
+    ):
+        result = await provider.measure_ttft(
+            audio_data=audio_pcm_bytes,
+            channels=1,
+            sample_width=2,
+            sample_rate=16000,
+            realtime_resolution=0.5,
+        )
+
+    assert result.error is None
+    assert result.complete_transcript == "hello world"
+    assert result.word_count == 2
+
+
+@pytest.mark.asyncio
+async def test_revai_sends_eos_sentinel(fake_api_key: SecretStr, audio_pcm_bytes: bytes) -> None:
+    """End-of-audio is signalled with an ``EOS`` text frame after the PCM chunks."""
+    ws = FakeWebSocket([{"type": "connected"}])
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=ws)
+    cm.__aexit__ = AsyncMock(return_value=False)
+
+    provider = RevAISTTProvider(api_key=fake_api_key)
+    with patch("coval_bench.providers.stt.revai.ws_client.connect", return_value=cm):
+        await provider.measure_ttft(
+            audio_data=audio_pcm_bytes,
+            channels=1,
+            sample_width=2,
+            sample_rate=16000,
+            realtime_resolution=0.5,
+        )
+
+    assert ws._sent[-1] == "EOS"
+
+
+# ---------------------------------------------------------------------------
+# Provider name and model
+# ---------------------------------------------------------------------------
+
+
+def test_provider_name() -> None:
+    assert make_provider().name == "revai"
+
+
+def test_provider_model() -> None:
+    assert make_provider().model == "reverb"
+
+
+# ---------------------------------------------------------------------------
+# Invalid construction
+# ---------------------------------------------------------------------------
+
+
+def test_invalid_model_raises() -> None:
+    with pytest.raises(ValueError, match="Invalid Rev AI model"):
+        RevAISTTProvider(api_key=SecretStr("k"), model="machine_v3")
+
+
+def test_missing_api_key_raises() -> None:
+    with pytest.raises(ValueError, match="revai_api_key is required"):
+        RevAISTTProvider(api_key=None)
+
+
+# ---------------------------------------------------------------------------
+# Input validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_revai_rejects_non_mono_or_non_16bit(
+    fake_api_key: SecretStr, audio_pcm_bytes: bytes
+) -> None:
+    provider = RevAISTTProvider(api_key=fake_api_key)
+    result = await provider.measure_ttft(
+        audio_data=audio_pcm_bytes,
+        channels=2,
+        sample_width=2,
+        sample_rate=16000,
+    )
+
+    assert result.error is not None
+    assert "mono 16-bit" in result.error
+    assert result.ttft_seconds is None
+
+
+# ---------------------------------------------------------------------------
+# Failure paths
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_revai_empty_stream(fake_api_key: SecretStr, audio_pcm_bytes: bytes) -> None:
+    provider = RevAISTTProvider(api_key=fake_api_key)
+
+    with patch(
+        "coval_bench.providers.stt.revai.ws_client.connect",
+        return_value=_fake_connect([]),
+    ):
+        result = await provider.measure_ttft(
+            audio_data=audio_pcm_bytes,
+            channels=1,
+            sample_width=2,
+            sample_rate=16000,
+            realtime_resolution=0.5,
+        )
+
+    assert result.complete_transcript is None
+    assert result.ttft_seconds is None
+
+
+@pytest.mark.asyncio
+async def test_revai_connection_error(fake_api_key: SecretStr, audio_pcm_bytes: bytes) -> None:
+    """A connect failure surfaces as result.error, not a silent empty success."""
+    provider = RevAISTTProvider(api_key=fake_api_key)
+
+    with patch(
+        "coval_bench.providers.stt.revai.ws_client.connect",
+        side_effect=OSError("connection refused"),
+    ):
+        result = await provider.measure_ttft(
+            audio_data=audio_pcm_bytes,
+            channels=1,
+            sample_width=2,
+            sample_rate=16000,
+            realtime_resolution=0.5,
+        )
+
+    assert result.error is not None
+    assert "connection refused" in result.error
+    assert result.complete_transcript is None
+    assert result.ttft_seconds is None
+
+
+@pytest.mark.asyncio
+async def test_revai_surfaces_send_failure(fake_api_key: SecretStr, audio_pcm_bytes: bytes) -> None:
+    """A send failure inside the streaming task is surfaced, not swallowed by gather."""
+
+    def _raise_on_audio(msg: object) -> None:
+        if isinstance(msg, (bytes, bytearray)):
+            raise RuntimeError("send boom")
+
+    ws = FakeWebSocket([], on_send=_raise_on_audio)
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=ws)
+    cm.__aexit__ = AsyncMock(return_value=False)
+
+    provider = RevAISTTProvider(api_key=fake_api_key)
+    with patch("coval_bench.providers.stt.revai.ws_client.connect", return_value=cm):
+        result = await provider.measure_ttft(
+            audio_data=audio_pcm_bytes,
+            channels=1,
+            sample_width=2,
+            sample_rate=16000,
+            realtime_resolution=0.5,
+        )
+
+    assert result.error is not None
+    assert "send boom" in result.error
+    assert result.complete_transcript is None


### PR DESCRIPTION
Wire the Reverb model (transcriber=machine_v2) into the WER pipeline; TTFS is excluded since Rev has no force-finalize and its tail final is endpoint-detection-bound.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR wires the Rev AI Reverb model (`transcriber=machine_v2`) into the WER benchmarking pipeline as a new streaming STT provider. TTFS is correctly excluded from metric comparisons since Rev AI has no force-finalize and tail finals are endpoint-detection-bound; trailing silence is instead injected to coerce Reverb's endpointer before sending EOS.

- **New provider** (`revai.py`): WebSocket streaming with paced audio chunks, EOS sentinel, and recovery of un-finalized tail partials. The stale-partial bug (holding onto a longer hypothesis when Rev walks back its guess) that was raised on an earlier revision is fixed — `pending_partial` is now unconditionally overwritten with the latest partial on every message.
- **Registry updates**: Rev AI Reverb is registered as `_PENDING` (hidden until an API key is provisioned in benchmark-infra) and excluded from TTFS comparisons.
- **Tests**: 12 unit tests covering happy-path transcript assembly, TTFT-on-first-partial semantics, downward partial revision, EOS delivery, construction guards, and failure paths — all using `FakeWebSocket` with no live network calls.

<h3>Confidence Score: 4/5</h3>

Safe to merge with one known open defect: errors that occur after the first segment finalizes are silently dropped in _receive, so a mid-stream network drop after a successful final returns a clean (partial) result with no error signal.

The implementation logic is sound and the provider is gated behind _PENDING status so it won't affect live benchmark runs. The error-suppression guard in the _receive except block was surfaced in a prior review round and is still present.

runner/src/coval_bench/providers/stt/revai.py — specifically the exception handler in _receive at line 208.

<sub>Reviews (2): Last reviewed commit: ["Keep latest Rev AI tail partial, not the..."](https://github.com/coval-ai/benchmarks/commit/10b694c92ed564dd1db644c2c65fdcd554a74b46) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43104815)</sub>

<!-- /greptile_comment -->