### PR TITLE
Add Palabra TTS streaming provider

### DIFF
--- a/runner/src/coval_bench/config.py
+++ b/runner/src/coval_bench/config.py
@@ -84,6 +84,7 @@ class Settings(BaseSettings):
     azure_api_key: SecretStr | None = None
     alibaba_api_key: SecretStr | None = None
     minimax_api_key: SecretStr | None = None
+    palabra_api_key: SecretStr | None = None
 
     # Azure region hosting the Speech resource (e.g. "eastus"). Determines the
     # region-scoped WebSocket host; required only when the Azure STT provider runs.

--- a/runner/src/coval_bench/providers/tts/__init__.py
+++ b/runner/src/coval_bench/providers/tts/__init__.py
@@ -27,6 +27,7 @@ from coval_bench.providers.tts.groq import GroqTTSProvider
 from coval_bench.providers.tts.inworld import InworldTTSProvider
 from coval_bench.providers.tts.minimax import MinimaxTTSProvider
 from coval_bench.providers.tts.openai import OpenAITTSProvider
+from coval_bench.providers.tts.palabra import PalabraTTSProvider
 from coval_bench.providers.tts.rime import RimeTTSProvider
 from coval_bench.providers.tts.smallest import SmallestTTSProvider
 from coval_bench.providers.tts.soniox import SonioxTTSProvider
@@ -63,6 +64,7 @@ TTS_PROVIDERS: dict[str, type[TTSProvider]] = {
     "fishaudio": FishAudioTTSProvider,
     "alibaba": AlibabaTTSProvider,
     "minimax": MinimaxTTSProvider,
+    "palabra": PalabraTTSProvider,
 }
 
 if HumeTTSProvider is not None:
@@ -85,4 +87,5 @@ __all__ = [
     "XaiTTSProvider",
     "GroqTTSProvider",
     "SonioxTTSProvider",
+    "PalabraTTSProvider",
 ]

--- a/runner/src/coval_bench/providers/tts/palabra.py
+++ b/runner/src/coval_bench/providers/tts/palabra.py
@@ -55,7 +55,10 @@ class PalabraTTSProvider(TTSProvider):
     async def _get_session_token(self) -> str:
         """POST /session-storage/session -> the session auth token."""
         async with httpx.AsyncClient(timeout=5.0) as client:
