### PR TITLE
Raise arena pairing SCALE to 300

### DIFF
--- a/runner/src/coval_bench/__main__.py
+++ b/runner/src/coval_bench/__main__.py
@@ -422,7 +422,7 @@ def arena_seed_battles(per_domain: int) -> None:
 )
 @click.option(
     "--scales",
-    default="50,100,150,200,250",
+    default="100,150,200,250,300,400",
     show_default=True,
     help="Comma-separated candidate SCALE values.",
 )

--- a/runner/src/coval_bench/arena/pairing.py
+++ b/runner/src/coval_bench/arena/pairing.py
@@ -22,7 +22,7 @@ from coval_bench.registries.models import MODEL_REGISTRY, ModelStatus, Registere
 # Volume knob (Elo points): the rating gap at which a matchup's sampling priority
 # decays by 1/e. Tuned offline and committed — deliberately a constant, never an
 # env var, so the value running in prod is always the value in source.
-SCALE = 150.0
+SCALE = 300.0
 
 # Which leaderboard board pairing reads ratings from. A single global board for
 # now; per-domain boards can replace these once a domain has enough votes.

--- a/runner/src/coval_bench/arena/tune_scale.py
+++ b/runner/src/coval_bench/arena/tune_scale.py
@@ -45,7 +45,7 @@ from coval_bench.registries.models import RegisteredModel
 
 _EPS = 1e-12
 
-DEFAULT_SCALES = (50.0, 100.0, 150.0, 200.0, 250.0)
+DEFAULT_SCALES = (100.0, 150.0, 200.0, 250.0, 300.0, 400.0)
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
Tune-scale sims with the real 27-model roster and board-seeded strengths show SCALE 150 losing to 300/600 at every horizon past a few hundred votes; 300 captures most of the gain while keeping the battle graph connected. Takes effect on the next runner release after merge.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR raises the arena pairing scale and aligns the tuning sweep with the new value. The main changes are:

- Raises the production pairing scale from 150 to 300.
- Adds 300 and 400 to the default tuning candidates.
- Aligns the CLI and programmatic tuning defaults.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- The default CLI sweep now includes the production scale of 300.
- The programmatic tuning default uses the same candidate values.
- No blocking issues remain in the updated code.

<sub>Reviews (2): Last reviewed commit: ["Re-center the tune-scale grid on the new..."](https://github.com/coval-ai/benchmarks/commit/219e0416a7b540c52e69e48947069c4cd0d75b34) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44877148)</sub>

<!-- /greptile_comment -->