### PR TITLE
[BENCH-437] Pin WER chart y-axis when bars scroll horizontally (mobile/narrow)

### DIFF
--- a/web/components/charts/d3/BoxPlot.tsx
+++ b/web/components/charts/d3/BoxPlot.tsx
@@ -29,6 +29,7 @@ const BoxPlot: React.FC<BoxPlotProps> = ({
   isMobile = false
 }) => {
   const svgRef = useRef<SVGSVGElement>(null);
+  const axisRef = useRef<SVGSVGElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const [dimensions, setDimensions] = useState({
     width: width || 800,
@@ -118,14 +119,22 @@ const BoxPlot: React.FC<BoxPlotProps> = ({
     const xScale = d3
       .scaleBand()
       .domain(data.data.map((d) => d.model))
-      .range([0, chartWidth])
+      .range([6, chartWidth])
       .paddingInner(0.2)
       .paddingOuter(0);
 
-    // Ticks every 0.5 s. The domain snaps to those boundaries so the
-    // outermost gridlines — the visible floor and ceiling — enclose the
-    // whiskers.
-    const tickStepMs = 500;
+    // Ticks land on 0.5 s multiples, with the step widened until the range
+    // fits a readable tick count (phones get fewer — 19 labels of TTFT data
+    // is noise). The domain snaps to those boundaries so the outermost
+    // gridlines — the visible floor and ceiling — enclose the whiskers.
+    const baseStepMs = 500;
+    const maxTicks = isMobile ? 7 : 12;
+    const tickStepMs =
+      baseStepMs *
+      Math.ceil(
+        Math.max(data.globalMax - Math.max(0, data.globalMin), baseStepMs) /
+          (baseStepMs * maxTicks)
+      );
     const yMin = Math.max(0, Math.floor(data.globalMin / tickStepMs) * tickStepMs);
     let yMax = Math.ceil(data.globalMax / tickStepMs) * tickStepMs;
     if (yMax === yMin) yMax = yMin + tickStepMs;
@@ -134,10 +143,11 @@ const BoxPlot: React.FC<BoxPlotProps> = ({
       .domain([yMin, yMax])
       .range([chartHeight, 0]);
 
-    // Create main group
+    // The plot svg scrolls while the y-axis labels live in a separate fixed
+    // svg to its left, so the scale stays visible at any scroll position.
     const g = svg
       .append("g")
-      .attr("transform", `translate(${margin.left},${margin.top})`);
+      .attr("transform", `translate(0,${margin.top})`);
 
     // Add Y axis
     const yAxis = d3
@@ -160,11 +170,22 @@ const BoxPlot: React.FC<BoxPlotProps> = ({
       .attr("stroke", themeColors.grid)
       .attr("stroke-dasharray", "2 2");
 
-    yAxisGroup.selectAll("text")
-      .attr("fill", themeColors.axisText)
-      .attr("font-size", yAxisTickFontSize);
+    yAxisGroup.selectAll("text").remove();
 
     yAxisGroup.select(".domain").remove();
+
+    const axisSvg = d3.select(axisRef.current);
+    axisSvg.selectAll("*").remove();
+    const axisGroup = axisSvg
+      .append("g")
+      .attr("transform", `translate(${margin.left},${margin.top})`)
+      .call(yAxis);
+
+    axisGroup.selectAll("line").remove();
+    axisGroup.select(".domain").remove();
+    axisGroup.selectAll("text")
+      .attr("fill", themeColors.axisText)
+      .attr("font-size", yAxisTickFontSize);
 
     // Add X axis
     const xAxis = d3.axisBottom(xScale);
@@ -417,17 +438,26 @@ const BoxPlot: React.FC<BoxPlotProps> = ({
           <p>No data available for box plot</p>
         </div>
       ) : (
-        <div
-          className="overflow-x-auto touch-manipulation select-none"
-          onScroll={(e) => setScrollX(e.currentTarget.scrollLeft)}
-        >
+        <div className="flex">
           <svg
-            ref={svgRef}
-            width={svgWidth}
+            ref={axisRef}
+            width={margin.left}
             height={dimensions.height}
-            className="overflow-visible"
-            style={{ background: "transparent" }}
+            className="shrink-0"
+            data-chart-axis
           />
+          <div
+            className="min-w-0 flex-1 overflow-x-auto touch-manipulation select-none"
+            onScroll={(e) => setScrollX(e.currentTarget.scrollLeft)}
+          >
+            <svg
+              ref={svgRef}
+              width={svgWidth - margin.left}
+              height={dimensions.height}
+              className="overflow-visible"
+              style={{ background: "transparent" }}
+            />
+          </div>
         </div>
       )}
       {tip && (

--- a/web/components/dashboard/AccuracyBarSection.tsx
+++ b/web/components/dashboard/AccuracyBarSection.tsx
@@ -30,6 +30,8 @@ import { POSTHOG_EVENTS } from "@/lib/posthog/events";
 const AccuracyBarSection: React.FC = () => {
   const {
     werDescription: description,
+    werBarView,
+    availableWerBarViews,
     werBarDataWithColors,
     getProviderForModel,
     isMobile,
@@ -104,12 +106,27 @@ const AccuracyBarSection: React.FC = () => {
   // WER-based: never rendered on S2S (no WER metric).
   if (mode === "s2s") return null;
 
+  // The toggle buttons carry no tooltips; the active view's blurb rides along
+  // in the "About this benchmark" tooltip instead (only when a toggle shows).
+  const activeWerView =
+    availableWerBarViews.length > 1
+      ? availableWerBarViews.find((view) => view.key === werBarView)
+      : undefined;
+
   return (
     <div className="mb-4">
       <Card padding="p-5 lg:p-8">
         <SectionHeader
           label="Accuracy by Model"
           description={description}
+          note={
+            activeWerView
+              ? {
+                  term: `${activeWerView.label} view`,
+                  text: activeWerView.tooltip,
+                }
+              : undefined
+          }
           hint="Click bar to compare models"
           exportXLabel="Model"
           exportRows={() =>
@@ -166,92 +183,112 @@ const AccuracyBarSection: React.FC = () => {
           </div>
         )}
         <div
-          className={`h-96 overflow-x-auto transition-opacity ${werBarLoading ? "opacity-40" : ""}`}
+          className={`flex h-96 transition-opacity ${werBarLoading ? "opacity-40" : ""}`}
           onMouseEnter={trackChartHover}
+          data-export-frame
         >
-          <ResponsiveContainer
-            width="100%"
-            height="100%"
-            minWidth={werBarDataWithColors.length * 48}
-            debounce={200}
-          >
-            <BarChart
-              data={werBarDataWithColors}
-              margin={{
-                top: 20,
-                right: 8,
-                left: 0,
-                bottom: 80,
-              }}
+          {/* The y-axis lives in its own zero-plot chart outside the scroll
+              container so it stays pinned while the bars scroll. It gets the
+              same data (via an invisible Bar) so both charts compute the same
+              scale, and the 180 bottom margin mirrors the main chart's
+              80 margin + 100 x-axis height so ticks align with gridlines. */}
+          <div className="w-[52px] shrink-0" data-chart-axis>
+            <ResponsiveContainer width="100%" height="100%" debounce={200}>
+              <BarChart
+                data={werBarDataWithColors}
+                margin={{ top: 20, right: 0, left: 0, bottom: 180 }}
+              >
+                <YAxis
+                  width={52}
+                  axisLine={false}
+                  tickLine={false}
+                  tick={{ fill: themeColors.axisText, fontSize: 12 }}
+                  tickFormatter={(value) => `${value}%`}
+                  label={{
+                    value: "WER % · lower is better",
+                    angle: -90,
+                    position: "insideLeft",
+                    fill: themeColors.axisText,
+                    fontSize: 12,
+                    style: { textAnchor: "middle" },
+                  }}
+                />
+                <Bar dataKey="averageWER" fill="transparent" isAnimationActive={false} />
+              </BarChart>
+            </ResponsiveContainer>
+          </div>
+          <div className="min-w-0 flex-1 overflow-x-auto">
+            <ResponsiveContainer
+              width="100%"
+              height="100%"
+              minWidth={werBarDataWithColors.length * 48 + 52}
+              debounce={200}
             >
-              <CartesianGrid
-                vertical={false}
-                strokeDasharray="2 2"
-                stroke={themeColors.grid}
-              />
-              <XAxis
-                dataKey="model"
-                axisLine={false}
-                tickLine={false}
-                tick={
-                  <CustomBarChartTick
-                    getProviderForModel={getProviderForModel}
-                    isMobile={isMobile}
-                  />
-                }
-                height={100}
-                interval={0}
-              />
-              <YAxis
-                width={52}
-                axisLine={false}
-                tickLine={false}
-                tick={{ fill: themeColors.axisText, fontSize: 12 }}
-                tickFormatter={(value) => `${value}%`}
-                label={{
-                  value: "WER % · lower is better",
-                  angle: -90,
-                  position: "insideLeft",
-                  fill: themeColors.axisText,
-                  fontSize: 12,
-                  style: { textAnchor: "middle" },
-                }}
-              />
-              <Tooltip
-                content={<CustomBarTooltip getProviderForModel={getProviderForModel} />}
-                cursor={false}
-                active={isMobile ? false : undefined}
-              />
-              <Bar
-                dataKey="averageWER"
-                radius={[4, 4, 0, 0]}
-                isAnimationActive={false}
-                onClick={handleWERBarClickTracked}
-                label={barLabel}
-                style={{
-                  cursor: "pointer",
+              <BarChart
+                data={werBarDataWithColors}
+                margin={{
+                  top: 20,
+                  right: 8,
+                  left: 0,
+                  bottom: 80,
                 }}
               >
-                {werBarDataWithColors.map((entry) => (
-                  <Cell
-                    key={`wer-cell-${entry.model}`}
-                    fill={entry.fill}
-                    fillOpacity={entry.fillOpacity}
-                    role="button"
-                    tabIndex={0}
-                    aria-label={`${normalizeModelName(entry.model)}: ${entry.averageWER.toFixed(1)}% WER${clickedWERBars.has(entry.model) ? ", selected" : ""}`}
-                    onKeyDown={(e: React.KeyboardEvent) => {
-                      if (e.key === "Enter" || e.key === " ") {
-                        e.preventDefault();
-                        handleWERBarClickTracked(entry);
-                      }
-                    }}
-                    onMouseDown={(e: React.MouseEvent) => e.preventDefault()}
-                  />
-                ))}
-              </Bar>
-            </BarChart>
-          </ResponsiveContainer>
+                <CartesianGrid
+                  vertical={false}
+                  strokeDasharray="2 2"
+                  stroke={themeColors.grid}
+                />
+                <XAxis
+                  dataKey="model"
+                  axisLine={false}
+                  tickLine={false}
+                  tick={
+                    <CustomBarChartTick
+                      getProviderForModel={getProviderForModel}
+                      isMobile={isMobile}
+                    />
+                  }
+                  height={100}
+                  interval={0}
+                  padding={{ left: 52 }}
+                />
+                <YAxis hide />
+                <Tooltip
+                  content={<CustomBarTooltip getProviderForModel={getProviderForModel} />}
+                  cursor={false}
+                  active={isMobile ? false : undefined}
+                />
+                <Bar
+                  dataKey="averageWER"
+                  radius={[4, 4, 0, 0]}
+                  isAnimationActive={false}
+                  onClick={handleWERBarClickTracked}
+                  label={barLabel}
+                  style={{
+                    cursor: "pointer",
+                  }}
+                >
+                  {werBarDataWithColors.map((entry) => (
+                    <Cell
+                      key={`wer-cell-${entry.model}`}
+                      fill={entry.fill}
+                      fillOpacity={entry.fillOpacity}
+                      role="button"
+                      tabIndex={0}
+                      aria-label={`${normalizeModelName(entry.model)}: ${entry.averageWER.toFixed(1)}% WER${clickedWERBars.has(entry.model) ? ", selected" : ""}`}
+                      onKeyDown={(e: React.KeyboardEvent) => {
+                        if (e.key === "Enter" || e.key === " ") {
+                          e.preventDefault();
+                          handleWERBarClickTracked(entry);
+                        }
+                      }}
+                      onMouseDown={(e: React.MouseEvent) => e.preventDefault()}
+                    />
+                  ))}
+                </Bar>
+              </BarChart>
+            </ResponsiveContainer>
+          </div>
         </div>
       </Card>
     </div>

--- a/web/components/dashboard/BoxPlotSection.tsx
+++ b/web/components/dashboard/BoxPlotSection.tsx
@@ -11,6 +11,7 @@ import Card from "@/components/shared/Card";
 import SectionHeader from "@/components/shared/SectionHeader";
 import MetricInfo from "@/components/shared/MetricInfo";
 import MetricToggle from "@/components/dashboard/MetricToggle";
+import { metricAboutNote } from "@/lib/config/metrics";
 import { useDashboard } from "@/contexts/DashboardContext";
 import { useChartHoverTracking } from "@/hooks/useChartHoverTracking";
 
@@ -39,6 +40,7 @@ const BoxPlotSection: React.FC = () => {
         <SectionHeader
           label="Latency Variation"
           description={description}
+          note={metricAboutNote(activeMetric)}
           exportRows={() =>
             boxPlotData.data.map(({ model, quartiles, stats }) => ({
               model,

--- a/web/components/dashboard/LatencyAccuracySection.tsx
+++ b/web/components/dashboard/LatencyAccuracySection.tsx
@@ -15,6 +15,7 @@ import {
   ResponsiveContainer,
   Tooltip,
 } from "recharts";
+import { Info } from "lucide-react";
 import type { ScatterDataPoint } from "@/types/benchmark.types";
 import { getModelColor } from "@/lib/utils/colors";
 import { normalizeModelName } from "@/lib/utils/formatters";
@@ -24,6 +25,7 @@ import Card from "@/components/shared/Card";
 import SectionHeader from "@/components/shared/SectionHeader";
 import MetricToggle from "@/components/dashboard/MetricToggle";
 import MetricInfo from "@/components/shared/MetricInfo";
+import { metricAboutNote } from "@/lib/config/metrics";
 import { useDashboard } from "@/contexts/DashboardContext";
 import { useThemeColors } from "@/hooks/useThemeColors";
 import { useActiveTab } from "@/hooks/useActiveTab";
@@ -133,6 +135,7 @@ const LatencyAccuracySection: React.FC = () => {
         <SectionHeader
           label="Latency vs Accuracy"
           description={description}
+          note={metricAboutNote(metric)}
           exportXLabel={`Average ${latencyLabel}`}
           exportAnnotate={(clone) => {
             const nameCounts = new Map<string, number>();
@@ -189,7 +192,8 @@ const LatencyAccuracySection: React.FC = () => {
                   aria-hidden="true"
                 />
                 <MetricInfo metric="human-parity" align="right">
-                  Human-parity zone
+                  Human-parity zone{" "}
+                  <Info size={12} aria-hidden="true" className="inline align-[-2px]" />
                 </MetricInfo>
               </li>
             </ul>

--- a/web/components/dashboard/MetricToggle.tsx
+++ b/web/components/dashboard/MetricToggle.tsx
@@ -6,7 +6,6 @@
 import React from "react";
 import { useDashboard } from "@/contexts/DashboardContext";
 import { useActiveTab } from "@/hooks/useActiveTab";
-import MetricInfo from "@/components/shared/MetricInfo";
 
 // Shared TTFS / TTFT switch. Reads and writes the single dashboard-wide metric,
 // so every chart that renders it stays in sync. Hidden on TTS (single-metric).
@@ -19,20 +18,19 @@ const MetricToggle: React.FC = () => {
   return (
     <div className="mb-4 inline-flex gap-0.5 rounded-lg bg-surface-toggle-inactive p-0.5">
       {(["TTFS", "TTFT"] as const).map((m) => (
-        <MetricInfo key={m} metric={m} align="left">
-          <button
-            type="button"
-            onClick={() => setSttMetric(m)}
-            className={
-              "rounded-md px-4 py-3 text-sm sm:px-3 sm:py-1 sm:text-xs font-medium transition-colors " +
-              (sttMetric === m
-                ? "bg-surface-primary text-text-primary shadow-sm"
-                : "text-text-secondary hover:text-text-primary")
-            }
-          >
-            {m}
-          </button>
-        </MetricInfo>
+        <button
+          key={m}
+          type="button"
+          onClick={() => setSttMetric(m)}
+          className={
+            "rounded-md px-4 py-3 text-sm sm:px-3 sm:py-1 sm:text-xs font-medium transition-colors " +
+            (sttMetric === m
+              ? "bg-surface-primary text-text-primary shadow-sm"
+              : "text-text-secondary hover:text-text-primary")
+          }
+        >
+          {m}
+        </button>
       ))}
     </div>
   );

--- a/web/components/dashboard/ModelComparisonSection.tsx
+++ b/web/components/dashboard/ModelComparisonSection.tsx
@@ -12,6 +12,7 @@ import Card from "@/components/shared/Card";
 import SectionHeader from "@/components/shared/SectionHeader";
 import MetricToggle from "@/components/dashboard/MetricToggle";
 import { datasetLabel } from "@/lib/config/datasets";
+import { metricAboutNote } from "@/lib/config/metrics";
 import { useDashboard } from "@/contexts/DashboardContext";
 import { useChartHoverTracking } from "@/hooks/useChartHoverTracking";
 
@@ -37,7 +38,7 @@ const ModelComparisonSection: React.FC = () => {
             detailed:
               "Latency percentiles come straight from the measured runs — drag the slider to move from the fastest run (p0) through the median to the slowest (p100). Click a column to sort.",
           }}
-          expandable={false}
+          note={metricAboutNote(activeMetric)}
           exportRows={() =>
             data.map(({ model, latency, avgWER, werStdDev, sampleCount }) => ({
               model,

--- a/web/components/dashboard/WerBarViewToggle.tsx
+++ b/web/components/dashboard/WerBarViewToggle.tsx
@@ -5,7 +5,6 @@
 
 import React from "react";
 import { useDashboard } from "@/contexts/DashboardContext";
-import MetricInfo from "@/components/shared/MetricInfo";
 
 const WerBarViewToggle: React.FC = () => {
   const { werBarView, changeWerBarView, availableWerBarViews } = useDashboard();
@@ -14,27 +13,20 @@ const WerBarViewToggle: React.FC = () => {
 
   return (
     <div className="mb-4 inline-flex gap-0.5 rounded-lg bg-surface-toggle-inactive p-0.5">
-      {availableWerBarViews.map((view, i) => (
-        <MetricInfo
+      {availableWerBarViews.map((view) => (
+        <button
           key={view.key}
-          content={view.tooltip}
-          align={
-            i === 0 ? "left" : i === availableWerBarViews.length - 1 ? "right" : "center"
+          type="button"
+          onClick={() => changeWerBarView(view.key)}
+          className={
+            "rounded-md px-4 py-3 text-sm sm:px-3 sm:py-1 sm:text-xs font-medium transition-colors " +
+            (werBarView === view.key
+              ? "bg-surface-primary text-text-primary shadow-sm"
+              : "text-text-secondary hover:text-text-primary")
           }
         >
-          <button
-            type="button"
-            onClick={() => changeWerBarView(view.key)}
-            className={
-              "rounded-md px-4 py-3 text-sm sm:px-3 sm:py-1 sm:text-xs font-medium transition-colors " +
-              (werBarView === view.key
-                ? "bg-surface-primary text-text-primary shadow-sm"
-                : "text-text-secondary hover:text-text-primary")
-            }
-          >
-            {view.label}
-          </button>
-        </MetricInfo>
+          {view.label}
+        </button>
       ))}
     </div>
   );

--- a/web/components/dashboard/WerDatasetSelect.tsx
+++ b/web/components/dashboard/WerDatasetSelect.tsx
@@ -4,6 +4,7 @@
 "use client";
 
 import React from "react";
+import { Info } from "lucide-react";
 import { useDashboard } from "@/contexts/DashboardContext";
 import { useActiveTab } from "@/hooks/useActiveTab";
 import { datasetLabel, isPerturbationDataset } from "@/lib/config/datasets";
@@ -35,7 +36,8 @@ const WerDatasetSelect: React.FC<{ className?: string }> = ({ className }) => {
         content="Scopes the WER column to one evaluation set. Full datasets are distinct recordings; WildASR perturbations replay the clean utterances with one degradation applied. Pooled blends every dataset in the window."
         align={isMobile ? "left" : "right"}
       >
-        WER dataset
+        WER dataset{" "}
+        <Info size={12} aria-hidden="true" className="inline align-[-2px]" />
       </MetricInfo>
       <span className="relative inline-flex">
         <select

--- a/web/components/shared/MetricInfo.tsx
+++ b/web/components/shared/MetricInfo.tsx
@@ -42,9 +42,12 @@ const MetricInfo: React.FC<{
     : undefined;
   let body: React.ReactNode = content ?? null;
   if (body == null && info?.tooltip) {
+    const childText = React.Children.toArray(children)
+      .filter((c): c is string => typeof c === "string")
+      .join("")
+      .trim();
     const repeatsTrigger =
-      typeof children === "string" &&
-      children.trim().toLowerCase() === info.short.toLowerCase();
+      childText.toLowerCase() === info.short.toLowerCase();
     body = repeatsTrigger ? (
       info.tooltip
     ) : (

--- a/web/components/shared/SectionHeader.tsx
+++ b/web/components/shared/SectionHeader.tsx
@@ -27,6 +27,9 @@ interface SectionHeaderProps {
   };
   /** Optional hint shown after the "About this benchmark" label, separated by an interpunct. */
   hint?: string;
+  /** Context that changes with a toggle (active metric or dataset view), shown
+   *  as its own bolded block under the description in the tooltip. */
+  note?: { term: string; text: string };
   /** When false, the detailed text shows inline instead of behind a toggle. */
   expandable?: boolean;
   /** Rows for the Download Data (CSV) button; must reflect the active filters. */
@@ -44,6 +47,7 @@ const SectionHeader: React.FC<SectionHeaderProps> = ({
   description,
   stat,
   hint,
+  note,
   expandable = true,
   exportRows,
   exportImage = true,
@@ -110,6 +114,12 @@ const SectionHeader: React.FC<SectionHeaderProps> = ({
           (a, b) =>
             b.clientWidth * b.clientHeight - a.clientWidth * a.clientHeight
         )[0];
+    // Charts with a pinned y-axis render it as a slim sibling SVG; the export
+    // composites it back to the left of the scrolling plot.
+    const findAxis = () =>
+      card.querySelector<SVGSVGElement>(
+        "[data-chart-axis] svg, svg[data-chart-axis]"
+      ) ?? undefined;
     let svg = findSvg();
     // The exporting flag rejects overlapping clicks on the same card, which
     // would otherwise read the temporary stage size as the layout to restore.
@@ -119,9 +129,9 @@ const SectionHeader: React.FC<SectionHeaderProps> = ({
     // the same image, taller than the on-screen chart so dense charts have
     // room to place labels. The charts re-render on container resize, which
     // can replace the SVG node, hence the re-query once the stage settles.
-    const wrapper = svg.closest<HTMLElement>(
-      ".recharts-responsive-container"
-    )?.parentElement;
+    const wrapper =
+      svg.closest<HTMLElement>("[data-export-frame]") ??
+      svg.closest<HTMLElement>(".recharts-responsive-container")?.parentElement;
     const priorWidth = card.style.width;
     const priorHeight = wrapper?.style.height ?? "";
     card.style.width = "1000px";
@@ -163,6 +173,7 @@ const SectionHeader: React.FC<SectionHeaderProps> = ({
         value: stat.value,
       },
       annotate: exportAnnotate,
+      axis: findAxis(),
       legend: Array.from(
         card.querySelectorAll(".recharts-legend-wrapper li, [data-chart-legend] li")
       ).map((li) => {
@@ -236,7 +247,19 @@ const SectionHeader: React.FC<SectionHeaderProps> = ({
         {expandable ? (
           <span className="text-sm font-light text-text-tertiary">
             <MetricInfo
-              content={description.detailed}
+              content={
+                note ? (
+                  <>
+                    {description.detailed}
+                    <span className="mt-2 block border-t border-border-secondary pt-2">
+                      <span className="font-semibold">{note.term}.</span>{" "}
+                      {note.text}
+                    </span>
+                  </>
+                ) : (
+                  description.detailed
+                )
+              }
               align="left"
               panelClassName="top-full mt-1.5 w-[min(38rem,calc(100vw-4rem))]"
             >

--- a/web/hooks/useDashboardState.tsx
+++ b/web/hooks/useDashboardState.tsx
@@ -356,7 +356,7 @@ export function useDashboardState(page: "tts" | "stt" | "s2s") {
     : {
         short: "Word Error Rate (%)",
         detailed:
-          "In voice AI applications, transcription accuracy directly impacts the performance of downstream tasks. Even small transcription errors can lead to misinterpretations, frustrating experiences, or incorrect system responses. We evaluate against test audio that includes diverse speakers, accents, and real-world audio conditions. Click a bar to highlight it for comparison.",
+          "In voice AI applications, transcription accuracy directly impacts the performance of downstream tasks. Even small transcription errors can lead to misinterpretations, frustrating experiences, or incorrect system responses.",
       };
 
   const heatmapDisplayData = useMemo(() => {

--- a/web/lib/config/metrics.ts
+++ b/web/lib/config/metrics.ts
@@ -1,6 +1,20 @@
 // Copyright 2026 The Coval Benchmarks Authors
 // SPDX-License-Identifier: Apache-2.0
 
+// Definition of the active metric, shown as a bolded block inside the
+// "About this benchmark" tooltip on cards that carry the TTFS/TTFT toggle —
+// the toggle buttons themselves carry no tooltips. Metrics without a tooltip
+// (TTFA, V2V) resolve to undefined and add nothing.
+export const metricAboutNote = (
+  metric: string
+): { term: string; text: string } | undefined => {
+  const d =
+    metricDescriptions[metric.toLowerCase() as keyof typeof metricDescriptions];
+  return d && "tooltip" in d
+    ? { term: `${metric} — ${d.short}`, text: d.tooltip }
+    : undefined;
+};
+
 export const metricDescriptions = {
   ttfa: {
     short: "Time to First Audio",
@@ -24,7 +38,7 @@ export const metricDescriptions = {
   wer: {
     short: "Word Error Rate (%)",
     detailed:
-      "Ensuring accurate speech output is fundamental to user trust and comprehension in voice AI systems. We recognize that even minor pronunciation errors can undermine the entire conversation experience and our evaluation captures how faithfully text-to-speech systems pronounce complex terminology, proper nouns, and domain-specific vocabulary that matter most to your users. Click a bar to highlight it for comparison."
+      "Ensuring accurate speech output is fundamental to user trust and comprehension in voice AI systems. We recognize that even minor pronunciation errors can undermine the entire conversation experience and our evaluation captures how faithfully text-to-speech systems pronounce complex terminology, proper nouns, and domain-specific vocabulary that matter most to your users."
   },
   "human-parity": {
     short: "Human-parity zone",

--- a/web/lib/utils/chartExport.ts
+++ b/web/lib/utils/chartExport.ts
@@ -68,6 +68,8 @@ export interface ChartPNGHeader {
   stat?: { label: string; value: string };
   /** Mutates the cloned SVG before rasterizing, e.g. to label scatter dots. */
   annotate?: (clone: SVGSVGElement) => void;
+  /** Pinned y-axis rendered as a sibling SVG, composited left of the plot. */
+  axis?: SVGSVGElement;
 }
 
 const FONT = "ui-sans-serif, system-ui, sans-serif";
@@ -279,6 +281,8 @@ export async function downloadChartPNG(
   const dark = isDarkBg(colors.tooltipBg);
   const svgRect = svg.getBoundingClientRect();
   const { width, height } = svgRect;
+  const axisWidth = header.axis?.getBoundingClientRect().width ?? 0;
+  const fullWidth = width + axisWidth;
   // The rendered SVG often reserves empty space below its content (e.g. room
   // recharts keeps for its HTML legend); crop it so the image ends where the
   // chart does. The bound comes from text elements (axis ticks/titles are the
@@ -292,6 +296,12 @@ export async function downloadChartPNG(
   clone.setAttribute("width", `${width}`);
   clone.setAttribute("height", `${height}`);
   header.annotate?.(clone);
+  let axisClone: SVGSVGElement | undefined;
+  if (header.axis) {
+    axisClone = header.axis.cloneNode(true) as SVGSVGElement;
+    axisClone.setAttribute("width", `${axisWidth}`);
+    axisClone.setAttribute("height", `${height}`);
+  }
   // Annotations may land below the chart's own text (labelScatterDots records
   // how far down it drew); they must survive the crop too.
   const annotationBottom =
@@ -305,11 +315,17 @@ export async function downloadChartPNG(
     )
   );
   let chart: HTMLImageElement;
+  let axisImg: HTMLImageElement | undefined;
   let logo: HTMLImageElement;
   try {
     chart = await loadImage(
       `data:image/svg+xml;charset=utf-8,${encodeURIComponent(new XMLSerializer().serializeToString(clone))}`
     );
+    if (axisClone) {
+      axisImg = await loadImage(
+        `data:image/svg+xml;charset=utf-8,${encodeURIComponent(new XMLSerializer().serializeToString(axisClone))}`
+      );
+    }
     logo = await loadImage("/coval-logo.svg");
   } catch {
     return false;
@@ -319,7 +335,7 @@ export async function downloadChartPNG(
   const canvas = document.createElement("canvas");
   const measure = canvas.getContext("2d");
   if (!measure) return false;
-  const rows = legendRows(measure, header.legend ?? [], width);
+  const rows = legendRows(measure, header.legend ?? [], fullWidth);
   // Measure the headline stat first so we know how much width it claims.
   let statW = 0;
   if (header.stat) {
@@ -332,9 +348,9 @@ export async function downloadChartPNG(
   // so stack the stat under the title when a legible title strip (≥140px) can't
   // sit beside it. Either way the title WRAPS into the width actually available,
   // so a long multi-word title wraps instead of running off the canvas edge.
-  const statFitsBeside = header.stat ? statW + 16 + 140 <= width : false;
+  const statFitsBeside = header.stat ? statW + 16 + 140 <= fullWidth : false;
   const availableTitleWidth =
-    width - (header.stat && statFitsBeside ? statW + 16 : 0);
+    fullWidth - (header.stat && statFitsBeside ? statW + 16 : 0);
   measure.font = `600 20px ${FONT}`;
   const titleLines = header.title
     ? wrapText(measure, header.title, availableTitleWidth)
@@ -352,7 +368,7 @@ export async function downloadChartPNG(
     (titleBlock > 0 || rows.length > 0 ? 12 : 0);
   // The bottom strip carries the optional x-axis title and the watermark.
   const bottomBlock = Math.max(header.xLabel ? 24 : 0, logoHeight + 10);
-  const totalWidth = width + 2 * MARGIN;
+  const totalWidth = fullWidth + 2 * MARGIN;
   const totalHeight = MARGIN + headerBlock + contentHeight + bottomBlock + MARGIN / 2;
   canvas.width = totalWidth * 2;
   canvas.height = totalHeight * 2;
@@ -412,13 +428,26 @@ export async function downloadChartPNG(
   }
   ctx.globalAlpha = 1;
   const chartY = MARGIN + headerBlock;
+  if (axisImg) {
+    ctx.drawImage(
+      axisImg,
+      0,
+      0,
+      axisWidth,
+      contentHeight,
+      MARGIN,
+      chartY,
+      axisWidth,
+      contentHeight
+    );
+  }
   ctx.drawImage(
     chart,
     0,
     0,
     width,
     contentHeight,
-    MARGIN,
+    MARGIN + axisWidth,
     chartY,
     width,
     contentHeight


### PR DESCRIPTION
## Summary

**Pinned y-axes (BENCH-437).** On mobile/narrow viewports the WER bar chart and the latency box plot scroll horizontally, and the y-axis scrolled off with the bars — once gone, there's no scale or "WER % · lower is better" label in view. Both charts now render the y-axis in a slim fixed pane outside the scroll container:

- **WER bar chart** (recharts): the axis lives in a 52px sibling chart fed the same data (invisible bar) so both compute an identical scale; the main chart hides its own axis but keeps it for gridlines. `padding={{left: 52}}` preserves the room the old axis gutter gave the first bar's rotated label.
- **Box plot** (d3): tick labels draw into a fixed sibling SVG; gridlines stay in the scrolling plot. Tooltip anchoring is unchanged.
- **PNG export** previously rasterized only the largest SVG in a card, which would have dropped the split-off axis — it now composites the `data-chart-axis` SVG to the left of the plot, and the height-staging targets the whole flex row (`data-export-frame`) so both panes resize together.

**Box plot tick density.** The y-axis stepped every 0.5s regardless of range, so TTFT (~9s) produced 19 labels. The step now widens with the range: max ~7 ticks on mobile, ~12 on desktop, always on 0.5s multiples.

**Tooltip cleanup.** The TTFS/TTFT and Cumulative/Clean/Production toggle buttons no longer carry tooltips. Instead, the card's "About this benchmark" tooltip ends with a bolded block for the active option ("**TTFS — Time to Final Segment.** Time from end of speech…" / "**Clean view.** WildASR clean only…") and follows the toggle. Model Comparison switches from inline description text to the same About tooltip. "Human-parity zone" and "WER dataset" labels get a visible info icon for their existing tooltips.

## Test plan

- Verified in-browser at 375px / 800px / 1600px: axes stay pinned at full scroll on both charts, ticks align with gridlines, first x-labels unclipped at scroll 0
- Bar tap-to-select + chips, box plot tap-to-pin tooltips (correct column while scrolled), and dataset/metric toggles all exercised
- PNG exports produce canvases sized axis+plot (compositing verified via toBlob spy); CSV export unchanged
- About tooltips checked per toggle state on STT, and on TTS (no metric note appended — TTFA has no toggle)
- `tsc --noEmit`, `eslint --max-warnings 0`, and all 56 vitest tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR keeps chart scales visible while horizontally scrolling narrow dashboards. The main changes are:

- Splits the WER and latency charts into fixed y-axis and scrolling plot panes.
- Composites split chart panes during PNG export.
- Adjusts box-plot tick density based on range and viewport size.
- Moves active metric and WER-view details into section About tooltips.
- Adds visible information icons to existing tooltip labels.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<sub>Reviews (1): Last reviewed commit: ["\[BENCH-437\] Pin chart y-axes while bars ..."](https://github.com/coval-ai/benchmarks/commit/7a0332e0068b62a4b892b1221d0e2cd91c2c3ede) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44953180)</sub>

<!-- /greptile_comment -->