### PR TITLE
Retire Together nemotron-3 ASR streaming

### DIFF
--- a/runner/src/coval_bench/registries/models.py
+++ b/runner/src/coval_bench/registries/models.py
@@ -320,7 +320,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         source=Source.SHARED_INFERENCE,
         tags=(_STREAMING,),
         licensing=_OPEN,
-        status=_ACTIVE,
+        status=_RETIRED,
     ),
     RegisteredModel(
         benchmark=_STT,

--- a/web/lib/config/colors.ts
+++ b/web/lib/config/colors.ts
@@ -94,7 +94,6 @@ export const modelColors: Record<string, string> = {
 
   // Together AI — green, dark range (STT; Rime's greens are TTS-only and
   // Gradium's STT default sits in the light range, so they stay apart).
-  "nemotron-3-asr-streaming-0.6b": "#62ab5b",
   "nemotron-3.5-asr-streaming-0.6b": "#4a9243",
   "parakeet-tdt-0.6b-v3": "#33792c",
   "together:whisper-large-v3": "#1c6016",

--- a/web/lib/utils/formatters.ts
+++ b/web/lib/utils/formatters.ts
@@ -131,7 +131,6 @@ export function normalizeModelName(modelKey: string): string {
     "ink-2": "Ink 2",
     "stt-rt-v5": "STT RT v5",
     "inworld-stt-1": "STT 1",
-    "nemotron-3-asr-streaming-0.6b": "Nemotron 3 ASR Streaming",
     "nemotron-3.5-asr-streaming-0.6b": "Nemotron 3.5 ASR Streaming",
     "parakeet-tdt-0.6b-v3": "Parakeet TDT 0.6B v3",
     "whisper-large-v3": "Whisper Large v3",


### PR DESCRIPTION
The WildASR datasets expose a server-side endpoint stall on nearly half its clips, so flip it to retired in the registry and drop its web color/label entries.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR retires Together's Nemotron 3 ASR streaming model and removes its dedicated web metadata. The main changes are:

- Marks the model as retired in the runner registry.
- Removes its fixed chart color.
- Removes its explicit display-name mapping.

<h3>Confidence Score: 4/5</h3>

The explicit probe path can still invoke the retired endpoint.

- Scheduled benchmark runs correctly exclude the model.
- Web color and label helpers retain usable fallbacks.
- Explicit CLI selectors bypass the retirement status and can still contact the stalled service.

runner/src/coval_bench/registries/models.py and runner/src/coval_bench/__main__.py

<sub>Reviews (1): Last reviewed commit: ["Retire Together nemotron-3 ASR streaming"](https://github.com/coval-ai/benchmarks/commit/8d8aa2ed24753eebcb52ff06996e824830695ef9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45234443)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->