### PR TITLE
Keep only spoken turns in S2S conversation samples

### DIFF
--- a/runner/src/coval_bench/s2s/samples.py
+++ b/runner/src/coval_bench/s2s/samples.py
@@ -69,6 +69,9 @@ class SampleRun:
     agent_id: str = ""
 
 
+_SPOKEN_ROLES = frozenset({"user", "assistant"})
+
+
 def _offset_seconds(value: object) -> float | None:
     """A Coval transcript offset as float seconds, or ``None`` when absent/non-numeric."""
     if isinstance(value, bool) or not isinstance(value, (int, float)):
@@ -77,19 +80,23 @@ def _offset_seconds(value: object) -> float | None:
 
 
 def _conversation_turns(sim: dict[str, Any]) -> list[dict[str, Any]]:
-    """Full ordered conversation as ``{index, role, content, start_offset, end_offset}`` turns.
+    """Spoken conversation as ``{index, role, content, start_offset, end_offset}`` turns.
 
-    Non-string content is skipped so a malformed message can't poison the
-    manifest; an empty list means the transcript couldn't be resolved and the
-    sample is treated as incomplete. ``start_offset``/``end_offset`` are
-    full-recording positions in seconds (``None`` when Coval omits them) that
-    the dashboard uses to sync the playhead to each turn.
+    Only ``user`` (the persona) and ``assistant`` (the agent) messages are
+    spoken. Coval's transcript also carries the persona's tool records — the
+    ``end_conversation`` call arrives as ``role="tool"`` with raw JSON content —
+    and those are dropped rather than rendered as a caller turn. Non-string
+    content is skipped so a malformed message can't poison the manifest; an
+    empty list means the transcript couldn't be resolved and the sample is
+    treated as incomplete. ``start_offset``/``end_offset`` are full-recording
+    positions in seconds (``None`` when Coval omits them) that the dashboard
+    uses to sync the playhead to each turn.
     """
     turns: list[dict[str, Any]] = []
     for message in cast("list[dict[str, Any]]", sim.get("transcript") or []):
         role = message.get("role")
         content = message.get("content")
-        if isinstance(role, str) and isinstance(content, str):
+        if role in _SPOKEN_ROLES and isinstance(content, str):
             turns.append(
                 {
                     "index": len(turns),

--- a/runner/tests/unit/test_s2s_samples.py
+++ b/runner/tests/unit/test_s2s_samples.py
@@ -84,6 +84,8 @@ def _fake_client(
             else [
                 {"role": "user", "content": "hi there", "start_offset": 1.5, "end_offset": 2.25},
                 {"role": "assistant", "content": "how can i help", "start_offset": 3.0},
+                # The persona's end_conversation tool record, as Coval returns it.
+                {"role": "tool", "content": '{"function": "end_conversation"}'},
             ]
         )
         return httpx.Response(200, json={"simulation": {"transcript": turns}})

--- a/web/lib/audioSamples/createSampleFeed.test.ts
+++ b/web/lib/audioSamples/createSampleFeed.test.ts
@@ -132,6 +132,23 @@ describe("parseS2SManifest", () => {
     expect(m.input_audio_url).toBe("u");
   });
 
+  it("drops non-spoken turns from an already-published manifest", () => {
+    const m = parseS2SManifest({
+      ...validManifest,
+      recordings: [
+        {
+          ...validManifest.recordings[0]!,
+          turns: [
+            { index: 0, role: "user", content: "hi" },
+            { index: 1, role: "assistant", content: "hello" },
+            { index: 2, role: "tool", content: '{"function": "end_conversation"}' },
+          ],
+        },
+      ],
+    });
+    expect(m.recordings[0]!.turns?.map((t) => t.role)).toEqual(["user", "assistant"]);
+  });
+
   it.each([
     ["null", null],
     ["missing recordings", { bucket_at: "x", test_case_id: "y", transcript: null, input_audio_url: null }],

--- a/web/lib/audioSamples/s2sFeed.ts
+++ b/web/lib/audioSamples/s2sFeed.ts
@@ -63,23 +63,31 @@ function asOptionalString(v: unknown, field: string): string | undefined {
   return asString(v, field);
 }
 
+// Manifests written before the sampler filtered them carry the persona's
+// `end_conversation` tool record as a `role: "tool"` turn whose content is raw
+// JSON. Drop anything that isn't spoken dialogue so it can't render as a caller
+// turn — those manifests stay readable for their 30-day retention.
+const SPOKEN_ROLES: ReadonlySet<string> = new Set(["user", "assistant"]);
+
 function parseTurns(v: unknown, field: string): S2STurn[] | undefined {
   if (v === undefined) return undefined;
   if (!Array.isArray(v)) throw new Error(`${field} must be an array`);
-  return v.map((t, i): S2STurn => {
-    if (typeof t !== "object" || t === null) {
-      throw new Error(`${field}[${i}] must be an object`);
-    }
-    const turn = t as Record<string, unknown>;
-    if (typeof turn.index !== "number") {
-      throw new Error(`${field}[${i}].index must be a number`);
-    }
-    return {
-      index: turn.index,
-      role: asString(turn.role, `${field}[${i}].role`),
-      content: asString(turn.content, `${field}[${i}].content`),
-    };
-  });
+  return v
+    .map((t, i): S2STurn => {
+      if (typeof t !== "object" || t === null) {
+        throw new Error(`${field}[${i}] must be an object`);
+      }
+      const turn = t as Record<string, unknown>;
+      if (typeof turn.index !== "number") {
+        throw new Error(`${field}[${i}].index must be a number`);
+      }
+      return {
+        index: turn.index,
+        role: asString(turn.role, `${field}[${i}].role`),
+        content: asString(turn.content, `${field}[${i}].content`),
+      };
+    })
+    .filter((t) => SPOKEN_ROLES.has(t.role));
 }
 
 // Validate the full manifest shape before the UI touches it — a shallow object


### PR DESCRIPTION
Coval's transcript includes the persona's end_conversation tool record, which the samples card was rendering as a caller turn full of raw JSON. The dashboard drops it too, so manifests already published stay clean for the rest of their retention.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR keeps S2S sample transcripts limited to spoken dialogue.
- Filters generated runner manifests to `user` and `assistant` turns.
- Filters legacy published manifests when parsed by the dashboard.
- Adds runner and web regression coverage for Coval’s terminal `tool` record.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable defects identified.

Both manifest production and legacy-manifest parsing consistently retain only the established spoken roles, and existing consumers do not depend on removed tool turns or contiguous legacy turn indices.

<sub>Reviews (1): Last reviewed commit: ["Keep only spoken turns in S2S conversati..."](https://github.com/coval-ai/benchmarks/commit/b6ad064cd8b6c666e28df5963023b7ad8b56bd1f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47725452)</sub>

**Context used:**

- Knowledge Base — [Runner Orchestration](https://app.greptile.com/coval/-/custom-context/knowledge-base/coval-ai/benchmarks/-/docs/runner-orchestration.md)

<!-- /greptile_comment -->