### PR TITLE
Add S2S conversation samples card

### DIFF
--- a/web/app/s2s/components/S2STopRow.tsx
+++ b/web/app/s2s/components/S2STopRow.tsx
@@ -1,0 +1,39 @@
+// Copyright 2026 The Coval Benchmarks Authors
+// SPDX-License-Identifier: Apache-2.0
+
+"use client";
+
+import Card from "@/components/shared/Card";
+import { useDashboard } from "@/contexts/DashboardContext";
+import { SamplesCard } from "./SamplesCard";
+
+// S2S headline row: the single latency KeyMetric tile beside the samples card.
+// The tile mirrors KeyMetrics.tsx (as DashboardSkeleton already does) so the
+// shared component stays untouched for STT/TTS; both cells stretch to level.
+export function S2STopRow() {
+  const { primaryKeyMetric: metric } = useDashboard();
+
+  return (
+    <div className="mb-[0.8rem] grid grid-cols-1 items-stretch gap-[0.8rem] lg:grid-cols-2">
+      <Card className="text-left min-w-0 h-full" padding="p-5 lg:p-8">
+        <div className="text-[0.9rem] font-light text-text-secondary mb-2">
+          {metric.label}
+        </div>
+        <div className="font-mono text-3xl sm:text-4xl lg:text-5xl font-bold mb-4 break-words leading-tight">
+          {metric.displayValue}
+        </div>
+        {metric.subtitle && (
+          <div className="text-text-secondary flex flex-col sm:flex-row sm:items-baseline gap-0.5 sm:gap-2">
+            {metric.subtitle.name && (
+              <span className="font-medium">{metric.subtitle.name}</span>
+            )}
+            {metric.subtitle.detail && (
+              <span className="text-sm text-text-tertiary">{metric.subtitle.detail}</span>
+            )}
+          </div>
+        )}
+      </Card>
+      <SamplesCard />
+    </div>
+  );
+}

--- a/web/app/s2s/components/SampleInput.tsx
+++ b/web/app/s2s/components/SampleInput.tsx
@@ -1,0 +1,60 @@
+// Copyright 2026 The Coval Benchmarks Authors
+// SPDX-License-Identifier: Apache-2.0
+
+"use client";
+
+import { Pause, Play } from "lucide-react";
+import { useMemo, useState } from "react";
+import { useSequencedPlayback } from "@/hooks/useSequencedPlayback";
+
+// The shared side of a tick: the one utterance every provider heard. Rendered
+// once above the per-provider outputs. Input audio is optional — the sampler
+// emits a null clip URL when the transcript can't be resolved to a dataset clip.
+export function SampleInput({
+  transcript,
+  inputAudioUrl,
+}: {
+  transcript: string | null;
+  inputAudioUrl: string | null;
+}) {
+  const tracks = useMemo(
+    () => (inputAudioUrl ? [{ key: "input", url: inputAudioUrl }] : []),
+    [inputAudioUrl]
+  );
+  const { audioRef, isPlaying, toggle, handleEnded } = useSequencedPlayback(tracks);
+  const [expanded, setExpanded] = useState(false);
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center gap-2">
+        <p className="font-mono text-[10px] font-medium uppercase tracking-[0.28em] text-text-tertiary">
+          Prompt
+        </p>
+        {inputAudioUrl ? (
+          <button
+            type="button"
+            onClick={toggle}
+            className="flex items-center gap-1 rounded-full border border-border-primary bg-surface-secondary px-2 py-0.5 text-[11px] text-text-secondary transition-colors hover:text-text-primary"
+            aria-label={isPlaying ? "Pause input clip" : "Play input clip"}
+          >
+            {isPlaying ? <Pause className="size-3" /> : <Play className="size-3" />}
+            <span>Input clip</span>
+          </button>
+        ) : null}
+      </div>
+      {transcript ? (
+        <button
+          type="button"
+          onClick={() => setExpanded((v) => !v)}
+          className={`block w-full text-left text-sm text-text-primary ${expanded ? "" : "line-clamp-2"}`}
+          title={expanded ? "Collapse" : "Expand"}
+        >
+          &ldquo;{transcript}&rdquo;
+        </button>
+      ) : (
+        <p className="text-sm italic text-text-tertiary">Transcript unavailable</p>
+      )}
+      <audio ref={audioRef} onEnded={handleEnded} hidden />
+    </div>
+  );
+}

--- a/web/app/s2s/components/SampleInput.tsx
+++ b/web/app/s2s/components/SampleInput.tsx
@@ -5,7 +5,10 @@
 
 import { Pause, Play } from "lucide-react";
 import { useMemo, useState } from "react";
-import { useSequencedPlayback } from "@/hooks/useSequencedPlayback";
+import {
+  useSequencedPlayback,
+  type PlaybackCoordinator,
+} from "@/hooks/useSequencedPlayback";
 
 // The shared side of a tick: the one utterance every provider heard. Rendered
 // once above the per-provider outputs. Input audio is optional — the sampler
