### PR TITLE
Keep the timeline axis labels inside the plot (BENCH-543)

### DIFF
--- a/web/components/visualizations/TimelineChart.tsx
+++ b/web/components/visualizations/TimelineChart.tsx
@@ -462,9 +462,12 @@ const TimelineChart: React.FC = () => {
   const zoomTicks = useMemo(
     () =>
       zoomX &&
+      // Inset off the domain edges: a label centred on zoomX[0] hangs half its
+      // width left of the plot, over the Y axis labels. Five ticks keep the
+      // same spacing the edge-to-edge six had, without the crowding.
       Array.from(
-        { length: 6 },
-        (_, i) => zoomX[0] + ((zoomX[1] - zoomX[0]) * i) / 5
+        { length: 5 },
+        (_, i) => zoomX[0] + ((zoomX[1] - zoomX[0]) * (i + 0.5)) / 5
       ),
     [zoomX]
   );
@@ -1004,7 +1007,7 @@ const TimelineChart: React.FC = () => {
                 }}
               />
               <YAxis
-                width={40}
+                width={48}
                 axisLine={false}
                 tickLine={false}
                 tick={{ fill: themeColors.axisText, fontSize: 12 }}
@@ -1133,11 +1136,14 @@ const TimelineChart: React.FC = () => {
                 }}
               />
               <div
-                className="absolute z-[15] border-t border-dashed border-text-secondary/40 bg-surface-toggle-inactive/35 touch-pan-y md:hidden"
+                className="absolute z-[15] touch-pan-y md:hidden"
                 style={{
-                  left: interactionBox.left,
+                  // Full-width hit area: scrubDateAxis clamps into the plot box,
+                  // so the Y axis gutter and right margin scrub to the end
+                  // values instead of being dead zones.
+                  left: 0,
                   top: interactionBox.top + interactionBox.height,
-                  width: interactionBox.width,
+                  right: 0,
                   bottom: 0,
                 }}
                 onPointerDown={(e) => {
@@ -1157,6 +1163,15 @@ const TimelineChart: React.FC = () => {
                   cancelAxisScrub();
                 }}
               >
+                {/* Band stays plot-aligned so its rule never runs into the Y
+                    axis labels. */}
+                <div
+                  className="absolute inset-y-0 border-t border-dashed border-text-secondary/40 bg-surface-toggle-inactive/35"
+                  style={{
+                    left: interactionBox.left,
+                    width: interactionBox.width,
+                  }}
+                />
               </div>
             </>
           )}


### PR DESCRIPTION
Fixes the cropped Y axis labels reported in Slack, plus two adjacent overflow/reach problems on the same chart's axes.

## Y axis labels were cropped (the reported bug)

`YAxis` reserved `width={40}`, but Recharts places left-axis tick text at `width − tickSize(6) − tickMargin(2)`, so labels only got 32px. At the 2-decimal step the formatter emits 5-character labels (`0.20s`, `1.00s`) that measure **36px**, so every label overflowed the SVG's left edge by 4px and lost its leading digit — `".00s"`, `".80s"`.

Measured in the DOM rather than eyeballed: labels started at `x=49` with the surface at `x=53`. Now `width={48}`, which puts every label 4px *inside* the edge and also covers the `0.05s` labels the 50ms zoom step can produce.

## X axis labels overflowed at both ends

Same class of bug on the other axis. `zoomTicks` generated 6 evenly spaced values where the first is exactly `zoomX[0]` and the last exactly `zoomX[1]` — the plot's left and right edges. Centred on an endpoint, those labels hung half their width outside the plot: the first one back over the Y axis tick labels, the last one 1.4px past the SVG.

Ticks are now inset off both edges. Five of them preserve the **50.6px spacing** the edge-to-edge six had — insetting six would have cut spacing to 42.2px, leaving only a 6px gap between 36px labels:

| | spacing | gap between labels | first label |
|---|---|---|---|
| before (6, edge-to-edge) | 50.6px | 14.6px | overhangs Y axis by 10px |
| 6, inset | 42.2px | 6px (crowded) | clear |
| **now (5, inset)** | **50.6px** | **14.6px** | **clear** |

Tradeoff worth a reviewer's opinion: five labels means the exact zoom bounds are no longer labelled. Reading times off the axis is unaffected. Unzoomed ticks are untouched — they snap to 4-hour/midnight boundaries and already sat clear.

## Mobile scrub couldn't reach the ends

The axis-scrub strip spanned only the plot box — 253px of the frame's 309px — leaving the 48px Y axis gutter and 8px right margin as dead zones. The earliest and latest values were unreachable by touch.

The hit area is now full-width. No mapping changes were needed because `scrubDateAxis` already clamps into the plot box, so the gutter and margin scrub to the end values. An inner band carries the border and tint and stays plot-aligned, so the dashed rule never runs into the `0.00s` label.

| touch point | before | after |
|---|---|---|
| x=4 (gutter, under Y axis) | no element | `11:00:00` — domain start |
| x=154 (middle) | works | `21:00:00` |
| x=305 (right margin) | no element | `10:00:00` — domain end |

## Verification

Measured in the running app, not assumed. All labels sit inside the SVG in every state:

| State | Labels | Clearance |
|---|---|---|
| STT / TTFS, cold load | `0.00s`–`1.00s` | +4px |
| STT / TTFT tab | `0.0s`–`6.0s` | +11.2px |
| Y max = 500 (2-decimal worst case) | `0.00s`–`0.50s` | +4px |
| TTS / TTFA | `0.0s`–`1.5s` | +11.2px |
| Mobile 375px | `0.00s`–`1.00s` | +4px |

The chart's left edge moved 8px, and both mobile touch overlays (crop-drag and axis-scrub) followed automatically to match the grid — `syncInteractionBox` derives from Recharts' own `plotArea`, so no touch-target code needed changing. `npm run typecheck` and `npm run lint` pass; no console errors.

## Notes for the reviewer

- **The scrub strip is 35px tall**, under the 44px touch-target guidance. It's the gap between the plot bottom and the frame bottom, so raising it means overlapping the crop-drag zone or growing the card — a layout change beyond this fix's scope. Flagging for a follow-up.
- While scanning all five charts for the same class of bug, the rotated `WER % · lower is better` label on *Accuracy by Model* reports −2.7px overflow. Checked visually: that's em-box descender overhang, the glyphs render fully. Left alone deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updates the shared timeline chart to keep axis labels within the plot and make mobile axis scrubbing reachable across the full chart width.
- Widens the Y-axis gutter to prevent formatted latency labels from being cropped.
- Insets zoomed X-axis ticks and reduces their count from six to five.
- Expands the mobile scrub hit area while keeping its visual band aligned with the plot.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the changed axis geometry and mobile scrub behavior remaining internally consistent.

The expanded scrub target still maps coordinates relative to the chart and clamps them to the Recharts plot bounds, while the wider Y-axis and inset X-axis ticks address label overflow without breaking a demonstrated contract.

<sub>Reviews (1): Last reviewed commit: ["Keep the timeline axis labels inside the..."](https://github.com/coval-ai/benchmarks/commit/ee6337d9d15f69d1542320292478b6f101b0b91c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47659967)</sub>

<!-- /greptile_comment -->