### PR TITLE
Embargo S2S models as early-access until launch

### DIFF
--- a/runner/src/coval_bench/registries/models.py
+++ b/runner/src/coval_bench/registries/models.py
@@ -777,27 +777,29 @@ MODEL_REGISTRY: list[RegisteredModel] = [
     # S2S #
     #######
     # S2S realtime models. Numbers are fetched daily from Coval (no local
-    # provider client).
+    # provider client). EARLY_ACCESS = pre-launch embargo: they run and fetch
+    # normally, but every data endpoint strips them for public callers and
+    # serves them only to X-Internal-Key requests until the benchmark launches.
     RegisteredModel(
         benchmark=_S2S,
         provider="openai",
         model="gpt-realtime",
         tags=(_STREAMING, _MULTI),
-        status=_ACTIVE,
+        status=_EARLY_ACCESS,
     ),
     RegisteredModel(
         benchmark=_S2S,
         provider="google",
         model="gemini-live",
         tags=(_STREAMING, _MULTI),
-        status=_ACTIVE,
+        status=_EARLY_ACCESS,
     ),
     RegisteredModel(
         benchmark=_S2S,
         provider="xai",
         model="grok-realtime",
         tags=(_STREAMING, _MULTI),
-        status=_ACTIVE,
+        status=_EARLY_ACCESS,
     ),
 ]
 


### PR DESCRIPTION
Marks the three S2S realtime models (`gpt-realtime`, `gemini-live`, `grok-realtime`) `EARLY_ACCESS` so the benchmark stays embargoed until launch.

They keep running and fetching into prod on the normal schedule, but every data endpoint (aggregates, providers, results, leaderboard) already strips `EARLY_ACCESS` models for public callers, so S2S results are no longer publicly queryable. The benchmarking team sees them exactly like any other early-access model: open the site with `?internal=<key>` (stored in localStorage, sent as `X-Internal-Key`).

Note: the samples GCS bucket is public by design, so the example clips/transcripts stay world-readable, covers the metrics/leaderboard only.

At launch: flip these three back to `ACTIVE` and enable the `/s2s` route flag.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Marks the three S2S realtime models as early access, hiding their metrics from public API callers while preserving internal access and scheduled ingestion.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable issues identified.

The status changes activate the existing public visibility filters without affecting the independently configured S2S ingestion path or internal-key access.

<sub>Reviews (1): Last reviewed commit: ["Embargo S2S models as early-access"](https://github.com/coval-ai/benchmarks/commit/6f91cf5bf62ba1d5ebb9aaae6325385d9062a0c8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46864043)</sub>

<!-- /greptile_comment -->