### PR TITLE
Scrub a conversation sample and reach every day from the timeline

### DIFF
--- a/web/app/s2s/components/ConversationTurns.test.ts
+++ b/web/app/s2s/components/ConversationTurns.test.ts
@@ -1,0 +1,46 @@
+// Copyright 2026 The Coval Benchmarks Authors
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+import type { S2STurn } from "@/lib/audioSamples/s2sFeed";
+import { activeTurnIndex } from "./ConversationTurns";
+
+function turn(index: number, start?: number, end?: number): S2STurn {
+  return { index, role: index % 2 === 0 ? "user" : "assistant", content: "x", start_offset: start, end_offset: end };
+}
+
+describe("activeTurnIndex", () => {
+  const turns = [turn(0, 0, 2), turn(1, 2.5, 5), turn(2, 6, 9)];
+
+  it("finds the turn holding the playhead", () => {
+    expect(activeTurnIndex(turns, 1)).toBe(0);
+    expect(activeTurnIndex(turns, 3)).toBe(1);
+    expect(activeTurnIndex(turns, 7)).toBe(2);
+  });
+
+  it("keeps the last started turn while the playhead sits in a gap", () => {
+    // 5.5s is past turn 1's end but before turn 2 starts — the pane should not
+    // flicker back to nothing between utterances.
+    expect(activeTurnIndex(turns, 5.5)).toBe(1);
+  });
+
+  it("is inactive before the first turn starts", () => {
+    expect(activeTurnIndex([turn(0, 1.5, 2)], 0.5)).toBe(-1);
+  });
+
+  it("holds the final turn past the end of the audio", () => {
+    expect(activeTurnIndex(turns, 99)).toBe(2);
+  });
+
+  it("treats a turn with no start as never active", () => {
+    expect(activeTurnIndex([turn(0), turn(1)], 5)).toBe(-1);
+  });
+
+  it("still resolves when only some turns carry offsets", () => {
+    expect(activeTurnIndex([turn(0), turn(1, 3)], 4)).toBe(1);
+  });
+
+  it("handles an open-ended turn (Coval omitted end_offset)", () => {
+    expect(activeTurnIndex([turn(0, 1)], 500)).toBe(0);
+  });
+});

--- a/web/app/s2s/components/ConversationTurns.tsx
+++ b/web/app/s2s/components/ConversationTurns.tsx
@@ -5,32 +5,76 @@
 
 import type { S2STurn } from "@/lib/audioSamples/s2sFeed";
 
+// The turn holding the playhead, or -1. The latest turn started at or before
+// the playhead wins; deliberately ignoring end_offset keeps the highlight put
+// during the silence between utterances instead of flickering off, and covers
+// turns whose end Coval omitted. Offsets are optional, so a turn without a
+// start is never active and a conversation with none never highlights.
+export function activeTurnIndex(turns: S2STurn[], currentTime: number): number {
+  for (let i = turns.length - 1; i >= 0; i--) {
+    const start = turns[i]?.start_offset;
+    if (start !== undefined && start <= currentTime) return i;
+  }
+  return -1;
+}
+
 // Compact per-provider conversation: Caller (the persona) and Agent turns.
 // Presentational + provider-agnostic — `accentColor` ties the agent's turns to
 // its pane/dot color, so this can be reused verbatim if STT/TTS ever surface
 // transcripts. The caller passes the color from the shared getModelColor map.
