### PR TITLE
Add ElevenLabs eleven_v3 TTS

### DIFF
--- a/runner/src/coval_bench/providers/tts/elevenlabs.py
+++ b/runner/src/coval_bench/providers/tts/elevenlabs.py
@@ -6,6 +6,8 @@
 TTFA is measured from the first request byte to the first PCM chunk. The
 shared client is pre-warmed by ``warmup`` before the dataset loop, so the
 measurement excludes TCP+TLS setup.
+
+eleven_v3 has no realtime WebSocket; all models use the chunked HTTP stream.
 """
 
 from __future__ import annotations
@@ -34,7 +36,9 @@ _OUTPUT_FORMAT = "pcm_24000"
 class ElevenLabsTTSProvider(TTSProvider):
     """ElevenLabs TTS provider over the REST streaming endpoint."""
 
-    _VALID_MODELS = frozenset({"eleven_flash_v2_5", "eleven_multilingual_v2", "eleven_turbo_v2_5"})
+    _VALID_MODELS = frozenset(
+        {"eleven_flash_v2_5", "eleven_multilingual_v2", "eleven_turbo_v2_5", "eleven_v3"}
+    )
 
     def __init__(self, settings: Settings, model: str, voice: str) -> None:
         if model not in self._VALID_MODELS:

--- a/runner/src/coval_bench/registries/models.py
+++ b/runner/src/coval_bench/registries/models.py
@@ -333,6 +333,14 @@ MODEL_REGISTRY: list[RegisteredModel] = [
     ),
     RegisteredModel(
         benchmark=_TTS,
+        provider="elevenlabs",
+        model="eleven_v3",
+        voice="IKne3meq5aSn9XLyUdCD",
+        tags=(_REALTIME, _MULTI, _CLONE, _EMOTION),
+        status=_ACTIVE,
+    ),
+    RegisteredModel(
+        benchmark=_TTS,
         provider="openai",
         model="gpt-4o-mini-tts",
         voice="alloy",

--- a/runner/tests/providers/tts/test_elevenlabs.py
+++ b/runner/tests/providers/tts/test_elevenlabs.py
@@ -196,11 +196,6 @@ def test_elevenlabs_name_and_model(fake_settings: Settings) -> None:
     assert p.model == "eleven_turbo_v2_5"
 
 
-def test_elevenlabs_v3_supported(fake_settings: Settings) -> None:
-    p = ElevenLabsTTSProvider(fake_settings, model="eleven_v3", voice="v")
-    assert p.model == "eleven_v3"
-
-
 def test_elevenlabs_rejects_unsupported_model(fake_settings: Settings) -> None:
     with pytest.raises(ValueError, match="Unsupported ElevenLabs model"):
         ElevenLabsTTSProvider(fake_settings, model="not-a-real-model", voice="v")

--- a/runner/tests/providers/tts/test_elevenlabs.py
+++ b/runner/tests/providers/tts/test_elevenlabs.py
@@ -196,6 +196,11 @@ def test_elevenlabs_name_and_model(fake_settings: Settings) -> None:
     assert p.model == "eleven_turbo_v2_5"
 
 
+def test_elevenlabs_v3_supported(fake_settings: Settings) -> None:
+    p = ElevenLabsTTSProvider(fake_settings, model="eleven_v3", voice="v")
+    assert p.model == "eleven_v3"
+
+
 def test_elevenlabs_rejects_unsupported_model(fake_settings: Settings) -> None:
     with pytest.raises(ValueError, match="Unsupported ElevenLabs model"):
         ElevenLabsTTSProvider(fake_settings, model="not-a-real-model", voice="v")

--- a/web/lib/config/colors.ts
+++ b/web/lib/config/colors.ts
@@ -29,6 +29,7 @@ export const modelColors: Record<string, string> = {
   eleven_multilingual_v2: "#fb9167",
   eleven_flash_v2_5: "#d87248",
   eleven_turbo_v2_5: "#bd592f",
+  eleven_v3: "#b04d20",
   scribe_v2_realtime: "#e67e54",
 
   // xAI — purple.

--- a/web/lib/utils/formatters.ts
+++ b/web/lib/utils/formatters.ts
@@ -98,7 +98,7 @@ export function normalizeModelName(modelKey: string): string {
     eleven_multilingual_v2: "Multilingual v2",
     eleven_flash_v2_5: "Flash v2.5",
     eleven_turbo_v2_5: "Turbo v2.5",
-    eleven_v3: "Eleven v3",
+    eleven_v3: "v3",
     "sonic-3": "Sonic 3",
     "sonic-3.5": "Sonic 3.5",
     "aura-2-thalia-en": "Aura 2",

--- a/web/lib/utils/formatters.ts
+++ b/web/lib/utils/formatters.ts
@@ -98,6 +98,7 @@ export function normalizeModelName(modelKey: string): string {
     eleven_multilingual_v2: "Multilingual v2",
     eleven_flash_v2_5: "Flash v2.5",
     eleven_turbo_v2_5: "Turbo v2.5",
+    eleven_v3: "Eleven v3",
     "sonic-3": "Sonic 3",
     "sonic-3.5": "Sonic 3.5",
     "aura-2-thalia-en": "Aura 2",


### PR DESCRIPTION
Registers eleven_v3 as active on the existing chunked HTTP streaming path; the model has no public realtime WebSocket.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR registers `eleven_v3` as an active ElevenLabs TTS model across all four layers it needs to touch: the provider's valid-model allowlist, the model registry, the UI color map, and the display-name formatter.

- Adds `"eleven_v3"` to `ElevenLabsTTSProvider._VALID_MODELS` so the existing chunked HTTP streaming path accepts the new model ID.
- Creates a `RegisteredModel` entry with `status=_ACTIVE` and new `_EMOTION` tag, using the same voice ID and color family as the other ElevenLabs entries.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is additive, self-contained, and touches only the four locations required to onboard a new model.

All four integration points (provider allowlist, model registry, color map, display name) are updated consistently. The new model reuses the established chunked HTTP path without any logic changes. The _EMOTION tag is correctly added for v3's new capability, and the deliberate omission of _STREAM is documented in the module docstring.

No files require special attention.

<sub>Reviews (2): Last reviewed commit: ["Trim redundant eleven\_v3 test and displa..."](https://github.com/coval-ai/benchmarks/commit/1b49f27e36d083a2d2743ccf97f5dceb168251f0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43136902)</sub>

<!-- /greptile_comment -->