### PR TITLE
[BENCH-516] Show cymatics loading logo on Overview page when range selector is clicked

### DIFF
--- a/web/components/overview/OverviewLeaderboards.tsx
+++ b/web/components/overview/OverviewLeaderboards.tsx
@@ -15,6 +15,7 @@ import type { ModelStatEntry } from "@/lib/api/client";
 import { useTimeWindow } from "@/hooks/useTimeWindow";
 import { WINDOW_LABELS, type TimeWindow } from "@/lib/config/timeWindows";
 import TimeWindowToggle from "@/components/shared/TimeWindowToggle";
+import { CymaticLoader } from "@/components/shared/CymaticLoader";
 import LeaderboardCard, { type LeaderboardRow } from "./LeaderboardCard";
 
 const TOP_N = 5;
@@ -48,6 +49,7 @@ const OverviewLeaderboards: React.FC = () => {
   // entry with the dashboards whenever the selected windows coincide.
   const ttsQuery = useAggregatesQuery({ benchmark: "TTS", window: timeWindow });
   const sttQuery = useAggregatesQuery({ benchmark: "STT", window: timeWindow });
+  const windowDataStale = ttsQuery.isPlaceholderData || sttQuery.isPlaceholderData;
 
   const ttsRows = useMemo(
     () =>
@@ -75,8 +77,19 @@ const OverviewLeaderboards: React.FC = () => {
 
   return (
     <div>
-      <div className="mb-3 flex justify-end">
-        <TimeWindowToggle value={timeWindow} onChange={changeTimeWindow} />
+      <div className="mb-3 flex items-center justify-end gap-3">
+        <CymaticLoader
+          size={20}
+          animated={windowDataStale}
+          className={`text-text-primary transition-opacity duration-300 ${
+            windowDataStale ? "opacity-100" : "opacity-0"
+          }`}
+        />
+        <TimeWindowToggle
+          value={timeWindow}
+          onChange={changeTimeWindow}
+          loading={windowDataStale}
+        />
       </div>
       <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
         <LeaderboardCard

--- a/web/components/shared/CymaticLoader.tsx
+++ b/web/components/shared/CymaticLoader.tsx
@@ -154,6 +154,7 @@ export function CymaticLoader({
         <span
           // eslint-disable-next-line react/no-array-index-key -- fixed-size positional bead grid; index is the identity
           key={index}
+          suppressHydrationWarning
           className="absolute rounded-full bg-current will-change-[transform,opacity]"
           style={{
             left: "50%",


### PR DESCRIPTION
## Summary
<img width="222" height="71" alt="Screenshot 2026-07-20 at 4 17 50 PM" src="https://github.com/user-attachments/assets/53fef2a6-dd6c-43cc-b957-e348b9905f4e" />

- Show the cymatic loading logo to the left of the 1d/7d/30d selector on the Overview page while leaderboard data refetches after a range change
- Reuses `CymaticLoader` and the exact fade pattern FacetFilter uses on the dashboards (BENCH-514); driven by React Query's `isPlaceholderData` from both the TTS and STT queries, so the logo stays until the slower panel lands
- Passes `loading` to `TimeWindowToggle` so the radiogroup announces `aria-busy`
- Drive-by: `suppressHydrationWarning` on `CymaticLoader` bead spans — its sub-pixel inline styles trip a React hydration-mismatch dev error that pre-exists on /tts and /stt; the beads are `aria-hidden` decorative and restyle on the first animation tick

## Verification
- Verified in-browser with artificially delayed fetches: logo animates beside the selector while both cards dim, fades out when data lands; switching to an already-cached range is instant with no loader
- Checked at 320 / 375 / 768 / 1280 px: loader sits left of the toggle, vertically centered, no overflow or horizontal scroll; toggle keeps 44px touch height below `lg`
- Caught the mid-flight state where TTS had landed but STT was still fetching — loader correctly persists
- `tsc --noEmit` and `next lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds loading feedback to the Overview leaderboard range selector. The main changes are:

- Shows `CymaticLoader` while either leaderboard displays placeholder data.
- Marks the time-window toggle as busy during the range update.
- Suppresses hydration warnings on decorative loader beads.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<sub>Reviews (1): Last reviewed commit: ["\[BENCH-516\] Show cymatics loading logo o..."](https://github.com/coval-ai/benchmarks/commit/fc1372782b10efd44c9bf26df1404028421a5a85) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45789795)</sub>

<!-- /greptile_comment -->