### PR TITLE
[BENCH-529] Move Modulate english-fast to early access

### DIFF
--- a/runner/src/coval_bench/registries/models.py
+++ b/runner/src/coval_bench/registries/models.py
@@ -365,7 +365,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         provider="modulate",
         model="english-fast-transcription-streaming",
         tags=(_STREAMING,),
-        status=_ACTIVE,
+        status=_EARLY_ACCESS,
     ),
     RegisteredModel(
         benchmark=_STT,


### PR DESCRIPTION
Hides the model from public responses while Modulate fixes the server-side transcript duplication; the runner keeps benchmarking it daily.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Reclassifies Modulate’s `english-fast-transcription-streaming` model as early access.
- Keeps the model in scheduled benchmark runs.
- Hides the model and its results from public API responses while retaining internal access.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with the model continuing to benchmark while being hidden from public responses.

The scheduled runner includes both active and early-access models, while public API filtering excludes early-access entries as intended.

<sub>Reviews (1): Last reviewed commit: ["\[BENCH-529\] Move Modulate english-fast t..."](https://github.com/coval-ai/benchmarks/commit/69c94474aebae885ff3b172367d53edf222ce778) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46724057)</sub>

**Context used:**

- Knowledge Base — [Runner Orchestration](https://app.greptile.com/coval/-/custom-context/knowledge-base/coval-ai/benchmarks/-/docs/runner-orchestration.md)

<!-- /greptile_comment -->