### PR TITLE
[BENCH-400] Keep facet filter chips visually stable while filtering

### DIFF
--- a/web/components/layout/FacetFilter.tsx
+++ b/web/components/layout/FacetFilter.tsx
@@ -72,13 +72,14 @@ const FacetFilter: React.FC = () => {
                 >
                   <span>{option.label}</span>
                   <span
-                    className={
+                    style={{ minWidth: `${String(option.maxCount).length}ch` }}
+                    className={`inline-block text-center tabular-nums ${
                       fill
                         ? "opacity-70"
                         : option.active
                           ? "text-text-on-toggle-active/70"
                           : "text-text-tertiary"
-                    }
+                    }`}
                   >
                     {option.count}
                   </span>

--- a/web/lib/utils/facets.test.ts
+++ b/web/lib/utils/facets.test.ts
@@ -102,6 +102,14 @@ describe("buildFacetGroups", () => {
     expect(byValue).toEqual({ deepgram: 1, openai: 1, cartesia: 0 });
   });
 
+  it("keeps labels, order, and colors stable while other categories filter", () => {
+    const snapshot = (selected: Parameters<typeof buildFacetGroups>[2]) =>
+      buildFacetGroups(ALL, index(), selected, cats(), id)
+        .find((g) => g.category === "host")!
+        .options.map(({ value, label, color, maxCount }) => ({ value, label, color, maxCount }));
+    expect(snapshot({ features: ["multilingual"] })).toEqual(snapshot({}));
+  });
+
   it("uses the API-supplied label and marks active options", () => {
     const groups = buildFacetGroups(ALL, index(), { features: ["vad"] }, cats(), id);
     const features = groups.find((g) => g.category === "features")!;

--- a/web/lib/utils/facets.ts
+++ b/web/lib/utils/facets.ts
@@ -14,6 +14,7 @@ export interface FacetOption {
   value: string;
   label: string;
   count: number;
+  maxCount: number;
   active: boolean;
   color?: string;
 }
@@ -101,7 +102,8 @@ export function filterModelsByFacets(
  * Build the chip groups, in the API's category order. A category is shown only
  * when the visible models hold at least two distinct values for it. Each
  * option's count is how many models would remain if it were selected, honoring
- * the other categories' selection.
+ * the other categories' selection; labels and colors ignore the selection so
+ * chips never rename or recolor while filtering.
  */
 export function buildFacetGroups(
   modelsByProvider: ModelsByProvider,
@@ -125,34 +127,24 @@ export function buildFacetGroups(
     const others: FacetSelection = { ...selected, [category]: [] };
     const options: FacetOption[] = [...valueLabels.entries()]
       .map(([value, valueLabel]) => {
-        const count = visibleKeys.filter((key) => {
-          const tags = tagIndex.get(key) ?? [];
-          return (
-            tags.some((t) => t.category === category && t.value === value) &&
-            matchesSelection(tags, others)
-          );
-        }).length;
+        const matching = visibleKeys.filter((key) =>
+          (tagIndex.get(key) ?? []).some((t) => t.category === category && t.value === value)
+        );
+        const count = matching.filter((key) =>
+          matchesSelection(tagIndex.get(key) ?? [], others)
+        ).length;
         const label = provider_valued ? normalizeProvider(value) : valueLabel;
         let color: string | undefined;
         if (provider_valued) {
-          // Chip follows the chart: derive the host chip from the color of one
-          // of its visible models so the sidebar can never drift from the
-          // series colors. Match the same predicate as `count` (including the
-          // other active facets) so the representative model is one that's
-          // actually visible. providerColors is only a fallback when none is.
-          const repKey = visibleKeys.find((key) => {
-            const tags = tagIndex.get(key) ?? [];
-            return (
-              tags.some((t) => t.category === category && t.value === value) &&
-              matchesSelection(tags, others)
-            );
-          });
-          color = (repKey ? getModelColor(repKey) : undefined) ?? providerColors[label];
+          // Chip follows the chart: derive the chip from the color of one of
+          // its models so the sidebar can never drift from the series colors.
+          color = (matching[0] ? getModelColor(matching[0]) : undefined) ?? providerColors[label];
         }
         return {
           value,
           label,
           count,
+          maxCount: matching.length,
           active: (selected[category] ?? []).includes(value),
           color,
         };


### PR DESCRIPTION
## Problem

Clicking a provider chip in the Filters panel visi
<img width="720" height="416" alt="Screenshot 2026-07-10 at 11 58 00 AM" src="https://github.com/user-attachments/assets/99054f3b-0d50-4422-8bce-4029cf70aa6d" />
bly mutated the other filter sections (BENCH-400):

- **Colors changed or vanished** — chip colors were derived from the *filtered* model set, so once a chip's representative model was filtered out it changed color or fell back to gray (Microsoft and Rev have no `providerColors` entry).
- **Chips shuffled around** — count text changing width (e.g. `12` → `0`) narrowed a chip and reflowed every chip after it, so the panel visibly jumped on every select/deselect.

Counts reacting to the other groups' selection is intended faceted behavior and is kept: picking HOST AssemblyAI still zeroes out inapplicable LAB entries.

## Fix

- `buildFacetGroups` now derives each provider chip's color from the full data-backed model universe instead of the filtered one, so colors never change with the selection.
- Each option carries its unfiltered count (`maxCount`), and `FacetFilter` reserves the count span's width at that many characters (`tabular-nums`). A filtered count can never exceed the unfiltered one, so chip widths — and therefore positions — never change. At rest nothing looks different.

Data-level change only; the mobile filter sheet renders the same component and inherits the fix.

## Verification

- Measured all 90 chip bounding boxes across every filter group before selecting, after selecting, and after deselecting: zero position/width changes, on both the STT and TTS dashboards, in dark and light themes.
- Counts still facet correctly (HOST Gladia → LAB collapses to Gladia 1; two-host selection on TTS filters charts to the 3 matching models).
- `vitest` 55/55 (new test asserts labels/order/colors/maxCount are selection-independent), `tsc` and `eslint --max-warnings 0` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR keeps facet filter chips visually stable while selections change. The main changes are:

- Adds `maxCount` to facet options for count-width reservation.
- Uses `maxCount` in the filter chip count span with tabular numerals.
- Derives provider chip colors from the full data-backed model set.
- Adds a test for stable provider labels, order, colors, and `maxCount`.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<sub>Reviews (1): Last reviewed commit: ["\[BENCH-400\] Keep facet chips visually st..."](https://github.com/coval-ai/benchmarks/commit/2ca5d95106168bc3bc3d31c80b26265e6d41a5f3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43377239)</sub>

<!-- /greptile_comment -->