### PR TITLE
Sort the latency variation chart by IQR

### DIFF
--- a/web/components/charts/d3/BoxPlot.tsx
+++ b/web/components/charts/d3/BoxPlot.tsx
@@ -371,7 +371,7 @@ const BoxPlot: React.FC<BoxPlotProps> = ({
       .style("text-anchor", "middle")
       .attr("fill", themeColors.axisText)
       .attr("font-size", axisLabelFontSize)
-      .text("Ranked by P50 latency");
+      .text("Ranked by IQR (tightest first)");
 
     // Render a box plot for each model
     data.data.forEach((modelData) => {

--- a/web/hooks/useChartData.ts
+++ b/web/hooks/useChartData.ts
@@ -225,7 +225,7 @@ export function useChartData({
   }, [modelStats, toDisplayUnits]);
 
   // Box plot data for a given metric: the selected models' pieces, sorted by
-  // median, with the pooled axis bounds.
+  // IQR so the tightest models read left to right, with the pooled axis bounds.
   const getBoxPlotData = useCallback(
     (metric: string): BoxPlotData => {
       const byModel = boxByMetricModel[metric] ?? {};
@@ -247,7 +247,10 @@ export function useChartData({
         globalMax = 0;
       }
 
-      data.sort((a, b) => a.quartiles.median - b.quartiles.median);
+      data.sort(
+        (a, b) =>
+          a.quartiles.q3 - a.quartiles.q1 - (b.quartiles.q3 - b.quartiles.q1)
+      );
 
       return {
         data,


### PR DESCRIPTION
The Latency Variation boxes were ordered by median, which repeated the ranking the other latency charts already show. They now sort by IQR ascending, so the tightest model reads leftmost and spread widens to the right — matching what the card measures and what its headline reports.

CSV export follows the same order, so downloads change from median-ascending to IQR-ascending.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR aligns latency-variation ranking with the chart’s IQR-focused purpose.
- Sorts box-plot models by ascending interquartile range instead of median latency.
- Updates the x-axis caption to describe IQR ranking and tightest-first order.
- Causes CSV exports to follow the same IQR-based ordering.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failures remain.

<sub>Reviews (2): Last reviewed commit: ["Update the box plot axis caption to matc..."](https://github.com/coval-ai/benchmarks/commit/60ea606f5a971e17b484e30da6c4bb41b22f6eab) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47161292)</sub>

**Context used:**

- Knowledge Base — [Web Dashboard (STT/TTS/S2S + Overview)](https://app.greptile.com/coval/-/custom-context/knowledge-base/coval-ai/benchmarks/-/docs/web-dashboard.md)

<!-- /greptile_comment -->