### PR TITLE
Publish a conversation sample for every day in the fetch window

### DIFF
--- a/runner/src/coval_bench/s2s/fetch_v2v.py
+++ b/runner/src/coval_bench/s2s/fetch_v2v.py
@@ -480,21 +480,26 @@ async def _fetch_one_provider(
     caught here so one provider can't abort others.
     """
     statuses: list[RunStatus] = []
-    candidates: dict[str, SampleRun] = {}
+    candidates: dict[tuple[datetime, str], SampleRun] = {}
 
     def note_sample_candidate(coval_run: CovalRun) -> None:
-        # Newest-first scan: keep the newest eligible run PER PERSONA. Multi-turn
-        # runs the same test set once per persona, so a provider yields one
-        # candidate per persona (single-turn has no persona -> a single "" key).
-        # Staggered arrivals must not shrink the sample; committed only after the
-        # staleness check so a stale provider's old recording never ships today.
-        if coval_run.persona_id in candidates:
+        # Newest-first scan: keep the newest eligible run PER (BUCKET, PERSONA).
+        # Multi-turn runs the same test set once per persona, so a provider yields
+        # one candidate per persona per day (single-turn has no persona -> a "" key).
+        # Keying on the bucket too is what lets a missed day still be published: the
+        # window spans two periods, and keying on persona alone let today's run evict
+        # yesterday's before the sampler ever saw it. Staggered arrivals must not
+        # shrink the sample; committed only after the staleness check so a stale
+        # provider's old recording never ships today.
+        bucket_at = _bucket_start(coval_run.create_time or datetime.now(tz=UTC), period_seconds)
+        key = (bucket_at, coval_run.persona_id)
+        if key in candidates:
             return
-        candidates[coval_run.persona_id] = SampleRun(
+        candidates[key] = SampleRun(
             provider=spec.provider,
             model=spec.model,
             coval_run_id=coval_run.run_id,
-            bucket_at=_bucket_start(coval_run.create_time or datetime.now(tz=UTC), period_seconds),
+            bucket_at=bucket_at,
             persona_id=coval_run.persona_id,
             agent_id=agent_id,
         )
@@ -656,7 +661,7 @@ async def fetch_and_write_v2v(settings: Settings | None = None) -> dict[str, Run
             missing = expected - {r.provider for r in sampled_runs}
             if missing:
                 # Error level on purpose: this is the alert that a provider is
-                # absent from the day's sample; the tick still publishes the rest.
+                # absent from the window, so no day in it can publish a sample.
                 logger.error("samples_provider_missing", missing=sorted(missing))
             await publish_tick_sample(
                 client,
@@ -664,6 +669,7 @@ async def fetch_and_write_v2v(settings: Settings | None = None) -> dict[str, Run
                 test_set_id=test_set_id,
                 runs=sampled_runs,
                 rng=random.Random(),  # noqa: S311
+                expected_providers=expected,
             )
         logger.info(
             "s2s_fetch_done",

--- a/runner/src/coval_bench/s2s/samples.py
+++ b/runner/src/coval_bench/s2s/samples.py
@@ -37,6 +37,7 @@ logger = structlog.get_logger("coval_bench.s2s.samples")
 
 PREFIX = "s2s-samples"
 INDEX_KEY = f"{PREFIX}/index.json"
+_TICK_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 _INDEX_MAX_ENTRIES = 60
 _DOWNLOAD_TIMEOUT = 120.0
 
@@ -165,7 +166,14 @@ def _upload(bucket: storage.Bucket, key: str, data: bytes, content_type: str) ->
 
 
 def _update_index(bucket: storage.Bucket, tick_key: str) -> None:
-    """Prepend the tick to index.json (single daily writer — no race to guard).
+    """Add the tick to index.json, kept newest-first (single writer — no race to guard).
+
+    Sorted rather than prepended because ticks are not always written in
+    chronological order: one fetch publishes every day in its window oldest
+    first, and a recovery can add a day older than everything already there.
+    The dashboard reads index[0] as the latest tick, so write order must not
+    decide it. Fixed-width ISO-8601 UTC makes a reverse string sort
+    chronological, and it keeps the newest entries when truncating.
 
     Only a confirmed missing object starts an empty index; any other read
     failure leaves the existing index untouched so a transient error can't
@@ -183,7 +191,7 @@ def _update_index(bucket: storage.Bucket, tick_key: str) -> None:
     except Exception:
         logger.error("samples_index_read_failed", tick=tick_key, exc_info=True)
         return
-    ticks = [tick_key, *(t for t in ticks if t != tick_key)][:_INDEX_MAX_ENTRIES]
+    ticks = sorted({tick_key, *ticks}, reverse=True)[:_INDEX_MAX_ENTRIES]
     _upload(bucket, INDEX_KEY, json.dumps(ticks).encode(), "application/json")
 
 
@@ -196,8 +204,13 @@ async def publish_tick_sample(
     rng: Random,
     storage_client: storage.Client | None = None,
     download_client: httpx.AsyncClient | None = None,
+    expected_providers: set[str] | None = None,
 ) -> int:
     """Copy one multi-turn conversation (every provider, one persona) as a v2 sample.
+
+    ``expected_providers`` is the configured provider set a sample must cover.
+    Pass it: without it completeness is judged against whichever providers turned
+    up, so a day one provider sat out would publish a lopsided comparison.
 
     Never raises: any failure is logged and the tick is simply skipped.
     """
@@ -213,6 +226,7 @@ async def publish_tick_sample(
                 runs=runs,
                 rng=rng,
                 storage_client=storage_client,
+                expected_providers=expected_providers,
             )
     except Exception:
         logger.error("samples_tick_failed", exc_info=True)
@@ -228,8 +242,68 @@ async def _publish_tick_sample(
     runs: list[SampleRun],
     rng: Random,
     storage_client: storage.Client | None,
+    expected_providers: set[str] | None,
 ) -> int:
-    providers = {r.provider for r in runs}
+    """Publish a sample for EVERY bucket present in ``runs``, oldest first.
+
+    The fetch window spans two periods, so a run set can carry both yesterday and
+    today. Publishing per bucket is what recovers a missed day: yesterday
+    republishes if it never landed, and is skipped cheaply if it did (the
+    manifest-exists check below). One bucket failing never blocks the others.
+
+    Each bucket must cover ``expected_providers`` on its own. A provider can be
+    present for today and absent for yesterday, and judging each bucket against
+    only its own runs would call that yesterday complete.
+    """
+    if storage_client is None:  # pragma: no cover -- real client only outside tests
+        from google.cloud import storage as gcs
+
+        storage_client = gcs.Client()
+    bucket = storage_client.bucket(bucket_name)
+
+    by_bucket: dict[datetime, list[SampleRun]] = {}
+    for run in runs:
+        by_bucket.setdefault(run.bucket_at, []).append(run)
+
+    published = 0
+    for bucket_at in sorted(by_bucket):
+        try:
+            published += await _publish_one_bucket(
+                client,
+                download_client,
+                bucket=bucket,
+                test_set_id=test_set_id,
+                runs=by_bucket[bucket_at],
+                bucket_at=bucket_at,
+                rng=rng,
+                expected_providers=expected_providers,
+            )
+        except Exception:
+            logger.error(
+                "samples_bucket_failed",
+                tick=bucket_at.strftime(_TICK_FORMAT),
+                exc_info=True,
+            )
+    return published
+
+
+async def _publish_one_bucket(
+    client: httpx.AsyncClient,
+    download_client: httpx.AsyncClient,
+    *,
+    bucket: storage.Bucket,
+    test_set_id: str,
+    runs: list[SampleRun],
+    bucket_at: datetime,
+    rng: Random,
+    expected_providers: set[str] | None,
+) -> int:
+    tick_key = bucket_at.strftime(_TICK_FORMAT)
+    providers = expected_providers or {r.provider for r in runs}
+    absent = providers - {r.provider for r in runs}
+    if absent:
+        logger.error("samples_bucket_provider_absent", tick=tick_key, absent=sorted(absent))
+        return 0
 
     # A "conversation" is one (test_case, persona) pair — the same scenario and
     # the same simulated caller, which is what makes the sample comparable across
@@ -265,31 +339,30 @@ async def _publish_tick_sample(
         pool.extend((persona_id, tc) for tc in sorted(shared))
 
     if not pool:
-        logger.error("samples_no_shared_clip", runs=[r.coval_run_id for r in runs])
+        logger.error(
+            "samples_no_shared_clip",
+            tick=tick_key,
+            providers=sorted(providers),
+            personas=sorted(runs_by_persona),
+            runs=[r.coval_run_id for r in runs],
+        )
         return 0
-
-    if storage_client is None:  # pragma: no cover -- real client only outside tests
-        from google.cloud import storage as gcs
-
-        storage_client = gcs.Client()
-    bucket = storage_client.bucket(bucket_name)
 
     # Uniform draw over the shared conversations of both personas; repick on any
     # incomplete provider so only a fully-complete conversation (audio + turns for
     # EVERY provider) is ever surfaced.
     rng.shuffle(pool)
+    manifest_key = f"{PREFIX}/{tick_key}/manifest.json"
+    if bucket.blob(manifest_key).exists():
+        # Idempotent repair: manifest published but the index update failed. This
+        # is also what makes replaying an already-published day cheap.
+        _update_index(bucket, tick_key)
+        logger.info("samples_tick_exists", tick=tick_key)
+        return 0
+
     for persona_id, test_case_id in pool:
         prov_runs = runs_by_persona[persona_id]
-        # Key the sample by the CHOSEN conversation's own bucket, not the max across
-        # all personas: personas can straddle bucket boundaries, and the global max
-        # would store this sample under an unrelated (newer) tick and mislabel it.
-        tick_key = max(prov_runs[p].bucket_at for p in providers).strftime("%Y-%m-%dT%H:%M:%SZ")
-        manifest_key = f"{PREFIX}/{tick_key}/manifest.json"
-        if bucket.blob(manifest_key).exists():
-            # Idempotent repair: manifest published but the index update failed.
-            _update_index(bucket, tick_key)
-            logger.info("samples_tick_exists", tick=tick_key)
-            return 0
+        blocked_by: str | None = None
         staged: list[tuple[SampleRun, str, bytes, list[dict[str, Any]]]] = []
         for provider in sorted(providers):
             run = prov_runs[provider]
@@ -314,11 +387,18 @@ async def _publish_tick_sample(
             except Exception:
                 logger.error("sample_copy_failed", provider=provider, sim_id=sim_id, exc_info=True)
             if audio is None or not turns:
+                blocked_by = provider
                 break
             staged.append((run, sim_id, audio, turns))
 
         if len(staged) != len(providers):
-            logger.info("sample_incomplete_skipped", persona=persona_id, test_case_id=test_case_id)
+            logger.info(
+                "sample_incomplete_skipped",
+                tick=tick_key,
+                persona=persona_id,
+                test_case_id=test_case_id,
+                provider=blocked_by,
+            )
             continue
 
         recordings: list[dict[str, Any]] = []
@@ -355,5 +435,11 @@ async def _publish_tick_sample(
         )
         return len(recordings)
 
-    logger.error("samples_no_complete_sample")
+    logger.error(
+        "samples_no_complete_sample",
+        tick=tick_key,
+        providers=sorted(providers),
+        attempted=len(pool),
+        test_case_ids=sorted({tc for _, tc in pool}),
+    )
     return 0

--- a/runner/src/coval_bench/s2s/samples.py
+++ b/runner/src/coval_bench/s2s/samples.py
@@ -299,6 +299,16 @@ async def _publish_one_bucket(
     expected_providers: set[str] | None,
 ) -> int:
     tick_key = bucket_at.strftime(_TICK_FORMAT)
+    manifest_key = f"{PREFIX}/{tick_key}/manifest.json"
+    # Ahead of every other gate: an already-published day needs no runs at all,
+    # only its index entry restored if that write once failed. Gating this behind
+    # the checks below would strand such a day for good — its runs age out of the
+    # window, so no later fetch would revisit the bucket to repair it.
+    if bucket.blob(manifest_key).exists():
+        _update_index(bucket, tick_key)
+        logger.info("samples_tick_exists", tick=tick_key)
+        return 0
+
     providers = expected_providers or {r.provider for r in runs}
     absent = providers - {r.provider for r in runs}
     if absent:
@@ -352,14 +362,6 @@ async def _publish_one_bucket(
     # incomplete provider so only a fully-complete conversation (audio + turns for
     # EVERY provider) is ever surfaced.
     rng.shuffle(pool)
-    manifest_key = f"{PREFIX}/{tick_key}/manifest.json"
-    if bucket.blob(manifest_key).exists():
-        # Idempotent repair: manifest published but the index update failed. This
-        # is also what makes replaying an already-published day cheap.
-        _update_index(bucket, tick_key)
-        logger.info("samples_tick_exists", tick=tick_key)
-        return 0
-
     for persona_id, test_case_id in pool:
         prov_runs = runs_by_persona[persona_id]
         blocked_by: str | None = None

--- a/runner/tests/unit/test_s2s_fetch.py
+++ b/runner/tests/unit/test_s2s_fetch.py
@@ -438,13 +438,45 @@ async def test_already_ingested_run_still_becomes_sample_candidate() -> None:
 
 
 @pytest.mark.asyncio
-async def test_newest_run_is_the_sample_candidate_once() -> None:
+async def test_each_bucket_contributes_its_own_sample_candidate() -> None:
+    """Runs in different buckets are both candidates — this is what recovers a missed day."""
     from coval_bench.s2s.samples import SampleRun
 
     writer = _stub_writer()
+    # Exactly one period apart, so the two always floor to different buckets.
     list_json = _list_json(
         {"run_id": "R2", "create_time": _iso(timedelta(hours=1))},
         {"run_id": "R1", "create_time": _iso(timedelta(hours=4))},
+    )
+    values = [{"simulation_output_id": "s1", "value": 0.5}]
+    sampled: list[SampleRun] = []
+    async with _fake_client(list_json, _run_json(values)) as client:
+        await fetch_v2v._fetch_one_provider(
+            client,
+            writer,
+            spec=SPEC,
+            agent_id="a1",
+            metric_id="MID",
+            runner_sha="test",
+            period_seconds=10_800,
+            stale_grace_seconds=5_400,
+            sampled_runs=sampled,
+        )
+    assert [r.coval_run_id for r in sampled] == ["R2", "R1"]
+    assert len({r.bucket_at for r in sampled}) == 2
+
+
+@pytest.mark.asyncio
+async def test_one_bucket_keeps_only_its_newest_candidate() -> None:
+    """Staggered arrivals within a bucket must not shrink that bucket's sample."""
+    from coval_bench.s2s.samples import SampleRun
+
+    writer = _stub_writer()
+    # Same create_time, so both are certainly in one bucket; newest-first wins.
+    same_time = _iso(timedelta(hours=1))
+    list_json = _list_json(
+        {"run_id": "R2", "create_time": same_time},
+        {"run_id": "R1", "create_time": same_time},
     )
     values = [{"simulation_output_id": "s1", "value": 0.5}]
     sampled: list[SampleRun] = []

--- a/runner/tests/unit/test_s2s_samples.py
+++ b/runner/tests/unit/test_s2s_samples.py
@@ -20,6 +20,9 @@ from coval_bench.s2s.samples import PREFIX, SampleRun, publish_tick_sample
 
 BUCKET_AT = datetime(2026, 7, 17, tzinfo=UTC)
 TICK = "2026-07-17T00:00:00Z"
+# The fetch window spans two periods, so a run set can carry the previous day too.
+PREV_BUCKET_AT = datetime(2026, 7, 16, tzinfo=UTC)
+PREV_TICK = "2026-07-16T00:00:00Z"
 TEST_SET = "DvAqQ4md"
 
 # Real bench persona ids so the label map is exercised too.
@@ -27,15 +30,33 @@ FEMALE = "PN3xgmsqeLDjsNNEA2e55e"
 MALE = "9ATy64zKXxSUaVWb5YnQtd"
 
 
-def _run(provider: str, model: str, run_id: str, persona_id: str, agent_id: str) -> SampleRun:
+def _run(
+    provider: str,
+    model: str,
+    run_id: str,
+    persona_id: str,
+    agent_id: str,
+    bucket_at: datetime = BUCKET_AT,
+) -> SampleRun:
     return SampleRun(
         provider=provider,
         model=model,
         coval_run_id=run_id,
-        bucket_at=BUCKET_AT,
+        bucket_at=bucket_at,
         persona_id=persona_id,
         agent_id=agent_id,
     )
+
+
+# One day's worth: two providers x two personas, ids suffixed so each day's runs
+# stay distinct when a set spans two buckets.
+def _runs_on(bucket_at: datetime, suffix: str) -> list[SampleRun]:
+    return [
+        _run("openai", "gpt-realtime", f"RO_F{suffix}", FEMALE, "AO", bucket_at),
+        _run("openai", "gpt-realtime", f"RO_M{suffix}", MALE, "AO", bucket_at),
+        _run("google", "gemini-live", f"RG_F{suffix}", FEMALE, "AG", bucket_at),
+        _run("google", "gemini-live", f"RG_M{suffix}", MALE, "AG", bucket_at),
+    ]
 
 
 # Two providers, each run once per persona (mirrors run = agent + persona + test_set).
@@ -129,6 +150,7 @@ async def _publish(
     runs: list[SampleRun],
     *,
     rng_seed: int = 0,
+    expected_providers: set[str] | None = None,
 ) -> int:
     return await publish_tick_sample(
         client,
@@ -138,6 +160,7 @@ async def _publish(
         rng=random.Random(rng_seed),
         storage_client=storage_client,
         download_client=client,
+        expected_providers=expected_providers,
     )
 
 
@@ -269,14 +292,32 @@ async def test_existing_manifest_is_never_overwritten() -> None:
 
 
 @pytest.mark.asyncio
-async def test_index_prepends_existing_history() -> None:
+async def test_index_keeps_existing_history() -> None:
     storage_client, bucket = _fake_storage()
-    bucket.objects[samples.INDEX_KEY] = json.dumps(["2026-07-16T00:00:00Z"]).encode()
+    bucket.objects[samples.INDEX_KEY] = json.dumps([PREV_TICK]).encode()
     cases = {"RO_F": ["b"], "RG_F": ["b"], "RO_M": ["b"], "RG_M": ["b"]}
     async with _fake_client(cases) as client:
         await _publish(client, storage_client, _runs())
 
-    assert json.loads(bucket.objects[samples.INDEX_KEY]) == [TICK, "2026-07-16T00:00:00Z"]
+    assert json.loads(bucket.objects[samples.INDEX_KEY]) == [TICK, PREV_TICK]
+
+
+@pytest.mark.asyncio
+async def test_index_stays_newest_first_when_an_older_day_lands_later() -> None:
+    """A recovered day is older than the history, and must not become index[0].
+
+    The dashboard treats index[0] as the latest tick, so ordering has to come
+    from the timestamps rather than from the order days happened to be written.
+    """
+    storage_client, bucket = _fake_storage()
+    newer = ["2026-07-27T00:00:00Z", TICK]
+    bucket.objects[samples.INDEX_KEY] = json.dumps(newer).encode()
+    runs = _runs_on(PREV_BUCKET_AT, "_Y")
+    cases = {r.coval_run_id: ["b"] for r in runs}
+    async with _fake_client(cases) as client:
+        await _publish(client, storage_client, runs)
+
+    assert json.loads(bucket.objects[samples.INDEX_KEY]) == [*newer, PREV_TICK]
 
 
 @pytest.mark.asyncio
@@ -292,6 +333,88 @@ async def test_never_raises_on_total_failure() -> None:
 
     assert stored == 0
     assert bucket.objects == {}
+
+
+@pytest.mark.asyncio
+async def test_missed_day_publishes_alongside_the_current_tick() -> None:
+    """A run set spanning two buckets publishes BOTH — this is the day-gap recovery."""
+    storage_client, bucket = _fake_storage()
+    runs = _runs_on(PREV_BUCKET_AT, "_Y") + _runs_on(BUCKET_AT, "_T")
+    cases = {r.coval_run_id: ["b", "c"] for r in runs}
+    async with _fake_client(cases) as client:
+        stored = await _publish(client, storage_client, runs)
+
+    assert stored == 4  # two providers x two days
+    for tick in (PREV_TICK, TICK):
+        manifest = json.loads(bucket.objects[f"{PREFIX}/{tick}/manifest.json"])
+        assert manifest["bucket_at"] == tick
+        assert {r["provider"] for r in manifest["recordings"]} == {"openai", "google"}
+        assert f"{PREFIX}/{tick}/openai.wav" in bucket.objects
+        assert f"{PREFIX}/{tick}/google.wav" in bucket.objects
+    # Published oldest-first, so the index ends up newest-first.
+    assert json.loads(bucket.objects[f"{PREFIX}/index.json"]) == [TICK, PREV_TICK]
+
+
+@pytest.mark.asyncio
+async def test_bucket_missing_an_expected_provider_publishes_nothing() -> None:
+    """A provider can be present today and absent yesterday.
+
+    Completeness has to be judged against the configured provider set, not
+    against whichever providers happen to appear in that one bucket — otherwise
+    yesterday calls itself complete and ships a one-provider comparison.
+    """
+    storage_client, bucket = _fake_storage()
+    openai_only = [
+        _run("openai", "gpt-realtime", "RO_F_Y", FEMALE, "AO", PREV_BUCKET_AT),
+        _run("openai", "gpt-realtime", "RO_M_Y", MALE, "AO", PREV_BUCKET_AT),
+    ]
+    runs = openai_only + _runs_on(BUCKET_AT, "_T")
+    cases = {r.coval_run_id: ["b", "c"] for r in runs}
+    async with _fake_client(cases) as client:
+        stored = await _publish(
+            client, storage_client, runs, expected_providers={"openai", "google"}
+        )
+
+    # Today is complete and publishes; yesterday is refused outright.
+    assert stored == 2
+    assert f"{PREFIX}/{TICK}/manifest.json" in bucket.objects
+    assert f"{PREFIX}/{PREV_TICK}/manifest.json" not in bucket.objects
+    assert f"{PREFIX}/{PREV_TICK}/openai.wav" not in bucket.objects
+    assert json.loads(bucket.objects[samples.INDEX_KEY]) == [TICK]
+
+
+@pytest.mark.asyncio
+async def test_recovery_never_overwrites_an_existing_manifest() -> None:
+    storage_client, bucket = _fake_storage()
+    already_there = b'{"schema_version": 2, "bucket_at": "2026-07-16T00:00:00Z"}'
+    bucket.objects[f"{PREFIX}/{PREV_TICK}/manifest.json"] = already_there
+    runs = _runs_on(PREV_BUCKET_AT, "_Y") + _runs_on(BUCKET_AT, "_T")
+    cases = {r.coval_run_id: ["b", "c"] for r in runs}
+    async with _fake_client(cases) as client:
+        stored = await _publish(client, storage_client, runs)
+
+    assert stored == 2  # only the current tick
+    assert bucket.objects[f"{PREFIX}/{PREV_TICK}/manifest.json"] == already_there
+    assert f"{PREFIX}/{PREV_TICK}/openai.wav" not in bucket.objects
+    assert f"{PREFIX}/{TICK}/manifest.json" in bucket.objects
+    # The existing day is still repaired into the index.
+    assert PREV_TICK in json.loads(bucket.objects[f"{PREFIX}/index.json"])
+
+
+@pytest.mark.asyncio
+async def test_an_unusable_day_does_not_block_the_other() -> None:
+    storage_client, bucket = _fake_storage()
+    stale = _runs_on(PREV_BUCKET_AT, "_Y")
+    runs = stale + _runs_on(BUCKET_AT, "_T")
+    cases = {r.coval_run_id: ["b", "c"] for r in runs}
+    # Every recording for the previous day 404s.
+    gone = frozenset(f"{r.coval_run_id}-{tc}" for r in stale for tc in ("b", "c"))
+    async with _fake_client(cases, audio_404=gone) as client:
+        stored = await _publish(client, storage_client, runs)
+
+    assert stored == 2
+    assert f"{PREFIX}/{PREV_TICK}/manifest.json" not in bucket.objects
+    assert f"{PREFIX}/{TICK}/manifest.json" in bucket.objects
 
 
 def test_conversation_turns_coerces_offsets() -> None:

--- a/runner/tests/unit/test_s2s_samples.py
+++ b/runner/tests/unit/test_s2s_samples.py
@@ -384,6 +384,31 @@ async def test_bucket_missing_an_expected_provider_publishes_nothing() -> None:
 
 
 @pytest.mark.asyncio
+async def test_published_day_is_reindexed_even_when_a_provider_is_absent() -> None:
+    """An index write that once failed must still be repairable.
+
+    A published day whose current runs no longer cover every provider still owns
+    its manifest, so it has to be put back in the index. Checking completeness
+    first would strand it: its runs age out of the window, and no later fetch
+    would revisit the bucket.
+    """
+    storage_client, bucket = _fake_storage()
+    already_there = b'{"schema_version": 2, "bucket_at": "2026-07-16T00:00:00Z"}'
+    bucket.objects[f"{PREFIX}/{PREV_TICK}/manifest.json"] = already_there
+    # Only openai remains for that day, so the provider gate would otherwise fire.
+    openai_only = [_run("openai", "gpt-realtime", "RO_F_Y", FEMALE, "AO", PREV_BUCKET_AT)]
+    cases = {r.coval_run_id: ["b"] for r in openai_only}
+    async with _fake_client(cases) as client:
+        stored = await _publish(
+            client, storage_client, openai_only, expected_providers={"openai", "google"}
+        )
+
+    assert stored == 0
+    assert bucket.objects[f"{PREFIX}/{PREV_TICK}/manifest.json"] == already_there
+    assert json.loads(bucket.objects[samples.INDEX_KEY]) == [PREV_TICK]
+
+
+@pytest.mark.asyncio
 async def test_recovery_never_overwrites_an_existing_manifest() -> None:
     storage_client, bucket = _fake_storage()
     already_there = b'{"schema_version": 2, "bucket_at": "2026-07-16T00:00:00Z"}'


### PR DESCRIPTION
Jul 24 and Jul 26 never got a sample, and a day that produced none had no second chance. Yesterday's runs were already inside the scan window, but candidates were keyed by persona alone, so today's run evicted them they are now keyed by bucket as well.

Publishing partitions runs by day and runs the existing per-day logic for each, oldest first. Since days no longer arrive in order, index.json is sorted by timestamp rather than prepended (the dashboard reads the first entry as the latest tick), and each day must now cover the configured provider set on its own.

Days older than the fetch window, Jul 24 and Jul 26 included, still need a one-off.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Publishes conversation samples independently for each day in the fetch window.
- Retains sample candidates by time bucket and persona.
- Enforces configured provider coverage within each bucket.
- Processes buckets oldest-first while keeping the sample index newest-first.
- Adds coverage for missed-day recovery, incomplete buckets, index repair, and cross-day failure isolation.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<sub>Reviews (2): Last reviewed commit: ["Reindex an already-published day before ..."](https://github.com/coval-ai/benchmarks/commit/0e8e198d950365877fa97bb8d488e16d0328028a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47764087)</sub>

**Context used:**

- Knowledge Base — [Runner Orchestration](https://app.greptile.com/coval/-/custom-context/knowledge-base/coval-ai/benchmarks/-/docs/runner-orchestration.md)

<!-- /greptile_comment -->