### PR TITLE
[BENCH-558] Add Pareto frontier to the latency-accuracy scatter

### DIFF
--- a/web/components/dashboard/LatencyAccuracySection.tsx
+++ b/web/components/dashboard/LatencyAccuracySection.tsx
@@ -10,7 +10,6 @@ import {
   XAxis,
   YAxis,
   CartesianGrid,
-  ReferenceArea,
   ReferenceLine,
   ResponsiveContainer,
   Tooltip,
@@ -35,15 +34,6 @@ import { useMobileDetection } from "@/hooks/useMobileDetection";
 import ChartInteractionLayer, {
   type ChartInteractionHandle,
 } from "@/components/charts/ChartInteractionLayer";
-
-// Human transcription accuracy is 2–4% WER under optimal conditions (per our
-// ASR benchmarks doc); the band's ceiling puts human-level-or-better inside
-// the zone. Y axis is whole percent.
-const HUMAN_WER_CEILING = 4;
-// Median human conversational turn-taking gap. X axis is ms. Only meaningful
-// against TTFS — humans have no token-streaming analogue, so the zone hides
-// on TTFT. TODO(bench-405): confirm the canonical figure with product.
-const HUMAN_LATENCY_MS = 200;
 
 // The frontier's plot-edge extensions meet the fastest/most-accurate models
 // at up to a right angle, which no x-monotone curve interpolation can round —
@@ -297,22 +287,6 @@ const LatencyAccuracySection: React.FC = () => {
         <div className="flex flex-wrap items-center">
           <MetricToggle />
           <ul data-chart-legend className="mb-4 ml-auto flex items-center gap-4">
-            {activeTab === "stt" && metric === "TTFS" && (
-              <li
-                className="flex items-center gap-1.5 whitespace-nowrap text-xs"
-                style={{ color: themeColors.textSecondary }}
-              >
-                <span
-                  className="inline-block h-3 w-3 rounded-[2px]"
-                  style={{ backgroundColor: themeColors.zoneStroke }}
-                  aria-hidden="true"
-                />
-                <MetricInfo metric="human-parity" align="right">
-                  Human-parity zone{" "}
-                  <Info size={12} aria-hidden="true" className="inline align-[-2px]" />
-                </MetricInfo>
-              </li>
-            )}
             <li
               className="flex items-center gap-1.5 whitespace-nowrap text-xs"
               style={{ color: themeColors.textSecondary }}
@@ -393,19 +367,6 @@ const LatencyAccuracySection: React.FC = () => {
                 stroke={themeColors.grid}
                 strokeDasharray="2 2"
               />
-              {activeTab === "stt" && metric === "TTFS" && (
-                <ReferenceArea
-                  x1={0}
-                  x2={HUMAN_LATENCY_MS}
-                  y1={0}
-                  y2={HUMAN_WER_CEILING}
-                  fill={themeColors.zoneFill}
-                  fillOpacity={1}
-                  stroke={themeColors.zoneStroke}
-                  strokeWidth={1}
-                  ifOverflow="hidden"
-                />
-              )}
               <XAxis
                 dataKey="x"
                 type="number"

--- a/web/components/dashboard/LatencyAccuracySection.tsx
+++ b/web/components/dashboard/LatencyAccuracySection.tsx
@@ -78,9 +78,19 @@ const LatencyAccuracySection: React.FC = () => {
     () => [...scatterData].sort((a, b) => a.x - b.x || a.y - b.y),
     [scatterData]
   );
+  // Exact duplicates of a frontier point tie it rather than lose to it, so
+  // they stay on the frontier too (the sort keeps duplicates adjacent).
   const paretoData = useMemo(() => {
     let minY = Infinity;
-    return sortedData.filter((p) => (p.y < minY ? ((minY = p.y), true) : false));
+    let frontierX = NaN;
+    return sortedData.filter((p) => {
+      if (p.y < minY) {
+        minY = p.y;
+        frontierX = p.x;
+        return true;
+      }
+      return p.y === minY && p.x === frontierX;
+    });
   }, [sortedData]);
   const [activeIdx, setActiveIdx] = useState(-1);
   const chartRef = useRef<HTMLDivElement>(null);

--- a/web/components/dashboard/LatencyAccuracySection.tsx
+++ b/web/components/dashboard/LatencyAccuracySection.tsx
@@ -45,6 +45,30 @@ const HUMAN_WER_CEILING = 4;
 // on TTFT. TODO(bench-405): confirm the canonical figure with product.
 const HUMAN_LATENCY_MS = 200;
 
+// The frontier's plot-edge extensions meet the fastest/most-accurate models
+// at up to a right angle, which no x-monotone curve interpolation can round —
+// so the path is built by hand: straight runs with quadratic corners. The
+// radius is capped by the adjacent segments, so gentle interior bends read as
+// one smooth curve while a single dominant model gets a visibly rounded knee.
+const PARETO_CORNER_RADIUS = 16;
+const roundedFrontierPath = (points: { x: number; y: number }[]) => {
+  const pts = points.filter((p) => Number.isFinite(p.x) && Number.isFinite(p.y));
+  const first = pts[0];
+  if (!first || pts.length < 2) return "";
+  let d = `M${first.x},${first.y}`;
+  for (let i = 1; i < pts.length - 1; i++) {
+    const [a, p, b] = [pts[i - 1]!, pts[i]!, pts[i + 1]!];
+    const la = Math.hypot(p.x - a.x, p.y - a.y) || 1;
+    const lb = Math.hypot(b.x - p.x, b.y - p.y) || 1;
+    const r = Math.min(PARETO_CORNER_RADIUS, la / 2, lb / 2);
+    d +=
+      `L${p.x - ((p.x - a.x) / la) * r},${p.y - ((p.y - a.y) / la) * r}` +
+      `Q${p.x},${p.y} ${p.x + ((b.x - p.x) / lb) * r},${p.y + ((b.y - p.y) / lb) * r}`;
+  }
+  const last = pts[pts.length - 1]!;
+  return `${d}L${last.x},${last.y}`;
+};
+
 const LatencyAccuracySection: React.FC = () => {
   const { selectedModels, getScatterData, activeMetric: metric, dedicatedModels } = useDashboard();
 
@@ -61,9 +85,13 @@ const LatencyAccuracySection: React.FC = () => {
 
   const isMobile = useMobileDetection();
   const sortedData = useMemo(
-    () => [...scatterData].sort((a, b) => a.x - b.x),
+    () => [...scatterData].sort((a, b) => a.x - b.x || a.y - b.y),
     [scatterData]
   );
+  const paretoData = useMemo(() => {
+    let minY = Infinity;
+    return sortedData.filter((p) => (p.y < minY ? ((minY = p.y), true) : false));
+  }, [sortedData]);
   const [activeIdx, setActiveIdx] = useState(-1);
   const chartRef = useRef<HTMLDivElement>(null);
   const interactionRef = useRef<ChartInteractionHandle>(null);
@@ -151,6 +179,30 @@ const LatencyAccuracySection: React.FC = () => {
     return { xMax: max, xTicks: ticks };
   }, [scatterData]);
 
+  // The non-dominated set is rarely convex, so a curve through every one of
+  // its points would dip and flatten between them. The drawn curve is its
+  // lower convex hull instead — every chord point is achievable by splitting
+  // traffic between the two neighboring models, so the hull is the boundary
+  // of achievable trade-offs. Non-dominated models off the hull keep their
+  // full-opacity highlight.
+  const paretoLine = useMemo(() => {
+    const hull: ScatterDataPoint[] = [];
+    for (const p of paretoData) {
+      let a = hull[hull.length - 1];
+      let o = hull[hull.length - 2];
+      while (o && a && (a.x - o.x) * (p.y - o.y) - (a.y - o.y) * (p.x - o.x) <= 0) {
+        hull.pop();
+        a = hull[hull.length - 1];
+        o = hull[hull.length - 2];
+      }
+      hull.push(p);
+    }
+    const first = hull[0];
+    const last = hull[hull.length - 1];
+    if (!first || !last) return [];
+    return [{ ...first, y: yMax }, ...hull, { ...last, x: xMax }];
+  }, [paretoData, xMax, yMax]);
+
   const scrub = (e: React.PointerEvent<HTMLDivElement>) => {
     if (!sortedData.length) return;
     const { relativeX } = getRelativeCoordinate(e);
@@ -180,6 +232,28 @@ const LatencyAccuracySection: React.FC = () => {
           exportNote={metricTab}
           exportXLabel={`Average ${latencyLabel}`}
           exportAnnotate={(clone) => {
+            // A tapped point leaves crosshairs, an enlarged dot and dimmed
+            // neighbors in the SVG; the export is selection-neutral, so strip
+            // that state and restore each dot's frontier opacity. Circles pair
+            // with data by (cx, cy) order, the same pairing labelScatterDots
+            // uses.
+            clone
+              .querySelectorAll(".recharts-reference-line")
+              .forEach((el) => el.remove());
+            const attr = (el: Element, name: string) => Number(el.getAttribute(name));
+            const byPosition = Array.from(
+              clone.querySelectorAll("[data-export-point]")
+            ).sort((a, b) => attr(a, "cx") - attr(b, "cx") || attr(a, "cy") - attr(b, "cy"));
+            const ordered = [...scatterData].sort((a, b) => a.x - b.x || b.y - a.y);
+            byPosition.forEach((circle, i) => {
+              circle.setAttribute("r", "6");
+              circle.removeAttribute("stroke");
+              const point = ordered[i];
+              circle.setAttribute(
+                "fill-opacity",
+                point && paretoData.includes(point) ? "1" : "0.5"
+              );
+            });
             const nameCounts = new Map<string, number>();
             for (const { model } of scatterData) {
               const name = normalizeModelName(model);
@@ -222,10 +296,10 @@ const LatencyAccuracySection: React.FC = () => {
 
         <div className="flex flex-wrap items-center">
           <MetricToggle />
-          {activeTab === "stt" && metric === "TTFS" && (
-            <ul data-chart-legend className="mb-4 ml-auto">
+          <ul data-chart-legend className="mb-4 ml-auto flex items-center gap-4">
+            {activeTab === "stt" && metric === "TTFS" && (
               <li
-                className="flex items-center gap-1.5 text-xs"
+                className="flex items-center gap-1.5 whitespace-nowrap text-xs"
                 style={{ color: themeColors.textSecondary }}
               >
                 <span
@@ -238,8 +312,22 @@ const LatencyAccuracySection: React.FC = () => {
                   <Info size={12} aria-hidden="true" className="inline align-[-2px]" />
                 </MetricInfo>
               </li>
-            </ul>
-          )}
+            )}
+            <li
+              className="flex items-center gap-1.5 whitespace-nowrap text-xs"
+              style={{ color: themeColors.textSecondary }}
+            >
+              <span
+                className="inline-block w-4 border-t-2 border-dashed"
+                style={{ borderColor: themeColors.axisText }}
+                aria-hidden="true"
+              />
+              <MetricInfo metric="pareto" align="right">
+                Pareto frontier{" "}
+                <Info size={12} aria-hidden="true" className="inline align-[-2px]" />
+              </MetricInfo>
+            </li>
+          </ul>
         </div>
 
         <div
@@ -362,6 +450,23 @@ const LatencyAccuracySection: React.FC = () => {
               {activePoint && (
                 <ReferenceLine y={activePoint.y} stroke={themeColors.axisText} strokeDasharray="3 3" />
               )}
+              {paretoLine.length > 0 && (
+                <Scatter
+                  data={paretoLine}
+                  line={(props: { points: { x: number; y: number }[] }) => (
+                    <path
+                      d={roundedFrontierPath(props.points)}
+                      fill="none"
+                      stroke={themeColors.axisText}
+                      strokeWidth={1.5}
+                      strokeDasharray="4 4"
+                    />
+                  )}
+                  shape={() => <g />}
+                  tooltipType="none"
+                  isAnimationActive={false}
+                />
+              )}
               {selectedModels.map((model: string) => (
                 <Scatter
                   key={model}
@@ -381,12 +486,20 @@ const LatencyAccuracySection: React.FC = () => {
                         cy={props.cy}
                         r={props.payload === activePoint ? 8 : 6}
                         fill={props.fill}
-                        fillOpacity={activePoint && props.payload !== activePoint ? 0.35 : 1}
+                        fillOpacity={
+                          activePoint
+                            ? props.payload !== activePoint
+                              ? 0.35
+                              : 1
+                            : paretoData.includes(props.payload!)
+                              ? 1
+                              : 0.5
+                        }
                         stroke={props.payload === activePoint ? themeColors.axisText : undefined}
                         strokeWidth={2}
                         role="option"
                         aria-selected={props.payload === activePoint}
-                        aria-label={`${normalizeModelName(props.payload!.model)}: ${props.payload!.x.toFixed(0)}ms ${metric}, ${props.payload!.y.toFixed(1)}% WER`}
+                        aria-label={`${normalizeModelName(props.payload!.model)}: ${props.payload!.x.toFixed(0)}ms ${metric}, ${props.payload!.y.toFixed(1)}% WER${paretoData.includes(props.payload!) ? ", on Pareto frontier" : ""}`}
                         onClick={() => setActiveIdx(idx)}
                       />
                     );

--- a/web/components/shared/MetricInfo.tsx
+++ b/web/components/shared/MetricInfo.tsx
@@ -83,7 +83,7 @@ const MetricInfo: React.FC<{
       <span
         id={id}
         role="tooltip"
-        className={`pointer-events-none absolute z-50 ${panelClassName} max-w-[calc(100vw-1.5rem)] rounded-lg border border-border-secondary bg-surface-tooltip px-3 py-2 text-left font-sans text-xs font-normal leading-snug text-[var(--color-text-on-tooltip)] shadow-md transition-opacity group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 group-has-[:focus-visible]:visible group-has-[:focus-visible]:opacity-100 ${open ? "visible opacity-100" : "invisible opacity-0"} ${alignClasses[align]}`}
+        className={`pointer-events-none absolute z-50 ${panelClassName} max-w-[calc(100vw-1.5rem)] whitespace-normal rounded-lg border border-border-secondary bg-surface-tooltip px-3 py-2 text-left font-sans text-xs font-normal leading-snug text-[var(--color-text-on-tooltip)] shadow-md transition-opacity group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 group-has-[:focus-visible]:visible group-has-[:focus-visible]:opacity-100 ${open ? "visible opacity-100" : "invisible opacity-0"} ${alignClasses[align]}`}
       >
         {body}
       </span>

--- a/web/components/shared/SectionHeader.tsx
+++ b/web/components/shared/SectionHeader.tsx
@@ -183,9 +183,14 @@ const SectionHeader: React.FC<SectionHeaderProps> = ({
       ).map((li) => {
         const entry = li.cloneNode(true) as HTMLElement;
         entry.querySelectorAll('[role="tooltip"]').forEach((el) => el.remove());
+        const swatch = li.querySelector("span");
         return {
           label: entry.textContent?.trim() ?? "",
-          color: li.querySelector("span")?.style.backgroundColor ?? "#0f0c0a",
+          color:
+            swatch?.style.backgroundColor ||
+            swatch?.style.borderColor ||
+            "#0f0c0a",
+          dashed: !swatch?.style.backgroundColor && !!swatch?.style.borderColor,
           dimmed: li.hasAttribute("data-dimmed"),
         };
       }),

--- a/web/hooks/useThemeColors.ts
+++ b/web/hooks/useThemeColors.ts
@@ -17,8 +17,6 @@ export interface ThemeColors {
   tooltipSecondary: string;
   textPrimary: string;
   textSecondary: string;
-  zoneFill: string;
-  zoneStroke: string;
 }
 
 // Charts read these via JS (recharts/d3 fills), not CSS, so they must mirror the
@@ -36,8 +34,6 @@ export const LIGHT_CHART_COLORS: ThemeColors = {
   tooltipSecondary: "#515151",
   textPrimary: "#0f0c0a",
   textSecondary: "#515151",
-  zoneFill: "rgba(198, 220, 250, 0.45)",
-  zoneStroke: "rgba(26, 44, 54, 0.2)",
 };
 
 const DARK_CHART_COLORS: ThemeColors = {
@@ -52,8 +48,6 @@ const DARK_CHART_COLORS: ThemeColors = {
   tooltipSecondary: "#dbdbd3",
   textPrimary: "#f9faf8",
   textSecondary: "#dbdbd3",
-  zoneFill: "rgba(150, 190, 250, 0.18)",
-  zoneStroke: "rgba(198, 220, 250, 0.45)",
 };
 
 export function useThemeColors(): ThemeColors {

--- a/web/lib/config/metrics.ts
+++ b/web/lib/config/metrics.ts
@@ -47,6 +47,13 @@ export const metricDescriptions = {
     detailed:
       "The human-parity zone reframes the latency-accuracy trade-off around a human baseline instead of arbitrary thresholds. Human transcription accuracy is typically 2–4% WER under optimal conditions, and the median turn-taking gap in human conversation is roughly 200ms. A model inside the zone transcribes at least as accurately as a person and responds at least as fast as one."
   },
+  pareto: {
+    short: "Pareto frontier",
+    tooltip:
+      "The dashed line traces the best WER you can get at each latency budget. Bright dots earn their spot: nothing beats them on speed and accuracy at once. Every faded dot loses on both counts to some bright one.",
+    detailed:
+      "Speed and accuracy pull against each other, and the dashed line shows what the trade actually costs: follow it to read the best WER on offer at each latency budget. Bright models set that boundary — nothing beats them on both axes at once. Faded models are beaten outright by a bright one, so picking them only makes sense for reasons this chart can't see, like price or language coverage."
+  },
   // Shared by the Latency Variation card's description and its headline tooltip.
   iqr: {
     short: "Interquartile Range",

--- a/web/lib/config/metrics.ts
+++ b/web/lib/config/metrics.ts
@@ -40,13 +40,6 @@ export const metricDescriptions = {
     detailed:
       "Ensuring accurate speech output is fundamental to user trust and comprehension in voice AI systems. We recognize that even minor pronunciation errors can undermine the entire conversation experience and our evaluation captures how faithfully text-to-speech systems pronounce complex terminology, proper nouns, and domain-specific vocabulary that matter most to your users."
   },
-  "human-parity": {
-    short: "Human-parity zone",
-    tooltip:
-      "Models in this region match or beat a human on both axes: professional human transcribers achieve 2–4% WER under optimal conditions, and ~200ms is the median gap before a person replies in conversation. Anything inside the zone is at or beyond human performance.",
-    detailed:
-      "The human-parity zone reframes the latency-accuracy trade-off around a human baseline instead of arbitrary thresholds. Human transcription accuracy is typically 2–4% WER under optimal conditions, and the median turn-taking gap in human conversation is roughly 200ms. A model inside the zone transcribes at least as accurately as a person and responds at least as fast as one."
-  },
   pareto: {
     short: "Pareto frontier",
     tooltip:

--- a/web/lib/config/metrics.ts
+++ b/web/lib/config/metrics.ts
@@ -45,7 +45,7 @@ export const metricDescriptions = {
     tooltip:
       "The dashed line traces the best WER you can get at each latency budget. Bright dots earn their spot: nothing beats them on speed and accuracy at once. Every faded dot loses on both counts to some bright one.",
     detailed:
-      "Speed and accuracy pull against each other, and the dashed line shows what the trade actually costs: follow it to read the best WER on offer at each latency budget. Bright models set that boundary — nothing beats them on both axes at once. Faded models are beaten outright by a bright one, so picking them only makes sense for reasons this chart can't see, like price or language coverage."
+      "Speed and accuracy pull against each other, and the dashed line shows what the trade actually costs: follow it to read the best WER on offer at each latency budget. A straight stretch of the line is reachable too — split traffic between the models at its two ends. Bright models are the ones nothing beats on both axes at once, even where the line cuts below them. Faded models are beaten outright by a bright one, so picking them only makes sense for reasons this chart can't see, like price or language coverage."
   },
   // Shared by the Latency Variation card's description and its headline tooltip.
   iqr: {

--- a/web/lib/utils/chartExport.ts
+++ b/web/lib/utils/chartExport.ts
@@ -54,6 +54,8 @@ export function downloadCSV(
 interface LegendItem {
   label: string;
   color: string;
+  /** Swatch drawn as a dashed line (e.g. the Pareto frontier) instead of a filled square. */
+  dashed?: boolean;
   /** Grayed out in the export, e.g. a series clipped off-chart by the zoom. */
   dimmed?: boolean;
 }
@@ -230,6 +232,20 @@ export function labelScatterDots(
     boxes.some(
       (b) => box.x1 < b.x2 && box.x2 > b.x1 && box.y1 < b.y2 && box.y2 > b.y1
     );
+  // Overlay lines (e.g. the Pareto frontier) are obstacles too, or labels land
+  // on top of them. Their paths are absolute M/L/Q commands, so the coordinate
+  // pairs walked as a polyline track the drawn curve closely enough.
+  clone.querySelectorAll(".recharts-scatter-line path").forEach((path) => {
+    const nums = (path.getAttribute("d") ?? "").match(/-?\d*\.?\d+/g)?.map(Number) ?? [];
+    for (let i = 3; i < nums.length; i += 2) {
+      const [ax, ay, bx, by] = [nums[i - 3]!, nums[i - 2]!, nums[i - 1]!, nums[i]!];
+      const steps = Math.max(1, Math.ceil(Math.hypot(bx - ax, by - ay) / 8));
+      for (let s = 0; s <= steps; s++) {
+        const [px, py] = [ax + ((bx - ax) * s) / steps, ay + ((by - ay) * s) / steps];
+        boxes.push({ x1: px - 3, y1: py - 3, x2: px + 3, y2: py + 3 });
+      }
+    }
+  });
   // Stacked dots hide each other completely on screen; a rim in the canvas
   // color splits them into visible crescents so every label has a referent.
   circles.forEach((circle) => {
@@ -262,7 +278,7 @@ export function labelScatterDots(
     // In dense clusters, spiral outward in small rings so a squeezed-out label
     // still sits near its dot (its color keeps it attributable) rather than at
     // the end of a hard-to-follow leader line.
-    for (let r = 22; r <= 58; r += 12) {
+    for (let r = 22; r <= 94; r += 12) {
       for (let deg = 0; deg < 360; deg += 30) {
         const dx = Math.cos((deg * Math.PI) / 180);
         const dy = Math.sin((deg * Math.PI) / 180);
@@ -479,8 +495,19 @@ export async function downloadChartPNG(
   for (const row of rows) {
     for (const item of row) {
       ctx.globalAlpha = item.dimmed ? 0.35 : 1;
-      ctx.fillStyle = item.color;
-      ctx.fillRect(MARGIN + item.x, y + 5, 12, 12);
+      if (item.dashed) {
+        ctx.strokeStyle = item.color;
+        ctx.lineWidth = 2;
+        ctx.setLineDash([3, 3]);
+        ctx.beginPath();
+        ctx.moveTo(MARGIN + item.x, y + 11);
+        ctx.lineTo(MARGIN + item.x + 12, y + 11);
+        ctx.stroke();
+        ctx.setLineDash([]);
+      } else {
+        ctx.fillStyle = item.color;
+        ctx.fillRect(MARGIN + item.x, y + 5, 12, 12);
+      }
       ctx.fillStyle = colors.textPrimary;
       ctx.fillText(item.label, MARGIN + item.x + 18, y + 15);
     }

--- a/web/lib/utils/chartExport.ts
+++ b/web/lib/utils/chartExport.ts
@@ -233,17 +233,30 @@ export function labelScatterDots(
       (b) => box.x1 < b.x2 && box.x2 > b.x1 && box.y1 < b.y2 && box.y2 > b.y1
     );
   // Overlay lines (e.g. the Pareto frontier) are obstacles too, or labels land
-  // on top of them. Their paths are absolute M/L/Q commands, so the coordinate
-  // pairs walked as a polyline track the drawn curve closely enough.
+  // on top of them. Their paths are absolute M/L/Q commands; straight runs are
+  // sampled along the segment and rounded corners evaluate the quadratic
+  // itself, so the boxes hug the drawn curve rather than its control polygon.
   clone.querySelectorAll(".recharts-scatter-line path").forEach((path) => {
-    const nums = (path.getAttribute("d") ?? "").match(/-?\d*\.?\d+/g)?.map(Number) ?? [];
-    for (let i = 3; i < nums.length; i += 2) {
-      const [ax, ay, bx, by] = [nums[i - 3]!, nums[i - 2]!, nums[i - 1]!, nums[i]!];
-      const steps = Math.max(1, Math.ceil(Math.hypot(bx - ax, by - ay) / 8));
+    let cursor = { x: 0, y: 0 };
+    const sample = (to: { x: number; y: number }, at: (t: number) => [number, number]) => {
+      const steps = Math.max(1, Math.ceil(Math.hypot(to.x - cursor.x, to.y - cursor.y) / 8));
       for (let s = 0; s <= steps; s++) {
-        const [px, py] = [ax + ((bx - ax) * s) / steps, ay + ((by - ay) * s) / steps];
+        const [px, py] = at(s / steps);
         boxes.push({ x1: px - 3, y1: py - 3, x2: px + 3, y2: py + 3 });
       }
+      cursor = to;
+    };
+    for (const m of (path.getAttribute("d") ?? "").matchAll(/([MLQ])([^MLQ]*)/g)) {
+      const n = (m[2] ?? "").match(/-?\d*\.?\d+/g)?.map(Number) ?? [];
+      const end = { x: n[n.length - 2] ?? cursor.x, y: n[n.length - 1] ?? cursor.y };
+      const { x, y } = cursor;
+      if (m[1] === "M") cursor = end;
+      else if (m[1] === "L") sample(end, (t) => [x + (end.x - x) * t, y + (end.y - y) * t]);
+      else
+        sample(end, (t) => [
+          (1 - t) ** 2 * x + 2 * (1 - t) * t * n[0]! + t * t * end.x,
+          (1 - t) ** 2 * y + 2 * (1 - t) * t * n[1]! + t * t * end.y,
+        ]);
     }
   });
   // Stacked dots hide each other completely on screen; a rim in the canvas


### PR DESCRIPTION
## What
<img width="797" height="493" alt="Screenshot 2026-07-29 at 11 18 05 AM" src="https://github.com/user-attachments/assets/042fe9c7-492f-44e6-a09e-6f51f466ac7a" />
<img width="1107" height="484" alt="Screenshot 2026-07-29 at 11 18 32 AM" src="https://github.com/user-attachments/assets/12c700e3-acad-48c4-bf2e-8df64e9bbf53" />



Overlays a dashed Pareto frontier on the "Average TTFA/TTFS/TTFT and WER per model" scatter so the best latency-accuracy trade-offs read at a glance.

## How

- **Frontier set**: single-pass strict-dominance scan over the x-sorted points (verified against a brute-force check).
- **Drawn curve**: the lower convex hull of that set — chord points are achievable by splitting traffic between the two neighboring models, so the hull is the boundary of achievable trade-offs and can never wiggle. Non-dominated models that fall off the hull keep their highlight; only the line skips them.
- **Full-span boundary**: extended to the plot edges (vertical above the fastest model, horizontal right of the best WER) with hand-built rounded corners, so a single dominant model (e.g. TTFT) renders as a rounded knee instead of crosshairs.
- **Styling**: dominated dots fade to 0.5 opacity; frontier membership is announced in dot aria-labels; legend entry reuses MetricInfo with tap-friendly tooltip copy.
- **Exports**: legend swatches can render as dashed lines, dot labels treat the frontier path as an obstacle, and any tap-selection state (crosshairs, enlarged dot, dimmed neighbors) is stripped from the export clone.

## Testing

- `tsc`, `eslint`, and the vitest suite (91 tests) all pass.
- Verified in-browser on TTS/TTFA, STT/TTFS, and STT/TTFT (single-point frontier), light + dark themes, desktop + 375px mobile, including tap-select/dismiss and filter changes recomputing the frontier live.
- PNG export verified selection-neutral with correct dashed legend swatch.