### PR TITLE
[BENCH-396] MOBILE: Chart tooltip: scrub sets a persistent playhead, tap toggles details

### DIFF
--- a/web/components/visualizations/TimelineChart.tsx
+++ b/web/components/visualizations/TimelineChart.tsx
@@ -210,6 +210,10 @@ const TimelineChart: React.FC = () => {
   const pinnedRef = useRef<HTMLDivElement>(null);
   const [pinned, setPinned] = useState<PinnedTooltip | null>(null);
   const [mobileScrub, setMobileScrub] = useState<PinnedTooltip | null>(null);
+  // Whether a finger is actively scrubbing the axis. The compact readout only
+  // shows during the live gesture; after lift-off the measurement persists as
+  // just the playhead line.
+  const [axisScrubLive, setAxisScrubLive] = useState(false);
   const [interactionBox, setInteractionBox] = useState<PlotBox | null>(null);
   const [zoom, setZoom] = useState<{
     x?: [number, number];
@@ -219,7 +223,8 @@ const TimelineChart: React.FC = () => {
   const axisScrubRef = useRef<{
     x: number;
     moved: boolean;
-    wasPinned: boolean;
+    following: boolean;
+    hadPin: boolean;
   } | null>(null);
   const dragRef = useRef<{
     x: number;
@@ -246,10 +251,12 @@ const TimelineChart: React.FC = () => {
     setZoom(null);
   }, [metric, windowStart, windowEnd]);
 
-  // The pin is anchored in pixel space, so a zoom change (drag, Y-max select,
-  // reset) moves the ground under it — drop it rather than mislabel a point.
+  // The pin and the persisted measurement are anchored in pixel space, so a
+  // zoom change (drag, Y-max select, reset) moves the ground under them —
+  // drop both rather than mislabel a point.
   useEffect(() => {
     setPinned(null);
+    setMobileScrub(null);
   }, [zoom, metric, windowStart, windowEnd]);
 
   // A mobile chart has separate touch targets for the plot and the date axis.
@@ -263,13 +270,46 @@ const TimelineChart: React.FC = () => {
     const onDocMouseDown = (e: MouseEvent) => {
       const target = e.target as Node;
       if (pinnedRef.current?.contains(target)) return;
+      // The mobile overlays own in-chart dismissal at pointerdown; the
+      // synthesized mousedown a tap fires afterwards must not kill the pin
+      // that same tap just placed.
+      if (isMobile && chartRef.current?.contains(target)) return;
       const surface = chartRef.current?.querySelector(".recharts-surface");
       if (surface?.contains(target)) return;
       setPinned(null);
     };
     document.addEventListener("mousedown", onDocMouseDown);
     return () => document.removeEventListener("mousedown", onDocMouseDown);
-  }, [pinned]);
+  }, [pinned, isMobile]);
+
+  // Touching or scrolling away from the chart dismisses both the persisted
+  // measurement and the open list. Touch scrolling rarely synthesizes mouse
+  // events, so the mousedown dismiss above never sees a scroll-away; the
+  // scroll listener is capture-phase to catch scrolls in nested containers,
+  // and scrolling the pinned list itself is the one scroll that means "keep
+  // it open". In-chart touches are exempt — the overlays own those gestures.
+  const hasMobileMeasurement = mobileScrub !== null || pinned !== null;
+  useEffect(() => {
+    if (!isMobile || !hasMobileMeasurement) return;
+    const onDocPointerDown = (e: Event) => {
+      const target = e.target as Node;
+      if (pinnedRef.current?.contains(target)) return;
+      if (chartRef.current?.contains(target)) return;
+      setPinned(null);
+      setMobileScrub(null);
+    };
+    const onScroll = (e: Event) => {
+      if (pinnedRef.current?.contains(e.target as Node)) return;
+      setPinned(null);
+      setMobileScrub(null);
+    };
+    document.addEventListener("pointerdown", onDocPointerDown);
+    window.addEventListener("scroll", onScroll, { capture: true, passive: true });
+    return () => {
+      document.removeEventListener("pointerdown", onDocPointerDown);
+      window.removeEventListener("scroll", onScroll, { capture: true });
+    };
+  }, [isMobile, hasMobileMeasurement]);
 
   const themeColors = useThemeColors();
   const modelsWithData = getModelsWithTimelineData(metric);
