### PR TITLE
Track clicks on the By Coval header link

### DIFF
--- a/web/components/layout/DashboardHeader.tsx
+++ b/web/components/layout/DashboardHeader.tsx
@@ -8,6 +8,8 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import React from "react";
 import ThemeSwitch from "@/components/layout/ThemeSwitch";
+import { capturePostHogEvent } from "@/lib/posthog/client";
+import { POSTHOG_EVENTS } from "@/lib/posthog/events";
 
 // Benchmark sections, shown as tabs in the upper right of the top nav bar.
 const SECTIONS = [
@@ -50,6 +52,11 @@ const DashboardHeader: React.FC = () => {
             target="_blank"
             rel="noopener noreferrer"
             aria-label="By Coval"
+            onClick={() =>
+              capturePostHogEvent(POSTHOG_EVENTS.headerCovalLinkClicked, {
+                path: pathname
+              })
+            }
             className="flex items-center gap-1 text-[11px] text-text-tertiary transition-opacity hover:opacity-80"
           >
             By

--- a/web/lib/posthog/events.ts
+++ b/web/lib/posthog/events.ts
@@ -21,7 +21,8 @@ export const POSTHOG_EVENTS = {
   dashboardChartShared: "dashboard_chart_shared",
   dashboardWerDatasetChanged: "dashboard_wer_dataset_changed",
   dashboardWerBarViewChanged: "dashboard_wer_bar_view_changed",
-  s2sSamplePlayRequested: "s2s_sample_play_requested"
+  s2sSamplePlayRequested: "s2s_sample_play_requested",
+  headerCovalLinkClicked: "header_coval_link_clicked"
 } as const;
 
 export type PostHogSurface =


### PR DESCRIPTION
## Summary
- Add a `header_coval_link_clicked` PostHog event to the "By Coval" link in the site header, capturing the current `path` so we can see which page the click came from
- Uses the existing `capturePostHogEvent` guard (no-ops when PostHog isn't configured), same pattern as the other tracked components

## Analytics
A trends insight for this event is already on the [Web Traffic dashboard](https://us.posthog.com/project/453429/dashboard/1685520); it will start populating once this deploys.

## Testing
- `tsc --noEmit`, `eslint` on the changed files, and `vitest run lib/posthog/client.test.ts` all pass
- Verified locally that the header renders and the click handler fires without console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR tracks clicks on the “By Coval” header link. The main changes are:

- Adds the `header_coval_link_clicked` PostHog event.
- Captures the current pathname when the external link is clicked.
- Uses the existing guarded PostHog client helper.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<sub>Reviews (1): Last reviewed commit: ["Track clicks on the By Coval header link"](https://github.com/coval-ai/benchmarks/commit/6e7d338344cbc85d7390b798b99ed16998918d36) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46518540)</sub>

<!-- /greptile_comment -->