### PR TITLE
Make the S2S fetch self-healing and alert on stale providers

### DIFF
--- a/runner/src/coval_bench/config.py
+++ b/runner/src/coval_bench/config.py
@@ -115,6 +115,9 @@ class Settings(BaseSettings):
     # Fetch grid, in seconds; kept in sync with the s2s-fetch-trigger cron in
     # benchmark-infra (override via S2S_FETCH_PERIOD_SECONDS). Default = 3h.
     s2s_fetch_period_seconds: int = Field(default=10_800, gt=0)
+    # Staleness watchdog: warn ("provider_stale") when a provider's newest
+    # usable Coval run is older than the fetch period plus this grace.
+    s2s_stale_grace_seconds: int = Field(default=5_400, gt=0)
 
     # --- Analytics ---
     posthog_project_token: str = ""

--- a/runner/src/coval_bench/config.py
+++ b/runner/src/coval_bench/config.py
@@ -115,9 +115,8 @@ class Settings(BaseSettings):
     # Fetch grid, in seconds; kept in sync with the s2s-fetch-trigger cron in
     # benchmark-infra (override via S2S_FETCH_PERIOD_SECONDS). Default = 3h.
     s2s_fetch_period_seconds: int = Field(default=10_800, gt=0)
-    # Staleness watchdog: warn ("provider_stale") when a provider's newest
-    # usable Coval run is older than the fetch period plus this grace.
-    s2s_stale_grace_seconds: int = Field(default=5_400, gt=0)
+    # Staleness threshold = fetch period + this grace.
+    s2s_stale_grace_seconds: int = Field(default=0, ge=0)
 
     # --- Analytics ---
     posthog_project_token: str = ""

--- a/runner/src/coval_bench/s2s/fetch_v2v.py
+++ b/runner/src/coval_bench/s2s/fetch_v2v.py
@@ -3,10 +3,14 @@
 
 """Fetch S2S (voice-to-voice) latency from the Coval API and write per-clip rows.
 
-For each provider, find its newest completed Coval run, read the per-clip
-latency values (seconds), convert to milliseconds, and write one results row
-per clip via ``RunWriter``; the existing matviews aggregate. Agent ids, the
-metric id, and the API key are read from the environment, never committed.
+Each tick scans a window of recent completed Coval runs per provider and
+ingests every clean run not yet in the DB, one results row per clip via
+``RunWriter``; the existing matviews aggregate. A run's slot is its Coval
+``create_time`` floored to the fetch grid, so data lands in the bucket it was
+measured in and a late-resolved run backfills its own slot. Runs finalized
+with an ``error_status`` (pipeline faults, not provider faults) are never
+ingested. Agent ids, the metric id, and the API key are read from the
+environment, never committed.
 """
 
 from __future__ import annotations
@@ -34,6 +38,12 @@ logger = structlog.get_logger("coval_bench.s2s.fetch_v2v")
 # The dataset the S2S sims run against (matches the packaged manifest name).
 DATASET_ID = "s2s-v1"
 
+# Ingest window: how far back one tick looks for not-yet-ingested runs, and
+# how many list results that scan reads. Wide enough that a run resolving
+# late (the >180min reconciler sweep) is still picked up.
+WINDOW_SECONDS = 86_400
+WINDOW_PAGE_SIZE = 10
+
 
 @dataclass(frozen=True)
 class AgentSpec:
@@ -42,6 +52,15 @@ class AgentSpec:
     agent_id_attr: str
     provider: str
     model: str
+
+
+@dataclass(frozen=True)
+class CovalRun:
+    """One completed Coval run from the list endpoint's summary view."""
+
+    run_id: str
+    create_time: datetime | None
+    error_status: str | None
 
 
 # Agent ids resolved from Settings; model strings are display labels.
@@ -76,31 +95,57 @@ def _dataset_sha256() -> str:
         return "unknown"
 
 
-async def latest_completed_run_id(client: httpx.AsyncClient, agent_id: str) -> str | None:
-    """Newest completed Coval run for one agent.
+def _parse_time(raw: object) -> datetime | None:
+    if not isinstance(raw, str):
+        return None
+    try:
+        return datetime.fromisoformat(raw.replace("Z", "+00:00")).astimezone(UTC)
+    except ValueError:
+        return None
+
+
+def _bucket_start(at: datetime, period_seconds: int) -> datetime:
+    """Floor a timestamp to the epoch-anchored fetch grid."""
+    epoch = int(at.timestamp())
+    return datetime.fromtimestamp(epoch - epoch % period_seconds, tz=UTC)
+
+
+async def recent_completed_runs(client: httpx.AsyncClient, agent_id: str) -> list[CovalRun]:
+    """Completed Coval runs for one agent within the ingest window, newest first.
 
     List returns the summary view newest-first; filter by agent_id + status
-    (tags are not filterable).
+    (tags are not filterable). Runs without a parseable create_time are kept:
+    better to ingest with a fetch-time slot than to drop data.
     """
     resp = await client.get(
         "/runs",
         params={
             "filter": f'status="COMPLETED" AND agent_id="{agent_id}"',
             "order_by": "-create_time",
-            "page_size": 1,
+            "page_size": WINDOW_PAGE_SIZE,
         },
     )
     resp.raise_for_status()
-    runs = cast("list[dict[str, Any]]", resp.json().get("runs", []))
-    return cast("str | None", runs[0]["run_id"]) if runs else None
+    raw = cast("list[dict[str, Any]]", resp.json().get("runs", []))
+    now = datetime.now(tz=UTC)
+    runs: list[CovalRun] = []
+    for r in raw:
+        run = CovalRun(
+            run_id=cast("str", r["run_id"]),
+            create_time=_parse_time(r.get("create_time")),
+            error_status=cast("str | None", r.get("error_status")) or None,
+        )
+        if run.create_time is not None and (now - run.create_time).total_seconds() > WINDOW_SECONDS:
+            continue
+        runs.append(run)
+    return runs
 
 
-async def per_clip_rows(
-    client: httpx.AsyncClient,
+def _result_rows(
+    values: list[dict[str, Any]],
     *,
     run_pk: int,
     coval_run_id: str,
-    metric_id: str,
     spec: AgentSpec,
 ) -> list[Result]:
     """Map a Coval run's per-clip values to Result rows.
