### PR TITLE
Activate Google chirp-3-hd and Fish Audio s1/s2.1-pro TTS

### DIFF
--- a/runner/src/coval_bench/registries/models.py
+++ b/runner/src/coval_bench/registries/models.py
@@ -510,7 +510,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         model="chirp-3-hd",
         voice="en-US-Chirp3-HD-Kore",
         tags=(_REALTIME, _MULTI, _STREAM),
-        status=_PENDING,
+        status=_ACTIVE,
         arena_enabled=False,
     ),
     RegisteredModel(
@@ -545,16 +545,15 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         status=_ACTIVE,
         arena_enabled=False,
     ),
-    # Fish Audio. PENDING: no billing on the account yet — the WS handshake
-    # 402s on paid models. Voice is "Energetic Male", the reference_id Fish
-    # Audio's own docs use in examples.
+    # Fish Audio. Voice is "Energetic Male", the reference_id Fish Audio's own
+    # docs use in examples.
     RegisteredModel(
         benchmark=_TTS,
         provider="fishaudio",
         model="s1",
         voice="802e3bc2b27e49c2995d23ef70e6ac89",
         tags=(_REALTIME, _MULTI, _CLONE, _EMOTION, _STREAM),
-        status=_PENDING,
+        status=_ACTIVE,
     ),
     RegisteredModel(
         benchmark=_TTS,
@@ -562,7 +561,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         model="s2.1-pro",
         voice="802e3bc2b27e49c2995d23ef70e6ac89",
         tags=(_REALTIME, _MULTI, _CLONE, _EMOTION, _STREAM),
-        status=_PENDING,
+        status=_ACTIVE,
     ),
     # gpt-realtime is a speech-to-speech LLM, not a TTS provider: driving it
     # from a text "instructions" prompt folds LLM inference into TTFA and never


### PR DESCRIPTION
Smoke-verified: chirp from the prod runner environment, Fish Audio paid models against the now-funded account; gemini-2.5-flash-tts stays pending on Vertex AI enablement.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR activates three TTS models — Google `chirp-3-hd` and Fish Audio `s1`/`s2.1-pro` — by flipping their status from `_PENDING` to `_ACTIVE` in the model registry, and removes the now-resolved billing-block comment for Fish Audio.

- `chirp-3-hd` is marked `arena_enabled=False` (consistent with the existing ADC auth note for Google TTS); the two Fish Audio entries carry no explicit `arena_enabled`, so they inherit the default `True`, which is appropriate for key-based providers.
- The `gemini-2.5-flash-tts` entry remains `_PENDING` as noted in the PR description, pending Vertex AI enablement.

<h3>Confidence Score: 5/5</h3>

Three status fields flipped from pending to active; no logic, schema, or auth changes. Smoke-verified per PR description.

The change is limited to activating pre-implemented models in the registry. The Fish Audio models correctly inherit arena_enabled=True (key-based auth), chirp-3-hd retains its explicit arena_enabled=False (ADC auth). All three activations are consistent with the surrounding registry patterns and the PR description's verification note.

No files require special attention.

<sub>Reviews (1): Last reviewed commit: ["Activate Google chirp-3-hd and Fish Audi..."](https://github.com/coval-ai/benchmarks/commit/1bb6a9b81bb812250feba3d30f1a680522b4a933) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43164197)</sub>

<!-- /greptile_comment -->