### PR TITLE
[BENCH-402] Add touch scrubbing to Latency vs Accuracy scatter on mobile

### DIFF
--- a/web/components/dashboard/LatencyAccuracySection.tsx
+++ b/web/components/dashboard/LatencyAccuracySection.tsx
@@ -171,7 +171,11 @@ const LatencyAccuracySection: React.FC = () => {
           className="relative h-64 select-none"
           onMouseEnter={trackChartHover}
           onPointerDown={isMobile ? scrub : undefined}
-          onPointerMove={isMobile ? (e) => e.buttons > 0 && scrub(e) : undefined}
+          onPointerMove={
+            isMobile
+              ? (e) => (e.pointerType === "touch" || e.buttons > 0) && scrub(e)
+              : undefined
+          }
           onPointerUp={isMobile ? () => setActiveIdx(-1) : undefined}
           onPointerCancel={isMobile ? () => setActiveIdx(-1) : undefined}
           style={isMobile ? { touchAction: "pan-y" } : undefined}

--- a/web/components/dashboard/LatencyAccuracySection.tsx
+++ b/web/components/dashboard/LatencyAccuracySection.tsx
@@ -3,13 +3,14 @@
 
 "use client";
 
-import React, { useMemo } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import {
   ScatterChart,
   Scatter,
   XAxis,
   YAxis,
   CartesianGrid,
+  ReferenceLine,
   ResponsiveContainer,
   Tooltip,
 } from "recharts";
@@ -26,6 +27,7 @@ import { useDashboard } from "@/contexts/DashboardContext";
 import { useThemeColors } from "@/hooks/useThemeColors";
 import { useActiveTab } from "@/hooks/useActiveTab";
 import { useChartHoverTracking } from "@/hooks/useChartHoverTracking";
+import { useMobileDetection } from "@/hooks/useMobileDetection";
 
 const LatencyAccuracySection: React.FC = () => {
   const { selectedModels, getScatterData, activeMetric: metric } = useDashboard();
@@ -39,6 +41,15 @@ const LatencyAccuracySection: React.FC = () => {
     () => getScatterData(metric),
     [getScatterData, metric]
   );
+
+  const isMobile = useMobileDetection();
+  const sortedData = useMemo(
+    () => [...scatterData].sort((a, b) => a.x - b.x),
+    [scatterData]
+  );
+  const [activeIdx, setActiveIdx] = useState(-1);
+  useEffect(() => setActiveIdx(-1), [sortedData]);
+  const activePoint = isMobile ? sortedData[activeIdx] : undefined;
 
   const description = {
     short: `Average ${latencyLabel} and WER per model`,
@@ -87,6 +98,21 @@ const LatencyAccuracySection: React.FC = () => {
     for (let t = 0; t <= max; t += step) ticks.push(t);
     return { xMax: max, xTicks: ticks };
   }, [scatterData]);
+
+  const scrub = (e: React.PointerEvent<HTMLDivElement>) => {
+    if (!sortedData.length) return;
+    const rect = e.currentTarget.getBoundingClientRect();
+    const xValue = ((e.clientX - rect.left - 40) / (rect.width - 48)) * xMax;
+    setActiveIdx(
+      sortedData.reduce(
+        (best, p, i) =>
+          Math.abs(p.x - xValue) < Math.abs((sortedData[best] ?? p).x - xValue)
+            ? i
+            : best,
+        0
+      )
+    );
+  };
 
   // WER-based: never rendered on S2S (no WER metric).
   if (activeTab === "s2s") return null;
@@ -141,7 +167,29 @@ const LatencyAccuracySection: React.FC = () => {
 
         <MetricToggle />
 
-        <div className="h-64" onMouseEnter={trackChartHover}>
+        <div
+          className="relative h-64 select-none"
+          onMouseEnter={trackChartHover}
+          onPointerDown={isMobile ? scrub : undefined}
+          onPointerMove={isMobile ? (e) => e.buttons > 0 && scrub(e) : undefined}
+          onPointerUp={isMobile ? () => setActiveIdx(-1) : undefined}
+          onPointerCancel={isMobile ? () => setActiveIdx(-1) : undefined}
+          style={isMobile ? { touchAction: "pan-y" } : undefined}
+        >
+          {activePoint && (
+            <div
+              className={`pointer-events-none absolute top-2 z-10 max-w-[40%] text-xs ${
+                activePoint.x > xMax / 2 ? "left-12" : "right-2"
+              }`}
+            >
+              <CustomScatterTooltip
+                active
+                payload={[{ payload: activePoint, name: activePoint.model, value: activePoint.x }]}
+                activeTab={activeTab}
+                metric={metric}
+              />
+            </div>
+          )}
           <ResponsiveContainer width="100%" height="100%">
             <ScatterChart
               margin={{ top: 10, right: 8, left: 0, bottom: 0 }}
@@ -173,7 +221,15 @@ const LatencyAccuracySection: React.FC = () => {
                 tick={{ fill: themeColors.axisText, fontSize: 12 }}
                 tickFormatter={(value) => `${value}%`}
               />
-              <Tooltip content={<CustomScatterTooltip activeTab={activeTab} metric={metric} />} />
+              {!isMobile && (
+                <Tooltip content={<CustomScatterTooltip activeTab={activeTab} metric={metric} />} />
+              )}
+              {activePoint && (
+                <ReferenceLine x={activePoint.x} stroke={themeColors.axisText} strokeDasharray="3 3" />
+              )}
+              {activePoint && (
+                <ReferenceLine y={activePoint.y} stroke={themeColors.axisText} strokeDasharray="3 3" />
+              )}
               {selectedModels.map((model: string) => (
                 <Scatter
                   key={model}
@@ -183,12 +239,15 @@ const LatencyAccuracySection: React.FC = () => {
                   fill={getModelColor(model)}
                   name={model}
                   isAnimationActive={false}
-                  shape={(props: { cx?: number; cy?: number; fill?: string }) => (
+                  shape={(props: { cx?: number; cy?: number; fill?: string; payload?: ScatterDataPoint }) => (
                     <circle
                       cx={props.cx}
                       cy={props.cy}
-                      r={6}
+                      r={props.payload === activePoint ? 8 : 6}
                       fill={props.fill}
+                      fillOpacity={activePoint && props.payload !== activePoint ? 0.35 : 1}
+                      stroke={props.payload === activePoint ? themeColors.axisText : undefined}
+                      strokeWidth={2}
                     />
                   )}
                 />


### PR DESCRIPTION
## Summary
<img width="1512" height="982" alt="Screenshot 2026-07-10 at 1 29 54 PM" src="https://github.com/user-attachments/assets/1bca2dab-72ce-417c-a80e-c3d851eb2d4c" />


Fixes bench-402: on mobile, the Latency vs Accuracy scatter's tightly-clustered dots (especially below 0.5s TTFA) were nearly impossible to tap individually — the wrong tooltip appeared or nothing registered.

Instead of requiring precise taps, the whole plot is now a scrub surface on mobile, matching how the Latency Benchmarks timeline feels:

- **Drag anywhere across the chart** and a dashed crosshair snaps to the nearest point by TTFA; a single tap does the same.
- The active dot **enlarges with a ring** while the others dim, so it's always clear which point is inspected.
- Details render in a **fixed panel pinned to the top** of the chart (above the finger, clear of a right-handed palm), flipped to the side opposite the active dot and capped at 40% width so it can never cover the dot or the crosshair intersection.
- **Lifting the finger clears everything** (also on pointercancel, so no stray crosshair after a page scroll).
- Vertical page scrolling over the chart is preserved (`touch-action: pan-y`).

All behavior is gated behind the existing `useMobileDetection` hook (<768px) — **desktop hover is untouched**. Reuses the existing `CustomScatterTooltip` component for the pinned panel.

## Testing

- Verified in a 375px viewport: drag-scrub walks the crosshair through the sub-0.5s cluster point by point; tap selects; release clears (reference lines drop to 0).
- Reproduced the tooltip-covers-dot case (Qwen3 Tts Flash Realtime, top-center) and measured no overlap after the width cap.
- Verified at 1380px: no crosshair/panel, stock hover tooltip fires.
- `tsc --noEmit` and `eslint --max-warnings 0` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds mobile touch scrubbing to the Latency vs Accuracy scatter chart. The main changes are:

- Mobile-only pointer scrubbing across the chart surface.
- A pinned tooltip panel for the active point.
- Crosshair reference lines and active-dot styling while scrubbing.
- Desktop hover tooltip behavior kept behind the non-mobile path.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<sub>Reviews (2): Last reviewed commit: ["Accept touch pointermove regardless of b..."](https://github.com/coval-ai/benchmarks/commit/df1481d60e15af6af94843f53a4b14be4a312a47) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43399704)</sub>

<!-- /greptile_comment -->