### PR TITLE
[BENCH-405] Human-parity zone on Latency vs Accuracy + pixel-identical mobile/desktop exports

### DIFF
--- a/web/components/charts/d3/BoxPlot.tsx
+++ b/web/components/charts/d3/BoxPlot.tsx
@@ -3,7 +3,7 @@
 
 "use client";
 
-import React, { useState, useEffect, useRef } from "react";
+import React, { useState, useEffect, useLayoutEffect, useRef } from "react";
 import * as d3 from "d3";
 import { BoxPlotProps } from "@/types/chart.types";
 import { BoxPlotDataPoint } from "@/types/benchmark.types";
@@ -91,7 +91,10 @@ const BoxPlot: React.FC<BoxPlotProps> = ({
       )
     : dimensions.width;
 
-  useEffect(() => {
+  // Layout effect so the d3 content redraws in the same frame the <svg>
+  // resizes — the PNG export clones the SVG as soon as its width settles, and
+  // a post-paint redraw would let it capture stale content in a resized box.
+  useLayoutEffect(() => {
     if (!svgRef.current || data.data.length === 0) return;
 
     setTip(null);

--- a/web/components/dashboard/LatencyAccuracySection.tsx
+++ b/web/components/dashboard/LatencyAccuracySection.tsx
@@ -10,6 +10,7 @@ import {
   XAxis,
   YAxis,
   CartesianGrid,
+  ReferenceArea,
   ReferenceLine,
   ResponsiveContainer,
   Tooltip,
@@ -28,6 +29,15 @@ import { useThemeColors } from "@/hooks/useThemeColors";
 import { useActiveTab } from "@/hooks/useActiveTab";
 import { useChartHoverTracking } from "@/hooks/useChartHoverTracking";
 import { useMobileDetection } from "@/hooks/useMobileDetection";
+
+// Human transcription accuracy is 2–4% WER under optimal conditions (per our
+// ASR benchmarks doc); the band's ceiling puts human-level-or-better inside
+// the zone. Y axis is whole percent.
+const HUMAN_WER_CEILING = 4;
+// Median human conversational turn-taking gap. X axis is ms.
+// TODO(bench-405): confirm the canonical figure with product before merge;
+// TTFT reuses the TTFS bound until a human TTFT reference is defined.
+const HUMAN_LATENCY_MS = 200;
 
 const LatencyAccuracySection: React.FC = () => {
   const { selectedModels, getScatterData, activeMetric: metric } = useDashboard();
@@ -165,7 +175,24 @@ const LatencyAccuracySection: React.FC = () => {
           }}
         />
 
-        <MetricToggle />
+        <div className="flex flex-wrap items-center">
+          <MetricToggle />
+          <ul data-chart-legend className="mb-4 ml-auto">
+            <li
+              className="flex items-center gap-1.5 font-mono text-xs"
+              style={{ color: themeColors.textSecondary }}
+            >
+              <span
+                className="inline-block h-3 w-3 rounded-[2px]"
+                style={{ backgroundColor: themeColors.zoneStroke }}
+                aria-hidden="true"
+              />
+              <MetricInfo metric="human-parity" align="right">
+                Human-parity zone
+              </MetricInfo>
+            </li>
+          </ul>
+        </div>
 
         <div
           className="relative h-64 select-none"
@@ -201,6 +228,17 @@ const LatencyAccuracySection: React.FC = () => {
               <CartesianGrid
                 stroke={themeColors.grid}
                 strokeDasharray="2 2"
+              />
+              <ReferenceArea
+                x1={0}
+                x2={HUMAN_LATENCY_MS}
+                y1={0}
+                y2={HUMAN_WER_CEILING}
+                fill={themeColors.zoneFill}
+                fillOpacity={1}
+                stroke={themeColors.zoneStroke}
+                strokeWidth={1}
+                ifOverflow="hidden"
               />
               <XAxis
                 dataKey="x"

--- a/web/components/shared/SectionHeader.tsx
+++ b/web/components/shared/SectionHeader.tsx
@@ -154,11 +154,15 @@ const SectionHeader: React.FC<SectionHeaderProps> = ({
       annotate: exportAnnotate,
       legend: Array.from(
         card.querySelectorAll(".recharts-legend-wrapper li, [data-chart-legend] li")
-      ).map((li) => ({
-        label: li.textContent?.trim() ?? "",
-        color: li.querySelector("span")?.style.backgroundColor ?? "#0f0c0a",
-        dimmed: li.hasAttribute("data-dimmed"),
-      })),
+      ).map((li) => {
+        const entry = li.cloneNode(true) as HTMLElement;
+        entry.querySelectorAll('[role="tooltip"]').forEach((el) => el.remove());
+        return {
+          label: entry.textContent?.trim() ?? "",
+          color: li.querySelector("span")?.style.backgroundColor ?? "#0f0c0a",
+          dimmed: li.hasAttribute("data-dimmed"),
+        };
+      }),
     }, themeColors);
     // downloadChartPNG measures and clones the SVG synchronously before its
     // first await, so the stage can be struck as soon as it returns — the

--- a/web/components/shared/SectionHeader.tsx
+++ b/web/components/shared/SectionHeader.tsx
@@ -7,6 +7,7 @@ import React, { useEffect, useState } from "react";
 import { Check, ImageDown, Link2, Table } from "lucide-react";
 import { downloadCSV, downloadChartPNG } from "@/lib/utils/chartExport";
 import { useThemeColors } from "@/hooks/useThemeColors";
+import { setExportStaged } from "@/hooks/useMobileDetection";
 import { capturePostHogEvent } from "@/lib/posthog/client";
 import { POSTHOG_EVENTS } from "@/lib/posthog/events";
 
@@ -120,15 +121,22 @@ const SectionHeader: React.FC<SectionHeaderProps> = ({
     )?.parentElement;
     const priorWidth = card.style.width;
     const priorHeight = wrapper?.style.height ?? "";
-    card.style.width = "880px";
+    card.style.width = "1000px";
     if (wrapper) wrapper.style.height = "420px";
+    setExportStaged(true);
+    // Mobile charts render slot-scrolled SVGs wider than the stage; settling
+    // also requires the SVG to fit it, so the capture waits out the desktop
+    // re-render instead of grabbing the still-mobile layout.
     const settled = () => {
       const el = findSvg();
       return (
-        !!el && el.clientWidth >= 640 && (!wrapper || el.clientHeight >= 416)
+        !!el &&
+        el.clientWidth >= 640 &&
+        el.clientWidth <= 1000 &&
+        (!wrapper || el.clientHeight >= 416)
       );
     };
-    for (let i = 0; i < 30 && !settled(); i++) {
+    for (let i = 0; i < 60 && !settled(); i++) {
       await new Promise(requestAnimationFrame);
     }
     svg = findSvg() ?? svg;
@@ -167,6 +175,7 @@ const SectionHeader: React.FC<SectionHeaderProps> = ({
     // downloadChartPNG measures and clones the SVG synchronously before its
     // first await, so the stage can be struck as soon as it returns — the
     // layout is never left widened if rasterizing stalls or rejects.
+    setExportStaged(false);
     card.style.width = priorWidth;
     if (wrapper) wrapper.style.height = priorHeight;
     const ok = await capture.catch(() => false);

--- a/web/components/shared/SectionHeader.tsx
+++ b/web/components/shared/SectionHeader.tsx
@@ -99,17 +99,39 @@ const SectionHeader: React.FC<SectionHeaderProps> = ({
   const downloadImage = async () => {
     const root = document.getElementById(anchorId);
     const card = root?.parentElement;
+    if (!card) return;
     // The chart is the largest SVG in the card; icon SVGs and a chart still
     // sizing to zero during layout are excluded so we never export those.
-    const svg =
-      card &&
+    const findSvg = () =>
       Array.from(card.querySelectorAll("svg"))
         .filter((el) => el.clientWidth > 100 && el.clientHeight > 100)
         .sort(
           (a, b) =>
             b.clientWidth * b.clientHeight - a.clientWidth * a.clientHeight
         )[0];
+    let svg = findSvg();
     if (!svg) return;
+    // Exports render on a fixed desktop-sized stage so every device produces
+    // the same image, taller than the on-screen chart so dense charts have
+    // room to place labels. The charts re-render on container resize, which
+    // can replace the SVG node, hence the re-query once the stage settles.
+    const wrapper = svg.closest<HTMLElement>(
+      ".recharts-responsive-container"
+    )?.parentElement;
+    const priorWidth = card.style.width;
+    const priorHeight = wrapper?.style.height ?? "";
+    card.style.width = "880px";
+    if (wrapper) wrapper.style.height = "420px";
+    const settled = () => {
+      const el = findSvg();
+      return (
+        !!el && el.clientWidth >= 640 && (!wrapper || el.clientHeight >= 416)
+      );
+    };
+    for (let i = 0; i < 30 && !settled(); i++) {
+      await new Promise(requestAnimationFrame);
+    }
+    svg = findSvg() ?? svg;
     // The stat label can be a ReactNode (MetricInfo), so its text comes from
     // the DOM — minus the hidden tooltip MetricInfo keeps mounted.
     const statLabel = root?.querySelector("[data-stat-label]")?.cloneNode(true);
@@ -138,6 +160,8 @@ const SectionHeader: React.FC<SectionHeaderProps> = ({
         dimmed: li.hasAttribute("data-dimmed"),
       })),
     }, themeColors).catch(() => false);
+    card.style.width = priorWidth;
+    if (wrapper) wrapper.style.height = priorHeight;
     if (ok) trackShare("png");
   };
 

--- a/web/components/shared/SectionHeader.tsx
+++ b/web/components/shared/SectionHeader.tsx
@@ -140,7 +140,7 @@ const SectionHeader: React.FC<SectionHeaderProps> = ({
         .querySelectorAll('[role="tooltip"]')
         .forEach((el) => el.remove());
     }
-    const ok = await downloadChartPNG(svg, `${anchorId}.png`, {
+    const capture = downloadChartPNG(svg, `${anchorId}.png`, {
       label,
       title: description.short,
       xLabel: exportXLabel,
@@ -159,9 +159,13 @@ const SectionHeader: React.FC<SectionHeaderProps> = ({
         color: li.querySelector("span")?.style.backgroundColor ?? "#0f0c0a",
         dimmed: li.hasAttribute("data-dimmed"),
       })),
-    }, themeColors).catch(() => false);
+    }, themeColors);
+    // downloadChartPNG measures and clones the SVG synchronously before its
+    // first await, so the stage can be struck as soon as it returns — the
+    // layout is never left widened if rasterizing stalls or rejects.
     card.style.width = priorWidth;
     if (wrapper) wrapper.style.height = priorHeight;
+    const ok = await capture.catch(() => false);
     if (ok) trackShare("png");
   };
 

--- a/web/hooks/useMobileDetection.ts
+++ b/web/hooks/useMobileDetection.ts
@@ -5,17 +5,33 @@
 
 import { useState, useEffect } from "react";
 
+// PNG exports stage the card at desktop width, but charts gate their mobile
+// layouts (scroll slots, tick fonts, touch targets) on the viewport, not the
+// card. Exports flip this flag so every chart renders its desktop layout and
+// a phone export is pixel-identical to a desktop one.
+const EXPORT_STAGE_EVENT = "chart-export-stage";
+let exportStaged = false;
+
+export const setExportStaged = (staged: boolean) => {
+  exportStaged = staged;
+  window.dispatchEvent(new Event(EXPORT_STAGE_EVENT));
+};
+
 export const useMobileDetection = () => {
   const [isMobile, setIsMobile] = useState(false);
 
   useEffect(() => {
     const checkMobile = () => {
-      setIsMobile(window.innerWidth < 768);
+      setIsMobile(window.innerWidth < 768 && !exportStaged);
     };
 
     checkMobile();
     window.addEventListener("resize", checkMobile);
-    return () => window.removeEventListener("resize", checkMobile);
+    window.addEventListener(EXPORT_STAGE_EVENT, checkMobile);
+    return () => {
+      window.removeEventListener("resize", checkMobile);
+      window.removeEventListener(EXPORT_STAGE_EVENT, checkMobile);
+    };
   }, []);
 
   return isMobile;

--- a/web/hooks/useThemeColors.ts
+++ b/web/hooks/useThemeColors.ts
@@ -17,6 +17,8 @@ export interface ThemeColors {
   tooltipSecondary: string;
   textPrimary: string;
   textSecondary: string;
+  zoneFill: string;
+  zoneStroke: string;
 }
 
 // Charts read these via JS (recharts/d3 fills), not CSS, so they must mirror the
@@ -34,6 +36,8 @@ export const LIGHT_CHART_COLORS: ThemeColors = {
   tooltipSecondary: "#515151",
   textPrimary: "#0f0c0a",
   textSecondary: "#515151",
+  zoneFill: "rgba(198, 220, 250, 0.45)",
+  zoneStroke: "rgba(26, 44, 54, 0.2)",
 };
 
 export const DARK_CHART_COLORS: ThemeColors = {
@@ -48,6 +52,8 @@ export const DARK_CHART_COLORS: ThemeColors = {
   tooltipSecondary: "#c7c2bc",
   textPrimary: "#f9faf8",
   textSecondary: "#c7c2bc",
+  zoneFill: "rgba(150, 190, 250, 0.18)",
+  zoneStroke: "rgba(198, 220, 250, 0.45)",
 };
 
 export function useThemeColors(): ThemeColors {

--- a/web/lib/config/metrics.ts
+++ b/web/lib/config/metrics.ts
@@ -26,6 +26,13 @@ export const metricDescriptions = {
     detailed:
       "Ensuring accurate speech output is fundamental to user trust and comprehension in voice AI systems. We recognize that even minor pronunciation errors can undermine the entire conversation experience and our evaluation captures how faithfully text-to-speech systems pronounce complex terminology, proper nouns, and domain-specific vocabulary that matter most to your users. Click a bar to highlight it for comparison."
   },
+  "human-parity": {
+    short: "Human-parity zone",
+    tooltip:
+      "Models in this region match or beat a human on both axes: professional human transcribers achieve 2–4% WER under optimal conditions, and ~200ms is the median gap before a person replies in conversation. Anything inside the zone is at or beyond human performance.",
+    detailed:
+      "The human-parity zone reframes the latency-accuracy trade-off around a human baseline instead of arbitrary thresholds. Human transcription accuracy is typically 2–4% WER under optimal conditions, and the median turn-taking gap in human conversation is roughly 200ms. A model inside the zone transcribes at least as accurately as a person and responds at least as fast as one."
+  },
   v2v: {
     short: "Voice-to-Voice Latency",
     detailed:

--- a/web/lib/utils/chartExport.ts
+++ b/web/lib/utils/chartExport.ts
@@ -180,6 +180,14 @@ export function labelScatterDots(
     boxes.some(
       (b) => box.x1 < b.x2 && box.x2 > b.x1 && box.y1 < b.y2 && box.y2 > b.y1
     );
+  // Stacked dots hide each other completely on screen; a rim in the canvas
+  // color splits them into visible crescents so every label has a referent.
+  circles.forEach((circle) => {
+    if (!circle.getAttribute("stroke")) {
+      circle.setAttribute("stroke", colors.tooltipBg);
+      circle.setAttribute("stroke-width", "1.5");
+    }
+  });
   circles.forEach((circle, index) => {
     const point = sorted[index];
     if (!point) return;
@@ -200,23 +208,21 @@ export function labelScatterDots(
       [cx - 10, cy - 7, "end"],
       [cx - 10, cy + 15, "end"],
     ];
-    let placement = candidates.find(([x, y, a]) => !blocked(box(x, y, a)));
-    if (!placement) {
-      for (let step = 2; step < 10 && !placement; step++) {
-        const y = cy + 5 + step * 13;
-        if (!blocked(box(cx, y, "middle"))) placement = [cx, y, "middle"];
-      }
-      if (placement) {
-        const leader = document.createElementNS(SVG_NS, "line");
-        leader.setAttribute("x1", `${cx}`);
-        leader.setAttribute("y1", `${cy + 7}`);
-        leader.setAttribute("x2", `${cx}`);
-        leader.setAttribute("y2", `${placement[1] - 9}`);
-        leader.setAttribute("stroke", colors.barStroke);
-        leader.setAttribute("stroke-width", "1");
-        clone.appendChild(leader);
+    // In dense clusters, spiral outward in small rings so a squeezed-out label
+    // still sits near its dot (its color keeps it attributable) rather than at
+    // the end of a hard-to-follow leader line.
+    for (let r = 22; r <= 58; r += 12) {
+      for (let deg = 0; deg < 360; deg += 30) {
+        const dx = Math.cos((deg * Math.PI) / 180);
+        const dy = Math.sin((deg * Math.PI) / 180);
+        candidates.push([
+          cx + r * dx,
+          cy + r * dy + 4,
+          Math.abs(dx) < 0.4 ? "middle" : dx > 0 ? "start" : "end",
+        ]);
       }
     }
+    const placement = candidates.find(([x, y, a]) => !blocked(box(x, y, a)));
     // Last-resort fallback: no collision-free slot exists, so accept overlap
     // but keep the label horizontally in-bounds (never clipped at the edge).
     // Prefer the side with room; else clamp a centered label into the canvas.
@@ -229,7 +235,25 @@ export function labelScatterDots(
       fallback = [2, cy + 4, "start"];
     else fallback = [Math.min(Math.max(cx, 2 + w / 2), width - 2 - w / 2), cy + 4, "middle"];
     const [x, y, anchor] = placement ?? fallback;
-    boxes.push(box(x, y, anchor));
+    const placed = box(x, y, anchor);
+    boxes.push(placed);
+    // A label pushed off its dot gets a short connector in the dot's own
+    // color — grey lines are untrackable and were rejected in review.
+    const tx = Math.min(Math.max(cx, placed.x1), placed.x2);
+    const ty = Math.min(Math.max(cy, placed.y1), placed.y2);
+    const dist = Math.hypot(tx - cx, ty - cy);
+    if (dist > 16) {
+      const [ux, uy] = [(tx - cx) / dist, (ty - cy) / dist];
+      const tick = document.createElementNS(SVG_NS, "line");
+      tick.setAttribute("x1", `${cx + ux * 8}`);
+      tick.setAttribute("y1", `${cy + uy * 8}`);
+      tick.setAttribute("x2", `${tx - ux * 2}`);
+      tick.setAttribute("y2", `${ty - uy * 2}`);
+      tick.setAttribute("stroke", labelColor(point.color, dark));
+      tick.setAttribute("stroke-width", "1.5");
+      tick.setAttribute("stroke-linecap", "round");
+      clone.appendChild(tick);
+    }
     const text = document.createElementNS(SVG_NS, "text");
     text.setAttribute("x", `${x}`);
     text.setAttribute("y", `${y}`);
@@ -408,16 +432,29 @@ export async function downloadChartPNG(
   }
   ctx.globalAlpha = 0.45;
   // The logo art is ink; the brand rule allows ink or white only, so flip it to
-  // white on the dark canvas to keep the watermark readable.
-  if (dark) ctx.filter = "brightness(0) invert(1)";
+  // white on the dark canvas to keep the watermark readable. Tinted with a
+  // composite pass rather than ctx.filter, which Safari doesn't implement.
+  let mark: HTMLImageElement | HTMLCanvasElement = logo;
+  if (dark) {
+    const tint = document.createElement("canvas");
+    tint.width = logoWidth * 2;
+    tint.height = Math.ceil(logoHeight * 2);
+    const tctx = tint.getContext("2d");
+    if (tctx) {
+      tctx.drawImage(logo, 0, 0, tint.width, tint.height);
+      tctx.globalCompositeOperation = "source-in";
+      tctx.fillStyle = "#ffffff";
+      tctx.fillRect(0, 0, tint.width, tint.height);
+      mark = tint;
+    }
+  }
   ctx.drawImage(
-    logo,
+    mark,
     totalWidth - MARGIN - logoWidth,
     totalHeight - logoHeight - 8,
     logoWidth,
     logoHeight
   );
-  ctx.filter = "none";
   canvas.toBlob((blob) => {
     if (blob) triggerDownload(URL.createObjectURL(blob), filename);
   });

--- a/web/lib/utils/formatters.ts
+++ b/web/lib/utils/formatters.ts
@@ -154,6 +154,7 @@ export function normalizeModelName(modelKey: string): string {
     .replace(/\b\w+/g, (word) => {
       // Capitalize first letter of each word, except version numbers
       if (/^v\d+/.test(word)) return word;
+      if (/^(tts|stt|s2s|hd|asr|api)$/i.test(word)) return word.toUpperCase();
       return word.charAt(0).toUpperCase() + word.slice(1).toLowerCase();
     });
 }


### PR DESCRIPTION
## What

**Stacked on #275** — merge that first; this diff is the two commits on top.

### Human-parity zone (BENCH-405)
Shades the region of the Latency vs Accuracy scatter where a model matches or beats a human on both axes, so the chart reads against a human baseline instead of arbitrary cutoffs (à la Artificial Analysis's "most attractive quadrant"):

- **Y bound**: WER ≤ 4% — the ceiling of the 2–4% human transcription band under optimal conditions
- **X bound**: latency ≤ 200ms — median human conversational turn-taking gap
- Recharts `ReferenceArea` anchored at the origin: tracks axis domains, resizes, renders behind points, clips when the TTFT domain shrinks it
- Brand-blue theme tokens (green is reserved away from product surfaces per the brand guide); Geist Mono legend chip
- Legend chip reuses `MetricInfo` with a new `human-parity` entry explaining the human basis on hover; rendered as a `data-chart-legend` item so PNG exports label the zone
- Export legend labels strip `role=tooltip` text (same treatment stat labels already had)

### Pixel-identical exports (BENCH-403 follow-up)
Phone exports of the box plot still rendered the mobile layout (slot-scrolled SVG) and could capture mid-resize, squeezing the chart into the left of the canvas:

- `useMobileDetection` exposes an export-staged flag; exports flip it so every chart renders its desktop layout while the stage is up
- Settling requires the SVG to *fit* the stage, so wide mobile SVGs are never captured before the desktop re-render lands; stage widened 880 → 1000px for readable box-plot label spacing
- BoxPlot draws d3 content in a `useLayoutEffect` so the SVG never paints resized-but-stale

## Verification

- Mobile (375px) and desktop exports are **byte-identical**: TTFA box plot 191,957 B (×4 runs), scatter w/ zone 205,295 B
- Zoomed Performance Consistency exports keep their crop
- TTFS/TTFT toggle, light/dark themes, mobile scrub all verified in browser
- `tsc --noEmit` and ESLint clean

## Open before merge

- [ ] Canonical source for the 200ms human-latency figure (Cale/Madina) — flagged in `TODO(bench-405)`
- [ ] Whether TTFT should keep reusing the TTFS bound
- [ ] Zone also renders on the TTS tab (shared component) — gate to STT if human-parity framing shouldn't apply there (one-line change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates chart exports and adds a human-parity region to the latency/accuracy chart. The main changes are:

- Adds a shaded human-parity area and legend entry to the scatter chart.
- Adds theme colors and metric copy for the new chart region.
- Forces mobile PNG exports through a desktop chart layout while staging.
- Redraws the D3 box plot in a layout effect for export timing.

<h3>Confidence Score: 4/5</h3>

The export staging path needs fixes before merging. The shared mobile-export flag can race and can remain enabled after a synchronous export failure.

- Overlapping exports can clear the staged state while another export is still running.
- A synchronous throw during PNG cloning or annotation skips the restore path.
- The human-parity region can appear on the TTS chart with transcription-specific copy.

web/components/shared/SectionHeader.tsx, web/hooks/useMobileDetection.ts, web/components/dashboard/LatencyAccuracySection.tsx

<sub>Reviews (1): Last reviewed commit: ["\[BENCH-403\] Make phone and desktop PNG e..."](https://github.com/coval-ai/benchmarks/commit/ccc652c557a797a9cb78ee29de4093c1c710a9f1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43430129)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->