### PR TITLE
Add Grok Voice Think Fast 2.0 under early access

### DIFF
--- a/runner/src/coval_bench/config.py
+++ b/runner/src/coval_bench/config.py
@@ -131,6 +131,7 @@ class Settings(BaseSettings):
     coval_s2s_openai_agent_id: str | None = None
     coval_s2s_gemini_agent_id: str | None = None
     coval_s2s_xai_agent_id: str | None = None
+    coval_s2s_xai_think_fast_2_agent_id: str | None = None
     # The S2S instruction-adherence metric id (opaque, not secret). Optional: the
     # fetch pulls its per-conversation scores only when set, so latency still
     # ingests without it.

--- a/runner/src/coval_bench/registries/models.py
+++ b/runner/src/coval_bench/registries/models.py
@@ -822,6 +822,13 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         tags=(_STREAMING, _MULTI),
         status=_EARLY_ACCESS,
     ),
+    RegisteredModel(
+        benchmark=_S2S,
+        provider="xai",
+        model="grok-voice-think-fast-2.0",
+        tags=(_STREAMING, _MULTI),
+        status=_EARLY_ACCESS,
+    ),
 ]
 
 _key_counts = Counter((m.benchmark, m.provider, m.model) for m in MODEL_REGISTRY)

--- a/runner/src/coval_bench/s2s/fetch_v2v.py
+++ b/runner/src/coval_bench/s2s/fetch_v2v.py
@@ -28,7 +28,7 @@ from coval_bench.db.models import Result, ResultStatus, RunStatus
 from coval_bench.db.writer import RunWriter
 from coval_bench.registries import Metric
 from coval_bench.registries.benchmarks import Benchmark
-from coval_bench.s2s.samples import SampleRun, publish_tick_sample
+from coval_bench.s2s.samples import SampleRun, model_labels, publish_tick_sample
 
 logger = structlog.get_logger("coval_bench.s2s.fetch_v2v")
 
@@ -70,6 +70,11 @@ AGENTS: tuple[AgentSpec, ...] = (
     AgentSpec(agent_id_attr="coval_s2s_openai_agent_id", provider="openai", model="gpt-realtime"),
     AgentSpec(agent_id_attr="coval_s2s_gemini_agent_id", provider="google", model="gemini-live"),
     AgentSpec(agent_id_attr="coval_s2s_xai_agent_id", provider="xai", model="grok-realtime"),
+    AgentSpec(
+        agent_id_attr="coval_s2s_xai_think_fast_2_agent_id",
+        provider="xai",
+        model="grok-voice-think-fast-2.0",
+    ),
 )
 
 
