### PR TITLE
[BENCH-530] Serialize dedicated-inference runs

### DIFF
--- a/runner/src/coval_bench/runner/orchestrator.py
+++ b/runner/src/coval_bench/runner/orchestrator.py
@@ -19,7 +19,8 @@ Design notes
   call time, not at module load, which also lets tests patch ``sys.modules``
   without triggering import errors.  ``coval_bench.registries`` is the
   exception: dependency-light by design, imported eagerly.
-- Concurrency: ``asyncio.Semaphore(8)`` caps simultaneous provider connections.
+- Concurrency: ``asyncio.Semaphore(8)`` caps simultaneous provider connections;
+  dedicated runs use a cap of 1 so a single pinned replica is never contended.
 - Timeouts: ``asyncio.timeout(45)`` for STT, ``asyncio.timeout(60)`` for TTS.
 - Audio cleanup: TTS audio files are deleted in ``finally`` blocks; this module
   owns cleanup, NOT the provider.
@@ -69,6 +70,7 @@ if TYPE_CHECKING:
 logger = structlog.get_logger("coval_bench.runner")
 
 _CONCURRENCY_CAP = 8
+_DEDICATED_CONCURRENCY_CAP = 1
 _STT_TIMEOUT_S = 45
 _TTS_TIMEOUT_S = 60
 _MAX_ERROR_LEN = 4000  # truncate error messages stored in DB (Postgres text is unbounded
@@ -949,7 +951,7 @@ async def run_benchmarks(
         )
 
         all_results: list[Any] = []
-        sem = asyncio.Semaphore(_CONCURRENCY_CAP)
+        sem = asyncio.Semaphore(_DEDICATED_CONCURRENCY_CAP if dedicated else _CONCURRENCY_CAP)
 
         # Cloud Run sends SIGTERM ~10s before SIGKILL when a task hits its timeout.
         # We catch it, cancel the in-flight gather, and finalize the run row as

--- a/runner/tests/unit/test_orchestrator.py
+++ b/runner/tests/unit/test_orchestrator.py
@@ -20,6 +20,7 @@ Test catalogue
 10. test_disabled_providers_skipped — non-ACTIVE entries not instantiated
 11. test_shared_run_excludes_dedicated — default run never touches dedicated endpoints
 12. test_dedicated_run_only_dedicated  — source='dedicated' runs only dedicated endpoints
+13. test_dedicated_run_serialized      — source='dedicated' streams one clip at a time
 """
 
 from __future__ import annotations
@@ -1267,6 +1268,57 @@ async def test_dedicated_run_only_dedicated(audio_file: Path, settings: Settings
     shared_cls.assert_not_called()
     dedicated_cls.assert_called()
     assert summary.success_count == summary.total_results
+
+
+# ---------------------------------------------------------------------------
+# 13. test_dedicated_run_serialized
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_dedicated_run_serialized(audio_file: Path, settings: Settings) -> None:
+    """source='dedicated' never runs more than one clip at a time."""
+    max_concurrent = 0
+    current_concurrent = 0
+    lock = asyncio.Lock()
+
+    async def tracked_measure_ttft(*args: Any, **kwargs: Any) -> TranscriptionResult:
+        nonlocal max_concurrent, current_concurrent
+        async with lock:
+            current_concurrent += 1
+            max_concurrent = max(max_concurrent, current_concurrent)
+        await asyncio.sleep(0)
+        async with lock:
+            current_concurrent -= 1
+        return _good_transcription()
+
+    provider_inst = MagicMock()
+    provider_inst.measure_ttft = tracked_measure_ttft
+    dedicated_cls = MagicMock(return_value=provider_inst)
+
+    stt_providers = {"baseten": dedicated_cls}
+    items_10 = [_make_dataset_item(audio_file, f"item {i}") for i in range(10)]
+
+    run = _make_run()
+    writer = _make_stub_writer(run)
+
+    async with _orchestrator_env(
+        audio_path=audio_file,
+        stt_items=items_10,
+        stt_providers=stt_providers,
+        run=run,
+        writer=writer,
+    ) as _:
+        summary = await run_benchmarks(
+            settings=settings,
+            benchmark_kind="stt",
+            smoke=False,
+            source="dedicated",
+            matrix_overrides=_source_split_matrix(),
+        )
+
+    assert max_concurrent == 1, f"max concurrent was {max_concurrent}"
+    assert summary.total_results >= 10
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
A dedicated lane's single model otherwise inherits all eight semaphore slots and contends its own pinned replica.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR serializes dedicated-inference benchmark work and adds focused STT coverage.
- Adds a dedicated-run semaphore cap of one while retaining the shared-run cap of eight.
- Adds a unit test confirming dedicated STT clips do not overlap.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with a non-blocking test-coverage gap for dedicated TTS serialization.

The shared production semaphore correctly applies the dedicated cap to both item runners, but the added regression test validates only the STT branch.

runner/tests/unit/test_orchestrator.py

<sub>Reviews (1): Last reviewed commit: ["\[BENCH-530\] Serialize dedicated-inferenc..."](https://github.com/coval-ai/benchmarks/commit/3d0731514fbb675c60c4dcb40eb0ee3d834de5d8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46813164)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Runner Orchestration](https://app.greptile.com/coval/-/custom-context/knowledge-base/coval-ai/benchmarks/-/docs/runner-orchestration.md)

<!-- /greptile_comment -->