### PR TITLE
[BENCH-514] Move the time-range selector into the Filters panel + cymatic loading state

### DIFF
--- a/web/components/layout/DashboardLayout.tsx
+++ b/web/components/layout/DashboardLayout.tsx
@@ -13,17 +13,10 @@ import DashboardFooter from "@/components/dashboard/DashboardFooter";
 import MobileModelSheet from "@/components/layout/MobileModelSheet";
 import ModelSidebar from "@/components/layout/ModelSidebar";
 import DashboardSkeleton from "@/components/dashboard/DashboardSkeleton";
-import TimeWindowToggle from "@/components/shared/TimeWindowToggle";
 
 const DashboardLayout: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-  const {
-    loading,
-    loadError,
-    benchmarkTitle,
-    timeWindow,
-    changeTimeWindow,
-    windowDataStale,
-  } = useDashboard();
+  const { loading, loadError, benchmarkTitle, windowDataStale } =
+    useDashboard();
   const mode = useActiveTab();
   const firedDepthsRef = useRef<Set<number>>(new Set());
 
@@ -64,16 +57,9 @@ const DashboardLayout: React.FC<{ children: React.ReactNode }> = ({ children }) 
       <div className="relative z-10 flex flex-1">
         <ModelSidebar />
         <div className="pt-20 px-3 py-8 sm:px-8 pb-24 lg:pb-8 overflow-x-hidden flex-1 min-w-0">
