### PR TITLE
Seed same-tick sampling across the WildASR family

### DIFF
--- a/runner/src/coval_bench/datasets/__init__.py
+++ b/runner/src/coval_bench/datasets/__init__.py
@@ -21,11 +21,14 @@ Public surface::
 """
 
 from coval_bench.datasets.loader import (
+    WILDASR_ENV_FAMILY,
     Dataset,
     DatasetIntegrityError,
     DatasetItem,
+    ManifestAlignmentError,
     TTSDataset,
     TTSDatasetItem,
+    family_rng,
     load_dataset,
     load_stt_dataset,
     load_tts_dataset,
@@ -33,9 +36,12 @@ from coval_bench.datasets.loader import (
 from coval_bench.datasets.manifest import Manifest, STTManifestItem, TTSManifestItem
 
 __all__ = [
+    "WILDASR_ENV_FAMILY",
     "Dataset",
     "DatasetIntegrityError",
     "DatasetItem",
+    "ManifestAlignmentError",
+    "family_rng",
     "TTSDataset",
     "TTSDatasetItem",
     "load_dataset",

--- a/runner/src/coval_bench/datasets/loader.py
+++ b/runner/src/coval_bench/datasets/loader.py
@@ -38,6 +38,7 @@ from __future__ import annotations
 import hashlib
 import os
 import random
+from datetime import datetime
 from importlib.resources import files
 from pathlib import Path
 
@@ -55,15 +56,31 @@ from coval_bench.datasets.manifest import (
 logger = structlog.get_logger(__name__)
 
 __all__ = [
+    "WILDASR_ENV_FAMILY",
     "Dataset",
     "DatasetIntegrityError",
     "DatasetItem",
+    "ManifestAlignmentError",
     "TTSDatasetItem",
     "TTSDataset",
+    "family_rng",
     "load_dataset",
     "load_stt_dataset",
     "load_tts_dataset",
 ]
+
+# Index-aligned manifests sharing one utterance pool; same-tick runs across the
+# family must draw the same sample indices so their rows pair per utterance.
+WILDASR_ENV_FAMILY = frozenset(
+    {
+        "stt-wildasr-clean",
+        "stt-wildasr-clipping",
+        "stt-wildasr-farfield",
+        "stt-wildasr-noisegap",
+        "stt-wildasr-phonecodec",
+        "stt-wildasr-reverb",
+    }
+)
 
 
 # ---------------------------------------------------------------------------
@@ -84,6 +101,14 @@ class DatasetIntegrityError(Exception):
         self.expected = expected
         self.actual = actual
         super().__init__(f"SHA256 mismatch for '{path}': expected={expected} actual={actual}")
+
+
+class ManifestAlignmentError(Exception):
+    """Raised when a WildASR family manifest drifts out of index alignment.
+
+    Same-tick pairing joins rows across the family by filename, so a rebuilt
+    sibling with a different selection must abort the run, never run misaligned.
+    """
 
 
 # ---------------------------------------------------------------------------
@@ -160,6 +185,35 @@ def _sample_items[T](items: list[T], sample_size: int | None, rng: random.Random
         return items
     sampler = rng if rng is not None else random.Random()  # noqa: S311
     return sampler.sample(items, sample_size)
+
+
+def family_rng(dataset_id: str, scheduled_at: datetime | None) -> random.Random | None:
+    """Sampler for family datasets: executions on one tick draw the same indices.
+
+    Returns ``None`` (independent random sampling) for datasets outside the
+    family or when no tick is known.
+    """
+    if scheduled_at is None or dataset_id not in WILDASR_ENV_FAMILY:
+        return None
+    return random.Random(f"wildasr-env:{int(scheduled_at.timestamp())}")  # noqa: S311
+
+
+def _assert_family_alignment(dataset_id: str, manifest: Manifest) -> None:
+    """Fail loudly if any family sibling's manifest no longer index-aligns."""
+    for sibling_id in sorted(WILDASR_ENV_FAMILY - {dataset_id}):
+        sibling = _load_manifest(sibling_id)
+        pairs = zip(manifest.items, sibling.items, strict=False)
+        if len(sibling.items) != len(manifest.items) or any(
+            not isinstance(a, STTManifestItem)
+            or not isinstance(b, STTManifestItem)
+            or a.path != b.path
+            or a.transcript != b.transcript
+            for a, b in pairs
+        ):
+            raise ManifestAlignmentError(
+                f"family manifests misaligned: '{dataset_id}' vs '{sibling_id}' — "
+                "a sibling was rebuilt with a different selection"
+            )
 
 
 def _load_manifest(dataset_id: str) -> Manifest:
