### PR TITLE
Add S2S instruction-adherence metric to the fetch

### DIFF
--- a/runner/src/coval_bench/config.py
+++ b/runner/src/coval_bench/config.py
@@ -125,6 +125,14 @@ class Settings(BaseSettings):
     coval_s2s_openai_agent_id: str | None = None
     coval_s2s_gemini_agent_id: str | None = None
     coval_s2s_xai_agent_id: str | None = None
+    # The S2S instruction-adherence metric id (opaque, not secret). Optional: the
+    # fetch pulls its per-conversation scores only when set, so latency still
+    # ingests without it.
+    coval_s2s_instruction_metric_id: str | None = None
+    # Restrict the fetch to one Coval test set (the multi-turn set). Without it,
+    # other sims on the same agents (e.g. the single-turn set) would be ingested
+    # and pooled into the same provider. Opaque id, not secret.
+    coval_s2s_test_set_id: str | None = None
     # Fetch grid, in seconds; kept in sync with the s2s-fetch-trigger cron in
     # benchmark-infra (override via S2S_FETCH_PERIOD_SECONDS). Default = 3h.
     s2s_fetch_period_seconds: int = Field(default=10_800, gt=0)

--- a/runner/src/coval_bench/db/writer.py
+++ b/runner/src/coval_bench/db/writer.py
@@ -270,6 +270,33 @@ class RunWriter:
             await conn.commit()
         return row is not None
 
