### PR TITLE
Surface multi-turn S2S conversation samples

### DIFF
--- a/runner/src/coval_bench/s2s/fetch_v2v.py
+++ b/runner/src/coval_bench/s2s/fetch_v2v.py
@@ -28,7 +28,7 @@ from coval_bench.db.models import Result, ResultStatus, RunStatus
 from coval_bench.db.writer import RunWriter
 from coval_bench.registries import Metric
 from coval_bench.registries.benchmarks import Benchmark
-from coval_bench.s2s.samples import SampleRun, copy_tick_samples
+from coval_bench.s2s.samples import SampleRun, publish_tick_sample
 
 logger = structlog.get_logger("coval_bench.s2s.fetch_v2v")
 
@@ -62,6 +62,7 @@ class CovalRun:
     run_id: str
     create_time: datetime | None
     error_status: str | None
+    persona_id: str = ""
 
 
 # Agent ids resolved from Settings; model strings are display labels.
@@ -166,6 +167,7 @@ async def recent_completed_runs(
             run_id=cast("str", r["run_id"]),
             create_time=_parse_time(r.get("create_time")),
             error_status=_error_status(r.get("error_status")),
+            persona_id=cast("str", r.get("persona_id") or ""),
         )
         if run.create_time is not None and (now - run.create_time).total_seconds() > window_seconds:
             continue
