### PR TITLE
Show p25/p75/p95 and true min/max in the latency box-plot info box

### DIFF
--- a/web/components/charts/d3/BoxPlot.tsx
+++ b/web/components/charts/d3/BoxPlot.tsx
@@ -477,6 +477,7 @@ const BoxPlot: React.FC<BoxPlotProps> = ({
           </p>
           {(tip.pinned
             ? [
+                ["Max", `${tip.point.stats.max.toFixed(0)}ms`],
                 ["P95", `${tip.point.stats.p95.toFixed(0)}ms`],
                 ["P75", `${tip.point.quartiles.q3.toFixed(0)}ms`],
                 ["P50", `${tip.point.quartiles.median.toFixed(0)}ms`],

--- a/web/components/charts/d3/BoxPlot.tsx
+++ b/web/components/charts/d3/BoxPlot.tsx
@@ -477,15 +477,11 @@ const BoxPlot: React.FC<BoxPlotProps> = ({
           </p>
           {(tip.pinned
             ? [
-                ["Count", `${tip.point.stats.count}`],
-                ["Mean", `${tip.point.stats.mean.toFixed(0)}ms`],
-                ["Std", `${tip.point.stats.std.toFixed(0)}ms`],
-                ["Min", `${tip.point.stats.min.toFixed(0)}ms`],
-                ["P25", `${tip.point.quartiles.q1.toFixed(0)}ms`],
-                ["Median", `${tip.point.quartiles.median.toFixed(0)}ms`],
-                ["P75", `${tip.point.quartiles.q3.toFixed(0)}ms`],
                 ["P95", `${tip.point.stats.p95.toFixed(0)}ms`],
-                ["Max", `${tip.point.stats.max.toFixed(0)}ms`]
+                ["P75", `${tip.point.quartiles.q3.toFixed(0)}ms`],
+                ["P50", `${tip.point.quartiles.median.toFixed(0)}ms`],
+                ["P25", `${tip.point.quartiles.q1.toFixed(0)}ms`],
+                ["Count", `${tip.point.stats.count}`]
               ]
             : [
                 [

--- a/web/components/charts/d3/BoxPlot.tsx
+++ b/web/components/charts/d3/BoxPlot.tsx
@@ -479,8 +479,13 @@ const BoxPlot: React.FC<BoxPlotProps> = ({
             ? [
                 ["Count", `${tip.point.stats.count}`],
                 ["Mean", `${tip.point.stats.mean.toFixed(0)}ms`],
+                ["Std", `${tip.point.stats.std.toFixed(0)}ms`],
+                ["Min", `${tip.point.stats.min.toFixed(0)}ms`],
+                ["P25", `${tip.point.quartiles.q1.toFixed(0)}ms`],
                 ["Median", `${tip.point.quartiles.median.toFixed(0)}ms`],
-                ["Std", `${tip.point.stats.std.toFixed(0)}ms`]
+                ["P75", `${tip.point.quartiles.q3.toFixed(0)}ms`],
+                ["P95", `${tip.point.stats.p95.toFixed(0)}ms`],
+                ["Max", `${tip.point.stats.max.toFixed(0)}ms`]
               ]
             : [
                 [

--- a/web/hooks/useChartData.ts
+++ b/web/hooks/useChartData.ts
@@ -214,7 +214,8 @@ export function useChartData({
           mean: toDisplayUnits(stat.avg_value),
           std: toDisplayUnits(stat.stddev_value),
           count: stat.sample_count,
-          p95: toDisplayUnits(stat.p95)
+          p95: toDisplayUnits(stat.p95),
+          max: toDisplayUnits(stat.max_value)
         }
       };
     });

--- a/web/hooks/useChartData.ts
+++ b/web/hooks/useChartData.ts
@@ -213,7 +213,10 @@ export function useChartData({
         stats: {
           mean: toDisplayUnits(stat.avg_value),
           std: toDisplayUnits(stat.stddev_value),
-          count: stat.sample_count
+          count: stat.sample_count,
+          min: toDisplayUnits(stat.min_value),
+          max: toDisplayUnits(stat.max_value),
+          p95: toDisplayUnits(stat.p95)
         }
       };
     });

--- a/web/hooks/useChartData.ts
+++ b/web/hooks/useChartData.ts
@@ -214,8 +214,6 @@ export function useChartData({
           mean: toDisplayUnits(stat.avg_value),
           std: toDisplayUnits(stat.stddev_value),
           count: stat.sample_count,
-          min: toDisplayUnits(stat.min_value),
-          max: toDisplayUnits(stat.max_value),
           p95: toDisplayUnits(stat.p95)
         }
       };

--- a/web/types/benchmark.types.ts
+++ b/web/types/benchmark.types.ts
@@ -65,6 +65,10 @@ export interface BoxPlotDataPoint {
     mean: number;
     std: number;
     count: number;
+    /** True extremes and p95, before any whisker clamping. */
+    min: number;
+    max: number;
+    p95: number;
   };
 }
 

--- a/web/types/benchmark.types.ts
+++ b/web/types/benchmark.types.ts
@@ -66,6 +66,8 @@ export interface BoxPlotDataPoint {
     std: number;
     count: number;
     p95: number;
+    /** True maximum, before whisker clamping. */
+    max: number;
   };
 }
 

--- a/web/types/benchmark.types.ts
+++ b/web/types/benchmark.types.ts
@@ -65,9 +65,6 @@ export interface BoxPlotDataPoint {
     mean: number;
     std: number;
     count: number;
-    /** True extremes and p95, before any whisker clamping. */
-    min: number;
-    max: number;
     p95: number;
   };
 }

--- a/web/types/benchmark.types.ts
+++ b/web/types/benchmark.types.ts
@@ -66,7 +66,6 @@ export interface BoxPlotDataPoint {
     std: number;
     count: number;
     p95: number;
-    /** True maximum, before whisker clamping. */
     max: number;
   };
 }


### PR DESCRIPTION
Clicking a box now surfaces the full distribution, not just count/mean/median/std.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR expands the latency box-plot details shown for a selected data point. The main changes are:

- Adds P95 and true maximum values to the chart data.
- Shows Max, P95, P75, P50, P25, and Count in the pinned tooltip.
- Extends the box-plot data type with the new statistics.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- The new statistics are populated by the chart-data mapping before the tooltip reads them.
- The fields match the generated API response types.
- No blocking issues remain in the updated code.

<sub>Reviews (4): Last reviewed commit: ["Drop stray comment on box-plot stats typ..."](https://github.com/coval-ai/benchmarks/commit/cfcae98f4918e6147f5ec1b2ead269c8765897ab) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44936507)</sub>

<!-- /greptile_comment -->