### PR TITLE
Hide dedicated-inference models from dashboards

### DIFF
--- a/web/lib/utils/modelsFromResults.test.ts
+++ b/web/lib/utils/modelsFromResults.test.ts
@@ -105,6 +105,47 @@ describe("buildModelsByProvider", () => {
     expect(out.openai).toEqual(["openai:gpt-realtime-whisper"]);
   });
 
+  it("does not include dedicated-inference catalogue models or data-backed entries", () => {
+    const catalogue = {
+      tts: [
+        {
+          provider: "baseten",
+          models: [
+            {
+              model: "qwen3-tts-1.7b",
+              disabled: false,
+              tags: [
+                {
+                  category: "source",
+                  value: "dedicated-inference",
+                  label: "Dedicated inference",
+                },
+              ],
+            },
+          ],
+        },
+        {
+          provider: "openai",
+          models: [{ model: "gpt-4o-mini-tts", disabled: false }],
+        },
+      ],
+      stt: [],
+      s2s: [],
+    };
+
+    const out = buildModelsByProvider(
+      [
+        entry("baseten", "qwen3-tts-1.7b"),
+        entry("openai", "gpt-4o-mini-tts"),
+      ],
+      "TTS",
+      catalogue as never
+    );
+
+    expect(out.baseten).toBeUndefined();
+    expect(out.openai).toEqual(["openai:gpt-4o-mini-tts"]);
+  });
+
   it("adds data-backed TTS models alongside catalogue models", () => {
     const catalogue = {
       stt: [],

--- a/web/lib/utils/modelsFromResults.ts
+++ b/web/lib/utils/modelsFromResults.ts
@@ -3,6 +3,7 @@
 
 import type { ProvidersApiResponse } from "../api/client";
 import type { ModelsByProvider } from "../../types/benchmark.types";
+import { isDedicated } from "./facets";
 import { toModelKey } from "./formatters";
 
 /** Anything that names a (provider, model) pair — e.g. a ModelStatEntry. */
@@ -29,7 +30,8 @@ function modelIsEnabled(
   if (!providerInfo) return true;
 
   const modelInfo = providerInfo.models.find((item) => item.model === model);
-  return modelInfo?.disabled !== true;
+  if (!modelInfo) return true;
+  return modelInfo.disabled !== true && !isDedicated(modelInfo.tags ?? []);
 }
 
 function addModel(
@@ -60,7 +62,7 @@ function buildModelsByProviderFromCatalogue(
         : providers.tts) ?? [];
   for (const providerInfo of catalogue) {
     for (const modelInfo of providerInfo.models) {
-      if (modelInfo.disabled) continue;
+      if (modelInfo.disabled || isDedicated(modelInfo.tags ?? [])) continue;
       addModel(modelsByProvider, providerInfo.provider, modelInfo.model);
     }
   }


### PR DESCRIPTION
## What changed

- Exclude models tagged `dedicated-inference` when the frontend builds dashboard model lists.
- Apply the exclusion to both catalogue-backed models and data-backed aggregate entries.
- Add a regression test covering Baseten Whisper STT and Qwen TTS alongside
  shared Deepgram and OpenAI models.

## Why

Baseten traffic was exercised through a non-persisting probe, so there is no persisted benchmark run backing public TTFA/WER values. Dedicated endpoints should stay off the public dashboards until the benchmark persistence and publication flow is agreed and implemented.

This is intentionally frontend-only. It does not change the API, runner,
registry, or provider integrations. The frontend contains no synthetic or
hardcoded benchmark values; dedicated STT and TTS aggregate rows are ignored
even if they are present.

## Impact

Dedicated-inference models no longer appear in dashboard filters, charts, or comparison tables. Shared models are unaffected.

## Validation

- `pnpm test lib/utils/modelsFromResults.test.ts` — 9 passed
- `pnpm typecheck`
- `pnpm exec eslint lib/utils/modelsFromResults.ts lib/utils/modelsFromResults.test.ts --max-warnings 0`
