### PR TITLE
Mint a signed identity for every arena visitor

### DIFF
--- a/web/.env.example
+++ b/web/.env.example
@@ -38,6 +38,11 @@ ARENA_ACCESS_TOKEN=
 # HMAC key for the access cookie. 32+ random bytes, base64. Generate with:
 #   node -e "console.log(require('crypto').randomBytes(32).toString('base64'))"
 ARENA_SESSION_SECRET=
+# The outgoing ARENA_SESSION_SECRET, accepted for verification only. Rotating without it
+# invalidates every live cookie at once: labelers lose access and every voter is issued a
+# new identity. Set this to the current value BEFORE replacing ARENA_SESSION_SECRET, then
+# clear it once the 30-day cookie lifetime has passed.
+ARENA_SESSION_SECRET_PREVIOUS=
 # Runner base URL the BFF proxies to (e.g. http://localhost:8000). Server-side only.
 ARENA_API_URL=
 # Injected as X-Labeler-Key; must equal the runner's ARENA_LABELER_KEY.

--- a/web/lib/arena/access.test.ts
+++ b/web/lib/arena/access.test.ts
@@ -9,6 +9,7 @@ import {
   accessSecretConfigured,
   gateAllows,
   identified,
+  legacyLabeler,
   mintAccess,
   needsRefresh,
   verifyAccess,
@@ -116,8 +117,18 @@ describe("arena identity", () => {
     expect(identified(verified(old, NOW + 1))?.sid).toBe("sid-9");
   });
 
-  it("rejects an empty sid instead of reading it as a pre-identity cookie", () => {
-    const forged = signed(encode({ sid: "", iat: NOW, exp: NOW + 30 * DAY }));
+  it("rejects an empty sid", () => {
+    const forged = signed(encode({ sid: "", role: "labeler", iat: NOW, exp: NOW + 30 * DAY }));
+    expect(verifyAccess(forged, NOW)).toBeNull();
+  });
+
+  it("rejects a payload carrying a role but no sid", () => {
+    const forged = signed(encode({ role: "external", iat: NOW, exp: NOW + 30 * DAY }));
+    expect(verifyAccess(forged, NOW)).toBeNull();
+  });
+
+  it("rejects a payload carrying a sid but no role", () => {
+    const forged = signed(encode({ sid: "sid-1", iat: NOW, exp: NOW + 30 * DAY }));
     expect(verifyAccess(forged, NOW)).toBeNull();
   });
 
@@ -138,6 +149,13 @@ describe("arena gate", () => {
   it("honours a pre-identity cookie until the migration cutoff", () => {
     const legacy = signed(encode({ iat: NOW, exp: NOW + 30 * DAY }));
     expect(gateAllows(verified(legacy, NOW), NOW)).toBe(true);
+  });
+
+  // Verification rejects these outright, so this guards the second layer on its own: were
+  // that check ever loosened, a half-filled payload still must not read as pre-identity.
+  it("does not read a half-filled payload as a pre-identity cookie", () => {
+    expect(legacyLabeler({ role: "external", iat: NOW, exp: NOW + 30 * DAY }, NOW)).toBe(false);
+    expect(legacyLabeler({ sid: "sid-1", iat: NOW, exp: NOW + 30 * DAY }, NOW)).toBe(false);
   });
 
   it("stops honouring a pre-identity cookie once the cutoff passes", () => {

--- a/web/lib/arena/access.test.ts
+++ b/web/lib/arena/access.test.ts
@@ -1,43 +1,61 @@
 // Copyright 2026 The Coval Benchmarks Authors
 // SPDX-License-Identifier: Apache-2.0
 
-import { beforeEach, describe, expect, it } from "vitest";
-import { mintAccess, needsRefresh, verifyAccess } from "./access";
+import { createHmac } from "node:crypto";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { type AccessPayload, identified, mintAccess, needsRefresh, verifyAccess } from "./access";
 
 const DAY = 24 * 60 * 60 * 1000;
+const NOW = 1_000_000;
 
 beforeEach(() => {
   process.env.ARENA_SESSION_SECRET = "test-arena-session-secret";
 });
 
+afterEach(() => {
+  delete process.env.ARENA_SESSION_SECRET_PREVIOUS;
+});
+
+/** Verify and assert, so tests read without non-null assertions everywhere. */
+function verified(token: string, now: number = NOW): AccessPayload {
+  const payload = verifyAccess(token, now);
+  if (payload === null) throw new Error("expected a valid payload");
+  return payload;
+}
+
+/** Sign an arbitrary payload body the way the module does, for hand-built cookies. */
+function signed(body: string): string {
+  const secret = process.env.ARENA_SESSION_SECRET ?? "";
+  return `${body}.${createHmac("sha256", secret).update(body).digest("base64url")}`;
+}
+
+function encode(payload: Record<string, unknown>): string {
+  return Buffer.from(JSON.stringify(payload)).toString("base64url");
+}
+
 describe("arena access cookie", () => {
   it("mints a token that verifies and carries a future expiry", () => {
-    const now = 1_000_000;
-    const payload = verifyAccess(mintAccess(now), now + 1000);
-    expect(payload).not.toBeNull();
-    expect(payload?.exp).toBeGreaterThan(now);
+    expect(verified(mintAccess("external", "sid-1", NOW), NOW + 1000).exp).toBeGreaterThan(NOW);
   });
 
   it("rejects a tampered signature", () => {
-    const [body = ""] = mintAccess(1_000_000).split(".");
+    const [body = ""] = mintAccess("external", "sid-1", NOW).split(".");
     expect(verifyAccess(`${body}.deadbeef`)).toBeNull();
   });
 
   it("rejects a tampered payload", () => {
-    const [, sig = ""] = mintAccess(1_000_000).split(".");
-    const forged = Buffer.from(JSON.stringify({ iat: 0, exp: 9e15 })).toString("base64url");
-    expect(verifyAccess(`${forged}.${sig}`)).toBeNull();
+    const [, sig = ""] = mintAccess("external", "sid-1", NOW).split(".");
+    expect(verifyAccess(`${encode({ iat: 0, exp: 9e15 })}.${sig}`)).toBeNull();
   });
 
   it("rejects an expired token", () => {
-    const now = 1_000_000;
-    expect(verifyAccess(mintAccess(now), now + 31 * DAY)).toBeNull();
+    expect(verifyAccess(mintAccess("external", "sid-1", NOW), NOW + 31 * DAY)).toBeNull();
   });
 
   it("rejects a token signed with a different secret", () => {
-    const token = mintAccess(1_000_000);
+    const token = mintAccess("external", "sid-1", NOW);
     process.env.ARENA_SESSION_SECRET = "a-different-secret";
-    expect(verifyAccess(token, 1_000_001)).toBeNull();
+    expect(verifyAccess(token, NOW + 1)).toBeNull();
   });
 
   it("returns null for missing or malformed tokens", () => {
@@ -46,10 +64,46 @@ describe("arena access cookie", () => {
   });
 
   it("refreshes only after the refresh interval (1 day)", () => {
-    const now = 1_000_000;
-    const payload = verifyAccess(mintAccess(now), now);
-    if (payload === null) throw new Error("expected a valid payload");
-    expect(needsRefresh(payload, now + 60_000)).toBe(false); // 1 min later
-    expect(needsRefresh(payload, now + 2 * DAY)).toBe(true); // 2 days later
+    const payload = verified(mintAccess("external", "sid-1", NOW), NOW);
+    expect(needsRefresh(payload, NOW + 60_000)).toBe(false); // 1 min later
+    expect(needsRefresh(payload, NOW + 2 * DAY)).toBe(true); // 2 days later
+  });
+});
+
+describe("arena identity", () => {
+  it("carries the sid and role it was minted with", () => {
+    const payload = verified(mintAccess("labeler", "sid-42", NOW), NOW);
+    expect(identified(payload)).toMatchObject({ sid: "sid-42", role: "labeler" });
+  });
+
+  it("keeps the same sid across a refresh so a voter stays recognisable", () => {
+    const first = identified(verified(mintAccess("external", "sid-7", NOW), NOW));
+    if (first === null) throw new Error("expected an identified payload");
+    const rolled = verified(mintAccess("external", first.sid, NOW + 2 * DAY), NOW + 2 * DAY);
+    expect(identified(rolled)?.sid).toBe("sid-7");
+  });
+
+  it("mints a distinct sid when none is supplied", () => {
+    const now = Date.now();
+    const a = identified(verified(mintAccess("external"), now))?.sid;
+    const b = identified(verified(mintAccess("external"), now))?.sid;
+    expect(a).not.toBe(b);
+  });
+
+  it("treats a pre-identity cookie as verified but unidentified", () => {
+    const legacy = signed(encode({ iat: NOW, exp: NOW + 30 * DAY }));
+    expect(identified(verified(legacy, NOW))).toBeNull();
+  });
+
+  it("rejects a role outside the known set", () => {
+    const forged = signed(encode({ sid: "sid-1", role: "admin", iat: NOW, exp: NOW + 30 * DAY }));
+    expect(verifyAccess(forged, NOW)).toBeNull();
+  });
+
+  it("accepts a cookie signed with the previous secret during rotation", () => {
+    const old = mintAccess("labeler", "sid-9", NOW);
+    process.env.ARENA_SESSION_SECRET_PREVIOUS = "test-arena-session-secret";
+    process.env.ARENA_SESSION_SECRET = "rotated-secret";
+    expect(identified(verified(old, NOW + 1))?.sid).toBe("sid-9");
   });
 });

--- a/web/lib/arena/access.test.ts
+++ b/web/lib/arena/access.test.ts
@@ -3,7 +3,16 @@
 
 import { createHmac } from "node:crypto";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { type AccessPayload, identified, mintAccess, needsRefresh, verifyAccess } from "./access";
+import {
+  type AccessPayload,
+  LEGACY_LABELER_UNTIL,
+  accessSecretConfigured,
+  gateAllows,
+  identified,
+  mintAccess,
+  needsRefresh,
+  verifyAccess,
+} from "./access";
 
 const DAY = 24 * 60 * 60 * 1000;
 const NOW = 1_000_000;
@@ -105,5 +114,52 @@ describe("arena identity", () => {
     process.env.ARENA_SESSION_SECRET_PREVIOUS = "test-arena-session-secret";
     process.env.ARENA_SESSION_SECRET = "rotated-secret";
     expect(identified(verified(old, NOW + 1))?.sid).toBe("sid-9");
+  });
+
+  it("rejects an empty sid instead of reading it as a pre-identity cookie", () => {
+    const forged = signed(encode({ sid: "", iat: NOW, exp: NOW + 30 * DAY }));
+    expect(verifyAccess(forged, NOW)).toBeNull();
+  });
+
+  it("rejects a token at the exact expiry instant", () => {
+    expect(verifyAccess(mintAccess("external", "sid-1", NOW), NOW + 30 * DAY)).toBeNull();
+  });
+});
+
+describe("arena gate", () => {
+  it("lets a labeler reach the gated surfaces", () => {
+    expect(gateAllows(verified(mintAccess("labeler", "sid-1", NOW)), NOW)).toBe(true);
+  });
+
+  it("keeps an external visitor out, signed cookie and all", () => {
+    expect(gateAllows(verified(mintAccess("external", "sid-1", NOW)), NOW)).toBe(false);
+  });
+
+  it("honours a pre-identity cookie until the migration cutoff", () => {
+    const legacy = signed(encode({ iat: NOW, exp: NOW + 30 * DAY }));
+    expect(gateAllows(verified(legacy, NOW), NOW)).toBe(true);
+  });
+
+  it("stops honouring a pre-identity cookie once the cutoff passes", () => {
+    const at = LEGACY_LABELER_UNTIL;
+    const legacy = signed(encode({ iat: at, exp: at + 30 * DAY }));
+    expect(gateAllows(verified(legacy, at), at)).toBe(false);
+  });
+});
+
+describe("arena session secret", () => {
+  it("treats a missing secret as unconfigured", () => {
+    delete process.env.ARENA_SESSION_SECRET;
+    expect(accessSecretConfigured()).toBe(false);
+  });
+
+  it("treats a secret shorter than 32 characters as unconfigured", () => {
+    process.env.ARENA_SESSION_SECRET = "x".repeat(31);
+    expect(accessSecretConfigured()).toBe(false);
+  });
+
+  it("accepts a secret of at least 32 characters", () => {
+    process.env.ARENA_SESSION_SECRET = "x".repeat(32);
+    expect(accessSecretConfigured()).toBe(true);
   });
 });

--- a/web/lib/arena/access.ts
+++ b/web/lib/arena/access.ts
@@ -1,18 +1,33 @@
-import { createHmac, timingSafeEqual } from "node:crypto";
+import { createHmac, randomUUID, timingSafeEqual } from "node:crypto";
 
 const SECRET_ENV = "ARENA_SESSION_SECRET";
+const SECRET_PREVIOUS_ENV = "ARENA_SESSION_SECRET_PREVIOUS";
 const TTL_MS = 30 * 24 * 60 * 60 * 1000; // 30 days of inactivity before lock-out
 const REFRESH_AFTER_MS = 24 * 60 * 60 * 1000; // re-issue at most once/day (sliding window)
 
 export const ACCESS_COOKIE_NAME = "arena_access";
 export const ACCESS_COOKIE_MAX_AGE_S = TTL_MS / 1000;
 
-export type AccessPayload = { iat: number; exp: number };
+// Disjoint paths, so a request matches exactly one and the browser never holds two
+// cookies of this name. Cookies issued before scoping used "/" and are expired on sight.
+export const ACCESS_COOKIE_PATHS = ["/arena", "/api/arena"] as const;
+
+export type ArenaRole = "labeler" | "external";
+
+/** A verified cookie. `sid`/`role` are absent on cookies minted before identity existed. */
+export type AccessPayload = { sid?: string; role?: ArenaRole; iat: number; exp: number };
+
+/** A cookie carrying identity — what the BFF requires before attributing a vote. */
+export type IdentifiedAccess = { sid: string; role: ArenaRole; iat: number; exp: number };
 
 function requireSecret(): string {
   const value = process.env[SECRET_ENV];
   if (!value) throw new Error(`${SECRET_ENV} is not configured`);
   return value;
+}
+
+export function accessSecretConfigured(): boolean {
+  return Boolean(process.env[SECRET_ENV]);
 }
 
 function b64url(buf: Buffer): string {
@@ -35,8 +50,19 @@ export function safeEqual(a: string, b: string): boolean {
   return timingSafeEqual(aBuf, bBuf);
 }
 
-export function mintAccess(now: number = Date.now()): string {
-  const payload: AccessPayload = { iat: now, exp: now + TTL_MS };
+/**
+ * Issue a cookie for `role`, reusing `sid` when refreshing an existing one.
+ *
+ * Passing the previous `sid` is what keeps a voter recognisable across the sliding
+ * refresh — minting a fresh one every 24h would weaken vote dedupe and strip any
+ * cross-day signal from later scoring.
+ */
+export function mintAccess(
+  role: ArenaRole,
+  sid: string = randomUUID(),
+  now: number = Date.now(),
+): string {
+  const payload: IdentifiedAccess = { sid, role, iat: now, exp: now + TTL_MS };
   const body = b64url(Buffer.from(JSON.stringify(payload)));
   return `${body}.${sign(body, requireSecret())}`;
 }
@@ -49,7 +75,10 @@ export function verifyAccess(
   const parts = token.split(".");
   if (parts.length !== 2) return null;
   const [body, sig] = parts as [string, string];
-  if (!safeEqual(sig, sign(body, requireSecret()))) return null;
+
+  const previous = process.env[SECRET_PREVIOUS_ENV];
+  const secrets = previous ? [requireSecret(), previous] : [requireSecret()];
+  if (!secrets.some((secret) => safeEqual(sig, sign(body, secret)))) return null;
 
   let payload: AccessPayload;
   try {
@@ -59,7 +88,17 @@ export function verifyAccess(
   }
   if (typeof payload?.iat !== "number" || typeof payload?.exp !== "number") return null;
   if (now > payload.exp) return null;
+  if (payload.sid !== undefined && typeof payload.sid !== "string") return null;
+  if (payload.role !== undefined && payload.role !== "labeler" && payload.role !== "external") {
+    return null;
+  }
   return payload;
+}
+
+/** Narrow a verified cookie to one that actually carries identity. */
+export function identified(payload: AccessPayload): IdentifiedAccess | null {
+  if (!payload.sid || !payload.role) return null;
+  return { sid: payload.sid, role: payload.role, iat: payload.iat, exp: payload.exp };
 }
 
 export function needsRefresh(payload: AccessPayload, now: number = Date.now()): boolean {

--- a/web/lib/arena/access.ts
+++ b/web/lib/arena/access.ts
@@ -26,8 +26,14 @@ function requireSecret(): string {
   return value;
 }
 
+// Below this, treat the secret as absent rather than sign with it: a short secret yields a
+// forgeable cookie, and failing closed beats quietly accepting one. The previous secret is
+// deliberately exempt — it is verification-only, and rejecting it would lock out the live
+// cookies rotation exists to preserve.
+const SECRET_MIN_LENGTH = 32;
+
 export function accessSecretConfigured(): boolean {
-  return Boolean(process.env[SECRET_ENV]);
+  return (process.env[SECRET_ENV] ?? "").length >= SECRET_MIN_LENGTH;
 }
 
 function b64url(buf: Buffer): string {
@@ -87,8 +93,12 @@ export function verifyAccess(
     return null;
   }
   if (typeof payload?.iat !== "number" || typeof payload?.exp !== "number") return null;
-  if (now > payload.exp) return null;
-  if (payload.sid !== undefined && typeof payload.sid !== "string") return null;
+  if (now >= payload.exp) return null;
+  // An empty sid would pass a bare string check and then fail `identified`, landing on the
+  // legacy branch below — i.e. reading as a labeler. Reject it here instead.
+  if (payload.sid !== undefined && (typeof payload.sid !== "string" || payload.sid === "")) {
+    return null;
+  }
   if (payload.role !== undefined && payload.role !== "labeler" && payload.role !== "external") {
     return null;
   }
@@ -99,6 +109,32 @@ export function verifyAccess(
 export function identified(payload: AccessPayload): IdentifiedAccess | null {
   if (!payload.sid || !payload.role) return null;
   return { sid: payload.sid, role: payload.role, iat: payload.iat, exp: payload.exp };
+}
+
+/**
+ * When a cookie predating identity stops counting as a labeler.
+ *
+ * Such cookies could only have come from the unlock link, so honouring them keeps the
+ * internal labelers signed in across this change. None can be minted any more, and each
+ * is reissued with a `sid` on its owner's next visit, so the allowance is spent well
+ * before this date. The bound is wall-clock on purpose: `iat` sits inside the payload a
+ * forger would control, so comparing against it would guard nothing.
+ */
+export const LEGACY_LABELER_UNTIL = Date.UTC(2026, 8, 1);
+
+export function legacyLabeler(payload: AccessPayload, now: number = Date.now()): boolean {
+  return identified(payload) === null && now < LEGACY_LABELER_UNTIL;
+}
+
+/**
+ * Whether a verified cookie may reach the gated arena surfaces.
+ *
+ * `external` is minted for anyone who merely loaded a public arena page, and its cookie is
+ * path-scoped to /arena and /api/arena — so it is sent to the gated routes too, and the
+ * role is the only thing keeping it out of them.
+ */
+export function gateAllows(payload: AccessPayload, now: number = Date.now()): boolean {
+  return identified(payload)?.role === "labeler" || legacyLabeler(payload, now);
 }
 
 export function needsRefresh(payload: AccessPayload, now: number = Date.now()): boolean {

--- a/web/lib/arena/access.ts
+++ b/web/lib/arena/access.ts
@@ -94,14 +94,14 @@ export function verifyAccess(
   }
   if (typeof payload?.iat !== "number" || typeof payload?.exp !== "number") return null;
   if (now >= payload.exp) return null;
-  // An empty sid would pass a bare string check and then fail `identified`, landing on the
-  // legacy branch below — i.e. reading as a labeler. Reject it here instead.
-  if (payload.sid !== undefined && (typeof payload.sid !== "string" || payload.sid === "")) {
-    return null;
-  }
-  if (payload.role !== undefined && payload.role !== "labeler" && payload.role !== "external") {
-    return null;
-  }
+  // Identity is both fields or neither. Nothing mints a half-filled payload, and one that
+  // arrives fails `identified` and so reads as a cookie predating identity — which the gate
+  // honours as a labeler. An explicit `role: "external"` would then arrive as a grant.
+  const hasSid = payload.sid !== undefined;
+  const hasRole = payload.role !== undefined;
+  if (hasSid !== hasRole) return null;
+  if (hasSid && (typeof payload.sid !== "string" || payload.sid === "")) return null;
+  if (hasRole && payload.role !== "labeler" && payload.role !== "external") return null;
   return payload;
 }
 
@@ -123,7 +123,9 @@ export function identified(payload: AccessPayload): IdentifiedAccess | null {
 export const LEGACY_LABELER_UNTIL = Date.UTC(2026, 8, 1);
 
 export function legacyLabeler(payload: AccessPayload, now: number = Date.now()): boolean {
-  return identified(payload) === null && now < LEGACY_LABELER_UNTIL;
+  // Both fields absent, not merely `identified` returning null — that is also true of a
+  // half-filled payload, which is a different thing and must not be honoured.
+  return payload.sid === undefined && payload.role === undefined && now < LEGACY_LABELER_UNTIL;
 }
 
 /**

--- a/web/lib/arena/guard.ts
+++ b/web/lib/arena/guard.ts
@@ -1,8 +1,13 @@
 import { cookies } from "next/headers";
-import { ACCESS_COOKIE_NAME, verifyAccess } from "./access";
+import { ACCESS_COOKIE_NAME, accessSecretConfigured, gateAllows, verifyAccess } from "./access";
 
+/**
+ * Whether the caller may read an admin route. Middleware gates these paths first; this is
+ * the same decision made again at the route, so a matcher change cannot quietly open them.
+ */
 export async function arenaAccessOk(): Promise<boolean> {
   if (process.env.NODE_ENV !== "production") return true;
-  const token = (await cookies()).get(ACCESS_COOKIE_NAME)?.value;
-  return verifyAccess(token) !== null;
+  if (!accessSecretConfigured()) return false;
+  const payload = verifyAccess((await cookies()).get(ACCESS_COOKIE_NAME)?.value);
+  return payload !== null && gateAllows(payload);
 }

--- a/web/middleware.ts
+++ b/web/middleware.ts
@@ -2,6 +2,10 @@ import { NextResponse, type NextRequest } from "next/server";
 import {
   ACCESS_COOKIE_MAX_AGE_S,
   ACCESS_COOKIE_NAME,
+  ACCESS_COOKIE_PATHS,
+  type ArenaRole,
+  accessSecretConfigured,
+  identified,
   mintAccess,
   needsRefresh,
   safeEqual,
@@ -11,9 +15,9 @@ import { COOKIE_NAME, COOKIE_PATHS, mintSession, verifySession } from "@/lib/pla
 
 export const runtime = "nodejs";
 
-function buildCookieHeader(value: string, path: string, expires: Date): string {
+function buildCookieHeader(name: string, value: string, path: string, expires: Date): string {
   const parts = [
-    `${COOKIE_NAME}=${value}`,
+    `${name}=${value}`,
     `Path=${path}`,
     `Expires=${expires.toUTCString()}`,
     "HttpOnly",
@@ -23,14 +27,62 @@ function buildCookieHeader(value: string, path: string, expires: Date): string {
   return parts.join("; ");
 }
 
-function setAccessCookie(res: NextResponse): void {
-  res.cookies.set(ACCESS_COOKIE_NAME, mintAccess(), {
-    httpOnly: true,
-    sameSite: "lax",
-    secure: true,
-    path: "/",
-    maxAge: ACCESS_COOKIE_MAX_AGE_S,
-  });
+/**
+ * Issue the arena identity cookie over both scoped paths, retiring any unscoped one.
+ *
+ * The pre-scoping cookie sat at "/" and still prefix-matches /arena, so leaving it in
+ * place would have the browser send two cookies of the same name and pick between them
+ * by path length. Expiring it in the same response keeps that from happening, and costs
+ * the visitor nothing.
+ */
+function setIdentityCookie(res: NextResponse, token: string): void {
+  const expires = new Date(Date.now() + ACCESS_COOKIE_MAX_AGE_S * 1000);
+  for (const path of ACCESS_COOKIE_PATHS) {
+    res.headers.append("Set-Cookie", buildCookieHeader(ACCESS_COOKIE_NAME, token, path, expires));
+  }
+  res.headers.append(
+    "Set-Cookie",
+    buildCookieHeader(ACCESS_COOKIE_NAME, "", "/", new Date(0)),
+  );
+}
+
+/** The unlock link, when it carries the right token: mint a labeler and clean the URL. */
+function unlockedAsLabeler(req: NextRequest): NextResponse | null {
+  const token = process.env.ARENA_ACCESS_TOKEN;
+  const provided = req.nextUrl.searchParams.get("access");
+  if (!token || !provided || !safeEqual(provided, token)) return null;
+  const url = req.nextUrl.clone();
+  url.searchParams.delete("access");
+  const res = NextResponse.redirect(url);
+  setIdentityCookie(res, mintAccess("labeler"));
+  return res;
+}
+
+function reissue(res: NextResponse, role: ArenaRole, sid?: string): void {
+  setIdentityCookie(res, sid === undefined ? mintAccess(role) : mintAccess(role, sid));
+}
+
+/**
+ * Give every visitor to a public arena surface a signed identity.
+ *
+ * Votes are attributed to the `sid` in this cookie, so a visitor without one cannot be
+ * held to a quota or judged by later scoring. Cookies predating identity belong to the
+ * internal labelers who were here before the arena opened, so they are reissued as
+ * `labeler`; everyone arriving since is `external`.
+ */
+function ensureArenaIdentity(req: NextRequest): NextResponse {
+  if (!accessSecretConfigured()) return NextResponse.next();
+
+  const unlocked = unlockedAsLabeler(req);
+  if (unlocked) return unlocked;
+
+  const res = NextResponse.next();
+  const payload = verifyAccess(req.cookies.get(ACCESS_COOKIE_NAME)?.value);
+  const current = payload && identified(payload);
+  if (!payload) reissue(res, "external");
+  else if (!current) reissue(res, "labeler");
+  else if (needsRefresh(current)) reissue(res, current.role, current.sid);
+  return res;
 }
 
 function arenaGate(req: NextRequest): NextResponse {
@@ -38,23 +90,17 @@ function arenaGate(req: NextRequest): NextResponse {
   if (process.env.NODE_ENV !== "production") return NextResponse.next();
 
   const token = process.env.ARENA_ACCESS_TOKEN;
-  const secret = process.env.ARENA_SESSION_SECRET;
-  if (!token || !secret) return new NextResponse(null, { status: 404 }); // fail closed if misconfigured
+  if (!token || !accessSecretConfigured()) return new NextResponse(null, { status: 404 });
 
-  // Unlock link: ?access=<token> -> mint cookie, redirect to the clean URL.
-  const provided = req.nextUrl.searchParams.get("access");
-  if (provided && safeEqual(provided, token)) {
-    const url = req.nextUrl.clone();
-    url.searchParams.delete("access");
-    const res = NextResponse.redirect(url);
-    setAccessCookie(res);
-    return res;
-  }
+  const unlocked = unlockedAsLabeler(req);
+  if (unlocked) return unlocked;
 
   const payload = verifyAccess(req.cookies.get(ACCESS_COOKIE_NAME)?.value);
   if (payload) {
     const res = NextResponse.next();
-    if (needsRefresh(payload)) setAccessCookie(res); // sliding window
+    const current = identified(payload);
+    if (!current) reissue(res, "labeler");
+    else if (needsRefresh(current)) reissue(res, current.role, current.sid);
     return res;
   }
 
@@ -70,7 +116,7 @@ function playgroundSession(req: NextRequest): NextResponse {
   const { token, expiresAt } = mintSession();
   const expires = new Date(expiresAt);
   for (const path of COOKIE_PATHS) {
-    response.headers.append("Set-Cookie", buildCookieHeader(token, path, expires));
+    response.headers.append("Set-Cookie", buildCookieHeader(COOKIE_NAME, token, path, expires));
   }
   return response;
 }
@@ -101,7 +147,7 @@ function isPublicArenaPath(pathname: string): boolean {
 export function middleware(req: NextRequest): NextResponse {
   const { pathname } = req.nextUrl;
   if (pathname.startsWith("/arena") || pathname.startsWith("/api/arena")) {
-    return isPublicArenaPath(pathname) ? NextResponse.next() : arenaGate(req);
+    return isPublicArenaPath(pathname) ? ensureArenaIdentity(req) : arenaGate(req);
   }
   return playgroundSession(req);
 }

--- a/web/middleware.ts
+++ b/web/middleware.ts
@@ -5,7 +5,9 @@ import {
   ACCESS_COOKIE_PATHS,
   type ArenaRole,
   accessSecretConfigured,
+  gateAllows,
   identified,
+  legacyLabeler,
   mintAccess,
   needsRefresh,
   safeEqual,
@@ -64,16 +66,25 @@ function reissue(res: NextResponse, role: ArenaRole, sid?: string): void {
 
 /**
  * Say so when identity is off, rather than serving an arena that quietly attributes
- * nothing. Once per instance: enough to alert on, without a line per request.
+ * nothing.
+ *
+ * Rate-limited rather than once-per-instance: a warm instance would otherwise report the
+ * outage once and then go quiet for as long as it lives, which is the wrong shape for
+ * something you want to alert on.
  */
-let reportedMissingSecret = false;
+const IDENTITY_REPORT_INTERVAL_MS = 10 * 60 * 1000;
+let identityLastReportedAt = 0;
 
 function reportIdentityDisabled(): void {
-  if (reportedMissingSecret || process.env.NODE_ENV !== "production") return;
-  reportedMissingSecret = true;
+  if (process.env.NODE_ENV !== "production") return;
+  const now = Date.now();
+  if (identityLastReportedAt !== 0 && now - identityLastReportedAt < IDENTITY_REPORT_INTERVAL_MS) {
+    return;
+  }
+  identityLastReportedAt = now;
   console.error(
-    "arena identity disabled: ARENA_SESSION_SECRET is not configured, so no visitor is " +
-      "issued a signed identity and no vote can be attributed",
+    "arena identity disabled: ARENA_SESSION_SECRET is missing or shorter than the required " +
+      "32 characters, so no visitor is issued a signed identity and no vote can be attributed",
   );
 }
 
@@ -100,7 +111,8 @@ function ensureArenaIdentity(req: NextRequest): NextResponse {
   const payload = verifyAccess(req.cookies.get(ACCESS_COOKIE_NAME)?.value);
   const current = payload && identified(payload);
   if (!payload) reissue(res, "external");
-  else if (!current) reissue(res, "labeler");
+  else if (legacyLabeler(payload)) reissue(res, "labeler");
+  else if (!current) reissue(res, "external");
   else if (needsRefresh(current)) reissue(res, current.role, current.sid);
   return res;
 }
@@ -115,8 +127,11 @@ function arenaGate(req: NextRequest): NextResponse {
   const unlocked = unlockedAsLabeler(req);
   if (unlocked) return unlocked;
 
+  // A signature alone is not enough: every public visitor now holds a validly signed
+  // `external` cookie, and it is sent here because it is scoped to /arena. Only a labeler
+  // gets through.
   const payload = verifyAccess(req.cookies.get(ACCESS_COOKIE_NAME)?.value);
-  if (payload) {
+  if (payload && gateAllows(payload)) {
     const res = NextResponse.next();
     const current = identified(payload);
     if (!current) reissue(res, "labeler");

--- a/web/middleware.ts
+++ b/web/middleware.ts
@@ -63,6 +63,21 @@ function reissue(res: NextResponse, role: ArenaRole, sid?: string): void {
 }
 
 /**
+ * Say so when identity is off, rather than serving an arena that quietly attributes
+ * nothing. Once per instance: enough to alert on, without a line per request.
+ */
+let reportedMissingSecret = false;
+
+function reportIdentityDisabled(): void {
+  if (reportedMissingSecret || process.env.NODE_ENV !== "production") return;
+  reportedMissingSecret = true;
+  console.error(
+    "arena identity disabled: ARENA_SESSION_SECRET is not configured, so no visitor is " +
+      "issued a signed identity and no vote can be attributed",
+  );
+}
+
+/**
  * Give every visitor to a public arena surface a signed identity.
  *
  * Votes are attributed to the `sid` in this cookie, so a visitor without one cannot be
@@ -71,7 +86,12 @@ function reissue(res: NextResponse, role: ArenaRole, sid?: string): void {
  * `labeler`; everyone arriving since is `external`.
  */
 function ensureArenaIdentity(req: NextRequest): NextResponse {
-  if (!accessSecretConfigured()) return NextResponse.next();
+  // Serve the arena anyway — a misconfigured secret should not take the public page
+  // down — but never silently.
+  if (!accessSecretConfigured()) {
+    reportIdentityDisabled();
+    return NextResponse.next();
+  }
 
   const unlocked = unlockedAsLabeler(req);
   if (unlocked) return unlocked;


### PR DESCRIPTION
The arena opened to the public in #395, and public visitors get no cookie at all: `isPublicArenaPath` returns a bare `NextResponse.next()`, so the gate that used to mint one never runs. Votes are therefore attributed to a UUID the browser generates in localStorage, which means a vote cannot be tied to a person, held to a quota, or judged by later scoring.

This mints a signed identity for everyone instead. The cookie payload gains a server-generated `sid` and a `role` of `labeler` or `external`, both covered by the existing HMAC so neither can be forged. Refreshing preserves them minting a fresh `sid` every 24 hours would weaken vote dedupe and strip any cross-day signal from scoring.

Cookies predating identity belong to the internal labelers who were using the arena before it opened, so they are reissued as `labeler`; everyone arriving since is `external`. Nobody is logged out and no link needs resending.

**Nothing reads `sid` or `role` yet.** The BFF still takes `voterId` from the request body, so voting and the board are unchanged by this PR 