### PR TITLE
Extend arena clip retention to 30 days

### DIFF
--- a/runner/src/coval_bench/config.py
+++ b/runner/src/coval_bench/config.py
@@ -143,7 +143,7 @@ class Settings(BaseSettings):
     arena_audio_base_url: str = ""
     arena_gcs_bucket: str = ""
     # Must match the GCS bucket's object-deletion lifecycle (set in benchmark-infra).
-    arena_clip_retention_days: int = 7
+    arena_clip_retention_days: int = 30
     arena_daily_battle_cap: int = 500
 
 

--- a/runner/tests/api/test_arena.py
+++ b/runner/tests/api/test_arena.py
@@ -200,7 +200,7 @@ async def test_get_battle_excludes_expired_clips(
     aconn = await psycopg.AsyncConnection.connect(_make_db_url(postgresql), autocommit=True)
     try:
         await aconn.execute(
-            "UPDATE arena.battles SET created_at = now() - interval '8 days' WHERE id = %(id)s",
+            "UPDATE arena.battles SET created_at = now() - interval '31 days' WHERE id = %(id)s",
             {"id": battle_id},
         )
     finally:
@@ -230,7 +230,7 @@ async def test_get_battle_by_id_excludes_expired_clip(
     aconn = await psycopg.AsyncConnection.connect(_make_db_url(postgresql), autocommit=True)
     try:
         await aconn.execute(
-            "UPDATE arena.battles SET created_at = now() - interval '8 days' WHERE id = %(id)s",
+            "UPDATE arena.battles SET created_at = now() - interval '31 days' WHERE id = %(id)s",
             {"id": battle_id},
         )
     finally:


### PR DESCRIPTION
desc : literally what it says

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extends arena clip availability to 30 days. The main changes are:

- Arena clip retention default changed from 7 to 30 days.
- Expired-clip API tests now use 31-day-old battles.

<h3>Confidence Score: 4/5</h3>

The changed retention default needs the matching GCS lifecycle update before merging.

- The API uses this setting to decide which battles can return signed clip URLs.
- A lifecycle mismatch can return battles whose audio objects have already been deleted.
- The tests cover the new 31-day expiry point, but they do not prove the external bucket lifecycle changed with this PR.

runner/src/coval_bench/config.py

<sub>Reviews (1): Last reviewed commit: ["Extend arena clip retention to 30 days"](https://github.com/coval-ai/benchmarks/commit/d8dbb217b6f929e3907b0ab6d70f88c502a50427) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43410993)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->