### PR TITLE
Add Speechify TTS streaming provider

### DIFF
--- a/runner/src/coval_bench/config.py
+++ b/runner/src/coval_bench/config.py
@@ -96,6 +96,7 @@ class Settings(BaseSettings):
     minimax_api_key: SecretStr | None = None
     palabra_api_key: SecretStr | None = None
     modulate_api_key: SecretStr | None = None
+    speechify_api_key: SecretStr | None = None
 
     # Azure region hosting the Speech resource (e.g. "eastus"). Determines the
     # region-scoped WebSocket host; required only when the Azure STT provider runs.

--- a/runner/src/coval_bench/providers/tts/__init__.py
+++ b/runner/src/coval_bench/providers/tts/__init__.py
@@ -31,6 +31,7 @@ from coval_bench.providers.tts.palabra import PalabraTTSProvider
 from coval_bench.providers.tts.rime import RimeTTSProvider
 from coval_bench.providers.tts.smallest import SmallestTTSProvider
 from coval_bench.providers.tts.soniox import SonioxTTSProvider
+from coval_bench.providers.tts.speechify import SpeechifyTTSProvider
 from coval_bench.providers.tts.xai import XaiTTSProvider
 
 try:
@@ -65,6 +66,7 @@ TTS_PROVIDERS: dict[str, type[TTSProvider]] = {
     "alibaba": AlibabaTTSProvider,
     "minimax": MinimaxTTSProvider,
     "palabra": PalabraTTSProvider,
+    "speechify": SpeechifyTTSProvider,
 }
 
 if HumeTTSProvider is not None:
@@ -88,4 +90,5 @@ __all__ = [
     "GroqTTSProvider",
     "SonioxTTSProvider",
     "PalabraTTSProvider",
+    "SpeechifyTTSProvider",
 ]

