### PR TITLE
[BENCH 398] Make WER bar chart usable on mobile 

### DIFF
--- a/web/components/dashboard/AccuracyBarSection.tsx
+++ b/web/components/dashboard/AccuracyBarSection.tsx
@@ -162,8 +162,12 @@ const AccuracyBarSection: React.FC = () => {
             </button>
           </div>
         )}
-        <div className="h-96" onMouseEnter={trackChartHover}>
-          <ResponsiveContainer width="100%" height="100%">
+        <div className="h-96 overflow-x-auto" onMouseEnter={trackChartHover}>
+          <ResponsiveContainer
+            width="100%"
+            height="100%"
+            minWidth={isMobile ? werBarDataWithColors.length * 48 : 0}
+          >
             <BarChart
               data={werBarDataWithColors}
               margin={{
@@ -206,7 +210,11 @@ const AccuracyBarSection: React.FC = () => {
                   style: { textAnchor: "middle" },
                 }}
               />
-              <Tooltip content={<CustomBarTooltip getProviderForModel={getProviderForModel} />} cursor={false} />
+              <Tooltip
+                content={<CustomBarTooltip getProviderForModel={getProviderForModel} />}
+                cursor={false}
+                active={isMobile ? false : undefined}
+              />
               <Bar
                 dataKey="averageWER"
                 radius={[4, 4, 0, 0]}


### PR DESCRIPTION
## Summary
Before:
<img width="1179" height="2556" alt="image" src="https://github.com/user-attachments/assets/9de0b566-2e67-4622-8e0c-a146e2f361ab" />

Fixes the three mobile issues from BENCH-398 on the Voice AI Benchmarks WER chart with a net +10 line change to `AccuracyBarSection.tsx`:

- **Colliding axis labels** and **untappable bars**: the chart now scrolls horizontally on mobile with a guaranteed 48px slot per model (`overflow-x-auto` + `ResponsiveContainer minWidth`). The wider slots re-activate the existing adaptive logic — `CustomBarChartTick` renders its two-line model + provider labels without collisions, bars grow from ~9px to ~36px touch targets, and bar-top value labels reappear (compensating for the y-axis scrolling off-screen mid-chart).
- **Tooltip covering the tapped bar**: the hover tooltip is disabled on mobile entirely (`active={isMobile ? false : undefined}`, the same pattern `TimelineChart` uses). Hover isn't a mobile gesture — tap already selects the bar, and the existing comparison chips show model + WER%. Desktop hover behavior is unchanged.

## Testing

- Verified at 375px viewport: 24 models scroll at 1152px width, native touch panning (`touch-action: auto`, vertical page scroll unaffected), tap toggles selection chips, tooltip never activates.
- Verified at 1280px: no scrollbar (`minWidth: 0`), hover tooltip renders as before.
- `eslint` and `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes three mobile usability issues in the WER bar chart by adding horizontal scroll support, enforcing a minimum bar width on mobile, and disabling the hover tooltip on touch devices.

- Adds `overflow-x-auto` to the chart wrapper and `minWidth={isMobile ? werBarDataWithColors.length * 48 : 0}` to `ResponsiveContainer`, guaranteeing 48 px touch targets and collision-free tick labels on mobile.
- Disables the recharts `Tooltip` on mobile with `active={isMobile ? false : undefined}`, matching the identical pattern already used in `TimelineChart.tsx`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a small, self-contained mobile layout fix with no logic mutations to data processing or click handling.

The diff is 10 lines touching only layout and tooltip visibility. `isMobile` is already wired through the dashboard context from `useMobileDetection`, the `active` prop pattern is a direct copy of what `TimelineChart` does, and the `minWidth` math (48 px × model count) is straightforward. The existing `barLabel` callback's 28 px threshold means every bar at 48 px slot width will still show its value label when the Y-axis scrolls offscreen — the compensation works correctly. No data paths, API calls, or state mutations are touched.

No files require special attention.

<sub>Reviews (1): Last reviewed commit: ["Make WER bar chart usable on mobile"](https://github.com/coval-ai/benchmarks/commit/38451f7818711f4935972ee483a83a8d054a06f2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43349444)</sub>

<!-- /greptile_comment -->