### PR TITLE
Add a required domain dropdown to arena battle generation

### DIFF
--- a/web/app/api/arena/battle/route.ts
+++ b/web/app/api/arena/battle/route.ts
@@ -1,6 +1,7 @@
 export const runtime = "nodejs";
 export const maxDuration = 60;
 
+import { isArenaDomain } from "@/lib/arena/domains";
 import { arenaAccessOk } from "@/lib/arena/guard";
 import { arenaRunnerFetch } from "@/lib/arena/runner";
 import type { BlindBattle } from "@/lib/arena/types";
@@ -15,7 +16,7 @@ interface BattleOut {
 
 export async function POST(req: Request) {
   if (!(await arenaAccessOk())) return new Response(null, { status: 404 });
-  let body: { text?: string };
+  let body: { text?: string; domain?: string };
   try {
     body = await req.json();
   } catch {
@@ -23,10 +24,13 @@ export async function POST(req: Request) {
   }
   const text = body.text?.trim();
   if (!text) return Response.json({ error: "Prompt is empty." }, { status: 400 });
+  if (!isArenaDomain(body.domain)) {
+    return Response.json({ error: "Invalid domain." }, { status: 400 });
+  }
 
   let res: Response;
   try {
-    res = await arenaRunnerFetch("/v1/arena/battle", { prompt: text });
+    res = await arenaRunnerFetch("/v1/arena/battle", { prompt: text, domain: body.domain });
   } catch {
     return Response.json({ error: "Battle generation failed." }, { status: 502 });
   }

--- a/web/app/arena/page.tsx
+++ b/web/app/arena/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
+import { ARENA_DOMAINS, type ArenaDomain } from "@/lib/arena/domains";
 import { getBattleSource } from "@/lib/arena/source";
 import type { BlindBattle, Outcome, Reveal, RevealedModel } from "@/lib/arena/types";
 import { AudioPlayer } from "./components/AudioPlayer";
@@ -19,6 +20,7 @@ export default function ArenaPage() {
 
   const [step, setStep] = useState<1 | 2 | 4>(1);
   const [text, setText] = useState("");
+  const [domain, setDomain] = useState<ArenaDomain | "">("");
   const [battle, setBattle] = useState<BlindBattle | null>(null);
   const [vote, setVote] = useState<Outcome | null>(null);
   const [reveal, setReveal] = useState<Reveal | null>(null);
@@ -46,12 +48,12 @@ export default function ArenaPage() {
 
   const generate = async () => {
     const trimmed = text.trim();
-    if (trimmed.length < MIN_CHARS || loading) return;
+    if (trimmed.length < MIN_CHARS || !domain || loading) return;
     const token = ++runToken.current;
     setLoading(true);
     setError(null);
     try {
-      const b = await source.createBattle(trimmed);
+      const b = await source.createBattle(trimmed, domain);
       if (token !== runToken.current) return; // a newer action superseded this one
       setBattle(b);
       setStep(2);
@@ -117,6 +119,21 @@ export default function ArenaPage() {
 
         {step === 1 && (
           <section className="flex flex-col gap-3">
+            <select
+              value={domain}
+              onChange={(e) => setDomain(e.target.value as ArenaDomain | "")}
+              aria-label="Domain"
+              className="w-full appearance-none rounded-xl border border-border-primary bg-surface-elevated px-4 py-3 font-sans text-sm outline-none focus:border-selected-border"
+            >
+              <option value="" disabled>
+                Select a domain…
+              </option>
+              {ARENA_DOMAINS.map((d) => (
+                <option key={d.value} value={d.value}>
+                  {d.label}
+                </option>
+              ))}
+            </select>
             <textarea
               value={text}
               maxLength={MAX_CHARS}
@@ -140,7 +157,7 @@ export default function ArenaPage() {
             <button
               type="button"
               onClick={generate}
-              disabled={text.trim().length < MIN_CHARS || loading}
+              disabled={text.trim().length < MIN_CHARS || !domain || loading}
               className="self-start rounded-full bg-surface-toggle-active px-6 py-2.5 font-mono text-sm text-text-on-toggle-active disabled:opacity-40"
             >
               {loading ? "Generating…" : "Generate speech"}

--- a/web/lib/arena/apiSource.ts
+++ b/web/lib/arena/apiSource.ts
@@ -1,10 +1,11 @@
+import type { ArenaDomain } from "./domains";
 import type { BattleSource, BlindBattle, Reveal, VoteInput, VoteResult } from "./types";
 
 // Real battle source: talks to same-origin Next.js API proxy routes under /api/arena/*,
 // which inject the server-only X-Labeler-Key and proxy to the runner. Inert until
 // NEXT_PUBLIC_ARENA_SOURCE=api is set (the factory defaults to the mock). The BFF routes it
 // calls:
-//   POST /api/arena/battle              { text }                        -> BlindBattle
+//   POST /api/arena/battle              { text, domain }                -> BlindBattle
 //   POST /api/arena/vote                { battleId, outcome, voterId }  -> VoteResult
 //   GET  /api/arena/battle/{id}/reveal?voterId=...                      -> Reveal
 
@@ -24,8 +25,8 @@ async function postJson<T>(url: string, body: unknown, timeoutMs = QUICK_TIMEOUT
 }
 
 export class ApiBattleSource implements BattleSource {
-  createBattle(text: string): Promise<BlindBattle> {
-    return postJson<BlindBattle>("/api/arena/battle", { text }, SYNTH_TIMEOUT_MS);
+  createBattle(text: string, domain: ArenaDomain): Promise<BlindBattle> {
+    return postJson<BlindBattle>("/api/arena/battle", { text, domain }, SYNTH_TIMEOUT_MS);
   }
 
   submitVote(input: VoteInput): Promise<VoteResult> {

--- a/web/lib/arena/arena.test.ts
+++ b/web/lib/arena/arena.test.ts
@@ -2,12 +2,22 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, expect, it } from "vitest";
+import { ARENA_DOMAINS, isArenaDomain } from "./domains";
 import { MockBattleSource } from "./mockSource";
 import { getBattleSource } from "./source";
 
+describe("arena domains", () => {
+  it("accepts every dropdown value and rejects everything else", () => {
+    for (const d of ARENA_DOMAINS) expect(isArenaDomain(d.value)).toBe(true);
+    expect(isArenaDomain("all")).toBe(false);
+    expect(isArenaDomain("")).toBe(false);
+    expect(isArenaDomain(undefined)).toBe(false);
+  });
+});
+
 describe("MockBattleSource", () => {
   it("creates a blind battle: prompt echoed, two distinct playable audio sources", async () => {
-    const battle = await new MockBattleSource().createBattle("hello world");
+    const battle = await new MockBattleSource().createBattle("hello world", "healthcare");
     expect(battle.battleId).toBeTruthy();
     expect(battle.prompt).toBe("hello world");
     expect(battle.audioA).toMatch(/^data:audio\/wav;base64,/);
@@ -16,13 +26,13 @@ describe("MockBattleSource", () => {
   });
 
   it("does not leak any model identity in the blind battle payload", async () => {
-    const battle = await new MockBattleSource().createBattle("hi");
+    const battle = await new MockBattleSource().createBattle("hi", "sales");
     expect(Object.keys(battle).sort()).toEqual(["audioA", "audioB", "battleId", "prompt"]);
   });
 
   it("reveals two distinct models for a created battle", async () => {
     const src = new MockBattleSource();
-    const battle = await src.createBattle("hi");
+    const battle = await src.createBattle("hi", "other");
     const reveal = await src.reveal(battle.battleId, "t");
     expect(reveal.a.model).toBeTruthy();
     expect(reveal.b.model).toBeTruthy();
@@ -35,7 +45,7 @@ describe("MockBattleSource", () => {
 
   it("echoes the outcome on submitVote", async () => {
     const src = new MockBattleSource();
-    const battle = await src.createBattle("hi");
+    const battle = await src.createBattle("hi", "customer-service");
     const res = await src.submitVote({ battleId: battle.battleId, outcome: "A_WIN", voterId: "t" });
     expect(res).toEqual({ battleId: battle.battleId, outcome: "A_WIN" });
   });

--- a/web/lib/arena/domains.ts
+++ b/web/lib/arena/domains.ts
@@ -1,0 +1,15 @@
+// Values must match ArenaDomain in runner/src/coval_bench/api/schemas.py — they are
+// stored on battles and used as leaderboard keys ("all" is reserved for the aggregate board).
+export const ARENA_DOMAINS = [
+  { value: "customer-service", label: "Customer Service" },
+  { value: "healthcare", label: "Healthcare" },
+  { value: "sales", label: "Sales" },
+  { value: "receptionist-booking", label: "Receptionist / Booking" },
+  { value: "other", label: "Other" },
+] as const;
+
+export type ArenaDomain = (typeof ARENA_DOMAINS)[number]["value"];
+
+export function isArenaDomain(value: unknown): value is ArenaDomain {
+  return ARENA_DOMAINS.some((d) => d.value === value);
+}

--- a/web/lib/arena/mockSource.ts
+++ b/web/lib/arena/mockSource.ts
@@ -1,4 +1,5 @@
 import { getEnabledTtsModels } from "../playground/providers";
+import type { ArenaDomain } from "./domains";
 import type { BattleSource, BlindBattle, Reveal, RevealedModel, VoteInput, VoteResult } from "./types";
 
 // Self-contained mock: no network, no backend. Generates two distinct audible tones as
@@ -56,7 +57,7 @@ export class MockBattleSource implements BattleSource {
   private assignments = new Map<string, Reveal>();
   private counter = 0;
 
-  async createBattle(text: string): Promise<BlindBattle> {
+  async createBattle(text: string, _domain: ArenaDomain): Promise<BlindBattle> {
     await delay(600); // exercise the loading state
     const pool = [...getEnabledTtsModels()];
     const a = pool.splice(Math.floor(Math.random() * pool.length), 1)[0];

--- a/web/lib/arena/types.ts
+++ b/web/lib/arena/types.ts
@@ -1,3 +1,5 @@
+import type { ArenaDomain } from "./domains";
+
 export type Outcome = "A_WIN" | "B_WIN" | "TIE";
 
 // What the UI renders during the blind phase — never any model identity.
@@ -34,7 +36,7 @@ export interface Reveal {
 // The single seam the UI depends on. Swap the implementation (mock <-> api) and the
 // whole battle page keeps working unchanged. See ./README.md.
 export interface BattleSource {
-  createBattle(text: string): Promise<BlindBattle>;
+  createBattle(text: string, domain: ArenaDomain): Promise<BlindBattle>;
   submitVote(input: VoteInput): Promise<VoteResult>;
   reveal(battleId: string, voterId: string): Promise<Reveal>;
 }


### PR DESCRIPTION
Voters now pick a domain (Customer Service, Healthcare, Sales, Receptionist / Booking, Other) before generating a battle; the choice is stored on the battle and sticks across consecutive battles. The BFF validates the value against the same fixed list and forwards it to the runner.

Safe to deploy against the current backend, which already accepts an optional free-form domain — server-side validation lands separately. First of three: dropdown → domain validation/filter → backfill + require.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR requires voters to choose a domain when generating an arena battle. The main changes are:

- Adds a shared list of supported arena domains.
- Adds a required domain dropdown that persists across consecutive battles.
- Validates domains in the BFF and forwards them to the runner.
- Updates battle-source types, implementations, and unit tests.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.
- The UI and BFF use the same domain values.
- The BFF rejects missing or invalid domains before calling the runner.

<sub>Reviews (1): Last reviewed commit: ["Add a required domain dropdown to arena ..."](https://github.com/coval-ai/benchmarks/commit/a57433774cde84630d3ab07f6c16137fcf4f13a0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44604146)</sub>

<!-- /greptile_comment -->