### PR TITLE
[BENCH-397] Add Together AI realtime STT provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,6 +35,7 @@ SONIOX_API_KEY=
 REVAI_API_KEY=
 FISHAUDIO_API_KEY=
 ALIBABA_API_KEY=
+TOGETHER_API_KEY=
 
 # --- Google STT/TTS (optional; requires the `google-stt` / `google-tts` extras) ---
 # GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json

--- a/docs/methodology.md
+++ b/docs/methodology.md
@@ -137,7 +137,7 @@ but the rule is the same.
 
 | Cohort | What is excluded from t0 |
 |---|---|
-| WS streaming (Deepgram, AssemblyAI, ElevenLabs Scribe, Speechmatics, Gradium STT, Cartesia, Deepgram aura-2, Rime, Gradium TTS, Hume) | TLS + WS upgrade + optional session-setup RTT (~50–200 ms). Handshake naturally completes inside `measure_ttft` / `synthesize` before t0. |
+| WS streaming (Deepgram, AssemblyAI, ElevenLabs Scribe, Speechmatics, Gradium STT, Cartesia, Together AI, Deepgram aura-2, Rime, Gradium TTS, Hume) | TLS + WS upgrade + optional session-setup RTT (~50–200 ms). Handshake naturally completes inside `measure_ttft` / `synthesize` before t0. |
 | HTTP TTS (ElevenLabs HTTP, OpenAI `gpt-4o-mini-tts`) | TLS + TCP via a shared `httpx.AsyncClient` pre-warmed once per run (~80–200 ms). |
 
 HTTP-pool warming lives in `runner/src/coval_bench/providers/_http_session.py`.

--- a/runner/src/coval_bench/config.py
+++ b/runner/src/coval_bench/config.py
@@ -79,6 +79,7 @@ class Settings(BaseSettings):
     soniox_api_key: SecretStr | None = None
     revai_api_key: SecretStr | None = None
     baseten_api_key: SecretStr | None = None
+    together_api_key: SecretStr | None = None
     fishaudio_api_key: SecretStr | None = None
     azure_api_key: SecretStr | None = None
     alibaba_api_key: SecretStr | None = None

--- a/runner/src/coval_bench/providers/stt/__init__.py
+++ b/runner/src/coval_bench/providers/stt/__init__.py
@@ -30,6 +30,7 @@ from coval_bench.providers.stt.revai import RevAISTTProvider
 from coval_bench.providers.stt.smallest import SmallestSTTProvider
 from coval_bench.providers.stt.soniox import SonioxSTTProvider
 from coval_bench.providers.stt.speechmatics import SpeechmaticsProvider
+from coval_bench.providers.stt.together import TogetherSTTProvider
 from coval_bench.providers.stt.xai import XaiSTTProvider
 
 # Google is optional — gated on the ``google-stt`` extra
@@ -57,6 +58,7 @@ STT_PROVIDERS: dict[str, type[STTProvider]] = {
     "smallest": SmallestSTTProvider,
     "soniox": SonioxSTTProvider,
     "speechmatics": SpeechmaticsProvider,
+    "together": TogetherSTTProvider,
     "xai": XaiSTTProvider,
 }
 
@@ -81,6 +83,7 @@ __all__ = [
     "SmallestSTTProvider",
     "SonioxSTTProvider",
     "SpeechmaticsProvider",
+    "TogetherSTTProvider",
     "XaiSTTProvider",
     "GoogleSTTProvider",
 ]

