### PR TITLE
Screen arena prompts before synthesis

### DIFF
--- a/runner/src/coval_bench/api/routers/arena.py
+++ b/runner/src/coval_bench/api/routers/arena.py
@@ -40,7 +40,6 @@ from starlette.requests import Request
 from coval_bench.api.deps import capture_api_event, get_pool, get_posthog, get_settings
 from coval_bench.api.ratelimit import limiter
 from coval_bench.api.schemas import (
-    ArenaDomain,
     ArenaLeaderboardResponse,
     BattleCreate,
     BattleOut,
@@ -52,6 +51,7 @@ from coval_bench.api.schemas import (
     VoteOut,
 )
 from coval_bench.arena.audio_store import clip_url
+from coval_bench.arena.domains import ArenaDomain
 from coval_bench.arena.generate import generate_battle
 from coval_bench.arena.moderation import moderation_verdict, pii_match
 from coval_bench.arena.monitoring import (
@@ -335,15 +335,15 @@ async def create_battle(
     uniform at cold start. Returns 502 if either side fails to synthesize (no battle
     is written).
 
-    The prompt is screened before anything is spent: personal data locally, then
-    content via the moderation API (422 either way). Screening precedes the cap so a
-    rejected prompt costs neither money nor anyone's quota.
+    Prompts are screened before anything is spent — personal data locally, then content
+    via the moderation API (422), and 503 if the moderator is unreachable while
+    ``arena_moderation_fail_closed``. Screening precedes the cap so a rejected prompt
+    costs neither money nor quota.
 
-    Then a global daily cap (``arena_daily_battle_cap``, ``<= 0`` disables), also
-    checked before synthesis so a tripped cap spends nothing (429). Known limits: it
-    counts successful battles only (a failed one still costs ~2 calls, uncounted but
-    logged), and the non-transactional check may overshoot slightly under concurrency
-    (no data is overwritten).
+    Then a global daily cap (``arena_daily_battle_cap``, ``<= 0`` disables), also checked
+    before synthesis (429). Known limits: it counts successful battles only (a failed one
+    still costs ~2 calls, uncounted but logged), and the non-transactional check may
+    overshoot slightly under concurrency (no data is overwritten).
     """
     store = ArenaStore(pool)
     prompt = body.prompt.strip()
@@ -355,14 +355,17 @@ async def create_battle(
         logger.info("arena_prompt_rejected", reason="pii", kind=pii)
         raise HTTPException(422, "prompt must not contain payment card or national id numbers")
 
-    flagged, category_scores = await moderation_verdict(settings, prompt)
-    if flagged:
+    verdict = await moderation_verdict(settings, prompt)
+    if verdict.flagged:
         logger.info(
             "arena_prompt_rejected",
             reason="moderation",
-            categories=sorted(name for name, score in category_scores.items() if score >= 0.5),
+            categories=sorted(name for name, score in verdict.scores.items() if score >= 0.5),
         )
         raise HTTPException(422, "prompt rejected by content moderation")
+    if not verdict.available and settings.arena_moderation_fail_closed:
+        logger.warning("arena_prompt_rejected", reason="moderation_unavailable")
+        raise HTTPException(503, "content moderation is unavailable, please retry")
 
     cap = settings.arena_daily_battle_cap
     if cap > 0 and await store.count_battles_today() >= cap:

--- a/runner/src/coval_bench/api/routers/arena.py
+++ b/runner/src/coval_bench/api/routers/arena.py
@@ -53,6 +53,7 @@ from coval_bench.api.schemas import (
 )
 from coval_bench.arena.audio_store import clip_url
 from coval_bench.arena.generate import generate_battle
+from coval_bench.arena.moderation import moderation_verdict, pii_match
 from coval_bench.arena.monitoring import (
     build_convergence,
     build_cooccurrence,
@@ -332,16 +333,36 @@ async def create_battle(
 
     Pairing weights informative matchups from the latest ratings, falling back to
     uniform at cold start. Returns 502 if either side fails to synthesize (no battle
-    is written). Guarded by a global daily cap (``arena_daily_battle_cap``, ``<= 0``
-    disables), checked before synthesis so a tripped cap spends nothing (429). Known
-    limits: it counts successful battles only (a failed one still costs ~2 calls,
-    uncounted but logged), and the non-transactional check may overshoot slightly
-    under concurrency (no data is overwritten).
+    is written).
+
+    The prompt is screened before anything is spent: personal data locally, then
+    content via the moderation API (422 either way). Screening precedes the cap so a
+    rejected prompt costs neither money nor anyone's quota.
+
+    Then a global daily cap (``arena_daily_battle_cap``, ``<= 0`` disables), also
+    checked before synthesis so a tripped cap spends nothing (429). Known limits: it
+    counts successful battles only (a failed one still costs ~2 calls, uncounted but
+    logged), and the non-transactional check may overshoot slightly under concurrency
+    (no data is overwritten).
     """
     store = ArenaStore(pool)
     prompt = body.prompt.strip()
     if not prompt:
         raise HTTPException(422, "prompt must not be empty")
+
+    pii = pii_match(prompt)
+    if pii is not None:
+        logger.info("arena_prompt_rejected", reason="pii", kind=pii)
+        raise HTTPException(422, "prompt must not contain payment card or national id numbers")
+
+    flagged, category_scores = await moderation_verdict(settings, prompt)
+    if flagged:
+        logger.info(
+            "arena_prompt_rejected",
+            reason="moderation",
+            categories=sorted(name for name, score in category_scores.items() if score >= 0.5),
+        )
+        raise HTTPException(422, "prompt rejected by content moderation")
 
     cap = settings.arena_daily_battle_cap
     if cap > 0 and await store.count_battles_today() >= cap:

--- a/runner/src/coval_bench/api/schemas.py
+++ b/runner/src/coval_bench/api/schemas.py
@@ -17,6 +17,7 @@ from typing import Literal
 from pydantic import BaseModel, ConfigDict, Field
 
 from coval_bench.api.common import BenchmarkLiteral, WindowLiteral
+from coval_bench.arena.domains import ArenaDomain
 from coval_bench.registries import TagCategory
 
 
@@ -203,11 +204,6 @@ class BattleOut(BaseModel):
     domain: str | None
     audio_a_url: str
     audio_b_url: str
-
-
-ArenaDomain = Literal["customer-service", "healthcare", "sales", "receptionist-booking", "other"]
-"""Domains a battle can be tagged with. Each doubles as a leaderboard key, so the set is
-closed and excludes ``all`` — that key is reserved for the aggregate board."""
 
 
 class BattleCreate(BaseModel):

--- a/runner/src/coval_bench/arena/domains.py
+++ b/runner/src/coval_bench/arena/domains.py
@@ -1,0 +1,17 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""The closed set of domains a battle can be tagged with.
+
+Lives here rather than in ``api.schemas`` because it is arena vocabulary, not an API
+shape: ``arena.prompts`` needs it, and importing it from ``api`` pulled in the whole
+FastAPI app, which cycles back through ``api.routers.arena``.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+ArenaDomain = Literal["customer-service", "healthcare", "sales", "receptionist-booking", "other"]
+"""Each value doubles as a leaderboard key, so the set is closed and excludes ``all`` —
+that key is reserved for the aggregate board."""

--- a/runner/src/coval_bench/arena/moderation.py
+++ b/runner/src/coval_bench/arena/moderation.py
@@ -3,20 +3,22 @@
 
 """Prompt screening for arena battle generation — the only guard that prevents spend.
 
-``pii_match`` is local and deliberately narrow: Luhn-checked card numbers and national
-id patterns only. Phone numbers, order refs and emails are allowed — the arena's
-customer-service and booking domains are full of them, and a blanket digit-run rule
-flagged one of the hundred curated example prompts.
+``pii_match``: local and narrow — national ids, and cards with an issuer prefix that also
+pass Luhn. Phone numbers and order refs are allowed; a blanket digit rule rejected one of
+the curated example prompts.
 
-``moderation_verdict`` calls OpenAI's ``omni-moderation-latest`` (free) for hate,
-sexual, violent and self-harm content. It fails **open**, so ``pii_match`` is the
-always-on backstop.
+``moderation_verdict``: OpenAI ``omni-moderation-latest`` (free). Reports whether the
+service answered; the caller decides what silence means. Bounded by our own timeout as
+well as the client's, since the public route dies at 60s and the SDK defaults to 600.
 """
 
 from __future__ import annotations
 
+import asyncio
+import hashlib
 import re
 import unicodedata
+from dataclasses import dataclass, field
 
 import structlog
 from openai import AsyncOpenAI
@@ -26,11 +28,22 @@ from coval_bench.config import Settings
 logger: structlog.BoundLogger = structlog.get_logger(__name__)
 
 MODERATION_MODEL = "omni-moderation-latest"
+MODERATION_TIMEOUT_S = 4.0
 
 _CARD_CANDIDATE = re.compile(r"(?:\d[ -]?){12,18}\d")
 _NATIONAL_ID = re.compile(r"\b\d{3}-\d{2}-\d{4}\b")
 
 _client: AsyncOpenAI | None = None
+_client_fingerprint: str | None = None
+
+
+@dataclass(frozen=True)
+class ModerationResult:
+    """What the moderator said, and whether it answered at all."""
+
+    flagged: bool
+    available: bool
+    scores: dict[str, float] = field(default_factory=dict)
 
 
 def _luhn_ok(digits: str) -> bool:
@@ -46,12 +59,31 @@ def _luhn_ok(digits: str) -> bool:
     return total % 10 == 0
 
 
+def _has_card_iin(digits: str) -> bool:
+    """Whether *digits* opens with a known card issuer prefix.
+
+    Luhn alone passes ~1 in 10 arbitrary numbers, so a tracking reference of the right
+    length would read as a card without this.
+    """
+    two, three, four = int(digits[:2]), int(digits[:3]), int(digits[:4])
+    return (
+        digits[0] == "4"
+        or two in {34, 36, 37, 38, 39, 65}
+        or 51 <= two <= 55
+        or 2221 <= four <= 2720
+        or 3528 <= four <= 3589
+        or 300 <= three <= 305
+        or 644 <= three <= 649
+        or digits[:4] == "6011"
+    )
+
+
 def pii_match(prompt: str) -> str | None:
     """Return the kind of personal data found in *prompt*, or ``None`` if clean."""
     text = unicodedata.normalize("NFKC", prompt)
     for candidate in _CARD_CANDIDATE.finditer(text):
         digits = re.sub(r"[ -]", "", candidate.group())
-        if 13 <= len(digits) <= 19 and _luhn_ok(digits):
+        if 13 <= len(digits) <= 19 and _has_card_iin(digits) and _luhn_ok(digits):
             return "payment_card"
     if _NATIONAL_ID.search(text):
         return "national_id"
@@ -59,34 +91,43 @@ def pii_match(prompt: str) -> str | None:
 
 
 def _get_client(settings: Settings) -> AsyncOpenAI | None:
-    """Return a shared moderation client, or ``None`` when no key is configured."""
-    global _client
-    if _client is None:
-        key = settings.openai_api_key
-        if key is None:
-            return None
-        _client = AsyncOpenAI(api_key=key.get_secret_value())
+    """Return a client for the configured key, rebuilding it when the key changes."""
+    global _client, _client_fingerprint
+    key = settings.openai_api_key
+    if key is None:
+        return None
+    secret = key.get_secret_value()
+    fingerprint = hashlib.sha256(secret.encode()).hexdigest()
+    if _client is None or _client_fingerprint != fingerprint:
+        _client = AsyncOpenAI(
+            api_key=secret,
+            timeout=MODERATION_TIMEOUT_S,
+            max_retries=0,
+        )
+        _client_fingerprint = fingerprint
     return _client
 
 
-async def moderation_verdict(settings: Settings, prompt: str) -> tuple[bool, dict[str, float]]:
-    """Return ``(flagged, category_scores)`` for *prompt*, allowing it on any failure.
+async def moderation_verdict(settings: Settings, prompt: str) -> ModerationResult:
+    """Classify *prompt*, reporting ``available=False`` if the moderator did not answer.
 
-    Scores come back even when nothing is flagged so callers can persist them, letting
-    thresholds be calibrated later and past battles re-judged without re-calling.
+    Scores come back even when nothing is flagged, so they can be stored and re-judged
+    later without re-calling. Parsing sits inside the guard: a malformed response is an
+    unavailable moderator, not a 500.
     """
     client = _get_client(settings)
     if client is None:
         logger.warning("arena_moderation_unconfigured")
-        return False, {}
+        return ModerationResult(flagged=False, available=False)
     try:
-        response = await client.moderations.create(model=MODERATION_MODEL, input=prompt)
+        async with asyncio.timeout(MODERATION_TIMEOUT_S):
+            response = await client.moderations.create(model=MODERATION_MODEL, input=prompt)
+        result = response.results[0]
+        scores = {
+            name: float(score)
+            for name, score in result.category_scores.model_dump(by_alias=True).items()
+        }
+        return ModerationResult(flagged=result.flagged, available=True, scores=scores)
     except Exception:
         logger.warning("arena_moderation_unavailable", exc_info=True)
-        return False, {}
-    result = response.results[0]
-    scores = {
-        name: float(score)
-        for name, score in result.category_scores.model_dump(by_alias=True).items()
-    }
-    return result.flagged, scores
+        return ModerationResult(flagged=False, available=False)

--- a/runner/src/coval_bench/arena/moderation.py
+++ b/runner/src/coval_bench/arena/moderation.py
@@ -1,0 +1,92 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Prompt screening for arena battle generation — the only guard that prevents spend.
+
+``pii_match`` is local and deliberately narrow: Luhn-checked card numbers and national
+id patterns only. Phone numbers, order refs and emails are allowed — the arena's
+customer-service and booking domains are full of them, and a blanket digit-run rule
+flagged one of the hundred curated example prompts.
+
+``moderation_verdict`` calls OpenAI's ``omni-moderation-latest`` (free) for hate,
+sexual, violent and self-harm content. It fails **open**, so ``pii_match`` is the
+always-on backstop.
+"""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+
+import structlog
+from openai import AsyncOpenAI
+
+from coval_bench.config import Settings
+
+logger: structlog.BoundLogger = structlog.get_logger(__name__)
+
+MODERATION_MODEL = "omni-moderation-latest"
+
+_CARD_CANDIDATE = re.compile(r"(?:\d[ -]?){12,18}\d")
+_NATIONAL_ID = re.compile(r"\b\d{3}-\d{2}-\d{4}\b")
+
+_client: AsyncOpenAI | None = None
+
+
+def _luhn_ok(digits: str) -> bool:
+    """Whether *digits* satisfies the Luhn checksum used by payment cards."""
+    total = 0
+    for index, char in enumerate(reversed(digits)):
+        value = int(char)
+        if index % 2 == 1:
+            value *= 2
+            if value > 9:
+                value -= 9
+        total += value
+    return total % 10 == 0
+
+
+def pii_match(prompt: str) -> str | None:
+    """Return the kind of personal data found in *prompt*, or ``None`` if clean."""
+    text = unicodedata.normalize("NFKC", prompt)
+    for candidate in _CARD_CANDIDATE.finditer(text):
+        digits = re.sub(r"[ -]", "", candidate.group())
+        if 13 <= len(digits) <= 19 and _luhn_ok(digits):
+            return "payment_card"
+    if _NATIONAL_ID.search(text):
+        return "national_id"
+    return None
+
+
+def _get_client(settings: Settings) -> AsyncOpenAI | None:
+    """Return a shared moderation client, or ``None`` when no key is configured."""
+    global _client
+    if _client is None:
+        key = settings.openai_api_key
+        if key is None:
+            return None
+        _client = AsyncOpenAI(api_key=key.get_secret_value())
+    return _client
+
+
+async def moderation_verdict(settings: Settings, prompt: str) -> tuple[bool, dict[str, float]]:
+    """Return ``(flagged, category_scores)`` for *prompt*, allowing it on any failure.
+
+    Scores come back even when nothing is flagged so callers can persist them, letting
+    thresholds be calibrated later and past battles re-judged without re-calling.
+    """
+    client = _get_client(settings)
+    if client is None:
+        logger.warning("arena_moderation_unconfigured")
+        return False, {}
+    try:
+        response = await client.moderations.create(model=MODERATION_MODEL, input=prompt)
+    except Exception:
+        logger.warning("arena_moderation_unavailable", exc_info=True)
+        return False, {}
+    result = response.results[0]
+    scores = {
+        name: float(score)
+        for name, score in result.category_scores.model_dump(by_alias=True).items()
+    }
+    return result.flagged, scores

--- a/runner/src/coval_bench/arena/moderation.py
+++ b/runner/src/coval_bench/arena/moderation.py
@@ -90,8 +90,11 @@ def pii_match(prompt: str) -> str | None:
     return None
 
 
-def _get_client(settings: Settings) -> AsyncOpenAI | None:
-    """Return a client for the configured key, rebuilding it when the key changes."""
+async def _get_client(settings: Settings) -> AsyncOpenAI | None:
+    """Return a client for the configured key, rebuilding it when the key changes.
+
+    The superseded client is closed, otherwise each rotation leaks its connection pool.
+    """
     global _client, _client_fingerprint
     key = settings.openai_api_key
     if key is None:
@@ -99,6 +102,8 @@ def _get_client(settings: Settings) -> AsyncOpenAI | None:
     secret = key.get_secret_value()
     fingerprint = hashlib.sha256(secret.encode()).hexdigest()
     if _client is None or _client_fingerprint != fingerprint:
+        if _client is not None:
+            await _client.close()
         _client = AsyncOpenAI(
             api_key=secret,
             timeout=MODERATION_TIMEOUT_S,
@@ -115,7 +120,7 @@ async def moderation_verdict(settings: Settings, prompt: str) -> ModerationResul
     later without re-calling. Parsing sits inside the guard: a malformed response is an
     unavailable moderator, not a 500.
     """
-    client = _get_client(settings)
+    client = await _get_client(settings)
     if client is None:
         logger.warning("arena_moderation_unconfigured")
         return ModerationResult(flagged=False, available=False)

--- a/runner/src/coval_bench/arena/moderation.py
+++ b/runner/src/coval_bench/arena/moderation.py
@@ -33,8 +33,7 @@ MODERATION_TIMEOUT_S = 4.0
 _CARD_CANDIDATE = re.compile(r"(?:\d[ -]?){12,18}\d")
 _NATIONAL_ID = re.compile(r"\b\d{3}-\d{2}-\d{4}\b")
 
-_client: AsyncOpenAI | None = None
-_client_fingerprint: str | None = None
+_clients: dict[str, AsyncOpenAI] = {}
 
 
 @dataclass(frozen=True)
@@ -90,27 +89,29 @@ def pii_match(prompt: str) -> str | None:
     return None
 
 
-async def _get_client(settings: Settings) -> AsyncOpenAI | None:
-    """Return a client for the configured key, rebuilding it when the key changes.
+def _get_client(settings: Settings) -> AsyncOpenAI | None:
+    """Return the client for the configured key, building it on first use.
 
-    The superseded client is closed, otherwise each rotation leaks its connection pool.
+    One client per key, keyed by a digest so no plaintext copy is kept. Clients are
+    never replaced or closed: the instance is shared across concurrent requests, so
+    closing one on rotation would abort whichever requests are mid-flight on it, which
+    reads as a moderation outage. Distinct keys therefore each keep their own client
+    rather than taking turns over a single mutable slot.
     """
-    global _client, _client_fingerprint
     key = settings.openai_api_key
     if key is None:
         return None
     secret = key.get_secret_value()
     fingerprint = hashlib.sha256(secret.encode()).hexdigest()
-    if _client is None or _client_fingerprint != fingerprint:
-        if _client is not None:
-            await _client.close()
-        _client = AsyncOpenAI(
+    client = _clients.get(fingerprint)
+    if client is None:
+        client = AsyncOpenAI(
             api_key=secret,
             timeout=MODERATION_TIMEOUT_S,
             max_retries=0,
         )
-        _client_fingerprint = fingerprint
-    return _client
+        _clients[fingerprint] = client
+    return client
 
 
 async def moderation_verdict(settings: Settings, prompt: str) -> ModerationResult:
@@ -120,7 +121,7 @@ async def moderation_verdict(settings: Settings, prompt: str) -> ModerationResul
     later without re-calling. Parsing sits inside the guard: a malformed response is an
     unavailable moderator, not a 500.
     """
-    client = await _get_client(settings)
+    client = _get_client(settings)
     if client is None:
         logger.warning("arena_moderation_unconfigured")
         return ModerationResult(flagged=False, available=False)

--- a/runner/src/coval_bench/arena/prompts.py
+++ b/runner/src/coval_bench/arena/prompts.py
@@ -16,7 +16,7 @@ the arena votes on naturalness, so expressive delivery is the biggest test surfa
 
 from __future__ import annotations
 
-from coval_bench.api.schemas import ArenaDomain
+from coval_bench.arena.domains import ArenaDomain
 
 EXAMPLE_PROMPTS: dict[ArenaDomain, list[str]] = {
     "customer-service": [

--- a/runner/src/coval_bench/config.py
+++ b/runner/src/coval_bench/config.py
@@ -174,6 +174,10 @@ class Settings(BaseSettings):
     # Must match the GCS bucket's object-deletion lifecycle (set in benchmark-infra).
     arena_clip_retention_days: int = 30
     arena_daily_battle_cap: int = 500
+    # When the moderator cannot be reached, reject rather than synthesize: the local PII
+    # check is not a content-safety fallback, and the arena publishes its audio. Flip to
+    # false to trade safety for availability during a prolonged provider outage.
+    arena_moderation_fail_closed: bool = True
 
 
 @functools.lru_cache(maxsize=1)

--- a/runner/tests/api/conftest.py
+++ b/runner/tests/api/conftest.py
@@ -178,6 +178,9 @@ async def app(postgresql: Any, monkeypatch: pytest.MonkeyPatch) -> AsyncIterator
     monkeypatch.setenv("POSTHOG_DISABLED", "true")
     monkeypatch.setenv("ARENA_LABELER_KEY", ARENA_LABELER_KEY)
     monkeypatch.setenv("INTERNAL_API_KEY", INTERNAL_API_KEY)
+    # Battle generation screens prompts through the moderation API. Without this the
+    # suite would reach the network on any machine that has the key exported.
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
 
     settings = Settings()
 

--- a/runner/tests/api/conftest.py
+++ b/runner/tests/api/conftest.py
@@ -37,6 +37,7 @@ from psycopg_pool import AsyncConnectionPool
 from pytest_postgresql import factories
 
 from coval_bench.api.app import create_app
+from coval_bench.arena.moderation import ModerationResult
 from coval_bench.config import Settings
 
 ARENA_LABELER_KEY = "test-labeler-key"
@@ -208,6 +209,21 @@ async def app(postgresql: Any, monkeypatch: pytest.MonkeyPatch) -> AsyncIterator
     test_app = create_app(settings)
     async with LifespanManager(test_app):
         yield test_app
+
+
+@pytest.fixture(autouse=True)
+def moderation_allows(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Default every test to a reachable moderator that flags nothing.
+
+    Battle generation fails closed when moderation is unavailable, and the suite has no
+    API key, so without this every create-battle test would 503 regardless of subject.
+    Tests about screening override it.
+    """
+
+    async def _clean(*args: Any, **kwargs: Any) -> ModerationResult:
+        return ModerationResult(flagged=False, available=True)
+
+    monkeypatch.setattr("coval_bench.api.routers.arena.moderation_verdict", _clean)
 
 
 @pytest.fixture

--- a/runner/tests/api/test_arena.py
+++ b/runner/tests/api/test_arena.py
@@ -15,6 +15,7 @@ import pytest
 from fastapi import FastAPI
 from httpx import AsyncClient
 
+from coval_bench.arena.moderation import ModerationResult
 from coval_bench.arena.pairing import active_tts_models
 from coval_bench.arena.prompts import EXAMPLE_PROMPTS
 from coval_bench.providers.base import TTSResult
@@ -812,8 +813,8 @@ async def test_create_battle_rejects_flagged_prompt(
     """A prompt the moderation API flags is rejected, and synthesis never runs."""
     await _apply_arena_schema(_make_db_url(postgresql))
 
-    async def _flagged(*args: Any, **kwargs: Any) -> tuple[bool, dict[str, float]]:
-        return True, {"hate": 0.97}
+    async def _flagged(*args: Any, **kwargs: Any) -> ModerationResult:
+        return ModerationResult(flagged=True, available=True, scores={"hate": 0.97})
 
     async def _no_synth(*args: Any, **kwargs: Any) -> None:
         raise AssertionError("generate_battle must not run for a flagged prompt")
@@ -829,18 +830,42 @@ async def test_create_battle_rejects_flagged_prompt(
     assert response.status_code == 422
 
 
-async def test_create_battle_proceeds_when_moderation_unavailable(
+async def test_create_battle_503_when_moderation_unavailable(
     client: AsyncClient, postgresql: Any, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Screening fails open: a moderation outage must not block generation."""
+    """Fail closed by default: an unreachable moderator blocks synthesis with 503."""
     await _apply_arena_schema(_make_db_url(postgresql))
+
+    async def _unavailable(*args: Any, **kwargs: Any) -> ModerationResult:
+        return ModerationResult(flagged=False, available=False)
+
+    async def _no_synth(*args: Any, **kwargs: Any) -> None:
+        raise AssertionError("generate_battle must not run while moderation is down")
+
+    monkeypatch.setattr("coval_bench.api.routers.arena.moderation_verdict", _unavailable)
+    monkeypatch.setattr("coval_bench.api.routers.arena.generate_battle", _no_synth)
+
+    response = await client.post(
+        "/v1/arena/battle", json={"prompt": "hello", "domain": "other"}, headers=_LABELER_HEADERS
+    )
+    assert response.status_code == 503
+
+
+async def test_create_battle_proceeds_when_configured_to_fail_open(
+    client: AsyncClient, app: FastAPI, postgresql: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """With fail-closed disabled, an outage trades safety for availability."""
+    await _apply_arena_schema(_make_db_url(postgresql))
+    app.state.settings = app.state.settings.model_copy(
+        update={"arena_moderation_fail_closed": False}
+    )
     monkeypatch.setattr("coval_bench.arena.generate.TTS_PROVIDERS", _fake_tts_providers(set()))
     monkeypatch.setattr(
         "coval_bench.arena.audio_store.store_clip", lambda *a, **k: "clips/stub.wav"
     )
 
-    async def _unavailable(*args: Any, **kwargs: Any) -> tuple[bool, dict[str, float]]:
-        return False, {}
+    async def _unavailable(*args: Any, **kwargs: Any) -> ModerationResult:
+        return ModerationResult(flagged=False, available=False)
 
     monkeypatch.setattr("coval_bench.api.routers.arena.moderation_verdict", _unavailable)
 

--- a/runner/tests/api/test_arena.py
+++ b/runner/tests/api/test_arena.py
@@ -787,6 +787,69 @@ async def test_reveal_requires_the_requesting_voters_own_vote(
     assert response.status_code == 409
 
 
+async def test_create_battle_rejects_personal_data(
+    client: AsyncClient, postgresql: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A prompt carrying a payment card is rejected before anything is spent."""
+    await _apply_arena_schema(_make_db_url(postgresql))
+
+    async def _no_synth(*args: Any, **kwargs: Any) -> None:
+        raise AssertionError("generate_battle must not run for a rejected prompt")
+
+    monkeypatch.setattr("coval_bench.api.routers.arena.generate_battle", _no_synth)
+
+    response = await client.post(
+        "/v1/arena/battle",
+        json={"prompt": "Read back 4242 4242 4242 4242 please.", "domain": "other"},
+        headers=_LABELER_HEADERS,
+    )
+    assert response.status_code == 422
+
+
+async def test_create_battle_rejects_flagged_prompt(
+    client: AsyncClient, postgresql: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A prompt the moderation API flags is rejected, and synthesis never runs."""
+    await _apply_arena_schema(_make_db_url(postgresql))
+
+    async def _flagged(*args: Any, **kwargs: Any) -> tuple[bool, dict[str, float]]:
+        return True, {"hate": 0.97}
+
+    async def _no_synth(*args: Any, **kwargs: Any) -> None:
+        raise AssertionError("generate_battle must not run for a flagged prompt")
+
+    monkeypatch.setattr("coval_bench.api.routers.arena.moderation_verdict", _flagged)
+    monkeypatch.setattr("coval_bench.api.routers.arena.generate_battle", _no_synth)
+
+    response = await client.post(
+        "/v1/arena/battle",
+        json={"prompt": "something vile", "domain": "other"},
+        headers=_LABELER_HEADERS,
+    )
+    assert response.status_code == 422
+
+
+async def test_create_battle_proceeds_when_moderation_unavailable(
+    client: AsyncClient, postgresql: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Screening fails open: a moderation outage must not block generation."""
+    await _apply_arena_schema(_make_db_url(postgresql))
+    monkeypatch.setattr("coval_bench.arena.generate.TTS_PROVIDERS", _fake_tts_providers(set()))
+    monkeypatch.setattr(
+        "coval_bench.arena.audio_store.store_clip", lambda *a, **k: "clips/stub.wav"
+    )
+
+    async def _unavailable(*args: Any, **kwargs: Any) -> tuple[bool, dict[str, float]]:
+        return False, {}
+
+    monkeypatch.setattr("coval_bench.api.routers.arena.moderation_verdict", _unavailable)
+
+    response = await client.post(
+        "/v1/arena/battle", json={"prompt": "hello", "domain": "other"}, headers=_LABELER_HEADERS
+    )
+    assert response.status_code == 201
+
+
 async def test_create_battle_429_when_cap_reached(
     client: AsyncClient, app: FastAPI, postgresql: Any, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/runner/tests/unit/test_arena_moderation.py
+++ b/runner/tests/unit/test_arena_moderation.py
@@ -53,11 +53,7 @@ def _install_stub(monkeypatch: pytest.MonkeyPatch, create: Any) -> None:
             pass
 
     _Stub.moderations.create = staticmethod(create)  # type: ignore[attr-defined]
-
-    async def _stub_get_client(_settings: Any) -> Any:
-        return _Stub()
-
-    monkeypatch.setattr(moderation, "_get_client", _stub_get_client)
+    monkeypatch.setattr(moderation, "_get_client", lambda _settings: _Stub())
 
 
 async def test_verdict_unavailable_when_unconfigured(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -66,7 +62,7 @@ async def test_verdict_unavailable_when_unconfigured(monkeypatch: pytest.MonkeyP
     ``_env_file=None`` matters: ``Settings`` otherwise reads ``.env``, so a key sitting
     there would build a real client and send this prompt to OpenAI.
     """
-    monkeypatch.setattr(moderation, "_client", None)
+    monkeypatch.setattr(moderation, "_clients", {})
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     verdict = await moderation_verdict(Settings(_env_file=None), "hello")
     assert verdict.available is False
@@ -149,16 +145,19 @@ async def test_verdict_does_not_outlive_the_request_budget(
     assert verdict.available is False
 
 
-async def test_client_is_rebuilt_when_the_key_changes(monkeypatch: pytest.MonkeyPatch) -> None:
-    """A rotated key must not keep moderating under the previous credential."""
-    monkeypatch.setattr(moderation, "_client", None)
-    monkeypatch.setattr(moderation, "_client_fingerprint", None)
+def test_each_key_gets_its_own_client(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A rotated key must not keep moderating under the previous credential.
+
+    The superseded client stays open on purpose — it is shared, so closing it would
+    abort whatever requests are still in flight on it.
+    """
+    monkeypatch.setattr(moderation, "_clients", {})
 
     monkeypatch.setenv("OPENAI_API_KEY", "first-key")
-    first = await moderation._get_client(Settings())
-    assert first is await moderation._get_client(Settings())
+    first = moderation._get_client(Settings())
+    assert first is moderation._get_client(Settings())
 
     monkeypatch.setenv("OPENAI_API_KEY", "second-key")
-    second = await moderation._get_client(Settings())
+    second = moderation._get_client(Settings())
     assert second is not first
-    assert first is not None and first.is_closed()
+    assert first is not None and not first.is_closed()

--- a/runner/tests/unit/test_arena_moderation.py
+++ b/runner/tests/unit/test_arena_moderation.py
@@ -53,14 +53,22 @@ def _install_stub(monkeypatch: pytest.MonkeyPatch, create: Any) -> None:
             pass
 
     _Stub.moderations.create = staticmethod(create)  # type: ignore[attr-defined]
-    monkeypatch.setattr(moderation, "_get_client", lambda _settings: _Stub())
+
+    async def _stub_get_client(_settings: Any) -> Any:
+        return _Stub()
+
+    monkeypatch.setattr(moderation, "_get_client", _stub_get_client)
 
 
 async def test_verdict_unavailable_when_unconfigured(monkeypatch: pytest.MonkeyPatch) -> None:
-    """With no API key the moderator is unavailable, and no client is built."""
+    """With no API key the moderator is unavailable, and no client is built.
+
+    ``_env_file=None`` matters: ``Settings`` otherwise reads ``.env``, so a key sitting
+    there would build a real client and send this prompt to OpenAI.
+    """
     monkeypatch.setattr(moderation, "_client", None)
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
-    verdict = await moderation_verdict(Settings(), "hello")
+    verdict = await moderation_verdict(Settings(_env_file=None), "hello")
     assert verdict.available is False
     assert verdict.flagged is False
 
@@ -141,14 +149,16 @@ async def test_verdict_does_not_outlive_the_request_budget(
     assert verdict.available is False
 
 
-def test_client_is_rebuilt_when_the_key_changes(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_client_is_rebuilt_when_the_key_changes(monkeypatch: pytest.MonkeyPatch) -> None:
     """A rotated key must not keep moderating under the previous credential."""
     monkeypatch.setattr(moderation, "_client", None)
     monkeypatch.setattr(moderation, "_client_fingerprint", None)
 
     monkeypatch.setenv("OPENAI_API_KEY", "first-key")
-    first = moderation._get_client(Settings())
-    assert first is moderation._get_client(Settings())
+    first = await moderation._get_client(Settings())
+    assert first is await moderation._get_client(Settings())
 
     monkeypatch.setenv("OPENAI_API_KEY", "second-key")
-    assert moderation._get_client(Settings()) is not first
+    second = await moderation._get_client(Settings())
+    assert second is not first
+    assert first is not None and first.is_closed()

--- a/runner/tests/unit/test_arena_moderation.py
+++ b/runner/tests/unit/test_arena_moderation.py
@@ -5,12 +5,14 @@
 
 from __future__ import annotations
 
+import asyncio
 from typing import Any
 
 import pytest
 
 from coval_bench.arena import moderation
-from coval_bench.arena.moderation import moderation_verdict, pii_match
+from coval_bench.arena.moderation import MODERATION_TIMEOUT_S, moderation_verdict, pii_match
+from coval_bench.arena.prompts import EXAMPLE_PROMPTS
 from coval_bench.config import Settings
 
 
@@ -19,9 +21,12 @@ from coval_bench.config import Settings
     [
         ("Please read back 4242 4242 4242 4242 to confirm.", "payment_card"),
         ("Card 4242-4242-4242-4242 on file.", "payment_card"),
+        ("Amex 3782 822463 10005 on file.", "payment_card"),
         ("My ssn is 123-45-6789 for the file.", "national_id"),
-        # Sixteen digits that fail Luhn are an order reference, not a card.
-        ("Your order reference is 1234567890123456, thanks.", None),
+        # Luhn-valid but no issuer prefix: a tracking reference, not a card.
+        ("Tracking 9999999999999995 is out for delivery.", None),
+        # Right length and issuer prefix but fails Luhn.
+        ("Your order reference is 4242424242424243, thanks.", None),
         # The curated example prompt that a blanket digit-run rule rejected.
         ("Call us back at 1-800-555-0142, extension 230, if anything changes.", None),
         ("Booking ref 998812 for Tuesday at 4.", None),
@@ -30,48 +35,71 @@ from coval_bench.config import Settings
     ],
 )
 def test_pii_match(prompt: str, expected: str | None) -> None:
-    """Only Luhn-valid cards and national ids are treated as personal data."""
+    """Only issuer-prefixed Luhn-valid cards and national ids count as personal data."""
     assert pii_match(prompt) == expected
 
 
 def test_example_prompts_are_never_rejected() -> None:
-    """The bank must survive its own screening; read off the router because
-    ``arena.prompts`` imports ``api.schemas`` and cycles if imported first."""
-    from coval_bench.api.routers.arena import EXAMPLE_PROMPTS
-
+    """The bank must survive its own screening."""
     offenders = [p for prompts in EXAMPLE_PROMPTS.values() for p in prompts if pii_match(p)]
     assert offenders == []
 
 
-async def test_moderation_verdict_allows_when_unconfigured(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """With no API key the prompt is allowed and no client is built."""
+def _install_stub(monkeypatch: pytest.MonkeyPatch, create: Any) -> None:
+    """Point the module at a stand-in client whose ``moderations.create`` is *create*."""
+
+    class _Stub:
+        class moderations:  # noqa: N801
+            pass
+
+    _Stub.moderations.create = staticmethod(create)  # type: ignore[attr-defined]
+    monkeypatch.setattr(moderation, "_get_client", lambda _settings: _Stub())
+
+
+async def test_verdict_unavailable_when_unconfigured(monkeypatch: pytest.MonkeyPatch) -> None:
+    """With no API key the moderator is unavailable, and no client is built."""
     monkeypatch.setattr(moderation, "_client", None)
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
-    flagged, scores = await moderation_verdict(Settings(), "hello")
-    assert flagged is False
-    assert scores == {}
+    verdict = await moderation_verdict(Settings(), "hello")
+    assert verdict.available is False
+    assert verdict.flagged is False
 
 
-async def test_moderation_verdict_fails_open_on_error(monkeypatch: pytest.MonkeyPatch) -> None:
-    """A moderation outage allows the prompt rather than taking the arena down."""
+@pytest.mark.parametrize(
+    "error",
+    [RuntimeError("upstream down"), TimeoutError(), ValueError("429 rate limited")],
+)
+async def test_verdict_unavailable_on_error(
+    monkeypatch: pytest.MonkeyPatch, error: Exception
+) -> None:
+    """Any upstream failure — outage, timeout, 429 — reports unavailable, never raises."""
 
-    class _Boom:
-        class moderations:  # noqa: N801
-            @staticmethod
-            async def create(**_: Any) -> Any:
-                raise RuntimeError("upstream down")
+    async def _raise(**_: Any) -> Any:
+        raise error
 
-    monkeypatch.setattr(moderation, "_client", _Boom())
-    flagged, scores = await moderation_verdict(Settings(), "hello")
-    assert flagged is False
-    assert scores == {}
+    _install_stub(monkeypatch, _raise)
+    verdict = await moderation_verdict(Settings(), "hello")
+    assert verdict.available is False
+    assert verdict.flagged is False
 
 
-async def test_moderation_verdict_returns_scores_when_flagged(
+async def test_verdict_unavailable_on_malformed_response(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """An empty results list is an unavailable moderator, not an unhandled 500."""
+
+    class _Empty:
+        results: list[Any] = []
+
+    async def _empty(**_: Any) -> Any:
+        return _Empty()
+
+    _install_stub(monkeypatch, _empty)
+    verdict = await moderation_verdict(Settings(), "hello")
+    assert verdict.available is False
+
+
+async def test_verdict_returns_scores_when_flagged(monkeypatch: pytest.MonkeyPatch) -> None:
     """A flagged prompt reports its category scores so callers can persist them."""
 
     class _Scores:
@@ -84,16 +112,43 @@ async def test_moderation_verdict_returns_scores_when_flagged(
         flagged = True
         category_scores = _Scores()
 
-    class _Response:
-        results = [_Result()]
+    async def _flagged(**_: Any) -> Any:
+        class _Response:
+            results = [_Result()]
 
-    class _Stub:
-        class moderations:  # noqa: N801
-            @staticmethod
-            async def create(**_: Any) -> Any:
-                return _Response()
+        return _Response()
 
-    monkeypatch.setattr(moderation, "_client", _Stub())
-    flagged, scores = await moderation_verdict(Settings(), "something vile")
-    assert flagged is True
-    assert scores["hate"] == pytest.approx(0.91)
+    _install_stub(monkeypatch, _flagged)
+    verdict = await moderation_verdict(Settings(), "something vile")
+    assert verdict.flagged is True
+    assert verdict.available is True
+    assert verdict.scores["hate"] == pytest.approx(0.91)
+
+
+async def test_verdict_does_not_outlive_the_request_budget(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A hanging moderator must surface well inside the 60s public route limit."""
+
+    async def _hang(**_: Any) -> Any:
+        await asyncio.sleep(30)
+        raise AssertionError("should have been abandoned long before this")
+
+    _install_stub(monkeypatch, _hang)
+    verdict = await asyncio.wait_for(
+        moderation_verdict(Settings(), "hello"), timeout=MODERATION_TIMEOUT_S + 1
+    )
+    assert verdict.available is False
+
+
+def test_client_is_rebuilt_when_the_key_changes(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A rotated key must not keep moderating under the previous credential."""
+    monkeypatch.setattr(moderation, "_client", None)
+    monkeypatch.setattr(moderation, "_client_fingerprint", None)
+
+    monkeypatch.setenv("OPENAI_API_KEY", "first-key")
+    first = moderation._get_client(Settings())
+    assert first is moderation._get_client(Settings())
+
+    monkeypatch.setenv("OPENAI_API_KEY", "second-key")
+    assert moderation._get_client(Settings()) is not first

--- a/runner/tests/unit/test_arena_moderation.py
+++ b/runner/tests/unit/test_arena_moderation.py
@@ -1,0 +1,99 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for arena prompt screening (local PII match + moderation verdict)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from coval_bench.arena import moderation
+from coval_bench.arena.moderation import moderation_verdict, pii_match
+from coval_bench.config import Settings
+
+
+@pytest.mark.parametrize(
+    ("prompt", "expected"),
+    [
+        ("Please read back 4242 4242 4242 4242 to confirm.", "payment_card"),
+        ("Card 4242-4242-4242-4242 on file.", "payment_card"),
+        ("My ssn is 123-45-6789 for the file.", "national_id"),
+        # Sixteen digits that fail Luhn are an order reference, not a card.
+        ("Your order reference is 1234567890123456, thanks.", None),
+        # The curated example prompt that a blanket digit-run rule rejected.
+        ("Call us back at 1-800-555-0142, extension 230, if anything changes.", None),
+        ("Booking ref 998812 for Tuesday at 4.", None),
+        ("Email support@acme.com if it changes.", None),
+        ("", None),
+    ],
+)
+def test_pii_match(prompt: str, expected: str | None) -> None:
+    """Only Luhn-valid cards and national ids are treated as personal data."""
+    assert pii_match(prompt) == expected
+
+
+def test_example_prompts_are_never_rejected() -> None:
+    """The bank must survive its own screening; read off the router because
+    ``arena.prompts`` imports ``api.schemas`` and cycles if imported first."""
+    from coval_bench.api.routers.arena import EXAMPLE_PROMPTS
+
+    offenders = [p for prompts in EXAMPLE_PROMPTS.values() for p in prompts if pii_match(p)]
+    assert offenders == []
+
+
+async def test_moderation_verdict_allows_when_unconfigured(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With no API key the prompt is allowed and no client is built."""
+    monkeypatch.setattr(moderation, "_client", None)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    flagged, scores = await moderation_verdict(Settings(), "hello")
+    assert flagged is False
+    assert scores == {}
+
+
+async def test_moderation_verdict_fails_open_on_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A moderation outage allows the prompt rather than taking the arena down."""
+
+    class _Boom:
+        class moderations:  # noqa: N801
+            @staticmethod
+            async def create(**_: Any) -> Any:
+                raise RuntimeError("upstream down")
+
+    monkeypatch.setattr(moderation, "_client", _Boom())
+    flagged, scores = await moderation_verdict(Settings(), "hello")
+    assert flagged is False
+    assert scores == {}
+
+
+async def test_moderation_verdict_returns_scores_when_flagged(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A flagged prompt reports its category scores so callers can persist them."""
+
+    class _Scores:
+        @staticmethod
+        def model_dump(*, by_alias: bool) -> dict[str, float]:
+            assert by_alias is True
+            return {"hate": 0.91, "sexual/minors": 0.0}
+
+    class _Result:
+        flagged = True
+        category_scores = _Scores()
+
+    class _Response:
+        results = [_Result()]
+
+    class _Stub:
+        class moderations:  # noqa: N801
+            @staticmethod
+            async def create(**_: Any) -> Any:
+                return _Response()
+
+    monkeypatch.setattr(moderation, "_client", _Stub())
+    flagged, scores = await moderation_verdict(Settings(), "something vile")
+    assert flagged is True
+    assert scores["hate"] == pytest.approx(0.91)


### PR DESCRIPTION
Reject payment cards and national ids locally, then run the prompt through OpenAI moderation. Both checks run ahead of the daily cap so a rejected prompt costs neither credits nor anyone's quota.

Moderation fails open, which leaves the local check as the backstop. It also does not treat scam framing as harmful, so the two cover different ground and both are needed.

The PII match is narrow on purpose: a blanket digit-run rule rejected one of the hundred curated example prompts, so cards are Luhn-checked and phone numbers and order refs are allowed.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds local card/national-ID detection and OpenAI prompt moderation before arena quota checks and synthesis.
- Adds configurable fail-closed handling for unavailable moderation.
- Extracts the arena domain literal into the arena package.
- Adds API and unit coverage for rejection, outage, parsing, timeout, and credential-rotation behavior.

<h3>Confidence Score: 4/5</h3>

The PR should not merge until credential rotation can no longer close a moderation client that an active request is using.

The parsing failure and stale-key behavior from the previous threads are addressed, but the replacement logic now closes a process-global client without coordinating with concurrent moderation calls, so requests overlapping key rotation can be misclassified as moderation outages.

**Files Needing Attention:** runner/src/coval_bench/arena/moderation.py

<sub>Reviews (3): Last reviewed commit: ["Close the superseded moderation client a..."](https://github.com/coval-ai/benchmarks/commit/997f422966f407848de21da4b9adcd8ac361e202) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47775550)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [API service](https://app.greptile.com/coval/-/custom-context/knowledge-base/coval-ai/benchmarks/-/docs/api-service.md)
- Knowledge Base — [Arena subsystem](https://app.greptile.com/coval/-/custom-context/knowledge-base/coval-ai/benchmarks/-/docs/arena-subsystem.md)

<!-- /greptile_comment -->