-          <div className="mb-6 flex flex-wrap items-center justify-between gap-3">
-            <h1 className="text-2xl font-bold tracking-tight text-text-primary">
-              {benchmarkTitle}
-            </h1>
-            <TimeWindowToggle
-              value={timeWindow}
-              onChange={changeTimeWindow}
-              className="ml-auto"
-            />
-          </div>
+          <h1 className="mb-6 text-2xl font-bold tracking-tight text-text-primary">
+            {benchmarkTitle}
+          </h1>
 
           <div
             className={`transition-opacity duration-200 ${

--- a/web/components/layout/FacetFilter.tsx
+++ b/web/components/layout/FacetFilter.tsx
@@ -25,8 +25,6 @@ const FacetFilter: React.FC = () => {
   const { openFacetGroups: openGroups, setOpenFacetGroups: setOpenGroups } =
     useSidebarMenu();
 
-  if (facetGroups.length === 0) return null;
-
   return (
     <div className="space-y-1">
       <div className="flex items-center justify-between px-2 pb-2">

--- a/web/components/layout/FacetFilter.tsx
+++ b/web/components/layout/FacetFilter.tsx
@@ -7,12 +7,21 @@ import React from "react";
 import { ChevronDown } from "lucide-react";
 import { useDashboard } from "@/contexts/DashboardContext";
 import { useSidebarMenu } from "@/contexts/SidebarMenuContext";
+import TimeWindowToggle from "@/components/shared/TimeWindowToggle";
+import { CymaticLoader } from "@/components/shared/CymaticLoader";
 
 const COLLAPSE_THRESHOLD = 8;
 
 const FacetFilter: React.FC = () => {
-  const { facetGroups, toggleFacet, clearFacets, hasActiveFacets } =
-    useDashboard();
+  const {
+    facetGroups,
+    toggleFacet,
+    clearFacets,
+    hasActiveFacets,
+    timeWindow,
+    changeTimeWindow,
+    windowDataStale,
+  } = useDashboard();
   const { openFacetGroups: openGroups, setOpenFacetGroups: setOpenGroups } =
     useSidebarMenu();
 
@@ -31,6 +40,34 @@ const FacetFilter: React.FC = () => {
             Clear
           </button>
         )}
+      </div>
+
+      <div
+        role="group"
+        aria-labelledby="facet-time-range"
+        className="px-2 py-1"
+      >
+        <div className="flex min-h-11 items-center gap-2 py-2 lg:min-h-0">
+          <span
+            id="facet-time-range"
+            className="font-mono text-[13px] text-text-tertiary"
+          >
+            Time range
+          </span>
+          <CymaticLoader
+            size={20}
+            animated={windowDataStale}
+            className={`text-text-primary transition-opacity duration-300 ${
+              windowDataStale ? "opacity-100" : "opacity-0"
+            }`}
+          />
+        </div>
+        <TimeWindowToggle
+          value={timeWindow}
+          onChange={changeTimeWindow}
+          loading={windowDataStale}
+          className="mb-2 w-full"
+        />
       </div>
 
       {facetGroups.map((group) => {

--- a/web/components/layout/MobileModelSheet.tsx
+++ b/web/components/layout/MobileModelSheet.tsx
@@ -7,9 +7,14 @@ import React from "react";
 import { useDashboard } from "@/contexts/DashboardContext";
 import { useSidebarMenu } from "@/contexts/SidebarMenuContext";
 import FacetFilter from "@/components/layout/FacetFilter";
+import { CymaticLoader } from "@/components/shared/CymaticLoader";
 
 const MobileModelSheet: React.FC = () => {
-  const { mobileSheetTitle: title, hasActiveFacets } = useDashboard();
+  const {
+    mobileSheetTitle: title,
+    hasActiveFacets,
+    windowDataStale,
+  } = useDashboard();
   const {
     mobileSheetOpen,
     setMobileSheetOpen: onSetMobileSheetOpen,
@@ -64,7 +69,11 @@ const MobileModelSheet: React.FC = () => {
                 aria-label="Filters active"
               />
             )}
-            <div className="w-6 h-0.5 bg-text-tertiary rounded-full"></div>
+            {windowDataStale ? (
+              <CymaticLoader size={20} animated className="text-text-primary" />
+            ) : (
+              <div className="w-6 h-0.5 bg-text-tertiary rounded-full"></div>
+            )}
           </div>
         </div>
       )}

--- a/web/components/shared/CymaticLoader.tsx
+++ b/web/components/shared/CymaticLoader.tsx
@@ -119,12 +119,17 @@ export function CymaticLoader({
   animated?: boolean;
 }) {
   const [step, setStep] = useState(1);
-  const [reduceMotion] = useState(
-    () =>
-      typeof window !== "undefined" &&
-      typeof window.matchMedia === "function" &&
-      window.matchMedia("(prefers-reduced-motion: reduce)").matches
-  );
+  const [reduceMotion, setReduceMotion] = useState(false);
+
+  useEffect(() => {
+    if (typeof window.matchMedia !== "function") return;
+
+    const mediaQuery = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const updateReduceMotion = () => setReduceMotion(mediaQuery.matches);
+    updateReduceMotion();
+    mediaQuery.addEventListener("change", updateReduceMotion);
+    return () => mediaQuery.removeEventListener("change", updateReduceMotion);
+  }, []);
 
   useEffect(() => {
     if (!animated || reduceMotion) return;

--- a/web/components/shared/CymaticLoader.tsx
+++ b/web/components/shared/CymaticLoader.tsx
@@ -1,0 +1,171 @@
+// Copyright 2026 The Coval Benchmarks Authors
+// SPDX-License-Identifier: Apache-2.0
+
+"use client";
+
+import { useEffect, useState } from "react";
+
+const PARTICLE_COUNT = 144;
+const STEP_MS = 700;
+
+interface ParticleTarget {
+  x: number;
+  y: number;
+  opacity: number;
+  scale: number;
+}
+
+function chladni(x: number, y: number, n: number, m: number) {
+  return (
+    Math.cos(n * Math.PI * x) * Math.cos(m * Math.PI * y) -
+    Math.cos(m * Math.PI * x) * Math.cos(n * Math.PI * y)
+  );
+}
+
+function seededNoise(x: number, y: number, salt: number) {
+  const value = Math.sin((x + 1) * 127.1 + (y + 1) * 311.7 + salt * 74.7);
+  return value - Math.floor(value);
+}
+
+function makeScatterTargets(salt: number) {
+  return Array.from({ length: PARTICLE_COUNT }, (_, index) => {
+    const angle = index * 2.399963 + salt * 0.71;
+    const radius = Math.sqrt((index + 0.5) / PARTICLE_COUNT) * 39;
+    const wobble = 1 + (seededNoise(index, salt, 3) - 0.5) * 0.35;
+    return {
+      x: 50 + Math.cos(angle) * radius * wobble,
+      y: 50 + Math.sin(angle) * radius * wobble,
+      opacity: 0.55 + seededNoise(index, salt, 4) * 0.3,
+      scale: 0.72 + seededNoise(index, salt, 5) * 0.38,
+    };
+  });
+}
+
+// Beads settle onto the nodal lines of a Chladni plate mode (n, m) — the
+// pattern sand forms on a vibrating plate, per the brand's cymatics identity.
+function makeChladniTargets(n: number, m: number, salt: number) {
+  const candidates: Array<ParticleTarget & { score: number }> = [];
+  const grid = 76;
+
+  for (let row = 0; row < grid; row += 1) {
+    const y = -1 + (row / (grid - 1)) * 2;
+    for (let column = 0; column < grid; column += 1) {
+      const x = -1 + (column / (grid - 1)) * 2;
+      if (Math.hypot(x, y) > 1.06) continue;
+
+      const distanceFromNode = Math.abs(chladni(x, y, n, m));
+      const score = distanceFromNode + seededNoise(column, row, salt) * 0.018;
+      const closeness = Math.max(0, 1 - distanceFromNode / 0.22);
+
+      candidates.push({
+        x: 50 + x * 40 + (seededNoise(column, row, salt + 10) - 0.5) * 2.2,
+        y: 50 - y * 40 + (seededNoise(column, row, salt + 20) - 0.5) * 2.2,
+        opacity: 0.58 + closeness * 0.42,
+        scale: 0.72 + closeness * 0.46,
+        score,
+      });
+    }
+  }
+
+  candidates.sort((a, b) => a.score - b.score);
+
+  const selected: ParticleTarget[] = [];
+  let minDistance = 5.1;
+  while (selected.length < PARTICLE_COUNT && minDistance >= 1.6) {
+    for (const candidate of candidates) {
+      if (selected.length >= PARTICLE_COUNT) break;
+      if (
+        selected.every(
+          (target) =>
+            Math.hypot(target.x - candidate.x, target.y - candidate.y) >=
+            minDistance
+        )
+      ) {
+        selected.push(candidate);
+      }
+    }
+    minDistance -= 0.55;
+  }
+  return selected.concat(candidates).slice(0, PARTICLE_COUNT);
+}
+
+const CHLADNI_23 = makeChladniTargets(2, 3, 11);
+const CHLADNI_35 = makeChladniTargets(3, 5, 22);
+const CHLADNI_45 = makeChladniTargets(4, 5, 33);
+const CHLADNI_53 = makeChladniTargets(5, 3, 44);
+
+const TARGETS = [
+  makeScatterTargets(1),
+  CHLADNI_23,
+  CHLADNI_23,
+  makeScatterTargets(2),
+  CHLADNI_35,
+  CHLADNI_35,
+  makeScatterTargets(3),
+  CHLADNI_45,
+  CHLADNI_45,
+  makeScatterTargets(4),
+  CHLADNI_53,
+  CHLADNI_53,
+];
+
+export function CymaticLoader({
+  size = 20,
+  className = "",
+  animated = false,
+}: {
+  size?: number;
+  className?: string;
+  animated?: boolean;
+}) {
+  const [step, setStep] = useState(1);
+  const [reduceMotion] = useState(
+    () =>
+      typeof window !== "undefined" &&
+      typeof window.matchMedia === "function" &&
+      window.matchMedia("(prefers-reduced-motion: reduce)").matches
+  );
+
+  useEffect(() => {
+    if (!animated || reduceMotion) return;
+    setStep(0);
+    const interval = window.setInterval(
+      () => setStep((current) => (current + 1) % TARGETS.length),
+      STEP_MS
+    );
+    return () => window.clearInterval(interval);
+  }, [animated, reduceMotion]);
+
+  const targets = TARGETS[step] ?? CHLADNI_23;
+  const dotSize = Math.max(1.2, size * 0.058);
+
+  return (
+    <span
+      aria-hidden="true"
+      style={{ width: size, height: size }}
+      className={`relative inline-flex shrink-0 ${className}`}
+    >
+      {targets.map((target, index) => (
+        <span
+          // eslint-disable-next-line react/no-array-index-key -- fixed-size positional bead grid; index is the identity
+          key={index}
+          className="absolute rounded-full bg-current will-change-[transform,opacity]"
+          style={{
+            left: "50%",
+            top: "50%",
+            width: dotSize,
+            height: dotSize,
+            opacity: target.opacity,
+            transform: `translate(${((target.x - 50) * size) / 100}px, ${
+              ((target.y - 50) * size) / 100
+            }px) translate(-50%, -50%) scale(${target.scale})`,
+            transitionProperty: reduceMotion ? "none" : "opacity, transform",
+            transitionDuration: reduceMotion ? "0ms" : "560ms",
+            transitionDelay: reduceMotion ? "0ms" : `${(index % 9) * 8}ms`,
+            transitionTimingFunction: "cubic-bezier(0.22, 1, 0.36, 1)",
+          }}
+        />
+      ))}
+    </span>
+  );
+}

--- a/web/components/shared/TimeWindowToggle.tsx
+++ b/web/components/shared/TimeWindowToggle.tsx
@@ -13,12 +13,14 @@ import {
 interface TimeWindowToggleProps {
   value: TimeWindow;
   onChange: (window: TimeWindow) => void;
+  loading?: boolean;
   className?: string;
 }
 
 const TimeWindowToggle: React.FC<TimeWindowToggleProps> = ({
   value,
   onChange,
+  loading,
   className = "",
 }) => {
   // Radiogroup contract: one Tab stop, arrows move the selection.
@@ -45,8 +47,9 @@ const TimeWindowToggle: React.FC<TimeWindowToggleProps> = ({
     <div
       role="radiogroup"
       aria-label="Time window"
+      aria-busy={loading ?? false}
       onKeyDown={handleKeyDown}
-      className={`inline-flex h-8 items-center gap-0.5 rounded-md bg-surface-toggle-inactive p-[3px] ${className}`}
+      className={`inline-flex h-11 items-center gap-0.5 rounded-md bg-surface-toggle-inactive p-[3px] lg:h-8 ${className}`}
     >
       {TIME_WINDOWS.map((timeWindow) => {
         const active = timeWindow === value;
@@ -58,7 +61,7 @@ const TimeWindowToggle: React.FC<TimeWindowToggleProps> = ({
             aria-checked={active}
             tabIndex={active ? 0 : -1}
             onClick={() => onChange(timeWindow)}
-            className={`inline-flex items-center justify-center self-stretch rounded-sm px-3 text-sm font-medium transition-colors duration-150 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-text-tertiary/40 focus-visible:ring-offset-1 ${
+            className={`inline-flex grow items-center justify-center self-stretch rounded-sm px-3 text-sm font-medium transition-colors duration-150 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-text-tertiary/40 focus-visible:ring-offset-1 ${
               active
                 ? "bg-surface-primary text-text-primary shadow-sm"
                 : "text-text-secondary hover:text-text-primary"


### PR DESCRIPTION
## What

now, the day filter is inside of filters, and it shows the same cymatics loading info as Covi on the main platform. 
<img width="665" height="361" alt="Screenshot 2026-07-20 at 1 56 32 PM" src="https://github.com/user-attachments/assets/8f9abd6e-0bdd-481b-878f-25768a84a72e" />

Two related UI changes on the benchmark tabs (TTS / STT / S2S — shared layout), from Madina's feedback about slow 1d→30d switches having no loading feedback:

1. **Time-range selector moved into the Filters panel.** The 1d/7d/30d toggle now sits at the top of Filters as a `Time range` group, styled like the other facet groups, so all controls live together. On mobile it moves into the filter bottom sheet with 44px touch targets; the content-header copy is removed.

2. **Loading state on range switch.** A new `CymaticLoader` (beads morphing through Chladni plate patterns — the brand's cymatics identity, adapted from the main app's thinking indicator) fades in beside the `Time range` label while a window fetch is in flight, alongside the existing content dim. On mobile it also replaces the dash on the floating Filters pill, so loading is visible while the sheet is closed. The toggle exposes the fetch via `aria-busy`, and the loader lives outside the pill so the day buttons never shift.

## Notes

- The Overview page's toggle is untouched (it has its own per-card stale handling).
- `CymaticLoader` freezes on a single pattern under `prefers-reduced-motion`.
- Verified in the browser (light/dark, desktop/mobile): no layout shift on the day buttons during loading, loader fades in/out with `windowDataStale`, sheet + floating pill behavior. `tsc`, ESLint, and production build pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR moves benchmark time-range controls into the Filters panel and adds loading feedback. The main changes are:

- Moves the shared time-range selector from the dashboard header into Filters.
- Adds a responsive cymatic loading indicator for range fetches.
- Adds mobile touch sizing and an accessible busy state to the range toggle.
- Keeps the range selector available when facet data is empty.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- The range selector remains available during empty, loading, and error states.
- Motion preferences now update while the loader is mounted, with animation cleanup when motion is reduced.
- No blocking issue remains in the updated code.

<sub>Reviews (2): Last reviewed commit: ["\[BENCH-514\] Address Greptile review feed..."](https://github.com/coval-ai/benchmarks/commit/2679addcc2647d493e6aa515a205a941a19778a5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45757374)</sub>

<!-- /greptile_comment -->