--- a/runner/src/coval_bench/providers/stt/together.py
+++ b/runner/src/coval_bench/providers/stt/together.py
@@ -1,0 +1,256 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Together AI real-time STT provider (WebSocket).
+
+Wire protocol (OpenAI-Realtime style):
+  URL:   wss://api.together.ai/v1/realtime?model=<id>&input_audio_format=pcm_s16le_16000
+  Auth:  Authorization: Bearer <key> + OpenAI-Beta: realtime=v1
+  Send:  {"type": "input_audio_buffer.append", "audio": <base64 PCM>} then
+         {"type": "input_audio_buffer.commit"} to force the final.
+  Recv:  conversation.item.input_audio_transcription.delta (partial) /
+         .completed (final). The server never closes; the client closes after
+         draining the forced final.
+
+The Nemotron models run with ~1.1 s of encoder lookahead and commit drops it,
+truncating the tail. Trailing silence is paced in before the commit to flush
+the lookahead (Flux/Rev AI pattern); their TTFS is excluded in
+``registries/metrics.py`` since the final's timing then tracks the client's
+silence length, not the engine.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import contextlib
+import json
+import time
+from typing import Any
+
+import structlog
+import websockets.asyncio.client as ws_client
+from pydantic import SecretStr
+
+from coval_bench.providers.base import STTProvider, TranscriptionResult
+from coval_bench.providers.stt._pacing import paced_chunks
+
+logger = structlog.get_logger(__name__)
+
+_MODEL_IDS = {
+    "nemotron-3-asr-streaming-0.6b": "nvidia/nemotron-3-asr-streaming-0.6b",
+    "nemotron-3.5-asr-streaming-0.6b": "nvidia/nemotron-3.5-asr-streaming-0.6b",
+    "parakeet-tdt-0.6b-v3": "nvidia/parakeet-tdt-0.6b-v3",
+    "whisper-large-v3": "openai/whisper-large-v3",
+}
+
+# Models whose commit drops the encoder-lookahead buffer; they get trailing
+# silence before the commit so the tail is decoded.
+_LOOKAHEAD_FLUSH_MODELS = frozenset(
+    {"nemotron-3-asr-streaming-0.6b", "nemotron-3.5-asr-streaming-0.6b"}
+)
+
+# Nemotron's deepest lookahead config is 1.12 s; pad past it.
+_TAIL_SILENCE_S = 1.6
+
+# After commit, wait this long for the forced final before closing, so the
+# close can't race the final.
+_FINAL_WAIT_S = 5.0
+
+
+class TogetherSTTProvider(STTProvider):
+    """Together AI streaming STT provider."""
+
+    _VALID_MODELS = frozenset(_MODEL_IDS)
+
+    def __init__(self, api_key: SecretStr | None, model: str = "whisper-large-v3") -> None:
+        if not self._model_supported(model):
+            raise ValueError(
+                f"Invalid Together STT model {model!r}. Valid: {sorted(self._VALID_MODELS)}"
+            )
+        if api_key is None:
+            raise ValueError("together_api_key is required for the Together STT provider")
+        self._api_key = api_key
+        self._model = model
+
+    @property
+    def name(self) -> str:
+        return f"together-{self._model}"
+
+    @property
+    def model(self) -> str:
+        return self._model
+
+    async def measure_ttft(
+        self,
+        audio_data: bytes,
+        channels: int,
+        sample_width: int,
+        sample_rate: int,
+        realtime_resolution: float = 0.1,
+    ) -> TranscriptionResult:
+        result = TranscriptionResult(provider=self.name)
+        if sample_rate != 16000 or channels != 1 or sample_width != 2:
+            result.error = (
+                "Together requires 16 kHz mono 16-bit PCM input; got "
+                f"sample_rate={sample_rate}, channels={channels}, sample_width={sample_width}"
+            )
+            return result
+
+        total_start = time.monotonic()
+
+        try:
+            url = (
+                "wss://api.together.ai/v1/realtime"
+                f"?model={_MODEL_IDS[self._model]}"
+                "&input_audio_format=pcm_s16le_16000"
+            )
+            headers = {
+                "Authorization": f"Bearer {self._api_key.get_secret_value()}",
+                "OpenAI-Beta": "realtime=v1",
+            }
+            final_event = asyncio.Event()
+            async with ws_client.connect(url, additional_headers=headers) as ws:
+                send_task = asyncio.create_task(
+                    self._send_audio(
+                        ws, audio_data, sample_rate, result, realtime_resolution, final_event
+                    )
+                )
+                recv_task = asyncio.create_task(self._receive(ws, result, final_event))
+                tasks = (send_task, recv_task)
+                done, pending = await asyncio.wait(tasks, return_when=asyncio.FIRST_EXCEPTION)
+                if any(not task.cancelled() and task.exception() is not None for task in done):
+                    for task in pending:
+                        task.cancel()
+                outcomes = await asyncio.gather(*tasks, return_exceptions=True)
+                if result.error is None and result.audio_to_final_seconds is None:
+                    for outcome in outcomes:
+                        if isinstance(outcome, Exception):
+                            result.error = str(outcome)
+                            break
+
+        except Exception as exc:
+            logger.warning(
+                "together_measure_ttft_failed",
+                provider="together",
+                model=self._model,
+                exc_info=exc,
+            )
+            result.error = str(exc)
+
+        result.total_time = time.monotonic() - total_start
+        return result
+
+    async def _send_audio(
+        self,
+        ws: Any,
+        audio_data: bytes,
+        sample_rate: int,
+        result: TranscriptionResult,
+        realtime_resolution: float,
+        final_event: asyncio.Event,
+    ) -> None:
+        byte_rate = sample_rate * 2
+        chunk_size = int(byte_rate * realtime_resolution)
+        try:
+            async for chunk, start in paced_chunks(audio_data, chunk_size, byte_rate):
+                result.audio_start_time = start
+                await self._append(ws, chunk)
+            if self._model in _LOOKAHEAD_FLUSH_MODELS:
+                silence = bytes(int(byte_rate * _TAIL_SILENCE_S))
+                async for chunk, _ in paced_chunks(silence, chunk_size, byte_rate):
+                    await self._append(ws, chunk)
+            # Clear first: a mid-stream turn final would leave the latch set
+            # and make the wait a no-op.
+            final_event.clear()
+            await ws.send(json.dumps({"type": "input_audio_buffer.commit"}))
+            with contextlib.suppress(TimeoutError):
+                await asyncio.wait_for(final_event.wait(), timeout=_FINAL_WAIT_S)
+            # The server holds the socket open; close so the receive loop ends.
+            await ws.close()
+        except Exception as exc:
+            logger.warning(
+                "together_send_error", provider="together", model=self._model, exc_info=exc
+            )
+            raise
+
+    @staticmethod
+    async def _append(ws: Any, chunk: bytes) -> None:
+        await ws.send(
+            json.dumps(
+                {
+                    "type": "input_audio_buffer.append",
+                    "audio": base64.b64encode(chunk).decode("ascii"),
+                }
+            )
+        )
+
+    async def _receive(
+        self, ws: Any, result: TranscriptionResult, final_event: asyncio.Event
+    ) -> None:
+        final_segments: list[str] = []
+        delta_fragments: list[str] = []
+        last_final_time: float | None = None
+
+        try:
+            async for raw in ws:
+                if isinstance(raw, bytes):
+                    continue
+
+                msg: dict[str, Any] = json.loads(raw)
+                now = time.monotonic()
+                msg_type: str = msg.get("type", "")
+
+                if msg_type == "error":
+                    error_obj = msg.get("error")
+                    detail = (
+                        error_obj.get("message") if isinstance(error_obj, dict) else None
+                    ) or msg.get("message")
+                    result.error = str(detail or msg)
+                    logger.warning(
+                        "together_stt_error", provider="together", model=self._model, msg=msg
+                    )
+                    final_event.set()
+                    break
+
+                if msg_type.endswith("input_audio_transcription.delta"):
+                    delta = str(msg.get("delta", ""))
+                    if not delta.strip():
+                        continue
+                    if result.ttft_seconds is None and result.audio_start_time is not None:
+                        result.ttft_seconds = now - result.audio_start_time
+                        snippet = delta.strip()
+                        result.first_token_content = (
+                            snippet[:30] + "..." if len(snippet) > 30 else snippet
+                        )
+                    result.partial_transcripts.append(delta.strip())
+                    delta_fragments.append(delta)
+                    continue
+
+                if msg_type.endswith("input_audio_transcription.completed"):
+                    transcript = str(msg.get("transcript", "")).strip()
+                    if transcript:
+                        final_segments.append(transcript)
+                        last_final_time = now
+                    final_event.set()
+
+        except Exception as exc:
+            logger.warning(
+                "together_receive_error", provider="together", model=self._model, exc_info=exc
+            )
+            if result.error is None and last_final_time is None:
+                result.error = str(exc)
+
+        if last_final_time is not None and result.audio_start_time is not None:
+            result.audio_to_final_seconds = last_final_time - result.audio_start_time
+
+        if final_segments:
+            result.complete_transcript = " ".join(final_segments).strip() or None
+        elif delta_fragments:
+            # Deltas are incremental fragments; concatenation reconstructs the
+            # not-yet-finalized transcript.
+            result.complete_transcript = "".join(delta_fragments).strip() or None
+
+        if result.complete_transcript:
+            result.transcript_length = len(result.complete_transcript)
+            result.word_count = len(result.complete_transcript.split())

