### PR TITLE
Land the remaining WildASR datasets on main

### DIFF
--- a/runner/src/coval_bench/datasets/manifests/README.md
+++ b/runner/src/coval_bench/datasets/manifests/README.md
@@ -95,6 +95,13 @@ inserted into the audio, so every clip runs longer than its clean sibling
 draws exceed it). Randomized, 8 distinct draws per utterance (4 where the
 source published no duplicate row).
 
+#### `stt-wildasr-phonecodec.json`
+
+The telephony-codec intervention
+(`environment_degradation__en__fleurs_phone_codec_en`). Deterministic, 2
+codec conditions per utterance, rotation split evenly across the pool;
+durations identical to clean.
+
 ### `stt-v3.json`
 
 **What it is.** A frozen 897-clip set — the full usable pool of

--- a/runner/src/coval_bench/datasets/manifests/README.md
+++ b/runner/src/coval_bench/datasets/manifests/README.md
@@ -86,6 +86,15 @@ degradation: 6 distinct draws per utterance (3 where the source published no
 duplicate row), one chosen by the family rotation and recorded as
 `condition_idx`/`condition_count`.
 
+#### `stt-wildasr-noisegap.json`
+
+The noise-gap intervention
+(`environment_degradation__en__fleurs_noise_gap_en`): silence/noise segments
+inserted into the audio, so every clip runs longer than its clean sibling
+(still inside the 15 s band — the family filter dropped the utterances whose
+draws exceed it). Randomized, 8 distinct draws per utterance (4 where the
+source published no duplicate row).
+
 ### `stt-v3.json`
 
 **What it is.** A frozen 897-clip set — the full usable pool of

--- a/runner/src/coval_bench/datasets/manifests/README.md
+++ b/runner/src/coval_bench/datasets/manifests/README.md
@@ -71,6 +71,13 @@ five degradation datasets. Succeeds `stt-v2` (same source split, which stays
 frozen): built via the family selection above instead of stt-v2's 50-clip
 first-100-rows window.
 
+#### `stt-wildasr-clipping.json`
+
+The clipping-distortion intervention
+(`environment_degradation__en__fleurs_clipping_en`). One condition per
+utterance, 1:1 with clean: identical transcripts and durations at every index,
+different audio.
+
 ### `stt-v3.json`
 
 **What it is.** A frozen 897-clip set — the full usable pool of

--- a/runner/src/coval_bench/datasets/manifests/README.md
+++ b/runner/src/coval_bench/datasets/manifests/README.md
@@ -102,6 +102,14 @@ The telephony-codec intervention
 codec conditions per utterance, rotation split evenly across the pool;
 durations identical to clean.
 
+#### `stt-wildasr-reverb.json`
+
+The room-reverberation intervention
+(`environment_degradation__en__fleurs_reverberation_en`). 3 RIR conditions
+per utterance; reverb tails lengthen every clip past its clean sibling, so
+the rotation advances past out-of-band draws (hence the uneven condition
+spread).
+
 ### `stt-v3.json`
 
 **What it is.** A frozen 897-clip set — the full usable pool of

--- a/runner/src/coval_bench/datasets/manifests/README.md
+++ b/runner/src/coval_bench/datasets/manifests/README.md
@@ -78,6 +78,14 @@ The clipping-distortion intervention
 utterance, 1:1 with clean: identical transcripts and durations at every index,
 different audio.
 
+#### `stt-wildasr-farfield.json`
+
+The far-field / distant-mic intervention
+(`environment_degradation__en__fleurs_far_field_en`). A randomized
+degradation: 6 distinct draws per utterance (3 where the source published no
+duplicate row), one chosen by the family rotation and recorded as
+`condition_idx`/`condition_count`.
+
 ### `stt-v3.json`
 
 **What it is.** A frozen 897-clip set — the full usable pool of

--- a/runner/src/coval_bench/datasets/manifests/stt-wildasr-clipping.json
+++ b/runner/src/coval_bench/datasets/manifests/stt-wildasr-clipping.json
@@ -1,0 +1,2849 @@
+{
+  "_license": "Apache-2.0 (WildASR; audio derived from FLEURS, CC-BY-4.0)",
+  "id": "stt-wildasr-clipping",
+  "version": "1.0.0",
+  "license": "Apache-2.0 (WildASR; audio derived from FLEURS, CC-BY-4.0)",
+  "source": "bosonai/WildASR environment_degradation__en__fleurs_clipping_en",
+  "items": [
+    {
+      "path": "audio/0001.wav",
+      "sha256": "adb3947b5b9eb2c26142fe4d32614536c5d8e6e9efea65df88ad923d8b880938",
+      "transcript": "\"he [wales] basically lied to us from the start. first by acting as if this was for legal reasons. second by pretending he was listening to us right up to his art deletion.",
+      "duration_sec": 12.36,
+      "speech_end_offset_ms": 11428.0,
+      "audio_hash_id": "068314818d285d26fec699001abfca2ad9a734a9ff574d846e2b80fd04844173",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0002.wav",
+      "sha256": "fb5b3ed485e796d93a61976c272880202418260c7642d22e017322f888361411",
+      "transcript": "a car bomb detonated at police headquarters in gaziantep turkey yesterday morning killed two police officers and injured more than twenty other people",
+      "duration_sec": 10.02,
+      "speech_end_offset_ms": 8644.0,
+      "audio_hash_id": "bcbda036920850fd78d42743d27e84c77525370c5ccf0137cccc7073e9aabdda",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0003.wav",
+      "sha256": "47b3c69578ddc1008c3756d4b5978d9ed837a69b5417bfa3ad53ff79a3493afd",
+      "transcript": "a civilization is a singular culture shared by a significant large group of people who live and work co-operatively a society",
+      "duration_sec": 8.88,
+      "speech_end_offset_ms": 7780.0,
+      "audio_hash_id": "a7b3bfba98676ece3a20f0ce6fb5aed1aa1986b2225a58a293f8041585523e22",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0004.wav",
+      "sha256": "95d2fde2660bae6450b41af61d3b1234982de813f110e149ae112091d6d2a9d5",
+      "transcript": "a curry is a dish based on herbs and spices together with either meat or vegetables",
+      "duration_sec": 9.06,
+      "speech_end_offset_ms": 7428.0,
+      "audio_hash_id": "be6cd15ad1fd5ce3ee2e65adfeb7c117618df16b77c5ed27fd7091b5c6f3cda4",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0005.wav",
+      "sha256": "314644f44bdd1209fae2667ea32a0b331903983574f6d5fc6f6a16dbbd07b78a",
+      "transcript": "a full 20% of the water that pours out of the planet's rivers into the oceans comes from the amazon",
+      "duration_sec": 7.32,
+      "speech_end_offset_ms": 6692.0,
+      "audio_hash_id": "31b857470e24349f68a23d93d743dda79c9d0017b6d5904512cb391ad024f98f",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0006.wav",
+      "sha256": "4d17895ecde311aa29dfb857ceb82164a6c8a2deb3069494e80ff1e0a8923005",
+      "transcript": "a search of the internet for hostile environment course' will probably provide the address of a local company",
+      "duration_sec": 7.2,
+      "speech_end_offset_ms": 6244.0,
+      "audio_hash_id": "dc6d44312f1e48dd235c2b90ddeca1f684d9e31bc53db9af97761f48c0d40e33",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0007.wav",
+      "sha256": "f95faa0526fb756f74df3fc213ff8160b587f969dd86b624769688cd5c09c476",
+      "transcript": "a simple popular dinner especially during the summer is the pa amb oli bread with olive oil tomato and any available condiments such as cheese tunafish etc",
+      "duration_sec": 12.24,
+      "speech_end_offset_ms": 11268.0,
+      "audio_hash_id": "6534e5e91f493c712f30263fe73786f58981b462a01658c31c1d89b2b8f10f61",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0008.wav",
+      "sha256": "adcdf338d2bdfe3f33a40309210744d2e53159f7b3cbff71217b8921179ebae0",
+      "transcript": "a well rounded athlete the tiger can climb though not well swim leap great distances and pull with five times the force of a strong human",
+      "duration_sec": 10.2,
+      "speech_end_offset_ms": 9284.0,
+      "audio_hash_id": "fb1d5d17ab4f4a5459d5a74d826a899a4b0dad38eefb2e2246ae9599848e3b0d",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0009.wav",
+      "sha256": "8c844f1bc81b340168a2e769f5db9e8166598f064d5e07ebe153830bf90ffb01",
+      "transcript": "accepted were aristotle's views on all matters of science including psychology",
+      "duration_sec": 6.72,
+      "speech_end_offset_ms": 4836.0,
+      "audio_hash_id": "33b643588da2a8526d82a5d40fd67db4c0fe53961773375bad2c2c00443b592e",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0010.wav",
+      "sha256": "331e58dad282654ecbfdf86c6cb3e309f85bbf18e5c0c024f27984cddf67ab8e",
+      "transcript": "according to japan's nuclear agency radioactive caesium and iodine has been identified at the plant",
+      "duration_sec": 7.38,
+      "speech_end_offset_ms": 6276.0,
+      "audio_hash_id": "05d50e276a2d26f12b9f2e0d7f54ed01653e732f13a82179548530db657acce0",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0011.wav",
+      "sha256": "c414f9bf34ab7ebcf3c231f09feb5a23b04050372f846000c156f104768a7901",
+      "transcript": "aerosmith have cancelled their remaining concerts on their tour",
+      "duration_sec": 3.96,
+      "speech_end_offset_ms": 3652.0,
+      "audio_hash_id": "9a992ee806ff73b559f35aad79afbd49f4ff0323dff239aca191ce1c824b5919",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0012.wav",
+      "sha256": "37ff869b25a77113c7abfa65144f84f01ce5c3e5a487a94aa89f5bea25f656dc",
+      "transcript": "after the accident occurred gibson was transported to a hospital but died shortly afterwards",
+      "duration_sec": 6.24,
+      "speech_end_offset_ms": 5476.0,
+      "audio_hash_id": "7753fa43c8f90e80c78a99392b5d8753c38ce2a3b81d7350d8990a4b495e55ca",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0013.wav",
+      "sha256": "e2898a92258499c55b997bca3bdf07d2c50b6292eb0dd80509302a38dedfb49a",
+      "transcript": "after the dam was built in 1963 the seasonal floods that would spread sediment throughout the river were halted",
+      "duration_sec": 9.24,
+      "speech_end_offset_ms": 7556.0,
+      "audio_hash_id": "5a7db473bfc595ffe701fcef6257a8e57c082f6840b1c19daec58f6af5a3eb11",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0014.wav",
+      "sha256": "11f7a83b5540ee1c634a9d5e0d903419fed81164bb4a7851e00a781f8a5b3e69",
+      "transcript": "all nouns alongside the word sie for you always begin with a capital letter even in the middle of a sentence",
+      "duration_sec": 8.76,
+      "speech_end_offset_ms": 8324.0,
+      "audio_hash_id": "0ef5c70d395f403d2668d910efaed5927fa5a061cef769fe0fbd50693041ef75",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0015.wav",
+      "sha256": "54bce258d28f94e6c7fb8166555d94d7ac2c01b8751c734962f097131ec74ab8",
+      "transcript": "all things considered we should not be surprised if our own ancestors solved their protein problem in somewhat the same way that chimps on the savanna do today",
+      "duration_sec": 9.48,
+      "speech_end_offset_ms": 8548.0,
+      "audio_hash_id": "530a3fc83adeee3f98ab2c7706e2c64acfb3dfa3ce5dd5a757a85f9f0f92aaf9",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0016.wav",
+      "sha256": "545efd5b162c91c2edfa947ec5c3f7e769bd3d4226e75bc36e7c8ea856b69325",
+      "transcript": "alloys are basically a mixture of two or more metals don't forget that there are many elements on the periodic table",
+      "duration_sec": 8.38,
+      "speech_end_offset_ms": 7428.0,
+      "audio_hash_id": "b3f09f1fa8d7199c1b8976748d9c079e0ef119468b1f2aba5cf798dd4899a163",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0017.wav",
+      "sha256": "3ad34e21cb34a39eb60facca1ed3c52c1240d7d9e7d4228594cb0c6827a29f1f",
+      "transcript": "along the same line men are required to wear trousers covering the knees",
+      "duration_sec": 6.0,
+      "speech_end_offset_ms": 5284.0,
+      "audio_hash_id": "1cf675e92a397d3dadcedf56d11d473dee243229884b29c23cb1da6f9df44190",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0018.wav",
+      "sha256": "f0b2695b4359f012ab832317f824c47b7dd2cf5cbb7195192aecb17941c8a232",
+      "transcript": "also after the revolution occupations were open to all male applicants allowing the most ambitious and successful to succeed",
+      "duration_sec": 7.02,
+      "speech_end_offset_ms": 6724.0,
+      "audio_hash_id": "5f9da1608b22e91ce56c70f38a09436020afd318f85cd87d67f1948434aa82df",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0019.wav",
+      "sha256": "c610e9b80d3f648683864b7ec644609ee380373b8bc77fa0b782d30f118a83eb",
+      "transcript": "also between each dynasty was an unstable age of divided provinces the best-known of these periods was the three kingdoms epoch taking place for 60 years between the han and the jin dynasty",
+      "duration_sec": 11.82,
+      "speech_end_offset_ms": 11332.0,
+      "audio_hash_id": "4199b75fd6f2c4e20bff45fa712dd5d12724c00bc979c83e5b90c4aa5eaaba59",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0020.wav",
+      "sha256": "a9a4a6dcd6a875300d65a17db74f49f4baa9feda9d7e7ff23dbc33c67bc58de2",
+      "transcript": "also to the north visit the great sanctuary of our lady of fatima shrine a place of worldwide famous marian apparitions",
+      "duration_sec": 7.56,
+      "speech_end_offset_ms": 7560.0,
+      "audio_hash_id": "f3dcf7cd87a18d8ca615b7b8b2f72d1aacf174a5148cff452202869e6d64ef81",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0021.wav",
+      "sha256": "41b0a4e57a871371541b41503f5b0ca0ffd7b1663b8a41cfc0133080562a8c7f",
+      "transcript": "ancient cultures and tribes began to keep them for easy access to milk hair meat and skins",
+      "duration_sec": 6.84,
+      "speech_end_offset_ms": 6564.0,
+      "audio_hash_id": "c39c36420de65209a8938521e66bf0a374269aebdf2fef72e2950fddc31aa617",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0022.wav",
+      "sha256": "3acc3c0fe5c952b2a3e541e7311fec92cb9f64b8bb1168992d1a16e70520518c",
+      "transcript": "angel 2006 explains the continuum approach as a method being used to help organizations reach a higher level of performance",
+      "duration_sec": 8.28,
+      "speech_end_offset_ms": 7876.0,
+      "audio_hash_id": "f85de95a3f409c4fcb4f13c939461499ad631673d647be33bb94e934bbf114a3",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0023.wav",
+      "sha256": "7e477163270e2c6f1c65d618fa0769bcccf09fde6d7e899d3b5ac1117e847a67",
+      "transcript": "anyone who's going to drive at high latitudes or over mountain passes should consider the possibility of snow ice or freezing temperatures",
+      "duration_sec": 8.58,
+      "speech_end_offset_ms": 7684.0,
+      "audio_hash_id": "3578d5712b790aa55d22306aa837d8bd86b716007d314c0fdc8d409a529653d3",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0024.wav",
+      "sha256": "356a7ed0c59472bf359fc3286b46f79460d509ff93dfd6f405b0b1480cc55cc9",
+      "transcript": "apia is the capital of samoa the town is on the island of upolu and has a population of just under 40,000",
+      "duration_sec": 10.96,
+      "speech_end_offset_ms": 10500.0,
+      "audio_hash_id": "ce1e39efb82952a2ebaa82c666ded87951ea986c3d4811850efb936a705d510c",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0025.wav",
+      "sha256": "3a9522bb53887fa67f7d6ed67a9c131b43830311e9623dd3146c0e8fd688711f",
+      "transcript": "aristotle a philosopher theorised that everything is made up of a mixture of one or more of four elements they were earth water air and fire",
+      "duration_sec": 9.06,
+      "speech_end_offset_ms": 8612.0,
+      "audio_hash_id": "acb7b65042c7444e3ade1ba200f253fd13a13aacfa2f277da5f69c55185ee2d7",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0026.wav",
+      "sha256": "8c3900fda334207533eb8b9dc92497f1b1735b3f9d02272c2663083dd7c91020",
+      "transcript": "as a result the performers smoke cannabis joints on stage and the theatre itself is encouraging the audience to join in",
+      "duration_sec": 10.56,
+      "speech_end_offset_ms": 8804.0,
+      "audio_hash_id": "e5302cf3be2524d9efecd20d118a489183bad4503509f704f2da45c230d0a62f",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0027.wav",
+      "sha256": "3377abae47f850a9c80516b053f18adcefcbe8db0a991192a214cd83966f5647",
+      "transcript": "as a result the process of an organization working together to overcome an obstacle can lead to a new innovative process to serve the customer's need",
+      "duration_sec": 12.12,
+      "speech_end_offset_ms": 10820.0,
+      "audio_hash_id": "f263485c7ac061edf2c10eec896bc07ae2952de905b33635194fff791bc9290e",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0028.wav",
+      "sha256": "eaba9fcc7af5eaa20330c5bfb74d62885465ea86329268a4ea761cf3e6dbaebf",
+      "transcript": "as a result two fish species have become extinct and two others have become endangered including the humpback chub",
+      "duration_sec": 11.44,
+      "speech_end_offset_ms": 10404.0,
+      "audio_hash_id": "f441b23e69c66c62e257c3e745531081e95f0db859f14ddff09c7daec09d75fb",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0029.wav",
+      "sha256": "0feb7c917585f5311058c90ab73051f8d2476f0a743dcde34c5c6aa0e8f4a14d",
+      "transcript": "as knowledge of greek declined the west found itself cut off from its greek philosophical and scientific roots",
+      "duration_sec": 10.18,
+      "speech_end_offset_ms": 8836.0,
+      "audio_hash_id": "c2c5e851f26ecf6775d0e8a85d5c2714ce22816285af435ee3885db386044b8d",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0030.wav",
+      "sha256": "4cdabc034115def29c973c1143d0be55972848ddc954a49a4bee6259af8c7c55",
+      "transcript": "as light pollution in their heyday was not the kind of problem it is today they are usually located in cities or at campuses easier to reach than those built in modern times",
+      "duration_sec": 9.9,
+      "speech_end_offset_ms": 8804.0,
+      "audio_hash_id": "46a53544260fe1d09edb90a7348198a51d7d0e13ac01637fb54277356d49ee58",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0031.wav",
+      "sha256": "491bbc422664b41764b9571f7515e3374c6aca25f69e5fda9bd2491d90c3ea20",
+      "transcript": "as with all south african national parks there are daily conservation and entry fees for the park",
+      "duration_sec": 9.42,
+      "speech_end_offset_ms": 8452.0,
+      "audio_hash_id": "0956fadbeefa4f1575561898135f376493f1c64cdd0b6864bde592ab4d81513b",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0032.wav",
+      "sha256": "1ce807fd52a2e36be26ad99c4d3278158a697d7163e29031d2bc7fc11032b210",
+      "transcript": "asus eee pc earlier launched world-wide for cost-saving and functionality factors became a hot topic in 2007 taipei it month",
+      "duration_sec": 10.74,
+      "speech_end_offset_ms": 9476.0,
+      "audio_hash_id": "259ac92e466bb3768b44432c177f999e809e56340dea2a9b3137aed96ecc09a5",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0033.wav",
+      "sha256": "65d9340b799bc405bcea47d5b3006b1235cbc972ff6d4745383bd78b5e5c1670",
+      "transcript": "barcelona's official languages are catalan and spanish about a half prefer to speak catalan a vast majority understands it and virtually everyone knows spanish",
+      "duration_sec": 11.22,
+      "speech_end_offset_ms": 9476.0,
+      "audio_hash_id": "5a03d01919156f4eac463a3ac78fd96f1125e1c7111e29dd20d6dbc9cf32a9f5",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0034.wav",
+      "sha256": "8041bd3322ca79ca6a1a6161fa71ff19377730db141de9b808f67cb860048593",
+      "transcript": "be careful not to allow fabric to become too hot which can cause shrinkage or in extreme cases scorch",
+      "duration_sec": 10.16,
+      "speech_end_offset_ms": 9668.0,
+      "audio_hash_id": "9aa0fa620d93277dacd45e5998b99409f4c0022e8bac4e2f87097291df90112a",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0035.wav",
+      "sha256": "cbab605715b54bc2b8d5ba68db73be2b2c8a29660d8f52c88d1449429c155173",
+      "transcript": "be firm in turning down men and don't be afraid to stand your ground cultural differences or not it doesn't make it ok!",
+      "duration_sec": 10.98,
+      "speech_end_offset_ms": 9220.0,
+      "audio_hash_id": "5383b674813da9e15d8c31fa0c711ac278f5c3a51a3e63158f1eab80545795e8",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0036.wav",
+      "sha256": "a52133651bfb93c406bd8b648e33b424458ca82e7b6b572212460535e0d480ae",
+      "transcript": "between 10:00-11:00 pm mdt a fire was started by the inmates in the yard",
+      "duration_sec": 8.94,
+      "speech_end_offset_ms": 7812.0,
+      "audio_hash_id": "79056b1e8e86a1b3919357bcab5fc9f8e8983e4cc2c9e8f46ee068e58f082a72",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0037.wav",
+      "sha256": "9db060e31c9fe7693b817853701a43c1bd1e8a6a01b44ac1601fca67cc51c18b",
+      "transcript": "beyond wednesday's event carpanedo competed in two individual races at the championships",
+      "duration_sec": 5.7,
+      "speech_end_offset_ms": 5412.0,
+      "audio_hash_id": "f1f38a0e1d4628f01cb06db53fc89a8864ebb35f249f4e822bc5ccee471d2e73",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0038.wav",
+      "sha256": "0e6f66631adef691cca71b177b66694b7409e2b54d55cd3890082a7b712d4b37",
+      "transcript": "bishkek was described as sinking into a state of anarchy by one observer as gangs of people roamed the streets and plundered stores of consumer goods",
+      "duration_sec": 9.6,
+      "speech_end_offset_ms": 8612.0,
+      "audio_hash_id": "a1c3184cd09054a2ec38823c4dd166df7c72ff3d7125a7e6e5d9cb4d683b65f6",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0039.wav",
+      "sha256": "f3f5fbb02732514ff4c27053b06507827df85a3176d8c4cb61deab1da97d8c12",
+      "transcript": "blogging is a tool that inspires collaboration and encourages students to extend learning well beyond the traditional school day",
+      "duration_sec": 9.6,
+      "speech_end_offset_ms": 8644.0,
+      "audio_hash_id": "9d0303bef0c842ca79621de5765c9739a0ac1add55357906b4494b7879ee055d",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0040.wav",
+      "sha256": "c6ed566a8bcc4445195ed1492370aa2103d25222ccdb945b815a3db2e4a629ee",
+      "transcript": "blogs can also help improve student writing while students often begin their blog experience with sloppy grammar and spelling the presence of an audience generally changes that",
+      "duration_sec": 8.76,
+      "speech_end_offset_ms": 8388.0,
+      "audio_hash_id": "0094cbaa1f28f9eb0c567ac7c1d14c9c8d2c9e9f99f6a35c7fda94f985c13c17",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0041.wav",
+      "sha256": "9b1fba12774adc7b9f3a2b83ae2097f7ff7a36937c1a17e5d23667a23f7456df",
+      "transcript": "built by the egyptians in the third century bce the great pyramid is one of many large pyramid structures built to honor dead pharaoh",
+      "duration_sec": 8.94,
+      "speech_end_offset_ms": 7844.0,
+      "audio_hash_id": "786abb218d3e63506f09f0fa1432f1e21973a9025ce9d5227cf3043870a09db7",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0042.wav",
+      "sha256": "ec9732da1561765406c3cb835a1d1776af2c82da0745a6df2bca70775793d3f2",
+      "transcript": "buses depart the inter-district bus station across the river throughout the day though most especially those heading to the east and jakar/bumthang leave between 06:30 and 07:30",
+      "duration_sec": 12.12,
+      "speech_end_offset_ms": 11108.0,
+      "audio_hash_id": "35609ccef62545658d9a604cd32cc57cd7073337b2747eecf55cc4d30a25e656",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0043.wav",
+      "sha256": "862fd6e46f1e2799a3021162b92dc68e25a418f3d6f168c8a511d17d572e0c97",
+      "transcript": "but after losing the captain's wicket india only made 36 runs loosing 7 wickets to end the innings",
+      "duration_sec": 8.52,
+      "speech_end_offset_ms": 7364.0,
+      "audio_hash_id": "7332e0aa19804ff9169e4036ed50b55273dcb2eefa2b7893f01a847afd375241",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0044.wav",
+      "sha256": "f2ff7362c89c77db652d1faa81f68e9170b7889faa09721c25724e37fc32840d",
+      "transcript": "but being placed in the high tropics just a few degrees north of equator you will need to deal with both heat always and strong sun when the sky is clear more rarely",
+      "duration_sec": 10.44,
+      "speech_end_offset_ms": 9508.0,
+      "audio_hash_id": "34ba6e1353352f29c04d8800d2d3eb507d8530c8b74a148c5e9e73994b4befd8",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0045.wav",
+      "sha256": "a22612fcf63554403e149f0132530edb74699b43772e27f10f417c79233e1fb6",
+      "transcript": "but there are a lot of things about birds that still look like a dinosaur",
+      "duration_sec": 5.36,
+      "speech_end_offset_ms": 4836.0,
+      "audio_hash_id": "d27b036364bf9939b9cb8ca3002882d875776642f8308ba0b413586d88aadc5a",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0046.wav",
+      "sha256": "fd10487d45af5104f70cfb16dced23e05d9326eb5fe8a4c87d11b4f0297a1f09",
+      "transcript": "by 1976 thirty percent of machu picchu had been restored and restoration continues till today",
+      "duration_sec": 6.78,
+      "speech_end_offset_ms": 6780.0,
+      "audio_hash_id": "7d4bafeaf1166b2d062c1a1fb947dd19d5c73df5eb661490a38db1e164b40abf",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0047.wav",
+      "sha256": "5d916750474f663bf7ab9abf78e2e98dd85bd30c0ce29e4adb0b73d9b6e7e8da",
+      "transcript": "california governor arnold schwarzenegger signed into law a bill that bans the sale or rental of violent video games to minors",
+      "duration_sec": 11.34,
+      "speech_end_offset_ms": 8996.0,
+      "audio_hash_id": "b27a1caa2afa1a3b39d45ea0c48b7c56b37676cd5bdf15c3bf3f5c4ad8ee7371",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0048.wav",
+      "sha256": "c5fb55a84059462aec20aee5caff16b044bd56c280735cb53f0bad3016f5f98e",
+      "transcript": "cancellation policies vary but as of late march most coronavirus-based cancellation policies don't extend to july 2020 when the olympics had been scheduled",
+      "duration_sec": 9.3,
+      "speech_end_offset_ms": 8868.0,
+      "audio_hash_id": "5d76581feff501e8dc295ea21f702a2770031afaf211249ace3bb1a5c983881d",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0049.wav",
+      "sha256": "822f7af763f5d231a2864bd4362627eb27d4f2ec93b6ac860cd4af2d4c3ac62e",
+      "transcript": "casablanca is one of the least interesting places to shop in all of morocco",
+      "duration_sec": 6.24,
+      "speech_end_offset_ms": 5124.0,
+      "audio_hash_id": "7891c204e2828dea3a741b88de7d811127f4f19072b4395895f4a7f3b3208c17",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0050.wav",
+      "sha256": "2b1e3fa1c4f1a788ced2fc87fb0304a29069a3d06d9dd65910646c8eaceea55d",
+      "transcript": "children are placed in foster care for a wide variety of reasons that range from neglect to abuse and even to extortion",
+      "duration_sec": 10.72,
+      "speech_end_offset_ms": 10180.0,
+      "audio_hash_id": "1458a822154bb3cb8c3388e0c65ecba01251549c6849148e677d971ef9ac9415",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0051.wav",
+      "sha256": "a5e1b287f239afd08fe0a0de01c808a51cb8aa289c6c2c9cf318a53bc82e634f",
+      "transcript": "cochamó valley - chile's premier climbing destination known as the yosemite of south america with a variety of granite big walls and crags",
+      "duration_sec": 12.12,
+      "speech_end_offset_ms": 10436.0,
+      "audio_hash_id": "1d92ffc39beb7601b75ad3079b028788c952f29f1bf2a5b09ea58902f9e02cfe",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0052.wav",
+      "sha256": "0476ed46d5cfab033443befbbc2b2357e2583766b9f3e47c0049cfd43c7c505a",
+      "transcript": "congress began funding the obscenity initiative in fiscal 2005 and specified that the fbi must devote 10 agents to adult pornography",
+      "duration_sec": 10.02,
+      "speech_end_offset_ms": 8804.0,
+      "audio_hash_id": "5e429e34af263eda037ec6c55d57e4b2b10141cd4ce32fb2ab99c12c3ccfff9b",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0053.wav",
+      "sha256": "212c6b4f63589e0785bc6790568ca0c132083d14fe46b1a05c84545820302a96",
+      "transcript": "crossties were introduced fairly early to hold the tracks in place gradually however it was realised that tracks would be more efficient if they had a stip of iron on the top",
+      "duration_sec": 10.74,
+      "speech_end_offset_ms": 10436.0,
+      "audio_hash_id": "2a14ad88307f1e08843996337482d90407fdb899a839522c55b0bdaa99dd9fa8",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0054.wav",
+      "sha256": "e590ad7686258e897b90310667ce818998ef6ba2325e571df78705bde6eefb40",
+      "transcript": "cuomo 53 began his governorship earlier this year and signed a bill last month legalizing same-sex marriage",
+      "duration_sec": 9.42,
+      "speech_end_offset_ms": 8164.0,
+      "audio_hash_id": "003570bc0a672c763a3965da2933ea3e2cbb947e3a296c66123e0100f6957ad3",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0055.wav",
+      "sha256": "4bf6a20e74646985e5452a826d547015ed1a9f195a001ef9d22c6a0f72ac0fbe",
+      "transcript": "danielle lantagne a un expert on the disease stated the outbreak was likely caused by the peacekeepers",
+      "duration_sec": 6.3,
+      "speech_end_offset_ms": 5892.0,
+      "audio_hash_id": "68267fca97e365dc20424367c2d6a39474832ae6163a91985189d0d674660f63",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0056.wav",
+      "sha256": "630315db89268d3ef09291b9c79f5b1205fd288ced54f89a557ca7574d2cd3f3",
+      "transcript": "del potro had the early advantage in the second set but this too required a tie break after reaching 6-6",
+      "duration_sec": 8.1,
+      "speech_end_offset_ms": 6980.0,
+      "audio_hash_id": "cfbc287098d371f807b3f7d7ed6ffb0a26ae322d5f71ee7a9e7c922370590c6b",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0057.wav",
+      "sha256": "116445d61c25a89c82e8a885a6d8fa2aa072b0a971becd04b5b423dbc599eb56",
+      "transcript": "do not deface the site by marking or scratching graffiti into structures",
+      "duration_sec": 4.5,
+      "speech_end_offset_ms": 4260.0,
+      "audio_hash_id": "a832aa0d3ad30ad4e08d76412a77051dffe7e75c9941a809990dc48e32841ff4",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0058.wav",
+      "sha256": "4f9e23c27053b7cfe2cfa1497baf6bdc7b331d7cffdd91b07c6e21b25d431961",
+      "transcript": "due to the underwater topology the return flow is concentrated at a few deeper sections and a fast current to deep water may form there",
+      "duration_sec": 10.92,
+      "speech_end_offset_ms": 9764.0,
+      "audio_hash_id": "9dd71d24807f2032b57430dfe8b6b60425f2606b0830678244b7d98aedb744ae",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0059.wav",
+      "sha256": "79ed1dcdaf5c346637c86cc90223a3990873ce5d0f120f252a0b66fd72ec4783",
+      "transcript": "during the 1920s the prevailing attitudes of most citizens and nations was that of pacifism and isolation",
+      "duration_sec": 7.68,
+      "speech_end_offset_ms": 6628.0,
+      "audio_hash_id": "5b9442288d19cea552904cf7a41268ae63cf9fde675df220a9f6bd74b3e77acd",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0060.wav",
+      "sha256": "132e39af4ddb994a67088e054b0774b73ad4e135e34b442662179be64260a9dc",
+      "transcript": "during the revolutionary war the thirteen states first formed a weak central government-with the congress being its only component-under the articles of confederation",
+      "duration_sec": 10.08,
+      "speech_end_offset_ms": 9028.0,
+      "audio_hash_id": "641cdac683122fa5ff1662a5eb95dc90568977cc50ab40bba9efe53623609343",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0061.wav",
+      "sha256": "e8ab94568047c25e50ec01291a7c3c791e254ac6fb77180038021f319d8a89bf",
+      "transcript": "during the struggle for independence organised by the mau movement a peaceful gathering in the town resulted in the killing of the paramount chief tupua tamasese lealofi iii",
+      "duration_sec": 12.12,
+      "speech_end_offset_ms": 11428.0,
+      "audio_hash_id": "f1f1d6a8bf70863fff58c36b20bf3371a5c2990c2b6659be8c016d5d0ea3507c",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0062.wav",
+      "sha256": "8fb9302574d82bbb193cfd1e8e396fb3da30673d893035a6c9cae6b691380f4c",
+      "transcript": "during this period of european history the catholic church which had become rich and powerful came under scrutiny",
+      "duration_sec": 11.4,
+      "speech_end_offset_ms": 10532.0,
+      "audio_hash_id": "1f80c3c3bfd5b6ac0a17e76b2ad91034e267ef76e8584ffc6c1c262b10c6b7bd",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0063.wav",
+      "sha256": "61b720bf29b7cfa5965304d486a3775e97d5bdeca61e6b1df0d42ed8b7f67b7e",
+      "transcript": "duvall who is married with two adult children did not leave a big impression on miller to whom the story was related",
+      "duration_sec": 6.24,
+      "speech_end_offset_ms": 6240.0,
+      "audio_hash_id": "12f71cc8f69fa93efce0fc2fae1d49b58c387ca138a9a5a537ad9fa6ca1a2ebc",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0064.wav",
+      "sha256": "5d3a81ac70c339f2f90046e3aabfe7f1538d9f77f0d58e3f6c8562e67bec66be",
+      "transcript": "elements like calcium and potassium are considered metals of course there are also metals like silver and gold",
+      "duration_sec": 6.24,
+      "speech_end_offset_ms": 5924.0,
+      "audio_hash_id": "8a8503cefc170c54b5fbc11d7f6aac79a6c2ab278ac3b2fa7592e45512b80e0f",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0065.wav",
+      "sha256": "39b4eb836dbbe40573893b4e430c4da05aa8bd94bf199c5a32856ece79984ecf",
+      "transcript": "everyone participates in society and uses transportation systems almost everyone complains about transportation systems",
+      "duration_sec": 11.64,
+      "speech_end_offset_ms": 10724.0,
+      "audio_hash_id": "42dcde60ffc3f64723a9840673bd480cf6a3fa4ff9e1a4709c98662ce326f9e0",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0066.wav",
+      "sha256": "d78ab9e950e027124d78106a82c72b62b94b1793caee0d98763765292850f3f0",
+      "transcript": "everything in the universe is made of matter all matter is made of tiny particles called atoms",
+      "duration_sec": 6.42,
+      "speech_end_offset_ms": 5924.0,
+      "audio_hash_id": "ec5fd36d67a7290b99d50e73dd87b7ace99a35094643160baeac61f625503ea9",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0067.wav",
+      "sha256": "f130b08ad15bbb19c269ab91cb165fe6a781f7d5863f754ce2bdfcbfa10a6485",
+      "transcript": "fellow wrestlers also paid tribute to luna",
+      "duration_sec": 3.6,
+      "speech_end_offset_ms": 2852.0,
+      "audio_hash_id": "529e0ed0ea986f28358ecec7c81824c5fb508778941ab200fd490a33ffd4422e",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0068.wav",
+      "sha256": "cadc43f982aff6b45030f2be775da32d47a92d60689f149becf28eccedca7228",
+      "transcript": "feral children may have experienced severe child abuse or trauma before being abandoned or running away",
+      "duration_sec": 6.54,
+      "speech_end_offset_ms": 5796.0,
+      "audio_hash_id": "d947af0d3e3805cd0518fecad29dc895750437b9a06b30a4630c0c2482519c28",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0069.wav",
+      "sha256": "bc3463666368b5e4a7f1282ecd3e597809b672d1faa91a7f7d001861bcf2c79c",
+      "transcript": "field trips are a large part of any classroom quite often a teacher would love to take her students places to which a bus trip is not an option",
+      "duration_sec": 9.84,
+      "speech_end_offset_ms": 8452.0,
+      "audio_hash_id": "0769c9a5d0614415a86d0cbb47157673e1ab9c932d35dd5958d68c67d37ebfaf",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0070.wav",
+      "sha256": "48cb752bd48cb2ad11718c16140fa5e32f5d160f501a126e04bc253694444a84",
+      "transcript": "finally there are many small cats including loose pet cats that eat the far more numerous small prey like insects rodents lizards and birds",
+      "duration_sec": 8.64,
+      "speech_end_offset_ms": 8640.0,
+      "audio_hash_id": "56c44e182a568bcf92c986b4838bf447754bb1d0a217aca6ad439b6784c8130e",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0071.wav",
+      "sha256": "8b3662b9983b899769d2a5b6b8d84acfee42f21f3cd625c30dc169eb003fd515",
+      "transcript": "finland is a great boating destination the land of a thousand lakes has thousands of islands too in the lakes and in the coastal archipelagos",
+      "duration_sec": 9.36,
+      "speech_end_offset_ms": 8292.0,
+      "audio_hash_id": "bc01a6e67134eb1bc13e7edda51885c8fb3c582f21c93ef30a4e9cdda93ac558",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0072.wav",
+      "sha256": "40b3e243d7767becd66d83d7a0097c4a657cc39593cef9c2f42c3bc2205b5526",
+      "transcript": "fire rescue crews eventually doused the fire by 11:35 pm",
+      "duration_sec": 5.72,
+      "speech_end_offset_ms": 5476.0,
+      "audio_hash_id": "699c1696848a08aed4e89a55001ea524cbfe004d93abc8e9210496aaf3736f88",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0073.wav",
+      "sha256": "2f77be373e7ffe2aa2a80f8b1f76b80657d9c51781deb4bac2dfe931ef2009ed",
+      "transcript": "first most riders wear riding boots with a heel and a smooth quite narrow sole",
+      "duration_sec": 7.86,
+      "speech_end_offset_ms": 6852.0,
+      "audio_hash_id": "05507e423cecfd05c06a6fc97c4b252fa60edd9dbdaa4872a7967f522bd39e11",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0074.wav",
+      "sha256": "fa11bf350e351880962cd6a73f785665232107e0813dfca51566fb4180289a86",
+      "transcript": "for example each year students from bennet school in north carolina design a website about their trip to the state capital each year the website gets remodeled but old versions are kept online to serve as a scrapbook",
+      "duration_sec": 11.28,
+      "speech_end_offset_ms": 10948.0,
+      "audio_hash_id": "478b208ae4874426b5b3bceb836152caf999ed4ed1be407f14dfb74d7195351b",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0075.wav",
+      "sha256": "bf69118997d1df9de59b5750c0bb854b98fec8dc8eea5d52d6c92454d41aac23",
+      "transcript": "for the springboks it ended a five-match losing streak",
+      "duration_sec": 4.98,
+      "speech_end_offset_ms": 4644.0,
+      "audio_hash_id": "c4ec4b0e11432cdcdb188ba75ba6aacbdbeb7463817336af70d9207ff8b1a5e5",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0076.wav",
+      "sha256": "dca8e01f5dbc6601f0252d7030f62f2ec96896beb9e5ae18fe80bfdfe2044c8b",
+      "transcript": "four skiers in the women's sitting group failed to finish their runs and 45 of the 117 total skiers in the giant slalom failed to rank in the race",
+      "duration_sec": 7.68,
+      "speech_end_offset_ms": 7680.0,
+      "audio_hash_id": "3cebc9025c97f1f95bff871d0007f85a84359b421d3ccdf2b13c550c1f1a75d9",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0077.wav",
+      "sha256": "421fc5c58e3833b7abd0048fd6d00dcb396ccfdc68e688166bde4a76286ff860",
+      "transcript": "giancarlo fisichella lost control of his car and ended the race very soon after the start",
+      "duration_sec": 5.16,
+      "speech_end_offset_ms": 4868.0,
+      "audio_hash_id": "9fd2f540e2f7439cae61b8f94805f26c929cd50aa2f3c1412b12127a6cb5951c",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0078.wav",
+      "sha256": "2af2fccd7d25fd1b2f4d176393dfe264e2a34f473a6743a0fb2b5b75f5558779",
+      "transcript": "goats seem to have been first domesticated roughly 10,000 years ago in the zagros mountains of iran",
+      "duration_sec": 10.62,
+      "speech_end_offset_ms": 8772.0,
+      "audio_hash_id": "f63d1b7ac792b41e2b1d3e4e534d1eebf8ec2727ed0135f834ebb8643b274d98",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0079.wav",
+      "sha256": "052a634ab62106d9711567d35b9b8c493740ef18c6929fa36e04ce6104e017aa",
+      "transcript": "he added that they should not however be asked to take on obligations that go beyond their development stage responsibility and capabilities",
+      "duration_sec": 12.22,
+      "speech_end_offset_ms": 11012.0,
+      "audio_hash_id": "d50ed88754c27dd2d1bd5c30a0315f9f514c4764695c4c0003a06d4a8617ae7c",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0080.wav",
+      "sha256": "ea8cbb4573d14d6962c184b07d7a9d6c3a63b8d0fa8464960e38f913dde12647",
+      "transcript": "he did not set a figure for the cuts saying they will be made based on china's economic output",
+      "duration_sec": 6.36,
+      "speech_end_offset_ms": 5476.0,
+      "audio_hash_id": "1b1df35406aa453a7afe2ae9235aec49a6310fe0e40d464555344d3cd94c2d1c",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0081.wav",
+      "sha256": "f6f1e4629bf99f74675e6096830e4378c98d5a75866581c0c65de364eaf72b9c",
+      "transcript": "he has been unable to take the drugs needed to overcome his pain as they are banned from the games",
+      "duration_sec": 6.36,
+      "speech_end_offset_ms": 5316.0,
+      "audio_hash_id": "0e0b3072b1cf2577eb20448e99b7458671ee2e6d87dd696f85920809d3ff3be6",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0082.wav",
+      "sha256": "37ef76aee801dd3a0cebd13225b857bba669afb6e542e8bd85147be9e2dc7b2f",
+      "transcript": "he referred to the rumors as political chatter and silliness",
+      "duration_sec": 3.84,
+      "speech_end_offset_ms": 3588.0,
+      "audio_hash_id": "ced89c0cb53ef317cb9eda09f76affee44d44f4f193c6e73f5b46539adff9c08",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0083.wav",
+      "sha256": "3aa23ae7381cc732f093557ebed004bdd5887baca807ac91bcbfc4e82633a86b",
+      "transcript": "he was also engaged in engraving banknotes for many countries recent examples of his work including the prime ministerial portraits on the front of the new canadian $5 and $100 bills",
+      "duration_sec": 12.36,
+      "speech_end_offset_ms": 12360.0,
+      "audio_hash_id": "561679e386e26db0936c2e341727c3a9b0f320c1167a1b51088df8f295f7e5ba",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0084.wav",
+      "sha256": "a120d462753549efd9055044a0882924d0277bf6553f82fb9604f18f22c40bb2",
+      "transcript": "he was greeted by singapore's deputy prime minister wong kan seng and discussed trade and terrorism issues with the singapore prime minister lee hsien loong",
+      "duration_sec": 11.64,
+      "speech_end_offset_ms": 10436.0,
+      "audio_hash_id": "1c0b42a9b0d61959178f84424c3ac7a336d3184e3ae599ab6c164b2177a7906f",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0085.wav",
+      "sha256": "7c2ad9836a31be8d25a6aaab7126029744d900f1f2897006ade0a5cfeba1ef60",
+      "transcript": "he was initially hospitalised in the james paget hospital in great yarmouth",
+      "duration_sec": 7.5,
+      "speech_end_offset_ms": 7044.0,
+      "audio_hash_id": "aaac96b7826cd656c8e7efc14c167f7681a6556dc47654da21e4f5025526b798",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0086.wav",
+      "sha256": "b8c5bb5a40665f999c22fb41717b0a25136ecfe8718192a670009cfcbfe2fbd9",
+      "transcript": "he was reportedly aged in his 20s. in a statement bieber said [w]hile i was not present nor directly involved with this tragic accident my thoughts and prayers are with the family of the victim.",
+      "duration_sec": 10.56,
+      "speech_end_offset_ms": 9636.0,
+      "audio_hash_id": "4d02c66531d71ecdedd4118261d287ca8bde9755d49ade780ffd803c32d523c8",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0087.wav",
+      "sha256": "7aeb5a108ce35f94f39e0612bbcad9b970aa6b78dfbb97a48f209d091d9dfb56",
+      "transcript": "he was subsequently relocated to addenbrooke's hospital in cambridge",
+      "duration_sec": 6.84,
+      "speech_end_offset_ms": 5124.0,
+      "audio_hash_id": "75acaa470e56ed6e541cd2fe09d1530c872912116928d18318a27316e4a0d9f6",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0088.wav",
+      "sha256": "6f290a1d9b62d0949189c33629dcaf5ccf1a97e2be7a10f1c53dd6d173288917",
+      "transcript": "hong kong island gives the territory of hong kong its name and is the place that many tourists regard as the main focus",
+      "duration_sec": 7.02,
+      "speech_end_offset_ms": 6468.0,
+      "audio_hash_id": "80396d1ac761d9ce45cbb5e0f442de97a33bd067b1d67d8b717cc2fc341d9b12",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0089.wav",
+      "sha256": "187fe845ced04addd591d0094f689e8b092c5e529202dcab04d82466607243f4",
+      "transcript": "however due to the slow communication channels styles in the west could lag behind by 25 to 30 year",
+      "duration_sec": 10.56,
+      "speech_end_offset_ms": 8932.0,
+      "audio_hash_id": "f86223c93b135de71e203aa094e629d9b98f04917fb74a77db77fcdd988ecc03",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0090.wav",
+      "sha256": "f5a7bc20823f9ba763bbe0dd6a3d3962c26fa2a4023c7a7a25c6e8fece6aa59b",
+      "transcript": "however that is not true although there is something written on the back of the document it is not a treasure map",
+      "duration_sec": 10.02,
+      "speech_end_offset_ms": 8804.0,
+      "audio_hash_id": "edfdb1ad3efa69458e0d1ddfd367f70cc24450fcfcaeb1a0e95592e8ed7bdce8",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0091.wav",
+      "sha256": "11d7e77cb7ce59033c81a9a61cc4974ffbae6bc020f2352eb8672ae97c46558d",
+      "transcript": "hydrogen ions are protons that had their electrons stripped off them since hydrogen atoms consist of one proton and one electron",
+      "duration_sec": 7.68,
+      "speech_end_offset_ms": 7332.0,
+      "audio_hash_id": "0394c323ee0fa3d8c976ad5cd7af4edbd45c845a9978e073db551d749bf50a7c",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0092.wav",
+      "sha256": "cf00c3fb6e920444ad2d7c14b623fb23e50d86671cd63844e35c44d66103bc78",
+      "transcript": "if you have watched the movie national treasure you may think a treasure map was written on the back of the declaration of independence",
+      "duration_sec": 6.78,
+      "speech_end_offset_ms": 6468.0,
+      "audio_hash_id": "c4dc2eedfe8715ac622f34c2d7192a9ee8c52add9478a7f1b0ac4a066139f110",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0093.wav",
+      "sha256": "c42a8f9bf617dbcc30502ac32fea1f1816b222f7ca211998cab5ee4b28090ef5",
+      "transcript": "if you only go ashore using shipboard excursions you will not need a separate visa as of 2009",
+      "duration_sec": 9.26,
+      "speech_end_offset_ms": 8196.0,
+      "audio_hash_id": "7c4d6bc9d047287c6170f4b5be7122dce0f8957c8ad829e7ac96429bf3b31af0",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0094.wav",
+      "sha256": "dc82f22dc82e60863cf32f9c9368c01cddc24992089ffc74c6f1a9a99f1a9637",
+      "transcript": "if you want to be close to the action you're going to have to get in early to get a camping site close to the music",
+      "duration_sec": 9.24,
+      "speech_end_offset_ms": 7940.0,
+      "audio_hash_id": "2662d9adec6e73ab1df437a68d7d59e452c54f36ce1848b6b9c3b659d4ecb74b",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0095.wav",
+      "sha256": "e585fd60c5f550b3d57a0d8064d2ec0bd78c7e303c1a3fa6fd43413d3405b345",
+      "transcript": "if you're not used to driving on country roads keep your wits about you steep grades narrow lanes and sharp curves predominate",
+      "duration_sec": 11.1,
+      "speech_end_offset_ms": 10532.0,
+      "audio_hash_id": "73ae4db8e4ea2836d68347cd42faff731199768aee9df6c221c53ce22555e019",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0096.wav",
+      "sha256": "b918971a0a98868eca5b56e6168fc25487c142837fa16231c848c3ed5f52679a",
+      "transcript": "in 1990 it was added to the list of world heritage sites in danger due to the threat of desert sands",
+      "duration_sec": 7.32,
+      "speech_end_offset_ms": 6628.0,
+      "audio_hash_id": "0692c92638f3d78627dc186fbf8a8cf51baad5031a0e0e36ff4f52e0709dd456",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0097.wav",
+      "sha256": "3bf775cb6792d0356a372e9061ea949428152d2aa54aeebb16d29fa50483b4c1",
+      "transcript": "in 2002 goma was destroyed by lava from the nyiragongo volcano which buried most of the town's streets particularly the town centre",
+      "duration_sec": 10.38,
+      "speech_end_offset_ms": 9188.0,
+      "audio_hash_id": "78869531437cb1c5e48abfa5e6bcf766d25fcf88256f8770895880b90c432e9d",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0098.wav",
+      "sha256": "993f83ebd176cd930c155650adabb00398b8c2b0ffc2a09aaed2423e67d8a360",
+      "transcript": "in a carriage they traveled back to paris surrounded by a mob of people screaming and shouting threats against the king and queen",
+      "duration_sec": 10.22,
+      "speech_end_offset_ms": 8612.0,
+      "audio_hash_id": "de49aed17a191c969aa24adc7ae76ce3c90605717729674ea191bc6dfeb61457",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0099.wav",
+      "sha256": "1548754ed660ce24bb86fda3e9826837ad2da0df763ac707c2789e3e1641c612",
+      "transcript": "in fact it is not easy to find at all even if one knew it existed once inside the cave it is a total isolation",
+      "duration_sec": 7.92,
+      "speech_end_offset_ms": 7204.0,
+      "audio_hash_id": "65c8ef43e6be69e296c569514c57fd82a02388088a68cad27faf5373774048df",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0100.wav",
+      "sha256": "53cb04ec97191378995b268b25e716251fd2352263677e4a11e38dc02584f1c0",
+      "transcript": "in just two weeks the americans and free french forces had liberated southern france and were turning towards germany",
+      "duration_sec": 10.18,
+      "speech_end_offset_ms": 9412.0,
+      "audio_hash_id": "7da0ae12d177edc80ea1dc67b5644195b1dddd3295273395d9e1dda4bdbf7981",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0101.wav",
+      "sha256": "e5b361351ac7eac1ab2cfc1142f987c0e67ed6e7aa746db55be24dc0054577da",
+      "transcript": "in many other cities of italy and in the rest of the world particularly in poland similar setups were made which were viewed by a great number of people",
+      "duration_sec": 8.4,
+      "speech_end_offset_ms": 7524.0,
+      "audio_hash_id": "f802045e216397dcf6ce223cc7416683d7c369f01585991c7c8ccdf851a186d4",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0102.wav",
+      "sha256": "200fe1513d25a4f14c8db99129141614f92ae4810a62fbbe0a32ed6658bb9a02",
+      "transcript": "in particular it is claimed that one can detect whether a person is lying by interpreting micro-expressions correctly",
+      "duration_sec": 6.12,
+      "speech_end_offset_ms": 5828.0,
+      "audio_hash_id": "e6c6713c93b6edf4883a4f562c09eba57d6c0b41465ac2e0fc3a16a71c0ae98a",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0103.wav",
+      "sha256": "53c9c9a637c2d864fe461bf0dd2afd1ad3c9601d08431b1196c7f3cc8c45c101",
+      "transcript": "in some areas boiling water for a minute is enough in others several minutes are needed",
+      "duration_sec": 5.64,
+      "speech_end_offset_ms": 4772.0,
+      "audio_hash_id": "2e0c9b224b11bfd934f77cd35277038dab0081fa621b0c5bb75d9ff23fd101f8",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0104.wav",
+      "sha256": "f5fc665773365bbd4280076c0b82019d224d2a1bbe4a83fe77979d96bc465bcd",
+      "transcript": "in the archipelagos and lakes you do not necessarily need a yacht",
+      "duration_sec": 7.48,
+      "speech_end_offset_ms": 6788.0,
+      "audio_hash_id": "f18ba5de78ef526fe516e4313e32f60fac32feb96cc76707bc074f07868619c2",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0105.wav",
+      "sha256": "fb2e4d9dc1a39bc5e4ae8bdfa420b8be61dcd63531b832987081c0c581830151",
+      "transcript": "in the north the region is bounded by the sahel and in the south and west by the atlantic ocean",
+      "duration_sec": 9.58,
+      "speech_end_offset_ms": 8164.0,
+      "audio_hash_id": "1535bb82cd3f68cd91370af8b74126b1f6f5ba4adf2db28c98e07813b909d3ae",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0106.wav",
+      "sha256": "054a22f5dbddc15cc1f13b0f0dac182aaaa0f65ebe1ca8936092f89ff5a60ace",
+      "transcript": "in the warm climate of the middle east the house was not so important",
+      "duration_sec": 6.72,
+      "speech_end_offset_ms": 5476.0,
+      "audio_hash_id": "b4496021220cb7e69de3c1f1bffefcdaa80bb37c71a47627831986b99def4098",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0107.wav",
+      "sha256": "ce45516339526c036bbdf2d49c63e5bb867c8e962d918f848aec4986e918d2f2",
+      "transcript": "it also attacked anything that entered the water even a giant dinosaur such as t rex would be no match for it",
+      "duration_sec": 9.12,
+      "speech_end_offset_ms": 7684.0,
+      "audio_hash_id": "407224d4003a66ac006371ec3b549097d1b1dfc559b727ee73ff529202189ffc",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0108.wav",
+      "sha256": "cbe192b57320857db6c09c9cb3426b491d84cf3c43f0cf5d9bf7efe0a3de84a0",
+      "transcript": "it has brought us the train the car and many other transportation devices",
+      "duration_sec": 4.86,
+      "speech_end_offset_ms": 4860.0,
+      "audio_hash_id": "6f6b43348365aad541208602ff56bcec730828bc04686920f51a6965757a3b37",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0109.wav",
+      "sha256": "599c669ea5c8bff587ecc1ea1e2bc84f3b35688304a3b3e3a07e6470793eb847",
+      "transcript": "it is one of the main attractions of south africa and it is considered the flagship of south african national parks sanparks",
+      "duration_sec": 10.92,
+      "speech_end_offset_ms": 9444.0,
+      "audio_hash_id": "06735536d0fd3aa6369049aeba0403346759cc669d75abde6cdecd1a916767ac",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0110.wav",
+      "sha256": "8e862e4e08a8fe2a46bcc4d8b6224549a537064010d064f89a16e8722e96c635",
+      "transcript": "it is related to but usually not involving alpine style ski touring or mountaineering the latter ones done in steep terrain and requiring much stiffer skis and boots",
+      "duration_sec": 9.9,
+      "speech_end_offset_ms": 8868.0,
+      "audio_hash_id": "ccfdcc51718f0959b81cc093342c5dec473af395ae851729558eea777789e66d",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0111.wav",
+      "sha256": "df0a95689bc8d6649f39cd8726049d14e7263ec5074031b6b2d9ad18fa79f971",
+      "transcript": "it is thinner under the maria and thicker under the highlands",
+      "duration_sec": 7.2,
+      "speech_end_offset_ms": 6884.0,
+      "audio_hash_id": "d58c3540f218854746c6758da06fb6020a949ef60977ce3f7cb89a7f5d6e1ba0",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0112.wav",
+      "sha256": "4aa0e2b5b8363257542ccd724cce820fbe4e4c085e87c882f189c4ef0b10e22c",
+      "transcript": "it was ruled by the vichy french these were french people who had made peace with the germans in 1940 and worked with the invaders instead of fighting them",
+      "duration_sec": 9.6,
+      "speech_end_offset_ms": 8420.0,
+      "audio_hash_id": "9bc021ca5260e2ce6b6fea2e2dec8def57775bac4ee910ea231089f0131ee94e",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0113.wav",
+      "sha256": "1819b7345c5711a59ac13e3b447a3b5739c466884e1d1bbcd96b57b62a583ae6",
+      "transcript": "italian is also the everyday language used by most of those who work in the state while latin is often used in religious ceremonies",
+      "duration_sec": 12.32,
+      "speech_end_offset_ms": 12068.0,
+      "audio_hash_id": "ccf99f40f79812df16f7f4462e7f180de003b32b8aac0660a2dcb9dd323e0071",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0114.wav",
+      "sha256": "66280bcfe826c0f21da65b6793d26dbdcce45800f223a69e07b2cd00224a18dd",
+      "transcript": "its renown for being an epicenter of luxury began in about 400 a.d. and lasted up until about 1100 a.d",
+      "duration_sec": 11.48,
+      "speech_end_offset_ms": 10948.0,
+      "audio_hash_id": "7280d0d49c00fe775e8c1488a090ae7c55e294089d81a88d8fcff9392aa5d89b",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0115.wav",
+      "sha256": "95e0383cf47ae33d0f393a58ce336969cf58be975ed6766bc6c4ce9fc808ce98",
+      "transcript": "just like the moon exerts a pull on the earth causing tides so does the milky way exert a force on the sagittarius galaxy",
+      "duration_sec": 7.14,
+      "speech_end_offset_ms": 6724.0,
+      "audio_hash_id": "10080127046fd90ec06845a9ccfce9a7c73f2094fff4ba1c274efb5b3ce60d7a",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0116.wav",
+      "sha256": "f18f02e657008239ceed24942214ad3624596e2d66c8799388dc0fd8d10dd9b2",
+      "transcript": "large areas further north are quite sparsely populated and some is nearly uninhabited wilderness",
+      "duration_sec": 7.44,
+      "speech_end_offset_ms": 6276.0,
+      "audio_hash_id": "9992b9f00a90c281566da0e5fb622e32500962e43d278a14c303c99e78ce8c48",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0117.wav",
+      "sha256": "c5cde97d72d3aa4e0fe337f27a0a7d4a0134ba0af4b93a6eb3d34edfb0bf6900",
+      "transcript": "last week meti announced that apple had informed it of 34 additional overheating incidents which the company called non-serious",
+      "duration_sec": 9.12,
+      "speech_end_offset_ms": 8548.0,
+      "audio_hash_id": "153dda096168d4eed22cd0c5a635bda3de39ee25078ac296c61fae049fe460c3",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0118.wav",
+      "sha256": "38c9905b4a01fcb845dd1e9d59385a1c9a322c8e1e2305871a6a006da2703c72",
+      "transcript": "late on sunday the united states president donald trump in a statement delivered via the press secretary announced us troops would be leaving syria",
+      "duration_sec": 9.96,
+      "speech_end_offset_ms": 8836.0,
+      "audio_hash_id": "ee85472801d49bb45ee23098d99f8032f2a35233d84b06d20c3112726e24f5c4",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0119.wav",
+      "sha256": "05af7609de4f7d5611bd0eda7d14754dcd38e91f67f43a59e52bc23a5ca96601",
+      "transcript": "layton had asked for changes to the conservatives' environmental bill during the meeting with the pm asking for a thorough and complete rewriting of the conservative party's environmental bill",
+      "duration_sec": 9.72,
+      "speech_end_offset_ms": 9252.0,
+      "audio_hash_id": "f7364e0e0f48915dd581760ece704ddea34beae846caa6b3fc707fe845fd066d",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0120.wav",
+      "sha256": "73245b51f9bad77d8454152c71dfd6c3f587f7ed8da8e9d733b92c2e83715e87",
+      "transcript": "liberal criticism of the reconstruction effort has focused on the awarding of reconstruction contracts to perceived washington insiders",
+      "duration_sec": 8.04,
+      "speech_end_offset_ms": 7780.0,
+      "audio_hash_id": "7705bfb57e2d6aba63d364266bb1b92b92ef44337e3a7e6d1c355dbf0e0140e5",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0121.wav",
+      "sha256": "ed0a4fb0476bc3b94f5264ee9eed663c3e6088e0ae1cadc78933d6cbdb21ff58",
+      "transcript": "lion prides act much like packs of wolves or dogs animals surprisingly similar to lions but not other big cats in behavior and also very deadly to their prey",
+      "duration_sec": 10.92,
+      "speech_end_offset_ms": 10148.0,
+      "audio_hash_id": "5ead2f5badc4df50c98a3c2de30e8644dfb90989e59d5a211f57c1c4e76515a2",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0122.wav",
+      "sha256": "e2091a92911373efb4cf74cf93e582a1fac4ed24b19fe86e45e8e6fd18d9d722",
+      "transcript": "lions are the most social cats living in large groups called prides",
+      "duration_sec": 6.6,
+      "speech_end_offset_ms": 5540.0,
+      "audio_hash_id": "feafa6eff30d6801665d66e626cb9d9b0ad6e7885ce9fc896e2b060f8ff9cd76",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0123.wav",
+      "sha256": "6cea30785898581a00a7696099200edd67ec94c893f13e6810d8c92993284cbd",
+      "transcript": "madagascar is by far the biggest and a continent on its own when it comes to wildlife",
+      "duration_sec": 7.32,
+      "speech_end_offset_ms": 6500.0,
+      "audio_hash_id": "0ffebeb460008c94fca301dec41c18c21dd7054322a264641ffc5783f7168a06",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0124.wav",
+      "sha256": "de327ecc1669c196456fca9d16e8f976aaa53c9271bcd54a205559e97734c5b7",
+      "transcript": "many german baked goods also feature almonds hazelnuts and other tree nuts popular cakes often pair particularly well with a cup of strong coffee",
+      "duration_sec": 10.44,
+      "speech_end_offset_ms": 9348.0,
+      "audio_hash_id": "23426b9db6e9bc911c9556875f3c44416545ead3dcbb22701531b93121b41be0",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0125.wav",
+      "sha256": "6695d20dc3ef097874f66bc0f1da0398b47835e8ab598f632dbaad770e112dcd",
+      "transcript": "many people don't think about them as dinosaurs because they have feathers and can fly",
+      "duration_sec": 4.32,
+      "speech_end_offset_ms": 4320.0,
+      "audio_hash_id": "72ca5c538f08af8dc411979af26a7b0423627dba0a00f282015ddcb404e2db21",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0126.wav",
+      "sha256": "f44749c2c693893bca6d0ed01498584b9ef5496d0afb783c4c218e14e923bae0",
+      "transcript": "martelly swore in a new provisional electoral council cep of nine members yesterday",
+      "duration_sec": 10.12,
+      "speech_end_offset_ms": 8100.0,
+      "audio_hash_id": "11c31dab0cf9b18fd17c8bd393987e259d742b496f4af7fd97e7bef8e12f4d23",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0127.wav",
+      "sha256": "c42367fd8a5e8ef4b7577dd0e356768c04afb6ebda5e919207f4fbb3ce7b0fac",
+      "transcript": "mass car ownership also leads to a higher incidence of accidents on the roads which leads to the invention of new techniques in healthcare for repairing damaged bodies",
+      "duration_sec": 9.48,
+      "speech_end_offset_ms": 9092.0,
+      "audio_hash_id": "3d281b45994f0818093110c7d9d7ac4705c3a62aecbc9869bc288edacf173fa7",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0128.wav",
+      "sha256": "27e140a9dfda2c741aedc147df111fae8a62152cb357b182e78130dc8760ff83",
+      "transcript": "middle order batsmen sachin tendulkar and rahul dravid performed well and made a hundred-run partnership",
+      "duration_sec": 8.64,
+      "speech_end_offset_ms": 7460.0,
+      "audio_hash_id": "807f621637078ee843b597c73bfea63bf70ed412e50e75a3df5dc83621f72c3f",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0129.wav",
+      "sha256": "c7b27afe050dda42d14393fee37217b9552fd2197d762d8dca5a0862ece125c7",
+      "transcript": "mosasaurus was the apex predator of its time so it feared nothing except other mosasaurs",
+      "duration_sec": 6.9,
+      "speech_end_offset_ms": 6628.0,
+      "audio_hash_id": "eee4507ed3006d2f31cb874290c6f3832cb3f2471420385af51daa3b1a175c85",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0130.wav",
+      "sha256": "a4072e35f6687ca9434a0cff951e6e7a6de794e2c742f10213bed73b07d4bb19",
+      "transcript": "most modern research telescopes are enormous facilities in remote areas with favorable atmospheric conditions",
+      "duration_sec": 6.84,
+      "speech_end_offset_ms": 6840.0,
+      "audio_hash_id": "b50b6241451d1ca60a4b83b43350d43b23004b1da53921a1b5537dd5457fd640",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0131.wav",
+      "sha256": "46f3c000b1b5721bc2ff8bab384aa4349e885a3089bd57c53571903da0e9fc09",
+      "transcript": "most of the buildings on the edges of the complex have been rebuilt in order to give tourists a better idea of how they originally appeared",
+      "duration_sec": 7.62,
+      "speech_end_offset_ms": 7012.0,
+      "audio_hash_id": "9e6ed2a2de8e0798c9ffa9a2a8b8ec23d6edb1afde4dfbc7f3bbb16cdc344bb6",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0132.wav",
+      "sha256": "fe8406d42a257b55d36a54badcf9efbaeefbda444919febe25869c3d7b699856",
+      "transcript": "most of the smaller islands are independent nations or associated with france and known as luxury beach resorts",
+      "duration_sec": 10.52,
+      "speech_end_offset_ms": 10520.0,
+      "audio_hash_id": "69d9fbba207e1ef34ae51cdf76093e37ac3c28222bd3237022a9412bab417e59",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0133.wav",
+      "sha256": "bdd0cf75728d68aa9b37887fbc2c19b795cd043aed8796dbf4bffd6f99ba4306",
+      "transcript": "ms is a disease that affects the central nervous system which is made up of the brain the spinal cord and the optic nerve",
+      "duration_sec": 7.2,
+      "speech_end_offset_ms": 6948.0,
+      "audio_hash_id": "56b81ab91389c9a36cdf86530101a0a0fc38e26fc8ebcf3c655cdbe3078027fa",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0134.wav",
+      "sha256": "cda5aef68e0c230b63fe97b518788280e6418f394f725edc2ec5f14eda6bf4b9",
+      "transcript": "muhammad was deeply interested in matters beyond this mundane life. he used to frequent a cave that became known as  hira‘” on the mountain of  noor” light for contemplation",
+      "duration_sec": 11.28,
+      "speech_end_offset_ms": 9988.0,
+      "audio_hash_id": "cb0be16cb624ea264d9dd46bd27cd5faa2ca1ab0e2634b54cb335c2c61e0d7f6",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0135.wav",
+      "sha256": "314035d27b9dedc778ea2e00ce841dbdb81a627805316eda8004cf36c0ba01b2",
+      "transcript": "needless to say if you know a romance language it will be easier for you to learn portuguese",
+      "duration_sec": 8.64,
+      "speech_end_offset_ms": 6788.0,
+      "audio_hash_id": "71e1919c1002603ef767e6ba49dfac9b421f4df647ecca0e1b243a185ac27a14",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0136.wav",
+      "sha256": "7e7aa330b17a11aa8517fda48af04b50543dabaf6b96cda29197b6c1834087b9",
+      "transcript": "nextgen is a system the faa claims would allow aircraft to fly shorter routes and save millions of gallons of fuel each year and cut carbon emissions",
+      "duration_sec": 10.08,
+      "speech_end_offset_ms": 8740.0,
+      "audio_hash_id": "179ec871f1602f58d5ee464a6d22edb22fb508e16eeb8d359e950d7d278f9cd9",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0137.wav",
+      "sha256": "8447192b722540d93f900bdfc98e0a042420e5206f9ea813896d4d6615fd1ace",
+      "transcript": "no tsunami warning has been issued and according to the jakarta geophysics agency no tsunami warning will be issued because the quake did not meet the magnitude 6.5 requirement",
+      "duration_sec": 11.88,
+      "speech_end_offset_ms": 10724.0,
+      "audio_hash_id": "d2fd2c79b2524e9beff68596699ce891463cd525462973c7f0a4ec22b093814f",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0138.wav",
+      "sha256": "bc04542c4424123681f8aba6d9b81fd6fcd838908ea311bce87ec9d1707031e5",
+      "transcript": "nothing can be seen other than the clear beautiful sky above and the many surrounding mountains very little of this world can be seen or heard from inside the cave",
+      "duration_sec": 9.48,
+      "speech_end_offset_ms": 9092.0,
+      "audio_hash_id": "1f6a1792e5cc2885ae744762394bc8eaa3425d714b9d1d823b51364cc38a5395",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0139.wav",
+      "sha256": "57387a6665790914f830cdd697e1c112b455570ff0a6d56385cb716debe91083",
+      "transcript": "on 15 august 1940 the allies invaded southern france the invasion was called operation dragoon",
+      "duration_sec": 10.12,
+      "speech_end_offset_ms": 9700.0,
+      "audio_hash_id": "b09d6abd2e4aed55deee65ab3d5d4456d6eb62a3378e4e1a013f876548d873fa",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0140.wav",
+      "sha256": "e6fc5a283d8bedba230d4ab9d8621e6cd952c79409f2f93dd1a6319de21b5804",
+      "transcript": "on some routes the larger companies have their own planes but for other routes and smaller firms there was a problem",
+      "duration_sec": 9.36,
+      "speech_end_offset_ms": 7620.0,
+      "audio_hash_id": "3475c3cad304ebed990ac59ca3e997e72c04487d3c8ac89bd853123190065450",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0141.wav",
+      "sha256": "3c5939ce04ec44c74f842c00c11d58b7dca3b8e445d908f8bbe6fb3ac3d334a7",
+      "transcript": "on the other hand icy and snowy conditions are normal in many countries and traffic goes on mostly uninterrupted all year round",
+      "duration_sec": 9.72,
+      "speech_end_offset_ms": 8004.0,
+      "audio_hash_id": "3fb08b4fd8391622311335401051420ee38bdafc5a934434a0562ad68b8def91",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0142.wav",
+      "sha256": "eba113da68cd894c7604429746e431ab25197ccad934172bb7d6d040de3eced6",
+      "transcript": "one bomb exploded outside the governor general's office",
+      "duration_sec": 6.64,
+      "speech_end_offset_ms": 5828.0,
+      "audio_hash_id": "cf61dc2705da104a73f7d16223abf338b8120ce1ebe4a1928e4e0e6b20f5f07b",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0143.wav",
+      "sha256": "c74c9e1bad7884bc7b3181b7a2b3e5254e8ac7d1267be15f7ec68faab45618a3",
+      "transcript": "one can only wonder what the keyboard will become when something newer comes along",
+      "duration_sec": 5.46,
+      "speech_end_offset_ms": 5028.0,
+      "audio_hash_id": "a265a7b879262ef9b3c8f429728e089abf67752b3a94262cdcf045baf5fdd4d1",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0144.wav",
+      "sha256": "542eec523e51666b2983dd46226a14404364778c3a9ad74861c2cc54043a036d",
+      "transcript": "only mutations in germ-line cells can be passed on to children while mutations elsewhere can cause cell-death or cancer",
+      "duration_sec": 10.98,
+      "speech_end_offset_ms": 8452.0,
+      "audio_hash_id": "de56461c796e872e47765500bacc6a3dc4a9fbb5a56d64787a04cc4a99a90c4d",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0145.wav",
+      "sha256": "835a22f3a8d1af1750260d1e7b43842caa19e11171d237b07ba986f0896979fb",
+      "transcript": "other subjects on the agenda in bali include saving the world's remaining forests and sharing technologies to help developing nations grow in less-polluting ways",
+      "duration_sec": 9.66,
+      "speech_end_offset_ms": 8548.0,
+      "audio_hash_id": "43a99764d26abfd64aaa91105a8b1ba8a4ff43a0a636e1b8f359949f8fa2be75",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0146.wav",
+      "sha256": "6a74e216e7be7b9907e2e7c4600e14d866c46d3d751f8444575e11d631c2392b",
+      "transcript": "ottawa is canada's charming bilingual capital and features an array of art galleries and museums that showcase canada's past and present",
+      "duration_sec": 8.52,
+      "speech_end_offset_ms": 8292.0,
+      "audio_hash_id": "50865c5c1d1c7132649cd44cfea56cca8ead89683b5b043042ebe8bb28ed60b7",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0147.wav",
+      "sha256": "a2d3aa90f358ef850fa11ffdcfd1d3c103e8bf649ca82236674cb59fa0e89ebe",
+      "transcript": "parisians have a reputation for being egocentric rude and arrogant",
+      "duration_sec": 7.54,
+      "speech_end_offset_ms": 6692.0,
+      "audio_hash_id": "e9d4183f9cc2f5cd4bbfcf000e82150d86aca580f73de546fbdb888c24124bba",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0148.wav",
+      "sha256": "3b5dadde19fffb23be9632cd221f30a6b71ae7fc7864d4e4bfd0b9c1acc25f51",
+      "transcript": "people have known about basic chemical elements such as gold silver and copper from antiquity as these can all be discovered in nature in native form and are relatively simple to mine with primitive tools",
+      "duration_sec": 10.8,
+      "speech_end_offset_ms": 10800.0,
+      "audio_hash_id": "ded9038212745ce1bc8c86c77e90e4a9582a827ad86c9f3814b6dc507ce12e57",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0149.wav",
+      "sha256": "3a84bdf7e81713af0dd962b95935e5a794b17febf7251a80ca74ab4970a8f1d2",
+      "transcript": "people may not anticipate that patience and understanding are also necessary for travellers returning home",
+      "duration_sec": 5.94,
+      "speech_end_offset_ms": 5636.0,
+      "audio_hash_id": "96d0e834ab318ac7f07092c6a0ebb083858aa6b9844ebb5590c749e915138e22",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0150.wav",
+      "sha256": "ee9a45899119b767a1d464cac46d45e9af0d4db4f1efce293e27b6ac02c55153",
+      "transcript": "people now write messages on computer screens never having to come close to a sharpener",
+      "duration_sec": 8.8,
+      "speech_end_offset_ms": 7972.0,
+      "audio_hash_id": "97d8cb86f77ffef9e336cd02fee3c9f388976054151f7433f73bf2dc9adc5379",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0151.wav",
+      "sha256": "29454850fc1a7c2623b1333945866700cc623b4de79aa2523409695ca4beb2da",
+      "transcript": "plants look their best when in a natural environment so resist the temptation to remove even just one specimen",
+      "duration_sec": 7.68,
+      "speech_end_offset_ms": 6724.0,
+      "audio_hash_id": "2cfe54975d2b819e3a9bb2a048db5017a0b26ffea3c4334772303701f260f2b8",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0152.wav",
+      "sha256": "2f55582544ae959c23fba89020ed7f1fc8a1228ba8276454f2514b93b108e959",
+      "transcript": "plants make oxygen which humans breathe and they take in carbon-dioxide which humans exhale that is breathe out",
+      "duration_sec": 7.02,
+      "speech_end_offset_ms": 6564.0,
+      "audio_hash_id": "64de75b16d54b065bb17d4cc69c9eaed2be703ba1d62954ec96480b20bea7072",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0153.wav",
+      "sha256": "4f4283626d6cfa825bd1c1dde75e21a1dec131ee914e9868b79c418db77bacaa",
+      "transcript": "plants make their food from the sun by photosynthesis they also provide shade",
+      "duration_sec": 7.94,
+      "speech_end_offset_ms": 6884.0,
+      "audio_hash_id": "c06f972f0d5b9151c8bb35b54a4a2581f1a5a4a84dcd81123e1fa0aea766fc63",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0154.wav",
+      "sha256": "60d15a2d90ace3f49ccfaadaf799b2588c1a23bf2024f36e2fe42cc9b02b4363",
+      "transcript": "police superintendent chandra shekhar solanki said the accused appeared in court with covered faces",
+      "duration_sec": 7.2,
+      "speech_end_offset_ms": 6596.0,
+      "audio_hash_id": "b6b3bfaa8e1aab680ad427a28fb7dd8934df06ec0989264515b866225ae51835",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0155.wav",
+      "sha256": "9d9acc8dcc727387826726decaa8ec77bcedda8d25eeff83a3021302971efa37",
+      "transcript": "popular sports include football basketball volleyball water-polo fencing rugby cycling ice hockey roller hockey and f1 motor racing",
+      "duration_sec": 9.3,
+      "speech_end_offset_ms": 8996.0,
+      "audio_hash_id": "f623cd7b66e30559f188aa34d770789b4276c211e25bf1158f34d1b53d99a982",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0156.wav",
+      "sha256": "180bccb03d4255084317758e000b5918e8c87b5b891d2e50e4d613ad0c8f3018",
+      "transcript": "prides are made up of one to three related adult males along with as many as thirty females and cubs",
+      "duration_sec": 6.78,
+      "speech_end_offset_ms": 6468.0,
+      "audio_hash_id": "57aedfa0ba453762c08fbf04f82744d96ae4fb405133153c36c8bca5e68b3d5b",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0157.wav",
+      "sha256": "653f199a929880ffc477d605347227904f983c3ee5dbe1dd412dd24d824539d6",
+      "transcript": "prior to the arrival of troops haiti had not encountered problems related to the disease since the 1800s",
+      "duration_sec": 7.38,
+      "speech_end_offset_ms": 6276.0,
+      "audio_hash_id": "dcf8319fa70d6bb24082df702f533e1682cdd0c8f10336f69f8487b59b816ada",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0158.wav",
+      "sha256": "b2dda3ccb06f795c6527530085a6a4faab00bd30e4e319f8b2ebaf7635351d2b",
+      "transcript": "professor pamela ferguson of the university of dundee notes journalists do seem to be walking a dangerous line if publishing photos etc of suspects",
+      "duration_sec": 10.5,
+      "speech_end_offset_ms": 9316.0,
+      "audio_hash_id": "cd676993f23e22cb81e8126da3e52aa4e20e6c4eae55ef89f57fd229fa90e185",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0159.wav",
+      "sha256": "e6b2c5161d2ec0ddb73e365864868d2949558cc03c05d9df05b201d745eb5e79",
+      "transcript": "re-entry shock comes on sooner than culture shock there's less of a honeymoon phase lasts longer and can be more severe",
+      "duration_sec": 8.58,
+      "speech_end_offset_ms": 7684.0,
+      "audio_hash_id": "88ae1e588e2f20f94899fa3d6b0f2fc224ae3adcfc80137e29d11cef64b17d9c",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0160.wav",
+      "sha256": "c9d929ab39de35c5d011ef84bfc9c3ae56b3f9c73bc5931743042a73c2a69124",
+      "transcript": "regional and seasonal severe weather phenomena include blizzards snowstorms ice storms and dust storms",
+      "duration_sec": 7.58,
+      "speech_end_offset_ms": 7140.0,
+      "audio_hash_id": "91bbe3996b41b523d0b16ef1e4b7d1d115cde4c99ea1461b5ee58f4c28dead8d",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0161.wav",
+      "sha256": "6f062f0bfac1fe03dd99e700bf2e467dc293ab4a06957d2ad2c09ce19f07b76d",
+      "transcript": "regular announcements in the metro are made only in catalan but unplanned disruptions are announced by an automated system in a wide variety of languages including spanish english french arabic and japanese",
+      "duration_sec": 11.52,
+      "speech_end_offset_ms": 11172.0,
+      "audio_hash_id": "0b07b44c5630052fd6d47e487c2f1bd866dc283de290c2b0a6f10e7edfba4aec",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0162.wav",
+      "sha256": "2045aedb756b48c7617b88afc057f03ab753b7c503c15234313c59cb77551463",
+      "transcript": "remember that even though music on the main stages may have finished there may be sections of the festival that will keep playing music until late into the night",
+      "duration_sec": 11.9,
+      "speech_end_offset_ms": 10980.0,
+      "audio_hash_id": "1d34609d0830e8c274d4a5eee55ad1af4147a8a414da7d1a7e63570753c93cf5",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0163.wav",
+      "sha256": "b2c0f52ad6ac3882fe7a5474b656801a60fa501ad6219a9627ce94373bfcb9bf",
+      "transcript": "resting on the top of one of the mountains north of mecca the cave is completely isolated from the rest of the world",
+      "duration_sec": 10.14,
+      "speech_end_offset_ms": 8036.0,
+      "audio_hash_id": "6f324cb6d765b809721c2cd67c3f2672d4c170ef63b905063d8b12d328c3d53a",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0164.wav",
+      "sha256": "9668d46778489aa2e450c938cc88067f786f5e388c8683e8f8b58cdb07e5b5e5",
+      "transcript": "rip currents are the returning flow from waves breaking off the beach often at a reef or similar",
+      "duration_sec": 6.42,
+      "speech_end_offset_ms": 6020.0,
+      "audio_hash_id": "96129b1b6bff54f8be199c286a7eff589e49875aff403166cd0c425d1be4452c",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0165.wav",
+      "sha256": "a7f6767f03caa984ba7e2ed5d47970ce78d478b2112eb9dec00ed81c7ad4c64e",
+      "transcript": "rolando mendoza fired his m16 rifle at the tourists",
+      "duration_sec": 6.0,
+      "speech_end_offset_ms": 5220.0,
+      "audio_hash_id": "0f03f5f758baf2e397a12314b967c5a642ec155924e09ce2b6d067cd18af329b",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0166.wav",
+      "sha256": "485ba2486713c8b5fe12525e36a17df49f18d10abee1929346121dd540a1437d",
+      "transcript": "romanticism had a large element of cultural determinism drawn from writers such as goethe fichte and schlegel",
+      "duration_sec": 10.68,
+      "speech_end_offset_ms": 8836.0,
+      "audio_hash_id": "50041f119bacc2dd35517e2ed96bf23dc0054ac2863b1ada239fd46943658632",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0167.wav",
+      "sha256": "69e79eee023b62056d7dafbd49bed73d0f58b3bb2710472ef3675e5c6f61f929",
+      "transcript": "saint petersburg cruises include time in town. cruise passengers are exempted from visa requirements check the terms",
+      "duration_sec": 7.5,
+      "speech_end_offset_ms": 7500.0,
+      "audio_hash_id": "7bb485acdbd41be833832c00a803a8af791af9970ae71dbc8870421b63394fa0",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0168.wav",
+      "sha256": "3463dfd4ea3c49041bd4a552730d3bc2adfc33225a4e2ead1b9c7c45f43505e6",
+      "transcript": "scaffolding is not a method of learning but rather an aid that provides support to individuals whom are undergoing a new learning experience such as using a new computer program or beginning a new project",
+      "duration_sec": 11.76,
+      "speech_end_offset_ms": 10756.0,
+      "audio_hash_id": "63e17fd44aae91c5035e60fa260aa540e150e407d1dc8c2c01952c77ed809174",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0169.wav",
+      "sha256": "803098d44f7d3cb0430aaec0b24941edd7bcd730b6c122c5234e4683e315c126",
+      "transcript": "scientists hope to understand how planets form especially how the earth formed since comets collided with the earth long ago",
+      "duration_sec": 6.18,
+      "speech_end_offset_ms": 5828.0,
+      "audio_hash_id": "5441d7f1cfc94c25d12ee202cfa6bb3de7c0a91899d93da1d37d9c11d696d622",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0170.wav",
+      "sha256": "a9253d429917b81357083a3654dbdfecfb7e8f06fb89e483ce2fd8fdf96f4ca3",
+      "transcript": "scotturb bus 403 travels regularly to sintra stopping at cabo da roca",
+      "duration_sec": 11.56,
+      "speech_end_offset_ms": 10852.0,
+      "audio_hash_id": "b95dae8cbb1e98ae9614e4812862fe6a47b6085d107deb49f0c136f2d13674c2",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0171.wav",
+      "sha256": "567c4aaeec4ee97acefb5e6ecdfd4ded502ab53413559a9b8d99785e25cb5f58",
+      "transcript": "segregation and recombination shuffle variation back and forth between the two pools with each generation",
+      "duration_sec": 11.52,
+      "speech_end_offset_ms": 10052.0,
+      "audio_hash_id": "6ff568673260fb6904bd86665deda49438f5d9874af4d17bfbfb84059ea3f8da",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0172.wav",
+      "sha256": "5fd5bb1b82bdf8aebeade97bec4ec8a212a7c592747cc46260f112b9fce1eb29",
+      "transcript": "several large television screens were installed in various places in rome to let the people watch the ceremony",
+      "duration_sec": 10.26,
+      "speech_end_offset_ms": 8644.0,
+      "audio_hash_id": "38f5cc1bb39b4c941a198d79d04e7533453896aea58daccc7685a68a8e044b7b",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0173.wav",
+      "sha256": "6ef5ce3e41514b3c39cc41696f377e9acd8d5c9a397dd340775ca15ce66fa52e",
+      "transcript": "severe weather is the generic term for any dangerous weather phenomenon with the potential to cause damage serious social disruption or loss of human life",
+      "duration_sec": 10.8,
+      "speech_end_offset_ms": 9572.0,
+      "audio_hash_id": "29cd85c17b1c9af1bad54f8aeb9a90e71e4defbb0e298eb47d781746dee96650",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0174.wav",
+      "sha256": "778c38bbcaca4c67bbdc815d31aebab8e4fecfec4738d23f284bf19b5f5c7308",
+      "transcript": "sharing a field trip virtually is also a great way to reflect a on a trip and share experiences with future classes",
+      "duration_sec": 7.68,
+      "speech_end_offset_ms": 6788.0,
+      "audio_hash_id": "bc510911276fbef97c0bf79da309bb2db79f43f75161de43c25ff3935067620c",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0175.wav",
+      "sha256": "6495ae78bfab4bdaa80da6ce0b97b805a54b46247e6fc65ff482263836923f79",
+      "transcript": "since the foundation of asunción in 1537 paraguay has managed to keep a lot of its indigenous character and identity",
+      "duration_sec": 11.82,
+      "speech_end_offset_ms": 9636.0,
+      "audio_hash_id": "6b62122bfb56f04a4471e739143934731b9b5372486241436d992ef620a85895",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0176.wav",
+      "sha256": "526e03216a6716ddc82574117d7a4c09a4ccd1557be855a9c494b30abf4e43ce",
+      "transcript": "six hostages including the children and elderly were released early as were the filipino photographers",
+      "duration_sec": 9.16,
+      "speech_end_offset_ms": 8612.0,
+      "audio_hash_id": "2ee0a1cf6ded0077190be32daf9967ba0f0fa4b29660824f8e0580e2ebe2a200",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0177.wav",
+      "sha256": "0ed1b3a1fee1334adaac0e24c5fe58c068df249d6e53ee67274dbb1ca9d53ac2",
+      "transcript": "so it is likely that the notation was added simply as a label",
+      "duration_sec": 5.86,
+      "speech_end_offset_ms": 4868.0,
+      "audio_hash_id": "1a604f2ea31776fc985487240ef9c6e5f1d862ae5b7b28f51b607853697502ad",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0178.wav",
+      "sha256": "ca69e6ffdb453163c57db974418c863f58817aa859e094b34b57b28364cd27da",
+      "transcript": "some atoms have unstable nuclei which means that they tend to break apart with little or no nudging",
+      "duration_sec": 6.12,
+      "speech_end_offset_ms": 5700.0,
+      "audio_hash_id": "392755977ec4924bdf07e11a8a7c044f95ef68c5e1cf5513dce16898c17af16a",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0179.wav",
+      "sha256": "44181ec699cc009d75025c2080b3bc04defd527fd4692f7018a382e294402732",
+      "transcript": "some cruises feature berlin germany in the brochures as you can see from the map above berlin is no where near the sea and a visit to the city is not included in the price of the cruise",
+      "duration_sec": 10.8,
+      "speech_end_offset_ms": 9892.0,
+      "audio_hash_id": "4950229b40db7c2e45399ae41748e09f7edc54563eca9cb44df7d885f308a019",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0180.wav",
+      "sha256": "9dbbf59805881ff09563820da8127c9492df5ebcb3c8d9e69c2cf1b6a75a48b0",
+      "transcript": "some people thought he was right but many people believed the opposite; that the solar system moved around the earth including the sun and even the other stars",
+      "duration_sec": 7.74,
+      "speech_end_offset_ms": 7492.0,
+      "audio_hash_id": "902951ccef110041c620da086e54997f4fb385839f2ab81e4b4cbd257c4927fb",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0181.wav",
+      "sha256": "daee5f6d18149d0f9763d16bcfecb9da50ff067a72d89d836039dad45b3e8843",
+      "transcript": "soon after the outbreak of hostilities britain initiated a naval blockade of germany",
+      "duration_sec": 5.46,
+      "speech_end_offset_ms": 5156.0,
+      "audio_hash_id": "4db75521cb1e44e4f20e8fcf57418b9de14439923c6d73ee24e6ce85443e0cb4",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0182.wav",
+      "sha256": "b8c5792db5cfa81fff13f0490135f45700c907200da14f30c7d6cf23e2984c1f",
+      "transcript": "still take advice from authorities obey all signs and pay close attention to safety warnings",
+      "duration_sec": 8.64,
+      "speech_end_offset_ms": 7492.0,
+      "audio_hash_id": "87bf0b7c87db10e65d81f82b277c85cbfa2eb447ab82746b4ece475af9254f9a",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0183.wav",
+      "sha256": "973bfa55e3bd948801b4281d01ca6ebd8bcd73533da5f09f10f4ec7bb6740528",
+      "transcript": "swirl the two dry powders together and then with clean wet hands squeeze them into a ball",
+      "duration_sec": 8.36,
+      "speech_end_offset_ms": 7300.0,
+      "audio_hash_id": "a2bf46bb7fd2d8e707ee4261f232ec14aaa81acf547f8ae848193668c7cc2ecd",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0184.wav",
+      "sha256": "bc3b06dd28ea2dba2a56f15ab2703d31a0a777dd24607be22f2b17c543892b68",
+      "transcript": "television reports show white smoke coming from the plant",
+      "duration_sec": 5.04,
+      "speech_end_offset_ms": 3876.0,
+      "audio_hash_id": "123510cca9fdec97a653a3c0a8a1de96f98a14b48458c21e850c13cb85bbd754",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0185.wav",
+      "sha256": "e159cdee27b2f7cd80da3421ed0af13aa0269d21dfbc5104b160d1a41c732215",
+      "transcript": "the 25 dunlap broadsides still known to exist are the oldest surviving copies of the document the original handwritten copy has not survived",
+      "duration_sec": 9.84,
+      "speech_end_offset_ms": 8900.0,
+      "audio_hash_id": "ca5fe66d6b90cc3a7ea045ee913e5cd4cfbc2957338295a1a8a2cfce1e048e66",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0186.wav",
+      "sha256": "2960a15ef1eb82c3d680df9c9a85ad6b93c9b58c55b6b1c8552bc265a5f6945d",
+      "transcript": "the 802.11n standard operates on both the 2.4ghz and 5.0ghz frequencies",
+      "duration_sec": 12.0,
+      "speech_end_offset_ms": 10788.0,
+      "audio_hash_id": "8a92a04fd8d59fac6644016c99ea93b96821e2542a5fa94219cd0fc782d1ec1e",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0187.wav",
+      "sha256": "11a3e7fde58da1f2efead8b8abb6142b69f026b662e525e37cb461239423397f",
+      "transcript": "the announcement was made after trump had a phone conversation with turkish president recep tayyip erdoğan",
+      "duration_sec": 10.8,
+      "speech_end_offset_ms": 9252.0,
+      "audio_hash_id": "6da42e7857195d6ae3f7a4c30ac76e2fc08b335bebd8ec86a414acadf7457866",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0188.wav",
+      "sha256": "9d4da50177ff3480f3e972c44a02b735a20426b67dfb3cbeec39be83547d9da0",
+      "transcript": "the aspect ratio of this format dividing by twelve to obtain the simplest whole-number ratio is therefore said to be 3:2",
+      "duration_sec": 11.04,
+      "speech_end_offset_ms": 10468.0,
+      "audio_hash_id": "0f32733745a86cf0958de7cbbfe9b6540ce04506683939c3e92a9a945eb9f537",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0189.wav",
+      "sha256": "33c2ecf15840967d353022e419597790eed64e894879ebae620957e537d60fb3",
+      "transcript": "the bridge is scheduled to be fully operational in september 2017 when the brazilian customs checkpoints are expected to be finished",
+      "duration_sec": 8.28,
+      "speech_end_offset_ms": 7364.0,
+      "audio_hash_id": "800d0378a42b078d7e38420be576fd742be9f3d41c066721c20c74092eb9eea3",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0190.wav",
+      "sha256": "536bbf4f05da1294042c5bf4fb51807228fb65a35e9ad80c57fff124b6df78fe",
+      "transcript": "the cabbage juice changes color depending on how acidic or basic alkaline the chemical is",
+      "duration_sec": 5.76,
+      "speech_end_offset_ms": 5412.0,
+      "audio_hash_id": "b42505e73bd7839b4760e06a30e02cfce4570ff82030ffc14baed45bfde6b1d2",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0191.wav",
+      "sha256": "feaab9cc552f0a4f0a387d534fda90b46fb1daa586a1e629237a92f34b73370c",
+      "transcript": "the capital of moldova is chişinău. the local language is romanian but russian is widely used",
+      "duration_sec": 6.6,
+      "speech_end_offset_ms": 6372.0,
+      "audio_hash_id": "1d0310687a6469b727c86588c790086aa196dd1e3b4ea54406a4c8877a0f8078",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0192.wav",
+      "sha256": "d2fc2ec09c6849459a25bcecd843c83c45fb757c21aca04da45dfc80232d9ce5",
+      "transcript": "the central authority of the church had been in rome for over a thousand years and this concentration of power and money led many to question whether this tenet was being met",
+      "duration_sec": 9.24,
+      "speech_end_offset_ms": 8868.0,
+      "audio_hash_id": "fa45421a5f7de10728ff205434d97dea7f59dabc9d2e17bb3a10895b08a86e5c",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0193.wav",
+      "sha256": "886f6007f339119d430b0a4c7c908ea70bb44104fd7a3ee9ef58cea7cf39eebe",
+      "transcript": "the city is also the base to climb the nyiragongo volcano along with some of the cheapest mountain gorilla tracking in africa",
+      "duration_sec": 11.28,
+      "speech_end_offset_ms": 9860.0,
+      "audio_hash_id": "b5954b837a2d31fa53ab0eda66ce44be882d716e5e36ee1316047beb0ce04e17",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0194.wav",
+      "sha256": "91baf4a03abae0ff606f5bfdb98b38e2b477e4f3aeafe4d2e30922fb91e670fd",
+      "transcript": "the city is in stark contrast to the rest of the country's cities because it has more of an arabic flair than of an african",
+      "duration_sec": 6.72,
+      "speech_end_offset_ms": 6468.0,
+      "audio_hash_id": "6e9ae8a237f128b2098d2280e228d8a289176230bf4ad09b717441d13baa3ef2",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0195.wav",
+      "sha256": "0ec14e46d2c0b86d5aab6221452eeac4a3d9005743ad1ac87c1de6ea3355e1c7",
+      "transcript": "the commission was martelly's response to widespread anti-regime protests that started in october",
+      "duration_sec": 8.52,
+      "speech_end_offset_ms": 7460.0,
+      "audio_hash_id": "68ff8151c9756cab7b89ab53b95ebc01628c392570c8f7632cd1262e744dca65",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0196.wav",
+      "sha256": "b6173c3eba4da09b6c68dbd8d8b2a5d4baa4aa91b64bbacb0d5ce5e0450ea3bb",
+      "transcript": "the composition of these crystals matches those found in the urine of affected pets when compared by infrared spectroscopy ftir",
+      "duration_sec": 11.88,
+      "speech_end_offset_ms": 10628.0,
+      "audio_hash_id": "88d97ad413088f8e9295a774c71d441cb3b95ad65955aba698de52d1d5ddb497",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0197.wav",
+      "sha256": "aee80d000b2764688998d5e0a34dc9e02b7445a65fd9436e7a6ff2b2202c5ce6",
+      "transcript": "the correlation between brain pathology and behaviour supports scientists in their research",
+      "duration_sec": 6.36,
+      "speech_end_offset_ms": 5476.0,
+      "audio_hash_id": "96617c1c14ea21102c22c9f1f29895db6f7d85797e0798b3ffef8b32aa761f3e",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0198.wav",
+      "sha256": "f7c3eeb59ddf33fcaf796a7ddb4a0cb4306958092711f1d07d8c079daafccd68",
+      "transcript": "the crash occurred high up in mountainous terrain and is believed to have been the result of hostile fire",
+      "duration_sec": 9.82,
+      "speech_end_offset_ms": 8612.0,
+      "audio_hash_id": "da29f581e50aa9dd88eec5a0f06315049ea8c0bf330cd06634c53b942214edad",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0199.wav",
+      "sha256": "4628d70c65bcca29f57047568efe85afb7bf811d8c80d01969857e3f813c3320",
+      "transcript": "the crust is about 70 km thick on the near side and 100 km thick on the far side",
+      "duration_sec": 7.68,
+      "speech_end_offset_ms": 6628.0,
+      "audio_hash_id": "b9d93f31af3623ed8b09fe94826de16dc851d1f15d9cf1d058eb7da5bd9c7b54",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0200.wav",
+      "sha256": "cdaddff66a5b795e12a52b2b695a3e9e3240c8546015d16874cdf3889bd47ed9",
+      "transcript": "the debate was sparked by controversy over spending on relief and reconstruction in the wake hurricane katrina which some fiscal conservatives have humorously labeled bush's new orleans deal",
+      "duration_sec": 12.36,
+      "speech_end_offset_ms": 11300.0,
+      "audio_hash_id": "25ba9935ce5aff5c38fc5f3a84777c28083ac3f40aa97ce3f7651426a053af27",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0201.wav",
+      "sha256": "efda2334f13b91a1af82464982102dee90873cac6ae62d75f88d292f6773722f",
+      "transcript": "the disease is carried by pigs which then migrates to humans through mosquitos",
+      "duration_sec": 5.4,
+      "speech_end_offset_ms": 5092.0,
+      "audio_hash_id": "f6223afd87f6fcd3b854dcc079926f6b1c1e223f12e4b92bc1d49d157aa0dae5",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0202.wav",
+      "sha256": "5f8ee8a0762b6565351ef8a3a422c69b7e7144200ab35a386e49e40110839830",
+      "transcript": "the document according to the leak will refer to the borders dispute which palestine wants based on the borders before the 1967 mideast war",
+      "duration_sec": 8.28,
+      "speech_end_offset_ms": 7908.0,
+      "audio_hash_id": "58cc7e5b877073d3fc249505eaf20d5900d9aa2e4d81a5c7beac713fa1b9fa67",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0203.wav",
+      "sha256": "9358ac94a7fbf27e4eea0f9a1250bda9312d2a2ce1d6a6785f7cc6578e443d05",
+      "transcript": "the find also grants insight into the evolution of feathers in birds",
+      "duration_sec": 4.62,
+      "speech_end_offset_ms": 4620.0,
+      "audio_hash_id": "628ef170fd71d41ffdf1aa593de92ee7f756475901427ddc33d2c959ba0859b7",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0204.wav",
+      "sha256": "388bebf1a71c9fee98dfb4f6b70ecb6484f4e946745e0a5a96c295e981759782",
+      "transcript": "the fission bomb works on the principle that it takes energy to put together a nucleus with many protons and neutrons",
+      "duration_sec": 6.3,
+      "speech_end_offset_ms": 6300.0,
+      "audio_hash_id": "027d51eae32d564ca614ec3c4940b4aab8a71fad657bb3fc86e9f0e5da1dfb91",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0205.wav",
+      "sha256": "dd811b23ef2c3fa85d3ed6e2f7e548be8198d67526325c6c3f36cfa65e4abbc6",
+      "transcript": "the governor's office said nineteen of the injured were police officers",
+      "duration_sec": 7.26,
+      "speech_end_offset_ms": 5124.0,
+      "audio_hash_id": "c6adb8efc3103a5ff3234301da5b1dedecbc0b8689f4687bf61e078e8462023c",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0206.wav",
+      "sha256": "0156887c729aec4b1cd8c2a638928e80b9d7f074c9497762c0e3afb4b9b11941",
+      "transcript": "the great pyramid at giza is the only one of the seven wonders that is still standing today",
+      "duration_sec": 6.06,
+      "speech_end_offset_ms": 5252.0,
+      "audio_hash_id": "f63df9966558b79f93d72cdfe3196de5a712f38d70ede03263c4af0f12491a66",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0207.wav",
+      "sha256": "470a56ed54cf35caa78b4c00255a4791f950d590f51bf3c38395d477cf9283cb",
+      "transcript": "the haitian institute for justice and democracy has referenced independent studies that suggest the nepalese un peacekeeping battalion unknowingly brought the disease to haiti",
+      "duration_sec": 11.04,
+      "speech_end_offset_ms": 11040.0,
+      "audio_hash_id": "32c1b4162db8ee378bbba1e5c2f8890cae3be0f78a57851f03028f9acec9de48",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0208.wav",
+      "sha256": "c07faf65175023ae2ada1c5201bf488e8b46c2e4ef9a3436f30387a3e886b196",
+      "transcript": "the hospital has followed protocol for infection control including separating the patient from others to prevent possible infection of others",
+      "duration_sec": 11.42,
+      "speech_end_offset_ms": 10692.0,
+      "audio_hash_id": "11d0531604af12e2b7db86a8e0bfcf5485e58f466a9766f04604af269e1a52ec",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0209.wav",
+      "sha256": "3a5e2b446438dc7ee8f86c88b528c8599224a9627bc38f25eb849d653df25891",
+      "transcript": "the hot chocolate is up to belgian standards fruit juices are pricey but excellent",
+      "duration_sec": 6.42,
+      "speech_end_offset_ms": 6020.0,
+      "audio_hash_id": "b62bc3921291e94c61553d91a834c354a79f707f4b2b215643e974018cff6cb2",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0210.wav",
+      "sha256": "b5bb4a3406fad027b8ca52a7c5282740799c2a8aa0cb5ed64a3ffb50be25b0b0",
+      "transcript": "the internet combines elements of both mass and interpersonal communication",
+      "duration_sec": 5.72,
+      "speech_end_offset_ms": 5476.0,
+      "audio_hash_id": "030fa88f39820a6c30d0e508d717f4cdacef0ab8ec3a64471738c20508fd3175",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0211.wav",
+      "sha256": "53671a68a5725eb10afaa57bc4464d63e5173b96a3ceeba012ca81366ab2f596",
+      "transcript": "the lower the tension the more positive the life force present every person has the potential to find absolute peace and contentment",
+      "duration_sec": 10.4,
+      "speech_end_offset_ms": 9892.0,
+      "audio_hash_id": "5d63151fa1d4f280f269893b0b4598c2ae60aa6f96f9804bcbd118182d248531",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0212.wav",
+      "sha256": "76dda5f4a1193cf3ff6289252675ceb0829c0cbe16e2b0ea5eebb140cd6f5f00",
+      "transcript": "the moisture on your hands will react with the outer layers which will feel funny and form a sort of shell",
+      "duration_sec": 8.52,
+      "speech_end_offset_ms": 8036.0,
+      "audio_hash_id": "5428d0520fdc6ba2476f88f85a7da28506361678e8512462d77556f7ae36f133",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0213.wav",
+      "sha256": "574e52716afbcccdf60a71725b198c45138b0378b44d25febae42042ec4c9bbb",
+      "transcript": "the moroccan sultan rebuilt the city as daru l-badya and it was given the name casablanca by spanish traders who established trading bases there",
+      "duration_sec": 11.52,
+      "speech_end_offset_ms": 10596.0,
+      "audio_hash_id": "7b5f7371bafbe445c8d32f17706e2e06f7940db33978472812b0c83aa62c5598",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0214.wav",
+      "sha256": "f67d20bfbb9f132f90992c3f8d5336281db13ddf4133cc958824675cb83709ec",
+      "transcript": "the northern marianas emergency management office said that there were no damages reported in the nation",
+      "duration_sec": 10.8,
+      "speech_end_offset_ms": 7652.0,
+      "audio_hash_id": "4278147c2d191b9741eb84342389f8f70f9fad90c821aafee81a12a93e0c4c70",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0215.wav",
+      "sha256": "ac825a962558570b3352c1035b6733bf6879d545fb13ffb32e97b82b865dc850",
+      "transcript": "the number of people present was so large that it was not possible for everybody to gain access to the funeral in st peter's square",
+      "duration_sec": 9.66,
+      "speech_end_offset_ms": 8036.0,
+      "audio_hash_id": "24b6381df9737d38399fbe3b6e6ed879fb90564074b27dfab1b2c1a7016e4f03",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0216.wav",
+      "sha256": "bd9697ed0031e917d05ef624e8537d9e5d015a42df10946d7337592ef5116ba7",
+      "transcript": "the official falklands currency is the falkland pound fkp whose value is set equivalent to that of one british pound gbp",
+      "duration_sec": 10.08,
+      "speech_end_offset_ms": 10080.0,
+      "audio_hash_id": "c14d72f66b58e23b2fe0f8007651af99f8430af049fbe1e3444aa8122e9326fd",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0217.wav",
+      "sha256": "9b6f0c3a2e54af3d4cf4a956cd5fba4d5f865007ce654011394d50526be50dd4",
+      "transcript": "the ph level is indicated by the amount of hydrogen the h in ph ions in the tested chemical",
+      "duration_sec": 6.6,
+      "speech_end_offset_ms": 6148.0,
+      "audio_hash_id": "30c6fece9fccb64e8216378119c700e08d1582a4b1555d163b6166885f3348d6",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0218.wav",
+      "sha256": "7ae644db28974b87ef218b5bf4f974ecda321d1971ae4d0a52f86e48d1618541",
+      "transcript": "the photographers later took the place of an aged lady as she needed the lavatory mendoza was gunned down",
+      "duration_sec": 8.62,
+      "speech_end_offset_ms": 7812.0,
+      "audio_hash_id": "12c3ecd97461d32cb13138d340da2ede53980a882c8e7daf976e71aae160125b",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0219.wav",
+      "sha256": "7f580187be1129d9073c1f3072af52a9a799bd603b69e7d2a3886e0dc55f6f6a",
+      "transcript": "the presence of a true  invisible team” larson and lafasto 1989 p109 is also a unique component of a virtual team",
+      "duration_sec": 11.94,
+      "speech_end_offset_ms": 10724.0,
+      "audio_hash_id": "f66fd862afba6567e71d1ff6633ac81655144d4d56abafd6d2c66e971fb11713",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0220.wav",
+      "sha256": "bb0616bdbfcfbc794c98de5aa75d00ab872dd1ba1989fbdbd762a01a616e359f",
+      "transcript": "the pyramid sound and light show is one of the most interesting things in the area for kids",
+      "duration_sec": 8.34,
+      "speech_end_offset_ms": 7972.0,
+      "audio_hash_id": "badf853e8df00a8f6ca966c7b63f4235132a75156a0887ca02c10cea85fdded1",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0221.wav",
+      "sha256": "7b8d683677c1351bbd48178adabb4a0491c148da367516e6d5645cefc418e6a9",
+      "transcript": "the report is highly critical of almost every aspect of the present policy of the executive towards iraq and it urges an immediate change of direction",
+      "duration_sec": 8.64,
+      "speech_end_offset_ms": 8640.0,
+      "audio_hash_id": "5e228c79d6c65f3f77f38eb5a15b3696e10cc0fb0e47752f188566ca36640e68",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0222.wav",
+      "sha256": "c2bb0250885b712d8e748bc8f587c2aba8949b65b0ac8f9dda2dfa2cfb3bd786",
+      "transcript": "the ruling party south west africa people's organisation swapo also retained a majority in the parliamentary elections",
+      "duration_sec": 10.64,
+      "speech_end_offset_ms": 9988.0,
+      "audio_hash_id": "40624047c82578faba690dfebe9f5d964cb5cc1faf09b6f7131d0a352962a1fa",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0223.wav",
+      "sha256": "6e7d165695432b86abf2d8afaf8385da00dee17d0c180ec304565f0806bd837f",
+      "transcript": "the same month saw another airliner overrun a runway at mashhad and strike a wall killing seventeen",
+      "duration_sec": 6.48,
+      "speech_end_offset_ms": 6212.0,
+      "audio_hash_id": "f9bae4871a3caf71595bc3e9a1652ade1ceb1a6705080223b34f999b86bb9b7b",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0224.wav",
+      "sha256": "f10d7c8721fc3703fd49259ba3fba73344f1885f4983f4bddde3a57e91541f15",
+      "transcript": "the scenes are displayed on the pyramids and the different pyramids are lit up",
+      "duration_sec": 4.32,
+      "speech_end_offset_ms": 3908.0,
+      "audio_hash_id": "25271cf6aed02f64d68774f04cbc141bb70431cf5f80c3b049dc0cfee1719b8d",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0225.wav",
+      "sha256": "2c9c27d0d4cac6aacec9cab7b6f73a9aab473279a011b2dc5af2123778373599",
+      "transcript": "the schengen zone however works somewhat like one country in this respect",
+      "duration_sec": 6.8,
+      "speech_end_offset_ms": 6052.0,
+      "audio_hash_id": "2e461b0996bcf54c8cd20f04290834e3b2f99f2cbdd2850d2565d7c340f6a005",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0226.wav",
+      "sha256": "3b7020d6dfd79130e39fb4d656408121506cc9e14945591b9289ca9d61cf7d48",
+      "transcript": "the scientists were able to conclude that the dark matter affect other dark matter in the same way regular matter does",
+      "duration_sec": 12.12,
+      "speech_end_offset_ms": 11108.0,
+      "audio_hash_id": "91a8d17d67df17cd2688aa39b8a1acc23ef84cb1d815a56e34fde5b118297023",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0227.wav",
+      "sha256": "0b91cc5d3b000cbbb8116d9c6fb567c80df8fa97773708cc3769f30c3cb17975",
+      "transcript": "the service is frequently used by shipping including pleasure craft as well as expeditions who have remote data and voice needs",
+      "duration_sec": 11.28,
+      "speech_end_offset_ms": 8932.0,
+      "audio_hash_id": "045d0d35882767bf3a5d81c6c72e523771aea1914a000f1e2307b27f2426f080",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0228.wav",
+      "sha256": "e85d494c261aa3f5950141fea221ec51bfa8da7cb031170e666cbfd3c114766c",
+      "transcript": "the smaller the rossby number the less active the star with respect to magnetic reversals",
+      "duration_sec": 5.64,
+      "speech_end_offset_ms": 5412.0,
+      "audio_hash_id": "8dea8f4a653fdf6a8088b34d5c56a96419eff0d84b31f15fa17476ab18617cd1",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0229.wav",
+      "sha256": "646e2725773c2fcf52b2a9eefccba06b6a50daa58b97838897aa373b54da188e",
+      "transcript": "the sundarbans are the largest littoral mangrove belt in the world stretching 80 km 50 mi into the bangladeshi and indian hinterland from the coast",
+      "duration_sec": 10.2,
+      "speech_end_offset_ms": 9060.0,
+      "audio_hash_id": "c27b5da65d3edb1fb59b82654d2d6fff9e8804865eca0c47b3ffb7831522c668",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0230.wav",
+      "sha256": "a10c1539c5de40c69743bff0a476d45024eda69679f4a3f2da40c04c1bb5ceb1",
+      "transcript": "the sundarbans has been declared a unesco world heritage site the part of the forest within indian territory is called sundarbans national park",
+      "duration_sec": 11.88,
+      "speech_end_offset_ms": 10020.0,
+      "audio_hash_id": "2568dab08075f059bff5b4dd5354b0e0d1011286de42a302e1dddb8890deb1f7",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0231.wav",
+      "sha256": "28b0cb776f034d40bd8b92a1498ecd522ac2060a6c1c981428cb98149bab2553",
+      "transcript": "the surface of the moon is made of rocks and dust the outer layer of the moon is called the crust",
+      "duration_sec": 5.64,
+      "speech_end_offset_ms": 5380.0,
+      "audio_hash_id": "e9dfc2b38f93e30c73dd926e535a77a672ef1b417a5c2aa97fa391a9ad5b24ac",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0232.wav",
+      "sha256": "afb66e440d81a3be846aeab30d434094e30ed23214d007160800e1b61d9529a0",
+      "transcript": "the tenth named storm of the atlantic hurricane season subtropical storm jerry formed in the atlantic ocean today",
+      "duration_sec": 8.66,
+      "speech_end_offset_ms": 7876.0,
+      "audio_hash_id": "a8a8a98bdd3f35d6417f98ce539793e4faae32a1dd39b201234317624295223b",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0233.wav",
+      "sha256": "87793ddc80f9ab7737a451e7c71e76be6c4cd1e7fdfa027d94ae1b3f849c464a",
+      "transcript": "the term bug is used by entomologists in a formal sense for this group of insects",
+      "duration_sec": 6.48,
+      "speech_end_offset_ms": 5412.0,
+      "audio_hash_id": "a6cda0eb5a5dec99968e29d5b97c63fde7c2e06c80fa19786007f1abc84f7b3e",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0234.wav",
+      "sha256": "55595764f7e39be67da74b487c476c09e3aa884aabef9c3644728d3174908f43",
+      "transcript": "the term safari in popular use refers to overland travel to view the stunning african wildlife particularly on savanna",
+      "duration_sec": 8.64,
+      "speech_end_offset_ms": 7780.0,
+      "audio_hash_id": "14f2e3bd391637d1ab9676ef62706950c6522b2f81d43694c7f2185ffe795c4d",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0235.wav",
+      "sha256": "3e10921e87b3586240f8ef9b417f1b71e12c67ddfac49e8494af0768aa5b9f2a",
+      "transcript": "the three kingdoms was one of the bloodiest eras in ancient china's history thousands of people died fighting to sit in the highest seat in the grand palace at xi'an",
+      "duration_sec": 11.88,
+      "speech_end_offset_ms": 10660.0,
+      "audio_hash_id": "5fd8f2c9cb0724085f68ec3c20aa64ab8f53052dc4d9ec3e2e83da48494d7fb7",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0236.wav",
+      "sha256": "f1ae9e3814cdece31a81c644d91152e9f507f0e0fc1df32828c4394cb471df48",
+      "transcript": "the tiger's roar is not like the full-voiced roar of a lion but more like a sentence of snarly shouted words",
+      "duration_sec": 8.76,
+      "speech_end_offset_ms": 7332.0,
+      "audio_hash_id": "995663c9838ab1ef97c64417169e60e1993cb6020c8996eef912fe7d2b43978e",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0237.wav",
+      "sha256": "ae2959ad19b987e5992007df169c7d1d37bfe064e9067b220b1e110060b5ad95",
+      "transcript": "the two compounds react with one another to form crystals that may block kidney function researchers at the university said",
+      "duration_sec": 7.44,
+      "speech_end_offset_ms": 6436.0,
+      "audio_hash_id": "1c46d7238a2c16cf61ae642b70dff6ec8bb7687180b863c4d382571771538b17",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0238.wav",
+      "sha256": "9def8a6db2794d40325c810da85dbef764e4e42634bf6a0fc14a88f839f839d0",
+      "transcript": "the u.s. corps of engineers estimated that 6 inches of rainfall could breach the previously damaged levees",
+      "duration_sec": 8.76,
+      "speech_end_offset_ms": 7748.0,
+      "audio_hash_id": "2b218045859ed1a1bb6d876a6eb9caae204a2c49d4f43bb0ccc961beb5e1d323",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0239.wav",
+      "sha256": "9908fc4543b84f9967af3d4bd8b1441bb69187caa63b44678555ced49fc3592e",
+      "transcript": "the use of video recording has led to important discoveries in the interpretation of micro-expressions facial movements which last a few milliseconds",
+      "duration_sec": 11.54,
+      "speech_end_offset_ms": 11108.0,
+      "audio_hash_id": "6bd61a4af5a9e09635e3f652fc073c6eff387befd5c16461eb8bf5af0cdd71d1",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0240.wav",
+      "sha256": "387010065380e15f357328e6c8aa8a3b6237b7c227d80d44f0d210a07f492dca",
+      "transcript": "the vehicle itself was taken away from the scene of the accident at approximately 1200 gmt on the same day",
+      "duration_sec": 8.58,
+      "speech_end_offset_ms": 7748.0,
+      "audio_hash_id": "72035bfef79d53a6c5011752e084c4d4158d759b4a8d85d90972fa69c71c01d6",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0241.wav",
+      "sha256": "3822d9cf7f0f97d56da2ac09bf0a71fe13dcc4af71c3b79f78b1513166ac42da",
+      "transcript": "the vertical clearance under the bridge is 15 meters construction was completed in august 2011 it didn't open to traffic until march 2017",
+      "duration_sec": 9.84,
+      "speech_end_offset_ms": 8868.0,
+      "audio_hash_id": "5c7dd4ca418a100a63d942d4ad87ff3aba18575af5bbc5b3e9946215004576a6",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0242.wav",
+      "sha256": "4d362b7355328d54061bd5c2def4b6b1c307ab7fd1e10b41bd05b85c48eaa78e",
+      "transcript": "the work done was mostly theoretical but the program was written to simulate observations made of the sagittarius galaxy",
+      "duration_sec": 10.8,
+      "speech_end_offset_ms": 8740.0,
+      "audio_hash_id": "9a78a3ee1d326992167062be911c3149de257ab59bc3f6720f7544fdbb22b4e2",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0243.wav",
+      "sha256": "9eee7181a35ff6d5f4fd0538151b46075b07e28ed840a631eeda087afdacd35c",
+      "transcript": "their disciplined defence ball handling skills and excellent team work made them stand out and it was clear that this was the team to beat",
+      "duration_sec": 7.86,
+      "speech_end_offset_ms": 6980.0,
+      "audio_hash_id": "35e55bc4d970b715f5a2c89e388889e28a67dd6599773f54832a7fedb52a99ae",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0244.wav",
+      "sha256": "a1214eadcfa991946f9c101b91d6fce9155cbe35b4ed7c8d24da82fd810f662a",
+      "transcript": "there are of course christian theological explanations for this tradition but it may well be a pre-christian spring and fertility ritual",
+      "duration_sec": 9.36,
+      "speech_end_offset_ms": 9360.0,
+      "audio_hash_id": "121fcf212c0ae090a484821c524d0c4af0818a1e08489533dd875d3ceb186e63",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0245.wav",
+      "sha256": "565df453b770e814fe9db8d379b463cfc2faf514b18ebf9137ce807b3e3a76e6",
+      "transcript": "there are still many men and women alive who survived their time here and many more who had loved ones who were murdered or worked to death there jews and non-jews alike",
+      "duration_sec": 11.1,
+      "speech_end_offset_ms": 9956.0,
+      "audio_hash_id": "188b0011b8eaeb5c233066cd179ab17328616fa00f9e41638a6fd940e9c672dc",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0246.wav",
+      "sha256": "af5f5d6fa984e91de43d122b47d2e186e7cc16bf5b07a6e1aa3a826b3753e8b4",
+      "transcript": "there is no universal definition for which manufactured items are antiques some tax agencies define goods older than 100 years as antiques",
+      "duration_sec": 11.8,
+      "speech_end_offset_ms": 10692.0,
+      "audio_hash_id": "140d727ad3ac0d59f800555f96163ad88f99168912055c88271ab8d7c55f7060",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0247.wav",
+      "sha256": "d618df7b3c0e697b9120df06973dd5d9028a71763de358e6fdf5b576a58ae808",
+      "transcript": "there may be more maria on the near side because the crust is thinner it was easier for lava to rise up to the surface",
+      "duration_sec": 8.96,
+      "speech_end_offset_ms": 8484.0,
+      "audio_hash_id": "061078ccfc433f1620bea56e368d66e39b8f3bfe93e278d63686b41b524ebf3d",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0248.wav",
+      "sha256": "ab276dc6bd478e6f01bffe055659d03eae4929e65a5086a821c0075d8c5ed8e5",
+      "transcript": "these are sometimes-crowded family beaches with a good range of shops lining the shore swimming is safe",
+      "duration_sec": 10.5,
+      "speech_end_offset_ms": 8292.0,
+      "audio_hash_id": "2c29a15e334a8a718f61767997a0ee7093b615d1bcd47df6f108d1c2405d64ec",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0249.wav",
+      "sha256": "9550f3e4bd0daab1d0b2fde71ec01a46588b229a9d1a2c2df06322c5f49ef382",
+      "transcript": "these couples may choose to make an adoption plan for their baby",
+      "duration_sec": 6.84,
+      "speech_end_offset_ms": 6052.0,
+      "audio_hash_id": "b79d66136c54805b55b849c0c0faedc1832e8e7f661b331073a6d648976257f4",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0250.wav",
+      "sha256": "bae661916831112ab7e543ca6b47b57b4c2eeb1b76d2fb0eaff500c9754b2dbe",
+      "transcript": "they are almost all sandy beaches with safe swimming and most have shade provided by pohutukawa trees",
+      "duration_sec": 8.46,
+      "speech_end_offset_ms": 7492.0,
+      "audio_hash_id": "358ccf8cf673390ee341492cc189c64d01e722f93ce4bbc0f6a6cc8ebf6e0948",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0251.wav",
+      "sha256": "485dece97b6dbf30fc84126ef14919bd3717e4820c60ff7899f0673291a6e629",
+      "transcript": "they have feet with scales and claws they lay eggs and they walk on their two back legs like a t-rex",
+      "duration_sec": 6.66,
+      "speech_end_offset_ms": 6660.0,
+      "audio_hash_id": "7bd5fe3971b89f63a2c392f46e902c6d73e242a881783cca9ade077483c69019",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0252.wav",
+      "sha256": "5b9142d1e63762d0d2304c7cf3cdf3ea8c2763fe21ed9607c1deead7e1c89166",
+      "transcript": "they usually have special food drink and entertainment offers to keep guests in a good mood and keep them at the premise",
+      "duration_sec": 6.96,
+      "speech_end_offset_ms": 6084.0,
+      "audio_hash_id": "953571d8a0e4d5934877ca1a951c34d7ef46f86aecd3873e30fd7b76ea0ea20a",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0253.wav",
+      "sha256": "4e83763f570bb3f5af9546883f99a6e3ac036e5678a54a61807966a115f397d5",
+      "transcript": "think of the skiing route as of a similar hiking route",
+      "duration_sec": 4.94,
+      "speech_end_offset_ms": 4324.0,
+      "audio_hash_id": "2f3d4ce886d2ecb7e85219a67c17aab7fbf5fd6b8abdde7fc031ea7cfc8965c2",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0254.wav",
+      "sha256": "831bf3ea1a4b570ae5ede68269937595d73e09d54fa22b041338046b60ca1bdf",
+      "transcript": "this is an important way to distinguish between some verbs and objects",
+      "duration_sec": 4.5,
+      "speech_end_offset_ms": 4228.0,
+      "audio_hash_id": "bdc0c0dca3e385f0db334c4bb0090f283b790ce1fe5faee1e898cabe624fbcfc",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0255.wav",
+      "sha256": "482a4025286a20952bcca5531543e1f4f9cd6aea322641d952deaf6d2de813f4",
+      "transcript": "this is called a chemical's ph you can make an indicator using red cabbage juice",
+      "duration_sec": 5.88,
+      "speech_end_offset_ms": 4964.0,
+      "audio_hash_id": "46573c14f99bedfcbefb64444ed9860df49d557cd503b897a3c9a22d4a743e7d",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0256.wav",
+      "sha256": "4dcff268858f38be784d454e5aecf34e52317f9003e2bca8c2522592e8b36295",
+      "transcript": "this is not going to be goodbye this is the closing of one chapter and the opening of a new one",
+      "duration_sec": 5.88,
+      "speech_end_offset_ms": 5028.0,
+      "audio_hash_id": "89e8d5b258913bb0b806d3cc2ea7b4ff64a30dee267c546643887cef114918e8",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0257.wav",
+      "sha256": "d9b1a7333e53e5caf3efdd12ff79f099e5eb6367f85bcacfc2e97bd1a59c1b9f",
+      "transcript": "this offers a good opportunity to see the aurora borealis as the sky will be dark more or less around the clock",
+      "duration_sec": 6.72,
+      "speech_end_offset_ms": 6436.0,
+      "audio_hash_id": "5d063355e5ecc0ea50c99be8436890c12676dff49b25e4d6c31c932d9324ddb6",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0258.wav",
+      "sha256": "c7418e6cdf7f56307d41db0c0fea1d16273c36f864e5e18c0f980b890566c1fa",
+      "transcript": "this sediment was necessary for creating sandbars and beaches which served as wildlife habitats",
+      "duration_sec": 11.22,
+      "speech_end_offset_ms": 9540.0,
+      "audio_hash_id": "78ed26800b990333769662caaf7ca1bec451d92bff4dd2d9d491fadf33f77163",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0259.wav",
+      "sha256": "baf7b4cb60c7f168d13e60464fb767d5ebc173b5f47b6f32fec0c44e3ec2e812",
+      "transcript": "this seems sensible because the earth doesn't feel as if it's moving does it",
+      "duration_sec": 5.64,
+      "speech_end_offset_ms": 4708.0,
+      "audio_hash_id": "4aef435e39284bf33023cb564f69507b947ffc25bedcee3a635ce760143fcbf1",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0260.wav",
+      "sha256": "cb29bc550be524dec6c6605d672618717e9e473a70f67d21980ce03b2372c406",
+      "transcript": "this will allow players to control actions and movements in video games by moving the device through the air",
+      "duration_sec": 5.76,
+      "speech_end_offset_ms": 5760.0,
+      "audio_hash_id": "4abcc661550c69932a7d9956373cd1a7dad0ca8fd4edd3979cd77e20ec615023",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0261.wav",
+      "sha256": "a217a9b6b9db95494a5d356996e634a2a37ee731cb7592038ddb9351bfc0f56f",
+      "transcript": "through the night between 150 and 200 copies were made now known as dunlap broadsides",
+      "duration_sec": 4.8,
+      "speech_end_offset_ms": 4800.0,
+      "audio_hash_id": "86b92eb1b9473e06c948c1ffd6e72a6366ef83804e89eabfd1e9e1d1ac0fbb17",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0262.wav",
+      "sha256": "83139a8119d270c8b85e51819f37c87efd47a422cce60030bea18e4151ffb1df",
+      "transcript": "throughout 1960s brzezinski worked for john f kennedy as his advisor and then the lyndon b johnson administration",
+      "duration_sec": 8.76,
+      "speech_end_offset_ms": 7332.0,
+      "audio_hash_id": "c85fabc2d57639db4b66276ebd333b2d57f4f8039ebe7f5dfe974cbce6d2d1d7",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0263.wav",
+      "sha256": "e28225a1a023deca13e677fc532209e3b044c866b45460038b33c8bb2e806f31",
+      "transcript": "thus the pencil was a good friend to many people when it came out",
+      "duration_sec": 3.96,
+      "speech_end_offset_ms": 3652.0,
+      "audio_hash_id": "d7b5d1e29a83bf50d48d548e5871c97b622d76b1af9a71fea4896254327d8fe3",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0264.wav",
+      "sha256": "e64e468f399c925f0e804c78115b910d285482c782759fc0d4d02404d2debf96",
+      "transcript": "to get the best views of hong kong leave the island and head for the kowloon waterfront opposite",
+      "duration_sec": 6.9,
+      "speech_end_offset_ms": 5892.0,
+      "audio_hash_id": "012373bb34222552e35aae4b8ded9bd7c9363d9c18db85c852148485e5026880",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0265.wav",
+      "sha256": "f936aa3717ee02229ddd731c279bb395757456d144acd1abc3ee280b17873de2",
+      "transcript": "to the north and within easy reach is the romantic and fascinating town of sintra and which was made famous to foreigners after a glowing account of its splendours recorded by lord byron",
+      "duration_sec": 11.46,
+      "speech_end_offset_ms": 10980.0,
+      "audio_hash_id": "9fa5fef04c255efb4d3b47970e93fc5cd546c5c924906cb5659e5f2ba6ee8073",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0266.wav",
+      "sha256": "248b86bf91d8cf3a2b8b3e5b4aa89fed006cf2a25451f7731ad6f17efcb9197c",
+      "transcript": "today the only insects that cannot fold back their wings are dragon flies and mayflies",
+      "duration_sec": 5.94,
+      "speech_end_offset_ms": 4996.0,
+      "audio_hash_id": "3008cff13521e0463b33672de89ca06222d1ba2de1e2772c4c45d5a31199118e",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0267.wav",
+      "sha256": "4188e4d22a745b4998d4cc523ec1b99fdb21161295105fc5924d3f3be31ef88a",
+      "transcript": "traffic flow is the study of the movement of individual drivers and vehicles between two points and the interactions they make with one another",
+      "duration_sec": 7.68,
+      "speech_end_offset_ms": 7680.0,
+      "audio_hash_id": "9912c71c895388d8c35694b621007dc7503c55f1e54b6788a107cc67b1f6e60d",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0268.wav",
+      "sha256": "4159dd50c46fb25ea1d127907927effae679df03b697c469f79f202598d8d935",
+      "transcript": "travellers are strongly advised to be aware of any risk of severe weather affecting their area as they may affect any travel plans",
+      "duration_sec": 7.32,
+      "speech_end_offset_ms": 7320.0,
+      "audio_hash_id": "48237e091b6600ee6d754b0e8dc8728a590124f0325ffad311223a3c166ffa94",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0269.wav",
+      "sha256": "bac8d501df0953057e97fb630ca27f9739aad848428d88f2a4a09052512fdc09",
+      "transcript": "travellers bound for countries with heavy taxation can sometimes save a considerable amount of money especially on products such as alcoholic beverages and tobacco",
+      "duration_sec": 10.38,
+      "speech_end_offset_ms": 9252.0,
+      "audio_hash_id": "6035ffc66e9c9a4847e1bcaf3d50c6e0162872acfc9b7658aafa3d64998bbe24",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0270.wav",
+      "sha256": "62d67ed202891a139615abbab9a6918884a5e45a502b72521361e4a4390227de",
+      "transcript": "twentieth century research has shown that there are two pools of genetic variation hidden and expressed",
+      "duration_sec": 6.96,
+      "speech_end_offset_ms": 6180.0,
+      "audio_hash_id": "587c7b27face0abf3d035b463736091e5f0ab4e2c995f0990fa46ba1d5dbdd7f",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0271.wav",
+      "sha256": "f0a3bc0e5831ec17e5953321048fc64c6a07dd470c36d0daca49350dd4e1619a",
+      "transcript": "using ships to transport goods is by far the most efficient way to move large amounts of people and goods across oceans",
+      "duration_sec": 7.62,
+      "speech_end_offset_ms": 6820.0,
+      "audio_hash_id": "7abc97f683d10f8714e3147bdcc2f4776a0d262921e5431b35a4d6385d41b41e",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0272.wav",
+      "sha256": "a1066afb3f8b245aa41263c047ff9e076aa291e4e7cfca549dd99447b3ae0ddf",
+      "transcript": "usually you always here the sound of tourists and vendors the story of the sound and light is just like a story book",
+      "duration_sec": 7.38,
+      "speech_end_offset_ms": 6308.0,
+      "audio_hash_id": "98f5ed8c9b40ebd8058bd207202dadc9e0425a91fb2fd1e7c4ef0fd011a29d4d",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0273.wav",
+      "sha256": "93ce04e83e3243e5efcd017f4ef3b40a189c1b691f94d258d486a3ab0d98a96d",
+      "transcript": "vatican city's population is around 800 it is the smallest independent country in the world and the country with the lowest population",
+      "duration_sec": 10.74,
+      "speech_end_offset_ms": 7684.0,
+      "audio_hash_id": "90df64ccc033dceaf4352bfd68dac3f5aff4d41721d7aaf04626feaa0ba5788e",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0274.wav",
+      "sha256": "a6e1ab11bca6dacc3bb04966029ca42a37be2ba13a5a8790acd669b0b561f465",
+      "transcript": "virtual scaffolds are internalized in the software and are meant to question prompt and explain procedures that may have been to challenging for the student to handle alone",
+      "duration_sec": 9.72,
+      "speech_end_offset_ms": 9316.0,
+      "audio_hash_id": "a59cff0997b9d730f96ce925b95d5f92775f5f04111a8b82e2d3269f5b1c62a0",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0275.wav",
+      "sha256": "e0d89dbb2ce12bc93a4dfbd5eb59b022cc5fa0a057f86778852e3e256559b24d",
+      "transcript": "virtual teams are held to the same standards of excellence as conventional teams but there are subtle differences",
+      "duration_sec": 5.64,
+      "speech_end_offset_ms": 5640.0,
+      "audio_hash_id": "0da40689fe961980ae9498206e20245bfbdb3308cdda2437a0e1b6e2c4a1cad0",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0276.wav",
+      "sha256": "660e46b3dceae47602dc1a1288488f6526076658c04e15aa9c258afcb13ef898",
+      "transcript": "we make our houses from plants and make clothes from plants most foods that we eat are plants without plants animals could not survive",
+      "duration_sec": 7.92,
+      "speech_end_offset_ms": 7920.0,
+      "audio_hash_id": "087cd28b2feaf9623056f6a19f1f42c4e82d599309986bfd3fb020f7c4d65011",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0277.wav",
+      "sha256": "b6523ed0673121354a9687cef5c010d6e6fbc873582d5903b76ac09020a6ed38",
+      "transcript": "when all available resources are effectively used across the functional departments of an organization creativity and ingenuity can transpire",
+      "duration_sec": 9.18,
+      "speech_end_offset_ms": 8228.0,
+      "audio_hash_id": "4d9cb734ed1119e4230fadf268a3cf343aec631bbfd391d53888da0b84feb7d9",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0278.wav",
+      "sha256": "fdfa7fb40ebb52043e0b2d15977a24cb1115aded47372b5e60876414723e5c2f",
+      "transcript": "while goma is reasonably safe any visits outside of goma should be researched to understand the state of the fighting that persists in the north kivu province",
+      "duration_sec": 9.84,
+      "speech_end_offset_ms": 9316.0,
+      "audio_hash_id": "3ad26cff7c512146b749da26eb536c02dec8f366d495332d74686a466c2c4c8d",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0279.wav",
+      "sha256": "4da563805a69290f3fc735ce882d72681d89d234e62ddfcda86d23c556a11d72",
+      "transcript": "while he was working at the hospital liggins began to investigate premature labor during his spare time",
+      "duration_sec": 5.46,
+      "speech_end_offset_ms": 5460.0,
+      "audio_hash_id": "d6e2d2a0b7b90e6013b90c93b9972ee8fc9c07bca4618ed122f1644ce4d10f61",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0280.wav",
+      "sha256": "4f27434a6d16e534764b46ccd9f2e546411f0e1c1a52baa0e30802395cfb1793",
+      "transcript": "while one experimental vaccine appears able to reduce ebola mortality up until now no drugs have been clearly demonstrated suitable for treating existing infection",
+      "duration_sec": 12.0,
+      "speech_end_offset_ms": 11524.0,
+      "audio_hash_id": "d36761e84f74a70e379e100b2594d21e0243202d2610c2cea50c112a4e05fb15",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0281.wav",
+      "sha256": "37eb3de5536afeb54d7487f6b1934790135c0dec304a9fa43840b4169d3188b3",
+      "transcript": "with kundalini yoga the kundalini energy enlightenment energy is awakened through yoga postures breathing exercises mantras and visualizations",
+      "duration_sec": 11.04,
+      "speech_end_offset_ms": 10116.0,
+      "audio_hash_id": "3f1223d19be61189287270b268766640edb97621aa124490759c7adbc542a9e9",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0282.wav",
+      "sha256": "d98821709a6346430a377618a2b408c4174038b64579a8df828901f73c7d6b13",
+      "transcript": "with two years of the end of the war the former allies were now enemies and the cold war began",
+      "duration_sec": 7.68,
+      "speech_end_offset_ms": 6404.0,
+      "audio_hash_id": "35f8e160c7c8a41b72c6effffd4428d98e9d0dad6d2f4946dcf767bf91082900",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0283.wav",
+      "sha256": "799c052a2bad9493673f857507eac67319fb2f67bdd07c7294ac0daa905d44c2",
+      "transcript": "women it is recommended that any women travellers say that they are married regardless of actual marital status",
+      "duration_sec": 10.14,
+      "speech_end_offset_ms": 9124.0,
+      "audio_hash_id": "3d5f59331d53cd8b7a0054a9f659d8354f2adfff4c9c7810af94a00e4017c110",
+      "condition_idx": 0,
+      "condition_count": 1
+    },
+    {
+      "path": "audio/0284.wav",
+      "sha256": "b01f8c80d778b686c4933c5dd9c3fe64df2fd87b887452ba1c0a7e47398a60c7",
+      "transcript": "you may also wish to consult the advice of governments other than your own but their advice is designed for their citizens",
+      "duration_sec": 8.34,
+      "speech_end_offset_ms": 8340.0,
+      "audio_hash_id": "287eeefa4eb9ce31492cc50bff1ef3c66cd62f42f7fa548f047ac800bf9e72fc",
+      "condition_idx": 0,
+      "condition_count": 1
+    }
+  ]
+}

--- a/runner/src/coval_bench/datasets/manifests/stt-wildasr-farfield.json
+++ b/runner/src/coval_bench/datasets/manifests/stt-wildasr-farfield.json
@@ -1,0 +1,2849 @@
+{
+  "_license": "Apache-2.0 (WildASR; audio derived from FLEURS, CC-BY-4.0)",
+  "id": "stt-wildasr-farfield",
+  "version": "1.0.0",
+  "license": "Apache-2.0 (WildASR; audio derived from FLEURS, CC-BY-4.0)",
+  "source": "bosonai/WildASR environment_degradation__en__fleurs_far_field_en",
+  "items": [
+    {
+      "path": "audio/0001.wav",
+      "sha256": "e1eca791743deb2d8b47d02892bd32601df46f7187568209347f65215de9b8f9",
+      "transcript": "\"he [wales] basically lied to us from the start. first by acting as if this was for legal reasons. second by pretending he was listening to us right up to his art deletion.",
+      "duration_sec": 14.930687,
+      "speech_end_offset_ms": 11460.0,
+      "audio_hash_id": "075f9d18f77a75d45259c87ae860e5ba3a00eb21082c8ca695caf701cc5d3266",
+      "condition_idx": 2,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0002.wav",
+      "sha256": "5b7e9b7c519dd771ea63aab49b7a5092915ea241ecd7458ef9c10a930bcde483",
+      "transcript": "a car bomb detonated at police headquarters in gaziantep turkey yesterday morning killed two police officers and injured more than twenty other people",
+      "duration_sec": 12.590687,
+      "speech_end_offset_ms": 8740.0,
+      "audio_hash_id": "7d21140f42e6493fda48f8d8a8dbdd8c19a4c0830de9c1a41c591230b93386c3",
+      "condition_idx": 2,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0003.wav",
+      "sha256": "ea6951536c8cb05336e13ae2c340f4aa934b06032209ebe6793a9842995c019f",
+      "transcript": "a civilization is a singular culture shared by a significant large group of people who live and work co-operatively a society",
+      "duration_sec": 11.450688,
+      "speech_end_offset_ms": 7812.0,
+      "audio_hash_id": "9d2d9e2d9870595fca367d021081312a69ce1947155dc795da959ea49d38a01a",
+      "condition_idx": 2,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0004.wav",
+      "sha256": "1ff76bfe3f04db47470a543fca2b5d5ddaed156568da7b6dde83056332794179",
+      "transcript": "a curry is a dish based on herbs and spices together with either meat or vegetables",
+      "duration_sec": 11.630688,
+      "speech_end_offset_ms": 7172.0,
+      "audio_hash_id": "00d013ab4fc2dc1c20cb4c3d863a0576968f1705ba698e87079cd8b9c0ee78cb",
+      "condition_idx": 2,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0005.wav",
+      "sha256": "5659d0adc34b10ea80c5e5499a8481c97dbddecd23f1f47b8efa13a4f839b331",
+      "transcript": "a full 20% of the water that pours out of the planet's rivers into the oceans comes from the amazon",
+      "duration_sec": 9.890688,
+      "speech_end_offset_ms": 6660.0,
+      "audio_hash_id": "a6fa411c22c81016f900ffe72342e8da386a3e4ca1fabf7389e8435083f29dde",
+      "condition_idx": 5,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0006.wav",
+      "sha256": "f40ad82dbf85111359ba32a8074edbbfbd650eb82ff6ce75ff8c93824582d26c",
+      "transcript": "a search of the internet for hostile environment course' will probably provide the address of a local company",
+      "duration_sec": 9.770687,
+      "speech_end_offset_ms": 6340.0,
+      "audio_hash_id": "d2fcc762cd00287b1ef8ce1cf2bb0c92f1907d1933dd078cb999c966d54f2426",
+      "condition_idx": 5,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0007.wav",
+      "sha256": "d4c479ef77433b910c781acddac9ebed87f746eb67b8140c6c29e3a578c98e0b",
+      "transcript": "a simple popular dinner especially during the summer is the pa amb oli bread with olive oil tomato and any available condiments such as cheese tunafish etc",
+      "duration_sec": 14.787375,
+      "speech_end_offset_ms": 11332.0,
+      "audio_hash_id": "7d8c761d53d67dd9c97ba4e4c7c4a5e800397d6b0e0ada54d9843b77b7dbfaf2",
+      "condition_idx": 4,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0008.wav",
+      "sha256": "abb9df7826ad1d8135c3454234e50c5dc0f40040233162e4bfeac87d2247e579",
+      "transcript": "a well rounded athlete the tiger can climb though not well swim leap great distances and pull with five times the force of a strong human",
+      "duration_sec": 12.735687,
+      "speech_end_offset_ms": 9348.0,
+      "audio_hash_id": "5b2bf3a930639003b2bb4b2c656c2e3330cde16dcf768bc1dc76c73c1af90749",
+      "condition_idx": 0,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0009.wav",
+      "sha256": "3d97afffea631bac035215c916b421186ae318586610a677a6ec955edc6b4362",
+      "transcript": "accepted were aristotle's views on all matters of science including psychology",
+      "duration_sec": 9.290688,
+      "speech_end_offset_ms": 4900.0,
+      "audio_hash_id": "b5633d09184fdb8dc8805aafb1823b9d3eed1661ca156245a0d2fac81cf6b8b9",
+      "condition_idx": 2,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0010.wav",
+      "sha256": "867b09eb6883b6281313c1ccd75536a63901e0b4eb8d84da9e98dd1d56455a29",
+      "transcript": "according to japan's nuclear agency radioactive caesium and iodine has been identified at the plant",
+      "duration_sec": 9.915688,
+      "speech_end_offset_ms": 6308.0,
+      "audio_hash_id": "a3dca92046677b0ba5f138485a022a44aeb210d701ee587b8ae18c7bd97a8a60",
+      "condition_idx": 0,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0011.wav",
+      "sha256": "692551c4524466e2f64e0e576974aec6b7d417cd3140a24a2ec0b7d458cf6d22",
+      "transcript": "aerosmith have cancelled their remaining concerts on their tour",
+      "duration_sec": 6.507375,
+      "speech_end_offset_ms": 3748.0,
+      "audio_hash_id": "ceb6d4a8f750225136cf5307a9b118127fe4245c55a8f3ea23f778590c5d052b",
+      "condition_idx": 1,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0012.wav",
+      "sha256": "ff865855e31fa16438cc8407e74e86e669cc327b5b54faae8b647d019d4a634b",
+      "transcript": "after the accident occurred gibson was transported to a hospital but died shortly afterwards",
+      "duration_sec": 8.810688,
+      "speech_end_offset_ms": 5540.0,
+      "audio_hash_id": "d5603c7d2168ee5aa77bd50de6bd48b31e92dd957d7142308c7173885c56ffa0",
+      "condition_idx": 2,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0013.wav",
+      "sha256": "0af13a57422bea46f27dfb693ec766c900e0f66d53aaacac218fd6d6dd820da4",
+      "transcript": "after the dam was built in 1963 the seasonal floods that would spread sediment throughout the river were halted",
+      "duration_sec": 11.775688,
+      "speech_end_offset_ms": 7524.0,
+      "audio_hash_id": "a535b7c06195ec8f10f3984fe530d08c0893ab6707b47c474bdf60247ce301fb",
+      "condition_idx": 3,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0014.wav",
+      "sha256": "ff1e8e8426f5fbf6df96a0fd2ed74261aea1a5c9da6dca105087e85a012ce6ab",
+      "transcript": "all nouns alongside the word sie for you always begin with a capital letter even in the middle of a sentence",
+      "duration_sec": 11.295687,
+      "speech_end_offset_ms": 8260.0,
+      "audio_hash_id": "fc77d074ed0947ee482fa7db58180adac2539ca46ba06c32bc9592c5590f22ed",
+      "condition_idx": 0,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0015.wav",
+      "sha256": "f7081839705b54041998545fe93f8340b253ce864c7d04ad8347fd2b2cc79bf1",
+      "transcript": "all things considered we should not be surprised if our own ancestors solved their protein problem in somewhat the same way that chimps on the savanna do today",
+      "duration_sec": 12.027375,
+      "speech_end_offset_ms": 8612.0,
+      "audio_hash_id": "803d50cd6975b0c97c9eb51bf803fb2b0a3a37909da5e24fd236b3588e9af077",
+      "condition_idx": 4,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0016.wav",
+      "sha256": "be10418e7842c19fb627e868facdec7fcb880237a04cfa7263c401634a8db114",
+      "transcript": "alloys are basically a mixture of two or more metals don't forget that there are many elements on the periodic table",
+      "duration_sec": 10.927375,
+      "speech_end_offset_ms": 7556.0,
+      "audio_hash_id": "80f1f145429074fb346c413cf76eb968ff6229096ed653e0b828dae8106d88c8",
+      "condition_idx": 1,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0017.wav",
+      "sha256": "d18a0b929604e13ab7dab82166eba0c6b523f578e19b9eb545f3969a123e8792",
+      "transcript": "along the same line men are required to wear trousers covering the knees",
+      "duration_sec": 8.570688,
+      "speech_end_offset_ms": 5284.0,
+      "audio_hash_id": "c39ca686b5d7b6942b0a009d0dfab547265254c800c8f371aaba3ea912296d37",
+      "condition_idx": 2,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0018.wav",
+      "sha256": "b5647faf9c0606008f4da3b3d0b85b6a5bdc865c944760de7341278e45b84bb5",
+      "transcript": "also after the revolution occupations were open to all male applicants allowing the most ambitious and successful to succeed",
+      "duration_sec": 9.590687,
+      "speech_end_offset_ms": 6852.0,
+      "audio_hash_id": "ba05aee624e68efd6972fb0bfbb58eb3f634096fb979795e936a93f4c7db6377",
+      "condition_idx": 2,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0019.wav",
+      "sha256": "d72d5fc6b2c1355c47df7769137175377e3d260053ee813472a6296979acf71c",
+      "transcript": "also between each dynasty was an unstable age of divided provinces the best-known of these periods was the three kingdoms epoch taking place for 60 years between the han and the jin dynasty",
+      "duration_sec": 14.355688,
+      "speech_end_offset_ms": 11332.0,
+      "audio_hash_id": "d884d9f7a9114b30818024cf50875d9e91c34ee2fd8ba593e4a73e937b3bfb4c",
+      "condition_idx": 3,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0020.wav",
+      "sha256": "74c3d252e53ff43e7f5172e33aa7b372ff1089c7f2787eec844c5188bda58fa0",
+      "transcript": "also to the north visit the great sanctuary of our lady of fatima shrine a place of worldwide famous marian apparitions",
+      "duration_sec": 10.130688,
+      "speech_end_offset_ms": 7428.0,
+      "audio_hash_id": "239bd0a6d2391346266d6b41a111ed96f1cad9915bc3a18decf643e2bc2afe4f",
+      "condition_idx": 2,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0021.wav",
+      "sha256": "032af2252ed4f00ab6b4b9f48c6723080b4083e70a677bf79ea0c0ddf1dab68b",
+      "transcript": "ancient cultures and tribes began to keep them for easy access to milk hair meat and skins",
+      "duration_sec": 9.387375,
+      "speech_end_offset_ms": 6564.0,
+      "audio_hash_id": "06d806fbaef49a1404c620afba353936a3f9d007bf4aa1b17819d889da68fabe",
+      "condition_idx": 1,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0022.wav",
+      "sha256": "3f7105ecd2a614c0630397a0aaa100310357fc5c0a4b2efb739e51ee3fe7c9fb",
+      "transcript": "angel 2006 explains the continuum approach as a method being used to help organizations reach a higher level of performance",
+      "duration_sec": 10.815687,
+      "speech_end_offset_ms": 7812.0,
+      "audio_hash_id": "bed10c44b8031ffc106c9c28bfa4967bda56b3a61872a1fd8e6079460d85f99f",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0023.wav",
+      "sha256": "e159b57f909f9e4222d0dae046c1d151f8ba3a620d770fbc0ff44d05cb1187bc",
+      "transcript": "anyone who's going to drive at high latitudes or over mountain passes should consider the possibility of snow ice or freezing temperatures",
+      "duration_sec": 11.127375,
+      "speech_end_offset_ms": 7716.0,
+      "audio_hash_id": "a66612638d1af0323966187ab2af18014b6fdd81490cbccaab4bebe08af142e5",
+      "condition_idx": 1,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0024.wav",
+      "sha256": "37cfa7829adcbefd16f2e93dbfc6a01baaeb6850eee1f5889fb1efec7bc358d4",
+      "transcript": "apia is the capital of samoa the town is on the island of upolu and has a population of just under 40,000",
+      "duration_sec": 13.495688,
+      "speech_end_offset_ms": 10436.0,
+      "audio_hash_id": "9a750e820a9b8900582cae5998f4f79cfabae82260b1ba9932f22fbd224b1463",
+      "condition_idx": 0,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0025.wav",
+      "sha256": "2ee673871b6fd822c93d42a78e8f0ecd9fe7c1ad5dfd4fbb66c00b59873c9aca",
+      "transcript": "aristotle a philosopher theorised that everything is made up of a mixture of one or more of four elements they were earth water air and fire",
+      "duration_sec": 11.630688,
+      "speech_end_offset_ms": 9380.0,
+      "audio_hash_id": "ad8b886e405dc50d0b558c3e7fbe8c0eeb414c3e4b72751b8560c9b142b9c1ec",
+      "condition_idx": 5,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0026.wav",
+      "sha256": "42c779e34def8283e623103a945a34b2f565230aef7196f4f5f264e0dff077fb",
+      "transcript": "as a result the performers smoke cannabis joints on stage and the theatre itself is encouraging the audience to join in",
+      "duration_sec": 13.130688,
+      "speech_end_offset_ms": 8836.0,
+      "audio_hash_id": "372558a0c1b14dcd3ec8a288eb8e76262d9310f8fdf90ab8c04e2d26f6b524c1",
+      "condition_idx": 5,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0027.wav",
+      "sha256": "c250a3c1b8b0572c45b89cfa65cfd413534b037019c02ec35297a5a220e093d4",
+      "transcript": "as a result the process of an organization working together to overcome an obstacle can lead to a new innovative process to serve the customer's need",
+      "duration_sec": 14.690687,
+      "speech_end_offset_ms": 10820.0,
+      "audio_hash_id": "1baefc1cfd3fdb9cb98539b7efe029205f7b82335ab03065edc95b70da287a76",
+      "condition_idx": 2,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0028.wav",
+      "sha256": "133332e7b73e8bdda48030a96b2a6f08a4c21c5802709bac044c063f23d2e973",
+      "transcript": "as a result two fish species have become extinct and two others have become endangered including the humpback chub",
+      "duration_sec": 14.010687,
+      "speech_end_offset_ms": 10468.0,
+      "audio_hash_id": "5f4f812e98380264b617060891484d6d961065f4a2ddc72036c3173de2a46b4c",
+      "condition_idx": 2,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0029.wav",
+      "sha256": "57160a2d3e5d05d4256be071c76235cf117a9de26f5ee5da963d112b35f49e2e",
+      "transcript": "as knowledge of greek declined the west found itself cut off from its greek philosophical and scientific roots",
+      "duration_sec": 12.727375,
+      "speech_end_offset_ms": 9572.0,
+      "audio_hash_id": "04bc798cec39e026f9ae59738cba84060670938a713236dbb37ac071dcb01909",
+      "condition_idx": 4,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0030.wav",
+      "sha256": "2e6b336a3ef03012733eb5d68250d66003e8b4b64b06bfa06d2e606b36b48eb3",
+      "transcript": "as light pollution in their heyday was not the kind of problem it is today they are usually located in cities or at campuses easier to reach than those built in modern times",
+      "duration_sec": 12.447375,
+      "speech_end_offset_ms": 8804.0,
+      "audio_hash_id": "78d25200b01ad78b8ed24f350a74c1b990b7372380b22b1ed1dcca23d719fb33",
+      "condition_idx": 1,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0031.wav",
+      "sha256": "a76dc5904ef87a8f27332cd8ba045b23b4ea23988bedbdd5d6d6efcbd5d48f3c",
+      "transcript": "as with all south african national parks there are daily conservation and entry fees for the park",
+      "duration_sec": 11.967375,
+      "speech_end_offset_ms": 8420.0,
+      "audio_hash_id": "48f7cc0322eb0b37b3bbdd8d198980934bbb97dc6cd82afcf3beae7a2f7dbefc",
+      "condition_idx": 1,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0032.wav",
+      "sha256": "4ddd6a25b1133c0f676923c44dd75fcb738718562105980dedce4bc563771fe6",
+      "transcript": "asus eee pc earlier launched world-wide for cost-saving and functionality factors became a hot topic in 2007 taipei it month",
+      "duration_sec": 13.310688,
+      "speech_end_offset_ms": 9508.0,
+      "audio_hash_id": "0cbd4d8ba6cbe17dd43e424e27e244b2242acaf3caa11fbbf54f7adf148877a8",
+      "condition_idx": 2,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0033.wav",
+      "sha256": "fad8fdc66b1ff1bc9574f51d2d490ecccedfa377678ed220627dbaa4d66b99ab",
+      "transcript": "barcelona's official languages are catalan and spanish about a half prefer to speak catalan a vast majority understands it and virtually everyone knows spanish",
+      "duration_sec": 13.790688,
+      "speech_end_offset_ms": 9540.0,
+      "audio_hash_id": "45707621e203c5e43ddd1dc0e81d19c85c9dac0743843018c1b7e7d6cee38462",
+      "condition_idx": 5,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0034.wav",
+      "sha256": "e4e0db553519f42975363953736f83863e49642b0b2a3b7c36eee7f077e3a686",
+      "transcript": "be careful not to allow fabric to become too hot which can cause shrinkage or in extreme cases scorch",
+      "duration_sec": 12.730688,
+      "speech_end_offset_ms": 9796.0,
+      "audio_hash_id": "30dc72ba7990a185a55ea473da10ae575a83c3061a26a39c8bff95a2adf84488",
+      "condition_idx": 5,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0035.wav",
+      "sha256": "fe2a6cf471c7d22459d52f84538c9cd16de717c38aa860a2b112ea2ef649481f",
+      "transcript": "be firm in turning down men and don't be afraid to stand your ground cultural differences or not it doesn't make it ok!",
+      "duration_sec": 13.527375,
+      "speech_end_offset_ms": 9092.0,
+      "audio_hash_id": "6a05ad3bd10c7766721dafe1998ac67fb73cdfda7b3a95570bb07ed274ccca11",
+      "condition_idx": 4,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0036.wav",
+      "sha256": "7c721a9dae0c781739a9ac71cdc3d40ae1fa94435965ca3eb1ff6105fe09bfe0",
+      "transcript": "between 10:00-11:00 pm mdt a fire was started by the inmates in the yard",
+      "duration_sec": 11.510687,
+      "speech_end_offset_ms": 7876.0,
+      "audio_hash_id": "c0c79e59b3c8818bbc31bf60c41e283ec8431cf8f755153a214014c32d903bc0",
+      "condition_idx": 2,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0037.wav",
+      "sha256": "c399f8bc6d777647b3aa9237c64d913285fc4f5ef01b05a9a13a1d9650e1bb7b",
+      "transcript": "beyond wednesday's event carpanedo competed in two individual races at the championships",
+      "duration_sec": 8.270687,
+      "speech_end_offset_ms": 5476.0,
+      "audio_hash_id": "875ae2d9ec23c11704aece928c05ac6e1d5fda2c460e8ab50a70c052b63ac632",
+      "condition_idx": 5,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0038.wav",
+      "sha256": "9ce85c20ae25cf6c29eed14840a081c2b88859258239008f6b6b58b019bccb1c",
+      "transcript": "bishkek was described as sinking into a state of anarchy by one observer as gangs of people roamed the streets and plundered stores of consumer goods",
+      "duration_sec": 12.135687,
+      "speech_end_offset_ms": 8676.0,
+      "audio_hash_id": "dc5363d559da47584ebd6172a1632ad9b1c0f22c599a8dd22834803358727623",
+      "condition_idx": 0,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0039.wav",
+      "sha256": "cf9c18e8df5682fe31319e30b9b62b573dfb0ed99657ae6e2fe32a3f74d2289f",
+      "transcript": "blogging is a tool that inspires collaboration and encourages students to extend learning well beyond the traditional school day",
+      "duration_sec": 12.147375,
+      "speech_end_offset_ms": 8644.0,
+      "audio_hash_id": "9520dcefe24b2069851930b2c160a63edf886c42566dd5000b8d303d65a3ae8a",
+      "condition_idx": 4,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0040.wav",
+      "sha256": "10b88169f02358084651f101fbc2573fdcbf6e74f505526c6be960767ff3309f",
+      "transcript": "blogs can also help improve student writing while students often begin their blog experience with sloppy grammar and spelling the presence of an audience generally changes that",
+      "duration_sec": 11.307375,
+      "speech_end_offset_ms": 8420.0,
+      "audio_hash_id": "c8e8ae65a1ad3035da65b4b60d3e67f23e81fb6b5373d1990de47f6a3ba22f16",
+      "condition_idx": 1,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0041.wav",
+      "sha256": "ccfeb5e236fb29d34f8d5ed4986feee18d30777b68709f05ada7c89137772b35",
+      "transcript": "built by the egyptians in the third century bce the great pyramid is one of many large pyramid structures built to honor dead pharaoh",
+      "duration_sec": 11.487375,
+      "speech_end_offset_ms": 7908.0,
+      "audio_hash_id": "cc9237af0cff676dcfd19a5fe318cf46ab681e2f1cc618e7db4d23cfa6127e96",
+      "condition_idx": 4,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0042.wav",
+      "sha256": "f6809561feaf26d5a7e0d340f09c15835953668e9b173d5e56c85607553704f2",
+      "transcript": "buses depart the inter-district bus station across the river throughout the day though most especially those heading to the east and jakar/bumthang leave between 06:30 and 07:30",
+      "duration_sec": 14.690687,
+      "speech_end_offset_ms": 11140.0,
+      "audio_hash_id": "ec6b879ea3e7b5eaa6e41e55b4bf2663f9f7bb9dc943cf9c50d210bbeec7d8e7",
+      "condition_idx": 2,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0043.wav",
+      "sha256": "3c3614a7338f1f057456afffe9ba15536440a1e3d7feb2635b96d6f8dcd30a34",
+      "transcript": "but after losing the captain's wicket india only made 36 runs loosing 7 wickets to end the innings",
+      "duration_sec": 11.090687,
+      "speech_end_offset_ms": 7428.0,
+      "audio_hash_id": "6c694ba476dd5b836028588a8a1cecf9960d22661adbaa27d4319a5fcfed57db",
+      "condition_idx": 5,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0044.wav",
+      "sha256": "94577ea1c240111970ab487f1811f1f5ed997a679b52319769c428068b0ee02e",
+      "transcript": "but being placed in the high tropics just a few degrees north of equator you will need to deal with both heat always and strong sun when the sky is clear more rarely",
+      "duration_sec": 13.010687,
+      "speech_end_offset_ms": 9572.0,
+      "audio_hash_id": "49811adff5e7470ea149b7c33f813e60fa752870f7731dba1ea608de6dbaeba5",
+      "condition_idx": 2,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0045.wav",
+      "sha256": "1fe0fcbbcf270edc48586085e885fd2a882fef7e7c5ccc6f0bf7bc3c623e01ed",
+      "transcript": "but there are a lot of things about birds that still look like a dinosaur",
+      "duration_sec": 7.907375,
+      "speech_end_offset_ms": 5220.0,
+      "audio_hash_id": "0d96a473f1048c6067489a0e55636492ca5ad3188fe7d7cd09a5feb089911c57",
+      "condition_idx": 4,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0046.wav",
+      "sha256": "e7d3eaf9fae5096bd10611613552b1ac9c461fc7165376706a1c107af043e6ec",
+      "transcript": "by 1976 thirty percent of machu picchu had been restored and restoration continues till today",
+      "duration_sec": 9.350687,
+      "speech_end_offset_ms": 6660.0,
+      "audio_hash_id": "7e118e29b08237b61aff1c8995e26b4b2d887dfa763e49b89ad744e45290cc4c",
+      "condition_idx": 2,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0047.wav",
+      "sha256": "739f480fdb1581e156538d669a09f42d4e71b90e62eae1283bb263f92a56ccaf",
+      "transcript": "california governor arnold schwarzenegger signed into law a bill that bans the sale or rental of violent video games to minors",
+      "duration_sec": 13.910687,
+      "speech_end_offset_ms": 9124.0,
+      "audio_hash_id": "b4d403e7da69e80cb1ea640ea50436ca43335121a5ecb830b048eb6b8bd56b7c",
+      "condition_idx": 5,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0048.wav",
+      "sha256": "07a7aaafd144c680d42b14b7bcc4e7f1604e955f70aa72c8a01e975ac482b2bf",
+      "transcript": "cancellation policies vary but as of late march most coronavirus-based cancellation policies don't extend to july 2020 when the olympics had been scheduled",
+      "duration_sec": 11.835688,
+      "speech_end_offset_ms": 8932.0,
+      "audio_hash_id": "2f4773441122364c49c82de88ee794c3a43e476d05caf7dc18996c8dc252e023",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0049.wav",
+      "sha256": "c8a8da10693b34cb4b5c213d0b8489832aa2278ac50fc2619e4dda1fa86251cb",
+      "transcript": "casablanca is one of the least interesting places to shop in all of morocco",
+      "duration_sec": 8.775688,
+      "speech_end_offset_ms": 5156.0,
+      "audio_hash_id": "b783a033e8a0c9268658a50b26931fe528b74353aacd541c1d0f606ec696ff1b",
+      "condition_idx": 0,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0050.wav",
+      "sha256": "3c27dc24e4a28a0b9b73bcee1917b76bfbba5a52395d16b58675f9531c0b57f4",
+      "transcript": "children are placed in foster care for a wide variety of reasons that range from neglect to abuse and even to extortion",
+      "duration_sec": 13.267375,
+      "speech_end_offset_ms": 10148.0,
+      "audio_hash_id": "0017d497cccab9ce1521a148b6713b679279b55fe0af852e49eb8ea67595d202",
+      "condition_idx": 4,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0051.wav",
+      "sha256": "71327ecb318bcebcf5c091bd8ab48e5c6f59ad2b73b630943258d6056331ea24",
+      "transcript": "cochamó valley - chile's premier climbing destination known as the yosemite of south america with a variety of granite big walls and crags",
+      "duration_sec": 14.667375,
+      "speech_end_offset_ms": 10436.0,
+      "audio_hash_id": "eae8e0eb6651b8d03b12dd7fc0a522bbdfd32101f3e948a28880c7e2b26df9d0",
+      "condition_idx": 1,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0052.wav",
+      "sha256": "442471cbcba226848db7b8a6cfff3a04960eb8f1a88f9bdda36f8ba4e6c9beec",
+      "transcript": "congress began funding the obscenity initiative in fiscal 2005 and specified that the fbi must devote 10 agents to adult pornography",
+      "duration_sec": 12.555687,
+      "speech_end_offset_ms": 8868.0,
+      "audio_hash_id": "a4cdf1a2aed43e0a4661a0c177ccffd6ee5a489a9c1f14bd22b573efe3d412eb",
+      "condition_idx": 0,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0053.wav",
+      "sha256": "a110de5b18ac411fae2fcb57dac7128de15aa16a042c4cf94ec7d1c8f3f31960",
+      "transcript": "crossties were introduced fairly early to hold the tracks in place gradually however it was realised that tracks would be more efficient if they had a stip of iron on the top",
+      "duration_sec": 13.287375,
+      "speech_end_offset_ms": 10468.0,
+      "audio_hash_id": "bb9c7cf09a748e3f1964dabe6a496f7109dbe5716824f2b10fd4dfdbb8e0d9cf",
+      "condition_idx": 1,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0054.wav",
+      "sha256": "131ab5b021fd360711dc97f5ac70a1c947a0e9bbdf11871d78abd5e43ca61f2a",
+      "transcript": "cuomo 53 began his governorship earlier this year and signed a bill last month legalizing same-sex marriage",
+      "duration_sec": 11.967375,
+      "speech_end_offset_ms": 8228.0,
+      "audio_hash_id": "cb42cb1901a28e763a880ce3c79438c7569173a50f6b6d819e1df326e1c88f32",
+      "condition_idx": 4,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0055.wav",
+      "sha256": "99fa918617719608d472915d3246b87b2ac07cc5e5aa0aebd787459b354d6ce9",
+      "transcript": "danielle lantagne a un expert on the disease stated the outbreak was likely caused by the peacekeepers",
+      "duration_sec": 8.835688,
+      "speech_end_offset_ms": 5988.0,
+      "audio_hash_id": "355891183e6931767050d8510d7f92f1c4d15101e616516a5823e41be56d4d39",
+      "condition_idx": 3,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0056.wav",
+      "sha256": "2e4b0dc9b848e3a2e80ac04dc2f2dd2e64a9b9c11e0c079f7465051e58af7797",
+      "transcript": "del potro had the early advantage in the second set but this too required a tie break after reaching 6-6",
+      "duration_sec": 10.647375,
+      "speech_end_offset_ms": 7012.0,
+      "audio_hash_id": "9ecba4875cc7a3431e6ffebee361edaccbbf1d04eee55f687a592b28717d2c85",
+      "condition_idx": 1,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0057.wav",
+      "sha256": "78b325ec9d8e74cd8a16f8b2f12b0d6e67a5a3d53943ddfddc615c4f61feca8b",
+      "transcript": "do not deface the site by marking or scratching graffiti into structures",
+      "duration_sec": 7.047375,
+      "speech_end_offset_ms": 4292.0,
+      "audio_hash_id": "eb4a322d34c20c59af8a01df97e2e375648145666efce7ea9e759ab68c2176a1",
+      "condition_idx": 1,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0058.wav",
+      "sha256": "6a337297c35c795b7413b19bdd55dcbe4058fd2174c793fa0789d0114c371c61",
+      "transcript": "due to the underwater topology the return flow is concentrated at a few deeper sections and a fast current to deep water may form there",
+      "duration_sec": 13.467375,
+      "speech_end_offset_ms": 9828.0,
+      "audio_hash_id": "2f6b0ab813f136c7c145ce48322910d641e7375aa212e89511052602fbbe88d7",
+      "condition_idx": 4,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0059.wav",
+      "sha256": "f9a706e4624b4d63cbbbc7805e4910e04645dafcfe2bc21869749ef9e64ed7aa",
+      "transcript": "during the 1920s the prevailing attitudes of most citizens and nations was that of pacifism and isolation",
+      "duration_sec": 10.250687,
+      "speech_end_offset_ms": 6628.0,
+      "audio_hash_id": "0f6a1b01dec1edcc5e63665bc2bb16ab804643bd8724db7218eed3c6d4f6aa4d",
+      "condition_idx": 2,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0060.wav",
+      "sha256": "962476660c0d169e94d1d04ad94857524db1d97b8736676ac7bb08df4e8b430a",
+      "transcript": "during the revolutionary war the thirteen states first formed a weak central government-with the congress being its only component-under the articles of confederation",
+      "duration_sec": 12.615687,
+      "speech_end_offset_ms": 9028.0,
+      "audio_hash_id": "8d6aeefdd0f5967a356a4e67d0d2dbafd375788a3064f8def372db1ae85bf273",
+      "condition_idx": 0,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0061.wav",
+      "sha256": "de96315481bc5a15a5e674ad670d001f560052436f8b4eab84b9857d3d69ce0c",
+      "transcript": "during the struggle for independence organised by the mau movement a peaceful gathering in the town resulted in the killing of the paramount chief tupua tamasese lealofi iii",
+      "duration_sec": 14.655688,
+      "speech_end_offset_ms": 11524.0,
+      "audio_hash_id": "aeafaa98249df34b2b2ec1a77c7f8e3a4296b200f544ca3d0b8d8e1f6c2b2b16",
+      "condition_idx": 0,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0062.wav",
+      "sha256": "fb7d38a712a3fecccf6ce7abe1569c039cee01d425e76857ced3e590ab1a104f",
+      "transcript": "during this period of european history the catholic church which had become rich and powerful came under scrutiny",
+      "duration_sec": 13.970688,
+      "speech_end_offset_ms": 10596.0,
+      "audio_hash_id": "861c2fa5edd8078b366dd7727214faaf29543fa0c1c8fd6f625b01461d6b61aa",
+      "condition_idx": 5,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0063.wav",
+      "sha256": "89d5d3436d126a1fc2069f7c680b2029c62b8aec2bbd6266aaf78846c770ee84",
+      "transcript": "duvall who is married with two adult children did not leave a big impression on miller to whom the story was related",
+      "duration_sec": 8.775688,
+      "speech_end_offset_ms": 6084.0,
+      "audio_hash_id": "dada09dbb4b302f3a802e8d3bb05a044f866d2890114998878bd8a33d481d26e",
+      "condition_idx": 3,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0064.wav",
+      "sha256": "f81a829ea00e0d4b4f0406794c47ab8c7c7ce44c6a3097279e7225a4ab40ce89",
+      "transcript": "elements like calcium and potassium are considered metals of course there are also metals like silver and gold",
+      "duration_sec": 8.787375,
+      "speech_end_offset_ms": 6052.0,
+      "audio_hash_id": "dc35a1da7beabcaafe27fcb4acb1e39de20959ce1ce9a9dad4191b36e669b658",
+      "condition_idx": 1,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0065.wav",
+      "sha256": "5adc9f89c2fd3b42e6bd02867c64ef6eedf1b077732cb29a8def56e9df2c12f8",
+      "transcript": "everyone participates in society and uses transportation systems almost everyone complains about transportation systems",
+      "duration_sec": 14.175688,
+      "speech_end_offset_ms": 10660.0,
+      "audio_hash_id": "91abf638c4255c5e323e40e568da7f0538adf4f22e71da95674a275043a47e83",
+      "condition_idx": 3,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0066.wav",
+      "sha256": "ac67dee6db3d93988fc925f1202b6d1bb5d0d7b31b29b22a51118abfaa182c62",
+      "transcript": "everything in the universe is made of matter all matter is made of tiny particles called atoms",
+      "duration_sec": 8.967375,
+      "speech_end_offset_ms": 5924.0,
+      "audio_hash_id": "ef5a3d4100cdba4517bcb89a94e98ad19a544e6a8cc25ae50dfc6582daa21227",
+      "condition_idx": 1,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0067.wav",
+      "sha256": "ded4dc3379df7cdb1a22ea62bc8c4e6aad23f938d8294784ea17af98a977cd16",
+      "transcript": "fellow wrestlers also paid tribute to luna",
+      "duration_sec": 6.147375,
+      "speech_end_offset_ms": 2916.0,
+      "audio_hash_id": "a098b0a64f136136efbf4025b36b5a6ff35513c3c6839b513daed5c0926a1b9a",
+      "condition_idx": 1,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0068.wav",
+      "sha256": "1121a0e251ef97116cdd97da0fb24dcdf48f0dceafdc867c2ab5570821a42405",
+      "transcript": "feral children may have experienced severe child abuse or trauma before being abandoned or running away",
+      "duration_sec": 9.087375,
+      "speech_end_offset_ms": 5860.0,
+      "audio_hash_id": "a233cd089be7ff6a7aa822bca3fbdd64c57f7823cf451725f6cd3dc7d1b82b9e",
+      "condition_idx": 1,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0069.wav",
+      "sha256": "92ecfe4ef09c0f40129ac13e695db13ffbfe5e15529a79b757745fdae50e22a3",
+      "transcript": "field trips are a large part of any classroom quite often a teacher would love to take her students places to which a bus trip is not an option",
+      "duration_sec": 12.387375,
+      "speech_end_offset_ms": 8484.0,
+      "audio_hash_id": "b37c5ce741be1ab847e86193a4c4630e1e8cfe6b634770f33630b5b3e42e8829",
+      "condition_idx": 1,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0070.wav",
+      "sha256": "585fba81524c6fb4f83421bb3db1149609b472e88d6fbbb3787f2b2cf3ea3398",
+      "transcript": "finally there are many small cats including loose pet cats that eat the far more numerous small prey like insects rodents lizards and birds",
+      "duration_sec": 11.175688,
+      "speech_end_offset_ms": 8516.0,
+      "audio_hash_id": "802d7a44a0206b8585cc2c7c756d2908e53164eab1d51ba21665fe714c203f17",
+      "condition_idx": 0,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0071.wav",
+      "sha256": "50566fffbb1704b01b7bf66e3f34161df7eea91aa729429e64e18946e4de34d0",
+      "transcript": "finland is a great boating destination the land of a thousand lakes has thousands of islands too in the lakes and in the coastal archipelagos",
+      "duration_sec": 11.907375,
+      "speech_end_offset_ms": 8324.0,
+      "audio_hash_id": "77ebefc0ac33502b4aaec3ced0742463567cbfa1366e1d1e09c63add996697a7",
+      "condition_idx": 4,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0072.wav",
+      "sha256": "ef4f268e44bd7bd7048d8e988958e64530dfbd5134d3056174af0fc70c6f7f3a",
+      "transcript": "fire rescue crews eventually doused the fire by 11:35 pm",
+      "duration_sec": 8.267375,
+      "speech_end_offset_ms": 5348.0,
+      "audio_hash_id": "5e7c5d35a9ebde213fc8d915b871e30a09ba6d9939488e09b6d902bdb53eef74",
+      "condition_idx": 4,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0073.wav",
+      "sha256": "10d563fd4bf2242fff7cbc15558df72f55ef7e404ed046bd05a765cf8ee93d38",
+      "transcript": "first most riders wear riding boots with a heel and a smooth quite narrow sole",
+      "duration_sec": 10.430687,
+      "speech_end_offset_ms": 6884.0,
+      "audio_hash_id": "1de825fa4b353c04e348ea823eca8b3151018ee1dd323a41d6c3d791c0fa9a43",
+      "condition_idx": 2,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0074.wav",
+      "sha256": "8e18c1895519fb19393b3b87ddeaa4b56a4b8083e3c81bd52e2ab663388f1b37",
+      "transcript": "for example each year students from bennet school in north carolina design a website about their trip to the state capital each year the website gets remodeled but old versions are kept online to serve as a scrapbook",
+      "duration_sec": 13.827375,
+      "speech_end_offset_ms": 11012.0,
+      "audio_hash_id": "3dd1ebcddb596476688fa655f69e13f185b41aaa3e0e3b7c6dfae36eaf5cc8f4",
+      "condition_idx": 4,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0075.wav",
+      "sha256": "06962340d116a7d9c7666ffe85ae9871b55551763e410af41df0a7da88db2707",
+      "transcript": "for the springboks it ended a five-match losing streak",
+      "duration_sec": 7.527375,
+      "speech_end_offset_ms": 4548.0,
+      "audio_hash_id": "8e552d9e44ed7556b62c801517e6e39cd14326321056d4b4421b605c7eaa9dcd",
+      "condition_idx": 1,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0076.wav",
+      "sha256": "1af9ec4b30b0423c90184e0e31a44f259de10a7542876bd5a6ecf118b511bcdd",
+      "transcript": "four skiers in the women's sitting group failed to finish their runs and 45 of the 117 total skiers in the giant slalom failed to rank in the race",
+      "duration_sec": 10.250687,
+      "speech_end_offset_ms": 7524.0,
+      "audio_hash_id": "d4b45f9fef9643d2faf7c17a0ff56185f713d043b2f6fee60f1d317146528d26",
+      "condition_idx": 5,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0077.wav",
+      "sha256": "7e2274a624069c922fe7aba2a77ebb510cfdc48d33b6b49b78eb4031337af4dd",
+      "transcript": "giancarlo fisichella lost control of his car and ended the race very soon after the start",
+      "duration_sec": 7.730688,
+      "speech_end_offset_ms": 5028.0,
+      "audio_hash_id": "88b24c1dd1524b03b9edddcd41addfd2700aaeed9ebd949a35a317cf31f7875b",
+      "condition_idx": 2,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0078.wav",
+      "sha256": "ef28df49d57094483dfa55abad4feaedbc08009eb5de2ab843501c403f6918a4",
+      "transcript": "goats seem to have been first domesticated roughly 10,000 years ago in the zagros mountains of iran",
+      "duration_sec": 13.190687,
+      "speech_end_offset_ms": 8772.0,
+      "audio_hash_id": "b8efecdb1b3fd3baca42fccab0934c414a30bad40827218eba090b7b1b9b2a3c",
+      "condition_idx": 2,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0079.wav",
+      "sha256": "fa38c9bc0cc22769cc2eacb37b65e16d6735c9114436e32f89a4b38aad211075",
+      "transcript": "he added that they should not however be asked to take on obligations that go beyond their development stage responsibility and capabilities",
+      "duration_sec": 14.767375,
+      "speech_end_offset_ms": 10980.0,
+      "audio_hash_id": "e2e33c56d7523250b12c6a09d14934496b40282fce97750d7725aac7ffdda4dc",
+      "condition_idx": 1,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0080.wav",
+      "sha256": "01832e58284663da6e9534e69620f6bb2f0c6f1c3006490781d8cbdb1c66f264",
+      "transcript": "he did not set a figure for the cuts saying they will be made based on china's economic output",
+      "duration_sec": 8.895687,
+      "speech_end_offset_ms": 5540.0,
+      "audio_hash_id": "f3fcac1bec03b4a3fc50a42fff04449bbb527d38f670aae0d55c15c6d77681f9",
+      "condition_idx": 3,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0081.wav",
+      "sha256": "216cb96a6208e0cbfccea7860a4bba83260e04712a7b3780f6dd297db04253cc",
+      "transcript": "he has been unable to take the drugs needed to overcome his pain as they are banned from the games",
+      "duration_sec": 8.895687,
+      "speech_end_offset_ms": 5348.0,
+      "audio_hash_id": "24b88c5b2e27c8383d6c2431a95a8755f58e0dc4452ed7b5cea929c841097fbd",
+      "condition_idx": 0,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0082.wav",
+      "sha256": "8da0775ab98750c277c0c7561b5fac015ecedd8f0c734090bb68024b04141628",
+      "transcript": "he referred to the rumors as political chatter and silliness",
+      "duration_sec": 6.387375,
+      "speech_end_offset_ms": 3652.0,
+      "audio_hash_id": "a8ba64529b395b4efc8143425fe9ab1cca5bcdbe13aa20952879ceb0df7f3fb5",
+      "condition_idx": 4,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0083.wav",
+      "sha256": "a8a83abb1d4847f6171f5627a833c331445b3e4a38be5d78a29cfb7b6d950a31",
+      "transcript": "he was also engaged in engraving banknotes for many countries recent examples of his work including the prime ministerial portraits on the front of the new canadian $5 and $100 bills",
+      "duration_sec": 14.930687,
+      "speech_end_offset_ms": 12132.0,
+      "audio_hash_id": "5f1f4f296d2be84fb390b9ca361157e12856b697c79388a3183af9da4564a6b0",
+      "condition_idx": 2,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0084.wav",
+      "sha256": "a7ca8716250634c550ef008c048b3d487eb3007164fc1d97e4c0e4f0fac745de",
+      "transcript": "he was greeted by singapore's deputy prime minister wong kan seng and discussed trade and terrorism issues with the singapore prime minister lee hsien loong",
+      "duration_sec": 14.210688,
+      "speech_end_offset_ms": 10532.0,
+      "audio_hash_id": "5072c355dc9a544c3f2a07362ad6f9fccb63723503c6181ba627dabee0807d42",
+      "condition_idx": 2,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0085.wav",
+      "sha256": "12dcc9ea1cee4dd0fd1250dc896458eded8b8eedcd3585bdac0df547a5a98857",
+      "transcript": "he was initially hospitalised in the james paget hospital in great yarmouth",
+      "duration_sec": 10.047375,
+      "speech_end_offset_ms": 7684.0,
+      "audio_hash_id": "274499b964a72004e22d7571834ca4b730a0dd9090ff2a15130f6c6d0317f6a6",
+      "condition_idx": 1,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0086.wav",
+      "sha256": "7998a9b0c2403b574eda03ddefe11c2ab10f105586e6ff524c1e8e511f4b2f91",
+      "transcript": "he was reportedly aged in his 20s. in a statement bieber said [w]hile i was not present nor directly involved with this tragic accident my thoughts and prayers are with the family of the victim.",
+      "duration_sec": 13.107375,
+      "speech_end_offset_ms": 9636.0,
+      "audio_hash_id": "65ce81c9dd83fa1154a08c2882c86c99e0caffb911e837a4931d0d4e68614b28",
+      "condition_idx": 1,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0087.wav",
+      "sha256": "e2b6872094fcfa0fdab7ffc529eea5b7736af0a03e1f3353cb3db5f584a0489e",
+      "transcript": "he was subsequently relocated to addenbrooke's hospital in cambridge",
+      "duration_sec": 9.387375,
+      "speech_end_offset_ms": 5188.0,
+      "audio_hash_id": "267e83c5302aa37734bd6d2ae1d4e772cf7df86c41b014944564370664c84c89",
+      "condition_idx": 1,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0088.wav",
+      "sha256": "43f2cf7099134f47e04cd98f9e37d33d88832d3966f1d0da136f88c9959336c6",
+      "transcript": "hong kong island gives the territory of hong kong its name and is the place that many tourists regard as the main focus",
+      "duration_sec": 9.590687,
+      "speech_end_offset_ms": 6564.0,
+      "audio_hash_id": "ca6ec3fedae6ece340e107824e16bdebe628dcb412831023a8471008c6c5b409",
+      "condition_idx": 5,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0089.wav",
+      "sha256": "03234a9e20a19b57aaea78645b508e957e900796ee91d810d6bb62055006b21c",
+      "transcript": "however due to the slow communication channels styles in the west could lag behind by 25 to 30 year",
+      "duration_sec": 13.095688,
+      "speech_end_offset_ms": 8932.0,
+      "audio_hash_id": "33a9148738e320185ab97e669ccc4988a8b76cabbc9c26b9e2672d5d2af3a0b2",
+      "condition_idx": 3,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0090.wav",
+      "sha256": "427ca893905f63eaac7720b4cd1846b9f769d473ce203b4e2cf054e47c7a59c4",
+      "transcript": "however that is not true although there is something written on the back of the document it is not a treasure map",
+      "duration_sec": 12.555687,
+      "speech_end_offset_ms": 9188.0,
+      "audio_hash_id": "ba3a57eedefaf2bcd56041964058fdbe22a5f65e345e443a7d23c807b350ba0a",
+      "condition_idx": 3,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0091.wav",
+      "sha256": "35d138cab0b4c2a6c51b7ea9ac0a95586b3456c017bc499fdd5f0050c4627046",
+      "transcript": "hydrogen ions are protons that had their electrons stripped off them since hydrogen atoms consist of one proton and one electron",
+      "duration_sec": 10.215687,
+      "speech_end_offset_ms": 7396.0,
+      "audio_hash_id": "bee63930f70ad711a85fca8d3d4a272e8e92b4692b2e7a4fe3ad55b4d977af07",
+      "condition_idx": 0,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0092.wav",
+      "sha256": "0d0b416f12759d1185c8e81fac5e534ee7ae91a760681db8ce06974ed2f85c2c",
+      "transcript": "if you have watched the movie national treasure you may think a treasure map was written on the back of the declaration of independence",
+      "duration_sec": 9.327375,
+      "speech_end_offset_ms": 6500.0,
+      "audio_hash_id": "ed945379362b8c88584ba8d860406201817abb749b86d47684d0c35e692a0d40",
+      "condition_idx": 1,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0093.wav",
+      "sha256": "671aa77063ecc5023df920e99192cd58b1eac3dcf1dab32d49e008f1015489a1",
+      "transcript": "if you only go ashore using shipboard excursions you will not need a separate visa as of 2009",
+      "duration_sec": 11.830687,
+      "speech_end_offset_ms": 8260.0,
+      "audio_hash_id": "8e193ca641bc28ba5af08d720a5e20f8cddee9d9a2af2bad293a6d84d84fa081",
+      "condition_idx": 2,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0094.wav",
+      "sha256": "263125ba3d3ada9b1ebe94bcd0ac98bbd86e46e3e360a67d4bd795afc5c62a86",
+      "transcript": "if you want to be close to the action you're going to have to get in early to get a camping site close to the music",
+      "duration_sec": 11.810688,
+      "speech_end_offset_ms": 8004.0,
+      "audio_hash_id": "26dc5b60eff82fbf2a1789b34d67e6761620681c2355a725a963ac7a95fb42ba",
+      "condition_idx": 5,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0095.wav",
+      "sha256": "38d61648bd116e003a91448caeabaa52f69a16f94d46b76db1305eb6e7d0b688",
+      "transcript": "if you're not used to driving on country roads keep your wits about you steep grades narrow lanes and sharp curves predominate",
+      "duration_sec": 13.647375,
+      "speech_end_offset_ms": 10340.0,
+      "audio_hash_id": "e93bab2232660febcf64b4ca7dcbe4c0fdac31dbce4520d51e0df9cfcdb71485",
+      "condition_idx": 4,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0096.wav",
+      "sha256": "1f8c4fb71facbf49a9f339cc05bd2c2767df93fcb3e9b3cb29e8652e3d584b73",
+      "transcript": "in 1990 it was added to the list of world heritage sites in danger due to the threat of desert sands",
+      "duration_sec": 9.867375,
+      "speech_end_offset_ms": 6692.0,
+      "audio_hash_id": "55dc10f56e4dac13a40dd566caf24765bb2f59bef98a901505bf58748e8035ae",
+      "condition_idx": 4,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0097.wav",
+      "sha256": "a0174303eeb92ae1af7ffabd42baea9a21542214fd37f2f3638c2f86a1648042",
+      "transcript": "in 2002 goma was destroyed by lava from the nyiragongo volcano which buried most of the town's streets particularly the town centre",
+      "duration_sec": 12.915688,
+      "speech_end_offset_ms": 9188.0,
+      "audio_hash_id": "9851aed4ad2b33ce8d0a7d7c34e86b0cafecb262a39a8db06c57295e2b845ad5",
+      "condition_idx": 0,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0098.wav",
+      "sha256": "5c2d03343983b77167c63e42ee89d65293a10a6a5d20aebcb0f6aacdab4469da",
+      "transcript": "in a carriage they traveled back to paris surrounded by a mob of people screaming and shouting threats against the king and queen",
+      "duration_sec": 12.767375,
+      "speech_end_offset_ms": 8580.0,
+      "audio_hash_id": "fc1835250ee2564b4b9193072d380392aff92be31d58cedf3d555ef7f7316fdc",
+      "condition_idx": 4,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0099.wav",
+      "sha256": "64bdbe9e42f36531e0394e86604836c70493bdc0f4fba86d4ec913632a07bb25",
+      "transcript": "in fact it is not easy to find at all even if one knew it existed once inside the cave it is a total isolation",
+      "duration_sec": 10.455687,
+      "speech_end_offset_ms": 7236.0,
+      "audio_hash_id": "583d5e7aacbf42722070ac1c2a670791a242ef7b0697181310719bc8ed527ed4",
+      "condition_idx": 0,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0100.wav",
+      "sha256": "c9500fbb30a260f53b60dacbad2f54acf5c742cd7adb15ad407e8201519bca45",
+      "transcript": "in just two weeks the americans and free french forces had liberated southern france and were turning towards germany",
+      "duration_sec": 12.715687,
+      "speech_end_offset_ms": 9316.0,
+      "audio_hash_id": "958363563d42a34153b46a27c49a68649b09e60b669d4e5e3bd45b51651fedaf",
+      "condition_idx": 0,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0101.wav",
+      "sha256": "8acd44ec57f213000146677c7383c1c71e7d27364c459f760e17e4f4fdd0a313",
+      "transcript": "in many other cities of italy and in the rest of the world particularly in poland similar setups were made which were viewed by a great number of people",
+      "duration_sec": 10.947375,
+      "speech_end_offset_ms": 7620.0,
+      "audio_hash_id": "067cee0683920859b99822596a83f8f9c9c2ed7b3f0c9ad590f97b21995c1d68",
+      "condition_idx": 4,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0102.wav",
+      "sha256": "76d89ca153df928d23a8c8bb5862da20599807d29a2e9a9c4ba0e1a8d4b8290d",
+      "transcript": "in particular it is claimed that one can detect whether a person is lying by interpreting micro-expressions correctly",
+      "duration_sec": 8.690687,
+      "speech_end_offset_ms": 5988.0,
+      "audio_hash_id": "87ed70678c32ba31ae8407a59212f1f9bb16c5846498bb976e70db1fb1e393cd",
+      "condition_idx": 2,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0103.wav",
+      "sha256": "d60fc232e5f3be47a1a9f0c60db02258e5760c43f21b9366ea49da6d09ca8127",
+      "transcript": "in some areas boiling water for a minute is enough in others several minutes are needed",
+      "duration_sec": 8.187375,
+      "speech_end_offset_ms": 4836.0,
+      "audio_hash_id": "06b7910a29edc7f9348b8421ff6f0a52028340594e1c61701e722a9872dada24",
+      "condition_idx": 4,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0104.wav",
+      "sha256": "554f30c1b81b6c7cbfe18eb6e01ef80c1c70ac58a2b5146ed0fa38dc841328fe",
+      "transcript": "in the archipelagos and lakes you do not necessarily need a yacht",
+      "duration_sec": 10.015688,
+      "speech_end_offset_ms": 6980.0,
+      "audio_hash_id": "a4fcdf60da8fd3b57ff4ce8edec7e389e66ebbd53b3301f94f1914f2383ed322",
+      "condition_idx": 3,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0105.wav",
+      "sha256": "868b7b0bafc38f4268b92def9c7404f9436e0a59bd61a0003c2c2730ff690580",
+      "transcript": "in the north the region is bounded by the sahel and in the south and west by the atlantic ocean",
+      "duration_sec": 12.127375,
+      "speech_end_offset_ms": 8164.0,
+      "audio_hash_id": "e7f91468e9d1aa10339b309d2a6082f59dbd98b1ed749b6ba0e96397d4290610",
+      "condition_idx": 1,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0106.wav",
+      "sha256": "5189f8d5a6de4a9c2936d3c492a596b926865248d01a5ac0cb7bd75f48451ff8",
+      "transcript": "in the warm climate of the middle east the house was not so important",
+      "duration_sec": 9.267375,
+      "speech_end_offset_ms": 5476.0,
+      "audio_hash_id": "9ffc5f0afaa94886f4a5730684bf9e3df306f8052b0dc118d3b2a87b4fbed35e",
+      "condition_idx": 4,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0107.wav",
+      "sha256": "bcf2f539c74a0b2426ae3cd4dcf0e2d08b644a60f29545582aec3484912d427b",
+      "transcript": "it also attacked anything that entered the water even a giant dinosaur such as t rex would be no match for it",
+      "duration_sec": 11.655688,
+      "speech_end_offset_ms": 7716.0,
+      "audio_hash_id": "f478e67df396a066add4fe709841debe41c7153fcae3274e9cce0ac89494f779",
+      "condition_idx": 3,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0108.wav",
+      "sha256": "020c74719b79037c3ca99bdf32dbb7252fb76c45443265b114620a9bfb8979b8",
+      "transcript": "it has brought us the train the car and many other transportation devices",
+      "duration_sec": 7.395688,
+      "speech_end_offset_ms": 4772.0,
+      "audio_hash_id": "2785cd2a2b3d85eff5611af34a11c936209f8c48ba4c4fdb1c651df7deb8f5c0",
+      "condition_idx": 0,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0109.wav",
+      "sha256": "19b2ce509031e3829bb2f171096423b90bff705942a8860013274b6da92c3708",
+      "transcript": "it is one of the main attractions of south africa and it is considered the flagship of south african national parks sanparks",
+      "duration_sec": 13.455687,
+      "speech_end_offset_ms": 9444.0,
+      "audio_hash_id": "2f8140d4a2f672dfa1175af120a793fe0e68a827fcf4648e1d6a5b27fe0bb1f5",
+      "condition_idx": 3,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0110.wav",
+      "sha256": "2b1853a77c5cf31264c1c881ddee106329f0cf6ddfe01d85f6393aefe1fbe716",
+      "transcript": "it is related to but usually not involving alpine style ski touring or mountaineering the latter ones done in steep terrain and requiring much stiffer skis and boots",
+      "duration_sec": 12.447375,
+      "speech_end_offset_ms": 8900.0,
+      "audio_hash_id": "75e42c7f967ba910a21eb0ff441d903f2b745a91687d8cf980b6fe429853a2ff",
+      "condition_idx": 1,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0111.wav",
+      "sha256": "fe9c4278dda228788991c7aa6529651d8ec4c0a18ec23ac9ca3d8065be5fc5b8",
+      "transcript": "it is thinner under the maria and thicker under the highlands",
+      "duration_sec": 9.735687,
+      "speech_end_offset_ms": 6820.0,
+      "audio_hash_id": "bf326a4bdf7f877b002000c86b8b0d6d2dd265b18f63c682c0bb54098d9855cb",
+      "condition_idx": 3,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0112.wav",
+      "sha256": "6156f656989d29f26419276208a043a6896d0d9c53c75a5d811c270a74e375ea",
+      "transcript": "it was ruled by the vichy french these were french people who had made peace with the germans in 1940 and worked with the invaders instead of fighting them",
+      "duration_sec": 12.147375,
+      "speech_end_offset_ms": 8452.0,
+      "audio_hash_id": "2512409c4a9e3a75ff97c4d5d21d92f3fc19ee2e844acc221aafd68a10e99e97",
+      "condition_idx": 1,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0113.wav",
+      "sha256": "d5643942c2c9e30e7e3054217bc92d7fdd1f3a92e85d70f6574a9d27c4d28516",
+      "transcript": "italian is also the everyday language used by most of those who work in the state while latin is often used in religious ceremonies",
+      "duration_sec": 14.867375,
+      "speech_end_offset_ms": 11556.0,
+      "audio_hash_id": "1f06a5593ec61534e2d95e289abd3e3cb300e9984ca4c64f0325ca4ff937133d",
+      "condition_idx": 1,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0114.wav",
+      "sha256": "25751e0b879e7d2959a672ba253bff3585eb6e55e1d04bc0cea77756c5b0d056",
+      "transcript": "its renown for being an epicenter of luxury began in about 400 a.d. and lasted up until about 1100 a.d",
+      "duration_sec": 14.027375,
+      "speech_end_offset_ms": 11140.0,
+      "audio_hash_id": "2b8ae4f456c7132a6c81ba9109ce9e6b9653586dd88b7fa34a8d429b6dcbec82",
+      "condition_idx": 4,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0115.wav",
+      "sha256": "9edb6ce93b527273e93fd6ad39bff30d41421186b326b03519d9bb04ca0ca613",
+      "transcript": "just like the moon exerts a pull on the earth causing tides so does the milky way exert a force on the sagittarius galaxy",
+      "duration_sec": 9.675688,
+      "speech_end_offset_ms": 6820.0,
+      "audio_hash_id": "2f7d064d5cbf8b7255fc86dd32ba5ccae77cfcbb6f25c4c668329d1fa25c5491",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0116.wav",
+      "sha256": "aa289c7ce7fe0e4fa59e922029e60b064fcd6baeee2426e43a1882a6221c1988",
+      "transcript": "large areas further north are quite sparsely populated and some is nearly uninhabited wilderness",
+      "duration_sec": 10.010687,
+      "speech_end_offset_ms": 6276.0,
+      "audio_hash_id": "773fe26ec1289ba6121ba813854b62155412d9eabb0de5191f904ea5e11ae052",
+      "condition_idx": 2,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0117.wav",
+      "sha256": "665af498be917209a6bd096af3965022e8ed6c7a590233f80cfb9cc9c562bc80",
+      "transcript": "last week meti announced that apple had informed it of 34 additional overheating incidents which the company called non-serious",
+      "duration_sec": 11.690687,
+      "speech_end_offset_ms": 8548.0,
+      "audio_hash_id": "15c17cfa7dd5ddf29acb52eba87bb539ea62c91379107806b2cdc01174516c1a",
+      "condition_idx": 2,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0118.wav",
+      "sha256": "e37131b25be26aa3fd2b7d35ce55c0dc02ba64cc53e50df34e14c0da13183639",
+      "transcript": "late on sunday the united states president donald trump in a statement delivered via the press secretary announced us troops would be leaving syria",
+      "duration_sec": 12.495688,
+      "speech_end_offset_ms": 8900.0,
+      "audio_hash_id": "8f60877112923f9baccc61ef80918767c44c196d921a89172c80d06e9440e9a0",
+      "condition_idx": 0,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0119.wav",
+      "sha256": "97a87d23834d9fb38abff2c30c703dc8e7eec6c06cafe6a3e856a2d38f6252d2",
+      "transcript": "layton had asked for changes to the conservatives' environmental bill during the meeting with the pm asking for a thorough and complete rewriting of the conservative party's environmental bill",
+      "duration_sec": 12.255688,
+      "speech_end_offset_ms": 9316.0,
+      "audio_hash_id": "b7ef1261018e6ff954746c46667b2177967fb3461444c60de5cebbe35a0cd7ae",
+      "condition_idx": 3,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0120.wav",
+      "sha256": "2a7220e6d77f48007e74218ddcb384baa7384d86d0330ceb1da211dccca1a001",
+      "transcript": "liberal criticism of the reconstruction effort has focused on the awarding of reconstruction contracts to perceived washington insiders",
+      "duration_sec": 10.610687,
+      "speech_end_offset_ms": 7812.0,
+      "audio_hash_id": "0c0ffc849011834f3f16e1c584052ad862aac6039c0ffd8a0b38e3c33151937c",
+      "condition_idx": 5,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0121.wav",
+      "sha256": "2c7d24ec9dd51fa4137bcb8ae1c6b247bb89807740c92374aef034f5aac7d9bf",
+      "transcript": "lion prides act much like packs of wolves or dogs animals surprisingly similar to lions but not other big cats in behavior and also very deadly to their prey",
+      "duration_sec": 13.467375,
+      "speech_end_offset_ms": 10180.0,
+      "audio_hash_id": "bcdfbe44a2f5c0f5c85f11e1d96d7edc45a9caefcee69df0170f4c780e2e60be",
+      "condition_idx": 4,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0122.wav",
+      "sha256": "6ae4ee928ad952a521df16bb8a36712335907b26169fd0bf2bba9b09209d337d",
+      "transcript": "lions are the most social cats living in large groups called prides",
+      "duration_sec": 9.135687,
+      "speech_end_offset_ms": 5476.0,
+      "audio_hash_id": "edce4c2cffae6c1e278ad8df521f0a289dc2ac49c26f8efd354c57c005c137e3",
+      "condition_idx": 3,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0123.wav",
+      "sha256": "6162ec621154b6c54b2f4667913b828d027248d743168e7c9f32bf3f08360e6b",
+      "transcript": "madagascar is by far the biggest and a continent on its own when it comes to wildlife",
+      "duration_sec": 9.855688,
+      "speech_end_offset_ms": 6500.0,
+      "audio_hash_id": "0fab8ac228fffdde4eceaf9b8ab9d8c978b6820a38964e8166e89ba772319efe",
+      "condition_idx": 0,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0124.wav",
+      "sha256": "90835010f28515cd6faf6e781ddb3730b6bb6ec4452f3403de27e4a1faf915ca",
+      "transcript": "many german baked goods also feature almonds hazelnuts and other tree nuts popular cakes often pair particularly well with a cup of strong coffee",
+      "duration_sec": 12.987375,
+      "speech_end_offset_ms": 9380.0,
+      "audio_hash_id": "ecbbcf1456dbe5520e5f340f1b69ed043f82a87425ccfa032b0cf0c50d68f00d",
+      "condition_idx": 1,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0125.wav",
+      "sha256": "a605d96d841e629255c0807206b8c902254a4fad5a8368fb53bf378e68da501b",
+      "transcript": "many people don't think about them as dinosaurs because they have feathers and can fly",
+      "duration_sec": 6.890688,
+      "speech_end_offset_ms": 4068.0,
+      "audio_hash_id": "2be7002548224cb902fed3ad97732c64435ec5074eff79b96456b4042d76e012",
+      "condition_idx": 5,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0126.wav",
+      "sha256": "5c284f533515ec0d16db64a8b780ff27268795f13892ba43176232a01b989d54",
+      "transcript": "martelly swore in a new provisional electoral council cep of nine members yesterday",
+      "duration_sec": 12.667375,
+      "speech_end_offset_ms": 8900.0,
+      "audio_hash_id": "f616673c97956bedb3177ba2cd3f24b5706940196b2d8ff06f310005e882380c",
+      "condition_idx": 4,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0127.wav",
+      "sha256": "dcaefbe621069aa371b04e7477f5fdfea4fbfbb30c050e252865c8215bb94a87",
+      "transcript": "mass car ownership also leads to a higher incidence of accidents on the roads which leads to the invention of new techniques in healthcare for repairing damaged bodies",
+      "duration_sec": 12.050688,
+      "speech_end_offset_ms": 9124.0,
+      "audio_hash_id": "5630b6f7f83b5c1faddb0d21d829e5b875675400a6f751a9190a9c1d942180e6",
+      "condition_idx": 5,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0128.wav",
+      "sha256": "51494bdb2cdc6ed977306e250d4bc159e2eacb0eca470affe6fef14e1bdfe752",
+      "transcript": "middle order batsmen sachin tendulkar and rahul dravid performed well and made a hundred-run partnership",
+      "duration_sec": 11.210688,
+      "speech_end_offset_ms": 7492.0,
+      "audio_hash_id": "330b49de0ed359b62cf2447983e1076f6887338423e5f9bc78441be9ca445298",
+      "condition_idx": 2,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0129.wav",
+      "sha256": "32f88ef2b42ac58473cc3527b23fc21362cefc6c7ad18a98ecec4394d3bd1be9",
+      "transcript": "mosasaurus was the apex predator of its time so it feared nothing except other mosasaurs",
+      "duration_sec": 9.470688,
+      "speech_end_offset_ms": 6660.0,
+      "audio_hash_id": "9b8981d2406fd69370031618b76596dc11faa9bed47550302a049fbdbc2507f3",
+      "condition_idx": 2,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0130.wav",
+      "sha256": "b126b5d10f0380890f30b5549692e5a047565329c533091a044a7cbe51bb7e97",
+      "transcript": "most modern research telescopes are enormous facilities in remote areas with favorable atmospheric conditions",
+      "duration_sec": 9.375687,
+      "speech_end_offset_ms": 6596.0,
+      "audio_hash_id": "49aa8081a6176cc0efbc16fb9bb32743d07405b6b68e719b7edccc4d5038dde1",
+      "condition_idx": 3,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0131.wav",
+      "sha256": "cfec85641f22ad9232a0d44674cc540a17d0fbae688b07bb60fe0ac97511f542",
+      "transcript": "most of the buildings on the edges of the complex have been rebuilt in order to give tourists a better idea of how they originally appeared",
+      "duration_sec": 10.167375,
+      "speech_end_offset_ms": 7108.0,
+      "audio_hash_id": "1fa0426a2b63b30bd0affaf25f69f41b626036857385670373601a547f5f0a61",
+      "condition_idx": 4,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0132.wav",
+      "sha256": "8b9db69bba8741c876d5ba8694a36420efa808d9fcbc39572b3f8f866d14847c",
+      "transcript": "most of the smaller islands are independent nations or associated with france and known as luxury beach resorts",
+      "duration_sec": 13.067375,
+      "speech_end_offset_ms": 10596.0,
+      "audio_hash_id": "20e9ef85049d864d9c77acac5ca2959c1131a53c7c08e08bd5d7fea0b8c0cee7",
+      "condition_idx": 1,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0133.wav",
+      "sha256": "62c647a90c637d597ccebab5d024016d3176e1fea9f56e043c96fdffc3ded033",
+      "transcript": "ms is a disease that affects the central nervous system which is made up of the brain the spinal cord and the optic nerve",
+      "duration_sec": 9.735687,
+      "speech_end_offset_ms": 7108.0,
+      "audio_hash_id": "768e8fb905bce8f2d63942ea1912905fea13db5f07def6816986c346c171d7e2",
+      "condition_idx": 3,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0134.wav",
+      "sha256": "f3118be56ec154524db57c706d5c267dab6902179e86567c5bd95d268f8b6842",
+      "transcript": "muhammad was deeply interested in matters beyond this mundane life. he used to frequent a cave that became known as  hira‘” on the mountain of  noor” light for contemplation",
+      "duration_sec": 13.815687,
+      "speech_end_offset_ms": 10052.0,
+      "audio_hash_id": "c367f7ec26d0ea14a228a4c78b52fb51db42e9a49d383337792c1e17390d5d13",
+      "condition_idx": 3,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0135.wav",
+      "sha256": "119de811eba1d3cf2d5e18e434b6e3dc0ef9fe7ed2c24e5bb995c77affd298c3",
+      "transcript": "needless to say if you know a romance language it will be easier for you to learn portuguese",
+      "duration_sec": 11.175688,
+      "speech_end_offset_ms": 6756.0,
+      "audio_hash_id": "6a3b0f49add21fa3fc200d12c75387107012b15223e6e30f81ce9fd62b4afc0c",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0136.wav",
+      "sha256": "b79c9522148643bb00981685657bba7aedb0ad153b341a0277da284e2b7f01eb",
+      "transcript": "nextgen is a system the faa claims would allow aircraft to fly shorter routes and save millions of gallons of fuel each year and cut carbon emissions",
+      "duration_sec": 12.615687,
+      "speech_end_offset_ms": 8868.0,
+      "audio_hash_id": "22d84e6671a01b48c6b599b2b1a70d9361be48ab138a31db0755032be4aadc89",
+      "condition_idx": 3,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0137.wav",
+      "sha256": "2d755d1d7d8bfbb311b988607863da4f69a6f26d3878e2c27368aaafe59d1812",
+      "transcript": "no tsunami warning has been issued and according to the jakarta geophysics agency no tsunami warning will be issued because the quake did not meet the magnitude 6.5 requirement",
+      "duration_sec": 14.427375,
+      "speech_end_offset_ms": 10788.0,
+      "audio_hash_id": "30929473c93cf603ddef96738451023051168138b87bccfae9b299137faeaab5",
+      "condition_idx": 1,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0138.wav",
+      "sha256": "9fa9fc5a318ce81237243276e894d8196472705e9a73b2bce4cc03be1cf41d1b",
+      "transcript": "nothing can be seen other than the clear beautiful sky above and the many surrounding mountains very little of this world can be seen or heard from inside the cave",
+      "duration_sec": 12.015688,
+      "speech_end_offset_ms": 9060.0,
+      "audio_hash_id": "9af0796afc42f2132a9aed4cb90f89068ba496fb4c586a5e1a4bc129e8eaf6bc",
+      "condition_idx": 0,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0139.wav",
+      "sha256": "cc0d7de6b770bf02476cc302ae5496ac4f725508d2d1e5b23658aa33586c9d0f",
+      "transcript": "on 15 august 1940 the allies invaded southern france the invasion was called operation dragoon",
+      "duration_sec": 12.655688,
+      "speech_end_offset_ms": 9604.0,
+      "audio_hash_id": "137acac870aeec4d211cdbc3e0718fbad2a82d2ccf584469fc1010be05dcb525",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0140.wav",
+      "sha256": "30cf7eaa727379eab1e38fc2c95750d12ca00d8a9bad35c2ff3e66336d2e8d67",
+      "transcript": "on some routes the larger companies have their own planes but for other routes and smaller firms there was a problem",
+      "duration_sec": 11.895687,
+      "speech_end_offset_ms": 7428.0,
+      "audio_hash_id": "beac4e70410d6708768b015117cc62020217afcc8fa2c619d1484e287c6e191a",
+      "condition_idx": 0,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0141.wav",
+      "sha256": "9906068f3595f10b6f92b5e4ec918dea6e0751d5f5452e3445552311b036f7f7",
+      "transcript": "on the other hand icy and snowy conditions are normal in many countries and traffic goes on mostly uninterrupted all year round",
+      "duration_sec": 12.255688,
+      "speech_end_offset_ms": 8004.0,
+      "audio_hash_id": "ce7d5645f821dd9e94b2bde6360aa9f03ed1aaef68602e0743aedb3e9ba689bf",
+      "condition_idx": 3,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0142.wav",
+      "sha256": "51d9ebeb3c8e5fa4a7a0b2930ddccd9e5fa29d64434cbc59a12736c129ce5f21",
+      "transcript": "one bomb exploded outside the governor general's office",
+      "duration_sec": 9.210688,
+      "speech_end_offset_ms": 6404.0,
+      "audio_hash_id": "1cb51deaf14b0ab5ecc04c8cb13676c67a94f796fdf90857dff51c16e2a7076d",
+      "condition_idx": 2,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0143.wav",
+      "sha256": "5a1ed3f85f3e138be8a3c4b72607a6d40dbe800045a5dc2e91b859939c50b378",
+      "transcript": "one can only wonder what the keyboard will become when something newer comes along",
+      "duration_sec": 7.995687,
+      "speech_end_offset_ms": 5028.0,
+      "audio_hash_id": "dc2b5e5d0cef1690e23a045dad189733494ac25e557f8c5489f44d0030245bbd",
+      "condition_idx": 0,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0144.wav",
+      "sha256": "1d19d6658a4ad3453a7dcb5db92699b1864153c346a0d7939d2f6ebae5617f89",
+      "transcript": "only mutations in germ-line cells can be passed on to children while mutations elsewhere can cause cell-death or cancer",
+      "duration_sec": 13.515688,
+      "speech_end_offset_ms": 8452.0,
+      "audio_hash_id": "1951021285347297707a6957dc3d622ab96f732c253f4533e5ed048245d29a75",
+      "condition_idx": 0,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0145.wav",
+      "sha256": "9fc77fdff6a39e0814fc52dce26be69a3ae8213b8176a75ded5c1a5de232b32c",
+      "transcript": "other subjects on the agenda in bali include saving the world's remaining forests and sharing technologies to help developing nations grow in less-polluting ways",
+      "duration_sec": 12.207375,
+      "speech_end_offset_ms": 8548.0,
+      "audio_hash_id": "64f3cc6c947397f4942c703c271b801a68d20239afde9c62771c0ad2039d44c8",
+      "condition_idx": 1,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0146.wav",
+      "sha256": "611e44ab151c20991bd2785c2f3d74f9442b355052ee2cee1a7df9298b879523",
+      "transcript": "ottawa is canada's charming bilingual capital and features an array of art galleries and museums that showcase canada's past and present",
+      "duration_sec": 11.067375,
+      "speech_end_offset_ms": 8292.0,
+      "audio_hash_id": "74fe25024b8fd9b7ba2b7435193444a3138372635cdabd5b91ccf8f7e6ed3d71",
+      "condition_idx": 1,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0147.wav",
+      "sha256": "fa6493d91a9abb5c20d9a29a9d63efca530d0c42bab1d3038842040c774ed6f7",
+      "transcript": "parisians have a reputation for being egocentric rude and arrogant",
+      "duration_sec": 10.087375,
+      "speech_end_offset_ms": 6692.0,
+      "audio_hash_id": "86a4b24a9bd536cb5021c3d2519f9eb131dc611f2b70bc201384de2f014c5fbd",
+      "condition_idx": 1,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0148.wav",
+      "sha256": "ef01ab08d75e38b63bac3eabeedd527fbf9a96ac8c56a0bfe56cfebbbb08bcf1",
+      "transcript": "people have known about basic chemical elements such as gold silver and copper from antiquity as these can all be discovered in nature in native form and are relatively simple to mine with primitive tools",
+      "duration_sec": 13.370688,
+      "speech_end_offset_ms": 10724.0,
+      "audio_hash_id": "ebd922770c79d78263fa0f0f880b4b6d97f425fcac5215701b50e352f62a439e",
+      "condition_idx": 5,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0149.wav",
+      "sha256": "b4b730886b43f0f6f34ab294fcf4d3f6f8dbf1d630ff56f621c33274eb22dae8",
+      "transcript": "people may not anticipate that patience and understanding are also necessary for travellers returning home",
+      "duration_sec": 8.510687,
+      "speech_end_offset_ms": 5860.0,
+      "audio_hash_id": "86cd5ba68b58622aa790b2594e74726b51e645d961b5245a089d45bae5071456",
+      "condition_idx": 2,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0150.wav",
+      "sha256": "2c609ca7bf7ce7304db2409a26fb587798f6e307bd797b09835e2a5d6de1bab7",
+      "transcript": "people now write messages on computer screens never having to come close to a sharpener",
+      "duration_sec": 11.370688,
+      "speech_end_offset_ms": 8324.0,
+      "audio_hash_id": "9018171add3248c85e93a3b6dd875b53ebf3ebe74e1e775a76b3ef8647b7e12f",
+      "condition_idx": 5,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0151.wav",
+      "sha256": "801458d11e071bca8fc22e69ee341c0a9af2acc22eb2817505fc215039a66e72",
+      "transcript": "plants look their best when in a natural environment so resist the temptation to remove even just one specimen",
+      "duration_sec": 10.227375,
+      "speech_end_offset_ms": 6756.0,
+      "audio_hash_id": "2e09902451770b911d511ab10ee5e24fe962095834a16e2fd3f4943b28ff8b00",
+      "condition_idx": 4,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0152.wav",
+      "sha256": "f37fd1976f35dbf00b15478a26e563cab641854998cc8f803cfbf817b4592448",
+      "transcript": "plants make oxygen which humans breathe and they take in carbon-dioxide which humans exhale that is breathe out",
+      "duration_sec": 9.590687,
+      "speech_end_offset_ms": 6692.0,
+      "audio_hash_id": "b94ce5827ec59dc06b0d8269c3d14c7c167df7ea17003017794599a471673dd8",
+      "condition_idx": 5,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0153.wav",
+      "sha256": "3c0520159e2b67a770a140d07c339f763a1f57a7df7209d60cf456377d36d322",
+      "transcript": "plants make their food from the sun by photosynthesis they also provide shade",
+      "duration_sec": 10.475687,
+      "speech_end_offset_ms": 6884.0,
+      "audio_hash_id": "c404fd9471070aa82f9cc6d771bddfc3c300b6590cb6d092bc92750a27d28c1b",
+      "condition_idx": 0,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0154.wav",
+      "sha256": "bfcb65f90e472699546de56ab5574d779db7cbe236098678ea1131811723001f",
+      "transcript": "police superintendent chandra shekhar solanki said the accused appeared in court with covered faces",
+      "duration_sec": 9.770687,
+      "speech_end_offset_ms": 6660.0,
+      "audio_hash_id": "1412204fd4f66ebd7bdb17b3c58315061386d322deed304040d6237532310933",
+      "condition_idx": 2,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0155.wav",
+      "sha256": "d3be545a1df87f5dbf16255deedd7a51928c3edd64656ec4beb82d8dad1f82b1",
+      "transcript": "popular sports include football basketball volleyball water-polo fencing rugby cycling ice hockey roller hockey and f1 motor racing",
+      "duration_sec": 11.835688,
+      "speech_end_offset_ms": 9028.0,
+      "audio_hash_id": "95b5d1cc31a35c1755cf5527e4bf8dacb6cabddf3978d76496edc347f54c53bd",
+      "condition_idx": 0,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0156.wav",
+      "sha256": "00c15646af17ccb41c68fe09086f2c0f56ae751264d003252c3a308bf5485e86",
+      "transcript": "prides are made up of one to three related adult males along with as many as thirty females and cubs",
+      "duration_sec": 9.315687,
+      "speech_end_offset_ms": 6468.0,
+      "audio_hash_id": "58588e99eb1039498733fbc1897d51027cadd7241caa020931cbc4dcb924087b",
+      "condition_idx": 3,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0157.wav",
+      "sha256": "9e8b760782323b9acfa840ce2838c695812c2ecf96119fa291b2e1a93f9312a2",
+      "transcript": "prior to the arrival of troops haiti had not encountered problems related to the disease since the 1800s",
+      "duration_sec": 9.915688,
+      "speech_end_offset_ms": 6276.0,
+      "audio_hash_id": "3b24c81a94c2fc8bf08b52acfc00091de189e238eaf44c0737349dec5888bedb",
+      "condition_idx": 0,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0158.wav",
+      "sha256": "78ed4ed3a2fc5d7a27b27e4fc764169f104a009b1b55dd8db6f22614d538b26e",
+      "transcript": "professor pamela ferguson of the university of dundee notes journalists do seem to be walking a dangerous line if publishing photos etc of suspects",
+      "duration_sec": 13.035687,
+      "speech_end_offset_ms": 9316.0,
+      "audio_hash_id": "dad793cea6fdb81b6ff0009b9777672e576ac5ee1117e6076af9c8f6bedcf747",
+      "condition_idx": 0,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0159.wav",
+      "sha256": "0acf65fab36264a5491179adfc146b9ec9c59e601ee0c65b909ef6f0c8d79e79",
+      "transcript": "re-entry shock comes on sooner than culture shock there's less of a honeymoon phase lasts longer and can be more severe",
+      "duration_sec": 11.150688,
+      "speech_end_offset_ms": 7812.0,
+      "audio_hash_id": "f4c3a46e79d885fd86d191e8b184dce3430e4ca691967c8fd248a7acdca85c62",
+      "condition_idx": 2,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0160.wav",
+      "sha256": "06bf5e321cef2e5992d6a345b484fdbaced0b55d242d7dcea1e80de6cb2123a2",
+      "transcript": "regional and seasonal severe weather phenomena include blizzards snowstorms ice storms and dust storms",
+      "duration_sec": 10.127375,
+      "speech_end_offset_ms": 7044.0,
+      "audio_hash_id": "ce73b419934387f74f780ce700413e5acbf921b0ec081cbf13bd4560a6d856a0",
+      "condition_idx": 4,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0161.wav",
+      "sha256": "9ba98ed5cc6dfed0a25d8dfe4dda68abcb7e3b846209ca89c32c2e409c573170",
+      "transcript": "regular announcements in the metro are made only in catalan but unplanned disruptions are announced by an automated system in a wide variety of languages including spanish english french arabic and japanese",
+      "duration_sec": 14.090687,
+      "speech_end_offset_ms": 11268.0,
+      "audio_hash_id": "b51eb8d8ffabbb3615f62b34cc02a3fdff09b3fee69364ddada7b0d0094c7538",
+      "condition_idx": 5,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0162.wav",
+      "sha256": "2189e380250f974e79ad706d7b733f726b95d46e08e05eb6fdcd93d7c66290a8",
+      "transcript": "remember that even though music on the main stages may have finished there may be sections of the festival that will keep playing music until late into the night",
+      "duration_sec": 14.435688,
+      "speech_end_offset_ms": 12004.0,
+      "audio_hash_id": "7d26b6f205d696eac78f2e2146088d07cd70c7e6c97fd3e9ccd2b6d418ca0511",
+      "condition_idx": 0,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0163.wav",
+      "sha256": "7207e4cb792a978fbf1746477c32d58bef6bba464fe4cf1c63960cdc33abd7f9",
+      "transcript": "resting on the top of one of the mountains north of mecca the cave is completely isolated from the rest of the world",
+      "duration_sec": 12.675688,
+      "speech_end_offset_ms": 8068.0,
+      "audio_hash_id": "ffa640c373d3756c485cdaf90e402b5aa64c59c6aa6805153783fa3f081676c2",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0164.wav",
+      "sha256": "08f2e181fe665032d7aed5319044307031e84eb765f45d747d275082189c51a5",
+      "transcript": "rip currents are the returning flow from waves breaking off the beach often at a reef or similar",
+      "duration_sec": 8.955687,
+      "speech_end_offset_ms": 6116.0,
+      "audio_hash_id": "cf01a2a23db98d2aa5f9bbfaa9216f830ffe98f12f815b08cc69e180302681dc",
+      "condition_idx": 3,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0165.wav",
+      "sha256": "b3a5764196902c9aae0220e6adb490162f039034cdb289695e104adc254a003f",
+      "transcript": "rolando mendoza fired his m16 rifle at the tourists",
+      "duration_sec": 8.570688,
+      "speech_end_offset_ms": 6180.0,
+      "audio_hash_id": "cc75c78d2920b66fe41a15271192817dc429e30359dbd6befc2780984dab472a",
+      "condition_idx": 2,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0166.wav",
+      "sha256": "813b3b6e98dc62620983f4e8c9bc2ffd1b81428982840917821f3ed56932019e",
+      "transcript": "romanticism had a large element of cultural determinism drawn from writers such as goethe fichte and schlegel",
+      "duration_sec": 13.227375,
+      "speech_end_offset_ms": 8868.0,
+      "audio_hash_id": "915150600882ef7c09476c6427567bcfb2cffe33a604f6ba3a4a635c76f4fb7b",
+      "condition_idx": 1,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0167.wav",
+      "sha256": "fc7fb3a155106e56a7b5cd5f07606460e642da6fb1171d82a052d488e59021ec",
+      "transcript": "saint petersburg cruises include time in town. cruise passengers are exempted from visa requirements check the terms",
+      "duration_sec": 10.070688,
+      "speech_end_offset_ms": 7460.0,
+      "audio_hash_id": "09095a5cedd162fc75162dd9ea0a54f57fc1696d6bb2fc778ff8000f93a1ac2d",
+      "condition_idx": 2,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0168.wav",
+      "sha256": "34cd33018eb55ad90e8225a73a391d3ab6922540ef60d68fa5a94cafee206901",
+      "transcript": "scaffolding is not a method of learning but rather an aid that provides support to individuals whom are undergoing a new learning experience such as using a new computer program or beginning a new project",
+      "duration_sec": 14.330687,
+      "speech_end_offset_ms": 10820.0,
+      "audio_hash_id": "bda20dcd9c7b628e3fe9344f7ec9b142a5ecf10f517d6ff79f9ef9cfb470a9d7",
+      "condition_idx": 5,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0169.wav",
+      "sha256": "c512a62fe4939de1fee1056a92181135dc0c508a53f42cb600e1eaa9e9c51288",
+      "transcript": "scientists hope to understand how planets form especially how the earth formed since comets collided with the earth long ago",
+      "duration_sec": 8.750687,
+      "speech_end_offset_ms": 5956.0,
+      "audio_hash_id": "2857887d0186c61b4004a06f2e165211ad9f4c9101bb304c56809bbcc6bb48d2",
+      "condition_idx": 5,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0170.wav",
+      "sha256": "6d66bf91778cc77bc1bfa80bf2b293aa402534c65b693ed3c7beedb8a4caf0b7",
+      "transcript": "scotturb bus 403 travels regularly to sintra stopping at cabo da roca",
+      "duration_sec": 14.130688,
+      "speech_end_offset_ms": 11524.0,
+      "audio_hash_id": "dec722120ad3dfdc36c57595f62eef15fc88811647adb5c97ca9b657fcefb8bd",
+      "condition_idx": 2,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0171.wav",
+      "sha256": "0bfbdf975870ec64bacf9d4434a0df35ad5b7b0f7f2ecea0940ea1cf03ce212b",
+      "transcript": "segregation and recombination shuffle variation back and forth between the two pools with each generation",
+      "duration_sec": 14.090687,
+      "speech_end_offset_ms": 10084.0,
+      "audio_hash_id": "ba5b2b6f2d160fd15a41645a36b96d0c269060134225f22d916dc0c113c43e7b",
+      "condition_idx": 5,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0172.wav",
+      "sha256": "caad2ab1c4926c016e8f70c7e6061deaa5037b0dd975c40e234620eb416961fb",
+      "transcript": "several large television screens were installed in various places in rome to let the people watch the ceremony",
+      "duration_sec": 12.795687,
+      "speech_end_offset_ms": 8644.0,
+      "audio_hash_id": "010ea0ea49ec23637a859f77c53d03c0b4303cd0247623a192d1e9d7fb5a19bd",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0173.wav",
+      "sha256": "66f8cb2fda22706d8612e647668ce6fe56600b45da529e3057158ec87d700368",
+      "transcript": "severe weather is the generic term for any dangerous weather phenomenon with the potential to cause damage serious social disruption or loss of human life",
+      "duration_sec": 13.335688,
+      "speech_end_offset_ms": 9604.0,
+      "audio_hash_id": "607f843a109870fd49aa2e6767f0da5672aa02473c2a80b0f3a277f77220d9ac",
+      "condition_idx": 3,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0174.wav",
+      "sha256": "61fd24b0c416d63807ccbf2ed52a8824565cfc1f457d5ee4065156fb19a7c577",
+      "transcript": "sharing a field trip virtually is also a great way to reflect a on a trip and share experiences with future classes",
+      "duration_sec": 10.215687,
+      "speech_end_offset_ms": 6820.0,
+      "audio_hash_id": "e97a70a0bf711e6e04094e6b60f180b23238fdf8317a7f79008591554eceb762",
+      "condition_idx": 3,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0175.wav",
+      "sha256": "3577512f754d4045b6a5a4ab4230fb68aa32854e067b9663e5acabe89750a9cc",
+      "transcript": "since the foundation of asunción in 1537 paraguay has managed to keep a lot of its indigenous character and identity",
+      "duration_sec": 14.355688,
+      "speech_end_offset_ms": 9636.0,
+      "audio_hash_id": "a01f3754decccfd8dbfaae4bbd72d8b48eb03ce8e81194a0b9b148c34e704999",
+      "condition_idx": 0,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0176.wav",
+      "sha256": "4e9fb2e94a27854042fd14575ee80a42c1e4d6514a4d280ee31782dbb212ece4",
+      "transcript": "six hostages including the children and elderly were released early as were the filipino photographers",
+      "duration_sec": 11.730688,
+      "speech_end_offset_ms": 8612.0,
+      "audio_hash_id": "5106ddc08fbf3352b9e9390807fb709d806eec7a092ec773255d8e378608aaba",
+      "condition_idx": 2,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0177.wav",
+      "sha256": "b8cdec1378b6afa3840380b9d6afca66be102d6bcb0abcb8e892d63f085dd753",
+      "transcript": "so it is likely that the notation was added simply as a label",
+      "duration_sec": 8.430687,
+      "speech_end_offset_ms": 4964.0,
+      "audio_hash_id": "41616d1dd67f7be1ad05a4ec439d90e098d36487aa8a70128fab4a3a04704a12",
+      "condition_idx": 5,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0178.wav",
+      "sha256": "66ebf9409c8b0fcfd14c3678bf0c6594860b87147b4859cd03a3c3da99f3a2dc",
+      "transcript": "some atoms have unstable nuclei which means that they tend to break apart with little or no nudging",
+      "duration_sec": 8.655688,
+      "speech_end_offset_ms": 5796.0,
+      "audio_hash_id": "61d11f94f286561908a5d31036c8752087786198a3d5b8a7c5cd55c3666ff7cc",
+      "condition_idx": 3,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0179.wav",
+      "sha256": "dbfec1cd2f80fdb7418675f78682010967b8eb33d1eabade50d2d5982e94776f",
+      "transcript": "some cruises feature berlin germany in the brochures as you can see from the map above berlin is no where near the sea and a visit to the city is not included in the price of the cruise",
+      "duration_sec": 13.370688,
+      "speech_end_offset_ms": 9924.0,
+      "audio_hash_id": "f21850dc71c0d0fbad5a5da1475f4b88e8724d5481f7b699a73694360a7f8cd9",
+      "condition_idx": 5,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0180.wav",
+      "sha256": "ac75594e4b1c8f7f6f6593a8ffcb3be3ea6f941218d5ff852d1163b82c649a6c",
+      "transcript": "some people thought he was right but many people believed the opposite; that the solar system moved around the earth including the sun and even the other stars",
+      "duration_sec": 10.287375,
+      "speech_end_offset_ms": 7492.0,
+      "audio_hash_id": "e6610174b58e0a42b88cf1f9efdafd92e0c06471a7b4dea177fc239b9ffd8ffd",
+      "condition_idx": 4,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0181.wav",
+      "sha256": "9d17602f4eaa397df5b144b5b6275bd18d9f2e3cddbbd609fc64f14e34bdc888",
+      "transcript": "soon after the outbreak of hostilities britain initiated a naval blockade of germany",
+      "duration_sec": 8.030688,
+      "speech_end_offset_ms": 5316.0,
+      "audio_hash_id": "d5590dda968d38679c26dc00cb6fa17bdfa780931e59f887a382b2c12b51228b",
+      "condition_idx": 2,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0182.wav",
+      "sha256": "a51f96480d4de33a5ddb3b8946c12f2d6a6f166fb09bbc59a81be99d59ca8042",
+      "transcript": "still take advice from authorities obey all signs and pay close attention to safety warnings",
+      "duration_sec": 11.210688,
+      "speech_end_offset_ms": 7428.0,
+      "audio_hash_id": "a270b1356ae7dbdb7a31cd7f618f6e27c370ecd1b15e093ff6655d65a79cc931",
+      "condition_idx": 2,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0183.wav",
+      "sha256": "35c13dc276c2f1b81f6d6bd4975d0fe2a79f6cef7af92811c6d6ebc870305483",
+      "transcript": "swirl the two dry powders together and then with clean wet hands squeeze them into a ball",
+      "duration_sec": 10.907375,
+      "speech_end_offset_ms": 7524.0,
+      "audio_hash_id": "c12b0a870d192a49f23d2547c7c3dedb8f5d128c7c58e1d74b364c811d1e2135",
+      "condition_idx": 4,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0184.wav",
+      "sha256": "c4b765656bdba521a97f4ca486cdc52c21d97ba06bd19d48eabc61692aab7b1b",
+      "transcript": "television reports show white smoke coming from the plant",
+      "duration_sec": 7.610688,
+      "speech_end_offset_ms": 3972.0,
+      "audio_hash_id": "77c3542031fa2846df821f734cb84be94dd139329ee203886f0b9b6be91005e6",
+      "condition_idx": 5,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0185.wav",
+      "sha256": "a4e387fbdfb6cb42699c9524f892c0b085801bff25157b8e9580e7b4b34900d2",
+      "transcript": "the 25 dunlap broadsides still known to exist are the oldest surviving copies of the document the original handwritten copy has not survived",
+      "duration_sec": 12.375687,
+      "speech_end_offset_ms": 8932.0,
+      "audio_hash_id": "7d558e9b46ec5bdf86017667f76e909b9a870040736bcf549172bf951f3bb8af",
+      "condition_idx": 0,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0186.wav",
+      "sha256": "f90678dd41e8c808297aaff57365bbd0f8b8d2d48218ce0c3353d48ba9e05605",
+      "transcript": "the 802.11n standard operates on both the 2.4ghz and 5.0ghz frequencies",
+      "duration_sec": 14.535687,
+      "speech_end_offset_ms": 10788.0,
+      "audio_hash_id": "e04c9a46d2b4219b4aa0899024e8f24affee382a8eeeade9243e52d86465173b",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0187.wav",
+      "sha256": "718fbf06f52dce3f73ade7f7a37d36ddac36f1cb1054c3165c1c1886244548a9",
+      "transcript": "the announcement was made after trump had a phone conversation with turkish president recep tayyip erdoğan",
+      "duration_sec": 13.370688,
+      "speech_end_offset_ms": 9188.0,
+      "audio_hash_id": "2aa07a782a9ef68d65b202414cbc62770d3923c12465f33bbec7fba189ac7cbc",
+      "condition_idx": 2,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0188.wav",
+      "sha256": "78793554b6e09d71c83ca93a65acad31eac2a6b9cc62a793e4831c9243d571a5",
+      "transcript": "the aspect ratio of this format dividing by twelve to obtain the simplest whole-number ratio is therefore said to be 3:2",
+      "duration_sec": 13.587375,
+      "speech_end_offset_ms": 10436.0,
+      "audio_hash_id": "a71e7adf8ee85b7e6cc4ba8b52cc8ac335a1a701914d277ce08751a135a03e25",
+      "condition_idx": 4,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0189.wav",
+      "sha256": "c0dcfae99e8a0b73b6f8fd34f03d36abffe968e42d319ab02e45ac15b1b91991",
+      "transcript": "the bridge is scheduled to be fully operational in september 2017 when the brazilian customs checkpoints are expected to be finished",
+      "duration_sec": 10.850687,
+      "speech_end_offset_ms": 7428.0,
+      "audio_hash_id": "125816ff3a5275550a5d1d6b0dd82cb5a116381e9f3e1ccefb1194780973ef80",
+      "condition_idx": 5,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0190.wav",
+      "sha256": "b40d3133489671486b6a67e184815eac4e2d74f435b5a0fc1ed4e76c4602de55",
+      "transcript": "the cabbage juice changes color depending on how acidic or basic alkaline the chemical is",
+      "duration_sec": 8.307375,
+      "speech_end_offset_ms": 5412.0,
+      "audio_hash_id": "347296599955d980fe075d283109d6c1af4a3312c924e7410b8a9674182028de",
+      "condition_idx": 4,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0191.wav",
+      "sha256": "721b17a4cbe4eb81e46573bb1c394e49b04dcfbced2f926e3da03febc3d2a429",
+      "transcript": "the capital of moldova is chişinău. the local language is romanian but russian is widely used",
+      "duration_sec": 9.135687,
+      "speech_end_offset_ms": 6404.0,
+      "audio_hash_id": "6c835b73c5ecbf94cd7cee9c038b66128bfcfb6feca0a8f5f25d674941aaa5e5",
+      "condition_idx": 3,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0192.wav",
+      "sha256": "2139dafce8f38c2b35dabd57be5bf9025438fb94cd61957b163abbc09b0524ee",
+      "transcript": "the central authority of the church had been in rome for over a thousand years and this concentration of power and money led many to question whether this tenet was being met",
+      "duration_sec": 11.787375,
+      "speech_end_offset_ms": 8932.0,
+      "audio_hash_id": "bd449e493bf0d77bba9bb8d4590e80825d36fb455eea7f32b818d027f6853894",
+      "condition_idx": 1,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0193.wav",
+      "sha256": "2afb69b94fdc7bea9617a1f833356dd0553ca94852d03fae2167e8dff8de7dc1",
+      "transcript": "the city is also the base to climb the nyiragongo volcano along with some of the cheapest mountain gorilla tracking in africa",
+      "duration_sec": 13.850687,
+      "speech_end_offset_ms": 9924.0,
+      "audio_hash_id": "66bcc757081e2d5358c83639ec9061020fd484a42576b39fbb4a2230712337c2",
+      "condition_idx": 5,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0194.wav",
+      "sha256": "81d82cb1937e787f4b73a65e587e94594d05af53ec8df794d055f5a5e7c2bbb8",
+      "transcript": "the city is in stark contrast to the rest of the country's cities because it has more of an arabic flair than of an african",
+      "duration_sec": 9.267375,
+      "speech_end_offset_ms": 6500.0,
+      "audio_hash_id": "d20e4e06744365d5e59cf4e13be3c41ea53d35043c9c3c4208fd8f5ccd68046d",
+      "condition_idx": 4,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0195.wav",
+      "sha256": "01f750ae75eca5a9f3d84e7bc40ba8ca4188ab73cfae63b5892bc9f5da8e694f",
+      "transcript": "the commission was martelly's response to widespread anti-regime protests that started in october",
+      "duration_sec": 11.055687,
+      "speech_end_offset_ms": 7460.0,
+      "audio_hash_id": "4c53115b877cb4e94b47bc30c5e18ccbeaacb99fdafbcb7bc4dc8430b5b6e4e8",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0196.wav",
+      "sha256": "e965e474a84ae8681c22a1d71479d2d8f2553dbe57a4318b180eedba954ecfb7",
+      "transcript": "the composition of these crystals matches those found in the urine of affected pets when compared by infrared spectroscopy ftir",
+      "duration_sec": 14.450688,
+      "speech_end_offset_ms": 10628.0,
+      "audio_hash_id": "58239627053d4c3b988abf6cda24073c09d889c757ed6b674a53494d43462093",
+      "condition_idx": 5,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0197.wav",
+      "sha256": "c0871d5246a1728f23544a160726b3cbeac124130b62bc16273aea27d8b5d12c",
+      "transcript": "the correlation between brain pathology and behaviour supports scientists in their research",
+      "duration_sec": 8.895687,
+      "speech_end_offset_ms": 5476.0,
+      "audio_hash_id": "4648ed1f1cc12bf2bb136cef898512f5179f17fd548abc7a73102657b366da4c",
+      "condition_idx": 3,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0198.wav",
+      "sha256": "afdbf032ebd42e90eb94c4921486025035ef89690162a3bc6312a7b46d7cc7ec",
+      "transcript": "the crash occurred high up in mountainous terrain and is believed to have been the result of hostile fire",
+      "duration_sec": 12.367375,
+      "speech_end_offset_ms": 8612.0,
+      "audio_hash_id": "c9fdd529556c775ad1118ed4ebaef13a50613ee5aee27f4b739a87fa60c17e7c",
+      "condition_idx": 1,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0199.wav",
+      "sha256": "535a9dc2784188d58b45aa20d7ec36899180d0b9a29af6686cd3487b79d5db1a",
+      "transcript": "the crust is about 70 km thick on the near side and 100 km thick on the far side",
+      "duration_sec": 10.215687,
+      "speech_end_offset_ms": 6660.0,
+      "audio_hash_id": "acc13d6e4c0b32e19e41c4e6a5b325bf8c024ade7643deb309a9fda553d4b7d1",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0200.wav",
+      "sha256": "9864744b016a9da1357b1a42c3627a5b92051181999ed5eb7112606d07aab7cf",
+      "transcript": "the debate was sparked by controversy over spending on relief and reconstruction in the wake hurricane katrina which some fiscal conservatives have humorously labeled bush's new orleans deal",
+      "duration_sec": 14.895687,
+      "speech_end_offset_ms": 11332.0,
+      "audio_hash_id": "37fa9ee9cf992c6648eabe621d809b9a67ab5cebe1a643f885d2efc16a2084dc",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0201.wav",
+      "sha256": "ec15180cf0c328253c6aec02720f152719cf8bdba3757db90252323e0bef163c",
+      "transcript": "the disease is carried by pigs which then migrates to humans through mosquitos",
+      "duration_sec": 7.970688,
+      "speech_end_offset_ms": 5124.0,
+      "audio_hash_id": "95027a7f0db298884901ab65c5d22a23e563c3c44077f312628dc0c7a18cfe5f",
+      "condition_idx": 2,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0202.wav",
+      "sha256": "f185ca22f0075c3428c37ef434bc301e4e6ce46d7aa2bc398590d213adf3e9c0",
+      "transcript": "the document according to the leak will refer to the borders dispute which palestine wants based on the borders before the 1967 mideast war",
+      "duration_sec": 10.815687,
+      "speech_end_offset_ms": 7940.0,
+      "audio_hash_id": "323b1bed03869a88e1149bf45fd51b7571f0cd9a47b713498a7e2e86a56bbcfc",
+      "condition_idx": 0,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0203.wav",
+      "sha256": "6f9925e8a83561a274691b1902d23e383be324bab81672788d5723ad053ae739",
+      "transcript": "the find also grants insight into the evolution of feathers in birds",
+      "duration_sec": 7.190688,
+      "speech_end_offset_ms": 4516.0,
+      "audio_hash_id": "064898334730436925dab366260aeefa0254b6066850b3c99c7dd03833442f71",
+      "condition_idx": 5,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0204.wav",
+      "sha256": "f69386b760ca756135e50fb71e64672bdd5bf51b95e442ffcd6ec12d81892c38",
+      "transcript": "the fission bomb works on the principle that it takes energy to put together a nucleus with many protons and neutrons",
+      "duration_sec": 8.870688,
+      "speech_end_offset_ms": 6180.0,
+      "audio_hash_id": "0031fbb93a94f66cd9562aac0cb671983eb468463c922ce3c8d1dcfed533f8a9",
+      "condition_idx": 2,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0205.wav",
+      "sha256": "86d1a6e76a71029788fcf72b85dcc8f0fa5875c20cff8de8be48c1ca8b3456cb",
+      "transcript": "the governor's office said nineteen of the injured were police officers",
+      "duration_sec": 9.795687,
+      "speech_end_offset_ms": 5124.0,
+      "audio_hash_id": "fd06ef496f77c9e06c6bae6ec5202aef06154d6a2ee86f4d6612f022e788253c",
+      "condition_idx": 0,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0206.wav",
+      "sha256": "e84fa5c54f50c98dc327f61242c9de51d2aaf8b9f619107c1a3a22ee8cd459ac",
+      "transcript": "the great pyramid at giza is the only one of the seven wonders that is still standing today",
+      "duration_sec": 8.630688,
+      "speech_end_offset_ms": 5348.0,
+      "audio_hash_id": "00a3f7f00e1f0dc987b285d5eb2fde144eaf3029aaa282254c9d51efea95bb9e",
+      "condition_idx": 5,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0207.wav",
+      "sha256": "627e933750a96ac3d1da7708cc497bd87ea6e1ee12744e5d4c814c90a4c3bc77",
+      "transcript": "the haitian institute for justice and democracy has referenced independent studies that suggest the nepalese un peacekeeping battalion unknowingly brought the disease to haiti",
+      "duration_sec": 13.575688,
+      "speech_end_offset_ms": 10948.0,
+      "audio_hash_id": "6087c5c54c63c2a52c892dec0aeb60da437c1bc015bbf3717eeff5068d6101d0",
+      "condition_idx": 0,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0208.wav",
+      "sha256": "d55fd63c59f3caf8ad3fc7683095169d550746f9607e2aeef2c8de4f4e458c2d",
+      "transcript": "the hospital has followed protocol for infection control including separating the patient from others to prevent possible infection of others",
+      "duration_sec": 13.990687,
+      "speech_end_offset_ms": 10948.0,
+      "audio_hash_id": "fdc5f799827f7c59f10076c0576aac6030f620703bf11b3ab69407c820dce94e",
+      "condition_idx": 5,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0209.wav",
+      "sha256": "86c9b30d714f0e17ab4b18127ea60d6f64a5ace9343b15466e34bf68adf1430b",
+      "transcript": "the hot chocolate is up to belgian standards fruit juices are pricey but excellent",
+      "duration_sec": 8.967375,
+      "speech_end_offset_ms": 6052.0,
+      "audio_hash_id": "9c824d9ad65200e54a9656e58352f8a6a93ba3344be016eb616af92e3e398aca",
+      "condition_idx": 1,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0210.wav",
+      "sha256": "4af6100809f9d20cc97d60de496c33cacecfb1a9d8dd463c6c7daa196249ae3e",
+      "transcript": "the internet combines elements of both mass and interpersonal communication",
+      "duration_sec": 8.267375,
+      "speech_end_offset_ms": 5412.0,
+      "audio_hash_id": "fc56d603dce5610d9d4f6d0cc9474556fb0e1b7077ea335b032ec52fcc740481",
+      "condition_idx": 4,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0211.wav",
+      "sha256": "fbede3225ba34dc843c45710aec555c7d9f11cb04d149bf847a88c2efb66de51",
+      "transcript": "the lower the tension the more positive the life force present every person has the potential to find absolute peace and contentment",
+      "duration_sec": 12.947375,
+      "speech_end_offset_ms": 9476.0,
+      "audio_hash_id": "d478d2897afac08cf66c56d79d6f1b3c91013bae75741f18438a7016b2fbc756",
+      "condition_idx": 1,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0212.wav",
+      "sha256": "9bae28d1721c87db4bd30305becb47229fefe32b36f8b623dff05322ca5f8f48",
+      "transcript": "the moisture on your hands will react with the outer layers which will feel funny and form a sort of shell",
+      "duration_sec": 11.055687,
+      "speech_end_offset_ms": 8452.0,
+      "audio_hash_id": "418cff69d6ca294582fb7a2f5c90bf6f75d88f8db4a2d427e0c280cb80d7baf6",
+      "condition_idx": 3,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0213.wav",
+      "sha256": "caf4e571b0d6b9a84267ac8456b36ffb2b87936f62520a6cd848dc2e537d315a",
+      "transcript": "the moroccan sultan rebuilt the city as daru l-badya and it was given the name casablanca by spanish traders who established trading bases there",
+      "duration_sec": 14.090687,
+      "speech_end_offset_ms": 10692.0,
+      "audio_hash_id": "6e64f15e43f7f2b34ca2a0108a76b525768bebdfd8a3e959bde4331c84a84389",
+      "condition_idx": 5,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0214.wav",
+      "sha256": "6fd4714cc32c0dc9f9b836f55b616e90719d1425faaafbc6103dd62a7f9cc598",
+      "transcript": "the northern marianas emergency management office said that there were no damages reported in the nation",
+      "duration_sec": 13.347375,
+      "speech_end_offset_ms": 7556.0,
+      "audio_hash_id": "d3de379e9eb1df8fe1614da62b24261d7441b576b1cbf36986e70c6cce3b7af7",
+      "condition_idx": 1,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0215.wav",
+      "sha256": "7cbf7b183b94ee146d2836975340c74e644c51e8033152ab802f1d310d526c7c",
+      "transcript": "the number of people present was so large that it was not possible for everybody to gain access to the funeral in st peter's square",
+      "duration_sec": 12.207375,
+      "speech_end_offset_ms": 8036.0,
+      "audio_hash_id": "fd541475eb4fb231ffd7bd6ab0c46bcd3145b219aef9d17367d188cc69a13d6c",
+      "condition_idx": 4,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0216.wav",
+      "sha256": "6ea37c1919b9f770731fdab5defd6391d550c6e1c3d7fd305f1183504a54c0b7",
+      "transcript": "the official falklands currency is the falkland pound fkp whose value is set equivalent to that of one british pound gbp",
+      "duration_sec": 12.615687,
+      "speech_end_offset_ms": 9956.0,
+      "audio_hash_id": "538ab78703b81d15dadd1570702333b5dda4837f7a2bc2d28fc69f6647bb88ef",
+      "condition_idx": 0,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0217.wav",
+      "sha256": "54aebb5085ff04da9332fa9e034ed9e561b08486c923805e8359c1532c2eb044",
+      "transcript": "the ph level is indicated by the amount of hydrogen the h in ph ions in the tested chemical",
+      "duration_sec": 9.170687,
+      "speech_end_offset_ms": 6244.0,
+      "audio_hash_id": "4d2eb5a082351a2819f6b35417a915f366c5626826132dc72ce8d3ffd00c5f34",
+      "condition_idx": 2,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0218.wav",
+      "sha256": "55a14714ece7963cd0b9239797096074986b49b18ffd32bcc4e797cbe4473d9b",
+      "transcript": "the photographers later took the place of an aged lady as she needed the lavatory mendoza was gunned down",
+      "duration_sec": 11.190687,
+      "speech_end_offset_ms": 7844.0,
+      "audio_hash_id": "51785f99f4050f148f70100d0715ee48ac3b2de54d4cf86d527c06bada4d970c",
+      "condition_idx": 2,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0219.wav",
+      "sha256": "e8a4cd3557f04654e88fa65b49231ec00a77b81bdc94610ba871683be45b24e2",
+      "transcript": "the presence of a true  invisible team” larson and lafasto 1989 p109 is also a unique component of a virtual team",
+      "duration_sec": 14.510687,
+      "speech_end_offset_ms": 10852.0,
+      "audio_hash_id": "139532b258b5e4c32b078aa1fd20a8dc33b0664f41fe3c5b8893f71dd5a42eb5",
+      "condition_idx": 5,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0220.wav",
+      "sha256": "b354086e9d33c88a3151b2423d8690e39b6b77fee1ff1033d6558093d2691f3f",
+      "transcript": "the pyramid sound and light show is one of the most interesting things in the area for kids",
+      "duration_sec": 10.910687,
+      "speech_end_offset_ms": 7716.0,
+      "audio_hash_id": "64b9850db1d5ab1a3c7e29df061cf93555b49ac1f63463c0179e8184c33a2891",
+      "condition_idx": 2,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0221.wav",
+      "sha256": "cc9f6017ee683502529c4b19da862b22212e577c2010ecb83421869b62f3f21a",
+      "transcript": "the report is highly critical of almost every aspect of the present policy of the executive towards iraq and it urges an immediate change of direction",
+      "duration_sec": 11.187375,
+      "speech_end_offset_ms": 8612.0,
+      "audio_hash_id": "c8cce80f0fc6c582dce168b0baffa3fa12e2ec20a064bead7879aa2fa9ffdca0",
+      "condition_idx": 1,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0222.wav",
+      "sha256": "e3f8aeedfef6571986fab7de36ccaab20813aea4a030329fbfb992ccc5a9a026",
+      "transcript": "the ruling party south west africa people's organisation swapo also retained a majority in the parliamentary elections",
+      "duration_sec": 13.175688,
+      "speech_end_offset_ms": 9924.0,
+      "audio_hash_id": "966a581131c6d358b7dea3324a8ced0cf9c5eee6684cde0280b828445a96554a",
+      "condition_idx": 0,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0223.wav",
+      "sha256": "cda73f2c5d1320ad092d5683fb95bff5520776efd58212e4b7f22dc36e3eed76",
+      "transcript": "the same month saw another airliner overrun a runway at mashhad and strike a wall killing seventeen",
+      "duration_sec": 9.027375,
+      "speech_end_offset_ms": 6244.0,
+      "audio_hash_id": "65f7acb24c8340a1ae2fe12da885f169ea52cab771dc32bb0155a32d5b7f1899",
+      "condition_idx": 4,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0224.wav",
+      "sha256": "528caca29f017e37c563ffd03c00813702b85bd012015397a8a677f5b48d1e6d",
+      "transcript": "the scenes are displayed on the pyramids and the different pyramids are lit up",
+      "duration_sec": 6.890688,
+      "speech_end_offset_ms": 4004.0,
+      "audio_hash_id": "ba257b1f0ffe7370764e419e5444ee48fd1bd05f2135f81606f5327c90adeb06",
+      "condition_idx": 2,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0225.wav",
+      "sha256": "90e5df61d5a2055a5e0a72ad45d3f2415295fbcfc0c0485244fce80d5169d7ce",
+      "transcript": "the schengen zone however works somewhat like one country in this respect",
+      "duration_sec": 9.335688,
+      "speech_end_offset_ms": 6468.0,
+      "audio_hash_id": "7374f954964595b1526c9891a4cd4b68b74e84065f2934b5e4161ae92caa3ee0",
+      "condition_idx": 3,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0226.wav",
+      "sha256": "3e70f7c0811160c7cea6da19383997dfc78e75bd64781357397c5bc5ad32da53",
+      "transcript": "the scientists were able to conclude that the dark matter affect other dark matter in the same way regular matter does",
+      "duration_sec": 14.667375,
+      "speech_end_offset_ms": 11012.0,
+      "audio_hash_id": "a5e6a5a5e725eb9b43fa12cd300234bdd741911db1240a5e4ef65b440907c198",
+      "condition_idx": 1,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0227.wav",
+      "sha256": "9cc3f892de959099a37a92dd531d76a08c04da9453d0ad345bceeb18df02c495",
+      "transcript": "the service is frequently used by shipping including pleasure craft as well as expeditions who have remote data and voice needs",
+      "duration_sec": 13.850687,
+      "speech_end_offset_ms": 8996.0,
+      "audio_hash_id": "e62f5ba60b7283bf437722198302a4664a413a363b8c23a8027cc4ffdb868ba9",
+      "condition_idx": 5,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0228.wav",
+      "sha256": "24c373a18da8467b13db393f99253fae7cd9733f50b514f306925f3d88f66b43",
+      "transcript": "the smaller the rossby number the less active the star with respect to magnetic reversals",
+      "duration_sec": 8.175688,
+      "speech_end_offset_ms": 5444.0,
+      "audio_hash_id": "bf4a229bd3bb868b38384aceaefa5538d0a769249491847344bb1e2074aba9e1",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0229.wav",
+      "sha256": "241f45b41042b4f2d89ffc8e5f2efd7f5a1ec177dfc68779aef5ed91fd78941c",
+      "transcript": "the sundarbans are the largest littoral mangrove belt in the world stretching 80 km 50 mi into the bangladeshi and indian hinterland from the coast",
+      "duration_sec": 12.770687,
+      "speech_end_offset_ms": 9060.0,
+      "audio_hash_id": "348c7ea197bcb0f7268b350212b4cf0d13cce9a45f95d11172fb489216f360e0",
+      "condition_idx": 2,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0230.wav",
+      "sha256": "3988e861b688c1a5e7f5518b0f6b82cc3b1701631c27125b5b93a85c3c4bc5e7",
+      "transcript": "the sundarbans has been declared a unesco world heritage site the part of the forest within indian territory is called sundarbans national park",
+      "duration_sec": 14.427375,
+      "speech_end_offset_ms": 10052.0,
+      "audio_hash_id": "acba418ef9176e5565d71e279f20b6a0eb443c8f724a31c0fecbb6cc39cac6c6",
+      "condition_idx": 1,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0231.wav",
+      "sha256": "9e7769a7f5954b205c69671324f4876ee1d02bd21e75bae7af93d3a262050e85",
+      "transcript": "the surface of the moon is made of rocks and dust the outer layer of the moon is called the crust",
+      "duration_sec": 8.175688,
+      "speech_end_offset_ms": 5316.0,
+      "audio_hash_id": "6485c097c91da8f6413f09d5b648f05e62f159c9b9f5735312d64f2c91cec60f",
+      "condition_idx": 0,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0232.wav",
+      "sha256": "22ae56b45986557ead14868df52a85a9d465dff2ab22878422abd8398c549079",
+      "transcript": "the tenth named storm of the atlantic hurricane season subtropical storm jerry formed in the atlantic ocean today",
+      "duration_sec": 11.207375,
+      "speech_end_offset_ms": 7684.0,
+      "audio_hash_id": "255674d143a33be6b405a34dd0617315a133d14a96651f423c6a8a494b459d21",
+      "condition_idx": 1,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0233.wav",
+      "sha256": "bd7374f84743cbfaf696b9d920cf02ba8fdc9601f78856159d5e1a9d4d501e7d",
+      "transcript": "the term bug is used by entomologists in a formal sense for this group of insects",
+      "duration_sec": 9.015688,
+      "speech_end_offset_ms": 5444.0,
+      "audio_hash_id": "fb615f0dc4a4465cd9d9aa94fb942853eaef0ca29adfc08e9d4242d839efbbeb",
+      "condition_idx": 3,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0234.wav",
+      "sha256": "a916237fc3c4f8940ada7c8508dc3ef3b66e74c412794a671acb080b162bfb3b",
+      "transcript": "the term safari in popular use refers to overland travel to view the stunning african wildlife particularly on savanna",
+      "duration_sec": 11.187375,
+      "speech_end_offset_ms": 7876.0,
+      "audio_hash_id": "20f22ce08124393e7f7603f66bf2302bfd1bfa91ae56f13d8ea7ca7787b00cc0",
+      "condition_idx": 4,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0235.wav",
+      "sha256": "4c448aa37a6e04a4ce13a739efd69fac81f19ccf887bc30de0586fb4bf9e44a2",
+      "transcript": "the three kingdoms was one of the bloodiest eras in ancient china's history thousands of people died fighting to sit in the highest seat in the grand palace at xi'an",
+      "duration_sec": 14.415688,
+      "speech_end_offset_ms": 10596.0,
+      "audio_hash_id": "3cd34eb09a7da73618b3ac9c87ac95dbdd35a56d4e117a9c5b0d14889ec80856",
+      "condition_idx": 0,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0236.wav",
+      "sha256": "48f4df14c1229ac37dd8b95cc3dc7527da6da799c1fcbde45d335f3af83394e4",
+      "transcript": "the tiger's roar is not like the full-voiced roar of a lion but more like a sentence of snarly shouted words",
+      "duration_sec": 11.295687,
+      "speech_end_offset_ms": 7364.0,
+      "audio_hash_id": "78b132ef544c9f474e4f7cf4255c2a34dd8f1527d6d1b525a4c2b8c716806783",
+      "condition_idx": 3,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0237.wav",
+      "sha256": "2010608c52fe952bd2ebdd5ad6507cc13d48fc81d06862133b49e088448ea27d",
+      "transcript": "the two compounds react with one another to form crystals that may block kidney function researchers at the university said",
+      "duration_sec": 9.987375,
+      "speech_end_offset_ms": 6500.0,
+      "audio_hash_id": "20066a6996e2122805bb74e8bd05bbf71198e6b67582106d072d4d8aec255194",
+      "condition_idx": 4,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0238.wav",
+      "sha256": "793d6d260458e4631e478b736d00a6e442d093c2a749162774636109e42b8d4e",
+      "transcript": "the u.s. corps of engineers estimated that 6 inches of rainfall could breach the previously damaged levees",
+      "duration_sec": 11.295687,
+      "speech_end_offset_ms": 7716.0,
+      "audio_hash_id": "c47e95c3457bffce8df173046f72f6395d0c46eb88e40b397bb5ae4269b0f3c4",
+      "condition_idx": 0,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0239.wav",
+      "sha256": "786cb5aad087d9110fb806470dc67aa0f93602af061beb5550094568d04f00e6",
+      "transcript": "the use of video recording has led to important discoveries in the interpretation of micro-expressions facial movements which last a few milliseconds",
+      "duration_sec": 14.075688,
+      "speech_end_offset_ms": 11012.0,
+      "audio_hash_id": "9b5076711873607f34e9af8ede6b466d5b3724dcd867dfd07be76a3759f76156",
+      "condition_idx": 3,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0240.wav",
+      "sha256": "9b1f640538eb69eacbe86a1c70ea6b7ec83b1abbf2c40a9712d3cfd2a101c093",
+      "transcript": "the vehicle itself was taken away from the scene of the accident at approximately 1200 gmt on the same day",
+      "duration_sec": 11.150688,
+      "speech_end_offset_ms": 7716.0,
+      "audio_hash_id": "13e888a197342a60a2c7b3c1cfc41f0a68db364f958e53369287245c33f58e1d",
+      "condition_idx": 5,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0241.wav",
+      "sha256": "328b3ff8bf48fcec2385e385075e874d4b5233ce767a88638a618916210a18a9",
+      "transcript": "the vertical clearance under the bridge is 15 meters construction was completed in august 2011 it didn't open to traffic until march 2017",
+      "duration_sec": 12.387375,
+      "speech_end_offset_ms": 8900.0,
+      "audio_hash_id": "e96b23d382e764bb711e789e10a15b341b7796cc5429d40027bd922c2f7cbd48",
+      "condition_idx": 1,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0242.wav",
+      "sha256": "0899188623a1591ee38cbdcaa5d9135be089c533206cbec861a639251e27d666",
+      "transcript": "the work done was mostly theoretical but the program was written to simulate observations made of the sagittarius galaxy",
+      "duration_sec": 13.370688,
+      "speech_end_offset_ms": 8868.0,
+      "audio_hash_id": "b3bc414a19871e8150223642e11da1b3402499a31592d53f87cef0e26853ff0a",
+      "condition_idx": 2,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0243.wav",
+      "sha256": "cc9817e84a8d092b6cfc78135974d78d7a93415323384baa59636a34d859597a",
+      "transcript": "their disciplined defence ball handling skills and excellent team work made them stand out and it was clear that this was the team to beat",
+      "duration_sec": 10.430687,
+      "speech_end_offset_ms": 7044.0,
+      "audio_hash_id": "9e7b4f0b1ee2b3ca50080b01c3d4088839287c9624848339ff679253a55af4e2",
+      "condition_idx": 5,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0244.wav",
+      "sha256": "218bbb7c90a00b84659efc065b754c51e4e1da442abfcf432896dfc83fec2dc6",
+      "transcript": "there are of course christian theological explanations for this tradition but it may well be a pre-christian spring and fertility ritual",
+      "duration_sec": 11.907375,
+      "speech_end_offset_ms": 9252.0,
+      "audio_hash_id": "f0eb68058f0896a1c583ab2d2b67f7d64cc6ced0e49e7a2c00cd4c762d0af04c",
+      "condition_idx": 1,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0245.wav",
+      "sha256": "cf3663c7b8f433870cb6cfe8c66c3bb740c0cd19f58e7b5cf5328d9a2bd1ae9c",
+      "transcript": "there are still many men and women alive who survived their time here and many more who had loved ones who were murdered or worked to death there jews and non-jews alike",
+      "duration_sec": 13.635687,
+      "speech_end_offset_ms": 9956.0,
+      "audio_hash_id": "9c346d5c8d8ae45c25517bd00ba7fe2d413a6c458c5a2a2725abcfbfead4ee5b",
+      "condition_idx": 0,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0246.wav",
+      "sha256": "3dd2dc030cac2fa1aeb2bd5cdfac713c2ee93604a303119fdcd8b8402e3d3d64",
+      "transcript": "there is no universal definition for which manufactured items are antiques some tax agencies define goods older than 100 years as antiques",
+      "duration_sec": 14.370688,
+      "speech_end_offset_ms": 10724.0,
+      "audio_hash_id": "3f89b45ea9cb77807b35d660faeadf9532bd50918c4574f25d6a23ec8e2f1094",
+      "condition_idx": 5,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0247.wav",
+      "sha256": "f2834b80a54cac36b607b8682c8a26de906fb05dc9d3bc4ce9e21cd2d225d050",
+      "transcript": "there may be more maria on the near side because the crust is thinner it was easier for lava to rise up to the surface",
+      "duration_sec": 11.507375,
+      "speech_end_offset_ms": 8292.0,
+      "audio_hash_id": "164f5b0e85b495b88c91a910523f81fae13a03115723edc043dd0579c8491ace",
+      "condition_idx": 4,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0248.wav",
+      "sha256": "4131865aeae3328e3f6515a4672af9d3d941c4113aafe55fc3b8caeee6484abb",
+      "transcript": "these are sometimes-crowded family beaches with a good range of shops lining the shore swimming is safe",
+      "duration_sec": 13.070688,
+      "speech_end_offset_ms": 8196.0,
+      "audio_hash_id": "f32d6fba3680bc3547880f87809ad3258c4140cb5c500d77b1b31781ed67259f",
+      "condition_idx": 5,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0249.wav",
+      "sha256": "baa3d94ad0b432f8f9e690547a6afca60c101a252adc6277bd67b5af0773458b",
+      "transcript": "these couples may choose to make an adoption plan for their baby",
+      "duration_sec": 9.387375,
+      "speech_end_offset_ms": 6020.0,
+      "audio_hash_id": "bb71e24eafaffb838720f70acab1efbaa8c4e33206b237cff335a8acdd775950",
+      "condition_idx": 4,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0250.wav",
+      "sha256": "3d9a7847fcd103884846666a7f1d1a678c5094f1384b44a70861ffd3d101592f",
+      "transcript": "they are almost all sandy beaches with safe swimming and most have shade provided by pohutukawa trees",
+      "duration_sec": 11.030688,
+      "speech_end_offset_ms": 7556.0,
+      "audio_hash_id": "a78d92ba3f94dc521e5e2f6d8c7f0afd2d8365f4c6b9dbef009fc0952a895f84",
+      "condition_idx": 2,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0251.wav",
+      "sha256": "3777357307d01544d47eb7d3319afff732def4a1fe66a2836e14924e2b90cddb",
+      "transcript": "they have feet with scales and claws they lay eggs and they walk on their two back legs like a t-rex",
+      "duration_sec": 9.207375,
+      "speech_end_offset_ms": 6404.0,
+      "audio_hash_id": "e5611d81a2f5a290bb4054f77d58d002798b829a8105a3a45d4a183a3c2b6f97",
+      "condition_idx": 4,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0252.wav",
+      "sha256": "ae8f41dec6389128b1edec989a65628f8d9ae2cf232bf3bf1587399567bff1c3",
+      "transcript": "they usually have special food drink and entertainment offers to keep guests in a good mood and keep them at the premise",
+      "duration_sec": 9.495688,
+      "speech_end_offset_ms": 6084.0,
+      "audio_hash_id": "da45a75187f5673eea2c5f670a53af862ce187d2f354f4b978e59ad1581557a8",
+      "condition_idx": 3,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0253.wav",
+      "sha256": "08f134a1b0717079a4f14f5ab1d3e3fb4944840ed09fb9308a3c1719e70342b0",
+      "transcript": "think of the skiing route as of a similar hiking route",
+      "duration_sec": 7.510688,
+      "speech_end_offset_ms": 4356.0,
+      "audio_hash_id": "80634e56a0415567468414699a7b3a1cee9371dfc65e9454fb0a91e1a6620bde",
+      "condition_idx": 5,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0254.wav",
+      "sha256": "4d4ecb919cd507e4a92c92775206b1548181a698425792c094a5230ad798cbf5",
+      "transcript": "this is an important way to distinguish between some verbs and objects",
+      "duration_sec": 7.035687,
+      "speech_end_offset_ms": 4260.0,
+      "audio_hash_id": "6c42f3bdd95063bc807eea1dccba10cfdd771383a5a28bde07409dbd17a49032",
+      "condition_idx": 0,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0255.wav",
+      "sha256": "267a183cc0ace337bde364d551924515d60d7cfd39b9ce0c38ef9ebcbc933c0c",
+      "transcript": "this is called a chemical's ph you can make an indicator using red cabbage juice",
+      "duration_sec": 8.427375,
+      "speech_end_offset_ms": 4900.0,
+      "audio_hash_id": "782d69a559edfc32ac06f92324a8a8a2739395ecacce32afb3ad615ee9d4bf87",
+      "condition_idx": 1,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0256.wav",
+      "sha256": "e409408dd6ae842bdf6a2cfcead486de100efddc67f630dd089ed44e1e6e348a",
+      "transcript": "this is not going to be goodbye this is the closing of one chapter and the opening of a new one",
+      "duration_sec": 8.415688,
+      "speech_end_offset_ms": 5092.0,
+      "audio_hash_id": "c7eb05e8158048a9785e5709e1d20b9eaf18ccf01eabb8b543697f06816de724",
+      "condition_idx": 3,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0257.wav",
+      "sha256": "40a1c7c03d3d915913beb5f1c61cf800562832b4d8ce635261a354b19d8bb540",
+      "transcript": "this offers a good opportunity to see the aurora borealis as the sky will be dark more or less around the clock",
+      "duration_sec": 9.255688,
+      "speech_end_offset_ms": 6404.0,
+      "audio_hash_id": "1b977770b50de1d084805ffd75d8ab5bbdcd14121477cc795ebb0c6933c166b4",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0258.wav",
+      "sha256": "de9896e884616985e17b42118d71c74a852f1f28ff786108f01f2a14a2968873",
+      "transcript": "this sediment was necessary for creating sandbars and beaches which served as wildlife habitats",
+      "duration_sec": 13.790688,
+      "speech_end_offset_ms": 9540.0,
+      "audio_hash_id": "289ee9af4ee9d225227b7e4ebe31fb249c0a381b3921e90897a12bd3f2575df4",
+      "condition_idx": 2,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0259.wav",
+      "sha256": "874a7dce6da3fc2ab055ef954e6df048d73fc3c95a8e0bc9db032b3116d4d640",
+      "transcript": "this seems sensible because the earth doesn't feel as if it's moving does it",
+      "duration_sec": 8.175688,
+      "speech_end_offset_ms": 4804.0,
+      "audio_hash_id": "b573a9aafcdcfd6e31ed70f6d503c499eb31ab7277da03157b02a4aeb91cccf0",
+      "condition_idx": 0,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0260.wav",
+      "sha256": "bbcde4ecefb83abf7c5d37b9016f9a498a245f9d0730d1a9dc158d44cd618b16",
+      "transcript": "this will allow players to control actions and movements in video games by moving the device through the air",
+      "duration_sec": 8.307375,
+      "speech_end_offset_ms": 5668.0,
+      "audio_hash_id": "7696867b8dbc10630a597b7c2419115bdf0984e6c2a5ad736c86c3d924c48836",
+      "condition_idx": 1,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0261.wav",
+      "sha256": "f6d7d60372a888bc124f62e8af8a0a46b97ee1bb28435053ca6118b4f21e4ff9",
+      "transcript": "through the night between 150 and 200 copies were made now known as dunlap broadsides",
+      "duration_sec": 7.370687,
+      "speech_end_offset_ms": 4676.0,
+      "audio_hash_id": "89ef51f2b7f11907a2640350e27e6c34d34fa59ef4537ae8e09afa423d06c524",
+      "condition_idx": 2,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0262.wav",
+      "sha256": "014310ec002c343be3d330786627785828221985926a0179cadd1cb6656408e8",
+      "transcript": "throughout 1960s brzezinski worked for john f kennedy as his advisor and then the lyndon b johnson administration",
+      "duration_sec": 11.295687,
+      "speech_end_offset_ms": 7332.0,
+      "audio_hash_id": "28c13137ec3164e27a71e7b7b04d68742c3b97d3190055d24f55bd7694ee1d2f",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0263.wav",
+      "sha256": "c35181ff064bb3b03b2af3154d190c37c6ab5c9805b978375c9cc3f7f6b5eac9",
+      "transcript": "thus the pencil was a good friend to many people when it came out",
+      "duration_sec": 6.495687,
+      "speech_end_offset_ms": 3716.0,
+      "audio_hash_id": "718a032db2a6ec4d695bfb6c4c2be1a8f076ff2bb6779e3d420e573345b25b22",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0264.wav",
+      "sha256": "2d856ffaaa622a6252a0bf09c7235d189619b4cfadc87ee3f7bd408ccbc3558f",
+      "transcript": "to get the best views of hong kong leave the island and head for the kowloon waterfront opposite",
+      "duration_sec": 9.447375,
+      "speech_end_offset_ms": 5924.0,
+      "audio_hash_id": "44fa8d56001613b9d6dbec4a67f4b286e1953f9e3bdeb081552056bb162c5a49",
+      "condition_idx": 4,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0265.wav",
+      "sha256": "a06d23824a6950ae571309091f9c43b640464c0b1982b4c843845e15d0392d56",
+      "transcript": "to the north and within easy reach is the romantic and fascinating town of sintra and which was made famous to foreigners after a glowing account of its splendours recorded by lord byron",
+      "duration_sec": 14.030688,
+      "speech_end_offset_ms": 11044.0,
+      "audio_hash_id": "fcc751012b00426617c6afe73e5be8e89a9fb13a64f253de5f87834a9fb42ca2",
+      "condition_idx": 2,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0266.wav",
+      "sha256": "7905592e8ccd65408f03908d802caf3f0d8a8fa7784342a5be9be183e7c78845",
+      "transcript": "today the only insects that cannot fold back their wings are dragon flies and mayflies",
+      "duration_sec": 8.475687,
+      "speech_end_offset_ms": 5060.0,
+      "audio_hash_id": "126d9ec0d10143838462e9accc6f64b486c0199a1ee2de629ec755a518480cdb",
+      "condition_idx": 0,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0267.wav",
+      "sha256": "b46c2d46de6f27951d90f3698a7fc6bccfee4ba22fae9a0cab3d839548e0c9d0",
+      "transcript": "traffic flow is the study of the movement of individual drivers and vehicles between two points and the interactions they make with one another",
+      "duration_sec": 10.227375,
+      "speech_end_offset_ms": 7556.0,
+      "audio_hash_id": "9145461c27056c3577a2089c182763b424e295c7651a801bdd9b83791b533ce0",
+      "condition_idx": 1,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0268.wav",
+      "sha256": "a0e8e5112c0602e468e055bb1a6cc168cc79fdb60d607ddbe941222f833fdf13",
+      "transcript": "travellers are strongly advised to be aware of any risk of severe weather affecting their area as they may affect any travel plans",
+      "duration_sec": 9.867375,
+      "speech_end_offset_ms": 7140.0,
+      "audio_hash_id": "8aa56324b81b9af97f005ae701d5f1e27b56c4dfc3f064d49eec5c0ec7420b4c",
+      "condition_idx": 1,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0269.wav",
+      "sha256": "7cf1e3dd58c1f73524e6ce40143ec9806b748683c701540744caf207a7f7454f",
+      "transcript": "travellers bound for countries with heavy taxation can sometimes save a considerable amount of money especially on products such as alcoholic beverages and tobacco",
+      "duration_sec": 12.950688,
+      "speech_end_offset_ms": 9444.0,
+      "audio_hash_id": "7ef0f1812adc0037cb5f01170dbd274b678a4274ef98b9c9fc65f0bc1a86befb",
+      "condition_idx": 2,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0270.wav",
+      "sha256": "ee028ce0ec00660bf67446ede55b083c3ec6c20fd0a7a75257649644798e0295",
+      "transcript": "twentieth century research has shown that there are two pools of genetic variation hidden and expressed",
+      "duration_sec": 9.507375,
+      "speech_end_offset_ms": 6180.0,
+      "audio_hash_id": "0676dfe364aa85d82630b25c04fb5791a6db3ccca08198e36822793dc0de972c",
+      "condition_idx": 1,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0271.wav",
+      "sha256": "47e7a58c57c14df112a606ad89cc2a0ce24ad3f8f0567a21cacc5af5eeaa9d61",
+      "transcript": "using ships to transport goods is by far the most efficient way to move large amounts of people and goods across oceans",
+      "duration_sec": 10.155688,
+      "speech_end_offset_ms": 6852.0,
+      "audio_hash_id": "b8b8fb362f17f39dced21614a6f8620ba6980f82cfbcc762fa4492b4dad44727",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0272.wav",
+      "sha256": "e3289133f17b5bb86da2a0837a2f3ea6c9659d198f56081933a3e8107d3aa58a",
+      "transcript": "usually you always here the sound of tourists and vendors the story of the sound and light is just like a story book",
+      "duration_sec": 9.927375,
+      "speech_end_offset_ms": 6372.0,
+      "audio_hash_id": "cd5b891519eff577bbe795af16d17540184777b72c6cadcf39d384c55234b16f",
+      "condition_idx": 1,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0273.wav",
+      "sha256": "458672f4a1f6dfbbac6c621ce3f109eafb372447d53271e17611c4e00816d9e4",
+      "transcript": "vatican city's population is around 800 it is the smallest independent country in the world and the country with the lowest population",
+      "duration_sec": 13.287375,
+      "speech_end_offset_ms": 7652.0,
+      "audio_hash_id": "6b4f1f6db82c43eb517b544e5f79c74669b161b5e561b19b15374d18d4be8d6e",
+      "condition_idx": 1,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0274.wav",
+      "sha256": "14f2ba6c2ad3fb1fc5d07b83d1f811f769dfa4b88ac261b5b8c605550620f224",
+      "transcript": "virtual scaffolds are internalized in the software and are meant to question prompt and explain procedures that may have been to challenging for the student to handle alone",
+      "duration_sec": 12.267375,
+      "speech_end_offset_ms": 9380.0,
+      "audio_hash_id": "c09b939b29020ad37b4ab031cd055fd2391362fb4983f32724d3f10ad9f6cfd5",
+      "condition_idx": 4,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0275.wav",
+      "sha256": "772a0dd208543585c4afd051f697aaba0c08e5b5107a37a7c2458c31a6f65511",
+      "transcript": "virtual teams are held to the same standards of excellence as conventional teams but there are subtle differences",
+      "duration_sec": 8.175688,
+      "speech_end_offset_ms": 5380.0,
+      "audio_hash_id": "f83fdb729bbe1b8976d22735c94a162cbda7aebbf03fb129814862577c4f5f90",
+      "condition_idx": 3,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0276.wav",
+      "sha256": "9ac3d9a4e14a0384fe9b4febd6de4ac78e9b071545b163d43b29a08d3449cfed",
+      "transcript": "we make our houses from plants and make clothes from plants most foods that we eat are plants without plants animals could not survive",
+      "duration_sec": 10.467375,
+      "speech_end_offset_ms": 7748.0,
+      "audio_hash_id": "9d97c1bde0aa1faec4cfc507e10cb86039a8e2a38a839eb1e2afa66d075dba5b",
+      "condition_idx": 1,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0277.wav",
+      "sha256": "a8aed637c06af78b8483891a84c31ab72d40690b19b5e46604d150e5e0e997dc",
+      "transcript": "when all available resources are effectively used across the functional departments of an organization creativity and ingenuity can transpire",
+      "duration_sec": 11.727375,
+      "speech_end_offset_ms": 8292.0,
+      "audio_hash_id": "c5b6598860747c47c4a9ece04e7fc0fb460863f1dc932f3a0e52426ebbea4580",
+      "condition_idx": 1,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0278.wav",
+      "sha256": "f99b572f77ed2004d0ff34e6651c8332739c8e82c0bd0bdb1b6962b24fa029b6",
+      "transcript": "while goma is reasonably safe any visits outside of goma should be researched to understand the state of the fighting that persists in the north kivu province",
+      "duration_sec": 12.410687,
+      "speech_end_offset_ms": 9316.0,
+      "audio_hash_id": "722d407de3a779bd0d80c6d3dc60892b1dc19aeee7806ad53f4a90b434ded33e",
+      "condition_idx": 5,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0279.wav",
+      "sha256": "4ded67ea2c590ca98cf7b1359f84ebb4d6bf431f4cd6c4881fa2aba899a3c765",
+      "transcript": "while he was working at the hospital liggins began to investigate premature labor during his spare time",
+      "duration_sec": 7.995687,
+      "speech_end_offset_ms": 5348.0,
+      "audio_hash_id": "908e4cea7a924f6f4bec2387a56e39e5d4c0061bd27cd12e2bcecab3d3602f83",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0280.wav",
+      "sha256": "f96a46eb77116d768460df9679c518f7bc2d463ea18f55ac74c8e35da41ecf49",
+      "transcript": "while one experimental vaccine appears able to reduce ebola mortality up until now no drugs have been clearly demonstrated suitable for treating existing infection",
+      "duration_sec": 14.547375,
+      "speech_end_offset_ms": 11556.0,
+      "audio_hash_id": "b44b8af885405b8d2a9071f058e4328758bdb7c3f53f163ed319f8fdc4716205",
+      "condition_idx": 1,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0281.wav",
+      "sha256": "f0f85e09a798555eaadaf53eb1cc5b97bff1820f14565077d33e8b1711f34174",
+      "transcript": "with kundalini yoga the kundalini energy enlightenment energy is awakened through yoga postures breathing exercises mantras and visualizations",
+      "duration_sec": 13.587375,
+      "speech_end_offset_ms": 10148.0,
+      "audio_hash_id": "6a01af394dbdfa172b9c24635150c23bf5abdaf986eacc2a07ffc6a15a2f3035",
+      "condition_idx": 4,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0282.wav",
+      "sha256": "2424af12175ca51c302109b747bdad5531bdbedec7eb721c91cb24bc8543e73b",
+      "transcript": "with two years of the end of the war the former allies were now enemies and the cold war began",
+      "duration_sec": 10.227375,
+      "speech_end_offset_ms": 6372.0,
+      "audio_hash_id": "970666fe5d25ecd582f3d2254e88d6947a739a0a068359695cdc84ade9ab4450",
+      "condition_idx": 1,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0283.wav",
+      "sha256": "3f5ce7e1fe130bbb3a955b45cd177ec2979d2534e0e40beeb49a1f1db34222ba",
+      "transcript": "women it is recommended that any women travellers say that they are married regardless of actual marital status",
+      "duration_sec": 12.675688,
+      "speech_end_offset_ms": 9060.0,
+      "audio_hash_id": "2871946aeb5f087694c53e65c5e549ceb3585d3db37792143db232c91c173014",
+      "condition_idx": 3,
+      "condition_count": 6
+    },
+    {
+      "path": "audio/0284.wav",
+      "sha256": "97e2cf11b9651ae7c72388b8a640276400d99a411cada6a60431b7b115cd25dc",
+      "transcript": "you may also wish to consult the advice of governments other than your own but their advice is designed for their citizens",
+      "duration_sec": 10.910687,
+      "speech_end_offset_ms": 6756.0,
+      "audio_hash_id": "37050b56178ac9c08009938a3f93a32049a36ed3b96aae137c473089cabe7ceb",
+      "condition_idx": 5,
+      "condition_count": 6
+    }
+  ]
+}

--- a/runner/src/coval_bench/datasets/manifests/stt-wildasr-noisegap.json
+++ b/runner/src/coval_bench/datasets/manifests/stt-wildasr-noisegap.json
@@ -1,0 +1,2849 @@
+{
+  "_license": "Apache-2.0 (WildASR; audio derived from FLEURS, CC-BY-4.0)",
+  "id": "stt-wildasr-noisegap",
+  "version": "1.0.0",
+  "license": "Apache-2.0 (WildASR; audio derived from FLEURS, CC-BY-4.0)",
+  "source": "bosonai/WildASR environment_degradation__en__fleurs_noise_gap_en",
+  "items": [
+    {
+      "path": "audio/0001.wav",
+      "sha256": "520e861c77b0b7e1ae970cdc4ee78fb245713c885f8d569faafb135fef4338cd",
+      "transcript": "\"he [wales] basically lied to us from the start. first by acting as if this was for legal reasons. second by pretending he was listening to us right up to his art deletion.",
+      "duration_sec": 13.56,
+      "speech_end_offset_ms": 12644.0,
+      "audio_hash_id": "22bb9527aa633678a3824d20b76c3cfd47f81c88efb3546d46ec5f2c20b7b5bb",
+      "condition_idx": 2,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0002.wav",
+      "sha256": "deb2d6e6589b150208235dd506d05526f618a75925158ca38881bafa6634cfe8",
+      "transcript": "a car bomb detonated at police headquarters in gaziantep turkey yesterday morning killed two police officers and injured more than twenty other people",
+      "duration_sec": 11.22,
+      "speech_end_offset_ms": 9860.0,
+      "audio_hash_id": "754fccfc984dd33b465ed6eecd0843b080dcec05aaa24ab8af65b35afbd47192",
+      "condition_idx": 2,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0003.wav",
+      "sha256": "b205cb8b5b64a25adfff553cb2a52ee1978d517d04a7c7c1b722fad5dd2a7904",
+      "transcript": "a civilization is a singular culture shared by a significant large group of people who live and work co-operatively a society",
+      "duration_sec": 9.48,
+      "speech_end_offset_ms": 8388.0,
+      "audio_hash_id": "3b77fc8c9ff25a6c524b8574fc0463857c4807c82c4a965eacf4df94bf8f93b2",
+      "condition_idx": 0,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0004.wav",
+      "sha256": "4cdcb04658139f4aefb112619ca30fde1a51d6fcfdb25904c787210c51c302b8",
+      "transcript": "a curry is a dish based on herbs and spices together with either meat or vegetables",
+      "duration_sec": 10.26,
+      "speech_end_offset_ms": 7876.0,
+      "audio_hash_id": "daec746f08ce9a232597b2c0223a439cbc51bf8c0bbb95987d7019724aef012e",
+      "condition_idx": 6,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0005.wav",
+      "sha256": "4a8963c47934403d977d2332f89e838b216dd63004414d0595a048f6445e094a",
+      "transcript": "a full 20% of the water that pours out of the planet's rivers into the oceans comes from the amazon",
+      "duration_sec": 8.32,
+      "speech_end_offset_ms": 7652.0,
+      "audio_hash_id": "15ed15d798c66a081540462e66c018e0c47f6c2e493ea496928f3875991ec1fb",
+      "condition_idx": 5,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0006.wav",
+      "sha256": "dfce82f5ae250acab90df9841d34e253b6f013ef6785de996bb85e59badedd3d",
+      "transcript": "a search of the internet for hostile environment course' will probably provide the address of a local company",
+      "duration_sec": 8.2,
+      "speech_end_offset_ms": 7076.0,
+      "audio_hash_id": "2e0b5e57341f627bb87adc1b9447f5cc60bfff97300ffe9add09c9459ca548c7",
+      "condition_idx": 1,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0007.wav",
+      "sha256": "5ac3eb85901113bb9dde4ff00ed915c5e584b335efe5d381d01dc5bdf7fd2232",
+      "transcript": "a simple popular dinner especially during the summer is the pa amb oli bread with olive oil tomato and any available condiments such as cheese tunafish etc",
+      "duration_sec": 12.84,
+      "speech_end_offset_ms": 11812.0,
+      "audio_hash_id": "fa6f83382bc97f0579de2295bc04f2ac65305d50a45fea4599f3f21a6d0c4ef5",
+      "condition_idx": 0,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0008.wav",
+      "sha256": "9efb8cfbd617633f990e45ba3d01cbcb62e6cb1c53021e2372d9ed64bb013586",
+      "transcript": "a well rounded athlete the tiger can climb though not well swim leap great distances and pull with five times the force of a strong human",
+      "duration_sec": 11.4,
+      "speech_end_offset_ms": 10500.0,
+      "audio_hash_id": "d6fc05d6c5aba38dd1690ed5d48c900a977ff8f112a2a1d8df1e5b14847a9c79",
+      "condition_idx": 2,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0009.wav",
+      "sha256": "a6d7c12dd9d122b26d658be35a5932ae059f90e32dcc0a90cdc347c65a7bc6b6",
+      "transcript": "accepted were aristotle's views on all matters of science including psychology",
+      "duration_sec": 7.32,
+      "speech_end_offset_ms": 5220.0,
+      "audio_hash_id": "f1b9a3b715c87d67ce37f6cf689fd3369ccf9655950b02ff212ed7a1ceebc53f",
+      "condition_idx": 0,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0010.wav",
+      "sha256": "ba0a625f35ad7681a1552c3d21100ef582d33946cd36fc3e017d4a69c00fbd67",
+      "transcript": "according to japan's nuclear agency radioactive caesium and iodine has been identified at the plant",
+      "duration_sec": 7.98,
+      "speech_end_offset_ms": 6884.0,
+      "audio_hash_id": "81394a94ac4893498d289df78bc7face47e1696de6af395de48d51b016c15d6d",
+      "condition_idx": 0,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0011.wav",
+      "sha256": "c3a472ce0fcd077823d24417a1dd753708d54dafdec53242b81be553f6a6439f",
+      "transcript": "aerosmith have cancelled their remaining concerts on their tour",
+      "duration_sec": 5.96,
+      "speech_end_offset_ms": 5636.0,
+      "audio_hash_id": "6bf0d82f53d09b004820db1cfae62b47da2b0f7462504599cdf502ed18c274c4",
+      "condition_idx": 3,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0012.wav",
+      "sha256": "8c339b4dd73a3864956c6f37b1a253bbee899fcfb8159900426d80b44e7216a8",
+      "transcript": "after the accident occurred gibson was transported to a hospital but died shortly afterwards",
+      "duration_sec": 6.84,
+      "speech_end_offset_ms": 6084.0,
+      "audio_hash_id": "72e0d9b180adbcb4447b8fda4d933f86750d79cc730ffa09ce9ccee26a56a22f",
+      "condition_idx": 0,
+      "condition_count": 4
+    },
+    {
+      "path": "audio/0013.wav",
+      "sha256": "3d7453ecbef4abee2d5bf074f3d4523e5f612717f11449985bcbd0a22ef20dc7",
+      "transcript": "after the dam was built in 1963 the seasonal floods that would spread sediment throughout the river were halted",
+      "duration_sec": 10.24,
+      "speech_end_offset_ms": 8292.0,
+      "audio_hash_id": "91ab9c67f4a14240ba40d9dfd06896db3c7cf0976e795779613f32fa89411e66",
+      "condition_idx": 5,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0014.wav",
+      "sha256": "25fdf43375727926e88b686c8f6f8595c7666132398947e0b6ef5304f15dc1c5",
+      "transcript": "all nouns alongside the word sie for you always begin with a capital letter even in the middle of a sentence",
+      "duration_sec": 9.96,
+      "speech_end_offset_ms": 9284.0,
+      "audio_hash_id": "c3f40c87f34cd53c65e3301611560224160bf6b2303b36fd18464dd877851bd1",
+      "condition_idx": 6,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0015.wav",
+      "sha256": "056663d443a8701e7dcafb1db9d1aca785d28ab9a3c89d749586233bddffac44",
+      "transcript": "all things considered we should not be surprised if our own ancestors solved their protein problem in somewhat the same way that chimps on the savanna do today",
+      "duration_sec": 10.08,
+      "speech_end_offset_ms": 9124.0,
+      "audio_hash_id": "2567163e72ee98a372694951bf1601df063e902d35b1b32477b797df02e6d7fe",
+      "condition_idx": 0,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0016.wav",
+      "sha256": "abcdf1009869c9739b301b77ff21015a29fc3724c82db9c7f8c43adc69faf3c3",
+      "transcript": "alloys are basically a mixture of two or more metals don't forget that there are many elements on the periodic table",
+      "duration_sec": 9.38,
+      "speech_end_offset_ms": 8356.0,
+      "audio_hash_id": "b059b0600580de7214b5b643970339984dde5690941cf6375473035f56c88661",
+      "condition_idx": 5,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0017.wav",
+      "sha256": "de1cdb9e3daee22b79451b433ac63e3d1a4f47dfedecb615b67e193407794ce3",
+      "transcript": "along the same line men are required to wear trousers covering the knees",
+      "duration_sec": 7.2,
+      "speech_end_offset_ms": 6404.0,
+      "audio_hash_id": "9479fc6ddae0cb406fe2e7980e84517b78f6d7d25cbd2c78c6b0fb064cb464e7",
+      "condition_idx": 2,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0018.wav",
+      "sha256": "ce9d48d1ac7980dc1ab08ecf6ce8d8ec2a87db61b77c63acbda9970a78e0d294",
+      "transcript": "also after the revolution occupations were open to all male applicants allowing the most ambitious and successful to succeed",
+      "duration_sec": 8.22,
+      "speech_end_offset_ms": 7940.0,
+      "audio_hash_id": "8286ae4df704bbcf8494727d9a48000fa2f0930464f6a14fdebfb45b52193b53",
+      "condition_idx": 2,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0019.wav",
+      "sha256": "68defbe525c3e263d8d7e098239ee24bbc19d6925cef8ed9049d27f0924993d2",
+      "transcript": "also between each dynasty was an unstable age of divided provinces the best-known of these periods was the three kingdoms epoch taking place for 60 years between the han and the jin dynasty",
+      "duration_sec": 13.82,
+      "speech_end_offset_ms": 13316.0,
+      "audio_hash_id": "8e8cda78b6d7fc5bb52c5ce8950ae982789af871edd3033b76d8f76ccb9b89d1",
+      "condition_idx": 7,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0020.wav",
+      "sha256": "50c1974981e9c7ad8deb2bbe690874d1e0b3a1b16497a2cbf1e0b1d3936f7825",
+      "transcript": "also to the north visit the great sanctuary of our lady of fatima shrine a place of worldwide famous marian apparitions",
+      "duration_sec": 8.56,
+      "speech_end_offset_ms": 8560.0,
+      "audio_hash_id": "4763df3b3e2f1b26d61b49c30ec181a436a09e0411953c7ef7dbdb120ccc583f",
+      "condition_idx": 1,
+      "condition_count": 4
+    },
+    {
+      "path": "audio/0021.wav",
+      "sha256": "489932ac0379cfc4262f1dc3bb54b3106d001cded166d7e324a01b62dda831ac",
+      "transcript": "ancient cultures and tribes began to keep them for easy access to milk hair meat and skins",
+      "duration_sec": 7.84,
+      "speech_end_offset_ms": 7524.0,
+      "audio_hash_id": "257efee8d236de2a1f80bcba6dc549cd26495eea5d291cbf081702399b48ee82",
+      "condition_idx": 5,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0022.wav",
+      "sha256": "c1d447348e62f1662e92faa24cda2cd7fbd6d1b73b93a20f6fefbf5373c975e6",
+      "transcript": "angel 2006 explains the continuum approach as a method being used to help organizations reach a higher level of performance",
+      "duration_sec": 9.48,
+      "speech_end_offset_ms": 8996.0,
+      "audio_hash_id": "1d448e04b46c0e01f7fd95cebcf6a7428a67d3e264d4da68a03dbd9f2dc7f88c",
+      "condition_idx": 2,
+      "condition_count": 4
+    },
+    {
+      "path": "audio/0023.wav",
+      "sha256": "65766fe84c87ebecf9a771c753524773beb941a76995f3661a746d77db9cbaf1",
+      "transcript": "anyone who's going to drive at high latitudes or over mountain passes should consider the possibility of snow ice or freezing temperatures",
+      "duration_sec": 10.58,
+      "speech_end_offset_ms": 9668.0,
+      "audio_hash_id": "88cfb0af585c18f5a2fe90488bd620e6d486db096a9839c8007ef386c5ba694f",
+      "condition_idx": 3,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0024.wav",
+      "sha256": "ee75af73a9d93b0d3a3835e2128fe378669b05f4e3254fb4ced93c9a46a124d9",
+      "transcript": "apia is the capital of samoa the town is on the island of upolu and has a population of just under 40,000",
+      "duration_sec": 12.16,
+      "speech_end_offset_ms": 11492.0,
+      "audio_hash_id": "39e936709c62500f056f909a79da824bd51b4ee3df9e8c223f5fb70085c4f2af",
+      "condition_idx": 2,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0025.wav",
+      "sha256": "a70fb38395cdb85c899170c6a366369bb6272586128c9e5f72ca2530fb7ded9e",
+      "transcript": "aristotle a philosopher theorised that everything is made up of a mixture of one or more of four elements they were earth water air and fire",
+      "duration_sec": 11.06,
+      "speech_end_offset_ms": 10628.0,
+      "audio_hash_id": "50c173e941f5762eaee79585eb8077e856ee13a9eb064746b12325b317227267",
+      "condition_idx": 7,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0026.wav",
+      "sha256": "a4ca4d7b7b6abb000bebc9d10c0a73a567dcacae06b20f4e92f0757ef148377d",
+      "transcript": "as a result the performers smoke cannabis joints on stage and the theatre itself is encouraging the audience to join in",
+      "duration_sec": 11.56,
+      "speech_end_offset_ms": 9572.0,
+      "audio_hash_id": "2147f0c8e16bf8e53ef216852be4d470f6314ba24cb6feb2577010402fd3c5df",
+      "condition_idx": 1,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0027.wav",
+      "sha256": "3a7166fa623cf65b43b73cb7244f94db8ba84b79ed780ba04c71f6e7c64d084f",
+      "transcript": "as a result the process of an organization working together to overcome an obstacle can lead to a new innovative process to serve the customer's need",
+      "duration_sec": 12.72,
+      "speech_end_offset_ms": 11364.0,
+      "audio_hash_id": "572a55642505729e04574e58167e18af93d2e7d9731fdbaf0bafc39e015a5b6e",
+      "condition_idx": 4,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0028.wav",
+      "sha256": "aa85d9aeb2cd4816211e8dd9b5d0e2303af613ad31a4e653da6c4fb3402fdf68",
+      "transcript": "as a result two fish species have become extinct and two others have become endangered including the humpback chub",
+      "duration_sec": 12.64,
+      "speech_end_offset_ms": 11588.0,
+      "audio_hash_id": "cda35870279f8a0926860408d708cef6ba0e9f9e3901e105cf21ee2bb210749a",
+      "condition_idx": 6,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0029.wav",
+      "sha256": "17007597c67ad29b3ebb24e9f9ad788a781bacd5a436469c5ea54b6bcbdc1e75",
+      "transcript": "as knowledge of greek declined the west found itself cut off from its greek philosophical and scientific roots",
+      "duration_sec": 10.78,
+      "speech_end_offset_ms": 9380.0,
+      "audio_hash_id": "4c1c05c3aa669401b71189e0173cc6e50c196956f39bbd37ab367228579fe05f",
+      "condition_idx": 4,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0030.wav",
+      "sha256": "020130874cddef618b7850b5ba1ec9869398f1cc8e20c39919b6f86ad0edc9bf",
+      "transcript": "as light pollution in their heyday was not the kind of problem it is today they are usually located in cities or at campuses easier to reach than those built in modern times",
+      "duration_sec": 11.9,
+      "speech_end_offset_ms": 10820.0,
+      "audio_hash_id": "860efa3e4f901bff8f197a755c4cff8f376035d10ef99fd7a811d6f729092395",
+      "condition_idx": 3,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0031.wav",
+      "sha256": "aa6bda8203f6e2261e55f77b638666bdd2e982b04479666a6e34b43ef16c9b9e",
+      "transcript": "as with all south african national parks there are daily conservation and entry fees for the park",
+      "duration_sec": 11.42,
+      "speech_end_offset_ms": 10372.0,
+      "audio_hash_id": "afd59d4932a1eb6f0c48893b1808decf9f111302c3f22ce6be194941ea0a2610",
+      "condition_idx": 7,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0032.wav",
+      "sha256": "18e344e1502d2d1991a24a7a7eb16aea31c7cc79b6ec3ba26e2d07577d86ee63",
+      "transcript": "asus eee pc earlier launched world-wide for cost-saving and functionality factors became a hot topic in 2007 taipei it month",
+      "duration_sec": 11.34,
+      "speech_end_offset_ms": 9988.0,
+      "audio_hash_id": "06ccf1ed4585c683e3b002df5b348b7afe8d1138335c649c1be59fc62a01e323",
+      "condition_idx": 4,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0033.wav",
+      "sha256": "21eba4bb63947a67bf73afead390140ddfe8abdd247057194f58d2f2385cf6b8",
+      "transcript": "barcelona's official languages are catalan and spanish about a half prefer to speak catalan a vast majority understands it and virtually everyone knows spanish",
+      "duration_sec": 13.22,
+      "speech_end_offset_ms": 11076.0,
+      "audio_hash_id": "3b1e073e403127ae71d9f2d4232c0c859c951f10e1ae264fefc658646f550a80",
+      "condition_idx": 7,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0034.wav",
+      "sha256": "4ccd5e72b3177f70e9865b84f1bb36b954158701feebd7331893d12ff7b7a736",
+      "transcript": "be careful not to allow fabric to become too hot which can cause shrinkage or in extreme cases scorch",
+      "duration_sec": 11.16,
+      "speech_end_offset_ms": 10660.0,
+      "audio_hash_id": "8048168bef55abf9f988296ec39dea8f1848e068c48010b699bd01bbb5cbb106",
+      "condition_idx": 1,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0035.wav",
+      "sha256": "76f18ba678e6008b67d1017ce2bd6dc2763afd03015d6fddc8edafd0d17a5de1",
+      "transcript": "be firm in turning down men and don't be afraid to stand your ground cultural differences or not it doesn't make it ok!",
+      "duration_sec": 12.18,
+      "speech_end_offset_ms": 10276.0,
+      "audio_hash_id": "ea67128d3ff1b6ae95fbb1820799e08794a4461ffca9df1136bc6e374150973f",
+      "condition_idx": 2,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0036.wav",
+      "sha256": "1f464fcae84e2ea89470ca37a15989fd6db1c4868e3639ef71f638ee20b855e7",
+      "transcript": "between 10:00-11:00 pm mdt a fire was started by the inmates in the yard",
+      "duration_sec": 10.14,
+      "speech_end_offset_ms": 8996.0,
+      "audio_hash_id": "0d5c066e7a0169cbd300632e8e6b7b5072719b35e904a61f8fcd91cb35068fd0",
+      "condition_idx": 6,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0037.wav",
+      "sha256": "35be234ee647b01ead36620b15905ba09371b8819ab68b867d6d2a745fa79805",
+      "transcript": "beyond wednesday's event carpanedo competed in two individual races at the championships",
+      "duration_sec": 6.7,
+      "speech_end_offset_ms": 6404.0,
+      "audio_hash_id": "b824e5509f11a2131635692e76645afcb306b6246d55dca358bf0616eb01c9b5",
+      "condition_idx": 5,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0038.wav",
+      "sha256": "06c655dc1b9d7acc98bbdc22697e0472cfe6a35cb27dd0a21f8a21060ba60dc9",
+      "transcript": "bishkek was described as sinking into a state of anarchy by one observer as gangs of people roamed the streets and plundered stores of consumer goods",
+      "duration_sec": 10.2,
+      "speech_end_offset_ms": 9188.0,
+      "audio_hash_id": "2870eaac09b9bb4ae5fd5728e42c718327a4ae5665d5ead547b25f9febb82e43",
+      "condition_idx": 0,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0039.wav",
+      "sha256": "45db65871d9218a48074546c7cabb4640c0d463fc77c51f854a28a923f159382",
+      "transcript": "blogging is a tool that inspires collaboration and encourages students to extend learning well beyond the traditional school day",
+      "duration_sec": 10.8,
+      "speech_end_offset_ms": 9828.0,
+      "audio_hash_id": "e783bc728237ba0bd83c1626670fe4a07749f3c902fc7acd7beebb87b90392c4",
+      "condition_idx": 6,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0040.wav",
+      "sha256": "55d228fce103d6c1b2512591c8798dbbe52b2737c5132826e4778573578f801b",
+      "transcript": "blogs can also help improve student writing while students often begin their blog experience with sloppy grammar and spelling the presence of an audience generally changes that",
+      "duration_sec": 10.76,
+      "speech_end_offset_ms": 10404.0,
+      "audio_hash_id": "d3b14b3bc2b3ea188c5afdae6efa1b84dc7064c5bc9baa4cda9d233c5abd65b1",
+      "condition_idx": 7,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0041.wav",
+      "sha256": "033ae1a020c69fb3c541fe05f7da358a40415f313332c5ffb8a92c0a45935022",
+      "transcript": "built by the egyptians in the third century bce the great pyramid is one of many large pyramid structures built to honor dead pharaoh",
+      "duration_sec": 10.14,
+      "speech_end_offset_ms": 9028.0,
+      "audio_hash_id": "42351330cb90307b4f9b7c69739b3b9e1f06e0e645c6fd0dfa26b24418994f88",
+      "condition_idx": 2,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0042.wav",
+      "sha256": "886272bc42641c05eca21d5cffb928bf9c76c31161ac4cba1301177a6d7fb5ff",
+      "transcript": "buses depart the inter-district bus station across the river throughout the day though most especially those heading to the east and jakar/bumthang leave between 06:30 and 07:30",
+      "duration_sec": 14.12,
+      "speech_end_offset_ms": 13092.0,
+      "audio_hash_id": "a4b8fc6b2a61f4d9fe32008e5a5f959c4a1002fd70540445aee0a4a61a2c416c",
+      "condition_idx": 3,
+      "condition_count": 4
+    },
+    {
+      "path": "audio/0043.wav",
+      "sha256": "9f1c24d2eaf19df5e31166841f4fec7afd4bec333753a948cd9d3c1de8912a88",
+      "transcript": "but after losing the captain's wicket india only made 36 runs loosing 7 wickets to end the innings",
+      "duration_sec": 10.52,
+      "speech_end_offset_ms": 9092.0,
+      "audio_hash_id": "93100e4a877e6436cede1b1a98118cb514fef6de723ad5b378bab5e0521fd2f8",
+      "condition_idx": 3,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0044.wav",
+      "sha256": "00c4262bb825e39528e2979e623a298cd2713f303e5c592abd42d2e7a30fed76",
+      "transcript": "but being placed in the high tropics just a few degrees north of equator you will need to deal with both heat always and strong sun when the sky is clear more rarely",
+      "duration_sec": 11.04,
+      "speech_end_offset_ms": 10116.0,
+      "audio_hash_id": "2446dda392837671aaadff67941af9c245f5a503c1eaf6e84ce1cfa1385882a5",
+      "condition_idx": 0,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0045.wav",
+      "sha256": "01e1f6bcc64ccc548fb191d8fb7431a9839156806e46b322a5b5d27ae782cbec",
+      "transcript": "but there are a lot of things about birds that still look like a dinosaur",
+      "duration_sec": 5.96,
+      "speech_end_offset_ms": 5960.0,
+      "audio_hash_id": "9e9efceafc5ce0b849b77f0949614dc50d50e052d5f0f3e696566db2e6c0faa5",
+      "condition_idx": 4,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0046.wav",
+      "sha256": "1cc5eaa3fd8e476cea5af8738ad033644d936dc32c6d8c5799c4f0534407e5d8",
+      "transcript": "by 1976 thirty percent of machu picchu had been restored and restoration continues till today",
+      "duration_sec": 7.38,
+      "speech_end_offset_ms": 7380.0,
+      "audio_hash_id": "e805ffa2277fbe6ce411f5eb6ea44018f1fd083860645b068a20593cd2d55abb",
+      "condition_idx": 4,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0047.wav",
+      "sha256": "4eb2f46439956d2663ed27e24d2489a119de04b48fd2228b95bd615ea5921eb8",
+      "transcript": "california governor arnold schwarzenegger signed into law a bill that bans the sale or rental of violent video games to minors",
+      "duration_sec": 12.34,
+      "speech_end_offset_ms": 9796.0,
+      "audio_hash_id": "f9c5b7798d265d8e103cd69387be4ab5154725f5a284c143f94e088ce0f9d209",
+      "condition_idx": 1,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0048.wav",
+      "sha256": "abd2e23c7f78064b12caf89356024a1c0f649f690dbbeabcd1fd3dacc5bbdcd2",
+      "transcript": "cancellation policies vary but as of late march most coronavirus-based cancellation policies don't extend to july 2020 when the olympics had been scheduled",
+      "duration_sec": 9.9,
+      "speech_end_offset_ms": 9444.0,
+      "audio_hash_id": "4e2cfc450310d57d71db86e3239543ab7756767ebf177e6eb51608e0a71bf5e0",
+      "condition_idx": 0,
+      "condition_count": 4
+    },
+    {
+      "path": "audio/0049.wav",
+      "sha256": "9eeb492705bce783379cfe75cac546b55c110278a0fa8a5e96a4d1f5a21ba904",
+      "transcript": "casablanca is one of the least interesting places to shop in all of morocco",
+      "duration_sec": 6.84,
+      "speech_end_offset_ms": 5700.0,
+      "audio_hash_id": "86d0f5ad108298cb6ad5ddfe0b5fb1340a38765ca885e8c15d3bbe37cb70681c",
+      "condition_idx": 4,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0050.wav",
+      "sha256": "d538bdd63e6786e39ab59aa40fecb91ea066fdfddf49af2244103c4e4ac5d285",
+      "transcript": "children are placed in foster care for a wide variety of reasons that range from neglect to abuse and even to extortion",
+      "duration_sec": 11.92,
+      "speech_end_offset_ms": 11332.0,
+      "audio_hash_id": "6c946db25d4fe6c8811ee9f2143d44d6ac5ef73aba051f0fb9f3353d354baee1",
+      "condition_idx": 2,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0051.wav",
+      "sha256": "94489a2659e369fa537f7d4b69c23c3c711624c320172dc3926f856996d590d0",
+      "transcript": "cochamó valley - chile's premier climbing destination known as the yosemite of south america with a variety of granite big walls and crags",
+      "duration_sec": 13.12,
+      "speech_end_offset_ms": 11300.0,
+      "audio_hash_id": "6ab6c22a95a72bf63cd10e8ea9df6b17ecc5e670aee1bc03bea6a8db784ba569",
+      "condition_idx": 1,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0052.wav",
+      "sha256": "62d766147eb0f900c21270d7515f6d6db45634029ec95748edc2232988767701",
+      "transcript": "congress began funding the obscenity initiative in fiscal 2005 and specified that the fbi must devote 10 agents to adult pornography",
+      "duration_sec": 10.62,
+      "speech_end_offset_ms": 9380.0,
+      "audio_hash_id": "e8df0e6615f8cc1dca9855a381269e25b1dc4c31d185f7d1854296255bddf911",
+      "condition_idx": 4,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0053.wav",
+      "sha256": "8e034777e9fad99301f7cbcaf00896261b68aaa6ff1cb9007dcefbc583e2e85f",
+      "transcript": "crossties were introduced fairly early to hold the tracks in place gradually however it was realised that tracks would be more efficient if they had a stip of iron on the top",
+      "duration_sec": 12.74,
+      "speech_end_offset_ms": 12420.0,
+      "audio_hash_id": "06c12a178b14e7f351560c94a8c99dbb181c8506a18d1e5f154239f02e337306",
+      "condition_idx": 3,
+      "condition_count": 4
+    },
+    {
+      "path": "audio/0054.wav",
+      "sha256": "9560c4b16979ba04327a1491333a71a791231417978ef4471a23a88e0c315c41",
+      "transcript": "cuomo 53 began his governorship earlier this year and signed a bill last month legalizing same-sex marriage",
+      "duration_sec": 10.02,
+      "speech_end_offset_ms": 8772.0,
+      "audio_hash_id": "a984605c0c6159d546141e1e2635b141183effd24c8dd0efc98f879e3b39fed1",
+      "condition_idx": 0,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0055.wav",
+      "sha256": "fc8a4ee0db5d9353d61bfa3c7d12a6ff4d29b0c03538821d568136cd0918357b",
+      "transcript": "danielle lantagne a un expert on the disease stated the outbreak was likely caused by the peacekeepers",
+      "duration_sec": 7.3,
+      "speech_end_offset_ms": 6884.0,
+      "audio_hash_id": "1a18c593ecc84cf64aa566d643fa0b16a4f6a48154f0c342d03fa93534897ae2",
+      "condition_idx": 5,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0056.wav",
+      "sha256": "7174564e332ecea4fb3f665cb574e760fb94dce74e19c1778887e9d5521c14e5",
+      "transcript": "del potro had the early advantage in the second set but this too required a tie break after reaching 6-6",
+      "duration_sec": 9.1,
+      "speech_end_offset_ms": 7748.0,
+      "audio_hash_id": "65eca41f5d6c8e8d52c72075d653b1de2775bb9a499b322ec674f7f83b38dbdf",
+      "condition_idx": 1,
+      "condition_count": 4
+    },
+    {
+      "path": "audio/0057.wav",
+      "sha256": "f2496473f1ef50ba2348d92755bed368ce000b1e08de4febec47958851c4f0e0",
+      "transcript": "do not deface the site by marking or scratching graffiti into structures",
+      "duration_sec": 5.5,
+      "speech_end_offset_ms": 5220.0,
+      "audio_hash_id": "f66f8bd9d933ea28c0e2828dee6251d221547ec7753b5f6b8adb00a13b33115f",
+      "condition_idx": 5,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0058.wav",
+      "sha256": "037702dbe600aea7ea9cb263dc0b056e0ee74f518dc15d554a5fe40c27f5b93d",
+      "transcript": "due to the underwater topology the return flow is concentrated at a few deeper sections and a fast current to deep water may form there",
+      "duration_sec": 11.52,
+      "speech_end_offset_ms": 10308.0,
+      "audio_hash_id": "a03f23481366d5e74640d1662a51f467f654f12ada7f306268952f6620c044da",
+      "condition_idx": 4,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0059.wav",
+      "sha256": "022f32a3f6c3ccb99929eedcd959feee5b87b4f99c3f97d557cd41423cf69112",
+      "transcript": "during the 1920s the prevailing attitudes of most citizens and nations was that of pacifism and isolation",
+      "duration_sec": 8.28,
+      "speech_end_offset_ms": 7236.0,
+      "audio_hash_id": "13db5456cd59fcf502458c1b159ceda3670091c3e0261fda0e9394b5dbf9c475",
+      "condition_idx": 0,
+      "condition_count": 4
+    },
+    {
+      "path": "audio/0060.wav",
+      "sha256": "f2b7ceb0626796c1d24a7a99754f7bb6311806248d0919fc7ab236c815e9567b",
+      "transcript": "during the revolutionary war the thirteen states first formed a weak central government-with the congress being its only component-under the articles of confederation",
+      "duration_sec": 10.68,
+      "speech_end_offset_ms": 9604.0,
+      "audio_hash_id": "3b20ad3bbf62120e4fc42d775baa9e55b789a440cfda2bd26dea76f602553936",
+      "condition_idx": 0,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0061.wav",
+      "sha256": "9a7cbee2c72e23db0559ffbdc49a324c1194f4238e3f4912d9bd082be7956f91",
+      "transcript": "during the struggle for independence organised by the mau movement a peaceful gathering in the town resulted in the killing of the paramount chief tupua tamasese lealofi iii",
+      "duration_sec": 13.32,
+      "speech_end_offset_ms": 12612.0,
+      "audio_hash_id": "31d7af57cd3b436354a71d080c1f0d2b2022b9dec0853b8e06f21496d5443c4e",
+      "condition_idx": 6,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0062.wav",
+      "sha256": "e1d9147c6c43a3c62288cb4f23d4b1759991ea6f323372bb933eb1dbf78d40ac",
+      "transcript": "during this period of european history the catholic church which had become rich and powerful came under scrutiny",
+      "duration_sec": 12.4,
+      "speech_end_offset_ms": 11492.0,
+      "audio_hash_id": "1dafd83032c02d699841eea335be5170fb4a5b2378c253157a27bdbdb8bb83cd",
+      "condition_idx": 5,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0063.wav",
+      "sha256": "c19a08bb0b9da56963e5e63055bdcdf5126a5ddd1469bddc6cc14905acbcc67f",
+      "transcript": "duvall who is married with two adult children did not leave a big impression on miller to whom the story was related",
+      "duration_sec": 8.24,
+      "speech_end_offset_ms": 8240.0,
+      "audio_hash_id": "c9b75ec0f0d6ce05a001547fb9fb88685666c8c48f48c0663b30a88ad99f4fc5",
+      "condition_idx": 7,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0064.wav",
+      "sha256": "4f257f808ef635c06564125a27abae5d70b5a69d493bfd99febb7bec976510e5",
+      "transcript": "elements like calcium and potassium are considered metals of course there are also metals like silver and gold",
+      "duration_sec": 7.44,
+      "speech_end_offset_ms": 7140.0,
+      "audio_hash_id": "8535e2bf24e0e79fdca56f39943fc5d6d42af2903b74a184e8d4870d78419fca",
+      "condition_idx": 2,
+      "condition_count": 4
+    },
+    {
+      "path": "audio/0065.wav",
+      "sha256": "69829eb7e473c3e89fbf24da052163ef095f2c8f6a080696456dc26564153edf",
+      "transcript": "everyone participates in society and uses transportation systems almost everyone complains about transportation systems",
+      "duration_sec": 12.64,
+      "speech_end_offset_ms": 11652.0,
+      "audio_hash_id": "81bc539c10e02daeb279afc8b17d34a8234e93743aa1b33ae67c45836b4575eb",
+      "condition_idx": 1,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0066.wav",
+      "sha256": "159c97bb198e115bbca1b22f8dbea83095f64355617f77f55a1a3ee597840bd6",
+      "transcript": "everything in the universe is made of matter all matter is made of tiny particles called atoms",
+      "duration_sec": 7.42,
+      "speech_end_offset_ms": 6916.0,
+      "audio_hash_id": "69c1a2cfa84e22f48c04d2d64f288313202cfd823c2eb044dbc40cd3d2b3f5fd",
+      "condition_idx": 1,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0067.wav",
+      "sha256": "b679e44cf62a33060092ab3d8869785b0a9fc35653438e57087125df1dbd2062",
+      "transcript": "fellow wrestlers also paid tribute to luna",
+      "duration_sec": 4.6,
+      "speech_end_offset_ms": 3620.0,
+      "audio_hash_id": "47583ad161cb110a1081972e82fad79a1751379367111363d8ae0c578fb91cc3",
+      "condition_idx": 1,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0068.wav",
+      "sha256": "c9634eace8c3607f38120115e6b9854a0ef0d2ea8e4b4620676b6e0b3ac50f0f",
+      "transcript": "feral children may have experienced severe child abuse or trauma before being abandoned or running away",
+      "duration_sec": 7.54,
+      "speech_end_offset_ms": 6788.0,
+      "audio_hash_id": "cd9ebd9299d10686b23edfcb6e1930d44e181b00d51ed6e820387c8b9f59340f",
+      "condition_idx": 5,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0069.wav",
+      "sha256": "6d35919d7f5734452e7e6d0fba15dcf636d545fb8b055399e32ce2f4299ae7b3",
+      "transcript": "field trips are a large part of any classroom quite often a teacher would love to take her students places to which a bus trip is not an option",
+      "duration_sec": 11.84,
+      "speech_end_offset_ms": 10340.0,
+      "audio_hash_id": "e22d8d26a2519362aac655eb02a72a4df1800047cfadeb1d3eb65501d7aac429",
+      "condition_idx": 3,
+      "condition_count": 4
+    },
+    {
+      "path": "audio/0070.wav",
+      "sha256": "f1b6df5d64fb257419d6dc736db902227adf242c022aef915b5b55480ac12f7d",
+      "transcript": "finally there are many small cats including loose pet cats that eat the far more numerous small prey like insects rodents lizards and birds",
+      "duration_sec": 9.84,
+      "speech_end_offset_ms": 9572.0,
+      "audio_hash_id": "13bea54fd526149d5d931f65ff65aae53d00caf980360ae939d19c3b2b09c3e4",
+      "condition_idx": 2,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0071.wav",
+      "sha256": "fd8a1337d67f21c20434cc541c429cb707a46f3fdca954782b41c8e672f31baf",
+      "transcript": "finland is a great boating destination the land of a thousand lakes has thousands of islands too in the lakes and in the coastal archipelagos",
+      "duration_sec": 10.56,
+      "speech_end_offset_ms": 9508.0,
+      "audio_hash_id": "381cebdbf311b905e6f89ad39997068df377f9e35bbc2c74bd4aefb36e4d5884",
+      "condition_idx": 2,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0072.wav",
+      "sha256": "9649424f4cdb12218547cf05bfaa686b3fc99bb0793e3d1a9c03dfd380cf6754",
+      "transcript": "fire rescue crews eventually doused the fire by 11:35 pm",
+      "duration_sec": 6.32,
+      "speech_end_offset_ms": 6052.0,
+      "audio_hash_id": "f3ecb0e80cb2aa1c8033b9904f627c928a6d1ad0f573af73880094c348f47dfd",
+      "condition_idx": 0,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0073.wav",
+      "sha256": "cb34c5781add5fe15adbb3546941e843ad497765e1e940283fd0ae989d87e12c",
+      "transcript": "first most riders wear riding boots with a heel and a smooth quite narrow sole",
+      "duration_sec": 9.06,
+      "speech_end_offset_ms": 8036.0,
+      "audio_hash_id": "0f46a37d80bc7dadeabc2c30702ef21794b6543911893f226b607e994afe9a71",
+      "condition_idx": 6,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0074.wav",
+      "sha256": "349240abf97cad6f2c71942065888929b82a7783c6a1380f4e66f5b9b51c6083",
+      "transcript": "for example each year students from bennet school in north carolina design a website about their trip to the state capital each year the website gets remodeled but old versions are kept online to serve as a scrapbook",
+      "duration_sec": 11.88,
+      "speech_end_offset_ms": 11556.0,
+      "audio_hash_id": "6fca5224c7b7e73e77fa5b46685bd0fe72054c565c0e7b955262feb5a3b64e73",
+      "condition_idx": 4,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0075.wav",
+      "sha256": "87fb67ba068df45aae3f107562b8ea609c22c070d8d2d72a775666591e8bbea6",
+      "transcript": "for the springboks it ended a five-match losing streak",
+      "duration_sec": 6.98,
+      "speech_end_offset_ms": 6532.0,
+      "audio_hash_id": "7b755ea498f70f717cd80c2a2c579d9168149653c2f08a9213b35a82587c5082",
+      "condition_idx": 3,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0076.wav",
+      "sha256": "369d76ff79758978549152ecfcd5b6aaa0f2ee89f11e88956a318dc70adb49fc",
+      "transcript": "four skiers in the women's sitting group failed to finish their runs and 45 of the 117 total skiers in the giant slalom failed to rank in the race",
+      "duration_sec": 9.68,
+      "speech_end_offset_ms": 9412.0,
+      "audio_hash_id": "e0685d221c7362442831588bed9eb85fa8bf87ce71df5e40840f6cf46424c381",
+      "condition_idx": 3,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0077.wav",
+      "sha256": "aff64292711e8a65f0d26fd58cfefe53558244c58d292a6a75affea6c00b9d70",
+      "transcript": "giancarlo fisichella lost control of his car and ended the race very soon after the start",
+      "duration_sec": 6.36,
+      "speech_end_offset_ms": 6116.0,
+      "audio_hash_id": "e351eb55c8d25cd20cf0c982b87836bf3a516437ae7fe26d181a5529ebf1f72c",
+      "condition_idx": 6,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0078.wav",
+      "sha256": "f4f5178841078a639064d51731aaf43bb376c81b37b190a3b0268c018500227f",
+      "transcript": "goats seem to have been first domesticated roughly 10,000 years ago in the zagros mountains of iran",
+      "duration_sec": 11.82,
+      "speech_end_offset_ms": 9924.0,
+      "audio_hash_id": "b6704c9af27e50840a9324df95ec046e37a43085e7263f5664b78076c46a4a2c",
+      "condition_idx": 6,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0079.wav",
+      "sha256": "2cd6c2de65b570a644edf1a255a020effcbcbce001b693b589458ba4cc728a78",
+      "transcript": "he added that they should not however be asked to take on obligations that go beyond their development stage responsibility and capabilities",
+      "duration_sec": 14.22,
+      "speech_end_offset_ms": 12996.0,
+      "audio_hash_id": "677765d6f39cae3e175763dc0587e16aabb648d70cd3847eadbdd4b66e37adea",
+      "condition_idx": 3,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0080.wav",
+      "sha256": "f7d4fa121cb428f4c8cdb46a4e700101925232804b0e4436ca797e8f2e792da6",
+      "transcript": "he did not set a figure for the cuts saying they will be made based on china's economic output",
+      "duration_sec": 8.36,
+      "speech_end_offset_ms": 7108.0,
+      "audio_hash_id": "34df87f6478bbcaa1ab5750068f7f09333ee36061cc3d1ccf59024ad3690da0b",
+      "condition_idx": 3,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0081.wav",
+      "sha256": "e053ff39113fe0cb5ed9a455e32b2f491ca8ef334ceb8a86f686c29f579bac9a",
+      "transcript": "he has been unable to take the drugs needed to overcome his pain as they are banned from the games",
+      "duration_sec": 6.96,
+      "speech_end_offset_ms": 5924.0,
+      "audio_hash_id": "2c0478dcf555b216e7f5e373fb8168e4a240b417ae31d9d1b9ca55f9bcda9e0b",
+      "condition_idx": 4,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0082.wav",
+      "sha256": "4638215697a3bd17b160e486fa10d0e673b13314f28304642ea8a948b14b8578",
+      "transcript": "he referred to the rumors as political chatter and silliness",
+      "duration_sec": 5.04,
+      "speech_end_offset_ms": 4772.0,
+      "audio_hash_id": "60a6a72cbd81479c9425b2a83e27a2b0317222f3fb8c5fe27d328664776b6ae1",
+      "condition_idx": 2,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0083.wav",
+      "sha256": "18e18a9d1cdb915ef733b06896e8d372f497d8685a06a07388836ba853b76ae0",
+      "transcript": "he was also engaged in engraving banknotes for many countries recent examples of his work including the prime ministerial portraits on the front of the new canadian $5 and $100 bills",
+      "duration_sec": 12.96,
+      "speech_end_offset_ms": 12708.0,
+      "audio_hash_id": "6107dd46d486279cce8d603a16c9e72a3a7e3002d3667c62ab506b0ec8251869",
+      "condition_idx": 0,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0084.wav",
+      "sha256": "09aad8258e45734097fce2d66ec132a7193650124bcd32a6b7a6e3bc0d49edc0",
+      "transcript": "he was greeted by singapore's deputy prime minister wong kan seng and discussed trade and terrorism issues with the singapore prime minister lee hsien loong",
+      "duration_sec": 12.84,
+      "speech_end_offset_ms": 11620.0,
+      "audio_hash_id": "9136bb81d2220a2a78644aae4dc6c1ca6c5af28f82b7dba249321ea6be92ee90",
+      "condition_idx": 2,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0085.wav",
+      "sha256": "fe177e796d8412f53c0d09de6e179bcd7de12908fe060213a099bca8c5194672",
+      "transcript": "he was initially hospitalised in the james paget hospital in great yarmouth",
+      "duration_sec": 8.5,
+      "speech_end_offset_ms": 8500.0,
+      "audio_hash_id": "c923ebf14c5fc31df00cd98eda42cb44f31822d5a57416cbf1d8726dd3072885",
+      "condition_idx": 1,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0086.wav",
+      "sha256": "10aed23200a6b039d98d27178cc8bcabe02646b1d348cffe8d55820eefdec907",
+      "transcript": "he was reportedly aged in his 20s. in a statement bieber said [w]hile i was not present nor directly involved with this tragic accident my thoughts and prayers are with the family of the victim.",
+      "duration_sec": 12.56,
+      "speech_end_offset_ms": 11620.0,
+      "audio_hash_id": "433be5dcf9f7edb07acf455fee9cd0adabb921b09cb78909e64ca1a9fa0e06b1",
+      "condition_idx": 7,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0087.wav",
+      "sha256": "316c93154c34d3bd2118d5ce3434e28fac7b9e0bb16f81dcfabc3f3e1a2bbf7c",
+      "transcript": "he was subsequently relocated to addenbrooke's hospital in cambridge",
+      "duration_sec": 7.84,
+      "speech_end_offset_ms": 5892.0,
+      "audio_hash_id": "ba9170d196cbd96fb1f9f7bc2eebf742e67301da6c79b0a580342e7d10eeb7f5",
+      "condition_idx": 5,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0088.wav",
+      "sha256": "2d5df931cdca3eea012a634a3418906b7b5d5a801c4bc97846bfffbd6320d2b0",
+      "transcript": "hong kong island gives the territory of hong kong its name and is the place that many tourists regard as the main focus",
+      "duration_sec": 9.02,
+      "speech_end_offset_ms": 8484.0,
+      "audio_hash_id": "a09df0442fb6f2d344b3f3a82d2d2af82b9098902008b79e548ba91109707a6f",
+      "condition_idx": 7,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0089.wav",
+      "sha256": "357203231c7ebdc368a1f1e5d172861689cf6a5a6acf503ab318379084aabdcd",
+      "transcript": "however due to the slow communication channels styles in the west could lag behind by 25 to 30 year",
+      "duration_sec": 12.56,
+      "speech_end_offset_ms": 10500.0,
+      "audio_hash_id": "190813eeda2cd83bbaa028c7792381b58d84ec9220be85729a9c17ee9f97a18a",
+      "condition_idx": 3,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0090.wav",
+      "sha256": "37e83983c4e05401d85ad8ed087c8a18713837387f9c189991b6b059f9370f67",
+      "transcript": "however that is not true although there is something written on the back of the document it is not a treasure map",
+      "duration_sec": 12.02,
+      "speech_end_offset_ms": 10820.0,
+      "audio_hash_id": "de75734348cca98611993b76049c9a8a15362cacef7ff75261424b629e7f0a6c",
+      "condition_idx": 7,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0091.wav",
+      "sha256": "0512d986734aef2197afaf7d5c133dfe899f5c99c07fd85bad6545f1e8d82dba",
+      "transcript": "hydrogen ions are protons that had their electrons stripped off them since hydrogen atoms consist of one proton and one electron",
+      "duration_sec": 8.28,
+      "speech_end_offset_ms": 7940.0,
+      "audio_hash_id": "96fa71b2611ec52aa63f49962e64a051a7e21886b68f9fbb95eebca314c7b7da",
+      "condition_idx": 0,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0092.wav",
+      "sha256": "41b8abaedaaf0912f4f8a81ee8209470063099fc2e27b64878b1a4aa38abcd27",
+      "transcript": "if you have watched the movie national treasure you may think a treasure map was written on the back of the declaration of independence",
+      "duration_sec": 8.78,
+      "speech_end_offset_ms": 8452.0,
+      "audio_hash_id": "a6031b4d295d5d10aeaedc3bbe1864d64cf7ef952674f66672f7af3ce669986a",
+      "condition_idx": 3,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0093.wav",
+      "sha256": "55b7bd3e7f0f6fa3a56122d2e7080ba45f33c9fe5cff29759bcb6416c88662c5",
+      "transcript": "if you only go ashore using shipboard excursions you will not need a separate visa as of 2009",
+      "duration_sec": 9.86,
+      "speech_end_offset_ms": 8772.0,
+      "audio_hash_id": "b4e9600a9863a0fa6a08a42ee6238b3bdc032f083afdd8f4c383f8221e567bdc",
+      "condition_idx": 0,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0094.wav",
+      "sha256": "8608a694a2f07695e57be3570bb06a02d081faaac836ae757b2c6e9a0874efd1",
+      "transcript": "if you want to be close to the action you're going to have to get in early to get a camping site close to the music",
+      "duration_sec": 10.24,
+      "speech_end_offset_ms": 8740.0,
+      "audio_hash_id": "e54488dd367bea458eac14e869493add9079b3a2de0a4adbd58afa5af7953752",
+      "condition_idx": 5,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0095.wav",
+      "sha256": "24330ed23e44d037402eb7ee8b278754f4542edc14946ba04c89ff42eda293d3",
+      "transcript": "if you're not used to driving on country roads keep your wits about you steep grades narrow lanes and sharp curves predominate",
+      "duration_sec": 11.7,
+      "speech_end_offset_ms": 11012.0,
+      "audio_hash_id": "c4b0568a5061a23121412b92573a672cea05199fe1afc83203663190b852680a",
+      "condition_idx": 4,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0096.wav",
+      "sha256": "7bebdbf5098e1949e8fc10785d5259e38b30f18fcbca37d3839779864e00a797",
+      "transcript": "in 1990 it was added to the list of world heritage sites in danger due to the threat of desert sands",
+      "duration_sec": 7.92,
+      "speech_end_offset_ms": 7236.0,
+      "audio_hash_id": "22d951579894efafd21e8394d0afbeca07f8a2974b55463b646561e21cabcfa5",
+      "condition_idx": 4,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0097.wav",
+      "sha256": "e65b71bf731293ad81c77f71a8fcec182ef5922dacd715e08632c749c5ad9ab4",
+      "transcript": "in 2002 goma was destroyed by lava from the nyiragongo volcano which buried most of the town's streets particularly the town centre",
+      "duration_sec": 10.98,
+      "speech_end_offset_ms": 9764.0,
+      "audio_hash_id": "5a408c75eceb58249de58e8e51521ff8fd8e341060010d79ef41c17738b23be1",
+      "condition_idx": 0,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0098.wav",
+      "sha256": "755f420e7a58a22ae0ac0e7cb39d1f9831844e6f5d3b17151eda62ce557e1388",
+      "transcript": "in a carriage they traveled back to paris surrounded by a mob of people screaming and shouting threats against the king and queen",
+      "duration_sec": 10.82,
+      "speech_end_offset_ms": 9188.0,
+      "audio_hash_id": "692eecc8ad1205312c333adaa74d357bc07cf96ed58daf1f79ce6cd80ec2ee6a",
+      "condition_idx": 0,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0099.wav",
+      "sha256": "f0b1b791aaf5596bdd247f07ed2b65ce119104d827621493e35b1d31bb0a17f1",
+      "transcript": "in fact it is not easy to find at all even if one knew it existed once inside the cave it is a total isolation",
+      "duration_sec": 9.12,
+      "speech_end_offset_ms": 8388.0,
+      "audio_hash_id": "91df8af20654bf295cb10e1828e2aa7214173800a6fe50fa54237d6e1d3fad6f",
+      "condition_idx": 6,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0100.wav",
+      "sha256": "a033c10166b40a8c5e8246f85505ae5c71aaa27be7fa7031b33412bd639dce75",
+      "transcript": "in just two weeks the americans and free french forces had liberated southern france and were turning towards germany",
+      "duration_sec": 10.78,
+      "speech_end_offset_ms": 9796.0,
+      "audio_hash_id": "73607bce53b1b986b6863474872d0078c1fdf2a92896066c7118f584585d77f7",
+      "condition_idx": 0,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0101.wav",
+      "sha256": "86ef2327ab961d5206f062a4a44cd40115cb8871feddfe153bcaafe52a140c3d",
+      "transcript": "in many other cities of italy and in the rest of the world particularly in poland similar setups were made which were viewed by a great number of people",
+      "duration_sec": 9.0,
+      "speech_end_offset_ms": 8132.0,
+      "audio_hash_id": "339e7e5735461996debe85a78486dfe19d8f4fb24c6fb866088016e8a96e87f6",
+      "condition_idx": 4,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0102.wav",
+      "sha256": "f8f94d9db798eda4d45a6c6aff861b928ae8344ecd4f6fafbc3a9cb0b9c90450",
+      "transcript": "in particular it is claimed that one can detect whether a person is lying by interpreting micro-expressions correctly",
+      "duration_sec": 6.72,
+      "speech_end_offset_ms": 6436.0,
+      "audio_hash_id": "954317dcd3991f9a0d07298187578d059abd647abf4312240a0c5fc63fe907d4",
+      "condition_idx": 0,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0103.wav",
+      "sha256": "3bf95528e77185536ddadff0d28627c863cb1cb3a59b8bda1c21de0a96a27ac7",
+      "transcript": "in some areas boiling water for a minute is enough in others several minutes are needed",
+      "duration_sec": 6.24,
+      "speech_end_offset_ms": 5348.0,
+      "audio_hash_id": "4f395c988c41d8cd378e27d2b0498254db0bd3ae44a9bea1d4e96a1732868e5e",
+      "condition_idx": 0,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0104.wav",
+      "sha256": "c2fe315f6564390d7dc57106157b63baf22aba377fd791f0d543035fe530a42a",
+      "transcript": "in the archipelagos and lakes you do not necessarily need a yacht",
+      "duration_sec": 8.48,
+      "speech_end_offset_ms": 7780.0,
+      "audio_hash_id": "93d78d4c019658000f35c121c3db694df634f2be09b80a4511c852727ad66d02",
+      "condition_idx": 5,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0105.wav",
+      "sha256": "72850b54bbf303fa9de0b10bce2f1bd1a59456eb1dfdc3e356310773a0492e6a",
+      "transcript": "in the north the region is bounded by the sahel and in the south and west by the atlantic ocean",
+      "duration_sec": 10.58,
+      "speech_end_offset_ms": 8932.0,
+      "audio_hash_id": "cb78a110d54dba977c1f0161cd684e820a219b2d8e82dafabf69248017738be5",
+      "condition_idx": 1,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0106.wav",
+      "sha256": "051642e9540fa0d44cdbb34f10660d31bd0b3b53553070e2912299f030a7b51b",
+      "transcript": "in the warm climate of the middle east the house was not so important",
+      "duration_sec": 7.92,
+      "speech_end_offset_ms": 6628.0,
+      "audio_hash_id": "aa44975c8ae1c27bac1e21de95853a679a1b263a0757beedc55f23deb2592781",
+      "condition_idx": 6,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0107.wav",
+      "sha256": "0ed2dd2b9c66a135910e1491437fec8754bac4528a0a22ebe370e2182894dd01",
+      "transcript": "it also attacked anything that entered the water even a giant dinosaur such as t rex would be no match for it",
+      "duration_sec": 11.12,
+      "speech_end_offset_ms": 9284.0,
+      "audio_hash_id": "3dddca26afe1f8955b1c6415d9f5890825b85a507d4f789c2fe5890ddbb6b556",
+      "condition_idx": 7,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0108.wav",
+      "sha256": "dbfe638f59220df54b81b66edbae74c70d941f91ea77a7495179dc52a0787b91",
+      "transcript": "it has brought us the train the car and many other transportation devices",
+      "duration_sec": 6.06,
+      "speech_end_offset_ms": 6060.0,
+      "audio_hash_id": "24410c3db7c3e0cf904ce76269950c02fc68a1fc91275643cbafe1955b0a72d1",
+      "condition_idx": 2,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0109.wav",
+      "sha256": "6b8fad5997c10a1693689cfa4c7d09f6b306cb536cdfe67ca6924c268ba8ab9b",
+      "transcript": "it is one of the main attractions of south africa and it is considered the flagship of south african national parks sanparks",
+      "duration_sec": 12.92,
+      "speech_end_offset_ms": 10980.0,
+      "audio_hash_id": "c4fb56015b9d50ef4a1a516d0cfdf9516d28d81ffadd7d94a860d0bf34529c7c",
+      "condition_idx": 3,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0110.wav",
+      "sha256": "a396a6e5b63ce973bbb221a5bc814012af6abb00e65faa2b5f217b79859208a1",
+      "transcript": "it is related to but usually not involving alpine style ski touring or mountaineering the latter ones done in steep terrain and requiring much stiffer skis and boots",
+      "duration_sec": 11.9,
+      "speech_end_offset_ms": 10884.0,
+      "audio_hash_id": "6678f50cadbb1f40b000a3b2e3185fffed5ca8c83d73488f0eeaa3c14d339955",
+      "condition_idx": 7,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0111.wav",
+      "sha256": "4c3a4715e9c7f315c3f7a9b9827fa75076353cdb9108081a1f52a67f973c70a3",
+      "transcript": "it is thinner under the maria and thicker under the highlands",
+      "duration_sec": 8.2,
+      "speech_end_offset_ms": 7876.0,
+      "audio_hash_id": "3a2d561e8dd6e4ece6421e40103070c8a578f49bcaa400833e4fa26dd351cbb7",
+      "condition_idx": 1,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0112.wav",
+      "sha256": "d08e11d3ba90c5518a2226662b0516aed7b1dd24fd09158df65466f9f7bc33e6",
+      "transcript": "it was ruled by the vichy french these were french people who had made peace with the germans in 1940 and worked with the invaders instead of fighting them",
+      "duration_sec": 11.6,
+      "speech_end_offset_ms": 10372.0,
+      "audio_hash_id": "42ead55f1aef16a355b0bd29b815a8213ccbe922a01b839d701a17cb4b7767b9",
+      "condition_idx": 7,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0113.wav",
+      "sha256": "c2b4370c6646adb51e3baf509ccc6337063f2ff3a16b3dea16e1a696b61e4e60",
+      "transcript": "italian is also the everyday language used by most of those who work in the state while latin is often used in religious ceremonies",
+      "duration_sec": 14.32,
+      "speech_end_offset_ms": 14052.0,
+      "audio_hash_id": "d29234046d877eae3512669997cb828979b852a22e2e987191265cafe3dc574e",
+      "condition_idx": 7,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0114.wav",
+      "sha256": "f8e9c8835d52269257251a4182956a1f715eb6fe563e3a2e3b4e1b14691af102",
+      "transcript": "its renown for being an epicenter of luxury began in about 400 a.d. and lasted up until about 1100 a.d",
+      "duration_sec": 12.68,
+      "speech_end_offset_ms": 12196.0,
+      "audio_hash_id": "d1ff2503587a2e55a83c38575259624e152a88e98d76107ade581ae90dad7ff1",
+      "condition_idx": 6,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0115.wav",
+      "sha256": "dd81bc4a0745d7a8b3c562a90034cfdd793edaed6533f1d3880313a9db487420",
+      "transcript": "just like the moon exerts a pull on the earth causing tides so does the milky way exert a force on the sagittarius galaxy",
+      "duration_sec": 9.14,
+      "speech_end_offset_ms": 8708.0,
+      "audio_hash_id": "cf5ae5834213e8528576e720efbb16db539f35f6a3a734422a70dd56975e5c9b",
+      "condition_idx": 3,
+      "condition_count": 4
+    },
+    {
+      "path": "audio/0116.wav",
+      "sha256": "13880c25f8a503f5b533b4b7b71bb87af0a14bf1ff6b7f618fbbeda2a93d24c5",
+      "transcript": "large areas further north are quite sparsely populated and some is nearly uninhabited wilderness",
+      "duration_sec": 8.04,
+      "speech_end_offset_ms": 6884.0,
+      "audio_hash_id": "c681d286d00d34a3f77a9b9d752a177c5c778750a3a5e0db213a96191a485683",
+      "condition_idx": 0,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0117.wav",
+      "sha256": "c8ec25aa05620d83a52854bcf5a27f66b9b773652dd3bd9767bfd0c72fc4267a",
+      "transcript": "last week meti announced that apple had informed it of 34 additional overheating incidents which the company called non-serious",
+      "duration_sec": 9.72,
+      "speech_end_offset_ms": 9092.0,
+      "audio_hash_id": "c35059c8ddc2d9fb49b44224c8d32b0a1e6e434fab531ff5240d31e715ed86bc",
+      "condition_idx": 0,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0118.wav",
+      "sha256": "cbe00ac1b12f45825c71e07bdb5f3e6a626b79f812d13896fc811afefb22e0e3",
+      "transcript": "late on sunday the united states president donald trump in a statement delivered via the press secretary announced us troops would be leaving syria",
+      "duration_sec": 10.56,
+      "speech_end_offset_ms": 9412.0,
+      "audio_hash_id": "2613f5739681cd09d1dde796babf0d49369503335fc4dfb58c33789680d51e67",
+      "condition_idx": 4,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0119.wav",
+      "sha256": "5ae1ffa1bd1c74e90a75f20683ef41e61251e9945249292993058ae5626844e0",
+      "transcript": "layton had asked for changes to the conservatives' environmental bill during the meeting with the pm asking for a thorough and complete rewriting of the conservative party's environmental bill",
+      "duration_sec": 10.72,
+      "speech_end_offset_ms": 10212.0,
+      "audio_hash_id": "2222aaca5e21de4f65b632f90031224e11be4c7b6625f291ac501c977f6b1f8d",
+      "condition_idx": 1,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0120.wav",
+      "sha256": "3301c6c3765ed962db89deda6ba5dd37130f722218cdf2d4dc5cdfe5fad0d79e",
+      "transcript": "liberal criticism of the reconstruction effort has focused on the awarding of reconstruction contracts to perceived washington insiders",
+      "duration_sec": 10.04,
+      "speech_end_offset_ms": 9764.0,
+      "audio_hash_id": "9edd4368c3a12e4d005a963c8845e539ea7bd69251d37bf32b6f31eb070a5947",
+      "condition_idx": 3,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0121.wav",
+      "sha256": "d9a59205244157a6422eebb6807f33929d7770aaac4b33000b063b742890c449",
+      "transcript": "lion prides act much like packs of wolves or dogs animals surprisingly similar to lions but not other big cats in behavior and also very deadly to their prey",
+      "duration_sec": 12.12,
+      "speech_end_offset_ms": 11332.0,
+      "audio_hash_id": "2c5876a07cc11fd7f9a8b5e44157e33f7bad9f9a6d734fc14b8a0e64c45152af",
+      "condition_idx": 2,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0122.wav",
+      "sha256": "9bd099fdcdff32ad82c20d9e4814f085dab1c93818f0e45d98a04e29fe873c3e",
+      "transcript": "lions are the most social cats living in large groups called prides",
+      "duration_sec": 7.6,
+      "speech_end_offset_ms": 6276.0,
+      "audio_hash_id": "54b4e098401c15e72aa63ce0eb6946626449ba0ddc3434d4234b2126f42f2d63",
+      "condition_idx": 1,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0123.wav",
+      "sha256": "9a4f8c7f3d776b9bd24d02de5c57542a06af997ef8fc49be60022414649331c0",
+      "transcript": "madagascar is by far the biggest and a continent on its own when it comes to wildlife",
+      "duration_sec": 8.52,
+      "speech_end_offset_ms": 7716.0,
+      "audio_hash_id": "81835d4bbb14d1f2925eb54c903acb112455658470bfe1d522f628ba9198bfdf",
+      "condition_idx": 6,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0124.wav",
+      "sha256": "3f420ac6cc8b6ceca2ba49bd577394a6861ac86aa135815f19efec387d1be16d",
+      "transcript": "many german baked goods also feature almonds hazelnuts and other tree nuts popular cakes often pair particularly well with a cup of strong coffee",
+      "duration_sec": 11.64,
+      "speech_end_offset_ms": 10500.0,
+      "audio_hash_id": "ad38d3ac9b78c455aa94fad374eea62fff0aa0bba7d357799740b1f2a7ebd06c",
+      "condition_idx": 2,
+      "condition_count": 4
+    },
+    {
+      "path": "audio/0125.wav",
+      "sha256": "ff420b3791f7fe4e514153852fee2ff4e4b9ac39ae7d4f2745c07dfde932fae2",
+      "transcript": "many people don't think about them as dinosaurs because they have feathers and can fly",
+      "duration_sec": 5.32,
+      "speech_end_offset_ms": 5028.0,
+      "audio_hash_id": "9ed5a46378c0b49df62c0c3f3bc4355a4810848d6e55db968f8e9eeb858334ff",
+      "condition_idx": 1,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0126.wav",
+      "sha256": "7d3d59a7130bf9a909e412489ad4875486f69aa9b99a48773a4def8f47e21089",
+      "transcript": "martelly swore in a new provisional electoral council cep of nine members yesterday",
+      "duration_sec": 10.72,
+      "speech_end_offset_ms": 8932.0,
+      "audio_hash_id": "9c693dfaeeefa2c6c9025880df9713bc8020b684e064306d327f73450a3738f0",
+      "condition_idx": 4,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0127.wav",
+      "sha256": "9026344f0b8f55c3cf8f8b167a827dd3455ef648a054d2e692117a1a4a1dea1f",
+      "transcript": "mass car ownership also leads to a higher incidence of accidents on the roads which leads to the invention of new techniques in healthcare for repairing damaged bodies",
+      "duration_sec": 11.48,
+      "speech_end_offset_ms": 11076.0,
+      "audio_hash_id": "1ebdfaf30008c236924d80f31c1138f39a4d201f4ace79abd3dd1f53df2dd1bb",
+      "condition_idx": 3,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0128.wav",
+      "sha256": "d8b3a79b0718edd39895266d5639fbc9fb5d52360a21b8ec6393b7083a1dfc9c",
+      "transcript": "middle order batsmen sachin tendulkar and rahul dravid performed well and made a hundred-run partnership",
+      "duration_sec": 9.84,
+      "speech_end_offset_ms": 8676.0,
+      "audio_hash_id": "f1ca3ace961df48e284161ae173ca6705354fdb2d4392759fdddcc3df315d485",
+      "condition_idx": 2,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0129.wav",
+      "sha256": "86f52810280a1ce1d2206f5615d7b2289f955344079ddf41cda1e4d305446c83",
+      "transcript": "mosasaurus was the apex predator of its time so it feared nothing except other mosasaurs",
+      "duration_sec": 8.1,
+      "speech_end_offset_ms": 7812.0,
+      "audio_hash_id": "fe1adb120f0258b4521aadc3768c8facf798cdd23a3f1778a750442b7c1698b7",
+      "condition_idx": 2,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0130.wav",
+      "sha256": "9d4ee18f905a5e0bee48f592a81d2375fc348962d2aead048c4e8b287e59ef2d",
+      "transcript": "most modern research telescopes are enormous facilities in remote areas with favorable atmospheric conditions",
+      "duration_sec": 7.84,
+      "speech_end_offset_ms": 7840.0,
+      "audio_hash_id": "d04778e5aeda6b01f05d24c0ee49b3b4f6ee078b9f611336090b74b29796a634",
+      "condition_idx": 1,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0131.wav",
+      "sha256": "b3e689a4ca4dc8ddb3840a166b6e9c1b696a923ac6377e65f683eb56a3a477d4",
+      "transcript": "most of the buildings on the edges of the complex have been rebuilt in order to give tourists a better idea of how they originally appeared",
+      "duration_sec": 8.82,
+      "speech_end_offset_ms": 8228.0,
+      "audio_hash_id": "89e8221ea28ba64e908f8dd6c6e44aede964b8eeefc75bdc5bc36894e9e97928",
+      "condition_idx": 2,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0132.wav",
+      "sha256": "7e21ac7a79c9015693f4ae28bfd5bf7b0ef8f3e4ea0ced63315b0901b5de8d43",
+      "transcript": "most of the smaller islands are independent nations or associated with france and known as luxury beach resorts",
+      "duration_sec": 11.52,
+      "speech_end_offset_ms": 11520.0,
+      "audio_hash_id": "4ee62c915afbe8ae4ed60df26ce184356c8d9a64e00d3d1c04d8ed34f8f93145",
+      "condition_idx": 1,
+      "condition_count": 4
+    },
+    {
+      "path": "audio/0133.wav",
+      "sha256": "f2033e79590b301aedfa6ffe3f1a6d05536ad4a2cb17c89675ca706f09d4becc",
+      "transcript": "ms is a disease that affects the central nervous system which is made up of the brain the spinal cord and the optic nerve",
+      "duration_sec": 8.2,
+      "speech_end_offset_ms": 8200.0,
+      "audio_hash_id": "ecb97c2f4532bc1e3abbf140934e7ced28c18ef6dbd9970f65b4e85a019a7208",
+      "condition_idx": 1,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0134.wav",
+      "sha256": "1574e3743872269335aa469e352be9202d05c7f10ed5978a9475bce7c37e63f8",
+      "transcript": "muhammad was deeply interested in matters beyond this mundane life. he used to frequent a cave that became known as  hira‘” on the mountain of  noor” light for contemplation",
+      "duration_sec": 12.28,
+      "speech_end_offset_ms": 10980.0,
+      "audio_hash_id": "3b9e03d0e322569c169ef62b43d2b490b01147ce0192ca9e37e34b40be3b4234",
+      "condition_idx": 1,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0135.wav",
+      "sha256": "3a2750297db607f1f18af6d8cf38f68df42cd9494a5ae0b38fbb7dd162451c3a",
+      "transcript": "needless to say if you know a romance language it will be easier for you to learn portuguese",
+      "duration_sec": 10.64,
+      "speech_end_offset_ms": 8388.0,
+      "audio_hash_id": "c2fe8c59971a9a8c0ed4816eecb8adcd81bd81afcd995743bbebf85bf8ab1c6f",
+      "condition_idx": 3,
+      "condition_count": 4
+    },
+    {
+      "path": "audio/0136.wav",
+      "sha256": "d2a8ecf4aa7b0befbf2b255b3ecea30a8fe1934dc794d0f88479f338003937f6",
+      "transcript": "nextgen is a system the faa claims would allow aircraft to fly shorter routes and save millions of gallons of fuel each year and cut carbon emissions",
+      "duration_sec": 12.08,
+      "speech_end_offset_ms": 10756.0,
+      "audio_hash_id": "2d519bbd067a774962556bc1a686212f8d45eec967fd613745450062b66ad555",
+      "condition_idx": 7,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0137.wav",
+      "sha256": "1c95e3d3c7bbfddb1384880b36da81f8e209c2ee94baeb5787add6721c5c9156",
+      "transcript": "no tsunami warning has been issued and according to the jakarta geophysics agency no tsunami warning will be issued because the quake did not meet the magnitude 6.5 requirement",
+      "duration_sec": 12.88,
+      "speech_end_offset_ms": 11716.0,
+      "audio_hash_id": "5adb4ba49be42c0921f9e3195ae28fc7d1b04f56ebdd3a81fb8ce6478b17806b",
+      "condition_idx": 5,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0138.wav",
+      "sha256": "c8f30c0687aa296e44da24bcf4aba37445c8a5c909d1879f982d108cf6446b24",
+      "transcript": "nothing can be seen other than the clear beautiful sky above and the many surrounding mountains very little of this world can be seen or heard from inside the cave",
+      "duration_sec": 10.08,
+      "speech_end_offset_ms": 9636.0,
+      "audio_hash_id": "731c937b86fedc5bb481c34d54127edf123c4dfe007bb56e7a141d99f0b5b5af",
+      "condition_idx": 0,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0139.wav",
+      "sha256": "e886819bde958319c36985362cf5b73dbbf262c57d3c7c1e08acfa362d15efaf",
+      "transcript": "on 15 august 1940 the allies invaded southern france the invasion was called operation dragoon",
+      "duration_sec": 11.12,
+      "speech_end_offset_ms": 10692.0,
+      "audio_hash_id": "b445ac8036eac2aa5ab4e6727bc21b0cdc3f460426812e3171fad776db724914",
+      "condition_idx": 1,
+      "condition_count": 4
+    },
+    {
+      "path": "audio/0140.wav",
+      "sha256": "b049d8b279979984187020ac6124ee94a22ee0a0901ab113e08d7c89ce411e44",
+      "transcript": "on some routes the larger companies have their own planes but for other routes and smaller firms there was a problem",
+      "duration_sec": 9.96,
+      "speech_end_offset_ms": 8164.0,
+      "audio_hash_id": "c0dadb5872c08fddeaa15e68603b6fef5fafdb537723952232ae75d5f85ba426",
+      "condition_idx": 4,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0141.wav",
+      "sha256": "e403f20c6c954e0514906e328ed4045a051d0ebef55f33e1def8a887353cb2ec",
+      "transcript": "on the other hand icy and snowy conditions are normal in many countries and traffic goes on mostly uninterrupted all year round",
+      "duration_sec": 11.72,
+      "speech_end_offset_ms": 9572.0,
+      "audio_hash_id": "fb518f084da74a661ca12abcb4ce88e302dd2309217875c400c62738264d1f7c",
+      "condition_idx": 3,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0142.wav",
+      "sha256": "7283cb974dfa3d3c41d24bb2092fcc69b74c488a349a9b3eadb41ba267496a62",
+      "transcript": "one bomb exploded outside the governor general's office",
+      "duration_sec": 7.24,
+      "speech_end_offset_ms": 6948.0,
+      "audio_hash_id": "4c25c8d6b0c733507528c7e7b0af3da3392b5d6ac55928ec87e3e2a522826917",
+      "condition_idx": 4,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0143.wav",
+      "sha256": "81dca15a78851cf8bd10025d1aeed84da2a511f9814565ab0faa54c7db2f47b8",
+      "transcript": "one can only wonder what the keyboard will become when something newer comes along",
+      "duration_sec": 6.06,
+      "speech_end_offset_ms": 5604.0,
+      "audio_hash_id": "4988ed0a32a1266fe5086ddecc2b1f1882d034d81a387509dbe514e9b5fce9f4",
+      "condition_idx": 0,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0144.wav",
+      "sha256": "111e0b37a26de91e1699ebdfbddf5e8d9d50f2e4e669817943107ae969b0971b",
+      "transcript": "only mutations in germ-line cells can be passed on to children while mutations elsewhere can cause cell-death or cancer",
+      "duration_sec": 12.18,
+      "speech_end_offset_ms": 9284.0,
+      "audio_hash_id": "bedb01d16f17b6f14851fbffe45520cc44e9749e3768d5d6faa7ef67ec7808de",
+      "condition_idx": 6,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0145.wav",
+      "sha256": "e85cbb49860fb0a97eba1ff78088dad70869ba9dd7dbebf656dba02226ca7536",
+      "transcript": "other subjects on the agenda in bali include saving the world's remaining forests and sharing technologies to help developing nations grow in less-polluting ways",
+      "duration_sec": 10.66,
+      "speech_end_offset_ms": 9540.0,
+      "audio_hash_id": "915ab35fab6a6f3329e536b9adcb1de9210da7de055128d87aadbfed6aabdf6f",
+      "condition_idx": 1,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0146.wav",
+      "sha256": "23253e6ae890a73a9c8ccde73df7a3475df111dfd32b18dad690f3ead90f37ab",
+      "transcript": "ottawa is canada's charming bilingual capital and features an array of art galleries and museums that showcase canada's past and present",
+      "duration_sec": 9.52,
+      "speech_end_offset_ms": 9252.0,
+      "audio_hash_id": "5a38c83e06c42b4d777538030fbfccf0e02b12a507859817bad33f52b9f36939",
+      "condition_idx": 1,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0147.wav",
+      "sha256": "933cb5d26bdd17bb6dfe5251398ce2e96b7eae7a93a9eeb91fd7dc2b503e91d6",
+      "transcript": "parisians have a reputation for being egocentric rude and arrogant",
+      "duration_sec": 8.54,
+      "speech_end_offset_ms": 7684.0,
+      "audio_hash_id": "427c007288520be3027a1d4c9de85f91bd2ad0d01b7df2a857bff48cc8c08728",
+      "condition_idx": 5,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0148.wav",
+      "sha256": "350df28fa42f16062c9864e7e7f01eae42bebbd0a409d278d5da060226b6044e",
+      "transcript": "people have known about basic chemical elements such as gold silver and copper from antiquity as these can all be discovered in nature in native form and are relatively simple to mine with primitive tools",
+      "duration_sec": 12.8,
+      "speech_end_offset_ms": 12800.0,
+      "audio_hash_id": "dbff2dbaa56d5090cb4fa0d9ea1104f34bc2d9757bd5147bce24f1fb67091978",
+      "condition_idx": 7,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0149.wav",
+      "sha256": "2f1d6c6b9b26a290e53300efae8546e495d9d673d94c313e7f1318290683d007",
+      "transcript": "people may not anticipate that patience and understanding are also necessary for travellers returning home",
+      "duration_sec": 6.54,
+      "speech_end_offset_ms": 6244.0,
+      "audio_hash_id": "5beda1387d88d7e3ad643a63fdf396956eb80b266d3a36061da38e60c76dfecd",
+      "condition_idx": 0,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0150.wav",
+      "sha256": "f1ef93a37a9252f3e842e2b0a036ea485f6e08995a4eab8d71b3cf566c15a295",
+      "transcript": "people now write messages on computer screens never having to come close to a sharpener",
+      "duration_sec": 9.8,
+      "speech_end_offset_ms": 9124.0,
+      "audio_hash_id": "e5b68b454c322b36399fab8e3ed8facc9ee5c35f01eb09db3b3b4e9b3c7016ba",
+      "condition_idx": 1,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0151.wav",
+      "sha256": "20be18397484309fbffec08e9da3cb261a8ed6a7f6a7a31262a92843e05a4456",
+      "transcript": "plants look their best when in a natural environment so resist the temptation to remove even just one specimen",
+      "duration_sec": 8.88,
+      "speech_end_offset_ms": 7908.0,
+      "audio_hash_id": "f8bc047f88d95d8679e41a2009191d00ae6bce9b82a527c48da007932971561c",
+      "condition_idx": 6,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0152.wav",
+      "sha256": "8576c1a7176e39cc8dbac318a89dcbe95667ff5257d70cb73122065cd6596d41",
+      "transcript": "plants make oxygen which humans breathe and they take in carbon-dioxide which humans exhale that is breathe out",
+      "duration_sec": 9.02,
+      "speech_end_offset_ms": 8548.0,
+      "audio_hash_id": "9e5904a4b2fcef71806d61ea1de09863989ea9f792d5a7d2dbc68a99b9ec69f4",
+      "condition_idx": 7,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0153.wav",
+      "sha256": "a716db3cbc0d6ff2b66ed1e5873402b72da2a40a33a946a70b76214964db9d11",
+      "transcript": "plants make their food from the sun by photosynthesis they also provide shade",
+      "duration_sec": 8.54,
+      "speech_end_offset_ms": 7460.0,
+      "audio_hash_id": "5df89fd7ad3c1ee427d408181d7cc44d86e002b890631286f555e8d86ccf4e92",
+      "condition_idx": 0,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0154.wav",
+      "sha256": "1428bedd73c20a73556563463a50e406545b04ee23738610da329aeae15057b1",
+      "transcript": "police superintendent chandra shekhar solanki said the accused appeared in court with covered faces",
+      "duration_sec": 7.8,
+      "speech_end_offset_ms": 7172.0,
+      "audio_hash_id": "49d7daf6e1d98a708e753154b7bc0cb5d703cf07f4a3dd8a4f2ccd287ac1968f",
+      "condition_idx": 4,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0155.wav",
+      "sha256": "160f343ddfcfc2ca5ad0b0a8a10d83d109a7683372a6c2e4b254785bd0f1ab0b",
+      "transcript": "popular sports include football basketball volleyball water-polo fencing rugby cycling ice hockey roller hockey and f1 motor racing",
+      "duration_sec": 10.5,
+      "speech_end_offset_ms": 10180.0,
+      "audio_hash_id": "f44ff0ff46b2083e4c95b214cf9e717e1d67b14198ccc68b46f35eee5b7b542d",
+      "condition_idx": 6,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0156.wav",
+      "sha256": "1d130305a766aeb23c296f4c0938ae83ee9fc846b2df89b8cda63e0189c171bc",
+      "transcript": "prides are made up of one to three related adult males along with as many as thirty females and cubs",
+      "duration_sec": 7.78,
+      "speech_end_offset_ms": 7460.0,
+      "audio_hash_id": "852eac01553272d3735393093f0a9618d2ce02675a98a4e8e99c404d58c20bca",
+      "condition_idx": 5,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0157.wav",
+      "sha256": "14a0e70c1ff8998dd3ed42afb43a1f8d2411af1b88d7c58b22fe072a18b5f1ce",
+      "transcript": "prior to the arrival of troops haiti had not encountered problems related to the disease since the 1800s",
+      "duration_sec": 7.98,
+      "speech_end_offset_ms": 6884.0,
+      "audio_hash_id": "86d2395105cdc8a685e9804c007a4a51ec03ce592094581e603ea4c31bef19f4",
+      "condition_idx": 0,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0158.wav",
+      "sha256": "6878a5d89c539c15871ba2609eb58e8cf2cc1ee9a6c88ad9a74fa0740b64edb9",
+      "transcript": "professor pamela ferguson of the university of dundee notes journalists do seem to be walking a dangerous line if publishing photos etc of suspects",
+      "duration_sec": 11.7,
+      "speech_end_offset_ms": 10468.0,
+      "audio_hash_id": "af225be70bbc7c2ce67cf94c6bbeff2973c66d1474de46c870f9d8218857fd3d",
+      "condition_idx": 6,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0159.wav",
+      "sha256": "50170e271c1c74e07d4b5c63876cbbc2859cb9749d4025b83df6ad69ce51f9dd",
+      "transcript": "re-entry shock comes on sooner than culture shock there's less of a honeymoon phase lasts longer and can be more severe",
+      "duration_sec": 9.18,
+      "speech_end_offset_ms": 8260.0,
+      "audio_hash_id": "f6ade5191e4a154e1e79a23e97376246bf122421113b016fc2cade36eab09224",
+      "condition_idx": 4,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0160.wav",
+      "sha256": "35268420ced498ad82fd7c330adc61a9a6386f06a97db292632d034361d16b23",
+      "transcript": "regional and seasonal severe weather phenomena include blizzards snowstorms ice storms and dust storms",
+      "duration_sec": 8.18,
+      "speech_end_offset_ms": 7684.0,
+      "audio_hash_id": "5a1715eb494b8cf576333ffe5b66678cc2914d0c1f3cc0a9af2568601b0f14f2",
+      "condition_idx": 0,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0161.wav",
+      "sha256": "b1b25c3eea6977e677e8b474b9077ab749638a224ee0bba58962a74be2ea53d8",
+      "transcript": "regular announcements in the metro are made only in catalan but unplanned disruptions are announced by an automated system in a wide variety of languages including spanish english french arabic and japanese",
+      "duration_sec": 12.52,
+      "speech_end_offset_ms": 12196.0,
+      "audio_hash_id": "8ecd2beef775218ce81186ce82cdee02d8845ea1bdd0a423891cdefd9d28a7e8",
+      "condition_idx": 5,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0162.wav",
+      "sha256": "041807a293093dd790ab752dc4276cb9da3bf9cad12a8314b3c8f58bb62dd22f",
+      "transcript": "remember that even though music on the main stages may have finished there may be sections of the festival that will keep playing music until late into the night",
+      "duration_sec": 13.1,
+      "speech_end_offset_ms": 12484.0,
+      "audio_hash_id": "67daba6d83d36e1a3d4be94c0f5de630d258daa41a09a8b49797ac16994fb650",
+      "condition_idx": 6,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0163.wav",
+      "sha256": "7758e7388a3f15dfb8f6340c6c019844707ca64ffadf8804a434ee1ac0b2f707",
+      "transcript": "resting on the top of one of the mountains north of mecca the cave is completely isolated from the rest of the world",
+      "duration_sec": 10.74,
+      "speech_end_offset_ms": 8612.0,
+      "audio_hash_id": "c828f78628df232620c3763258399700f531460adae0d7dd0145d7010d911115",
+      "condition_idx": 0,
+      "condition_count": 4
+    },
+    {
+      "path": "audio/0164.wav",
+      "sha256": "46f9674232878f67877cdf71899f54004561858f5415a0fd7e7adece7fd24a9f",
+      "transcript": "rip currents are the returning flow from waves breaking off the beach often at a reef or similar",
+      "duration_sec": 8.42,
+      "speech_end_offset_ms": 8420.0,
+      "audio_hash_id": "5a34afe3b998728c07a2f228d64e3ca14bc9a45c1d5330cd371c4aa4b811b1bd",
+      "condition_idx": 3,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0165.wav",
+      "sha256": "76c3a003ba72de4c1d9ee96d0258aea86edc23056e6d5205417f3829d118342b",
+      "transcript": "rolando mendoza fired his m16 rifle at the tourists",
+      "duration_sec": 7.0,
+      "speech_end_offset_ms": 6180.0,
+      "audio_hash_id": "a4e90d7bbef3866e44d270e374a3bc956401d29d25ca689b7d6fccac66e3c31f",
+      "condition_idx": 1,
+      "condition_count": 4
+    },
+    {
+      "path": "audio/0166.wav",
+      "sha256": "a1d57eff78d42d707fe80c345ef472924a0edf84e1a83581eb09d24d7744251a",
+      "transcript": "romanticism had a large element of cultural determinism drawn from writers such as goethe fichte and schlegel",
+      "duration_sec": 12.68,
+      "speech_end_offset_ms": 10404.0,
+      "audio_hash_id": "06f9164f68ad754641d9570822d31ef303277eb5896117d37177def6679d339a",
+      "condition_idx": 7,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0167.wav",
+      "sha256": "1ded821e8c5e379b9034bd64458fe15ebc7eefb44f0042cc8b3c1cef48182fc1",
+      "transcript": "saint petersburg cruises include time in town. cruise passengers are exempted from visa requirements check the terms",
+      "duration_sec": 8.7,
+      "speech_end_offset_ms": 8700.0,
+      "audio_hash_id": "3363e4e0c273384c7549cd575c72a8a2cd8bcb0f5476506903bf3fcd345fce6e",
+      "condition_idx": 6,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0168.wav",
+      "sha256": "3ff0d710c907fea3290c04d41f0399195095d92e4909efc18d0e064bbec9bfe5",
+      "transcript": "scaffolding is not a method of learning but rather an aid that provides support to individuals whom are undergoing a new learning experience such as using a new computer program or beginning a new project",
+      "duration_sec": 13.76,
+      "speech_end_offset_ms": 12772.0,
+      "audio_hash_id": "5d97bb5797b2e954e6e4680cdd9e400aa057c9ff2fb850c23dbcfbd075c58408",
+      "condition_idx": 7,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0169.wav",
+      "sha256": "548ac9570c5444dfc17394d1113be00de40662fea7e6fa63e0288821cc214d43",
+      "transcript": "scientists hope to understand how planets form especially how the earth formed since comets collided with the earth long ago",
+      "duration_sec": 7.18,
+      "speech_end_offset_ms": 6788.0,
+      "audio_hash_id": "607f61886bbb6f138ef287f6098535a959957753f26dec9ca3c2064f841a8772",
+      "condition_idx": 1,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0170.wav",
+      "sha256": "1446daa6b10e001da51d7aa3576ca052343a55164b322cc77d1375c30d5bb816",
+      "transcript": "scotturb bus 403 travels regularly to sintra stopping at cabo da roca",
+      "duration_sec": 12.16,
+      "speech_end_offset_ms": 11652.0,
+      "audio_hash_id": "069edddd9fbd530844f7b94f0a67584e2e9ba96762521c6e103319359374d787",
+      "condition_idx": 4,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0171.wav",
+      "sha256": "69f39b0f099f6b576d540498810656794a8c87ff4a63e1ddd5d81534d0b0b346",
+      "transcript": "segregation and recombination shuffle variation back and forth between the two pools with each generation",
+      "duration_sec": 12.52,
+      "speech_end_offset_ms": 11012.0,
+      "audio_hash_id": "551698ba3998984788cf61c87a70dc3d9a20e39f35833d69d88f33cdd1608e4c",
+      "condition_idx": 1,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0172.wav",
+      "sha256": "9d2480b228d23ffa6598a1f61ef590ac2e64b8218baa5b0b01370990aace3672",
+      "transcript": "several large television screens were installed in various places in rome to let the people watch the ceremony",
+      "duration_sec": 11.26,
+      "speech_end_offset_ms": 9412.0,
+      "audio_hash_id": "33780c4360625f8f2cbea4d040bb345b9bc3f7f2f8f6c4ca1184e45d355b8711",
+      "condition_idx": 1,
+      "condition_count": 4
+    },
+    {
+      "path": "audio/0173.wav",
+      "sha256": "7c95270f705073f2fb11d4c029eae8aa705e85f2eec71fb95332fbf442321d9f",
+      "transcript": "severe weather is the generic term for any dangerous weather phenomenon with the potential to cause damage serious social disruption or loss of human life",
+      "duration_sec": 12.8,
+      "speech_end_offset_ms": 11556.0,
+      "audio_hash_id": "06cfd858c07f40f04c0c12bb0155495d25223b38e0836daa39d1c861dff921c9",
+      "condition_idx": 3,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0174.wav",
+      "sha256": "d7283ca6e2be394853f291ffb05b3cc0fca0e0478fc4900915cda9ea6c77ebe0",
+      "transcript": "sharing a field trip virtually is also a great way to reflect a on a trip and share experiences with future classes",
+      "duration_sec": 8.68,
+      "speech_end_offset_ms": 7780.0,
+      "audio_hash_id": "728372373494d20b54026271df4a7776368e818104f6bac0b0cad5077cd27c39",
+      "condition_idx": 5,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0175.wav",
+      "sha256": "6f613319dbe1cdf072ea897d63039dc95725a5374c11c73421490d178c5273fd",
+      "transcript": "since the foundation of asunción in 1537 paraguay has managed to keep a lot of its indigenous character and identity",
+      "duration_sec": 12.42,
+      "speech_end_offset_ms": 10212.0,
+      "audio_hash_id": "6b506f8565d097ecdc65961e12f139811af875598e30df6ef69a6f49bc6211f3",
+      "condition_idx": 0,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0176.wav",
+      "sha256": "54bfdcddb614b1586dd5dfaf69489d9f7706afd30ba6a2607eab826d46683a4a",
+      "transcript": "six hostages including the children and elderly were released early as were the filipino photographers",
+      "duration_sec": 9.76,
+      "speech_end_offset_ms": 9028.0,
+      "audio_hash_id": "a97a4abda4b44e96b32bc5bc88f1452a57b4cbe190afd90381bf39e5e92e7881",
+      "condition_idx": 0,
+      "condition_count": 4
+    },
+    {
+      "path": "audio/0177.wav",
+      "sha256": "c98d3a8bc11c9e6cf4a85ee8e8de0a9d45f59cc0f48103531390453e7011abb3",
+      "transcript": "so it is likely that the notation was added simply as a label",
+      "duration_sec": 7.86,
+      "speech_end_offset_ms": 6468.0,
+      "audio_hash_id": "3b331074014f10ebd60604db7c90cb0e1cff4444d918494367305883be43f1e2",
+      "condition_idx": 3,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0178.wav",
+      "sha256": "a28aeab9b9171b47bd40c517cea7da5fd23f6c35607137e2467e2196966f8db2",
+      "transcript": "some atoms have unstable nuclei which means that they tend to break apart with little or no nudging",
+      "duration_sec": 8.12,
+      "speech_end_offset_ms": 7684.0,
+      "audio_hash_id": "e4e8b0e1c8580be44de6fd4b5925c383101ae1769d8d5b0772fe37ddd64ce1fd",
+      "condition_idx": 3,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0179.wav",
+      "sha256": "ce2d31a9b773589c012209d072a6ea313307a7d5dc86312b457543ddaac07f83",
+      "transcript": "some cruises feature berlin germany in the brochures as you can see from the map above berlin is no where near the sea and a visit to the city is not included in the price of the cruise",
+      "duration_sec": 12.8,
+      "speech_end_offset_ms": 11876.0,
+      "audio_hash_id": "d88b5c80435ba2ab5ee80692fd5c9906fcc090279a6b8075aa5a9db422368013",
+      "condition_idx": 7,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0180.wav",
+      "sha256": "1de6efb649fa11c7090e7055ea688ed1acb357d43337533162c87749488d03e0",
+      "transcript": "some people thought he was right but many people believed the opposite; that the solar system moved around the earth including the sun and even the other stars",
+      "duration_sec": 8.34,
+      "speech_end_offset_ms": 8068.0,
+      "audio_hash_id": "4fa85aa55a2aa94caffe2374444b00742181f9103a11b9e30b3e32a77b01cfa3",
+      "condition_idx": 0,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0181.wav",
+      "sha256": "c4346e91b9a585ce6122864747f6dc2957be6d192b156452a57d2022151cdbd1",
+      "transcript": "soon after the outbreak of hostilities britain initiated a naval blockade of germany",
+      "duration_sec": 6.66,
+      "speech_end_offset_ms": 6340.0,
+      "audio_hash_id": "12661872d2de487cb747ae2c5b16dd803933c3bbce8062552a8a7c3155fc472c",
+      "condition_idx": 6,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0182.wav",
+      "sha256": "a603b5ac343f4afdc46773e575de33d734fa89279c8876cf0d6b6c3786892722",
+      "transcript": "still take advice from authorities obey all signs and pay close attention to safety warnings",
+      "duration_sec": 9.84,
+      "speech_end_offset_ms": 8548.0,
+      "audio_hash_id": "d11bff5e9f170774cc34a196e5eb8e49ff0d1b92c4034950f786c5b6167e0f24",
+      "condition_idx": 2,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0183.wav",
+      "sha256": "28ac81a2e2555a96e1602d933b3cde013ee4b0b4ecaaea0117d3e68981bca2e4",
+      "transcript": "swirl the two dry powders together and then with clean wet hands squeeze them into a ball",
+      "duration_sec": 9.56,
+      "speech_end_offset_ms": 8548.0,
+      "audio_hash_id": "c71eba0e6907c9b9dff1d4ae233edd1f7f1fcc407f7be149dbe2eb5a35954e8f",
+      "condition_idx": 6,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0184.wav",
+      "sha256": "0fa181f7ac462182d95e8615fb9d47d234017e8631950d5e0553d6be16fe3a79",
+      "transcript": "television reports show white smoke coming from the plant",
+      "duration_sec": 6.04,
+      "speech_end_offset_ms": 4612.0,
+      "audio_hash_id": "bc05f0670d774a4ab3563d17d09d4ad05f9fccf7248c45bfc2868d79b51f012d",
+      "condition_idx": 1,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0185.wav",
+      "sha256": "5d459a4a39d41c44eb88d6ff45e1339c6edd3960a2976c233f283e2800ab8f51",
+      "transcript": "the 25 dunlap broadsides still known to exist are the oldest surviving copies of the document the original handwritten copy has not survived",
+      "duration_sec": 10.44,
+      "speech_end_offset_ms": 9508.0,
+      "audio_hash_id": "fd8be8233d14401e5fdda8357a8c0917920c8ed7df0508f23a466e55704f65bd",
+      "condition_idx": 4,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0186.wav",
+      "sha256": "323e0677024a10af1dde94c089ded7c19cae5ae367fda8c2805f686f725c651f",
+      "transcript": "the 802.11n standard operates on both the 2.4ghz and 5.0ghz frequencies",
+      "duration_sec": 13.0,
+      "speech_end_offset_ms": 11780.0,
+      "audio_hash_id": "8a270e89737ef3965c4c1679f59e2ed73ecee1123a77e75e00fd34cea9797df0",
+      "condition_idx": 1,
+      "condition_count": 4
+    },
+    {
+      "path": "audio/0187.wav",
+      "sha256": "0520834290ad5cd376f7d8eec19d7f91c9bb35dbb274ad3ba0ea16ede4c9cd43",
+      "transcript": "the announcement was made after trump had a phone conversation with turkish president recep tayyip erdoğan",
+      "duration_sec": 11.4,
+      "speech_end_offset_ms": 9796.0,
+      "audio_hash_id": "ac9ae86ee87330a2c29be38d6fc99fbbf39571dbf2fd0da06460eb8ef3219f92",
+      "condition_idx": 0,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0188.wav",
+      "sha256": "d2d1aff1b1b068f622553f2fbe7f01234c8271753c2abec0431a51d61761f019",
+      "transcript": "the aspect ratio of this format dividing by twelve to obtain the simplest whole-number ratio is therefore said to be 3:2",
+      "duration_sec": 11.64,
+      "speech_end_offset_ms": 10980.0,
+      "audio_hash_id": "e0c8d5f2dea33c7d8cb9d7bfea3f795ac7f3fea90272ec18cea15da69060f214",
+      "condition_idx": 4,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0189.wav",
+      "sha256": "52471781f8c385e83c28980903e7cfb50d6c56f3e16599d73b831019081d3735",
+      "transcript": "the bridge is scheduled to be fully operational in september 2017 when the brazilian customs checkpoints are expected to be finished",
+      "duration_sec": 10.28,
+      "speech_end_offset_ms": 9380.0,
+      "audio_hash_id": "030ae9c45bc56722a58ed300278116f5b99a413ec109057a05cf281324032317",
+      "condition_idx": 7,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0190.wav",
+      "sha256": "a0884c644388ef6a40e25427d3ffa031658ff27c1fe0c0532740a1743cdd8de2",
+      "transcript": "the cabbage juice changes color depending on how acidic or basic alkaline the chemical is",
+      "duration_sec": 6.36,
+      "speech_end_offset_ms": 5988.0,
+      "audio_hash_id": "431194e7df1f522c7aee4032fe22075e130219a16bd3bb11a9b91bcdf765644b",
+      "condition_idx": 4,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0191.wav",
+      "sha256": "e73dcc1947eca2fa1d111d826695631d15973e2560d6d110a6ec35a11f72fc64",
+      "transcript": "the capital of moldova is chişinău. the local language is romanian but russian is widely used",
+      "duration_sec": 8.6,
+      "speech_end_offset_ms": 8356.0,
+      "audio_hash_id": "bcac4b66fc1056932c2cdaca0843789f31b4d0ee07903f68769917fe3d5d41ec",
+      "condition_idx": 3,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0192.wav",
+      "sha256": "1e82134f6e66539265381fdd913645c67805d35785ec5a07ba8df0cae5b363b7",
+      "transcript": "the central authority of the church had been in rome for over a thousand years and this concentration of power and money led many to question whether this tenet was being met",
+      "duration_sec": 10.24,
+      "speech_end_offset_ms": 9796.0,
+      "audio_hash_id": "2b34f2323062b7c6eff50901b465266a98b144170820aa6465b279b1cdc14d91",
+      "condition_idx": 5,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0193.wav",
+      "sha256": "a3901e71e1013a0f01d4f086f4d8194530e478b55c34cfefcdd0e4e4cc3cfb7c",
+      "transcript": "the city is also the base to climb the nyiragongo volcano along with some of the cheapest mountain gorilla tracking in africa",
+      "duration_sec": 13.28,
+      "speech_end_offset_ms": 11844.0,
+      "audio_hash_id": "4ee75a42d8a98ee517a3347d2a4628434dce6d48b735067a0bca33caca784b2b",
+      "condition_idx": 3,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0194.wav",
+      "sha256": "8a0d25a9d7fc577bad356ab6911bee3471134578ef11886ab5f87c57574e2ad4",
+      "transcript": "the city is in stark contrast to the rest of the country's cities because it has more of an arabic flair than of an african",
+      "duration_sec": 7.32,
+      "speech_end_offset_ms": 7044.0,
+      "audio_hash_id": "eb9f86df3ab9a01454908e284f26474fcb13d43b694f091db7637d578a5cd3c6",
+      "condition_idx": 0,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0195.wav",
+      "sha256": "2ef7678b1c0cc5f11429167b188d09069ea6ce51463e9ce91ddab159310412f0",
+      "transcript": "the commission was martelly's response to widespread anti-regime protests that started in october",
+      "duration_sec": 9.52,
+      "speech_end_offset_ms": 8452.0,
+      "audio_hash_id": "c0b76c95e8c77e4ba66b043b15d729323a5f1860743637a186a8dbaa44a51f48",
+      "condition_idx": 1,
+      "condition_count": 4
+    },
+    {
+      "path": "audio/0196.wav",
+      "sha256": "7baa1377cc7326f76c385799be8b252294aaf478097210a9896897ed7707f5e4",
+      "transcript": "the composition of these crystals matches those found in the urine of affected pets when compared by infrared spectroscopy ftir",
+      "duration_sec": 13.88,
+      "speech_end_offset_ms": 12676.0,
+      "audio_hash_id": "263f61ad53cde814cf7741008109ac193d846ca158d962686497661399871f69",
+      "condition_idx": 3,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0197.wav",
+      "sha256": "2cb05b6f6bef4a705ccd953241f4f9ff585e41ac3ebecca056aeebf929cd026e",
+      "transcript": "the correlation between brain pathology and behaviour supports scientists in their research",
+      "duration_sec": 8.36,
+      "speech_end_offset_ms": 7044.0,
+      "audio_hash_id": "b28e20e009c4f49e569cdeaa96f6bc473dda04daea9ae34fb63aebaabaaa33fc",
+      "condition_idx": 7,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0198.wav",
+      "sha256": "323db8834274db192626402de3b7c72aff564eabdd6923d71a33a4c867c2d092",
+      "transcript": "the crash occurred high up in mountainous terrain and is believed to have been the result of hostile fire",
+      "duration_sec": 10.42,
+      "speech_end_offset_ms": 9188.0,
+      "audio_hash_id": "6a1e3cb24c71630305c92202c8e250f5a41496861fcf0665ad40fbcefdafcb9b",
+      "condition_idx": 0,
+      "condition_count": 4
+    },
+    {
+      "path": "audio/0199.wav",
+      "sha256": "a6ac2d4c946ae212e5f5d3dfbc451c5b474bb6bd5bc31d2c9f017226459a4315",
+      "transcript": "the crust is about 70 km thick on the near side and 100 km thick on the far side",
+      "duration_sec": 9.68,
+      "speech_end_offset_ms": 8324.0,
+      "audio_hash_id": "839e69965d7b1e1849057735954ae23b7f1a576a401109bacf77c33e9e5c138e",
+      "condition_idx": 3,
+      "condition_count": 4
+    },
+    {
+      "path": "audio/0200.wav",
+      "sha256": "ceedc8096522854dd841e1ce2432099092c685e20a2ccaab626e39ad5d66e341",
+      "transcript": "the debate was sparked by controversy over spending on relief and reconstruction in the wake hurricane katrina which some fiscal conservatives have humorously labeled bush's new orleans deal",
+      "duration_sec": 13.56,
+      "speech_end_offset_ms": 12484.0,
+      "audio_hash_id": "b03b67982cbe97214b5f56c0e4de615f9480905c6e531e326163729ab7034dc3",
+      "condition_idx": 2,
+      "condition_count": 4
+    },
+    {
+      "path": "audio/0201.wav",
+      "sha256": "522c15bd3e3eeaf74014acd28222d25764ea5206cfc72a638104392eca1f2650",
+      "transcript": "the disease is carried by pigs which then migrates to humans through mosquitos",
+      "duration_sec": 6.6,
+      "speech_end_offset_ms": 6276.0,
+      "audio_hash_id": "b17b7a6d57e7359c41a58fc7b750953c9a430e96c8cbcce7ca7be127551738fd",
+      "condition_idx": 2,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0202.wav",
+      "sha256": "b7cd579b807ccb0f382be5b78005e55acde04037368830ae0ed2b1ff97c0b029",
+      "transcript": "the document according to the leak will refer to the borders dispute which palestine wants based on the borders before the 1967 mideast war",
+      "duration_sec": 8.88,
+      "speech_end_offset_ms": 8484.0,
+      "audio_hash_id": "6fcd43e9af16cfd1c5d8c71956fdd5f77f7c9c90bf60e554020eb26a8acb8751",
+      "condition_idx": 0,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0203.wav",
+      "sha256": "1bbab3cccb11877e7050853ceb9b3c6709523de7a5d2eb327b095f2392d2e4e6",
+      "transcript": "the find also grants insight into the evolution of feathers in birds",
+      "duration_sec": 6.62,
+      "speech_end_offset_ms": 6620.0,
+      "audio_hash_id": "05fd622845d6562edfd749b638b882c4322b778d4d02582d78783a256d511278",
+      "condition_idx": 3,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0204.wav",
+      "sha256": "9f1c451fdfbf0d873bfaad741930cf619968b6160e938e894235672464081640",
+      "transcript": "the fission bomb works on the principle that it takes energy to put together a nucleus with many protons and neutrons",
+      "duration_sec": 7.5,
+      "speech_end_offset_ms": 7268.0,
+      "audio_hash_id": "ee4f551c424b46543714de3d971017082d0ee64317700b9b934fa6a105e70f2c",
+      "condition_idx": 2,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0205.wav",
+      "sha256": "e1af55bd83b169a45c5776c60fcb872fc8a6f79d003bfe59c2f185afd535e22b",
+      "transcript": "the governor's office said nineteen of the injured were police officers",
+      "duration_sec": 8.46,
+      "speech_end_offset_ms": 5924.0,
+      "audio_hash_id": "ce7fa986a6bd9968b38708e3579c2214405776950a8d4189ad0b1a390c58f67e",
+      "condition_idx": 6,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0206.wav",
+      "sha256": "278c9f638dd044a7256a59c5cef17adf6347e2668f5a221a815bd4cec05f9b76",
+      "transcript": "the great pyramid at giza is the only one of the seven wonders that is still standing today",
+      "duration_sec": 7.06,
+      "speech_end_offset_ms": 6148.0,
+      "audio_hash_id": "6efce73fcf94e122f02cb92f2c4707cbc615f043249ea516543c424a483de9ff",
+      "condition_idx": 5,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0207.wav",
+      "sha256": "cc707bac69830b2bff03381097b75cfdb442f1ad8d18f203138e7994115a69de",
+      "transcript": "the haitian institute for justice and democracy has referenced independent studies that suggest the nepalese un peacekeeping battalion unknowingly brought the disease to haiti",
+      "duration_sec": 12.24,
+      "speech_end_offset_ms": 12240.0,
+      "audio_hash_id": "9491464fe5adf59ff7d88f64357fefba47670ab9be3e01e40a3259f07b814963",
+      "condition_idx": 6,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0208.wav",
+      "sha256": "b82c3e1b7e3419bbdc0ac4106428cf4dd6498fee9957e1909bda92f64fece6c9",
+      "transcript": "the hospital has followed protocol for infection control including separating the patient from others to prevent possible infection of others",
+      "duration_sec": 12.42,
+      "speech_end_offset_ms": 11748.0,
+      "audio_hash_id": "13cea7a8c274fbd3dd732d92d5b438cda1e76f555c2442c0947863601b3aa8e1",
+      "condition_idx": 1,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0209.wav",
+      "sha256": "d3842c345e88fa9047af945c227a63866904d4f7ffc12970cb96159e9e83db06",
+      "transcript": "the hot chocolate is up to belgian standards fruit juices are pricey but excellent",
+      "duration_sec": 7.42,
+      "speech_end_offset_ms": 7012.0,
+      "audio_hash_id": "782d207b3748545d36686829e9cf36cfbb68aeaf93c378837f6346f8b7a664a8",
+      "condition_idx": 5,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0210.wav",
+      "sha256": "414fb374da01d5e83592964de58c5d7f35e739436934f14731ef6f7caa54f709",
+      "transcript": "the internet combines elements of both mass and interpersonal communication",
+      "duration_sec": 6.92,
+      "speech_end_offset_ms": 6692.0,
+      "audio_hash_id": "7412c1b4cbcca8f69dd5bf7130e76e3df47ce7b3dd6b21d47711a914b026eb55",
+      "condition_idx": 6,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0211.wav",
+      "sha256": "1383149b45375c15b417dee92d1ddb5add72cc4b877785861e5857352934f266",
+      "transcript": "the lower the tension the more positive the life force present every person has the potential to find absolute peace and contentment",
+      "duration_sec": 11.4,
+      "speech_end_offset_ms": 10948.0,
+      "audio_hash_id": "2a618192f9daf1719f35fe7ef3282a7dc5ef2924aad75ad01f6643f49a945e4a",
+      "condition_idx": 1,
+      "condition_count": 4
+    },
+    {
+      "path": "audio/0212.wav",
+      "sha256": "750435d1e453401ffffbea50803492c89d3278217679403162871e8ab131b0fb",
+      "transcript": "the moisture on your hands will react with the outer layers which will feel funny and form a sort of shell",
+      "duration_sec": 10.52,
+      "speech_end_offset_ms": 10520.0,
+      "audio_hash_id": "7ea8d38ce79e40f6ede77d9b637b7ff0540de16a5f245ede706c91360209d308",
+      "condition_idx": 3,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0213.wav",
+      "sha256": "69dea2afffe2fe4504e7dbfbaf82c844cf32b5186868ea2223a470861b1c5c5d",
+      "transcript": "the moroccan sultan rebuilt the city as daru l-badya and it was given the name casablanca by spanish traders who established trading bases there",
+      "duration_sec": 13.52,
+      "speech_end_offset_ms": 12612.0,
+      "audio_hash_id": "424fcc50cfd32998408d39caa5107d931af68dbaf8b9d48836b752eede846602",
+      "condition_idx": 3,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0214.wav",
+      "sha256": "19de551062120b8b2e6d47164a1c3d1e758fcbfa4761b8dd884447bd1ff3772e",
+      "transcript": "the northern marianas emergency management office said that there were no damages reported in the nation",
+      "duration_sec": 12.8,
+      "speech_end_offset_ms": 9220.0,
+      "audio_hash_id": "81879fa14f7ae9395d453366aa32804ad9de0d1a8f87e699d02271f9275b033f",
+      "condition_idx": 3,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0215.wav",
+      "sha256": "18f13dbcccb3e013eaa284e2749376df6b0d7b1e079ec50e826de1bb08ace2ee",
+      "transcript": "the number of people present was so large that it was not possible for everybody to gain access to the funeral in st peter's square",
+      "duration_sec": 10.86,
+      "speech_end_offset_ms": 9156.0,
+      "audio_hash_id": "41151e40f036210eee149e7200a8f293b5dc2f7e5cd357b5bdc4f998c7180ea6",
+      "condition_idx": 2,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0216.wav",
+      "sha256": "da7729c68ce3e05e259027452da3c0d8889afeb0d82a68ec16459cf8893ea1e1",
+      "transcript": "the official falklands currency is the falkland pound fkp whose value is set equivalent to that of one british pound gbp",
+      "duration_sec": 10.68,
+      "speech_end_offset_ms": 10680.0,
+      "audio_hash_id": "cfa1d22c8707f3b90f44dfd5373623597a5eab902f9bd1eb0c0a472c52a0ff74",
+      "condition_idx": 4,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0217.wav",
+      "sha256": "391b8d894d5e150cca279e09f28973790259a0ec93fb91200cf5f0e7f41bbb8f",
+      "transcript": "the ph level is indicated by the amount of hydrogen the h in ph ions in the tested chemical",
+      "duration_sec": 7.8,
+      "speech_end_offset_ms": 7332.0,
+      "audio_hash_id": "8aea057690175aa624f551c8c86a9d4d4d667a67bf0ac654129daf43959d01a3",
+      "condition_idx": 6,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0218.wav",
+      "sha256": "e5d46dbbc67b954f84a9dc59b470f4a0ddb37511ef643ece48a62a1ddbcc7160",
+      "transcript": "the photographers later took the place of an aged lady as she needed the lavatory mendoza was gunned down",
+      "duration_sec": 9.82,
+      "speech_end_offset_ms": 8964.0,
+      "audio_hash_id": "f1a839ee405424df69a6a8275102e1275e72e26f9d0e1d4524509c851db5dd0f",
+      "condition_idx": 6,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0219.wav",
+      "sha256": "48dcf377aae137a456533f83a3b8768e5225e8525b376684d2494e493d82a813",
+      "transcript": "the presence of a true  invisible team” larson and lafasto 1989 p109 is also a unique component of a virtual team",
+      "duration_sec": 13.94,
+      "speech_end_offset_ms": 12708.0,
+      "audio_hash_id": "bd325652d0ffacf2e5e48ce198a6cf9a1232ad6444becaf70bd94f6ec08f3c29",
+      "condition_idx": 7,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0220.wav",
+      "sha256": "a87d49bbab97d12a749ea5d820ef0a88d0b30eadd7aa5aef26f70438b9ec2481",
+      "transcript": "the pyramid sound and light show is one of the most interesting things in the area for kids",
+      "duration_sec": 8.94,
+      "speech_end_offset_ms": 8132.0,
+      "audio_hash_id": "47baf3d68b9492ca26f0f3ca402412a92073d7e69631746b32ecaba74da5255f",
+      "condition_idx": 4,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0221.wav",
+      "sha256": "f85a4b64014d4c84c97963fe2c28a15bb0f771bbab6a59cccbf21ddb31bde89e",
+      "transcript": "the report is highly critical of almost every aspect of the present policy of the executive towards iraq and it urges an immediate change of direction",
+      "duration_sec": 9.84,
+      "speech_end_offset_ms": 9840.0,
+      "audio_hash_id": "56f39cb472f5e08566d50d5f4f1839a6494831c6d3958b5f42b6524f85fdf887",
+      "condition_idx": 2,
+      "condition_count": 4
+    },
+    {
+      "path": "audio/0222.wav",
+      "sha256": "0fd3ca329a4c386fc7523210a5cc1fb8fe3738dff01cc1c1525b049fba653c90",
+      "transcript": "the ruling party south west africa people's organisation swapo also retained a majority in the parliamentary elections",
+      "duration_sec": 11.24,
+      "speech_end_offset_ms": 10564.0,
+      "audio_hash_id": "3f884e58dd4f493270675458fa3e6d45cc22832f46cdc9267c0d3c928c7b0e4d",
+      "condition_idx": 4,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0223.wav",
+      "sha256": "830de05b29ed0e25e5687f9a38c92dd825720080a2090e2fa7aa44cc6a937393",
+      "transcript": "the same month saw another airliner overrun a runway at mashhad and strike a wall killing seventeen",
+      "duration_sec": 7.68,
+      "speech_end_offset_ms": 7396.0,
+      "audio_hash_id": "077edd230f2f12f8ed408ca5620059c1ea7eb9614b310986ede745a293c4106f",
+      "condition_idx": 6,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0224.wav",
+      "sha256": "990b8cb0f06a0d892b13b6c5852ae14db999bf94271c8d314f44a9d439fd733b",
+      "transcript": "the scenes are displayed on the pyramids and the different pyramids are lit up",
+      "duration_sec": 5.52,
+      "speech_end_offset_ms": 5124.0,
+      "audio_hash_id": "e5d76a33d02d76c15bc677ddf589d70cd72707f1a9383eeef3d95d65191c2c77",
+      "condition_idx": 2,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0225.wav",
+      "sha256": "2df3d0028902c7d43c1c9ce464497fd8bfaea14b53bf336586775142b2e3ed3f",
+      "transcript": "the schengen zone however works somewhat like one country in this respect",
+      "duration_sec": 8.8,
+      "speech_end_offset_ms": 8260.0,
+      "audio_hash_id": "d87daca1ab8772eae5b3a706afc84410d1d8aeae7cfc6c7e80d77b54968cd668",
+      "condition_idx": 3,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0226.wav",
+      "sha256": "590d0c213e7c8e36b35088fc1887d7f1945135f8548b3ac582a75fbb1c3c349b",
+      "transcript": "the scientists were able to conclude that the dark matter affect other dark matter in the same way regular matter does",
+      "duration_sec": 14.12,
+      "speech_end_offset_ms": 13124.0,
+      "audio_hash_id": "dd26bc777a2f214100392a18d943975bfea3c8e9e22338417c4549137bc4ef7a",
+      "condition_idx": 3,
+      "condition_count": 4
+    },
+    {
+      "path": "audio/0227.wav",
+      "sha256": "5d3c27ed7a463c3aae3e3754b5e9cf887a4287301e28389d1d96e5d0b131796f",
+      "transcript": "the service is frequently used by shipping including pleasure craft as well as expeditions who have remote data and voice needs",
+      "duration_sec": 12.28,
+      "speech_end_offset_ms": 9700.0,
+      "audio_hash_id": "381838e98957a531deeafcb8d6f08672b8021d9ffb2ebbcba70073ac5a3ddfdc",
+      "condition_idx": 5,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0228.wav",
+      "sha256": "4a963e54cbed7607082e0140b310a457421a69ec44e20b1aac73847b735d0aa2",
+      "transcript": "the smaller the rossby number the less active the star with respect to magnetic reversals",
+      "duration_sec": 7.64,
+      "speech_end_offset_ms": 7396.0,
+      "audio_hash_id": "7074fa34342a34bd8eb9c6f0a939a89d5f2cf1651e4e47784f4a0bf1584b84b6",
+      "condition_idx": 3,
+      "condition_count": 4
+    },
+    {
+      "path": "audio/0229.wav",
+      "sha256": "c100bf050083ba8fd7c8e7dbe85f6fb5936560d05bcbbce17b0f677e43feb820",
+      "transcript": "the sundarbans are the largest littoral mangrove belt in the world stretching 80 km 50 mi into the bangladeshi and indian hinterland from the coast",
+      "duration_sec": 11.4,
+      "speech_end_offset_ms": 10180.0,
+      "audio_hash_id": "5f94a84dd62f700444ff31aca44958ece604cf81093257ad0f139298d3f68c5a",
+      "condition_idx": 2,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0230.wav",
+      "sha256": "19528c47789d5d6d39e36ceacc794d03c1650291faaf83f4744da52a3a0e883c",
+      "transcript": "the sundarbans has been declared a unesco world heritage site the part of the forest within indian territory is called sundarbans national park",
+      "duration_sec": 12.88,
+      "speech_end_offset_ms": 10884.0,
+      "audio_hash_id": "81cd19b4560a7fc2091eac7ec586bc7f35338c03cd69a6fb44a053d54375a90f",
+      "condition_idx": 1,
+      "condition_count": 4
+    },
+    {
+      "path": "audio/0231.wav",
+      "sha256": "59b0f9a15640f5bad511d1e09b028aad2aff9ae204044ad2c002ac2dff940081",
+      "transcript": "the surface of the moon is made of rocks and dust the outer layer of the moon is called the crust",
+      "duration_sec": 6.24,
+      "speech_end_offset_ms": 5860.0,
+      "audio_hash_id": "3cc65541390f6b09eb4facccff912af271813214212d5431b317eebe3a70829d",
+      "condition_idx": 4,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0232.wav",
+      "sha256": "9da4799c4928a4acef402205edfaf494ffab7957e81298c99aff3e4fdbbc48a5",
+      "transcript": "the tenth named storm of the atlantic hurricane season subtropical storm jerry formed in the atlantic ocean today",
+      "duration_sec": 9.66,
+      "speech_end_offset_ms": 8644.0,
+      "audio_hash_id": "9d0fd14f333b38e9469ba0ac2e7da7073186b1a3220194449bf27ebf9abbca0d",
+      "condition_idx": 5,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0233.wav",
+      "sha256": "d3d5e31441a88dc7c3dac285bbad8bc20554cfb02e2e2ae3bf4fa7cd856862f8",
+      "transcript": "the term bug is used by entomologists in a formal sense for this group of insects",
+      "duration_sec": 8.48,
+      "speech_end_offset_ms": 6980.0,
+      "audio_hash_id": "0d3650a04b386227e5102337f652604b6a0626b0ddbfc53eb66e1bbfe39cf1b3",
+      "condition_idx": 7,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0234.wav",
+      "sha256": "9e0a0c3f561a38473bb62b18044dad61dc2b6b7232fa1a5e9895ebe1c6a4663b",
+      "transcript": "the term safari in popular use refers to overland travel to view the stunning african wildlife particularly on savanna",
+      "duration_sec": 9.84,
+      "speech_end_offset_ms": 8996.0,
+      "audio_hash_id": "52dcf1e5877d1fc6ee453d4a373cb3043ecec01c3b7372358be426d6c57a5283",
+      "condition_idx": 2,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0235.wav",
+      "sha256": "90adaacdc69f38fb4f55ee8d289df4239f3d770bbc20b899a7386267e73db51d",
+      "transcript": "the three kingdoms was one of the bloodiest eras in ancient china's history thousands of people died fighting to sit in the highest seat in the grand palace at xi'an",
+      "duration_sec": 13.08,
+      "speech_end_offset_ms": 11844.0,
+      "audio_hash_id": "7f2d6e540ff5f5de192e15e0ee8b91167768101bc7db43f8a743f9fd90c90141",
+      "condition_idx": 2,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0236.wav",
+      "sha256": "428784c8f6cff247362d91a9f98604fb7955c49abed478e8f01697fbd5334837",
+      "transcript": "the tiger's roar is not like the full-voiced roar of a lion but more like a sentence of snarly shouted words",
+      "duration_sec": 9.76,
+      "speech_end_offset_ms": 8132.0,
+      "audio_hash_id": "840e07da38990c236f44be87283661ca8d75c93d430c0096ea3eaf5216cea7f6",
+      "condition_idx": 5,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0237.wav",
+      "sha256": "f2803932a7ef8dc21089d30a78a2637465177bad9fad019288978805955d49d7",
+      "transcript": "the two compounds react with one another to form crystals that may block kidney function researchers at the university said",
+      "duration_sec": 8.04,
+      "speech_end_offset_ms": 7012.0,
+      "audio_hash_id": "71434aff05700c934c2852891cc36e533f750c05162dc485156852df3db85d04",
+      "condition_idx": 4,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0238.wav",
+      "sha256": "e5985bd26c4c83968849140b3f07df485460479bb2d04fe470aed5b952f720cf",
+      "transcript": "the u.s. corps of engineers estimated that 6 inches of rainfall could breach the previously damaged levees",
+      "duration_sec": 9.96,
+      "speech_end_offset_ms": 8996.0,
+      "audio_hash_id": "95dadfa10d52831ad343e3fe047ba3d0f71355617822f0b346d1372873b8becc",
+      "condition_idx": 2,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0239.wav",
+      "sha256": "b4cdb56da06b10b329447886a516b27707eabbfdbc5b9c89b1add9f416352919",
+      "transcript": "the use of video recording has led to important discoveries in the interpretation of micro-expressions facial movements which last a few milliseconds",
+      "duration_sec": 13.54,
+      "speech_end_offset_ms": 12900.0,
+      "audio_hash_id": "ffd983015185e01bf9f76273d7f4a821532f74e681c6e5ecfa628e0c0d8bebb7",
+      "condition_idx": 7,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0240.wav",
+      "sha256": "b84c6aa7e1d51a7fdf91b54dd1eb2e368303246b84d1431818e77e9c558f5460",
+      "transcript": "the vehicle itself was taken away from the scene of the accident at approximately 1200 gmt on the same day",
+      "duration_sec": 9.58,
+      "speech_end_offset_ms": 8740.0,
+      "audio_hash_id": "99a33f7cffd6649ffe450c109a0d9e1c602a5f7fa54d86f03ec959a7faacf1e8",
+      "condition_idx": 5,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0241.wav",
+      "sha256": "f7ee37c766bdc0f46cb1b953b40124f909c3e19f05b493f3fe7bb5c911cb2e29",
+      "transcript": "the vertical clearance under the bridge is 15 meters construction was completed in august 2011 it didn't open to traffic until march 2017",
+      "duration_sec": 10.84,
+      "speech_end_offset_ms": 9860.0,
+      "audio_hash_id": "31efa11e0c541ee6e39106f057f2f6d0ebe7d394c4cff94218b7edfa8e37a98d",
+      "condition_idx": 5,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0242.wav",
+      "sha256": "b3318523e0b1bda0139d0c99565bfcdfd3aef33160a9921fe958e657b88c1638",
+      "transcript": "the work done was mostly theoretical but the program was written to simulate observations made of the sagittarius galaxy",
+      "duration_sec": 11.4,
+      "speech_end_offset_ms": 9348.0,
+      "audio_hash_id": "e83ab13ef6021d83db24736de9f3971b1ac8cda095fbe3de65d7a58ff1bcd157",
+      "condition_idx": 4,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0243.wav",
+      "sha256": "fd6d3c47ecea002dfac7ffd92521c634193afb215ebad3facad25057259b1512",
+      "transcript": "their disciplined defence ball handling skills and excellent team work made them stand out and it was clear that this was the team to beat",
+      "duration_sec": 8.86,
+      "speech_end_offset_ms": 7940.0,
+      "audio_hash_id": "6b2cff13eb8cde0c65ff38ba28bf993686a95ff0c18dddaad600cb142049c61c",
+      "condition_idx": 5,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0244.wav",
+      "sha256": "0d5ad45864677b05ad2ddc2e7ac028f14aadae07d3066c811fd31bbd9abbf9a0",
+      "transcript": "there are of course christian theological explanations for this tradition but it may well be a pre-christian spring and fertility ritual",
+      "duration_sec": 11.36,
+      "speech_end_offset_ms": 11360.0,
+      "audio_hash_id": "78203678642f0460dcde28b5fabd99158bdcbb105205a80d2110754150b7f866",
+      "condition_idx": 7,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0245.wav",
+      "sha256": "92c5dcf0680ed940650e50e687488322153264bef6f943d3ae6da5eb985c43dd",
+      "transcript": "there are still many men and women alive who survived their time here and many more who had loved ones who were murdered or worked to death there jews and non-jews alike",
+      "duration_sec": 11.7,
+      "speech_end_offset_ms": 10532.0,
+      "audio_hash_id": "8a70c97ec203e2efb2c80c585f7d0c353ef82587680cf66a0ce9618c041bebe0",
+      "condition_idx": 0,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0246.wav",
+      "sha256": "4dd24d406ea52968784ab14b5753b280a4a27ae6d2824d85881d66d1e1d3537f",
+      "transcript": "there is no universal definition for which manufactured items are antiques some tax agencies define goods older than 100 years as antiques",
+      "duration_sec": 13.8,
+      "speech_end_offset_ms": 12676.0,
+      "audio_hash_id": "1fdb7c81616dd664e93ded8aa920edce96074293a3c9eed9bd0f3b5ff3d044f4",
+      "condition_idx": 7,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0247.wav",
+      "sha256": "bd6a8be45e55fe90ef044eaffe7852f9ff1435483002487c2ce7d041f2c3b0fb",
+      "transcript": "there may be more maria on the near side because the crust is thinner it was easier for lava to rise up to the surface",
+      "duration_sec": 9.56,
+      "speech_end_offset_ms": 8932.0,
+      "audio_hash_id": "fed5ab494b3482ed196a1a3c27393b6fe9f4fce87908ec8b02a3fca657a41ff5",
+      "condition_idx": 4,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0248.wav",
+      "sha256": "1bfd2e94a70436f0088a83f235540893f7efb215ab8de6b8dfa92f1006c328ef",
+      "transcript": "these are sometimes-crowded family beaches with a good range of shops lining the shore swimming is safe",
+      "duration_sec": 12.5,
+      "speech_end_offset_ms": 9828.0,
+      "audio_hash_id": "71d04c1601059ae610442d87ade16068d98c205b53996c5b312ae98cd56602d1",
+      "condition_idx": 3,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0249.wav",
+      "sha256": "2c834565c5e389b715b53f350fb6e26df55b73a0945a0ab25dce403105421f6d",
+      "transcript": "these couples may choose to make an adoption plan for their baby",
+      "duration_sec": 8.04,
+      "speech_end_offset_ms": 7172.0,
+      "audio_hash_id": "b912c1bb40b6d86b22f6613f95f170eba849bd46a0cacdb3cf5adc1d1fffc8f4",
+      "condition_idx": 6,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0250.wav",
+      "sha256": "4c52335e777cc42b6fe41ca1245798f93edc93de59da40021ff69b736435fc5d",
+      "transcript": "they are almost all sandy beaches with safe swimming and most have shade provided by pohutukawa trees",
+      "duration_sec": 9.66,
+      "speech_end_offset_ms": 8676.0,
+      "audio_hash_id": "885036c38977e0dcd6c2d3b4078a38502768753b02a4498188ad5206017fb42b",
+      "condition_idx": 2,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0251.wav",
+      "sha256": "8b04b2ca66334f7fd0b37507d2348f10679616d683d55d4cff76f4de3f129b92",
+      "transcript": "they have feet with scales and claws they lay eggs and they walk on their two back legs like a t-rex",
+      "duration_sec": 7.86,
+      "speech_end_offset_ms": 7860.0,
+      "audio_hash_id": "a62da697a00d8dacaebdc827d121add0944b9d81118981d0a73d4aa21f00a231",
+      "condition_idx": 2,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0252.wav",
+      "sha256": "2745f2ad2fee071d5fa416a618bb5e78547783e3239c5d5d26151e4a472858b2",
+      "transcript": "they usually have special food drink and entertainment offers to keep guests in a good mood and keep them at the premise",
+      "duration_sec": 8.96,
+      "speech_end_offset_ms": 7780.0,
+      "audio_hash_id": "e7200fd687b218bede50e89292f6cd80b771a59c9532a8d0890c0cf59fe1c1c7",
+      "condition_idx": 3,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0253.wav",
+      "sha256": "f81b7de822cc4012dbe1476ec6ca2de9b0f463baaa4b6dcdc2fb13af7a5be155",
+      "transcript": "think of the skiing route as of a similar hiking route",
+      "duration_sec": 5.94,
+      "speech_end_offset_ms": 5316.0,
+      "audio_hash_id": "d108be5d77844150c59c6bfb998622a176be070c74c057885c1df2f33f88d176",
+      "condition_idx": 5,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0254.wav",
+      "sha256": "910081a8e568fabc969fd19bf9667dc0a404a4ac7ed64755e8b88d34b570c133",
+      "transcript": "this is an important way to distinguish between some verbs and objects",
+      "duration_sec": 5.7,
+      "speech_end_offset_ms": 5412.0,
+      "audio_hash_id": "ed67fef0f5bfb4a23eee7771773bb077e2e4c194760155ee0b89ec7615a363af",
+      "condition_idx": 2,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0255.wav",
+      "sha256": "e5263ded8b8ac33d322bd886d3aaa16664750b3109ab3a4483e8f524386e2688",
+      "transcript": "this is called a chemical's ph you can make an indicator using red cabbage juice",
+      "duration_sec": 6.88,
+      "speech_end_offset_ms": 5668.0,
+      "audio_hash_id": "b09294baff95817dc6a6291643aeb080540340a70d4f73319bde25606757856a",
+      "condition_idx": 1,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0256.wav",
+      "sha256": "f7562a51c3b3e2c9b8e696fd8e75d74cc162759d7d738dbb55bd5dde4843f48b",
+      "transcript": "this is not going to be goodbye this is the closing of one chapter and the opening of a new one",
+      "duration_sec": 6.88,
+      "speech_end_offset_ms": 5828.0,
+      "audio_hash_id": "7d0f8f947a366f32a95a63aabaeeeb38a1409ef3ac376c2c7b828a0073bd2877",
+      "condition_idx": 1,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0257.wav",
+      "sha256": "d23871036618be963f28014f243a5595d9a6f9482118f3ce7bed59b6799e2ef8",
+      "transcript": "this offers a good opportunity to see the aurora borealis as the sky will be dark more or less around the clock",
+      "duration_sec": 7.92,
+      "speech_end_offset_ms": 7588.0,
+      "audio_hash_id": "c173ce12ab07bfef2b1756061c96162c6c284948f1ea59c8aeef3984db26301a",
+      "condition_idx": 2,
+      "condition_count": 4
+    },
+    {
+      "path": "audio/0258.wav",
+      "sha256": "2152ebb11eac2e85958b31fb67885d494430c46fcd51b1d7d6ef4a9a075318ab",
+      "transcript": "this sediment was necessary for creating sandbars and beaches which served as wildlife habitats",
+      "duration_sec": 11.82,
+      "speech_end_offset_ms": 10116.0,
+      "audio_hash_id": "f5a24dd137a3ca66c1999ae46f6dd94bbedd4c6419a2be7f687bc74696fa4bf4",
+      "condition_idx": 0,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0259.wav",
+      "sha256": "75c63b45fec92ad3dcada94c6f51930de1d0fb95771d9cc4ae62389bcde96704",
+      "transcript": "this seems sensible because the earth doesn't feel as if it's moving does it",
+      "duration_sec": 6.84,
+      "speech_end_offset_ms": 5860.0,
+      "audio_hash_id": "088a305f6b47ce20d4b81e8ffcefdffafb0342274dceb9559e3f8ff59ce7318e",
+      "condition_idx": 2,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0260.wav",
+      "sha256": "9108800be575d477de6424948609ac433b6b4c450c0f0b4c96a6307ed93ac0ee",
+      "transcript": "this will allow players to control actions and movements in video games by moving the device through the air",
+      "duration_sec": 6.76,
+      "speech_end_offset_ms": 6760.0,
+      "audio_hash_id": "0553cb428c142996cedbb4f5374c612590675031576ae7d0520e62f9a6cdcbba",
+      "condition_idx": 1,
+      "condition_count": 4
+    },
+    {
+      "path": "audio/0261.wav",
+      "sha256": "9972ac35f38925eb2057e28606cd91adaaebf97006fd1c636d57645c5e9aa299",
+      "transcript": "through the night between 150 and 200 copies were made now known as dunlap broadsides",
+      "duration_sec": 5.4,
+      "speech_end_offset_ms": 5400.0,
+      "audio_hash_id": "56f0ba3c3708c2da64bb49787322acdf477332f7e7839ce24028e0f6f0964663",
+      "condition_idx": 0,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0262.wav",
+      "sha256": "aec051a821ed510109f2c49ab3b188a48958de3b67ea522062dac70ac8533c83",
+      "transcript": "throughout 1960s brzezinski worked for john f kennedy as his advisor and then the lyndon b johnson administration",
+      "duration_sec": 9.76,
+      "speech_end_offset_ms": 8068.0,
+      "audio_hash_id": "9fca796bf16984fa314263b67823d508e5d19e7a7a620edef4607dc9ed372c82",
+      "condition_idx": 1,
+      "condition_count": 4
+    },
+    {
+      "path": "audio/0263.wav",
+      "sha256": "db3e4092925842e1983eeed0b3da46c34bd4d560476df2dcbb5fed651a034e7b",
+      "transcript": "thus the pencil was a good friend to many people when it came out",
+      "duration_sec": 5.16,
+      "speech_end_offset_ms": 4836.0,
+      "audio_hash_id": "4763749f410d5e108f30af525ad735f44d6e7f231df238e3142d69fdf66d2f04",
+      "condition_idx": 2,
+      "condition_count": 4
+    },
+    {
+      "path": "audio/0264.wav",
+      "sha256": "e504c5ea58762605b0c7c962502d17509777580049f0667cdb78f867bc7f9e4b",
+      "transcript": "to get the best views of hong kong leave the island and head for the kowloon waterfront opposite",
+      "duration_sec": 7.5,
+      "speech_end_offset_ms": 6468.0,
+      "audio_hash_id": "d2dbbda311dadac6c615468f14c2fd49c64397be802a8d42d35dfcd80d6439ef",
+      "condition_idx": 0,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0265.wav",
+      "sha256": "321bfd7c7e63291ce7002928977d07d7f1154c333c954b1cc7a20e0a698657c1",
+      "transcript": "to the north and within easy reach is the romantic and fascinating town of sintra and which was made famous to foreigners after a glowing account of its splendours recorded by lord byron",
+      "duration_sec": 12.66,
+      "speech_end_offset_ms": 12164.0,
+      "audio_hash_id": "3b0480c259f5875527e8d19650b58ce8560026e5cd083613a215f54acd6cfc41",
+      "condition_idx": 6,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0266.wav",
+      "sha256": "5269f3629f871313fb7666d31a5068715943a5f0af9a086a97222c4022fbe685",
+      "transcript": "today the only insects that cannot fold back their wings are dragon flies and mayflies",
+      "duration_sec": 6.54,
+      "speech_end_offset_ms": 5572.0,
+      "audio_hash_id": "a22b32c6d213d0c275d15401312011184914fcfaeb55fa4cabb997eacc4a11a3",
+      "condition_idx": 0,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0267.wav",
+      "sha256": "908400c9e2bd26cab9c5e8b1291a4b19c369048031a96ebea18908f22c0de87a",
+      "transcript": "traffic flow is the study of the movement of individual drivers and vehicles between two points and the interactions they make with one another",
+      "duration_sec": 9.68,
+      "speech_end_offset_ms": 9444.0,
+      "audio_hash_id": "862c826cf1f86726e3151158a1fb837650b6db64fe4cdd34ee14d3e1b6992ab4",
+      "condition_idx": 3,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0268.wav",
+      "sha256": "a69791ec7afe8c4db72d959b98f62ef7698d35bd2f3348c5bf619a9525ab5bd3",
+      "transcript": "travellers are strongly advised to be aware of any risk of severe weather affecting their area as they may affect any travel plans",
+      "duration_sec": 9.32,
+      "speech_end_offset_ms": 9320.0,
+      "audio_hash_id": "906c800fc3d5b413ab975131dde06f145b0edd8db4d71c70cbf345355fb00737",
+      "condition_idx": 3,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0269.wav",
+      "sha256": "153574fd0b36c5676a312d3016555c38525d3452e58b4cf28dee4166965636f7",
+      "transcript": "travellers bound for countries with heavy taxation can sometimes save a considerable amount of money especially on products such as alcoholic beverages and tobacco",
+      "duration_sec": 12.38,
+      "speech_end_offset_ms": 11268.0,
+      "audio_hash_id": "f4d4e6c11f95b6aee4b7433e21ff02acfcdbba0a2689178569ed32e086aba49e",
+      "condition_idx": 3,
+      "condition_count": 4
+    },
+    {
+      "path": "audio/0270.wav",
+      "sha256": "7fac6438913305131bad76a2b50b30843b0a15071529b85f496210966d57f037",
+      "transcript": "twentieth century research has shown that there are two pools of genetic variation hidden and expressed",
+      "duration_sec": 7.96,
+      "speech_end_offset_ms": 7076.0,
+      "audio_hash_id": "3640c1d9660a9e06ff4d8136b562d651e025c04aa3c55b166e769a8e57d58150",
+      "condition_idx": 5,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0271.wav",
+      "sha256": "f7270bc59e1396216f0afb634eea97565faeccc0cf9f33e425c78f051171f1f2",
+      "transcript": "using ships to transport goods is by far the most efficient way to move large amounts of people and goods across oceans",
+      "duration_sec": 8.62,
+      "speech_end_offset_ms": 7876.0,
+      "audio_hash_id": "5e1bd54de9a42da06908e10ce853f843da049bff5e8bcec7417f47d02a4de8fd",
+      "condition_idx": 1,
+      "condition_count": 4
+    },
+    {
+      "path": "audio/0272.wav",
+      "sha256": "c1f2c009ecabd8243ce3c10c14025586fd5d11cd36ac6773506332763d345233",
+      "transcript": "usually you always here the sound of tourists and vendors the story of the sound and light is just like a story book",
+      "duration_sec": 9.38,
+      "speech_end_offset_ms": 7972.0,
+      "audio_hash_id": "2e8ad1fd20f159eff22afebd1c03c43e4ad9619b8a366bbf2f19044d504d5d14",
+      "condition_idx": 3,
+      "condition_count": 4
+    },
+    {
+      "path": "audio/0273.wav",
+      "sha256": "3255127574c15a82fb882eeeeac3b787adb4155b0ac7a7fd59c0ff6f880314aa",
+      "transcript": "vatican city's population is around 800 it is the smallest independent country in the world and the country with the lowest population",
+      "duration_sec": 11.74,
+      "speech_end_offset_ms": 8356.0,
+      "audio_hash_id": "f91e4f05ccde0114539560569b47a7e769322eec361bbb749f79569e4ba759fb",
+      "condition_idx": 1,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0274.wav",
+      "sha256": "6501c1abf5cb081ae6c1bb851314bf01735b90d335fe503ccff77c92f35f974b",
+      "transcript": "virtual scaffolds are internalized in the software and are meant to question prompt and explain procedures that may have been to challenging for the student to handle alone",
+      "duration_sec": 10.92,
+      "speech_end_offset_ms": 10468.0,
+      "audio_hash_id": "ddb5d893a07d0a9a1de1b6af66fb41a74871ec06581c9ad165ecc29ac3e49867",
+      "condition_idx": 6,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0275.wav",
+      "sha256": "357347deb9778c258fea238334a187366d21a33bc2809af8778909aa7decabc9",
+      "transcript": "virtual teams are held to the same standards of excellence as conventional teams but there are subtle differences",
+      "duration_sec": 6.64,
+      "speech_end_offset_ms": 6340.0,
+      "audio_hash_id": "2c346faef9ded6219b178f620ad2471e870ba856ba310302dc7b005ad3f8aaf2",
+      "condition_idx": 5,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0276.wav",
+      "sha256": "2d6a0deeea603ed9e31f08d3e76aa5097bbd78169339dbee74bd84b13bfd5fb8",
+      "transcript": "we make our houses from plants and make clothes from plants most foods that we eat are plants without plants animals could not survive",
+      "duration_sec": 9.92,
+      "speech_end_offset_ms": 9920.0,
+      "audio_hash_id": "fa0b2f1c443737f97e62c2b96d5d48c8bcf7b1cebbd53c60fded3970da9a5006",
+      "condition_idx": 7,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0277.wav",
+      "sha256": "8d56e8563d40a7391cf4f709aa8b1eb6a7d393f05590be96c9ff36de0109dde9",
+      "transcript": "when all available resources are effectively used across the functional departments of an organization creativity and ingenuity can transpire",
+      "duration_sec": 9.78,
+      "speech_end_offset_ms": 8836.0,
+      "audio_hash_id": "106fa12a548e8810e766ab0d46c8ce3c18a0f3a07cde5d6627415d9fca64592c",
+      "condition_idx": 0,
+      "condition_count": 4
+    },
+    {
+      "path": "audio/0278.wav",
+      "sha256": "b6e0079a3ded79db7da34fa33d77e5000f28acccc03a5d982d935b6bd51de177",
+      "transcript": "while goma is reasonably safe any visits outside of goma should be researched to understand the state of the fighting that persists in the north kivu province",
+      "duration_sec": 11.84,
+      "speech_end_offset_ms": 11204.0,
+      "audio_hash_id": "50574497ae3af8487fc1f6f550d18b74dd51574ad04e1dc830f95be75f448c7a",
+      "condition_idx": 3,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0279.wav",
+      "sha256": "821d342b54e1793a778b735358c4292e726b28431a1a91e915a906618c44f39d",
+      "transcript": "while he was working at the hospital liggins began to investigate premature labor during his spare time",
+      "duration_sec": 6.66,
+      "speech_end_offset_ms": 6404.0,
+      "audio_hash_id": "d103e0d579fd38a649525f5b197fe8a09f61c025d50a3ba38df8f1034c7afdbf",
+      "condition_idx": 2,
+      "condition_count": 4
+    },
+    {
+      "path": "audio/0280.wav",
+      "sha256": "81f29b085f752a9c0c618a325dab1da533619b651cf0c4ba3587384693a1efc4",
+      "transcript": "while one experimental vaccine appears able to reduce ebola mortality up until now no drugs have been clearly demonstrated suitable for treating existing infection",
+      "duration_sec": 14.0,
+      "speech_end_offset_ms": 13540.0,
+      "audio_hash_id": "73963858f726cb36e44b4e36a3f64b843de46a2f323893effaf77bcc7ce5cbf4",
+      "condition_idx": 3,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0281.wav",
+      "sha256": "b906ef9f1cea220cedb5d54c6eef7abdecd5eb92de5383bbac3378d0b8eab595",
+      "transcript": "with kundalini yoga the kundalini energy enlightenment energy is awakened through yoga postures breathing exercises mantras and visualizations",
+      "duration_sec": 12.24,
+      "speech_end_offset_ms": 11300.0,
+      "audio_hash_id": "1b9bbbfae2d0685d974768dfac9b9a0856768df928a5568b89086e9f73d4d6df",
+      "condition_idx": 6,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0282.wav",
+      "sha256": "349aea33b40c5418f07f2f15cbfac7d72a3b408eee34f168c8dc1f960616379a",
+      "transcript": "with two years of the end of the war the former allies were now enemies and the cold war began",
+      "duration_sec": 8.68,
+      "speech_end_offset_ms": 7172.0,
+      "audio_hash_id": "323e56c1e59faf46ffc8ed67a609c27150c00d576f2f207078b9e44720f58dcc",
+      "condition_idx": 1,
+      "condition_count": 4
+    },
+    {
+      "path": "audio/0283.wav",
+      "sha256": "866dafe32edfd560dc74321ae30b4f0583349751e7b8abb3a54be3e5063662e4",
+      "transcript": "women it is recommended that any women travellers say that they are married regardless of actual marital status",
+      "duration_sec": 12.14,
+      "speech_end_offset_ms": 11108.0,
+      "audio_hash_id": "41d3e07c25188493a7e2b8b3c1003031880796e4a97a23698053c7740e752f25",
+      "condition_idx": 7,
+      "condition_count": 8
+    },
+    {
+      "path": "audio/0284.wav",
+      "sha256": "994f43c02b4815b1daeb2fbc12fa9a327d385a5b639a1b5ebd48aaa94ffaa657",
+      "transcript": "you may also wish to consult the advice of governments other than your own but their advice is designed for their citizens",
+      "duration_sec": 9.34,
+      "speech_end_offset_ms": 7524.0,
+      "audio_hash_id": "5093364caab74979b21314c67ea12683579d1b0d4d2715b9248ecb9ac699a6e0",
+      "condition_idx": 5,
+      "condition_count": 8
+    }
+  ]
+}

--- a/runner/src/coval_bench/datasets/manifests/stt-wildasr-phonecodec.json
+++ b/runner/src/coval_bench/datasets/manifests/stt-wildasr-phonecodec.json
@@ -1,0 +1,2849 @@
+{
+  "_license": "Apache-2.0 (WildASR; audio derived from FLEURS, CC-BY-4.0)",
+  "id": "stt-wildasr-phonecodec",
+  "version": "1.0.0",
+  "license": "Apache-2.0 (WildASR; audio derived from FLEURS, CC-BY-4.0)",
+  "source": "bosonai/WildASR environment_degradation__en__fleurs_phone_codec_en",
+  "items": [
+    {
+      "path": "audio/0001.wav",
+      "sha256": "f6dddeaaa6e2f182b22cc7678098d22f1f5237e67000260f1bdca53e1d832d83",
+      "transcript": "\"he [wales] basically lied to us from the start. first by acting as if this was for legal reasons. second by pretending he was listening to us right up to his art deletion.",
+      "duration_sec": 12.36,
+      "speech_end_offset_ms": 11364.0,
+      "audio_hash_id": "b8728d8af468d5bef7713c12beae550afbdb8a53b463bffccafa1ace85311978",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0002.wav",
+      "sha256": "9cb30a9bbb7b7ac1fce52b630f2aa3609a91b48552037dae4ae200ce3c3221f4",
+      "transcript": "a car bomb detonated at police headquarters in gaziantep turkey yesterday morning killed two police officers and injured more than twenty other people",
+      "duration_sec": 10.02,
+      "speech_end_offset_ms": 8644.0,
+      "audio_hash_id": "aee0ce833558674d4e2c05a8f176cf4ab32aec6c602971a505b3a899912c9d95",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0003.wav",
+      "sha256": "2020302d43e477fb56ad01c6c15f8ec297fbebf8354a20d41436df0974bb35f3",
+      "transcript": "a civilization is a singular culture shared by a significant large group of people who live and work co-operatively a society",
+      "duration_sec": 8.88,
+      "speech_end_offset_ms": 7716.0,
+      "audio_hash_id": "37b913573846e9d5f002ea8958a4649a6ca16cef7c439d618ed8d154077652fe",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0004.wav",
+      "sha256": "7a752ed747698fb9d456b839f1220252952a0c4a0dc5a0a1c0d9a7f63d7e9233",
+      "transcript": "a curry is a dish based on herbs and spices together with either meat or vegetables",
+      "duration_sec": 9.06,
+      "speech_end_offset_ms": 7396.0,
+      "audio_hash_id": "4b309fd30943294a931d9657c5a33c02ca7db70482f0ca19b9e069947eccf279",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0005.wav",
+      "sha256": "6b2a47acc3e41e46afbedc44e1d522f4fe805adf3c9bc7160eafa30a8330a5e6",
+      "transcript": "a full 20% of the water that pours out of the planet's rivers into the oceans comes from the amazon",
+      "duration_sec": 7.32,
+      "speech_end_offset_ms": 6628.0,
+      "audio_hash_id": "b3aafd4b7f0a4e8416c6b3fe12aa583cfedb26ad24e93e703da6306a1fcd16a1",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0006.wav",
+      "sha256": "69829727a31a9f9cab78fd4b114cd1e586adca26be531561fb3838210b50f5a0",
+      "transcript": "a search of the internet for hostile environment course' will probably provide the address of a local company",
+      "duration_sec": 7.2,
+      "speech_end_offset_ms": 6180.0,
+      "audio_hash_id": "f2c5e1810108b2719508df1e3094d2aa9863f4728e7ef68abbf5c7476b7a106d",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0007.wav",
+      "sha256": "4481a815983e9a2b95ab0326198666d5f077244972b1cd787231954f09d25ba7",
+      "transcript": "a simple popular dinner especially during the summer is the pa amb oli bread with olive oil tomato and any available condiments such as cheese tunafish etc",
+      "duration_sec": 12.24,
+      "speech_end_offset_ms": 11236.0,
+      "audio_hash_id": "c32af75a4b56736c6bce3906eb9449f02a21ef1f0eed3133f8af9399cb9f3bc9",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0008.wav",
+      "sha256": "abd7029d3c9f40166bde01a701f9cc0ef8ecda52004a7b6719223a4c72144e48",
+      "transcript": "a well rounded athlete the tiger can climb though not well swim leap great distances and pull with five times the force of a strong human",
+      "duration_sec": 10.2,
+      "speech_end_offset_ms": 9252.0,
+      "audio_hash_id": "9a6dd3aa0946a0ed30e9c6ec3fb9a97452c89202ad821beb258a962872cf3a95",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0009.wav",
+      "sha256": "4236ba991a7930d5ca2c6651741eb68971bac78adfd2ec336dd9d87e823afe32",
+      "transcript": "accepted were aristotle's views on all matters of science including psychology",
+      "duration_sec": 6.72,
+      "speech_end_offset_ms": 4804.0,
+      "audio_hash_id": "90307c7a4639777523b7c07865c643cb679b476490937af0b087a75a1cd09acc",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0010.wav",
+      "sha256": "2476690336d06823c00dc81ea6bc872ea3dd340bd30d8975795741ba4591b70f",
+      "transcript": "according to japan's nuclear agency radioactive caesium and iodine has been identified at the plant",
+      "duration_sec": 7.38,
+      "speech_end_offset_ms": 6244.0,
+      "audio_hash_id": "88f2c21af73e47c268b21b7f3ddc5a4a132bc4325d4f71fc720d1fdafad2ab5c",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0011.wav",
+      "sha256": "8e82a6627a0e38ebb01be1fa711cb67cf8f947c4861683f90f76fb20fa24fdc9",
+      "transcript": "aerosmith have cancelled their remaining concerts on their tour",
+      "duration_sec": 3.96,
+      "speech_end_offset_ms": 3620.0,
+      "audio_hash_id": "48d8b04c5e0e260a85c3254795b733c809edd92eab43cac41a9eaf433a881b4d",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0012.wav",
+      "sha256": "ae8856b67e5d52092e22619c2bc84b76b0320c3aafa04f796a9ad37a1247d7a4",
+      "transcript": "after the accident occurred gibson was transported to a hospital but died shortly afterwards",
+      "duration_sec": 6.24,
+      "speech_end_offset_ms": 5412.0,
+      "audio_hash_id": "402c14f71000eb09552c75714788852d335d707553d9f9cea0c5392676f38338",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0013.wav",
+      "sha256": "503a4a7b9b27956ecafa28af618541406a88b01564a239009acf3a823b71afe4",
+      "transcript": "after the dam was built in 1963 the seasonal floods that would spread sediment throughout the river were halted",
+      "duration_sec": 9.24,
+      "speech_end_offset_ms": 7524.0,
+      "audio_hash_id": "ae52670820247c604937208da6713038775b5c8702e25ee5292069570726365d",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0014.wav",
+      "sha256": "b0a062aac9fe570f74e52fc511a94a25ea03d50b593831df24dc35d0ae0b447a",
+      "transcript": "all nouns alongside the word sie for you always begin with a capital letter even in the middle of a sentence",
+      "duration_sec": 8.76,
+      "speech_end_offset_ms": 7876.0,
+      "audio_hash_id": "f81784a7758af5cd4cc2bce7b6d5fcc92a7b87295751c2e58491cc62772a3232",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0015.wav",
+      "sha256": "5e2f952ba4343c015dfdd12c3111dc534ed83213c4f8003af7037011c01d3216",
+      "transcript": "all things considered we should not be surprised if our own ancestors solved their protein problem in somewhat the same way that chimps on the savanna do today",
+      "duration_sec": 9.48,
+      "speech_end_offset_ms": 8484.0,
+      "audio_hash_id": "ad5968c54e0c5c5d0d78e8d376b0a77cf912f4dba977e68655a0438e409906ca",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0016.wav",
+      "sha256": "21d219e623ff6ea8b495fa752815f8ea23b282835dc127863e392ae5b0c1f68f",
+      "transcript": "alloys are basically a mixture of two or more metals don't forget that there are many elements on the periodic table",
+      "duration_sec": 8.38,
+      "speech_end_offset_ms": 7236.0,
+      "audio_hash_id": "3bef379d989022ce00681aa285ffc5ae19414faf2771541ad64d4b486b7c4da3",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0017.wav",
+      "sha256": "1364a46b0970bae4946909deab9fa678f58d7c37e1dd139217104648b23e1930",
+      "transcript": "along the same line men are required to wear trousers covering the knees",
+      "duration_sec": 6.0,
+      "speech_end_offset_ms": 5060.0,
+      "audio_hash_id": "c3c24f626573dd663cda5e5e6205ad785888ad6ce16b6b73149c1ddba8e018eb",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0018.wav",
+      "sha256": "6c13b52886aa063506e2fa8b4e19d52355aae0f2a9a0eb376fbd91a2a3df7855",
+      "transcript": "also after the revolution occupations were open to all male applicants allowing the most ambitious and successful to succeed",
+      "duration_sec": 7.02,
+      "speech_end_offset_ms": 6692.0,
+      "audio_hash_id": "bbea070bfaca290f641fbf8b267fe3b10f6e063ebeb8b7aa293c399108ed5b3c",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0019.wav",
+      "sha256": "3295406183832278815d31a5a72037934bd5c781e0fa9b070e908c434cfc71b4",
+      "transcript": "also between each dynasty was an unstable age of divided provinces the best-known of these periods was the three kingdoms epoch taking place for 60 years between the han and the jin dynasty",
+      "duration_sec": 11.82,
+      "speech_end_offset_ms": 11332.0,
+      "audio_hash_id": "20e7bfe17aaceb97507577255d81ce73f000abb133191d92be758f6c3798b2fc",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0020.wav",
+      "sha256": "d1371e4ce3bb729729f21b7a74ff9a09b804340f17c0dc78d4586f20d903e2d3",
+      "transcript": "also to the north visit the great sanctuary of our lady of fatima shrine a place of worldwide famous marian apparitions",
+      "duration_sec": 7.56,
+      "speech_end_offset_ms": 7268.0,
+      "audio_hash_id": "8da3705dfd22ab2f91e1bbd4d69d4dfc20d098f0b73dd07e72a2e44799089ca8",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0021.wav",
+      "sha256": "cf9dbbd7c3ebcf1e39882af9f304d8dae37b7da6a9d4803c23e272c1d239dac0",
+      "transcript": "ancient cultures and tribes began to keep them for easy access to milk hair meat and skins",
+      "duration_sec": 6.84,
+      "speech_end_offset_ms": 6404.0,
+      "audio_hash_id": "5255a07907f7face8d407d2d22a9f0a6db6bcc70efdd115e17227c0ea2576a63",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0022.wav",
+      "sha256": "08dc573e59f7eadd9b2991c747b2312047fb29a44e1111eb0ba98c3c6103e717",
+      "transcript": "angel 2006 explains the continuum approach as a method being used to help organizations reach a higher level of performance",
+      "duration_sec": 8.28,
+      "speech_end_offset_ms": 7556.0,
+      "audio_hash_id": "802b0ed69d90e41596f95dfdec148e326964405d32c7d50433eab6674ffedbab",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0023.wav",
+      "sha256": "319d94acb372fc3494b0d73ba8584229c43621d1e529c79ae5f5c6fabbfb0f11",
+      "transcript": "anyone who's going to drive at high latitudes or over mountain passes should consider the possibility of snow ice or freezing temperatures",
+      "duration_sec": 8.58,
+      "speech_end_offset_ms": 7556.0,
+      "audio_hash_id": "00da75262bf6e88fb0d461d4f8e4b73980cece1d7cc6af7004fd1f2dc165603c",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0024.wav",
+      "sha256": "07f9d6588ebf3e1fc6648ec37c91a8b6ad4c41f26ae962a9012632b504ccc8b5",
+      "transcript": "apia is the capital of samoa the town is on the island of upolu and has a population of just under 40,000",
+      "duration_sec": 10.96,
+      "speech_end_offset_ms": 10244.0,
+      "audio_hash_id": "7e58d3b9d123956eafed93f1fb42d3f20a62bd113b414de1f9c3beb166ec27ae",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0025.wav",
+      "sha256": "2d6a19bbf8001433952b0068dd138b15bcb5fc43cda8a904b882f919352fd641",
+      "transcript": "aristotle a philosopher theorised that everything is made up of a mixture of one or more of four elements they were earth water air and fire",
+      "duration_sec": 9.06,
+      "speech_end_offset_ms": 8612.0,
+      "audio_hash_id": "82688d87cba201849017b2e68a6375554944d791a92bae16d5c7c883fc36cc25",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0026.wav",
+      "sha256": "0e4381f51e0f6756d8fc61112efbe03fdf13ee20e218ab7805c30e39e590ead9",
+      "transcript": "as a result the performers smoke cannabis joints on stage and the theatre itself is encouraging the audience to join in",
+      "duration_sec": 10.56,
+      "speech_end_offset_ms": 8772.0,
+      "audio_hash_id": "82a82ee06d4414198fda392c928d6fcbd9721a61175948643cd165459b3a6a55",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0027.wav",
+      "sha256": "d4ccb2c10f8d27a1d99ccee63227c12c2c3c0c14b467cd3c6afa8e29beb5c465",
+      "transcript": "as a result the process of an organization working together to overcome an obstacle can lead to a new innovative process to serve the customer's need",
+      "duration_sec": 12.12,
+      "speech_end_offset_ms": 10756.0,
+      "audio_hash_id": "5781deea7965e38a9c888fc9ec3f0794b0e10977cbc923630475aa463fcc127b",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0028.wav",
+      "sha256": "7b5d27a31a0861395579f80ac0d9cef57d6ef1e7581edbfd23bbe8a864a2fbe5",
+      "transcript": "as a result two fish species have become extinct and two others have become endangered including the humpback chub",
+      "duration_sec": 11.44,
+      "speech_end_offset_ms": 10404.0,
+      "audio_hash_id": "9afa1844c8aa2ce805e0cada852769b9c4220b4633db4c30a8138c2664207b07",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0029.wav",
+      "sha256": "0e5e4a122f76eb2765574d688ea5d05499abc1bb92168a463a982ec795ba5631",
+      "transcript": "as knowledge of greek declined the west found itself cut off from its greek philosophical and scientific roots",
+      "duration_sec": 10.18,
+      "speech_end_offset_ms": 9380.0,
+      "audio_hash_id": "7968556b17dffeb5545d659875fc637f3d8f168a7e22870d038a043ba858d301",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0030.wav",
+      "sha256": "f6c4240af9d02d4a0afec840fd8690f2796546ed56ade569d4162b9a34f19b64",
+      "transcript": "as light pollution in their heyday was not the kind of problem it is today they are usually located in cities or at campuses easier to reach than those built in modern times",
+      "duration_sec": 9.9,
+      "speech_end_offset_ms": 8708.0,
+      "audio_hash_id": "612cdd1c28443cd9744b30730dfd6dabdc50b829911ed3373ffbc991fbad14e5",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0031.wav",
+      "sha256": "2313f97fb92f96c275ee0b9c024c827cda236c81bad503393e09398c33af63b9",
+      "transcript": "as with all south african national parks there are daily conservation and entry fees for the park",
+      "duration_sec": 9.42,
+      "speech_end_offset_ms": 8388.0,
+      "audio_hash_id": "d3d535fcb23df565e3f73c2402c3f564f615e410344e5912a3840357f7e90c19",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0032.wav",
+      "sha256": "730ac1782f6df54b0aa8024d19b3c393c8bb92e3146b12397832864cbf2717f9",
+      "transcript": "asus eee pc earlier launched world-wide for cost-saving and functionality factors became a hot topic in 2007 taipei it month",
+      "duration_sec": 10.74,
+      "speech_end_offset_ms": 9380.0,
+      "audio_hash_id": "8b731bf93f7221376b108b2b454d55a1184858477423e2e0f2f964eb9bbddb3e",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0033.wav",
+      "sha256": "be1899d277298729d6444a30694ebaa08853464d777ca7f34997ab2990989004",
+      "transcript": "barcelona's official languages are catalan and spanish about a half prefer to speak catalan a vast majority understands it and virtually everyone knows spanish",
+      "duration_sec": 11.22,
+      "speech_end_offset_ms": 9476.0,
+      "audio_hash_id": "b52bda080b1bd387628563c6498683c28b744aab8994fe5aacdec8eeac48643c",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0034.wav",
+      "sha256": "1bc62e0ff1fca190f7e33ff6719a97263ab2dffdfa73996da5de86f9022f4f91",
+      "transcript": "be careful not to allow fabric to become too hot which can cause shrinkage or in extreme cases scorch",
+      "duration_sec": 10.16,
+      "speech_end_offset_ms": 9636.0,
+      "audio_hash_id": "43538b2a7436e65910596faedd19c338f4b928d3767b41370ab9e1a343db84ff",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0035.wav",
+      "sha256": "c266dc53d615201b68dc7e2714d03ebed11558087f7d2719db693fc963e7223f",
+      "transcript": "be firm in turning down men and don't be afraid to stand your ground cultural differences or not it doesn't make it ok!",
+      "duration_sec": 10.98,
+      "speech_end_offset_ms": 9092.0,
+      "audio_hash_id": "75b03bbfc7cfdab7529eda8b4295e17d2538a91be07b4f2c7fc7feecda7fc3ae",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0036.wav",
+      "sha256": "6f7fa5cd43098d80aa5acefa7451de709ff38e35095d32eaf5f961f27b7c529d",
+      "transcript": "between 10:00-11:00 pm mdt a fire was started by the inmates in the yard",
+      "duration_sec": 8.94,
+      "speech_end_offset_ms": 7780.0,
+      "audio_hash_id": "8e8d58d22632c07c47f4acd08f414cab33d2ebdbe18593fe9c638f8fc2d157f9",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0037.wav",
+      "sha256": "d345bc4726d4498912c57af836dbf27973ea28fe1f4fbe5e38fb20c7d7bf4a6e",
+      "transcript": "beyond wednesday's event carpanedo competed in two individual races at the championships",
+      "duration_sec": 5.7,
+      "speech_end_offset_ms": 5284.0,
+      "audio_hash_id": "c27df26ed112b889a38db25825b659a4e2ef918a89cc05f7df19810839dcd586",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0038.wav",
+      "sha256": "c33f30479cb4c2939882ac55b53cbedbd05ba924877be761b258fb9b182f06af",
+      "transcript": "bishkek was described as sinking into a state of anarchy by one observer as gangs of people roamed the streets and plundered stores of consumer goods",
+      "duration_sec": 9.6,
+      "speech_end_offset_ms": 8484.0,
+      "audio_hash_id": "12895479bac562467f2d4c4f6201f52493dad97155669c2fadc05f22a6ea43c5",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0039.wav",
+      "sha256": "2483aa5645c091440acaccbda3a49bfb7344d186e789b0424b9d2e8111d73223",
+      "transcript": "blogging is a tool that inspires collaboration and encourages students to extend learning well beyond the traditional school day",
+      "duration_sec": 9.6,
+      "speech_end_offset_ms": 8644.0,
+      "audio_hash_id": "d27cc22e157a0f0bc86ed39f7f624f8b3c01b396ec1f8d17bc082b4551b15029",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0040.wav",
+      "sha256": "a9b8648aa73f9a8b6a40f74ce3e22129014dc51e5f61a4d3807dd6b75fb0afa0",
+      "transcript": "blogs can also help improve student writing while students often begin their blog experience with sloppy grammar and spelling the presence of an audience generally changes that",
+      "duration_sec": 8.76,
+      "speech_end_offset_ms": 8356.0,
+      "audio_hash_id": "a280619e0b66b3bbdf5735526539b94dc0063cc0e63cec2be7750ab0cfc8b016",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0041.wav",
+      "sha256": "4e61d90f6d562bcfa2ad384ca236a6f99d43814246d5edd0520b1c972fd0c5b2",
+      "transcript": "built by the egyptians in the third century bce the great pyramid is one of many large pyramid structures built to honor dead pharaoh",
+      "duration_sec": 8.94,
+      "speech_end_offset_ms": 7780.0,
+      "audio_hash_id": "66ef809a2570314b461a552cc8234d223c47da905a087403a23c8f1fcd758b56",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0042.wav",
+      "sha256": "7cbdf5a0185eeb0fdc683be414a4318a2536aa779e011e4ebffb168dd904789b",
+      "transcript": "buses depart the inter-district bus station across the river throughout the day though most especially those heading to the east and jakar/bumthang leave between 06:30 and 07:30",
+      "duration_sec": 12.12,
+      "speech_end_offset_ms": 11044.0,
+      "audio_hash_id": "9cfcb2daf160bee70aa54e62ec7597018fb143d1a7de365aeef61887f6c72ff9",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0043.wav",
+      "sha256": "5e61ef2376a81d484ba4369b16cc50d61987e27d74df18cb3c3cd80d50cd4857",
+      "transcript": "but after losing the captain's wicket india only made 36 runs loosing 7 wickets to end the innings",
+      "duration_sec": 8.52,
+      "speech_end_offset_ms": 7236.0,
+      "audio_hash_id": "f8b00b7772394eba446024ca114c0dac0256d735594591b6608e8d430bcbc0e6",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0044.wav",
+      "sha256": "be206f29729b01c497aff164f5751545fce3b47552f662962b161c1e0f4d194a",
+      "transcript": "but being placed in the high tropics just a few degrees north of equator you will need to deal with both heat always and strong sun when the sky is clear more rarely",
+      "duration_sec": 10.44,
+      "speech_end_offset_ms": 9476.0,
+      "audio_hash_id": "8d126012a9ed3040f77ebb07e8112282a4b357d76abb433cffe602ebd2cc7126",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0045.wav",
+      "sha256": "530ac4d4367a78674d0e4c1bc016a5eda5fa1519f649742830b5310435160dee",
+      "transcript": "but there are a lot of things about birds that still look like a dinosaur",
+      "duration_sec": 5.36,
+      "speech_end_offset_ms": 5028.0,
+      "audio_hash_id": "68da4589f972c79a949b0883dd7bb15bd2d9b9dfc2501818fbf1d6fd1ee7234c",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0046.wav",
+      "sha256": "d8c93a22c44b4bf8f7997658ae596b3aaf5183f849f8349cb9a887261f8c08ad",
+      "transcript": "by 1976 thirty percent of machu picchu had been restored and restoration continues till today",
+      "duration_sec": 6.78,
+      "speech_end_offset_ms": 6532.0,
+      "audio_hash_id": "1337b24ad6aa0129be6285dfc60368ed5746e7b7b5f9d99bb123075f66869178",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0047.wav",
+      "sha256": "354a67e061eaf0789424a41d8823074ce76c867fd01eccd83125c0d0290e0a5c",
+      "transcript": "california governor arnold schwarzenegger signed into law a bill that bans the sale or rental of violent video games to minors",
+      "duration_sec": 11.34,
+      "speech_end_offset_ms": 8900.0,
+      "audio_hash_id": "48ccd61f5f7cb2d9e9a18a7ef10216b633c1b4ddfec9134ed53f98a8cc9f058f",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0048.wav",
+      "sha256": "61a8133ef6e8572cdb3f1a4781483216c8cfada71025a12d4c084ca0dea40b82",
+      "transcript": "cancellation policies vary but as of late march most coronavirus-based cancellation policies don't extend to july 2020 when the olympics had been scheduled",
+      "duration_sec": 9.3,
+      "speech_end_offset_ms": 8836.0,
+      "audio_hash_id": "f97ff3cda8fb27236880ff2ed0ae5cab1925ab96291c6019b95b96673b3ef422",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0049.wav",
+      "sha256": "199daf809b05596cdfa1a823197413e74a3489143a5da6c12f8b133ebc923f3e",
+      "transcript": "casablanca is one of the least interesting places to shop in all of morocco",
+      "duration_sec": 6.24,
+      "speech_end_offset_ms": 5092.0,
+      "audio_hash_id": "ae4a259742fa3baad2086cbcfacbbfc91dad4dd523ac94d756db109281d42830",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0050.wav",
+      "sha256": "1b36eb1d56cc09f58736c453441cb78073a825783ace21d956eb9c80702393fa",
+      "transcript": "children are placed in foster care for a wide variety of reasons that range from neglect to abuse and even to extortion",
+      "duration_sec": 10.72,
+      "speech_end_offset_ms": 10116.0,
+      "audio_hash_id": "898fa0f924b4c5582cbecd67348d4b75b88c99c371aa0a6e5dcbd2669ee1b896",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0051.wav",
+      "sha256": "3f8c1fdf0409d0d6873a889783793dfdc18ff249194d584c36702d5cfe1e2fe0",
+      "transcript": "cochamó valley - chile's premier climbing destination known as the yosemite of south america with a variety of granite big walls and crags",
+      "duration_sec": 12.12,
+      "speech_end_offset_ms": 10276.0,
+      "audio_hash_id": "c413e773608acc4207f2b57a70692a81641acc8153854481f60be3834d2fe1a7",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0052.wav",
+      "sha256": "0150042ade006293c16e631cab3a98108529a79c62ea8c85cc4d9baf6c4167c4",
+      "transcript": "congress began funding the obscenity initiative in fiscal 2005 and specified that the fbi must devote 10 agents to adult pornography",
+      "duration_sec": 10.02,
+      "speech_end_offset_ms": 8772.0,
+      "audio_hash_id": "b44c651d6a34c80f52832187ead48d409b86d354526087e2da9e63f139388951",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0053.wav",
+      "sha256": "d6ef659696481c75c6b461603095f4cd0f523ddb399e9ba28e526c5538ed9356",
+      "transcript": "crossties were introduced fairly early to hold the tracks in place gradually however it was realised that tracks would be more efficient if they had a stip of iron on the top",
+      "duration_sec": 10.74,
+      "speech_end_offset_ms": 10404.0,
+      "audio_hash_id": "35a84179d836822832097b7b02e785daec80f36d84325d1a42149d04139de0b2",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0054.wav",
+      "sha256": "315df44eb84df3b93aac6e7748cc97fea5ff36e06027e1c14bc5ccaf3864db58",
+      "transcript": "cuomo 53 began his governorship earlier this year and signed a bill last month legalizing same-sex marriage",
+      "duration_sec": 9.42,
+      "speech_end_offset_ms": 8164.0,
+      "audio_hash_id": "2e062d0253665333e2709a3150c95cedaaa2675091e3f40292ce6df23894dc67",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0055.wav",
+      "sha256": "14e67ac0876ae3d28702ae9fb97ba5c108e5b61320399bcb8a9bfdfc0bca3d56",
+      "transcript": "danielle lantagne a un expert on the disease stated the outbreak was likely caused by the peacekeepers",
+      "duration_sec": 6.3,
+      "speech_end_offset_ms": 5796.0,
+      "audio_hash_id": "d114dcda8e57ae3dc497b1fdae7ba1ec9a8e07c87521ecf8f2d6d645699e6e73",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0056.wav",
+      "sha256": "e8895b066153c508dc9ffbc2e291dcf6af9bf6056ddf3de59d12a90ebc932b24",
+      "transcript": "del potro had the early advantage in the second set but this too required a tie break after reaching 6-6",
+      "duration_sec": 8.1,
+      "speech_end_offset_ms": 6756.0,
+      "audio_hash_id": "264f36c07394f137d28f313d1c8dc669a4429036ac8d974f5f5719a8570c64f4",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0057.wav",
+      "sha256": "2af27e1500a4648880882890496a7e8ee959ed81208121c5d303aa42eddcecde",
+      "transcript": "do not deface the site by marking or scratching graffiti into structures",
+      "duration_sec": 4.5,
+      "speech_end_offset_ms": 4132.0,
+      "audio_hash_id": "6a12e653ef43a2458a5a79ace54cb2d91fd955920ab003ba0b40fcdb600e2a72",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0058.wav",
+      "sha256": "01b2b70789f15b08634734acb859500bee3f9a5f0e8bcd34c69ec911fbb13c43",
+      "transcript": "due to the underwater topology the return flow is concentrated at a few deeper sections and a fast current to deep water may form there",
+      "duration_sec": 10.92,
+      "speech_end_offset_ms": 9732.0,
+      "audio_hash_id": "e8e669584821000324c19b988d9f7305c61b6d7ea89f933675fa5ffb5225ed1e",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0059.wav",
+      "sha256": "3631dd43791cd968fd0e89604cc77a157786b63109a122e13065cf791e1b8bfc",
+      "transcript": "during the 1920s the prevailing attitudes of most citizens and nations was that of pacifism and isolation",
+      "duration_sec": 7.68,
+      "speech_end_offset_ms": 6564.0,
+      "audio_hash_id": "fe10d552da52df61bb896a85609c795da999a798be2a09d24abdbb503812ca1b",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0060.wav",
+      "sha256": "0a9c1e6fcff607a0609d9026308d7d127b74b4ff5ea7b1b7e7242be3d61c8b54",
+      "transcript": "during the revolutionary war the thirteen states first formed a weak central government-with the congress being its only component-under the articles of confederation",
+      "duration_sec": 10.08,
+      "speech_end_offset_ms": 8964.0,
+      "audio_hash_id": "1045f3e9fd6e6632ccfff8cbe254e40a30f83b403a24e4085353fabb9969470c",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0061.wav",
+      "sha256": "9047bdd664fb8349124849be7e12e0638b1f2a415655c7364d00ad2d53404136",
+      "transcript": "during the struggle for independence organised by the mau movement a peaceful gathering in the town resulted in the killing of the paramount chief tupua tamasese lealofi iii",
+      "duration_sec": 12.12,
+      "speech_end_offset_ms": 11396.0,
+      "audio_hash_id": "4a18a08f44a48a03fce2a38935971e0c58561afb07db90aed62797bb5a503343",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0062.wav",
+      "sha256": "d0f2ced45855497b38a25840f411c2469be6b40395d52c8472d5f2a8e08f528b",
+      "transcript": "during this period of european history the catholic church which had become rich and powerful came under scrutiny",
+      "duration_sec": 11.4,
+      "speech_end_offset_ms": 10500.0,
+      "audio_hash_id": "99769fdaf7f63d4b86439e072330de75ce578fc3c93ec6fa2ba37b62daafe6fa",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0063.wav",
+      "sha256": "ed9fa0cc3700082b8328df05c403d16d0d5edd709a1b3fbe77b1c5f8b9104269",
+      "transcript": "duvall who is married with two adult children did not leave a big impression on miller to whom the story was related",
+      "duration_sec": 6.24,
+      "speech_end_offset_ms": 6240.0,
+      "audio_hash_id": "c6fba31cd5e9c38f2975623d3d77cb2205729e283c0b5c6b1261e1e89e0c03bf",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0064.wav",
+      "sha256": "a0777ed427e853b546c2c963f718ab74c767bb2d52f5011b51de4be03881f018",
+      "transcript": "elements like calcium and potassium are considered metals of course there are also metals like silver and gold",
+      "duration_sec": 6.24,
+      "speech_end_offset_ms": 5892.0,
+      "audio_hash_id": "38ea9033d33bd1a72c593ca5950452da4b9762ef485b55319e1d385739599540",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0065.wav",
+      "sha256": "532db03fb1853ccced092c993fe57616445aae20862803857e41a34b887590cd",
+      "transcript": "everyone participates in society and uses transportation systems almost everyone complains about transportation systems",
+      "duration_sec": 11.64,
+      "speech_end_offset_ms": 10660.0,
+      "audio_hash_id": "a791794ebc3e5bb12970d9f8c7e8ec8c33d294d7ff5378a319deafa946943f47",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0066.wav",
+      "sha256": "1bf6240b0cd4e97e35be1c6dc5292c25c288fefdf045279f0f71e74679613754",
+      "transcript": "everything in the universe is made of matter all matter is made of tiny particles called atoms",
+      "duration_sec": 6.42,
+      "speech_end_offset_ms": 5956.0,
+      "audio_hash_id": "2d9d11aeacfd7bc48f79f4e9cf8d794af7ca0b0c192f13dc053306c192129bad",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0067.wav",
+      "sha256": "61783f1ca02269d5e72ffbba273aecd504d9a75efc51ffdc812805f50c5d6ec6",
+      "transcript": "fellow wrestlers also paid tribute to luna",
+      "duration_sec": 3.6,
+      "speech_end_offset_ms": 2820.0,
+      "audio_hash_id": "1e1e4cfb6c6cd9cf000f0fd11c0d87df7e7cae34b3b2cb4b0b09b3039df12094",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0068.wav",
+      "sha256": "9241127587ebe595b972b1a62da335cc0f57af10ce014558b7f29190b8d4cfc4",
+      "transcript": "feral children may have experienced severe child abuse or trauma before being abandoned or running away",
+      "duration_sec": 6.54,
+      "speech_end_offset_ms": 5764.0,
+      "audio_hash_id": "2696e76742661c8aa4f1da25303c1af55c5fa308e41a13aa048fd2e4a646f2f9",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0069.wav",
+      "sha256": "2486bdd1671c47f2dff9ca5b366850c2e278dc60d4e5e0d5c4b859c5f26af53d",
+      "transcript": "field trips are a large part of any classroom quite often a teacher would love to take her students places to which a bus trip is not an option",
+      "duration_sec": 9.84,
+      "speech_end_offset_ms": 8420.0,
+      "audio_hash_id": "24aa1c6b2c5003a6ae82c300cf81fec68af7f6a14a78c65b882a1acdf06b72c8",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0070.wav",
+      "sha256": "0f50abb0210ccd9117098950a62ba1f4e92632b9baefa73f800cc5d0f76e7660",
+      "transcript": "finally there are many small cats including loose pet cats that eat the far more numerous small prey like insects rodents lizards and birds",
+      "duration_sec": 8.64,
+      "speech_end_offset_ms": 8356.0,
+      "audio_hash_id": "e3c24d09aa5743ec6846c6f3856ee8f29541b828f067025eacd9199e7ff3e7bf",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0071.wav",
+      "sha256": "744e0cd64fd8fbc62ef61a401b6cff00477927a317a46995e5be1c0b0176b024",
+      "transcript": "finland is a great boating destination the land of a thousand lakes has thousands of islands too in the lakes and in the coastal archipelagos",
+      "duration_sec": 9.36,
+      "speech_end_offset_ms": 8228.0,
+      "audio_hash_id": "60818234ea068c90783a9bcb388906f7770b2da5700dbe427e3de21b1279e66a",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0072.wav",
+      "sha256": "56d3f08005acecb18a664bb4349b9ba1ef04651a2455f0823dd12bae117c9726",
+      "transcript": "fire rescue crews eventually doused the fire by 11:35 pm",
+      "duration_sec": 5.72,
+      "speech_end_offset_ms": 5316.0,
+      "audio_hash_id": "78a842567f932f16201c39129fbd02bb41fddbcf1a618ce8a8f48dedb79d6c54",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0073.wav",
+      "sha256": "f5c326c9a13a22a7f5617cf2997cb4cd566f78f5116ba7f4228179b980e89bba",
+      "transcript": "first most riders wear riding boots with a heel and a smooth quite narrow sole",
+      "duration_sec": 7.86,
+      "speech_end_offset_ms": 6788.0,
+      "audio_hash_id": "380a1d2e7d39a063b5883c2ae3fb345d3bc556514111b0dfa35ac562d752c94b",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0074.wav",
+      "sha256": "490ddc96dc715442d8f4b07102b1bfa209e95935e2b3608860e36aee561bb608",
+      "transcript": "for example each year students from bennet school in north carolina design a website about their trip to the state capital each year the website gets remodeled but old versions are kept online to serve as a scrapbook",
+      "duration_sec": 11.28,
+      "speech_end_offset_ms": 10948.0,
+      "audio_hash_id": "07e5bfa2482cd05be4bcd750ad85d5b0bdcfe95abc3348ffb6e1c5d6a42df753",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0075.wav",
+      "sha256": "3e1926e5948a171ecfbddbdc2e9d3d0e12746de760308a640535efbc3f82a4ea",
+      "transcript": "for the springboks it ended a five-match losing streak",
+      "duration_sec": 4.98,
+      "speech_end_offset_ms": 4612.0,
+      "audio_hash_id": "195df39873b5575a8bddfe3ef3a0cb1653fb0e02d0337b00a1c86f1c23463476",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0076.wav",
+      "sha256": "b0df39f8d91f4c8665c9271392f62617fc9a89ced2b73e45a0efb4740686a8c1",
+      "transcript": "four skiers in the women's sitting group failed to finish their runs and 45 of the 117 total skiers in the giant slalom failed to rank in the race",
+      "duration_sec": 7.68,
+      "speech_end_offset_ms": 7268.0,
+      "audio_hash_id": "a4eb88ff781e9063001de0859d08927e0e78cd9e7247e5e40008868c2a528929",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0077.wav",
+      "sha256": "52c2b8fa84546fb622b534ba0b9c38ad17971846c9f84ce75cfa438cef65b876",
+      "transcript": "giancarlo fisichella lost control of his car and ended the race very soon after the start",
+      "duration_sec": 5.16,
+      "speech_end_offset_ms": 4836.0,
+      "audio_hash_id": "ef04c131d2325ae05e71aa745c3075cd7a6f9830afffd1698c72878844711c8e",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0078.wav",
+      "sha256": "3dafa1c163eaefc6e4b1fa8219ed302a5f53c258f8a1b2ea125ef24285440b9e",
+      "transcript": "goats seem to have been first domesticated roughly 10,000 years ago in the zagros mountains of iran",
+      "duration_sec": 10.62,
+      "speech_end_offset_ms": 8708.0,
+      "audio_hash_id": "2403b97ae7fa33c3ea8eb8405499cafbc3f55bca360c2ad0173b290d22da5e9f",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0079.wav",
+      "sha256": "9d961dd815eb19a12450e35233e7dc5065143e82d2fe07f5f6511eb9833f13a2",
+      "transcript": "he added that they should not however be asked to take on obligations that go beyond their development stage responsibility and capabilities",
+      "duration_sec": 12.22,
+      "speech_end_offset_ms": 10948.0,
+      "audio_hash_id": "c10b2100c6a81f93cdfbced09b9ea6ffd9247b448d17189e0348b8059d063ded",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0080.wav",
+      "sha256": "5b733867e617f229f7d22df64f6a951d8e5c33805445b0eac911d3bc6a161fcb",
+      "transcript": "he did not set a figure for the cuts saying they will be made based on china's economic output",
+      "duration_sec": 6.36,
+      "speech_end_offset_ms": 5476.0,
+      "audio_hash_id": "ae6894802faae65f64e51e432376e7c465b8e46dc0e63ddaf61bf078f1b327d4",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0081.wav",
+      "sha256": "e4e2c20143d9dca2022a78255ccd115696d016564bb703a6995bf0d15cf9b4bd",
+      "transcript": "he has been unable to take the drugs needed to overcome his pain as they are banned from the games",
+      "duration_sec": 6.36,
+      "speech_end_offset_ms": 5156.0,
+      "audio_hash_id": "b0f51eb468725043c822efc2061093bbbb1eb493c5fed686e10372e0b24bbf2b",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0082.wav",
+      "sha256": "a39d7fb940f14e6f5d67e88641c3959c4e839c820576db776296009771eb48d1",
+      "transcript": "he referred to the rumors as political chatter and silliness",
+      "duration_sec": 3.84,
+      "speech_end_offset_ms": 3460.0,
+      "audio_hash_id": "9d0cb3c26165e7cf02122ac93be9e5befbfe7b521429e24e8e19a1b62eb6a03b",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0083.wav",
+      "sha256": "7258886b56c09f111f632303dbf23a24ea6f1aa5e96d5eff8c23d768ad86e7ce",
+      "transcript": "he was also engaged in engraving banknotes for many countries recent examples of his work including the prime ministerial portraits on the front of the new canadian $5 and $100 bills",
+      "duration_sec": 12.36,
+      "speech_end_offset_ms": 11972.0,
+      "audio_hash_id": "51eda58f87c3da4b338c4bdf70a0a0182fe1624a3d4f7f5cde3c32b6866602ae",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0084.wav",
+      "sha256": "7daec3763344c795aa4e932d83f3e2ab7965a287b40776ca0de28b43920d3824",
+      "transcript": "he was greeted by singapore's deputy prime minister wong kan seng and discussed trade and terrorism issues with the singapore prime minister lee hsien loong",
+      "duration_sec": 11.64,
+      "speech_end_offset_ms": 10404.0,
+      "audio_hash_id": "2edd8e6e5cfbea43162b89b20c122319b4e6050048bc1bcbaa3c1ff67be8363e",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0085.wav",
+      "sha256": "1cb80364a39786e249e0d92469ac9c0ff01c3695d5d1563add132113bdcb6ab3",
+      "transcript": "he was initially hospitalised in the james paget hospital in great yarmouth",
+      "duration_sec": 7.5,
+      "speech_end_offset_ms": 6692.0,
+      "audio_hash_id": "ee92018efb4b2a83e893aea4650ec96d1d6ae80be457e35830e341340c083205",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0086.wav",
+      "sha256": "679b3c1fca3c6778e8ef7eb75d1224a093590fe34f2f0648dcc8948704590fcd",
+      "transcript": "he was reportedly aged in his 20s. in a statement bieber said [w]hile i was not present nor directly involved with this tragic accident my thoughts and prayers are with the family of the victim.",
+      "duration_sec": 10.56,
+      "speech_end_offset_ms": 9572.0,
+      "audio_hash_id": "0aeef7a2f4ebeed0f3f21a7f19075bcc2e7ef8e834c22ea56f2e98d224099a52",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0087.wav",
+      "sha256": "c1c4fcb58fbe4b2bc008bf433c8cbc62c76aa1bab83f607575c700b94a71d0e1",
+      "transcript": "he was subsequently relocated to addenbrooke's hospital in cambridge",
+      "duration_sec": 6.84,
+      "speech_end_offset_ms": 5092.0,
+      "audio_hash_id": "bfb1a2db655350611cf037ce88ea198e6035212daf5ee6bf06ec2a3f548f6950",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0088.wav",
+      "sha256": "01b85b38ac5fb99460501d990751d90b082c10d84423109b7f36d74e556119c4",
+      "transcript": "hong kong island gives the territory of hong kong its name and is the place that many tourists regard as the main focus",
+      "duration_sec": 7.02,
+      "speech_end_offset_ms": 6308.0,
+      "audio_hash_id": "6b0e93596f97cc14b99671798d4e357351490994eef27427eb54ce42a213b427",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0089.wav",
+      "sha256": "1f9e162062f598597d6e17f877c06a347629a8eab12b5d585a9215ea6024133d",
+      "transcript": "however due to the slow communication channels styles in the west could lag behind by 25 to 30 year",
+      "duration_sec": 10.56,
+      "speech_end_offset_ms": 8964.0,
+      "audio_hash_id": "dbc9348dc969c33e1568e9dac2d655aeee10a342e6768356489bf52f9c5727dd",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0090.wav",
+      "sha256": "a97f5ec1467cccdb19a10e12cc5bae56c1b3eca7ecdef1e103d0329d471206a3",
+      "transcript": "however that is not true although there is something written on the back of the document it is not a treasure map",
+      "duration_sec": 10.02,
+      "speech_end_offset_ms": 8740.0,
+      "audio_hash_id": "51af57f46114fc062f84cb1df421dd2458d8dbc4ccc73545bed45faed9f316ff",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0091.wav",
+      "sha256": "a9f348d1b46ef1c836c878bc3af6e75942e6737e9730c22768f77cc7f987099b",
+      "transcript": "hydrogen ions are protons that had their electrons stripped off them since hydrogen atoms consist of one proton and one electron",
+      "duration_sec": 7.68,
+      "speech_end_offset_ms": 7332.0,
+      "audio_hash_id": "cccc929fa787ee164413339ce77868df44e33e55609395a5beb6a75ac7e03a13",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0092.wav",
+      "sha256": "283796d88879436a64256d83a1d889dce71dd45206358a7723d85cb1e11e3507",
+      "transcript": "if you have watched the movie national treasure you may think a treasure map was written on the back of the declaration of independence",
+      "duration_sec": 6.78,
+      "speech_end_offset_ms": 6340.0,
+      "audio_hash_id": "611266d990ff8ab65ad5b3821db11d3a0e0fb358831b711d6430a9b514283b0d",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0093.wav",
+      "sha256": "830b70fc598d35fc708a45ddb318b5b322dba733d109c0896e88f8efbcb6007e",
+      "transcript": "if you only go ashore using shipboard excursions you will not need a separate visa as of 2009",
+      "duration_sec": 9.26,
+      "speech_end_offset_ms": 8196.0,
+      "audio_hash_id": "c69189ecbd9f525792d075b2310426df7458b5bfe8e43b538a58c68297670b0d",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0094.wav",
+      "sha256": "c078012a10af6ba841ed12618fa7e12a26141c13a9ede24ef2259556d3123446",
+      "transcript": "if you want to be close to the action you're going to have to get in early to get a camping site close to the music",
+      "duration_sec": 9.24,
+      "speech_end_offset_ms": 7972.0,
+      "audio_hash_id": "cf33933df190c2038dcbba6fb6e6510b2c2ebef8e6c3423c348bb717821f3200",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0095.wav",
+      "sha256": "f8453d83af9dd56345a0d0c9b7c6ea931f2f5889679ec525953fc706a9eebecc",
+      "transcript": "if you're not used to driving on country roads keep your wits about you steep grades narrow lanes and sharp curves predominate",
+      "duration_sec": 11.1,
+      "speech_end_offset_ms": 10436.0,
+      "audio_hash_id": "9a2ad9d71bea070dc5e0b48d32a9f8498f3b9f7647f0375d198242b6ef5a06f8",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0096.wav",
+      "sha256": "13e4bda602f158a7869a0be9816e4853cb7707d41c58bbef38856f9db6c55e7d",
+      "transcript": "in 1990 it was added to the list of world heritage sites in danger due to the threat of desert sands",
+      "duration_sec": 7.32,
+      "speech_end_offset_ms": 6564.0,
+      "audio_hash_id": "ed0b15d3b769b6f7b83f169bb969d9881b09d6f15a8eb9ba27e80ee88d354e3a",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0097.wav",
+      "sha256": "0b8e4e6f6f5d295a9956c2f31d87e0131088131bbd2d7fcd303fb1caf21b2c00",
+      "transcript": "in 2002 goma was destroyed by lava from the nyiragongo volcano which buried most of the town's streets particularly the town centre",
+      "duration_sec": 10.38,
+      "speech_end_offset_ms": 9156.0,
+      "audio_hash_id": "57e1faf069e5e31f2100feb38932376c196324d5abf087e11e92a7006feba711",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0098.wav",
+      "sha256": "3a94a5a39edaea093e84836dd698798f75e2ea8b54406f5451f26c70b3114e71",
+      "transcript": "in a carriage they traveled back to paris surrounded by a mob of people screaming and shouting threats against the king and queen",
+      "duration_sec": 10.22,
+      "speech_end_offset_ms": 8580.0,
+      "audio_hash_id": "2055bc7fb7c4287e4a089a2c1a8f1a58c8f116841169bb28bebc1937eab0d82d",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0099.wav",
+      "sha256": "cff1bbcdcbc700ca44115601a22a887de7ff3ac5e119581e5b3e6ae987f9cadb",
+      "transcript": "in fact it is not easy to find at all even if one knew it existed once inside the cave it is a total isolation",
+      "duration_sec": 7.92,
+      "speech_end_offset_ms": 7140.0,
+      "audio_hash_id": "0b652d70f49a3676ff30f33ebc0928aa1607d30c7fc006b29b36d373f1e05fa9",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0100.wav",
+      "sha256": "8bbca66643a79621bb0140a7a62b4ab5f6c36f491877b7f531e200667090e387",
+      "transcript": "in just two weeks the americans and free french forces had liberated southern france and were turning towards germany",
+      "duration_sec": 10.18,
+      "speech_end_offset_ms": 9220.0,
+      "audio_hash_id": "4760b1b7c3a7c11d97e94e5424cc8c3922e346c8f8175de98ef7473f0edbbf14",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0101.wav",
+      "sha256": "74abe0130035be22ef80307bd48165cc13a4f611bd6ebecb13f4686b4128f2d4",
+      "transcript": "in many other cities of italy and in the rest of the world particularly in poland similar setups were made which were viewed by a great number of people",
+      "duration_sec": 8.4,
+      "speech_end_offset_ms": 7492.0,
+      "audio_hash_id": "7e631ee6526bb38feef5ca6479361e06a0424d8b5dceba0a16d882bea784156d",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0102.wav",
+      "sha256": "1b6a5da76d813f486ddc8be7642cbf7e4b7aac33720b2c7ff9f153b3cafd2366",
+      "transcript": "in particular it is claimed that one can detect whether a person is lying by interpreting micro-expressions correctly",
+      "duration_sec": 6.12,
+      "speech_end_offset_ms": 5796.0,
+      "audio_hash_id": "f4b0f80765a5be8e32e3ebc991b3bd8b460472c54d9cf11666ba1a8eb9a4abd5",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0103.wav",
+      "sha256": "f01d59cd833d397aedaee6afc276a625305f31fbb497e86a0f2dbdb2af75e5b7",
+      "transcript": "in some areas boiling water for a minute is enough in others several minutes are needed",
+      "duration_sec": 5.64,
+      "speech_end_offset_ms": 4708.0,
+      "audio_hash_id": "20f7cb148bf0330bf58e4e07963ab03ca910649ae45497b215f6b47efc18ff6b",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0104.wav",
+      "sha256": "7ecbb3621327b344347f7f03991365afdba254bc1174fabcc83d229f6f1a33e9",
+      "transcript": "in the archipelagos and lakes you do not necessarily need a yacht",
+      "duration_sec": 7.48,
+      "speech_end_offset_ms": 6724.0,
+      "audio_hash_id": "7a0b7359441956c41895daa0e9850c0d4fb7429f7ea3fb0759735adec2f874a5",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0105.wav",
+      "sha256": "c9bf2154d0927de7bc98f759689e8c17262c7c3a2ed7d140d0852cc4e3a2e3ba",
+      "transcript": "in the north the region is bounded by the sahel and in the south and west by the atlantic ocean",
+      "duration_sec": 9.58,
+      "speech_end_offset_ms": 8068.0,
+      "audio_hash_id": "b97d0aa2160beed5cf504d84e69814b1dbdeb0c204242ae66f98f5c273d2e45f",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0106.wav",
+      "sha256": "c82a8bf537542bedb7c88c92cc02aa108737561d628a9ee5764f247ee11bb632",
+      "transcript": "in the warm climate of the middle east the house was not so important",
+      "duration_sec": 6.72,
+      "speech_end_offset_ms": 5444.0,
+      "audio_hash_id": "fd50062b5f48373e89a124e1ccd9e54ec0056342c73d2b50f9e7aa93f5fb4124",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0107.wav",
+      "sha256": "07c932e71b7547a628a120fec3d4b60c0ab5579b913450ed52265b826aad0050",
+      "transcript": "it also attacked anything that entered the water even a giant dinosaur such as t rex would be no match for it",
+      "duration_sec": 9.12,
+      "speech_end_offset_ms": 7652.0,
+      "audio_hash_id": "46953277c08c85e85e1c9b1be04a1f42f3dd2a75f59a19e249918ef444f4032d",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0108.wav",
+      "sha256": "f0834465b0374eedd1baef661bb899c086b8294b0dd26c04e693881a3eda08e9",
+      "transcript": "it has brought us the train the car and many other transportation devices",
+      "duration_sec": 4.86,
+      "speech_end_offset_ms": 4860.0,
+      "audio_hash_id": "746c535e2515ad52203a92941f27ef68c7dc6da30468ddc0a181efb52b29ea2b",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0109.wav",
+      "sha256": "e7cf8ab6768ec6fb8783235beeb22652648f23d127512689892c10b642c411e4",
+      "transcript": "it is one of the main attractions of south africa and it is considered the flagship of south african national parks sanparks",
+      "duration_sec": 10.92,
+      "speech_end_offset_ms": 9444.0,
+      "audio_hash_id": "644d970231b8a1f2f1e1b5005d27fd64264e6b231eb3cff9f13a26ad2e476ca9",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0110.wav",
+      "sha256": "3e03a9020a9ced99819267409f5f4d9eb2ed55fcb578121be769ad83ea8f1f7c",
+      "transcript": "it is related to but usually not involving alpine style ski touring or mountaineering the latter ones done in steep terrain and requiring much stiffer skis and boots",
+      "duration_sec": 9.9,
+      "speech_end_offset_ms": 8740.0,
+      "audio_hash_id": "e19ca3e158572f0929a6f1214cd0edb883cc3d6c914a596331da08dfd11a0eef",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0111.wav",
+      "sha256": "37ddbb58d6abd61c475049f5157f065cec70d7abb0b9eca16bd5fb699bf8f58d",
+      "transcript": "it is thinner under the maria and thicker under the highlands",
+      "duration_sec": 7.2,
+      "speech_end_offset_ms": 6820.0,
+      "audio_hash_id": "a2dbcbb455d48414e214d5fb2fac1c63323da492aa2b4b45f7d617d2ef0c6852",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0112.wav",
+      "sha256": "809d7b094380e59b57d26dbb7a2fb51e54967429fbe232a2ca0a46e79ceefb71",
+      "transcript": "it was ruled by the vichy french these were french people who had made peace with the germans in 1940 and worked with the invaders instead of fighting them",
+      "duration_sec": 9.6,
+      "speech_end_offset_ms": 8356.0,
+      "audio_hash_id": "139e9e64ed96006b1322de7dd4d03e7949863dd276166702bb1094d0cb361b91",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0113.wav",
+      "sha256": "69426e396ec76d517f4311d72b8cb4dafc3a7e39f170f4cb08d9b82ba446636d",
+      "transcript": "italian is also the everyday language used by most of those who work in the state while latin is often used in religious ceremonies",
+      "duration_sec": 12.32,
+      "speech_end_offset_ms": 12320.0,
+      "audio_hash_id": "41faebbbf133f3bdc100fea298729a3ed196858446a3e88ef5339174985bf58e",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0114.wav",
+      "sha256": "7d74bd54e0ff0c91f676a245c0759e725153953af93e771c7fbfd97e63681133",
+      "transcript": "its renown for being an epicenter of luxury began in about 400 a.d. and lasted up until about 1100 a.d",
+      "duration_sec": 11.48,
+      "speech_end_offset_ms": 10948.0,
+      "audio_hash_id": "9d3f95f3c39a2945a2826061a3cc5fa768c770e7d7082e8aac9e91146fac03cb",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0115.wav",
+      "sha256": "91aae502d898518cb608f55e51965810f34a33705ed97e7b80d8aaaeb09fc784",
+      "transcript": "just like the moon exerts a pull on the earth causing tides so does the milky way exert a force on the sagittarius galaxy",
+      "duration_sec": 7.14,
+      "speech_end_offset_ms": 6692.0,
+      "audio_hash_id": "c6028142ed768dd3ec4c5a5d7b25b53bbc57c943982d3292be795096ec04f68a",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0116.wav",
+      "sha256": "2eef13a4d21dbc00a2c71062a1ed6db51f209fc3af7c171cbaf305329557adf5",
+      "transcript": "large areas further north are quite sparsely populated and some is nearly uninhabited wilderness",
+      "duration_sec": 7.44,
+      "speech_end_offset_ms": 6116.0,
+      "audio_hash_id": "08a829524eaf39652eae01a28923a84ed1b08218160c51705beaaebf3fcd8318",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0117.wav",
+      "sha256": "725426bae0f463d4a28a23fd568910e91b4388030534c0a0d35a4a6e6458c93d",
+      "transcript": "last week meti announced that apple had informed it of 34 additional overheating incidents which the company called non-serious",
+      "duration_sec": 9.12,
+      "speech_end_offset_ms": 8388.0,
+      "audio_hash_id": "9a332defa1dc8d6565a4c579a3d89111c8821eec05cde7e95a94235b55a55460",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0118.wav",
+      "sha256": "b1a84c104304c031736092c481055351ea1472ec0f72ce67f6f3abab1d33e588",
+      "transcript": "late on sunday the united states president donald trump in a statement delivered via the press secretary announced us troops would be leaving syria",
+      "duration_sec": 9.96,
+      "speech_end_offset_ms": 8804.0,
+      "audio_hash_id": "cec4ee28c13c7453f97e7e142d2881edf01d2ea32608504be0bc39b64018492a",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0119.wav",
+      "sha256": "9d497ca0b864248b9b2bce13c7f930e0f7b55c317f5a5df8a37b6dfd957d76ef",
+      "transcript": "layton had asked for changes to the conservatives' environmental bill during the meeting with the pm asking for a thorough and complete rewriting of the conservative party's environmental bill",
+      "duration_sec": 9.72,
+      "speech_end_offset_ms": 9220.0,
+      "audio_hash_id": "d24f5c0a3ca17f5171463bf92b0d2711200d122bab4e4d1beafd772d3d00f40e",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0120.wav",
+      "sha256": "5dddec6216900f37d619a93e1ef5b6d4fce96fde1d6f0fbca4dbc7be8b3a4896",
+      "transcript": "liberal criticism of the reconstruction effort has focused on the awarding of reconstruction contracts to perceived washington insiders",
+      "duration_sec": 8.04,
+      "speech_end_offset_ms": 7716.0,
+      "audio_hash_id": "1c399e31d40e7590dc14acd1fa7c123d6126fba06a761ea0ba3bcf9c14e64548",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0121.wav",
+      "sha256": "d70d84835ab11f2ccba78a7a8761d4fae1cd3b3c5e178db884992c992085b3e0",
+      "transcript": "lion prides act much like packs of wolves or dogs animals surprisingly similar to lions but not other big cats in behavior and also very deadly to their prey",
+      "duration_sec": 10.92,
+      "speech_end_offset_ms": 10116.0,
+      "audio_hash_id": "45183aaa977f6a7172a9e155274e281ae8b6e7b15dcf5722fd1ab639938d2839",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0122.wav",
+      "sha256": "4cb2ed2d5369afb2531dc5366e07bf1fd7477c09cb8519e87f784cd57bb60efe",
+      "transcript": "lions are the most social cats living in large groups called prides",
+      "duration_sec": 6.6,
+      "speech_end_offset_ms": 5412.0,
+      "audio_hash_id": "b7c70a6005c1d40f459ee58b4e3223bfa4368ef4d5bf003cdf988a4a55da0fef",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0123.wav",
+      "sha256": "88cdccd3a5e51e8e3268653c13d6951323a02a0be147f93aa113101e6f5ec575",
+      "transcript": "madagascar is by far the biggest and a continent on its own when it comes to wildlife",
+      "duration_sec": 7.32,
+      "speech_end_offset_ms": 6500.0,
+      "audio_hash_id": "decd7e5d5d11972d76ba7bd9b43ac61b450c6d2132a051b6d1c4a8f7538738a3",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0124.wav",
+      "sha256": "40905f9e658e9a6a3bc90aa4dd82a3d787aaeb0c2c9a51ea2e17930cbf5928ce",
+      "transcript": "many german baked goods also feature almonds hazelnuts and other tree nuts popular cakes often pair particularly well with a cup of strong coffee",
+      "duration_sec": 10.44,
+      "speech_end_offset_ms": 9284.0,
+      "audio_hash_id": "6dca7eacabeef74ef8cd05cf85694260b94fdeaff6c739ad6a497f1af7b81756",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0125.wav",
+      "sha256": "c685b4dd262db75005eb9a5fe1e1982c52a3c869c473c409849ace82a83410f2",
+      "transcript": "many people don't think about them as dinosaurs because they have feathers and can fly",
+      "duration_sec": 4.32,
+      "speech_end_offset_ms": 3972.0,
+      "audio_hash_id": "7e9eaee19e0f8692ed8a48844ccc99e4d2e8ff3bb97cc4ca6897a8048b4c0ec6",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0126.wav",
+      "sha256": "74df6f135e8997eca9ba1923bf72bafd060eee34eaca61bd3889d9b5a1957ccd",
+      "transcript": "martelly swore in a new provisional electoral council cep of nine members yesterday",
+      "duration_sec": 10.12,
+      "speech_end_offset_ms": 8676.0,
+      "audio_hash_id": "2732b49b25eefab7518ba36269789d0f7ceedf12c7bc32276a0561cb75ca08ff",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0127.wav",
+      "sha256": "f4fa48a54551c3420291c40e026072b0464192ff5497029f455de9a0d056670b",
+      "transcript": "mass car ownership also leads to a higher incidence of accidents on the roads which leads to the invention of new techniques in healthcare for repairing damaged bodies",
+      "duration_sec": 9.48,
+      "speech_end_offset_ms": 8932.0,
+      "audio_hash_id": "c6b011544ddf5c278f2c9d1d90ae23def4b3e76e547a759b8a34de3944c4b0b4",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0128.wav",
+      "sha256": "87fea666c37fd7b240d80eed0d4f690098106d0750ce914ca93c75e88ddf6349",
+      "transcript": "middle order batsmen sachin tendulkar and rahul dravid performed well and made a hundred-run partnership",
+      "duration_sec": 8.64,
+      "speech_end_offset_ms": 7428.0,
+      "audio_hash_id": "6a70834c33326f52c3c87cb36e4c9c91a2b301dfe471d3ef536a92808a8e3654",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0129.wav",
+      "sha256": "0cde80bb1c6c5dc7e77385c86483625912be1c44bf17e90950a40929650a74d3",
+      "transcript": "mosasaurus was the apex predator of its time so it feared nothing except other mosasaurs",
+      "duration_sec": 6.9,
+      "speech_end_offset_ms": 6564.0,
+      "audio_hash_id": "e15aae861fc241d87fa401388259a8a37b168416e91283e74e00de93e890455c",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0130.wav",
+      "sha256": "410384340d9515a26b1b5d98a3ed7f6d96b5e79ec69b939bb5eac43bb00037e0",
+      "transcript": "most modern research telescopes are enormous facilities in remote areas with favorable atmospheric conditions",
+      "duration_sec": 6.84,
+      "speech_end_offset_ms": 6436.0,
+      "audio_hash_id": "ee400b1604b124e7618df851e88f65f999b7d23edc9981abb21ffc4e93852cc9",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0131.wav",
+      "sha256": "d76a4a5f76d54c662dd89b97deb3e33a0448cc7c3e950041345bcc72c09a8712",
+      "transcript": "most of the buildings on the edges of the complex have been rebuilt in order to give tourists a better idea of how they originally appeared",
+      "duration_sec": 7.62,
+      "speech_end_offset_ms": 7012.0,
+      "audio_hash_id": "ddcf30751c4d501f4b9256c74f5c095fd421ed292d17908517379bf882a124cf",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0132.wav",
+      "sha256": "a994c162a3252f2b33484f76d4ea2fc9f6afbbaf44404a94b9a7c4bdb8f240fb",
+      "transcript": "most of the smaller islands are independent nations or associated with france and known as luxury beach resorts",
+      "duration_sec": 10.52,
+      "speech_end_offset_ms": 10520.0,
+      "audio_hash_id": "8503252cb74e7522f4b40e689cde39ff96c105a62803772159a4fca22b949ab7",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0133.wav",
+      "sha256": "a0aaab437f614819994c8a62c8b98e313a10b839f600465503e47a6c3e1ac539",
+      "transcript": "ms is a disease that affects the central nervous system which is made up of the brain the spinal cord and the optic nerve",
+      "duration_sec": 7.2,
+      "speech_end_offset_ms": 6884.0,
+      "audio_hash_id": "489f20985d8dd4e6c537d34735f87601714ff3410a36009180b7fdd6fd1d1c53",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0134.wav",
+      "sha256": "c80164977ca772dae1b5c546a89844f24c8f513e0ae7dcead1e5e4bddfdf6a1a",
+      "transcript": "muhammad was deeply interested in matters beyond this mundane life. he used to frequent a cave that became known as  hira‘” on the mountain of  noor” light for contemplation",
+      "duration_sec": 11.28,
+      "speech_end_offset_ms": 9956.0,
+      "audio_hash_id": "426d794e18debb757e0037958937575a567f049bfabd2463020c07e3c307b7d0",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0135.wav",
+      "sha256": "a04b8b79a92e8c3dc3889c34210fb50aba64049f69ad91f71af9e0d8a2e6be0c",
+      "transcript": "needless to say if you know a romance language it will be easier for you to learn portuguese",
+      "duration_sec": 8.64,
+      "speech_end_offset_ms": 6596.0,
+      "audio_hash_id": "8b6b61fe7c58b16c6ad7a576eea36802315bee8bd3a3ed0595ff07bdbe5a9e2d",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0136.wav",
+      "sha256": "fd7443f9264b4b0e6e9350fa4041311f87a254729ca77afbe0ef68b3c338d38a",
+      "transcript": "nextgen is a system the faa claims would allow aircraft to fly shorter routes and save millions of gallons of fuel each year and cut carbon emissions",
+      "duration_sec": 10.08,
+      "speech_end_offset_ms": 8644.0,
+      "audio_hash_id": "1c689201475332af635c00ddb894267c07d6b5d6889eb0c9f6f2ed4fcbdb8cd2",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0137.wav",
+      "sha256": "0ff5a689ada5257a3f8f0803eb3f3a19005342a399b7da7de28320e5055f8be4",
+      "transcript": "no tsunami warning has been issued and according to the jakarta geophysics agency no tsunami warning will be issued because the quake did not meet the magnitude 6.5 requirement",
+      "duration_sec": 11.88,
+      "speech_end_offset_ms": 10692.0,
+      "audio_hash_id": "c0d14f1e68d0f55ca72b304c0c2b29e06bafc12a5c84e571133cee701fef211a",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0138.wav",
+      "sha256": "918cb74665e290d1377202d9c4b9e1b5b670cce112da673c37d9ec4c948bc11d",
+      "transcript": "nothing can be seen other than the clear beautiful sky above and the many surrounding mountains very little of this world can be seen or heard from inside the cave",
+      "duration_sec": 9.48,
+      "speech_end_offset_ms": 8996.0,
+      "audio_hash_id": "36787e9550c20a3f642884f7094271398623af20d6a7e59005c354b3a631206b",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0139.wav",
+      "sha256": "29c4c89e49d1afaa5a64b4a21b6b4b3bdf2798dc3c51a24fa009df6198662d1c",
+      "transcript": "on 15 august 1940 the allies invaded southern france the invasion was called operation dragoon",
+      "duration_sec": 10.12,
+      "speech_end_offset_ms": 9540.0,
+      "audio_hash_id": "ace4623076bc5882d38cd1e5c117bb647d69cba8c1ab76995c4aecb26c696ac0",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0140.wav",
+      "sha256": "7397d6efcddec5eb793a76cc142f73ae9e6a90a617192bb565a7071bf7297659",
+      "transcript": "on some routes the larger companies have their own planes but for other routes and smaller firms there was a problem",
+      "duration_sec": 9.36,
+      "speech_end_offset_ms": 7556.0,
+      "audio_hash_id": "0fb89dc3630ba5722089896e78510c784d4e27fbc20ee2b7989c97f6a9222ddc",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0141.wav",
+      "sha256": "d2e0f4cef9ea0fe4b8c86324677a50b6585e31be54397f2521d32dfb9858143b",
+      "transcript": "on the other hand icy and snowy conditions are normal in many countries and traffic goes on mostly uninterrupted all year round",
+      "duration_sec": 9.72,
+      "speech_end_offset_ms": 7972.0,
+      "audio_hash_id": "03071ab4ceaebaef8e03b8e08a4204a3805dabe596df2672a950df849ca2ff06",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0142.wav",
+      "sha256": "ba8932ed1d465901c648d5abe1657c56bf8b242fec4c2a52627df421b3696154",
+      "transcript": "one bomb exploded outside the governor general's office",
+      "duration_sec": 6.64,
+      "speech_end_offset_ms": 6020.0,
+      "audio_hash_id": "7ed83b510da08588c0ddc50dbffe4408822610b4a257c73c6366b2367b9b3be8",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0143.wav",
+      "sha256": "7ad658fd10888c11885c260a623812e6f8f4a5e5c8e558cd6b202dbfabca35bb",
+      "transcript": "one can only wonder what the keyboard will become when something newer comes along",
+      "duration_sec": 5.46,
+      "speech_end_offset_ms": 4996.0,
+      "audio_hash_id": "803103c22bddcde1cff631e5b14d9d773560dc31bd692f739070ae5557c4fed3",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0144.wav",
+      "sha256": "7e88e3267adbfc09e6c81be0a146fe0452a05b261a2fee2debcaf42690360150",
+      "transcript": "only mutations in germ-line cells can be passed on to children while mutations elsewhere can cause cell-death or cancer",
+      "duration_sec": 10.98,
+      "speech_end_offset_ms": 8420.0,
+      "audio_hash_id": "82daf8aace958d4f9de364a110b79f4f385fdb12f821c03955a3140fd57e1494",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0145.wav",
+      "sha256": "f4ceebd538e5c89a06e0c673f2444385d2979287528f15ec06c5f5d406898db1",
+      "transcript": "other subjects on the agenda in bali include saving the world's remaining forests and sharing technologies to help developing nations grow in less-polluting ways",
+      "duration_sec": 9.66,
+      "speech_end_offset_ms": 8388.0,
+      "audio_hash_id": "385dc846164a07131ca950d4aa7f6388147bc80b1f6c530da91ca33affe062c5",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0146.wav",
+      "sha256": "5ec889c4bcf2ae22d4af52f145991f1ffc1748f8bca81c10764994bc9fc49c5d",
+      "transcript": "ottawa is canada's charming bilingual capital and features an array of art galleries and museums that showcase canada's past and present",
+      "duration_sec": 8.52,
+      "speech_end_offset_ms": 8228.0,
+      "audio_hash_id": "76e224be4c55ff2fde7f51a7c2b75177e77c1f244d61d2e2b00dbe67e60aaf71",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0147.wav",
+      "sha256": "7b739bcaf8b0b6561d7f83540305a9c5eb345d38be6019db878fcdecdc53f06c",
+      "transcript": "parisians have a reputation for being egocentric rude and arrogant",
+      "duration_sec": 7.54,
+      "speech_end_offset_ms": 6660.0,
+      "audio_hash_id": "fca5a0b32904e0428ebdba6ed338bd9e300526a6ebc0871bd997ff197f84ed40",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0148.wav",
+      "sha256": "6843aede30e033ce0241661a37b7f34241697478ca607645732a44e77d839bdb",
+      "transcript": "people have known about basic chemical elements such as gold silver and copper from antiquity as these can all be discovered in nature in native form and are relatively simple to mine with primitive tools",
+      "duration_sec": 10.8,
+      "speech_end_offset_ms": 10532.0,
+      "audio_hash_id": "bfbae0829f68d6027fab9b013754407065889e3a2640d82588a1a93d195f73c3",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0149.wav",
+      "sha256": "dd4fd2fe83ea9ea12fe59f1c7ce99b1db69e21fa19d2ffbf2ae49c60b89528b6",
+      "transcript": "people may not anticipate that patience and understanding are also necessary for travellers returning home",
+      "duration_sec": 5.94,
+      "speech_end_offset_ms": 5604.0,
+      "audio_hash_id": "6f108c55c8819e00b91dcf89650d56e3bd913334964d95defe67068ef60d3090",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0150.wav",
+      "sha256": "bbff4a2ffed3a0c719d75e89650ff59bfcdf03abee1b34dfeaf1816d52fbf0f1",
+      "transcript": "people now write messages on computer screens never having to come close to a sharpener",
+      "duration_sec": 8.8,
+      "speech_end_offset_ms": 7812.0,
+      "audio_hash_id": "e47820abef83d32964c7be3691b2c6bab15cdb1c14d8a8b22de57353b3c40c93",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0151.wav",
+      "sha256": "ea414ff56791b476f49174d82b29c0320b93ba5544b1dbfc3412e7e4fb79ec36",
+      "transcript": "plants look their best when in a natural environment so resist the temptation to remove even just one specimen",
+      "duration_sec": 7.68,
+      "speech_end_offset_ms": 6660.0,
+      "audio_hash_id": "dc81d5975f05687546e05a7ba99214f615635e15680040b7cc2a17eb2a841c2e",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0152.wav",
+      "sha256": "51b88ee611b8b0ca59774770b4337afb77fe2467b8d58dcd8d06ece06c032830",
+      "transcript": "plants make oxygen which humans breathe and they take in carbon-dioxide which humans exhale that is breathe out",
+      "duration_sec": 7.02,
+      "speech_end_offset_ms": 6564.0,
+      "audio_hash_id": "06e23cc9dc911db70876c116c5d9fbe6c44c8d2774c35a045fcf63de6607dc21",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0153.wav",
+      "sha256": "1644f798121969952fc120dc84a914520c0ce00467ff624d91c8fd26ca23935f",
+      "transcript": "plants make their food from the sun by photosynthesis they also provide shade",
+      "duration_sec": 7.94,
+      "speech_end_offset_ms": 6852.0,
+      "audio_hash_id": "ae3f454f4994aa2d0d65c48319e655a536e7ce9216fd416ce970f89e30b0c770",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0154.wav",
+      "sha256": "d1b23a81a7cb630682f8123e132c3cd2d940e2e761ce44189edcda131caa86d9",
+      "transcript": "police superintendent chandra shekhar solanki said the accused appeared in court with covered faces",
+      "duration_sec": 7.2,
+      "speech_end_offset_ms": 6500.0,
+      "audio_hash_id": "24233fe8d3b1da4dddae05e0470052dde2d4df21cbebd9ee8326f9ac93cd11d9",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0155.wav",
+      "sha256": "be5bec67c8d2302f43fdad89989897adea48035d607c2bb818443d2ce8621dbe",
+      "transcript": "popular sports include football basketball volleyball water-polo fencing rugby cycling ice hockey roller hockey and f1 motor racing",
+      "duration_sec": 9.3,
+      "speech_end_offset_ms": 8964.0,
+      "audio_hash_id": "e791aa88a074cabef3d6a99972d218ffae130683cfdc5bd091ef618350120d42",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0156.wav",
+      "sha256": "1322df854173e008cd146a94f702b4caabb8749e4f6ed2e0b581d833772d2c66",
+      "transcript": "prides are made up of one to three related adult males along with as many as thirty females and cubs",
+      "duration_sec": 6.78,
+      "speech_end_offset_ms": 6372.0,
+      "audio_hash_id": "930f576318467c10372c1b8998c6cbbdebe05399cb9233cf3b77b07fe10ff7bf",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0157.wav",
+      "sha256": "de973c906ced0ee8d9af72f690ec07d68b28e0b413fb8d14b47bb0f465ea6f83",
+      "transcript": "prior to the arrival of troops haiti had not encountered problems related to the disease since the 1800s",
+      "duration_sec": 7.38,
+      "speech_end_offset_ms": 6244.0,
+      "audio_hash_id": "9926d95c968610f510157bc869d56c10b945400e2fa868e14d935c63e0a53837",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0158.wav",
+      "sha256": "2545ff7a465b5d02d21e7396572d25ab5c3436517fa580ff48be083968564d33",
+      "transcript": "professor pamela ferguson of the university of dundee notes journalists do seem to be walking a dangerous line if publishing photos etc of suspects",
+      "duration_sec": 10.5,
+      "speech_end_offset_ms": 9156.0,
+      "audio_hash_id": "2c09e98a7cd653989ca05b6804e2c138cfd16575eeb0e0218e51b5c367560e29",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0159.wav",
+      "sha256": "86156b69f38b9c6737fe841527dc955501f6588b294997b34fe54bbfccced2f4",
+      "transcript": "re-entry shock comes on sooner than culture shock there's less of a honeymoon phase lasts longer and can be more severe",
+      "duration_sec": 8.58,
+      "speech_end_offset_ms": 7652.0,
+      "audio_hash_id": "8dfbfd9a44ce1f4644428483d708161d496a1c101c773bcc4c62234e8d0b5cdc",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0160.wav",
+      "sha256": "1ca36be8a9b45c5baa292795c5921e9504c40db5ed543a90e86809793ac667b7",
+      "transcript": "regional and seasonal severe weather phenomena include blizzards snowstorms ice storms and dust storms",
+      "duration_sec": 7.58,
+      "speech_end_offset_ms": 6948.0,
+      "audio_hash_id": "48a2f906a9b2c0e3d495c83ebf9d34410c8f15f9ef4db88a082ea7da3962f5ed",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0161.wav",
+      "sha256": "49c81d4c16547a1d70c5f9e0a14769a8e26798ae4bf133036bad01bba8fc7454",
+      "transcript": "regular announcements in the metro are made only in catalan but unplanned disruptions are announced by an automated system in a wide variety of languages including spanish english french arabic and japanese",
+      "duration_sec": 11.52,
+      "speech_end_offset_ms": 11076.0,
+      "audio_hash_id": "8b636bbf78cc5e262bf3c68fc6a69548047324e9bc3a49f20946fd0a8a72e98f",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0162.wav",
+      "sha256": "b06f39399e544fd383633176df14cc37dcb9b37fccb336a472185329e30f1dde",
+      "transcript": "remember that even though music on the main stages may have finished there may be sections of the festival that will keep playing music until late into the night",
+      "duration_sec": 11.9,
+      "speech_end_offset_ms": 11268.0,
+      "audio_hash_id": "86a066ca39c76a8fcbc282c3ef6fdf74e99429ee6b2a0c73e1d84efb7d3588f7",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0163.wav",
+      "sha256": "f090f2c83b21d8da292544a38aa5171586eebc271d49d4b20efc672e603c02b0",
+      "transcript": "resting on the top of one of the mountains north of mecca the cave is completely isolated from the rest of the world",
+      "duration_sec": 10.14,
+      "speech_end_offset_ms": 7972.0,
+      "audio_hash_id": "5b071daa223eb2b8328e2209eeeeaeb75c93d5aeff0f62f9c1690f3c57941f0c",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0164.wav",
+      "sha256": "3f63873741075af824aa856519c8288bab9aed8aa97b185733a1d08801f38396",
+      "transcript": "rip currents are the returning flow from waves breaking off the beach often at a reef or similar",
+      "duration_sec": 6.42,
+      "speech_end_offset_ms": 6020.0,
+      "audio_hash_id": "fbcd340e589d6975bcb8bd2e0dc783378a1349aed0535fcb68873792d668de89",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0165.wav",
+      "sha256": "c95122e91e9bf507f01df4e29efc1aeccc39af85fc16c2db25e430c65592cb18",
+      "transcript": "rolando mendoza fired his m16 rifle at the tourists",
+      "duration_sec": 6.0,
+      "speech_end_offset_ms": 6000.0,
+      "audio_hash_id": "e0442c55ce767dec778b175cdfba4be3fd9f315cd380d90d05bc3841efd235c6",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0166.wav",
+      "sha256": "572267c2a21f959000b1689332b4ae014ccb37f8b2ed688d47404612c29b33df",
+      "transcript": "romanticism had a large element of cultural determinism drawn from writers such as goethe fichte and schlegel",
+      "duration_sec": 10.68,
+      "speech_end_offset_ms": 8804.0,
+      "audio_hash_id": "3e66ef6f47bc11ec9735808ff39ee8823445472578e8e2ca7ed33aac5f908d40",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0167.wav",
+      "sha256": "b27043a8a0fdb55225f1241ed7bd532fd6837fdd67372a068f4e31bccfdebf96",
+      "transcript": "saint petersburg cruises include time in town. cruise passengers are exempted from visa requirements check the terms",
+      "duration_sec": 7.5,
+      "speech_end_offset_ms": 7172.0,
+      "audio_hash_id": "7d54acd69a15cf9cc8278b578284c3c5d779493d50714b9d86d59ff590a0ea89",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0168.wav",
+      "sha256": "c7630174c9746c91fbd55167bb728831bfe7b026c823275029687e396ca4b842",
+      "transcript": "scaffolding is not a method of learning but rather an aid that provides support to individuals whom are undergoing a new learning experience such as using a new computer program or beginning a new project",
+      "duration_sec": 11.76,
+      "speech_end_offset_ms": 10724.0,
+      "audio_hash_id": "0dfd47ca9d855c9f2fe062c1ca0768fe0cab44f5b1baae960e466885cb81baf7",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0169.wav",
+      "sha256": "c19d87fd714005ddff47e905ec3e7cddc1692f9b0dbd2f5b21b177a494dca8bc",
+      "transcript": "scientists hope to understand how planets form especially how the earth formed since comets collided with the earth long ago",
+      "duration_sec": 6.18,
+      "speech_end_offset_ms": 5764.0,
+      "audio_hash_id": "93f486caf2c2e337be5adce9f3f7d3a1172aac2c2c8e884da363bd01fa7804b6",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0170.wav",
+      "sha256": "eee386b821a9ed3df5f2c26b1428f4d2ed79c377600901ce12e4951de2b93e91",
+      "transcript": "scotturb bus 403 travels regularly to sintra stopping at cabo da roca",
+      "duration_sec": 11.56,
+      "speech_end_offset_ms": 10852.0,
+      "audio_hash_id": "273f1a6220ebe131333a151ec3eaf67433e806c0c1cc0fe9e40e8faa120b2f56",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0171.wav",
+      "sha256": "0f7af9a8dba6bb1e308ee3094c86ffbfeff7abaef5f23d95e86968c8747559c4",
+      "transcript": "segregation and recombination shuffle variation back and forth between the two pools with each generation",
+      "duration_sec": 11.52,
+      "speech_end_offset_ms": 9924.0,
+      "audio_hash_id": "025e6fcaab5a15a5c2c378fb54b98a12be5c3e1cec8f3ba860f5de7ac3a1e9ab",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0172.wav",
+      "sha256": "d74d0e2c7f52cfd2bb120f670fe36e1cf01c50b2a19409c16c697073956453f1",
+      "transcript": "several large television screens were installed in various places in rome to let the people watch the ceremony",
+      "duration_sec": 10.26,
+      "speech_end_offset_ms": 8612.0,
+      "audio_hash_id": "f79f956b80247a997ed1b8cfe3bccfd19421c98cbee2243c73bf55a4db239a4a",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0173.wav",
+      "sha256": "97b72d6f54a18197faf6187842a088f0886be5cf2be87b3f77e6739bd2063323",
+      "transcript": "severe weather is the generic term for any dangerous weather phenomenon with the potential to cause damage serious social disruption or loss of human life",
+      "duration_sec": 10.8,
+      "speech_end_offset_ms": 9540.0,
+      "audio_hash_id": "562233438e46ebf414a23b77498dbfce1b6ddf6c3076af2cb389168bb391c800",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0174.wav",
+      "sha256": "9256e19e628b24976d2e076107386a6195f4d67b0dacf6ecab9ad726bf781f7a",
+      "transcript": "sharing a field trip virtually is also a great way to reflect a on a trip and share experiences with future classes",
+      "duration_sec": 7.68,
+      "speech_end_offset_ms": 6660.0,
+      "audio_hash_id": "3ae1fbd171930bc3c7e3b0f698968c87ba41c98ee76c1723dfb1552ce637f656",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0175.wav",
+      "sha256": "e4adbf625cd46ea08b98cde306d71b3beb3d4119f12e3eadcba76bc50cc142a4",
+      "transcript": "since the foundation of asunción in 1537 paraguay has managed to keep a lot of its indigenous character and identity",
+      "duration_sec": 11.82,
+      "speech_end_offset_ms": 9636.0,
+      "audio_hash_id": "cb994a86b910a8a768ed8df174e63df45ca57afa5330ff2b10fe7a96166cea9f",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0176.wav",
+      "sha256": "e86362305151fc0487b361183ca6b11da871847446d7487295ecac93dca6e22b",
+      "transcript": "six hostages including the children and elderly were released early as were the filipino photographers",
+      "duration_sec": 9.16,
+      "speech_end_offset_ms": 8292.0,
+      "audio_hash_id": "c43bc30ce56e79820940b5e0e9ce8b6b71423f5b1c16ac6f55407c114b8321b5",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0177.wav",
+      "sha256": "ee2437c3db3f212b436f5e323f4a5018d4eeaf10605766d63adcbb5ce48cfb60",
+      "transcript": "so it is likely that the notation was added simply as a label",
+      "duration_sec": 5.86,
+      "speech_end_offset_ms": 4868.0,
+      "audio_hash_id": "058bfd8d5ca8d26fa6ec7cf333c2c48f3d97d2952c54af538f1a2834bb1373c1",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0178.wav",
+      "sha256": "cb8239fc97c1aedca5d1057727c9da02c1afd6936a4f25725bd8c25c1cc303ca",
+      "transcript": "some atoms have unstable nuclei which means that they tend to break apart with little or no nudging",
+      "duration_sec": 6.12,
+      "speech_end_offset_ms": 5636.0,
+      "audio_hash_id": "cb70057817721b14df685917957c156edf830228bbeb7e311f9f56a4236ff050",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0179.wav",
+      "sha256": "5035a573abd3ee1ae8f6772b8e91a034ea42c0b100277bd529f6ed3cabad5f15",
+      "transcript": "some cruises feature berlin germany in the brochures as you can see from the map above berlin is no where near the sea and a visit to the city is not included in the price of the cruise",
+      "duration_sec": 10.8,
+      "speech_end_offset_ms": 9764.0,
+      "audio_hash_id": "3444ad8d4014002901bd715c29889aa210ae38eaf48148e747bdf53e17659627",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0180.wav",
+      "sha256": "06b4a90d6a584350590ec568c62d68f48d4e571ef585b90593935e650b5ed12a",
+      "transcript": "some people thought he was right but many people believed the opposite; that the solar system moved around the earth including the sun and even the other stars",
+      "duration_sec": 7.74,
+      "speech_end_offset_ms": 7396.0,
+      "audio_hash_id": "4f1c40e50e24ae934dc933e55179c4ff0e7ac71c5e09c00949b4da08b1bb3170",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0181.wav",
+      "sha256": "47b3c8b86694626615de96f5904ebe9a059c287e6ee3bdaf238ea96224b9aeba",
+      "transcript": "soon after the outbreak of hostilities britain initiated a naval blockade of germany",
+      "duration_sec": 5.46,
+      "speech_end_offset_ms": 5124.0,
+      "audio_hash_id": "b405029de087e69a20320d21b92b5a846de2956d41c885f549cba5985129af88",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0182.wav",
+      "sha256": "3fba458d52bf12c86dd72c9120f8dc180c98b32467da8bbb491fe7350840922d",
+      "transcript": "still take advice from authorities obey all signs and pay close attention to safety warnings",
+      "duration_sec": 8.64,
+      "speech_end_offset_ms": 7396.0,
+      "audio_hash_id": "552413c7198c60a7d936f7183bb2228ddb021dfe987f15255a2b0668ee091397",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0183.wav",
+      "sha256": "7e88ce1f657a4bd79d9aa2219946544217b50ed7afc57c227bf432ec3c7d9040",
+      "transcript": "swirl the two dry powders together and then with clean wet hands squeeze them into a ball",
+      "duration_sec": 8.36,
+      "speech_end_offset_ms": 7652.0,
+      "audio_hash_id": "28b8f3a64980345bed3ceb6fa05e1167a4e10f6fbee0fec303981b26906bb993",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0184.wav",
+      "sha256": "7b42a9df3a0e2d18c3e7da22a5adcc6f899210a68912ebf2a0ec4423bc2706c9",
+      "transcript": "television reports show white smoke coming from the plant",
+      "duration_sec": 5.04,
+      "speech_end_offset_ms": 3780.0,
+      "audio_hash_id": "c5177e517aae6416a1a1a1151ca3f3738dd0f927fe5b98600f3e682a820db4aa",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0185.wav",
+      "sha256": "d57fff1aa9bd094e803b36c3fbb41c8cf2983b1932a4a17d9f62cde7f49058cb",
+      "transcript": "the 25 dunlap broadsides still known to exist are the oldest surviving copies of the document the original handwritten copy has not survived",
+      "duration_sec": 9.84,
+      "speech_end_offset_ms": 8900.0,
+      "audio_hash_id": "a9d8cad62c6d4d691fd17dcf46cd0227dc822a12611d58c09aece387a77580bc",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0186.wav",
+      "sha256": "a25cbc2ef3164e5fce16f94ef3e641f6507476cdb84202935a1c644a86d71e87",
+      "transcript": "the 802.11n standard operates on both the 2.4ghz and 5.0ghz frequencies",
+      "duration_sec": 12.0,
+      "speech_end_offset_ms": 10724.0,
+      "audio_hash_id": "ea84cbcd00ae8bf53cc57121a2c154169c540f1e7c0982fe113cd945e031d5af",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0187.wav",
+      "sha256": "c21f63d2ad6200912e63529f81abe84efbb8a88839a14e54a08025c8cf0baf1f",
+      "transcript": "the announcement was made after trump had a phone conversation with turkish president recep tayyip erdoğan",
+      "duration_sec": 10.8,
+      "speech_end_offset_ms": 9188.0,
+      "audio_hash_id": "afdb584a802ab7876906dc3c5ced8b22659049ba31a535f57f9aed1f802c4a43",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0188.wav",
+      "sha256": "c9e9360b382f981fb827250cd331a5063503d070044aa9a6c1d0899e1a95b52e",
+      "transcript": "the aspect ratio of this format dividing by twelve to obtain the simplest whole-number ratio is therefore said to be 3:2",
+      "duration_sec": 11.04,
+      "speech_end_offset_ms": 10468.0,
+      "audio_hash_id": "d3127249a39e35a215fe63e65cef67b42cbf0c481a51e83aca54e4a9d8bd74a1",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0189.wav",
+      "sha256": "b9bcb85fb550a6a4c98a985edb6f2150c60e1cd2c3db2508ddf0b78a858c486a",
+      "transcript": "the bridge is scheduled to be fully operational in september 2017 when the brazilian customs checkpoints are expected to be finished",
+      "duration_sec": 8.28,
+      "speech_end_offset_ms": 7332.0,
+      "audio_hash_id": "1af7ac46bb4dc7b46332d9fa7eb0758abe09e599d45cc78191432654ab6777d1",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0190.wav",
+      "sha256": "41c31a5496a7e7e19f6775b6d786dc0d5b0bec756da0a081d62b3ba87396cd92",
+      "transcript": "the cabbage juice changes color depending on how acidic or basic alkaline the chemical is",
+      "duration_sec": 5.76,
+      "speech_end_offset_ms": 5348.0,
+      "audio_hash_id": "436bade2d5048b865013b0298af3c70d12720914bc98400733d27616f4eea8e6",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0191.wav",
+      "sha256": "8057969ed4b799c1381d8d2e86fdeda76fcebe03a0930e25027d9a9720d94262",
+      "transcript": "the capital of moldova is chişinău. the local language is romanian but russian is widely used",
+      "duration_sec": 6.6,
+      "speech_end_offset_ms": 6180.0,
+      "audio_hash_id": "729c5adc7349b906d5cda0fbf0faec0225a576101300db1e2cf90d6eff63d15f",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0192.wav",
+      "sha256": "9b06cd90f48dff165bd8f9041357f6db86f187abfc1cd4506fdba280e27d8624",
+      "transcript": "the central authority of the church had been in rome for over a thousand years and this concentration of power and money led many to question whether this tenet was being met",
+      "duration_sec": 9.24,
+      "speech_end_offset_ms": 8900.0,
+      "audio_hash_id": "1354600abe5e3178899ef00ae8c7423d5c5af906130a01d58d556bb7cac35ab3",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0193.wav",
+      "sha256": "22827b9a4b8bf7561b4874edfed99096a7aeec984d587094a3e7a7d784ea3dbf",
+      "transcript": "the city is also the base to climb the nyiragongo volcano along with some of the cheapest mountain gorilla tracking in africa",
+      "duration_sec": 11.28,
+      "speech_end_offset_ms": 9828.0,
+      "audio_hash_id": "a29dd1c0b1a2ee785ab174e2b3b6fe2f56e85f5d482c11e092097c0631d80130",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0194.wav",
+      "sha256": "d88c8782ae9d71e70ed76539635f3021d477a46f13f27498258992b8efb7da53",
+      "transcript": "the city is in stark contrast to the rest of the country's cities because it has more of an arabic flair than of an african",
+      "duration_sec": 6.72,
+      "speech_end_offset_ms": 6404.0,
+      "audio_hash_id": "216a00ff9bddccb78278a7f80b30006fdf4878ec8db1a60afc1afd0a7492f0e3",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0195.wav",
+      "sha256": "975c517cdd4716309f7433f67d865998b6bf4acb281429a936c020b7da7ef27f",
+      "transcript": "the commission was martelly's response to widespread anti-regime protests that started in october",
+      "duration_sec": 8.52,
+      "speech_end_offset_ms": 7460.0,
+      "audio_hash_id": "a38b1bea7f01deb673fc1a6ba59dc84d3e5c7092cd63419554608254a49e145c",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0196.wav",
+      "sha256": "3215f85071b8d93351bf564ed63b35424643663d462346404eb6a09788a61ec8",
+      "transcript": "the composition of these crystals matches those found in the urine of affected pets when compared by infrared spectroscopy ftir",
+      "duration_sec": 11.88,
+      "speech_end_offset_ms": 10692.0,
+      "audio_hash_id": "cfdefe9e920c8a49cba73545099741ccd7238b68d5fc3f913d4a753604fab3b3",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0197.wav",
+      "sha256": "7fab2eef225bebdb8b02ec63acfc5655b6c2fb1d78834a9d91dc01a1918fc4f8",
+      "transcript": "the correlation between brain pathology and behaviour supports scientists in their research",
+      "duration_sec": 6.36,
+      "speech_end_offset_ms": 5412.0,
+      "audio_hash_id": "e16fbd9ae8ba930071457b91a668ced45b1503f577b9349aabf2af59891ed2a1",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0198.wav",
+      "sha256": "97df561ba126d61f9caae7131bc09ed66e2f0418b6a73ddd341cfc97624b6584",
+      "transcript": "the crash occurred high up in mountainous terrain and is believed to have been the result of hostile fire",
+      "duration_sec": 9.82,
+      "speech_end_offset_ms": 8612.0,
+      "audio_hash_id": "7eaa885893ccfa791683855d3a5d409d02819be606514e033e385b293174aa6e",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0199.wav",
+      "sha256": "6e853a63219c1909ba96f428a41a3a10ad5e711f6452cc0590c607b32fd73784",
+      "transcript": "the crust is about 70 km thick on the near side and 100 km thick on the far side",
+      "duration_sec": 7.68,
+      "speech_end_offset_ms": 6596.0,
+      "audio_hash_id": "1147ebe8ca69b68a65751683cd81197f124c08f4f45c41654e9a89ca4d75e8d3",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0200.wav",
+      "sha256": "421ad56d5712b881b5f57c0ac55fb26f829bad546a0621f23764fc5b05d525c2",
+      "transcript": "the debate was sparked by controversy over spending on relief and reconstruction in the wake hurricane katrina which some fiscal conservatives have humorously labeled bush's new orleans deal",
+      "duration_sec": 12.36,
+      "speech_end_offset_ms": 11300.0,
+      "audio_hash_id": "18241d58de2d931eea9db96b4c796e6c0b5d4b5fa003460f25da54bdaf6f972f",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0201.wav",
+      "sha256": "90d0b3d2080dbbd5a3f8798cfc9157f047b986b303bf4f48eb3c1db4b35294bc",
+      "transcript": "the disease is carried by pigs which then migrates to humans through mosquitos",
+      "duration_sec": 5.4,
+      "speech_end_offset_ms": 4868.0,
+      "audio_hash_id": "f5d75735e4ff1d08c5dddf932f5847ad1a679c20cfe4635102c69df5939e8f0a",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0202.wav",
+      "sha256": "63f77a711cc3ec80d06d4684af0d78f67f50cf9916089cbf3934ab713fe15a16",
+      "transcript": "the document according to the leak will refer to the borders dispute which palestine wants based on the borders before the 1967 mideast war",
+      "duration_sec": 8.28,
+      "speech_end_offset_ms": 7876.0,
+      "audio_hash_id": "dcf62beaa31922ce4edf9578740023664ecb88e3c7e7eb8e7aa10366acbad9b7",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0203.wav",
+      "sha256": "ba1916556d0b17995e294859192657f0260b979713b2c8ab7fe98480561adf37",
+      "transcript": "the find also grants insight into the evolution of feathers in birds",
+      "duration_sec": 4.62,
+      "speech_end_offset_ms": 4324.0,
+      "audio_hash_id": "03ea428b1905647e810cd56c1099e509a9bf838afccc59dd4a70f2c0030da68b",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0204.wav",
+      "sha256": "712065b805aa7d2956c2332a170bd77833d52404d9f7ed7130b72517a1cc8f61",
+      "transcript": "the fission bomb works on the principle that it takes energy to put together a nucleus with many protons and neutrons",
+      "duration_sec": 6.3,
+      "speech_end_offset_ms": 5988.0,
+      "audio_hash_id": "262a174d71c4a5d8b8c010373809326123da2f8e3f45d316dc87e1493830ca52",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0205.wav",
+      "sha256": "9fdf5c0384ef030bef0e5a0d7cfb20f7d7ff29727ee1b61625d3aa8ca3aa5fdd",
+      "transcript": "the governor's office said nineteen of the injured were police officers",
+      "duration_sec": 7.26,
+      "speech_end_offset_ms": 5028.0,
+      "audio_hash_id": "a8c93268eaafab48810c2f81bd7c99c3cd08915ae68be25c662645295b4c48b9",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0206.wav",
+      "sha256": "cbd4b8dd37462b47b05d998e5fccea73f535cced5bdc08fb0f6eb2e2a9039b7c",
+      "transcript": "the great pyramid at giza is the only one of the seven wonders that is still standing today",
+      "duration_sec": 6.06,
+      "speech_end_offset_ms": 5220.0,
+      "audio_hash_id": "2810fc4a55c796f9b486b749583bed4416dfd8a64c2d4817a9cc7b07c7d35862",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0207.wav",
+      "sha256": "8fdd99ff1be48d8e96a663695ffb2843b7feda55daccf038ff54b6638e0ea5e1",
+      "transcript": "the haitian institute for justice and democracy has referenced independent studies that suggest the nepalese un peacekeeping battalion unknowingly brought the disease to haiti",
+      "duration_sec": 11.04,
+      "speech_end_offset_ms": 11040.0,
+      "audio_hash_id": "a3939405b89ea303895109f12628a4b05e6f3ccf77c357b155efd81f41aebde8",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0208.wav",
+      "sha256": "dce9081062b3928637be196417459b8b273f7dc9efe4f850a4aea1bae1042945",
+      "transcript": "the hospital has followed protocol for infection control including separating the patient from others to prevent possible infection of others",
+      "duration_sec": 11.42,
+      "speech_end_offset_ms": 10884.0,
+      "audio_hash_id": "4f0c897e38e6176ec5e66adc318fb67d0789e6bbae1b9007c3520ffafd7cb42b",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0209.wav",
+      "sha256": "fb97681afaa1b176ffa6d0ee4d135de064460cae936cb75133657912e13f4f05",
+      "transcript": "the hot chocolate is up to belgian standards fruit juices are pricey but excellent",
+      "duration_sec": 6.42,
+      "speech_end_offset_ms": 5988.0,
+      "audio_hash_id": "ad0915c57a6dca74c51d8a5f28fc5cb115964f8a917a8d29938ffb98fe150c45",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0210.wav",
+      "sha256": "33e7a0be9f1daa4feed2a98e6f411aa2f6b8a4f11aa7d3b3ec0e7054544cccae",
+      "transcript": "the internet combines elements of both mass and interpersonal communication",
+      "duration_sec": 5.72,
+      "speech_end_offset_ms": 5412.0,
+      "audio_hash_id": "e51a87cf1d7879c4aaf1f6de8025d421a9aad23297152e60c5e52b69a2a0e22d",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0211.wav",
+      "sha256": "b48117dd53108378aab58eb239cf14d321c498aec26b6fdb45b3d147a2d3a8c8",
+      "transcript": "the lower the tension the more positive the life force present every person has the potential to find absolute peace and contentment",
+      "duration_sec": 10.4,
+      "speech_end_offset_ms": 9508.0,
+      "audio_hash_id": "13a1b0923d4d83a8607b24f5b9ec96de87b187b81fe3e3906032019301966634",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0212.wav",
+      "sha256": "1c8f33999d4e45461bc985b91cdc96d6956e0e507cf642f8cff8118fd7793987",
+      "transcript": "the moisture on your hands will react with the outer layers which will feel funny and form a sort of shell",
+      "duration_sec": 8.52,
+      "speech_end_offset_ms": 8036.0,
+      "audio_hash_id": "961aac493937ffbfcf9f618b3a288ad066a5ed20ec846383a536dce85a67c405",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0213.wav",
+      "sha256": "faa1bd0c3dee914231c028c0b13b6c657ba2c9616e6c6efc6208836b5b9da849",
+      "transcript": "the moroccan sultan rebuilt the city as daru l-badya and it was given the name casablanca by spanish traders who established trading bases there",
+      "duration_sec": 11.52,
+      "speech_end_offset_ms": 10564.0,
+      "audio_hash_id": "f00d3f4c354862573a752db2d98c7538955d5b3d354ca42b7398b425b6791e4e",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0214.wav",
+      "sha256": "4a268741698620bf552ce078ec8e05defbaac3678b9bfb17a5fd78659143245d",
+      "transcript": "the northern marianas emergency management office said that there were no damages reported in the nation",
+      "duration_sec": 10.8,
+      "speech_end_offset_ms": 7588.0,
+      "audio_hash_id": "fad5b61d08b5aa6b10c12eab38a15443d5a29e02368fd29e35cb1a79d9caa875",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0215.wav",
+      "sha256": "dd8a26a3c399af81649640c3d634e71a9d27422bd517b6c0e1422bb25f1ac8d9",
+      "transcript": "the number of people present was so large that it was not possible for everybody to gain access to the funeral in st peter's square",
+      "duration_sec": 9.66,
+      "speech_end_offset_ms": 7972.0,
+      "audio_hash_id": "d9d76941b1910f77b2bf098d759a30acbd32d14ed93df224034d1fed77405836",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0216.wav",
+      "sha256": "af4966f1e6346c9792ca0213cd95e7ce121fe61f0739ad7149ef46b2c9c8608f",
+      "transcript": "the official falklands currency is the falkland pound fkp whose value is set equivalent to that of one british pound gbp",
+      "duration_sec": 10.08,
+      "speech_end_offset_ms": 9828.0,
+      "audio_hash_id": "ba43e8b90e20009d2556108f582d6d01829beeb3f221cb1cfa5cbd64f25b63ef",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0217.wav",
+      "sha256": "0a1f1fb716b19f30ba4a41f5d830a8a6bdb14f57118d29cbc063f39bcc577f0f",
+      "transcript": "the ph level is indicated by the amount of hydrogen the h in ph ions in the tested chemical",
+      "duration_sec": 6.6,
+      "speech_end_offset_ms": 6116.0,
+      "audio_hash_id": "5bc2694b6a848124aab223eb33cfa980e6505f9dc74006f367069d4d9ba66111",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0218.wav",
+      "sha256": "ab7fad352725fa1c6090e9574c21b3a4be2e08c4ac04e95d7b7fa08f178f4ebb",
+      "transcript": "the photographers later took the place of an aged lady as she needed the lavatory mendoza was gunned down",
+      "duration_sec": 8.62,
+      "speech_end_offset_ms": 7748.0,
+      "audio_hash_id": "c2df26ac2d17d3d4d9f9992efe73da21be2d38c8a8723bf12d977c8514745b27",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0219.wav",
+      "sha256": "41788ef7f607269aac05f1c871508d553cf60ebe92ab69a35b21dc0d90bcc5d9",
+      "transcript": "the presence of a true  invisible team” larson and lafasto 1989 p109 is also a unique component of a virtual team",
+      "duration_sec": 11.94,
+      "speech_end_offset_ms": 10692.0,
+      "audio_hash_id": "fe5f78743671d033552705b815bb98f57117952544cb3aec2f39576f1623b6f9",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0220.wav",
+      "sha256": "84b395d7ecb2307250486d28076431649d506d4f55942f66250535d468c14b72",
+      "transcript": "the pyramid sound and light show is one of the most interesting things in the area for kids",
+      "duration_sec": 8.34,
+      "speech_end_offset_ms": 7428.0,
+      "audio_hash_id": "69eb0515fcff6eff446aa1a173fd253734980e6111e1139979731744145e442f",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0221.wav",
+      "sha256": "3e0634b220436c606b783efa059c792472600249c2ed6d56bd3b5ddaee7e96ef",
+      "transcript": "the report is highly critical of almost every aspect of the present policy of the executive towards iraq and it urges an immediate change of direction",
+      "duration_sec": 8.64,
+      "speech_end_offset_ms": 8640.0,
+      "audio_hash_id": "60308b6068902e27ab2c262e2a5ba0dac6538f577b6e5d8c2b06fae09385d59a",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0222.wav",
+      "sha256": "da79bb7dd0dfb346903846d2f3259c7dffbe452460e902e2bf77f3402f650246",
+      "transcript": "the ruling party south west africa people's organisation swapo also retained a majority in the parliamentary elections",
+      "duration_sec": 10.64,
+      "speech_end_offset_ms": 9892.0,
+      "audio_hash_id": "326e0ba144b8a740e452c94517217a17df15f332035a4f0b0494df3d94e90a1f",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0223.wav",
+      "sha256": "74503ad38a3c277e4eea9de4453cd0f14d4fc19060c7411d31827378fa6f3476",
+      "transcript": "the same month saw another airliner overrun a runway at mashhad and strike a wall killing seventeen",
+      "duration_sec": 6.48,
+      "speech_end_offset_ms": 6148.0,
+      "audio_hash_id": "c287012489ff2582557423cd287d0911a777b16ee37c5ff28babb3a52ce8233c",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0224.wav",
+      "sha256": "4d2fed1b7fe2bd95743219a264bccca93a58f950baabdfd6127b0e9f82564314",
+      "transcript": "the scenes are displayed on the pyramids and the different pyramids are lit up",
+      "duration_sec": 4.32,
+      "speech_end_offset_ms": 3876.0,
+      "audio_hash_id": "c279b4e5ffc2a17a3c1fb82cf12c6e6660d8e9985031efc62317ff71e2b38618",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0225.wav",
+      "sha256": "1d61bc602cdc5ea5872b84c24117dee7ccdca24e19445451e212509f0796a27a",
+      "transcript": "the schengen zone however works somewhat like one country in this respect",
+      "duration_sec": 6.8,
+      "speech_end_offset_ms": 6276.0,
+      "audio_hash_id": "058ef4e05dec29ac342ceed23c35d11c0bbe20465e78668e9512fa0e0d14f93f",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0226.wav",
+      "sha256": "c86b790bd4b8755bf5debb0816a37f10e1049786c3e11da08a8bc2f08942c291",
+      "transcript": "the scientists were able to conclude that the dark matter affect other dark matter in the same way regular matter does",
+      "duration_sec": 12.12,
+      "speech_end_offset_ms": 11140.0,
+      "audio_hash_id": "b2740fb1b1f7e50e43cfa313dc6a918ab955c266788537b76af92df3dfb5b8d7",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0227.wav",
+      "sha256": "98cc97824c3a7ef71b89c4c1a09de40d86f42dd7cd7ff01682e1285808a8613e",
+      "transcript": "the service is frequently used by shipping including pleasure craft as well as expeditions who have remote data and voice needs",
+      "duration_sec": 11.28,
+      "speech_end_offset_ms": 8804.0,
+      "audio_hash_id": "f7be6bec1c5980f721b8f88b78e3c442143794db16bcc379fd616ffff4ddf3c7",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0228.wav",
+      "sha256": "c3fccf7c19a5ee34801b9503264d9e23d5c48eba57bb1eb3ada676ad1097b2c4",
+      "transcript": "the smaller the rossby number the less active the star with respect to magnetic reversals",
+      "duration_sec": 5.64,
+      "speech_end_offset_ms": 5284.0,
+      "audio_hash_id": "ca371c3898bd91b9b288041093e0f39c606f4e890d1cae3c4d7cef04339cfb52",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0229.wav",
+      "sha256": "9a55bc50bec0be1890f7b6046e05ad8e03b40ca4aa78966bc4104840d775529d",
+      "transcript": "the sundarbans are the largest littoral mangrove belt in the world stretching 80 km 50 mi into the bangladeshi and indian hinterland from the coast",
+      "duration_sec": 10.2,
+      "speech_end_offset_ms": 8868.0,
+      "audio_hash_id": "47e912490a81e6446c4f61a52becf4e11b490b5a3a3c5686dbcd3861ed2a73d1",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0230.wav",
+      "sha256": "922b34ea8668283146fde644e6ee1a0f53a1e606053777ffeac26185aeab539a",
+      "transcript": "the sundarbans has been declared a unesco world heritage site the part of the forest within indian territory is called sundarbans national park",
+      "duration_sec": 11.88,
+      "speech_end_offset_ms": 9988.0,
+      "audio_hash_id": "4b564afa8a1e9a843f44be08a67227bab5a803e38371108f7d967104c7d125c9",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0231.wav",
+      "sha256": "291273e34e31a919097adee64a186b897cc26c8bef8e449e556f488da59fb94d",
+      "transcript": "the surface of the moon is made of rocks and dust the outer layer of the moon is called the crust",
+      "duration_sec": 5.64,
+      "speech_end_offset_ms": 5220.0,
+      "audio_hash_id": "c48f30be0136b59badc2b84a5dc734454788413455b10d2af053cd4885307e06",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0232.wav",
+      "sha256": "1122135bd2aa0f4958263a2670a0ad3448070730c4ba21e1651d2a6d74402479",
+      "transcript": "the tenth named storm of the atlantic hurricane season subtropical storm jerry formed in the atlantic ocean today",
+      "duration_sec": 8.66,
+      "speech_end_offset_ms": 7684.0,
+      "audio_hash_id": "aed45d6262daf61fc3c0bde22cd931dc657722cef9964de5906195ba9282d1f4",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0233.wav",
+      "sha256": "b8ef29c39aa6a93dd67a44cd8b654877d7b365d2137886db3e5b569be5a40520",
+      "transcript": "the term bug is used by entomologists in a formal sense for this group of insects",
+      "duration_sec": 6.48,
+      "speech_end_offset_ms": 5316.0,
+      "audio_hash_id": "3c40ca6e4a306032986c27a406288d69176873cda9415b8fb9210637607ca91f",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0234.wav",
+      "sha256": "cb9a7c08cc53c3babbcf826b01edfadd88d4ced6cd16aa9bbcb9e106fd304993",
+      "transcript": "the term safari in popular use refers to overland travel to view the stunning african wildlife particularly on savanna",
+      "duration_sec": 8.64,
+      "speech_end_offset_ms": 7748.0,
+      "audio_hash_id": "de783ab62e1e0dce082600bc91811c65b13450877e667fa10268bd7a72c8c570",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0235.wav",
+      "sha256": "19c1ad705715117e3c82d7ab63695c9c968dde0619570ffa4b66688ff65a0c35",
+      "transcript": "the three kingdoms was one of the bloodiest eras in ancient china's history thousands of people died fighting to sit in the highest seat in the grand palace at xi'an",
+      "duration_sec": 11.88,
+      "speech_end_offset_ms": 10628.0,
+      "audio_hash_id": "8cab4319287629f9df015cc70a02dccb5a41cb12440a17edb67609bfd7ac5c1b",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0236.wav",
+      "sha256": "e449524b304afdde1d0984250d134a9d19c7fdea22566a326a0e3e1f09814023",
+      "transcript": "the tiger's roar is not like the full-voiced roar of a lion but more like a sentence of snarly shouted words",
+      "duration_sec": 8.76,
+      "speech_end_offset_ms": 7268.0,
+      "audio_hash_id": "368a0e185d5a6a8ba199739c2d0e8f7d1420764192908229fbaf1f5a31cbb74d",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0237.wav",
+      "sha256": "2b3daacbd245bb7992c7e566aac5c9b8ecbe4115f3e8fd27a2739a1f079a62fb",
+      "transcript": "the two compounds react with one another to form crystals that may block kidney function researchers at the university said",
+      "duration_sec": 7.44,
+      "speech_end_offset_ms": 6404.0,
+      "audio_hash_id": "fbb8ce6a34ff27b89af3902f1a0197af4493a6a527ec46a7d5ef45c05ecebaa3",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0238.wav",
+      "sha256": "52f3849d5a3bd8d25975e8a8cc847722d00072f00b03287fbf793ef446020ec3",
+      "transcript": "the u.s. corps of engineers estimated that 6 inches of rainfall could breach the previously damaged levees",
+      "duration_sec": 8.76,
+      "speech_end_offset_ms": 7748.0,
+      "audio_hash_id": "709178dbd2fb80eb48b17ee37c812ac28bf7bd5fe3f7117d387788abce3db874",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0239.wav",
+      "sha256": "23132b7ceeb882b64bbc955a37f8c24873510a75d5e5e2d37fe0d9d26b2fea89",
+      "transcript": "the use of video recording has led to important discoveries in the interpretation of micro-expressions facial movements which last a few milliseconds",
+      "duration_sec": 11.54,
+      "speech_end_offset_ms": 11012.0,
+      "audio_hash_id": "ff606a7d025d7713223b37ea8fbf52a891271f37710ba2d5d013e65960ca67db",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0240.wav",
+      "sha256": "dbc7f38a0002650c65e1d95a950a2f1cca08cfe2f127b0f4b96e771de1d15478",
+      "transcript": "the vehicle itself was taken away from the scene of the accident at approximately 1200 gmt on the same day",
+      "duration_sec": 8.58,
+      "speech_end_offset_ms": 7684.0,
+      "audio_hash_id": "1bb8da42053c4014d37ed8403454907c43879936b978ce0aaa037fda4cbb8c77",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0241.wav",
+      "sha256": "41c505e63914224b79d2e8488570c58bfd9612b520c2d47734d118f90d0bc1c9",
+      "transcript": "the vertical clearance under the bridge is 15 meters construction was completed in august 2011 it didn't open to traffic until march 2017",
+      "duration_sec": 9.84,
+      "speech_end_offset_ms": 8804.0,
+      "audio_hash_id": "caf7b57146c04c684a0d96acdfc0f120f751de2d312479775fb18340673eca19",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0242.wav",
+      "sha256": "5e18a8f02937faf77b6c995a4579454b190e82c31151f6b3714dc19815edbd2f",
+      "transcript": "the work done was mostly theoretical but the program was written to simulate observations made of the sagittarius galaxy",
+      "duration_sec": 10.8,
+      "speech_end_offset_ms": 8708.0,
+      "audio_hash_id": "cd83f96d7a0403525172e03d8c1336b1fb6b391492d340f7b38b3904b4277c3e",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0243.wav",
+      "sha256": "a9fb1951c151a9895f0f7f2bb4e32c8dc85580d7cd6632882b955fa61945a520",
+      "transcript": "their disciplined defence ball handling skills and excellent team work made them stand out and it was clear that this was the team to beat",
+      "duration_sec": 7.86,
+      "speech_end_offset_ms": 6916.0,
+      "audio_hash_id": "970c06d9d57dc913698ae2963e9a6b8bed4976e445f9913236be764a647e3cde",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0244.wav",
+      "sha256": "997a644ab86c406d2236c84d459fffb9a709e71049eb00ec56b4e05b1565375d",
+      "transcript": "there are of course christian theological explanations for this tradition but it may well be a pre-christian spring and fertility ritual",
+      "duration_sec": 9.36,
+      "speech_end_offset_ms": 9124.0,
+      "audio_hash_id": "70c892ace7a41979efca085ec42c254caab50647203908dd6306086be87b8ea2",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0245.wav",
+      "sha256": "074757bf0d76d489ebc12050d1f8c664df8e40dbd01d8b996d04be7d54fc226f",
+      "transcript": "there are still many men and women alive who survived their time here and many more who had loved ones who were murdered or worked to death there jews and non-jews alike",
+      "duration_sec": 11.1,
+      "speech_end_offset_ms": 9956.0,
+      "audio_hash_id": "0e09c028f076e3a0dbde405ff8f831cbeeb1f6960274d77c9f21da72b77e2b22",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0246.wav",
+      "sha256": "6f897b29256267236b435563befefdf2212da82a7ccf8adb65814b4d7b66c3b6",
+      "transcript": "there is no universal definition for which manufactured items are antiques some tax agencies define goods older than 100 years as antiques",
+      "duration_sec": 11.8,
+      "speech_end_offset_ms": 10596.0,
+      "audio_hash_id": "0d3d06b60d198b5af299eb77f90e988e2717ba3cfe880bf85e98495f8ccde6a0",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0247.wav",
+      "sha256": "93511edf177fe2f75f95ff21917922f9d7f056efe9b66a657a2091cb6058ca38",
+      "transcript": "there may be more maria on the near side because the crust is thinner it was easier for lava to rise up to the surface",
+      "duration_sec": 8.96,
+      "speech_end_offset_ms": 8324.0,
+      "audio_hash_id": "aa2c7c42dc58c3381a36069e0a88b43a7a1e15a53399f5a0b7385275629908b5",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0248.wav",
+      "sha256": "8b6c5bc34ca9847c8c4aa9f05aa43940dc8e5848296fde1a199bff09d0a746df",
+      "transcript": "these are sometimes-crowded family beaches with a good range of shops lining the shore swimming is safe",
+      "duration_sec": 10.5,
+      "speech_end_offset_ms": 8196.0,
+      "audio_hash_id": "497be8f1f7c54bd3bb7d09233c6ad85063121f2e4f2cc03c95d0de9eac6c432a",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0249.wav",
+      "sha256": "3a03231b0d4b8bdc0ea6ffa005e8c1ea07449e02cb9174c36065ff62fac753c5",
+      "transcript": "these couples may choose to make an adoption plan for their baby",
+      "duration_sec": 6.84,
+      "speech_end_offset_ms": 5956.0,
+      "audio_hash_id": "5d461585ec711932c5440e8568356717b7f6e8cd9c4afbde2ad483da348fcbfb",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0250.wav",
+      "sha256": "18fd614ddd8a742e4f4a8140bd6efbeecf6ad2054d5a1acb8c1da6f00230310c",
+      "transcript": "they are almost all sandy beaches with safe swimming and most have shade provided by pohutukawa trees",
+      "duration_sec": 8.46,
+      "speech_end_offset_ms": 7332.0,
+      "audio_hash_id": "fbb70e388c7536a4e7e4e21e6a2b4223c399c29b3b3e7da92bf1d9e6d7606d33",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0251.wav",
+      "sha256": "7b1b1df0b2d8887d59850fd86f6ed8f67f1747ab17ce084680cf34eff408bae5",
+      "transcript": "they have feet with scales and claws they lay eggs and they walk on their two back legs like a t-rex",
+      "duration_sec": 6.66,
+      "speech_end_offset_ms": 6308.0,
+      "audio_hash_id": "18e75034d753ff96375b742eaa8f95c69b9d4e654055f0ada7406b23488f6474",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0252.wav",
+      "sha256": "3784c9a807ba2e2c514d7fce15c6acdfa84705dfd04da5c4e49be771fe8ab6f8",
+      "transcript": "they usually have special food drink and entertainment offers to keep guests in a good mood and keep them at the premise",
+      "duration_sec": 6.96,
+      "speech_end_offset_ms": 5924.0,
+      "audio_hash_id": "311b44d2ee4545b4abc562f1dc35ceb3702708be5c529293aea594b1c91d16f0",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0253.wav",
+      "sha256": "d3f4a786c77a657cd14c7db408ff9c5cf6d34eee930dbe6a420414d8ec6c9d38",
+      "transcript": "think of the skiing route as of a similar hiking route",
+      "duration_sec": 4.94,
+      "speech_end_offset_ms": 4228.0,
+      "audio_hash_id": "426c98623ce267dcc3249d9a40063221cd2da05c0a6b7cdd157b47b825c64837",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0254.wav",
+      "sha256": "56dd2212a9890e28b1989d6f9c853b936c362558cb90e90292c94b44778abadb",
+      "transcript": "this is an important way to distinguish between some verbs and objects",
+      "duration_sec": 4.5,
+      "speech_end_offset_ms": 4132.0,
+      "audio_hash_id": "3aecc36e7c609b8f320eacbd4d3c3234476bb811c682ba4872b43528795ab3c3",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0255.wav",
+      "sha256": "879eccee9544e54631525ab46ac909b2b84aaf2ba023a54c85b43b3edfad7d33",
+      "transcript": "this is called a chemical's ph you can make an indicator using red cabbage juice",
+      "duration_sec": 5.88,
+      "speech_end_offset_ms": 4836.0,
+      "audio_hash_id": "f911ec7fb03e6581e71a7c58d4fb345307be3cf1c76008ecd52e73cc78843e76",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0256.wav",
+      "sha256": "a79a00436c99bfd48e54ffbda37b19a6b21ebdf06f2033b20bf167207c15f2c4",
+      "transcript": "this is not going to be goodbye this is the closing of one chapter and the opening of a new one",
+      "duration_sec": 5.88,
+      "speech_end_offset_ms": 4996.0,
+      "audio_hash_id": "79ac469d9dcf9b08b372bfa4facc12a3b9e2fa7c403e3d9983c279d5c18d202d",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0257.wav",
+      "sha256": "6ea5aedba9d115a3e3c601f86301ddb1e2496ff36aeaed9ab65626211d4c877b",
+      "transcript": "this offers a good opportunity to see the aurora borealis as the sky will be dark more or less around the clock",
+      "duration_sec": 6.72,
+      "speech_end_offset_ms": 6436.0,
+      "audio_hash_id": "ffdf642c80887c53556f1b87b756f58ffaddd4c37f239340b07bf94f1e9d7702",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0258.wav",
+      "sha256": "c47e787162e13fa2a7831e9478ec13e4947d221689d5c698db64cd382f8295cf",
+      "transcript": "this sediment was necessary for creating sandbars and beaches which served as wildlife habitats",
+      "duration_sec": 11.22,
+      "speech_end_offset_ms": 9540.0,
+      "audio_hash_id": "278dcaa2497b71c02fc1a533c3a25dac14a67b8338240faba539bedfc4241c4f",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0259.wav",
+      "sha256": "4b25e3a3c220ba35c8c172064169f1099505ec91a65ad0bef0aed7ed7134c23e",
+      "transcript": "this seems sensible because the earth doesn't feel as if it's moving does it",
+      "duration_sec": 5.64,
+      "speech_end_offset_ms": 4644.0,
+      "audio_hash_id": "028a85129e67cf2fc8e0c82c4d66502580fc32d1edb040ad8173e4dea19525c0",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0260.wav",
+      "sha256": "c2d3a62549755ca81fd390c5c81487600dd6ffdfd5a5f2d6c467fa7d3adb23b4",
+      "transcript": "this will allow players to control actions and movements in video games by moving the device through the air",
+      "duration_sec": 5.76,
+      "speech_end_offset_ms": 5760.0,
+      "audio_hash_id": "08975f590c26547ac5a1cf2e372de70fe0b948601ac648b20c749f4124f29fec",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0261.wav",
+      "sha256": "0326d90bd49300618413443267a6742d9baccd8eb45e9143593f0346af557200",
+      "transcript": "through the night between 150 and 200 copies were made now known as dunlap broadsides",
+      "duration_sec": 4.8,
+      "speech_end_offset_ms": 4484.0,
+      "audio_hash_id": "2c56ed78b8dd20099f8b19c2964be5893b17f3cff19f75d3bf8251faccb2eef2",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0262.wav",
+      "sha256": "b7fe3210244f881a030f3ae0af7d539a6e4da14aa0182bdd7db68cde2f0cd6a7",
+      "transcript": "throughout 1960s brzezinski worked for john f kennedy as his advisor and then the lyndon b johnson administration",
+      "duration_sec": 8.76,
+      "speech_end_offset_ms": 7268.0,
+      "audio_hash_id": "96ffd01b517c835829b4400c7b501c45881d498fd8fe83915841b2867df8a07e",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0263.wav",
+      "sha256": "e288a15924916d712b0ace9a6fe2fb6552840ddc042b4597267759376811d6f9",
+      "transcript": "thus the pencil was a good friend to many people when it came out",
+      "duration_sec": 3.96,
+      "speech_end_offset_ms": 3652.0,
+      "audio_hash_id": "ebad11119c03fbef938a11f224783b82ec0f8c630b3383cc2641e5494fc9bd9f",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0264.wav",
+      "sha256": "79685ba5563b85ab2d8dba4999d2e804e7457449ffaee2a68b3e6072d1e8284e",
+      "transcript": "to get the best views of hong kong leave the island and head for the kowloon waterfront opposite",
+      "duration_sec": 6.9,
+      "speech_end_offset_ms": 5892.0,
+      "audio_hash_id": "12cccc9c977e9810b39bd83a24e9cdf85911ce1b3d470b5f274de7f7d8e93952",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0265.wav",
+      "sha256": "b8e630784301c56b44775b088c1480f6984b82cf1aeb92c92f1cc64e8e72aba9",
+      "transcript": "to the north and within easy reach is the romantic and fascinating town of sintra and which was made famous to foreigners after a glowing account of its splendours recorded by lord byron",
+      "duration_sec": 11.46,
+      "speech_end_offset_ms": 10948.0,
+      "audio_hash_id": "b763ae2375f442d73b370ffe06c72644a3793658d2e97b4d4ed27ddcdab4478f",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0266.wav",
+      "sha256": "10ac5a93cc330edca21f0fac7204341d5f5de2e5a9c2bde672ce5117a6d822b0",
+      "transcript": "today the only insects that cannot fold back their wings are dragon flies and mayflies",
+      "duration_sec": 5.94,
+      "speech_end_offset_ms": 4932.0,
+      "audio_hash_id": "9bd77ca506ad8b6742857d22e68d75345fd854b6486c0c4968cc186229732008",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0267.wav",
+      "sha256": "f677c798f324a3976c10095e4617938eadeab4df330179d1b4b0446ef9a89b10",
+      "transcript": "traffic flow is the study of the movement of individual drivers and vehicles between two points and the interactions they make with one another",
+      "duration_sec": 7.68,
+      "speech_end_offset_ms": 7428.0,
+      "audio_hash_id": "2174736eff99f57b71acf734532b41c59a71928de75263cfe9a39b4e08663b86",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0268.wav",
+      "sha256": "f3606506788212b574d68aeb4402a2fcc25f70414a1fcba82598d9dd54736bd1",
+      "transcript": "travellers are strongly advised to be aware of any risk of severe weather affecting their area as they may affect any travel plans",
+      "duration_sec": 7.32,
+      "speech_end_offset_ms": 7044.0,
+      "audio_hash_id": "94867b7841937cc806c2c31f9993b74e13f21d6af3c57ee2417bcfa6873863d6",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0269.wav",
+      "sha256": "5b78a00c71e134047560e12f04d7f93b343b82b51b76179809280e1267dcbe80",
+      "transcript": "travellers bound for countries with heavy taxation can sometimes save a considerable amount of money especially on products such as alcoholic beverages and tobacco",
+      "duration_sec": 10.38,
+      "speech_end_offset_ms": 9220.0,
+      "audio_hash_id": "daf991556d3cddd130a5d77b260cb934d34ef5be8d2ca702c7d2b09310549fb4",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0270.wav",
+      "sha256": "877bd9386225f21f97e9d933c7bc5c55b1d95394e7e2d219997a3fb488cce58e",
+      "transcript": "twentieth century research has shown that there are two pools of genetic variation hidden and expressed",
+      "duration_sec": 6.96,
+      "speech_end_offset_ms": 6020.0,
+      "audio_hash_id": "2f575bd033612eaebc4f0ee31d30e697e0bc684a96ed7d91e55cd8c196dbdffa",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0271.wav",
+      "sha256": "5e1310f18368111c391fe3cebcfc0c6ff791d59006eab8b9ec2c14e6d7bcb0de",
+      "transcript": "using ships to transport goods is by far the most efficient way to move large amounts of people and goods across oceans",
+      "duration_sec": 7.62,
+      "speech_end_offset_ms": 6756.0,
+      "audio_hash_id": "5d35514d77e990e54fc6fdf057a3a9d4d06b865afb1def67183eb60b90cf011a",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0272.wav",
+      "sha256": "4c9829abd2e7e0c9dcf3db9797f43f30e19298634135e3c27e71bc844e18f8a9",
+      "transcript": "usually you always here the sound of tourists and vendors the story of the sound and light is just like a story book",
+      "duration_sec": 7.38,
+      "speech_end_offset_ms": 6276.0,
+      "audio_hash_id": "3c512c44943bd2d7e5ea4ed9ef9df70f46e07e8fb2c577375398529d18635376",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0273.wav",
+      "sha256": "17da5690cac39d7bb7e79dd52bd01c77600c98bf14a2021fcc5d137db249fcd1",
+      "transcript": "vatican city's population is around 800 it is the smallest independent country in the world and the country with the lowest population",
+      "duration_sec": 10.74,
+      "speech_end_offset_ms": 7460.0,
+      "audio_hash_id": "c91c9ec8777e54893ebdec8d51489a0d36871b092596b44ed3cfac81bf3d0860",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0274.wav",
+      "sha256": "7e4b0e2ca795e4816cb1977c465ac5057923a69bfcee47dd1040c3df6710a7fa",
+      "transcript": "virtual scaffolds are internalized in the software and are meant to question prompt and explain procedures that may have been to challenging for the student to handle alone",
+      "duration_sec": 9.72,
+      "speech_end_offset_ms": 9284.0,
+      "audio_hash_id": "c2998554f6686be5aaa10f53250e0f125f3121eda61e9b2531fe55c5bcffeddc",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0275.wav",
+      "sha256": "8e91f5b106a6a1e5f5746b199a36e8d9e7d1982e38b686de8ea50198835e84bf",
+      "transcript": "virtual teams are held to the same standards of excellence as conventional teams but there are subtle differences",
+      "duration_sec": 5.64,
+      "speech_end_offset_ms": 5188.0,
+      "audio_hash_id": "d6d48a2689d8c4fd192f4df2eb5631c92480c98b1573647dfaa8daab01b3c603",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0276.wav",
+      "sha256": "7cb1e8a99a5a62a7a52d0e470706d644c515d964b35de280b4a8f67152ddbdc0",
+      "transcript": "we make our houses from plants and make clothes from plants most foods that we eat are plants without plants animals could not survive",
+      "duration_sec": 7.92,
+      "speech_end_offset_ms": 7652.0,
+      "audio_hash_id": "b569967b1d6b3997df226982dabca94ef24b30d0759d1100337406e7c160ee12",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0277.wav",
+      "sha256": "dc8af129b8bb070a3c4329c5f10617da7ecb9fba7db7f76cc88e625024a0ba54",
+      "transcript": "when all available resources are effectively used across the functional departments of an organization creativity and ingenuity can transpire",
+      "duration_sec": 9.18,
+      "speech_end_offset_ms": 8228.0,
+      "audio_hash_id": "f699d10078ab8f8d9fbe975c45eb18e6ea6f3e45d9fc485630f0095ac2a44227",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0278.wav",
+      "sha256": "5685770164d59430aad14fb0ffcb36fde9346ed6332c2ed18db2b1dd2a6bf974",
+      "transcript": "while goma is reasonably safe any visits outside of goma should be researched to understand the state of the fighting that persists in the north kivu province",
+      "duration_sec": 9.84,
+      "speech_end_offset_ms": 9220.0,
+      "audio_hash_id": "b12675640fc73a7744408de8eea8eff3a77f7b5afd8b0b99552e0c3701067728",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0279.wav",
+      "sha256": "395ade7a5894c4d0285358579045fe9c88245d98863c0449beeb8409085f60bf",
+      "transcript": "while he was working at the hospital liggins began to investigate premature labor during his spare time",
+      "duration_sec": 5.46,
+      "speech_end_offset_ms": 5188.0,
+      "audio_hash_id": "81843f4d72d26f5e203d89a61761ff29c59af57aec83e0067789055da66992bf",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0280.wav",
+      "sha256": "7a5e02ef5cfd836846fac94d525efb20be9cb99dbd2167236c0a19f1ad18b9f6",
+      "transcript": "while one experimental vaccine appears able to reduce ebola mortality up until now no drugs have been clearly demonstrated suitable for treating existing infection",
+      "duration_sec": 12.0,
+      "speech_end_offset_ms": 11492.0,
+      "audio_hash_id": "4d5b665ffc78d0019966978ca23585df1b540eebcaf94361c2411f8bf0780ac3",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0281.wav",
+      "sha256": "48530f0085d0db8cdfe2ddb9136a2d01e7410d5dd128504e894ddb635f26df87",
+      "transcript": "with kundalini yoga the kundalini energy enlightenment energy is awakened through yoga postures breathing exercises mantras and visualizations",
+      "duration_sec": 11.04,
+      "speech_end_offset_ms": 10020.0,
+      "audio_hash_id": "0928a2908ac26c566c700c88368b04a88699a770e74a480beb9706aa3777c928",
+      "condition_idx": 0,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0282.wav",
+      "sha256": "e7a9dfeac53b6f7722cdd8d9dab295d895c74c9f717d7b80ba03cbacfc0a3412",
+      "transcript": "with two years of the end of the war the former allies were now enemies and the cold war began",
+      "duration_sec": 7.68,
+      "speech_end_offset_ms": 6340.0,
+      "audio_hash_id": "e82f0e3adf850672ee100373b640ae90720c6b46107ffa26ad9b6441890415a2",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0283.wav",
+      "sha256": "21e216adc693531cf3949d3874dc4f214817d136a96de91064c31dc4f9082a58",
+      "transcript": "women it is recommended that any women travellers say that they are married regardless of actual marital status",
+      "duration_sec": 10.14,
+      "speech_end_offset_ms": 9124.0,
+      "audio_hash_id": "881ce5db68b72c06c481e4a5fc5cfeeb27dbacfb65b0cbf045ba38e73dc949e4",
+      "condition_idx": 1,
+      "condition_count": 2
+    },
+    {
+      "path": "audio/0284.wav",
+      "sha256": "2de4d1049c712826630d1c922f53d207aacc94a4258aa0ddcf1d7b3bafc31085",
+      "transcript": "you may also wish to consult the advice of governments other than your own but their advice is designed for their citizens",
+      "duration_sec": 8.34,
+      "speech_end_offset_ms": 8340.0,
+      "audio_hash_id": "050ff014402b64e65355fbb8acfc8e13c7f31065a677ee3e7c1f36cdb0831ca2",
+      "condition_idx": 1,
+      "condition_count": 2
+    }
+  ]
+}

--- a/runner/src/coval_bench/datasets/manifests/stt-wildasr-reverb.json
+++ b/runner/src/coval_bench/datasets/manifests/stt-wildasr-reverb.json
@@ -1,0 +1,2849 @@
+{
+  "_license": "Apache-2.0 (WildASR; audio derived from FLEURS, CC-BY-4.0)",
+  "id": "stt-wildasr-reverb",
+  "version": "1.0.0",
+  "license": "Apache-2.0 (WildASR; audio derived from FLEURS, CC-BY-4.0)",
+  "source": "bosonai/WildASR environment_degradation__en__fleurs_reverberation_en",
+  "items": [
+    {
+      "path": "audio/0001.wav",
+      "sha256": "1bb8d094d17ec46aef04953941574ca9ee270708da26ba2453ee84d3eb8afd59",
+      "transcript": "\"he [wales] basically lied to us from the start. first by acting as if this was for legal reasons. second by pretending he was listening to us right up to his art deletion.",
+      "duration_sec": 13.43875,
+      "speech_end_offset_ms": 11396.0,
+      "audio_hash_id": "e16c4e2938dbcf9727c330cbcf913d98d5045cd6d2a021c1416d7299f4f644b6",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0002.wav",
+      "sha256": "565a99d7a310b2744a77b351ce7959c41d4ce8aca9dcfa11087c7b8bf2f027e1",
+      "transcript": "a car bomb detonated at police headquarters in gaziantep turkey yesterday morning killed two police officers and injured more than twenty other people",
+      "duration_sec": 14.317438,
+      "speech_end_offset_ms": 7940.0,
+      "audio_hash_id": "743e8fde062bd46565d7f433d8ae21a83fd3cab929a0d23267cbc448737eb123",
+      "condition_idx": 2,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0003.wav",
+      "sha256": "3464dbd166656ce7b9a4ec83644f99e07cdcbb91016755fd1400097722fe67dc",
+      "transcript": "a civilization is a singular culture shared by a significant large group of people who live and work co-operatively a society",
+      "duration_sec": 13.177437,
+      "speech_end_offset_ms": 7684.0,
+      "audio_hash_id": "a84096b33ba64e113341be28e88ef1741889a4da0a95a2691a3e70f9dd5048a6",
+      "condition_idx": 2,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0004.wav",
+      "sha256": "2f059474b3bf4dbf6fb870c34137e7f727d04be249ae98949418c20e9063a40a",
+      "transcript": "a curry is a dish based on herbs and spices together with either meat or vegetables",
+      "duration_sec": 13.357437,
+      "speech_end_offset_ms": 7204.0,
+      "audio_hash_id": "bf96a5049ebec10410bb11d4aad5074669ef73b56c8e48d64a723f44b08dda5f",
+      "condition_idx": 2,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0005.wav",
+      "sha256": "5243cd207a4f2cc289387ad8e5ba808788cd6dbf55a25f9ac419868e9aad0c69",
+      "transcript": "a full 20% of the water that pours out of the planet's rivers into the oceans comes from the amazon",
+      "duration_sec": 11.617437,
+      "speech_end_offset_ms": 6596.0,
+      "audio_hash_id": "6f7f481469433743eeac80f909a888f990c53e9b4321ddfda69754fe8aaff7a4",
+      "condition_idx": 2,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0006.wav",
+      "sha256": "1216f36f1d8ca627ab0f0fbf6b1d88f71bb4cae2110ac16beb37e4c202e095ce",
+      "transcript": "a search of the internet for hostile environment course' will probably provide the address of a local company",
+      "duration_sec": 11.497438,
+      "speech_end_offset_ms": 1572.0,
+      "audio_hash_id": "b241ebd9d210933d65e39b71f947a59c45da638fdc89d00b70d2f56c3e0f843a",
+      "condition_idx": 2,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0007.wav",
+      "sha256": "d268945e497bb6ed6ba1fb0c51dbb177b5926c969f77913de8194d04675ff169",
+      "transcript": "a simple popular dinner especially during the summer is the pa amb oli bread with olive oil tomato and any available condiments such as cheese tunafish etc",
+      "duration_sec": 14.379687,
+      "speech_end_offset_ms": 11204.0,
+      "audio_hash_id": "9afce90ee0b8702af203a42bcd280604cacdb10c0c21a6a2775a0724e0fde9ea",
+      "condition_idx": 1,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0008.wav",
+      "sha256": "30963990f2c8f9e5bc6384b2aa479aeb11489db92c33c9dca4e097868a9ba939",
+      "transcript": "a well rounded athlete the tiger can climb though not well swim leap great distances and pull with five times the force of a strong human",
+      "duration_sec": 11.27875,
+      "speech_end_offset_ms": 9316.0,
+      "audio_hash_id": "897c103ed8c6c665a591c159a33f69f1f9cd8e17094956042e1cad16219b088e",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0009.wav",
+      "sha256": "5a5ae358fb9a7edb340eb8aed4247ab6cd5291fae790510cf4cc199d50075fb0",
+      "transcript": "accepted were aristotle's views on all matters of science including psychology",
+      "duration_sec": 11.017437,
+      "speech_end_offset_ms": 3524.0,
+      "audio_hash_id": "f0325925f75138e56aa492091950c539b5180770117520de353d31c71ec40942",
+      "condition_idx": 2,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0010.wav",
+      "sha256": "5d7a22bdc5af6494be6294c16cf29180fabfdef594d7b2107a2607fb46048d5f",
+      "transcript": "according to japan's nuclear agency radioactive caesium and iodine has been identified at the plant",
+      "duration_sec": 8.45875,
+      "speech_end_offset_ms": 6276.0,
+      "audio_hash_id": "bd672a45c23c33d1fecce4471b347d19b20f2d12b875ea0ac01f9ad437856291",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0011.wav",
+      "sha256": "c773aacf1051268b85153a80e3c82b13814fec6e148c9ca7c57c4d8715068d98",
+      "transcript": "aerosmith have cancelled their remaining concerts on their tour",
+      "duration_sec": 6.099687,
+      "speech_end_offset_ms": 3684.0,
+      "audio_hash_id": "deb5ad6df46cfcf92ec69933160f32596960de642df3a64d8689ebf0d818f312",
+      "condition_idx": 1,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0012.wav",
+      "sha256": "eaf9362c9bb4182260eddedf57ab9cda919f41860970abdbe7c4c123af473e76",
+      "transcript": "after the accident occurred gibson was transported to a hospital but died shortly afterwards",
+      "duration_sec": 10.537437,
+      "speech_end_offset_ms": 1924.0,
+      "audio_hash_id": "0f1f75483a3ce52a84931141e7c09f9b92a486c2929f35449f3a1c351a5ee611",
+      "condition_idx": 2,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0013.wav",
+      "sha256": "f26814d747a8a8017cea41b19b963a7d79d5f9046e8b69610a81f4f74815e31c",
+      "transcript": "after the dam was built in 1963 the seasonal floods that would spread sediment throughout the river were halted",
+      "duration_sec": 10.31875,
+      "speech_end_offset_ms": 7524.0,
+      "audio_hash_id": "a50851255f8d1a15ebaa3dbfc9d0db1c3c1fb79b54197aeb42fb47b4e272fe8d",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0014.wav",
+      "sha256": "474b0bfd883e60062ab0c31386d2e04aa7437c38fadea5530e0a3c645c5fb55f",
+      "transcript": "all nouns alongside the word sie for you always begin with a capital letter even in the middle of a sentence",
+      "duration_sec": 9.83875,
+      "speech_end_offset_ms": 8292.0,
+      "audio_hash_id": "b4faaa147dea6cdc8106976443fb05156df8b8896db01f86cda2e20ecad7af4c",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0015.wav",
+      "sha256": "fdaeda515f53e2ed8d712c6dd48569fb3b6e91bfa2340ace7a7e4d26ea277db4",
+      "transcript": "all things considered we should not be surprised if our own ancestors solved their protein problem in somewhat the same way that chimps on the savanna do today",
+      "duration_sec": 11.619687,
+      "speech_end_offset_ms": 8548.0,
+      "audio_hash_id": "bb89a7334eb20431da63ef6e8ef0e6179be427549cfbdad49507ba0f314f7d17",
+      "condition_idx": 1,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0016.wav",
+      "sha256": "5aeb9db1d5a475cc82cead0f225c0899c0e4ddf903ba5bfd83b33500fed22c62",
+      "transcript": "alloys are basically a mixture of two or more metals don't forget that there are many elements on the periodic table",
+      "duration_sec": 10.519687,
+      "speech_end_offset_ms": 7204.0,
+      "audio_hash_id": "4d0da3a55590f2552a332fbe36f454b418a54e0ef9f04afe62a99febeb6ef0fb",
+      "condition_idx": 1,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0017.wav",
+      "sha256": "7d3ffc71c9660abb64d776c10cdb60f7c4d47b9ef8cfdb6617a32c1eddab8c2b",
+      "transcript": "along the same line men are required to wear trousers covering the knees",
+      "duration_sec": 10.297437,
+      "speech_end_offset_ms": 4900.0,
+      "audio_hash_id": "d1d5b8a53cd8f8cb834d2ad268de7b40388d784a6fa73d76bf179e12a59fbdb1",
+      "condition_idx": 2,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0018.wav",
+      "sha256": "a9f12cc508e3703a8ebeff1d40f24752b53f95f58177a278043db6e469bcb6f9",
+      "transcript": "also after the revolution occupations were open to all male applicants allowing the most ambitious and successful to succeed",
+      "duration_sec": 11.317438,
+      "speech_end_offset_ms": 804.0,
+      "audio_hash_id": "a71faf7756a12490d19d55d082b897ae3c14539bd8e3ee65756bdaec7d79653b",
+      "condition_idx": 2,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0019.wav",
+      "sha256": "e4ccee0e30a64142313609fbc4efd8c6ab769df2b64eabfd2ba0a4e9657ea641",
+      "transcript": "also between each dynasty was an unstable age of divided provinces the best-known of these periods was the three kingdoms epoch taking place for 60 years between the han and the jin dynasty",
+      "duration_sec": 12.89875,
+      "speech_end_offset_ms": 11332.0,
+      "audio_hash_id": "6cd40bbd0d3fec09f3603788482f7c1a73a2d81be1baad06b12cf782535c95dd",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0020.wav",
+      "sha256": "a7bb284d2519718c36d9308c1d4de93d413b0f6ff85c8c0b687197eda39f97ad",
+      "transcript": "also to the north visit the great sanctuary of our lady of fatima shrine a place of worldwide famous marian apparitions",
+      "duration_sec": 11.857437,
+      "speech_end_offset_ms": 932.0,
+      "audio_hash_id": "f83b6ce20433d0e549a6453db9a815447c990215c93a2f5fa2c02ffaf63816bd",
+      "condition_idx": 2,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0021.wav",
+      "sha256": "6605537bf0fc3288dd4968da7c4efe3e8d10edd3b2c3f717a19ae73d11b7f0f2",
+      "transcript": "ancient cultures and tribes began to keep them for easy access to milk hair meat and skins",
+      "duration_sec": 8.979688,
+      "speech_end_offset_ms": 6564.0,
+      "audio_hash_id": "42f24b40d077bc86a494f56d6b70f0888a9474bb99c5ed238a5c7fb64c423600",
+      "condition_idx": 1,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0022.wav",
+      "sha256": "b1d58b9cc9111f961922c436398bdd1d35a23aa78b09a7b55ed20e75a88894f5",
+      "transcript": "angel 2006 explains the continuum approach as a method being used to help organizations reach a higher level of performance",
+      "duration_sec": 9.35875,
+      "speech_end_offset_ms": 7812.0,
+      "audio_hash_id": "dc1b6110d75bdc53686c99506d1b7c85a85d931ec334d555d9913f3049b42458",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0023.wav",
+      "sha256": "da57105409c5af08ef7e9696e626a90e05a67e8af6df53c61f24cc6eb74a2b19",
+      "transcript": "anyone who's going to drive at high latitudes or over mountain passes should consider the possibility of snow ice or freezing temperatures",
+      "duration_sec": 10.719687,
+      "speech_end_offset_ms": 7684.0,
+      "audio_hash_id": "1aa73d94e86876e52529cc8b58e6103e69970cbd1fbbbf532f9051d0a2ad72b0",
+      "condition_idx": 1,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0024.wav",
+      "sha256": "161d52ac12ae3512f1a509ae6a4d82f07d36901f813cb0e8d4b642fde381ad6a",
+      "transcript": "apia is the capital of samoa the town is on the island of upolu and has a population of just under 40,000",
+      "duration_sec": 12.03875,
+      "speech_end_offset_ms": 10564.0,
+      "audio_hash_id": "de0f82b56af6c3a8cbbb561fdfe5e0bc9af2ba4f47efcb50ee1ccfafe9e3f85a",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0025.wav",
+      "sha256": "9b6427172bc4d146887cc1b3c945150bda466edbbda5b086e040622d3745df20",
+      "transcript": "aristotle a philosopher theorised that everything is made up of a mixture of one or more of four elements they were earth water air and fire",
+      "duration_sec": 13.357437,
+      "speech_end_offset_ms": null,
+      "audio_hash_id": "6f6cc2ce8b63dd19aa2a5f6acc39975b7b66f892eb22a0523a2eb4e76b845d42",
+      "condition_idx": 2,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0026.wav",
+      "sha256": "0562f7594f45cd58fed012761336bce22e3ece2a1bc335f6306c007c590a4acf",
+      "transcript": "as a result the performers smoke cannabis joints on stage and the theatre itself is encouraging the audience to join in",
+      "duration_sec": 14.857437,
+      "speech_end_offset_ms": 8708.0,
+      "audio_hash_id": "102f6c644b876945d428eb7c5ce6be738d02fdca67af05c66568e4de69d39f59",
+      "condition_idx": 2,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0027.wav",
+      "sha256": "e0aa77c8378048c4dcc52a8948e6270b86e2f0b6b0e6009293a390436ff88a2c",
+      "transcript": "as a result the process of an organization working together to overcome an obstacle can lead to a new innovative process to serve the customer's need",
+      "duration_sec": 13.19875,
+      "speech_end_offset_ms": 10788.0,
+      "audio_hash_id": "f673e78b4d42295e1b9bbb00f8fddf39991d5fb9d24e511ceaec8e13e8ad6ff9",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0028.wav",
+      "sha256": "688382ba5d60edee82bc497b3d013c429f78d07b1811862557357e1723dc0492",
+      "transcript": "as a result two fish species have become extinct and two others have become endangered including the humpback chub",
+      "duration_sec": 12.51875,
+      "speech_end_offset_ms": 10404.0,
+      "audio_hash_id": "80f23216f6de166c7cd10903fbec5aa0f3e17f1edc1a35033e042dbb6490f4b1",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0029.wav",
+      "sha256": "3218e1e85c6ec2850f8ed9658656a8920ad7aafbfe344024b374382710603471",
+      "transcript": "as knowledge of greek declined the west found itself cut off from its greek philosophical and scientific roots",
+      "duration_sec": 12.319688,
+      "speech_end_offset_ms": 8836.0,
+      "audio_hash_id": "a93aaaf4c7a25d6e4115ce1990d250f4036aa4e666d50da0f137b8db5fdb584f",
+      "condition_idx": 1,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0030.wav",
+      "sha256": "d29700a3c2933c7db724f7873b4a1ac89c30a49a5121b97ce1b8967fb713b3f3",
+      "transcript": "as light pollution in their heyday was not the kind of problem it is today they are usually located in cities or at campuses easier to reach than those built in modern times",
+      "duration_sec": 12.039687,
+      "speech_end_offset_ms": 8804.0,
+      "audio_hash_id": "556cac4cdbceff26ca70ee2763908bced1f7db5531b18cd154b9d6d19bce6b9b",
+      "condition_idx": 1,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0031.wav",
+      "sha256": "6634972807d6c70752148fa54cf8ce96b788be7ee7050ce04012940c46eda6b7",
+      "transcript": "as with all south african national parks there are daily conservation and entry fees for the park",
+      "duration_sec": 11.559688,
+      "speech_end_offset_ms": 8420.0,
+      "audio_hash_id": "d29e8c0ac70d1bc46e003bf2ef62391c410417ae77d2a4aadbc174c39ae4179a",
+      "condition_idx": 1,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0032.wav",
+      "sha256": "541f51b51bcd49539763adc7b779a54cb4d2657e98e58dc68f7b8160171d73a9",
+      "transcript": "asus eee pc earlier launched world-wide for cost-saving and functionality factors became a hot topic in 2007 taipei it month",
+      "duration_sec": 11.81875,
+      "speech_end_offset_ms": 9444.0,
+      "audio_hash_id": "b118edf24b8a099e4a53018ec75971e4d6565d9d103a344787a92e0e22533294",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0033.wav",
+      "sha256": "2fe72fae7dddbbe3d31b1364bcc5b80d2679e51ccc1c3d9e4e31e85b91085981",
+      "transcript": "barcelona's official languages are catalan and spanish about a half prefer to speak catalan a vast majority understands it and virtually everyone knows spanish",
+      "duration_sec": 12.29875,
+      "speech_end_offset_ms": 9476.0,
+      "audio_hash_id": "dc9a89095814559460739d86ce082130b213bfb51292ab53fe7d0416b7484752",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0034.wav",
+      "sha256": "04a0002baef34474f29ba31a708d0a14eea2882fab90d85437f06260c9670ed6",
+      "transcript": "be careful not to allow fabric to become too hot which can cause shrinkage or in extreme cases scorch",
+      "duration_sec": 14.457437,
+      "speech_end_offset_ms": 9476.0,
+      "audio_hash_id": "34d2988c0fc96dd7a33a46cd174ddeffed80ded4c095a5d2e2fba50ffa43487f",
+      "condition_idx": 2,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0035.wav",
+      "sha256": "2c4e18e0f40a25af0c2205c3fe93841012671df03f4e0939966b24312f5c2905",
+      "transcript": "be firm in turning down men and don't be afraid to stand your ground cultural differences or not it doesn't make it ok!",
+      "duration_sec": 13.119687,
+      "speech_end_offset_ms": 9060.0,
+      "audio_hash_id": "4701cd8710c2695b638677bccb05b1e2e60f650236ba06183c4dc282bf4dfe8a",
+      "condition_idx": 1,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0036.wav",
+      "sha256": "ee6589150cd941fa9305479c732f72abf6a5686ddff4d4d5ecb1718779077339",
+      "transcript": "between 10:00-11:00 pm mdt a fire was started by the inmates in the yard",
+      "duration_sec": 13.237438,
+      "speech_end_offset_ms": 7012.0,
+      "audio_hash_id": "4b2c14d48855922bede78eb8ea7436752a59515b10331dfb4833b48ccf245148",
+      "condition_idx": 2,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0037.wav",
+      "sha256": "68e31da26fa4e196b17ba03050f826d099571fa7fc202c24914083174d3efd8d",
+      "transcript": "beyond wednesday's event carpanedo competed in two individual races at the championships",
+      "duration_sec": 9.997438,
+      "speech_end_offset_ms": 3812.0,
+      "audio_hash_id": "832d878f785763a82ba29e2120a0241936476ef002de19c386df54b68f18fe83",
+      "condition_idx": 2,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0038.wav",
+      "sha256": "9fa6c75dc455f4c4a18eaf2d61139473b789b5c6dda5e85cdca8ef83064c3849",
+      "transcript": "bishkek was described as sinking into a state of anarchy by one observer as gangs of people roamed the streets and plundered stores of consumer goods",
+      "duration_sec": 10.67875,
+      "speech_end_offset_ms": 8644.0,
+      "audio_hash_id": "4ba629e68eddcfcfbb4d1a00333d5de1271929aea29653bf777db90b982125d1",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0039.wav",
+      "sha256": "cabaec19c50232e75f72084098d44bb7b26e64e7892c9dd298c5865d266477a3",
+      "transcript": "blogging is a tool that inspires collaboration and encourages students to extend learning well beyond the traditional school day",
+      "duration_sec": 11.739688,
+      "speech_end_offset_ms": 8644.0,
+      "audio_hash_id": "4160e1e3e6ec306f03ecdecce309130ae766ed51a96a5d9f4733d7785711b402",
+      "condition_idx": 1,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0040.wav",
+      "sha256": "d25b20bcc6d4b0f1384bd8a82676e61b794545d5f3a3f48992c9ba7065eb647f",
+      "transcript": "blogs can also help improve student writing while students often begin their blog experience with sloppy grammar and spelling the presence of an audience generally changes that",
+      "duration_sec": 10.899688,
+      "speech_end_offset_ms": 8356.0,
+      "audio_hash_id": "30ce2cf8744b07ac056e9c8d260ecdbcf2aa0ee2cc3ec8ea804302b43464a567",
+      "condition_idx": 1,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0041.wav",
+      "sha256": "0332e22b5c55a96d85fe76a35219bb6344fde902ad1cbb9e1e8fbeb9a9c452ac",
+      "transcript": "built by the egyptians in the third century bce the great pyramid is one of many large pyramid structures built to honor dead pharaoh",
+      "duration_sec": 11.079688,
+      "speech_end_offset_ms": 7812.0,
+      "audio_hash_id": "8d29fe5bc7978ce2e880da08415dd0564107170214b38f35b7c3afabe181c5b6",
+      "condition_idx": 1,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0042.wav",
+      "sha256": "f4469f9b32b811be08aee5b806dccaf22842a9b641ff5455db6cbc1e92a97edd",
+      "transcript": "buses depart the inter-district bus station across the river throughout the day though most especially those heading to the east and jakar/bumthang leave between 06:30 and 07:30",
+      "duration_sec": 13.19875,
+      "speech_end_offset_ms": 11076.0,
+      "audio_hash_id": "ca5dc3c789b3b49a1cd7af5bd37ac0062c7ce805e16280dd19859c53501b4f39",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0043.wav",
+      "sha256": "3cc750a7a043c76f48ed4206b1407c5c03fc4df40850f0d4b94949a2010930d9",
+      "transcript": "but after losing the captain's wicket india only made 36 runs loosing 7 wickets to end the innings",
+      "duration_sec": 12.817438,
+      "speech_end_offset_ms": 6916.0,
+      "audio_hash_id": "3abd3519b84aa5adbfba32b7d2233ee7ad5b2df1f6c8a6b4c227bdd1d4ac9f92",
+      "condition_idx": 2,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0044.wav",
+      "sha256": "aee42f9555656820923533c8f658ff3dd8c7df2a2e0fb69429237adfc6eba78f",
+      "transcript": "but being placed in the high tropics just a few degrees north of equator you will need to deal with both heat always and strong sun when the sky is clear more rarely",
+      "duration_sec": 14.737438,
+      "speech_end_offset_ms": 7620.0,
+      "audio_hash_id": "e9e3f595c2fdf8c9b353b5d3d0d8f237f2b41194a87a65610983f17411ba6c39",
+      "condition_idx": 2,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0045.wav",
+      "sha256": "db7aa4b184293a0ba83a23c4c92136580626e5cddc8fd3a78010efb9c4c278bd",
+      "transcript": "but there are a lot of things about birds that still look like a dinosaur",
+      "duration_sec": 7.499688,
+      "speech_end_offset_ms": 5412.0,
+      "audio_hash_id": "c446fbd3f6977c8569a74d34094ce5afd477813d22e52c31069c8fa5ec57ba43",
+      "condition_idx": 1,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0046.wav",
+      "sha256": "d3d16c63b1d6a2bc55af152b8f5335949c2686f10ff0d8b8099387117293d49f",
+      "transcript": "by 1976 thirty percent of machu picchu had been restored and restoration continues till today",
+      "duration_sec": 11.077438,
+      "speech_end_offset_ms": null,
+      "audio_hash_id": "c06720340c8566c46d5126d11156427090ce7af1c11b60964b2aaa4f43f6629e",
+      "condition_idx": 2,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0047.wav",
+      "sha256": "97be2f3e1f4d3397c37e7499dc0acd140a73d7f76cf20e1cf377ccb1513663a9",
+      "transcript": "california governor arnold schwarzenegger signed into law a bill that bans the sale or rental of violent video games to minors",
+      "duration_sec": 12.41875,
+      "speech_end_offset_ms": 8996.0,
+      "audio_hash_id": "1ad493b577f1267cbd3f7f4d8fd9c96310f3fe57cbd3514ae0cc3a983299a8fb",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0048.wav",
+      "sha256": "169f868e16961e3b482355c14c00a9419e85fd04b1b27c71b2ce1cc979108d17",
+      "transcript": "cancellation policies vary but as of late march most coronavirus-based cancellation policies don't extend to july 2020 when the olympics had been scheduled",
+      "duration_sec": 10.37875,
+      "speech_end_offset_ms": 8900.0,
+      "audio_hash_id": "c89e7127057aa9babf66c1abd7bf88aba2076939f26d37a7bfa0cfdf889e00ea",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0049.wav",
+      "sha256": "9384e7b85877e00495491f191f5348c6334de2a6816636387d4b73e9aee98a20",
+      "transcript": "casablanca is one of the least interesting places to shop in all of morocco",
+      "duration_sec": 7.31875,
+      "speech_end_offset_ms": 5092.0,
+      "audio_hash_id": "9fe42e0fd638f6fe8d6487ebde2bde63872ae0640a05b3d5e23ec1ab169ffd2a",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0050.wav",
+      "sha256": "6bfe722dc847d4bf2d0dd11546cc457e7cdec3c072ef68ba9455ef63e4db971d",
+      "transcript": "children are placed in foster care for a wide variety of reasons that range from neglect to abuse and even to extortion",
+      "duration_sec": 12.859687,
+      "speech_end_offset_ms": 10148.0,
+      "audio_hash_id": "43dff90b69760f26158b47d02f7b71ce356bb7f0b7c292f0af094e8d7c3ae7ad",
+      "condition_idx": 1,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0051.wav",
+      "sha256": "8c36471993450421cac376f83a9d6861db55f2387188045d4e9f08b663bab853",
+      "transcript": "cochamó valley - chile's premier climbing destination known as the yosemite of south america with a variety of granite big walls and crags",
+      "duration_sec": 14.259688,
+      "speech_end_offset_ms": 10468.0,
+      "audio_hash_id": "760aa97289c9959b2f3af42cf7ea20e79e476091084e42e647a1b6830e7d1ba8",
+      "condition_idx": 1,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0052.wav",
+      "sha256": "7e3dbf3a73091d90b4d42822928055ec20ed429725f48950c803d3e11ceadab7",
+      "transcript": "congress began funding the obscenity initiative in fiscal 2005 and specified that the fbi must devote 10 agents to adult pornography",
+      "duration_sec": 11.09875,
+      "speech_end_offset_ms": 8836.0,
+      "audio_hash_id": "ddeb4380057a74ef7ef765916fb3fbf445f24b893f4ff773f6c35675a728cf50",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0053.wav",
+      "sha256": "d2e16780c202617575b271b3c47e42bda0cf8a4f809ef8977842e2d4abf35412",
+      "transcript": "crossties were introduced fairly early to hold the tracks in place gradually however it was realised that tracks would be more efficient if they had a stip of iron on the top",
+      "duration_sec": 12.879687,
+      "speech_end_offset_ms": 10436.0,
+      "audio_hash_id": "d99d09783042f0c2c1f02c15a764cd840878365cda601f7d50a515178a760c96",
+      "condition_idx": 1,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0054.wav",
+      "sha256": "84c5f39787b42de4f8fde9d723011209f1faf383c942a3bcdd95d4039aa2b9cd",
+      "transcript": "cuomo 53 began his governorship earlier this year and signed a bill last month legalizing same-sex marriage",
+      "duration_sec": 11.559688,
+      "speech_end_offset_ms": 8228.0,
+      "audio_hash_id": "c9fbb47b276fe30a2e09606229e1500a289c38a75c08c357dd815778a630cbe1",
+      "condition_idx": 1,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0055.wav",
+      "sha256": "425adb5749edd70d6cfeba95c1272b001d284b2f55105a5e663e0835a087d062",
+      "transcript": "danielle lantagne a un expert on the disease stated the outbreak was likely caused by the peacekeepers",
+      "duration_sec": 7.37875,
+      "speech_end_offset_ms": 5956.0,
+      "audio_hash_id": "b43cb57d964fabece6397b97e813323bc370aa4be408dafb8b0fcfa774defd44",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0056.wav",
+      "sha256": "e3a7afa040f789c42599773822b598b08111345ec535333bdb83a3a7ce299243",
+      "transcript": "del potro had the early advantage in the second set but this too required a tie break after reaching 6-6",
+      "duration_sec": 10.239688,
+      "speech_end_offset_ms": 6948.0,
+      "audio_hash_id": "dbb6c767ec0d386d66e77c64a59cf1a589063f61e1dadb1d4365e78fd6f2eaab",
+      "condition_idx": 1,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0057.wav",
+      "sha256": "9b797833927ee955bea1390baf52fa55a3cd0529459af90041cc25d194cb9590",
+      "transcript": "do not deface the site by marking or scratching graffiti into structures",
+      "duration_sec": 6.639687,
+      "speech_end_offset_ms": 4260.0,
+      "audio_hash_id": "be0449b0e7c9c01348c6dee93afb0ab8d6f87fdb921e38609bba848cdb3e3a06",
+      "condition_idx": 1,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0058.wav",
+      "sha256": "74cf940caea4f6b16defecf5caf9badf3e61941da87c320cb6970314e6e1ea32",
+      "transcript": "due to the underwater topology the return flow is concentrated at a few deeper sections and a fast current to deep water may form there",
+      "duration_sec": 13.059688,
+      "speech_end_offset_ms": 9732.0,
+      "audio_hash_id": "67c0bdd4bab21580aa598dc6ec71034b079c2f716964a0dec1ae7b2df46ec7fe",
+      "condition_idx": 1,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0059.wav",
+      "sha256": "72e84b073c543ade23438598fa8de39b582e379231bfe21a2cc982c308a70cf0",
+      "transcript": "during the 1920s the prevailing attitudes of most citizens and nations was that of pacifism and isolation",
+      "duration_sec": 11.977438,
+      "speech_end_offset_ms": 5732.0,
+      "audio_hash_id": "be6f96aa0cf5a5bd7f3edc964637e04cefd47573eb6dd1676aeb5238c5e4ec6b",
+      "condition_idx": 2,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0060.wav",
+      "sha256": "a281ebd36d12a2fc7609c17a4e2c6e19786a24d96a0dc3bf6c2fbff7dae2979e",
+      "transcript": "during the revolutionary war the thirteen states first formed a weak central government-with the congress being its only component-under the articles of confederation",
+      "duration_sec": 11.15875,
+      "speech_end_offset_ms": 9028.0,
+      "audio_hash_id": "94c00ad2b15a0a51e18b514da607e62c455a6f692293db5be4a82bc3747f6382",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0061.wav",
+      "sha256": "22559b33d273a23dc21fd377680da6c1ba41a132018e20998abffa6c84cc0e72",
+      "transcript": "during the struggle for independence organised by the mau movement a peaceful gathering in the town resulted in the killing of the paramount chief tupua tamasese lealofi iii",
+      "duration_sec": 13.19875,
+      "speech_end_offset_ms": 11428.0,
+      "audio_hash_id": "43671cf3a4082c610a1d4f411638525b16d054034231b62859c930a62daecbb9",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0062.wav",
+      "sha256": "6a5023258b82b3a129e960b05590ef2366a5f139cc82be503d860b758bef9863",
+      "transcript": "during this period of european history the catholic church which had become rich and powerful came under scrutiny",
+      "duration_sec": 12.47875,
+      "speech_end_offset_ms": 10532.0,
+      "audio_hash_id": "54c80bbdc51462784438fe888dca4e4969f1c638af8391c34fb7ed1e6c57a64e",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0063.wav",
+      "sha256": "e3212a93bc4ec201809d01a715f79cff936c8f988b55c57181e25971068d5194",
+      "transcript": "duvall who is married with two adult children did not leave a big impression on miller to whom the story was related",
+      "duration_sec": 7.31875,
+      "speech_end_offset_ms": 6052.0,
+      "audio_hash_id": "a9981b3359214ee9319ef1e48c122d047ef3fd012bd5b7d2eced86efa83a0b20",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0064.wav",
+      "sha256": "aa28f42d97c092c0a2366f360f4fb2e4bfd50cb7d83e5da133842924d568a49e",
+      "transcript": "elements like calcium and potassium are considered metals of course there are also metals like silver and gold",
+      "duration_sec": 8.379687,
+      "speech_end_offset_ms": 5988.0,
+      "audio_hash_id": "34c8b0da72c661b3f49b0f65878a2cd183a0f7a1d4cd546f13c256e0080ec565",
+      "condition_idx": 1,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0065.wav",
+      "sha256": "f59d67b2b50252e5beb3c3b3a8c29bc027cba654129d22f700b548d1e0d2b827",
+      "transcript": "everyone participates in society and uses transportation systems almost everyone complains about transportation systems",
+      "duration_sec": 12.71875,
+      "speech_end_offset_ms": 10660.0,
+      "audio_hash_id": "37d684254313dad5b07b6ef90b64ab0852f80baf0fa22e68452472bacadf79d4",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0066.wav",
+      "sha256": "0da2ce7503c058afca646444255c6aec88cbef6d24e8878effaec36f408ce3a4",
+      "transcript": "everything in the universe is made of matter all matter is made of tiny particles called atoms",
+      "duration_sec": 8.559688,
+      "speech_end_offset_ms": 5924.0,
+      "audio_hash_id": "e75c4e094bb1289d796f1f9bacbd86ab4a05f47b74473a5d2bec89b9aedaf4f2",
+      "condition_idx": 1,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0067.wav",
+      "sha256": "0fcca49bb77678482c1171c900c3c80629f708d430588b367106b365950a0683",
+      "transcript": "fellow wrestlers also paid tribute to luna",
+      "duration_sec": 5.739687,
+      "speech_end_offset_ms": 2820.0,
+      "audio_hash_id": "9849c33498695afa5397667ce299bf0a4f37a70924729bbaf5712ac1533d48f8",
+      "condition_idx": 1,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0068.wav",
+      "sha256": "cc4a99fb8fad77cdd570dcec981b199655921fb3fa553640b266ec6f73aec2e9",
+      "transcript": "feral children may have experienced severe child abuse or trauma before being abandoned or running away",
+      "duration_sec": 8.679688,
+      "speech_end_offset_ms": 5796.0,
+      "audio_hash_id": "2fdc676bd2c3a6590137027d341ca9894b2f4a548f0d3d8f37e9061bbef26c8b",
+      "condition_idx": 1,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0069.wav",
+      "sha256": "6827735a408f7840669a648fa409d3cd277447b916377f083b5f6a0da39693e1",
+      "transcript": "field trips are a large part of any classroom quite often a teacher would love to take her students places to which a bus trip is not an option",
+      "duration_sec": 11.979688,
+      "speech_end_offset_ms": 8420.0,
+      "audio_hash_id": "5d018dacd6ebee79f86f4f3e39401da544fe4e288a8b32a78542ef2b28e461f8",
+      "condition_idx": 1,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0070.wav",
+      "sha256": "7abe680d4a21555970c81ce72cd74ed7a34a45fb2574834bf35b9e136ef9dab4",
+      "transcript": "finally there are many small cats including loose pet cats that eat the far more numerous small prey like insects rodents lizards and birds",
+      "duration_sec": 9.71875,
+      "speech_end_offset_ms": 8420.0,
+      "audio_hash_id": "dfe58b11af60e5f551eb6cefea16325f346c2278c22b6438f32c82807a141bac",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0071.wav",
+      "sha256": "ac0dc8d17d6332c9c16d43a0846aaa55ae538c287610dafdbbbf7183c504d0f2",
+      "transcript": "finland is a great boating destination the land of a thousand lakes has thousands of islands too in the lakes and in the coastal archipelagos",
+      "duration_sec": 11.499688,
+      "speech_end_offset_ms": 8324.0,
+      "audio_hash_id": "be1f9a77ac80f987dc57ab30aca7884758b14e97061b97df42791e3fa1ebe2dd",
+      "condition_idx": 1,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0072.wav",
+      "sha256": "f6f2f14d40166ddcdd0efb24a47b3c3e83480ea14a5c25818ff636ea6f42d791",
+      "transcript": "fire rescue crews eventually doused the fire by 11:35 pm",
+      "duration_sec": 7.859687,
+      "speech_end_offset_ms": 5412.0,
+      "audio_hash_id": "a0713c807a0509a4cda1359b8214e1ba3a9fa3afe4df4b330843d85c2cece485",
+      "condition_idx": 1,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0073.wav",
+      "sha256": "68807a99b6b568034b7e1d04da405cd143a80b215773a019c44b90d1e557803f",
+      "transcript": "first most riders wear riding boots with a heel and a smooth quite narrow sole",
+      "duration_sec": 12.157438,
+      "speech_end_offset_ms": 3396.0,
+      "audio_hash_id": "89ed7ce8209ac6f2b89c7d21cf8140138a8e8a7861b71670ec0ff0dc929aae67",
+      "condition_idx": 2,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0074.wav",
+      "sha256": "e9d6adc6d8627ea49d3a7a3c1d9c3398b0eaaef0803c5c53a197a0c370399241",
+      "transcript": "for example each year students from bennet school in north carolina design a website about their trip to the state capital each year the website gets remodeled but old versions are kept online to serve as a scrapbook",
+      "duration_sec": 13.419688,
+      "speech_end_offset_ms": 10948.0,
+      "audio_hash_id": "aabec8b4247eda61419d8b6d122278f1127203e3be20f431af235b1cf307ebdc",
+      "condition_idx": 1,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0075.wav",
+      "sha256": "89d53a391c67a6b775f875b26b49ae6aa558eb21e90b9277b787d7f03922371b",
+      "transcript": "for the springboks it ended a five-match losing streak",
+      "duration_sec": 7.119688,
+      "speech_end_offset_ms": 4516.0,
+      "audio_hash_id": "de84b49a6385b1e9752530ef7cfaa2b89501d7ef175c2706fb963998458880a1",
+      "condition_idx": 1,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0076.wav",
+      "sha256": "35fd43996cc44f3782a925ea70328adf92b7162503fac8d5bedbcc2836cd65e2",
+      "transcript": "four skiers in the women's sitting group failed to finish their runs and 45 of the 117 total skiers in the giant slalom failed to rank in the race",
+      "duration_sec": 11.977438,
+      "speech_end_offset_ms": null,
+      "audio_hash_id": "1115aceb6983968f84adf0074481b419ab0298d66462f59d26a4302a32294dc5",
+      "condition_idx": 2,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0077.wav",
+      "sha256": "cce378117d408cfb6e9db8aecd3c75bec4932567287a42576d5229a82cc7d10a",
+      "transcript": "giancarlo fisichella lost control of his car and ended the race very soon after the start",
+      "duration_sec": 9.457437,
+      "speech_end_offset_ms": null,
+      "audio_hash_id": "958f11d7ee0cc72f93278550ae45c90c23c5df857297d9d598e30b492c519349",
+      "condition_idx": 2,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0078.wav",
+      "sha256": "2771a087eede274b1172a6c10c7d19122c43274983d1fc637b60d96b5cbbd030",
+      "transcript": "goats seem to have been first domesticated roughly 10,000 years ago in the zagros mountains of iran",
+      "duration_sec": 14.917438,
+      "speech_end_offset_ms": 8580.0,
+      "audio_hash_id": "625280dc9f8bc931db56f19875a9c5e6b8bf2542b06c8125081f5ef7870be9bc",
+      "condition_idx": 2,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0079.wav",
+      "sha256": "985813d339f9b15b8b6bbc3fd6d41a90b866df45ef2c61babab12a32c2e88894",
+      "transcript": "he added that they should not however be asked to take on obligations that go beyond their development stage responsibility and capabilities",
+      "duration_sec": 14.359687,
+      "speech_end_offset_ms": 10980.0,
+      "audio_hash_id": "24115b090cdb94f9049ef8c08372a5d7fa8228237d2384b89a1f8d2018b8d29c",
+      "condition_idx": 1,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0080.wav",
+      "sha256": "cdb8d09af4382020d741b07387ba7242d3dbf1eec63c2f8793ae9df2ee7c1163",
+      "transcript": "he did not set a figure for the cuts saying they will be made based on china's economic output",
+      "duration_sec": 7.43875,
+      "speech_end_offset_ms": 5508.0,
+      "audio_hash_id": "641a7231df122c73d4880bb14196b3e970d6f68229ae210113f4b35d555323ea",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0081.wav",
+      "sha256": "3fe21ec4c9cf54913f1ee3b6d47988c0798b9a66b5ed0fff0626145bd23cb209",
+      "transcript": "he has been unable to take the drugs needed to overcome his pain as they are banned from the games",
+      "duration_sec": 7.43875,
+      "speech_end_offset_ms": 5348.0,
+      "audio_hash_id": "61b9f5dfcb331c53e05151bbf31c7386e791ac9c4f6d90ea2b70e5836af3c7f9",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0082.wav",
+      "sha256": "e5335ce97ffbe4988a300ffa9b0c9d1c7374d42ac0c7bc584525644c052dcc24",
+      "transcript": "he referred to the rumors as political chatter and silliness",
+      "duration_sec": 5.979687,
+      "speech_end_offset_ms": 3652.0,
+      "audio_hash_id": "21b1a151bd689094691d8ad6f3e8ed01d54dd1c5a27add67cd70aca4eb9f3ce6",
+      "condition_idx": 1,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0083.wav",
+      "sha256": "ba4b0909993edd3c241189f27676181f38931c101452dfa70a4ec96c76670d30",
+      "transcript": "he was also engaged in engraving banknotes for many countries recent examples of his work including the prime ministerial portraits on the front of the new canadian $5 and $100 bills",
+      "duration_sec": 13.43875,
+      "speech_end_offset_ms": 12132.0,
+      "audio_hash_id": "8ad86d1b83249f50f0ccafb2ca24a1b651bf7325bd0c269a335c19ee68029dfd",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0084.wav",
+      "sha256": "411180e8137d5001602b605d27d6073ad7bd92162ff9298556ae7533c2239653",
+      "transcript": "he was greeted by singapore's deputy prime minister wong kan seng and discussed trade and terrorism issues with the singapore prime minister lee hsien loong",
+      "duration_sec": 12.71875,
+      "speech_end_offset_ms": 10436.0,
+      "audio_hash_id": "ab1780960f59977ca65820f29d3abf6b02dd863fc49717436e5988d0a30f8369",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0085.wav",
+      "sha256": "1bc458434c5e5e470a30a42471ab9e90d23bcb3db65a9aca77c9022364bf270d",
+      "transcript": "he was initially hospitalised in the james paget hospital in great yarmouth",
+      "duration_sec": 9.639688,
+      "speech_end_offset_ms": 7588.0,
+      "audio_hash_id": "e787c9d839d0e209708e07a0fb21e85e5703e943da45e9ba8bd12ac8c675a972",
+      "condition_idx": 1,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0086.wav",
+      "sha256": "1f4f0bd8f48c53a9537c0cbbf63fc608362e03ffdbcac7da0489456ccd8163b2",
+      "transcript": "he was reportedly aged in his 20s. in a statement bieber said [w]hile i was not present nor directly involved with this tragic accident my thoughts and prayers are with the family of the victim.",
+      "duration_sec": 12.699687,
+      "speech_end_offset_ms": 9636.0,
+      "audio_hash_id": "2ce336b206a3a3fb4203e8543d71b4f65430b8afbd43b7953cacbca9d53b10a3",
+      "condition_idx": 1,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0087.wav",
+      "sha256": "aca916e94ddfdd335fb74bf037ee71b45d59335ca6bda6b348d730031b69422f",
+      "transcript": "he was subsequently relocated to addenbrooke's hospital in cambridge",
+      "duration_sec": 8.979688,
+      "speech_end_offset_ms": 5156.0,
+      "audio_hash_id": "72ab5aae19197ab02f4cbe11cb803207308e289789799fdc01d55cd17f564723",
+      "condition_idx": 1,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0088.wav",
+      "sha256": "90428eaac7e54d502c3231d759e0a81aa541dcd747430c5118df472eee400c8c",
+      "transcript": "hong kong island gives the territory of hong kong its name and is the place that many tourists regard as the main focus",
+      "duration_sec": 11.317438,
+      "speech_end_offset_ms": 1828.0,
+      "audio_hash_id": "928dcf5e9412f50a3ce911f7421d91fa8726de8ca1f37817b803d06af9334687",
+      "condition_idx": 2,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0089.wav",
+      "sha256": "65241060fae9f6dc6bdd3130d9932a90893caf0d6aee753b700f971415d13a0e",
+      "transcript": "however due to the slow communication channels styles in the west could lag behind by 25 to 30 year",
+      "duration_sec": 11.63875,
+      "speech_end_offset_ms": 8932.0,
+      "audio_hash_id": "21ba1e9d11f543eab6f3c8eb6290ce72964d7becca4c0a451a45044245cc854d",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0090.wav",
+      "sha256": "ea69b627ace37265e0cabc7251dad859a2ae5cd3c1052bc6086fa7bae25c44fd",
+      "transcript": "however that is not true although there is something written on the back of the document it is not a treasure map",
+      "duration_sec": 11.09875,
+      "speech_end_offset_ms": 8772.0,
+      "audio_hash_id": "b2cb69a499449fdc15347fe7dda0e3547dbb71c945300da070712d06ccb5d2ce",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0091.wav",
+      "sha256": "894289ced1aadd6a5213ad020e7a4b9fdc2909aff13369a42724df7462933e39",
+      "transcript": "hydrogen ions are protons that had their electrons stripped off them since hydrogen atoms consist of one proton and one electron",
+      "duration_sec": 8.75875,
+      "speech_end_offset_ms": 7364.0,
+      "audio_hash_id": "b4c65fd344148960e56122e06c82d9c17d208186f324db04050210df3e3fb52d",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0092.wav",
+      "sha256": "656f43739d49878584185feb3e28451817f8a1c1e3a4c6b3edc4ac9f85f14003",
+      "transcript": "if you have watched the movie national treasure you may think a treasure map was written on the back of the declaration of independence",
+      "duration_sec": 8.919688,
+      "speech_end_offset_ms": 6468.0,
+      "audio_hash_id": "4de4455b31c3be81d5afbb03dff0ac16b0a988377c15277fa5a786d88d966ac7",
+      "condition_idx": 1,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0093.wav",
+      "sha256": "da93d5803801a218444af91f7b0d039ebb26d221829ab8e8e60d432caba2fba9",
+      "transcript": "if you only go ashore using shipboard excursions you will not need a separate visa as of 2009",
+      "duration_sec": 13.557438,
+      "speech_end_offset_ms": 8164.0,
+      "audio_hash_id": "0725f7345e91a565fff4fc7cae8e1b12134ef8a4d47feb36638e6a6e9c762613",
+      "condition_idx": 2,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0094.wav",
+      "sha256": "ee1430ae5ffc0c0e002c94bc65fd1e46b20589319bb94e1d8413c29172fbc213",
+      "transcript": "if you want to be close to the action you're going to have to get in early to get a camping site close to the music",
+      "duration_sec": 13.537437,
+      "speech_end_offset_ms": 7908.0,
+      "audio_hash_id": "c7b37a670eb49b8c7bd6db2b6fa82b24f4db03d4fb03670e4a456bf52227d819",
+      "condition_idx": 2,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0095.wav",
+      "sha256": "48f31688c266cec967a513e8e13153427792bbb7b3e80fe875d31ef831c90a24",
+      "transcript": "if you're not used to driving on country roads keep your wits about you steep grades narrow lanes and sharp curves predominate",
+      "duration_sec": 13.239688,
+      "speech_end_offset_ms": 10532.0,
+      "audio_hash_id": "4e1cb5f329976e486817eb2fe99a785f68634d70238ae49f46a13399bb7793c9",
+      "condition_idx": 1,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0096.wav",
+      "sha256": "892e76c8c0da2ef21f0c90a556a6dbe851127d24da2324058f56dc12ffcd0fc7",
+      "transcript": "in 1990 it was added to the list of world heritage sites in danger due to the threat of desert sands",
+      "duration_sec": 9.459687,
+      "speech_end_offset_ms": 6660.0,
+      "audio_hash_id": "d0957fb750ccef24d24c0fe9ad44913c2de23887719651c5734b65459dead16b",
+      "condition_idx": 1,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0097.wav",
+      "sha256": "d6b1b1c9167bb35529315c77196bc63ce9b0979184046724c4415ed444a4837d",
+      "transcript": "in 2002 goma was destroyed by lava from the nyiragongo volcano which buried most of the town's streets particularly the town centre",
+      "duration_sec": 11.45875,
+      "speech_end_offset_ms": 9188.0,
+      "audio_hash_id": "91e19bbf7ec0a8a0c59db3a05a1554ec7610b39939b8ffe6cc3002af1d6301c1",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0098.wav",
+      "sha256": "0f3155ab5b26737fa5827aa064c65d545854c360a40466381f8bbb4c4a072239",
+      "transcript": "in a carriage they traveled back to paris surrounded by a mob of people screaming and shouting threats against the king and queen",
+      "duration_sec": 12.359687,
+      "speech_end_offset_ms": 8580.0,
+      "audio_hash_id": "d71e4e21e996c3092e1ea3938449ceca6127fbfc2c4c8409ad22bdf81b5048d5",
+      "condition_idx": 1,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0099.wav",
+      "sha256": "a0a3948b8040197a0c2461cd7977b9024ff60ce1301f3ce5b3dcd76002f93c1f",
+      "transcript": "in fact it is not easy to find at all even if one knew it existed once inside the cave it is a total isolation",
+      "duration_sec": 8.99875,
+      "speech_end_offset_ms": 7204.0,
+      "audio_hash_id": "0cc737b3a28b8c3e672c6adda78cda30be85d095bda12b2593b13772b6d59cb9",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0100.wav",
+      "sha256": "09d7632c9d7b9e23a586d0ee53fb42e8c089dbbc016944fb4fd2cd4d4bdc1d8f",
+      "transcript": "in just two weeks the americans and free french forces had liberated southern france and were turning towards germany",
+      "duration_sec": 11.25875,
+      "speech_end_offset_ms": 9284.0,
+      "audio_hash_id": "553268f7d286464894bfe4a13374ea43523e6771de64c5444aefc071c32f6511",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0101.wav",
+      "sha256": "d2455b2da6e91b529fd67ea56abce1b3a9d703ac32efb496a89d58ea97af5dc2",
+      "transcript": "in many other cities of italy and in the rest of the world particularly in poland similar setups were made which were viewed by a great number of people",
+      "duration_sec": 10.539687,
+      "speech_end_offset_ms": 7524.0,
+      "audio_hash_id": "97773e0b8aa57e46a8e685319bfd9d15a1037f8843c3f6e34ca175766db37ce9",
+      "condition_idx": 1,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0102.wav",
+      "sha256": "3dc9fffa529c1408a601b3accb6602a3adf7a4fdd4ab921a9541597f2039ebc0",
+      "transcript": "in particular it is claimed that one can detect whether a person is lying by interpreting micro-expressions correctly",
+      "duration_sec": 10.417438,
+      "speech_end_offset_ms": null,
+      "audio_hash_id": "e13fab3d2baf0907c43d904331400002ae3f5c9c5a42af098ca59aea41863c82",
+      "condition_idx": 2,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0103.wav",
+      "sha256": "0a2685721d4170655a621698a6de1363040aa8f6e7368caad356019d580f2794",
+      "transcript": "in some areas boiling water for a minute is enough in others several minutes are needed",
+      "duration_sec": 7.779687,
+      "speech_end_offset_ms": 4772.0,
+      "audio_hash_id": "b669b961c8ab6eeddee6ac81547cbdf8e04f1e414764d6ea4640c739b8450daf",
+      "condition_idx": 1,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0104.wav",
+      "sha256": "bf9a3be26b453a787afc6bbba05ca0f30c611d4d2412cdc75f07934b0c26d639",
+      "transcript": "in the archipelagos and lakes you do not necessarily need a yacht",
+      "duration_sec": 8.55875,
+      "speech_end_offset_ms": 6788.0,
+      "audio_hash_id": "3749b307886b560956b4d6df3ee42e83641c2a089628fcc8422d1e14484d84e1",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0105.wav",
+      "sha256": "9abed51227f5f34c3449d65fc3a38d36d568a3a3d18bf6b460c461d26258adbd",
+      "transcript": "in the north the region is bounded by the sahel and in the south and west by the atlantic ocean",
+      "duration_sec": 11.719687,
+      "speech_end_offset_ms": 8132.0,
+      "audio_hash_id": "d6cc99e5b231ab24d48d58527fb0a580bfd85bd1b428db7507688f8ce78c758e",
+      "condition_idx": 1,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0106.wav",
+      "sha256": "6444e0a3248a86bf3a034431eccfc2b0b44fc1c77831f3e277a46acd6f6d6606",
+      "transcript": "in the warm climate of the middle east the house was not so important",
+      "duration_sec": 8.859687,
+      "speech_end_offset_ms": 5444.0,
+      "audio_hash_id": "689c5afd7c03982482b3718cb00aced2477c5d8e81ae87569fb48c9a10773e79",
+      "condition_idx": 1,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0107.wav",
+      "sha256": "65e81570b1df9898497effa21b7db11adca6701748dac29d81c63791f5b0f64a",
+      "transcript": "it also attacked anything that entered the water even a giant dinosaur such as t rex would be no match for it",
+      "duration_sec": 10.19875,
+      "speech_end_offset_ms": 7684.0,
+      "audio_hash_id": "06de964b6f8c14cb9be77a2012c61d93cfa44122d7027d09c45a287c56c01330",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0108.wav",
+      "sha256": "eed2b37c44490ce39e3e63bcef5ee4eb7b852d3acd0ac07eab2b5350351ca886",
+      "transcript": "it has brought us the train the car and many other transportation devices",
+      "duration_sec": 5.93875,
+      "speech_end_offset_ms": 4772.0,
+      "audio_hash_id": "da2b03bdca08c07c39fd46f78d87d9e7e6d6f4e54899c91e2c3205d673a2a350",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0109.wav",
+      "sha256": "e3d5f21219774da29bcb1ffa8a7abc75321a66ad01f583f3d72ca20ce2e91279",
+      "transcript": "it is one of the main attractions of south africa and it is considered the flagship of south african national parks sanparks",
+      "duration_sec": 11.99875,
+      "speech_end_offset_ms": 9444.0,
+      "audio_hash_id": "0e457b0c0f537b46ace37a1b20f1348ac5ad89348d9208d4b439c23ac32e219f",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0110.wav",
+      "sha256": "873d48391f3947615eb1d4da66cb2d94637026d7832e20302ae48ed99c3448d4",
+      "transcript": "it is related to but usually not involving alpine style ski touring or mountaineering the latter ones done in steep terrain and requiring much stiffer skis and boots",
+      "duration_sec": 12.039687,
+      "speech_end_offset_ms": 8900.0,
+      "audio_hash_id": "ae586c3c2247dd7c5fc5df7685fc07145a0c32f380e2054475016442f8b968ca",
+      "condition_idx": 1,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0111.wav",
+      "sha256": "1a15a8bcd08cc549b075d75470f45eed432506274b397127c0d6e28b84d0bf94",
+      "transcript": "it is thinner under the maria and thicker under the highlands",
+      "duration_sec": 8.27875,
+      "speech_end_offset_ms": 6820.0,
+      "audio_hash_id": "593424aea0e150d6594687ea450275cfd6690f75c204a64ba2f8420dd9c3cfbd",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0112.wav",
+      "sha256": "f4ec9dbe5fb24956f91d253c88a1117f12c9b4571c0111ff2db310e8f518ad3c",
+      "transcript": "it was ruled by the vichy french these were french people who had made peace with the germans in 1940 and worked with the invaders instead of fighting them",
+      "duration_sec": 11.739688,
+      "speech_end_offset_ms": 8356.0,
+      "audio_hash_id": "05cd0b01cea31ecc7a932c9eb99451cfff73222bc117b0054c75e494cfbc1ed8",
+      "condition_idx": 1,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0113.wav",
+      "sha256": "c2853c27826606cd18c438d1a5bad4f9c9d9e57be0668879578c08692073c4b2",
+      "transcript": "italian is also the everyday language used by most of those who work in the state while latin is often used in religious ceremonies",
+      "duration_sec": 14.459687,
+      "speech_end_offset_ms": 12196.0,
+      "audio_hash_id": "0a7edcc47a8e60c83e8afbad7957adf01db2a3f58ea34e510ee4413277982008",
+      "condition_idx": 1,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0114.wav",
+      "sha256": "9186f2d391959764db03a5df9b7e8921ccf96ff7263573f56bbb24a8d4c7c210",
+      "transcript": "its renown for being an epicenter of luxury began in about 400 a.d. and lasted up until about 1100 a.d",
+      "duration_sec": 13.619687,
+      "speech_end_offset_ms": 11076.0,
+      "audio_hash_id": "33294fe801039530b17bf5abb486409bff4f3001622c752967f43ac45919a0cd",
+      "condition_idx": 1,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0115.wav",
+      "sha256": "59a7660a69b44f339e25a339c6bdabf3ffdf2b2ef1e353b84fb8e357489beddf",
+      "transcript": "just like the moon exerts a pull on the earth causing tides so does the milky way exert a force on the sagittarius galaxy",
+      "duration_sec": 8.21875,
+      "speech_end_offset_ms": 6756.0,
+      "audio_hash_id": "b685aac5bee1dd13c5a3f035f5a0d5e115440771af38fac53b7d1638044c497c",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0116.wav",
+      "sha256": "f5d109f2a4bb8f72525e5f6728353676f402b780451cfc4cc5cc8b1f7090dcad",
+      "transcript": "large areas further north are quite sparsely populated and some is nearly uninhabited wilderness",
+      "duration_sec": 11.737438,
+      "speech_end_offset_ms": 4580.0,
+      "audio_hash_id": "9c08dce629ea19e5ff9bd6bacf714a25c3da72047280a05f87f281ac1e1ab19a",
+      "condition_idx": 2,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0117.wav",
+      "sha256": "c67436c0b9f17f39c66b460a7ed4ad54fac111c2ec652b53f20fb79214265b2f",
+      "transcript": "last week meti announced that apple had informed it of 34 additional overheating incidents which the company called non-serious",
+      "duration_sec": 13.417438,
+      "speech_end_offset_ms": null,
+      "audio_hash_id": "9de0c7c4097f1febc747b9ba126fa430fae30ab30b715885f7ce474c56dc6a4f",
+      "condition_idx": 2,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0118.wav",
+      "sha256": "82a97a50bda4b4eee248961d498a55af0338bffc3a92e22114c9bdc9b23ff9e1",
+      "transcript": "late on sunday the united states president donald trump in a statement delivered via the press secretary announced us troops would be leaving syria",
+      "duration_sec": 11.03875,
+      "speech_end_offset_ms": 8836.0,
+      "audio_hash_id": "9e9791787c659b97909db7bc88d58b21521f0245b5f3e8daa3af96b0c83f348a",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0119.wav",
+      "sha256": "d908ec90409b8b82ccfb626bb0c77cc3f0605635e5eeb27cb536032b13541b0d",
+      "transcript": "layton had asked for changes to the conservatives' environmental bill during the meeting with the pm asking for a thorough and complete rewriting of the conservative party's environmental bill",
+      "duration_sec": 10.79875,
+      "speech_end_offset_ms": 9284.0,
+      "audio_hash_id": "cbe12fcf343a7aa19b80bce4c69253b0ef85ecec32ffe26c9045824c1367d7a2",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0120.wav",
+      "sha256": "f467cffef65ad1a3fae2b09f9c8da6d3a07c6bda0f0421452e28613b5ff12d6e",
+      "transcript": "liberal criticism of the reconstruction effort has focused on the awarding of reconstruction contracts to perceived washington insiders",
+      "duration_sec": 12.337438,
+      "speech_end_offset_ms": 5252.0,
+      "audio_hash_id": "b98af8d5e5158f67e757c06fc49dcdd1b3624632821e89b3b1302adb6536ca04",
+      "condition_idx": 2,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0121.wav",
+      "sha256": "2fc6c30944b51a30abf7582b53e010539a9d0a149cf063a9e9fbf7e2c39dd356",
+      "transcript": "lion prides act much like packs of wolves or dogs animals surprisingly similar to lions but not other big cats in behavior and also very deadly to their prey",
+      "duration_sec": 13.059688,
+      "speech_end_offset_ms": 10116.0,
+      "audio_hash_id": "9328c316f91f2226b25e6636814338f7eeff02d10837a1af305b9e5949b8046b",
+      "condition_idx": 1,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0122.wav",
+      "sha256": "201867a06cae142d0afde63493fba9271547ddcda4994179360e04f78c38fec1",
+      "transcript": "lions are the most social cats living in large groups called prides",
+      "duration_sec": 7.67875,
+      "speech_end_offset_ms": 5508.0,
+      "audio_hash_id": "d5f58fb227a9a03c92a8635ff713330bcf801d66e04ab8b922b8724e55ba341c",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0123.wav",
+      "sha256": "b391d1a8a9ec0fb22d6e130a12b14dc494e41addef4e67e7ccf3d07432790e80",
+      "transcript": "madagascar is by far the biggest and a continent on its own when it comes to wildlife",
+      "duration_sec": 8.39875,
+      "speech_end_offset_ms": 6468.0,
+      "audio_hash_id": "4703ba8f4df7d97e673a1c4ad7a423945607cca9be1ad7ef6249121a1abe12bb",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0124.wav",
+      "sha256": "820977968d9dc383a79c0f1253925a801ab650ae4b3de529133e19258ff9180d",
+      "transcript": "many german baked goods also feature almonds hazelnuts and other tree nuts popular cakes often pair particularly well with a cup of strong coffee",
+      "duration_sec": 12.579688,
+      "speech_end_offset_ms": 9316.0,
+      "audio_hash_id": "bca97e15bdee269655c036959b08865422a71f97c61f52dceef3997c0921348e",
+      "condition_idx": 1,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0125.wav",
+      "sha256": "7c861672c10919cefa2774635f4dea100e5a4e69ded576f261c8b867b455bf93",
+      "transcript": "many people don't think about them as dinosaurs because they have feathers and can fly",
+      "duration_sec": 8.617437,
+      "speech_end_offset_ms": null,
+      "audio_hash_id": "b4bd1faccbebec3a92a1c0c8bc41859d126a61bee900388f6666c7bf00151bb7",
+      "condition_idx": 2,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0126.wav",
+      "sha256": "3a1691f17ddd50c0e57da3b98898596e38c65ee2d6676e1bb90096a9ab855e5e",
+      "transcript": "martelly swore in a new provisional electoral council cep of nine members yesterday",
+      "duration_sec": 12.259688,
+      "speech_end_offset_ms": 8260.0,
+      "audio_hash_id": "504f4ad75f65c0b50954fc50794f72a1c947c3031b2bc613177a1ba127eda142",
+      "condition_idx": 1,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0127.wav",
+      "sha256": "f04e4a3a1481e573ecd6753654d5e71da537850ca4a4b3c9a6f2b21c9b644285",
+      "transcript": "mass car ownership also leads to a higher incidence of accidents on the roads which leads to the invention of new techniques in healthcare for repairing damaged bodies",
+      "duration_sec": 13.777437,
+      "speech_end_offset_ms": 1988.0,
+      "audio_hash_id": "54a2ebe47cf80f1171fe959bdd2ca28301827fd07fec843ab7872e62e3ca1b35",
+      "condition_idx": 2,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0128.wav",
+      "sha256": "4adceb5c37ca6b02cd44697e15993bdee88bb2aa9ac326e2a7f0fbb0482a75a6",
+      "transcript": "middle order batsmen sachin tendulkar and rahul dravid performed well and made a hundred-run partnership",
+      "duration_sec": 12.937437,
+      "speech_end_offset_ms": 2724.0,
+      "audio_hash_id": "f97923b0d0a096a7d6c2eee7702ae7cbb9ad4cb16d4c4cd0490ec5ab88c8e3af",
+      "condition_idx": 2,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0129.wav",
+      "sha256": "b00f67bb776fb7c4b995755e3f3abc133dd0d3a6ee66170aaa7a2f7f8e09d877",
+      "transcript": "mosasaurus was the apex predator of its time so it feared nothing except other mosasaurs",
+      "duration_sec": 11.197437,
+      "speech_end_offset_ms": 1380.0,
+      "audio_hash_id": "875074e048b39cd7579876cc1962677959545221f50e62d35e8717a6fd7431f2",
+      "condition_idx": 2,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0130.wav",
+      "sha256": "2f2d77855b8dbb280561c5fea8742eae2d150802fbdad4f4e1e05721b3cae23d",
+      "transcript": "most modern research telescopes are enormous facilities in remote areas with favorable atmospheric conditions",
+      "duration_sec": 7.91875,
+      "speech_end_offset_ms": 6596.0,
+      "audio_hash_id": "4a4fb9449544a24bc4448ed05e3b8398057009e010f5c6174a649699bfd3a076",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0131.wav",
+      "sha256": "d1ed39215d3c9049ba2ef3974ee3b9fdd5c5e76ebbe064709fcdf092026b61d3",
+      "transcript": "most of the buildings on the edges of the complex have been rebuilt in order to give tourists a better idea of how they originally appeared",
+      "duration_sec": 9.759688,
+      "speech_end_offset_ms": 7012.0,
+      "audio_hash_id": "512fbf0e79eb45fea590875127c25fbf4855bc9e955410b634061ffec099fec8",
+      "condition_idx": 1,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0132.wav",
+      "sha256": "9d4365faac2c1505ca4ab6327e9833316790dcd03ae14c6e6482fdd58ff67a45",
+      "transcript": "most of the smaller islands are independent nations or associated with france and known as luxury beach resorts",
+      "duration_sec": 12.659688,
+      "speech_end_offset_ms": 10340.0,
+      "audio_hash_id": "8cd7382fdd347db457c19df7f8a2f9520301099220d60555bade49bc9f2f23ab",
+      "condition_idx": 1,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0133.wav",
+      "sha256": "c92578e2e9e8f52808646f370873e20b2799de64bc61470590221532989d4e65",
+      "transcript": "ms is a disease that affects the central nervous system which is made up of the brain the spinal cord and the optic nerve",
+      "duration_sec": 8.27875,
+      "speech_end_offset_ms": 6916.0,
+      "audio_hash_id": "2b028fea9b3aa7be1e72c361bab29976ca7f1520385ee3cb8b8905ae28cb3e15",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0134.wav",
+      "sha256": "b0db23e1f6b459a6c002e8ba46bd12c0d105a2ff3cb9e0ed8a9346f211922204",
+      "transcript": "muhammad was deeply interested in matters beyond this mundane life. he used to frequent a cave that became known as  hira‘” on the mountain of  noor” light for contemplation",
+      "duration_sec": 12.35875,
+      "speech_end_offset_ms": 10020.0,
+      "audio_hash_id": "bcb91ae431d300009ad7458ff325405a7e9cbec50d91c8cfcbeefd3f798fa64f",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0135.wav",
+      "sha256": "f149804a76c2adf9460f81fae71d6ceff23175ce7e0bb3f4ed1544929e05752e",
+      "transcript": "needless to say if you know a romance language it will be easier for you to learn portuguese",
+      "duration_sec": 9.71875,
+      "speech_end_offset_ms": 6788.0,
+      "audio_hash_id": "0ec8f4f3e878336abada23cbc4e573091fd9975ce454a43890f34af8458e94c3",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0136.wav",
+      "sha256": "199e656a81b42408ab065dd1f1bf49170856a62f58f94ee2fd630ae419f76c63",
+      "transcript": "nextgen is a system the faa claims would allow aircraft to fly shorter routes and save millions of gallons of fuel each year and cut carbon emissions",
+      "duration_sec": 11.15875,
+      "speech_end_offset_ms": 8740.0,
+      "audio_hash_id": "1b813dd068cea56c3d0a4d90d2ede7e6b0f24f3bc9afea422474c4b307c5626a",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0137.wav",
+      "sha256": "b1a79c825455d2f33a7c0e981329c95e42f224c50a479d4f14950d7575ac18a7",
+      "transcript": "no tsunami warning has been issued and according to the jakarta geophysics agency no tsunami warning will be issued because the quake did not meet the magnitude 6.5 requirement",
+      "duration_sec": 14.019687,
+      "speech_end_offset_ms": 10692.0,
+      "audio_hash_id": "9f34d29274a63c6d192d8d5da3bf792b6660a90e6ab913e055eb5a29f4158130",
+      "condition_idx": 1,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0138.wav",
+      "sha256": "57a80d737414d3417f81c027a63bb45b41176dcc0f86b2e10a72ceb210f862c5",
+      "transcript": "nothing can be seen other than the clear beautiful sky above and the many surrounding mountains very little of this world can be seen or heard from inside the cave",
+      "duration_sec": 10.55875,
+      "speech_end_offset_ms": 9092.0,
+      "audio_hash_id": "49b289da03c67e746eb9d51bd6340c271db91ddd9ac2c36e5769c933b4077011",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0139.wav",
+      "sha256": "de027c8233fdf6faa206680952ba0156bbfd59d905fe30d1b967f778c8b67788",
+      "transcript": "on 15 august 1940 the allies invaded southern france the invasion was called operation dragoon",
+      "duration_sec": 11.19875,
+      "speech_end_offset_ms": 9572.0,
+      "audio_hash_id": "37d246c1d7ac34a1bdc2a8aada8d6e61665d1b1c963d7172ecd20010748bbfd2",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0140.wav",
+      "sha256": "db0604a81b6a4e31b039b82859682d1abb38f3d60f2e4e21b7de865e879fe3ab",
+      "transcript": "on some routes the larger companies have their own planes but for other routes and smaller firms there was a problem",
+      "duration_sec": 10.43875,
+      "speech_end_offset_ms": 7556.0,
+      "audio_hash_id": "b9c23248808825f64b61526f1834f88d6ee8e913406cd5f10b2398657663e3b9",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0141.wav",
+      "sha256": "b1494f37f3731996da9e4cce4df1f82210d3deb4f1f304e4498eaab8f580cfd8",
+      "transcript": "on the other hand icy and snowy conditions are normal in many countries and traffic goes on mostly uninterrupted all year round",
+      "duration_sec": 10.79875,
+      "speech_end_offset_ms": 7972.0,
+      "audio_hash_id": "7b2568b93a96c0979f76fe8f6d1986255f9b51e8f4b1ab18ecf816cf9ca6534f",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0142.wav",
+      "sha256": "1fad0eb387269945eec8becfa90c7dde8f3ddb715740706f2f0a15c61ad1aac4",
+      "transcript": "one bomb exploded outside the governor general's office",
+      "duration_sec": 10.937437,
+      "speech_end_offset_ms": 6660.0,
+      "audio_hash_id": "9f767d7db0bee3599556acfa298385e81968a36ab44573b364a78f3246a0924e",
+      "condition_idx": 2,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0143.wav",
+      "sha256": "1b1b6b1360c30f894efe3461b2aa691422fcd9f48f502cdb91808d9792b96cb9",
+      "transcript": "one can only wonder what the keyboard will become when something newer comes along",
+      "duration_sec": 6.53875,
+      "speech_end_offset_ms": 5060.0,
+      "audio_hash_id": "66a9b764659f309776a1f217d19407ecb7d0787e31634b8774deb6a48fb81e6c",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0144.wav",
+      "sha256": "e61923ad9c614d2d7d30a0e5347acc8a5a6ad74a58007022afd30b8f4963547e",
+      "transcript": "only mutations in germ-line cells can be passed on to children while mutations elsewhere can cause cell-death or cancer",
+      "duration_sec": 12.05875,
+      "speech_end_offset_ms": 8420.0,
+      "audio_hash_id": "217e357fcedf05c65cbf7353190b0918fa29eccaf5227a98b3f20304c5bf290b",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0145.wav",
+      "sha256": "803c7e47fe0996ddc7aa12a9f748bef3718b69b7700713069d8e0ce227c06a8c",
+      "transcript": "other subjects on the agenda in bali include saving the world's remaining forests and sharing technologies to help developing nations grow in less-polluting ways",
+      "duration_sec": 11.799687,
+      "speech_end_offset_ms": 8548.0,
+      "audio_hash_id": "0343043c7977e9a44bf153b99340c93ebf049977e9a69033e8827d0950ce7a5a",
+      "condition_idx": 1,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0146.wav",
+      "sha256": "500a6d631aae69485585b2b609db58825d8dd144b5878bbe3c87c8582f97691b",
+      "transcript": "ottawa is canada's charming bilingual capital and features an array of art galleries and museums that showcase canada's past and present",
+      "duration_sec": 10.659688,
+      "speech_end_offset_ms": 8260.0,
+      "audio_hash_id": "e072afa6b35d2896d3c5d7c99b36c63c7e0ca91b9c1ebf2b2affa7576728b437",
+      "condition_idx": 1,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0147.wav",
+      "sha256": "f2e455826f4bd700620d727fd8091c6d6a0dac51252d5fde1d01f39b4bff45f4",
+      "transcript": "parisians have a reputation for being egocentric rude and arrogant",
+      "duration_sec": 9.679688,
+      "speech_end_offset_ms": 6628.0,
+      "audio_hash_id": "63c902a6cefb73201eee840cd3b00351ca769fa085d276ccabc004e8db709048",
+      "condition_idx": 1,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0148.wav",
+      "sha256": "786939ea5628c8093e5993b66a0d3149972dcd6653e666ab01be0e362bb867d4",
+      "transcript": "people have known about basic chemical elements such as gold silver and copper from antiquity as these can all be discovered in nature in native form and are relatively simple to mine with primitive tools",
+      "duration_sec": 11.87875,
+      "speech_end_offset_ms": 10660.0,
+      "audio_hash_id": "1e583912a52c0525d2b960058b140bbb9a57939af063798b3c861de734f9741f",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0149.wav",
+      "sha256": "24fde76d12c2e895c7d3a19a6c3e7bd67bd6f1f9f9f8280587cfdbf162ebce2b",
+      "transcript": "people may not anticipate that patience and understanding are also necessary for travellers returning home",
+      "duration_sec": 10.237438,
+      "speech_end_offset_ms": 4804.0,
+      "audio_hash_id": "a58aadfada24db37201c6846e049f9ce03d01097c2b99c60a822d6dcc9d9da8d",
+      "condition_idx": 2,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0150.wav",
+      "sha256": "14190fd5337549c38d6888f2b846645693e85bf8f84530ebca4b65e28ed055fe",
+      "transcript": "people now write messages on computer screens never having to come close to a sharpener",
+      "duration_sec": 13.097437,
+      "speech_end_offset_ms": 8132.0,
+      "audio_hash_id": "62e9842dae00fcb2607139a33954900bc16a9d71b4137d2c22ef58911eca844f",
+      "condition_idx": 2,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0151.wav",
+      "sha256": "401ee59b6ddf409b45bc8e93f759b63b78c4f679755bbb8109c3c64618911641",
+      "transcript": "plants look their best when in a natural environment so resist the temptation to remove even just one specimen",
+      "duration_sec": 9.819688,
+      "speech_end_offset_ms": 6660.0,
+      "audio_hash_id": "b09ea7eab8e59b4e705bba861e966cfd06379284a2c3428567bac5cc7fc12195",
+      "condition_idx": 1,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0152.wav",
+      "sha256": "7505a02fd6c154713cc57d8961cbf78d074aa62a1e8b1d67a1d5e20313972cf3",
+      "transcript": "plants make oxygen which humans breathe and they take in carbon-dioxide which humans exhale that is breathe out",
+      "duration_sec": 11.317438,
+      "speech_end_offset_ms": null,
+      "audio_hash_id": "5a7a6a71f72f9a5bc311a5217e2cc72a92bf806e08eaaff72b5261e866e95310",
+      "condition_idx": 2,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0153.wav",
+      "sha256": "a1238e2958160bf5cc80f0262e807f65b527f32dfc941588728f779ec9b33e94",
+      "transcript": "plants make their food from the sun by photosynthesis they also provide shade",
+      "duration_sec": 9.01875,
+      "speech_end_offset_ms": 6916.0,
+      "audio_hash_id": "3da9359a5f5a217ae20437277d14910058d7f5b11039de0308fa57d07280ea56",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0154.wav",
+      "sha256": "3af5811e9e09b2e81f02c67f39b6252d0fd7498d4e10bf65d22d1960f6af6701",
+      "transcript": "police superintendent chandra shekhar solanki said the accused appeared in court with covered faces",
+      "duration_sec": 11.497438,
+      "speech_end_offset_ms": 6564.0,
+      "audio_hash_id": "12f530ee96c4549f6ae0d6d987dc017e82ab7512a35f3965c1f149075923b103",
+      "condition_idx": 2,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0155.wav",
+      "sha256": "08c1e9a5965065b5ddf1d9cddb02649dec6219f17912153c16a8b9f06dc1a783",
+      "transcript": "popular sports include football basketball volleyball water-polo fencing rugby cycling ice hockey roller hockey and f1 motor racing",
+      "duration_sec": 10.37875,
+      "speech_end_offset_ms": 9028.0,
+      "audio_hash_id": "50da6b0508188eb1c7efd89a0fb5811a2a8cafb0c9087c73c7fbec05a8204ed7",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0156.wav",
+      "sha256": "f3a888d0ad60a1498acea10972f892757e2c2d933a65a63cbe88bed457d6f45a",
+      "transcript": "prides are made up of one to three related adult males along with as many as thirty females and cubs",
+      "duration_sec": 7.85875,
+      "speech_end_offset_ms": 6436.0,
+      "audio_hash_id": "4ea40992d901f6ca0773938c19fb66453ab94a295e0a2a33cb1ebe933db34083",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0157.wav",
+      "sha256": "73890ebbca0a6cbfeb9740feed24c4a83ba38152da375f9f65db94503cbd614e",
+      "transcript": "prior to the arrival of troops haiti had not encountered problems related to the disease since the 1800s",
+      "duration_sec": 8.45875,
+      "speech_end_offset_ms": 6276.0,
+      "audio_hash_id": "c831cc0f8f5b0f6b25f02f64512ec0686899866bb71e78399ec2ddced7656999",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0158.wav",
+      "sha256": "c3e0e3f7c68e27749ec1ed766d57d011962e2380a7f9e959be6f04a8261ebd29",
+      "transcript": "professor pamela ferguson of the university of dundee notes journalists do seem to be walking a dangerous line if publishing photos etc of suspects",
+      "duration_sec": 11.57875,
+      "speech_end_offset_ms": 9316.0,
+      "audio_hash_id": "bd1e717ae5fa9a03808159651c450990cff34abe317e62fe74231581d1daa276",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0159.wav",
+      "sha256": "2d1b4cf10e8f89320a89cc9796bd30f6236cb19ffda51a4509d74eec4b559846",
+      "transcript": "re-entry shock comes on sooner than culture shock there's less of a honeymoon phase lasts longer and can be more severe",
+      "duration_sec": 12.877437,
+      "speech_end_offset_ms": 6052.0,
+      "audio_hash_id": "91b2770e194cee2e1e4e086acff516adf4d390c83bc1deb6324ade3c7ce573ed",
+      "condition_idx": 2,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0160.wav",
+      "sha256": "f6a9694235f490ffeb3cc177c57b947c75caa5aba6828d42364b46ce2fc88455",
+      "transcript": "regional and seasonal severe weather phenomena include blizzards snowstorms ice storms and dust storms",
+      "duration_sec": 9.719687,
+      "speech_end_offset_ms": 7076.0,
+      "audio_hash_id": "a21d406d8fe852bce8b191bf986a8cea8ba814dac4af6f8fd6b6ca704cca2c88",
+      "condition_idx": 1,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0161.wav",
+      "sha256": "14bec918e556ce8ed117caf5a73ee82e32c35d29e385342ed22200d88cb9d4b0",
+      "transcript": "regular announcements in the metro are made only in catalan but unplanned disruptions are announced by an automated system in a wide variety of languages including spanish english french arabic and japanese",
+      "duration_sec": 12.59875,
+      "speech_end_offset_ms": 11204.0,
+      "audio_hash_id": "5627cdedbdf574a0aba4d0abda71629cd41ba58dad994b22acb579ac78d4991d",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0162.wav",
+      "sha256": "e0d8bdb499b3e10321080691b06aab9664dd8cd0ad121eba5a0a7529a5502b2d",
+      "transcript": "remember that even though music on the main stages may have finished there may be sections of the festival that will keep playing music until late into the night",
+      "duration_sec": 12.97875,
+      "speech_end_offset_ms": 11332.0,
+      "audio_hash_id": "473eb215164674abc2103dca22e78ae8aa0142a4d7fc54b0f2a75d0ca0974ef4",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0163.wav",
+      "sha256": "9b48c78d2b2ea104818c158880ba297a02e178219e4e678fe1dd5971ea3b0867",
+      "transcript": "resting on the top of one of the mountains north of mecca the cave is completely isolated from the rest of the world",
+      "duration_sec": 11.21875,
+      "speech_end_offset_ms": 8036.0,
+      "audio_hash_id": "8c915ec3c80d82ad6bf64ee6c80828ec832641f4de7e02aca56cd22162185a32",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0164.wav",
+      "sha256": "bde0b2f3d7df1ab1aae5f04da67dd17b7150cab28237a3bcb2d05870a6346205",
+      "transcript": "rip currents are the returning flow from waves breaking off the beach often at a reef or similar",
+      "duration_sec": 7.49875,
+      "speech_end_offset_ms": 6084.0,
+      "audio_hash_id": "5ed046ac867c8864ae2d85ec73facacb301fd57edf5afb82b1ed68a2b04e3b87",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0165.wav",
+      "sha256": "88a23e0065e7832163789af4fdb25af08d62b77bcec3ca3c43b0562ed8c9bf29",
+      "transcript": "rolando mendoza fired his m16 rifle at the tourists",
+      "duration_sec": 10.297437,
+      "speech_end_offset_ms": 5220.0,
+      "audio_hash_id": "22e3113e8a92e16a677f3db3c34093423290692ef9b6f9718a00f7e8564cf99b",
+      "condition_idx": 2,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0166.wav",
+      "sha256": "0e45e0a53e25260e414c47b307b8f45e8c164b1684279e042c36f0e6f14c5ae6",
+      "transcript": "romanticism had a large element of cultural determinism drawn from writers such as goethe fichte and schlegel",
+      "duration_sec": 12.819688,
+      "speech_end_offset_ms": 8836.0,
+      "audio_hash_id": "8af3367a32b065fea8d78cb6dbe104ea6ee0ad84f6d4b83b9109afb7e71a8da0",
+      "condition_idx": 1,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0167.wav",
+      "sha256": "c13e29363b0e394a45488abd2051bf1afffa037da4affa418685bc676b1f5590",
+      "transcript": "saint petersburg cruises include time in town. cruise passengers are exempted from visa requirements check the terms",
+      "duration_sec": 11.797437,
+      "speech_end_offset_ms": 1092.0,
+      "audio_hash_id": "b02aa07915b807d8ae56f761bed6b222b941442feb98c0968a6d6e448582934b",
+      "condition_idx": 2,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0168.wav",
+      "sha256": "ba134c7270b0440387e2180d6a4f216111b4cb6d29fac20c05c843ab94906c8c",
+      "transcript": "scaffolding is not a method of learning but rather an aid that provides support to individuals whom are undergoing a new learning experience such as using a new computer program or beginning a new project",
+      "duration_sec": 12.83875,
+      "speech_end_offset_ms": 10724.0,
+      "audio_hash_id": "ad06908dd3b995169b9869ea22984d0531492854dd7ffb8a60dcaeff12ddb666",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0169.wav",
+      "sha256": "b50a3482c9815759247d906f7da847da6d59c76e0ede8aa4463eabea7be51fe9",
+      "transcript": "scientists hope to understand how planets form especially how the earth formed since comets collided with the earth long ago",
+      "duration_sec": 10.477438,
+      "speech_end_offset_ms": 3300.0,
+      "audio_hash_id": "e9f7be20ce7384b63a2761ca936a6ccf6b31e16470ccf0c54b9a358bc4f412c3",
+      "condition_idx": 2,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0170.wav",
+      "sha256": "1554e58a0d6c1da48a6104d08d7fd6b976b12c8829963540c5cbfb608cc68d72",
+      "transcript": "scotturb bus 403 travels regularly to sintra stopping at cabo da roca",
+      "duration_sec": 12.63875,
+      "speech_end_offset_ms": 11332.0,
+      "audio_hash_id": "8655902dbcd0bf600687f713785e8c6079512da35b04c9606daaa7c13bb7a40e",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0171.wav",
+      "sha256": "cf9e8481929eaf9001840597777a5dab93bb55aab5150a967875084c1145ae1b",
+      "transcript": "segregation and recombination shuffle variation back and forth between the two pools with each generation",
+      "duration_sec": 12.59875,
+      "speech_end_offset_ms": 10020.0,
+      "audio_hash_id": "cc4b3f19e592030fe83e803529abf5989dbbb2c2e7dbb2993f4014a81046fee8",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0172.wav",
+      "sha256": "d40210f9466d670c3e6177a319f2c01b37f7db8d98706e685336031460f8a06b",
+      "transcript": "several large television screens were installed in various places in rome to let the people watch the ceremony",
+      "duration_sec": 11.33875,
+      "speech_end_offset_ms": 8612.0,
+      "audio_hash_id": "cea480e9c5da132e9d2b12d75c628a7508f1850542467852a3dee0c9eed55deb",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0173.wav",
+      "sha256": "f489976b82fb9a3a1cf4c5e847aeeef7481b0f0718203d596c4391064c9d89ad",
+      "transcript": "severe weather is the generic term for any dangerous weather phenomenon with the potential to cause damage serious social disruption or loss of human life",
+      "duration_sec": 11.87875,
+      "speech_end_offset_ms": 9572.0,
+      "audio_hash_id": "a2119f4e6e40752931cb080c0c561e69d1e1343ef967596ad40487a9e3ae980a",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0174.wav",
+      "sha256": "38520e82a2452fe71a99245eca85d2fb3c8f83a1c214c6996503bd819d5bef0d",
+      "transcript": "sharing a field trip virtually is also a great way to reflect a on a trip and share experiences with future classes",
+      "duration_sec": 8.75875,
+      "speech_end_offset_ms": 6788.0,
+      "audio_hash_id": "829e7713b03084ede49ddd975637e102ddfe840e2d0fc5c572887db9a83ea018",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0175.wav",
+      "sha256": "f1c04296fb26fd00dfa860392ab5256b01a77dabec1722111a4982eaf2d69024",
+      "transcript": "since the foundation of asunción in 1537 paraguay has managed to keep a lot of its indigenous character and identity",
+      "duration_sec": 12.89875,
+      "speech_end_offset_ms": 9636.0,
+      "audio_hash_id": "e117f9cdbc8c9df8e6821348528a2a01f7493c1d166d3f6e3327292389c6c5e1",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0176.wav",
+      "sha256": "7387c7bc30204334666accfb0c1a2bc7e00633ed653a8dc579abbb2f7e523a50",
+      "transcript": "six hostages including the children and elderly were released early as were the filipino photographers",
+      "duration_sec": 13.457437,
+      "speech_end_offset_ms": 7716.0,
+      "audio_hash_id": "a9f76330c6fb7e4932a3fb10445c649f487cabc7ae0a9fca8d728076c5cc3dbf",
+      "condition_idx": 2,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0177.wav",
+      "sha256": "0fa4ce714549befa8a26eaef9b235ba4799c88f6066c903b9771aa03a1f8ef96",
+      "transcript": "so it is likely that the notation was added simply as a label",
+      "duration_sec": 10.157438,
+      "speech_end_offset_ms": 4964.0,
+      "audio_hash_id": "3a2c98a7faa9e1643e935889c24c5e7cedfdb0c63acef33ab5637ec5083ce748",
+      "condition_idx": 2,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0178.wav",
+      "sha256": "1f93ccc410075dbf802fb16123b9bf2a5ad3c822420529adfb22c9c5fb0bac2f",
+      "transcript": "some atoms have unstable nuclei which means that they tend to break apart with little or no nudging",
+      "duration_sec": 7.19875,
+      "speech_end_offset_ms": 5732.0,
+      "audio_hash_id": "8e62843881ea51cba4095c6f50c42e9450a1f3ae9a8df3dbab3bf595c59d47dc",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0179.wav",
+      "sha256": "bd3dac588a85f9d54b9e4c2701429d57686995688a6c3cd120d53e2dc721891e",
+      "transcript": "some cruises feature berlin germany in the brochures as you can see from the map above berlin is no where near the sea and a visit to the city is not included in the price of the cruise",
+      "duration_sec": 11.87875,
+      "speech_end_offset_ms": 9860.0,
+      "audio_hash_id": "7d9a3dd1dedaa96061676dc2be1fa8d5b6223e12c3cf0653f8929065b50e9b31",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0180.wav",
+      "sha256": "d53705da019375e3de5ec8f24e54813daea82ce19022346eeafb2873fa150f83",
+      "transcript": "some people thought he was right but many people believed the opposite; that the solar system moved around the earth including the sun and even the other stars",
+      "duration_sec": 9.879687,
+      "speech_end_offset_ms": 7460.0,
+      "audio_hash_id": "a1a7a371c79c0d053f1692b03102bfe53d4ca19376690a15cd0a8c642579ceb7",
+      "condition_idx": 1,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0181.wav",
+      "sha256": "38c71c1a092d6f868b85b47767ca9f80eba090d742f641e4c291f54a1490654d",
+      "transcript": "soon after the outbreak of hostilities britain initiated a naval blockade of germany",
+      "duration_sec": 9.757437,
+      "speech_end_offset_ms": 900.0,
+      "audio_hash_id": "35a929802e163bce2f4478fbd9dff0d0344cc0b3b96a0ca2f7902d03fd3c3792",
+      "condition_idx": 2,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0182.wav",
+      "sha256": "295211383d5b2c3f984fd3ec357490e0016cc833c6826a55a0239911b1f77cdc",
+      "transcript": "still take advice from authorities obey all signs and pay close attention to safety warnings",
+      "duration_sec": 12.937437,
+      "speech_end_offset_ms": 7172.0,
+      "audio_hash_id": "57d8247f468e6b097239b0c434818103c01d995e4c28dd4b90f2aa4952f3df1a",
+      "condition_idx": 2,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0183.wav",
+      "sha256": "10f68ca6f13fe07e3f91e0403e014bf67fdedcfa7fe55de8e6a645b7b42bc43f",
+      "transcript": "swirl the two dry powders together and then with clean wet hands squeeze them into a ball",
+      "duration_sec": 10.499688,
+      "speech_end_offset_ms": 7556.0,
+      "audio_hash_id": "b68091a54a4ebfbe51cefcb84e5c7f9238be9cd8dcef6144cd707d6d3fd3e4fb",
+      "condition_idx": 1,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0184.wav",
+      "sha256": "354e383d3c9d15fb7fe59c86e67a1787960e0113daa3f2a1acab877bd8b40b17",
+      "transcript": "television reports show white smoke coming from the plant",
+      "duration_sec": 9.337438,
+      "speech_end_offset_ms": 3748.0,
+      "audio_hash_id": "917ceab018f43e642d82533ad87ecc74b68c2fce769b5d84717136b76860a8b8",
+      "condition_idx": 2,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0185.wav",
+      "sha256": "d0791c8efe790f9ab6929b58dfa6e88c335eae92e5d759a6861b92868304c0db",
+      "transcript": "the 25 dunlap broadsides still known to exist are the oldest surviving copies of the document the original handwritten copy has not survived",
+      "duration_sec": 10.91875,
+      "speech_end_offset_ms": 8900.0,
+      "audio_hash_id": "c7cb9f904d0c813e2fe8cfbe7d5f68938e98db387841d99f3ae3a9db3ab7751a",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0186.wav",
+      "sha256": "0ccd9179fad92c626c2132c2daa3797d11a0c3b17ef2d7e46757b84e3392d451",
+      "transcript": "the 802.11n standard operates on both the 2.4ghz and 5.0ghz frequencies",
+      "duration_sec": 13.07875,
+      "speech_end_offset_ms": 10756.0,
+      "audio_hash_id": "5a9a88e0e2800bc2aca94396ae3a7debdc4ad0e085c6d5dfe4a29c131899ec84",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0187.wav",
+      "sha256": "4a949f1c1d6c1e88ed63402a780e127f29239f98fcdbbda233a4c7a76f68c219",
+      "transcript": "the announcement was made after trump had a phone conversation with turkish president recep tayyip erdoğan",
+      "duration_sec": 11.87875,
+      "speech_end_offset_ms": 9156.0,
+      "audio_hash_id": "ce8661ee088337493d6f2836d5b543033c00ba93adf33f805590f6251ef8a9b1",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0188.wav",
+      "sha256": "2b8c59d7132bc773fbaeffe9f8dd628532ca2ba1ea1db15161b07b2470ef2b3b",
+      "transcript": "the aspect ratio of this format dividing by twelve to obtain the simplest whole-number ratio is therefore said to be 3:2",
+      "duration_sec": 13.179688,
+      "speech_end_offset_ms": 10980.0,
+      "audio_hash_id": "a876838807cf08f567a69518118def87bf1b86f9d9a40ef9fde4a187fdb4b650",
+      "condition_idx": 1,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0189.wav",
+      "sha256": "a8ec5cafeaf5fa0520f6e546a537c2d64a54fbd4d651de45b82b84333c6fd6cf",
+      "transcript": "the bridge is scheduled to be fully operational in september 2017 when the brazilian customs checkpoints are expected to be finished",
+      "duration_sec": 12.577438,
+      "speech_end_offset_ms": 1732.0,
+      "audio_hash_id": "5bf05b135121617324570d42ec389bff662d8c04d8eb955d226bab2a87c7291a",
+      "condition_idx": 2,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0190.wav",
+      "sha256": "1594d68bdd69a125fffb9bc4644adfaa9f8be6f219d3edf44231563582f820a3",
+      "transcript": "the cabbage juice changes color depending on how acidic or basic alkaline the chemical is",
+      "duration_sec": 7.899687,
+      "speech_end_offset_ms": 5380.0,
+      "audio_hash_id": "c6e3529bdae4dc68689c43e0cb568fa5a15a724d653cc7fe4710b999a6575e16",
+      "condition_idx": 1,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0191.wav",
+      "sha256": "ae4337e09cd5a70256df3cc3da7f2a9efa009ef7dfe5bed92739d9ba0f85b93b",
+      "transcript": "the capital of moldova is chişinău. the local language is romanian but russian is widely used",
+      "duration_sec": 7.67875,
+      "speech_end_offset_ms": 6404.0,
+      "audio_hash_id": "d29efccf24ea4539aa4fe62ddd8ac92c35bd327e19c6b3c5d8688daac9cb1c2d",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0192.wav",
+      "sha256": "caf998e1db6eb11538f2e6ffa5912be9e8668b33e650f395de40928a9dc2bec9",
+      "transcript": "the central authority of the church had been in rome for over a thousand years and this concentration of power and money led many to question whether this tenet was being met",
+      "duration_sec": 11.379687,
+      "speech_end_offset_ms": 8900.0,
+      "audio_hash_id": "40f5856e7358feb4f3578cf2a2bf8aa9b31c6bd38469b8ee5ba2851b6b6c2432",
+      "condition_idx": 1,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0193.wav",
+      "sha256": "deb42e30ab57938e04bce89b5c494cc6c72783906c6133b045e6327f93790912",
+      "transcript": "the city is also the base to climb the nyiragongo volcano along with some of the cheapest mountain gorilla tracking in africa",
+      "duration_sec": 12.35875,
+      "speech_end_offset_ms": 9860.0,
+      "audio_hash_id": "e91deddb8f9c875fac8f627e2f2f153bcd8e83f9383b32adb27e4802965f6c76",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0194.wav",
+      "sha256": "f8dd6e3b925fe0991cda550f2a07d5508baea1031f83575bfd554aa36f672010",
+      "transcript": "the city is in stark contrast to the rest of the country's cities because it has more of an arabic flair than of an african",
+      "duration_sec": 8.859687,
+      "speech_end_offset_ms": 6468.0,
+      "audio_hash_id": "31bacf26ca84155b08a1c4e13a7217e862e572a401ea12d23446fa28afc63f5f",
+      "condition_idx": 1,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0195.wav",
+      "sha256": "1b294cbe85fd035191d101ccc4ca165a933f05bebaf79eb6742a1954cb080f1e",
+      "transcript": "the commission was martelly's response to widespread anti-regime protests that started in october",
+      "duration_sec": 9.59875,
+      "speech_end_offset_ms": 7428.0,
+      "audio_hash_id": "e9efc915321bbc607ea9dc296a14566fc312db41dc1f6a99b382bce826b5eacd",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0196.wav",
+      "sha256": "78a015869693e60dc989dd37eca7fe799c327d897e33198f8590bc581942985c",
+      "transcript": "the composition of these crystals matches those found in the urine of affected pets when compared by infrared spectroscopy ftir",
+      "duration_sec": 12.95875,
+      "speech_end_offset_ms": 10628.0,
+      "audio_hash_id": "b94e1a821a3ad20136bce4cd77dd44d332b8693e2350fdc0b7c8d8a8b4c28c7a",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0197.wav",
+      "sha256": "63cd9337b71b9901568754c7d6712a6f8da17236ba4fb38256db516fbb682453",
+      "transcript": "the correlation between brain pathology and behaviour supports scientists in their research",
+      "duration_sec": 7.43875,
+      "speech_end_offset_ms": 5444.0,
+      "audio_hash_id": "f1f98e646f0590f29bb72ba05d0b214f86aab8d40102a6464f68d2f6c531a3d4",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0198.wav",
+      "sha256": "fe8868e429f3a00be6054bf829b1b01fa6466b61544bfcb9778cac076820fc2c",
+      "transcript": "the crash occurred high up in mountainous terrain and is believed to have been the result of hostile fire",
+      "duration_sec": 11.959687,
+      "speech_end_offset_ms": 8644.0,
+      "audio_hash_id": "1e9171b596b94660cc73739cd58053692dd65a0589362d5191c2e58f190a9a3e",
+      "condition_idx": 1,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0199.wav",
+      "sha256": "2c92d5731abd32e0dd4a61e69d42e2dcf0574b3ea136916fb8cc45ebdb0bea6a",
+      "transcript": "the crust is about 70 km thick on the near side and 100 km thick on the far side",
+      "duration_sec": 8.75875,
+      "speech_end_offset_ms": 6596.0,
+      "audio_hash_id": "66cf89cb9809a2c182eabb9a4c812eee4ab002ff06f2d9e0bacbbf7c6eee3b39",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0200.wav",
+      "sha256": "43bb093d21a4e8d7a3beae2e06e9561b38ce4b4947a79fdb5009c850d643b883",
+      "transcript": "the debate was sparked by controversy over spending on relief and reconstruction in the wake hurricane katrina which some fiscal conservatives have humorously labeled bush's new orleans deal",
+      "duration_sec": 13.43875,
+      "speech_end_offset_ms": 11300.0,
+      "audio_hash_id": "580570e44dfad3ee8a226ce4c968dbf7bbace9682810b15bb180562f37a65bac",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0201.wav",
+      "sha256": "89d220cdf086402b1bf0b25ef1cfcca50bae3bd9a8886bf443bb4d25197948e4",
+      "transcript": "the disease is carried by pigs which then migrates to humans through mosquitos",
+      "duration_sec": 9.697437,
+      "speech_end_offset_ms": 900.0,
+      "audio_hash_id": "fa082ce6c5ae9518a77a6fd80b98a0b4afda8c64a37793230011fd52c7ff34d0",
+      "condition_idx": 2,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0202.wav",
+      "sha256": "47235a38f6a71f9b4bc965a736b7c864ab6bc435dc023f4492815980bcfd2804",
+      "transcript": "the document according to the leak will refer to the borders dispute which palestine wants based on the borders before the 1967 mideast war",
+      "duration_sec": 9.35875,
+      "speech_end_offset_ms": 7908.0,
+      "audio_hash_id": "e8e09b8b72fcb1089d9ab7eedb79c501038321972c1fe8d5279f15ee27aa98c0",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0203.wav",
+      "sha256": "fd3125a3c31b6683b24ab83e854db9066bf8f1964a3f03a0b22154380e86709d",
+      "transcript": "the find also grants insight into the evolution of feathers in birds",
+      "duration_sec": 8.917438,
+      "speech_end_offset_ms": null,
+      "audio_hash_id": "379687d0b12450c81b3b85b52809cf05b0d60a1294a5f915cf6eab3433405d62",
+      "condition_idx": 2,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0204.wav",
+      "sha256": "6aaea857b27da8ccf62ce876ff81ba18dc8af06f6e2d788bc10dda14cdea602d",
+      "transcript": "the fission bomb works on the principle that it takes energy to put together a nucleus with many protons and neutrons",
+      "duration_sec": 10.597437,
+      "speech_end_offset_ms": 1444.0,
+      "audio_hash_id": "f5d85f4202279b63ff41f10237f6b8cec066f8ee82946dfb02e117218b251770",
+      "condition_idx": 2,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0205.wav",
+      "sha256": "1c285dcd15f3a3a804e1a567ac9408e7d3a9e53dac8f0e16135f12bbdbab4a53",
+      "transcript": "the governor's office said nineteen of the injured were police officers",
+      "duration_sec": 8.33875,
+      "speech_end_offset_ms": 5124.0,
+      "audio_hash_id": "bd0c9c822b75deaa46a7ac428e6c1a1125c954005dec4ef24f3cf10505675a8d",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0206.wav",
+      "sha256": "19a3a37c9569feea4a36d039ceef81b823ab3bb87504cde2bc8b1c7f6ebc9c90",
+      "transcript": "the great pyramid at giza is the only one of the seven wonders that is still standing today",
+      "duration_sec": 10.357437,
+      "speech_end_offset_ms": 1732.0,
+      "audio_hash_id": "13be17e582d07c4fc5edb79996ef3ca8cb1a49a7e8e054e1c94d3b2222cc5298",
+      "condition_idx": 2,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0207.wav",
+      "sha256": "0ba64000d0ea2ef1bba0d3fca73b04988a0b3121609c3e41b2e8814ddc87ab71",
+      "transcript": "the haitian institute for justice and democracy has referenced independent studies that suggest the nepalese un peacekeeping battalion unknowingly brought the disease to haiti",
+      "duration_sec": 12.11875,
+      "speech_end_offset_ms": 10884.0,
+      "audio_hash_id": "ee838d9b02a4b181695f2e64a09a4012652abf643f177915d64c8bcbead726f5",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0208.wav",
+      "sha256": "999b7997de0fb3a98c8dfb870148e138f0647ba7bfcb0d4eb83f7a0712fd5e23",
+      "transcript": "the hospital has followed protocol for infection control including separating the patient from others to prevent possible infection of others",
+      "duration_sec": 12.49875,
+      "speech_end_offset_ms": 10884.0,
+      "audio_hash_id": "aaa9d3e9c6d5950e1ae003152ac820916ea49531361f87e6f548994653c288ed",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0209.wav",
+      "sha256": "7b6feac1d448db3a69f32e890f35d7794c2dbd589ec51c6d72a415c13a295415",
+      "transcript": "the hot chocolate is up to belgian standards fruit juices are pricey but excellent",
+      "duration_sec": 8.559688,
+      "speech_end_offset_ms": 6052.0,
+      "audio_hash_id": "c6513cc934ad2f204baf4f6f9be2647025faefa9063741cd3e40815d5c95b081",
+      "condition_idx": 1,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0210.wav",
+      "sha256": "7b77f5f0ec2689dc186d2068eb03c1b619fcd8d8959aeeb17d25a9b466c65e29",
+      "transcript": "the internet combines elements of both mass and interpersonal communication",
+      "duration_sec": 7.859687,
+      "speech_end_offset_ms": 5412.0,
+      "audio_hash_id": "881bfe7ebf9795486c464c30c37af2dca5540d16b6b78355a0c6e2c794382d03",
+      "condition_idx": 1,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0211.wav",
+      "sha256": "bf1b4fe173163d0e3d025fba5ce919227baa81722efa1f8fc10f797f1d98bd3d",
+      "transcript": "the lower the tension the more positive the life force present every person has the potential to find absolute peace and contentment",
+      "duration_sec": 12.539687,
+      "speech_end_offset_ms": 9668.0,
+      "audio_hash_id": "43b27c4b101d168f767c3b2977c2f4ba45b2026ab226eb14ced4c124965df67d",
+      "condition_idx": 1,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0212.wav",
+      "sha256": "c39a8c7fe6196c92473752476ff25b04644f4cf9e611eddafe0b0178172573bd",
+      "transcript": "the moisture on your hands will react with the outer layers which will feel funny and form a sort of shell",
+      "duration_sec": 9.59875,
+      "speech_end_offset_ms": 8612.0,
+      "audio_hash_id": "3de0af5c57211876ff6c7d2d7130c9b9a52f64394fd2b7e822fd3fd6c78a15b6",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0213.wav",
+      "sha256": "955b04fec5c668b0b4cc2b6303974c47e34640a7fa71ab2e15ced2b3ca57d0be",
+      "transcript": "the moroccan sultan rebuilt the city as daru l-badya and it was given the name casablanca by spanish traders who established trading bases there",
+      "duration_sec": 12.59875,
+      "speech_end_offset_ms": 10596.0,
+      "audio_hash_id": "a722deec16567023148b270bdf6c74ba4d23c1e9fd41894364cc55b769736ddb",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0214.wav",
+      "sha256": "4e9d145654500bb33e10e12305a152ef5f084523c3cd43fcbbcc22bd754f39c4",
+      "transcript": "the northern marianas emergency management office said that there were no damages reported in the nation",
+      "duration_sec": 12.939687,
+      "speech_end_offset_ms": 7556.0,
+      "audio_hash_id": "22389af32185eb183ed32770e5b651271427f7c64f102986a52812ce741f36a9",
+      "condition_idx": 1,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0215.wav",
+      "sha256": "b017a2076a7e4acdd472a23daab4512f141a774aa7175602938a28c991cda0a3",
+      "transcript": "the number of people present was so large that it was not possible for everybody to gain access to the funeral in st peter's square",
+      "duration_sec": 11.799687,
+      "speech_end_offset_ms": 8036.0,
+      "audio_hash_id": "b10b0dfcf3ae32ab971f96c0375903847e9d15ecec0020580272c22690f24d6e",
+      "condition_idx": 1,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0216.wav",
+      "sha256": "98690d5946e8851177cbca8117a5c0f9ee8906ceb5ebf678262e665385e180e7",
+      "transcript": "the official falklands currency is the falkland pound fkp whose value is set equivalent to that of one british pound gbp",
+      "duration_sec": 11.15875,
+      "speech_end_offset_ms": 9892.0,
+      "audio_hash_id": "1774c53b8063a80966172f513712156ee6f75864bc9141633b77a39148415cc3",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0217.wav",
+      "sha256": "a85761306a67db39aff138048a4c66a17e1f11da3356a7cd386cbc4fdced677d",
+      "transcript": "the ph level is indicated by the amount of hydrogen the h in ph ions in the tested chemical",
+      "duration_sec": 10.897438,
+      "speech_end_offset_ms": 1156.0,
+      "audio_hash_id": "f91b08a25cbd556f0481d5eca6178d01bfbe4f125ab19a494fd9144b7277e627",
+      "condition_idx": 2,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0218.wav",
+      "sha256": "cc6bb697f0566a34e3668974c86d2b29c598ba2302c6bb4f4488e7d4555b3cae",
+      "transcript": "the photographers later took the place of an aged lady as she needed the lavatory mendoza was gunned down",
+      "duration_sec": 12.917438,
+      "speech_end_offset_ms": 7748.0,
+      "audio_hash_id": "efcb16371ec055a14b544c6b106874bc6ad1f59532e10ee7040e03945d934f85",
+      "condition_idx": 2,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0219.wav",
+      "sha256": "f7893e6c37b755c421c8d5a40b958a82fbbe529440ebe4c0d6c80e0aa7ab450b",
+      "transcript": "the presence of a true  invisible team” larson and lafasto 1989 p109 is also a unique component of a virtual team",
+      "duration_sec": 13.01875,
+      "speech_end_offset_ms": 10692.0,
+      "audio_hash_id": "a8acdc35b955b1ac6d4ef844a02b7a4bfcccd14dfe907d9d51569d5e3d209d29",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0220.wav",
+      "sha256": "a9dab767741f323846fa2f75fb43bf92ae2f1910f7bd368c0ab3edf5f7ad992c",
+      "transcript": "the pyramid sound and light show is one of the most interesting things in the area for kids",
+      "duration_sec": 12.637438,
+      "speech_end_offset_ms": 7780.0,
+      "audio_hash_id": "8e6e9fa0276dee87fab349475124a33068270ca1952352c6bb953bbf16a05e7c",
+      "condition_idx": 2,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0221.wav",
+      "sha256": "e5074f648bbfaa703e104c21fa96bc171fcdf49eb09205bb7c0438821dd0a78c",
+      "transcript": "the report is highly critical of almost every aspect of the present policy of the executive towards iraq and it urges an immediate change of direction",
+      "duration_sec": 10.779687,
+      "speech_end_offset_ms": 8548.0,
+      "audio_hash_id": "78c4825bd04e4c3270f8e938bd4216f61df4ea9fd6235c0644837269d945d7e6",
+      "condition_idx": 1,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0222.wav",
+      "sha256": "d5475358de20b3c7281c8b6f617441d2a565fabb477eb397c76729fb49e71598",
+      "transcript": "the ruling party south west africa people's organisation swapo also retained a majority in the parliamentary elections",
+      "duration_sec": 11.71875,
+      "speech_end_offset_ms": 9956.0,
+      "audio_hash_id": "bb32fdbf20bcee4354872e8fe5fc3bd3de4dc7e8db1af8bc72881e1cf70023f1",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0223.wav",
+      "sha256": "9f135306df561bda0c463c0951b653376ccc1b94d27e3c570c1706b2940ff2eb",
+      "transcript": "the same month saw another airliner overrun a runway at mashhad and strike a wall killing seventeen",
+      "duration_sec": 8.619687,
+      "speech_end_offset_ms": 6244.0,
+      "audio_hash_id": "60dc2a347b4b6cdd1f55f0c92f4d5616be8b1047723acf65fcf6e5b52229fd9b",
+      "condition_idx": 1,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0224.wav",
+      "sha256": "b8885ad71310e6c6eb075781da3cac0a43724fe28df0453fd90dce7484440481",
+      "transcript": "the scenes are displayed on the pyramids and the different pyramids are lit up",
+      "duration_sec": 8.617437,
+      "speech_end_offset_ms": 548.0,
+      "audio_hash_id": "9c601cc5accad172437ef81551cd6219a8fb6df8e51b01248f236a2c9af6edef",
+      "condition_idx": 2,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0225.wav",
+      "sha256": "8346f3f76f26194c72b3b193f121adb7fcd9de4f36c3f5666b6cd6472eb94c60",
+      "transcript": "the schengen zone however works somewhat like one country in this respect",
+      "duration_sec": 7.87875,
+      "speech_end_offset_ms": 6468.0,
+      "audio_hash_id": "751ebe7311f128756bc4ff5d9ee874218a878f1a40937f192e85624a71025fae",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0226.wav",
+      "sha256": "5752c83ad58d6c70dc32121cf2cb6a3a682258c271b588c433be45e437638e89",
+      "transcript": "the scientists were able to conclude that the dark matter affect other dark matter in the same way regular matter does",
+      "duration_sec": 14.259688,
+      "speech_end_offset_ms": 11044.0,
+      "audio_hash_id": "91fcb5783b2de868af1255997c073ef856e64896bdb6d2511ead25c24f1d9874",
+      "condition_idx": 1,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0227.wav",
+      "sha256": "65ed9cdeb230d91ca031711649386282a712e4bf823ba051b3de025322c6ebf9",
+      "transcript": "the service is frequently used by shipping including pleasure craft as well as expeditions who have remote data and voice needs",
+      "duration_sec": 12.35875,
+      "speech_end_offset_ms": 8932.0,
+      "audio_hash_id": "353a9ad5f217071ffc2f59da70d95dd48000ffc650929d7da6b64214845c0e26",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0228.wav",
+      "sha256": "ef809a2d43b134efeb5c507ed050102132fec1c5539ce92406afaff9df3fb3b6",
+      "transcript": "the smaller the rossby number the less active the star with respect to magnetic reversals",
+      "duration_sec": 6.71875,
+      "speech_end_offset_ms": 5412.0,
+      "audio_hash_id": "d38bf647c5e9d5f33693bea9b7fdc6ae9529e67419658f7d1c38160abd03ab6b",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0229.wav",
+      "sha256": "45aa84b333a178ca2d6659f68424a8e125988e4b07c0b54dbfd33dae7c5c18a3",
+      "transcript": "the sundarbans are the largest littoral mangrove belt in the world stretching 80 km 50 mi into the bangladeshi and indian hinterland from the coast",
+      "duration_sec": 14.497438,
+      "speech_end_offset_ms": 7460.0,
+      "audio_hash_id": "c079680c2d1785a6da09c5737677bb7be91115e6497b29e68531a26963640564",
+      "condition_idx": 2,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0230.wav",
+      "sha256": "290078100944173a1bd8efcc56a463c32c1512d64d29fdcec71b511dc7bfd7a1",
+      "transcript": "the sundarbans has been declared a unesco world heritage site the part of the forest within indian territory is called sundarbans national park",
+      "duration_sec": 14.019687,
+      "speech_end_offset_ms": 10052.0,
+      "audio_hash_id": "84ce17b5ac17ab52f517c6fccdd64096dbed1c281a08ebae2d1a850a1bf4559c",
+      "condition_idx": 1,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0231.wav",
+      "sha256": "520846ce05a70fba22670c464e94f237a109b70350aeea79e9f5d9e00dfb2d41",
+      "transcript": "the surface of the moon is made of rocks and dust the outer layer of the moon is called the crust",
+      "duration_sec": 6.71875,
+      "speech_end_offset_ms": 5316.0,
+      "audio_hash_id": "83727780ae089bf771d6f660993f08f84b4104e83275e063eee19e0eb4d38f8f",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0232.wav",
+      "sha256": "2650698846606345fe50dcd989059cd3c1c1a0383668378a2d92d8cb505aa979",
+      "transcript": "the tenth named storm of the atlantic hurricane season subtropical storm jerry formed in the atlantic ocean today",
+      "duration_sec": 10.799687,
+      "speech_end_offset_ms": 7684.0,
+      "audio_hash_id": "4e050e05444d66aa8c34fa02c24d359a1c0c44408dcacced285d8079b9a76375",
+      "condition_idx": 1,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0233.wav",
+      "sha256": "db42c743d62573918b254232a2d664d400e14c50de24d6f237eae5cffdc3e944",
+      "transcript": "the term bug is used by entomologists in a formal sense for this group of insects",
+      "duration_sec": 7.55875,
+      "speech_end_offset_ms": 5412.0,
+      "audio_hash_id": "1a158da35d1fc859a544545dcfe902254e2886e12b7a52cdd1cb8e7a1eed3a8f",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0234.wav",
+      "sha256": "a6b1030764143f058c50dcc06cfa0d1b688dde0cf2f8490d32681882e52ec7c9",
+      "transcript": "the term safari in popular use refers to overland travel to view the stunning african wildlife particularly on savanna",
+      "duration_sec": 10.779687,
+      "speech_end_offset_ms": 7748.0,
+      "audio_hash_id": "5897fadde3ccb33b8a8b916ff398aa8e8509db6d48a678df878f7ad23b5fcd42",
+      "condition_idx": 1,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0235.wav",
+      "sha256": "6451b543d2ca2703c629b542516e92aaa8ffbacaef24c4ddc05bb4a18415a587",
+      "transcript": "the three kingdoms was one of the bloodiest eras in ancient china's history thousands of people died fighting to sit in the highest seat in the grand palace at xi'an",
+      "duration_sec": 12.95875,
+      "speech_end_offset_ms": 10596.0,
+      "audio_hash_id": "c6b9483847cade0ddc8899b1cb0aad364ab7e3b33ed20dd63c5b3cd68a217d68",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0236.wav",
+      "sha256": "3cfa45a0ca26280ce85c82ab8020d14ea0c0037b66bb93dc67818ed5f981ab8a",
+      "transcript": "the tiger's roar is not like the full-voiced roar of a lion but more like a sentence of snarly shouted words",
+      "duration_sec": 9.83875,
+      "speech_end_offset_ms": 7364.0,
+      "audio_hash_id": "3bb508aee7faebaf47b498048bb4bd30df6be00faa8fda97060c064c580cfcad",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0237.wav",
+      "sha256": "31550a3ab8dd95def0bf191751bd9bca15e26406a9520ff1f8419f179defc4ca",
+      "transcript": "the two compounds react with one another to form crystals that may block kidney function researchers at the university said",
+      "duration_sec": 9.579688,
+      "speech_end_offset_ms": 6404.0,
+      "audio_hash_id": "5ede188c2047ae39cb9c537e4b3476d59d549073f380148ff6b3b28982423915",
+      "condition_idx": 1,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0238.wav",
+      "sha256": "673368139a118437b2c2680ebb47a650a6c8b6c366114d58c24690b0bfc1e581",
+      "transcript": "the u.s. corps of engineers estimated that 6 inches of rainfall could breach the previously damaged levees",
+      "duration_sec": 9.83875,
+      "speech_end_offset_ms": 7780.0,
+      "audio_hash_id": "d78ce7f8ee5da4c0e33ba390459e2da39cadd814e53a71932f3cadc391b57ad9",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0239.wav",
+      "sha256": "bcef775c85562f9ebfdcf5c2bb6255a286aefcc5cdb87c2e14c77f5963eeffd1",
+      "transcript": "the use of video recording has led to important discoveries in the interpretation of micro-expressions facial movements which last a few milliseconds",
+      "duration_sec": 12.61875,
+      "speech_end_offset_ms": 11108.0,
+      "audio_hash_id": "d129f9deb27c22bc3b5c362ef77b91115bc9686bd1b72ef6494ca5570bec002d",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0240.wav",
+      "sha256": "d906e08024f9a7b12b0f436c6c9103285b9c482357b300724f4edfc5ca47b659",
+      "transcript": "the vehicle itself was taken away from the scene of the accident at approximately 1200 gmt on the same day",
+      "duration_sec": 12.877437,
+      "speech_end_offset_ms": 7716.0,
+      "audio_hash_id": "07ff95a177e23298eb614f7d514d561d4cd3bb93ba6b4d3736500ae348a230fa",
+      "condition_idx": 2,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0241.wav",
+      "sha256": "30d250cfc0c87994df7eedb9a24481d1c224eea6f454b05c8c7a794db78e1ef3",
+      "transcript": "the vertical clearance under the bridge is 15 meters construction was completed in august 2011 it didn't open to traffic until march 2017",
+      "duration_sec": 11.979688,
+      "speech_end_offset_ms": 8836.0,
+      "audio_hash_id": "523c389dfea4b56914e175baefa0497665b9304eea7429beeaccf94d1a2eb0d7",
+      "condition_idx": 1,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0242.wav",
+      "sha256": "1f7d5d6937172513c9aadd1f1c9ce3e948e8ada4cc478c41d6e22f81b6c713ec",
+      "transcript": "the work done was mostly theoretical but the program was written to simulate observations made of the sagittarius galaxy",
+      "duration_sec": 11.87875,
+      "speech_end_offset_ms": 8740.0,
+      "audio_hash_id": "09933e3c22dd84e667dac0f1506600d4a84f1c6562670dc4d697f561f02470d4",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0243.wav",
+      "sha256": "dcb6c31b481ff2f5e066447b37812a59024d119c2e18b171c160dd1a7483cd62",
+      "transcript": "their disciplined defence ball handling skills and excellent team work made them stand out and it was clear that this was the team to beat",
+      "duration_sec": 12.157438,
+      "speech_end_offset_ms": 1252.0,
+      "audio_hash_id": "17803ed609e0f0d266e57ee77bd4458ff964505751de814c1695ddef39d43c52",
+      "condition_idx": 2,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0244.wav",
+      "sha256": "582e6ad71872392bae74d94f7f348be44bc45b8e2d2ea9ad777d86f27704760a",
+      "transcript": "there are of course christian theological explanations for this tradition but it may well be a pre-christian spring and fertility ritual",
+      "duration_sec": 11.499688,
+      "speech_end_offset_ms": 9156.0,
+      "audio_hash_id": "15451a0cdabc122ca561a1066201a682264c35132b9863aa9963b86aec519c3e",
+      "condition_idx": 1,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0245.wav",
+      "sha256": "3e38328c234f251025f6c5803b7a60f3f704adcf6b7aa2f360be98c21777df12",
+      "transcript": "there are still many men and women alive who survived their time here and many more who had loved ones who were murdered or worked to death there jews and non-jews alike",
+      "duration_sec": 12.17875,
+      "speech_end_offset_ms": 9924.0,
+      "audio_hash_id": "171b5da58ff8efd8384bdd6b0daab61b9f82a1693fd075008741361b0885ffc1",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0246.wav",
+      "sha256": "3cc2a68d00544982d6154253ce99a521f3c0ad9ca21e3e157b408cd0e4345566",
+      "transcript": "there is no universal definition for which manufactured items are antiques some tax agencies define goods older than 100 years as antiques",
+      "duration_sec": 12.87875,
+      "speech_end_offset_ms": 10692.0,
+      "audio_hash_id": "49bb2a582daa2bfadf8e1e1d3643213efd66256ec5b27ad97d6851b039192de9",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0247.wav",
+      "sha256": "ea373deb32ea66ebe676a49e43bceee722950f0281499b7dcb0a16aa65fe4033",
+      "transcript": "there may be more maria on the near side because the crust is thinner it was easier for lava to rise up to the surface",
+      "duration_sec": 11.099687,
+      "speech_end_offset_ms": 8228.0,
+      "audio_hash_id": "5c3b009b55a0a6aa929755d7d73bb17609e4f19864522ed4cc8a51f0e836f83c",
+      "condition_idx": 1,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0248.wav",
+      "sha256": "7d10119ddf525cac5cf4c57e3a09441337db01a921dcc657a3aa6b637e1b77df",
+      "transcript": "these are sometimes-crowded family beaches with a good range of shops lining the shore swimming is safe",
+      "duration_sec": 14.797437,
+      "speech_end_offset_ms": 8228.0,
+      "audio_hash_id": "525e1f514c46a2ab3749cd32e3f9a9d344916c7267a79e1de41639d7a1e771ed",
+      "condition_idx": 2,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0249.wav",
+      "sha256": "78ec25685cec9b9755b4884d1a3669c365f319b348a7e6f432380a48483ec3c8",
+      "transcript": "these couples may choose to make an adoption plan for their baby",
+      "duration_sec": 8.979688,
+      "speech_end_offset_ms": 5988.0,
+      "audio_hash_id": "d5ec43a27772d66f970c2125084f452b123e8d7b8157f25715e515732ee46bbf",
+      "condition_idx": 1,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0250.wav",
+      "sha256": "a030eb51ec2cebf81c280130c778fbc363701527d2b9192c292b94352757fc0e",
+      "transcript": "they are almost all sandy beaches with safe swimming and most have shade provided by pohutukawa trees",
+      "duration_sec": 12.757437,
+      "speech_end_offset_ms": 7428.0,
+      "audio_hash_id": "111d9d146314817c10b76b4d653a4b03c6ddb4d1e0b8297404600e8e0da3b48a",
+      "condition_idx": 2,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0251.wav",
+      "sha256": "638308f398e7e93e825aa892cdf75e6fe0de6213b005416e76a630b5161d60a1",
+      "transcript": "they have feet with scales and claws they lay eggs and they walk on their two back legs like a t-rex",
+      "duration_sec": 8.799687,
+      "speech_end_offset_ms": 6468.0,
+      "audio_hash_id": "931dbae01869cbda28efffbabe56e8991ca12ad0b2b15461f1979a3c87c77fec",
+      "condition_idx": 1,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0252.wav",
+      "sha256": "a885d0c7533a48b29b835cfee4262455a9c3838cedebc69116a01b6be4a6ba87",
+      "transcript": "they usually have special food drink and entertainment offers to keep guests in a good mood and keep them at the premise",
+      "duration_sec": 8.03875,
+      "speech_end_offset_ms": 6052.0,
+      "audio_hash_id": "6e4b80a625cd9d82419c4e5cf353b0f87eec46a8f56019768c1324479cc5b3f3",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0253.wav",
+      "sha256": "e0c5e752d541b8c9154e534cb3acd45997ca98723843cb829645e37ce6a4cbce",
+      "transcript": "think of the skiing route as of a similar hiking route",
+      "duration_sec": 9.237438,
+      "speech_end_offset_ms": 4004.0,
+      "audio_hash_id": "549ec0dc49bc9e2aa882786cac4184b97cc1059d0a1b4c642ad228b4e158bba5",
+      "condition_idx": 2,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0254.wav",
+      "sha256": "92a4abfc7fba4a7f40a7f6041aa5a24242e37556cd434bb94b5f6e398852a27e",
+      "transcript": "this is an important way to distinguish between some verbs and objects",
+      "duration_sec": 5.57875,
+      "speech_end_offset_ms": 4260.0,
+      "audio_hash_id": "ae4e5ebe9384baefbc9af96f4dce6fafd6e794b7f2efc5a4b3ef8da96d1b615d",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0255.wav",
+      "sha256": "31fff6088a58975d7c2f3f9474e73e52af51e26215d2be96c7ad5ada650edc15",
+      "transcript": "this is called a chemical's ph you can make an indicator using red cabbage juice",
+      "duration_sec": 8.019687,
+      "speech_end_offset_ms": 4868.0,
+      "audio_hash_id": "bcb4a894cb14e8d90d56d67e8cb7c5d5ae1074ffba4e762cdf602f6baaa745c0",
+      "condition_idx": 1,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0256.wav",
+      "sha256": "9db450fe09e673b374b5f0eb2ad57130849b582508d8138c9103e102b0278f2f",
+      "transcript": "this is not going to be goodbye this is the closing of one chapter and the opening of a new one",
+      "duration_sec": 6.95875,
+      "speech_end_offset_ms": 5028.0,
+      "audio_hash_id": "a77ccd092334dbadced5be3fdaedd135951ff0a508f21347c28545f28455af49",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0257.wav",
+      "sha256": "3f3e2e5ac5afa767aa0a6d098cb647338a3f3a6f56317d891991ffe2a4239c90",
+      "transcript": "this offers a good opportunity to see the aurora borealis as the sky will be dark more or less around the clock",
+      "duration_sec": 7.79875,
+      "speech_end_offset_ms": 6404.0,
+      "audio_hash_id": "d0391cd2b40b45ea4fa147e920d5e33f6e0829e65499f9c08a17cf3c302d8140",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0258.wav",
+      "sha256": "23993d66624a9aaff3fdbe335fa71b6cfc9ca5a23751e95b7c33f15823d975e0",
+      "transcript": "this sediment was necessary for creating sandbars and beaches which served as wildlife habitats",
+      "duration_sec": 12.29875,
+      "speech_end_offset_ms": 9444.0,
+      "audio_hash_id": "d07933eb3d01f1f0ed54ea3c0f40fd5e094de40cbaae8444085cb7fce7247d62",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0259.wav",
+      "sha256": "f0da426cd6fa794d9bbba07e07582c1adf0236e9670ac192b7c4b1d3707934b9",
+      "transcript": "this seems sensible because the earth doesn't feel as if it's moving does it",
+      "duration_sec": 6.71875,
+      "speech_end_offset_ms": 4740.0,
+      "audio_hash_id": "b0b6eaa5b07d920841ee805b115091ad593ecbe7ff109b4ab940d7e76250165a",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0260.wav",
+      "sha256": "85d45c32bfbe25974706ff51666d5f536eff0e496e5b539769566608ed2383fd",
+      "transcript": "this will allow players to control actions and movements in video games by moving the device through the air",
+      "duration_sec": 7.899687,
+      "speech_end_offset_ms": 5572.0,
+      "audio_hash_id": "adfe2e28f9f147c49f5f419c186c065abcd8b0dbe018edf483c7e0cfb46cf1d2",
+      "condition_idx": 1,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0261.wav",
+      "sha256": "8f05b2807ba35e89251f9d621fba79a3df6c56f300a46000d65196acf3d95bde",
+      "transcript": "through the night between 150 and 200 copies were made now known as dunlap broadsides",
+      "duration_sec": 9.097437,
+      "speech_end_offset_ms": 1028.0,
+      "audio_hash_id": "a2bb4d7b1f574f67e9874fc067f1cb99774fa12d381d6e0933a03a1acd860607",
+      "condition_idx": 2,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0262.wav",
+      "sha256": "278f3e97c8a6d5c761551a0042f54a9d11b8f7aaef68b438ca741c709477af91",
+      "transcript": "throughout 1960s brzezinski worked for john f kennedy as his advisor and then the lyndon b johnson administration",
+      "duration_sec": 9.83875,
+      "speech_end_offset_ms": 7268.0,
+      "audio_hash_id": "edbd80764cd64777933252f0c289eedfc929b762eb8c6878ddf9ebb53ef11ed9",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0263.wav",
+      "sha256": "afc1ed16e9847020cc0bf4879c0d4c88220fde23aecb33bd997406691d31f711",
+      "transcript": "thus the pencil was a good friend to many people when it came out",
+      "duration_sec": 5.03875,
+      "speech_end_offset_ms": 3652.0,
+      "audio_hash_id": "8cc96fd115cdc8142ad24108c1b162077b175bc91ab38b536fd5850c47f9f127",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0264.wav",
+      "sha256": "bec182f7d2819759c9ffcc405777517a0328d9c7a8a8bf4ccd2544c813828b16",
+      "transcript": "to get the best views of hong kong leave the island and head for the kowloon waterfront opposite",
+      "duration_sec": 9.039687,
+      "speech_end_offset_ms": 5860.0,
+      "audio_hash_id": "2d55f5d32ee563fdd97de6840ce80c8ce2fd864bb6bcc9ad72ea2c2943ee7c69",
+      "condition_idx": 1,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0265.wav",
+      "sha256": "dd016335e5937bdc1ba2871d7612ab97614241ca1f199d4db53a4324a0a4d0ab",
+      "transcript": "to the north and within easy reach is the romantic and fascinating town of sintra and which was made famous to foreigners after a glowing account of its splendours recorded by lord byron",
+      "duration_sec": 12.53875,
+      "speech_end_offset_ms": 10980.0,
+      "audio_hash_id": "8ea7543eabdf06e84f2e4b146d527b90206b9dc04bde97a076b88db5c2ec3835",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0266.wav",
+      "sha256": "e50964b693f5f629047c060d655ee6293c445ee35d5957a7fba4f96e12ce94a7",
+      "transcript": "today the only insects that cannot fold back their wings are dragon flies and mayflies",
+      "duration_sec": 7.01875,
+      "speech_end_offset_ms": 5028.0,
+      "audio_hash_id": "eb5a3bf50a5b49fc2a307f440f109f98f12e7af6f8060065484bc5179052b24f",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0267.wav",
+      "sha256": "214ec02180821a60bd58b38d620daf3c41b1a43bb840cad33eee289002d0958f",
+      "transcript": "traffic flow is the study of the movement of individual drivers and vehicles between two points and the interactions they make with one another",
+      "duration_sec": 9.819688,
+      "speech_end_offset_ms": 7460.0,
+      "audio_hash_id": "de85e55211b82947c4bffc0d2484c8a86c9c8d17e0bfdf91894c0b044ffbc057",
+      "condition_idx": 1,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0268.wav",
+      "sha256": "d0d8319a9cafb6d2ad86c191359323b62eceed9ab58c4532eb21a88c2772d1d6",
+      "transcript": "travellers are strongly advised to be aware of any risk of severe weather affecting their area as they may affect any travel plans",
+      "duration_sec": 9.459687,
+      "speech_end_offset_ms": 7140.0,
+      "audio_hash_id": "21e5009b982c8c415a9fd0b9a0fd76b315e0ccdf8d35f15865f3e9d84060262d",
+      "condition_idx": 1,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0269.wav",
+      "sha256": "ec533412ba06f50d87760e85df48ce2656d9c5b1b6ab70e981a03ac7f8aabfb4",
+      "transcript": "travellers bound for countries with heavy taxation can sometimes save a considerable amount of money especially on products such as alcoholic beverages and tobacco",
+      "duration_sec": 14.677437,
+      "speech_end_offset_ms": 1476.0,
+      "audio_hash_id": "0ae0af630a967199ce3de20b899ad4653853420396a9acd79328be7dbfa73ce3",
+      "condition_idx": 2,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0270.wav",
+      "sha256": "2d74384624c99393fec87efc60bc6530d0d6de0524d5e443a3cd6492c9e6eab8",
+      "transcript": "twentieth century research has shown that there are two pools of genetic variation hidden and expressed",
+      "duration_sec": 9.099687,
+      "speech_end_offset_ms": 6148.0,
+      "audio_hash_id": "f9a044e19498dc1e285ef8c43c38475f80a4e7fc95c676d16aa5ff40b5c5e7aa",
+      "condition_idx": 1,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0271.wav",
+      "sha256": "1fd60fdab1d71a9ed1bd22716a97fb213fc08692cbf8084849dbec41d19c5047",
+      "transcript": "using ships to transport goods is by far the most efficient way to move large amounts of people and goods across oceans",
+      "duration_sec": 8.69875,
+      "speech_end_offset_ms": 6852.0,
+      "audio_hash_id": "b2b85ad5bbe19ee2c9983f9fb31e07498f89850df80215275bea694d87e3d671",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0272.wav",
+      "sha256": "4e2bed962925f26165fb26eed410d5e43c585efc2edc152840295175bddea494",
+      "transcript": "usually you always here the sound of tourists and vendors the story of the sound and light is just like a story book",
+      "duration_sec": 9.519687,
+      "speech_end_offset_ms": 6308.0,
+      "audio_hash_id": "cd2e19f4415f48e17e637c35d364fed9ea3af2fa348bec86747dbfc70040848c",
+      "condition_idx": 1,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0273.wav",
+      "sha256": "bb1a6a3a01fdf6c5e09c914ddb695e94ddeb4c5747415da180b33ec5f8ede890",
+      "transcript": "vatican city's population is around 800 it is the smallest independent country in the world and the country with the lowest population",
+      "duration_sec": 12.879687,
+      "speech_end_offset_ms": 7556.0,
+      "audio_hash_id": "89c4636c09cbfc50e98f1467172e9cdb3b68fe6b07b6585c978c8302685bce73",
+      "condition_idx": 1,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0274.wav",
+      "sha256": "e1a580817682206e5604e2d42a9a3c27cbfadddd5a64d66591e47d2d75b74f4e",
+      "transcript": "virtual scaffolds are internalized in the software and are meant to question prompt and explain procedures that may have been to challenging for the student to handle alone",
+      "duration_sec": 11.859687,
+      "speech_end_offset_ms": 9284.0,
+      "audio_hash_id": "6db710f65c789c1477b77f0dd3c230f7a24b0238eec08140a0af5e4cbef64766",
+      "condition_idx": 1,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0275.wav",
+      "sha256": "23f6744ae95fb9a4ccadc131cdcdf0ea5b7e23e9d3f744afcbbb3a04f93e99fe",
+      "transcript": "virtual teams are held to the same standards of excellence as conventional teams but there are subtle differences",
+      "duration_sec": 6.71875,
+      "speech_end_offset_ms": 5412.0,
+      "audio_hash_id": "d2f28e05701599eef8121075ba66baa1b80b8dfbe65c5ecd758ca8f7ddf5a886",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0276.wav",
+      "sha256": "8ed8f0900e1338983e91cddd493533eb296376b0043822abc7b3b2736713e663",
+      "transcript": "we make our houses from plants and make clothes from plants most foods that we eat are plants without plants animals could not survive",
+      "duration_sec": 10.059688,
+      "speech_end_offset_ms": 7716.0,
+      "audio_hash_id": "0438309c395174b93282923578b0ce92ff2df242a973123c4418d998b4776f9d",
+      "condition_idx": 1,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0277.wav",
+      "sha256": "dcac9d8142fdcc45ce523c43ce7f6c5d207d61df656ad820bc84fc7415f43acc",
+      "transcript": "when all available resources are effectively used across the functional departments of an organization creativity and ingenuity can transpire",
+      "duration_sec": 11.319688,
+      "speech_end_offset_ms": 8228.0,
+      "audio_hash_id": "2bdbce982b4583b9b8296643e1f3b819bb5aff5a7f42ec266ca795321c05664c",
+      "condition_idx": 1,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0278.wav",
+      "sha256": "d68ccfba50d3b761b021b9a0bf92c8c057cbdbddbb55ca3b9ddc4e6f05d12184",
+      "transcript": "while goma is reasonably safe any visits outside of goma should be researched to understand the state of the fighting that persists in the north kivu province",
+      "duration_sec": 14.137438,
+      "speech_end_offset_ms": 1476.0,
+      "audio_hash_id": "d16b7590d789ff09bb09d686d7810f213c66507db11cf51336f71d845d1f0ed1",
+      "condition_idx": 2,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0279.wav",
+      "sha256": "88fa953aa3cb92dbad75b6aa4daa8c39107c00aeb65051c7f9c60b78cd3677cb",
+      "transcript": "while he was working at the hospital liggins began to investigate premature labor during his spare time",
+      "duration_sec": 6.53875,
+      "speech_end_offset_ms": 5252.0,
+      "audio_hash_id": "3447b420921c876235116725f2f6578efc822b57745a75c05f878149f68e87e0",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0280.wav",
+      "sha256": "eff12a46a7ccabdc13624adde67191a59ce2c5bef112bdc54b4a71e3dd925ce7",
+      "transcript": "while one experimental vaccine appears able to reduce ebola mortality up until now no drugs have been clearly demonstrated suitable for treating existing infection",
+      "duration_sec": 14.139688,
+      "speech_end_offset_ms": 11524.0,
+      "audio_hash_id": "b35dbfb5db5fb73beef7f19d4b5c0a341bbbde5baa583dee74bf2a465e59e8ca",
+      "condition_idx": 1,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0281.wav",
+      "sha256": "3f1fbecc9d3f9fa535d77fd97e21d8cdb3533def768a46bf437afdcfadc3fb78",
+      "transcript": "with kundalini yoga the kundalini energy enlightenment energy is awakened through yoga postures breathing exercises mantras and visualizations",
+      "duration_sec": 13.179688,
+      "speech_end_offset_ms": 10052.0,
+      "audio_hash_id": "556f07b1a9c6864ea010000f56f20a96110230468f122a17ca68c7d74156b971",
+      "condition_idx": 1,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0282.wav",
+      "sha256": "0e3b303b4ef66307dcb534e567e60a6d1eaa3acad0835dfadb17deb6b771537b",
+      "transcript": "with two years of the end of the war the former allies were now enemies and the cold war began",
+      "duration_sec": 9.819688,
+      "speech_end_offset_ms": 6308.0,
+      "audio_hash_id": "79fd56f9fd4b992f90e89b4b252f25c5338cd216cc501f1c920ea04f82a8a0c6",
+      "condition_idx": 1,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0283.wav",
+      "sha256": "47a69784cb02fa82526d0fbac5300f7f8dfb88dbfbfece23eae4ae2f1e500854",
+      "transcript": "women it is recommended that any women travellers say that they are married regardless of actual marital status",
+      "duration_sec": 11.21875,
+      "speech_end_offset_ms": 9124.0,
+      "audio_hash_id": "ab9a7234817f9568b6ac23045af1072a8c8170a390d6667fa2ff70e55dfbdd21",
+      "condition_idx": 0,
+      "condition_count": 3
+    },
+    {
+      "path": "audio/0284.wav",
+      "sha256": "63481171b34d91828fa8259c4a4e185bb62df080ce3271cb481f03f7f20233ea",
+      "transcript": "you may also wish to consult the advice of governments other than your own but their advice is designed for their citizens",
+      "duration_sec": 12.637438,
+      "speech_end_offset_ms": 6692.0,
+      "audio_hash_id": "7bc1f83a7d437a958fba8816bd4c2c2d5a9543a71d9b30f54bfd8d1fbc96f82f",
+      "condition_idx": 2,
+      "condition_count": 3
+    }
+  ]
+}


### PR DESCRIPTION
PRs #296-#299 were stacked on each other's branches and merged into those branches instead of main — my mistake; only clean and clipping actually landed. This brings the other four over in one PR: `stt-wildasr-farfield`, `stt-wildasr-noisegap`, `stt-wildasr-phonecodec`, and `stt-wildasr-reverb`, manifests plus their README entries, identical to what was reviewed and approved in the original PRs.

All four re-validated against the runtime manifest model on this branch; audio was already uploaded and hash-verified.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds the remaining WildASR speech-to-text datasets. The main changes are:

- Four manifests for far-field, noise-gap, phone-codec, and reverberation audio.
- Dataset metadata for transcripts, hashes, durations, and degradation conditions.
- README entries describing each intervention and its condition rotation.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed files.
- The manifests follow the existing WildASR schema, identifiers, item ordering, and audio path conventions.
- The documented condition counts and degradation behavior match the manifest data inspected.

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;cale/bench-424-add-stt-wil..."](https://github.com/coval-ai/benchmarks/commit/a987914b8669f7c4cfb470cc6425126740f2edc1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44598201)</sub>

<!-- /greptile_comment -->