### PR TITLE
[BENCH-506] Expand overview page: add About Metrics & Methodology section

### DIFF
--- a/web/app/overview/overview-page-client.tsx
+++ b/web/app/overview/overview-page-client.tsx
@@ -6,6 +6,7 @@
 import DashboardHeader from "@/components/layout/DashboardHeader";
 import DashboardFooter from "@/components/dashboard/DashboardFooter";
 import OverviewLeaderboards from "@/components/overview/OverviewLeaderboards";
+import AboutMethodology from "@/components/overview/AboutMethodology";
 
 export function OverviewPageClient() {
   return (
@@ -27,19 +28,23 @@ export function OverviewPageClient() {
       />
       <DashboardHeader />
 
-      <main className="relative z-10 mx-auto flex min-h-[90vh] w-full max-w-5xl flex-1 flex-col px-4 sm:px-6 pb-10 pt-[84px] md:pt-[96px]">
-        <h1 className="mx-auto max-w-xl text-balance text-center text-2xl font-medium leading-tight tracking-tight text-text-primary sm:text-3xl md:text-4xl">
-          Voice AI benchmarks in real world conditions.
-        </h1>
+      <main className="relative z-10 mx-auto flex w-full max-w-5xl flex-1 flex-col px-4 sm:px-6 pb-10 pt-[84px] md:pt-[96px]">
+        <div className="flex min-h-[calc(100vh-84px)] flex-col md:min-h-[calc(100vh-96px)]">
+          <h1 className="mx-auto max-w-xl text-balance text-center text-2xl font-medium leading-tight tracking-tight text-text-primary sm:text-3xl md:text-4xl">
+            Voice AI benchmarks in real world conditions.
+          </h1>
 
-        <p className="mx-auto mt-3 max-w-md text-pretty text-center text-base leading-snug text-text-secondary">
-          Measuring the accuracy, latency, and quality of text-to-speech and
-          speech-to-text models.
-        </p>
+          <p className="mx-auto mt-3 max-w-md text-pretty text-center text-base leading-snug text-text-secondary">
+            Measuring the accuracy, latency, and quality of text-to-speech and
+            speech-to-text models.
+          </p>
 
-        <div className="mt-6 md:mt-8">
-          <OverviewLeaderboards />
+          <div className="mt-6 md:mt-8">
+            <OverviewLeaderboards />
+          </div>
         </div>
+
+        <AboutMethodology />
       </main>
 
       <DashboardFooter />

--- a/web/app/overview/overview-page-client.tsx
+++ b/web/app/overview/overview-page-client.tsx
@@ -3,10 +3,38 @@
 
 "use client";
 
+import { useEffect, useState } from "react";
+import { ChevronDown } from "lucide-react";
 import DashboardHeader from "@/components/layout/DashboardHeader";
 import DashboardFooter from "@/components/dashboard/DashboardFooter";
 import OverviewLeaderboards from "@/components/overview/OverviewLeaderboards";
 import AboutMethodology from "@/components/overview/AboutMethodology";
+
+function ScrollHint() {
+  const [hidden, setHidden] = useState(false);
+  useEffect(() => {
+    const onScroll = () => setHidden(window.scrollY > 80);
+    onScroll();
+    window.addEventListener("scroll", onScroll, { passive: true });
+    return () => window.removeEventListener("scroll", onScroll);
+  }, []);
+  return (
+    <button
+      type="button"
+      aria-label="Scroll down to methodology"
+      onClick={() =>
+        document
+          .getElementById("about-methodology")
+          ?.scrollIntoView({ behavior: "smooth" })
+      }
+      className={`mx-auto mt-auto flex h-11 w-11 items-center justify-center pt-4 text-text-tertiary transition-opacity duration-300 hover:text-text-primary ${
+        hidden ? "pointer-events-none opacity-0" : "opacity-100"
+      }`}
+    >
+      <ChevronDown size={20} aria-hidden className="animate-bounce" />
+    </button>
+  );
+}
 
 export function OverviewPageClient() {
   return (
@@ -42,6 +70,8 @@ export function OverviewPageClient() {
           <div className="mt-6 md:mt-8">
             <OverviewLeaderboards />
           </div>
+
+          <ScrollHint />
         </div>
 
         <AboutMethodology />

--- a/web/components/overview/AboutMethodology.tsx
+++ b/web/components/overview/AboutMethodology.tsx
@@ -25,43 +25,48 @@ const SECTIONS: MethodologySection[] = [
     summary:
       "Frozen, versioned datasets spanning studio-quality read speech and spontaneous conversational audio.",
     terms: [
-      { code: "stt-v1", tag: "STT", name: "LibriSpeech test-clean", def: "50 studio-quality read utterances (CC-BY-4.0), the easy tier" },
-      { code: "stt-v3", tag: "STT", name: "Conversational clips", def: "897 spontaneous voice-agent turns from pipecat's stt-benchmark-data, the hard tier" },
+      { code: "clean", tag: "STT", name: "Clean read speech", def: "284 FLEURS clips, the undistorted control" },
+      { code: "accent", tag: "STT", name: "Accented speech", def: "845 clips spanning demographic accents" },
+      { code: "noisegap", tag: "STT", name: "Background noise", def: "284 clips with intermittent noise bursts" },
+      { code: "reverb", tag: "STT", name: "Reverberation", def: "284 clips with room echo" },
+      { code: "farfield", tag: "STT", name: "Far-field mic", def: "284 clips recorded at distance" },
+      { code: "clipping", tag: "STT", name: "Clipped audio", def: "284 clips with peak distortion" },
+      { code: "phonecodec", tag: "STT", name: "Phone codec", def: "284 clips through telephony compression" },
+      { code: "stt-v3", tag: "STT", name: "Conversational clips", def: "897 spontaneous voice-agent turns from pipecat's stt-benchmark-data" },
       { code: "tts-v1", tag: "TTS", name: "Text prompts", def: "30 short text inputs for synthesis" },
     ],
     details: [
-      "Speech-to-text runs both tiers each cycle: studio-quality read speech that most providers train on, and real conversational speech — fragments, fillers, prompted turns. Every clip is loudness-normalized to −20 dBFS RMS and pinned by SHA-256, so the audio a provider hears is byte-identical across runs.",
+      "Clean studio audio is what most speech-to-text providers train on, so almost everyone scores well on it. We test that too, but we don't stop there. We pull open-source datasets that cover the conditions real calls actually run into: accents, background noise, reverb, mic distance, clipping, and phone-line compression, plus spontaneous conversational turns full of the fragments and fillers of real speech. Every clip is loudness-normalized to −20 dBFS RMS and locked to a SHA-256 hash, so the audio a provider hears stays identical from one run to the next.",
       "Each scheduled run draws a random sample from its manifest and every model scores on that identical draw, so comparisons within a run are apples-to-apples while the full set is covered over time. Retired datasets stay published for historical reproducibility.",
     ],
   },
   {
     title: "How We Calculate Metrics",
     summary:
-      "Each board carries the metrics that matter for its modality, aggregated as percentiles over continuous evaluation cycles.",
+      "Each board carries the metrics that matter for its modality, reported as percentiles across every evaluation run.",
     terms: [
       { code: "TTFA", tag: "TTS", name: "Time to First Audio", def: "first audio chunk arrival plus any leading silence before the first audible sample" },
       { code: "TTFT", tag: "STT", name: "Time to First Token", def: "how quickly partial transcripts start streaming" },
       { code: "TTFS", tag: "STT", name: "Time to Final Segment", def: "from a shared VAD end-of-speech anchor to the final transcript" },
       { code: "WER", tag: "STT", name: "Word Error Rate", def: "scored after Whisper's EnglishTextNormalizer on both reference and hypothesis" },
-      { code: "V2V", tag: "S2S", name: "Voice-to-Voice", def: "end of user speech to the first frame of agent audio, from the recorded conversation" },
     ],
     details: [
-      "Latency metrics measure what a voice agent actually waits on. TTFA is perceived first-audible latency, not just network arrival; TTFS anchors every provider at the same VAD end-of-speech instant; V2V is derived from the conversation audio itself, so it includes full pipeline overhead.",
-      "Connection setup — TCP, TLS, protocol handshakes — is excluded uniformly across every provider. Aggregates expose the full percentile distribution (p25 through p99) alongside the mean; leaderboards rank by the median (p50).",
+      "Latency metrics measure what a voice agent actually waits on. TTFA counts the delay a listener would notice, including any silence before the first audible sample, not just the moment the first bytes arrive. TTFS starts every provider from the same end-of-speech instant, picked by one shared voice-activity model, so no one gets an edge from where they decide the speaker stopped.",
+      "We exclude connection setup (TCP, TLS, and protocol handshakes) the same way for every provider, so the numbers reflect the model and not the network. Aggregates show the full spread from p25 to p99 next to the mean, and leaderboards rank by the median.",
     ],
   },
   {
     title: "Evaluation Standards",
     summary:
-      "Pinned inputs, reproducible outputs — every leaderboard number traces back to its exact configuration.",
+      "Pinned inputs, reproducible outputs. Every leaderboard number traces back to the exact configuration that produced it.",
     terms: [
-      { code: "matrix", name: "Exact model versions", def: "every provider entry uses the versioned identifier the provider exposes, never an alias" },
-      { code: "norm_version", name: "Versioned pipeline", def: "changed WER methodology never mixes with rows produced before it" },
+      { code: "model_id", name: "Exact model versions", def: "every provider entry uses the versioned identifier the provider exposes, never an alias" },
+      { code: "norm_version", name: "Versioned pipeline", def: "a change to WER methodology never mixes with rows produced before it" },
       { code: "runner_sha", name: "Traceable runs", def: "every run records the runner commit that produced it" },
     ],
     details: [
-      "Scoring is delegated to standard, lock-file-pinned libraries — jiwer for edit distance, whisper-normalizer for text normalization. When the methodology changes, results from before and after are marked incomparable rather than silently blended.",
-      "The full runner, dataset manifests, and methodology docs are open source, and every audio file is integrity-checked by SHA-256 on fetch — every number on this site can be reproduced from the repository.",
+      "Scoring runs on standard, lock-file-pinned libraries: jiwer for edit distance and whisper-normalizer for text normalization. When we change the methodology, we mark results from before and after as incomparable instead of quietly blending them.",
+      "The runner, the dataset manifests, and the methodology docs are all open source, and every audio file is checked against its SHA-256 hash on fetch. Every number on this site can be reproduced straight from the repository.",
     ],
   },
 ];

--- a/web/components/overview/AboutMethodology.tsx
+++ b/web/components/overview/AboutMethodology.tsx
@@ -1,0 +1,173 @@
+// Copyright 2026 The Coval Benchmarks Authors
+// SPDX-License-Identifier: Apache-2.0
+
+"use client";
+
+import React, { useState } from "react";
+
+interface MethodologyTerm {
+  code: string;
+  tag?: string;
+  name: string;
+  def: string;
+}
+
+interface MethodologySection {
+  title: string;
+  summary: string;
+  terms: MethodologyTerm[];
+  details: string[];
+}
+
+const SECTIONS: MethodologySection[] = [
+  {
+    title: "Our Datasets",
+    summary:
+      "Frozen, versioned datasets spanning studio-quality read speech and spontaneous conversational audio.",
+    terms: [
+      { code: "stt-v1", tag: "STT", name: "LibriSpeech test-clean", def: "50 studio-quality read utterances (CC-BY-4.0), the easy tier" },
+      { code: "stt-v3", tag: "STT", name: "Conversational clips", def: "897 spontaneous voice-agent turns from pipecat's stt-benchmark-data, the hard tier" },
+      { code: "tts-v1", tag: "TTS", name: "Text prompts", def: "30 short text inputs for synthesis" },
+    ],
+    details: [
+      "Speech-to-text runs both tiers each cycle: studio-quality read speech that most providers train on, and real conversational speech — fragments, fillers, prompted turns. Every clip is loudness-normalized to −20 dBFS RMS and pinned by SHA-256, so the audio a provider hears is byte-identical across runs.",
+      "Each scheduled run draws a random sample from its manifest and every model scores on that identical draw, so comparisons within a run are apples-to-apples while the full set is covered over time. Retired datasets stay published for historical reproducibility.",
+    ],
+  },
+  {
+    title: "How We Calculate Metrics",
+    summary:
+      "Each board carries the metrics that matter for its modality, aggregated as percentiles over continuous evaluation cycles.",
+    terms: [
+      { code: "TTFA", tag: "TTS", name: "Time to First Audio", def: "first audio chunk arrival plus any leading silence before the first audible sample" },
+      { code: "TTFT", tag: "STT", name: "Time to First Token", def: "how quickly partial transcripts start streaming" },
+      { code: "TTFS", tag: "STT", name: "Time to Final Segment", def: "from a shared VAD end-of-speech anchor to the final transcript" },
+      { code: "WER", tag: "STT", name: "Word Error Rate", def: "scored after Whisper's EnglishTextNormalizer on both reference and hypothesis" },
+      { code: "V2V", tag: "S2S", name: "Voice-to-Voice", def: "end of user speech to the first frame of agent audio, from the recorded conversation" },
+    ],
+    details: [
+      "Latency metrics measure what a voice agent actually waits on. TTFA is perceived first-audible latency, not just network arrival; TTFS anchors every provider at the same VAD end-of-speech instant; V2V is derived from the conversation audio itself, so it includes full pipeline overhead.",
+      "Connection setup — TCP, TLS, protocol handshakes — is excluded uniformly across every provider. Aggregates expose the full percentile distribution (p25 through p99) alongside the mean; leaderboards rank by the median (p50).",
+    ],
+  },
+  {
+    title: "Evaluation Standards",
+    summary:
+      "Pinned inputs, reproducible outputs — every leaderboard number traces back to its exact configuration.",
+    terms: [
+      { code: "matrix", name: "Exact model versions", def: "every provider entry uses the versioned identifier the provider exposes, never an alias" },
+      { code: "norm_version", name: "Versioned pipeline", def: "changed WER methodology never mixes with rows produced before it" },
+      { code: "runner_sha", name: "Traceable runs", def: "every run records the runner commit that produced it" },
+    ],
+    details: [
+      "Scoring is delegated to standard, lock-file-pinned libraries — jiwer for edit distance, whisper-normalizer for text normalization. When the methodology changes, results from before and after are marked incomparable rather than silently blended.",
+      "The full runner, dataset manifests, and methodology docs are open source, and every audio file is integrity-checked by SHA-256 on fetch — every number on this site can be reproduced from the repository.",
+    ],
+  },
+];
+
+const MethodologyRow: React.FC<{ section: MethodologySection }> = ({ section }) => {
+  const [open, setOpen] = useState(false);
+  const panelId = section.title.toLowerCase().replace(/[^a-z0-9]+/g, "-");
+  return (
+    <div className="border-t border-border-primary last:border-b">
+      <h3>
+        <button
+          type="button"
+          aria-expanded={open}
+          aria-controls={panelId}
+          onClick={() => setOpen((prev) => !prev)}
+          className="group flex w-full items-start justify-between gap-4 py-6 text-left"
+        >
+          <span>
+            <span className="block text-base font-medium text-text-primary md:text-lg">
+              {section.title}
+            </span>
+            <span className="mt-1 block max-w-prose text-sm font-light leading-snug text-text-secondary">
+              {section.summary}
+            </span>
+          </span>
+          <span
+            aria-hidden
+            className="mt-0.5 shrink-0 font-mono text-xl leading-none text-text-tertiary transition-colors group-hover:text-text-primary"
+          >
+            {open ? "–" : "+"}
+          </span>
+        </button>
+      </h3>
+      <div
+        id={panelId}
+        className={`grid transition-[grid-template-rows] duration-300 ease-in-out ${open ? "grid-rows-[1fr]" : "grid-rows-[0fr]"}`}
+      >
+        <div className="overflow-hidden">
+          <div className="pb-8">
+            <dl className="mb-4 divide-y divide-border-secondary overflow-hidden rounded-lg border border-border-secondary bg-surface-elevated">
+              {section.terms.map(({ code, tag, name, def }) => (
+                <div
+                  key={code}
+                  className="grid grid-cols-[6.75rem_1fr] items-baseline gap-x-4 px-4 py-3 sm:grid-cols-[8.5rem_1fr]"
+                >
+                  <dt className="flex flex-wrap items-baseline gap-x-1.5 gap-y-0.5">
+                    <span className="font-mono text-xs text-text-primary">{code}</span>
+                    {tag && (
+                      <span className="rounded bg-surface-secondary px-1 py-px font-mono text-[0.6rem] tracking-wider text-text-tertiary">
+                        {tag}
+                      </span>
+                    )}
+                  </dt>
+                  <dd className="text-xs leading-relaxed text-text-secondary">
+                    <span className="font-medium text-text-primary">{name}</span> &mdash; {def}
+                  </dd>
+                </div>
+              ))}
+            </dl>
+            {section.details.map((paragraph) => (
+              <p
+                key={paragraph.slice(0, 24)}
+                className="mt-3 max-w-prose text-sm font-light leading-relaxed text-text-secondary"
+              >
+                {paragraph}
+              </p>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const AboutMethodology: React.FC = () => (
+  <section
+    aria-labelledby="about-methodology"
+    className="grid grid-cols-1 gap-10 pb-10 pt-16 md:pt-24 lg:grid-cols-[minmax(0,2fr)_minmax(0,3fr)] lg:gap-16"
+  >
+    <div className="lg:sticky lg:top-24 lg:self-start">
+      <p className="font-mono text-sm text-text-tertiary">Methodology</p>
+      <h2
+        id="about-methodology"
+        className="mt-3 text-balance text-2xl font-medium leading-tight tracking-tight text-text-primary md:text-3xl"
+      >
+        About Metrics &amp; Methodology
+      </h2>
+      <p className="mt-3 max-w-md text-pretty text-base font-light leading-snug text-text-secondary">
+        Every leaderboard number is a function of pinned inputs. Here is what we
+        run, how we score it, and why you can trust it.
+      </p>
+      <a
+        href="https://github.com/coval-ai/benchmarks/blob/main/docs/methodology.md"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="mt-5 inline-flex items-center gap-1 text-sm font-medium text-text-secondary transition-colors hover:text-text-primary"
+      >
+        Read the full methodology <span aria-hidden>&rarr;</span>
+      </a>
+    </div>
+    <div>
+      {SECTIONS.map((section) => (
+        <MethodologyRow key={section.title} section={section} />
+      ))}
+    </div>
+  </section>
+);
+
+export default AboutMethodology;

--- a/web/components/overview/AboutMethodology.tsx
+++ b/web/components/overview/AboutMethodology.tsx
@@ -145,7 +145,7 @@ const AboutMethodology: React.FC = () => (
       <p className="font-mono text-sm text-text-tertiary">Methodology</p>
       <h2
         id="about-methodology"
-        className="mt-3 text-balance text-2xl font-medium leading-tight tracking-tight text-text-primary md:text-3xl"
+        className="mt-3 scroll-mt-24 text-balance text-2xl font-medium leading-tight tracking-tight text-text-primary md:text-3xl"
       >
         About Metrics &amp; Methodology
       </h2>


### PR DESCRIPTION
## Summary
<img width="1185" height="535" alt="Screenshot 2026-07-17 at 10 11 15 AM" src="https://github.com/user-attachments/assets/9bc2e956-23fa-4b32-af65-4043b33b33bb" />

Adds an "About Metrics & Methodology" section to the overview page, styled after the coval.ai www design language (mono eyebrow, sticky heading column, hairline accordion rows with `+`/`–` markers).

- **Below the fold at 100% zoom** — the hero + leaderboards wrapper now claims the full first viewport (`min-h-[calc(100vh-header)]`), so the section only appears on scroll.
- **Three expandable rows** — Our Datasets, How We Calculate Metrics, Evaluation Standards — full-width rows at every breakpoint (no 2-col orphan state), smooth `grid-rows-[0fr→1fr]` expansion with no layout shift, WAI-ARIA accordion semantics (`h3 > button`, `aria-expanded`/`aria-controls`), 44px+ tap targets.
- **Honest, complete metric coverage** — the definition tables list the exact metric registry from the runner (`TTFA·TTS`, `TTFT·STT`, `TTFS·STT`, `WER·STT`, `V2V·S2S`); copy is sourced from `docs/methodology.md` (dataset tiers, SHA-256 pinning, per-run sampling, uniform connection-setup exclusion, `norm_version`/`runner_sha` traceability, p25–p99 aggregates ranked by p50).
- **Term/definition tables** styled like the www scoreboard: elevated surface, rounded hairline border, `divide-y` rows, Geist Mono codes with small board badges, bolded names.

Theme tokens only (no hardcoded colors), PP Mori / Geist Mono only, works in light + dark and 375px → desktop.

## Test plan

- [x] `tsc --noEmit` and `eslint --max-warnings 0` pass
- [x] Verified in browser: default collapsed state, expand/collapse per row, keyboard focus, dark/light themes, 375px / 768px / 1280px / 1500px viewports
- [x] Section hidden on first screen at 100% zoom (1280×900 and 1500×840)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR expands the overview page with benchmark methodology details. The main changes are:

- Adds expandable sections for datasets, metrics, and evaluation standards.
- Makes the hero and leaderboards fill the initial viewport.
- Adds a scroll hint linking to the methodology section.
- Uses responsive, accessible accordion and definition-table markup.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<sub>Reviews (4): Last reviewed commit: ["\[BENCH-506\] Editorial pass on methodolog..."](https://github.com/coval-ai/benchmarks/commit/408b3135700b44253142144b09266080bc4b9e6e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45145533)</sub>

<!-- /greptile_comment -->