@@ -588,45 +628,74 @@ const TimelineChart: React.FC = () => {
     });
   };
 
+  // Scrubbing sets a measurement that persists after the finger lifts; a tap
+  // then toggles the full ranked list for that persisted spot. So a touch-down
+  // must not move an existing measurement — only real horizontal travel does.
   const startAxisScrub = (e: React.PointerEvent<HTMLDivElement>) => {
-    axisScrubRef.current = { x: e.clientX, moved: false, wasPinned: pinned != null };
-    scrubDateAxis(e);
+    const fresh = pinned == null && mobileScrub == null;
+    axisScrubRef.current = {
+      x: e.clientX,
+      moved: false,
+      following: fresh,
+      hadPin: pinned != null,
+    };
+    if (fresh) {
+      setAxisScrubLive(true);
+      scrubDateAxis(e);
+    }
   };
 
   const moveAxisScrub = (e: React.PointerEvent<HTMLDivElement>) => {
     const scrub = axisScrubRef.current;
     if (!scrub) return;
-    if (Math.abs(e.clientX - scrub.x) > 8) scrub.moved = true;
-    scrubDateAxis(e);
+    if (!scrub.moved && Math.abs(e.clientX - scrub.x) > 8) {
+      scrub.moved = true;
+      scrub.following = true;
+      // A real scrub takes over: the open list drops so the live readout
+      // tracks the finger instead of hiding behind the old panel.
+      setPinned(null);
+      setAxisScrubLive(true);
+    }
+    if (scrub.following) scrubDateAxis(e);
   };
 
