### PR TITLE
Show S2S instruction adherence in the headline card

### DIFF
--- a/web/app/s2s/components/S2STopRow.tsx
+++ b/web/app/s2s/components/S2STopRow.tsx
@@ -4,35 +4,62 @@
 "use client";
 
 import Card from "@/components/shared/Card";
+import { DedicatedInfoIcon } from "@/components/shared/DedicatedInferenceInfo";
+import type { KeyMetricData } from "@/components/dashboard/KeyMetrics";
 import { useDashboard } from "@/contexts/DashboardContext";
 import { SamplesCard } from "./SamplesCard";
 
-// S2S headline row: the single latency KeyMetric tile beside the samples card.
-// The tile mirrors KeyMetrics.tsx (as DashboardSkeleton already does) so the
-// shared component stays untouched for STT/TTS; both cells stretch to level.
+// A single KeyMetric tile body, mirroring KeyMetrics.tsx so the S2S headline
+// tiles read identically to the STT/TTS dashboards.
+function MetricTile({ metric }: { metric: KeyMetricData }) {
+  return (
+    <>
+      <div className="text-[0.9rem] font-light text-text-secondary mb-2">
+        {metric.label}
+      </div>
+      <div className="font-mono text-3xl sm:text-4xl lg:text-5xl font-bold mb-4 break-words leading-tight">
+        {metric.displayValue}
+      </div>
+      {metric.subtitle && (
+        <div className="text-text-secondary flex flex-col sm:flex-row sm:items-baseline gap-0.5 sm:gap-2">
+          {metric.subtitle.name && (
+            <span className="inline-flex items-center gap-1.5 font-medium">
+              {metric.subtitle.name}
+              {metric.subtitle.dedicated && (
+                <DedicatedInfoIcon size={14} className="-m-1 p-1" />
+              )}
+            </span>
+          )}
+          {metric.subtitle.detail && (
+            <span className="text-sm text-text-tertiary">
+              {metric.subtitle.detail}
+            </span>
+          )}
+        </div>
+      )}
+    </>
+  );
+}
+
+// S2S headline row: the latency tile (and, when present, the instruction
+// adherence tile stacked below it) beside the samples card. The left column
+// stretches to the samples card's height; each stacked tile is flex-1 so the
+// two tiles plus the gap between them exactly fill that height.
 export function S2STopRow() {
-  const { primaryKeyMetric: metric } = useDashboard();
+  const { primaryKeyMetric, secondaryKeyMetric } = useDashboard();
 
   return (
     <div className="mb-[0.8rem] grid grid-cols-1 items-stretch gap-[0.8rem] lg:grid-cols-2">
-      <Card className="text-left min-w-0 h-full" padding="p-5 lg:p-8">
-        <div className="text-[0.9rem] font-light text-text-secondary mb-2">
-          {metric.label}
-        </div>
-        <div className="font-mono text-3xl sm:text-4xl lg:text-5xl font-bold mb-4 break-words leading-tight">
-          {metric.displayValue}
-        </div>
-        {metric.subtitle && (
-          <div className="text-text-secondary flex flex-col sm:flex-row sm:items-baseline gap-0.5 sm:gap-2">
-            {metric.subtitle.name && (
-              <span className="font-medium">{metric.subtitle.name}</span>
-            )}
-            {metric.subtitle.detail && (
-              <span className="text-sm text-text-tertiary">{metric.subtitle.detail}</span>
-            )}
-          </div>
+      <div className="flex min-w-0 flex-col gap-[0.8rem]">
+        <Card className="text-left min-w-0 flex-1" padding="p-5 lg:p-8">
+          <MetricTile metric={primaryKeyMetric} />
+        </Card>
+        {secondaryKeyMetric && (
+          <Card className="text-left min-w-0 flex-1" padding="p-5 lg:p-8">
+            <MetricTile metric={secondaryKeyMetric} />
+          </Card>
         )}
-      </Card>
+      </div>
       <SamplesCard />
     </div>
   );

--- a/web/hooks/useDashboardState.tsx
+++ b/web/hooks/useDashboardState.tsx
@@ -460,6 +460,28 @@ export function useDashboardState(page: "tts" | "stt" | "s2s") {
 
   const { avgSecondary, lowestWERModel, lowestWERProvider } = keyMetrics;
 
+  // S2S instruction-adherence headline: the model with the highest mean
+  // InstructionFollowing score (higher is better; value is already a percent).
+  // Mirrors the WER secondary tile but maximizes instead of minimizes.
+  const highestInstruction = useMemo(() => {
+    let best = -Infinity;
+    let bestModel = "";
+    let bestProvider = "";
+    deferredSelectedModels.forEach((model) => {
+      const stat = getStat(model, "InstructionFollowing");
+      if (stat && typeof stat.avg_value === "number" && stat.avg_value > best) {
+        best = stat.avg_value;
+        bestModel = model;
+        bestProvider = parseModelKey(model).provider;
+      }
+    });
+    return {
+      pct: best === -Infinity ? null : best,
+      bestModel,
+      bestProvider,
+    };
+  }, [getStat, deferredSelectedModels]);
+
   // Get computed data
   const cumulativeWerBarData = chartData.getWERBarData();
   const werBarData = useMemo<BarDataPoint[]>(() => {
@@ -568,10 +590,25 @@ export function useDashboardState(page: "tts" | "stt" | "s2s") {
       : undefined,
   };
 
-  // S2S has no WER, so it renders a single KeyMetric tile (no secondary).
+  // S2S shows instruction adherence as its secondary tile (higher is better);
+  // STT/TTS show WER. The tile is hidden until instruction data exists.
   const secondaryKeyMetric =
     page === "s2s"
-      ? undefined
+      ? highestInstruction.pct === null
+        ? undefined
+        : {
+            label: "Highest Instruction Adherence",
+            displayValue: `${highestInstruction.pct.toFixed(0)}%`,
+            subtitle: highestInstruction.bestModel
+              ? {
+                  name: normalizeModelName(highestInstruction.bestModel),
+                  detail: highestInstruction.bestProvider
+                    ? normalizeProviderName(highestInstruction.bestProvider)
+                    : undefined,
+                  dedicated: dedicatedModels.has(highestInstruction.bestModel),
+                }
+              : undefined,
+          }
       : {
           label: `${deferredSelectedModels.length > 1 ? "Lowest" : "Average"} Word Error Rate`,
           displayValue: `${avgSecondary.toFixed(1)}%`,


### PR DESCRIPTION
The /s2s headline row showed only V2V latency. This adds instruction adherence as a second tile stacked beneath it — the highest mean instruction-adherence score with its model and provider, matching the pattern STT/TTS already use for WER.

It reads from the existing aggregates response with no extra query (`getStat(model, "InstructionFollowing")`, the same call WER uses), takes the mean rather than the median, and stays hidden until instruction data exists so it degrades cleanly on an empty board. The latency and instruction tiles are `flex-1` within the left column, so together with the gap they match the samples card's height.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds an optional S2S instruction-adherence headline tile derived from existing aggregate data.
- Selects the model with the highest mean InstructionFollowing score.
- Displays its score, model, provider, and dedicated-inference indicator.
- Refactors the S2S headline layout to stack the latency and instruction-adherence cards beside the samples card.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no concrete blocking or independently actionable issues identified.

The new headline uses the documented percentage-scale aggregate, handles absent instruction data by hiding the tile, and preserves the existing selected-model KPI and metric-rendering patterns.

<sub>Reviews (1): Last reviewed commit: ["Show S2S instruction adherence in the he..."](https://github.com/coval-ai/benchmarks/commit/ed55c59cc04c98d429b8a6dc3e55030f51728e42) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47073925)</sub>

**Context used:**

- Knowledge Base — [Web Dashboard (STT/TTS/S2S + Overview)](https://app.greptile.com/coval/-/custom-context/knowledge-base/coval-ai/benchmarks/-/docs/web-dashboard.md)

<!-- /greptile_comment -->