### PR TITLE
[BENCH-509] Surface a provider across metrics — radar view (STT)

### DIFF
--- a/web/app/stt/stt-dashboard.tsx
+++ b/web/app/stt/stt-dashboard.tsx
@@ -33,6 +33,11 @@ const AccuracyBarSection = dynamic(
   { ssr: false, loading: () => <ChartSkeleton /> }
 );
 
+const WerRadarSection = dynamic(
+  () => import("@/components/dashboard/WerRadarSection"),
+  { ssr: false, loading: () => <ChartSkeleton /> }
+);
+
 const ModelComparisonSection = dynamic(
   () => import("@/components/dashboard/ModelComparisonSection"),
   { ssr: false, loading: () => <ChartSkeleton /> }
@@ -45,6 +50,7 @@ export function STTDashboard() {
         <DashboardLayout>
           <KeyMetrics />
           <TimelineChart />
+          <WerRadarSection />
           <BoxPlotSection />
           <AccuracyBarSection />
           <LatencyAccuracySection />

--- a/web/app/stt/stt-dashboard.tsx
+++ b/web/app/stt/stt-dashboard.tsx
@@ -50,10 +50,10 @@ export function STTDashboard() {
         <DashboardLayout>
           <KeyMetrics />
           <TimelineChart />
-          <WerRadarSection />
           <BoxPlotSection />
           <AccuracyBarSection />
           <LatencyAccuracySection />
+          <WerRadarSection />
           <ModelComparisonSection />
         </DashboardLayout>
       </SidebarMenuProvider>

--- a/web/components/charts/d3/BoxPlot.tsx
+++ b/web/components/charts/d3/BoxPlot.tsx
@@ -434,7 +434,12 @@ const BoxPlot: React.FC<BoxPlotProps> = ({
   return (
     <div ref={containerRef} className="relative w-full">
       {data.data.length === 0 ? (
-        <div className="h-64 flex items-center justify-center text-text-secondary">
+        // Same height as the populated chart so toggling to a model with no
+        // latency runs doesn't shift the sections below.
+        <div
+          className="flex items-center justify-center text-text-secondary"
+          style={{ height: dimensions.height }}
+        >
           <p>No data available for box plot</p>
         </div>
       ) : (

--- a/web/components/charts/tooltips/TimelineTooltip.tsx
+++ b/web/components/charts/tooltips/TimelineTooltip.tsx
@@ -28,9 +28,13 @@ interface TimelineTooltipProps {
   interactionHint?: string | false;
   /** Caps the scroll area (px); keeps the pinned list from covering the chart on mobile. */
   maxHeight?: number;
+  /** Non-timeline charts: shown verbatim instead of the timestamp label. */
+  labelText?: string;
+  /** Non-latency values: overrides the default "123ms" rendering. */
+  formatValue?: (value: number) => string;
 }
 
-const CustomTimelineTooltip: React.FC<TimelineTooltipProps> = ({ active, payload, label, getProviderForModel, showDate, dimmedKeys, compact, interactionHint, maxHeight }) => {
+const CustomTimelineTooltip: React.FC<TimelineTooltipProps> = ({ active, payload, label, getProviderForModel, showDate, dimmedKeys, compact, interactionHint, maxHeight, labelText, formatValue }) => {
   if (!active || !payload || payload.length === 0) return null;
 
   // Filter out null/undefined values and sort by value (fastest to slowest)
@@ -74,9 +78,10 @@ const CustomTimelineTooltip: React.FC<TimelineTooltipProps> = ({ active, payload
       <p
         style={{ margin: "0 0 8px 0", fontWeight: "bold", fontSize: "12px" }}
       >
-        {showDate
-          ? `${formatDate(Number(label))} ${formatTimeWithSeconds(Number(label))}`
-          : formatTimeWithSeconds(Number(label))}
+        {labelText ??
+          (showDate
+            ? `${formatDate(Number(label))} ${formatTimeWithSeconds(Number(label))}`
+            : formatTimeWithSeconds(Number(label)))}
       </p>
       <div
         className="tooltip-scroll"
@@ -150,7 +155,7 @@ const CustomTimelineTooltip: React.FC<TimelineTooltipProps> = ({ active, payload
                   flexShrink: 0
                 }}
               >
-                {item.value.toFixed(0)}ms
+                {formatValue ? formatValue(item.value) : `${item.value.toFixed(0)}ms`}
               </span>
             </div>
           );

--- a/web/components/dashboard/WerRadarSection.tsx
+++ b/web/components/dashboard/WerRadarSection.tsx
@@ -1,0 +1,554 @@
+// Copyright 2026 The Coval Benchmarks Authors
+// SPDX-License-Identifier: Apache-2.0
+
+"use client";
+
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import {
+  Radar,
+  RadarChart,
+  PolarGrid,
+  PolarAngleAxis,
+  PolarRadiusAxis,
+  ResponsiveContainer,
+  Tooltip,
+} from "recharts";
+import Card from "@/components/shared/Card";
+import SectionHeader from "@/components/shared/SectionHeader";
+import CustomTimelineTooltip from "@/components/charts/tooltips/TimelineTooltip";
+import { TimelineLegend } from "@/components/visualizations/TimelineChart";
+import { useDashboard } from "@/contexts/DashboardContext";
+import { useThemeColors, type ThemeColors } from "@/hooks/useThemeColors";
+import { useChartHoverTracking } from "@/hooks/useChartHoverTracking";
+import { useWerDatasetMatrix } from "@/hooks/useWerDatasetMatrix";
+import { datasetLabel, isPerturbationDataset } from "@/lib/config/datasets";
+import { getModelColor } from "@/lib/utils/colors";
+import { normalizeModelName } from "@/lib/utils/formatters";
+
+// "WildASR reverb" → ["Reverb", "WildASR"]: the family drops to a second line
+// so ten axis labels stay legible on a phone-width radar.
+function splitAxisLabel(label: string): [string, string?] {
+  if (label.startsWith("WildASR ")) {
+    const rest = label.slice(8);
+    return [rest.charAt(0).toUpperCase() + rest.slice(1), "WildASR"];
+  }
+  const paren = label.match(/^(.*?) \((.+)\)$/);
+  if (paren) return [paren[1]!, paren[2]!];
+  return [label];
+}
+
+const RadarAxisTick: React.FC<{
+  payload?: { value: string };
+  x?: number;
+  y?: number;
+  textAnchor?: "inherit" | "start" | "middle" | "end";
+  colors: ThemeColors;
+  isMobile: boolean;
+  activeLabel?: string;
+}> = ({ payload, x = 0, y = 0, textAnchor, colors, isMobile, activeLabel }) => {
+  const [name, family] = splitAxisLabel(payload?.value ?? "");
+  const active = payload?.value != null && payload.value === activeLabel;
+  return (
+    <text
+      x={x}
+      y={y}
+      textAnchor={textAnchor}
+      fill={active ? colors.label : colors.axisText}
+      fontWeight={active ? 600 : undefined}
+      fontSize={isMobile ? 10 : 12}
+    >
+      <tspan x={x}>{name}</tspan>
+      {family && (
+        <tspan x={x} dy="1.15em" fillOpacity={0.65} fontSize={isMobile ? 9 : 10}>
+          {family}
+        </tspan>
+      )}
+    </text>
+  );
+};
+
+interface PinnedReading {
+  label: string;
+  x: number;
+  y: number;
+  flip: boolean;
+}
+
+const formatWer = (value: number) => `${value.toFixed(1)}%`;
+
+const WerRadarSection: React.FC = () => {
+  const {
+    selectedModels,
+    legendModels,
+    toggleLegendModel,
+    getProviderForModel,
+    formatChartLabel,
+    availableWerDatasets,
+    timeWindow,
+    isMobile,
+  } = useDashboard();
+  const themeColors = useThemeColors();
+  const trackChartHover = useChartHoverTracking("wer_radar");
+
+  const axes = useMemo(
+    () => [
+      ...availableWerDatasets.filter((d) => !isPerturbationDataset(d)),
+      ...availableWerDatasets.filter(isPerturbationDataset),
+    ],
+    [availableWerDatasets]
+  );
+
+  const { werByDataset, loading } = useWerDatasetMatrix(
+    { benchmark: "STT", window: timeWindow },
+    axes
+  );
+
+  const effectiveAxes = useMemo(
+    () => axes.filter((d) => werByDataset?.has(d)),
+    [axes, werByDataset]
+  );
+
+  // Only models measured on every axis draw a closed shape; partial coverage
+  // would render as a misleading dent.
+  const coveredModels = useMemo(
+    () =>
+      effectiveAxes.length === 0
+        ? []
+        : legendModels.filter((m) =>
+            effectiveAxes.every((d) => werByDataset!.get(d)!.has(m))
+          ),
+    [legendModels, effectiveAxes, werByDataset]
+  );
+
+  const ranked = useMemo(() => {
+    const selected = new Set(selectedModels);
+    return coveredModels
+      .filter((model) => selected.has(model))
+      .map((model) => ({
+        model,
+        mean:
+          effectiveAxes.reduce(
+            (sum, d) => sum + werByDataset!.get(d)!.get(model)!,
+            0
+          ) / effectiveAxes.length,
+      }))
+      .sort((a, b) => a.mean - b.mean);
+  }, [coveredModels, selectedModels, effectiveAxes, werByDataset]);
+  const plotted = useMemo(() => ranked.map((r) => r.model), [ranked]);
+
+  // Radius is 100 − WER so the outer edge is perfect transcription; the scale
+  // starts at the worst plotted value (rounded to a step) to keep gaps readable.
+  const { scaleMin, scaleTicks } = useMemo(() => {
+    let maxWer = 0;
+    plotted.forEach((m) =>
+      effectiveAxes.forEach((d) => {
+        maxWer = Math.max(maxWer, werByDataset?.get(d)?.get(m) ?? 0);
+      })
+    );
+    const step = maxWer > 20 ? 10 : 5;
+    const span = Math.max(2 * step, Math.ceil(maxWer / step) * step);
+    return { scaleMin: 100 - span, scaleTicks: span / step + 1 };
+  }, [plotted, effectiveAxes, werByDataset]);
+
+  const radarData = useMemo(
+    () =>
+      effectiveAxes.map((dataset) => {
+        const row: Record<string, string | number> = {
+          label: datasetLabel(dataset),
+        };
+        plotted.forEach((m) => {
+          row[m] = 100 - werByDataset!.get(dataset)!.get(m)!;
+        });
+        return row;
+      }),
+    [effectiveAxes, plotted, werByDataset]
+  );
+
+  const werRows = (label: string) => {
+    const row = radarData.find((r) => r.label === label);
+    if (!row) return [];
+    return plotted.map((model) => ({
+      dataKey: model,
+      name: model,
+      color: getModelColor(model),
+      value: 100 - (row[model] as number),
+    }));
+  };
+
+  const chartRef = useRef<HTMLDivElement>(null);
+  const pinnedRef = useRef<HTMLDivElement>(null);
+  const [pinned, setPinned] = useState<PinnedReading | null>(null);
+  const [scrub, setScrub] = useState<{ label: string; flip: boolean } | null>(
+    null
+  );
+  const touchRef = useRef<{
+    x: number;
+    y: number;
+    moved: boolean;
+    hadPin: boolean;
+  } | null>(null);
+
+  // The pin anchors to a vertex of the current data; a window or layout
+  // change moves the ground under it.
+  useEffect(() => {
+    setPinned(null);
+    setScrub(null);
+  }, [timeWindow, isMobile]);
+
+  useEffect(() => {
+    if (pinned === null) return;
+    const onDocMouseDown = (e: MouseEvent) => {
+      const target = e.target as Node;
+      if (pinnedRef.current?.contains(target)) return;
+      if (chartRef.current?.contains(target)) return;
+      setPinned(null);
+    };
+    document.addEventListener("mousedown", onDocMouseDown);
+    return () => document.removeEventListener("mousedown", onDocMouseDown);
+  }, [pinned]);
+
+  // Touching or scrolling away dismisses the pinned list on mobile; scrolling
+  // the list itself keeps it open.
+  useEffect(() => {
+    if (!isMobile || pinned === null) return;
+    const onScroll = (e: Event) => {
+      if (pinnedRef.current?.contains(e.target as Node)) return;
+      setPinned(null);
+    };
+    window.addEventListener("scroll", onScroll, { capture: true, passive: true });
+    return () => window.removeEventListener("scroll", onScroll, { capture: true });
+  }, [isMobile, pinned]);
+
+  const labelAtPoint = (e: React.PointerEvent<HTMLDivElement>) => {
+    const n = radarData.length;
+    if (n === 0) return undefined;
+    const rect = e.currentTarget.getBoundingClientRect();
+    const dx = e.clientX - (rect.left + rect.width / 2);
+    const dy = e.clientY - (rect.top + rect.height / 2);
+    const deg = (Math.atan2(-dy, dx) * 180) / Math.PI;
+    const idx = ((Math.round((90 - deg) / (360 / n)) % n) + n) % n;
+    return {
+      label: radarData[idx]?.label as string,
+      flip: e.clientX > rect.left + rect.width / 2,
+    };
+  };
+
+  const ready = effectiveAxes.length >= 3 && plotted.length > 0;
+  const best = ranked[0];
+  const activeAxisLabel = scrub?.label ?? pinned?.label;
+  const legendPayload = coveredModels.map((model) => ({
+    value: formatChartLabel(model, getProviderForModel(model)),
+    color: getModelColor(model),
+    dataKey: model,
+  }));
+  const plottedSet = new Set(plotted);
+  const legendHiddenKeys = new Set(
+    coveredModels.filter((m) => !plottedSet.has(m))
+  );
+
+  return (
+    <div className="mb-4">
+      <Card padding="p-5 lg:p-8">
+        <SectionHeader
+          label="Accuracy Across Datasets"
+          description={{
+            short: "Where each model holds up — and where it breaks",
+            detailed:
+              "Each axis is one evaluation dataset; the radius is word accuracy (100 − WER), so the outer edge is perfect transcription and dents show where a model degrades — accents, noise, reverb, or spontaneous production speech. The scale starts at the worst plotted value, not zero, to keep differences readable. The chart plots the models selected in Filters; click a legend entry to toggle a model, and click or tap the chart to pin a dataset's exact values.",
+          }}
+          hint={
+            isMobile
+              ? "Drag the chart to read a dataset · tap to pin"
+              : "Hover the chart to read a dataset, click to pin"
+          }
+          exportRows={() =>
+            plotted.flatMap((model) =>
+              effectiveAxes.map((dataset) => ({
+                dataset: datasetLabel(dataset),
+                model,
+                provider: getProviderForModel(model),
+                avg_wer_percent: werByDataset?.get(dataset)?.get(model),
+              }))
+            )
+          }
+          stat={{
+            label: best
+              ? `Lowest Avg WER (${normalizeModelName(best.model)})`
+              : "Lowest Avg WER",
+            value: best ? `${best.mean.toFixed(1)}%` : "—",
+          }}
+        />
+        <div
+          ref={chartRef}
+          className={`relative h-80 transition-opacity sm:h-96 ${loading ? "opacity-40" : ""} ${isMobile ? "select-none" : ""}`}
+          data-export-frame
+          onMouseEnter={trackChartHover}
+          onPointerDown={
+            isMobile
+              ? (e) => {
+                  touchRef.current = {
+                    x: e.clientX,
+                    y: e.clientY,
+                    moved: false,
+                    hadPin: pinned !== null,
+                  };
+                  if (!pinned) setScrub(labelAtPoint(e) ?? null);
+                }
+              : undefined
+          }
+          onPointerMove={
+            isMobile
+              ? (e) => {
+                  const t = touchRef.current;
+                  if (!t || (e.pointerType === "mouse" && e.buttons === 0))
+                    return;
+                  if (
+                    !t.moved &&
+                    Math.hypot(e.clientX - t.x, e.clientY - t.y) > 8
+                  ) {
+                    t.moved = true;
+                    setPinned(null);
+                  }
+                  if (t.moved) setScrub(labelAtPoint(e) ?? null);
+                }
+              : undefined
+          }
+          onPointerUp={
+            isMobile
+              ? (e) => {
+                  const t = touchRef.current;
+                  touchRef.current = null;
+                  setScrub(null);
+                  if (!t || t.moved) return;
+                  if (t.hadPin) {
+                    setPinned(null);
+                    return;
+                  }
+                  const at = labelAtPoint(e);
+                  const width = chartRef.current?.clientWidth ?? 0;
+                  if (!at) return;
+                  // Anchor the list to the half of the plot the axis is not in.
+                  setPinned({
+                    label: at.label,
+                    x: at.flip ? 0 : width,
+                    y: 8,
+                    flip: !at.flip,
+                  });
+                }
+              : undefined
+          }
+          onPointerCancel={
+            isMobile
+              ? () => {
+                  touchRef.current = null;
+                  setScrub(null);
+                }
+              : undefined
+          }
+          style={isMobile ? { touchAction: "pan-y" } : undefined}
+        >
+          {ready ? (
+            <ResponsiveContainer width="100%" height="100%" debounce={200}>
+              <RadarChart
+                data={radarData}
+                outerRadius={isMobile ? "62%" : "72%"}
+                margin={
+                  isMobile
+                    ? { top: 20, right: 10, bottom: 20, left: 10 }
+                    : { top: 24, right: 24, bottom: 24, left: 24 }
+                }
+                onClick={(state, e) => {
+                  if (isMobile) return;
+                  const lbl = state?.activeLabel;
+                  const rect = chartRef.current?.getBoundingClientRect();
+                  const me = e as unknown as React.MouseEvent;
+                  const coord = state?.activeCoordinate ?? {
+                    x: me.clientX - (rect?.left ?? 0),
+                    y: me.clientY - (rect?.top ?? 0),
+                  };
+                  if (lbl == null) return;
+                  setPinned((cur) => {
+                    if (cur) return null;
+                    const width = chartRef.current?.clientWidth ?? 0;
+                    const height = chartRef.current?.clientHeight ?? 0;
+                    const pad = 130;
+                    const y =
+                      height > pad * 2
+                        ? Math.min(Math.max(coord.y ?? 0, pad), height - pad)
+                        : coord.y ?? 0;
+                    // The radar sits centered with empty card space either
+                    // side, so the panel extends outward from the vertex —
+                    // away from the polygon, not across it.
+                    return {
+                      label: String(lbl),
+                      x: coord.x ?? 0,
+                      y,
+                      flip: width > 0 && (coord.x ?? 0) < width / 2,
+                    };
+                  });
+                }}
+              >
+                <PolarGrid stroke={themeColors.grid} />
+                <PolarAngleAxis
+                  dataKey="label"
+                  tick={
+                    <RadarAxisTick
+                      colors={themeColors}
+                      isMobile={isMobile}
+                      activeLabel={activeAxisLabel}
+                    />
+                  }
+                />
+                <PolarRadiusAxis
+                  angle={90 - 180 / Math.max(1, effectiveAxes.length)}
+                  domain={[scaleMin, 100]}
+                  tickCount={scaleTicks}
+                  axisLine={false}
+                  tick={{
+                    fill: themeColors.axisText,
+                    fillOpacity: 0.75,
+                    fontSize: 9,
+                  }}
+                  tickFormatter={(value: number) =>
+                    value === 100 ? "" : `${value}%`
+                  }
+                />
+                <Tooltip
+                  active={pinned || isMobile ? false : undefined}
+                  offset={72}
+                  content={({ active, label }) =>
+                    active && label != null ? (
+                      <CustomTimelineTooltip
+                        active
+                        payload={werRows(String(label))}
+                        labelText={String(label)}
+                        formatValue={formatWer}
+                        getProviderForModel={getProviderForModel}
+                        compact
+                        interactionHint="click to pin"
+                      />
+                    ) : null
+                  }
+                />
+                {[...plotted].reverse().map((model) => (
+                  <Radar
+                    key={model}
+                    name={formatChartLabel(model, getProviderForModel(model))}
+                    dataKey={model}
+                    stroke={getModelColor(model)}
+                    fill={getModelColor(model)}
+                    strokeWidth={
+                      model === best?.model || plotted.length <= 2 ? 2.5 : 1.25
+                    }
+                    strokeOpacity={
+                      model === best?.model || plotted.length <= 2 ? 1 : 0.7
+                    }
+                    fillOpacity={
+                      model === best?.model || plotted.length <= 2 ? 0.12 : 0
+                    }
+                    dot={false}
+                    isAnimationActive={false}
+                  />
+                ))}
+              </RadarChart>
+            </ResponsiveContainer>
+          ) : loading ? (
+            <span className="block h-full w-full animate-pulse rounded bg-surface-secondary" />
+          ) : (
+            <div className="flex h-full items-center justify-center text-sm text-text-tertiary">
+              No dataset-scoped WER data in this window.
+            </div>
+          )}
+          {scrub && !pinned && (
+            <div
+              className={`pointer-events-none absolute top-2 z-20 shadow-lg ${
+                scrub.flip ? "left-2" : "right-2"
+              }`}
+            >
+              <CustomTimelineTooltip
+                active
+                payload={werRows(scrub.label)}
+                labelText={scrub.label}
+                formatValue={formatWer}
+                getProviderForModel={getProviderForModel}
+                compact
+                interactionHint="tap to pin"
+              />
+            </div>
+          )}
+          {pinned && werRows(pinned.label).length > 0 && (
+            <div
+              ref={pinnedRef}
+              className="absolute z-20 cursor-auto shadow-lg"
+              style={{
+                left: pinned.x,
+                top: pinned.y,
+                transform: isMobile
+                  ? pinned.flip
+                    ? "translate(calc(-100% - 12px), 0)"
+                    : "translate(12px, 0)"
+                  : pinned.flip
+                    ? "translate(calc(-100% - 72px), -50%)"
+                    : "translate(72px, -50%)",
+              }}
+              onPointerDown={(e) => e.stopPropagation()}
+            >
+              <button
+                type="button"
+                aria-label="Close pinned stats"
+                onClick={() => setPinned(null)}
+                className="absolute right-2 top-2 z-10 flex h-5 w-5 items-center justify-center rounded-full bg-surface-toggle-inactive text-xs leading-none text-text-secondary hover:text-text-primary"
+              >
+                ×
+              </button>
+              <CustomTimelineTooltip
+                active
+                payload={werRows(pinned.label)}
+                labelText={pinned.label}
+                formatValue={formatWer}
+                getProviderForModel={getProviderForModel}
+                maxHeight={isMobile ? 106 : undefined}
+              />
+            </div>
+          )}
+        </div>
+        {ready && best && (
+          <p className="mt-2 text-sm text-text-secondary">
+            <span className="font-medium text-text-primary">
+              {formatChartLabel(best.model, getProviderForModel(best.model))}
+            </span>{" "}
+            has the lowest average WER ({best.mean.toFixed(1)}%) across{" "}
+            {effectiveAxes.length} datasets
+            {plotted.length > 1 && (
+              <>
+                , best on{" "}
+                {
+                  effectiveAxes.filter((d) =>
+                    plotted.every(
+                      (m) =>
+                        werByDataset!.get(d)!.get(best.model)! <=
+                        werByDataset!.get(d)!.get(m)!
+                    )
+                  ).length
+                }{" "}
+                of them
+              </>
+            )}
+            .
+          </p>
+        )}
+        {legendPayload.length > 0 && (
+          <div data-chart-legend>
+            <TimelineLegend
+              payload={legendPayload}
+              hiddenKeys={legendHiddenKeys}
+              onToggle={toggleLegendModel}
+            />
+          </div>
+        )}
+      </Card>
+    </div>
+  );
+};
+
+export default WerRadarSection;

--- a/web/components/dashboard/WerRadarSection.tsx
+++ b/web/components/dashboard/WerRadarSection.tsx
@@ -275,7 +275,7 @@ const WerRadarSection: React.FC = () => {
           description={{
             short: "Where each model holds up and where it breaks",
             detailed:
-              "Each spoke is one test set: clean audio, accents, background noise, phone lines, and so on. Distance from the center is accuracy (100 minus WER), so a bigger shape is a better model and a dent is a weak spot. Note the scale zooms in on the plotted models instead of starting at zero. A model is only drawn if it has results on every set. Click the chart to pin the exact numbers for a dataset.",
+              "Measures how each model's transcription accuracy holds up across recording conditions. Every axis is one evaluation dataset from the selected time window, ranging from clean studio speech to accented, noisy, reverberant, and phone-degraded audio, plus spontaneous production conversations. The radius plots word accuracy (100 minus WER): a model that stays accurate everywhere traces a large, even shape, and a pull toward the center marks the conditions where its accuracy degrades. Only models with results on every dataset are plotted, and the radial scale starts at the worst plotted value rather than zero so differences stay legible. Click the chart to pin a dataset's exact WER values.",
           }}
           hint={
             isMobile

--- a/web/components/dashboard/WerRadarSection.tsx
+++ b/web/components/dashboard/WerRadarSection.tsx
@@ -195,6 +195,19 @@ const WerRadarSection: React.FC = () => {
     setScrub(null);
   }, [timeWindow, isMobile]);
 
+  // Refreshed axes or model toggles can leave the pin pointing at a reading
+  // that no longer exists; holding it would hide the panel while keeping
+  // hover readouts suppressed.
+  useEffect(() => {
+    if (
+      pinned &&
+      (plotted.length === 0 ||
+        !radarData.some((r) => r.label === pinned.label))
+    ) {
+      setPinned(null);
+    }
+  }, [pinned, plotted, radarData]);
+
   useEffect(() => {
     if (pinned === null) return;
     const onDocMouseDown = (e: MouseEvent) => {
@@ -434,7 +447,9 @@ const WerRadarSection: React.FC = () => {
                   <Radar
                     key={model}
                     name={formatChartLabel(model, getProviderForModel(model))}
-                    dataKey={model}
+                    // Function form: a string key with a dot (e.g. a "-3.5"
+                    // slug) would be parsed as an object path and render empty.
+                    dataKey={(row: Record<string, number>) => row[model]}
                     stroke={getModelColor(model)}
                     fill={getModelColor(model)}
                     strokeWidth={
@@ -512,29 +527,35 @@ const WerRadarSection: React.FC = () => {
             </div>
           )}
         </div>
-        {ready && best && (
+        {effectiveAxes.length >= 3 && (
           <p className="mt-2 text-sm text-text-secondary">
-            <span className="font-medium text-text-primary">
-              {formatChartLabel(best.model, getProviderForModel(best.model))}
-            </span>{" "}
-            has the lowest average WER ({best.mean.toFixed(1)}%) across{" "}
-            {effectiveAxes.length} datasets
-            {plotted.length > 1 && (
+            {best ? (
               <>
-                , best on{" "}
-                {
-                  effectiveAxes.filter((d) =>
-                    plotted.every(
-                      (m) =>
-                        werByDataset!.get(d)!.get(best.model)! <=
-                        werByDataset!.get(d)!.get(m)!
-                    )
-                  ).length
-                }{" "}
-                of them
+                <span className="font-medium text-text-primary">
+                  {formatChartLabel(best.model, getProviderForModel(best.model))}
+                </span>{" "}
+                has the lowest average WER ({best.mean.toFixed(1)}%) across{" "}
+                {effectiveAxes.length} datasets
+                {plotted.length > 1 && (
+                  <>
+                    , best on{" "}
+                    {
+                      effectiveAxes.filter((d) =>
+                        plotted.every(
+                          (m) =>
+                            werByDataset!.get(d)!.get(best.model)! <=
+                            werByDataset!.get(d)!.get(m)!
+                        )
+                      ).length
+                    }{" "}
+                    of them
+                  </>
+                )}
+                .
               </>
+            ) : (
+              <>No selected models have WER results on every dataset above.</>
             )}
-            .
           </p>
         )}
         {legendPayload.length > 0 && (

--- a/web/components/dashboard/WerRadarSection.tsx
+++ b/web/components/dashboard/WerRadarSection.tsx
@@ -41,17 +41,25 @@ const RadarAxisTick: React.FC<{
   payload?: { value: string };
   x?: number;
   y?: number;
+  cy?: number;
   textAnchor?: "inherit" | "start" | "middle" | "end";
   colors: ThemeColors;
   isMobile: boolean;
   activeLabel?: string;
-}> = ({ payload, x = 0, y = 0, textAnchor, colors, isMobile, activeLabel }) => {
+}> = ({ payload, x = 0, y = 0, cy, textAnchor, colors, isMobile, activeLabel }) => {
   const [name, family] = splitAxisLabel(payload?.value ?? "");
   const active = payload?.value != null && payload.value === activeLabel;
+  // Labels straddling the chart's vertical axis sit flush against the top
+  // and bottom vertices: lift the top block one line so its family sublabel
+  // stays out of the grid, and drop the bottom block clear of the vertex.
+  const middle = textAnchor === "middle" && cy != null;
+  const aboveChart = middle && family != null && y < cy!;
+  const belowChart = middle && y >= cy!;
+  const dy = aboveChart ? -(isMobile ? 11 : 13) : belowChart ? (isMobile ? 8 : 10) : 0;
   return (
     <text
       x={x}
-      y={y}
+      y={y + dy}
       textAnchor={textAnchor}
       fill={active ? colors.label : colors.axisText}
       fontWeight={active ? 600 : undefined}

--- a/web/components/dashboard/WerRadarSection.tsx
+++ b/web/components/dashboard/WerRadarSection.tsx
@@ -273,9 +273,9 @@ const WerRadarSection: React.FC = () => {
         <SectionHeader
           label="Accuracy Across Datasets"
           description={{
-            short: "Where each model holds up — and where it breaks",
+            short: "Where each model holds up and where it breaks",
             detailed:
-              "Each axis is one evaluation dataset; the radius is word accuracy (100 − WER), so the outer edge is perfect transcription and dents show where a model degrades — accents, noise, reverb, or spontaneous production speech. The scale starts at the worst plotted value, not zero, to keep differences readable. The chart plots the models selected in Filters; click a legend entry to toggle a model, and click or tap the chart to pin a dataset's exact values.",
+              "Each spoke is one test set: clean audio, accents, background noise, phone lines, and so on. Distance from the center is accuracy (100 minus WER), so a bigger shape is a better model and a dent is a weak spot. Note the scale zooms in on the plotted models instead of starting at zero. A model is only drawn if it has results on every set. Click the chart to pin the exact numbers for a dataset.",
           }}
           hint={
             isMobile

--- a/web/components/dashboard/WerRadarSection.tsx
+++ b/web/components/dashboard/WerRadarSection.tsx
@@ -275,7 +275,7 @@ const WerRadarSection: React.FC = () => {
           description={{
             short: "Where each model holds up and where it breaks",
             detailed:
-              "Measures how each model's transcription accuracy holds up across recording conditions. Every axis is one evaluation dataset from the selected time window, ranging from clean studio speech to accented, noisy, reverberant, and phone-degraded audio, plus spontaneous production conversations. The radius plots word accuracy (100 minus WER): a model that stays accurate everywhere traces a large, even shape, and a pull toward the center marks the conditions where its accuracy degrades. Only models with results on every dataset are plotted, and the radial scale starts at the worst plotted value rather than zero so differences stay legible. Click the chart to pin a dataset's exact WER values.",
+              "A model that transcribes studio audio well can still fall apart on noisy, reverberant, or phone-quality speech. Each axis is one dataset from the selected window and the radius is word accuracy, so an even shape holds up across conditions while a dip toward the center marks where accuracy degrades. Only models with results on every dataset are plotted, and the scale starts at the worst plotted value rather than zero.\n\nClick the chart to pin a dataset's exact WER values.",
           }}
           hint={
             isMobile

--- a/web/components/shared/SectionHeader.tsx
+++ b/web/components/shared/SectionHeader.tsx
@@ -250,14 +250,14 @@ const SectionHeader: React.FC<SectionHeaderProps> = ({
               content={
                 note ? (
                   <>
-                    {description.detailed}
+                    <span className="whitespace-pre-line">{description.detailed}</span>
                     <span className="mt-2 block border-t border-border-secondary pt-2">
                       <span className="font-semibold">{note.term}.</span>{" "}
                       {note.text}
                     </span>
                   </>
                 ) : (
-                  description.detailed
+                  <span className="whitespace-pre-line">{description.detailed}</span>
                 )
               }
               align="left"

--- a/web/components/visualizations/TimelineChart.tsx
+++ b/web/components/visualizations/TimelineChart.tsx
@@ -43,7 +43,7 @@ interface LegendEntry {
 // by default), and items fill top-to-bottom within each column so the list
 // reads alphabetically down each column rather than across rows. Each entry
 // toggles its model in and out of the chart, like a Filters sidebar chip.
-const TimelineLegend: React.FC<{
+export const TimelineLegend: React.FC<{
   payload?: LegendEntry[];
   /** Zoom-clipped series: dimmed and pushed to the end. */
   dimmedKeys?: Set<string>;

--- a/web/hooks/useWerDatasetMatrix.ts
+++ b/web/hooks/useWerDatasetMatrix.ts
@@ -3,7 +3,7 @@
 
 "use client";
 
-import { useMemo, useRef } from "react";
+import { useMemo } from "react";
 import { useQueries } from "@tanstack/react-query";
 import { aggregatesQueryOptions } from "@/lib/api/queries";
 import { toModelKey } from "@/lib/utils/formatters";
@@ -19,22 +19,17 @@ export function useWerDatasetMatrix(
     ),
   });
 
-  // Settled = every query holds fresh data for the current params or ended in
-  // a terminal error. The matrix only rebuilds on that boundary, so axes never
-  // pop in one by one on first paint and a window switch never mixes
-  // new-window values on fast axes with old-window values on slow ones — the
-  // previous complete snapshot stays up (dimmed via `loading`) until the new
-  // one lands whole.
-  const settled = results.every(
-    (r) => (r.data && !r.isPlaceholderData) || r.isError
-  );
-  const lastMatrixRef = useRef<Map<string, Map<string, number>> | null>(null);
+  const resultsKey = results
+    .map((r) => `${r.dataUpdatedAt}:${r.isPlaceholderData}`)
+    .join();
 
+  // Each axis renders as soon as its own query lands — no waiting on the
+  // slowest dataset. Placeholder (previous-window) rows are excluded so a
+  // window switch can never mix old and new values across axes.
   const werByDataset = useMemo(() => {
-    if (!settled) return lastMatrixRef.current;
     const matrix = new Map<string, Map<string, number>>();
     results.forEach((r, i) => {
-      if (!r.data) return;
+      if (!r.data || r.isPlaceholderData) return;
       const byModel = new Map<string, number>();
       r.data.model_stats.forEach((s) => {
         if (s.metric_type !== "WER") return;
@@ -42,10 +37,11 @@ export function useWerDatasetMatrix(
       });
       if (byModel.size > 0) matrix.set(datasets[i]!, byModel);
     });
-    lastMatrixRef.current = matrix.size > 0 ? matrix : null;
-    return lastMatrixRef.current;
+    return matrix.size > 0 ? matrix : null;
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [settled, datasets, results.map((r) => r.dataUpdatedAt).join()]);
+  }, [datasets, resultsKey]);
 
-  return { werByDataset, loading: !settled };
+  const loading = results.some((r) => r.isPending || r.isPlaceholderData);
+
+  return { werByDataset, loading };
 }

--- a/web/hooks/useWerDatasetMatrix.ts
+++ b/web/hooks/useWerDatasetMatrix.ts
@@ -1,0 +1,40 @@
+// Copyright 2026 The Coval Benchmarks Authors
+// SPDX-License-Identifier: Apache-2.0
+
+"use client";
+
+import { useMemo } from "react";
+import { useQueries } from "@tanstack/react-query";
+import { aggregatesQueryOptions } from "@/lib/api/queries";
+import { toModelKey } from "@/lib/utils/formatters";
+import type { AggregatesQueryParams } from "@/lib/api/client";
+
+export function useWerDatasetMatrix(
+  base: Pick<AggregatesQueryParams, "benchmark" | "window">,
+  datasets: string[]
+): { werByDataset: Map<string, Map<string, number>> | null; loading: boolean } {
+  const results = useQueries({
+    queries: datasets.map((dataset) =>
+      aggregatesQueryOptions({ ...base, dataset })
+    ),
+  });
+
+  const werByDataset = useMemo(() => {
+    const matrix = new Map<string, Map<string, number>>();
+    results.forEach((r, i) => {
+      if (!r.data) return;
+      const byModel = new Map<string, number>();
+      r.data.model_stats.forEach((s) => {
+        if (s.metric_type !== "WER") return;
+        byModel.set(toModelKey(s.provider, s.model), s.avg_value);
+      });
+      if (byModel.size > 0) matrix.set(datasets[i]!, byModel);
+    });
+    return matrix.size > 0 ? matrix : null;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [datasets, results.map((r) => r.dataUpdatedAt).join()]);
+
+  const loading = results.some((r) => r.isPending || r.isPlaceholderData);
+
+  return { werByDataset, loading };
+}

--- a/web/hooks/useWerDatasetMatrix.ts
+++ b/web/hooks/useWerDatasetMatrix.ts
@@ -3,7 +3,7 @@
 
 "use client";
 
-import { useMemo } from "react";
+import { useMemo, useRef } from "react";
 import { useQueries } from "@tanstack/react-query";
 import { aggregatesQueryOptions } from "@/lib/api/queries";
 import { toModelKey } from "@/lib/utils/formatters";
@@ -19,7 +19,19 @@ export function useWerDatasetMatrix(
     ),
   });
 
+  // Settled = every query holds fresh data for the current params or ended in
+  // a terminal error. The matrix only rebuilds on that boundary, so axes never
+  // pop in one by one on first paint and a window switch never mixes
+  // new-window values on fast axes with old-window values on slow ones — the
+  // previous complete snapshot stays up (dimmed via `loading`) until the new
+  // one lands whole.
+  const settled = results.every(
+    (r) => (r.data && !r.isPlaceholderData) || r.isError
+  );
+  const lastMatrixRef = useRef<Map<string, Map<string, number>> | null>(null);
+
   const werByDataset = useMemo(() => {
+    if (!settled) return lastMatrixRef.current;
     const matrix = new Map<string, Map<string, number>>();
     results.forEach((r, i) => {
       if (!r.data) return;
@@ -30,11 +42,10 @@ export function useWerDatasetMatrix(
       });
       if (byModel.size > 0) matrix.set(datasets[i]!, byModel);
     });
-    return matrix.size > 0 ? matrix : null;
+    lastMatrixRef.current = matrix.size > 0 ? matrix : null;
+    return lastMatrixRef.current;
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [datasets, results.map((r) => r.dataUpdatedAt).join()]);
+  }, [settled, datasets, results.map((r) => r.dataUpdatedAt).join()]);
 
-  const loading = results.some((r) => r.isPending || r.isPlaceholderData);
-
-  return { werByDataset, loading };
+  return { werByDataset, loading: !settled };
 }

--- a/web/lib/api/queries.ts
+++ b/web/lib/api/queries.ts
@@ -10,14 +10,18 @@ import type {
   FetchOptions,
 } from "./client";
 
-export function useAggregatesQuery(params: AggregatesQueryParams) {
-  return useQuery({
+export function aggregatesQueryOptions(params: AggregatesQueryParams) {
+  return {
     queryKey: ["aggregates", params],
     queryFn: ({ signal }: { signal: AbortSignal }) =>
       getAggregates(params, { signal } satisfies FetchOptions),
     // Toggling windows keeps the prior data up instead of flashing the skeleton.
     placeholderData: keepPreviousData,
-  });
+  };
+}
+
+export function useAggregatesQuery(params: AggregatesQueryParams) {
+  return useQuery(aggregatesQueryOptions(params));
 }
 
 export function useProvidersQuery() {

--- a/web/lib/posthog/events.ts
+++ b/web/lib/posthog/events.ts
@@ -34,6 +34,7 @@ export type DashboardChartId =
   | "timeline"
   | "scatter"
   | "wer_bar"
+  | "wer_radar"
   | "box_plot"
   | "heatmap"
   | "performance_delta";


### PR DESCRIPTION
## Summary
<img width="1616" height="624" alt="Screenshot 2026-07-20 at 10 19 57 AM" src="https://github.com/user-attachments/assets/5da2c812-f427-4681-9c50-56d091f66501" />

Adds an **Accuracy Across Datasets** radar to the STT dashboard, between the timeline and the box plot. Each axis is one dataset-scoped WER benchmark (full sets first, then WildASR perturbations); the radius is word accuracy (100 − WER), so the outer edge is perfect transcription and dents show where a model breaks. The radius scale starts at the worst plotted value (rounded to a 5/10 step) instead of zero so differences stay readable. Only models measured on **every** axis are drawn — partial coverage would render as a fake dent — and the best model by mean WER gets the emphasized stroke.

## Interactions (mirrors Performance Consistency)
- **Desktop**: hover shows the compact one-row tooltip (`+N more · click to pin`); clicking pins the full ranked list next to the vertex, extending outward from the polygon with a 72px offset. × / outside click / re-click dismisses.
- **Mobile**: dragging scrubs a compact readout anchored to the corner opposite the finger; a tap pins the full list at the plot edge opposite the axis (scrollable, `maxHeight` capped). Tap again, ×, or scrolling away dismisses. `touch-action: pan-y` keeps the page scrollable.

## Implementation
- `useWerDatasetMatrix`: `useQueries` fan-out of one aggregates call per dataset, sharing the dashboard's `["aggregates", …]` react-query cache via a new exported `aggregatesQueryOptions` helper.
- Reuses `CustomTimelineTooltip` (two new optional props: `labelText`, `formatValue` — default rendering unchanged), `TimelineLegend` (now exported) for the clickable model-toggle legend, `Card`/`SectionHeader` with CSV export and stat, and `getModelColor`/`formatChartLabel`.
- No chart animations, no observers/rAF; re-renders only on discrete pin/scrub changes.
- Adds `wer_radar` to `DashboardChartId` for hover tracking.

## Test plan
- [x] `pnpm typecheck`, `pnpm lint`, `pnpm test` (57 passed)
- [x] Verified in browser at desktop (1280) and mobile (375) widths: hover/pin/dismiss, scrub/tap-pin/dismiss, legend toggling, dark mode
- [ ] Review radar readability with many models selected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds an accuracy-across-datasets radar chart to the STT dashboard. The main changes are:

- Dataset-scoped WER queries shared through the React Query cache.
- Radar visualization with model coverage filtering and ranking.
- Desktop and mobile hover, scrub, and pin interactions.
- Clickable model legend, summary statistic, and CSV export.
- Reusable tooltip formatting and multiline section descriptions.

<h3>Confidence Score: 5/5</h3>

No additional blocking issue qualifies for this follow-up review.

- No distinct unresolved failure was found beyond the issues already reported.
- The pin cleanup covers the stale hidden-panel state identified earlier.

<sub>Reviews (6): Last reviewed commit: ["Match the radar description to the house..."](https://github.com/coval-ai/benchmarks/commit/8dcfdf575b7a3be4249b59dd4648722ecb20e711) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45688175)</sub>

<!-- /greptile_comment -->