### PR TITLE
[BENCH-570] Arena leaderboard: give the table room on phones

### DIFF
--- a/web/app/overview/arena/leaderboard/arena-leaderboard.tsx
+++ b/web/app/overview/arena/leaderboard/arena-leaderboard.tsx
@@ -88,7 +88,10 @@ export function ArenaLeaderboardPage() {
         )}
 
         {entries.length > 0 && (
-          <Card padding="p-4 sm:p-6 md:p-8" className="mt-6">
+          <Card
+            padding="p-0 sm:p-6 md:p-8"
+            className="mt-6 max-sm:border-0 max-sm:bg-transparent"
+          >
             <div className="mb-4 flex justify-end">
               <button
                 type="button"


### PR DESCRIPTION
## Problem
<img width="346" height="765" alt="Screenshot 2026-07-30 at 11 18 42 AM" src="https://github.com/user-attachments/assets/35d4442c-202b-406f-be39-142cb3068a82" />
<img width="354" height="707" alt="Screenshot 2026-07-30 at 11 19 09 AM" src="https://github.com/user-attachments/assets/1390fd0e-528d-4a7a-a8db-2976ff0ea17c" />


On phones the arena leaderboard table was squeezed inside the card: page padding + 

card padding + border left the table only 309px of a 375px viewport, and the card surface painted over the page's noise texture, so any attempt to widen the card produced odd full-width color bands (BENCH-570).

## Fix

One edit in `arena-leaderboard.tsx`: below `sm` the Card keeps its structure but loses its chrome — `p-0`, `border-0`, `bg-transparent` — so the table sits directly on the page background at full content width (343px at 375px), the same presentation as the model comparison table. From `sm` up the card is unchanged (border, radius, `p-6`/`p-8`).

## Notes

- Investigated the "table can't scroll" report: no overflow constraint or scroll lock exists on the page, card, or mobile menu, and prod at 375px scrolls through all 27 rows. Verified locally against a 20-row seeded board — everything is reachable down to the footer.
- Verified in dark and light themes at 375px and at 1280px.