### PR TITLE
Arena/battle page ux

### DIFF
--- a/runner/src/coval_bench/api/routers/arena.py
+++ b/runner/src/coval_bench/api/routers/arena.py
@@ -3,10 +3,11 @@
 
 """Voice Arena endpoints.
 
-``GET  /v1/arena/battle``       — a battle to vote on (blind: no model identities).
-``GET  /v1/arena/battle/{id}``  — a specific battle.
-``GET  /v1/arena/leaderboard``  — the latest computed board for a metric/domain.
-``POST /v1/arena/vote``         — record a labeler's vote (labeler-only at MVP).
+``GET  /v1/arena/battle``          — a battle to vote on (blind: no model identities).
+``GET  /v1/arena/battle/{id}``     — a specific battle.
+``GET  /v1/arena/example-prompt``  — a random seed-bank prompt with its domain.
+``GET  /v1/arena/leaderboard``     — the latest computed board for a metric/domain.
+``POST /v1/arena/vote``            — record a labeler's vote (labeler-only at MVP).
 
 Reads hit the pool directly; the write path uses the arena DB-access layer
 (``ArenaStore``). Leaderboard rows are produced by the snapshot job, so the
@@ -21,6 +22,7 @@ from __future__ import annotations
 
 import asyncio
 import hmac
+import secrets
 import uuid
 from typing import Any
 
@@ -38,6 +40,7 @@ from coval_bench.api.schemas import (
     ArenaLeaderboardResponse,
     BattleCreate,
     BattleOut,
+    ExamplePromptOut,
     LeaderboardEntryOut,
     RevealModelOut,
     RevealOut,
@@ -52,6 +55,7 @@ from coval_bench.arena.pairing import (
     active_tts_models,
     select_pair,
 )
+from coval_bench.arena.prompts import EXAMPLE_PROMPTS
 from coval_bench.config import Settings
 from coval_bench.db.arena_store import ArenaStore
 from coval_bench.db.models import VoteOutcome, VoterType
@@ -155,6 +159,20 @@ async def get_battle(
         {"$process_person_profile": False},
     )
     return await _battle_out(settings, row)
+
+
+@router.get(
+    "/arena/example-prompt",
+    response_model=ExamplePromptOut,
+    dependencies=[Depends(require_labeler)],
+)
+@limiter.limit("60/minute")
+async def get_example_prompt(
+    request: Request,  # required by slowapi
+) -> ExamplePromptOut:
+    """Return a random prompt from the per-domain seed bank, tagged with its domain."""
+    domain = secrets.choice(list(EXAMPLE_PROMPTS))
+    return ExamplePromptOut(prompt=secrets.choice(EXAMPLE_PROMPTS[domain]), domain=domain)
 
 
 @router.get(

--- a/runner/src/coval_bench/api/routers/arena.py
+++ b/runner/src/coval_bench/api/routers/arena.py
@@ -31,6 +31,7 @@ import structlog
 from fastapi import APIRouter, Depends, Header, HTTPException, Query
 from posthog import Posthog
 from psycopg_pool import AsyncConnectionPool
+from slowapi.util import get_remote_address
 from starlette.requests import Request
 
 from coval_bench.api.deps import capture_api_event, get_pool, get_posthog, get_settings
@@ -110,6 +111,14 @@ def require_labeler(
         raise HTTPException(404)
 
 
+def _client_key(request: Request) -> str:
+    """Rate-limit key: the end client forwarded by the BFF, else the caller address.
+
+    All browser traffic reaches this API through the BFF, so keying on the remote
+    address would pool every labeler into one shared bucket."""
+    return request.headers.get("x-arena-client") or get_remote_address(request)
+
+
 async def _battle_out(settings: Settings, row: dict[str, Any]) -> BattleOut:
     """Resolve stored clip keys to fresh playable URLs (off the loop — GCS signing is I/O)."""
     row = dict(row)
@@ -166,7 +175,7 @@ async def get_battle(
     response_model=ExamplePromptOut,
     dependencies=[Depends(require_labeler)],
 )
-@limiter.limit("60/minute")
+@limiter.limit("60/minute", key_func=_client_key)
 async def get_example_prompt(
     request: Request,  # required by slowapi
 ) -> ExamplePromptOut:

--- a/runner/src/coval_bench/api/schemas.py
+++ b/runner/src/coval_bench/api/schemas.py
@@ -217,6 +217,13 @@ class BattleCreate(BaseModel):
     domain: ArenaDomain | None = None
 
 
+class ExamplePromptOut(BaseModel):
+    """A random seed-bank prompt for the arena UI's example picker."""
+
+    prompt: str
+    domain: ArenaDomain
+
+
 class LeaderboardEntryOut(BaseModel):
     """One model's row within an arena leaderboard board."""
 

--- a/runner/tests/api/test_arena.py
+++ b/runner/tests/api/test_arena.py
@@ -16,6 +16,7 @@ from fastapi import FastAPI
 from httpx import AsyncClient
 
 from coval_bench.arena.pairing import active_tts_models
