### PR TITLE
Add pg_stat_statements migration (BENCH-545)

### DIFF
--- a/runner/src/coval_bench/db/migrations/versions/20260727_0011_pg_stat_statements.py
+++ b/runner/src/coval_bench/db/migrations/versions/20260727_0011_pg_stat_statements.py
@@ -21,7 +21,7 @@ depends_on = None
 
 def upgrade() -> None:
     """Create the pg_stat_statements extension."""
-    op.execute("CREATE EXTENSION IF NOT EXISTS pg_stat_statements")
+    op.execute("CREATE EXTENSION IF NOT EXISTS pg_stat_statements SCHEMA public")
 
 
 def downgrade() -> None:

--- a/runner/src/coval_bench/db/migrations/versions/20260727_0011_pg_stat_statements.py
+++ b/runner/src/coval_bench/db/migrations/versions/20260727_0011_pg_stat_statements.py
@@ -1,0 +1,29 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Enable pg_stat_statements for query-level performance stats.
+
+Creating the extension only registers the view and functions; collection
+requires the library in ``shared_preload_libraries``, which Cloud SQL
+preloads by default. Local Postgres does not, so the view exists there but
+errors when queried.
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "20260727_0011"
+down_revision = "20260715_0010"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Create the pg_stat_statements extension."""
+    op.execute("CREATE EXTENSION IF NOT EXISTS pg_stat_statements")
+
+
+def downgrade() -> None:
+    """Drop the pg_stat_statements extension."""
+    op.execute("DROP EXTENSION IF EXISTS pg_stat_statements")

--- a/runner/src/coval_bench/db/migrations/versions/20260727_0012_pg_stat_statements.py
+++ b/runner/src/coval_bench/db/migrations/versions/20260727_0012_pg_stat_statements.py
@@ -13,8 +13,8 @@ from __future__ import annotations
 
 from alembic import op
 
-revision = "20260727_0011"
-down_revision = "20260715_0010"
+revision = "20260727_0012"
+down_revision = "20260724_0011"
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
Adds an extension to our db that lets us track query latency.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds an Alembic migration that enables `pg_stat_statements` on upgrade and removes it on downgrade.
- Extends the linear migration chain from revision `20260724_0011`.
- Creates the extension in the `public` schema.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<sub>Reviews (3): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/mai..."](https://github.com/coval-ai/benchmarks/commit/4e19a3efd0cd4e3516c81e6065520e1a9d62dbf1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47706953)</sub>

**Context used:**

- Knowledge Base — [DB Layer](https://app.greptile.com/coval/-/custom-context/knowledge-base/coval-ai/benchmarks/-/docs/db-layer.md)

<!-- /greptile_comment -->