+    async def coval_metric_ingested(
+        self, *, provider: str, coval_run_id: str, metric_type: str
+    ) -> bool:
+        """True if a succeeded/partial run already holds this Coval run's ``metric_type`` rows.
+
+        Metric-aware counterpart of :meth:`coval_run_ingested`: lets the fetch
+        backfill one metric (e.g. instruction) onto a run whose other metric
+        (latency) already landed, instead of skipping the whole run.
+        """
+        sql = """
+            SELECT 1
+            FROM benchmarks_v2.results r
+            JOIN benchmarks_v2.runs rn ON rn.id = r.run_id
+            WHERE r.provider = %s
+              AND r.benchmark = 'S2S'
+              AND r.metric_type = %s
+              AND split_part(r.audio_filename, '/', 1) = %s
+              AND rn.status IN ('succeeded', 'partial')
+            LIMIT 1
+        """
+        async with self._pool.connection() as conn:
+            async with conn.cursor() as cur:
+                await cur.execute(sql, (provider, metric_type, coval_run_id))
+                row = await cur.fetchone()
+            await conn.commit()
+        return row is not None
+
     async def refresh_stats_matviews(self) -> None:
         """Concurrently refresh the per-window stats materialized views.
 

--- a/runner/src/coval_bench/registries/metrics.py
+++ b/runner/src/coval_bench/registries/metrics.py
@@ -27,6 +27,7 @@ class Metric(StrEnum):
     RTF = "RTF"
     AUDIO_TO_FINAL = "AudioToFinal"
     V2V = "V2V"
+    INSTRUCTION_FOLLOWING = "InstructionFollowing"
 
 
 class MetricDirection(StrEnum):
@@ -96,6 +97,15 @@ METRIC_SPECS: dict[Metric, MetricSpec] = {
         units="milliseconds",
         direction=MetricDirection.LOWER_IS_BETTER,
         decimals=0,
+        benchmarks=frozenset({Benchmark.S2S}),
+    ),
+    Metric.INSTRUCTION_FOLLOWING: MetricSpec(
+        display_name="Instruction Adherence",
+        # Per-conversation pass stored as 100.0 (YES) / 0.0 (NO); the aggregate
+        # average is the pass rate as a percentage, like WER.
+        units="percent",
+        direction=MetricDirection.HIGHER_IS_BETTER,
+        decimals=1,
         benchmarks=frozenset({Benchmark.S2S}),
     ),
 }

--- a/runner/src/coval_bench/s2s/fetch_v2v.py
+++ b/runner/src/coval_bench/s2s/fetch_v2v.py
@@ -303,6 +303,8 @@ async def _ingest_run(
     instruction_metric_id: str | None = None,
     dataset_id: str = DATASET_ID,
     dataset_sha256: str = "",
+    want_latency: bool = True,
+    want_instruction: bool = True,
     runner_sha: str,
     period_seconds: int,
 ) -> RunStatus | None:
@@ -339,20 +341,11 @@ async def _ingest_run(
             return None
         values = cast("list[dict[str, Any]]", metric.get("values", []))
 
-        scheduled_at = _bucket_start(coval_run.create_time or datetime.now(tz=UTC), period_seconds)
-        run_row = await writer.start_run(
-            runner_sha=runner_sha,
-            dataset_id=dataset_id,
-            dataset_sha256=dataset_sha256 or _dataset_sha256(),
-            scheduled_at=scheduled_at,
-        )
-        if run_row.id is None:  # pragma: no cover -- start_run always returns an id
-            raise RuntimeError("start_run returned a run with no id")
-        run_pk = run_row.id
-
-        rows = _result_rows(values, run_pk=run_pk, coval_run_id=coval_run.run_id, spec=spec)
-        instruction_rows: list[Result] = []
-        if instruction_metric_id:
+        # Decide instruction writability up front (pure) so a backfill with
+        # nothing to add creates no run row and stays retryable.
+        instr_values: list[dict[str, Any]] = []
+        write_instruction = False
+        if want_instruction and instruction_metric_id:
             instr = metrics.get(instruction_metric_id)
             if instr is None:
                 # Latency still lands; instruction stays retryable on a later scan.
@@ -376,19 +369,44 @@ async def _ingest_run(
                     )
                 else:
                     try:
-                        instruction_rows = _instruction_rows(
-                            instr_values, run_pk=run_pk, coval_run_id=coval_run.run_id, spec=spec
-                        )
+                        for v in instr_values:
+                            _instruction_verdict(v.get("value"))
+                        write_instruction = True
                     except InvalidInstructionVerdict as exc:
                         # Judge-contract violation: discard instruction for the
                         # whole run (keep latency); retryable on a later scan.
-                        instruction_rows = []
                         logger.warning(
                             "instruction_verdict_invalid",
                             provider=spec.provider,
                             coval_run_id=coval_run.run_id,
                             error=str(exc),
                         )
+
+        if not want_latency and not write_instruction:
+            # Backfill with nothing to add; leave it retryable, write no run row.
+            return None
+
+        scheduled_at = _bucket_start(coval_run.create_time or datetime.now(tz=UTC), period_seconds)
+        run_row = await writer.start_run(
+            runner_sha=runner_sha,
+            dataset_id=dataset_id,
+            dataset_sha256=dataset_sha256 or _dataset_sha256(),
+            scheduled_at=scheduled_at,
+        )
+        if run_row.id is None:  # pragma: no cover -- start_run always returns an id
+            raise RuntimeError("start_run returned a run with no id")
+        run_pk = run_row.id
+
+        rows = (
+            _result_rows(values, run_pk=run_pk, coval_run_id=coval_run.run_id, spec=spec)
+            if want_latency
+            else []
+        )
+        instruction_rows = (
+            _instruction_rows(instr_values, run_pk=run_pk, coval_run_id=coval_run.run_id, spec=spec)
+            if write_instruction
+            else []
+        )
         all_rows = rows + instruction_rows
         if all_rows:
             await writer.record_results(all_rows)
@@ -401,12 +419,17 @@ async def _ingest_run(
             instruction=len(instruction_rows),
             success=sum(1 for r in rows if r.status is ResultStatus.SUCCESS),
         )
-        failed = sum(1 for r in rows if r.status is ResultStatus.FAILED)
-        if not rows or failed == len(rows):
-            status = RunStatus.FAILED
-        elif failed:
-            status = RunStatus.PARTIAL
+        if want_latency:
+            # Reliability is the latency signal (instruction lag never fails the run).
+            failed = sum(1 for r in rows if r.status is ResultStatus.FAILED)
+            if not rows or failed == len(rows):
+                status = RunStatus.FAILED
+            elif failed:
+                status = RunStatus.PARTIAL
+            else:
+                status = RunStatus.SUCCEEDED
         else:
+            # Instruction-only backfill onto an already-ingested run.
             status = RunStatus.SUCCEEDED
         await writer.finish_run(run_pk, status=status)
         if status in (RunStatus.SUCCEEDED, RunStatus.PARTIAL):
@@ -490,15 +513,24 @@ async def _fetch_one_provider(
                     error_status=coval_run.error_status,
                 )
                 continue
-            if await writer.coval_run_ingested(
-                provider=spec.provider, coval_run_id=coval_run.run_id
-            ):
-                logger.info(
-                    "run_already_ingested", provider=spec.provider, coval_run_id=coval_run.run_id
-                )
+            latency_done = await writer.coval_metric_ingested(
+                provider=spec.provider, coval_run_id=coval_run.run_id, metric_type=Metric.V2V
+            )
+            instruction_done = instruction_metric_id is None or await writer.coval_metric_ingested(
+                provider=spec.provider,
+                coval_run_id=coval_run.run_id,
+                metric_type=Metric.INSTRUCTION_FOLLOWING,
+            )
+            # A run whose latency already landed is fresh data + an eligible
+            # sample even if we still owe it an instruction backfill.
+            if latency_done:
                 note_sample_candidate(coval_run)
                 if not data_seen:
                     data_seen, newest_data_at = True, coval_run.create_time
+            if latency_done and instruction_done:
+                logger.info(
+                    "run_already_ingested", provider=spec.provider, coval_run_id=coval_run.run_id
+                )
                 continue
             status = await _ingest_run(
                 client,
@@ -509,6 +541,8 @@ async def _fetch_one_provider(
                 instruction_metric_id=instruction_metric_id,
                 dataset_id=dataset_id,
                 dataset_sha256=dataset_sha256,
+                want_latency=not latency_done,
+                want_instruction=instruction_metric_id is not None and not instruction_done,
                 runner_sha=runner_sha,
                 period_seconds=period_seconds,
             )

--- a/runner/src/coval_bench/s2s/fetch_v2v.py
+++ b/runner/src/coval_bench/s2s/fetch_v2v.py
@@ -34,6 +34,9 @@ logger = structlog.get_logger("coval_bench.s2s.fetch_v2v")
 
 # The dataset the S2S sims run against (matches the packaged manifest name).
 DATASET_ID = "s2s-v1"
+# Multi-turn runs have no local manifest -- they're keyed to the Coval test set --
+# so they use a distinct dataset id and never pool with single-turn s2s-v1.
+DATASET_ID_MULTITURN = "s2s-multiturn-v1"
 
 # Ingest window: how far back one tick looks for not-yet-ingested runs, and
 # how many list results that scan reads. Two periods (with a one-day floor)
@@ -91,6 +94,19 @@ def _dataset_sha256() -> str:
     except Exception:
         logger.warning("dataset_sha256_failed", dataset_id=DATASET_ID, exc_info=True)
         return "unknown"
+
+
+def _dataset_identity(test_set_id: str | None) -> tuple[str, str]:
+    """Dataset id + provenance for the fetched rows.
+
+    Multi-turn runs are keyed to their Coval test set, not the single-turn SLURP
+    manifest, so they get their own dataset id (never pooling with s2s-v1) and
+    record the test-set id as provenance. Without a test set (legacy latency-only
+    mode) the rows stay under the packaged s2s-v1 manifest.
+    """
+    if test_set_id:
+        return DATASET_ID_MULTITURN, test_set_id
+    return DATASET_ID, _dataset_sha256()
 
 
 def _parse_time(raw: object) -> datetime | None:
@@ -196,20 +212,49 @@ def _result_rows(
     return rows
 
 
-def _instruction_verdict(raw: object) -> bool | None:
-    """Classify a binary judge's per-conversation value into pass/fail/excluded.
+class InvalidInstructionVerdict(Exception):
+    """A run's instruction metric returned a value outside YES/NO/UNKNOWN."""
 
-    YES -> True (pass), explicit UNKNOWN -> None (excluded from the pool),
-    everything else -- NO, or a missing/unexpected value -> False (counts
-    against the rate). A binary judge's output type is string, so the run
-    endpoint returns the verdict verbatim; there is no numeric form to handle.
+
+def _instruction_verdict(raw: object) -> bool | None:
+    """Classify a binary judge verdict: YES -> True, NO -> False, UNKNOWN -> None.
+
+    UNKNOWN (None) is excluded from the pass rate. A binary judge only ever emits
+    canonical YES/NO/UNKNOWN, so anything else violates the contract and raises,
+    rather than being silently scored as a miss.
     """
-    verdict = raw.strip().upper() if isinstance(raw, str) else None
-    if verdict == "YES":
+    normalized = raw.strip().upper() if isinstance(raw, str) else raw
+    if normalized == "YES":
         return True
-    if verdict == "UNKNOWN":
+    if normalized == "NO":
+        return False
+    if normalized == "UNKNOWN":
         return None
