### PR TITLE
[BENCH-332] Add MiniMax Speech 2.8 TTS

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,6 +36,7 @@ REVAI_API_KEY=
 FISHAUDIO_API_KEY=
 ALIBABA_API_KEY=
 TOGETHER_API_KEY=
+MINIMAX_API_KEY=
 
 # --- Google STT/TTS (optional; requires the `google-stt` / `google-tts` extras) ---
 # GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json

--- a/runner/src/coval_bench/config.py
+++ b/runner/src/coval_bench/config.py
@@ -83,6 +83,7 @@ class Settings(BaseSettings):
     fishaudio_api_key: SecretStr | None = None
     azure_api_key: SecretStr | None = None
     alibaba_api_key: SecretStr | None = None
+    minimax_api_key: SecretStr | None = None
 
     # Azure region hosting the Speech resource (e.g. "eastus"). Determines the
     # region-scoped WebSocket host; required only when the Azure STT provider runs.

--- a/runner/src/coval_bench/providers/tts/__init__.py
+++ b/runner/src/coval_bench/providers/tts/__init__.py
@@ -25,6 +25,7 @@ from coval_bench.providers.tts.fishaudio import FishAudioTTSProvider
 from coval_bench.providers.tts.gradium import GradiumTTSProvider
 from coval_bench.providers.tts.groq import GroqTTSProvider
 from coval_bench.providers.tts.inworld import InworldTTSProvider
+from coval_bench.providers.tts.minimax import MinimaxTTSProvider
 from coval_bench.providers.tts.openai import OpenAITTSProvider
 from coval_bench.providers.tts.rime import RimeTTSProvider
 from coval_bench.providers.tts.smallest import SmallestTTSProvider
@@ -61,6 +62,7 @@ TTS_PROVIDERS: dict[str, type[TTSProvider]] = {
     "azure": AzureTTSProvider,
     "fishaudio": FishAudioTTSProvider,
     "alibaba": AlibabaTTSProvider,
+    "minimax": MinimaxTTSProvider,
 }
 
 if HumeTTSProvider is not None:
