### PR TITLE
Render S2S timeline dates in UTC

### DIFF
--- a/web/components/charts/tooltips/TimelineTooltip.tsx
+++ b/web/components/charts/tooltips/TimelineTooltip.tsx
@@ -34,9 +34,11 @@ interface TimelineTooltipProps extends Partial<Pick<
   labelText?: string;
   /** Non-latency values: overrides the default "123ms" rendering. */
   formatValue?: (value: number) => string;
+  /** IANA timezone (e.g. "UTC") for the timestamp label; defaults to the viewer's local zone. */
+  timeZone?: string;
 }
 
-const CustomTimelineTooltip: React.FC<TimelineTooltipProps> = ({ active, payload, label, getProviderForModel, showDate, dimmedKeys, compact, interactionHint, maxHeight, onModelClick, labelText, formatValue }) => {
+const CustomTimelineTooltip: React.FC<TimelineTooltipProps> = ({ active, payload, label, getProviderForModel, showDate, dimmedKeys, compact, interactionHint, maxHeight, onModelClick, labelText, formatValue, timeZone }) => {
   if (!active || !payload || payload.length === 0) return null;
 
   // Filter out null/undefined values and sort by value (fastest to slowest)
@@ -87,8 +89,8 @@ const CustomTimelineTooltip: React.FC<TimelineTooltipProps> = ({ active, payload
       >
         {labelText ??
           (showDate
-            ? `${formatDate(Number(label))} ${formatTimeWithSeconds(Number(label))}`
-            : formatTimeWithSeconds(Number(label)))}
+            ? `${formatDate(Number(label), timeZone)} ${formatTimeWithSeconds(Number(label), timeZone)}`
+            : formatTimeWithSeconds(Number(label), timeZone))}
       </p>
       <div
         className="tooltip-scroll"

--- a/web/components/visualizations/TimelineChart.tsx
+++ b/web/components/visualizations/TimelineChart.tsx
@@ -1021,6 +1021,7 @@ const TimelineChart: React.FC = () => {
                     showDate={dateScale}
                     dimmedKeys={dimmedLegendKeys}
                     compact
+                    timeZone={displayTz}
                   />
                 }
                 active={pinned || dragging || hoveredMarker || isMobile ? false : undefined}
@@ -1177,6 +1178,7 @@ const TimelineChart: React.FC = () => {
                 dimmedKeys={dimmedLegendKeys}
                 compact
                 interactionHint="tap axis to see all"
+                timeZone={displayTz}
               />
             </div>
           )}
@@ -1213,6 +1215,7 @@ const TimelineChart: React.FC = () => {
                 showDate={dateScale}
                 dimmedKeys={dimmedLegendKeys}
                 maxHeight={isMobile ? 106 : undefined}
+                timeZone={displayTz}
                 onModelClick={
                   page === "s2s"
                     ? (model, label) =>

--- a/web/components/visualizations/TimelineChart.tsx
+++ b/web/components/visualizations/TimelineChart.tsx
@@ -410,7 +410,12 @@ const TimelineChart: React.FC = () => {
         .filter((m) => m.ts >= windowStart && m.ts <= windowEnd),
     [activeMetricKey, windowStart, windowEnd]
   );
-  const tzAbbr = getLocalTimeZoneAbbr();
+  // S2S buckets are stored in UTC (runner + infra convention), so render the S2S
+  // timeline in UTC -- a midnight-UTC point rendered in a local zone behind UTC
+  // would slip to the previous day. STT/TTS keep the viewer's local time.
+  const isS2S = activeTab === "s2s";
+  const displayTz = isS2S ? "UTC" : undefined;
+  const tzAbbr = isS2S ? "UTC" : getLocalTimeZoneAbbr();
   const zoomX = zoom?.x;
   const zoomY = zoom?.y;
 
@@ -983,7 +988,7 @@ const TimelineChart: React.FC = () => {
                 tickLine={false}
                 tick={{ fill: themeColors.axisText, fontSize: 12 }}
                 tickFormatter={(value) =>
-                  dateTicks ? formatDate(value) : formatTime(value)
+                  dateTicks ? formatDate(value, displayTz) : formatTime(value, displayTz)
                 }
                 label={{
                   value: xAxisLabel,
@@ -1233,7 +1238,7 @@ const TimelineChart: React.FC = () => {
                 >
                   <p className="font-semibold">{hoveredMarker.change.title}</p>
                   <p className="mt-0.5 text-[10px] text-[var(--color-text-on-tooltip-secondary)]">
-                    Methodology change · {formatDate(hoveredMarker.ts)}
+                    Methodology change · {formatDate(hoveredMarker.ts, displayTz)}
                   </p>
                   <p className="mt-1.5">{hoveredMarker.change.detail}</p>
                 </div>

--- a/web/lib/utils/formatters.ts
+++ b/web/lib/utils/formatters.ts
@@ -35,12 +35,13 @@ export function formatDate(timestamp: number, timeZone?: string): string {
  * Same as {@link formatTime} but includes seconds — used in tooltips where
  * the user is hovering a specific data point and wants higher precision.
  */
-export function formatTimeWithSeconds(timestamp: number): string {
+export function formatTimeWithSeconds(timestamp: number, timeZone?: string): string {
   return new Date(timestamp).toLocaleTimeString(undefined, {
     hour: "2-digit",
     minute: "2-digit",
     second: "2-digit",
-    hour12: false
+    hour12: false,
+    timeZone
   });
 }
 

--- a/web/lib/utils/formatters.ts
+++ b/web/lib/utils/formatters.ts
@@ -6,25 +6,28 @@
  */
 
 /**
- * Format a timestamp as HH:MM in the viewer's local timezone (24-hour).
+ * Format a timestamp as HH:MM (24-hour). Defaults to the viewer's local timezone;
+ * pass `timeZone` (e.g. "UTC") to render in a fixed zone instead.
  *
- * `Intl.DateTimeFormat` defaults to the runtime timezone when none is given,
- * so chart axes always reflect what time the viewer was looking at the page —
- * not UTC, not the server's TZ.
+ * `Intl.DateTimeFormat` defaults to the runtime timezone when none is given, so
+ * axes reflect the viewer's local time unless a `timeZone` is supplied.
  */
-export function formatTime(timestamp: number): string {
+export function formatTime(timestamp: number, timeZone?: string): string {
   return new Date(timestamp).toLocaleTimeString(undefined, {
     hour: "2-digit",
     minute: "2-digit",
-    hour12: false
+    hour12: false,
+    timeZone
   });
 }
 
-/** Short month-day label (e.g. "Jun 5") for date-scale axis ticks. */
-export function formatDate(timestamp: number): string {
+/** Short month-day label (e.g. "Jun 5") for date-scale axis ticks. Defaults to the
+ * viewer's local timezone; pass `timeZone` (e.g. "UTC") to render in a fixed zone. */
+export function formatDate(timestamp: number, timeZone?: string): string {
   return new Date(timestamp).toLocaleDateString(undefined, {
     month: "short",
-    day: "numeric"
+    day: "numeric",
+    timeZone
   });
 }
 


### PR DESCRIPTION
S2S run buckets are stored at midnight UTC, but the timeline rendered them in the viewer's local timezone, so a bucket showed a day early for viewers behind UTC. Render the S2S timeline in UTC to match storage; STT/TTS keep local time.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updates S2S timeline date and time rendering to use UTC consistently.
- Adds optional timezone support to shared timestamp formatters and timeline tooltips.
- Applies UTC formatting to S2S axis ticks, tooltip variants, and methodology markers.
- Preserves local-time rendering for STT and TTS timelines.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failures remain.

<sub>Reviews (2): Last reviewed commit: ["Render S2S timeline tooltip in UTC"](https://github.com/coval-ai/benchmarks/commit/424f993c2f9461c93c0db90576d31339b5d61b42) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46823424)</sub>

<!-- /greptile_comment -->