### PR TITLE
Rename Modulate models to Velma-2 ids

### DIFF
--- a/runner/src/coval_bench/providers/stt/modulate.py
+++ b/runner/src/coval_bench/providers/stt/modulate.py
@@ -3,7 +3,9 @@
 
 """Modulate (Velma-2) real-time streaming STT provider.
 
-Wire protocol: WebSocket, one endpoint per model.
+Wire protocol: WebSocket, one endpoint per model; the model id is the endpoint
+path segment (``velma-2-stt-streaming`` is multilingual,
+``velma-2-stt-streaming-english-v2`` is fast English-only).
 Auth: ``api_key`` query parameter (no header).
 Audio in: raw binary PCM frames; format declared via query params
   (``audio_format=s16le&sample_rate=<hz>&num_channels=1``).
@@ -19,9 +21,9 @@ The multilingual endpoint needs ``partial_results=true`` to emit partials and
 runs with ``speaker_diarization=false`` so a single utterance is not split into
 per-speaker finals; the finals it does emit are concatenated in arrival order.
 
-The english-fast endpoint emits partials on a fixed ~1.5 s cadence, so its
-TTFT tracks the emission interval rather than engine latency and is excluded
-in ``registries/metrics.py``.
+The English endpoint emits partials on a fixed ~1.5 s cadence, so its TTFT
+tracks the emission interval rather than engine latency and is excluded in
+``registries/metrics.py``.
 """
 
 from __future__ import annotations
@@ -49,22 +51,16 @@ logger = structlog.get_logger(__name__)
 _WS_BASE = "wss://platform.modulate.ai/api"
 _EOS = ""
 
-_MODEL_ENDPOINTS: dict[str, str] = {
-    "english-fast-transcription-streaming": "velma-2-stt-streaming-english-v2",
-    "multilingual-transcription-streaming": "velma-2-stt-streaming",
-}
-
-_MULTILINGUAL_MODEL = "multilingual-transcription-streaming"
+_MULTILINGUAL_MODEL = "velma-2-stt-streaming"
+_ENGLISH_MODEL = "velma-2-stt-streaming-english-v2"
 
 
 class ModulateSTTProvider(STTProvider):
     """Modulate streaming STT provider."""
 
-    _VALID_MODELS = frozenset(_MODEL_ENDPOINTS)
+    _VALID_MODELS = frozenset({_MULTILINGUAL_MODEL, _ENGLISH_MODEL})
 
