### PR TITLE
Add arena monitoring page for convergence and co-occurrence

### DIFF
--- a/runner/src/coval_bench/api/routers/arena.py
+++ b/runner/src/coval_bench/api/routers/arena.py
@@ -7,6 +7,8 @@
 ``GET  /v1/arena/battle/{id}``     — a specific battle.
 ``GET  /v1/arena/example-prompt``  — a random seed-bank prompt with its domain.
 ``GET  /v1/arena/leaderboard``     — the latest computed board for a metric/domain.
+``GET  /v1/arena/admin/cooccurrence`` — who-battled-whom heatmap (labeler-only, HTML).
+``GET  /v1/arena/admin/convergence``  — CI-vs-votes per model (labeler-only, HTML).
 ``POST /v1/arena/vote``            — record a labeler's vote (labeler-only at MVP).
 
 Reads hit the pool directly; the write path uses the arena DB-access layer
@@ -29,6 +31,7 @@ from typing import Any
 import psycopg.rows
 import structlog
 from fastapi import APIRouter, Depends, Header, HTTPException, Query
+from fastapi.responses import HTMLResponse
 from posthog import Posthog
 from psycopg_pool import AsyncConnectionPool
 from slowapi.util import get_remote_address
@@ -50,6 +53,12 @@ from coval_bench.api.schemas import (
 )
 from coval_bench.arena.audio_store import clip_url
 from coval_bench.arena.generate import generate_battle
