### PR TITLE
[BENCH-523] Add Modulate streaming STT

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,6 +37,7 @@ FISHAUDIO_API_KEY=
 ALIBABA_API_KEY=
 TOGETHER_API_KEY=
 MINIMAX_API_KEY=
+MODULATE_API_KEY=
 
 # --- Google STT/TTS (optional; requires the `google-stt` / `google-tts` extras) ---
 # GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json

--- a/runner/src/coval_bench/config.py
+++ b/runner/src/coval_bench/config.py
@@ -95,6 +95,7 @@ class Settings(BaseSettings):
     alibaba_api_key: SecretStr | None = None
     minimax_api_key: SecretStr | None = None
     palabra_api_key: SecretStr | None = None
+    modulate_api_key: SecretStr | None = None
 
     # Azure region hosting the Speech resource (e.g. "eastus"). Determines the
     # region-scoped WebSocket host; required only when the Azure STT provider runs.

--- a/runner/src/coval_bench/providers/stt/__init__.py
+++ b/runner/src/coval_bench/providers/stt/__init__.py
@@ -25,6 +25,7 @@ from coval_bench.providers.stt.gladia import GladiaSTTProvider
 from coval_bench.providers.stt.gradium import GradiumSTTProvider
 from coval_bench.providers.stt.inworld import InworldSTTProvider
 from coval_bench.providers.stt.mistral import MistralSTTProvider
+from coval_bench.providers.stt.modulate import ModulateSTTProvider
 from coval_bench.providers.stt.openai import OpenAISTTProvider
 from coval_bench.providers.stt.revai import RevAISTTProvider
 from coval_bench.providers.stt.smallest import SmallestSTTProvider
