### PR TITLE
Fix S2S sampler reading transcript off the wrong nesting level

### DIFF
--- a/runner/src/coval_bench/s2s/samples.py
+++ b/runner/src/coval_bench/s2s/samples.py
@@ -280,7 +280,8 @@ async def _publish_tick_sample(
                     return resp
 
                 detail = await _fetch_retry(fetch_detail, provider=provider, what="sim_detail")
-                turns = _conversation_turns(cast("dict[str, Any]", detail.json()))
+                # /simulations/{id} wraps the object in a "simulation" envelope.
+                turns = _conversation_turns(cast("dict[str, Any]", detail.json()["simulation"]))
 
                 async def fetch_recording(sim_id: str = sim_id) -> bytes | None:
                     return await _download_recording(client, download_client, sim_id)

--- a/runner/tests/unit/test_s2s_samples.py
+++ b/runner/tests/unit/test_s2s_samples.py
@@ -86,7 +86,7 @@ def _fake_client(
                 {"role": "assistant", "content": "how can i help"},
             ]
         )
-        return httpx.Response(200, json={"transcript": turns})
+        return httpx.Response(200, json={"simulation": {"transcript": turns}})
 
     return httpx.AsyncClient(base_url="https://api.test/v1", transport=httpx.MockTransport(handler))
 


### PR DESCRIPTION
`GET /simulations/{id}` wraps the object in a `{"simulation": {...}}` envelope, but the sampler passed the raw response to `_conversation_turns`, which reads `["transcript"]` at the top level. It was always None, so every provider's turns came back empty and the sampler skipped every candidate as incomplete producing zero samples and firing the `S2S Sample Failure` alert on each fetch.

Unwrap `["simulation"]` (the list endpoint already unwraps its `{"simulations": [...]}` envelope; detail was the asymmetric miss). The detail-mock fixture returned a flat `{"transcript": ...}`, which hid the bug in CI corrected to the real envelope, which reproduces the failure without the fix (5 tests) and passes with it.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes S2S sample generation by unwrapping simulation detail responses before reading transcripts.
- Reads transcript turns from the detail endpoint's `simulation` envelope.
- Updates the unit-test fixture to reproduce the production API response shape.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the implementation and fixture consistently applying the simulation detail response envelope.

The changed lookup aligns transcript extraction with the detail endpoint's response shape, while existing exception handling continues to keep sampling failures from failing the surrounding fetch.

<sub>Reviews (1): Last reviewed commit: ["Fix S2S sampler reading transcript off t..."](https://github.com/coval-ai/benchmarks/commit/2f94d62e9a04679146f2a5a26dc50bc603cce008) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47127308)</sub>

**Context used:**

- Knowledge Base — [Runner Orchestration](https://app.greptile.com/coval/-/custom-context/knowledge-base/coval-ai/benchmarks/-/docs/runner-orchestration.md)

<!-- /greptile_comment -->