### PR TITLE
Add coval-dev-prod local dev script

### DIFF
--- a/web/scripts/coval-dev-prod
+++ b/web/scripts/coval-dev-prod
@@ -83,16 +83,11 @@ else
   fi
 fi
 
-# --- 3. install deps only when they're stale or missing ---
-if [ ! -d node_modules ] \
-  || [ pnpm-lock.yaml -nt node_modules ] \
-  || [ package.json -nt node_modules ] \
-  || { [ -f pnpm-workspace.yaml ] && [ pnpm-workspace.yaml -nt node_modules ]; }; then
-  echo "▶ deps     : installing (node_modules missing or a manifest changed)"
-  pnpm install
-else
-  echo "▶ deps     : up to date, skipping install"
-fi
+# --- 3. install deps — mtime heuristics are unreliable across branch switches,
+# so let pnpm decide: `pnpm install` is a fast no-op when the lockfile and
+# node_modules already match, and it installs whenever they don't. ---
+echo "▶ deps     : pnpm install"
+pnpm install
 
 # --- 4. start the dev server ---
 echo "▶ starting : pnpm dev"

--- a/web/scripts/coval-dev-prod
+++ b/web/scripts/coval-dev-prod
@@ -46,7 +46,9 @@ echo "▶ branch   : $BRANCH"
 # --- 2. read the effective NEXT_PUBLIC_API_URL (.env.local wins over .env) ---
 read_var() {
   [ -f "$1" ] || return 0
-  grep -E '^NEXT_PUBLIC_API_URL=' "$1" | tail -n1 | cut -d= -f2- | tr -d '"'"'"' '
+  # No match is normal (key absent); swallow grep's exit 1 so pipefail + set -e
+  # don't kill the script on the enclosing "$(...)" assignment.
+  grep -E '^NEXT_PUBLIC_API_URL=' "$1" | tail -n1 | cut -d= -f2- | tr -d '"'"'"' ' || true
 }
 
 set_local() {
@@ -74,13 +76,19 @@ else
     set_local
     echo "▶ data     : prod ✓ (overridden in .env.local)"
   else
-    echo "  Leaving as-is. Starting dev with the existing value."
+    # The exported NEXT_PUBLIC_API_URL would otherwise win over .env.local in
+    # Next.js (process.env beats .env files), so drop it to honor the kept value.
+    unset NEXT_PUBLIC_API_URL
+    echo "  Leaving as-is. Starting dev with the existing .env.local value."
   fi
 fi
 
 # --- 3. install deps only when they're stale or missing ---
-if [ ! -d node_modules ] || [ pnpm-lock.yaml -nt node_modules ]; then
-  echo "▶ deps     : installing (node_modules missing or lockfile changed)"
+if [ ! -d node_modules ] \
+  || [ pnpm-lock.yaml -nt node_modules ] \
+  || [ package.json -nt node_modules ] \
+  || { [ -f pnpm-workspace.yaml ] && [ pnpm-workspace.yaml -nt node_modules ]; }; then
+  echo "▶ deps     : installing (node_modules missing or a manifest changed)"
   pnpm install
 else
   echo "▶ deps     : up to date, skipping install"

--- a/web/scripts/coval-dev-prod
+++ b/web/scripts/coval-dev-prod
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Run the local Next.js dev server pointed at PROD benchmark data.
+#
+# Local dev convenience. Works from inside ANY coval-benchmarks worktree: it
+# detects the worktree you're standing in and targets that one's web/ dir.
+# "Prod data" = the deployed FastAPI backend (read-only). It only sets
+# NEXT_PUBLIC_API_URL; never touches prod Postgres.
+#
+# Usage:  cd into any worktree, then run it from the repo:
+#           ./web/scripts/coval-dev-prod
+#         (or symlink it into a directory on your PATH to call it by name).
+set -euo pipefail
+
+# The prod backend URL is intentionally NOT hardcoded here. It reuses the same
+# variable name as Vercel (NEXT_PUBLIC_API_URL) as the single source of truth:
+# copy the prod value from Vercel and export it in your shell before running,
+# e.g. export NEXT_PUBLIC_API_URL=https://... in ~/.zshrc
+PROD_URL="${NEXT_PUBLIC_API_URL:-}"
+if [ -z "$PROD_URL" ]; then
+  echo "✗ NEXT_PUBLIC_API_URL is not set. Copy the prod value from Vercel and export it, e.g.:" >&2
+  echo "    export NEXT_PUBLIC_API_URL=https://<your-prod-api-host>" >&2
+  exit 1
+fi
+
+# --- detect the worktree you're currently in ---
+ROOT="$(git -C "$PWD" rev-parse --show-toplevel 2>/dev/null || true)"
+if [ -z "$ROOT" ]; then
+  echo "✗ Not inside a git worktree. cd into a coval-benchmarks worktree first." >&2
+  exit 1
+fi
+WEB_DIR="$ROOT/web"
+if [ ! -d "$WEB_DIR" ]; then
+  echo "✗ No web/ dir at $ROOT — is this the benchmarks repo?" >&2
+  exit 1
+fi
+cd "$WEB_DIR"
+
+# Writes/updates NEXT_PUBLIC_API_URL in web/.env.local, creating the file if absent.
+LOCAL_ENV="$WEB_DIR/.env.local"
+
+# --- 1. show which worktree/branch we're about to run, so you can confirm ---
+BRANCH="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo '?')"
+echo "▶ worktree : $ROOT"
+echo "▶ branch   : $BRANCH"
+
+# --- 2. read the effective NEXT_PUBLIC_API_URL (.env.local wins over .env) ---
+read_var() {
+  [ -f "$1" ] || return 0
+  grep -E '^NEXT_PUBLIC_API_URL=' "$1" | tail -n1 | cut -d= -f2- | tr -d '"'"'"' '
+}
+
+set_local() {
+  if [ -f "$LOCAL_ENV" ] && grep -qE '^NEXT_PUBLIC_API_URL=' "$LOCAL_ENV"; then
+    sed -i.bak -E "s#^NEXT_PUBLIC_API_URL=.*#NEXT_PUBLIC_API_URL=$PROD_URL#" "$LOCAL_ENV"
+    rm -f "$LOCAL_ENV.bak"
+  else
+    printf 'NEXT_PUBLIC_API_URL=%s\n' "$PROD_URL" >> "$LOCAL_ENV"
+  fi
+}
+
+EFFECTIVE="$(read_var "$LOCAL_ENV")"
+[ -z "$EFFECTIVE" ] && EFFECTIVE="$(read_var "$WEB_DIR/.env")"
+
+if [ "$EFFECTIVE" = "$PROD_URL" ]; then
+  echo "▶ data     : prod ✓ ($PROD_URL)"
+elif [ -z "$EFFECTIVE" ]; then
+  echo "▶ data     : NEXT_PUBLIC_API_URL not set — writing prod URL to .env.local"
+  set_local
+else
+  echo "⚠ NEXT_PUBLIC_API_URL is currently: $EFFECTIVE"
+  echo "  That is NOT the prod API."
+  read -r -p "  Override it with the prod URL in .env.local? [y/N] " ans
+  if [ "$ans" = "y" ] || [ "$ans" = "Y" ]; then
+    set_local
+    echo "▶ data     : prod ✓ (overridden in .env.local)"
+  else
+    echo "  Leaving as-is. Starting dev with the existing value."
+  fi
+fi
+
+# --- 3. install deps only when they're stale or missing ---
+if [ ! -d node_modules ] || [ pnpm-lock.yaml -nt node_modules ]; then
+  echo "▶ deps     : installing (node_modules missing or lockfile changed)"
+  pnpm install
+else
+  echo "▶ deps     : up to date, skipping install"
+fi
+
+# --- 4. start the dev server ---
+echo "▶ starting : pnpm dev"
+exec pnpm dev


### PR DESCRIPTION
More of a handoff, since we all have our local scripts to spin this up

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a local development script for running the web application against production benchmark data.
- Resolves the active Git worktree and web directory.
- Manages `NEXT_PUBLIC_API_URL` through local environment files.
- Runs `pnpm install` before starting the Next.js development server.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failures remain.

<sub>Reviews (3): Last reviewed commit: ["Always run pnpm install in coval-dev-pro..."](https://github.com/coval-ai/benchmarks/commit/7c54dd9eaa555806c314cb720da39f5603676f5a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46829058)</sub>

<!-- /greptile_comment -->