### PR TITLE
Add Arena to the nav and open voting + leaderboard (BENCH-546)

### DIFF
--- a/web/app/api/arena/battle/[id]/reveal/route.ts
+++ b/web/app/api/arena/battle/[id]/reveal/route.ts
@@ -1,11 +1,9 @@
 export const runtime = "nodejs";
 
-import { arenaAccessOk } from "@/lib/arena/guard";
 import { arenaRunnerFetch } from "@/lib/arena/runner";
 import type { Reveal } from "@/lib/arena/types";
 
 export async function GET(req: Request, { params }: { params: Promise<{ id: string }> }) {
-  if (!(await arenaAccessOk())) return new Response(null, { status: 404 });
   const { id } = await params;
   const voterId = new URL(req.url).searchParams.get("voterId");
   if (!voterId) return Response.json({ error: "voterId required." }, { status: 400 });

--- a/web/app/api/arena/battle/route.ts
+++ b/web/app/api/arena/battle/route.ts
@@ -2,7 +2,6 @@ export const runtime = "nodejs";
 export const maxDuration = 60;
 
 import { isArenaDomain } from "@/lib/arena/domains";
-import { arenaAccessOk } from "@/lib/arena/guard";
 import { arenaRunnerFetch } from "@/lib/arena/runner";
 import type { BlindBattle } from "@/lib/arena/types";
 
@@ -15,7 +14,6 @@ interface BattleOut {
 }
 
 export async function POST(req: Request) {
-  if (!(await arenaAccessOk())) return new Response(null, { status: 404 });
   let body: { text?: string; domain?: string };
   try {
     body = await req.json();

--- a/web/app/api/arena/example-prompt/route.ts
+++ b/web/app/api/arena/example-prompt/route.ts
@@ -1,6 +1,5 @@
 export const runtime = "nodejs";
 
-import { arenaAccessOk } from "@/lib/arena/guard";
 import { arenaRunnerFetch } from "@/lib/arena/runner";
 import type { ExamplePrompt } from "@/lib/arena/types";
 
@@ -10,7 +9,6 @@ interface ExamplePromptOut {
 }
 
 export async function GET(req: Request) {
-  if (!(await arenaAccessOk())) return new Response(null, { status: 404 });
   let res: Response;
   try {
     res = await arenaRunnerFetch(

--- a/web/app/api/arena/leaderboard/route.ts
+++ b/web/app/api/arena/leaderboard/route.ts
@@ -1,10 +1,8 @@
 export const runtime = "nodejs";
 
-import { arenaAccessOk } from "@/lib/arena/guard";
 import { arenaRunnerFetch } from "@/lib/arena/runner";
 
 export async function GET(req: Request) {
-  if (!(await arenaAccessOk())) return new Response(null, { status: 404 });
   const { searchParams } = new URL(req.url);
   const qs = new URLSearchParams({
     metric: searchParams.get("metric") ?? "naturalness",

--- a/web/app/api/arena/vote/route.ts
+++ b/web/app/api/arena/vote/route.ts
@@ -1,6 +1,5 @@
 export const runtime = "nodejs";
 
-import { arenaAccessOk } from "@/lib/arena/guard";
 import { arenaRunnerFetch } from "@/lib/arena/runner";
 import type { VoteResult } from "@/lib/arena/types";
 
@@ -10,7 +9,6 @@ interface VoteOut {
 }
 
 export async function POST(req: Request) {
-  if (!(await arenaAccessOk())) return new Response(null, { status: 404 });
   let body: { battleId?: string; outcome?: string; voterId?: string };
   try {
     body = await req.json();

--- a/web/app/arena/components/AudioPlayer.tsx
+++ b/web/app/arena/components/AudioPlayer.tsx
@@ -84,7 +84,7 @@ export function AudioPlayer({ src, label, isActive, onActivate, autoPlay, onEnde
         onClick={toggle}
         disabled={disabled}
         aria-label={disabled ? `${label} — generate to enable` : `${playing ? "Pause" : "Play"} ${label}`}
-        className="shrink-0 rounded-full border border-border-primary bg-surface-primary px-4 py-2 font-mono text-sm text-text-primary hover:bg-hover-bg disabled:cursor-not-allowed disabled:opacity-40"
+        className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full border border-border-primary bg-surface-primary font-mono text-sm text-text-primary hover:bg-hover-bg disabled:cursor-not-allowed disabled:opacity-40"
       >
         {playing ? "❚❚" : "▶"}
       </button>

--- a/web/app/arena/leaderboard/arena-leaderboard.tsx
+++ b/web/app/arena/leaderboard/arena-leaderboard.tsx
@@ -51,7 +51,7 @@ export function ArenaLeaderboardPage() {
                   <th className="py-2 pr-4 font-medium">#</th>
                   <th className="py-2 pr-4 font-medium">Model</th>
                   <th className="py-2 pr-4 font-medium">Provider</th>
-                  <th className="py-2 pr-4 text-right font-medium">Elo</th>
+                  <th className="whitespace-nowrap py-2 pr-4 text-right font-medium">Elo</th>
                 </tr>
               </thead>
               <tbody>
@@ -71,7 +71,7 @@ export function ArenaLeaderboardPage() {
                       <td className="py-2.5 pr-4 text-text-secondary">
                         {normalizeTTSProviderName(entry.provider)}
                       </td>
-                      <td className="py-2.5 pr-4 text-right tabular-nums">
+                      <td className="whitespace-nowrap py-2.5 pr-4 text-right tabular-nums">
                         {eloLabel(entry)}
                       </td>
                     </tr>

--- a/web/app/arena/page.tsx
+++ b/web/app/arena/page.tsx
@@ -1,6 +1,8 @@
 "use client";
 
+import Link from "next/link";
 import { useEffect, useRef, useState } from "react";
+import DashboardHeader from "@/components/layout/DashboardHeader";
 import { ARENA_DOMAINS, type ArenaDomain } from "@/lib/arena/domains";
 import { getBattleSource } from "@/lib/arena/source";
 import type {
@@ -14,6 +16,11 @@ import { AudioPlayer } from "./components/AudioPlayer";
 
 const MIN_CHARS = 3;
 const MAX_CHARS = 500;
+
+// Post-vote only: standings shown before a vote anchor the judgment, and votes are what
+// tightens the provisional CIs. Flip to false to pull the link entirely — /arena/leaderboard
+// stays reachable by URL either way.
+const SHOW_LEADERBOARD_LINK = true;
 
 export default function ArenaPage() {
   const source = getBattleSource();
@@ -160,157 +167,158 @@ export default function ArenaPage() {
   const canVote = battle !== null && !recorded && !dirty;
 
   return (
-    <main className="min-h-screen bg-surface-primary px-6 pb-24 pt-32 text-text-primary">
-      <div className="mx-auto flex max-w-[760px] flex-col gap-8">
-        <h1 className="text-center font-sans text-2xl">Which voice sounds more natural?</h1>
+    <>
+      <DashboardHeader />
+      <main className="min-h-screen bg-surface-primary px-6 pb-24 pt-32 text-text-primary">
+        <div className="mx-auto flex max-w-[760px] flex-col gap-8">
+          <h1 className="text-center font-sans text-2xl">Which voice sounds more natural?</h1>
 
-        <section className="flex flex-col gap-3">
-          <select
-            value={domain}
-            onChange={(e) => setDomain(e.target.value as ArenaDomain | "")}
-            aria-label="Domain"
-            className="w-full appearance-none rounded-xl border border-border-primary bg-surface-elevated px-4 py-3 font-sans text-sm outline-none focus:border-selected-border"
-          >
-            <option value="" disabled>
-              Select a domain *
-            </option>
-            {ARENA_DOMAINS.map((d) => (
-              <option key={d.value} value={d.value}>
-                {d.label}
-              </option>
-            ))}
-          </select>
-          <textarea
-            value={text}
-            maxLength={MAX_CHARS}
-            onChange={(e) => setText(e.target.value)}
-            placeholder="Describe a scenario or write text to synthesize…"
-            rows={4}
-            className="w-full resize-none rounded-xl border border-border-primary bg-surface-elevated p-4 font-sans text-base leading-relaxed outline-none focus:border-selected-border"
-          />
-          <div className="flex items-center justify-between text-sm text-text-tertiary">
-            <button
-              type="button"
-              onClick={() => void applyExample()}
-              className="font-sans underline underline-offset-2 hover:text-text-secondary"
+          <section className="flex flex-col gap-3">
+            <select
+              value={domain}
+              onChange={(e) => setDomain(e.target.value as ArenaDomain | "")}
+              aria-label="Domain"
+              className="w-full appearance-none rounded-xl border border-border-primary bg-surface-elevated px-4 py-3 font-sans text-sm outline-none focus:border-selected-border"
             >
-              Use an example
-            </button>
-            <span className="font-mono">
-              {text.length}/{MAX_CHARS}
-            </span>
-          </div>
-        </section>
-
-        <div
-          key={battle?.battleId ?? "pending"}
-          className="grid grid-cols-[1fr_44px_1fr] items-stretch"
-        >
-          <BattleCard
-            side="a"
-            blindTitle="Model A"
-            revealed={recorded && reveal ? reveal.a : null}
-            picked={recorded ? vote : null}
-            isActive={active === "a"}
-            src={battle?.audioA ?? null}
-            onActivate={() => setActive("a")}
-            autoPlay={autoPlay}
-            onEnded={() => chainEnded("a")}
-          />
-          <div className="flex items-center justify-center font-mono text-xs text-text-tertiary">
-            VS
-          </div>
-          <BattleCard
-            side="b"
-            blindTitle="Model B"
-            revealed={recorded && reveal ? reveal.b : null}
-            picked={recorded ? vote : null}
-            isActive={active === "b"}
-            src={battle?.audioB ?? null}
-            onActivate={() => setActive("b")}
-            autoPlay={autoPlay}
-            onEnded={() => chainEnded("b")}
-          />
-        </div>
-
-        <section className="flex min-h-[52px] flex-col gap-3" aria-live="polite">
-          {recorded && loading ? (
-            <div className="flex items-center justify-center gap-3">
-              <p className="font-mono text-sm text-text-secondary">
-                ✓ Recorded — loading the next battle…
-              </p>
+              <option value="" disabled>
+                Select a domain *
+              </option>
+              {ARENA_DOMAINS.map((d) => (
+                <option key={d.value} value={d.value}>
+                  {d.label}
+                </option>
+              ))}
+            </select>
+            <textarea
+              value={text}
+              maxLength={MAX_CHARS}
+              onChange={(e) => setText(e.target.value)}
+              placeholder="Describe a scenario or write text to synthesize…"
+              rows={4}
+              className="w-full resize-none rounded-xl border border-border-primary bg-surface-elevated p-4 font-sans text-base leading-relaxed outline-none focus:border-selected-border"
+            />
+            <div className="flex items-center justify-between text-sm text-text-tertiary">
               <button
                 type="button"
-                onClick={stopAutoAdvance}
-                className="rounded-full border border-border-primary px-4 py-1.5 font-mono text-xs text-text-secondary hover:bg-hover-bg"
+                onClick={() => void applyExample()}
+                className="flex min-h-11 items-center font-sans underline underline-offset-2 hover:text-text-secondary"
               >
-                Stop
+                Use an example
               </button>
+              <span className="font-mono">
+                {text.length}/{MAX_CHARS}
+              </span>
             </div>
-          ) : canVote && !loading ? (
-            <>
-              <div className="grid grid-cols-[1fr_0.7fr_1fr] gap-3">
-                <VoteButton label="Model A" onClick={() => castVote("A_WIN")} disabled={submitting} />
-                <VoteButton label="Tie" onClick={() => castVote("TIE")} disabled={submitting} />
-                <VoteButton label="Model B" onClick={() => castVote("B_WIN")} disabled={submitting} />
-              </div>
-              <label className="flex cursor-pointer items-center gap-2 self-center font-mono text-xs text-text-secondary">
-                <input
-                  type="checkbox"
-                  checked={autoAdvance}
-                  onChange={() => persistAutoAdvance(!autoAdvance)}
-                />
-                Auto-advance
-              </label>
-            </>
-          ) : recorded && !dirty && !loading ? (
-            <div className="flex flex-col items-center gap-4">
-              <p className="font-mono text-sm text-text-secondary">✓ Battle recorded</p>
-              <div className="flex flex-wrap items-center justify-center gap-3">
+          </section>
+
+          <div
+            key={battle?.battleId ?? "pending"}
+            className="grid grid-cols-1 gap-2 sm:grid-cols-[1fr_44px_1fr] sm:gap-0 sm:items-stretch"
+          >
+            <BattleCard
+              side="a"
+              blindTitle="Model A"
+              revealed={recorded && reveal ? reveal.a : null}
+              picked={recorded ? vote : null}
+              isActive={active === "a"}
+              src={battle?.audioA ?? null}
+              onActivate={() => setActive("a")}
+              autoPlay={autoPlay}
+              onEnded={() => chainEnded("a")}
+            />
+            <div className="flex items-center justify-center font-mono text-xs text-text-tertiary">
+              VS
+            </div>
+            <BattleCard
+              side="b"
+              blindTitle="Model B"
+              revealed={recorded && reveal ? reveal.b : null}
+              picked={recorded ? vote : null}
+              isActive={active === "b"}
+              src={battle?.audioB ?? null}
+              onActivate={() => setActive("b")}
+              autoPlay={autoPlay}
+              onEnded={() => chainEnded("b")}
+            />
+          </div>
+
+          <section className="flex min-h-[52px] flex-col gap-3" aria-live="polite">
+            {recorded && loading ? (
+              <div className="flex items-center justify-center gap-3">
+                <p className="font-mono text-sm text-text-secondary">
+                  ✓ Recorded — loading the next battle…
+                </p>
                 <button
-                  ref={nextBattleRef}
                   type="button"
-                  onClick={() => void quickBattle()}
-                  className="rounded-full bg-surface-toggle-active px-6 py-2.5 font-mono text-sm text-text-on-toggle-active"
+                  onClick={stopAutoAdvance}
+                  className="min-h-11 rounded-full border border-border-primary px-4 font-mono text-xs text-text-secondary hover:bg-hover-bg"
                 >
-                  Another battle
+                  Stop
                 </button>
-                <label className="flex cursor-pointer items-center gap-2 font-mono text-xs text-text-secondary">
+              </div>
+            ) : canVote && !loading ? (
+              <>
+                <div className="grid grid-cols-[1fr_0.7fr_1fr] gap-3">
+                  <VoteButton label="Model A" onClick={() => castVote("A_WIN")} disabled={submitting} />
+                  <VoteButton label="Tie" onClick={() => castVote("TIE")} disabled={submitting} />
+                  <VoteButton label="Model B" onClick={() => castVote("B_WIN")} disabled={submitting} />
+                </div>
+                <label className="flex min-h-11 cursor-pointer items-center gap-2 self-center font-mono text-xs text-text-secondary">
                   <input
                     type="checkbox"
+                    className="h-5 w-5"
                     checked={autoAdvance}
                     onChange={() => persistAutoAdvance(!autoAdvance)}
                   />
                   Auto-advance
                 </label>
-                <a
-                  href="/arena/leaderboard"
-                  className="rounded-full border border-border-primary px-6 py-2.5 font-mono text-sm text-text-secondary hover:bg-hover-bg"
-                >
-                  View leaderboard
-                </a>
-                <a
-                  href="/arena/admin"
-                  className="rounded-full border border-border-primary px-6 py-2.5 font-mono text-sm text-text-secondary hover:bg-hover-bg"
-                >
-                  Monitoring
-                </a>
+              </>
+            ) : recorded && !dirty && !loading ? (
+              <div className="flex flex-col items-center gap-4">
+                <p className="font-mono text-sm text-text-secondary">✓ Battle recorded</p>
+                <div className="flex flex-wrap items-center justify-center gap-3">
+                  <button
+                    ref={nextBattleRef}
+                    type="button"
+                    onClick={() => void quickBattle()}
+                    className="min-h-11 rounded-full bg-surface-toggle-active px-6 font-mono text-sm text-text-on-toggle-active"
+                  >
+                    Another battle
+                  </button>
+                  <label className="flex min-h-11 cursor-pointer items-center gap-2 font-mono text-xs text-text-secondary">
+                    <input
+                      type="checkbox"
+                      className="h-5 w-5"
+                      checked={autoAdvance}
+                      onChange={() => persistAutoAdvance(!autoAdvance)}
+                    />
+                    Auto-advance
+                  </label>
+                  {SHOW_LEADERBOARD_LINK && (
+                    <Link
+                      href="/arena/leaderboard"
+                      className="flex min-h-11 items-center rounded-full border border-border-primary px-6 font-mono text-sm text-text-secondary hover:bg-hover-bg"
+                    >
+                      View leaderboard
+                    </Link>
+                  )}
+                </div>
               </div>
-            </div>
-          ) : (
-            <button
-              type="button"
-              onClick={() => void generate(text, domain)}
-              disabled={trimmed.length < MIN_CHARS || !domain || loading}
-              className="self-start rounded-full bg-surface-toggle-active px-6 py-2.5 font-mono text-sm text-text-on-toggle-active disabled:opacity-40"
-            >
-              {loading ? "Generating…" : "Generate speech"}
-            </button>
-          )}
-          {error && <p className="text-center font-sans text-sm text-accent-rust">{error}</p>}
-        </section>
-      </div>
-    </main>
+            ) : (
+              <button
+                type="button"
+                onClick={() => void generate(text, domain)}
+                disabled={trimmed.length < MIN_CHARS || !domain || loading}
+                className="min-h-11 self-start rounded-full bg-surface-toggle-active px-6 font-mono text-sm text-text-on-toggle-active disabled:opacity-40"
+              >
+                {loading ? "Generating…" : "Generate speech"}
+              </button>
+            )}
+            {error && <p className="text-center font-sans text-sm text-accent-rust">{error}</p>}
+          </section>
+        </div>
+      </main>
+    </>
   );
 }
 
@@ -416,7 +424,7 @@ function VoteButton({
       type="button"
       onClick={onClick}
       disabled={disabled}
-      className="rounded-xl border border-border-primary bg-surface-elevated py-3 font-mono text-sm hover:border-selected-border hover:bg-selected-bg disabled:opacity-40"
+      className="min-h-11 rounded-xl border border-border-primary bg-surface-elevated py-3 font-mono text-sm hover:border-selected-border hover:bg-selected-bg disabled:opacity-40"
     >
       {label}
     </button>

--- a/web/components/dashboard/DashboardFooter.tsx
+++ b/web/components/dashboard/DashboardFooter.tsx
@@ -12,6 +12,7 @@ const FOOTER_LINKS = [
   { href: "/overview", label: "Overview" },
   { href: "/tts", label: "Text-to-Speech" },
   { href: "/stt", label: "Speech-to-Text" },
+  { href: "/arena", label: "Arena" },
   { href: "/playground", label: "Playground" }
 ];
 

--- a/web/components/layout/DashboardHeader.tsx
+++ b/web/components/layout/DashboardHeader.tsx
@@ -16,6 +16,7 @@ const SECTIONS = [
   { href: "/overview", label: "Overview", short: "Overview" },
   { href: "/tts", label: "Text-to-Speech", short: "TTS" },
   { href: "/stt", label: "Speech-to-Text", short: "STT" },
+  { href: "/arena", label: "Arena", short: "Arena" },
   { href: "/playground", label: "Playground", short: "Playground" }
 ];
 
@@ -77,7 +78,8 @@ const DashboardHeader: React.FC = () => {
           className="absolute left-1/2 top-0 hidden h-full -translate-x-1/2 items-center gap-1 lg:flex"
         >
           {SECTIONS.map((section) => {
-            const active = pathname === section.href;
+            const active =
+              pathname === section.href || pathname.startsWith(`${section.href}/`);
             return (
               <Link
                 key={section.href}
@@ -150,7 +152,8 @@ const DashboardHeader: React.FC = () => {
         }`}
       >
         {SECTIONS.map((section) => {
-          const active = pathname === section.href;
+          const active =
+            pathname === section.href || pathname.startsWith(`${section.href}/`);
           return (
             <Link
               key={section.href}

--- a/web/middleware.ts
+++ b/web/middleware.ts
@@ -75,9 +75,34 @@ function playgroundSession(req: NextRequest): NextResponse {
   return response;
 }
 
+// Exactly two arena surfaces are public — the voting page and the leaderboard — plus
+// the endpoints they call. The arena needs traffic to tighten its provisional
+// confidence intervals, and the runner caps every arena endpoint at 60/minute.
+//
+// This is an allowlist on purpose: anything else under /arena or /api/arena stays
+// behind the access token, so a route added later is gated by default rather than
+// published by omission. /arena/admin and /api/arena/admin/* are the current such
+// routes — convergence and Elo pairing internals, with no auth of their own.
+const PUBLIC_ARENA_PAGES = new Set(["/arena", "/arena/leaderboard"]);
+const PUBLIC_ARENA_API_PREFIXES = [
+  "/api/arena/battle", // create a battle, and /battle/<id>/reveal after the vote
+  "/api/arena/vote",
+  "/api/arena/example-prompt",
+  "/api/arena/leaderboard",
+];
+
+function isPublicArenaPath(pathname: string): boolean {
+  if (PUBLIC_ARENA_PAGES.has(pathname)) return true;
+  return PUBLIC_ARENA_API_PREFIXES.some(
+    (prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`),
+  );
+}
+
 export function middleware(req: NextRequest): NextResponse {
-  if (req.nextUrl.pathname.startsWith("/api/arena")) return arenaGate(req);
-  if (req.nextUrl.pathname.startsWith("/arena")) return arenaGate(req);
+  const { pathname } = req.nextUrl;
+  if (pathname.startsWith("/arena") || pathname.startsWith("/api/arena")) {
+    return isPublicArenaPath(pathname) ? NextResponse.next() : arenaGate(req);
+  }
   return playgroundSession(req);
 }
 


### PR DESCRIPTION
> **Scope changed after review.** Greptile's P1 was correct: the nav entry pointed at a route that 404'd for the public. This now opens the arena — what the pre-release access token was a stopgap for — but **only the voting page and leaderboard**, via an explicit allowlist. ⚠️ **Touches auth in `middleware.ts` and 5 route handlers; please review that closely.**
<img width="1023" height="775" alt="Screenshot 2026-07-27 at 2 30 14 PM" src="https://github.com/user-attachments/assets/2cf09635-d91a-474d-b9a6-bb2267a4bebd" />

## Problem

1. `/arena` was the only route in the app that never rendered `DashboardHeader` — `/arena/leaderboard` and `/arena/admin` both do. Landing there left no way out but the browser back button.
2. The arena was **not publicly reachable**, despite appearing to be. Production, real browser UA, no cookies:

| URL | Status |
|---|---|
| `/overview` | 200, 104,250 bytes |
| `/arena` | **404, 0 bytes** |
| `/arena/leaderboard` | **404, 0 bytes** |

It looks live to anyone who has opened an `?access=` link: the cookie lasts 30 days and refreshes silently, so it's invisible in your own browser.

## Opening it — two gates, and an allowlist

`arenaAccessOk()` is a **second, independent** gate inside each route handler, separate from the middleware matcher. Relaxing middleware alone produced a page that loaded (200) but whose every API call 404'd. Both gates no-op when `NODE_ENV !== "production"`, so this was invisible in dev — caught only by running a real production build.

Opened via **allowlist, not denylist**, so a route added later is gated by default rather than published by omission:

```
public pages: /arena, /arena/leaderboard
public APIs:  /api/arena/battle (+ /battle/<id>/reveal), /vote,
              /example-prompt, /leaderboard
```

Everything else under `/arena` or `/api/arena` still hits `arenaGate`. `/arena/admin` and `/api/arena/admin/*` — convergence and Elo pairing internals, no auth of their own — keep **both** the middleware gate and their route-level check.

**Model visibility is unaffected by any of this.** The arena roster is filtered in the runner: [`active_tts_models()`](../blob/main/runner/src/coval_bench/arena/pairing.py) admits only `ACTIVE` + `arena_enabled` TTS models, and boards strip `RETIRED`/`PENDING`/`EARLY_ACCESS`. No early-access model was ever gated by the web cookie.

### Verified under a production build (throwaway tokens, cookieless)

| URL | Status | |
|---|---|---|
| `/arena` | 200 | public |
| `/arena/leaderboard` | 200 | public |
| `/api/arena/leaderboard` | 502 | handler reached; 502 only because the test env had no `ARENA_API_URL` |
| `/api/arena/example-prompt` | 502 | handler reached |
| `/api/arena/battle/abc/reveal` | 400 | handler reached, validated input |
| `POST /api/arena/vote` | 400 | handler reached, validated input |
| `/arena/admin` | 404 | gated |
| `/api/arena/admin/convergence` | 404 | gated |
| `/api/arena/admin/cooccurrence` | 404 | gated |
| `/arena/<unknown>` | 404, **0 bytes** | gate answered → fail-closed |
| `/api/arena/<unknown>` | 404, **0 bytes** | gate answered → fail-closed |
| `/definitely-not-a-route` | 404, **9,842 bytes** | Next's 404 page, for contrast |
| `/arena/admin?access=<token>` | 307 + cookie | unlock works |
| `/arena/admin?access=wrong` | 404 | rejects |
| `/arena/admin` + cookie | 200 | admin reachable |

The 0-byte vs 9,842-byte contrast is the proof that unknown arena paths are *gated*, not merely absent.

## Other changes

**Dead end.** `/arena` renders `DashboardHeader`. Active matching covers subroutes so Arena stays lit on `/arena/leaderboard`. `DashboardFooter` mirrors the top nav per its own comment.

**Admin link** removed from the post-vote row.

**Leaderboard link.** Post-vote only, behind `SHOW_LEADERBOARD_LINK` — standings shown before a vote anchor the judgment. `<a>` → `<Link>`; it was doing a full page reload.

## Mobile

Touch targets measured off the live DOM, not eyeballed. Before: play button 42×38, "Use an example" 103×20, Generate 174×40, Stop ~30px. All now ≥44px; the auto-advance checkbox keeps its 20px box inside a 44px label, the real tap target.

- **A/B cards** sat side by side at ~141px each on a 375px screen, squeezing the progress bar to a stub. They stack below `sm`; side-by-side preserved from `sm` up.
- **Leaderboard Elo column** wrapped at phone width — `1720 ± 107` broke across two lines, inflating rows 41px → 61px. Pinned to `whitespace-nowrap`; table measures 343px inside a 343px container at 375px, no horizontal scroll.

Verified with real prod rows (27 entries, longest `Qwen3 TTS Flash Realtime` / Alibaba / `1245 ± 107`). No page-level horizontal overflow on `/arena`, `/arena/leaderboard`, or `/arena/admin` at 375px.

## Verification

Full flow against `MockBattleSource`: example → generate → play → vote → reveal → another battle, at 375px and 1440px. Leaderboard link counted in the DOM: pre-vote 0, awaiting-vote 0, post-vote 1.

`tsc --noEmit` clean, `eslint . --max-warnings 0` clean, 81/81 tests, production build succeeds.

## Notes for review

- Most of the `page.tsx` diff is the indent shift from wrapping the return in a fragment.
- The battle flow was verified against the mock; the live API path (`NEXT_PUBLIC_ARENA_SOURCE=api`) is unexercised here.
- Worth confirming before merge: opening the vote endpoint means unauthenticated writes to the Elo board, bounded only by the runner's 60/minute per-IP limit. Per-voter abuse controls beyond that should be a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Opens the Arena voting and leaderboard surfaces to public visitors while retaining access-token protection for admin and unknown Arena routes.
- Adds Arena to the shared header and footer navigation and renders the header on the voting page.
- Publicly allowlists the voting flow’s pages and API endpoints while preserving middleware and route-level guards for admin endpoints.
- Improves mobile Arena controls, battle-card layout, and leaderboard rating rendering.
- Shows a client-side leaderboard link only after a vote and removes the post-vote admin link.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

The previously reported navigation failure is fixed: cookieless visitors can reach both public Arena pages and every API endpoint required by the voting and leaderboard flows, while admin endpoints remain gated.

<sub>Reviews (5): Last reviewed commit: ["Add Arena to the nav and open voting + l..."](https://github.com/coval-ai/benchmarks/commit/0c42784ff6c3cdf82a128afad2807f2a54f08597) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47721558)</sub>

**Context used:**

- Knowledge Base — [Web Arena (voting UI, admin, leaderboard)](https://app.greptile.com/coval/-/custom-context/knowledge-base/coval-ai/benchmarks/-/docs/web-arena.md)
- Knowledge Base — [Web Dashboard (STT/TTS/S2S + Overview)](https://app.greptile.com/coval/-/custom-context/knowledge-base/coval-ai/benchmarks/-/docs/web-dashboard.md)

<!-- /greptile_comment -->