### PR TITLE
Refit Arena to the Coval brand spec (BENCH-551)

### DIFF
--- a/web/app/arena/components/AudioPlayer.tsx
+++ b/web/app/arena/components/AudioPlayer.tsx
@@ -84,7 +84,7 @@ export function AudioPlayer({ src, label, isActive, onActivate, autoPlay, onEnde
         onClick={toggle}
         disabled={disabled}
         aria-label={disabled ? `${label} — generate to enable` : `${playing ? "Pause" : "Play"} ${label}`}
-        className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full border border-border-primary bg-surface-primary font-mono text-sm text-text-primary hover:bg-hover-bg disabled:cursor-not-allowed disabled:opacity-40"
+        className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full border border-border-primary bg-surface-primary font-mono text-sm text-text-primary hover:bg-hover-bg focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-text-tertiary/40 disabled:cursor-not-allowed disabled:opacity-40"
       >
         {playing ? "❚❚" : "▶"}
       </button>

--- a/web/app/arena/leaderboard/arena-leaderboard.tsx
+++ b/web/app/arena/leaderboard/arena-leaderboard.tsx
@@ -5,18 +5,14 @@
 
 import DashboardHeader from "@/components/layout/DashboardHeader";
 import DashboardFooter from "@/components/dashboard/DashboardFooter";
+import Card from "@/components/shared/Card";
+import { CymaticLoader } from "@/components/shared/CymaticLoader";
 import {
   normalizeModelName,
   normalizeTTSProviderName,
   toModelKey,
 } from "@/lib/utils/formatters";
-import { useArenaLeaderboardQuery, type ArenaLeaderboardEntry } from "@/lib/arena/leaderboard";
-
-function eloLabel(entry: ArenaLeaderboardEntry): string {
-  const elo = Math.round(entry.rating_elo);
-  if (entry.ci_half_width == null) return `${elo}`;
-  return `${elo} ± ${Math.round(entry.ci_half_width)}`;
-}
+import { useArenaLeaderboardQuery } from "@/lib/arena/leaderboard";
 
 export function ArenaLeaderboardPage() {
   const { data, isLoading, isError } = useArenaLeaderboardQuery();
@@ -29,29 +25,37 @@ export function ArenaLeaderboardPage() {
       <main className="relative z-10 mx-auto w-full max-w-3xl flex-1 px-4 pb-10 pt-[84px] sm:px-6 md:pt-[96px]">
         <h1 className="text-2xl font-medium tracking-tight sm:text-3xl">Voice Arena leaderboard</h1>
         <p className="mt-2 text-sm text-text-secondary">
-          Models ranked by Elo rating from blind A/B votes. Greyed rows are
-          provisional — the confidence interval is still wide.
+          Models ranked by Elo rating from blind A/B votes. Ratings marked
+          provisional have too few votes to separate them yet — their confidence
+          interval is still wide.
         </p>
 
-        {isLoading && <p className="mt-8 text-sm text-text-tertiary">Loading…</p>}
-        {isError && (
-          <p className="mt-8 text-sm text-text-tertiary">
-            Couldn’t load the leaderboard. Try again.
-          </p>
+        {isLoading && (
+          <div className="mt-8 flex justify-center">
+            <CymaticLoader size={40} animated className="text-text-primary" />
+          </div>
         )}
-        {isEmpty && (
-          <p className="mt-8 text-sm text-text-tertiary">No ratings yet. Vote to populate.</p>
+        {(isError || isEmpty) && (
+          <Card padding="p-4 sm:p-6 md:p-8" className="mt-6">
+            <p className="py-10 text-center text-sm text-text-tertiary">
+              {isError
+                ? "Couldn’t load the leaderboard. Try again."
+                : "No ratings yet. Vote to populate."}
+            </p>
+          </Card>
         )}
 
         {entries.length > 0 && (
-          <div className="mt-6 overflow-x-auto">
+          <Card padding="p-4 sm:p-6 md:p-8" className="mt-6">
             <table className="w-full border-collapse text-sm">
               <thead>
-                <tr className="border-b border-border-primary text-left font-mono text-xs text-text-tertiary">
-                  <th className="py-2 pr-4 font-medium">#</th>
+                <tr className="border-b border-border-primary text-left text-text-tertiary">
+                  <th className="w-8 py-2 pr-2 font-medium">#</th>
                   <th className="py-2 pr-4 font-medium">Model</th>
-                  <th className="py-2 pr-4 font-medium">Provider</th>
-                  <th className="whitespace-nowrap py-2 pr-4 text-right font-medium">Elo</th>
+                  <th className="hidden whitespace-nowrap py-2 pr-4 text-right font-medium sm:table-cell">
+                    Votes
+                  </th>
+                  <th className="whitespace-nowrap py-2 text-right font-medium">Elo</th>
                 </tr>
               </thead>
               <tbody>
@@ -60,26 +64,56 @@ export function ArenaLeaderboardPage() {
                   return (
                     <tr
                       key={`${entry.provider}/${entry.model}`}
-                      className={`border-b border-border-secondary ${
-                        preliminary ? "text-text-tertiary" : "text-text-primary"
-                      }`}
+                      className="border-b border-border-secondary last:border-b-0 hover:bg-hover-bg"
                     >
-                      <td className="py-2.5 pr-4 font-mono tabular-nums">{i + 1}</td>
-                      <td className="py-2.5 pr-4">
-                        {normalizeModelName(toModelKey(entry.provider, entry.model))}
+                      <td className="py-3 pr-2 align-top font-mono tabular-nums text-text-tertiary">
+                        {i + 1}
                       </td>
-                      <td className="py-2.5 pr-4 text-text-secondary">
-                        {normalizeTTSProviderName(entry.provider)}
+                      {/* Provider stacks under the model instead of taking its own column, so the
+                          table fits a phone without horizontal scroll. */}
+                      <td className="py-3 pr-4 align-top">
+                        <div
+                          className={`font-medium ${
+                            preliminary ? "text-text-tertiary" : "text-text-primary"
+                          }`}
+                        >
+                          {normalizeModelName(toModelKey(entry.provider, entry.model))}
+                        </div>
+                        <div className="text-xs text-text-tertiary">
+                          {normalizeTTSProviderName(entry.provider)}
+                          {/* The Votes column is hidden on phones, so carry the count here
+                              rather than dropping it off the small screen entirely. */}
+                          <span className="font-mono sm:hidden">
+                            {" · "}
+                            {entry.votes_total.toLocaleString()} votes
+                          </span>
+                          {/* Provisional was greying alone — a colour-only signal. */}
+                          {preliminary && <span className="font-mono uppercase"> provisional</span>}
+                        </div>
                       </td>
-                      <td className="whitespace-nowrap py-2.5 pr-4 text-right font-mono tabular-nums">
-                        {eloLabel(entry)}
+                      <td className="hidden py-3 pr-4 text-right align-top font-mono text-xs tabular-nums text-text-tertiary sm:table-cell">
+                        {entry.votes_total.toLocaleString()}
+                      </td>
+                      <td className="whitespace-nowrap py-3 text-right align-top">
+                        <span
+                          className={`font-mono text-base tabular-nums ${
+                            preliminary ? "text-text-tertiary" : "text-text-primary"
+                          }`}
+                        >
+                          {Math.round(entry.rating_elo)}
+                        </span>{" "}
+                        {entry.ci_half_width != null && (
+                          <span className="font-mono text-xs tabular-nums text-text-tertiary">
+                            ± {Math.round(entry.ci_half_width)}
+                          </span>
+                        )}
                       </td>
                     </tr>
                   );
                 })}
               </tbody>
             </table>
-          </div>
+          </Card>
         )}
       </main>
       <DashboardFooter />

--- a/web/app/arena/leaderboard/arena-leaderboard.tsx
+++ b/web/app/arena/leaderboard/arena-leaderboard.tsx
@@ -36,13 +36,11 @@ export function ArenaLeaderboardPage() {
           </div>
         )}
         {(isError || isEmpty) && (
-          <Card padding="p-4 sm:p-6 md:p-8" className="mt-6">
-            <p className="py-10 text-center text-sm text-text-tertiary">
-              {isError
-                ? "Couldn’t load the leaderboard. Try again."
-                : "No ratings yet. Vote to populate."}
-            </p>
-          </Card>
+          <p className="mt-8 text-sm text-text-tertiary">
+            {isError
+              ? "Couldn’t load the leaderboard. Try again."
+              : "No ratings yet. Vote to populate."}
+          </p>
         )}
 
         {entries.length > 0 && (

--- a/web/app/arena/leaderboard/arena-leaderboard.tsx
+++ b/web/app/arena/leaderboard/arena-leaderboard.tsx
@@ -19,20 +19,30 @@ export function ArenaLeaderboardPage() {
   const entries = data?.entries ?? [];
   const isEmpty = !isLoading && !isError && entries.length === 0;
 
+  // Every live rating is currently "preliminary", so a per-row badge fires on all 27 and
+  // greying by status drains the whole table to tertiary. Both only carry meaning once the
+  // board actually spans tiers; until then the state is stated once, above the table.
+  const statuses = new Set(entries.map((e) => e.status));
+  const mixedStatus = statuses.size > 1;
+  const allProvisional = statuses.size === 1 && statuses.has("preliminary");
+
   return (
     <div className="relative flex min-h-screen flex-col bg-background text-text-primary">
       <DashboardHeader />
       <main className="relative z-10 mx-auto w-full max-w-3xl flex-1 px-4 pb-10 pt-[84px] sm:px-6 md:pt-[96px]">
         <h1 className="text-2xl font-medium tracking-tight sm:text-3xl">Voice Arena leaderboard</h1>
         <p className="mt-2 text-sm text-text-secondary">
-          Models ranked by Elo rating from blind A/B votes. Ratings marked
-          provisional have too few votes to separate them yet — their confidence
-          interval is still wide.
+          Models ranked by Elo rating from blind A/B votes. The ± figure is the
+          confidence interval — the fewer votes a model has, the wider it runs.
+          {allProvisional && " Every rating is still provisional at these vote counts."}
+          {mixedStatus && " Ratings marked provisional have too few votes to separate them yet."}
         </p>
 
         {isLoading && (
-          <div className="mt-8 flex justify-center">
+          <div role="status" className="mt-8 flex justify-center">
+            {/* CymaticLoader is aria-hidden, so the spinner alone announces nothing. */}
             <CymaticLoader size={40} animated className="text-text-primary" />
+            <span className="sr-only">Loading the leaderboard…</span>
           </div>
         )}
         {(isError || isEmpty) && (
@@ -70,11 +80,7 @@ export function ArenaLeaderboardPage() {
                       {/* Provider stacks under the model instead of taking its own column, so the
                           table fits a phone without horizontal scroll. */}
                       <td className="py-3 pr-4 align-top">
-                        <div
-                          className={`font-medium ${
-                            preliminary ? "text-text-tertiary" : "text-text-primary"
-                          }`}
-                        >
+                        <div className="font-medium text-text-primary">
                           {normalizeModelName(toModelKey(entry.provider, entry.model))}
                         </div>
                         <div className="text-xs text-text-tertiary">
@@ -85,19 +91,16 @@ export function ArenaLeaderboardPage() {
                             {" · "}
                             {entry.votes_total.toLocaleString()} votes
                           </span>
-                          {/* Provisional was greying alone — a colour-only signal. */}
-                          {preliminary && <span className="font-mono uppercase"> provisional</span>}
+                          {mixedStatus && preliminary && (
+                            <span className="font-mono uppercase"> provisional</span>
+                          )}
                         </div>
                       </td>
                       <td className="hidden py-3 pr-4 text-right align-top font-mono text-xs tabular-nums text-text-tertiary sm:table-cell">
                         {entry.votes_total.toLocaleString()}
                       </td>
                       <td className="whitespace-nowrap py-3 text-right align-top">
-                        <span
-                          className={`font-mono text-base tabular-nums ${
-                            preliminary ? "text-text-tertiary" : "text-text-primary"
-                          }`}
-                        >
+                        <span className="font-mono text-base tabular-nums text-text-primary">
                           {Math.round(entry.rating_elo)}
                         </span>{" "}
                         {entry.ci_half_width != null && (

--- a/web/app/arena/leaderboard/arena-leaderboard.tsx
+++ b/web/app/arena/leaderboard/arena-leaderboard.tsx
@@ -47,7 +47,7 @@ export function ArenaLeaderboardPage() {
           <div className="mt-6 overflow-x-auto">
             <table className="w-full border-collapse text-sm">
               <thead>
-                <tr className="border-b border-border-primary text-left text-text-tertiary">
+                <tr className="border-b border-border-primary text-left font-mono text-xs text-text-tertiary">
                   <th className="py-2 pr-4 font-medium">#</th>
                   <th className="py-2 pr-4 font-medium">Model</th>
                   <th className="py-2 pr-4 font-medium">Provider</th>
@@ -64,14 +64,14 @@ export function ArenaLeaderboardPage() {
                         preliminary ? "text-text-tertiary" : "text-text-primary"
                       }`}
                     >
-                      <td className="py-2.5 pr-4 tabular-nums">{i + 1}</td>
+                      <td className="py-2.5 pr-4 font-mono tabular-nums">{i + 1}</td>
                       <td className="py-2.5 pr-4">
                         {normalizeModelName(toModelKey(entry.provider, entry.model))}
                       </td>
                       <td className="py-2.5 pr-4 text-text-secondary">
                         {normalizeTTSProviderName(entry.provider)}
                       </td>
-                      <td className="whitespace-nowrap py-2.5 pr-4 text-right tabular-nums">
+                      <td className="whitespace-nowrap py-2.5 pr-4 text-right font-mono tabular-nums">
                         {eloLabel(entry)}
                       </td>
                     </tr>

--- a/web/app/arena/page.tsx
+++ b/web/app/arena/page.tsx
@@ -162,13 +162,15 @@ export default function ArenaPage() {
   };
 
   const chainEnded = (side: "a" | "b") => {
-    if (!autoPlay) return;
-    if (side === "a") {
+    // Hand A off to B only while auto-playing. Every other ending releases focus, because
+    // `active` also drives the per-card playing dot — leaving it set kept a card lit with
+    // nothing playing once a manual listen finished.
+    if (autoPlay && side === "a") {
       setActive("b");
-    } else {
-      setAutoPlay(false);
-      setActive(null);
+      return;
     }
+    setAutoPlay(false);
+    setActive(null);
   };
 
   const trimmed = text.trim();

--- a/web/app/arena/page.tsx
+++ b/web/app/arena/page.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { useEffect, useRef, useState } from "react";
 import DashboardHeader from "@/components/layout/DashboardHeader";
+import { CymaticLoader } from "@/components/shared/CymaticLoader";
 import { ARENA_DOMAINS, type ArenaDomain } from "@/lib/arena/domains";
 import { getBattleSource } from "@/lib/arena/source";
 import type {
@@ -16,6 +17,14 @@ import { AudioPlayer } from "./components/AudioPlayer";
 
 const MIN_CHARS = 3;
 const MAX_CHARS = 500;
+
+// Brand focus state — the app-wide ring, so nothing here falls back to the
+// browser's off-palette blue outline.
+const FOCUS = "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-text-tertiary/40";
+const FIELD =
+  "w-full rounded-xl border border-border-primary bg-surface-elevated outline-none transition-colors focus:border-selected-border focus:ring-2 focus:ring-text-tertiary/40";
+// b1: PP Mori Semibold, 14px, 1% letter spacing (500 is the heaviest PP Mori weight we self-host).
+const BTN = `min-h-11 font-sans text-sm font-medium tracking-[0.01em] ${FOCUS}`;
 
 // Post-vote only: standings shown before a vote anchor the judgment, and votes are what
 // tightens the provisional CIs. Flip to false to pull the link entirely — /arena/leaderboard
@@ -171,37 +180,55 @@ export default function ArenaPage() {
       <DashboardHeader />
       <main className="min-h-screen bg-surface-primary px-6 pb-24 pt-32 text-text-primary">
         <div className="mx-auto flex max-w-[760px] flex-col gap-8">
-          <h1 className="text-center font-sans text-2xl">Which voice sounds more natural?</h1>
+          <h1 className="text-center font-sans text-2xl font-medium tracking-tight sm:text-3xl">
+            Which voice sounds more natural?
+          </h1>
 
           <section className="flex flex-col gap-3">
-            <select
-              value={domain}
-              onChange={(e) => setDomain(e.target.value as ArenaDomain | "")}
-              aria-label="Domain"
-              className="w-full appearance-none rounded-xl border border-border-primary bg-surface-elevated px-4 py-3 font-sans text-sm outline-none focus:border-selected-border"
-            >
-              <option value="" disabled>
-                Select a domain *
-              </option>
-              {ARENA_DOMAINS.map((d) => (
-                <option key={d.value} value={d.value}>
-                  {d.label}
+            <div className="relative">
+              <select
+                value={domain}
+                onChange={(e) => setDomain(e.target.value as ArenaDomain | "")}
+                aria-label="Domain"
+                className={`${FIELD} appearance-none px-4 py-3 pr-10 font-mono text-sm`}
+              >
+                <option value="" disabled>
+                  Select a domain *
                 </option>
-              ))}
-            </select>
+                {ARENA_DOMAINS.map((d) => (
+                  <option key={d.value} value={d.value}>
+                    {d.label}
+                  </option>
+                ))}
+              </select>
+              <svg
+                aria-hidden
+                viewBox="0 0 12 12"
+                className="pointer-events-none absolute right-4 top-1/2 h-3 w-3 -translate-y-1/2 text-text-tertiary"
+              >
+                <path
+                  d="M2.5 4.5 6 8l3.5-3.5"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="1.5"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            </div>
             <textarea
               value={text}
               maxLength={MAX_CHARS}
               onChange={(e) => setText(e.target.value)}
               placeholder="Describe a scenario or write text to synthesize…"
               rows={4}
-              className="w-full resize-none rounded-xl border border-border-primary bg-surface-elevated p-4 font-sans text-base leading-relaxed outline-none focus:border-selected-border"
+              className={`${FIELD} resize-none p-4 font-sans text-base leading-relaxed`}
             />
             <div className="flex items-center justify-between text-sm text-text-tertiary">
               <button
                 type="button"
                 onClick={() => void applyExample()}
-                className="flex min-h-11 items-center font-sans underline underline-offset-2 hover:text-text-secondary"
+                className={`${BTN} flex items-center rounded-md underline underline-offset-2 hover:text-text-secondary`}
               >
                 Use an example
               </button>
@@ -251,7 +278,7 @@ export default function ArenaPage() {
                 <button
                   type="button"
                   onClick={stopAutoAdvance}
-                  className="min-h-11 rounded-full border border-border-primary px-4 font-mono text-xs text-text-secondary hover:bg-hover-bg"
+                  className={`${BTN} rounded-full border border-border-primary px-4 text-text-secondary hover:bg-hover-bg`}
                 >
                   Stop
                 </button>
@@ -266,7 +293,7 @@ export default function ArenaPage() {
                 <label className="flex min-h-11 cursor-pointer items-center gap-2 self-center font-mono text-xs text-text-secondary">
                   <input
                     type="checkbox"
-                    className="h-5 w-5"
+                    className={`h-5 w-5 accent-text-primary ${FOCUS}`}
                     checked={autoAdvance}
                     onChange={() => persistAutoAdvance(!autoAdvance)}
                   />
@@ -281,14 +308,14 @@ export default function ArenaPage() {
                     ref={nextBattleRef}
                     type="button"
                     onClick={() => void quickBattle()}
-                    className="min-h-11 rounded-full bg-surface-toggle-active px-6 font-mono text-sm text-text-on-toggle-active"
+                    className={`${BTN} rounded-full bg-surface-toggle-active px-6 text-text-on-toggle-active`}
                   >
                     Another battle
                   </button>
                   <label className="flex min-h-11 cursor-pointer items-center gap-2 font-mono text-xs text-text-secondary">
                     <input
                       type="checkbox"
-                      className="h-5 w-5"
+                      className={`h-5 w-5 accent-text-primary ${FOCUS}`}
                       checked={autoAdvance}
                       onChange={() => persistAutoAdvance(!autoAdvance)}
                     />
@@ -297,7 +324,7 @@ export default function ArenaPage() {
                   {SHOW_LEADERBOARD_LINK && (
                     <Link
                       href="/arena/leaderboard"
-                      className="flex min-h-11 items-center rounded-full border border-border-primary px-6 font-mono text-sm text-text-secondary hover:bg-hover-bg"
+                      className={`${BTN} flex items-center rounded-full border border-border-primary px-6 text-text-secondary hover:bg-hover-bg`}
                     >
                       View leaderboard
                     </Link>
@@ -309,8 +336,9 @@ export default function ArenaPage() {
                 type="button"
                 onClick={() => void generate(text, domain)}
                 disabled={trimmed.length < MIN_CHARS || !domain || loading}
-                className="min-h-11 self-start rounded-full bg-surface-toggle-active px-6 font-mono text-sm text-text-on-toggle-active disabled:opacity-40"
+                className={`${BTN} inline-flex items-center gap-2 self-start rounded-full bg-surface-toggle-active px-6 text-text-on-toggle-active disabled:opacity-40`}
               >
+                {loading && <CymaticLoader size={16} animated />}
                 {loading ? "Generating…" : "Generate speech"}
               </button>
             )}
@@ -382,14 +410,19 @@ function BattleCard({
     >
       <div className="flex items-start justify-between gap-2">
         <span className="flex items-center gap-2">
-          <span className="mt-1 h-2 w-2 shrink-0 self-start rounded-full bg-text-tertiary" />
+          {/* Doubles as the playing indicator — the only cue outside the play glyph itself. */}
+          <span
+            className={`mt-1 h-2 w-2 shrink-0 self-start rounded-full ${
+              isActive ? "bg-text-primary" : "bg-text-tertiary"
+            }`}
+          />
           {revealed ? (
             <span className="flex flex-col leading-tight">
               <span className="font-sans text-sm text-text-primary">{revealed.model}</span>
               <span className="font-mono text-xs text-text-tertiary">{revealed.provider}</span>
             </span>
           ) : (
-            <span className="font-sans text-sm">{blindTitle}</span>
+            <span className="font-mono text-sm">{blindTitle}</span>
           )}
         </span>
         {picked !== null && (
@@ -424,7 +457,7 @@ function VoteButton({
       type="button"
       onClick={onClick}
       disabled={disabled}
-      className="min-h-11 rounded-xl border border-border-primary bg-surface-elevated py-3 font-mono text-sm hover:border-selected-border hover:bg-selected-bg disabled:opacity-40"
+      className={`${BTN} rounded-xl border border-border-primary bg-surface-elevated py-3 hover:border-selected-border hover:bg-selected-bg disabled:opacity-40`}
     >
       {label}
     </button>


### PR DESCRIPTION
Brand-spec refit of the two Arena pages. UI only — `lib/arena` and every API route are untouched, so the data path is identical to `main`.

## Voting page

- **Buttons were `font-mono`.** Brand b1 is PP Mori Semibold 14px / 1% tracking, which the rest of the app already uses — Arena was the outlier. One `BTN` constant now covers all of them. (500 is the heaviest PP Mori weight we self-host, so Semibold resolves to `font-medium`.)
- **Geist Mono** for data labels: domain value, blind `Model A` / `Model B`.
- **Focus states.** Replaced the browser's blue ring with the app's `ring-text-tertiary/40`. The fields had `outline-none` and nothing in its place, so keyboard users previously got no focus indicator at all. Checkboxes use `accent-text-primary` instead of browser blue.
- **The domain select had no chevron** — `appearance-none` stripped it with nothing put back, so it didn't read as a select. Reuses `WerDatasetSelect`'s SVG.
- Battle-card dots track playback instead of being static decoration.

## Leaderboard

- Table moved into a `Card` — it was the only content surface in the app sitting bare on the page background.
- Rows follow `ModelComparisonTable`: hover state, mono values, PP Mori headers. Elo splits into a mono value plus a smaller mono CI, like that table's `WER ± stdDev` cell.
- **Mobile:** provider stacks under the model name instead of taking its own column, dropping 4 columns to 3 so a phone no longer scrolls sideways to reach the Elo score. Votes are a column at `sm`+ and ride under the model name below that.
- Loading uses `CymaticLoader` in a `role="status"` — it's `aria-hidden`, so it announced nothing on its own.

## Worth a look: status is currently meaningless

On the live board **all 27 entries are `preliminary`** (votes 2–113). So `main`'s "greyed rows are provisional" greys every row and tells you nothing, and my first pass stacked a `PROVISIONAL` badge on all 27 rows on top of that.

Status now renders only when the board spans more than one tier. Names and Elo are full contrast, the badge comes back on its own once statuses diverge, and while everything is provisional the copy says so once above the table. The ± interval carries confidence instead — `1531 ± 265` at 2 votes against `1545 ± 68` at 112.

## Not included

- **Cymatic geometry for the players and vs divider** (brief item 4). Tried and backed out: `CymaticLoader` is a 20px loading glyph, and at player or divider scale its 144 beads read as gravel rather than a Chladni figure. Needs a component that actually renders the nodal form — worth its own ticket.
- **No surface changes.** The issue's dark-on-dark screenshot was the app's dark theme, not an Arena default; Arena already renders ink-on-white in light and matches `/stt` in dark.
- h1 keeps `tracking-tight` rather than the spec's +1%, matching the existing leaderboard h1. Easy to change if you'd rather both move to spec.

BENCH-546 covers the nav entry and the arena → overview flow.

## Verification

`lint`, `typecheck`, 82 tests and `build` all pass. Both pages checked in light and dark at desktop and 375px against the real 27-row payload; loading, error, empty, populated and post-vote reveal states all exercised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
