### PR TITLE
[BENCH-505] Make chart legend models clickable to filter

### DIFF
--- a/web/components/layout/FacetFilter.tsx
+++ b/web/components/layout/FacetFilter.tsx
@@ -44,6 +44,7 @@ const FacetFilter: React.FC = () => {
             {group.options.map((option) => {
               const fill = option.color ?? null;
               const fg = fill ? getReadableTextColor(fill) : null;
+              const ringed = option.active || option.implied;
               return (
                 <button
                   key={option.value}
@@ -56,7 +57,7 @@ const FacetFilter: React.FC = () => {
                           backgroundColor: fill,
                           color: fg!,
                           borderColor: "transparent",
-                          boxShadow: option.active
+                          boxShadow: ringed
                             ? "0 0 0 2px var(--color-surface-primary), 0 0 0 3.5px var(--color-text-primary)"
                             : undefined,
                         }

--- a/web/components/visualizations/TimelineChart.tsx
+++ b/web/components/visualizations/TimelineChart.tsx
@@ -41,11 +41,16 @@ interface LegendEntry {
 
 // Custom legend: names are rendered in black (recharts colors them per-series
 // by default), and items fill top-to-bottom within each column so the list
-// reads alphabetically down each column rather than across rows.
+// reads alphabetically down each column rather than across rows. Each entry
+// toggles its model in and out of the chart, like a Filters sidebar chip.
 const TimelineLegend: React.FC<{
   payload?: LegendEntry[];
+  /** Zoom-clipped series: dimmed and pushed to the end. */
   dimmedKeys?: Set<string>;
-}> = ({ payload, dimmedKeys }) => (
+  /** Deselected models: dimmed in place so entries never move under the pointer mid-toggle. */
+  hiddenKeys?: Set<string>;
+  onToggle?: (dataKey: string) => void;
+}> = ({ payload, dimmedKeys, hiddenKeys, onToggle }) => (
   <ul className="columns-2 gap-x-4 px-2 pt-5 sm:columns-3 sm:gap-x-6 lg:columns-4">
     {[...(payload ?? [])]
       .sort(
@@ -54,19 +59,27 @@ const TimelineLegend: React.FC<{
           Number(dimmedKeys?.has(b.dataKey ?? "") ?? 0)
       )
       .map((entry) => {
-        const dimmed = dimmedKeys?.has(entry.dataKey ?? "");
+        const hidden = hiddenKeys?.has(entry.dataKey ?? "");
+        const dimmed = dimmedKeys?.has(entry.dataKey ?? "") || hidden;
         return (
           <li
             key={entry.dataKey ?? entry.value}
             data-dimmed={dimmed || undefined}
-            className={`mb-1.5 flex items-start gap-1.5 text-xs leading-tight text-text-primary break-inside-avoid${dimmed ? " opacity-35" : ""}`}
+            className="mb-0.5 break-inside-avoid"
           >
-            <span
-              className="mt-0.5 inline-block w-3 h-3 shrink-0 rounded-[2px]"
-              style={{ backgroundColor: entry.color }}
-              aria-hidden="true"
-            />
-            <span>{entry.value}</span>
+            <button
+              type="button"
+              aria-pressed={!hidden}
+              onClick={() => onToggle?.(entry.dataKey ?? "")}
+              className={`flex w-full items-start gap-1.5 rounded-md px-1 py-2 text-left text-xs leading-tight text-text-primary transition-opacity hover:bg-surface-toggle-inactive focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-text-tertiary/40 sm:py-1${dimmed ? " opacity-35" : ""}`}
+            >
+              <span
+                className="mt-0.5 inline-block w-3 h-3 shrink-0 rounded-[2px]"
+                style={{ backgroundColor: entry.color }}
+                aria-hidden="true"
+              />
+              <span>{entry.value}</span>
+            </button>
           </li>
         );
       })}
@@ -202,6 +215,8 @@ const TimelineChart: React.FC = () => {
     getAvgLatencyMs,
     activeMetric: metric,
     dataTimeWindow,
+    legendModels,
+    toggleLegendModel,
   } = useDashboard();
   const trackChartHover = useChartHoverTracking("timeline");
 
@@ -705,12 +720,19 @@ const TimelineChart: React.FC = () => {
   // The legend is rendered as a sibling BELOW the chart (not a recharts
   // <Legend>), so the plot keeps the full card height instead of being
   // squeezed — a 20-series legend inside the chart left only ~40px to plot on
-  // mobile. Build the payload the custom legend expects from the plotted models.
-  const legendPayload: LegendEntry[] = modelsWithData.map((model) => ({
+  // mobile. Its universe is every data-backed model, chip-style: filtered-out
+  // models stay listed but dim, and a click toggles them back in.
+  const legendModelList = getModelsWithTimelineData(metric, legendModels);
+  const legendPayload: LegendEntry[] = legendModelList.map((model) => ({
     value: formatChartLabel(model, getProviderForModel(model)),
     color: getModelColor(model),
     dataKey: `${model}_value`,
   }));
+  const plottedKeys = new Set(modelsWithData);
+  const legendHiddenKeys = new Set<string>();
+  for (const model of legendModelList) {
+    if (!plottedKeys.has(model)) legendHiddenKeys.add(`${model}_value`);
+  }
 
   // Mobile has no hover cursor, so a vertical playhead marks the instant being
   // scrubbed or pinned — the timestamp both the compact readout and the pinned
@@ -1113,11 +1135,15 @@ const TimelineChart: React.FC = () => {
               );
             })()}
         </div>
-        {modelsWithData.length > 1 && (
+        {legendPayload.length > 0 && (
           <div data-chart-legend>
             <TimelineLegend
               payload={legendPayload}
               dimmedKeys={dimmedLegendKeys}
+              hiddenKeys={legendHiddenKeys}
+              onToggle={(dataKey) =>
+                toggleLegendModel(dataKey.replace(/_value$/, ""))
+              }
             />
           </div>
         )}

--- a/web/hooks/useChartData.ts
+++ b/web/hooks/useChartData.ts
@@ -450,22 +450,19 @@ export function useChartData({
     [getCurrentTimeWindow, getTimelineData]
   );
 
-  /** Models that have at least one plotted point in the current timeline window. */
+  /** Of `models` (default: the selected ones), those with at least one point in the current timeline window. */
   const getModelsWithTimelineData = useCallback(
-    (metric: string): string[] => {
+    (metric: string, models: string[] = selectedModels): string[] => {
       const [windowStart, windowEnd] = getCurrentTimeWindow();
-      const windowed = getTimelineData(metric).filter(
-        (point) => point.timestamp >= windowStart && point.timestamp <= windowEnd
-      );
-      return selectedModels.filter((model) =>
-        windowed.some(
-          (point) =>
-            point[`${model}_value`] !== undefined &&
-            point[`${model}_value`] !== null
-        )
+      const byModel = timelineByMetricModel[metric] ?? {};
+      return models.filter((model) =>
+        Object.keys(byModel[model] ?? {}).some((ts) => {
+          const t = Number(ts);
+          return t >= windowStart && t <= windowEnd;
+        })
       );
     },
-    [selectedModels, getCurrentTimeWindow, getTimelineData]
+    [selectedModels, getCurrentTimeWindow, timelineByMetricModel]
   );
 
   return {

--- a/web/hooks/useDashboardState.tsx
+++ b/web/hooks/useDashboardState.tsx
@@ -159,6 +159,37 @@ export function useDashboardState(page: "tts" | "stt" | "s2s") {
   // and write this mirror of the latest selection: every transition and its
   // analytics see the same up-to-date value instead of a stale render's state.
   const selectedFacetsRef = useRef(selectedFacets);
+
+  // A data refresh (e.g. a different time window) can drop models a legend
+  // selection references; prune them — and reset entirely if nothing would
+  // plot — so a stale selection can never pin the charts empty.
+  useEffect(() => {
+    const universe = new Set(Object.values(dataBackedByProvider).flat());
+    if (universe.size === 0) return;
+    const current = selectedFacetsRef.current;
+    let next = current;
+    for (const category of [MODEL_FACET_CATEGORY, MODEL_EXCLUDE_CATEGORY]) {
+      const values = next[category];
+      if (!values) continue;
+      const kept = values.filter((key) => universe.has(key));
+      if (kept.length !== values.length) {
+        next = { ...next };
+        if (kept.length > 0) next[category] = kept;
+        else delete next[category];
+      }
+    }
+    if (
+      hasAnySelection(next) &&
+      Object.keys(filterModelsByFacets(dataBackedByProvider, tagIndex, next))
+        .length === 0
+    ) {
+      next = {};
+    }
+    if (next !== current) {
+      selectedFacetsRef.current = next;
+      setSelectedFacets(next);
+    }
+  }, [dataBackedByProvider, tagIndex]);
   const modelsByProvider = useMemo(
     () => filterModelsByFacets(dataBackedByProvider, tagIndex, selectedFacets),
     [dataBackedByProvider, tagIndex, selectedFacets]

--- a/web/hooks/useDashboardState.tsx
+++ b/web/hooks/useDashboardState.tsx
@@ -257,10 +257,13 @@ export function useDashboardState(page: "tts" | "stt" | "s2s") {
       capturePostHogEvent(POSTHOG_EVENTS.dashboardFacetChanged, {
         surface: `${page}_dashboard`,
         mode: page,
-        action:
-          removing ||
-          (next[MODEL_FACET_CATEGORY] ?? []).length <
-            (current[MODEL_FACET_CATEGORY] ?? []).length
+        // A toggle that trips the empty-chart reset reports "clear", matching
+        // the state it actually produced.
+        action: !removing && !hasAnySelection(next)
+          ? "clear"
+          : removing ||
+              (next[MODEL_FACET_CATEGORY] ?? []).length <
+                (current[MODEL_FACET_CATEGORY] ?? []).length
             ? "remove"
             : "add",
         category,
@@ -333,7 +336,11 @@ export function useDashboardState(page: "tts" | "stt" | "s2s") {
       capturePostHogEvent(POSTHOG_EVENTS.dashboardFacetChanged, {
         surface: `${page}_dashboard`,
         mode: page,
-        action: removing ? "remove" : "add",
+        action: !removing && !hasAnySelection(next)
+          ? "clear"
+          : removing
+            ? "remove"
+            : "add",
         category,
         value: model,
         active_facet_count: Object.values(next).reduce((n, v) => n + v.length, 0),

--- a/web/hooks/useDashboardState.tsx
+++ b/web/hooks/useDashboardState.tsx
@@ -23,6 +23,8 @@ import {
   hasAnySelection,
   restrictToModelKeys,
   toggleFacetValue,
+  MODEL_FACET_CATEGORY,
+  MODEL_EXCLUDE_CATEGORY,
   type FacetSelection,
 } from "@/lib/utils/facets";
 import { capturePostHogEvent } from "@/lib/posthog/client";
@@ -160,21 +162,77 @@ export function useDashboardState(page: "tts" | "stt" | "s2s") {
     () => hasAnySelection(selectedFacets),
     [selectedFacets]
   );
+  // Pure selection transition shared by chip clicks and legend toggles. It is
+  // applied inside functional setState below so rapid successive clicks never
+  // compute from a stale render's state.
+  const applyFacetToggle = useCallback(
+    (current: FacetSelection, category: string, value: string): FacetSelection => {
+      const removing = (current[category] ?? []).includes(value);
+      const isModelCategory =
+        category === MODEL_FACET_CATEGORY || category === MODEL_EXCLUDE_CATEGORY;
+      const taggedWith = (key: string) =>
+        (tagIndex.get(key) ?? []).some(
+          (t) => t.category === category && t.value === value
+        );
+      const picks = current[MODEL_FACET_CATEGORY] ?? [];
+      // A provider chip ringed only by legend picks reads as "on": clicking it
+      // clears those picks rather than layering the tag filter on top.
+      const clearingPicks =
+        !removing &&
+        !!tagCategories.find((c) => c.category === category)?.provider_valued &&
+        picks.some(taggedWith);
+      let next: FacetSelection;
+      if (clearingPicks) {
+        next = { ...current };
+        const kept = picks.filter((k) => !taggedWith(k));
+        if (kept.length > 0) next[MODEL_FACET_CATEGORY] = kept;
+        else delete next[MODEL_FACET_CATEGORY];
+      } else {
+        next = toggleFacetValue(current, category, value);
+        if (removing && !isModelCategory) {
+          // Dropping a tag filter also forgets the per-model hides beneath it.
+          const excludes = (next[MODEL_EXCLUDE_CATEGORY] ?? []).filter(
+            (k) => !taggedWith(k)
+          );
+          if (excludes.length > 0) next[MODEL_EXCLUDE_CATEGORY] = excludes;
+          else delete next[MODEL_EXCLUDE_CATEGORY];
+        }
+      }
+      // Toggling your way down to zero models resets the selection: the chart
+      // reloads with everything rather than sitting empty.
+      if (
+        Object.keys(dataBackedByProvider).length > 0 &&
+        Object.keys(filterModelsByFacets(dataBackedByProvider, tagIndex, next))
+          .length === 0
+      ) {
+        next = {};
+      }
+      return next;
+    },
+    [tagIndex, tagCategories, dataBackedByProvider]
+  );
   const toggleFacet = useCallback(
     (category: string, value: string) => {
+      setSelectedFacets((current) => applyFacetToggle(current, category, value));
+      // Analytics reads the render-time state; only the transition above must
+      // be race-proof.
       const removing = (selectedFacets[category] ?? []).includes(value);
-      const next = toggleFacetValue(selectedFacets, category, value);
-      setSelectedFacets(next);
+      const next = applyFacetToggle(selectedFacets, category, value);
       capturePostHogEvent(POSTHOG_EVENTS.dashboardFacetChanged, {
         surface: `${page}_dashboard`,
         mode: page,
-        action: removing ? "remove" : "add",
+        action:
+          removing ||
+          (next[MODEL_FACET_CATEGORY] ?? []).length <
+            (selectedFacets[MODEL_FACET_CATEGORY] ?? []).length
+            ? "remove"
+            : "add",
         category,
         value,
         active_facet_count: Object.values(next).reduce((n, v) => n + v.length, 0),
       });
     },
-    [selectedFacets, page]
+    [applyFacetToggle, selectedFacets, page]
   );
   const clearFacets = useCallback(() => {
     if (!hasAnySelection(selectedFacets)) return;
@@ -191,6 +249,61 @@ export function useDashboardState(page: "tts" | "stt" | "s2s") {
   const selectedModels = useMemo(
     () => Object.values(modelsByProvider).flat(),
     [modelsByProvider]
+  );
+
+  // Legend universe: every data-backed model, like the chips panel — filtering
+  // dims legend entries rather than hiding them.
+  const legendModels = useMemo(
+    () => Object.values(dataBackedByProvider).flat(),
+    [dataBackedByProvider]
+  );
+
+  // A legend click toggles exactly what the user sees: un-pick a picked model,
+  // re-show an excluded one, hide a line an active tag filter covers, or —
+  // with no tag filter — pick the model to isolate it. Classification also
+  // runs inside the functional update so it always sees the freshest state.
+  const classifyLegendToggle = useCallback(
+    (current: FacetSelection, model: string): string => {
+      if ((current[MODEL_FACET_CATEGORY] ?? []).includes(model))
+        return MODEL_FACET_CATEGORY;
+      if ((current[MODEL_EXCLUDE_CATEGORY] ?? []).includes(model))
+        return MODEL_EXCLUDE_CATEGORY;
+      const hasTagFilter = Object.entries(current).some(
+        ([c, v]) =>
+          c !== MODEL_FACET_CATEGORY &&
+          c !== MODEL_EXCLUDE_CATEGORY &&
+          v.length > 0
+      );
+      const shown = Object.values(
+        filterModelsByFacets(dataBackedByProvider, tagIndex, current)
+      )
+        .flat()
+        .includes(model);
+      return hasTagFilter && shown
+        ? MODEL_EXCLUDE_CATEGORY
+        : MODEL_FACET_CATEGORY;
+    },
+    [dataBackedByProvider, tagIndex]
+  );
+  const toggleLegendModel = useCallback(
+    (model: string) => {
+      setSelectedFacets((current) =>
+        applyFacetToggle(current, classifyLegendToggle(current, model), model)
+      );
+      const category = classifyLegendToggle(selectedFacets, model);
+      const next = applyFacetToggle(selectedFacets, category, model);
+      capturePostHogEvent(POSTHOG_EVENTS.dashboardFacetChanged, {
+        surface: `${page}_dashboard`,
+        mode: page,
+        action: (selectedFacets[category] ?? []).includes(model)
+          ? "remove"
+          : "add",
+        category,
+        value: model,
+        active_facet_count: Object.values(next).reduce((n, v) => n + v.length, 0),
+      });
+    },
+    [applyFacetToggle, classifyLegendToggle, selectedFacets, page]
   );
 
   const loading = aggregatesQuery.isLoading || providersQuery.isLoading;
@@ -455,6 +568,8 @@ export function useDashboardState(page: "tts" | "stt" | "s2s") {
     toggleFacet,
     clearFacets,
     hasActiveFacets,
+    legendModels,
+    toggleLegendModel,
 
     // UI state
     isMobile,

--- a/web/hooks/useDashboardState.tsx
+++ b/web/hooks/useDashboardState.tsx
@@ -9,6 +9,7 @@ import {
   useCallback,
   useDeferredValue,
   useEffect,
+  useRef,
 } from "react";
 import { useChartData } from "@/hooks/useChartData";
 import { useMobileDetection } from "@/hooks/useMobileDetection";
@@ -154,6 +155,10 @@ export function useDashboardState(page: "tts" | "stt" | "s2s") {
   }, [allModelsByProvider, modelStats]);
 
   const [selectedFacets, setSelectedFacets] = useState<FacetSelection>({});
+  // Rapid clicks dispatch before React re-renders, so the handlers below read
+  // and write this mirror of the latest selection: every transition and its
+  // analytics see the same up-to-date value instead of a stale render's state.
+  const selectedFacetsRef = useRef(selectedFacets);
   const modelsByProvider = useMemo(
     () => filterModelsByFacets(dataBackedByProvider, tagIndex, selectedFacets),
     [dataBackedByProvider, tagIndex, selectedFacets]
@@ -162,8 +167,8 @@ export function useDashboardState(page: "tts" | "stt" | "s2s") {
     () => hasAnySelection(selectedFacets),
     [selectedFacets]
   );
-  // Pure selection transition shared by chip clicks and legend toggles. It is
-  // applied inside functional setState below so rapid successive clicks never
+  // Pure selection transition shared by chip clicks and legend toggles; the
+  // handlers below apply it to the ref mirror so rapid successive clicks never
   // compute from a stale render's state.
   const applyFacetToggle = useCallback(
     (current: FacetSelection, category: string, value: string): FacetSelection => {
@@ -213,18 +218,18 @@ export function useDashboardState(page: "tts" | "stt" | "s2s") {
   );
   const toggleFacet = useCallback(
     (category: string, value: string) => {
-      setSelectedFacets((current) => applyFacetToggle(current, category, value));
-      // Analytics reads the render-time state; only the transition above must
-      // be race-proof.
-      const removing = (selectedFacets[category] ?? []).includes(value);
-      const next = applyFacetToggle(selectedFacets, category, value);
+      const current = selectedFacetsRef.current;
+      const removing = (current[category] ?? []).includes(value);
+      const next = applyFacetToggle(current, category, value);
+      selectedFacetsRef.current = next;
+      setSelectedFacets(next);
       capturePostHogEvent(POSTHOG_EVENTS.dashboardFacetChanged, {
         surface: `${page}_dashboard`,
         mode: page,
         action:
           removing ||
           (next[MODEL_FACET_CATEGORY] ?? []).length <
-            (selectedFacets[MODEL_FACET_CATEGORY] ?? []).length
+            (current[MODEL_FACET_CATEGORY] ?? []).length
             ? "remove"
             : "add",
         category,
@@ -232,17 +237,18 @@ export function useDashboardState(page: "tts" | "stt" | "s2s") {
         active_facet_count: Object.values(next).reduce((n, v) => n + v.length, 0),
       });
     },
-    [applyFacetToggle, selectedFacets, page]
+    [applyFacetToggle, page]
   );
   const clearFacets = useCallback(() => {
-    if (!hasAnySelection(selectedFacets)) return;
+    if (!hasAnySelection(selectedFacetsRef.current)) return;
+    selectedFacetsRef.current = {};
     setSelectedFacets({});
     capturePostHogEvent(POSTHOG_EVENTS.dashboardFacetChanged, {
       surface: `${page}_dashboard`,
       mode: page,
       action: "clear",
     });
-  }, [selectedFacets, page]);
+  }, [page]);
 
   // The facet filter is the only selector now, and its universe is already the
   // data-backed models, so everything still visible after filtering is plotted.
@@ -260,8 +266,8 @@ export function useDashboardState(page: "tts" | "stt" | "s2s") {
 
   // A legend click toggles exactly what the user sees: un-pick a picked model,
   // re-show an excluded one, hide a line an active tag filter covers, or —
-  // with no tag filter — pick the model to isolate it. Classification also
-  // runs inside the functional update so it always sees the freshest state.
+  // with no tag filter — pick the model to isolate it. Classification reads
+  // the ref mirror so it always sees the freshest state.
   const classifyLegendToggle = useCallback(
     (current: FacetSelection, model: string): string => {
       if ((current[MODEL_FACET_CATEGORY] ?? []).includes(model))
@@ -287,23 +293,22 @@ export function useDashboardState(page: "tts" | "stt" | "s2s") {
   );
   const toggleLegendModel = useCallback(
     (model: string) => {
-      setSelectedFacets((current) =>
-        applyFacetToggle(current, classifyLegendToggle(current, model), model)
-      );
-      const category = classifyLegendToggle(selectedFacets, model);
-      const next = applyFacetToggle(selectedFacets, category, model);
+      const current = selectedFacetsRef.current;
+      const category = classifyLegendToggle(current, model);
+      const removing = (current[category] ?? []).includes(model);
+      const next = applyFacetToggle(current, category, model);
+      selectedFacetsRef.current = next;
+      setSelectedFacets(next);
       capturePostHogEvent(POSTHOG_EVENTS.dashboardFacetChanged, {
         surface: `${page}_dashboard`,
         mode: page,
-        action: (selectedFacets[category] ?? []).includes(model)
-          ? "remove"
-          : "add",
+        action: removing ? "remove" : "add",
         category,
         value: model,
         active_facet_count: Object.values(next).reduce((n, v) => n + v.length, 0),
       });
     },
-    [applyFacetToggle, classifyLegendToggle, selectedFacets, page]
+    [applyFacetToggle, classifyLegendToggle, page]
   );
 
   const loading = aggregatesQuery.isLoading || providersQuery.isLoading;

--- a/web/lib/utils/facets.ts
+++ b/web/lib/utils/facets.ts
@@ -10,12 +10,23 @@ import { getModelColor } from "./colors";
 /** category -> selected values. Within a category values OR; across categories they AND. */
 export type FacetSelection = Record<string, string[]>;
 
+/**
+ * Reserved selection categories for individual models (the chart legend
+ * toggles them). Not API tag categories, so they never render as sidebar chip
+ * groups; a model matches them by its own composite key rather than a tag.
+ * Picks show a model on top of the tag filter; excludes hide one from it.
+ */
+export const MODEL_FACET_CATEGORY = "model";
+export const MODEL_EXCLUDE_CATEGORY = "model_hidden";
+
 export interface FacetOption {
   value: string;
   label: string;
   count: number;
   maxCount: number;
   active: boolean;
+  /** A legend-selected model carries this tag, so the chip rings without being toggled itself. */
+  implied: boolean;
   color?: string;
 }
 
@@ -83,16 +94,31 @@ export function restrictToModelKeys(
   return out;
 }
 
-/** Narrow modelsByProvider to the models passing the current facet selection. */
+/**
+ * Narrow modelsByProvider to the models passing the current facet selection.
+ * Legend model picks broaden an active tag filter (union) but stand alone
+ * when no tag category is selected; excludes hide single models from either.
+ */
 export function filterModelsByFacets(
   modelsByProvider: ModelsByProvider,
   tagIndex: Map<string, ModelTagOut[]>,
   selected: FacetSelection
 ): ModelsByProvider {
   if (!hasAnySelection(selected)) return modelsByProvider;
+  const {
+    [MODEL_FACET_CATEGORY]: picks = [],
+    [MODEL_EXCLUDE_CATEGORY]: excludes = [],
+    ...tagSelected
+  } = selected;
+  const hasTags = hasAnySelection(tagSelected);
   const out: ModelsByProvider = {};
   for (const [provider, keys] of Object.entries(modelsByProvider)) {
-    const kept = keys.filter((key) => matchesSelection(tagIndex.get(key) ?? [], selected));
+    const kept = keys.filter((key) => {
+      if (excludes.includes(key)) return false;
+      if (picks.includes(key)) return true;
+      if (hasTags) return matchesSelection(tagIndex.get(key) ?? [], tagSelected);
+      return picks.length === 0;
+    });
     if (kept.length > 0) out[provider] = kept;
   }
   return out;
@@ -113,6 +139,14 @@ export function buildFacetGroups(
   normalizeProvider: (name: string) => string
 ): FacetGroup[] {
   const visibleKeys = Object.values(modelsByProvider).flat();
+  // Counts and active states follow only the tag categories; legend model
+  // picks surface solely as the implied ring on provider chips.
+  const modelSelection = selected[MODEL_FACET_CATEGORY] ?? [];
+  const tagSelected = Object.fromEntries(
+    Object.entries(selected).filter(
+      ([c]) => c !== MODEL_FACET_CATEGORY && c !== MODEL_EXCLUDE_CATEGORY
+    )
+  );
   const groups: FacetGroup[] = [];
 
   for (const { category, label, provider_valued } of tagCategories) {
@@ -124,7 +158,7 @@ export function buildFacetGroups(
     }
     if (valueLabels.size < 2) continue;
 
-    const others: FacetSelection = { ...selected, [category]: [] };
+    const others: FacetSelection = { ...tagSelected, [category]: [] };
     const options: FacetOption[] = [...valueLabels.entries()]
       .map(([value, valueLabel]) => {
         const matching = visibleKeys.filter((key) =>
@@ -145,7 +179,10 @@ export function buildFacetGroups(
           label,
           count,
           maxCount: matching.length,
-          active: (selected[category] ?? []).includes(value),
+          active: (tagSelected[category] ?? []).includes(value),
+          implied:
+            !!provider_valued &&
+            modelSelection.some((key) => matching.includes(key)),
           color,
         };
       })


### PR DESCRIPTION
## Summary
<img width="1653" height="698" alt="Screenshot 2026-07-16 at 5 42 32 PM" src="https://github.com/user-attachments/assets/83646b3b-c996-4a89-82bb-8ef46e7bd6b4" />

Legend entries below the timeline chart are now buttons that toggle model visibility, behaving consistently with the Filters sidebar chips.

**Interaction model**
- No filter active: clicking a legend model isolates it; further clicks accumulate (OR); unclicking the last pick restores all models.
- Filter active: clicking an uncovered model adds it on top of the filter (union); clicking a covered model hides just that line, and clicking it again re-shows it.
- Picked models show the black selection ring on their Host/Lab chips; clicking a ringed chip clears those picks instead of stacking a filter.
- Unselecting a filter chip also forgets the per-model hides beneath it.
- Any interaction that would leave the chart empty resets the selection so the chart reloads with everything.

**Legend behavior**
- Lists every data-backed model like the chips panel — filtered-out models dim in place (stable order, nothing moves under the pointer mid-toggle) rather than disappearing.
- Stays visible even when only one model is plotted, so the line is always identifiable.
- Larger touch targets on mobile (py-2 below sm), tap-to-toggle works without hover.

**Implementation**
- Reserved `model` (picks) and `model_hidden` (excludes) selection categories ride the existing facet machinery in `facets.ts`; shown = (filter matches ∪ picks) − hides.
- `toggleLegendModel` classifies each click (un-pick / re-show / hide / isolate) against the freshest state.
- All selection transitions run inside functional setState, so rapid successive clicks can't compute from a stale render's state.
- Chip counts remain driven by tag filters only; PNG export keeps working off the same legend DOM.

## Test plan
- [x] Click legend model with no filter → isolates; second click restores all
- [x] Accumulate multiple picks (OR); unpick individually
- [x] Filter (Host) + pick outside model → union (filter's lines + picked line), chip stays active
- [x] Filter + click covered model → hides that line only; click again re-shows
- [x] Ringed provider chip click clears its picks
- [x] Unselect chip with hidden models beneath → hides forgotten, no residue
- [x] Unselect everything individually (incl. same-tick click bursts) → resets to full view
- [x] Clear button resets picks, hides, and filters
- [x] Mobile: tap targets ≥31px, legend toggles by tap, sheet chips consistent
- [x] tsc + eslint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes timeline chart legends interactive for model filtering. The main changes are:

- Clickable legend entries for picking, hiding, and restoring models.
- Shared facet logic for combining tag filters, model picks, and exclusions.
- Stable dimmed legend entries for filtered-out models.
- Ref-backed state transitions and matching analytics for rapid interactions.
- Selection cleanup when refreshed data removes referenced models.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- Rapid chip and legend interactions now read and update the same current selection.
- Empty-chart resets are reported as clear actions.
- No blocking issues were found in the updated code.

<sub>Reviews (4): Last reviewed commit: ["Prune stale legend selections when the d..."](https://github.com/coval-ai/benchmarks/commit/40a432f958060047c72a0ca29c6106ad7d2ae092) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44970269)</sub>

<!-- /greptile_comment -->