--- a/runner/src/coval_bench/providers/stt/together.py
+++ b/runner/src/coval_bench/providers/stt/together.py
@@ -189,7 +189,9 @@ class TogetherSTTProvider(STTProvider):
         self, ws: Any, result: TranscriptionResult, final_event: asyncio.Event
     ) -> None:
         final_segments: list[str] = []
-        delta_fragments: list[str] = []
+        # Deltas are cumulative running transcripts revised in place, keyed by
+        # conversation item — keep only each item's latest.
+        item_deltas: dict[str, str] = {}
         last_final_time: float | None = None
 
         try:
@@ -224,7 +226,7 @@ class TogetherSTTProvider(STTProvider):
                             snippet[:30] + "..." if len(snippet) > 30 else snippet
                         )
                     result.partial_transcripts.append(delta.strip())
-                    delta_fragments.append(delta)
+                    item_deltas[str(msg.get("item_id", ""))] = delta
                     continue
 
                 if msg_type.endswith("input_audio_transcription.completed"):
@@ -246,10 +248,10 @@ class TogetherSTTProvider(STTProvider):
 
         if final_segments:
             result.complete_transcript = " ".join(final_segments).strip() or None
-        elif delta_fragments:
-            # Deltas are incremental fragments; concatenation reconstructs the
-            # not-yet-finalized transcript.
-            result.complete_transcript = "".join(delta_fragments).strip() or None
+        elif item_deltas:
+            result.complete_transcript = (
+                " ".join(d.strip() for d in item_deltas.values()).strip() or None
+            )
 
         if result.complete_transcript:
             result.transcript_length = len(result.complete_transcript)

