### PR TITLE
Stop skipping successful runs in the S2S fetch

### DIFF
--- a/runner/src/coval_bench/s2s/fetch_v2v.py
+++ b/runner/src/coval_bench/s2s/fetch_v2v.py
@@ -100,6 +100,12 @@ def _parse_time(raw: object) -> datetime | None:
         return None
 
 
+def _error_status(raw: object) -> str | None:
+    """Normalize Coval's error_status field; clean runs report the string "SUCCESS"."""
+    status = cast("str | None", raw) or None
+    return None if status == "SUCCESS" else status
+
+
 def _bucket_start(at: datetime, period_seconds: int) -> datetime:
     """Floor a timestamp to the epoch-anchored fetch grid."""
     epoch = int(at.timestamp())
@@ -132,7 +138,7 @@ async def recent_completed_runs(
         run = CovalRun(
             run_id=cast("str", r["run_id"]),
             create_time=_parse_time(r.get("create_time")),
-            error_status=cast("str | None", r.get("error_status")) or None,
+            error_status=_error_status(r.get("error_status")),
         )
         if run.create_time is not None and (now - run.create_time).total_seconds() > window_seconds:
             continue
@@ -201,7 +207,7 @@ async def _ingest_run(
         resp = await client.get(f"/runs/{coval_run.run_id}")
         resp.raise_for_status()
         run = cast("dict[str, Any]", resp.json()["run"])
-        error_status = run.get("error_status")
+        error_status = _error_status(run.get("error_status"))
         if error_status:
             logger.warning(
                 "errored_run_skipped",

--- a/runner/tests/unit/test_s2s_fetch.py
+++ b/runner/tests/unit/test_s2s_fetch.py
@@ -33,7 +33,7 @@ def _list_json(*runs: dict[str, Any]) -> dict[str, Any]:
 def _run_json(
     values: list[dict[str, Any]],
     metric_id: str = "MID",
-    error_status: str | None = None,
+    error_status: str | None = "SUCCESS",
 ) -> dict[str, Any]:
     run: dict[str, Any] = {"results": {"metrics": {metric_id: {"values": values}}}}
     if error_status:
@@ -125,7 +125,7 @@ def test_result_rows_maps_values() -> None:
 async def test_recent_completed_runs_window_and_parse() -> None:
     captured: list[httpx.Request] = []
     list_json = _list_json(
-        {"run_id": "R3", "create_time": _iso(timedelta(hours=1))},
+        {"run_id": "R3", "create_time": _iso(timedelta(hours=1)), "error_status": "SUCCESS"},
         {
             "run_id": "R2",
             "create_time": _iso(timedelta(hours=4)),


### PR DESCRIPTION
The Coval API reports error_status="SUCCESS" on clean runs, so the errored-run guard from #287 skipped every run and the daily fetch has ingested nothing since Jul 14. Normalize SUCCESS to None when parsing.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR restores ingestion of successful Coval runs. The main changes are:

- Normalizes Coval's `SUCCESS` error status to `None`.
- Applies normalization to list and detail responses.
- Updates successful-run fixtures and parsing coverage.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.
- Failed statuses remain truthy and continue to skip ingestion.
- Missing and successful statuses now follow the clean-run path.

<sub>Reviews (1): Last reviewed commit: ["Stop skipping successful runs in the S2S..."](https://github.com/coval-ai/benchmarks/commit/91027c5c7a5861bc6974f65768e32fe7e8951fe8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44930716)</sub>

<!-- /greptile_comment -->