### PR TITLE
[BENCH-571] Hide xAI from S2S and launch S2S to live

### DIFF
--- a/runner/src/coval_bench/registries/models.py
+++ b/runner/src/coval_bench/registries/models.py
@@ -798,36 +798,37 @@ MODEL_REGISTRY: list[RegisteredModel] = [
     # S2S #
     #######
     # S2S realtime models. Numbers are fetched daily from Coval (no local
-    # provider client). EARLY_ACCESS = pre-launch embargo: they run and fetch
-    # normally, but every data endpoint strips them for public callers and
-    # serves them only to X-Internal-Key requests until the benchmark launches.
+    # provider client).
     RegisteredModel(
         benchmark=_S2S,
         provider="openai",
         model="gpt-realtime",
         tags=(_STREAMING, _MULTI),
-        status=_EARLY_ACCESS,
+        status=_ACTIVE,
     ),
     RegisteredModel(
         benchmark=_S2S,
         provider="google",
         model="gemini-live",
         tags=(_STREAMING, _MULTI),
-        status=_EARLY_ACCESS,
+        status=_ACTIVE,
     ),
+    # xAI hidden for launch while they are unresponsive to outreach; the fetch
+    # job doesn't read this registry, so data keeps accruing for the flip back
+    # to active.
     RegisteredModel(
         benchmark=_S2S,
         provider="xai",
         model="grok-realtime",
         tags=(_STREAMING, _MULTI),
-        status=_EARLY_ACCESS,
+        status=_PENDING,
     ),
     RegisteredModel(
         benchmark=_S2S,
         provider="xai",
         model="grok-voice-think-fast-2.0",
         tags=(_STREAMING, _MULTI),
-        status=_EARLY_ACCESS,
+        status=_PENDING,
     ),
 ]
 

--- a/runner/src/coval_bench/registries/models.py
+++ b/runner/src/coval_bench/registries/models.py
@@ -813,22 +813,23 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         tags=(_STREAMING, _MULTI),
         status=_ACTIVE,
     ),
-    # xAI hidden for launch while they are unresponsive to outreach; the fetch
-    # job doesn't read this registry, so data keeps accruing for the flip back
-    # to active.
+    # xAI stays under the early-access embargo while they are unresponsive to
+    # outreach: runs and fetches normally, but every data endpoint strips both
+    # models for public callers (unlike PENDING, which only disables the
+    # catalogue entry and still serves their rows).
     RegisteredModel(
         benchmark=_S2S,
         provider="xai",
         model="grok-realtime",
         tags=(_STREAMING, _MULTI),
-        status=_PENDING,
+        status=_EARLY_ACCESS,
     ),
     RegisteredModel(
         benchmark=_S2S,
         provider="xai",
         model="grok-voice-think-fast-2.0",
         tags=(_STREAMING, _MULTI),
-        status=_PENDING,
+        status=_EARLY_ACCESS,
     ),
 ]
 

