### PR TITLE
Enable Azure, Inworld, Alibaba, and MiniMax in the arena

### DIFF
--- a/runner/scripts/check_arena_keys.py
+++ b/runner/scripts/check_arena_keys.py
@@ -1,11 +1,15 @@
 # Copyright 2026 The Coval Benchmarks Authors
 # SPDX-License-Identifier: Apache-2.0
-"""Assert every arena-eligible TTS provider's API key is mounted on benchmarks-api.
+"""Assert arena roster and benchmarks-api key mounts agree, in both directions.
 
 Reads the ``coval-ai/benchmark-infra`` Cloud Run service module (passed as a
 path; the CI workflow fetches it) and structurally extracts the env-var names it
 mounts from Secret Manager. Fails if any provider the arena would synthesize
-lacks its key on the service — the cross-repo parity gate.
+lacks its key on the service (the cross-repo parity gate), and also fails when
+an ACTIVE provider is opted out with ``arena_enabled=False`` even though its key
+IS mounted — a stale opt-out that silently keeps the provider off the arena.
+Opted-out providers without a ``PROVIDER_ENV`` mapping (e.g. ADC-authenticated
+ones) are skipped: there is no key mount to check them against.
 
 Usage: python scripts/check_arena_keys.py <path-to-cloud_run_service/main.tf>
 """
@@ -17,6 +21,8 @@ import sys
 import hcl2
 
 from coval_bench.arena.pairing import active_tts_models
+from coval_bench.registries.benchmarks import Benchmark
+from coval_bench.registries.models import MODEL_REGISTRY, ModelStatus
 from coval_bench.registries.provider_keys import PROVIDER_ENV
 
 
@@ -76,6 +82,25 @@ def main(tf_path: str) -> int:
             "(modules/cloud_run_service/main.tf env{} block + "
             "envs/prod/cloud_run_service.tf secret_ids + the secret_manager secret), "
             "then re-run this check."
+        )
+        return 1
+
+    stale_opt_outs = sorted(
+        {
+            m.provider
+            for m in MODEL_REGISTRY
+            if m.benchmark is Benchmark.TTS
+            and m.status is ModelStatus.ACTIVE
+            and not m.arena_enabled
+            and PROVIDER_ENV.get(m.provider) in mounted
+        }
+    )
+    if stale_opt_outs:
+        print(
+            f"ERROR: key mounted on benchmarks-api but arena_enabled=False: {stale_opt_outs}\n"
+            "The opt-out is stale — remove arena_enabled=False from these providers' "
+            "ACTIVE models in registries/models.py (or unmount the key if the "
+            "exclusion is intentional)."
         )
         return 1
 

--- a/runner/src/coval_bench/registries/models.py
+++ b/runner/src/coval_bench/registries/models.py
@@ -511,7 +511,6 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         tags=(_REALTIME, _MULTI, _CLONE, _EMOTION, _STREAM),
         self_hostable=True,
         status=_ACTIVE,
-        arena_enabled=False,
     ),
     RegisteredModel(
         benchmark=_TTS,
@@ -521,7 +520,6 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         tags=(_REALTIME, _MULTI, _CLONE, _EMOTION, _STREAM),
         self_hostable=True,
         status=_ACTIVE,
-        arena_enabled=False,
     ),
     RegisteredModel(
         benchmark=_TTS,
@@ -542,7 +540,6 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         creator="microsoft",
         tags=(_REALTIME, _MULTI, _EMOTION, _STREAM),
         status=_ACTIVE,
-        arena_enabled=False,
     ),
     RegisteredModel(
         benchmark=_TTS,
@@ -552,7 +549,6 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         creator="microsoft",
         tags=(_REALTIME, _MULTI, _STREAM),
         status=_ACTIVE,
-        arena_enabled=False,
     ),
     RegisteredModel(
         benchmark=_TTS,
@@ -607,7 +603,6 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         voice="Cherry",
         tags=(_REALTIME, _MULTI, _STREAM),
         status=_ACTIVE,
-        arena_enabled=False,
     ),
     # Fish Audio. Voice is the benchmark-selected speaker used in Fish Audio docs.
     RegisteredModel(
@@ -642,7 +637,6 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         voice="English_expressive_narrator",
         tags=(_REALTIME, _MULTI, _CLONE, _EMOTION, _STREAM),
         status=_ACTIVE,
-        arena_enabled=False,
     ),
     RegisteredModel(
         benchmark=_TTS,
@@ -651,7 +645,6 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         voice="English_expressive_narrator",
         tags=(_REALTIME, _MULTI, _CLONE, _EMOTION, _STREAM),
         status=_ACTIVE,
-        arena_enabled=False,
     ),
     # gpt-realtime is a speech-to-speech LLM, not a TTS provider: driving it
     # from a text "instructions" prompt folds LLM inference into TTFA and never

--- a/runner/src/coval_bench/registries/provider_keys.py
+++ b/runner/src/coval_bench/registries/provider_keys.py
@@ -30,6 +30,7 @@ PROVIDER_ENV: dict[str, str] = {
     "smallest": "SMALLEST_API_KEY",
     "soniox": "SONIOX_API_KEY",
     "inworld": "INWORLD_API_KEY",
+    "azure": "AZURE_API_KEY",
     "groq": "GROQ_API_KEY",
     "baseten": "BASETEN_API_KEY",
     "fishaudio": "FISHAUDIO_API_KEY",


### PR DESCRIPTION
Their keys are now mounted on benchmarks-api, so the arena_enabled opt-outs are stale. Extend check_arena_keys.py to fail on exactly that state, key mounted but provider still opted out,  so future flips aren't forgotten. Google stays out: ADC auth, no mountable key.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR expands the TTS arena roster and tightens the key parity check.

- Adds a reverse check for mounted keys with stale arena opt-outs.
- Enables several Azure, Inworld, Alibaba, Fish Audio, and MiniMax TTS models.
- Adds Azure to the provider API-key registry.

<h3>Confidence Score: 4/5</h3>

Azure arena battles can fail when the API key is mounted but the Azure region is not configured.

- The new roster path can select Azure TTS models.
- The Azure TTS provider requires `azure_region` during construction.
- The updated parity check only verifies provider API-key mounts, so it can miss this required runtime setting.

runner/src/coval_bench/registries/models.py

<sub>Reviews (1): Last reviewed commit: ["Enable Azure, Inworld, Alibaba, and Mini..."](https://github.com/coval-ai/benchmarks/commit/1349921c8ef890b7d7e40ca133169582416ceb29) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44257860)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->