### PR TITLE
Add the dataset dimension to aggregates

### DIFF
--- a/runner/src/coval_bench/api/common.py
+++ b/runner/src/coval_bench/api/common.py
@@ -14,10 +14,6 @@ from typing import Literal
 BenchmarkLiteral = Literal["STT", "TTS", "S2S"]
 WindowLiteral = Literal["24h", "7d", "30d"]
 
-# Sentinel dataset_id under which the matviews and results_by_bucket
-# materialize the pooled (all-datasets) rows.
-DATASET_ALL = "__all__"
-
 # Fixed interval strings — looked up by Python, never user-interpolated into
 # SQL. Used by live queries (the aggregates series block).
 WINDOW_INTERVALS: dict[str, str] = {

--- a/runner/src/coval_bench/api/common.py
+++ b/runner/src/coval_bench/api/common.py
@@ -14,6 +14,10 @@ from typing import Literal
 BenchmarkLiteral = Literal["STT", "TTS", "S2S"]
 WindowLiteral = Literal["24h", "7d", "30d"]
 
+# Sentinel dataset_id under which the matviews and results_by_bucket
+# materialize the pooled (all-datasets) rows.
+DATASET_ALL = "__all__"
+
 # Fixed interval strings — looked up by Python, never user-interpolated into
 # SQL. Used by live queries (the aggregates series block).
 WINDOW_INTERVALS: dict[str, str] = {

--- a/runner/src/coval_bench/api/routers/aggregates.py
+++ b/runner/src/coval_bench/api/routers/aggregates.py
@@ -34,7 +34,6 @@ from starlette.requests import Request
 
 from coval_bench.api.cache import get_or_fill
 from coval_bench.api.common import (
-    DATASET_ALL,
     WINDOW_INTERVALS,
     WINDOW_VIEWS,
     BenchmarkLiteral,
@@ -49,6 +48,7 @@ from coval_bench.api.deps import (
 )
 from coval_bench.api.ratelimit import limiter
 from coval_bench.api.schemas import AggregatesResponse, ModelStatEntry, SeriesPoint
+from coval_bench.config import DATASET_ALL
 from coval_bench.registries import is_metric_excluded
 
 logger = structlog.get_logger("coval_bench.api")

--- a/runner/src/coval_bench/api/routers/aggregates.py
+++ b/runner/src/coval_bench/api/routers/aggregates.py
@@ -34,6 +34,7 @@ from starlette.requests import Request
 
 from coval_bench.api.cache import get_or_fill
 from coval_bench.api.common import (
+    DATASET_ALL,
     WINDOW_INTERVALS,
     WINDOW_VIEWS,
     BenchmarkLiteral,
@@ -60,6 +61,7 @@ _STATS_SQL_TEMPLATE = (
     " min_value, max_value, sample_count"
     " FROM {view}"
     " WHERE benchmark = %(benchmark)s"
+    " AND dataset_id = %(dataset)s"
     " ORDER BY provider, model, metric_type"
 )
 
@@ -68,8 +70,15 @@ _SERIES_SQL = (
     " min_value, p25, p50, p75, max_value, value_sum, sample_count"
     " FROM benchmarks_v2.results_by_bucket"
     " WHERE benchmark = %(benchmark)s"
+    " AND dataset_id = %(dataset)s"
     " AND bucket_at >= NOW() - %(interval)s::interval"
     " ORDER BY bucket_at, provider, model, metric_type"
+)
+
+_DATASETS_SQL_TEMPLATE = (
+    "SELECT DISTINCT dataset_id FROM {view}"
+    " WHERE benchmark = %(benchmark)s AND dataset_id <> %(sentinel)s"
+    " ORDER BY dataset_id"
 )
 
 
@@ -79,6 +88,10 @@ async def get_results_aggregates(
     request: Request,  # required by slowapi
     benchmark: BenchmarkLiteral = Query(...),
     window: WindowLiteral = Query(default="24h"),
+    dataset: str | None = Query(
+        default=None,
+        description="Dataset id to aggregate over; omit for the pooled all-dataset blocks.",
+    ),
     pool: AsyncConnectionPool[Any] = Depends(get_pool),
     posthog_client: Posthog | None = Depends(get_posthog),
     cache: TTLCache[Any, Any] = Depends(get_cache),
@@ -90,23 +103,35 @@ async def get_results_aggregates(
         benchmark: One of STT, TTS.
         window: Time window — stats over results.created_at, series over
             bucket_at. Defaults to 24h.
+        dataset: Dataset id the blocks are computed over. Omitted, the pooled
+            rows (every dataset together) are served — the pre-dataset-dimension
+            behavior.
     """
+    dataset_key = dataset or DATASET_ALL
 
     async def fill() -> AggregatesResponse:
         stats_sql = _STATS_SQL_TEMPLATE.format(view=WINDOW_VIEWS[window])
+        datasets_sql = _DATASETS_SQL_TEMPLATE.format(view=WINDOW_VIEWS[window])
+        stats_params: dict[str, Any] = {"benchmark": benchmark, "dataset": dataset_key}
         series_params: dict[str, Any] = {
             "benchmark": benchmark,
+            "dataset": dataset_key,
             "interval": WINDOW_INTERVALS[window],
         }
 
         async with pool.connection() as conn:
             conn.row_factory = psycopg.rows.dict_row
-            stat_rows = await (await conn.execute(stats_sql, {"benchmark": benchmark})).fetchall()
+            stat_rows = await (await conn.execute(stats_sql, stats_params)).fetchall()
             series_rows = await (await conn.execute(_SERIES_SQL, series_params)).fetchall()
+            dataset_rows = await (
+                await conn.execute(datasets_sql, {"benchmark": benchmark, "sentinel": DATASET_ALL})
+            ).fetchall()
 
         return AggregatesResponse(
             benchmark=benchmark,
             window=window,
+            dataset=dataset_key,
+            datasets=[r["dataset_id"] for r in dataset_rows],
             model_stats=[
                 ModelStatEntry.model_validate(r)
                 for r in stat_rows
@@ -119,7 +144,7 @@ async def get_results_aggregates(
             ],
         )
 
-    cache_key = ("aggregates", benchmark, window)
+    cache_key = ("aggregates", benchmark, window, dataset_key)
     response, cache_status = await get_or_fill(cache, cache_locks, cache_key, fill)
 
     capture_api_event(
@@ -128,6 +153,7 @@ async def get_results_aggregates(
         {
             "benchmark": benchmark,
             "window": window,
+            "dataset": dataset_key,
             "model_stat_count": len(response.model_stats),
             "series_point_count": len(response.series),
             "cache_hit": cache_status != "miss",

--- a/runner/src/coval_bench/api/routers/leaderboard.py
+++ b/runner/src/coval_bench/api/routers/leaderboard.py
@@ -24,7 +24,7 @@ from posthog import Posthog
 from psycopg_pool import AsyncConnectionPool
 from starlette.requests import Request
 
-from coval_bench.api.common import WINDOW_VIEWS, BenchmarkLiteral, WindowLiteral
+from coval_bench.api.common import DATASET_ALL, WINDOW_VIEWS, BenchmarkLiteral, WindowLiteral
 from coval_bench.api.deps import capture_api_event, get_pool, get_posthog
 from coval_bench.api.ratelimit import limiter
 from coval_bench.api.schemas import LeaderboardEntry, LeaderboardResponse
@@ -54,6 +54,7 @@ _MV_SQL_TEMPLATE = """
     FROM {view}
     WHERE metric_type = %(metric)s
       AND benchmark = %(benchmark)s
+      AND dataset_id = %(dataset)s
     ORDER BY avg_value ASC
 """
 
@@ -88,7 +89,7 @@ async def get_leaderboard(
             f"Valid combinations: WER+STT, TTFT+STT, TTFS+STT, TTFA+TTS, V2V+S2S.",
         )
 
-    params: dict[str, Any] = {"metric": metric, "benchmark": benchmark}
+    params: dict[str, Any] = {"metric": metric, "benchmark": benchmark, "dataset": DATASET_ALL}
     sql = _MV_SQL_TEMPLATE.format(view=WINDOW_VIEWS[window])
 
     async with pool.connection() as conn:

--- a/runner/src/coval_bench/api/routers/leaderboard.py
+++ b/runner/src/coval_bench/api/routers/leaderboard.py
@@ -24,10 +24,11 @@ from posthog import Posthog
 from psycopg_pool import AsyncConnectionPool
 from starlette.requests import Request
 
-from coval_bench.api.common import DATASET_ALL, WINDOW_VIEWS, BenchmarkLiteral, WindowLiteral
+from coval_bench.api.common import WINDOW_VIEWS, BenchmarkLiteral, WindowLiteral
 from coval_bench.api.deps import capture_api_event, get_pool, get_posthog
 from coval_bench.api.ratelimit import limiter
 from coval_bench.api.schemas import LeaderboardEntry, LeaderboardResponse
+from coval_bench.config import DATASET_ALL
 from coval_bench.registries import is_metric_excluded
 
 logger = structlog.get_logger("coval_bench.api")

--- a/runner/src/coval_bench/api/schemas.py
+++ b/runner/src/coval_bench/api/schemas.py
@@ -167,11 +167,15 @@ class AggregatesResponse(BaseModel):
     """Response schema for GET /v1/results/aggregates.
 
     Wraps and returns all our ModelStatEntry and SeriesPoint data for a time
-    window.
+    window. ``dataset`` echoes the dataset the blocks were computed over
+    ('__all__' = pooled across datasets); ``datasets`` lists the dataset ids
+    with data in the window.
     """
 
     benchmark: BenchmarkLiteral
     window: WindowLiteral
+    dataset: str
+    datasets: list[str]
     model_stats: list[ModelStatEntry]
     series: list[SeriesPoint]
 

--- a/runner/src/coval_bench/config.py
+++ b/runner/src/coval_bench/config.py
@@ -14,8 +14,11 @@ import functools
 from pathlib import Path
 from typing import Literal
 
-from pydantic import Field, SecretStr
+from pydantic import Field, SecretStr, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+# Reserved: the aggregation layer materializes pooled rows under this sentinel.
+DATASET_ALL = "__all__"
 
 
 class Settings(BaseSettings):
@@ -44,6 +47,13 @@ class Settings(BaseSettings):
     # --- Dataset ---
     dataset_bucket: str = "coval-benchmarks-datasets"
     dataset_id: str = "stt-v1"
+
+    @field_validator("dataset_id")
+    @classmethod
+    def _dataset_id_not_reserved(cls, value: str) -> str:
+        if value == DATASET_ALL:
+            raise ValueError(f"dataset_id {DATASET_ALL!r} is reserved for pooled aggregates")
+        return value
 
     # Items drawn at random per run from each manifest, shared across all
     # models for parity. Set >= manifest size to run everything.

--- a/runner/src/coval_bench/datasets/scripts/framework.py
+++ b/runner/src/coval_bench/datasets/scripts/framework.py
@@ -28,6 +28,8 @@ from typing import TYPE_CHECKING
 import soundfile as sf
 import structlog
 
+from coval_bench.config import DATASET_ALL
+
 if TYPE_CHECKING:
     import google.cloud.storage as _gcs_storage
 
@@ -279,6 +281,8 @@ def _write_manifest(json_text: str, dataset_id: str) -> Path:
     """Write the manifest to the packaged ``<dataset_id>.json``."""
     if not re.fullmatch(r"[A-Za-z0-9._-]+", dataset_id):
         raise ValueError(f"invalid dataset_id {dataset_id!r}: use letters, digits, '.', '_', '-'")
+    if dataset_id == DATASET_ALL:
+        raise ValueError(f"dataset_id {DATASET_ALL!r} is reserved for pooled aggregates")
     pkg = impres.files("coval_bench.datasets.manifests")
     dest = Path(str(pkg.joinpath(f"{dataset_id}.json")))
     dest.write_text(json_text, encoding="utf-8")

--- a/runner/src/coval_bench/db/migrations/versions/20260715_0010_dataset_dim_in_aggregates.py
+++ b/runner/src/coval_bench/db/migrations/versions/20260715_0010_dataset_dim_in_aggregates.py
@@ -1,0 +1,228 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Add the dataset dimension to the stats matviews and the series rollup.
+
+The per-window matviews (results_24h/7d/30d) and results_by_bucket grouped by
+(provider, model, benchmark, metric_type) only, pooling every dataset into one
+row. Both now carry ``dataset_id`` and materialize two granularities via
+GROUPING SETS: one row per dataset, plus a pooled row under the ``'__all__'``
+sentinel that reproduces the previous numbers exactly (pooled percentiles are
+not derivable from per-dataset percentiles, so both must be materialized).
+
+Dataset attribution joins through runs, with TTS rows pinned to ``tts-v1``:
+a 'both' run's row records only the STT dataset id, and historical TTS-only
+runs recorded the env default.
+
+The sentinel is a literal (not NULL) so each matview keeps a plain-column
+unique index, which REFRESH MATERIALIZED VIEW CONCURRENTLY requires.
+
+results_by_bucket is dropped and rebuilt from raw results with ``dataset_id``
+in the primary key. Migrations deploy separately from images, so rerun the
+backfill (truncate + the ``upgrade`` insert-select) once the new image is
+live. Same recovery if the table ever drifts from ``results``.
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "20260715_0010"
+down_revision = "20260707_0009"
+branch_labels = None
+depends_on = None
+
+_WINDOWS: dict[str, str] = {
+    "results_24h": "24 hours",
+    "results_7d": "7 days",
+    "results_30d": "30 days",
+}
+
+_DATASET_CASE = "CASE WHEN r.benchmark = 'TTS' THEN 'tts-v1' ELSE rn.dataset_id END"
+
+# Settings.schedule_period_seconds default; only used for legacy rows with a
+# null scheduled_at.
+_SCHEDULE_PERIOD_SECONDS = 1800
+
+_BUCKET_EXPR = f"""COALESCE(
+    rn.scheduled_at,
+    to_timestamp(
+        floor(extract(epoch FROM r.created_at) / {_SCHEDULE_PERIOD_SECONDS})
+        * {_SCHEDULE_PERIOD_SECONDS}
+    )
+)"""
+
+
+def _view_sql(name: str, interval: str) -> str:
+    # S608 false-positive: interpolations come from module constants.
+    return f"""
+        CREATE MATERIALIZED VIEW benchmarks_v2.{name} AS
+        SELECT provider, model, benchmark, dataset_id, metric_type,
+               avg_value, stddev_value, min_value,
+               pct[1] AS p25, pct[2] AS p50, pct[3] AS p75,
+               pct[4] AS p90, pct[5] AS p95, pct[6] AS p99,
+               max_value, sample_count
+        FROM (
+            SELECT r.provider, r.model, r.benchmark,
+                   COALESCE({_DATASET_CASE}, '__all__') AS dataset_id,
+                   r.metric_type,
+                   AVG(r.metric_value)::float8 AS avg_value,
+                   COALESCE(STDDEV_SAMP(r.metric_value), 0)::float8 AS stddev_value,
+                   MIN(r.metric_value)::float8 AS min_value,
+                   PERCENTILE_CONT(ARRAY[0.25, 0.5, 0.75, 0.9, 0.95, 0.99])
+                       WITHIN GROUP (ORDER BY r.metric_value)::float8[] AS pct,
+                   MAX(r.metric_value)::float8 AS max_value,
+                   COUNT(*)::int AS sample_count
+            FROM benchmarks_v2.results r
+            JOIN benchmarks_v2.runs rn ON rn.id = r.run_id
+            WHERE r.status = 'success'
+              AND rn.status IN ('succeeded', 'partial')
+              AND r.metric_value IS NOT NULL
+              AND r.created_at >= now() - INTERVAL '{interval}'
+            GROUP BY GROUPING SETS (
+                (r.provider, r.model, r.benchmark, r.metric_type, {_DATASET_CASE}),
+                (r.provider, r.model, r.benchmark, r.metric_type)
+            )
+        ) stats
+    """  # noqa: S608
+
+
+_BUCKET_TABLE_SQL = """
+    CREATE TABLE benchmarks_v2.results_by_bucket (
+        provider      TEXT NOT NULL,
+        model         TEXT NOT NULL,
+        benchmark     TEXT NOT NULL CHECK (benchmark IN ('STT','TTS','S2S')),
+        dataset_id    TEXT NOT NULL,
+        metric_type   TEXT NOT NULL,
+        bucket_at     TIMESTAMPTZ NOT NULL,
+        min_value     DOUBLE PRECISION NOT NULL,
+        p25           DOUBLE PRECISION NOT NULL,
+        p50           DOUBLE PRECISION NOT NULL,
+        p75           DOUBLE PRECISION NOT NULL,
+        max_value     DOUBLE PRECISION NOT NULL,
+        value_sum     DOUBLE PRECISION NOT NULL,
+        sample_count  INTEGER NOT NULL,
+        PRIMARY KEY (provider, model, benchmark, dataset_id, metric_type, bucket_at)
+    )
+"""
+
+# S608 false-positive: interpolations come from module constants.
+_BACKFILL_SQL = f"""
+    INSERT INTO benchmarks_v2.results_by_bucket
+        (provider, model, benchmark, dataset_id, metric_type, bucket_at,
+         min_value, p25, p50, p75, max_value, value_sum, sample_count)
+    SELECT r.provider, r.model, r.benchmark,
+           COALESCE({_DATASET_CASE}, '__all__'),
+           r.metric_type,
+           {_BUCKET_EXPR},
+           MIN(r.metric_value)::float8,
+           PERCENTILE_CONT(0.25) WITHIN GROUP (ORDER BY r.metric_value)::float8,
+           PERCENTILE_CONT(0.5)  WITHIN GROUP (ORDER BY r.metric_value)::float8,
+           PERCENTILE_CONT(0.75) WITHIN GROUP (ORDER BY r.metric_value)::float8,
+           MAX(r.metric_value)::float8,
+           SUM(r.metric_value)::float8,
+           COUNT(*)::int
+    FROM benchmarks_v2.results r
+    JOIN benchmarks_v2.runs rn ON rn.id = r.run_id
+    WHERE r.status = 'success'
+      AND rn.status IN ('succeeded', 'partial')
+      AND r.metric_value IS NOT NULL
+    GROUP BY GROUPING SETS (
+        (r.provider, r.model, r.benchmark, r.metric_type, {_DATASET_CASE}, {_BUCKET_EXPR}),
+        (r.provider, r.model, r.benchmark, r.metric_type, {_BUCKET_EXPR})
+    )
+"""  # noqa: S608
+
+
+def upgrade() -> None:
+    """Recreate the matviews and the rollup table with the dataset dimension."""
+    for name, interval in _WINDOWS.items():
+        op.execute(f"DROP MATERIALIZED VIEW IF EXISTS benchmarks_v2.{name}")
+        op.execute(_view_sql(name, interval))
+        op.execute(
+            f"CREATE UNIQUE INDEX {name}_group_key "
+            f"ON benchmarks_v2.{name} (provider, model, benchmark, dataset_id, metric_type)"
+        )
+    op.execute("DROP TABLE IF EXISTS benchmarks_v2.results_by_bucket")
+    op.execute(_BUCKET_TABLE_SQL)
+    op.execute(
+        "CREATE INDEX results_by_bucket_series_idx "
+        "ON benchmarks_v2.results_by_bucket (benchmark, bucket_at)"
+    )
+    op.execute(_BACKFILL_SQL)
+
+
+def downgrade() -> None:
+    """Restore the pooled-only matviews and rollup table (shapes of 0005/0006/0009)."""
+    for name, interval in _WINDOWS.items():
+        op.execute(f"DROP MATERIALIZED VIEW IF EXISTS benchmarks_v2.{name}")
+        op.execute(f"""
+            CREATE MATERIALIZED VIEW benchmarks_v2.{name} AS
+            SELECT provider, model, benchmark, metric_type,
+                   avg_value, stddev_value, min_value,
+                   pct[1] AS p25, pct[2] AS p50, pct[3] AS p75,
+                   pct[4] AS p90, pct[5] AS p95, pct[6] AS p99,
+                   max_value, sample_count
+            FROM (
+                SELECT r.provider, r.model, r.benchmark, r.metric_type,
+                       AVG(r.metric_value)::float8 AS avg_value,
+                       COALESCE(STDDEV_SAMP(r.metric_value), 0)::float8 AS stddev_value,
+                       MIN(r.metric_value)::float8 AS min_value,
+                       PERCENTILE_CONT(ARRAY[0.25, 0.5, 0.75, 0.9, 0.95, 0.99])
+                           WITHIN GROUP (ORDER BY r.metric_value)::float8[] AS pct,
+                       MAX(r.metric_value)::float8 AS max_value,
+                       COUNT(*)::int AS sample_count
+                FROM benchmarks_v2.results r
+                JOIN benchmarks_v2.runs rn ON rn.id = r.run_id
+                WHERE r.status = 'success'
+                  AND rn.status IN ('succeeded', 'partial')
+                  AND r.metric_value IS NOT NULL
+                  AND r.created_at >= now() - INTERVAL '{interval}'
+                GROUP BY r.provider, r.model, r.benchmark, r.metric_type
+            ) stats
+        """)  # noqa: S608
+        op.execute(
+            f"CREATE UNIQUE INDEX {name}_group_key "
+            f"ON benchmarks_v2.{name} (provider, model, benchmark, metric_type)"
+        )
+    op.execute("DROP TABLE IF EXISTS benchmarks_v2.results_by_bucket")
+    op.execute("""
+        CREATE TABLE benchmarks_v2.results_by_bucket (
+            provider      TEXT NOT NULL,
+            model         TEXT NOT NULL,
+            benchmark     TEXT NOT NULL CHECK (benchmark IN ('STT','TTS','S2S')),
+            metric_type   TEXT NOT NULL,
+            bucket_at     TIMESTAMPTZ NOT NULL,
+            min_value     DOUBLE PRECISION NOT NULL,
+            p25           DOUBLE PRECISION NOT NULL,
+            p50           DOUBLE PRECISION NOT NULL,
+            p75           DOUBLE PRECISION NOT NULL,
+            max_value     DOUBLE PRECISION NOT NULL,
+            value_sum     DOUBLE PRECISION NOT NULL,
+            sample_count  INTEGER NOT NULL,
+            PRIMARY KEY (provider, model, benchmark, metric_type, bucket_at)
+        )
+    """)
+    op.execute(
+        "CREATE INDEX results_by_bucket_series_idx "
+        "ON benchmarks_v2.results_by_bucket (benchmark, bucket_at)"
+    )
+    op.execute(f"""
+        INSERT INTO benchmarks_v2.results_by_bucket
+            (provider, model, benchmark, metric_type, bucket_at,
+             min_value, p25, p50, p75, max_value, value_sum, sample_count)
+        SELECT r.provider, r.model, r.benchmark, r.metric_type, {_BUCKET_EXPR},
+               MIN(r.metric_value)::float8,
+               PERCENTILE_CONT(0.25) WITHIN GROUP (ORDER BY r.metric_value)::float8,
+               PERCENTILE_CONT(0.5)  WITHIN GROUP (ORDER BY r.metric_value)::float8,
+               PERCENTILE_CONT(0.75) WITHIN GROUP (ORDER BY r.metric_value)::float8,
+               MAX(r.metric_value)::float8,
+               SUM(r.metric_value)::float8,
+               COUNT(*)::int
+        FROM benchmarks_v2.results r
+        JOIN benchmarks_v2.runs rn ON rn.id = r.run_id
+        WHERE r.status = 'success'
+          AND rn.status IN ('succeeded', 'partial')
+          AND r.metric_value IS NOT NULL
+        GROUP BY r.provider, r.model, r.benchmark, r.metric_type, {_BUCKET_EXPR}
+    """)  # noqa: S608

--- a/runner/src/coval_bench/db/writer.py
+++ b/runner/src/coval_bench/db/writer.py
@@ -185,9 +185,15 @@ class RunWriter:
                 await cur.execute(
                     """
                     INSERT INTO benchmarks_v2.results_by_bucket
-                        (provider, model, benchmark, metric_type, bucket_at,
+                        (provider, model, benchmark, dataset_id, metric_type, bucket_at,
                          min_value, p25, p50, p75, max_value, value_sum, sample_count)
-                    SELECT r.provider, r.model, r.benchmark, r.metric_type, %(bucket)s,
+                    SELECT r.provider, r.model, r.benchmark,
+                           COALESCE(
+                               CASE WHEN r.benchmark = 'TTS' THEN 'tts-v1'
+                                    ELSE rn.dataset_id END,
+                               '__all__'
+                           ),
+                           r.metric_type, %(bucket)s,
                            MIN(r.metric_value)::float8,
                            PERCENTILE_CONT(0.25) WITHIN GROUP (ORDER BY r.metric_value)::float8,
                            PERCENTILE_CONT(0.5)  WITHIN GROUP (ORDER BY r.metric_value)::float8,
@@ -209,7 +215,11 @@ class RunWriter:
                                   + (%(period)s::double precision) * INTERVAL '1 second'
                           )
                       )
-                    GROUP BY r.provider, r.model, r.benchmark, r.metric_type
+                    GROUP BY GROUPING SETS (
+                        (r.provider, r.model, r.benchmark, r.metric_type,
+                         CASE WHEN r.benchmark = 'TTS' THEN 'tts-v1' ELSE rn.dataset_id END),
+                        (r.provider, r.model, r.benchmark, r.metric_type)
+                    )
                     """,
                     params,
                 )

--- a/runner/src/coval_bench/runner/orchestrator.py
+++ b/runner/src/coval_bench/runner/orchestrator.py
@@ -863,12 +863,17 @@ async def run_benchmarks(
     async with lifespan_pool(settings) as pool:
         writer = RunWriter(pool)
 
+        # A TTS-only run never touches the configured STT dataset; a 'both'
+        # run's row still records the STT id (its TTS rows are attributed to
+        # tts-v1 at the aggregation layer).
+        run_dataset_id = "tts-v1" if benchmark_kind == "tts" else settings.dataset_id
+
         # Dataset SHA256 for the run record (computed from the packaged manifest)
         try:
             import importlib.resources as _importlib_resources
 
             manifest_ref = _importlib_resources.files("coval_bench.datasets.manifests").joinpath(
-                f"{settings.dataset_id}.json"
+                f"{run_dataset_id}.json"
             )
             manifest_bytes = manifest_ref.read_bytes()
             dataset_sha256 = hashlib.sha256(manifest_bytes).hexdigest()
@@ -880,7 +885,7 @@ async def run_benchmarks(
         scheduled_at = datetime.fromtimestamp(epoch - epoch % period, tz=UTC)
         run = await writer.start_run(
             runner_sha=settings.runner_sha,
-            dataset_id=settings.dataset_id,
+            dataset_id=run_dataset_id,
             dataset_sha256=dataset_sha256,
             scheduled_at=scheduled_at,
         )

--- a/runner/tests/api/conftest.py
+++ b/runner/tests/api/conftest.py
@@ -48,12 +48,15 @@ def _make_db_url(postgresql: Any) -> str:
     return f"postgresql://{info.user}:{info.password or ''}@{info.host}:{info.port}/{info.dbname}"
 
 
-# Mirrors the per-window matview migration (20260611_0005).
+# Mirrors the per-window matview migrations (20260611_0005 + 20260715_0010).
 _MV_WINDOWS: dict[str, str] = {
     "results_24h": "24 hours",
     "results_7d": "7 days",
     "results_30d": "30 days",
 }
+
+# Dataset attribution for aggregate rows (mirrors migration 20260715_0010).
+_DATASET_CASE_SQL = "CASE WHEN r.benchmark = 'TTS' THEN 'tts-v1' ELSE rn.dataset_id END"
 
 
 def _load_schema(**connect_kwargs: Any) -> None:
@@ -99,17 +102,21 @@ def _load_schema(**connect_kwargs: Any) -> None:
             )
         """)
         # Per-window stats materialized views (model_stats + leaderboard).
+        # Mirrors migration 20260715_0010: per-dataset rows plus pooled rows
+        # under the '__all__' sentinel.
         # S608 false-positive: name and interval come from the _MV_WINDOWS constant.
         for name, interval in _MV_WINDOWS.items():
             conn.execute(f"""
                 CREATE MATERIALIZED VIEW IF NOT EXISTS benchmarks_v2.{name} AS
-                SELECT provider, model, benchmark, metric_type,
+                SELECT provider, model, benchmark, dataset_id, metric_type,
                        avg_value, stddev_value, min_value,
                        pct[1] AS p25, pct[2] AS p50, pct[3] AS p75,
                        pct[4] AS p90, pct[5] AS p95, pct[6] AS p99,
                        max_value, sample_count
                 FROM (
-                    SELECT r.provider, r.model, r.benchmark, r.metric_type,
+                    SELECT r.provider, r.model, r.benchmark,
+                           COALESCE({_DATASET_CASE_SQL}, '__all__') AS dataset_id,
+                           r.metric_type,
                            AVG(r.metric_value)::float8 AS avg_value,
                            COALESCE(STDDEV_SAMP(r.metric_value), 0)::float8 AS stddev_value,
                            MIN(r.metric_value)::float8 AS min_value,
@@ -123,15 +130,19 @@ def _load_schema(**connect_kwargs: Any) -> None:
                       AND rn.status IN ('succeeded', 'partial')
                       AND r.metric_value IS NOT NULL
                       AND r.created_at >= now() - INTERVAL '{interval}'
-                    GROUP BY r.provider, r.model, r.benchmark, r.metric_type
+                    GROUP BY GROUPING SETS (
+                        (r.provider, r.model, r.benchmark, r.metric_type, {_DATASET_CASE_SQL}),
+                        (r.provider, r.model, r.benchmark, r.metric_type)
+                    )
                 ) stats
             """)  # noqa: S608
-        # Series rollup table (mirrors migration 20260611_0006).
+        # Series rollup table (mirrors migrations 20260611_0006 + 20260715_0010).
         conn.execute("""
             CREATE TABLE IF NOT EXISTS benchmarks_v2.results_by_bucket (
                 provider      text NOT NULL,
                 model         text NOT NULL,
-                benchmark     text NOT NULL CHECK (benchmark IN ('STT','TTS')),
+                benchmark     text NOT NULL CHECK (benchmark IN ('STT','TTS','S2S')),
+                dataset_id    text NOT NULL,
                 metric_type   text NOT NULL,
                 bucket_at     timestamptz NOT NULL,
                 min_value     double precision NOT NULL,
@@ -141,7 +152,7 @@ def _load_schema(**connect_kwargs: Any) -> None:
                 max_value     double precision NOT NULL,
                 value_sum     double precision NOT NULL,
                 sample_count  integer NOT NULL,
-                PRIMARY KEY (provider, model, benchmark, metric_type, bucket_at)
+                PRIMARY KEY (provider, model, benchmark, dataset_id, metric_type, bucket_at)
             )
         """)
 
@@ -357,9 +368,11 @@ async def _fill_buckets(postgresql: Any) -> None:
         await aconn.execute("TRUNCATE benchmarks_v2.results_by_bucket")
         await aconn.execute(f"""
             INSERT INTO benchmarks_v2.results_by_bucket
-                (provider, model, benchmark, metric_type, bucket_at,
+                (provider, model, benchmark, dataset_id, metric_type, bucket_at,
                  min_value, p25, p50, p75, max_value, value_sum, sample_count)
-            SELECT r.provider, r.model, r.benchmark, r.metric_type, {bucket_sql},
+            SELECT r.provider, r.model, r.benchmark,
+                   COALESCE({_DATASET_CASE_SQL}, '__all__'),
+                   r.metric_type, {bucket_sql},
                    MIN(r.metric_value)::float8,
                    PERCENTILE_CONT(0.25) WITHIN GROUP (ORDER BY r.metric_value)::float8,
                    PERCENTILE_CONT(0.5)  WITHIN GROUP (ORDER BY r.metric_value)::float8,
@@ -372,7 +385,11 @@ async def _fill_buckets(postgresql: Any) -> None:
             WHERE r.status = 'success'
               AND rn.status IN ('succeeded', 'partial')
               AND r.metric_value IS NOT NULL
-            GROUP BY r.provider, r.model, r.benchmark, r.metric_type, {bucket_sql}
+            GROUP BY GROUPING SETS (
+                (r.provider, r.model, r.benchmark, r.metric_type, {_DATASET_CASE_SQL},
+                 {bucket_sql}),
+                (r.provider, r.model, r.benchmark, r.metric_type, {bucket_sql})
+            )
         """)  # noqa: S608
     finally:
         await aconn.close()

--- a/runner/tests/api/test_aggregates.py
+++ b/runner/tests/api/test_aggregates.py
@@ -110,6 +110,75 @@ async def test_excludes_failed_null_and_other_benchmark(
     assert stats[0]["sample_count"] == 1
 
 
+async def test_dataset_filter_splits_and_default_pools(
+    client: AsyncClient, postgresql: Any
+) -> None:
+    """Default response pools every dataset; ?dataset= scopes to one; the
+    datasets list enumerates what has data."""
+    run_v1 = await _insert_run(postgresql, dataset_id="stt-v1")
+    await _insert_result(postgresql, run_v1, metric_value=1.0)
+    run_v3 = await _insert_run(postgresql, dataset_id="stt-v3")
+    await _insert_result(postgresql, run_v3, metric_value=3.0)
+    await _insert_result(postgresql, run_v3, metric_value=5.0)
+    await _refresh_mv(postgresql)
+    await _fill_buckets(postgresql)
+
+    pooled = (await client.get("/v1/results/aggregates", params={"benchmark": "STT"})).json()
+    assert pooled["dataset"] == "__all__"
+    assert pooled["datasets"] == ["stt-v1", "stt-v3"]
+    assert pooled["model_stats"][0]["sample_count"] == 3
+    assert pooled["model_stats"][0]["avg_value"] == pytest.approx(3.0)
+
+    scoped = (
+        await client.get("/v1/results/aggregates", params={"benchmark": "STT", "dataset": "stt-v3"})
+    ).json()
+    assert scoped["dataset"] == "stt-v3"
+    assert scoped["model_stats"][0]["sample_count"] == 2
+    assert scoped["model_stats"][0]["avg_value"] == pytest.approx(4.0)
+
+    missing = (
+        await client.get("/v1/results/aggregates", params={"benchmark": "STT", "dataset": "nope"})
+    ).json()
+    assert missing["model_stats"] == []
+    assert missing["datasets"] == ["stt-v1", "stt-v3"]
+
+
+async def test_tts_rows_attributed_to_tts_dataset(client: AsyncClient, postgresql: Any) -> None:
+    """TTS rows aggregate under tts-v1 regardless of the run row's dataset id."""
+    run_id = await _insert_run(postgresql, dataset_id="stt-v1")
+    await _insert_result(
+        postgresql, run_id, metric_value=250.0, benchmark="TTS", metric_type="TTFA"
+    )
+    await _refresh_mv(postgresql)
+
+    scoped = (
+        await client.get("/v1/results/aggregates", params={"benchmark": "TTS", "dataset": "tts-v1"})
+    ).json()
+    assert scoped["model_stats"][0]["sample_count"] == 1
+    assert scoped["datasets"] == ["tts-v1"]
+
+
+async def test_series_split_by_dataset(client: AsyncClient, postgresql: Any) -> None:
+    """The series block scopes to the requested dataset's bucket rows."""
+    scheduled = datetime.now(dt.UTC).replace(microsecond=0, second=0, minute=0)
+    run_v1 = await _insert_run(postgresql, dataset_id="stt-v1", scheduled_at=scheduled)
+    await _insert_result(postgresql, run_v1, metric_value=1.0)
+    run_v3 = await _insert_run(postgresql, dataset_id="stt-v3", scheduled_at=scheduled)
+    await _insert_result(postgresql, run_v3, metric_value=3.0)
+    await _fill_buckets(postgresql)
+
+    pooled = (await client.get("/v1/results/aggregates", params={"benchmark": "STT"})).json()
+    assert len(pooled["series"]) == 1
+    assert pooled["series"][0]["sample_count"] == 2
+
+    scoped = (
+        await client.get("/v1/results/aggregates", params={"benchmark": "STT", "dataset": "stt-v1"})
+    ).json()
+    assert len(scoped["series"]) == 1
+    assert scoped["series"][0]["sample_count"] == 1
+    assert scoped["series"][0]["value_sum"] == pytest.approx(1.0)
+
+
 async def test_partial_runs_included(client: AsyncClient, postgresql: Any) -> None:
     run_id = await _insert_run(postgresql, status="partial")
     await _insert_result(postgresql, run_id, metric_value=2.0)

--- a/runner/tests/unit/test_db_writer.py
+++ b/runner/tests/unit/test_db_writer.py
@@ -190,19 +190,20 @@ def test_migration_backfills_existing_results(pg_conn: psycopg.Connection[Any]) 
 
     with pg_conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
         cur.execute(
-            "SELECT min_value, p50, max_value, value_sum, sample_count "
+            "SELECT dataset_id, min_value, p50, max_value, value_sum, sample_count "
             "FROM benchmarks_v2.results_by_bucket "
             "WHERE provider = 'openai' AND model = 'whisper-1' AND metric_type = 'WER'"
         )
         rows = cur.fetchall()
 
-    assert len(rows) == 1
-    row = rows[0]
-    assert row["sample_count"] == 2
-    assert float(row["value_sum"]) == pytest.approx(4.0)
-    assert float(row["min_value"]) == pytest.approx(1.0)
-    assert float(row["max_value"]) == pytest.approx(3.0)
-    assert float(row["p50"]) == pytest.approx(2.0)
+    # One per-dataset row plus the pooled '__all__' row, identical stats here.
+    assert {row["dataset_id"] for row in rows} == {"d", "__all__"}
+    for row in rows:
+        assert row["sample_count"] == 2
+        assert float(row["value_sum"]) == pytest.approx(4.0)
+        assert float(row["min_value"]) == pytest.approx(1.0)
+        assert float(row["max_value"]) == pytest.approx(3.0)
+        assert float(row["p50"]) == pytest.approx(2.0)
 
 
 def test_run_lifecycle(pg_conn: psycopg.Connection[Any]) -> None:
@@ -667,21 +668,65 @@ def test_refresh_bucket(pg_conn: psycopg.Connection[Any]) -> None:
     pg_conn.autocommit = True
     with pg_conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
         cur.execute(
-            "SELECT bucket_at, min_value, p50, max_value, value_sum, sample_count "
+            "SELECT dataset_id, bucket_at, min_value, p50, max_value, value_sum, sample_count "
             "FROM benchmarks_v2.results_by_bucket "
             "WHERE provider = 'openai' AND model = 'whisper-1' AND metric_type = 'WER'"
         )
         rows = cur.fetchall()
 
-    # One bucket spanning all three samples.
-    assert len(rows) == 1
-    row = rows[0]
-    assert row["bucket_at"] == scheduled
-    assert row["sample_count"] == 3
-    assert float(row["value_sum"]) == pytest.approx(9.0)
-    assert float(row["min_value"]) == pytest.approx(1.0)
-    assert float(row["max_value"]) == pytest.approx(5.0)
-    assert float(row["p50"]) == pytest.approx(3.0)
+    # One bucket spanning all three samples: per-dataset row + pooled row.
+    assert {row["dataset_id"] for row in rows} == {"stt-v1", "__all__"}
+    for row in rows:
+        assert row["bucket_at"] == scheduled
+        assert row["sample_count"] == 3
+        assert float(row["value_sum"]) == pytest.approx(9.0)
+        assert float(row["min_value"]) == pytest.approx(1.0)
+        assert float(row["max_value"]) == pytest.approx(5.0)
+        assert float(row["p50"]) == pytest.approx(3.0)
+
+
+def test_refresh_bucket_splits_datasets(pg_conn: psycopg.Connection[Any]) -> None:
+    """Two runs on different datasets in one bucket: per-dataset rows split,
+    the pooled '__all__' row spans both."""
+    _apply_migrations(pg_conn)
+    scheduled = datetime.now(UTC).replace(microsecond=0) - timedelta(hours=1)
+
+    async def _run() -> None:
+        pool = await _make_pool(pg_conn)
+        try:
+            writer = RunWriter(pool)
+            for dataset_id, values in (("stt-v1", [1.0]), ("stt-v3", [3.0, 5.0])):
+                run = await writer.start_run(
+                    runner_sha="abc123",
+                    dataset_id=dataset_id,
+                    dataset_sha256="deadbeef",
+                    scheduled_at=scheduled,
+                )
+                assert run.id is not None
+                await writer.record_results([_wer_result(run.id, v) for v in values])
+                await writer.finish_run(run.id, status=RunStatus.SUCCEEDED)
+                await writer.refresh_bucket(run.id, period_seconds=1800)
+        finally:
+            await pool.close()
+
+    asyncio.run(_run())
+
+    pg_conn.autocommit = True
+    with pg_conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            "SELECT dataset_id, value_sum, sample_count "
+            "FROM benchmarks_v2.results_by_bucket "
+            "WHERE provider = 'openai' AND model = 'whisper-1' AND metric_type = 'WER'"
+        )
+        by_dataset = {row["dataset_id"]: row for row in cur.fetchall()}
+
+    assert set(by_dataset) == {"stt-v1", "stt-v3", "__all__"}
+    assert by_dataset["stt-v1"]["sample_count"] == 1
+    assert float(by_dataset["stt-v1"]["value_sum"]) == pytest.approx(1.0)
+    assert by_dataset["stt-v3"]["sample_count"] == 2
+    assert float(by_dataset["stt-v3"]["value_sum"]) == pytest.approx(8.0)
+    assert by_dataset["__all__"]["sample_count"] == 3
+    assert float(by_dataset["__all__"]["value_sum"]) == pytest.approx(9.0)
 
 
 def test_refresh_bucket_excludes_failed_run(pg_conn: psycopg.Connection[Any]) -> None:

--- a/runner/tests/unit/test_framework.py
+++ b/runner/tests/unit/test_framework.py
@@ -13,7 +13,9 @@ from pathlib import Path
 from typing import cast
 
 import pytest
+from pydantic import ValidationError
 
+from coval_bench.config import Settings
 from coval_bench.datasets.scripts.framework import (
     Clip,
     _clean,
@@ -21,6 +23,18 @@ from coval_bench.datasets.scripts.framework import (
     _write_manifest,
     balanced_sample,
 )
+
+
+def test_write_manifest_rejects_reserved_dataset_id() -> None:
+    """'__all__' is the pooled-aggregates sentinel — never a real dataset."""
+    with pytest.raises(ValueError, match="reserved"):
+        _write_manifest("{}", "__all__")
+
+
+def test_settings_reject_reserved_dataset_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DATASET_ID", "__all__")
+    with pytest.raises(ValidationError, match="reserved"):
+        Settings(_env_file=None)
 
 
 def _clip(

--- a/runner/tests/unit/test_orchestrator.py
+++ b/runner/tests/unit/test_orchestrator.py
@@ -316,6 +316,7 @@ async def test_smoke_run_stt(audio_file: Path, settings: Settings) -> None:
     assert summary.success_count == summary.total_results
     assert summary.fail_count == 0
     writer.start_run.assert_awaited_once()
+    assert writer.start_run.await_args.kwargs["dataset_id"] == settings.dataset_id
     # Per-task incremental flush — one call per (registered) provider × item.
     # The default STT matrix has additional deepgram models (nova-3, flux), so
     # both deepgram and elevenlabs each fire multiple times via the same mock.
@@ -822,6 +823,8 @@ async def test_audio_file_cleanup(settings: Settings) -> None:
         assert not audio_path.exists(), "TTS audio file was not cleaned up"
         # TTFA result was still recorded successfully
         assert summary.success_count >= 1
+        # A TTS-only run is stamped with the TTS dataset, not the env default.
+        assert writer.start_run.await_args.kwargs["dataset_id"] == "tts-v1"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Matviews and the series rollup now carry per-dataset rows plus pooled rows under the __all__ sentinel; the aggregates API takes an optional dataset filter and TTS-only runs stamp tts-v1.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds dataset-aware aggregates while preserving pooled results. The main changes are:

- Per-dataset and `__all__` rows in materialized views and series buckets.
- An optional dataset filter and dataset metadata in the aggregates API.
- Pooled filtering for leaderboard queries.
- `tts-v1` attribution for TTS-only runs.
- Sentinel validation and dataset aggregation tests.

<h3>Confidence Score: 4/5</h3>

The migration needs one compatibility fix before merging.

- New application settings reject future `__all__` dataset IDs.
- Existing sentinel rows can still create duplicate aggregation keys and abort the backfill.
- Migration-time cleanup and database enforcement are needed to cover all stored data.

runner/src/coval_bench/config.py and runner/src/coval_bench/db/migrations/versions/20260715_0010_dataset_dim_in_aggregates.py

<sub>Reviews (2): Last reviewed commit: ["Reserve the \_\_all\_\_ dataset id"](https://github.com/coval-ai/benchmarks/commit/6d692f13c5935c315c430ea56d1c387740b0045f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44552392)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->