-            client_id, client_secret = self._api_key.split("_")
+            try:
+                client_id, client_secret = self._api_key.split("_", 1)
+            except ValueError as exc:
+                raise ValueError("palabra_api_key must be '<client_id>_<client_secret>'") from exc
             resp = await client.post(
                 _SESSION_URL,
                 headers={"ClientID": client_id, "ClientSecret": client_secret},
@@ -106,7 +109,7 @@ class PalabraTTSProvider(TTSProvider):
                         continue
                     event: dict[str, Any] = json.loads(raw)
 
-                    data: dict[str, Any] = event.get("data", {})
+                    data: dict[str, Any] = event.get("data") or {}
 
                     if event.get("message_type") == "error":
                         raise RuntimeError(f"{data.get('code')}: {data.get('desc')}")

--- a/runner/src/coval_bench/providers/tts/palabra.py
+++ b/runner/src/coval_bench/providers/tts/palabra.py
@@ -109,7 +109,8 @@ class PalabraTTSProvider(TTSProvider):
                         continue
                     event: dict[str, Any] = json.loads(raw)
 
-                    data: dict[str, Any] = event.get("data") or {}
+                    data_raw = event.get("data")
+                    data: dict[str, Any] = data_raw if isinstance(data_raw, dict) else {}
 
                     if event.get("message_type") == "error":
                         raise RuntimeError(f"{data.get('code')}: {data.get('desc')}")

--- a/runner/src/coval_bench/providers/tts/palabra.py
+++ b/runner/src/coval_bench/providers/tts/palabra.py
@@ -1,0 +1,149 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Palabra real-time TTS streaming provider."""
+
+from __future__ import annotations
+
+import base64
+import json
+import time
+from typing import Any
+from uuid import uuid4
+
+import httpx
+import structlog
+import websockets.asyncio.client as ws_client
+
+from coval_bench.config import Settings
+from coval_bench.providers.base import TTSProvider, TTSResult
+from coval_bench.providers.tts._common import finalize_tts_result
+
+logger: structlog.BoundLogger = structlog.get_logger(__name__)
+
+_VALID_MODELS = ("palabra-tts-v1",)
+_VALID_VOICES = ("default_low", "default_high")
+_SESSION_URL = "https://api.palabra.ai/session-storage/session"
+_WS_URL = "wss://stream.us.palabra.ai/tts-api/v1/text-to-speech/stream"
+_SAMPLE_RATE = 24000
+
+
+class PalabraTTSProvider(TTSProvider):
+    """Palabra TTS provider using WebSocket streaming (JSON frames, base64 audio)."""
+
+    def __init__(self, settings: Settings, model: str, voice: str) -> None:
+        if model not in _VALID_MODELS:
+            raise ValueError(f"Invalid Palabra TTS model {model!r}. Valid: {_VALID_MODELS}")
+        if voice not in _VALID_VOICES:
+            raise ValueError(f"Invalid Palabra TTS voice {voice!r}. Valid: {_VALID_VOICES}")
+        self._model = model
+        self._voice = voice
+
+        api_key_secret = settings.palabra_api_key
+        if api_key_secret is None:
+            raise ValueError("palabra_api_key is required in Settings")
+        self._api_key = api_key_secret.get_secret_value()
+
+    @property
+    def name(self) -> str:
+        return "palabra"
+
+    @property
+    def model(self) -> str:
+        return self._model
+
+    async def _get_session_token(self) -> str:
+        """POST /session-storage/session -> the session auth token."""
+        async with httpx.AsyncClient(timeout=5.0) as client:
+            client_id, client_secret = self._api_key.split("_")
+            resp = await client.post(
+                _SESSION_URL,
+                headers={"ClientID": client_id, "ClientSecret": client_secret},
+                json={"data": {}},
+            )
+            resp.raise_for_status()
+            token: str = resp.json()["data"]["publisher"]
+        return token
+
+    async def synthesize(self, text: str) -> TTSResult:
+        audio_chunks: list[bytes] = []
+        start: float | None = None
+        first_chunk_at: float | None = None
+
+        try:
+            # Pre-t0: get auth token
+            token = await self._get_session_token()
+
+            async with ws_client.connect(f"{_WS_URL}?token={token}") as ws:
+                # Pre-t0: session init
+                await ws.send(
+                    json.dumps(
+                        {
+                            "type": "init",
+                            "language": "en",
+                            "model": self._model,
+                            "voice_options": {"voice_id": self._voice},
+                            "output": {"format": "pcm", "sample_rate": _SAMPLE_RATE},
+                        }
+                    )
+                )
+
+                start = time.monotonic()
+                generation_id = f"coval_{uuid4().hex}"
+                await ws.send(
+                    json.dumps(
+                        {
+                            "type": "text",
+                            "text": text,
+                            "generation_id": generation_id,
+                            "is_eos": True,
+                        }
+                    )
+                )
+
+                async for raw in ws:
+                    if isinstance(raw, bytes):
+                        continue
+                    event: dict[str, Any] = json.loads(raw)
+
+                    data: dict[str, Any] = event.get("data", {})
+
+                    if event.get("message_type") == "error":
+                        raise RuntimeError(f"{data.get('code')}: {data.get('desc')}")
+
+                    if event.get("message_type") != "audio_chunk":
+                        continue
+
+                    audio_b64: str = data.get("audio", "")
+                    if audio_b64:
+                        chunk = base64.b64decode(audio_b64)
+                        if chunk:
+                            if first_chunk_at is None:
+                                first_chunk_at = time.monotonic()
+                            audio_chunks.append(chunk)
+
+                    if data.get("last_chunk"):
+                        break
+
+        except Exception as exc:
+            logger.warning("palabra_tts_error", provider="palabra", model=self._model, exc_info=exc)
+            return finalize_tts_result(
+                provider="palabra",
+                model=self._model,
+                voice=self._voice,
+                pcm=b"",
+                sample_rate=_SAMPLE_RATE,
+                audio_synthesis_start=start,
+                first_audio_chunk_at=first_chunk_at,
+                error=str(exc),
+            )
+
+        return finalize_tts_result(
+            provider="palabra",
+            model=self._model,
+            voice=self._voice,
+            pcm=b"".join(audio_chunks),
+            sample_rate=_SAMPLE_RATE,
+            audio_synthesis_start=start,
+            first_audio_chunk_at=first_chunk_at,
+        )

--- a/runner/src/coval_bench/registries/models.py
+++ b/runner/src/coval_bench/registries/models.py
@@ -437,6 +437,14 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         tags=(_REALTIME, _MULTI, _CLONE, _STREAM),
         status=_ACTIVE,
     ),
+    RegisteredModel(
+        benchmark=_TTS,
+        provider="palabra",
+        model="palabra-tts-v1",
+        voice="default_low",
+        tags=(_REALTIME, _MULTI, _CLONE, _STREAM),
+        status=_PENDING,
+    ),
     # Rime — all three on /ws3 WebSocket.
     # "arcana" resolves server-side to Arcana v3; "coda" to May 2026 flagship.
     RegisteredModel(

--- a/runner/src/coval_bench/registries/provider_keys.py
+++ b/runner/src/coval_bench/registries/provider_keys.py
@@ -35,4 +35,5 @@ PROVIDER_ENV: dict[str, str] = {
     "fishaudio": "FISHAUDIO_API_KEY",
     "alibaba": "ALIBABA_API_KEY",
     "minimax": "MINIMAX_API_KEY",
+    "palabra": "PALABRA_API_KEY",
 }


### PR DESCRIPTION
WebSocket streaming provider for palabra-tts-v1, registered pending until the prod key is mounted.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a pending Palabra TTS streaming provider. The main changes are:

- New Palabra provider using session-token auth and WebSocket audio streaming.
- Settings and provider-key wiring for `PALABRA_API_KEY`.
- TTS provider registration for `palabra`.
- Pending registry entry for `palabra-tts-v1`.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<sub>Reviews (3): Last reviewed commit: ["Tolerate scalar data fields in Palabra s..."](https://github.com/coval-ai/benchmarks/commit/42e7c83d07bf94bde63f555f039313d61012dc57) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44258663)</sub>

<!-- /greptile_comment -->