### PR TITLE
Migrate Palabra TTS to platform auth

### DIFF
--- a/runner/src/coval_bench/providers/tts/palabra.py
+++ b/runner/src/coval_bench/providers/tts/palabra.py
@@ -9,6 +9,7 @@ import base64
 import json
 import time
 from typing import Any
+from urllib.parse import quote
 from uuid import uuid4
 
 import structlog
@@ -57,7 +58,8 @@ class PalabraTTSProvider(TTSProvider):
 
         try:
             # Platform auth: the API key authenticates the WebSocket directly.
-            async with ws_client.connect(f"{_WS_URL}?token={self._api_key}") as ws:
+            token = quote(self._api_key, safe="")
+            async with ws_client.connect(f"{_WS_URL}?token={token}") as ws:
                 # Pre-t0: session init
                 await ws.send(
                     json.dumps(

--- a/runner/src/coval_bench/providers/tts/palabra.py
+++ b/runner/src/coval_bench/providers/tts/palabra.py
@@ -11,7 +11,6 @@ import time
 from typing import Any
 from uuid import uuid4
 
-import httpx
 import structlog
 import websockets.asyncio.client as ws_client
 
@@ -23,7 +22,6 @@ logger: structlog.BoundLogger = structlog.get_logger(__name__)
 
 _VALID_MODELS = ("palabra-tts-v1",)
 _VALID_VOICES = ("default_low", "default_high")
-_SESSION_URL = "https://api.palabra.ai/session-storage/session"
 _WS_URL = "wss://stream.us.palabra.ai/tts-api/v1/text-to-speech/stream"
 _SAMPLE_RATE = 24000
 
@@ -52,32 +50,14 @@ class PalabraTTSProvider(TTSProvider):
     def model(self) -> str:
         return self._model
 
-    async def _get_session_token(self) -> str:
-        """POST /session-storage/session -> the session auth token."""
-        async with httpx.AsyncClient(timeout=5.0) as client:
-            try:
-                client_id, client_secret = self._api_key.split("_", 1)
-            except ValueError as exc:
-                raise ValueError("palabra_api_key must be '<client_id>_<client_secret>'") from exc
-            resp = await client.post(
-                _SESSION_URL,
-                headers={"ClientID": client_id, "ClientSecret": client_secret},
-                json={"data": {}},
-            )
-            resp.raise_for_status()
-            token: str = resp.json()["data"]["publisher"]
-        return token
-
     async def synthesize(self, text: str) -> TTSResult:
         audio_chunks: list[bytes] = []
         start: float | None = None
         first_chunk_at: float | None = None
 
         try:
-            # Pre-t0: get auth token
-            token = await self._get_session_token()
-
-            async with ws_client.connect(f"{_WS_URL}?token={token}") as ws:
+            # Platform auth: the API key authenticates the WebSocket directly.
+            async with ws_client.connect(f"{_WS_URL}?token={self._api_key}") as ws:
                 # Pre-t0: session init
                 await ws.send(
                     json.dumps(


### PR DESCRIPTION
The new platform authenticates the WebSocket directly via the API key, so the session-creation step and clientid_secret splitting are gone.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR migrates Palabra TTS to direct platform authentication. The main changes are:

- Removes the session-token request and legacy credential splitting.
- Passes the API key directly to the WebSocket endpoint.
- Percent-encodes the API key before adding it to the query string.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- The API key is encoded as an opaque query value, including reserved characters and literal percent signs.
- No blocking issue remains in the updated authentication path.

<sub>Reviews (2): Last reviewed commit: ["URL-encode the Palabra token query param"](https://github.com/coval-ai/benchmarks/commit/a527e109d998dacada38c64f3465253908b10ff9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46383487)</sub>

<!-- /greptile_comment -->