### PR TITLE
refactor(s2s): remove obsolete ingestion check

### DIFF
--- a/runner/src/coval_bench/db/writer.py
+++ b/runner/src/coval_bench/db/writer.py
@@ -245,39 +245,13 @@ class RunWriter:
                 await cur.execute(sql, (status, error, run_id))
             await conn.commit()
 
-    async def coval_run_ingested(self, *, provider: str, coval_run_id: str) -> bool:
-        """True if a succeeded or partial run already holds rows for this Coval run.
-
-        S2S rows store ``audio_filename = '<coval_run_id>/<sim_id>'``. Lets the
-        fetch job skip a re-pulled run so a retry or stale re-pull doesn't
-        double-write the day's bucket. Rows from failed runs don't count: they
-        never reach the bucket, so a retry must stay free to re-ingest the run.
-        """
-        sql = """
-            SELECT 1
-            FROM benchmarks_v2.results r
-            JOIN benchmarks_v2.runs rn ON rn.id = r.run_id
-            WHERE r.provider = %s
-              AND r.benchmark = 'S2S'
-              AND split_part(r.audio_filename, '/', 1) = %s
-              AND rn.status IN ('succeeded', 'partial')
-            LIMIT 1
-        """
-        async with self._pool.connection() as conn:
-            async with conn.cursor() as cur:
-                await cur.execute(sql, (provider, coval_run_id))
-                row = await cur.fetchone()
-            await conn.commit()
-        return row is not None
-
     async def coval_metric_ingested(
         self, *, provider: str, coval_run_id: str, metric_type: str
     ) -> bool:
         """True if a succeeded/partial run already holds this Coval run's ``metric_type`` rows.
 
-        Metric-aware counterpart of :meth:`coval_run_ingested`: lets the fetch
-        backfill one metric (e.g. instruction) onto a run whose other metric
-        (latency) already landed, instead of skipping the whole run.
+        Lets the fetch backfill one metric (e.g. instruction) onto a run whose
+        other metric (latency) already landed, instead of skipping the whole run.
         """
         sql = """
             SELECT 1

--- a/runner/src/coval_bench/s2s/fetch_v2v.py
+++ b/runner/src/coval_bench/s2s/fetch_v2v.py
@@ -592,7 +592,7 @@ async def fetch_and_write_v2v(settings: Settings | None = None) -> dict[str, Run
     """Ingest every provider's recent runs; return per-provider status.
 
     Each ingested Coval run gets its own run row slotted by its create_time,
-    and ``coval_run_ingested`` makes re-scans no-ops, so ticks are idempotent
+    and ``coval_metric_ingested`` makes re-scans no-ops, so ticks are idempotent
     and the fetch cadence only affects how soon data appears — the cron may
     run more often than the sims.
     """

--- a/runner/tests/unit/test_s2s_fetch.py
+++ b/runner/tests/unit/test_s2s_fetch.py
@@ -80,7 +80,6 @@ def _stub_writer() -> MagicMock:
             status=RunStatus.RUNNING,
         )
     )
-    writer.coval_run_ingested = AsyncMock(return_value=False)
     writer.coval_metric_ingested = AsyncMock(return_value=False)
     writer.record_results = AsyncMock()
     writer.finish_run = AsyncMock()


### PR DESCRIPTION
## Summary
- remove the superseded run-level S2S ingestion lookup
- keep the metric-aware ingestion lookup used by the fetch path
- remove the stale mock and update method references

## Verification
- `uv run ruff check ...`
- `uv run ruff format --check ...`
- `uv run mypy --strict src/coval_bench` (132 source files)
- `uv run pytest -q tests/unit/test_s2s_fetch.py tests/unit/test_db_writer.py` (52 passed)
- `git diff --check`