### PR TITLE
[BENCH-415] Compress API responses

### DIFF
--- a/runner/src/coval_bench/api/app.py
+++ b/runner/src/coval_bench/api/app.py
@@ -22,6 +22,7 @@ from contextlib import asynccontextmanager
 import structlog
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.middleware.gzip import GZipMiddleware
 from fastapi.staticfiles import StaticFiles
 from posthog import Posthog
 from slowapi.errors import RateLimitExceeded
@@ -108,6 +109,8 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         allow_headers=["*"],
         max_age=600,
     )
+
+    app.add_middleware(GZipMiddleware, minimum_size=1024)
 
     app.state.response_cache = new_response_cache()
     app.state.cache_locks = new_cache_locks()

--- a/runner/src/coval_bench/api/app.py
+++ b/runner/src/coval_bench/api/app.py
@@ -22,13 +22,13 @@ from contextlib import asynccontextmanager
 import structlog
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.middleware.gzip import GZipMiddleware
 from fastapi.staticfiles import StaticFiles
 from posthog import Posthog
 from slowapi.errors import RateLimitExceeded
 from slowapi.middleware import SlowAPIMiddleware
 
 from coval_bench.api.cache import new_cache_locks, new_response_cache
+from coval_bench.api.compression import SelectiveGZipMiddleware
 from coval_bench.api.ratelimit import _rate_limit_handler, limiter
 from coval_bench.api.request_logging import RequestLoggingMiddleware
 from coval_bench.api.routers import (
@@ -110,7 +110,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         max_age=600,
     )
 
-    app.add_middleware(GZipMiddleware, minimum_size=1024)
+    app.add_middleware(SelectiveGZipMiddleware, minimum_size=1024, exclude_prefixes=("/clips",))
 
     app.state.response_cache = new_response_cache()
     app.state.cache_locks = new_cache_locks()

