### PR TITLE
[BENCH-507] Refactor filter panel UI: dropdown pattern & brand alignment

### DIFF
--- a/web/components/layout/FacetFilter.tsx
+++ b/web/components/layout/FacetFilter.tsx
@@ -3,18 +3,23 @@
 
 "use client";
 
-import React from "react";
+import React, { useState } from "react";
+import { ChevronDown } from "lucide-react";
 import { useDashboard } from "@/contexts/DashboardContext";
 import { getReadableTextColor } from "@/lib/utils/colors";
 
+const COLLAPSE_THRESHOLD = 8;
+
 const FacetFilter: React.FC = () => {
-  const { facetGroups, toggleFacet, clearFacets, hasActiveFacets } = useDashboard();
+  const { facetGroups, toggleFacet, clearFacets, hasActiveFacets } =
+    useDashboard();
+  const [openGroups, setOpenGroups] = useState<Record<string, boolean>>({});
 
   if (facetGroups.length === 0) return null;
 
   return (
-    <div className="space-y-3">
-      <div className="flex items-center justify-between px-2">
+    <div className="space-y-1">
+      <div className="flex items-center justify-between px-2 pb-2">
         <span className="text-sm font-bold text-text-primary">Filters</span>
         {hasActiveFacets && (
           <button
@@ -27,69 +32,102 @@ const FacetFilter: React.FC = () => {
         )}
       </div>
 
-      {facetGroups.map((group) => (
-        <div
-          key={group.category}
-          role="group"
-          aria-labelledby={`facet-${group.category}`}
-          className="px-2"
-        >
+      {facetGroups.map((group) => {
+        const activeCount = group.options.filter((o) => o.active).length;
+        const isOpen =
+          openGroups[group.category] ??
+          group.options.length <= COLLAPSE_THRESHOLD;
+        const visibleOptions = isOpen
+          ? group.options
+          : group.options.filter((o) => o.active || o.implied);
+        return (
           <div
-            id={`facet-${group.category}`}
-            className="mb-1.5 text-[11px] font-semibold uppercase tracking-wide text-text-tertiary"
+            key={group.category}
+            role="group"
+            aria-labelledby={`facet-${group.category}`}
+            className="border-t border-border-primary px-2 py-1"
           >
-            {group.label}
-          </div>
-          <div className="flex flex-wrap gap-1.5">
-            {group.options.map((option) => {
-              const fill = option.color ?? null;
-              const fg = fill ? getReadableTextColor(fill) : null;
-              const ringed = option.active || option.implied;
-              return (
-                <button
-                  key={option.value}
-                  type="button"
-                  aria-pressed={option.active}
-                  onClick={() => toggleFacet(group.category, option.value)}
-                  style={
-                    fill
-                      ? {
-                          backgroundColor: fill,
-                          color: fg!,
-                          borderColor: "transparent",
-                          boxShadow: ringed
-                            ? "0 0 0 2px var(--color-surface-primary), 0 0 0 3.5px var(--color-text-primary)"
-                            : undefined,
-                        }
-                      : undefined
-                  }
-                  className={`inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-text-tertiary/40 ${
-                    fill
-                      ? ""
-                      : option.active
-                        ? "border-transparent bg-surface-toggle-active text-text-on-toggle-active"
-                        : "border-border-primary text-text-secondary hover:border-text-tertiary/50 hover:text-text-primary"
-                  }`}
-                >
-                  <span>{option.label}</span>
-                  <span
-                    style={{ minWidth: `${String(option.maxCount).length}ch` }}
-                    className={`inline-block text-center tabular-nums ${
-                      fill
-                        ? "opacity-70"
-                        : option.active
-                          ? "text-text-on-toggle-active/70"
-                          : "text-text-tertiary"
-                    }`}
-                  >
-                    {option.count}
+            <button
+              type="button"
+              id={`facet-${group.category}`}
+              aria-expanded={isOpen}
+              onClick={() =>
+                setOpenGroups((prev) => ({
+                  ...prev,
+                  [group.category]: !isOpen,
+                }))
+              }
+              className="flex min-h-11 w-full items-center justify-between gap-2 py-2 text-[11px] font-semibold uppercase tracking-wide text-text-tertiary transition-colors hover:text-text-primary lg:min-h-0"
+            >
+              <span>{group.label}</span>
+              <span className="flex items-center gap-1.5">
+                {activeCount > 0 && (
+                  <span className="rounded-full bg-surface-toggle-active px-1.5 py-px text-[10px] tabular-nums text-text-on-toggle-active">
+                    {activeCount}
                   </span>
-                </button>
-              );
-            })}
+                )}
+                <ChevronDown
+                  size={14}
+                  aria-hidden="true"
+                  className={`transition-transform ${isOpen ? "rotate-180" : ""}`}
+                />
+              </span>
+            </button>
+            {visibleOptions.length > 0 && (
+              <div className="flex flex-wrap gap-1.5 pb-2">
+                {visibleOptions.map((option) => {
+                  const fill = option.color ?? null;
+                  const fg = fill ? getReadableTextColor(fill) : null;
+                  const ringed = option.active || option.implied;
+                  return (
+                    <button
+                      key={option.value}
+                      type="button"
+                      aria-pressed={option.active}
+                      onClick={() => toggleFacet(group.category, option.value)}
+                      style={
+                        fill
+                          ? {
+                              backgroundColor: fill,
+                              color: fg!,
+                              borderColor: "transparent",
+                              boxShadow: ringed
+                                ? "0 0 0 2px var(--color-surface-primary), 0 0 0 3.5px var(--color-text-primary)"
+                                : undefined,
+                            }
+                          : undefined
+                      }
+                      className={`inline-flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-xs transition-colors focus-visible:outline-none lg:px-2.5 lg:py-1 focus-visible:ring-1 focus-visible:ring-text-tertiary/40 ${
+                        fill
+                          ? ""
+                          : option.active
+                            ? "border-transparent bg-surface-toggle-active text-text-on-toggle-active"
+                            : "border-border-primary text-text-secondary hover:border-text-tertiary/50 hover:text-text-primary"
+                      }`}
+                    >
+                      <span>{option.label}</span>
+                      <span
+                        style={{
+                          minWidth: `${String(option.maxCount).length}ch`,
+                        }}
+                        className={`inline-block text-center tabular-nums ${
+                          fill
+                            ? "opacity-70"
+                            : option.active
+                              ? "text-text-on-toggle-active/70"
+                              : "text-text-tertiary"
+                        }`}
+                      >
+                        {option.count}
+                      </span>
+                    </button>
+                  );
+                })}
+              </div>
+            )}
           </div>
-        </div>
-      ))}
+        );
+      })}
     </div>
   );
 };

--- a/web/components/layout/FacetFilter.tsx
+++ b/web/components/layout/FacetFilter.tsx
@@ -3,16 +3,18 @@
 
 "use client";
 
-import React, { useState } from "react";
+import React from "react";
 import { ChevronDown } from "lucide-react";
 import { useDashboard } from "@/contexts/DashboardContext";
+import { useSidebarMenu } from "@/contexts/SidebarMenuContext";
 
 const COLLAPSE_THRESHOLD = 8;
 
 const FacetFilter: React.FC = () => {
   const { facetGroups, toggleFacet, clearFacets, hasActiveFacets } =
     useDashboard();
-  const [openGroups, setOpenGroups] = useState<Record<string, boolean>>({});
+  const { openFacetGroups: openGroups, setOpenFacetGroups: setOpenGroups } =
+    useSidebarMenu();
 
   if (facetGroups.length === 0) return null;
 

--- a/web/components/layout/FacetFilter.tsx
+++ b/web/components/layout/FacetFilter.tsx
@@ -6,7 +6,6 @@
 import React, { useState } from "react";
 import { ChevronDown } from "lucide-react";
 import { useDashboard } from "@/contexts/DashboardContext";
-import { getReadableTextColor } from "@/lib/utils/colors";
 
 const COLLAPSE_THRESHOLD = 8;
 
@@ -76,32 +75,17 @@ const FacetFilter: React.FC = () => {
             {visibleOptions.length > 0 && (
               <div className="flex flex-wrap gap-1.5 pb-2">
                 {visibleOptions.map((option) => {
-                  const fill = option.color ?? null;
-                  const fg = fill ? getReadableTextColor(fill) : null;
-                  const ringed = option.active || option.implied;
                   return (
                     <button
                       key={option.value}
                       type="button"
                       aria-pressed={option.active}
                       onClick={() => toggleFacet(group.category, option.value)}
-                      style={
-                        fill
-                          ? {
-                              backgroundColor: fill,
-                              color: fg!,
-                              borderColor: "transparent",
-                              boxShadow: ringed
-                                ? "0 0 0 2px var(--color-surface-primary), 0 0 0 3.5px var(--color-text-primary)"
-                                : undefined,
-                            }
-                          : undefined
-                      }
                       className={`inline-flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-xs transition-colors focus-visible:outline-none lg:px-2.5 lg:py-1 focus-visible:ring-1 focus-visible:ring-text-tertiary/40 ${
-                        fill
-                          ? ""
-                          : option.active
-                            ? "border-transparent bg-surface-toggle-active text-text-on-toggle-active"
+                        option.active
+                          ? "border-transparent bg-surface-toggle-active text-text-on-toggle-active"
+                          : option.implied
+                            ? "border-text-primary text-text-primary"
                             : "border-border-primary text-text-secondary hover:border-text-tertiary/50 hover:text-text-primary"
                       }`}
                     >
@@ -111,11 +95,9 @@ const FacetFilter: React.FC = () => {
                           minWidth: `${String(option.maxCount).length}ch`,
                         }}
                         className={`inline-block text-center font-mono tabular-nums ${
-                          fill
-                            ? "opacity-70"
-                            : option.active
-                              ? "text-text-on-toggle-active/70"
-                              : "text-text-tertiary"
+                          option.active
+                            ? "text-text-on-toggle-active/70"
+                            : "text-text-tertiary"
                         }`}
                       >
                         {option.count}

--- a/web/components/layout/FacetFilter.tsx
+++ b/web/components/layout/FacetFilter.tsx
@@ -57,12 +57,12 @@ const FacetFilter: React.FC = () => {
                   [group.category]: !isOpen,
                 }))
               }
-              className="flex min-h-11 w-full items-center justify-between gap-2 py-2 text-[11px] font-semibold uppercase tracking-wide text-text-tertiary transition-colors hover:text-text-primary lg:min-h-0"
+              className="flex min-h-11 w-full items-center justify-between gap-2 py-2 font-mono text-[13px] text-text-tertiary transition-colors hover:text-text-primary lg:min-h-0"
             >
               <span>{group.label}</span>
               <span className="flex items-center gap-1.5">
                 {activeCount > 0 && (
-                  <span className="rounded-full bg-surface-toggle-active px-1.5 py-px text-[10px] tabular-nums text-text-on-toggle-active">
+                  <span className="rounded-full bg-surface-toggle-active px-1.5 py-px font-mono text-[10px] tabular-nums text-text-on-toggle-active">
                     {activeCount}
                   </span>
                 )}
@@ -110,7 +110,7 @@ const FacetFilter: React.FC = () => {
                         style={{
                           minWidth: `${String(option.maxCount).length}ch`,
                         }}
-                        className={`inline-block text-center tabular-nums ${
+                        className={`inline-block text-center font-mono tabular-nums ${
                           fill
                             ? "opacity-70"
                             : option.active

--- a/web/hooks/useSidebarMenuState.ts
+++ b/web/hooks/useSidebarMenuState.ts
@@ -7,5 +7,6 @@ import { useState } from "react";
 
 export function useSidebarMenuState() {
   const [mobileSheetOpen, setMobileSheetOpen] = useState(false);
-  return { mobileSheetOpen, setMobileSheetOpen };
+  const [openFacetGroups, setOpenFacetGroups] = useState<Record<string, boolean>>({});
+  return { mobileSheetOpen, setMobileSheetOpen, openFacetGroups, setOpenFacetGroups };
 }

--- a/web/lib/config/colors.ts
+++ b/web/lib/config/colors.ts
@@ -14,12 +14,14 @@
 // from OKLCH anchors — see the brand guide color families.
 
 export const modelColors: Record<string, string> = {
-  // OpenAI — rose. TTS, STT, and S2S span the rose range.
+  // OpenAI — rose. TTS, STT, and S2S span the rose range. Cross-hosted models
+  // follow their lab's family, so Together-hosted Whisper sits here too.
   "gpt-4o-mini-tts": "#de6d9b",
   "gpt-4o-transcribe": "#f782b1",
   "gpt-4o-mini-transcribe": "#d1608f",
   "gpt-realtime-whisper": "#b24574",
   "gpt-realtime": "#c35483", // S2S
+  "together:whisper-large-v3": "#8f3055",
 
   // Google — sky (light blue). Chirp STT + Gemini realtime.
   chirp_2: "#53b0de",
@@ -98,7 +100,6 @@ export const modelColors: Record<string, string> = {
   "nemotron-3-asr-streaming-0.6b": "#62ab5b",
   "nemotron-3.5-asr-streaming-0.6b": "#4a9243",
   "parakeet-tdt-0.6b-v3": "#33792c",
-  "together:whisper-large-v3": "#1c6016",
 
   // Composite keys for models whose slug is shared across providers
   "speechmatics:default": "#a24112",

--- a/web/lib/config/colors.ts
+++ b/web/lib/config/colors.ts
@@ -115,6 +115,8 @@ export const providerColors: Record<string, string> = {
   Rime: "#3c8836",
   Gradium: "#74c16c",
   Hume: "#59b7e4",
+  "Fish Audio": "#ec79a8",
+  MiniMax: "#3cc3ab",
   "Inworld AI": "#8b85de",
   xAI: "#c890ea",
   Soniox: "#859704",

--- a/web/lib/utils/colors.ts
+++ b/web/lib/utils/colors.ts
@@ -51,6 +51,9 @@ const PROVIDER_ID_ALIASES: Record<string, string> = {
   openai: "OpenAI",
   xai: "xAI",
   inworld: "Inworld AI",
+  fishaudio: "Fish Audio",
+  minimax: "MiniMax",
+  together: "Together AI",
 };
 
 /** Map a raw provider id (from a "provider:model" key) to its providerColors key. */
@@ -120,6 +123,15 @@ export function getModelColor(modelKey: string): string {
       const step = ((Math.abs(hashCode(model)) % 3) - 1) * 0.16; // -0.16 | 0 | +0.16
       return step === 0 ? base : shiftLightness(base, step);
     }
+  }
+
+  if (provider) {
+    // Unknown provider: hash the provider (not the model) into an anchor so
+    // its models still share one family, shaded per model like above.
+    const base =
+      fallbackColors[Math.abs(hashCode(provider)) % fallbackColors.length] ?? "#70a6f5";
+    const step = ((Math.abs(hashCode(model)) % 3) - 1) * 0.16;
+    return step === 0 ? base : shiftLightness(base, step);
   }
 
   const hash = hashCode(modelKey);

--- a/web/lib/utils/facets.test.ts
+++ b/web/lib/utils/facets.test.ts
@@ -29,7 +29,7 @@ const TAG_CATEGORIES: TagCategoryOut[] = [
   { category: "type", label: "Type", provider_valued: false },
   { category: "mode", label: "Mode", provider_valued: false },
   { category: "host", label: "Host", provider_valued: true },
-  { category: "lab", label: "Lab", provider_valued: true },
+  { category: "creator", label: "Creator", provider_valued: true },
   { category: "features", label: "Features", provider_valued: false },
 ];
 
@@ -65,8 +65,8 @@ const index = () => buildTagIndex("STT", PROVIDERS);
 const cats = () => getTagCategories(PROVIDERS);
 
 describe("getTagCategories", () => {
-  it("hoists lab above host, keeping the rest in API order", () => {
-    expect(cats().map((c) => c.category)).toEqual(["type", "mode", "lab", "host", "features"]);
+  it("hoists creator above host, keeping the rest in API order", () => {
+    expect(cats().map((c) => c.category)).toEqual(["type", "mode", "creator", "host", "features"]);
   });
 });
 

--- a/web/lib/utils/facets.test.ts
+++ b/web/lib/utils/facets.test.ts
@@ -29,6 +29,7 @@ const TAG_CATEGORIES: TagCategoryOut[] = [
   { category: "type", label: "Type", provider_valued: false },
   { category: "mode", label: "Mode", provider_valued: false },
   { category: "host", label: "Host", provider_valued: true },
+  { category: "lab", label: "Lab", provider_valued: true },
   { category: "features", label: "Features", provider_valued: false },
 ];
 
@@ -62,6 +63,12 @@ const ALL: ModelsByProvider = {
 
 const index = () => buildTagIndex("STT", PROVIDERS);
 const cats = () => getTagCategories(PROVIDERS);
+
+describe("getTagCategories", () => {
+  it("hoists lab above host, keeping the rest in API order", () => {
+    expect(cats().map((c) => c.category)).toEqual(["type", "mode", "lab", "host", "features"]);
+  });
+});
 
 describe("filterModelsByFacets", () => {
   it("returns everything when nothing is selected", () => {

--- a/web/lib/utils/facets.ts
+++ b/web/lib/utils/facets.ts
@@ -37,14 +37,15 @@ export interface FacetGroup {
 }
 
 /**
- * The facet vocabulary (categories, labels) — sourced from the API, except lab
- * is hoisted above host: who built a model matters more than who serves it.
+ * The facet vocabulary (categories, labels) — sourced from the API, except
+ * creator is hoisted above host: who built a model matters more than who
+ * serves it.
  */
 export function getTagCategories(providers?: ProvidersApiResponse): TagCategoryOut[] {
   const categories = [...(providers?.tag_categories ?? [])];
-  const lab = categories.findIndex((c) => c.category === "lab");
+  const creator = categories.findIndex((c) => c.category === "creator");
   const host = categories.findIndex((c) => c.category === "host");
-  if (host !== -1 && lab > host) categories.splice(host, 0, ...categories.splice(lab, 1));
+  if (host !== -1 && creator > host) categories.splice(host, 0, ...categories.splice(creator, 1));
   return categories;
 }
 

--- a/web/lib/utils/facets.ts
+++ b/web/lib/utils/facets.ts
@@ -36,9 +36,16 @@ export interface FacetGroup {
   options: FacetOption[];
 }
 
-/** The facet vocabulary (categories, labels, order) — sourced entirely from the API. */
+/**
+ * The facet vocabulary (categories, labels) — sourced from the API, except lab
+ * is hoisted above host: who built a model matters more than who serves it.
+ */
 export function getTagCategories(providers?: ProvidersApiResponse): TagCategoryOut[] {
-  return providers?.tag_categories ?? [];
+  const categories = [...(providers?.tag_categories ?? [])];
+  const lab = categories.findIndex((c) => c.category === "lab");
+  const host = categories.findIndex((c) => c.category === "host");
+  if (host !== -1 && lab > host) categories.splice(host, 0, ...categories.splice(lab, 1));
+  return categories;
 }
 
 /** Map every catalogue model's composite key to its tags. */


### PR DESCRIPTION
## Summary
<img width="1858" height="955" alt="Screenshot 2026-07-17 at 2 02 54 PM" src="https://github.com/user-attachments/assets/5fdf1f19-027b-45f6-8afb-d22b414b9462" />

Refactors the dashboard filter panel per BENCH-507 and aligns it with the Coval brand guidelines. One shared component (`FacetFilter`) drives both the desktop sidebar and the mobile bottom sheet, so all changes apply to both surfaces.

- **Collapsible dropdown groups**: each facet group is now a disclosure with a full-width header (label, active-count badge, chevron). Groups with more than 8 options (Host/Lab) collapse by default; small groups start open. The threshold rule means Features will collapse itself automatically as it grows. Collapsed groups still render their *active* chips, so selections are never hidden.
- **Brand typography**: section labels and counts use Geist Mono, Regular 400, zero letter-spacing, sentence case at 13px — matching the brand's `.eyebrow`/`.spec-label` caption spec.
- **Neutral chips**: provider chips drop the per-provider brand colors for the theme-aware neutral treatment already used by Features/Source chips (ink-on-white / white-on-ink depending on theme). Legend-implied providers get a strong border in place of the old colored ring.
- **Lab above Host**: `getTagCategories` hoists `lab` ahead of `host` — who built the model matters more than who serves it. Covered by a new unit test.
- **Chart color families**: models of the same provider now always share one hue family:
  - Added missing `providerColors` entries (Fish Audio, MiniMax) and id aliases (`fishaudio`, `minimax`, `together`) that previously fell through to random per-model hash colors.
  - The last-resort fallback now hashes the *provider* (not the model) into a palette anchor, so any future unmapped provider still gets one family.
  - Together-hosted Whisper Large v3 moved into OpenAI's rose family — cross-hosted models follow their **lab's** family, consistent with the Lab-first ordering.

## Mobile

Headers are 44px tap targets below `lg`, chips get larger padding, everything is tap-based (no hover dependency), and state was verified in the 375px bottom sheet.

## Testing

- 57 unit tests pass (one added for the Lab/Host ordering), typecheck and `eslint --max-warnings 0` clean.
- Manually verified in the browser on desktop and mobile viewports, light and dark themes: expand/collapse, chip toggle states (default/active/implied), collapsed-state selection visibility, and chart line families for Fish Audio, MiniMax, and LAB=OpenAI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR refreshes the dashboard filter panel and provider color handling. The main changes are:

- Shared disclosure state for desktop and mobile filters.
- Collapsible facet groups with active selections kept visible.
- Updated typography, chips, spacing, and mobile tap targets.
- Lab-first facet ordering with unit coverage.
- Provider-based chart color families and aliases.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- The desktop and mobile filters now use the same disclosure state.
- Breakpoint changes keep both filter instances mounted, so the shared state is preserved.
- No blocking issues were found in the updated fix.

<sub>Reviews (3): Last reviewed commit: ["Rename lab facet to creator in category ..."](https://github.com/coval-ai/benchmarks/commit/242ff7302d574a61d9729d3470c4565f28f1ffd3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45214828)</sub>

<!-- /greptile_comment -->