### PR TITLE
[BENCH-401] Fix mobile box plot tooltip covering the Average TTFA header

### DIFF
--- a/web/components/charts/d3/BoxPlot.tsx
+++ b/web/components/charts/d3/BoxPlot.tsx
@@ -423,7 +423,8 @@ const BoxPlot: React.FC<BoxPlotProps> = ({
           onClick={(e) => e.stopPropagation()}
           className="absolute z-10 whitespace-nowrap text-xs"
           style={{
-            // On mobile the panel sits above the plot and tracks its column
+            // On mobile the panel hangs from the top of the plot — inside
+            // the card, clear of the heading above — and tracks its column
             // as the chart scrolls, so it never covers the box being
             // inspected and follows the finger while swiping.
             left: Math.min(
@@ -432,7 +433,7 @@ const BoxPlot: React.FC<BoxPlotProps> = ({
             ),
             top: isMobile ? margin.top : tip.yTop,
             transform: isMobile
-              ? "translate(-50%, -100%)"
+              ? "translate(-50%, 0)"
               : "translate(-50%, calc(-100% - 8px))",
             transition: "left 150ms ease-out, top 150ms ease-out",
             pointerEvents: tip.pinned ? "auto" : "none",


### PR DESCRIPTION
## Summary
- On mobile, the pinned tap tooltip on the latency variation (TTFA) box plot anchored its bottom edge 20px from the chart container top, so the panel escaped the container upward and covered the "Average TTFA" heading and stat value.
- Introduced by the BENCH-399 mobile box plot work (#269). One-line fix: hang the panel *down* from the top of the plot area (`translate(-50%, 0)` instead of `translate(-50%, -100%)`), which is reliably empty space since the y-axis ceiling snaps above the tallest whisker.
- The panel stays inside the card, still tracks its column while the chart scrolls horizontally, and never covers the box being inspected. Desktop hover/pin behavior untouched.

## Testing
- Reproduced the overlap at 375×812 on /tts, then verified post-fix: tapping TTS-1.5 Mini and TTS-1.5 Max pins the stats panel inside the plot, clear of the header; ✕ and tap-away dismiss it; no console errors.
- Verified desktop (1280×800) hover tooltip still renders above the whisker as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adjusts the mobile BoxPlot tooltip placement for the TTFA chart.

- Moves the mobile pinned tooltip below the plot top edge.
- Keeps desktop tooltip positioning unchanged.
- Updates the positioning comment to match the new behavior.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge after a small mobile layout cleanup.

- The change is limited to tooltip positioning.
- The mobile panel can now overlap tall chart values because it grows downward from the plot top.
- No security, data, or build behavior is affected.

web/components/charts/d3/BoxPlot.tsx

<sub>Reviews (1): Last reviewed commit: ["Fix mobile box plot tooltip covering the..."](https://github.com/coval-ai/benchmarks/commit/fa88e97cb74fb9e25b04c970c3e45cde0407aefc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43384803)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->