### PR TITLE
[BENCH-569] Simplify arena leaderboard CSV export and improve table formatting

### DIFF
--- a/web/app/overview/arena/leaderboard/arena-leaderboard.tsx
+++ b/web/app/overview/arena/leaderboard/arena-leaderboard.tsx
@@ -9,6 +9,8 @@ import DashboardHeader from "@/components/layout/DashboardHeader";
 import DashboardFooter from "@/components/dashboard/DashboardFooter";
 import Card from "@/components/shared/Card";
 import { CymaticLoader } from "@/components/shared/CymaticLoader";
+import MetricInfo from "@/components/shared/MetricInfo";
+import { downloadCSV } from "@/lib/utils/chartExport";
 import {
   normalizeModelName,
   normalizeTTSProviderName,
@@ -18,31 +20,25 @@ import { useArenaLeaderboardQuery, type ArenaLeaderboard } from "@/lib/arena/lea
 
 const CAPTION = "font-mono text-[11px] uppercase tracking-[0.14em] text-text-tertiary";
 
-const CSV_COLUMNS = [
-  "rank", "provider", "model", "rating_elo", "rating_bt", "ci_low", "ci_high",
-  "ci_half_width", "votes_total", "wins", "losses", "ties", "status",
-];
-
-function csvField(value: string | number): string {
-  const s = String(value);
-  return /[",\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
-}
+const CI_TOOLTIP =
+  "The model's true rating most likely sits within this many points of the shown Elo. Fewer votes mean a wider margin.";
 
 function downloadCsv(board: ArenaLeaderboard): void {
-  const rows = board.entries.map((e, i) => [
-    i + 1, e.provider, e.model, e.rating_elo, e.rating_bt, e.ci_low ?? "",
-    e.ci_high ?? "", e.ci_half_width ?? "", e.votes_total, e.wins, e.losses,
-    e.ties, e.status,
-  ]);
-  const csv = [CSV_COLUMNS, ...rows]
-    .map((row) => row.map(csvField).join(","))
-    .join("\n");
-  const url = URL.createObjectURL(new Blob([csv], { type: "text/csv;charset=utf-8" }));
-  const a = document.createElement("a");
-  a.href = url;
-  a.download = `voice-arena-leaderboard-${board.metric}-${board.domain}.csv`;
-  a.click();
-  URL.revokeObjectURL(url);
+  downloadCSV(
+    board.entries.map((e, i) => ({
+      Rank: i + 1,
+      Provider: normalizeTTSProviderName(e.provider),
+      Model: normalizeModelName(toModelKey(e.provider, e.model)),
+      Rating: Math.round(e.rating_elo),
+      "Rating Margin (±)": e.ci_half_width == null ? "" : Math.round(e.ci_half_width),
+      Votes: e.votes_total,
+      Wins: e.wins,
+      Losses: e.losses,
+      Ties: e.ties,
+      Status: e.status,
+    })),
+    `voice-arena-leaderboard-${board.metric}-${board.domain}.csv`
+  );
 }
 
 export function ArenaLeaderboardPage() {
@@ -140,7 +136,9 @@ export function ArenaLeaderboardPage() {
                             {entry.votes_total.toLocaleString()} votes
                           </span>
                           {mixedStatus && preliminary && (
-                            <span className="font-mono uppercase"> provisional</span>
+                            <span className="ml-1.5 inline-block rounded-full border border-border-primary px-1.5 font-mono text-[10px] uppercase tracking-[0.08em]">
+                              provisional
+                            </span>
                           )}
                         </div>
                       </td>
@@ -153,7 +151,9 @@ export function ArenaLeaderboardPage() {
                         </span>{" "}
                         {entry.ci_half_width != null && (
                           <span className="font-mono text-xs tabular-nums text-text-tertiary">
-                            ± {Math.round(entry.ci_half_width)}
+                            <MetricInfo content={CI_TOOLTIP} align="right">
+                              {`± ${Math.round(entry.ci_half_width)}`}
+                            </MetricInfo>
                           </span>
                         )}
                       </td>


### PR DESCRIPTION
## Summary

Example output: 
Rank,Provider,Model,Rating,Rating Margin (±),Votes,Wins,Losses,Ties,Status
1,Cartesia,Sonic 3.5,1709,183,21,15,3,3,preliminary
2,ElevenLabs,Flash v2.5,1566,138,21,11,7,3,preliminary
3,OpenAI,GPT-4o mini TTS,1434,129,21,7,11,3,preliminary
4,Deepgram,Aura 2,1291,182,21,3,15,3,preliminary


- CSV export now uses friendly, human-readable columns: `Rank, Provider, Model, Rating, Rating Margin (±), Votes, Wins, Losses, Ties, Status` — ratings rounded to whole numbers, provider/model as display names, `rating_bt` and the three raw CI columns dropped in favor of a single margin column
- CSV generation reuses the shared `downloadCSV`/`serializeCSV` helpers (BOM for Excel, deferred blob revoke) instead of the component's hand-rolled serializer
- The table's ± value gets the shared `MetricInfo` tooltip explaining the confidence interval — works on tap (mobile), hover, and keyboard focus, with the panel opening above the trigger
- The mixed-status "provisional" marker is now a small badge instead of plain inline text

## Testing
- `pnpm test` (112 passed), `pnpm lint`, `pnpm typecheck` all clean
- Verified against the local full-stack arena: CSV blob content matches the new schema exactly; tooltip opens on tap at mobile width and dismisses on outside tap