-    return False
+    raise InvalidInstructionVerdict(f"unexpected instruction verdict: {raw!r}")
+
+
+def _instruction_id_mismatch(
+    latency_values: list[dict[str, Any]], instruction_values: list[dict[str, Any]]
+) -> dict[str, object] | None:
+    """None if instruction's sim-id set matches latency exactly; else the diff.
+
+    Equal counts can still be different conversations, so compare the id sets and
+    reject duplicates. A mismatch means the pass rate would not be over the same
+    population as latency, so instruction is skipped for the run.
+    """
+    lat_ids = [v.get("simulation_output_id") for v in latency_values]
+    ins_ids = [v.get("simulation_output_id") for v in instruction_values]
+    lat_set, ins_set = set(lat_ids), set(ins_ids)
+    duplicate = len(ins_ids) != len(ins_set)
+    missing = sorted(str(x) for x in lat_set - ins_set)
+    extra = sorted(str(x) for x in ins_set - lat_set)
+    if not duplicate and not missing and not extra:
+        return None
+    return {
+        "missing_instruction_ids": missing,
+        "extra_instruction_ids": extra,
+        "duplicate_instruction_ids": duplicate,
+    }
 
 
 def _instruction_rows(
@@ -219,29 +264,17 @@ def _instruction_rows(
     coval_run_id: str,
     spec: AgentSpec,
 ) -> list[Result]:
-    """Map a run's per-conversation instruction verdicts to Result rows.
+    """Map a run's per-conversation verdicts to instruction Result rows.
 
-    Pass is stored as 100.0 and fail as 0.0 (percent); an explicit UNKNOWN
-    becomes a FAILED row and drops out of the pool. The aggregate mean is then
-    the pass rate = YES / (total - UNKNOWN).
+    YES -> 100.0, NO -> 0.0 (both SUCCESS, both in the pool); UNKNOWN produces no
+    row (excluded), so the aggregate mean is YES / (YES + NO). Raises
+    InvalidInstructionVerdict on any value outside the contract.
     """
     rows: list[Result] = []
     for i, v in enumerate(values):
-        raw = v.get("value")
-        verdict = _instruction_verdict(raw)
-        if verdict is None:
-            metric_value: float | None = None
-            status = ResultStatus.FAILED
-        else:
-            metric_value = 100.0 if verdict else 0.0
-            status = ResultStatus.SUCCESS
-            if not verdict and not (isinstance(raw, str) and raw.strip().upper() == "NO"):
-                logger.warning(
-                    "instruction_unexpected_value",
-                    provider=spec.provider,
-                    coval_run_id=coval_run_id,
-                    value=raw,
-                )
+        verdict = _instruction_verdict(v.get("value"))
+        if verdict is None:  # UNKNOWN: excluded from the pool, no row written
+            continue
         sim_id = v.get("simulation_output_id")
         clip_key = f"{coval_run_id}/{sim_id}" if sim_id else f"{coval_run_id}/{i}"
         rows.append(
@@ -252,9 +285,9 @@ def _instruction_rows(
                 benchmark=Benchmark.S2S,
                 metric_type=Metric.INSTRUCTION_FOLLOWING,
                 metric_units="percent",
-                metric_value=metric_value,
+                metric_value=100.0 if verdict else 0.0,
                 audio_filename=clip_key,
-                status=status,
+                status=ResultStatus.SUCCESS,
             )
         )
     return rows
@@ -268,6 +301,8 @@ async def _ingest_run(
     coval_run: CovalRun,
     metric_id: str,
     instruction_metric_id: str | None = None,
+    dataset_id: str = DATASET_ID,
+    dataset_sha256: str = "",
     runner_sha: str,
     period_seconds: int,
 ) -> RunStatus | None:
@@ -307,8 +342,8 @@ async def _ingest_run(
         scheduled_at = _bucket_start(coval_run.create_time or datetime.now(tz=UTC), period_seconds)
         run_row = await writer.start_run(
             runner_sha=runner_sha,
-            dataset_id=DATASET_ID,
-            dataset_sha256=_dataset_sha256(),
+            dataset_id=dataset_id,
+            dataset_sha256=dataset_sha256 or _dataset_sha256(),
             scheduled_at=scheduled_at,
         )
         if run_row.id is None:  # pragma: no cover -- start_run always returns an id
@@ -320,6 +355,7 @@ async def _ingest_run(
         if instruction_metric_id:
             instr = metrics.get(instruction_metric_id)
             if instr is None:
+                # Latency still lands; instruction stays retryable on a later scan.
                 logger.warning(
                     "instruction_metric_absent",
                     provider=spec.provider,
@@ -328,20 +364,31 @@ async def _ingest_run(
                 )
             else:
                 instr_values = cast("list[dict[str, Any]]", instr.get("values", []))
-                instruction_rows = _instruction_rows(
-                    instr_values, run_pk=run_pk, coval_run_id=coval_run.run_id, spec=spec
-                )
-                if len(instruction_rows) != len(rows):
-                    # Denominator should be the same conversation set as latency;
-                    # a mismatch means Coval graded a different count, so the pass
-                    # rate is no longer over the full sample.
+                mismatch = _instruction_id_mismatch(values, instr_values)
+                if mismatch is not None:
+                    # Different conversation population than latency -> skip
+                    # instruction (keep latency) so the rate stays comparable.
                     logger.warning(
-                        "instruction_count_mismatch",
+                        "instruction_id_mismatch",
                         provider=spec.provider,
                         coval_run_id=coval_run.run_id,
-                        latency=len(rows),
-                        instruction=len(instruction_rows),
+                        **mismatch,
                     )
+                else:
+                    try:
+                        instruction_rows = _instruction_rows(
+                            instr_values, run_pk=run_pk, coval_run_id=coval_run.run_id, spec=spec
+                        )
+                    except InvalidInstructionVerdict as exc:
+                        # Judge-contract violation: discard instruction for the
+                        # whole run (keep latency); retryable on a later scan.
+                        instruction_rows = []
+                        logger.warning(
+                            "instruction_verdict_invalid",
+                            provider=spec.provider,
+                            coval_run_id=coval_run.run_id,
+                            error=str(exc),
+                        )
         all_rows = rows + instruction_rows
         if all_rows:
             await writer.record_results(all_rows)
@@ -430,6 +477,7 @@ async def _fetch_one_provider(
         runs = await recent_completed_runs(
             client, agent_id, period_seconds=period_seconds, test_set_id=test_set_id
         )
+        dataset_id, dataset_sha256 = _dataset_identity(test_set_id)
 
         data_seen = False
         newest_data_at: datetime | None = None
@@ -459,6 +507,8 @@ async def _fetch_one_provider(
                 coval_run=coval_run,
                 metric_id=metric_id,
                 instruction_metric_id=instruction_metric_id,
+                dataset_id=dataset_id,
+                dataset_sha256=dataset_sha256,
                 runner_sha=runner_sha,
                 period_seconds=period_seconds,
             )
@@ -514,8 +564,24 @@ async def fetch_and_write_v2v(settings: Settings | None = None) -> dict[str, Run
     metric_id = settings.coval_s2s_latency_metric_id
     if not metric_id:
         raise RuntimeError("coval_s2s_latency_metric_id is not set")
-    instruction_metric_id = settings.coval_s2s_instruction_metric_id
-    test_set_id = settings.coval_s2s_test_set_id
+    # Instruction ingestion and the test-set filter go together: instruction
+    # without the filter would pool other sims on the same agents into the S2S
+    # rows. Reject a blank (misconfigured) value and require the pair; both
+    # absent keeps the legacy latency-only behavior.
+    raw_instr = settings.coval_s2s_instruction_metric_id
+    raw_test_set = settings.coval_s2s_test_set_id
+    if (raw_instr is not None and not raw_instr.strip()) or (
+        raw_test_set is not None and not raw_test_set.strip()
+    ):
+        raise RuntimeError(
+            "coval_s2s_instruction_metric_id / coval_s2s_test_set_id must not be blank"
+        )
+    instruction_metric_id = raw_instr or None
+    test_set_id = raw_test_set or None
+    if bool(instruction_metric_id) != bool(test_set_id):
+        raise RuntimeError(
+            "coval_s2s_instruction_metric_id and coval_s2s_test_set_id must be set together"
+        )
 
     async with _client(settings) as client, lifespan_pool(settings) as pool:
         writer = RunWriter(pool)

--- a/runner/src/coval_bench/s2s/fetch_v2v.py
+++ b/runner/src/coval_bench/s2s/fetch_v2v.py
@@ -115,19 +115,28 @@ def _bucket_start(at: datetime, period_seconds: int) -> datetime:
 
 
 async def recent_completed_runs(
-    client: httpx.AsyncClient, agent_id: str, *, period_seconds: int
+    client: httpx.AsyncClient,
+    agent_id: str,
+    *,
+    period_seconds: int,
+    test_set_id: str | None = None,
 ) -> list[CovalRun]:
     """Completed Coval runs for one agent within the ingest window, newest first.
 
     List returns the summary view newest-first; filter by agent_id + status
-    (tags are not filterable). Runs without a parseable create_time are kept:
-    better to ingest with a fetch-time slot than to drop data.
+    (tags are not filterable). ``test_set_id`` narrows to one test set so other
+    sims on the same agents (e.g. the single-turn set) are not ingested. Runs
+    without a parseable create_time are kept: better to ingest with a fetch-time
+    slot than to drop data.
     """
     window_seconds = max(WINDOW_FLOOR_SECONDS, 2 * period_seconds)
+    filt = f'status="COMPLETED" AND agent_id="{agent_id}"'
+    if test_set_id:
+        filt += f' AND test_set_id="{test_set_id}"'
     resp = await client.get(
         "/runs",
         params={
-            "filter": f'status="COMPLETED" AND agent_id="{agent_id}"',
+            "filter": filt,
             "order_by": "-create_time",
             "page_size": WINDOW_PAGE_SIZE,
         },
@@ -187,6 +196,70 @@ def _result_rows(
     return rows
 
 
+def _instruction_verdict(raw: object) -> bool | None:
+    """Classify a binary judge's per-conversation value into pass/fail/excluded.
+
+    YES -> True (pass), explicit UNKNOWN -> None (excluded from the pool),
+    everything else -- NO, or a missing/unexpected value -> False (counts
+    against the rate). A binary judge's output type is string, so the run
+    endpoint returns the verdict verbatim; there is no numeric form to handle.
+    """
+    verdict = raw.strip().upper() if isinstance(raw, str) else None
+    if verdict == "YES":
+        return True
+    if verdict == "UNKNOWN":
+        return None
+    return False
+
+
+def _instruction_rows(
+    values: list[dict[str, Any]],
+    *,
+    run_pk: int,
+    coval_run_id: str,
+    spec: AgentSpec,
+) -> list[Result]:
+    """Map a run's per-conversation instruction verdicts to Result rows.
+
+    Pass is stored as 100.0 and fail as 0.0 (percent); an explicit UNKNOWN
+    becomes a FAILED row and drops out of the pool. The aggregate mean is then
+    the pass rate = YES / (total - UNKNOWN).
+    """
+    rows: list[Result] = []
+    for i, v in enumerate(values):
+        raw = v.get("value")
+        verdict = _instruction_verdict(raw)
+        if verdict is None:
+            metric_value: float | None = None
+            status = ResultStatus.FAILED
+        else:
+            metric_value = 100.0 if verdict else 0.0
+            status = ResultStatus.SUCCESS
+            if not verdict and not (isinstance(raw, str) and raw.strip().upper() == "NO"):
+                logger.warning(
+                    "instruction_unexpected_value",
+                    provider=spec.provider,
+                    coval_run_id=coval_run_id,
+                    value=raw,
+                )
+        sim_id = v.get("simulation_output_id")
+        clip_key = f"{coval_run_id}/{sim_id}" if sim_id else f"{coval_run_id}/{i}"
+        rows.append(
+            Result(
+                run_id=run_pk,
+                provider=spec.provider,
+                model=spec.model,
+                benchmark=Benchmark.S2S,
+                metric_type=Metric.INSTRUCTION_FOLLOWING,
+                metric_units="percent",
+                metric_value=metric_value,
+                audio_filename=clip_key,
+                status=status,
+            )
+        )
+    return rows
+
+
 async def _ingest_run(
     client: httpx.AsyncClient,
     writer: RunWriter,
@@ -194,6 +267,7 @@ async def _ingest_run(
     spec: AgentSpec,
     coval_run: CovalRun,
     metric_id: str,
+    instruction_metric_id: str | None = None,
     runner_sha: str,
     period_seconds: int,
 ) -> RunStatus | None:
@@ -242,14 +316,42 @@ async def _ingest_run(
         run_pk = run_row.id
 
         rows = _result_rows(values, run_pk=run_pk, coval_run_id=coval_run.run_id, spec=spec)
-        if rows:
-            await writer.record_results(rows)
+        instruction_rows: list[Result] = []
+        if instruction_metric_id:
+            instr = metrics.get(instruction_metric_id)
+            if instr is None:
+                logger.warning(
+                    "instruction_metric_absent",
+                    provider=spec.provider,
+                    coval_run_id=coval_run.run_id,
+                    metric_id=instruction_metric_id,
+                )
+            else:
+                instr_values = cast("list[dict[str, Any]]", instr.get("values", []))
+                instruction_rows = _instruction_rows(
+                    instr_values, run_pk=run_pk, coval_run_id=coval_run.run_id, spec=spec
+                )
+                if len(instruction_rows) != len(rows):
+                    # Denominator should be the same conversation set as latency;
+                    # a mismatch means Coval graded a different count, so the pass
+                    # rate is no longer over the full sample.
+                    logger.warning(
+                        "instruction_count_mismatch",
+                        provider=spec.provider,
+                        coval_run_id=coval_run.run_id,
+                        latency=len(rows),
+                        instruction=len(instruction_rows),
+                    )
+        all_rows = rows + instruction_rows
+        if all_rows:
+            await writer.record_results(all_rows)
         logger.info(
             "fetched_clips",
             provider=spec.provider,
             coval_run_id=coval_run.run_id,
             slot=str(scheduled_at),
             clips=len(rows),
+            instruction=len(instruction_rows),
             success=sum(1 for r in rows if r.status is ResultStatus.SUCCESS),
         )
         failed = sum(1 for r in rows if r.status is ResultStatus.FAILED)
@@ -290,6 +392,8 @@ async def _fetch_one_provider(
     spec: AgentSpec,
     agent_id: str,
     metric_id: str,
+    instruction_metric_id: str | None = None,
+    test_set_id: str | None = None,
     runner_sha: str,
     period_seconds: int,
     stale_grace_seconds: int,
@@ -323,7 +427,9 @@ async def _fetch_one_provider(
         )
 
     try:
-        runs = await recent_completed_runs(client, agent_id, period_seconds=period_seconds)
+        runs = await recent_completed_runs(
+            client, agent_id, period_seconds=period_seconds, test_set_id=test_set_id
+        )
 
         data_seen = False
         newest_data_at: datetime | None = None
@@ -352,6 +458,7 @@ async def _fetch_one_provider(
                 spec=spec,
                 coval_run=coval_run,
                 metric_id=metric_id,
+                instruction_metric_id=instruction_metric_id,
                 runner_sha=runner_sha,
                 period_seconds=period_seconds,
             )
@@ -407,6 +514,8 @@ async def fetch_and_write_v2v(settings: Settings | None = None) -> dict[str, Run
     metric_id = settings.coval_s2s_latency_metric_id
     if not metric_id:
         raise RuntimeError("coval_s2s_latency_metric_id is not set")
+    instruction_metric_id = settings.coval_s2s_instruction_metric_id
+    test_set_id = settings.coval_s2s_test_set_id
 
     async with _client(settings) as client, lifespan_pool(settings) as pool:
         writer = RunWriter(pool)
@@ -424,6 +533,8 @@ async def fetch_and_write_v2v(settings: Settings | None = None) -> dict[str, Run
                 spec=spec,
                 agent_id=agent_id,
                 metric_id=metric_id,
+                instruction_metric_id=instruction_metric_id,
+                test_set_id=test_set_id,
                 runner_sha=settings.runner_sha,
                 period_seconds=settings.s2s_fetch_period_seconds,
                 stale_grace_seconds=settings.s2s_stale_grace_seconds,

--- a/runner/tests/unit/test_metric_registry.py
+++ b/runner/tests/unit/test_metric_registry.py
@@ -22,6 +22,7 @@ def test_metric_values_match_stored_strings() -> None:
         "RTF",
         "AudioToFinal",
         "V2V",
+        "InstructionFollowing",
     }
 
 
@@ -35,6 +36,7 @@ def test_units_match_stored_strings() -> None:
         Metric.RTF: "ratio",
         Metric.AUDIO_TO_FINAL: "seconds",
         Metric.V2V: "milliseconds",
+        Metric.INSTRUCTION_FOLLOWING: "percent",
     }
     assert {m: spec.units for m, spec in METRIC_SPECS.items()} == expected
 
@@ -46,5 +48,12 @@ def test_benchmark_coverage() -> None:
         assert METRIC_SPECS[metric].benchmarks == {Benchmark.STT}
 
 
-def test_all_current_metrics_are_lower_is_better() -> None:
-    assert all(spec.direction is MetricDirection.LOWER_IS_BETTER for spec in METRIC_SPECS.values())
+def test_metric_directions() -> None:
+    # Instruction adherence is a pass rate: higher is better. Every other metric
+    # is a latency/error measure: lower is better.
+    assert METRIC_SPECS[Metric.INSTRUCTION_FOLLOWING].direction is MetricDirection.HIGHER_IS_BETTER
+    assert all(
+        spec.direction is MetricDirection.LOWER_IS_BETTER
+        for m, spec in METRIC_SPECS.items()
+        if m is not Metric.INSTRUCTION_FOLLOWING
+    )

--- a/runner/tests/unit/test_s2s_fetch.py
+++ b/runner/tests/unit/test_s2s_fetch.py
@@ -78,6 +78,7 @@ def _stub_writer() -> MagicMock:
         )
     )
     writer.coval_run_ingested = AsyncMock(return_value=False)
+    writer.coval_metric_ingested = AsyncMock(return_value=False)
     writer.record_results = AsyncMock()
     writer.finish_run = AsyncMock()
     writer.refresh_bucket = AsyncMock()
@@ -278,7 +279,7 @@ async def test_fetch_one_provider_ingests_every_new_run() -> None:
 @pytest.mark.asyncio
 async def test_fetch_one_provider_noop_when_fresh() -> None:
     writer = _stub_writer()
-    writer.coval_run_ingested = AsyncMock(return_value=True)
+    writer.coval_metric_ingested = AsyncMock(return_value=True)
     list_json = _list_json({"run_id": "R1", "create_time": _iso(timedelta(hours=2))})
     async with _fake_client(list_json, {}) as client:
         status, ingested = await _fetch(client, writer)
@@ -290,7 +291,7 @@ async def test_fetch_one_provider_noop_when_fresh() -> None:
 async def test_fetch_one_provider_stale_fails() -> None:
     # Newest usable run is older than period + grace (4.5h) -> stale.
     writer = _stub_writer()
-    writer.coval_run_ingested = AsyncMock(return_value=True)
+    writer.coval_metric_ingested = AsyncMock(return_value=True)
     list_json = _list_json({"run_id": "R1", "create_time": _iso(timedelta(hours=6))})
     async with _fake_client(list_json, {}) as client:
         status, ingested = await _fetch(client, writer)
@@ -319,7 +320,7 @@ async def test_fetch_one_provider_stale_wins_over_backfill() -> None:
 async def test_fetch_one_provider_unknown_age_is_stale() -> None:
     # A usable run without a parseable create_time is no evidence of freshness.
     writer = _stub_writer()
-    writer.coval_run_ingested = AsyncMock(return_value=True)
+    writer.coval_metric_ingested = AsyncMock(return_value=True)
     list_json = _list_json({"run_id": "R1"})
     async with _fake_client(list_json, {}) as client:
         status, ingested = await _fetch(client, writer)
@@ -389,7 +390,7 @@ async def test_fetch_and_write_v2v_noop_skips_matview_refresh(
     )
 
     writer = _stub_writer()
-    writer.coval_run_ingested = AsyncMock(return_value=True)  # nothing new this tick
+    writer.coval_metric_ingested = AsyncMock(return_value=True)  # nothing new this tick
     list_json = _list_json({"run_id": "R1", "create_time": _iso(timedelta(hours=1))})
     client = _fake_client(list_json, {})
 
@@ -412,7 +413,7 @@ async def test_already_ingested_run_still_becomes_sample_candidate() -> None:
     from coval_bench.s2s.samples import SampleRun
 
     writer = _stub_writer()
-    writer.coval_run_ingested = AsyncMock(return_value=True)
+    writer.coval_metric_ingested = AsyncMock(return_value=True)
     list_json = _list_json(
         {"run_id": "R1", "create_time": _iso(timedelta(hours=1)), "error_status": "SUCCESS"}
     )
@@ -464,7 +465,7 @@ async def test_stale_provider_lends_no_sample_candidate() -> None:
     from coval_bench.s2s.samples import SampleRun
 
     writer = _stub_writer()
-    writer.coval_run_ingested = AsyncMock(return_value=True)
+    writer.coval_metric_ingested = AsyncMock(return_value=True)
     list_json = _list_json(
         {"run_id": "R1", "create_time": _iso(timedelta(hours=5)), "error_status": "SUCCESS"}
     )
@@ -647,6 +648,54 @@ async def test_fetch_and_write_requires_id_pair(monkeypatch: pytest.MonkeyPatch)
     )
     with pytest.raises(RuntimeError, match="set together"):
         await fetch_v2v.fetch_and_write_v2v(settings)
+
+
+@pytest.mark.asyncio
+async def test_ingest_run_backfill_instruction_only() -> None:
+    # Latency already ingested (want_latency=False): backfill only instruction.
+    writer = _stub_writer()
+    latency = [{"simulation_output_id": "s0", "value": 0.5}]
+    instruction = [{"simulation_output_id": "s0", "value": "YES"}]
+    async with _fake_client({}, _multi_metric_run(latency, instruction)) as client:
+        status = await fetch_v2v._ingest_run(
+            client,
+            writer,
+            spec=SPEC,
+            coval_run=CovalRun(run_id="R1", create_time=None, error_status=None),
+            metric_id="MID",
+            instruction_metric_id="IID",
+            want_latency=False,
+            want_instruction=True,
+            runner_sha="test",
+            period_seconds=10_800,
+        )
+    assert status is RunStatus.SUCCEEDED
+    rows = writer.record_results.await_args.args[0]
+    assert len(rows) == 1
+    assert all(r.metric_type == Metric.INSTRUCTION_FOLLOWING for r in rows)  # no latency rewrite
+
+
+@pytest.mark.asyncio
+async def test_ingest_run_backfill_instruction_absent_is_noop() -> None:
+    # Backfill wanted but the instruction metric isn't on the run yet -> retryable no-op.
+    writer = _stub_writer()
+    latency = [{"simulation_output_id": "s0", "value": 0.5}]
+    async with _fake_client({}, _run_json(latency)) as client:
+        status = await fetch_v2v._ingest_run(
+            client,
+            writer,
+            spec=SPEC,
+            coval_run=CovalRun(run_id="R1", create_time=None, error_status=None),
+            metric_id="MID",
+            instruction_metric_id="IID",
+            want_latency=False,
+            want_instruction=True,
+            runner_sha="test",
+            period_seconds=10_800,
+        )
+    assert status is None  # nothing to write -> no run row, stays retryable
+    writer.start_run.assert_not_awaited()
+    writer.record_results.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/runner/tests/unit/test_s2s_fetch.py
+++ b/runner/tests/unit/test_s2s_fetch.py
@@ -500,16 +500,42 @@ def test_instruction_rows_maps_verdicts() -> None:
         {"simulation_output_id": "s3", "value": "UNKNOWN"},
     ]
     rows = fetch_v2v._instruction_rows(values, run_pk=1, coval_run_id="R1", spec=SPEC)
-    assert [r.metric_value for r in rows] == [100.0, 0.0, None]
-    assert [r.status for r in rows] == [
-        ResultStatus.SUCCESS,  # YES pass
-        ResultStatus.SUCCESS,  # NO counts against the rate
-        ResultStatus.FAILED,  # UNKNOWN excluded from the pool
-    ]
-    assert [r.audio_filename for r in rows] == ["R1/s1", "R1/s2", "R1/s3"]
+    # UNKNOWN produces no row (excluded from the pool); only YES/NO are written.
+    assert [r.metric_value for r in rows] == [100.0, 0.0]
+    assert [r.status for r in rows] == [ResultStatus.SUCCESS, ResultStatus.SUCCESS]
+    assert [r.audio_filename for r in rows] == ["R1/s1", "R1/s2"]
     assert all(
         r.metric_type == Metric.INSTRUCTION_FOLLOWING and r.metric_units == "percent" for r in rows
     )
+
+
+def test_instruction_verdict_raises_on_unexpected() -> None:
+    with pytest.raises(fetch_v2v.InvalidInstructionVerdict):
+        fetch_v2v._instruction_verdict("MAYBE")
+    with pytest.raises(fetch_v2v.InvalidInstructionVerdict):
+        fetch_v2v._instruction_verdict(None)
+
+
+def test_instruction_id_mismatch() -> None:
+    lat = [{"simulation_output_id": "s1"}, {"simulation_output_id": "s2"}]
+    assert fetch_v2v._instruction_id_mismatch(lat, lat) is None
+    # different population (same count) -> diff reported
+    ins = [{"simulation_output_id": "s1"}, {"simulation_output_id": "s3"}]
+    diff = fetch_v2v._instruction_id_mismatch(lat, ins)
+    assert diff == {
+        "missing_instruction_ids": ["s2"],
+        "extra_instruction_ids": ["s3"],
+        "duplicate_instruction_ids": False,
+    }
+    # duplicate id
+    dup = [{"simulation_output_id": "s1"}, {"simulation_output_id": "s1"}]
+    assert fetch_v2v._instruction_id_mismatch(lat, dup)["duplicate_instruction_ids"] is True
+
+
+def test_dataset_identity() -> None:
+    assert fetch_v2v._dataset_identity("TS1") == ("s2s-multiturn-v1", "TS1")
+    dataset_id, _sha = fetch_v2v._dataset_identity(None)
+    assert dataset_id == "s2s-v1"
 
 
 @pytest.mark.asyncio
@@ -544,11 +570,83 @@ async def test_ingest_run_writes_instruction_rows() -> None:
     latency_rows = [r for r in rows if r.metric_type == Metric.V2V]
     instr_rows = [r for r in rows if r.metric_type == Metric.INSTRUCTION_FOLLOWING]
     assert len(latency_rows) == 3
-    assert len(instr_rows) == 3
+    assert len(instr_rows) == 2  # UNKNOWN (s2) excluded from the pool
     by_sim = {r.audio_filename: (r.metric_value, r.status) for r in instr_rows}
     assert by_sim["R1/s0"] == (100.0, ResultStatus.SUCCESS)
     assert by_sim["R1/s1"] == (0.0, ResultStatus.SUCCESS)
-    assert by_sim["R1/s2"] == (None, ResultStatus.FAILED)
+    assert "R1/s2" not in by_sim  # UNKNOWN produced no row
+
+
+def _multi_metric_run(
+    latency: list[dict[str, Any]], instruction: list[dict[str, Any]]
+) -> dict[str, Any]:
+    return {
+        "run": {
+            "error_status": "SUCCESS",
+            "results": {"metrics": {"MID": {"values": latency}, "IID": {"values": instruction}}},
+        }
+    }
+
+
+@pytest.mark.asyncio
+async def test_ingest_run_id_mismatch_keeps_latency() -> None:
+    writer = _stub_writer()
+    latency = [
+        {"simulation_output_id": "s0", "value": 0.5},
+        {"simulation_output_id": "s1", "value": 0.5},
+    ]
+    instruction = [
+        {"simulation_output_id": "s0", "value": "YES"},
+        {"simulation_output_id": "s2", "value": "YES"},  # s2 not in latency -> mismatch
+    ]
+    async with _fake_client({}, _multi_metric_run(latency, instruction)) as client:
+        status = await fetch_v2v._ingest_run(
+            client,
+            writer,
+            spec=SPEC,
+            coval_run=CovalRun(run_id="R1", create_time=None, error_status=None),
+            metric_id="MID",
+            instruction_metric_id="IID",
+            runner_sha="test",
+            period_seconds=10_800,
+        )
+    assert status is RunStatus.SUCCEEDED  # latency intact
+    rows = writer.record_results.await_args.args[0]
+    assert all(r.metric_type == Metric.V2V for r in rows)  # instruction skipped on mismatch
+
+
+@pytest.mark.asyncio
+async def test_ingest_run_invalid_verdict_discards_instruction() -> None:
+    writer = _stub_writer()
+    latency = [{"simulation_output_id": "s0", "value": 0.5}]
+    instruction = [{"simulation_output_id": "s0", "value": "GARBAGE"}]
+    async with _fake_client({}, _multi_metric_run(latency, instruction)) as client:
+        status = await fetch_v2v._ingest_run(
+            client,
+            writer,
+            spec=SPEC,
+            coval_run=CovalRun(run_id="R1", create_time=None, error_status=None),
+            metric_id="MID",
+            instruction_metric_id="IID",
+            runner_sha="test",
+            period_seconds=10_800,
+        )
+    assert status is RunStatus.SUCCEEDED  # latency kept
+    rows = writer.record_results.await_args.args[0]
+    assert all(r.metric_type == Metric.V2V for r in rows)  # instruction discarded
+
+
+@pytest.mark.asyncio
+async def test_fetch_and_write_requires_id_pair(monkeypatch: pytest.MonkeyPatch) -> None:
+    # instruction id set but test-set id missing -> startup failure (must be paired).
+    settings = Settings(
+        runner_sha="test",
+        coval_s2s_latency_metric_id="MID",
+        coval_s2s_openai_agent_id="a1",
+        coval_s2s_instruction_metric_id="IID",
+    )
+    with pytest.raises(RuntimeError, match="set together"):
+        await fetch_v2v.fetch_and_write_v2v(settings)
 
 
 @pytest.mark.asyncio

--- a/runner/tests/unit/test_s2s_fetch.py
+++ b/runner/tests/unit/test_s2s_fetch.py
@@ -16,6 +16,7 @@ import pytest
 
 from coval_bench.config import Settings
 from coval_bench.db.models import ResultStatus, Run, RunStatus
+from coval_bench.registries import Metric
 from coval_bench.s2s import fetch_v2v
 from coval_bench.s2s.fetch_v2v import AgentSpec, CovalRun
 
@@ -482,3 +483,102 @@ async def test_stale_provider_lends_no_sample_candidate() -> None:
         )
     assert status is RunStatus.FAILED
     assert sampled == []
+
+
+def test_instruction_verdict_classifies() -> None:
+    # The binary judge only ever emits canonical YES / NO / UNKNOWN (BinaryResult.parse
+    # normalizes case and maps anything missing/invalid to UNKNOWN server-side).
+    assert fetch_v2v._instruction_verdict("YES") is True
+    assert fetch_v2v._instruction_verdict("NO") is False
+    assert fetch_v2v._instruction_verdict("UNKNOWN") is None
+
+
+def test_instruction_rows_maps_verdicts() -> None:
+    values: list[dict[str, Any]] = [
+        {"simulation_output_id": "s1", "value": "YES"},
+        {"simulation_output_id": "s2", "value": "NO"},
+        {"simulation_output_id": "s3", "value": "UNKNOWN"},
+    ]
+    rows = fetch_v2v._instruction_rows(values, run_pk=1, coval_run_id="R1", spec=SPEC)
+    assert [r.metric_value for r in rows] == [100.0, 0.0, None]
+    assert [r.status for r in rows] == [
+        ResultStatus.SUCCESS,  # YES pass
+        ResultStatus.SUCCESS,  # NO counts against the rate
+        ResultStatus.FAILED,  # UNKNOWN excluded from the pool
+    ]
+    assert [r.audio_filename for r in rows] == ["R1/s1", "R1/s2", "R1/s3"]
+    assert all(
+        r.metric_type == Metric.INSTRUCTION_FOLLOWING and r.metric_units == "percent" for r in rows
+    )
+
+
+@pytest.mark.asyncio
+async def test_ingest_run_writes_instruction_rows() -> None:
+    writer = _stub_writer()
+    latency = [{"simulation_output_id": f"s{i}", "value": 0.5} for i in range(3)]
+    instruction = [
+        {"simulation_output_id": "s0", "value": "YES"},
+        {"simulation_output_id": "s1", "value": "NO"},
+        {"simulation_output_id": "s2", "value": "UNKNOWN"},
+    ]
+    run_json = {
+        "run": {
+            "error_status": "SUCCESS",
+            "results": {"metrics": {"MID": {"values": latency}, "IID": {"values": instruction}}},
+        }
+    }
+    async with _fake_client({}, run_json) as client:
+        status = await fetch_v2v._ingest_run(
+            client,
+            writer,
+            spec=SPEC,
+            coval_run=CovalRun(run_id="R1", create_time=None, error_status=None),
+            metric_id="MID",
+            instruction_metric_id="IID",
+            runner_sha="test",
+            period_seconds=10_800,
+        )
+    # Run status reflects latency (all numeric) -> SUCCEEDED.
+    assert status is RunStatus.SUCCEEDED
+    rows = writer.record_results.await_args.args[0]
+    latency_rows = [r for r in rows if r.metric_type == Metric.V2V]
+    instr_rows = [r for r in rows if r.metric_type == Metric.INSTRUCTION_FOLLOWING]
+    assert len(latency_rows) == 3
+    assert len(instr_rows) == 3
+    by_sim = {r.audio_filename: (r.metric_value, r.status) for r in instr_rows}
+    assert by_sim["R1/s0"] == (100.0, ResultStatus.SUCCESS)
+    assert by_sim["R1/s1"] == (0.0, ResultStatus.SUCCESS)
+    assert by_sim["R1/s2"] == (None, ResultStatus.FAILED)
+
+
+@pytest.mark.asyncio
+async def test_ingest_run_without_instruction_metric_id() -> None:
+    # No instruction metric id -> only latency rows, no crash.
+    writer = _stub_writer()
+    latency = [{"simulation_output_id": "s0", "value": 0.5}]
+    async with _fake_client({}, _run_json(latency)) as client:
+        status = await fetch_v2v._ingest_run(
+            client,
+            writer,
+            spec=SPEC,
+            coval_run=CovalRun(run_id="R1", create_time=None, error_status=None),
+            metric_id="MID",
+            runner_sha="test",
+            period_seconds=10_800,
+        )
+    assert status is RunStatus.SUCCEEDED
+    rows = writer.record_results.await_args.args[0]
+    assert all(r.metric_type == Metric.V2V for r in rows)
+
+
+@pytest.mark.asyncio
+async def test_recent_completed_runs_filters_by_test_set() -> None:
+    captured: list[httpx.Request] = []
+    list_json = _list_json({"run_id": "R1", "create_time": _iso(timedelta(hours=1))})
+    async with _fake_client(list_json, {}, captured) as client:
+        await fetch_v2v.recent_completed_runs(
+            client, "a1", period_seconds=10_800, test_set_id="TS1"
+        )
+    filter_expr = captured[0].url.params["filter"]
+    assert 'test_set_id="TS1"' in filter_expr
+    assert 'agent_id="a1"' in filter_expr

--- a/runner/tests/unit/test_s2s_fetch.py
+++ b/runner/tests/unit/test_s2s_fetch.py
@@ -530,7 +530,9 @@ def test_instruction_id_mismatch() -> None:
     }
     # duplicate id
     dup = [{"simulation_output_id": "s1"}, {"simulation_output_id": "s1"}]
-    assert fetch_v2v._instruction_id_mismatch(lat, dup)["duplicate_instruction_ids"] is True
+    dup_diff = fetch_v2v._instruction_id_mismatch(lat, dup)
+    assert dup_diff is not None
+    assert dup_diff["duplicate_instruction_ids"] is True
 
 
 def test_dataset_identity() -> None:


### PR DESCRIPTION
Ingestion + storage groundwork for a second S2S metric — instruction adherence — alongside V2V latency. **No frontend in this PR**: the `/s2s` UI stays V2V-only; the adherence UI (pass-rate card, mean aggregation, higher-is-better sort) lands in a follow-up.

The fetch pulls the multi-turn instruction judge (binary YES/NO/UNKNOWN) per conversation and stores it as a percent — YES=100, NO=0; UNKNOWN produces no row (excluded), so the aggregate mean is `YES / (YES + NO)`. Multi-turn rows carry a distinct `s2s-multiturn-v1` dataset id so they never pool with single-turn `s2s-v1`. The instruction-metric and test-set ids must be configured together (the test-set filter scopes the fetch to the multi-turn set); a blank or half-set config fails at startup. The instruction sim-id set is validated against latency before ingesting, and out-of-contract verdicts discard that run's instruction while keeping latency. Dedup is metric-aware, so an instruction that lags a run backfills on a later scan; run status stays latency-derived, so instruction lag never fails the provider. Served through the existing `/aggregates` and `/results` endpoints (`metric_type` is a free string) — no API changes.

Needs infra before it produces prod data (benchmark-infra #59, then tf-apply):
- [ ] `COVAL_S2S_INSTRUCTION_METRIC_ID`
- [ ] `COVAL_S2S_TEST_SET_ID`

Follow-ups: `/s2s` adherence UI (pass-rate card, mean not median); cold-start / drift metrics pending validation.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds ingestion and storage for S2S instruction-adherence results. The main changes are:

- Adds configuration for the instruction metric and multi-turn test set.
- Stores binary instruction verdicts as percentage results.
- Separates multi-turn data from the single-turn dataset.
- Validates conversation IDs before writing instruction results.
- Adds metric-aware deduplication for delayed instruction backfills.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- Conversation populations are checked before instruction results are stored.
- Delayed instruction results can backfill after latency has already landed.
- Configuration validation prevents partial instruction-metric setup.
- No blocking issues were found in the updated code.

<sub>Reviews (4): Last reviewed commit: ["Fix mypy strict error in S2S fetch test ..."](https://github.com/coval-ai/benchmarks/commit/04c6efecfee15a7a5490fa478af2d6f1841e2489) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46496771)</sub>

<!-- /greptile_comment -->