### PR TITLE
Split dedicated-inference endpoints into their own run lane

### DIFF
--- a/runner/src/coval_bench/__main__.py
+++ b/runner/src/coval_bench/__main__.py
@@ -52,7 +52,18 @@ def cli() -> None:
     default=False,
     help="Run a single dataset item — for local dev.",
 )
-def run(kind: str, smoke: bool) -> None:
+@click.option(
+    "--source",
+    type=click.Choice(["shared", "dedicated"]),
+    default="shared",
+    show_default=True,
+    help=(
+        "Which endpoints to run: 'shared' is every non-dedicated endpoint "
+        "(official APIs and shared inference); 'dedicated' is only "
+        "dedicated-inference endpoints, which run in their own scheduled job."
+    ),
+)
+def run(kind: str, smoke: bool, source: str) -> None:
     """Execute one benchmark run — invoked by Cloud Run Job."""
     from coval_bench.config import get_settings
     from coval_bench.db.models import RunStatus
@@ -60,7 +71,7 @@ def run(kind: str, smoke: bool) -> None:
 
     settings = get_settings()
     summary: RunSummary = asyncio.run(
-        run_benchmarks(settings=settings, benchmark_kind=kind, smoke=smoke)  # type: ignore[arg-type]
+        run_benchmarks(settings=settings, benchmark_kind=kind, smoke=smoke, source=source)  # type: ignore[arg-type]
     )
     click.echo(summary.model_dump_json())
     if summary.status == str(RunStatus.FAILED):

--- a/runner/src/coval_bench/registries/models.py
+++ b/runner/src/coval_bench/registries/models.py
@@ -266,9 +266,9 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         licensing=_OPEN,
         status=_ACTIVE,
     ),
-    # Baseten dedicated endpoints (Whisper Large V3). PENDING: implemented and
-    # hidden while Baseten tunes the setup — kept off the scheduled runner and
-    # the public site, run manually during the daily test window.
+    # Baseten dedicated endpoint (Whisper Large V3). Benchmarked nightly by the
+    # dedicated runner job during Baseten's test window; EARLY_ACCESS keeps it
+    # off the public site until the dedicated-inference dashboards ship.
     RegisteredModel(
         benchmark=_STT,
         provider="baseten",
@@ -278,7 +278,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         source=Source.DEDICATED_INFERENCE,
         licensing=_OPEN,
         on_prem=True,
-        status=_PENDING,
+        status=_EARLY_ACCESS,
     ),
     # Azure AI Speech real-time (raw WebSocket, conversation mode).
     RegisteredModel(
@@ -654,8 +654,8 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         status=_PENDING,
         arena_enabled=False,
     ),
