### PR TITLE
[BENCH-562] Refine S2S benchmark experience

### DIFF
--- a/web/app/s2s/components/S2STopRow.tsx
+++ b/web/app/s2s/components/S2STopRow.tsx
@@ -41,21 +41,17 @@ function MetricTile({ metric }: { metric: KeyMetricData }) {
   );
 }
 
-// S2S headline row: the latency tile (and, when present, the instruction
-// adherence tile stacked below it) beside the samples card. The left column
-// stretches to the samples card's height; each stacked tile is flex-1 so the
-// two tiles plus the gap between them exactly fill that height.
 export function S2STopRow() {
   const { primaryKeyMetric, secondaryKeyMetric } = useDashboard();
 
   return (
-    <div className="mb-[0.8rem] grid grid-cols-1 items-stretch gap-[0.8rem] lg:grid-cols-2">
-      <div className="flex min-w-0 flex-col gap-[0.8rem]">
-        <Card className="text-left min-w-0 flex-1" padding="p-5 lg:p-8">
+    <div className="mb-[0.8rem] flex min-w-0 flex-col gap-[0.8rem]">
+      <div className={`grid min-w-0 gap-[0.8rem] ${secondaryKeyMetric ? "grid-cols-2" : "grid-cols-1"}`}>
+        <Card className="min-w-0 text-left" padding="p-4 sm:p-5 lg:p-6">
           <MetricTile metric={primaryKeyMetric} />
         </Card>
         {secondaryKeyMetric && (
-          <Card className="text-left min-w-0 flex-1" padding="p-5 lg:p-8">
+          <Card className="min-w-0 text-left" padding="p-4 sm:p-5 lg:p-6">
             <MetricTile metric={secondaryKeyMetric} />
           </Card>
         )}

--- a/web/app/s2s/components/SampleOutputs.tsx
+++ b/web/app/s2s/components/SampleOutputs.tsx
@@ -97,6 +97,11 @@ export function SampleOutputs({
     if (idx < 0) return;
     consumedNonce.current = playRequest.nonce;
     playFrom(idx);
+    viewportRef.current?.children.item(idx)?.scrollIntoView({
+      behavior: "smooth",
+      block: "center",
+      inline: "center",
+    });
   }, [playRequest, items, playFrom]);
 
   const hints = useScrollHints(viewportRef, `${items.length}:${items.map((i) => i.provider).join(",")}`);

--- a/web/app/s2s/components/SamplesCard.tsx
+++ b/web/app/s2s/components/SamplesCard.tsx
@@ -4,6 +4,7 @@
 "use client";
 
 import { useCallback, useEffect, useMemo } from "react";
+import { ChevronLeft, ChevronRight } from "lucide-react";
 import Card from "@/components/shared/Card";
 import { useDashboard } from "@/contexts/DashboardContext";
 import { SampleFetchError } from "@/lib/audioSamples/createSampleFeed";
@@ -30,7 +31,13 @@ function pinnedDayLabel(tick: string): string {
 }
 
 export function SamplesCard() {
-  const { modelsByProvider, normalizeProviderName, s2sPlayRequest, clearS2SPlay } = useDashboard();
+  const {
+    modelsByProvider,
+    normalizeProviderName,
+    s2sPlayRequest,
+    selectS2SSample,
+    getCurrentTimeWindow,
+  } = useDashboard();
   const coordinator = usePlaybackCoordinator();
   const visibleProviders = useMemo(
     () => new Set(Object.keys(modelsByProvider)),
@@ -38,9 +45,27 @@ export function SamplesCard() {
   );
 
   const indexQuery = s2sSampleFeed.useIndexQuery();
-  const latestTick = indexQuery.data?.[0] ?? null;
+  const [windowStart, windowEnd] = getCurrentTimeWindow();
+  const sampleTicks = useMemo(
+    () =>
+      (indexQuery.data ?? [])
+        .filter((tick) => {
+          const timestamp = new Date(tick).getTime();
+          return timestamp >= windowStart && timestamp <= windowEnd;
+        })
+        .reverse(),
+    [indexQuery.data, windowStart, windowEnd]
+  );
+  const latestTick = sampleTicks.at(-1) ?? null;
   // A timeline-tooltip click pins the card to that bucket; otherwise show latest.
   const effectiveTick = s2sPlayRequest?.tick ?? latestTick;
+  const effectiveTime = effectiveTick ? new Date(effectiveTick).getTime() : NaN;
+  const olderTick = [...sampleTicks]
+    .reverse()
+    .find((tick) => new Date(tick).getTime() < effectiveTime);
+  const newerTick = sampleTicks.find(
+    (tick) => new Date(tick).getTime() > effectiveTime
+  );
   const manifestQuery = s2sSampleFeed.useManifestQuery(effectiveTick);
   const manifest = manifestQuery.data ?? null;
 
@@ -71,10 +96,18 @@ export function SamplesCard() {
   // catalogue. Autoplay then finds no matching pane and stays quiet, so the
   // click reads as broken unless we say what happened.
   const requestedProvider = s2sPlayRequest?.provider;
+  const requestedItem = requestedProvider
+    ? items.find(
+        (item) =>
+          normalizeProviderName(item.provider) ===
+          normalizeProviderName(requestedProvider)
+      )
+    : undefined;
   const requestedProviderMissing =
     requestedProvider !== undefined &&
     manifest !== null &&
-    !items.some((i) => i.provider === requestedProvider);
+    !manifestQuery.isPlaceholderData &&
+    requestedItem === undefined;
 
   const handlePlay = useCallback(
     (provider: string) => {
@@ -92,7 +125,7 @@ export function SamplesCard() {
     indexQuery.isLoading || (effectiveTick != null && manifestQuery.isLoading);
 
   useEffect(() => {
-    if (s2sPlayRequest) {
+    if (s2sPlayRequest?.source === "timeline") {
       document.getElementById("s2s-samples")?.scrollIntoView({ behavior: "smooth", block: "center" });
     }
   }, [s2sPlayRequest]);
@@ -103,19 +136,45 @@ export function SamplesCard() {
         <h2 className="text-xl font-medium text-text-primary">
           Conversation samples
         </h2>
-        {/* A timeline click pins the card to that day. Without a way back, a day
-            holding metrics but no recording would trap the card on an empty
-            state. */}
-        {s2sPlayRequest ? (
-          <button
-            type="button"
-            onClick={clearS2SPlay}
-            className="inline-flex min-h-11 shrink-0 items-center rounded-full border border-border-primary px-2 py-0.5 font-mono text-[10px] text-text-secondary transition-colors hover:text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-text-tertiary/40 lg:min-h-0"
-          >
-            {pinnedDayLabel(s2sPlayRequest.tick)} · show latest
-          </button>
-        ) : null}
       </div>
+
+      {effectiveTick && sampleTicks.length > 1 ? (
+        <div className="mb-4 flex flex-wrap items-center gap-2">
+          <div className="flex w-fit items-center gap-2 rounded-lg border border-border-secondary bg-surface-secondary/40 p-1">
+            <button
+              type="button"
+              aria-label="Show older conversation sample"
+              disabled={!olderTick}
+              onClick={() => olderTick && selectS2SSample(olderTick)}
+              className="flex size-11 items-center justify-center rounded-md border border-border-secondary text-text-secondary transition-colors hover:bg-surface-tertiary hover:text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-text-tertiary/40 disabled:cursor-default disabled:text-text-tertiary disabled:opacity-30 lg:size-8"
+            >
+              <ChevronLeft className="size-4" />
+            </button>
+            <span className="min-w-28 text-center font-mono text-xs text-text-secondary">
+              {pinnedDayLabel(effectiveTick)}
+              {effectiveTick === latestTick ? " · latest" : ""}
+            </span>
+            <button
+              type="button"
+              aria-label="Show newer conversation sample"
+              disabled={!newerTick}
+              onClick={() => newerTick && selectS2SSample(newerTick)}
+              className="flex size-11 items-center justify-center rounded-md border border-border-secondary text-text-secondary transition-colors hover:bg-surface-tertiary hover:text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-text-tertiary/40 disabled:cursor-default disabled:text-text-tertiary disabled:opacity-30 lg:size-8"
+            >
+              <ChevronRight className="size-4" />
+            </button>
+          </div>
+          {effectiveTick !== latestTick ? (
+            <button
+              type="button"
+              onClick={() => latestTick && selectS2SSample(latestTick)}
+              className="min-h-11 rounded-full border border-border-primary px-3 text-xs text-text-secondary transition-colors hover:text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-text-tertiary/40 lg:min-h-8"
+            >
+              Return to latest
+            </button>
+          ) : null}
+        </div>
+      ) : null}
 
       {loading ? (
         <div className="h-40 animate-pulse rounded-lg bg-surface-secondary" />
@@ -141,8 +200,8 @@ export function SamplesCard() {
             normalizeProvider={normalizeProviderName}
             onPlay={handlePlay}
             playRequest={
-              s2sPlayRequest
-                ? { provider: s2sPlayRequest.provider, nonce: s2sPlayRequest.nonce }
+              requestedItem && !manifestQuery.isPlaceholderData
+                ? { provider: requestedItem.provider, nonce: s2sPlayRequest!.nonce }
                 : null
             }
             coordinator={coordinator}

--- a/web/app/s2s/components/SamplesCard.tsx
+++ b/web/app/s2s/components/SamplesCard.tsx
@@ -68,6 +68,10 @@ export function SamplesCard() {
   );
   const manifestQuery = s2sSampleFeed.useManifestQuery(effectiveTick);
   const manifest = manifestQuery.data ?? null;
+  const displayedTick =
+    manifestQuery.isPlaceholderData && manifest?.bucket_at
+      ? manifest.bucket_at
+      : effectiveTick;
 
   const fetchError = manifestQuery.isError || indexQuery.isError;
   // Keep the failure cause internal (dev console only); public visitors just see
@@ -151,8 +155,8 @@ export function SamplesCard() {
               <ChevronLeft className="size-4" />
             </button>
             <span className="min-w-28 text-center font-mono text-xs text-text-secondary">
-              {pinnedDayLabel(effectiveTick)}
-              {effectiveTick === latestTick ? " · latest" : ""}
+              {pinnedDayLabel(displayedTick ?? effectiveTick)}
+              {displayedTick === latestTick ? " · latest" : ""}
             </span>
             <button
               type="button"

--- a/web/app/s2s/components/SamplesCard.tsx
+++ b/web/app/s2s/components/SamplesCard.tsx
@@ -91,12 +91,18 @@ export function SamplesCard() {
   const loading =
     indexQuery.isLoading || (effectiveTick != null && manifestQuery.isLoading);
 
+  useEffect(() => {
+    if (s2sPlayRequest) {
+      document.getElementById("s2s-samples")?.scrollIntoView({ behavior: "smooth", block: "center" });
+    }
+  }, [s2sPlayRequest]);
+
   return (
-    <Card className="text-left min-w-0 h-full flex flex-col" padding="p-5 lg:p-8">
-      <div className="mb-3 flex items-baseline justify-between gap-2">
-        <div className="text-[0.9rem] font-light text-text-secondary">
+    <Card id="s2s-samples" className="text-left min-w-0 h-full flex flex-col" padding="p-5 lg:p-8">
+      <div className="mb-4 flex items-baseline justify-between gap-2">
+        <h2 className="text-xl font-medium text-text-primary">
           Conversation samples
-        </div>
+        </h2>
         {/* A timeline click pins the card to that day. Without a way back, a day
             holding metrics but no recording would trap the card on an empty
             state. */}

--- a/web/components/charts/tooltips/TimelineTooltip.tsx
+++ b/web/components/charts/tooltips/TimelineTooltip.tsx
@@ -30,7 +30,7 @@ interface TimelineTooltipProps extends Partial<Pick<
    * static and unchanged.
    */
   onModelClick?: (model: string, label: number) => void;
-  hasRecording?: (label: number) => boolean | undefined;
+  hasRecording?: (label: number, provider: string) => boolean | undefined;
   /** Non-timeline charts: shown verbatim instead of the timestamp label. */
   labelText?: string;
   /** Non-latency values: overrides the default "123ms" rendering. */
@@ -73,7 +73,18 @@ const CustomTimelineTooltip: React.FC<TimelineTooltipProps> = ({ active, payload
   // Emphasize the first row shown — the fastest in-view model — rather than the
   // global #1, which a Y-zoom can push into the dimmed group at the bottom.
   const leaderKey = rows[0]?.dataKey;
-  const recordingAvailable = hasRecording?.(Number(label));
+  const recordingAvailability = new Map(
+    rows.map((item) => {
+      const model = item.dataKey.replace(/_value$/, "");
+      return [
+        item.dataKey,
+        hasRecording?.(Number(label), getProviderForModel(model)),
+      ];
+    })
+  );
+  const noRecordings =
+    hasRecording != null &&
+    [...recordingAvailability.values()].every((available) => available === false);
 
   return (
     <div
@@ -94,7 +105,7 @@ const CustomTimelineTooltip: React.FC<TimelineTooltipProps> = ({ active, payload
             ? `${formatDate(Number(label), timeZone)} ${formatTimeWithSeconds(Number(label), timeZone)}`
             : formatTimeWithSeconds(Number(label), timeZone))}
       </p>
-      {recordingAvailable === false && (
+      {noRecordings && (
         <p
           style={{
             margin: "0 0 8px",
@@ -126,7 +137,10 @@ const CustomTimelineTooltip: React.FC<TimelineTooltipProps> = ({ active, payload
           const modelName = item.dataKey.replace(/_value$/, "");
           const provider = getProviderForModel(modelName);
           const isLeader = item.dataKey === leaderKey;
-          const clickable = onModelClick != null && recordingAvailable !== false;
+          const recordingAvailable = recordingAvailability.get(item.dataKey);
+          const clickable =
+            onModelClick != null &&
+            (hasRecording == null || recordingAvailable === true);
 
           return (
             <div
@@ -193,6 +207,9 @@ const CustomTimelineTooltip: React.FC<TimelineTooltipProps> = ({ active, payload
                 }}
               >
                 {formatValue ? formatValue(item.value) : `${item.value.toFixed(0)}ms`}
+                {recordingAvailable === false && !noRecordings ? (
+                  <span style={{ marginLeft: "6px" }}>· no sample</span>
+                ) : null}
                 {clickable ? <span style={{ marginLeft: "6px" }} aria-hidden>▶</span> : null}
               </span>
             </div>

--- a/web/components/charts/tooltips/TimelineTooltip.tsx
+++ b/web/components/charts/tooltips/TimelineTooltip.tsx
@@ -30,6 +30,7 @@ interface TimelineTooltipProps extends Partial<Pick<
    * static and unchanged.
    */
   onModelClick?: (model: string, label: number) => void;
+  hasRecording?: (label: number) => boolean | undefined;
   /** Non-timeline charts: shown verbatim instead of the timestamp label. */
   labelText?: string;
   /** Non-latency values: overrides the default "123ms" rendering. */
@@ -38,7 +39,7 @@ interface TimelineTooltipProps extends Partial<Pick<
   timeZone?: string;
 }
 
-const CustomTimelineTooltip: React.FC<TimelineTooltipProps> = ({ active, payload, label, getProviderForModel, showDate, dimmedKeys, compact, interactionHint, maxHeight, onModelClick, labelText, formatValue, timeZone }) => {
+const CustomTimelineTooltip: React.FC<TimelineTooltipProps> = ({ active, payload, label, getProviderForModel, showDate, dimmedKeys, compact, interactionHint, maxHeight, onModelClick, hasRecording, labelText, formatValue, timeZone }) => {
   if (!active || !payload || payload.length === 0) return null;
 
   // Filter out null/undefined values and sort by value (fastest to slowest)
@@ -72,6 +73,7 @@ const CustomTimelineTooltip: React.FC<TimelineTooltipProps> = ({ active, payload
   // Emphasize the first row shown — the fastest in-view model — rather than the
   // global #1, which a Y-zoom can push into the dimmed group at the bottom.
   const leaderKey = rows[0]?.dataKey;
+  const recordingAvailable = hasRecording?.(Number(label));
 
   return (
     <div
@@ -92,6 +94,17 @@ const CustomTimelineTooltip: React.FC<TimelineTooltipProps> = ({ active, payload
             ? `${formatDate(Number(label), timeZone)} ${formatTimeWithSeconds(Number(label), timeZone)}`
             : formatTimeWithSeconds(Number(label), timeZone))}
       </p>
+      {recordingAvailable === false && (
+        <p
+          style={{
+            margin: "0 0 8px",
+            fontSize: "10px",
+            color: "var(--color-text-on-tooltip-secondary)"
+          }}
+        >
+          No conversation sample recorded
+        </p>
+      )}
       <div
         className="tooltip-scroll"
         style={
@@ -113,7 +126,7 @@ const CustomTimelineTooltip: React.FC<TimelineTooltipProps> = ({ active, payload
           const modelName = item.dataKey.replace(/_value$/, "");
           const provider = getProviderForModel(modelName);
           const isLeader = item.dataKey === leaderKey;
-          const clickable = onModelClick != null;
+          const clickable = onModelClick != null && recordingAvailable !== false;
 
           return (
             <div

--- a/web/components/dashboard/BoxPlotSection.tsx
+++ b/web/components/dashboard/BoxPlotSection.tsx
@@ -5,7 +5,7 @@
 
 import React, { useMemo } from "react";
 import { getModelColor } from "@/lib/utils/colors";
-import { normalizeModelName } from "@/lib/utils/formatters";
+import { normalizeModelName, parseModelKey } from "@/lib/utils/formatters";
 import BoxPlot from "@/components/charts/d3/BoxPlot";
 import Card from "@/components/shared/Card";
 import SectionHeader from "@/components/shared/SectionHeader";
@@ -55,7 +55,7 @@ const BoxPlotSection: React.FC = () => {
           exportXLabel="Ranked by median latency (fastest first)"
           exportRows={() =>
             boxPlotData.data.map(({ model, quartiles, stats }) => ({
-              model,
+              model: parseModelKey(model).model,
               provider: getProviderForModel(model),
               metric: activeMetric,
               whisker_low_ms: quartiles.min,
@@ -69,6 +69,9 @@ const BoxPlotSection: React.FC = () => {
                   ? ((quartiles.q3 - quartiles.q1) / quartiles.median) * 100
                   : undefined,
               mean_ms: stats.mean,
+              std_dev_ms: stats.std,
+              p95_ms: stats.p95,
+              max_ms: stats.max,
               runs: stats.count,
             }))
           }

--- a/web/components/dashboard/LatencyAccuracySection.tsx
+++ b/web/components/dashboard/LatencyAccuracySection.tsx
@@ -18,7 +18,7 @@ import {
 import { Info } from "lucide-react";
 import type { ScatterDataPoint } from "@/types/benchmark.types";
 import { getModelColor } from "@/lib/utils/colors";
-import { normalizeModelName } from "@/lib/utils/formatters";
+import { normalizeModelName, parseModelKey } from "@/lib/utils/formatters";
 import { labelScatterDots } from "@/lib/utils/chartExport";
 import CustomScatterTooltip from "@/components/charts/tooltips/ScatterTooltip";
 import Card from "@/components/shared/Card";
@@ -278,7 +278,7 @@ const LatencyAccuracySection: React.FC = () => {
           }}
           exportRows={() =>
             scatterData.map(({ model, provider, benchmark, x, y, count }) => ({
-              model,
+              model: parseModelKey(model).model,
               provider,
               benchmark,
               [`avg_${metric}_ms`]: x,

--- a/web/components/dashboard/ModelComparisonSection.tsx
+++ b/web/components/dashboard/ModelComparisonSection.tsx
@@ -13,6 +13,7 @@ import SectionHeader from "@/components/shared/SectionHeader";
 import MetricToggle from "@/components/dashboard/MetricToggle";
 import { datasetLabel } from "@/lib/config/datasets";
 import { metricAboutNote } from "@/lib/config/metrics";
+import { parseModelKey } from "@/lib/utils/formatters";
 import { useDashboard } from "@/contexts/DashboardContext";
 import { useChartHoverTracking } from "@/hooks/useChartHoverTracking";
 
@@ -42,14 +43,14 @@ const ModelComparisonSection: React.FC = () => {
           note={metricAboutNote(activeMetric)}
           exportRows={() =>
             data.map(({ model, latency, avgWER, werStdDev, sampleCount }) => ({
-              model,
+              model: parseModelKey(model).model,
               provider: getProviderForModel(model),
               metric: activeMetric,
               ...(latency
                 ? { [`latency_${percentile}_ms`]: latency[percentile] }
                 : {}),
               ...(avgWER !== undefined
-                ? { avg_wer_percent: avgWER, wer_std_dev: werStdDev }
+                ? { avg_wer_percent: avgWER, wer_std_dev_percent: werStdDev }
                 : {}),
               ...(werDataset ? { wer_dataset: werDataset } : {}),
               runs: sampleCount,

--- a/web/components/dashboard/ModelComparisonTable.tsx
+++ b/web/components/dashboard/ModelComparisonTable.tsx
@@ -182,11 +182,14 @@ const ModelComparisonTable: React.FC<ModelComparisonTableProps> = ({
 
       <div ref={tableWrapRef} className="relative">
         {dedicatedOverlay}
+        <p className="mb-2 text-right text-xs text-text-tertiary sm:hidden">
+          Swipe table for more →
+        </p>
         <div className="overflow-x-auto">
         <table className="w-full min-w-[560px] border-collapse text-sm">
           <thead>
             <tr className="border-b border-border-primary text-text-tertiary">
-              <th className="py-2 pr-4 text-left font-medium">Model</th>
+              <th className="sticky left-0 z-10 bg-surface-elevated py-2 pr-4 text-left font-medium">Model</th>
               {columns.map((column) => (
                 <th
                   key={column.key}
@@ -230,7 +233,7 @@ const ModelComparisonTable: React.FC<ModelComparisonTableProps> = ({
                 key={row.model}
                 className="border-b border-border-secondary last:border-b-0 hover:bg-hover-bg"
               >
-                <td className="py-3 pr-4 align-middle">
+                <td className="sticky left-0 z-[1] bg-surface-elevated py-3 pr-4 align-middle">
                   <div className="flex items-center gap-1.5 font-medium text-text-primary">
                     {normalizeModelName(row.model)}
                     {dedicatedModels?.has(row.model) && (

--- a/web/components/dashboard/QualityBarSection.tsx
+++ b/web/components/dashboard/QualityBarSection.tsx
@@ -8,7 +8,7 @@ import { Server } from "lucide-react";
 import { Cell, type LabelProps } from "recharts";
 import CustomBarTooltip from "@/components/charts/tooltips/BarTooltip";
 import QualityMetricBars from "@/components/charts/QualityMetricBars";
-import { normalizeModelName } from "@/lib/utils/formatters";
+import { normalizeModelName, parseModelKey } from "@/lib/utils/formatters";
 import Card from "@/components/shared/Card";
 import { useDedicatedInfoTip } from "@/components/shared/DedicatedInferenceInfo";
 import SectionHeader from "@/components/shared/SectionHeader";
@@ -184,7 +184,7 @@ const QualityBarSection: React.FC = () => {
             exportXLabel="Model"
             exportRows={() =>
               instructionBarDataWithColors.map(({ model, instructionScore }) => ({
-                model,
+                model: parseModelKey(model).model,
                 provider: getProviderForModel(model),
                 instruction_adherence_percent: instructionScore,
               }))
@@ -211,8 +211,10 @@ const QualityBarSection: React.FC = () => {
             exportXLabel="Model"
             exportRows={() =>
               werBarDataWithColors.map(({ model, averageWER }) => ({
-                model,
+                model: parseModelKey(model).model,
                 provider: getProviderForModel(model),
+                wer_view: werBarView,
+                wer_dataset: activeWerView?.dataset ?? "all",
                 avg_wer_percent: averageWER,
               }))
             }

--- a/web/components/dashboard/WerRadarSection.tsx
+++ b/web/components/dashboard/WerRadarSection.tsx
@@ -27,7 +27,7 @@ import { useChartHoverTracking } from "@/hooks/useChartHoverTracking";
 import { MIN_RADAR_AXES, useWerDatasetMatrix } from "@/hooks/useWerDatasetMatrix";
 import { datasetLabel, isPerturbationDataset } from "@/lib/config/datasets";
 import { getModelColor } from "@/lib/utils/colors";
-import { normalizeModelName } from "@/lib/utils/formatters";
+import { normalizeModelName, parseModelKey } from "@/lib/utils/formatters";
 
 // "WildASR reverb" → ["Reverb", "WildASR"], "PipeCat (production)" →
 // ["Production", "PipeCat"]: every axis reads its condition first, with the
@@ -295,8 +295,9 @@ const WerRadarSection: React.FC = () => {
           exportRows={() =>
             plotted.flatMap((model) =>
               effectiveAxes.map((dataset) => ({
+                dataset_id: dataset,
                 dataset: datasetLabel(dataset),
-                model,
+                model: parseModelKey(model).model,
                 provider: getProviderForModel(model),
                 avg_wer_percent: werByDataset?.get(dataset)?.get(model),
               }))

--- a/web/components/layout/FacetFilter.tsx
+++ b/web/components/layout/FacetFilter.tsx
@@ -10,12 +10,14 @@ import { useDashboard } from "@/contexts/DashboardContext";
 import { useSidebarMenu } from "@/contexts/SidebarMenuContext";
 import TimeWindowToggle from "@/components/shared/TimeWindowToggle";
 import { CymaticLoader } from "@/components/shared/CymaticLoader";
+import { timeWindowsFor } from "@/lib/config/timeWindows";
 
 const COLLAPSE_THRESHOLD = 8;
 
 const FacetFilter: React.FC = () => {
   const {
     facetGroups,
+    page,
     toggleFacet,
     clearFacets,
     hasActiveFacets,
@@ -64,6 +66,7 @@ const FacetFilter: React.FC = () => {
         <TimeWindowToggle
           value={timeWindow}
           onChange={changeTimeWindow}
+          windows={timeWindowsFor(page)}
           loading={windowDataStale}
           className="mb-2 w-full"
         />

--- a/web/components/shared/SectionHeader.tsx
+++ b/web/components/shared/SectionHeader.tsx
@@ -95,12 +95,20 @@ const SectionHeader: React.FC<SectionHeaderProps> = ({
       format,
     });
 
-  const copyLink = () => {
+  const copyLink = async () => {
     // The utm params tag visitors who arrive through a copied link: PostHog
     // reads utm_* from the landing URL, so these visits separate from $direct.
-    navigator.clipboard.writeText(
-      `${window.location.origin}${window.location.pathname}?utm_source=copy_link&utm_content=${anchorId}#${anchorId}`
-    );
+    const url = `${window.location.origin}${window.location.pathname}?utm_source=copy_link&utm_content=${anchorId}#${anchorId}`;
+    try {
+      await navigator.clipboard.writeText(url);
+    } catch {
+      const input = document.createElement("textarea");
+      input.value = url;
+      document.body.appendChild(input);
+      input.select();
+      document.execCommand("copy");
+      input.remove();
+    }
     window.history.replaceState(null, "", `#${anchorId}`);
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);
@@ -216,14 +224,14 @@ const SectionHeader: React.FC<SectionHeaderProps> = ({
   return (
     <div id={anchorId} className="flex flex-col sm:flex-row sm:justify-between sm:items-start gap-3 sm:gap-8 mb-4 scroll-mt-24">
       <div className="w-full sm:w-3/4 min-w-0">
-        <h2 className="flex items-center gap-2 text-[0.9rem] font-light text-text-secondary mb-2">
-          {label}
+        <h2 className="mb-2 flex items-start gap-2 text-[0.9rem] font-light text-text-secondary">
+          <span className="min-w-0 flex-1 pt-3 lg:pt-1">{label}</span>
           <button
             type="button"
-            onClick={copyLink}
+            onClick={() => void copyLink()}
             aria-label="Copy link to this chart"
             title="Copy link"
-            className={iconButtonClass}
+            className={`${iconButtonClass} shrink-0`}
           >
             {copied ? <Check size={14} /> : <Link2 size={14} />}
           </button>
@@ -233,7 +241,7 @@ const SectionHeader: React.FC<SectionHeaderProps> = ({
               onClick={() => void downloadImage()}
               aria-label="Download chart as image"
               title="Download image"
-              className={iconButtonClass}
+              className={`${iconButtonClass} shrink-0`}
             >
               <ImageDown size={14} />
             </button>
@@ -244,7 +252,7 @@ const SectionHeader: React.FC<SectionHeaderProps> = ({
               onClick={downloadData}
               aria-label="Download chart data"
               title="Download data"
-              className={iconButtonClass}
+              className={`${iconButtonClass} shrink-0`}
             >
               <Table size={14} />
             </button>

--- a/web/components/shared/SectionHeader.tsx
+++ b/web/components/shared/SectionHeader.tsx
@@ -223,8 +223,7 @@ const SectionHeader: React.FC<SectionHeaderProps> = ({
   const downloadData = () => {
     const rows = exportRows?.() ?? [];
     if (rows.length === 0) return;
-    downloadCSV(rows, `${anchorId}.csv`);
-    trackShare("csv");
+    if (downloadCSV(rows, `${anchorId}.csv`)) trackShare("csv");
   };
 
   return (

--- a/web/components/shared/SectionHeader.tsx
+++ b/web/components/shared/SectionHeader.tsx
@@ -99,16 +99,22 @@ const SectionHeader: React.FC<SectionHeaderProps> = ({
     // The utm params tag visitors who arrive through a copied link: PostHog
     // reads utm_* from the landing URL, so these visits separate from $direct.
     const url = `${window.location.origin}${window.location.pathname}?utm_source=copy_link&utm_content=${anchorId}#${anchorId}`;
+    let copiedSuccessfully = false;
     try {
       await navigator.clipboard.writeText(url);
+      copiedSuccessfully = true;
     } catch {
       const input = document.createElement("textarea");
-      input.value = url;
-      document.body.appendChild(input);
-      input.select();
-      document.execCommand("copy");
-      input.remove();
+      try {
+        input.value = url;
+        document.body.appendChild(input);
+        input.select();
+        copiedSuccessfully = document.execCommand("copy");
+      } finally {
+        input.remove();
+      }
     }
+    if (!copiedSuccessfully) return;
     window.history.replaceState(null, "", `#${anchorId}`);
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);

--- a/web/components/shared/TimeWindowToggle.tsx
+++ b/web/components/shared/TimeWindowToggle.tsx
@@ -13,6 +13,7 @@ import {
 interface TimeWindowToggleProps {
   value: TimeWindow;
   onChange: (window: TimeWindow) => void;
+  windows?: readonly TimeWindow[];
   loading?: boolean;
   className?: string;
 }
@@ -20,6 +21,7 @@ interface TimeWindowToggleProps {
 const TimeWindowToggle: React.FC<TimeWindowToggleProps> = ({
   value,
   onChange,
+  windows = TIME_WINDOWS,
   loading,
   className = "",
 }) => {
@@ -34,10 +36,10 @@ const TimeWindowToggle: React.FC<TimeWindowToggleProps> = ({
       return;
     }
     event.preventDefault();
-    const currentIndex = TIME_WINDOWS.indexOf(value);
+    const currentIndex = windows.indexOf(value);
     const nextIndex =
-      (currentIndex + step + TIME_WINDOWS.length) % TIME_WINDOWS.length;
-    onChange(TIME_WINDOWS[nextIndex] ?? value);
+      (currentIndex + step + windows.length) % windows.length;
+    onChange(windows[nextIndex] ?? value);
     const radios =
       event.currentTarget.querySelectorAll<HTMLButtonElement>("button");
     radios[nextIndex]?.focus();
@@ -51,7 +53,7 @@ const TimeWindowToggle: React.FC<TimeWindowToggleProps> = ({
       onKeyDown={handleKeyDown}
       className={`inline-flex h-[50px] items-center gap-0.5 rounded-md bg-surface-toggle-inactive p-[3px] lg:h-8 ${className}`}
     >
-      {TIME_WINDOWS.map((timeWindow) => {
+      {windows.map((timeWindow) => {
         const active = timeWindow === value;
         return (
           <button

--- a/web/components/visualizations/TimelineChart.tsx
+++ b/web/components/visualizations/TimelineChart.tsx
@@ -288,6 +288,7 @@ const TimelineChart: React.FC = () => {
   const surfaceRef = useRef<SVGSVGElement>(null);
   const interactionRef = useRef<ChartInteractionHandle>(null);
   const pinnedRef = useRef<HTMLDivElement>(null);
+  const handledS2SPlayNonceRef = useRef<number | null>(null);
   const [pinned, setPinned] = useState<PinnedTooltip | null>(null);
   const [mobileScrub, setMobileScrub] = useState<PinnedTooltip | null>(null);
   const inspectedLabel = pinned?.label ?? mobileScrub?.label;
@@ -642,19 +643,36 @@ const TimelineChart: React.FC = () => {
 
   useEffect(() => {
     if (page !== "s2s" || !s2sPlayRequest) return;
+    if (handledS2SPlayNonceRef.current === s2sPlayRequest.nonce) return;
     const timestamp = new Date(s2sPlayRequest.tick).getTime();
-    if (!Number.isFinite(timestamp)) return;
+    if (!Number.isFinite(timestamp)) {
+      handledS2SPlayNonceRef.current = s2sPlayRequest.nonce;
+      setPinned(null);
+      return;
+    }
     if (timestamp < xDomain[0] || timestamp > xDomain[1]) {
-      setZoom(null);
+      if (zoom) setZoom(null);
+      else {
+        handledS2SPlayNonceRef.current = s2sPlayRequest.nonce;
+        setPinned(null);
+      }
       return;
     }
     const point = windowedTimelineData.find(
       (candidate) => candidate.timestamp === timestamp
     );
     const box = interactionBox ?? plotBox();
-    if (!point || !box) return;
+    if (!point || !box) {
+      handledS2SPlayNonceRef.current = s2sPlayRequest.nonce;
+      setPinned(null);
+      return;
+    }
     const payload = tooltipPayload(point);
-    if (payload.length === 0) return;
+    handledS2SPlayNonceRef.current = s2sPlayRequest.nonce;
+    if (payload.length === 0) {
+      setPinned(null);
+      return;
+    }
     const pointX =
       box.left +
       ((timestamp - xDomain[0]) / (xDomain[1] - xDomain[0])) * box.width;
@@ -670,6 +688,7 @@ const TimelineChart: React.FC = () => {
     page,
     s2sPlayRequest,
     xDomain,
+    zoom,
     windowedTimelineData,
     interactionBox,
     plotBox,

--- a/web/components/visualizations/TimelineChart.tsx
+++ b/web/components/visualizations/TimelineChart.tsx
@@ -268,10 +268,12 @@ const TimelineChart: React.FC = () => {
     dedicatedModels,
     selectedModels,
     page,
+    s2sPlayRequest,
     requestS2SPlay,
+    normalizeProviderName,
   } = useDashboard();
   const s2sSampleIndex = s2sSampleFeed.useIndexQuery(page === "s2s").data;
-  const hasS2SRecording = useCallback(
+  const hasS2SBucketRecording = useCallback(
     (label: number) => s2sSampleIndex?.includes(bucketTickKey(label)),
     [s2sSampleIndex]
   );
@@ -283,6 +285,45 @@ const TimelineChart: React.FC = () => {
   const pinnedRef = useRef<HTMLDivElement>(null);
   const [pinned, setPinned] = useState<PinnedTooltip | null>(null);
   const [mobileScrub, setMobileScrub] = useState<PinnedTooltip | null>(null);
+  const inspectedLabel = pinned?.label ?? mobileScrub?.label;
+  const inspectedKey =
+    page === "s2s" && inspectedLabel
+      ? bucketTickKey(Number(inspectedLabel))
+      : null;
+  const inspectedTick =
+    inspectedKey && s2sSampleIndex?.includes(inspectedKey)
+      ? inspectedKey
+      : null;
+  const inspectedManifestQuery = s2sSampleFeed.useManifestQuery(inspectedTick);
+  const hasS2SProviderRecording = useCallback(
+    (label: number, provider: string) => {
+      const tick = bucketTickKey(label);
+      if (s2sSampleIndex && !s2sSampleIndex.includes(tick)) return false;
+      if (
+        tick !== inspectedTick ||
+        inspectedManifestQuery.isLoading ||
+        inspectedManifestQuery.isError ||
+        inspectedManifestQuery.isPlaceholderData
+      )
+        return undefined;
+      return (
+        inspectedManifestQuery.data?.recordings.some(
+          (recording) =>
+            normalizeProviderName(recording.provider) ===
+            normalizeProviderName(provider)
+        ) ?? false
+      );
+    },
+    [
+      inspectedManifestQuery.data,
+      inspectedManifestQuery.isError,
+      inspectedManifestQuery.isLoading,
+      inspectedManifestQuery.isPlaceholderData,
+      inspectedTick,
+      normalizeProviderName,
+      s2sSampleIndex,
+    ]
+  );
   // Synchronous mirror for the gesture handlers: a tap's pointerup must not
   // depend on the pointerdown's state update having committed.
   const mobileScrubRef = useRef<PinnedTooltip | null>(null);
@@ -555,6 +596,23 @@ const TimelineChart: React.FC = () => {
     };
   }, []);
 
+  const tooltipPayload = useCallback(
+    (point: (typeof windowedTimelineData)[number]) =>
+      modelsWithData.flatMap((model) => {
+        const value = point[`${model}_value`];
+        return typeof value === "number"
+          ? [{
+              dataKey: `${model}_value`,
+              graphicalItemId: `${model}_value`,
+              value,
+              name: formatChartLabel(model, getProviderForModel(model)),
+              color: getModelColor(model),
+            }]
+          : [];
+      }),
+    [modelsWithData, formatChartLabel, getProviderForModel]
+  );
+
   // Recharts owns the exact plot offset (including the Y axis). Mirror it so
   // the mobile touch overlays line up with the visible plot and date axis.
   const syncInteractionBox = useCallback(() => {
@@ -576,6 +634,42 @@ const TimelineChart: React.FC = () => {
     const frame = requestAnimationFrame(syncInteractionBox);
     return () => cancelAnimationFrame(frame);
   }, [isMobile, syncInteractionBox, windowedTimelineData, zoom, yAxisMax]);
+
+  useEffect(() => {
+    if (page !== "s2s" || !s2sPlayRequest) return;
+    const timestamp = new Date(s2sPlayRequest.tick).getTime();
+    if (!Number.isFinite(timestamp)) return;
+    if (timestamp < xDomain[0] || timestamp > xDomain[1]) {
+      setZoom(null);
+      return;
+    }
+    const point = windowedTimelineData.find(
+      (candidate) => candidate.timestamp === timestamp
+    );
+    const box = interactionBox ?? plotBox();
+    if (!point || !box) return;
+    const payload = tooltipPayload(point);
+    if (payload.length === 0) return;
+    const pointX =
+      box.left +
+      ((timestamp - xDomain[0]) / (xDomain[1] - xDomain[0])) * box.width;
+    const onLeft = pointX < box.left + box.width / 2;
+    setPinned({
+      label: String(timestamp),
+      payload,
+      x: onLeft ? box.left + box.width : box.left,
+      y: box.top + box.height / 2,
+      flip: onLeft,
+    });
+  }, [
+    page,
+    s2sPlayRequest,
+    xDomain,
+    windowedTimelineData,
+    interactionBox,
+    plotBox,
+    tooltipPayload,
+  ]);
 
   const endDrag = () => {
     dragRef.current = null;
@@ -701,18 +795,7 @@ const TimelineChart: React.FC = () => {
         ? candidate
         : nearest
     );
-    const payload = modelsWithData.flatMap((model) => {
-      const value = point[`${model}_value`];
-      return typeof value === "number"
-        ? [{
-            dataKey: `${model}_value`,
-            graphicalItemId: `${model}_value`,
-            value,
-            name: formatChartLabel(model, getProviderForModel(model)),
-            color: getModelColor(model),
-          }]
-        : [];
-    });
+    const payload = tooltipPayload(point);
     if (payload.length === 0) {
       updateMobileScrub(null);
       return;
@@ -825,9 +908,16 @@ const TimelineChart: React.FC = () => {
   // Mobile has no hover cursor, so a vertical playhead marks the instant being
   // scrubbed or pinned — the timestamp both the compact readout and the pinned
   // list are reading from.
-  const scrubMarkerTs = isMobile
-    ? Number(mobileScrub?.label ?? pinned?.label ?? NaN)
-    : NaN;
+  const selectedSampleTs =
+    page === "s2s"
+      ? new Date(s2sPlayRequest?.tick ?? s2sSampleIndex?.[0] ?? "").getTime()
+      : NaN;
+  const interactionMarkerTs = Number(
+    pinned?.label ?? (isMobile ? mobileScrub?.label : NaN)
+  );
+  const scrubMarkerTs = Number.isFinite(interactionMarkerTs)
+    ? interactionMarkerTs
+    : selectedSampleTs;
 
   return (
     <div className="mb-4">
@@ -857,7 +947,7 @@ const TimelineChart: React.FC = () => {
                       metric,
                       latency_ms: value,
                       ...(page === "s2s"
-                        ? { conversation_sample_recorded: hasS2SRecording(point.timestamp) ?? false }
+                        ? { conversation_sample_recorded: hasS2SBucketRecording(point.timestamp) ?? false }
                         : {}),
                     }]
                   : [];
@@ -954,20 +1044,7 @@ const TimelineChart: React.FC = () => {
                 const point = windowedTimelineData.find(
                   (candidate) => candidate.timestamp === Number(lbl)
                 );
-                const payload = point
-                  ? modelsWithData.flatMap((model) => {
-                      const value = point[`${model}_value`];
-                      return typeof value === "number"
-                        ? [{
-                            dataKey: `${model}_value`,
-                            graphicalItemId: `${model}_value`,
-                            value,
-                            name: formatChartLabel(model, getProviderForModel(model)),
-                            color: getModelColor(model),
-                          }]
-                        : [];
-                    })
-                  : [];
+                const payload = point ? tooltipPayload(point) : [];
                 const hasRows = payload.some(
                   (item) => typeof item?.value === "number" && item.value > 0
                 );
@@ -1046,7 +1123,7 @@ const TimelineChart: React.FC = () => {
                     dimmedKeys={dimmedLegendKeys}
                     compact
                     timeZone={displayTz}
-                    hasRecording={page === "s2s" ? hasS2SRecording : undefined}
+                    hasRecording={page === "s2s" ? hasS2SBucketRecording : undefined}
                   />
                 }
                 active={pinned || dragging || hoveredMarker || isMobile ? false : undefined}
@@ -1216,7 +1293,7 @@ const TimelineChart: React.FC = () => {
                 compact
                 interactionHint="tap axis to see all"
                 timeZone={displayTz}
-                hasRecording={page === "s2s" ? hasS2SRecording : undefined}
+                hasRecording={page === "s2s" ? hasS2SProviderRecording : undefined}
               />
             </div>
           )}
@@ -1254,7 +1331,7 @@ const TimelineChart: React.FC = () => {
                 dimmedKeys={dimmedLegendKeys}
                 maxHeight={isMobile ? 106 : undefined}
                 timeZone={displayTz}
-                hasRecording={page === "s2s" ? hasS2SRecording : undefined}
+                hasRecording={page === "s2s" ? hasS2SProviderRecording : undefined}
                 onModelClick={
                   page === "s2s"
                     ? (model, label) =>

--- a/web/components/visualizations/TimelineChart.tsx
+++ b/web/components/visualizations/TimelineChart.tsx
@@ -17,7 +17,12 @@ import {
 } from "recharts";
 import { getModelColor } from "@/lib/utils/colors";
 import { DedicatedInfoIcon } from "@/components/shared/DedicatedInferenceInfo";
-import { formatDate, formatTime, getLocalTimeZoneAbbr } from "@/lib/utils/formatters";
+import {
+  formatDate,
+  formatTime,
+  getLocalTimeZoneAbbr,
+  parseModelKey,
+} from "@/lib/utils/formatters";
 import { metricDescriptions } from "@/lib/config/metrics";
 import {
   methodologyChanges,
@@ -942,12 +947,12 @@ const TimelineChart: React.FC = () => {
                 return typeof value === "number"
                   ? [{
                       timestamp: point.timestampLabel,
-                      model,
+                      model: parseModelKey(model).model,
                       provider: getProviderForModel(model),
                       metric,
                       latency_ms: value,
                       ...(page === "s2s"
-                        ? { conversation_sample_recorded: hasS2SBucketRecording(point.timestamp) ?? false }
+                        ? { conversation_bucket_has_sample: hasS2SBucketRecording(point.timestamp) }
                         : {}),
                     }]
                   : [];

--- a/web/components/visualizations/TimelineChart.tsx
+++ b/web/components/visualizations/TimelineChart.tsx
@@ -37,6 +37,7 @@ import { useDashboard } from "@/contexts/DashboardContext";
 import { useThemeColors } from "@/hooks/useThemeColors";
 import { useChartHoverTracking } from "@/hooks/useChartHoverTracking";
 import { useMobileDetection } from "@/hooks/useMobileDetection";
+import { s2sSampleFeed } from "@/lib/audioSamples/s2sFeed";
 
 interface LegendEntry {
   value: string;
@@ -269,6 +270,11 @@ const TimelineChart: React.FC = () => {
     page,
     requestS2SPlay,
   } = useDashboard();
+  const s2sSampleIndex = s2sSampleFeed.useIndexQuery(page === "s2s").data;
+  const hasS2SRecording = useCallback(
+    (label: number) => s2sSampleIndex?.includes(bucketTickKey(label)),
+    [s2sSampleIndex]
+  );
   const trackChartHover = useChartHoverTracking("timeline");
 
   const chartRef = useRef<HTMLDivElement>(null);
@@ -471,7 +477,12 @@ const TimelineChart: React.FC = () => {
       ),
     [zoomX]
   );
-  const timelineTicks = useMemo(getTimelineTicks, [getTimelineTicks]);
+  const timelineTicks = useMemo(() => {
+    const ticks = getTimelineTicks();
+    return isMobile && isS2S && ticks.length > 4
+      ? ticks.filter((_, index) => index % 2 === 0)
+      : ticks;
+  }, [getTimelineTicks, isMobile, isS2S]);
   const dateScale = dataTimeWindow !== "24h";
   const dateTicks =
     dateScale && !(zoomX && zoomX[1] - zoomX[0] <= 48 * 60 * 60 * 1000);
@@ -835,15 +846,23 @@ const TimelineChart: React.FC = () => {
           }
           exportNote={metricTab}
           exportRows={() =>
-            windowedTimelineData.map((point) => ({
-              time: point.timestampLabel,
-              ...Object.fromEntries(
-                modelsWithData.map((model) => [
-                  `${model}_${metric}_ms`,
-                  point[`${model}_value`],
-                ])
-              ),
-            }))
+            windowedTimelineData.flatMap((point) =>
+              modelsWithData.flatMap((model) => {
+                const value = point[`${model}_value`];
+                return typeof value === "number"
+                  ? [{
+                      timestamp: point.timestampLabel,
+                      model,
+                      provider: getProviderForModel(model),
+                      metric,
+                      latency_ms: value,
+                      ...(page === "s2s"
+                        ? { conversation_sample_recorded: hasS2SRecording(point.timestamp) ?? false }
+                        : {}),
+                    }]
+                  : [];
+              })
+            )
           }
           stat={{
             label: (
@@ -1027,6 +1046,7 @@ const TimelineChart: React.FC = () => {
                     dimmedKeys={dimmedLegendKeys}
                     compact
                     timeZone={displayTz}
+                    hasRecording={page === "s2s" ? hasS2SRecording : undefined}
                   />
                 }
                 active={pinned || dragging || hoveredMarker || isMobile ? false : undefined}
@@ -1196,6 +1216,7 @@ const TimelineChart: React.FC = () => {
                 compact
                 interactionHint="tap axis to see all"
                 timeZone={displayTz}
+                hasRecording={page === "s2s" ? hasS2SRecording : undefined}
               />
             </div>
           )}
@@ -1233,6 +1254,7 @@ const TimelineChart: React.FC = () => {
                 dimmedKeys={dimmedLegendKeys}
                 maxHeight={isMobile ? 106 : undefined}
                 timeZone={displayTz}
+                hasRecording={page === "s2s" ? hasS2SRecording : undefined}
                 onModelClick={
                   page === "s2s"
                     ? (model, label) =>

--- a/web/hooks/useDashboardState.tsx
+++ b/web/hooks/useDashboardState.tsx
@@ -70,9 +70,16 @@ export function useDashboardState(page: "tts" | "stt" | "s2s") {
       source: "samples",
     }));
   }, []);
-  const { timeWindow, changeTimeWindow } = useTimeWindow(
+  const { timeWindow, changeTimeWindow: setTimeWindow } = useTimeWindow(
     `${page}_dashboard`,
     page
+  );
+  const changeTimeWindow = useCallback(
+    (next: typeof timeWindow) => {
+      if (next !== timeWindow) setS2sPlayRequest(null);
+      setTimeWindow(next);
+    },
+    [setTimeWindow, timeWindow]
   );
 
   const benchmarkParam =

--- a/web/hooks/useDashboardState.tsx
+++ b/web/hooks/useDashboardState.tsx
@@ -55,20 +55,21 @@ export function useDashboardState(page: "tts" | "stt" | "s2s") {
     nonce: number;
     source: "timeline" | "samples";
   } | null>(null);
+  const s2sPlayNonceRef = useRef(0);
   const requestS2SPlay = useCallback((tick: string, provider: string) => {
-    setS2sPlayRequest((prev) => ({
+    setS2sPlayRequest({
       tick,
       provider,
-      nonce: (prev?.nonce ?? 0) + 1,
+      nonce: ++s2sPlayNonceRef.current,
       source: "timeline",
-    }));
+    });
   }, []);
   const selectS2SSample = useCallback((tick: string) => {
-    setS2sPlayRequest((prev) => ({
+    setS2sPlayRequest({
       tick,
-      nonce: (prev?.nonce ?? 0) + 1,
+      nonce: ++s2sPlayNonceRef.current,
       source: "samples",
-    }));
+    });
   }, []);
   const { timeWindow, changeTimeWindow: setTimeWindow } = useTimeWindow(
     `${page}_dashboard`,

--- a/web/hooks/useDashboardState.tsx
+++ b/web/hooks/useDashboardState.tsx
@@ -49,21 +49,27 @@ export function useDashboardState(page: "tts" | "stt" | "s2s") {
   const activeMetric =
     page === "s2s" ? "V2V" : page === "tts" ? "TTFA" : sttMetric;
 
-  // S2S only: a click on a model row in the pinned timeline tooltip asks the
-  // samples card to jump to that bucket + provider and play. nonce lets a repeat
-  // click on the same row replay.
   const [s2sPlayRequest, setS2sPlayRequest] = useState<{
     tick: string;
-    provider: string;
+    provider?: string;
     nonce: number;
+    source: "timeline" | "samples";
   } | null>(null);
   const requestS2SPlay = useCallback((tick: string, provider: string) => {
-    setS2sPlayRequest((prev) => ({ tick, provider, nonce: (prev?.nonce ?? 0) + 1 }));
+    setS2sPlayRequest((prev) => ({
+      tick,
+      provider,
+      nonce: (prev?.nonce ?? 0) + 1,
+      source: "timeline",
+    }));
   }, []);
-  // Releasing the request hands the card back to the newest tick. Without this a
-  // single click pins it forever, so landing on a day that has metrics but no
-  // recording leaves the card empty with no way back.
-  const clearS2SPlay = useCallback(() => setS2sPlayRequest(null), []);
+  const selectS2SSample = useCallback((tick: string) => {
+    setS2sPlayRequest((prev) => ({
+      tick,
+      nonce: (prev?.nonce ?? 0) + 1,
+      source: "samples",
+    }));
+  }, []);
   const { timeWindow, changeTimeWindow } = useTimeWindow(
     `${page}_dashboard`,
     page
@@ -645,10 +651,9 @@ export function useDashboardState(page: "tts" | "stt" | "s2s") {
     page,
     latencyLabel,
 
-    // S2S samples card <-> timeline tooltip bridge
     s2sPlayRequest,
     requestS2SPlay,
-    clearS2SPlay,
+    selectS2SSample,
 
     // Display strings
     pageTitle,

--- a/web/hooks/useTimeWindow.ts
+++ b/web/hooks/useTimeWindow.ts
@@ -10,10 +10,12 @@ import {
   type PostHogMode,
   type PostHogSurface,
 } from "@/lib/posthog/events";
-import type { TimeWindow } from "@/lib/config/timeWindows";
+import { timeWindowsFor, type TimeWindow } from "@/lib/config/timeWindows";
 
 export function useTimeWindow(surface: PostHogSurface, mode?: PostHogMode) {
-  const [timeWindow, setTimeWindow] = useState<TimeWindow>("24h");
+  const [timeWindow, setTimeWindow] = useState<TimeWindow>(
+    () => timeWindowsFor(mode)[0] ?? "24h"
+  );
 
   const changeTimeWindow = useCallback(
     (next: TimeWindow) => {

--- a/web/lib/audioSamples/createSampleFeed.ts
+++ b/web/lib/audioSamples/createSampleFeed.ts
@@ -116,10 +116,11 @@ export function createSampleFeed<TManifest>(
     refetchInterval: config.refetchMs,
   } as const;
 
-  const useIndexQuery = () =>
+  const useIndexQuery = (enabled = true) =>
     useQuery({
       queryKey: [config.name, "index"],
       queryFn: ({ signal }: { signal: AbortSignal }) => fetchIndex(signal),
+      enabled,
       ...cadence,
     });
 

--- a/web/lib/audioSamples/createSampleFeed.ts
+++ b/web/lib/audioSamples/createSampleFeed.ts
@@ -3,7 +3,7 @@
 
 "use client";
 
-import { useQuery } from "@tanstack/react-query";
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
 
 // Generic reader for a modality's public sample bucket. The fetch job publishes
 // one folder per tick (keyed by the timeline bucket timestamp) with a
@@ -129,6 +129,7 @@ export function createSampleFeed<TManifest>(
       queryKey: [config.name, "manifest", tick],
       queryFn: ({ signal }: { signal: AbortSignal }) => fetchManifest(tick!, signal),
       enabled: tick != null,
+      placeholderData: keepPreviousData,
       ...cadence,
     });
 

--- a/web/lib/config/timeWindows.ts
+++ b/web/lib/config/timeWindows.ts
@@ -5,6 +5,12 @@ const DAY_MS = 24 * 60 * 60 * 1000;
 
 export const TIME_WINDOWS = ["24h", "7d", "30d"] as const;
 export type TimeWindow = (typeof TIME_WINDOWS)[number];
+export const S2S_24H_ENABLED = false;
+
+export const timeWindowsFor = (mode?: "tts" | "stt" | "s2s") =>
+  mode === "s2s" && !S2S_24H_ENABLED
+    ? TIME_WINDOWS.filter((window) => window !== "24h")
+    : TIME_WINDOWS;
 
 // Values mirror the API's window literals; "1d" is display-only.
 export const WINDOW_LABELS: Record<TimeWindow, string> = {

--- a/web/lib/utils/chartExport.test.ts
+++ b/web/lib/utils/chartExport.test.ts
@@ -1,0 +1,25 @@
+// Copyright 2026 The Coval Benchmarks Authors
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+import { serializeCSV } from "./csv";
+
+describe("serializeCSV", () => {
+  it("keeps later-row columns and leaves missing values blank", () => {
+    expect(serializeCSV([{ model: "a" }, { model: "b", runs: 2 }])).toBe(
+      "model,runs\r\na,\r\nb,2"
+    );
+  });
+
+  it("escapes quotes, commas, and line breaks", () => {
+    expect(
+      serializeCSV([{ model: 'A, "quoted"', detail: "line 1\r\nline 2" }])
+    ).toBe('model,detail\r\n"A, ""quoted""","line 1\r\nline 2"');
+  });
+
+  it("exports null and non-finite values as blank cells", () => {
+    expect(
+      serializeCSV([{ a: null, b: undefined, c: NaN, d: Infinity }])
+    ).toBe("a,b,c,d\r\n,,,");
+  });
+});

--- a/web/lib/utils/chartExport.ts
+++ b/web/lib/utils/chartExport.ts
@@ -16,7 +16,9 @@ const triggerDownload = (href: string, filename: string) => {
   const a = document.createElement("a");
   a.href = href;
   a.download = filename;
+  document.body.appendChild(a);
   a.click();
+  a.remove();
   // Browsers may read the blob URL after click() returns; revoking in the same
   // tick can abort the download, so defer it.
   window.setTimeout(() => URL.revokeObjectURL(href), 0);
@@ -36,7 +38,7 @@ export function downloadCSV(
 ) {
   const [first] = rows;
   if (!first) return;
-  const headers = Object.keys(first);
+  const headers = Array.from(new Set(rows.flatMap((row) => Object.keys(row))));
   const escape = (value: unknown) => {
     const s = String(value ?? "");
     return /[",\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
@@ -584,8 +586,10 @@ export async function downloadChartPNG(
     logoWidth,
     logoHeight
   );
-  canvas.toBlob((blob) => {
-    if (blob) triggerDownload(URL.createObjectURL(blob), filename);
+  return new Promise((resolve) => {
+    canvas.toBlob((blob) => {
+      if (blob) triggerDownload(URL.createObjectURL(blob), filename);
+      resolve(!!blob);
+    });
   });
-  return true;
 }

--- a/web/lib/utils/chartExport.ts
+++ b/web/lib/utils/chartExport.ts
@@ -587,8 +587,13 @@ export async function downloadChartPNG(
   );
   return new Promise((resolve) => {
     canvas.toBlob((blob) => {
-      if (blob) triggerDownload(URL.createObjectURL(blob), filename);
-      resolve(!!blob);
+      try {
+        if (!blob) return resolve(false);
+        triggerDownload(URL.createObjectURL(blob), filename);
+        resolve(true);
+      } catch {
+        resolve(false);
+      }
     });
   });
 }

--- a/web/lib/utils/chartExport.ts
+++ b/web/lib/utils/chartExport.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { LIGHT_CHART_COLORS, type ThemeColors } from "@/hooks/useThemeColors";
+import { serializeCSV } from "@/lib/utils/csv";
 
 // The export mirrors the on-screen theme. Chrome colours come from the same
 // chart-* palette the charts render with; the shared light palette is the
@@ -35,22 +36,20 @@ const loadImage = (src: string) =>
 export function downloadCSV(
   rows: Record<string, unknown>[],
   filename: string
-) {
-  const [first] = rows;
-  if (!first) return;
-  const headers = Array.from(new Set(rows.flatMap((row) => Object.keys(row))));
-  const escape = (value: unknown) => {
-    const s = String(value ?? "");
-    return /[",\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
-  };
-  const csv = [
-    headers.join(","),
-    ...rows.map((row) => headers.map((h) => escape(row[h])).join(",")),
-  ].join("\n");
-  triggerDownload(
-    URL.createObjectURL(new Blob([csv], { type: "text/csv" })),
-    filename
-  );
+): boolean {
+  const csv = serializeCSV(rows);
+  if (!csv) return false;
+  try {
+    triggerDownload(
+      URL.createObjectURL(
+        new Blob(["\uFEFF", csv], { type: "text/csv;charset=utf-8" })
+      ),
+      filename
+    );
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 interface LegendItem {

--- a/web/lib/utils/csv.ts
+++ b/web/lib/utils/csv.ts
@@ -1,0 +1,17 @@
+// Copyright 2026 The Coval Benchmarks Authors
+// SPDX-License-Identifier: Apache-2.0
+
+export function serializeCSV(rows: Record<string, unknown>[]): string {
+  const [first] = rows;
+  if (!first) return "";
+  const headers = Array.from(new Set(rows.flatMap((row) => Object.keys(row))));
+  const escape = (value: unknown) => {
+    if (typeof value === "number" && !Number.isFinite(value)) return "";
+    const s = String(value ?? "");
+    return /[",\r\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
+  };
+  return [
+    headers.map(escape).join(","),
+    ...rows.map((row) => headers.map((h) => escape(row[h])).join(",")),
+  ].join("\r\n");
+}


### PR DESCRIPTION
## Summary
<img width="1563" height="782" alt="Screenshot 2026-07-29 at 3 58 24 PM" src="https://github.com/user-attachments/assets/d5070195-f2d0-47bb-9166-4b4c502ed7d8" />

- promote Conversation samples to a full-width primary card with a scalable horizontal model carousel
- hide the S2S 1-day window behind a single re-enable flag and default S2S to 7 days
- distinguish timeline points without recordings, remove unavailable play actions, and scroll playable selections into view
- improve mobile chart labels and comparison-table navigation
- harden copy-link, CSV, and PNG exports and provide structured timeline export rows

## Why

S2S runs currently arrive once per day, so the 1-day view is not useful. Conversation samples were visually secondary and cramped as model count grows, missing recordings looked playable, and shared exports could silently fail or omit later-row CSV fields.

## Impact

The S2S dashboard is easier to scan, scales to additional models, behaves clearly on touch devices, and produces more reliable chart exports. This is frontend-only; no backend, API, authentication, environment, or deployment behavior changes.

## Validation

- `pnpm typecheck`
- `pnpm lint`
- `pnpm test` — 91 tests passed
- `git diff --check`
- local desktop and mobile verification at `localhost:3000/s2s`
