### PR TITLE
Export chart PNGs in the brand faces (BENCH-533)

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -212,6 +212,14 @@ body {
     sans-serif;
 }
 
+/* Brand rule: captions and data readouts are Geist Mono, which is what chart
+   chrome is — axis ticks, axis titles and legends. Body copy stays PP Mori. */
+[data-export-frame] text,
+[data-chart-axis] text,
+[data-chart-legend] {
+  font-family: var(--font-mono), ui-monospace, monospace;
+}
+
 @layer utilities {
   .scrollbar-hide::-webkit-scrollbar {
     display: none;

--- a/web/components/charts/CustomBarChartTick.tsx
+++ b/web/components/charts/CustomBarChartTick.tsx
@@ -6,9 +6,21 @@ import { normalizeModelName } from "@/lib/utils/formatters";
 import { useThemeColors } from "@/hooks/useThemeColors";
 
 // Match the text sizes on the timeline chart: 12px category/legend text.
-const modelFontSize = "12px";
-const providerFontSize = "12px";
-const mobileFontSize = "12px";
+const labelFontPx = 12;
+/** Longest label kept before it is ellipsized, per layout. */
+const maxLabelChars = { compact: 12, mobile: 14, desktop: 18 };
+/**
+ * Geist Mono advances 0.6em and the label hangs at 45°, so a label reaches this
+ * far left of its own tick. The axis must reserve it as left padding or the
+ * first label is clipped at the plot edge — it reads as cut off by the y-axis.
+ */
+export const tickLabelReach = (isMobile: boolean) =>
+  Math.ceil(
+    (isMobile ? maxLabelChars.mobile : maxLabelChars.desktop) *
+      labelFontPx *
+      0.6 *
+      Math.SQRT1_2
+  );
 
 const CustomBarChartTick: React.FC<{
   x?: number;
@@ -41,7 +53,11 @@ const CustomBarChartTick: React.FC<{
   // and shorten the name (the tooltip and <title> still carry the full info).
   const slot = visibleTicksCount > 0 ? width / visibleTicksCount : width;
   const showProvider = slot >= 40;
-  const maxChars = !showProvider ? 12 : isMobile ? 14 : 18;
+  const maxChars = !showProvider
+    ? maxLabelChars.compact
+    : isMobile
+      ? maxLabelChars.mobile
+      : maxLabelChars.desktop;
   const normalizedModel =
     fullName.length > maxChars ? `${fullName.slice(0, maxChars - 1)}…` : fullName;
   const showTitle = !showProvider || normalizedModel !== fullName;
@@ -49,8 +65,6 @@ const CustomBarChartTick: React.FC<{
   // Render every label on a single 45° diagonal so they don't collide when many
   // models are shown: model name (bold) on the first line, provider below it,
   // both anchored at the tick so the text fans out down-left.
-  const fontSize = isMobile ? mobileFontSize : modelFontSize;
-
   return (
     <g transform={`translate(${x},${y})`}>
       <g transform="rotate(-45)">
@@ -60,7 +74,7 @@ const CustomBarChartTick: React.FC<{
           dy={14}
           textAnchor="end"
           fill={themeColors.label}
-          fontSize={fontSize}
+          fontSize={labelFontPx}
           fontWeight="bold"
         >
           {showTitle && <title>{`${provider} ${fullName}`}</title>}
@@ -73,7 +87,7 @@ const CustomBarChartTick: React.FC<{
             dy={28}
             textAnchor="end"
             fill={themeColors.axisText}
-            fontSize={providerFontSize}
+            fontSize={labelFontPx}
           >
             {provider}
           </text>

--- a/web/components/charts/CustomBarChartTick.tsx
+++ b/web/components/charts/CustomBarChartTick.tsx
@@ -9,16 +9,23 @@ import { useThemeColors } from "@/hooks/useThemeColors";
 const labelFontPx = 12;
 /** Longest label kept before it is ellipsized, per layout. */
 const maxLabelChars = { compact: 12, mobile: 14, desktop: 18 };
+/** Geist Mono advances a fixed 0.6em, so label widths are predictable. */
+const monoAdvance = 0.6;
 /**
  * Geist Mono advances 0.6em and the label hangs at 45°, so a label reaches this
  * far left of its own tick. The axis must reserve it as left padding or the
  * first label is clipped at the plot edge — it reads as cut off by the y-axis.
+ * The model line is ellipsized to the budget above but the provider line is
+ * not, so pass the providers on show: a longer one sets the reach.
  */
-export const tickLabelReach = (isMobile: boolean) =>
+export const tickLabelReach = (isMobile: boolean, providers: string[] = []) =>
   Math.ceil(
-    (isMobile ? maxLabelChars.mobile : maxLabelChars.desktop) *
+    Math.max(
+      isMobile ? maxLabelChars.mobile : maxLabelChars.desktop,
+      ...providers.map((provider) => provider.length)
+    ) *
       labelFontPx *
-      0.6 *
+      monoAdvance *
       Math.SQRT1_2
   );
 

--- a/web/components/charts/d3/BoxPlot.tsx
+++ b/web/components/charts/d3/BoxPlot.tsx
@@ -24,6 +24,12 @@ const modelLineHeight = 14;
 // marker, and the axis caption — 80px stacked marker over caption.
 const margin = { top: 20, right: 8, bottom: 88, left: 40 };
 const minSlotWidth = 48;
+/** Share of a slot the label block may occupy; the rest is breathing room. */
+const labelBandRatio = 0.82;
+/** Floor the label text shrinks to before a slot has to widen instead. */
+const minModelFont = 8;
+/** Geist Mono advances a fixed 0.6em, so label widths are predictable. */
+const monoAdvance = 0.6;
 
 const BoxPlot: React.FC<BoxPlotProps> = ({
   data,
@@ -108,9 +114,26 @@ const BoxPlot: React.FC<BoxPlotProps> = ({
   // chart) rather than crushing the axis labels into each other. This holds at
   // any viewport width — full screen, half, quarter, drag-resized, or mobile —
   // so wide desktops render flush while narrow ones scroll.
+  // A slot also has to hold the widest line of its label at the floor font —
+  // below that the text stops shrinking and spills into its neighbours.
+  const slotWidth = Math.ceil(
+    Math.max(
+      minSlotWidth,
+      ...data.data.map(
+        (d) =>
+          (Math.max(
+            getProviderForModel(d.model).length,
+            ...normalizeModelName(d.model).split(/[-_\s]/).map((w) => w.length)
+          ) *
+            minModelFont *
+            monoAdvance) /
+          labelBandRatio
+      )
+    )
+  );
   const svgWidth = Math.max(
     dimensions.width,
-    data.data.length * minSlotWidth + margin.left + margin.right
+    data.data.length * slotWidth + margin.left + margin.right
   );
   const scrollable = svgWidth > dimensions.width;
 
@@ -249,8 +272,7 @@ const BoxPlot: React.FC<BoxPlotProps> = ({
 
     // Create custom wrapped text with model first
     {
-      const labelMaxWidth = xScale.step() * 0.82;
-      const minModelFont = 8;
+      const labelMaxWidth = xScale.step() * labelBandRatio;
 
       data.data.forEach((modelData) => {
         const model = modelData.model;

--- a/web/components/charts/d3/BoxPlot.tsx
+++ b/web/components/charts/d3/BoxPlot.tsx
@@ -30,6 +30,25 @@ const labelBandRatio = 0.82;
 const minModelFont = 8;
 /** Geist Mono advances a fixed 0.6em, so label widths are predictable. */
 const monoAdvance = 0.6;
+const maxCharsPerLine = 8;
+
+// Model name wrapped onto label lines, rejoining words with hyphens while they
+// fit the budget. Slot sizing and the renderer share it so the width reserved
+// for a label is measured on the very lines that get drawn — note a rejoined
+// line runs one over the budget, since its new hyphen lands after the check.
+const modelLabelLines = (model: string) => {
+  const lines: string[] = [];
+  let line = "";
+  for (const word of model.split(/[-_\s]/)) {
+    if ((line + word).length <= maxCharsPerLine) line += (line ? "-" : "") + word;
+    else if (line) {
+      lines.push(line);
+      line = word;
+    } else lines.push(word);
+  }
+  if (line) lines.push(line);
+  return lines;
+};
 
 const BoxPlot: React.FC<BoxPlotProps> = ({
   data,
@@ -123,7 +142,7 @@ const BoxPlot: React.FC<BoxPlotProps> = ({
         (d) =>
           (Math.max(
             getProviderForModel(d.model).length,
-            ...normalizeModelName(d.model).split(/[-_\s]/).map((w) => w.length)
+            ...modelLabelLines(normalizeModelName(d.model)).map((l) => l.length)
           ) *
             minModelFont *
             monoAdvance) /
@@ -282,27 +301,7 @@ const BoxPlot: React.FC<BoxPlotProps> = ({
         const xPosition = (xScale(model) ?? 0) + xScale.bandwidth() / 2;
         const yPosition = chartHeight + 15; // Base position
 
-        const maxCharsPerLine = 8;
-        const modelWords = normalizedModel.split(/[-_\s]/);
-        const modelLines: string[] = [];
-        let currentLine = "";
-
-        modelWords.forEach((word) => {
-          if ((currentLine + word).length <= maxCharsPerLine) {
-            currentLine += (currentLine ? "-" : "") + word;
-          } else {
-            if (currentLine) {
-              modelLines.push(currentLine);
-              currentLine = word;
-            } else {
-              modelLines.push(word);
-            }
-          }
-        });
-
-        if (currentLine) {
-          modelLines.push(currentLine);
-        }
+        const modelLines = modelLabelLines(normalizedModel);
 
         const modelTextNodes = modelLines.map((line, lineIndex) =>
           g

--- a/web/components/dashboard/AccuracyBarSection.tsx
+++ b/web/components/dashboard/AccuracyBarSection.tsx
@@ -19,7 +19,9 @@ import {
 } from "recharts";
 import CustomBarTooltip from "@/components/charts/tooltips/BarTooltip";
 import { normalizeModelName } from "@/lib/utils/formatters";
-import CustomBarChartTick from "@/components/charts/CustomBarChartTick";
+import CustomBarChartTick, {
+  tickLabelReach,
+} from "@/components/charts/CustomBarChartTick";
 import Card from "@/components/shared/Card";
 import { useDedicatedInfoTip } from "@/components/shared/DedicatedInferenceInfo";
 import SectionHeader from "@/components/shared/SectionHeader";
@@ -164,6 +166,7 @@ const AccuracyBarSection: React.FC = () => {
                 }
               : undefined
           }
+          exportNote={activeWerView?.label}
           hint="Click bar to compare models"
           exportXLabel="Model"
           exportRows={() =>
@@ -260,7 +263,10 @@ const AccuracyBarSection: React.FC = () => {
             <ResponsiveContainer
               width="100%"
               height="100%"
-              minWidth={werBarDataWithColors.length * (isMobile ? 56 : 48) + 52}
+              minWidth={
+                werBarDataWithColors.length * (isMobile ? 56 : 48) +
+                tickLabelReach(isMobile)
+              }
               debounce={200}
             >
               <BarChart
@@ -292,7 +298,7 @@ const AccuracyBarSection: React.FC = () => {
                   }
                   height={X_AXIS_HEIGHT}
                   interval={0}
-                  padding={{ left: 52 }}
+                  padding={{ left: tickLabelReach(isMobile) }}
                 />
                 <YAxis hide />
                 <Tooltip

--- a/web/components/dashboard/AccuracyBarSection.tsx
+++ b/web/components/dashboard/AccuracyBarSection.tsx
@@ -151,6 +151,12 @@ const AccuracyBarSection: React.FC = () => {
     availableWerBarViews.length > 1
       ? availableWerBarViews.find((view) => view.key === werBarView)
       : undefined;
+  // Room the diagonal tick labels need left of the first bar, measured on the
+  // providers actually on show since their line is never ellipsized.
+  const labelReach = tickLabelReach(
+    isMobile,
+    werBarDataWithColors.map(({ model }) => getProviderForModel(model))
+  );
 
   return (
     <div className="mb-4">
@@ -263,10 +269,7 @@ const AccuracyBarSection: React.FC = () => {
             <ResponsiveContainer
               width="100%"
               height="100%"
-              minWidth={
-                werBarDataWithColors.length * (isMobile ? 56 : 48) +
-                tickLabelReach(isMobile)
-              }
+              minWidth={werBarDataWithColors.length * (isMobile ? 56 : 48) + labelReach}
               debounce={200}
             >
               <BarChart
@@ -298,7 +301,7 @@ const AccuracyBarSection: React.FC = () => {
                   }
                   height={X_AXIS_HEIGHT}
                   interval={0}
-                  padding={{ left: tickLabelReach(isMobile) }}
+                  padding={{ left: labelReach }}
                 />
                 <YAxis hide />
                 <Tooltip

--- a/web/components/dashboard/BoxPlotSection.tsx
+++ b/web/components/dashboard/BoxPlotSection.tsx
@@ -10,7 +10,7 @@ import BoxPlot from "@/components/charts/d3/BoxPlot";
 import Card from "@/components/shared/Card";
 import SectionHeader from "@/components/shared/SectionHeader";
 import MetricInfo from "@/components/shared/MetricInfo";
-import MetricToggle from "@/components/dashboard/MetricToggle";
+import MetricToggle, { useMetricTab } from "@/components/dashboard/MetricToggle";
 import { metricAboutNote } from "@/lib/config/metrics";
 import { useDashboard } from "@/contexts/DashboardContext";
 import { useChartHoverTracking } from "@/hooks/useChartHoverTracking";
@@ -27,6 +27,7 @@ const BoxPlotSection: React.FC = () => {
     activeMetric,
   } = useDashboard();
   const trackChartHover = useChartHoverTracking("box_plot");
+  const metricTab = useMetricTab();
 
   const boxPlotData = useMemo(
     () => getBoxPlotData(activeMetric),
@@ -42,6 +43,7 @@ const BoxPlotSection: React.FC = () => {
           label="Latency Variation"
           description={description}
           note={metricAboutNote(activeMetric)}
+          exportNote={metricTab}
           exportRows={() =>
             boxPlotData.data.map(({ model, quartiles, stats }) => ({
               model,

--- a/web/components/dashboard/LatencyAccuracySection.tsx
+++ b/web/components/dashboard/LatencyAccuracySection.tsx
@@ -24,7 +24,7 @@ import { labelScatterDots } from "@/lib/utils/chartExport";
 import CustomScatterTooltip from "@/components/charts/tooltips/ScatterTooltip";
 import Card from "@/components/shared/Card";
 import SectionHeader from "@/components/shared/SectionHeader";
-import MetricToggle from "@/components/dashboard/MetricToggle";
+import MetricToggle, { useMetricTab } from "@/components/dashboard/MetricToggle";
 import MetricInfo from "@/components/shared/MetricInfo";
 import { metricAboutNote } from "@/lib/config/metrics";
 import { useDashboard } from "@/contexts/DashboardContext";
@@ -51,6 +51,7 @@ const LatencyAccuracySection: React.FC = () => {
   const activeTab = useActiveTab();
   const themeColors = useThemeColors();
   const trackChartHover = useChartHoverTracking("scatter");
+  const metricTab = useMetricTab();
 
   const latencyLabel = metric;
   const scatterData = useMemo(
@@ -176,6 +177,7 @@ const LatencyAccuracySection: React.FC = () => {
           label="Latency vs Accuracy"
           description={description}
           note={metricAboutNote(metric)}
+          exportNote={metricTab}
           exportXLabel={`Average ${latencyLabel}`}
           exportAnnotate={(clone) => {
             const nameCounts = new Map<string, number>();
@@ -395,7 +397,7 @@ const LatencyAccuracySection: React.FC = () => {
           </ResponsiveContainer>
         </div>
         <div
-          className="mt-1 text-center text-sm"
+          className="mt-1 text-center font-mono text-sm"
           style={{ color: themeColors.axisText }}
         >
           <MetricInfo metric={metric}>{latencyLabel}</MetricInfo>

--- a/web/components/dashboard/MetricToggle.tsx
+++ b/web/components/dashboard/MetricToggle.tsx
@@ -7,13 +7,24 @@ import React from "react";
 import { useDashboard } from "@/contexts/DashboardContext";
 import { useActiveTab } from "@/hooks/useActiveTab";
 
+/**
+ * The tab this toggle is showing, or undefined where it stays hidden. Charts
+ * pass it to SectionHeader as `exportNote` so a downloaded PNG — which has no
+ * toggle to read — still says which tab it was taken on.
+ */
+export const useMetricTab = () => {
+  const activeTab = useActiveTab();
+  const { sttMetric } = useDashboard();
+  return activeTab === "stt" ? sttMetric : undefined;
+};
+
 // Shared TTFS / TTFT switch. Reads and writes the single dashboard-wide metric,
 // so every chart that renders it stays in sync. Hidden on TTS (single-metric).
 const MetricToggle: React.FC = () => {
-  const activeTab = useActiveTab();
   const { sttMetric, setSttMetric } = useDashboard();
+  const shown = useMetricTab();
 
-  if (activeTab !== "stt") return null;
+  if (!shown) return null;
 
   return (
     <div className="mb-4 inline-flex gap-0.5 rounded-lg bg-surface-toggle-inactive p-0.5">

--- a/web/components/shared/SectionHeader.tsx
+++ b/web/components/shared/SectionHeader.tsx
@@ -32,6 +32,9 @@ interface SectionHeaderProps {
   note?: { term: string; text: string };
   /** When false, the detailed text shows inline instead of behind a toggle. */
   expandable?: boolean;
+  /** Active toggle state, captioned into the export — the PNG can't show the
+   *  toggle itself, so a reader has no other way to tell which view it is. */
+  exportNote?: string;
   /** Rows for the Download Data (CSV) button; must reflect the active filters. */
   exportRows?: () => Record<string, unknown>[];
   /** Set false for sections without a chart SVG to hide Download Image. */
@@ -49,6 +52,7 @@ const SectionHeader: React.FC<SectionHeaderProps> = ({
   hint,
   note,
   expandable = true,
+  exportNote,
   exportRows,
   exportImage = true,
   exportXLabel,
@@ -162,7 +166,7 @@ const SectionHeader: React.FC<SectionHeaderProps> = ({
         .forEach((el) => el.remove());
     }
     const capture = downloadChartPNG(svg, `${anchorId}.png`, {
-      label,
+      label: exportNote ? `${label} · ${exportNote}` : label,
       title: description.short,
       xLabel: exportXLabel,
       stat: stat && {

--- a/web/components/visualizations/TimelineChart.tsx
+++ b/web/components/visualizations/TimelineChart.tsx
@@ -31,7 +31,7 @@ import ChartInteractionLayer, {
 import Card from "@/components/shared/Card";
 import SectionHeader from "@/components/shared/SectionHeader";
 import MetricInfo from "@/components/shared/MetricInfo";
-import MetricToggle from "@/components/dashboard/MetricToggle";
+import MetricToggle, { useMetricTab } from "@/components/dashboard/MetricToggle";
 import { useActiveTab } from "@/hooks/useActiveTab";
 import { useDashboard } from "@/contexts/DashboardContext";
 import { useThemeColors } from "@/hooks/useThemeColors";
@@ -249,6 +249,7 @@ function segmentIntersectsRect(
 
 const TimelineChart: React.FC = () => {
   const activeTab = useActiveTab();
+  const metricTab = useMetricTab();
   const isMobile = useMobileDetection();
   const {
     getModelsWithTimelineData,
@@ -829,6 +830,7 @@ const TimelineChart: React.FC = () => {
               ? "Drag chart to zoom · swipe axis for values"
               : undefined
           }
+          exportNote={metricTab}
           exportRows={() =>
             windowedTimelineData.map((point) => ({
               time: point.timestampLabel,

--- a/web/lib/utils/chartExport.ts
+++ b/web/lib/utils/chartExport.ts
@@ -72,7 +72,55 @@ export interface ChartPNGHeader {
   axis?: SVGSVGElement;
 }
 
-const FONT = "ui-sans-serif, system-ui, sans-serif";
+// The export types with the brand faces the dashboard renders with: PP Mori for
+// headings, Geist Mono for captions, axis text and data readouts.
+const fontStack = (kind: "sans" | "mono") =>
+  `${getComputedStyle(document.body).getPropertyValue(`--font-${kind}`).trim()}, ${
+    kind === "mono" ? "ui-monospace, monospace" : "ui-sans-serif, system-ui, sans-serif"
+  }`;
+
+// Rasterizing loads the cloned SVG as an image, which can't fetch the page's
+// @font-face files — its text falls back to serif unless the faces travel with
+// it, so the mono ones are inlined as base64. Fetched once per page load.
+let monoFaceCSS: Promise<string> | undefined;
+const embedMonoFaces = () =>
+  (monoFaceCSS ??= Promise.all(
+    Array.from(document.styleSheets)
+      .flatMap((sheet) => {
+        try {
+          return Array.from(sheet.cssRules);
+        } catch {
+          return [];
+        }
+      })
+      // The CSS variable and the @font-face rule can quote the family
+      // differently, so match on the unquoted names.
+      .filter((rule): rule is CSSFontFaceRule => {
+        if (!(rule instanceof CSSFontFaceRule)) return false;
+        const unquoted = (value: string) => value.replace(/["']/g, "").trim();
+        return unquoted(fontStack("mono")).startsWith(
+          unquoted(rule.style.getPropertyValue("font-family"))
+        );
+      })
+      .map(async (rule) => {
+        const [, src] =
+          /url\("?([^")]+)"?\)/.exec(rule.style.getPropertyValue("src")) ?? [];
+        if (!src) return "";
+        const blob = await fetch(
+          new URL(src, rule.parentStyleSheet?.href ?? location.href)
+        ).then((res) => res.blob());
+        const data = await new Promise<string>((resolve, reject) => {
+          const reader = new FileReader();
+          reader.onload = () => resolve(String(reader.result));
+          reader.onerror = reject;
+          reader.readAsDataURL(blob);
+        });
+        return `@font-face{font-family:${rule.style.getPropertyValue("font-family")};font-weight:${rule.style.getPropertyValue("font-weight")};unicode-range:${rule.style.getPropertyValue("unicode-range")};src:url(${data})}`;
+      })
+  )
+    .then((faces) => faces.join(""))
+    .catch(() => ""));
+
 /** Outer margin between the canvas edge and every piece of content. */
 const MARGIN = 24;
 const LEGEND_ROW_HEIGHT = 20;
@@ -85,7 +133,7 @@ function legendRows(
   legend: LegendItem[],
   maxWidth: number
 ) {
-  ctx.font = `12px ${FONT}`;
+  ctx.font = `12px ${fontStack("mono")}`;
   const rows: (LegendItem & { x: number })[][] = [];
   let row: (LegendItem & { x: number })[] = [];
   let x = 0;
@@ -103,7 +151,7 @@ function legendRows(
   return rows;
 }
 
-/** Height of one wrapped title line (600 20px). */
+/** Height of one wrapped title line (500 20px). */
 const TITLE_LINE_HEIGHT = 28;
 
 // Greedily wrap `text` into lines that fit `maxWidth` under the caller's current
@@ -195,7 +243,8 @@ export function labelScatterDots(
     if (!point) return;
     const cx = pos(circle, "cx");
     const cy = pos(circle, "cy");
-    const w = point.label.length * 6;
+    // Geist Mono advances 0.6em, so every glyph is 6.6px at the 11px below.
+    const w = point.label.length * 6.6;
     const box = (x: number, y: number, anchor: string): Box => {
       const x1 = anchor === "start" ? x : anchor === "end" ? x - w : x - w / 2;
       return { x1, y1: y - 11, x2: x1 + w, y2: y + 3 };
@@ -261,7 +310,7 @@ export function labelScatterDots(
     text.setAttribute("y", `${y}`);
     if (anchor !== "start") text.setAttribute("text-anchor", anchor);
     text.setAttribute("font-size", "11");
-    text.setAttribute("font-family", FONT);
+    text.setAttribute("font-family", fontStack("mono"));
     text.setAttribute("font-weight", "500");
     text.setAttribute("fill", labelColor(point.color, dark));
     text.textContent = point.label;
@@ -279,6 +328,8 @@ export async function downloadChartPNG(
   colors: ThemeColors = LIGHT_CHART_COLORS
 ): Promise<boolean> {
   const dark = isDarkBg(colors.tooltipBg);
+  const sans = fontStack("sans");
+  const mono = fontStack("mono");
   const svgRect = svg.getBoundingClientRect();
   const { width, height } = svgRect;
   const axisWidth = header.axis?.getBoundingClientRect().width ?? 0;
@@ -318,6 +369,15 @@ export async function downloadChartPNG(
   let axisImg: HTMLImageElement | undefined;
   let logo: HTMLImageElement;
   try {
+    await document.fonts.ready;
+    const faces = await embedMonoFaces();
+    for (const target of [clone, axisClone]) {
+      if (!target) continue;
+      const style = document.createElementNS(SVG_NS, "style");
+      style.textContent = faces;
+      target.prepend(style);
+      target.setAttribute("font-family", mono);
+    }
     chart = await loadImage(
       `data:image/svg+xml;charset=utf-8,${encodeURIComponent(new XMLSerializer().serializeToString(clone))}`
     );
@@ -339,9 +399,9 @@ export async function downloadChartPNG(
   // Measure the headline stat first so we know how much width it claims.
   let statW = 0;
   if (header.stat) {
-    measure.font = `13px ${FONT}`;
+    measure.font = `13px ${sans}`;
     const statLabelW = measure.measureText(header.stat.label).width;
-    measure.font = `700 24px ui-monospace, SFMono-Regular, Menlo, monospace`;
+    measure.font = `700 24px ${mono}`;
     statW = Math.max(statLabelW, measure.measureText(header.stat.value).width);
   }
   // On a narrow (mobile) export the left title and right-aligned stat collide,
@@ -351,7 +411,7 @@ export async function downloadChartPNG(
   const statFitsBeside = header.stat ? statW + 16 + 140 <= fullWidth : false;
   const availableTitleWidth =
     fullWidth - (header.stat && statFitsBeside ? statW + 16 : 0);
-  measure.font = `600 20px ${FONT}`;
+  measure.font = `500 20px ${sans}`;
   const titleLines = header.title
     ? wrapText(measure, header.title, availableTitleWidth)
     : [];
@@ -383,22 +443,22 @@ export async function downloadChartPNG(
   let y = MARGIN;
   if (header.stat && statFitsBeside) {
     ctx.textAlign = "right";
-    ctx.font = `13px ${FONT}`;
+    ctx.font = `13px ${sans}`;
     ctx.fillStyle = colors.textSecondary;
     ctx.fillText(header.stat.label, totalWidth - MARGIN, y + 13);
-    ctx.font = `700 24px ui-monospace, SFMono-Regular, Menlo, monospace`;
+    ctx.font = `700 24px ${mono}`;
     ctx.fillStyle = colors.textPrimary;
     ctx.fillText(header.stat.value, totalWidth - MARGIN, y + 44);
     ctx.textAlign = "left";
   }
   if (header.label) {
-    ctx.font = `13px ${FONT}`;
+    ctx.font = `13px ${sans}`;
     ctx.fillStyle = colors.textSecondary;
     ctx.fillText(header.label, MARGIN, y + 13);
     y += 20;
   }
   if (titleLines.length) {
-    ctx.font = `600 20px ${FONT}`;
+    ctx.font = `500 20px ${sans}`;
     ctx.fillStyle = colors.textPrimary;
     for (const line of titleLines) {
       ctx.fillText(line, MARGIN, y + 20);
@@ -406,16 +466,16 @@ export async function downloadChartPNG(
     }
   }
   if (header.stat && !statFitsBeside) {
-    ctx.font = `13px ${FONT}`;
+    ctx.font = `13px ${sans}`;
     ctx.fillStyle = colors.textSecondary;
     ctx.fillText(header.stat.label, MARGIN, y + 13);
-    ctx.font = `700 24px ui-monospace, SFMono-Regular, Menlo, monospace`;
+    ctx.font = `700 24px ${mono}`;
     ctx.fillStyle = colors.textPrimary;
     ctx.fillText(header.stat.value, MARGIN, y + 40);
     y += 50;
   }
   y = MARGIN + titleBlock;
-  ctx.font = `12px ${FONT}`;
+  ctx.font = `12px ${mono}`;
   for (const row of rows) {
     for (const item of row) {
       ctx.globalAlpha = item.dimmed ? 0.35 : 1;
@@ -453,7 +513,7 @@ export async function downloadChartPNG(
     contentHeight
   );
   if (header.xLabel) {
-    ctx.font = `12px ${FONT}`;
+    ctx.font = `12px ${mono}`;
     ctx.fillStyle = colors.textSecondary;
     ctx.textAlign = "center";
     ctx.fillText(header.xLabel, totalWidth / 2, chartY + contentHeight + 16);


### PR DESCRIPTION
Closes [BENCH-533](https://linear.app/coval/issue/BENCH-533/fix-download-image-export-to-use-brand-fonts-pp-mori-geist-mono).
<img width="2000" height="1241" alt="image" src="https://github.com/user-attachments/assets/c8a2c2f5-b619-4b56-a277-1ab0b362e880" />

<img width="1964" height="1288" alt="latency-benchmarks (21)" src="https://github.com/user-attachments/assets/343aebc7-2a5a-4717-817d-0124ec60df52" />


## The bug

Download Image rasterizes the chart SVG through an `<img>`, and an image document can't fetch the page's `@font-face` files. Every `<text>` in the exported PNG therefore fell back to the browser default serif — most visibly `Time (PDT)` on the TTFA chart.

## Fix

- **Embed the faces.** `embedMonoFaces()` pulls the `CSSFontFaceRule`s belonging to `--font-mono` out of the page stylesheets, inlines each `woff2` as base64 into a `<style>` on the cloned SVG (and the pinned-axis clone), and sets `font-family` on the clone root. Fetched once per page load, cached in a module promise, degrades to the previous behaviour if anything throws.
- **Canvas chrome reads the brand variables.** The hardcoded `ui-sans-serif…` / `ui-monospace, SFMono-Regular…` strings are gone; `fontStack("sans"|"mono")` resolves the same `--font-sans` / `--font-mono` the dashboard uses. PP Mori for the section label and title, Geist Mono for legend, x-label and stat readout. Title weight 600 → 500 because PP Mori ships 400/500 and 600 was synthetic bold.
- **`await document.fonts.ready`** before rasterizing. It sits inside the existing `try`, after the synchronous measure-and-clone, so `SectionHeader`'s "strike the stage as soon as it returns" invariant still holds.
- **On-screen chart chrome moves to Geist Mono** (`globals.css`), per the brand guide — captions, section labels and data readouts are mono — which is also what makes the PNG match the live chart.

## Fallout from the wider face, fixed here

Geist Mono is ~10% wider than PP Mori, which exposed three layout bugs that were already latent:

| | Before | After |
|---|---|---|
| Box plot x-labels | 25 of 60 label lines overflowed their band and collided (`AssemblyAI`/`Together AI` ran together) | Slots size to their widest label at the 8px floor font; **0 overflow**, min font lands exactly on 8px |
| Bar chart first tick | `padding: 52px` vs a real diagonal reach of ~92px, so `Universal 3.5 Pro` was clipped 9px into the y-axis | `tickLabelReach(isMobile)` derived from the truncation ceiling, so a label can never outgrow its reserved room |
| Scatter dot labels | collision boxes estimated 6px/char, so labels overlapped | 6.6px = Geist Mono's 0.6em advance at 11px |

## Exports now name the active tab

A static PNG has no toggle to read, so `exportNote` captions it: `Accuracy by Model · Clean`, `Latency Variation · TTFT`. `useMetricTab()` lives next to `MetricToggle` and is what the toggle itself uses for its own visibility, so caption and toggle can't disagree. Charts without a toggle (radar, all of TTS) get a plain caption — no stray separator.

## Verification

Exports were captured by intercepting the download and inspecting the real PNG bytes, on both themes:

- `Time (PDT)`, ticks, legend and readout render in Geist Mono at 3× zoom; title in PP Mori; **no serif anywhere**.
- All five exporting charts checked: timeline, box plot, WER bar (incl. its pinned-axis SVG), scatter, radar.
- **Mobile/desktop parity by SHA:** `latency-variation.png` and `accuracy-by-model.png` are byte-identical at 375px and 1280px. The timeline and scatter differ by 24 CSS px of plot width — the card's own padding is `p-5` on mobile vs `lg:p-8`, which predates this branch (see below).
- Live DOM scan: 251 SVG text nodes on `/stt`, 197 on `/tts`, **zero** not resolving to Geist Mono.
- Production `next build` passes, and in the production bundle the families stay readable (`"Geist Mono"`), so the face matcher selects all six subsets. No CSP in the app, so the `data:` fonts aren't blocked.
- `typecheck`, `lint`, 81 tests pass.

## Known trade-offs for review

1. **Box plot exports are wider** — ~1760px for 24 models instead of ~1100px, so a flatter image. Labels are legible and uncollided; fixing the aspect means growing the plot height with its width, and `BoxPlot` takes height from a `height = 500` prop rather than the export wrapper, so it needs the export-staged flag plumbed in. Left for a follow-up.
2. **Desktop box plots now scroll** where they used to sit flush, and mobile shows ~4 models per screen instead of ~6. In exchange slots are 71px, so touch targets improved.
3. **24px mobile/desktop delta** on the two container-sized charts, from viewport-conditional card padding. Pre-existing; normalizing it centrally is awkward because each section passes its own `padding` prop.
4. The stat **label** (`Avg TTFS`) stays PP Mori while its **value** is mono — matches the live dashboard, though the brand guide arguably wants the label mono too. Easy to flip both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updates dashboard chart typography and PNG exports to use brand fonts.
- Embeds Geist Mono font faces into cloned SVGs before rasterization.
- Uses dashboard font variables for exported chart headers, legends, labels, and statistics.
- Adjusts chart label sizing, spacing, and collision estimates for Geist Mono.
- Adds active metric or dataset captions to exported images.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains within the scope of the previous review thread.

<sub>Reviews (2): Last reviewed commit: ["Measure label sizing on the lines that g..."](https://github.com/coval-ai/benchmarks/commit/4853bc6f7c55818364b55995998bd79d6d647120) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47077413)</sub>

<!-- /greptile_comment -->