### PR TITLE
Add stt-wildasr-accent dataset

### DIFF
--- a/runner/src/coval_bench/datasets/manifests/README.md
+++ b/runner/src/coval_bench/datasets/manifests/README.md
@@ -108,7 +108,32 @@ The room-reverberation intervention
 (`environment_degradation__en__fleurs_reverberation_en`). 3 RIR conditions
 per utterance; reverb tails lengthen every clip past its clean sibling, so
 the rotation advances past out-of-band draws (hence the uneven condition
-spread).
+spread). 9 of the 284 items carry a null `speech_end_offset_ms`: SileroVAD
+detects no speech in the harshest draws, so WER is measured but TTFS is
+skipped for those clips.
+
+### `stt-wildasr-accent.json`
+
+The demographic intervention: the `demographic_shift__en__demographic_accent_en`
+split of [bosonai/WildASR](https://huggingface.co/datasets/bosonai/WildASR),
+accented English speech. Unpaired — zero transcript overlap with the
+environment family — and the source publishes no accent or speaker labels, so
+it benchmarks accented speech in aggregate.
+
+- **Selection** (in `datasets/scripts/wildasr.py`, deterministic): every
+  distinct recording in the split, deduped by `audio_hash_id`. The same
+  transcript read under different accents is deliberately kept as distinct
+  clips, so transcripts repeat while recordings never do.
+- **845 clips** of the source's 1,000 survive the standard 2.0–15.0 s band and
+  ≥ 3-word floor (the split skews short: median 3.7 s, max 8.0 s), ~54 minutes
+  of audio.
+- Loudness-normalized like the rest of the WildASR sets; `speech_end_offset_ms`
+  filled by `scripts/precompute_vad_offsets.py`.
+
+To rebuild: `uv run --extra hf-parquet coval-build-dataset stt-wildasr-accent`,
+then the VAD offsets script. **Never overwrite** — expansions get new ids.
+
+License: `Apache-2.0` (WildASR).
 
 ### `stt-v3.json`
 

--- a/runner/src/coval_bench/datasets/manifests/stt-wildasr-accent.json
+++ b/runner/src/coval_bench/datasets/manifests/stt-wildasr-accent.json
@@ -1,0 +1,6769 @@
+{
+  "_license": "Apache-2.0 (WildASR)",
+  "id": "stt-wildasr-accent",
+  "version": "1.0.0",
+  "license": "Apache-2.0 (WildASR)",
+  "source": "bosonai/WildASR demographic_shift__en__demographic_accent_en",
+  "items": [
+    {
+      "path": "audio/0001.wav",
+      "sha256": "7e247f1f968c3e1f8a860082d6fe4ae2d85108789a16d6deca2ed9e37657176e",
+      "transcript": "this proposal was known as the virginia plan.",
+      "duration_sec": 2.236063,
+      "speech_end_offset_ms": 2236.1,
+      "audio_hash_id": "00066f79b61e52b50f26be52d2fe3ec3941d6a92b0467932de0b193802e71b6c"
+    },
+    {
+      "path": "audio/0002.wav",
+      "sha256": "de7a182d4ff3f37234f4d42ca4995c2cb87ba50da41aeee5d5aad801d0565781",
+      "transcript": "the heavyweight playoffs also began.",
+      "duration_sec": 2.364063,
+      "speech_end_offset_ms": 2364.1,
+      "audio_hash_id": "00b90d6ece5778e3b1d7402a8dbab3affba9929afaa360cdc9c54a26b58a8cc2"
+    },
+    {
+      "path": "audio/0003.wav",
+      "sha256": "2eea311cf6e23d5512d0cb234cf7d799e3265084ffbfa1799d112cc86c627e87",
+      "transcript": "he was most active at night and would travel about stealing souls.",
+      "duration_sec": 3.42,
+      "speech_end_offset_ms": 3420.0,
+      "audio_hash_id": "00c4c5a71e985c12af7634ffc5e78b977b7c535eee345df835117079abfe4253"
+    },
+    {
+      "path": "audio/0004.wav",
+      "sha256": "d183f0b70bff301d8e5139f3a750c4fdbbff25e97b12edb45e78161ef6d0575a",
+      "transcript": "because of the short summer in finland, nokian tests summer tyres at other locations.",
+      "duration_sec": 4.764,
+      "speech_end_offset_ms": 4764.0,
+      "audio_hash_id": "015c2ffd0c56ebbc9ef8bde7b321b71e65582a40f4bd80403536ff756c96c53c"
+    },
+    {
+      "path": "audio/0005.wav",
+      "sha256": "9aff126457a4a005600014fa175df76a3b21f4bd281dcd0768dcfc8ae6ae5e8b",
+      "transcript": "book signings provide more than a just a chance to obtain signatures.",
+      "duration_sec": 5.02,
+      "speech_end_offset_ms": 5020.0,
+      "audio_hash_id": "01f7a536dd2cd14f2b472349111d7ed161c6e1cc37e6972a6cb489d88e588d6c"
+    },
+    {
+      "path": "audio/0006.wav",
+      "sha256": "c8f0f6045e75fa5db4108f9e433e0c13b2a5b7475b052a1f8fff260b63f607cd",
+      "transcript": "adam was not well, said shuttleworth indignantly.",
+      "duration_sec": 3.676,
+      "speech_end_offset_ms": 3676.0,
+      "audio_hash_id": "0263c66362217d019d5fbf2477f73d288a1c2a9719c5697d98444cfffd4c1644"
+    },
+    {
+      "path": "audio/0007.wav",
+      "sha256": "54f4c88762b30f8d169d3595f632e1ed8eaf86ba05673fdc4d74f0bf88a1dcd8",
+      "transcript": "if members are bisexual, they may have evolved sexual relationships with either gender.",
+      "duration_sec": 4.476063,
+      "speech_end_offset_ms": 4476.1,
+      "audio_hash_id": "029027240bb8b4e10c133ae64525a7744655c62c8c4b781c264e1dcc9277bd66"
+    },
+    {
+      "path": "audio/0008.wav",
+      "sha256": "e548d402c6edffc9d3443b6640d39fb4c9696429222a90fe3ea9a03b155e6ab5",
+      "transcript": "it shut, and i was left alone again.",
+      "duration_sec": 2.3,
+      "speech_end_offset_ms": 2300.0,
+      "audio_hash_id": "031224346eccea3a96b32a6d14eb30e02ffbb689d923580eab93c6c23a7dd2f2"
+    },
+    {
+      "path": "audio/0009.wav",
+      "sha256": "30d4df75dc60aea05126fa3c434b999b95d7bd7e3cef318238230157a12e07ea",
+      "transcript": "furthermore, he liked to photograph and owned a small fruit farm.",
+      "duration_sec": 3.548062,
+      "speech_end_offset_ms": 3548.1,
+      "audio_hash_id": "0354b21b48319891200e63e06f1e5d1c0081a0810f14cf10dd060ef29173a11b"
+    },
+    {
+      "path": "audio/0010.wav",
+      "sha256": "68c7d74abba41d28abbf6110c27828f0bc42a5dcc80118a46cc56a57b28dc23e",
+      "transcript": "christine jessop's murderer is still unknown.",
+      "duration_sec": 2.3,
+      "speech_end_offset_ms": 2300.0,
+      "audio_hash_id": "03be684684ab0f4926c76319d406ffb112f12b95e5c39a88d02755931df7412d"
+    },
+    {
+      "path": "audio/0011.wav",
+      "sha256": "80ae47d771d013dde10215d299b4f2b95fea8222fe42c04a0d61b8649d42e7c3",
+      "transcript": "his son, james everard home, became an eminent officer in the royal navy.",
+      "duration_sec": 5.66,
+      "speech_end_offset_ms": 5660.0,
+      "audio_hash_id": "03d58b56f2c6458f21e6b624c7e9eba32e927dd0e48c714586848f6d4d51f1d3"
+    },
+    {
+      "path": "audio/0012.wav",
+      "sha256": "62d4a88c06fec801392655f3267de745cbd633a2dc1644e64968c8d56fd56d95",
+      "transcript": "television can make you dumb, but it can also be good education.",
+      "duration_sec": 3.132,
+      "speech_end_offset_ms": 3132.0,
+      "audio_hash_id": "03ffbefc220e02297f30a6a862e1ccbc924ac00e33640513e68add0ae43871de"
+    },
+    {
+      "path": "audio/0013.wav",
+      "sha256": "03e9b18d9f28e6704c4c9faad26b1689e18d0d063d8396deccd7adfc66077e5c",
+      "transcript": "whether this occurred is not clear.",
+      "duration_sec": 2.3,
+      "speech_end_offset_ms": 2300.0,
+      "audio_hash_id": "0419f2ddb4271006b7e021aca62a68abd1c31509650ca8839e21c6c286c9e3d3"
+    },
+    {
+      "path": "audio/0014.wav",
+      "sha256": "90ca950a1b8de201dbca33e7b0f3d7fe86c50b07f1ebd7fac43a4e13cd3c196b",
+      "transcript": "he made his international debut the following september in a friendly match against paraguay.",
+      "duration_sec": 5.18,
+      "speech_end_offset_ms": 5180.0,
+      "audio_hash_id": "046d1780772532c48ce67fc8b82fa1b96194db8a57e7b4d78e3947c178aaeea8"
+    },
+    {
+      "path": "audio/0015.wav",
+      "sha256": "1b8f58becbe4ee6d7ffe6dd89dd7de02df3fb8a402a02951b9adb8662da7fb32",
+      "transcript": "i was forced to reconsider everything i'd once believed.",
+      "duration_sec": 2.908063,
+      "speech_end_offset_ms": 2908.1,
+      "audio_hash_id": "04c2b4e55ca7bc548404a7493d64fe8fafdffce8c252bc2da7668bd20e50823f"
+    },
+    {
+      "path": "audio/0016.wav",
+      "sha256": "02da6fb437e135620673ab3f244cfb1af451932f4c92ff48e25330291f3df905",
+      "transcript": "tears would be the first rush song to feature an outside musician.",
+      "duration_sec": 5.18,
+      "speech_end_offset_ms": 5180.0,
+      "audio_hash_id": "04e70d4bac9eec268934086b3d478de7369db6a6c27026d2d7ab93fcc9ba4b4e"
+    },
+    {
+      "path": "audio/0017.wav",
+      "sha256": "028a7573f29458ef2d1453a85b1abefabe8e375de369efa3f3715332943ce90c",
+      "transcript": "the belly is often a bright shade of yellow or orange.",
+      "duration_sec": 3.548062,
+      "speech_end_offset_ms": 3548.1,
+      "audio_hash_id": "058985f4c4acadd3441512157e7ca77f55d22afa103b75f858b3232384579e2f"
+    },
+    {
+      "path": "audio/0018.wav",
+      "sha256": "2e9e0cd333187a7b4d1aa0e433e60470516ea8d315fe6c37dafd114a8c1fc365",
+      "transcript": "these parts are generated into javascript.",
+      "duration_sec": 2.94,
+      "speech_end_offset_ms": 2940.0,
+      "audio_hash_id": "058ac96ceddaa53204231bfca7685a922ffeba649841350cc9796056fb238f1e"
+    },
+    {
+      "path": "audio/0019.wav",
+      "sha256": "9780427d0e5cca3272fb39bd3424864bae1288e47d63bb6a330c6ce5422af221",
+      "transcript": "vacuum aspiration has lower rates of complications when compared to d and c.",
+      "duration_sec": 4.796062,
+      "speech_end_offset_ms": 4796.1,
+      "audio_hash_id": "05920c5cc2f0ce7a677b7514792212513014ca823f15763c057aa729eb7bfa36"
+    },
+    {
+      "path": "audio/0020.wav",
+      "sha256": "2876de63df9725a9cf4551b5c483be3bcccbd08d93bad40550a964b6136c1cea",
+      "transcript": "the island hosts immaculate waterfalls, and pretty beaches.",
+      "duration_sec": 3.932,
+      "speech_end_offset_ms": 3932.0,
+      "audio_hash_id": "05df8af3bd05212e1ece5ae0e5dfab33a42f1dde9ad97fe568cc3765a1a738a8"
+    },
+    {
+      "path": "audio/0021.wav",
+      "sha256": "58d5b14aa2b7a9e159ccdc4ec7bacb965072f938c47d3cf1d3bb9ec347b6249d",
+      "transcript": "their ears are small.",
+      "duration_sec": 2.172,
+      "speech_end_offset_ms": 2172.0,
+      "audio_hash_id": "063147d36d2a976da776ff9ba340fe6a5f78c8548f7234b337a470b22feb9355"
+    },
+    {
+      "path": "audio/0022.wav",
+      "sha256": "aacdd8dd99542547940d54dd2bdfb4ad71714c83e1626a01b709fd2a5d15f56e",
+      "transcript": "for example, you cannot take their address.",
+      "duration_sec": 2.236,
+      "speech_end_offset_ms": 2236.0,
+      "audio_hash_id": "0754033e360376b8fca1b05e8967ddb565fa5d74fb0ce7dd942414156f220796"
+    },
+    {
+      "path": "audio/0023.wav",
+      "sha256": "03e8feff2354be2d9fec6c7b143d155ad6876f49d65274b0e1143a51053fa36f",
+      "transcript": "finally in space, homer reveals he has smuggled potato chips on board.",
+      "duration_sec": 3.548062,
+      "speech_end_offset_ms": 3548.1,
+      "audio_hash_id": "0769f34e434f865ad8e41dc6af03e93e9c9330c65de258860b5e7365689f9752"
+    },
+    {
+      "path": "audio/0024.wav",
+      "sha256": "85bd649db07a9985853f2324f1634b2a7f7315430eb40d82484e330d7e00681d",
+      "transcript": "summer season persists for longest period during the year.",
+      "duration_sec": 3.292,
+      "speech_end_offset_ms": 3292.0,
+      "audio_hash_id": "078ef48ad415d35f42abfdeaa9be372e12eb83ecebe7cfc4ffdd32ed48857554"
+    },
+    {
+      "path": "audio/0025.wav",
+      "sha256": "ad0a939f71d65d07db18ff2b5f48601995a2a9169df7d8958e6bf0ebeef2e691",
+      "transcript": "changes are calculated for each industry in the analysis, both regionally and nationally.",
+      "duration_sec": 4.828062,
+      "speech_end_offset_ms": 4828.1,
+      "audio_hash_id": "07cf86f796572797a70751d03e5b3f61bf6f84c849778000646c124c37d857b3"
+    },
+    {
+      "path": "audio/0026.wav",
+      "sha256": "88d7fc99d9b770fba9d42b2d68962b27e6978c16471e32db7608bbd361eca34f",
+      "transcript": "kiss recorded most of live album alive!",
+      "duration_sec": 3.324,
+      "speech_end_offset_ms": 3324.0,
+      "audio_hash_id": "08449265383e29653c3bd9f75a3ef9e8a3a0cac6c5616f129c8106e4283d2ab0"
+    },
+    {
+      "path": "audio/0027.wav",
+      "sha256": "ca36b91847be7618642f5b9d876b2e3b0cc844cfb5fb60a39fda926295d72684",
+      "transcript": "a phd may also be obtained by physicians during the residency training period.",
+      "duration_sec": 5.34,
+      "speech_end_offset_ms": 5340.0,
+      "audio_hash_id": "0976a293c839802867f57ac926dcbeb98328689cffad7ec8f55eb9fbf63bc90f"
+    },
+    {
+      "path": "audio/0028.wav",
+      "sha256": "3339b16e5abd3b7afa8213dbe5f057580e5ca66768df30c79187fdd007975293",
+      "transcript": "allison was married to music publisher archie levington.",
+      "duration_sec": 3.324,
+      "speech_end_offset_ms": 3324.0,
+      "audio_hash_id": "0984b050271976f99a2cf719a85623982ef8671493c0d3da38bbb22a4e1d4ae8"
+    },
+    {
+      "path": "audio/0029.wav",
+      "sha256": "68d82cf6bca3d9570ae38736c1af1f4132c708d3c2adcede31ed9ffcacebd85a",
+      "transcript": "the birmingham six were initially refused permission to further appeal against their convictions.",
+      "duration_sec": 7.996062,
+      "speech_end_offset_ms": 7996.1,
+      "audio_hash_id": "09926d609428ee4b3e8bc69c4cd09339ca914ebc887f148178f37cc84109add7"
+    },
+    {
+      "path": "audio/0030.wav",
+      "sha256": "9002e6a16391e42e2bbaf7157a32074bc11f31679d5d3cb3903e76b86d71a4d3",
+      "transcript": "the first rule of don't fight club is let's talk about it.",
+      "duration_sec": 2.908063,
+      "speech_end_offset_ms": 2908.1,
+      "audio_hash_id": "09ada9eecf99622995f24a36eab86d46eb3c1917d790d8ecdf404c0690495df1"
+    },
+    {
+      "path": "audio/0031.wav",
+      "sha256": "c013f4b5f946d546683352edb3b658d90fa77c3d72d10491c85d0a43d4d045d3",
+      "transcript": "his way isn't the same as mine, nor mine as his.",
+      "duration_sec": 3.356063,
+      "speech_end_offset_ms": 3356.1,
+      "audio_hash_id": "0ae7b8dd71bb833b8f35a47ae0f0f0931bed7fdb26b7730add8da3cc338e762b"
+    },
+    {
+      "path": "audio/0032.wav",
+      "sha256": "172659bf03c1b6fd18c3467a74761858ecac6e3f3af80688b25fec556451af31",
+      "transcript": "for example, colombia, chile, argentina and venezuela.",
+      "duration_sec": 3.612062,
+      "speech_end_offset_ms": 3612.1,
+      "audio_hash_id": "0b045bcfe0ffcf6bb6792044edc65187261db42799b8656217395f41daf7b239"
+    },
+    {
+      "path": "audio/0033.wav",
+      "sha256": "ddda63c74ff3a74381b955ebffea874d05ba8f383042755de2cc93b02f04d89b",
+      "transcript": "on the western front the largest of these was operation ironside.",
+      "duration_sec": 4.572,
+      "speech_end_offset_ms": 4572.0,
+      "audio_hash_id": "0b20062790d3b8299a059c93619c83bc94716890e570e71c5bae94e51a3f2d81"
+    },
+    {
+      "path": "audio/0034.wav",
+      "sha256": "15118eff3958766753614461ad759c0dbecd935d7cf41ef448133433f989b968",
+      "transcript": "no sound came to me in that dark place.",
+      "duration_sec": 2.556,
+      "speech_end_offset_ms": 2556.0,
+      "audio_hash_id": "0b77ecee46b0770327e180f1177d8774405eb849a78da4b09689d1dbe3aabc44"
+    },
+    {
+      "path": "audio/0035.wav",
+      "sha256": "6c6df6807b27d88bf5fa7e62c52d8c33529457ce4879c37c9a7dbce7860dda9c",
+      "transcript": "williams did not live far from ridgefield, and he became involved in the magazine.",
+      "duration_sec": 4.7,
+      "speech_end_offset_ms": 4700.0,
+      "audio_hash_id": "0c7c7995924c34af3ab370169226203c9823f0867f069e45e39da9d6f085cc31"
+    },
+    {
+      "path": "audio/0036.wav",
+      "sha256": "10bb3dc02313ab3d781f25252227487da7100cee9819760471665b011be990d7",
+      "transcript": "are they selling faggots as well as sausages?",
+      "duration_sec": 2.428,
+      "speech_end_offset_ms": 2428.0,
+      "audio_hash_id": "0c9cd2a6a15036ec373c1d6595131ef097fc98475138c0cefadb54ea79702b77"
+    },
+    {
+      "path": "audio/0037.wav",
+      "sha256": "f5ebd9cd2bffcb68346396508b4d9d26dd0d41a2ae67ccca99d64d7bccbbf047",
+      "transcript": "he later worked as a chief engineer in mogadishu.",
+      "duration_sec": 2.972,
+      "speech_end_offset_ms": 2972.0,
+      "audio_hash_id": "0cb453e4864c2cd5e2e81214e4878b70b771389dce9509bca716ec4f77a959b8"
+    },
+    {
+      "path": "audio/0038.wav",
+      "sha256": "2c61115695dd1746fa1ad81c54df294fcabb1eb53af5612ebdb7e55c474fa613",
+      "transcript": "he continues to work privately as an interrogation and deception expert.",
+      "duration_sec": 4.476063,
+      "speech_end_offset_ms": 4476.1,
+      "audio_hash_id": "0d92c16ecfdf4079b3b6a99589c5a88461cb08a7597ff20d5ccf628197a75f3f"
+    },
+    {
+      "path": "audio/0039.wav",
+      "sha256": "5b65dfd605dc85251794575e89147760cf386d6bc4d407a7a88bff1c4422d4dd",
+      "transcript": "the relationship became tabloid news and his mother did not approve of them together.",
+      "duration_sec": 6.524,
+      "speech_end_offset_ms": 6524.0,
+      "audio_hash_id": "0dc102cc5fc9b919251fd00b886e8a05b5d3587be9e0b31b6cc0e952d3dc070d"
+    },
+    {
+      "path": "audio/0040.wav",
+      "sha256": "d15af63e1eab3e18791e86a4a939dc428b13c1cc13cd54482a9941b700104f1c",
+      "transcript": "it is due for redevelopment in the near future.",
+      "duration_sec": 2.588062,
+      "speech_end_offset_ms": 2588.1,
+      "audio_hash_id": "0e0151ffc199969be96bab4c05d193994db035c4f096fcd7a628aa5ba2cb8f84"
+    },
+    {
+      "path": "audio/0041.wav",
+      "sha256": "5805eac2e97bf98a98d1181fe8fd49a28f9e128d6dbd03176dc893f3ef9436a1",
+      "transcript": "the frenulum can be observed only when a specimen is in hand.",
+      "duration_sec": 3.42,
+      "speech_end_offset_ms": 3420.0,
+      "audio_hash_id": "0e763a1eb9e9c4220a0392a1c5e210647c62e5d07732cee5bfac03c73d7ba13d"
+    },
+    {
+      "path": "audio/0042.wav",
+      "sha256": "6b28af75306f7defd1ccccf0920e33d61f43eb9c4b2cfa3ec3ce6a83f7c42e00",
+      "transcript": "he never fully recovered after his resettlement to siberia.",
+      "duration_sec": 3.1,
+      "speech_end_offset_ms": 3100.0,
+      "audio_hash_id": "0e9ca9f857aac0e251e72f755f8db09d5406c103ff7efb321fd92899a56cc2a6"
+    },
+    {
+      "path": "audio/0043.wav",
+      "sha256": "73f6f1b548882fa4a7a92491cf62b6faab9ebdb3434eed44b91fe4df306dc366",
+      "transcript": "the path connects broadway and binney street in cambridge.",
+      "duration_sec": 4.412,
+      "speech_end_offset_ms": 4412.0,
+      "audio_hash_id": "0ecfe9eb4f793d14cd655460180baee26c0a88c411fab43f7392227d7b713c0e"
+    },
+    {
+      "path": "audio/0044.wav",
+      "sha256": "9b412b1e22d6577733e38d8ce97122838663555a03c8422b1585cbdcf630edb0",
+      "transcript": "if you pay attention to the present, you can improve upon it.",
+      "duration_sec": 3.324,
+      "speech_end_offset_ms": 3324.0,
+      "audio_hash_id": "0ee34e9d8447b3ab6324d165b2e48f5e6508991770a01c86654e69d4ee24aac9"
+    },
+    {
+      "path": "audio/0045.wav",
+      "sha256": "b3970209977c3167a4690d87bc7283a0201ff5fa740ff6963277c262977276f1",
+      "transcript": "imagine if everyone went around transforming lead into gold.",
+      "duration_sec": 3.74,
+      "speech_end_offset_ms": 3740.0,
+      "audio_hash_id": "0f68d67af84d3e70f5d0710f9d47e8d431e4df28a1c5f8791ceb9131326a0d90"
+    },
+    {
+      "path": "audio/0046.wav",
+      "sha256": "75b4835523f99f014e36f5b3a18865cc18be720a87bcebfd77fb1b846af94ac9",
+      "transcript": "a girl riding a pony with braids and pink bows",
+      "duration_sec": 3.804063,
+      "speech_end_offset_ms": 3804.1,
+      "audio_hash_id": "0f8941edf4923773e69d36412fe2c711c1ac9ceb860ec7848ba9d09d06919079"
+    },
+    {
+      "path": "audio/0047.wav",
+      "sha256": "0020b0a339228f1a0d04804a31bb365a1fe7f1cb9e4e9fd7a8d6ab1645a89193",
+      "transcript": "the story deals with the literary world that gissing himself had experienced.",
+      "duration_sec": 4.892,
+      "speech_end_offset_ms": 4892.0,
+      "audio_hash_id": "0fd3e58742fb16b435adcbc14d784da9cf8f6da194e3af6c842cdf1b1237ae16"
+    },
+    {
+      "path": "audio/0048.wav",
+      "sha256": "c7f9d5c191826b67df1848166ed194f22be8664d3802837473f467a8144a286e",
+      "transcript": "visiting a university offers great chances for your career.",
+      "duration_sec": 3.708,
+      "speech_end_offset_ms": 3708.0,
+      "audio_hash_id": "100b4aa18c388d98e953593e4752703b7ffb27ef0dc0436736f8a78b331d7d8d"
+    },
+    {
+      "path": "audio/0049.wav",
+      "sha256": "fb1bc255de34ff0451c4fafa7f1c3c5950b6041b61ca48829d7467bc5e410b4e",
+      "transcript": "the class goes on a bus trip to the local planetarium.",
+      "duration_sec": 3.9,
+      "speech_end_offset_ms": 3900.0,
+      "audio_hash_id": "106ba27136814f23aa9a2ff7276bc83bad0b0e6d530bee9007cd903fe83bd235"
+    },
+    {
+      "path": "audio/0050.wav",
+      "sha256": "b78a9a1c55af1ccd86130b0fc4a10809a00de07e373db9339fd221d99b160854",
+      "transcript": "he gained theatre experience while touring australia.",
+      "duration_sec": 2.684,
+      "speech_end_offset_ms": 2684.0,
+      "audio_hash_id": "10810dc369ab0909d8ccd713e266f5dfa42ccf25ffae586d8bd6fdf94217efac"
+    },
+    {
+      "path": "audio/0051.wav",
+      "sha256": "cff80d04b71551120f8b2f9cbe66333291df1aaf9038e9dabca4c3e8c4f7fd20",
+      "transcript": "this structure is referred to as the pre-primosome.",
+      "duration_sec": 2.908063,
+      "speech_end_offset_ms": 2908.1,
+      "audio_hash_id": "10bfab7ef06f5f0bd78249ab48fec158800c50f76040ac427070cea1607d6e41"
+    },
+    {
+      "path": "audio/0052.wav",
+      "sha256": "2dca638a420999a1e99db33fb2760eb52831d186d0e939702bd7dacb1e99b349",
+      "transcript": "hampton is drained by the hampton and drakes rivers.",
+      "duration_sec": 4.284063,
+      "speech_end_offset_ms": 4284.1,
+      "audio_hash_id": "10d8149f1c9df26f63f4183d1f6bb8303cef091e607f99d44e5f31cec4157617"
+    },
+    {
+      "path": "audio/0053.wav",
+      "sha256": "9369933a3564d1034c29c9080a4a28e0a960203512cb4b4e9e0b622bdc604bc7",
+      "transcript": "everybody inside the house was arrested.",
+      "duration_sec": 2.204063,
+      "speech_end_offset_ms": 2204.1,
+      "audio_hash_id": "10ea840b4d9ef401f96eed69567b11367e23f192032a38120b2aaf2672e3d26d"
+    },
+    {
+      "path": "audio/0054.wav",
+      "sha256": "bff4d753246cc9975962457e7bca1bbc802b4a6ee7f2ebfebfeb1cfb7d6343f2",
+      "transcript": "the farming is mostly livestock although a number of wineries operate in the district.",
+      "duration_sec": 5.052,
+      "speech_end_offset_ms": 5052.0,
+      "audio_hash_id": "10eb76684820b43ad26ad807c3beed7df01ae33eba7dfee4d02cf9930f0448e3"
+    },
+    {
+      "path": "audio/0055.wav",
+      "sha256": "a9ab1611112e29b655ffaeb76365792ba0ced12e2e370460678116623a5a6182",
+      "transcript": "this town was named after the prominent war hero of the time, william bainbridge.",
+      "duration_sec": 4.86,
+      "speech_end_offset_ms": 4860.0,
+      "audio_hash_id": "10f2fe917511ff689883e3356e14cf879b9a0df08a91b4e963b931c606899c62"
+    },
+    {
+      "path": "audio/0056.wav",
+      "sha256": "091a922d56ef3080f4751581cffbef5c4e55580e6c7a3e6e99254f5ff47eb743",
+      "transcript": "love is a fluid concept, and i'm not sure if androids get that.",
+      "duration_sec": 3.868,
+      "speech_end_offset_ms": 3868.0,
+      "audio_hash_id": "10fdd9f203cf53af34f1819f1aa52984f68b1f5b77f7de668aee12b0780cd094"
+    },
+    {
+      "path": "audio/0057.wav",
+      "sha256": "c8d63957cb3c15fc823940ccb23d078a50bdc0e8e89288167c92d89e581348b8",
+      "transcript": "the tag team disbanded after they lost the championships to the dupps.",
+      "duration_sec": 4.188,
+      "speech_end_offset_ms": 4188.0,
+      "audio_hash_id": "110c2e6c5f61e5daf3fec225d75891287edd83999f0cd39524bc3150760df559"
+    },
+    {
+      "path": "audio/0058.wav",
+      "sha256": "87c38d743178cef62c8c4d3b1e0e851f564f732af337aee044716e830f720d3c",
+      "transcript": "it creates a special magazine section each time for the hunt.",
+      "duration_sec": 3.452062,
+      "speech_end_offset_ms": 3452.1,
+      "audio_hash_id": "111b01333117dfb7e2f5934eaf08470fcc08120c65356d3636f98c0520c99326"
+    },
+    {
+      "path": "audio/0059.wav",
+      "sha256": "159ca672c53b9a1c1895aaaa18504840f3af075789eace9337f6af96aeede10d",
+      "transcript": "the crew abandons the submarine with the enigma in their possession.",
+      "duration_sec": 4.732,
+      "speech_end_offset_ms": 4732.0,
+      "audio_hash_id": "111fd89b1f76e370d0973e4ff542dd5bda686f940b816dc489355f316234af83"
+    },
+    {
+      "path": "audio/0060.wav",
+      "sha256": "a6423d8da920599e1fdfd65f48ef41882373ab2aa5d0f432efcfdda1701ffcd3",
+      "transcript": "the monk laughed when he saw me come back in tatters.",
+      "duration_sec": 2.62,
+      "speech_end_offset_ms": 2620.0,
+      "audio_hash_id": "1158b78307f38ccdd14e6d45cffd3d88d57eceee91cfe618cf7519b88353d1c3"
+    },
+    {
+      "path": "audio/0061.wav",
+      "sha256": "184d22cc54632e9fac608eebb9e98ea85b57df1230d095257443f0b148b3f654",
+      "transcript": "the sun thought about that, and decided to shine more brightly.",
+      "duration_sec": 2.812063,
+      "speech_end_offset_ms": 2812.1,
+      "audio_hash_id": "121e8164c39f12069cfb660fe46316224599ec6ca02e763a3fb7c4a864b1c9fb"
+    },
+    {
+      "path": "audio/0062.wav",
+      "sha256": "c76039774a765cce5bbbd4d75602b937fad6b66712568fb0800ccef0ddec3af4",
+      "transcript": "but the boy knew that he was referring to fatima.",
+      "duration_sec": 2.172,
+      "speech_end_offset_ms": 2172.0,
+      "audio_hash_id": "1245a3e78662c275744b54ccc479bfed224cfba608d6b6e27eee0068a21aaa39"
+    },
+    {
+      "path": "audio/0063.wav",
+      "sha256": "6a5274ea5c6d7ff40769eb63140e1cbc4e59b9394c93fc23a0cacdbf5efe0f43",
+      "transcript": "newhouse center for law and justice.",
+      "duration_sec": 3.068062,
+      "speech_end_offset_ms": 3068.1,
+      "audio_hash_id": "1257099967a6f194f557e7ded14130e89685b74bf1f9ce8b76130e6276e7421b"
+    },
+    {
+      "path": "audio/0064.wav",
+      "sha256": "5966e7bd4b5c285b6cd1bc259076085aaff89ac82651620dfae233c0505bdd41",
+      "transcript": "he is best known as the drummer of the rock band daniel amos.",
+      "duration_sec": 4.348063,
+      "speech_end_offset_ms": 4348.1,
+      "audio_hash_id": "1270c33bd4bdebd9ee97fe86c32385f432d0eb492e94ff2b91a0f06ca4167afe"
+    },
+    {
+      "path": "audio/0065.wav",
+      "sha256": "dca4979eaae6affdeeb8675de1ec9af052702c15e17000c63ed859fc7ff568b9",
+      "transcript": "other inspirations include gil evans and john williams.",
+      "duration_sec": 3.196,
+      "speech_end_offset_ms": 3196.0,
+      "audio_hash_id": "12fd2245d2131f0d4d115e3f2176d32ace480307161ebe124a7af4889477bac0"
+    },
+    {
+      "path": "audio/0066.wav",
+      "sha256": "a6d6e4264e8454a1839a7378d10a1cc5634ef340d7e6e8bac684518aa42472bd",
+      "transcript": "kobayashi's reputation as a brilliant literary critic emerged from the war largely intact.",
+      "duration_sec": 5.628063,
+      "speech_end_offset_ms": 5628.1,
+      "audio_hash_id": "136b74fcd31f705281a7c0caeb34e45bbe8540274d193fe55cd9bbe5e3b9272d"
+    },
+    {
+      "path": "audio/0067.wav",
+      "sha256": "85d46a910f6a3768e4988834f5048bdce86212986d52f4343d40139251fca5b0",
+      "transcript": "this specific combination reaction produces the bright flame generated by flares.",
+      "duration_sec": 6.268,
+      "speech_end_offset_ms": 6268.0,
+      "audio_hash_id": "13919935a9e57b4f72ae46572af04692ed69701ed43d492b24a04a8c0e254139"
+    },
+    {
+      "path": "audio/0068.wav",
+      "sha256": "327801a1a9fc8a2e99243cd6621e8255a11cd52540106b845d5aaa907df1e808",
+      "transcript": "his father was an astronomic photographer.",
+      "duration_sec": 2.364063,
+      "speech_end_offset_ms": 2364.1,
+      "audio_hash_id": "13ab8d7380328b668b5a07c288f0ed94be031528dec55235cff47d358f0bed92"
+    },
+    {
+      "path": "audio/0069.wav",
+      "sha256": "856395bba8a3bb3ee8f7f17e44395fe44e68c817df3752defd91ef90e2e1eb7e",
+      "transcript": "however, the losses continued to pile up.",
+      "duration_sec": 2.524,
+      "speech_end_offset_ms": 2524.0,
+      "audio_hash_id": "146f1bc9c8bce8f510807904ce48de47405af0a163561148ab5e84436e5efd6e"
+    },
+    {
+      "path": "audio/0070.wav",
+      "sha256": "9293a2d93e45257775e2f086351e002dc1a498ecacd7c9ffca1f0113831bb036",
+      "transcript": "i was disappointed at this inanimate bulk.",
+      "duration_sec": 2.396063,
+      "speech_end_offset_ms": 2396.1,
+      "audio_hash_id": "150769a2cd9c09495e0e77ff21849e691531eca245c8ddf89eac328d56766514"
+    },
+    {
+      "path": "audio/0071.wav",
+      "sha256": "0ba15fd960ac81e2dbe11b00cd4e7bd447dac86b3c541a8f8bf86dfa3d6c7781",
+      "transcript": "he was the first of four children from the marriage.",
+      "duration_sec": 2.78,
+      "speech_end_offset_ms": 2780.0,
+      "audio_hash_id": "1582245aea8feab6bb23802ca28bba978d572a79ff2d41d61f7f396a2701aa9d"
+    },
+    {
+      "path": "audio/0072.wav",
+      "sha256": "f7122044a4700278d942ced2601507d33ad41ce83694c5fbc3153a3620e7954e",
+      "transcript": "i would give a good review of the new tv i bought a week ago.",
+      "duration_sec": 3.388063,
+      "speech_end_offset_ms": 3388.1,
+      "audio_hash_id": "15d7ea2239f6882c788902585ffca019137b3570386b3c27eb95b84bffd79d2c"
+    },
+    {
+      "path": "audio/0073.wav",
+      "sha256": "84d83852d249c3adae363598f7345c261e88bc820ee76bab0fa0de503f794f96",
+      "transcript": "other authors have done this as well.",
+      "duration_sec": 2.012,
+      "speech_end_offset_ms": 2012.0,
+      "audio_hash_id": "15dfba8cf3e209c81b776fd010ef76f31b7270a197999b5ca626dde7f1ae3785"
+    },
+    {
+      "path": "audio/0074.wav",
+      "sha256": "4e5745654c98582bf6a0d0847fb20afb4a0d10d7c88f6d58d827dcd5d981b1d5",
+      "transcript": "neither thompson nor anderson were full-fledged group members.",
+      "duration_sec": 3.164,
+      "speech_end_offset_ms": 3164.0,
+      "audio_hash_id": "15f361400987510febe2c2a988e32bd7bda8a965746e09a29fffb12e7665cc94"
+    },
+    {
+      "path": "audio/0075.wav",
+      "sha256": "bf4ac0e72505ab43b882216cf82d13c79a5ff7f2ebb105be4f71267d35487a43",
+      "transcript": "it was later adapted for the stage by beth escuda.",
+      "duration_sec": 4.604,
+      "speech_end_offset_ms": 4604.0,
+      "audio_hash_id": "15f48837515cd105b4774be6a3baa12353b146cb4a9dee001a82f907be57ca59"
+    },
+    {
+      "path": "audio/0076.wav",
+      "sha256": "a54823403ec432535ae057ab295065f266b56480debfd63d4d53afbe53f6fb18",
+      "transcript": "the interior of the building did not arrive in its original form.",
+      "duration_sec": 4.508063,
+      "speech_end_offset_ms": 4508.1,
+      "audio_hash_id": "15ff79d3596f860006dfe94bdfa8b7d48955cd8986651814fd8daa3048a91da2"
+    },
+    {
+      "path": "audio/0077.wav",
+      "sha256": "7eac77135e4112cad9205b5e084418ec2f49ea5b90e4213d146b528943106d6f",
+      "transcript": "the track resurfacing was also completed.",
+      "duration_sec": 2.492,
+      "speech_end_offset_ms": 2492.0,
+      "audio_hash_id": "16264f66ef217d957995aab8cf24e95857889f6f267c23b6eb03ed1d02c738ac"
+    },
+    {
+      "path": "audio/0078.wav",
+      "sha256": "5a2ae7cc0080df8463eb167ca70b1cc89cc9d468535f80107eb8ba7d1780a8d7",
+      "transcript": "the climate of the coachella valley is influenced by the surrounding geography.",
+      "duration_sec": 4.38,
+      "speech_end_offset_ms": 4380.0,
+      "audio_hash_id": "163a1bcd0aa1dca309c1e30712603e6e60088868c727104bab2d5a1a37dbcc55"
+    },
+    {
+      "path": "audio/0079.wav",
+      "sha256": "893fa960f6c8ec55fd633db8ca5f94e81364b317cb5d63eb6b501b0921917821",
+      "transcript": "the first teachers were americans.",
+      "duration_sec": 2.108,
+      "speech_end_offset_ms": 2108.0,
+      "audio_hash_id": "164e3708aa38e67909743ac4f89274143f120f21ef62b7d679a1cc2915d3f08c"
+    },
+    {
+      "path": "audio/0080.wav",
+      "sha256": "57162245f72370e5c9c4b43a0d543c7e427e522e03a13fcef38340e7349f1cc5",
+      "transcript": "this compound triggers sperm release by males.",
+      "duration_sec": 3.228,
+      "speech_end_offset_ms": 3228.0,
+      "audio_hash_id": "17a1fe5b521f94ff89409d874dce2e1b1eaae7f0e78a7f3f905f107d01e2b176"
+    },
+    {
+      "path": "audio/0081.wav",
+      "sha256": "3352fe8a36d7681b63ea49dc3e2e33af239163323219c14edb57b764351d3ba4",
+      "transcript": "the computer was going insane, it displayed garbled nonsense and then shut down.",
+      "duration_sec": 4.988,
+      "speech_end_offset_ms": 4988.0,
+      "audio_hash_id": "17cb8db599d2d55f0bf7850a5cd3b667d05f6afedd1cd2d48d94b6094dc46b77"
+    },
+    {
+      "path": "audio/0082.wav",
+      "sha256": "5ab7a560333fa64b4ec0657465d5d3bd90696c53b2b4384b606f8ec194848ef9",
+      "transcript": "the phrase is introduced in the first chapter.",
+      "duration_sec": 2.044,
+      "speech_end_offset_ms": 2044.0,
+      "audio_hash_id": "187d73f0819141fb4f4815a5a81e4b1f29dcb7eec6fa4ed682ef3b80fd67a2e2"
+    },
+    {
+      "path": "audio/0083.wav",
+      "sha256": "49e593ffeb0041042fda3cb647e9e48e13667b9a0313c245f862bd5012c70de6",
+      "transcript": "he is the grandson of american astrophysicist irwin shapiro and psychiatrist leah dickstein.",
+      "duration_sec": 6.588063,
+      "speech_end_offset_ms": 6588.1,
+      "audio_hash_id": "18c2a0e7c94ad5cc8cdef5641761e733238dac8c135c46b7187aa2166069942e"
+    },
+    {
+      "path": "audio/0084.wav",
+      "sha256": "62dfdcd91f529808b65b58e6eba941219971d4756c7d7a675e5c185568a761b8",
+      "transcript": "due to unpublicized reasons, the carrier did not accept deliveries of the type.",
+      "duration_sec": 5.116062,
+      "speech_end_offset_ms": 5116.1,
+      "audio_hash_id": "18c5966ad31df3e6da843db20f4fbcee77f6068b995491a53bf17fde057e684d"
+    },
+    {
+      "path": "audio/0085.wav",
+      "sha256": "4a0889f3d146de32d5973f9053ed6f73d4c735730f3bad6e78901ed1aede0bdb",
+      "transcript": "do you have any idea how long he's likely to be?",
+      "duration_sec": 2.172,
+      "speech_end_offset_ms": 2172.0,
+      "audio_hash_id": "18c76193bdf682109dbf9b4b95e15a4599e582a448bec5192645659be918378f"
+    },
+    {
+      "path": "audio/0086.wav",
+      "sha256": "5fadc243b4fca618e8c86023cd13158b1b6887ba8df1f8023281ed1c75ff71ea",
+      "transcript": "north goa konkani is different from the south goa konkani.",
+      "duration_sec": 4.284,
+      "speech_end_offset_ms": 4284.0,
+      "audio_hash_id": "1920c21cf118fd9729a27db0b04eef1aa61ca0e3cccd80c12dd768ff0e3285e9"
+    },
+    {
+      "path": "audio/0087.wav",
+      "sha256": "ea1a6528646d3368bd949c0a9a4495fb699002bee6ca64fc4c24571043ec4ed0",
+      "transcript": "the constituency included glasgow city centre.",
+      "duration_sec": 3.292,
+      "speech_end_offset_ms": 3292.0,
+      "audio_hash_id": "1941ed60452a7ceb482ed768547ffa5a3c4c7fe936d5e1c35643022573504c64"
+    },
+    {
+      "path": "audio/0088.wav",
+      "sha256": "eccc2829d6dc20ef8175351ce589ce2d8be927b8924995879e4fa463a86793ea",
+      "transcript": "when the table presents both red and green color, the states are not convertible.",
+      "duration_sec": 4.156,
+      "speech_end_offset_ms": 4156.0,
+      "audio_hash_id": "19841c71e906b8a7753d5390da6541a06aca5a6e562cbe76d28807b5ecbdceab"
+    },
+    {
+      "path": "audio/0089.wav",
+      "sha256": "ef4a8ad32c9a5ab128bb3e272c5fef4e31929cbe1bb518473d42bc0847af30c4",
+      "transcript": "the group is known for the improvisational and often unscripted performances they give.",
+      "duration_sec": 6.268063,
+      "speech_end_offset_ms": 6268.1,
+      "audio_hash_id": "19b88d3a46385d0530ca075b9400b86de015be2387acbd84a73215a70ba96b19"
+    },
+    {
+      "path": "audio/0090.wav",
+      "sha256": "289046f6c27327e0c70d2be7fa1696afeea7c81c301d13e3e3c0e55acd027fec",
+      "transcript": "the asteroid's name comes from the latin name for munich.",
+      "duration_sec": 3.26,
+      "speech_end_offset_ms": 3260.0,
+      "audio_hash_id": "19fd3b120500cbb6325c146a926d1bed7a22246156ef79705bc8fcec76f7d9a3"
+    },
+    {
+      "path": "audio/0091.wav",
+      "sha256": "6085b4e7b108eafe728df19f15e9ff4bb077d39d206e296b8c2e8beecd452f6f",
+      "transcript": "henderson stood up with a spade in his hand.",
+      "duration_sec": 2.14,
+      "speech_end_offset_ms": 2140.0,
+      "audio_hash_id": "1a7d6c4fc5c5c69a6fa9d2cf8f3fae41518d6d3862310a4e5fa403fb5698f00f"
+    },
+    {
+      "path": "audio/0092.wav",
+      "sha256": "e0e64614a7213eb901ecc64b588f4696963369c88b3d8d1de770395d4ed46f0b",
+      "transcript": "she danced almost exclusively to classical music.",
+      "duration_sec": 3.482063,
+      "speech_end_offset_ms": 3482.1,
+      "audio_hash_id": "1a834969ca0795f9916afdf1c4266405f4da36b8679fb929f1eeef2380040df6"
+    },
+    {
+      "path": "audio/0093.wav",
+      "sha256": "ee8222be588953f40c309852b27d6383f5ab4a50e48fe4923d866a091932a4cb",
+      "transcript": "palm oil is cheap, but workers on illegal plantations get exploited and huge areas of jungle get destroyed for its production.",
+      "duration_sec": 7.548063,
+      "speech_end_offset_ms": 7548.1,
+      "audio_hash_id": "1acf4cab156689bd0a7ddc05abafcb47012ea609c3b8d7fb95443472dd40bed7"
+    },
+    {
+      "path": "audio/0094.wav",
+      "sha256": "4f5bf3eb18cb07c8f33b29700baf9eb8c3e62dd90c1d608afaec022dc55bb285",
+      "transcript": "this looser definition almost equates to that of the nordic countries.",
+      "duration_sec": 4.06,
+      "speech_end_offset_ms": 4060.0,
+      "audio_hash_id": "1b2d29cb344c7da938131aaf49afc721c3b56b43d9f54768bfa72b26a3e601a8"
+    },
+    {
+      "path": "audio/0095.wav",
+      "sha256": "0ac9f6c374739797d94c1473b628e0da9480d593c4b6b3e37f88723994c3557d",
+      "transcript": "romanus was son of constantine.",
+      "duration_sec": 2.268063,
+      "speech_end_offset_ms": 2268.1,
+      "audio_hash_id": "1b3eee29a29a161d494025a34808bc34264c90ed614bed076d3451c02936399c"
+    },
+    {
+      "path": "audio/0096.wav",
+      "sha256": "68094969ee3d9cfad43c727c00223fe9a3742408f3f064052456349c3d8ab363",
+      "transcript": "it was largely these funds which made the building of the bixby library possible.",
+      "duration_sec": 4.092,
+      "speech_end_offset_ms": 4092.0,
+      "audio_hash_id": "1bacdc41a7b5d4383414915034d68e88727e29658d86153813213a3275fcdf7c"
+    },
+    {
+      "path": "audio/0097.wav",
+      "sha256": "912df988ba47f918d0eace1fdb1cc821457429f000217b8a7c54eb5232bad3bc",
+      "transcript": "how he wanted it to be when he looked back on it.",
+      "duration_sec": 2.684,
+      "speech_end_offset_ms": 2684.0,
+      "audio_hash_id": "1c078d4980ecfd4663823bda4e02eccf83d05d0438a7113deb1f453db6952381"
+    },
+    {
+      "path": "audio/0098.wav",
+      "sha256": "80954d6a8d20238a182a44f702fbb6dfff9fffb787c9ada50ef91e88e83bad0d",
+      "transcript": "he made the bench on three more occasions before the end of the season.",
+      "duration_sec": 4.828062,
+      "speech_end_offset_ms": 4828.1,
+      "audio_hash_id": "1c718b8790e8626ee3aba50beecd49d6ca0de2211a1a32d6587130e4416bc316"
+    },
+    {
+      "path": "audio/0099.wav",
+      "sha256": "7bc32bfa6ce2fd13313dc3b91008a031ff0e755d7ebcd6cf844ae6d7fe66d165",
+      "transcript": "garden houses were replaced with crowded residential blocks.",
+      "duration_sec": 3.132,
+      "speech_end_offset_ms": 3132.0,
+      "audio_hash_id": "1cae525e94cf91ceea980d6e96d566bd1b7796ff2151b4cfc0e5a7bda6093c05"
+    },
+    {
+      "path": "audio/0100.wav",
+      "sha256": "95267a3d13590563e123f8e140a6b54b9c1cfe1651105a788902845fb15a9ab8",
+      "transcript": "the turf and gravel around it seemed charred as if by a sudden explosion.",
+      "duration_sec": 4.092,
+      "speech_end_offset_ms": 4092.0,
+      "audio_hash_id": "1ce5e66d864845763546e1c9d4fb88e55a794cf5b2e374d051cad1fcb1f8ae14"
+    },
+    {
+      "path": "audio/0101.wav",
+      "sha256": "a96eb686fce60052b6007b3379113094e9dd1551e4942b1917de247e154a5e05",
+      "transcript": "these rivers are used for irrigation purpose.",
+      "duration_sec": 3.132,
+      "speech_end_offset_ms": 3132.0,
+      "audio_hash_id": "1d0abec9e1800fb7cb0fcf7786b1b771abac669338a8bce8eca7caed0fa55755"
+    },
+    {
+      "path": "audio/0102.wav",
+      "sha256": "a8924a5b480d67bce6a47d82734b111b2051c1758d4071c584c9cbbabd328ee6",
+      "transcript": "with this, unkindness and infertility are associated with a thin person.",
+      "duration_sec": 4.828062,
+      "speech_end_offset_ms": 4828.1,
+      "audio_hash_id": "1d2b3d1e7a5647b64f40652b29c98bfc0f9444fb704199a6c16591182b089340"
+    },
+    {
+      "path": "audio/0103.wav",
+      "sha256": "fa466a92b834aef14cdac6c96594bc99eceee765ed89ae36b268aa153aa0bd8b",
+      "transcript": "the sons are graduates of walton high school in marietta, georgia.",
+      "duration_sec": 3.932,
+      "speech_end_offset_ms": 3932.0,
+      "audio_hash_id": "1d4345052428ea8567fa7cc5ad5cb5a8b130a8232a71372f2a450de59c915ca8"
+    },
+    {
+      "path": "audio/0104.wav",
+      "sha256": "32d65e9c5723720f6836da61c89de25d345a5ada7f0a079b49c398d9e91e58e9",
+      "transcript": "he transformed himself into a stone that rolled up to the miner's foot.",
+      "duration_sec": 3.494063,
+      "speech_end_offset_ms": 3494.1,
+      "audio_hash_id": "1dad94cdcb64eed581f15e1ccbc891ba61dd6306a5feea33c93e0349e1ae2d8a"
+    },
+    {
+      "path": "audio/0105.wav",
+      "sha256": "071238a9a2fd72e076d6fb724673d87831dd96dd25cc572ec2c3f9fcc5cf86eb",
+      "transcript": "texhoma high school is housed in a pair of monolithic dome structures.",
+      "duration_sec": 4.892,
+      "speech_end_offset_ms": 4892.0,
+      "audio_hash_id": "1e82abcccd2d763245da49b644b991b88f489f3e7369c4ec43872d75b509a425"
+    },
+    {
+      "path": "audio/0106.wav",
+      "sha256": "c53781349ae19efac130004c24fbcdb721c278087f06c35b609993098581abf8",
+      "transcript": "yes, ada thought she had better go with me.",
+      "duration_sec": 2.94,
+      "speech_end_offset_ms": 2940.0,
+      "audio_hash_id": "1e9301e5e240d528349d35f4ea80300917b9504ae23e0377fe24265d9b1b05f2"
+    },
+    {
+      "path": "audio/0107.wav",
+      "sha256": "d64e0a946e099f324943c7b00851e8fdd7238958837642f15cd677659588b7ff",
+      "transcript": "the book begins and ends in the vicinity of torrington.",
+      "duration_sec": 3.388063,
+      "speech_end_offset_ms": 3388.1,
+      "audio_hash_id": "1e97f59412b5404716243e213417f636516fb27b52c736e67ba28d87e00829ab"
+    },
+    {
+      "path": "audio/0108.wav",
+      "sha256": "1193574b097efd43e3044ec41c08f84015ed007a3aba915fee4631095a283174",
+      "transcript": "the affair caused a controversy and prompted an investigated by a special prosecutor.",
+      "duration_sec": 5.308,
+      "speech_end_offset_ms": 5308.0,
+      "audio_hash_id": "1ec7f14ea0e8bf4712fc27ba3153e847b7ec4de5f5e8fdd8d11e0297fd85b71a"
+    },
+    {
+      "path": "audio/0109.wav",
+      "sha256": "c6487cf4db01e3f38f9f6a05ae82027b363c7739e56237a72b4d405984c71cdd",
+      "transcript": "like most rotis in south asian cuisine, it is baked on a \"tava\".",
+      "duration_sec": 3.548062,
+      "speech_end_offset_ms": 3548.1,
+      "audio_hash_id": "1f1e2e2aa72ec687b0467a9d8ed1f8cc3690cfd6f73c44957a3ef266e82e4fc8"
+    },
+    {
+      "path": "audio/0110.wav",
+      "sha256": "389c16426856859882fc93c5502c4da851f4a1e9c6626d1002ed6146beb13232",
+      "transcript": "they looked for the fallen mass, but found nothing.",
+      "duration_sec": 2.876063,
+      "speech_end_offset_ms": 2876.1,
+      "audio_hash_id": "1f21d719fd97a727d2853fd9d47bf136df5439561bb8e133833075bacbbebb27"
+    },
+    {
+      "path": "audio/0111.wav",
+      "sha256": "d6463c1c33dc58a12efa67f6671d68d06536f8cddf4ef43264822efc4b9c14dc",
+      "transcript": "as a result, it was rancid and had a foul odor.",
+      "duration_sec": 3.164,
+      "speech_end_offset_ms": 3164.0,
+      "audio_hash_id": "1f254be98868e25f4b46ab5579170d4fff2bbca9fefae9be367f0dfdcf799bef"
+    },
+    {
+      "path": "audio/0112.wav",
+      "sha256": "b17d9e1b4198d11e4a53e10dec03bac5bbd085b7a04af8b67fc9a90ce4a1c0eb",
+      "transcript": "the shop folks were taking down their shutters, and people were opening their bedroom windows.",
+      "duration_sec": 4.412063,
+      "speech_end_offset_ms": 4412.1,
+      "audio_hash_id": "1f98d393dd78a4f684a8a609ff9e61b2790985304d2317128edcd1e3776211b7"
+    },
+    {
+      "path": "audio/0113.wav",
+      "sha256": "8c463262f3c35fd82623803233f832f082a5c7e6380eb747a2340ecf36abaf96",
+      "transcript": "eyes, voices, and accessories such as clothing or weapons can be added.",
+      "duration_sec": 5.116062,
+      "speech_end_offset_ms": 5116.1,
+      "audio_hash_id": "1ffaef96563a7846278ce1a7ea9f4354de26d67979e3405a12f2daab38da3e55"
+    },
+    {
+      "path": "audio/0114.wav",
+      "sha256": "aaa8076e181c9b57af93b1f9030355385ae725d6c7e049f86631758c05776bdc",
+      "transcript": "the options were basically two.",
+      "duration_sec": 2.524062,
+      "speech_end_offset_ms": 2524.1,
+      "audio_hash_id": "20178f32cabb7285da3d772c5fc5f79f141acc99a7a2a0fe72e08b75e30a34fb"
+    },
+    {
+      "path": "audio/0115.wav",
+      "sha256": "99d1c2373d370171bc04be28921191bada20ef657ca4efa821e5bba9a48cb400",
+      "transcript": "you can't trust anybody in this crazy world.",
+      "duration_sec": 2.172,
+      "speech_end_offset_ms": 2172.0,
+      "audio_hash_id": "204ed4cb6419a4490b203caa5224018289401053a8cf7cc0b5a74124e8431b2c"
+    },
+    {
+      "path": "audio/0116.wav",
+      "sha256": "497257b6415415514f03bd0cc77e4e38d2d0f7bd53c095b238c9fcff8bebd6c6",
+      "transcript": "disembodied existence in sheol is unreal.",
+      "duration_sec": 2.684,
+      "speech_end_offset_ms": 2684.0,
+      "audio_hash_id": "2072f22a6be3bcc282ff36cf8813020200ec4c891add45bcb56a632356484685"
+    },
+    {
+      "path": "audio/0117.wav",
+      "sha256": "a8b8199e7c76029a197532d1cd31e5e9adfa8db1e26ed0f8f524340c5f1bad6e",
+      "transcript": "she has one child from a previous marriage.",
+      "duration_sec": 2.46,
+      "speech_end_offset_ms": 2460.0,
+      "audio_hash_id": "20a64262d0349702aabbb2e13958d54ccc46dc6e1195fa46bd7a489b1faa3e2a"
+    },
+    {
+      "path": "audio/0118.wav",
+      "sha256": "101eb2c914935b432eb3bb7cc8993c6dbe2e8e592302f379acfbf0210b2580b7",
+      "transcript": "tarpaulins are pulled over the holds and the crew leave.",
+      "duration_sec": 3.708063,
+      "speech_end_offset_ms": 3708.1,
+      "audio_hash_id": "2128ab238d7e794eae2da2d6ebc7cc4fccf8a3a8de22ed87901fc72e528143a8"
+    },
+    {
+      "path": "audio/0119.wav",
+      "sha256": "77f086de5cce0e61b80c69bc595592b456153605d453eb9b8736b6b725b8e8c0",
+      "transcript": "hermansen is professor and director of islamic world studies at loyola university chicago.",
+      "duration_sec": 6.012,
+      "speech_end_offset_ms": 6012.0,
+      "audio_hash_id": "21f0f829f2d218fdc8b5a518cc39c4074f9d3850c7e23e93a4bc83fa56111cb7"
+    },
+    {
+      "path": "audio/0120.wav",
+      "sha256": "f4c887f4f2af6e07e4abf9dcddcb5d41aca66fa85f0be19d5402b6e0b11aa26c",
+      "transcript": "the mainline trail is blazed with blue rectangles.",
+      "duration_sec": 2.812,
+      "speech_end_offset_ms": 2812.0,
+      "audio_hash_id": "21fa237fadea9b2948f1a32efe54f59e41a6dbe04026d512c018b22b24aae458"
+    },
+    {
+      "path": "audio/0121.wav",
+      "sha256": "2f37a3b6f6e5a6156e5f3287f8a3493d318f22a07430bdc86f04d57f94baafbc",
+      "transcript": "this was then the most prestigious post available for an astronomer in germany.",
+      "duration_sec": 4.796062,
+      "speech_end_offset_ms": 4796.1,
+      "audio_hash_id": "232fd715eee1c46efd0cb304126939faa19ebaf2b471e3e80006d25cbc70ccb8"
+    },
+    {
+      "path": "audio/0122.wav",
+      "sha256": "23b9dff0d263810200548d6aa848d9286560616a8ad23840b5a9f610f522f26d",
+      "transcript": "the film featured several of warhol superstars from his studio the factory.",
+      "duration_sec": 7.132,
+      "speech_end_offset_ms": 7132.0,
+      "audio_hash_id": "244fdd09c2738e6ea4ab4666b2b59cabef143a405d03a4f6776d19f6fb585000"
+    },
+    {
+      "path": "audio/0123.wav",
+      "sha256": "3a55b088129f2058bb528f5aedd87647c1c73d531cfee0499562b5201493d5c3",
+      "transcript": "bonnie loves clyde and vice versa.",
+      "duration_sec": 3.004,
+      "speech_end_offset_ms": 3004.0,
+      "audio_hash_id": "2500537c6b726ffd46b5693d889d8615b436882f50bf4cabe4ea43d98bdd62f6"
+    },
+    {
+      "path": "audio/0124.wav",
+      "sha256": "e076a0138c7b9941250a103227d4c8f2ad9305ba13964be2703af8b137a5e74d",
+      "transcript": "the wall was eventually treated to prevent strong echoes.",
+      "duration_sec": 4.188,
+      "speech_end_offset_ms": 4188.0,
+      "audio_hash_id": "25058b17ab2a53d5a6449b475bdaec3590193e0dce4b912b108bc4f157b8db17"
+    },
+    {
+      "path": "audio/0125.wav",
+      "sha256": "6775d3fa3d16743f04366d532e3cf00e5bec2cc56837baa7852b1d08c0671fd4",
+      "transcript": "very little of the \"narwhal\"s design was based on the submarine.",
+      "duration_sec": 3.452,
+      "speech_end_offset_ms": 3452.0,
+      "audio_hash_id": "25348acb45bcd2999353a92c80e92230ab412f61bd4a560198ba0748b14e9e92"
+    },
+    {
+      "path": "audio/0126.wav",
+      "sha256": "80a0a4dfaca421c3e063d5e98947ae503ce95e3e2c79b8e4e8dc5aedbdf1ab81",
+      "transcript": "the solution to the puzzle has never been made public.",
+      "duration_sec": 3.036,
+      "speech_end_offset_ms": 3036.0,
+      "audio_hash_id": "25466f4aa1688e83a121cc1c0c9dd14ebe65ac837d9d326c08f961698d7bfe87"
+    },
+    {
+      "path": "audio/0127.wav",
+      "sha256": "974111250aa7535fb98a09b46a804d1a94569fad9abf2149bad5841830469fd2",
+      "transcript": "it is usually noted on microscopic examination of a blood smear.",
+      "duration_sec": 4.028,
+      "speech_end_offset_ms": 4028.0,
+      "audio_hash_id": "25561cbcad8ea53591d895278ed9904e23d1a656124ddabaf221ba82796fc304"
+    },
+    {
+      "path": "audio/0128.wav",
+      "sha256": "306425459b5e4597bd14fc225cbd183694e2bc0627744b770da9db77ca293da6",
+      "transcript": "exact details of this operation were never released by the russian government.",
+      "duration_sec": 4.188063,
+      "speech_end_offset_ms": 4188.1,
+      "audio_hash_id": "2570ddb5271703776bd0bbdb2d3ea08fafea296ddc06c1dabb86bc52496dc3fc"
+    },
+    {
+      "path": "audio/0129.wav",
+      "sha256": "e60af40b292f36e5235aaa6e27503fed69a8781a40a89ec096b331274f92a200",
+      "transcript": "you'll watch them as they grow, demonstrating how the world is always changing.",
+      "duration_sec": 3.996,
+      "speech_end_offset_ms": 3996.0,
+      "audio_hash_id": "25e4da1956ee9b3bc208786248cc183275dc0b50943420d18b41dde762f743c5"
+    },
+    {
+      "path": "audio/0130.wav",
+      "sha256": "2de8a2adaa63783e688f1dfe58e8548d037411d5b6d148297da5cca8245b7a6c",
+      "transcript": "the concept of universal default is criticized for many reasons.",
+      "duration_sec": 3.58,
+      "speech_end_offset_ms": 3580.0,
+      "audio_hash_id": "2615e2b26e0067d85aed890b94b2edce16abeb54b792f03844266f3df75ba55c"
+    },
+    {
+      "path": "audio/0131.wav",
+      "sha256": "89ce4c0f0e712fd19aa1d973409e9709773e0c1e1ed90a6fb1409b5b3cadb203",
+      "transcript": "the lower lobe of the corolla is up to long with wings about wide.",
+      "duration_sec": 5.148062,
+      "speech_end_offset_ms": 5148.1,
+      "audio_hash_id": "264d0910b86946c76f878db5a4e5d7c860a70cd24936b0ad2765db1c9e958ed2"
+    },
+    {
+      "path": "audio/0132.wav",
+      "sha256": "da796cb62028af51dad76866367bb86252d1b4b20ecbc9899a435664be2df202",
+      "transcript": "asa's long reign was more successful.",
+      "duration_sec": 2.396,
+      "speech_end_offset_ms": 2396.0,
+      "audio_hash_id": "265e2f849aa2ff0ae2192707949715e7e1e36aa5b9f8c30430d20980aefe6abc"
+    },
+    {
+      "path": "audio/0133.wav",
+      "sha256": "3dad4ec1bb1610473a652cb3409a984698b0a49a355abf00254005224450e4c3",
+      "transcript": "this is the most popular time at camp ware.",
+      "duration_sec": 3.42,
+      "speech_end_offset_ms": 3420.0,
+      "audio_hash_id": "2674bb65eabdc263d2ce77abd9ec91027a46496d67809ab6251d418aa41793b6"
+    },
+    {
+      "path": "audio/0134.wav",
+      "sha256": "1c929b616277fc8585992644d49ccc7116639d07999ae173939a8da3d6190ac1",
+      "transcript": "his victoria cross is held in a private collection in melbourne.",
+      "duration_sec": 3.612,
+      "speech_end_offset_ms": 3612.0,
+      "audio_hash_id": "26ab99251902b404bb3d80fc7f08aa62e470ff15400a94599f96e9bd52e4ebb0"
+    },
+    {
+      "path": "audio/0135.wav",
+      "sha256": "b4b1bb477ba93972cb1a39de3690a7084c54dca106e3a4b57feb681baaf68604",
+      "transcript": "unstable stratification is when each layer is denser than the one below it.",
+      "duration_sec": 5.692,
+      "speech_end_offset_ms": 5692.0,
+      "audio_hash_id": "26ebdc0763847b334e4db7ec52767eb52c02eee24008b15ed2dcddaa6092e4b6"
+    },
+    {
+      "path": "audio/0136.wav",
+      "sha256": "7eab98e6aefe19ea277ad33ecad89df0b26cd8ec6a80e9083981f8daf95a74a9",
+      "transcript": "the liner notes feature an exclusive interview with some members of the band.",
+      "duration_sec": 3.772,
+      "speech_end_offset_ms": 3772.0,
+      "audio_hash_id": "27310a8025cf53f305c382cde1aad6302715519cf0c954ab8c4fb5f73ee8e26b"
+    },
+    {
+      "path": "audio/0137.wav",
+      "sha256": "002a3cd817696c0d6cc9e54d0d0b238526eff32c60a696d5f2c2fba57b1f64d3",
+      "transcript": "the compiler was constructed by torgil ekman and leif robertson.",
+      "duration_sec": 5.244063,
+      "speech_end_offset_ms": 5244.1,
+      "audio_hash_id": "273c079d517013b8ff5aef61b02b8ce7f94a6cdf40ce9240f5d02b2508f8d936"
+    },
+    {
+      "path": "audio/0138.wav",
+      "sha256": "1e1613fd04b9c44515b4009e52a8fbf0dbf76e3b65545891e1ab0d6f171de952",
+      "transcript": "these unmarked prisoner transports were targeted as enemy ships by allied submarines and aircraft.",
+      "duration_sec": 4.988062,
+      "speech_end_offset_ms": 4988.1,
+      "audio_hash_id": "276d780c611f8b75494397a299408d072cda37fca91b2743d1244f377b07fee3"
+    },
+    {
+      "path": "audio/0139.wav",
+      "sha256": "84befd90b7f4273e23575b62e1e4992a5a050c67c95040824ab2cd5cbab2d350",
+      "transcript": "he ran his fingers slowly over the stones, sensing their temperature and feeling their surfaces.",
+      "duration_sec": 5.398062,
+      "speech_end_offset_ms": 5398.1,
+      "audio_hash_id": "2783fb13480e2ece85ce61e4ac6abae27090ac44cddee7d50685cab31c0d40d3"
+    },
+    {
+      "path": "audio/0140.wav",
+      "sha256": "ad291730569f237606899030be8ce8df683ad3498521496576f7dde076168b84",
+      "transcript": "when were these books written? the boy asked.",
+      "duration_sec": 2.396063,
+      "speech_end_offset_ms": 2396.1,
+      "audio_hash_id": "27891509fa07070a476e846f0dbe143b09257eb16e9e956a8b2723c93d605fea"
+    },
+    {
+      "path": "audio/0141.wav",
+      "sha256": "5711873bed134de5a26265b3b860bf380e3abba723931b8472d77d59ce6e52b9",
+      "transcript": "the land includes a natural spring whose water local tradition holds has healing powers.",
+      "duration_sec": 4.892,
+      "speech_end_offset_ms": 4892.0,
+      "audio_hash_id": "27edeb191c546ac8deb326cd68af813e24aa1583b50202ef68dac17b83463a2c"
+    },
+    {
+      "path": "audio/0142.wav",
+      "sha256": "adcc55801c954481f3e2b64012ff52475c6fbbc336f8ddc70c67a2f6f70299b5",
+      "transcript": "it was the site of several historic events during the american revolutionary war.",
+      "duration_sec": 4.22,
+      "speech_end_offset_ms": 4220.0,
+      "audio_hash_id": "2ab9e5765377997ba186eaaafc9bfada66b6bdc77a62043b25d83ebc8f5adcdf"
+    },
+    {
+      "path": "audio/0143.wav",
+      "sha256": "a7a1aed59082a1aa1d23b79a3f19455f9a6c673ae1ee95c9cea0748a96f9a5db",
+      "transcript": "the subject would be noah and the flood, based on the chester text.",
+      "duration_sec": 3.868063,
+      "speech_end_offset_ms": 3868.1,
+      "audio_hash_id": "2b0e5f95867fa6e7367d422ada90a15d81d95598c33f0ab5961ba9f908552d74"
+    },
+    {
+      "path": "audio/0144.wav",
+      "sha256": "c1ecdc52cebdd375a953fec9168fe81aa31b831e82f03521e31141dcb9e6f306",
+      "transcript": "it's called the principle of favorability.",
+      "duration_sec": 2.492062,
+      "speech_end_offset_ms": 2492.1,
+      "audio_hash_id": "2cbbc5d2e8edbd5f7a861faddbddf8f5b4c74414bc4c2510da2e01ce57be49e4"
+    },
+    {
+      "path": "audio/0145.wav",
+      "sha256": "4fd6fe193aca56553e73cd45262aa96f27dd5f2e2c2e07ac32d1f7ea62d699a9",
+      "transcript": "at the former, magical rites were performed both for malevolent and benevolent ends.",
+      "duration_sec": 6.46,
+      "speech_end_offset_ms": 6460.0,
+      "audio_hash_id": "2cc0f319567df6a59a45968cc28a51f359167269eaccfd82ea074b488579a854"
+    },
+    {
+      "path": "audio/0146.wav",
+      "sha256": "522ac6c3cc3f61a309cb2be9db1015b62673839646b81c33575fe91a4da15303",
+      "transcript": "departures from norms connected to religion can have other labels, such as sin.",
+      "duration_sec": 6.044062,
+      "speech_end_offset_ms": 6044.1,
+      "audio_hash_id": "2ccb23733c106dfff21fa9f1bfa1eb22adf86560dbc9280cff23d2fa90d96526"
+    },
+    {
+      "path": "audio/0147.wav",
+      "sha256": "2a42aaeb5e4c76b57f11f59583c4c7ddda81dc24558c2c848f17360915dccfae",
+      "transcript": "for military details see murid war.",
+      "duration_sec": 2.204,
+      "speech_end_offset_ms": 2204.0,
+      "audio_hash_id": "2d183c4c1c137bcba773ce6e2323d8ad71169ee4dfdc2e88cbe86a87d67ac149"
+    },
+    {
+      "path": "audio/0148.wav",
+      "sha256": "301afb4b368627c84727ecc3be6eba7657757875904e6c95a794d55588dd5697",
+      "transcript": "it has extensive largely untouched beaches and provides nursery areas for snappers.",
+      "duration_sec": 6.684062,
+      "speech_end_offset_ms": 6684.1,
+      "audio_hash_id": "2d7384a084c208004a9974f9548ac624b0de1f31be91459752966fc872b6c893"
+    },
+    {
+      "path": "audio/0149.wav",
+      "sha256": "2a16ad2555d6e45e273774f35fe92749a4f5cf9f4914d6ec48e5a61e748513a2",
+      "transcript": "swinburne was a prominent engineer in the electrical industry.",
+      "duration_sec": 3.58,
+      "speech_end_offset_ms": 3580.0,
+      "audio_hash_id": "2da215d3083862daf57f6a9abd7c888c3d45fc51fb40790a2c48bf8a5c6da6a3"
+    },
+    {
+      "path": "audio/0150.wav",
+      "sha256": "dca607e487e60abc1d548bf8ce48614738b939c4512c4295bf70c38c3640162f",
+      "transcript": "after hearing the gospel from paul, onesimus converted to christianity.",
+      "duration_sec": 5.404,
+      "speech_end_offset_ms": 5404.0,
+      "audio_hash_id": "2da659a95b972ca70782f16898ee9978a463fc5f4ec677951aa936e7ddab9362"
+    },
+    {
+      "path": "audio/0151.wav",
+      "sha256": "16aae276062a69725cb505f5ad9e83c60f43c12c1699aa041a1eaa6d3d3978ec",
+      "transcript": "it refers to many questions about the meaning of life.",
+      "duration_sec": 3.164062,
+      "speech_end_offset_ms": 3164.1,
+      "audio_hash_id": "2daf5c8dd4a2a8900bf17d52727b67b2b0dd7e573f473482d00234a43fe8409f"
+    },
+    {
+      "path": "audio/0152.wav",
+      "sha256": "0d85e4240d4c43b2889f7180e3dcb03c6006ea9ab5c0fffe68622196fd7c813b",
+      "transcript": "he asked it, please, never to stop speaking to him.",
+      "duration_sec": 3.356063,
+      "speech_end_offset_ms": 3356.1,
+      "audio_hash_id": "2ddb71320ee05c64bf5ee2fa0dd40fa188b6760c48e59092c9ab3fe3b430d301"
+    },
+    {
+      "path": "audio/0153.wav",
+      "sha256": "3bbfaf20a6b468f64e333438d6a6df6de89264ef835547a5ae78c517fee5d061",
+      "transcript": "he acquires them and sells them to an american collector.",
+      "duration_sec": 2.62,
+      "speech_end_offset_ms": 2620.0,
+      "audio_hash_id": "2e7f094db8a18b3302533067985f6a34a22ab88b943e023cb47c1319c9541c3b"
+    },
+    {
+      "path": "audio/0154.wav",
+      "sha256": "fd21e151c1d834531d59e4c2ff97301c00e342e95783751b5376a73111f48c21",
+      "transcript": "it matters not if he reads these words or those.",
+      "duration_sec": 3.196063,
+      "speech_end_offset_ms": 3196.1,
+      "audio_hash_id": "2e86f57bc94dd4e7ab060830a8b62ba80f8c4e6d2d563393585b805ecc090715"
+    },
+    {
+      "path": "audio/0155.wav",
+      "sha256": "9b0cf54af1f30ce282a4b4c8bd5e6836ff20d72a97a10fde550db586e78ccdec",
+      "transcript": "failure of ceramic plates by cracking must also be controlled.",
+      "duration_sec": 3.996062,
+      "speech_end_offset_ms": 3996.1,
+      "audio_hash_id": "2ecb073db73d5bdb4d9d0c5885c3d033c09bf43b66a361363d5565b81d5a73ea"
+    },
+    {
+      "path": "audio/0156.wav",
+      "sha256": "bdf79237306c83cae58c6218d14be0bd80102e15a1b4d5ad4b72c77160828343",
+      "transcript": "let's not tempt him with the quarter pounder.",
+      "duration_sec": 3.132,
+      "speech_end_offset_ms": 3132.0,
+      "audio_hash_id": "2ed94830d164b755337bab00d2cca973d1435a41ebfcb52ac3e5574d915eead7"
+    },
+    {
+      "path": "audio/0157.wav",
+      "sha256": "fc3f3480a54d3410616263851e7a832a91e74e66ba65d80012bc8d02becab874",
+      "transcript": "nevertheless, he achieved an expressive intensity which was his own.",
+      "duration_sec": 3.868063,
+      "speech_end_offset_ms": 3868.1,
+      "audio_hash_id": "2eeef5c622266233317e7ffeea618a3f3765079cfb1b1d3ea3b00548c6d74d37"
+    },
+    {
+      "path": "audio/0158.wav",
+      "sha256": "cf59678d1703e4006782cd56db237b8091a083bb7041a33d5f2165c4f27027b1",
+      "transcript": "the mixed color fraction is the least valuable.",
+      "duration_sec": 3.534063,
+      "speech_end_offset_ms": 3534.1,
+      "audio_hash_id": "2f1b0b8f765c0d99ae3fa5e1118b247eb49ba5b113380a4c3886c76cd069780a"
+    },
+    {
+      "path": "audio/0159.wav",
+      "sha256": "aaf0f9e5b338f0a5938730e4bbc5b204fcd2776c3d29818345ab41255a4ced3b",
+      "transcript": "the naskapis live in northern quebec.",
+      "duration_sec": 3.26,
+      "speech_end_offset_ms": 3260.0,
+      "audio_hash_id": "2f4135725a0b26c1a6a758565195bb69cf6fea4c724951268ad3cd7a6583cdad"
+    },
+    {
+      "path": "audio/0160.wav",
+      "sha256": "9bb8651b9dd40282e6a875714276706791d7b33f269835f4a3afd03695bcd94a",
+      "transcript": "madan saddle on smith island, south shetland islands is named after madan.",
+      "duration_sec": 5.404063,
+      "speech_end_offset_ms": 5404.1,
+      "audio_hash_id": "2f9780bd712925098bc29ff3de8c4e25d1d841a86409d3dd75615482393e62ce"
+    },
+    {
+      "path": "audio/0161.wav",
+      "sha256": "90cf0d9217a11292788b5be95f7a0673f3c5464347070bacde51d10d31c85de1",
+      "transcript": "the two spend their last year living life to the fullest.",
+      "duration_sec": 3.868063,
+      "speech_end_offset_ms": 3868.1,
+      "audio_hash_id": "2ff2ef02ec679d2ba9a28c9a73eb5984e8961bf87b89ea31835732918aa0213b"
+    },
+    {
+      "path": "audio/0162.wav",
+      "sha256": "6050ebe594ed36acc9639d32e3c5eea0fa6cc555f0239ba78b9eac310388f2e6",
+      "transcript": "other project participants included boeing, computer sciences corporation, and booz allen hamilton.",
+      "duration_sec": 5.788062,
+      "speech_end_offset_ms": 5788.1,
+      "audio_hash_id": "2ff70571de81abdc86b9f91c80a9cf52a21e5d03efaebc0502ad471f592f9ac8"
+    },
+    {
+      "path": "audio/0163.wav",
+      "sha256": "927e6b11fae1b9ec48b88533f5238db6958a6c8ff5b1f417434c5ab11fb34bf5",
+      "transcript": "his mother showed interest in jehovah's witnesses and gradually the children also became interested.",
+      "duration_sec": 4.828062,
+      "speech_end_offset_ms": 4828.1,
+      "audio_hash_id": "302729f2f12b3f08817c7ec811906968df336d3439200322c3295c58e44e33e3"
+    },
+    {
+      "path": "audio/0164.wav",
+      "sha256": "59c3cd5a0207c1511585f81a4edb4eff662d76e6a13aaf71b223d26f1b857e7a",
+      "transcript": "innuendo received mixed reviews.",
+      "duration_sec": 2.716063,
+      "speech_end_offset_ms": 2716.1,
+      "audio_hash_id": "3044d6cc8676d35b91aec4684bc35174c12c64356676e815c631a2d6a339d788"
+    },
+    {
+      "path": "audio/0165.wav",
+      "sha256": "318ad03fc18141826a13f605e9bfc71797967d7ffe54ec05b54d4816ea71f209",
+      "transcript": "they were always just somebody to fill up the bleachers.",
+      "duration_sec": 2.46,
+      "speech_end_offset_ms": 2460.0,
+      "audio_hash_id": "306a30e6dfac787efdc9ca5f5a44005f1a668f2211f614ee2f12ff5d6125e537"
+    },
+    {
+      "path": "audio/0166.wav",
+      "sha256": "e298aeca149ab945a4a352e51f19883d55ae9956a2cb42485146283ffbfa99bb",
+      "transcript": "lancaster was the home of the first governor of wisconsin, nelson dewey.",
+      "duration_sec": 4.092,
+      "speech_end_offset_ms": 4092.0,
+      "audio_hash_id": "3075702351ee303fc8ac7cfdfb7361753f04dd63417de4fed857d503ceb800e4"
+    },
+    {
+      "path": "audio/0167.wav",
+      "sha256": "382528e70f6a23788a31b4fde7fe4e0e203c8c90d60835e5a3a275f34097bcf5",
+      "transcript": "the rush for funds reached its peak tuesday.",
+      "duration_sec": 2.62,
+      "speech_end_offset_ms": 2620.0,
+      "audio_hash_id": "316de8deb01d60c44217d47513fd41e451c2ced4453aad269859f47847e6223b"
+    },
+    {
+      "path": "audio/0168.wav",
+      "sha256": "c3025e4cf11ee144cfec2eb7c44c79de0a0c4bd2bdeb97d5fef03139b7ac0c74",
+      "transcript": "there is some variation in the use of the term in england.",
+      "duration_sec": 3.964,
+      "speech_end_offset_ms": 3964.0,
+      "audio_hash_id": "319c7419ce207333a4d13cb1638fe61c7cafdcc04d7c746878cc48869e5fad5c"
+    },
+    {
+      "path": "audio/0169.wav",
+      "sha256": "b199f72a42ec7f0c10b1be3f79a08536add7077f07898b4f2407e5d01f5e8284",
+      "transcript": "he remained a regular lecturer at the hospital for decades after.",
+      "duration_sec": 4.188063,
+      "speech_end_offset_ms": 4188.1,
+      "audio_hash_id": "31e5e97ab4c9ffc1d687168e33eded426b5d14844aae6d94f6602a586c8d81de"
+    },
+    {
+      "path": "audio/0170.wav",
+      "sha256": "5a3063dafff162e5c70768d588115bfb3de6a53d998301ff98a3a4a1aa24139c",
+      "transcript": "its neighbors are the boroughs of kingston, wyoming, and swoyersville.",
+      "duration_sec": 6.172,
+      "speech_end_offset_ms": 6172.0,
+      "audio_hash_id": "3202efcfbba6ce27bd5df2babc38edcf06fcc2afbfcfe6c5022780b2318ac3c8"
+    },
+    {
+      "path": "audio/0171.wav",
+      "sha256": "0717d618527de9b91ad5bf32c8f1f4c2e2fe767565f020bc80982366adb1b452",
+      "transcript": "the family name was pronounced as \"duggan\".",
+      "duration_sec": 2.524062,
+      "speech_end_offset_ms": 2524.1,
+      "audio_hash_id": "32413b9fab1f7ac5b3bd625843a70e0aca400a68186a7abdcf8b9578a8455b15"
+    },
+    {
+      "path": "audio/0172.wav",
+      "sha256": "b5d836cbd879693eb4ea634e544e4f96714c73b53c895d247503edbf3ee88880",
+      "transcript": "he said, professional football is something like war.",
+      "duration_sec": 2.588062,
+      "speech_end_offset_ms": 2588.1,
+      "audio_hash_id": "33c8edcbd097c86cd22b5e9c0b7cd7c2397e0f034753293dd7594c1bd3af48a4"
+    },
+    {
+      "path": "audio/0173.wav",
+      "sha256": "07e968c854ec1e0b6b4cb3caa7521c15b6f63e2315ac1dd9e24b4cececbafe93",
+      "transcript": "spitzer was married three times, divorced his first two marriages.",
+      "duration_sec": 4.988,
+      "speech_end_offset_ms": 4988.0,
+      "audio_hash_id": "33d341cf487214c44db8e3669b65dcdccee855e19e872ef949d5848539cb8779"
+    },
+    {
+      "path": "audio/0174.wav",
+      "sha256": "45dd8424dbecc8dec5b81468616c9a6374f120895ca30d77d09d781147d7941c",
+      "transcript": "however, the settlers west of the mississippi river complained strongly about the arrangement.",
+      "duration_sec": 7.1,
+      "speech_end_offset_ms": 7100.0,
+      "audio_hash_id": "34afa23c827ff2a42136781082888c01446b56989ffa6f2bd3f789b1652c3035"
+    },
+    {
+      "path": "audio/0175.wav",
+      "sha256": "857fabe7585f5c7c3d6f120e4fb02f2f30585051512c682ac985d87244efd44f",
+      "transcript": "deo favente had only ten letters.",
+      "duration_sec": 3.74,
+      "speech_end_offset_ms": 3740.0,
+      "audio_hash_id": "34e25869075c06679903c35de22539ebff76f2b49fdeacb48b2957081efc7de1"
+    },
+    {
+      "path": "audio/0176.wav",
+      "sha256": "0466903c1191883c3e37bd49cfca7514970231d8fce6fda2cbbb8d733d4096e5",
+      "transcript": "badger, muskrat, beaver, coyote, and pronghorn are commonly observed.",
+      "duration_sec": 3.932,
+      "speech_end_offset_ms": 3932.0,
+      "audio_hash_id": "35334f0393c7e2a5ca1f868c374f8f85b6b4947e98a16dcfde1828b84181e990"
+    },
+    {
+      "path": "audio/0177.wav",
+      "sha256": "5a88654b2cea80441125851d3ac53ff5e8b95f58f84327acb5d236fdc0071ddb",
+      "transcript": "this fishery catches mainly antarctic toothfish, a close relative to the patagonian toothfish.",
+      "duration_sec": 6.46,
+      "speech_end_offset_ms": 6460.0,
+      "audio_hash_id": "36666960efa46b5a84b06bde4f3a892dd424ceeab7c8426122a722dbb254239e"
+    },
+    {
+      "path": "audio/0178.wav",
+      "sha256": "aba382b3c23af8d9192deac3ded5e069471c49a320ad84385ce506c4dba64b95",
+      "transcript": "it must have fallen while i was sitting over there.",
+      "duration_sec": 2.108062,
+      "speech_end_offset_ms": 2108.1,
+      "audio_hash_id": "36a90ee63419274e347795c245c24606b26c643fe75275f5338d1448545201be"
+    },
+    {
+      "path": "audio/0179.wav",
+      "sha256": "4715a3314ff4826427d8ad1be961353758418b303d829855f2f7902f3bf9ee79",
+      "transcript": "he has been an advocate of american values in foreign policy.",
+      "duration_sec": 3.388063,
+      "speech_end_offset_ms": 3388.1,
+      "audio_hash_id": "36fb2ca2f6e1c100af3163b90b9a909d90ddbb7fdf64c8cf87d52610e85c1fc1"
+    },
+    {
+      "path": "audio/0180.wav",
+      "sha256": "a6f7ea3250f31072ff3fd759651821716e67d67b135078cf6be556d9f9b9e029",
+      "transcript": "a tradition in the family also associates it with the staufen dynasty.",
+      "duration_sec": 4.828,
+      "speech_end_offset_ms": 4828.0,
+      "audio_hash_id": "3751c2a0fb65e285c3ff70e70a64333f29cdaab056ff4457597624d83f9355b0"
+    },
+    {
+      "path": "audio/0181.wav",
+      "sha256": "c4eeeb94e82c208078dad8887834efd23b98d99e342dbdc1c2757b758a6075f1",
+      "transcript": "she began teaching speech and drama, but had always wanted to act.",
+      "duration_sec": 4.06,
+      "speech_end_offset_ms": 4060.0,
+      "audio_hash_id": "3757873b12be1a68362f87c9ee1dacd89724cd807ea1ccc6dae34d970f9276d7"
+    },
+    {
+      "path": "audio/0182.wav",
+      "sha256": "5e89f69398d90af7121f7eaad105b124494fe240d032e5cf5803a40296b79354",
+      "transcript": "modern democracy builds on such participation of the people and media.",
+      "duration_sec": 3.964,
+      "speech_end_offset_ms": 3964.0,
+      "audio_hash_id": "37a93a0acc60622ace06d3c927bce0765a5889c4da9b0c490342ca38a4cfaa39"
+    },
+    {
+      "path": "audio/0183.wav",
+      "sha256": "5c0dd8733df2327bdd40e6449b6915264817d96df7d5167f9df26ce478f13586",
+      "transcript": "the film received negative reviews from film critics.",
+      "duration_sec": 3.068062,
+      "speech_end_offset_ms": 3068.1,
+      "audio_hash_id": "37b099b7dfb01b1f7edd1ab96ea3a5a744147e2fdb60447d0506df286a5d7e06"
+    },
+    {
+      "path": "audio/0184.wav",
+      "sha256": "4f4cdcd4a84b5f9640fcb413d0b23280edfda09e9d02d687e740ddcc85f5a8ad",
+      "transcript": "tourism is an important economic factor for italy.",
+      "duration_sec": 3.612,
+      "speech_end_offset_ms": 3612.0,
+      "audio_hash_id": "37f4ed4671df4e682954bc1410580d8627577dc13e030de3fdb9b45d37e1bc85"
+    },
+    {
+      "path": "audio/0185.wav",
+      "sha256": "bfdc07698c58dc6552313918ef674021f8d20fb13e6ae69b3aed5527111c4ca6",
+      "transcript": "and when i am for myself, what am 'i'?",
+      "duration_sec": 3.42,
+      "speech_end_offset_ms": 3420.0,
+      "audio_hash_id": "3801661d24a3e066d6bfb20c791cafde9a77e4e7262e71ca04f81f74dd545f1e"
+    },
+    {
+      "path": "audio/0186.wav",
+      "sha256": "65c24ca5011c303de4791139b171467151a88be57b6f6f1cbe216e33b223f3bf",
+      "transcript": "the book features lethal violence and gore, while the comic strip does not.",
+      "duration_sec": 3.708063,
+      "speech_end_offset_ms": 3708.1,
+      "audio_hash_id": "3840b32eb917428ee27291c20ae5f917a9f07d44cbb67edc3b29ffc44262e7fe"
+    },
+    {
+      "path": "audio/0187.wav",
+      "sha256": "01688b749f6f9d79bf52bd5aa317dbfe3f1a49829f6657f1695d2329036d01c4",
+      "transcript": "in the army, she felt she was among free women for the first time.",
+      "duration_sec": 4.796,
+      "speech_end_offset_ms": 4796.0,
+      "audio_hash_id": "3847cbe2483b7b0f30c6e63042c5fa18f5f994373cb558efbd93dd14dea60f1d"
+    },
+    {
+      "path": "audio/0188.wav",
+      "sha256": "da3b4c986862523949799ed022ce4be31f17fa2fbc53a14dc5a957b32c1d0592",
+      "transcript": "it is part of the ozark micropolitan statistical area.",
+      "duration_sec": 3.42,
+      "speech_end_offset_ms": 3420.0,
+      "audio_hash_id": "38956579b0811df31a4cdff24a9d7af5fba3fdd9917953c5f6aaf1f0e9a75e63"
+    },
+    {
+      "path": "audio/0189.wav",
+      "sha256": "c389dfe036b74b144f050e9c4a68f412ce2567da8a44b0aeb4aeebe807806e4f",
+      "transcript": "they proposed that the southern half would allow slavery.",
+      "duration_sec": 3.004,
+      "speech_end_offset_ms": 3004.0,
+      "audio_hash_id": "389a47cf62d2f965ffd8b41e3ef6e4af67331a07879c3ab61b015a5cd7880ee6"
+    },
+    {
+      "path": "audio/0190.wav",
+      "sha256": "89f2044fe8420f61156803a71c766bc9ce7c691309d64ecefcf9cc9a0fbd3727",
+      "transcript": "you will need to know to build your own custom environment.",
+      "duration_sec": 2.556,
+      "speech_end_offset_ms": 2556.0,
+      "audio_hash_id": "394fa02ece3ad4c18b6baf2c4a413ba272ec3903eaeb3ac8005f01a2f3d1290f"
+    },
+    {
+      "path": "audio/0191.wav",
+      "sha256": "b40874f749acaa18f3f88bef05cea3c9ed26feae0e8a1cf585cbef9b57950246",
+      "transcript": "the boy recalled the brilliance he had noticed on the previous day.",
+      "duration_sec": 2.814062,
+      "speech_end_offset_ms": 2814.1,
+      "audio_hash_id": "39eac367753186a2fb389b49dfba32454476dd0c4c66b7d1ee5f4cc5804ef760"
+    },
+    {
+      "path": "audio/0192.wav",
+      "sha256": "faa8594dabe346af41743461987e3dbe98a69a33af88e392cc330a35878e1bc2",
+      "transcript": "the blueprints for the new airport and container port had already been drawn.",
+      "duration_sec": 4.156062,
+      "speech_end_offset_ms": 4156.1,
+      "audio_hash_id": "3a3b1c8b35511a42fc6d5194df0aa17268f9a989bf948a63d5c541001edbc141"
+    },
+    {
+      "path": "audio/0193.wav",
+      "sha256": "1b60fb817f6d78c0bc8a35dc1955558603f7caf11dc7b501244907cefeef1f5a",
+      "transcript": "it is funded through a mixture of national grant and council tax.",
+      "duration_sec": 3.708063,
+      "speech_end_offset_ms": 3708.1,
+      "audio_hash_id": "3a771e4db65977bf29df048899ed40ad1944ea8214cbbf1318e09f0979cfb82d"
+    },
+    {
+      "path": "audio/0194.wav",
+      "sha256": "28c6c9e2030bb2218dc9a8ee5ed9ae0af969e10c4b84552e687705585f41d7fd",
+      "transcript": "the first president was arthur minden.",
+      "duration_sec": 2.172,
+      "speech_end_offset_ms": 2172.0,
+      "audio_hash_id": "3b5c36daef09542b691680f4caa026fd51da9d47d36c4ef73cabd6151ba470a3"
+    },
+    {
+      "path": "audio/0195.wav",
+      "sha256": "09b7140c90d511028c1f25dc545e7803039dba69c60a98ced478e38249d65d08",
+      "transcript": "it was developed by computer's dream and published by ubisoft.",
+      "duration_sec": 3.804,
+      "speech_end_offset_ms": 3804.0,
+      "audio_hash_id": "3b99d53ed4be769e1bc1482c273060af5eed7fa1c74ade4949735f1eba2f3e75"
+    },
+    {
+      "path": "audio/0196.wav",
+      "sha256": "1fdc2f89f41f210ae033879e25d0e4d7dca16940741977928e8af77985fe1198",
+      "transcript": "mechanical ventilation is indicated when the patient's spontaneous ventilation is inadequate to maintain life.",
+      "duration_sec": 6.204063,
+      "speech_end_offset_ms": 6204.1,
+      "audio_hash_id": "3bd9d88edaad0f93afeeba5ee2ebcf60ded303e1c747b802022830e57c4c011d"
+    },
+    {
+      "path": "audio/0197.wav",
+      "sha256": "4384b6872f83ed21cca9ec940694a75eb9cb396758793fc33d6255efee080284",
+      "transcript": "the play garnered both critical and public acclaim.",
+      "duration_sec": 3.58,
+      "speech_end_offset_ms": 3580.0,
+      "audio_hash_id": "3c7f003e464b974a68b89a4e68532cf510c0f344801195242d4fa96a56fd1965"
+    },
+    {
+      "path": "audio/0198.wav",
+      "sha256": "6b7f51a49e1ef44738a14aa2a6646dafd6e92211ad331eaa874759cdb0c0d0b5",
+      "transcript": "the crew abandons the submarine with the enigma in their possession.",
+      "duration_sec": 4.732,
+      "speech_end_offset_ms": 4732.0,
+      "audio_hash_id": "3c915ebc151c63a1ff0cbbca3a5efc193c35864e7022aa87debf31269c23eb38"
+    },
+    {
+      "path": "audio/0199.wav",
+      "sha256": "5a4aedd57547d6016f73f94c8587c6fbddf1a837b61982d8cb679724e1be475f",
+      "transcript": "many of the company's stores were in shopping malls.",
+      "duration_sec": 2.876063,
+      "speech_end_offset_ms": 2876.1,
+      "audio_hash_id": "3ce2fbd7c22ccd4627e3679ef858c20585c7c52bf5eb5bcaba133cdd847538f8"
+    },
+    {
+      "path": "audio/0200.wav",
+      "sha256": "f92c6a241301b5882acfab25107ddc384378a834c54f29e1daaa27c4bccc6b90",
+      "transcript": "when its commander lorenzo de olazo was wounded, the spaniards retreated.",
+      "duration_sec": 4.124062,
+      "speech_end_offset_ms": 4124.1,
+      "audio_hash_id": "3dfe047ba7d1fe7fcc0d3b3eb1f1788a9989ec9fd2a1e588014d088ab9a7d3fb"
+    },
+    {
+      "path": "audio/0201.wav",
+      "sha256": "5eb7fdeccf01b28bebbe2c1a8afe622886507288461ad9df69be5010cb8e2b0f",
+      "transcript": "but then i realized she couldn't have been.",
+      "duration_sec": 2.332,
+      "speech_end_offset_ms": 2332.0,
+      "audio_hash_id": "3dff11cc0ccfc9b9b6ff344af554067164777d6e41ade0cfd8ecdb0bbf5affbc"
+    },
+    {
+      "path": "audio/0202.wav",
+      "sha256": "ebeeef1ea1ab9a8baf9ff1fd57fe4dd7e8b1fcb5d6549744adbe1357a01c58cb",
+      "transcript": "he found an armed man, who, it appears later, was gowrie's servant, henderson.",
+      "duration_sec": 6.428063,
+      "speech_end_offset_ms": 6428.1,
+      "audio_hash_id": "3e5894f35e3fcedc341c9ce3e33659ecb744173ee32e2480fe6f294b385dc230"
+    },
+    {
+      "path": "audio/0203.wav",
+      "sha256": "0d4154dd1169fa60dcb7472654012f6b7227029ed91f3706eeb1b824322c1d56",
+      "transcript": "no fixed radio transmitters are allowed within the area closest to the telescope.",
+      "duration_sec": 4.188063,
+      "speech_end_offset_ms": 4188.1,
+      "audio_hash_id": "3e6093a1ca8c95c4a413277b573c0292ed6d19d7de2780e7e39d36b9dfc2f829"
+    },
+    {
+      "path": "audio/0204.wav",
+      "sha256": "e4fec63720ab02938cd6ae34ff087351d4a10294ee5f1e13b4aeea11e648ea5e",
+      "transcript": "i know why i want to get back to my flock, he thought.",
+      "duration_sec": 2.524062,
+      "speech_end_offset_ms": 2524.1,
+      "audio_hash_id": "3e6db41db2402a60e18a6553f997e7bba80d06788dd09aa3fea8cfd3cbaf956c"
+    },
+    {
+      "path": "audio/0205.wav",
+      "sha256": "b0af9fab7931a91ea5f6b4cbffc8ad1fd19386809b79cafa855d4f6284a3a3e0",
+      "transcript": "they rule narnia for many years, bringing peace and prosperity to the land.",
+      "duration_sec": 4.796,
+      "speech_end_offset_ms": 4796.0,
+      "audio_hash_id": "3eb703f65b15680f86f49654421886ad134a49621fec7692f1cc23d338cbf8e2"
+    },
+    {
+      "path": "audio/0206.wav",
+      "sha256": "dcec83022a218c9c82515ce824ce3c297b3a5a41846e86a408dbf92cc8f88e3e",
+      "transcript": "the final remaining residents left when the buildings were deemed unsafe.",
+      "duration_sec": 5.276063,
+      "speech_end_offset_ms": 5276.1,
+      "audio_hash_id": "3f103dec5c2a22c83089c2b792bf815618445cb14392bd95f6f12d5bc68720c7"
+    },
+    {
+      "path": "audio/0207.wav",
+      "sha256": "5e05a8ee20f786b4b2142df498cdc790e7b9d7aba79beeea54f430f46d4c81e9",
+      "transcript": "he started learning the violin at age six and very soon showed promise.",
+      "duration_sec": 3.804,
+      "speech_end_offset_ms": 3804.0,
+      "audio_hash_id": "3f152d9d7e23d466587206e5884fb736ec8e5c3787efa1fb89c9181c6ac09426"
+    },
+    {
+      "path": "audio/0208.wav",
+      "sha256": "b7505c34a5356ade36832eeffbcf01256ff9268611b23147687e7d164220143c",
+      "transcript": "a man in a white tshirt cleaning up debris.",
+      "duration_sec": 3.548062,
+      "speech_end_offset_ms": 3548.1,
+      "audio_hash_id": "3f94d0f0ac29efcdc697a99fa843b0b918fd133194f2c2486eca650bc428dfd8"
+    },
+    {
+      "path": "audio/0209.wav",
+      "sha256": "c92c5ecd8084e834212ee964f362cf9085b884bb2559b27314b68f69a1faa3ca",
+      "transcript": "gallo is a historic minority language spoken in eastern brittany.",
+      "duration_sec": 4.188063,
+      "speech_end_offset_ms": 4188.1,
+      "audio_hash_id": "3f9ccf36ee85cf4a2c9076a529ed81923e71ecc05dc36d0610a79650d9c41d57"
+    },
+    {
+      "path": "audio/0210.wav",
+      "sha256": "4d877f889e824c0223aafbfc056938b1a7d1b12d99a95f7de9328bd2f1d0f0b3",
+      "transcript": "as soon as he saw me among the crowd, he called to me to come down.",
+      "duration_sec": 3.374062,
+      "speech_end_offset_ms": 3374.1,
+      "audio_hash_id": "403ae36151471effe7f2fd7d6a82ece7ac421bfeb34eec1fc03553c827caa747"
+    },
+    {
+      "path": "audio/0211.wav",
+      "sha256": "7c37c28cccba2ee1d803bfdadb9da988c70bbf2697a90e123eb067fbf9dc73e3",
+      "transcript": "most meteorites are more or less rounded.",
+      "duration_sec": 2.172,
+      "speech_end_offset_ms": 2172.0,
+      "audio_hash_id": "409bb9b62641ec89dcea8168887577687ca0d6a4a5e5a8154ba49b69d655d483"
+    },
+    {
+      "path": "audio/0212.wav",
+      "sha256": "714de0c7e203390646e23b9b4d27a5e0f2968abbb466cc39658664e98a9aa4d2",
+      "transcript": "like most latin american leagues, it crowns two separate champions in each season.",
+      "duration_sec": 3.996062,
+      "speech_end_offset_ms": 3996.1,
+      "audio_hash_id": "40a210b5576f04d453bd30557893b0a6e3bf6e6925d43aa454d3b0d11641b727"
+    },
+    {
+      "path": "audio/0213.wav",
+      "sha256": "932862bfd8307651a3abea7a687a409d749105b845a898f18eed94738ce11e84",
+      "transcript": "during this time he acquired his writing skills.",
+      "duration_sec": 2.62,
+      "speech_end_offset_ms": 2620.0,
+      "audio_hash_id": "423758d9a9bc5bdeacd5430f61d0efd4e55922ecd07997841651abeb29f293c5"
+    },
+    {
+      "path": "audio/0214.wav",
+      "sha256": "e2e836568cbf51df18099f9929c276e39216703883531faaaa868aed5c6e6a8b",
+      "transcript": "his artistic training was thorough and influential.",
+      "duration_sec": 2.748063,
+      "speech_end_offset_ms": 2748.1,
+      "audio_hash_id": "42f1814c3996b8d045ecaa75f7d4a3ec03bf88eea39b2bcde2cb6c59d0942adf"
+    },
+    {
+      "path": "audio/0215.wav",
+      "sha256": "3c772c36cbb622289f1805a766feb35d0bf4faf03d93f60e94f7a057cfbc8679",
+      "transcript": "he was also an instructor for paul gilbert's great guitar escape.",
+      "duration_sec": 4.54,
+      "speech_end_offset_ms": 4540.0,
+      "audio_hash_id": "431cc065fe3e74cc90e41c99d09d36e15f2d714d52bb52b4de509c32c41c83d6"
+    },
+    {
+      "path": "audio/0216.wav",
+      "sha256": "a11ca29d3b9297c6707a6ece3f6a6e963dc5832d86a974acd62cf8910ec0d2eb",
+      "transcript": "Mathewson, who's this bookkeeper? Rogers?",
+      "duration_sec": 2.652062,
+      "speech_end_offset_ms": 2652.1,
+      "audio_hash_id": "433ecd402a364807b1e6acb6f44e34addbb62b1c2f25b5ac9d3e102943174fd0"
+    },
+    {
+      "path": "audio/0217.wav",
+      "sha256": "47471c32e865101ef9f957e3881f41427100efbf94216b8006e8e8a6e74aaff7",
+      "transcript": "each team could only score a short field goal in the second half.",
+      "duration_sec": 3.612,
+      "speech_end_offset_ms": 3612.0,
+      "audio_hash_id": "4427ccf4349200de904ea5553cb30dfa720a1d2a17b1afb5ee034c82fb7a80f9"
+    },
+    {
+      "path": "audio/0218.wav",
+      "sha256": "a0ffd3643a687fe0b9c9b5c8da768d3172b0b4f3d997609507c1e88dd502b830",
+      "transcript": "it left a greenish streak that glowed for some seconds.",
+      "duration_sec": 2.750062,
+      "speech_end_offset_ms": 2750.1,
+      "audio_hash_id": "446c6f254b09c1e65f4c0d797700b0b92dc12a73ba545bce1971dcefd10641bc"
+    },
+    {
+      "path": "audio/0219.wav",
+      "sha256": "8b851512dda788e81756cf0f8892609f4cc86cfb2e8f9406baafe50fd3cc9a6f",
+      "transcript": "music for some basic records were composed by him.",
+      "duration_sec": 3.036062,
+      "speech_end_offset_ms": 3036.1,
+      "audio_hash_id": "44b02848312250fbe975328b2b6ef8da4164e23d4d10ccfc900c90fc41e200dd"
+    },
+    {
+      "path": "audio/0220.wav",
+      "sha256": "c924221118d12dca0bad102e2cb4eb33171293a0774eed9be8e79c408dc53f6a",
+      "transcript": "this convention was known as the national union convention.",
+      "duration_sec": 3.612,
+      "speech_end_offset_ms": 3612.0,
+      "audio_hash_id": "44b0437b1786dc9d7423f3215697864ad157dc273d1c97f6dfdc3a30ad7ce20b"
+    },
+    {
+      "path": "audio/0221.wav",
+      "sha256": "d013611a465aa5e46ad2529a4ca7e3d3e284e78e5ac4fd1349fe72ea010aba81",
+      "transcript": "he was schooled at radley college in oxfordshire.",
+      "duration_sec": 3.1,
+      "speech_end_offset_ms": 3100.0,
+      "audio_hash_id": "4528886ee809ec4635680dc104dfd21c651064e562c68eb2aa3819c3a5455c0c"
+    },
+    {
+      "path": "audio/0222.wav",
+      "sha256": "8aeff1dcf7ca402f3288a5c1f1a7e4de46a7409eb7ba8a33207809b422b51bd0",
+      "transcript": "their goal is to protect the natural, recreational, cultural, and historical resources.",
+      "duration_sec": 5.116062,
+      "speech_end_offset_ms": 5116.1,
+      "audio_hash_id": "45d522dfbef8fb541193aa5f148cad86609fa5cf46a880ef70978ba93ce74b9d"
+    },
+    {
+      "path": "audio/0223.wav",
+      "sha256": "5bfe75320064aa889c7e283188fd5ac836980745733f329d991e23edf233299d",
+      "transcript": "computational irreducibility explains observed limitations of existing mainstream science.",
+      "duration_sec": 7.612,
+      "speech_end_offset_ms": 7612.0,
+      "audio_hash_id": "4617d7852d3973c19663d478f6ec927f98bd2f6005e6bdf745300c8cac6842c8"
+    },
+    {
+      "path": "audio/0224.wav",
+      "sha256": "77a02ec674e3e2027ddee7d27fabece3e9d959a7baf3e5a5344484733bae9d66",
+      "transcript": "he also published the work of sir arthur grimble.",
+      "duration_sec": 3.388063,
+      "speech_end_offset_ms": 3388.1,
+      "audio_hash_id": "46444ebfeab26fd9787ae3b64813321f18f6be7c0addf084880e9a1e955bdcd4"
+    },
+    {
+      "path": "audio/0225.wav",
+      "sha256": "eb13cfd2dc176d1182720b92f73b982f2a9dbb7ae38d4e8f0162f7e944fc0969",
+      "transcript": "a key issue in the election was controlling spiralling inflation.",
+      "duration_sec": 5.308063,
+      "speech_end_offset_ms": 5308.1,
+      "audio_hash_id": "46b250ad6d585aa7ec0c94b15abc101723e69450b3e8fd06231bfcfdf9120f41"
+    },
+    {
+      "path": "audio/0226.wav",
+      "sha256": "5cf6b9db264db3f8ff09cdbca1f97e1bd6ca6ba2ec0ef34d13a9b2e8b2aea70d",
+      "transcript": "the ten stamens are joined in the lower part and hairy above.",
+      "duration_sec": 3.836063,
+      "speech_end_offset_ms": 3836.1,
+      "audio_hash_id": "46f0fc570adafd0f4633ed8caac6a79efbc0f4601e13fefb58ba3ab4e6d30659"
+    },
+    {
+      "path": "audio/0227.wav",
+      "sha256": "7499e19880f16b4b8d035054edcd732b1d08ff9ea837db8b2cb21ff29e3b2669",
+      "transcript": "the complex included offices, factories, a power plant and a foundry.",
+      "duration_sec": 5.212,
+      "speech_end_offset_ms": 5212.0,
+      "audio_hash_id": "4704597ca2c58620556d05965b751d6e5fe826a4dc4d508a6691bf7d13f0f81a"
+    },
+    {
+      "path": "audio/0228.wav",
+      "sha256": "01fde285d08e3f5cbdd95501dc90156a9b3987abc639da1d421875d7861cf698",
+      "transcript": "he is an avid sailor and cartoonist.",
+      "duration_sec": 2.14,
+      "speech_end_offset_ms": 2140.0,
+      "audio_hash_id": "4792a262d33e001bc0391e264f2220f3bc43fba485f04223a83653e4bae7e92a"
+    },
+    {
+      "path": "audio/0229.wav",
+      "sha256": "dd824e5c32cd1e818d0e083db876f974e0a4b6ab9114d35ace4cf688c18dad52",
+      "transcript": "he had not a cent in his pocket, but he had faith.",
+      "duration_sec": 2.94,
+      "speech_end_offset_ms": 2940.0,
+      "audio_hash_id": "47fc29c57db1f6d6f7e6d5ae8435d38479e29d668ee6c1be4fd285ab9bd22a4e"
+    },
+    {
+      "path": "audio/0230.wav",
+      "sha256": "42356702f4716d10540c57385c38e89bf0db94a62756269613941535c1d496f4",
+      "transcript": "the film was the idea of actor ted hamilton, who became executive producer.",
+      "duration_sec": 4.38,
+      "speech_end_offset_ms": 4380.0,
+      "audio_hash_id": "4854352fb7143969eecc4e76d6f90f7946218e9b0057d6fe7083486e35511e86"
+    },
+    {
+      "path": "audio/0231.wav",
+      "sha256": "3ca5be309918e0bf6499d423a180785898a19ffc38ef787d491058c882408e8f",
+      "transcript": "he graduated from allentown catholic high.",
+      "duration_sec": 2.716,
+      "speech_end_offset_ms": 2716.0,
+      "audio_hash_id": "4861401ff0d77be70f07e23bee864e6c9a9cb58152ead168f3b3ad7f6629e01e"
+    },
+    {
+      "path": "audio/0232.wav",
+      "sha256": "5043e6ff29382fbe7fda353f7c3d2b8e4b2bae9dbd3df90d59bbee153d9a5b45",
+      "transcript": "seven issues were released, including a christmas and a summer special.",
+      "duration_sec": 3.868063,
+      "speech_end_offset_ms": 3868.1,
+      "audio_hash_id": "486440a5ab1bd6053e948eb43853ef035f2c456604133a5f988eefa7e7a0a153"
+    },
+    {
+      "path": "audio/0233.wav",
+      "sha256": "76ad79371a55dd1e0d1fa0c2b7bbd22089f646891971b5f3350158271faa6618",
+      "transcript": "students perception of instructors has great importance and possible consequences.",
+      "duration_sec": 6.684,
+      "speech_end_offset_ms": 6684.0,
+      "audio_hash_id": "49dc2be1a8939799a2b47962974449ea31b5e6bd6f5a35e4060b6c1fbedf02c2"
+    },
+    {
+      "path": "audio/0234.wav",
+      "sha256": "0a2963fede15254fa835edd72767f1fae2929aa48a1c4a3e75ad10e2c1a3141a",
+      "transcript": "henderson was born in edinburgh, the son of a railway porter.",
+      "duration_sec": 4.412,
+      "speech_end_offset_ms": 4412.0,
+      "audio_hash_id": "49e8fd626a42a9a2ba6dffaafcbf966a8517cd1e003c0c13768eb2749153d8dd"
+    },
+    {
+      "path": "audio/0235.wav",
+      "sha256": "3eed37f40a059e3c46fcc8a103557f7f224374452d691e72fda2c1d3afa482ff",
+      "transcript": "as i watched, the planet seemed to grow larger and smaller.",
+      "duration_sec": 2.812,
+      "speech_end_offset_ms": 2812.0,
+      "audio_hash_id": "49f04ee3be0008b25086f119494f7dce408767fe42fa4bfff5bdb9aa6657f695"
+    },
+    {
+      "path": "audio/0236.wav",
+      "sha256": "1ba04c914645de59abc043cc3fe3039050f3c8ae82dfd93557f98d9deb2d5906",
+      "transcript": "it is bordered to the east by mount repose.",
+      "duration_sec": 2.3,
+      "speech_end_offset_ms": 2300.0,
+      "audio_hash_id": "4a23f2c5ffd2a9c7eaf60315cfeaa0192dd4d25df7a02557de86460c68b5bb64"
+    },
+    {
+      "path": "audio/0237.wav",
+      "sha256": "fcc6a2da320129f2b8e566366857a3515d3275c6d97e2fa45de2a2f8ab4109cd",
+      "transcript": "this artistic choice polarized film critics.",
+      "duration_sec": 3.292,
+      "speech_end_offset_ms": 3292.0,
+      "audio_hash_id": "4a9175310574f799b3797be40d8b5976b9d6346abee7842dbc6f3b015b1d6b48"
+    },
+    {
+      "path": "audio/0238.wav",
+      "sha256": "b78407379eb69f608b38fdf1b510df42b103ee74793e4c90e38689261b21cf64",
+      "transcript": "the paper prided itself to value information over opinion.",
+      "duration_sec": 3.9,
+      "speech_end_offset_ms": 3900.0,
+      "audio_hash_id": "4b8562b0da4b83151208fd61be00f0ef25ea901d953a24136b4b4b7e5aceda73"
+    },
+    {
+      "path": "audio/0239.wav",
+      "sha256": "8c6a73723c01bdb7b9d6f0f2b38e0eaf0ae87693a5a5b99db0979b09b0dac9a5",
+      "transcript": "stanfold is located north of the center of barron county.",
+      "duration_sec": 4.092,
+      "speech_end_offset_ms": 4092.0,
+      "audio_hash_id": "4c3ed49faaff26fe58262f5b655b60d321c80d21c34d6ae47f769667f22533a3"
+    },
+    {
+      "path": "audio/0240.wav",
+      "sha256": "9bc0261f610a963a400e3d784d721f3424287af10f12d61e2366c4e3fd2bda80",
+      "transcript": "wow, look how deep this canyon is!",
+      "duration_sec": 2.684,
+      "speech_end_offset_ms": 2684.0,
+      "audio_hash_id": "4c4b17f18853bd354c40dc48dc033146ce945d699d998c47671a79001af6613a"
+    },
+    {
+      "path": "audio/0241.wav",
+      "sha256": "c5d4aa16660f6f09464070aa5ab92f766be31d09627edc3439cb42b24cd93336",
+      "transcript": "their live shows in support of the album were well received by the press.",
+      "duration_sec": 3.676,
+      "speech_end_offset_ms": 3676.0,
+      "audio_hash_id": "4c95a458d9da68104c3586c928ae653cff8b397509a7d23c914b88faf9a8076a"
+    },
+    {
+      "path": "audio/0242.wav",
+      "sha256": "2f40f3abcc1e450905df993ab977c844689c930a9b8406422b19d870bdc487bf",
+      "transcript": "the front spine on the dorsal fin points forwards.",
+      "duration_sec": 3.228,
+      "speech_end_offset_ms": 3228.0,
+      "audio_hash_id": "4ca8a036c2db89a55fcf5a75318e8f9be24a37a413c41033c8539be9a022e16a"
+    },
+    {
+      "path": "audio/0243.wav",
+      "sha256": "4faef1a47f12af6a85528f098628fd9bce12779c7bf544f9608125dc1738a231",
+      "transcript": "the same is true for speed readers and skimmers.",
+      "duration_sec": 3.548062,
+      "speech_end_offset_ms": 3548.1,
+      "audio_hash_id": "4d28c8c875ab97f600e01ad9421073788dd5029c9dfa9caeb3e4edd9641d88a2"
+    },
+    {
+      "path": "audio/0244.wav",
+      "sha256": "cd6f0928b18c8b34906375d8fbaeb6a2112f18f288ca296454ffd2e3a04f0dd9",
+      "transcript": "the plant's large underground tuber distinguishes it from other \"apios\" species.",
+      "duration_sec": 5.052,
+      "speech_end_offset_ms": 5052.0,
+      "audio_hash_id": "4d9d63963292378c8193eb2e6d5151565b9d64289e30d229b6d5add4bedd24fe"
+    },
+    {
+      "path": "audio/0245.wav",
+      "sha256": "c5aa7556d92f06f570e96295f6d3faa06c0f0f958657e5b7661dac4a0a78a06a",
+      "transcript": "the small statue is less than three feet tall.",
+      "duration_sec": 3.1,
+      "speech_end_offset_ms": 3100.0,
+      "audio_hash_id": "4ddfcaf75be591c5cb0ab060ad8934c0a8aee6739ce6271a5cac0a68d9e6a8bf"
+    },
+    {
+      "path": "audio/0246.wav",
+      "sha256": "3d754102f499987ae799ac0b0817a24acdcbcef1fc4c2f0190782d65aab4b3fb",
+      "transcript": "why do people even eat peanut butter and jelly?",
+      "duration_sec": 2.652,
+      "speech_end_offset_ms": 2652.0,
+      "audio_hash_id": "4dfe233eee4fbc12e731116e98226212174c89927a2249ee55e04ef77ac5acff"
+    },
+    {
+      "path": "audio/0247.wav",
+      "sha256": "e82bc220ef7d3fe1ddbdff7d41539a6ddbfc24859331cb39baa77062dfd5f8e8",
+      "transcript": "this memory can only be configured for one single size.",
+      "duration_sec": 3.1,
+      "speech_end_offset_ms": 3100.0,
+      "audio_hash_id": "4e6e7e13f08095bfda67f63de6da6a00982a579562529351b601ad92fc20c0ef"
+    },
+    {
+      "path": "audio/0248.wav",
+      "sha256": "b781fde97941c86fcffa1692e22566b8a83a4adbc5770d493110d79b456199a7",
+      "transcript": "the significance of the battle of the metaurus is recognized amongst historians.",
+      "duration_sec": 4.38,
+      "speech_end_offset_ms": 4380.0,
+      "audio_hash_id": "4e8728e48a64e77e4e178ad0af56a06f062a680c5a0d98ef9350cd6c6b0d1e95"
+    },
+    {
+      "path": "audio/0249.wav",
+      "sha256": "4950902ac08d180b9099881e24f89eeedafc1f4052444c287c672af96e6cb8b3",
+      "transcript": "the resulting brutal carnage pushes the proper and civilized girl to the breaking point.",
+      "duration_sec": 6.332,
+      "speech_end_offset_ms": 6332.0,
+      "audio_hash_id": "4ea32fe3cc3bcdc8893a05b735e68fb24cb1e7c8e4938eb604e45f321797917a"
+    },
+    {
+      "path": "audio/0250.wav",
+      "sha256": "cb0227d7969e511dd926274b6d56e481a12ac74cf6646b6fbf7978a1393a325f",
+      "transcript": "the alchemist removed the pan from the fire, and set it aside to cool.",
+      "duration_sec": 3.804063,
+      "speech_end_offset_ms": 3804.1,
+      "audio_hash_id": "4edbde1def91293d1d6b969570a1bc00ca0bca584168e4ed28a8496416674ee7"
+    },
+    {
+      "path": "audio/0251.wav",
+      "sha256": "ff099b58fdd212ef78e7c0e08c5932943f6abdf694915019a0898d9630c5c51e",
+      "transcript": "they was both too smart for us!",
+      "duration_sec": 2.972,
+      "speech_end_offset_ms": 2972.0,
+      "audio_hash_id": "4ee2a990acce7b6b3711abaaf220dbaeedabfa488d60b2ea5981dd5ab8c015a3"
+    },
+    {
+      "path": "audio/0252.wav",
+      "sha256": "ac4abdd7d16817ee3994c79dcfe60c38252eccae31eff4bb3cb98d2f03d3884c",
+      "transcript": "sephadex is used to separate low and high molecular weight molecules.",
+      "duration_sec": 3.74,
+      "speech_end_offset_ms": 3740.0,
+      "audio_hash_id": "4f04b3e89528924f0b8eabdc1b23a30f59ed5379e5c72b7490afd6f3a2d17c95"
+    },
+    {
+      "path": "audio/0253.wav",
+      "sha256": "ef51c8d71c07eef77378d65df127eec2101bef142c38a95d603750b8511a1325",
+      "transcript": "large branches are known as boughs and small branches are known as twigs.",
+      "duration_sec": 4.348063,
+      "speech_end_offset_ms": 4348.1,
+      "audio_hash_id": "4f68d311a22969ece4fc2ca0696fe79e2d00f66bd76623dccf62a46d04d44ebb"
+    },
+    {
+      "path": "audio/0254.wav",
+      "sha256": "b2240a14ad15e2795ff8f7c6d36428afc29455e19f3ccb86e759c49789a37e43",
+      "transcript": "the division fought on peleliu for one month before being relieved.",
+      "duration_sec": 4.252,
+      "speech_end_offset_ms": 4252.0,
+      "audio_hash_id": "4f9aed9c2c8173086e204b3229bbd3ad97e94a0206a0aadbffc4caf8813a4e3e"
+    },
+    {
+      "path": "audio/0255.wav",
+      "sha256": "f4b707ba46dd2566d124ebfd75d15578cebaa2505b501a78f20add6872f37978",
+      "transcript": "not all the psalms are usually regarded as belonging to the wisdom tradition.",
+      "duration_sec": 4.156062,
+      "speech_end_offset_ms": 4156.1,
+      "audio_hash_id": "4fba853f5f2c4201f711782bda07cca16b75432bb9281a84db5e951ad3884937"
+    },
+    {
+      "path": "audio/0256.wav",
+      "sha256": "8aaf32465e85f965af1e882ece524941286d68f5b8aa594f218ed0522e87360a",
+      "transcript": "butterworth was developed much later by the british.",
+      "duration_sec": 2.716063,
+      "speech_end_offset_ms": 2716.1,
+      "audio_hash_id": "50b9099c53c86809e581d8f74a873498ba4c1edef0c23c5d3d13148cb934d0ce"
+    },
+    {
+      "path": "audio/0257.wav",
+      "sha256": "d9c928e4585d662dc0767531d815e41ec1de2d6fc92cfeff6683e0861650f52f",
+      "transcript": "the title and his estates passed to his son and heir charles.",
+      "duration_sec": 4.156062,
+      "speech_end_offset_ms": 4156.1,
+      "audio_hash_id": "50f61156c1997d07976d887ba24a20b169ae68c1096fca166b4fa055488eb5dd"
+    },
+    {
+      "path": "audio/0258.wav",
+      "sha256": "7cfa6e4dcc7982d4c1ba8303ca1bf73999091f6a326c3d9e065b765fb673639a",
+      "transcript": "it is run by the american film institute.",
+      "duration_sec": 2.78,
+      "speech_end_offset_ms": 2780.0,
+      "audio_hash_id": "5133fb8b7e1837a125c1670e010e2579a826711fec913c56f12df5239afd17c7"
+    },
+    {
+      "path": "audio/0259.wav",
+      "sha256": "5e981a7dab962c92717524d4c92f57dbbe71691294db4064debf14146ed86241",
+      "transcript": "i've crossed these sands many times, said one of the camel drivers one night.",
+      "duration_sec": 3.644,
+      "speech_end_offset_ms": 3644.0,
+      "audio_hash_id": "5138208b44b4dd82218df512b32cab110faf773a90cda827c72a03b84ca339f0"
+    },
+    {
+      "path": "audio/0260.wav",
+      "sha256": "7628d689edcc30babbeddfd5e86700b6c99106912cb2d4b9d618dc015fbd3f84",
+      "transcript": "each is elected every two years.",
+      "duration_sec": 2.14,
+      "speech_end_offset_ms": 2140.0,
+      "audio_hash_id": "5144a07da12bc847abf458cbb346eec014446598240bcff113dbb3320c21cf91"
+    },
+    {
+      "path": "audio/0261.wav",
+      "sha256": "42d5c0f63336eaf9aef325135a83a6663b35e4b9291f4dae4cb133da0cdd7320",
+      "transcript": "in his early years, escher sketched landscapes and nature.",
+      "duration_sec": 2.972,
+      "speech_end_offset_ms": 2972.0,
+      "audio_hash_id": "519dd2a13d112dd957c1e4d205fd6f6be4ecaa1cfa671fa0f66c6b66666f6c8a"
+    },
+    {
+      "path": "audio/0262.wav",
+      "sha256": "df6ad6b797bff1d0ba9d2332e898b6b084776ffa52ce780fda701b32150eac5b",
+      "transcript": "the confluence is given in parentheses.",
+      "duration_sec": 2.46,
+      "speech_end_offset_ms": 2460.0,
+      "audio_hash_id": "51c00facf19f9893c957fcbeb336c910919dce283f6dd3471148fc5a6d119172"
+    },
+    {
+      "path": "audio/0263.wav",
+      "sha256": "7d8aa6df0e957e499256afefd75e06778d0a9d86e6871a1bff8aa3514bb22a56",
+      "transcript": "unfortunately, the new nose with its radar and radio equipment added significant weight.",
+      "duration_sec": 5.724,
+      "speech_end_offset_ms": 5724.0,
+      "audio_hash_id": "52593310cef0413cccf7922a7cf778a76a8c17d60e62b5e99841310887ad4814"
+    },
+    {
+      "path": "audio/0264.wav",
+      "sha256": "bbca8d8550d241da1b33478c52246913a9a181eb5def5c5a1da07553bc0a976f",
+      "transcript": "little is known of the details of the battle.",
+      "duration_sec": 2.876063,
+      "speech_end_offset_ms": 2876.1,
+      "audio_hash_id": "526c8e9be6fc7ef5269baa4d3d0687169764d239b4eb76cbc68e8c566a8d0ac9"
+    },
+    {
+      "path": "audio/0265.wav",
+      "sha256": "c2ddc353331ff9a21ddf7089e0d971d5ef63a09c39bcbcfcbe523dcbefaed80a",
+      "transcript": "as an international correspondent, rushing has hosted and produced programs all over the world.",
+      "duration_sec": 6.14,
+      "speech_end_offset_ms": 6140.0,
+      "audio_hash_id": "528a24caf02b4b65d9d5f5ab881fbfe2a726f02e33192bea6db1aa36e4d978b0"
+    },
+    {
+      "path": "audio/0266.wav",
+      "sha256": "0b536c36b04a98433d17e55e71afc709afafa959fc553b8528141b111d106869",
+      "transcript": "adams said, i think that lee should have been hanged.",
+      "duration_sec": 2.748,
+      "speech_end_offset_ms": 2748.0,
+      "audio_hash_id": "535a9c8bca87c2c29a6498fbfbe1e96ef15fb2ba5b51a7f3bfa05169bfd56c7f"
+    },
+    {
+      "path": "audio/0267.wav",
+      "sha256": "5e509bf83d42c8896286d619791b7c8543e162cb7ae0ac4ab2df916519ebaba6",
+      "transcript": "the patent expired, and the royal navy eventually adopted the tar mixture.",
+      "duration_sec": 4.38,
+      "speech_end_offset_ms": 4380.0,
+      "audio_hash_id": "540d446e11982f21693ac2198a1285a52fbfa31659f080cbd4f59263bc391209"
+    },
+    {
+      "path": "audio/0268.wav",
+      "sha256": "4ce95adc98a82f2ae7727c6f2d7ac3cb5ba56423510810030b1228984d3050cf",
+      "transcript": "in the case of lisburn, the status extends to the entire local government district.",
+      "duration_sec": 4.732,
+      "speech_end_offset_ms": 4732.0,
+      "audio_hash_id": "54159ae6a97a06add810861a88402ec13cc24b89c9b9ceaa5d6df7040f317a04"
+    },
+    {
+      "path": "audio/0269.wav",
+      "sha256": "12811fe1cb5cf0e6704f1d866bf685dc48ed4dfa5aeab376a16960d734a78160",
+      "transcript": "do you know what an engagement ring is?",
+      "duration_sec": 2.598063,
+      "speech_end_offset_ms": 2598.1,
+      "audio_hash_id": "542495196c26f745d0261dd35a27ed8b843852e02a3361dc85c4a4ca79363ab6"
+    },
+    {
+      "path": "audio/0270.wav",
+      "sha256": "fa04ff10a983c88dd9746da048423f4ad16a444f755ebd10121f6d1bc5b030db",
+      "transcript": "the orange fruit is not yet ripened.",
+      "duration_sec": 2.012,
+      "speech_end_offset_ms": 2012.0,
+      "audio_hash_id": "542eba434412e201044607b020e854e3485c468738c93ab885f0c5b75500dc26"
+    },
+    {
+      "path": "audio/0271.wav",
+      "sha256": "559a3562f5fb2247935bc67abf4cba2dcf77d40206dd27ddb20ea9b12f40cad5",
+      "transcript": "they are spread around the central and northern part of the province.",
+      "duration_sec": 3.74,
+      "speech_end_offset_ms": 3740.0,
+      "audio_hash_id": "543403fcd22530d0d23293339f095f0fbf7ad0bbdc24b9556dc75501e27b75bf"
+    },
+    {
+      "path": "audio/0272.wav",
+      "sha256": "f0ddf9d782e7951217cb4f52bc8d9b57a98e0e3eb9fd1ebcd345accdb00c15fd",
+      "transcript": "however, the carbon dating result was a consequence of an incorrect calibration.",
+      "duration_sec": 5.852,
+      "speech_end_offset_ms": 5852.0,
+      "audio_hash_id": "543a989e841e5818e73be869a71f8a9a6a1a892db31d7c34bd9dfd73a9c4ebf2"
+    },
+    {
+      "path": "audio/0273.wav",
+      "sha256": "8bfd3df6a6e83deb4c6afe35cfaf32d4d45c50c5ab5582554d5b1bb4c5633cae",
+      "transcript": "he was president of the arts federation of new york.",
+      "duration_sec": 2.972,
+      "speech_end_offset_ms": 2972.0,
+      "audio_hash_id": "5461aaa419f977aecc961206c8157fae9b5f9ad512dc247e54c2ca09a2755997"
+    },
+    {
+      "path": "audio/0274.wav",
+      "sha256": "c1849bad1e174cb6ab04994ffaee25a84d81cdc34dc1228d7af3d6193c681044",
+      "transcript": "we took our initiatory step this evening.",
+      "duration_sec": 2.044,
+      "speech_end_offset_ms": 2044.0,
+      "audio_hash_id": "54cf63a60a821506d22ede68506b58247f3ec014f99d44388f772dd3c4c45709"
+    },
+    {
+      "path": "audio/0275.wav",
+      "sha256": "b805ac656058bf9d0849686a1ebc1a4ac4abf608ee42ac11c961a8be8816020b",
+      "transcript": "eggs, milk and flour are the main ingredients of pancakes.",
+      "duration_sec": 3.836063,
+      "speech_end_offset_ms": 3836.1,
+      "audio_hash_id": "54d55f2afad27ceff18b730f53b5681af6101c2bdd1e1afd5762652e29a83848"
+    },
+    {
+      "path": "audio/0276.wav",
+      "sha256": "301655232491ddc546d7b91642ca50b0875f3e971a150364b7d8c9d868105ecd",
+      "transcript": "the show was not made into a series.",
+      "duration_sec": 2.076062,
+      "speech_end_offset_ms": 2076.1,
+      "audio_hash_id": "54e619e71f31fcd9ef19f1603079f979cb157756702da4d2d83f8c8445e2bc04"
+    },
+    {
+      "path": "audio/0277.wav",
+      "sha256": "537e6eab9d8ec304ffecdb4e94daca4e8cc76117531104f9fdc673c262d1a878",
+      "transcript": "the wizard cast a very powerful spell over the town.",
+      "duration_sec": 3.676,
+      "speech_end_offset_ms": 3676.0,
+      "audio_hash_id": "55915f14dab3c8597790821c33e32d031ac8649d4368cfc5c526b8f54e5ef1e9"
+    },
+    {
+      "path": "audio/0278.wav",
+      "sha256": "81029e166898d03163c8cfd1444059cdebcd63de8055875cb15fb2fa47074b38",
+      "transcript": "viewership declined slightly each week during the first season.",
+      "duration_sec": 2.716063,
+      "speech_end_offset_ms": 2716.1,
+      "audio_hash_id": "55b573743555f1aa5c5753f46574abfe04ec4865d4742cca6b4a6982f6d48952"
+    },
+    {
+      "path": "audio/0279.wav",
+      "sha256": "0b8cc31e574ddd489669f58e51c94960c99f64d7d1cdb6a5feca0101ce23a066",
+      "transcript": "the plot revolves around three parallel stories in the style of magic realism.",
+      "duration_sec": 5.084062,
+      "speech_end_offset_ms": 5084.1,
+      "audio_hash_id": "55e77a91314cd7461b82691d99e95b7f4d5d8aaf7f227ba388d8330b23254fe3"
+    },
+    {
+      "path": "audio/0280.wav",
+      "sha256": "6b12a6c708fafbd1559336a357a55c9466ae2e88c04203e092e4fb1a6dd4059f",
+      "transcript": "trample the spark, else the flames will spread.",
+      "duration_sec": 2.236063,
+      "speech_end_offset_ms": 2236.1,
+      "audio_hash_id": "55ee08d4c95ff621f12afdbd7adcd24d2ab0367aedd764f33a5d9feff721c275"
+    },
+    {
+      "path": "audio/0281.wav",
+      "sha256": "7a0e2e589f5a3453cd1e730f0d79ba2e7cbccfc77547854ca2667bf62446492e",
+      "transcript": "many other european languages have one lateral and one rhotic phoneme.",
+      "duration_sec": 4.156062,
+      "speech_end_offset_ms": 4156.1,
+      "audio_hash_id": "565e1f17d051c7a454b59840d73411f88849be853de599bfb1117572880370ac"
+    },
+    {
+      "path": "audio/0282.wav",
+      "sha256": "133511bc33f49f243dde7353f0d2f1013b1a82a8b3d3fb0a6f4522df98a9746c",
+      "transcript": "relaxed and unhurried, he resolved that he would walk through the narrow streets of tangier.",
+      "duration_sec": 4.924062,
+      "speech_end_offset_ms": 4924.1,
+      "audio_hash_id": "56749fdcf03447adc72734f96f2c64995fcdc6d8bb4a93a9fa8efb46442b08ce"
+    },
+    {
+      "path": "audio/0283.wav",
+      "sha256": "eb88b16e91350c52f511c04d07e32c43e740defc1b740cce1066abe3bf4b2cca",
+      "transcript": "he remains incarcerated at south dakota state penitentiary awaiting execution.",
+      "duration_sec": 4.828062,
+      "speech_end_offset_ms": 4828.1,
+      "audio_hash_id": "56a7a32ff222dc8277faede100eccbc7d3648aa137261335649c34e6111d4ebd"
+    },
+    {
+      "path": "audio/0284.wav",
+      "sha256": "919e20fd2261eed9002481dbfd4c8ecad9b23fa6ff623a3d9fa92d71c6b59f82",
+      "transcript": "this river drains about half the county.",
+      "duration_sec": 2.204,
+      "speech_end_offset_ms": 2204.0,
+      "audio_hash_id": "56ab3d44700552570421b8432cf35829eefe1f3570d9d84706adb5085d324b86"
+    },
+    {
+      "path": "audio/0285.wav",
+      "sha256": "5d2e8800d62b4e7303801413a0eeeb2ee1e2b4128facd8d35a86fab2fdc4ae09",
+      "transcript": "some storms are worth the wreckage.",
+      "duration_sec": 2.27,
+      "speech_end_offset_ms": 2270.0,
+      "audio_hash_id": "5708cfe04b8a9e7984a28ca6a744c3b838d815aceb9b1a823705f66678086f01"
+    },
+    {
+      "path": "audio/0286.wav",
+      "sha256": "f71d56a35bc3a1310b2c003fa2d74ddce57aca3cc04c83a18296f81bc5fa1600",
+      "transcript": "there was a hole there among the stones.",
+      "duration_sec": 2.14,
+      "speech_end_offset_ms": 2140.0,
+      "audio_hash_id": "57210f5c26a3ac4fb4eb368a4b033934e98a140ff684314535c2bea364696e4c"
+    },
+    {
+      "path": "audio/0287.wav",
+      "sha256": "9e769c5c21f3bfd4880c88c0f4e0469f7a5f4c9057fe5e34c7705168e6d757af",
+      "transcript": "its function is to bring the pupil closer to the midline of the body.",
+      "duration_sec": 3.804,
+      "speech_end_offset_ms": 3804.0,
+      "audio_hash_id": "57527cc5398c858cdc05dcbb278c1225f12c704a3b475ce31845d30b05f18156"
+    },
+    {
+      "path": "audio/0288.wav",
+      "sha256": "c40b297ec0337a93aa91805795bf133a9078d0605aaecf87918e60a50041616c",
+      "transcript": "the only tribesman spared was the commander of the battalion.",
+      "duration_sec": 3.068062,
+      "speech_end_offset_ms": 3068.1,
+      "audio_hash_id": "581bfbd0c3b15637af933893ee4133962ca91e2bfed42f13c2618d62fe67a09d"
+    },
+    {
+      "path": "audio/0289.wav",
+      "sha256": "c576998d2284c2b3465f53d8ef93a39dab5c855fdfad4ea26e612b38eae73c55",
+      "transcript": "did you learn anything? the englishman asked, eager to hear what it might be.",
+      "duration_sec": 3.670062,
+      "speech_end_offset_ms": 3670.1,
+      "audio_hash_id": "584690e39a35e976d3180b5c7b643628afbed0964c938f5e4259c2ec8cd78716"
+    },
+    {
+      "path": "audio/0290.wav",
+      "sha256": "eed01f18777bb099eafc86f73472c97b8373aa31fdabbe73cbd5fa5b5dd8a269",
+      "transcript": "the players' league folded after one season.",
+      "duration_sec": 2.748063,
+      "speech_end_offset_ms": 2748.1,
+      "audio_hash_id": "5856bc0a9da9275bd17b5ce77d33f0022cef16ffe84e555007bdffe5417accc8"
+    },
+    {
+      "path": "audio/0291.wav",
+      "sha256": "129064cdba26e56ffa6d3af7d47cb8be2b5a449afba0d6df505165cf8c60968f",
+      "transcript": "the album was well received commercially and critically.",
+      "duration_sec": 3.228063,
+      "speech_end_offset_ms": 3228.1,
+      "audio_hash_id": "588b1501b11b93ffb5bc17734767949a030014abe77111e92424f7030ad9717e"
+    },
+    {
+      "path": "audio/0292.wav",
+      "sha256": "060b097e88e1344383f32ccee76a52c2d5a98beba7999831819efe8d7b63b66d",
+      "transcript": "the antibody also reacts positively against junctional nevus cells and fetal melanocytes.",
+      "duration_sec": 5.596,
+      "speech_end_offset_ms": 5596.0,
+      "audio_hash_id": "59383eb8731abb3ca41c4b754fb5ced7d995d2c66d2e9ca485f93c96855226ae"
+    },
+    {
+      "path": "audio/0293.wav",
+      "sha256": "e298845bef2d1235208b84fdbea22c92e6344179ac6e998b4801cda2c4c5e53f",
+      "transcript": "inspired by his classmate's rhymes, he started writing his own songs.",
+      "duration_sec": 4.22,
+      "speech_end_offset_ms": 4220.0,
+      "audio_hash_id": "596f4ac272c0ec8c36830327bea1149702441700b719f0d49746964517ad3dc6"
+    },
+    {
+      "path": "audio/0294.wav",
+      "sha256": "9493fa551e43d507ab210c5ce32399e834c220755f8a09196fd94b98c72afab9",
+      "transcript": "the scene begins with a closeup to paula's face.",
+      "duration_sec": 2.588062,
+      "speech_end_offset_ms": 2588.1,
+      "audio_hash_id": "59bcd8361b2bfe367fc10f9827157b5a6f6d8c3e7f113c25822d91df4f010066"
+    },
+    {
+      "path": "audio/0295.wav",
+      "sha256": "3b17d5ece152037112a865facf5ab49410a715720364a8a3de167517d81010bc",
+      "transcript": "this is referred to locally as 'gallifords' reflecting its ownership.",
+      "duration_sec": 5.404063,
+      "speech_end_offset_ms": 5404.1,
+      "audio_hash_id": "5a4b36725bcba34f7c218d6ac2003b6e5870fd1ad2e9b432efd3a7762652e67e"
+    },
+    {
+      "path": "audio/0296.wav",
+      "sha256": "93272a52a76737aafa176f6924a743fb7cfa78599038e23bf173784f73d744fd",
+      "transcript": "the building is visible from the detroit people mover, as well as comerica park.",
+      "duration_sec": 4.252063,
+      "speech_end_offset_ms": 4252.1,
+      "audio_hash_id": "5a562cbc233a5aaa59dfb880ce6c8be7dc44cfbdbe9f219beddc6721d5412c21"
+    },
+    {
+      "path": "audio/0297.wav",
+      "sha256": "20ea1a2baa02bafe1ea9eeb5d755d8ea47477a6b31bf94bc604e826aecc9d371",
+      "transcript": "the magna, like its forebear the sigma, was based on the japanese galant.",
+      "duration_sec": 5.66,
+      "speech_end_offset_ms": 5660.0,
+      "audio_hash_id": "5a755cc2e95f08393bf2d149e311b754c9f6e61bc3f5c0f5f905b46a013e2f7b"
+    },
+    {
+      "path": "audio/0298.wav",
+      "sha256": "1bc13d5d71abfb31b2d120ee10b18e744be9d22bb7728bf2683264ad539902a2",
+      "transcript": "mewati gharana is a distinctive style of indian classical music.",
+      "duration_sec": 6.972,
+      "speech_end_offset_ms": 6972.0,
+      "audio_hash_id": "5a96d7c163fc75376e9ee22c54fa17312acfbdcec87ccbec040012e524facca2"
+    },
+    {
+      "path": "audio/0299.wav",
+      "sha256": "5d329932e95bb3f415d5a907c86bbaf797deec5b42b168b75aaf507b8f6bc520",
+      "transcript": "do you have any remedy for louses?",
+      "duration_sec": 2.46,
+      "speech_end_offset_ms": 2460.0,
+      "audio_hash_id": "5ae5205d4c25d8bc58bd6dfe3666bac548108a2c4eb886cf232c9c4338d939f5"
+    },
+    {
+      "path": "audio/0300.wav",
+      "sha256": "c27d1538e961eaf888cb8860304ce5b6cdf5cb303958d31101227458e902ff11",
+      "transcript": "he is interred at philadelphia cemetery in prattsville.",
+      "duration_sec": 3.004062,
+      "speech_end_offset_ms": 3004.1,
+      "audio_hash_id": "5b04641e61927a736ca5408e45e066ab666d100ed523dac8515fc5ab5332a51d"
+    },
+    {
+      "path": "audio/0301.wav",
+      "sha256": "bc2161325f1ecaceeb75cbb83591c508e63e65e0ab815eb280a35cac1f1bf847",
+      "transcript": "this was the first championship for the argonauts in eight years.",
+      "duration_sec": 3.548062,
+      "speech_end_offset_ms": 3548.1,
+      "audio_hash_id": "5b4bdf0916eafa2f03a2f1ee0578a816b57b8f76fab7cde40fb8d22e0ecd0e04"
+    },
+    {
+      "path": "audio/0302.wav",
+      "sha256": "584fb3e40df2aa9428b1ca14c9059f1cd37f98de4bf7315190c2228cb661ab5b",
+      "transcript": "the sun was setting when the boy's heart sounded a danger signal.",
+      "duration_sec": 3.228063,
+      "speech_end_offset_ms": 3228.1,
+      "audio_hash_id": "5c05c79b98084672a7c18b13d517a4a71bdb225d1f32af9456c87000af062258"
+    },
+    {
+      "path": "audio/0303.wav",
+      "sha256": "f6a552392cdc12631f98dae599e9234094989f72a477bc0a45fa5f3212fa9c9e",
+      "transcript": "now, god is his own power which subsists by itself.",
+      "duration_sec": 3.708063,
+      "speech_end_offset_ms": 3708.1,
+      "audio_hash_id": "5c1694114dafff9016749cd246eb409a8d917cb923c851f376a5055951d28cb1"
+    },
+    {
+      "path": "audio/0304.wav",
+      "sha256": "95fe67e07726a4eadc76d68199dbe84924dd12d69201eeb36bda8e1197238629",
+      "transcript": "nothing else that he knows of.",
+      "duration_sec": 2.044,
+      "speech_end_offset_ms": 2044.0,
+      "audio_hash_id": "5c53ec1f73e5dfb45c9066b946fb59dcae0c5fa0f3c0bc3513dc11052ea68ea1"
+    },
+    {
+      "path": "audio/0305.wav",
+      "sha256": "14e1c551824b27274acf6eaf46a2a382afe05a30222477c0cba4ed3b8817b566",
+      "transcript": "the submarine then rushed out of the gulf for repairs.",
+      "duration_sec": 2.908063,
+      "speech_end_offset_ms": 2908.1,
+      "audio_hash_id": "5d9f49f6bfc029bb23526f8f32ac18b457eeb56e9eec04c05c5a5c73a198a75c"
+    },
+    {
+      "path": "audio/0306.wav",
+      "sha256": "fc546a1750427ead690b221c0e11749f364c68051572667997d8ec3d11e745ec",
+      "transcript": "there he was found guilty and condemned to death.",
+      "duration_sec": 3.196,
+      "speech_end_offset_ms": 3196.0,
+      "audio_hash_id": "5dcb3e886250a341037969faff1360b68057e2d9519928b401836f2870deaa9b"
+    },
+    {
+      "path": "audio/0307.wav",
+      "sha256": "fb357a4afb6dae80bfcdf7bbd78e7ae3e00d5e59afd0499965b6b016970a0f38",
+      "transcript": "he had never even wept in front of his own sheep.",
+      "duration_sec": 2.524062,
+      "speech_end_offset_ms": 2524.1,
+      "audio_hash_id": "5e452da38e0b17027760e17106a08081d8e7d164fd3eea18d93acd388fdfbcdc"
+    },
+    {
+      "path": "audio/0308.wav",
+      "sha256": "e2c7d56ba226f12349c9ab69676a5c2f6d64f278cb18e2d1a9143881a394a582",
+      "transcript": "it lies in an area of cities and communities known as downriver.",
+      "duration_sec": 4.188,
+      "speech_end_offset_ms": 4188.0,
+      "audio_hash_id": "5e819fe6b9bca6492cf51a482852e01609ad009bf16e4cdc163c6481fc2e3c0d"
+    },
+    {
+      "path": "audio/0309.wav",
+      "sha256": "ae15033af5d5b41e71b54fd02888d71e0c11668c91c3df664fa2c55db873254f",
+      "transcript": "she received her doctorate in early detection of throat cancer.",
+      "duration_sec": 3.868,
+      "speech_end_offset_ms": 3868.0,
+      "audio_hash_id": "5ed879c4055bb7ca73cc1bdc2d8a18d27655d0bae5d2c15d31c0689e222fa1da"
+    },
+    {
+      "path": "audio/0310.wav",
+      "sha256": "256e0c0ac0f8c02127d0e5ace23aefa3e265c2e2a9513892faa9156ca057e1da",
+      "transcript": "this order made it illegal to sell any good below the invoice price.",
+      "duration_sec": 5.02,
+      "speech_end_offset_ms": 5020.0,
+      "audio_hash_id": "5ef7dfc3d2c80bbeec206dc6ef292c30d051b840434dc48ff455183956b83aac"
+    },
+    {
+      "path": "audio/0311.wav",
+      "sha256": "c414ff8b2cd1ce5a2c34c5648b53727afa26ff8630665df8ace671e5cf232ded",
+      "transcript": "the top three stories contained most of the property's mechanical space.",
+      "duration_sec": 3.868063,
+      "speech_end_offset_ms": 3868.1,
+      "audio_hash_id": "5fa6c2d89f4bd6f1563b0eb312b7aa9e6c0a107b23ee8a3a9edbfad2dde4600e"
+    },
+    {
+      "path": "audio/0312.wav",
+      "sha256": "41035e240da1cc43ea5b6093ce0b88749d8933c490ffd89e03706f7523316d77",
+      "transcript": "perhaps the origin of this character archetype is the biblical account of esther.",
+      "duration_sec": 4.86,
+      "speech_end_offset_ms": 4860.0,
+      "audio_hash_id": "6061eeda344491c5678c59506ecf37517f347c4941c95e8e9e6393f0f9ff7742"
+    },
+    {
+      "path": "audio/0313.wav",
+      "sha256": "6425b4dd226c47036bd213aac3b53df84b25c68bda90fe5200a8db8d1c1d3d6a",
+      "transcript": "he also owns a large collection of contemporary art.",
+      "duration_sec": 3.548062,
+      "speech_end_offset_ms": 3548.1,
+      "audio_hash_id": "607d28b8377ad4d9800f969cb36e7f1c2628a540f1455c282c11b7d9dfda2db1"
+    },
+    {
+      "path": "audio/0314.wav",
+      "sha256": "c329036b1252ab2e02a6ac1903627b071bf862b5d47018e75d196d2e23fcd46f",
+      "transcript": "he also does freelance work for disney and other companies.",
+      "duration_sec": 3.164062,
+      "speech_end_offset_ms": 3164.1,
+      "audio_hash_id": "60a48883b950f672a8fb76b2fbd6306a791680b0d7a74dbfe68ba807c5ed0a4c"
+    },
+    {
+      "path": "audio/0315.wav",
+      "sha256": "a24e2bf4b80354df601be8bbf6f11f6e88cebae4a6d4350c18cca04681ed439a",
+      "transcript": "she was an alumna of the film and television institute of india, pune.",
+      "duration_sec": 4.7,
+      "speech_end_offset_ms": 4700.0,
+      "audio_hash_id": "60ca79ffbf0f5653b3fe5a51c3ce20c0c39d5fb7458dbb398e4028622192b588"
+    },
+    {
+      "path": "audio/0316.wav",
+      "sha256": "c53390376f3922e524bb7ec1266c2f10104ef0a7fd7d2d92c365a1e8b12c2782",
+      "transcript": "the warrego river runs just to the west of the town.",
+      "duration_sec": 3.196063,
+      "speech_end_offset_ms": 3196.1,
+      "audio_hash_id": "617ccc21d8685de197be4e19a363224a37c513286b217b1c344241fb12431102"
+    },
+    {
+      "path": "audio/0317.wav",
+      "sha256": "fe63decef1a7e9ec9e926b4a5e45090bc9b544cce891771752a86c1a2d5c8de7",
+      "transcript": "the boyanup line was extended to donnybrook, western australia in the same year.",
+      "duration_sec": 5.98,
+      "speech_end_offset_ms": 5980.0,
+      "audio_hash_id": "617e934b5140c1897be39a9bf038fc67e72fe79e25607811cfad37a8f814f0f1"
+    },
+    {
+      "path": "audio/0318.wav",
+      "sha256": "3e3368f01747133595c13a1a6651e3a9708d1180ca37519ae9dcfb9332f977c5",
+      "transcript": "your son went to serve at a distant place, and became a centurion.",
+      "duration_sec": 3.292,
+      "speech_end_offset_ms": 3292.0,
+      "audio_hash_id": "61c77db932a4acaed8675435ce6d0cc730c19da26778567dfaa85c9de334d55d"
+    },
+    {
+      "path": "audio/0319.wav",
+      "sha256": "708eab33a7582dbd044a4f9563b643f1e17a84d0d622bb7bfaca564c5d5e5d5a",
+      "transcript": "this was the first atlas to cover the entire celestial sphere.",
+      "duration_sec": 3.772,
+      "speech_end_offset_ms": 3772.0,
+      "audio_hash_id": "6214b1bea1fddb5f3dda5d2cddd0f84d034a7a93e47fdada900449b05d5a3f42"
+    },
+    {
+      "path": "audio/0320.wav",
+      "sha256": "1468977f8473549a445ea25e0bcc55526b065a27bbe3f68ada2d4488656f2d98",
+      "transcript": "it is the only known member of genus anisocoma.",
+      "duration_sec": 4.316063,
+      "speech_end_offset_ms": 4316.1,
+      "audio_hash_id": "62f795688e4a024e35155ebb3c9a1164d1c23e475da60810e80b831b6d087fb4"
+    },
+    {
+      "path": "audio/0321.wav",
+      "sha256": "dc7c379c731be5c82b1949bcf8a7d999e5006b84797f512f5949df3211058659",
+      "transcript": "carothers dropped his research on polymers for several years.",
+      "duration_sec": 3.196,
+      "speech_end_offset_ms": 3196.0,
+      "audio_hash_id": "631720ee6df50aad50260063e19117b405fdccbc60e05112dd56b83706aad146"
+    },
+    {
+      "path": "audio/0322.wav",
+      "sha256": "0342cc30874f209e3b094db1d0e617f635bbf39f0b649d2a3d2dad8cde6fa120",
+      "transcript": "the men at the bar were obviously drunk.",
+      "duration_sec": 2.044062,
+      "speech_end_offset_ms": 2044.1,
+      "audio_hash_id": "633b0190a7fb228b29a8ca9b53fc925f6cec3d7fb2c3f692ecd7102b5d98c765"
+    },
+    {
+      "path": "audio/0323.wav",
+      "sha256": "40fd52a10375dd7f4bacd5eedf8b947a96ba40f729d5d2a5f01a631047e4dc3c",
+      "transcript": "lyons was born in stanley, tasmania, the grandson of irish immigrants.",
+      "duration_sec": 5.468,
+      "speech_end_offset_ms": 5468.0,
+      "audio_hash_id": "636246292781bc3ac07f851677c94996b1095654919ee37402748bb679cb87bc"
+    },
+    {
+      "path": "audio/0324.wav",
+      "sha256": "f83303e65e3ee15c06315cd8153fcc774b2dcfd5548dc615f5b49ffd10658360",
+      "transcript": "presentism is also a factor in the problematic question of history and moral judgments.",
+      "duration_sec": 5.66,
+      "speech_end_offset_ms": 5660.0,
+      "audio_hash_id": "63858f097cf41f30d028c2d333aaa2fa769d8a04fadd586617d8476c2087b206"
+    },
+    {
+      "path": "audio/0325.wav",
+      "sha256": "e1079f3605a66c3b0a405d4be8de07887f177748ef0fc951958bb95438a25ac6",
+      "transcript": "however, the physical mechanism is not well understood.",
+      "duration_sec": 2.972,
+      "speech_end_offset_ms": 2972.0,
+      "audio_hash_id": "638f19e066332107f14738cc92bc8b2bbc87e902b6d0c70c0ff6b7b3e335d46d"
+    },
+    {
+      "path": "audio/0326.wav",
+      "sha256": "f528a15846c07d2689a6cde9c4f017eb9e3b3ddc3cae7839db9d3a7d38ba6bca",
+      "transcript": "there are deep gouges from cratering along the northeastern rim.",
+      "duration_sec": 7.228063,
+      "speech_end_offset_ms": 7228.1,
+      "audio_hash_id": "63e5d5451e0dcb228ff1de97eda6902aca727593fd42a581d0a9931b0626e57c"
+    },
+    {
+      "path": "audio/0327.wav",
+      "sha256": "11fde2d17f4a990fa28ce29cdebb7bca3d0ed4306113bb75504271cb19f57343",
+      "transcript": "it was the second election to the parliament of northern ireland.",
+      "duration_sec": 4.252,
+      "speech_end_offset_ms": 4252.0,
+      "audio_hash_id": "63f79e2074fb67ef1a71db67461c6537ad6cd5ba099148dd63ba63f619e8900a"
+    },
+    {
+      "path": "audio/0328.wav",
+      "sha256": "bf4c67098820df7b6de9a567cd5591f6abebc4090d81a29a1f1151bab6f5d4ec",
+      "transcript": "the first verse of the poem illustrates this structure of six eight-syllable lines.",
+      "duration_sec": 5.18,
+      "speech_end_offset_ms": 5180.0,
+      "audio_hash_id": "646e38b8fcfcf8893d8b6ca017d853ce6c106ab993d7a158a46b73516b6d3ef1"
+    },
+    {
+      "path": "audio/0329.wav",
+      "sha256": "d39d677bffe6a7a4a4ae76960a0566b3751804a443c4c340288a29a6ac72510e",
+      "transcript": "his first role was as assistant at elgin parish church.",
+      "duration_sec": 4.316,
+      "speech_end_offset_ms": 4316.0,
+      "audio_hash_id": "647dd68ae729ac76110bc730490c5eb797648be2041414494d34e0e5892c122f"
+    },
+    {
+      "path": "audio/0330.wav",
+      "sha256": "a0147ea145ea6c39c2036ea4c327d40aa6f06da7f39aba52cf44bb2746dfc834",
+      "transcript": "i can stand being spoiled a little.",
+      "duration_sec": 2.102063,
+      "speech_end_offset_ms": 2102.1,
+      "audio_hash_id": "64fa7a32df93b295798dbfdde175b6c5ccaf3d397ce98c01ba5973fcc1b39eea"
+    },
+    {
+      "path": "audio/0331.wav",
+      "sha256": "1818653b6d2ad14165cae9b449dc42cfbc23d4ba2d68746c89f7297bef9e6d75",
+      "transcript": "the table of results is complete to the end of the micromax asia cup.",
+      "duration_sec": 3.548062,
+      "speech_end_offset_ms": 3548.1,
+      "audio_hash_id": "653bbd3d8b731d01e87508305e0526c94faeb5dc4c98ec8f714d0559e5086728"
+    },
+    {
+      "path": "audio/0332.wav",
+      "sha256": "2bc8955e9a8e12f06106c54373b17a8c9d6a87a69e9fd9be804a889449660b05",
+      "transcript": "the wakefield line is coloured yellow on maps and publications by west yorkshire metro.",
+      "duration_sec": 5.532,
+      "speech_end_offset_ms": 5532.0,
+      "audio_hash_id": "6559b3bfc7942b21ccd7d5278d6a60fe6554746898c468bce02a966d6bfc91b3"
+    },
+    {
+      "path": "audio/0333.wav",
+      "sha256": "888f26b9742c16103b0ee52c25c02ca12a9794704721d67eff965d8f156137a4",
+      "transcript": "during this time he began to befriend and gain the trust of his neighbors.",
+      "duration_sec": 3.9,
+      "speech_end_offset_ms": 3900.0,
+      "audio_hash_id": "655d0b77220607248270b1f8b4a22b52949b8f0307589bd890fc761abc15238c"
+    },
+    {
+      "path": "audio/0334.wav",
+      "sha256": "7332c5cd5c0cb219fb274d565099f8a647e28b7b09dd8d582c4ac0e4c1e4f9a4",
+      "transcript": "fraser was always a safe seat for the australian labor party.",
+      "duration_sec": 4.54,
+      "speech_end_offset_ms": 4540.0,
+      "audio_hash_id": "6574b02966195554f73a59fb03423b15d9f6252de0800e889de72ab507437150"
+    },
+    {
+      "path": "audio/0335.wav",
+      "sha256": "82349890d408f95d8125db50ce71d808ee622fe1429a1a5b5ec83c5eff6ec577",
+      "transcript": "roller derby girl dressed in pink helmet, white tank top, and black shorts skates.",
+      "duration_sec": 5.276063,
+      "speech_end_offset_ms": 5276.1,
+      "audio_hash_id": "65b72396ff8efcde72c8f171ca37d9b6b6f089d1287f0c3c83bed2c65aa1f102"
+    },
+    {
+      "path": "audio/0336.wav",
+      "sha256": "3aca8197b5b89c415c136a3f57a6e4c31411db158775db69fca8c7daefea5211",
+      "transcript": "the ghost town of worden was located in the town.",
+      "duration_sec": 2.908063,
+      "speech_end_offset_ms": 2908.1,
+      "audio_hash_id": "65cfc17ebc0bccf9d87edac9a522d8a37780e68fc39d4dc65fa8c4eda4234d9c"
+    },
+    {
+      "path": "audio/0337.wav",
+      "sha256": "f2a40aa8617fdf912282ce23f0b98a864867adc411f0ae2c1979db712809164b",
+      "transcript": "the santa cruz mountains are subject to sharp diurnal temperature fluctuations.",
+      "duration_sec": 4.284,
+      "speech_end_offset_ms": 4284.0,
+      "audio_hash_id": "65f0457dd6a13a46fe1ed361b686e61ce1e6d1e056f48a362315b7a4867f1652"
+    },
+    {
+      "path": "audio/0338.wav",
+      "sha256": "aebef9ba80aaa1a20320b592e4c5f9dd2d0e907343e0a6c654b72d862b3ab205",
+      "transcript": "their presence disrupted normal shopping and attracted onlookers.",
+      "duration_sec": 4.06,
+      "speech_end_offset_ms": 4060.0,
+      "audio_hash_id": "667071b24e9813d9865f2c20ad98f60f40d91c9a88273981e8649f5848bb269e"
+    },
+    {
+      "path": "audio/0339.wav",
+      "sha256": "243c8636029fa254022f04f03930499b7f136b1fe2f3567ed647fc68e8ab737c",
+      "transcript": "and i will tell you how to find the hidden treasure.",
+      "duration_sec": 2.108062,
+      "speech_end_offset_ms": 2108.1,
+      "audio_hash_id": "668c2b89ecf737fcfbd5925ff7c4c3e4e61c8a31410b332ba02fd7d73e57d1d1"
+    },
+    {
+      "path": "audio/0340.wav",
+      "sha256": "c31826479ef6beba2287dddd0f0ebeacfb968b34b0e1606540b960337043e803",
+      "transcript": "editor chris stone took over the writing chores for the series.",
+      "duration_sec": 3.612,
+      "speech_end_offset_ms": 3612.0,
+      "audio_hash_id": "674b0f6c3d694cf54a072fb1198a3688b1734c6170c4d569a39c29471fe0ebd4"
+    },
+    {
+      "path": "audio/0341.wav",
+      "sha256": "f34a14c8365e302ab5cc399af2204c3703bcb85fd994c3e8438bea08a24051a1",
+      "transcript": "the boy stepped closer to the girl, and when she smiled, he did the same.",
+      "duration_sec": 4.188063,
+      "speech_end_offset_ms": 4188.1,
+      "audio_hash_id": "684e7b8b87f2047b44f223709c800189b07039f3bae424e9acda57c90a75d042"
+    },
+    {
+      "path": "audio/0342.wav",
+      "sha256": "3418e2999e5d7c04230b766d341dbceb9cb866cbc954ff82e14bedee23f4a25e",
+      "transcript": "their daughter and his wife's family are also buried there.",
+      "duration_sec": 3.612,
+      "speech_end_offset_ms": 3612.0,
+      "audio_hash_id": "686506d636b37f26eba08a7587344b867f7c7d63c6dd0338fd4ef6354afd6718"
+    },
+    {
+      "path": "audio/0343.wav",
+      "sha256": "50129927fdb66ee76f66c5b9d32f28a278d2216d3d0e4a2da331197f3fcecda2",
+      "transcript": "practical electronic converters use switching techniques.",
+      "duration_sec": 3.132,
+      "speech_end_offset_ms": 3132.0,
+      "audio_hash_id": "688c2bf456b9c7d95e407101dba21c05a3d64fde199c41b15ce1333a51eabbd6"
+    },
+    {
+      "path": "audio/0344.wav",
+      "sha256": "064f43a34263b7a09b99c4d1407460edcddba4a79bfd4fce841e660501ce3e98",
+      "transcript": "using the debugger, he found out that there was a buffer overflow.",
+      "duration_sec": 3.58,
+      "speech_end_offset_ms": 3580.0,
+      "audio_hash_id": "6a263ead4d28001f81df0d5e1d2874690377f1987bea1412d5c6c7e25c344d8f"
+    },
+    {
+      "path": "audio/0345.wav",
+      "sha256": "98761ae6738a30002bf3a9c16e0fe79334a68f697e78c1a04adad5ee42cb95f7",
+      "transcript": "the knife was hung inside its bright sheath.",
+      "duration_sec": 2.012,
+      "speech_end_offset_ms": 2012.0,
+      "audio_hash_id": "6a75facccbd92c895285daa94ed046d0e8a151d0e0ac139ce73cd7ed0228f806"
+    },
+    {
+      "path": "audio/0346.wav",
+      "sha256": "e8ab720b31aee736447b7fe5cc45ca13d643bac22cfd557baffaa2f2033c0a66",
+      "transcript": "mister jackson was sorry for albert.",
+      "duration_sec": 2.396063,
+      "speech_end_offset_ms": 2396.1,
+      "audio_hash_id": "6a944572df61613a09a5f7fbdd74495cedff970f3d06988c9fb13fc111a18a44"
+    },
+    {
+      "path": "audio/0347.wav",
+      "sha256": "57785f7c09e800315c029c445804a55199f63ea1839cdf189b8b3f0f24c31fa8",
+      "transcript": "tolls are collected on both crossings from vehicles travelling in a westward direction only.",
+      "duration_sec": 4.54,
+      "speech_end_offset_ms": 4540.0,
+      "audio_hash_id": "6b29528fe5bc17eea3920a8089833431a3182edfc20f1fa73a22bb3c8aefa224"
+    },
+    {
+      "path": "audio/0348.wav",
+      "sha256": "4bc26dd9c041c7aa36b7329fdd3f5c22a90171ba625b1538ae13136ce5f8854e",
+      "transcript": "instead, over time, the species wobbles about its phenotypic mean.",
+      "duration_sec": 4.476,
+      "speech_end_offset_ms": 4476.0,
+      "audio_hash_id": "6b48cc5dd68abbfe8c6f2d54be88f60596d539cb3ef7e2b6e54ac354a4688d48"
+    },
+    {
+      "path": "audio/0349.wav",
+      "sha256": "016782b901aa896e5473d46a24362884ddbd8e738e7bec7b5530f047f0e43011",
+      "transcript": "the hand with the whip pointed to the south.",
+      "duration_sec": 3.708063,
+      "speech_end_offset_ms": 3708.1,
+      "audio_hash_id": "6b927b333bd81f7ae5798924de7ca37505956647851d06c7373ff84c43a543f2"
+    },
+    {
+      "path": "audio/0350.wav",
+      "sha256": "448673216590419e2a104cf5a5c1ebfae512b3ec697bf36c96848956135e5bec",
+      "transcript": "it was named from the quality of their land.",
+      "duration_sec": 2.46,
+      "speech_end_offset_ms": 2460.0,
+      "audio_hash_id": "6bd9079e3858fa562b8ef69602dc0d554d3b7e6cb747f2c3b736976261bf066c"
+    },
+    {
+      "path": "audio/0351.wav",
+      "sha256": "b2d5c85935afb0cffdd09c536b5124df236ea854d0e0064822ce923565e29e21",
+      "transcript": "there are conflicting reports as to why blair was asked to resign.",
+      "duration_sec": 4.348063,
+      "speech_end_offset_ms": 4348.1,
+      "audio_hash_id": "6bff2508c7d96318fa48f6539c885de26080d5fea7a43456584c68f3572de044"
+    },
+    {
+      "path": "audio/0352.wav",
+      "sha256": "fcb213220f05c05352bf54b8721e625b26df8d096b0514d42d7d809e2dfb0a12",
+      "transcript": "its consumer products are marketed under the brands crucial technology and lexar.",
+      "duration_sec": 4.54,
+      "speech_end_offset_ms": 4540.0,
+      "audio_hash_id": "6c34e51dd4f672a22289934f6b49b69d4201ce05cafa09dbc7544c563b381ac1"
+    },
+    {
+      "path": "audio/0353.wav",
+      "sha256": "3ec98d78333e1b891c80e2e8fd20093e814ed05b1f94cd44cb28494cd5af0161",
+      "transcript": "where your treasure is, there also will be your heart, the alchemist had told him.",
+      "duration_sec": 3.964,
+      "speech_end_offset_ms": 3964.0,
+      "audio_hash_id": "6cc02e571b1a2f324305c81eb355421e84ea2882fb2b0028d06218fa13fd73e6"
+    },
+    {
+      "path": "audio/0354.wav",
+      "sha256": "9479c1346e11e7534023f49fdcdb82e0279e52701a71908ad846e7213996b2f9",
+      "transcript": "what had been next to him five minutes ago was now at the other side.",
+      "duration_sec": 3.708063,
+      "speech_end_offset_ms": 3708.1,
+      "audio_hash_id": "6cc46a0397385d8f067889312886ce972c65e2c0f7e5bf6138acaaa4ab37be31"
+    },
+    {
+      "path": "audio/0355.wav",
+      "sha256": "ff60a6c787b7322fb8de136c8f485c2a56ee78daf4283480b0aa4564580b0258",
+      "transcript": "females will have primary amenorrhea.",
+      "duration_sec": 2.428,
+      "speech_end_offset_ms": 2428.0,
+      "audio_hash_id": "6ceaa562f6a4e69f10bc939ea25ac3df195a6b5b8361e856cb209786d4af1256"
+    },
+    {
+      "path": "audio/0356.wav",
+      "sha256": "ae02a0ac74bb8b40d02ce5bbc5ccd2c1e5313e69b6b01bb16183bd2fd1a5b442",
+      "transcript": "it is based on the eponymous novel by william wharton.",
+      "duration_sec": 3.068062,
+      "speech_end_offset_ms": 3068.1,
+      "audio_hash_id": "6d01d8f3605f30678e032b153c24a97468ef914638056d1cb8a99f2c7c3078cf"
+    },
+    {
+      "path": "audio/0357.wav",
+      "sha256": "04412d7c0004659cb5870c29d977f03a9e78aae0d0f95b16f6745657144ce3e3",
+      "transcript": "it is generally treated with blepharoplasty.",
+      "duration_sec": 2.94,
+      "speech_end_offset_ms": 2940.0,
+      "audio_hash_id": "6d3c46aa9f8ccdc25115883ba8a7ca5228a269ef12643525660ad5c4dee8f025"
+    },
+    {
+      "path": "audio/0358.wav",
+      "sha256": "f40f2d51a364d966ac8a528eeec41aa63f703d93b8644441819eb1bd8716c74f",
+      "transcript": "it temporarily suspended publication during the japanese occupation of malaya and singapore.",
+      "duration_sec": 5.276063,
+      "speech_end_offset_ms": 5276.1,
+      "audio_hash_id": "6d4d936e4176ad51fae5c8f2281f38b090d0f3f52db3b001afd3dbb93012a321"
+    },
+    {
+      "path": "audio/0359.wav",
+      "sha256": "9d3c9f401e46b965dc3e2537366e4d334eba6240df23fc82856393798bbc4396",
+      "transcript": "eventually a string of tragic events strike the team.",
+      "duration_sec": 3.388063,
+      "speech_end_offset_ms": 3388.1,
+      "audio_hash_id": "6df0b5857355e57f47a645035c31b41e8f901aa37bfc2959057b6c8337abb995"
+    },
+    {
+      "path": "audio/0360.wav",
+      "sha256": "1e1fd854601534050607d455b3e6712bc071696fc5b3afdd0d12fcaa8a9aa4b2",
+      "transcript": "the county land was flattened by two glaciers millions of years ago.",
+      "duration_sec": 4.476063,
+      "speech_end_offset_ms": 4476.1,
+      "audio_hash_id": "6e6f5c81ef1c530ae9cbfe6e92114cbaa9a385bc32e6c882ff2a8ae3b9caee88"
+    },
+    {
+      "path": "audio/0361.wav",
+      "sha256": "d718835af9aafda555154b8d571bbb8240e6e07b87a5627e1a332d193f8f0d31",
+      "transcript": "further interactivity is achieved through non-verbal methods.",
+      "duration_sec": 3.708063,
+      "speech_end_offset_ms": 3708.1,
+      "audio_hash_id": "6e82f6ae4994abc05d7877b218ca86790df11d4742d2cc8a88de26478e1ec7fa"
+    },
+    {
+      "path": "audio/0362.wav",
+      "sha256": "019d8b5463ae494f8c071d607b33cf035ad8d2d55ce0dc05810b720413e91d5d",
+      "transcript": "it must have fallen while i was sitting over there.",
+      "duration_sec": 2.076062,
+      "speech_end_offset_ms": 2076.1,
+      "audio_hash_id": "6e9499d0982bdf9bf3fac682a572827f36a9e34d5634fb009072fdffaacb00de"
+    },
+    {
+      "path": "audio/0363.wav",
+      "sha256": "f4635f3388d5add3833ba43146406c838c027513bc4fccc9700bafa30bff4397",
+      "transcript": "members of the big five meet in private to negotiate california's state government budget.",
+      "duration_sec": 4.828062,
+      "speech_end_offset_ms": 4828.1,
+      "audio_hash_id": "6eb313f5903712bb3a17753827bb366c426fcfcecff4d547d1d5cf92d3c95e6e"
+    },
+    {
+      "path": "audio/0364.wav",
+      "sha256": "fd583eb91873db189c7fa71112ada3c7a786e9a1ebced2971c7e9aae68bfadda",
+      "transcript": "the englishman had been profoundly impressed by the story.",
+      "duration_sec": 3.26,
+      "speech_end_offset_ms": 3260.0,
+      "audio_hash_id": "6ecfa52ffb26ffc495d8f7976ae7ac9823e5c2597f2b52786c1dc6b08ae50f1e"
+    },
+    {
+      "path": "audio/0365.wav",
+      "sha256": "44a4772021c400582873d7d2da132ec797ad4dbb4d37ad0e7ba85dbec130b97b",
+      "transcript": "mary bergin was born in shankill, county dublin, ireland.",
+      "duration_sec": 4.252,
+      "speech_end_offset_ms": 4252.0,
+      "audio_hash_id": "6f1cf28de0588a994414de970fc193509c19e659032cc5ae10419cd64f015e2c"
+    },
+    {
+      "path": "audio/0366.wav",
+      "sha256": "beece3d2ae2abff935444d3532b885e199875c845748e4a5d24b9db2ee8bf77d",
+      "transcript": "in the end, yuki and kyo called a truce.",
+      "duration_sec": 3.388063,
+      "speech_end_offset_ms": 3388.1,
+      "audio_hash_id": "6f4fed3155a92df98a6f4c9e03320cc73401714d2d450475e0a84b04e99379ac"
+    },
+    {
+      "path": "audio/0367.wav",
+      "sha256": "05b6d02f5d4f59e523ce07faa391294c2c6b815333dcb302fba7f6dd73f1a640",
+      "transcript": "most of them are found in the sibiu county.",
+      "duration_sec": 2.236063,
+      "speech_end_offset_ms": 2236.1,
+      "audio_hash_id": "6fb723b7d09dc6162d487fe3f0a9f26b609c83bb132937665ce4f055dde1bf7b"
+    },
+    {
+      "path": "audio/0368.wav",
+      "sha256": "19f9a87f41b06516178c4fb7958d1937561236d2f2f2d5aa2114e86121b7516e",
+      "transcript": "kudat formation is originated from deep marine environment.",
+      "duration_sec": 3.772,
+      "speech_end_offset_ms": 3772.0,
+      "audio_hash_id": "70414baef5cc8fbd6ab95672debdef2ca01c4ff619e2d89dd8713fc3c8a65c1f"
+    },
+    {
+      "path": "audio/0369.wav",
+      "sha256": "b17be4220959a95d0cbf9d28273332b07d26c975de5ff444bb9d22d62967e21e",
+      "transcript": "he was thus a man of high position in both clerical and secular society.",
+      "duration_sec": 4.604,
+      "speech_end_offset_ms": 4604.0,
+      "audio_hash_id": "7068a427d869abf0142768a66ffd0e6194bc550aab3fffc03b54700a51f15a24"
+    },
+    {
+      "path": "audio/0370.wav",
+      "sha256": "e5ac5084567e9e2662124dbceaed59d8cf1a3a23d1baf7e8411d03a21d24622f",
+      "transcript": "people said that gypsies spent their lives tricking others.",
+      "duration_sec": 2.662063,
+      "speech_end_offset_ms": 2662.1,
+      "audio_hash_id": "7092dc78bacacd1f7ff4f657134fbd815b9e587429a80c195e4fc8ea99800f8f"
+    },
+    {
+      "path": "audio/0371.wav",
+      "sha256": "489aa5b92155e46ba69686d3b6e2a53ceb5ea996cfe6106e213c36a696285ec0",
+      "transcript": "a documentary is also in the works from the super oldies label.",
+      "duration_sec": 3.388,
+      "speech_end_offset_ms": 3388.0,
+      "audio_hash_id": "70a4d57baff29462f1a1c90f9096bff6cfe1e56fed198e33f23e06f77feafabd"
+    },
+    {
+      "path": "audio/0372.wav",
+      "sha256": "ab1af7080bbea041d0a68082623d645283c55afa9799c2df73a3c002c5548fb3",
+      "transcript": "its most renowned industry is that of dairy products.",
+      "duration_sec": 2.332063,
+      "speech_end_offset_ms": 2332.1,
+      "audio_hash_id": "70fce10a86445e0dad1425d47ea8ac2c5331dd11e5ae039ab5b1b3a25a8232f1"
+    },
+    {
+      "path": "audio/0373.wav",
+      "sha256": "ff95a1b34d91dbaffc630accb97ffd292b49cb37237b9aad7d6998422c42bd0b",
+      "transcript": "the snake fought frantically, making hissing sounds that shattered the silence of the desert.",
+      "duration_sec": 4.252063,
+      "speech_end_offset_ms": 4252.1,
+      "audio_hash_id": "70fd7bb63c9bc84253d8042ab3b1f1cd262915a65595a63a279601aaf9678942"
+    },
+    {
+      "path": "audio/0374.wav",
+      "sha256": "67cafdcf9560d0924d30ff39a3aae46d10932c250645e4923ce3a69a25c2748b",
+      "transcript": "there he led the technical preparation of plastics, namely polyamide and caprolactam.",
+      "duration_sec": 7.036,
+      "speech_end_offset_ms": 7036.0,
+      "audio_hash_id": "7107501c9df4fb59d15127d323c82088d248350bc2fff6dbede1dd4636b7fa16"
+    },
+    {
+      "path": "audio/0375.wav",
+      "sha256": "95a1306363a51f217546391441ffd2890415f2e9eb81c7e14a30c66f8a1dfd3f",
+      "transcript": "they toured both north america and europe.",
+      "duration_sec": 2.876063,
+      "speech_end_offset_ms": 2876.1,
+      "audio_hash_id": "7147d83f39d88a063362eb9736d0365935284337b81df0525997387a2e797e39"
+    },
+    {
+      "path": "audio/0376.wav",
+      "sha256": "fdd0c9b08e49de30f32b5c16698554999cc77a854e35a899498ef18c6242d263",
+      "transcript": "the new patch is less invasive than the old one, but still causes regressions.",
+      "duration_sec": 3.964,
+      "speech_end_offset_ms": 3964.0,
+      "audio_hash_id": "719052fcc358e6b123d38df915168ad916c4ddd628e52c214b82c414d86fa016"
+    },
+    {
+      "path": "audio/0377.wav",
+      "sha256": "8a8dd633a40217b14f92f9d84ac515647e4cb4d7d10fd73a881690ff9299688f",
+      "transcript": "midlothian was also the name of a historic county formed in the middle ages.",
+      "duration_sec": 5.116062,
+      "speech_end_offset_ms": 5116.1,
+      "audio_hash_id": "7195d7859d2cd95022ba40e6f65e28c47046ade090d040d5efc065aae8c33ce1"
+    },
+    {
+      "path": "audio/0378.wav",
+      "sha256": "22a7a1d1595f86b30da62fb204e9aaeb58890d0a27c8f784c5fb2bda39f1fd7a",
+      "transcript": "i want my husband to wander as free as the wind that shapes the dunes.",
+      "duration_sec": 3.726062,
+      "speech_end_offset_ms": 3726.1,
+      "audio_hash_id": "71fb8e7d34e87eed69525794567ab56cee45b61552e6ec0763fc4796410123dc"
+    },
+    {
+      "path": "audio/0379.wav",
+      "sha256": "dc1129aa17d69cc8202bd1fb60129d7d16b8a66cef2f3ba7da375206bd85feb1",
+      "transcript": "but we could sell tea in crystal glasses.",
+      "duration_sec": 2.268063,
+      "speech_end_offset_ms": 2268.1,
+      "audio_hash_id": "72019d9894660f9ee5a8d0788b9647c2113bbdf3dbac20b76ef74247b9dd44c3"
+    },
+    {
+      "path": "audio/0380.wav",
+      "sha256": "a725d533d6679ea606487dbcdf69a85f7f50427bf35cffeb54052ef4d8870ea7",
+      "transcript": "the electrolyte chemistry below isn't rechargeable.",
+      "duration_sec": 3.004,
+      "speech_end_offset_ms": 3004.0,
+      "audio_hash_id": "7227df0b10defe789898a2982a14d88ade7d373061cfaa3cd8c3905dbecee02d"
+    },
+    {
+      "path": "audio/0381.wav",
+      "sha256": "a5b7a9ea4c1f499b93b85932fac9d19b6eecdf298da4fab476709867a5d0f71a",
+      "transcript": "in dark conditions this cluster can be faintly seen with a pair of binoculars.",
+      "duration_sec": 3.644062,
+      "speech_end_offset_ms": 3644.1,
+      "audio_hash_id": "723c02f3fbd6e5a61e7957222a581447d4a59b32cd4541847ef09799e67c2c24"
+    },
+    {
+      "path": "audio/0382.wav",
+      "sha256": "64b660f440d5ffaca31a872b775e12c4bb3276920680045dcf09ae598f1a200c",
+      "transcript": "demonstrations should be held at every congressional or convention seating of dixiecrats.",
+      "duration_sec": 4.956062,
+      "speech_end_offset_ms": 4956.1,
+      "audio_hash_id": "7242340bad80322cf80a35de917b517c058f1a5f1d88170c05f779a2a3b8ad98"
+    },
+    {
+      "path": "audio/0383.wav",
+      "sha256": "4fbdf185c005c93510e272f64aeab54aefa02915ad72c4b62a8fa459f1c4cb46",
+      "transcript": "its eastern boundary is the rideau river, its namesake.",
+      "duration_sec": 3.58,
+      "speech_end_offset_ms": 3580.0,
+      "audio_hash_id": "72ec49231dcb182fdaaab456753f2bca8a30a85d6412d45c47cee89ebb70d359"
+    },
+    {
+      "path": "audio/0384.wav",
+      "sha256": "62c1066e40a0603c4288f11c45f9fe91aa8e530c34b47549358d79dadf2677df",
+      "transcript": "brian grazer and ron howard were executive producers through imagine entertainment.",
+      "duration_sec": 4.956062,
+      "speech_end_offset_ms": 4956.1,
+      "audio_hash_id": "73f33fc3dbd26e6c8f8475872c33ecb0d7744281f605a818a6c5fabe19b356cb"
+    },
+    {
+      "path": "audio/0385.wav",
+      "sha256": "7f4d1e8cd1d9f12f37b34cdedb6c9381fdb3983bd94fe50e6355d463db2ff9a0",
+      "transcript": "roberts is a graduate of brentwood college school, located in mill bay, british columbia.",
+      "duration_sec": 6.588063,
+      "speech_end_offset_ms": 6588.1,
+      "audio_hash_id": "74890b754b113eb70fb63aaaa54cd1d5cea2d775f4719b1a01b359b83b288a31"
+    },
+    {
+      "path": "audio/0386.wav",
+      "sha256": "afd94077d7e787d8a5034644a92acd6f75eb00831ff54b33d2e7a55258f55510",
+      "transcript": "the music video removes eminem saying 'whatever'.",
+      "duration_sec": 2.62,
+      "speech_end_offset_ms": 2620.0,
+      "audio_hash_id": "7559000baa0cce13e2c09ba01845148fafd9e1d4463d7931a341c496db5f6252"
+    },
+    {
+      "path": "audio/0387.wav",
+      "sha256": "2579bedc5f1363788bc194c0b9983dfcb49b63538e3f22665c9627d17f057a06",
+      "transcript": "lanarkshire was historically divided between two administrative areas.",
+      "duration_sec": 4.444,
+      "speech_end_offset_ms": 4444.0,
+      "audio_hash_id": "76016e27f2adbde8ee8e3184506fade26a13a215bebdb062c09bb8bc2b953392"
+    },
+    {
+      "path": "audio/0388.wav",
+      "sha256": "c5f06050a0bbae955e36c66b04909c88816f9366ac6b051a12986fe189bf0e2b",
+      "transcript": "crystal icicles had formed around the cave.",
+      "duration_sec": 2.236063,
+      "speech_end_offset_ms": 2236.1,
+      "audio_hash_id": "76096331bcc13d77ea7f64f4459a77d6176d7b7c5125ed5399307acc9f8c9cd3"
+    },
+    {
+      "path": "audio/0389.wav",
+      "sha256": "a617e474893608b988595486f571e88c56b679d671570caa5b9ed3b5cc8c7586",
+      "transcript": "moreover, the substitute could only replace an injured player.",
+      "duration_sec": 3.836063,
+      "speech_end_offset_ms": 3836.1,
+      "audio_hash_id": "7716a59578ffba8aa8403ea8e5d791267926ef992ea5a0a48303e1211ec34e41"
+    },
+    {
+      "path": "audio/0390.wav",
+      "sha256": "9bde6cda5fb33d9f54809e649c8831a39815dbf4812732b8d5493d3c7c656f83",
+      "transcript": "but he granted the travelers three days.",
+      "duration_sec": 2.716,
+      "speech_end_offset_ms": 2716.0,
+      "audio_hash_id": "775b5d31c8d74d853d7547d235c3d657cca752f69b0c7e10c3fa7e7457dd59d5"
+    },
+    {
+      "path": "audio/0391.wav",
+      "sha256": "529e435321d797c32248fb0ee7d55ff2c2105dcf204448563ea81f5a09aaf713",
+      "transcript": "now i want to ask you fellows a couple of questions.",
+      "duration_sec": 2.486063,
+      "speech_end_offset_ms": 2486.1,
+      "audio_hash_id": "782cf32097e4a5cf29f4c8e215f432d755ac3d43c8ba901253e90d5240c2364e"
+    },
+    {
+      "path": "audio/0392.wav",
+      "sha256": "1067bfa79f8690f3a7832be9dc24cc0660d7ae45851dd1c8e8e230189be0256d",
+      "transcript": "in september, she was sent to vietnam to assist communications between naval units.",
+      "duration_sec": 4.636063,
+      "speech_end_offset_ms": 4636.1,
+      "audio_hash_id": "782ee9d74cbb2fdc3ee1e7e8778545ee8bbd970e31548186a59555e996c0eb1f"
+    },
+    {
+      "path": "audio/0393.wav",
+      "sha256": "d90d744893cb291a21f39ec7ccc30cb89e61d78a0b1f08e99a9e3e719f0b701e",
+      "transcript": "it is located at a sharp curve along the vernon river, a tidal creek.",
+      "duration_sec": 3.9,
+      "speech_end_offset_ms": 3900.0,
+      "audio_hash_id": "7890632a7839fd9cc0ff6bbe990bb61b484c96b2776e5752946acfc0e0c99abc"
+    },
+    {
+      "path": "audio/0394.wav",
+      "sha256": "3b31dfa86f5c48d8b8b33d88a0c6d9282d5af707bb39fd73d7b1f97c095364f4",
+      "transcript": "i want to tell you a story about dreams, said the alchemist.",
+      "duration_sec": 3.292063,
+      "speech_end_offset_ms": 3292.1,
+      "audio_hash_id": "78ee6d2227629a0b5237df2170b1a26893cadc5e8efb01b38dac0a69705d044b"
+    },
+    {
+      "path": "audio/0395.wav",
+      "sha256": "f56b5e8f323bc624d00fdba0cd9980eadb83c70d5d46b60299ecad706e25ae69",
+      "transcript": "it is most common in the tropics, especially among pregnant women.",
+      "duration_sec": 3.996,
+      "speech_end_offset_ms": 3996.0,
+      "audio_hash_id": "796150c5d69479fbe37b51a969a266a3f88bb6f12426854fdcc3c6d6fa8107a1"
+    },
+    {
+      "path": "audio/0396.wav",
+      "sha256": "2731176c8abd44d19478ef5cde6fdb1a5b8314739b69bdc809dbb1c8e1ee6110",
+      "transcript": "he played two seasons before retiring as a player.",
+      "duration_sec": 2.972,
+      "speech_end_offset_ms": 2972.0,
+      "audio_hash_id": "79a179c0d80c3ff1b35e4b13a1ccc1d6a4fcc7498a7505ab96a5da80ad199712"
+    },
+    {
+      "path": "audio/0397.wav",
+      "sha256": "99bfa4402ea5732541d0a2e9f6f29dfbb364e3ca2b2bfce38aec1969ceb67006",
+      "transcript": "it works at the butterley park miniature railway, part of the swanwick junction complex.",
+      "duration_sec": 4.604,
+      "speech_end_offset_ms": 4604.0,
+      "audio_hash_id": "79cd8231e46959cdb7016ebb181b0a3050f5f06d7153631f8e6350ec280fa3fb"
+    },
+    {
+      "path": "audio/0398.wav",
+      "sha256": "10d2ae0ebf628fb4a3067c74838dd07d8439e0a327048b2057b4fc5a7f3e47e9",
+      "transcript": "the two spend their last year living life to the fullest.",
+      "duration_sec": 3.868063,
+      "speech_end_offset_ms": 3868.1,
+      "audio_hash_id": "79d8fa7bca1ad9a8cd25eeb7135829ee46c87d673559368e6c7d914497c431da"
+    },
+    {
+      "path": "audio/0399.wav",
+      "sha256": "2ddd8d2fcbe5765a81af4b6a67fd5a17776d68b81d4e910cde9117994b745764",
+      "transcript": "well, then, why do we need all these books? the boy asked.",
+      "duration_sec": 3.58,
+      "speech_end_offset_ms": 3580.0,
+      "audio_hash_id": "7a3e18938bb7872053cc35f830aacad4c905b05a93a51bd3d202396de5b0563b"
+    },
+    {
+      "path": "audio/0400.wav",
+      "sha256": "9735c293afdd6e2c32f998281ee4a3c1d32cdc41ef476ce855be3343f69c0655",
+      "transcript": "it uses very aggressive pruning, leading to imbalanced search trees.",
+      "duration_sec": 4.444063,
+      "speech_end_offset_ms": 4444.1,
+      "audio_hash_id": "7a444cd185f665c3c72aad426b5a79b54fa24c52650fb35470fcdeef2513e8b6"
+    },
+    {
+      "path": "audio/0401.wav",
+      "sha256": "18ddf5a0fd11c3b698dd849f7d3d68dc8039f6c8eb3596302767cf4522aed157",
+      "transcript": "henrys lake is a popular destination for sport fishing.",
+      "duration_sec": 2.684,
+      "speech_end_offset_ms": 2684.0,
+      "audio_hash_id": "7aa8205ace686e01deb6371c25542ea07151be7662d542c113737b67a649637b"
+    },
+    {
+      "path": "audio/0402.wav",
+      "sha256": "093fe79e028360df8d55c202ac61bab0c630be592db5590fbed54184e24c17f0",
+      "transcript": "they are made using several different shapes and sizes.",
+      "duration_sec": 3.1,
+      "speech_end_offset_ms": 3100.0,
+      "audio_hash_id": "7b1b40c3ac80e8a7c45e53841f03682e611559635d43c26be9d33a9f34de6f36"
+    },
+    {
+      "path": "audio/0403.wav",
+      "sha256": "b6ce7782406680bbc3418968ea45d14f58eda990862eee5334491948102bbea7",
+      "transcript": "barron has referred to the bible as the greatest horror story ever told.",
+      "duration_sec": 3.676,
+      "speech_end_offset_ms": 3676.0,
+      "audio_hash_id": "7b6cde1f540f1c394a20fb653d0b7f9b3bf957419d19e50121406599dbb732a1"
+    },
+    {
+      "path": "audio/0404.wav",
+      "sha256": "18c20afc0e6366a07e55b6f4824488e7062f1c7223c9fb85bfc1b9bc5674d62a",
+      "transcript": "to the north was another siding which served black rock and nightingale quarries.",
+      "duration_sec": 5.564063,
+      "speech_end_offset_ms": 5564.1,
+      "audio_hash_id": "7b8a289c07e1ef160f55dc65547b0cba0eb14ade4429cbbc83f9be23d4ed5690"
+    },
+    {
+      "path": "audio/0405.wav",
+      "sha256": "5cb3e67a35ef080a973f0699c19c56238d98bf8b4a06d62d8bbf245c612500bd",
+      "transcript": "he is also a director of imanova limited, an imaging company.",
+      "duration_sec": 3.74,
+      "speech_end_offset_ms": 3740.0,
+      "audio_hash_id": "7c2ecd6278df7a67a91437be981318c40b8f565f3f1c3414108638e30ecd77a8"
+    },
+    {
+      "path": "audio/0406.wav",
+      "sha256": "ebd7549f1104d92e253b73f51d804320768665fab0a9d25bc74e474d545dfe21",
+      "transcript": "they have a higher right than ours.",
+      "duration_sec": 2.236063,
+      "speech_end_offset_ms": 2236.1,
+      "audio_hash_id": "7c52cdf9687986473be701ad66b79f64947ba5e398c0aef00763b0372dd393d7"
+    },
+    {
+      "path": "audio/0407.wav",
+      "sha256": "57c8eaeea6470938a85f21fdb5dc13d902b6bde907e8ad14788fb74a3dcbe469",
+      "transcript": "both statements were condemned by armenian prime minister nikol pashinyan.",
+      "duration_sec": 5.34,
+      "speech_end_offset_ms": 5340.0,
+      "audio_hash_id": "7c72648120e648f8bfc01c486ad6724ca636c6541cca55fb24cdd2c150582fe0"
+    },
+    {
+      "path": "audio/0408.wav",
+      "sha256": "08161ca691a1e1017599b199901588d3be6ea688fda70693f3e227a04e1cba19",
+      "transcript": "there is a quite large arab community on the island, who immigrated from oman.",
+      "duration_sec": 4.22,
+      "speech_end_offset_ms": 4220.0,
+      "audio_hash_id": "7c8bc3b120f8854fa7fd30eb8231488004e113a0dd622743ebe3e2df045d9592"
+    },
+    {
+      "path": "audio/0409.wav",
+      "sha256": "5a9a7af3a703672066b329dd8a62d1f356a2e031e0ed313a5d7241022a11f435",
+      "transcript": "separation of garbage makes recycling possible.",
+      "duration_sec": 2.652,
+      "speech_end_offset_ms": 2652.0,
+      "audio_hash_id": "7c91d7a2ec1795ec2fe87fb4306e21c4968216fe121aca8ee8f8905b5a2738af"
+    },
+    {
+      "path": "audio/0410.wav",
+      "sha256": "1909e59e51d67f78f384db8f94b8ffbf6d782c5813731fa807c3d676551f6341",
+      "transcript": "it was quite a joke in the hotel.",
+      "duration_sec": 2.364,
+      "speech_end_offset_ms": 2364.0,
+      "audio_hash_id": "7ca27cad0eec6680683566de0f6a62a404b8a225341b5f924c027da0924db3f6"
+    },
+    {
+      "path": "audio/0411.wav",
+      "sha256": "1f732a97c80fea5230beb5e2b6d7450af5932e0db1b8346b7ecfa70f8778720c",
+      "transcript": "much of the masonry was reused at the king's nonsuch palace.",
+      "duration_sec": 3.708063,
+      "speech_end_offset_ms": 3708.1,
+      "audio_hash_id": "7ca8bdbf91af964c04ab8e66761f87d3196a65099199d22162543e19f24485a1"
+    },
+    {
+      "path": "audio/0412.wav",
+      "sha256": "9b29a624950c61184431cd60f204eb23a645536011eadde482f952095c5534c8",
+      "transcript": "this collapse formed a depression which then filled with lava flows.",
+      "duration_sec": 3.868063,
+      "speech_end_offset_ms": 3868.1,
+      "audio_hash_id": "7cdc8034c1763af68c9c92bf893d8fa89148293df2830d211cb81cf329bd3b7d"
+    },
+    {
+      "path": "audio/0413.wav",
+      "sha256": "b4af057f41817ef3ab06fdf797d944b2df4be9b31b373a7ee4968e2bcd9f5968",
+      "transcript": "regular elections take place in odd years.",
+      "duration_sec": 2.812,
+      "speech_end_offset_ms": 2812.0,
+      "audio_hash_id": "7d526a561b2d5471018c2e8c7c866f7327e1aeada27129aa9d3d94bf73b79c11"
+    },
+    {
+      "path": "audio/0414.wav",
+      "sha256": "ebd40755465569cd7549d8b8903deabd1b94a0202c2d95a816615f5ca61c4459",
+      "transcript": "a dichotomy of musical styling was featured in the album's songs.",
+      "duration_sec": 3.836063,
+      "speech_end_offset_ms": 3836.1,
+      "audio_hash_id": "7d6cfaf87451bc237b696926b9d077b9b75cc97040a2ec3608b9538d74106d25"
+    },
+    {
+      "path": "audio/0415.wav",
+      "sha256": "e4373eef95282952543ac9dfad9e41784e21e7495b51e564c6a670a17bdf755a",
+      "transcript": "then beal starts his match with chip reese.",
+      "duration_sec": 2.716063,
+      "speech_end_offset_ms": 2716.1,
+      "audio_hash_id": "7dd73977c62997b50c6a0cbda01a0229c33e4ced5e13f63c89840083f9f1b7bb"
+    },
+    {
+      "path": "audio/0416.wav",
+      "sha256": "710ee91141b4bba8a544f719cf89ec45281a4c02ec333ecd27e69cc98e3e1542",
+      "transcript": "critics argue that it will bolster and strengthen the violent buddhist groups.",
+      "duration_sec": 3.964,
+      "speech_end_offset_ms": 3964.0,
+      "audio_hash_id": "7ddc9bf4c99464d045dd9d0dea096f951431bf81bfb487347ffb9a950132b027"
+    },
+    {
+      "path": "audio/0417.wav",
+      "sha256": "1e1c76d2d643006896f94dcb269f67ce93482ed436086b93504b79c0ffbacc93",
+      "transcript": "he has a particular interest in the brazilian portuguese and spanish languages.",
+      "duration_sec": 4.444063,
+      "speech_end_offset_ms": 4444.1,
+      "audio_hash_id": "7e899966a4d8d0ef1373f419b39d41c1d36b2148c4a4d3d32547e2c0771f040c"
+    },
+    {
+      "path": "audio/0418.wav",
+      "sha256": "977fc01b160b59335223bd5ca2d8aab3ccb17c2c859dfc5d753f54eaf7d97ffd",
+      "transcript": "i was surprised to see heathcliff there also.",
+      "duration_sec": 2.556,
+      "speech_end_offset_ms": 2556.0,
+      "audio_hash_id": "7e900c561911dd658e79144e955ecd0cb1980a4212b8cda82d536265a01c3850"
+    },
+    {
+      "path": "audio/0419.wav",
+      "sha256": "c15892f2b2006b17acb7361a70fe58bc3cd4cc1812934092bd948bd0b2dcdb9c",
+      "transcript": "it was developed by computer's dream and published by ubisoft.",
+      "duration_sec": 3.836063,
+      "speech_end_offset_ms": 3836.1,
+      "audio_hash_id": "7f5a8284a6aed3d1ed24e2917e8f1233bb5dad1571597a55ae19c7e9fb0198be"
+    },
+    {
+      "path": "audio/0420.wav",
+      "sha256": "7b81aa23a603f2696f58b3038e1da9fbfd3770365ef6d9ec62a64d5fc1451fce",
+      "transcript": "one of his advisors, the novelist macdonald harris, sent it to his literary agent.",
+      "duration_sec": 5.308,
+      "speech_end_offset_ms": 5308.0,
+      "audio_hash_id": "8052edf3c6805aca93977f618cd0bd4f8263a8877e783d4a14936a612e5fa6a3"
+    },
+    {
+      "path": "audio/0421.wav",
+      "sha256": "e40edca9aa61a73da92864ca2cacd66fe17d6ed74279c2264a125288ebbb89cc",
+      "transcript": "most of the articles are signed with the initials of the author.",
+      "duration_sec": 3.772063,
+      "speech_end_offset_ms": 3772.1,
+      "audio_hash_id": "81092046e9411c76b9347b7fe20a5d402eea012109547634c59e5b8e4168a8d8"
+    },
+    {
+      "path": "audio/0422.wav",
+      "sha256": "f4b42f78308379008e33298210f22610b68cd15bef9b5aed9817c9c8f6d8ec26",
+      "transcript": "she can't survive a day without having a kebab.",
+      "duration_sec": 2.396,
+      "speech_end_offset_ms": 2396.0,
+      "audio_hash_id": "8133ecd9781101fb5644a01da2e68c97e9b56c2ac131ce024b6ddfa669dfdf4a"
+    },
+    {
+      "path": "audio/0423.wav",
+      "sha256": "f3070a376bc6f47d97839441036d683756909f3cd59ca98874aadea1d56c5dc7",
+      "transcript": "the uniform was not used in many games.",
+      "duration_sec": 2.076,
+      "speech_end_offset_ms": 2076.0,
+      "audio_hash_id": "81605fbba4db950197c481a8d17ea645ccde651ba022d98f847720f94b6c835b"
+    },
+    {
+      "path": "audio/0424.wav",
+      "sha256": "0b2fa443d8afe5b89817b35c0e67e4ce0ff699840672f5b0e7eb34b199d29ebc",
+      "transcript": "surely when you explain the circumstances of our untimely call she'll understand.",
+      "duration_sec": 3.932062,
+      "speech_end_offset_ms": 3932.1,
+      "audio_hash_id": "824f896f743188bbd7b6462675567856ba89a4bf03a2a97b427938adab8efeb1"
+    },
+    {
+      "path": "audio/0425.wav",
+      "sha256": "e5a4073dfa692b63d1c3d21d382bf3181b0454e6b59f338432ce3f9f48d1a8d1",
+      "transcript": "bradshaw with the stipulation that the railroad build a depot on the property.",
+      "duration_sec": 4.412,
+      "speech_end_offset_ms": 4412.0,
+      "audio_hash_id": "82b92ba8226645a6d104bb114d428ae7b1e0d0e5984ad19286079916014aeb54"
+    },
+    {
+      "path": "audio/0426.wav",
+      "sha256": "8fbf0580c284b0662a1c36dfd4928510b7bd364740f4ab489a26a2daaec54f1a",
+      "transcript": "the shop folks were taking down their shutters, and people were opening their bedroom windows.",
+      "duration_sec": 4.412063,
+      "speech_end_offset_ms": 4412.1,
+      "audio_hash_id": "839e39b72fa603a09dd8673552521afb73c5b1ebf1791160f7513167f03d9a72"
+    },
+    {
+      "path": "audio/0427.wav",
+      "sha256": "a26a76786fdccb8851ab34f7eb29dbd06c67d3fca78726ec0805416d21aaa7c4",
+      "transcript": "a similar game is roadkill bingo.",
+      "duration_sec": 3.068062,
+      "speech_end_offset_ms": 3068.1,
+      "audio_hash_id": "83a19e481b304a4f8b2302a46570cc8bdb8a3cc5839c3dddfb1f48732093353a"
+    },
+    {
+      "path": "audio/0428.wav",
+      "sha256": "867f567945250e8e3e075c01c9a1774d15089cf56cd2eb3deb7f3a98ec0fe6f5",
+      "transcript": "among other activities, freedomworks runs boot camps for supporters of republican candidates.",
+      "duration_sec": 6.972062,
+      "speech_end_offset_ms": 6972.1,
+      "audio_hash_id": "841b6814825762466873782bc900f0e0218ba1a67c9580be9b609388ed31067e"
+    },
+    {
+      "path": "audio/0429.wav",
+      "sha256": "338fe5e067d9d197fbbc76a9f9bddfe0e50db3beacd3c55ee7f62c2e8525dfee",
+      "transcript": "he was buried at mount pleasant cemetery, newark.",
+      "duration_sec": 3.004,
+      "speech_end_offset_ms": 3004.0,
+      "audio_hash_id": "8428e898b6b8994e8ae040fa43236dcd03abcb5d88b4879e1e1cf72264f2a05c"
+    },
+    {
+      "path": "audio/0430.wav",
+      "sha256": "0a083ddc6c6d0560f641d8150212c1e069c9aaef221d257b2917125d1797169e",
+      "transcript": "take this pill twice daily, once in the morning and once at bedtime.",
+      "duration_sec": 3.324,
+      "speech_end_offset_ms": 3324.0,
+      "audio_hash_id": "84cc215e6d4487de0fd3551f733ae045606fa8ee4ea32b3cf7a1132e096167d9"
+    },
+    {
+      "path": "audio/0431.wav",
+      "sha256": "6143a0ddbbf9034a5609c02e2e6df777b6fd9ea2df1a11817766a8596f8a7d70",
+      "transcript": "the twelve teams were divided into four pools of three.",
+      "duration_sec": 2.812,
+      "speech_end_offset_ms": 2812.0,
+      "audio_hash_id": "84e0f09960b7a53aae3d1c3fd116b89289fc2ae9ac8eedb5d9a4619e58623d16"
+    },
+    {
+      "path": "audio/0432.wav",
+      "sha256": "67c3f94dc0ffe6dbf8a3df380a57744315a6854a417bf0da92f606aafc4e69c3",
+      "transcript": "toward the end of june the new georgia campaign began.",
+      "duration_sec": 3.388063,
+      "speech_end_offset_ms": 3388.1,
+      "audio_hash_id": "84f6a3162336e5ed882277b837de000525bf1bc6ad733f3fb741996b7e9c9288"
+    },
+    {
+      "path": "audio/0433.wav",
+      "sha256": "0ff643367dec6f9e620f9dcc9062beba4f428cf77a80eccee1111ec2eeb82fde",
+      "transcript": "the tape runs to the take-up reel of a second machine.",
+      "duration_sec": 2.748063,
+      "speech_end_offset_ms": 2748.1,
+      "audio_hash_id": "852e451cf38eafd319dcfbc40dc370dd1e21fc199eb55c95abef6a41618bc763"
+    },
+    {
+      "path": "audio/0434.wav",
+      "sha256": "f5f995923c570bed09b0e73b07d2cd6b0ad000a7f5af0fc12590e3f6138942c7",
+      "transcript": "sponsors were commonly associated with the community for which the ship was named.",
+      "duration_sec": 4.156062,
+      "speech_end_offset_ms": 4156.1,
+      "audio_hash_id": "863241162ad203c793a714c54eb2645c8bddc6ae1bf1101732d95e552ed9e568"
+    },
+    {
+      "path": "audio/0435.wav",
+      "sha256": "70ba738f3815f86334acd2781e64b6bc4033e5a9de68ffe324d81b8df08a971c",
+      "transcript": "this is the only stadium in india where students gallery is available.",
+      "duration_sec": 3.996,
+      "speech_end_offset_ms": 3996.0,
+      "audio_hash_id": "86a42dff7b0b59128894f5ad2ad78c56e5c9ed972e36a3b1612ae8297cde242c"
+    },
+    {
+      "path": "audio/0436.wav",
+      "sha256": "73989d5ce483024823e7f3c011d80e0ae52ee0cbff719c53902074372833bac5",
+      "transcript": "longden was a member of the church of jesus christ of latter-day saints.",
+      "duration_sec": 3.516,
+      "speech_end_offset_ms": 3516.0,
+      "audio_hash_id": "8741ff262429e777295c31083d6ae6576b7c1d12618c0c26d6cfdf7553a0bc7e"
+    },
+    {
+      "path": "audio/0437.wav",
+      "sha256": "e627a63bd506d7fc9b5f7419afbf17d9bfc19513ebf259105ee05a4aee8c45de",
+      "transcript": "she is the first person of indian descent to serve in this position.",
+      "duration_sec": 3.388063,
+      "speech_end_offset_ms": 3388.1,
+      "audio_hash_id": "875a428a45ae3a62967595ab12465901aa8bf0ad16d2858235c057744b8d5b1a"
+    },
+    {
+      "path": "audio/0438.wav",
+      "sha256": "6f57e8bd70ffc9fb0fa86e048f15d8fabf59fd9d7d35f084d6bc4540c4bdcadb",
+      "transcript": "there's a caravan leaving today for al-fayoum.",
+      "duration_sec": 3.004062,
+      "speech_end_offset_ms": 3004.1,
+      "audio_hash_id": "877d68021eb366e6665a315c90a7e7525e65b21144e3216cf54017785276c8eb"
+    },
+    {
+      "path": "audio/0439.wav",
+      "sha256": "c26ac8f4efaa591a13d516a1c9976db4349475b0f7097d1c59be419a1821c1f9",
+      "transcript": "a later latin form is herveus.",
+      "duration_sec": 2.812,
+      "speech_end_offset_ms": 2812.0,
+      "audio_hash_id": "877eb9bb93438984b023560af4e7fd71d25e0ba9baeb6deedfa4755e693f2278"
+    },
+    {
+      "path": "audio/0440.wav",
+      "sha256": "19661587d2539d65ebb48865dc83986aa6e67661ed75fcc291eeac7b2d7c8cc0",
+      "transcript": "it is an institute of public character.",
+      "duration_sec": 2.876063,
+      "speech_end_offset_ms": 2876.1,
+      "audio_hash_id": "87d6bbce1154a26308be83123a77c18eb81673fbcc0defdd56f86c551d933c4d"
+    },
+    {
+      "path": "audio/0441.wav",
+      "sha256": "f618f107be3215ea1445fca006d560678db57a000d99e8f2d2206435d4190f95",
+      "transcript": "milton's father was a descendant from slaves, which gave santos motivation to study.",
+      "duration_sec": 4.028062,
+      "speech_end_offset_ms": 4028.1,
+      "audio_hash_id": "8811967bf702aef3d0a00428339b8a54a717ef47697058cf237da0a59eeab245"
+    },
+    {
+      "path": "audio/0442.wav",
+      "sha256": "f7fd674b58685484d047560c7067ffaf1eda7240fab818bc08368315bdf1adcd",
+      "transcript": "ogilvy told him everything that he had seen.",
+      "duration_sec": 2.428,
+      "speech_end_offset_ms": 2428.0,
+      "audio_hash_id": "883567137aa02b6952d36a2dd7356871be77fd98add68b35fbe60c69903b1eed"
+    },
+    {
+      "path": "audio/0443.wav",
+      "sha256": "657d08aad9e145c3f5c93221e1b6d1fa84366319b997bb3e260012007f7baae5",
+      "transcript": "along the asia beach there are hotels, resorts, and upscale homes, even mansions.",
+      "duration_sec": 5.372,
+      "speech_end_offset_ms": 5372.0,
+      "audio_hash_id": "886ce5c3db20e43c6215394e47cec2fb10ba4e780f7c31148ea022824ddd9b16"
+    },
+    {
+      "path": "audio/0444.wav",
+      "sha256": "54b1e3473ffe8d64b2acc41e71001e48e2db5d7a6eaca36f5c66e18c98e522ad",
+      "transcript": "it consisted of the counties of hants and kings.",
+      "duration_sec": 3.068,
+      "speech_end_offset_ms": 3068.0,
+      "audio_hash_id": "8875ab8915746af9952aa20e15a19e03577e8736aa6eb91991deac1a8b2dc176"
+    },
+    {
+      "path": "audio/0445.wav",
+      "sha256": "829f429f624165021beff66ba2344229a216622e64fab4e7cfa4da6db27986b2",
+      "transcript": "addiction to cigarettes can be beaten with help.",
+      "duration_sec": 2.492,
+      "speech_end_offset_ms": 2492.0,
+      "audio_hash_id": "88cea4e32564ae0750c217a80806ad60d04455d1567955f2d3081c5619202818"
+    },
+    {
+      "path": "audio/0446.wav",
+      "sha256": "e9ac95975b3e85fadb5e009612163190b0c5bf98ef9c8f533687efd6d1249cf9",
+      "transcript": "even the worst will beat his low score.",
+      "duration_sec": 2.62,
+      "speech_end_offset_ms": 2620.0,
+      "audio_hash_id": "8917758241cd7aeee401ab6657e9a9c1ee91643007d807f1badc7364d21a98cd"
+    },
+    {
+      "path": "audio/0447.wav",
+      "sha256": "1fe5553b17dfa4d7d1c8817c9238819fd31f8df2276c074722d2bfdbb21c424d",
+      "transcript": "it is known as the largest land transaction in history.",
+      "duration_sec": 3.932,
+      "speech_end_offset_ms": 3932.0,
+      "audio_hash_id": "894e96315a767a4aaf4716755708678cdf826f8de800d7587c3867fa8ab149ba"
+    },
+    {
+      "path": "audio/0448.wav",
+      "sha256": "9abecc7fe8de991119b9a05657e0ff822c0ff92e8e0da4dd6d5a91e6b9d08d31",
+      "transcript": "this is one of the categories with different stages of nominating.",
+      "duration_sec": 3.324,
+      "speech_end_offset_ms": 3324.0,
+      "audio_hash_id": "899f9173573cf6cb2208248000cd2466d24dae38eb95042cf866f3590a8e5404"
+    },
+    {
+      "path": "audio/0449.wav",
+      "sha256": "a72176989f52b5a003c6a65bf8640cd5f6232e5b65d8baedc3ebfafd0c795be7",
+      "transcript": "after going undrafted bolton signed with the green bay packers.",
+      "duration_sec": 4.188063,
+      "speech_end_offset_ms": 4188.1,
+      "audio_hash_id": "8a4db92c3ce5d956e88aee42af4ee4b57e9f05407bc65d8804ddb17ec45e9cf8"
+    },
+    {
+      "path": "audio/0450.wav",
+      "sha256": "4a9eacfb3b97fb452362708eaa7b1b77dc825c42a8101a920e9d596b93df1fe8",
+      "transcript": "it offers him cryptic advice on his love life throughout the movie.",
+      "duration_sec": 3.676063,
+      "speech_end_offset_ms": 3676.1,
+      "audio_hash_id": "8a74fbc40fc0195aa531ce1b551a025bc801dc0a8ca5089c3b59679eae75e352"
+    },
+    {
+      "path": "audio/0451.wav",
+      "sha256": "5b3247ae057c8b02781fecc64f9957b6b879e5c2a23220d4045917a991da98c5",
+      "transcript": "surveys from law enforcement training programs reveal that some instructors were prejudiced and unprofessional.",
+      "duration_sec": 6.524,
+      "speech_end_offset_ms": 6524.0,
+      "audio_hash_id": "8ac1936b1cdde8805942248252d46338c07e26ed8bf28ce0d8bb89f5aa8ca87a"
+    },
+    {
+      "path": "audio/0452.wav",
+      "sha256": "e44991498c14605de0c7143cc5a4078eedc60baba60e146f20a9b191dcac2569",
+      "transcript": "bigger pieces can be placed so that they cover smaller ones.",
+      "duration_sec": 3.708063,
+      "speech_end_offset_ms": 3708.1,
+      "audio_hash_id": "8b5d421613ac72911b2ccfa5809b758a01a65a22aa5fc0ad7e7e1cd7f2ea52b7"
+    },
+    {
+      "path": "audio/0453.wav",
+      "sha256": "3bf5ba76ee374cc09f34918e62defce640af8ea38e85b027abcef8c5fff86781",
+      "transcript": "it was named for its location on the columbia river.",
+      "duration_sec": 2.684063,
+      "speech_end_offset_ms": 2684.1,
+      "audio_hash_id": "8b866b63d37803fe0f974cecf64d845c51f757e10f8ffa925441387120a32357"
+    },
+    {
+      "path": "audio/0454.wav",
+      "sha256": "e4c5d53b11b37e94934d02b2250a3bb61f69e30a387e13295946a410d3564d57",
+      "transcript": "logan sama also had a show that ran for three months on the station.",
+      "duration_sec": 3.836,
+      "speech_end_offset_ms": 3836.0,
+      "audio_hash_id": "8bb9dd0e995372ebcf577e47cb8492b58a2763bc2b2d35e03efe4834b95e999e"
+    },
+    {
+      "path": "audio/0455.wav",
+      "sha256": "f28823ec1daf40c39ff6903215dfe005b258a5e59efc9010005fcf4eef41d59c",
+      "transcript": "mandan shares a print, radio, and television media market with nearby bismarck.",
+      "duration_sec": 6.14,
+      "speech_end_offset_ms": 6140.0,
+      "audio_hash_id": "8c49632c8a8a40cd8cc03dcb6f90534b213f8c8064d2108584b80b5541fe59cb"
+    },
+    {
+      "path": "audio/0456.wav",
+      "sha256": "4f7a94e8c1310159249c2d0d61cae790c9d01c8366228f7f6aa90c5acb8bd485",
+      "transcript": "when is the usual monsoon period in bangladesh?",
+      "duration_sec": 2.812,
+      "speech_end_offset_ms": 2812.0,
+      "audio_hash_id": "8c50c85c96a34e4ad98d91a1a44dbc952a6cbe5662f897d0abdeacd9c62ca2da"
+    },
+    {
+      "path": "audio/0457.wav",
+      "sha256": "c94f8a74d4926572bfec763a3328d91b06154b4f4da9788dca37f6000be6e004",
+      "transcript": "no, you cannot have that lollipop.",
+      "duration_sec": 2.652062,
+      "speech_end_offset_ms": 2652.1,
+      "audio_hash_id": "8ca3bef56162e16bccd097e31bc0388b540498ce3b78a36c65120b73a9783731"
+    },
+    {
+      "path": "audio/0458.wav",
+      "sha256": "9cac6eb65c75090239af1a5df78703efb6a89872ba78504f229fbce2517fd916",
+      "transcript": "the ranger took his rifle and went into the forest to shoot the bear.",
+      "duration_sec": 3.964,
+      "speech_end_offset_ms": 3964.0,
+      "audio_hash_id": "8d19aa7bf95a94a5ac96001745eac0b7bdc604c4aecdc2b8c0d0fab755b83d2d"
+    },
+    {
+      "path": "audio/0459.wav",
+      "sha256": "7e4e0eda961560102ccd310d63236902c6a363531f42cea541cde06dce99104e",
+      "transcript": "he decided to concentrate on more practical matters.",
+      "duration_sec": 2.748063,
+      "speech_end_offset_ms": 2748.1,
+      "audio_hash_id": "8dbda979d48c12c211d861e051358f6ef0d615e3b68a0d4de634f446e66379a0"
+    },
+    {
+      "path": "audio/0460.wav",
+      "sha256": "b1dd3e65ec9d1f28d977393d634c31e9ccd746c96b98f221ed90deadc58361ef",
+      "transcript": "however, there is no concrete proof in this regard.",
+      "duration_sec": 3.9,
+      "speech_end_offset_ms": 3900.0,
+      "audio_hash_id": "8e90d5e9dbec59b3690448d7dee179627e032cfa75a35f3776f61e216a91afaa"
+    },
+    {
+      "path": "audio/0461.wav",
+      "sha256": "3b64a4b29976c92576a62b9bbd3da2bcecaa414b5c29fb5d9e2735e776edc9fb",
+      "transcript": "since then, marsh has attempted to enter politics, first for the labour party.",
+      "duration_sec": 4.828062,
+      "speech_end_offset_ms": 4828.1,
+      "audio_hash_id": "8eb5e1c7a5db97a720128c93fe2ea4b42725740ac32b664c3fb26159c2f551bb"
+    },
+    {
+      "path": "audio/0462.wav",
+      "sha256": "025947e25c02c245f707ff21994f04f568b0ec894296fe1245408e45aeae83fd",
+      "transcript": "it was originally published by jasc software.",
+      "duration_sec": 2.876063,
+      "speech_end_offset_ms": 2876.1,
+      "audio_hash_id": "8f0a29036cc28105087117a5fb9698815ec2558fa69daa0b3c704f52c0a0bdbe"
+    },
+    {
+      "path": "audio/0463.wav",
+      "sha256": "a96395d63df26988390ec36d015b194a7edc0a62c489b4ee85519a4fccd2e79e",
+      "transcript": "the boy smiled, and continued digging.",
+      "duration_sec": 2.012,
+      "speech_end_offset_ms": 2012.0,
+      "audio_hash_id": "8f4b97490ffaee7e777bc50d59ae68af2cb63e2847dc8bd38f5e62cc3d37eb8f"
+    },
+    {
+      "path": "audio/0464.wav",
+      "sha256": "d017688587e4cf7e0ac65fc67bef4b14a72e9358a0d4009a17486d23e05970d0",
+      "transcript": "the delegates blamed the whites for the chief's death.",
+      "duration_sec": 3.452,
+      "speech_end_offset_ms": 3452.0,
+      "audio_hash_id": "8f776768a2019fb400e74a7d7aad201b2c2955998d39e89957806ec1c1736a70"
+    },
+    {
+      "path": "audio/0465.wav",
+      "sha256": "b07392ceb4a242a27d7fd811414e8ca5a33f1ad8d4364fca1178dc1729276c4f",
+      "transcript": "it would have been visible to me, had i only looked up as it passed.",
+      "duration_sec": 3.358062,
+      "speech_end_offset_ms": 3358.1,
+      "audio_hash_id": "8fb62ef72824f8806f4b937c30f28eacf60adb052ba9417e365082d89bb6c875"
+    },
+    {
+      "path": "audio/0466.wav",
+      "sha256": "a18d7c98265851181211fc0838d4e869a80557f7d6fef4a62a5c15033a659d0b",
+      "transcript": "the stranger was speaking of things that very few people knew about.",
+      "duration_sec": 3.228,
+      "speech_end_offset_ms": 3228.0,
+      "audio_hash_id": "90a331ad27e8cc10ba4ded500cf383abadf64a5245c2413c35aae73f583632b4"
+    },
+    {
+      "path": "audio/0467.wav",
+      "sha256": "910ab3cba2d5f8756db8c52a4a80a3ed1b95e00717cbc0c326ac978f1fc9168a",
+      "transcript": "after consultation, the community is largely supportive of recommended new location.",
+      "duration_sec": 7.164062,
+      "speech_end_offset_ms": 7164.1,
+      "audio_hash_id": "90b8654caded88868acf3f7fc4b7c0ea84b76e5332a9a7af2c9fa2a5cc282898"
+    },
+    {
+      "path": "audio/0468.wav",
+      "sha256": "e9226e0834b5a578b066978e2b99b2ea19dd99db1cd67faae3a5b33084b80767",
+      "transcript": "its native range is southern tropical america.",
+      "duration_sec": 2.908,
+      "speech_end_offset_ms": 2908.0,
+      "audio_hash_id": "90c5e4646b5630c2d62370ed430f524e5465ab991703cff95949f61536d108b8"
+    },
+    {
+      "path": "audio/0469.wav",
+      "sha256": "8bae9cf6ec55d12a5321dec0c4c0ace01c3ab66cbe3c11314ef72aff7466dbb1",
+      "transcript": "once to the thief, and once to the general.",
+      "duration_sec": 2.844,
+      "speech_end_offset_ms": 2844.0,
+      "audio_hash_id": "913ed61db2aae6ae4d8a71ea0255519e03426c8e6076a6e2b4ed0b7214e25860"
+    },
+    {
+      "path": "audio/0470.wav",
+      "sha256": "10ff439e175d311c3993766bf5f9569aa3b9bbba569c1d6271ecf2d89ef7145e",
+      "transcript": "there were many american patriots that lived in this area.",
+      "duration_sec": 4.092,
+      "speech_end_offset_ms": 4092.0,
+      "audio_hash_id": "927fe2a46a6634ade8069f91656006591713babd35c319c5e7475b76091dd115"
+    },
+    {
+      "path": "audio/0471.wav",
+      "sha256": "53fc80d487374f8de2bdfb098a5a3ab4e210ae3802beb7ea935d587c69d23d59",
+      "transcript": "also there was a decrease in trade interest between east and west.",
+      "duration_sec": 3.164062,
+      "speech_end_offset_ms": 3164.1,
+      "audio_hash_id": "92e72ebc764bd2d7f54a9969ca5eb5a194c3d7f3dbe1a242ed64e98756c3b3f2"
+    },
+    {
+      "path": "audio/0472.wav",
+      "sha256": "27877a93ec9ceb2c149bf73c0bf3167b6166df5053f404c6aedfde4f6fd19cea",
+      "transcript": "this variable is set to indicate the present time.",
+      "duration_sec": 2.844,
+      "speech_end_offset_ms": 2844.0,
+      "audio_hash_id": "9345590b1f368be12ab2b7f8af801af5fa0f148617e7fb939d2031353ffc86db"
+    },
+    {
+      "path": "audio/0473.wav",
+      "sha256": "c6627d9c797efba1c54cfbfbd4679b713f57b60f3940be716ec46e7c7d7c1a73",
+      "transcript": "eight americans and two filipinos were killed.",
+      "duration_sec": 2.396,
+      "speech_end_offset_ms": 2396.0,
+      "audio_hash_id": "9355fb61b18033aa023f3b664d0c885cd2ce92ee5dbaff7fd62cbea98240cfb6"
+    },
+    {
+      "path": "audio/0474.wav",
+      "sha256": "a9b969381a44eed43a4826ec3d6f0cd1f49f18e938fc653d174aee603db61f2f",
+      "transcript": "a man wearing jeans with a belt and glasses with brown hair scratching his head",
+      "duration_sec": 5.422063,
+      "speech_end_offset_ms": 5422.1,
+      "audio_hash_id": "938115021b7114c730032fc04ac7e2c04579ffa457561b244892696c6d276d16"
+    },
+    {
+      "path": "audio/0475.wav",
+      "sha256": "e1b21d0516a6d2d8e8320c05130b083a03a48e8299d6c069f0862312a2beb4eb",
+      "transcript": "the tribal chieftain called for the boy, and presented him with fifty pieces of gold.",
+      "duration_sec": 3.996062,
+      "speech_end_offset_ms": 3996.1,
+      "audio_hash_id": "9418ee0cd533ab58ba954e142fec0e8345b9ddec29be0753435aa67b6cb6603b"
+    },
+    {
+      "path": "audio/0476.wav",
+      "sha256": "21d1a9ae25b6ccf77207270dedd40db9eb4193f610289ec46f22f4800db52862",
+      "transcript": "families turned their houses into shops providing refreshments and farmers sold milk.",
+      "duration_sec": 4.988062,
+      "speech_end_offset_ms": 4988.1,
+      "audio_hash_id": "941f250ee972933e374dd929ce50460b395fabcfd00a900ce71392d1f550002b"
+    },
+    {
+      "path": "audio/0477.wav",
+      "sha256": "5c2250ce878765922ac186ae78f8aaab2367fb3f782bf4d6fd1de70ad60d71f0",
+      "transcript": "after leaving office as mayor, jackson continued to be active with the democratic party.",
+      "duration_sec": 4.732,
+      "speech_end_offset_ms": 4732.0,
+      "audio_hash_id": "9473f643ce97ca1a97181edee52cb13c8533c5e955e04ee8bc0db23e7a90b099"
+    },
+    {
+      "path": "audio/0478.wav",
+      "sha256": "1eee8b4bd52a6a9a2bfa03b9bde621eb724db748e2a0eb9e4a1e16d13ef93b2e",
+      "transcript": "it remained in wide service throughout the war.",
+      "duration_sec": 3.548062,
+      "speech_end_offset_ms": 3548.1,
+      "audio_hash_id": "94edd5b640555f7f45da447d57fd1ea056839a35ecbf4d48dab3269618737862"
+    },
+    {
+      "path": "audio/0479.wav",
+      "sha256": "b16fb9f8160d354f37c2d529520c13f0f2b24843cfbe48e3e91a844870366273",
+      "transcript": "its facade overlooking albert square had oriental influences.",
+      "duration_sec": 4.124062,
+      "speech_end_offset_ms": 4124.1,
+      "audio_hash_id": "94efc03816c64e4f25fbc9ecc478806d7bcabfaf8742dbc572c95d6cb7908afa"
+    },
+    {
+      "path": "audio/0480.wav",
+      "sha256": "fa285e1578f2f7768aaf0a522bd81817f8ef1ac9535b6681c994626db4110ab1",
+      "transcript": "the most important element of the budget is retirement savings reform.",
+      "duration_sec": 5.148062,
+      "speech_end_offset_ms": 5148.1,
+      "audio_hash_id": "950f0900a60f8fbf7f90a0dd0c1c9cc92949652dfcdf4d9b405786a164ee26eb"
+    },
+    {
+      "path": "audio/0481.wav",
+      "sha256": "94a1bf9cc6c0b00086897b8ebf8065af4a430e60c4f7ae8c7a19c3c94f25696d",
+      "transcript": "she recalled my democratic colleagues were enormously welcoming.",
+      "duration_sec": 3.644,
+      "speech_end_offset_ms": 3644.0,
+      "audio_hash_id": "951c075413ed13641f137a2f1b0f2ca12247fba42325c82ec9e48a1a6675eb0d"
+    },
+    {
+      "path": "audio/0482.wav",
+      "sha256": "3e06b2f5f1d5862ee1b70cf6d65d268a1f817a2f394e998af719e7e05afa7afa",
+      "transcript": "about ten years later, he sold the company to his partner.",
+      "duration_sec": 3.068062,
+      "speech_end_offset_ms": 3068.1,
+      "audio_hash_id": "954121ecd4fd86688764a01dc5e9add849aa3b90c687a85a8701a9ae8aa766bc"
+    },
+    {
+      "path": "audio/0483.wav",
+      "sha256": "420d41b548235ad36ec2d2ef1399e1a488ab22f31be139d62b8c73824d8cab30",
+      "transcript": "china bandy is mainly financed by private resources.",
+      "duration_sec": 3.612,
+      "speech_end_offset_ms": 3612.0,
+      "audio_hash_id": "95534d3744a4b3ede81114e11fae2f6116f2fb58e0b3754a8a5d8f336ffbb10c"
+    },
+    {
+      "path": "audio/0484.wav",
+      "sha256": "c30cd056adce7c0acb06d408a5d4d916640bad02092f5673ddde0ce936f7cc47",
+      "transcript": "the four were subsequently ordained as the first japanese jesuit fathers by alessandro valignano.",
+      "duration_sec": 6.556063,
+      "speech_end_offset_ms": 6556.1,
+      "audio_hash_id": "955c72e3f9771c9a67b805560bd6d5c9cfd2904483502425ab7cac779b117b82"
+    },
+    {
+      "path": "audio/0485.wav",
+      "sha256": "d32884c06c4de88036ff9806ee1dc8ab331a8077d993c8e68e70c23cbfa60f2f",
+      "transcript": "trell helps users to find meaningful content in video format.",
+      "duration_sec": 4.188,
+      "speech_end_offset_ms": 4188.0,
+      "audio_hash_id": "95d3792bacfba2e0bf545a427ca100c8b86cacb591aae61c5efb50bae0f8ea94"
+    },
+    {
+      "path": "audio/0486.wav",
+      "sha256": "ffee3af126f982ec108f8962fb3e35e8b81ef07a88535c52cc53dcfe740041e9",
+      "transcript": "after these early attempts, the portuguese took a decade-long break from indian ocean exploration.",
+      "duration_sec": 6.332,
+      "speech_end_offset_ms": 6332.0,
+      "audio_hash_id": "95fa6470628616f0239b8e1a8df26d136100f2a10d4a892d34a9c31e6cbacd63"
+    },
+    {
+      "path": "audio/0487.wav",
+      "sha256": "46bf9dbd108edc37fffc9bc182f10ffeb8137d974aa23c0f445217466d5b8ed5",
+      "transcript": "a roadside museum provides background on flora, fauna, and the history of the area.",
+      "duration_sec": 5.084,
+      "speech_end_offset_ms": 5084.0,
+      "audio_hash_id": "96172e8ec015ad9f030c8203331e277bb78f1d29b75363ba1beb5912b5f87cf5"
+    },
+    {
+      "path": "audio/0488.wav",
+      "sha256": "97b0fb216a9e580858f767d8d815988b077f04a5a1fa4fe3cb726f44796277f9",
+      "transcript": "that same day, taylor was handed over to the sheriff of essex at chelmsford.",
+      "duration_sec": 5.148062,
+      "speech_end_offset_ms": 5148.1,
+      "audio_hash_id": "965d481865ff2cc241e3ebb08fd442ed9d95d00da9a87648a873474c66288d1c"
+    },
+    {
+      "path": "audio/0489.wav",
+      "sha256": "ef75660197352a05ff12e72be6c30691972eb72d2bd14d5e9a7581e8eb8fd4f0",
+      "transcript": "the plant's large underground tuber distinguishes it from other \"apios\" species.",
+      "duration_sec": 5.052,
+      "speech_end_offset_ms": 5052.0,
+      "audio_hash_id": "967da074ff826c9acf9d82a6cbfc97619383836965147f4c3f71684de85aaa8c"
+    },
+    {
+      "path": "audio/0490.wav",
+      "sha256": "ee24a4d0f25bb4902113cc4e1127c11bf4005251d556c204c9794c7d0b005de5",
+      "transcript": "the inflorescences are frequently dense.",
+      "duration_sec": 3.26,
+      "speech_end_offset_ms": 3260.0,
+      "audio_hash_id": "96a4c34b900e9ae82e863a31b8b33b0a1b0fcc2885a6e3013e9811b88239b312"
+    },
+    {
+      "path": "audio/0491.wav",
+      "sha256": "38920075604fcbe92d8d0c7b940081ab0cc00923d2b59e716c114f2cea70838c",
+      "transcript": "clearing these events rewarded the players with characters and costumes.",
+      "duration_sec": 3.612,
+      "speech_end_offset_ms": 3612.0,
+      "audio_hash_id": "975c8ddc1f3234bbc4afa321d5499d4b4a86edf0c92ac9dfbbf0e0ba5d77ac0d"
+    },
+    {
+      "path": "audio/0492.wav",
+      "sha256": "5acc430a121b9bdecc74fa7c442863a4ef00c80f025c2982d8165973cb8325c4",
+      "transcript": "items the player collects can be viewed on the status screen.",
+      "duration_sec": 3.324,
+      "speech_end_offset_ms": 3324.0,
+      "audio_hash_id": "97a51cbb89f69814c3c0bf0374d9f6ebc5d49890668f2382ca075bbce47ac39f"
+    },
+    {
+      "path": "audio/0493.wav",
+      "sha256": "cba5b4c901f1a96dd7e9a0f668b6b53a80d87cfaaab0ecd95b205496d75ff630",
+      "transcript": "vaginectomy can be divided into two kinds of operations.",
+      "duration_sec": 3.58,
+      "speech_end_offset_ms": 3580.0,
+      "audio_hash_id": "97af3605e857c45a413a2375e5b515ecc2f727e4608884d8161b59c57a92f2d4"
+    },
+    {
+      "path": "audio/0494.wav",
+      "sha256": "6bf1184e51c7dcf058261776b981ea6c20d967b06ec56cbca11b1cffb271c024",
+      "transcript": "nevertheless, it was an overall success.",
+      "duration_sec": 2.396,
+      "speech_end_offset_ms": 2396.0,
+      "audio_hash_id": "97ee52b2d6cdcbbb447e4c0774f1a2eeaa6380a9fd6274a980462f9d1c615864"
+    },
+    {
+      "path": "audio/0495.wav",
+      "sha256": "cb489482f4a5d70ec3ad1f34e1ba234a48c8892d39a86f7dd69c8b5bd1760800",
+      "transcript": "none of those jobs were school-funded positions.",
+      "duration_sec": 2.812,
+      "speech_end_offset_ms": 2812.0,
+      "audio_hash_id": "9802c752e734ea806b871157a0a7812d9a3c9d9687746a395b99ce814376ef8e"
+    },
+    {
+      "path": "audio/0496.wav",
+      "sha256": "0659c46ce7e4d4228cfd1930fc2f4f162b06b3cb785c91f6527edc75dcd0bc30",
+      "transcript": "the eastern and western sites were connected by a rail track.",
+      "duration_sec": 3.612,
+      "speech_end_offset_ms": 3612.0,
+      "audio_hash_id": "9834be241833b3a5da3a955debf5980cbca4b31f42e161e33f21c0006687ed89"
+    },
+    {
+      "path": "audio/0497.wav",
+      "sha256": "4b22eb1f1f44a1b585271552f1235c2494e5a1e6b7b386f0ac57bc082626d07f",
+      "transcript": "ten sets of hurdles were set on the course.",
+      "duration_sec": 2.204063,
+      "speech_end_offset_ms": 2204.1,
+      "audio_hash_id": "984894528596f1c4514dccfec42e1c821ba58b579fddac0119cef698fa1ff928"
+    },
+    {
+      "path": "audio/0498.wav",
+      "sha256": "8e88df71bfbd23ea1547633ce26cc225b45bc78f663ed77bbaea54c8a7a49fc1",
+      "transcript": "the hull husk and the full in plenty virtue is the highest good.",
+      "duration_sec": 4.924062,
+      "speech_end_offset_ms": 4924.1,
+      "audio_hash_id": "985f2251166c262d7aec7770465e326cecd89e8a640b3d7ee8e231bed087b4a2"
+    },
+    {
+      "path": "audio/0499.wav",
+      "sha256": "45ba75f85dd7fa92979485df1038d394093bdbc93537732ed57b5802b66b2e1a",
+      "transcript": "this desert was once a sea, he said.",
+      "duration_sec": 2.342062,
+      "speech_end_offset_ms": 2342.1,
+      "audio_hash_id": "987ea63b70e3ad58216dda7250be9db8f7d1728a36930a670f7afc71e05e6a0e"
+    },
+    {
+      "path": "audio/0500.wav",
+      "sha256": "03939f0053ada4f9f18afd5993a9aa3a8b27bcda4d03698a9aada10c49ad83b1",
+      "transcript": "penrith needed to wait until they could develop their own 'stars'.",
+      "duration_sec": 3.388063,
+      "speech_end_offset_ms": 3388.1,
+      "audio_hash_id": "9891c1533dc66bc84e165b7bb554286cd1e05bc66f9d53fe505d5af7db367900"
+    },
+    {
+      "path": "audio/0501.wav",
+      "sha256": "40227f8211415a885146a5e8f0b2a6d492741b1ae73847ee07d15485b47b95f8",
+      "transcript": "margaret tucker was another notable member.",
+      "duration_sec": 2.49,
+      "speech_end_offset_ms": 2490.0,
+      "audio_hash_id": "98c53113141158ff3dd181c79b269171f5f8330b521c125ab22fc38c93f202a8"
+    },
+    {
+      "path": "audio/0502.wav",
+      "sha256": "f02a9736ec7131b9de3ea1ffeb0507b8ee65287a2ac8c183dc80dd4b7bea8e8c",
+      "transcript": "the current governor of kunar province is wahidullah kalimzai.",
+      "duration_sec": 3.74,
+      "speech_end_offset_ms": 3740.0,
+      "audio_hash_id": "98fd1e0cdd7e9a8048ddeaffae5c9f1dec547919c3a53f6b6827406dda38ceb5"
+    },
+    {
+      "path": "audio/0503.wav",
+      "sha256": "9326ebdeb8025353aabf25a48793b1700ce95c45f665cb5c77cb16697561c208",
+      "transcript": "at least one bridge in saskatoon was destroyed by ice carried by the river.",
+      "duration_sec": 4.924,
+      "speech_end_offset_ms": 4924.0,
+      "audio_hash_id": "992bc75f03e336d8c26782ae50c1eace1eb2c20d4011387a5e2024b57ab45d98"
+    },
+    {
+      "path": "audio/0504.wav",
+      "sha256": "e239d5ea92318121f778dbdd38708137be2cc3eb465959efc51b1f613722a2c5",
+      "transcript": "what is a foreigner doing here? asked another of the men.",
+      "duration_sec": 3.004,
+      "speech_end_offset_ms": 3004.0,
+      "audio_hash_id": "9984f60e7f11dc86e010de473000caf4ef1663add77a4834919342f0574c9b50"
+    },
+    {
+      "path": "audio/0505.wav",
+      "sha256": "5b59d919162cbcf3f4a654dbe296c1f9de4515cb32cb020e14935951e6b16712",
+      "transcript": "a current of love rushed from his heart, and the boy began to pray.",
+      "duration_sec": 3.238062,
+      "speech_end_offset_ms": 3238.1,
+      "audio_hash_id": "99e399135966983cce36ea3a34d43b3331bbb5489dbfe3a5c3226d04bb67eeab"
+    },
+    {
+      "path": "audio/0506.wav",
+      "sha256": "e05cdb9af3ca8cc2b45fc3908b0f8f266268583a3a3575043d8581c84493cada",
+      "transcript": "evacuation was lifted after five days when the reservoir was nearly empty.",
+      "duration_sec": 5.372,
+      "speech_end_offset_ms": 5372.0,
+      "audio_hash_id": "99fbe28d6600cbb6b4098d7534845d6c2b43d144f28574f3195181ecf8b804ff"
+    },
+    {
+      "path": "audio/0507.wav",
+      "sha256": "e7d01c4b7dcad43023597ed97216526fe9fb836a99f9dc89891572050ca46a69",
+      "transcript": "then i suggest you call one of them.",
+      "duration_sec": 2.318062,
+      "speech_end_offset_ms": 2318.1,
+      "audio_hash_id": "9a24826efbee6e8b271b2806121466fbd3c15add8a23c39561adc4c87ac15968"
+    },
+    {
+      "path": "audio/0508.wav",
+      "sha256": "6452df6fe5d8c847f10718984cb00e6010bf29a79307fbbd80a12492e7429f1e",
+      "transcript": "protonation gives the ferrous hydride.",
+      "duration_sec": 2.076,
+      "speech_end_offset_ms": 2076.0,
+      "audio_hash_id": "9a2b1f371861aafb925b324edff4380458be3aa89da57ed602f0b7de6eb1b49a"
+    },
+    {
+      "path": "audio/0509.wav",
+      "sha256": "1db15bdf475fe8a43db9b44f931f8f4c646bfd83bacc05cb4d978beec63b8df2",
+      "transcript": "there is no magic, and unlike many strategy games, it has no technology tree.",
+      "duration_sec": 5.436063,
+      "speech_end_offset_ms": 5436.1,
+      "audio_hash_id": "9a3b3d9c7816920105e84167cbdc4dc44d0a936ff93a872bf8786cb1ca2387a5"
+    },
+    {
+      "path": "audio/0510.wav",
+      "sha256": "bc3136568331c30c23ff2756a663cb5dcca3ca0bf53eaf47183abc9c6fbf91bf",
+      "transcript": "everything on earth is being continuously transformed, because the earth is alive.",
+      "duration_sec": 4.764062,
+      "speech_end_offset_ms": 4764.1,
+      "audio_hash_id": "9a77fb298258e1c0a22f1d40b211fb54fd29472411f5b83f341535c0c7f1e41f"
+    },
+    {
+      "path": "audio/0511.wav",
+      "sha256": "acf8b9e3cf85eb0c97ab46b6bac09c4a85b7321618654796dfa54288180e5982",
+      "transcript": "refueling at sea, the carriers kept up a constant bombardment of the home islands.",
+      "duration_sec": 4.604,
+      "speech_end_offset_ms": 4604.0,
+      "audio_hash_id": "9a81eac212b61cf7188f883624e2193561948f2ee5ad3b4f6bed37f85881fbbe"
+    },
+    {
+      "path": "audio/0512.wav",
+      "sha256": "237feb1e111c296abcf12229f9f731d353ae8138accd891fb8b277c90003c348",
+      "transcript": "most species are highly agile, and regularly leap several metres between trees.",
+      "duration_sec": 4.668062,
+      "speech_end_offset_ms": 4668.1,
+      "audio_hash_id": "9b16b870d5be3784eb2f34ed876c6fc989d5dc9809147368186bff1cc85cf9ac"
+    },
+    {
+      "path": "audio/0513.wav",
+      "sha256": "6929bb9aac80516ed50fd38544e1ae50cb244122104c9d94d5cbf1ce2e0c706d",
+      "transcript": "during their pursuit of the story, peter and sabrina clash over virtually everything.",
+      "duration_sec": 6.076062,
+      "speech_end_offset_ms": 6076.1,
+      "audio_hash_id": "9b874ba90dfdbda47b822c52644e7f76c061750719ea02b0ddd6314e5428e6c1"
+    },
+    {
+      "path": "audio/0514.wav",
+      "sha256": "5b4b44ad268b051eafe33e34a4a38d9b6c2056102ce9a2cc0ecd598dc0e80228",
+      "transcript": "bobby first of all is an actor, clint first of all is a star.",
+      "duration_sec": 4.22,
+      "speech_end_offset_ms": 4220.0,
+      "audio_hash_id": "9c3ee871240768914a8e0e365c0bf6e37788b9c1298c070b2bfecbe2b439f4af"
+    },
+    {
+      "path": "audio/0515.wav",
+      "sha256": "5569dd36541b8ea009ab7464ca7f72f1aa2190ea0f89a4d44fa0c592b04a00c4",
+      "transcript": "the remainder is flat and almost featureless except for a few tiny craterlets.",
+      "duration_sec": 3.932,
+      "speech_end_offset_ms": 3932.0,
+      "audio_hash_id": "9c7bdb086bfcecc04509640563f208fc8afb38b94b5363647311132adf6b14f1"
+    },
+    {
+      "path": "audio/0516.wav",
+      "sha256": "4d8c6e79cd0e1ff97b0d8d2d7ce176813c96e19603e1989617aa5c8a2d763408",
+      "transcript": "the volumes contain many stories that together comprise the fenian cycle.",
+      "duration_sec": 4.316,
+      "speech_end_offset_ms": 4316.0,
+      "audio_hash_id": "9c80ab182a59fd83181f3679ce2dd53b772d0d49456df1efe7232784ddb8f988"
+    },
+    {
+      "path": "audio/0517.wav",
+      "sha256": "4bd88e708f3f48e55a0a61297b699f4629d127158cc28442f854ada62d7fee2d",
+      "transcript": "he moved about, invisible but everyone could hear him.",
+      "duration_sec": 2.716063,
+      "speech_end_offset_ms": 2716.1,
+      "audio_hash_id": "9d85acb867a913871dd5046a9786b0cd3f90847d60c933c27fa667bc31ea5277"
+    },
+    {
+      "path": "audio/0518.wav",
+      "sha256": "2e39aa8fcab82a36a2ffafff0818035b511e177e22843751160e591ee0cd80b6",
+      "transcript": "italy, closely followed by france, is the world's largest wine producer by volume.",
+      "duration_sec": 5.276063,
+      "speech_end_offset_ms": 5276.1,
+      "audio_hash_id": "9e58c31c6c42a882f131a7adaf6633a5e9e804d73cf387ee47d9065f8ec87111"
+    },
+    {
+      "path": "audio/0519.wav",
+      "sha256": "d6bb35d558888bd18d718231e4d68c8c3eef2cf8041f7fad797d78a588a2c47e",
+      "transcript": "golden penguins are so last season.",
+      "duration_sec": 2.110063,
+      "speech_end_offset_ms": 2110.1,
+      "audio_hash_id": "9e8dfa1bdcf80d51169857e7e0be55ed415e2e1a403d1b4896c224879bbb6057"
+    },
+    {
+      "path": "audio/0520.wav",
+      "sha256": "859b0e5ee0782c62fbdba050e8c617f3223401f16b15fba42faefb59225688a5",
+      "transcript": "the local police arrested a member of staff whom faulds believed to be innocent.",
+      "duration_sec": 4.956062,
+      "speech_end_offset_ms": 4956.1,
+      "audio_hash_id": "9ea2f4be6aec9caa709e4e3cf04f27aa5af0f1f2c5218df7416681f0e71e0678"
+    },
+    {
+      "path": "audio/0521.wav",
+      "sha256": "5b74cda3eabec3a5c2c64fd029b755b765a31acddf42dc04815272242ea74f71",
+      "transcript": "later the club members also began to organise fencing, hiking, boxing and cycling.",
+      "duration_sec": 4.444,
+      "speech_end_offset_ms": 4444.0,
+      "audio_hash_id": "9ee348f86d353aa9e827afc373262fc445ef22c530d992b0d0c0c01dd1457bae"
+    },
+    {
+      "path": "audio/0522.wav",
+      "sha256": "40ed099a624425451fc4e3544585fcdd9a18e8262ee6eabda5c8b3ef9d513195",
+      "transcript": "there are even vegetarian variations.",
+      "duration_sec": 2.908,
+      "speech_end_offset_ms": 2908.0,
+      "audio_hash_id": "9f2040c5fcf4bf64b14ef7335fd9342c9eb1fba30f51ca5f53cd5799d0468dc7"
+    },
+    {
+      "path": "audio/0523.wav",
+      "sha256": "8be3eef010cd95987b459d04d984ee676e8da0f8eb594b60fe311e367295a06d",
+      "transcript": "however, these plans were changed as a result of significant opposition and public opinion.",
+      "duration_sec": 5.404,
+      "speech_end_offset_ms": 5404.0,
+      "audio_hash_id": "9fe605ecc19fba452a7565d42e591157c31677c4bf68eeb4d5aa4312fb7b32e8"
+    },
+    {
+      "path": "audio/0524.wav",
+      "sha256": "0eb806442df4502e2138179a61c8ba9283dc726bd1999ea811180e701fa45817",
+      "transcript": "i guess, it's a never-ending story.",
+      "duration_sec": 2.812,
+      "speech_end_offset_ms": 2812.0,
+      "audio_hash_id": "a0160f315fb5f39a9becd2091e9fc2173d0606dd73b3406b3c66333f6e4f3729"
+    },
+    {
+      "path": "audio/0525.wav",
+      "sha256": "281c04369828abc452cd95c81ac0d40527f5e6f4698362e7f8d078ee6312ff62",
+      "transcript": "it was the time of day when all of spain slept during the summer.",
+      "duration_sec": 3.26,
+      "speech_end_offset_ms": 3260.0,
+      "audio_hash_id": "a09c29feb94b3a6b9659f47ee398b8243bafbd78f43fb4d69b99c4eb32d1a5a6"
+    },
+    {
+      "path": "audio/0526.wav",
+      "sha256": "ade6d18311eff2260fc28fbef16e425dc215fa2892114a008d5447b5415c5186",
+      "transcript": "they joined the fight and gave jackson a great advantage.",
+      "duration_sec": 2.844063,
+      "speech_end_offset_ms": 2844.1,
+      "audio_hash_id": "a0c427f79dde85a841b0ea0cbb54a6fb3e9a9507e1cf5ecdcc8a9eceec13c43e"
+    },
+    {
+      "path": "audio/0527.wav",
+      "sha256": "f10a9cfbfb05a9cfdee8c12dce0ca92b05a8b9e6b1c414cd52875a1910c96350",
+      "transcript": "imagine if everyone went around transforming lead into gold.",
+      "duration_sec": 3.74,
+      "speech_end_offset_ms": 3740.0,
+      "audio_hash_id": "a0d9ea35f93e870bc2185892016242ae01da8c42ce27b05498874e2d212afd92"
+    },
+    {
+      "path": "audio/0528.wav",
+      "sha256": "d89640383f38627743489519b59efbe8d8eb6566284c9de569cdc5256e7ad664",
+      "transcript": "a man is standing in coconuts while trying to open one.",
+      "duration_sec": 3.228063,
+      "speech_end_offset_ms": 3228.1,
+      "audio_hash_id": "a1234cb9c6f0ad63ac84d5ef694acf54323355825fd0348b7a470d6c8117d8ba"
+    },
+    {
+      "path": "audio/0529.wav",
+      "sha256": "f14cd613eb2436c256cffb1b7fa40623834a7f65c6f02824ed327eb5fa17b0f9",
+      "transcript": "mother ships carrying the illegal cigarette loads hid just behind capri.",
+      "duration_sec": 3.996062,
+      "speech_end_offset_ms": 3996.1,
+      "audio_hash_id": "a1f4e9fcc7716e1a004587ca6386b53c28213d4df08314ef3f38d41e9dc30937"
+    },
+    {
+      "path": "audio/0530.wav",
+      "sha256": "9de030b1666839864ba3c4cc8d9c2ecec9e5d380dbf3249241119ffd1f6521ee",
+      "transcript": "she has also set to music many poems by rudyard kipling.",
+      "duration_sec": 3.004062,
+      "speech_end_offset_ms": 3004.1,
+      "audio_hash_id": "a229dbf7c2e87ba961e5bcb5fe99a2c51f7357fb13b6f85cee346e65499fb18f"
+    },
+    {
+      "path": "audio/0531.wav",
+      "sha256": "4d34cb001a77bbe933bf2bd75e5ecfe470c4b8b33cf91d7c0a90e2529594ebe0",
+      "transcript": "each vehicle consists of two compartments with full internal access.",
+      "duration_sec": 4.22,
+      "speech_end_offset_ms": 4220.0,
+      "audio_hash_id": "a29d274fd1559a5b60eaff326cb133626d16d47c21b6106740b37853fc4d32b5"
+    },
+    {
+      "path": "audio/0532.wav",
+      "sha256": "e039eaf30ecdeb49138f35740972ee018fce4238af9ff5c5a8b21fdf65f12c6d",
+      "transcript": "the boy noticed that the owner of the bar stood nearby, listening attentively to their conversation.",
+      "duration_sec": 5.244063,
+      "speech_end_offset_ms": 5244.1,
+      "audio_hash_id": "a2a0bbfc2dae73e15ab4ce1d432cb096c2d385a53591ba144f53dc088bdf6559"
+    },
+    {
+      "path": "audio/0533.wav",
+      "sha256": "7d4908805bf95c27b505d823be436613515b1cbfed21b1eb3ef0c064b0578f05",
+      "transcript": "he has studied synaptic transmitter release in the squid giant synapse.",
+      "duration_sec": 3.836063,
+      "speech_end_offset_ms": 3836.1,
+      "audio_hash_id": "a2c93daa7a6f29486c236609387d2e0ca22cbe0a0e53b2f480e1b984d2272bcb"
+    },
+    {
+      "path": "audio/0534.wav",
+      "sha256": "7925147afb104055ff5766558dd0e0136b959ee37201443b29d1a2be72897c3a",
+      "transcript": "this is referred to locally as 'gallifords' reflecting its ownership.",
+      "duration_sec": 5.404063,
+      "speech_end_offset_ms": 5404.1,
+      "audio_hash_id": "a2e5971d8ace3d840a33651ca8d387dab8361acd162aacd103a97897c0d6d265"
+    },
+    {
+      "path": "audio/0535.wav",
+      "sha256": "56f692c84508053fa132724e829cf67f9a6c687788a28be0279c3767ca8318e5",
+      "transcript": "the chief of the dental corps is a major general.",
+      "duration_sec": 2.492,
+      "speech_end_offset_ms": 2492.0,
+      "audio_hash_id": "a2eb51939ecd3a263fb63dfbef4403b77a3db66dd6008aa88ed81eed14015421"
+    },
+    {
+      "path": "audio/0536.wav",
+      "sha256": "c12551ad2544e5504c4fd83a15a4ebac34a427896cd3cec9280db934252e218d",
+      "transcript": "randy was definitely one of my biggest influences and i still love his stuff.",
+      "duration_sec": 4.732,
+      "speech_end_offset_ms": 4732.0,
+      "audio_hash_id": "a338f55a11daf3a38c2c2b0798afd66bd575229df3d8afff44073d4b291cf345"
+    },
+    {
+      "path": "audio/0537.wav",
+      "sha256": "6647e4693eec6e319429843eb10c73c246072e4b104d59c7e3f7504390fb0b1f",
+      "transcript": "the area is served by chinle unified school district.",
+      "duration_sec": 4.284,
+      "speech_end_offset_ms": 4284.0,
+      "audio_hash_id": "a3ad9f0c08346165cbd15afafb99135bb3e83a0fef0dfe58fd12a9115befb385"
+    },
+    {
+      "path": "audio/0538.wav",
+      "sha256": "95416a57cf81a592b41f675dfa8addb0f52596ae521a84935022ec788f927f2d",
+      "transcript": "the packaging is reusable and environmentally friendly.",
+      "duration_sec": 3.164062,
+      "speech_end_offset_ms": 3164.1,
+      "audio_hash_id": "a4127e07eb94e61b48a0a9f874db5d490ff1fbefffc7f9700ce247fe023109e6"
+    },
+    {
+      "path": "audio/0539.wav",
+      "sha256": "49c34b37f309d1bf88ee7ac5b9705149c7c660e6f80d8c82217ab53cdb96775c",
+      "transcript": "the glow deepened in the eyes of the sweet girl.",
+      "duration_sec": 2.652,
+      "speech_end_offset_ms": 2652.0,
+      "audio_hash_id": "a45f007dc13376bad0af4de45eaab4c2341e5cedef3a85a545d8e76e0020fa1a"
+    },
+    {
+      "path": "audio/0540.wav",
+      "sha256": "804e2e5f3c9cbaf609eb3469284b24346acb763c826098f6dd7eb0e24e34a0a2",
+      "transcript": "don't advertise: tell it to a gossip.",
+      "duration_sec": 2.748063,
+      "speech_end_offset_ms": 2748.1,
+      "audio_hash_id": "a4688b9145a5f9d2ca8cda7fec80138a4cc869e92889852fe9eabf5c9714d658"
+    },
+    {
+      "path": "audio/0541.wav",
+      "sha256": "c51903aa543d5c5fbef399c7730064b30bf22e0b197f3322767763e378190daa",
+      "transcript": "however, not many of these plants survived the journey from java to the netherlands.",
+      "duration_sec": 4.54,
+      "speech_end_offset_ms": 4540.0,
+      "audio_hash_id": "a5428e5c91dd48d4d7930ffb4975a9e762862a997d45cf5a9345aba3228d74cf"
+    },
+    {
+      "path": "audio/0542.wav",
+      "sha256": "0be4409caf2a565daeba3a84cf003e839d593602bf0a7a3fd1849494687807b4",
+      "transcript": "it added a number of movies to its lineup.",
+      "duration_sec": 2.748063,
+      "speech_end_offset_ms": 2748.1,
+      "audio_hash_id": "a54a6453ea31d7bca2e19912c6d513e22318f29b89d4699cf82ed6d518d61c05"
+    },
+    {
+      "path": "audio/0543.wav",
+      "sha256": "c3d36a565591f970eb1f69d4a2c39378c1cca687e8e233ea25b9611b81094ff0",
+      "transcript": "it was built by london and south western railway in their typical style.",
+      "duration_sec": 3.42,
+      "speech_end_offset_ms": 3420.0,
+      "audio_hash_id": "a55d59926f00809ee98474e92f33e2db06e2c0afacfd86c23f23f74875f999d9"
+    },
+    {
+      "path": "audio/0544.wav",
+      "sha256": "cd085907ec62627d77a53d6e78de8eae525b9627328095dde6bd6f7f248b9741",
+      "transcript": "disembodied existence in sheol is unreal.",
+      "duration_sec": 2.684,
+      "speech_end_offset_ms": 2684.0,
+      "audio_hash_id": "a5b24ba06b50236eab9d1aca715e03f83a646cf02207c4009c1bafa99bca8fb3"
+    },
+    {
+      "path": "audio/0545.wav",
+      "sha256": "44600b7252d9e3c1e49de723afdb093ba419fe523767e9d1f2b6f94783c5d862",
+      "transcript": "i want to stay at the oasis, the boy answered.",
+      "duration_sec": 2.364,
+      "speech_end_offset_ms": 2364.0,
+      "audio_hash_id": "a5ca230ff713c42f3003c7c010fbdadc51f91ad541ff11be566933d3e2bc671f"
+    },
+    {
+      "path": "audio/0546.wav",
+      "sha256": "0d8b8f206bce2fd5d77153549c0054c7cbc3af09711a32462a3a2bca7c606ae8",
+      "transcript": "he also confesses to having an affair.",
+      "duration_sec": 2.332,
+      "speech_end_offset_ms": 2332.0,
+      "audio_hash_id": "a5fbf652bcb74549a01c2b0e82ec3896fb009d91c05b0e7e679bb88553e69d79"
+    },
+    {
+      "path": "audio/0547.wav",
+      "sha256": "ff87aa4fe9284411c697dc1484e23273673af570072b46f4d040514b150869c3",
+      "transcript": "three of its four battalions, however, were absent that day.",
+      "duration_sec": 3.548062,
+      "speech_end_offset_ms": 3548.1,
+      "audio_hash_id": "a603f6eb2891a1e47917d4fd3ba3f5c4d4c4c44e31fba76116cc70db1fb716ae"
+    },
+    {
+      "path": "audio/0548.wav",
+      "sha256": "b8f6833c009b7924bce6b73b3ce990ad51a4d6a1cba4873c598a8eeb5a6bccc9",
+      "transcript": "he was the son of an episcopalian minister, and was born in colorado.",
+      "duration_sec": 4.796062,
+      "speech_end_offset_ms": 4796.1,
+      "audio_hash_id": "a646903cf44600efa385ffc47c929b2ab48e0372f4fcc1e593530d740d322ccd"
+    },
+    {
+      "path": "audio/0549.wav",
+      "sha256": "16c8898a2e803dc4e62748ec23e273b5a2338a8e5f313d770a8213300bb0f253",
+      "transcript": "although the obligations of this relationship were mutual, they were also hierarchical.",
+      "duration_sec": 5.244,
+      "speech_end_offset_ms": 5244.0,
+      "audio_hash_id": "a649dafa6ea5ca96762f04bdb77f85730661f7db5621a76154936249c7fa6645"
+    },
+    {
+      "path": "audio/0550.wav",
+      "sha256": "e7517ae60a42070fd3b29fae086374c7f8ad354079eafbb7e6e2562147566bce",
+      "transcript": "robert sirico said at the time that it constituted a \"vindication\".",
+      "duration_sec": 6.492,
+      "speech_end_offset_ms": 6492.0,
+      "audio_hash_id": "a65b5789d7dc4e7b0dba8e31c07a057ec743667b33f18e5e897353ad4d581813"
+    },
+    {
+      "path": "audio/0551.wav",
+      "sha256": "ca7339b94acbb00e42e75ef76345fd0e5daae91b029e85e7be991c7372b1d556",
+      "transcript": "it has numerous tributary rivulets.",
+      "duration_sec": 2.588062,
+      "speech_end_offset_ms": 2588.1,
+      "audio_hash_id": "a6bbc189db2a1dea7ff086067b8e486ca1b55847b9af6d9ad13af392b260cd4d"
+    },
+    {
+      "path": "audio/0552.wav",
+      "sha256": "cfb118ec106d46639bcdcc44b7774d526b97cbb8a765cd8a16809e24f8793c62",
+      "transcript": "it is actively imported into the endoplasmic reticulum of cells via glucose transporters.",
+      "duration_sec": 5.116062,
+      "speech_end_offset_ms": 5116.1,
+      "audio_hash_id": "a6dfe2b69dba36603f640f73634108252f643794b3f4ee91ce952a10414dfb7a"
+    },
+    {
+      "path": "audio/0553.wav",
+      "sha256": "d7b9eb2d1d2aedbd03da2e2d7d335535a30b3577803f0b0a35669713a7ad625d",
+      "transcript": "the englishman asked if they were in danger.",
+      "duration_sec": 2.748063,
+      "speech_end_offset_ms": 2748.1,
+      "audio_hash_id": "a7b32617722f61ed151f4ba39be9ee8f626823a4f54a3c9ca5452391c6319398"
+    },
+    {
+      "path": "audio/0554.wav",
+      "sha256": "9b6c21e1f7f9a914d288a87c2ce5f35d75d8c317b84e0d093baf7215165f3491",
+      "transcript": "the scale model of the architects plans sat at the center of the conference room.",
+      "duration_sec": 4.316,
+      "speech_end_offset_ms": 4316.0,
+      "audio_hash_id": "a7ba9662cc8184cb18b9c116ccfcddcfb9f98d1c631277089ef3b9cc35f66107"
+    },
+    {
+      "path": "audio/0555.wav",
+      "sha256": "f308065f2f44d878ccae207ee9d602b16d2f705c0d73a0f923dfdee3f284af1c",
+      "transcript": "all songs written by kelly moran",
+      "duration_sec": 2.14,
+      "speech_end_offset_ms": 2140.0,
+      "audio_hash_id": "a7e0b8c7b161f0ae9c625f815d080506831fca1ab142ec1fef13d30a876f23ad"
+    },
+    {
+      "path": "audio/0556.wav",
+      "sha256": "01a86f90c6ff44d4889d314687de7d832821857ac41f3f998b4da709d0b426f1",
+      "transcript": "it was the pure language of the world.",
+      "duration_sec": 2.844,
+      "speech_end_offset_ms": 2844.0,
+      "audio_hash_id": "a7ec0474e3446c1bf23573329dc96326b1f0461ac0e6f1f0466bf058d3358020"
+    },
+    {
+      "path": "audio/0557.wav",
+      "sha256": "14dc76a5a10e7325268ec67396e2eb0a7bcf6833db702be60dc17096a68a06b4",
+      "transcript": "the englishman had been profoundly impressed by the story.",
+      "duration_sec": 3.26,
+      "speech_end_offset_ms": 3260.0,
+      "audio_hash_id": "a82014787539466ca5e5d2a9c6f3a659716297ce4ef5196efbb9d92a0635b733"
+    },
+    {
+      "path": "audio/0558.wav",
+      "sha256": "de6e52c8eaf5bf0d12f92e239bf4cd70834a582ba6ab9b884c2a7fe1e6ae841a",
+      "transcript": "adam sandler served as the film's executive producer.",
+      "duration_sec": 3.516062,
+      "speech_end_offset_ms": 3516.1,
+      "audio_hash_id": "a8d3dc5936844532dbba777bf7d98cc5efddf14c8155bdf6873bd3de7d4c44c9"
+    },
+    {
+      "path": "audio/0559.wav",
+      "sha256": "201dbf270a06346b9e08db157405cd077e632f32bb348d38d4ccfaca8daaed14",
+      "transcript": "the flowers are bell-shaped, long, white or pink, and arranged in racemes long.",
+      "duration_sec": 5.788,
+      "speech_end_offset_ms": 5788.0,
+      "audio_hash_id": "a8e2b03ae536cea4d021275ce27a68315bc1d5f163e804bc01cf143bd43825e5"
+    },
+    {
+      "path": "audio/0560.wav",
+      "sha256": "503bb07ff9468ab65f9e345088317a49b2905dfcb036877071b31f49a9b6df82",
+      "transcript": "it left a greenish streak that glowed for some seconds.",
+      "duration_sec": 2.750062,
+      "speech_end_offset_ms": 2750.1,
+      "audio_hash_id": "aa21c84084e187e4fc58c5716bc41c22c5ae41b495c2940d185e3bfa7283185e"
+    },
+    {
+      "path": "audio/0561.wav",
+      "sha256": "deaf1f8e3254f304d028e01c9386c34c2e8335975e843cb8c6c482299759ab1c",
+      "transcript": "a constable an inferior officer of justice.",
+      "duration_sec": 3.228063,
+      "speech_end_offset_ms": 3228.1,
+      "audio_hash_id": "aa647944f4cc7dd14cea6765ee85da4c5acfafd889f261ce1f9665329b09bfe4"
+    },
+    {
+      "path": "audio/0562.wav",
+      "sha256": "797b6f68d42ede9e5e0bb9a702a611aa681c9bc8feb3d7d1361824ad25fb7aac",
+      "transcript": "the stelvio national park is located in the northern end of the province.",
+      "duration_sec": 3.932062,
+      "speech_end_offset_ms": 3932.1,
+      "audio_hash_id": "ab2a2d8e290668080a352a1b2a99a002aede846c1e5e145fef4face867428fbb"
+    },
+    {
+      "path": "audio/0563.wav",
+      "sha256": "8e684940bff4fcefb979509d562ecde1f8e1fecd020bc39c2a93628c48d5bcf5",
+      "transcript": "the axle was destroyed in the collision.",
+      "duration_sec": 2.012,
+      "speech_end_offset_ms": 2012.0,
+      "audio_hash_id": "ab42b5583b14aefcad4feec08ef5e906450e0ec57ce11d42020aec50a72d5889"
+    },
+    {
+      "path": "audio/0564.wav",
+      "sha256": "a4298f19e9f7a97ce3a2c66c91e46af290b36aa3ce1d5b7dd1f870933c8be744",
+      "transcript": "this afternoon you shall go to brinkley court, an honoured guest.",
+      "duration_sec": 3.516,
+      "speech_end_offset_ms": 3516.0,
+      "audio_hash_id": "ac6ed7ae1e4e94e43955cdbe115886f3d7584821a3039888faf76cf10c182849"
+    },
+    {
+      "path": "audio/0565.wav",
+      "sha256": "c8849899f34b608ce8d52e134fdf2e9b928cfe9cc0dfbaf552d533eee958c28e",
+      "transcript": "wild animals can be tame, such as a hand-raised cheetah.",
+      "duration_sec": 3.836,
+      "speech_end_offset_ms": 3836.0,
+      "audio_hash_id": "ac9292c00f3907e60f42194d861525c795d858e3160a6134ded3025368e9f31d"
+    },
+    {
+      "path": "audio/0566.wav",
+      "sha256": "0b618bff9630b9e98b189f480c090418288430ebfa7fe7dd09d50619f694b8d9",
+      "transcript": "in addition to the former polytechnic site, several other buildings have recently been acquired.",
+      "duration_sec": 5.724062,
+      "speech_end_offset_ms": 5724.1,
+      "audio_hash_id": "ac9938c43960298a6a76e06eadacc68edc6d42a924180b56b1de64cbb95a4a1c"
+    },
+    {
+      "path": "audio/0567.wav",
+      "sha256": "1c21533271b26df8d457761b5854c6d806bc51d79048fa97df50086973b48869",
+      "transcript": "as a result of the takeover, washington mutual shareholders lost all their equity.",
+      "duration_sec": 3.932,
+      "speech_end_offset_ms": 3932.0,
+      "audio_hash_id": "acbe58ed50296dcd4012e307ec45f9489dc2190aa6d7ea5a7f670b454b7d092d"
+    },
+    {
+      "path": "audio/0568.wav",
+      "sha256": "4d3d282a859e12a61df083a33a302604c4cdbbc7bb1b5461fa51121d6dca57d1",
+      "transcript": "much of the home is decorated with original period furniture.",
+      "duration_sec": 3.164062,
+      "speech_end_offset_ms": 3164.1,
+      "audio_hash_id": "acdf898e2632aaa1e66e5243ce781f94477f9484c319f16d2979738e41b79383"
+    },
+    {
+      "path": "audio/0569.wav",
+      "sha256": "776d53554e3a11eb3aa55ca9d67c25d51cd23021a6bcf66ae60d6da29af399ba",
+      "transcript": "despite his many pleas, carthage only ever sent reinforcements successfully to hispania.",
+      "duration_sec": 5.18,
+      "speech_end_offset_ms": 5180.0,
+      "audio_hash_id": "acf61252d57798c37a1823a6d3428c6c1b3038639ff34460e42a64505bb7b07c"
+    },
+    {
+      "path": "audio/0570.wav",
+      "sha256": "3af562b9bd1e499110deafa3509e6cb0079966368553adc1386f67260f803d45",
+      "transcript": "do you have any secret hiding place here in the house?",
+      "duration_sec": 2.278062,
+      "speech_end_offset_ms": 2278.1,
+      "audio_hash_id": "add154539fc83a407f6086aaeb31c3dffd7999cbf9efa6535ea179398ae37e3a"
+    },
+    {
+      "path": "audio/0571.wav",
+      "sha256": "2488fe0c57851ec72c982ef7f471bf8fa47598036b3ee113874502abc9047ae3",
+      "transcript": "the main crops grown are maize, cotton, sorghum, and yams.",
+      "duration_sec": 4.22,
+      "speech_end_offset_ms": 4220.0,
+      "audio_hash_id": "add6182d9c10601e0b9795dbf7b6714a74016f080b5329d3f116139eefa1584f"
+    },
+    {
+      "path": "audio/0572.wav",
+      "sha256": "c67c91092c0459b1559f482b78d63b91c5896874eb12f0df7e35051c98829403",
+      "transcript": "the first publisher was stilson hutchins.",
+      "duration_sec": 2.076,
+      "speech_end_offset_ms": 2076.0,
+      "audio_hash_id": "ae515c4a7bf8e71e1eeeb531074121178ea6f755f0c9d413ccffde490a9d52ae"
+    },
+    {
+      "path": "audio/0573.wav",
+      "sha256": "22925e41eb7fd7ca2ed2d650b8b6136e74ced4958f194dd55ba2fb9d6d229044",
+      "transcript": "the arabs laughed at him, and the alchemist laughed along.",
+      "duration_sec": 3.004062,
+      "speech_end_offset_ms": 3004.1,
+      "audio_hash_id": "aecac66070caba011229ba61e802f577cc0008e9d1c9ea4240fd791293344958"
+    },
+    {
+      "path": "audio/0574.wav",
+      "sha256": "fc9db7953332959f8496d18d9ea1f82d8dfbcbc1b5dff8de3e349fd15bbf7500",
+      "transcript": "advancing slowly, they searched among the stones.",
+      "duration_sec": 3.356,
+      "speech_end_offset_ms": 3356.0,
+      "audio_hash_id": "af523f754d9c8e52a102910230a000357617a5c973ec33cad0615898efca89b7"
+    },
+    {
+      "path": "audio/0575.wav",
+      "sha256": "db23d662eb7dd8fa8b1ae155943c399169ce87755baf9c9690b06e77f64fd317",
+      "transcript": "it was an oblong shape.",
+      "duration_sec": 2.204,
+      "speech_end_offset_ms": 2204.0,
+      "audio_hash_id": "af6aae02d73bb5d837d55c747876a580777aae0268848d1601662e0d77375dd0"
+    },
+    {
+      "path": "audio/0576.wav",
+      "sha256": "ede46d6151fe9a081da8f410f3941ae93ca839229c40c26e6274102063aba2b4",
+      "transcript": "it is also the seat of the municipality of the same name.",
+      "duration_sec": 3.868063,
+      "speech_end_offset_ms": 3868.1,
+      "audio_hash_id": "af7ded814e45f0c0a49f9aa53d8df1afb4b964915a22c57d3d2590a36894342b"
+    },
+    {
+      "path": "audio/0577.wav",
+      "sha256": "5a0d92d8a2e9327800a3b39f08493bc7924a69396426272d4718f0401ca55517",
+      "transcript": "it is also always stated that helen is the daughter of zeus.",
+      "duration_sec": 6.588,
+      "speech_end_offset_ms": 6588.0,
+      "audio_hash_id": "afad21504a7a42f342f28e4518a00b766aea7245ba512082c849d60ab3b64987"
+    },
+    {
+      "path": "audio/0578.wav",
+      "sha256": "5b0853713c3beabfe94ba105c124a3446684c856b728a1e3d0cd9fba57c7154a",
+      "transcript": "is it possible to see the italian job at malco theatres",
+      "duration_sec": 5.372,
+      "speech_end_offset_ms": 5372.0,
+      "audio_hash_id": "afafd9504ff5ad3047a0d847da065f04b867d09512c84c0f655793ec59017f59"
+    },
+    {
+      "path": "audio/0579.wav",
+      "sha256": "5096b47c3b074dfdce94cd61f90741d8194d07e78a2473843a4c451acd322dcf",
+      "transcript": "glynn is a prolific composer of music for television and film.",
+      "duration_sec": 4.348063,
+      "speech_end_offset_ms": 4348.1,
+      "audio_hash_id": "b0031eeb82c447984eccf873697f4cecc4f63611133626ca4338a0549d7a4622"
+    },
+    {
+      "path": "audio/0580.wav",
+      "sha256": "2bfa0be097389bbb82d88539d84f3caee736023a411bd22aecc8e5adf8e37ead",
+      "transcript": "that is unlikely considering it has his name on it.",
+      "duration_sec": 2.556062,
+      "speech_end_offset_ms": 2556.1,
+      "audio_hash_id": "b02003955ec8607d57a8036950ba8e73f3c61cef39653bcf527aaf0023d85318"
+    },
+    {
+      "path": "audio/0581.wav",
+      "sha256": "666ab43e68af97a92718bc9ad79ae2821746fee91d1859b39633f08f807ac9d7",
+      "transcript": "from there, the river passes through wilderness areas and well as the countryside.",
+      "duration_sec": 6.012,
+      "speech_end_offset_ms": 6012.0,
+      "audio_hash_id": "b0bb2b17455d1ac7fc1706ea047d4e79a109c219501cb3395221de8e7dfa1c49"
+    },
+    {
+      "path": "audio/0582.wav",
+      "sha256": "de31d2909c5d5e5367b44b8579148afd277eac7c1b1f7f634a7855664af70d6e",
+      "transcript": "these were gradually replaced as central district expanded.",
+      "duration_sec": 3.932,
+      "speech_end_offset_ms": 3932.0,
+      "audio_hash_id": "b106ec501a71f6f030e69a3d16678057c3c5b06c4e2ce7efcf180a04fa6fcf8e"
+    },
+    {
+      "path": "audio/0583.wav",
+      "sha256": "f82928d7e84a1db02c9749fde5b31aaed0695ff982d6b0e668678fe63924bba1",
+      "transcript": "it's true; life really is generous to those who pursue their destiny, the boy thought.",
+      "duration_sec": 4.764062,
+      "speech_end_offset_ms": 4764.1,
+      "audio_hash_id": "b12372887aca1fb0fb0c8706fab3cc5a823fd0a4009c687b15d2c6a438843d1c"
+    },
+    {
+      "path": "audio/0584.wav",
+      "sha256": "bdc094dff92896f6f1a48a741999c97350eef6fbc9c6880a972368d2608ecc0a",
+      "transcript": "furthermore, a number of boards have merged making a much lower number overall.",
+      "duration_sec": 4.892,
+      "speech_end_offset_ms": 4892.0,
+      "audio_hash_id": "b1254b53fc0d95354934351ed77ab7fb20e2143993455acfd96c5ab41a5bb8c8"
+    },
+    {
+      "path": "audio/0585.wav",
+      "sha256": "4df6b00d926a2631b5d55dec9e3544f87329daf26f0648a1a51c9ac9aaf32fc1",
+      "transcript": "having similar ranges in the wild, they are often confused.",
+      "duration_sec": 3.9,
+      "speech_end_offset_ms": 3900.0,
+      "audio_hash_id": "b13959c5cbf5a93dd5f6170988018b4e03c6cfe71a97034a283dbf1a51b1f709"
+    },
+    {
+      "path": "audio/0586.wav",
+      "sha256": "946caeef209cc3fd5771e2f6cc7f1880f03e13af16521d7e67f7da5fbc0d10fb",
+      "transcript": "he kneeled there, holding her hand, and neither said anything.",
+      "duration_sec": 3.036062,
+      "speech_end_offset_ms": 3036.1,
+      "audio_hash_id": "b1bdf37bc3a01e5ad082c4fcd998901c643cd07ae74ae4895716e20aa308cd9d"
+    },
+    {
+      "path": "audio/0587.wav",
+      "sha256": "5578611deb88b32cc62b7c3dacb7337fc30c7516cb402374fb2c074cae709952",
+      "transcript": "he spent the entire morning observing the infrequent comings and goings in the street.",
+      "duration_sec": 4.092,
+      "speech_end_offset_ms": 4092.0,
+      "audio_hash_id": "b23e3dd1b0670c7fe7224c4fde53d816c1f772e2d651f29dc3c7a9a336e77042"
+    },
+    {
+      "path": "audio/0588.wav",
+      "sha256": "928275a0895c4361e544641ec56c188939cd70d8a327b671d42194fb6c02e3a3",
+      "transcript": "in fact, there is an everlasting list of genres and subgenres of indie rock.",
+      "duration_sec": 5.308063,
+      "speech_end_offset_ms": 5308.1,
+      "audio_hash_id": "b25aeba1d2f7109aa5af30d7b6183b0189698174d1c358d19241f9d7d4ce6a9c"
+    },
+    {
+      "path": "audio/0589.wav",
+      "sha256": "30572571faf6eac9107343003e1a38fac01fa0d86f295a050c8580107b8191b5",
+      "transcript": "my review of the sun: one star.",
+      "duration_sec": 2.14,
+      "speech_end_offset_ms": 2140.0,
+      "audio_hash_id": "b27713bbf6071a8a6580560d92e9788c654c836ac00e34173ebc77db35bbd581"
+    },
+    {
+      "path": "audio/0590.wav",
+      "sha256": "5cb0029f6aa5f337adc93bdba7382b9551a949e785225c9cb54362f35894f727",
+      "transcript": "alpha delta phi, however, is a thriving organization.",
+      "duration_sec": 4.796,
+      "speech_end_offset_ms": 4796.0,
+      "audio_hash_id": "b3002a40ad2d9c0349b2237ef2f237eb79072da3ddfd379d06e1d7b194c527ef"
+    },
+    {
+      "path": "audio/0591.wav",
+      "sha256": "097557c2ceb1cf1626fe5c61016a57f84a7824fb350b2a5dcaa7754c5fefb648",
+      "transcript": "partisan forces, however, continued to be active.",
+      "duration_sec": 3.26,
+      "speech_end_offset_ms": 3260.0,
+      "audio_hash_id": "b3065ff270442073b5f6f2d2649dcdcef0fda6030d1e10bf68d2bc86528219e9"
+    },
+    {
+      "path": "audio/0592.wav",
+      "sha256": "9374562a4dc4e3b5c34d3fc017ea04e1a0c2ddb24b17affb5bf7dda58d3564db",
+      "transcript": "the teams most recent state title was the culmination of an undefeated season.",
+      "duration_sec": 4.956,
+      "speech_end_offset_ms": 4956.0,
+      "audio_hash_id": "b3082471334c7050c721bee6318f8766b6295e3530ec3ef3ea3d99e08346e863"
+    },
+    {
+      "path": "audio/0593.wav",
+      "sha256": "1bf8c40353c9bc9b44cbe7115f997525cd6b53488a8de476601d0c54c8c63c9b",
+      "transcript": "his name is not mentioned after the fall of antigonus.",
+      "duration_sec": 3.964,
+      "speech_end_offset_ms": 3964.0,
+      "audio_hash_id": "b312504ef7d13787dbd183be70db9866a21b2eaaa73e466fed9678d45dbcc081"
+    },
+    {
+      "path": "audio/0594.wav",
+      "sha256": "ee0b7456a11dec333b0e269896f63587e7c2c2101a56fc108c80ade786de5000",
+      "transcript": "it is strongly migratory, wintering in tropical africa.",
+      "duration_sec": 4.156,
+      "speech_end_offset_ms": 4156.0,
+      "audio_hash_id": "b34b8779740bcdea751aa638347b9103f973326218633bedce1e44b4facf7538"
+    },
+    {
+      "path": "audio/0595.wav",
+      "sha256": "3976c493f9e54cf0591600019dc5c3f29f7e2c8efdbda91332b93a58452e425d",
+      "transcript": "every three years in june, the college hosts a commemoration ball.",
+      "duration_sec": 5.148,
+      "speech_end_offset_ms": 5148.0,
+      "audio_hash_id": "b398df64b679effbc95a9cf2bc350fc05599131170babc037f0b8ad4950d1b54"
+    },
+    {
+      "path": "audio/0596.wav",
+      "sha256": "1144f508ae76427e22e0c4227a08900ca2c30bd9753d64ae8582bda0d6885ef8",
+      "transcript": "sarah told him that she was there to see her brother.",
+      "duration_sec": 2.396063,
+      "speech_end_offset_ms": 2396.1,
+      "audio_hash_id": "b3a59f0d9840640fda7130d6447b08825093c37f29467252856217d9259a7e16"
+    },
+    {
+      "path": "audio/0597.wav",
+      "sha256": "f4f8a60ec0f28e5ab27271af9f0cc8d0935dad89fdfb6b35678f57a673e886f4",
+      "transcript": "he also gained the friendship of julius caesar, who placed great confidence in him.",
+      "duration_sec": 4.444063,
+      "speech_end_offset_ms": 4444.1,
+      "audio_hash_id": "b46496ec6a4bcd014ea23676087867c376730659694913cca431d91b1662be16"
+    },
+    {
+      "path": "audio/0598.wav",
+      "sha256": "2cecc09a63ce93cbe16e50fcc9d25acf9ba6ba44a2278af01ad51b026ad142a2",
+      "transcript": "the dome continues to be the park's primary landmark.",
+      "duration_sec": 3.356063,
+      "speech_end_offset_ms": 3356.1,
+      "audio_hash_id": "b48611cb950c4b4786489b82c0e50e12bce14fad7b2930a4c1c2aef430171c88"
+    },
+    {
+      "path": "audio/0599.wav",
+      "sha256": "fff95ab87240fd038f4a75b586a2286d081591111f47e364beda2f869671f5e0",
+      "transcript": "the lettering on the cylinders puzzled him.",
+      "duration_sec": 2.652,
+      "speech_end_offset_ms": 2652.0,
+      "audio_hash_id": "b4bed6c574057b15bb8d18e4a9cd37b6f0df939ffde51bab70da7b3caed5610a"
+    },
+    {
+      "path": "audio/0600.wav",
+      "sha256": "fca7572b16a48fe8bd9d76682fb0b62769c69dcc71bcda9c98a59dd0b46addbe",
+      "transcript": "i just don't trust anyone who says they've never had hamburger helper.",
+      "duration_sec": 3.470063,
+      "speech_end_offset_ms": 3470.1,
+      "audio_hash_id": "b56178f2b200ff4befaeb30956956c4d03cfa32d799963484febd4268546814b"
+    },
+    {
+      "path": "audio/0601.wav",
+      "sha256": "8988203d9c5af50b5edeac610c4252ede6f8ec696880cbdd1417dc64aee1af68",
+      "transcript": "the surviving oscar was then shot down by \"laffey\"s gunners.",
+      "duration_sec": 3.9,
+      "speech_end_offset_ms": 3900.0,
+      "audio_hash_id": "b56ada3d503e7121ec60d905c5e41cbe81c165c92f73203ab351d68528a1c26b"
+    },
+    {
+      "path": "audio/0602.wav",
+      "sha256": "e1f65279ac1d302ccd9c94b32cf9be7c30754a9967d92bc68b5c6c75fe29c880",
+      "transcript": "lucas is part of the mansfield, ohio metropolitan statistical area.",
+      "duration_sec": 5.788,
+      "speech_end_offset_ms": 5788.0,
+      "audio_hash_id": "b58301fb227f45ebd64f6c33014e632c98e71cdae3439b18892ea91ea36fbca2"
+    },
+    {
+      "path": "audio/0603.wav",
+      "sha256": "e5a909a62744455009347aef4001a1c007442b7aff367a84e7d8e289cbf6fd16",
+      "transcript": "the retama park horse racing track is located in selma.",
+      "duration_sec": 3.228063,
+      "speech_end_offset_ms": 3228.1,
+      "audio_hash_id": "b5f4859011fd5ff2150887e5e6198cb4f7bf3ea2f0a4cb8d763b7f6c117b8291"
+    },
+    {
+      "path": "audio/0604.wav",
+      "sha256": "cbc541c9c915a5a251872ecc11adee88102a8508009fa9b7986517a964f73b4c",
+      "transcript": "this is recommended to be carried out within two hours.",
+      "duration_sec": 3.9,
+      "speech_end_offset_ms": 3900.0,
+      "audio_hash_id": "b62e80fa51f1bda441620aace1e44dcdab3e722ae3b2e720872d91d14aa1faf5"
+    },
+    {
+      "path": "audio/0605.wav",
+      "sha256": "0d2519aeab2791550ba31701bccf95f98337992f7742e4db54b61de7adaee41d",
+      "transcript": "however, southwest subsequently ceased all service to the airport.",
+      "duration_sec": 4.316,
+      "speech_end_offset_ms": 4316.0,
+      "audio_hash_id": "b6a8fbb9f7035318763bf2192e3b38b06e326f2b8f921a3fe720ee77ddfd78d0"
+    },
+    {
+      "path": "audio/0606.wav",
+      "sha256": "96d00ab825a82481daffd005a29e2ccba6227e1bd06a5385da0b03b316c6c738",
+      "transcript": "rose was educated in rural schools.",
+      "duration_sec": 2.908063,
+      "speech_end_offset_ms": 2908.1,
+      "audio_hash_id": "b6e307697d78bd1e109237edc553de7a54ea98808bbcd2b7631d7e318465db32"
+    },
+    {
+      "path": "audio/0607.wav",
+      "sha256": "9ff4f4f8c24517b544496943da0d27c4c8721e38f53c9c50e7394c4664fe213d",
+      "transcript": "the next most common mother tongue was italian.",
+      "duration_sec": 2.812,
+      "speech_end_offset_ms": 2812.0,
+      "audio_hash_id": "b73bf121df534628b3d51b8049f260961c06ea2c07d07ba003e8fc8175a1cffc"
+    },
+    {
+      "path": "audio/0608.wav",
+      "sha256": "6b14df9958b2e4d10b14bb8357e027b0e4c6a432b30f9353327980dff6c0a4da",
+      "transcript": "although conjugation rules are relatively straightforward, a large number of verbs are irregular.",
+      "duration_sec": 5.404,
+      "speech_end_offset_ms": 5404.0,
+      "audio_hash_id": "b7ab64d77bb7cde9457fd0646902f9270918f8071f21b7f9c1a4537e460cd6d6"
+    },
+    {
+      "path": "audio/0609.wav",
+      "sha256": "63ef93e853188ea03ff8a4a48218d1f68612ba5ec7c30d184166eac3b68b9a27",
+      "transcript": "even so, the menu and prices continue to differ little.",
+      "duration_sec": 3.996,
+      "speech_end_offset_ms": 3996.0,
+      "audio_hash_id": "b7e30cc50c9f0ac86e60cb129f1cf19232b158113d816ca490e7302d0ef5da3f"
+    },
+    {
+      "path": "audio/0610.wav",
+      "sha256": "baa74ac6f7709ce5d972ff1b451efa9667bb5978565a4306f6dbfe1127868de7",
+      "transcript": "located in the washington township shopping center, it has three viewing screens.",
+      "duration_sec": 6.716062,
+      "speech_end_offset_ms": 6716.1,
+      "audio_hash_id": "b9a655e5828dbceaa0d86b2986f8c4f0f4917aa2f04159a7ce612517be75833c"
+    },
+    {
+      "path": "audio/0611.wav",
+      "sha256": "43f3b6500c9a81695878aaacbc54dac28e587fdf44a4923da4fbac98878c0447",
+      "transcript": "heaton also lived in leeds for a year.",
+      "duration_sec": 2.78,
+      "speech_end_offset_ms": 2780.0,
+      "audio_hash_id": "b9c9841daad37ebe292f71ad8f209c7593b2c8622adb528308b91668a2dd60cf"
+    },
+    {
+      "path": "audio/0612.wav",
+      "sha256": "6c4ad13cbf8eeeef707ab5f24dc0e16889f6396020239ab48abe9400f29146a7",
+      "transcript": "the current host is jeff stelling.",
+      "duration_sec": 2.556062,
+      "speech_end_offset_ms": 2556.1,
+      "audio_hash_id": "b9ce7866d2ce3fb37bd5009528bf320d216a91a679cf203360368ae9fd55b1f8"
+    },
+    {
+      "path": "audio/0613.wav",
+      "sha256": "f46631e4c25acdd18dbde94e4151a6816617f8931d009b1c85c94fde40a4d9dc",
+      "transcript": "they play their home games at blackberry lane in onchan.",
+      "duration_sec": 4.956062,
+      "speech_end_offset_ms": 4956.1,
+      "audio_hash_id": "b9df2a50f8ac454097a2ed1dab6b452bc7bb0e75a07275d665cf6e1c967bfffc"
+    },
+    {
+      "path": "audio/0614.wav",
+      "sha256": "f204b48935dda3676a1ecae45a80079f2984f731a83455a29e8ebc7ef26fb6cd",
+      "transcript": "various techniques, such as in the following paragraph, are described in the literature.",
+      "duration_sec": 5.724,
+      "speech_end_offset_ms": 5724.0,
+      "audio_hash_id": "bafebd2c948e6956dcff58c86c6d43fba1ba7434eedd3f01b04b5252f223c100"
+    },
+    {
+      "path": "audio/0615.wav",
+      "sha256": "a44be356ce9996cd47c605f688552550f6102ed0fd3ee4465bc8fc45270ec3b3",
+      "transcript": "the latter is located at the northern tip of the peninsula.",
+      "duration_sec": 3.42,
+      "speech_end_offset_ms": 3420.0,
+      "audio_hash_id": "bb1052717498e1ed8798c16406dc0040f0fb3bc3b87ede38a8e8fc2e716a9de8"
+    },
+    {
+      "path": "audio/0616.wav",
+      "sha256": "f66e3935fa48b26ddddf136e1d97504f6cd2812d538ad8af72a6a44e59e63913",
+      "transcript": "as with oxidative addition, several mechanisms are possible with reductive elimination.",
+      "duration_sec": 7.228063,
+      "speech_end_offset_ms": 7228.1,
+      "audio_hash_id": "bb1c918f50a6d0a3d023b62cee2b225925b7355024a7e1b6f420805ad41e315b"
+    },
+    {
+      "path": "audio/0617.wav",
+      "sha256": "1601da4adbc161457896863f44834805f01b5a28584de38246840511d805e341",
+      "transcript": "he managed to retrieve it only after a pursuit against the robber.",
+      "duration_sec": 3.132,
+      "speech_end_offset_ms": 3132.0,
+      "audio_hash_id": "bb3872b88e817cb941eb2d8f6e16a643249a82be175ca7e18d6e7cf586d9c45e"
+    },
+    {
+      "path": "audio/0618.wav",
+      "sha256": "dd003b514e0426c97b8e3073a000853a7d9142535c79ee8690bc2e476c32b5e7",
+      "transcript": "they became the first chinese known to have visited the pacific northwest and hawaii.",
+      "duration_sec": 6.396063,
+      "speech_end_offset_ms": 6396.1,
+      "audio_hash_id": "bb5e09a042f53ade89621575a915a085c904007249ad90491363e17324d2946d"
+    },
+    {
+      "path": "audio/0619.wav",
+      "sha256": "be83250e977065167498816d8b291092c9d746d0a55252174d961fef70f5a016",
+      "transcript": "longden was a member of the church of jesus christ of latter-day saints.",
+      "duration_sec": 3.516,
+      "speech_end_offset_ms": 3516.0,
+      "audio_hash_id": "bbf32853625d63b6b3c5204ae8a7b0b0076c93871450cdb4a2a38c273df15bf2"
+    },
+    {
+      "path": "audio/0620.wav",
+      "sha256": "ed38853274459d5ce6a3e5e4abe1f0c03e29d6889c9013a635ed0068acf437cf",
+      "transcript": "it is slightly poisonous and is purgative and rubefacient when used fresh.",
+      "duration_sec": 5.692,
+      "speech_end_offset_ms": 5692.0,
+      "audio_hash_id": "bc0c4b189ce32b023f91e8bab1c4d5548c7911de6efdd2a32aeabd9729b868d6"
+    },
+    {
+      "path": "audio/0621.wav",
+      "sha256": "9cd7e751b433e73c1e4b39b127581a77dd638db5eafb40f9159fc4ce5eda307d",
+      "transcript": "flying through any of the warps starts the game with that difficulty.",
+      "duration_sec": 4.636,
+      "speech_end_offset_ms": 4636.0,
+      "audio_hash_id": "bc6ae3de10e6dcf5b943d3f36ecbb4abfc345362c990606bb2b787f9384813b2"
+    },
+    {
+      "path": "audio/0622.wav",
+      "sha256": "8711fb927a60ffa8882337acdd88ce30af8e745e3c49441d06b6308476c321c6",
+      "transcript": "in these inscriptions she is shown to have led numerous military campaigns.",
+      "duration_sec": 4.924062,
+      "speech_end_offset_ms": 4924.1,
+      "audio_hash_id": "bcad69b60f74e7709fc906060a699764ffbf47581cf9102905f6eec8edf6a4dd"
+    },
+    {
+      "path": "audio/0623.wav",
+      "sha256": "03d592029293fa676901270d90a7dcc65ddf5014248644a0967bdfb2bf5dab62",
+      "transcript": "he played college football for georgia.",
+      "duration_sec": 2.044,
+      "speech_end_offset_ms": 2044.0,
+      "audio_hash_id": "bce40535338f8d75b1c5dfaa7c1105440abe0e30a154173b0333b3763333ef86"
+    },
+    {
+      "path": "audio/0624.wav",
+      "sha256": "f5b8ee1aa4d681223051ec7ac05447495654f3da04ad1ecf22d04fdc9704f0ce",
+      "transcript": "republic picked a different air carrier to feed its memphis hub.",
+      "duration_sec": 3.228,
+      "speech_end_offset_ms": 3228.0,
+      "audio_hash_id": "bd3990c080503f8b985c57c54aca8e5482adfa4d8713faf9ad1263eb4bba89dc"
+    },
+    {
+      "path": "audio/0625.wav",
+      "sha256": "ed5f1724421e77dde50febd9236e8f1043ff700afed481e4a33fac37d5c5f692",
+      "transcript": "the problem for james south's telescope was the equatorial mount.",
+      "duration_sec": 4.412,
+      "speech_end_offset_ms": 4412.0,
+      "audio_hash_id": "bd6bd19a2e2aa188cde61cba5595149e6b31275afb4209ef0dcda056b0e0ad86"
+    },
+    {
+      "path": "audio/0626.wav",
+      "sha256": "e065f2be837b09f3ebab11c9efc269bae990f214e5e6b658f8976711ba2c33e4",
+      "transcript": "it was performed at the olympics by a big band led by rob mcconnell.",
+      "duration_sec": 4.604,
+      "speech_end_offset_ms": 4604.0,
+      "audio_hash_id": "bdbd0f93077c5d2c3f946adff6d8d9b7898e292c96f4a4820a70c20301ef046f"
+    },
+    {
+      "path": "audio/0627.wav",
+      "sha256": "5276e0ecec06aba0d16c3b6e561c419387b791d53a01f2e34fa86c769947a985",
+      "transcript": "she found history, geography and latin to be exceptionally boring.",
+      "duration_sec": 3.644,
+      "speech_end_offset_ms": 3644.0,
+      "audio_hash_id": "bdd00c0a7620ae917c2019be5e490fdf225181846f7c2cec700a3d88edae8169"
+    },
+    {
+      "path": "audio/0628.wav",
+      "sha256": "e1f4133064d50c6dd5c21dcfd6ad42c2299d904985d9a524f231a782da5f8a1d",
+      "transcript": "stuart determined to create a university that served the chinese nation.",
+      "duration_sec": 3.996062,
+      "speech_end_offset_ms": 3996.1,
+      "audio_hash_id": "bde47a58132efa51604b5f2287c60849b592b3b0bab4bddcfeabe59b0aef833a"
+    },
+    {
+      "path": "audio/0629.wav",
+      "sha256": "82c89794768b72f5f774d9a4d1ead59c0390e659b0f97babebc29556cb72f593",
+      "transcript": "i saw it all myself, and it was splendid.",
+      "duration_sec": 2.588062,
+      "speech_end_offset_ms": 2588.1,
+      "audio_hash_id": "be52c41663a38030c540842cf64465ae55afe7d09622a72fbbeafdf4432674f9"
+    },
+    {
+      "path": "audio/0630.wav",
+      "sha256": "d8d1ccdeb3c4f4ba7ac2202a3e29db4012aecb151a80a63ab2b39429b2ce4663",
+      "transcript": "in general, \"voyage\" received mixed reviews upon its release.",
+      "duration_sec": 3.356,
+      "speech_end_offset_ms": 3356.0,
+      "audio_hash_id": "be6859b672d3f8ef3d2ac29a3aca19cebbe83f25ee291796f2cebf3ea3c31e94"
+    },
+    {
+      "path": "audio/0631.wav",
+      "sha256": "1993ae4969d8e8092ccaba3f624e1dff80a8ea77b7f8c97205de0f5f1f68a6b7",
+      "transcript": "this practice has in recent times come under criticism.",
+      "duration_sec": 3.26,
+      "speech_end_offset_ms": 3260.0,
+      "audio_hash_id": "bec9a38848c2095c1de487efa6bf5359b4d12d6668cebbc87c9f1f4f1dc41846"
+    },
+    {
+      "path": "audio/0632.wav",
+      "sha256": "74c0b263cebacd5b2bbfd0d2df0c2a126a257d6e0d321e4506bfaeab217b4f0a",
+      "transcript": "raman resides in the silver lake neighborhood of los angeles.",
+      "duration_sec": 4.028062,
+      "speech_end_offset_ms": 4028.1,
+      "audio_hash_id": "bf74872f26befef2cdc6aef437ed9851782f8a94b4262c67abceed60db33547b"
+    },
+    {
+      "path": "audio/0633.wav",
+      "sha256": "17b2d0da954b531f6c8965ed43753c3731caaa84327a8fa74098e430ffabc4e9",
+      "transcript": "the approach places value on transparency, stakeholder inclusion, and accountability.",
+      "duration_sec": 4.892,
+      "speech_end_offset_ms": 4892.0,
+      "audio_hash_id": "bf76c61cdd36ab8f71858cd0698fbec45ca33c0689ae13cdb4a34e3efdd99ab5"
+    },
+    {
+      "path": "audio/0634.wav",
+      "sha256": "18cf07e3800461ef68b82850ee0957662936a72a5c2e3f5229a077b50d73b8b8",
+      "transcript": "while in the military, he was awarded the legion of merit.",
+      "duration_sec": 3.068,
+      "speech_end_offset_ms": 3068.0,
+      "audio_hash_id": "bf84d04a77dbf5028ad40c10665f7208dd0ed87f60def83f5275776d86d5d501"
+    },
+    {
+      "path": "audio/0635.wav",
+      "sha256": "9204a137dc6fd32db79013f9d4670586f5a98a7c0178182d0030853ad1baa793",
+      "transcript": "nena as a continent has been associated with the sudbury basin impact.",
+      "duration_sec": 3.996,
+      "speech_end_offset_ms": 3996.0,
+      "audio_hash_id": "bfe745e1cd930b586e726124450be94083b0398430a2145e891bca236a43c0c6"
+    },
+    {
+      "path": "audio/0636.wav",
+      "sha256": "547d52a94535cb07349fcd18fcae544a1f74f116899ab86a8d00072e59097a7a",
+      "transcript": "this was due to structural failure that could not be safely resolved.",
+      "duration_sec": 4.028062,
+      "speech_end_offset_ms": 4028.1,
+      "audio_hash_id": "bff3a595dc6c550f0d662f00d83e90821696aadbdf363929b71407459ba01cbe"
+    },
+    {
+      "path": "audio/0637.wav",
+      "sha256": "1c219f294fb26f63b2bc4488c710e88be72770caa7e14410c88ec77bcfcb4182",
+      "transcript": "she was still hoping that houghton would marry her.",
+      "duration_sec": 2.972,
+      "speech_end_offset_ms": 2972.0,
+      "audio_hash_id": "c03a7def558c49138b93b95456258c0dd753b823b532482979f0345373ca8c6b"
+    },
+    {
+      "path": "audio/0638.wav",
+      "sha256": "417b0380b7395bc08442f514459f8bf1b76bac59c2727a51cc74b73100681549",
+      "transcript": "on the following day, the first clear sign of danger appeared.",
+      "duration_sec": 3.228063,
+      "speech_end_offset_ms": 3228.1,
+      "audio_hash_id": "c03baff2aee160a76dfa4f5d0759fbe57d830ba71a6c66a61640a365e163fd2a"
+    },
+    {
+      "path": "audio/0639.wav",
+      "sha256": "4a915cbb758f683ca14f8f4d0858ef165478db5b696dae1170be5ac3d729eb07",
+      "transcript": "he started learning the violin at age six and very soon showed promise.",
+      "duration_sec": 3.836,
+      "speech_end_offset_ms": 3836.0,
+      "audio_hash_id": "c0f5d0d13bbca6804ca5fb6e46780e2d296a0035f8782051471d5d6df73453ce"
+    },
+    {
+      "path": "audio/0640.wav",
+      "sha256": "2970898b79379454b69d59e4a236c943f4f2142c843017edf45cd6b61f4a3ddd",
+      "transcript": "on election night phone lines to both campaign offices were cut.",
+      "duration_sec": 4.668,
+      "speech_end_offset_ms": 4668.0,
+      "audio_hash_id": "c0ff13d362df4b4445954d810fc412d9a36aa701b7dcb928658593066999089c"
+    },
+    {
+      "path": "audio/0641.wav",
+      "sha256": "5efacd7b8bfa917c1b13b486627c4e3eae8ac92d49235b48ca278d5c54005314",
+      "transcript": "augustinus's mother gave birth to twins but the other child was stillborn.",
+      "duration_sec": 4.22,
+      "speech_end_offset_ms": 4220.0,
+      "audio_hash_id": "c12ad95bc339eb72d1a7106d86c43789a4f026b02c4174bbe5e4b3080418e392"
+    },
+    {
+      "path": "audio/0642.wav",
+      "sha256": "f42efea794b233902e55b1a8f6e95d96f535c553ae0d76e153ec02e441c33833",
+      "transcript": "each major religion in fiji has a public holiday dedicated to it.",
+      "duration_sec": 3.26,
+      "speech_end_offset_ms": 3260.0,
+      "audio_hash_id": "c1acd57e0f9f87cbf4b7d34f49247a9322d576b630b271e35f7930a48ac56104"
+    },
+    {
+      "path": "audio/0643.wav",
+      "sha256": "e146e4d2e10bd02910685fa48205f42e813f19066234ffee06e3890ed0798f03",
+      "transcript": "after that foul, the whole stadium was yelling angry things.",
+      "duration_sec": 3.004062,
+      "speech_end_offset_ms": 3004.1,
+      "audio_hash_id": "c22499962ee1eaa91f36332e18e3e37b22a46ede37dbaf448e4aa19af1df3caa"
+    },
+    {
+      "path": "audio/0644.wav",
+      "sha256": "98f343f16190cc05a200ff1f02d3860acb5d1efcb8b18fbd6eed183528466adf",
+      "transcript": "once settled, he was introduced to legendary songwriting duo kenny gamble and leon huff.",
+      "duration_sec": 5.212063,
+      "speech_end_offset_ms": 5212.1,
+      "audio_hash_id": "c227178dd5d7662b486044b7334eb46391588aa0206e7f2828ee8eadd18159fd"
+    },
+    {
+      "path": "audio/0645.wav",
+      "sha256": "5b8c99d2cb189a7d88b0ebae13cc25006e8fa34375125304c95ba953809d73ae",
+      "transcript": "like his brother robin, he has played on record with double bassist dave holland.",
+      "duration_sec": 4.54,
+      "speech_end_offset_ms": 4540.0,
+      "audio_hash_id": "c271c4e4aa410c4c51fe87dedf331b61099935185dcdc698bae2e8ab520abe77"
+    },
+    {
+      "path": "audio/0646.wav",
+      "sha256": "1a4676b041eb82def925db4eebdc12e640cc81758d3130036c84a3fe8c3b58d1",
+      "transcript": "then he roused himself from his reverie with a start.",
+      "duration_sec": 3.1,
+      "speech_end_offset_ms": 3100.0,
+      "audio_hash_id": "c29741721632de22e16fe6d602cb603ac1e785a086d8a0b115ac64490f19b59c"
+    },
+    {
+      "path": "audio/0647.wav",
+      "sha256": "d1308226e87d75f7661dceb471b6f71f32817b5d91d247ec80d24cbb99e28a89",
+      "transcript": "after later invasion by the goths, the region changed hands many times.",
+      "duration_sec": 3.772,
+      "speech_end_offset_ms": 3772.0,
+      "audio_hash_id": "c3736d2f9f3af3f18e1796781a26d0943c139badb5a26dc3d17ff3c27d632940"
+    },
+    {
+      "path": "audio/0648.wav",
+      "sha256": "eb398849107908321ec4e0bbfae50e63f913c5e26c11da54a802919e6dc6617b",
+      "transcript": "enthusiasts praise the cars for their looks, reliability, performance, and affordability.",
+      "duration_sec": 5.628063,
+      "speech_end_offset_ms": 5628.1,
+      "audio_hash_id": "c4451151fec7ec8fd807748abbc69e10661a099252f0bb52a6905a4473863a90"
+    },
+    {
+      "path": "audio/0649.wav",
+      "sha256": "219b9e10dc917c86d5311694027ccaab1d0b945eb41851c3e876be81d13cf7bc",
+      "transcript": "the press also commissioned works by contemporary artists, including dora carrington and vanessa bell.",
+      "duration_sec": 7.9,
+      "speech_end_offset_ms": 7900.0,
+      "audio_hash_id": "c44f9581de61c9aca3936f3387716ca77ef2601affafa779f007fcad4b804821"
+    },
+    {
+      "path": "audio/0650.wav",
+      "sha256": "7e2bfa2a597c196b519641088ccfb7436821937c187e1d6787ba4b0815c0443b",
+      "transcript": "he eventually worked at both directing and producing plays for the company.",
+      "duration_sec": 3.9,
+      "speech_end_offset_ms": 3900.0,
+      "audio_hash_id": "c4938aeb107b75f7eaa2ccaa6504aa534f99c4fa081c2a7bf79c74a4e3c13e0f"
+    },
+    {
+      "path": "audio/0651.wav",
+      "sha256": "de4340eb5c973fe89875268385f7026ad2915a7b676fb93b5587ad357eb30f5d",
+      "transcript": "his strongest showing was in kanata and kitchissippi ward.",
+      "duration_sec": 4.572063,
+      "speech_end_offset_ms": 4572.1,
+      "audio_hash_id": "c4bea1676bc66ea09e34ba43292ab346bb06db656305ba0693f07403985469dd"
+    },
+    {
+      "path": "audio/0652.wav",
+      "sha256": "9be4299d5e7b6dc78ddb8af566cef77e3fb9bc34ee5a8ee9a857424c52bfd9aa",
+      "transcript": "van orden has said he is a eurosceptic.",
+      "duration_sec": 3.804,
+      "speech_end_offset_ms": 3804.0,
+      "audio_hash_id": "c4e6f43ebfcaae2479f24558ee922763ee5f4ed098af80373a7d1921fe0358b5"
+    },
+    {
+      "path": "audio/0653.wav",
+      "sha256": "cca376d92933696412b99863402d942bce41185d8ac915b40fe8cb670569f3ea",
+      "transcript": "not everyone was intimidated by the axeman.",
+      "duration_sec": 2.204,
+      "speech_end_offset_ms": 2204.0,
+      "audio_hash_id": "c4f031397e83248b89236feb4599a3db42266f4474f57c7270213b46f49ef790"
+    },
+    {
+      "path": "audio/0654.wav",
+      "sha256": "de127bfae26823d1ad20d24a3c11b85286bc8ed9f7f1b8701c3d5ba8b7f8f780",
+      "transcript": "this presented a real threat to any government the tories attempted to form.",
+      "duration_sec": 4.156,
+      "speech_end_offset_ms": 4156.0,
+      "audio_hash_id": "c545a63f5f0505631cfbf64fa1b44fb9b147163f04d200c41bce3b59b81a227b"
+    },
+    {
+      "path": "audio/0655.wav",
+      "sha256": "9ce58b871a83513ba30ee5b2c98e40c74c614b08d30a282beb251d9df80f6afc",
+      "transcript": "a team in belfast has begun translating portions of the bible into ulster scots.",
+      "duration_sec": 5.34,
+      "speech_end_offset_ms": 5340.0,
+      "audio_hash_id": "c5559ce847fc93c4bb78db9e4405cd10c86070ef01916622cbdd846542ca87a6"
+    },
+    {
+      "path": "audio/0656.wav",
+      "sha256": "3fda26976ce7f9b4a5544df4cedc93a20c30694cf239a5162f27d227e9649802",
+      "transcript": "it is a typical traditional english village, centred on a village green.",
+      "duration_sec": 4.7,
+      "speech_end_offset_ms": 4700.0,
+      "audio_hash_id": "c59734c4ed82048be22afabba28a9dcc800aa1f2e62d8788f3fec9786400c047"
+    },
+    {
+      "path": "audio/0657.wav",
+      "sha256": "5aa5021f5a8d8e3709566311ddc09d32d18d6372b2d11b5ec81016c0af7e9931",
+      "transcript": "a large group of people sitting in a room and watching something.",
+      "duration_sec": 3.58,
+      "speech_end_offset_ms": 3580.0,
+      "audio_hash_id": "c59801a9720293a41f024aea1c1879db00ab806bf140a1f0332628a7501df972"
+    },
+    {
+      "path": "audio/0658.wav",
+      "sha256": "a4d7222be50e329e3905652812d61223296b838964d0b3007beff4f9f6df743f",
+      "transcript": "both of them includes one special bonus live track from the live sessions.",
+      "duration_sec": 4.572063,
+      "speech_end_offset_ms": 4572.1,
+      "audio_hash_id": "c6fa9bc3f485e4487283accabc81403c29c94a8797543f95f8cad0e1a5f6f243"
+    },
+    {
+      "path": "audio/0659.wav",
+      "sha256": "9e9cf7c4c670ba35f8a07ce4de41bcd4bdf946ff62d30f1b45f7c70e90e96cd3",
+      "transcript": "these fitted exactly the endoscope's tube, making them self-aligning, and required no other support.",
+      "duration_sec": 7.068,
+      "speech_end_offset_ms": 7068.0,
+      "audio_hash_id": "c6fd559464b635632416f96f565f4fae01f824f99e89f6d48a8e42f6c4971ebd"
+    },
+    {
+      "path": "audio/0660.wav",
+      "sha256": "3fdc14d89ec280fd6ac6c6d3d3db19d4bba6f968fd43eb0f8002574332b08c75",
+      "transcript": "on his return he was promoted to deputy commissioner.",
+      "duration_sec": 3.164062,
+      "speech_end_offset_ms": 3164.1,
+      "audio_hash_id": "c701aa937a27e92c80dfec7eb14a5c6a1bee0963c7a6bd7f49a3fa6685a4407d"
+    },
+    {
+      "path": "audio/0661.wav",
+      "sha256": "3fd43ef51a9832868f8d489a46b17da5e0b3552433e00bab1c593fbf82f155b7",
+      "transcript": "the family has a longer recorded heritage in politics, however.",
+      "duration_sec": 3.42,
+      "speech_end_offset_ms": 3420.0,
+      "audio_hash_id": "c73cb5282373009ffee3663aca348f3fe3b91ec8023491e7889487f902f52ee2"
+    },
+    {
+      "path": "audio/0662.wav",
+      "sha256": "ce3638e4dd1a4529bdd0bfdeb788f2a7695e382cb853f964006db75fa1db1615",
+      "transcript": "scientists have found the remains of several prehistoric animals, including a sloth.",
+      "duration_sec": 4.412063,
+      "speech_end_offset_ms": 4412.1,
+      "audio_hash_id": "c79548092d4d0790e4d20a7f20dd2f41fa13fd88e2bb04cd4e0e1e4b2422ae30"
+    },
+    {
+      "path": "audio/0663.wav",
+      "sha256": "59eeaedadd37f5dec6668d4db007d9f595dd367796f8256848b727ce6a8c8eb6",
+      "transcript": "pogue was a boy scout and earned the rank of second class.",
+      "duration_sec": 3.516062,
+      "speech_end_offset_ms": 3516.1,
+      "audio_hash_id": "c7cdc24133080f21c5fbfdf53f3b15fe552d924af5650eeaf707bb1837dc3784"
+    },
+    {
+      "path": "audio/0664.wav",
+      "sha256": "f138b988e64a4fa0b484362445f0ca4093b3503a66bd54337714a72150729912",
+      "transcript": "these laws had been extended over the entire territory of the republic.",
+      "duration_sec": 5.212,
+      "speech_end_offset_ms": 5212.0,
+      "audio_hash_id": "c8062fc419620fd008b7df39f27a717862f7a0508dc76786e65a5cacdebd3c5f"
+    },
+    {
+      "path": "audio/0665.wav",
+      "sha256": "af38dd22c2876d57fbccd6a647822cc90613628ffa886dd7e4e8d87dd2db6586",
+      "transcript": "he was again named to the pro bowl after the season.",
+      "duration_sec": 3.196,
+      "speech_end_offset_ms": 3196.0,
+      "audio_hash_id": "c82c9113a778db58a7e83e3d4e15e97cbc8e2aa08cd6380243bb502cede06e34"
+    },
+    {
+      "path": "audio/0666.wav",
+      "sha256": "b9a3d2e7cf3be8b4091f57392affa61fb9b111b7c155f769f42d47e0665af7b8",
+      "transcript": "mostly just the hearts of those who are trying to realize their destinies.",
+      "duration_sec": 3.772063,
+      "speech_end_offset_ms": 3772.1,
+      "audio_hash_id": "c84343ad7feb631b5cbb9fd1010550aec6786210b3518fe49a4fc02b83088514"
+    },
+    {
+      "path": "audio/0667.wav",
+      "sha256": "72b95b6235cd40bc022077f41aef598d1eda78e93d8eb7494eea7790fd6e5084",
+      "transcript": "insufficient purging had permitted oxygen to freeze in the gas generator during flight.",
+      "duration_sec": 4.22,
+      "speech_end_offset_ms": 4220.0,
+      "audio_hash_id": "c8a547f48fbdde6701c02616150aa016b543d1022646a925ce365ff2cb0202fd"
+    },
+    {
+      "path": "audio/0668.wav",
+      "sha256": "6f94a0a5e1ae7eff2d9f45228e6767afe71a5c0047215125436cd053741ecfb6",
+      "transcript": "many parishes have been created since then.",
+      "duration_sec": 2.684,
+      "speech_end_offset_ms": 2684.0,
+      "audio_hash_id": "c8adc7e80037e458a6e6d2ad0df20e67199166bc03d8f864c19d7254da8f129f"
+    },
+    {
+      "path": "audio/0669.wav",
+      "sha256": "caecb5b7c53b247a2e4884e428aafacdd20e072f27ec75eab06b806f3271fef1",
+      "transcript": "in addition he owned or co-owned all of the teams in the league.",
+      "duration_sec": 4.636063,
+      "speech_end_offset_ms": 4636.1,
+      "audio_hash_id": "c8cfd31171758e6f9ce338de443ecbd45f9c1df2046e776c374e3d1fdc2c49a3"
+    },
+    {
+      "path": "audio/0670.wav",
+      "sha256": "34ec28f22a5364dda96c0af405011643cf862920894b67ecf0976e52c454c54d",
+      "transcript": "he majored in english and history.",
+      "duration_sec": 2.812,
+      "speech_end_offset_ms": 2812.0,
+      "audio_hash_id": "c8df1eb0c17c7acc1ba7afe6acc213abfa56b6ea3f1017e21493cb877f6073df"
+    },
+    {
+      "path": "audio/0671.wav",
+      "sha256": "46b41e3e4fae82c587f2c698748e7ae6e619fab0d1558f0d940d147834a9da65",
+      "transcript": "then what does she want with you?",
+      "duration_sec": 2.364,
+      "speech_end_offset_ms": 2364.0,
+      "audio_hash_id": "c8e769fcd7faefb2d9926aa53cca2acafe562593c137b214365b017fcbe9893b"
+    },
+    {
+      "path": "audio/0672.wav",
+      "sha256": "5eff06faa3b5449c1a8c2e9579916dde0ae29b1449a60be148cd761a6f8748be",
+      "transcript": "the company enjoyed success under the direction of the odlums.",
+      "duration_sec": 2.94,
+      "speech_end_offset_ms": 2940.0,
+      "audio_hash_id": "c9b40072dfb87e72de87b94d214e9f5cfb7878e50ef4c9a76ae5b602501f8ce5"
+    },
+    {
+      "path": "audio/0673.wav",
+      "sha256": "5237336c326a025df84981c1a581aa967ce6c2fdbcc84f12cd6fc34fff12bd42",
+      "transcript": "go back to watching the caravan, he said.",
+      "duration_sec": 2.46,
+      "speech_end_offset_ms": 2460.0,
+      "audio_hash_id": "ca17936eba4faf7107f16cf51eeecbf8ecc199e671fa72ae9f97084d7617ef6d"
+    },
+    {
+      "path": "audio/0674.wav",
+      "sha256": "3b8e053dc69a44558aab64a7d8d05a1689eee849bd4856e8c330cf819d8b961b",
+      "transcript": "the stems are self-supporting or twining and climbing.",
+      "duration_sec": 3.356063,
+      "speech_end_offset_ms": 3356.1,
+      "audio_hash_id": "ca8a1798ce0693b1f9d3587fe6a1f4eb71c0b3e516ea0c92323c5e38ed399428"
+    },
+    {
+      "path": "audio/0675.wav",
+      "sha256": "2e51dd148243a3823e5af0ca8d93b127168e72c40e17347888ba80c8596e1919",
+      "transcript": "it also differs according to the amount of alumina present in it.",
+      "duration_sec": 3.676,
+      "speech_end_offset_ms": 3676.0,
+      "audio_hash_id": "cb3ce4167ab69b801d2d21c67b2403ec946d1e5fc3e25ccb3b0e5fed083728d4"
+    },
+    {
+      "path": "audio/0676.wav",
+      "sha256": "56ca7b4ecf0396eaaeadbf8badda3646d01e52910eb3b75343e124425481da64",
+      "transcript": "they took particular inspiration from aristophanes' disguising of political attacks as buffoonery.",
+      "duration_sec": 5.756062,
+      "speech_end_offset_ms": 5756.1,
+      "audio_hash_id": "cb9098db1d7be6406efc0e04210cd6f5b9d8c7661b175137f23751901fa0d1ea"
+    },
+    {
+      "path": "audio/0677.wav",
+      "sha256": "2ee7bba8872810de67daa40c73326b9a909687d78aca02b2d1afad0cd3d14c70",
+      "transcript": "this type of patients' skeletal maturation should be closely and regularly monitored.",
+      "duration_sec": 4.988062,
+      "speech_end_offset_ms": 4988.1,
+      "audio_hash_id": "cb91854edf13ed5ece10f68ae11f2ccf63fa1b3f49e944d65d7701b4c6ace7d4"
+    },
+    {
+      "path": "audio/0678.wav",
+      "sha256": "27262faa9a39eaf07a74d387fcfe6e2b597d08cd8f01218aafe06e45d6e2c428",
+      "transcript": "without loss of generality, we can consider only centered profiles, which peak at zero.",
+      "duration_sec": 5.66,
+      "speech_end_offset_ms": 5660.0,
+      "audio_hash_id": "cbb10e267d9850d5d8aca5b6631a281fff331a113ccad1f5a9345b973c94c6e0"
+    },
+    {
+      "path": "audio/0679.wav",
+      "sha256": "df2a89184e9b71c5c0d520171569ee0544c85f2b33c141e011f52859473493ee",
+      "transcript": "a white dog holds a tennis ball in its mouth in a field.",
+      "duration_sec": 3.158063,
+      "speech_end_offset_ms": 3158.1,
+      "audio_hash_id": "cbdb9e6b743134b764d156475330cbcbc072f82571dc2e25058ed674f1fcf875"
+    },
+    {
+      "path": "audio/0680.wav",
+      "sha256": "ad128aed707d05cfde8a43bccaf6ade869cd1eb74f631fe04f9c42572be29fc5",
+      "transcript": "bayard studied the law, and began his legal practice in the city of wilmington.",
+      "duration_sec": 3.964,
+      "speech_end_offset_ms": 3964.0,
+      "audio_hash_id": "cbfad72803e80ef088174bd75e91cb71fd3329ecf057026ae600e121e259491d"
+    },
+    {
+      "path": "audio/0681.wav",
+      "sha256": "b86b5835386e24c90a687504e69fea73260dd62163999d19c6aa664aa406f61c",
+      "transcript": "the cassette single made more references to sex.",
+      "duration_sec": 3.356,
+      "speech_end_offset_ms": 3356.0,
+      "audio_hash_id": "cc1bb4999ec4404617f1c9b40cf82db2b03dca1636d1460cf3c982f3afea5267"
+    },
+    {
+      "path": "audio/0682.wav",
+      "sha256": "00a8f8aa145720db51d0dd3f63fc9ad547fa71a86ff921b09722695df9d87be8",
+      "transcript": "the man looked up from his book and, noticing nothing newsworthy, returned his gaze to the page and continued reading.",
+      "duration_sec": 6.076,
+      "speech_end_offset_ms": 6076.0,
+      "audio_hash_id": "cc897cf96a6ee8d5fd4df37f167f7ffdef6ffa6cb7bf6fad4ccea4193620657b"
+    },
+    {
+      "path": "audio/0683.wav",
+      "sha256": "b41f2c6b9d87bb8345f9688786aa8be4e9332f345b793339717b3c3b74028c1b",
+      "transcript": "these streets are often built at the same grade as sidewalks, without curbs.",
+      "duration_sec": 4.252,
+      "speech_end_offset_ms": 4252.0,
+      "audio_hash_id": "cc9233cc149dc44b4754ed60d8c5e502bcd2d442dc448d98ad5837f0e2e123dc"
+    },
+    {
+      "path": "audio/0684.wav",
+      "sha256": "56f81cc2b43837747a71e656749c895816b9485a3836b399d12fcb4d6fca3226",
+      "transcript": "his engravings representing satirical peasant scenes are well known.",
+      "duration_sec": 5.948062,
+      "speech_end_offset_ms": 5948.1,
+      "audio_hash_id": "cce76fda4d82c124dee171d3df2e135a8ea80d2281dd646b79ffc1fbb1d5c8e6"
+    },
+    {
+      "path": "audio/0685.wav",
+      "sha256": "b4f8bdd7844f420e511dec438b5d91913ba4b40e5c979a93fd8a05dcc9524292",
+      "transcript": "the town contracts for its trash collection and fire-fighting services.",
+      "duration_sec": 4.284,
+      "speech_end_offset_ms": 4284.0,
+      "audio_hash_id": "cd0968fec73376b14b62310c805e696aa74be52ab91fe97d4f65ec5ccb42d3c3"
+    },
+    {
+      "path": "audio/0686.wav",
+      "sha256": "207e4d915ae4da98124756baec4e93b8464ec8a7f5e2b00425495418b726d8cc",
+      "transcript": "the christians were already numerous in the time of diocletian.",
+      "duration_sec": 3.42,
+      "speech_end_offset_ms": 3420.0,
+      "audio_hash_id": "cd3ae9afbdaa77583da4c5d616ce97d998f3ba86705c1350558e9c3b8a369a6d"
+    },
+    {
+      "path": "audio/0687.wav",
+      "sha256": "6b545dc9ac61bfd652253ab22e60e59275cfb42e1f3728cd356f5a9d24b65bed",
+      "transcript": "they looked for the fallen mass, but found nothing.",
+      "duration_sec": 2.876063,
+      "speech_end_offset_ms": 2876.1,
+      "audio_hash_id": "cd419386ab59931e195a6ed78c0cd6ffcd5b677b43969e95b4878f83cdc7d252"
+    },
+    {
+      "path": "audio/0688.wav",
+      "sha256": "4c538e3fa4e13db10a921a23b3154f782d34599808571c7b3f57360ae51bb3bf",
+      "transcript": "it can be grown from a melt by the czochralski technique.",
+      "duration_sec": 3.196,
+      "speech_end_offset_ms": 3196.0,
+      "audio_hash_id": "cd522303768a370a9391e0ac932fe7dcae9187525f79ba540a6cefaf010f22e6"
+    },
+    {
+      "path": "audio/0689.wav",
+      "sha256": "957d0e7559215820aadd0988a269db44db9e018be67f7d8bea35b619559bb15e",
+      "transcript": "prickly pear cactus and poison ivy are fairly common as well.",
+      "duration_sec": 4.188,
+      "speech_end_offset_ms": 4188.0,
+      "audio_hash_id": "cd87d8b9f8db916b95e441c5a8b4c2b63e572175f45d805cc70801ec2c7598a4"
+    },
+    {
+      "path": "audio/0690.wav",
+      "sha256": "3a7d5be10ab4c51c053b8349ab33bcd9e794c0e405e195acd32b46fd73803189",
+      "transcript": "not an angling target due to small size.",
+      "duration_sec": 2.652,
+      "speech_end_offset_ms": 2652.0,
+      "audio_hash_id": "cda9ec44b3010394ef3949a8e866944e6294890adc3bdd1e3926967726a4a24d"
+    },
+    {
+      "path": "audio/0691.wav",
+      "sha256": "d6bc295858f04bba7a77cf810d94831b46f5b5aefb009d250d4160de75b494ec",
+      "transcript": "the show revolves around ellingham's interactions with the local cornish villagers.",
+      "duration_sec": 5.02,
+      "speech_end_offset_ms": 5020.0,
+      "audio_hash_id": "ce21feec21f6bd573593672cda2d0dcea762d65227de280884048c8d134990f1"
+    },
+    {
+      "path": "audio/0692.wav",
+      "sha256": "07e8d17276930b9260680fe3f588f061093341d9fbae00ef6152d3878a00bad4",
+      "transcript": "the memories of great battles linger long among the peasantry of the neighborhood.",
+      "duration_sec": 4.476063,
+      "speech_end_offset_ms": 4476.1,
+      "audio_hash_id": "ce562585e7a6ea74d2e5ad6823a8b2c3a0bbd13712fc1db121433ef535fee8bb"
+    },
+    {
+      "path": "audio/0693.wav",
+      "sha256": "61cdb20c1d9024b61086dd7b2ff0ce788bf2e28f11a207cd47236ead6f444560",
+      "transcript": "if the valuable resources were dispersed, there would be less observable territorial behaviour.",
+      "duration_sec": 5.244,
+      "speech_end_offset_ms": 5244.0,
+      "audio_hash_id": "cebcf607c01e331dc950abad8087fd877a3ead11dbc4074e6de7d7ac7e0d5f3b"
+    },
+    {
+      "path": "audio/0694.wav",
+      "sha256": "d50d16180957ca2ac036a2439448191f82f7146791557630127c18b2c538fe7f",
+      "transcript": "the receiver then declares that it has found the frame.",
+      "duration_sec": 2.652,
+      "speech_end_offset_ms": 2652.0,
+      "audio_hash_id": "cf08a90ebb3d167d0a228f1a9b82707f8eadf21e42315fa41c16dc4add4c71b0"
+    },
+    {
+      "path": "audio/0695.wav",
+      "sha256": "58054ee7740aa0a5a623dacaf59d21552626457c5a07421084c6bb19f96b3063",
+      "transcript": "salt and sour receptors are chemically gated ion channels, which depolarize the cell.",
+      "duration_sec": 6.204,
+      "speech_end_offset_ms": 6204.0,
+      "audio_hash_id": "cf3da58da84164abb6b3ea6e028b93175425bacad8b76a8bd42148b568992e98"
+    },
+    {
+      "path": "audio/0696.wav",
+      "sha256": "a53ec1627759499937b1ec1816a41458069b67c23b83245aaa23506cae130d90",
+      "transcript": "the young are similar but have yellow bills.",
+      "duration_sec": 2.46,
+      "speech_end_offset_ms": 2460.0,
+      "audio_hash_id": "d02c08b8e97d6da77d91d343f0aa4ce81d5b09c36297e70e8ae6570093c113ed"
+    },
+    {
+      "path": "audio/0697.wav",
+      "sha256": "c6b078bf7d158d66dae4aa3077cba83e2e52bc47f5a92b7fdf2fe96da1cea2ac",
+      "transcript": "the stranger was speaking of things that very few people knew about.",
+      "duration_sec": 3.228,
+      "speech_end_offset_ms": 3228.0,
+      "audio_hash_id": "d058e589fc4d18875d4f376114f00711255a93b3e7fe14850dd0487585373647"
+    },
+    {
+      "path": "audio/0698.wav",
+      "sha256": "d50ab9ddae4a8c97158e08e1f99884cef17fec299f36525fa285c321fccdba64",
+      "transcript": "he who drinks a little too much drinks much too much.",
+      "duration_sec": 4.092062,
+      "speech_end_offset_ms": 4092.1,
+      "audio_hash_id": "d112923b8f58929adf496d47abe876c98bdf6c9b57eb39252097e726bb1870d5"
+    },
+    {
+      "path": "audio/0699.wav",
+      "sha256": "3f208e6b5d027bc9a51ebae7e947865ec368c7a0a8086de4346f114c2428f60f",
+      "transcript": "but there they saw a crystal shop that offered refreshing mint tea.",
+      "duration_sec": 3.918063,
+      "speech_end_offset_ms": 3918.1,
+      "audio_hash_id": "d168e3eb377dbca22adc98fdb3bfb69cf6ec0d2177b0e678f9c23eac800b9dff"
+    },
+    {
+      "path": "audio/0700.wav",
+      "sha256": "a9840325012c8c03952ae3a516f9ee4ee26b5547ab133b62102973eb733c19bf",
+      "transcript": "however, he was suspended for multiple personal offenses, which hurt him deeply.",
+      "duration_sec": 5.628063,
+      "speech_end_offset_ms": 5628.1,
+      "audio_hash_id": "d1b75eb2736ff4beb3318dfbc44275e69f57a7437e96194a2f6caf95aab6fd66"
+    },
+    {
+      "path": "audio/0701.wav",
+      "sha256": "9978f939bcd54415da1dc7a6033fe485126ae004fe5250510c9205f221ef42fd",
+      "transcript": "so the boy was disappointed; he decided that he would never again believe in dreams.",
+      "duration_sec": 4.670063,
+      "speech_end_offset_ms": 4670.1,
+      "audio_hash_id": "d20228de4f127e0d9bd4bd1b5d80d1c863a376d4cb1b1cffef4b43ec77e7e22e"
+    },
+    {
+      "path": "audio/0702.wav",
+      "sha256": "60be4b1826f861dde8307883baad92679b970a299931396abf745f4343c39944",
+      "transcript": "as he looked at the stones, he felt relieved for some reason.",
+      "duration_sec": 2.812,
+      "speech_end_offset_ms": 2812.0,
+      "audio_hash_id": "d20c6b268ad9f4f3adf036dbdfc2e9b0e73a5429d59aefd6d966faefa1c50e9a"
+    },
+    {
+      "path": "audio/0703.wav",
+      "sha256": "0410ceeadcb21ddb2c193f9a4cfc25b8e1db7259cc8a2ea2aab36099889628f9",
+      "transcript": "when there's a loss of cabin pressure, oxygen masks will automatically drop down.",
+      "duration_sec": 4.444063,
+      "speech_end_offset_ms": 4444.1,
+      "audio_hash_id": "d253d7e3eab8c8220919e4f8871e16cdc1061221ec837ef64afa16816c971c03"
+    },
+    {
+      "path": "audio/0704.wav",
+      "sha256": "1c7112354aea1a83852d098bbe7ff9738d6b785fff1788befa428edd1d63f034",
+      "transcript": "they walked together through the narrow streets of tangier.",
+      "duration_sec": 2.78,
+      "speech_end_offset_ms": 2780.0,
+      "audio_hash_id": "d32d85d719883871cf20356d24920a772be536275488d93611f1406b4838324d"
+    },
+    {
+      "path": "audio/0705.wav",
+      "sha256": "54af111c0c5735704cb56fcc62ff2343bf754ea8fb4e67ccf19908354c7ae1b5",
+      "transcript": "the ship was named after admiral lord rodney.",
+      "duration_sec": 3.036062,
+      "speech_end_offset_ms": 3036.1,
+      "audio_hash_id": "d36d3af71cd75e6dc76370aa7dea40c51b032e37d4a4ba4bc2492407063601f6"
+    },
+    {
+      "path": "audio/0706.wav",
+      "sha256": "aba87572f8b9b30868441900b816dd4e998a589695b162b093aa71f2b8c2a329",
+      "transcript": "the relationship between material conditions and value priorities is not one of immediate adjustment.",
+      "duration_sec": 5.788062,
+      "speech_end_offset_ms": 5788.1,
+      "audio_hash_id": "d389edd9c7203b9251dfd16ad36717b82c4c1dc4c3ce0090c1314e8b3ba51a12"
+    },
+    {
+      "path": "audio/0707.wav",
+      "sha256": "9023c19151be49d1ffe388edfcbc3835f8894ddb8a4a2cb31bb063d070136b97",
+      "transcript": "the city is the county seat of sharp county.",
+      "duration_sec": 3.1,
+      "speech_end_offset_ms": 3100.0,
+      "audio_hash_id": "d3f926c72014a4cc7621b2b094b7d744c3e839620517c086387858584fda364c"
+    },
+    {
+      "path": "audio/0708.wav",
+      "sha256": "5770cc7ae60dc805508f158ccf3838a8038374a2431009abe83feef13b107a21",
+      "transcript": "the solemnity of his manner impressed him.",
+      "duration_sec": 3.046063,
+      "speech_end_offset_ms": 3046.1,
+      "audio_hash_id": "d439f9556ec84da8c1d50ab718c94ba5e14c088db9d95af2e891bbc4a243b845"
+    },
+    {
+      "path": "audio/0709.wav",
+      "sha256": "4eb6eae1f0581199f71c7f98237c627f452063603f6b8ee45daf27715c59a135",
+      "transcript": "it was such a gradual movement that he found it only by noticing the dots.",
+      "duration_sec": 4.828062,
+      "speech_end_offset_ms": 4828.1,
+      "audio_hash_id": "d496b8465c00961111ad59f468447116cf710c9040c897751c3c43481f553df0"
+    },
+    {
+      "path": "audio/0710.wav",
+      "sha256": "6c64c2a205052c831fc398ebc245ed8efcc33adaab883777927a7da848de7798",
+      "transcript": "it is a lexicographical product which shows inter-relationships among the data.",
+      "duration_sec": 4.828062,
+      "speech_end_offset_ms": 4828.1,
+      "audio_hash_id": "d4a7a15d24fb0611d0ebc84878caeb11a5ff03f119e328684e4baca8662ff658"
+    },
+    {
+      "path": "audio/0711.wav",
+      "sha256": "77ec2143834896a863c9a2302501672604154dafce88f3465054ff293d44b822",
+      "transcript": "the kennel club separated the two types eight years later.",
+      "duration_sec": 2.94,
+      "speech_end_offset_ms": 2940.0,
+      "audio_hash_id": "d4b51a5c79d480f15172a68d5184f576b49b754c62c75c40531003da0e3c9902"
+    },
+    {
+      "path": "audio/0712.wav",
+      "sha256": "9a9a03c153144eba889da20fac9c8acf54142a4cab7dcb8aa82e2ac7536172ae",
+      "transcript": "the feast of saint dominic is held every last sunday of august.",
+      "duration_sec": 4.54,
+      "speech_end_offset_ms": 4540.0,
+      "audio_hash_id": "d4d4542cea56e474efce0b1ad024f840133f59aa4b3874ef01293ad2c767746a"
+    },
+    {
+      "path": "audio/0713.wav",
+      "sha256": "539f1454be37939517fc51ce4046c0f6537714253db3d295a51da16752040732",
+      "transcript": "another development was the insight into the delimitation of the concept of 'plant'.",
+      "duration_sec": 4.796062,
+      "speech_end_offset_ms": 4796.1,
+      "audio_hash_id": "d4d6b0f0aab8d4b5e80e16e0e9c8827f8992888cc86ff02e2958cb7e2603c90a"
+    },
+    {
+      "path": "audio/0714.wav",
+      "sha256": "02d490121cc8fc83200630c0d8448bbc8b45ae310abe96645d5bf0d975e43b67",
+      "transcript": "the stranger withdrew the sword from the boy's forehead, and the boy felt immensely relieved.",
+      "duration_sec": 5.18,
+      "speech_end_offset_ms": 5180.0,
+      "audio_hash_id": "d4ebc63bd35757c57de6c5ce9047f0de6276aaf424ca0308036a0fb24bf19687"
+    },
+    {
+      "path": "audio/0715.wav",
+      "sha256": "1468132585b7a08e1ff89764700be15f38e4ba59ecd86081d63bde272700fc7e",
+      "transcript": "melrose park sits on the northern bank of the parramatta river.",
+      "duration_sec": 3.772063,
+      "speech_end_offset_ms": 3772.1,
+      "audio_hash_id": "d5a8642a695957d319bac22ece882a222cd3c1c443b18fbeb7801998f5202a27"
+    },
+    {
+      "path": "audio/0716.wav",
+      "sha256": "9699c9785c352b6f9ab935a75fc05594be3a435c4fa2897ffc39ea33775c2a7b",
+      "transcript": "the village is nowadays part of the municipality of korsholm.",
+      "duration_sec": 4.348063,
+      "speech_end_offset_ms": 4348.1,
+      "audio_hash_id": "d5ace1622be7f571ed9e1cf813b79a38f13b8089c5fc9ccc812ef50ac2f4319d"
+    },
+    {
+      "path": "audio/0717.wav",
+      "sha256": "2ae4ed045cb812863c6bfc594dfc70d17b4478d5d0c76c223dad6abe75aec4e3",
+      "transcript": "they naturalize easily and can come back year after year in the garden.",
+      "duration_sec": 3.516062,
+      "speech_end_offset_ms": 3516.1,
+      "audio_hash_id": "d6bc7c756faaafee9242996f8d488e659e2b6d705c4e562036cf28aa8a3890e7"
+    },
+    {
+      "path": "audio/0718.wav",
+      "sha256": "1a22fba435a7f3d21151ffb594fb3e57d6b478dcf9071a699545ff487c91d6ba",
+      "transcript": "the number often identifies one who is persecuted.",
+      "duration_sec": 3.004,
+      "speech_end_offset_ms": 3004.0,
+      "audio_hash_id": "d710a0046949ba8bc79b0a3a502bfdc4d5f1dcf4e55d4ba8e8efef532b40cbba"
+    },
+    {
+      "path": "audio/0719.wav",
+      "sha256": "8e90f75ab706c0521e91afacbad4590efd794187ac4f72cb8efb22309824ed01",
+      "transcript": "the main sources of income for the jewish community were trading and industrial occupations.",
+      "duration_sec": 5.244,
+      "speech_end_offset_ms": 5244.0,
+      "audio_hash_id": "d733d2270062df67dd440a2b1b844f1040dbf375ade9432fa8617c2a682a9a6d"
+    },
+    {
+      "path": "audio/0720.wav",
+      "sha256": "287988766d269b89f2d50f8e0b48e479f20ff56e4a258853786679ab8e87d243",
+      "transcript": "the town is within the locality of bakers bend.",
+      "duration_sec": 3.196,
+      "speech_end_offset_ms": 3196.0,
+      "audio_hash_id": "d771bf2c5bf3d9f3eda0f75206ed63c8bfc07fdf9a195d7aa0717424938b0e44"
+    },
+    {
+      "path": "audio/0721.wav",
+      "sha256": "df04569630c42a2fd3be52ada91537652b0b9e19f2ee194cdbfd737787391c64",
+      "transcript": "since he has your orders to come, i will not interrupt you.",
+      "duration_sec": 3.42,
+      "speech_end_offset_ms": 3420.0,
+      "audio_hash_id": "d77565d0bcaa3bcf9764afd66efce00eed1353d14471f0faaa9c7634d2edb4eb"
+    },
+    {
+      "path": "audio/0722.wav",
+      "sha256": "019cdf012d9f30628f3683115982f3ed3b72c8f48662c5f7351f92bb11a01d5a",
+      "transcript": "yes, but why is there straw anyway?",
+      "duration_sec": 2.972,
+      "speech_end_offset_ms": 2972.0,
+      "audio_hash_id": "d7c5e9d4955404ace58fd8fdfa33a7028f7da100f2b0425ee3997144f036d71e"
+    },
+    {
+      "path": "audio/0723.wav",
+      "sha256": "62c91fa3ffa8383952d7af32f2630b6d7a95f69fc2ae8f6fe2d8d39b73f63aa7",
+      "transcript": "the tallinn boycott influenced most sailing events.",
+      "duration_sec": 3.036062,
+      "speech_end_offset_ms": 3036.1,
+      "audio_hash_id": "d8f765630a159232cb9ee624cdc9beb865c8b436194f2c00f94f4e20e71ff20f"
+    },
+    {
+      "path": "audio/0724.wav",
+      "sha256": "46796fbe3e7fd24a1c56ff0d2c87cdbfd83d408864dce6e3cbf045103feedbf1",
+      "transcript": "shortly after david brown purchased aston martin, construction began on an updated version.",
+      "duration_sec": 6.716,
+      "speech_end_offset_ms": 6716.0,
+      "audio_hash_id": "d9048a4f2bc47a43cb4c65d4705f86856bb0673394993edea18f56415f01daa3"
+    },
+    {
+      "path": "audio/0725.wav",
+      "sha256": "a249aa054615cad630aedac16fb028877c1e2e1fee129d1db45a97b4ed8b4c8f",
+      "transcript": "he died at home with his wife and family around him.",
+      "duration_sec": 3.1,
+      "speech_end_offset_ms": 3100.0,
+      "audio_hash_id": "d9484b787e34bd950574a37049e50b4bc24dbd30eb1549414a1850cd7853a7ea"
+    },
+    {
+      "path": "audio/0726.wav",
+      "sha256": "0fda02f4b0a987700ec3527543187adbec4dd1a8e842837e4f1c364ed6c099f1",
+      "transcript": "the fungus grows parasitically on \"xanthoparmelia\" lichens.",
+      "duration_sec": 4.86,
+      "speech_end_offset_ms": 4860.0,
+      "audio_hash_id": "d9b926684be0f1b42bf9e72922bae30fc6aa196cb572c6405d0661da32ace487"
+    },
+    {
+      "path": "audio/0727.wav",
+      "sha256": "c2a166d5e734f1b8891748017999331d61015e443da8982c0a27519229827ef4",
+      "transcript": "harrison's troops buried their own dead on the site of their camp.",
+      "duration_sec": 2.908063,
+      "speech_end_offset_ms": 2908.1,
+      "audio_hash_id": "da0954e835ee913e0ccbc3cba147d9b9013912f0c9f4b0d81ddbe9a964040fca"
+    },
+    {
+      "path": "audio/0728.wav",
+      "sha256": "372c5c7fa8a7cf7581e495b18bf857a4e796232ab226452767f564726bbe49a1",
+      "transcript": "the majority of chinese people in semporna are from the hakka dialect group.",
+      "duration_sec": 5.02,
+      "speech_end_offset_ms": 5020.0,
+      "audio_hash_id": "da5b3a6270dd9de18776c1bbae8966de2be471b18fb887b28b3c7ca6dd18063b"
+    },
+    {
+      "path": "audio/0729.wav",
+      "sha256": "dd9d9e99de487da380740ff2df81c23202df1f0aabb5a0c0e5f581945027f1ed",
+      "transcript": "to do that successfully, i must have no fear of failure.",
+      "duration_sec": 3.036062,
+      "speech_end_offset_ms": 3036.1,
+      "audio_hash_id": "da5d2e0e9cc27cda91a5ca80d20dfecac6cb4b0576173ece4f0b2b1fd2e25dc5"
+    },
+    {
+      "path": "audio/0730.wav",
+      "sha256": "0f848cd96ad1c1c29019a4d745f052a72121c76b207fd1fe886cae965a4dceb8",
+      "transcript": "air tank for raising the pantograph is located in \"b\" crew compartment.",
+      "duration_sec": 4.732,
+      "speech_end_offset_ms": 4732.0,
+      "audio_hash_id": "dac4928fa6c95dad35c05ee3496cfe32a12e4d74975dca4f0c663f3eec0e870a"
+    },
+    {
+      "path": "audio/0731.wav",
+      "sha256": "d16431743906cb0360996b08613c5f02aba7568f2f7436dfd6c64a15527579dd",
+      "transcript": "the ambassador featured a lengthy list of standard features and options.",
+      "duration_sec": 3.836063,
+      "speech_end_offset_ms": 3836.1,
+      "audio_hash_id": "dae42a5261a04ffa6c11dd831adc5e6d519271cf248c890f1e2ba48df252369c"
+    },
+    {
+      "path": "audio/0732.wav",
+      "sha256": "3fe9206e7eec4b29c9f6d33d92d836414def59aa08e1835eb78896823d8712a3",
+      "transcript": "the couple had no children, perhaps because of karl's homosexuality.",
+      "duration_sec": 4.06,
+      "speech_end_offset_ms": 4060.0,
+      "audio_hash_id": "daea8bc1a16e5bb643a1f5e65e2b6c455918142d951f401e97f947882f0b24ba"
+    },
+    {
+      "path": "audio/0733.wav",
+      "sha256": "39a0765fe1c444a4b826dbbe821d263738fdb70cdc2d1e16f8ddf31615ea228f",
+      "transcript": "despite this, it was used in the past in herbal medicines.",
+      "duration_sec": 3.484,
+      "speech_end_offset_ms": 3484.0,
+      "audio_hash_id": "db650cfbfe4a411a74197219bc6f80eb8ff3aa26a07a4066bb496a1d38b3b1ea"
+    },
+    {
+      "path": "audio/0734.wav",
+      "sha256": "2ed7cac7d9c4e5592169c48f6ff2d3dd32b6601220f5c0e38bd858b43ce8d81f",
+      "transcript": "the turf and gravel around it seemed charred as if by a sudden explosion.",
+      "duration_sec": 4.124,
+      "speech_end_offset_ms": 4124.0,
+      "audio_hash_id": "db8c75100d24a6f98a46e9dc95ce6b198a62809aab609cdd63dc54e9a9037bd1"
+    },
+    {
+      "path": "audio/0735.wav",
+      "sha256": "6b4d4251dd7c189c4557c5ef4c5e1cead7dcf318c63a4d3a3ea170261286ed7f",
+      "transcript": "the ethnic majority in belarus are called belarusians.",
+      "duration_sec": 3.42,
+      "speech_end_offset_ms": 3420.0,
+      "audio_hash_id": "db9c27387875d8ab88cb003bcac23ff10c890cfbddfed5e0739dc07104b2e40b"
+    },
+    {
+      "path": "audio/0736.wav",
+      "sha256": "bf9ea7455a0da1efbb89fd9efcfe3925350ee9873f989d94a7cabb0f34ad9c61",
+      "transcript": "the people were also praying to heaven for protection.",
+      "duration_sec": 3.484,
+      "speech_end_offset_ms": 3484.0,
+      "audio_hash_id": "dbebaa67ef8a3ce61ae7da817b1338433b717711857acbc40419f0622bd62872"
+    },
+    {
+      "path": "audio/0737.wav",
+      "sha256": "b1c658f99214cc3aa55a14e55eaab13e0ce55199444e1ab9896294d8a36c7748",
+      "transcript": "under state law, state legislators are required to live in the districts they represent.",
+      "duration_sec": 4.828062,
+      "speech_end_offset_ms": 4828.1,
+      "audio_hash_id": "dc1e8514cb103fcd74db624b29c607d69808df09280a6d258a67f911610d2845"
+    },
+    {
+      "path": "audio/0738.wav",
+      "sha256": "3d0b35dbbd056267ff154891007592492b038a9123dea129e718f35ff31ab11e",
+      "transcript": "in the film, lee played loti, a hong kong narcotic agent.",
+      "duration_sec": 4.252,
+      "speech_end_offset_ms": 4252.0,
+      "audio_hash_id": "dcb24574ac9f9277aa88cafd9f3979d6898f982ac861e3e2bdbf2264c786ae5b"
+    },
+    {
+      "path": "audio/0739.wav",
+      "sha256": "a6abe9260ffa52d75730ed503763911c7e5ca887054b63e762c000afd876ab47",
+      "transcript": "satoshi takebe composed the music for the film.",
+      "duration_sec": 3.26,
+      "speech_end_offset_ms": 3260.0,
+      "audio_hash_id": "dd10bbd7c3371b5b9130e5956a666e941389840569343bca6b0e3c0e8e8d98a1"
+    },
+    {
+      "path": "audio/0740.wav",
+      "sha256": "534bade4669ddecca39f14bbe2703065369fb5ccd9fccb3f15eb5b93e375b605",
+      "transcript": "the streamer of gas came out towards us.",
+      "duration_sec": 2.134063,
+      "speech_end_offset_ms": 2134.1,
+      "audio_hash_id": "dd23f3ce832ef91508959045c2c1ac00ca79930c9c59bf40548d8c251ea4f8b5"
+    },
+    {
+      "path": "audio/0741.wav",
+      "sha256": "8aa27d16941c867dac1bfc711b95c2350139a96c80e012e6c629b5e55b0939ce",
+      "transcript": "the hot spare is active and connected as part of a working system.",
+      "duration_sec": 3.612062,
+      "speech_end_offset_ms": 3612.1,
+      "audio_hash_id": "dd699c4eb22df9cbebc53030fcbffe38b7c0f5ca7e2ce45aea3beb134c4ee5bd"
+    },
+    {
+      "path": "audio/0742.wav",
+      "sha256": "c79bc24b3542856d816fda02147c00dca94f8de02cb83541a24097d84c307df9",
+      "transcript": "unfortunately, nobody can warrant that the sanctions will have an effect on the community.",
+      "duration_sec": 3.966063,
+      "speech_end_offset_ms": 3966.1,
+      "audio_hash_id": "ddcaaf835ff69f081d88e0dc064263a8e041652f15a9a7700587cd585c84520e"
+    },
+    {
+      "path": "audio/0743.wav",
+      "sha256": "f9c74826e1283f4366658aeb00497d83d1b53410d3777d146b744e92ab62d5b5",
+      "transcript": "karl lagerfeld has described her as one of the best models in the world.",
+      "duration_sec": 4.028062,
+      "speech_end_offset_ms": 4028.1,
+      "audio_hash_id": "ddf8ae782a03da15647a6d34e7cb08391df6f3822bdf8d3e6f98d6c5c189d6e1"
+    },
+    {
+      "path": "audio/0744.wav",
+      "sha256": "4479d8b6359965ee43699e69a7c5452c1f18b4cbb83b551c78aa651a20e13b6c",
+      "transcript": "this was the strangest of all things that ever came to earth from outer space.",
+      "duration_sec": 4.118062,
+      "speech_end_offset_ms": 4118.1,
+      "audio_hash_id": "de0af115915becad5ce05b9a5c1a63bf5b7a6046f2296dc409041b3970cbf455"
+    },
+    {
+      "path": "audio/0745.wav",
+      "sha256": "cc80c02e1078bc3d976b41e14e2b515970ea2cf93bfb253189a89093fa0ea5d9",
+      "transcript": "forecasters recognized the elevated risk for severe weather early in the day.",
+      "duration_sec": 4.54,
+      "speech_end_offset_ms": 4540.0,
+      "audio_hash_id": "de1009c315384ba08fe1fd99a891794cc33928f1200f8aa083bce3b1ce8bc831"
+    },
+    {
+      "path": "audio/0746.wav",
+      "sha256": "fd6cb2f821382a43e5df59e1dcacf1ddf0d350105b1edbca096ef3eece5129fa",
+      "transcript": "today, robert resides in southern california.",
+      "duration_sec": 2.492,
+      "speech_end_offset_ms": 2492.0,
+      "audio_hash_id": "dedc515fffeffb17ad67b02f4e7bfa8ded1267d81841e7df6dfd5840722c498a"
+    },
+    {
+      "path": "audio/0747.wav",
+      "sha256": "311590dbede0a1d1ce6bd3d8225cd20afe7494efeff4c40905fbbb772d8f1da7",
+      "transcript": "the vestry is behind the main church.",
+      "duration_sec": 2.204063,
+      "speech_end_offset_ms": 2204.1,
+      "audio_hash_id": "df54fec174d4112e8ced6cd5f197b041d12b7b0616b9028fc0e065e318c4b789"
+    },
+    {
+      "path": "audio/0748.wav",
+      "sha256": "1bd3a5efe8ef1ea3d9b17ec4148f25727d53929d4d7e4184a2ed49f281a8d7da",
+      "transcript": "douglas has also collaborated with artist puppies puppies.",
+      "duration_sec": 3.452,
+      "speech_end_offset_ms": 3452.0,
+      "audio_hash_id": "e03eaf13213bb7549b138ac48c4d0e778c93c8e09a5b689430616decd5c5dd87"
+    },
+    {
+      "path": "audio/0749.wav",
+      "sha256": "00802bf83a2a4a93354db193fad41cba7529e7b075cb04f0acda72a9c0e10ae6",
+      "transcript": "adam was not well, said shuttleworth indignantly.",
+      "duration_sec": 3.676,
+      "speech_end_offset_ms": 3676.0,
+      "audio_hash_id": "e04bf68fed70503b7d91dafb0dea1a4270110f1de7cce239e4c1a919ed353215"
+    },
+    {
+      "path": "audio/0750.wav",
+      "sha256": "05412e7ba7f73b1bde8e123010f36c3f571b5e7f7ae42fd5f5c502331096fc04",
+      "transcript": "no republican filed to run, so landrieu faced only democratic opponents.",
+      "duration_sec": 6.46,
+      "speech_end_offset_ms": 6460.0,
+      "audio_hash_id": "e068491057ac3c19aa2f6c1ea5f80910c77ada2b76ec57b6b75c180790ae1e4f"
+    },
+    {
+      "path": "audio/0751.wav",
+      "sha256": "1fea6e9eef91bf73ae6a6ae545389c375cbfa762c12a8646a6bb0f9176231b38",
+      "transcript": "it was quite a joke in the hotel.",
+      "duration_sec": 2.364,
+      "speech_end_offset_ms": 2364.0,
+      "audio_hash_id": "e0af6d57e9024aa543853a00790f3659c19157e390b1d94853a2558c0750c63c"
+    },
+    {
+      "path": "audio/0752.wav",
+      "sha256": "b95e3f482dbc9695443d7ca90fa3ea9b3ef1e23e8f64db21836c26b908f447ee",
+      "transcript": "a \"carabinero\" general was one of the town's founders.",
+      "duration_sec": 4.028,
+      "speech_end_offset_ms": 4028.0,
+      "audio_hash_id": "e125e69d080e429f8e9cca4c8386d05950760e698b926e929c6ca0b357be7d4a"
+    },
+    {
+      "path": "audio/0753.wav",
+      "sha256": "765dea33232adee18f0aa5efe9e34588c72f369c30d0c0c5ae3b6b0cf1a4dd7d",
+      "transcript": "that identifier might be repeated several times.",
+      "duration_sec": 3.004,
+      "speech_end_offset_ms": 3004.0,
+      "audio_hash_id": "e12a727db3a1014b1ec377244ca0ed34030a323a681707f286f7f923f7bf1caf"
+    },
+    {
+      "path": "audio/0754.wav",
+      "sha256": "fccf266ac0e51b499ccbbb16e540e942ff9f1dbe16f624eb6fa3847c6e81f93d",
+      "transcript": "ministers of central government departments rarely hold politburo seats.",
+      "duration_sec": 4.476,
+      "speech_end_offset_ms": 4476.0,
+      "audio_hash_id": "e15c7d32c46c3624c2e65f282b52256bb985c0701d660338801562ca5265f118"
+    },
+    {
+      "path": "audio/0755.wav",
+      "sha256": "9f7d56674c3c90c38d3e71c3d6fc2571e8ba856710ffd9dba4a80076a27b0b38",
+      "transcript": "it uses a stack to detect and remove concavities in the boundary efficiently.",
+      "duration_sec": 5.692062,
+      "speech_end_offset_ms": 5692.1,
+      "audio_hash_id": "e16fd0dfce36a98d43d753ad9c400b098d5316da58bc841512cf8347476c0ac9"
+    },
+    {
+      "path": "audio/0756.wav",
+      "sha256": "babe56a9b80136c31216008280449dc4d0bfe26a983ef8ab3d8a2e342d4907e2",
+      "transcript": "large lumps and uneven surface would tend to make the planting depth random.",
+      "duration_sec": 5.372,
+      "speech_end_offset_ms": 5372.0,
+      "audio_hash_id": "e182ed87acfbcdcc1af24dd9127dc5d206c24a62af38a577ecbb6ba048a85ce6"
+    },
+    {
+      "path": "audio/0757.wav",
+      "sha256": "882b60777f6158a8ba1488c41d830e6050f1bce108ed3452f2d29a95bdc6df74",
+      "transcript": "sometimes vowel changes are also observed.",
+      "duration_sec": 2.876063,
+      "speech_end_offset_ms": 2876.1,
+      "audio_hash_id": "e1ab43c89917e0c6e38b5c98b53eae3dba3a194efbe014f33bfdcc8d5d840d82"
+    },
+    {
+      "path": "audio/0758.wav",
+      "sha256": "fae5163791dae85c1b8d9dd1ef07ce2ab1845bde2f34b2c5cb4ca6a7a58a6b51",
+      "transcript": "the courage of the swordfish crews was noted by friend and foe alike.",
+      "duration_sec": 5.948,
+      "speech_end_offset_ms": 5948.0,
+      "audio_hash_id": "e20d35b2d620886be24ac3999c564ddcd458f95613b967ad7ef80b720487a32b"
+    },
+    {
+      "path": "audio/0759.wav",
+      "sha256": "4dfcd26c3b04b85e7005e5be33ba9a603701f5db1285c6d597d3f057bbf244c3",
+      "transcript": "the horse reared again, raising a cloud of dust.",
+      "duration_sec": 2.876,
+      "speech_end_offset_ms": 2876.0,
+      "audio_hash_id": "e2296424121865cc46359f5c49c1f41af2bdf16127c05261504ef7125141dcef"
+    },
+    {
+      "path": "audio/0760.wav",
+      "sha256": "ec44d2cba95ee19811318177147a50d1e8348d638e8f2320896337eefb7bb05c",
+      "transcript": "it may be the gases of the firing that caused the martians inconvenience.",
+      "duration_sec": 3.804063,
+      "speech_end_offset_ms": 3804.1,
+      "audio_hash_id": "e231cb43453b21f362d5bfe5253132363a4866ef46238a31ff6a6487ec93c9a9"
+    },
+    {
+      "path": "audio/0761.wav",
+      "sha256": "92a479c49e3abf58ef55c88c1ca049028a9c09c9e33f2e479e0e1a7ea04975d4",
+      "transcript": "he began his teaching in utah, where he soon became professor of agronomy.",
+      "duration_sec": 3.932,
+      "speech_end_offset_ms": 3932.0,
+      "audio_hash_id": "e259aa9aaa61aeca4bfcce004fc341dfaf005824b15c9ad549622ea64485560e"
+    },
+    {
+      "path": "audio/0762.wav",
+      "sha256": "cc70e9c3222958700a5bf0e5db49f60ddf5f4dd12702cbb7a22f70dd76f0f664",
+      "transcript": "the island became part of the roman province of illyricum after the illyrian wars.",
+      "duration_sec": 6.172,
+      "speech_end_offset_ms": 6172.0,
+      "audio_hash_id": "e2efd5368ca91e484c94c0f13dfde6fbce1435d8ab1b088f5f8f89b536454bd4"
+    },
+    {
+      "path": "audio/0763.wav",
+      "sha256": "30e073337c79ad42ee0ccf05ae2d145f88884edcf9376e143e5198bf864f0604",
+      "transcript": "crystals of calcium sulfate or calcium fluoride are doped with dysprosium.",
+      "duration_sec": 4.572063,
+      "speech_end_offset_ms": 4572.1,
+      "audio_hash_id": "e48db7274cd54e52a882c534188426bd4425f7264410fb62fe263daeb1f363aa"
+    },
+    {
+      "path": "audio/0764.wav",
+      "sha256": "3d52bcb93f01a496a8922bdbc3631279bc11e49202ce5ed0c3645a63493da7b1",
+      "transcript": "a drowned krusty the clown floats near marge.",
+      "duration_sec": 2.684,
+      "speech_end_offset_ms": 2684.0,
+      "audio_hash_id": "e5415c6de17d3c33a1f3141eaeed20103877281eb8fa3cce66313c67e0d33fde"
+    },
+    {
+      "path": "audio/0765.wav",
+      "sha256": "2e6287b0412f8e5184602a03d6e6049024cddc38fdf34b27607b4930e4b47b42",
+      "transcript": "he has been an advocate of american values in foreign policy.",
+      "duration_sec": 3.356,
+      "speech_end_offset_ms": 3356.0,
+      "audio_hash_id": "e60bc2fcc8eaeb4f14c25cfc33393672c016b0c8c1b746139601e2aa492be9ff"
+    },
+    {
+      "path": "audio/0766.wav",
+      "sha256": "7a019529b25dcf39840412194afe90e2c91120278f7fb07a735a5f8616b20038",
+      "transcript": "some locations were in canada as well.",
+      "duration_sec": 2.556062,
+      "speech_end_offset_ms": 2556.1,
+      "audio_hash_id": "e62d057fd5081a9c66090ba24e0b984f5634e080ca2e8b70f36090ade44e9113"
+    },
+    {
+      "path": "audio/0767.wav",
+      "sha256": "31bec91a1f46c08bbfa64d3286177b3732b0b3f35dd70b7653db57dd84eb6a44",
+      "transcript": "the eleventh edition introduced a number of changes of the format of the \"britannica\".",
+      "duration_sec": 3.868063,
+      "speech_end_offset_ms": 3868.1,
+      "audio_hash_id": "e66852d4c63f4dda6a1ce8ad60e3ba467fcb368d99ff67c5ca9222736c29d0d7"
+    },
+    {
+      "path": "audio/0768.wav",
+      "sha256": "1a2545f7816f8a7242bf4014fdad2eb76e1e55effab4c6bbcbf46a79a72c5917",
+      "transcript": "singapore polytechnic offers full-time diploma courses and a range of continuing education programmes.",
+      "duration_sec": 5.948062,
+      "speech_end_offset_ms": 5948.1,
+      "audio_hash_id": "e6b765388e71a731ad82241c25a7549d4d8eb23827f863e1743c53c3174fe684"
+    },
+    {
+      "path": "audio/0769.wav",
+      "sha256": "83e1ed5a431d22ad592c100a052137c5c4690c49f7203980ae1c4fd841797d22",
+      "transcript": "it's not a battle of good against evil.",
+      "duration_sec": 2.204,
+      "speech_end_offset_ms": 2204.0,
+      "audio_hash_id": "e6c3acece4a0522c62d1ddaebd4a9bcd24a7fbd769be7b7fe80ea3838f4f4e91"
+    },
+    {
+      "path": "audio/0770.wav",
+      "sha256": "24a85d9c349d14c9887d9bfcea8a05ff0fb98ca2b8e4d2c9577e8f041f083e59",
+      "transcript": "tower tours are available daily.",
+      "duration_sec": 2.268063,
+      "speech_end_offset_ms": 2268.1,
+      "audio_hash_id": "e719a8a73eb6ab720b6741b4f92144fb9fb3d443558cb909c20a662091c74a66"
+    },
+    {
+      "path": "audio/0771.wav",
+      "sha256": "b111ca84aff420d09a3fe665e950fcf81f19097b6f3b0a162969a3a98990cbed",
+      "transcript": "they had two children; a son, james, and a daughter, elizabeth.",
+      "duration_sec": 4.732,
+      "speech_end_offset_ms": 4732.0,
+      "audio_hash_id": "e723f6ce4258109106d82c463709c8efbbe6586ff8accd087afa11ca516fb029"
+    },
+    {
+      "path": "audio/0772.wav",
+      "sha256": "9ffb693a061b4f7aeec3b4b983df27e4b5506945d95e2b9b947a9b4758a8312f",
+      "transcript": "the situation with the expulsion was reacted at the russian ministry of foreign affairs.",
+      "duration_sec": 5.308063,
+      "speech_end_offset_ms": 5308.1,
+      "audio_hash_id": "e727e0d4e868f49f93fdfe24442254d05809a32f77dac6f9ab401c723ba929c4"
+    },
+    {
+      "path": "audio/0773.wav",
+      "sha256": "d3416277370fd2d71bb31b549370e33f7ed309bff8fe643d56456fcf94096a8a",
+      "transcript": "it is arguably one of the biggest social events in nigeria.",
+      "duration_sec": 3.198062,
+      "speech_end_offset_ms": 3198.1,
+      "audio_hash_id": "e7bec6f41d4f042ad975468adc67999057eabda004c89c9388dff3f77cd4786f"
+    },
+    {
+      "path": "audio/0774.wav",
+      "sha256": "997340e4e74de4528d62f2cc487208cd9725d787822338b72103f7f50bfaf5e5",
+      "transcript": "the competition determines the champion of south america.",
+      "duration_sec": 3.1,
+      "speech_end_offset_ms": 3100.0,
+      "audio_hash_id": "e7e30b3411ba616e6e1df049c0a19975ebfaf557193c0a5882d4d42b2d87fe1c"
+    },
+    {
+      "path": "audio/0775.wav",
+      "sha256": "d77652f9df8593fa4bf4f4b70cece0f7ca65a79a23438950627c0795f92b7b74",
+      "transcript": "the school's curriculum and policies emphasize individual student freedoms.",
+      "duration_sec": 4.54,
+      "speech_end_offset_ms": 4540.0,
+      "audio_hash_id": "e7ed0d43a27a2f4a6d839a99f3c3c0cb4016f741e4b1c429403532b1c22b5745"
+    },
+    {
+      "path": "audio/0776.wav",
+      "sha256": "21cb461c675008984c0c41407ae7ade20f739b8a2b17f6bd1c7dfe3290a00dab",
+      "transcript": "the genus includes only oviparous species.",
+      "duration_sec": 3.42,
+      "speech_end_offset_ms": 3420.0,
+      "audio_hash_id": "e86b4f1be3f7c592513276cfac39f94dc3a39d5d53304a0c491e65b8b782871d"
+    },
+    {
+      "path": "audio/0777.wav",
+      "sha256": "fe3c5b600b35ee00dc7882aa58c5af743277eb031b9b5cdff04bd9b102b3a781",
+      "transcript": "the mechanical relays emitted an audible \"clicking\" sound when they engaged and disengaged.",
+      "duration_sec": 4.956,
+      "speech_end_offset_ms": 4956.0,
+      "audio_hash_id": "e87a332df75765f75047be8d7935fddf4082d8c3925a21dd506836611f02a981"
+    },
+    {
+      "path": "audio/0778.wav",
+      "sha256": "209638c7219dcc029cb7c0e1021bee4808b70ee3ff6583508dc01fe9287f3374",
+      "transcript": "haidar has won several international awards in recognition of her human rights work.",
+      "duration_sec": 4.636063,
+      "speech_end_offset_ms": 4636.1,
+      "audio_hash_id": "e88d7267e8ee38032e13674cea36d1b2bf7c21cafe6cb5e06897a7afd7d33494"
+    },
+    {
+      "path": "audio/0779.wav",
+      "sha256": "30ee89257b0c35f4add602cb41b4bf2dd09cceb50aabdee48a191a16665597f8",
+      "transcript": "it has an isometric crystal system, conchoidal fracture, non-magnetic and non-radioactive.",
+      "duration_sec": 5.788062,
+      "speech_end_offset_ms": 5788.1,
+      "audio_hash_id": "e8d8d748a501380c66342f6edd5d394a9e356b90a136551d7f1ac84819efba69"
+    },
+    {
+      "path": "audio/0780.wav",
+      "sha256": "90539edbfa4c46d4397559e472b791badb336590dfc1779ee585a6c4d32bfdf5",
+      "transcript": "the band was formed by some members of dishwater.",
+      "duration_sec": 2.556,
+      "speech_end_offset_ms": 2556.0,
+      "audio_hash_id": "e8db01f75480a0b117029a2d6fb0aac7e8ab919b9d21340b8ebfadc158bb7aa0"
+    },
+    {
+      "path": "audio/0781.wav",
+      "sha256": "df54bcc3c759fdde7fd84da8627a32bb3043dd2c52cc49afff29de7ab7b1abfc",
+      "transcript": "that guy over there likes to drink a lot, talk a lot, but do nothing.",
+      "duration_sec": 4.988,
+      "speech_end_offset_ms": 4988.0,
+      "audio_hash_id": "e9c251ede83d55c57987731ca2c26bc8a82e3391c76be00aa677108763146758"
+    },
+    {
+      "path": "audio/0782.wav",
+      "sha256": "c78ff700f570bd575124aea8ed46d79d93cf517ce91f76042537e9eb4c437387",
+      "transcript": "kane's personal effects, including a sled that reveals the meaning of \"rosebud\", are incinerated.",
+      "duration_sec": 5.308063,
+      "speech_end_offset_ms": 5308.1,
+      "audio_hash_id": "ea8ec8329d223b7f0b182c19bf2465fd25e023ec5bafa722a7dc465296c83cfe"
+    },
+    {
+      "path": "audio/0783.wav",
+      "sha256": "64a27488d74169922fbbe0a96dfee6934bf00a9540882d8fb91623975401cd34",
+      "transcript": "the police use kettling, batons and are dressed in riot gear.",
+      "duration_sec": 3.74,
+      "speech_end_offset_ms": 3740.0,
+      "audio_hash_id": "eae375c57c7c788f2ea58d7e6405824c5498da43dc9fd81aa114e202e0eea9a8"
+    },
+    {
+      "path": "audio/0784.wav",
+      "sha256": "a2e4b9bfbb696050ea28a4a9e2b69ca10bafb9b88041abcaf3d4728cdc7de4f7",
+      "transcript": "poets sometimes personify the star, placing it in a mythological context.",
+      "duration_sec": 5.34,
+      "speech_end_offset_ms": 5340.0,
+      "audio_hash_id": "eb7e7813a796fb3d51187d324aae657e25b892be5ccb8e37a5d76b7d2484c2fb"
+    },
+    {
+      "path": "audio/0785.wav",
+      "sha256": "212a1e091d316cbb821351b3e5974200b677682d726d05a13d9d11a50e8ab03c",
+      "transcript": "it is home to the notting hill carnival, europe's largest.",
+      "duration_sec": 2.78,
+      "speech_end_offset_ms": 2780.0,
+      "audio_hash_id": "ebb12b99b6fb02783ec8876b418d7cf6dc03f19acd5c8a0c70680030e0e9cb0d"
+    },
+    {
+      "path": "audio/0786.wav",
+      "sha256": "442f2be70b1a4488b7ea7d33c2fbcd5c882b4312be8d22a20f06bbe1881b210f",
+      "transcript": "Some preparations may include other plants ingredients like Colocasia esculenta.",
+      "duration_sec": 5.052062,
+      "speech_end_offset_ms": 5052.1,
+      "audio_hash_id": "ebdc2b0693cd25804351227399ec545f1c867cf0053044e7b94e13a40c6ce4b2"
+    },
+    {
+      "path": "audio/0787.wav",
+      "sha256": "18910f712ab45fdb00daa1f9a7eefc2683652db57f64e77804f3680a49f7d44b",
+      "transcript": "there were some big shoe manufacturers like van lier.",
+      "duration_sec": 3.132062,
+      "speech_end_offset_ms": 3132.1,
+      "audio_hash_id": "ebe83032faf913af7b31cff6d82e9df1c3d2bd16066883a2ecd7d2a7531937b9"
+    },
+    {
+      "path": "audio/0788.wav",
+      "sha256": "7f04a66107568c2e16a7c940d3d15f3fb14102ecd714c9aad86be8c04ec66593",
+      "transcript": "she started out as an actress but slowly transitioned into writing.",
+      "duration_sec": 3.74,
+      "speech_end_offset_ms": 3740.0,
+      "audio_hash_id": "ec7c5a66493bc429ae8242a5bb6c7cc30b7383e004486e9ab817b2164788b28f"
+    },
+    {
+      "path": "audio/0789.wav",
+      "sha256": "145c6a7b16ed5edd469b8a45f2a95493eb974808ccddec5f6e598ccbf4f5f106",
+      "transcript": "like the \"histoire\", it is more interesting than exact.",
+      "duration_sec": 2.876,
+      "speech_end_offset_ms": 2876.0,
+      "audio_hash_id": "ecc5c41d7c970b129110a45b52ea5401949b7bbe1f128f01af1da6cb519c4ecd"
+    },
+    {
+      "path": "audio/0790.wav",
+      "sha256": "36bf3e0dde7ceb40de7b3d07315585a7a82d4000e5cd5f81c5289e79853bee37",
+      "transcript": "the schools colors are pink and blue.",
+      "duration_sec": 2.652,
+      "speech_end_offset_ms": 2652.0,
+      "audio_hash_id": "ecf82be9749af5d6a97c9606e50c0a0f75a56d1a0ee7eb0daf8ccc1db438127b"
+    },
+    {
+      "path": "audio/0791.wav",
+      "sha256": "6a30601b0c3e9f434196f7a67beb318787ed7440754f4e47fa673efc2cb02e49",
+      "transcript": "riverside traffic had to cross bridge traffic in the same level.",
+      "duration_sec": 3.708063,
+      "speech_end_offset_ms": 3708.1,
+      "audio_hash_id": "ed649bf535e5a7982621befc0ab04c7eb0f6b6b001d4386fd929935e5151a812"
+    },
+    {
+      "path": "audio/0792.wav",
+      "sha256": "2a325d279a61372e92bc0a84961d69379ba068186b0bed3dec9d3c0060975129",
+      "transcript": "he and his wife make their home in baldwin city, kansas.",
+      "duration_sec": 3.772,
+      "speech_end_offset_ms": 3772.0,
+      "audio_hash_id": "edaa2eab9880e398862df7191c6547f8cb2ce9e37de76adcb3480ed4296778fa"
+    },
+    {
+      "path": "audio/0793.wav",
+      "sha256": "d202d8ce5d9d867a352cd5ba8169e0691cbafaa502498adb601fd4345987ca9b",
+      "transcript": "ultimately, the abolitionist movement split apart.",
+      "duration_sec": 4.284,
+      "speech_end_offset_ms": 4284.0,
+      "audio_hash_id": "edb117538fda9acbc46b977b3f270e2e2c8f4b0deb88e44e2a3395e584896b08"
+    },
+    {
+      "path": "audio/0794.wav",
+      "sha256": "887c5ee553460e3fc94c965f812919be2b5ae7f0591d090a90935c080d181b71",
+      "transcript": "two of these catastrophic flooding events significantly affected the river and its surrounds.",
+      "duration_sec": 5.02,
+      "speech_end_offset_ms": 5020.0,
+      "audio_hash_id": "edcf18dcfff8bfdaf2ed2af043f99c4ae3c085c9f7defceff81545796e46e99e"
+    },
+    {
+      "path": "audio/0795.wav",
+      "sha256": "f42d3189a69579bc8466deead07c9c8b60b45744db73ae4cf4d6216ef930f7c7",
+      "transcript": "it achieves exceptional resolution in both top-down and bottom-up proteomics.",
+      "duration_sec": 5.212063,
+      "speech_end_offset_ms": 5212.1,
+      "audio_hash_id": "edd57ef79d112c539e8826452daf430b7f70f6ee38f74ba78f4880fb0e05491c"
+    },
+    {
+      "path": "audio/0796.wav",
+      "sha256": "196880d690e162f9461dd0e01013ee660f46164589e2d2ee4161cafbc97d5adb",
+      "transcript": "a strong bid may scare your partner stiff.",
+      "duration_sec": 2.204,
+      "speech_end_offset_ms": 2204.0,
+      "audio_hash_id": "edd77b3216738095fd2610aaacf8100fee0ccccacedbbc1559e38e4bc920815e"
+    },
+    {
+      "path": "audio/0797.wav",
+      "sha256": "1976bc8037c6bc41698c5d34f708b9c6bb06c6133d9507d75b646ce5baea30ca",
+      "transcript": "ketura also offers accounting and bookkeeping services, with many members working in these positions.",
+      "duration_sec": 6.012,
+      "speech_end_offset_ms": 6012.0,
+      "audio_hash_id": "eefe079098d580f950c504146dcd6ca43ae05d2c3f84e5e477e80ef9c23c095b"
+    },
+    {
+      "path": "audio/0798.wav",
+      "sha256": "76ffd1ef6fb386fb44ec5dd5866a8cb1fcbccd5e0549f307609e555f5eb994c1",
+      "transcript": "a stuffed chair slipped from the moving van.",
+      "duration_sec": 2.396,
+      "speech_end_offset_ms": 2396.0,
+      "audio_hash_id": "ef1d738d449bfc5441b9b8c880a984fc8e5e6f0a96d05d2ed101438436e2d9b1"
+    },
+    {
+      "path": "audio/0799.wav",
+      "sha256": "95d8cef44cd9bf07edacdafc8ba7f851ab9b0faf6c5c5c36d7df1b295bf3e0d2",
+      "transcript": "i can send contextual information to it from other apps.",
+      "duration_sec": 3.676,
+      "speech_end_offset_ms": 3676.0,
+      "audio_hash_id": "ef611e1ffa844b94bb54765bf9f2f0b5d9f9945ad03257fb8540dfbf722651c4"
+    },
+    {
+      "path": "audio/0800.wav",
+      "sha256": "e0fc0b6fa140b3a30d7bd700460d38a1c36cf7a578b1e880e551bcbd24cd430d",
+      "transcript": "gray paint stretched for miles around.",
+      "duration_sec": 2.268063,
+      "speech_end_offset_ms": 2268.1,
+      "audio_hash_id": "efd3e7ef3ed931a14d0b7001b7b16efbaab0e6156bac5a7d77dc05f72684fd0a"
+    },
+    {
+      "path": "audio/0801.wav",
+      "sha256": "57878bc016d1cbaad8f4bf78f69e4f948ce9f776866b70a21f7ff468a8a1bb1c",
+      "transcript": "companies will need to prioritize their workforce over profit.",
+      "duration_sec": 2.748063,
+      "speech_end_offset_ms": 2748.1,
+      "audio_hash_id": "eff36d027b30ab0d23ee3859e26cc7c29847a1b703ac09f94c8a3a7fe3bc25e8"
+    },
+    {
+      "path": "audio/0802.wav",
+      "sha256": "13f060b6ff01569a346d0b97ecbb82d3541e7f20c1d86c536b0e2c091d11433c",
+      "transcript": "it has been suggested that acute fear and extreme stress can cause hematidrosis.",
+      "duration_sec": 5.724062,
+      "speech_end_offset_ms": 5724.1,
+      "audio_hash_id": "f00cdcc7df122f0eae372fcad2fff5979d75f440e42df8a0dca115951b2b061f"
+    },
+    {
+      "path": "audio/0803.wav",
+      "sha256": "1dd4ac28ac2f5d2a26f9665f857e934afd6549ad93d0ed98c4358e188afd27de",
+      "transcript": "he also managed the white sox, as well as the pittsburgh pirates.",
+      "duration_sec": 3.004,
+      "speech_end_offset_ms": 3004.0,
+      "audio_hash_id": "f0186172a2d9a12b4cc0cb2a8d3ed0c93067f5ab5bc82a1f7363b14cf02b595c"
+    },
+    {
+      "path": "audio/0804.wav",
+      "sha256": "db0e5eb3e9bc948b62ee3035c15571b2c03fa188cb630fa312c15399f1f36ccf",
+      "transcript": "he photographed led zeppelin for the back cover of their debut album.",
+      "duration_sec": 4.892,
+      "speech_end_offset_ms": 4892.0,
+      "audio_hash_id": "f01dc32299cf88fa6fc997d629b12465c5f96ffc5b7fc7bea2b3ebaf85483b3f"
+    },
+    {
+      "path": "audio/0805.wav",
+      "sha256": "68171c57acf3588bbd4155c5b69e8b7c052cc3ceb490661ff5951c3772f89940",
+      "transcript": "it took its name from nearby whitewood creek.",
+      "duration_sec": 2.652,
+      "speech_end_offset_ms": 2652.0,
+      "audio_hash_id": "f1281aee7f431305a40bea4839bb2576e0fa9d010158cabdf0f1276003d2e05b"
+    },
+    {
+      "path": "audio/0806.wav",
+      "sha256": "4a898cb448ad86b9a0eeec52b5a2ca40d76e201b0688bef0d4dbbcbdb1ac0ff9",
+      "transcript": "loveless helped to align iowa's democratic party more closely with its national counterpart.",
+      "duration_sec": 6.46,
+      "speech_end_offset_ms": 6460.0,
+      "audio_hash_id": "f1f286833e770e7f66af43aeee7f0814a0ed49891fc735baeba5f38c1f4d98f7"
+    },
+    {
+      "path": "audio/0807.wav",
+      "sha256": "7be0bc3eb36420d1f38b9bd649b6670af46868ffb2ca270d2c5438f6fc7c857a",
+      "transcript": "president george w. bush commuted the sentence of white house staffer lewis \"scooter\" libby.",
+      "duration_sec": 6.908062,
+      "speech_end_offset_ms": 6908.1,
+      "audio_hash_id": "f2424a05e97ffb1986ee304156646f1b8c065fbb69aeda0d2bc84f5f21d41bb7"
+    },
+    {
+      "path": "audio/0808.wav",
+      "sha256": "a1b360b5541c6e29ca3de57fef85b8171e1adb74614679de546299708e99e74d",
+      "transcript": "plutarch also explains that the festival included a human sacrifice.",
+      "duration_sec": 3.9,
+      "speech_end_offset_ms": 3900.0,
+      "audio_hash_id": "f27c42b13ce5b8e522f48b38d8ae922d7112d2ddded30f461030006c703791c2"
+    },
+    {
+      "path": "audio/0809.wav",
+      "sha256": "c6a88c98972dc2805cbe817a84fd510b4473b707c9a77fb206208d1932f9b5ff",
+      "transcript": "lilliput, meanwhile, was divided among several petty kingdoms.",
+      "duration_sec": 2.94,
+      "speech_end_offset_ms": 2940.0,
+      "audio_hash_id": "f375298e047651bb9a50578ecadfb6246797ea3ce5dcaaac7d8551be10f0b86c"
+    },
+    {
+      "path": "audio/0810.wav",
+      "sha256": "3e84211c4b03f30a888e5855e8fd966c20d7eb1d2f95e514cfbb6bc476900ee3",
+      "transcript": "the solution to the puzzle has never been made public.",
+      "duration_sec": 3.036,
+      "speech_end_offset_ms": 3036.0,
+      "audio_hash_id": "f43788240f173006ca5ec9cbab4d51382e77bac42db1e15aa0fd3397e83cc154"
+    },
+    {
+      "path": "audio/0811.wav",
+      "sha256": "698ff2dcc22c593299f430756dfa1774738f84bccc1ef2e1d116a30d5d7a7bdb",
+      "transcript": "everyone seemed very excited.",
+      "duration_sec": 2.3,
+      "speech_end_offset_ms": 2300.0,
+      "audio_hash_id": "f4fbdbd6c708bc2c7e7186dff269b2b6336520132f7dfb2e61b3ce4327e00529"
+    },
+    {
+      "path": "audio/0812.wav",
+      "sha256": "969f6b7790f46a3cbeff5d0384c95df43b4837dff6cb301ea6b73afa14e44ef5",
+      "transcript": "you can't go any farther, one of them said.",
+      "duration_sec": 2.62,
+      "speech_end_offset_ms": 2620.0,
+      "audio_hash_id": "f55bf9e0900de8148180f9c8db66f6a47dc749d6810d4bc458bbec1fcd53be8d"
+    },
+    {
+      "path": "audio/0813.wav",
+      "sha256": "7c3009646cacb66954534504d3fe5b2bd9ec348f2463839154eba831a6587af3",
+      "transcript": "raja is married and the couple has three children.",
+      "duration_sec": 2.716063,
+      "speech_end_offset_ms": 2716.1,
+      "audio_hash_id": "f5a0f0a89d7c485d0d7275849125167c975c3aa9e69eb070577098cb9d330c5e"
+    },
+    {
+      "path": "audio/0814.wav",
+      "sha256": "ea080561f1ac5fb294b5fddf0948a48b533fbbf1d79cfdd1147a8062735a9424",
+      "transcript": "lunar symbolism dominates his iconography.",
+      "duration_sec": 2.588062,
+      "speech_end_offset_ms": 2588.1,
+      "audio_hash_id": "f5addc9910744efb882d7f8020a3dc9c98a278f50404c8958b8683683c75973d"
+    },
+    {
+      "path": "audio/0815.wav",
+      "sha256": "e52185b4c6ba6baacbdff0fff966291a87a7a76c226c0d9148757e42829a1677",
+      "transcript": "lady wishfort agrees to let sir rowland bring a marriage contract that night.",
+      "duration_sec": 4.604,
+      "speech_end_offset_ms": 4604.0,
+      "audio_hash_id": "f5d339045065a4ad8e4d06a6aa17e6f25da16a5b73d0341e13e214b375b82a2a"
+    },
+    {
+      "path": "audio/0816.wav",
+      "sha256": "784e9788c0dd38a1a628faf8bcd0049bbbb1f9a9311980e2f30203b2812d4236",
+      "transcript": "however these factors have not stopped it becoming highly popular.",
+      "duration_sec": 3.324,
+      "speech_end_offset_ms": 3324.0,
+      "audio_hash_id": "f5f87880191352a0e15a632d004463b6b3578f3bab54129d8c8207c62c3f4cc8"
+    },
+    {
+      "path": "audio/0817.wav",
+      "sha256": "4a8505eb3792b7b2ddf4bbe447e77978f9024e790f7317a6b994bac316bf3316",
+      "transcript": "white was the first swimmer from utah to compete in an olympic games.",
+      "duration_sec": 5.852,
+      "speech_end_offset_ms": 5852.0,
+      "audio_hash_id": "f6510741e388d2ead347ed391222d2d804eecefed27fd73bbb496db0bcb5693e"
+    },
+    {
+      "path": "audio/0818.wav",
+      "sha256": "427bc70e81ff59a1b5c249027761f11e91c438dcd05874f449f95dfac55761f3",
+      "transcript": "it does best when sheltered from winds and should be protected from frost.",
+      "duration_sec": 4.252063,
+      "speech_end_offset_ms": 4252.1,
+      "audio_hash_id": "f6b06010a09936038bf3c8324dbe3cfda29edb65f8535745234b8c34711eb016"
+    },
+    {
+      "path": "audio/0819.wav",
+      "sha256": "ec5afd0ae30a3e9059ddf7b2e5a9b760a0bd30b9ee2cdc500ff1c99244cc3c74",
+      "transcript": "a music video was recorded for monosynth.",
+      "duration_sec": 2.524062,
+      "speech_end_offset_ms": 2524.1,
+      "audio_hash_id": "f6c80dbb4b0ee6c8311740ce6f9cdd09424304fa05147f726186f2701a302ae4"
+    },
+    {
+      "path": "audio/0820.wav",
+      "sha256": "0eccae5840ab8ac0506f7afa0348312455cbc82903fdffb413e77e385061850e",
+      "transcript": "but in reality, it was totally the other way around.",
+      "duration_sec": 3.614063,
+      "speech_end_offset_ms": 3614.1,
+      "audio_hash_id": "f6e68a6d534e4f8a2b2a478e49630ea8707fc525d957762721903022298f0fc7"
+    },
+    {
+      "path": "audio/0821.wav",
+      "sha256": "b21044795234e12eca485d0ee911681e1619de23061f04d42685cb7007bc4ad4",
+      "transcript": "that's a despicable thing to do, an evil thing.",
+      "duration_sec": 3.164,
+      "speech_end_offset_ms": 3164.0,
+      "audio_hash_id": "f71890b969bddec59080a0a56213c3e0c98c7a9b997fcfb41597a4e672a70883"
+    },
+    {
+      "path": "audio/0822.wav",
+      "sha256": "afd6a0b742876937d56025baea9bdee06596fb9edad93eec9748d8922f2e570a",
+      "transcript": "he was subsequently elected to another term as chief justice.",
+      "duration_sec": 4.7,
+      "speech_end_offset_ms": 4700.0,
+      "audio_hash_id": "f73d9e8c13fc176a1a10992548be64c6d3d25f16185e4ce6cda70f24a124450e"
+    },
+    {
+      "path": "audio/0823.wav",
+      "sha256": "351fb4f27d8ae0aef80207f35a9d25e281f60c88f1ca5b0dd346e621b2f5e413",
+      "transcript": "if the problem is a variable or function with multiple misrecognized words, add the whole phrase to your vocabulary.",
+      "duration_sec": 7.996,
+      "speech_end_offset_ms": 7996.0,
+      "audio_hash_id": "f74dc7080b007b8942511d47796df7adba2dd6b9878562fd1f5bd33a2ea3833b"
+    },
+    {
+      "path": "audio/0824.wav",
+      "sha256": "86d5dc3214a0a9669521291c756fd8e6e4f4f0b1c52428e420517dde916628d8",
+      "transcript": "soon after, another woman is found raped and murdered in a field.",
+      "duration_sec": 3.484,
+      "speech_end_offset_ms": 3484.0,
+      "audio_hash_id": "f85f7db0cf761db8ab8788928f3974c682ddd405476d1932dd2adb3a859b0e1d"
+    },
+    {
+      "path": "audio/0825.wav",
+      "sha256": "663322bb20607056c226cabfe18b3f23d0a847639d1b2e236c3043a8e6499337",
+      "transcript": "his policy was to make theatre accessible to the greatest possible number of people.",
+      "duration_sec": 4.06,
+      "speech_end_offset_ms": 4060.0,
+      "audio_hash_id": "f8bfae3d06d12b392b479d0292cb5229a1d6fa14bc3ed7529ac5100df36caa5b"
+    },
+    {
+      "path": "audio/0826.wav",
+      "sha256": "6a426277b0239fd189f0f4d293d7703d40c46e54549e402ad7991cf255960821",
+      "transcript": "then, you taught me something of the universal language and the soul of the world.",
+      "duration_sec": 4.604,
+      "speech_end_offset_ms": 4604.0,
+      "audio_hash_id": "f8d08d88652d76c743bdcab138300ba74ccb12071725b48d7b67ac2b042294a3"
+    },
+    {
+      "path": "audio/0827.wav",
+      "sha256": "67b38a63e49a8fea7f7fdc1ec96f51751ae66a5743c9b4215f3728409a5c8bcb",
+      "transcript": "harper's publisher fletcher harper strongly supported nast in his disputes with curtis.",
+      "duration_sec": 6.108062,
+      "speech_end_offset_ms": 6108.1,
+      "audio_hash_id": "f92172583d060c99342156c7bc7ece0424e64b6977c6c1734d9de06218f5b206"
+    },
+    {
+      "path": "audio/0828.wav",
+      "sha256": "3886a34251302329a55354495acc278f8b6941fa1d932af9389e9e3298de2358",
+      "transcript": "the newspaper articles had prepared everyone for the reception of the idea.",
+      "duration_sec": 3.42,
+      "speech_end_offset_ms": 3420.0,
+      "audio_hash_id": "f9fc4992f6228a2603169a792773450a76dfec0d37ce471644b7ced226ca61d6"
+    },
+    {
+      "path": "audio/0829.wav",
+      "sha256": "746f41f278a96906ca583101c1b36240ff726be763918449056e5b3f96b158ba",
+      "transcript": "in particular, he clashed with uthman on the question of religious law.",
+      "duration_sec": 4.38,
+      "speech_end_offset_ms": 4380.0,
+      "audio_hash_id": "fa61a9a4b9e865909c5386b65f42d41ed5aa9d6c45333f6faa986546c3ae1cda"
+    },
+    {
+      "path": "audio/0830.wav",
+      "sha256": "b78ddbf56c87437eaaf1a2e504db5b118b066e15db6d41ae47d526b8d6472004",
+      "transcript": "serve the hot rum to the tired heroes.",
+      "duration_sec": 2.844,
+      "speech_end_offset_ms": 2844.0,
+      "audio_hash_id": "fa7b4a2c4e960aa03de0a6c9d7ccadddd08ca6ab44c9273153e2035d72596860"
+    },
+    {
+      "path": "audio/0831.wav",
+      "sha256": "4faf9456f71275c7ef339c1c89decd0c5a6e299661533651dc386a4f775beb15",
+      "transcript": "baldwin points out that the rent is very expensive in harlem.",
+      "duration_sec": 5.052,
+      "speech_end_offset_ms": 5052.0,
+      "audio_hash_id": "fb0d57717528a5d4f4d2c0219fa39843d47c2d4cae13b7178f7163e1f8677c18"
+    },
+    {
+      "path": "audio/0832.wav",
+      "sha256": "b390871bcefefe81c4bbc7f496e6ec8c7ee277cf0a8f5371022b4c7caf6888d4",
+      "transcript": "the capitol is listed on the national register of historic places.",
+      "duration_sec": 3.26,
+      "speech_end_offset_ms": 3260.0,
+      "audio_hash_id": "fb3a809bfb8841cc0a2f2781ed357c1e22df77851e3f168c3a41891cc55ffd3a"
+    },
+    {
+      "path": "audio/0833.wav",
+      "sha256": "25dde7d9c260df519eb7964c4b814c1af0e97dc768e5c1b4dcbd6d819faf7ce8",
+      "transcript": "the town is named after general winfield scott.",
+      "duration_sec": 3.004,
+      "speech_end_offset_ms": 3004.0,
+      "audio_hash_id": "fbf0a9673a6015611a2e03f202add6ccbbfec3f08623e41dc94cef36a747e520"
+    },
+    {
+      "path": "audio/0834.wav",
+      "sha256": "552251b08c996ef84b324ee7b85df7f0e7db18e1ab028d92e945a4f259a85a90",
+      "transcript": "so there was no pressure to demolish old buildings to put new ones at their place.",
+      "duration_sec": 4.764062,
+      "speech_end_offset_ms": 4764.1,
+      "audio_hash_id": "fca4a916fb407911333c1361b210fb723e6c16c646125d8baa1bedc9f35e0a61"
+    },
+    {
+      "path": "audio/0835.wav",
+      "sha256": "9b81b060b8fd7fe0c766f2486d2ffaab92ce0af4a7912f5c6bc7b5aeeb1e7330",
+      "transcript": "israel's earliest selections were picked by the israel broadcasting authority.",
+      "duration_sec": 5.148062,
+      "speech_end_offset_ms": 5148.1,
+      "audio_hash_id": "fd6e79ab3936be49e7d411f2e2f83b606f5fecea456c86d496a3b487198b9f6f"
+    },
+    {
+      "path": "audio/0836.wav",
+      "sha256": "5cf7fc7f7625f5a3032325f6b444a6a7f859eb8efafb546a0d69a16b8fdec3e6",
+      "transcript": "he grew up in temple city, california, where he was a highly ranked student.",
+      "duration_sec": 5.532,
+      "speech_end_offset_ms": 5532.0,
+      "audio_hash_id": "fd9066e41eac92a7222cd675d30b8ba8a21e948216a547080ab390fb368a5eec"
+    },
+    {
+      "path": "audio/0837.wav",
+      "sha256": "09dc6be1df2c42f9a6dee4d4ccf3201f40caee7271a5b232d0ac722018f0b4be",
+      "transcript": "the uppermost arm of the reservoir extends into the clearwater national forest.",
+      "duration_sec": 5.372,
+      "speech_end_offset_ms": 5372.0,
+      "audio_hash_id": "fde2ded700dd8517d06b190c2e30d1f90f9e82615a4528640208100b0147f5a6"
+    },
+    {
+      "path": "audio/0838.wav",
+      "sha256": "20c0f682d6c23373538003792a63673c6d02e7852de3982e4d15c43a828581a2",
+      "transcript": "we used to just dismantle and hide our sofa in someone's boot.",
+      "duration_sec": 3.356,
+      "speech_end_offset_ms": 3356.0,
+      "audio_hash_id": "fde7ab8666e3d31bc4c6eae42c8869614e017c5de27afb315e85294e71601c82"
+    },
+    {
+      "path": "audio/0839.wav",
+      "sha256": "bd2de5f2c27322dc4a3c166fe8e7f0aa8cfdcbf3b7b94c3783d4784116c19075",
+      "transcript": "having heard that, the boy became even more interested in alchemy.",
+      "duration_sec": 3.548062,
+      "speech_end_offset_ms": 3548.1,
+      "audio_hash_id": "fe00cfdb430487a10d36dc36c2653a51296b489da1955b7e627c4d611a2171d7"
+    },
+    {
+      "path": "audio/0840.wav",
+      "sha256": "21fdff1c7a3563fa59a478da3f71bfb062a02d41da5141fe29dd2c1dfad187b6",
+      "transcript": "they met each other via online video messaging.",
+      "duration_sec": 2.716,
+      "speech_end_offset_ms": 2716.0,
+      "audio_hash_id": "fe93b9cb942cfff9e1c15bd5e9b8ff0070527bae8aff44696a14bd8749e27ea0"
+    },
+    {
+      "path": "audio/0841.wav",
+      "sha256": "4564e3982de4b821ed734c97fcb484ad34db70098930f8a2054dbd0b888c67cb",
+      "transcript": "performed by the warsaw philharmonic orchestra.",
+      "duration_sec": 2.972,
+      "speech_end_offset_ms": 2972.0,
+      "audio_hash_id": "fec6e79497b0e714eba97a610d3cb3b9edc3cb8a4cc62dd9b9ba6900a36ebeff"
+    },
+    {
+      "path": "audio/0842.wav",
+      "sha256": "9070cd8380a4e7a7c79c0959624578df1c35ce518f93fce7169c652762c21436",
+      "transcript": "some writers used it in poetry for comical effect.",
+      "duration_sec": 3.708,
+      "speech_end_offset_ms": 3708.0,
+      "audio_hash_id": "fefa8618212fdcc5b56d7a553000964806f16bb484025605e5754a3e419e4781"
+    },
+    {
+      "path": "audio/0843.wav",
+      "sha256": "d2ff55681f485f560e9718722fe9c753ea2569ecb5f937526274acc7b7bd9bee",
+      "transcript": "they are widespread in asia, australia and some pacific islands.",
+      "duration_sec": 3.676063,
+      "speech_end_offset_ms": 3676.1,
+      "audio_hash_id": "ff23d7d2b1ee1ac20b1f6d1c53eae0a452ada275597bad0ab7862738524cd14b"
+    },
+    {
+      "path": "audio/0844.wav",
+      "sha256": "de45584743e74f034fdcc4a7467b4de6fcdac15e164ea0f2b8c1715b75debe43",
+      "transcript": "my grippers are made of stainless steel.",
+      "duration_sec": 2.204,
+      "speech_end_offset_ms": 2204.0,
+      "audio_hash_id": "ff40675198d9aad63c16dc360c2fde6341ae8c66ce4280c2e6a771f8970afa91"
+    },
+    {
+      "path": "audio/0845.wav",
+      "sha256": "ed3c8746cb539155b64e2808dca5662c2259ae025a18e754d4430e956e8e8620",
+      "transcript": "the characters, plot and description of the landscape always form an integrated whole.",
+      "duration_sec": 4.636,
+      "speech_end_offset_ms": 4636.0,
+      "audio_hash_id": "ffd119eae1134a3ea08ef0cadff721787d465493bd2b8bb0dc333a4e752d5835"
+    }
+  ]
+}

--- a/runner/src/coval_bench/datasets/scripts/build.py
+++ b/runner/src/coval_bench/datasets/scripts/build.py
@@ -28,9 +28,13 @@ import structlog
 from coval_bench.datasets.scripts import hf_source
 from coval_bench.datasets.scripts.framework import Clip, DatasetSpec, run_build
 from coval_bench.datasets.scripts.s2s_v1 import S2S_V1
-from coval_bench.datasets.scripts.wildasr import WILDASR_ENV_SPECS
+from coval_bench.datasets.scripts.wildasr import WILDASR_ACCENT, WILDASR_ENV_SPECS
 
-_SPECS: dict[str, DatasetSpec] = {S2S_V1.dataset_id: S2S_V1, **WILDASR_ENV_SPECS}
+_SPECS: dict[str, DatasetSpec] = {
+    S2S_V1.dataset_id: S2S_V1,
+    WILDASR_ACCENT.dataset_id: WILDASR_ACCENT,
+    **WILDASR_ENV_SPECS,
+}
 _CACHE_ROOT = Path.home() / ".cache" / "coval-bench"
 _ADAPTERS_DIR = Path(__file__).parent / "adapters"
 

--- a/runner/src/coval_bench/datasets/scripts/wildasr.py
+++ b/runner/src/coval_bench/datasets/scripts/wildasr.py
@@ -96,20 +96,20 @@ class _Utterance:
     chosen: dict[str, _Chosen]
 
 
-def _read_split_rows(source: Path, variant: str) -> dict[str, list[_Row]]:
-    """Rows of *variant* grouped by transcript, deduped by audio hash, in order.
+def _read_split_rows(source: Path, split: str) -> dict[str, list[_Row]]:
+    """Rows of *split* grouped by transcript, deduped by audio hash, in order.
 
-    A transcript's row list is its distinct condition audios: consecutive for
-    interleaved splits, file-order separated for block-layout splits — order of
-    first appearance gives stable condition indices either way. Exact duplicate
-    rows (same ``audio_hash_id``) collapse to their first occurrence; a row
-    without a hash is kept as its own entry.
+    A transcript's row list is its distinct audios: consecutive for interleaved
+    splits, file-order separated for block-layout splits — order of first
+    appearance gives stable condition indices either way. Exact duplicate rows
+    (same ``audio_hash_id``) collapse to their first occurrence; a row without
+    a hash is kept as its own entry.
     """
     import pyarrow.parquet as pq
 
-    shards = sorted((source / "parquet").glob(f"*{_split(variant)}-*.parquet"))
+    shards = sorted((source / "parquet").glob(f"*{split}-*.parquet"))
     if not shards:
-        raise hf_source.HFUnsupported(f"{_REPO}: no cached parquet for split {_split(variant)}")
+        raise hf_source.HFUnsupported(f"{_REPO}: no cached parquet for split {split}")
     grouped: dict[str, list[_Row]] = {}
     seen: dict[str, set[str]] = {}
     for shard in shards:
@@ -143,7 +143,7 @@ def _family_pool(source: Path) -> list[_Utterance]:
     the rotation advances to the first in-band condition rather than dropping
     an utterance whose rotation-point condition is too long.
     """
-    split_rows = {variant: _read_split_rows(source, variant) for variant in _VARIANTS}
+    split_rows = {variant: _read_split_rows(source, _split(variant)) for variant in _VARIANTS}
     shape = {
         variant: dict(Counter(len(rows) for rows in split_rows[variant].values()))
         for variant in _VARIANTS
@@ -189,27 +189,34 @@ def _family_pool(source: Path) -> list[_Utterance]:
     return pool
 
 
-def _download(cache_root: Path) -> Path:
-    """Download the six environment-split parquet shards into the shared cache."""
+def _require_pyarrow() -> None:
     try:
         import pyarrow  # noqa: F401
     except ImportError as exc:
         raise hf_source.HFUnsupported(
-            "WildASR family build needs pyarrow (run with --extra hf-parquet)"
+            "WildASR builds need pyarrow (run with --extra hf-parquet)"
         ) from exc
+
+
+def _download_split(pq_dir: Path, files: list[str], split: str) -> None:
+    shards = [f for f in files if Path(f).name.startswith(f"{split}-")]
+    if not shards:
+        raise hf_source.HFUnsupported(f"{_REPO}: no parquet shards for split {split}")
+    for rel in shards:
+        dest = pq_dir / rel.replace("/", "__")
+        if not dest.exists():
+            logger.info("wildasr_parquet_download", file=rel)
+            hf_source.download_parquet(_REPO, rel, dest)
+
+
+def _download(cache_root: Path) -> Path:
+    """Download the six environment-split parquet shards into the shared cache."""
+    _require_pyarrow()
     pq_dir = cache_root / "parquet"
     pq_dir.mkdir(parents=True, exist_ok=True)
     files = hf_source.list_parquet_files(_REPO, _CONFIG)
     for variant in _VARIANTS:
-        split = _split(variant)
-        shards = [f for f in files if Path(f).name.startswith(f"{split}-")]
-        if not shards:
-            raise hf_source.HFUnsupported(f"{_REPO}: no parquet shards for split {split}")
-        for rel in shards:
-            dest = pq_dir / rel.replace("/", "__")
-            if not dest.exists():
-                logger.info("wildasr_parquet_download", file=rel)
-                hf_source.download_parquet(_REPO, rel, dest)
+        _download_split(pq_dir, files, _split(variant))
     return cache_root
 
 
@@ -266,3 +273,62 @@ def _make_spec(variant: str) -> DatasetSpec:
 WILDASR_ENV_SPECS: dict[str, DatasetSpec] = {
     spec.dataset_id: spec for spec in (_make_spec(variant) for variant in _VARIANTS)
 }
+
+# The demographic accent split shares the parquet plumbing but none of the
+# family selection: it overlaps zero utterances with the env family, carries no
+# accent or speaker labels, and is benchmarked unpaired. The same transcript
+# read under different accents is a distinct clip, so identity is the audio
+# hash, not the transcript.
+_ACCENT_SPLIT = "demographic_shift__en__demographic_accent_en"
+
+
+def _accent_download(cache_root: Path) -> Path:
+    _require_pyarrow()
+    pq_dir = cache_root / "parquet"
+    pq_dir.mkdir(parents=True, exist_ok=True)
+    _download_split(pq_dir, hf_source.list_parquet_files(_REPO, _CONFIG), _ACCENT_SPLIT)
+    return cache_root
+
+
+def _accent_parse(source: Path) -> list[Clip]:
+    audio_dir = source / "audio"
+    audio_dir.mkdir(parents=True, exist_ok=True)
+    clips: list[Clip] = []
+    for transcript, rows in _read_split_rows(source, _ACCENT_SPLIT).items():
+        for row in rows:
+            clips.append(
+                Clip(
+                    audio_path=audio_dir / f"{row.shard.stem}-{row.shard_row}.wav",
+                    transcript=transcript,
+                    duration_sec=row.duration,
+                    meta={
+                        "audio_hash_id": row.audio_hash_id,
+                        "_pq": str(row.shard),
+                        "_row": row.shard_row,
+                    },
+                )
+            )
+    return clips
+
+
+def _accent_key(clip: Clip) -> object:
+    return clip.meta["audio_hash_id"] or (clip.meta["_pq"], clip.meta["_row"])
+
+
+WILDASR_ACCENT = DatasetSpec(
+    dataset_id="stt-wildasr-accent",
+    cache_name="wildasr-accent",
+    download=_accent_download,
+    parse=_accent_parse,
+    dur_min=_DUR_MIN,
+    dur_max=_DUR_MAX,
+    min_words=_MIN_WORDS,
+    num=None,
+    dedup_key=_accent_key,
+    balance_dims=(),
+    license="Apache-2.0 (WildASR)",
+    source=f"{_REPO} {_ACCENT_SPLIT}",
+    needs_vad_offset=True,
+    fetch=_fetch,
+    normalize_audio=True,
+)

--- a/runner/tests/unit/test_wildasr.py
+++ b/runner/tests/unit/test_wildasr.py
@@ -14,6 +14,7 @@ pq = pytest.importorskip("pyarrow.parquet")
 from coval_bench.datasets.scripts.framework import _clean, balanced_sample  # noqa: E402
 from coval_bench.datasets.scripts.hf_source import extract_parquet_audio  # noqa: E402
 from coval_bench.datasets.scripts.wildasr import (  # noqa: E402
+    WILDASR_ACCENT,
     WILDASR_ENV_SPECS,
     _family_pool,
     _Utterance,
@@ -145,9 +146,47 @@ def test_family_pool_is_deterministic(source: Path) -> None:
 
 
 def test_specs_normalize_audio_and_need_vad_offsets() -> None:
-    """Every family dataset is loudness-normalized and gets a TTFS anchor."""
-    assert all(s.normalize_audio for s in WILDASR_ENV_SPECS.values())
-    assert all(s.needs_vad_offset for s in WILDASR_ENV_SPECS.values())
+    """Every WildASR dataset is loudness-normalized and gets a TTFS anchor."""
+    specs = [*WILDASR_ENV_SPECS.values(), WILDASR_ACCENT]
+    assert all(s.normalize_audio for s in specs)
+    assert all(s.needs_vad_offset for s in specs)
+
+
+def test_accent_keeps_distinct_audio_per_transcript(tmp_path: Path) -> None:
+    """Same transcript under different accents = distinct clips; exact duplicate
+    rows collapse; the take-all selection keeps every survivor."""
+    pq_dir = tmp_path / "parquet"
+    pq_dir.mkdir()
+    rows = [
+        ("one two three four", 4.0, "acc-a"),
+        ("one two three four", 4.5, "acc-b"),
+        ("one two three four", 4.0, "acc-a"),
+        ("five six seven eight", 3.0, "acc-c"),
+    ]
+    table = pa.table(
+        {
+            "transcript": [t for t, _, _ in rows],
+            "duration": [d for _, d, _ in rows],
+            "audio_hash_id": [h for _, _, h in rows],
+        }
+    )
+    name = "data__demographic_shift__en__demographic_accent_en-00000-of-00001.parquet"
+    pq.write_table(table, pq_dir / name)
+
+    clips = WILDASR_ACCENT.parse(tmp_path)
+    clips = _clean(
+        clips,
+        dur_min=WILDASR_ACCENT.dur_min,
+        dur_max=WILDASR_ACCENT.dur_max,
+        min_words=WILDASR_ACCENT.min_words,
+    )
+    selected = balanced_sample(
+        clips,
+        num=WILDASR_ACCENT.num,
+        dedup_key=WILDASR_ACCENT.dedup_key,
+        balance_dims=WILDASR_ACCENT.balance_dims,
+    )
+    assert sorted(str(c.meta["audio_hash_id"]) for c in selected) == ["acc-a", "acc-b", "acc-c"]
 
 
 def test_extract_parquet_audio_writes_selected_rows(tmp_path: Path) -> None:


### PR DESCRIPTION
The seventh and final WildASR dataset: accented English speech from `demographic_shift__en__demographic_accent_en`. Unpaired — zero transcript overlap with the environment family, and the source publishes no accent or speaker labels, so it benchmarks accented speech in aggregate.

Registered as a take-all spec sharing the family module's parquet plumbing, with identity keyed on `audio_hash_id`: the same transcript read under different accents is deliberately kept as distinct clips. 845 of the source's 1,000 recordings survive the standard 2.0-15.0s band and 3-word floor (the split skews short: median 3.7s, max 8.0s) — the floor stays, since sub-2s clips distort latency metrics and the WER denominator. ~54 minutes of audio, loudness-normalized, uploaded with SHA verification, VAD anchors on every item.

Also documents stt-wildasr-reverb's nine null-anchor items in the README (WER measured, TTFS skipped), closing the review note from #299.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds the final WildASR dataset for accented English speech. The main changes are:

- Adds an 845-item `stt-wildasr-accent` manifest.
- Registers a take-all dataset specification keyed by audio hash.
- Reuses the WildASR parquet download and extraction flow.
- Adds tests for retaining distinct recordings with repeated transcripts.
- Documents the accent dataset and null VAD offsets in the reverb dataset.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<sub>Reviews (1): Last reviewed commit: ["Add the stt-wildasr-accent dataset"](https://github.com/coval-ai/benchmarks/commit/bc6b53b58f8e177c867b84ee04dac256b30176e0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44607907)</sub>

<!-- /greptile_comment -->