### PR TITLE
Retire Cartesia sonic-3

### DIFF
--- a/runner/src/coval_bench/api/routers/arena.py
+++ b/runner/src/coval_bench/api/routers/arena.py
@@ -69,6 +69,7 @@ from coval_bench.arena.prompts import EXAMPLE_PROMPTS
 from coval_bench.config import Settings
 from coval_bench.db.arena_store import ArenaStore
 from coval_bench.db.models import VoteOutcome, VoterType
+from coval_bench.registries import MODEL_REGISTRY, Benchmark, ModelStatus
 
 logger = structlog.get_logger("coval_bench.api")
 
@@ -97,6 +98,14 @@ _LEADERBOARD_SQL = """
     WHERE s.metric_name = %(metric)s AND s.domain = %(domain)s
     ORDER BY s.rating_elo DESC
 """
+
+# TTS models the site hides (retired/pending). Their votes still feed the rating
+# fit, but boards computed before a retirement must not keep showing them.
+_HIDDEN_TTS_MODELS = frozenset(
+    (m.provider, m.model)
+    for m in MODEL_REGISTRY
+    if m.benchmark is Benchmark.TTS and m.status in (ModelStatus.RETIRED, ModelStatus.PENDING)
+)
 
 
 def _is_authenticated_labeler(provided: str | None, settings: Settings) -> bool:
