### PR TITLE
Audit STT tags

### DIFF
--- a/runner/src/coval_bench/api/routers/providers.py
+++ b/runner/src/coval_bench/api/routers/providers.py
@@ -56,7 +56,7 @@ def _tag(category: TagCategory, value: str) -> ModelTagOut:
 def _model_tags(m: RegisteredModel) -> list[ModelTagOut]:
     """Flatten a model's facets: derived columns/attributes plus curated tags."""
     source = "inference" if m.creator and m.creator != m.provider else "original"
-    deployment = "self-hostable" if m.self_hostable else "cloud"
+    deployment = "on-prem" if m.on_prem else "cloud"
     return [
         _tag(TagCategory.TYPE, m.benchmark),
         _tag(TagCategory.HOST, m.provider),

--- a/runner/src/coval_bench/registries/models.py
+++ b/runner/src/coval_bench/registries/models.py
@@ -57,7 +57,7 @@ class RegisteredModel(BaseModel, frozen=True):
     tags: tuple[ModelTag, ...] = ()
     tenancy: Tenancy = Tenancy.SHARED
     licensing: Licensing = Licensing.PROPRIETARY
-    self_hostable: bool = False  # can run in the customer's own infra
+    on_prem: bool = False  # provider offers on-prem/customer-infra deployment
     status: ModelStatus
     arena_enabled: bool = True  # in the arena roster? independent of dashboard `status`
 
@@ -91,7 +91,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         provider="deepgram",
         model="nova-2",
         tags=(_REALTIME, _MULTI, _VAD, _DIAR, _CODESW, _KEYTERM),
-        self_hostable=True,
+        on_prem=True,
         status=_ACTIVE,
     ),
     RegisteredModel(
@@ -99,7 +99,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         provider="deepgram",
         model="nova-3",
         tags=(_REALTIME, _MULTI, _VAD, _DIAR, _CODESW, _KEYTERM),
-        self_hostable=True,
+        on_prem=True,
         status=_ACTIVE,
     ),
     RegisteredModel(
@@ -107,7 +107,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         provider="deepgram",
         model="flux-general-en",
         tags=(_REALTIME, _VAD, _KEYTERM),
-        self_hostable=True,
+        on_prem=True,
         status=_ACTIVE,
     ),
     RegisteredModel(
@@ -115,14 +115,14 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         provider="deepgram",
         model="flux-general-multi",
         tags=(_REALTIME, _MULTI, _VAD, _CODESW, _KEYTERM),
-        self_hostable=True,
+        on_prem=True,
         status=_ACTIVE,
     ),
     RegisteredModel(
         benchmark=_STT,
         provider="elevenlabs",
         model="scribe_v2_realtime",
-        tags=(_REALTIME, _MULTI, _VAD, _CODESW, _KEYTERM),
+        tags=(_REALTIME, _MULTI, _VAD, _KEYTERM),
         status=_ACTIVE,
     ),
     RegisteredModel(
@@ -151,7 +151,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         provider="assemblyai",
         model="universal-streaming",
         tags=(_REALTIME, _VAD, _DIAR, _KEYTERM),
-        self_hostable=True,
+        on_prem=True,
         status=_ACTIVE,
     ),
     RegisteredModel(
@@ -159,7 +159,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         provider="assemblyai",
         model="universal-streaming-multilingual",
         tags=(_REALTIME, _MULTI, _VAD, _DIAR, _CODESW, _KEYTERM),
-        self_hostable=True,
+        on_prem=True,
         status=_ACTIVE,
     ),
     # No longer offered on AssemblyAI's streaming API (u3-rt-pro); superseded by
@@ -169,7 +169,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         provider="assemblyai",
         model="universal-3-pro",
         tags=(_REALTIME, _MULTI, _VAD, _DIAR, _CODESW, _KEYTERM),