--- a/runner/src/coval_bench/providers/tts/speechify.py
+++ b/runner/src/coval_bench/providers/tts/speechify.py
@@ -1,0 +1,150 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Speechify TTS provider — chunked HTTP streaming against a shared httpx pool."""
+
+from __future__ import annotations
+
+import time
+
+import structlog
+
+from coval_bench.config import Settings
+from coval_bench.providers._http_session import (
+    connection_reused,
+    get_shared_client,
+    submit_to_headers_ms,
+)
+from coval_bench.providers.base import TTSProvider, TTSResult
+from coval_bench.providers.tts._common import finalize_tts_result
+
+logger: structlog.BoundLogger = structlog.get_logger(__name__)
+
+SAMPLE_RATE = 24000
+
+_BASE_URL = "https://api.speechify.ai"
+_OUTPUT_FORMAT = "pcm_24000"
+
+
+class SpeechifyTTSProvider(TTSProvider):
+    """Speechify TTS provider over the REST streaming endpoint."""
+
+    _VALID_MODELS = frozenset({"simba-3.2", "simba-3.0"})
+
+    def __init__(self, settings: Settings, model: str, voice: str) -> None:
+        if model not in self._VALID_MODELS:
+            raise ValueError(
+                f"Unsupported Speechify model {model!r}. Valid: {sorted(self._VALID_MODELS)}"
+            )
+        self._model = model
+        self._voice = voice
+
+        api_key_secret = settings.speechify_api_key
+        if api_key_secret is None:
+            raise ValueError("speechify_api_key is required in Settings")
+        self._api_key = api_key_secret.get_secret_value()
+
+    @property
+    def name(self) -> str:
+        return f"speechify-{self._model}"
+
+    @property
+    def model(self) -> str:
+        return self._model
+
+    @classmethod
+    async def warmup(cls, settings: Settings) -> None:
+        """Pre-warm the shared httpx pool; a 401 on the HEAD still warms the socket."""
+        client = get_shared_client("speechify", _BASE_URL)
+        t0 = time.monotonic()
+        response = await client.head("/v1/voices")
+        logger.info(
+            "speechify_prewarm",
+            warmup_ms=round((time.monotonic() - t0) * 1000, 1),
+            http_version=response.http_version,
+        )
+        if response.http_version != "HTTP/2":
+            logger.warning("speechify_prewarm_no_http2", http_version=response.http_version)
+
+    async def synthesize(self, text: str) -> TTSResult:
+        client = get_shared_client("speechify", _BASE_URL)
+        headers = {
+            "Authorization": f"Bearer {self._api_key}",
+            "Content-Type": "application/json",
+            "Accept": "audio/pcm",
+        }
+        payload = {
+            "input": text,
+            "voice_id": self._voice,
+            "model": self._model,
+            "output_format": _OUTPUT_FORMAT,
+        }
+
+        audio_chunks: list[bytes] = []
+        http_version: str | None = None
+        setup_ms: float | None = None
+        reused: bool | None = None
+        start: float | None = None
+        first_chunk_at: float | None = None
+
+        try:
+            start = time.monotonic()
+            async with client.stream(
+                "POST", "/v1/audio/stream", headers=headers, json=payload
+            ) as response:
+                http_version = response.http_version
+                setup_ms = submit_to_headers_ms(response.request)
+                reused = connection_reused(response.request)
+                if response.is_error:
+                    body = await response.aread()
+                    detail = body.decode("utf-8", "replace").strip() or response.reason_phrase
+                    return finalize_tts_result(
+                        provider="speechify",
+                        model=self._model,
+                        voice=self._voice,
+                        pcm=b"",
+                        sample_rate=SAMPLE_RATE,
+                        audio_synthesis_start=None,
+                        first_audio_chunk_at=None,
+                        error=f"HTTP {response.status_code}: {detail[:500]}",
+                        http_version=http_version,
+                        submit_to_headers_ms=setup_ms,
+                        connection_reused=reused,
+                    )
+                async for chunk in response.aiter_bytes():
+                    if chunk:
+                        if first_chunk_at is None:
+                            first_chunk_at = time.monotonic()
+                        audio_chunks.append(chunk)
+        except Exception as exc:
+            logger.warning("speechify_error", provider="speechify", model=self._model, exc_info=exc)
+            return finalize_tts_result(
+                provider="speechify",
+                model=self._model,
+                voice=self._voice,
+                pcm=b"",
+                sample_rate=SAMPLE_RATE,
+                audio_synthesis_start=start,
+                first_audio_chunk_at=first_chunk_at,
+                error=str(exc),
+                http_version=http_version,
+                submit_to_headers_ms=setup_ms,
+                connection_reused=reused,
+            )
+
+        audio_data = b"".join(audio_chunks)
+        if not audio_data:
+            logger.warning("speechify_no_audio", model=self._model)
+
+        return finalize_tts_result(
+            provider="speechify",
+            model=self._model,
+            voice=self._voice,
+            pcm=audio_data,
+            sample_rate=SAMPLE_RATE,
+            audio_synthesis_start=start,
+            first_audio_chunk_at=first_chunk_at,
+            http_version=http_version,
+            submit_to_headers_ms=setup_ms,
+            connection_reused=reused,
+        )

--- a/runner/src/coval_bench/registries/models.py
+++ b/runner/src/coval_bench/registries/models.py
@@ -724,6 +724,22 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         tags=(_STREAMING, _MULTI, _CLONE, _EMOTION, _STREAM),
         status=_ACTIVE,
     ),
+    RegisteredModel(
+        benchmark=_TTS,
+        provider="speechify",
+        model="simba-3.2",
+        voice="geffen_32",
+        tags=(_STREAMING, _CLONE, _EMOTION),
+        status=_EARLY_ACCESS,
+    ),
+    RegisteredModel(
+        benchmark=_TTS,
+        provider="speechify",
+        model="simba-3.0",
+        voice="geffen_32",
+        tags=(_STREAMING, _MULTI, _CLONE, _EMOTION),
+        status=_EARLY_ACCESS,
+    ),
     # gpt-realtime is a speech-to-speech LLM, not a TTS provider: driving it
     # from a text "instructions" prompt folds LLM inference into TTFA and never
     # guarantees verbatim speech, so its metrics are incomparable here. Kept

--- a/runner/src/coval_bench/registries/provider_keys.py
+++ b/runner/src/coval_bench/registries/provider_keys.py
@@ -37,4 +37,5 @@ PROVIDER_ENV: dict[str, str] = {
     "alibaba": "ALIBABA_API_KEY",
     "minimax": "MINIMAX_API_KEY",
     "palabra": "PALABRA_API_KEY",
+    "speechify": "SPEECHIFY_API_KEY",
 }

--- a/runner/tests/providers/tts/test_speechify.py
+++ b/runner/tests/providers/tts/test_speechify.py
@@ -1,0 +1,188 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the Speechify TTS provider."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Generator
+from typing import Any
+
+import httpx
+import pytest
+from pydantic import SecretStr
+
+from coval_bench.config import Settings
+from coval_bench.providers import _http_session
+from coval_bench.providers.tts.speechify import SpeechifyTTSProvider
+
+from .conftest import make_pcm_bytes
+
+_VOICE = "geffen_32"
+
+
+def _settings(**overrides: object) -> Settings:
+    base: dict[str, object] = {
+        "database_url": "postgresql://runner:password@localhost:5432/benchmarks",
+        "dataset_bucket": "test-bucket",
+        "dataset_id": "stt-v1",
+        "runner_sha": "test",
+        "log_level": "DEBUG",
+        "speechify_api_key": SecretStr("test-speechify-key"),
+    }
+    base.update(overrides)
+    return Settings(**base)  # type: ignore[arg-type]
+
+
+def _install_mock(handler: Any) -> None:
+    _http_session._CLIENTS["speechify"] = httpx.AsyncClient(
+        base_url="https://api.speechify.ai",
+        transport=httpx.MockTransport(handler),
+    )
+
+
+@pytest.fixture(autouse=True)
+def reset_clients() -> Generator[None, None, None]:
+    _http_session._CLIENTS.clear()
+    yield
+    _http_session._CLIENTS.clear()
+
+
+@pytest.mark.asyncio
+async def test_speechify_happy_path() -> None:
+    pcm = make_pcm_bytes(480) * 4
+    captured: dict[str, object] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        captured["authorization"] = request.headers.get("authorization")
+        captured["accept"] = request.headers.get("accept")
+        captured["body"] = json.loads(request.read())
+        return httpx.Response(200, content=pcm)
+
+    _install_mock(handler)
+
+    provider = SpeechifyTTSProvider(_settings(), model="simba-3.2", voice=_VOICE)
+    result = await provider.synthesize("Hello from Speechify")
+
+    assert result.error is None, result.error
+    assert result.ttfa_ms is not None and 0 < result.ttfa_ms < 10_000
+    assert result.audio_path is not None and result.audio_path.exists()
+    assert result.audio_path.stat().st_size > 0
+    assert result.provider == "speechify"
+    assert result.model == "simba-3.2"
+
+    assert str(captured["url"]).endswith("/v1/audio/stream")
+    assert captured["authorization"] == "Bearer test-speechify-key"
+    assert captured["accept"] == "audio/pcm"
+    body = captured["body"]
+    assert isinstance(body, dict)
+    assert body["input"] == "Hello from Speechify"
+    assert body["voice_id"] == _VOICE
+    assert body["model"] == "simba-3.2"
+    assert body["output_format"] == "pcm_24000"
+
+    result.audio_path.unlink()
+
+
+@pytest.mark.asyncio
+async def test_speechify_all_models() -> None:
+    def handler(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=make_pcm_bytes(240))
+
+    _install_mock(handler)
+
+    for model in SpeechifyTTSProvider._VALID_MODELS:
+        provider = SpeechifyTTSProvider(_settings(), model=model, voice=_VOICE)
+        result = await provider.synthesize("test")
+        assert result.error is None, f"{model}: {result.error}"
+        if result.audio_path is not None:
+            result.audio_path.unlink()
+
+
+@pytest.mark.asyncio
+async def test_speechify_http_error() -> None:
+    def handler(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(429, content=b'{"detail": "rate limit"}')
+
+    _install_mock(handler)
+
+    provider = SpeechifyTTSProvider(_settings(), model="simba-3.2", voice=_VOICE)
+    result = await provider.synthesize("hi")
+
+    assert result.error is not None
+    assert "429" in result.error
+    assert "rate limit" in result.error
+    assert result.audio_path is None
+
+
+@pytest.mark.asyncio
+async def test_speechify_transport_exception() -> None:
+    def handler(_: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("synthetic network failure")
+
+    _install_mock(handler)
+
+    provider = SpeechifyTTSProvider(_settings(), model="simba-3.2", voice=_VOICE)
+    result = await provider.synthesize("hi")
+
+    assert result.error is not None
+    assert "synthetic network failure" in result.error
+    assert result.audio_path is None
+    assert result.ttfa_ms is None
+
+
+@pytest.mark.asyncio
+async def test_speechify_empty_response() -> None:
+    def handler(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=b"")
+
+    _install_mock(handler)
+
+    provider = SpeechifyTTSProvider(_settings(), model="simba-3.2", voice=_VOICE)
+    result = await provider.synthesize("silence")
+
+    assert result.error is None
+    assert result.audio_path is None
+    assert result.ttfa_ms is None
+
+
+@pytest.mark.asyncio
+async def test_speechify_warmup_issues_head() -> None:
+    seen: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(f"{request.method} {request.url.path}")
+        return httpx.Response(401, content=b"unauthorized")
+
+    _install_mock(handler)
+    await SpeechifyTTSProvider.warmup(_settings())
+
+    assert seen == ["HEAD /v1/voices"]
+
+
+@pytest.mark.asyncio
+async def test_speechify_warmup_propagates_transport_error() -> None:
+    def handler(_: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("dns blew up")
+
+    _install_mock(handler)
+    with pytest.raises(httpx.ConnectError):
+        await SpeechifyTTSProvider.warmup(_settings())
+
+
+def test_speechify_name_and_model() -> None:
+    p = SpeechifyTTSProvider(_settings(), model="simba-3.0", voice=_VOICE)
+    assert p.name == "speechify-simba-3.0"
+    assert p.model == "simba-3.0"
+
+
+def test_speechify_rejects_unsupported_model() -> None:
+    with pytest.raises(ValueError, match="Unsupported Speechify model"):
+        SpeechifyTTSProvider(_settings(), model="simba-english", voice=_VOICE)
+
+
+def test_speechify_missing_api_key() -> None:
+    with pytest.raises(ValueError, match="speechify_api_key"):
+        SpeechifyTTSProvider(_settings(speechify_api_key=None), model="simba-3.2", voice=_VOICE)


### PR DESCRIPTION
Chunked HTTP streaming for simba-3.2 and simba-3.0, registered early-access until the prod key is mounted.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds an early-access Speechify TTS integration with chunked HTTP streaming.
- Registers the simba-3.2 and simba-3.0 models with the Speechify provider.
- Adds API-key configuration and provider-key mapping.
- Implements shared-client warmup, streaming synthesis, timing instrumentation, and error handling.
- Adds unit coverage for supported models, successful synthesis, empty and error responses, transport failures, warmup, and configuration validation.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable defects identified.

Speechify is wired consistently through configuration and registries, its early-access models remain appropriately scoped, and synthesis failures are converted into controlled benchmark results.

<sub>Reviews (1): Last reviewed commit: ["Add Speechify TTS streaming provider"](https://github.com/coval-ai/benchmarks/commit/7cb38168f051b91ab4065cff83a764e858ea3df0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46829418)</sub>

**Context used:**

- Knowledge Base — [Runner Orchestration](https://app.greptile.com/coval/-/custom-context/knowledge-base/coval-ai/benchmarks/-/docs/runner-orchestration.md)

<!-- /greptile_comment -->