### PR TITLE
[BENCH-404] Salvage parakeet's empty Together segment finals

### DIFF
--- a/runner/src/coval_bench/providers/stt/together.py
+++ b/runner/src/coval_bench/providers/stt/together.py
@@ -17,6 +17,11 @@ truncating the tail. Trailing silence is paced in before the commit to flush
 the lookahead (Flux/Rev AI pattern); their TTFS is excluded in
 ``registries/metrics.py`` since the final's timing then tracks the client's
 silence length, not the engine.
+
+Parakeet's endpointer can close a segment with an empty ``completed`` even
+though the segment's deltas carried the text; such finals count as real
+finalizations, with the item's latest delta salvaged as the segment text
+(punctuation-only remnants excepted).
 """
 
 from __future__ import annotations
@@ -231,6 +236,10 @@ class TogetherSTTProvider(STTProvider):
 
                 if msg_type.endswith("input_audio_transcription.completed"):
                     transcript = str(msg.get("transcript", "")).strip()
+                    if not transcript:
+                        salvaged = item_deltas.get(str(msg.get("item_id", "")), "").strip()
+                        if any(ch.isalnum() for ch in salvaged):
+                            transcript = salvaged
                     if transcript:
                         final_segments.append(transcript)
                         last_final_time = now

--- a/runner/tests/providers/stt/test_together.py
+++ b/runner/tests/providers/stt/test_together.py
@@ -130,6 +130,85 @@ async def test_together_deltas_only_falls_back_to_latest_per_item(
     assert result.audio_to_final_seconds is None
 
 
+@pytest.mark.asyncio
+async def test_together_empty_final_salvages_item_deltas(
+    fake_api_key: SecretStr, audio_pcm_bytes: bytes
+) -> None:
+    """An empty final counts as a finalization, using the item's latest delta as its text."""
+    events: list[Any] = [
+        {
+            "type": "conversation.item.input_audio_transcription.delta",
+            "item_id": "item_1",
+            "delta": "hello",
+        },
+        {
+            "type": "conversation.item.input_audio_transcription.completed",
+            "item_id": "item_1",
+            "transcript": "hello world",
+        },
+        {
+            "type": "conversation.item.input_audio_transcription.delta",
+            "item_id": "item_2",
+            "delta": "how are",
+        },
+        {
+            "type": "conversation.item.input_audio_transcription.delta",
+            "item_id": "item_2",
+            "delta": "how are you",
+        },
+        {
+            "type": "conversation.item.input_audio_transcription.completed",
+            "item_id": "item_2",
+            "transcript": "",
+        },
+    ]
+    ws = FakeWebSocket(events, server_closes=False)
+    provider = TogetherSTTProvider(api_key=fake_api_key, model="parakeet-tdt-0.6b-v3")
+
+    result = await _run(provider, ws, audio_pcm_bytes)
+
+    assert result.error is None
+    assert result.complete_transcript == "hello world how are you"
+    assert result.audio_to_final_seconds is not None
+
+
+@pytest.mark.asyncio
+async def test_together_punctuation_only_final_not_salvaged(
+    fake_api_key: SecretStr, audio_pcm_bytes: bytes
+) -> None:
+    """A final whose item deltas hold no words stays dropped."""
+    events: list[Any] = [
+        {
+            "type": "conversation.item.input_audio_transcription.delta",
+            "item_id": "item_1",
+            "delta": "hello world",
+        },
+        {
+            "type": "conversation.item.input_audio_transcription.completed",
+            "item_id": "item_1",
+            "transcript": "hello world",
+        },
+        {
+            "type": "conversation.item.input_audio_transcription.delta",
+            "item_id": "item_2",
+            "delta": ". ",
+        },
+        {
+            "type": "conversation.item.input_audio_transcription.completed",
+            "item_id": "item_2",
+            "transcript": " ",
+        },
+    ]
+    ws = FakeWebSocket(events, server_closes=False)
+    provider = TogetherSTTProvider(api_key=fake_api_key, model="parakeet-tdt-0.6b-v3")
+
+    result = await _run(provider, ws, audio_pcm_bytes)
+
+    assert result.error is None
+    assert result.complete_transcript == "hello world"
+    assert result.word_count == 2
+
+
 def test_provider_name() -> None:
     provider = TogetherSTTProvider(api_key=SecretStr("k"), model="parakeet-tdt-0.6b-v3")
     assert provider.name == "together-parakeet-tdt-0.6b-v3"


### PR DESCRIPTION
Together's parakeet closes trailing-silence segments with an empty final even though the deltas carried the text; salvaging the item's latest delta keeps the tail in the WER transcript and stops TTFS clamping to 0.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates Together STT handling for Parakeet empty final segments.

- Salvages the latest matching item delta when an empty final has usable text.
- Keeps punctuation-only empty finals out of the final transcript.
- Adds tests for salvaged empty finals and punctuation-only drops.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.
- The new salvage path is limited to empty finals with matching alphanumeric item deltas.
- The added tests cover the main transcript and timing behavior for this change.

<sub>Reviews (1): Last reviewed commit: ["\[BENCH-404\] Salvage parakeet&#39;s empty Tog..."](https://github.com/coval-ai/benchmarks/commit/3d1243e38e373dbadbab95e3f7b87b6541c6dccf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43420443)</sub>

<!-- /greptile_comment -->