### PR TITLE
Surface multi-turn S2S conversations on the dashboard

### DIFF
--- a/web/app/s2s/components/ConversationTurns.tsx
+++ b/web/app/s2s/components/ConversationTurns.tsx
@@ -1,0 +1,38 @@
+// Copyright 2026 The Coval Benchmarks Authors
+// SPDX-License-Identifier: Apache-2.0
+
+"use client";
+
+import type { S2STurn } from "@/lib/audioSamples/s2sFeed";
+
+// Compact per-provider conversation: Caller (the persona) and Agent turns.
+// Presentational + provider-agnostic — `accentColor` ties the agent's turns to
+// its pane/dot color, so this can be reused verbatim if STT/TTS ever surface
+// transcripts. The caller passes the color from the shared getModelColor map.
+export function ConversationTurns({
+  turns,
+  accentColor,
+}: {
+  turns: S2STurn[];
+  accentColor: string;
+}) {
+  return (
+    <div className="mt-1 max-h-56 space-y-2 overflow-y-auto pr-1">
+      {turns.map((t) => {
+        const agent = t.role === "assistant";
+        return (
+          <div
+            key={t.index}
+            className={`border-l-2 pl-2 ${agent ? "" : "border-border-primary"}`}
+            style={agent ? { borderColor: accentColor } : undefined}
+          >
+            <span className="font-mono text-[9px] uppercase tracking-wider text-text-tertiary">
+              {agent ? "Agent" : "Caller"}
+            </span>
+            <p className="text-[11px] leading-snug text-text-primary">{t.content}</p>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/web/app/s2s/components/SampleOutputs.tsx
+++ b/web/app/s2s/components/SampleOutputs.tsx
@@ -12,11 +12,15 @@ import {
 } from "@/hooks/useSequencedPlayback";
 import { getModelColor } from "@/lib/utils/colors";
 import { toModelKey } from "@/lib/utils/formatters";
+import type { S2STurn } from "@/lib/audioSamples/s2sFeed";
+import { ConversationTurns } from "./ConversationTurns";
 
 export interface SampleOutputItem {
   provider: string;
   model: string;
   url: string;
+  // Multi-turn (v2) only: this provider's own conversation transcript.
+  turns?: S2STurn[];
 }
 
 // Left/right chevron/fade visibility from scroll extents; remeasures on scroll,
@@ -68,6 +72,9 @@ export function SampleOutputs({
     () => items.map((i) => ({ key: i.provider, url: i.url })),
     [items]
   );
+  // Multi-turn manifests carry per-provider turns; widen the panes and show the
+  // conversation. All items in a manifest share a shape, so a single flag holds.
+  const conversation = items.some((i) => (i.turns?.length ?? 0) > 0);
   const viewportRef = useRef<HTMLDivElement>(null);
   const paneRefs = useRef<(HTMLDivElement | null)[]>([]);
 
@@ -112,7 +119,7 @@ export function SampleOutputs({
     <div className="space-y-2">
       <div className="flex items-center justify-between">
         <p className="font-mono text-[10px] font-medium uppercase tracking-[0.28em] text-text-tertiary">
-          Responses
+          {conversation ? "Conversation" : "Responses"}
         </p>
         <button
           type="button"
@@ -156,6 +163,8 @@ export function SampleOutputs({
           {items.map((item, i) => {
             const active = i === activeIndex;
             const playingThis = active && isPlaying;
+            const color = getModelColor(toModelKey(item.provider, item.model));
+            const turns = item.turns ?? [];
             return (
               <div
                 key={item.provider}
@@ -163,7 +172,9 @@ export function SampleOutputs({
                   paneRefs.current[i] = el;
                 }}
                 role="listitem"
-                className={`flex w-[180px] min-w-[180px] shrink-0 snap-start flex-col gap-2 rounded-xl border p-3 transition-colors ${
+                className={`flex shrink-0 snap-start flex-col gap-2 rounded-xl border p-3 transition-colors ${
+                  conversation ? "w-[300px] min-w-[300px]" : "w-[180px] min-w-[180px]"
+                } ${
                   active
                     ? "border-text-primary/40 bg-surface-secondary"
                     : "border-border-primary bg-surface-secondary/60"
@@ -172,7 +183,7 @@ export function SampleOutputs({
                 <div className="flex items-center gap-1.5">
                   <span
                     className="size-2 shrink-0 rounded-full"
-                    style={{ backgroundColor: getModelColor(toModelKey(item.provider, item.model)) }}
+                    style={{ backgroundColor: color }}
                   />
                   <span className="truncate text-xs font-medium text-text-primary">
                     {normalizeProvider(item.provider)}
@@ -184,12 +195,17 @@ export function SampleOutputs({
                 <button
                   type="button"
                   onClick={() => (playingThis ? toggle() : playFrom(i))}
-                  className="mt-auto flex items-center gap-1 self-start rounded-full border border-border-primary px-2 py-0.5 text-[11px] text-text-secondary transition-colors hover:text-text-primary"
+                  className={`flex items-center gap-1 self-start rounded-full border border-border-primary px-2 py-0.5 text-[11px] text-text-secondary transition-colors hover:text-text-primary ${
+                    turns.length ? "" : "mt-auto"
+                  }`}
                   aria-label={playingThis ? `Pause ${item.provider}` : `Play ${item.provider}`}
                 >
                   {playingThis ? <Pause className="size-3" /> : <Play className="size-3" />}
                   <span>{playingThis ? "Playing" : "Play"}</span>
                 </button>
+                {turns.length ? (
+                  <ConversationTurns turns={turns} accentColor={color} />
+                ) : null}
               </div>
             );
           })}

--- a/web/app/s2s/components/SamplesCard.tsx
+++ b/web/app/s2s/components/SamplesCard.tsx
@@ -7,7 +7,7 @@ import { useCallback, useEffect, useMemo } from "react";
 import Card from "@/components/shared/Card";
 import { useDashboard } from "@/contexts/DashboardContext";
 import { SampleFetchError } from "@/lib/audioSamples/createSampleFeed";
-import { s2sSampleFeed, visibleRecordings } from "@/lib/audioSamples/s2sFeed";
+import { isMultiTurn, s2sSampleFeed, visibleRecordings } from "@/lib/audioSamples/s2sFeed";
 import { capturePostHogEvent } from "@/lib/posthog/client";
 import { POSTHOG_EVENTS } from "@/lib/posthog/events";
 import { usePlaybackCoordinator } from "@/hooks/useSequencedPlayback";
@@ -43,6 +43,7 @@ export function SamplesCard() {
   const effectiveTick = s2sPlayRequest?.tick ?? latestTick;
   const manifestQuery = s2sSampleFeed.useManifestQuery(effectiveTick);
   const manifest = manifestQuery.data ?? null;
+  const multiTurn = manifest ? isMultiTurn(manifest) : false;
 
   const fetchError = manifestQuery.isError || indexQuery.isError;
   // Keep the failure cause internal (dev console only); public visitors just see
@@ -59,6 +60,7 @@ export function SamplesCard() {
       provider: r.provider,
       model: r.model,
       url: s2sSampleFeed.objectUrl(r.object),
+      turns: r.turns,
     }));
   }, [manifest, visibleProviders]);
 
@@ -84,8 +86,11 @@ export function SamplesCard() {
           Conversation samples
         </div>
         {manifest ? (
-          <span className="font-mono text-xs text-text-tertiary">
-            {tickLabel(manifest.bucket_at)}
+          <span className="flex items-baseline gap-2 font-mono text-xs text-text-tertiary">
+            {manifest.persona_name ? (
+              <span className="text-text-secondary">{manifest.persona_name}</span>
+            ) : null}
+            <span>{tickLabel(manifest.bucket_at)}</span>
           </span>
         ) : null}
       </div>
@@ -104,11 +109,13 @@ export function SamplesCard() {
         </p>
       ) : (
         <div className="flex flex-1 flex-col gap-4">
-          <SampleInput
-            transcript={manifest?.transcript ?? null}
-            inputAudioUrl={manifest?.input_audio_url ?? null}
-            coordinator={coordinator}
-          />
+          {!multiTurn ? (
+            <SampleInput
+              transcript={manifest?.transcript ?? null}
+              inputAudioUrl={manifest?.input_audio_url ?? null}
+              coordinator={coordinator}
+            />
+          ) : null}
           <SampleOutputs
             items={items}
             normalizeProvider={normalizeProviderName}
@@ -123,9 +130,11 @@ export function SamplesCard() {
         </div>
       )}
 
-      <p className="mt-4 text-[10px] text-text-tertiary">
-        Prompts from the SLURP dataset (CC BY-NC 4.0).
-      </p>
+      {!multiTurn ? (
+        <p className="mt-4 text-[10px] text-text-tertiary">
+          Prompts from the SLURP dataset (CC BY-NC 4.0).
+        </p>
+      ) : null}
     </Card>
   );
 }

--- a/web/hooks/useDashboardState.tsx
+++ b/web/hooks/useDashboardState.tsx
@@ -68,9 +68,12 @@ export function useDashboardState(page: "tts" | "stt" | "s2s") {
   const benchmarkParam =
     page === "s2s" ? "S2S" : page === "tts" ? "TTS" : "STT";
 
+  // S2S is a multi-turn-only board: pin its aggregates to the multi-turn dataset
+  // so legacy single-turn (s2s-v1) rows never pool into the V2V charts.
   const aggregatesQuery = useAggregatesQuery({
     benchmark: benchmarkParam,
     window: timeWindow,
+    dataset: page === "s2s" ? "s2s-multiturn-v1" : undefined,
   });
   const providersQuery = useProvidersQuery();
 


### PR DESCRIPTION
Renders the multi-turn conversation samples on `/s2s` and scopes the board to the multi-turn dataset.

Each provider's sample now shows its own Caller/Agent transcript — a small reusable `ConversationTurns` component — with the persona label, while single-turn (v1) manifests keep the existing prompt-and-clip layout; the card branches on the manifest's `schema_version`. Provider colors come from the shared `getModelColor` map, and the pieces are factored so STT/TTS can reuse them.

The S2S aggregates query is pinned to `dataset=s2s-multiturn-v1` so retired single-turn (`s2s-v1`) rows never pool into the V2V charts. STT and TTS are untouched.

Stacked on `s2s-multiturn-surfacing` — review against that base to see only the four frontend files, and merge that first. The samples card renders the multi-turn view once a v2 manifest is published; until then it shows the v1 sample from the bucket.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds multi-turn S2S conversation samples and scopes dashboard aggregates to the multi-turn dataset.
- Introduces a reusable caller/agent transcript component.
- Selects the sample layout based on the manifest schema version.
- Displays per-provider transcripts and persona labels.
- Filters S2S aggregate queries to `s2s-multiturn-v1`.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failures remain.

<sub>Reviews (2): Last reviewed commit: ["Scope the S2S dashboard to the multi-tur..."](https://github.com/coval-ai/benchmarks/commit/a7fec36925a2da0bec66b9a881b2a54f0a075f30) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46855486)</sub>

**Context used:**

- Knowledge Base — [Web Dashboard (STT/TTS/S2S + Overview)](https://app.greptile.com/coval/-/custom-context/knowledge-base/coval-ai/benchmarks/-/docs/web-dashboard.md)

<!-- /greptile_comment -->