@@ -635,7 +640,7 @@ async def fetch_and_write_v2v(settings: Settings | None = None) -> dict[str, Run
             if not agent_id:
                 logger.warning("agent_id_unset", provider=spec.provider, attr=spec.agent_id_attr)
                 continue
-            statuses[spec.provider], ingested = await _fetch_one_provider(
+            statuses[f"{spec.provider}:{spec.model}"], ingested = await _fetch_one_provider(
                 client,
                 writer,
                 spec=spec,
@@ -657,19 +662,23 @@ async def fetch_and_write_v2v(settings: Settings | None = None) -> dict[str, Run
                 logger.warning("refresh_stats_matviews_failed", exc_info=True)
 
         if settings.s2s_samples_bucket and sampled_runs and test_set_id:
-            expected = {spec.provider for spec in AGENTS if getattr(settings, spec.agent_id_attr)}
-            missing = expected - {r.provider for r in sampled_runs}
+            expected = {
+                (spec.provider, spec.model)
+                for spec in AGENTS
+                if getattr(settings, spec.agent_id_attr)
+            }
+            missing = expected - {r.key for r in sampled_runs}
             if missing:
-                # Error level on purpose: this is the alert that a provider is
+                # Error level on purpose: this is the alert that a model is
                 # absent from the window, so no day in it can publish a sample.
-                logger.error("samples_provider_missing", missing=sorted(missing))
+                logger.error("samples_provider_missing", missing=model_labels(missing))
             await publish_tick_sample(
                 client,
                 bucket_name=settings.s2s_samples_bucket,
                 test_set_id=test_set_id,
                 runs=sampled_runs,
                 rng=random.Random(),  # noqa: S311
-                expected_providers=expected,
+                expected_models=expected,
             )
         logger.info(
             "s2s_fetch_done",

--- a/runner/src/coval_bench/s2s/samples.py
+++ b/runner/src/coval_bench/s2s/samples.py
@@ -3,11 +3,11 @@
 
 """Publish one multi-turn conversation sample per fetch tick.
 
-Each tick picks ONE (scenario, persona) present for every provider, uploads
-each provider's full-conversation recording plus its per-agent transcript into
-the public samples bucket, and writes a ``manifest.json`` keyed by the timeline
-bucket timestamp. Only a fully-complete sample (audio + transcript for every
-provider) is published; otherwise the tick is skipped. The dashboard reads the
+Each tick picks ONE (scenario, persona) present for every benchmarked model,
+uploads each model's full-conversation recording plus its per-agent transcript
+into the public samples bucket, and writes a ``manifest.json`` keyed by the
+timeline bucket timestamp. Only a fully-complete sample (audio + transcript for
+every model) is published; otherwise the tick is skipped. The dashboard reads the
 manifests directly (public bucket, no API hop); a rolling ``index.json`` lists
 the available ticks newest-first. The bucket's 30-day TTL prunes old ticks.
 
@@ -17,7 +17,7 @@ Sampling failures never fail the fetch — the metric rows are the product.
 from __future__ import annotations
 
 import json
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Iterable
 from dataclasses import dataclass
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, cast
@@ -68,6 +68,16 @@ class SampleRun:
     bucket_at: datetime
     persona_id: str = ""
     agent_id: str = ""
+
+    @property
+    def key(self) -> tuple[str, str]:
+        """Identity of the benchmarked model: a provider may carry several."""
+        return (self.provider, self.model)
+
+
+def model_labels(keys: Iterable[tuple[str, str]]) -> list[str]:
+    """``(provider, model)`` pairs as sorted ``provider:model`` strings for logs."""
+    return sorted(f"{provider}:{model}" for provider, model in keys)
 
 
 _SPOKEN_ROLES = frozenset({"user", "assistant"})
@@ -204,13 +214,13 @@ async def publish_tick_sample(
     rng: Random,
     storage_client: storage.Client | None = None,
     download_client: httpx.AsyncClient | None = None,
-    expected_providers: set[str] | None = None,
+    expected_models: set[tuple[str, str]] | None = None,
 ) -> int:
-    """Copy one multi-turn conversation (every provider, one persona) as a v2 sample.
+    """Copy one multi-turn conversation (every model, one persona) as a v2 sample.
 
-    ``expected_providers`` is the configured provider set a sample must cover.
-    Pass it: without it completeness is judged against whichever providers turned
-    up, so a day one provider sat out would publish a lopsided comparison.
+    ``expected_models`` is the configured ``(provider, model)`` set a sample must
+    cover. Pass it: without it completeness is judged against whichever models
+    turned up, so a day one model sat out would publish a lopsided comparison.
 
     Never raises: any failure is logged and the tick is simply skipped.
     """
@@ -226,7 +236,7 @@ async def publish_tick_sample(
                 runs=runs,
                 rng=rng,
                 storage_client=storage_client,
-                expected_providers=expected_providers,
+                expected_models=expected_models,
             )
     except Exception:
         logger.error("samples_tick_failed", exc_info=True)
@@ -242,7 +252,7 @@ async def _publish_tick_sample(
     runs: list[SampleRun],
     rng: Random,
     storage_client: storage.Client | None,
-    expected_providers: set[str] | None,
+    expected_models: set[tuple[str, str]] | None,
 ) -> int:
     """Publish a sample for EVERY bucket present in ``runs``, oldest first.
 
@@ -251,7 +261,7 @@ async def _publish_tick_sample(
     republishes if it never landed, and is skipped cheaply if it did (the
     manifest-exists check below). One bucket failing never blocks the others.
 
-    Each bucket must cover ``expected_providers`` on its own. A provider can be
+    Each bucket must cover ``expected_models`` on its own. A model can be
     present for today and absent for yesterday, and judging each bucket against
     only its own runs would call that yesterday complete.
     """
@@ -276,7 +286,7 @@ async def _publish_tick_sample(
                 runs=by_bucket[bucket_at],
                 bucket_at=bucket_at,
                 rng=rng,
-                expected_providers=expected_providers,
+                expected_models=expected_models,
             )
         except Exception:
             logger.error(
@@ -296,7 +306,7 @@ async def _publish_one_bucket(
     runs: list[SampleRun],
     bucket_at: datetime,
     rng: Random,
-    expected_providers: set[str] | None,
+    expected_models: set[tuple[str, str]] | None,
 ) -> int:
     tick_key = bucket_at.strftime(_TICK_FORMAT)
     manifest_key = f"{PREFIX}/{tick_key}/manifest.json"
@@ -309,66 +319,70 @@ async def _publish_one_bucket(
         logger.info("samples_tick_exists", tick=tick_key)
         return 0
 
-    providers = expected_providers or {r.provider for r in runs}
-    absent = providers - {r.provider for r in runs}
+    expected = expected_models or {r.key for r in runs}
+    absent = expected - {r.key for r in runs}
     if absent:
-        logger.error("samples_bucket_provider_absent", tick=tick_key, absent=sorted(absent))
+        logger.error("samples_bucket_provider_absent", tick=tick_key, absent=model_labels(absent))
         return 0
 
     # A "conversation" is one (test_case, persona) pair — the same scenario and
     # the same simulated caller, which is what makes the sample comparable across
-    # providers. Group runs by persona; only a persona present for EVERY provider
-    # can yield a conversation. sims[(persona, provider)] = {test_case_id: sim_id}.
-    runs_by_persona: dict[str, dict[str, SampleRun]] = {}
+    # models. Group runs by persona; only a persona present for EVERY model can
+    # yield a conversation. sims[(persona, provider, model)] = {test_case_id: sim_id}.
+    runs_by_persona: dict[str, dict[tuple[str, str], SampleRun]] = {}
     for run in runs:
-        runs_by_persona.setdefault(run.persona_id, {})[run.provider] = run
+        runs_by_persona.setdefault(run.persona_id, {})[run.key] = run
 
-    sims: dict[tuple[str, str], dict[str, str]] = {}
+    sims: dict[tuple[str, str, str], dict[str, str]] = {}
     pool: list[tuple[str, str]] = []
-    for persona_id, prov_runs in runs_by_persona.items():
-        if set(prov_runs) != providers:
+    for persona_id, model_runs in runs_by_persona.items():
+        if set(model_runs) != expected:
             logger.error(
                 "samples_persona_incomplete",
                 persona=persona_id,
-                missing=sorted(providers - set(prov_runs)),
+                missing=model_labels(expected - set(model_runs)),
             )
             continue
-        for provider, run in prov_runs.items():
+        for (provider, model), run in model_runs.items():
 
             async def list_sims(run: SampleRun = run) -> dict[str, str]:
                 return await _sims_by_test_case(client, run.coval_run_id)
 
             try:
-                sims[(persona_id, provider)] = await _fetch_retry(
+                sims[(persona_id, provider, model)] = await _fetch_retry(
                     list_sims, provider=provider, what="sims_list"
                 )
             except Exception:
-                logger.error("samples_provider_missing", missing=[provider], exc_info=True)
-                sims[(persona_id, provider)] = {}
-        shared = set.intersection(*(set(sims[(persona_id, p)]) for p in providers))
+                logger.error(
+                    "samples_provider_missing",
+                    missing=model_labels({(provider, model)}),
+                    exc_info=True,
+                )
+                sims[(persona_id, provider, model)] = {}
+        shared = set.intersection(*(set(sims[(persona_id, p, m)]) for p, m in expected))
         pool.extend((persona_id, tc) for tc in sorted(shared))
 
     if not pool:
         logger.error(
             "samples_no_shared_clip",
             tick=tick_key,
-            providers=sorted(providers),
+            models=model_labels(expected),
             personas=sorted(runs_by_persona),
             runs=[r.coval_run_id for r in runs],
         )
         return 0
 
     # Uniform draw over the shared conversations of both personas; repick on any
-    # incomplete provider so only a fully-complete conversation (audio + turns for
-    # EVERY provider) is ever surfaced.
+    # incomplete model so only a fully-complete conversation (audio + turns for
+    # EVERY model) is ever surfaced.
     rng.shuffle(pool)
     for persona_id, test_case_id in pool:
-        prov_runs = runs_by_persona[persona_id]
+        model_runs = runs_by_persona[persona_id]
         blocked_by: str | None = None
         staged: list[tuple[SampleRun, str, bytes, list[dict[str, Any]]]] = []
-        for provider in sorted(providers):
-            run = prov_runs[provider]
-            sim_id = sims[(persona_id, provider)][test_case_id]
+        for provider, model in sorted(expected):
+            run = model_runs[(provider, model)]
+            sim_id = sims[(persona_id, provider, model)][test_case_id]
             audio: bytes | None = None
             turns: list[dict[str, Any]] = []
             try:
@@ -387,25 +401,31 @@ async def _publish_one_bucket(
 
                 audio = await _fetch_retry(fetch_recording, provider=provider, what="recording")
             except Exception:
-                logger.error("sample_copy_failed", provider=provider, sim_id=sim_id, exc_info=True)
+                logger.error(
+                    "sample_copy_failed",
+                    provider=provider,
+                    model=model,
+                    sim_id=sim_id,
+                    exc_info=True,
+                )
             if audio is None or not turns:
-                blocked_by = provider
+                blocked_by = f"{provider}:{model}"
                 break
             staged.append((run, sim_id, audio, turns))
 
-        if len(staged) != len(providers):
+        if len(staged) != len(expected):
             logger.info(
                 "sample_incomplete_skipped",
                 tick=tick_key,
                 persona=persona_id,
                 test_case_id=test_case_id,
-                provider=blocked_by,
+                model=blocked_by,
             )
             continue
 
         recordings: list[dict[str, Any]] = []
         for s_run, s_sim_id, s_audio, s_turns in staged:
-            key = f"{PREFIX}/{tick_key}/{s_run.provider}.wav"
+            key = f"{PREFIX}/{tick_key}/{s_run.provider}/{s_run.model}.wav"
             _upload(bucket, key, s_audio, "audio/wav")
             recordings.append(
                 {
@@ -440,7 +460,7 @@ async def _publish_one_bucket(
     logger.error(
         "samples_no_complete_sample",
         tick=tick_key,
-        providers=sorted(providers),
+        models=model_labels(expected),
         attempted=len(pool),
         test_case_ids=sorted({tc for _, tc in pool}),
     )

--- a/runner/tests/unit/test_s2s_fetch.py
+++ b/runner/tests/unit/test_s2s_fetch.py
@@ -377,7 +377,7 @@ async def test_fetch_and_write_v2v_per_provider(monkeypatch: pytest.MonkeyPatch)
     statuses = await fetch_v2v.fetch_and_write_v2v(settings)
 
     # only openai runs (gemini unset), and it fully succeeds.
-    assert statuses == {"openai": RunStatus.SUCCEEDED}
+    assert statuses == {"openai:gpt-realtime": RunStatus.SUCCEEDED}
     writer.refresh_stats_matviews.assert_awaited_once()
 
 
@@ -407,7 +407,7 @@ async def test_fetch_and_write_v2v_noop_skips_matview_refresh(
 
     statuses = await fetch_v2v.fetch_and_write_v2v(settings)
 
-    assert statuses == {"openai": RunStatus.SUCCEEDED}
+    assert statuses == {"openai:gpt-realtime": RunStatus.SUCCEEDED}
     writer.refresh_stats_matviews.assert_not_awaited()
 
 

--- a/runner/tests/unit/test_s2s_samples.py
+++ b/runner/tests/unit/test_s2s_samples.py
@@ -150,7 +150,7 @@ async def _publish(
     runs: list[SampleRun],
     *,
     rng_seed: int = 0,
-    expected_providers: set[str] | None = None,
+    expected_models: set[tuple[str, str]] | None = None,
 ) -> int:
     return await publish_tick_sample(
         client,
@@ -160,7 +160,7 @@ async def _publish(
         rng=random.Random(rng_seed),
         storage_client=storage_client,
         download_client=client,
-        expected_providers=expected_providers,
+        expected_models=expected_models,
     )
 
 
@@ -172,8 +172,8 @@ async def test_publishes_complete_conversation_for_all_providers() -> None:
         stored = await _publish(client, storage_client, _runs())
 
     assert stored == 2
-    assert f"{PREFIX}/{TICK}/openai.wav" in bucket.objects
-    assert f"{PREFIX}/{TICK}/google.wav" in bucket.objects
+    assert f"{PREFIX}/{TICK}/openai/gpt-realtime.wav" in bucket.objects
+    assert f"{PREFIX}/{TICK}/google/gemini-live.wav" in bucket.objects
 
     manifest = json.loads(bucket.objects[f"{PREFIX}/{TICK}/manifest.json"])
     assert manifest["schema_version"] == 2
@@ -349,8 +349,8 @@ async def test_missed_day_publishes_alongside_the_current_tick() -> None:
         manifest = json.loads(bucket.objects[f"{PREFIX}/{tick}/manifest.json"])
         assert manifest["bucket_at"] == tick
         assert {r["provider"] for r in manifest["recordings"]} == {"openai", "google"}
-        assert f"{PREFIX}/{tick}/openai.wav" in bucket.objects
-        assert f"{PREFIX}/{tick}/google.wav" in bucket.objects
+        assert f"{PREFIX}/{tick}/openai/gpt-realtime.wav" in bucket.objects
+        assert f"{PREFIX}/{tick}/google/gemini-live.wav" in bucket.objects
     # Published oldest-first, so the index ends up newest-first.
     assert json.loads(bucket.objects[f"{PREFIX}/index.json"]) == [TICK, PREV_TICK]
 
@@ -372,14 +372,17 @@ async def test_bucket_missing_an_expected_provider_publishes_nothing() -> None:
     cases = {r.coval_run_id: ["b", "c"] for r in runs}
     async with _fake_client(cases) as client:
         stored = await _publish(
-            client, storage_client, runs, expected_providers={"openai", "google"}
+            client,
+            storage_client,
+            runs,
+            expected_models={("openai", "gpt-realtime"), ("google", "gemini-live")},
         )
 
     # Today is complete and publishes; yesterday is refused outright.
     assert stored == 2
     assert f"{PREFIX}/{TICK}/manifest.json" in bucket.objects
     assert f"{PREFIX}/{PREV_TICK}/manifest.json" not in bucket.objects
-    assert f"{PREFIX}/{PREV_TICK}/openai.wav" not in bucket.objects
+    assert f"{PREFIX}/{PREV_TICK}/openai/gpt-realtime.wav" not in bucket.objects
     assert json.loads(bucket.objects[samples.INDEX_KEY]) == [TICK]
 
 
@@ -400,7 +403,10 @@ async def test_published_day_is_reindexed_even_when_a_provider_is_absent() -> No
     cases = {r.coval_run_id: ["b"] for r in openai_only}
     async with _fake_client(cases) as client:
         stored = await _publish(
-            client, storage_client, openai_only, expected_providers={"openai", "google"}
+            client,
+            storage_client,
+            openai_only,
+            expected_models={("openai", "gpt-realtime"), ("google", "gemini-live")},
         )
 
     assert stored == 0
@@ -420,7 +426,7 @@ async def test_recovery_never_overwrites_an_existing_manifest() -> None:
 
     assert stored == 2  # only the current tick
     assert bucket.objects[f"{PREFIX}/{PREV_TICK}/manifest.json"] == already_there
-    assert f"{PREFIX}/{PREV_TICK}/openai.wav" not in bucket.objects
+    assert f"{PREFIX}/{PREV_TICK}/openai/gpt-realtime.wav" not in bucket.objects
     assert f"{PREFIX}/{TICK}/manifest.json" in bucket.objects
     # The existing day is still repaired into the index.
     assert PREV_TICK in json.loads(bucket.objects[f"{PREFIX}/index.json"])

--- a/web/app/s2s/components/SamplesCard.tsx
+++ b/web/app/s2s/components/SamplesCard.tsx
@@ -39,8 +39,8 @@ export function SamplesCard() {
     getCurrentTimeWindow,
   } = useDashboard();
   const coordinator = usePlaybackCoordinator();
-  const visibleProviders = useMemo(
-    () => new Set(Object.keys(modelsByProvider)),
+  const visibleModels = useMemo(
+    () => new Set(Object.values(modelsByProvider).flat()),
     [modelsByProvider]
   );
 
@@ -87,13 +87,13 @@ export function SamplesCard() {
   // turn list, so a timeline click always reaches its audio.
   const items = useMemo<SampleOutputItem[]>(() => {
     if (!manifest) return [];
-    return visibleRecordings(manifest, visibleProviders).map((r) => ({
+    return visibleRecordings(manifest, visibleModels).map((r) => ({
       provider: r.provider,
       model: r.model,
       url: s2sSampleFeed.objectUrl(r.object),
       turns: r.turns,
     }));
-  }, [manifest, visibleProviders]);
+  }, [manifest, visibleModels]);
 
   // A timeline row can name a provider this bucket never recorded — an older
   // tick from before that model was benchmarked, or one absent from the page's

--- a/web/lib/audioSamples/createSampleFeed.test.ts
+++ b/web/lib/audioSamples/createSampleFeed.test.ts
@@ -194,17 +194,30 @@ describe("parseS2SManifest", () => {
 });
 
 describe("visibleRecordings", () => {
-  it("keeps only recordings whose provider is visible", () => {
+  it("keeps only recordings whose model is visible", () => {
     const manifest: S2SSampleManifest = {
       ...validManifest,
       recordings: [
-        { ...validManifest.recordings[0]!, provider: "openai" },
-        { ...validManifest.recordings[0]!, provider: "hidden" },
+        { ...validManifest.recordings[0]!, provider: "openai", model: "gpt-realtime" },
+        { ...validManifest.recordings[0]!, provider: "hidden", model: "hidden-model" },
       ],
     };
-    const out = visibleRecordings(manifest, new Set(["openai"]));
+    const out = visibleRecordings(manifest, new Set(["openai:gpt-realtime"]));
     expect(out).toHaveLength(1);
     expect(out[0]!.provider).toBe("openai");
+  });
+
+  it("distinguishes two models of the same provider", () => {
+    const manifest: S2SSampleManifest = {
+      ...validManifest,
+      recordings: [
+        { ...validManifest.recordings[0]!, provider: "xai", model: "grok-realtime" },
+        { ...validManifest.recordings[0]!, provider: "xai", model: "grok-voice-think-fast-2.0" },
+      ],
+    };
+    const out = visibleRecordings(manifest, new Set(["xai:grok-voice-think-fast-2.0"]));
+    expect(out).toHaveLength(1);
+    expect(out[0]!.model).toBe("grok-voice-think-fast-2.0");
   });
 });
 

--- a/web/lib/audioSamples/s2sFeed.ts
+++ b/web/lib/audioSamples/s2sFeed.ts
@@ -4,6 +4,7 @@
 "use client";
 
 import { createSampleFeed } from "./createSampleFeed";
+import { toModelKey } from "../utils/formatters";
 
 // One turn of a multi-turn conversation (v2 manifests). `role` is "user"
 // (the persona) or "assistant" (the agent); `index` is the turn's position.
@@ -166,10 +167,11 @@ export function isMultiTurn(manifest: S2SSampleManifest): boolean {
   return (manifest.schema_version ?? 1) >= 2;
 }
 
-// Drop recordings whose provider isn't visible on the page (disabled catalogue).
+// Drop recordings whose model isn't visible on the page (disabled catalogue).
+// Keyed by (provider, model): one provider can carry several S2S models.
 export function visibleRecordings(
   manifest: S2SSampleManifest,
-  visibleProviders: ReadonlySet<string>
+  visibleModels: ReadonlySet<string>
 ): S2SSampleRecording[] {
-  return manifest.recordings.filter((r) => visibleProviders.has(r.provider));
+  return manifest.recordings.filter((r) => visibleModels.has(toModelKey(r.provider, r.model)));
 }

--- a/web/lib/utils/formatters.ts
+++ b/web/lib/utils/formatters.ts
@@ -142,6 +142,7 @@ export function normalizeModelName(modelKey: string): string {
     "gpt-realtime": "GPT Realtime 2",
     "gemini-live": "Gemini 3.1 Flash Live (Preview)",
     "grok-realtime": "Grok Realtime",
+    "grok-voice-think-fast-2.0": "Grok Voice Think Fast 2.0",
     default: "Default",
     enhanced: "Enhanced"
   };


### PR DESCRIPTION
A second model on the same provider collided in the sampler, which keyed on provider name alone; samples and the fetch status map now key on provider and model together. Older ticks still play.