### PR TITLE
Show IQR on the latency variation card

### DIFF
--- a/web/components/charts/d3/BoxPlot.tsx
+++ b/web/components/charts/d3/BoxPlot.tsx
@@ -467,10 +467,9 @@ const BoxPlot: React.FC<BoxPlotProps> = ({
           .attr("fill", "transparent");
       }
 
-      // Hover shows a compact name + median tooltip above the whiskers;
-      // clicking pins that same tooltip and populates it with the full
-      // stats so it never chases the cursor or blocks neighboring boxes.
-      // On mobile there is no hover: a tap pins the full stats directly.
+      // Hover shows the model's name and IQR above the whiskers; clicking pins
+      // that same tooltip so it never chases the cursor or blocks neighboring
+      // boxes. On mobile there is no hover: a tap pins it directly.
       const anchor = {
         point: modelData,
         x: margin.left + centerX,
@@ -606,22 +605,12 @@ const BoxPlot: React.FC<BoxPlotProps> = ({
             {normalizeModelName(tip.point.model)}
           </p>
           {dedicatedModels?.has(tip.point.model) && <DedicatedBadge />}
-          {(tip.pinned
-            ? [
-                ["Max", `${tip.point.stats.max.toFixed(0)}ms`],
-                ["P95", `${tip.point.stats.p95.toFixed(0)}ms`],
-                ["P75", `${tip.point.quartiles.q3.toFixed(0)}ms`],
-                ["P50", `${tip.point.quartiles.median.toFixed(0)}ms`],
-                ["P25", `${tip.point.quartiles.q1.toFixed(0)}ms`],
-                ["Count", `${tip.point.stats.count}`]
-              ]
-            : [
-                [
-                  "Median",
-                  `${tip.point.quartiles.median.toFixed(0)}ms · click for details`
-                ]
-              ]
-          ).map(([label, value]) => (
+          {[
+            [
+              "IQR",
+              `${(tip.point.quartiles.q3 - tip.point.quartiles.q1).toFixed(0)}ms`
+            ]
+          ].map(([label, value]) => (
             <p
               key={label}
               style={{

--- a/web/components/dashboard/BoxPlotSection.tsx
+++ b/web/components/dashboard/BoxPlotSection.tsx
@@ -20,7 +20,6 @@ const BoxPlotSection: React.FC = () => {
     boxPlotDescription: description,
     latencyLabel,
     getBoxPlotData,
-    getAvgLatencyMs,
     getProviderForModel,
     dedicatedModels,
     isMobile,
@@ -33,8 +32,17 @@ const BoxPlotSection: React.FC = () => {
     () => getBoxPlotData(activeMetric),
     [getBoxPlotData, activeMetric]
   );
-  // Run-weighted average latency across all selected models.
-  const avgLatency = getAvgLatencyMs(activeMetric);
+
+  // Headline: mean IQR across the models on the chart — how predictable the
+  // field is, which is what this card is for, rather than how fast it is.
+  const avgIqrMs = useMemo(() => {
+    const widths = boxPlotData.data
+      .map(({ quartiles }) => quartiles.q3 - quartiles.q1)
+      .filter((width) => Number.isFinite(width) && width >= 0);
+    return widths.length > 0
+      ? widths.reduce((sum, width) => sum + width, 0) / widths.length
+      : undefined;
+  }, [boxPlotData]);
 
   return (
     <div className="mb-4">
@@ -54,16 +62,25 @@ const BoxPlotSection: React.FC = () => {
               median_ms: quartiles.median,
               q3_ms: quartiles.q3,
               whisker_high_ms: quartiles.max,
+              iqr_ms: quartiles.q3 - quartiles.q1,
+              iqr_pct_of_median:
+                quartiles.median > 0
+                  ? ((quartiles.q3 - quartiles.q1) / quartiles.median) * 100
+                  : undefined,
               mean_ms: stats.mean,
               runs: stats.count,
             }))
           }
-          stat={{
-            label: (
-              <MetricInfo metric={activeMetric} align="right">{`Average ${latencyLabel}`}</MetricInfo>
-            ),
-            value: `${avgLatency.toFixed(0)} ms`,
-          }}
+          stat={
+            avgIqrMs === undefined
+              ? undefined
+              : {
+                  label: (
+                    <MetricInfo metric="iqr" align="right">{`Average ${latencyLabel} IQR`}</MetricInfo>
+                  ),
+                  value: `${avgIqrMs.toFixed(0)} ms`,
+                }
+          }
         />
 
         <MetricToggle />

--- a/web/hooks/useDashboardState.tsx
+++ b/web/hooks/useDashboardState.tsx
@@ -557,7 +557,7 @@ export function useDashboardState(page: "tts" | "stt" | "s2s") {
   const boxPlotDescription = {
     short: `Distribution of ${latencyLabel} values across all runs`,
     detailed:
-      "Narrow distributions indicate reliable, predictable response times, while wide distributions show erratic performance that may frustrate users despite good average speeds. A model with moderate median latency and tight distribution often provides superior user experience compared to a faster median model with high variability." +
+      metricDescriptions.iqr.detailed +
       (hasDedicatedBoxes
         ? ` Endpoints marked with a server icon use dedicated inference. ${DEDICATED_INFERENCE_BLURB}`
         : ""),

--- a/web/lib/config/metrics.ts
+++ b/web/lib/config/metrics.ts
@@ -47,6 +47,14 @@ export const metricDescriptions = {
     detailed:
       "The human-parity zone reframes the latency-accuracy trade-off around a human baseline instead of arbitrary thresholds. Human transcription accuracy is typically 2–4% WER under optimal conditions, and the median turn-taking gap in human conversation is roughly 200ms. A model inside the zone transcribes at least as accurately as a person and responds at least as fast as one."
   },
+  // Shared by the Latency Variation card's description and its headline tooltip.
+  iqr: {
+    short: "Interquartile Range",
+    tooltip:
+      "The width of the middle 50% of runs, p75 − p25 — the box drawn for each model. Narrow means predictable; wide means erratic even when the average looks good. Lower is better.",
+    detailed:
+      "IQR is the width of the middle 50% of runs, p75 − p25 — the box drawn for each model. Narrow distributions mean reliable, predictable response times; wide ones mean erratic performance despite good average speeds, so a moderate median with a tight box often beats a faster median with high variability. The headline averages it across the models shown."
+  },
   v2v: {
     short: "Voice-to-Voice Latency",
     detailed:


### PR DESCRIPTION
The Latency Variation card's headline was the same run-weighted average latency the timeline above it already reports, so the card spent its one stat on a number that says nothing about variation. It now reports the average IQR (p75 − p25) across the models on the chart, and each box's tooltip reports that model's own IQR in place of the percentile ladder.

The IQR definition lives once in the metrics config and is shared by the card description and the headline tooltip, so the two can't drift. CSV export gains iqr_ms and iqr_pct_of_median. Applies to STT, TTS and S2S — the existing per-page metric and unit handling covered it, so no new conditioning was needed.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updates the Latency Variation card to emphasize interquartile range.
- Replaces the headline average latency with the mean IQR across displayed models.
- Simplifies box-plot tooltips to show each model's IQR.
- Adds IQR values and median-relative percentages to CSV exports.
- Centralizes the IQR description in the metrics configuration.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no concrete correctness, compatibility, or security failures identified.

The new metric key resolves correctly, latency units remain consistent across STT, TTS, and S2S, empty chart data is handled without rendering an invalid headline, and the CSV serializer safely preserves optional ratio fields as empty cells.

<sub>Reviews (1): Last reviewed commit: ["Show IQR on the latency variation card"](https://github.com/coval-ai/benchmarks/commit/597f47b2d97f1595089eac11cfb61d60885ee3df) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47158502)</sub>

**Context used:**

- Knowledge Base — [Web Dashboard (STT/TTS/S2S + Overview)](https://app.greptile.com/coval/-/custom-context/knowledge-base/coval-ai/benchmarks/-/docs/web-dashboard.md)

<!-- /greptile_comment -->