@@ -78,6 +80,7 @@ __all__ = [
     "BasetenTTSProvider",
     "FishAudioTTSProvider",
     "GradiumTTSProvider",
+    "MinimaxTTSProvider",
     "SmallestTTSProvider",
     "XaiTTSProvider",
     "GroqTTSProvider",

--- a/runner/src/coval_bench/providers/tts/minimax.py
+++ b/runner/src/coval_bench/providers/tts/minimax.py
@@ -1,0 +1,134 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""MiniMax TTS provider (Speech 2.8 line over WebSocket).
+
+Wire protocol on wss://api.minimax.io/ws/v1/t2a_v2, Bearer auth:
+  connect → recv connected_success → send task_start (model + voice/audio)
+  → recv task_started → send task_continue(text) + task_finish
+  → recv task_continued frames (hex-encoded PCM) until is_final → close
+
+The TTFA clock starts at task_continue, after the task_started ack, so the
+session-setup round trip is excluded (parity with providers that configure the
+model on the WS handshake itself).
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from typing import Any
+
+import structlog
+import websockets.asyncio.client as ws_client
+
+from coval_bench.config import Settings
+from coval_bench.providers.base import TTSProvider, TTSResult
+from coval_bench.providers.tts._common import finalize_tts_result
+
+logger: structlog.BoundLogger = structlog.get_logger(__name__)
+
+_VALID_MODELS = ("speech-2.8-hd", "speech-2.8-turbo")
+_WS_URL = "wss://api.minimax.io/ws/v1/t2a_v2"
+_SAMPLE_RATE = 44100
+_MAX_WS_SIZE = 16 * 1024 * 1024
+
+
+class MinimaxTTSProvider(TTSProvider):
+    """MiniMax TTS provider using WebSocket streaming."""
+
+    def __init__(self, settings: Settings, model: str, voice: str) -> None:
+        if model not in _VALID_MODELS:
+            raise ValueError(f"Invalid MiniMax TTS model {model!r}. Valid: {_VALID_MODELS}")
+        if not voice:
+            raise ValueError("MiniMax TTS requires a voice (voice_id)")
+        self._model = model
+        self._voice = voice
+
+        api_key_secret = settings.minimax_api_key
+        if api_key_secret is None or not api_key_secret.get_secret_value().strip():
+            raise ValueError("minimax_api_key is required in Settings")
+        self._api_key = api_key_secret.get_secret_value()
+
+    @property
+    def name(self) -> str:
+        return f"minimax-{self._model}"
+
+    @property
+    def model(self) -> str:
+        return self._model
+
+    async def synthesize(self, text: str) -> TTSResult:
+        audio_chunks: list[bytes] = []
+        start: float | None = None
+        first_chunk_at: float | None = None
+        headers = {"Authorization": f"Bearer {self._api_key}"}
+
+        try:
+            async with ws_client.connect(
+                _WS_URL,
+                additional_headers=headers,
+                max_size=_MAX_WS_SIZE,
+            ) as ws:
+                async for message in ws:
+                    if isinstance(message, (bytes, bytearray)):
+                        continue
+                    data: dict[str, Any] = json.loads(message)
+                    event = data.get("event")
+                    base = data.get("base_resp") or {}
+                    if event == "task_failed" or base.get("status_code", 0) != 0:
+                        raise RuntimeError(
+                            f"{event}: [{base.get('status_code')}] {base.get('status_msg', '')}"
+                        )
+                    if event == "connected_success":
+                        await ws.send(
+                            json.dumps(
+                                {
+                                    "event": "task_start",
+                                    "model": self._model,
+                                    "voice_setting": {"voice_id": self._voice},
+                                    "audio_setting": {
+                                        "format": "pcm",
+                                        "sample_rate": _SAMPLE_RATE,
+                                        "channel": 1,
+                                    },
+                                }
+                            )
+                        )
+                    elif event == "task_started":
+                        start = time.monotonic()
+                        await ws.send(json.dumps({"event": "task_continue", "text": text}))
+                        await ws.send(json.dumps({"event": "task_finish"}))
+                    elif event == "task_continued":
+                        chunk = (data.get("data") or {}).get("audio")
+                        if chunk:
+                            if first_chunk_at is None:
+                                first_chunk_at = time.monotonic()
+                            audio_chunks.append(bytes.fromhex(chunk))
+                        if data.get("is_final"):
+                            break
+                    elif event == "task_finished":
+                        break
+
+        except Exception as exc:
+            logger.warning("minimax_tts_error", provider="minimax", model=self._model, exc_info=exc)
+            return finalize_tts_result(
+                provider="minimax",
+                model=self._model,
+                voice=self._voice,
+                pcm=b"",
+                sample_rate=_SAMPLE_RATE,
+                audio_synthesis_start=start,
+                first_audio_chunk_at=first_chunk_at,
+                error=str(exc),
+            )
+
+        return finalize_tts_result(
+            provider="minimax",
+            model=self._model,
+            voice=self._voice,
+            pcm=b"".join(audio_chunks),
+            sample_rate=_SAMPLE_RATE,
+            audio_synthesis_start=start,
+            first_audio_chunk_at=first_chunk_at,
+        )

--- a/runner/src/coval_bench/registries/models.py
+++ b/runner/src/coval_bench/registries/models.py
@@ -627,6 +627,25 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         tags=(_REALTIME, _MULTI, _CLONE, _EMOTION, _STREAM),
         status=_ACTIVE,
     ),
+    # MiniMax. Voice is the English narrator MiniMax's own docs use in examples.
+    RegisteredModel(
+        benchmark=_TTS,
+        provider="minimax",
+        model="speech-2.8-hd",
+        voice="English_expressive_narrator",
+        tags=(_REALTIME, _MULTI, _CLONE, _EMOTION, _STREAM),
+        status=_ACTIVE,
+        arena_enabled=False,
+    ),
+    RegisteredModel(
+        benchmark=_TTS,
+        provider="minimax",
+        model="speech-2.8-turbo",
+        voice="English_expressive_narrator",
+        tags=(_REALTIME, _MULTI, _CLONE, _EMOTION, _STREAM),
+        status=_ACTIVE,
+        arena_enabled=False,
+    ),
     # gpt-realtime is a speech-to-speech LLM, not a TTS provider: driving it
     # from a text "instructions" prompt folds LLM inference into TTFA and never
     # guarantees verbatim speech, so its metrics are incomparable here. Kept

--- a/runner/src/coval_bench/registries/provider_keys.py
+++ b/runner/src/coval_bench/registries/provider_keys.py
@@ -34,4 +34,5 @@ PROVIDER_ENV: dict[str, str] = {
     "baseten": "BASETEN_API_KEY",
     "fishaudio": "FISHAUDIO_API_KEY",
     "alibaba": "ALIBABA_API_KEY",
+    "minimax": "MINIMAX_API_KEY",
 }

