### PR TITLE
[BENCH-431] Collapse filter groups and drop chip colors

### DIFF
--- a/runner/src/coval_bench/registries/tags.py
+++ b/runner/src/coval_bench/registries/tags.py
@@ -17,8 +17,8 @@ class TagCategory(StrEnum):
 
     TYPE = "type"
     MODE = "mode"
-    HOST = "host"
     CREATOR = "creator"
+    HOST = "host"
     FEATURES = "features"
     SOURCE = "source"
     LICENSING = "licensing"
@@ -72,8 +72,8 @@ if TAG_CATEGORIES.keys() != set(ModelTag):
 CATEGORY_LABELS: dict[TagCategory, str] = {
     TagCategory.TYPE: "Type",
     TagCategory.MODE: "Mode",
-    TagCategory.HOST: "Host",
     TagCategory.CREATOR: "Creator",
+    TagCategory.HOST: "Host",
     TagCategory.FEATURES: "Features",
     TagCategory.SOURCE: "Source",
     TagCategory.LICENSING: "Licensing",

--- a/runner/tests/api/test_providers.py
+++ b/runner/tests/api/test_providers.py
@@ -157,8 +157,8 @@ async def test_tag_categories_metadata(client: AsyncClient) -> None:
     assert [c["category"] for c in categories] == [
         "type",
         "mode",
-        "host",
         "creator",
+        "host",
         "features",
         "source",
         "licensing",

--- a/web/components/layout/FacetFilter.tsx
+++ b/web/components/layout/FacetFilter.tsx
@@ -3,12 +3,12 @@
 
 "use client";
 
-import React from "react";
+import React, { useState } from "react";
 import { useDashboard } from "@/contexts/DashboardContext";
-import { getReadableTextColor } from "@/lib/utils/colors";
 
 const FacetFilter: React.FC = () => {
   const { facetGroups, toggleFacet, clearFacets, hasActiveFacets } = useDashboard();
+  const [expanded, setExpanded] = useState<Record<string, boolean>>({});
 
   if (facetGroups.length === 0) return null;
 
@@ -27,69 +27,86 @@ const FacetFilter: React.FC = () => {
         )}
       </div>
 
-      {facetGroups.map((group) => (
-        <div
-          key={group.category}
-          role="group"
-          aria-labelledby={`facet-${group.category}`}
-          className="px-2"
-        >
+      {facetGroups.map((group) => {
+        const isOpen = expanded[group.category] ?? false;
+        const selectedCount = group.options.filter((o) => o.active).length;
+        return (
           <div
-            id={`facet-${group.category}`}
-            className="mb-1.5 text-[11px] font-semibold uppercase tracking-wide text-text-tertiary"
+            key={group.category}
+            role="group"
+            aria-labelledby={`facet-${group.category}`}
+            className="px-2"
           >
-            {group.label}
-          </div>
-          <div className="flex flex-wrap gap-1.5">
-            {group.options.map((option) => {
-              const fill = option.color ?? null;
-              const fg = fill ? getReadableTextColor(fill) : null;
-              const ringed = option.active || option.implied;
-              return (
-                <button
-                  key={option.value}
-                  type="button"
-                  aria-pressed={option.active}
-                  onClick={() => toggleFacet(group.category, option.value)}
-                  style={
-                    fill
-                      ? {
-                          backgroundColor: fill,
-                          color: fg!,
-                          borderColor: "transparent",
-                          boxShadow: ringed
-                            ? "0 0 0 2px var(--color-surface-primary), 0 0 0 3.5px var(--color-text-primary)"
-                            : undefined,
-                        }
-                      : undefined
-                  }
-                  className={`inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-text-tertiary/40 ${
-                    fill
-                      ? ""
-                      : option.active
+            <button
+              type="button"
+              id={`facet-${group.category}`}
+              aria-expanded={isOpen}
+              onClick={() =>
+                setExpanded((prev) => ({ ...prev, [group.category]: !isOpen }))
+              }
+              className="mb-1.5 flex w-full items-center justify-between text-[11px] font-semibold uppercase tracking-wide text-text-tertiary transition-colors hover:text-text-primary"
+            >
+              <span className="flex items-center gap-1.5">
+                {group.label}
+                {selectedCount > 0 && (
+                  <span className="rounded-full bg-surface-toggle-active px-1.5 text-[10px] tabular-nums text-text-on-toggle-active">
+                    {selectedCount}
+                  </span>
+                )}
+              </span>
+              <svg
+                viewBox="0 0 12 12"
+                aria-hidden="true"
+                className={`h-3 w-3 transition-transform ${isOpen ? "rotate-180" : ""}`}
+              >
+                <path
+                  d="M2.5 4.5 6 8l3.5-3.5"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="1.5"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            </button>
+            {isOpen && (
+              <div className="flex flex-wrap gap-1.5">
+                {group.options.map((option) => (
+                  <button
+                    key={option.value}
+                    type="button"
+                    aria-pressed={option.active}
+                    onClick={() => toggleFacet(group.category, option.value)}
+                    style={
+                      option.implied && !option.active
+                        ? {
+                            boxShadow:
+                              "0 0 0 2px var(--color-surface-primary), 0 0 0 3.5px var(--color-text-primary)",
+                          }
+                        : undefined
+                    }
+                    className={`inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-text-tertiary/40 ${
+                      option.active
                         ? "border-transparent bg-surface-toggle-active text-text-on-toggle-active"
                         : "border-border-primary text-text-secondary hover:border-text-tertiary/50 hover:text-text-primary"
-                  }`}
-                >
-                  <span>{option.label}</span>
-                  <span
-                    style={{ minWidth: `${String(option.maxCount).length}ch` }}
-                    className={`inline-block text-center tabular-nums ${
-                      fill
-                        ? "opacity-70"
-                        : option.active
-                          ? "text-text-on-toggle-active/70"
-                          : "text-text-tertiary"
                     }`}
                   >
-                    {option.count}
-                  </span>
-                </button>
-              );
-            })}
+                    <span>{option.label}</span>
+                    <span
+                      style={{ minWidth: `${String(option.maxCount).length}ch` }}
+                      className={`inline-block text-center tabular-nums ${
+                        option.active ? "text-text-on-toggle-active/70" : "text-text-tertiary"
+                      }`}
+                    >
+                      {option.count}
+                    </span>
+                  </button>
+                ))}
+              </div>
+            )}
           </div>
-        </div>
-      ))}
+        );
+      })}
     </div>
   );
 };

--- a/web/lib/api/generated/schema.ts
+++ b/web/lib/api/generated/schema.ts
@@ -116,8 +116,8 @@ export interface components {
     TagCategory:
       | "type"
       | "mode"
-      | "host"
       | "creator"
+      | "host"
       | "features"
       | "source"
       | "licensing"

--- a/web/lib/utils/facets.test.ts
+++ b/web/lib/utils/facets.test.ts
@@ -102,11 +102,11 @@ describe("buildFacetGroups", () => {
     expect(byValue).toEqual({ deepgram: 1, openai: 1, cartesia: 0 });
   });
 
-  it("keeps labels, order, and colors stable while other categories filter", () => {
+  it("keeps labels and order stable while other categories filter", () => {
     const snapshot = (selected: Parameters<typeof buildFacetGroups>[2]) =>
       buildFacetGroups(ALL, index(), selected, cats(), id)
         .find((g) => g.category === "host")!
-        .options.map(({ value, label, color, maxCount }) => ({ value, label, color, maxCount }));
+        .options.map(({ value, label, maxCount }) => ({ value, label, maxCount }));
     expect(snapshot({ features: ["multilingual"] })).toEqual(snapshot({}));
   });
 

--- a/web/lib/utils/facets.ts
+++ b/web/lib/utils/facets.ts
@@ -4,8 +4,6 @@
 import type { ModelTagOut, ProvidersApiResponse, TagCategoryOut } from "../api/client";
 import type { ModelsByProvider } from "../../types/benchmark.types";
 import { toModelKey } from "./formatters";
-import { providerColors } from "../config/colors";
-import { getModelColor } from "./colors";
 
 /** category -> selected values. Within a category values OR; across categories they AND. */
 export type FacetSelection = Record<string, string[]>;
@@ -27,7 +25,6 @@ export interface FacetOption {
   active: boolean;
   /** A legend-selected model carries this tag, so the chip rings without being toggled itself. */
   implied: boolean;
-  color?: string;
 }
 
 export interface FacetGroup {
@@ -128,8 +125,8 @@ export function filterModelsByFacets(
  * Build the chip groups, in the API's category order. A category is shown only
  * when the visible models hold at least two distinct values for it. Each
  * option's count is how many models would remain if it were selected, honoring
- * the other categories' selection; labels and colors ignore the selection so
- * chips never rename or recolor while filtering.
+ * the other categories' selection; labels ignore the selection so chips never
+ * rename while filtering.
  */
 export function buildFacetGroups(
   modelsByProvider: ModelsByProvider,
@@ -168,12 +165,6 @@ export function buildFacetGroups(
           matchesSelection(tagIndex.get(key) ?? [], others)
         ).length;
         const label = provider_valued ? normalizeProvider(value) : valueLabel;
-        let color: string | undefined;
-        if (provider_valued) {
-          // Chip follows the chart: derive the chip from the color of one of
-          // its models so the sidebar can never drift from the series colors.
-          color = (matching[0] ? getModelColor(matching[0]) : undefined) ?? providerColors[label];
-        }
         return {
           value,
           label,
@@ -183,7 +174,6 @@ export function buildFacetGroups(
           implied:
             !!provider_valued &&
             modelSelection.some((key) => matching.includes(key)),
-          color,
         };
       })
       .sort((a, b) => a.label.localeCompare(b.label));


### PR DESCRIPTION
Facet categories now render as collapsible dropdowns with uncolored chips, and Creator sorts above Host.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR simplifies and collapses the dashboard facet filters. The main changes are:

- Renders each facet category as a collapsed dropdown with an active-selection count.
- Removes provider colors from facet chips.
- Moves Creator before Host in API and UI category order.
- Updates related API and facet utility tests.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<sub>Reviews (1): Last reviewed commit: ["\[BENCH-431\] Collapse filter groups and d..."](https://github.com/coval-ai/benchmarks/commit/bf762f1aedba43c056c575f2f53e474d049906c4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45207028)</sub>

<!-- /greptile_comment -->