### PR TITLE
[BENCH-321] Add /v1/health endpoint

### DIFF
--- a/runner/src/coval_bench/api/app.py
+++ b/runner/src/coval_bench/api/app.py
@@ -124,6 +124,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
 
     # Routers
     app.include_router(health.router)
+    app.include_router(health.v1_router, prefix="/v1")
     app.include_router(robots.router)
     app.include_router(runs.router, prefix="/v1")
     app.include_router(results.router, prefix="/v1")

--- a/runner/src/coval_bench/api/ratelimit.py
+++ b/runner/src/coval_bench/api/ratelimit.py
@@ -17,8 +17,7 @@ Usage::
     app.add_middleware(SlowAPIMiddleware)
 
 All ``/v1/*`` endpoints are decorated with ``@limiter.limit("60/minute")``.
-``/healthz``, ``/readyz`` and ``/v1/health`` are exempt (they are polled by GCP
-load balancers and uptime monitors).
+``/healthz`` and ``/readyz`` are exempt (they are polled by GCP load balancers).
 """
 
 from __future__ import annotations

--- a/runner/src/coval_bench/api/ratelimit.py
+++ b/runner/src/coval_bench/api/ratelimit.py
@@ -17,7 +17,8 @@ Usage::
     app.add_middleware(SlowAPIMiddleware)
 
 All ``/v1/*`` endpoints are decorated with ``@limiter.limit("60/minute")``.
-``/healthz`` and ``/readyz`` are exempt (they are polled by GCP load balancers).
+``/healthz``, ``/readyz`` and ``/v1/health`` are exempt (they are polled by GCP
+load balancers and uptime monitors).
 """
 
 from __future__ import annotations

--- a/runner/src/coval_bench/api/request_logging.py
+++ b/runner/src/coval_bench/api/request_logging.py
@@ -30,7 +30,7 @@ logger = structlog.get_logger("coval_bench.api.access")
 _TRACE_HEADER = b"x-cloud-trace-context"
 _TRACE_ID_RE = re.compile(r"[0-9a-f]{32}", re.IGNORECASE)
 
-_QUIET_PATHS = frozenset({"/healthz", "/readyz"})
+_QUIET_PATHS = frozenset({"/healthz", "/readyz", "/v1/health"})
 
 
 class RequestLoggingMiddleware:

--- a/runner/src/coval_bench/api/routers/health.py
+++ b/runner/src/coval_bench/api/routers/health.py
@@ -5,9 +5,12 @@
 
 ``GET /healthz`` — liveness probe. No DB hit. Always answers.
 ``GET /readyz`` — readiness probe. Acquires a DB connection and runs SELECT 1.
+``GET /v1/health`` — public health check for API consumers. Same DB probe as
+``/readyz``, without the internal error string in the body.
 
-Both endpoints are **exempt from rate limiting** — they are polled by the
-GCP load balancer / Cloud Run health check and must never return 429.
+All three are **exempt from rate limiting** — they are polled by the GCP load
+balancer / Cloud Run health check and by external uptime monitors, and must
+never return 429.
 """
 
 from __future__ import annotations
@@ -24,6 +27,18 @@ from coval_bench.api.deps import get_pool
 logger = structlog.get_logger("coval_bench.api")
 
 router = APIRouter(tags=["health"])
+v1_router = APIRouter(tags=["health"])
+
+
+async def _probe_db(pool: AsyncConnectionPool[Any]) -> str | None:
+    """Run SELECT 1. Returns ``None`` when reachable, else a truncated error."""
+    try:
+        async with pool.connection() as conn:
+            await conn.execute("SELECT 1")
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("health_db_unreachable", error=str(exc)[:200])
+        return str(exc)[:200]
+    return None
 
 
 @router.get("/healthz")
@@ -41,13 +56,22 @@ async def readyz(
     Never raises an exception — DB unreachable is the expected failure mode
     during Cloud Run startup.
     """
-    try:
-        async with pool.connection() as conn:
-            await conn.execute("SELECT 1")
+    error = await _probe_db(pool)
+    if error is None:
         return JSONResponse({"status": "ready"})
-    except Exception as exc:  # noqa: BLE001
-        logger.warning("readyz_db_unreachable", error=str(exc)[:200])
-        return JSONResponse(
-            {"status": "not ready", "error": str(exc)[:200]},
-            status_code=503,
-        )
+    return JSONResponse({"status": "not ready", "error": error}, status_code=503)
+
+
+@v1_router.get("/health")
+async def health(
+    pool: AsyncConnectionPool[Any] = Depends(get_pool),
+) -> JSONResponse:
+    """Public health check — 200 when the API can serve data, 503 otherwise.
+
+    The error string stays out of the body: this path is publicly reachable,
+    while ``/readyz`` exists for operators.
+    """
+    error = await _probe_db(pool)
+    if error is None:
+        return JSONResponse({"status": "ok"})
+    return JSONResponse({"status": "unavailable"}, status_code=503)

--- a/runner/src/coval_bench/api/routers/health.py
+++ b/runner/src/coval_bench/api/routers/health.py
@@ -6,11 +6,17 @@
 ``GET /healthz`` — liveness probe. No DB hit. Always answers.
 ``GET /readyz`` — readiness probe. Acquires a DB connection and runs SELECT 1.
 ``GET /v1/health`` — public health check for API consumers. Same DB probe as
-``/readyz``, without the internal error string in the body.
+``/readyz``, rate-limited like the rest of ``/v1``.
 
-All three are **exempt from rate limiting** — they are polled by the GCP load
-balancer / Cloud Run health check and by external uptime monitors, and must
-never return 429.
+``/healthz`` and ``/readyz`` are **exempt from rate limiting** — they are polled
+by the GCP load balancer / Cloud Run health check and must never return 429.
+``/v1/health`` carries the standard 60/minute limit: it is publicly advertised
+and hits the 4-connection pool shared with the data routes, and 60/minute leaves
+ample headroom for an uptime monitor polling every few seconds.
+
+Neither DB-backed route returns the underlying error to the caller — both paths
+are publicly reachable and psycopg errors can carry connection details. The
+error is logged instead (``health_db_unreachable``).
 """
 
 from __future__ import annotations
@@ -21,8 +27,10 @@ import structlog
 from fastapi import APIRouter, Depends
 from fastapi.responses import JSONResponse
 from psycopg_pool import AsyncConnectionPool
+from starlette.requests import Request
 
 from coval_bench.api.deps import get_pool
+from coval_bench.api.ratelimit import limiter
 
 logger = structlog.get_logger("coval_bench.api")
 
@@ -30,15 +38,15 @@ router = APIRouter(tags=["health"])
 v1_router = APIRouter(tags=["health"])
 
 
-async def _probe_db(pool: AsyncConnectionPool[Any]) -> str | None:
-    """Run SELECT 1. Returns ``None`` when reachable, else a truncated error."""
+async def _db_reachable(pool: AsyncConnectionPool[Any]) -> bool:
+    """Run SELECT 1. Logs and returns ``False`` when the DB is unreachable."""
     try:
         async with pool.connection() as conn:
             await conn.execute("SELECT 1")
-    except Exception as exc:  # noqa: BLE001
-        logger.warning("health_db_unreachable", error=str(exc)[:200])
-        return str(exc)[:200]
-    return None
+    except Exception:
+        logger.warning("health_db_unreachable", exc_info=True)
+        return False
+    return True
 
 
 @router.get("/healthz")
@@ -56,22 +64,18 @@ async def readyz(
     Never raises an exception — DB unreachable is the expected failure mode
     during Cloud Run startup.
     """
-    error = await _probe_db(pool)
-    if error is None:
+    if await _db_reachable(pool):
         return JSONResponse({"status": "ready"})
-    return JSONResponse({"status": "not ready", "error": error}, status_code=503)
+    return JSONResponse({"status": "not ready"}, status_code=503)
 
 
 @v1_router.get("/health")
+@limiter.limit("60/minute")
 async def health(
+    request: Request,
     pool: AsyncConnectionPool[Any] = Depends(get_pool),
 ) -> JSONResponse:
-    """Public health check — 200 when the API can serve data, 503 otherwise.
-
-    The error string stays out of the body: this path is publicly reachable,
-    while ``/readyz`` exists for operators.
-    """
-    error = await _probe_db(pool)
-    if error is None:
+    """Public health check — 200 when the API can serve data, 503 otherwise."""
+    if await _db_reachable(pool):
         return JSONResponse({"status": "ok"})
     return JSONResponse({"status": "unavailable"}, status_code=503)

--- a/runner/tests/api/test_health.py
+++ b/runner/tests/api/test_health.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 
 from typing import Any
 
-import pytest
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
 
@@ -26,10 +25,9 @@ async def test_readyz_healthy_db(client: AsyncClient) -> None:
     assert response.json() == {"status": "ready"}
 
 
-async def test_readyz_closed_pool(app: FastAPI, monkeypatch: pytest.MonkeyPatch) -> None:
-    """GET /readyz with a broken pool returns 503 and never raises."""
+async def test_readyz_closed_pool(app: FastAPI) -> None:
+    """GET /readyz with a broken pool returns 503 and leaks no error detail."""
 
-    # Replace the pool with one that always raises on connection()
     class BrokenPool:
         def connection(self) -> Any:
             raise RuntimeError("simulated DB failure")
@@ -46,9 +44,8 @@ async def test_readyz_closed_pool(app: FastAPI, monkeypatch: pytest.MonkeyPatch)
         app.state.pool = original_pool
 
     assert response.status_code == 503
-    data = response.json()
-    assert data["status"] == "not ready"
-    assert "error" in data
+    assert response.json() == {"status": "not ready"}
+    assert "simulated DB failure" not in response.text
 
 
 async def test_v1_health_healthy_db(client: AsyncClient) -> None:
@@ -78,3 +75,4 @@ async def test_v1_health_closed_pool(app: FastAPI) -> None:
 
     assert response.status_code == 503
     assert response.json() == {"status": "unavailable"}
+    assert "simulated DB failure" not in response.text

--- a/runner/tests/api/test_health.py
+++ b/runner/tests/api/test_health.py
@@ -49,3 +49,32 @@ async def test_readyz_closed_pool(app: FastAPI, monkeypatch: pytest.MonkeyPatch)
     data = response.json()
     assert data["status"] == "not ready"
     assert "error" in data
+
+
+async def test_v1_health_healthy_db(client: AsyncClient) -> None:
+    """GET /v1/health with a healthy DB returns 200 with status ok."""
+    response = await client.get("/v1/health")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+
+
+async def test_v1_health_closed_pool(app: FastAPI) -> None:
+    """GET /v1/health with a broken pool returns 503 and leaks no error detail."""
+
+    class BrokenPool:
+        def connection(self) -> Any:
+            raise RuntimeError("simulated DB failure")
+
+    original_pool = app.state.pool
+    app.state.pool = BrokenPool()
+    try:
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+        ) as c:
+            response = await c.get("/v1/health")
+    finally:
+        app.state.pool = original_pool
+
+    assert response.status_code == 503
+    assert response.json() == {"status": "unavailable"}

--- a/runner/tests/api/test_ratelimit.py
+++ b/runner/tests/api/test_ratelimit.py
@@ -60,12 +60,14 @@ async def test_healthz_exempt_from_ratelimit(app: FastAPI) -> None:
     assert all(r.status_code == 200 for r in responses)
 
 
-async def test_v1_health_exempt_from_ratelimit(app: FastAPI) -> None:
-    """GET /v1/health is not rate-limited — 100 hits all return 200."""
+async def test_v1_health_is_rate_limited(app: FastAPI) -> None:
+    """GET /v1/health carries the standard 60/minute limit — the 61st hit 429s."""
     async with AsyncClient(
         transport=ASGITransport(app=app),
         base_url="http://test",
     ) as c:
-        responses = [await c.get("/v1/health") for _ in range(100)]
+        allowed = [await c.get("/v1/health") for _ in range(60)]
+        blocked = await c.get("/v1/health")
 
-    assert all(r.status_code == 200 for r in responses)
+    assert all(r.status_code == 200 for r in allowed)
+    assert blocked.status_code == 429

--- a/runner/tests/api/test_ratelimit.py
+++ b/runner/tests/api/test_ratelimit.py
@@ -58,3 +58,14 @@ async def test_healthz_exempt_from_ratelimit(app: FastAPI) -> None:
         responses = [await c.get("/healthz") for _ in range(100)]
 
     assert all(r.status_code == 200 for r in responses)
+
+
+async def test_v1_health_exempt_from_ratelimit(app: FastAPI) -> None:
+    """GET /v1/health is not rate-limited — 100 hits all return 200."""
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+    ) as c:
+        responses = [await c.get("/v1/health") for _ in range(100)]
+
+    assert all(r.status_code == 200 for r in responses)


### PR DESCRIPTION
Public API consumers now get a DB-backed health check under the versioned prefix instead of a 404.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a versioned, database-backed public health endpoint.
- Mounts the health router under `/v1` and exposes `GET /v1/health`.
- Refactors readiness and public health checks to share a sanitized database probe.
- Adds access-log suppression and rate-limit/response tests for the endpoint.

<h3>Confidence Score: 4/5</h3>

This PR is not yet safe to merge because concurrent health requests can still exhaust the shared database pool despite the new per-minute limit.

The limiter controls request count rather than concurrent execution, allowing a burst within the 60-request allowance to occupy all four shared database connections and block normal API traffic.

**Files Needing Attention:** runner/src/coval_bench/api/routers/health.py

<sub>Reviews (3): Last reviewed commit: ["Throttle /v1/health and stop leaking DB ..."](https://github.com/coval-ai/benchmarks/commit/1c26b822b927a97a9658011fcf49beaf3817b994) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47118888)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [API service](https://app.greptile.com/coval/-/custom-context/knowledge-base/coval-ai/benchmarks/-/docs/api-service.md)

<!-- /greptile_comment -->