### PR TITLE
Add Google Cloud TTS streaming provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,7 +34,7 @@ SMALLEST_API_KEY=
 SONIOX_API_KEY=
 REVAI_API_KEY=
 
-# --- Google STT (optional; requires the `google-stt` extra) ---
+# --- Google STT/TTS (optional; requires the `google-stt` / `google-tts` extras) ---
 # GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json
 # GOOGLE_PROJECT_ID=
 

--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -31,7 +31,7 @@ ENV UV_COMPILE_BYTECODE=1 \
 COPY pyproject.toml uv.lock README.md ./
 
 # Install production dependencies (no dev) into /app/.venv
-RUN uv sync --frozen --no-dev --extra google-stt
+RUN uv sync --frozen --no-dev --extra google-stt --extra google-tts
 
 # Copy source tree + alembic config (db/cli.py reads /app/alembic.ini)
 COPY src/ ./src/

--- a/runner/pyproject.toml
+++ b/runner/pyproject.toml
@@ -45,6 +45,7 @@ dependencies = [
 
 [project.optional-dependencies]
 google-stt = ["google-cloud-speech>=2.27"]
+google-tts = ["google-cloud-texttospeech>=2.29"]  # >=2.29 for Gemini-TTS streaming
 hume-tts = ["hume>=0.7"]
 hf-parquet = ["pyarrow>=17"]  # build-time only: parquet fallback for unconverted HF datasets
 

--- a/runner/src/coval_bench/providers/tts/__init__.py
+++ b/runner/src/coval_bench/providers/tts/__init__.py
@@ -36,6 +36,12 @@ except ImportError:
     HumeTTSProvider = None  # type: ignore[assignment,misc]
     HUME_AVAILABLE = False
 
+try:
+    from coval_bench.providers.tts.google import GOOGLE_TTS_AVAILABLE, GoogleTTSProvider
+except ImportError:
+    GoogleTTSProvider = None  # type: ignore[assignment,misc]
+    GOOGLE_TTS_AVAILABLE = False
+
 TTS_PROVIDERS: dict[str, type[TTSProvider]] = {
     "openai": OpenAITTSProvider,
     "cartesia": CartesiaTTSProvider,
@@ -54,9 +60,13 @@ TTS_PROVIDERS: dict[str, type[TTSProvider]] = {
 if HumeTTSProvider is not None:
     TTS_PROVIDERS["hume"] = HumeTTSProvider
 
+if GoogleTTSProvider is not None and GOOGLE_TTS_AVAILABLE:
+    TTS_PROVIDERS["google"] = GoogleTTSProvider
+
 __all__ = [
     "TTS_PROVIDERS",
     "HUME_AVAILABLE",
+    "GOOGLE_TTS_AVAILABLE",
     "BasetenTTSProvider",
     "GradiumTTSProvider",
     "SmallestTTSProvider",

--- a/runner/src/coval_bench/providers/tts/google.py
+++ b/runner/src/coval_bench/providers/tts/google.py
@@ -1,0 +1,168 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Google Cloud Text-to-Speech provider (gRPC StreamingSynthesize).
+
+This provider is gated on the optional extra ``google-tts``:
+
+    uv sync --extra google-tts
+
+Auth: Application Default Credentials (the runner service account in Cloud Run).
+Models: chirp-3-hd (bidirectional — audio streams while text streams in),
+gemini-2.5-flash-tts (output streaming only — synthesis starts at input half-close).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+from collections.abc import Generator
+
+import structlog
+
+from coval_bench.config import Settings
+from coval_bench.providers.base import TTSProvider, TTSResult
+from coval_bench.providers.tts._common import finalize_tts_result
+
+logger: structlog.BoundLogger = structlog.get_logger(__name__)
+
+try:
+    from google.cloud import texttospeech
+
+    GOOGLE_TTS_AVAILABLE = True
+except ImportError:
+    GOOGLE_TTS_AVAILABLE = False
+
+SAMPLE_RATE = 24000
+
+# One warm gRPC channel per process so TTFA never pays connection/auth cold start.
+_client_lock = threading.Lock()
+_shared_client: texttospeech.TextToSpeechClient | None = None
+
+
+def _get_shared_client() -> texttospeech.TextToSpeechClient:
+    global _shared_client
+    with _client_lock:
+        if _shared_client is None:
+            _shared_client = texttospeech.TextToSpeechClient()
+        return _shared_client
+
+
+class GoogleTTSProvider(TTSProvider):
+    """Google Cloud TTS over the bidirectional StreamingSynthesize RPC.
+
+    Install with:  uv sync --extra google-tts
+    Requires:      Application Default Credentials (the runner service account in Cloud Run).
+    """
+
+    _VALID_MODELS = frozenset({"chirp-3-hd", "gemini-2.5-flash-tts"})
+
+    def __init__(self, settings: Settings, model: str, voice: str) -> None:
+        if not GOOGLE_TTS_AVAILABLE:
+            raise ImportError(
+                "google-cloud-texttospeech is not installed. "
+                "Install it with: uv sync --extra google-tts"
+            )
+        self._model = model
+        self._voice = voice
+
+    @property
+    def name(self) -> str:
+        return f"google-{self._model}"
+
+    @property
+    def model(self) -> str:
+        return self._model
+
+    @classmethod
+    async def warmup(cls, settings: Settings) -> None:
+        """Open the shared gRPC channel and cache an auth token before t0."""
+        if not GOOGLE_TTS_AVAILABLE:
+            return
+        t0 = time.monotonic()
+        await asyncio.to_thread(lambda: _get_shared_client().list_voices(language_code="en-US"))
+        logger.info("google_tts_prewarm", warmup_ms=round((time.monotonic() - t0) * 1000, 1))
+
+    def _voice_params(self) -> texttospeech.VoiceSelectionParams:
+        if self._model.startswith("gemini-"):
+            return texttospeech.VoiceSelectionParams(
+                name=self._voice,
+                language_code="en-US",
+                model_name=self._model,
+            )
+        # Chirp voice names embed the locale: en-US-Chirp3-HD-Kore.
+        return texttospeech.VoiceSelectionParams(
+            name=self._voice,
+            language_code="-".join(self._voice.split("-")[:2]),
+        )
+
+    async def synthesize(self, text: str) -> TTSResult:
+        """Synthesize speech via StreamingSynthesize and return a TTSResult."""
+        if not self._model_supported(self._model):
+            return TTSResult(
+                provider="google",
+                model=self._model,
+                voice=self._voice,
+                ttfa_ms=None,
+                audio_path=None,
+                error=(
+                    f"Unsupported Google TTS model: {self._model}. "
+                    f"Valid: {sorted(self._VALID_MODELS)}"
+                ),
+            )
+
+        audio_chunks: list[bytes] = []
+        start: float | None = None
+        first_chunk_at: float | None = None
+
+        streaming_config = texttospeech.StreamingSynthesizeConfig(
+            voice=self._voice_params(),
+            streaming_audio_config=texttospeech.StreamingAudioConfig(
+                audio_encoding=texttospeech.AudioEncoding.PCM,
+                sample_rate_hertz=SAMPLE_RATE,
+            ),
+        )
+
+        def _requests() -> Generator[texttospeech.StreamingSynthesizeRequest, None, None]:
+            yield texttospeech.StreamingSynthesizeRequest(streaming_config=streaming_config)
+            yield texttospeech.StreamingSynthesizeRequest(
+                input=texttospeech.StreamingSynthesisInput(text=text)
+            )
+            # Generator exhaustion half-closes the stream (Gemini's synthesis trigger).
+
+        def _run_sync() -> None:
+            nonlocal start, first_chunk_at
+            client = _get_shared_client()
+            # t0 — synthesis trigger; the channel is warm, so no connect cost leaks in.
+            start = time.monotonic()
+            for response in client.streaming_synthesize(requests=_requests()):
+                if response.audio_content:
+                    if first_chunk_at is None:
+                        first_chunk_at = time.monotonic()
+                    audio_chunks.append(bytes(response.audio_content))
+
+        try:
+            await asyncio.to_thread(_run_sync)
+        except Exception as exc:
+            logger.warning("google_tts_error", provider="google", model=self._model, exc_info=exc)
+            return finalize_tts_result(
+                provider="google",
+                model=self._model,
+                voice=self._voice,
+                pcm=b"",
+                sample_rate=SAMPLE_RATE,
+                audio_synthesis_start=start,
+                first_audio_chunk_at=first_chunk_at,
+                error=str(exc),
+            )
+
+        return finalize_tts_result(
+            provider="google",
+            model=self._model,
+            voice=self._voice,
+            pcm=b"".join(audio_chunks),
+            sample_rate=SAMPLE_RATE,
+            audio_synthesis_start=start,
+            first_audio_chunk_at=first_chunk_at,
+        )

--- a/runner/src/coval_bench/registries/models.py
+++ b/runner/src/coval_bench/registries/models.py
@@ -494,6 +494,26 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         status=_PENDING,
         arena_enabled=False,
     ),
+    # Google TTS: Gemini buffers input until half-close, hence no streaming-input
+    # tag. Arena-disabled: auth is ADC, not a mountable API-key env var.
+    RegisteredModel(
+        benchmark=_TTS,
+        provider="google",
+        model="chirp-3-hd",
+        voice="en-US-Chirp3-HD-Kore",
+        tags=(_REALTIME, _MULTI, _STREAM),
+        status=_PENDING,
+        arena_enabled=False,
+    ),
+    RegisteredModel(
+        benchmark=_TTS,
+        provider="google",
+        model="gemini-2.5-flash-tts",
+        voice="Kore",
+        tags=(_REALTIME, _MULTI),
+        status=_PENDING,
+        arena_enabled=False,
+    ),
     # Baseten dedicated endpoints (Qwen3-TTS 1.7B). PENDING for the same reason
     # as the Whisper STT entry above — implemented, hidden, run manually.
     RegisteredModel(

--- a/runner/tests/providers/tts/test_google.py
+++ b/runner/tests/providers/tts/test_google.py
@@ -1,0 +1,163 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for coval_bench.providers.tts.google (GoogleTTSProvider).
+
+The google-cloud-texttospeech package is optional (extra: ``google-tts``).
+Tests are skipped when it is not installed.
+
+To run these tests locally:
+    uv sync --extra google-tts
+    uv run pytest tests/providers/tts/test_google.py -v
+"""
+
+from __future__ import annotations
+
+from collections.abc import Generator
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+texttospeech = pytest.importorskip(
+    "google.cloud.texttospeech",
+    reason="google-cloud-texttospeech not installed; install with: uv sync --extra google-tts",
+)
+
+from coval_bench.config import Settings  # noqa: E402
+from coval_bench.providers.tts import google as google_tts  # noqa: E402
+from coval_bench.providers.tts.google import SAMPLE_RATE, GoogleTTSProvider  # noqa: E402
+
+from .conftest import make_pcm_bytes  # noqa: E402
+
+CHIRP_MODEL = "chirp-3-hd"
+CHIRP_VOICE = "en-US-Chirp3-HD-Kore"
+GEMINI_MODEL = "gemini-2.5-flash-tts"
+GEMINI_VOICE = "Kore"
+
+
+@pytest.fixture(autouse=True)
+def _reset_shared_client() -> Generator[None, None, None]:
+    """Isolate the module-level shared client between tests."""
+    google_tts._shared_client = None
+    yield
+    google_tts._shared_client = None
+
+
+def _make_client(responses: list[Any] | None = None) -> tuple[MagicMock, dict[str, Any]]:
+    """Mock client whose streaming_synthesize consumes and captures requests."""
+    captured: dict[str, Any] = {}
+    client = MagicMock()
+
+    def _fake_streaming_synthesize(requests: Any) -> Any:
+        captured["requests"] = list(requests)
+        return iter(responses or [])
+
+    client.streaming_synthesize.side_effect = _fake_streaming_synthesize
+    return client, captured
+
+
+def _audio_responses(n: int = 3) -> list[Any]:
+    return [
+        texttospeech.StreamingSynthesizeResponse(audio_content=make_pcm_bytes(480))
+        for _ in range(n)
+    ]
+
+
+@pytest.mark.asyncio
+async def test_google_chirp_success(fake_settings: Settings, sample_text: str) -> None:
+    client, captured = _make_client(_audio_responses())
+
+    with patch.object(google_tts, "_get_shared_client", return_value=client):
+        provider = GoogleTTSProvider(fake_settings, model=CHIRP_MODEL, voice=CHIRP_VOICE)
+        result = await provider.synthesize(sample_text)
+
+    assert result.error is None
+    assert result.provider == "google"
+    assert result.model == CHIRP_MODEL
+    assert result.voice == CHIRP_VOICE
+    assert result.ttfa_ms is not None and 0 < result.ttfa_ms < 60_000
+    assert result.audio_path is not None and result.audio_path.exists()
+    result.audio_path.unlink()
+
+    requests = captured["requests"]
+    assert len(requests) == 2
+    config = requests[0].streaming_config
+    assert config.voice.name == CHIRP_VOICE
+    assert config.voice.language_code == "en-US"
+    assert config.voice.model_name == ""
+    assert config.streaming_audio_config.audio_encoding == texttospeech.AudioEncoding.PCM
+    assert config.streaming_audio_config.sample_rate_hertz == SAMPLE_RATE
+    assert requests[1].input.text == sample_text
+
+
+@pytest.mark.asyncio
+async def test_google_gemini_voice_params(fake_settings: Settings, sample_text: str) -> None:
+    client, captured = _make_client(_audio_responses())
+
+    with patch.object(google_tts, "_get_shared_client", return_value=client):
+        provider = GoogleTTSProvider(fake_settings, model=GEMINI_MODEL, voice=GEMINI_VOICE)
+        result = await provider.synthesize(sample_text)
+
+    assert result.error is None
+    voice = captured["requests"][0].streaming_config.voice
+    assert voice.name == GEMINI_VOICE
+    assert voice.language_code == "en-US"
+    assert voice.model_name == GEMINI_MODEL
+    assert result.audio_path is not None
+    result.audio_path.unlink()
+
+
+@pytest.mark.asyncio
+async def test_google_stream_error(fake_settings: Settings, sample_text: str) -> None:
+    client = MagicMock()
+    client.streaming_synthesize.side_effect = RuntimeError("stream exploded")
+
+    with patch.object(google_tts, "_get_shared_client", return_value=client):
+        provider = GoogleTTSProvider(fake_settings, model=CHIRP_MODEL, voice=CHIRP_VOICE)
+        result = await provider.synthesize(sample_text)
+
+    assert result.error is not None and "stream exploded" in result.error
+    assert result.audio_path is None
+
+
+@pytest.mark.asyncio
+async def test_google_no_audio(fake_settings: Settings, sample_text: str) -> None:
+    client, _ = _make_client([])
+
+    with patch.object(google_tts, "_get_shared_client", return_value=client):
+        provider = GoogleTTSProvider(fake_settings, model=CHIRP_MODEL, voice=CHIRP_VOICE)
+        result = await provider.synthesize(sample_text)
+
+    assert result.error is None
+    assert result.ttfa_ms is None
+    assert result.audio_path is None
+
+
+@pytest.mark.asyncio
+async def test_google_unsupported_model(fake_settings: Settings, sample_text: str) -> None:
+    client, _ = _make_client()
+
+    with patch.object(google_tts, "_get_shared_client", return_value=client):
+        provider = GoogleTTSProvider(fake_settings, model="chirp-2-hd", voice=CHIRP_VOICE)
+        result = await provider.synthesize(sample_text)
+
+    assert result.error is not None and "Unsupported" in result.error
+    assert result.audio_path is None
+    client.streaming_synthesize.assert_not_called()
+
+
+def test_google_properties(fake_settings: Settings) -> None:
+    provider = GoogleTTSProvider(fake_settings, model=CHIRP_MODEL, voice=CHIRP_VOICE)
+    assert provider.name == "google-chirp-3-hd"
+    assert provider.model == CHIRP_MODEL
+
+
+@pytest.mark.asyncio
+async def test_google_warmup_opens_channel(fake_settings: Settings) -> None:
+    client = MagicMock()
+
+    with patch.object(google_tts, "_get_shared_client", return_value=client):
+        await GoogleTTSProvider.warmup(settings=fake_settings)
+
+    client.list_voices.assert_called_once_with(language_code="en-US")

--- a/runner/uv.lock
+++ b/runner/uv.lock
@@ -306,6 +306,9 @@ dependencies = [
 google-stt = [
     { name = "google-cloud-speech" },
 ]
+google-tts = [
+    { name = "google-cloud-texttospeech" },
+]
 hf-parquet = [
     { name = "pyarrow" },
 ]
@@ -341,6 +344,7 @@ requires-dist = [
     { name = "fastapi", specifier = ">=0.111" },
     { name = "google-cloud-speech", marker = "extra == 'google-stt'", specifier = ">=2.27" },
     { name = "google-cloud-storage", specifier = ">=2.18" },
+    { name = "google-cloud-texttospeech", marker = "extra == 'google-tts'", specifier = ">=2.29" },
     { name = "httpx", extras = ["http2"], specifier = ">=0.27" },
     { name = "hume", marker = "extra == 'hume-tts'", specifier = ">=0.7" },
     { name = "jiwer", specifier = ">=3.0" },
@@ -359,7 +363,7 @@ requires-dist = [
     { name = "websockets", specifier = ">=13,<14" },
     { name = "whisper-normalizer", specifier = ">=0.0.10" },
 ]
-provides-extras = ["google-stt", "hume-tts", "hf-parquet"]
+provides-extras = ["google-stt", "google-tts", "hume-tts", "hf-parquet"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -603,6 +607,22 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/22/09/8953e2993e604c8882fd441b5b2de624a2dfe7e6144c6166d7b477509596/google_cloud_storage-3.11.0.tar.gz", hash = "sha256:498bf37c999028f69a245f586b5e50d89f59df1fafc0e3a93783ac56be2a456b", size = 17335639, upload-time = "2026-06-03T16:14:04.649Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/09/7e/ee0dd1a67ac75d29d0c438969d85d4fadbc4bcab47b0a8ccfa7eb22f643c/google_cloud_storage-3.11.0-py3-none-any.whl", hash = "sha256:cfcc33aa6b899ec9dd1771286f8e79fbed5c35c1c174718071b079aa827f37c2", size = 339654, upload-time = "2026-06-03T16:12:46.052Z" },
+]
+
+[[package]]
+name = "google-cloud-texttospeech"
+version = "2.37.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-api-core", extra = ["grpc"] },
+    { name = "google-auth" },
+    { name = "grpcio" },
+    { name = "proto-plus" },
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/af/bf/42e7d2f32d79c75bc23f949e97a278d46b7d08638e94b570947be02e3bce/google_cloud_texttospeech-2.37.0.tar.gz", hash = "sha256:db726382f393ceb6b36002c35abd62b53c4d8e17fc2f31df8b07fd0fabbe4f8b", size = 196465, upload-time = "2026-06-22T23:22:37.28Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/44/675358f0b939f14ae6481dddecbde5fd91b92b51f7991a70d98d3c68c02e/google_cloud_texttospeech-2.37.0-py3-none-any.whl", hash = "sha256:911f42f327027975d7781efcace1993afdf311b692b95b6814b71085750cc38a", size = 199697, upload-time = "2026-06-22T23:20:37.235Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Chirp 3 HD and Gemini 2.5 Flash TTS over StreamingSynthesize, registered PENDING until the TTS API is enabled for the runner project.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a Google Cloud TTS streaming provider (`GoogleTTSProvider`) backed by the gRPC `StreamingSynthesize` API, supporting chirp-3-hd (bidirectional) and gemini-2.5-flash-tts (output-only streaming). Both models are registered as `PENDING` pending TTS API enablement on the runner project.

- Adds `runner/src/coval_bench/providers/tts/google.py` with a process-level shared gRPC client, `asyncio.to_thread` offload for the blocking RPC, and error handling via the existing `finalize_tts_result` helper.
- Adds the `google-tts` optional dependency (`google-cloud-texttospeech>=2.29`) and installs it in the Dockerfile alongside `google-stt`.
- Registers chirp-3-hd and gemini-2.5-flash-tts in the model registry with `arena_enabled=False` (ADC auth is not API-key mountable).

<h3>Confidence Score: 4/5</h3>

Safe to merge for the PENDING/hidden models; the two minor issues are in non-crashing edge cases and don't affect the happy path.

The new provider is well-structured and follows existing patterns. The two findings are both in edge-case paths: timing is silently omitted only when the gRPC client itself fails to construct (rare), and the voice locale extraction only misbehaves for non-standard Chirp voice names not in the current registry. Neither causes a crash or incorrect audio output on the registered voices.

runner/src/coval_bench/providers/tts/google.py — the _run_sync timing assignment and the _voice_params locale extraction are the spots worth a second look before adding new Chirp voices.

<sub>Reviews (1): Last reviewed commit: ["Add Google Cloud TTS streaming provider"](https://github.com/coval-ai/benchmarks/commit/2d5f53331f51980e31922d0f9a707b818e499b30) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43140603)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->