-    def __init__(
-        self, api_key: SecretStr | None, model: str = "english-fast-transcription-streaming"
-    ) -> None:
+    def __init__(self, api_key: SecretStr | None, model: str = _ENGLISH_MODEL) -> None:
         if not self._model_supported(model):
             raise ValueError(
                 f"Invalid Modulate model {model!r}. Valid: {sorted(self._VALID_MODELS)}"
@@ -92,7 +88,7 @@ class ModulateSTTProvider(STTProvider):
         if self._model == _MULTILINGUAL_MODEL:
             params["partial_results"] = "true"
             params["speaker_diarization"] = "false"
-        return f"{_WS_BASE}/{_MODEL_ENDPOINTS[self._model]}?{urlencode(params)}"
+        return f"{_WS_BASE}/{self._model}?{urlencode(params)}"
 
     async def measure_ttft(
         self,

--- a/runner/src/coval_bench/registries/metrics.py
+++ b/runner/src/coval_bench/registries/metrics.py
@@ -115,9 +115,9 @@ METRIC_EXCLUSIONS: dict[Metric, frozenset[tuple[str, str]]] = {
             ("xai", "grok-stt"),
             ("openai", "gpt-4o-transcribe"),
             ("openai", "gpt-4o-mini-transcribe"),
-            # Modulate's english-fast endpoint emits partials on a fixed ~1.5s
+            # Modulate's English endpoint emits partials on a fixed ~1.5s
             # cadence, so first-token timing tracks the emission interval.
-            ("modulate", "english-fast-transcription-streaming"),
+            ("modulate", "velma-2-stt-streaming-english-v2"),
         }
     ),
     Metric.TTFS: frozenset(

--- a/runner/src/coval_bench/registries/models.py
+++ b/runner/src/coval_bench/registries/models.py
@@ -356,21 +356,21 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         licensing=_OPEN,
         status=_ACTIVE,
     ),
-    # Modulate Velma-2 real-time streaming. The empty-frame EOS is a genuine
-    # finalize: the complete transcript lands ~150-300 ms after the last audio,
-    # so TTFS is comparable. English-fast's TTFT is cadence-floored and
-    # excluded in registries/metrics.py.
+    # Modulate Velma-2 real-time streaming; ids are the endpoint path segments.
+    # The empty-frame EOS is a genuine finalize: the complete transcript lands
+    # ~150-300 ms after the last audio, so TTFS is comparable. The English
+    # endpoint's TTFT is cadence-floored and excluded in registries/metrics.py.
     RegisteredModel(
         benchmark=_STT,
         provider="modulate",
-        model="english-fast-transcription-streaming",
+        model="velma-2-stt-streaming-english-v2",
         tags=(_STREAMING,),
         status=_ACTIVE,
     ),
     RegisteredModel(
         benchmark=_STT,
         provider="modulate",
-        model="multilingual-transcription-streaming",
+        model="velma-2-stt-streaming",
         tags=(_STREAMING, _MULTI, _DIAR),
         status=_ACTIVE,
     ),

--- a/runner/tests/providers/stt/test_modulate.py
+++ b/runner/tests/providers/stt/test_modulate.py
@@ -21,10 +21,10 @@ from coval_bench.metrics.wer import compute_wer
 from coval_bench.providers.stt.modulate import ModulateSTTProvider
 from tests.providers.stt.conftest import FakeWebSocket, load_fixture_events
 
-_MULTILINGUAL = "multilingual-transcription-streaming"
+_MULTILINGUAL = "velma-2-stt-streaming"
 
 
-def make_provider(model: str = "english-fast-transcription-streaming") -> ModulateSTTProvider:
+def make_provider(model: str = "velma-2-stt-streaming-english-v2") -> ModulateSTTProvider:
     return ModulateSTTProvider(api_key=SecretStr("test-key-modulate"), model=model)
 
 
@@ -201,12 +201,12 @@ def test_modulate_english_url_omits_partials(fake_api_key: SecretStr) -> None:
 
 
 def test_provider_name() -> None:
-    assert make_provider().name == "modulate-english-fast-transcription-streaming"
+    assert make_provider().name == "modulate-velma-2-stt-streaming-english-v2"
     assert make_provider(_MULTILINGUAL).name == f"modulate-{_MULTILINGUAL}"
 
 
 def test_provider_model() -> None:
-    assert make_provider().model == "english-fast-transcription-streaming"
+    assert make_provider().model == "velma-2-stt-streaming-english-v2"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Renames the Modulate model ids to the vendor endpoint slugs, velma-2-stt-streaming (multilingual) and velma-2-stt-streaming-english-v2 (fast English), matching the registry convention of vendor identifiers and mapping each id 1:1 to Modulate's documented endpoints. The model id now doubles as the endpoint path segment, so the endpoint lookup table is gone. The English endpoint's TTFT exclusion pair moves to the new id. Existing result rows remain keyed to the old ids and stop being served by the registry-driven API.

Both renamed models smoke-verified against the live API.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR renames the Modulate models to their Velma-2 endpoint identifiers. The main changes are:

- Uses model IDs directly as WebSocket endpoint paths.
- Updates both Modulate entries in the model registry.
- Moves the English model's TTFT exclusion to its new ID.
- Updates provider tests for the new identifiers.

<h3>Confidence Score: 4/5</h3>

The historical TTFT filtering path needs a fix before merging.

- New Modulate runs use consistent registry, provider, and endpoint IDs.
- Historical English-model rows retain the old ID and can bypass the renamed TTFT exclusion.

runner/src/coval_bench/registries/metrics.py

<sub>Reviews (1): Last reviewed commit: ["\[BENCH-526\] Rename Modulate models to Ve..."](https://github.com/coval-ai/benchmarks/commit/637454d4330db604133ecd9446877f53eed13e91) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46510249)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->