-        self_hostable=True,
+        on_prem=True,
         status=_RETIRED,
     ),
     RegisteredModel(
@@ -177,7 +177,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         provider="assemblyai",
         model="universal-3.5-pro",
         tags=(_REALTIME, _MULTI, _VAD, _DIAR, _CODESW, _KEYTERM, _CONVCTX),
-        self_hostable=True,
+        on_prem=True,
         status=_ACTIVE,
     ),
     RegisteredModel(
@@ -185,7 +185,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         provider="speechmatics",
         model="default",
         tags=(_REALTIME, _MULTI, _VAD, _DIAR, _TRANS, _CODESW, _KEYTERM),
-        self_hostable=True,
+        on_prem=True,
         status=_ACTIVE,
     ),
     RegisteredModel(
@@ -193,7 +193,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         provider="speechmatics",
         model="enhanced",
         tags=(_REALTIME, _MULTI, _VAD, _DIAR, _TRANS, _CODESW, _KEYTERM),
-        self_hostable=True,
+        on_prem=True,
         status=_ACTIVE,
     ),
     RegisteredModel(
@@ -258,7 +258,6 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         model="voxtral-mini-transcribe-realtime-2602",
         tags=(_REALTIME, _MULTI),
         licensing=_OPEN,
-        self_hostable=True,
         status=_ACTIVE,
     ),
     # Baseten dedicated endpoints (Whisper Large V3). PENDING: implemented and
@@ -272,7 +271,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         tags=(_REALTIME, _MULTI, _VAD),
         tenancy=Tenancy.DEDICATED,
         licensing=_OPEN,
-        self_hostable=True,
+        on_prem=True,
         status=_PENDING,
     ),
     # Azure AI Speech real-time (raw WebSocket, conversation mode).
@@ -289,6 +288,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         provider="google",
         model="chirp_2",
         tags=(_REALTIME, _MULTI, _VAD),
+        on_prem=True,
         status=_ACTIVE,
     ),
     RegisteredModel(
@@ -296,6 +296,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         provider="google",
         model="chirp_3",
         tags=(_REALTIME, _MULTI, _VAD),
+        on_prem=True,
         status=_ACTIVE,
     ),
     RegisteredModel(
@@ -304,8 +305,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         model="reverb",
         creator="rev",
         tags=(_REALTIME, _MULTI, _VAD, _KEYTERM),
-        licensing=_OPEN,
-        self_hostable=True,
+        on_prem=True,
         status=_ACTIVE,
     ),
     # Together AI serverless realtime endpoints (open-weight models).
@@ -316,7 +316,6 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         creator="nvidia",
         tags=(_REALTIME,),
         licensing=_OPEN,
-        self_hostable=True,
         status=_ACTIVE,
     ),
     RegisteredModel(
@@ -326,7 +325,6 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         creator="nvidia",
         tags=(_REALTIME, _MULTI),
         licensing=_OPEN,
-        self_hostable=True,
         status=_ACTIVE,
     ),
     RegisteredModel(
@@ -336,7 +334,6 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         creator="nvidia",
         tags=(_REALTIME, _MULTI),
         licensing=_OPEN,
-        self_hostable=True,
         status=_ACTIVE,
     ),
     RegisteredModel(
@@ -346,7 +343,6 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         creator="openai",
         tags=(_REALTIME, _MULTI),
         licensing=_OPEN,
-        self_hostable=True,
         status=_ACTIVE,
     ),
     #######
@@ -435,7 +431,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         model="aura-2-thalia-en",
         voice="aura-2-thalia-en",
         tags=(_REALTIME, _STREAM),
-        self_hostable=True,
+        on_prem=True,
         status=_ACTIVE,
     ),
     RegisteredModel(
@@ -544,7 +540,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         voice="Ashley",
         voices=("Ashley", "Alex"),
         tags=(_REALTIME, _MULTI, _CLONE, _EMOTION, _STREAM),
-        self_hostable=True,
+        on_prem=True,
         status=_ACTIVE,
     ),
     RegisteredModel(
@@ -554,7 +550,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         voice="Ashley",
         voices=("Ashley", "Alex"),
         tags=(_REALTIME, _MULTI, _CLONE, _EMOTION, _STREAM),
-        self_hostable=True,
+        on_prem=True,
         status=_ACTIVE,
     ),
     RegisteredModel(
@@ -597,7 +593,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         creator="canopylabs",
         tags=(_REALTIME, _EMOTION),
         licensing=_OPEN,
-        self_hostable=True,
+        on_prem=True,
         status=_PENDING,
         arena_enabled=False,
     ),
@@ -633,7 +629,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         tags=(_REALTIME, _MULTI, _STREAM),
         tenancy=Tenancy.DEDICATED,
         licensing=_OPEN,
