### PR TITLE
Sort the latency box plot by median so it reads as a progression (BENCH-550)

### DIFF
--- a/web/components/charts/d3/BoxPlot.tsx
+++ b/web/components/charts/d3/BoxPlot.tsx
@@ -63,6 +63,7 @@ const BoxPlot: React.FC<BoxPlotProps> = ({
   const svgRef = useRef<SVGSVGElement>(null);
   const axisRef = useRef<SVGSVGElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
+  const captionRef = useRef<SVGTextElement | null>(null);
   const [dimensions, setDimensions] = useState({
     width: width || 800,
     height
@@ -155,6 +156,8 @@ const BoxPlot: React.FC<BoxPlotProps> = ({
     data.data.length * slotWidth + margin.left + margin.right
   );
   const scrollable = svgWidth > dimensions.width;
+  // Shared by the draw and the scroll-tracking effects below.
+  const captionY = dimensions.height - margin.top - 6;
 
   // Layout effect so the d3 content redraws in the same frame the <svg>
   // resizes — the PNG export clones the SVG as soon as its width settles, and
@@ -363,15 +366,21 @@ const BoxPlot: React.FC<BoxPlotProps> = ({
 
     // X-axis label (the Y axis title is omitted — it's redundant with the
     // card heading).
-    g.append("text")
-      .attr(
-        "transform",
-        `translate(${chartWidth / 2}, ${chartHeight + margin.bottom - 6})`
-      )
-      .style("text-anchor", "middle")
+    // Left-anchored once the plot scrolls: centering on the full canvas parks
+    // the caption off-screen, so on mobile it never reaches the reader. Phone
+    // widths can't fit the long form either.
+    captionRef.current = g
+      .append("text")
+      .attr("transform", `translate(${scrollable ? 0 : chartWidth / 2}, ${captionY})`)
+      .style("text-anchor", scrollable ? "start" : "middle")
       .attr("fill", themeColors.axisText)
       .attr("font-size", axisLabelFontSize)
-      .text("Ranked by IQR (tightest first)");
+      .text(
+        isMobile
+          ? "Fastest median first"
+          : "Ranked by median latency (fastest first)"
+      )
+      .node();
 
     // Render a box plot for each model
     data.data.forEach((modelData) => {
@@ -510,7 +519,18 @@ const BoxPlot: React.FC<BoxPlotProps> = ({
     });
 
     svg.on("mouseleave", () => setTip((t) => (t?.pinned ? t : null)));
-  }, [data, dimensions.height, svgWidth, scrollable, getModelColor, getProviderForModel, normalizeModelName, dedicatedModels, dedicatedIcon, dismissDedicated, isMobile, themeColors]);
+  }, [data, dimensions.height, svgWidth, scrollable, captionY, getModelColor, getProviderForModel, normalizeModelName, dedicatedModels, dedicatedIcon, dismissDedicated, isMobile, themeColors]);
+
+  // The caption sits inside the scrolling plot so PNG exports capture it, which
+  // means panning would carry it off-screen; slide it back by the scroll offset
+  // so the ranking stays legible wherever the reader has swiped to.
+  useEffect(() => {
+    if (!captionRef.current || !scrollable) return;
+    captionRef.current.setAttribute(
+      "transform",
+      `translate(${scrollX}, ${captionY})`
+    );
+  }, [scrollX, scrollable, captionY, data]);
 
   // The measured container must always render — an early return here would
   // leave the sizing effect's ResizeObserver attached to nothing, freezing
@@ -606,6 +626,7 @@ const BoxPlot: React.FC<BoxPlotProps> = ({
           </p>
           {dedicatedModels?.has(tip.point.model) && <DedicatedBadge />}
           {[
+            ["Median", `${tip.point.quartiles.median.toFixed(0)}ms`],
             [
               "IQR",
               `${(tip.point.quartiles.q3 - tip.point.quartiles.q1).toFixed(0)}ms`

--- a/web/components/charts/d3/BoxPlot.tsx
+++ b/web/components/charts/d3/BoxPlot.tsx
@@ -523,14 +523,18 @@ const BoxPlot: React.FC<BoxPlotProps> = ({
 
   // The caption sits inside the scrolling plot so PNG exports capture it, which
   // means panning would carry it off-screen; slide it back by the scroll offset
-  // so the ranking stays legible wherever the reader has swiped to.
-  useEffect(() => {
+  // so the ranking stays legible wherever the reader has swiped to. Deliberately
+  // unconditional: the redraw above rebuilds the caption at x=0 on any of its
+  // deps, so this has to re-run after every one of them, not just after a
+  // scroll. It follows the redraw in the same commit, so the caption never
+  // paints at the stale offset.
+  useLayoutEffect(() => {
     if (!captionRef.current || !scrollable) return;
     captionRef.current.setAttribute(
       "transform",
       `translate(${scrollX}, ${captionY})`
     );
-  }, [scrollX, scrollable, captionY, data]);
+  });
 
   // The measured container must always render — an early return here would
   // leave the sizing effect's ResizeObserver attached to nothing, freezing

--- a/web/hooks/useChartData.ts
+++ b/web/hooks/useChartData.ts
@@ -225,7 +225,8 @@ export function useChartData({
   }, [modelStats, toDisplayUnits]);
 
   // Box plot data for a given metric: the selected models' pieces, sorted by
-  // IQR so the tightest models read left to right, with the pooled axis bounds.
+  // median so the boxes climb left to right, with the pooled axis bounds.
+  // Ranking on IQR instead scatters them vertically and the chart reads as noise.
   const getBoxPlotData = useCallback(
     (metric: string): BoxPlotData => {
       const byModel = boxByMetricModel[metric] ?? {};
@@ -247,10 +248,7 @@ export function useChartData({
         globalMax = 0;
       }
 
-      data.sort(
-        (a, b) =>
-          a.quartiles.q3 - a.quartiles.q1 - (b.quartiles.q3 - b.quartiles.q1)
-      );
+      data.sort((a, b) => a.quartiles.median - b.quartiles.median);
 
       return {
         data,


### PR DESCRIPTION
## The problem
<img width="1175" height="597" alt="Screenshot 2026-07-27 at 3 52 24 PM" src="https://github.com/user-attachments/assets/5eae86d4-1171-47fa-a851-6e0c29a55854" />

Reported as "the bars seem to be sorted by something else" — the footer said *Ranked by IQR (tightest first)* but the chart looked unordered.

The sort wasn't inconsistent. The sort key, the tooltip value, and the drawn box span all read the same expression (`q3 - q1`), and the IQR sort had already landed via #391. The real issue is that **ranking by IQR orders boxes by height, which says nothing about where a box sits vertically** — so the boxes scattered up and down and the plot read as noise.

The ticket's suspected cause (a legacy quartile calculation) doesn't exist: quartiles come straight from SQL `PERCENTILE_CONT` as `p25/p50/p75`, with only the whisker clamp computed in JS. No nulls or inverted percentiles in any window/benchmark either, so there was no NaN-comparator failure mode.

## The change

Sort on the median, so the quantity that increases is the one you actually see:

- `useChartData.ts` — sort on `quartiles.median` (4 lines → 1)
- Caption follows the key: *Ranked by median latency (fastest first)*
- Tooltip leads with `Median`, so the ordering is verifiable by hover or tap

Medians left→right are now `101, 153, 202, 223, 235, 255, 272, 290, 291, 300, 302, 331, 332, 339, 367, 406, 494, 589, 649, 665, 702, 764, 920, 1249` ms — monotonic, measured off the rendered SVG rather than eyeballed.

## Caption visibility (found while verifying)

The caption was centered on the *full scroll canvas*, so at 375px it rendered at x `753–1097` inside a `73–342` viewport — entirely off-screen. The one label explaining the ordering was invisible on phones.

It now anchors left when the plot scrolls and tracks the existing `scrollX` state, so it holds position while panning. It stays **inside the SVG** on purpose: `SectionHeader.downloadImage` exports by capturing the SVG element, so an HTML caption would disappear from PNGs. Exports also force `isMobile = false`, so they keep the full desktop wording.

## Verification

- `tsc --noEmit` and `eslint` clean; 82 tests passing
- Ordering measured from the DOM at desktop and mobile widths
- Tap-to-pin works at 375px; touch targets 71×392px
- Caption visible at scroll 0, 700, and max on mobile; full wording at desktop

## Not included

The headline stat still reads "Average TTFA IQR" while the sort is now median. IQR remains the right headline for a card called *Latency Variation*, so I left it — say the word if you'd rather it match the sort.

Also: the stale remote branch `sort-latency-variation-by-iqr` is an unsquashed duplicate of #391 and is now superseded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)