@@ -245,7 +254,11 @@ async def get_arena_leaderboard(
         rows = await conn.execute(_LEADERBOARD_SQL, {"metric": metric, "domain": domain})
         board = await rows.fetchall()
 
-    entries = [LeaderboardEntryOut.model_validate(r) for r in board]
+    entries = [
+        LeaderboardEntryOut.model_validate(r)
+        for r in board
+        if (r["provider"], r["model"]) not in _HIDDEN_TTS_MODELS
+    ]
     capture_api_event(
         posthog_client,
         "arena_leaderboard_queried",

--- a/runner/src/coval_bench/registries/models.py
+++ b/runner/src/coval_bench/registries/models.py
@@ -417,9 +417,8 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         provider="cartesia",
         model="sonic-3",
         voice="f786b574-daa5-4673-aa0c-cbe3e8534c02",
-        voices=("f786b574-daa5-4673-aa0c-cbe3e8534c02", "a5136bf9-224c-4d76-b823-52bd5efcffcc"),
         tags=(_REALTIME, _MULTI, _CLONE, _EMOTION, _STREAM),
-        status=_ACTIVE,
+        status=_RETIRED,
     ),
     RegisteredModel(
         benchmark=_TTS,

--- a/runner/tests/api/test_arena.py
+++ b/runner/tests/api/test_arena.py
@@ -334,7 +334,7 @@ async def test_leaderboard_returns_latest_board_sorted(
     await _insert_snapshot(postgresql, computed_at=stale, provider="old", model="m", rating_elo=999)
     # The latest board: two models, inserted out of rank order.
     await _insert_snapshot(
-        postgresql, computed_at=latest, provider="cartesia", model="sonic-3", rating_elo=1480
+        postgresql, computed_at=latest, provider="cartesia", model="sonic-3.5", rating_elo=1480
     )
     await _insert_snapshot(
         postgresql, computed_at=latest, provider="elevenlabs", model="v2", rating_elo=1520
@@ -345,8 +345,24 @@ async def test_leaderboard_returns_latest_board_sorted(
     data = response.json()
     entries = data["entries"]
     assert len(entries) == 2
-    assert [e["model"] for e in entries] == ["v2", "sonic-3"]
+    assert [e["model"] for e in entries] == ["v2", "sonic-3.5"]
     assert data["methodology_version"] == "davidson-v1"
+
+
+async def test_leaderboard_hides_retired_models(client: AsyncClient, postgresql: Any) -> None:
+    """A board computed before a model was retired must not keep showing it."""
+    await _apply_arena_schema(_make_db_url(postgresql))
+    computed = datetime(2026, 6, 18, 12, 0, tzinfo=UTC)
+    await _insert_snapshot(
+        postgresql, computed_at=computed, provider="cartesia", model="sonic-3", rating_elo=1520
+    )
+    await _insert_snapshot(
+        postgresql, computed_at=computed, provider="cartesia", model="sonic-3.5", rating_elo=1480
+    )
+
+    response = await client.get("/v1/arena/leaderboard", headers=_LABELER_HEADERS)
+    assert response.status_code == 200
+    assert [e["model"] for e in response.json()["entries"]] == ["sonic-3.5"]
 
 
 async def test_leaderboard_domain_filter(client: AsyncClient, postgresql: Any) -> None:
@@ -357,7 +373,7 @@ async def test_leaderboard_domain_filter(client: AsyncClient, postgresql: Any) -
         postgresql, computed_at=computed, domain="all", provider="elevenlabs", model="v2"
     )
     await _insert_snapshot(
-        postgresql, computed_at=computed, domain="support", provider="cartesia", model="sonic-3"
+        postgresql, computed_at=computed, domain="support", provider="cartesia", model="sonic-3.5"
     )
 
     support = await client.get(
@@ -365,7 +381,7 @@ async def test_leaderboard_domain_filter(client: AsyncClient, postgresql: Any) -
     )
     assert support.status_code == 200
     assert support.json()["domain"] == "support"
-    assert [e["model"] for e in support.json()["entries"]] == ["sonic-3"]
+    assert [e["model"] for e in support.json()["entries"]] == ["sonic-3.5"]
 
     default = await client.get("/v1/arena/leaderboard", headers=_LABELER_HEADERS)
     assert [e["model"] for e in default.json()["entries"]] == ["v2"]
@@ -388,7 +404,7 @@ async def test_leaderboard_latest_is_scoped_per_metric(
         computed_at=datetime(2026, 6, 17, 12, 0, tzinfo=UTC),
         metric_name="clarity",
         provider="cartesia",
-        model="sonic-3",
+        model="sonic-3.5",
     )
 
     response = await client.get(
@@ -397,7 +413,7 @@ async def test_leaderboard_latest_is_scoped_per_metric(
     assert response.status_code == 200
     data = response.json()
     assert data["metric"] == "clarity"
-    assert [e["model"] for e in data["entries"]] == ["sonic-3"]
+    assert [e["model"] for e in data["entries"]] == ["sonic-3.5"]
 
 
 async def test_leaderboard_does_not_mix_methodology_versions(
@@ -418,7 +434,7 @@ async def test_leaderboard_does_not_mix_methodology_versions(
         computed_at=shared,
         methodology_version="davidson-v2",
         provider="cartesia",
-        model="sonic-3",
+        model="sonic-3.5",
     )
 
     response = await client.get("/v1/arena/leaderboard", headers=_LABELER_HEADERS)
@@ -426,7 +442,7 @@ async def test_leaderboard_does_not_mix_methodology_versions(
     data = response.json()
     # One board only: the tiebreaker picks davidson-v2, so v1's row is excluded.
     assert data["methodology_version"] == "davidson-v2"
-    assert [e["model"] for e in data["entries"]] == ["sonic-3"]
+    assert [e["model"] for e in data["entries"]] == ["sonic-3.5"]
 
 
 async def test_locked_reads_are_404_without_key(client: AsyncClient, postgresql: Any) -> None:

--- a/web/lib/config/colors.ts
+++ b/web/lib/config/colors.ts
@@ -37,7 +37,6 @@ export const modelColors: Record<string, string> = {
   "grok-stt": "#844da2",
 
   // Cartesia — blue (TTS sonic + STT ink).
-  "sonic-3": "#80b3fe",
   "sonic-3.5": "#5e93e1",
   "ink-2": "#3b6eb9",
 

--- a/web/lib/playground/providers.ts
+++ b/web/lib/playground/providers.ts
@@ -68,11 +68,11 @@ export const ttsModels: TtsModelConfig[] = [
     enabled: true
   },
   {
-    id: "cartesia:sonic-3:default",
+    id: "cartesia:sonic-3.5:default",
     provider: "cartesia",
-    label: "Sonic 3",
-    model: "sonic-3",
-    voice: "f786b574-daa5-4673-aa0c-cbe3e8534c02",
+    label: "Sonic 3.5",
+    model: "sonic-3.5",
+    voice: "db6b0ed5-d5d3-463d-ae85-518a07d3c2b4",
     enabled: true
   },
   {

--- a/web/lib/utils/formatters.ts
+++ b/web/lib/utils/formatters.ts
@@ -99,7 +99,6 @@ export function normalizeModelName(modelKey: string): string {
     eleven_flash_v2_5: "Flash v2.5",
     eleven_turbo_v2_5: "Turbo v2.5",
     eleven_v3: "v3",
-    "sonic-3": "Sonic 3",
     "sonic-3.5": "Sonic 3.5",
     "aura-2-thalia-en": "Aura 2",
     arcana: "Arcana",


### PR DESCRIPTION
Registry status flips to retired, so it leaves the dashboards, the run schedule, and arena pairing. The arena leaderboard now drops retired/pending models from boards computed before the retirement. Playground slot moves to sonic-3.5.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR retires Cartesia Sonic 3 and moves active surfaces to Sonic 3.5. The main changes are:

- Marks Sonic 3 as retired in the model registry.
- Hides retired and pending TTS models from arena leaderboards.
- Updates the playground model and voice to Sonic 3.5.
- Removes obsolete Sonic 3 display mappings and updates arena tests.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.
- The Sonic 3.5 model and voice identifiers match across the registry and playground.
- Historical leaderboard filtering follows the registry status and preserves board ordering.

<sub>Reviews (1): Last reviewed commit: ["Retire Cartesia sonic-3"](https://github.com/coval-ai/benchmarks/commit/94194714062f6bd8722ec7befa6c0f5d5d375c97) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44966121)</sub>

<!-- /greptile_comment -->