@@ -478,22 +480,23 @@ async def _fetch_one_provider(
     caught here so one provider can't abort others.
     """
     statuses: list[RunStatus] = []
-    candidate: SampleRun | None = None
+    candidates: dict[str, SampleRun] = {}
 
     def note_sample_candidate(coval_run: CovalRun) -> None:
-        # Newest-first scan: the first eligible run per provider is its newest,
-        # whether it was ingested this tick or on an earlier one — staggered
-        # arrivals must not shrink the sample to one provider. Held locally and
-        # committed only after the staleness check, so a stale provider's old
-        # recording never ships under today's tick.
-        nonlocal candidate
-        if candidate is not None:
+        # Newest-first scan: keep the newest eligible run PER PERSONA. Multi-turn
+        # runs the same test set once per persona, so a provider yields one
+        # candidate per persona (single-turn has no persona -> a single "" key).
+        # Staggered arrivals must not shrink the sample; committed only after the
+        # staleness check so a stale provider's old recording never ships today.
+        if coval_run.persona_id in candidates:
             return
-        candidate = SampleRun(
+        candidates[coval_run.persona_id] = SampleRun(
             provider=spec.provider,
             model=spec.model,
             coval_run_id=coval_run.run_id,
             bucket_at=_bucket_start(coval_run.create_time or datetime.now(tz=UTC), period_seconds),
+            persona_id=coval_run.persona_id,
+            agent_id=agent_id,
         )
 
     try:
@@ -570,8 +573,8 @@ async def _fetch_one_provider(
             )
             return RunStatus.FAILED, len(statuses)
 
-        if sampled_runs is not None and candidate is not None:
-            sampled_runs.append(candidate)
+        if sampled_runs is not None:
+            sampled_runs.extend(candidates.values())
 
         if statuses:
             if all(s is RunStatus.FAILED for s in statuses):
@@ -648,16 +651,17 @@ async def fetch_and_write_v2v(settings: Settings | None = None) -> dict[str, Run
             except Exception:
                 logger.warning("refresh_stats_matviews_failed", exc_info=True)
 
-        if settings.s2s_samples_bucket and sampled_runs:
+        if settings.s2s_samples_bucket and sampled_runs and test_set_id:
             expected = {spec.provider for spec in AGENTS if getattr(settings, spec.agent_id_attr)}
             missing = expected - {r.provider for r in sampled_runs}
             if missing:
                 # Error level on purpose: this is the alert that a provider is
                 # absent from the day's sample; the tick still publishes the rest.
                 logger.error("samples_provider_missing", missing=sorted(missing))
-            await copy_tick_samples(
+            await publish_tick_sample(
                 client,
                 bucket_name=settings.s2s_samples_bucket,
+                test_set_id=test_set_id,
                 runs=sampled_runs,
                 rng=random.Random(),  # noqa: S311
             )

--- a/runner/src/coval_bench/s2s/samples.py
+++ b/runner/src/coval_bench/s2s/samples.py
@@ -250,20 +250,22 @@ async def _publish_tick_sample(
         storage_client = gcs.Client()
     bucket = storage_client.bucket(bucket_name)
 
-    tick_key = max(r.bucket_at for r in runs).strftime("%Y-%m-%dT%H:%M:%SZ")
-    manifest_key = f"{PREFIX}/{tick_key}/manifest.json"
-    if bucket.blob(manifest_key).exists():
-        # Idempotent repair: manifest published but the index update failed.
-        _update_index(bucket, tick_key)
-        logger.info("samples_tick_exists", tick=tick_key)
-        return 0
-
     # Uniform draw over the shared conversations of both personas; repick on any
     # incomplete provider so only a fully-complete conversation (audio + turns for
     # EVERY provider) is ever surfaced.
     rng.shuffle(pool)
     for persona_id, test_case_id in pool:
         prov_runs = runs_by_persona[persona_id]
+        # Key the sample by the CHOSEN conversation's own bucket, not the max across
+        # all personas: personas can straddle bucket boundaries, and the global max
+        # would store this sample under an unrelated (newer) tick and mislabel it.
+        tick_key = max(prov_runs[p].bucket_at for p in providers).strftime("%Y-%m-%dT%H:%M:%SZ")
+        manifest_key = f"{PREFIX}/{tick_key}/manifest.json"
+        if bucket.blob(manifest_key).exists():
+            # Idempotent repair: manifest published but the index update failed.
+            _update_index(bucket, tick_key)
+            logger.info("samples_tick_exists", tick=tick_key)
+            return 0
         staged: list[tuple[SampleRun, str, bytes, list[dict[str, Any]]]] = []
         for provider in sorted(providers):
             run = prov_runs[provider]
@@ -329,5 +331,5 @@ async def _publish_tick_sample(
         )
         return len(recordings)
 
-    logger.error("samples_no_complete_sample", tick=tick_key)
+    logger.error("samples_no_complete_sample")
     return 0

--- a/runner/src/coval_bench/s2s/samples.py
+++ b/runner/src/coval_bench/s2s/samples.py
@@ -1,21 +1,21 @@
 # Copyright 2026 The Coval Benchmarks Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Copy one shared utterance's conversation recordings into the samples bucket.
+"""Publish one multi-turn conversation sample per fetch tick.
 
-Each fetch tick picks ONE dataset clip present in every provider's newest
-ingested run and copies that clip's reconstructed conversation recording from
-each provider into the public samples bucket, next to a ``manifest.json``
-keyed by the timeline bucket timestamp. The dashboard reads the manifests
-directly (public bucket, no API hop); a rolling ``index.json`` lists the
-available ticks newest-first. The bucket's 30-day TTL prunes old ticks.
+Each tick picks ONE (scenario, persona) present for every provider, uploads
+each provider's full-conversation recording plus its per-agent transcript into
+the public samples bucket, and writes a ``manifest.json`` keyed by the timeline
+bucket timestamp. Only a fully-complete sample (audio + transcript for every
+provider) is published; otherwise the tick is skipped. The dashboard reads the
+manifests directly (public bucket, no API hop); a rolling ``index.json`` lists
+the available ticks newest-first. The bucket's 30-day TTL prunes old ticks.
 
 Sampling failures never fail the fetch — the metric rows are the product.
 """
 
 from __future__ import annotations
 
-import importlib.resources
 import json
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
@@ -38,47 +38,51 @@ logger = structlog.get_logger("coval_bench.s2s.samples")
 PREFIX = "s2s-samples"
 INDEX_KEY = f"{PREFIX}/index.json"
 _INDEX_MAX_ENTRIES = 60
-_PUBLIC_DATASET_BASE = "https://storage.googleapis.com/coval-benchmarks-datasets/s2s-v1"
 _DOWNLOAD_TIMEOUT = 120.0
+
+# Multi-turn bench personas, matched by id — raw Coval names are unreliable (the
+# male persona's name carries a trailing space). If the personas churn, update
+# here (or lift into Settings).
+_PERSONA_LABELS: dict[str, str] = {
+    "PN3xgmsqeLDjsNNEA2e55e": "Standard Female",
+    "9ATy64zKXxSUaVWb5YnQtd": "Standard Male",
+}
+
+
+def _persona_label(persona_id: str) -> str:
+    return _PERSONA_LABELS.get(persona_id, persona_id)
 
 
 @dataclass(frozen=True)
 class SampleRun:
-    """One provider's newest ingested run, eligible for this tick's sample."""
+    """One provider's ingested run, eligible for this tick's sample.
+
+    ``persona_id``/``agent_id`` are populated for multi-turn (where a provider
+    has one run per persona); the single-turn path leaves them empty.
+    """
 
     provider: str
     model: str
     coval_run_id: str
     bucket_at: datetime
+    persona_id: str = ""
+    agent_id: str = ""
 
 
-def _norm(text: str) -> str:
-    return " ".join(text.split()).casefold()
+def _conversation_turns(sim: dict[str, Any]) -> list[dict[str, Any]]:
+    """Full ordered conversation as ``{index, role, content}`` turns.
 
-
-def _clips_by_transcript() -> dict[str, str]:
-    """Packaged-manifest transcript -> public dataset clip path, unambiguous only.
-
-    Several transcripts appear on multiple clips (different speakers); those
-    can't be resolved by text, so they're dropped and the sample ships with
-    input_audio_url = null rather than possibly the wrong recording.
+    Non-string content is skipped so a malformed message can't poison the
+    manifest; an empty list means the transcript couldn't be resolved and the
+    sample is treated as incomplete.
     """
-    ref = importlib.resources.files("coval_bench.datasets.manifests").joinpath("s2s-v1.json")
-    manifest = json.loads(ref.read_bytes())
-    paths_by_transcript: dict[str, set[str]] = {}
-    for item in manifest["items"]:
-        if item.get("transcript") and item.get("path"):
-            paths_by_transcript.setdefault(_norm(item["transcript"]), set()).add(item["path"])
-    return {t: next(iter(paths)) for t, paths in paths_by_transcript.items() if len(paths) == 1}
-
-
-def _input_transcript(sim: dict[str, Any]) -> str | None:
-    """First user turn of the conversation — the utterance the model heard."""
+    turns: list[dict[str, Any]] = []
     for message in cast("list[dict[str, Any]]", sim.get("transcript") or []):
-        if message.get("role") == "user":
-            content = message.get("content")
-            return content if isinstance(content, str) else None
-    return None
+        role = message.get("role")
+        content = message.get("content")
+        if isinstance(role, str) and isinstance(content, str):
+            turns.append({"index": len(turns), "role": role, "content": content})
+    return turns
 
 
 async def _fetch_retry[T](fn: Callable[[], Awaitable[T]], *, provider: str, what: str) -> T:
@@ -159,28 +163,29 @@ def _update_index(bucket: storage.Bucket, tick_key: str) -> None:
     _upload(bucket, INDEX_KEY, json.dumps(ticks).encode(), "application/json")
 
 
-async def copy_tick_samples(
+async def publish_tick_sample(
     client: httpx.AsyncClient,
     *,
     bucket_name: str,
+    test_set_id: str,
     runs: list[SampleRun],
     rng: Random,
     storage_client: storage.Client | None = None,
     download_client: httpx.AsyncClient | None = None,
 ) -> int:
-    """Copy this tick's shared-clip recordings; return how many were stored.
+    """Copy one multi-turn conversation (every provider, one persona) as a v2 sample.
 
-    Never raises: any failure is logged and the tick is simply skipped or
-    shipped with fewer providers.
+    Never raises: any failure is logged and the tick is simply skipped.
     """
     if not bucket_name or not runs:
         return 0
     try:
         async with httpx.AsyncClient(timeout=_DOWNLOAD_TIMEOUT) as default_download:
-            return await _copy_tick_samples(
+            return await _publish_tick_sample(
                 client,
                 download_client or default_download,
                 bucket_name=bucket_name,
+                test_set_id=test_set_id,
                 runs=runs,
                 rng=rng,
                 storage_client=storage_client,
@@ -190,37 +195,54 @@ async def copy_tick_samples(
         return 0
 
 
-async def _copy_tick_samples(
+async def _publish_tick_sample(
     client: httpx.AsyncClient,
     download_client: httpx.AsyncClient,
     *,
     bucket_name: str,
+    test_set_id: str,
     runs: list[SampleRun],
     rng: Random,
     storage_client: storage.Client | None,
 ) -> int:
-    sims_per_run: dict[str, dict[str, str]] = {}
+    providers = {r.provider for r in runs}
+
+    # A "conversation" is one (test_case, persona) pair — the same scenario and
+    # the same simulated caller, which is what makes the sample comparable across
+    # providers. Group runs by persona; only a persona present for EVERY provider
+    # can yield a conversation. sims[(persona, provider)] = {test_case_id: sim_id}.
+    runs_by_persona: dict[str, dict[str, SampleRun]] = {}
     for run in runs:
+        runs_by_persona.setdefault(run.persona_id, {})[run.provider] = run
 
-        async def list_sims(run: SampleRun = run) -> dict[str, str]:
-            return await _sims_by_test_case(client, run.coval_run_id)
-
-        try:
-            sims_per_run[run.coval_run_id] = await _fetch_retry(
-                list_sims, provider=run.provider, what="sims_list"
+    sims: dict[tuple[str, str], dict[str, str]] = {}
+    pool: list[tuple[str, str]] = []
+    for persona_id, prov_runs in runs_by_persona.items():
+        if set(prov_runs) != providers:
+            logger.error(
+                "samples_persona_incomplete",
+                persona=persona_id,
+                missing=sorted(providers - set(prov_runs)),
             )
-        except Exception:
-            logger.error("samples_provider_missing", missing=[run.provider], exc_info=True)
+            continue
+        for provider, run in prov_runs.items():
 
-    runs = [run for run in runs if run.coval_run_id in sims_per_run]
-    if not runs:
-        return 0
+            async def list_sims(run: SampleRun = run) -> dict[str, str]:
+                return await _sims_by_test_case(client, run.coval_run_id)
 
-    shared = set.intersection(*(set(m) for m in sims_per_run.values()))
-    if not shared:
+            try:
+                sims[(persona_id, provider)] = await _fetch_retry(
+                    list_sims, provider=provider, what="sims_list"
+                )
+            except Exception:
+                logger.error("samples_provider_missing", missing=[provider], exc_info=True)
+                sims[(persona_id, provider)] = {}
+        shared = set.intersection(*(set(sims[(persona_id, p)]) for p in providers))
+        pool.extend((persona_id, tc) for tc in sorted(shared))
+
+    if not pool:
         logger.error("samples_no_shared_clip", runs=[r.coval_run_id for r in runs])
         return 0
-    test_case_id = rng.choice(sorted(shared))
 
     if storage_client is None:  # pragma: no cover -- real client only outside tests
         from google.cloud import storage as gcs
@@ -228,72 +250,84 @@ async def _copy_tick_samples(
         storage_client = gcs.Client()
     bucket = storage_client.bucket(bucket_name)
 
-    # Providers of one Coval round land in the same daily bucket; if they ever
-    # straddle midnight, key the folder by the newest so the timeline join
-    # points at data that exists.
     tick_key = max(r.bucket_at for r in runs).strftime("%Y-%m-%dT%H:%M:%SZ")
-
     manifest_key = f"{PREFIX}/{tick_key}/manifest.json"
     if bucket.blob(manifest_key).exists():
-        # Idempotent repair: a prior run may have published the manifest but
-        # failed the index update, leaving the tick invisible.
+        # Idempotent repair: manifest published but the index update failed.
         _update_index(bucket, tick_key)
         logger.info("samples_tick_exists", tick=tick_key)
         return 0
 
-    transcript: str | None = None
-    recordings: list[dict[str, Any]] = []
-    for run in runs:
-        sim_id = sims_per_run[run.coval_run_id][test_case_id]
-        try:
-            if transcript is None:
+    # Uniform draw over the shared conversations of both personas; repick on any
+    # incomplete provider so only a fully-complete conversation (audio + turns for
+    # EVERY provider) is ever surfaced.
+    rng.shuffle(pool)
+    for persona_id, test_case_id in pool:
+        prov_runs = runs_by_persona[persona_id]
+        staged: list[tuple[SampleRun, str, bytes, list[dict[str, Any]]]] = []
+        for provider in sorted(providers):
+            run = prov_runs[provider]
+            sim_id = sims[(persona_id, provider)][test_case_id]
+            audio: bytes | None = None
+            turns: list[dict[str, Any]] = []
+            try:
 
                 async def fetch_detail(sim_id: str = sim_id) -> httpx.Response:
                     resp = await client.get(f"/simulations/{sim_id}")
                     resp.raise_for_status()
                     return resp
 
-                detail = await _fetch_retry(fetch_detail, provider=run.provider, what="sim_detail")
-                transcript = _input_transcript(cast("dict[str, Any]", detail.json()))
+                detail = await _fetch_retry(fetch_detail, provider=provider, what="sim_detail")
+                turns = _conversation_turns(cast("dict[str, Any]", detail.json()))
 
-            async def fetch_recording(sim_id: str = sim_id) -> bytes | None:
-                return await _download_recording(client, download_client, sim_id)
+                async def fetch_recording(sim_id: str = sim_id) -> bytes | None:
+                    return await _download_recording(client, download_client, sim_id)
 
-            audio = await _fetch_retry(fetch_recording, provider=run.provider, what="recording")
-            if audio is None:
-                logger.error("sample_audio_missing", provider=run.provider, sim_id=sim_id)
-                continue
-            key = f"{PREFIX}/{tick_key}/{run.provider}.wav"
-            _upload(bucket, key, audio, "audio/wav")
+                audio = await _fetch_retry(fetch_recording, provider=provider, what="recording")
+            except Exception:
+                logger.error("sample_copy_failed", provider=provider, sim_id=sim_id, exc_info=True)
+            if audio is None or not turns:
+                break
+            staged.append((run, sim_id, audio, turns))
+
+        if len(staged) != len(providers):
+            logger.info("sample_incomplete_skipped", persona=persona_id, test_case_id=test_case_id)
+            continue
+
+        recordings: list[dict[str, Any]] = []
+        for s_run, s_sim_id, s_audio, s_turns in staged:
+            key = f"{PREFIX}/{tick_key}/{s_run.provider}.wav"
+            _upload(bucket, key, s_audio, "audio/wav")
             recordings.append(
                 {
-                    "provider": run.provider,
-                    "model": run.model,
+                    "provider": s_run.provider,
+                    "model": s_run.model,
                     "object": key,
-                    "coval_run_id": run.coval_run_id,
-                    "sim_id": sim_id,
+                    "coval_run_id": s_run.coval_run_id,
+                    "sim_id": s_sim_id,
+                    "agent_id": s_run.agent_id,
+                    "turns": s_turns,
                 }
             )
-        except Exception:
-            logger.error("sample_copy_failed", provider=run.provider, sim_id=sim_id, exc_info=True)
+        manifest = {
+            "schema_version": 2,
+            "bucket_at": tick_key,
+            "test_set_id": test_set_id,
+            "test_case_id": test_case_id,
+            "persona_name": _persona_label(persona_id),
+            "input_audio_url": None,
+            "recordings": recordings,
+        }
+        _upload(bucket, manifest_key, json.dumps(manifest).encode(), "application/json")
+        _update_index(bucket, tick_key)
+        logger.info(
+            "samples_tick_stored",
+            tick=tick_key,
+            recordings=len(recordings),
+            persona=persona_id,
+            test_case_id=test_case_id,
+        )
+        return len(recordings)
 
-    if not recordings:
-        return 0
-
-    clip_path = _clips_by_transcript().get(_norm(transcript)) if transcript else None
-    manifest = {
-        "bucket_at": tick_key,
-        "test_case_id": test_case_id,
-        "transcript": transcript,
-        "input_audio_url": f"{_PUBLIC_DATASET_BASE}/{clip_path}" if clip_path else None,
-        "recordings": recordings,
-    }
-    _upload(
-        bucket,
-        f"{PREFIX}/{tick_key}/manifest.json",
-        json.dumps(manifest).encode(),
-        "application/json",
-    )
-    _update_index(bucket, tick_key)
-    logger.info("samples_tick_stored", tick=tick_key, recordings=len(recordings))
-    return len(recordings)
+    logger.error("samples_no_complete_sample", tick=tick_key)
+    return 0

--- a/runner/tests/unit/test_s2s_samples.py
+++ b/runner/tests/unit/test_s2s_samples.py
@@ -1,7 +1,7 @@
 # Copyright 2026 The Coval Benchmarks Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Unit tests for the S2S sample-recording copier."""
+"""Unit tests for the multi-turn S2S sample publisher."""
 
 from __future__ import annotations
 
@@ -16,14 +16,38 @@ import pytest
 from google.api_core.exceptions import NotFound
 
 from coval_bench.s2s import samples
-from coval_bench.s2s.samples import PREFIX, SampleRun, copy_tick_samples
+from coval_bench.s2s.samples import PREFIX, SampleRun, publish_tick_sample
 
 BUCKET_AT = datetime(2026, 7, 17, tzinfo=UTC)
+TICK = "2026-07-17T00:00:00Z"
+TEST_SET = "DvAqQ4md"
 
-RUNS = [
-    SampleRun(provider="openai", model="gpt-realtime", coval_run_id="RO", bucket_at=BUCKET_AT),
-    SampleRun(provider="google", model="gemini-live", coval_run_id="RG", bucket_at=BUCKET_AT),
-]
+# Real bench persona ids so the label map is exercised too.
+FEMALE = "PN3xgmsqeLDjsNNEA2e55e"
+MALE = "9ATy64zKXxSUaVWb5YnQtd"
+
+
+def _run(provider: str, model: str, run_id: str, persona_id: str, agent_id: str) -> SampleRun:
+    return SampleRun(
+        provider=provider,
+        model=model,
+        coval_run_id=run_id,
+        bucket_at=BUCKET_AT,
+        persona_id=persona_id,
+        agent_id=agent_id,
+    )
+
+
+# Two providers, each run once per persona (mirrors run = agent + persona + test_set).
+def _runs(*, include_google_male: bool = True) -> list[SampleRun]:
+    runs = [
+        _run("openai", "gpt-realtime", "RO_F", FEMALE, "AO"),
+        _run("openai", "gpt-realtime", "RO_M", MALE, "AO"),
+        _run("google", "gemini-live", "RG_F", FEMALE, "AG"),
+    ]
+    if include_google_male:
+        runs.append(_run("google", "gemini-live", "RG_M", MALE, "AG"))
+    return runs
 
 
 def _sims_payload(run_id: str, test_cases: list[str]) -> dict[str, Any]:
@@ -38,25 +62,31 @@ def _fake_client(
     test_cases_by_run: dict[str, list[str]],
     *,
     audio_404: frozenset[str] = frozenset(),
-    transcript: str = "is my alarm set for tomorrow morning",
+    empty_turns: frozenset[str] = frozenset(),
 ) -> httpx.AsyncClient:
     def handler(request: httpx.Request) -> httpx.Response:
         path = request.url.path
         if path.endswith("/simulations"):
-            flt = request.url.params["filter"]
-            run_id = flt.split('"')[1]
+            run_id = request.url.params["filter"].split('"')[1]
             return httpx.Response(200, json=_sims_payload(run_id, test_cases_by_run[run_id]))
+        if "blobs.test" in str(request.url):
+            return httpx.Response(200, content=b"RIFFfake")
         if path.endswith("/audio"):
             sim_id = path.rsplit("/", 2)[-2]
             if sim_id in audio_404:
                 return httpx.Response(404)
             return httpx.Response(200, json={"audio_url": "https://blobs.test/x.wav"})
-        if "blobs.test" in str(request.url):
-            return httpx.Response(200, content=b"RIFFfake")
-        return httpx.Response(
-            200,
-            json={"transcript": [{"role": "user", "content": transcript}], "test_case_id": "tc"},
+        # sim detail: /simulations/{sim_id}
+        sim_id = path.rsplit("/", 1)[-1]
+        turns = (
+            []
+            if sim_id in empty_turns
+            else [
+                {"role": "user", "content": "hi there"},
+                {"role": "assistant", "content": "how can i help"},
+            ]
         )
+        return httpx.Response(200, json={"transcript": turns})
 
     return httpx.AsyncClient(base_url="https://api.test/v1", transport=httpx.MockTransport(handler))
 
@@ -91,127 +121,157 @@ def _fake_storage() -> tuple[MagicMock, _FakeBucket]:
     return client, bucket
 
 
+async def _publish(
+    client: httpx.AsyncClient,
+    storage_client: MagicMock,
+    runs: list[SampleRun],
+    *,
+    rng_seed: int = 0,
+) -> int:
+    return await publish_tick_sample(
+        client,
+        bucket_name="bkt",
+        test_set_id=TEST_SET,
+        runs=runs,
+        rng=random.Random(rng_seed),
+        storage_client=storage_client,
+        download_client=client,
+    )
+
+
 @pytest.mark.asyncio
-async def test_copies_shared_clip_for_all_providers() -> None:
+async def test_publishes_complete_conversation_for_all_providers() -> None:
     storage_client, bucket = _fake_storage()
-    async with _fake_client({"RO": ["a", "b", "c"], "RG": ["b", "c", "d"]}) as client:
-        stored = await copy_tick_samples(
-            client,
-            bucket_name="bkt",
-            runs=RUNS,
-            rng=random.Random(7),
-            storage_client=storage_client,
-            download_client=client,
-        )
+    cases = {"RO_F": ["b", "c"], "RG_F": ["b", "c"], "RO_M": ["b", "c"], "RG_M": ["b", "c"]}
+    async with _fake_client(cases) as client:
+        stored = await _publish(client, storage_client, _runs())
 
     assert stored == 2
-    tick = "2026-07-17T00:00:00Z"
-    assert f"{PREFIX}/{tick}/openai.wav" in bucket.objects
-    assert f"{PREFIX}/{tick}/google.wav" in bucket.objects
+    assert f"{PREFIX}/{TICK}/openai.wav" in bucket.objects
+    assert f"{PREFIX}/{TICK}/google.wav" in bucket.objects
 
-    manifest = json.loads(bucket.objects[f"{PREFIX}/{tick}/manifest.json"])
-    assert manifest["bucket_at"] == tick
-    assert manifest["test_case_id"] in {"b", "c"}  # only shared clips eligible
-    assert manifest["transcript"] == "is my alarm set for tomorrow morning"
-    assert manifest["input_audio_url"].endswith("/s2s-v1/audio/s2s-v1-0001.wav")
+    manifest = json.loads(bucket.objects[f"{PREFIX}/{TICK}/manifest.json"])
+    assert manifest["schema_version"] == 2
+    assert manifest["bucket_at"] == TICK
+    assert manifest["test_set_id"] == TEST_SET
+    assert manifest["persona_name"] in {"Standard Female", "Standard Male"}
+    assert manifest["input_audio_url"] is None
+    assert "transcript" not in manifest  # dropped in v2
+    assert {r["provider"] for r in manifest["recordings"]} == {"openai", "google"}
+    for rec in manifest["recordings"]:
+        assert rec["agent_id"] in {"AO", "AG"}
+        assert [t["index"] for t in rec["turns"]] == [0, 1]
+        assert [t["role"] for t in rec["turns"]] == ["user", "assistant"]
+
+    assert json.loads(bucket.objects[samples.INDEX_KEY]) == [TICK]
+
+
+@pytest.mark.asyncio
+async def test_conversation_key_never_mixes_personas() -> None:
+    # Female shares only "b"; male shares only "d" — the pick must stay within one persona.
+    storage_client, bucket = _fake_storage()
+    cases = {"RO_F": ["b"], "RG_F": ["b"], "RO_M": ["d"], "RG_M": ["d"]}
+    async with _fake_client(cases) as client:
+        stored = await _publish(client, storage_client, _runs())
+
+    assert stored == 2
+    manifest = json.loads(bucket.objects[f"{PREFIX}/{TICK}/manifest.json"])
+    assert (manifest["persona_name"], manifest["test_case_id"]) in {
+        ("Standard Female", "b"),
+        ("Standard Male", "d"),
+    }
+
+
+@pytest.mark.asyncio
+async def test_incomplete_persona_is_skipped_and_other_is_published() -> None:
+    # Female's openai audio is missing → female can never complete → male is published.
+    storage_client, bucket = _fake_storage()
+    cases = {"RO_F": ["b"], "RG_F": ["b"], "RO_M": ["c"], "RG_M": ["c"]}
+    async with _fake_client(cases, audio_404=frozenset({"RO_F-b"})) as client:
+        stored = await _publish(client, storage_client, _runs())
+
+    assert stored == 2
+    manifest = json.loads(bucket.objects[f"{PREFIX}/{TICK}/manifest.json"])
+    assert manifest["persona_name"] == "Standard Male"
+    assert manifest["test_case_id"] == "c"
     assert {r["provider"] for r in manifest["recordings"]} == {"openai", "google"}
 
-    index = json.loads(bucket.objects[samples.INDEX_KEY])
-    assert index == [tick]
-
 
 @pytest.mark.asyncio
-async def test_deterministic_pick_under_seeded_rng() -> None:
-    picks = set()
-    for _ in range(3):
-        storage_client, bucket = _fake_storage()
-        async with _fake_client({"RO": ["a", "b", "c"], "RG": ["a", "b", "c"]}) as client:
-            await copy_tick_samples(
-                client,
-                bucket_name="bkt",
-                runs=RUNS,
-                rng=random.Random(42),
-                storage_client=storage_client,
-                download_client=client,
-            )
-        manifest = json.loads(bucket.objects[f"{PREFIX}/2026-07-17T00:00:00Z/manifest.json"])
-        picks.add(manifest["test_case_id"])
-    assert len(picks) == 1
-
-
-@pytest.mark.asyncio
-async def test_no_shared_clip_stores_nothing() -> None:
+async def test_no_complete_conversation_publishes_nothing() -> None:
+    # Every candidate has a provider missing audio → no partial sample, nothing stored.
     storage_client, bucket = _fake_storage()
-    async with _fake_client({"RO": ["a"], "RG": ["b"]}) as client:
-        stored = await copy_tick_samples(
-            client,
-            bucket_name="bkt",
-            runs=RUNS,
-            rng=random.Random(0),
-            storage_client=storage_client,
-            download_client=client,
-        )
+    cases = {"RO_F": ["b"], "RG_F": ["b"], "RO_M": ["c"], "RG_M": ["c"]}
+    async with _fake_client(cases, audio_404=frozenset({"RO_F-b", "RO_M-c"})) as client:
+        stored = await _publish(client, storage_client, _runs())
+
+    assert stored == 0
+    assert f"{PREFIX}/{TICK}/manifest.json" not in bucket.objects
+
+
+@pytest.mark.asyncio
+async def test_empty_transcript_counts_as_incomplete() -> None:
+    # Only the female persona is eligible, but one provider's transcript is empty → skip.
+    storage_client, bucket = _fake_storage()
+    runs = [
+        _run("openai", "gpt-realtime", "RO_F", FEMALE, "AO"),
+        _run("google", "gemini-live", "RG_F", FEMALE, "AG"),
+    ]
+    async with _fake_client(
+        {"RO_F": ["b"], "RG_F": ["b"]}, empty_turns=frozenset({"RO_F-b"})
+    ) as client:
+        stored = await _publish(client, storage_client, runs)
+
     assert stored == 0
     assert bucket.objects == {}
 
 
 @pytest.mark.asyncio
-async def test_missing_audio_ships_partial_manifest() -> None:
+async def test_persona_missing_a_provider_is_skipped() -> None:
+    # No google male run → male persona lacks a provider → only female is eligible.
     storage_client, bucket = _fake_storage()
-    async with _fake_client({"RO": ["b"], "RG": ["b"]}, audio_404=frozenset({"RO-b"})) as client:
-        stored = await copy_tick_samples(
-            client,
-            bucket_name="bkt",
-            runs=RUNS,
-            rng=random.Random(0),
-            storage_client=storage_client,
-            download_client=client,
-        )
-    assert stored == 1
-    manifest = json.loads(bucket.objects[f"{PREFIX}/2026-07-17T00:00:00Z/manifest.json"])
-    assert [r["provider"] for r in manifest["recordings"]] == ["google"]
+    cases = {"RO_F": ["b"], "RG_F": ["b"], "RO_M": ["b"]}
+    async with _fake_client(cases) as client:
+        stored = await _publish(client, storage_client, _runs(include_google_male=False))
+
+    assert stored == 2
+    manifest = json.loads(bucket.objects[f"{PREFIX}/{TICK}/manifest.json"])
+    assert manifest["persona_name"] == "Standard Female"
 
 
 @pytest.mark.asyncio
-async def test_unknown_transcript_omits_input_audio_url() -> None:
+async def test_no_shared_conversation_stores_nothing() -> None:
     storage_client, bucket = _fake_storage()
-    async with _fake_client({"RO": ["b"], "RG": ["b"]}, transcript="not in the manifest") as client:
-        await copy_tick_samples(
-            client,
-            bucket_name="bkt",
-            runs=RUNS,
-            rng=random.Random(0),
-            storage_client=storage_client,
-            download_client=client,
-        )
-    manifest = json.loads(bucket.objects[f"{PREFIX}/2026-07-17T00:00:00Z/manifest.json"])
-    assert manifest["input_audio_url"] is None
-    assert manifest["transcript"] == "not in the manifest"
+    cases = {"RO_F": ["a"], "RG_F": ["b"], "RO_M": ["c"], "RG_M": ["d"]}
+    async with _fake_client(cases) as client:
+        stored = await _publish(client, storage_client, _runs())
+
+    assert stored == 0
+    assert bucket.objects == {}
 
 
 @pytest.mark.asyncio
-async def test_index_prepends_and_dedupes() -> None:
+async def test_existing_manifest_is_never_overwritten() -> None:
+    storage_client, bucket = _fake_storage()
+    bucket.objects[f"{PREFIX}/{TICK}/manifest.json"] = b'{"sentinel": true}'
+    cases = {"RO_F": ["b"], "RG_F": ["b"], "RO_M": ["b"], "RG_M": ["b"]}
+    async with _fake_client(cases) as client:
+        stored = await _publish(client, storage_client, _runs())
+
+    assert stored == 0
+    assert bucket.objects[f"{PREFIX}/{TICK}/manifest.json"] == b'{"sentinel": true}'
+    assert json.loads(bucket.objects[samples.INDEX_KEY]) == [TICK]  # index repaired
+
+
+@pytest.mark.asyncio
+async def test_index_prepends_existing_history() -> None:
     storage_client, bucket = _fake_storage()
     bucket.objects[samples.INDEX_KEY] = json.dumps(["2026-07-16T00:00:00Z"]).encode()
-    async with _fake_client({"RO": ["b"], "RG": ["b"]}) as client:
-        await copy_tick_samples(
-            client,
-            bucket_name="bkt",
-            runs=RUNS,
-            rng=random.Random(0),
-            storage_client=storage_client,
-            download_client=client,
-        )
-        await copy_tick_samples(
-            client,
-            bucket_name="bkt",
-            runs=RUNS,
-            rng=random.Random(0),
-            storage_client=storage_client,
-            download_client=client,
-        )
-    index = json.loads(bucket.objects[samples.INDEX_KEY])
-    assert index == ["2026-07-17T00:00:00Z", "2026-07-16T00:00:00Z"]
+    cases = {"RO_F": ["b"], "RG_F": ["b"], "RO_M": ["b"], "RG_M": ["b"]}
+    async with _fake_client(cases) as client:
+        await _publish(client, storage_client, _runs())
+
+    assert json.loads(bucket.objects[samples.INDEX_KEY]) == [TICK, "2026-07-16T00:00:00Z"]
 
 
 @pytest.mark.asyncio
@@ -219,177 +279,11 @@ async def test_never_raises_on_total_failure() -> None:
     def handler(request: httpx.Request) -> httpx.Response:
         return httpx.Response(500)
 
-    storage_client, _ = _fake_storage()
-    async with httpx.AsyncClient(
-        base_url="https://api.test/v1", transport=httpx.MockTransport(handler)
-    ) as client:
-        stored = await copy_tick_samples(
-            client,
-            bucket_name="bkt",
-            runs=RUNS,
-            rng=random.Random(0),
-            storage_client=storage_client,
-            download_client=client,
-        )
-    assert stored == 0
-
-
-@pytest.mark.asyncio
-async def test_existing_manifest_is_never_overwritten() -> None:
-    storage_client, bucket = _fake_storage()
-    tick = "2026-07-17T00:00:00Z"
-    bucket.objects[f"{PREFIX}/{tick}/manifest.json"] = b'{"sentinel": true}'
-    async with _fake_client({"RO": ["b"], "RG": ["b"]}) as client:
-        stored = await copy_tick_samples(
-            client,
-            bucket_name="bkt",
-            runs=RUNS,
-            rng=random.Random(0),
-            storage_client=storage_client,
-            download_client=client,
-        )
-    assert stored == 0
-    assert bucket.objects[f"{PREFIX}/{tick}/manifest.json"] == b'{"sentinel": true}'
-
-
-@pytest.mark.asyncio
-async def test_ambiguous_transcript_omits_input_audio_url() -> None:
-    storage_client, bucket = _fake_storage()
-    async with _fake_client(
-        {"RO": ["b"], "RG": ["b"]}, transcript="what is the weather now"
-    ) as client:
-        await copy_tick_samples(
-            client,
-            bucket_name="bkt",
-            runs=RUNS,
-            rng=random.Random(0),
-            storage_client=storage_client,
-            download_client=client,
-        )
-    manifest = json.loads(bucket.objects[f"{PREFIX}/2026-07-17T00:00:00Z/manifest.json"])
-    assert manifest["input_audio_url"] is None
-
-
-@pytest.mark.asyncio
-async def test_index_read_failure_preserves_history() -> None:
-    storage_client, bucket = _fake_storage()
-    bucket.objects[samples.INDEX_KEY] = json.dumps(["2026-07-16T00:00:00Z"]).encode()
-    bucket.fail_reads.add(samples.INDEX_KEY)
-    async with _fake_client({"RO": ["b"], "RG": ["b"]}) as client:
-        stored = await copy_tick_samples(
-            client,
-            bucket_name="bkt",
-            runs=RUNS,
-            rng=random.Random(0),
-            storage_client=storage_client,
-            download_client=client,
-        )
-    assert stored == 2
-    assert json.loads(bucket.objects[samples.INDEX_KEY]) == ["2026-07-16T00:00:00Z"]
-    assert f"{PREFIX}/2026-07-17T00:00:00Z/manifest.json" in bucket.objects
-
-
-@pytest.mark.asyncio
-async def test_fetch_failure_retries_once_and_succeeds() -> None:
-    attempts = {"audio": 0}
-
-    def handler(request: httpx.Request) -> httpx.Response:
-        path = request.url.path
-        if path.endswith("/simulations"):
-            run_id = request.url.params["filter"].split('"')[1]
-            return httpx.Response(200, json=_sims_payload(run_id, ["b"]))
-        if path.endswith("/audio"):
-            attempts["audio"] += 1
-            if attempts["audio"] == 1:
-                return httpx.Response(500)
-            return httpx.Response(200, json={"audio_url": "https://blobs.test/x.wav"})
-        if "blobs.test" in str(request.url):
-            return httpx.Response(200, content=b"RIFFfake")
-        return httpx.Response(
-            200, json={"transcript": [{"role": "user", "content": "hi"}], "test_case_id": "b"}
-        )
-
     storage_client, bucket = _fake_storage()
     async with httpx.AsyncClient(
         base_url="https://api.test/v1", transport=httpx.MockTransport(handler)
     ) as client:
-        stored = await copy_tick_samples(
-            client,
-            bucket_name="bkt",
-            runs=RUNS,
-            rng=random.Random(0),
-            storage_client=storage_client,
-            download_client=client,
-        )
-    assert stored == 2
-    assert attempts["audio"] == 3  # provider one: fail+retry; provider two: first try
+        stored = await _publish(client, storage_client, _runs())
 
-
-@pytest.mark.asyncio
-async def test_tick_exists_repairs_missing_index() -> None:
-    storage_client, bucket = _fake_storage()
-    tick = "2026-07-17T00:00:00Z"
-    bucket.objects[f"{PREFIX}/{tick}/manifest.json"] = b'{"sentinel": true}'
-    async with _fake_client({"RO": ["b"], "RG": ["b"]}) as client:
-        stored = await copy_tick_samples(
-            client,
-            bucket_name="bkt",
-            runs=RUNS,
-            rng=random.Random(0),
-            storage_client=storage_client,
-            download_client=client,
-        )
     assert stored == 0
-    assert json.loads(bucket.objects[samples.INDEX_KEY]) == [tick]
-    assert bucket.objects[f"{PREFIX}/{tick}/manifest.json"] == b'{"sentinel": true}'
-
-
-@pytest.mark.asyncio
-async def test_malformed_index_is_preserved() -> None:
-    storage_client, bucket = _fake_storage()
-    bucket.objects[samples.INDEX_KEY] = b'{"not": "a list"}'
-    async with _fake_client({"RO": ["b"], "RG": ["b"]}) as client:
-        stored = await copy_tick_samples(
-            client,
-            bucket_name="bkt",
-            runs=RUNS,
-            rng=random.Random(0),
-            storage_client=storage_client,
-            download_client=client,
-        )
-    assert stored == 2
-    assert bucket.objects[samples.INDEX_KEY] == b'{"not": "a list"}'
-
-
-@pytest.mark.asyncio
-async def test_sims_list_failure_drops_only_that_provider() -> None:
-    def handler(request: httpx.Request) -> httpx.Response:
-        path = request.url.path
-        if path.endswith("/simulations"):
-            run_id = request.url.params["filter"].split('"')[1]
-            if run_id == "RO":
-                return httpx.Response(500)
-            return httpx.Response(200, json=_sims_payload(run_id, ["b"]))
-        if path.endswith("/audio"):
-            return httpx.Response(200, json={"audio_url": "https://blobs.test/x.wav"})
-        if "blobs.test" in str(request.url):
-            return httpx.Response(200, content=b"RIFFfake")
-        return httpx.Response(
-            200, json={"transcript": [{"role": "user", "content": "hi"}], "test_case_id": "b"}
-        )
-
-    storage_client, bucket = _fake_storage()
-    async with httpx.AsyncClient(
-        base_url="https://api.test/v1", transport=httpx.MockTransport(handler)
-    ) as client:
-        stored = await copy_tick_samples(
-            client,
-            bucket_name="bkt",
-            runs=RUNS,
-            rng=random.Random(0),
-            storage_client=storage_client,
-            download_client=client,
-        )
-    assert stored == 1
-    manifest = json.loads(bucket.objects[f"{PREFIX}/2026-07-17T00:00:00Z/manifest.json"])
-    assert [r["provider"] for r in manifest["recordings"]] == ["google"]
+    assert bucket.objects == {}

--- a/web/lib/audioSamples/s2sFeed.ts
+++ b/web/lib/audioSamples/s2sFeed.ts
@@ -5,17 +5,38 @@
 
 import { createSampleFeed } from "./createSampleFeed";
 
+// One turn of a multi-turn conversation (v2 manifests). `role` is "user"
+// (the persona) or "assistant" (the agent); `index` is the turn's position.
+export interface S2STurn {
+  index: number;
+  role: string;
+  content: string;
+}
+
 export interface S2SSampleRecording {
   provider: string;
   model: string;
   object: string;
   coval_run_id: string;
   sim_id: string;
+  // v2 only: the Coval agent behind the provider, and this agent's own
+  // conversation transcript (transcripts diverge per agent).
+  agent_id?: string;
+  turns?: S2STurn[];
 }
 
 export interface S2SSampleManifest {
+  // Absent on v1 (single-turn) manifests; 2 on multi-turn.
+  schema_version?: number;
   bucket_at: string;
   test_case_id: string;
+  // v2 only: the multi-turn test set + the sampled persona as a display label
+  // (e.g. "Standard Male") — a label, not a selection axis. The persona id
+  // stays internal to the sampler's composite key and is not written out.
+  test_set_id?: string;
+  persona_name?: string;
+  // v1 single-turn fields: first user turn + its baked dataset clip. Null/absent
+  // on v2 (the transcript lives per-recording as `turns`; no baked clip).
   transcript: string | null;
   input_audio_url: string | null;
   recordings: S2SSampleRecording[];
@@ -29,18 +50,49 @@ function asString(v: unknown, field: string): string {
   return v;
 }
 
+// Absent (undefined) and null both collapse to null — a v2 manifest omits the
+// v1-only transcript/input_audio_url keys, and that must not fail the parse.
 function asNullableString(v: unknown, field: string): string | null {
-  if (v === null) return null;
+  if (v === null || v === undefined) return null;
   return asString(v, field);
 }
 
+// undefined -> undefined (optional field omitted); otherwise must be a string.
+function asOptionalString(v: unknown, field: string): string | undefined {
+  if (v === undefined) return undefined;
+  return asString(v, field);
+}
+
+function parseTurns(v: unknown, field: string): S2STurn[] | undefined {
+  if (v === undefined) return undefined;
+  if (!Array.isArray(v)) throw new Error(`${field} must be an array`);
+  return v.map((t, i): S2STurn => {
+    if (typeof t !== "object" || t === null) {
+      throw new Error(`${field}[${i}] must be an object`);
+    }
+    const turn = t as Record<string, unknown>;
+    if (typeof turn.index !== "number") {
+      throw new Error(`${field}[${i}].index must be a number`);
+    }
+    return {
+      index: turn.index,
+      role: asString(turn.role, `${field}[${i}].role`),
+      content: asString(turn.content, `${field}[${i}].content`),
+    };
+  });
+}
+
 // Validate the full manifest shape before the UI touches it — a shallow object
-// check would let `{}` through and crash visibleRecordings' .filter().
+// check would let `{}` through and crash visibleRecordings' .filter(). Tolerant
+// of both single-turn (v1) and multi-turn (v2) shapes.
 export function parseS2SManifest(data: unknown): S2SSampleManifest {
   if (typeof data !== "object" || data === null) {
     throw new Error("manifest must be an object");
   }
   const m = data as Record<string, unknown>;
+  if (m.schema_version !== undefined && typeof m.schema_version !== "number") {
+    throw new Error("schema_version must be a number");
+  }
   if (!Array.isArray(m.recordings)) {
     throw new Error("recordings must be an array");
   }
@@ -55,11 +107,16 @@ export function parseS2SManifest(data: unknown): S2SSampleManifest {
       object: asString(rec.object, `recordings[${i}].object`),
       coval_run_id: asString(rec.coval_run_id, `recordings[${i}].coval_run_id`),
       sim_id: asString(rec.sim_id, `recordings[${i}].sim_id`),
+      agent_id: asOptionalString(rec.agent_id, `recordings[${i}].agent_id`),
+      turns: parseTurns(rec.turns, `recordings[${i}].turns`),
     };
   });
   return {
+    schema_version: m.schema_version as number | undefined,
     bucket_at: asString(m.bucket_at, "bucket_at"),
     test_case_id: asString(m.test_case_id, "test_case_id"),
+    test_set_id: asOptionalString(m.test_set_id, "test_set_id"),
+    persona_name: asOptionalString(m.persona_name, "persona_name"),
     transcript: asNullableString(m.transcript, "transcript"),
     input_audio_url: asNullableString(m.input_audio_url, "input_audio_url"),
     recordings,
@@ -75,6 +132,11 @@ export const s2sSampleFeed = createSampleFeed<S2SSampleManifest>(
   },
   parseS2SManifest
 );
+
+// True when a manifest carries the multi-turn shape (per-recording turns).
+export function isMultiTurn(manifest: S2SSampleManifest): boolean {
+  return (manifest.schema_version ?? 1) >= 2;
+}
 
 // Drop recordings whose provider isn't visible on the page (disabled catalogue).
 export function visibleRecordings(


### PR DESCRIPTION
Publish one (scenario, persona) conversation per tick across all providers as a v2 manifest with per-agent turns and a persona label, only when every provider has audio + transcript. Remove the single-turn samples path and widen the web manifest parser for v2.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Surface multi-turn S2S conversation samples.
- Groups provider runs by persona and publishes one shared scenario with complete audio and per-agent turns.
- Emits a versioned v2 manifest with persona and agent metadata.
- Extends the web parser to support both legacy and v2 manifests.
- Replaces the single-turn sample publishing path and updates unit coverage.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failures remain within the scope of the previous review threads.

<sub>Reviews (2): Last reviewed commit: ["Scope S2S sample tick to the chosen conv..."](https://github.com/coval-ai/benchmarks/commit/b9b3524111e790d75b21dee37b01f67943210fc6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46829465)</sub>

**Context used:**

- Knowledge Base — [Runner Orchestration](https://app.greptile.com/coval/-/custom-context/knowledge-base/coval-ai/benchmarks/-/docs/runner-orchestration.md)

<!-- /greptile_comment -->