+from coval_bench.arena.prompts import EXAMPLE_PROMPTS
 from coval_bench.providers.base import TTSResult
 from tests.api.conftest import ARENA_LABELER_KEY, _make_db_url
 
@@ -174,6 +175,24 @@ async def test_get_battle_404_when_empty(client: AsyncClient, postgresql: Any) -
     """No battles seeded -> 404."""
     await _apply_arena_schema(_make_db_url(postgresql))
     response = await client.get("/v1/arena/battle", headers=_LABELER_HEADERS)
+    assert response.status_code == 404
+
+
+async def test_example_prompt_served_from_bank(client: AsyncClient, postgresql: Any) -> None:
+    """The example endpoint returns a bank prompt tagged with its source domain."""
+    await _apply_arena_schema(_make_db_url(postgresql))
+    response = await client.get("/v1/arena/example-prompt", headers=_LABELER_HEADERS)
+    assert response.status_code == 200
+    data = response.json()
+    assert data["prompt"] in EXAMPLE_PROMPTS[data["domain"]]
+
+
+async def test_example_prompt_hidden_without_labeler_key(
+    client: AsyncClient, postgresql: Any
+) -> None:
+    """Unauthenticated callers get 404, indistinguishable from a missing route."""
+    await _apply_arena_schema(_make_db_url(postgresql))
+    response = await client.get("/v1/arena/example-prompt")
     assert response.status_code == 404
 
 

--- a/web/app/api/arena/example-prompt/route.ts
+++ b/web/app/api/arena/example-prompt/route.ts
@@ -9,11 +9,15 @@ interface ExamplePromptOut {
   domain: ExamplePrompt["domain"];
 }
 
