### PR TITLE
[BENCH-399] Make TTFA box plot usable on mobile

### DIFF
--- a/web/components/charts/d3/BoxPlot.tsx
+++ b/web/components/charts/d3/BoxPlot.tsx
@@ -399,14 +399,14 @@ const BoxPlot: React.FC<BoxPlotProps> = ({
   // leave the sizing effect's ResizeObserver attached to nothing, freezing
   // dimensions at their initial value once data arrives.
   return (
-    <div ref={containerRef} className="relative w-full select-none">
+    <div ref={containerRef} className="relative w-full">
       {data.data.length === 0 ? (
         <div className="h-64 flex items-center justify-center text-text-secondary">
           <p>No data available for box plot</p>
         </div>
       ) : (
         <div
-          className="overflow-x-auto touch-manipulation"
+          className="overflow-x-auto touch-manipulation select-none"
           onScroll={(e) => setScrollX(e.currentTarget.scrollLeft)}
         >
           <svg

--- a/web/components/charts/d3/BoxPlot.tsx
+++ b/web/components/charts/d3/BoxPlot.tsx
@@ -16,6 +16,8 @@ const providerFontSize = 12;
 const axisLabelFontSize = "14px";
 const yAxisTickFontSize = "12px";
 const modelLineHeight = 14;
+const margin = { top: 20, right: 8, bottom: 80, left: 40 };
+const mobileSlotWidth = 48;
 
 const BoxPlot: React.FC<BoxPlotProps> = ({
   data,
@@ -38,6 +40,7 @@ const BoxPlot: React.FC<BoxPlotProps> = ({
     yTop: number;
     pinned: boolean;
   } | null>(null);
+  const [scrollX, setScrollX] = useState(0);
   const themeColors = useThemeColors();
 
   useEffect(() => {
@@ -77,13 +80,23 @@ const BoxPlot: React.FC<BoxPlotProps> = ({
     };
   }, [height]);
 
+  // On mobile every model gets a guaranteed slot and the chart scrolls
+  // horizontally (same pattern as the WER bar chart) — wide enough slots
+  // re-enable the desktop axis labels and make each column a real touch
+  // target.
+  const svgWidth = isMobile
+    ? Math.max(
+        dimensions.width,
+        data.data.length * mobileSlotWidth + margin.left + margin.right
+      )
+    : dimensions.width;
+
   useEffect(() => {
     if (!svgRef.current || data.data.length === 0) return;
 
     setTip(null);
 
-    const margin = { top: 20, right: 8, bottom: 80, left: 40 };
-    const chartWidth = dimensions.width - margin.left - margin.right;
+    const chartWidth = svgWidth - margin.left - margin.right;
     const chartHeight = dimensions.height - margin.top - margin.bottom;
 
     const svg = d3.select(svgRef.current);
@@ -154,8 +167,8 @@ const BoxPlot: React.FC<BoxPlotProps> = ({
     xAxisGroup.select(".domain").remove();
     xAxisGroup.selectAll("text").remove();
 
-    // Create custom wrapped text with model first (desktop only)
-    if (!isMobile) {
+    // Create custom wrapped text with model first
+    {
       const labelMaxWidth = xScale.step() * 0.96;
       const minModelFont = 8;
 
@@ -324,33 +337,51 @@ const BoxPlot: React.FC<BoxPlotProps> = ({
         .attr("stroke", color)
         .attr("stroke-width", 1.5);
 
+      // Full-height invisible hit area so a finger can land anywhere in the
+      // model's column, not just on the thin strokes.
+      if (isMobile) {
+        boxGroup
+          .append("rect")
+          .attr("x", centerX - xScale.step() / 2)
+          .attr("y", 0)
+          .attr("width", xScale.step())
+          .attr("height", chartHeight)
+          .attr("fill", "transparent");
+      }
+
       // Hover shows a compact name + median tooltip above the whiskers;
       // clicking pins that same tooltip and populates it with the full
       // stats so it never chases the cursor or blocks neighboring boxes.
+      // On mobile there is no hover: a tap pins the full stats directly.
       const anchor = {
         point: modelData,
         x: margin.left + centerX,
         yTop: margin.top + yScale(max),
       };
 
-      boxGroup
-        .style("cursor", "pointer")
-        .on("mouseenter", function () {
-          d3.select(this)
-            .select("rect")
-            .attr("fill-opacity", 0.5);
+      boxGroup.style("cursor", "pointer");
 
-          setTip((t) =>
-            t?.pinned && t.point.model === modelData.model
-              ? t
-              : { ...anchor, pinned: false }
-          );
-        })
-        .on("mouseleave", function () {
-          d3.select(this)
-            .select("rect")
-            .attr("fill-opacity", 0.3);
-        })
+      if (!isMobile) {
+        boxGroup
+          .on("mouseenter", function () {
+            d3.select(this)
+              .select("rect")
+              .attr("fill-opacity", 0.5);
+
+            setTip((t) =>
+              t?.pinned && t.point.model === modelData.model
+                ? t
+                : { ...anchor, pinned: false }
+            );
+          })
+          .on("mouseleave", function () {
+            d3.select(this)
+              .select("rect")
+              .attr("fill-opacity", 0.3);
+          });
+      }
+
+      boxGroup
         .on("click", (event: MouseEvent) => {
           event.stopPropagation();
           setTip((t) =>
@@ -362,34 +393,47 @@ const BoxPlot: React.FC<BoxPlotProps> = ({
     });
 
     svg.on("mouseleave", () => setTip((t) => (t?.pinned ? t : null)));
-  }, [data, dimensions, getModelColor, getProviderForModel, normalizeModelName, isMobile, themeColors]);
+  }, [data, dimensions, svgWidth, getModelColor, getProviderForModel, normalizeModelName, isMobile, themeColors]);
 
   // The measured container must always render — an early return here would
   // leave the sizing effect's ResizeObserver attached to nothing, freezing
   // dimensions at their initial value once data arrives.
   return (
-    <div ref={containerRef} className="relative w-full">
+    <div ref={containerRef} className="relative w-full select-none">
       {data.data.length === 0 ? (
         <div className="h-64 flex items-center justify-center text-text-secondary">
           <p>No data available for box plot</p>
         </div>
       ) : (
-        <svg
-          ref={svgRef}
-          width={dimensions.width}
-          height={dimensions.height}
-          className="overflow-visible"
-          style={{ background: "transparent" }}
-        />
+        <div
+          className="overflow-x-auto touch-manipulation"
+          onScroll={(e) => setScrollX(e.currentTarget.scrollLeft)}
+        >
+          <svg
+            ref={svgRef}
+            width={svgWidth}
+            height={dimensions.height}
+            className="overflow-visible"
+            style={{ background: "transparent" }}
+          />
+        </div>
       )}
       {tip && (
         <div
           onClick={(e) => e.stopPropagation()}
           className="absolute z-10 whitespace-nowrap text-xs"
           style={{
-            left: Math.min(Math.max(tip.x, 90), dimensions.width - 90),
-            top: tip.yTop,
-            transform: "translate(-50%, calc(-100% - 8px))",
+            // On mobile the panel sits above the plot and tracks its column
+            // as the chart scrolls, so it never covers the box being
+            // inspected and follows the finger while swiping.
+            left: Math.min(
+              Math.max(isMobile ? tip.x - scrollX : tip.x, 90),
+              dimensions.width - 90
+            ),
+            top: isMobile ? margin.top : tip.yTop,
+            transform: isMobile
+              ? "translate(-50%, -100%)"
+              : "translate(-50%, calc(-100% - 8px))",
             transition: "left 150ms ease-out, top 150ms ease-out",
             pointerEvents: tip.pinned ? "auto" : "none",
             backgroundColor: "var(--color-surface-tooltip)",


### PR DESCRIPTION
Fixes BENCH-399: on mobile the TTFA latency box plot crammed all ~25 models into the viewport width, the thin candles were nearly impossible to tap, tap-to-expand didn't work, and the tooltip covered the candles being compared.
Before:
<img width="1179" height="2556" alt="image" src="https://github.com/user-attachments/assets/44883a77-86b3-4fd6-a980-1a655be5e3a5" />


After:
<img width="694" height="679" alt="Screenshot 2026-07-10 at 11 03 08 AM" src="https://github.com/user-attachments/assets/230a69af-3cac-45ba-8605-4548ac531a53" />

## Changes (mobile only — desktop unchanged)

- **Horizontal scroll with 48px slots**: each model gets a guaranteed 48px column and the chart pans horizontally (same pattern as the WER bar chart, #268)
- **Real touch targets**: a full-height invisible hit rect per column, so a tap anywhere in the column selects the model
- **Tap pins details directly**: no hover step on mobile — one tap opens the full stats (Count / Mean / Median / Std), ✕ / tap-elsewhere dismisses
- **Axis labels on mobile**: the wider slots re-enable the desktop model + provider labels
- **Tooltip never covers the inspected box**: it anchors above the plot and tracks its column while swiping
- **Drag feels right**: `select-none` stops the blue text-selection highlight, `touch-manipulation` removes the double-tap-zoom delay

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes the TTFA latency box plot mobile-usable by adding horizontal scrolling with 48px per-model slots, full-height invisible tap targets, tap-to-pin tooltips (skipping the hover step), and a scroll-aware tooltip that tracks the selected column as the chart pans. Desktop behavior is unchanged.

- **Horizontal scroll + wider slots**: `svgWidth` expands on mobile to guarantee 48px per model; the existing D3 drawing logic reuses the wider space automatically to re-enable axis labels and widen the IQR boxes.
- **Tap targets + mobile interaction model**: an invisible full-height `rect` covers each column on mobile; hover handlers are gated behind `!isMobile`, and a single tap goes straight to the pinned full-stats tooltip without an intermediate hover state.
- **Scroll-tracking tooltip**: `scrollX` state mirrors the container's `scrollLeft`, and the tooltip's `left` is adjusted by `tip.x - scrollX`, keeping the panel above the tapped column as the chart scrolls.

<h3>Confidence Score: 5/5</h3>

Safe to merge — mobile-only interaction and layout changes, with desktop rendering paths unchanged and no data logic modified.

The D3 drawing changes are cleanly gated on isMobile: hover handlers are skipped, the invisible hit rect is only appended on mobile, and svgWidth expands only when isMobile is true. The scrollX state only affects the tooltip's CSS left value and never triggers a D3 redraw. The dismiss flow is correct for both platforms. No data-fetching, authentication, or shared-state paths are touched.

No files require special attention; the single changed file is self-contained.

<sub>Reviews (2): Last reviewed commit: ["Scope select-none to the scroll wrapper"](https://github.com/coval-ai/benchmarks/commit/67b13e10e251617731246c5794d7f4a3e2b434f2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43361864)</sub>

<!-- /greptile_comment -->