### PR TITLE
Require a domain on new battles and backfill old ones to other

### DIFF
--- a/runner/src/coval_bench/__main__.py
+++ b/runner/src/coval_bench/__main__.py
@@ -330,12 +330,21 @@ def arena() -> None:
     help="RNG seed; keeps the bootstrap CI reproducible.",
 )
 @click.option(
+    "--domain",
+    default="all",
+    show_default=True,
+    type=click.Choice(
+        ("all", "customer-service", "healthcare", "sales", "receptionist-booking", "other")
+    ),
+    help="Domain board to compute ('all' aggregates every battle regardless of domain).",
+)
+@click.option(
     "--force",
     is_flag=True,
     default=False,
     help="Run even if another snapshot is in progress (bypass the advisory lock).",
 )
-def arena_snapshot(metric: str, bootstrap_rounds: int, seed: int, force: bool) -> None:
+def arena_snapshot(metric: str, bootstrap_rounds: int, seed: int, domain: str, force: bool) -> None:
     """Refit Davidson-BT ratings from all votes and persist a leaderboard board."""
     from coval_bench.arena.rating import ConvergenceError
     from coval_bench.arena.snapshot import run_snapshot
@@ -351,6 +360,7 @@ def arena_snapshot(metric: str, bootstrap_rounds: int, seed: int, force: bool) -
                 metric_name=metric,
                 bootstrap_rounds=bootstrap_rounds,
                 seed=seed,
+                domain=domain,
                 force=force,
             )
         return None if result is None else len(result.models)
@@ -363,6 +373,7 @@ def arena_snapshot(metric: str, bootstrap_rounds: int, seed: int, force: bool) -
                 {
                     "event": "arena_snapshot",
                     "metric": metric,
+                    "domain": domain,
                     "error": "convergence_failed",
                     "detail": str(exc),
                 }
@@ -370,9 +381,17 @@ def arena_snapshot(metric: str, bootstrap_rounds: int, seed: int, force: bool) -
         )
         sys.exit(1)
     if written is None:
-        click.echo(json.dumps({"event": "arena_snapshot", "metric": metric, "skipped": True}))
+        click.echo(
+            json.dumps(
+                {"event": "arena_snapshot", "metric": metric, "domain": domain, "skipped": True}
+            )
+        )
     else:
-        click.echo(json.dumps({"event": "arena_snapshot", "metric": metric, "models": written}))
+        click.echo(
+            json.dumps(
+                {"event": "arena_snapshot", "metric": metric, "domain": domain, "models": written}
+            )
+        )
 
 
 @arena.command(name="seed-battles")

--- a/runner/src/coval_bench/api/schemas.py
+++ b/runner/src/coval_bench/api/schemas.py
@@ -214,7 +214,7 @@ class BattleCreate(BaseModel):
     """Request to generate a new battle from a user prompt."""
 
     prompt: str = Field(..., max_length=500)
-    domain: ArenaDomain | None = None
+    domain: ArenaDomain
 
 
 class LeaderboardEntryOut(BaseModel):

--- a/runner/src/coval_bench/db/migrations/versions/20260715_0011_backfill_arena_battle_domains.py
+++ b/runner/src/coval_bench/db/migrations/versions/20260715_0011_backfill_arena_battle_domains.py
@@ -1,0 +1,29 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Arena battles: fold pre-domain battles into ``other``.
+
+Battles created before the domain dropdown have ``domain`` NULL (confirmed the only
+value in prod as of 2026-07-15); the API now only accepts the fixed domain set, so
+tag them ``other``. Their votes already count toward the aggregate ``all`` board,
+which ignores domain — this only adds them to the ``other`` per-domain board.
+
+Irreversible: which rows were NULL is not preserved, so ``downgrade`` is a no-op.
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "20260715_0011"
+down_revision = "20260715_0010"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("UPDATE arena.battles SET domain = 'other' WHERE domain IS NULL")
+
+
+def downgrade() -> None:
+    pass

--- a/runner/tests/api/test_arena.py
+++ b/runner/tests/api/test_arena.py
@@ -658,9 +658,10 @@ async def test_create_battle_rejects_empty_prompt(client: AsyncClient, postgresq
 
 
 async def test_create_battle_rejects_bad_domain(client: AsyncClient, postgresql: Any) -> None:
-    """An unknown or reserved ('all') domain is rejected with 422."""
+    """A missing, unknown, or reserved ('all') domain is rejected with 422."""
     await _apply_arena_schema(_make_db_url(postgresql))
     for payload in (
+        {"prompt": "hello"},
         {"prompt": "hello", "domain": "banking"},
         {"prompt": "hello", "domain": "all"},
     ):


### PR DESCRIPTION
With the dropdown live, domain becomes required on battle creation. Migration 0011 tags the pre-dropdown battles as "other" — all 265 battles in prod have domain NULL today (verified against prod on 2026-07-15), and their 256 votes keep counting toward the aggregate "all" board, which never looks at domain. The snapshot CLI also gains --domain (default all), so the daily job can start computing per-domain boards.

Stacked on #302; retarget to main once it merges. Release the runner image for this one only after the dropdown (#301) is deployed on Vercel, otherwise battle generation from the old UI would 422. Last of three.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR requires domains for new battles and supports domain-specific leaderboard snapshots. The main changes are:

- Adds `--domain` to the snapshot CLI and its structured output.
- Requires a valid domain in battle creation requests.
- Backfills existing NULL battle domains to `other`.
- Adds coverage for missing-domain validation.

<h3>Confidence Score: 4/5</h3>

The API-backed web creation path will fail until it forwards the required domain.

- The runner now rejects the payload currently sent by the web proxy.
- The migration value matches the accepted domain set.
- Snapshot filtering and persistence receive the selected domain consistently.

runner/src/coval_bench/api/schemas.py and the web battle-creation proxy

<sub>Reviews (1): Last reviewed commit: ["Require a domain on new battles and back..."](https://github.com/coval-ai/benchmarks/commit/d88c6b0a4b5879990407ec64f492c8747f9e3c7f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44604617)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->