### PR TITLE
[BENCH-411] Log client 4xx at info and serve robots.txt on the API

### DIFF
--- a/runner/src/coval_bench/api/app.py
+++ b/runner/src/coval_bench/api/app.py
@@ -37,6 +37,7 @@ from coval_bench.api.routers import (
     leaderboard,
     providers,
     results,
+    robots,
     runs,
 )
 from coval_bench.config import Settings, get_settings
@@ -120,6 +121,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
 
     # Routers
     app.include_router(health.router)
+    app.include_router(robots.router)
     app.include_router(runs.router, prefix="/v1")
     app.include_router(results.router, prefix="/v1")
     app.include_router(aggregates.router, prefix="/v1")

--- a/runner/src/coval_bench/api/request_logging.py
+++ b/runner/src/coval_bench/api/request_logging.py
@@ -79,7 +79,7 @@ class RequestLoggingMiddleware:
                 emit = (
                     logger.error
                     if status >= 500
-                    else logger.warning
+                    else logger.info
                     if status >= 400
                     else logger.debug
                 )

--- a/runner/src/coval_bench/api/routers/robots.py
+++ b/runner/src/coval_bench/api/routers/robots.py
@@ -1,0 +1,23 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""``GET /robots.txt`` — disallow-all robots exclusion file.
+
+The API is served from a raw Cloud Run host that must stay out of search
+indexes; the public site's robots.txt lives in the web frontend.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter
+from fastapi.responses import PlainTextResponse
+
+router = APIRouter(tags=["robots"])
+
+_ROBOTS_TXT = "User-agent: *\nDisallow: /\n"
+
+
+@router.get("/robots.txt", include_in_schema=False)
+async def robots_txt() -> PlainTextResponse:
+    """Disallow all crawlers."""
+    return PlainTextResponse(_ROBOTS_TXT)

--- a/runner/tests/api/test_request_logging.py
+++ b/runner/tests/api/test_request_logging.py
@@ -1,0 +1,94 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the request-logging middleware's level policy."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+import pytest
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+from httpx import ASGITransport, AsyncClient
+
+from coval_bench.api import request_logging
+from coval_bench.api.request_logging import RequestLoggingMiddleware
+
+
+class _RecordingLogger:
+    """Records (level, event, kwargs) for every log call."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str, dict[str, Any]]] = []
+
+    def __getattr__(self, level: str) -> Callable[..., None]:
+        def _log(event: str, **kwargs: Any) -> None:
+            self.calls.append((level, event, kwargs))
+
+        return _log
+
+    def http_requests(self) -> list[tuple[str, int]]:
+        """Return (level, status) for each http_request line logged."""
+        return [
+            (level, kwargs["status"])
+            for level, event, kwargs in self.calls
+            if event == "http_request"
+        ]
+
+
+@pytest.fixture
+def recorder(monkeypatch: pytest.MonkeyPatch) -> _RecordingLogger:
+    rec = _RecordingLogger()
+    monkeypatch.setattr(request_logging, "logger", rec)
+    return rec
+
+
+def _make_app() -> FastAPI:
+    app = FastAPI()
+
+    @app.get("/ok")
+    async def ok() -> dict[str, str]:
+        return {"status": "ok"}
+
+    @app.get("/fail")
+    async def fail() -> JSONResponse:
+        return JSONResponse({"detail": "boom"}, status_code=500)
+
+    @app.get("/healthz")
+    async def healthz() -> dict[str, str]:
+        return {"status": "ok"}
+
+    app.add_middleware(RequestLoggingMiddleware)
+    return app
+
+
+async def _get(path: str) -> None:
+    transport = ASGITransport(app=_make_app())
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        await client.get(path)
+
+
+async def test_success_logs_debug(recorder: _RecordingLogger) -> None:
+    """2xx responses log at debug."""
+    await _get("/ok")
+    assert recorder.http_requests() == [("debug", 200)]
+
+
+async def test_client_error_logs_info(recorder: _RecordingLogger) -> None:
+    """4xx responses are expected client traffic and log at info, not warning."""
+    await _get("/missing")
+    assert recorder.http_requests() == [("info", 404)]
+
+
+async def test_server_error_logs_error(recorder: _RecordingLogger) -> None:
+    """5xx responses log at error."""
+    await _get("/fail")
+    assert recorder.http_requests() == [("error", 500)]
+
+
+async def test_quiet_path_success_not_logged(recorder: _RecordingLogger) -> None:
+    """Successful health probes are not logged at all."""
+    await _get("/healthz")
+    assert recorder.http_requests() == []

--- a/runner/tests/api/test_robots.py
+++ b/runner/tests/api/test_robots.py
@@ -15,3 +15,6 @@ async def test_robots_txt_disallows_all(client: AsyncClient) -> None:
     assert response.headers["content-type"].startswith("text/plain")
     assert "User-agent: *" in response.text
     assert "Disallow: /" in response.text
+
+    openapi = await client.get("/openapi.json")
+    assert "/robots.txt" not in openapi.json()["paths"]

--- a/runner/tests/api/test_robots.py
+++ b/runner/tests/api/test_robots.py
@@ -1,0 +1,17 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the robots.txt endpoint."""
+
+from __future__ import annotations
+
+from httpx import AsyncClient
+
+
+async def test_robots_txt_disallows_all(client: AsyncClient) -> None:
+    """GET /robots.txt returns a disallow-all exclusion file."""
+    response = await client.get("/robots.txt")
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/plain")
+    assert "User-agent: *" in response.text
+    assert "Disallow: /" in response.text


### PR DESCRIPTION
API warnings now mean something on our side needs fixing: expected client 4xx traffic logs at info, and the raw Cloud Run host serves a disallow-all robots.txt.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adjusts API request logging and adds a robots exclusion endpoint.

- Logs handled client error responses at info.
- Adds a root-level `/robots.txt` response that disallows all crawlers.
- Registers the robots router in the FastAPI app.
- Adds tests for request log levels and the robots endpoint.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<sub>Reviews (2): Last reviewed commit: ["\[BENCH-411\] Assert robots.txt stays out ..."](https://github.com/coval-ai/benchmarks/commit/d02cecd3bf1832c1fbed1ea6f35b8f6be643bafc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43950735)</sub>

<!-- /greptile_comment -->