### PR TITLE
Cale/bench 427 surface the new stt datasets on the dashboard

### DIFF
--- a/web/components/dashboard/AccuracyBarSection.tsx
+++ b/web/components/dashboard/AccuracyBarSection.tsx
@@ -19,6 +19,7 @@ import { normalizeModelName } from "@/lib/utils/formatters";
 import CustomBarChartTick from "@/components/charts/CustomBarChartTick";
 import Card from "@/components/shared/Card";
 import SectionHeader from "@/components/shared/SectionHeader";
+import WerBarViewToggle from "@/components/dashboard/WerBarViewToggle";
 import { useDashboard } from "@/contexts/DashboardContext";
 import { useThemeColors } from "@/hooks/useThemeColors";
 import { useActiveTab } from "@/hooks/useActiveTab";
@@ -36,6 +37,7 @@ const AccuracyBarSection: React.FC = () => {
     handleWERBarClick,
     clearWERBars,
     hasActiveFacets,
+    werBarLoading,
   } = useDashboard();
 
   const themeColors = useThemeColors();
@@ -128,6 +130,7 @@ const AccuracyBarSection: React.FC = () => {
               werBarDataWithColors.length === 0 ? "—" : `${avgWER.toFixed(1)}%`,
           }}
         />
+        <WerBarViewToggle />
         {selectedBars.length > 0 && (
           <div className="mb-3 flex flex-wrap items-center gap-1.5">
             {selectedBars.map((item) => (
@@ -162,7 +165,10 @@ const AccuracyBarSection: React.FC = () => {
             </button>
           </div>
         )}
-        <div className="h-96 overflow-x-auto" onMouseEnter={trackChartHover}>
+        <div
+          className={`h-96 overflow-x-auto transition-opacity ${werBarLoading ? "opacity-40" : ""}`}
+          onMouseEnter={trackChartHover}
+        >
           <ResponsiveContainer
             width="100%"
             height="100%"

--- a/web/components/dashboard/ModelComparisonSection.tsx
+++ b/web/components/dashboard/ModelComparisonSection.tsx
@@ -43,7 +43,9 @@ const ModelComparisonSection: React.FC = () => {
               model,
               provider: getProviderForModel(model),
               metric: activeMetric,
-              [`latency_${percentile}_ms`]: latency[percentile],
+              ...(latency
+                ? { [`latency_${percentile}_ms`]: latency[percentile] }
+                : {}),
               ...(avgWER !== undefined
                 ? { avg_wer_percent: avgWER, wer_std_dev: werStdDev }
                 : {}),

--- a/web/components/dashboard/ModelComparisonSection.tsx
+++ b/web/components/dashboard/ModelComparisonSection.tsx
@@ -11,6 +11,7 @@ import ModelComparisonTable, {
 import Card from "@/components/shared/Card";
 import SectionHeader from "@/components/shared/SectionHeader";
 import MetricToggle from "@/components/dashboard/MetricToggle";
+import { datasetLabel } from "@/lib/config/datasets";
 import { useDashboard } from "@/contexts/DashboardContext";
 import { useChartHoverTracking } from "@/hooks/useChartHoverTracking";
 
@@ -19,6 +20,8 @@ const ModelComparisonSection: React.FC = () => {
     heatmapDisplayData: data,
     getProviderForModel,
     activeMetric,
+    werDataset,
+    werDatasetLoading,
   } = useDashboard();
   const trackChartHover = useChartHoverTracking("heatmap");
   const [percentileIdx, setPercentileIdx] = useState(DEFAULT_PERCENTILE_IDX);
@@ -44,6 +47,7 @@ const ModelComparisonSection: React.FC = () => {
               ...(avgWER !== undefined
                 ? { avg_wer_percent: avgWER, wer_std_dev: werStdDev }
                 : {}),
+              ...(werDataset ? { wer_dataset: werDataset } : {}),
               runs: sampleCount,
             }))
           }
@@ -57,6 +61,8 @@ const ModelComparisonSection: React.FC = () => {
           getProviderForModel={getProviderForModel}
           percentileIdx={percentileIdx}
           onPercentileChange={setPercentileIdx}
+          werLabel={werDataset ? datasetLabel(werDataset) : undefined}
+          werLoading={werDatasetLoading}
         />
       </Card>
     </div>

--- a/web/components/dashboard/ModelComparisonTable.tsx
+++ b/web/components/dashboard/ModelComparisonTable.tsx
@@ -6,6 +6,7 @@
 import React, { useCallback, useMemo, useState } from "react";
 import { LatencyPercentile, ModelHeatmapData } from "@/types/benchmark.types";
 import { normalizeModelName } from "@/lib/utils/formatters";
+import WerDatasetSelect from "@/components/dashboard/WerDatasetSelect";
 import { useActiveTab } from "@/hooks/useActiveTab";
 import { capturePostHogEvent } from "@/lib/posthog/client";
 import { POSTHOG_EVENTS } from "@/lib/posthog/events";
@@ -15,6 +16,8 @@ interface ModelComparisonTableProps {
   getProviderForModel: (model: string) => string;
   percentileIdx: number;
   onPercentileChange: (idx: number) => void;
+  werLabel?: string;
+  werLoading?: boolean;
 }
 
 type ColumnKey = "latency" | "avgWER" | "sampleCount";
@@ -47,7 +50,9 @@ const ModelComparisonTable: React.FC<ModelComparisonTableProps> = ({
   data,
   getProviderForModel,
   percentileIdx,
-  onPercentileChange
+  onPercentileChange,
+  werLabel,
+  werLoading
 }) => {
   const activeTab = useActiveTab();
   const [sort, setSort] = useState<{ key: ColumnKey; direction: "asc" | "desc" }>(
@@ -57,7 +62,7 @@ const ModelComparisonTable: React.FC<ModelComparisonTableProps> = ({
   const percentile = (PERCENTILES[percentileIdx] ?? PERCENTILES[DEFAULT_PERCENTILE_IDX])!;
 
   // Latency-only benchmarks (S2S) ship rows without WER; hide that column.
-  const hasWER = useMemo(() => data.every((d) => d.avgWER !== undefined), [data]);
+  const hasWER = useMemo(() => data.some((d) => d.avgWER !== undefined), [data]);
   const columns = useMemo(
     () => (hasWER ? COLUMNS : COLUMNS.filter((c) => c.key !== "avgWER")),
     [hasWER]
@@ -74,9 +79,10 @@ const ModelComparisonTable: React.FC<ModelComparisonTableProps> = ({
     const [latencyMin, latencySpan] = span(
       data.map((d) => d.latency[percentile.key])
     );
-    const [werMin, werSpan] = hasWER
-      ? span(data.map((d) => d.avgWER ?? 0))
-      : [0, 0];
+    const werValues = data
+      .map((d) => d.avgWER)
+      .filter((v): v is number => v !== undefined);
+    const [werMin, werSpan] = werValues.length > 0 ? span(werValues) : [0, 0];
     const rel = (v: number, min: number, s: number) =>
       s === 0 ? 1 : (min + s - v) / s;
 
@@ -85,10 +91,16 @@ const ModelComparisonTable: React.FC<ModelComparisonTableProps> = ({
         ...d,
         latency: d.latency[percentile.key],
         latencyRel: rel(d.latency[percentile.key], latencyMin, latencySpan),
-        werRel: hasWER ? rel(d.avgWER ?? 0, werMin, werSpan) : 1
+        werRel:
+          hasWER && d.avgWER !== undefined
+            ? rel(d.avgWER, werMin, werSpan)
+            : 1
       }))
       .sort((a, b) => {
-        const delta = (a[sort.key] ?? 0) - (b[sort.key] ?? 0);
+        const [av, bv] = [a[sort.key], b[sort.key]];
+        if (av === undefined || bv === undefined)
+          return (av === undefined ? 1 : 0) - (bv === undefined ? 1 : 0);
+        const delta = av - bv;
         return sort.direction === "asc" ? delta : -delta;
       });
 
@@ -177,6 +189,7 @@ const ModelComparisonTable: React.FC<ModelComparisonTableProps> = ({
             </span>
           )}
         </span>
+        <WerDatasetSelect className="ml-auto" />
       </div>
 
       <div className="overflow-x-auto">
@@ -213,6 +226,11 @@ const ModelComparisonTable: React.FC<ModelComparisonTableProps> = ({
                           : "↓"
                         : ""}
                     </span>
+                    {column.key === "avgWER" && werLabel && (
+                      <span className="block text-[10px] font-normal normal-case text-text-tertiary">
+                        {werLabel}
+                      </span>
+                    )}
                   </button>
                 </th>
               ))}
@@ -245,13 +263,21 @@ const ModelComparisonTable: React.FC<ModelComparisonTableProps> = ({
                   cell(
                     row,
                     "avgWER",
-                    <>
-                      {(row.avgWER ?? 0).toFixed(1)}
-                      <span className="text-xs text-text-tertiary">
-                        % ± {(row.werStdDev ?? 0).toFixed(1)}
-                      </span>
-                      {bar(row.werRel)}
-                    </>
+                    <div
+                      className={`transition-opacity ${werLoading ? "opacity-40" : ""}`}
+                    >
+                      {row.avgWER !== undefined ? (
+                        <>
+                          {row.avgWER.toFixed(1)}
+                          <span className="text-xs text-text-tertiary">
+                            % ± {(row.werStdDev ?? 0).toFixed(1)}
+                          </span>
+                          {bar(row.werRel)}
+                        </>
+                      ) : (
+                        <span className="text-text-tertiary">—</span>
+                      )}
+                    </div>
                   )}
                 {cell(
                   row,

--- a/web/components/dashboard/ModelComparisonTable.tsx
+++ b/web/components/dashboard/ModelComparisonTable.tsx
@@ -76,9 +76,11 @@ const ModelComparisonTable: React.FC<ModelComparisonTableProps> = ({
       const min = Math.min(...values);
       return [min, Math.max(...values) - min];
     };
-    const [latencyMin, latencySpan] = span(
-      data.map((d) => d.latency[percentile.key])
-    );
+    const latencyValues = data
+      .map((d) => d.latency?.[percentile.key])
+      .filter((v): v is number => v !== undefined);
+    const [latencyMin, latencySpan] =
+      latencyValues.length > 0 ? span(latencyValues) : [0, 0];
     const werValues = data
       .map((d) => d.avgWER)
       .filter((v): v is number => v !== undefined);
@@ -87,15 +89,19 @@ const ModelComparisonTable: React.FC<ModelComparisonTableProps> = ({
       s === 0 ? 1 : (min + s - v) / s;
 
     const rows = data
-      .map((d) => ({
-        ...d,
-        latency: d.latency[percentile.key],
-        latencyRel: rel(d.latency[percentile.key], latencyMin, latencySpan),
-        werRel:
-          hasWER && d.avgWER !== undefined
-            ? rel(d.avgWER, werMin, werSpan)
-            : 1
-      }))
+      .map((d) => {
+        const latency = d.latency?.[percentile.key];
+        return {
+          ...d,
+          latency,
+          latencyRel:
+            latency !== undefined ? rel(latency, latencyMin, latencySpan) : 1,
+          werRel:
+            hasWER && d.avgWER !== undefined
+              ? rel(d.avgWER, werMin, werSpan)
+              : 1
+        };
+      })
       .sort((a, b) => {
         const [av, bv] = [a[sort.key], b[sort.key]];
         if (av === undefined || bv === undefined)
@@ -253,11 +259,15 @@ const ModelComparisonTable: React.FC<ModelComparisonTableProps> = ({
                 {cell(
                   row,
                   "latency",
-                  <>
-                    {Math.round(row.latency)}
-                    <span className="text-xs text-text-tertiary"> ms</span>
-                    {bar(row.latencyRel)}
-                  </>
+                  row.latency !== undefined ? (
+                    <>
+                      {Math.round(row.latency)}
+                      <span className="text-xs text-text-tertiary"> ms</span>
+                      {bar(row.latencyRel)}
+                    </>
+                  ) : (
+                    <span className="text-text-tertiary">Not applicable</span>
+                  )
                 )}
                 {hasWER &&
                   cell(

--- a/web/components/dashboard/WerBarViewToggle.tsx
+++ b/web/components/dashboard/WerBarViewToggle.tsx
@@ -1,0 +1,37 @@
+// Copyright 2026 The Coval Benchmarks Authors
+// SPDX-License-Identifier: Apache-2.0
+
+"use client";
+
+import React from "react";
+import { useDashboard } from "@/contexts/DashboardContext";
+import { datasetLabel } from "@/lib/config/datasets";
+
+const WerBarViewToggle: React.FC = () => {
+  const { werBarView, changeWerBarView, availableWerBarViews } = useDashboard();
+
+  if (availableWerBarViews.length <= 1) return null;
+
+  return (
+    <div className="mb-4 inline-flex gap-0.5 rounded-lg bg-surface-toggle-inactive p-0.5">
+      {availableWerBarViews.map((view) => (
+        <button
+          key={view.key}
+          type="button"
+          title={view.dataset ? datasetLabel(view.dataset) : undefined}
+          onClick={() => changeWerBarView(view.key)}
+          className={
+            "rounded-md px-3 py-1 text-xs font-medium transition-colors " +
+            (werBarView === view.key
+              ? "bg-surface-primary text-text-primary shadow-sm"
+              : "text-text-secondary hover:text-text-primary")
+          }
+        >
+          {view.label}
+        </button>
+      ))}
+    </div>
+  );
+};
+
+export default WerBarViewToggle;

--- a/web/components/dashboard/WerDatasetSelect.tsx
+++ b/web/components/dashboard/WerDatasetSelect.tsx
@@ -1,0 +1,70 @@
+// Copyright 2026 The Coval Benchmarks Authors
+// SPDX-License-Identifier: Apache-2.0
+
+"use client";
+
+import React from "react";
+import { useDashboard } from "@/contexts/DashboardContext";
+import { useActiveTab } from "@/hooks/useActiveTab";
+import { datasetLabel, isPerturbationDataset } from "@/lib/config/datasets";
+
+const WerDatasetSelect: React.FC<{ className?: string }> = ({ className }) => {
+  const activeTab = useActiveTab();
+  const { werDataset, changeWerDataset, availableWerDatasets } = useDashboard();
+
+  if (activeTab !== "stt" || availableWerDatasets.length === 0) return null;
+
+  const fullSets = availableWerDatasets.filter((d) => !isPerturbationDataset(d));
+  const perturbations = availableWerDatasets.filter(isPerturbationDataset);
+  const options = (ids: string[]) =>
+    ids.map((id) => (
+      <option key={id} value={id}>
+        {datasetLabel(id)}
+      </option>
+    ));
+
+  return (
+    <label
+      className={`inline-flex items-center gap-2 text-xs text-text-secondary${
+        className ? ` ${className}` : ""
+      }`}
+    >
+      WER dataset
+      <span className="relative inline-flex">
+        <select
+          value={werDataset ?? ""}
+          onChange={(e) => changeWerDataset(e.target.value || null)}
+          className="appearance-none rounded-lg border border-border-primary bg-surface-elevated py-1.5 pl-2.5 pr-7 text-xs font-medium text-text-primary outline-none transition-colors hover:border-selected-border focus:border-selected-border"
+        >
+          <option value="">All datasets (pooled)</option>
+          {perturbations.length > 0 ? (
+            <>
+              <optgroup label="Full datasets">{options(fullSets)}</optgroup>
+              <optgroup label="WildASR perturbations">
+                {options(perturbations)}
+              </optgroup>
+            </>
+          ) : (
+            options(fullSets)
+          )}
+        </select>
+        <svg
+          aria-hidden
+          viewBox="0 0 12 12"
+          className="pointer-events-none absolute right-2 top-1/2 h-3 w-3 -translate-y-1/2 text-text-tertiary"
+        >
+          <path
+            d="M2.5 4.5 6 8l3.5-3.5"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      </span>
+    </label>
+  );
+};
+
+export default WerDatasetSelect;

--- a/web/hooks/useChartData.ts
+++ b/web/hooks/useChartData.ts
@@ -12,7 +12,8 @@ import type {
   BoxPlotData,
   BoxPlotDataPoint,
   ModelHeatmapData,
-  BarDataPoint
+  BarDataPoint,
+  LatencyPercentile
 } from "@/types/benchmark.types";
 import type { SeriesPoint } from "@/lib/api/client";
 import { latencyToMs, normalizeModelName, normalizeProviderNameForTab, toModelKey, parseModelKey } from "@/lib/utils/formatters";
@@ -304,28 +305,26 @@ export function useChartData({
         // S2S is latency-only; the table hides the WER column for such rows.
         const werStat = activeTab === "s2s" ? undefined : getStat(model, "WER");
 
-        if (!latencyStat || (activeTab !== "s2s" && !werStat)) return;
-
         // The schema types every stat as a number, but guard the raw fields
         // (before unit conversion, which would coerce null to 0) against a
         // response with missing/non-finite values leaking into the table.
-        const rawFields = [
-          latencyStat.min_value,
-          latencyStat.p25,
-          latencyStat.p50,
-          latencyStat.p75,
-          latencyStat.p90,
-          latencyStat.p95,
-          latencyStat.p99,
-          latencyStat.max_value,
-          latencyStat.sample_count
-        ];
-        if (werStat) rawFields.push(werStat.avg_value, werStat.stddev_value);
-        if (!rawFields.every(Number.isFinite)) return;
-
-        heatmapData.push({
-          model,
-          latency: {
+        let latency: Record<LatencyPercentile, number> | undefined;
+        let latencySampleCount: number | undefined;
+        if (
+          latencyStat &&
+          [
+            latencyStat.min_value,
+            latencyStat.p25,
+            latencyStat.p50,
+            latencyStat.p75,
+            latencyStat.p90,
+            latencyStat.p95,
+            latencyStat.p99,
+            latencyStat.max_value,
+            latencyStat.sample_count
+          ].every(Number.isFinite)
+        ) {
+          latency = {
             p0: toDisplayUnits(latencyStat.min_value),
             p25: toDisplayUnits(latencyStat.p25),
             p50: toDisplayUnits(latencyStat.p50),
@@ -334,11 +333,30 @@ export function useChartData({
             p95: toDisplayUnits(latencyStat.p95),
             p99: toDisplayUnits(latencyStat.p99),
             p100: toDisplayUnits(latencyStat.max_value)
-          },
+          };
+          latencySampleCount = latencyStat.sample_count;
+        }
+
+        // S2S needs a latency stat (no WER to fall back on). Other tabs anchor
+        // on WER: a model measured for WER but not the active latency metric
+        // (e.g. TTFT but not TTFS) stays in the table with N/A latency.
+        if (activeTab === "s2s") {
+          if (!latency) return;
+        } else if (
+          !werStat ||
+          !Number.isFinite(werStat.avg_value) ||
+          !Number.isFinite(werStat.stddev_value)
+        ) {
+          return;
+        }
+
+        heatmapData.push({
+          model,
+          ...(latency ? { latency } : {}),
           ...(werStat
             ? { avgWER: werStat.avg_value, werStdDev: werStat.stddev_value }
             : {}),
-          sampleCount: latencyStat.sample_count
+          sampleCount: latencySampleCount ?? werStat?.sample_count ?? 0
         });
       });
 

--- a/web/hooks/useDashboardState.tsx
+++ b/web/hooks/useDashboardState.tsx
@@ -28,9 +28,10 @@ import { capturePostHogEvent } from "@/lib/posthog/client";
 import { POSTHOG_EVENTS } from "@/lib/posthog/events";
 import { getModelColor } from "@/lib/utils/colors";
 import { metricDescriptions } from "@/lib/config/metrics";
+import { WER_BAR_VIEWS, type WerBarView } from "@/lib/config/datasets";
 import { useAggregatesQuery, useProvidersQuery } from "@/lib/api/queries";
 import { useTimeWindow } from "@/hooks/useTimeWindow";
-import type { ModelStats } from "@/types/benchmark.types";
+import type { BarDataPoint, ModelStats } from "@/types/benchmark.types";
 import type { SeriesPoint } from "@/lib/api/client";
 
 export function useDashboardState(page: "tts" | "stt" | "s2s") {
@@ -93,6 +94,32 @@ export function useDashboardState(page: "tts" | "stt" | "s2s") {
   const werDatasetLoading =
     activeWerDataset !== null &&
     (werDatasetQuery.isLoading || werDatasetQuery.isPlaceholderData);
+
+  // STT only: the accuracy bar chart switches between the pooled WER
+  // (cumulative) and the easy/hard single-dataset views.
+  const [werBarView, setWerBarView] = useState<WerBarView>("cumulative");
+  const activeWerBarView = page === "stt" ? werBarView : "cumulative";
+  const werBarDatasetId =
+    WER_BAR_VIEWS.find((v) => v.key === activeWerBarView)?.dataset ?? null;
+  const changeWerBarView = useCallback(
+    (view: WerBarView) => {
+      setWerBarView(view);
+      capturePostHogEvent(POSTHOG_EVENTS.dashboardWerBarViewChanged, {
+        surface: `${page}_dashboard`,
+        mode: page,
+        view,
+      });
+    },
+    [page]
+  );
+  const werBarDatasetQuery = useAggregatesQuery({
+    benchmark: benchmarkParam,
+    window: timeWindow,
+    ...(werBarDatasetId ? { dataset: werBarDatasetId } : {}),
+  });
+  const werBarLoading =
+    werBarDatasetId !== null &&
+    (werBarDatasetQuery.isLoading || werBarDatasetQuery.isPlaceholderData);
 
   // The charts keep showing the prior window's data while a new one loads,
   // so window-derived rendering must follow the data, not the toggle.
@@ -264,7 +291,40 @@ export function useDashboardState(page: "tts" | "stt" | "s2s") {
   const { avgSecondary, lowestWERModel, lowestWERProvider } = keyMetrics;
 
   // Get computed data
-  const werBarData = chartData.getWERBarData();
+  const cumulativeWerBarData = chartData.getWERBarData();
+  const werBarData = useMemo<BarDataPoint[]>(() => {
+    if (!werBarDatasetId) return cumulativeWerBarData;
+    const byKey = new Map<string, { avg: number; provider: string }>();
+    (werBarDatasetQuery.data?.model_stats ?? []).forEach((s) => {
+      if (s.metric_type !== "WER") return;
+      byKey.set(toModelKey(s.provider, s.model), {
+        avg: s.avg_value,
+        provider: s.provider,
+      });
+    });
+    return deferredSelectedModels
+      .map((model) => {
+        const hit = byKey.get(model);
+        return hit
+          ? { model, averageWER: hit.avg, provider: hit.provider }
+          : null;
+      })
+      .filter((b): b is BarDataPoint => b !== null)
+      .sort((a, b) => a.averageWER - b.averageWER);
+  }, [
+    werBarDatasetId,
+    cumulativeWerBarData,
+    werBarDatasetQuery.data,
+    deferredSelectedModels,
+  ]);
+
+  const availableWerBarViews = useMemo(() => {
+    if (page !== "stt") return [];
+    const available = new Set(availableWerDatasets);
+    return WER_BAR_VIEWS.filter(
+      (v) => v.dataset === null || available.has(v.dataset)
+    );
+  }, [page, availableWerDatasets]);
 
   const werBarDataWithColors = useMemo(() => {
     const hasSelection = werBarData.some((item) => clickedWERBars.has(item.model));
@@ -388,6 +448,12 @@ export function useDashboardState(page: "tts" | "stt" | "s2s") {
     changeWerDataset,
     availableWerDatasets,
     werDatasetLoading,
+
+    // WER bar chart view (STT accuracy card)
+    werBarView: activeWerBarView,
+    changeWerBarView,
+    availableWerBarViews,
+    werBarLoading,
 
     // Key metrics
     primaryKeyMetric,

--- a/web/hooks/useDashboardState.tsx
+++ b/web/hooks/useDashboardState.tsx
@@ -30,6 +30,7 @@ import { getModelColor } from "@/lib/utils/colors";
 import { metricDescriptions } from "@/lib/config/metrics";
 import { WER_BAR_VIEWS, type WerBarView } from "@/lib/config/datasets";
 import { useAggregatesQuery, useProvidersQuery } from "@/lib/api/queries";
+import { useDatasetScopedWer } from "@/hooks/useDatasetScopedWer";
 import { useTimeWindow } from "@/hooks/useTimeWindow";
 import type { BarDataPoint, ModelStats } from "@/types/benchmark.types";
 import type { SeriesPoint } from "@/lib/api/client";
@@ -70,30 +71,15 @@ export function useDashboardState(page: "tts" | "stt" | "s2s") {
     [page]
   );
 
-  const werDatasetQuery = useAggregatesQuery({
-    benchmark: benchmarkParam,
-    window: timeWindow,
-    ...(activeWerDataset ? { dataset: activeWerDataset } : {}),
-  });
+  const { werByModel: werDatasetStats, loading: werDatasetLoading } =
+    useDatasetScopedWer(
+      { benchmark: benchmarkParam, window: timeWindow },
+      activeWerDataset
+    );
   const availableWerDatasets = useMemo(
     () => aggregatesQuery.data?.datasets ?? [],
     [aggregatesQuery.data]
   );
-  const werDatasetStats = useMemo(() => {
-    if (!activeWerDataset) return null;
-    const map = new Map<string, { avg: number; std: number }>();
-    (werDatasetQuery.data?.model_stats ?? []).forEach((s) => {
-      if (s.metric_type !== "WER") return;
-      map.set(toModelKey(s.provider, s.model), {
-        avg: s.avg_value,
-        std: s.stddev_value,
-      });
-    });
-    return map;
-  }, [activeWerDataset, werDatasetQuery.data]);
-  const werDatasetLoading =
-    activeWerDataset !== null &&
-    (werDatasetQuery.isLoading || werDatasetQuery.isPlaceholderData);
 
   // STT only: the accuracy bar chart switches between the pooled WER
   // (cumulative) and the easy/hard single-dataset views.
@@ -112,14 +98,11 @@ export function useDashboardState(page: "tts" | "stt" | "s2s") {
     },
     [page]
   );
-  const werBarDatasetQuery = useAggregatesQuery({
-    benchmark: benchmarkParam,
-    window: timeWindow,
-    ...(werBarDatasetId ? { dataset: werBarDatasetId } : {}),
-  });
-  const werBarLoading =
-    werBarDatasetId !== null &&
-    (werBarDatasetQuery.isLoading || werBarDatasetQuery.isPlaceholderData);
+  const { werByModel: werBarDatasetStats, loading: werBarLoading } =
+    useDatasetScopedWer(
+      { benchmark: benchmarkParam, window: timeWindow },
+      werBarDatasetId
+    );
 
   // The charts keep showing the prior window's data while a new one loads,
   // so window-derived rendering must follow the data, not the toggle.
@@ -293,30 +276,17 @@ export function useDashboardState(page: "tts" | "stt" | "s2s") {
   // Get computed data
   const cumulativeWerBarData = chartData.getWERBarData();
   const werBarData = useMemo<BarDataPoint[]>(() => {
-    if (!werBarDatasetId) return cumulativeWerBarData;
-    const byKey = new Map<string, { avg: number; provider: string }>();
-    (werBarDatasetQuery.data?.model_stats ?? []).forEach((s) => {
-      if (s.metric_type !== "WER") return;
-      byKey.set(toModelKey(s.provider, s.model), {
-        avg: s.avg_value,
-        provider: s.provider,
-      });
-    });
+    if (!werBarDatasetStats) return cumulativeWerBarData;
     return deferredSelectedModels
       .map((model) => {
-        const hit = byKey.get(model);
+        const hit = werBarDatasetStats.get(model);
         return hit
-          ? { model, averageWER: hit.avg, provider: hit.provider }
+          ? { model, averageWER: hit.avg_value, provider: hit.provider }
           : null;
       })
       .filter((b): b is BarDataPoint => b !== null)
       .sort((a, b) => a.averageWER - b.averageWER);
-  }, [
-    werBarDatasetId,
-    cumulativeWerBarData,
-    werBarDatasetQuery.data,
-    deferredSelectedModels,
-  ]);
+  }, [werBarDatasetStats, cumulativeWerBarData, deferredSelectedModels]);
 
   const availableWerBarViews = useMemo(() => {
     if (page !== "stt") return [];
@@ -385,8 +355,8 @@ export function useDashboardState(page: "tts" | "stt" | "s2s") {
       const wer = werDatasetStats.get(row.model);
       return {
         ...row,
-        avgWER: wer?.avg,
-        werStdDev: wer?.std,
+        avgWER: wer?.avg_value,
+        werStdDev: wer?.stddev_value,
       };
     });
   }, [getHeatmapData, activeMetric, werDatasetStats]);

--- a/web/hooks/useDashboardState.tsx
+++ b/web/hooks/useDashboardState.tsx
@@ -54,6 +54,46 @@ export function useDashboardState(page: "tts" | "stt" | "s2s") {
   });
   const providersQuery = useProvidersQuery();
 
+  // STT only: pin the WER column to one dataset (null = pooled across all).
+  const [werDataset, setWerDataset] = useState<string | null>(null);
+  const activeWerDataset = page === "stt" ? werDataset : null;
+  const changeWerDataset = useCallback(
+    (dataset: string | null) => {
+      setWerDataset(dataset);
+      capturePostHogEvent(POSTHOG_EVENTS.dashboardWerDatasetChanged, {
+        surface: `${page}_dashboard`,
+        mode: page,
+        dataset: dataset ?? "all",
+      });
+    },
+    [page]
+  );
+
+  const werDatasetQuery = useAggregatesQuery({
+    benchmark: benchmarkParam,
+    window: timeWindow,
+    ...(activeWerDataset ? { dataset: activeWerDataset } : {}),
+  });
+  const availableWerDatasets = useMemo(
+    () => aggregatesQuery.data?.datasets ?? [],
+    [aggregatesQuery.data]
+  );
+  const werDatasetStats = useMemo(() => {
+    if (!activeWerDataset) return null;
+    const map = new Map<string, { avg: number; std: number }>();
+    (werDatasetQuery.data?.model_stats ?? []).forEach((s) => {
+      if (s.metric_type !== "WER") return;
+      map.set(toModelKey(s.provider, s.model), {
+        avg: s.avg_value,
+        std: s.stddev_value,
+      });
+    });
+    return map;
+  }, [activeWerDataset, werDatasetQuery.data]);
+  const werDatasetLoading =
+    activeWerDataset !== null &&
+    (werDatasetQuery.isLoading || werDatasetQuery.isPlaceholderData);
+
   // The charts keep showing the prior window's data while a new one loads,
   // so window-derived rendering must follow the data, not the toggle.
   const dataTimeWindow = aggregatesQuery.data?.window ?? timeWindow;
@@ -278,10 +318,18 @@ export function useDashboardState(page: "tts" | "stt" | "s2s") {
           "In voice AI applications, transcription accuracy directly impacts the performance of downstream tasks. Even small transcription errors can lead to misinterpretations, frustrating experiences, or incorrect system responses. We evaluate against test audio that includes diverse speakers, accents, and real-world audio conditions. Click a bar to highlight it for comparison.",
       };
 
-  const heatmapDisplayData = useMemo(
-    () => getHeatmapData(activeMetric),
-    [getHeatmapData, activeMetric]
-  );
+  const heatmapDisplayData = useMemo(() => {
+    const rows = getHeatmapData(activeMetric);
+    if (!werDatasetStats) return rows;
+    return rows.map((row) => {
+      const wer = werDatasetStats.get(row.model);
+      return {
+        ...row,
+        avgWER: wer?.avg,
+        werStdDev: wer?.std,
+      };
+    });
+  }, [getHeatmapData, activeMetric, werDatasetStats]);
 
   // Pre-computed key metrics for display
   const primaryKeyMetric = {
@@ -334,6 +382,12 @@ export function useDashboardState(page: "tts" | "stt" | "s2s") {
     sttMetric,
     setSttMetric,
     activeMetric,
+
+    // WER dataset pin (STT comparison card)
+    werDataset: activeWerDataset,
+    changeWerDataset,
+    availableWerDatasets,
+    werDatasetLoading,
 
     // Key metrics
     primaryKeyMetric,

--- a/web/hooks/useDashboardState.tsx
+++ b/web/hooks/useDashboardState.tsx
@@ -357,6 +357,7 @@ export function useDashboardState(page: "tts" | "stt" | "s2s") {
         ...row,
         avgWER: wer?.avg_value,
         werStdDev: wer?.stddev_value,
+        sampleCount: wer?.sample_count ?? 0,
       };
     });
   }, [getHeatmapData, activeMetric, werDatasetStats]);

--- a/web/hooks/useDashboardState.tsx
+++ b/web/hooks/useDashboardState.tsx
@@ -8,6 +8,7 @@ import {
   useMemo,
   useCallback,
   useDeferredValue,
+  useEffect,
 } from "react";
 import { useChartData } from "@/hooks/useChartData";
 import { useMobileDetection } from "@/hooks/useMobileDetection";
@@ -103,6 +104,16 @@ export function useDashboardState(page: "tts" | "stt" | "s2s") {
       { benchmark: benchmarkParam, window: timeWindow },
       werBarDatasetId
     );
+
+  useEffect(() => {
+    if (availableWerDatasets.length === 0) return;
+    if (werDataset && !availableWerDatasets.includes(werDataset)) {
+      setWerDataset(null);
+    }
+    if (werBarDatasetId && !availableWerDatasets.includes(werBarDatasetId)) {
+      setWerBarView("cumulative");
+    }
+  }, [availableWerDatasets, werDataset, werBarDatasetId]);
 
   // The charts keep showing the prior window's data while a new one loads,
   // so window-derived rendering must follow the data, not the toggle.

--- a/web/hooks/useDatasetScopedWer.ts
+++ b/web/hooks/useDatasetScopedWer.ts
@@ -1,0 +1,34 @@
+// Copyright 2026 The Coval Benchmarks Authors
+// SPDX-License-Identifier: Apache-2.0
+
+import { useMemo } from "react";
+import { useAggregatesQuery } from "@/lib/api/queries";
+import { toModelKey } from "@/lib/utils/formatters";
+import type { AggregatesQueryParams, ModelStatEntry } from "@/lib/api/client";
+
+// A null datasetId is "pooled": the query dedupes onto the main aggregates
+// fetch and werByModel stays null so callers fall back to their pooled data.
+export function useDatasetScopedWer(
+  base: Pick<AggregatesQueryParams, "benchmark" | "window">,
+  datasetId: string | null
+): { werByModel: Map<string, ModelStatEntry> | null; loading: boolean } {
+  const query = useAggregatesQuery({
+    ...base,
+    ...(datasetId ? { dataset: datasetId } : {}),
+  });
+
+  const werByModel = useMemo(() => {
+    if (!datasetId) return null;
+    const map = new Map<string, ModelStatEntry>();
+    (query.data?.model_stats ?? []).forEach((s) => {
+      if (s.metric_type !== "WER") return;
+      map.set(toModelKey(s.provider, s.model), s);
+    });
+    return map;
+  }, [datasetId, query.data]);
+
+  const loading =
+    datasetId !== null && (query.isLoading || query.isPlaceholderData);
+
+  return { werByModel, loading };
+}

--- a/web/hooks/useDatasetScopedWer.ts
+++ b/web/hooks/useDatasetScopedWer.ts
@@ -18,14 +18,14 @@ export function useDatasetScopedWer(
   });
 
   const werByModel = useMemo(() => {
-    if (!datasetId) return null;
+    if (!datasetId || (query.isError && !query.data)) return null;
     const map = new Map<string, ModelStatEntry>();
     (query.data?.model_stats ?? []).forEach((s) => {
       if (s.metric_type !== "WER") return;
       map.set(toModelKey(s.provider, s.model), s);
     });
     return map;
-  }, [datasetId, query.data]);
+  }, [datasetId, query.data, query.isError]);
 
   const loading =
     datasetId !== null && (query.isLoading || query.isPlaceholderData);

--- a/web/lib/api/generated/schema.ts
+++ b/web/lib/api/generated/schema.ts
@@ -10,6 +10,7 @@ export interface paths {
         query: {
           benchmark: components["schemas"]["BenchmarkLiteral"];
           window?: components["schemas"]["WindowLiteral"];
+          dataset?: string | null;
           schedule_period?: number;
         };
       };
@@ -29,6 +30,8 @@ export interface components {
     AggregatesResponse: {
       benchmark: components["schemas"]["BenchmarkLiteral"];
       window: components["schemas"]["WindowLiteral"];
+      dataset: string;
+      datasets: string[];
       model_stats: components["schemas"]["ModelStatEntry"][];
       series: components["schemas"]["SeriesPoint"][];
     };

--- a/web/lib/config/datasets.ts
+++ b/web/lib/config/datasets.ts
@@ -19,7 +19,8 @@ export function datasetLabel(id: string): string {
 }
 
 export function isPerturbationDataset(id: string): boolean {
-  return id.startsWith("stt-wildasr-");
+  // WildASR clean is the undegraded baseline, so it groups with the full sets.
+  return id.startsWith("stt-wildasr-") && id !== "stt-wildasr-clean";
 }
 
 export type WerBarView = "cumulative" | "clean" | "production";

--- a/web/lib/config/datasets.ts
+++ b/web/lib/config/datasets.ts
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 const DATASET_LABELS: Record<string, string> = {
-  "stt-v1": "LibriSpeech (read speech)",
-  "stt-v2": "FLEURS (read speech)",
-  "stt-v3": "PipeCat (conversational)",
+  "stt-v1": "LibriSpeech",
+  "stt-v2": "FLEURS",
+  "stt-v3": "PipeCat (production)",
   "stt-wildasr-clean": "WildASR clean",
   "stt-wildasr-clipping": "WildASR clipping",
   "stt-wildasr-farfield": "WildASR far-field",
@@ -22,12 +22,12 @@ export function isPerturbationDataset(id: string): boolean {
   return id.startsWith("stt-wildasr-");
 }
 
-export type WerBarView = "cumulative" | "easy" | "hard";
+export type WerBarView = "cumulative" | "clean" | "production";
 
-// cumulative pools every dataset; easy/hard pin the bar chart to the clean-audio
-// (WildASR clean) and conversational (PipeCat) sets respectively.
+// cumulative pools every dataset; clean/production pin the bar chart to the
+// clean-audio (WildASR clean) and conversational (PipeCat) sets respectively.
 export const WER_BAR_VIEWS: { key: WerBarView; label: string; dataset: string | null }[] = [
   { key: "cumulative", label: "Cumulative", dataset: null },
-  { key: "easy", label: "Easy", dataset: "stt-wildasr-clean" },
-  { key: "hard", label: "Hard", dataset: "stt-v3" },
+  { key: "clean", label: "Clean", dataset: "stt-wildasr-clean" },
+  { key: "production", label: "Production", dataset: "stt-v3" },
 ];

--- a/web/lib/config/datasets.ts
+++ b/web/lib/config/datasets.ts
@@ -24,10 +24,10 @@ export function isPerturbationDataset(id: string): boolean {
 
 export type WerBarView = "cumulative" | "easy" | "hard";
 
-// cumulative pools every dataset; easy/hard pin the bar chart to the read-speech
-// and conversational sets respectively.
+// cumulative pools every dataset; easy/hard pin the bar chart to the clean-audio
+// (WildASR clean) and conversational (PipeCat) sets respectively.
 export const WER_BAR_VIEWS: { key: WerBarView; label: string; dataset: string | null }[] = [
   { key: "cumulative", label: "Cumulative", dataset: null },
-  { key: "easy", label: "Easy", dataset: "stt-v1" },
+  { key: "easy", label: "Easy", dataset: "stt-wildasr-clean" },
   { key: "hard", label: "Hard", dataset: "stt-v3" },
 ];

--- a/web/lib/config/datasets.ts
+++ b/web/lib/config/datasets.ts
@@ -1,0 +1,23 @@
+// Copyright 2026 The Coval Benchmarks Authors
+// SPDX-License-Identifier: Apache-2.0
+
+const DATASET_LABELS: Record<string, string> = {
+  "stt-v1": "LibriSpeech (read speech)",
+  "stt-v2": "FLEURS (read speech)",
+  "stt-v3": "PipeCat (conversational)",
+  "stt-wildasr-clean": "WildASR clean",
+  "stt-wildasr-clipping": "WildASR clipping",
+  "stt-wildasr-farfield": "WildASR far-field",
+  "stt-wildasr-noisegap": "WildASR noise gaps",
+  "stt-wildasr-phonecodec": "WildASR phone codec",
+  "stt-wildasr-reverb": "WildASR reverb",
+  "stt-wildasr-accent": "WildASR accents",
+};
+
+export function datasetLabel(id: string): string {
+  return DATASET_LABELS[id] ?? id;
+}
+
+export function isPerturbationDataset(id: string): boolean {
+  return id.startsWith("stt-wildasr-");
+}

--- a/web/lib/config/datasets.ts
+++ b/web/lib/config/datasets.ts
@@ -21,3 +21,13 @@ export function datasetLabel(id: string): string {
 export function isPerturbationDataset(id: string): boolean {
   return id.startsWith("stt-wildasr-");
 }
+
+export type WerBarView = "cumulative" | "easy" | "hard";
+
+// cumulative pools every dataset; easy/hard pin the bar chart to the read-speech
+// and conversational sets respectively.
+export const WER_BAR_VIEWS: { key: WerBarView; label: string; dataset: string | null }[] = [
+  { key: "cumulative", label: "Cumulative", dataset: null },
+  { key: "easy", label: "Easy", dataset: "stt-v1" },
+  { key: "hard", label: "Hard", dataset: "stt-v3" },
+];

--- a/web/lib/posthog/events.ts
+++ b/web/lib/posthog/events.ts
@@ -18,7 +18,8 @@ export const POSTHOG_EVENTS = {
   playgroundModeSwitched: "playground_mode_switched",
   playgroundResultPlayed: "playground_result_played",
   dashboardTimeWindowChanged: "dashboard_time_window_changed",
-  dashboardChartShared: "dashboard_chart_shared"
+  dashboardChartShared: "dashboard_chart_shared",
+  dashboardWerDatasetChanged: "dashboard_wer_dataset_changed"
 } as const;
 
 export type PostHogSurface =

--- a/web/lib/posthog/events.ts
+++ b/web/lib/posthog/events.ts
@@ -19,7 +19,8 @@ export const POSTHOG_EVENTS = {
   playgroundResultPlayed: "playground_result_played",
   dashboardTimeWindowChanged: "dashboard_time_window_changed",
   dashboardChartShared: "dashboard_chart_shared",
-  dashboardWerDatasetChanged: "dashboard_wer_dataset_changed"
+  dashboardWerDatasetChanged: "dashboard_wer_dataset_changed",
+  dashboardWerBarViewChanged: "dashboard_wer_bar_view_changed"
 } as const;
 
 export type PostHogSurface =

--- a/web/types/benchmark.types.ts
+++ b/web/types/benchmark.types.ts
@@ -34,7 +34,9 @@ export type LatencyPercentile =
 
 export interface ModelHeatmapData {
   model: string;
-  latency: Record<LatencyPercentile, number>;
+  // Absent when the model isn't measured under the active latency metric (e.g.
+  // reports TTFT but not TTFS); the comparison table shows "Not applicable".
+  latency?: Record<LatencyPercentile, number>;
   // Absent on latency-only benchmarks (S2S), or on models with no rows for a
   // pinned WER dataset.
   avgWER?: number;

--- a/web/types/benchmark.types.ts
+++ b/web/types/benchmark.types.ts
@@ -35,8 +35,8 @@ export type LatencyPercentile =
 export interface ModelHeatmapData {
   model: string;
   latency: Record<LatencyPercentile, number>;
-  // Absent on latency-only benchmarks (S2S); the comparison table hides the
-  // WER column when any row lacks it.
+  // Absent on latency-only benchmarks (S2S), or on models with no rows for a
+  // pinned WER dataset.
   avgWER?: number;
   werStdDev?: number;
   sampleCount: number;


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds dataset-scoped STT results to the dashboard. The main changes are:

- Dataset selection for the model comparison table.
- Clean, production, and cumulative WER chart views.
- Dataset-scoped aggregate queries with loading and failure handling.
- Comparison rows for models without latency measurements.
- Analytics events for the new dataset controls.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- The scoped-query failure fix now falls back instead of treating a failed initial request as an empty successful result.
- No remaining blocking issue qualifies for this follow-up review.

<sub>Reviews (7): Last reviewed commit: ["Guard dataset-scoped WER against stale s..."](https://github.com/coval-ai/benchmarks/commit/cfad2597213eaac51d570d275646fce66fe9bdb6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44670377)</sub>

<!-- /greptile_comment -->