--- a/runner/src/coval_bench/registries/metrics.py
+++ b/runner/src/coval_bench/registries/metrics.py
@@ -127,6 +127,11 @@ METRIC_EXCLUSIONS: dict[Metric, frozenset[tuple[str, str]]] = {
             # endpointer fires on trailing silence, so TTFS bundles endpoint-detection
             # latency and isn't comparable to force-endpoint providers.
             ("revai", "reverb"),
+            # Together's commit drops Nemotron's encoder lookahead, so the client
+            # pads trailing silence before committing; the final's timing then
+            # tracks the pad length, not the engine.
+            ("together", "nemotron-3-asr-streaming-0.6b"),
+            ("together", "nemotron-3.5-asr-streaming-0.6b"),
         }
     ),
 }

--- a/runner/src/coval_bench/registries/models.py
+++ b/runner/src/coval_bench/registries/models.py
@@ -304,6 +304,47 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         self_hostable=True,
         status=_ACTIVE,
     ),
+    # Together AI serverless realtime endpoints (open-weight models).
+    RegisteredModel(
+        benchmark=_STT,
+        provider="together",
+        model="nemotron-3-asr-streaming-0.6b",
+        creator="nvidia",
+        tags=(_REALTIME,),
+        licensing=_OPEN,
+        self_hostable=True,
+        status=_ACTIVE,
+    ),
+    RegisteredModel(
+        benchmark=_STT,
+        provider="together",
+        model="nemotron-3.5-asr-streaming-0.6b",
+        creator="nvidia",
+        tags=(_REALTIME, _MULTI),
+        licensing=_OPEN,
+        self_hostable=True,
+        status=_ACTIVE,
+    ),
+    RegisteredModel(
+        benchmark=_STT,
+        provider="together",
+        model="parakeet-tdt-0.6b-v3",
+        creator="nvidia",
+        tags=(_REALTIME, _MULTI),
+        licensing=_OPEN,
+        self_hostable=True,
+        status=_ACTIVE,
+    ),
+    RegisteredModel(
+        benchmark=_STT,
+        provider="together",
+        model="whisper-large-v3",
+        creator="openai",
+        tags=(_REALTIME, _MULTI),
+        licensing=_OPEN,
+        self_hostable=True,
+        status=_ACTIVE,
+    ),
     #######
     # TTS #
     #######

