### PR TITLE
[BENCH-416] Pin the two-dataset marker to the first blended run

### DIFF
--- a/web/lib/config/methodologyChanges.ts
+++ b/web/lib/config/methodologyChanges.ts
@@ -65,8 +65,8 @@ export const methodologyChanges: MethodologyChange[] = [
       "The STT benchmark corpus moved from LibriSpeech test-clean to the clean English FLEURS subset of WildASR (stt-v2), loudness-normalized to a −20 dBFS RMS target. LibriSpeech is heavily represented in provider training data, which compressed WER differences between engines. WER values before and after are not comparable; latency metrics shift with the new clip mix. The runner also now streams exact PCM frames to STT providers (previously the WAV container header was included at stream start).",
   },
   {
-    date: "2026-07-13",
-    time: "16:00:00-07:00",
+    date: "2026-07-14",
+    time: "09:30:00-07:00",
     metrics: ["wer", "ttft", "ttfs"],
     title: "STT benchmark now runs two datasets: easy and hard",
     detail:


### PR DESCRIPTION
The newest methodology marker (the stt-v1 + stt-v3 two-dataset flip) was timestamped 2026-07-13 16:00 PDT, which is when the last stt-v2 run finished. The new mix didn't produce its first data until 2026-07-14 09:30 PDT, 17.5 hours later, so the marker sat on the wrong side of a scheduling gap and labeled the tail of the old dataset's data as the start of the new mix.

Verified against prod runs: the last stt-v2 run started 2026-07-13T23:00:43Z, the first stt-v1 + stt-v3 run started 2026-07-14T16:30:42Z, and the STT series has no buckets in between. The marker now sits on the first blended bucket, matching the existing convention of pinning methodology markers to the real data discontinuity (933765b).

Rendering verified on the STT 7d chart: the marker lands exactly on the first new-mix bucket, and the Jul 8 WildASR marker is unaffected.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR moves the STT two-dataset methodology marker to the first blended run. The main changes are:

- Updates the marker date from July 13 to July 14.
- Updates the marker time from 16:00 PDT to 09:30 PDT.
- Leaves the affected STT metrics and marker text unchanged.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<sub>Reviews (1): Last reviewed commit: ["\[BENCH-416\] Pin the two-dataset marker t..."](https://github.com/coval-ai/benchmarks/commit/c4fe040a80ed4a48b7db62f0ed88eb05881b867f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44197362)</sub>

<!-- /greptile_comment -->