### PR TITLE
Auto-play battle audio in auto-advance

### DIFF
--- a/web/app/arena/components/AudioPlayer.tsx
+++ b/web/app/arena/components/AudioPlayer.tsx
@@ -7,6 +7,8 @@ type Props = {
   label: string;
   isActive: boolean; // true when this is the side currently allowed to play
   onActivate: () => void; // claim single-playback focus
+  autoPlay?: boolean; // start playing as soon as this side holds focus
+  onEnded?: () => void;
 };
 
 function fmt(t: number): string {
@@ -16,7 +18,7 @@ function fmt(t: number): string {
   return `${m}:${s.toString().padStart(2, "0")}`;
 }
 
-export function AudioPlayer({ src, label, isActive, onActivate }: Props) {
+export function AudioPlayer({ src, label, isActive, onActivate, autoPlay, onEnded }: Props) {
   const ref = useRef<HTMLAudioElement>(null);
   const [playing, setPlaying] = useState(false);
   const [progress, setProgress] = useState(0);
@@ -28,6 +30,12 @@ export function AudioPlayer({ src, label, isActive, onActivate }: Props) {
   useEffect(() => {
     if (!isActive) ref.current?.pause();
   }, [isActive]);
+
+  // Auto-play on gaining focus. A browser autoplay block just leaves the
+  // player paused with its normal play button.
+  useEffect(() => {
+    if (autoPlay && isActive) ref.current?.play().catch(() => {});
+  }, [autoPlay, isActive]);
 
   // Pause on unmount so audio never outlives the component.
   useEffect(() => {
@@ -61,6 +69,7 @@ export function AudioPlayer({ src, label, isActive, onActivate }: Props) {
             setPlaying(false);
             setProgress(0);
             if (ref.current) ref.current.currentTime = 0; // rearm for replay from the start
+            onEnded?.();
           }}
           onLoadedMetadata={(e) => setDuration(e.currentTarget.duration)}
           onTimeUpdate={(e) =>

--- a/web/app/arena/page.tsx
+++ b/web/app/arena/page.tsx
@@ -34,6 +34,8 @@ export default function ArenaPage() {
   const [autoPlay, setAutoPlay] = useState(false);
   const nextBattleRef = useRef<HTMLButtonElement>(null);
   const runToken = useRef(0);
+  const autoAdvanceRef = useRef(autoAdvance);
+  autoAdvanceRef.current = autoAdvance;
 
   useEffect(() => {
     try {
@@ -84,8 +86,8 @@ export default function ArenaPage() {
       setRecorded(false);
       // With auto-advance on, play the new battle hands-free: A starts now,
       // B takes over when A ends (see onEnded below).
-      setActive(autoAdvance ? "a" : null);
-      setAutoPlay(autoAdvance);
+      setActive(autoAdvanceRef.current ? "a" : null);
+      setAutoPlay(autoAdvanceRef.current);
     } catch {
       if (token === runToken.current) setError("Couldn't generate audio. Please try again.");
     } finally {
@@ -134,7 +136,7 @@ export default function ArenaPage() {
         setReveal(null); // vote is recorded; identities just unavailable
       }
       setRecorded(true);
-      if (autoAdvance) void quickBattle();
+      if (autoAdvanceRef.current) void quickBattle();
     } catch {
       setVote(null); // let them retry
       setError("Couldn't record your vote. Please try again.");

--- a/web/app/arena/page.tsx
+++ b/web/app/arena/page.tsx
@@ -31,6 +31,7 @@ export default function ArenaPage() {
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [active, setActive] = useState<"a" | "b" | null>(null);
+  const [autoPlay, setAutoPlay] = useState(false);
   const nextBattleRef = useRef<HTMLButtonElement>(null);
   const runToken = useRef(0);
 
@@ -81,7 +82,10 @@ export default function ArenaPage() {
       setVote(null);
       setReveal(null);
       setRecorded(false);
-      setActive(null);
+      // With auto-advance on, play the new battle hands-free: A starts now,
+      // B takes over when A ends (see onEnded below).
+      setActive(autoAdvance ? "a" : null);
+      setAutoPlay(autoAdvance);
     } catch {
       if (token === runToken.current) setError("Couldn't generate audio. Please try again.");
     } finally {
@@ -121,6 +125,7 @@ export default function ArenaPage() {
     setSubmitting(true);
     setVote(outcome);
     setActive(null); // stop both players
+    setAutoPlay(false);
     try {
       await source.submitVote({ battleId: battle.battleId, outcome, voterId });
       try {
@@ -135,6 +140,16 @@ export default function ArenaPage() {
       setError("Couldn't record your vote. Please try again.");
     } finally {
       setSubmitting(false);
+    }
+  };
+
+  const chainEnded = (side: "a" | "b") => {
+    if (!autoPlay) return;
+    if (side === "a") {
+      setActive("b");
+    } else {
+      setAutoPlay(false);
+      setActive(null);
     }
   };
 
@@ -197,6 +212,8 @@ export default function ArenaPage() {
             isActive={active === "a"}
             src={battle?.audioA ?? null}
             onActivate={() => setActive("a")}
+            autoPlay={autoPlay}
+            onEnded={() => chainEnded("a")}
           />
           <div className="flex items-center justify-center font-mono text-xs text-text-tertiary">
             VS
@@ -209,6 +226,8 @@ export default function ArenaPage() {
             isActive={active === "b"}
             src={battle?.audioB ?? null}
             onActivate={() => setActive("b")}
+            autoPlay={autoPlay}
+            onEnded={() => chainEnded("b")}
           />
         </div>
 
@@ -323,6 +342,8 @@ function BattleCard({
   isActive,
   src,
   onActivate,
+  autoPlay,
+  onEnded,
 }: {
   side: "a" | "b";
   blindTitle: string;
@@ -331,6 +352,8 @@ function BattleCard({
   isActive: boolean;
   src: string | null;
   onActivate: () => void;
+  autoPlay: boolean;
+  onEnded: () => void;
 }) {
   const won = picked === (side === "a" ? "A_WIN" : "B_WIN");
   const tie = picked === "TIE";
@@ -364,6 +387,8 @@ function BattleCard({
         label={`Model ${side.toUpperCase()}`}
         isActive={isActive}
         onActivate={onActivate}
+        autoPlay={autoPlay}
+        onEnded={onEnded}
       />
     </div>
   );


### PR DESCRIPTION
With auto-advance on, each new battle now plays hands-free: model A starts as soon as the battle's audio is ready, and model B starts when A finishes, so a labeler can vote without touching the players. Voting mid-play still stops both, and if the browser blocks programmatic playback the players just sit paused with their normal buttons.

The page arms a small autoplay chain when a battle arrives while auto-advance is enabled, reusing the existing single-playback focus: A gets focus and plays, A's `ended` hands focus to B, B's `ended` clears the chain. Manual clicks keep working exactly as before.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds hands-free battle audio when auto-advance is enabled. The main changes are:

- Starts model A when a new battle is ready.
- Starts model B after model A finishes.
- Stops the playback chain when voting begins.
- Uses the latest auto-advance setting after asynchronous work completes.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- The updated code reads the current auto-advance setting when generation and voting finish.
- No blocking issues were found in the changed code.

<sub>Reviews (2): Last reviewed commit: ["Fix stale auto-advance reads after await..."](https://github.com/coval-ai/benchmarks/commit/06bd80ead1121a7c795e058026132992d6cb9e51) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44854764)</sub>

<!-- /greptile_comment -->