### PR TITLE
Tag copied chart links with utm params for share attribution

### DIFF
--- a/web/components/shared/SectionHeader.tsx
+++ b/web/components/shared/SectionHeader.tsx
@@ -92,8 +92,10 @@ const SectionHeader: React.FC<SectionHeaderProps> = ({
     });
 
   const copyLink = () => {
+    // The utm params tag visitors who arrive through a copied link: PostHog
+    // reads utm_* from the landing URL, so these visits separate from $direct.
     navigator.clipboard.writeText(
-      `${window.location.origin}${window.location.pathname}#${anchorId}`
+      `${window.location.origin}${window.location.pathname}?utm_source=copy_link&utm_content=${anchorId}#${anchorId}`
     );
     window.history.replaceState(null, "", `#${anchorId}`);
     setCopied(true);


### PR DESCRIPTION
## Why

Visits arriving through the chart copy-link button are indistinguishable from `$direct` traffic in PostHog (no referrer survives a pasted link), so we can't tell whether the share feature drives any return traffic — e.g. a link shared on LinkedIn.

## What

The copy-link button now copies URLs of the form:

```
https://<site>/tts?utm_source=copy_link&utm_content=<chart-anchor>#<chart-anchor>
```

- PostHog auto-captures `utm_source` / `utm_content` from the landing URL, so arrivals via copied links become attributable — `utm_content` also identifies *which* chart drew the visitor in.
- The sharer's own address bar still only gets the `#fragment` (unchanged `replaceState`), so the sharer's session never self-attributes as copy-link traffic.

The "Copy Link Button Usage" insight on the Feature Tracking PostHog dashboard has an "Arrivals via copied links" series that starts counting once this deploys.

## Verification

- `pnpm typecheck`, `pnpm lint` (file), `pnpm test` — all pass (81/81).
- Verified in the browser: clicking the button copies `http://localhost:3100/tts?utm_source=copy_link&utm_content=latency-benchmarks#latency-benchmarks`, and the current page URL keeps only the fragment. Anchor scroll on landing still works with the query string present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds attribution parameters to copied chart links. The main changes are:

- Adds `utm_source=copy_link` to copied URLs.
- Adds the chart anchor as `utm_content`.
- Keeps the sharer's address bar limited to the chart fragment.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.
- Current callers use routes without query-dependent page state.
- Chart identifiers contain only URL-safe characters.

<sub>Reviews (1): Last reviewed commit: ["Tag copied chart links with utm params f..."](https://github.com/coval-ai/benchmarks/commit/5835d6e7308dfc754f9b683926c6ce03f75717ca) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46524232)</sub>

<!-- /greptile_comment -->