### PR TITLE
Add Fish Audio s2.1-pro-free

### DIFF
--- a/runner/src/coval_bench/providers/tts/fishaudio.py
+++ b/runner/src/coval_bench/providers/tts/fishaudio.py
@@ -23,8 +23,6 @@ from coval_bench.providers.tts._common import finalize_tts_result
 
 logger: structlog.BoundLogger = structlog.get_logger(__name__)
 
-# s2.1-pro-free is unregistered: same engine as s2.1-pro at $0, kept for smoke
-# tests while the account has no billing.
 _VALID_MODELS = ("s1", "s2.1-pro", "s2.1-pro-free")
 _WS_URL = "wss://api.fish.audio/v1/tts/live"
 _SAMPLE_RATE = 44100
@@ -81,6 +79,7 @@ class FishAudioTTSProvider(TTSProvider):
                                 "sample_rate": _SAMPLE_RATE,
                                 "reference_id": self._voice,
                                 "latency": "balanced",
+                                "features": ["quality-guard"],
                             },
                         }
                     )

--- a/runner/src/coval_bench/registries/models.py
+++ b/runner/src/coval_bench/registries/models.py
@@ -609,13 +609,12 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         status=_ACTIVE,
         arena_enabled=False,
     ),
-    # Fish Audio. Voice is "Energetic Male", the reference_id Fish Audio's own
-    # docs use in examples.
+    # Fish Audio. Voice is the benchmark-selected speaker used in Fish Audio docs.
     RegisteredModel(
         benchmark=_TTS,
         provider="fishaudio",
         model="s1",
-        voice="802e3bc2b27e49c2995d23ef70e6ac89",
+        voice="9a9cf47702da476aa4629e2506d4a857",
         tags=(_REALTIME, _MULTI, _CLONE, _EMOTION, _STREAM),
         status=_ACTIVE,
     ),
@@ -623,7 +622,15 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         benchmark=_TTS,
         provider="fishaudio",
         model="s2.1-pro",
-        voice="802e3bc2b27e49c2995d23ef70e6ac89",
+        voice="9a9cf47702da476aa4629e2506d4a857",
+        tags=(_REALTIME, _MULTI, _CLONE, _EMOTION, _STREAM),
+        status=_ACTIVE,
+    ),
+    RegisteredModel(
+        benchmark=_TTS,
+        provider="fishaudio",
+        model="s2.1-pro-free",
+        voice="9a9cf47702da476aa4629e2506d4a857",
         tags=(_REALTIME, _MULTI, _CLONE, _EMOTION, _STREAM),
         status=_ACTIVE,
     ),

--- a/runner/tests/providers/tts/test_fishaudio.py
+++ b/runner/tests/providers/tts/test_fishaudio.py
@@ -16,7 +16,7 @@ from coval_bench.providers.tts.fishaudio import FishAudioTTSProvider
 
 from .conftest import FakeWebSocket, make_pcm_bytes
 
-_VOICE = "802e3bc2b27e49c2995d23ef70e6ac89"
+_VOICE = "9a9cf47702da476aa4629e2506d4a857"
 
 
 def _settings(**overrides: object) -> Settings:
@@ -107,6 +107,7 @@ async def test_fishaudio_tts_sends_start_text_stop(fishaudio_settings: Settings)
     assert request["sample_rate"] == 44100
     assert request["reference_id"] == _VOICE
     assert request["latency"] == "balanced"
+    assert request["features"] == ["quality-guard"]
     assert sent[1] == {"event": "text", "text": "Hello world"}
     assert sent[2] == {"event": "stop"}
     if result.audio_path is not None:


### PR DESCRIPTION
Adds Fish Audio's `s2.1-pro-free` to the active TTS registry as a zero-cost sibling to `s2.1-pro`, making the benchmark include a truly accessible Fish Audio model.

Also syncs the benchmark voice to `9a9cf47702da476aa4629e2506d4a857` across the Fish Audio entries and sends the `quality-guard` feature flag in the realtime WebSocket request. The provider test now asserts the updated voice and request shape.

Validation:
- `uv run pytest -q tests/providers/tts/test_fishaudio.py tests/unit/test_provider_config.py`
- `uv run ruff check src/coval_bench/providers/tts/fishaudio.py src/coval_bench/registries/models.py tests/providers/tts/test_fishaudio.py`
- Non-persisting probe, `fishaudio/s2.1-pro`, `tts-v1`, 30 samples, 3 runs: average TTFA mean 284.30 ms; average WER mean 4.79%.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds an accessible Fish Audio TTS model and updates the shared Fish Audio request shape.

- Registers `fishaudio/s2.1-pro-free` as an active TTS model.
- Switches Fish Audio registry voices to `9a9cf47702da476aa4629e2506d4a857`.
- Sends `quality-guard` in Fish Audio realtime WebSocket requests.
- Updates Fish Audio provider tests for the new voice and request body.

<h3>Confidence Score: 4/5</h3>

The Fish Audio request path needs a fix before merging.

- The new `quality-guard` field is sent for every Fish Audio model.
- A server close before any audio can still be recorded as a successful empty-audio result.
- The `s1` voice change is conditionally risky if the new reference is not available across Fish Audio tiers or accounts.

runner/src/coval_bench/providers/tts/fishaudio.py

<sub>Reviews (1): Last reviewed commit: ["Update Fish Audio benchmark defaults"](https://github.com/coval-ai/benchmarks/commit/bcea2f4793b0882758a2697c904cb0f08f0792d4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44043714)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->