-        self_hostable=True,
+        on_prem=True,
         status=_PENDING,
     ),
     RegisteredModel(

--- a/runner/src/coval_bench/registries/models.py
+++ b/runner/src/coval_bench/registries/models.py
@@ -43,7 +43,7 @@ class Licensing(StrEnum):
     OPEN_WEIGHT = "open-weight"
 
 
-class RegisteredModel(BaseModel, frozen=True):
+class RegisteredModel(BaseModel, frozen=True, extra="forbid"):
     """A single benchmarked model: identity, display metadata, run config."""
 
     benchmark: Benchmark

--- a/runner/src/coval_bench/registries/tags.py
+++ b/runner/src/coval_bench/registries/tags.py
@@ -27,10 +27,13 @@ class TagCategory(StrEnum):
 
 
 class ModelTag(StrEnum):
-    """Curated model attributes surfaced as MODE and FEATURES filter chips."""
+    """Curated model attributes surfaced as MODE and FEATURES filter chips.
+
+    CODE_SWITCHING means intra-sentence language mixing in one stream;
+    session-level language identification or switching does not qualify.
+    """
 
     REALTIME = "realtime"
-    BATCH = "batch"
     MULTILINGUAL = "multilingual"
     VAD = "vad"
     DIARIZATION = "diarization"
@@ -45,7 +48,6 @@ class ModelTag(StrEnum):
 
 TAG_CATEGORIES: dict[ModelTag, TagCategory] = {
     ModelTag.REALTIME: TagCategory.MODE,
-    ModelTag.BATCH: TagCategory.MODE,
     ModelTag.MULTILINGUAL: TagCategory.FEATURES,
     ModelTag.VAD: TagCategory.FEATURES,
     ModelTag.DIARIZATION: TagCategory.FEATURES,

--- a/runner/tests/api/test_providers.py
+++ b/runner/tests/api/test_providers.py
@@ -124,7 +124,7 @@ async def test_every_model_carries_derived_facets(client: AsyncClient) -> None:
 
 
 async def test_capability_and_licensing_facets(client: AsyncClient) -> None:
-    """Curated capability tags, open-weight licensing, and self-hostable deployment surface."""
+    """Curated capability tags, open-weight licensing, and on-prem deployment surface."""
     response = await client.get("/v1/providers")
     data = response.json()
 
@@ -133,7 +133,7 @@ async def test_capability_and_licensing_facets(client: AsyncClient) -> None:
     sm_facets = {(t["category"], t["value"]) for t in default["tags"]}
     assert ("features", "diarization") in sm_facets
     assert ("features", "translation") in sm_facets
-    assert ("deployment", "self-hostable") in sm_facets
+    assert ("deployment", "on-prem") in sm_facets
 
     groq = next(e for e in data["tts"] if e["provider"] == "groq")
     orpheus = next(m for m in groq["models"] if m["model"] == "canopylabs/orpheus-v1-english")

--- a/runner/tests/unit/test_provider_config.py
+++ b/runner/tests/unit/test_provider_config.py
@@ -34,11 +34,11 @@ def test_registered_model_defaults() -> None:
     assert m.tags == ()
     assert m.tenancy is Tenancy.SHARED
     assert m.licensing is Licensing.PROPRIETARY
-    assert m.self_hostable is False
+    assert m.on_prem is False
 
 
 def test_every_model_has_exactly_one_mode() -> None:
-    modes = {ModelTag.REALTIME, ModelTag.BATCH}
+    modes = {ModelTag.REALTIME}
     for m in MODEL_REGISTRY:
         assert len(set(m.tags) & modes) == 1, f"{m.provider}/{m.model} needs one mode tag"
 


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the speech model registry and provider facets.

- Renames the deployment field from `self_hostable` to `on_prem`.
- Changes the public deployment tag to `on-prem`.
- Audits deployment, licensing, source, and capability metadata.
- Rejects unknown `RegisteredModel` fields.
- Updates provider and registry tests.

<h3>Confidence Score: 4/5</h3>

The latest constructor validation fix is safe, but an earlier compatibility issue remains open.

- Unknown constructor fields now fail explicitly instead of being silently discarded.
- Current registry constructors use valid field names.
- The public deployment value still changes without a compatibility path.

runner/src/coval_bench/api/routers/providers.py

<sub>Reviews (3): Last reviewed commit: ["Forbid unknown fields on RegisteredModel"](https://github.com/coval-ai/benchmarks/commit/f94d9148108fccdf6b1f08729bce0e92bb386f01) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45184401)</sub>

<!-- /greptile_comment -->