### PR TITLE
Activate xAI grok-realtime on the S2S dashboard

### DIFF
--- a/runner/src/coval_bench/registries/models.py
+++ b/runner/src/coval_bench/registries/models.py
@@ -797,10 +797,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         provider="xai",
         model="grok-realtime",
         tags=(_STREAMING, _MULTI),
-        # hidden from the site for launch while xAI capacity issues distort
-        # latency; the fetch job doesn't read this registry, so data keeps
-        # accruing for the flip back to active.
-        status=_PENDING,
+        status=_ACTIVE,
     ),
 ]
 


### PR DESCRIPTION
Flip grok-realtime from PENDING to ACTIVE so xAI shows on the S2S site alongside OpenAI and Gemini. The STT/TTS xAI entries are unchanged.

Note: will push gaitng based on internal key later, so all good

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Activates the existing xAI `grok-realtime` S2S registry entry, making it visible and selectable on the public dashboard.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable defects identified.

The existing xAI S2S entry has the required registry, fetch, and display metadata, while activation does not alter ingestion and empty result sets are handled without request or rendering failures.

<sub>Reviews (1): Last reviewed commit: ["Activate xAI grok-realtime on the S2S da..."](https://github.com/coval-ai/benchmarks/commit/3540f6024d8c2fde19b17cc8acadd0b1ccb4f946) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46858508)</sub>

**Context used:**

- Knowledge Base — [Runner Orchestration](https://app.greptile.com/coval/-/custom-context/knowledge-base/coval-ai/benchmarks/-/docs/runner-orchestration.md)

<!-- /greptile_comment -->