### PR TITLE
ci: adopt switchboard-plan resolve mode

### DIFF
--- a/.github/workflows/switchboard.yml
+++ b/.github/workflows/switchboard.yml
@@ -80,7 +80,9 @@ jobs:
         uses: actions/checkout@v7
         with:
           repository: coval-ai/ci-cd-switchboard
-          ref: main
+          # VALIDATION: pinned to the #262 branch to exercise resolve mode with
+          # the now-present token. Flip back to `main` after (green-pending-#262).
+          ref: dana/plan-resolve-event
           token: ${{ steps.app_token.outputs.token }}
           path: switchboard-src
           persist-credentials: false

--- a/.github/workflows/switchboard.yml
+++ b/.github/workflows/switchboard.yml
@@ -80,7 +80,9 @@ jobs:
         uses: actions/checkout@v7
         with:
           repository: coval-ai/ci-cd-switchboard
-          ref: main
+          # DRY-RUN: pinned to #262 branch so `resolve` mode is available.
+          # Flip back to `main` before hand-back (green-pending-#262-merge).
+          ref: dana/plan-resolve-event
           token: ${{ steps.app_token.outputs.token }}
           path: switchboard-src
           persist-credentials: false
@@ -90,82 +92,15 @@ jobs:
         with:
           node-version: "22"
 
-      - name: Resolve changed files
-        id: changed_files
-        if: steps.app_token.outputs.token != ''
-        uses: ./switchboard-src/.github/actions/resolve-changed-files
-        with:
-          manual-changed-files-json: ${{ github.event.inputs.changed_files_json }}
-          default-changed-files-json: '["runner/pyproject.toml","web/package.json"]'
-          pull-request-fallback-json: '["runner/pyproject.toml","web/package.json"]'
-          merge-group-fallback-json: '["runner/pyproject.toml","web/package.json",".github/workflows/ci.yml",".github/workflows/web-ci.yml"]'
-
-      - name: Resolve changed files without Switchboard token
-        id: changed_files_fallback
-        if: steps.app_token.outputs.token == ''
-        run: |
-          set -euo pipefail
-          mkdir -p switchboard
-          node <<'NODE'
-          const fs = require("node:fs")
-          const fallbackReason = "Switchboard app token unavailable; running conservative fallback adapters"
-          const changedFiles = [
-            "runner/pyproject.toml",
-            "web/package.json",
-            ".github/workflows/ci.yml",
-            ".github/workflows/web-ci.yml",
-          ]
-          fs.writeFileSync(
-            "switchboard/changed-files.json",
-            `${JSON.stringify({ changedFiles, fallbackReason, selectorMode: "token-unavailable-fallback" }, null, 2)}\n`,
-          )
-          NODE
-          echo "selector_failed=true" >> "$GITHUB_OUTPUT"
-          echo "fallback_reason=Switchboard app token unavailable; running conservative fallback adapters" >> "$GITHUB_OUTPUT"
-
-      - name: Build Switchboard event
-        env:
-          SELECTOR_FAILED: ${{ steps.changed_files.outputs.selector_failed || steps.changed_files_fallback.outputs.selector_failed || 'false' }}
-        run: |
-          set -euo pipefail
-          node <<'NODE'
-          const fs = require("node:fs")
-
-          const payload = JSON.parse(fs.readFileSync(process.env.GITHUB_EVENT_PATH, "utf8"))
-          const changedFilesPayload = JSON.parse(fs.readFileSync("switchboard/changed-files.json", "utf8"))
-          const eventName = process.env.GITHUB_EVENT_NAME
-          const pullRequest = payload.pull_request
-          const mergeGroup = payload.merge_group
-
-          const event = {
-            eventName,
-            phase: eventName === "merge_group" ? "merge_group" : "pull_request",
-            repo: "benchmarks",
-            ref: process.env.GITHUB_REF,
-            sha: process.env.GITHUB_SHA,
-            actor: process.env.GITHUB_ACTOR,
-            selectorFailed: process.env.SELECTOR_FAILED === "true",
-          }
-
-          if (pullRequest) {
-            event.pullRequestNumber = pullRequest.number
-            event.pullRequestTitle = pullRequest.title
-          } else if (typeof changedFilesPayload.pullRequestNumber === "number") {
-            event.pullRequestNumber = changedFilesPayload.pullRequestNumber
-          }
-
-          if (!event.pullRequestTitle && mergeGroup?.head_commit?.message) {
-            event.pullRequestTitle = mergeGroup.head_commit.message
-          }
-
-          fs.writeFileSync("switchboard/event.json", `${JSON.stringify(event, null, 2)}\n`)
-          NODE
-
       - name: Plan Switchboard checks
         id: switchboard
         if: steps.app_token.outputs.token != ''
         uses: ./switchboard-src/.github/actions/switchboard-plan
         with:
