### PR TITLE
Index results_by_bucket by dataset (BENCH-540)

### DIFF
--- a/runner/src/coval_bench/db/migrations/versions/20260724_0011_dataset_series_idx.py
+++ b/runner/src/coval_bench/db/migrations/versions/20260724_0011_dataset_series_idx.py
@@ -1,0 +1,36 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Cover dataset_id in the results_by_bucket series index.
+
+The aggregates series query filters on (benchmark, dataset_id, bucket_at);
+the previous (benchmark, bucket_at) index made every per-dataset read scan
+all datasets' rows for the window.
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "20260724_0011"
+down_revision = "20260715_0010"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Replace the series index with one that covers dataset_id."""
+    op.execute("DROP INDEX IF EXISTS benchmarks_v2.results_by_bucket_series_idx")
+    op.execute(
+        "CREATE INDEX results_by_bucket_series_idx "
+        "ON benchmarks_v2.results_by_bucket (benchmark, dataset_id, bucket_at)"
+    )
+
+
+def downgrade() -> None:
+    """Restore the pre-dataset series index."""
+    op.execute("DROP INDEX IF EXISTS benchmarks_v2.results_by_bucket_series_idx")
+    op.execute(
+        "CREATE INDEX results_by_bucket_series_idx "
+        "ON benchmarks_v2.results_by_bucket (benchmark, bucket_at)"
+    )


### PR DESCRIPTION
Per-dataset aggregates queries were scanning every dataset's rows; the series index now covers (benchmark, dataset_id, bucket_at).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaces the `results_by_bucket` series index so dataset-scoped aggregate queries can use `(benchmark, dataset_id, bucket_at)`.

<h3>Confidence Score: 3/5</h3>

This PR should not merge until the live index replacement is made non-blocking.

The migration executes a blocking index drop and rebuild while separately deployed API readers and overlapping runner writers can still access results_by_bucket, creating a concrete deployment-time outage or timeout path.

**Files Needing Attention:** runner/src/coval_bench/db/migrations/versions/20260724_0011_dataset_series_idx.py

<sub>Reviews (1): Last reviewed commit: ["Index results\_by\_bucket by dataset (BENC..."](https://github.com/coval-ai/benchmarks/commit/985d675379bca984008cf2001da34909c68cb413) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47141238)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [DB Layer](https://app.greptile.com/coval/-/custom-context/knowledge-base/coval-ai/benchmarks/-/docs/db-layer.md)

<!-- /greptile_comment -->