### PR TITLE
Add Fish Audio streaming TTS provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,6 +33,7 @@ XAI_API_KEY=
 SMALLEST_API_KEY=
 SONIOX_API_KEY=
 REVAI_API_KEY=
+FISHAUDIO_API_KEY=
 
 # --- Google STT (optional; requires the `google-stt` extra) ---
 # GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json

--- a/runner/pyproject.toml
+++ b/runner/pyproject.toml
@@ -30,6 +30,8 @@ dependencies = [
     "cachetools>=5.3",
     # WebSocket clients (STT providers)
     "websockets>=13,<14",
+    # Fish Audio WS protocol serialization
+    "ormsgpack>=1.5",
     # TTS provider SDKs
     "openai>=1.40",
     "cartesia>=2",

--- a/runner/src/coval_bench/config.py
+++ b/runner/src/coval_bench/config.py
@@ -79,6 +79,7 @@ class Settings(BaseSettings):
     soniox_api_key: SecretStr | None = None
     revai_api_key: SecretStr | None = None
     baseten_api_key: SecretStr | None = None
+    fishaudio_api_key: SecretStr | None = None
     azure_api_key: SecretStr | None = None
 
     # Azure region hosting the Speech resource (e.g. "eastus"). Determines the

--- a/runner/src/coval_bench/providers/tts/__init__.py
+++ b/runner/src/coval_bench/providers/tts/__init__.py
@@ -19,6 +19,7 @@ from coval_bench.providers.tts.baseten import BasetenTTSProvider
 from coval_bench.providers.tts.cartesia import CartesiaTTSProvider
 from coval_bench.providers.tts.deepgram import DeepgramTTSProvider
 from coval_bench.providers.tts.elevenlabs import ElevenLabsTTSProvider
+from coval_bench.providers.tts.fishaudio import FishAudioTTSProvider
 from coval_bench.providers.tts.gradium import GradiumTTSProvider
 from coval_bench.providers.tts.groq import GroqTTSProvider
 from coval_bench.providers.tts.inworld import InworldTTSProvider
@@ -49,6 +50,7 @@ TTS_PROVIDERS: dict[str, type[TTSProvider]] = {
     "groq": GroqTTSProvider,
     "soniox": SonioxTTSProvider,
     "baseten": BasetenTTSProvider,
+    "fishaudio": FishAudioTTSProvider,
 }
 
 if HumeTTSProvider is not None:
@@ -58,6 +60,7 @@ __all__ = [
     "TTS_PROVIDERS",
     "HUME_AVAILABLE",
     "BasetenTTSProvider",
+    "FishAudioTTSProvider",
     "GradiumTTSProvider",
     "SmallestTTSProvider",
     "XaiTTSProvider",

--- a/runner/src/coval_bench/providers/tts/fishaudio.py
+++ b/runner/src/coval_bench/providers/tts/fishaudio.py
@@ -1,0 +1,126 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Fish Audio TTS provider (S1 / S2 line over WebSocket).
+
+Protocol: MessagePack-serialized events on ``wss://api.fish.audio/v1/tts/live``.
+The model is chosen by a ``model`` header on the WS handshake; the voice is a
+``reference_id`` from the Fish Audio voice library.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+import ormsgpack
+import structlog
+import websockets.asyncio.client as ws_client
+
+from coval_bench.config import Settings
+from coval_bench.providers.base import TTSProvider, TTSResult
+from coval_bench.providers.tts._common import finalize_tts_result
+
+logger: structlog.BoundLogger = structlog.get_logger(__name__)
+
+_VALID_MODELS = ("s1", "s2-pro", "s2.1-pro", "s2.1-pro-free")
+_WS_URL = "wss://api.fish.audio/v1/tts/live"
+_SAMPLE_RATE = 44100
+_MAX_WS_SIZE = 16 * 1024 * 1024
+
+
+class FishAudioTTSProvider(TTSProvider):
+    """Fish Audio TTS provider using WebSocket streaming."""
+
+    def __init__(self, settings: Settings, model: str, voice: str) -> None:
+        if model not in _VALID_MODELS:
+            raise ValueError(f"Invalid Fish Audio TTS model {model!r}. Valid: {_VALID_MODELS}")
+        if not voice:
+            raise ValueError("Fish Audio TTS requires a voice (library reference_id)")
+        self._model = model
+        self._voice = voice
+
+        api_key_secret = settings.fishaudio_api_key
+        if api_key_secret is None or not api_key_secret.get_secret_value().strip():
+            raise ValueError("fishaudio_api_key is required in Settings")
+        self._api_key = api_key_secret.get_secret_value()
+
+    @property
+    def name(self) -> str:
+        return f"fishaudio-{self._model}"
+
+    @property
+    def model(self) -> str:
+        return self._model
+
+    async def synthesize(self, text: str) -> TTSResult:
+        audio_chunks: list[bytes] = []
+        start: float | None = None
+        first_chunk_at: float | None = None
+        headers = {"Authorization": f"Bearer {self._api_key}", "model": self._model}
+
+        try:
+            async with ws_client.connect(
+                _WS_URL,
+                additional_headers=headers,
+                max_size=_MAX_WS_SIZE,
+            ) as ws:
+                # Clock starts post-handshake so TTFA excludes connect (cohort parity).
+                start = time.monotonic()
+                # latency "balanced" streams chunks as synthesized; the default
+                # "normal" buffers whole segments, folding generation into TTFA.
+                await ws.send(
+                    ormsgpack.packb(
+                        {
+                            "event": "start",
+                            "request": {
+                                "text": "",
+                                "format": "pcm",
+                                "sample_rate": _SAMPLE_RATE,
+                                "reference_id": self._voice,
+                                "latency": "balanced",
+                            },
+                        }
+                    )
+                )
+                await ws.send(ormsgpack.packb({"event": "text", "text": text}))
+                await ws.send(ormsgpack.packb({"event": "stop"}))
+
+                async for message in ws:
+                    if not isinstance(message, (bytes, bytearray)):
+                        continue
+                    data: dict[str, Any] = ormsgpack.unpackb(bytes(message))
+                    event = data.get("event")
+                    if event == "audio":
+                        if first_chunk_at is None:
+                            first_chunk_at = time.monotonic()
+                        audio_chunks.append(data["audio"])
+                    elif event == "finish":
+                        if data.get("reason") == "error":
+                            raise RuntimeError(str(data.get("message", "finish reason=error")))
+                        break
+
+        except Exception as exc:
+            logger.warning(
+                "fishaudio_tts_error", provider="fishaudio", model=self._model, exc_info=exc
+            )
+            return finalize_tts_result(
+                provider="fishaudio",
+                model=self._model,
+                voice=self._voice,
+                pcm=b"",
+                sample_rate=_SAMPLE_RATE,
+                audio_synthesis_start=start,
+                first_audio_chunk_at=first_chunk_at,
+                error=str(exc),
+            )
+
+        return finalize_tts_result(
+            provider="fishaudio",
+            model=self._model,
+            voice=self._voice,
+            pcm=b"".join(audio_chunks),
+            sample_rate=_SAMPLE_RATE,
+            audio_synthesis_start=start,
+            first_audio_chunk_at=first_chunk_at,
+        )

--- a/runner/src/coval_bench/providers/tts/fishaudio.py
+++ b/runner/src/coval_bench/providers/tts/fishaudio.py
@@ -23,7 +23,9 @@ from coval_bench.providers.tts._common import finalize_tts_result
 
 logger: structlog.BoundLogger = structlog.get_logger(__name__)
 
-_VALID_MODELS = ("s1", "s2-pro", "s2.1-pro", "s2.1-pro-free")
+# s2.1-pro-free is unregistered: same engine as s2.1-pro at $0, kept for smoke
+# tests while the account has no billing.
+_VALID_MODELS = ("s1", "s2.1-pro", "s2.1-pro-free")
 _WS_URL = "wss://api.fish.audio/v1/tts/live"
 _SAMPLE_RATE = 44100
 _MAX_WS_SIZE = 16 * 1024 * 1024
@@ -92,9 +94,11 @@ class FishAudioTTSProvider(TTSProvider):
                     data: dict[str, Any] = ormsgpack.unpackb(bytes(message))
                     event = data.get("event")
                     if event == "audio":
-                        if first_chunk_at is None:
-                            first_chunk_at = time.monotonic()
-                        audio_chunks.append(data["audio"])
+                        chunk = data.get("audio")
+                        if chunk:
+                            if first_chunk_at is None:
+                                first_chunk_at = time.monotonic()
+                            audio_chunks.append(chunk)
                     elif event == "finish":
                         if data.get("reason") == "error":
                             raise RuntimeError(str(data.get("message", "finish reason=error")))

--- a/runner/src/coval_bench/registries/models.py
+++ b/runner/src/coval_bench/registries/models.py
@@ -508,6 +508,25 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         self_hostable=True,
         status=_PENDING,
     ),
+    # Fish Audio. PENDING: no billing on the account yet — the WS handshake
+    # 402s on paid models. Voice is "Energetic Male", the reference_id Fish
+    # Audio's own docs use in examples.
+    RegisteredModel(
+        benchmark=_TTS,
+        provider="fishaudio",
+        model="s1",
+        voice="802e3bc2b27e49c2995d23ef70e6ac89",
+        tags=(_REALTIME, _MULTI, _CLONE, _EMOTION, _STREAM),
+        status=_PENDING,
+    ),
+    RegisteredModel(
+        benchmark=_TTS,
+        provider="fishaudio",
+        model="s2.1-pro",
+        voice="802e3bc2b27e49c2995d23ef70e6ac89",
+        tags=(_REALTIME, _MULTI, _CLONE, _EMOTION, _STREAM),
+        status=_PENDING,
+    ),
     # gpt-realtime is a speech-to-speech LLM, not a TTS provider: driving it
     # from a text "instructions" prompt folds LLM inference into TTFA and never
     # guarantees verbatim speech, so its metrics are incomparable here. Kept

--- a/runner/src/coval_bench/registries/provider_keys.py
+++ b/runner/src/coval_bench/registries/provider_keys.py
@@ -32,4 +32,5 @@ PROVIDER_ENV: dict[str, str] = {
     "inworld": "INWORLD_API_KEY",
     "groq": "GROQ_API_KEY",
     "baseten": "BASETEN_API_KEY",
+    "fishaudio": "FISHAUDIO_API_KEY",
 }

--- a/runner/tests/providers/tts/test_fishaudio.py
+++ b/runner/tests/providers/tts/test_fishaudio.py
@@ -142,6 +142,26 @@ async def test_fishaudio_tts_skips_non_audio_events(fishaudio_settings: Settings
 
 
 @pytest.mark.asyncio
+async def test_fishaudio_tts_skips_empty_audio_payloads(fishaudio_settings: Settings) -> None:
+    events: list[bytes | str] = [
+        ormsgpack.packb({"event": "audio", "audio": None}),
+        ormsgpack.packb({"event": "audio"}),
+        ormsgpack.packb({"event": "audio", "audio": b""}),
+    ]
+    events.extend(_finish_events([make_pcm_bytes(240)]))
+    ws = FakeWebSocket(events)
+    provider = FishAudioTTSProvider(fishaudio_settings, model="s1", voice=_VOICE)
+
+    with patch("coval_bench.providers.tts.fishaudio.ws_client.connect", return_value=ws):
+        result = await provider.synthesize("Hello")
+
+    assert result.error is None
+    assert result.ttfa_ms is not None
+    assert result.audio_path is not None
+    result.audio_path.unlink()
+
+
+@pytest.mark.asyncio
 async def test_fishaudio_tts_ttfa_on_first_chunk(fishaudio_settings: Settings) -> None:
     chunks = [make_pcm_bytes(240), make_pcm_bytes(240), make_pcm_bytes(240)]
     ws = FakeWebSocket(_finish_events(chunks))

--- a/runner/tests/providers/tts/test_fishaudio.py
+++ b/runner/tests/providers/tts/test_fishaudio.py
@@ -1,0 +1,185 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the Fish Audio WebSocket TTS provider."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import ormsgpack
+import pytest
+from pydantic import SecretStr
+
+from coval_bench.config import Settings
+from coval_bench.providers.tts.fishaudio import FishAudioTTSProvider
+
+from .conftest import FakeWebSocket, make_pcm_bytes
+
+_VOICE = "802e3bc2b27e49c2995d23ef70e6ac89"
+
+
+def _settings(**overrides: object) -> Settings:
+    base: dict[str, object] = {
+        "database_url": "postgresql://runner:password@localhost:5432/benchmarks",
+        "dataset_bucket": "test-bucket",
+        "dataset_id": "stt-v1",
+        "runner_sha": "test",
+        "log_level": "DEBUG",
+        "fishaudio_api_key": SecretStr("test-fishaudio-key"),
+    }
+    base.update(overrides)
+    return Settings(**base)  # type: ignore[arg-type]
+
+
+def _finish_events(pcm_chunks: list[bytes]) -> list[bytes | str]:
+    events: list[bytes | str] = [
+        ormsgpack.packb({"event": "audio", "audio": chunk}) for chunk in pcm_chunks
+    ]
+    events.append(ormsgpack.packb({"event": "finish", "reason": "stop"}))
+    return events
+
+
+@pytest.fixture()
+def fishaudio_settings() -> Settings:
+    return _settings()
+
+
+@pytest.mark.asyncio
+async def test_fishaudio_tts_happy_path(fishaudio_settings: Settings) -> None:
+    ws = FakeWebSocket(_finish_events([make_pcm_bytes(240)]))
+    provider = FishAudioTTSProvider(fishaudio_settings, model="s1", voice=_VOICE)
+
+    with patch("coval_bench.providers.tts.fishaudio.ws_client.connect", return_value=ws):
+        result = await provider.synthesize("Hello from Fish Audio")
+
+    assert result.error is None, f"Unexpected error: {result.error}"
+    assert result.ttfa_ms is not None
+    assert 0 < result.ttfa_ms < 60_000
+    assert result.audio_path is not None
+    assert result.audio_path.exists()
+    assert result.audio_path.read_bytes()[:4] == b"RIFF"
+    assert result.provider == "fishaudio"
+    assert result.model == "s1"
+    assert result.voice == _VOICE
+    result.audio_path.unlink()
+
+
+@pytest.mark.asyncio
+async def test_fishaudio_tts_url_and_headers(fishaudio_settings: Settings) -> None:
+    ws = FakeWebSocket(_finish_events([make_pcm_bytes(240)]))
+    captured: dict[str, object] = {}
+
+    def connect_side_effect(url: str, **kwargs: object) -> FakeWebSocket:
+        captured["url"] = url
+        captured["kwargs"] = kwargs
+        return ws
+
+    provider = FishAudioTTSProvider(fishaudio_settings, model="s2.1-pro", voice=_VOICE)
+
+    with patch(
+        "coval_bench.providers.tts.fishaudio.ws_client.connect",
+        side_effect=connect_side_effect,
+    ):
+        result = await provider.synthesize("Hello")
+
+    assert result.error is None
+    assert captured["url"] == "wss://api.fish.audio/v1/tts/live"
+    headers = captured["kwargs"]["additional_headers"]  # type: ignore[index]
+    assert headers["Authorization"] == "Bearer test-fishaudio-key"
+    assert headers["model"] == "s2.1-pro"
+    if result.audio_path is not None:
+        result.audio_path.unlink()
+
+
+@pytest.mark.asyncio
+async def test_fishaudio_tts_sends_start_text_stop(fishaudio_settings: Settings) -> None:
+    ws = FakeWebSocket(_finish_events([make_pcm_bytes(240)]))
+    provider = FishAudioTTSProvider(fishaudio_settings, model="s1", voice=_VOICE)
+
+    with patch("coval_bench.providers.tts.fishaudio.ws_client.connect", return_value=ws):
+        result = await provider.synthesize("Hello world")
+
+    sent = [ormsgpack.unpackb(m) for m in ws.sent if isinstance(m, bytes)]
+    assert sent[0]["event"] == "start"
+    request = sent[0]["request"]
+    assert request["format"] == "pcm"
+    assert request["sample_rate"] == 44100
+    assert request["reference_id"] == _VOICE
+    assert request["latency"] == "balanced"
+    assert sent[1] == {"event": "text", "text": "Hello world"}
+    assert sent[2] == {"event": "stop"}
+    if result.audio_path is not None:
+        result.audio_path.unlink()
+
+
+@pytest.mark.asyncio
+async def test_fishaudio_tts_finish_error(fishaudio_settings: Settings) -> None:
+    ws = FakeWebSocket([ormsgpack.packb({"event": "finish", "reason": "error"})])
+    provider = FishAudioTTSProvider(fishaudio_settings, model="s1", voice=_VOICE)
+
+    with patch("coval_bench.providers.tts.fishaudio.ws_client.connect", return_value=ws):
+        result = await provider.synthesize("Hello")
+
+    assert result.error is not None
+    assert result.audio_path is None
+    assert result.ttfa_ms is None
+
+
+@pytest.mark.asyncio
+async def test_fishaudio_tts_skips_non_audio_events(fishaudio_settings: Settings) -> None:
+    events: list[bytes | str] = [ormsgpack.packb({"event": "log", "message": "queued"})]
+    events.extend(_finish_events([make_pcm_bytes(240)]))
+    ws = FakeWebSocket(events)
+    provider = FishAudioTTSProvider(fishaudio_settings, model="s1", voice=_VOICE)
+
+    with patch("coval_bench.providers.tts.fishaudio.ws_client.connect", return_value=ws):
+        result = await provider.synthesize("Hello")
+
+    assert result.error is None
+    assert result.audio_path is not None
+    result.audio_path.unlink()
+
+
+@pytest.mark.asyncio
+async def test_fishaudio_tts_ttfa_on_first_chunk(fishaudio_settings: Settings) -> None:
+    chunks = [make_pcm_bytes(240), make_pcm_bytes(240), make_pcm_bytes(240)]
+    ws = FakeWebSocket(_finish_events(chunks))
+    provider = FishAudioTTSProvider(fishaudio_settings, model="s1", voice=_VOICE)
+
+    times = iter([0.0, 0.1])
+
+    with (
+        patch(
+            "coval_bench.providers.tts.fishaudio.time.monotonic",
+            side_effect=lambda: next(times, 10.0),
+        ),
+        patch("coval_bench.providers.tts.fishaudio.ws_client.connect", return_value=ws),
+    ):
+        result = await provider.synthesize("Hello")
+
+    assert result.error is None
+    assert result.ttfa_ms == pytest.approx(100.0)
+    assert result.audio_path is not None
+    result.audio_path.unlink()
+
+
+def test_fishaudio_tts_invalid_model_raises(fishaudio_settings: Settings) -> None:
+    with pytest.raises(ValueError, match="Invalid Fish Audio TTS model"):
+        FishAudioTTSProvider(fishaudio_settings, model="not-a-model", voice=_VOICE)
+
+
+def test_fishaudio_tts_missing_voice_raises(fishaudio_settings: Settings) -> None:
+    with pytest.raises(ValueError, match="requires a voice"):
+        FishAudioTTSProvider(fishaudio_settings, model="s1", voice="")
+
+
+def test_fishaudio_tts_missing_api_key_raises() -> None:
+    with pytest.raises(ValueError, match="fishaudio_api_key is required"):
+        FishAudioTTSProvider(_settings(fishaudio_api_key=None), model="s1", voice=_VOICE)
+
+
+def test_fishaudio_tts_provider_name(fishaudio_settings: Settings) -> None:
+    provider = FishAudioTTSProvider(fishaudio_settings, model="s1", voice=_VOICE)
+    assert provider.name == "fishaudio-s1"
+    assert provider.model == "s1"

--- a/runner/uv.lock
+++ b/runner/uv.lock
@@ -289,6 +289,7 @@ dependencies = [
     { name = "jiwer" },
     { name = "numpy" },
     { name = "openai" },
+    { name = "ormsgpack" },
     { name = "posthog" },
     { name = "psycopg", extra = ["binary", "pool"] },
     { name = "pydantic" },
@@ -346,6 +347,7 @@ requires-dist = [
     { name = "jiwer", specifier = ">=3.0" },
     { name = "numpy", specifier = ">=1.26" },
     { name = "openai", specifier = ">=1.40" },
+    { name = "ormsgpack", specifier = ">=1.5" },
     { name = "posthog", specifier = ">=3.0" },
     { name = "psycopg", extras = ["binary", "pool"], specifier = ">=3.2" },
     { name = "pyarrow", marker = "extra == 'hf-parquet'", specifier = ">=17" },
@@ -1048,6 +1050,23 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/3c/a6/5815fe2e2aca74b36c650d1bd43b69827cee568073d0d2d9b6fc5aaac80c/openai-2.41.0.tar.gz", hash = "sha256:db5c362acd6604b84f076abbefa66826ea4b46ecba2954ed866e6a149a1352c0", size = 783525, upload-time = "2026-06-03T22:39:40.719Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/be/51/d82bb424e8aa372190c5233253a2ceb399a778747d18b42cff487411e663/openai-2.41.0-py3-none-any.whl", hash = "sha256:20cc7952e8501c7e5773dd2ef7be437bae9cb549044902e1041a83a54516e375", size = 1353378, upload-time = "2026-06-03T22:39:38.964Z" },
+]
+
+[[package]]
+name = "ormsgpack"
+version = "1.12.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/12/0c/f1761e21486942ab9bb6feaebc610fa074f7c5e496e6962dea5873348077/ormsgpack-1.12.2.tar.gz", hash = "sha256:944a2233640273bee67521795a73cf1e959538e0dfb7ac635505010455e53b33", size = 39031, upload-time = "2026-01-18T20:55:28.023Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4c/36/16c4b1921c308a92cef3bf6663226ae283395aa0ff6e154f925c32e91ff5/ormsgpack-1.12.2-cp312-cp312-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:7a29d09b64b9694b588ff2f80e9826bdceb3a2b91523c5beae1fab27d5c940e7", size = 378618, upload-time = "2026-01-18T20:55:50.835Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/68/468de634079615abf66ed13bb5c34ff71da237213f29294363beeeca5306/ormsgpack-1.12.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0b39e629fd2e1c5b2f46f99778450b59454d1f901bc507963168985e79f09c5d", size = 203186, upload-time = "2026-01-18T20:56:11.163Z" },
+    { url = "https://files.pythonhosted.org/packages/73/a9/d756e01961442688b7939bacd87ce13bfad7d26ce24f910f6028178b2cc8/ormsgpack-1.12.2-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:958dcb270d30a7cb633a45ee62b9444433fa571a752d2ca484efdac07480876e", size = 210738, upload-time = "2026-01-18T20:56:09.181Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/ba/795b1036888542c9113269a3f5690ab53dd2258c6fb17676ac4bd44fcf94/ormsgpack-1.12.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:58d379d72b6c5e964851c77cfedfb386e474adee4fd39791c2c5d9efb53505cc", size = 212569, upload-time = "2026-01-18T20:56:06.135Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/aa/bff73c57497b9e0cba8837c7e4bcab584b1a6dbc91a5dd5526784a5030c8/ormsgpack-1.12.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8463a3fc5f09832e67bdb0e2fda6d518dc4281b133166146a67f54c08496442e", size = 387166, upload-time = "2026-01-18T20:55:36.738Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/cf/f8283cba44bcb7b14f97b6274d449db276b3a86589bdb363169b51bc12de/ormsgpack-1.12.2-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:eddffb77eff0bad4e67547d67a130604e7e2dfbb7b0cde0796045be4090f35c6", size = 482498, upload-time = "2026-01-18T20:55:29.626Z" },
+    { url = "https://files.pythonhosted.org/packages/05/be/71e37b852d723dfcbe952ad04178c030df60d6b78eba26bfd14c9a40575e/ormsgpack-1.12.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fcd55e5f6ba0dbce624942adf9f152062135f991a0126064889f68eb850de0dd", size = 425518, upload-time = "2026-01-18T20:55:49.556Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/0c/9803aa883d18c7ef197213cd2cbf73ba76472a11fe100fb7dab2884edf48/ormsgpack-1.12.2-cp312-cp312-win_amd64.whl", hash = "sha256:d024b40828f1dde5654faebd0d824f9cc29ad46891f626272dd5bfd7af2333a4", size = 117462, upload-time = "2026-01-18T20:55:47.726Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/9e/029e898298b2cc662f10d7a15652a53e3b525b1e7f07e21fef8536a09bb8/ormsgpack-1.12.2-cp312-cp312-win_arm64.whl", hash = "sha256:da538c542bac7d1c8f3f2a937863dba36f013108ce63e55745941dda4b75dbb6", size = 111559, upload-time = "2026-01-18T20:55:54.273Z" },
 ]
 
 [[package]]

--- a/web/lib/utils/formatters.ts
+++ b/web/lib/utils/formatters.ts
@@ -188,6 +188,7 @@ export function normalizeTTSProviderName(providerName: string): string {
     cartesia: "Cartesia",
     deepgram: "Deepgram",
     elevenlabs: "ElevenLabs",
+    fishaudio: "Fish Audio",
     gradium: "Gradium",
     hume: "Hume",
     inworld: "Inworld AI",


### PR DESCRIPTION
S1 and S2.1 Pro over the msgpack WebSocket API, registered PENDING until account billing is enabled; Fish Audio's STT is batch-only and out of scope.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds Fish Audio (S1 and S2.1 Pro) as a new TTS provider using Fish Audio's msgpack WebSocket API, registered as `PENDING` until account billing is enabled. The implementation follows the same pattern as the existing Soniox WebSocket provider.

- New `FishAudioTTSProvider` streams PCM audio over `wss://api.fish.audio/v1/tts/live`, sending three sequential msgpack frames (`start`, `text`, `stop`) and collecting audio chunks until a `finish` event.
- The provider is wired into the TTS registry (`models.py`, `provider_keys.py`, `__init__.py`), the settings model, and the web formatter, with `ormsgpack` added as a hard dependency locked to cp312 wheels (safe given `requires-python = \">=3.12,<3.13\"`).
- A thorough test suite covers the happy path, error handling, header assertions, skipped null/empty audio payloads, and TTFA timing.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the new provider is isolated, registered as PENDING, and cannot affect existing benchmark runs.

The change is additive: a brand-new provider class, new registry entries marked PENDING, one new dependency, and no modifications to shared logic. Audio chunk handling correctly uses data.get('audio') with a truthiness guard, null/empty payloads are skipped and tested, and all error paths return a well-formed TTSResult rather than raising. The s2.1-pro-free entry in _VALID_MODELS is documented with an explanatory comment and intentionally excluded from the registry.

No files require special attention.

<sub>Reviews (2): Last reviewed commit: ["Guard Fish Audio audio events and trim m..."](https://github.com/coval-ai/benchmarks/commit/90dc73e720e846b0e96213328093f1081ab55fab) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43138825)</sub>

<!-- /greptile_comment -->