### PR TITLE
[BENCH-413] Document the two-dataset STT mix

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,7 +12,7 @@ POSTGRES_DB=benchmarks
 
 # --- Runner / dataset ---
 DATASET_BUCKET=coval-benchmarks-datasets
-DATASET_ID=stt-v2
+DATASET_ID=stt-v1
 RUNNER_SHA=local
 LOG_LEVEL=INFO
 

--- a/docs/methodology.md
+++ b/docs/methodology.md
@@ -6,59 +6,61 @@ four. This document describes each one and where it lives.
 
 ## 1. Dataset
 
-**STT benchmark.** A 50-utterance subset of the
-`environment_degradation__en__fleurs_clean_en` split of
-[bosonai/WildASR](https://huggingface.co/datasets/bosonai/WildASR)
-(`Apache-2.0`; audio derived from FLEURS, `CC-BY-4.0`). Selection rule: the
-builder scans the split's first 100 rows, keeps clips of 2.0–15.0 s with at
-least 3 words, dedups by transcript (the source publishes some recordings
-under several row indices), and takes the lexicographically-first 50 by
-transcript. Each clip is loudness-normalized (RMS target −20 dBFS,
-peak-guarded); the source audio is published quiet enough to defeat some
-providers' speech detection.
-The selection is deterministic and reproducible from the frozen split. Runs
-recorded before the swap used `stt-v1` (LibriSpeech `test-clean`; see
-`runner/src/coval_bench/datasets/manifests/README.md`).
+**STT benchmark.** Two frozen datasets run each cycle, each as its own run:
+
+- `stt-v1` — a 50-utterance subset of
+  [LibriSpeech `test-clean`](https://www.openslr.org/12/) (`CC-BY-4.0`):
+  studio-quality read English speech, speaker-balanced per ADR-020. The easy
+  tier: most providers train on LibriSpeech, so absolute WER runs low.
+- `stt-v3` — 897 conversational clips from
+  [pipecat-ai/stt-benchmark-data](https://huggingface.co/datasets/pipecat-ai/stt-benchmark-data):
+  spontaneous voice-agent speech (fragments, fillers, prompted turns) with
+  model-generated reference transcripts. The hard tier.
+
+Each clip is loudness-normalized (RMS target −20 dBFS, peak-guarded) and
+selection is deterministic from the frozen sources; per-dataset selection
+rules, provenance, and licenses are documented in
+`runner/src/coval_bench/datasets/manifests/README.md`. Runs recorded between
+2026-07-08 and 2026-07-13 used `stt-v2` (WildASR `fleurs_clean_en`), and runs
+before that used `stt-v1` alone.
 
 **TTS benchmark.** A 30-prompt set of short text inputs. Source and selection
 rule are documented in `runner/src/coval_bench/datasets/manifests/tts-v1.json`.
 
 **Per-run sampling.** Each scheduled run draws a random sample of
-`dataset_sample_size` items (default 10) from each manifest before any provider
-is called; the STT and TTS pools are sampled independently. The sample is drawn
+`dataset_sample_size` items (default 10) from its manifest before any provider
+is called; each dataset's pool is sampled independently. The sample is drawn
 once at the start of the run and shared across every model, so all models are
 scored on the identical subset within a run (parity); the draw is independent
 across runs, so the full manifest is covered over time. The manifests still
-carry the complete 50 / 30 items — sampling only controls how many run each
+carry their complete item sets — sampling only controls how many run each
 cycle. Set `DATASET_SAMPLE_SIZE` ≥ the manifest size to run everything.
 
-**SHA pinning.** Every audio file referenced by `stt-v2.json` carries a
+**SHA pinning.** Every audio file referenced by an STT manifest carries a
 `sha256` field. The runner verifies the SHA after fetching from GCS and raises
 `DatasetIntegrityError` on mismatch (see `runner/src/coval_bench/datasets/loader.py`).
 TTS items are text-only and have no SHA.
 
 **Versioning.** Dataset manifests live at
-`runner/src/coval_bench/datasets/manifests/{stt-v2,tts-v1}.json` and carry a
-`version` field. Bumping the dataset re-pins by minting a new manifest;
-old manifests (`stt-v1.json`) stay for historical reproducibility.
+`runner/src/coval_bench/datasets/manifests/{stt-v1,stt-v3,tts-v1}.json` and
+carry a `version` field. Bumping a dataset re-pins by minting a new manifest;
+retired manifests (`stt-v2.json`) stay for historical reproducibility.
 
-**Multiple STT datasets.** Additional frozen STT manifests (`stt-v1`
-LibriSpeech, `stt-v3` pipecat conversational speech) can run alongside the
-default: each dataset runs as its own run (one `DATASET_ID` per execution),
-and a result's dataset is derived from its parent run. The aggregation layer
-pools every result in the window regardless of dataset, so headline stats
-(e.g. average WER) blend all datasets that ran. `/v1/results` exposes each
-row's `dataset_id` and takes a `dataset` filter for per-dataset inspection.
-See ADR-023.
+**Aggregation across datasets.** Each dataset runs as its own run (one
+`DATASET_ID` per execution), and a result's dataset is derived from its parent
+run. The aggregation layer pools every result in the window regardless of
+dataset, so headline stats (e.g. average WER) blend all datasets that ran.
+`/v1/results` exposes each row's `dataset_id` and takes a `dataset` filter for
+per-dataset inspection. See ADR-023.
 
-**Rebuilding from scratch.** `coval-build-dataset --hf bosonai/WildASR
---normalize` applies the selection rule, transcodes to the canonical audio
-format, uploads to GCS, and writes the manifest with fresh SHAs. See
-`runner/src/coval_bench/datasets/manifests/README.md` for the full procedure
+**Rebuilding from scratch.** `coval-build-dataset` applies each dataset's
+selection rule, transcodes to the canonical audio format, uploads to GCS, and
+writes the manifest with fresh SHAs. See
+`runner/src/coval_bench/datasets/manifests/README.md` for per-dataset commands
 and exact flags.
 
-**Selection rationale.** See [ADR-022](#adr-references) below (ADR-020 for
-the retired `stt-v1` rule).
+**Selection rationale.** See [ADR-020](#adr-references) below for the `stt-v1`
+rule, ADR-023 for the multi-dataset mix (ADR-022 for the retired `stt-v2`).
 
 ## 2. Provider model versions
 
@@ -227,9 +229,12 @@ where the decision context is load-bearing.
 
 ## Caveats
 
-- The STT corpus is public and FLEURS-derived; providers may include it in
-  training data, which skews absolute WER low. Latency and per-provider
-  drift over time are the more informative signals.
+- The STT corpora are public; LibriSpeech in particular is heavily represented
+  in provider training data, which skews `stt-v1` absolute WER low. The
+  `stt-v3` reference transcripts are model-generated rather than
+  human-verified, so its absolute WER carries a reference-error floor shared
+  by all providers. Latency and per-provider drift over time are the more
+  informative signals.
 - This is a research benchmark. Results reflect a specific dataset and
   methodology and may not generalize to production workloads. See the
   Apache-2.0 `LICENSE` for the warranty disclaimer.

--- a/runner/README.md
+++ b/runner/README.md
@@ -7,14 +7,13 @@ Runner + API for Coval voice-AI benchmarks. Implements:
 
 ## What we benchmark
 
-**STT** — providers are scored against a frozen 50-utterance sample of
-[LibriSpeech `test-clean`](https://www.openslr.org/12/) (CC-BY-4.0, English read
-speech, 2.0–15.0 s utterances). Selection is round-robin by speaker in lex
-order, so all 40 source-pool speakers (20 F / 20 M) contribute, with the
-lex-first 10 providing 2 utterances each (deterministic per ADR-020). Metrics:
-WER, TTFT, audio→final latency, RTF. Total audio per run ≈ 5–6 min. Absolute
-WER is artificially low (most providers train on LibriSpeech) — the value is
-in latency and per-provider regression-over-time.
+**STT** — providers are scored against two frozen datasets, each run as its
+own execution per cycle: [LibriSpeech `test-clean`](https://www.openslr.org/12/)
+(`stt-v1`, CC-BY-4.0 read English speech, the easy set) and pipecat's
+conversational benchmark data (`stt-v3`, 897 spontaneous voice-agent clips,
+the hard set). Metrics: WER, TTFT, TTFS, audio→final latency, RTF. Headline
+stats pool both datasets; absolute WER on `stt-v1` runs low (most providers
+train on LibriSpeech) and `stt-v3` references are model-generated.
 
 **TTS** — providers are scored on 30 short English customer-service transcripts
 (order tracking, appointments, account verification, tech support; Apache-2.0).

--- a/runner/src/coval_bench/config.py
+++ b/runner/src/coval_bench/config.py
@@ -43,7 +43,7 @@ class Settings(BaseSettings):
 
     # --- Dataset ---
     dataset_bucket: str = "coval-benchmarks-datasets"
-    dataset_id: str = "stt-v2"
+    dataset_id: str = "stt-v1"
 
     # Items drawn at random per run from each manifest, shared across all
     # models for parity. Set >= manifest size to run everything.

--- a/runner/src/coval_bench/datasets/manifests/README.md
+++ b/runner/src/coval_bench/datasets/manifests/README.md
@@ -66,7 +66,10 @@ publishes a data license, record it here and in the manifest.
 
 ### `stt-v2.json`
 
-**What we benchmark.** STT providers are scored against a frozen 50-utterance
+**Retired from the scheduled mix** (replaced by the `stt-v1` + `stt-v3` pair);
+retained for reproducibility of runs recorded against it. Never overwrite.
+
+**What we benchmark.** STT providers were scored against a frozen 50-utterance
 sample of the `environment_degradation__en__fleurs_clean_en` split of
 [bosonai/WildASR](https://huggingface.co/datasets/bosonai/WildASR) — the clean
 (undegraded) English baseline of WildASR's environment-degradation suite,
@@ -120,8 +123,8 @@ License: `Apache-2.0` (WildASR); audio derived from FLEURS (`CC-BY-4.0`).
 
 ### `stt-v1.json`
 
-**Superseded by `stt-v2`** — retained for historical reproducibility of runs
-recorded against it. Never overwrite.
+**In the scheduled mix** as the easy set alongside `stt-v3` (it was retired in
+favor of `stt-v2` from 2026-07-08 to 2026-07-13). Never overwrite.
 
 **What we benchmark.** STT providers are scored against a frozen 50-utterance
 sample of [LibriSpeech `test-clean`](https://www.openslr.org/12/) (OpenSLR-12).

--- a/web/lib/config/methodologyChanges.ts
+++ b/web/lib/config/methodologyChanges.ts
@@ -64,4 +64,12 @@ export const methodologyChanges: MethodologyChange[] = [
     detail:
       "The STT benchmark corpus moved from LibriSpeech test-clean to the clean English FLEURS subset of WildASR (stt-v2), loudness-normalized to a −20 dBFS RMS target. LibriSpeech is heavily represented in provider training data, which compressed WER differences between engines. WER values before and after are not comparable; latency metrics shift with the new clip mix. The runner also now streams exact PCM frames to STT providers (previously the WAV container header was included at stream start).",
   },
+  {
+    date: "2026-07-13",
+    time: "16:00:00-07:00",
+    metrics: ["wer", "ttft", "ttfs"],
+    title: "STT benchmark now runs two datasets: easy and hard",
+    detail:
+      "Each cycle now benchmarks two STT datasets as separate runs, 10 clips sampled from each: LibriSpeech test-clean (stt-v1, studio-read speech) and a new conversational set built from pipecat's stt-benchmark data (stt-v3, 897 spontaneous voice-agent clips with model-generated reference transcripts). Headline stats pool both, so average WER becomes the blend of an easy and a hard set; the WildASR clean set (stt-v2) is retired from the schedule. WER values before and after are not comparable; latency metrics shift with the new clip mix.",
+  },
 ];


### PR DESCRIPTION
The scheduler now runs stt-v1 (LibriSpeech, easy) and stt-v3 (pipecat conversational, hard) each cycle instead of stt-v2, which changes what the public average WER means.

Adds the methodology timeline entry for the flip, rewrites the dataset sections of docs/methodology.md and both READMEs to describe the mix (including the stt-v2 retirement and per-dataset caveats), and moves the runner's default DATASET_ID to stt-v1 so bare local runs match prod.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR documents the new two-dataset STT benchmark mix. The main changes are:

- Updates the default runner dataset from `stt-v2` to `stt-v1`.
- Rewrites methodology docs and READMEs for `stt-v1`, `stt-v3`, and retired `stt-v2`.
- Adds a web methodology timeline entry for the July 13 dataset mix change.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge after confirming the scheduler launches the `stt-v3` run.

- The changed default makes single-run execution use only `stt-v1`.
- The docs and web timeline updates match the new dataset names and public aggregation behavior.
- No security-sensitive code changed.

runner/src/coval_bench/config.py

<sub>Reviews (1): Last reviewed commit: ["\[BENCH-413\] Document the two-dataset STT..."](https://github.com/coval-ai/benchmarks/commit/a6d35ff1f7ae67f9ef0ac1be95052caee6d9c24b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43981710)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->