### PR TITLE
[BENCH-531] Retire old Modulate model ids

### DIFF
--- a/runner/src/coval_bench/registries/models.py
+++ b/runner/src/coval_bench/registries/models.py
@@ -374,6 +374,21 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         tags=(_STREAMING, _MULTI, _DIAR),
         status=_ACTIVE,
     ),
+    # Pre-Velma-2 ids; retired so their orphaned result rows stay off the site.
+    RegisteredModel(
+        benchmark=_STT,
+        provider="modulate",
+        model="english-fast-transcription-streaming",
+        tags=(_STREAMING,),
+        status=_RETIRED,
+    ),
+    RegisteredModel(
+        benchmark=_STT,
+        provider="modulate",
+        model="multilingual-transcription-streaming",
+        tags=(_STREAMING, _MULTI, _DIAR),
+        status=_RETIRED,
+    ),
     #######
     # TTS #
     #######


### PR DESCRIPTION
The BENCH-526 rename left prod result rows orphaned under the old ids (english-fast-transcription-streaming, multilingual-transcription-streaming), and the frontend shows any data-backed model the catalogue doesn't know about, so both old names still render on the site.

Re-adds both ids to the registry as retired, so /v1/providers returns them disabled=true and the frontend hides them.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR restores two legacy Modulate STT model identifiers as retired catalogue entries.
- Marks both pre-Velma-2 identifiers as retired so the provider API reports them as disabled.
- Prevents orphaned historical result rows from causing the legacy models to appear on the frontend.
- Keeps the retired identifiers out of scheduled benchmark execution.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable defects identified.

The new registry entries are unique, retired models are serialized as disabled and hidden by the frontend, and scheduled benchmark execution excludes them.

<sub>Reviews (1): Last reviewed commit: ["\[BENCH-531\] Retire old Modulate model id..."](https://github.com/coval-ai/benchmarks/commit/1c49119c03adf43dc50e581e7b93e9f43fc63c8e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46828591)</sub>

**Context used:**

- Knowledge Base — [Runner Orchestration](https://app.greptile.com/coval/-/custom-context/knowledge-base/coval-ai/benchmarks/-/docs/runner-orchestration.md)

<!-- /greptile_comment -->