### PR TITLE
Hide Grok from the S2S board for launch

### DIFF
--- a/runner/src/coval_bench/registries/models.py
+++ b/runner/src/coval_bench/registries/models.py
@@ -735,7 +735,10 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         provider="xai",
         model="grok-realtime",
         tags=(_REALTIME, _MULTI),
-        status=_ACTIVE,
+        # hidden from the site for launch while xAI capacity issues distort
+        # latency; the fetch job doesn't read this registry, so data keeps
+        # accruing for the flip back to active.
+        status=_PENDING,
     ),
 ]
 


### PR DESCRIPTION
Flips the S2S grok-realtime registry entry to pending — the same status mechanism that keeps retired STT and TTS models off the site: the providers API marks it disabled and the frontend drops it from every chart and filter. The fetch job doesn't read the registry, so xAI data keeps accruing and history is intact whenever it flips back to active.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hides Grok from the S2S provider catalogue while preserving its benchmark history. The main change is:

- Marks `xai/grok-realtime` as pending instead of active.

<h3>Confidence Score: 4/5</h3>

The public results paths need consistent status filtering before merging.

- The providers catalogue disables pending models.
- Aggregates and leaderboard results can still include Grok while ingestion continues.

runner/src/coval_bench/registries/models.py and the public results endpoints

<sub>Reviews (1): Last reviewed commit: ["Hide Grok from the S2S board for launch"](https://github.com/coval-ai/benchmarks/commit/1746e6ef5c713b671bd2def9be199ffa05806134) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44953653)</sub>

<!-- /greptile_comment -->