### PR TITLE
Add backfill-s2s CLI to seed sample recordings

### DIFF
--- a/runner/src/coval_bench/__main__.py
+++ b/runner/src/coval_bench/__main__.py
@@ -20,6 +20,7 @@ import click
 from coval_bench import __version__
 from coval_bench.db.cli import db_check, db_migrate
 from coval_bench.migrations.import_legacy import import_legacy_cli
+from coval_bench.s2s.backfill import backfill_s2s
 from coval_bench.s2s.fetch_v2v import fetch_s2s
 
 # Backstop so a stalled connection can't hang a smoke probe forever. Loose enough
@@ -85,6 +86,8 @@ migrate.add_command(import_legacy_cli, name="import-legacy")
 
 # S2S is fetch-only, so a standalone command rather than a `run --kind` value.
 cli.add_command(fetch_s2s, name="fetch-s2s")
+# One-shot: seed sample recordings for recent buckets from already-ingested runs.
+cli.add_command(backfill_s2s, name="backfill-s2s")
 
 
 @cli.command(name="tts-smoke")

--- a/runner/src/coval_bench/s2s/backfill.py
+++ b/runner/src/coval_bench/s2s/backfill.py
@@ -1,0 +1,140 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""One-shot backfill of S2S sample recordings for recent buckets.
+
+The daily fetch tick only samples its newest bucket. This CLI walks the last N
+days of already-ingested runs, groups them by timeline bucket, and copies each
+bucket's shared-clip recordings into the samples bucket by reusing the live
+sampler's :func:`copy_tick_samples`. Idempotent: a bucket whose manifest already
+exists is skipped, so re-runs only fill gaps and never reshape a published tick.
+
+Run this AFTER the silence-trim sampler ships, so backfilled recordings come out
+trimmed too — a bucket already published fat is not reshaped by a later re-run.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import random
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING, Any, cast
+
+import click
+import psycopg
+import psycopg.rows
+import structlog
+from psycopg_pool import AsyncConnectionPool
+
+from coval_bench.config import Settings, get_settings
+from coval_bench.db.conn import lifespan_pool
+from coval_bench.s2s.fetch_v2v import _client
+from coval_bench.s2s.samples import SampleRun, copy_tick_samples
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Mapping
+
+logger = structlog.get_logger("coval_bench.s2s.backfill")
+
+# Newest ingested run per (provider, bucket) over the window. audio_filename is
+# "<coval_run_id>/<sim_id>", so its prefix is the Coval run id; scheduled_at is
+# the timeline bucket the sampler keys folders by. Failed runs never reached the
+# bucket, so only succeeded/partial rows are eligible.
+_RUNS_BY_BUCKET_SQL = """
+    SELECT DISTINCT ON (r.provider, rn.scheduled_at)
+        r.provider AS provider,
+        r.model AS model,
+        rn.scheduled_at AS scheduled_at,
+        split_part(r.audio_filename, '/', 1) AS coval_run_id
+    FROM benchmarks_v2.results r
+    JOIN benchmarks_v2.runs rn ON rn.id = r.run_id
+    WHERE r.benchmark = 'S2S'
+      AND rn.status IN ('succeeded', 'partial')
+      AND rn.scheduled_at >= %(since)s
+      AND r.audio_filename <> ''
+    ORDER BY r.provider, rn.scheduled_at, rn.id DESC
+"""
+
+
+def _group_rows(rows: Iterable[Mapping[str, Any]]) -> dict[datetime, list[SampleRun]]:
+    """Group query rows into one SampleRun list per bucket timestamp."""
+    buckets: dict[datetime, list[SampleRun]] = {}
+    for row in rows:
+        coval_run_id = cast("str", row["coval_run_id"])
+        if not coval_run_id:
+            continue
+        bucket_at = cast("datetime", row["scheduled_at"])
+        buckets.setdefault(bucket_at, []).append(
+            SampleRun(
+                provider=cast("str", row["provider"]),
+                model=cast("str", row["model"]),
+                coval_run_id=coval_run_id,
+                bucket_at=bucket_at,
+            )
+        )
+    return buckets
+
+
+async def _runs_by_bucket(
+    pool: AsyncConnectionPool[psycopg.AsyncConnection[psycopg.rows.DictRow]],
+    since: datetime,
+) -> dict[datetime, list[SampleRun]]:
+    async with pool.connection() as conn:
+        async with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+            await cur.execute(_RUNS_BY_BUCKET_SQL, {"since": since})
+            rows = await cur.fetchall()
+        await conn.commit()
+    return _group_rows(rows)
+
+
+async def backfill_v2v_samples(settings: Settings, *, days: int) -> dict[str, int]:
+    """Copy sample recordings for every eligible bucket in the last *days*."""
+    if not settings.s2s_samples_bucket:
+        raise RuntimeError("s2s_samples_bucket is not set")
+    since = datetime.now(tz=UTC) - timedelta(days=days)
+    stored = 0
+    async with _client(settings) as client, lifespan_pool(settings) as pool:
+        buckets = await _runs_by_bucket(pool, since)
+        # Oldest first so each prepend leaves index.json newest-first.
+        for bucket_at in sorted(buckets):
+            runs = buckets[bucket_at]
+            recordings = await copy_tick_samples(
+                client,
+                bucket_name=settings.s2s_samples_bucket,
+                runs=runs,
+                rng=random.Random(),  # noqa: S311 -- sample pick, not security
+            )
+            if recordings > 0:
+                stored += 1
+            logger.info(
+                "backfill_bucket",
+                bucket_at=bucket_at.isoformat(),
+                providers=len(runs),
+                recordings=recordings,
+            )
+    result = {"buckets": len(buckets), "stored": stored, "skipped": len(buckets) - stored}
+    logger.info("backfill_done", days=days, **result)
+    return result
+
+
+@click.command(name="backfill-s2s")
+@click.option(
+    "--days",
+    default=7,
+    show_default=True,
+    type=click.IntRange(min=1),
+    help="How many days back to backfill sample recordings.",
+)
+def backfill_s2s(days: int) -> None:
+    """One-shot: seed sample recordings for the last N days of ingested runs."""
+    from coval_bench.logging import configure_logging
+
+    settings = get_settings()
+    configure_logging(level=settings.log_level)
+    result = asyncio.run(backfill_v2v_samples(settings, days=days))
+    click.echo(json.dumps({"event": "backfill_s2s", **result}))
+
+
+if __name__ == "__main__":
+    backfill_s2s()