+          resolve: "true"
+          switchboard-repo: benchmarks
+          dispatch-default: runner/pyproject.toml,web/package.json
+          manual-json: ${{ github.event.inputs.changed_files_json }}
           event: ${{ github.workspace }}/switchboard/event.json
           changed-files: ${{ github.workspace }}/switchboard/changed-files.json
           config: ${{ github.workspace }}/switchboard-src/config/switchboard
@@ -200,8 +135,7 @@ jobs:
             echo "- Selected check ids: ${{ steps.switchboard.outputs.selected_check_ids || '[]' }}"
             echo "- Required gates: ${{ steps.switchboard.outputs.required_gates || '[]' }}"
             echo "- Workflow ownership: ${{ steps.switchboard.outputs.workflow_ownership || '{}' }}"
-            echo "- Selector failed: ${{ steps.changed_files.outputs.selector_failed || steps.changed_files_fallback.outputs.selector_failed || 'false' }}"
-            echo "- Fallback reason: ${{ steps.changed_files.outputs.fallback_reason || steps.changed_files_fallback.outputs.fallback_reason || 'none' }}"
+            echo "- Fallback reason: ${{ steps.switchboard.outputs.fallback_reason || 'none' }}"
             echo "- Planner outcome: ${{ steps.switchboard.outcome }}"
           } >> "$GITHUB_STEP_SUMMARY"
 

--- a/.github/workflows/switchboard.yml
+++ b/.github/workflows/switchboard.yml
@@ -80,9 +80,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           repository: coval-ai/ci-cd-switchboard
-          # DRY-RUN: pinned to #262 branch so `resolve` mode is available.
-          # Flip back to `main` before hand-back (green-pending-#262-merge).
-          ref: dana/plan-resolve-event
+          ref: main
           token: ${{ steps.app_token.outputs.token }}
           path: switchboard-src
           persist-credentials: false

--- a/.github/workflows/switchboard.yml
+++ b/.github/workflows/switchboard.yml
@@ -80,9 +80,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           repository: coval-ai/ci-cd-switchboard
-          # VALIDATION: pinned to the #262 branch to exercise resolve mode with
-          # the now-present token. Flip back to `main` after (green-pending-#262).
-          ref: dana/plan-resolve-event
+          ref: main
           token: ${{ steps.app_token.outputs.token }}
           path: switchboard-src
           persist-credentials: false


### PR DESCRIPTION
## What

Adopts ci-cd-switchboard #262's canonical resolver: replaces the `resolve-changed-files` composite action **and** the inline "Build Switchboard event" heredoc with the `switchboard-plan` action's `resolve` mode (`switchboard-repo: benchmarks`, `dispatch-default` = the repo's default files, `manual-json` from the `changed_files_json` dispatch input).

Per the consolidation onto one resolver (Dana's call), the bespoke per-event fallback lists and the `selectorFailed` flag are **dropped** — git-diff over the full `fetch-depth: 0` checkout is the standard resolution. The token-conditional structure (fork-PR "run everything" fallback) is preserved untouched.

## Follow-up

The `resolve-changed-files` action itself is retired in a **separate switchboard PR** that merges after this + the benchmarks sibling (so main never has a dangling action reference).

## Dry-run / merge-order

Switchboard checkout pinned to `dana/plan-resolve-event` (#262) for the dry-run, then flips to `ref: main` — a **green-pending-#262-merge** draft. **Depends on #262.**

---
🤖 Draft — CI/CD consolidation sweep. Do not merge before #262.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR moves changed-file and event resolution into the canonical Switchboard planner. The main changes are:

- Enables `switchboard-plan` resolve mode.
- Passes repository defaults and manual dispatch input to the planner.
- Removes the separate resolver and inline event builder.
- Preserves the run-all fallback when the app token is unavailable.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- The Switchboard checkout now uses `main`, removing the temporary branch dependency.
- No new blocking issue was found in the latest changes.

<sub>Reviews (4): Last reviewed commit: ["chore: point switchboard checkout back t..."](https://github.com/coval-ai/benchmarks/commit/779462520203f687ce265f195c2515aa9cb4828f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45869041)</sub>

<!-- /greptile_comment -->