### PR TITLE
ci(web): fail CI when committed API types drift from codegen

### DIFF
--- a/.github/workflows/web-ci.yml
+++ b/.github/workflows/web-ci.yml
@@ -91,6 +91,14 @@ jobs:
           NEXT_PUBLIC_API_URL: http://localhost:8000
         run: pnpm codegen
 
+      - name: Check generated API types are up to date
+        run: |
+          set -euo pipefail
+          if ! git diff --exit-code -- lib/api/generated; then
+            echo "::error::Generated API types under web/lib/api/generated are stale — regenerate with \`pnpm codegen\` in web/ and commit the result."
+            exit 1
+          fi
+
       - name: Lint
         run: pnpm lint
 


### PR DESCRIPTION
## What

Adds a drift guard to `web-ci.yml`: right after `pnpm codegen`, fail if the committed generated API types (`web/lib/api/generated/`) differ from what codegen just produced.

## Why

`web-ci.yml` regenerates the API types from the served runner OpenAPI schema, but never compares the result against the committed output. A change to the runner API that isn't followed by a re-run + commit of `pnpm codegen` silently ships **stale** generated types — the generated file is committed (`web/lib/api/generated/schema.ts`), so this is a real, currently-unguarded drift. This is the missing "freshness" check for that vendored/generated artifact.

## Verification

`web-ci.yml` is a Switchboard adapter (`workflow_call`), and this PR changes it, so the benchmarks Switchboard run will select + run `web_ci` and exercise the new step. Expected: green on this PR (committed types are current); the step fails (with an actionable message) only when codegen output drifts from what's committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a freshness check for generated web API types. The main changes are:

- Runs the check immediately after `pnpm codegen`.
- Fails CI when the tracked generated schema differs.
- Prints instructions for regenerating and committing stale types.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- The path is correct for the workflow's `web` working directory.
- The check detects changes or deletion of the tracked generated schema.
- No blocking issues found in the changed code.

<sub>Reviews (1): Last reviewed commit: ["ci(web): fail CI when committed API type..."](https://github.com/coval-ai/benchmarks/commit/88dd2f4ad941921a9b12afae0f91bc5906db6cb4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46155406)</sub>

<!-- /greptile_comment -->