--- a/runner/src/coval_bench/s2s/backfill.py
+++ b/runner/src/coval_bench/s2s/backfill.py
@@ -11,6 +11,10 @@ exists is skipped, so re-runs only fill gaps and never reshape a published tick.
 
 Run this AFTER the silence-trim sampler ships, so backfilled recordings come out
 trimmed too — a bucket already published fat is not reshaped by a later re-run.
+
+Buckets are processed sequentially, so this never races itself. It does share
+index.json's read-modify-write with the daily fetch tick, though, so run it when
+that job is idle (outside the ~23:00 UTC window) to avoid a lost index update.
 """
 
 from __future__ import annotations

--- a/runner/src/coval_bench/s2s/samples.py
+++ b/runner/src/coval_bench/s2s/samples.py
@@ -24,7 +24,7 @@ from typing import TYPE_CHECKING, Any, cast
 
 import httpx
 import structlog
-from google.api_core.exceptions import NotFound
+from google.api_core.exceptions import NotFound, PreconditionFailed
 
 from coval_bench.runner.retry import with_retry
 
@@ -38,6 +38,7 @@ logger = structlog.get_logger("coval_bench.s2s.samples")
 PREFIX = "s2s-samples"
 INDEX_KEY = f"{PREFIX}/index.json"
 _INDEX_MAX_ENTRIES = 60
+_INDEX_WRITE_ATTEMPTS = 5
 _PUBLIC_DATASET_BASE = "https://storage.googleapis.com/coval-benchmarks-datasets/s2s-v1"
 _DOWNLOAD_TIMEOUT = 120.0
 
@@ -137,26 +138,44 @@ def _upload(bucket: storage.Bucket, key: str, data: bytes, content_type: str) ->
 
 
 def _update_index(bucket: storage.Bucket, tick_key: str) -> None:
-    """Prepend the tick to index.json (single daily writer — no race to guard).
+    """Prepend the tick to index.json under compare-and-swap.
 
-    Only a confirmed missing object starts an empty index; any other read
-    failure leaves the existing index untouched so a transient error can't
-    erase the history.
+    The daily fetch tick and the one-shot backfill can both write this object,
+    each as a read-modify-write, so the write is guarded with if_generation_match
+    (0 means require-absent): it only lands if index.json hasn't changed since it
+    was read. A lost race raises PreconditionFailed and re-runs the cycle on the
+    winner's version instead of clobbering their tick. Only a confirmed missing
+    object starts an empty index; any other read failure leaves the existing
+    index untouched so a transient error can't erase the history.
     """
     blob = bucket.blob(INDEX_KEY)