+// When `onSeek` is given, a turn carrying an offset jumps the playhead to it.
 export function ConversationTurns({
   turns,
   accentColor,
+  currentTime = 0,
+  onSeek,
 }: {
   turns: S2STurn[];
   accentColor: string;
+  currentTime?: number;
+  onSeek?: (seconds: number) => void;
 }) {
+  const active = onSeek ? activeTurnIndex(turns, currentTime) : -1;
+  // Only fade the others once something is genuinely highlighted. Without
+  // offsets nothing ever is, and dimming every turn would just look broken.
+  const fadeInactive = active >= 0;
   return (
     <div className="mt-1 max-h-56 space-y-2 overflow-y-auto pr-1">
-      {turns.map((t) => {
+      {turns.map((t, i) => {
         const agent = t.role === "assistant";
-        return (
-          <div
-            key={t.index}
-            className={`border-l-2 pl-2 ${agent ? "" : "border-border-primary"}`}
-            style={agent ? { borderColor: accentColor } : undefined}
-          >
+        const seekable = onSeek !== undefined && t.start_offset !== undefined;
+        const isActive = i === active;
+        const body = (
+          <>
             <span className="font-mono text-[9px] uppercase tracking-wider text-text-tertiary">
               {agent ? "Agent" : "Caller"}
             </span>
             <p className="text-[11px] leading-snug text-text-primary">{t.content}</p>
-          </div>
+          </>
+        );
+        const className = `border-l-2 pl-2 transition-opacity ${
+          agent ? "" : "border-border-primary"
+        } ${fadeInactive && !isActive ? "opacity-60" : ""}`;
+        const style = agent ? { borderColor: accentColor } : undefined;
+
+        if (!seekable) {
+          return (
+            <div key={t.index} className={className} style={style}>
+              {body}
+            </div>
+          );
+        }
+        return (
+          <button
+            key={t.index}
+            type="button"
+            onClick={() => onSeek(t.start_offset as number)}
+            aria-current={isActive ? "true" : undefined}
+            className={`${className} block w-full cursor-pointer text-left hover:opacity-100`}
+            style={style}
+          >
+            {body}
+          </button>
         );
       })}
     </div>

--- a/web/app/s2s/components/SampleOutputs.tsx
+++ b/web/app/s2s/components/SampleOutputs.tsx
@@ -23,6 +23,13 @@ export interface SampleOutputItem {
   turns?: S2STurn[];
 }
 
+// Elapsed position as m:ss. The existing formatTime helpers render wall-clock
+// timestamps, which is a different thing.
+function elapsed(seconds: number): string {
+  const whole = Math.max(0, Math.floor(seconds));
+  return `${Math.floor(whole / 60)}:${String(whole % 60).padStart(2, "0")}`;
+}
+
 // Left/right chevron/fade visibility from scroll extents; remeasures on scroll,
 // resize, and when the item set changes.
 function useScrollHints(
@@ -77,11 +84,8 @@ export function SampleOutputs({
   const conversation = items.some((i) => (i.turns?.length ?? 0) > 0);
   const viewportRef = useRef<HTMLDivElement>(null);
 
-  const { audioRef, activeIndex, isPlaying, toggle, playFrom, stop } = useSequencedPlayback(
-    tracks,
-    (track) => onPlay?.(track.key),
-    coordinator
-  );
+  const { audioRef, activeIndex, isPlaying, toggle, playFrom, stop, currentTime, duration, seek } =
+    useSequencedPlayback(tracks, (track) => onPlay?.(track.key), coordinator);
 
   // A timeline-tooltip click plays a specific provider. Wait until that tick's
   // items have loaded (provider present) before playing, then mark the request
@@ -147,9 +151,7 @@ export function SampleOutputs({
               <div
                 key={item.provider}
                 role="listitem"
-                className={`flex shrink-0 snap-start flex-col gap-2 rounded-xl border p-3 transition-colors ${
-                  conversation ? "w-[300px] min-w-[300px]" : "w-[180px] min-w-[180px]"
-                } ${
+                className={`flex w-[300px] min-w-[300px] shrink-0 snap-start flex-col gap-2 rounded-xl border p-3 transition-colors ${
                   active
                     ? "border-text-primary/40 bg-surface-secondary"
                     : "border-border-primary bg-surface-secondary/60"
@@ -178,8 +180,33 @@ export function SampleOutputs({
                   {playingThis ? <Pause className="size-3" /> : <Play className="size-3" />}
                   <span>{playingThis ? "Playing" : "Play"}</span>
                 </button>
+                {/* One <audio> is shared, so the playhead belongs to the active
+                    pane alone; other panes keep their turns static. */}
+                {active && duration > 0 ? (
+                  <div className="flex items-center gap-1.5">
+                    <input
+                      type="range"
+                      min={0}
+                      max={duration}
+                      step={0.1}
+                      value={Math.min(currentTime, duration)}
+                      onChange={(e) => seek(Number(e.target.value))}
+                      aria-label={`Seek ${normalizeProvider(item.provider)} recording`}
+                      className="h-1 w-full cursor-pointer"
+                      style={{ accentColor: color }}
+                    />
+                    <span className="shrink-0 font-mono text-[9px] tabular-nums text-text-tertiary">
+                      {elapsed(currentTime)}/{elapsed(duration)}
+                    </span>
+                  </div>
+                ) : null}
                 {turns.length ? (
-                  <ConversationTurns turns={turns} accentColor={color} />
+                  <ConversationTurns
+                    turns={turns}
+                    accentColor={color}
+                    currentTime={active ? currentTime : 0}
+                    onSeek={active ? seek : undefined}
+                  />
                 ) : null}
               </div>
             );

--- a/web/app/s2s/components/SamplesCard.tsx
+++ b/web/app/s2s/components/SamplesCard.tsx
@@ -7,7 +7,7 @@ import { useCallback, useEffect, useMemo } from "react";
 import Card from "@/components/shared/Card";
 import { useDashboard } from "@/contexts/DashboardContext";
 import { SampleFetchError } from "@/lib/audioSamples/createSampleFeed";
-import { isMultiTurn, s2sSampleFeed, visibleRecordings } from "@/lib/audioSamples/s2sFeed";
+import { s2sSampleFeed, visibleRecordings } from "@/lib/audioSamples/s2sFeed";
 import { capturePostHogEvent } from "@/lib/posthog/client";
 import { POSTHOG_EVENTS } from "@/lib/posthog/events";
 import { usePlaybackCoordinator } from "@/hooks/useSequencedPlayback";
@@ -22,8 +22,15 @@ function describeError(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
 }
 
+// Day of a pinned tick, for the "showing an older day" control only.
+function pinnedDayLabel(tick: string): string {
+  const d = new Date(tick);
+  if (Number.isNaN(d.getTime())) return tick;
+  return d.toLocaleDateString(undefined, { month: "short", day: "numeric", timeZone: "UTC" });
+}
+
 export function SamplesCard() {
-  const { modelsByProvider, normalizeProviderName, s2sPlayRequest } = useDashboard();
+  const { modelsByProvider, normalizeProviderName, s2sPlayRequest, clearS2SPlay } = useDashboard();
   const coordinator = usePlaybackCoordinator();
   const visibleProviders = useMemo(
     () => new Set(Object.keys(modelsByProvider)),
@@ -36,7 +43,6 @@ export function SamplesCard() {
   const effectiveTick = s2sPlayRequest?.tick ?? latestTick;
   const manifestQuery = s2sSampleFeed.useManifestQuery(effectiveTick);
   const manifest = manifestQuery.data ?? null;
-  const hasNoConversation = manifest != null && !isMultiTurn(manifest);
 
   const fetchError = manifestQuery.isError || indexQuery.isError;
   // Keep the failure cause internal (dev console only); public visitors just see
@@ -47,15 +53,28 @@ export function SamplesCard() {
     if (err) console.error(`[s2s-samples] fetch failed: ${describeError(err)}`, err);
   }, [manifestQuery.error, indexQuery.error]);
 
+  // Every tick with recordings is playable, including the pre-multi-turn ones
+  // that carry no transcript — those render as panes with a play button and no
+  // turn list, so a timeline click always reaches its audio.
   const items = useMemo<SampleOutputItem[]>(() => {
-    if (!manifest || hasNoConversation) return [];
+    if (!manifest) return [];
     return visibleRecordings(manifest, visibleProviders).map((r) => ({
       provider: r.provider,
       model: r.model,
       url: s2sSampleFeed.objectUrl(r.object),
       turns: r.turns,
     }));
-  }, [manifest, hasNoConversation, visibleProviders]);
+  }, [manifest, visibleProviders]);
+
+  // A timeline row can name a provider this bucket never recorded — an older
+  // tick from before that model was benchmarked, or one absent from the page's
+  // catalogue. Autoplay then finds no matching pane and stays quiet, so the
+  // click reads as broken unless we say what happened.
+  const requestedProvider = s2sPlayRequest?.provider;
+  const requestedProviderMissing =
+    requestedProvider !== undefined &&
+    manifest !== null &&
+    !items.some((i) => i.provider === requestedProvider);
 
   const handlePlay = useCallback(
     (provider: string) => {
@@ -74,8 +93,22 @@ export function SamplesCard() {
 
   return (
     <Card className="text-left min-w-0 h-full flex flex-col" padding="p-5 lg:p-8">
-      <div className="mb-3 text-[0.9rem] font-light text-text-secondary">
-        Conversation samples
+      <div className="mb-3 flex items-baseline justify-between gap-2">
+        <div className="text-[0.9rem] font-light text-text-secondary">
+          Conversation samples
+        </div>
+        {/* A timeline click pins the card to that day. Without a way back, a day
+            holding metrics but no recording would trap the card on an empty
+            state. */}
+        {s2sPlayRequest ? (
+          <button
+            type="button"
+            onClick={clearS2SPlay}
+            className="inline-flex min-h-11 shrink-0 items-center rounded-full border border-border-primary px-2 py-0.5 font-mono text-[10px] text-text-secondary transition-colors hover:text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-text-tertiary/40 lg:min-h-0"
+          >
+            {pinnedDayLabel(s2sPlayRequest.tick)} · show latest
+          </button>
+        ) : null}
       </div>
 
       {loading ? (
@@ -86,12 +119,17 @@ export function SamplesCard() {
         </p>
       ) : items.length === 0 ? (
         <p className="py-8 text-center text-sm text-text-tertiary">
-          {hasNoConversation || (!manifest && s2sPlayRequest)
-            ? "No conversation recorded for this point."
+          {!manifest && s2sPlayRequest
+            ? "No sample recorded for this point."
             : "Samples appear here after the next benchmark run."}
         </p>
       ) : (
         <div className="flex flex-1 flex-col gap-4">
+          {requestedProviderMissing && requestedProvider ? (
+            <p className="text-[11px] text-text-tertiary">
+              No recording for {normalizeProviderName(requestedProvider)} at this point.
+            </p>
+          ) : null}
           <SampleOutputs
             items={items}
             normalizeProvider={normalizeProviderName}

--- a/web/hooks/useDashboardState.tsx
+++ b/web/hooks/useDashboardState.tsx
@@ -60,6 +60,10 @@ export function useDashboardState(page: "tts" | "stt" | "s2s") {
   const requestS2SPlay = useCallback((tick: string, provider: string) => {
     setS2sPlayRequest((prev) => ({ tick, provider, nonce: (prev?.nonce ?? 0) + 1 }));
   }, []);
+  // Releasing the request hands the card back to the newest tick. Without this a
+  // single click pins it forever, so landing on a day that has metrics but no
+  // recording leaves the card empty with no way back.
+  const clearS2SPlay = useCallback(() => setS2sPlayRequest(null), []);
   const { timeWindow, changeTimeWindow } = useTimeWindow(
     `${page}_dashboard`,
     page
@@ -644,6 +648,7 @@ export function useDashboardState(page: "tts" | "stt" | "s2s") {
     // S2S samples card <-> timeline tooltip bridge
     s2sPlayRequest,
     requestS2SPlay,
+    clearS2SPlay,
 
     // Display strings
     pageTitle,

--- a/web/hooks/useSequencedPlayback.ts
+++ b/web/hooks/useSequencedPlayback.ts
@@ -43,6 +43,11 @@ export interface SequencedPlayback {
   playFrom: (index: number) => void;
   handleEnded: () => void;
   stop: () => void;
+  // Playhead in seconds, and the loaded track's length (0 until known). `seek`
+  // moves within the current track — unlike playFrom, which restarts at 0.
+  currentTime: number;
+  duration: number;
+  seek: (seconds: number) => void;
 }
 
 // A playlist over one <audio> element: one click plays the active track, and
@@ -57,6 +62,8 @@ export function useSequencedPlayback(
   const audioRef = useRef<HTMLAudioElement | null>(null);
   const [activeIndex, setActiveIndex] = useState(0);
   const [isPlaying, setIsPlaying] = useState(false);
+  const [currentTime, setCurrentTime] = useState(0);
+  const [duration, setDuration] = useState(0);
 
   // Bumped by every operation that supersedes playback (new play, pause, stop,
   // unmount, track swap) so a late play() rejection can't clear a newer state.
@@ -89,6 +96,16 @@ export function useSequencedPlayback(
     }
     playingIdRef.current = null;
     setIsPlaying(false);
+    setCurrentTime(0);
+  }, []);
+
+  const seek = useCallback((seconds: number) => {
+    const audio = audioRef.current;
+    if (!audio) return;
+    const limit = Number.isFinite(audio.duration) ? audio.duration : seconds;
+    const target = Math.min(Math.max(seconds, 0), limit);
+    audio.currentTime = target;
+    setCurrentTime(target);
   }, []);
 
   const playFrom = useCallback(
@@ -102,6 +119,8 @@ export function useSequencedPlayback(
       onActivate?.(track, index);
       audio.src = track.url;
       audio.currentTime = 0;
+      setCurrentTime(0);
+      setDuration(0);
       requestPlay();
     },
     [tracks, onActivate, coordinator, pauseSelf, requestPlay]
@@ -151,6 +170,23 @@ export function useSequencedPlayback(
     }
   }, [tracks, activeIndex, stop]);
 
+  // Mirror the element's clock into state so a slider and the turn list can
+  // follow it. timeupdate fires a few times a second, enough for both.
+  useEffect(() => {
+    const audio = audioRef.current;
+    if (!audio) return;
+    const onTime = () => setCurrentTime(audio.currentTime);
+    const onMeta = () => setDuration(Number.isFinite(audio.duration) ? audio.duration : 0);
+    audio.addEventListener("timeupdate", onTime);
+    audio.addEventListener("loadedmetadata", onMeta);
+    audio.addEventListener("durationchange", onMeta);
+    return () => {
+      audio.removeEventListener("timeupdate", onTime);
+      audio.removeEventListener("loadedmetadata", onMeta);
+      audio.removeEventListener("durationchange", onMeta);
+    };
+  }, []);
+
   useEffect(
     () => () => {
       genRef.current++;
@@ -159,5 +195,16 @@ export function useSequencedPlayback(
     []
   );
 
-  return { audioRef, activeIndex, isPlaying, toggle, playFrom, handleEnded, stop };
+  return {
+    audioRef,
+    activeIndex,
+    isPlaying,
+    toggle,
+    playFrom,
+    handleEnded,
+    stop,
+    currentTime,
+    duration,
+    seek,
+  };
 }

--- a/web/lib/audioSamples/createSampleFeed.test.ts
+++ b/web/lib/audioSamples/createSampleFeed.test.ts
@@ -149,9 +149,42 @@ describe("parseS2SManifest", () => {
     expect(m.recordings[0]!.turns?.map((t) => t.role)).toEqual(["user", "assistant"]);
   });
 
+  it("reads turn offsets, and tolerates absent or null ones", () => {
+    const m = parseS2SManifest({
+      ...validManifest,
+      recordings: [
+        {
+          ...validManifest.recordings[0]!,
+          turns: [
+            { index: 0, role: "user", content: "hi", start_offset: 1.5, end_offset: 2.25 },
+            // Coval omitted the end; the runner writes null.
+            { index: 1, role: "assistant", content: "hello", start_offset: 3, end_offset: null },
+            // Published before offsets were captured — keys absent entirely.
+            { index: 2, role: "user", content: "bye" },
+          ],
+        },
+      ],
+    });
+    const turns = m.recordings[0]!.turns!;
+    expect(turns.map((t) => t.start_offset)).toEqual([1.5, 3, undefined]);
+    expect(turns.map((t) => t.end_offset)).toEqual([2.25, undefined, undefined]);
+  });
+
   it.each([
     ["null", null],
     ["missing recordings", { bucket_at: "x", test_case_id: "y", transcript: null, input_audio_url: null }],
+    [
+      "a non-finite turn offset",
+      {
+        ...validManifest,
+        recordings: [
+          {
+            ...validManifest.recordings[0]!,
+            turns: [{ index: 0, role: "user", content: "hi", start_offset: "1.5" }],
+          },
+        ],
+      },
+    ],
     ["recordings not an array", { ...validManifest, recordings: {} }],
     ["recording missing a string field", { ...validManifest, recordings: [{ provider: "openai" }] }],
     ["transcript wrong type", { ...validManifest, transcript: 42 }],

--- a/web/lib/audioSamples/s2sFeed.ts
+++ b/web/lib/audioSamples/s2sFeed.ts
@@ -7,10 +7,16 @@ import { createSampleFeed } from "./createSampleFeed";
 
 // One turn of a multi-turn conversation (v2 manifests). `role` is "user"
 // (the persona) or "assistant" (the agent); `index` is the turn's position.
+// The offsets are positions in the full recording, in seconds, and map 1:1 to
+// audio.currentTime. They are optional: manifests published before the sampler
+// captured them omit the keys, and Coval itself sometimes omits an offset on a
+// turn, which the runner writes as null.
 export interface S2STurn {
   index: number;
   role: string;
   content: string;
+  start_offset?: number;
+  end_offset?: number;
 }
 
 export interface S2SSampleRecording {
@@ -63,6 +69,18 @@ function asOptionalString(v: unknown, field: string): string | undefined {
   return asString(v, field);
 }
 
+// A turn offset in seconds. Absent and null both collapse to undefined: the key
+// is missing on manifests written before offsets were captured, and null when
+// Coval omitted it for that turn. Non-finite is rejected rather than coerced,
+// so a bad value can't silently become a playhead position.
+function asOptionalSeconds(v: unknown, field: string): number | undefined {
+  if (v === null || v === undefined) return undefined;
+  if (typeof v !== "number" || !Number.isFinite(v)) {
+    throw new Error(`${field} must be a finite number`);
+  }
+  return v;
+}
+
 // Manifests written before the sampler filtered them carry the persona's
 // `end_conversation` tool record as a `role: "tool"` turn whose content is raw
 // JSON. Drop anything that isn't spoken dialogue so it can't render as a caller
@@ -85,6 +103,8 @@ function parseTurns(v: unknown, field: string): S2STurn[] | undefined {
         index: turn.index,
         role: asString(turn.role, `${field}[${i}].role`),
         content: asString(turn.content, `${field}[${i}].content`),
+        start_offset: asOptionalSeconds(turn.start_offset, `${field}[${i}].start_offset`),
+        end_offset: asOptionalSeconds(turn.end_offset, `${field}[${i}].end_offset`),
       };
     })
     .filter((t) => SPOKEN_ROLES.has(t.role));


### PR DESCRIPTION
The sampler has been publishing per-turn offsets into each recording, but the dashboard dropped them on parse, so a sample could only be played start to finish. They are read now: the active pane gets a scrub bar with an elapsed readout, the turn under the playhead is highlighted, and any turn can be clicked to jump there. Offsets stay optional, so samples published before they were captured simply do not highlight.

Reaching those samples was the other half. Hiding the pre-multi-turn ticks to keep the card one shape had also made them unplayable, and they are four of the six days in the bucket. They render as panes with a play button and no turn list, and pane width no longer changes with the tick.

A pinned day now offers a way back to the latest, since a day can hold metrics without holding a recording, and a click naming a provider that day never recorded says so instead of going quiet.