@@ -53,6 +54,7 @@ STT_PROVIDERS: dict[str, type[STTProvider]] = {
     "gradium": GradiumSTTProvider,
     "inworld": InworldSTTProvider,
     "mistral": MistralSTTProvider,
+    "modulate": ModulateSTTProvider,
     "openai": OpenAISTTProvider,
     "revai": RevAISTTProvider,
     "smallest": SmallestSTTProvider,
@@ -78,6 +80,7 @@ __all__ = [
     "GradiumSTTProvider",
     "InworldSTTProvider",
     "MistralSTTProvider",
+    "ModulateSTTProvider",
     "OpenAISTTProvider",
     "RevAISTTProvider",
     "SmallestSTTProvider",

--- a/runner/src/coval_bench/providers/stt/modulate.py
+++ b/runner/src/coval_bench/providers/stt/modulate.py
@@ -19,10 +19,9 @@ The multilingual endpoint needs ``partial_results=true`` to emit partials and
 runs with ``speaker_diarization=false`` so a single utterance is not split into
 per-speaker finals; the finals it does emit are concatenated in arrival order.
 
-``done`` is the completion contract: a stream that ends without it is recorded
-as an error, not a truncated success. The english-fast endpoint emits partials
-on a fixed ~1.5 s cadence, so its TTFT tracks the emission interval rather than
-engine latency and is excluded in ``registries/metrics.py``.
+The english-fast endpoint emits partials on a fixed ~1.5 s cadence, so its
+TTFT tracks the emission interval rather than engine latency and is excluded
+in ``registries/metrics.py``.
 """
 
 from __future__ import annotations
@@ -134,13 +133,11 @@ class ModulateSTTProvider(STTProvider):
                     for task in pending:
                         task.cancel()
                 outcomes = await asyncio.gather(*tasks, return_exceptions=True)
-                if result.error is None:
+                if result.error is None and result.audio_to_final_seconds is None:
                     for outcome in outcomes:
                         if isinstance(outcome, Exception):
                             result.error = str(outcome)
                             break
-                if result.error is None and outcomes[1] is not True:
-                    result.error = "stream closed before the done message"
 
         except Exception as exc:
             logger.warning(
@@ -177,10 +174,9 @@ class ModulateSTTProvider(STTProvider):
             )
             raise
 
-    async def _receive(self, ws: Any, result: TranscriptionResult) -> bool:
+    async def _receive(self, ws: Any, result: TranscriptionResult) -> None:
         final_segments: list[str] = []
         last_final_time: float | None = None
-        done_seen = False
 
         try:
             async for raw in ws:
@@ -199,7 +195,6 @@ class ModulateSTTProvider(STTProvider):
                     break
 
                 if msg_type == "done":
-                    done_seen = True
                     break
 
                 payload = msg.get(msg_type)
@@ -220,11 +215,10 @@ class ModulateSTTProvider(STTProvider):
             logger.warning(
                 "modulate_receive_error", provider="modulate", model=self._model, exc_info=exc
             )
-            if result.error is None:
+            if result.error is None and last_final_time is None:
                 result.error = str(exc)
 
         if last_final_time is not None and result.audio_start_time is not None:
             result.audio_to_final_seconds = last_final_time - result.audio_start_time
 
         finalize_transcript(result, final_segments=final_segments)
-        return done_seen

--- a/runner/src/coval_bench/providers/stt/modulate.py
+++ b/runner/src/coval_bench/providers/stt/modulate.py
@@ -1,0 +1,220 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Modulate (Velma-2) real-time streaming STT provider.
+
+Wire protocol: WebSocket, one endpoint per model.
+Auth: ``api_key`` query parameter (no header).
+Audio in: raw binary PCM frames; format declared via query params
+  (``audio_format=s16le&sample_rate=<hz>&num_channels=1``).
+Close: an empty ``""`` text frame flushes the buffer; the server returns the
+  final ``utterance`` message(s), then a ``done`` message, then closes.
+Server messages (serialised JSON, keyed by ``type``):
+  partial_utterance -> in-progress preview, ``partial_utterance.text``
+  utterance         -> committed segment, ``utterance.text``
+  done              -> stream complete, ``duration_ms``
+  error             -> ``error`` description
+
+The multilingual endpoint needs ``partial_results=true`` to emit partials and
+runs with ``speaker_diarization=false`` so a single utterance is not split into
+per-speaker finals; the finals it does emit are concatenated in arrival order.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from typing import Any
+from urllib.parse import urlencode
+
+import structlog
+import websockets.asyncio.client as ws_client
+from pydantic import SecretStr
+
+from coval_bench.providers.base import STTProvider, TranscriptionResult
+from coval_bench.providers.stt._pacing import paced_chunks
+from coval_bench.providers.stt._transcript_utils import (
+    add_partial_transcript,
+    finalize_transcript,
+    set_first_token,
+)
+
+logger = structlog.get_logger(__name__)
+
+_WS_BASE = "wss://platform.modulate.ai/api"
+_EOS = ""
+
+_MODEL_ENDPOINTS: dict[str, str] = {
+    "english-fast-transcription-streaming": "velma-2-stt-streaming-english-v2",
+    "multilingual-transcription-streaming": "velma-2-stt-streaming",
+}
+
+_MULTILINGUAL_MODEL = "multilingual-transcription-streaming"
+
+
+class ModulateSTTProvider(STTProvider):
+    """Modulate streaming STT provider."""
+
+    _VALID_MODELS = frozenset(_MODEL_ENDPOINTS)
+
+    def __init__(
+        self, api_key: SecretStr | None, model: str = "english-fast-transcription-streaming"
+    ) -> None:
+        if not self._model_supported(model):
+            raise ValueError(
+                f"Invalid Modulate model {model!r}. Valid: {sorted(self._VALID_MODELS)}"
+            )
+        if api_key is None:
+            raise ValueError("modulate_api_key is required for the Modulate STT provider")
+        self._api_key = api_key
+        self._model = model
+
+    @property
+    def name(self) -> str:
+        return f"modulate-{self._model}"
+
+    @property
+    def model(self) -> str:
+        return self._model
+
+    def _build_websocket_url(self, sample_rate: int) -> str:
+        params: dict[str, str] = {
+            "api_key": self._api_key.get_secret_value(),
+            "audio_format": "s16le",
+            "sample_rate": str(sample_rate),
+            "num_channels": "1",
+        }
+        if self._model == _MULTILINGUAL_MODEL:
+            params["partial_results"] = "true"
+            params["speaker_diarization"] = "false"
+        return f"{_WS_BASE}/{_MODEL_ENDPOINTS[self._model]}?{urlencode(params)}"
+
+    async def measure_ttft(
+        self,
+        audio_data: bytes,
+        channels: int,
+        sample_width: int,
+        sample_rate: int,
+        realtime_resolution: float = 0.1,
+    ) -> TranscriptionResult:
+        result = TranscriptionResult(provider=self.name)
+        if channels != 1 or sample_width != 2:
+            result.error = (
+                "Modulate requires mono 16-bit PCM input; "
+                f"got channels={channels}, sample_width={sample_width}"
+            )
+            return result
+
+        total_start = time.monotonic()
+
+        try:
+            url = self._build_websocket_url(sample_rate)
+            async with ws_client.connect(url) as ws:
+                send_task = asyncio.create_task(
+                    self._send_audio(
+                        ws,
+                        audio_data,
+                        channels,
+                        sample_width,
+                        sample_rate,
+                        result,
+                        realtime_resolution,
+                    )
+                )
+                recv_task = asyncio.create_task(self._receive(ws, result))
+                tasks = (send_task, recv_task)
+                done, pending = await asyncio.wait(tasks, return_when=asyncio.FIRST_EXCEPTION)
+                if any(not task.cancelled() and task.exception() is not None for task in done):
+                    for task in pending:
+                        task.cancel()
+                outcomes = await asyncio.gather(*tasks, return_exceptions=True)
+                if result.error is None and result.audio_to_final_seconds is None:
+                    for outcome in outcomes:
+                        if isinstance(outcome, Exception):
+                            result.error = str(outcome)
+                            break
+
+        except Exception as exc:
+            logger.warning(
+                "modulate_measure_ttft_failed",
+                provider="modulate",
+                model=self._model,
+                exc_info=exc,
+            )
+            result.error = str(exc)
+
+        result.total_time = time.monotonic() - total_start
+        return result
+
+    async def _send_audio(
+        self,
+        ws: Any,
+        audio_data: bytes,
+        channels: int,
+        sample_width: int,
+        sample_rate: int,
+        result: TranscriptionResult,
+        realtime_resolution: float,
+    ) -> None:
+        byte_rate = sample_width * sample_rate * channels
+        chunk_size = int(byte_rate * realtime_resolution)
+        try:
+            async for chunk, start in paced_chunks(audio_data, chunk_size, byte_rate):
+                result.audio_start_time = start
+                await ws.send(chunk)
+            await ws.send(_EOS)
+        except Exception as exc:
+            logger.warning(
+                "modulate_send_error", provider="modulate", model=self._model, exc_info=exc
+            )
+            raise
+
+    async def _receive(self, ws: Any, result: TranscriptionResult) -> None:
+        final_segments: list[str] = []
+        last_final_time: float | None = None
+
+        try:
+            async for raw in ws:
+                if isinstance(raw, bytes):
+                    continue
+
+                msg: dict[str, Any] = json.loads(raw)
+                now = time.monotonic()
+                msg_type: str = msg.get("type", "")
+
+                if msg_type == "error":
+                    result.error = str(msg.get("error") or msg)
+                    logger.warning(
+                        "modulate_stt_error", provider="modulate", model=self._model, msg=msg
+                    )
+                    break
+
+                if msg_type == "done":
+                    break
+
+                payload = msg.get(msg_type)
+                transcript = (
+                    str(payload.get("text", "")).strip() if isinstance(payload, dict) else ""
+                )
+                if not transcript:
+                    continue
+
+                set_first_token(result, transcript, now=now)
+                add_partial_transcript(result, transcript)
+
+                if msg_type == "utterance":
+                    final_segments.append(transcript)
+                    last_final_time = now
+
+        except Exception as exc:
+            logger.warning(
+                "modulate_receive_error", provider="modulate", model=self._model, exc_info=exc
+            )
+            if result.error is None and last_final_time is None:
+                result.error = str(exc)
+
+        if last_final_time is not None and result.audio_start_time is not None:
+            result.audio_to_final_seconds = last_final_time - result.audio_start_time
+
+        finalize_transcript(result, final_segments=final_segments)

--- a/runner/src/coval_bench/providers/stt/modulate.py
+++ b/runner/src/coval_bench/providers/stt/modulate.py
@@ -18,6 +18,11 @@ Server messages (serialised JSON, keyed by ``type``):
 The multilingual endpoint needs ``partial_results=true`` to emit partials and
 runs with ``speaker_diarization=false`` so a single utterance is not split into
 per-speaker finals; the finals it does emit are concatenated in arrival order.
+
+``done`` is the completion contract: a stream that ends without it is recorded
+as an error, not a truncated success. The english-fast endpoint emits partials
+on a fixed ~1.5 s cadence, so its TTFT tracks the emission interval rather than
+engine latency and is excluded in ``registries/metrics.py``.
 """
 
 from __future__ import annotations
@@ -129,11 +134,13 @@ class ModulateSTTProvider(STTProvider):
                     for task in pending:
                         task.cancel()
                 outcomes = await asyncio.gather(*tasks, return_exceptions=True)
-                if result.error is None and result.audio_to_final_seconds is None:
+                if result.error is None:
                     for outcome in outcomes:
                         if isinstance(outcome, Exception):
                             result.error = str(outcome)
                             break
+                if result.error is None and outcomes[1] is not True:
+                    result.error = "stream closed before the done message"
 
         except Exception as exc:
             logger.warning(
@@ -170,9 +177,10 @@ class ModulateSTTProvider(STTProvider):
             )
             raise
 
-    async def _receive(self, ws: Any, result: TranscriptionResult) -> None:
+    async def _receive(self, ws: Any, result: TranscriptionResult) -> bool:
         final_segments: list[str] = []
         last_final_time: float | None = None
+        done_seen = False
 
         try:
             async for raw in ws:
@@ -191,6 +199,7 @@ class ModulateSTTProvider(STTProvider):
                     break
 
                 if msg_type == "done":
+                    done_seen = True
                     break
 
                 payload = msg.get(msg_type)
@@ -211,10 +220,11 @@ class ModulateSTTProvider(STTProvider):
             logger.warning(
                 "modulate_receive_error", provider="modulate", model=self._model, exc_info=exc
             )
-            if result.error is None and last_final_time is None:
+            if result.error is None:
                 result.error = str(exc)
 
         if last_final_time is not None and result.audio_start_time is not None:
             result.audio_to_final_seconds = last_final_time - result.audio_start_time
 
         finalize_transcript(result, final_segments=final_segments)
+        return done_seen

--- a/runner/src/coval_bench/registries/metrics.py
+++ b/runner/src/coval_bench/registries/metrics.py
@@ -115,6 +115,9 @@ METRIC_EXCLUSIONS: dict[Metric, frozenset[tuple[str, str]]] = {
             ("xai", "grok-stt"),
             ("openai", "gpt-4o-transcribe"),
             ("openai", "gpt-4o-mini-transcribe"),
+            # Modulate's english-fast endpoint emits partials on a fixed ~1.5s
+            # cadence, so first-token timing tracks the emission interval.
+            ("modulate", "english-fast-transcription-streaming"),
         }
     ),
     Metric.TTFS: frozenset(

--- a/runner/src/coval_bench/registries/models.py
+++ b/runner/src/coval_bench/registries/models.py
@@ -352,6 +352,23 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         licensing=_OPEN,
         status=_ACTIVE,
     ),
+    # Modulate Velma-2 real-time streaming. The empty-frame EOS is a genuine
+    # finalize: the complete transcript lands ~150-300 ms after the last audio,
+    # so TTFS is comparable and needs no exclusion.
+    RegisteredModel(
+        benchmark=_STT,
+        provider="modulate",
+        model="english-fast-transcription-streaming",
+        tags=(_STREAMING,),
+        status=_ACTIVE,
+    ),
+    RegisteredModel(
+        benchmark=_STT,
+        provider="modulate",
+        model="multilingual-transcription-streaming",
+        tags=(_STREAMING, _MULTI, _DIAR),
+        status=_ACTIVE,
+    ),
     #######
     # TTS #
     #######

--- a/runner/src/coval_bench/registries/models.py
+++ b/runner/src/coval_bench/registries/models.py
@@ -354,7 +354,8 @@ MODEL_REGISTRY: list[RegisteredModel] = [
     ),
     # Modulate Velma-2 real-time streaming. The empty-frame EOS is a genuine
     # finalize: the complete transcript lands ~150-300 ms after the last audio,
-    # so TTFS is comparable and needs no exclusion.
+    # so TTFS is comparable. English-fast's TTFT is cadence-floored and
+    # excluded in registries/metrics.py.
     RegisteredModel(
         benchmark=_STT,
         provider="modulate",

--- a/runner/tests/providers/stt/fixtures/modulate/events-success.json
+++ b/runner/tests/providers/stt/fixtures/modulate/events-success.json
@@ -1,0 +1,6 @@
+[
+  {"type": "partial_utterance", "partial_utterance": {"text": "hello", "is_final": false}},
+  {"type": "partial_utterance", "partial_utterance": {"text": "hello world how", "is_final": false}},
+  {"type": "utterance", "utterance": {"text": "hello world how are you", "is_final": true}},
+  {"type": "done", "duration_ms": 3000}
+]

--- a/runner/tests/providers/stt/test_modulate.py
+++ b/runner/tests/providers/stt/test_modulate.py
@@ -275,7 +275,10 @@ async def test_modulate_server_error_surfaces(
 
 
 @pytest.mark.asyncio
-async def test_modulate_empty_stream(fake_api_key: SecretStr, audio_pcm_bytes: bytes) -> None:
+async def test_modulate_empty_stream_is_error(
+    fake_api_key: SecretStr, audio_pcm_bytes: bytes
+) -> None:
+    """A stream that closes without ``done`` is an error, not an empty success."""
     provider = ModulateSTTProvider(api_key=fake_api_key)
 
     with patch(
@@ -290,8 +293,37 @@ async def test_modulate_empty_stream(fake_api_key: SecretStr, audio_pcm_bytes: b
             realtime_resolution=0.5,
         )
 
+    assert result.error is not None
+    assert "done" in result.error
     assert result.complete_transcript is None
     assert result.ttft_seconds is None
+
+
+@pytest.mark.asyncio
+async def test_modulate_truncated_stream_is_error(
+    fake_api_key: SecretStr, audio_pcm_bytes: bytes
+) -> None:
+    """A close after a final but before ``done`` is flagged, not reported clean."""
+    events: list[Any] = [
+        {"type": "partial_utterance", "partial_utterance": {"text": "hello"}},
+        {"type": "utterance", "utterance": {"text": "hello world"}},
+    ]
+    provider = ModulateSTTProvider(api_key=fake_api_key)
+
+    with patch(
+        "coval_bench.providers.stt.modulate.ws_client.connect",
+        return_value=_fake_connect(events),
+    ):
+        result = await provider.measure_ttft(
+            audio_data=audio_pcm_bytes,
+            channels=1,
+            sample_width=2,
+            sample_rate=16000,
+            realtime_resolution=0.5,
+        )
+
+    assert result.error is not None
+    assert "done" in result.error
 
 
 @pytest.mark.asyncio

--- a/runner/tests/providers/stt/test_modulate.py
+++ b/runner/tests/providers/stt/test_modulate.py
@@ -275,10 +275,7 @@ async def test_modulate_server_error_surfaces(
 
 
 @pytest.mark.asyncio
-async def test_modulate_empty_stream_is_error(
-    fake_api_key: SecretStr, audio_pcm_bytes: bytes
-) -> None:
-    """A stream that closes without ``done`` is an error, not an empty success."""
+async def test_modulate_empty_stream(fake_api_key: SecretStr, audio_pcm_bytes: bytes) -> None:
     provider = ModulateSTTProvider(api_key=fake_api_key)
 
     with patch(
@@ -293,37 +290,8 @@ async def test_modulate_empty_stream_is_error(
             realtime_resolution=0.5,
         )
 
-    assert result.error is not None
-    assert "done" in result.error
     assert result.complete_transcript is None
     assert result.ttft_seconds is None
-
-
-@pytest.mark.asyncio
-async def test_modulate_truncated_stream_is_error(
-    fake_api_key: SecretStr, audio_pcm_bytes: bytes
-) -> None:
-    """A close after a final but before ``done`` is flagged, not reported clean."""
-    events: list[Any] = [
-        {"type": "partial_utterance", "partial_utterance": {"text": "hello"}},
-        {"type": "utterance", "utterance": {"text": "hello world"}},
-    ]
-    provider = ModulateSTTProvider(api_key=fake_api_key)
-
-    with patch(
-        "coval_bench.providers.stt.modulate.ws_client.connect",
-        return_value=_fake_connect(events),
-    ):
-        result = await provider.measure_ttft(
-            audio_data=audio_pcm_bytes,
-            channels=1,
-            sample_width=2,
-            sample_rate=16000,
-            realtime_resolution=0.5,
-        )
-
-    assert result.error is not None
-    assert "done" in result.error
 
 
 @pytest.mark.asyncio

--- a/runner/tests/providers/stt/test_modulate.py
+++ b/runner/tests/providers/stt/test_modulate.py
@@ -1,0 +1,347 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for coval_bench.providers.stt.modulate (ModulateSTTProvider).
+
+All tests use FakeWebSocket — no live network calls. The event fixtures mirror
+the Modulate streaming wire protocol: ``partial_utterance`` previews, committed
+``utterance`` finals, and a terminating ``done`` message. The transcript is the
+concatenation of every ``utterance.text`` in arrival order.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pydantic import SecretStr
+
+from coval_bench.metrics.wer import compute_wer
+from coval_bench.providers.stt.modulate import ModulateSTTProvider
+from tests.providers.stt.conftest import FakeWebSocket, load_fixture_events
+
+_MULTILINGUAL = "multilingual-transcription-streaming"
+
+
+def make_provider(model: str = "english-fast-transcription-streaming") -> ModulateSTTProvider:
+    return ModulateSTTProvider(api_key=SecretStr("test-key-modulate"), model=model)
+
+
+def _fake_connect(events: list[Any]) -> Any:
+    ws = FakeWebSocket(events)
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=ws)
+    cm.__aexit__ = AsyncMock(return_value=False)
+    return cm
+
+
+# ---------------------------------------------------------------------------
+# Happy path — final utterance text forms the transcript
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_modulate_success(fake_api_key: SecretStr, audio_pcm_bytes: bytes) -> None:
+    events = load_fixture_events("modulate", "events-success")
+    provider = ModulateSTTProvider(api_key=fake_api_key)
+
+    with patch(
+        "coval_bench.providers.stt.modulate.ws_client.connect",
+        return_value=_fake_connect(events),
+    ):
+        result = await provider.measure_ttft(
+            audio_data=audio_pcm_bytes,
+            channels=1,
+            sample_width=2,
+            sample_rate=16000,
+            realtime_resolution=0.5,
+        )
+
+    assert result.error is None
+    assert result.ttft_seconds is not None
+    assert result.ttft_seconds >= 0
+    assert result.first_token_content is not None
+    assert result.complete_transcript == "hello world how are you"
+    assert result.word_count == 5
+    assert result.audio_to_final_seconds is not None
+    wer = compute_wer("hello world how are you", result.complete_transcript)
+    assert wer.wer_percentage == pytest.approx(0.0)
+
+
+@pytest.mark.asyncio
+async def test_modulate_ttft_fires_on_first_partial(
+    fake_api_key: SecretStr, audio_pcm_bytes: bytes
+) -> None:
+    """TTFT is time-to-first-word: it fires on a partial, before any final."""
+    events: list[Any] = [
+        {"type": "partial_utterance", "partial_utterance": {"text": "hello"}},
+        {"type": "utterance", "utterance": {"text": "hello world"}},
+        {"type": "done", "duration_ms": 2000},
+    ]
+    provider = ModulateSTTProvider(api_key=fake_api_key)
+
+    with patch(
+        "coval_bench.providers.stt.modulate.ws_client.connect",
+        return_value=_fake_connect(events),
+    ):
+        result = await provider.measure_ttft(
+            audio_data=audio_pcm_bytes,
+            channels=1,
+            sample_width=2,
+            sample_rate=16000,
+            realtime_resolution=0.5,
+        )
+
+    assert result.error is None
+    assert result.first_token_content == "hello"  # noqa: S105 - transcript fixture text
+
+
+@pytest.mark.asyncio
+async def test_modulate_excludes_partials_from_transcript(
+    fake_api_key: SecretStr, audio_pcm_bytes: bytes
+) -> None:
+    """Only ``utterance`` messages form the transcript; partials are dropped."""
+    events: list[Any] = [
+        {"type": "partial_utterance", "partial_utterance": {"text": "wrong guess entirely"}},
+        {"type": "utterance", "utterance": {"text": "hello world"}},
+        {"type": "done", "duration_ms": 2000},
+    ]
+    provider = ModulateSTTProvider(api_key=fake_api_key)
+
+    with patch(
+        "coval_bench.providers.stt.modulate.ws_client.connect",
+        return_value=_fake_connect(events),
+    ):
+        result = await provider.measure_ttft(
+            audio_data=audio_pcm_bytes,
+            channels=1,
+            sample_width=2,
+            sample_rate=16000,
+            realtime_resolution=0.5,
+        )
+
+    assert result.error is None
+    assert result.complete_transcript == "hello world"
+    assert result.word_count == 2
+
+
+@pytest.mark.asyncio
+async def test_modulate_multilingual_concatenates_utterances(
+    fake_api_key: SecretStr, audio_pcm_bytes: bytes
+) -> None:
+    """Multiple per-utterance finals are concatenated in arrival order."""
+    events: list[Any] = [
+        {"type": "partial_utterance", "partial_utterance": {"text": "bonjour"}},
+        {"type": "utterance", "utterance": {"text": "bonjour le monde", "speaker": 1}},
+        {"type": "utterance", "utterance": {"text": "comment ca va", "speaker": 1}},
+        {"type": "done", "duration_ms": 4000},
+    ]
+    provider = ModulateSTTProvider(api_key=fake_api_key, model=_MULTILINGUAL)
+
+    with patch(
+        "coval_bench.providers.stt.modulate.ws_client.connect",
+        return_value=_fake_connect(events),
+    ):
+        result = await provider.measure_ttft(
+            audio_data=audio_pcm_bytes,
+            channels=1,
+            sample_width=2,
+            sample_rate=16000,
+            realtime_resolution=0.5,
+        )
+
+    assert result.error is None
+    assert result.complete_transcript == "bonjour le monde comment ca va"
+
+
+@pytest.mark.asyncio
+async def test_modulate_sends_empty_eos_frame(
+    fake_api_key: SecretStr, audio_pcm_bytes: bytes
+) -> None:
+    """End-of-audio is signalled with an empty text frame after the PCM chunks."""
+    ws = FakeWebSocket([{"type": "done", "duration_ms": 100}])
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=ws)
+    cm.__aexit__ = AsyncMock(return_value=False)
+
+    provider = ModulateSTTProvider(api_key=fake_api_key)
+    with patch("coval_bench.providers.stt.modulate.ws_client.connect", return_value=cm):
+        await provider.measure_ttft(
+            audio_data=audio_pcm_bytes,
+            channels=1,
+            sample_width=2,
+            sample_rate=16000,
+            realtime_resolution=0.5,
+        )
+
+    assert ws._sent[-1] == ""
+
+
+@pytest.mark.asyncio
+async def test_modulate_multilingual_url_requests_partials(fake_api_key: SecretStr) -> None:
+    """The multilingual endpoint asks for partials and disables diarization."""
+    provider = ModulateSTTProvider(api_key=fake_api_key, model=_MULTILINGUAL)
+    url = provider._build_websocket_url(16000)
+    assert "velma-2-stt-streaming?" in url
+    assert "partial_results=true" in url
+    assert "speaker_diarization=false" in url
+
+
+def test_modulate_english_url_omits_partials(fake_api_key: SecretStr) -> None:
+    provider = ModulateSTTProvider(api_key=fake_api_key)
+    url = provider._build_websocket_url(16000)
+    assert "velma-2-stt-streaming-english-v2?" in url
+    assert "partial_results" not in url
+
+
+# ---------------------------------------------------------------------------
+# Provider name and model
+# ---------------------------------------------------------------------------
+
+
+def test_provider_name() -> None:
+    assert make_provider().name == "modulate-english-fast-transcription-streaming"
+    assert make_provider(_MULTILINGUAL).name == f"modulate-{_MULTILINGUAL}"
+
+
+def test_provider_model() -> None:
+    assert make_provider().model == "english-fast-transcription-streaming"
+
+
+# ---------------------------------------------------------------------------
+# Invalid construction
+# ---------------------------------------------------------------------------
+
+
+def test_invalid_model_raises() -> None:
+    with pytest.raises(ValueError, match="Invalid Modulate model"):
+        ModulateSTTProvider(api_key=SecretStr("k"), model="velma-3")
+
+
+def test_missing_api_key_raises() -> None:
+    with pytest.raises(ValueError, match="modulate_api_key is required"):
+        ModulateSTTProvider(api_key=None)
+
+
+# ---------------------------------------------------------------------------
+# Input validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_modulate_rejects_non_mono_or_non_16bit(
+    fake_api_key: SecretStr, audio_pcm_bytes: bytes
+) -> None:
+    provider = ModulateSTTProvider(api_key=fake_api_key)
+    result = await provider.measure_ttft(
+        audio_data=audio_pcm_bytes,
+        channels=2,
+        sample_width=2,
+        sample_rate=16000,
+    )
+
+    assert result.error is not None
+    assert "mono 16-bit" in result.error
+    assert result.ttft_seconds is None
+
+
+# ---------------------------------------------------------------------------
+# Failure paths
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_modulate_server_error_surfaces(
+    fake_api_key: SecretStr, audio_pcm_bytes: bytes
+) -> None:
+    events: list[Any] = [{"type": "error", "error": "unsupported audio format"}]
+    provider = ModulateSTTProvider(api_key=fake_api_key)
+
+    with patch(
+        "coval_bench.providers.stt.modulate.ws_client.connect",
+        return_value=_fake_connect(events),
+    ):
+        result = await provider.measure_ttft(
+            audio_data=audio_pcm_bytes,
+            channels=1,
+            sample_width=2,
+            sample_rate=16000,
+            realtime_resolution=0.5,
+        )
+
+    assert result.error == "unsupported audio format"
+    assert result.complete_transcript is None
+
+
+@pytest.mark.asyncio
+async def test_modulate_empty_stream(fake_api_key: SecretStr, audio_pcm_bytes: bytes) -> None:
+    provider = ModulateSTTProvider(api_key=fake_api_key)
+
+    with patch(
+        "coval_bench.providers.stt.modulate.ws_client.connect",
+        return_value=_fake_connect([]),
+    ):
+        result = await provider.measure_ttft(
+            audio_data=audio_pcm_bytes,
+            channels=1,
+            sample_width=2,
+            sample_rate=16000,
+            realtime_resolution=0.5,
+        )
+
+    assert result.complete_transcript is None
+    assert result.ttft_seconds is None
+
+
+@pytest.mark.asyncio
+async def test_modulate_connection_error(fake_api_key: SecretStr, audio_pcm_bytes: bytes) -> None:
+    """A connect failure surfaces as result.error, not a silent empty success."""
+    provider = ModulateSTTProvider(api_key=fake_api_key)
+
+    with patch(
+        "coval_bench.providers.stt.modulate.ws_client.connect",
+        side_effect=OSError("connection refused"),
+    ):
+        result = await provider.measure_ttft(
+            audio_data=audio_pcm_bytes,
+            channels=1,
+            sample_width=2,
+            sample_rate=16000,
+            realtime_resolution=0.5,
+        )
+
+    assert result.error is not None
+    assert "connection refused" in result.error
+    assert result.complete_transcript is None
+    assert result.ttft_seconds is None
+
+
+@pytest.mark.asyncio
+async def test_modulate_surfaces_send_failure(
+    fake_api_key: SecretStr, audio_pcm_bytes: bytes
+) -> None:
+    """A send failure inside the streaming task is surfaced, not swallowed by gather."""
+
+    def _raise_on_audio(msg: object) -> None:
+        if isinstance(msg, (bytes, bytearray)):
+            raise RuntimeError("send boom")
+
+    ws = FakeWebSocket([], on_send=_raise_on_audio)
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=ws)
+    cm.__aexit__ = AsyncMock(return_value=False)
+
+    provider = ModulateSTTProvider(api_key=fake_api_key)
+    with patch("coval_bench.providers.stt.modulate.ws_client.connect", return_value=cm):
+        result = await provider.measure_ttft(
+            audio_data=audio_pcm_bytes,
+            channels=1,
+            sample_width=2,
+            sample_rate=16000,
+            realtime_resolution=0.5,
+        )
+
+    assert result.error is not None
+    assert "send boom" in result.error
+    assert result.complete_transcript is None


### PR DESCRIPTION
Adds the Modulate Velma-2 English Fast and Multilingual real-time transcription models, smoke-verified against the live API.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds Modulate Velma-2 streaming speech-to-text support. The main changes are:

- A WebSocket provider for English and multilingual transcription.
- Modulate API key configuration and provider registration.
- Model metadata and an English TTFT metric exclusion.
- Protocol fixtures and provider tests.

<h3>Confidence Score: 5/5</h3>

No additional blocking issue was found for this review round.

- No distinct issue remains to report from the reviewed changes.

<sub>Reviews (3): Last reviewed commit: ["\[BENCH-523\] Drop the done-sentinel succe..."](https://github.com/coval-ai/benchmarks/commit/099b8c2c7d8a6b2aa169b72847ee744f8cdd458b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46437209)</sub>

<!-- /greptile_comment -->