-    ticks: list[str]
-    try:
-        decoded = json.loads(blob.download_as_bytes())
-        if not isinstance(decoded, list) or not all(isinstance(t, str) for t in decoded):
-            raise ValueError("index.json must be a list of tick strings")
-        ticks = decoded
-    except NotFound:
-        ticks = []
-    except Exception:
-        logger.error("samples_index_read_failed", tick=tick_key, exc_info=True)
+    for _ in range(_INDEX_WRITE_ATTEMPTS):
+        ticks: list[str]
+        try:
+            data = blob.download_as_bytes()
+            generation = blob.generation
+            decoded = json.loads(data)
+            if not isinstance(decoded, list) or not all(isinstance(t, str) for t in decoded):
+                raise ValueError("index.json must be a list of tick strings")
+            ticks = decoded
+        except NotFound:
+            ticks = []
+            generation = 0
+        except Exception:
+            logger.error("samples_index_read_failed", tick=tick_key, exc_info=True)
+            return
+        ticks = [tick_key, *(t for t in ticks if t != tick_key)][:_INDEX_MAX_ENTRIES]
+        try:
+            blob.upload_from_string(
+                json.dumps(ticks).encode(),
+                content_type="application/json",
+                if_generation_match=generation,
+            )
+        except PreconditionFailed:
+            logger.info("samples_index_contended", tick=tick_key)
+            continue
         return