--- a/runner/tests/providers/tts/test_minimax.py
+++ b/runner/tests/providers/tts/test_minimax.py
@@ -1,0 +1,264 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the MiniMax WebSocket TTS provider."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import pytest
+from pydantic import SecretStr
+
+from coval_bench.config import Settings
+from coval_bench.providers.tts.minimax import MinimaxTTSProvider
+
+from .conftest import FakeWebSocket, make_pcm_bytes
+
+_VOICE = "English_expressive_narrator"
+
+
+def _settings(**overrides: object) -> Settings:
+    base: dict[str, object] = {
+        "database_url": "postgresql://runner:password@localhost:5432/benchmarks",
+        "dataset_bucket": "test-bucket",
+        "dataset_id": "stt-v1",
+        "runner_sha": "test",
+        "log_level": "DEBUG",
+        "minimax_api_key": SecretStr("test-minimax-key"),
+    }
+    base.update(overrides)
+    return Settings(**base)  # type: ignore[arg-type]
+
+
+def _ok(event: str, **extra: object) -> str:
+    return json.dumps({"event": event, "base_resp": {"status_code": 0}, **extra})
+
+
+def _session_events(pcm_chunks: list[bytes]) -> list[bytes | str]:
+    events: list[bytes | str] = [_ok("connected_success"), _ok("task_started")]
+    events.extend(_ok("task_continued", data={"audio": chunk.hex()}) for chunk in pcm_chunks)
+    events.append(_ok("task_finished"))
+    return events
+
+
+@pytest.fixture()
+def minimax_settings() -> Settings:
+    return _settings()
+
+
+@pytest.mark.asyncio
+async def test_minimax_tts_happy_path(minimax_settings: Settings) -> None:
+    ws = FakeWebSocket(_session_events([make_pcm_bytes(240)]))
+    provider = MinimaxTTSProvider(minimax_settings, model="speech-2.8-hd", voice=_VOICE)
+
+    with patch("coval_bench.providers.tts.minimax.ws_client.connect", return_value=ws):
+        result = await provider.synthesize("Hello from MiniMax")
+
+    assert result.error is None, f"Unexpected error: {result.error}"
+    assert result.ttfa_ms is not None
+    assert 0 < result.ttfa_ms < 60_000
+    assert result.audio_path is not None
+    assert result.audio_path.exists()
+    assert result.audio_path.read_bytes()[:4] == b"RIFF"
+    assert result.provider == "minimax"
+    assert result.model == "speech-2.8-hd"
+    assert result.voice == _VOICE
+    result.audio_path.unlink()
+
+
+@pytest.mark.asyncio
+async def test_minimax_tts_url_and_headers(minimax_settings: Settings) -> None:
+    ws = FakeWebSocket(_session_events([make_pcm_bytes(240)]))
+    captured: dict[str, object] = {}
+
+    def connect_side_effect(url: str, **kwargs: object) -> FakeWebSocket:
+        captured["url"] = url
+        captured["kwargs"] = kwargs
+        return ws
+
+    provider = MinimaxTTSProvider(minimax_settings, model="speech-2.8-turbo", voice=_VOICE)
+
+    with patch(
+        "coval_bench.providers.tts.minimax.ws_client.connect",
+        side_effect=connect_side_effect,
+    ):
+        result = await provider.synthesize("Hello")
+
+    assert result.error is None
+    assert captured["url"] == "wss://api.minimax.io/ws/v1/t2a_v2"
+    headers = captured["kwargs"]["additional_headers"]  # type: ignore[index]
+    assert headers["Authorization"] == "Bearer test-minimax-key"
+    if result.audio_path is not None:
+        result.audio_path.unlink()
+
+
+@pytest.mark.asyncio
+async def test_minimax_tts_sends_start_continue_finish(minimax_settings: Settings) -> None:
+    ws = FakeWebSocket(_session_events([make_pcm_bytes(240)]))
+    provider = MinimaxTTSProvider(minimax_settings, model="speech-2.8-hd", voice=_VOICE)
+
+    with patch("coval_bench.providers.tts.minimax.ws_client.connect", return_value=ws):
+        result = await provider.synthesize("Hello world")
+
+    sent = [json.loads(m) for m in ws.sent if isinstance(m, str)]
+    assert sent[0]["event"] == "task_start"
+    assert sent[0]["model"] == "speech-2.8-hd"
+    assert sent[0]["voice_setting"] == {"voice_id": _VOICE}
+    assert sent[0]["audio_setting"] == {"format": "pcm", "sample_rate": 44100, "channel": 1}
+    assert sent[1] == {"event": "task_continue", "text": "Hello world"}
+    assert sent[2] == {"event": "task_finish"}
+    if result.audio_path is not None:
+        result.audio_path.unlink()
+
+
+@pytest.mark.asyncio
+async def test_minimax_tts_task_failed(minimax_settings: Settings) -> None:
+    events: list[bytes | str] = [
+        _ok("connected_success"),
+        json.dumps(
+            {
+                "event": "task_failed",
+                "base_resp": {"status_code": 1004, "status_msg": "authentication failed"},
+            }
+        ),
+    ]
+    ws = FakeWebSocket(events)
+    provider = MinimaxTTSProvider(minimax_settings, model="speech-2.8-hd", voice=_VOICE)
+
+    with patch("coval_bench.providers.tts.minimax.ws_client.connect", return_value=ws):
+        result = await provider.synthesize("Hello")
+
+    assert result.error is not None
+    assert "1004" in result.error
+    assert result.audio_path is None
+    assert result.ttfa_ms is None
+
+
+@pytest.mark.asyncio
+async def test_minimax_tts_nonzero_status_code(minimax_settings: Settings) -> None:
+    events: list[bytes | str] = [
+        _ok("connected_success"),
+        _ok("task_started"),
+        json.dumps(
+            {
+                "event": "task_continued",
+                "base_resp": {"status_code": 1002, "status_msg": "rate limit"},
+            }
+        ),
+    ]
+    ws = FakeWebSocket(events)
+    provider = MinimaxTTSProvider(minimax_settings, model="speech-2.8-hd", voice=_VOICE)
+
+    with patch("coval_bench.providers.tts.minimax.ws_client.connect", return_value=ws):
+        result = await provider.synthesize("Hello")
+
+    assert result.error is not None
+    assert "1002" in result.error
+    assert result.audio_path is None
+
+
+@pytest.mark.asyncio
+async def test_minimax_tts_skips_empty_audio_payloads(minimax_settings: Settings) -> None:
+    events: list[bytes | str] = [
+        _ok("connected_success"),
+        _ok("task_started"),
+        _ok("task_continued"),
+        _ok("task_continued", data={}),
+        _ok("task_continued", data={"audio": ""}),
+        _ok("task_continued", data={"audio": make_pcm_bytes(240).hex()}),
+        _ok("task_finished"),
+    ]
+    ws = FakeWebSocket(events)
+    provider = MinimaxTTSProvider(minimax_settings, model="speech-2.8-hd", voice=_VOICE)
+
+    with patch("coval_bench.providers.tts.minimax.ws_client.connect", return_value=ws):
+        result = await provider.synthesize("Hello")
+
+    assert result.error is None
+    assert result.ttfa_ms is not None
+    assert result.audio_path is not None
+    result.audio_path.unlink()
+
+
+@pytest.mark.asyncio
+async def test_minimax_tts_skips_binary_frames(minimax_settings: Settings) -> None:
+    events: list[bytes | str] = [
+        _ok("connected_success"),
+        _ok("task_started"),
+        b"\x00\x01\x02",
+        _ok("task_continued", data={"audio": make_pcm_bytes(240).hex()}),
+        _ok("task_finished"),
+    ]
+    ws = FakeWebSocket(events)
+    provider = MinimaxTTSProvider(minimax_settings, model="speech-2.8-hd", voice=_VOICE)
+
+    with patch("coval_bench.providers.tts.minimax.ws_client.connect", return_value=ws):
+        result = await provider.synthesize("Hello")
+
+    assert result.error is None
+    assert result.audio_path is not None
+    result.audio_path.unlink()
+
+
+@pytest.mark.asyncio
+async def test_minimax_tts_stops_on_is_final(minimax_settings: Settings) -> None:
+    events: list[bytes | str] = [
+        _ok("connected_success"),
+        _ok("task_started"),
+        _ok("task_continued", data={"audio": make_pcm_bytes(240).hex()}, is_final=True),
+    ]
+    ws = FakeWebSocket(events)
+    provider = MinimaxTTSProvider(minimax_settings, model="speech-2.8-hd", voice=_VOICE)
+
+    with patch("coval_bench.providers.tts.minimax.ws_client.connect", return_value=ws):
+        result = await provider.synthesize("Hello")
+
+    assert result.error is None
+    assert result.audio_path is not None
+    result.audio_path.unlink()
+
+
+@pytest.mark.asyncio
+async def test_minimax_tts_ttfa_on_first_chunk(minimax_settings: Settings) -> None:
+    chunks = [make_pcm_bytes(240), make_pcm_bytes(240), make_pcm_bytes(240)]
+    ws = FakeWebSocket(_session_events(chunks))
+    provider = MinimaxTTSProvider(minimax_settings, model="speech-2.8-hd", voice=_VOICE)
+
+    times = iter([0.0, 0.1])
+
+    with (
+        patch(
+            "coval_bench.providers.tts.minimax.time.monotonic",
+            side_effect=lambda: next(times, 10.0),
+        ),
+        patch("coval_bench.providers.tts.minimax.ws_client.connect", return_value=ws),
+    ):
+        result = await provider.synthesize("Hello")
+
+    assert result.error is None
+    assert result.ttfa_ms == pytest.approx(100.0)
+    assert result.audio_path is not None
+    result.audio_path.unlink()
+
+
+def test_minimax_tts_invalid_model_raises(minimax_settings: Settings) -> None:
+    with pytest.raises(ValueError, match="Invalid MiniMax TTS model"):
+        MinimaxTTSProvider(minimax_settings, model="not-a-model", voice=_VOICE)
+
+
+def test_minimax_tts_missing_voice_raises(minimax_settings: Settings) -> None:
+    with pytest.raises(ValueError, match="requires a voice"):
+        MinimaxTTSProvider(minimax_settings, model="speech-2.8-hd", voice="")
+
+
+def test_minimax_tts_missing_api_key_raises() -> None:
+    with pytest.raises(ValueError, match="minimax_api_key is required"):
+        MinimaxTTSProvider(_settings(minimax_api_key=None), model="speech-2.8-hd", voice=_VOICE)
+
+
+def test_minimax_tts_provider_name(minimax_settings: Settings) -> None:
+    provider = MinimaxTTSProvider(minimax_settings, model="speech-2.8-hd", voice=_VOICE)
+    assert provider.name == "minimax-speech-2.8-hd"
+    assert provider.model == "speech-2.8-hd"

