### PR TITLE
Default all pages to the 1d timeframe

### DIFF
--- a/web/hooks/useTimeWindow.ts
+++ b/web/hooks/useTimeWindow.ts
@@ -13,7 +13,7 @@ import {
 import type { TimeWindow } from "@/lib/config/timeWindows";
 
 export function useTimeWindow(surface: PostHogSurface, mode?: PostHogMode) {
-  const [timeWindow, setTimeWindow] = useState<TimeWindow>("7d");
+  const [timeWindow, setTimeWindow] = useState<TimeWindow>("24h");
 
   const changeTimeWindow = useCallback(
     (next: TimeWindow) => {


### PR DESCRIPTION
Initialize the shared time-window hook at 24h so every dashboard and the overview open on a 1d view.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes the 1-day view the initial time range across shared dashboard pages.

- Changes the shared default from `7d` to `24h`.
- Leaves existing time-window selection behavior unchanged.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.
- The `24h` value is supported by existing queries, labels, chart calculations, and controls.

<sub>Reviews (1): Last reviewed commit: ["Default all pages to the 1d timeframe"](https://github.com/coval-ai/benchmarks/commit/1e4038de56e9dcc817d810b5a6e16128f89e693b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44871609)</sub>

<!-- /greptile_comment -->