### PR TITLE
Read every radar axis condition-first (BENCH-536)

### DIFF
--- a/web/components/dashboard/WerRadarSection.tsx
+++ b/web/components/dashboard/WerRadarSection.tsx
@@ -29,16 +29,16 @@ import { datasetLabel, isPerturbationDataset } from "@/lib/config/datasets";
 import { getModelColor } from "@/lib/utils/colors";
 import { normalizeModelName } from "@/lib/utils/formatters";
 
-// "WildASR reverb" → ["Reverb", "WildASR"]: the family drops to a second line
-// so ten axis labels stay legible on a phone-width radar.
+// "WildASR reverb" → ["Reverb", "WildASR"], "PipeCat (production)" →
+// ["Production", "PipeCat"]: every axis reads its condition first, with the
+// source family on a second line so ten labels stay legible on a phone-width
+// radar.
 function splitAxisLabel(label: string): [string, string?] {
-  if (label.startsWith("WildASR ")) {
-    const rest = label.slice(8);
-    return [rest.charAt(0).toUpperCase() + rest.slice(1), "WildASR"];
-  }
-  const paren = label.match(/^(.*?) \((.+)\)$/);
-  if (paren) return [paren[1]!, paren[2]!];
-  return [label];
+  const parts =
+    label.match(/^(WildASR) (.+)$/) ?? label.match(/^(.*?) \((.+)\)$/);
+  if (!parts) return [label];
+  const [, family, condition] = parts as [string, string, string];
+  return [condition.charAt(0).toUpperCase() + condition.slice(1), family];
 }
 
 const RadarAxisTick: React.FC<{


### PR DESCRIPTION
## Problem

On the STT dashboard's **Accuracy Across Datasets** radar, nine axes read *condition over source* — `Reverb / WildASR`, `Clean / WildASR` — and one didn't. `PipeCat (production)` rendered as **PipeCat** with **production** as the subtitle, so the odd axis out put the source where every neighbour puts the condition. New customers read it as a different kind of thing.

The cause was `splitAxisLabel` having two branches with opposite orderings:

```ts
if (label.startsWith("WildASR ")) return [condition, "WildASR"];   // condition first
const paren = label.match(/^(.*?) \((.+)\)$/);
if (paren) return [paren[1], paren[2]];                            // family first
```

## Fix

Collapse both forms into one family-then-condition match, so the return is unconditionally condition-first. Net zero lines, and the next parenthetical dataset can't reintroduce the split.

## Result

```
Production / PipeCat    Clean / WildASR         Accents / WildASR
Reverb / WildASR        Clipping / WildASR      Far-field / WildASR
Noise gaps / WildASR    Phone codec / WildASR
```

Verified in the browser against live API data at desktop and 375×812. The top-vertex lift in `RadarAxisTick` still applies — PipeCat had a subtitle before and after, so no vertical offset changed.

Label parity checked for every id in `DATASET_LABELS`; only the intended axis moved:

| Label | Before | After |
|---|---|---|
| `PipeCat (production)` | PipeCat / production | **Production / PipeCat** |
| `WildASR reverb` (and the 6 other perturbation sets) | Reverb / WildASR | unchanged |
| `LibriSpeech`, `FLEURS` | single line | unchanged |

## Checks

- `pnpm lint` — clean (`--max-warnings 0`)
- `pnpm typecheck` — clean
- `pnpm test` — 81/81 passing
- No console errors in the preview

## Out of scope

At 375px the west label `Phone codec` is clipped to "hone codec" by the card edge. Pre-existing — that label is byte-identical before and after this change — so it's tracked separately rather than folded in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR consistently renders radar-axis conditions before their dataset families.
- Unifies WildASR and parenthetical label parsing in `splitAxisLabel`.
- Changes `PipeCat (production)` to render as `Production / PipeCat`.
- Preserves existing WildASR and single-line dataset labels.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable defects identified.

The generalized parser produces the intended condition-first output for every currently configured WildASR and parenthetical dataset label while leaving unmatched labels unchanged.

<sub>Reviews (1): Last reviewed commit: ["Read every radar axis condition-first (B..."](https://github.com/coval-ai/benchmarks/commit/18f42c9192ea0356702daf22cb94aacb10525072) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47105043)</sub>

<!-- /greptile_comment -->