### PR TITLE
[BENCH-504] Restyle footer with theme tokens instead of hardcoded black

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -228,37 +228,11 @@ body {
   mix-blend-mode: multiply;
 }
 
-/* Multiply vanishes on Ink, so screen-blend the grain (like the footer) and
-   lift the opacity to keep the texture visible in dark mode. */
+/* Multiply vanishes on Ink, so screen-blend the grain and lift the opacity to
+   keep the texture visible in dark mode. */
 [data-theme="dark"] .noise-overlay {
   opacity: 0.06;
   mix-blend-mode: screen;
-}
-
-/* Footer grain — coval.ai's `.footer-noise`: screen-blended, fading in toward
-   the bottom of the dark band. */
-.footer-noise {
-  position: absolute;
-  inset: 0;
-  background-image: var(--noise-bg);
-  background-repeat: repeat;
-  background-size: 256px 256px;
-  opacity: 0.27;
-  mix-blend-mode: screen;
-  pointer-events: none;
-  z-index: 0;
-  mask-image: linear-gradient(
-    to bottom,
-    transparent 0%,
-    rgba(0, 0, 0, 0.4) 25%,
-    rgba(0, 0, 0, 1) 60%
-  );
-  -webkit-mask-image: linear-gradient(
-    to bottom,
-    transparent 0%,
-    rgba(0, 0, 0, 0.4) 25%,
-    rgba(0, 0, 0, 1) 60%
-  );
 }
 
 .tooltip-scroll {

--- a/web/components/dashboard/DashboardFooter.tsx
+++ b/web/components/dashboard/DashboardFooter.tsx
@@ -4,9 +4,8 @@
 import Link from "next/link";
 import React from "react";
 
-// Dark gradient footer mirrored from www.coval.ai (`.footer`). Layout and
-// colors replicate the live site's `.footer-*` classes. Colors are hardcoded
-// light-on-dark (the cream design tokens would be dark-on-dark here).
+// Footer layout mirrored from www.coval.ai (`.footer-*`), recolored with the
+// theme tokens so it sits flush on the page background in both themes.
 
 // Site navigation, mirrored from the top nav sections plus the source repo.
 const FOOTER_LINKS = [
@@ -20,20 +19,12 @@ const GITHUB_URL = "https://github.com/coval-ai/benchmarks";
 
 const DashboardFooter: React.FC = () => {
   return (
-    <footer
-      className="relative flex min-h-[calc(25vh-30px)] w-full flex-col overflow-hidden text-[#999]"
-      style={{
-        background:
-          "linear-gradient(to bottom, #0f0c0a 0% 55%, #0c0908 68%, #080604 80%, #040302, #000)"
-      }}
-    >
-      <div aria-hidden className="footer-noise" />
-
+    <footer className="w-full border-t border-border-primary bg-background text-text-secondary">
       {/* .footer-inner */}
-      <div className="relative z-[1] flex w-full flex-1 flex-col justify-center px-4 py-8 md:px-6">
+      <div className="flex w-full flex-col justify-center px-4 py-8 md:px-6">
         {/* .footer-bottom */}
         <div className="flex flex-col items-start gap-3">
-          <span className="font-sans text-lg font-medium tracking-wide text-[#f2f1ee]">
+          <span className="font-sans text-lg font-medium tracking-wide text-text-primary">
             Voice AI Benchmarks
           </span>
 
@@ -45,7 +36,7 @@ const DashboardFooter: React.FC = () => {
               <Link
                 key={link.href}
                 href={link.href}
-                className="text-[#ccc] transition-colors duration-150 hover:text-[#f2f1ee]"
+                className="text-text-secondary transition-colors duration-150 hover:text-text-primary"
               >
                 {link.label}
               </Link>
@@ -54,7 +45,7 @@ const DashboardFooter: React.FC = () => {
               href={GITHUB_URL}
               target="_blank"
               rel="noopener noreferrer"
-              className="inline-flex items-center gap-1.5 text-[#ccc] transition-colors duration-150 hover:text-[#f2f1ee]"
+              className="inline-flex items-center gap-1.5 text-text-secondary transition-colors duration-150 hover:text-text-primary"
             >
               <svg
                 viewBox="0 0 16 16"
@@ -69,7 +60,7 @@ const DashboardFooter: React.FC = () => {
             </a>
           </nav>
 
-          <p className="text-xs text-[#555]">&copy; 2026 Coval, Inc.</p>
+          <p className="text-xs text-text-tertiary">&copy; 2026 Coval, Inc.</p>
         </div>
       </div>
     </footer>


### PR DESCRIPTION
## Summary
Before:
<img width="1910" height="964" alt="Screenshot 2026-07-16 at 4 36 51 PM" src="https://github.com/user-attachments/assets/d1c31ef5-4f53-4c27-8831-d6b4b4f9d224" />
After
<img width="1909" height="958" alt="Screenshot 2026-07-16 at 4 37 16 PM" src="https://github.com/user-attachments/assets/d9b11ac6-7493-4891-a471-7a77a1771d6b" />


- The shared `DashboardFooter` rendered as a hardcoded black gradient band, which clashed with the light theme at the bottom of the Overview page (reported by Brooke in Slack).
- Recolored it with the existing design tokens — `bg-background` + `border-border-primary` top border, `text-text-primary/secondary/tertiary` — so it sits flush on the page in both themes. Content (title, nav links, GitHub, copyright) is unchanged.
- Dropped the footer's own `.footer-noise` grain overlay (the global `noise-overlay` already covers the page) and the `min-h-[25vh]` band sizing.

Matches the brand guidelines' "ink on white" default; the tokens already encode the brand palette. Fixes the footer everywhere it appears (Overview, TTS, STT, Playground, Arena) and adapts to dark mode for free.

## Testing
- Verified in browser: Overview light desktop, TTS dashboard dark mode, Overview on 375px mobile viewport (links wrap cleanly).
- `pnpm typecheck` and `pnpm lint` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the shared dashboard footer to follow the active theme. The main changes are:

- Replaces the hardcoded dark gradient and text colors with design tokens.
- Adds a theme-aware top border and background.
- Removes the footer-specific noise overlay and minimum-height band.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.
- The new classes map to existing theme tokens used throughout the application.
- The removed height, gradient, and local noise effects match the stated design change.

<sub>Reviews (1): Last reviewed commit: ["\[BENCH-504\] Restyle footer with theme to..."](https://github.com/coval-ai/benchmarks/commit/dfa32c665e2494df859bd9daa8da2d4222abbe9c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44955555)</sub>

<!-- /greptile_comment -->