--- a/runner/tests/providers/stt/conftest.py
+++ b/runner/tests/providers/stt/conftest.py
@@ -144,6 +144,8 @@ _WAIT_PATCHES = (
     "coval_bench.providers.stt.xai._FINAL_WAIT_S",
     "coval_bench.providers.stt.gradium._FLUSH_WAIT_S",
     "coval_bench.providers.stt.inworld._CLOSE_WAIT_S",
+    "coval_bench.providers.stt.together._FINAL_WAIT_S",
+    "coval_bench.providers.stt.together._TAIL_SILENCE_S",
 )
 
 

--- a/runner/tests/providers/stt/fixtures/together/events-error.json
+++ b/runner/tests/providers/stt/fixtures/together/events-error.json
@@ -1,0 +1,4 @@
+[
+  { "type": "session.created" },
+  { "type": "error", "error": { "message": "Invalid API key" } }
+]

--- a/runner/tests/providers/stt/fixtures/together/events-success.json
+++ b/runner/tests/providers/stt/fixtures/together/events-success.json
@@ -1,0 +1,10 @@
+[
+  { "type": "session.created" },
+  { "type": "conversation.item.input_audio_transcription.delta", "delta": "hello" },
+  { "type": "conversation.item.input_audio_transcription.delta", "delta": " world" },
+  { "type": "conversation.item.input_audio_transcription.delta", "delta": " how are you" },
+  {
+    "type": "conversation.item.input_audio_transcription.completed",
+    "transcript": "hello world how are you"
+  }
+]

--- a/runner/tests/providers/stt/fixtures/together/events-success.json
+++ b/runner/tests/providers/stt/fixtures/together/events-success.json
@@ -1,10 +1,23 @@
 [
   { "type": "session.created" },
-  { "type": "conversation.item.input_audio_transcription.delta", "delta": "hello" },
-  { "type": "conversation.item.input_audio_transcription.delta", "delta": " world" },
-  { "type": "conversation.item.input_audio_transcription.delta", "delta": " how are you" },
+  {
+    "type": "conversation.item.input_audio_transcription.delta",
+    "item_id": "item_1",
+    "delta": "hello"
+  },
+  {
+    "type": "conversation.item.input_audio_transcription.delta",
+    "item_id": "item_1",
+    "delta": "hello world"
+  },
+  {
+    "type": "conversation.item.input_audio_transcription.delta",
+    "item_id": "item_1",
+    "delta": "hello world how are you"
+  },
   {
     "type": "conversation.item.input_audio_transcription.completed",
+    "item_id": "item_1",
     "transcript": "hello world how are you"
   }
 ]

