### PR TITLE
[BENCH-435] Move WER benchmark description into ⓘ tooltip on mobile

### DIFF
--- a/web/components/shared/SectionHeader.tsx
+++ b/web/components/shared/SectionHeader.tsx
@@ -50,7 +50,6 @@ const SectionHeader: React.FC<SectionHeaderProps> = ({
   exportXLabel,
   exportAnnotate,
 }) => {
-  const [showDetails, setShowDetails] = useState(false);
   const [copied, setCopied] = useState(false);
   const themeColors = useThemeColors();
   const anchorId = label.toLowerCase().replace(/[^a-z0-9]+/g, "-");
@@ -235,31 +234,17 @@ const SectionHeader: React.FC<SectionHeaderProps> = ({
           {description.short}
         </p>
         {expandable ? (
-          <>
-            <span className="text-sm font-light text-text-tertiary">
-              <MetricInfo
-                content={description.detailed}
-                align="left"
-                panelClassName="top-full mt-1.5 hidden w-[min(38rem,calc(100vw-4rem))] sm:block"
-              >
-                <button
-                  type="button"
-                  onClick={() => setShowDetails((prev) => !prev)}
-                  aria-expanded={showDetails}
-                  className="-my-2 inline-flex cursor-help items-center gap-1 py-2 transition-colors hover:text-text-secondary"
-                >
-                  About this benchmark
-                  <Info size={14} aria-hidden="true" />
-                </button>
-              </MetricInfo>
-              {hint && <span> • {hint}</span>}
-            </span>
-            {showDetails && (
-              <p className="mt-2 text-text-tertiary text-sm leading-snug sm:hidden">
-                {description.detailed}
-              </p>
-            )}
-          </>
+          <span className="text-sm font-light text-text-tertiary">
+            <MetricInfo
+              content={description.detailed}
+              align="left"
+              panelClassName="top-full mt-1.5 w-[min(38rem,calc(100vw-4rem))]"
+            >
+              About this benchmark{" "}
+              <Info size={14} aria-hidden="true" className="inline align-[-2px]" />
+            </MetricInfo>
+            {hint && <span> • {hint}</span>}
+          </span>
         ) : (
           <p className="text-text-tertiary text-sm leading-snug">
             {description.detailed}


### PR DESCRIPTION
## Summary
On mobile, tapping "About this benchmark ⓘ" on the benchmark cards expanded the description as an inline paragraph, pushing the chart down. It now opens the same `MetricInfo` tooltip used by the human-parity legend entry: tap to open, tap outside or blur to dismiss, positioned below the trigger so it never sits under the finger.

## How
- `SectionHeader` passes the trigger to `MetricInfo` as text + icon (non-element children), which routes through `MetricInfo`'s existing tap-to-toggle / outside-tap-close / focus handling — the exact human-parity code path. `MetricInfo` itself is untouched.
- Dropped `hidden sm:block` from the panel so the tooltip renders on all breakpoints; deleted the `showDetails` inline-expand state.
- Desktop hover behavior unchanged; a desktop click now pins the tooltip open, matching the other MetricInfo triggers.

Applies to every card sharing `SectionHeader` (Accuracy by Model, Latency vs Accuracy, Performance Consistency, …). No copy, data, or backend changes. Net −15 lines.

## Verification
- Mobile (375px): description hidden by default; tap ⓘ opens tooltip, outside tap dismisses.
- Desktop: hover shows tooltip (`visibility: visible / opacity: 1`).
- `tsc --noEmit` and `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR moves mobile benchmark details into the shared tooltip. The main changes are:

- Removes the mobile inline expansion state and paragraph.
- Uses MetricInfo’s text-and-icon trigger path.
- Displays the tooltip panel at every breakpoint.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge after a small accessibility cleanup.

- The tooltip interaction follows the existing MetricInfo path.
- The new trigger no longer exposes its expanded state to assistive technology.

web/components/shared/SectionHeader.tsx

<sub>Reviews (1): Last reviewed commit: ["\[BENCH-435\] About this benchmark: Metric..."](https://github.com/coval-ai/benchmarks/commit/a2a627b2e95cd974e954a91894fb601599af8d8e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44934996)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->