+from coval_bench.arena.monitoring import (
+    build_convergence,
+    build_cooccurrence,
+    render_convergence,
+    render_cooccurrence,
+)
 from coval_bench.arena.pairing import (
     PAIRING_DOMAIN,
     PAIRING_METRIC,
@@ -374,3 +383,45 @@ async def reveal_battle(
         a=RevealModelOut(provider=battle.provider_a, model=battle.model_a, label=battle.model_a),
         b=RevealModelOut(provider=battle.provider_b, model=battle.model_b, label=battle.model_b),
     )
+
+
+@router.get("/arena/admin/cooccurrence", dependencies=[Depends(require_labeler)])
+@limiter.limit("60/minute")
+async def get_arena_cooccurrence(
+    request: Request,  # required by slowapi
+    metric: str = Query(default=PAIRING_METRIC),
+    domain: str = Query(default=PAIRING_DOMAIN),
+    pool: AsyncConnectionPool[Any] = Depends(get_pool),
+    posthog_client: Posthog | None = Depends(get_posthog),
+) -> HTMLResponse:
+    """The who-battled-whom heatmap. Reveals model identities, hence labeler-only."""
+    store = ArenaStore(pool)
+    rows = await store.get_cooccurrence_counts()
+    ratings = await store.get_latest_ratings(metric_name=metric, domain=domain)
+    cooc = build_cooccurrence(rows, {key: r.rating_elo for key, r in ratings.items()})
+    capture_api_event(
+        posthog_client,
+        "arena_admin_report_viewed",
+        {"report": "cooccurrence", "$process_person_profile": False},
+    )
+    return HTMLResponse(render_cooccurrence(cooc))
+
+
+@router.get("/arena/admin/convergence", dependencies=[Depends(require_labeler)])
+@limiter.limit("60/minute")
+async def get_arena_convergence(
+    request: Request,  # required by slowapi
+    metric: str = Query(default=PAIRING_METRIC),
+    domain: str = Query(default=PAIRING_DOMAIN),
+    pool: AsyncConnectionPool[Any] = Depends(get_pool),
+    posthog_client: Posthog | None = Depends(get_posthog),
+) -> HTMLResponse:
+    """Per-model CI-vs-votes curves from snapshot history. Labeler-only."""
+    rows = await ArenaStore(pool).get_snapshot_history(metric_name=metric, domain=domain)
+    conv = build_convergence(rows)
+    capture_api_event(
+        posthog_client,
+        "arena_admin_report_viewed",
+        {"report": "convergence", "$process_person_profile": False},
+    )
+    return HTMLResponse(render_convergence(conv))

--- a/runner/src/coval_bench/arena/_render.py
+++ b/runner/src/coval_bench/arena/_render.py
@@ -10,24 +10,35 @@ operator can open in any browser. Pure string builders — trivially unit-testab
 
 from __future__ import annotations
 
+import math
 from collections.abc import Mapping, Sequence
 
 # Sequential white -> deep-blue ramp (low count -> high count).
 _RAMP_LOW = (255, 255, 255)
 _RAMP_HIGH = (8, 48, 107)
-# Distinct hues cycled across series in a line chart.
+# CVD-validated 8-hue categorical palette; ordering is the safety mechanism.
+# Beyond 8 series, identity is color+dash (never a 9th generated hue).
 _SERIES_COLORS = (
-    "#1f77b4",
-    "#d62728",
-    "#2ca02c",
-    "#9467bd",
-    "#ff7f0e",
-    "#17becf",
-    "#8c564b",
-    "#e377c2",
-    "#7f7f7f",
-    "#bcbd22",
+    "#2a78d6",
+    "#008300",
+    "#e87ba4",
+    "#eda100",
+    "#1baf7a",
+    "#eb6834",
+    "#4a3aa7",
+    "#e34948",
 )
+_SERIES_DASHES = ("", "6 3", "2 2", "8 3 2 3")
+
+
+def _nice_step(span: float, target_ticks: int = 6) -> float:
+    """A 1/2/5-scaled tick step giving roughly ``target_ticks`` labels."""
+    raw = span / max(target_ticks, 1)
+    magnitude = 10.0 ** math.floor(math.log10(raw))
+    for mult in (1.0, 2.0, 5.0, 10.0):
+        if raw <= mult * magnitude:
+            return mult * magnitude
+    return 10.0 * magnitude
 
 
 def _lerp_color(t: float) -> str:
@@ -113,8 +124,10 @@ def line_chart(
     pad = 48.0
     xs = [x for x, _ in pts]
     ys = [y for _, y in pts] + ([ref_y] if ref_y is not None else [])
-    x_min, x_max = min(xs), max(xs)
-    y_min, y_max = min(ys), max(ys)
+    # Anchor both axes at 0 when the data allows: votes and CI widths are
+    # non-negative, and distance-to-zero is part of what the chart shows.
+    x_min, x_max = min(0.0, min(xs)), max(xs)
+    y_min, y_max = min(0.0, min(ys)), max(ys)
     x_span = x_max - x_min or 1.0
     y_span = y_max - y_min or 1.0
 
@@ -124,18 +137,59 @@ def line_chart(
     def py(y: float) -> float:
         return height - pad - (y - y_min) / y_span * (height - 2 * pad)
 
-    # Legend grows rightward from the plot edge; widen the canvas so long names
-    # are not clipped at the viewBox (~6px/char at font 10).
-    label_px = max((len(name) for name in series), default=0) * 6
+    # Legend grows rightward from the plot edge; widen the canvas so the
+    # color+dash swatch and long names are not clipped at the viewBox
+    # (~6px/char at font 10, plus 28px for the swatch).
+    label_px = max((len(name) for name in series), default=0) * 6 + 28
     canvas_w = width - pad + 12 + label_px
     parts = [f'<svg viewBox="0 0 {canvas_w:g} {height}" width="{canvas_w:g}" height="{height}">']
     parts.append(
-        f'<line x1="{pad}" y1="{height - pad}" x2="{width - pad}" '
-        f'y2="{height - pad}" stroke="#999"/>'
-        f'<line x1="{pad}" y1="{pad}" x2="{pad}" y2="{height - pad}" stroke="#999"/>'
+        "<style>"
+        "g.s polyline{stroke-width:2}"
+        "g.s:hover polyline{stroke-width:3.5}"
+        "svg:has(g.s:hover) g.s:not(:hover){opacity:.25}"
+        "</style>"
+    )
+
+    x0, y0 = px(x_min), py(y_min)
+    x_step = _nice_step(x_span)
+    y_step = _nice_step(y_span)
+    ticks: list[str] = []
+    v = math.ceil(x_min / x_step) * x_step
+    while v <= x_max + 1e-9:
+        tx = px(v)
+        ticks.append(
+            f'<line x1="{tx:.1f}" y1="{pad}" x2="{tx:.1f}" y2="{y0:.1f}" stroke="#e1e0d9"/>'
+            f'<line x1="{tx:.1f}" y1="{y0:.1f}" x2="{tx:.1f}" y2="{y0 + 5:.1f}" stroke="#c3c2b7"/>'
+            f'<text x="{tx:.1f}" y="{y0 + 16:.1f}" text-anchor="middle" font-size="10" '
+            f'fill="#898781">{v:g}</text>'
+        )
+        v += x_step
+    if x_span <= 60:
+        for unit in range(math.ceil(x_min), math.floor(x_max) + 1):
+            tx = px(unit)
+            ticks.append(
+                f'<line x1="{tx:.1f}" y1="{y0:.1f}" x2="{tx:.1f}" y2="{y0 + 3:.1f}" '
+                f'stroke="#c3c2b7"/>'
+            )
+    v = math.ceil(y_min / y_step) * y_step
+    while v <= y_max + 1e-9:
+        ty = py(v)
+        ticks.append(
+            f'<line x1="{pad}" y1="{ty:.1f}" x2="{width - pad}" y2="{ty:.1f}" stroke="#e1e0d9"/>'
+            f'<line x1="{pad - 5}" y1="{ty:.1f}" x2="{pad}" y2="{ty:.1f}" stroke="#c3c2b7"/>'
+            f'<text x="{pad - 8}" y="{ty + 3:.1f}" text-anchor="end" font-size="10" '
+            f'fill="#898781">{v:g}</text>'
+        )
+        v += y_step
+    parts.extend(ticks)
+
+    parts.append(
+        f'<line x1="{pad}" y1="{y0:.1f}" x2="{width - pad}" y2="{y0:.1f}" stroke="#c3c2b7"/>'
+        f'<line x1="{x0:.1f}" y1="{pad}" x2="{x0:.1f}" y2="{y0:.1f}" stroke="#c3c2b7"/>'
     )
     parts.append(
-        f'<text x="{width / 2}" y="{height - 12}" text-anchor="middle" '
+        f'<text x="{width / 2}" y="{height - 8}" text-anchor="middle" '
         f'font-size="12">{_esc(x_label)}</text>'
         f'<text x="14" y="{height / 2}" text-anchor="middle" font-size="12" '
         f'transform="rotate(-90 14 {height / 2})">{_esc(y_label)}</text>'
@@ -143,18 +197,31 @@ def line_chart(
     if ref_y is not None:
         ry = py(ref_y)
         parts.append(
-            f'<line x1="{pad}" y1="{ry}" x2="{width - pad}" y2="{ry}" '
-            f'stroke="#c00" stroke-dasharray="4 3"/>'
-            f'<text x="{width - pad}" y="{ry - 4}" text-anchor="end" '
-            f'font-size="10" fill="#c00">{ref_y:g}</text>'
+            f'<line x1="{pad}" y1="{ry:.1f}" x2="{width - pad}" y2="{ry:.1f}" '
+            f'stroke="#d03b3b" stroke-dasharray="4 3"/>'
+            f'<text x="{width - pad}" y="{ry - 4:.1f}" text-anchor="end" '
+            f'font-size="10" fill="#d03b3b">target {ref_y:g}</text>'
         )
     for idx, (name, points) in enumerate(series.items()):
         color = _SERIES_COLORS[idx % len(_SERIES_COLORS)]
+        dash = _SERIES_DASHES[(idx // len(_SERIES_COLORS)) % len(_SERIES_DASHES)]
+        dash_attr = f' stroke-dasharray="{dash}"' if dash else ""
         path = " ".join(f"{px(x):.1f},{py(y):.1f}" for x, y in points)
-        parts.append(f'<polyline fill="none" stroke="{color}" points="{path}"/>')
+        markers = "".join(
+            f'<circle cx="{px(x):.1f}" cy="{py(y):.1f}" r="3" fill="{color}">'
+            f"<title>{_esc(name)} — {x_label} {x:g}, {y_label} {y:.4g}</title></circle>"
+            for x, y in points
+        )
         parts.append(
-            f'<text x="{width - pad + 6}" y="{12 + idx * 14}" font-size="10" '
-            f'fill="{color}">{_esc(name)}</text>'
+            f'<g class="s"><polyline fill="none" stroke="{color}"{dash_attr} '
+            f'points="{path}"><title>{_esc(name)}</title></polyline>{markers}</g>'
+        )
+        ly = 12 + idx * 14
+        parts.append(
+            f'<line x1="{width - pad + 6}" y1="{ly - 3}" x2="{width - pad + 26}" '
+            f'y2="{ly - 3}" stroke="{color}"{dash_attr} stroke-width="2"/>'
+            f'<text x="{width - pad + 30}" y="{ly}" font-size="10" '
+            f'fill="#111">{_esc(name)}</text>'
         )
     parts.append("</svg>")
     return "".join(parts)

--- a/runner/src/coval_bench/arena/monitoring.py
+++ b/runner/src/coval_bench/arena/monitoring.py
@@ -208,8 +208,8 @@ def render_convergence(conv: Convergence) -> str:
     """Full standalone HTML document for the convergence view."""
     chart = _render.line_chart(
         conv.series,
-        x_label="votes_total",
-        y_label="ci_half_width (Elo)",
+        x_label="votes",
+        y_label="CI half-width (± Elo)",
         ref_y=conv.threshold,
     )
 

--- a/runner/tests/api/test_arena.py
+++ b/runner/tests/api/test_arena.py
@@ -809,3 +809,43 @@ async def test_create_battle_cap_disabled_when_zero(
         "/v1/arena/battle", json={"prompt": "hello", "domain": "other"}, headers=_LABELER_HEADERS
     )
     assert response.status_code == 201
+
+
+async def test_admin_reports_hidden_without_labeler_key(
+    client: AsyncClient, postgresql: Any
+) -> None:
+    """Both admin reports 404 (not 403) without the labeler key."""
+    await _apply_arena_schema(_make_db_url(postgresql))
+    for path in ("/v1/arena/admin/cooccurrence", "/v1/arena/admin/convergence"):
+        response = await client.get(path)
+        assert response.status_code == 404
+
+
+async def test_admin_cooccurrence_renders_battles(client: AsyncClient, postgresql: Any) -> None:
+    """The heatmap includes the battled pair's identities."""
+    await _apply_arena_schema(_make_db_url(postgresql))
+    await _insert_battle(postgresql)
+    await _insert_snapshot(postgresql)
+
+    response = await client.get("/v1/arena/admin/cooccurrence", headers=_LABELER_HEADERS)
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/html")
+    assert "elevenlabs/eleven_multilingual_v2" in response.text
+    assert "cartesia/sonic-3" in response.text
+
+
+async def test_admin_convergence_renders_history(client: AsyncClient, postgresql: Any) -> None:
+    """The convergence chart includes models from snapshot history."""
+    await _apply_arena_schema(_make_db_url(postgresql))
+    await _insert_snapshot(postgresql)
+    await _insert_snapshot(
+        postgresql,
+        computed_at=datetime(2026, 6, 19, 12, 0, tzinfo=UTC),
+        votes_total=20,
+        ci_half_width=35.0,
+    )
+
+    response = await client.get("/v1/arena/admin/convergence", headers=_LABELER_HEADERS)
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/html")
+    assert "elevenlabs/eleven_multilingual_v2" in response.text

--- a/web/app/api/arena/admin/convergence/route.ts
+++ b/web/app/api/arena/admin/convergence/route.ts
@@ -1,0 +1,27 @@
+// Copyright 2026 The Coval Benchmarks Authors
+// SPDX-License-Identifier: Apache-2.0
+
+export const runtime = "nodejs";
+
+import { arenaAccessOk } from "@/lib/arena/guard";
+import { arenaRunnerFetch } from "@/lib/arena/runner";
+
+export async function GET(req: Request) {
+  if (!(await arenaAccessOk())) return new Response(null, { status: 404 });
+  const { searchParams } = new URL(req.url);
+  const qs = new URLSearchParams({
+    metric: searchParams.get("metric") ?? "naturalness",
+    domain: searchParams.get("domain") ?? "all",
+  });
+
+  let res: Response;
+  try {
+    res = await arenaRunnerFetch(`/v1/arena/admin/convergence?${qs}`);
+  } catch {
+    return new Response("Report unavailable.", { status: 502 });
+  }
+  if (!res.ok) return new Response("Report unavailable.", { status: res.status });
+  return new Response(await res.text(), {
+    headers: { "Content-Type": "text/html; charset=utf-8" },
+  });
+}

--- a/web/app/api/arena/admin/cooccurrence/route.ts
+++ b/web/app/api/arena/admin/cooccurrence/route.ts
@@ -1,0 +1,27 @@
+// Copyright 2026 The Coval Benchmarks Authors
+// SPDX-License-Identifier: Apache-2.0
+
+export const runtime = "nodejs";
+
+import { arenaAccessOk } from "@/lib/arena/guard";
+import { arenaRunnerFetch } from "@/lib/arena/runner";
+
+export async function GET(req: Request) {
+  if (!(await arenaAccessOk())) return new Response(null, { status: 404 });
+  const { searchParams } = new URL(req.url);
+  const qs = new URLSearchParams({
+    metric: searchParams.get("metric") ?? "naturalness",
+    domain: searchParams.get("domain") ?? "all",
+  });
+
+  let res: Response;
+  try {
+    res = await arenaRunnerFetch(`/v1/arena/admin/cooccurrence?${qs}`);
+  } catch {
+    return new Response("Report unavailable.", { status: 502 });
+  }
+  if (!res.ok) return new Response("Report unavailable.", { status: res.status });
+  return new Response(await res.text(), {
+    headers: { "Content-Type": "text/html; charset=utf-8" },
+  });
+}

--- a/web/app/arena/admin/page.tsx
+++ b/web/app/arena/admin/page.tsx
@@ -1,0 +1,36 @@
+// Copyright 2026 The Coval Benchmarks Authors
+// SPDX-License-Identifier: Apache-2.0
+
+import DashboardHeader from "@/components/layout/DashboardHeader";
+import DashboardFooter from "@/components/dashboard/DashboardFooter";
+
+export default function Page() {
+  return (
+    <div className="relative flex min-h-screen flex-col bg-background text-text-primary">
+      <DashboardHeader />
+      <main className="relative z-10 mx-auto w-full max-w-5xl flex-1 px-4 pb-10 pt-[84px] sm:px-6 md:pt-[96px]">
+        <h1 className="text-2xl font-medium tracking-tight sm:text-3xl">Arena monitoring</h1>
+        <p className="mt-2 text-sm text-text-secondary">
+          Convergence shows whether rating confidence intervals shrink as votes accumulate.
+          Co-occurrence shows which model pairs have battled — empty blocks away from the
+          diagonal mean groups of models that never face each other.
+        </p>
+
+        <h2 className="mt-8 text-lg font-medium">Convergence</h2>
+        <iframe
+          src="/api/arena/admin/convergence"
+          title="Arena convergence"
+          className="mt-3 h-[560px] w-full rounded-md border bg-white"
+        />
+
+        <h2 className="mt-8 text-lg font-medium">Co-occurrence</h2>
+        <iframe
+          src="/api/arena/admin/cooccurrence"
+          title="Arena co-occurrence"
+          className="mt-3 h-[760px] w-full rounded-md border bg-white"
+        />
+      </main>
+      <DashboardFooter />
+    </div>
+  );
+}

--- a/web/app/arena/admin/page.tsx
+++ b/web/app/arena/admin/page.tsx
@@ -29,6 +29,58 @@ export default function Page() {
           title="Arena co-occurrence"
           className="mt-3 h-[760px] w-full rounded-md border bg-white"
         />
+
+        <h2 className="mt-8 text-lg font-medium">Pairing SCALE tuning</h2>
+        <p className="mt-2 text-sm text-text-secondary">
+          SCALE is the pairing knob: how sharply matchup priority decays with the Elo gap
+          between two models. It is a committed constant in the runner
+          (runner/src/coval_bench/arena/pairing.py), tuned offline — the simulation below
+          does not run live. Loss is penalized cross-entropy per decisive battle: how well
+          the fitted board predicted outcomes as votes accumulated (0.693 = coin flip,
+          lower is better).
+        </p>
+        <div className="mt-3 overflow-x-auto">
+          <table className="w-full max-w-xl text-sm">
+            <thead>
+              <tr className="border-b text-left text-text-secondary">
+                <th className="py-1.5 pr-4 font-medium">SCALE</th>
+                <th className="py-1.5 pr-4 font-medium">300 battles</th>
+                <th className="py-1.5 pr-4 font-medium">2000 battles</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr className="border-b">
+                <td className="py-1.5 pr-4">50</td>
+                <td className="py-1.5 pr-4">0.744</td>
+                <td className="py-1.5 pr-4">0.743</td>
+              </tr>
+              <tr className="border-b">
+                <td className="py-1.5 pr-4">150</td>
+                <td className="py-1.5 pr-4">0.816</td>
+                <td className="py-1.5 pr-4">0.748</td>
+              </tr>
+              <tr className="border-b">
+                <td className="py-1.5 pr-4">300</td>
+                <td className="py-1.5 pr-4">0.838</td>
+                <td className="py-1.5 pr-4">0.719</td>
+              </tr>
+              <tr className="border-b">
+                <td className="py-1.5 pr-4">600</td>
+                <td className="py-1.5 pr-4">0.856</td>
+                <td className="py-1.5 pr-4">0.703</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <p className="mt-3 text-sm text-text-secondary">
+          Offline simulation, 2026-07-16: real 27-model roster, true strengths seeded from
+          the live board, observed 19% tie rate, mean of 3 seeds. Reading: past a few
+          hundred votes, SCALE 150 consistently loses to 300/600; at today&apos;s volume the
+          short-horizon column is noise (no setting beats coin flip yet, and small SCALE
+          partly grades its own homework by re-matching pairs it already knows).
+          Re-run with: <code className="font-mono text-xs">uv run coval-bench arena
+          tune-scale --scales 50,150,300,600</code>
+        </p>
       </main>
       <DashboardFooter />
     </div>

--- a/web/app/arena/page.tsx
+++ b/web/app/arena/page.tsx
@@ -289,6 +289,12 @@ export default function ArenaPage() {
                 >
                   View leaderboard
                 </a>
+                <a
+                  href="/arena/admin"
+                  className="rounded-full border border-border-primary px-6 py-2.5 font-mono text-sm text-text-secondary hover:bg-hover-bg"
+                >
+                  Monitoring
+                </a>
               </div>
             </div>
           ) : (


### PR DESCRIPTION
Surfaces the arena convergence and co-occurrence reports to people without GCP access: two labeler-gated runner endpoints render the same HTML the arena convergence/cooccurrence CLI commands produce, and a new /arena/admin page (behind the existing arena access gate) embeds them via BFF routes that inject the labeler key server-side. No middleware or infra changes — the existing /arena matchers cover the new paths.

Also makes the convergence chart readable: labeled axis ticks with per-vote minors, gridlines, point markers with hover tooltips, and a CVD-safe palette with dash patterns so 27 series stay distinguishable. The arena page gets a Monitoring button next to View leaderboard, and the admin page includes the latest offline SCALE-tuning sweep results as a dated static section (the sim is minutes of CPU, so it doesn't run live).