### PR TITLE
Activate the S2S models

### DIFF
--- a/runner/src/coval_bench/registries/models.py
+++ b/runner/src/coval_bench/registries/models.py
@@ -675,27 +675,27 @@ MODEL_REGISTRY: list[RegisteredModel] = [
     # S2S #
     #######
     # S2S realtime models. Numbers are fetched daily from Coval (no local
-    # provider client). PENDING until the first run lands data.
+    # provider client).
     RegisteredModel(
         benchmark=_S2S,
         provider="openai",
         model="gpt-realtime",
         tags=(_REALTIME, _MULTI),
-        status=_PENDING,
+        status=_ACTIVE,
     ),
     RegisteredModel(
         benchmark=_S2S,
         provider="google",
         model="gemini-live",
         tags=(_REALTIME, _MULTI),
-        status=_PENDING,
+        status=_ACTIVE,
     ),
     RegisteredModel(
         benchmark=_S2S,
         provider="xai",
         model="grok-realtime",
         tags=(_REALTIME, _MULTI),
-        status=_PENDING,
+        status=_ACTIVE,
     ),
 ]
 


### PR DESCRIPTION
The three S2S realtime models (gpt-realtime, gemini-live, grok-realtime) have been ingesting daily data since July 10 and were registered PENDING so they stayed hidden while the pipeline proved out. This flips them ACTIVE so `/v1/providers` serves them and the dashboard can render them. The `/s2s` page itself stays gated behind `NEXT_PUBLIC_S2S_ENABLED`, so nothing becomes publicly visible from this change alone.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR enables the existing S2S realtime models in the model registry. The main changes are:

- Marks `gpt-realtime` as active.
- Marks `gemini-live` as active.
- Marks `grok-realtime` as active.
- Removes the outdated pending-status comment.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- The status changes intentionally make the three models enabled in provider discovery.
- The S2S ingestion path already uses the same model identifiers independently of registry status.
- No blocking issues were found in the changed code.

<sub>Reviews (1): Last reviewed commit: ["Activate the S2S models"](https://github.com/coval-ai/benchmarks/commit/be79ff2cb08b0d1a89c98da11bfa0a4748e80376) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44255456)</sub>

<!-- /greptile_comment -->