### PR TITLE
Capture per-turn timing offsets in S2S conversation samples

### DIFF
--- a/runner/src/coval_bench/s2s/samples.py
+++ b/runner/src/coval_bench/s2s/samples.py
@@ -69,19 +69,36 @@ class SampleRun:
     agent_id: str = ""
 
 
+def _offset_seconds(value: object) -> float | None:
+    """A Coval transcript offset as float seconds, or ``None`` when absent/non-numeric."""
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    return float(value)
+
+
 def _conversation_turns(sim: dict[str, Any]) -> list[dict[str, Any]]:
-    """Full ordered conversation as ``{index, role, content}`` turns.
+    """Full ordered conversation as ``{index, role, content, start_offset, end_offset}`` turns.
 
     Non-string content is skipped so a malformed message can't poison the
     manifest; an empty list means the transcript couldn't be resolved and the
-    sample is treated as incomplete.
+    sample is treated as incomplete. ``start_offset``/``end_offset`` are
+    full-recording positions in seconds (``None`` when Coval omits them) that
+    the dashboard uses to sync the playhead to each turn.
     """
     turns: list[dict[str, Any]] = []
     for message in cast("list[dict[str, Any]]", sim.get("transcript") or []):
         role = message.get("role")
         content = message.get("content")
         if isinstance(role, str) and isinstance(content, str):
-            turns.append({"index": len(turns), "role": role, "content": content})
+            turns.append(
+                {
+                    "index": len(turns),
+                    "role": role,
+                    "content": content,
+                    "start_offset": _offset_seconds(message.get("start_offset")),
+                    "end_offset": _offset_seconds(message.get("end_offset")),
+                }
+            )
     return turns
 
 
@@ -318,7 +335,6 @@ async def _publish_tick_sample(
             "test_set_id": test_set_id,
             "test_case_id": test_case_id,
             "persona_name": _persona_label(persona_id),
-            "input_audio_url": None,
             "recordings": recordings,
         }
         _upload(bucket, manifest_key, json.dumps(manifest).encode(), "application/json")

--- a/runner/tests/unit/test_s2s_samples.py
+++ b/runner/tests/unit/test_s2s_samples.py
@@ -82,8 +82,8 @@ def _fake_client(
             []
             if sim_id in empty_turns
             else [
-                {"role": "user", "content": "hi there"},
-                {"role": "assistant", "content": "how can i help"},
+                {"role": "user", "content": "hi there", "start_offset": 1.5, "end_offset": 2.25},
+                {"role": "assistant", "content": "how can i help", "start_offset": 3.0},
             ]
         )
         return httpx.Response(200, json={"simulation": {"transcript": turns}})
@@ -155,13 +155,16 @@ async def test_publishes_complete_conversation_for_all_providers() -> None:
     assert manifest["bucket_at"] == TICK
     assert manifest["test_set_id"] == TEST_SET
     assert manifest["persona_name"] in {"Standard Female", "Standard Male"}
-    assert manifest["input_audio_url"] is None
+    assert "input_audio_url" not in manifest  # dropped in v2
     assert "transcript" not in manifest  # dropped in v2
     assert {r["provider"] for r in manifest["recordings"]} == {"openai", "google"}
     for rec in manifest["recordings"]:
         assert rec["agent_id"] in {"AO", "AG"}
         assert [t["index"] for t in rec["turns"]] == [0, 1]
         assert [t["role"] for t in rec["turns"]] == ["user", "assistant"]
+        # Per-agent offsets flow through; a missing offset coerces to None.
+        assert [t["start_offset"] for t in rec["turns"]] == [1.5, 3.0]
+        assert [t["end_offset"] for t in rec["turns"]] == [2.25, None]
 
     assert json.loads(bucket.objects[samples.INDEX_KEY]) == [TICK]
 
@@ -287,3 +290,19 @@ async def test_never_raises_on_total_failure() -> None:
 
     assert stored == 0
     assert bucket.objects == {}
+
+
+def test_conversation_turns_coerces_offsets() -> None:
+    sim = {
+        "transcript": [
+            {"role": "user", "content": "a", "start_offset": 1, "end_offset": 2.5},
+            {"role": "assistant", "content": "b", "start_offset": "x", "end_offset": True},
+            {"role": "user", "content": "c"},
+        ]
+    }
+    turns = samples._conversation_turns(sim)
+    assert [(t["start_offset"], t["end_offset"]) for t in turns] == [
+        (1.0, 2.5),
+        (None, None),
+        (None, None),
+    ]


### PR DESCRIPTION
Each S2S conversation-sample turn now carries start_offset and end_offset, the turn's position in seconds within that provider's full-conversation recording, coerced to float seconds, or null when simulation omits them. The offsets come from each provider's own simulation, so they map one-to-one onto that provider's own recording; the dashboard uses them to sync the playhead and jump to a turn.

Also drops input_audio_url from the v2 manifest. It was only ever populated by the retired single-turn sampler (a link to the single source clip); multi-turn recordings have no separate input file, so it was hardcoded to null. The web reader already treats a missing key as null, so nothing on the dashboard changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds per-turn recording offsets to S2S sample manifests and removes the obsolete input_audio_url field.
- Coerces numeric start and end offsets to float seconds and uses null for absent or non-numeric values.
- Extends sample tests to cover offset serialization and the reduced manifest shape.

<h3>Confidence Score: 3/5</h3>

This PR should not merge until the dashboard parser and playback path preserve and consume the newly published turn offsets.

The runner serializes the timing fields successfully, but the sole manifest consumer strips them from every parsed turn, leaving the advertised synchronization and turn-seeking behavior unavailable.

**Files Needing Attention:** runner/src/coval_bench/s2s/samples.py and web/lib/audioSamples/s2sFeed.ts

<sub>Reviews (1): Last reviewed commit: ["Capture per-turn timing offsets in S2S c..."](https://github.com/coval-ai/benchmarks/commit/f986a2e21ec10da3137567712f2a0f2cd65fac7d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47158275)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Runner Orchestration](https://app.greptile.com/coval/-/custom-context/knowledge-base/coval-ai/benchmarks/-/docs/runner-orchestration.md)

<!-- /greptile_comment -->