### PR TITLE
Add the model comparison table to S2S

### DIFF
--- a/web/app/s2s/s2s-dashboard.tsx
+++ b/web/app/s2s/s2s-dashboard.tsx
@@ -11,9 +11,8 @@ import KeyMetrics from "@/components/dashboard/KeyMetrics";
 import { ChartSkeleton } from "@/components/dashboard/DashboardSkeleton";
 
 // S2S has a single metric (V2V latency, no WER). The WER-based sections
-// (AccuracyBarSection, LatencyAccuracySection) are omitted, and the model
-// comparison table (HeatmapSection) is deferred to a later pass — its WER
-// columns would need per-column S2S gating.
+// (AccuracyBarSection, LatencyAccuracySection) are omitted; the model
+// comparison table renders WER-free (it hides the column when rows lack it).
 const TimelineChart = dynamic(
   () => import("@/components/visualizations/TimelineChart"),
   { ssr: false, loading: () => <ChartSkeleton /> }
@@ -21,6 +20,11 @@ const TimelineChart = dynamic(
 
 const BoxPlotSection = dynamic(
   () => import("@/components/dashboard/BoxPlotSection"),
+  { ssr: false, loading: () => <ChartSkeleton /> }
+);
+
+const ModelComparisonSection = dynamic(
+  () => import("@/components/dashboard/ModelComparisonSection"),
   { ssr: false, loading: () => <ChartSkeleton /> }
 );
 
@@ -32,6 +36,7 @@ export function S2SDashboard() {
           <KeyMetrics />
           <TimelineChart />
           <BoxPlotSection />
+          <ModelComparisonSection />
         </DashboardLayout>
       </SidebarMenuProvider>
     </DashboardProvider>

--- a/web/app/stt/stt-dashboard.tsx
+++ b/web/app/stt/stt-dashboard.tsx
@@ -33,8 +33,8 @@ const AccuracyBarSection = dynamic(
   { ssr: false, loading: () => <ChartSkeleton /> }
 );
 
-const HeatmapSection = dynamic(
-  () => import("@/components/dashboard/HeatmapSection"),
+const ModelComparisonSection = dynamic(
+  () => import("@/components/dashboard/ModelComparisonSection"),
   { ssr: false, loading: () => <ChartSkeleton /> }
 );
 
@@ -48,7 +48,7 @@ export function STTDashboard() {
           <BoxPlotSection />
           <AccuracyBarSection />
           <LatencyAccuracySection />
-          <HeatmapSection />
+          <ModelComparisonSection />
         </DashboardLayout>
       </SidebarMenuProvider>
     </DashboardProvider>

--- a/web/app/tts/tts-dashboard.tsx
+++ b/web/app/tts/tts-dashboard.tsx
@@ -33,8 +33,8 @@ const AccuracyBarSection = dynamic(
   { ssr: false, loading: () => <ChartSkeleton /> }
 );
 
-const HeatmapSection = dynamic(
-  () => import("@/components/dashboard/HeatmapSection"),
+const ModelComparisonSection = dynamic(
+  () => import("@/components/dashboard/ModelComparisonSection"),
   { ssr: false, loading: () => <ChartSkeleton /> }
 );
 
@@ -48,7 +48,7 @@ export function TTSDashboard() {
           <BoxPlotSection />
           <AccuracyBarSection />
           <LatencyAccuracySection />
-          <HeatmapSection />
+          <ModelComparisonSection />
         </DashboardLayout>
       </SidebarMenuProvider>
     </DashboardProvider>

--- a/web/components/dashboard/ModelComparisonSection.tsx
+++ b/web/components/dashboard/ModelComparisonSection.tsx
@@ -14,7 +14,7 @@ import MetricToggle from "@/components/dashboard/MetricToggle";
 import { useDashboard } from "@/contexts/DashboardContext";
 import { useChartHoverTracking } from "@/hooks/useChartHoverTracking";
 
-const HeatmapSection: React.FC = () => {
+const ModelComparisonSection: React.FC = () => {
   const {
     heatmapDisplayData: data,
     getProviderForModel,
@@ -41,8 +41,9 @@ const HeatmapSection: React.FC = () => {
               provider: getProviderForModel(model),
               metric: activeMetric,
               [`latency_${percentile}_ms`]: latency[percentile],
-              avg_wer_percent: avgWER,
-              wer_std_dev: werStdDev,
+              ...(avgWER !== undefined
+                ? { avg_wer_percent: avgWER, wer_std_dev: werStdDev }
+                : {}),
               runs: sampleCount,
             }))
           }
@@ -62,4 +63,4 @@ const HeatmapSection: React.FC = () => {
   );
 };
 
-export default HeatmapSection;
+export default ModelComparisonSection;

--- a/web/components/dashboard/ModelComparisonTable.tsx
+++ b/web/components/dashboard/ModelComparisonTable.tsx
@@ -56,6 +56,13 @@ const ModelComparisonTable: React.FC<ModelComparisonTableProps> = ({
 
   const percentile = (PERCENTILES[percentileIdx] ?? PERCENTILES[DEFAULT_PERCENTILE_IDX])!;
 
+  // Latency-only benchmarks (S2S) ship rows without WER; hide that column.
+  const hasWER = useMemo(() => data.every((d) => d.avgWER !== undefined), [data]);
+  const columns = useMemo(
+    () => (hasWER ? COLUMNS : COLUMNS.filter((c) => c.key !== "avgWER")),
+    [hasWER]
+  );
+
   // One pass per (data, percentile, sort) change: pull the selected latency
   // percentile, precompute the relative bar fractions, sort, and note the best
   // value per column.
@@ -67,7 +74,9 @@ const ModelComparisonTable: React.FC<ModelComparisonTableProps> = ({
     const [latencyMin, latencySpan] = span(
       data.map((d) => d.latency[percentile.key])
     );
-    const [werMin, werSpan] = span(data.map((d) => d.avgWER));
+    const [werMin, werSpan] = hasWER
+      ? span(data.map((d) => d.avgWER ?? 0))
+      : [0, 0];
     const rel = (v: number, min: number, s: number) =>
       s === 0 ? 1 : (min + s - v) / s;
 
@@ -76,10 +85,10 @@ const ModelComparisonTable: React.FC<ModelComparisonTableProps> = ({
         ...d,
         latency: d.latency[percentile.key],
         latencyRel: rel(d.latency[percentile.key], latencyMin, latencySpan),
-        werRel: rel(d.avgWER, werMin, werSpan)
+        werRel: hasWER ? rel(d.avgWER ?? 0, werMin, werSpan) : 1
       }))
       .sort((a, b) => {
-        const delta = a[sort.key] - b[sort.key];
+        const delta = (a[sort.key] ?? 0) - (b[sort.key] ?? 0);
         return sort.direction === "asc" ? delta : -delta;
       });
 
@@ -91,7 +100,7 @@ const ModelComparisonTable: React.FC<ModelComparisonTableProps> = ({
         sampleCount: Math.max(...data.map((d) => d.sampleCount))
       }
     };
-  }, [data, percentile.key, sort]);
+  }, [data, percentile.key, sort, hasWER]);
 
   type Row = (typeof rows)[number];
 
@@ -175,7 +184,7 @@ const ModelComparisonTable: React.FC<ModelComparisonTableProps> = ({
           <thead>
             <tr className="border-b border-border-primary text-text-tertiary">
               <th className="py-2 pr-4 text-left font-medium">Model</th>
-              {COLUMNS.map((column) => (
+              {columns.map((column) => (
                 <th
                   key={column.key}
                   aria-sort={
@@ -232,17 +241,18 @@ const ModelComparisonTable: React.FC<ModelComparisonTableProps> = ({
                     {bar(row.latencyRel)}
                   </>
                 )}
-                {cell(
-                  row,
-                  "avgWER",
-                  <>
-                    {row.avgWER.toFixed(1)}
-                    <span className="text-xs text-text-tertiary">
-                      % ± {row.werStdDev.toFixed(1)}
-                    </span>
-                    {bar(row.werRel)}
-                  </>
-                )}
+                {hasWER &&
+                  cell(
+                    row,
+                    "avgWER",
+                    <>
+                      {(row.avgWER ?? 0).toFixed(1)}
+                      <span className="text-xs text-text-tertiary">
+                        % ± {(row.werStdDev ?? 0).toFixed(1)}
+                      </span>
+                      {bar(row.werRel)}
+                    </>
+                  )}
                 {cell(
                   row,
                   "sampleCount",

--- a/web/hooks/useChartData.ts
+++ b/web/hooks/useChartData.ts
@@ -301,30 +301,27 @@ export function useChartData({
 
       selectedModels.forEach((model) => {
         const latencyStat = getStat(model, metric);
-        const werStat = getStat(model, "WER");
+        // S2S is latency-only; the table hides the WER column for such rows.
+        const werStat = activeTab === "s2s" ? undefined : getStat(model, "WER");
 
-        if (!latencyStat || !werStat) return;
+        if (!latencyStat || (activeTab !== "s2s" && !werStat)) return;
 
         // The schema types every stat as a number, but guard the raw fields
         // (before unit conversion, which would coerce null to 0) against a
         // response with missing/non-finite values leaking into the table.
-        if (
-          ![
-            latencyStat.min_value,
-            latencyStat.p25,
-            latencyStat.p50,
-            latencyStat.p75,
-            latencyStat.p90,
-            latencyStat.p95,
-            latencyStat.p99,
-            latencyStat.max_value,
-            werStat.avg_value,
-            werStat.stddev_value,
-            latencyStat.sample_count
-          ].every(Number.isFinite)
-        ) {
-          return;
-        }
+        const rawFields = [
+          latencyStat.min_value,
+          latencyStat.p25,
+          latencyStat.p50,
+          latencyStat.p75,
+          latencyStat.p90,
+          latencyStat.p95,
+          latencyStat.p99,
+          latencyStat.max_value,
+          latencyStat.sample_count
+        ];
+        if (werStat) rawFields.push(werStat.avg_value, werStat.stddev_value);
+        if (!rawFields.every(Number.isFinite)) return;
 
         heatmapData.push({
           model,
@@ -338,8 +335,9 @@ export function useChartData({
             p99: toDisplayUnits(latencyStat.p99),
             p100: toDisplayUnits(latencyStat.max_value)
           },
-          avgWER: werStat.avg_value,
-          werStdDev: werStat.stddev_value,
+          ...(werStat
+            ? { avgWER: werStat.avg_value, werStdDev: werStat.stddev_value }
+            : {}),
           sampleCount: latencyStat.sample_count
         });
       });
@@ -351,7 +349,7 @@ export function useChartData({
           ) || a.model.localeCompare(b.model)
       );
     },
-    [selectedModels, getStat, toDisplayUnits]
+    [selectedModels, getStat, toDisplayUnits, activeTab]
   );
 
   const werBarDataMemo = useMemo<BarDataPoint[]>(() => {

--- a/web/types/benchmark.types.ts
+++ b/web/types/benchmark.types.ts
@@ -35,8 +35,10 @@ export type LatencyPercentile =
 export interface ModelHeatmapData {
   model: string;
   latency: Record<LatencyPercentile, number>;
-  avgWER: number;
-  werStdDev: number;
+  // Absent on latency-only benchmarks (S2S); the comparison table hides the
+  // WER column when any row lacks it.
+  avgWER?: number;
+  werStdDev?: number;
   sampleCount: number;
 }
 


### PR DESCRIPTION
The S2S dashboard omitted the model comparison table because it was WER-coupled — the row builder dropped any model without a WER stat and the table hardcoded the WER column. The rows now carry WER optionally, the table hides that column when rows lack it (STT/TTS are unaffected since their rows always have it), and the S2S page renders the section, giving it the full latency percentile slider. The section file also loses its legacy `HeatmapSection` name — it has rendered `ModelComparisonTable` since the redesign, so it's now `ModelComparisonSection`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds the model comparison table to the S2S dashboard. The main changes are:

- Renames `HeatmapSection` to `ModelComparisonSection`.
- Makes WER fields optional for latency-only comparison rows.
- Hides the WER column when rows do not include WER data.
- Adds the comparison section and percentile control to S2S.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.
- S2S rows omit WER consistently, while STT and TTS still require complete WER data.
- The renamed component resolves consistently across all updated imports.

<sub>Reviews (1): Last reviewed commit: ["Add the model comparison table to S2S an..."](https://github.com/coval-ai/benchmarks/commit/c23c99391f31ca153ce5ac25abde9762ff3386e6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44554779)</sub>

<!-- /greptile_comment -->