### PR TITLE
[BENCH-429] Chart labels legible and layout fluid at any viewport width

### DIFF
--- a/web/components/charts/d3/BoxPlot.tsx
+++ b/web/components/charts/d3/BoxPlot.tsx
@@ -17,7 +17,7 @@ const axisLabelFontSize = "14px";
 const yAxisTickFontSize = "12px";
 const modelLineHeight = 14;
 const margin = { top: 20, right: 8, bottom: 80, left: 40 };
-const mobileSlotWidth = 48;
+const minSlotWidth = 48;
 
 const BoxPlot: React.FC<BoxPlotProps> = ({
   data,
@@ -55,17 +55,25 @@ const BoxPlot: React.FC<BoxPlotProps> = ({
     };
   }, [tip]);
 
-  // Handle responsive sizing — always fit the card's content box.
+  // Handle responsive sizing — always fit the card's content box. Resizes
+  // are debounced (matching the recharts containers' debounce) so a window
+  // drag doesn't force a full d3 redraw per frame, and unchanged sizes bail
+  // out before triggering a render.
   useEffect(() => {
-    const handleResize = () => {
+    let timer: ReturnType<typeof setTimeout>;
+    const measure = () => {
       if (!containerRef.current) return;
-      setDimensions({
-        width: containerRef.current.offsetWidth,
-        height: height
-      });
+      const width = containerRef.current.offsetWidth;
+      setDimensions((d) =>
+        d.width === width && d.height === height ? d : { width, height }
+      );
+    };
+    const handleResize = () => {
+      clearTimeout(timer);
+      timer = setTimeout(measure, 50);
     };
 
-    handleResize();
+    measure();
     window.addEventListener("resize", handleResize);
 
     // Track container size changes that happen without a window resize
@@ -75,21 +83,22 @@ const BoxPlot: React.FC<BoxPlotProps> = ({
     }
 
     return () => {
+      clearTimeout(timer);
       window.removeEventListener("resize", handleResize);
       resizeObserver.disconnect();
     };
   }, [height]);
 
-  // On mobile every model gets a guaranteed slot and the chart scrolls
-  // horizontally (same pattern as the WER bar chart) — wide enough slots
-  // re-enable the desktop axis labels and make each column a real touch
-  // target.
-  const svgWidth = isMobile
-    ? Math.max(
-        dimensions.width,
-        data.data.length * mobileSlotWidth + margin.left + margin.right
-      )
-    : dimensions.width;
+  // Guarantee every model a minimum-width slot; when they don't all fit the
+  // container the chart scrolls horizontally (same pattern as the WER bar
+  // chart) rather than crushing the axis labels into each other. This holds at
+  // any viewport width — full screen, half, quarter, drag-resized, or mobile —
+  // so wide desktops render flush while narrow ones scroll.
+  const svgWidth = Math.max(
+    dimensions.width,
+    data.data.length * minSlotWidth + margin.left + margin.right
+  );
+  const scrollable = svgWidth > dimensions.width;
 
   // Layout effect so the d3 content redraws in the same frame the <svg>
   // resizes — the PNG export clones the SVG as soon as its width settles, and
@@ -172,7 +181,7 @@ const BoxPlot: React.FC<BoxPlotProps> = ({
 
     // Create custom wrapped text with model first
     {
-      const labelMaxWidth = xScale.step() * 0.96;
+      const labelMaxWidth = xScale.step() * 0.82;
       const minModelFont = 8;
 
       data.data.forEach((modelData) => {
@@ -342,7 +351,7 @@ const BoxPlot: React.FC<BoxPlotProps> = ({
 
       // Full-height invisible hit area so a finger can land anywhere in the
       // model's column, not just on the thin strokes.
-      if (isMobile) {
+      if (scrollable) {
         boxGroup
           .append("rect")
           .attr("x", centerX - xScale.step() / 2)
@@ -396,7 +405,7 @@ const BoxPlot: React.FC<BoxPlotProps> = ({
     });
 
     svg.on("mouseleave", () => setTip((t) => (t?.pinned ? t : null)));
-  }, [data, dimensions, svgWidth, getModelColor, getProviderForModel, normalizeModelName, isMobile, themeColors]);
+  }, [data, dimensions.height, svgWidth, scrollable, getModelColor, getProviderForModel, normalizeModelName, isMobile, themeColors]);
 
   // The measured container must always render — an early return here would
   // leave the sizing effect's ResizeObserver attached to nothing, freezing
@@ -426,16 +435,16 @@ const BoxPlot: React.FC<BoxPlotProps> = ({
           onClick={(e) => e.stopPropagation()}
           className="absolute z-10 whitespace-nowrap text-xs"
           style={{
-            // On mobile the panel hangs from the top of the plot — inside
-            // the card, clear of the heading above — and tracks its column
-            // as the chart scrolls, so it never covers the box being
+            // When the chart scrolls the panel hangs from the top of the plot
+            // — inside the card, clear of the heading above — and tracks its
+            // column as the chart scrolls, so it never covers the box being
             // inspected and follows the finger while swiping.
             left: Math.min(
-              Math.max(isMobile ? tip.x - scrollX : tip.x, 90),
+              Math.max(scrollable ? tip.x - scrollX : tip.x, 90),
               dimensions.width - 90
             ),
-            top: isMobile ? margin.top : tip.yTop,
-            transform: isMobile
+            top: scrollable ? margin.top : tip.yTop,
+            transform: scrollable
               ? "translate(-50%, 0)"
               : "translate(-50%, calc(-100% - 8px))",
             transition: "left 150ms ease-out, top 150ms ease-out",

--- a/web/components/dashboard/AccuracyBarSection.tsx
+++ b/web/components/dashboard/AccuracyBarSection.tsx
@@ -172,7 +172,8 @@ const AccuracyBarSection: React.FC = () => {
           <ResponsiveContainer
             width="100%"
             height="100%"
-            minWidth={isMobile ? werBarDataWithColors.length * 48 : 0}
+            minWidth={werBarDataWithColors.length * 48}
+            debounce={200}
           >
             <BarChart
               data={werBarDataWithColors}

--- a/web/components/dashboard/LatencyAccuracySection.tsx
+++ b/web/components/dashboard/LatencyAccuracySection.tsx
@@ -223,7 +223,7 @@ const LatencyAccuracySection: React.FC = () => {
               />
             </div>
           )}
-          <ResponsiveContainer width="100%" height="100%">
+          <ResponsiveContainer width="100%" height="100%" debounce={200}>
             <ScatterChart
               margin={{ top: 10, right: 8, left: 0, bottom: 0 }}
             >

--- a/web/components/layout/DashboardLayout.tsx
+++ b/web/components/layout/DashboardLayout.tsx
@@ -55,15 +55,15 @@ const DashboardLayout: React.FC<{ children: React.ReactNode }> = ({ children }) 
       <DashboardHeader />
       <MobileModelSheet />
 
-      {/* Content column — centered on the page (under the centered tabs). The
-          sticky sidebar and the spacer are 18rem each so the column stays
-          centered. The footer sits below this row, so it pushes the sticky
-          sidebar up natively. w-full is load-bearing below lg: mx-auto
-          disables the flex cross-axis stretch, and the column would otherwise
-          size to its content and overflow the viewport. */}
+      {/* Content column fills whatever the sticky sidebar leaves — it tracks
+          window resizes instantly (no width transition, which would drag the
+          charts through a 300ms animation on every resize). min-w-0 is
+          load-bearing: the column would otherwise size to its content and
+          overflow the viewport. The footer sits below this row, so it pushes
+          the sticky sidebar up natively. */}
       <div className="relative z-10 flex flex-1">
         <ModelSidebar />
-        <div className="transition-all duration-300 pt-20 px-3 py-8 sm:px-8 pb-24 lg:pb-8 overflow-x-hidden w-full mx-auto lg:w-[calc(100vw-36rem)]">
+        <div className="pt-20 px-3 py-8 sm:px-8 pb-24 lg:pb-8 overflow-x-hidden flex-1 min-w-0">
           <div className="mb-6 flex flex-wrap items-center justify-between gap-3">
             <h1 className="text-2xl font-bold tracking-tight text-text-primary">
               {benchmarkTitle}
@@ -92,7 +92,6 @@ const DashboardLayout: React.FC<{ children: React.ReactNode }> = ({ children }) 
             )}
           </div>
         </div>
-        <div className="hidden lg:block w-72 shrink-0" />
       </div>
 
       {!loading && <DashboardFooter />}

--- a/web/components/layout/ModelSidebar.tsx
+++ b/web/components/layout/ModelSidebar.tsx
@@ -6,8 +6,15 @@
 import React from "react";
 import FacetFilter from "@/components/layout/FacetFilter";
 
+// The margin animates across the lg breakpoint so the filters slide in and
+// the content column reflows with them, instead of teleporting 18rem when a
+// window drag crosses 50% of the screen. Within a regime the margin is
+// constant, so plain resizes never fire the transition. Sliding via margin
+// (clipped by the page root's overflow-x-clip) rather than width +
+// overflow-hidden keeps this ancestor scroll-free, which position: sticky
+// needs to track the viewport.
 const ModelSidebar: React.FC = () => (
-  <div className="hidden lg:block w-72 shrink-0">
+  <div className="w-72 -ml-72 lg:ml-0 shrink-0 invisible lg:visible transition-[margin-left,visibility] duration-300">
     <div className="sticky top-20 max-h-[calc(100vh-6rem)] overflow-y-auto scrollbar-hide px-4 py-3">
       <FacetFilter />
     </div>

--- a/web/components/visualizations/TimelineChart.tsx
+++ b/web/components/visualizations/TimelineChart.tsx
@@ -818,6 +818,7 @@ const TimelineChart: React.FC = () => {
           <ResponsiveContainer
             width="100%"
             height="100%"
+            debounce={200}
             onResize={() => requestAnimationFrame(syncInteractionBox)}
           >
             <LineChart


### PR DESCRIPTION
## Summary
Before
<img width="1031" height="796" alt="Screenshot 2026-07-16 at 1 27 32 PM" src="https://github.com/user-attachments/assets/a504c229-eb68-49e3-9cdb-e61eef8e35d8" />
After
<img width="1031" height="863" alt="Screenshot 2026-07-16 at 1 27 53 PM" src="https://github.com/user-attachments/assets/d4c0a68b-99ce-48e0-8112-5131b04d5ba1" />

Fixes BENCH-429: box plot x-axis labels overlapped at narrow / non-standard window widths, plus the related layout and resize-jank issues that surfaced while testing.

- **BoxPlot** (`web/components/charts/d3/BoxPlot.tsx`): the existing mobile slot-scroll layout (48px minimum slot per model, horizontal scroll, full-column touch targets, top-docked scroll-tracking tooltip) now applies at every viewport width instead of only below the 768px breakpoint. Wide windows render flush exactly as before; anything narrower scrolls instead of crushing labels. Labels are also capped at 82% of their column (was 96%) so adjacent blocks always have a visible gutter. Hover-vs-tap gating still keys off `isMobile`.
- **WER bar chart** (`AccuracyBarSection.tsx`): same rule — the 48px/bar minimum width is now unconditional, so the 45°-rotated ticks never collide on narrow desktops.
- **Dashboard layout** (`DashboardLayout.tsx`): the content column is now `flex-1 min-w-0` — it fills whatever the sidebar leaves instead of reserving a phantom 288px centering spacer, and the `transition-all duration-300` that made the column lag 300ms behind every window drag is gone.
- **Sidebar breakpoint** (`ModelSidebar.tsx`): crossing the `lg` breakpoint animates the sidebar width 0 → 18rem over 300ms, so going from mobile layout (filters bottom) to desktop (filters left) slides instead of teleporting. Within a regime the width is constant, so plain resizes never fire the transition.
- **Resize performance**: the three recharts `ResponsiveContainer`s get `debounce={200}` and BoxPlot's measurer debounces 50ms with an unchanged-size bail-out. Measured on a simulated 1s continuous drag: average frame time 46ms → 11ms, janky frames (>34ms) 50/59 → 4/59.

## Test plan

- [x] `npm test` (56 passed), `tsc --noEmit`, eslint clean
- [x] Verified in-browser at 375 (mobile), 800, 1000/1100 (breakpoint crossing), 1280, 1600: no label overlap on box plot or WER chart at any width, charts settle to exact container size after resize
- [x] Tap-to-pin tooltip works in the scrollable regime (full stats panel, close button, docked clear of the boxes)
- [x] Rebased on main (`99d0325`); 1d-default timeframe behavior intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves chart readability and dashboard resizing across viewport widths. The main changes are:

- Gives box-plot and WER chart entries a minimum width with horizontal scrolling.
- Debounces chart resizing to reduce redraw work.
- Makes the dashboard content column fill the space beside the sidebar.
- Animates the model sidebar when crossing the desktop breakpoint.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- The sidebar fix keeps its layout space and visual movement coordinated across the breakpoint.
- No blocking issues were found in the updated code.

<sub>Reviews (3): Last reviewed commit: ["\[BENCH-429\] Keep chart labels legible at..."](https://github.com/coval-ai/benchmarks/commit/2107bd3f34d8ab66802d7081d951f51b40fa4b99) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44904429)</sub>

<!-- /greptile_comment -->