### PR TITLE
Sample one shared utterance's recordings per S2S fetch tick

### DIFF
--- a/runner/src/coval_bench/config.py
+++ b/runner/src/coval_bench/config.py
@@ -129,6 +129,8 @@ class Settings(BaseSettings):
     s2s_fetch_period_seconds: int = Field(default=10_800, gt=0)
     # Staleness threshold = fetch period + this grace.
     s2s_stale_grace_seconds: int = Field(default=0, ge=0)
+    # Public bucket for per-tick sample recordings; empty disables sampling.
+    s2s_samples_bucket: str = ""
 
     # --- Analytics ---
     posthog_project_token: str = ""

--- a/runner/src/coval_bench/s2s/fetch_v2v.py
+++ b/runner/src/coval_bench/s2s/fetch_v2v.py
@@ -304,22 +304,22 @@ async def _fetch_one_provider(
     caught here so one provider can't abort others.
     """
     statuses: list[RunStatus] = []
+    candidate: SampleRun | None = None
 
     def note_sample_candidate(coval_run: CovalRun) -> None:
         # Newest-first scan: the first eligible run per provider is its newest,
         # whether it was ingested this tick or on an earlier one — staggered
-        # arrivals must not shrink the sample to one provider.
-        if sampled_runs is None or any(r.provider == spec.provider for r in sampled_runs):
+        # arrivals must not shrink the sample to one provider. Held locally and
+        # committed only after the staleness check, so a stale provider's old
+        # recording never ships under today's tick.
+        nonlocal candidate
+        if candidate is not None:
             return
-        sampled_runs.append(
-            SampleRun(
-                provider=spec.provider,
-                model=spec.model,
-                coval_run_id=coval_run.run_id,
-                bucket_at=_bucket_start(
-                    coval_run.create_time or datetime.now(tz=UTC), period_seconds
-                ),
-            )
+        candidate = SampleRun(
+            provider=spec.provider,
+            model=spec.model,
+            coval_run_id=coval_run.run_id,
+            bucket_at=_bucket_start(coval_run.create_time or datetime.now(tz=UTC), period_seconds),
         )
 
     try:
@@ -379,6 +379,9 @@ async def _fetch_one_provider(
             )
             return RunStatus.FAILED, len(statuses)
 
+        if sampled_runs is not None and candidate is not None:
+            sampled_runs.append(candidate)
+
         if statuses:
             if all(s is RunStatus.FAILED for s in statuses):
                 return RunStatus.FAILED, len(statuses)
@@ -434,7 +437,7 @@ async def fetch_and_write_v2v(settings: Settings | None = None) -> dict[str, Run
             except Exception:
                 logger.warning("refresh_stats_matviews_failed", exc_info=True)
 
-        if settings.s2s_samples_bucket and total_ingested and sampled_runs:
+        if settings.s2s_samples_bucket and sampled_runs:
             expected = {spec.provider for spec in AGENTS if getattr(settings, spec.agent_id_attr)}
             missing = expected - {r.provider for r in sampled_runs}
             if missing:

--- a/runner/src/coval_bench/s2s/fetch_v2v.py
+++ b/runner/src/coval_bench/s2s/fetch_v2v.py
@@ -304,6 +304,24 @@ async def _fetch_one_provider(
     caught here so one provider can't abort others.
     """
     statuses: list[RunStatus] = []
+
+    def note_sample_candidate(coval_run: CovalRun) -> None:
+        # Newest-first scan: the first eligible run per provider is its newest,
+        # whether it was ingested this tick or on an earlier one — staggered
+        # arrivals must not shrink the sample to one provider.
+        if sampled_runs is None or any(r.provider == spec.provider for r in sampled_runs):
+            return
+        sampled_runs.append(
+            SampleRun(
+                provider=spec.provider,
+                model=spec.model,
+                coval_run_id=coval_run.run_id,
+                bucket_at=_bucket_start(
+                    coval_run.create_time or datetime.now(tz=UTC), period_seconds
+                ),
+            )
+        )
+
     try:
         runs = await recent_completed_runs(client, agent_id, period_seconds=period_seconds)
 
@@ -324,6 +342,7 @@ async def _fetch_one_provider(
                 logger.info(
                     "run_already_ingested", provider=spec.provider, coval_run_id=coval_run.run_id
                 )
+                note_sample_candidate(coval_run)
                 if not data_seen:
                     data_seen, newest_data_at = True, coval_run.create_time
                 continue
@@ -338,21 +357,8 @@ async def _fetch_one_provider(
             )
             if status is None:
                 continue
-            if (
-                sampled_runs is not None
-                and status is not RunStatus.FAILED
-                and not any(r.provider == spec.provider for r in sampled_runs)
-            ):
-                sampled_runs.append(
-                    SampleRun(
-                        provider=spec.provider,
-                        model=spec.model,
-                        coval_run_id=coval_run.run_id,
-                        bucket_at=_bucket_start(
-                            coval_run.create_time or datetime.now(tz=UTC), period_seconds
-                        ),
-                    )
-                )
+            if status is not RunStatus.FAILED:
+                note_sample_candidate(coval_run)
             statuses.append(status)
             if not data_seen:
                 data_seen, newest_data_at = True, coval_run.create_time
@@ -428,7 +434,13 @@ async def fetch_and_write_v2v(settings: Settings | None = None) -> dict[str, Run
             except Exception:
                 logger.warning("refresh_stats_matviews_failed", exc_info=True)
 
-        if settings.s2s_samples_bucket and sampled_runs:
+        if settings.s2s_samples_bucket and total_ingested and sampled_runs:
+            expected = {spec.provider for spec in AGENTS if getattr(settings, spec.agent_id_attr)}
+            missing = expected - {r.provider for r in sampled_runs}
+            if missing:
+                # Error level on purpose: this is the alert that a provider is
+                # absent from the day's sample; the tick still publishes the rest.
+                logger.error("samples_provider_missing", missing=sorted(missing))
             await copy_tick_samples(
                 client,
                 bucket_name=settings.s2s_samples_bucket,

--- a/runner/src/coval_bench/s2s/fetch_v2v.py
+++ b/runner/src/coval_bench/s2s/fetch_v2v.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import importlib.resources
+import random
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any, cast
@@ -27,6 +28,7 @@ from coval_bench.db.models import Result, ResultStatus, RunStatus
 from coval_bench.db.writer import RunWriter
 from coval_bench.registries import Metric
 from coval_bench.registries.benchmarks import Benchmark
+from coval_bench.s2s.samples import SampleRun, copy_tick_samples
 
 logger = structlog.get_logger("coval_bench.s2s.fetch_v2v")
 
@@ -291,6 +293,7 @@ async def _fetch_one_provider(
     runner_sha: str,
     period_seconds: int,
     stale_grace_seconds: int,
+    sampled_runs: list[SampleRun] | None = None,
 ) -> tuple[RunStatus, int]:
     """Scan the window and ingest every clean, not-yet-ingested run.
 
@@ -335,6 +338,21 @@ async def _fetch_one_provider(
             )
             if status is None:
                 continue
+            if (
+                sampled_runs is not None
+                and status is not RunStatus.FAILED
+                and not any(r.provider == spec.provider for r in sampled_runs)
+            ):
+                sampled_runs.append(
+                    SampleRun(
+                        provider=spec.provider,
+                        model=spec.model,
+                        coval_run_id=coval_run.run_id,
+                        bucket_at=_bucket_start(
+                            coval_run.create_time or datetime.now(tz=UTC), period_seconds
+                        ),
+                    )
+                )
             statuses.append(status)
             if not data_seen:
                 data_seen, newest_data_at = True, coval_run.create_time
@@ -385,6 +403,7 @@ async def fetch_and_write_v2v(settings: Settings | None = None) -> dict[str, Run
         writer = RunWriter(pool)
         statuses: dict[str, RunStatus] = {}
         total_ingested = 0
+        sampled_runs: list[SampleRun] = []
         for spec in AGENTS:
             agent_id = getattr(settings, spec.agent_id_attr)
             if not agent_id:
@@ -399,6 +418,7 @@ async def fetch_and_write_v2v(settings: Settings | None = None) -> dict[str, Run
                 runner_sha=settings.runner_sha,
                 period_seconds=settings.s2s_fetch_period_seconds,
                 stale_grace_seconds=settings.s2s_stale_grace_seconds,
+                sampled_runs=sampled_runs,
             )
             total_ingested += ingested
 
@@ -407,6 +427,14 @@ async def fetch_and_write_v2v(settings: Settings | None = None) -> dict[str, Run
                 await writer.refresh_stats_matviews()
             except Exception:
                 logger.warning("refresh_stats_matviews_failed", exc_info=True)
+
+        if settings.s2s_samples_bucket and sampled_runs:
+            await copy_tick_samples(
+                client,
+                bucket_name=settings.s2s_samples_bucket,
+                runs=sampled_runs,
+                rng=random.Random(),  # noqa: S311
+            )
         logger.info(
             "s2s_fetch_done",
             statuses={p: str(s) for p, s in statuses.items()},

--- a/runner/src/coval_bench/s2s/samples.py
+++ b/runner/src/coval_bench/s2s/samples.py
@@ -1,0 +1,228 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Copy one shared utterance's conversation recordings into the samples bucket.
+
+Each fetch tick picks ONE dataset clip present in every provider's newest
+ingested run and copies that clip's reconstructed conversation recording from
+each provider into the public samples bucket, next to a ``manifest.json``
+keyed by the timeline bucket timestamp. The dashboard reads the manifests
+directly (public bucket, no API hop); a rolling ``index.json`` lists the
+available ticks newest-first. The bucket's 30-day TTL prunes old ticks.
+
+Sampling failures never fail the fetch — the metric rows are the product.
+"""
+
+from __future__ import annotations
+
+import importlib.resources
+import json
+from dataclasses import dataclass
+from datetime import datetime
+from typing import TYPE_CHECKING, Any, cast
+
+import httpx
+import structlog
+
+if TYPE_CHECKING:
+    from random import Random
+
+    from google.cloud import storage
+
+logger = structlog.get_logger("coval_bench.s2s.samples")
+
+PREFIX = "s2s-samples"
+INDEX_KEY = f"{PREFIX}/index.json"
+_INDEX_MAX_ENTRIES = 60
+_PUBLIC_DATASET_BASE = "https://storage.googleapis.com/coval-benchmarks-datasets/s2s-v1"
+_DOWNLOAD_TIMEOUT = 120.0
+
+
+@dataclass(frozen=True)
+class SampleRun:
+    """One provider's newest ingested run, eligible for this tick's sample."""
+
+    provider: str
+    model: str
+    coval_run_id: str
+    bucket_at: datetime
+
+
+def _norm(text: str) -> str:
+    return " ".join(text.split()).casefold()
+
+
+def _clips_by_transcript() -> dict[str, str]:
+    """Packaged-manifest transcript -> public dataset clip path."""
+    ref = importlib.resources.files("coval_bench.datasets.manifests").joinpath("s2s-v1.json")
+    manifest = json.loads(ref.read_bytes())
+    return {
+        _norm(item["transcript"]): cast("str", item["path"])
+        for item in manifest["items"]
+        if item.get("transcript") and item.get("path")
+    }
+
+
+def _input_transcript(sim: dict[str, Any]) -> str | None:
+    """First user turn of the conversation — the utterance the model heard."""
+    for message in cast("list[dict[str, Any]]", sim.get("transcript") or []):
+        if message.get("role") == "user":
+            content = message.get("content")
+            return content if isinstance(content, str) else None
+    return None
+
+
+async def _sims_by_test_case(client: httpx.AsyncClient, coval_run_id: str) -> dict[str, str]:
+    """Map test_case_id -> simulation id for one run (run_id is AIP-160-filterable)."""
+    resp = await client.get(
+        "/simulations", params={"filter": f'run_id="{coval_run_id}"', "page_size": 100}
+    )
+    resp.raise_for_status()
+    payload = resp.json()
+    items = next((v for v in payload.values() if isinstance(v, list)), [])
+    return {
+        cast("str", s["test_case_id"]): cast("str", s["simulation_id"])
+        for s in cast("list[dict[str, Any]]", items)
+        if s.get("test_case_id") and s.get("simulation_id")
+    }
+
+
+async def _download_recording(
+    client: httpx.AsyncClient, download_client: httpx.AsyncClient, sim_id: str
+) -> bytes | None:
+    """Recording bytes via the presigned URL; None when the object is gone."""
+    url_resp = await client.get(f"/simulations/{sim_id}/audio")
+    if url_resp.status_code == 404:
+        return None
+    url_resp.raise_for_status()
+    audio_url = cast("str", url_resp.json()["audio_url"])
+    blob = await download_client.get(audio_url)
+    blob.raise_for_status()
+    return blob.content
+
+
+def _upload(bucket: storage.Bucket, key: str, data: bytes, content_type: str) -> None:
+    bucket.blob(key).upload_from_string(data, content_type=content_type)
+
+
+def _update_index(bucket: storage.Bucket, tick_key: str) -> None:
+    """Prepend the tick to index.json (single daily writer — no race to guard)."""
+    blob = bucket.blob(INDEX_KEY)
+    try:
+        ticks = cast("list[str]", json.loads(blob.download_as_bytes()))
+    except Exception:
+        ticks = []
+    ticks = [tick_key, *(t for t in ticks if t != tick_key)][:_INDEX_MAX_ENTRIES]
+    _upload(bucket, INDEX_KEY, json.dumps(ticks).encode(), "application/json")
+
+
+async def copy_tick_samples(
+    client: httpx.AsyncClient,
+    *,
+    bucket_name: str,
+    runs: list[SampleRun],
+    rng: Random,
+    storage_client: storage.Client | None = None,
+    download_client: httpx.AsyncClient | None = None,
+) -> int:
+    """Copy this tick's shared-clip recordings; return how many were stored.
+
+    Never raises: any failure is logged and the tick is simply skipped or
+    shipped with fewer providers.
+    """
+    if not bucket_name or not runs:
+        return 0
+    try:
+        async with httpx.AsyncClient(timeout=_DOWNLOAD_TIMEOUT) as default_download:
+            return await _copy_tick_samples(
+                client,
+                download_client or default_download,
+                bucket_name=bucket_name,
+                runs=runs,
+                rng=rng,
+                storage_client=storage_client,
+            )
+    except Exception:
+        logger.warning("samples_tick_failed", exc_info=True)
+        return 0
+
+
+async def _copy_tick_samples(
+    client: httpx.AsyncClient,
+    download_client: httpx.AsyncClient,
+    *,
+    bucket_name: str,
+    runs: list[SampleRun],
+    rng: Random,
+    storage_client: storage.Client | None,
+) -> int:
+    sims_per_run: dict[str, dict[str, str]] = {}
+    for run in runs:
+        sims_per_run[run.coval_run_id] = await _sims_by_test_case(client, run.coval_run_id)
+
+    shared = set.intersection(*(set(m) for m in sims_per_run.values()))
+    if not shared:
+        logger.warning("samples_no_shared_clip", runs=[r.coval_run_id for r in runs])
+        return 0
+    test_case_id = rng.choice(sorted(shared))
+
+    if storage_client is None:  # pragma: no cover -- real client only outside tests
+        from google.cloud import storage as gcs
+
+        storage_client = gcs.Client()
+    bucket = storage_client.bucket(bucket_name)
+
+    # Providers of one Coval round land in the same daily bucket; if they ever
+    # straddle midnight, key the folder by the newest so the timeline join
+    # points at data that exists.
+    tick_key = max(r.bucket_at for r in runs).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    transcript: str | None = None
+    recordings: list[dict[str, Any]] = []
+    for run in runs:
+        sim_id = sims_per_run[run.coval_run_id][test_case_id]
+        try:
+            if transcript is None:
+                detail = await client.get(f"/simulations/{sim_id}")
+                detail.raise_for_status()
+                transcript = _input_transcript(cast("dict[str, Any]", detail.json()))
+            audio = await _download_recording(client, download_client, sim_id)
+            if audio is None:
+                logger.warning("sample_audio_missing", provider=run.provider, sim_id=sim_id)
+                continue
+            key = f"{PREFIX}/{tick_key}/{run.provider}.wav"
+            _upload(bucket, key, audio, "audio/wav")
+            recordings.append(
+                {
+                    "provider": run.provider,
+                    "model": run.model,
+                    "object": key,
+                    "coval_run_id": run.coval_run_id,
+                    "sim_id": sim_id,
+                }
+            )
+        except Exception:
+            logger.warning(
+                "sample_copy_failed", provider=run.provider, sim_id=sim_id, exc_info=True
+            )
+
+    if not recordings:
+        return 0
+
+    clip_path = _clips_by_transcript().get(_norm(transcript)) if transcript else None
+    manifest = {
+        "bucket_at": tick_key,
+        "test_case_id": test_case_id,
+        "transcript": transcript,
+        "input_audio_url": f"{_PUBLIC_DATASET_BASE}/{clip_path}" if clip_path else None,
+        "recordings": recordings,
+    }
+    _upload(
+        bucket,
+        f"{PREFIX}/{tick_key}/manifest.json",
+        json.dumps(manifest).encode(),
+        "application/json",
+    )
+    _update_index(bucket, tick_key)
+    logger.info("samples_tick_stored", tick=tick_key, recordings=len(recordings))
+    return len(recordings)

--- a/runner/src/coval_bench/s2s/samples.py
+++ b/runner/src/coval_bench/s2s/samples.py
@@ -17,12 +17,16 @@ from __future__ import annotations
 
 import importlib.resources
 import json
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, cast
 
 import httpx
 import structlog
+from google.api_core.exceptions import NotFound
+
+from coval_bench.runner.retry import with_retry
 
 if TYPE_CHECKING:
     from random import Random
@@ -53,14 +57,19 @@ def _norm(text: str) -> str:
 
 
 def _clips_by_transcript() -> dict[str, str]:
-    """Packaged-manifest transcript -> public dataset clip path."""
+    """Packaged-manifest transcript -> public dataset clip path, unambiguous only.
+
+    Several transcripts appear on multiple clips (different speakers); those
+    can't be resolved by text, so they're dropped and the sample ships with
+    input_audio_url = null rather than possibly the wrong recording.
+    """
     ref = importlib.resources.files("coval_bench.datasets.manifests").joinpath("s2s-v1.json")
     manifest = json.loads(ref.read_bytes())
-    return {
-        _norm(item["transcript"]): cast("str", item["path"])
-        for item in manifest["items"]
-        if item.get("transcript") and item.get("path")
-    }
+    paths_by_transcript: dict[str, set[str]] = {}
+    for item in manifest["items"]:
+        if item.get("transcript") and item.get("path"):
+            paths_by_transcript.setdefault(_norm(item["transcript"]), set()).add(item["path"])
+    return {t: next(iter(paths)) for t, paths in paths_by_transcript.items() if len(paths) == 1}
 
 
 def _input_transcript(sim: dict[str, Any]) -> str | None:
@@ -70,6 +79,23 @@ def _input_transcript(sim: dict[str, Any]) -> str | None:
             content = message.get("content")
             return content if isinstance(content, str) else None
     return None
+
+
+async def _fetch_retry[T](fn: Callable[[], Awaitable[T]], *, provider: str, what: str) -> T:
+    """with_retry for Coval fetches, alerting (error log) on the FIRST failure."""
+    first = True
+
+    async def attempt() -> T:
+        nonlocal first
+        try:
+            return await fn()
+        except httpx.HTTPError:
+            if first:
+                first = False
+                logger.error("sample_fetch_failed", provider=provider, what=what)
+            raise
+
+    return await with_retry(attempt, max_attempts=2, retry_on=(httpx.HTTPError,))
 
 
 async def _sims_by_test_case(client: httpx.AsyncClient, coval_run_id: str) -> dict[str, str]:
@@ -106,12 +132,20 @@ def _upload(bucket: storage.Bucket, key: str, data: bytes, content_type: str) ->
 
 
 def _update_index(bucket: storage.Bucket, tick_key: str) -> None:
-    """Prepend the tick to index.json (single daily writer — no race to guard)."""
+    """Prepend the tick to index.json (single daily writer — no race to guard).
+
+    Only a confirmed missing object starts an empty index; any other read
+    failure leaves the existing index untouched so a transient error can't
+    erase the history.
+    """
     blob = bucket.blob(INDEX_KEY)
     try:
         ticks = cast("list[str]", json.loads(blob.download_as_bytes()))
-    except Exception:
+    except NotFound:
         ticks = []
+    except Exception:
+        logger.error("samples_index_read_failed", tick=tick_key, exc_info=True)
+        return
     ticks = [tick_key, *(t for t in ticks if t != tick_key)][:_INDEX_MAX_ENTRIES]
     _upload(bucket, INDEX_KEY, json.dumps(ticks).encode(), "application/json")
 
@@ -143,7 +177,7 @@ async def copy_tick_samples(
                 storage_client=storage_client,
             )
     except Exception:
-        logger.warning("samples_tick_failed", exc_info=True)
+        logger.error("samples_tick_failed", exc_info=True)
         return 0
 
 
@@ -158,11 +192,17 @@ async def _copy_tick_samples(
 ) -> int:
     sims_per_run: dict[str, dict[str, str]] = {}
     for run in runs:
-        sims_per_run[run.coval_run_id] = await _sims_by_test_case(client, run.coval_run_id)
+
+        async def list_sims(run: SampleRun = run) -> dict[str, str]:
+            return await _sims_by_test_case(client, run.coval_run_id)
+
+        sims_per_run[run.coval_run_id] = await _fetch_retry(
+            list_sims, provider=run.provider, what="sims_list"
+        )
 
     shared = set.intersection(*(set(m) for m in sims_per_run.values()))
     if not shared:
-        logger.warning("samples_no_shared_clip", runs=[r.coval_run_id for r in runs])
+        logger.error("samples_no_shared_clip", runs=[r.coval_run_id for r in runs])
         return 0
     test_case_id = rng.choice(sorted(shared))
 
@@ -177,18 +217,32 @@ async def _copy_tick_samples(
     # points at data that exists.
     tick_key = max(r.bucket_at for r in runs).strftime("%Y-%m-%dT%H:%M:%SZ")
 
+    manifest_key = f"{PREFIX}/{tick_key}/manifest.json"
+    if bucket.blob(manifest_key).exists():
+        logger.info("samples_tick_exists", tick=tick_key)
+        return 0
+
     transcript: str | None = None
     recordings: list[dict[str, Any]] = []
     for run in runs:
         sim_id = sims_per_run[run.coval_run_id][test_case_id]
         try:
             if transcript is None:
-                detail = await client.get(f"/simulations/{sim_id}")
-                detail.raise_for_status()
+
+                async def fetch_detail(sim_id: str = sim_id) -> httpx.Response:
+                    resp = await client.get(f"/simulations/{sim_id}")
+                    resp.raise_for_status()
+                    return resp
+
+                detail = await _fetch_retry(fetch_detail, provider=run.provider, what="sim_detail")
                 transcript = _input_transcript(cast("dict[str, Any]", detail.json()))
-            audio = await _download_recording(client, download_client, sim_id)
+
+            async def fetch_recording(sim_id: str = sim_id) -> bytes | None:
+                return await _download_recording(client, download_client, sim_id)
+
+            audio = await _fetch_retry(fetch_recording, provider=run.provider, what="recording")
             if audio is None:
-                logger.warning("sample_audio_missing", provider=run.provider, sim_id=sim_id)
+                logger.error("sample_audio_missing", provider=run.provider, sim_id=sim_id)
                 continue
             key = f"{PREFIX}/{tick_key}/{run.provider}.wav"
             _upload(bucket, key, audio, "audio/wav")
@@ -202,9 +256,7 @@ async def _copy_tick_samples(
                 }
             )
         except Exception:
-            logger.warning(
-                "sample_copy_failed", provider=run.provider, sim_id=sim_id, exc_info=True
-            )
+            logger.error("sample_copy_failed", provider=run.provider, sim_id=sim_id, exc_info=True)
 
     if not recordings:
         return 0

--- a/runner/src/coval_bench/s2s/samples.py
+++ b/runner/src/coval_bench/s2s/samples.py
@@ -106,8 +106,9 @@ async def _sims_by_test_case(client: httpx.AsyncClient, coval_run_id: str) -> di
     resp.raise_for_status()
     payload = resp.json()
     if payload.get("next_page_token"):
-        # 100 covers today's 50-clip dataset twice over; page instead of
-        # truncating silently if a future dataset outgrows it.
+        # 100 covers today's 50-clip dataset twice over; if a dataset outgrows
+        # it we proceed on the first page but alert, so paging gets added
+        # instead of shared clips silently going missing.
         logger.error("samples_sims_truncated", coval_run_id=coval_run_id)
     items = next((v for v in payload.values() if isinstance(v, list)), [])
     return {
@@ -204,9 +205,16 @@ async def _copy_tick_samples(
         async def list_sims(run: SampleRun = run) -> dict[str, str]:
             return await _sims_by_test_case(client, run.coval_run_id)
 
-        sims_per_run[run.coval_run_id] = await _fetch_retry(
-            list_sims, provider=run.provider, what="sims_list"
-        )
+        try:
+            sims_per_run[run.coval_run_id] = await _fetch_retry(
+                list_sims, provider=run.provider, what="sims_list"
+            )
+        except Exception:
+            logger.error("samples_provider_missing", missing=[run.provider], exc_info=True)
+
+    runs = [run for run in runs if run.coval_run_id in sims_per_run]
+    if not runs:
+        return 0
 
     shared = set.intersection(*(set(m) for m in sims_per_run.values()))
     if not shared:

--- a/runner/src/coval_bench/s2s/samples.py
+++ b/runner/src/coval_bench/s2s/samples.py
@@ -105,6 +105,10 @@ async def _sims_by_test_case(client: httpx.AsyncClient, coval_run_id: str) -> di
     )
     resp.raise_for_status()
     payload = resp.json()
+    if payload.get("next_page_token"):
+        # 100 covers today's 50-clip dataset twice over; page instead of
+        # truncating silently if a future dataset outgrows it.
+        logger.error("samples_sims_truncated", coval_run_id=coval_run_id)
     items = next((v for v in payload.values() if isinstance(v, list)), [])
     return {
         cast("str", s["test_case_id"]): cast("str", s["simulation_id"])
@@ -139,8 +143,12 @@ def _update_index(bucket: storage.Bucket, tick_key: str) -> None:
     erase the history.
     """
     blob = bucket.blob(INDEX_KEY)
+    ticks: list[str]
     try:
-        ticks = cast("list[str]", json.loads(blob.download_as_bytes()))
+        decoded = json.loads(blob.download_as_bytes())
+        if not isinstance(decoded, list) or not all(isinstance(t, str) for t in decoded):
+            raise ValueError("index.json must be a list of tick strings")
+        ticks = decoded
     except NotFound:
         ticks = []
     except Exception:
@@ -219,6 +227,9 @@ async def _copy_tick_samples(
 
     manifest_key = f"{PREFIX}/{tick_key}/manifest.json"
     if bucket.blob(manifest_key).exists():
+        # Idempotent repair: a prior run may have published the manifest but
+        # failed the index update, leaving the tick invisible.
+        _update_index(bucket, tick_key)
         logger.info("samples_tick_exists", tick=tick_key)
         return 0
 

--- a/runner/tests/unit/test_s2s_fetch.py
+++ b/runner/tests/unit/test_s2s_fetch.py
@@ -456,3 +456,29 @@ async def test_newest_run_is_the_sample_candidate_once() -> None:
             sampled_runs=sampled,
         )
     assert [r.coval_run_id for r in sampled] == ["R2"]
+
+
+@pytest.mark.asyncio
+async def test_stale_provider_lends_no_sample_candidate() -> None:
+    from coval_bench.s2s.samples import SampleRun
+
+    writer = _stub_writer()
+    writer.coval_run_ingested = AsyncMock(return_value=True)
+    list_json = _list_json(
+        {"run_id": "R1", "create_time": _iso(timedelta(hours=5)), "error_status": "SUCCESS"}
+    )
+    sampled: list[SampleRun] = []
+    async with _fake_client(list_json, {}) as client:
+        status, _ingested = await fetch_v2v._fetch_one_provider(
+            client,
+            writer,
+            spec=SPEC,
+            agent_id="a1",
+            metric_id="MID",
+            runner_sha="test",
+            period_seconds=10_800,
+            stale_grace_seconds=5_400,
+            sampled_runs=sampled,
+        )
+    assert status is RunStatus.FAILED
+    assert sampled == []

--- a/runner/tests/unit/test_s2s_fetch.py
+++ b/runner/tests/unit/test_s2s_fetch.py
@@ -404,3 +404,55 @@ async def test_fetch_and_write_v2v_noop_skips_matview_refresh(
 
     assert statuses == {"openai": RunStatus.SUCCEEDED}
     writer.refresh_stats_matviews.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_already_ingested_run_still_becomes_sample_candidate() -> None:
+    from coval_bench.s2s.samples import SampleRun
+
+    writer = _stub_writer()
+    writer.coval_run_ingested = AsyncMock(return_value=True)
+    list_json = _list_json(
+        {"run_id": "R1", "create_time": _iso(timedelta(hours=1)), "error_status": "SUCCESS"}
+    )
+    sampled: list[SampleRun] = []
+    async with _fake_client(list_json, {}) as client:
+        _status, ingested = await fetch_v2v._fetch_one_provider(
+            client,
+            writer,
+            spec=SPEC,
+            agent_id="a1",
+            metric_id="MID",
+            runner_sha="test",
+            period_seconds=10_800,
+            stale_grace_seconds=5_400,
+            sampled_runs=sampled,
+        )
+    assert ingested == 0
+    assert [(r.provider, r.coval_run_id) for r in sampled] == [("openai", "R1")]
+
+
+@pytest.mark.asyncio
+async def test_newest_run_is_the_sample_candidate_once() -> None:
+    from coval_bench.s2s.samples import SampleRun
+
+    writer = _stub_writer()
+    list_json = _list_json(
+        {"run_id": "R2", "create_time": _iso(timedelta(hours=1))},
+        {"run_id": "R1", "create_time": _iso(timedelta(hours=4))},
+    )
+    values = [{"simulation_output_id": "s1", "value": 0.5}]
+    sampled: list[SampleRun] = []
+    async with _fake_client(list_json, _run_json(values)) as client:
+        await fetch_v2v._fetch_one_provider(
+            client,
+            writer,
+            spec=SPEC,
+            agent_id="a1",
+            metric_id="MID",
+            runner_sha="test",
+            period_seconds=10_800,
+            stale_grace_seconds=5_400,
+            sampled_runs=sampled,
+        )
+    assert [r.coval_run_id for r in sampled] == ["R2"]

--- a/runner/tests/unit/test_s2s_samples.py
+++ b/runner/tests/unit/test_s2s_samples.py
@@ -37,7 +37,7 @@ def _sims_payload(run_id: str, test_cases: list[str]) -> dict[str, Any]:
 def _fake_client(
     test_cases_by_run: dict[str, list[str]],
     *,
-    audio_404: set[str] = frozenset(),
+    audio_404: frozenset[str] = frozenset(),
     transcript: str = "is my alarm set for tomorrow morning",
 ) -> httpx.AsyncClient:
     def handler(request: httpx.Request) -> httpx.Response:
@@ -76,7 +76,7 @@ class _FakeBucket:
             if key in self.fail_reads:
                 raise RuntimeError("transient read failure")
             if key not in self.objects:
-                raise NotFound(key)
+                raise NotFound(key)  # type: ignore[no-untyped-call]
             return self.objects[key]
 
         blob.download_as_bytes = _download
@@ -158,7 +158,7 @@ async def test_no_shared_clip_stores_nothing() -> None:
 @pytest.mark.asyncio
 async def test_missing_audio_ships_partial_manifest() -> None:
     storage_client, bucket = _fake_storage()
-    async with _fake_client({"RO": ["b"], "RG": ["b"]}, audio_404={"RO-b"}) as client:
+    async with _fake_client({"RO": ["b"], "RG": ["b"]}, audio_404=frozenset({"RO-b"})) as client:
         stored = await copy_tick_samples(
             client,
             bucket_name="bkt",

--- a/runner/tests/unit/test_s2s_samples.py
+++ b/runner/tests/unit/test_s2s_samples.py
@@ -359,3 +359,37 @@ async def test_malformed_index_is_preserved() -> None:
         )
     assert stored == 2
     assert bucket.objects[samples.INDEX_KEY] == b'{"not": "a list"}'
+
+
+@pytest.mark.asyncio
+async def test_sims_list_failure_drops_only_that_provider() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        if path.endswith("/simulations"):
+            run_id = request.url.params["filter"].split('"')[1]
+            if run_id == "RO":
+                return httpx.Response(500)
+            return httpx.Response(200, json=_sims_payload(run_id, ["b"]))
+        if path.endswith("/audio"):
+            return httpx.Response(200, json={"audio_url": "https://blobs.test/x.wav"})
+        if "blobs.test" in str(request.url):
+            return httpx.Response(200, content=b"RIFFfake")
+        return httpx.Response(
+            200, json={"transcript": [{"role": "user", "content": "hi"}], "test_case_id": "b"}
+        )
+
+    storage_client, bucket = _fake_storage()
+    async with httpx.AsyncClient(
+        base_url="https://api.test/v1", transport=httpx.MockTransport(handler)
+    ) as client:
+        stored = await copy_tick_samples(
+            client,
+            bucket_name="bkt",
+            runs=RUNS,
+            rng=random.Random(0),
+            storage_client=storage_client,
+            download_client=client,
+        )
+    assert stored == 1
+    manifest = json.loads(bucket.objects[f"{PREFIX}/2026-07-17T00:00:00Z/manifest.json"])
+    assert [r["provider"] for r in manifest["recordings"]] == ["google"]

--- a/runner/tests/unit/test_s2s_samples.py
+++ b/runner/tests/unit/test_s2s_samples.py
@@ -13,6 +13,7 @@ from unittest.mock import MagicMock
 
 import httpx
 import pytest
+from google.api_core.exceptions import NotFound
 
 from coval_bench.s2s import samples
 from coval_bench.s2s.samples import PREFIX, SampleRun, copy_tick_samples
@@ -63,6 +64,7 @@ def _fake_client(
 class _FakeBucket:
     def __init__(self) -> None:
         self.objects: dict[str, bytes] = {}
+        self.fail_reads: set[str] = set()
 
     def blob(self, key: str) -> MagicMock:
         blob = MagicMock()
@@ -71,11 +73,14 @@ class _FakeBucket:
         )
 
         def _download() -> bytes:
+            if key in self.fail_reads:
+                raise RuntimeError("transient read failure")
             if key not in self.objects:
-                raise KeyError(key)
+                raise NotFound(key)
             return self.objects[key]
 
         blob.download_as_bytes = _download
+        blob.exists = lambda: key in self.objects
         return blob
 
 
@@ -227,3 +232,94 @@ async def test_never_raises_on_total_failure() -> None:
             download_client=client,
         )
     assert stored == 0
+
+
+@pytest.mark.asyncio
+async def test_existing_manifest_is_never_overwritten() -> None:
+    storage_client, bucket = _fake_storage()
+    tick = "2026-07-17T00:00:00Z"
+    bucket.objects[f"{PREFIX}/{tick}/manifest.json"] = b'{"sentinel": true}'
+    async with _fake_client({"RO": ["b"], "RG": ["b"]}) as client:
+        stored = await copy_tick_samples(
+            client,
+            bucket_name="bkt",
+            runs=RUNS,
+            rng=random.Random(0),
+            storage_client=storage_client,
+            download_client=client,
+        )
+    assert stored == 0
+    assert bucket.objects[f"{PREFIX}/{tick}/manifest.json"] == b'{"sentinel": true}'
+
+
+@pytest.mark.asyncio
+async def test_ambiguous_transcript_omits_input_audio_url() -> None:
+    storage_client, bucket = _fake_storage()
+    async with _fake_client(
+        {"RO": ["b"], "RG": ["b"]}, transcript="what is the weather now"
+    ) as client:
+        await copy_tick_samples(
+            client,
+            bucket_name="bkt",
+            runs=RUNS,
+            rng=random.Random(0),
+            storage_client=storage_client,
+            download_client=client,
+        )
+    manifest = json.loads(bucket.objects[f"{PREFIX}/2026-07-17T00:00:00Z/manifest.json"])
+    assert manifest["input_audio_url"] is None
+
+
+@pytest.mark.asyncio
+async def test_index_read_failure_preserves_history() -> None:
+    storage_client, bucket = _fake_storage()
+    bucket.objects[samples.INDEX_KEY] = json.dumps(["2026-07-16T00:00:00Z"]).encode()
+    bucket.fail_reads.add(samples.INDEX_KEY)
+    async with _fake_client({"RO": ["b"], "RG": ["b"]}) as client:
+        stored = await copy_tick_samples(
+            client,
+            bucket_name="bkt",
+            runs=RUNS,
+            rng=random.Random(0),
+            storage_client=storage_client,
+            download_client=client,
+        )
+    assert stored == 2
+    assert json.loads(bucket.objects[samples.INDEX_KEY]) == ["2026-07-16T00:00:00Z"]
+    assert f"{PREFIX}/2026-07-17T00:00:00Z/manifest.json" in bucket.objects
+
+
+@pytest.mark.asyncio
+async def test_fetch_failure_retries_once_and_succeeds() -> None:
+    attempts = {"audio": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        if path.endswith("/simulations"):
+            run_id = request.url.params["filter"].split('"')[1]
+            return httpx.Response(200, json=_sims_payload(run_id, ["b"]))
+        if path.endswith("/audio"):
+            attempts["audio"] += 1
+            if attempts["audio"] == 1:
+                return httpx.Response(500)
+            return httpx.Response(200, json={"audio_url": "https://blobs.test/x.wav"})
+        if "blobs.test" in str(request.url):
+            return httpx.Response(200, content=b"RIFFfake")
+        return httpx.Response(
+            200, json={"transcript": [{"role": "user", "content": "hi"}], "test_case_id": "b"}
+        )
+
+    storage_client, bucket = _fake_storage()
+    async with httpx.AsyncClient(
+        base_url="https://api.test/v1", transport=httpx.MockTransport(handler)
+    ) as client:
+        stored = await copy_tick_samples(
+            client,
+            bucket_name="bkt",
+            runs=RUNS,
+            rng=random.Random(0),
+            storage_client=storage_client,
+            download_client=client,
+        )
+    assert stored == 2
+    assert attempts["audio"] == 3  # provider one: fail+retry; provider two: first try

--- a/runner/tests/unit/test_s2s_samples.py
+++ b/runner/tests/unit/test_s2s_samples.py
@@ -1,0 +1,229 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the S2S sample-recording copier."""
+
+from __future__ import annotations
+
+import json
+import random
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+
+from coval_bench.s2s import samples
+from coval_bench.s2s.samples import PREFIX, SampleRun, copy_tick_samples
+
+BUCKET_AT = datetime(2026, 7, 17, tzinfo=UTC)
+
+RUNS = [
+    SampleRun(provider="openai", model="gpt-realtime", coval_run_id="RO", bucket_at=BUCKET_AT),
+    SampleRun(provider="google", model="gemini-live", coval_run_id="RG", bucket_at=BUCKET_AT),
+]
+
+
+def _sims_payload(run_id: str, test_cases: list[str]) -> dict[str, Any]:
+    return {
+        "simulations": [
+            {"simulation_id": f"{run_id}-{tc}", "test_case_id": tc} for tc in test_cases
+        ]
+    }
+
+
+def _fake_client(
+    test_cases_by_run: dict[str, list[str]],
+    *,
+    audio_404: set[str] = frozenset(),
+    transcript: str = "is my alarm set for tomorrow morning",
+) -> httpx.AsyncClient:
+    def handler(request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        if path.endswith("/simulations"):
+            flt = request.url.params["filter"]
+            run_id = flt.split('"')[1]
+            return httpx.Response(200, json=_sims_payload(run_id, test_cases_by_run[run_id]))
+        if path.endswith("/audio"):
+            sim_id = path.rsplit("/", 2)[-2]
+            if sim_id in audio_404:
+                return httpx.Response(404)
+            return httpx.Response(200, json={"audio_url": "https://blobs.test/x.wav"})
+        if "blobs.test" in str(request.url):
+            return httpx.Response(200, content=b"RIFFfake")
+        return httpx.Response(
+            200,
+            json={"transcript": [{"role": "user", "content": transcript}], "test_case_id": "tc"},
+        )
+
+    return httpx.AsyncClient(base_url="https://api.test/v1", transport=httpx.MockTransport(handler))
+
+
+class _FakeBucket:
+    def __init__(self) -> None:
+        self.objects: dict[str, bytes] = {}
+
+    def blob(self, key: str) -> MagicMock:
+        blob = MagicMock()
+        blob.upload_from_string = lambda data, content_type: self.objects.__setitem__(
+            key, data if isinstance(data, bytes) else data.encode()
+        )
+
+        def _download() -> bytes:
+            if key not in self.objects:
+                raise KeyError(key)
+            return self.objects[key]
+
+        blob.download_as_bytes = _download
+        return blob
+
+
+def _fake_storage() -> tuple[MagicMock, _FakeBucket]:
+    bucket = _FakeBucket()
+    client = MagicMock()
+    client.bucket.return_value = bucket
+    return client, bucket
+
+
+@pytest.mark.asyncio
+async def test_copies_shared_clip_for_all_providers() -> None:
+    storage_client, bucket = _fake_storage()
+    async with _fake_client({"RO": ["a", "b", "c"], "RG": ["b", "c", "d"]}) as client:
+        stored = await copy_tick_samples(
+            client,
+            bucket_name="bkt",
+            runs=RUNS,
+            rng=random.Random(7),
+            storage_client=storage_client,
+            download_client=client,
+        )
+
+    assert stored == 2
+    tick = "2026-07-17T00:00:00Z"
+    assert f"{PREFIX}/{tick}/openai.wav" in bucket.objects
+    assert f"{PREFIX}/{tick}/google.wav" in bucket.objects
+
+    manifest = json.loads(bucket.objects[f"{PREFIX}/{tick}/manifest.json"])
+    assert manifest["bucket_at"] == tick
+    assert manifest["test_case_id"] in {"b", "c"}  # only shared clips eligible
+    assert manifest["transcript"] == "is my alarm set for tomorrow morning"
+    assert manifest["input_audio_url"].endswith("/s2s-v1/audio/s2s-v1-0001.wav")
+    assert {r["provider"] for r in manifest["recordings"]} == {"openai", "google"}
+
+    index = json.loads(bucket.objects[samples.INDEX_KEY])
+    assert index == [tick]
+
+
+@pytest.mark.asyncio
+async def test_deterministic_pick_under_seeded_rng() -> None:
+    picks = set()
+    for _ in range(3):
+        storage_client, bucket = _fake_storage()
+        async with _fake_client({"RO": ["a", "b", "c"], "RG": ["a", "b", "c"]}) as client:
+            await copy_tick_samples(
+                client,
+                bucket_name="bkt",
+                runs=RUNS,
+                rng=random.Random(42),
+                storage_client=storage_client,
+                download_client=client,
+            )
+        manifest = json.loads(bucket.objects[f"{PREFIX}/2026-07-17T00:00:00Z/manifest.json"])
+        picks.add(manifest["test_case_id"])
+    assert len(picks) == 1
+
+
+@pytest.mark.asyncio
+async def test_no_shared_clip_stores_nothing() -> None:
+    storage_client, bucket = _fake_storage()
+    async with _fake_client({"RO": ["a"], "RG": ["b"]}) as client:
+        stored = await copy_tick_samples(
+            client,
+            bucket_name="bkt",
+            runs=RUNS,
+            rng=random.Random(0),
+            storage_client=storage_client,
+            download_client=client,
+        )
+    assert stored == 0
+    assert bucket.objects == {}
+
+
+@pytest.mark.asyncio
+async def test_missing_audio_ships_partial_manifest() -> None:
+    storage_client, bucket = _fake_storage()
+    async with _fake_client({"RO": ["b"], "RG": ["b"]}, audio_404={"RO-b"}) as client:
+        stored = await copy_tick_samples(
+            client,
+            bucket_name="bkt",
+            runs=RUNS,
+            rng=random.Random(0),
+            storage_client=storage_client,
+            download_client=client,
+        )
+    assert stored == 1
+    manifest = json.loads(bucket.objects[f"{PREFIX}/2026-07-17T00:00:00Z/manifest.json"])
+    assert [r["provider"] for r in manifest["recordings"]] == ["google"]
+
+
+@pytest.mark.asyncio
+async def test_unknown_transcript_omits_input_audio_url() -> None:
+    storage_client, bucket = _fake_storage()
+    async with _fake_client({"RO": ["b"], "RG": ["b"]}, transcript="not in the manifest") as client:
+        await copy_tick_samples(
+            client,
+            bucket_name="bkt",
+            runs=RUNS,
+            rng=random.Random(0),
+            storage_client=storage_client,
+            download_client=client,
+        )
+    manifest = json.loads(bucket.objects[f"{PREFIX}/2026-07-17T00:00:00Z/manifest.json"])
+    assert manifest["input_audio_url"] is None
+    assert manifest["transcript"] == "not in the manifest"
+
+
+@pytest.mark.asyncio
+async def test_index_prepends_and_dedupes() -> None:
+    storage_client, bucket = _fake_storage()
+    bucket.objects[samples.INDEX_KEY] = json.dumps(["2026-07-16T00:00:00Z"]).encode()
+    async with _fake_client({"RO": ["b"], "RG": ["b"]}) as client:
+        await copy_tick_samples(
+            client,
+            bucket_name="bkt",
+            runs=RUNS,
+            rng=random.Random(0),
+            storage_client=storage_client,
+            download_client=client,
+        )
+        await copy_tick_samples(
+            client,
+            bucket_name="bkt",
+            runs=RUNS,
+            rng=random.Random(0),
+            storage_client=storage_client,
+            download_client=client,
+        )
+    index = json.loads(bucket.objects[samples.INDEX_KEY])
+    assert index == ["2026-07-17T00:00:00Z", "2026-07-16T00:00:00Z"]
+
+
+@pytest.mark.asyncio
+async def test_never_raises_on_total_failure() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(500)
+
+    storage_client, _ = _fake_storage()
+    async with httpx.AsyncClient(
+        base_url="https://api.test/v1", transport=httpx.MockTransport(handler)
+    ) as client:
+        stored = await copy_tick_samples(
+            client,
+            bucket_name="bkt",
+            runs=RUNS,
+            rng=random.Random(0),
+            storage_client=storage_client,
+            download_client=client,
+        )
+    assert stored == 0

--- a/runner/tests/unit/test_s2s_samples.py
+++ b/runner/tests/unit/test_s2s_samples.py
@@ -323,3 +323,39 @@ async def test_fetch_failure_retries_once_and_succeeds() -> None:
         )
     assert stored == 2
     assert attempts["audio"] == 3  # provider one: fail+retry; provider two: first try
+
+
+@pytest.mark.asyncio
+async def test_tick_exists_repairs_missing_index() -> None:
+    storage_client, bucket = _fake_storage()
+    tick = "2026-07-17T00:00:00Z"
+    bucket.objects[f"{PREFIX}/{tick}/manifest.json"] = b'{"sentinel": true}'
+    async with _fake_client({"RO": ["b"], "RG": ["b"]}) as client:
+        stored = await copy_tick_samples(
+            client,
+            bucket_name="bkt",
+            runs=RUNS,
+            rng=random.Random(0),
+            storage_client=storage_client,
+            download_client=client,
+        )
+    assert stored == 0
+    assert json.loads(bucket.objects[samples.INDEX_KEY]) == [tick]
+    assert bucket.objects[f"{PREFIX}/{tick}/manifest.json"] == b'{"sentinel": true}'
+
+
+@pytest.mark.asyncio
+async def test_malformed_index_is_preserved() -> None:
+    storage_client, bucket = _fake_storage()
+    bucket.objects[samples.INDEX_KEY] = b'{"not": "a list"}'
+    async with _fake_client({"RO": ["b"], "RG": ["b"]}) as client:
+        stored = await copy_tick_samples(
+            client,
+            bucket_name="bkt",
+            runs=RUNS,
+            rng=random.Random(0),
+            storage_client=storage_client,
+            download_client=client,
+        )
+    assert stored == 2
+    assert bucket.objects[samples.INDEX_KEY] == b'{"not": "a list"}'


### PR DESCRIPTION
Each daily fetch tick now picks one dataset clip present in every provider's newest run and copies that clip's reconstructed conversation recording from each provider into the public samples bucket, next to a manifest.json keyed by the timeline bucket timestamp and a rolling index.json. The dashboard's upcoming samples card reads the bucket directly — no API changes.

Candidates come from already-ingested runs as well as fresh ones, so providers arriving on different ticks complete a set instead of shrinking it; a published tick is never overwritten. When a provider has no eligible run the tick still ships the others and logs samples_provider_missing at error level. Coval fetches retry once with an error-level sample_fetch_failed on the first failure; all viewer-visible gaps log at error, matching the alert policy in coval-ai/benchmark-infra#56. Transcripts that appear on multiple dataset clips ship input_audio_url: null rather than guessing a recording, and only a confirmed missing index.json starts an empty index — other read failures preserve history.

Inert until infra#56 applies: with S2S_SAMPLES_BUCKET unset, sampling is disabled and the fetch behaves exactly as today.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR publishes one shared S2S recording set for each fetch tick. The main changes are:

- Collects eligible runs from fresh and previously ingested provider data.
- Copies one shared clip per provider into an optional public samples bucket.
- Writes per-tick manifests and a rolling sample index.
- Adds retry, partial-provider, transcript-matching, and index-repair behavior.
- Adds unit coverage for sampling and fetch integration.

<h3>Confidence Score: 4/5</h3>

The latest fixes address the reported sampling-candidate and index-repair gaps.

- Previously ingested runs can now complete a later sample set.
- Existing manifests now trigger an index repair attempt.
- No additional blocking issue met the follow-up review scope.

<sub>Reviews (4): Last reviewed commit: ["Drop a failing provider from the tick in..."](https://github.com/coval-ai/benchmarks/commit/ac4679ef91a5784671f0741cc6669324f58f4f66) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45242731)</sub>

<!-- /greptile_comment -->