### PR TITLE
[BENCH-512] Mobile: collapse the chart legend into a horizontal-scroll disclosure

### DIFF
--- a/web/components/visualizations/TimelineChart.tsx
+++ b/web/components/visualizations/TimelineChart.tsx
@@ -79,7 +79,7 @@ export const TimelineLegend: React.FC<{
       </button>
       <div
         id={panelId}
-        className={`grid transition-[grid-template-rows] duration-300 ease-in-out ${open ? "grid-rows-[1fr]" : "grid-rows-[0fr]"} sm:grid-rows-[1fr]`}
+        className={`grid transition-[grid-template-rows,visibility] duration-300 ease-in-out ${open ? "visible grid-rows-[1fr]" : "invisible grid-rows-[0fr]"} sm:visible sm:grid-rows-[1fr]`}
       >
         <div className="overflow-hidden">
           <ul className="grid auto-cols-max grid-flow-col grid-rows-4 gap-x-4 overflow-x-auto px-2 pb-1 sm:block sm:columns-3 sm:gap-x-6 sm:pt-5 lg:columns-4">

--- a/web/components/visualizations/TimelineChart.tsx
+++ b/web/components/visualizations/TimelineChart.tsx
@@ -3,7 +3,7 @@
 
 "use client";
 
-import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import React, { useCallback, useEffect, useId, useMemo, useRef, useState } from "react";
 import {
   LineChart,
   Line,
@@ -50,8 +50,39 @@ export const TimelineLegend: React.FC<{
   /** Deselected models: dimmed in place so entries never move under the pointer mid-toggle. */
   hiddenKeys?: Set<string>;
   onToggle?: (dataKey: string) => void;
-}> = ({ payload, dimmedKeys, hiddenKeys, onToggle }) => (
-  <ul className="columns-2 gap-x-4 px-2 pt-5 sm:columns-3 sm:gap-x-6 lg:columns-4">
+}> = ({ payload, dimmedKeys, hiddenKeys, onToggle }) => {
+  const [open, setOpen] = useState(false);
+  const panelId = useId();
+  return (
+    <div className="mt-3 border-t border-border-primary sm:mt-0 sm:border-0">
+      <button
+        type="button"
+        aria-expanded={open}
+        aria-controls={panelId}
+        onClick={() => setOpen((prev) => !prev)}
+        className="group flex w-full items-center justify-between gap-4 px-2 py-3 text-left sm:hidden"
+      >
+        <span className="text-sm font-medium text-text-primary">
+          Models{" "}
+          <span className="font-mono text-xs text-text-tertiary">
+            {payload?.length ?? 0}
+          </span>
+        </span>
+        <span aria-hidden className="flex shrink-0 items-center gap-2">
+          <span className="text-xs font-light text-text-tertiary">
+            {open ? "Click to collapse" : "Click to expand"}
+          </span>
+          <span className="font-mono text-xl leading-none text-text-tertiary transition-colors group-hover:text-text-primary">
+            {open ? "–" : "+"}
+          </span>
+        </span>
+      </button>
+      <div
+        id={panelId}
+        className={`grid transition-[grid-template-rows] duration-300 ease-in-out ${open ? "grid-rows-[1fr]" : "grid-rows-[0fr]"} sm:grid-rows-[1fr]`}
+      >
+        <div className="overflow-hidden">
+          <ul className="grid auto-cols-max grid-flow-col grid-rows-4 gap-x-4 overflow-x-auto px-2 pb-1 sm:block sm:columns-3 sm:gap-x-6 sm:pt-5 lg:columns-4">
     {[...(payload ?? [])]
       .sort(
         (a, b) =>
@@ -71,7 +102,7 @@ export const TimelineLegend: React.FC<{
               type="button"
               aria-pressed={!hidden}
               onClick={() => onToggle?.(entry.dataKey ?? "")}
-              className={`flex w-full items-start gap-1.5 rounded-md px-1 py-2 text-left text-xs leading-tight text-text-primary transition-opacity hover:bg-surface-toggle-inactive focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-text-tertiary/40 sm:py-1${dimmed ? " opacity-35" : ""}`}
+              className={`flex min-h-11 w-full items-center gap-1.5 rounded-md px-1 py-2 text-left text-xs leading-tight text-text-primary transition-opacity hover:bg-surface-toggle-inactive focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-text-tertiary/40 sm:min-h-0 sm:items-start sm:py-1${dimmed ? " opacity-35" : ""}`}
             >
               <span
                 className="mt-0.5 inline-block w-3 h-3 shrink-0 rounded-[2px]"
@@ -83,8 +114,12 @@ export const TimelineLegend: React.FC<{
           </li>
         );
       })}
-  </ul>
-);
+          </ul>
+        </div>
+      </div>
+    </div>
+  );
+};
 
 interface MarkerLabelProps {
   viewBox?: { x?: number; y?: number; width?: number; height?: number };


### PR DESCRIPTION
## Summary
<img width="441" height="425" alt="Screenshot 2026-07-20 at 12 42 19 PM" src="https://github.com/user-attachments/assets/ddd5d31f-dfb7-4bf8-9dc2-b8421700f63d" />

<img width="432" height="217" alt="Screenshot 2026-07-20 at 12 41 40 PM" src="https://github.com/user-attachments/assets/38bc8079-cbf5-4e24-a150-c8e94f6bdbf6" />

On mobile, the ~25-entry agent legend under each benchmark chart pushed the rest of the page far down. This collapses it into a disclosure row — closed by default — and lays the entries out in a horizontally scrollable strip when opened.

- **Mobile (<640px):** the legend renders as a \"Models N — Click to expand +\" row, using the same disclosure idiom as the methodology rows (mono +/– glyph, top border, animated `grid-rows-[0fr]→[1fr]` open transition). Expanded, entries flow into 4 rows of horizontally scrollable columns, so browsing is a sideways swipe instead of a long vertical scroll. Entry rows are ≥44px tall for touch.
- **Desktop (≥640px):** unchanged — the toggle is `sm:hidden` and the list keeps its original multi-column layout.
- Both the timeline chart and the WER radar share `TimelineLegend`, so one change covers every chart. PNG exports stage cards at desktop width, so exports are unaffected.

Verified in the browser at 375px/600px/768px/desktop widths, light and dark themes: collapse/expand animates, the strip scrolls horizontally, and tapping an entry still drives the existing model-toggle logic.

## Test plan
- [ ] On a phone-width viewport, open /stt: both chart cards end in a collapsed \"Models N\" row
- [ ] Tap to expand: entries browse horizontally; tap an agent to toggle it in/out of the chart
- [ ] Desktop legend renders exactly as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the long mobile chart legend with a collapsible, horizontally scrollable disclosure. The main changes are:

- A closed-by-default mobile legend toggle with model count.
- A four-row horizontal strip for expanded mobile legends.
- Larger mobile touch targets while preserving the desktop layout.
- Hidden collapsed controls are removed from keyboard focus.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- The collapsed mobile legend no longer exposes hidden model buttons to keyboard focus.
- The desktop breakpoint keeps the legend visible and interactive.
- No blocking issues were found in the updated code.

<sub>Reviews (2): Last reviewed commit: ["Hide the collapsed mobile legend from th..."](https://github.com/coval-ai/benchmarks/commit/f2ae27099d0844faf53c97116864bb14f2b66b20) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45735422)</sub>

<!-- /greptile_comment -->