### PR TITLE
Retire Soniox STT stt-rt-v4

### DIFF
--- a/runner/src/coval_bench/providers/stt/soniox.py
+++ b/runner/src/coval_bench/providers/stt/soniox.py
@@ -27,7 +27,7 @@ class SonioxSTTProvider(STTProvider):
 
     _VALID_MODELS = frozenset({"stt-rt-v4", "stt-rt-v5"})
 
-    def __init__(self, api_key: SecretStr | None, model: str = "stt-rt-v4") -> None:
+    def __init__(self, api_key: SecretStr | None, model: str = "stt-rt-v5") -> None:
         if not self._model_supported(model):
             raise ValueError(
                 f"Invalid Soniox STT model {model!r}. Valid: {sorted(self._VALID_MODELS)}"

--- a/runner/src/coval_bench/registries/models.py
+++ b/runner/src/coval_bench/registries/models.py
@@ -215,7 +215,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         provider="soniox",
         model="stt-rt-v4",
         tags=(_REALTIME, _MULTI, _VAD, _DIAR, _TRANS, _CODESW, _KEYTERM),
-        status=_ACTIVE,
+        status=_RETIRED,
     ),
     RegisteredModel(
         benchmark=_STT,

--- a/runner/tests/providers/stt/test_soniox.py
+++ b/runner/tests/providers/stt/test_soniox.py
@@ -112,11 +112,11 @@ def test_provider_name() -> None:
 
 
 def test_provider_model() -> None:
-    assert make_provider().model == "stt-rt-v4"
+    assert make_provider().model == "stt-rt-v5"
 
 
-def test_stt_rt_v5_supported() -> None:
-    assert SonioxSTTProvider(api_key=SecretStr("k"), model="stt-rt-v5").model == "stt-rt-v5"
+def test_stt_rt_v4_still_supported() -> None:
+    assert SonioxSTTProvider(api_key=SecretStr("k"), model="stt-rt-v4").model == "stt-rt-v4"
 
 
 # ---------------------------------------------------------------------------

--- a/web/lib/config/colors.ts
+++ b/web/lib/config/colors.ts
@@ -75,7 +75,6 @@ export const modelColors: Record<string, string> = {
 
   // Soniox — lime (green-gold).
   "tts-rt-v1": "#9db030",
-  "stt-rt-v4": "#859704",
   "stt-rt-v5": "#697800",
 
   // Smallest — amber.

--- a/web/lib/utils/formatters.ts
+++ b/web/lib/utils/formatters.ts
@@ -129,7 +129,6 @@ export function normalizeModelName(modelKey: string): string {
     "universal-streaming-multilingual": "Universal Streaming Multilingual",
     "universal-3.5-pro": "Universal 3.5 Pro",
     "ink-2": "Ink 2",
-    "stt-rt-v4": "STT RT v4",
     "stt-rt-v5": "STT RT v5",
     "inworld-stt-1": "STT 1",
     "nemotron-3-asr-streaming-0.6b": "Nemotron 3 ASR Streaming",


### PR DESCRIPTION
Its endpoint now routes to stt-rt-v5, so flip it to retired in the registry and drop its web color/label entries; the provider default moves to v5.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR retires Soniox STT v4 and makes v5 the default. The main changes are:

- Changes the Soniox provider default to `stt-rt-v5`.
- Marks `stt-rt-v4` as retired in the model registry.
- Updates provider tests for the new default and explicit v4 support.
- Removes the v4 web color and display-name entries.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge after a small historical-label cleanup.

- Active benchmark runs exclude the retired registry entry.
- Explicit v4 support matches the existing retirement behavior.
- Historical v4 colors retain a valid fallback, but the display label loses its intended casing.

web/lib/utils/formatters.ts

<sub>Reviews (1): Last reviewed commit: ["Retire Soniox STT stt-rt-v4"](https://github.com/coval-ai/benchmarks/commit/7cff437e2fae648ed9441e72ad32768456087d70) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45153141)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->