--- a/web/app/overview/overview-page-client.tsx
+++ b/web/app/overview/overview-page-client.tsx
@@ -96,8 +96,8 @@ export function OverviewPageClient() {
           </h1>
 
           <p className="mx-auto mt-3 max-w-md text-pretty text-center text-base leading-snug text-text-secondary">
-            Measuring the accuracy, latency, and quality of text-to-speech and
-            speech-to-text models.
+            Measuring the accuracy, latency, and quality of text-to-speech,
+            speech-to-text, and speech-to-speech models.
           </p>
 
           <div className="mt-6 md:mt-8">

--- a/web/app/s2s/page.tsx
+++ b/web/app/s2s/page.tsx
@@ -1,16 +1,10 @@
 // Copyright 2026 The Coval Benchmarks Authors
 // SPDX-License-Identifier: Apache-2.0
 
-import { notFound } from "next/navigation";
 import { Suspense } from "react";
 import { S2SDashboard } from "./s2s-dashboard";
 
 export default function Page() {
-  // Gated rollout: /s2s is unreachable until NEXT_PUBLIC_S2S_ENABLED is set.
-  // It is intentionally left out of the nav and Overview until launch.
-  if (process.env.NEXT_PUBLIC_S2S_ENABLED !== "true") {
-    notFound();
-  }
   return (
     <Suspense fallback={null}>
       <S2SDashboard />

--- a/web/components/dashboard/DashboardFooter.tsx
+++ b/web/components/dashboard/DashboardFooter.tsx
@@ -12,6 +12,7 @@ const FOOTER_LINKS = [
   { href: "/overview", label: "Overview" },
   { href: "/tts", label: "Text-to-Speech" },
   { href: "/stt", label: "Speech-to-Text" },
+  { href: "/s2s", label: "Speech-to-Speech" },
   { href: "/playground", label: "Playground" }
 ];
 

--- a/web/components/layout/DashboardHeader.tsx
+++ b/web/components/layout/DashboardHeader.tsx
@@ -18,6 +18,7 @@ const SECTIONS = [
   { href: "/overview", label: "Overview", short: "Overview" },
   { href: "/tts", label: "Text-to-Speech", short: "TTS" },
   { href: "/stt", label: "Speech-to-Text", short: "STT" },
+  { href: "/s2s", label: "Speech-to-Speech", short: "S2S" },
   { href: "/playground", label: "Playground", short: "Playground" }
 ];
 

--- a/web/components/overview/OverviewLeaderboards.tsx
+++ b/web/components/overview/OverviewLeaderboards.tsx
@@ -17,7 +17,7 @@ import { S2S_MULTITURN_DATASET } from "@/lib/config/datasets";
 import type { ModelStatEntry, ProvidersApiResponse } from "@/lib/api/client";
 import { disabledModelKeys } from "@/lib/utils/modelsFromResults";
 import { useTimeWindow } from "@/hooks/useTimeWindow";
-import { WINDOW_LABELS, type TimeWindow } from "@/lib/config/timeWindows";
+import { S2S_24H_ENABLED, WINDOW_LABELS, type TimeWindow } from "@/lib/config/timeWindows";
 import TimeWindowToggle from "@/components/shared/TimeWindowToggle";
 import { CymaticLoader } from "@/components/shared/CymaticLoader";
 import LeaderboardCard, { type LeaderboardRow } from "./LeaderboardCard";
@@ -69,9 +69,12 @@ const OverviewLeaderboards: React.FC = () => {
   // entry with the dashboards whenever the selected windows coincide.
   const ttsQuery = useAggregatesQuery({ benchmark: "TTS", window: timeWindow });
   const sttQuery = useAggregatesQuery({ benchmark: "STT", window: timeWindow });
+  // S2S ingests daily, so it has no 24h window — pin the card to 7d there.
+  const s2sWindow: TimeWindow =
+    timeWindow === "24h" && !S2S_24H_ENABLED ? "7d" : timeWindow;
   const s2sQuery = useAggregatesQuery({
     benchmark: "S2S",
-    window: timeWindow,
+    window: s2sWindow,
     dataset: S2S_MULTITURN_DATASET,
   });
   const providersQuery = useProvidersQuery();
@@ -171,7 +174,7 @@ const OverviewLeaderboards: React.FC = () => {
         <LeaderboardCard
           title="Speech-to-Speech"
           metricLabel="Voice-to-Voice Latency"
-          windowLabel={windowBadge(s2sQuery.data?.window ?? timeWindow)}
+          windowLabel={windowBadge(s2sQuery.data?.window ?? s2sWindow)}
           rows={s2sRows}
           href="/s2s"
           loading={s2sQuery.isLoading || providersQuery.isLoading}

--- a/web/components/overview/OverviewLeaderboards.tsx
+++ b/web/components/overview/OverviewLeaderboards.tsx
@@ -8,11 +8,14 @@ import { useAggregatesQuery, useProvidersQuery } from "@/lib/api/queries";
 import { buildTagIndex, dedicatedModelKeys } from "@/lib/utils/facets";
 import {
   normalizeModelName,
+  normalizeS2SProviderName,
   normalizeSTTProviderName,
   normalizeTTSProviderName,
   toModelKey,
 } from "@/lib/utils/formatters";
-import type { ModelStatEntry } from "@/lib/api/client";
+import { S2S_MULTITURN_DATASET } from "@/lib/config/datasets";
+import type { ModelStatEntry, ProvidersApiResponse } from "@/lib/api/client";
+import { disabledModelKeys } from "@/lib/utils/modelsFromResults";
 import { useTimeWindow } from "@/hooks/useTimeWindow";
 import { WINDOW_LABELS, type TimeWindow } from "@/lib/config/timeWindows";
 import TimeWindowToggle from "@/components/shared/TimeWindowToggle";
@@ -48,6 +51,17 @@ function toRows(
 
 const windowBadge = (window: TimeWindow): string => `Last ${WINDOW_LABELS[window]}`;
 
+// Dedicated-inference endpoints stay off these shared-latency rankings, and
+// disabled (retired/pending) models still present in the window's stats too.
+const excludedKeys = (
+  benchmark: "STT" | "TTS" | "S2S",
+  providers: ProvidersApiResponse
+): Set<string> =>
+  new Set([
+    ...dedicatedModelKeys(buildTagIndex(benchmark, providers)),
+    ...disabledModelKeys(benchmark, providers),
+  ]);
+
 const OverviewLeaderboards: React.FC = () => {
   const { timeWindow, changeTimeWindow } = useTimeWindow("overview");
 
@@ -55,8 +69,16 @@ const OverviewLeaderboards: React.FC = () => {
   // entry with the dashboards whenever the selected windows coincide.
   const ttsQuery = useAggregatesQuery({ benchmark: "TTS", window: timeWindow });
   const sttQuery = useAggregatesQuery({ benchmark: "STT", window: timeWindow });
+  const s2sQuery = useAggregatesQuery({
+    benchmark: "S2S",
+    window: timeWindow,
+    dataset: S2S_MULTITURN_DATASET,
+  });
   const providersQuery = useProvidersQuery();
-  const windowDataStale = ttsQuery.isPlaceholderData || sttQuery.isPlaceholderData;
+  const windowDataStale =
+    ttsQuery.isPlaceholderData ||
+    sttQuery.isPlaceholderData ||
+    s2sQuery.isPlaceholderData;
 
   // These cards rank shared latency, so dedicated-inference endpoints stay
   // off them — same rule as the dashboards' latency timeline. Rankings are
@@ -70,7 +92,7 @@ const OverviewLeaderboards: React.FC = () => {
             "p50",
             normalizeTTSProviderName,
             (value) => `${Math.round(value)} ms`,
-            dedicatedModelKeys(buildTagIndex("TTS", providersQuery.data))
+            excludedKeys("TTS", providersQuery.data)
           )
         : [],
     [ttsQuery.data, providersQuery.data]
@@ -85,10 +107,25 @@ const OverviewLeaderboards: React.FC = () => {
             "p50",
             normalizeSTTProviderName,
             (value) => `${Math.round(value * 1000)} ms`,
-            dedicatedModelKeys(buildTagIndex("STT", providersQuery.data))
+            excludedKeys("STT", providersQuery.data)
           )
         : [],
     [sttQuery.data, providersQuery.data]
+  );
+
+  const s2sRows = useMemo(
+    () =>
+      providersQuery.data
+        ? toRows(
+            s2sQuery.data?.model_stats,
+            "V2V",
+            "p50",
+            normalizeS2SProviderName,
+            (value) => `${Math.round(value)} ms`,
+            excludedKeys("S2S", providersQuery.data)
+          )
+        : [],
+    [s2sQuery.data, providersQuery.data]
   );
 
   return (
@@ -107,7 +144,7 @@ const OverviewLeaderboards: React.FC = () => {
           loading={windowDataStale}
         />
       </div>
-      <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
         {/* Providers metadata drives the dedicated exclusion, so these cards
             wait for it (and surface its failure) rather than momentarily
             ranking a dedicated endpoint as shared. */}
@@ -130,6 +167,16 @@ const OverviewLeaderboards: React.FC = () => {
           loading={sttQuery.isLoading || providersQuery.isLoading}
           stale={sttQuery.isPlaceholderData}
           error={sttQuery.isError || providersQuery.isError}
+        />
+        <LeaderboardCard
+          title="Speech-to-Speech"
+          metricLabel="Voice-to-Voice Latency"
+          windowLabel={windowBadge(s2sQuery.data?.window ?? timeWindow)}
+          rows={s2sRows}
+          href="/s2s"
+          loading={s2sQuery.isLoading || providersQuery.isLoading}
+          stale={s2sQuery.isPlaceholderData}
+          error={s2sQuery.isError || providersQuery.isError}
         />
       </div>
     </div>

--- a/web/hooks/useDashboardState.tsx
+++ b/web/hooks/useDashboardState.tsx
@@ -34,7 +34,7 @@ import { capturePostHogEvent } from "@/lib/posthog/client";
 import { POSTHOG_EVENTS } from "@/lib/posthog/events";
 import { getModelColor } from "@/lib/utils/colors";
 import { metricDescriptions } from "@/lib/config/metrics";
-import { WER_BAR_VIEWS, type WerBarView } from "@/lib/config/datasets";
+import { S2S_MULTITURN_DATASET, WER_BAR_VIEWS, type WerBarView } from "@/lib/config/datasets";
 import { useAggregatesQuery, useProvidersQuery } from "@/lib/api/queries";
 import { useDatasetScopedWer } from "@/hooks/useDatasetScopedWer";
 import { useTimeWindow } from "@/hooks/useTimeWindow";
@@ -91,7 +91,7 @@ export function useDashboardState(page: "tts" | "stt" | "s2s") {
   const aggregatesQuery = useAggregatesQuery({
     benchmark: benchmarkParam,
     window: timeWindow,
-    dataset: page === "s2s" ? "s2s-multiturn-v1" : undefined,
+    dataset: page === "s2s" ? S2S_MULTITURN_DATASET : undefined,
   });
   const providersQuery = useProvidersQuery();
 

--- a/web/lib/config/datasets.ts
+++ b/web/lib/config/datasets.ts
@@ -14,6 +14,10 @@ const DATASET_LABELS: Record<string, string> = {
   "stt-wildasr-accent": "WildASR accents",
 };
 
+// S2S aggregates are pinned to the multi-turn dataset everywhere (dashboard
+// and overview) so legacy single-turn s2s-v1 rows never pool into V2V stats.
+export const S2S_MULTITURN_DATASET = "s2s-multiturn-v1";
+
 export function datasetLabel(id: string): string {
   return DATASET_LABELS[id] ?? id;
 }

--- a/web/lib/utils/formatters.ts
+++ b/web/lib/utils/formatters.ts
@@ -201,7 +201,7 @@ export function normalizeSTTProviderName(providerName: string): string {
   return mappings[lower] ?? capitalizeProviderSlug(providerName);
 }
 
-function normalizeS2SProviderName(providerName: string): string {
+export function normalizeS2SProviderName(providerName: string): string {
   const mappings: Record<string, string> = {
     google: "Google",
     openai: "OpenAI",

--- a/web/lib/utils/modelsFromResults.ts
+++ b/web/lib/utils/modelsFromResults.ts
@@ -32,6 +32,31 @@ function modelIsEnabled(
   return modelInfo?.disabled !== true;
 }
 
+/**
+ * Composite keys of catalogue models flagged disabled (retired/pending
+ * server-side). Data endpoints still return rows for them — pending models
+ * keep ingesting — so rankings built from raw stats must exclude these.
+ */
+export function disabledModelKeys(
+  benchmark: "STT" | "TTS" | "S2S",
+  providers?: ProvidersApiResponse
+): Set<string> {
+  const keys = new Set<string>();
+  if (!providers) return keys;
+  const catalogue =
+    (benchmark === "STT"
+      ? providers.stt
+      : benchmark === "S2S"
+        ? providers.s2s
+        : providers.tts) ?? [];
+  for (const providerInfo of catalogue) {
+    for (const modelInfo of providerInfo.models) {
+      if (modelInfo.disabled) keys.add(toModelKey(providerInfo.provider, modelInfo.model));
+    }
+  }
+  return keys;
+}
+
 function addModel(
   modelsByProvider: ModelsByProvider,
   provider: string,


### PR DESCRIPTION
## What

Launches the S2S benchmark publicly and hides xAI from it.
<img width="1664" height="819" alt="Screenshot 2026-07-30 at 1 08 02 PM" src="https://github.com/user-attachments/assets/9766f0cb-fa13-4ffe-99ae-02bb3d9cb109" />

**Runner registry**
- `gpt-realtime` (OpenAI) and `gemini-live` (Google) leave the `EARLY_ACCESS` pre-launch embargo → `ACTIVE`.
- Both xAI models (`grok-realtime`, `grok-voice-think-fast-2.0`) → `PENDING`: hidden sitewide while xAI is unresponsive to outreach; the fetch job doesn't read the registry, so data keeps accruing for the flip back (same pattern as #322).

**Web launch surfaces**
- Removed the `NEXT_PUBLIC_S2S_ENABLED` gate from `/s2s` (the deployment env var is now dead config and can be cleaned up separately).
- Added Speech-to-Speech to the header tabs, mobile menu, footer, and overview hero copy.
- New third overview leaderboard card ranking V2V p50, pinned to the `s2s-multiturn-v1` dataset (hoisted to a named constant shared with the dashboard) and clamped to 7d when the shared toggle sits on 1d — S2S ingests daily and has no 24h window.

**Bug fix caught along the way**
- Data endpoints only strip `EARLY_ACCESS` models; `PENDING`/`RETIRED` rows still come back in `model_stats`. The overview cards ranked raw stats, so pending xAI (which keeps ingesting) would have surfaced there. Added `disabledModelKeys` and excluded disabled catalogue models from all three overview cards — closing the same latent gap for TTS/STT.

## Testing

- 432 runner unit tests, 113 web tests, typecheck + lint all green.
- Verified against a local runner API running this registry: `/v1/providers` serves xAI as `disabled`, OpenAI/Google enabled; `/s2s`, nav, footer, and overview card all render; overview card requests/labels 7d on the 1d toggle.
- Verified with prod data (providers catalogue from local API, data endpoints from prod): all S2S surfaces — overview card, key metrics, charts, comparison table, conversation samples — show OpenAI + Google only, no Grok.

## Rollout

The registry flip takes effect when the runner API redeploys; the web changes are independent and safe to deploy alongside.