### PR TITLE
[BENCH-520] Keep radar chart visible while a window switch reloads

### DIFF
--- a/web/components/dashboard/WerRadarSection.tsx
+++ b/web/components/dashboard/WerRadarSection.tsx
@@ -14,13 +14,14 @@ import {
   Tooltip,
 } from "recharts";
 import Card from "@/components/shared/Card";
+import { CymaticLoader } from "@/components/shared/CymaticLoader";
 import SectionHeader from "@/components/shared/SectionHeader";
 import CustomTimelineTooltip from "@/components/charts/tooltips/TimelineTooltip";
 import { TimelineLegend } from "@/components/visualizations/TimelineChart";
 import { useDashboard } from "@/contexts/DashboardContext";
 import { useThemeColors, type ThemeColors } from "@/hooks/useThemeColors";
 import { useChartHoverTracking } from "@/hooks/useChartHoverTracking";
-import { useWerDatasetMatrix } from "@/hooks/useWerDatasetMatrix";
+import { MIN_RADAR_AXES, useWerDatasetMatrix } from "@/hooks/useWerDatasetMatrix";
 import { datasetLabel, isPerturbationDataset } from "@/lib/config/datasets";
 import { getModelColor } from "@/lib/utils/colors";
 import { normalizeModelName } from "@/lib/utils/formatters";
@@ -254,7 +255,7 @@ const WerRadarSection: React.FC = () => {
     };
   };
 
-  const ready = effectiveAxes.length >= 3 && plotted.length > 0;
+  const ready = effectiveAxes.length >= MIN_RADAR_AXES && plotted.length > 0;
   const best = ranked[0];
   const activeAxisLabel = scrub?.label ?? pinned?.label;
   const legendPayload = coveredModels.map((model) => ({
@@ -476,7 +477,10 @@ const WerRadarSection: React.FC = () => {
               </RadarChart>
             </ResponsiveContainer>
           ) : loading ? (
-            <span className="block h-full w-full animate-pulse rounded bg-surface-secondary" />
+            <div role="status" className="flex h-full items-center justify-center">
+              <CymaticLoader size={40} animated className="text-text-primary" />
+              <span className="sr-only">Loading benchmark data</span>
+            </div>
           ) : (
             <div className="flex h-full items-center justify-center text-sm text-text-tertiary">
               No dataset-scoped WER data in this window.
@@ -535,7 +539,7 @@ const WerRadarSection: React.FC = () => {
             </div>
           )}
         </div>
-        {effectiveAxes.length >= 3 && (
+        {effectiveAxes.length >= MIN_RADAR_AXES && (
           <p className="mt-2 text-sm text-text-secondary">
             {best ? (
               <>

--- a/web/hooks/useWerDatasetMatrix.ts
+++ b/web/hooks/useWerDatasetMatrix.ts
@@ -3,11 +3,14 @@
 
 "use client";
 
-import { useMemo } from "react";
+import { useMemo, useRef } from "react";
 import { useQueries } from "@tanstack/react-query";
 import { aggregatesQueryOptions } from "@/lib/api/queries";
 import { toModelKey } from "@/lib/utils/formatters";
 import type { AggregatesQueryParams } from "@/lib/api/client";
+
+// A radar polygon needs at least three axes; below this the chart can't draw.
+export const MIN_RADAR_AXES = 3;
 
 export function useWerDatasetMatrix(
   base: Pick<AggregatesQueryParams, "benchmark" | "window">,
@@ -26,7 +29,7 @@ export function useWerDatasetMatrix(
   // Each axis renders as soon as its own query lands — no waiting on the
   // slowest dataset. Placeholder (previous-window) rows are excluded so a
   // window switch can never mix old and new values across axes.
-  const werByDataset = useMemo(() => {
+  const fresh = useMemo(() => {
     const matrix = new Map<string, Map<string, number>>();
     results.forEach((r, i) => {
       if (!r.data || r.isPlaceholderData) return;
@@ -43,5 +46,13 @@ export function useWerDatasetMatrix(
 
   const loading = results.some((r) => r.isPending || r.isPlaceholderData);
 
-  return { werByDataset, loading };
+  // While a refetch is in flight, keep showing the previous window's matrix
+  // (dimmed by the caller) until the fresh one has enough axes to draw a
+  // radar — the chart never blanks, and no render ever mixes windows.
+  // Render-phase ref write is idempotent by construction: it only ever
+  // stores the current render's own derived value.
+  const last = useRef(fresh);
+  if ((fresh?.size ?? 0) >= MIN_RADAR_AXES || !loading) last.current = fresh;
+
+  return { werByDataset: last.current, loading };
 }


### PR DESCRIPTION
## Problem
<img width="2000" height="875" alt="image" src="https://github.com/user-attachments/assets/a1920ae2-8a11-4c5a-b872-facd829b9827" />

On the STT dashboard's "Accuracy Across Datasets" radar, switching the 1d/7d/30d time range blanked the whole chart for as long as the slowest dataset query took (up to a minute). The data hook deliberately drops `keepPreviousData` placeholder rows so a single render can never mix old- and new-window values across axes — but on a window switch that nulls the entire matrix until 3+ fresh datasets land, unmounting the chart into a blank pulse block.

## Fix

- `useWerDatasetMatrix` now holds the last renderable matrix in a ref and keeps returning it while a refetch is in flight, swapping to fresh data once it has enough axes to draw. Every returned matrix is still built entirely from a single window, so the no-mixing invariant is preserved; the existing `opacity-40` dim signals the reload, matching the bar chart and comparison table.
- The first-load blank pulse is replaced with the existing `CymaticLoader` (BENCH-516 brand loader), with a `role="status"` sr-only label.
- The radar's minimum-axes threshold is now a named export (`MIN_RADAR_AXES`) used by both the hook and the component's two existing `>= 3` checks, so the invariant has one home.

## Acceptance criteria

- Changing the time range never leaves the chart fully blank — the previous window's chart stays up, dimmed, until the new window is drawable, then axes grow in as remaining queries land.
- First load shows the brand loader instead of an empty pulse rectangle.

## Verification

- Live on localhost:3000: switched 7d → 30d → 1d (uncached) while sampling the DOM every 200ms for 8s — the radar SVG stayed mounted the entire time and settled on correct 1d data.
- Typecheck, ESLint (`--max-warnings 0`), and all 78 vitest tests pass; no console errors. Mobile scrub/pin interactions untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR keeps the WER radar visible while a new time window loads. The main changes are:

- Retains the last drawable single-window matrix during refetching.
- Replaces retained data as fresh dataset axes arrive.
- Shares a named minimum-axis threshold between the hook and chart.
- Shows the accessible Cymatic loader during the initial load.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.
- Placeholder rows remain excluded, so one matrix cannot mix time windows.
- Terminal empty and error states replace the retained matrix once loading ends.

<sub>Reviews (1): Last reviewed commit: ["\[BENCH-520\] Keep radar chart visible whi..."](https://github.com/coval-ai/benchmarks/commit/40f61c8723a1ff1b65e2c2dbe18a8e51c0848a33) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46012273)</sub>

<!-- /greptile_comment -->