### PR TITLE
Activate Rev AI STT (BENCH-330)

### DIFF
--- a/runner/src/coval_bench/registries/models.py
+++ b/runner/src/coval_bench/registries/models.py
@@ -294,9 +294,8 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         tags=(_REALTIME, _MULTI, _VAD),
         status=_ACTIVE,
     ),
-    # Rev AI streaming (Reverb ASR, transcriber=machine_v2). PENDING: implemented
-    # and hidden until an API key is provisioned in benchmark-infra. Reverb weights
-    # are openly released (github.com/revdotcom/reverb), hence open-weight.
+    # Rev AI streaming (Reverb ASR, transcriber=machine_v2). Reverb weights are
+    # openly released (github.com/revdotcom/reverb), hence open-weight.
     RegisteredModel(
         benchmark=_STT,
         provider="revai",
@@ -305,7 +304,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         tags=(_REALTIME, _MULTI, _VAD, _KEYTERM),
         licensing=_OPEN,
         self_hostable=True,
-        status=_PENDING,
+        status=_ACTIVE,
     ),
     #######
     # TTS #

--- a/runner/src/coval_bench/registries/models.py
+++ b/runner/src/coval_bench/registries/models.py
@@ -294,8 +294,6 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         tags=(_REALTIME, _MULTI, _VAD),
         status=_ACTIVE,
     ),
-    # Rev AI streaming (Reverb ASR, transcriber=machine_v2). Reverb weights are
-    # openly released (github.com/revdotcom/reverb), hence open-weight.
     RegisteredModel(
         benchmark=_STT,
         provider="revai",


### PR DESCRIPTION
Flip revai/reverb from PENDING to ACTIVE now that the prod key is live.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR activates the Rev AI (Reverb ASR) speech-to-text model in the benchmark registry by changing its status from `_PENDING` to `_ACTIVE` and removing the explanatory comment that noted the model was waiting on API key provisioning.

- The `RegisteredModel` entry for `revai`/`reverb` in `models.py` has its `status` field flipped from `_PENDING` to `_ACTIVE`, making it visible and runnable in benchmarks.
- The three-line comment block explaining the pending state is removed, as it is no longer relevant now that the production key is live.

<h3>Confidence Score: 5/5</h3>

Safe to merge — this is a one-line status flag change that enables a model that was already fully implemented and integrated.

The change is isolated to flipping a single status constant from `_PENDING` to `_ACTIVE` for the Rev AI Reverb ASR entry in the model registry. The model implementation, tags, licensing, and configuration were already in place; only the activation gate needed to be opened once the production API key was provisioned.

No files require special attention.

<sub>Reviews (2): Last reviewed commit: ["Drop revai registry comments"](https://github.com/coval-ai/benchmarks/commit/4a1c971196151113450a339232e3af008f891f29) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43118545)</sub>

<!-- /greptile_comment -->