### PR TITLE
[BENCH-518] Make performance consistency bubbles match accuracy across datasets

### DIFF
--- a/web/components/dashboard/WerRadarSection.tsx
+++ b/web/components/dashboard/WerRadarSection.tsx
@@ -488,6 +488,7 @@ const WerRadarSection: React.FC = () => {
                       model === best?.model || plotted.length <= 2 ? 0.12 : 0
                     }
                     dot={false}
+                    activeDot={{ stroke: "none" }}
                     isAnimationActive={false}
                   />
                 ))}


### PR DESCRIPTION
## Summary
<img width="128" height="284" alt="image" src="https://github.com/user-attachments/assets/5c75e000-c08d-45fb-b29e-6dbc6350ea0a" />

<img width="200" height="76" alt="image" src="https://github.com/user-attachments/assets/434ab082-a27a-4a0c-b067-53ad262d3de3" />

- remove the default white outline from radar active data-point bubbles
- preserve each bubble's existing fill color and radius
- align the active bubble treatment with the filled style used elsewhere

## Root cause

Recharts applies a white `2px` stroke to radar active dots by default when no active-dot stroke is specified.

## Impact

Radar data points now render as solid filled bubbles with no white ring. This is a frontend-only visual change; backend, API, auth, and configuration are unchanged.

## Validation

- `pnpm exec eslint components/dashboard/WerRadarSection.tsx`
- `pnpm typecheck`
- verified all 27 desktop hover bubbles render with `stroke="none"` on `localhost:3000/stt`
- verified the mobile tap-to-pin interaction at 390×844
- verified a clean browser console

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the active bubbles in the performance consistency radar chart.

- Removes the default white outline from active data points.
- Preserves the existing bubble fill color and radius.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.
- The new prop only overrides the active dot stroke.

<sub>Reviews (1): Last reviewed commit: ["Remove radar bubble outlines"](https://github.com/coval-ai/benchmarks/commit/fa3d41fdecd72097f5f007abba1d2e38b60002a9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46133091)</sub>

<!-- /greptile_comment -->