### PR TITLE
Alert on S2S fetch failures, add xAI, make the fetch grid configurable

### DIFF
--- a/runner/src/coval_bench/config.py
+++ b/runner/src/coval_bench/config.py
@@ -110,6 +110,10 @@ class Settings(BaseSettings):
     coval_s2s_latency_metric_id: str | None = None
     coval_s2s_openai_agent_id: str | None = None
     coval_s2s_gemini_agent_id: str | None = None
+    coval_s2s_xai_agent_id: str | None = None
+    # Fetch grid, in seconds; kept in sync with the s2s-fetch-trigger cron in
+    # benchmark-infra (override via S2S_FETCH_PERIOD_SECONDS). Default = 3h.
+    s2s_fetch_period_seconds: int = Field(default=10_800, gt=0)
 
     # --- Analytics ---
     posthog_project_token: str = ""

--- a/runner/src/coval_bench/logging.py
+++ b/runner/src/coval_bench/logging.py
@@ -70,6 +70,21 @@ def configure_logging(
         logging.getLogger(noisy).setLevel(max(log_level, logging.WARNING))
 
 
+_run_logger = structlog.get_logger("coval_bench.run")
+
+
+def log_run_failed(error: str, exc: BaseException | None = None) -> None:
+    """Emit the single log line the infra alert metric greps for.
+
+    The literal ``event="RUN_FAILED"`` triggers the ``benchmark_run_failure``
+    Cloud Logging metric in benchmark-infra. Centralized here so every
+    entrypoint (the STT/TTS orchestrator, the S2S fetch job) emits the identical
+    contract string and they can't drift. structlog uses the first positional
+    arg as the ``event`` key.
+    """
+    _run_logger.error("RUN_FAILED", error=error, exc_info=exc)
+
+
 def uvicorn_log_config(level: LogLevel = "INFO") -> dict[str, Any]:
     """Return a uvicorn ``log_config`` that renders uvicorn's logs as JSON.
 

--- a/runner/src/coval_bench/registries/models.py
+++ b/runner/src/coval_bench/registries/models.py
@@ -623,6 +623,13 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         tags=(_REALTIME, _MULTI),
         status=_PENDING,
     ),
+    RegisteredModel(
+        benchmark=_S2S,
+        provider="xai",
+        model="grok-realtime",
+        tags=(_REALTIME, _MULTI),
+        status=_PENDING,
+    ),
 ]
 
 _key_counts = Counter((m.benchmark, m.provider, m.model) for m in MODEL_REGISTRY)

--- a/runner/src/coval_bench/runner/orchestrator.py
+++ b/runner/src/coval_bench/runner/orchestrator.py
@@ -47,6 +47,7 @@ import structlog
 from posthog import Posthog
 from pydantic import BaseModel
 
+from coval_bench.logging import log_run_failed
 from coval_bench.providers._http_session import close_all as _close_http_clients
 from coval_bench.providers.base import Provider
 from coval_bench.registries import (
@@ -1163,17 +1164,10 @@ async def run_benchmarks(
             )
 
         except Exception as exc:
-            # Unrecoverable error — log RUN_FAILED (triggers Cloud Logging metric),
-            # update run row, then re-raise so Cloud Run Job exits non-zero.
+            # Unrecoverable error — emit RUN_FAILED (triggers the Cloud Logging
+            # metric), update run row, then re-raise so the job exits non-zero.
             err_msg = _truncate(str(exc))
-            # The literal event="RUN_FAILED" in this log line triggers the
-            # Cloud Logging log-based metric (see ARCHITECTURE.md § Logging + Alerting).
-            # structlog uses the first positional arg as the ``event`` key.
-            logger.error(
-                "RUN_FAILED",
-                error=err_msg,
-                exc_info=exc,
-            )
+            log_run_failed(err_msg, exc)
             try:
                 await writer.finish_run(run_id, status=RunStatus.FAILED, error=err_msg)
             except Exception as write_exc:

--- a/runner/src/coval_bench/s2s/fetch_v2v.py
+++ b/runner/src/coval_bench/s2s/fetch_v2v.py
@@ -31,9 +31,6 @@ from coval_bench.registries.benchmarks import Benchmark
 
 logger = structlog.get_logger("coval_bench.s2s.fetch_v2v")
 
-# Daily job: floor scheduled_at to the day so a run's clip rows share one bucket.
-DAILY_PERIOD_SECONDS = 86_400
-
 # The dataset the S2S sims run against (matches the packaged manifest name).
 DATASET_ID = "s2s-v1"
 
@@ -51,6 +48,7 @@ class AgentSpec:
 AGENTS: tuple[AgentSpec, ...] = (
     AgentSpec(agent_id_attr="coval_s2s_openai_agent_id", provider="openai", model="gpt-realtime"),
     AgentSpec(agent_id_attr="coval_s2s_gemini_agent_id", provider="google", model="gemini-live"),
+    AgentSpec(agent_id_attr="coval_s2s_xai_agent_id", provider="xai", model="grok-realtime"),
 )
 
 
@@ -166,6 +164,7 @@ async def _fetch_one_provider(
     metric_id: str,
     runner_sha: str,
     scheduled_at: datetime,
+    period_seconds: int,
 ) -> RunStatus:
     """Fetch one provider's latest run into its own run row; return its status.
 
@@ -210,7 +209,7 @@ async def _fetch_one_provider(
         await writer.finish_run(run_pk, status=status)
         if status in (RunStatus.SUCCEEDED, RunStatus.PARTIAL):
             try:
-                await writer.refresh_bucket(run_pk, period_seconds=DAILY_PERIOD_SECONDS)
+                await writer.refresh_bucket(run_pk, period_seconds=period_seconds)
             except Exception:
                 logger.warning("refresh_bucket_failed", provider=spec.provider, exc_info=True)
         return status
@@ -240,7 +239,7 @@ async def fetch_and_write_v2v(settings: Settings | None = None) -> dict[str, Run
         raise RuntimeError("coval_s2s_latency_metric_id is not set")
 
     epoch = int(datetime.now(tz=UTC).timestamp())
-    scheduled_at = datetime.fromtimestamp(epoch - epoch % DAILY_PERIOD_SECONDS, tz=UTC)
+    scheduled_at = datetime.fromtimestamp(epoch - epoch % settings.s2s_fetch_period_seconds, tz=UTC)
 
     async with _client(settings) as client, lifespan_pool(settings) as pool:
         writer = RunWriter(pool)
@@ -258,6 +257,7 @@ async def fetch_and_write_v2v(settings: Settings | None = None) -> dict[str, Run
                 metric_id=metric_id,
                 runner_sha=settings.runner_sha,
                 scheduled_at=scheduled_at,
+                period_seconds=settings.s2s_fetch_period_seconds,
             )
 
         if any(s in (RunStatus.SUCCEEDED, RunStatus.PARTIAL) for s in statuses.values()):
@@ -271,12 +271,26 @@ async def fetch_and_write_v2v(settings: Settings | None = None) -> dict[str, Run
 
 @click.command(name="fetch-s2s")
 def fetch_s2s() -> None:
-    """Fetch S2S latency from Coval and write per-clip rows (daily Cloud Run Job)."""
-    from coval_bench.logging import configure_logging
+    """Fetch S2S latency from Coval and write per-clip rows (scheduled Cloud Run Job)."""
+    from coval_bench.logging import configure_logging, log_run_failed
 
     settings = get_settings()
     configure_logging(level=settings.log_level)
-    statuses = asyncio.run(fetch_and_write_v2v(settings))
+    # A setup crash fails the whole job.
+    try:
+        statuses = asyncio.run(fetch_and_write_v2v(settings))
+    except Exception as exc:
+        log_run_failed(str(exc), exc)
+        raise
+
+    # Alert if any provider returned no data (a silently-missing provider). The
+    # succeeding providers' rows are already committed, so a partial run still
+    # exits 0 — only a total loss fails the job (non-zero exit).
+    failed = [p for p, s in statuses.items() if s is RunStatus.FAILED]
+    if not statuses:
+        log_run_failed("s2s fetch ran no providers (none configured)")
+    elif failed:
+        log_run_failed(f"s2s fetch got no data from: {', '.join(failed)}")
     if not statuses or all(s is RunStatus.FAILED for s in statuses.values()):
         raise click.ClickException("s2s fetch failed for all providers")
 

--- a/runner/tests/unit/test_s2s_fetch.py
+++ b/runner/tests/unit/test_s2s_fetch.py
@@ -111,6 +111,7 @@ async def test_fetch_one_provider_succeeded() -> None:
             metric_id="MID",
             runner_sha="test",
             scheduled_at=SLOT,
+            period_seconds=10_800,
         )
     assert status is RunStatus.SUCCEEDED
     writer.record_results.assert_awaited_once()
@@ -134,6 +135,7 @@ async def test_fetch_one_provider_partial() -> None:
             metric_id="MID",
             runner_sha="test",
             scheduled_at=SLOT,
+            period_seconds=10_800,
         )
     assert status is RunStatus.PARTIAL
 
@@ -150,6 +152,7 @@ async def test_fetch_one_provider_no_run_failed() -> None:
             metric_id="MID",
             runner_sha="test",
             scheduled_at=SLOT,
+            period_seconds=10_800,
         )
     assert status is RunStatus.FAILED
     writer.record_results.assert_not_awaited()
@@ -169,6 +172,7 @@ async def test_fetch_one_provider_skips_already_ingested_run() -> None:
             metric_id="MID",
             runner_sha="test",
             scheduled_at=SLOT,
+            period_seconds=10_800,
         )
     assert status is RunStatus.SUCCEEDED  # no-op: last good data left in place
     writer.start_run.assert_not_awaited()


