### PR TITLE
[BENCH-414] Anchor the timeline to real time

### DIFF
--- a/web/hooks/useChartData.ts
+++ b/web/hooks/useChartData.ts
@@ -381,11 +381,17 @@ export function useChartData({
 
   // ─── Timeline window functions ───
 
-  const getCurrentTimeWindow = useCallback((): [number, number] => {
+  const currentTimeWindow = useMemo<[number, number]>(() => {
     const windowEnd = Date.now();
     const windowStart = windowEnd - WINDOW_MS[timeWindow];
     return [windowStart, windowEnd];
-  }, [timeWindow]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- series retriggers the now() snapshot on data reload
+  }, [timeWindow, series]);
+
+  const getCurrentTimeWindow = useCallback(
+    (): [number, number] => currentTimeWindow,
+    [currentTimeWindow]
+  );
 
   // Pinned ticks — Recharts' auto-picked ticks space unevenly. Wider windows
   // tick at local midnights so date labels sit on day starts in the viewer's

--- a/web/hooks/useChartData.ts
+++ b/web/hooks/useChartData.ts
@@ -381,24 +381,11 @@ export function useChartData({
 
   // ─── Timeline window functions ───
 
-  // Anchor the timeline window to the latest plotted bucket, not Date.now().
-  // Charts plot scheduled_at so every result from one benchmark run shares a
-  // tick.
-  const timelineWindowEnd = useMemo<number>(() => {
-    if (series.length === 0) return Date.now();
-    let max = 0;
-    for (const point of series) {
-      const t = new Date(point.scheduled_at).getTime();
-      if (Number.isNaN(t)) continue;
-      if (t > max) max = t;
-    }
-    return max > 0 ? max : Date.now();
-  }, [series]);
-
   const getCurrentTimeWindow = useCallback((): [number, number] => {
-    const windowStart = timelineWindowEnd - WINDOW_MS[timeWindow];
-    return [windowStart, timelineWindowEnd];
-  }, [timelineWindowEnd, timeWindow]);
+    const windowEnd = Date.now();
+    const windowStart = windowEnd - WINDOW_MS[timeWindow];
+    return [windowStart, windowEnd];
+  }, [timeWindow]);
 
   // Pinned ticks — Recharts' auto-picked ticks space unevenly. Wider windows
   // tick at local midnights so date labels sit on day starts in the viewer's


### PR DESCRIPTION
The chart ran from the latest data bucket meaning missing benchmarks are quite than they should be.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR changes the chart timeline to use real time. The main changes are:

- Compute the visible time window from `Date.now()`.
- Refresh the time snapshot when the selected window or series changes.
- Return the memoized time window through `getCurrentTimeWindow`.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<sub>Reviews (2): Last reviewed commit: ["\[BENCH-414\] Stabilize timeline bounds ac..."](https://github.com/coval-ai/benchmarks/commit/f1451a455a648fb5004c9c337c71953bd0ef4120) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44177260)</sub>

<!-- /greptile_comment -->