### PR TITLE
[BENCH-434] Improve WER dataset toggle responsiveness + add Clean/Production tooltips

### DIFF
--- a/web/components/dashboard/MetricToggle.tsx
+++ b/web/components/dashboard/MetricToggle.tsx
@@ -24,7 +24,7 @@ const MetricToggle: React.FC = () => {
             type="button"
             onClick={() => setSttMetric(m)}
             className={
-              "rounded-md px-3 py-1 text-xs font-medium transition-colors " +
+              "rounded-md px-4 py-3 text-sm sm:px-3 sm:py-1 sm:text-xs font-medium transition-colors " +
               (sttMetric === m
                 ? "bg-surface-primary text-text-primary shadow-sm"
                 : "text-text-secondary hover:text-text-primary")

--- a/web/components/dashboard/WerBarViewToggle.tsx
+++ b/web/components/dashboard/WerBarViewToggle.tsx
@@ -5,7 +5,7 @@
 
 import React from "react";
 import { useDashboard } from "@/contexts/DashboardContext";
-import { datasetLabel } from "@/lib/config/datasets";
+import MetricInfo from "@/components/shared/MetricInfo";
 
 const WerBarViewToggle: React.FC = () => {
   const { werBarView, changeWerBarView, availableWerBarViews } = useDashboard();
@@ -14,21 +14,27 @@ const WerBarViewToggle: React.FC = () => {
 
   return (
     <div className="mb-4 inline-flex gap-0.5 rounded-lg bg-surface-toggle-inactive p-0.5">
-      {availableWerBarViews.map((view) => (
-        <button
+      {availableWerBarViews.map((view, i) => (
+        <MetricInfo
           key={view.key}
-          type="button"
-          title={view.dataset ? datasetLabel(view.dataset) : undefined}
-          onClick={() => changeWerBarView(view.key)}
-          className={
-            "rounded-md px-3 py-1 text-xs font-medium transition-colors " +
-            (werBarView === view.key
-              ? "bg-surface-primary text-text-primary shadow-sm"
-              : "text-text-secondary hover:text-text-primary")
+          content={view.tooltip}
+          align={
+            i === 0 ? "left" : i === availableWerBarViews.length - 1 ? "right" : "center"
           }
         >
-          {view.label}
-        </button>
+          <button
+            type="button"
+            onClick={() => changeWerBarView(view.key)}
+            className={
+              "rounded-md px-4 py-3 text-sm sm:px-3 sm:py-1 sm:text-xs font-medium transition-colors " +
+              (werBarView === view.key
+                ? "bg-surface-primary text-text-primary shadow-sm"
+                : "text-text-secondary hover:text-text-primary")
+            }
+          >
+            {view.label}
+          </button>
+        </MetricInfo>
       ))}
     </div>
   );

--- a/web/components/dashboard/WerDatasetSelect.tsx
+++ b/web/components/dashboard/WerDatasetSelect.tsx
@@ -7,10 +7,12 @@ import React from "react";
 import { useDashboard } from "@/contexts/DashboardContext";
 import { useActiveTab } from "@/hooks/useActiveTab";
 import { datasetLabel, isPerturbationDataset } from "@/lib/config/datasets";
+import MetricInfo from "@/components/shared/MetricInfo";
 
 const WerDatasetSelect: React.FC<{ className?: string }> = ({ className }) => {
   const activeTab = useActiveTab();
-  const { werDataset, changeWerDataset, availableWerDatasets } = useDashboard();
+  const { werDataset, changeWerDataset, availableWerDatasets, isMobile } =
+    useDashboard();
 
   if (activeTab !== "stt" || availableWerDatasets.length === 0) return null;
 
@@ -24,14 +26,20 @@ const WerDatasetSelect: React.FC<{ className?: string }> = ({ className }) => {
     ));
 
   return (
-    <label
+    <span
       className={`inline-flex items-center gap-2 text-xs text-text-secondary${
         className ? ` ${className}` : ""
       }`}
     >
-      WER dataset
+      <MetricInfo
+        content="Scopes the WER column to one evaluation set. Full datasets are distinct recordings; WildASR perturbations replay the clean utterances with one degradation applied. Pooled blends every dataset in the window."
+        align={isMobile ? "left" : "right"}
+      >
+        WER dataset
+      </MetricInfo>
       <span className="relative inline-flex">
         <select
+          aria-label="WER dataset"
           value={werDataset ?? ""}
           onChange={(e) => changeWerDataset(e.target.value || null)}
           className="appearance-none rounded-lg border border-border-primary bg-surface-elevated py-1.5 pl-2.5 pr-7 text-xs font-medium text-text-primary outline-none transition-colors hover:border-selected-border focus:border-selected-border"
@@ -63,7 +71,7 @@ const WerDatasetSelect: React.FC<{ className?: string }> = ({ className }) => {
           />
         </svg>
       </span>
-    </label>
+    </span>
   );
 };
 

--- a/web/components/shared/MetricInfo.tsx
+++ b/web/components/shared/MetricInfo.tsx
@@ -62,6 +62,11 @@ const MetricInfo: React.FC<{
       tabIndex={isElement ? undefined : 0}
       aria-describedby={isElement ? undefined : id}
       onClick={isElement ? undefined : () => setOpen((prev) => !prev)}
+      onPointerUp={
+        isElement
+          ? (e) => e.pointerType !== "mouse" && setOpen((prev) => !prev)
+          : undefined
+      }
       onBlur={isElement ? undefined : () => setOpen(false)}
     >
       {isElement

--- a/web/lib/config/datasets.ts
+++ b/web/lib/config/datasets.ts
@@ -27,8 +27,26 @@ export type WerBarView = "cumulative" | "clean" | "production";
 
 // cumulative pools every dataset; clean/production pin the bar chart to the
 // clean-audio (WildASR clean) and conversational (PipeCat) sets respectively.
-export const WER_BAR_VIEWS: { key: WerBarView; label: string; dataset: string | null }[] = [
-  { key: "cumulative", label: "Cumulative", dataset: null },
-  { key: "clean", label: "Clean", dataset: "stt-wildasr-clean" },
-  { key: "production", label: "Production", dataset: "stt-v3" },
+export const WER_BAR_VIEWS: { key: WerBarView; label: string; dataset: string | null; tooltip: string }[] = [
+  {
+    key: "cumulative",
+    label: "Cumulative",
+    dataset: null,
+    tooltip:
+      "Pools every dataset in the window — clean, production, and WildASR perturbation sets — into one blended WER.",
+  },
+  {
+    key: "clean",
+    label: "Clean",
+    dataset: "stt-wildasr-clean",
+    tooltip:
+      "WildASR clean only: studio-quality, undegraded speech — the baseline the perturbation sets degrade.",
+  },
+  {
+    key: "production",
+    label: "Production",
+    dataset: "stt-v3",
+    tooltip:
+      "PipeCat only: spontaneous voice-agent conversations with fragments and fillers — the closest to real production traffic.",
+  },
 ];


### PR DESCRIPTION
## What

- **Dataset-slice tooltips** on the Accuracy by Model chart's Cumulative / Clean / Production tabs, explaining what each slice contains (Cumulative = pooled, Clean = WildASR clean, Production = PipeCat). Reuses the existing `MetricInfo` tooltip, same pattern the TTFS/TTFT toggle already uses; copy lives next to the view definitions in `lib/config/datasets.ts`.
- **Tooltip on the "WER dataset" select label** in the Model Comparison table, mirroring the Human-parity zone legend tooltip. The label's implicit `<label>` association moves to an `aria-label` on the select so a tap shows the tooltip without also popping the native picker.
- **44px mobile tap targets** for both segmented controls (WER views and TTFS/TTFT) below the `sm` breakpoint; desktop sizing unchanged.
- **`MetricInfo` tap-to-open on touch**: element-child tooltips (the toggle buttons) previously only opened on hover/keyboard focus, so they were unreachable on touch devices. A touch/pen-only `onPointerUp` toggle fixes that — mouse clicks are excluded so desktop clicks never leave a lingering tooltip. This also makes the existing TTFS/TTFT tooltips reachable on mobile.

Tooltip panels align per position (left/center/right, and viewport-dependent for the select label) so they never clip at a viewport edge.

## Notes

- Tooltip copy is drafted from `docs/methodology.md` and the dataset manifests README — **needs sign-off from Cale/Madina** (open question on the ticket).
- No changes to WER computation, dataset definitions, or the latency-chart dataset dropdown.

## Testing

- Verified in-browser at 375×812 and desktop: tap targets measure 44px on mobile, tap opens the tooltip above the control (never under the finger) and switches the view, outside-tap dismisses, desktop hover shows/hides with no lingering panel after mouse clicks, all panels stay within the viewport.
- `tsc --noEmit` and `next lint` clean; no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves dataset controls and tooltip behavior on the dashboard. The main changes are:

- Adds descriptions to the Cumulative, Clean, and Production WER views.
- Adds an accessible tooltip to the WER dataset selector label.
- Enables touch and pen interactions for element-based tooltips.
- Enlarges segmented-control targets below the `sm` breakpoint.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<sub>Reviews (1): Last reviewed commit: ["\[BENCH-434\] WER dataset toggle: mobile t..."](https://github.com/coval-ai/benchmarks/commit/c91bf46310ebe1da3284ba49b3680dcb014b16fa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44922689)</sub>

<!-- /greptile_comment -->