### PR DESCRIPTION
the s2s-fetch alert filter watches for `event="RUN_FAILED"`, but the S2S fetch job never emitted it (only the STT/TTS orchestrator did), so a broken fetch would fail silently.

Extracts a shared `log_run_failed()` helper so both the orchestrator and the fetch job emit the exact `RUN_FAILED` line the infra `benchmark_run_failure` metric greps for — the alert contract now lives in one place. Each path keeps its own failure condition; only the emit is shared.

Failure handling for the fetch job decouples the alert from the exit code:
- **Alert (`RUN_FAILED`) fires when *any* provider returns no data** — a silently-missing provider (e.g. a mis-wired agent) is exactly what you want to know about.
- **The job exits non-zero only when *all* providers fail** (or a setup crash). A partial run has already committed the succeeding providers' rows, so it exits 0 (no retry / no data loss) while still alerting.
- Clip-level partials *within* a provider (e.g. the 0.5s latency floor dropping sub-500ms clips) are expected and don't alert.

Also lands two things that were stranded on a local branch:
- Registers the xAI `grok-realtime` S2S model (`PENDING`, hidden) plus its fetch agent, so it joins OpenAI and Gemini once its Coval agent id + `COVAL_S2S_XAI_AGENT_ID` are set.
- Replaces the hardcoded daily bucket with `settings.s2s_fetch_period_seconds` (default 3h, `S2S_FETCH_PERIOD_SECONDS`), kept in sync with the `s2s-fetch-trigger` cron so the runner's timeline bucket matches the actual cadence — tunable without a redeploy.
