### PR TITLE
Use Baseten's brand green on benchmark charts (BENCH-544)

### DIFF
--- a/web/lib/config/colors.ts
+++ b/web/lib/config/colors.ts
@@ -125,5 +125,10 @@ export const providerColors: Record<string, string> = {
   Smallest: "#d7a03d",
   Azure: "#3d7fd1",
   Alibaba: "#9c6c03",
-  "Together AI": "#4a9243"
+  "Together AI": "#4a9243",
+  // Baseten's own brand green, at their request. Sits above the categorical
+  // band's lightness ceiling (L 0.81) so it reads brighter than the palette's
+  // other greens — which is what keeps it clearly theirs next to Gradium,
+  // Together AI, and Rime.
+  Baseten: "#19E76E"
 };


### PR DESCRIPTION
Nit from Ansel Erol (Slack): the Baseten columns on the benchmark chart should use their brand green, `#19E76E`.

## Cause

Baseten was never added to `providerColors`, so `getModelColor` fell through to its hash ramp and handed it `#59b7e4` — the light blue in the screenshot.

That fallback anchor is also byte-identical to Hume's `octave-2`, so Baseten's TTS bar would have been indistinguishable from Hume's on the TTS chart. This fixes that too.

## Change

One entry. Every chart resolves color through `getModelColor` / `getProviderColor`, so bars, box plot, radar, scatter, facet chips, and playground swatches all pick it up with no other edits.

Both Baseten models (`baseten:whisper-large-v3`, `baseten:qwen3-tts-1.7b`) land on the exact brand hex — the per-model shade offset computes to 0 for each — and they're in different modalities, so they never co-occur.

## Verification

Baseten is `EARLY_ACCESS`, so it only renders with `?internal=<key>`. I verified by stubbing the API response in the browser and confirming the real code path:

- Renders at the #1 slot labeled `Whisper Large v3 / Baseten` in brand green, with its dedicated-inference icon and border intact, in both light and dark themes.
- The green propagates to the box plot and latency scatter from the single entry.
- Direct assertion of both model keys plus `getProviderColor("Baseten")` → `#19E76E`, and no existing color moved (`together:whisper-large-v3` → `#8f3055`, `gradium:default` → `#74c16c`, `octave-2` → `#59b7e4`).
- `tsc --noEmit` and `eslint --max-warnings 0` clean. No test churn — `facets.test.ts` already fixtures `host("baseten")` + `whisper-large-v3`.

## One deliberate deviation

`#19E76E` is `L 0.813` / **1.58:1** on the light chart surface, above the categorical band's lightness ceiling documented at the top of `colors.ts` and the faintest series color in the palette (next-lightest is Gradium at 2.09:1). That's intentional — the ask was brand fidelity, and muting it into the band defeats the point.

It costs nothing on the chart Ansel screenshotted: dedicated-inference bars get `stroke={themeColors.label}` at 1.5px, so the bar is outlined near-black in light / near-white in dark regardless of fill. The box plot outline, radar stroke, and scatter dot do read fainter than peers in light mode, since those use the color alone. Dark mode is 11.79:1, best in the palette. Timeline lines are unaffected — they exclude dedicated endpoints.

Flagged in a code comment so it isn't "corrected" back into the band later. If we'd rather trade a little brand fidelity for legibility there, `shiftLightness("#19E76E", -0.16)` = `#15c25c` gives 2.25:1, inside the band, same hue — one value to change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds Baseten’s brand green (`#19E76E`) to the shared provider color mapping so benchmark charts and related UI consistently use the branded color.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable defects identified.

The change adds a valid static entry to the existing provider color map and does not modify control flow, data contracts, or existing provider mappings.

<sub>Reviews (1): Last reviewed commit: ["Use Baseten&#39;s brand green on benchmark c..."](https://github.com/coval-ai/benchmarks/commit/85000426f3e20913035b7237177849de3245e6f0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47674567)</sub>

<!-- /greptile_comment -->