### PR TITLE
[BENCH-522] Dedicated-inference framework for the public benchmarks

### DIFF
--- a/web/components/charts/CustomBarChartTick.tsx
+++ b/web/components/charts/CustomBarChartTick.tsx
@@ -90,8 +90,9 @@ const CustomBarChartTick: React.FC<{
           // reads at a glance even when labels fan out at 45°.
           <g
             {...dedicatedIconHandlers}
-            role="img"
-            aria-label="Dedicated inference"
+            role="button"
+            tabIndex={0}
+            aria-label="About dedicated inference"
             style={{ cursor: "help" }}
           >
             <Server

--- a/web/components/charts/CustomBarChartTick.tsx
+++ b/web/components/charts/CustomBarChartTick.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React from "react";
+import { Server } from "lucide-react";
 import { normalizeModelName } from "@/lib/utils/formatters";
 import { useThemeColors } from "@/hooks/useThemeColors";
 
@@ -17,6 +18,10 @@ const CustomBarChartTick: React.FC<{
   visibleTicksCount?: number;
   payload?: { value: string };
   getProviderForModel: (model: string) => string;
+  /** Dedicated-inference endpoints carry the server marker beside the label. */
+  dedicatedModels?: Set<string>;
+  /** Hover/tap handlers for the marker, from useDedicatedInfoTip. */
+  dedicatedIconHandlers?: React.DOMAttributes<SVGGElement>;
   isMobile?: boolean;
 }> = ({
   x = 0,
@@ -25,6 +30,8 @@ const CustomBarChartTick: React.FC<{
   visibleTicksCount = 1,
   payload,
   getProviderForModel,
+  dedicatedModels,
+  dedicatedIconHandlers,
   isMobile = false,
 }) => {
   const themeColors = useThemeColors();
@@ -77,6 +84,32 @@ const CustomBarChartTick: React.FC<{
           >
             {provider}
           </text>
+        )}
+        {dedicatedModels?.has(model) && (
+          // Sits just past the label's anchor, nearest the bar, so the marker
+          // reads at a glance even when labels fan out at 45°.
+          <g
+            {...dedicatedIconHandlers}
+            role="img"
+            aria-label="Dedicated inference"
+            style={{ cursor: "help" }}
+          >
+            <Server
+              x={4}
+              y={showProvider ? 18 : 4}
+              size={12}
+              color={themeColors.label}
+              strokeWidth={2.4}
+              aria-hidden
+            />
+            <rect
+              x={-2}
+              y={showProvider ? 12 : -2}
+              width={24}
+              height={24}
+              fill="transparent"
+            />
+          </g>
         )}
       </g>
     </g>

--- a/web/components/charts/CustomBarChartTick.tsx
+++ b/web/components/charts/CustomBarChartTick.tsx
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React from "react";
-import { Server } from "lucide-react";
 import { normalizeModelName } from "@/lib/utils/formatters";
 import { useThemeColors } from "@/hooks/useThemeColors";
 
@@ -18,10 +17,6 @@ const CustomBarChartTick: React.FC<{
   visibleTicksCount?: number;
   payload?: { value: string };
   getProviderForModel: (model: string) => string;
-  /** Dedicated-inference endpoints carry the server marker beside the label. */
-  dedicatedModels?: Set<string>;
-  /** Hover/tap handlers for the marker, from useDedicatedInfoTip. */
-  dedicatedIconHandlers?: React.DOMAttributes<SVGGElement>;
   isMobile?: boolean;
 }> = ({
   x = 0,
@@ -30,8 +25,6 @@ const CustomBarChartTick: React.FC<{
   visibleTicksCount = 1,
   payload,
   getProviderForModel,
-  dedicatedModels,
-  dedicatedIconHandlers,
   isMobile = false,
 }) => {
   const themeColors = useThemeColors();
@@ -84,33 +77,6 @@ const CustomBarChartTick: React.FC<{
           >
             {provider}
           </text>
-        )}
-        {dedicatedModels?.has(model) && (
-          // Sits just past the label's anchor, nearest the bar, so the marker
-          // reads at a glance even when labels fan out at 45°.
-          <g
-            {...dedicatedIconHandlers}
-            role="button"
-            tabIndex={0}
-            aria-label="About dedicated inference"
-            style={{ cursor: "help" }}
-          >
-            <Server
-              x={4}
-              y={showProvider ? 18 : 4}
-              size={12}
-              color={themeColors.label}
-              strokeWidth={2.4}
-              aria-hidden
-            />
-            <rect
-              x={-2}
-              y={showProvider ? 12 : -2}
-              width={24}
-              height={24}
-              fill="transparent"
-            />
-          </g>
         )}
       </g>
     </g>

--- a/web/components/charts/d3/BoxPlot.tsx
+++ b/web/components/charts/d3/BoxPlot.tsx
@@ -222,8 +222,9 @@ const BoxPlot: React.FC<BoxPlotProps> = ({
       const wrap = g
         .append("g")
         .attr("transform", `translate(${x},${y})`)
-        .attr("role", "img")
-        .attr("aria-label", "Dedicated inference");
+        .attr("role", "button")
+        .attr("tabindex", 0)
+        .attr("aria-label", "About dedicated inference");
       const icon = wrap
         .append("g")
         .attr("transform", `scale(${size / 24})`)
@@ -333,7 +334,8 @@ const BoxPlot: React.FC<BoxPlotProps> = ({
             .style("cursor", "help")
             .on("mouseenter", (e: React.MouseEvent) => dedicatedIcon.onMouseEnter(e))
             .on("mouseleave", dedicatedIcon.onMouseLeave)
-            .on("click", (e: React.MouseEvent) => dedicatedIcon.onClick(e));
+            .on("click", (e: React.MouseEvent) => dedicatedIcon.onClick(e))
+            .on("keydown", (e: React.KeyboardEvent) => dedicatedIcon.onKeyDown(e));
         }
       });
     }

--- a/web/components/charts/d3/BoxPlot.tsx
+++ b/web/components/charts/d3/BoxPlot.tsx
@@ -7,6 +7,10 @@ import React, { useState, useEffect, useLayoutEffect, useRef } from "react";
 import * as d3 from "d3";
 import { BoxPlotProps } from "@/types/chart.types";
 import { BoxPlotDataPoint } from "@/types/benchmark.types";
+import {
+  DedicatedBadge,
+  useDedicatedInfoTip,
+} from "@/components/shared/DedicatedInferenceInfo";
 import { useThemeColors } from "@/hooks/useThemeColors";
 
 // Match the text sizes on the timeline chart above: 14px axis labels, 12px
@@ -16,7 +20,9 @@ const providerFontSize = 12;
 const axisLabelFontSize = "14px";
 const yAxisTickFontSize = "12px";
 const modelLineHeight = 14;
-const margin = { top: 20, right: 8, bottom: 80, left: 40 };
+// Bottom holds up to three label lines, the provider, the dedicated-inference
+// marker, and the axis caption — 80px stacked marker over caption.
+const margin = { top: 20, right: 8, bottom: 88, left: 40 };
 const minSlotWidth = 48;
 
 const BoxPlot: React.FC<BoxPlotProps> = ({
@@ -26,6 +32,7 @@ const BoxPlot: React.FC<BoxPlotProps> = ({
   getModelColor,
   getProviderForModel,
   normalizeModelName,
+  dedicatedModels,
   isMobile = false
 }) => {
   const svgRef = useRef<SVGSVGElement>(null);
@@ -41,6 +48,12 @@ const BoxPlot: React.FC<BoxPlotProps> = ({
     yTop: number;
     pinned: boolean;
   } | null>(null);
+  // Explainer for the dedicated-inference marker under a model's axis label.
+  const {
+    iconHandlers: dedicatedIcon,
+    overlay: dedicatedOverlay,
+    dismiss: dismissDedicated,
+  } = useDedicatedInfoTip(containerRef);
   const [scrollX, setScrollX] = useState(0);
   const themeColors = useThemeColors();
 
@@ -108,6 +121,7 @@ const BoxPlot: React.FC<BoxPlotProps> = ({
     if (!svgRef.current || data.data.length === 0) return;
 
     setTip(null);
+    dismissDedicated();
 
     const chartWidth = svgWidth - margin.left - margin.right;
     const chartHeight = dimensions.height - margin.top - margin.bottom;
@@ -200,6 +214,38 @@ const BoxPlot: React.FC<BoxPlotProps> = ({
     xAxisGroup.select(".domain").remove();
     xAxisGroup.selectAll("text").remove();
 
+    // Lucide's Server icon, drawn inline: it must live inside the axis SVG
+    // (an HTML overlay would detach when the plot scrolls) and always show —
+    // it is the dedicated-endpoint marker. Hovering or tapping it opens the
+    // explainer, so the wrapper carries a generous transparent hit rect.
+    const drawServerIcon = (x: number, y: number, size: number) => {
+      const wrap = g
+        .append("g")
+        .attr("transform", `translate(${x},${y})`)
+        .attr("role", "img")
+        .attr("aria-label", "Dedicated inference");
+      const icon = wrap
+        .append("g")
+        .attr("transform", `scale(${size / 24})`)
+        .attr("stroke", themeColors.label)
+        .attr("fill", "none")
+        .attr("stroke-width", 2.4)
+        .attr("stroke-linecap", "round")
+        .attr("stroke-linejoin", "round");
+      icon.append("rect").attr("x", 2).attr("y", 2).attr("width", 20).attr("height", 8).attr("rx", 2);
+      icon.append("rect").attr("x", 2).attr("y", 14).attr("width", 20).attr("height", 8).attr("rx", 2);
+      icon.append("line").attr("x1", 6).attr("y1", 6).attr("x2", 6.01).attr("y2", 6);
+      icon.append("line").attr("x1", 6).attr("y1", 18).attr("x2", 6.01).attr("y2", 18);
+      wrap
+        .append("rect")
+        .attr("x", -10)
+        .attr("y", -10)
+        .attr("width", size + 20)
+        .attr("height", size + 20)
+        .attr("fill", "transparent");
+      return wrap;
+    };
+
     // Create custom wrapped text with model first
     {
       const labelMaxWidth = xScale.step() * 0.82;
@@ -272,9 +318,23 @@ const BoxPlot: React.FC<BoxPlotProps> = ({
             .attr("y", yPosition + lineIndex * lineHeight);
         });
 
+        const providerY = yPosition + modelLines.length * lineHeight + 1;
         providerNode
           .attr("font-size", `${providerFontSize * scale}px`)
-          .attr("y", yPosition + modelLines.length * lineHeight + 1);
+          .attr("y", providerY);
+
+        // Dedicated endpoints carry the server icon on its own line beneath
+        // the label, centered in the slot; hover or tap opens the explainer.
+        // Fixed size on purpose: crowded views shrink the label text, and the
+        // marker must stay legible — it is the only dedicated cue at a glance.
+        if (dedicatedModels?.has(model)) {
+          const iconSize = 15;
+          drawServerIcon(xPosition - iconSize / 2, providerY + 4, iconSize)
+            .style("cursor", "help")
+            .on("mouseenter", (e: React.MouseEvent) => dedicatedIcon.onMouseEnter(e))
+            .on("mouseleave", dedicatedIcon.onMouseLeave)
+            .on("click", (e: React.MouseEvent) => dedicatedIcon.onClick(e));
+        }
       });
     }
 
@@ -283,7 +343,7 @@ const BoxPlot: React.FC<BoxPlotProps> = ({
     g.append("text")
       .attr(
         "transform",
-        `translate(${chartWidth / 2}, ${chartHeight + margin.bottom - 10})`
+        `translate(${chartWidth / 2}, ${chartHeight + margin.bottom - 6})`
       )
       .style("text-anchor", "middle")
       .attr("fill", themeColors.axisText)
@@ -305,7 +365,8 @@ const BoxPlot: React.FC<BoxPlotProps> = ({
       const centerX = (xScale(modelData.model) ?? 0) + xScale.bandwidth() / 2;
       const boxWidth = Math.min(xScale.bandwidth() * 0.5, 48);
 
-      // Main box (IQR)
+      // Main box (IQR). Dedicated endpoints get a dashed border — the visual
+      // cue that this box runs on reserved capacity, not the shared fleet.
       boxGroup
         .append("rect")
         .attr("x", centerX - boxWidth / 2)
@@ -316,6 +377,7 @@ const BoxPlot: React.FC<BoxPlotProps> = ({
         .attr("fill-opacity", 0.3)
         .attr("stroke", color)
         .attr("stroke-width", 2)
+        .attr("stroke-dasharray", dedicatedModels?.has(modelData.model) ? "5 3" : null)
         .attr("rx", 2);
 
       // Median line
@@ -426,7 +488,7 @@ const BoxPlot: React.FC<BoxPlotProps> = ({
     });
 
     svg.on("mouseleave", () => setTip((t) => (t?.pinned ? t : null)));
-  }, [data, dimensions.height, svgWidth, scrollable, getModelColor, getProviderForModel, normalizeModelName, isMobile, themeColors]);
+  }, [data, dimensions.height, svgWidth, scrollable, getModelColor, getProviderForModel, normalizeModelName, dedicatedModels, dedicatedIcon, dismissDedicated, isMobile, themeColors]);
 
   // The measured container must always render — an early return here would
   // leave the sizing effect's ResizeObserver attached to nothing, freezing
@@ -517,8 +579,10 @@ const BoxPlot: React.FC<BoxPlotProps> = ({
               color: "var(--color-text-on-tooltip)"
             }}
           >
-            {tip.point.model}
+            {getProviderForModel(tip.point.model)}{" "}
+            {normalizeModelName(tip.point.model)}
           </p>
+          {dedicatedModels?.has(tip.point.model) && <DedicatedBadge />}
           {(tip.pinned
             ? [
                 ["Max", `${tip.point.stats.max.toFixed(0)}ms`],
@@ -547,6 +611,7 @@ const BoxPlot: React.FC<BoxPlotProps> = ({
           ))}
         </div>
       )}
+      {dedicatedOverlay}
     </div>
   );
 };

--- a/web/components/charts/tooltips/BarTooltip.tsx
+++ b/web/components/charts/tooltips/BarTooltip.tsx
@@ -3,6 +3,7 @@
 
 import React from "react";
 import type { TooltipContentProps } from "recharts";
+import { DedicatedBadge } from "@/components/shared/DedicatedInferenceInfo";
 import { normalizeModelName } from "@/lib/utils/formatters";
 
 interface CustomBarTooltipProps extends Partial<Pick<
@@ -10,13 +11,16 @@ interface CustomBarTooltipProps extends Partial<Pick<
   "active" | "payload" | "label"
 >> {
   getProviderForModel?: (model: string) => string;
+  /** Dedicated-inference endpoints carry the badge in their tooltip. */
+  dedicatedModels?: Set<string>;
 }
 
 const CustomBarTooltip: React.FC<CustomBarTooltipProps> = ({
   active,
   payload,
   label,
-  getProviderForModel
+  getProviderForModel,
+  dedicatedModels
 }) => {
   if (active && payload && payload.length > 0) {
     const item = payload[0];
@@ -39,6 +43,7 @@ const CustomBarTooltip: React.FC<CustomBarTooltipProps> = ({
         <p
           style={{ margin: 0, fontWeight: "bold", color: "var(--color-text-on-tooltip)" }}
         >{`Model: ${modelLabel}`}</p>
+        {dedicatedModels?.has(modelKey) && <DedicatedBadge />}
         <p style={{ margin: 0, color: "var(--color-text-on-tooltip)" }}>{`Average WER: ${Number(
           value
         ).toFixed(1)}%`}</p>

--- a/web/components/charts/tooltips/ScatterTooltip.tsx
+++ b/web/components/charts/tooltips/ScatterTooltip.tsx
@@ -4,6 +4,7 @@
 import React from "react";
 import type { TooltipContentProps } from "recharts";
 import type { ScatterDataPoint } from "@/types/benchmark.types";
+import { DedicatedBadge } from "@/components/shared/DedicatedInferenceInfo";
 import { normalizeModelName, normalizeSTTProviderName, normalizeTTSProviderName } from "@/lib/utils/formatters";
 
 interface ScatterTooltipProps extends Partial<Pick<
@@ -12,9 +13,11 @@ interface ScatterTooltipProps extends Partial<Pick<
 >> {
   activeTab: "tts" | "stt";
   metric: string;
+  /** Dedicated-inference endpoints carry the server marker in their tooltip. */
+  dedicatedModels?: Set<string>;
 }
 
-const CustomScatterTooltip: React.FC<ScatterTooltipProps> = ({ active, payload, activeTab, metric }) => {
+const CustomScatterTooltip: React.FC<ScatterTooltipProps> = ({ active, payload, activeTab, metric, dedicatedModels }) => {
   if (active && payload && payload.length > 0) {
     const item = payload[0];
     const point = item?.payload as ScatterDataPoint | undefined;
@@ -33,6 +36,7 @@ const CustomScatterTooltip: React.FC<ScatterTooltipProps> = ({ active, payload, 
           style={{ margin: 0, fontWeight: "bold" }}
         >{`Model: ${normalizeModelName(point.model)}`}</p>
         <p style={{ margin: 0 }}>{`Provider: ${activeTab === "stt" ? normalizeSTTProviderName(point.provider) : normalizeTTSProviderName(point.provider)}`}</p>
+        {dedicatedModels?.has(point.model) && <DedicatedBadge />}
         <p style={{ margin: 0 }}>{`Avg ${metric}: ${point.x.toFixed(0)}ms`}</p>
         <p style={{ margin: 0 }}>{`Avg WER: ${point.y.toFixed(1)}%`}</p>
         <p style={{ margin: 0 }}>{`Samples: ${point.count}`}</p>

--- a/web/components/dashboard/AccuracyBarSection.tsx
+++ b/web/components/dashboard/AccuracyBarSection.tsx
@@ -274,6 +274,9 @@ const AccuracyBarSection: React.FC = () => {
                   cursor={false}
                   active={isMobile ? false : undefined}
                   isAnimationActive={false}
+                  // Recharts defaults the wrapper to pointer-events: none,
+                  // which would make the dedicated badge's explainer inert.
+                  wrapperStyle={{ pointerEvents: "auto" }}
                 />
                 <Bar
                   dataKey="averageWER"

--- a/web/components/dashboard/AccuracyBarSection.tsx
+++ b/web/components/dashboard/AccuracyBarSection.tsx
@@ -4,6 +4,7 @@
 "use client";
 
 import React, { useCallback, useMemo, useRef } from "react";
+import { Server } from "lucide-react";
 import {
   BarChart,
   Bar,
@@ -53,8 +54,11 @@ const AccuracyBarSection: React.FC = () => {
   const mode = useActiveTab();
   const trackChartHover = useChartHoverTracking("wer_bar");
   const chartWrapRef = useRef<HTMLDivElement>(null);
-  const { iconHandlers: dedicatedIconHandlers, overlay: dedicatedOverlay } =
-    useDedicatedInfoTip(chartWrapRef);
+  const {
+    iconHandlers: dedicatedIconHandlers,
+    overlay: dedicatedOverlay,
+    open: dedicatedTipOpen,
+  } = useDedicatedInfoTip(chartWrapRef);
 
   const handleWERBarClickTracked = (
     data: Parameters<typeof handleWERBarClick>[0]
@@ -93,19 +97,48 @@ const AccuracyBarSection: React.FC = () => {
   }: LabelProps) => {
     const entry = werBarDataWithColors[index];
     if (Number(width) < 28 && !(entry && clickedWERBars.has(entry.model))) return <g />;
+    const cx = Number(x) + Number(width) / 2;
     return (
-      <text
-        x={Number(x) + Number(width) / 2}
-        y={Number(y) - 8}
-        textAnchor="middle"
-        fill={themeColors.label}
-        fillOpacity={entry?.fillOpacity}
-        fontSize={12}
-      >
-        {`${Number(value).toFixed(1)}%`}
-      </text>
+      <g opacity={entry?.fillOpacity}>
+        <text
+          x={cx}
+          y={Number(y) - 8}
+          textAnchor="middle"
+          fill={themeColors.label}
+          fontSize={12}
+        >
+          {`${Number(value).toFixed(1)}%`}
+        </text>
+        {entry && dedicatedModels.has(entry.model) && (
+          // The dedicated marker rides the top of the bar, under the value;
+          // hover or tap opens the explainer.
+          <g
+            {...dedicatedIconHandlers}
+            role="button"
+            tabIndex={0}
+            aria-label="About dedicated inference"
+            style={{ cursor: "help" }}
+          >
+            <Server
+              x={cx - 6}
+              y={Number(y) + 5}
+              size={12}
+              color={themeColors.label}
+              strokeWidth={2.4}
+              aria-hidden
+            />
+            <rect
+              x={cx - 12}
+              y={Number(y) - 1}
+              width={24}
+              height={24}
+              fill="transparent"
+            />
+          </g>
+        )}
+      </g>
     );
-  }, [werBarDataWithColors, clickedWERBars, themeColors.label]);
+  }, [werBarDataWithColors, clickedWERBars, themeColors.label, dedicatedModels, dedicatedIconHandlers]);
 
   // WER-based: never rendered on S2S (no WER metric).
   if (mode === "s2s") return null;
@@ -254,8 +287,6 @@ const AccuracyBarSection: React.FC = () => {
                   tick={
                     <CustomBarChartTick
                       getProviderForModel={getProviderForModel}
-                      dedicatedModels={dedicatedModels}
-                      dedicatedIconHandlers={dedicatedIconHandlers}
                       isMobile={isMobile}
                     />
                   }
@@ -272,7 +303,9 @@ const AccuracyBarSection: React.FC = () => {
                     />
                   }
                   cursor={false}
-                  active={isMobile ? false : undefined}
+                  // The dedicated marker sits inside the plot, so its open
+                  // explainer silences the bar tooltip instead of overlapping it.
+                  active={isMobile || dedicatedTipOpen ? false : undefined}
                   isAnimationActive={false}
                   // Recharts defaults the wrapper to pointer-events: none,
                   // which would make the dedicated badge's explainer inert.
@@ -295,6 +328,8 @@ const AccuracyBarSection: React.FC = () => {
                       key={`wer-cell-${entry.model}`}
                       fill={entry.fill}
                       fillOpacity={entry.fillOpacity}
+                      stroke={dedicatedModels.has(entry.model) ? themeColors.label : undefined}
+                      strokeWidth={dedicatedModels.has(entry.model) ? 1.5 : undefined}
                       role="button"
                       tabIndex={0}
                       aria-label={`${normalizeModelName(entry.model)}: ${entry.averageWER.toFixed(1)}% WER${clickedWERBars.has(entry.model) ? ", selected" : ""}`}

--- a/web/components/dashboard/AccuracyBarSection.tsx
+++ b/web/components/dashboard/AccuracyBarSection.tsx
@@ -3,7 +3,7 @@
 
 "use client";
 
-import React, { useCallback, useMemo } from "react";
+import React, { useCallback, useMemo, useRef } from "react";
 import {
   BarChart,
   Bar,
@@ -20,6 +20,7 @@ import CustomBarTooltip from "@/components/charts/tooltips/BarTooltip";
 import { normalizeModelName } from "@/lib/utils/formatters";
 import CustomBarChartTick from "@/components/charts/CustomBarChartTick";
 import Card from "@/components/shared/Card";
+import { useDedicatedInfoTip } from "@/components/shared/DedicatedInferenceInfo";
 import SectionHeader from "@/components/shared/SectionHeader";
 import WerBarViewToggle from "@/components/dashboard/WerBarViewToggle";
 import { useDashboard } from "@/contexts/DashboardContext";
@@ -39,6 +40,7 @@ const AccuracyBarSection: React.FC = () => {
     availableWerBarViews,
     werBarDataWithColors,
     getProviderForModel,
+    dedicatedModels,
     isMobile,
     clickedWERBars,
     handleWERBarClick,
@@ -50,6 +52,9 @@ const AccuracyBarSection: React.FC = () => {
   const themeColors = useThemeColors();
   const mode = useActiveTab();
   const trackChartHover = useChartHoverTracking("wer_bar");
+  const chartWrapRef = useRef<HTMLDivElement>(null);
+  const { iconHandlers: dedicatedIconHandlers, overlay: dedicatedOverlay } =
+    useDedicatedInfoTip(chartWrapRef);
 
   const handleWERBarClickTracked = (
     data: Parameters<typeof handleWERBarClick>[0]
@@ -182,7 +187,8 @@ const AccuracyBarSection: React.FC = () => {
           </div>
         )}
         <div
-          className={`flex h-96 transition-opacity ${werBarLoading ? "opacity-40" : ""}`}
+          ref={chartWrapRef}
+          className={`relative flex h-96 transition-opacity ${werBarLoading ? "opacity-40" : ""}`}
           onMouseEnter={trackChartHover}
           data-export-frame
         >
@@ -248,6 +254,8 @@ const AccuracyBarSection: React.FC = () => {
                   tick={
                     <CustomBarChartTick
                       getProviderForModel={getProviderForModel}
+                      dedicatedModels={dedicatedModels}
+                      dedicatedIconHandlers={dedicatedIconHandlers}
                       isMobile={isMobile}
                     />
                   }
@@ -257,7 +265,12 @@ const AccuracyBarSection: React.FC = () => {
                 />
                 <YAxis hide />
                 <Tooltip
-                  content={<CustomBarTooltip getProviderForModel={getProviderForModel} />}
+                  content={
+                    <CustomBarTooltip
+                      getProviderForModel={getProviderForModel}
+                      dedicatedModels={dedicatedModels}
+                    />
+                  }
                   cursor={false}
                   active={isMobile ? false : undefined}
                   isAnimationActive={false}
@@ -295,6 +308,7 @@ const AccuracyBarSection: React.FC = () => {
               </BarChart>
             </ResponsiveContainer>
           </div>
+          {dedicatedOverlay}
         </div>
       </Card>
     </div>

--- a/web/components/dashboard/BoxPlotSection.tsx
+++ b/web/components/dashboard/BoxPlotSection.tsx
@@ -22,6 +22,7 @@ const BoxPlotSection: React.FC = () => {
     getBoxPlotData,
     getAvgLatencyMs,
     getProviderForModel,
+    dedicatedModels,
     isMobile,
     activeMetric,
   } = useDashboard();
@@ -70,6 +71,7 @@ const BoxPlotSection: React.FC = () => {
           getModelColor={getModelColor}
           getProviderForModel={getProviderForModel}
           normalizeModelName={normalizeModelName}
+          dedicatedModels={dedicatedModels}
           isMobile={isMobile}
         />
       </Card>

--- a/web/components/dashboard/KeyMetrics.tsx
+++ b/web/components/dashboard/KeyMetrics.tsx
@@ -5,6 +5,7 @@
 
 import React from "react";
 import Card from "@/components/shared/Card";
+import { DedicatedInfoIcon } from "@/components/shared/DedicatedInferenceInfo";
 import { useDashboard } from "@/contexts/DashboardContext";
 
 export interface KeyMetricData {
@@ -13,6 +14,7 @@ export interface KeyMetricData {
   subtitle?: {
     name?: string;
     detail?: string;
+    dedicated?: boolean;
   };
 }
 
@@ -41,7 +43,12 @@ const KeyMetrics: React.FC = () => {
           {metric.subtitle && (
             <div className="text-text-secondary flex flex-col sm:flex-row sm:items-baseline gap-0.5 sm:gap-2">
               {metric.subtitle.name && (
-                <span className="font-medium">{metric.subtitle.name}</span>
+                <span className="inline-flex items-center gap-1.5 font-medium">
+                  {metric.subtitle.name}
+                  {metric.subtitle.dedicated && (
+                    <DedicatedInfoIcon size={14} className="-m-1 p-1" />
+                  )}
+                </span>
               )}
               {metric.subtitle.detail && (
                 <span className="text-sm text-text-tertiary">

--- a/web/components/dashboard/LatencyAccuracySection.tsx
+++ b/web/components/dashboard/LatencyAccuracySection.tsx
@@ -349,6 +349,9 @@ const LatencyAccuracySection: React.FC = () => {
                     />
                   }
                   isAnimationActive={false}
+                  // Recharts defaults the wrapper to pointer-events: none,
+                  // which would make the dedicated badge's explainer inert.
+                  wrapperStyle={{ pointerEvents: "auto" }}
                 />
               )}
               {activePoint && (

--- a/web/components/dashboard/LatencyAccuracySection.tsx
+++ b/web/components/dashboard/LatencyAccuracySection.tsx
@@ -46,7 +46,7 @@ const HUMAN_WER_CEILING = 4;
 const HUMAN_LATENCY_MS = 200;
 
 const LatencyAccuracySection: React.FC = () => {
-  const { selectedModels, getScatterData, activeMetric: metric } = useDashboard();
+  const { selectedModels, getScatterData, activeMetric: metric, dedicatedModels } = useDashboard();
 
   const activeTab = useActiveTab();
   const themeColors = useThemeColors();
@@ -287,6 +287,7 @@ const LatencyAccuracySection: React.FC = () => {
                 }]}
                 activeTab={activeTab}
                 metric={metric}
+                dedicatedModels={dedicatedModels}
               />
             </div>
           )}
@@ -340,7 +341,13 @@ const LatencyAccuracySection: React.FC = () => {
               />
               {!isMobile && (
                 <Tooltip
-                  content={<CustomScatterTooltip activeTab={activeTab} metric={metric} />}
+                  content={
+                    <CustomScatterTooltip
+                      activeTab={activeTab}
+                      metric={metric}
+                      dedicatedModels={dedicatedModels}
+                    />
+                  }
                   isAnimationActive={false}
                 />
               )}

--- a/web/components/dashboard/ModelComparisonSection.tsx
+++ b/web/components/dashboard/ModelComparisonSection.tsx
@@ -23,6 +23,7 @@ const ModelComparisonSection: React.FC = () => {
     activeMetric,
     werDataset,
     werDatasetLoading,
+    dedicatedModels,
   } = useDashboard();
   const trackChartHover = useChartHoverTracking("heatmap");
   const [percentileIdx, setPercentileIdx] = useState(DEFAULT_PERCENTILE_IDX);
@@ -62,6 +63,7 @@ const ModelComparisonSection: React.FC = () => {
         <ModelComparisonTable
           data={data}
           getProviderForModel={getProviderForModel}
+          dedicatedModels={dedicatedModels}
           percentileIdx={percentileIdx}
           onPercentileChange={setPercentileIdx}
           werLabel={werDataset ? datasetLabel(werDataset) : undefined}

--- a/web/components/dashboard/ModelComparisonTable.tsx
+++ b/web/components/dashboard/ModelComparisonTable.tsx
@@ -3,7 +3,9 @@
 
 "use client";
 
-import React, { useCallback, useMemo, useState } from "react";
+import React, { useCallback, useMemo, useRef, useState } from "react";
+import { Server } from "lucide-react";
+import { useDedicatedInfoTip } from "@/components/shared/DedicatedInferenceInfo";
 import { LatencyPercentile, ModelHeatmapData } from "@/types/benchmark.types";
 import { normalizeModelName } from "@/lib/utils/formatters";
 import WerDatasetSelect from "@/components/dashboard/WerDatasetSelect";
@@ -14,6 +16,8 @@ import { POSTHOG_EVENTS } from "@/lib/posthog/events";
 interface ModelComparisonTableProps {
   data: ModelHeatmapData[];
   getProviderForModel: (model: string) => string;
+  /** Dedicated-inference endpoints carry the server marker beside the name. */
+  dedicatedModels?: Set<string>;
   percentileIdx: number;
   onPercentileChange: (idx: number) => void;
   werLabel?: string;
@@ -49,12 +53,18 @@ const COLUMNS: {
 const ModelComparisonTable: React.FC<ModelComparisonTableProps> = ({
   data,
   getProviderForModel,
+  dedicatedModels,
   percentileIdx,
   onPercentileChange,
   werLabel,
   werLoading
 }) => {
   const activeTab = useActiveTab();
+  // The table scrolls horizontally, which clips anchored popovers, so the
+  // dedicated explainer renders as an overlay on this unclipped wrapper.
+  const tableWrapRef = useRef<HTMLDivElement>(null);
+  const { iconHandlers: dedicatedIconHandlers, overlay: dedicatedOverlay } =
+    useDedicatedInfoTip(tableWrapRef);
   const [sort, setSort] = useState<{ key: ColumnKey; direction: "asc" | "desc" }>(
     { key: "latency", direction: "asc" }
   );
@@ -198,7 +208,9 @@ const ModelComparisonTable: React.FC<ModelComparisonTableProps> = ({
         <WerDatasetSelect className="ml-auto" />
       </div>
 
-      <div className="overflow-x-auto">
+      <div ref={tableWrapRef} className="relative">
+        {dedicatedOverlay}
+        <div className="overflow-x-auto">
         <table className="w-full min-w-[560px] border-collapse text-sm">
           <thead>
             <tr className="border-b border-border-primary text-text-tertiary">
@@ -249,8 +261,18 @@ const ModelComparisonTable: React.FC<ModelComparisonTableProps> = ({
                 className="border-b border-border-secondary last:border-b-0 hover:bg-hover-bg"
               >
                 <td className="py-3 pr-4 align-top">
-                  <div className="font-medium text-text-primary">
+                  <div className="flex items-center gap-1.5 font-medium text-text-primary">
                     {normalizeModelName(row.model)}
+                    {dedicatedModels?.has(row.model) && (
+                      <button
+                        type="button"
+                        aria-label="About dedicated inference"
+                        className="flex shrink-0 cursor-help items-center rounded-md p-1 -m-1 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-text-tertiary/40"
+                        {...dedicatedIconHandlers}
+                      >
+                        <Server size={13} aria-hidden />
+                      </button>
+                    )}
                   </div>
                   <div className="text-xs text-text-tertiary">
                     {getProviderForModel(row.model)}
@@ -298,6 +320,7 @@ const ModelComparisonTable: React.FC<ModelComparisonTableProps> = ({
             ))}
           </tbody>
         </table>
+        </div>
       </div>
     </div>
   );

--- a/web/components/dashboard/WerRadarSection.tsx
+++ b/web/components/dashboard/WerRadarSection.tsx
@@ -94,6 +94,7 @@ const WerRadarSection: React.FC = () => {
     selectedModels,
     legendModels,
     toggleLegendModel,
+    dedicatedModels,
     getProviderForModel,
     formatChartLabel,
     availableWerDatasets,
@@ -269,6 +270,7 @@ const WerRadarSection: React.FC = () => {
     value: formatChartLabel(model, getProviderForModel(model)),
     color: getModelColor(model),
     dataKey: model,
+    dedicated: dedicatedModels.has(model),
   }));
   const plottedSet = new Set(plotted);
   const legendHiddenKeys = new Set(

--- a/web/components/layout/FacetFilter.tsx
+++ b/web/components/layout/FacetFilter.tsx
@@ -4,7 +4,8 @@
 "use client";
 
 import React from "react";
-import { ChevronDown } from "lucide-react";
+import { ChevronDown, Server } from "lucide-react";
+import { DEDICATED_INFERENCE, SOURCE_CATEGORY } from "@/lib/utils/facets";
 import { useDashboard } from "@/contexts/DashboardContext";
 import { useSidebarMenu } from "@/contexts/SidebarMenuContext";
 import TimeWindowToggle from "@/components/shared/TimeWindowToggle";
@@ -126,6 +127,10 @@ const FacetFilter: React.FC = () => {
                             : "border-border-primary text-text-secondary hover:border-text-tertiary/50 hover:text-text-primary"
                       }`}
                     >
+                      {group.category === SOURCE_CATEGORY &&
+                        option.value === DEDICATED_INFERENCE && (
+                          <Server size={12} aria-hidden className="shrink-0" />
+                        )}
                       <span>{option.label}</span>
                       <span
                         style={{

--- a/web/components/overview/OverviewLeaderboards.tsx
+++ b/web/components/overview/OverviewLeaderboards.tsx
@@ -103,15 +103,18 @@ const OverviewLeaderboards: React.FC = () => {
         />
       </div>
       <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+        {/* Providers metadata drives the dedicated exclusion, so these cards
+            wait for it (and surface its failure) rather than momentarily
+            ranking a dedicated endpoint as shared. */}
         <LeaderboardCard
           title="Text-to-Speech"
           metricLabel="Time to First Audio"
           windowLabel={windowBadge(ttsQuery.data?.window ?? timeWindow)}
           rows={ttsRows}
           href="/tts"
-          loading={ttsQuery.isLoading}
+          loading={ttsQuery.isLoading || providersQuery.isLoading}
           stale={ttsQuery.isPlaceholderData}
-          error={ttsQuery.isError}
+          error={ttsQuery.isError || providersQuery.isError}
         />
         <LeaderboardCard
           title="Speech-to-Text"
@@ -119,9 +122,9 @@ const OverviewLeaderboards: React.FC = () => {
           windowLabel={windowBadge(sttQuery.data?.window ?? timeWindow)}
           rows={sttRows}
           href="/stt"
-          loading={sttQuery.isLoading}
+          loading={sttQuery.isLoading || providersQuery.isLoading}
           stale={sttQuery.isPlaceholderData}
-          error={sttQuery.isError}
+          error={sttQuery.isError || providersQuery.isError}
         />
       </div>
     </div>

--- a/web/components/overview/OverviewLeaderboards.tsx
+++ b/web/components/overview/OverviewLeaderboards.tsx
@@ -59,30 +59,35 @@ const OverviewLeaderboards: React.FC = () => {
   const windowDataStale = ttsQuery.isPlaceholderData || sttQuery.isPlaceholderData;
 
   // These cards rank shared latency, so dedicated-inference endpoints stay
-  // off them — same rule as the dashboards' latency timeline.
+  // off them — same rule as the dashboards' latency timeline. Rankings are
+  // never built without the provider metadata that classifies endpoints.
   const ttsRows = useMemo(
     () =>
-      toRows(
-        ttsQuery.data?.model_stats,
-        "TTFA",
-        "p50",
-        normalizeTTSProviderName,
-        (value) => `${Math.round(value)} ms`,
-        dedicatedModelKeys(buildTagIndex("TTS", providersQuery.data))
-      ),
+      providersQuery.data
+        ? toRows(
+            ttsQuery.data?.model_stats,
+            "TTFA",
+            "p50",
+            normalizeTTSProviderName,
+            (value) => `${Math.round(value)} ms`,
+            dedicatedModelKeys(buildTagIndex("TTS", providersQuery.data))
+          )
+        : [],
     [ttsQuery.data, providersQuery.data]
   );
 
   const sttRows = useMemo(
     () =>
-      toRows(
-        sttQuery.data?.model_stats,
-        "TTFS",
-        "p50",
-        normalizeSTTProviderName,
-        (value) => `${Math.round(value * 1000)} ms`,
-        dedicatedModelKeys(buildTagIndex("STT", providersQuery.data))
-      ),
+      providersQuery.data
+        ? toRows(
+            sttQuery.data?.model_stats,
+            "TTFS",
+            "p50",
+            normalizeSTTProviderName,
+            (value) => `${Math.round(value * 1000)} ms`,
+            dedicatedModelKeys(buildTagIndex("STT", providersQuery.data))
+          )
+        : [],
     [sttQuery.data, providersQuery.data]
   );
 

--- a/web/components/overview/OverviewLeaderboards.tsx
+++ b/web/components/overview/OverviewLeaderboards.tsx
@@ -4,7 +4,8 @@
 "use client";
 
 import React, { useMemo } from "react";
-import { useAggregatesQuery } from "@/lib/api/queries";
+import { useAggregatesQuery, useProvidersQuery } from "@/lib/api/queries";
+import { buildTagIndex, dedicatedModelKeys } from "@/lib/utils/facets";
 import {
   normalizeModelName,
   normalizeSTTProviderName,
@@ -25,11 +26,16 @@ function toRows(
   metricType: string,
   rankField: "p50" | "avg_value",
   normalizeProvider: (p: string) => string,
-  formatValue: (value: number) => string
+  formatValue: (value: number) => string,
+  exclude: Set<string>
 ): LeaderboardRow[] {
   if (!stats) return [];
   return stats
-    .filter((s) => s.metric_type === metricType)
+    .filter(
+      (s) =>
+        s.metric_type === metricType &&
+        !exclude.has(toModelKey(s.provider, s.model))
+    )
     .sort((a, b) => a[rankField] - b[rankField])
     .slice(0, TOP_N)
     .map((s) => ({
@@ -49,8 +55,11 @@ const OverviewLeaderboards: React.FC = () => {
   // entry with the dashboards whenever the selected windows coincide.
   const ttsQuery = useAggregatesQuery({ benchmark: "TTS", window: timeWindow });
   const sttQuery = useAggregatesQuery({ benchmark: "STT", window: timeWindow });
+  const providersQuery = useProvidersQuery();
   const windowDataStale = ttsQuery.isPlaceholderData || sttQuery.isPlaceholderData;
 
+  // These cards rank shared latency, so dedicated-inference endpoints stay
+  // off them — same rule as the dashboards' latency timeline.
   const ttsRows = useMemo(
     () =>
       toRows(
@@ -58,9 +67,10 @@ const OverviewLeaderboards: React.FC = () => {
         "TTFA",
         "p50",
         normalizeTTSProviderName,
-        (value) => `${Math.round(value)} ms`
+        (value) => `${Math.round(value)} ms`,
+        dedicatedModelKeys(buildTagIndex("TTS", providersQuery.data))
       ),
-    [ttsQuery.data]
+    [ttsQuery.data, providersQuery.data]
   );
 
   const sttRows = useMemo(
@@ -70,9 +80,10 @@ const OverviewLeaderboards: React.FC = () => {
         "TTFS",
         "p50",
         normalizeSTTProviderName,
-        (value) => `${Math.round(value * 1000)} ms`
+        (value) => `${Math.round(value * 1000)} ms`,
+        dedicatedModelKeys(buildTagIndex("STT", providersQuery.data))
       ),
-    [sttQuery.data]
+    [sttQuery.data, providersQuery.data]
   );
 
   return (

--- a/web/components/shared/DedicatedInferenceInfo.tsx
+++ b/web/components/shared/DedicatedInferenceInfo.tsx
@@ -1,0 +1,132 @@
+// Copyright 2026 The Coval Benchmarks Authors
+// SPDX-License-Identifier: Apache-2.0
+
+"use client";
+
+import React, { useCallback, useEffect, useMemo, useState, type RefObject } from "react";
+import { Server } from "lucide-react";
+import MetricInfo from "@/components/shared/MetricInfo";
+import {
+  DEDICATED_INFERENCE_BLURB,
+  DEDICATED_INFERENCE_LABEL,
+} from "@/lib/utils/facets";
+
+/** The one explainer body every dedicated-inference popover shows. */
+const CONTENT = (
+  <>
+    <span className="font-semibold">{DEDICATED_INFERENCE_LABEL}.</span>{" "}
+    {DEDICATED_INFERENCE_BLURB}
+  </>
+);
+
+/**
+ * Server-icon button that opens the explainer on hover/tap. The panel opens
+ * upward (inside the z-[2] Cards only upward overlap paints above later
+ * siblings) and becomes a viewport-fixed sheet below sm, where legend/scroll
+ * containers would clip an anchored panel.
+ */
+export const DedicatedInfoIcon: React.FC<{ size?: number; className?: string }> = ({
+  size = 13,
+  className = "",
+}) => (
+  <MetricInfo
+    content={CONTENT}
+    align="left"
+    panelClassName="bottom-full mb-1.5 w-60 max-sm:fixed max-sm:inset-x-4 max-sm:bottom-auto max-sm:top-24 max-sm:mb-0 max-sm:w-auto"
+  >
+    <button
+      type="button"
+      aria-label="About dedicated inference"
+      className={`flex shrink-0 cursor-help items-center justify-center rounded-md text-text-tertiary transition-colors hover:bg-surface-toggle-inactive hover:text-text-primary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-text-tertiary/40 ${className}`}
+    >
+      <Server size={size} aria-hidden />
+    </button>
+  </MetricInfo>
+);
+
+/** "Dedicated inference" tooltip row; hover/tap opens the explainer. */
+export const DedicatedBadge: React.FC = () => (
+  <MetricInfo
+    content={CONTENT}
+    align="left"
+    panelClassName="top-full mt-1.5 w-60 whitespace-normal"
+  >
+    <button
+      type="button"
+      className="flex cursor-help items-center gap-1 border-0 bg-transparent p-0 text-[color:var(--color-text-on-tooltip-secondary)]"
+      style={{ font: "inherit" }}
+    >
+      <Server size={10} aria-hidden /> {DEDICATED_INFERENCE_LABEL}
+    </button>
+  </MetricInfo>
+);
+
+/**
+ * Explainer for dedicated icons rendered inside scroll or SVG containers,
+ * where an anchored panel would clip. The trigger spreads `iconHandlers`; the
+ * host renders `overlay` inside the unclipped position:relative ancestor that
+ * `containerRef` points at, and calls `dismiss` before repositioning content.
+ */
+export function useDedicatedInfoTip(containerRef: RefObject<HTMLElement | null>) {
+  const [tip, setTip] = useState<{ x: number; yTop: number; pinned: boolean } | null>(
+    null
+  );
+  const dismiss = useCallback(() => setTip(null), []);
+
+  useEffect(() => {
+    if (!tip?.pinned) return;
+    const onKey = (e: KeyboardEvent) => e.key === "Escape" && dismiss();
+    document.addEventListener("click", dismiss);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("click", dismiss);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [tip, dismiss]);
+
+  // Identity-stable so hosts can safely reference the handlers from redraw
+  // effects (BoxPlot's d3 pass) without re-triggering them every render.
+  const iconHandlers = useMemo(() => {
+    const anchor = (e: React.MouseEvent) => {
+      const box = containerRef.current?.getBoundingClientRect();
+      const icon = (e.currentTarget as Element).getBoundingClientRect();
+      return {
+        x: icon.x + icon.width / 2 - (box?.x ?? 0),
+        yTop: icon.y - (box?.y ?? 0),
+      };
+    };
+    // Anchors are computed before setTip: React may replay updater functions
+    // on a later render, when the event's currentTarget is already null.
+    return {
+      onMouseEnter: (e: React.MouseEvent) => {
+        const a = anchor(e);
+        setTip((t) => (t?.pinned ? t : { ...a, pinned: false }));
+      },
+      onMouseLeave: () => setTip((t) => (t?.pinned ? t : null)),
+      onClick: (e: React.MouseEvent) => {
+        e.stopPropagation();
+        const a = anchor(e);
+        setTip((t) => (t?.pinned ? null : { ...a, pinned: true }));
+      },
+    };
+  }, [containerRef]);
+
+  const width = containerRef.current?.clientWidth ?? 0;
+  const overlay = tip ? (
+    <div
+      role="tooltip"
+      onClick={(e) => e.stopPropagation()}
+      className="absolute z-10 w-60 rounded-lg border border-border-secondary bg-surface-tooltip px-3 py-2 text-left text-xs font-normal leading-snug text-[var(--color-text-on-tooltip)] shadow-md"
+      style={{
+        left: width ? Math.min(Math.max(tip.x, 122), width - 122) : tip.x,
+        top: tip.yTop,
+        transform: "translate(-50%, calc(-100% - 8px))",
+        pointerEvents: tip.pinned ? "auto" : "none",
+      }}
+    >
+      {CONTENT}
+    </div>
+  ) : null;
+
+  return { iconHandlers, overlay, dismiss };
+}

--- a/web/components/shared/DedicatedInferenceInfo.tsx
+++ b/web/components/shared/DedicatedInferenceInfo.tsx
@@ -73,23 +73,28 @@ export function useDedicatedInfoTip(containerRef: RefObject<HTMLElement | null>)
   );
   const dismiss = useCallback(() => setTip(null), []);
 
+  // A pinned overlay is pixel-anchored, so scrolling anywhere (page or the
+  // chart's own scroller) would detach it from its icon — dismiss instead,
+  // matching the pinned chart tooltips.
   useEffect(() => {
     if (!tip?.pinned) return;
     const onKey = (e: KeyboardEvent) => e.key === "Escape" && dismiss();
     document.addEventListener("click", dismiss);
     document.addEventListener("keydown", onKey);
+    document.addEventListener("scroll", dismiss, { capture: true, passive: true });
     return () => {
       document.removeEventListener("click", dismiss);
       document.removeEventListener("keydown", onKey);
+      document.removeEventListener("scroll", dismiss, { capture: true });
     };
   }, [tip, dismiss]);
 
   // Identity-stable so hosts can safely reference the handlers from redraw
   // effects (BoxPlot's d3 pass) without re-triggering them every render.
   const iconHandlers = useMemo(() => {
-    const anchor = (e: React.MouseEvent) => {
+    const anchor = (e: React.SyntheticEvent) => {
       const box = containerRef.current?.getBoundingClientRect();
-      const icon = (e.currentTarget as Element).getBoundingClientRect();
+      const icon = e.currentTarget.getBoundingClientRect();
       return {
         x: icon.x + icon.width / 2 - (box?.x ?? 0),
         yTop: icon.y - (box?.y ?? 0),
@@ -97,16 +102,23 @@ export function useDedicatedInfoTip(containerRef: RefObject<HTMLElement | null>)
     };
     // Anchors are computed before setTip: React may replay updater functions
     // on a later render, when the event's currentTarget is already null.
+    const togglePin = (e: React.SyntheticEvent) => {
+      e.stopPropagation();
+      const a = anchor(e);
+      setTip((t) => (t?.pinned ? null : { ...a, pinned: true }));
+    };
     return {
       onMouseEnter: (e: React.MouseEvent) => {
         const a = anchor(e);
         setTip((t) => (t?.pinned ? t : { ...a, pinned: false }));
       },
       onMouseLeave: () => setTip((t) => (t?.pinned ? t : null)),
-      onClick: (e: React.MouseEvent) => {
-        e.stopPropagation();
-        const a = anchor(e);
-        setTip((t) => (t?.pinned ? null : { ...a, pinned: true }));
+      onClick: togglePin,
+      // SVG triggers have no native button semantics, so Enter/Space pin here.
+      onKeyDown: (e: React.KeyboardEvent) => {
+        if (e.key !== "Enter" && e.key !== " ") return;
+        e.preventDefault();
+        togglePin(e);
       },
     };
   }, [containerRef]);

--- a/web/components/shared/DedicatedInferenceInfo.tsx
+++ b/web/components/shared/DedicatedInferenceInfo.tsx
@@ -140,5 +140,7 @@ export function useDedicatedInfoTip(containerRef: RefObject<HTMLElement | null>)
     </div>
   ) : null;
 
-  return { iconHandlers, overlay, dismiss };
+  // `open` lets hosts silence competing hover chrome (e.g. a recharts
+  // tooltip) while the explainer is showing.
+  return { iconHandlers, overlay, dismiss, open: tip !== null };
 }

--- a/web/components/visualizations/TimelineChart.tsx
+++ b/web/components/visualizations/TimelineChart.tsx
@@ -16,6 +16,7 @@ import {
   type TooltipPayloadEntry,
 } from "recharts";
 import { getModelColor } from "@/lib/utils/colors";
+import { DedicatedInfoIcon } from "@/components/shared/DedicatedInferenceInfo";
 import { formatDate, formatTime, getLocalTimeZoneAbbr } from "@/lib/utils/formatters";
 import { metricDescriptions } from "@/lib/config/metrics";
 import {
@@ -41,6 +42,7 @@ interface LegendEntry {
   value: string;
   color?: string;
   dataKey?: string;
+  dedicated?: boolean;
 }
 
 // Custom legend: names are rendered in black (recharts colors them per-series
@@ -85,8 +87,10 @@ export const TimelineLegend: React.FC<{
         id={panelId}
         className={`grid transition-[grid-template-rows,visibility] duration-300 ease-in-out ${open ? "visible grid-rows-[1fr]" : "invisible grid-rows-[0fr]"} sm:visible sm:grid-rows-[1fr]`}
       >
-        <div className="overflow-hidden">
-          <ul className="grid auto-cols-max grid-flow-col grid-rows-4 gap-x-4 overflow-x-auto px-2 pb-1 sm:block sm:columns-3 sm:gap-x-6 sm:pt-5 lg:columns-4">
+        {/* The clip only matters for the mobile collapse animation and scroll;
+            above sm it would cut off the dedicated-inference popover. */}
+        <div className="overflow-hidden sm:overflow-visible">
+          <ul className="grid auto-cols-max grid-flow-col grid-rows-4 gap-x-4 overflow-x-auto px-2 pb-1 sm:block sm:columns-3 sm:gap-x-6 sm:overflow-visible sm:pt-5 lg:columns-4">
     {[...(payload ?? [])]
       .sort(
         (a, b) =>
@@ -100,13 +104,13 @@ export const TimelineLegend: React.FC<{
           <li
             key={entry.dataKey ?? entry.value}
             data-dimmed={dimmed || undefined}
-            className="mb-0.5 break-inside-avoid"
+            className="mb-0.5 flex items-start break-inside-avoid"
           >
             <button
               type="button"
               aria-pressed={!hidden}
               onClick={() => onToggle?.(entry.dataKey ?? "")}
-              className={`flex min-h-11 w-full items-center gap-1.5 rounded-md px-1 py-2 text-left text-xs leading-tight text-text-primary transition-opacity hover:bg-surface-toggle-inactive focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-text-tertiary/40 sm:min-h-0 sm:items-start sm:py-1${dimmed ? " opacity-35" : ""}`}
+              className={`flex min-h-11 flex-1 items-center gap-1.5 rounded-md px-1 py-2 text-left text-xs leading-tight text-text-primary transition-opacity hover:bg-surface-toggle-inactive focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-text-tertiary/40 sm:min-h-0 sm:items-start sm:py-1${dimmed ? " opacity-35" : ""}`}
             >
               <span
                 className="mt-0.5 inline-block w-3 h-3 shrink-0 rounded-[2px]"
@@ -115,6 +119,9 @@ export const TimelineLegend: React.FC<{
               />
               <span>{entry.value}</span>
             </button>
+            {entry.dedicated && (
+              <DedicatedInfoIcon className="min-h-11 w-8 sm:min-h-0 sm:py-1" />
+            )}
           </li>
         );
       })}
@@ -256,6 +263,8 @@ const TimelineChart: React.FC = () => {
     dataTimeWindow,
     legendModels,
     toggleLegendModel,
+    dedicatedModels,
+    selectedModels,
     page,
     requestS2SPlay,
   } = useDashboard();
@@ -372,9 +381,12 @@ const TimelineChart: React.FC = () => {
   }, [isMobile, hasMobileMeasurement, updateMobileScrub]);
 
   const themeColors = useThemeColors();
+  // Dedicated endpoints chart in Latency Variation, never as timeline lines —
+  // a line here would read as the shared fleet's polling cadence.
   const modelsWithData = useMemo(
-    () => getModelsWithTimelineData(metric),
-    [getModelsWithTimelineData, metric]
+    () =>
+      getModelsWithTimelineData(metric).filter((m) => !dedicatedModels.has(m)),
+    [getModelsWithTimelineData, metric, dedicatedModels]
   );
   const windowedTimelineData = useMemo(
     () => getWindowedTimelineData(metric),
@@ -780,7 +792,10 @@ const TimelineChart: React.FC = () => {
     value: formatChartLabel(model, getProviderForModel(model)),
     color: getModelColor(model),
     dataKey: `${model}_value`,
+    dedicated: dedicatedModels.has(model),
   }));
+  // Dedicated models never draw here, so their entry reads permanently
+  // "off" — they live on every other chart instead.
   const plottedKeys = new Set(modelsWithData);
   const legendHiddenKeys = new Set<string>();
   for (const model of legendModelList) {
@@ -1064,6 +1079,13 @@ const TimelineChart: React.FC = () => {
               )}
             </LineChart>
           </ResponsiveContainer>
+          {modelsWithData.length === 0 &&
+            selectedModels.some((m) => dedicatedModels.has(m)) && (
+              <p className="pointer-events-none absolute inset-0 z-10 flex items-center justify-center px-8 text-center text-sm text-text-secondary">
+                Dedicated inference endpoints do not show on the shared
+                timeline. See Latency Variation below.
+              </p>
+            )}
           <div
             ref={boxRef}
             className="pointer-events-none absolute z-10 hidden rounded-sm border border-dashed border-text-secondary/50 bg-text-secondary/10"

--- a/web/hooks/useDashboardState.tsx
+++ b/web/hooks/useDashboardState.tsx
@@ -136,7 +136,9 @@ export function useDashboardState(page: "tts" | "stt" | "s2s") {
   // so window-derived rendering must follow the data, not the toggle.
   const dataTimeWindow = aggregatesQuery.data?.window ?? timeWindow;
   const windowDataStale = aggregatesQuery.isPlaceholderData;
-  const loadError = aggregatesQuery.isError;
+  // Providers metadata classifies dedicated endpoints; without it the charts
+  // would misrepresent them as shared, so its failure is a load failure too.
+  const loadError = aggregatesQuery.isError || providersQuery.isError;
 
   const modelStats = useMemo<ModelStats[]>(
     () => aggregatesQuery.data?.model_stats ?? [],

--- a/web/hooks/useDashboardState.tsx
+++ b/web/hooks/useDashboardState.tsx
@@ -19,11 +19,13 @@ import { buildModelsByProvider } from "@/lib/utils/modelsFromResults";
 import {
   buildFacetGroups,
   buildTagIndex,
+  dedicatedModelKeys,
   filterModelsByFacets,
   getTagCategories,
   hasAnySelection,
   restrictToModelKeys,
   toggleFacetValue,
+  DEDICATED_INFERENCE_BLURB,
   MODEL_FACET_CATEGORY,
   MODEL_EXCLUDE_CATEGORY,
   type FacetSelection,
@@ -157,6 +159,7 @@ export function useDashboardState(page: "tts" | "stt" | "s2s") {
     () => getTagCategories(providersQuery.data),
     [providersQuery.data]
   );
+  const dedicatedModels = useMemo(() => dedicatedModelKeys(tagIndex), [tagIndex]);
 
   // Facets are driven only by models that actually have data to plot. A
   // catalogue model without stats (e.g. a batch-only or not-yet-benchmarked
@@ -510,10 +513,14 @@ export function useDashboardState(page: "tts" | "stt" | "s2s") {
     [dataBackedByProvider, tagIndex, selectedFacets, tagCategories, normalizeProviderName]
   );
 
+  const hasDedicatedBoxes = selectedModels.some((m) => dedicatedModels.has(m));
   const boxPlotDescription = {
     short: `Distribution of ${latencyLabel} values across all runs`,
     detailed:
-      "Narrow distributions indicate reliable, predictable response times, while wide distributions show erratic performance that may frustrate users despite good average speeds. A model with moderate median latency and tight distribution often provides superior user experience compared to a faster median model with high variability.",
+      "Narrow distributions indicate reliable, predictable response times, while wide distributions show erratic performance that may frustrate users despite good average speeds. A model with moderate median latency and tight distribution often provides superior user experience compared to a faster median model with high variability." +
+      (hasDedicatedBoxes
+        ? ` Endpoints marked with a server icon use dedicated inference. ${DEDICATED_INFERENCE_BLURB}`
+        : ""),
   };
 
   const werDescription = page === "tts"
@@ -551,6 +558,7 @@ export function useDashboardState(page: "tts" | "stt" | "s2s") {
           detail: fastestPrimary.fastestProvider
             ? normalizeProviderName(fastestPrimary.fastestProvider)
             : undefined,
+          dedicated: dedicatedModels.has(fastestPrimary.fastestModel),
         }
       : undefined,
   };
@@ -568,6 +576,7 @@ export function useDashboardState(page: "tts" | "stt" | "s2s") {
                 detail: lowestWERProvider
                   ? normalizeProviderName(lowestWERProvider)
                   : undefined,
+                dedicated: dedicatedModels.has(lowestWERModel),
               }
             : undefined,
         };
@@ -630,6 +639,7 @@ export function useDashboardState(page: "tts" | "stt" | "s2s") {
     hasActiveFacets,
     legendModels,
     toggleLegendModel,
+    dedicatedModels,
 
     // UI state
     isMobile,

--- a/web/lib/utils/facets.test.ts
+++ b/web/lib/utils/facets.test.ts
@@ -7,10 +7,13 @@ import type { ModelsByProvider } from "../../types/benchmark.types";
 import {
   buildFacetGroups,
   buildTagIndex,
+  dedicatedModelKeys,
   filterModelsByFacets,
   getTagCategories,
   restrictToModelKeys,
   toggleFacetValue,
+  DEDICATED_INFERENCE,
+  SOURCE_CATEGORY,
 } from "./facets";
 
 // Four STT models: every mode is streaming (single-value → not a facet); host
@@ -157,5 +160,30 @@ describe("toggleFacetValue", () => {
     const added = toggleFacetValue({}, "host", "openai");
     expect(added).toEqual({ host: ["openai"] });
     expect(toggleFacetValue(added, "host", "openai")).toEqual({});
+  });
+});
+
+// Dedicated endpoints filter like any other model; the timeline excludes them
+// at the chart level using this helper's keys.
+describe("dedicatedModelKeys", () => {
+  it("collects the composite keys carrying the dedicated-inference source tag", () => {
+    const DEDICATED = tag(SOURCE_CATEGORY, DEDICATED_INFERENCE, "Dedicated inference");
+    const providers = {
+      stt: [
+        {
+          provider: "deepgram",
+          models: [{ model: "nova-2", tags: [TYPE, host("deepgram"), MULTI] }],
+        },
+        {
+          provider: "baseten",
+          models: [{ model: "whisper-large-v3", tags: [TYPE, host("baseten"), DEDICATED] }],
+        },
+      ],
+      tts: [],
+      tag_categories: TAG_CATEGORIES,
+    } as unknown as ProvidersApiResponse;
+    expect(dedicatedModelKeys(buildTagIndex("STT", providers))).toEqual(
+      new Set(["baseten:whisper-large-v3"])
+    );
   });
 });

--- a/web/lib/utils/facets.test.ts
+++ b/web/lib/utils/facets.test.ts
@@ -163,6 +163,69 @@ describe("toggleFacetValue", () => {
   });
 });
 
+// A dedicated endpoint never mints a new filter group on its own; Source (the
+// shared/dedicated axis itself) is the one category it may bring to life.
+describe("buildFacetGroups dedicated gating", () => {
+  const CATS: TagCategoryOut[] = [
+    ...TAG_CATEGORIES,
+    { category: "source", label: "Source", provider_valued: false },
+    { category: "licensing", label: "Licensing", provider_valued: false },
+  ];
+  const OFFICIAL = tag("source", "official-api", "Official API");
+  const DEDICATED = tag("source", DEDICATED_INFERENCE, "Dedicated inference");
+  const PROP = tag("licensing", "proprietary", "Proprietary");
+  const OPEN = tag("licensing", "open-weight", "Open-weight");
+  const providers = (sharedOpenWeight: boolean) =>
+    ({
+      stt: [
+        {
+          provider: "deepgram",
+          models: [{ model: "nova-2", tags: [TYPE, host("deepgram"), OFFICIAL, PROP] }],
+        },
+        {
+          provider: "openai",
+          models: [
+            {
+              model: "gpt-4o-transcribe",
+              tags: [TYPE, host("openai"), OFFICIAL, sharedOpenWeight ? OPEN : PROP],
+            },
+          ],
+        },
+        {
+          provider: "baseten",
+          models: [
+            { model: "whisper-large-v3", tags: [TYPE, host("baseten"), DEDICATED, OPEN] },
+          ],
+        },
+      ],
+      tts: [],
+      tag_categories: CATS,
+    }) as unknown as ProvidersApiResponse;
+  const all: ModelsByProvider = {
+    deepgram: ["deepgram:nova-2"],
+    openai: ["openai:gpt-4o-transcribe"],
+    baseten: ["baseten:whisper-large-v3"],
+  };
+  const groupsFor = (sharedOpenWeight: boolean) =>
+    buildFacetGroups(
+      all,
+      buildTagIndex("STT", providers(sharedOpenWeight)),
+      {},
+      CATS,
+      (s) => s
+    ).map((g) => g.category);
+
+  it("shows Source but not a licensing split only a dedicated endpoint carries", () => {
+    const categories = groupsFor(false);
+    expect(categories).toContain("source");
+    expect(categories).not.toContain("licensing");
+  });
+
+  it("shows licensing once shared endpoints split on it", () => {
+    expect(groupsFor(true)).toContain("licensing");
+  });
+});
+
 // Dedicated endpoints filter like any other model; the timeline excludes them
 // at the chart level using this helper's keys.
 describe("dedicatedModelKeys", () => {

--- a/web/lib/utils/facets.ts
+++ b/web/lib/utils/facets.ts
@@ -31,7 +31,7 @@ export const DEDICATED_INFERENCE_LABEL = "Dedicated inference";
 // Balanced by design: Baseten flagged fairness, so the shared side's
 // advantages are stated alongside dedicated's. One string, every surface.
 export const DEDICATED_INFERENCE_BLURB =
-  "Shared endpoints serve every customer from the same servers, so latency reflects real multi-tenant load. Dedicated endpoints run on hardware reserved for one customer, so the two aren't ranked directly against each other.";
+  "Shared endpoints serve many customers on the same infrastructure, while dedicated endpoints run on hardware reserved for a single customer. Since these represent different deployment configurations, we distinguish them separately.";
 
 /** Whether a model's tags mark it as a dedicated-inference endpoint. */
 export const isDedicated = (tags: ModelTagOut[]): boolean =>

--- a/web/lib/utils/facets.ts
+++ b/web/lib/utils/facets.ts
@@ -19,6 +19,33 @@ export type FacetSelection = Record<string, string[]>;
 export const MODEL_FACET_CATEGORY = "model";
 export const MODEL_EXCLUDE_CATEGORY = "model_hidden";
 
+/**
+ * Source facet identifiers, mirroring runner registries/tags.py. Shared by the
+ * filter chips, the shared-graph exclusion below, and the dedicated-endpoint
+ * chart styling.
+ */
+export const SOURCE_CATEGORY = "source";
+export const DEDICATED_INFERENCE = "dedicated-inference";
+
+export const DEDICATED_INFERENCE_LABEL = "Dedicated inference";
+// Balanced by design: Baseten flagged fairness, so the shared side's
+// advantages are stated alongside dedicated's. One string, every surface.
+export const DEDICATED_INFERENCE_BLURB =
+  "These endpoints run on capacity reserved for a single customer, so they appear on every chart except the shared latency timeline. Dedicated capacity typically delivers steadier response times, while shared endpoints serve many tenants, scale instantly, and reflect the out-of-the-box experience most users get.";
+
+/** Whether a model's tags mark it as a dedicated-inference endpoint. */
+export const isDedicated = (tags: ModelTagOut[]): boolean =>
+  tags.some((t) => t.category === SOURCE_CATEGORY && t.value === DEDICATED_INFERENCE);
+
+/** The composite keys of every dedicated-inference model in the catalogue. */
+export function dedicatedModelKeys(tagIndex: Map<string, ModelTagOut[]>): Set<string> {
+  const keys = new Set<string>();
+  for (const [key, tags] of tagIndex) {
+    if (isDedicated(tags)) keys.add(key);
+  }
+  return keys;
+}
+
 export interface FacetOption {
   value: string;
   label: string;
@@ -106,6 +133,8 @@ export function restrictToModelKeys(
  * Narrow modelsByProvider to the models passing the current facet selection.
  * Legend model picks broaden an active tag filter (union) but stand alone
  * when no tag category is selected; excludes hide single models from either.
+ * Dedicated-inference endpoints pass like any other model — only the latency
+ * timeline excludes them, at the chart level.
  */
 export function filterModelsByFacets(
   modelsByProvider: ModelsByProvider,

--- a/web/lib/utils/facets.ts
+++ b/web/lib/utils/facets.ts
@@ -31,7 +31,7 @@ export const DEDICATED_INFERENCE_LABEL = "Dedicated inference";
 // Balanced by design: Baseten flagged fairness, so the shared side's
 // advantages are stated alongside dedicated's. One string, every surface.
 export const DEDICATED_INFERENCE_BLURB =
-  "These endpoints run on capacity reserved for a single customer, so they appear on every chart except the shared latency timeline. Dedicated capacity typically delivers steadier response times, while shared endpoints serve many tenants, scale instantly, and reflect the out-of-the-box experience most users get.";
+  "Shared endpoints serve every customer from the same servers, so latency reflects real multi-tenant load. Dedicated endpoints run on hardware reserved for one customer, so the two aren't ranked directly against each other.";
 
 /** Whether a model's tags mark it as a dedicated-inference endpoint. */
 export const isDedicated = (tags: ModelTagOut[]): boolean =>

--- a/web/lib/utils/facets.ts
+++ b/web/lib/utils/facets.ts
@@ -188,12 +188,20 @@ export function buildFacetGroups(
 
   for (const { category, label, provider_valued } of tagCategories) {
     const valueLabels = new Map<string, string>();
+    const sharedValues = new Set<string>();
     for (const key of visibleKeys) {
-      for (const tag of tagIndex.get(key) ?? []) {
-        if (tag.category === category) valueLabels.set(tag.value, tag.label);
+      const tags = tagIndex.get(key) ?? [];
+      for (const tag of tags) {
+        if (tag.category !== category) continue;
+        valueLabels.set(tag.value, tag.label);
+        if (!isDedicated(tags)) sharedValues.add(tag.value);
       }
     }
-    if (valueLabels.size < 2) continue;
+    // A dedicated endpoint never mints a new filter group on its own: aside
+    // from Source (the shared/dedicated axis itself), a category becomes a
+    // facet only once shared endpoints hold two distinct values for it.
+    if ((category === SOURCE_CATEGORY ? valueLabels.size : sharedValues.size) < 2)
+      continue;
 
     const others: FacetSelection = { ...tagSelected, [category]: [] };
     const options: FacetOption[] = [...valueLabels.entries()]

--- a/web/types/chart.types.ts
+++ b/web/types/chart.types.ts
@@ -10,5 +10,7 @@ export interface BoxPlotProps {
   getModelColor: (model: string) => string;
   getProviderForModel: (model: string) => string;
   normalizeModelName: (model: string) => string;
+  /** Dedicated-inference endpoints: dashed box border + server icon by the label. */
+  dedicatedModels?: Set<string>;
   isMobile?: boolean;
 }


### PR DESCRIPTION
## What this does
<img width="800" height="706" alt="image" src="https://github.com/user-attachments/assets/45dc882e-f87d-4a28-909f-e71b4bd0f322" />

Builds the frontend framework for representing dedicated-inference endpoints (vs. shared multi-tenant APIs), driven entirely by the existing `dedicated-inference` source tag. No endpoint names are hardcoded and no synthetic data ships — the treatment is inert until the API serves a dedicated model enabled with result rows, then everything below lights up automatically.

## Behavior

| Surface | Dedicated endpoints |
|---|---|
| Latency timeline (TTFA/TTFS lines) | **Never drawn.** Legend entry stays listed but permanently dimmed, with the server icon. If a filter selects only dedicated models, the empty chart explains itself. |
| Overview homepage top-5 (latency rankings) | **Excluded** — same shared-latency rule as the timeline. |
| Latency Variation (box plot) | Shown, with a **dashed box border** and the icon under the label. |
| WER bars, Model Comparison, Latency vs Accuracy, KPI tiles | Shown normally, marked with the server icon (labels, rows, tooltips). |

Every icon/badge opens the same explainer on hover (desktop) and tap (mobile), from one shared component + copy string ([DedicatedInferenceInfo.tsx](../blob/HEAD/web/components/shared/DedicatedInferenceInfo.tsx)). The copy states both sides' advantages — dedicated capacity is steadier; shared endpoints scale instantly and reflect the out-of-the-box experience — per Base10's fairness flag. The Latency Variation "About this benchmark" text gains the same explanation whenever a dedicated box is on screen.

Icons inside scroll/SVG containers (WER ticks, comparison table, box plot axis) use a small overlay hook instead of the anchored popover, which ancestor `overflow` clipping would cut off.

## Auto-sync (verified against the live API)

Prod already serves the Baseten catalogue entries (`disabled: true`, full tags) — this PR was developed against a dev-only fixture that simulated the flip, then removed. When the endpoint profile is assigned and runs start:

1. `/v1/providers` returns the entry enabled → facet chips (Source, Licensing) appear automatically.
2. First completed run writes `model_stats` + `series` rows → the model becomes data-backed and appears on every surface above with the full treatment.
3. Until both are true, nothing renders and nothing breaks. Early-access status limits all of this to internal-key sessions, as usual.

Note: this needs to be **deployed before the status flip** — the current prod frontend would draw a dedicated endpoint as a normal timeline line.

## Tests

`pnpm typecheck` / `lint` / `test` green (79 tests, including new coverage for the dedicated-key helper). Verified in-browser on desktop and mobile viewports: filters, legend toggles, all seven explainer triggers, pinned tooltips, and both dashboards plus the homepage with the fixture removed (dev now matches prod exactly).

## Flagged, not changed

Enabling the first open-weight TTS model will also make the sidebar's **Licensing** facet group appear on /tts — that's the existing tag-driven sidebar (STT already shows this group in prod today), not new code. Follow-ups from Ansel's feedback (violin plots, expanded filter presets) are intentionally out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds tag-driven support for dedicated-inference endpoints across the benchmark frontend. The main changes are:

- Excludes dedicated endpoints from shared-latency timelines and overview rankings.
- Adds dedicated markers and explainers to charts, tables, tooltips, filters, and metrics.
- Adds metadata-aware loading and error handling for endpoint classification.
- Adds facet helpers and tests for dedicated endpoint tags.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- Provider metadata now gates dashboard and leaderboard rendering.
- The previously reported classification failures are no longer reachable through normal loading or query-error states.
- No blocking issues were found in the updated code.

<sub>Reviews (7): Last reviewed commit: ["Reword the dedicated-inference explainer..."](https://github.com/coval-ai/benchmarks/commit/5c60d546e4f426f2fd0c4789261ff968a307f0c1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46452497)</sub>

<!-- /greptile_comment -->