-  // A drag scrubs (compact readout only); a tap toggles the full ranked list
-  // at that timestamp, reusing the pinned tooltip. wasPinned is captured at
-  // tap-start so the toggle survives the outside-tap dismiss handler.
+  // Lift after a scrub keeps only the playhead line — the measured position
+  // persists without the readout covering the chart. Lift after a tap toggles
+  // the full ranked list for the persisted spot, no matter where on the axis
+  // the tap landed.
   const endAxisScrub = () => {
     const scrub = axisScrubRef.current;
-    const tapped = scrub != null && !scrub.moved;
     axisScrubRef.current = null;
-    if (tapped) {
-      if (scrub!.wasPinned) {
-        setPinned(null);
-      } else if (mobileScrub) {
-        const box = interactionBox ?? plotBox();
-        setPinned(
-          box
-            ? { ...mobileScrub, x: box.left, y: box.top, flip: false }
-            : mobileScrub
-        );
-      }
+    setAxisScrubLive(false);
+    if (!scrub || scrub.moved) return;
+    if (scrub.hadPin) {
+      setPinned(null);
+    } else if (mobileScrub) {
+      // Anchor the list to the half of the plot the playhead is NOT in, so it
+      // never covers the measured spot or the data band around it.
+      const box = interactionBox ?? plotBox();
+      const onLeft = box
+        ? mobileScrub.x < box.left + box.width / 2
+        : false;
+      setPinned(
+        box
+          ? {
+              ...mobileScrub,
+              x: onLeft ? box.left + box.width : box.left,
+              y: box.top,
+              flip: onLeft,
+            }
+          : mobileScrub
+      );
     }
-    setMobileScrub(null);
   };
 
   // The browser hijacking the touch into a native scroll fires pointercancel
-  // with no horizontal travel — that must not read as a tap, so drop the
-  // gesture without toggling the pin.
+  // with no horizontal travel — that must not read as a tap and toggle the
+  // list. Scrolling away dismisses the measurement instead.
   const cancelAxisScrub = () => {
     axisScrubRef.current = null;
+    setAxisScrubLive(false);
     setMobileScrub(null);
   };
 
@@ -918,6 +987,7 @@ const TimelineChart: React.FC = () => {
                 onPointerDown={(e) => {
                   e.preventDefault();
                   e.stopPropagation();
+                  setPinned(null);
                   setMobileScrub(null);
                   startDrag(e, true);
                 }}
@@ -964,7 +1034,10 @@ const TimelineChart: React.FC = () => {
               </div>
             </>
           )}
-          {mobileScrub && (
+          {/* The readout only shows during a live scrub; the persisted
+              measurement (state kept for the tap-to-open payload) renders as
+              just the playhead line once the finger lifts. */}
+          {mobileScrub && axisScrubLive && !pinned && (
             <div
               className="pointer-events-none absolute z-20 shadow-lg md:hidden"
               style={{
@@ -995,7 +1068,9 @@ const TimelineChart: React.FC = () => {
                 left: pinned.x,
                 top: pinned.y,
                 transform: isMobile
-                  ? "translate(12px, 0)"
+                  ? pinned.flip
+                    ? "translate(calc(-100% - 12px), 0)"
+                    : "translate(12px, 0)"
                   : pinned.flip
                     ? "translate(calc(-100% - 12px), -50%)"
                     : "translate(12px, -50%)",

--- a/web/components/visualizations/TimelineChart.tsx
+++ b/web/components/visualizations/TimelineChart.tsx
@@ -210,18 +210,15 @@ const TimelineChart: React.FC = () => {
   const pinnedRef = useRef<HTMLDivElement>(null);
   const [pinned, setPinned] = useState<PinnedTooltip | null>(null);
   const [mobileScrub, setMobileScrub] = useState<PinnedTooltip | null>(null);
-  // Synchronous mirror of mobileScrub for the gesture handlers: pointerdown
-  // and pointerup are separate browser events, so a fresh tap's pointerup
-  // must not depend on React having committed the pointerdown's state update
-  // before it can see the measurement it just took.
+  // Synchronous mirror for the gesture handlers: a tap's pointerup must not
+  // depend on the pointerdown's state update having committed.
   const mobileScrubRef = useRef<PinnedTooltip | null>(null);
   const updateMobileScrub = useCallback((next: PinnedTooltip | null) => {
     mobileScrubRef.current = next;
     setMobileScrub(next);
   }, []);
-  // Whether a finger is actively scrubbing the axis. The compact readout only
-  // shows during the live gesture; after lift-off the measurement persists as
-  // just the playhead line.
+  // Finger actively on the axis — the compact readout only shows live;
+  // after lift-off the measurement persists as just the playhead line.
   const [axisScrubLive, setAxisScrubLive] = useState(false);
   const [interactionBox, setInteractionBox] = useState<PlotBox | null>(null);
   const [zoom, setZoom] = useState<{
@@ -260,9 +257,8 @@ const TimelineChart: React.FC = () => {
     setZoom(null);
   }, [metric, windowStart, windowEnd]);
 
-  // The pin and the persisted measurement are anchored in pixel space, so a
-  // zoom change (drag, Y-max select, reset) moves the ground under them —
-  // drop both rather than mislabel a point.
+  // Pin and measurement are pixel-anchored; a zoom change moves the ground
+  // under them — drop both rather than mislabel a point.
   useEffect(() => {
     setPinned(null);
     updateMobileScrub(null);
@@ -279,9 +275,8 @@ const TimelineChart: React.FC = () => {
     const onDocMouseDown = (e: MouseEvent) => {
       const target = e.target as Node;
       if (pinnedRef.current?.contains(target)) return;
-      // The mobile overlays own in-chart dismissal at pointerdown; the
-      // synthesized mousedown a tap fires afterwards must not kill the pin
-      // that same tap just placed.
+      // A tap's synthesized mousedown must not kill the pin it just placed;
+      // the mobile overlays own in-chart dismissal.
       if (isMobile && chartRef.current?.contains(target)) return;
       const surface = chartRef.current?.querySelector(".recharts-surface");
       if (surface?.contains(target)) return;
@@ -291,12 +286,9 @@ const TimelineChart: React.FC = () => {
     return () => document.removeEventListener("mousedown", onDocMouseDown);
   }, [pinned, isMobile]);
 
-  // Touching or scrolling away from the chart dismisses both the persisted
-  // measurement and the open list. Touch scrolling rarely synthesizes mouse
-  // events, so the mousedown dismiss above never sees a scroll-away; the
-  // scroll listener is capture-phase to catch scrolls in nested containers,
-  // and scrolling the pinned list itself is the one scroll that means "keep
-  // it open". In-chart touches are exempt — the overlays own those gestures.
+  // Touching or scrolling away dismisses the measurement and the open list.
+  // Touch scrolls rarely synthesize mouse events, so listen to capture-phase
+  // scroll + pointerdown; scrolling the pinned list itself keeps it open.
   const hasMobileMeasurement = mobileScrub !== null || pinned !== null;
   useEffect(() => {
     if (!isMobile || !hasMobileMeasurement) return;
@@ -637,9 +629,8 @@ const TimelineChart: React.FC = () => {
     });
   };
 
-  // Scrubbing sets a measurement that persists after the finger lifts; a tap
-  // then toggles the full ranked list for that persisted spot. So a touch-down
-  // must not move an existing measurement — only real horizontal travel does.
+  // A touch-down must not move an existing measurement — only real travel
+  // does, so a tap can inspect the persisted spot wherever it lands.
   const startAxisScrub = (e: React.PointerEvent<HTMLDivElement>) => {
     const fresh = pinned == null && mobileScrubRef.current == null;
     axisScrubRef.current = {
@@ -660,18 +651,15 @@ const TimelineChart: React.FC = () => {
     if (!scrub.moved && Math.abs(e.clientX - scrub.x) > 8) {
       scrub.moved = true;
       scrub.following = true;
-      // A real scrub takes over: the open list drops so the live readout
-      // tracks the finger instead of hiding behind the old panel.
+      // a real scrub takes over from the open list
       setPinned(null);
       setAxisScrubLive(true);
     }
     if (scrub.following) scrubDateAxis(e);
   };
 
-  // Lift after a scrub keeps only the playhead line — the measured position
-  // persists without the readout covering the chart. Lift after a tap toggles
-  // the full ranked list for the persisted spot, no matter where on the axis
-  // the tap landed.
+  // Scrub lift keeps only the playhead; a tap toggles the full ranked list
+  // for the persisted spot.
   const endAxisScrub = () => {
     const scrub = axisScrubRef.current;
     axisScrubRef.current = null;
@@ -681,8 +669,7 @@ const TimelineChart: React.FC = () => {
     if (scrub.hadPin) {
       setPinned(null);
     } else if (measurement) {
-      // Anchor the list to the half of the plot the playhead is NOT in, so it
-      // never covers the measured spot or the data band around it.
+      // anchor the list to the half of the plot the playhead is not in
       const box = interactionBox ?? plotBox();
       const onLeft = box
         ? measurement.x < box.left + box.width / 2
@@ -700,9 +687,8 @@ const TimelineChart: React.FC = () => {
     }
   };
 
-  // The browser hijacking the touch into a native scroll fires pointercancel
-  // with no horizontal travel — that must not read as a tap and toggle the
-  // list. Scrolling away dismisses the measurement instead.
+  // A touch hijacked into a native scroll fires pointercancel with no travel;
+  // that must not read as a tap — scrolling away dismisses instead.
   const cancelAxisScrub = () => {
     axisScrubRef.current = null;
     setAxisScrubLive(false);
@@ -1044,9 +1030,6 @@ const TimelineChart: React.FC = () => {
               </div>
             </>
           )}
-          {/* The readout only shows during a live scrub; the persisted
-              measurement (state kept for the tap-to-open payload) renders as
-              just the playhead line once the finger lifts. */}
           {mobileScrub && axisScrubLive && !pinned && (
             <div
               className="pointer-events-none absolute z-20 shadow-lg md:hidden"

--- a/web/components/visualizations/TimelineChart.tsx
+++ b/web/components/visualizations/TimelineChart.tsx
@@ -210,6 +210,15 @@ const TimelineChart: React.FC = () => {
   const pinnedRef = useRef<HTMLDivElement>(null);
   const [pinned, setPinned] = useState<PinnedTooltip | null>(null);
   const [mobileScrub, setMobileScrub] = useState<PinnedTooltip | null>(null);
+  // Synchronous mirror of mobileScrub for the gesture handlers: pointerdown
+  // and pointerup are separate browser events, so a fresh tap's pointerup
+  // must not depend on React having committed the pointerdown's state update
+  // before it can see the measurement it just took.
+  const mobileScrubRef = useRef<PinnedTooltip | null>(null);
+  const updateMobileScrub = useCallback((next: PinnedTooltip | null) => {
+    mobileScrubRef.current = next;
+    setMobileScrub(next);
+  }, []);
   // Whether a finger is actively scrubbing the axis. The compact readout only
   // shows during the live gesture; after lift-off the measurement persists as
   // just the playhead line.
@@ -256,8 +265,8 @@ const TimelineChart: React.FC = () => {
   // drop both rather than mislabel a point.
   useEffect(() => {
     setPinned(null);
-    setMobileScrub(null);
-  }, [zoom, metric, windowStart, windowEnd]);
+    updateMobileScrub(null);
+  }, [zoom, metric, windowStart, windowEnd, updateMobileScrub]);
 
   // A mobile chart has separate touch targets for the plot and the date axis.
   // A pin from a desktop-sized layout would otherwise sit over those targets.
@@ -296,12 +305,12 @@ const TimelineChart: React.FC = () => {
       if (pinnedRef.current?.contains(target)) return;
       if (chartRef.current?.contains(target)) return;
       setPinned(null);
-      setMobileScrub(null);
+      updateMobileScrub(null);
     };
     const onScroll = (e: Event) => {
       if (pinnedRef.current?.contains(e.target as Node)) return;
       setPinned(null);
-      setMobileScrub(null);
+      updateMobileScrub(null);
     };
     document.addEventListener("pointerdown", onDocPointerDown);
     window.addEventListener("scroll", onScroll, { capture: true, passive: true });
@@ -309,7 +318,7 @@ const TimelineChart: React.FC = () => {
       document.removeEventListener("pointerdown", onDocPointerDown);
       window.removeEventListener("scroll", onScroll, { capture: true });
     };
-  }, [isMobile, hasMobileMeasurement]);
+  }, [isMobile, hasMobileMeasurement, updateMobileScrub]);
 
   const themeColors = useThemeColors();
   const modelsWithData = getModelsWithTimelineData(metric);
@@ -616,10 +625,10 @@ const TimelineChart: React.FC = () => {
         : [];
     });
     if (payload.length === 0) {
-      setMobileScrub(null);
+      updateMobileScrub(null);
       return;
     }
-    setMobileScrub({
+    updateMobileScrub({
       label: String(point.timestamp),
       payload,
       x,
@@ -632,7 +641,7 @@ const TimelineChart: React.FC = () => {
   // then toggles the full ranked list for that persisted spot. So a touch-down
   // must not move an existing measurement — only real horizontal travel does.
   const startAxisScrub = (e: React.PointerEvent<HTMLDivElement>) => {
-    const fresh = pinned == null && mobileScrub == null;
+    const fresh = pinned == null && mobileScrubRef.current == null;
     axisScrubRef.current = {
       x: e.clientX,
       moved: false,
@@ -668,24 +677,25 @@ const TimelineChart: React.FC = () => {
     axisScrubRef.current = null;
     setAxisScrubLive(false);
     if (!scrub || scrub.moved) return;
+    const measurement = mobileScrubRef.current;
     if (scrub.hadPin) {
       setPinned(null);
-    } else if (mobileScrub) {
+    } else if (measurement) {
       // Anchor the list to the half of the plot the playhead is NOT in, so it
       // never covers the measured spot or the data band around it.
       const box = interactionBox ?? plotBox();
       const onLeft = box
-        ? mobileScrub.x < box.left + box.width / 2
+        ? measurement.x < box.left + box.width / 2
         : false;
       setPinned(
         box
           ? {
-              ...mobileScrub,
+              ...measurement,
               x: onLeft ? box.left + box.width : box.left,
               y: box.top,
               flip: onLeft,
             }
-          : mobileScrub
+          : measurement
       );
     }
   };
@@ -696,7 +706,7 @@ const TimelineChart: React.FC = () => {
   const cancelAxisScrub = () => {
     axisScrubRef.current = null;
     setAxisScrubLive(false);
-    setMobileScrub(null);
+    updateMobileScrub(null);
   };
 
   // Whether a data value sits inside the visible (possibly zoomed) Y range.
@@ -988,7 +998,7 @@ const TimelineChart: React.FC = () => {
                   e.preventDefault();
                   e.stopPropagation();
                   setPinned(null);
-                  setMobileScrub(null);
+                  updateMobileScrub(null);
                   startDrag(e, true);
                 }}
                 onPointerMove={(e) => {


### PR DESCRIPTION
## Problem
<img width="721" height="560" alt="Screenshot 2026-07-10 at 9 18 18 AM" src="https://github.com/user-attachments/assets/44197b1a-c2df-40af-836b-431ef322db6e" />

On mobile, the timeline tooltip toggled open on an axis tap and only closed on a second explicit tap. Two consequences (BENCH-396):

- With the tooltip open, scrubbing along the axis hid the new hover position behind the stuck panel — the only way out was an explicit second tap, which doesn't match how scrubbing works.
- The tap that opened the list also *moved* the measurement to wherever the finger happened to land, so you couldn't scrub to a precise spot and then inspect it.

## New interaction model (mobile only)

**Scrub = persistent measurement.** Dragging the date axis shows the live compact readout; lifting keeps only the playhead line at the measured spot, so the chart stays readable at rest.

**Tap = toggle details, position-independent.** A tap anywhere on the axis opens the full ranked list for the persisted playhead spot — tapping does not move the measurement. Tapping again closes it. The panel anchors to the opposite half of the plot from the playhead so it never covers the region being read (previously it was hard-anchored top-left and sat over the data when measuring the left side).

**Everything else dismisses.** A new scrub while the list is open takes over immediately (panel drops, readout follows the finger). Tapping the plot, tapping off the chart, or scrolling the page dismisses the measurement — except scrolling inside the panel's own list, which keeps it open. Touch scrolls rarely synthesize mouse events, so dismissal listens to capture-phase scroll + document pointerdown instead of the desktop mousedown path.

All new behavior is gated on `isMobile`; desktop hover and click-to-pin are unchanged.

## Verification

- `pnpm typecheck`, `pnpm lint`, `pnpm test` (53/53) pass.
- Exercised every gesture with synthetic `pointerType: "touch"` events against the dev server at mobile viewport: scrub→persist, tap-open anchored to the persisted spot from both directions, tap-close, scrub-while-open takeover, plot-tap/scroll/outside-tap dismissal, and both panel anchor sides.
- Manually tested on a phone against the dev server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR reworks the mobile touch interaction model for the timeline chart axis. The core change separates scrubbing (which was previously a click-to-inspect model) into two distinct gestures — dragging to set a persistent measurement playhead and tapping to toggle the ranked details panel — and adds smart panel anchoring so the list always opens on the opposite half of the chart from the playhead.

- **Ref-mirror pattern for synchronous gesture reads**: `mobileScrubRef` and `updateMobileScrub` ensure `endAxisScrub`'s open-list branch never reads stale React state that may not have committed between `pointerdown` and `pointerup` (addresses the concern flagged in the previous review thread).
- **New dismissal surfaces**: A capture-phase scroll listener and a document-level `pointerdown` handler clear both the measurement and the pinned list on outside interaction; the existing synthesized-mousedown path is updated to skip in-chart events on mobile so it no longer races with the new handlers.
- **Plot-tap now correctly closes the pinned list**: The `onPointerDown` handler on the plot overlay now calls `setPinned(null)` in addition to `updateMobileScrub(null)`, fixing a pre-existing gap where the old `onDocMouseDown` handler would have bailed for the chart surface and left the list open.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all new gesture paths are gated on isMobile and the changes to shared state management are self-contained within this component.

The gesture logic is carefully decomposed: the fresh/hadPin/following flags on axisScrubRef cover all four meaningful touch-start states without overlapping, state cleanup is consistent across endAxisScrub, cancelAxisScrub, the scroll listener, and the document pointerdown listener, and the panel-anchor math correctly places the list on the opposite half of the chart from the playhead. Desktop behavior is entirely unchanged. The previously flagged stale-closure problem is properly resolved by the ref mirror.

No files require special attention.

<sub>Reviews (3): Last reviewed commit: ["Trim gesture-handler comments for brevit..."](https://github.com/coval-ai/benchmarks/commit/acc906e510132bddd752df247950ec1eec12744c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43334780)</sub>

<!-- /greptile_comment -->