### PR TITLE
[BENCH-395] Make the mobile latency tooltip readable: tap to expand + scrubber playhead

### DIFF
--- a/web/components/charts/tooltips/TimelineTooltip.tsx
+++ b/web/components/charts/tooltips/TimelineTooltip.tsx
@@ -26,9 +26,11 @@ interface TimelineTooltipProps {
   compact?: boolean;
   /** Optional replacement for the compact hover interaction hint. */
   interactionHint?: string | false;
+  /** Caps the scroll area (px); keeps the pinned list from covering the chart on mobile. */
+  maxHeight?: number;
 }
 
-const CustomTimelineTooltip: React.FC<TimelineTooltipProps> = ({ active, payload, label, getProviderForModel, showDate, dimmedKeys, compact, interactionHint }) => {
+const CustomTimelineTooltip: React.FC<TimelineTooltipProps> = ({ active, payload, label, getProviderForModel, showDate, dimmedKeys, compact, interactionHint, maxHeight }) => {
   if (!active || !payload || payload.length === 0) return null;
 
   // Filter out null/undefined values and sort by value (fastest to slowest)
@@ -81,7 +83,7 @@ const CustomTimelineTooltip: React.FC<TimelineTooltipProps> = ({ active, payload
         style={
           compact
             ? { fontSize: "11px" }
-            : { fontSize: "11px", maxHeight: "300px", overflowY: "scroll", paddingRight: "8px" }
+            : { fontSize: "11px", maxHeight: `${maxHeight ?? 300}px`, overflowY: "scroll", paddingRight: "8px" }
         }
       >
         {rows.map((item) => {

--- a/web/components/charts/tooltips/TimelineTooltip.tsx
+++ b/web/components/charts/tooltips/TimelineTooltip.tsx
@@ -83,7 +83,15 @@ const CustomTimelineTooltip: React.FC<TimelineTooltipProps> = ({ active, payload
         style={
           compact
             ? { fontSize: "11px" }
-            : { fontSize: "11px", maxHeight: `${maxHeight ?? 300}px`, overflowY: "scroll", paddingRight: "8px" }
+            : {
+                fontSize: "11px",
+                maxHeight: `${maxHeight ?? 300}px`,
+                overflowY: "scroll",
+                paddingRight: "8px",
+                touchAction: "pan-y",
+                overscrollBehavior: "contain",
+                WebkitOverflowScrolling: "touch",
+              }
         }
       >
         {rows.map((item) => {

--- a/web/components/visualizations/TimelineChart.tsx
+++ b/web/components/visualizations/TimelineChart.tsx
@@ -622,6 +622,14 @@ const TimelineChart: React.FC = () => {
     setMobileScrub(null);
   };
 
+  // The browser hijacking the touch into a native scroll fires pointercancel
+  // with no horizontal travel — that must not read as a tap, so drop the
+  // gesture without toggling the pin.
+  const cancelAxisScrub = () => {
+    axisScrubRef.current = null;
+    setMobileScrub(null);
+  };
+
   // Whether a data value sits inside the visible (possibly zoomed) Y range.
   // Recharts doesn't clip active dots, so out-of-view dots must not render.
   const inYView = (v?: number) =>
@@ -950,7 +958,7 @@ const TimelineChart: React.FC = () => {
                 }}
                 onPointerCancel={(e) => {
                   e.stopPropagation();
-                  endAxisScrub();
+                  cancelAxisScrub();
                 }}
               >
               </div>

--- a/web/components/visualizations/TimelineChart.tsx
+++ b/web/components/visualizations/TimelineChart.tsx
@@ -110,6 +110,22 @@ const MethodologyMarkerLabel: React.FC<MarkerLabelProps> = ({
   );
 };
 
+// Scrubber playhead knob: a dot at the top of the reference line so the
+// scrubbed instant reads at a glance on mobile, where there is no hover cursor.
+const ScrubMarkerDot: React.FC<{
+  viewBox?: { x?: number; y?: number };
+  color: string;
+}> = ({ viewBox, color }) => (
+  <circle
+    cx={viewBox?.x ?? 0}
+    cy={viewBox?.y ?? 0}
+    r={4}
+    fill={color}
+    stroke="var(--color-surface-primary)"
+    strokeWidth={1.5}
+  />
+);
+
 interface TooltipPayloadItem {
   dataKey: string;
   value: number;
@@ -200,7 +216,11 @@ const TimelineChart: React.FC = () => {
     y?: [number, number];
   } | null>(null);
   const boxRef = useRef<HTMLDivElement>(null);
-  const axisScrubRef = useRef(false);
+  const axisScrubRef = useRef<{
+    x: number;
+    moved: boolean;
+    wasPinned: boolean;
+  } | null>(null);
   const dragRef = useRef<{
     x: number;
     y: number;
@@ -569,17 +589,36 @@ const TimelineChart: React.FC = () => {
   };
 
   const startAxisScrub = (e: React.PointerEvent<HTMLDivElement>) => {
-    axisScrubRef.current = true;
+    axisScrubRef.current = { x: e.clientX, moved: false, wasPinned: pinned != null };
     scrubDateAxis(e);
   };
 
   const moveAxisScrub = (e: React.PointerEvent<HTMLDivElement>) => {
-    if (!axisScrubRef.current) return;
+    const scrub = axisScrubRef.current;
+    if (!scrub) return;
+    if (Math.abs(e.clientX - scrub.x) > 8) scrub.moved = true;
     scrubDateAxis(e);
   };
 
+  // A drag scrubs (compact readout only); a tap toggles the full ranked list
+  // at that timestamp, reusing the pinned tooltip. wasPinned is captured at
+  // tap-start so the toggle survives the outside-tap dismiss handler.
   const endAxisScrub = () => {
-    axisScrubRef.current = false;
+    const scrub = axisScrubRef.current;
+    const tapped = scrub != null && !scrub.moved;
+    axisScrubRef.current = null;
+    if (tapped) {
+      if (scrub!.wasPinned) {
+        setPinned(null);
+      } else if (mobileScrub) {
+        const box = interactionBox ?? plotBox();
+        setPinned(
+          box
+            ? { ...mobileScrub, x: box.left, y: box.top, flip: false }
+            : mobileScrub
+        );
+      }
+    }
     setMobileScrub(null);
   };
 
@@ -599,6 +638,13 @@ const TimelineChart: React.FC = () => {
     color: getModelColor(model),
     dataKey: `${model}_value`,
   }));
+
+  // Mobile has no hover cursor, so a vertical playhead marks the instant being
+  // scrubbed or pinned — the timestamp both the compact readout and the pinned
+  // list are reading from.
+  const scrubMarkerTs = isMobile
+    ? Number(mobileScrub?.label ?? pinned?.label ?? NaN)
+    : NaN;
 
   return (
     <div className="mb-4">
@@ -834,6 +880,15 @@ const TimelineChart: React.FC = () => {
                   }
                 />
               ))}
+              {Number.isFinite(scrubMarkerTs) && (
+                <ReferenceLine
+                  x={scrubMarkerTs}
+                  stroke={themeColors.label}
+                  strokeWidth={1.5}
+                  strokeOpacity={0.65}
+                  label={<ScrubMarkerDot color={themeColors.label} />}
+                />
+              )}
             </LineChart>
           </ResponsiveContainer>
           <div
@@ -920,7 +975,7 @@ const TimelineChart: React.FC = () => {
                 showDate={dateScale}
                 dimmedKeys={dimmedLegendKeys}
                 compact
-                interactionHint="drag chart area to zoom"
+                interactionHint="tap axis to see all"
               />
             </div>
           )}
@@ -931,9 +986,11 @@ const TimelineChart: React.FC = () => {
               style={{
                 left: pinned.x,
                 top: pinned.y,
-                transform: pinned.flip
-                  ? "translate(calc(-100% - 12px), -50%)"
-                  : "translate(12px, -50%)",
+                transform: isMobile
+                  ? "translate(12px, 0)"
+                  : pinned.flip
+                    ? "translate(calc(-100% - 12px), -50%)"
+                    : "translate(12px, -50%)",
               }}
               onPointerDown={(e) => e.stopPropagation()}
             >
@@ -952,6 +1009,7 @@ const TimelineChart: React.FC = () => {
                 getProviderForModel={getProviderForModel}
                 showDate={dateScale}
                 dimmedKeys={dimmedLegendKeys}
+                maxHeight={isMobile ? 106 : undefined}
               />
             </div>
           )}


### PR DESCRIPTION
## Problem
On mobile, scrubbing the TTS latency chart only surfaced the **fastest** model plus a `+16 more · drag chart area to zoom` line — a dead end. With 18 series on screen, the tooltip was nearly useless on phones, defeating the point of a comparison chart. (BENCH-395)

## Fix
Makes the touch scrub interaction usable, **reusing the existing tooltip and scrub payload — no separate mobile data path**, and no changes to backend/API/auth:

- **Tap the date axis** to open the full ranked list at that timestamp. **Dragging** still scrubs (compact readout) and no longer auto-opens.
- The tapped list persists as a **compact, scrollable panel** showing the **top ~3** (drag to scroll the other 14), **anchored to the empty top of the plot** so it doesn't cover the data band or clip off-canvas.
- A **vertical playhead with a knob** marks the scrubbed/pinned instant — standing in for the hover cursor touch devices lack (YouTube-scrubber feel).

All new behavior is gated on `isMobile`; **desktop hover + click-to-pin are unchanged**. A small optional `maxHeight` prop was added to the timeline tooltip so the mobile panel can cap its height while desktop keeps the full 300px list.

## Files
- `web/components/visualizations/TimelineChart.tsx`
- `web/components/charts/tooltips/TimelineTooltip.tsx`

## Verification (dev server, real pointer gestures)
- **Tap** → full 17-row list, ~3 visible, scrollable, playhead persists, panel sits above the data band ✓
- **Drag** (single flick, multi-step, and <8px tap) → all resolve correctly; drag scrubs without opening and clears the playhead on release ✓
- **× / outside-tap** dismisses the panel and playhead ✓
- Light + dark mode both verified (theme-aware tokens) ✓
- Desktop: no playhead leak, hover tooltip keeps its `click to pin · drag to zoom` hint, click-to-pin unchanged ✓
- `tsc --noEmit` + `eslint` clean

### Acceptance criteria
- [x] Mobile users can view all series values (not just #1) for a timestamp
- [x] Discoverable (`tap axis to see all`), doesn't conflict with drag-to-zoom (separate axis strip)
- [x] Reuses existing tooltip/data logic — no separate mobile data path
- [x] No regression to desktop hover behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a mobile-usable scrub interaction to the TTS latency timeline chart: tapping the date axis opens a scrollable full ranked list (pinned panel), dragging still shows the compact single-model readout, and a vertical playhead marks the active instant on devices without a hover cursor.

- **Tap vs. drag discrimination** is handled via a ref object (`axisScrubRef`) that tracks horizontal travel; moves >8px are classified as drags (compact readout only), while shorter movements are treated as taps that toggle the pinned full list. `pointercancel` (browser stealing a vertical scroll) is routed to a separate `cancelAxisScrub` to avoid spuriously toggling the pin.
- **Pinned panel** reuses the existing `PinnedTooltip` type and `CustomTimelineTooltip`, anchored to the top-left of the plot area on mobile with a new `maxHeight` prop (106px, ~3 rows) capping the scroll region. Desktop hover and click-to-pin paths are unchanged.

<h3>Confidence Score: 5/5</h3>

Safe to merge; all new interaction logic is isolated behind the isMobile guard and desktop hover/pin paths are unchanged.

The tap/drag discrimination, wasPinned toggle, and pointercancel escape hatch are each handled correctly. The mobileScrub closure read in endAxisScrub is safe because pointerup is a separate browser event — React will have committed the setMobileScrub call from startAxisScrub before endAxisScrub runs. No pre-existing desktop code paths are modified.

No files require special attention.

<sub>Reviews (2): Last reviewed commit: ["Address review: touch-scroll the pinned ..."](https://github.com/coval-ai/benchmarks/commit/b8c716587a9e377f1f587b008d8c9c3a9cb92e27) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43167140)</sub>

<!-- /greptile_comment -->