@@ -108,18 +153,6 @@ async def per_clip_rows(
     Values are seconds; convert to ms. A clip with no numeric value becomes a
     FAILED row, so reliability = success/total.
     """
-    resp = await client.get(f"/runs/{coval_run_id}")
-    resp.raise_for_status()
-    run = cast("dict[str, Any]", resp.json()["run"])
-    metrics = cast("dict[str, Any]", (run.get("results") or {}).get("metrics") or {})
-    metric = metrics.get(metric_id)
-    if metric is None:
-        logger.warning(
-            "metric_absent", provider=spec.provider, run_id=coval_run_id, metric_id=metric_id
-        )
-        return []
-
-    values = cast("list[dict[str, Any]]", metric.get("values", []))
     rows: list[Result] = []
     for i, v in enumerate(values):
         raw = v.get("value")
@@ -144,61 +177,75 @@ async def per_clip_rows(
                 status=status,
             )
         )
-
-    logger.info(
-        "fetched_clips",
-        provider=spec.provider,
-        run_id=coval_run_id,
-        clips=len(rows),
-        success=sum(1 for r in rows if r.status is ResultStatus.SUCCESS),
-    )
     return rows
 
 
-async def _fetch_one_provider(
+async def _ingest_run(
     client: httpx.AsyncClient,
     writer: RunWriter,
     *,
     spec: AgentSpec,
-    agent_id: str,
+    coval_run: CovalRun,
     metric_id: str,
     runner_sha: str,
-    scheduled_at: datetime,
     period_seconds: int,
-) -> RunStatus:
-    """Fetch one provider's latest run into its own run row; return its status.
+) -> RunStatus | None:
+    """Ingest one Coval run into its own run row; None = skipped, nothing written.
 
-    SUCCEEDED = all clips numeric, PARTIAL = some clips failed, FAILED = no
-    clips or all failed. Errors are caught here so one provider can't abort others.
-    Skips (no write) if this Coval run was already ingested, so a retry or a
-    re-pulled stale run doesn't double-count and the last good data stays.
+    Skips (before any DB write) runs finalized with an error_status — the
+    reconciler flips wrapup-race casualties to COMPLETED+EXECUTION_FAILURE and
+    those are pipeline faults that must not dent provider reliability — and
+    runs missing the metric. Otherwise SUCCEEDED = all clips numeric, PARTIAL =
+    some failed, FAILED = all failed.
     """
     run_pk: int | None = None
     try:
-        coval_run_id = await latest_completed_run_id(client, agent_id)
-        if coval_run_id is None:
+        resp = await client.get(f"/runs/{coval_run.run_id}")
+        resp.raise_for_status()
+        run = cast("dict[str, Any]", resp.json()["run"])
+        error_status = run.get("error_status")
+        if error_status:
             logger.warning(
-                "no_completed_run", provider=spec.provider, agent_attr=spec.agent_id_attr
+                "errored_run_skipped",
+                provider=spec.provider,
+                coval_run_id=coval_run.run_id,
+                error_status=error_status,
             )
-            return RunStatus.FAILED
-        if await writer.coval_run_ingested(provider=spec.provider, coval_run_id=coval_run_id):
-            logger.info("run_already_ingested", provider=spec.provider, coval_run_id=coval_run_id)
-            return RunStatus.SUCCEEDED
+            return None
+        metrics = cast("dict[str, Any]", (run.get("results") or {}).get("metrics") or {})
+        metric = metrics.get(metric_id)
+        if metric is None:
+            logger.warning(
+                "metric_absent",
+                provider=spec.provider,
+                coval_run_id=coval_run.run_id,
+                metric_id=metric_id,
+            )
+            return None
+        values = cast("list[dict[str, Any]]", metric.get("values", []))
 