-    # Baseten dedicated endpoints (Qwen3-TTS 1.7B). PENDING for the same reason
-    # as the Whisper STT entry above — implemented, hidden, run manually.
+    # Baseten dedicated endpoint (Qwen3-TTS 1.7B). Same treatment as the
+    # Whisper STT entry above — nightly dedicated runner job, EARLY_ACCESS.
     RegisteredModel(
         benchmark=_TTS,
         provider="baseten",
@@ -666,7 +666,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         source=Source.DEDICATED_INFERENCE,
         licensing=_OPEN,
         on_prem=True,
-        status=_PENDING,
+        status=_EARLY_ACCESS,
     ),
     RegisteredModel(
         benchmark=_TTS,

--- a/runner/src/coval_bench/runner/orchestrator.py
+++ b/runner/src/coval_bench/runner/orchestrator.py
@@ -59,6 +59,7 @@ from coval_bench.registries import (
     Metric,
     ModelStatus,
     RegisteredModel,
+    Source,
 )
 from coval_bench.runner.retry import with_retry
 
@@ -825,6 +826,7 @@ async def run_benchmarks(
     settings: Settings,
     benchmark_kind: Literal["stt", "tts", "both"] = "both",
     smoke: bool = False,
+    source: Literal["shared", "dedicated"] = "shared",
     matrix_overrides: list[RegisteredModel] | None = None,
 ) -> RunSummary:
     """Execute one complete benchmark run.
@@ -833,6 +835,9 @@ async def run_benchmarks(
         settings: Injected application settings (no global state).
         benchmark_kind: Which benchmark(s) to run.
         smoke: If True, process only the first dataset item (local dev mode).
+        source: ``shared`` runs every non-dedicated endpoint; ``dedicated``
+            runs only dedicated-inference endpoints. The two never mix in one
+            run — dedicated endpoints have their own scheduled job.
         matrix_overrides: Optional list of ``RegisteredModel`` objects that
             override the registry by ``(benchmark, provider, model)`` key.
 
@@ -885,8 +890,17 @@ async def run_benchmarks(
 
     # EARLY_ACCESS models run on the normal schedule; only the API hides them.
     scheduled = (ModelStatus.ACTIVE, ModelStatus.EARLY_ACCESS)
-    enabled_stt = [e for e in stt_matrix if e.status in scheduled]
-    enabled_tts = [e for e in tts_matrix if e.status in scheduled]
+    dedicated = source == "dedicated"
+    enabled_stt = [
+        e
+        for e in stt_matrix
+        if e.status in scheduled and (e.source is Source.DEDICATED_INFERENCE) == dedicated
+    ]
+    enabled_tts = [
+        e
+        for e in tts_matrix
+        if e.status in scheduled and (e.source is Source.DEDICATED_INFERENCE) == dedicated
+    ]
 
     # ------------------------------------------------------------------
     # 2. Open DB pool + start run row
@@ -930,6 +944,7 @@ async def run_benchmarks(
             "benchmark_run_started",
             benchmark_kind=benchmark_kind,
             smoke=smoke,
+            source=source,
             runner_sha=settings.runner_sha,
         )
 

--- a/runner/tests/api/test_providers.py
+++ b/runner/tests/api/test_providers.py
@@ -9,6 +9,8 @@ import pytest
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
 
+from tests.api.conftest import INTERNAL_API_KEY
+
 
 async def test_providers_200(client: AsyncClient) -> None:
     """GET /v1/providers returns 200 with correct shape."""
@@ -140,7 +142,11 @@ async def test_capability_and_licensing_facets(client: AsyncClient) -> None:
     assert ("features", "emotion-control") in orpheus_facets
     assert labels[("features", "emotion-control")] == "Emotion control"
 
-    baseten = next(e for e in data["tts"] if e["provider"] == "baseten")
+    # Baseten's dedicated endpoints are EARLY_ACCESS, so their facets are only
+    # visible on the internal view.
+    internal = await client.get("/v1/providers", headers={"X-Internal-Key": INTERNAL_API_KEY})
+    internal_data = internal.json()
+    baseten = next(e for e in internal_data["tts"] if e["provider"] == "baseten")
     qwen = next(m for m in baseten["models"] if m["model"] == "qwen3-tts-1.7b")
     qwen_facets = {(t["category"], t["value"]) for t in qwen["tags"]}
     qwen_labels = {(t["category"], t["value"]): t["label"] for t in qwen["tags"]}

--- a/runner/tests/unit/test_orchestrator.py
+++ b/runner/tests/unit/test_orchestrator.py
@@ -18,6 +18,8 @@ Test catalogue
 8.  test_audio_file_cleanup        — TTS audio deleted even when WER raises
 9.  test_matrix_overrides          — nova-3 disabled via override → not called
 10. test_disabled_providers_skipped — non-ACTIVE entries not instantiated
+11. test_shared_run_excludes_dedicated — default run never touches dedicated endpoints
+12. test_dedicated_run_only_dedicated  — source='dedicated' runs only dedicated endpoints
 """
 
 from __future__ import annotations
@@ -40,7 +42,7 @@ from pydantic import SecretStr
 from coval_bench.config import Settings
 from coval_bench.db.models import Benchmark, Result, ResultStatus, Run, RunStatus
 from coval_bench.providers.base import TranscriptionResult, TTSResult
-from coval_bench.registries import MODEL_REGISTRY, ModelStatus, RegisteredModel
+from coval_bench.registries import MODEL_REGISTRY, ModelStatus, RegisteredModel, Source
 from coval_bench.runner.orchestrator import RunSummary, run_benchmarks
 from coval_bench.runner.retry import with_retry
 
@@ -65,11 +67,18 @@ _TEST_SETTINGS = Settings(
 # ---------------------------------------------------------------------------
 
 
-def _stt_entry(provider: str, model: str, *, active: bool = True) -> RegisteredModel:
+def _stt_entry(
+    provider: str,
+    model: str,
+    *,
+    active: bool = True,
+    source: Source = Source.OFFICIAL_API,
+) -> RegisteredModel:
     return RegisteredModel(
         benchmark=Benchmark.STT,
         provider=provider,
         model=model,
+        source=source,
         status=ModelStatus.ACTIVE if active else ModelStatus.PAUSED,
     )
 
@@ -1171,6 +1180,93 @@ async def test_disabled_providers_skipped(audio_file: Path, settings: Settings) 
 
     disabled_cls.assert_not_called()
     provider_cls.assert_called()
+
+
+# ---------------------------------------------------------------------------
+# 11. test_shared_run_excludes_dedicated
+# ---------------------------------------------------------------------------
+
+
+def _source_split_matrix() -> list[RegisteredModel]:
+    """One shared and one dedicated ACTIVE entry on an otherwise paused registry."""
+    return [
+        *_paused_registry(Benchmark.STT),
+        _stt_entry("deepgram", "nova-2"),
+        _stt_entry(
+            "baseten",
+            "whisper-large-v3",
+            source=Source.DEDICATED_INFERENCE,
+        ),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_shared_run_excludes_dedicated(audio_file: Path, settings: Settings) -> None:
+    """The default (shared) run never instantiates dedicated-inference entries."""
+    provider_inst = MagicMock()
+    provider_inst.measure_ttft = AsyncMock(return_value=_good_transcription())
+    shared_cls = MagicMock(return_value=provider_inst)
+    dedicated_cls = MagicMock()
+
+    stt_providers = {"deepgram": shared_cls, "baseten": dedicated_cls}
+
+    run = _make_run()
+    writer = _make_stub_writer(run)
+
+    async with _orchestrator_env(
+        audio_path=audio_file,
+        stt_items=[_make_dataset_item(audio_file)],
+        stt_providers=stt_providers,
+        run=run,
+        writer=writer,
+    ) as _:
+        await run_benchmarks(
+            settings=settings,
+            benchmark_kind="stt",
+            smoke=True,
+            matrix_overrides=_source_split_matrix(),
+        )
+
+    dedicated_cls.assert_not_called()
+    shared_cls.assert_called()
+
+
+# ---------------------------------------------------------------------------
+# 12. test_dedicated_run_only_dedicated
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_dedicated_run_only_dedicated(audio_file: Path, settings: Settings) -> None:
+    """source='dedicated' runs only dedicated-inference entries."""
+    provider_inst = MagicMock()
+    provider_inst.measure_ttft = AsyncMock(return_value=_good_transcription())
+    dedicated_cls = MagicMock(return_value=provider_inst)
+    shared_cls = MagicMock()
+
+    stt_providers = {"deepgram": shared_cls, "baseten": dedicated_cls}
+
+    run = _make_run()
+    writer = _make_stub_writer(run)
+
+    async with _orchestrator_env(
+        audio_path=audio_file,
+        stt_items=[_make_dataset_item(audio_file)],
+        stt_providers=stt_providers,
+        run=run,
+        writer=writer,
+    ) as _:
+        summary = await run_benchmarks(
+            settings=settings,
+            benchmark_kind="stt",
+            smoke=True,
+            source="dedicated",
+            matrix_overrides=_source_split_matrix(),
+        )
+
+    shared_cls.assert_not_called()
+    dedicated_cls.assert_called()
+    assert summary.success_count == summary.total_results
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
run --source keeps dedicated endpoints off the shared 30-minute cadence, and the Baseten endpoints move to EARLY_ACCESS so the daily dedicated job benchmarks them under embargo.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR separates shared and dedicated inference benchmarks into different run lanes. The main changes are:

- Adds a `--source` option to the benchmark command.
- Filters models into shared and dedicated runs.
- Promotes two Baseten models to embargoed `EARLY_ACCESS` status.
- Adds tests for lane filtering and internal API visibility.

<h3>Confidence Score: 4/5</h3>

The dedicated benchmark path needs a scheduled invocation before merging.

- Existing no-flag jobs now run only the shared lane.
- Both Baseten endpoints are excluded unless another job passes `--source dedicated`.
- The source filtering and API embargo logic otherwise match the intended split.

runner/src/coval_bench/__main__.py and the scheduled-job configuration

<sub>Reviews (1): Last reviewed commit: ["Split dedicated-inference endpoints into..."](https://github.com/coval-ai/benchmarks/commit/a659c6c83ae0a294c03ffc61ac953600fc7fade9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46519545)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->