### PR TITLE
Show provisional Elo on the arena leaderboard

### DIFF
--- a/web/app/arena/leaderboard/arena-leaderboard.tsx
+++ b/web/app/arena/leaderboard/arena-leaderboard.tsx
@@ -29,7 +29,8 @@ export function ArenaLeaderboardPage() {
       <main className="relative z-10 mx-auto w-full max-w-3xl flex-1 px-4 pb-10 pt-[84px] sm:px-6 md:pt-[96px]">
         <h1 className="text-2xl font-medium tracking-tight sm:text-3xl">Voice Arena leaderboard</h1>
         <p className="mt-2 text-sm text-text-secondary">
-          Models ranked by Elo rating from blind A/B votes.
+          Models ranked by Elo rating from blind A/B votes. Greyed rows are
+          provisional — the confidence interval is still wide.
         </p>
 
         {isLoading && <p className="mt-8 text-sm text-text-tertiary">Loading…</p>}
@@ -71,11 +72,7 @@ export function ArenaLeaderboardPage() {
                         {normalizeTTSProviderName(entry.provider)}
                       </td>
                       <td className="py-2.5 pr-4 text-right tabular-nums">
-                        {preliminary ? (
-                          <span className="text-text-tertiary">collecting…</span>
-                        ) : (
-                          eloLabel(entry)
-                        )}
+                        {eloLabel(entry)}
                       </td>
                     </tr>
                   );


### PR DESCRIPTION
Every arena model is still in the preliminary tier (the CI thresholds need far more votes to clear), so the leaderboard rendered "collecting…" for all 27 rows and looked empty despite 268 votes. Preliminary rows now show their Elo ± CI in the existing greyed style, and the subtitle explains that grey means provisional. Rows still promote to full contrast once their interval tightens.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR shows provisional Elo results on the arena leaderboard. The main changes are:

- Display Elo and available confidence intervals for preliminary rows.
- Keep preliminary rows greyed until their intervals tighten.
- Explain provisional styling in the leaderboard subtitle.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge after a small wording cleanup.

- Elo rendering handles missing confidence intervals.
- The subtitle inaccurately describes preliminary rows that have no interval.

web/app/arena/leaderboard/arena-leaderboard.tsx

<sub>Reviews (1): Last reviewed commit: ["Show provisional Elo on the arena leader..."](https://github.com/coval-ai/benchmarks/commit/4979a58ee7432f0a6b4ed4e2dfe54e3cbf1351aa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44656948)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->