### PR TITLE
chore: add CODEOWNERS for the benchmarking team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Everyone on the benchmarking team owns everything in this repo.
+* @seribaymadina @coval-cale

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Everyone on the benchmarking team owns everything in this repo.
-* @seribaymadina @coval-cale
+* @coval-ai/coval-benchmarking


### PR DESCRIPTION
## Summary
Adds a CODEOWNERS assigning the whole repo to the benchmarking team.

## Changes
- `.github/CODEOWNERS`: `* @coval-ai/coval-benchmarking`

The team was given `maintain` access on the repo, so it's a valid code owner and membership stays in sync automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
