### PR TITLE
Show only conversation samples on the S2S card

### DIFF
--- a/web/app/s2s/components/SampleOutputs.tsx
+++ b/web/app/s2s/components/SampleOutputs.tsx
@@ -76,9 +76,8 @@ export function SampleOutputs({
   // conversation. All items in a manifest share a shape, so a single flag holds.
   const conversation = items.some((i) => (i.turns?.length ?? 0) > 0);
   const viewportRef = useRef<HTMLDivElement>(null);
-  const paneRefs = useRef<(HTMLDivElement | null)[]>([]);
 
-  const { audioRef, activeIndex, isPlaying, toggle, playFrom, handleEnded } = useSequencedPlayback(
+  const { audioRef, activeIndex, isPlaying, toggle, playFrom, stop } = useSequencedPlayback(
     tracks,
     (track) => onPlay?.(track.key),
     coordinator
@@ -96,16 +95,6 @@ export function SampleOutputs({
     playFrom(idx);
   }, [playRequest, items, playFrom]);
 
-  // Auto-scroll the active pane to center while a sequence is playing.
-  useEffect(() => {
-    if (!isPlaying) return;
-    const vp = viewportRef.current;
-    const pane = paneRefs.current[activeIndex];
-    if (!vp || !pane) return;
-    const target = pane.offsetLeft - (vp.clientWidth - pane.clientWidth) / 2;
-    vp.scrollTo({ left: Math.max(0, target), behavior: "smooth" });
-  }, [activeIndex, isPlaying]);
-
   const hints = useScrollHints(viewportRef, `${items.length}:${items.map((i) => i.provider).join(",")}`);
 
   const step = (dir: -1 | 1) => {
@@ -117,20 +106,9 @@ export function SampleOutputs({
 
   return (
     <div className="space-y-2">
-      <div className="flex items-center justify-between">
-        <p className="font-mono text-[10px] font-medium uppercase tracking-[0.28em] text-text-tertiary">
-          {conversation ? "Conversation" : "Responses"}
-        </p>
-        <button
-          type="button"
-          onClick={toggle}
-          className="flex items-center gap-1.5 rounded-full bg-text-primary px-3 py-1 text-[11px] font-medium text-surface-primary transition-opacity hover:opacity-90"
-          aria-label={isPlaying ? "Pause" : "Play all responses"}
-        >
-          {isPlaying ? <Pause className="size-3" /> : <Play className="size-3" />}
-          <span>{isPlaying ? "Pause" : "Play all"}</span>
-        </button>
-      </div>
+      <p className="font-mono text-[10px] font-medium uppercase tracking-[0.28em] text-text-tertiary">
+        {conversation ? "Conversation" : "Responses"}
+      </p>
 
       <div className="relative">
         {hints.left ? (
@@ -168,9 +146,6 @@ export function SampleOutputs({
             return (
               <div
                 key={item.provider}
-                ref={(el) => {
-                  paneRefs.current[i] = el;
-                }}
                 role="listitem"
                 className={`flex shrink-0 snap-start flex-col gap-2 rounded-xl border p-3 transition-colors ${
                   conversation ? "w-[300px] min-w-[300px]" : "w-[180px] min-w-[180px]"
@@ -212,7 +187,7 @@ export function SampleOutputs({
         </div>
       </div>
 
-      <audio ref={audioRef} onEnded={handleEnded} hidden />
+      <audio ref={audioRef} onEnded={stop} hidden />
     </div>
   );
 }

--- a/web/app/s2s/components/SamplesCard.tsx
+++ b/web/app/s2s/components/SamplesCard.tsx
@@ -11,14 +11,7 @@ import { isMultiTurn, s2sSampleFeed, visibleRecordings } from "@/lib/audioSample
 import { capturePostHogEvent } from "@/lib/posthog/client";
 import { POSTHOG_EVENTS } from "@/lib/posthog/events";
 import { usePlaybackCoordinator } from "@/hooks/useSequencedPlayback";
-import { SampleInput } from "./SampleInput";
 import { SampleOutputs, type SampleOutputItem } from "./SampleOutputs";
-
-function tickLabel(tick: string): string {
-  const d = new Date(tick);
-  if (Number.isNaN(d.getTime())) return tick;
-  return d.toLocaleDateString(undefined, { month: "short", day: "numeric" });
-}
 
 // Which failure case fired, for the console — network/http/parse vs an
 // unclassified error, with the status when we have one.
@@ -43,7 +36,7 @@ export function SamplesCard() {
   const effectiveTick = s2sPlayRequest?.tick ?? latestTick;
   const manifestQuery = s2sSampleFeed.useManifestQuery(effectiveTick);
   const manifest = manifestQuery.data ?? null;
-  const multiTurn = manifest ? isMultiTurn(manifest) : false;
+  const hasNoConversation = manifest != null && !isMultiTurn(manifest);
 
   const fetchError = manifestQuery.isError || indexQuery.isError;
   // Keep the failure cause internal (dev console only); public visitors just see
@@ -55,14 +48,14 @@ export function SamplesCard() {
   }, [manifestQuery.error, indexQuery.error]);
 
   const items = useMemo<SampleOutputItem[]>(() => {
-    if (!manifest) return [];
+    if (!manifest || hasNoConversation) return [];
     return visibleRecordings(manifest, visibleProviders).map((r) => ({
       provider: r.provider,
       model: r.model,
       url: s2sSampleFeed.objectUrl(r.object),
       turns: r.turns,
     }));
-  }, [manifest, visibleProviders]);
+  }, [manifest, hasNoConversation, visibleProviders]);
 
   const handlePlay = useCallback(
     (provider: string) => {
@@ -81,18 +74,8 @@ export function SamplesCard() {
 
   return (
     <Card className="text-left min-w-0 h-full flex flex-col" padding="p-5 lg:p-8">
-      <div className="mb-3 flex items-baseline justify-between gap-2">
-        <div className="text-[0.9rem] font-light text-text-secondary">
-          Conversation samples
-        </div>
-        {manifest ? (
-          <span className="flex items-baseline gap-2 font-mono text-xs text-text-tertiary">
-            {manifest.persona_name ? (
-              <span className="text-text-secondary">{manifest.persona_name}</span>
-            ) : null}
-            <span>{tickLabel(manifest.bucket_at)}</span>
-          </span>
-        ) : null}
+      <div className="mb-3 text-[0.9rem] font-light text-text-secondary">
+        Conversation samples
       </div>
 
       {loading ? (
@@ -103,19 +86,12 @@ export function SamplesCard() {
         </p>
       ) : items.length === 0 ? (
         <p className="py-8 text-center text-sm text-text-tertiary">
-          {!manifest && s2sPlayRequest
-            ? "No sample recorded for this point."
+          {hasNoConversation || (!manifest && s2sPlayRequest)
+            ? "No conversation recorded for this point."
             : "Samples appear here after the next benchmark run."}
         </p>
       ) : (
         <div className="flex flex-1 flex-col gap-4">
-          {!multiTurn ? (
-            <SampleInput
-              transcript={manifest?.transcript ?? null}
-              inputAudioUrl={manifest?.input_audio_url ?? null}
-              coordinator={coordinator}
-            />
-          ) : null}
           <SampleOutputs
             items={items}
             normalizeProvider={normalizeProviderName}
@@ -129,12 +105,6 @@ export function SamplesCard() {
           />
         </div>
       )}
-
-      {!multiTurn ? (
-        <p className="mt-4 text-[10px] text-text-tertiary">
-          Prompts from the SLURP dataset (CC BY-NC 4.0).
-        </p>
-      ) : null}
     </Card>
   );
 }


### PR DESCRIPTION
The Jul 20-23 ticks predate multi-turn sampling, so scrubbing the timeline onto one of them reshaped the whole card. Those days now read as having no conversation, which also retires the prompt block and the SLURP footnote. Drops the date, persona label and "Play all"; a pane now stops at the end of its own recording instead of rolling into the next provider.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updates the S2S samples card to focus exclusively on conversation recordings.
- Hides legacy single-turn samples and replaces them with a conversation-specific empty state.
- Removes prompt, persona, date, attribution, and “Play all” UI.
- Stops playback when an individual provider recording ends instead of advancing to the next provider.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no concrete blocking or independently actionable issues identified.

The conversation filter matches the producer’s versioned manifest contract, and completed provider recordings reset through the existing playback hook without breaking replay or coordinator behavior.

<sub>Reviews (1): Last reviewed commit: ["Show only conversation samples on the S2..."](https://github.com/coval-ai/benchmarks/commit/96d140bfd2853327b5ecf026503545af6a8b6c89) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47736236)</sub>

<!-- /greptile_comment -->