-    ticks = [tick_key, *(t for t in ticks if t != tick_key)][:_INDEX_MAX_ENTRIES]
-    _upload(bucket, INDEX_KEY, json.dumps(ticks).encode(), "application/json")
+    logger.error("samples_index_write_contended", tick=tick_key)
 
 
 async def copy_tick_samples(

--- a/runner/tests/unit/test_s2s_backfill.py
+++ b/runner/tests/unit/test_s2s_backfill.py
@@ -1,0 +1,100 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the S2S sample backfill."""
+
+from __future__ import annotations
+
+import contextlib
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from coval_bench.s2s import backfill
+from coval_bench.s2s.samples import SampleRun
+
+B1 = datetime(2026, 7, 18, tzinfo=UTC)
+B2 = datetime(2026, 7, 19, tzinfo=UTC)
+
+
+def _row(provider: str, model: str, bucket: datetime, coval_run_id: str) -> dict[str, Any]:
+    return {
+        "provider": provider,
+        "model": model,
+        "scheduled_at": bucket,
+        "coval_run_id": coval_run_id,
+    }
+
+
+def test_group_rows_buckets_by_scheduled_at_and_skips_empty() -> None:
+    rows = [
+        _row("openai", "gpt-realtime", B1, "R1"),
+        _row("google", "gemini-live", B1, "R2"),
+        _row("xai", "grok-realtime", B1, ""),  # no coval_run_id -> dropped
+        _row("openai", "gpt-realtime", B2, "R3"),
+    ]
+
+    grouped = backfill._group_rows(rows)
+
+    assert set(grouped) == {B1, B2}
+    assert {r.provider for r in grouped[B1]} == {"openai", "google"}
+    assert grouped[B1][0].bucket_at == B1
+    assert [r.coval_run_id for r in grouped[B2]] == ["R3"]
+
+
+@contextlib.asynccontextmanager
+async def _noop_cm(*_args: Any, **_kwargs: Any) -> AsyncIterator[MagicMock]:
+    yield MagicMock()
+
+
+@pytest.mark.asyncio
+async def test_backfill_copies_each_bucket_oldest_first(monkeypatch: pytest.MonkeyPatch) -> None:
+    runs = {
+        B2: [SampleRun(provider="openai", model="m", coval_run_id="R2", bucket_at=B2)],
+        B1: [SampleRun(provider="openai", model="m", coval_run_id="R1", bucket_at=B1)],
+    }
+    monkeypatch.setattr(backfill, "_runs_by_bucket", AsyncMock(return_value=runs))
+    monkeypatch.setattr(backfill, "_client", lambda _s: _noop_cm())
+    monkeypatch.setattr(backfill, "lifespan_pool", lambda _s: _noop_cm())
+
+    order: list[datetime] = []
+
+    async def fake_copy(_client: Any, *, bucket_name: str, runs: list[SampleRun], rng: Any) -> int:
+        order.append(runs[0].bucket_at)
+        return 3
+
+    monkeypatch.setattr(backfill, "copy_tick_samples", fake_copy)
+
+    settings = MagicMock()
+    settings.s2s_samples_bucket = "bkt"
+    result = await backfill.backfill_v2v_samples(settings, days=7)
+
+    assert order == [B1, B2]  # oldest first, so the index ends up newest-first
+    assert result == {"buckets": 2, "stored": 2, "skipped": 0}
+
+
+@pytest.mark.asyncio
+async def test_backfill_counts_skipped_buckets(monkeypatch: pytest.MonkeyPatch) -> None:
+    runs = {B1: [SampleRun(provider="openai", model="m", coval_run_id="R1", bucket_at=B1)]}
+    monkeypatch.setattr(backfill, "_runs_by_bucket", AsyncMock(return_value=runs))
+    monkeypatch.setattr(backfill, "_client", lambda _s: _noop_cm())
+    monkeypatch.setattr(backfill, "lifespan_pool", lambda _s: _noop_cm())
+    # 0 recordings => the bucket already existed or had no shared clip.
+    monkeypatch.setattr(backfill, "copy_tick_samples", AsyncMock(return_value=0))
+
+    settings = MagicMock()
+    settings.s2s_samples_bucket = "bkt"
+    result = await backfill.backfill_v2v_samples(settings, days=7)
+
+    assert result == {"buckets": 1, "stored": 0, "skipped": 1}
+
+
+@pytest.mark.asyncio
+async def test_backfill_requires_bucket() -> None:
+    settings = MagicMock()
+    settings.s2s_samples_bucket = ""
+    with pytest.raises(RuntimeError, match="s2s_samples_bucket"):
+        await backfill.backfill_v2v_samples(settings, days=7)

--- a/runner/tests/unit/test_s2s_samples.py
+++ b/runner/tests/unit/test_s2s_samples.py
@@ -13,7 +13,7 @@ from unittest.mock import MagicMock
 
 import httpx
 import pytest
-from google.api_core.exceptions import NotFound
+from google.api_core.exceptions import NotFound, PreconditionFailed
 
 from coval_bench.s2s import samples
 from coval_bench.s2s.samples import PREFIX, SampleRun, copy_tick_samples
@@ -64,19 +64,44 @@ def _fake_client(
 class _FakeBucket:
     def __init__(self) -> None:
         self.objects: dict[str, bytes] = {}
+        self.generations: dict[str, int] = {}
         self.fail_reads: set[str] = set()
+        # One-shot competing index write injected just before our next upload,
+        # to exercise the compare-and-swap retry in _update_index.
+        self.race_winner: str | None = None
+
+    def _current_gen(self, key: str) -> int:
+        if key in self.objects and key not in self.generations:
+            self.generations[key] = 1
+        return self.generations.get(key, 0)
+
+    def _store(self, key: str, data: bytes | str) -> None:
+        gen = self._current_gen(key)
+        self.objects[key] = data if isinstance(data, bytes) else data.encode()
+        self.generations[key] = gen + 1
 
     def blob(self, key: str) -> MagicMock:
         blob = MagicMock()
-        blob.upload_from_string = lambda data, content_type: self.objects.__setitem__(
-            key, data if isinstance(data, bytes) else data.encode()
-        )
+
+        def _upload(
+            data: bytes | str, content_type: str, if_generation_match: int | None = None
+        ) -> None:
+            if key == samples.INDEX_KEY and self.race_winner is not None:
+                winner, self.race_winner = self.race_winner, None
+                existing = json.loads(self.objects[key]) if key in self.objects else []
+                self._store(key, json.dumps([winner, *existing]))
+            if if_generation_match is not None and if_generation_match != self._current_gen(key):
+                raise PreconditionFailed("generation mismatch")  # type: ignore[no-untyped-call]
+            self._store(key, data)
+
+        blob.upload_from_string = _upload
 
         def _download() -> bytes:
             if key in self.fail_reads:
                 raise RuntimeError("transient read failure")
             if key not in self.objects:
                 raise NotFound(key)  # type: ignore[no-untyped-call]
+            blob.generation = self._current_gen(key)
             return self.objects[key]
 
         blob.download_as_bytes = _download
@@ -212,6 +237,24 @@ async def test_index_prepends_and_dedupes() -> None:
         )
     index = json.loads(bucket.objects[samples.INDEX_KEY])
     assert index == ["2026-07-17T00:00:00Z", "2026-07-16T00:00:00Z"]
+
+
+def test_index_write_retries_and_preserves_concurrent_tick() -> None:
+    _, bucket = _fake_storage()
+    bucket.objects[samples.INDEX_KEY] = json.dumps(["2026-07-15T00:00:00Z"]).encode()
+    # A competing writer lands its tick between our read and our write, so the
+    # first upload loses the compare-and-swap and we retry on its version.
+    bucket.race_winner = "2026-07-16T00:00:00Z"
+
+    samples._update_index(bucket, "2026-07-17T00:00:00Z")
+
+    assert bucket.race_winner is None
+    index = json.loads(bucket.objects[samples.INDEX_KEY])
+    assert index == [
+        "2026-07-17T00:00:00Z",
+        "2026-07-16T00:00:00Z",
+        "2026-07-15T00:00:00Z",
+    ]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
A one-shot `coval-bench backfill-s2s --days N` command that seeds sample recordings for recent buckets. It walks the last N days of already-ingested S2S runs, groups them by timeline bucket (the newest run per provider per bucket), and copies each bucket's shared-clip recordings by reusing the live sampler's copy_tick_samples. Idempotent: a bucket whose manifest already exists is skipped, so re-runs only fill gaps and never reshape a published tick.

The daily fetch tick only samples its own newest bucket; this fills history that predates the sampler or that a failed tick missed, bounded by however far back Coval still retains recordings. Run it after the silence-trim sampler ships so seeded recordings come out trimmed too.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a CLI command for seeding historical S2S sample recordings. The main changes are:

- Adds `backfill-s2s --days N` and registers it with the CLI.
- Groups recent ingested runs by timeline bucket and backfills them oldest first.
- Uses generation-based writes to preserve concurrent `index.json` updates.
- Adds unit tests for grouping, ordering, skip counts, and concurrent writes.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- The updated index write retries generation conflicts and preserves concurrent entries.
- No blocking issues remain in the latest changes.

<sub>Reviews (3): Last reviewed commit: ["Guard S2S sample index writes against lo..."](https://github.com/coval-ai/benchmarks/commit/bb87ae20c13788bd414cacdfc416ee382a7b4b31) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45796841)</sub>

<!-- /greptile_comment -->