-export async function GET() {
+export async function GET(req: Request) {
   if (!(await arenaAccessOk())) return new Response(null, { status: 404 });
   let res: Response;
   try {
-    res = await arenaRunnerFetch("/v1/arena/example-prompt");
+    res = await arenaRunnerFetch(
+      "/v1/arena/example-prompt",
+      undefined,
+      req.headers.get("x-forwarded-for"),
+    );
   } catch {
     return Response.json({ error: "Example fetch failed." }, { status: 502 });
   }

--- a/web/app/api/arena/example-prompt/route.ts
+++ b/web/app/api/arena/example-prompt/route.ts
@@ -1,0 +1,24 @@
+export const runtime = "nodejs";
+
+import { arenaAccessOk } from "@/lib/arena/guard";
+import { arenaRunnerFetch } from "@/lib/arena/runner";
+import type { ExamplePrompt } from "@/lib/arena/types";
+
+interface ExamplePromptOut {
+  prompt: string;
+  domain: ExamplePrompt["domain"];
+}
+
+export async function GET() {
+  if (!(await arenaAccessOk())) return new Response(null, { status: 404 });
+  let res: Response;
+  try {
+    res = await arenaRunnerFetch("/v1/arena/example-prompt");
+  } catch {
+    return Response.json({ error: "Example fetch failed." }, { status: 502 });
+  }
+  if (!res.ok) return Response.json({ error: "Example fetch failed." }, { status: res.status });
+  const p = (await res.json()) as ExamplePromptOut;
+  const example: ExamplePrompt = { text: p.prompt, domain: p.domain };
+  return Response.json(example);
+}

--- a/web/app/arena/page.tsx
+++ b/web/app/arena/page.tsx
@@ -3,27 +3,17 @@
 import { useEffect, useRef, useState } from "react";
 import { ARENA_DOMAINS, type ArenaDomain } from "@/lib/arena/domains";
 import { getBattleSource } from "@/lib/arena/source";
-import type { BlindBattle, Outcome, Reveal, RevealedModel } from "@/lib/arena/types";
+import type {
+  BlindBattle,
+  ExamplePrompt,
+  Outcome,
+  Reveal,
+  RevealedModel,
+} from "@/lib/arena/types";
 import { AudioPlayer } from "./components/AudioPlayer";
 
 const MIN_CHARS = 3;
 const MAX_CHARS = 500;
-const EXAMPLES: { text: string; domain: ArenaDomain }[] = [
-  { text: "Thanks for calling — I can help you with that refund right away.", domain: "customer-service" },
-  { text: "This is the third time I've called about the same broken dishwasher, and I am absolutely furious!", domain: "customer-service" },
-  { text: "Your prescription refill is ready for pickup at the pharmacy.", domain: "healthcare" },
-  { text: "Take 500 milligrams every eight hours for the next 10 days.", domain: "healthcare" },
-  { text: "Would Tuesday or Thursday work better for a quick demo?", domain: "sales" },
-  { text: "We won it! The committee voted unanimously — welcome to the family!", domain: "sales" },
-  { text: "Good morning, thank you for calling — how may I direct your call?", domain: "receptionist-booking" },
-  { text: "You won't believe it — a cancellation just came in for the exact date you wanted!", domain: "receptionist-booking" },
-  { text: "The northern lights danced across the sky in ribbons of green and violet.", domain: "other" },
-  { text: "Honestly? I'd grab the earlier train. Traffic downtown is brutal today.", domain: "other" },
-];
-
-function pickExample(): { text: string; domain: ArenaDomain } {
-  return EXAMPLES[Math.floor(Math.random() * EXAMPLES.length)] ?? EXAMPLES[0]!;
-}
 
 export default function ArenaPage() {
   const source = getBattleSource();
@@ -93,8 +83,28 @@ export default function ArenaPage() {
     }
   };
 
-  const quickBattle = () => {
-    const example = pickExample();
+  const applyExample = async () => {
+    setError(null);
+    try {
+      const example = await source.getExamplePrompt();
+      setText(example.text);
+      setDomain(example.domain);
+    } catch {
+      setError("Couldn't fetch an example. Please try again.");
+    }
+  };
+
+  const quickBattle = async () => {
+    const token = ++runToken.current;
+    setError(null);
+    let example: ExamplePrompt;
+    try {
+      example = await source.getExamplePrompt();
+    } catch {
+      if (token === runToken.current) setError("Couldn't fetch an example. Please try again.");
+      return;
+    }
+    if (token !== runToken.current) return; // Stop (or a newer action) superseded this
     setText(example.text);
     setDomain(example.domain);
     void generate(example.text, example.domain);
@@ -113,7 +123,7 @@ export default function ArenaPage() {
         setReveal(null); // vote is recorded; identities just unavailable
       }
       setRecorded(true);
-      if (autoAdvance) quickBattle();
+      if (autoAdvance) void quickBattle();
     } catch {
       setVote(null); // let them retry
       setError("Couldn't record your vote. Please try again.");
@@ -158,11 +168,7 @@ export default function ArenaPage() {
           <div className="flex items-center justify-between text-sm text-text-tertiary">
             <button
               type="button"
-              onClick={() => {
-                const example = pickExample();
-                setText(example.text);
-                setDomain(example.domain);
-              }}
+              onClick={() => void applyExample()}
               className="font-sans underline underline-offset-2 hover:text-text-secondary"
             >
               Use an example
@@ -237,7 +243,7 @@ export default function ArenaPage() {
                 <button
                   ref={nextBattleRef}
                   type="button"
-                  onClick={quickBattle}
+                  onClick={() => void quickBattle()}
                   className="rounded-full bg-surface-toggle-active px-6 py-2.5 font-mono text-sm text-text-on-toggle-active"
                 >
                   Another battle

--- a/web/app/arena/page.tsx
+++ b/web/app/arena/page.tsx
@@ -8,11 +8,22 @@ import { AudioPlayer } from "./components/AudioPlayer";
 
 const MIN_CHARS = 3;
 const MAX_CHARS = 500;
-const EXAMPLES = [
-  "Thanks for calling — I can help you with that refund right away.",
-  "The northern lights danced across the sky in ribbons of green and violet.",
-  "Honestly? I'd grab the earlier train. Traffic downtown is brutal today.",
+const EXAMPLES: { text: string; domain: ArenaDomain }[] = [
+  { text: "Thanks for calling — I can help you with that refund right away.", domain: "customer-service" },
+  { text: "This is the third time I've called about the same broken dishwasher, and I am absolutely furious!", domain: "customer-service" },
+  { text: "Your prescription refill is ready for pickup at the pharmacy.", domain: "healthcare" },
+  { text: "Take 500 milligrams every eight hours for the next 10 days.", domain: "healthcare" },
+  { text: "Would Tuesday or Thursday work better for a quick demo?", domain: "sales" },
+  { text: "We won it! The committee voted unanimously — welcome to the family!", domain: "sales" },
+  { text: "Good morning, thank you for calling — how may I direct your call?", domain: "receptionist-booking" },
+  { text: "You won't believe it — a cancellation just came in for the exact date you wanted!", domain: "receptionist-booking" },
+  { text: "The northern lights danced across the sky in ribbons of green and violet.", domain: "other" },
+  { text: "Honestly? I'd grab the earlier train. Traffic downtown is brutal today.", domain: "other" },
 ];
+
+function pickExample(): { text: string; domain: ArenaDomain } {
+  return EXAMPLES[Math.floor(Math.random() * EXAMPLES.length)] ?? EXAMPLES[0]!;
+}
 
 export default function ArenaPage() {
   const source = getBattleSource();
@@ -46,14 +57,14 @@ export default function ArenaPage() {
     setActive(null);
   }, []);
 
-  const generate = async () => {
-    const trimmed = text.trim();
-    if (trimmed.length < MIN_CHARS || !domain || loading) return;
+  const generate = async (promptText: string, promptDomain: ArenaDomain | "") => {
+    const trimmed = promptText.trim();
+    if (trimmed.length < MIN_CHARS || !promptDomain || loading) return;
     const token = ++runToken.current;
     setLoading(true);
     setError(null);
     try {
-      const b = await source.createBattle(trimmed, domain);
+      const b = await source.createBattle(trimmed, promptDomain);
       if (token !== runToken.current) return; // a newer action superseded this one
       setBattle(b);
       setStep(2);
@@ -62,6 +73,14 @@ export default function ArenaPage() {
     } finally {
       if (token === runToken.current) setLoading(false);
     }
+  };
+
+  const quickBattle = () => {
+    const example = pickExample();
+    reset();
+    setText(example.text);
+    setDomain(example.domain);
+    void generate(example.text, example.domain);
   };
 
   const castVote = async (outcome: Outcome) => {
@@ -89,6 +108,12 @@ export default function ArenaPage() {
     <main className="min-h-screen bg-surface-primary px-6 pb-24 pt-32 text-text-primary">
       <div className="mx-auto flex max-w-[760px] flex-col gap-8">
         <h1 className="text-center font-sans text-2xl">Which voice sounds more natural?</h1>
+
+        {battle && (
+          <p className="text-center font-sans text-base italic leading-relaxed text-text-secondary">
+            “{battle.prompt}”
+          </p>
+        )}
 
         <div
           key={battle?.battleId ?? "pending"}
@@ -126,7 +151,7 @@ export default function ArenaPage() {
               className="w-full appearance-none rounded-xl border border-border-primary bg-surface-elevated px-4 py-3 font-sans text-sm outline-none focus:border-selected-border"
             >
               <option value="" disabled>
-                Select a domain…
+                Select a domain *
               </option>
               {ARENA_DOMAINS.map((d) => (
                 <option key={d.value} value={d.value}>
@@ -145,7 +170,11 @@ export default function ArenaPage() {
             <div className="flex items-center justify-between text-sm text-text-tertiary">
               <button
                 type="button"
-                onClick={() => setText(EXAMPLES[Math.floor(Math.random() * EXAMPLES.length)] ?? "")}
+                onClick={() => {
+                  const example = pickExample();
+                  setText(example.text);
+                  setDomain(example.domain);
+                }}
                 className="font-sans underline underline-offset-2 hover:text-text-secondary"
               >
                 Use an example
@@ -156,7 +185,7 @@ export default function ArenaPage() {
             </div>
             <button
               type="button"
-              onClick={generate}
+              onClick={() => void generate(text, domain)}
               disabled={text.trim().length < MIN_CHARS || !domain || loading}
               className="self-start rounded-full bg-surface-toggle-active px-6 py-2.5 font-mono text-sm text-text-on-toggle-active disabled:opacity-40"
             >
@@ -184,10 +213,17 @@ export default function ArenaPage() {
               <button
                 ref={newBattleRef}
                 type="button"
-                onClick={reset}
+                onClick={quickBattle}
                 className="rounded-full bg-surface-toggle-active px-6 py-2.5 font-mono text-sm text-text-on-toggle-active"
               >
-                New battle
+                Another battle
+              </button>
+              <button
+                type="button"
+                onClick={reset}
+                className="rounded-full border border-border-primary px-6 py-2.5 font-mono text-sm text-text-secondary hover:bg-hover-bg"
+              >
+                Write my own
               </button>
               <a
                 href="/arena/leaderboard"

--- a/web/app/arena/page.tsx
+++ b/web/app/arena/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { ARENA_DOMAINS, type ArenaDomain } from "@/lib/arena/domains";
 import { getBattleSource } from "@/lib/arena/source";
 import type { BlindBattle, Outcome, Reveal, RevealedModel } from "@/lib/arena/types";
@@ -29,33 +29,47 @@ export default function ArenaPage() {
   const source = getBattleSource();
   const voterId = useVoterId();
 
-  const [step, setStep] = useState<1 | 2 | 4>(1);
   const [text, setText] = useState("");
   const [domain, setDomain] = useState<ArenaDomain | "">("");
   const [battle, setBattle] = useState<BlindBattle | null>(null);
+  const [battleDomain, setBattleDomain] = useState<ArenaDomain | "">("");
   const [vote, setVote] = useState<Outcome | null>(null);
   const [reveal, setReveal] = useState<Reveal | null>(null);
+  const [recorded, setRecorded] = useState(false);
+  const [autoAdvance, setAutoAdvance] = useState(false);
   const [loading, setLoading] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [active, setActive] = useState<"a" | "b" | null>(null);
-  const newBattleRef = useRef<HTMLButtonElement>(null);
+  const nextBattleRef = useRef<HTMLButtonElement>(null);
   const runToken = useRef(0);
 
   useEffect(() => {
-    if (step === 4) newBattleRef.current?.focus();
-  }, [step]);
-
-  const reset = useCallback(() => {
-    runToken.current += 1; // invalidate any in-flight createBattle
-    setStep(1);
-    setText("");
-    setBattle(null);
-    setVote(null);
-    setReveal(null);
-    setError(null);
-    setActive(null);
+    try {
+      setAutoAdvance(localStorage.getItem("arena_auto_advance") === "1");
+    } catch {
+      // Storage blocked (private mode, sandboxed iframe, etc.): session-only default.
+    }
   }, []);
+
+  useEffect(() => {
+    if (recorded && !loading) nextBattleRef.current?.focus();
+  }, [recorded, loading]);
+
+  const persistAutoAdvance = (on: boolean) => {
+    setAutoAdvance(on);
+    try {
+      localStorage.setItem("arena_auto_advance", on ? "1" : "0");
+    } catch {
+      // Storage blocked: the toggle still works for this session.
+    }
+  };
+
+  const stopAutoAdvance = () => {
+    runToken.current += 1; // drop the in-flight next battle
+    setLoading(false);
+    persistAutoAdvance(false);
+  };
 
   const generate = async (promptText: string, promptDomain: ArenaDomain | "") => {
     const trimmed = promptText.trim();
@@ -67,7 +81,11 @@ export default function ArenaPage() {
       const b = await source.createBattle(trimmed, promptDomain);
       if (token !== runToken.current) return; // a newer action superseded this one
       setBattle(b);
-      setStep(2);
+      setBattleDomain(promptDomain);
+      setVote(null);
+      setReveal(null);
+      setRecorded(false);
+      setActive(null);
     } catch {
       if (token === runToken.current) setError("Couldn't generate audio. Please try again.");
     } finally {
@@ -77,7 +95,6 @@ export default function ArenaPage() {
 
   const quickBattle = () => {
     const example = pickExample();
-    reset();
     setText(example.text);
     setDomain(example.domain);
     void generate(example.text, example.domain);
@@ -95,7 +112,8 @@ export default function ArenaPage() {
       } catch {
         setReveal(null); // vote is recorded; identities just unavailable
       }
-      setStep(4);
+      setRecorded(true);
+      if (autoAdvance) quickBattle();
     } catch {
       setVote(null); // let them retry
       setError("Couldn't record your vote. Please try again.");
@@ -104,16 +122,56 @@ export default function ArenaPage() {
     }
   };
 
+  const trimmed = text.trim();
+  const dirty = battle !== null && (trimmed !== battle.prompt || domain !== battleDomain);
+  const canVote = battle !== null && !recorded && !dirty;
+
   return (
     <main className="min-h-screen bg-surface-primary px-6 pb-24 pt-32 text-text-primary">
       <div className="mx-auto flex max-w-[760px] flex-col gap-8">
         <h1 className="text-center font-sans text-2xl">Which voice sounds more natural?</h1>
 
-        {battle && (
-          <p className="text-center font-sans text-base italic leading-relaxed text-text-secondary">
-            “{battle.prompt}”
-          </p>
-        )}
+        <section className="flex flex-col gap-3">
+          <select
+            value={domain}
+            onChange={(e) => setDomain(e.target.value as ArenaDomain | "")}
+            aria-label="Domain"
+            className="w-full appearance-none rounded-xl border border-border-primary bg-surface-elevated px-4 py-3 font-sans text-sm outline-none focus:border-selected-border"
+          >
+            <option value="" disabled>
+              Select a domain *
+            </option>
+            {ARENA_DOMAINS.map((d) => (
+              <option key={d.value} value={d.value}>
+                {d.label}
+              </option>
+            ))}
+          </select>
+          <textarea
+            value={text}
+            maxLength={MAX_CHARS}
+            onChange={(e) => setText(e.target.value)}
+            placeholder="Describe a scenario or write text to synthesize…"
+            rows={4}
+            className="w-full resize-none rounded-xl border border-border-primary bg-surface-elevated p-4 font-sans text-base leading-relaxed outline-none focus:border-selected-border"
+          />
+          <div className="flex items-center justify-between text-sm text-text-tertiary">
+            <button
+              type="button"
+              onClick={() => {
+                const example = pickExample();
+                setText(example.text);
+                setDomain(example.domain);
+              }}
+              className="font-sans underline underline-offset-2 hover:text-text-secondary"
+            >
+              Use an example
+            </button>
+            <span className="font-mono">
+              {text.length}/{MAX_CHARS}
+            </span>
+          </div>
+        </section>
 
         <div
           key={battle?.battleId ?? "pending"}
@@ -122,8 +180,8 @@ export default function ArenaPage() {
           <BattleCard
             side="a"
             blindTitle="Model A"
-            revealed={step === 4 && reveal ? reveal.a : null}
-            picked={step === 4 ? vote : null}
+            revealed={recorded && reveal ? reveal.a : null}
+            picked={recorded ? vote : null}
             isActive={active === "a"}
             src={battle?.audioA ?? null}
             onActivate={() => setActive("a")}
@@ -134,106 +192,84 @@ export default function ArenaPage() {
           <BattleCard
             side="b"
             blindTitle="Model B"
-            revealed={step === 4 && reveal ? reveal.b : null}
-            picked={step === 4 ? vote : null}
+            revealed={recorded && reveal ? reveal.b : null}
+            picked={recorded ? vote : null}
             isActive={active === "b"}
             src={battle?.audioB ?? null}
             onActivate={() => setActive("b")}
           />
         </div>
 
-        {step === 1 && (
-          <section className="flex flex-col gap-3">
-            <select
-              value={domain}
-              onChange={(e) => setDomain(e.target.value as ArenaDomain | "")}
-              aria-label="Domain"
-              className="w-full appearance-none rounded-xl border border-border-primary bg-surface-elevated px-4 py-3 font-sans text-sm outline-none focus:border-selected-border"
-            >
-              <option value="" disabled>
-                Select a domain *
-              </option>
-              {ARENA_DOMAINS.map((d) => (
-                <option key={d.value} value={d.value}>
-                  {d.label}
-                </option>
-              ))}
-            </select>
-            <textarea
-              value={text}
-              maxLength={MAX_CHARS}
-              onChange={(e) => setText(e.target.value)}
-              placeholder="Describe a scenario or write text to synthesize…"
-              rows={4}
-              className="w-full resize-none rounded-xl border border-border-primary bg-surface-elevated p-4 font-sans text-base leading-relaxed outline-none focus:border-selected-border"
-            />
-            <div className="flex items-center justify-between text-sm text-text-tertiary">
+        <section className="flex min-h-[52px] flex-col gap-3" aria-live="polite">
+          {recorded && loading ? (
+            <div className="flex items-center justify-center gap-3">
+              <p className="font-mono text-sm text-text-secondary">
+                ✓ Recorded — loading the next battle…
+              </p>
               <button
                 type="button"
-                onClick={() => {
-                  const example = pickExample();
-                  setText(example.text);
-                  setDomain(example.domain);
-                }}
-                className="font-sans underline underline-offset-2 hover:text-text-secondary"
+                onClick={stopAutoAdvance}
+                className="rounded-full border border-border-primary px-4 py-1.5 font-mono text-xs text-text-secondary hover:bg-hover-bg"
               >
-                Use an example
+                Stop
               </button>
-              <span className="font-mono">
-                {text.length}/{MAX_CHARS}
-              </span>
             </div>
+          ) : canVote && !loading ? (
+            <>
+              <div className="grid grid-cols-[1fr_0.7fr_1fr] gap-3">
+                <VoteButton label="Model A" onClick={() => castVote("A_WIN")} disabled={submitting} />
+                <VoteButton label="Tie" onClick={() => castVote("TIE")} disabled={submitting} />
+                <VoteButton label="Model B" onClick={() => castVote("B_WIN")} disabled={submitting} />
+              </div>
+              <label className="flex cursor-pointer items-center gap-2 self-center font-mono text-xs text-text-secondary">
+                <input
+                  type="checkbox"
+                  checked={autoAdvance}
+                  onChange={() => persistAutoAdvance(!autoAdvance)}
+                />
+                Auto-advance
+              </label>
+            </>
+          ) : recorded && !dirty && !loading ? (
+            <div className="flex flex-col items-center gap-4">
+              <p className="font-mono text-sm text-text-secondary">✓ Battle recorded</p>
+              <div className="flex flex-wrap items-center justify-center gap-3">
+                <button
+                  ref={nextBattleRef}
+                  type="button"
+                  onClick={quickBattle}
+                  className="rounded-full bg-surface-toggle-active px-6 py-2.5 font-mono text-sm text-text-on-toggle-active"
+                >
+                  Another battle
+                </button>
+                <label className="flex cursor-pointer items-center gap-2 font-mono text-xs text-text-secondary">
+                  <input
+                    type="checkbox"
+                    checked={autoAdvance}
+                    onChange={() => persistAutoAdvance(!autoAdvance)}
+                  />
+                  Auto-advance
+                </label>
+                <a
+                  href="/arena/leaderboard"
+                  className="rounded-full border border-border-primary px-6 py-2.5 font-mono text-sm text-text-secondary hover:bg-hover-bg"
+                >
+                  View leaderboard
+                </a>
+              </div>
+            </div>
+          ) : (
             <button
               type="button"
               onClick={() => void generate(text, domain)}
-              disabled={text.trim().length < MIN_CHARS || !domain || loading}
+              disabled={trimmed.length < MIN_CHARS || !domain || loading}
               className="self-start rounded-full bg-surface-toggle-active px-6 py-2.5 font-mono text-sm text-text-on-toggle-active disabled:opacity-40"
             >
               {loading ? "Generating…" : "Generate speech"}
             </button>
-            {error && <p className="font-sans text-sm text-accent-rust">{error}</p>}
-          </section>
-        )}
-
-        {battle && step !== 4 && (
-          <section className="flex flex-col gap-3">
-            <div className="grid grid-cols-[1fr_0.7fr_1fr] gap-3">
-              <VoteButton label="Model A" onClick={() => castVote("A_WIN")} disabled={submitting} />
-              <VoteButton label="Tie" onClick={() => castVote("TIE")} disabled={submitting} />
-              <VoteButton label="Model B" onClick={() => castVote("B_WIN")} disabled={submitting} />
-            </div>
-            {error && <p className="text-center font-sans text-sm text-accent-rust">{error}</p>}
-          </section>
-        )}
-
-        {step === 4 && (
-          <div className="flex flex-col items-center gap-4" aria-live="polite">
-            <p className="font-mono text-sm text-text-secondary">✓ Battle recorded</p>
-            <div className="flex gap-3">
-              <button
-                ref={newBattleRef}
-                type="button"
-                onClick={quickBattle}
-                className="rounded-full bg-surface-toggle-active px-6 py-2.5 font-mono text-sm text-text-on-toggle-active"
-              >
-                Another battle
-              </button>
-              <button
-                type="button"
-                onClick={reset}
-                className="rounded-full border border-border-primary px-6 py-2.5 font-mono text-sm text-text-secondary hover:bg-hover-bg"
-              >
-                Write my own
-              </button>
-              <a
-                href="/arena/leaderboard"
-                className="rounded-full border border-border-primary px-6 py-2.5 font-mono text-sm text-text-secondary hover:bg-hover-bg"
-              >
-                View leaderboard
-              </a>
-            </div>
-          </div>
-        )}
+          )}
+          {error && <p className="text-center font-sans text-sm text-accent-rust">{error}</p>}
+        </section>
       </div>
     </main>
   );

--- a/web/app/arena/page.tsx
+++ b/web/app/arena/page.tsx
@@ -57,6 +57,12 @@ export default function ArenaPage() {
 
   const stopAutoAdvance = () => {
     runToken.current += 1; // drop the in-flight next battle
+    if (battle) {
+      // Realign the inputs with the battle still on screen — quickBattle may
+      // have already written the aborted example into them.
+      setText(battle.prompt);
+      setDomain(battleDomain);
+    }
     setLoading(false);
     persistAutoAdvance(false);
   };

--- a/web/lib/arena/apiSource.ts
+++ b/web/lib/arena/apiSource.ts
@@ -1,5 +1,12 @@
 import type { ArenaDomain } from "./domains";
-import type { BattleSource, BlindBattle, Reveal, VoteInput, VoteResult } from "./types";
+import type {
+  BattleSource,
+  BlindBattle,
+  ExamplePrompt,
+  Reveal,
+  VoteInput,
+  VoteResult,
+} from "./types";
 
 // Real battle source: talks to same-origin Next.js API proxy routes under /api/arena/*,
 // which inject the server-only X-Labeler-Key and proxy to the runner. Inert until
@@ -8,6 +15,7 @@ import type { BattleSource, BlindBattle, Reveal, VoteInput, VoteResult } from ".
 //   POST /api/arena/battle              { text, domain }                -> BlindBattle
 //   POST /api/arena/vote                { battleId, outcome, voterId }  -> VoteResult
 //   GET  /api/arena/battle/{id}/reveal?voterId=...                      -> Reveal
+//   GET  /api/arena/example-prompt                                      -> ExamplePrompt
 
 // Coarse hang-backstops, not latency SLAs; tune once real backend latency is known.
 const QUICK_TIMEOUT_MS = 5_000; // vote/reveal: quick DB ops
@@ -31,6 +39,14 @@ export class ApiBattleSource implements BattleSource {
 
   submitVote(input: VoteInput): Promise<VoteResult> {
     return postJson<VoteResult>("/api/arena/vote", input);
+  }
+
+  async getExamplePrompt(): Promise<ExamplePrompt> {
+    const res = await fetch("/api/arena/example-prompt", {
+      signal: AbortSignal.timeout(QUICK_TIMEOUT_MS),
+    });
+    if (!res.ok) throw new Error(`example-prompt -> ${res.status}`);
+    return (await res.json()) as ExamplePrompt;
   }
 
   async reveal(battleId: string, voterId: string): Promise<Reveal> {

--- a/web/lib/arena/mockSource.ts
+++ b/web/lib/arena/mockSource.ts
@@ -1,6 +1,28 @@
 import { getEnabledTtsModels } from "../playground/providers";
 import type { ArenaDomain } from "./domains";
-import type { BattleSource, BlindBattle, Reveal, RevealedModel, VoteInput, VoteResult } from "./types";
+import type {
+  BattleSource,
+  BlindBattle,
+  ExamplePrompt,
+  Reveal,
+  RevealedModel,
+  VoteInput,
+  VoteResult,
+} from "./types";
+
+// Offline stand-in for the runner's seed bank (GET /v1/arena/example-prompt).
+const EXAMPLE_PROMPTS: ExamplePrompt[] = [
+  { text: "Thanks for calling — I can help you with that refund right away.", domain: "customer-service" },
+  { text: "This is the third time I've called about the same broken dishwasher, and I am absolutely furious!", domain: "customer-service" },
+  { text: "Your prescription refill is ready for pickup at the pharmacy.", domain: "healthcare" },
+  { text: "Take 500 milligrams every eight hours for the next 10 days.", domain: "healthcare" },
+  { text: "Would Tuesday or Thursday work better for a quick demo?", domain: "sales" },
+  { text: "We won it! The committee voted unanimously — welcome to the family!", domain: "sales" },
+  { text: "Good morning, thank you for calling — how may I direct your call?", domain: "receptionist-booking" },
+  { text: "You won't believe it — a cancellation just came in for the exact date you wanted!", domain: "receptionist-booking" },
+  { text: "The northern lights danced across the sky in ribbons of green and violet.", domain: "other" },
+  { text: "Honestly? I'd grab the earlier train. Traffic downtown is brutal today.", domain: "other" },
+];
 
 // Self-contained mock: no network, no backend. Generates two distinct audible tones as
 // WAV data URIs so the real <audio> player works exactly as in production, picks two
@@ -71,6 +93,13 @@ export class MockBattleSource implements BattleSource {
       audioA: toneDataUri(220), // A3
       audioB: toneDataUri(330), // E4 — clearly distinct from A
     };
+  }
+
+  async getExamplePrompt(): Promise<ExamplePrompt> {
+    await delay(120);
+    const example = EXAMPLE_PROMPTS[Math.floor(Math.random() * EXAMPLE_PROMPTS.length)];
+    if (!example) throw new Error("arena mock: no example prompts");
+    return example;
   }
 
   async submitVote(input: VoteInput): Promise<VoteResult> {

--- a/web/lib/arena/runner.ts
+++ b/web/lib/arena/runner.ts
@@ -1,10 +1,15 @@
 const BASE = process.env.ARENA_API_URL ?? "";
 const KEY = process.env.ARENA_LABELER_KEY ?? "";
 
-export async function arenaRunnerFetch(path: string, body?: unknown): Promise<Response> {
+export async function arenaRunnerFetch(
+  path: string,
+  body?: unknown,
+  clientKey?: string | null,
+): Promise<Response> {
   if (!BASE) throw new Error("ARENA_API_URL is not configured");
   if (!KEY) throw new Error("ARENA_LABELER_KEY is not configured");
   const headers = new Headers({ "X-Labeler-Key": KEY });
+  if (clientKey) headers.set("X-Arena-Client", clientKey);
   if (body === undefined) {
     return fetch(`${BASE}${path}`, { method: "GET", headers });
   }

--- a/web/lib/arena/types.ts
+++ b/web/lib/arena/types.ts
@@ -2,6 +2,12 @@ import type { ArenaDomain } from "./domains";
 
 export type Outcome = "A_WIN" | "B_WIN" | "TIE";
 
+// A seed-bank prompt with the domain it belongs to, for the "Use an example" picker.
+export interface ExamplePrompt {
+  text: string;
+  domain: ArenaDomain;
+}
+
 // What the UI renders during the blind phase — never any model identity.
 export interface BlindBattle {
   battleId: string;
@@ -39,4 +45,5 @@ export interface BattleSource {
   createBattle(text: string, domain: ArenaDomain): Promise<BlindBattle>;
   submitVote(input: VoteInput): Promise<VoteResult>;
   reveal(battleId: string, voterId: string): Promise<Reveal>;
+  getExamplePrompt(): Promise<ExamplePrompt>;
 }


### PR DESCRIPTION
The battle page is now one persistent layout: the domain and text inputs stay above the players and double as the prompt display, editing them mid-battle swaps the vote row back to Generate, and voting reveals the models in place. An opt-in auto-advance starts loading the next randomized battle as soon as a vote lands, so a labeling session needs zero clicks between battles; the toggle is reachable mid-vote and Stop cancels the chain.

Examples come from the runner's seed bank via a new labeler-gated GET /v1/arena/example-prompt (BFF-proxied), replacing the hardcoded frontend list  all 100 prompts, single-sourced.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR redesigns the arena battle workflow and adds runner-backed example prompts. The main changes are:

- Keeps prompt inputs, players, voting, and model reveals in one persistent layout.
- Adds optional automatic loading of randomized battles after voting.
- Serves seed-bank prompts through a labeler-protected runner endpoint and BFF route.
- Adds real and mock data-source support for randomized examples.

<h3>Confidence Score: 5/5</h3>

The latest changes look safe to merge.

- No additional blocking issue qualifies for this follow-up review.

<sub>Reviews (2): Last reviewed commit: ["Realign the prompt inputs when stopping ..."](https://github.com/coval-ai/benchmarks/commit/d1c55f55d4760fd986ac6c65a33b2083f68cbae7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44658487)</sub>

<!-- /greptile_comment -->