--- a/runner/tests/providers/stt/test_together.py
+++ b/runner/tests/providers/stt/test_together.py
@@ -98,13 +98,26 @@ async def test_together_nemotron_pads_tail_silence(
 
 
 @pytest.mark.asyncio
-async def test_together_deltas_only_falls_back_to_concatenation(
+async def test_together_deltas_only_falls_back_to_latest_per_item(
     fake_api_key: SecretStr, audio_pcm_bytes: bytes
 ) -> None:
-    """With no final, the concatenated deltas are salvaged as the transcript."""
+    """With no final, each item's latest cumulative delta is salvaged."""
     events: list[Any] = [
-        {"type": "conversation.item.input_audio_transcription.delta", "delta": "hello"},
-        {"type": "conversation.item.input_audio_transcription.delta", "delta": " world"},
+        {
+            "type": "conversation.item.input_audio_transcription.delta",
+            "item_id": "item_1",
+            "delta": "hello",
+        },
+        {
+            "type": "conversation.item.input_audio_transcription.delta",
+            "item_id": "item_1",
+            "delta": "hello world",
+        },
+        {
+            "type": "conversation.item.input_audio_transcription.delta",
+            "item_id": "item_2",
+            "delta": "how are you",
+        },
     ]
     ws = FakeWebSocket(events, server_closes=False)
     provider = TogetherSTTProvider(api_key=fake_api_key)
@@ -113,7 +126,7 @@ async def test_together_deltas_only_falls_back_to_concatenation(
 
     assert result.error is None
     assert result.ttft_seconds is not None
-    assert result.complete_transcript == "hello world"
+    assert result.complete_transcript == "hello world how are you"
     assert result.audio_to_final_seconds is None
 
 

--- a/runner/tests/providers/stt/test_together.py
+++ b/runner/tests/providers/stt/test_together.py
@@ -1,0 +1,170 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for coval_bench.providers.stt.together (TogetherSTTProvider).
+
+The WebSocket is replayed with FakeWebSocket — no live network calls. Deltas
+are incremental fragments; each ``completed`` event carries a full utterance
+transcript, so the complete transcript is the in-order join of the finals.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pydantic import SecretStr
+
+from coval_bench.metrics.wer import compute_wer
+from coval_bench.providers.stt.together import TogetherSTTProvider
+from tests.providers.stt.conftest import FakeWebSocket, load_fixture_events
+
+_CHUNK_BYTES = int(16000 * 2 * 0.1)
+
+
+def _fake_ws_connect(ws: FakeWebSocket) -> Any:
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=ws)
+    cm.__aexit__ = AsyncMock(return_value=False)
+    return cm
+
+
+def _frames(sent: list[Any]) -> list[dict[str, Any]]:
+    return [json.loads(f) for f in sent if isinstance(f, str)]
+
+
+async def _run(provider: TogetherSTTProvider, ws: FakeWebSocket, audio: bytes) -> Any:
+    with patch(
+        "coval_bench.providers.stt.together.ws_client.connect",
+        return_value=_fake_ws_connect(ws),
+    ):
+        return await provider.measure_ttft(
+            audio_data=audio, channels=1, sample_width=2, sample_rate=16000
+        )
+
+
+@pytest.mark.asyncio
+async def test_together_success(fake_api_key: SecretStr, audio_pcm_bytes: bytes) -> None:
+    ws = FakeWebSocket(load_fixture_events("together"), server_closes=False)
+    provider = TogetherSTTProvider(api_key=fake_api_key)
+
+    result = await _run(provider, ws, audio_pcm_bytes)
+
+    assert result.error is None
+    assert result.ttft_seconds is not None
+    assert result.ttft_seconds >= 0
+    assert result.first_token_content == "hello"  # noqa: S105
+    assert result.complete_transcript == "hello world how are you"
+    assert result.word_count == 5
+    assert result.audio_to_final_seconds is not None
+    wer = compute_wer("hello world how are you", result.complete_transcript)
+    assert wer.wer_percentage == pytest.approx(0.0)
+
+
+@pytest.mark.asyncio
+async def test_together_commit_is_last_frame(
+    fake_api_key: SecretStr, audio_pcm_bytes: bytes
+) -> None:
+    sent: list[Any] = []
+    ws = FakeWebSocket(load_fixture_events("together"), on_send=sent.append, server_closes=False)
+    provider = TogetherSTTProvider(api_key=fake_api_key)
+
+    await _run(provider, ws, audio_pcm_bytes)
+
+    frames = _frames(sent)
+    assert frames[-1]["type"] == "input_audio_buffer.commit"
+    appends = [f for f in frames if f["type"] == "input_audio_buffer.append"]
+    assert len(appends) == math.ceil(len(audio_pcm_bytes) / _CHUNK_BYTES)
+
+
+@pytest.mark.asyncio
+async def test_together_nemotron_pads_tail_silence(
+    fake_api_key: SecretStr, audio_pcm_bytes: bytes
+) -> None:
+    """Nemotron models get trailing silence appended before the commit."""
+    sent: list[Any] = []
+    ws = FakeWebSocket(load_fixture_events("together"), on_send=sent.append, server_closes=False)
+    provider = TogetherSTTProvider(api_key=fake_api_key, model="nemotron-3.5-asr-streaming-0.6b")
+
+    await _run(provider, ws, audio_pcm_bytes)
+
+    frames = _frames(sent)
+    assert frames[-1]["type"] == "input_audio_buffer.commit"
+    appends = [f for f in frames if f["type"] == "input_audio_buffer.append"]
+    assert len(appends) > math.ceil(len(audio_pcm_bytes) / _CHUNK_BYTES)
+
+
+@pytest.mark.asyncio
+async def test_together_deltas_only_falls_back_to_concatenation(
+    fake_api_key: SecretStr, audio_pcm_bytes: bytes
+) -> None:
+    """With no final, the concatenated deltas are salvaged as the transcript."""
+    events: list[Any] = [
+        {"type": "conversation.item.input_audio_transcription.delta", "delta": "hello"},
+        {"type": "conversation.item.input_audio_transcription.delta", "delta": " world"},
+    ]
+    ws = FakeWebSocket(events, server_closes=False)
+    provider = TogetherSTTProvider(api_key=fake_api_key)
+
+    result = await _run(provider, ws, audio_pcm_bytes)
+
+    assert result.error is None
+    assert result.ttft_seconds is not None
+    assert result.complete_transcript == "hello world"
+    assert result.audio_to_final_seconds is None
+
+
+def test_provider_name() -> None:
+    provider = TogetherSTTProvider(api_key=SecretStr("k"), model="parakeet-tdt-0.6b-v3")
+    assert provider.name == "together-parakeet-tdt-0.6b-v3"
+
+
+def test_provider_model() -> None:
+    provider = TogetherSTTProvider(api_key=SecretStr("k"))
+    assert provider.model == "whisper-large-v3"
+
+
+def test_invalid_model_raises() -> None:
+    with pytest.raises(ValueError, match="Invalid Together STT model"):
+        TogetherSTTProvider(api_key=SecretStr("k"), model="whisper-large-v2")
+
+
+def test_missing_api_key_raises() -> None:
+    with pytest.raises(ValueError, match="together_api_key is required"):
+        TogetherSTTProvider(api_key=None)
+
+
+@pytest.mark.asyncio
+async def test_together_error_event(fake_api_key: SecretStr, audio_pcm_bytes: bytes) -> None:
+    ws = FakeWebSocket(load_fixture_events("together", "events-error"), server_closes=False)
+    provider = TogetherSTTProvider(api_key=fake_api_key)
+
+    result = await _run(provider, ws, audio_pcm_bytes)
+
+    assert result.error is not None
+    assert "Invalid API key" in result.error
+    assert result.complete_transcript is None
+
+
+@pytest.mark.asyncio
+async def test_together_unsupported_audio_format(fake_api_key: SecretStr) -> None:
+    provider = TogetherSTTProvider(api_key=fake_api_key)
+    result = await provider.measure_ttft(
+        audio_data=b"\x00\x00", channels=2, sample_width=2, sample_rate=44100
+    )
+    assert result.error is not None
+    assert "16 kHz mono" in result.error
+
+
+@pytest.mark.asyncio
+async def test_together_empty_stream(fake_api_key: SecretStr, audio_pcm_bytes: bytes) -> None:
+    ws = FakeWebSocket([], server_closes=False)
+    provider = TogetherSTTProvider(api_key=fake_api_key)
+
+    result = await _run(provider, ws, audio_pcm_bytes)
+
+    assert result.complete_transcript is None
+    assert result.ttft_seconds is None

--- a/web/lib/config/colors.ts
+++ b/web/lib/config/colors.ts
@@ -98,7 +98,7 @@ export const modelColors: Record<string, string> = {
   "nemotron-3-asr-streaming-0.6b": "#62ab5b",
   "nemotron-3.5-asr-streaming-0.6b": "#4a9243",
   "parakeet-tdt-0.6b-v3": "#33792c",
-  "whisper-large-v3": "#1c6016",
+  "together:whisper-large-v3": "#1c6016",
 
   // Composite keys for models whose slug is shared across providers
   "speechmatics:default": "#a24112",

--- a/web/lib/config/colors.ts
+++ b/web/lib/config/colors.ts
@@ -93,6 +93,13 @@ export const modelColors: Record<string, string> = {
 
   "qwen3-tts-flash-realtime": "#9c6c03",
 
+  // Together AI — green, dark range (STT; Rime's greens are TTS-only and
+  // Gradium's STT default sits in the light range, so they stay apart).
+  "nemotron-3-asr-streaming-0.6b": "#62ab5b",
+  "nemotron-3.5-asr-streaming-0.6b": "#4a9243",
+  "parakeet-tdt-0.6b-v3": "#33792c",
+  "whisper-large-v3": "#1c6016",
+
   // Composite keys for models whose slug is shared across providers
   "speechmatics:default": "#a24112",
   "gradium:default": "#74c16c"
@@ -116,5 +123,6 @@ export const providerColors: Record<string, string> = {
   Mistral: "#835a01",
   Smallest: "#d7a03d",
   Azure: "#3d7fd1",
-  Alibaba: "#9c6c03"
+  Alibaba: "#9c6c03",
+  "Together AI": "#4a9243"
 };

--- a/web/lib/utils/formatters.ts
+++ b/web/lib/utils/formatters.ts
@@ -130,6 +130,10 @@ export function normalizeModelName(modelKey: string): string {
     "stt-rt-v4": "STT RT v4",
     "stt-rt-v5": "STT RT v5",
     "inworld-stt-1": "STT 1",
+    "nemotron-3-asr-streaming-0.6b": "Nemotron 3 ASR Streaming",
+    "nemotron-3.5-asr-streaming-0.6b": "Nemotron 3.5 ASR Streaming",
+    "parakeet-tdt-0.6b-v3": "Parakeet TDT 0.6B v3",
+    "whisper-large-v3": "Whisper Large v3",
     default: "Default",
     enhanced: "Enhanced"
   };
@@ -179,6 +183,7 @@ export function normalizeSTTProviderName(providerName: string): string {
     rime: "Rime",
     soniox: "Soniox",
     speechmatics: "Speechmatics",
+    together: "Together AI",
     xai: "xAI"
   };
 


### PR DESCRIPTION
Benchmarks four open-weight models (Nemotron 3/3.5 ASR Streaming, Parakeet TDT 0.6B v3, Whisper Large v3) over Together's realtime WebSocket, padding trailing silence for the Nemotrons whose commit drops encoder lookahead and excluding them from TTFS.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds Together AI as a new real-time STT provider backed by a WebSocket following the OpenAI Realtime wire protocol, covering four open-weight models (Nemotron 3/3.5, Parakeet TDT, Whisper Large v3). The PR also registers all four models in the model registry, excludes the Nemotron models from TTFS comparisons (because trailing silence is padded before commit to flush their encoder lookahead), adds colors and display names in the web layer, and ships a full FakeWebSocket-based test suite.

- **Core provider** (`together.py`): dual-task send/receive pattern with correct asyncio coordination (`FIRST_EXCEPTION` wait + gather), graceful timeout on the post-commit final wait, and a configurable silence-padding path for Nemotron's lookahead flush.
- **Metrics exclusion** (`metrics.py`): correctly excludes `nemotron-3-asr-streaming-0.6b` and `nemotron-3.5-asr-streaming-0.6b` from TTFS, matching the same approach used for Rev AI's `reverb` model.
- **Web layer** (`colors.ts`, `formatters.ts`): `whisper-large-v3` correctly uses a composite `together:` key (Baseten shares that slug), while the three Nvidia-only slugs use unqualified keys consistent with the rest of the map.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the new provider is well-isolated and the two observations are minor edge cases with no impact on normal runs.

Both findings require unusual failure conditions (task cancellation mid-cleanup, or a developer scanning the send loop and misreading the intent of the repeated assignment). The core send/receive task coordination, error propagation, silence-padding logic, and TTFS exclusion are all correct, and the test suite covers the key behavioral paths.

No files require special attention.

<sub>Reviews (3): Last reviewed commit: ["Salvage the latest delta per item in the..."](https://github.com/coval-ai/benchmarks/commit/9a56239a7c4e06236eacdc8a25ef274863f3c042) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43346547)</sub>

<!-- /greptile_comment -->