@@ -273,6 +327,8 @@ def load_stt_dataset(
         Fully-verified dataset with local file paths.
     """
     manifest = _load_manifest(dataset_id)
+    if dataset_id in WILDASR_ENV_FAMILY:
+        _assert_family_alignment(dataset_id, manifest)
     resolved_cache = cache_dir if cache_dir is not None else _default_cache_dir()
     client = storage_client if storage_client is not None else _make_storage_client(settings)
 

--- a/runner/src/coval_bench/runner/orchestrator.py
+++ b/runner/src/coval_bench/runner/orchestrator.py
@@ -190,6 +190,12 @@ def _get_load_dataset() -> Any:  # noqa: ANN401
     return mod.load_dataset
 
 
+def _get_family_rng() -> Any:  # noqa: ANN401
+    """Resolve ``family_rng`` at call time (lazy import)."""
+    mod = importlib.import_module("coval_bench.datasets")
+    return mod.family_rng
+
+
 def _get_db_symbols() -> tuple[Any, Any, Any, Any]:
     """Return (lifespan_pool, RunWriter, RunStatus, ResultStatus, Result) at call time."""
     conn_mod = importlib.import_module("coval_bench.db.conn")
@@ -968,6 +974,7 @@ async def run_benchmarks(
                     settings.dataset_id,
                     settings=settings,
                     sample_size=None if smoke else settings.dataset_sample_size,
+                    rng=_get_family_rng()(settings.dataset_id, scheduled_at),
                 )
                 items = stt_dataset.items[:1] if smoke else stt_dataset.items
                 logger.info("stt_dataset_sampled", item_count=len(items))

--- a/runner/tests/unit/test_dataset_loader.py
+++ b/runner/tests/unit/test_dataset_loader.py
@@ -31,6 +31,7 @@ import hashlib
 import json
 import random
 import shutil
+from datetime import UTC, datetime
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -39,8 +40,13 @@ from pydantic import ValidationError
 
 from coval_bench.config import Settings
 from coval_bench.datasets.loader import (
+    WILDASR_ENV_FAMILY,
     DatasetIntegrityError,
+    ManifestAlignmentError,
     TTSDataset,
+    _assert_family_alignment,
+    _load_manifest,
+    family_rng,
     load_stt_dataset,
     load_tts_dataset,
 )
@@ -670,3 +676,53 @@ def test_load_dataset_dispatcher_threads_sample_size(test_settings: Settings) ->
             rng=random.Random(1),
         )
     assert len(result.items) == 2
+
+
+# ---------------------------------------------------------------------------
+# WildASR family: seeded same-tick sampling + alignment guard
+# ---------------------------------------------------------------------------
+
+
+def test_family_rng_pairs_same_tick_across_family() -> None:
+    """Every family dataset on one tick draws the same sample indices."""
+    tick = datetime(2026, 7, 15, 12, 30, tzinfo=UTC)
+    draws = [
+        family_rng(dataset_id, tick).sample(range(284), 3)  # type: ignore[union-attr]
+        for dataset_id in sorted(WILDASR_ENV_FAMILY)
+    ]
+    assert all(d == draws[0] for d in draws)
+
+
+def test_family_rng_differs_across_ticks() -> None:
+    early = family_rng("stt-wildasr-clean", datetime(2026, 7, 15, 12, 0, tzinfo=UTC))
+    late = family_rng("stt-wildasr-clean", datetime(2026, 7, 15, 12, 30, tzinfo=UTC))
+    assert early is not None and late is not None
+    assert early.sample(range(284), 3) != late.sample(range(284), 3)
+
+
+def test_family_rng_none_outside_family_or_without_tick() -> None:
+    tick = datetime(2026, 7, 15, 12, 30, tzinfo=UTC)
+    assert family_rng("stt-v3", tick) is None
+    assert family_rng("stt-wildasr-accent", tick) is None
+    assert family_rng("stt-wildasr-clean", None) is None
+
+
+def test_family_alignment_passes_on_packaged_manifests() -> None:
+    """The shipped family manifests must index-align — this is the pairing contract."""
+    _assert_family_alignment("stt-wildasr-clean", _load_manifest("stt-wildasr-clean"))
+
+
+def test_family_alignment_rejects_drifted_sibling(monkeypatch: pytest.MonkeyPatch) -> None:
+    real_load = _load_manifest
+
+    def drifted(dataset_id: str) -> Manifest:
+        manifest = real_load(dataset_id)
+        if dataset_id != "stt-wildasr-reverb":
+            return manifest
+        items = list(manifest.items)
+        items[0], items[1] = items[1], items[0]
+        return manifest.model_copy(update={"items": items})
+
+    monkeypatch.setattr("coval_bench.datasets.loader._load_manifest", drifted)
+    with pytest.raises(ManifestAlignmentError, match="stt-wildasr-reverb"):
+        _assert_family_alignment("stt-wildasr-clean", real_load("stt-wildasr-clean"))

--- a/runner/tests/unit/test_orchestrator.py
+++ b/runner/tests/unit/test_orchestrator.py
@@ -198,7 +198,9 @@ async def _orchestrator_env(  # noqa: ANN202
     tts_dataset = MagicMock()
     tts_dataset.items = tts_items
 
-    def _load_dataset(dataset_id: str, *, settings: Any, sample_size: int | None = None) -> Any:
+    def _load_dataset(
+        dataset_id: str, *, settings: Any, sample_size: int | None = None, rng: Any = None
+    ) -> Any:
         return stt_dataset if dataset_id == "stt-v1" else tts_dataset
 
     fake_pool = MagicMock()
@@ -670,7 +672,9 @@ async def test_dataset_integrity_failure(settings: Settings) -> None:
     class DatasetIntegrityError(Exception):
         pass
 
-    def _bad_load(dataset_id: str, *, settings: Any, sample_size: int | None = None) -> Any:
+    def _bad_load(
+        dataset_id: str, *, settings: Any, sample_size: int | None = None, rng: Any = None
+    ) -> Any:
         raise DatasetIntegrityError("hash mismatch: expected abc actual def")
 
     run = _make_run()
@@ -763,7 +767,9 @@ async def test_audio_file_cleanup(settings: Settings) -> None:
         tts_dataset = MagicMock()
         tts_dataset.items = [tts_item]
 
-        def _load(dataset_id: str, *, settings: Any, sample_size: int | None = None) -> Any:
+        def _load(
+            dataset_id: str, *, settings: Any, sample_size: int | None = None, rng: Any = None
+        ) -> Any:
             return tts_dataset
 
         fake_pool = MagicMock()
@@ -858,7 +864,9 @@ async def test_tts_http1_downgrade_nulls_ttfa_row(settings: Settings) -> None:
         tts_dataset = MagicMock()
         tts_dataset.items = [_make_tts_item("hello world")]
 
-        def _load(dataset_id: str, *, settings: Any, sample_size: int | None = None) -> Any:
+        def _load(
+            dataset_id: str, *, settings: Any, sample_size: int | None = None, rng: Any = None
+        ) -> Any:
             return tts_dataset
 
         fake_pool = MagicMock()
@@ -959,7 +967,9 @@ async def test_tts_cold_connection_nulls_ttfa_row(settings: Settings) -> None:
         tts_dataset = MagicMock()
         tts_dataset.items = [_make_tts_item("hello world")]
 
-        def _load(dataset_id: str, *, settings: Any, sample_size: int | None = None) -> Any:
+        def _load(
+            dataset_id: str, *, settings: Any, sample_size: int | None = None, rng: Any = None
+        ) -> Any:
             return tts_dataset
 
         fake_pool = MagicMock()
@@ -1187,7 +1197,9 @@ async def test_run_samples_dataset_once_with_configured_size(
     stt_dataset = MagicMock()
     stt_dataset.items = items
 
-    def _load(dataset_id: str, *, settings: Any, sample_size: int | None = None) -> Any:
+    def _load(
+        dataset_id: str, *, settings: Any, sample_size: int | None = None, rng: Any = None
+    ) -> Any:
         captured.append(sample_size)
         return stt_dataset
 
@@ -1225,7 +1237,9 @@ async def test_smoke_run_skips_sampling(audio_file: Path, settings: Settings) ->
     stt_dataset = MagicMock()
     stt_dataset.items = [_make_dataset_item(audio_file, "only")]
 
-    def _load(dataset_id: str, *, settings: Any, sample_size: int | None = None) -> Any:
+    def _load(
+        dataset_id: str, *, settings: Any, sample_size: int | None = None, rng: Any = None
+    ) -> Any:
         captured.append(sample_size)
         return stt_dataset
 
@@ -2197,7 +2211,9 @@ async def test_posthog_failed_event(settings: Settings) -> None:
     class _DatasetIntegrityError(Exception):
         pass
 
-    def _bad_load(dataset_id: str, *, settings: Any, sample_size: int | None = None) -> Any:
+    def _bad_load(
+        dataset_id: str, *, settings: Any, sample_size: int | None = None, rng: Any = None
+    ) -> Any:
         raise _DatasetIntegrityError("hash mismatch")
 
     deepgram_cls = MagicMock()


### PR DESCRIPTION
Runner half of the WildASR wiring (BENCH-425 pairs this with the benchmark-infra roster change).

- `family_rng(dataset_id, scheduled_at)`: WildASR environment-family runs seed their sampler with the family key and the tick, so every family execution on one scheduler tick draws the same utterance indices — the property that makes same-tick clean-vs-degraded rows pairable by filename. Non-family datasets keep independent random sampling.
- The loader asserts family-manifest index alignment (same length, same paths and transcripts) before any family run and aborts with `ManifestAlignmentError` on drift, so a rebuilt sibling can never silently break pairing.

No behavior change for any currently scheduled dataset; the family ids only run once the infra roster references them.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds paired sampling for the WildASR environment family. The main changes are:

- Seeds family sampling from the dataset tick.
- Checks sibling manifests for matching paths and transcripts.
- Exports the family helpers and updates loader tests.

<h3>Confidence Score: 4/5</h3>

The sampling tick path needs a fix before merging.

- Delayed sibling jobs can calculate different ticks for one scheduler event.
- Different seeds break the clean-versus-degraded pairing guarantee.
- The manifest alignment checks otherwise match the stated filename-pairing contract.

runner/src/coval_bench/runner/orchestrator.py

<sub>Reviews (1): Last reviewed commit: ["Seed same-tick sampling across the WildA..."](https://github.com/coval-ai/benchmarks/commit/9277908974055a198760ff0f0a4fb2f99b50185d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44615211)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->