### PR TITLE
Align benchmark themes with Coval brand

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -10,8 +10,8 @@
 :root {
   /* Surfaces */
   --color-surface-primary: #f9faf8;
-  --color-surface-secondary: #f2f1ee;
-  --color-surface-elevated: #f5f4f0;
+  --color-surface-secondary: #f3f2eb;
+  --color-surface-elevated: #f9faf8;
   --color-surface-tooltip: #f9faf8;
   --color-surface-backdrop: rgba(15, 12, 10, 0.5);
   --color-surface-overlay: rgba(242, 241, 238, 0.85);
@@ -25,7 +25,7 @@
 
   /* Borders */
   --color-border-primary: #dbdbd3;
-  --color-border-secondary: #e8e6e0;
+  --color-border-secondary: #eae9e0;
 
   /* Charts */
   --color-chart-grid: #dbdbd3;
@@ -43,7 +43,7 @@
   /* Toggle */
   --color-surface-toggle-active: #0f0c0a;
   --color-text-on-toggle-active: #f9faf8;
-  --color-surface-toggle-inactive: #e8e6e0;
+  --color-surface-toggle-inactive: #eae9e0;
   --color-text-on-toggle-inactive: #515151;
 
   /* Spinner */
@@ -65,7 +65,7 @@
   --color-accent-lavender: #6e51a6;
 
   /* Base */
-  --background: #f2f1ee;
+  --background: #f9faf8;
   --foreground: #0f0c0a;
 
   /* Film grain (coval.ai). Tiled fractal-noise SVG; layered via overlays. */
@@ -83,29 +83,29 @@
   color-scheme: dark;
 
     --color-surface-primary: #0f0c0a;
-    --color-surface-secondary: #17120f;
-    --color-surface-elevated: #1c1611;
-    --color-surface-tooltip: #1c1611;
+    --color-surface-secondary: #292720;
+    --color-surface-elevated: #0f0c0a;
+    --color-surface-tooltip: #292720;
     --color-surface-backdrop: rgba(0, 0, 0, 0.6);
     --color-surface-overlay: rgba(15, 12, 10, 0.85);
 
     --color-text-primary: #f9faf8;
-    --color-text-secondary: #c7c2bc;
+    --color-text-secondary: #dbdbd3;
     /* Graphite, lightened from brand #7f7a76 so muted text still clears WCAG AA
        (4.5:1) on the lightest elevated surface, not just the Ink base. */
-    --color-text-tertiary: #8b8681;
+    --color-text-tertiary: #8c887b;
     --color-text-on-tooltip: #f9faf8;
-    --color-text-on-tooltip-secondary: #c7c2bc;
+    --color-text-on-tooltip-secondary: #dbdbd3;
 
-    --color-border-primary: #2e2823;
-    --color-border-secondary: #241f1b;
+    --color-border-primary: #292720;
+    --color-border-secondary: #292720;
 
-    --color-chart-grid: #2e2823;
-    --color-chart-axis-text: #c7c2bc;
+    --color-chart-grid: #292720;
+    --color-chart-axis-text: #dbdbd3;
     --color-chart-label: #f9faf8;
     --color-chart-median: #f9faf8;
     --color-chart-box-fill: rgba(249, 250, 248, 0.08);
-    --color-chart-bar-stroke: #3a332d;
+    --color-chart-bar-stroke: #3d3b34;
 
     --color-hover-bg: rgba(249, 250, 248, 0.06);
     --color-selected-bg: rgba(249, 250, 248, 0.1);
@@ -113,8 +113,8 @@
 
     --color-surface-toggle-active: #f9faf8;
     --color-text-on-toggle-active: #0f0c0a;
-    --color-surface-toggle-inactive: #241f1b;
-    --color-text-on-toggle-inactive: #c7c2bc;
+    --color-surface-toggle-inactive: #292720;
+    --color-text-on-toggle-inactive: #dbdbd3;
 
     --color-spinner-track: rgba(249, 250, 248, 0.15);
     --color-spinner-head: #f9faf8;

--- a/web/app/overview/overview-page-client.tsx
+++ b/web/app/overview/overview-page-client.tsx
@@ -38,22 +38,7 @@ function ScrollHint() {
 
 export function OverviewPageClient() {
   return (
-    <div className="relative flex min-h-screen flex-col overflow-hidden bg-background text-text-primary">
-      <div
-        aria-hidden
-        className="pointer-events-none absolute inset-0 z-0"
-        style={{ backgroundColor: "rgba(120, 72, 40, 0.06)" }}
-      />
-      <div
-        aria-hidden
-        className="pointer-events-none absolute inset-0 z-0 opacity-[0.07]"
-        style={{
-          backgroundImage: "url(/chladni-13-1-6.svg)",
-          backgroundSize: "max(120vw, 120vh)",
-          backgroundPosition: "center",
-          backgroundRepeat: "no-repeat",
-        }}
-      />
+    <div className="flex min-h-screen flex-col overflow-hidden bg-background text-text-primary">
       <DashboardHeader />
 
       <main className="relative z-10 mx-auto flex w-full max-w-5xl flex-1 flex-col px-4 sm:px-6 pb-10 pt-[84px] md:pt-[96px]">

--- a/web/app/playground/components/playground-draft/ModelPill.tsx
+++ b/web/app/playground/components/playground-draft/ModelPill.tsx
@@ -26,8 +26,8 @@ export function ModelPill({
 
   const className = [
     fullWidth
-      ? "flex w-full max-w-full min-w-0 items-center justify-between gap-2 rounded-xl border px-3 py-2 text-xs font-medium transition-colors"
-      : "inline-flex max-w-full min-w-0 items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs font-medium transition-colors",
+      ? "flex min-h-11 w-full max-w-full min-w-0 items-center justify-between gap-2 rounded-xl border px-3 py-2 text-xs font-medium transition-colors"
+      : "inline-flex min-h-11 max-w-full min-w-0 items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs font-medium transition-colors lg:min-h-0",
     selected ? "bg-surface-primary text-text-primary" : "bg-transparent text-text-tertiary",
     disabled ? "cursor-not-allowed opacity-50" : ""
   ].join(" ");

--- a/web/app/playground/components/playground-draft/PlaygroundDraftChrome.tsx
+++ b/web/app/playground/components/playground-draft/PlaygroundDraftChrome.tsx
@@ -68,7 +68,7 @@ export function PlaygroundDraftChrome({
                 aria-controls="playground-panel-tts"
                 tabIndex={mode === "tts" ? 0 : -1}
                 disabled={modeTabsLocked}
-                className={`relative z-10 flex min-h-9 min-w-[100px] flex-1 items-center justify-center rounded-full px-4 py-1.5 text-xs font-medium transition-[color,background-color,box-shadow] duration-300 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-text-tertiary/40 ${
+                className={`relative z-10 flex min-h-11 min-w-[100px] flex-1 items-center justify-center rounded-full px-4 py-1.5 text-xs font-medium transition-[color,background-color,box-shadow] duration-300 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-text-tertiary/40 lg:min-h-9 ${
                   mode === "tts"
                     ? "bg-surface-toggle-active text-text-on-toggle-active shadow-sm"
                     : "text-text-secondary hover:text-text-primary"
@@ -87,7 +87,7 @@ export function PlaygroundDraftChrome({
                 aria-controls="playground-panel-stt"
                 tabIndex={mode === "stt" ? 0 : -1}
                 disabled={modeTabsLocked}
-                className={`relative z-10 flex min-h-9 min-w-[100px] flex-1 items-center justify-center rounded-full px-4 py-1.5 text-xs font-medium transition-[color,background-color,box-shadow] duration-300 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-text-tertiary/40 ${
+                className={`relative z-10 flex min-h-11 min-w-[100px] flex-1 items-center justify-center rounded-full px-4 py-1.5 text-xs font-medium transition-[color,background-color,box-shadow] duration-300 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-text-tertiary/40 lg:min-h-9 ${
                   mode === "stt"
                     ? "bg-surface-toggle-active text-text-on-toggle-active shadow-sm"
                     : "text-text-secondary hover:text-text-primary"

--- a/web/app/playground/components/playground-draft/STTPlaygroundPanel.tsx
+++ b/web/app/playground/components/playground-draft/STTPlaygroundPanel.tsx
@@ -581,7 +581,7 @@ export function STTPlaygroundPanel({
               />
               <button
                 type="button"
-                className="absolute left-0.5 top-1/2 z-[3] flex size-10 -translate-y-1/2 items-center justify-center rounded-full bg-surface-secondary/90 text-text-primary shadow-md ring-1 ring-border-primary backdrop-blur-[1px] transition-opacity hover:opacity-95 dark:bg-black/55 dark:text-white/90 dark:ring-white/12"
+                className="absolute left-0.5 top-1/2 z-[3] flex size-11 -translate-y-1/2 items-center justify-center rounded-full bg-surface-secondary/90 text-text-primary shadow-md ring-1 ring-border-primary backdrop-blur-[1px] transition-opacity hover:opacity-95 dark:bg-black/55 dark:text-white/90 dark:ring-white/12"
                 aria-label="Swipe or scroll transcripts to the left"
                 onClick={() => scrollCarouselStep(-1)}
               >
@@ -597,7 +597,7 @@ export function STTPlaygroundPanel({
               />
               <button
                 type="button"
-                className="absolute right-0.5 top-1/2 z-[3] flex size-10 -translate-y-1/2 items-center justify-center rounded-full bg-surface-secondary/90 text-text-primary shadow-md ring-1 ring-border-primary backdrop-blur-[1px] transition-opacity hover:opacity-95 dark:bg-black/55 dark:text-white/90 dark:ring-white/12"
+                className="absolute right-0.5 top-1/2 z-[3] flex size-11 -translate-y-1/2 items-center justify-center rounded-full bg-surface-secondary/90 text-text-primary shadow-md ring-1 ring-border-primary backdrop-blur-[1px] transition-opacity hover:opacity-95 dark:bg-black/55 dark:text-white/90 dark:ring-white/12"
                 aria-label="Swipe or scroll transcripts to the right for more models"
                 onClick={() => scrollCarouselStep(1)}
               >
@@ -698,7 +698,7 @@ export function STTPlaygroundPanel({
             <button
               type="button"
               onClick={() => setLeaderOpen(true)}
-              className="inline-flex items-center justify-center gap-2 self-stretch rounded-full border border-border-primary px-5 py-2.5 text-sm font-medium text-text-primary transition-colors hover:bg-hover-bg focus-visible:ring-2 focus-visible:ring-text-tertiary/30 sm:self-auto"
+              className="inline-flex min-h-11 items-center justify-center gap-2 self-stretch rounded-full border border-border-primary px-5 py-2.5 text-sm font-medium text-text-primary transition-colors hover:bg-hover-bg focus-visible:ring-2 focus-visible:ring-text-tertiary/30 sm:self-auto"
             >
               View results
             </button>
@@ -716,7 +716,7 @@ export function STTPlaygroundPanel({
                 ? "Turn on at least one model to record a comparison."
                 : "Hold Enter to record, release to stop when focus is outside buttons and fields"
             }
-            className={`inline-flex items-center justify-center gap-2 self-stretch rounded-full border px-5 py-2.5 text-sm font-medium transition-colors sm:self-auto ${
+            className={`inline-flex min-h-11 items-center justify-center gap-2 self-stretch rounded-full border px-5 py-2.5 text-sm font-medium transition-colors sm:self-auto ${
               ((phase === "idle" || phase === "complete" || phase === "error") &&
                 !canStartOrRetakeRecording) ||
               phase === "submitting"
@@ -769,7 +769,7 @@ export function STTPlaygroundPanel({
                     ref={closeButtonRef}
                     type="button"
                     aria-label="Close results"
-                    className="mb-3 flex size-9 shrink-0 items-center justify-center rounded-full border playground-modal-border-subtle text-text-tertiary transition-colors hover:bg-hover-bg hover:text-text-primary sm:mb-4 dark:text-zinc-400 dark:hover:bg-white/5 dark:hover:text-white"
+                    className="mb-3 flex size-11 shrink-0 items-center justify-center rounded-full border playground-modal-border-subtle text-text-tertiary transition-colors hover:bg-hover-bg hover:text-text-primary sm:mb-4 lg:size-9 dark:text-zinc-400 dark:hover:bg-white/5 dark:hover:text-white"
                     onClick={() => setLeaderOpen(false)}
                   >
                     <X className="size-4" />
@@ -821,7 +821,7 @@ export function STTPlaygroundPanel({
                   <button
                     type="button"
                     title="Close (Enter)"
-                    className="w-full rounded-lg py-2.5 text-xs font-medium text-text-secondary transition-colors hover:bg-hover-bg hover:text-text-primary sm:text-sm dark:text-zinc-400 dark:hover:bg-white/5 dark:hover:text-white"
+                    className="min-h-11 w-full rounded-lg py-2.5 text-xs font-medium text-text-secondary transition-colors hover:bg-hover-bg hover:text-text-primary sm:text-sm dark:text-zinc-400 dark:hover:bg-white/5 dark:hover:text-white"
                     onClick={() => setLeaderOpen(false)}
                   >
                     Done

--- a/web/app/playground/components/playground-draft/TTSPlaygroundPanel.tsx
+++ b/web/app/playground/components/playground-draft/TTSPlaygroundPanel.tsx
@@ -343,7 +343,7 @@ export function TTSPlaygroundPanel({
               aria-label="Clear prompt text, cancel in-flight requests, and close results"
               onClick={handleClear}
               disabled={hasInFlight}
-              className="rounded-full border border-border-primary px-3 py-1.5 text-xs font-medium text-text-secondary transition-colors hover:bg-hover-bg hover:text-text-primary disabled:cursor-not-allowed disabled:opacity-40"
+              className="min-h-11 rounded-full border border-border-primary px-3 py-1.5 text-xs font-medium text-text-secondary transition-colors hover:bg-hover-bg hover:text-text-primary disabled:cursor-not-allowed disabled:opacity-40 lg:min-h-0"
             >
               Clear
             </button>
@@ -357,7 +357,7 @@ export function TTSPlaygroundPanel({
                 <button
                   key={ex.label}
                   type="button"
-                  className="rounded-full border border-border-primary bg-transparent px-3 py-1.5 text-xs font-medium text-text-secondary transition-colors hover:border-text-tertiary hover:text-text-primary"
+                  className="min-h-11 rounded-full border border-border-primary bg-transparent px-3 py-1.5 text-xs font-medium text-text-secondary transition-colors hover:border-text-tertiary hover:text-text-primary lg:min-h-0"
                   onClick={() => {
                     capturePostHogEvent(POSTHOG_EVENTS.playgroundExamplePromptUsed, {
                       surface: "playground",
@@ -415,7 +415,7 @@ export function TTSPlaygroundPanel({
             <button
               type="button"
               onClick={() => setBenchmarkOpen(true)}
-              className="inline-flex items-center justify-center gap-2 self-stretch rounded-full border border-border-primary px-5 py-2.5 text-sm font-medium text-text-primary transition-colors hover:bg-hover-bg focus-visible:ring-2 focus-visible:ring-text-tertiary/30 sm:self-auto"
+              className="inline-flex min-h-11 items-center justify-center gap-2 self-stretch rounded-full border border-border-primary px-5 py-2.5 text-sm font-medium text-text-primary transition-colors hover:bg-hover-bg focus-visible:ring-2 focus-visible:ring-text-tertiary/30 sm:self-auto"
             >
               View results
             </button>
@@ -429,7 +429,7 @@ export function TTSPlaygroundPanel({
                 ? "Enter runs benchmark when focus is outside fields, or ⌘/Ctrl+Enter from the text box"
                 : undefined
             }
-            className="inline-flex items-center justify-center gap-2 self-stretch rounded-full border border-border-primary px-5 py-2.5 text-sm font-medium text-text-primary transition-colors hover:bg-hover-bg disabled:cursor-not-allowed disabled:opacity-40 sm:self-auto"
+            className="inline-flex min-h-11 items-center justify-center gap-2 self-stretch rounded-full border border-border-primary px-5 py-2.5 text-sm font-medium text-text-primary transition-colors hover:bg-hover-bg disabled:cursor-not-allowed disabled:opacity-40 sm:self-auto"
           >
             <Play className="size-4 shrink-0" aria-hidden />
             Benchmark
@@ -465,7 +465,7 @@ export function TTSPlaygroundPanel({
                   <button
                     type="button"
                     aria-label="Close benchmark results"
-                    className="mb-3 flex size-9 shrink-0 items-center justify-center rounded-full border playground-modal-border-subtle text-text-tertiary transition-colors hover:bg-hover-bg hover:text-text-primary sm:mb-4 dark:text-zinc-400 dark:hover:bg-white/5 dark:hover:text-white"
+                    className="mb-3 flex size-11 shrink-0 items-center justify-center rounded-full border playground-modal-border-subtle text-text-tertiary transition-colors hover:bg-hover-bg hover:text-text-primary sm:mb-4 lg:size-9 dark:text-zinc-400 dark:hover:bg-white/5 dark:hover:text-white"
                     onClick={() => setBenchmarkOpen(false)}
                   >
                     <X className="size-4" />

--- a/web/components/dashboard/AccuracyBarSection.tsx
+++ b/web/components/dashboard/AccuracyBarSection.tsx
@@ -221,7 +221,7 @@ const AccuracyBarSection: React.FC = () => {
             <ResponsiveContainer
               width="100%"
               height="100%"
-              minWidth={werBarDataWithColors.length * 48 + 52}
+              minWidth={werBarDataWithColors.length * (isMobile ? 56 : 48) + 52}
               debounce={200}
             >
               <BarChart

--- a/web/components/dashboard/ModelComparisonTable.tsx
+++ b/web/components/dashboard/ModelComparisonTable.tsx
@@ -184,7 +184,7 @@ const ModelComparisonTable: React.FC<ModelComparisonTableProps> = ({
           step={1}
           value={percentileIdx}
           onChange={(e) => onPercentileChange(Number(e.target.value))}
-          className="w-44 accent-accent-blue"
+          className="h-11 w-44 accent-accent-blue lg:h-auto"
           aria-valuetext={percentile.key}
         />
         <span className="tabular-nums font-medium text-text-primary">
@@ -218,7 +218,7 @@ const ModelComparisonTable: React.FC<ModelComparisonTableProps> = ({
                   <button
                     type="button"
                     onClick={() => handleSort(column)}
-                    className={`whitespace-nowrap hover:text-text-primary transition-colors ${
+                    className={`min-h-11 whitespace-nowrap hover:text-text-primary transition-colors lg:min-h-0 ${
                       sort.key === column.key ? "text-text-primary" : ""
                     }`}
                   >

--- a/web/components/dashboard/WerDatasetSelect.tsx
+++ b/web/components/dashboard/WerDatasetSelect.tsx
@@ -44,7 +44,7 @@ const WerDatasetSelect: React.FC<{ className?: string }> = ({ className }) => {
           aria-label="WER dataset"
           value={werDataset ?? ""}
           onChange={(e) => changeWerDataset(e.target.value || null)}
-          className="appearance-none rounded-lg border border-border-primary bg-surface-elevated py-1.5 pl-2.5 pr-7 text-xs font-medium text-text-primary outline-none transition-colors hover:border-selected-border focus:border-selected-border"
+          className="h-11 appearance-none rounded-lg border border-border-primary bg-surface-elevated pl-2.5 pr-7 text-xs font-medium text-text-primary outline-none transition-colors hover:border-selected-border focus:border-selected-border lg:h-auto lg:py-1.5"
         >
           <option value="">All datasets (pooled)</option>
           {perturbations.length > 0 ? (

--- a/web/components/layout/DashboardHeader.tsx
+++ b/web/components/layout/DashboardHeader.tsx
@@ -67,7 +67,7 @@ const DashboardHeader: React.FC = () => {
         {/* Section tabs — centered on the page, independent of the brand width */}
         <nav
           aria-label="Benchmark sections"
-          className="absolute left-1/2 top-0 hidden h-full -translate-x-1/2 items-center gap-1 md:flex"
+          className="absolute left-1/2 top-0 hidden h-full -translate-x-1/2 items-center gap-1 lg:flex"
         >
           {SECTIONS.map((section) => {
             const active = pathname === section.href;
@@ -96,7 +96,7 @@ const DashboardHeader: React.FC = () => {
         </nav>
 
         {/* Theme toggle + GitHub link (desktop only) */}
-        <div className="ml-auto hidden items-center gap-4 md:flex">
+        <div className="ml-auto hidden items-center gap-4 lg:flex">
           <ThemeSwitch />
           <a
             href="https://github.com/coval-ai/benchmarks"
@@ -116,7 +116,7 @@ const DashboardHeader: React.FC = () => {
           aria-label={menuOpen ? "Close menu" : "Open menu"}
           aria-expanded={menuOpen}
           aria-controls="mobile-menu"
-          className="ml-auto flex h-10 w-10 flex-col items-center justify-center gap-1.5 text-text-primary md:hidden"
+          className="ml-auto flex h-11 w-11 flex-col items-center justify-center gap-1.5 text-text-primary lg:hidden"
         >
           <span
             className={`h-0.5 w-6 bg-current transition-transform duration-300 ease-out ${
@@ -136,7 +136,7 @@ const DashboardHeader: React.FC = () => {
         id="mobile-menu"
         aria-label="Global navigation"
         aria-hidden={!menuOpen}
-        className={`fixed inset-x-0 top-[60px] bottom-0 flex flex-col gap-2 bg-surface-primary px-4 py-6 transition-all duration-300 ease-out md:hidden ${
+        className={`fixed inset-x-0 top-[60px] bottom-0 flex flex-col gap-2 bg-surface-primary px-4 py-6 transition-all duration-300 ease-out lg:hidden ${
           menuOpen
             ? "translate-y-0 opacity-100 pointer-events-auto"
             : "-translate-y-2 opacity-0 pointer-events-none"

--- a/web/components/layout/FacetFilter.tsx
+++ b/web/components/layout/FacetFilter.tsx
@@ -33,7 +33,7 @@ const FacetFilter: React.FC = () => {
           <button
             type="button"
             onClick={clearFacets}
-            className="text-xs text-text-tertiary transition-colors hover:text-text-primary"
+            className="min-h-11 px-2 text-xs text-text-tertiary transition-colors hover:text-text-primary lg:min-h-0"
           >
             Clear
           </button>
@@ -118,7 +118,7 @@ const FacetFilter: React.FC = () => {
                       type="button"
                       aria-pressed={option.active}
                       onClick={() => toggleFacet(group.category, option.value)}
-                      className={`inline-flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-xs transition-colors focus-visible:outline-none lg:px-2.5 lg:py-1 focus-visible:ring-1 focus-visible:ring-text-tertiary/40 ${
+                      className={`inline-flex min-h-11 items-center gap-1.5 rounded-full border px-3 py-1.5 text-xs transition-colors focus-visible:outline-none lg:min-h-0 lg:px-2.5 lg:py-1 focus-visible:ring-1 focus-visible:ring-text-tertiary/40 ${
                         option.active
                           ? "border-transparent bg-surface-toggle-active text-text-on-toggle-active"
                           : option.implied

--- a/web/components/layout/MobileModelSheet.tsx
+++ b/web/components/layout/MobileModelSheet.tsx
@@ -37,7 +37,7 @@ const MobileModelSheet: React.FC = () => {
         aria-hidden={!mobileSheetOpen}
         inert={!mobileSheetOpen}
         className={`fixed bottom-0 left-0 right-0 z-40 bg-surface-overlay backdrop-blur-xl border-t border-border-primary rounded-t-3xl transition-transform duration-200 ease-out ${
-          mobileSheetOpen ? "translate-y-0" : "translate-y-full"
+          mobileSheetOpen ? "visible translate-y-0" : "invisible translate-y-full"
         }`}
         style={{ height: "50vh" }}
       >

--- a/web/components/layout/MobileModelSheet.tsx
+++ b/web/components/layout/MobileModelSheet.tsx
@@ -24,7 +24,9 @@ const MobileModelSheet: React.FC = () => {
     <div className="lg:hidden">
       {/* Backdrop - only when open */}
       {mobileSheetOpen && (
-        <div
+        <button
+          type="button"
+          aria-label="Close filters"
           className="fixed inset-0 z-30 bg-surface-backdrop transition-opacity duration-200"
           onClick={() => onSetMobileSheetOpen(false)}
         />
@@ -32,18 +34,22 @@ const MobileModelSheet: React.FC = () => {
 
       {/* Bottom Sheet */}
       <div
+        aria-hidden={!mobileSheetOpen}
+        inert={!mobileSheetOpen}
         className={`fixed bottom-0 left-0 right-0 z-40 bg-surface-overlay backdrop-blur-xl border-t border-border-primary rounded-t-3xl transition-transform duration-200 ease-out ${
           mobileSheetOpen ? "translate-y-0" : "translate-y-full"
         }`}
         style={{ height: "50vh" }}
       >
         {/* Handle */}
-        <div
-          className="flex justify-center pt-3 pb-2 cursor-pointer"
+        <button
+          type="button"
+          aria-label="Close filters"
+          className="flex min-h-11 w-full items-center justify-center"
           onClick={() => onSetMobileSheetOpen(!mobileSheetOpen)}
         >
           <div className="w-12 h-1 bg-text-tertiary rounded-full"></div>
-        </div>
+        </button>
 
         {/* Sheet Content */}
         <div className="px-4 pb-8 h-full overflow-y-auto">
@@ -57,8 +63,10 @@ const MobileModelSheet: React.FC = () => {
 
       {/* Floating Handle - Only when sheet is closed */}
       {!mobileSheetOpen && (
-        <div
-          className="fixed bottom-4 left-1/2 transform -translate-x-1/2 z-40 bg-surface-overlay backdrop-blur-xl border border-border-primary rounded-full px-4 py-2 cursor-pointer shadow-lg"
+        <button
+          type="button"
+          aria-label="Open filters"
+          className="fixed bottom-4 left-1/2 z-40 min-h-11 -translate-x-1/2 rounded-full border border-border-primary bg-surface-overlay px-4 py-2 shadow-lg backdrop-blur-xl"
           onClick={() => onSetMobileSheetOpen(true)}
         >
           <div className="flex items-center space-x-2 text-text-secondary text-sm">
@@ -75,7 +83,7 @@ const MobileModelSheet: React.FC = () => {
               <div className="w-6 h-0.5 bg-text-tertiary rounded-full"></div>
             )}
           </div>
-        </div>
+        </button>
       )}
     </div>
   );

--- a/web/components/layout/ThemeSwitch.tsx
+++ b/web/components/layout/ThemeSwitch.tsx
@@ -21,7 +21,7 @@ const ThemeSwitch: React.FC<{ className?: string }> = ({ className = "" }) => {
     <div
       role="radiogroup"
       aria-label="Theme"
-      className={`inline-flex h-8 items-center gap-0.5 rounded-md bg-surface-toggle-inactive p-[3px] ${className}`}
+      className={`inline-flex h-[50px] items-center gap-0.5 rounded-md bg-surface-toggle-inactive p-[3px] lg:h-8 ${className}`}
     >
       {OPTIONS.map(({ value, Icon, label }) => {
         const active = mounted && resolvedTheme === value;
@@ -33,7 +33,7 @@ const ThemeSwitch: React.FC<{ className?: string }> = ({ className = "" }) => {
             aria-checked={active}
             aria-label={label}
             onClick={() => setTheme(value)}
-            className={`inline-flex items-center justify-center self-stretch rounded-sm px-2.5 transition-colors duration-150 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-text-tertiary/40 ${
+            className={`inline-flex w-11 items-center justify-center self-stretch rounded-sm px-0 transition-colors duration-150 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-text-tertiary/40 lg:w-auto lg:px-2.5 ${
               active
                 ? "bg-surface-primary text-text-primary shadow-sm"
                 : "text-text-secondary hover:text-text-primary"

--- a/web/components/shared/MetricInfo.tsx
+++ b/web/components/shared/MetricInfo.tsx
@@ -32,7 +32,10 @@ const MetricInfo: React.FC<{
   useEffect(() => {
     if (!open) return;
     const close = (e: PointerEvent) => {
-      if (!wrapperRef.current?.contains(e.target as Node)) setOpen(false);
+      if (!wrapperRef.current?.contains(e.target as Node)) {
+        setOpen(false);
+        wrapperRef.current?.blur();
+      }
     };
     document.addEventListener("pointerdown", close);
     return () => document.removeEventListener("pointerdown", close);
@@ -61,7 +64,7 @@ const MetricInfo: React.FC<{
   return (
     <span
       ref={wrapperRef}
-      className={`group relative inline-block ${isElement ? "" : "-m-2 cursor-help p-2"}`}
+      className={`group relative inline-block ${isElement ? "" : "-m-3.5 cursor-help p-3.5 lg:-m-2 lg:p-2"}`}
       tabIndex={isElement ? undefined : 0}
       aria-describedby={isElement ? undefined : id}
       onClick={isElement ? undefined : () => setOpen((prev) => !prev)}

--- a/web/components/shared/SectionHeader.tsx
+++ b/web/components/shared/SectionHeader.tsx
@@ -13,7 +13,7 @@ import { capturePostHogEvent } from "@/lib/posthog/client";
 import { POSTHOG_EVENTS } from "@/lib/posthog/events";
 
 const iconButtonClass =
-  "flex h-7 w-7 items-center justify-center rounded-lg border border-border-secondary bg-surface-primary text-text-secondary transition-colors hover:bg-surface-toggle-inactive hover:text-text-primary";
+  "flex h-11 w-11 items-center justify-center rounded-lg border border-border-secondary bg-surface-primary text-text-secondary transition-colors hover:bg-surface-toggle-inactive hover:text-text-primary lg:h-7 lg:w-7";
 
 interface SectionHeaderProps {
   label: string;

--- a/web/components/shared/TimeWindowToggle.tsx
+++ b/web/components/shared/TimeWindowToggle.tsx
@@ -49,7 +49,7 @@ const TimeWindowToggle: React.FC<TimeWindowToggleProps> = ({
       aria-label="Time window"
       aria-busy={loading ?? false}
       onKeyDown={handleKeyDown}
-      className={`inline-flex h-11 items-center gap-0.5 rounded-md bg-surface-toggle-inactive p-[3px] lg:h-8 ${className}`}
+      className={`inline-flex h-[50px] items-center gap-0.5 rounded-md bg-surface-toggle-inactive p-[3px] lg:h-8 ${className}`}
     >
       {TIME_WINDOWS.map((timeWindow) => {
         const active = timeWindow === value;
@@ -61,7 +61,7 @@ const TimeWindowToggle: React.FC<TimeWindowToggleProps> = ({
             aria-checked={active}
             tabIndex={active ? 0 : -1}
             onClick={() => onChange(timeWindow)}
-            className={`inline-flex grow items-center justify-center self-stretch rounded-sm px-3 text-sm font-medium transition-colors duration-150 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-text-tertiary/40 focus-visible:ring-offset-1 ${
+            className={`inline-flex min-w-11 grow items-center justify-center self-stretch rounded-sm px-3 text-sm font-medium transition-colors duration-150 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-text-tertiary/40 focus-visible:ring-offset-1 lg:min-w-0 ${
               active
                 ? "bg-surface-primary text-text-primary shadow-sm"
                 : "text-text-secondary hover:text-text-primary"

--- a/web/components/visualizations/TimelineChart.tsx
+++ b/web/components/visualizations/TimelineChart.tsx
@@ -817,7 +817,7 @@ const TimelineChart: React.FC = () => {
               <button
                 type="button"
                 onClick={() => setZoom(null)}
-                className="rounded-md bg-surface-toggle-inactive px-3 py-1 text-xs font-medium text-text-secondary transition-colors hover:text-text-primary"
+                className="h-11 rounded-md bg-surface-toggle-inactive px-3 text-xs font-medium text-text-secondary transition-colors hover:text-text-primary lg:h-auto lg:py-1"
               >
                 Reset zoom
               </button>
@@ -837,7 +837,7 @@ const TimelineChart: React.FC = () => {
                       : { x: z?.x, y: [0, Number(v)] }
                   );
                 }}
-                className="rounded-md bg-surface-toggle-inactive px-2 py-1 text-xs font-medium text-text-primary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-text-tertiary/40"
+                className="h-11 rounded-md bg-surface-toggle-inactive px-3 text-xs font-medium text-text-primary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-text-tertiary/40 lg:h-auto lg:px-2"
               >
                 <option value="auto">Auto</option>
                 {Y_MAX_PRESETS.map((v) => (

--- a/web/hooks/useThemeColors.ts
+++ b/web/hooks/useThemeColors.ts
@@ -41,17 +41,17 @@ export const LIGHT_CHART_COLORS: ThemeColors = {
 };
 
 export const DARK_CHART_COLORS: ThemeColors = {
-  grid: "#2e2823",
-  axisText: "#c7c2bc",
+  grid: "#292720",
+  axisText: "#dbdbd3",
   label: "#f9faf8",
   median: "#f9faf8",
   boxFill: "rgba(249, 250, 248, 0.08)",
-  barStroke: "#3a332d",
-  tooltipBg: "#1c1611",
+  barStroke: "#3d3b34",
+  tooltipBg: "#292720",
   tooltipText: "#f9faf8",
-  tooltipSecondary: "#c7c2bc",
+  tooltipSecondary: "#dbdbd3",
   textPrimary: "#f9faf8",
-  textSecondary: "#c7c2bc",
+  textSecondary: "#dbdbd3",
   zoneFill: "rgba(150, 190, 250, 0.18)",
   zoneStroke: "rgba(198, 220, 250, 0.45)",
 };

--- a/web/lib/utils/chartExport.ts
+++ b/web/lib/utils/chartExport.ts
@@ -136,7 +136,7 @@ const SVG_NS = "http://www.w3.org/2000/svg";
 // nudged for legibility on the export surface: bright colors darken on the light
 // canvas, dark colors lighten on the dark canvas.
 const labelColor = (hex?: string, dark = false) => {
-  if (!hex || !/^#[0-9a-f]{6}$/i.test(hex)) return dark ? "#c7c2bc" : "#3d3d3d";
+  if (!hex || !/^#[0-9a-f]{6}$/i.test(hex)) return dark ? "#dbdbd3" : "#3d3d3d";
   const n = parseInt(hex.slice(1), 16);
   let [r, g, b] = [n >> 16, (n >> 8) & 255, n & 255];
   const lum = (0.299 * r + 0.587 * g + 0.114 * b) / 255;


### PR DESCRIPTION
## Summary
Before (All brown)
<img width="1512" height="725" alt="Screenshot 2026-07-20 at 3 30 15 PM" src="https://github.com/user-attachments/assets/59265601-7f6d-42ee-9d9d-8258ef67ec1f" />

After: (Charcoal and Black)

<img width="1509" height="768" alt="Screenshot 2026-07-20 at 3 30 24 PM" src="https://github.com/user-attachments/assets/414b1b1a-b71d-4821-a46d-6300c32d9ab0" />

- remove the one-off cymatic and brown background treatment
- standardize light and dark surfaces around Coval White, Paper, Ink, and warm neutrals
- align overview, benchmark, and playground pages across themes
- fix the tablet header breakpoint and improve mobile touch targets
- make help, filter, and chart interactions accessible by tap

## Validation

- responsive QA at 320, 390, 768, 1024, and 1440px
- Overview, Text-to-Speech, Speech-to-Text, and Playground checked in light and dark modes
- no horizontal page overflow found
- pnpm typecheck
- pnpm lint
- pnpm test (57 tests)
- git diff --check

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR aligns the benchmark experience with Coval’s visual style and improves responsive interactions. The main changes are:

- Standardized light and dark surface, text, border, and chart colors.
- Removed the overview page’s one-off brown and cymatic background.
- Moved the desktop header breakpoint and enlarged mobile touch targets.
- Made help, filter, chart, and playground controls easier to use by touch.
- Hid the closed mobile filter sheet from interaction and keyboard navigation.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- The closed filter sheet now combines `inert`, `aria-hidden`, and hidden visibility to keep its controls out of keyboard navigation.
- No blocking issue remains in the updated code.

<sub>Reviews (2): Last reviewed commit: ["Hide closed mobile filter sheet from foc..."](https://github.com/coval-ai/benchmarks/commit/83dc3a7bf50cf693d6401ba32b3436a566755026) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45783314)</sub>

<!-- /greptile_comment -->