@@ -13,15 +16,21 @@ import { useSequencedPlayback } from "@/hooks/useSequencedPlayback";
 export function SampleInput({
   transcript,
   inputAudioUrl,
+  coordinator,
 }: {
   transcript: string | null;
   inputAudioUrl: string | null;
+  coordinator?: PlaybackCoordinator;
 }) {
   const tracks = useMemo(
     () => (inputAudioUrl ? [{ key: "input", url: inputAudioUrl }] : []),
     [inputAudioUrl]
   );
-  const { audioRef, isPlaying, toggle, handleEnded } = useSequencedPlayback(tracks);
+  const { audioRef, isPlaying, toggle, handleEnded } = useSequencedPlayback(
+    tracks,
+    undefined,
+    coordinator
+  );
   const [expanded, setExpanded] = useState(false);
 
   return (

--- a/web/app/s2s/components/SampleOutputs.tsx
+++ b/web/app/s2s/components/SampleOutputs.tsx
@@ -5,7 +5,11 @@
 
 import { ChevronLeft, ChevronRight, Pause, Play } from "lucide-react";
 import { type RefObject, useEffect, useMemo, useRef, useState } from "react";
-import { useSequencedPlayback, type PlaybackTrack } from "@/hooks/useSequencedPlayback";
+import {
+  useSequencedPlayback,
+  type PlaybackCoordinator,
+  type PlaybackTrack,
+} from "@/hooks/useSequencedPlayback";
 import { getModelColor } from "@/lib/utils/colors";
 import { toModelKey } from "@/lib/utils/formatters";
 
@@ -52,11 +56,13 @@ export function SampleOutputs({
   normalizeProvider,
   onPlay,
   playRequest,
+  coordinator,
 }: {
   items: SampleOutputItem[];
   normalizeProvider: (provider: string) => string;
   onPlay?: (provider: string) => void;
   playRequest?: { provider: string; nonce: number } | null;
+  coordinator?: PlaybackCoordinator;
 }) {
   const tracks = useMemo<PlaybackTrack[]>(
     () => items.map((i) => ({ key: i.provider, url: i.url })),
@@ -67,7 +73,8 @@ export function SampleOutputs({
 
   const { audioRef, activeIndex, isPlaying, toggle, playFrom, handleEnded } = useSequencedPlayback(
     tracks,
-    (track) => onPlay?.(track.key)
+    (track) => onPlay?.(track.key),
+    coordinator
   );
 
   // A timeline-tooltip click plays a specific provider. Wait until that tick's

--- a/web/app/s2s/components/SampleOutputs.tsx
+++ b/web/app/s2s/components/SampleOutputs.tsx
@@ -1,0 +1,195 @@
+// Copyright 2026 The Coval Benchmarks Authors
+// SPDX-License-Identifier: Apache-2.0
+
+"use client";
+
+import { ChevronLeft, ChevronRight, Pause, Play } from "lucide-react";
+import { type RefObject, useEffect, useMemo, useRef, useState } from "react";
+import { useSequencedPlayback, type PlaybackTrack } from "@/hooks/useSequencedPlayback";
+import { getModelColor } from "@/lib/utils/colors";
+import { toModelKey } from "@/lib/utils/formatters";
+
+export interface SampleOutputItem {
+  provider: string;
+  model: string;
+  url: string;
+}
+
+// Left/right chevron/fade visibility from scroll extents; remeasures on scroll,
+// resize, and when the item set changes.
+function useScrollHints(
+  ref: RefObject<HTMLDivElement | null>,
+  activityKey: string
+): { left: boolean; right: boolean } {
+  const [hints, setHints] = useState({ left: false, right: false });
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    const measure = () => {
+      const { scrollLeft, scrollWidth, clientWidth } = el;
+      const maxScroll = scrollWidth - clientWidth;
+      const eps = 8;
+      if (maxScroll <= eps) {
+        setHints({ left: false, right: false });
+        return;
+      }
+      setHints({ left: scrollLeft > eps, right: scrollLeft < maxScroll - eps });
+    };
+    measure();
+    el.addEventListener("scroll", measure, { passive: true });
+    const ro = new ResizeObserver(measure);
+    ro.observe(el);
+    return () => {
+      el.removeEventListener("scroll", measure);
+      ro.disconnect();
+    };
+  }, [ref, activityKey]);
+  return hints;
+}
+
+export function SampleOutputs({
+  items,
+  normalizeProvider,
+  onPlay,
+  playRequest,
+}: {
+  items: SampleOutputItem[];
+  normalizeProvider: (provider: string) => string;
+  onPlay?: (provider: string) => void;
+  playRequest?: { provider: string; nonce: number } | null;
+}) {
+  const tracks = useMemo<PlaybackTrack[]>(
+    () => items.map((i) => ({ key: i.provider, url: i.url })),
+    [items]
+  );
+  const viewportRef = useRef<HTMLDivElement>(null);
+  const paneRefs = useRef<(HTMLDivElement | null)[]>([]);
+
+  const { audioRef, activeIndex, isPlaying, toggle, playFrom, handleEnded } = useSequencedPlayback(
+    tracks,
+    (track) => onPlay?.(track.key)
+  );
+
+  // A timeline-tooltip click plays a specific provider. Wait until that tick's
+  // items have loaded (provider present) before playing, then mark the request
+  // consumed — so the async manifest swap doesn't play the previous tick.
+  const consumedNonce = useRef<number | null>(null);
+  useEffect(() => {
+    if (!playRequest || consumedNonce.current === playRequest.nonce) return;
+    const idx = items.findIndex((i) => i.provider === playRequest.provider);
+    if (idx < 0) return;
+    consumedNonce.current = playRequest.nonce;
+    playFrom(idx);
+  }, [playRequest, items, playFrom]);
+
+  // Auto-scroll the active pane to center while a sequence is playing.
+  useEffect(() => {
+    if (!isPlaying) return;
+    const vp = viewportRef.current;
+    const pane = paneRefs.current[activeIndex];
+    if (!vp || !pane) return;
+    const target = pane.offsetLeft - (vp.clientWidth - pane.clientWidth) / 2;
+    vp.scrollTo({ left: Math.max(0, target), behavior: "smooth" });
+  }, [activeIndex, isPlaying]);
+
+  const hints = useScrollHints(viewportRef, `${items.length}:${items.map((i) => i.provider).join(",")}`);
+
+  const step = (dir: -1 | 1) => {
+    const vp = viewportRef.current;
+    if (!vp) return;
+    const first = vp.querySelector<HTMLElement>('[role="listitem"]');
+    vp.scrollBy({ left: dir * (first ? first.offsetWidth + 12 : 240), behavior: "smooth" });
+  };
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between">
+        <p className="font-mono text-[10px] font-medium uppercase tracking-[0.28em] text-text-tertiary">
+          Responses
+        </p>
+        <button
+          type="button"
+          onClick={toggle}
+          className="flex items-center gap-1.5 rounded-full bg-text-primary px-3 py-1 text-[11px] font-medium text-surface-primary transition-opacity hover:opacity-90"
+          aria-label={isPlaying ? "Pause" : "Play all responses"}
+        >
+          {isPlaying ? <Pause className="size-3" /> : <Play className="size-3" />}
+          <span>{isPlaying ? "Pause" : "Play all"}</span>
+        </button>
+      </div>
+
+      <div className="relative">
+        {hints.left ? (
+          <button
+            type="button"
+            onClick={() => step(-1)}
+            aria-label="Scroll responses left"
+            className="absolute left-0.5 top-1/2 z-[3] flex size-8 -translate-y-1/2 items-center justify-center rounded-full bg-surface-secondary/90 text-text-primary shadow-md ring-1 ring-border-primary backdrop-blur-[1px]"
+          >
+            <ChevronLeft className="size-5" />
+          </button>
+        ) : null}
+        {hints.right ? (
+          <button
+            type="button"
+            onClick={() => step(1)}
+            aria-label="Scroll responses right"
+            className="absolute right-0.5 top-1/2 z-[3] flex size-8 -translate-y-1/2 items-center justify-center rounded-full bg-surface-secondary/90 text-text-primary shadow-md ring-1 ring-border-primary backdrop-blur-[1px]"
+          >
+            <ChevronRight className="size-5" />
+          </button>
+        ) : null}
+
+        <div
+          ref={viewportRef}
+          className="scrollbar-hide flex snap-x snap-mandatory gap-3 overflow-x-auto pb-1"
+          role="list"
+          aria-label="Provider responses"
+        >
+          {items.map((item, i) => {
+            const active = i === activeIndex;
+            const playingThis = active && isPlaying;
+            return (
+              <div
+                key={item.provider}
+                ref={(el) => {
+                  paneRefs.current[i] = el;
+                }}
+                role="listitem"
+                className={`flex w-[180px] min-w-[180px] shrink-0 snap-start flex-col gap-2 rounded-xl border p-3 transition-colors ${
+                  active
+                    ? "border-text-primary/40 bg-surface-secondary"
+                    : "border-border-primary bg-surface-secondary/60"
+                }`}
+              >
+                <div className="flex items-center gap-1.5">
+                  <span
+                    className="size-2 shrink-0 rounded-full"
+                    style={{ backgroundColor: getModelColor(toModelKey(item.provider, item.model)) }}
+                  />
+                  <span className="truncate text-xs font-medium text-text-primary">
+                    {normalizeProvider(item.provider)}
+                  </span>
+                </div>
+                <span className="truncate font-mono text-[11px] text-text-tertiary">
+                  {item.model}
+                </span>
+                <button
+                  type="button"
+                  onClick={() => (playingThis ? toggle() : playFrom(i))}
+                  className="mt-auto flex items-center gap-1 self-start rounded-full border border-border-primary px-2 py-0.5 text-[11px] text-text-secondary transition-colors hover:text-text-primary"
+                  aria-label={playingThis ? `Pause ${item.provider}` : `Play ${item.provider}`}
+                >
+                  {playingThis ? <Pause className="size-3" /> : <Play className="size-3" />}
+                  <span>{playingThis ? "Playing" : "Play"}</span>
+                </button>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      <audio ref={audioRef} onEnded={handleEnded} hidden />
+    </div>
+  );
+}

--- a/web/app/s2s/components/SamplesCard.tsx
+++ b/web/app/s2s/components/SamplesCard.tsx
@@ -3,12 +3,14 @@
 
 "use client";
 
-import { useCallback, useMemo } from "react";
+import { useCallback, useEffect, useMemo } from "react";
 import Card from "@/components/shared/Card";
 import { useDashboard } from "@/contexts/DashboardContext";
+import { SampleFetchError } from "@/lib/audioSamples/createSampleFeed";
 import { s2sSampleFeed, visibleRecordings } from "@/lib/audioSamples/s2sFeed";
 import { capturePostHogEvent } from "@/lib/posthog/client";
 import { POSTHOG_EVENTS } from "@/lib/posthog/events";
+import { usePlaybackCoordinator } from "@/hooks/useSequencedPlayback";
 import { SampleInput } from "./SampleInput";
 import { SampleOutputs, type SampleOutputItem } from "./SampleOutputs";
 
@@ -18,8 +20,18 @@ function tickLabel(tick: string): string {
   return d.toLocaleDateString(undefined, { month: "short", day: "numeric" });
 }
 
+// Which failure case fired, for the console — network/http/parse vs an
+// unclassified error, with the status when we have one.
+function describeError(err: unknown): string {
+  if (err instanceof SampleFetchError) {
+    return err.status != null ? `${err.kind} (status ${err.status})` : err.kind;
+  }
+  return err instanceof Error ? err.message : String(err);
+}
+
 export function SamplesCard() {
   const { modelsByProvider, normalizeProviderName, s2sPlayRequest } = useDashboard();
+  const coordinator = usePlaybackCoordinator();
   const visibleProviders = useMemo(
     () => new Set(Object.keys(modelsByProvider)),
     [modelsByProvider]
@@ -32,6 +44,15 @@ export function SamplesCard() {
   const manifestQuery = s2sSampleFeed.useManifestQuery(effectiveTick);
   const manifest = manifestQuery.data ?? null;
 
+  const fetchError = manifestQuery.isError || indexQuery.isError;
+  // Keep the failure cause internal (dev console only); public visitors just see
+  // the generic "temporarily unavailable" copy below.
+  useEffect(() => {
+    if (process.env.NODE_ENV === "production") return;
+    const err = manifestQuery.error ?? indexQuery.error;
+    if (err) console.error(`[s2s-samples] fetch failed: ${describeError(err)}`, err);
+  }, [manifestQuery.error, indexQuery.error]);
+
   const items = useMemo<SampleOutputItem[]>(() => {
     if (!manifest) return [];
     return visibleRecordings(manifest, visibleProviders).map((r) => ({
@@ -43,7 +64,7 @@ export function SamplesCard() {
 
   const handlePlay = useCallback(
     (provider: string) => {
-      capturePostHogEvent(POSTHOG_EVENTS.s2sSamplePlayed, {
+      capturePostHogEvent(POSTHOG_EVENTS.s2sSamplePlayRequested, {
         surface: "s2s_dashboard",
         mode: "s2s",
         provider,
@@ -71,7 +92,7 @@ export function SamplesCard() {
 
       {loading ? (
         <div className="h-40 animate-pulse rounded-lg bg-surface-secondary" />
-      ) : indexQuery.isError ? (
+      ) : fetchError ? (
         <p className="py-8 text-center text-sm text-text-tertiary">
           Samples are temporarily unavailable.
         </p>
@@ -86,6 +107,7 @@ export function SamplesCard() {
           <SampleInput
             transcript={manifest?.transcript ?? null}
             inputAudioUrl={manifest?.input_audio_url ?? null}
+            coordinator={coordinator}
           />
           <SampleOutputs
             items={items}
@@ -96,6 +118,7 @@ export function SamplesCard() {
                 ? { provider: s2sPlayRequest.provider, nonce: s2sPlayRequest.nonce }
                 : null
             }
+            coordinator={coordinator}
           />
         </div>
       )}

--- a/web/app/s2s/components/SamplesCard.tsx
+++ b/web/app/s2s/components/SamplesCard.tsx
@@ -1,0 +1,108 @@
+// Copyright 2026 The Coval Benchmarks Authors
+// SPDX-License-Identifier: Apache-2.0
+
+"use client";
+
+import { useCallback, useMemo } from "react";
+import Card from "@/components/shared/Card";
+import { useDashboard } from "@/contexts/DashboardContext";
+import { s2sSampleFeed, visibleRecordings } from "@/lib/audioSamples/s2sFeed";
+import { capturePostHogEvent } from "@/lib/posthog/client";
+import { POSTHOG_EVENTS } from "@/lib/posthog/events";
+import { SampleInput } from "./SampleInput";
+import { SampleOutputs, type SampleOutputItem } from "./SampleOutputs";
+
+function tickLabel(tick: string): string {
+  const d = new Date(tick);
+  if (Number.isNaN(d.getTime())) return tick;
+  return d.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+}
+
+export function SamplesCard() {
+  const { modelsByProvider, normalizeProviderName, s2sPlayRequest } = useDashboard();
+  const visibleProviders = useMemo(
+    () => new Set(Object.keys(modelsByProvider)),
+    [modelsByProvider]
+  );
+
+  const indexQuery = s2sSampleFeed.useIndexQuery();
+  const latestTick = indexQuery.data?.[0] ?? null;
+  // A timeline-tooltip click pins the card to that bucket; otherwise show latest.
+  const effectiveTick = s2sPlayRequest?.tick ?? latestTick;
+  const manifestQuery = s2sSampleFeed.useManifestQuery(effectiveTick);
+  const manifest = manifestQuery.data ?? null;
+
+  const items = useMemo<SampleOutputItem[]>(() => {
+    if (!manifest) return [];
+    return visibleRecordings(manifest, visibleProviders).map((r) => ({
+      provider: r.provider,
+      model: r.model,
+      url: s2sSampleFeed.objectUrl(r.object),
+    }));
+  }, [manifest, visibleProviders]);
+
+  const handlePlay = useCallback(
+    (provider: string) => {
+      capturePostHogEvent(POSTHOG_EVENTS.s2sSamplePlayed, {
+        surface: "s2s_dashboard",
+        mode: "s2s",
+        provider,
+        bucket_at: manifest?.bucket_at,
+      });
+    },
+    [manifest?.bucket_at]
+  );
+
+  const loading =
+    indexQuery.isLoading || (effectiveTick != null && manifestQuery.isLoading);
+
+  return (
+    <Card className="text-left min-w-0 h-full flex flex-col" padding="p-5 lg:p-8">
+      <div className="mb-3 flex items-baseline justify-between gap-2">
+        <div className="text-[0.9rem] font-light text-text-secondary">
+          Conversation samples
+        </div>
+        {manifest ? (
+          <span className="font-mono text-xs text-text-tertiary">
+            {tickLabel(manifest.bucket_at)}
+          </span>
+        ) : null}
+      </div>
+
+      {loading ? (
+        <div className="h-40 animate-pulse rounded-lg bg-surface-secondary" />
+      ) : indexQuery.isError ? (
+        <p className="py-8 text-center text-sm text-text-tertiary">
+          Samples are temporarily unavailable.
+        </p>
+      ) : items.length === 0 ? (
+        <p className="py-8 text-center text-sm text-text-tertiary">
+          {!manifest && s2sPlayRequest
+            ? "No sample recorded for this point."
+            : "Samples appear here after the next benchmark run."}
+        </p>
+      ) : (
+        <div className="flex flex-1 flex-col gap-4">
+          <SampleInput
+            transcript={manifest?.transcript ?? null}
+            inputAudioUrl={manifest?.input_audio_url ?? null}
+          />
+          <SampleOutputs
+            items={items}
+            normalizeProvider={normalizeProviderName}
+            onPlay={handlePlay}
+            playRequest={
+              s2sPlayRequest
+                ? { provider: s2sPlayRequest.provider, nonce: s2sPlayRequest.nonce }
+                : null
+            }
+          />
+        </div>
+      )}
+
+      <p className="mt-4 text-[10px] text-text-tertiary">
+        Prompts from the SLURP dataset (CC BY-NC 4.0).
+      </p>
+    </Card>
+  );
+}

--- a/web/app/s2s/s2s-dashboard.tsx
+++ b/web/app/s2s/s2s-dashboard.tsx
@@ -7,8 +7,8 @@ import dynamic from "next/dynamic";
 import { DashboardProvider } from "@/contexts/DashboardContext";
 import { SidebarMenuProvider } from "@/contexts/SidebarMenuContext";
 import DashboardLayout from "@/components/layout/DashboardLayout";
-import KeyMetrics from "@/components/dashboard/KeyMetrics";
 import { ChartSkeleton } from "@/components/dashboard/DashboardSkeleton";
+import { S2STopRow } from "./components/S2STopRow";
 
 // S2S has a single metric (V2V latency, no WER). The WER-based sections
 // (AccuracyBarSection, LatencyAccuracySection) are omitted; the model
@@ -33,7 +33,7 @@ export function S2SDashboard() {
     <DashboardProvider page="s2s">
       <SidebarMenuProvider>
         <DashboardLayout>
-          <KeyMetrics />
+          <S2STopRow />
           <TimelineChart />
           <BoxPlotSection />
           <ModelComparisonSection />

--- a/web/components/charts/tooltips/TimelineTooltip.tsx
+++ b/web/components/charts/tooltips/TimelineTooltip.tsx
@@ -28,13 +28,19 @@ interface TimelineTooltipProps {
   interactionHint?: string | false;
   /** Caps the scroll area (px); keeps the pinned list from covering the chart on mobile. */
   maxHeight?: number;
+  /**
+   * S2S pinned tooltip only: makes each row a play control for that model's
+   * recording at this bucket. Omitted everywhere else, so those rows stay
+   * static and unchanged.
+   */
+  onModelClick?: (model: string, label: number) => void;
   /** Non-timeline charts: shown verbatim instead of the timestamp label. */
   labelText?: string;
   /** Non-latency values: overrides the default "123ms" rendering. */
   formatValue?: (value: number) => string;
 }
 
-const CustomTimelineTooltip: React.FC<TimelineTooltipProps> = ({ active, payload, label, getProviderForModel, showDate, dimmedKeys, compact, interactionHint, maxHeight, labelText, formatValue }) => {
+const CustomTimelineTooltip: React.FC<TimelineTooltipProps> = ({ active, payload, label, getProviderForModel, showDate, dimmedKeys, compact, interactionHint, maxHeight, onModelClick, labelText, formatValue }) => {
   if (!active || !payload || payload.length === 0) return null;
 
   // Filter out null/undefined values and sort by value (fastest to slowest)
@@ -104,16 +110,31 @@ const CustomTimelineTooltip: React.FC<TimelineTooltipProps> = ({ active, payload
           const modelName = item.dataKey.replace(/_value$/, "");
           const provider = getProviderForModel(modelName);
           const isLeader = item.dataKey === leaderKey;
+          const clickable = onModelClick != null;
 
           return (
             <div
               key={item.dataKey}
+              {...(clickable
+                ? {
+                    role: "button" as const,
+                    tabIndex: 0,
+                    onClick: () => onModelClick(modelName, Number(label)),
+                    onKeyDown: (e: React.KeyboardEvent) => {
+                      if (e.key === "Enter" || e.key === " ") {
+                        e.preventDefault();
+                        onModelClick(modelName, Number(label));
+                      }
+                    }
+                  }
+                : {})}
               style={{
                 margin: "6px 0",
                 display: "flex",
                 alignItems: "center",
                 justifyContent: "space-between",
-                opacity: item.inView ? 1 : 0.35
+                opacity: item.inView ? 1 : 0.35,
+                ...(clickable ? { cursor: "pointer" } : {})
               }}
             >
               <div style={{ display: "flex", alignItems: "center", flex: 1 }}>
@@ -156,6 +177,7 @@ const CustomTimelineTooltip: React.FC<TimelineTooltipProps> = ({ active, payload
                 }}
               >
                 {formatValue ? formatValue(item.value) : `${item.value.toFixed(0)}ms`}
+                {clickable ? <span style={{ marginLeft: "6px" }} aria-hidden>▶</span> : null}
               </span>
             </div>
           );

--- a/web/components/visualizations/TimelineChart.tsx
+++ b/web/components/visualizations/TimelineChart.tsx
@@ -181,6 +181,13 @@ interface TooltipPayloadItem {
   color: string;
 }
 
+// A timeline point's timestamp (epoch ms) is the 3h bucket start, which the S2S
+// sampler uses verbatim as the tick-folder key — so this reproduces that key to
+// join a clicked tooltip row to its recording set.
+function bucketTickKey(label: number): string {
+  return new Date(label).toISOString().replace(/\.\d{3}Z$/, "Z");
+}
+
 interface PinnedTooltip {
   label: string;
   payload: TooltipPayloadItem[];
@@ -252,6 +259,8 @@ const TimelineChart: React.FC = () => {
     dataTimeWindow,
     legendModels,
     toggleLegendModel,
+    page,
+    requestS2SPlay,
   } = useDashboard();
   const trackChartHover = useChartHoverTracking("timeline");
 
@@ -1144,6 +1153,12 @@ const TimelineChart: React.FC = () => {
                 showDate={dateScale}
                 dimmedKeys={dimmedLegendKeys}
                 maxHeight={isMobile ? 106 : undefined}
+                onModelClick={
+                  page === "s2s"
+                    ? (model, label) =>
+                        requestS2SPlay(bucketTickKey(label), getProviderForModel(model))
+                    : undefined
+                }
               />
             </div>
           )}

--- a/web/hooks/useDashboardState.tsx
+++ b/web/hooks/useDashboardState.tsx
@@ -46,6 +46,18 @@ export function useDashboardState(page: "tts" | "stt" | "s2s") {
   const [sttMetric, setSttMetric] = useState<"TTFS" | "TTFT">("TTFS");
   const activeMetric =
     page === "s2s" ? "V2V" : page === "tts" ? "TTFA" : sttMetric;
+
+  // S2S only: a click on a model row in the pinned timeline tooltip asks the
+  // samples card to jump to that bucket + provider and play. nonce lets a repeat
+  // click on the same row replay.
+  const [s2sPlayRequest, setS2sPlayRequest] = useState<{
+    tick: string;
+    provider: string;
+    nonce: number;
+  } | null>(null);
+  const requestS2SPlay = useCallback((tick: string, provider: string) => {
+    setS2sPlayRequest((prev) => ({ tick, provider, nonce: (prev?.nonce ?? 0) + 1 }));
+  }, []);
   const { timeWindow, changeTimeWindow } = useTimeWindow(
     `${page}_dashboard`,
     page
@@ -562,7 +574,12 @@ export function useDashboardState(page: "tts" | "stt" | "s2s") {
 
   return {
     // Page identity
+    page,
     latencyLabel,
+
+    // S2S samples card <-> timeline tooltip bridge
+    s2sPlayRequest,
+    requestS2SPlay,
 
     // Display strings
     pageTitle,

--- a/web/hooks/useSequencedPlayback.ts
+++ b/web/hooks/useSequencedPlayback.ts
@@ -1,0 +1,95 @@
+// Copyright 2026 The Coval Benchmarks Authors
+// SPDX-License-Identifier: Apache-2.0
+
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+export interface PlaybackTrack {
+  key: string;
+  url: string;
+}
+
+export interface SequencedPlayback {
+  audioRef: React.RefObject<HTMLAudioElement | null>;
+  activeIndex: number;
+  isPlaying: boolean;
+  toggle: () => void;
+  playFrom: (index: number) => void;
+  handleEnded: () => void;
+  stop: () => void;
+}
+
+// A playlist over one <audio> element: one click plays the active track, and
+// each track's end auto-advances to the next until the list is exhausted or
+// the user stops. onActivate fires the moment a track becomes active (for
+// auto-scroll + analytics), not when its play() promise resolves.
+export function useSequencedPlayback(
+  tracks: PlaybackTrack[],
+  onActivate?: (track: PlaybackTrack, index: number) => void
+): SequencedPlayback {
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+  const [activeIndex, setActiveIndex] = useState(0);
+  const [isPlaying, setIsPlaying] = useState(false);
+
+  useEffect(() => {
+    if (tracks.length > 0 && activeIndex >= tracks.length) setActiveIndex(0);
+  }, [tracks.length, activeIndex]);
+
+  const playFrom = useCallback(
+    (index: number) => {
+      const audio = audioRef.current;
+      const track = tracks[index];
+      if (!audio || !track) return;
+      setActiveIndex(index);
+      onActivate?.(track, index);
+      audio.src = track.url;
+      audio.currentTime = 0;
+      setIsPlaying(true);
+      void audio.play().catch(() => setIsPlaying(false));
+    },
+    [tracks, onActivate]
+  );
+
+  const toggle = useCallback(() => {
+    const audio = audioRef.current;
+    if (!audio) return;
+    if (isPlaying) {
+      audio.pause();
+      setIsPlaying(false);
+      return;
+    }
+    // Resume a paused track; otherwise (re)start the active one.
+    if (audio.src && !audio.ended) {
+      setIsPlaying(true);
+      void audio.play().catch(() => setIsPlaying(false));
+    } else {
+      playFrom(activeIndex);
+    }
+  }, [isPlaying, activeIndex, playFrom]);
+
+  const handleEnded = useCallback(() => {
+    const next = activeIndex + 1;
+    if (next < tracks.length) playFrom(next);
+    else setIsPlaying(false);
+  }, [activeIndex, tracks.length, playFrom]);
+
+  const stop = useCallback(() => {
+    const audio = audioRef.current;
+    if (audio) {
+      audio.pause();
+      audio.currentTime = 0;
+    }
+    setIsPlaying(false);
+  }, []);
+
+  useEffect(
+    () => () => {
+      const audio = audioRef.current;
+      if (audio) audio.pause();
+    },
+    []
+  );
+
+  return { audioRef, activeIndex, isPlaying, toggle, playFrom, handleEnded, stop };
+}

--- a/web/hooks/useSequencedPlayback.ts
+++ b/web/hooks/useSequencedPlayback.ts
@@ -3,11 +3,36 @@
 
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 export interface PlaybackTrack {
   key: string;
   url: string;
+}
+
+// Stable identity of what's loaded into the <audio> element, so we can tell a
+// genuine track swap (key or url changed) from a same-index re-render.
+const trackId = (t: PlaybackTrack): string => JSON.stringify([t.key, t.url]);
+
+// Makes sibling players mutually exclusive: a player claims it before playing,
+// which pauses whoever held it. Share one per group; omit to run independent.
+export interface PlaybackCoordinator {
+  claim: (pause: () => void) => void;
+}
+
+export function usePlaybackCoordinator(): PlaybackCoordinator {
+  const currentPause = useRef<(() => void) | null>(null);
+  return useMemo(
+    () => ({
+      claim: (pause: () => void) => {
+        if (currentPause.current && currentPause.current !== pause) {
+          currentPause.current();
+        }
+        currentPause.current = pause;
+      },
+    }),
+    []
+  );
 }
 
 export interface SequencedPlayback {
@@ -26,47 +51,79 @@ export interface SequencedPlayback {
 // auto-scroll + analytics), not when its play() promise resolves.
 export function useSequencedPlayback(
   tracks: PlaybackTrack[],
-  onActivate?: (track: PlaybackTrack, index: number) => void
+  onActivate?: (track: PlaybackTrack, index: number) => void,
+  coordinator?: PlaybackCoordinator
 ): SequencedPlayback {
   const audioRef = useRef<HTMLAudioElement | null>(null);
   const [activeIndex, setActiveIndex] = useState(0);
   const [isPlaying, setIsPlaying] = useState(false);
 
-  useEffect(() => {
-    if (tracks.length > 0 && activeIndex >= tracks.length) setActiveIndex(0);
-  }, [tracks.length, activeIndex]);
+  // Bumped by every operation that supersedes playback (new play, pause, stop,
+  // unmount, track swap) so a late play() rejection can't clear a newer state.
+  const genRef = useRef(0);
+  // Identity currently loaded into the element, or null when nothing is loaded.
+  const playingIdRef = useRef<string | null>(null);
+
+  const requestPlay = useCallback(() => {
+    const audio = audioRef.current;
+    if (!audio) return;
+    const gen = ++genRef.current;
+    setIsPlaying(true);
+    void audio.play().catch(() => {
+      if (genRef.current === gen) setIsPlaying(false);
+    });
+  }, []);
+
+  const pauseSelf = useCallback(() => {
+    genRef.current++;
+    audioRef.current?.pause();
+    setIsPlaying(false);
+  }, []);
+
+  const stop = useCallback(() => {
+    genRef.current++;
+    const audio = audioRef.current;
+    if (audio) {
+      audio.pause();
+      audio.currentTime = 0;
+    }
+    playingIdRef.current = null;
+    setIsPlaying(false);
+  }, []);
 
   const playFrom = useCallback(
     (index: number) => {
       const audio = audioRef.current;
       const track = tracks[index];
       if (!audio || !track) return;
+      coordinator?.claim(pauseSelf);
       setActiveIndex(index);
+      playingIdRef.current = trackId(track);
       onActivate?.(track, index);
       audio.src = track.url;
       audio.currentTime = 0;
-      setIsPlaying(true);
-      void audio.play().catch(() => setIsPlaying(false));
+      requestPlay();
     },
-    [tracks, onActivate]
+    [tracks, onActivate, coordinator, pauseSelf, requestPlay]
   );
 
   const toggle = useCallback(() => {
     const audio = audioRef.current;
     if (!audio) return;
     if (isPlaying) {
-      audio.pause();
-      setIsPlaying(false);
+      pauseSelf();
       return;
     }
-    // Resume a paused track; otherwise (re)start the active one.
-    if (audio.src && !audio.ended) {
-      setIsPlaying(true);
-      void audio.play().catch(() => setIsPlaying(false));
+    // Resume only if the loaded clip is still the active track; after a track
+    // swap the element holds a stale src, so (re)load via playFrom instead.
+    const active = tracks[activeIndex];
+    if (audio.src && !audio.ended && active && playingIdRef.current === trackId(active)) {
+      coordinator?.claim(pauseSelf);
+      requestPlay();
     } else {
       playFrom(activeIndex);
     }
-  }, [isPlaying, activeIndex, playFrom]);
+  }, [isPlaying, activeIndex, tracks, playFrom, coordinator, pauseSelf, requestPlay]);
 
   const handleEnded = useCallback(() => {
     const next = activeIndex + 1;
@@ -74,19 +131,30 @@ export function useSequencedPlayback(
     else setIsPlaying(false);
   }, [activeIndex, tracks.length, playFrom]);
 
-  const stop = useCallback(() => {
-    const audio = audioRef.current;
-    if (audio) {
-      audio.pause();
-      audio.currentTime = 0;
+  // Stop and rebase when the list mutates under us: empty list, active index now
+  // out of range, or the active slot's identity changed — otherwise the old clip
+  // keeps playing after a tick/manifest swap.
+  useEffect(() => {
+    if (tracks.length === 0) {
+      if (playingIdRef.current !== null) stop();
+      if (activeIndex !== 0) setActiveIndex(0);
+      return;
     }
-    setIsPlaying(false);
-  }, []);
+    const active = tracks[activeIndex];
+    if (!active) {
+      stop();
+      setActiveIndex(0);
+      return;
+    }
+    if (playingIdRef.current !== null && playingIdRef.current !== trackId(active)) {
+      stop();
+    }
+  }, [tracks, activeIndex, stop]);
 
   useEffect(
     () => () => {
-      const audio = audioRef.current;
-      if (audio) audio.pause();
+      genRef.current++;
+      audioRef.current?.pause();
     },
     []
   );

--- a/web/lib/audioSamples/createSampleFeed.test.ts
+++ b/web/lib/audioSamples/createSampleFeed.test.ts
@@ -1,0 +1,176 @@
+// Copyright 2026 The Coval Benchmarks Authors
+// SPDX-License-Identifier: Apache-2.0
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createSampleFeed, SampleFetchError } from "./createSampleFeed";
+import {
+  parseS2SManifest,
+  s2sSampleFeed,
+  visibleRecordings,
+  type S2SSampleManifest,
+} from "./s2sFeed";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function stubFetch(impl: () => Promise<Response>): void {
+  vi.stubGlobal("fetch", vi.fn(impl));
+}
+
+const validManifest: S2SSampleManifest = {
+  bucket_at: "2026-07-19T00:00:00Z",
+  test_case_id: "tc1",
+  transcript: "hello",
+  input_audio_url: null,
+  recordings: [
+    {
+      provider: "openai",
+      model: "gpt-realtime",
+      object: "s2s-samples/x/openai.wav",
+      coval_run_id: "r1",
+      sim_id: "s1",
+    },
+  ],
+};
+
+const feed = createSampleFeed<S2SSampleManifest>(
+  { name: "test", bucket: "b", prefix: "p", refetchMs: 1000 },
+  parseS2SManifest
+);
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("fetchIndex", () => {
+  it("returns [] on 404 (nothing published yet)", async () => {
+    stubFetch(() => Promise.resolve(new Response("", { status: 404 })));
+    await expect(feed.fetchIndex()).resolves.toEqual([]);
+  });
+
+  it("sorts ticks newest-first regardless of source order", async () => {
+    stubFetch(() =>
+      Promise.resolve(
+        jsonResponse([
+          "2026-07-01T00:00:00Z",
+          "2026-07-03T00:00:00Z",
+          "2026-07-02T00:00:00Z",
+        ])
+      )
+    );
+    await expect(feed.fetchIndex()).resolves.toEqual([
+      "2026-07-03T00:00:00Z",
+      "2026-07-02T00:00:00Z",
+      "2026-07-01T00:00:00Z",
+    ]);
+  });
+
+  it("classifies a non-array body as a parse error", async () => {
+    stubFetch(() => Promise.resolve(jsonResponse({ nope: true })));
+    await expect(feed.fetchIndex()).rejects.toMatchObject({ kind: "parse" });
+  });
+
+  it("classifies an array with non-string entries as a parse error", async () => {
+    stubFetch(() => Promise.resolve(jsonResponse(["a", 2])));
+    await expect(feed.fetchIndex()).rejects.toMatchObject({ kind: "parse" });
+  });
+
+  it("classifies a 5xx as an http error carrying the status", async () => {
+    stubFetch(() => Promise.resolve(new Response("", { status: 503 })));
+    await expect(feed.fetchIndex()).rejects.toMatchObject({ kind: "http", status: 503 });
+  });
+
+  it("classifies a rejected fetch as a network error", async () => {
+    stubFetch(() => Promise.reject(new TypeError("Failed to fetch")));
+    await expect(feed.fetchIndex()).rejects.toBeInstanceOf(SampleFetchError);
+    stubFetch(() => Promise.reject(new TypeError("Failed to fetch")));
+    await expect(feed.fetchIndex()).rejects.toMatchObject({ kind: "network" });
+  });
+});
+
+describe("fetchManifest", () => {
+  it("returns null on 404 (a genuine no-sample tick)", async () => {
+    stubFetch(() => Promise.resolve(new Response("", { status: 404 })));
+    await expect(feed.fetchManifest("t")).resolves.toBeNull();
+  });
+
+  it("returns the parsed manifest on 200", async () => {
+    stubFetch(() => Promise.resolve(jsonResponse(validManifest)));
+    await expect(feed.fetchManifest("t")).resolves.toEqual(validManifest);
+  });
+
+  it("classifies a 5xx as an http error, not a missing sample", async () => {
+    stubFetch(() => Promise.resolve(new Response("", { status: 500 })));
+    await expect(feed.fetchManifest("t")).rejects.toMatchObject({ kind: "http", status: 500 });
+  });
+
+  it("classifies malformed JSON as a parse error", async () => {
+    stubFetch(() => Promise.resolve(new Response("{not json", { status: 200 })));
+    await expect(feed.fetchManifest("t")).rejects.toMatchObject({ kind: "parse" });
+  });
+
+  it("rejects a structurally invalid manifest ({} would crash the UI)", async () => {
+    stubFetch(() => Promise.resolve(jsonResponse({})));
+    await expect(feed.fetchManifest("t")).rejects.toMatchObject({ kind: "parse" });
+  });
+
+  it("passes an aborted request through untouched", async () => {
+    const abort = new DOMException("aborted", "AbortError");
+    stubFetch(() => Promise.reject(abort));
+    await expect(feed.fetchManifest("t")).rejects.toBe(abort);
+  });
+});
+
+describe("parseS2SManifest", () => {
+  it("accepts a valid manifest and null transcript/input", () => {
+    const m = parseS2SManifest({ ...validManifest, transcript: null, input_audio_url: "u" });
+    expect(m.transcript).toBeNull();
+    expect(m.input_audio_url).toBe("u");
+  });
+
+  it.each([
+    ["null", null],
+    ["missing recordings", { bucket_at: "x", test_case_id: "y", transcript: null, input_audio_url: null }],
+    ["recordings not an array", { ...validManifest, recordings: {} }],
+    ["recording missing a string field", { ...validManifest, recordings: [{ provider: "openai" }] }],
+    ["transcript wrong type", { ...validManifest, transcript: 42 }],
+  ])("throws on %s", (_label, bad) => {
+    expect(() => parseS2SManifest(bad)).toThrow();
+  });
+});
+
+describe("visibleRecordings", () => {
+  it("keeps only recordings whose provider is visible", () => {
+    const manifest: S2SSampleManifest = {
+      ...validManifest,
+      recordings: [
+        { ...validManifest.recordings[0]!, provider: "openai" },
+        { ...validManifest.recordings[0]!, provider: "hidden" },
+      ],
+    };
+    const out = visibleRecordings(manifest, new Set(["openai"]));
+    expect(out).toHaveLength(1);
+    expect(out[0]!.provider).toBe("openai");
+  });
+});
+
+describe("SampleFetchError", () => {
+  it("carries kind and status", () => {
+    const err = new SampleFetchError("http", "boom", 403);
+    expect(err).toBeInstanceOf(Error);
+    expect(err.kind).toBe("http");
+    expect(err.status).toBe(403);
+  });
+});
+
+describe("s2sSampleFeed.objectUrl", () => {
+  it("resolves a bucket-root-relative object path", () => {
+    expect(s2sSampleFeed.objectUrl("s2s-samples/x/openai.wav")).toBe(
+      "https://storage.googleapis.com/coval-benchmarks-s2s-samples/s2s-samples/x/openai.wav"
+    );
+  });
+});

--- a/web/lib/audioSamples/createSampleFeed.ts
+++ b/web/lib/audioSamples/createSampleFeed.ts
@@ -1,0 +1,81 @@
+// Copyright 2026 The Coval Benchmarks Authors
+// SPDX-License-Identifier: Apache-2.0
+
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+
+// Generic reader for a modality's public sample bucket. The fetch job publishes
+// one folder per tick (keyed by the timeline bucket timestamp) with a
+// manifest.json, next to a rolling index.json listing ticks newest-first. The
+// bucket is public-read, so the dashboard reads it directly — no backend hop.
+// Each modality (s2s/tts/stt) wraps this with its own bucket + manifest type.
+
+const BUCKET_HOST = "https://storage.googleapis.com";
+
+export interface SampleFeedConfig {
+  // Query-key namespace so modalities don't collide, e.g. "s2s-samples".
+  name: string;
+  bucket: string;
+  prefix: string;
+  // Shortest interval a new tick can appear = the runner's fetch period for
+  // this modality. Drives staleTime and a background refetch backstop.
+  refetchMs: number;
+}
+
+export function createSampleFeed<TManifest>(config: SampleFeedConfig) {
+  const root = `${BUCKET_HOST}/${config.bucket}`;
+  const indexUrl = `${root}/${config.prefix}/index.json`;
+  const manifestUrl = (tick: string) =>
+    `${root}/${config.prefix}/${encodeURIComponent(tick)}/manifest.json`;
+
+  // Public URL for an object whose manifest path is bucket-root-relative.
+  const objectUrl = (object: string): string => `${root}/${object}`;
+
+  // Tick keys newest-first; [] before the first tick has published.
+  const fetchIndex = async (signal?: AbortSignal): Promise<string[]> => {
+    const res = await fetch(indexUrl, { signal, cache: "no-store" });
+    if (res.status === 404) return [];
+    if (!res.ok) throw new Error(`${config.name} index -> ${res.status}`);
+    const data: unknown = await res.json();
+    if (!Array.isArray(data) || !data.every((t) => typeof t === "string")) {
+      throw new Error(`${config.name} index is not a list of tick strings`);
+    }
+    // Sort newest-first ourselves: backfill prepends older ticks out of order,
+    // so index order isn't reliable. Tick keys are ISO, so lexical = chrono.
+    return [...data].sort((a, b) => (a < b ? 1 : a > b ? -1 : 0));
+  };
+
+  // null when the tick has no manifest (e.g. a timeline bucket with no sample).
+  const fetchManifest = async (
+    tick: string,
+    signal?: AbortSignal
+  ): Promise<TManifest | null> => {
+    const res = await fetch(manifestUrl(tick), { signal, cache: "no-store" });
+    if (res.status === 404) return null;
+    if (!res.ok) throw new Error(`${config.name} manifest ${tick} -> ${res.status}`);
+    return (await res.json()) as TManifest;
+  };
+
+  const cadence = {
+    staleTime: config.refetchMs,
+    refetchInterval: config.refetchMs,
+  } as const;
+
+  const useIndexQuery = () =>
+    useQuery({
+      queryKey: [config.name, "index"],
+      queryFn: ({ signal }: { signal: AbortSignal }) => fetchIndex(signal),
+      ...cadence,
+    });
+
+  const useManifestQuery = (tick: string | null) =>
+    useQuery({
+      queryKey: [config.name, "manifest", tick],
+      queryFn: ({ signal }: { signal: AbortSignal }) => fetchManifest(tick!, signal),
+      enabled: tick != null,
+      ...cadence,
+    });
+
+  return { objectUrl, fetchIndex, fetchManifest, useIndexQuery, useManifestQuery };
+}

--- a/web/lib/audioSamples/createSampleFeed.ts
+++ b/web/lib/audioSamples/createSampleFeed.ts
@@ -13,6 +13,22 @@ import { useQuery } from "@tanstack/react-query";
 
 const BUCKET_HOST = "https://storage.googleapis.com";
 
+// A real fetch failure, as distinct from a 404 (turned into empty index / null
+// manifest). `kind`: network (fetch rejected — offline/DNS/CORS), http (bad
+// status), parse (bad JSON) — so callers don't show a false "no sample" state.
+export type SampleFetchErrorKind = "network" | "http" | "parse";
+
+export class SampleFetchError extends Error {
+  readonly kind: SampleFetchErrorKind;
+  readonly status?: number;
+  constructor(kind: SampleFetchErrorKind, message: string, status?: number) {
+    super(message);
+    this.name = "SampleFetchError";
+    this.kind = kind;
+    this.status = status;
+  }
+}
+
 export interface SampleFeedConfig {
   // Query-key namespace so modalities don't collide, e.g. "s2s-samples".
   name: string;
@@ -23,7 +39,13 @@ export interface SampleFeedConfig {
   refetchMs: number;
 }
 
-export function createSampleFeed<TManifest>(config: SampleFeedConfig) {
+// parseManifest validates+narrows the raw JSON into TManifest; it must throw on
+// any unexpected shape so a malformed manifest surfaces as a fetch error rather
+// than crashing a consumer that trusts the type.
+export function createSampleFeed<TManifest>(
+  config: SampleFeedConfig,
+  parseManifest: (data: unknown) => TManifest
+) {
   const root = `${BUCKET_HOST}/${config.bucket}`;
   const indexUrl = `${root}/${config.prefix}/index.json`;
   const manifestUrl = (tick: string) =>
@@ -32,29 +54,61 @@ export function createSampleFeed<TManifest>(config: SampleFeedConfig) {
   // Public URL for an object whose manifest path is bucket-root-relative.
   const objectUrl = (object: string): string => `${root}/${object}`;
 
+  // fetch() rejects on network/CORS failure; classify as network. Let an
+  // aborted request (cancelled query / unmount) pass through untouched.
+  const fetchOrThrow = async (
+    url: string,
+    label: string,
+    signal?: AbortSignal
+  ): Promise<Response> => {
+    try {
+      return await fetch(url, { signal, cache: "no-store" });
+    } catch (err) {
+      if (err instanceof DOMException && err.name === "AbortError") throw err;
+      throw new SampleFetchError("network", `${config.name} ${label}: network/CORS failure`);
+    }
+  };
+
+  const readJson = async (res: Response, label: string): Promise<unknown> => {
+    try {
+      return await res.json();
+    } catch {
+      throw new SampleFetchError("parse", `${config.name} ${label}: malformed JSON`, res.status);
+    }
+  };
+
   // Tick keys newest-first; [] before the first tick has published.
   const fetchIndex = async (signal?: AbortSignal): Promise<string[]> => {
-    const res = await fetch(indexUrl, { signal, cache: "no-store" });
+    const res = await fetchOrThrow(indexUrl, "index", signal);
     if (res.status === 404) return [];
-    if (!res.ok) throw new Error(`${config.name} index -> ${res.status}`);
-    const data: unknown = await res.json();
+    if (!res.ok) throw new SampleFetchError("http", `${config.name} index -> ${res.status}`, res.status);
+    const data = await readJson(res, "index");
     if (!Array.isArray(data) || !data.every((t) => typeof t === "string")) {
-      throw new Error(`${config.name} index is not a list of tick strings`);
+      throw new SampleFetchError("parse", `${config.name} index is not a list of tick strings`, res.status);
     }
     // Sort newest-first ourselves: backfill prepends older ticks out of order,
     // so index order isn't reliable. Tick keys are ISO, so lexical = chrono.
     return [...data].sort((a, b) => (a < b ? 1 : a > b ? -1 : 0));
   };
 
-  // null when the tick has no manifest (e.g. a timeline bucket with no sample).
+  // null on 404 (no sample for this tick); any other failure throws so the
+  // caller shows an error, not a false "no sample" state.
   const fetchManifest = async (
     tick: string,
     signal?: AbortSignal
   ): Promise<TManifest | null> => {
-    const res = await fetch(manifestUrl(tick), { signal, cache: "no-store" });
+    const res = await fetchOrThrow(manifestUrl(tick), `manifest ${tick}`, signal);
     if (res.status === 404) return null;
-    if (!res.ok) throw new Error(`${config.name} manifest ${tick} -> ${res.status}`);
-    return (await res.json()) as TManifest;
+    if (!res.ok) {
+      throw new SampleFetchError("http", `${config.name} manifest ${tick} -> ${res.status}`, res.status);
+    }
+    const data = await readJson(res, `manifest ${tick}`);
+    try {
+      return parseManifest(data);
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : String(err);
+      throw new SampleFetchError("parse", `${config.name} manifest ${tick}: ${detail}`, res.status);
+    }
   };
 
   const cadence = {

--- a/web/lib/audioSamples/s2sFeed.ts
+++ b/web/lib/audioSamples/s2sFeed.ts
@@ -1,0 +1,40 @@
+// Copyright 2026 The Coval Benchmarks Authors
+// SPDX-License-Identifier: Apache-2.0
+
+"use client";
+
+import { createSampleFeed } from "./createSampleFeed";
+
+export interface S2SSampleRecording {
+  provider: string;
+  model: string;
+  object: string;
+  coval_run_id: string;
+  sim_id: string;
+}
+
+export interface S2SSampleManifest {
+  bucket_at: string;
+  test_case_id: string;
+  transcript: string | null;
+  input_audio_url: string | null;
+  recordings: S2SSampleRecording[];
+}
+
+// Mirror the runner's s2s_fetch_period_seconds (config.py, default 10_800 = 3h).
+const S2S_FETCH_PERIOD_MS = 10_800 * 1000;
+
+export const s2sSampleFeed = createSampleFeed<S2SSampleManifest>({
+  name: "s2s-samples",
+  bucket: "coval-benchmarks-s2s-samples",
+  prefix: "s2s-samples",
+  refetchMs: S2S_FETCH_PERIOD_MS,
+});
+
+// Drop recordings whose provider isn't visible on the page (disabled catalogue).
+export function visibleRecordings(
+  manifest: S2SSampleManifest,
+  visibleProviders: ReadonlySet<string>
+): S2SSampleRecording[] {
+  return manifest.recordings.filter((r) => visibleProviders.has(r.provider));
+}

--- a/web/lib/audioSamples/s2sFeed.ts
+++ b/web/lib/audioSamples/s2sFeed.ts
@@ -24,12 +24,57 @@ export interface S2SSampleManifest {
 // Mirror the runner's s2s_fetch_period_seconds (config.py, default 10_800 = 3h).
 const S2S_FETCH_PERIOD_MS = 10_800 * 1000;
 
-export const s2sSampleFeed = createSampleFeed<S2SSampleManifest>({
-  name: "s2s-samples",
-  bucket: "coval-benchmarks-s2s-samples",
-  prefix: "s2s-samples",
-  refetchMs: S2S_FETCH_PERIOD_MS,
-});
+function asString(v: unknown, field: string): string {
+  if (typeof v !== "string") throw new Error(`${field} must be a string`);
+  return v;
+}
+
+function asNullableString(v: unknown, field: string): string | null {
+  if (v === null) return null;
+  return asString(v, field);
+}
+
+// Validate the full manifest shape before the UI touches it — a shallow object
+// check would let `{}` through and crash visibleRecordings' .filter().
+export function parseS2SManifest(data: unknown): S2SSampleManifest {
+  if (typeof data !== "object" || data === null) {
+    throw new Error("manifest must be an object");
+  }
+  const m = data as Record<string, unknown>;
+  if (!Array.isArray(m.recordings)) {
+    throw new Error("recordings must be an array");
+  }
+  const recordings = m.recordings.map((r, i): S2SSampleRecording => {
+    if (typeof r !== "object" || r === null) {
+      throw new Error(`recordings[${i}] must be an object`);
+    }
+    const rec = r as Record<string, unknown>;
+    return {
+      provider: asString(rec.provider, `recordings[${i}].provider`),
+      model: asString(rec.model, `recordings[${i}].model`),
+      object: asString(rec.object, `recordings[${i}].object`),
+      coval_run_id: asString(rec.coval_run_id, `recordings[${i}].coval_run_id`),
+      sim_id: asString(rec.sim_id, `recordings[${i}].sim_id`),
+    };
+  });
+  return {
+    bucket_at: asString(m.bucket_at, "bucket_at"),
+    test_case_id: asString(m.test_case_id, "test_case_id"),
+    transcript: asNullableString(m.transcript, "transcript"),
+    input_audio_url: asNullableString(m.input_audio_url, "input_audio_url"),
+    recordings,
+  };
+}
+
+export const s2sSampleFeed = createSampleFeed<S2SSampleManifest>(
+  {
+    name: "s2s-samples",
+    bucket: "coval-benchmarks-s2s-samples",
+    prefix: "s2s-samples",
+    refetchMs: S2S_FETCH_PERIOD_MS,
+  },
+  parseS2SManifest
+);
 
 // Drop recordings whose provider isn't visible on the page (disabled catalogue).
 export function visibleRecordings(

--- a/web/lib/posthog/events.ts
+++ b/web/lib/posthog/events.ts
@@ -21,7 +21,7 @@ export const POSTHOG_EVENTS = {
   dashboardChartShared: "dashboard_chart_shared",
   dashboardWerDatasetChanged: "dashboard_wer_dataset_changed",
   dashboardWerBarViewChanged: "dashboard_wer_bar_view_changed",
-  s2sSamplePlayed: "s2s_sample_played"
+  s2sSamplePlayRequested: "s2s_sample_play_requested"
 } as const;
 
 export type PostHogSurface =

--- a/web/lib/posthog/events.ts
+++ b/web/lib/posthog/events.ts
@@ -20,7 +20,8 @@ export const POSTHOG_EVENTS = {
   dashboardTimeWindowChanged: "dashboard_time_window_changed",
   dashboardChartShared: "dashboard_chart_shared",
   dashboardWerDatasetChanged: "dashboard_wer_dataset_changed",
-  dashboardWerBarViewChanged: "dashboard_wer_bar_view_changed"
+  dashboardWerBarViewChanged: "dashboard_wer_bar_view_changed",
+  s2sSamplePlayed: "s2s_sample_played"
 } as const;
 
 export type PostHogSurface =


### PR DESCRIPTION
A conversation samples card on the S2S dashboard, beside the headline latency tile. It plays each provider's reconstructed recording for the newest daily tick — one shared utterance across providers — read straight from the public samples bucket the fetch job writes, with no API hop. Clicking a model row in the pinned timeline tooltip jumps the card to that bucket and plays that provider; providers hidden from the board (disabled catalogue) are filtered out client-side.

The playback engine (useSequencedPlayback) and bucket reader (lib/audioSamples) are modality-agnostic, so STT/TTS can drive them from their own timeline tooltips later without a card. Everything is gated behind NEXT_PUBLIC_S2S_ENABLED; STT, TTS, and overview are untouched.

Two follow-ups land as separate PRs: trimming the ~24s of trailing silence in each recording at the sampler, and a 7-day backfill to seed history.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds conversation-sample playback to the S2S dashboard. The main changes are:

- A samples card beside the headline latency metric.
- Public-bucket index and manifest loading with validation and error states.
- Sequenced prompt and provider-response playback.
- Timeline tooltip controls that select and play samples.
- Provider filtering and playback analytics.

<h3>Confidence Score: 5/5</h3>

No additional blocking issues were found in this review.

- The updated fetch path distinguishes unavailable manifests from missing samples.
- The playback changes coordinate the prompt and response audio players.
- No new distinct production failure met the follow-up review scope.

<sub>Reviews (3): Last reviewed commit: ["Surface S2S sample fetch failures and fi..."](https://github.com/coval-ai/benchmarks/commit/26ed289f98f0c22c741dda5251e1c1ff0e1db63e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45787766)</sub>

<!-- /greptile_comment -->