-        run = await writer.start_run(
+        scheduled_at = _bucket_start(coval_run.create_time or datetime.now(tz=UTC), period_seconds)
+        run_row = await writer.start_run(
             runner_sha=runner_sha,
             dataset_id=DATASET_ID,
             dataset_sha256=_dataset_sha256(),
             scheduled_at=scheduled_at,
         )
-        if run.id is None:  # pragma: no cover -- start_run always returns an id
+        if run_row.id is None:  # pragma: no cover -- start_run always returns an id
             raise RuntimeError("start_run returned a run with no id")
-        run_pk = run.id
-        rows = await per_clip_rows(
-            client, run_pk=run_pk, coval_run_id=coval_run_id, metric_id=metric_id, spec=spec
-        )
+        run_pk = run_row.id
+
+        rows = _result_rows(values, run_pk=run_pk, coval_run_id=coval_run.run_id, spec=spec)
         if rows:
             await writer.record_results(rows)
+        logger.info(
+            "fetched_clips",
+            provider=spec.provider,
+            coval_run_id=coval_run.run_id,
+            slot=str(scheduled_at),
+            clips=len(rows),
+            success=sum(1 for r in rows if r.status is ResultStatus.SUCCESS),
+        )
         failed = sum(1 for r in rows if r.status is ResultStatus.FAILED)
         if not rows or failed == len(rows):
             status = RunStatus.FAILED
@@ -221,16 +268,109 @@ async def _fetch_one_provider(
                 logger.warning(
                     "finish_run_failed", provider=spec.provider, run_id=run_pk, exc_info=True
                 )
-        logger.warning("provider_fetch_failed", provider=spec.provider, error=str(exc))
+        logger.warning(
+            "run_ingest_failed",
+            provider=spec.provider,
+            coval_run_id=coval_run.run_id,
+            error=str(exc),
+        )
         return RunStatus.FAILED
 
 
-async def fetch_and_write_v2v(settings: Settings | None = None) -> dict[str, RunStatus]:
-    """Fetch each provider's latest run into its own run row; return per-provider status.
+async def _fetch_one_provider(
+    client: httpx.AsyncClient,
+    writer: RunWriter,
+    *,
+    spec: AgentSpec,
+    agent_id: str,
+    metric_id: str,
+    runner_sha: str,
+    period_seconds: int,
+    stale_grace_seconds: int,
+) -> tuple[RunStatus, int]:
+    """Scan the window and ingest every clean, not-yet-ingested run.
 
-    Mirrors the STT/TTS orchestrator: per-provider ``finish_run``, then a best-effort
-    bucket/matview refresh that never fails the job. No cross-run dedup -- a same-day
-    retry re-aggregates the slot, matching the orchestrator's behaviour.
+    Returns (provider status, runs ingested this tick). A tick with nothing
+    new is a healthy no-op (SUCCEEDED) while the newest usable run is younger
+    than period + grace; past that it logs "provider_stale" and returns FAILED,
+    so a stuck sim, a paused schedule, or a Coval outage is always loud.
+    Errors are caught here so one provider can't abort others.
+    """
+    statuses: list[RunStatus] = []
+    try:
+        runs = await recent_completed_runs(client, agent_id)
+
+        data_seen = False
+        newest_data_at: datetime | None = None
+        for coval_run in runs:
+            if coval_run.error_status:
+                logger.warning(
+                    "errored_run_skipped",
+                    provider=spec.provider,
+                    coval_run_id=coval_run.run_id,
+                    error_status=coval_run.error_status,
+                )
+                continue
+            if await writer.coval_run_ingested(
+                provider=spec.provider, coval_run_id=coval_run.run_id
+            ):
+                logger.info(
+                    "run_already_ingested", provider=spec.provider, coval_run_id=coval_run.run_id
+                )
+                if not data_seen:
+                    data_seen, newest_data_at = True, coval_run.create_time
+                continue
+            status = await _ingest_run(
+                client,
+                writer,
+                spec=spec,
+                coval_run=coval_run,
+                metric_id=metric_id,
+                runner_sha=runner_sha,
+                period_seconds=period_seconds,
+            )
+            if status is None:
+                continue
+            statuses.append(status)
+            if not data_seen:
+                data_seen, newest_data_at = True, coval_run.create_time
+
+        threshold = period_seconds + stale_grace_seconds
+        age = (
+            None
+            if newest_data_at is None
+            else (datetime.now(tz=UTC) - newest_data_at).total_seconds()
+        )
+        stale = not data_seen or (age is not None and age > threshold)
+        if stale:
+            logger.warning(
+                "provider_stale",
+                provider=spec.provider,
+                newest_data_at=str(newest_data_at),
+                threshold_seconds=threshold,
+            )
+
+        if statuses:
+            if all(s is RunStatus.FAILED for s in statuses):
+                aggregate = RunStatus.FAILED
+            elif all(s is RunStatus.SUCCEEDED for s in statuses):
+                aggregate = RunStatus.SUCCEEDED
+            else:
+                aggregate = RunStatus.PARTIAL
+            return aggregate, len(statuses)
+        return (RunStatus.FAILED if stale else RunStatus.SUCCEEDED), 0
+    except Exception as exc:
+        logger.warning("provider_fetch_failed", provider=spec.provider, error=str(exc))
+        return RunStatus.FAILED, len(statuses)
+
+
+async def fetch_and_write_v2v(settings: Settings | None = None) -> dict[str, RunStatus]:
+    """Ingest every provider's recent runs; return per-provider status.
+
+    Each ingested Coval run gets its own run row slotted by its create_time,
+    and ``coval_run_ingested`` makes re-scans no-ops, so ticks are idempotent
+    and the fetch cadence only affects how soon data appears — the cron may
+    run more often than the sims.
     """
     settings = settings or get_settings()
 
@@ -238,34 +378,37 @@ async def fetch_and_write_v2v(settings: Settings | None = None) -> dict[str, Run
     if not metric_id:
         raise RuntimeError("coval_s2s_latency_metric_id is not set")
 
-    epoch = int(datetime.now(tz=UTC).timestamp())
-    scheduled_at = datetime.fromtimestamp(epoch - epoch % settings.s2s_fetch_period_seconds, tz=UTC)
-
     async with _client(settings) as client, lifespan_pool(settings) as pool:
         writer = RunWriter(pool)
         statuses: dict[str, RunStatus] = {}
+        total_ingested = 0
         for spec in AGENTS:
             agent_id = getattr(settings, spec.agent_id_attr)
             if not agent_id:
                 logger.warning("agent_id_unset", provider=spec.provider, attr=spec.agent_id_attr)
                 continue
-            statuses[spec.provider] = await _fetch_one_provider(
+            statuses[spec.provider], ingested = await _fetch_one_provider(
                 client,
                 writer,
                 spec=spec,
                 agent_id=agent_id,
                 metric_id=metric_id,
                 runner_sha=settings.runner_sha,
-                scheduled_at=scheduled_at,
                 period_seconds=settings.s2s_fetch_period_seconds,
+                stale_grace_seconds=settings.s2s_stale_grace_seconds,
             )
+            total_ingested += ingested
 
-        if any(s in (RunStatus.SUCCEEDED, RunStatus.PARTIAL) for s in statuses.values()):
+        if total_ingested:
             try:
                 await writer.refresh_stats_matviews()
             except Exception:
                 logger.warning("refresh_stats_matviews_failed", exc_info=True)
-        logger.info("s2s_fetch_done", statuses={p: str(s) for p, s in statuses.items()})
+        logger.info(
+            "s2s_fetch_done",
+            statuses={p: str(s) for p, s in statuses.items()},
+            ingested=total_ingested,
+        )
         return statuses
 
 
@@ -283,14 +426,14 @@ def fetch_s2s() -> None:
         log_run_failed(str(exc), exc)
         raise
 
-    # Alert if any provider returned no data (a silently-missing provider). The
-    # succeeding providers' rows are already committed, so a partial run still
-    # exits 0 — only a total loss fails the job (non-zero exit).
+    # Alert if any provider has no fresh data. The succeeding providers' rows
+    # are already committed, so a partial run still exits 0 — only a total
+    # loss fails the job (non-zero exit).
     failed = [p for p, s in statuses.items() if s is RunStatus.FAILED]
     if not statuses:
         log_run_failed("s2s fetch ran no providers (none configured)")
     elif failed:
-        log_run_failed(f"s2s fetch got no data from: {', '.join(failed)}")
+        log_run_failed(f"s2s fetch has no fresh data from: {', '.join(failed)}")
     if not statuses or all(s is RunStatus.FAILED for s in statuses.values()):
         raise click.ClickException("s2s fetch failed for all providers")
 

--- a/runner/src/coval_bench/s2s/fetch_v2v.py
+++ b/runner/src/coval_bench/s2s/fetch_v2v.py
@@ -288,11 +288,11 @@ async def _fetch_one_provider(
 ) -> tuple[RunStatus, int]:
     """Scan the window and ingest every clean, not-yet-ingested run.
 
-    Returns (provider status, runs ingested this tick). A tick with nothing
-    new is a healthy no-op (SUCCEEDED) while the newest usable run is younger
-    than period + grace; past that it logs "provider_stale" and returns FAILED,
-    so a stuck sim, a paused schedule, or a Coval outage is always loud.
-    Errors are caught here so one provider can't abort others.
+    Returns (provider status, runs ingested this tick). Staleness wins: when
+    the newest usable run is unknown-age or older than period + grace, the
+    provider is FAILED even if old runs were backfilled this tick, so a stuck
+    sim, a paused schedule, or a Coval outage is always loud. Errors are
+    caught here so one provider can't abort others.
     """
     statuses: list[RunStatus] = []
     try:
@@ -339,7 +339,7 @@ async def _fetch_one_provider(
             if newest_data_at is None
             else (datetime.now(tz=UTC) - newest_data_at).total_seconds()
         )
-        stale = not data_seen or (age is not None and age > threshold)
+        stale = not data_seen or age is None or age > threshold
         if stale:
             logger.warning(
                 "provider_stale",
@@ -347,16 +347,15 @@ async def _fetch_one_provider(
                 newest_data_at=str(newest_data_at),
                 threshold_seconds=threshold,
             )
+            return RunStatus.FAILED, len(statuses)
 
         if statuses:
             if all(s is RunStatus.FAILED for s in statuses):
-                aggregate = RunStatus.FAILED
-            elif all(s is RunStatus.SUCCEEDED for s in statuses):
-                aggregate = RunStatus.SUCCEEDED
-            else:
-                aggregate = RunStatus.PARTIAL
-            return aggregate, len(statuses)
-        return (RunStatus.FAILED if stale else RunStatus.SUCCEEDED), 0
+                return RunStatus.FAILED, len(statuses)
+            if all(s is RunStatus.SUCCEEDED for s in statuses):
+                return RunStatus.SUCCEEDED, len(statuses)
+            return RunStatus.PARTIAL, len(statuses)
+        return RunStatus.SUCCEEDED, 0
     except Exception as exc:
         logger.warning("provider_fetch_failed", provider=spec.provider, error=str(exc))
         return RunStatus.FAILED, len(statuses)

--- a/runner/src/coval_bench/s2s/fetch_v2v.py
+++ b/runner/src/coval_bench/s2s/fetch_v2v.py
@@ -3,14 +3,9 @@
 
 """Fetch S2S (voice-to-voice) latency from the Coval API and write per-clip rows.
 
-Each tick scans a window of recent completed Coval runs per provider and
-ingests every clean run not yet in the DB, one results row per clip via
-``RunWriter``; the existing matviews aggregate. A run's slot is its Coval
-``create_time`` floored to the fetch grid, so data lands in the bucket it was
-measured in and a late-resolved run backfills its own slot. Runs finalized
-with an ``error_status`` (pipeline faults, not provider faults) are never
-ingested. Agent ids, the metric id, and the API key are read from the
-environment, never committed.
+Ingests each provider's recent completed runs not yet in the DB, slotted by
+run create_time, and flags providers with no fresh data. Agent ids, the
+metric id, and the API key are read from the environment, never committed.
 """
 
 from __future__ import annotations
@@ -39,9 +34,10 @@ logger = structlog.get_logger("coval_bench.s2s.fetch_v2v")
 DATASET_ID = "s2s-v1"
 
 # Ingest window: how far back one tick looks for not-yet-ingested runs, and
-# how many list results that scan reads. Wide enough that a run resolving
-# late (the >180min reconciler sweep) is still picked up.
-WINDOW_SECONDS = 86_400
+# how many list results that scan reads. Two periods (with a one-day floor)
+# so the previous run stays visible while the current one is due, and a run
+# resolving late is still picked up.
+WINDOW_FLOOR_SECONDS = 86_400
 WINDOW_PAGE_SIZE = 10
 
 
@@ -110,13 +106,16 @@ def _bucket_start(at: datetime, period_seconds: int) -> datetime:
     return datetime.fromtimestamp(epoch - epoch % period_seconds, tz=UTC)
 
 
-async def recent_completed_runs(client: httpx.AsyncClient, agent_id: str) -> list[CovalRun]:
+async def recent_completed_runs(
+    client: httpx.AsyncClient, agent_id: str, *, period_seconds: int
+) -> list[CovalRun]:
     """Completed Coval runs for one agent within the ingest window, newest first.
 
     List returns the summary view newest-first; filter by agent_id + status
     (tags are not filterable). Runs without a parseable create_time are kept:
     better to ingest with a fetch-time slot than to drop data.
     """
+    window_seconds = max(WINDOW_FLOOR_SECONDS, 2 * period_seconds)
     resp = await client.get(
         "/runs",
         params={
@@ -135,7 +134,7 @@ async def recent_completed_runs(client: httpx.AsyncClient, agent_id: str) -> lis
             create_time=_parse_time(r.get("create_time")),
             error_status=cast("str | None", r.get("error_status")) or None,
         )
-        if run.create_time is not None and (now - run.create_time).total_seconds() > WINDOW_SECONDS:
+        if run.create_time is not None and (now - run.create_time).total_seconds() > window_seconds:
             continue
         runs.append(run)
     return runs
@@ -192,9 +191,8 @@ async def _ingest_run(
 ) -> RunStatus | None:
     """Ingest one Coval run into its own run row; None = skipped, nothing written.
 
-    Skips (before any DB write) runs finalized with an error_status — the
-    reconciler flips wrapup-race casualties to COMPLETED+EXECUTION_FAILURE and
-    those are pipeline faults that must not dent provider reliability — and
+    Skips (before any DB write) runs finalized with an error_status — those
+    failed upstream of the provider and must not dent its reliability — and
     runs missing the metric. Otherwise SUCCEEDED = all clips numeric, PARTIAL =
     some failed, FAILED = all failed.
     """
@@ -298,7 +296,7 @@ async def _fetch_one_provider(
     """
     statuses: list[RunStatus] = []
     try:
-        runs = await recent_completed_runs(client, agent_id)
+        runs = await recent_completed_runs(client, agent_id, period_seconds=period_seconds)
 
         data_seen = False
         newest_data_at: datetime | None = None

--- a/runner/tests/unit/test_s2s_fetch.py
+++ b/runner/tests/unit/test_s2s_fetch.py
@@ -135,7 +135,7 @@ async def test_recent_completed_runs_window_and_parse() -> None:
         {"run_id": "R0"},  # no create_time -> kept
     )
     async with _fake_client(list_json, {}, captured) as client:
-        runs = await fetch_v2v.recent_completed_runs(client, "a1")
+        runs = await fetch_v2v.recent_completed_runs(client, "a1", period_seconds=10_800)
 
     filter_expr = captured[0].url.params["filter"]
     assert 'status="COMPLETED"' in filter_expr
@@ -146,7 +146,7 @@ async def test_recent_completed_runs_window_and_parse() -> None:
     assert runs[2].create_time is None
 
     async with _fake_client({"runs": []}, {}) as client:
-        assert await fetch_v2v.recent_completed_runs(client, "a1") == []
+        assert await fetch_v2v.recent_completed_runs(client, "a1", period_seconds=10_800) == []
 
 
 @pytest.mark.asyncio
@@ -209,7 +209,7 @@ async def test_ingest_run_partial_and_failed() -> None:
 
 @pytest.mark.asyncio
 async def test_ingest_run_skips_before_any_write() -> None:
-    # Errored detail (reconciler zombie): skipped, no run row created.
+    # Errored detail: skipped, no run row created.
     writer = _stub_writer()
     run = CovalRun(run_id="R1", create_time=None, error_status=None)
     async with _fake_client({}, _run_json([], error_status="EXECUTION_FAILURE")) as client:

--- a/runner/tests/unit/test_s2s_fetch.py
+++ b/runner/tests/unit/test_s2s_fetch.py
@@ -303,6 +303,29 @@ async def test_fetch_one_provider_stale_fails() -> None:
 
 
 @pytest.mark.asyncio
+async def test_fetch_one_provider_stale_wins_over_backfill() -> None:
+    # Only an old run ingests this tick: rows land, provider still FAILED.
+    writer = _stub_writer()
+    list_json = _list_json({"run_id": "R1", "create_time": _iso(timedelta(hours=6))})
+    values = [{"simulation_output_id": "s1", "value": 0.5}]
+    async with _fake_client(list_json, _run_json(values)) as client:
+        status, ingested = await _fetch(client, writer)
+    assert (status, ingested) == (RunStatus.FAILED, 1)
+    writer.record_results.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_fetch_one_provider_unknown_age_is_stale() -> None:
+    # A usable run without a parseable create_time is no evidence of freshness.
+    writer = _stub_writer()
+    writer.coval_run_ingested = AsyncMock(return_value=True)
+    list_json = _list_json({"run_id": "R1"})
+    async with _fake_client(list_json, {}) as client:
+        status, ingested = await _fetch(client, writer)
+    assert (status, ingested) == (RunStatus.FAILED, 0)
+
+
+@pytest.mark.asyncio
 async def test_fetch_one_provider_skips_errored_ingests_older_clean() -> None:
     # Newest run errored (summary view): skip it, ingest the older clean one.
     writer = _stub_writer()

--- a/runner/tests/unit/test_s2s_fetch.py
+++ b/runner/tests/unit/test_s2s_fetch.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import contextlib
 from collections.abc import AsyncIterator
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
@@ -17,32 +17,52 @@ import pytest
 from coval_bench.config import Settings
 from coval_bench.db.models import ResultStatus, Run, RunStatus
 from coval_bench.s2s import fetch_v2v
-from coval_bench.s2s.fetch_v2v import AgentSpec
+from coval_bench.s2s.fetch_v2v import AgentSpec, CovalRun
 
 SPEC = AgentSpec(agent_id_attr="coval_s2s_openai_agent_id", provider="openai", model="gpt-realtime")
-SLOT = datetime(2026, 7, 7, tzinfo=UTC)
-_LIST_ONE: dict[str, Any] = {"runs": [{"run_id": "R1", "status": "COMPLETED"}]}
+
+
+def _iso(age: timedelta) -> str:
+    return (datetime.now(tz=UTC) - age).isoformat().replace("+00:00", "Z")
+
+
+def _list_json(*runs: dict[str, Any]) -> dict[str, Any]:
+    return {"runs": list(runs)}
+
+
+def _run_json(
+    values: list[dict[str, Any]],
+    metric_id: str = "MID",
+    error_status: str | None = None,
+) -> dict[str, Any]:
+    run: dict[str, Any] = {"results": {"metrics": {metric_id: {"values": values}}}}
+    if error_status:
+        run["error_status"] = error_status
+    return {"run": run}
 
 
 def _fake_client(
     list_json: dict[str, Any],
-    run_json: dict[str, Any],
+    run_json: dict[str, Any] | dict[str, dict[str, Any]],
     captured: list[httpx.Request] | None = None,
 ) -> httpx.AsyncClient:
-    """AsyncClient that answers /runs (list) and /runs/{id} (get) from fixtures."""
+    """AsyncClient answering /runs (list) and /runs/{id} (get) from fixtures.
+
+    ``run_json`` is either one detail fixture for every id, or a mapping of
+    run id -> fixture.
+    """
 
     def handler(request: httpx.Request) -> httpx.Response:
         if captured is not None:
             captured.append(request)
         if request.url.path.endswith("/runs"):
             return httpx.Response(200, json=list_json)
-        return httpx.Response(200, json=run_json)
+        run_id = request.url.path.rsplit("/", 1)[-1]
+        if "run" in run_json:
+            return httpx.Response(200, json=run_json)
+        return httpx.Response(200, json=run_json[run_id])
 
     return httpx.AsyncClient(base_url="https://api.test/v1", transport=httpx.MockTransport(handler))
-
-
-def _run_json(values: list[dict[str, Any]], metric_id: str = "MID") -> dict[str, Any]:
-    return {"run": {"results": {"metrics": {metric_id: {"values": values}}}}}
 
 
 def _stub_writer() -> MagicMock:
@@ -64,17 +84,33 @@ def _stub_writer() -> MagicMock:
     return writer
 
 
-@pytest.mark.asyncio
-async def test_per_clip_rows_maps_values() -> None:
+async def _fetch(client: httpx.AsyncClient, writer: MagicMock) -> tuple[RunStatus, int]:
+    return await fetch_v2v._fetch_one_provider(
+        client,
+        writer,
+        spec=SPEC,
+        agent_id="a1",
+        metric_id="MID",
+        runner_sha="test",
+        period_seconds=10_800,
+        stale_grace_seconds=5_400,
+    )
+
+
+def test_bucket_start_floors_to_grid() -> None:
+    at = datetime(2026, 7, 7, 4, 59, 59, tzinfo=UTC)
+    assert fetch_v2v._bucket_start(at, 10_800) == datetime(2026, 7, 7, 3, tzinfo=UTC)
+    on_boundary = datetime(2026, 7, 7, 9, tzinfo=UTC)
+    assert fetch_v2v._bucket_start(on_boundary, 10_800) == on_boundary
+
+
+def test_result_rows_maps_values() -> None:
     values: list[dict[str, Any]] = [
         {"simulation_output_id": "s1", "value": 0.842},
         {"simulation_output_id": "s2", "value": None},
         {"value": 0.5},  # missing sim id -> index fallback in the clip key
     ]
-    async with _fake_client(_LIST_ONE, _run_json(values)) as client:
-        rows = await fetch_v2v.per_clip_rows(
-            client, run_pk=1, coval_run_id="R1", metric_id="MID", spec=SPEC
-        )
+    rows = fetch_v2v._result_rows(values, run_pk=1, coval_run_id="R1", spec=SPEC)
     assert [r.metric_value for r in rows] == [842.0, None, 500.0]
     assert [r.status for r in rows] == [
         ResultStatus.SUCCESS,
@@ -86,98 +122,205 @@ async def test_per_clip_rows_maps_values() -> None:
 
 
 @pytest.mark.asyncio
-async def test_latest_completed_run_id() -> None:
+async def test_recent_completed_runs_window_and_parse() -> None:
     captured: list[httpx.Request] = []
-    async with _fake_client(_LIST_ONE, {}, captured) as client:
-        assert await fetch_v2v.latest_completed_run_id(client, "a1") == "R1"
+    list_json = _list_json(
+        {"run_id": "R3", "create_time": _iso(timedelta(hours=1))},
+        {
+            "run_id": "R2",
+            "create_time": _iso(timedelta(hours=4)),
+            "error_status": "EXECUTION_FAILURE",
+        },
+        {"run_id": "R1", "create_time": _iso(timedelta(days=3))},  # outside the window
+        {"run_id": "R0"},  # no create_time -> kept
+    )
+    async with _fake_client(list_json, {}, captured) as client:
+        runs = await fetch_v2v.recent_completed_runs(client, "a1")
+
     filter_expr = captured[0].url.params["filter"]
     assert 'status="COMPLETED"' in filter_expr
     assert 'agent_id="a1"' in filter_expr
+    assert [r.run_id for r in runs] == ["R3", "R2", "R0"]
+    assert runs[1].error_status == "EXECUTION_FAILURE"
+    assert runs[0].error_status is None
+    assert runs[2].create_time is None
 
     async with _fake_client({"runs": []}, {}) as client:
-        assert await fetch_v2v.latest_completed_run_id(client, "a1") is None
+        assert await fetch_v2v.recent_completed_runs(client, "a1") == []
 
 
 @pytest.mark.asyncio
-async def test_fetch_one_provider_succeeded() -> None:
+async def test_ingest_run_slots_by_create_time() -> None:
     writer = _stub_writer()
+    created = datetime(2026, 7, 7, 1, 15, tzinfo=UTC)
     values = [{"simulation_output_id": f"s{i}", "value": 0.5} for i in range(3)]
-    async with _fake_client(_LIST_ONE, _run_json(values)) as client:
-        status = await fetch_v2v._fetch_one_provider(
+    async with _fake_client({}, _run_json(values)) as client:
+        status = await fetch_v2v._ingest_run(
             client,
             writer,
             spec=SPEC,
-            agent_id="a1",
+            coval_run=CovalRun(run_id="R1", create_time=created, error_status=None),
             metric_id="MID",
             runner_sha="test",
-            scheduled_at=SLOT,
             period_seconds=10_800,
         )
     assert status is RunStatus.SUCCEEDED
+    assert writer.start_run.await_args.kwargs["scheduled_at"] == datetime(2026, 7, 7, 0, tzinfo=UTC)
     writer.record_results.assert_awaited_once()
     writer.refresh_bucket.assert_awaited_once()
     assert writer.finish_run.await_args.kwargs["status"] is RunStatus.SUCCEEDED
 
 
 @pytest.mark.asyncio
-async def test_fetch_one_provider_partial() -> None:
+async def test_ingest_run_partial_and_failed() -> None:
     writer = _stub_writer()
-    values: list[dict[str, Any]] = [
+    mixed: list[dict[str, Any]] = [
         {"simulation_output_id": "s1", "value": 0.5},
         {"simulation_output_id": "s2", "value": None},
     ]
-    async with _fake_client(_LIST_ONE, _run_json(values)) as client:
-        status = await fetch_v2v._fetch_one_provider(
+    run = CovalRun(run_id="R1", create_time=None, error_status=None)
+    async with _fake_client({}, _run_json(mixed)) as client:
+        status = await fetch_v2v._ingest_run(
             client,
             writer,
             spec=SPEC,
-            agent_id="a1",
+            coval_run=run,
             metric_id="MID",
             runner_sha="test",
-            scheduled_at=SLOT,
             period_seconds=10_800,
         )
     assert status is RunStatus.PARTIAL
 
-
-@pytest.mark.asyncio
-async def test_fetch_one_provider_no_run_failed() -> None:
     writer = _stub_writer()
-    async with _fake_client({"runs": []}, {}) as client:
-        status = await fetch_v2v._fetch_one_provider(
+    all_null: list[dict[str, Any]] = [{"simulation_output_id": "s1", "value": None}]
+    async with _fake_client({}, _run_json(all_null)) as client:
+        status = await fetch_v2v._ingest_run(
             client,
             writer,
             spec=SPEC,
-            agent_id="a1",
+            coval_run=run,
             metric_id="MID",
             runner_sha="test",
-            scheduled_at=SLOT,
             period_seconds=10_800,
         )
     assert status is RunStatus.FAILED
-    writer.record_results.assert_not_awaited()
     writer.refresh_bucket.assert_not_awaited()
 
 
 @pytest.mark.asyncio
-async def test_fetch_one_provider_skips_already_ingested_run() -> None:
+async def test_ingest_run_skips_before_any_write() -> None:
+    # Errored detail (reconciler zombie): skipped, no run row created.
     writer = _stub_writer()
-    writer.coval_run_ingested = AsyncMock(return_value=True)  # run already in the DB
-    async with _fake_client(_LIST_ONE, _run_json([])) as client:
-        status = await fetch_v2v._fetch_one_provider(
-            client,
-            writer,
-            spec=SPEC,
-            agent_id="a1",
-            metric_id="MID",
-            runner_sha="test",
-            scheduled_at=SLOT,
-            period_seconds=10_800,
+    run = CovalRun(run_id="R1", create_time=None, error_status=None)
+    async with _fake_client({}, _run_json([], error_status="EXECUTION_FAILURE")) as client:
+        assert (
+            await fetch_v2v._ingest_run(
+                client,
+                writer,
+                spec=SPEC,
+                coval_run=run,
+                metric_id="MID",
+                runner_sha="test",
+                period_seconds=10_800,
+            )
+            is None
         )
-    assert status is RunStatus.SUCCEEDED  # no-op: last good data left in place
     writer.start_run.assert_not_awaited()
-    writer.record_results.assert_not_awaited()
-    writer.refresh_bucket.assert_not_awaited()
+
+    # Metric absent: skipped, no run row created.
+    writer = _stub_writer()
+    async with _fake_client({}, _run_json([], metric_id="OTHER")) as client:
+        assert (
+            await fetch_v2v._ingest_run(
+                client,
+                writer,
+                spec=SPEC,
+                coval_run=run,
+                metric_id="MID",
+                runner_sha="test",
+                period_seconds=10_800,
+            )
+            is None
+        )
+    writer.start_run.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_fetch_one_provider_ingests_every_new_run() -> None:
+    writer = _stub_writer()
+    writer.start_run = AsyncMock(
+        side_effect=[
+            Run(
+                id=i,
+                runner_sha="t",
+                dataset_id="s2s-v1",
+                dataset_sha256="x",
+                status=RunStatus.RUNNING,
+            )
+            for i in (1, 2)
+        ]
+    )
+    list_json = _list_json(
+        {"run_id": "R2", "create_time": _iso(timedelta(hours=1))},
+        {"run_id": "R1", "create_time": _iso(timedelta(hours=4))},
+    )
+    values = [{"simulation_output_id": "s1", "value": 0.5}]
+    async with _fake_client(list_json, _run_json(values)) as client:
+        status, ingested = await _fetch(client, writer)
+
+    assert (status, ingested) == (RunStatus.SUCCEEDED, 2)
+    assert writer.start_run.await_count == 2
+    written = [c.args[0][0].audio_filename for c in writer.record_results.await_args_list]
+    assert written == ["R2/s1", "R1/s1"]
+
+
+@pytest.mark.asyncio
+async def test_fetch_one_provider_noop_when_fresh() -> None:
+    writer = _stub_writer()
+    writer.coval_run_ingested = AsyncMock(return_value=True)
+    list_json = _list_json({"run_id": "R1", "create_time": _iso(timedelta(hours=2))})
+    async with _fake_client(list_json, {}) as client:
+        status, ingested = await _fetch(client, writer)
+    assert (status, ingested) == (RunStatus.SUCCEEDED, 0)
+    writer.start_run.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_fetch_one_provider_stale_fails() -> None:
+    # Newest usable run is older than period + grace (4.5h) -> stale.
+    writer = _stub_writer()
+    writer.coval_run_ingested = AsyncMock(return_value=True)
+    list_json = _list_json({"run_id": "R1", "create_time": _iso(timedelta(hours=6))})
+    async with _fake_client(list_json, {}) as client:
+        status, ingested = await _fetch(client, writer)
+    assert (status, ingested) == (RunStatus.FAILED, 0)
+
+    # No usable runs at all -> stale.
+    writer = _stub_writer()
+    async with _fake_client({"runs": []}, {}) as client:
+        status, ingested = await _fetch(client, writer)
+    assert (status, ingested) == (RunStatus.FAILED, 0)
+
+
+@pytest.mark.asyncio
+async def test_fetch_one_provider_skips_errored_ingests_older_clean() -> None:
+    # Newest run errored (summary view): skip it, ingest the older clean one.
+    writer = _stub_writer()
+    list_json = _list_json(
+        {
+            "run_id": "R2",
+            "create_time": _iso(timedelta(hours=1)),
+            "error_status": "EXECUTION_FAILURE",
+        },
+        {"run_id": "R1", "create_time": _iso(timedelta(hours=4))},
+    )
+    values = [{"simulation_output_id": "s1", "value": 0.5}]
+    async with _fake_client(list_json, {"R1": _run_json(values)}, None) as client:
+        status, ingested = await _fetch(client, writer)
+
+    assert (status, ingested) == (RunStatus.SUCCEEDED, 1)
+    written = [c.args[0][0].audio_filename for c in writer.record_results.await_args_list]
+    assert written == ["R1/s1"]
 
 
 @pytest.mark.asyncio
@@ -191,8 +334,9 @@ async def test_fetch_and_write_v2v_per_provider(monkeypatch: pytest.MonkeyPatch)
     )
 
     writer = _stub_writer()
+    list_json = _list_json({"run_id": "R1", "create_time": _iso(timedelta(hours=1))})
     values = [{"simulation_output_id": f"s{i}", "value": 0.5} for i in range(2)]
-    client = _fake_client(_LIST_ONE, _run_json(values))
+    client = _fake_client(list_json, _run_json(values))
 
     @contextlib.asynccontextmanager
     async def _fake_pool(_settings: Any) -> AsyncIterator[MagicMock]:
@@ -207,3 +351,33 @@ async def test_fetch_and_write_v2v_per_provider(monkeypatch: pytest.MonkeyPatch)
     # only openai runs (gemini unset), and it fully succeeds.
     assert statuses == {"openai": RunStatus.SUCCEEDED}
     writer.refresh_stats_matviews.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_fetch_and_write_v2v_noop_skips_matview_refresh(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("COVAL_S2S_GEMINI_AGENT_ID", raising=False)
+    settings = Settings(
+        runner_sha="test",
+        coval_s2s_latency_metric_id="MID",
+        coval_s2s_openai_agent_id="a1",
+    )
+
+    writer = _stub_writer()
+    writer.coval_run_ingested = AsyncMock(return_value=True)  # nothing new this tick
+    list_json = _list_json({"run_id": "R1", "create_time": _iso(timedelta(hours=1))})
+    client = _fake_client(list_json, {})
+
+    @contextlib.asynccontextmanager
+    async def _fake_pool(_settings: Any) -> AsyncIterator[MagicMock]:
+        yield MagicMock()
+
+    monkeypatch.setattr(fetch_v2v, "_client", lambda _s: client)
+    monkeypatch.setattr(fetch_v2v, "lifespan_pool", _fake_pool)
+    monkeypatch.setattr(fetch_v2v, "RunWriter", lambda _pool: writer)
+
+    statuses = await fetch_v2v.fetch_and_write_v2v(settings)
+
+    assert statuses == {"openai": RunStatus.SUCCEEDED}
+    writer.refresh_stats_matviews.assert_not_awaited()


### PR DESCRIPTION
The fetch read only each provider's newest completed Coval run and silently skipped it when already ingested, so a paused schedule or a stuck sim left the dashboard frozen with no signal. Each tick now scans the recent window (two fetch periods, floored at one day), ingests every clean not-yet-ingested run slotted by its create_time on the fetch grid, and never ingests runs finalized with an error_status. A provider whose newest usable run is older than the fetch period (plus an optional grace, default zero) is reported FAILED, which flows into the existing RUN_FAILED log alert — a missed sim round at the daily cadence gets flagged on the next fetch instead of going unnoticed. Also adds unit tests for the fetch module, which had none.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes the S2S Coval fetch scan recent runs and report stale providers. The main changes are:

- Adds a configurable stale grace period.
- Ingests recent clean runs instead of only the newest completed run.
- Slots ingested runs by Coval `create_time`.
- Skips runs finalized with an error status.
- Adds unit tests for the S2S fetch path.

<h3>Confidence Score: 4/5</h3>

This is close, but the paginated fetch path should be fixed before merging.

- The stale backfill and missing timestamp cases now fail closed.
- The runs scan still stops after the first page, so valid recent runs can be skipped.
- The new tests cover freshness behavior, but they only model single-page responses.

runner/src/coval_bench/s2s/fetch_v2v.py

<sub>Reviews (2): Last reviewed commit: ["Let staleness override backfill-only and..."](https://github.com/coval-ai/benchmarks/commit/5625f3ba7a301b198add7b84734e4aa880405bdc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44226651)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->