--- a/runner/src/coval_bench/api/compression.py
+++ b/runner/src/coval_bench/api/compression.py
@@ -1,0 +1,35 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Gzip compression for API responses, bypassing static clip files.
+
+Wraps Starlette's ``GZipMiddleware`` with a path-prefix bypass. Compressing
+the ``/clips`` static mount would break it: a 206 body gets gzipped while
+``Content-Range`` still describes offsets in the original file, and streamed
+file responses lose ``Content-Length``. WAV clips barely compress anyway.
+"""
+
+from __future__ import annotations
+
+from starlette.middleware.gzip import GZipMiddleware
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+
+class SelectiveGZipMiddleware(GZipMiddleware):
+    """``GZipMiddleware`` that leaves excluded path prefixes uncompressed."""
+
+    def __init__(
+        self,
+        app: ASGIApp,
+        minimum_size: int = 500,
+        compresslevel: int = 9,
+        exclude_prefixes: tuple[str, ...] = (),
+    ) -> None:
+        super().__init__(app, minimum_size, compresslevel)
+        self.exclude_prefixes = exclude_prefixes
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] == "http" and scope["path"].startswith(self.exclude_prefixes):
+            await self.app(scope, receive, send)
+            return
+        await super().__call__(scope, receive, send)

--- a/runner/tests/api/test_compression.py
+++ b/runner/tests/api/test_compression.py
@@ -1,0 +1,56 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for response compression.
+
+The aggregates payload for wide windows exceeds Cloud Run's 32 MiB response cap
+uncompressed, which returns a 500. GZipMiddleware keeps it well under.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from httpx import AsyncClient
+
+from tests.api.conftest import _fill_buckets, _insert_result, _insert_run, _refresh_mv
+
+
+async def test_large_aggregates_response_is_gzipped(client: AsyncClient, postgresql: Any) -> None:
+    """A response over the size threshold is gzip-encoded and still decodes."""
+    run_id = await _insert_run(postgresql)
+    for i in range(12):
+        for value in (1.0, 2.0, 3.0, 4.0):
+            await _insert_result(
+                postgresql,
+                run_id,
+                provider=f"prov{i}",
+                model=f"model{i}",
+                metric_type="WER",
+                metric_value=value,
+            )
+    await _refresh_mv(postgresql)
+    await _fill_buckets(postgresql)
+
+    response = await client.get(
+        "/v1/results/aggregates",
+        params={"benchmark": "STT", "window": "30d"},
+        headers={"Accept-Encoding": "gzip"},
+    )
+
+    assert response.status_code == 200
+    assert response.headers.get("content-encoding") == "gzip"
+    # Body still decodes through the transparent gunzip.
+    assert len(response.json()["model_stats"]) == 12
+
+
+async def test_small_response_is_not_compressed(client: AsyncClient) -> None:
+    """Responses under the size threshold are sent uncompressed."""
+    response = await client.get(
+        "/v1/results/aggregates",
+        params={"benchmark": "STT"},
+        headers={"Accept-Encoding": "gzip"},
+    )
+
+    assert response.status_code == 200
+    assert "content-encoding" not in response.headers

--- a/runner/tests/api/test_compression.py
+++ b/runner/tests/api/test_compression.py
@@ -9,11 +9,16 @@ uncompressed, which returns a 500. GZipMiddleware keeps it well under.
 
 from __future__ import annotations
 
+from collections.abc import Awaitable, Callable
+from pathlib import Path
 from typing import Any
 
-from httpx import AsyncClient
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
 
 from tests.api.conftest import _fill_buckets, _insert_result, _insert_run, _refresh_mv
+
+AppFactory = Callable[[dict[str, str] | None], Awaitable[FastAPI]]
 
 
 async def test_large_aggregates_response_is_gzipped(client: AsyncClient, postgresql: Any) -> None:
@@ -54,3 +59,31 @@ async def test_small_response_is_not_compressed(client: AsyncClient) -> None:
 
     assert response.status_code == 200
     assert "content-encoding" not in response.headers
+
+
+async def test_clips_are_not_compressed(app_factory: AppFactory, tmp_path: Path) -> None:
+    """Static clip responses stay identity-encoded.
+
+    Gzipping them would return a 206 whose ``Content-Range`` describes offsets
+    in the original file while the body is compressed, and would drop
+    ``Content-Length`` from full-file responses.
+    """
+    clips_dir = tmp_path / "clips"
+    clips_dir.mkdir()
+    (clips_dir / "clip.wav").write_bytes(b"\x00" * 4096)
+    app = await app_factory({"ARENA_AUDIO_DIR": str(tmp_path)})
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        full = await c.get("/clips/clip.wav", headers={"Accept-Encoding": "gzip"})
+        assert full.status_code == 200
+        assert "content-encoding" not in full.headers
+        assert full.headers["content-length"] == "4096"
+
+        partial = await c.get(
+            "/clips/clip.wav",
+            headers={"Accept-Encoding": "gzip", "Range": "bytes=0-1499"},
+        )
+        assert partial.status_code == 206
+        assert "content-encoding" not in partial.headers
+        assert partial.headers["content-length"] == "1500"
+        assert partial.content == b"\x00" * 1500


### PR DESCRIPTION
The STT 30d aggregates payload outgrew Cloud Run's 32 MiB response cap and the request 500'd; gzip keeps every large response well under it.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds gzip compression for large API responses while keeping clip files uncompressed.

- Adds selective gzip middleware for non-clip routes.
- Excludes the `/clips` static mount from compression.
- Adds tests for aggregate compression and clip range responses.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<sub>Reviews (2): Last reviewed commit: ["\[BENCH-415\] Exclude clips from gzip"](https://github.com/coval-ai/benchmarks/commit/ba52bbaaab2ee7e6a2f63b8f5258659b6bbb07bd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44193644)</sub>

<!-- /greptile_comment -->