### PR TITLE
Alert S2S partial failure separately from total failure

### DIFF
--- a/runner/src/coval_bench/logging.py
+++ b/runner/src/coval_bench/logging.py
@@ -73,16 +73,25 @@ def configure_logging(
 _run_logger = structlog.get_logger("coval_bench.run")
 
 
-def log_run_failed(error: str, exc: BaseException | None = None) -> None:
-    """Emit the single log line the infra alert metric greps for.
+def _emit_run_event(event: str, error: str, exc: BaseException | None = None) -> None:
+    """Emit one structured run-status line the infra alert metrics grep for.
 
-    The literal ``event="RUN_FAILED"`` triggers the ``benchmark_run_failure``
-    Cloud Logging metric in benchmark-infra. Centralized here so every
-    entrypoint (the STT/TTS orchestrator, the S2S fetch job) emits the identical
-    contract string and they can't drift. structlog uses the first positional
-    arg as the ``event`` key.
+    The literal ``event`` value (``RUN_FAILED`` / ``RUN_PARTIAL``) is the contract
+    each Cloud Logging metric in benchmark-infra filters on. Centralized here so
+    every entrypoint emits the identical string and they can't drift. structlog
+    uses the first positional arg as the ``event`` key.
     """
-    _run_logger.error("RUN_FAILED", error=error, exc_info=exc)
+    _run_logger.error(event, error=error, exc_info=exc)
+
+
+def log_run_failed(error: str, exc: BaseException | None = None) -> None:
+    """Total run failure -> ``RUN_FAILED`` (fails the job; used by all modalities)."""
+    _emit_run_event("RUN_FAILED", error, exc)
+
+
+def log_run_partial(error: str, exc: BaseException | None = None) -> None:
+    """Partial run -> ``RUN_PARTIAL`` (some providers failed; the job still exits 0)."""
+    _emit_run_event("RUN_PARTIAL", error, exc)
 
 
 def uvicorn_log_config(level: LogLevel = "INFO") -> dict[str, Any]:

--- a/runner/src/coval_bench/s2s/fetch_v2v.py
+++ b/runner/src/coval_bench/s2s/fetch_v2v.py
@@ -676,7 +676,7 @@ async def fetch_and_write_v2v(settings: Settings | None = None) -> dict[str, Run
 @click.command(name="fetch-s2s")
 def fetch_s2s() -> None:
     """Fetch S2S latency from Coval and write per-clip rows (scheduled Cloud Run Job)."""
-    from coval_bench.logging import configure_logging, log_run_failed
+    from coval_bench.logging import configure_logging, log_run_failed, log_run_partial
 
     settings = get_settings()
     configure_logging(level=settings.log_level)
@@ -687,16 +687,17 @@ def fetch_s2s() -> None:
         log_run_failed(str(exc), exc)
         raise
 
-    # Alert if any provider has no fresh data. The succeeding providers' rows
-    # are already committed, so a partial run still exits 0 — only a total
-    # loss fails the job (non-zero exit).
+    # Healthy providers' rows are already committed, so a PARTIAL run alerts but
+    # still exits 0 (no Cloud Run retry). Only a total loss fails the job.
     failed = [p for p, s in statuses.items() if s is RunStatus.FAILED]
-    if not statuses:
-        log_run_failed("s2s fetch ran no providers (none configured)")
-    elif failed:
-        log_run_failed(f"s2s fetch has no fresh data from: {', '.join(failed)}")
     if not statuses or all(s is RunStatus.FAILED for s in statuses.values()):
+        if statuses:
+            log_run_failed(f"s2s fetch failed for all providers: {', '.join(failed)}")
+        else:
+            log_run_failed("s2s fetch ran no providers (none configured)")
         raise click.ClickException("s2s fetch failed for all providers")
+    if failed:
+        log_run_partial(f"s2s fetch has no fresh data from: {', '.join(failed)}")
 
 
 if __name__ == "__main__":

--- a/runner/tests/unit/test_s2s_fetch.py
+++ b/runner/tests/unit/test_s2s_fetch.py
@@ -13,9 +13,11 @@ from unittest.mock import AsyncMock, MagicMock
 
 import httpx
 import pytest
+from structlog.testing import capture_logs
 
 from coval_bench.config import Settings
 from coval_bench.db.models import ResultStatus, Run, RunStatus
+from coval_bench.logging import log_run_failed, log_run_partial
 from coval_bench.registries import Metric
 from coval_bench.s2s import fetch_v2v
 from coval_bench.s2s.fetch_v2v import AgentSpec, CovalRun
@@ -731,3 +733,17 @@ async def test_recent_completed_runs_filters_by_test_set() -> None:
     filter_expr = captured[0].url.params["filter"]
     assert 'test_set_id="TS1"' in filter_expr
     assert 'agent_id="a1"' in filter_expr
+
+
+def test_log_run_partial_emits_run_partial_event() -> None:
+    # The infra partial-alert metric greps for this exact event string.
+    with capture_logs() as logs:
+        log_run_partial("s2s fetch has no fresh data from: openai")
+    assert [entry["event"] for entry in logs] == ["RUN_PARTIAL"]
+
+
+def test_log_run_failed_emits_run_failed_event() -> None:
+    # Unchanged contract shared with the STT/TTS orchestrator's failure metric.
+    with capture_logs() as logs:
+        log_run_failed("s2s fetch failed for all providers")
+    assert [entry["event"] for entry in logs] == ["RUN_FAILED"]

--- a/runner/tests/unit/test_s2s_fetch.py
+++ b/runner/tests/unit/test_s2s_fetch.py
@@ -13,6 +13,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import httpx
 import pytest
+from click.testing import CliRunner
 from structlog.testing import capture_logs
 
 from coval_bench.config import Settings
@@ -747,3 +748,43 @@ def test_log_run_failed_emits_run_failed_event() -> None:
     with capture_logs() as logs:
         log_run_failed("s2s fetch failed for all providers")
     assert [entry["event"] for entry in logs] == ["RUN_FAILED"]
+
+
+def _run_fetch_cli(
+    monkeypatch: pytest.MonkeyPatch, statuses: dict[str, RunStatus]
+) -> tuple[int, list[str]]:
+    async def fake_fetch(_settings: Settings) -> dict[str, RunStatus]:
+        return statuses
+
+    settings = Settings.model_construct(log_level="INFO")
+    monkeypatch.setattr(fetch_v2v, "fetch_and_write_v2v", fake_fetch)
+    monkeypatch.setattr(fetch_v2v, "get_settings", lambda: settings)
+    monkeypatch.setattr("coval_bench.logging.configure_logging", lambda level: None)
+    with capture_logs() as logs:
+        result = CliRunner().invoke(fetch_v2v.fetch_s2s, [])
+    return result.exit_code, [str(entry.get("event")) for entry in logs]
+
+
+def test_cli_mixed_alerts_partial_exit_zero(monkeypatch: pytest.MonkeyPatch) -> None:
+    code, events = _run_fetch_cli(
+        monkeypatch, {"openai": RunStatus.SUCCEEDED, "google": RunStatus.FAILED}
+    )
+    assert code == 0
+    assert "RUN_PARTIAL" in events
+    assert "RUN_FAILED" not in events
+
+
+def test_cli_all_failed_alerts_failed_exit_nonzero(monkeypatch: pytest.MonkeyPatch) -> None:
+    code, events = _run_fetch_cli(
+        monkeypatch, {"openai": RunStatus.FAILED, "google": RunStatus.FAILED}
+    )
+    assert code != 0
+    assert "RUN_FAILED" in events
+    assert "RUN_PARTIAL" not in events
+
+
+def test_cli_no_providers_alerts_failed_exit_nonzero(monkeypatch: pytest.MonkeyPatch) -> None:
+    code, events = _run_fetch_cli(monkeypatch, {})
+    assert code != 0
+    assert "RUN_FAILED" in events
+    assert "RUN_PARTIAL" not in events


### PR DESCRIPTION
The S2S fetch emitted `RUN_FAILED` for any provider failure, so one provider going down looked identical to a total loss. This splits the two so a partial outage can alert as partial without paging as a full failure.

The CLI now emits three outcomes: all providers failed (or none configured) → `RUN_FAILED` + non-zero exit (unchanged); some but not all providers failed all their runs → `RUN_PARTIAL`, exit 0 (the healthy providers' rows are already committed, so there's nothing to retry); everything healthy → no alert. `log_run_failed` keeps its signature and a shared private emitter backs both, so the STT/TTS orchestrator is untouched — only the S2S job emits `RUN_PARTIAL`.

This is the runner half of the contract. The infra half (a `benchmark_run_partial` log-metric + alert policy scoped to the s2s-fetch job, routing to the same Slack notifier) is a separate benchmark-infra change and does nothing until it lands — the new `RUN_PARTIAL` log line is harmless on its own.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR distinguishes partial S2S provider outages from total failures and adds CLI-level coverage for mixed, all-failed, and empty provider-status outcomes.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<sub>Reviews (2): Last reviewed commit: ["Add CLI-level tests for S2S failure bran..."](https://github.com/coval-ai/benchmarks/commit/dba901d6214c83816c47a2a8c96ddb66fa3ab582) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46855322)</sub>

**Context used:**

- Knowledge Base — [Runner Orchestration](https://app.greptile.com/coval/-/custom-context/knowledge-base/coval-ai/benchmarks/-/docs/runner-orchestration.md)

<!-- /greptile_comment -->