### PR TITLE
[BENCH-428] About this benchmark: hover/tap tooltip instead of dropdown

### DIFF
--- a/web/components/dashboard/LatencyAccuracySection.tsx
+++ b/web/components/dashboard/LatencyAccuracySection.tsx
@@ -180,7 +180,7 @@ const LatencyAccuracySection: React.FC = () => {
           {activeTab === "stt" && metric === "TTFS" && (
             <ul data-chart-legend className="mb-4 ml-auto">
               <li
-                className="flex items-center gap-1.5 font-mono text-xs"
+                className="flex items-center gap-1.5 text-xs"
                 style={{ color: themeColors.textSecondary }}
               >
                 <span

--- a/web/components/shared/MetricInfo.tsx
+++ b/web/components/shared/MetricInfo.tsx
@@ -3,7 +3,7 @@
 
 "use client";
 
-import React, { useId, useState } from "react";
+import React, { useEffect, useId, useRef, useState } from "react";
 import { metricDescriptions } from "@/lib/config/metrics";
 
 const alignClasses = {
@@ -28,6 +28,15 @@ const MetricInfo: React.FC<{
 }) => {
   const id = useId();
   const [open, setOpen] = useState(false);
+  const wrapperRef = useRef<HTMLSpanElement>(null);
+  useEffect(() => {
+    if (!open) return;
+    const close = (e: PointerEvent) => {
+      if (!wrapperRef.current?.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener("pointerdown", close);
+    return () => document.removeEventListener("pointerdown", close);
+  }, [open]);
   const info: { short: string; tooltip?: string } | undefined = metric
     ? metricDescriptions[metric.toLowerCase() as keyof typeof metricDescriptions]
     : undefined;
@@ -48,6 +57,7 @@ const MetricInfo: React.FC<{
   const isElement = React.isValidElement(children);
   return (
     <span
+      ref={wrapperRef}
       className={`group relative inline-block ${isElement ? "" : "-m-2 cursor-help p-2"}`}
       tabIndex={isElement ? undefined : 0}
       aria-describedby={isElement ? undefined : id}

--- a/web/components/shared/MetricInfo.tsx
+++ b/web/components/shared/MetricInfo.tsx
@@ -3,7 +3,7 @@
 
 "use client";
 
-import React, { useId } from "react";
+import React, { useId, useState } from "react";
 import { metricDescriptions } from "@/lib/config/metrics";
 
 const alignClasses = {
@@ -13,20 +13,46 @@ const alignClasses = {
 };
 
 const MetricInfo: React.FC<{
-  metric: string;
+  metric?: string;
+  content?: React.ReactNode;
   align?: keyof typeof alignClasses;
+  /** Placement and sizing of the tooltip panel; defaults to above the trigger. */
+  panelClassName?: string;
   children: React.ReactNode;
-}> = ({ metric, align = "center", children }) => {
+}> = ({
+  metric,
+  content,
+  align = "center",
+  panelClassName = "bottom-full mb-1.5 w-64",
+  children,
+}) => {
   const id = useId();
-  const info =
-    metricDescriptions[metric.toLowerCase() as keyof typeof metricDescriptions];
-  if (!info || !("tooltip" in info)) return <>{children}</>;
+  const [open, setOpen] = useState(false);
+  const info: { short: string; tooltip?: string } | undefined = metric
+    ? metricDescriptions[metric.toLowerCase() as keyof typeof metricDescriptions]
+    : undefined;
+  let body: React.ReactNode = content ?? null;
+  if (body == null && info?.tooltip) {
+    const repeatsTrigger =
+      typeof children === "string" &&
+      children.trim().toLowerCase() === info.short.toLowerCase();
+    body = repeatsTrigger ? (
+      info.tooltip
+    ) : (
+      <>
+        <span className="font-semibold">{info.short}.</span> {info.tooltip}
+      </>
+    );
+  }
+  if (!body) return <>{children}</>;
   const isElement = React.isValidElement(children);
   return (
     <span
-      className="group relative inline-block"
+      className={`group relative inline-block ${isElement ? "" : "-m-2 cursor-help p-2"}`}
       tabIndex={isElement ? undefined : 0}
       aria-describedby={isElement ? undefined : id}
+      onClick={isElement ? undefined : () => setOpen((prev) => !prev)}
+      onBlur={isElement ? undefined : () => setOpen(false)}
     >
       {isElement
         ? React.cloneElement(children as React.ReactElement<Record<string, unknown>>, {
@@ -36,9 +62,9 @@ const MetricInfo: React.FC<{
       <span
         id={id}
         role="tooltip"
-        className={`pointer-events-none invisible absolute bottom-full z-50 mb-1.5 w-64 rounded-lg border border-border-secondary bg-surface-tooltip px-3 py-2 text-left text-xs font-normal leading-snug text-[var(--color-text-on-tooltip)] opacity-0 shadow-md transition-opacity group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 group-has-[:focus-visible]:visible group-has-[:focus-visible]:opacity-100 ${alignClasses[align]}`}
+        className={`pointer-events-none absolute z-50 ${panelClassName} max-w-[calc(100vw-1.5rem)] rounded-lg border border-border-secondary bg-surface-tooltip px-3 py-2 text-left font-sans text-xs font-normal leading-snug text-[var(--color-text-on-tooltip)] shadow-md transition-opacity group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 group-has-[:focus-visible]:visible group-has-[:focus-visible]:opacity-100 ${open ? "visible opacity-100" : "invisible opacity-0"} ${alignClasses[align]}`}
       >
-        <span className="font-semibold">{info.short}.</span> {info.tooltip}
+        {body}
       </span>
     </span>
   );

--- a/web/components/shared/SectionHeader.tsx
+++ b/web/components/shared/SectionHeader.tsx
@@ -4,7 +4,8 @@
 "use client";
 
 import React, { useEffect, useState } from "react";
-import { Check, ImageDown, Link2, Table } from "lucide-react";
+import { Check, ImageDown, Info, Link2, Table } from "lucide-react";
+import MetricInfo from "@/components/shared/MetricInfo";
 import { downloadCSV, downloadChartPNG } from "@/lib/utils/chartExport";
 import { useThemeColors } from "@/hooks/useThemeColors";
 import { setExportStaged } from "@/hooks/useMobileDetection";
@@ -24,7 +25,7 @@ interface SectionHeaderProps {
     label: React.ReactNode;
     value: string;
   };
-  /** Optional hint shown after the "About this benchmark" link, separated by an interpunct. */
+  /** Optional hint shown after the "About this benchmark" label, separated by an interpunct. */
   hint?: string;
   /** When false, the detailed text shows inline instead of behind a toggle. */
   expandable?: boolean;
@@ -236,18 +237,25 @@ const SectionHeader: React.FC<SectionHeaderProps> = ({
         {expandable ? (
           <>
             <span className="text-sm font-light text-text-tertiary">
-              <button
-                type="button"
-                onClick={() => setShowDetails((prev) => !prev)}
-                aria-expanded={showDetails}
-                className="underline decoration-1 underline-offset-2 decoration-text-tertiary/40"
+              <MetricInfo
+                content={description.detailed}
+                align="left"
+                panelClassName="top-full mt-1.5 w-[min(38rem,calc(100vw-4rem))]"
               >
-                About this benchmark
-              </button>
+                <button
+                  type="button"
+                  onClick={() => setShowDetails((prev) => !prev)}
+                  aria-expanded={showDetails}
+                  className="-my-2 inline-flex cursor-help items-center gap-1 py-2 transition-colors hover:text-text-secondary"
+                >
+                  About this benchmark
+                  <Info size={14} aria-hidden="true" />
+                </button>
+              </MetricInfo>
               {hint && <span> • {hint}</span>}
             </span>
             {showDetails && (
-              <p className="mt-2 text-text-tertiary text-sm leading-snug">
+              <p className="mt-2 text-text-tertiary text-sm leading-snug sm:hidden">
                 {description.detailed}
               </p>
             )}

--- a/web/components/shared/SectionHeader.tsx
+++ b/web/components/shared/SectionHeader.tsx
@@ -240,7 +240,7 @@ const SectionHeader: React.FC<SectionHeaderProps> = ({
               <MetricInfo
                 content={description.detailed}
                 align="left"
-                panelClassName="top-full mt-1.5 w-[min(38rem,calc(100vw-4rem))]"
+                panelClassName="top-full mt-1.5 hidden w-[min(38rem,calc(100vw-4rem))] sm:block"
               >
                 <button
                   type="button"

--- a/web/lib/config/metrics.ts
+++ b/web/lib/config/metrics.ts
@@ -10,16 +10,16 @@ export const metricDescriptions = {
   ttft: {
     short: "Time to First Token",
     tooltip:
-      "Time until the provider returns its first transcript token — how quickly partial results start streaming. Low TTFT with high TTFS points to slow finalization. Lower is better.",
+      "Time until the provider returns its first transcript token, showing how quickly partial results start streaming. Low TTFT with high TTFS points to slow finalization. Lower is better.",
     detailed:
       "We run TTFT measurements on a fixed test case to measure consistency over time. A model that consistently responds within a narrow time range provides better user experience than one with highly variable timing, even if the variable model is sometimes faster. Unpredictable delays can be seen through sudden latency spikes."
   },
   ttfs: {
     short: "Time to Final Segment",
     tooltip:
-      "Time from end of speech until the final transcript is returned — the delay a voice agent actually waits before it can respond. Lower is better.",
+      "Time from end of speech until the final transcript is returned, the delay a voice agent actually waits before it can respond. Lower is better.",
     detailed:
-      "TTFS measures how quickly a provider returns the final transcript once speech has ended, anchored at a shared VAD end-of-speech point so every provider is compared from the same instant. It isolates engine finalization speed — the latency a voice agent actually waits on before it can respond — independent of how long the speaker talked."
+      "TTFS measures how quickly a provider returns the final transcript once speech has ended, anchored at a shared VAD end-of-speech point so every provider is compared from the same instant. It isolates engine finalization speed, the latency a voice agent actually waits on before it can respond, independent of how long the speaker talked."
   },
   wer: {
     short: "Word Error Rate (%)",


### PR DESCRIPTION
## What & why
<img width="743" height="228" alt="Screenshot 2026-07-16 at 10 55 35 AM" src="https://github.com/user-attachments/assets/62e75cc9-8217-43c4-b86e-b6e78bf93dfe" />
After:
<img width="670" height="225" alt="Screenshot 2026-07-16 at 10 55 49 AM" src="https://github.com/user-attachments/assets/f3188d40-83ce-4a8f-873f-f6e2f8a6331b" />

"About this benchmark" was a text dropdown under the chart title that felt bad to use. This replaces it with an info-icon tooltip built on the **existing `MetricInfo` component** — the same one already powering the TTFS/TTFT and human-parity tooltips — so behavior is consistent across the app rather than a new one-off.

## Changes

- **`MetricInfo`** (shared tooltip): now accepts an explicit `content` node and a `panelClassName` for placement/width. Adds tap-to-toggle on touch (there's no hover on mobile) with a finger-sized hit target, clamps panel width to the viewport so tooltips can't overflow a narrow/pinched screen, and drops the bold lead-in when it would just repeat the trigger label.
- **`SectionHeader`**: renders "About this benchmark ⓘ" under the title, with the tooltip opening *below* so it never covers the chart or the title. Desktop = hover/focus; mobile = tap, dismissible. Help (`?`) cursor on info triggers.
- **`metrics.ts`**: removed em dashes from the TTFS/TTFT copy.
- **`LatencyAccuracySection`**: "Human-parity zone" legend label back in the body font (PP Mori) instead of mono, matching the model legend labels beside it.

## Testing

- `tsc --noEmit`, `eslint`, and `vitest` (56/56) all pass.
- Verified in-browser (read-only) on desktop and a 375px mobile viewport: single font across all tooltips, no overflow, correct cursors, tap-toggle on touch.

## Out of scope

The box plot x-axis label overflow on the Latency Variation chart is a separate subsystem (`BoxPlot.tsx`) and is deferred to its own ticket (relates to BENCH-382 / BENCH-393).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the benchmark description dropdown with the shared tooltip experience. The main changes are:

- Adds explicit tooltip content, responsive sizing, touch toggling, and outside-tap dismissal to `MetricInfo`.
- Shows benchmark details as a desktop tooltip with a mobile inline fallback.
- Refines TTFS and TTFT copy and restores the body font for the human-parity legend.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- The latest changes cover touch interaction and outside-tap dismissal.
- No blocking issues remain in the changed code.

<sub>Reviews (2): Last reviewed commit: ["\[BENCH-428\] Address review: robust tap d..."](https://github.com/coval-ai/benchmarks/commit/daf72da3ec6c50a03cd3921fa785b1f89e5b804b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44859796)</sub>

<!-- /greptile_comment -->