--- a/web/lib/utils/formatters.ts
+++ b/web/lib/utils/formatters.ts
@@ -113,6 +113,8 @@ export function normalizeModelName(modelKey: string): string {
     "tts-rt-v1": "TTS RT v1",
     neural: "Neural", // azure
     "dragon-hd-latest": "Dragon HD Latest", // azure
+    "speech-2.8-hd": "Speech 2.8 HD",
+    "speech-2.8-turbo": "Speech 2.8 Turbo",
     // STT
     "nova-2": "Nova 2",
     "nova-3": "Nova 3",
@@ -228,6 +230,7 @@ export function normalizeTTSProviderName(providerName: string): string {
     gradium: "Gradium",
     hume: "Hume",
     inworld: "Inworld AI",
+    minimax: "MiniMax",
     openai: "OpenAI",
     rime: "Rime",
     soniox: "Soniox",


### PR DESCRIPTION
Adds speech-2.8-hd and speech-2.8-turbo over the T2A v2 WebSocket.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds MiniMax Speech 2.8 TTS support. The main changes are:

- New MiniMax TTS provider over the T2A v2 WebSocket.
- Settings and provider-key wiring for `MINIMAX_API_KEY`.
- Registry entries for `speech-2.8-hd` and `speech-2.8-turbo`.
- Tests for MiniMax WebSocket behavior.
- UI display names for the new provider and models.

<h3>Confidence Score: 5/5</h3>

The changed flow looks mergeable after a small cleanup to final-frame handling.

- Provider registration, settings, and key wiring line up with existing patterns.
- The import path uses an existing core WebSocket dependency.
- The only issue found is a conditional MiniMax frame-shape case that can drop audio carried on `task_finished`.

runner/src/coval_bench/providers/tts/minimax.py

<sub>Reviews (1): Last reviewed commit: ["\[BENCH-332\] Add MiniMax Speech 2.8 TTS"](https://github.com/coval-ai/benchmarks/commit/ae3d6cc7fa334ea0a73eaa36e292b6b3c6144292) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43978186)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->