### PR TITLE
Keep a privileged view of the embargo out of shared caches

### DIFF
--- a/runner/src/coval_bench/api/internal.py
+++ b/runner/src/coval_bench/api/internal.py
@@ -34,6 +34,10 @@ logger = structlog.get_logger("coval_bench.api.internal")
 # Which proof the response honoured: internal, accepted, unknown, or absent.
 EA_STATUS_HEADER = "X-EA-Token-Status"
 
+# Both proof headers. Listing one is worse than listing none: a cached internal
+# response carries no X-EA-Token, so it would match a public request.
+VARY_HEADERS = "X-Internal-Key, X-EA-Token"
+
 
 def embargoed_pairs() -> frozenset[tuple[str, str]]:
     """Every ``(provider, model)`` pair currently under embargo."""
@@ -126,13 +130,19 @@ def hidden_early_access(
 ) -> frozenset[tuple[str, str]]:
     """The pairs this caller's responses must not contain.
 
-    Only a presented-but-unknown token is logged; an absent one is ordinary public
-    traffic. Subtracting the allowlist means an entry naming a model that is no
-    longer embargoed is inert, and no token reveals what the registry does not
-    currently embargo.
+    Sets the cache headers here rather than per route, so no endpoint can serve
+    embargoed rows without them. Only a presented-but-unknown token is logged; an
+    absent one is ordinary public traffic. Subtracting the allowlist means an entry
+    naming a model that is no longer embargoed is inert, and no token reveals what
+    the registry does not currently embargo.
     """
+    # Appended, not assigned: SelectiveGZipMiddleware adds Accept-Encoding after
+    # the route returns, and assignment here would be overwritten.
+    response.headers.append("Vary", VARY_HEADERS)
+
     if internal:
         response.headers[EA_STATUS_HEADER] = "internal"
+        response.headers["Cache-Control"] = "private, no-store"
         return frozenset()
 
     embargoed = embargoed_pairs()
@@ -148,4 +158,5 @@ def hidden_early_access(
         return embargoed
 
     response.headers[EA_STATUS_HEADER] = "accepted"
+    response.headers["Cache-Control"] = "private, no-store"
     return embargoed - allowed

--- a/runner/tests/api/conftest.py
+++ b/runner/tests/api/conftest.py
@@ -20,6 +20,7 @@ pool per test instead of reusing the singleton.
 
 from __future__ import annotations
 
+import json
 from collections.abc import AsyncIterator, Awaitable, Callable
 from contextlib import asynccontextmanager
 from datetime import datetime
@@ -42,6 +43,19 @@ from coval_bench.config import Settings
 
 ARENA_LABELER_KEY = "test-labeler-key"
 INTERNAL_API_KEY = "test-internal-key"
+
+# Two synthetic embargoed models on one provider, and a partner token entitled to
+# each. Same provider on purpose: it proves the allowlist separates callers by
+# model, not just by vendor.
+EA_PROVIDER = "acme"
+EA_MODEL = "unreleased-stt"
+EA_MODEL_OTHER = "unreleased-stt-2"
+EA_TOKEN = "test-ea-token"  # noqa: S105 - fake grant token
+EA_TOKEN_OTHER = "test-ea-token-other"  # noqa: S105 - fake grant token
+EARLY_ACCESS_TOKENS = {
+    EA_TOKEN: [f"{EA_PROVIDER}/{EA_MODEL}"],
+    EA_TOKEN_OTHER: [f"{EA_PROVIDER}/{EA_MODEL_OTHER}"],
+}
 
 
 def _make_db_url(postgresql: Any) -> str:
@@ -179,6 +193,7 @@ async def app(postgresql: Any, monkeypatch: pytest.MonkeyPatch) -> AsyncIterator
     monkeypatch.setenv("POSTHOG_DISABLED", "true")
     monkeypatch.setenv("ARENA_LABELER_KEY", ARENA_LABELER_KEY)
     monkeypatch.setenv("INTERNAL_API_KEY", INTERNAL_API_KEY)
+    monkeypatch.setenv("EARLY_ACCESS_TOKENS", json.dumps(EARLY_ACCESS_TOKENS))
     # Battle generation screens prompts through the moderation API. Without this the
     # suite would reach the network on any machine that has the key exported.
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)

--- a/runner/tests/api/test_early_access_scope.py
+++ b/runner/tests/api/test_early_access_scope.py
@@ -22,6 +22,7 @@ from fastapi import Response
 
 from coval_bench.api.internal import (
     EA_STATUS_HEADER,
+    VARY_HEADERS,
     embargoed_pairs,
     hidden_early_access,
     hidden_models,
@@ -49,12 +50,23 @@ def _settings(monkeypatch: pytest.MonkeyPatch, tokens: object | None) -> Setting
 def _resolve(
     settings: Settings, token: str | None, internal: bool = False
 ) -> tuple[frozenset[tuple[str, str]], str]:
-    """Return this caller's hidden set and the status header the response carries."""
+    """Return this caller's hidden set and the status header the response carries.
+
+    Every caller is varied on both proof headers, so that is asserted here rather
+    than repeated in each case.
+    """
     response = Response()
     hidden = hidden_early_access(
         response=response, internal=internal, x_ea_token=token, settings=settings
     )
+    assert response.headers["Vary"] == VARY_HEADERS
     return hidden, response.headers[EA_STATUS_HEADER]
+
+
+def _cache_control(settings: Settings, token: str | None, internal: bool = False) -> str | None:
+    response = Response()
+    hidden_early_access(response=response, internal=internal, x_ea_token=token, settings=settings)
+    return response.headers.get("Cache-Control")
 
 
 def _hidden(settings: Settings, token: str | None) -> frozenset[tuple[str, str]]:
@@ -178,3 +190,14 @@ def test_a_model_id_containing_a_slash_still_parses(monkeypatch: pytest.MonkeyPa
     # Split on the first slash, so the model is "org/model" — no such model is
     # embargoed, so nothing is revealed, but the entry parsed rather than raised.
     assert _hidden(settings, token=_TOKEN) == embargoed_pairs()
+
+
+def test_cache_control_is_private_only_when_a_proof_resolved(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A privileged response must never be stored; a public one is cacheable."""
+    settings = _settings(monkeypatch, {_TOKEN: [_entry(_some_pair())]})
+    assert _cache_control(settings, token=None, internal=True) == "private, no-store"
+    assert _cache_control(settings, token=_TOKEN) == "private, no-store"
+    assert _cache_control(settings, token=None) is None
+    assert _cache_control(settings, token="wrong") is None  # noqa: S106 - fake token

--- a/runner/tests/api/test_internal_access.py
+++ b/runner/tests/api/test_internal_access.py
@@ -14,7 +14,7 @@ from typing import Any
 import pytest
 from httpx import AsyncClient
 
-from coval_bench.api.internal import is_internal
+from coval_bench.api.internal import VARY_HEADERS, is_internal
 from coval_bench.config import Settings
 from coval_bench.registries import MODEL_REGISTRY, Benchmark, ModelStatus, RegisteredModel
 from tests.api.conftest import (
@@ -182,3 +182,51 @@ def test_is_internal_requires_configured_key(monkeypatch: pytest.MonkeyPatch) ->
     configured = Settings()
     assert is_internal(x_internal_key="k", settings=configured) is True
     assert is_internal(x_internal_key="wrong", settings=configured) is False
+
+
+@pytest.mark.parametrize(
+    ("path", "params"),
+    [
+        ("/v1/providers", None),
+        ("/v1/results", None),
+        ("/v1/leaderboard", {"metric": "WER", "benchmark": "STT"}),
+        ("/v1/results/aggregates", {"benchmark": "STT"}),
+    ],
+)
+async def test_vary_lists_both_proof_headers(
+    client: AsyncClient, path: str, params: dict[str, str] | None
+) -> None:
+    """Every embargo-gated endpoint must vary on both proofs.
+
+    Listing one and not the other is worse than listing neither: a cached internal
+    response carries no X-EA-Token, so it would match a public request.
+    """
+    response = await client.get(path, params=params)
+    assert response.status_code == 200
+    vary = response.headers["Vary"]
+    for header in VARY_HEADERS.split(", "):
+        assert header in vary, f"{header} missing from Vary: {vary!r}"
+
+
+async def test_vary_keeps_the_proof_headers_once_gzip_appends(client: AsyncClient) -> None:
+    """SelectiveGZipMiddleware appends Accept-Encoding after the route returns.
+
+    /v1/providers serves the whole registry, so it clears the 1024-byte gzip
+    threshold — an assignment in the dependency would be lost here.
+    """
+    response = await client.get("/v1/providers", headers={"Accept-Encoding": "gzip"})
+    assert response.status_code == 200
+    vary = response.headers["Vary"]
+    for header in (*VARY_HEADERS.split(", "), "Accept-Encoding"):
+        assert header in vary, f"{header} missing from Vary: {vary!r}"
+
+
+async def test_public_responses_are_cacheable_privileged_ones_are_not(
+    client: AsyncClient,
+) -> None:
+    """The embargo gate must mark a privileged response no-store."""
+    public = await client.get("/v1/providers")
+    assert public.headers.get("Cache-Control") is None
+
+    internal = await client.get("/v1/providers", headers=_INTERNAL_HEADERS)
+    assert internal.headers["Cache-Control"] == "private, no-store"

--- a/runner/tests/api/test_internal_access.py
+++ b/runner/tests/api/test_internal_access.py
@@ -18,6 +18,11 @@ from coval_bench.api.internal import VARY_HEADERS, is_internal
 from coval_bench.config import Settings
 from coval_bench.registries import MODEL_REGISTRY, Benchmark, ModelStatus, RegisteredModel
 from tests.api.conftest import (
+    EA_MODEL,
+    EA_MODEL_OTHER,
+    EA_PROVIDER,
+    EA_TOKEN,
+    EA_TOKEN_OTHER,
     INTERNAL_API_KEY,
     _fill_buckets,
     _insert_result,
@@ -28,20 +33,27 @@ from tests.api.conftest import (
 _INTERNAL_HEADERS = {"X-Internal-Key": INTERNAL_API_KEY}
 _WRONG_HEADERS = {"X-Internal-Key": "not-the-key"}
 
-_EA_PROVIDER = "acme"
-_EA_MODEL = "unreleased-stt"
+_EA_PROVIDER = EA_PROVIDER
+_EA_MODEL = EA_MODEL
 
 
 @pytest.fixture
 def early_access_registry(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Extend the registry with one EARLY_ACCESS STT model for the duration of a test."""
+    """Extend the registry with two EARLY_ACCESS STT models for the duration of a test.
+
+    Both sit on one provider so a per-model allowlist can be told apart from a
+    per-provider one.
+    """
     patched = [
         *MODEL_REGISTRY,
-        RegisteredModel(
-            benchmark=Benchmark.STT,
-            provider=_EA_PROVIDER,
-            model=_EA_MODEL,
-            status=ModelStatus.EARLY_ACCESS,
+        *(
+            RegisteredModel(
+                benchmark=Benchmark.STT,
+                provider=_EA_PROVIDER,
+                model=model,
+                status=ModelStatus.EARLY_ACCESS,
+            )
+            for model in (_EA_MODEL, EA_MODEL_OTHER)
         ),
     ]
     monkeypatch.setattr("coval_bench.api.internal.MODEL_REGISTRY", patched)
@@ -161,9 +173,9 @@ async def test_providers_serves_early_access_enabled_to_internal(client: AsyncCl
     assert response.status_code == 200
     by_provider = {p["provider"]: p["models"] for p in response.json()["stt"]}
     assert _EA_PROVIDER in by_provider
-    (model,) = by_provider[_EA_PROVIDER]
-    assert model["model"] == _EA_MODEL
-    assert model["disabled"] is False
+    models = {m["model"]: m for m in by_provider[_EA_PROVIDER]}
+    assert models.keys() == {_EA_MODEL, EA_MODEL_OTHER}
+    assert all(m["disabled"] is False for m in models.values())
 
 
 def test_is_internal_requires_configured_key(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -230,3 +242,47 @@ async def test_public_responses_are_cacheable_privileged_ones_are_not(
 
     internal = await client.get("/v1/providers", headers=_INTERNAL_HEADERS)
     assert internal.headers["Cache-Control"] == "private, no-store"
+
+
+@pytest.mark.usefixtures("early_access_registry")
+async def test_two_partner_tokens_never_share_an_aggregates_cache_entry(
+    client: AsyncClient, postgresql: Any
+) -> None:
+    """Token A then token B on the same cache: B must not see A's model.
+
+    This is the case that actually proves the cache key. Only /v1/results/aggregates
+    caches, and A goes first so a key that ignored the caller would serve A's rows
+    straight back to B.
+    """
+    run_id = await _insert_run(postgresql)
+    await _insert_result(postgresql, run_id, provider=_EA_PROVIDER, model=_EA_MODEL)
+    await _insert_result(postgresql, run_id, provider=_EA_PROVIDER, model=EA_MODEL_OTHER)
+    await _refresh_mv(postgresql)
+    await _fill_buckets(postgresql)
+
+    params = {"benchmark": "STT", "window": "24h"}
+
+    first = await client.get(
+        "/v1/results/aggregates", params=params, headers={"X-EA-Token": EA_TOKEN}
+    )
+    assert first.status_code == 200
+    assert first.headers["X-EA-Token-Status"] == "accepted"
+    assert (_EA_PROVIDER, _EA_MODEL) in _models_in(first.json()["model_stats"])
+    assert (_EA_PROVIDER, EA_MODEL_OTHER) not in _models_in(first.json()["model_stats"])
+
+    second = await client.get(
+        "/v1/results/aggregates", params=params, headers={"X-EA-Token": EA_TOKEN_OTHER}
+    )
+    assert second.status_code == 200
+    stats = _models_in(second.json()["model_stats"])
+    assert (_EA_PROVIDER, EA_MODEL_OTHER) in stats
+    assert (_EA_PROVIDER, _EA_MODEL) not in stats, "token A's model leaked into token B's view"
+
+
+@pytest.mark.usefixtures("early_access_registry")
+async def test_partner_token_scopes_the_providers_catalogue(client: AsyncClient) -> None:
+    """A token reveals its own model and keeps the sibling on the same provider hidden."""
+    response = await client.get("/v1/providers", headers={"X-EA-Token": EA_TOKEN})
+    assert response.status_code == 200
+    by_provider = {p["provider"]: p["models"] for p in response.json()["stt"]}
+    assert {m["model"] for m in by_provider[_EA_PROVIDER]} == {_EA_MODEL}

--- a/web/lib/api/accessTokens.test.ts
+++ b/web/lib/api/accessTokens.test.ts
@@ -1,22 +1,28 @@
 // Copyright 2026 The Coval Benchmarks Authors
 // SPDX-License-Identifier: Apache-2.0
 
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { captureTokensFromUrl, tokenHeaders } from "./accessTokens";
+import { applyTokensFromUrl, captureTokensFromUrl, tokenHeaders } from "./accessTokens";
 
 // The suite runs without a DOM, so stub only what the module touches. Storage
 // persists across setUrl calls, the way a real browser's does.
 const store = new Map<string, string>();
 
 function setUrl(url: string): void {
+  const location = { href: url };
   (globalThis as { window?: unknown }).window = {
-    location: { href: url },
+    location,
     localStorage: {
       getItem: (k: string) => store.get(k) ?? null,
       setItem: (k: string, v: string) => void store.set(k, v),
       removeItem: (k: string) => void store.delete(k),
     },
+    // replaceState rewrites the address bar without navigating, so the stub just
+    // moves href — that is what the strip is observed through.
+    history: { state: null, replaceState: (_s: unknown, _t: string, next: string) => {
+      location.href = next;
+    } },
   };
 }
 
@@ -75,5 +81,45 @@ describe("captureTokensFromUrl", () => {
     setUrl("https://benchmarks.coval.ai/s2s?ea=");
     expect(captureTokensFromUrl()).toBe(true);
     expect(tokenHeaders()).toEqual({ "X-Internal-Key": "team-key" });
+  });
+});
+
+describe("applyTokensFromUrl", () => {
+  it("signals the identity change and strips the param", () => {
+    setUrl("https://benchmarks.coval.ai/s2s?ea=partner-token");
+    const onChange = vi.fn();
+    applyTokensFromUrl(onChange);
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(tokenHeaders()).toEqual({ "X-EA-Token": "partner-token" });
+    expect(window.location.href).toBe("https://benchmarks.coval.ai/s2s");
+  });
+
+  it("still signals when Strict Mode replays the effect", () => {
+    // Strict Mode mounts, unmounts and remounts, so the effect body runs twice.
+    // The second pass sees the token already stored: the signal must survive the
+    // first pass rather than being recomputed, which is why capture cannot live in
+    // render — there, React keeps the second pass and the change is lost.
+    setUrl("https://benchmarks.coval.ai/s2s?ea=partner-token");
+    const onChange = vi.fn();
+    applyTokensFromUrl(onChange);
+    applyTokensFromUrl(onChange);
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(tokenHeaders()).toEqual({ "X-EA-Token": "partner-token" });
+  });
+
+  it("signals again when a later token differs", () => {
+    setUrl("https://benchmarks.coval.ai/s2s?ea=partner-one");
+    const onChange = vi.fn();
+    applyTokensFromUrl(onChange);
+    setUrl("https://benchmarks.coval.ai/s2s?ea=partner-two");
+    applyTokensFromUrl(onChange);
+    expect(onChange).toHaveBeenCalledTimes(2);
+    expect(tokenHeaders()).toEqual({ "X-EA-Token": "partner-two" });
+  });
+
+  it("does not signal when there is no token to adopt", () => {
+    const onChange = vi.fn();
+    applyTokensFromUrl(onChange);
+    expect(onChange).not.toHaveBeenCalled();
   });
 });

--- a/web/lib/api/accessTokens.test.ts
+++ b/web/lib/api/accessTokens.test.ts
@@ -1,0 +1,79 @@
+// Copyright 2026 The Coval Benchmarks Authors
+// SPDX-License-Identifier: Apache-2.0
+
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { captureTokensFromUrl, tokenHeaders } from "./accessTokens";
+
+// The suite runs without a DOM, so stub only what the module touches. Storage
+// persists across setUrl calls, the way a real browser's does.
+const store = new Map<string, string>();
+
+function setUrl(url: string): void {
+  (globalThis as { window?: unknown }).window = {
+    location: { href: url },
+    localStorage: {
+      getItem: (k: string) => store.get(k) ?? null,
+      setItem: (k: string, v: string) => void store.set(k, v),
+      removeItem: (k: string) => void store.delete(k),
+    },
+  };
+}
+
+beforeEach(() => {
+  store.clear();
+  setUrl("https://benchmarks.coval.ai/s2s");
+});
+
+describe("captureTokensFromUrl", () => {
+  it("stores a token from the URL and reports the change", () => {
+    setUrl("https://benchmarks.coval.ai/s2s?ea=partner-token");
+    expect(captureTokensFromUrl()).toBe(true);
+    expect(tokenHeaders()).toEqual({ "X-EA-Token": "partner-token" });
+  });
+
+  it("reports no change when the same token is seen again", () => {
+    setUrl("https://benchmarks.coval.ai/s2s?ea=partner-token");
+    expect(captureTokensFromUrl()).toBe(true);
+    expect(captureTokensFromUrl()).toBe(false);
+  });
+
+  it("reports a change when the token is swapped", () => {
+    setUrl("https://benchmarks.coval.ai/s2s?ea=partner-one");
+    captureTokensFromUrl();
+    setUrl("https://benchmarks.coval.ai/s2s?ea=partner-two");
+    expect(captureTokensFromUrl()).toBe(true);
+    expect(tokenHeaders()).toEqual({ "X-EA-Token": "partner-two" });
+  });
+
+  it("treats an empty value as a clear, and reports it", () => {
+    setUrl("https://benchmarks.coval.ai/s2s?ea=partner-token");
+    captureTokensFromUrl();
+    setUrl("https://benchmarks.coval.ai/s2s?ea=");
+    expect(captureTokensFromUrl()).toBe(true);
+    expect(tokenHeaders()).toEqual({});
+  });
+
+  it("reports no change when clearing an already-absent token", () => {
+    setUrl("https://benchmarks.coval.ai/s2s?ea=");
+    expect(captureTokensFromUrl()).toBe(false);
+  });
+
+  it("reports no change when no token param is present", () => {
+    expect(captureTokensFromUrl()).toBe(false);
+    expect(tokenHeaders()).toEqual({});
+  });
+
+  it("keeps the two tokens independent", () => {
+    setUrl("https://benchmarks.coval.ai/s2s?ea=partner-token&internal=team-key");
+    expect(captureTokensFromUrl()).toBe(true);
+    expect(tokenHeaders()).toEqual({
+      "X-Internal-Key": "team-key",
+      "X-EA-Token": "partner-token",
+    });
+
+    setUrl("https://benchmarks.coval.ai/s2s?ea=");
+    expect(captureTokensFromUrl()).toBe(true);
+    expect(tokenHeaders()).toEqual({ "X-Internal-Key": "team-key" });
+  });
+});

--- a/web/lib/api/accessTokens.ts
+++ b/web/lib/api/accessTokens.ts
@@ -42,9 +42,9 @@ export function tokenHeaders(): Record<string, string> {
 /**
  * Store any token present in the URL, returning true when a stored value changed.
  *
- * Safe to call during render (idempotent), but act on the return value from an
- * effect — a caller that changed identity has a stale cache to drop, and clearing
- * it during render is not allowed.
+ * Call from a committed effect, never from render: the change is reported once, so
+ * a replayed render would write the token on the first pass and report no change on
+ * the second, losing it. Prefer `applyTokensFromUrl`.
  */
 export function captureTokensFromUrl(): boolean {
   const params = new URL(window.location.href).searchParams;
@@ -76,4 +76,17 @@ export function stripTokensFromUrl(): void {
   if (present.length === 0) return;
   for (const { param } of present) url.searchParams.delete(param);
   window.history.replaceState(window.history.state, "", url.toString());
+}
+
+/**
+ * Adopt the URL's tokens, then clean the URL, calling `onIdentityChange` when the
+ * caller's identity actually changed.
+ *
+ * The whole sequence belongs in one committed effect. Running any of it in render
+ * makes the change flag depend on which render pass React keeps — Strict Mode
+ * replays the pass, and the second one sees the token already stored.
+ */
+export function applyTokensFromUrl(onIdentityChange: () => void): void {
+  if (captureTokensFromUrl()) onIdentityChange();
+  stripTokensFromUrl();
 }

--- a/web/lib/api/accessTokens.ts
+++ b/web/lib/api/accessTokens.ts
@@ -39,22 +39,33 @@ export function tokenHeaders(): Record<string, string> {
   return headers;
 }
 
-/** Store any token present in the URL. Safe to call during render (idempotent). */
-export function captureTokensFromUrl(): void {
+/**
+ * Store any token present in the URL, returning true when a stored value changed.
+ *
+ * Safe to call during render (idempotent), but act on the return value from an
+ * effect — a caller that changed identity has a stale cache to drop, and clearing
+ * it during render is not allowed.
+ */
+export function captureTokensFromUrl(): boolean {
   const params = new URL(window.location.href).searchParams;
+  let changed = false;
   for (const { param, storage } of Object.values(TOKENS)) {
     const value = params.get(param);
     if (value === null) continue;
     try {
-      if (value === "") {
+      const next = value === "" ? null : value;
+      if (window.localStorage.getItem(storage) === next) continue;
+      if (next === null) {
         window.localStorage.removeItem(storage);
       } else {
-        window.localStorage.setItem(storage, value);
+        window.localStorage.setItem(storage, next);
       }
+      changed = true;
     } catch {
       // storage unavailable — requests just won't carry the token
     }
   }
+  return changed;
 }
 
 /** Remove token params from the URL. Call after hydration — during render the

--- a/web/lib/api/providers.tsx
+++ b/web/lib/api/providers.tsx
@@ -11,7 +11,7 @@ import { captureTokensFromUrl, stripTokensFromUrl } from "@/lib/api/accessTokens
 export function ApiProviders({ children }: { children: ReactNode }) {
   // Store ?internal=<key> / ?ea=<token> before the first query fires (idempotent);
   // the URL cleanup must wait until after hydration or the router restores the param.
-  if (typeof window !== "undefined") captureTokensFromUrl();
+  const tokensChanged = typeof window === "undefined" ? false : captureTokensFromUrl();
   useEffect(() => stripTokensFromUrl(), []);
   const [client] = useState(
     () =>
@@ -26,6 +26,11 @@ export function ApiProviders({ children }: { children: ReactNode }) {
         },
       })
   );
+  // A different token is a different view of the embargo, so whatever is cached was
+  // fetched for someone else. Dropped rather than revalidated, and never in render.
+  useEffect(() => {
+    if (tokensChanged) client.clear();
+  }, [client, tokensChanged]);
   return (
     <ThemeProvider attribute="data-theme" defaultTheme="system" enableSystem>
       <QueryClientProvider client={client}>{children}</QueryClientProvider>

--- a/web/lib/api/providers.tsx
+++ b/web/lib/api/providers.tsx
@@ -6,13 +6,9 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ThemeProvider } from "next-themes";
 import { useEffect, useState, type ReactNode } from "react";
-import { captureTokensFromUrl, stripTokensFromUrl } from "@/lib/api/accessTokens";
+import { applyTokensFromUrl } from "@/lib/api/accessTokens";
 
 export function ApiProviders({ children }: { children: ReactNode }) {
-  // Store ?internal=<key> / ?ea=<token> before the first query fires (idempotent);
-  // the URL cleanup must wait until after hydration or the router restores the param.
-  const tokensChanged = typeof window === "undefined" ? false : captureTokensFromUrl();
-  useEffect(() => stripTokensFromUrl(), []);
   const [client] = useState(
     () =>
       new QueryClient({
@@ -26,11 +22,10 @@ export function ApiProviders({ children }: { children: ReactNode }) {
         },
       })
   );
-  // A different token is a different view of the embargo, so whatever is cached was
-  // fetched for someone else. Dropped rather than revalidated, and never in render.
-  useEffect(() => {
-    if (tokensChanged) client.clear();
-  }, [client, tokensChanged]);
+  // Adopting ?internal=<key> / ?ea=<token>, dropping a previous caller's cached rows,
+  // and cleaning the URL all happen here: one committed effect, so the identity change
+  // cannot be lost to a replayed render, and the router cannot restore the param.
+  useEffect(() => applyTokensFromUrl(() => client.clear()), [client]);
   return (
     <ThemeProvider attribute="data-theme" defaultTheme="system" enableSystem>
       <QueryClientProvider client={client}>{children}</QueryClientProvider>


### PR DESCRIPTION
The token gate landed in #414 with no cache headers, so a response carrying embargoed rows could be stored and handed to the next caller. The gate now varies on both proof headers and marks any privileged response no-store, appended rather than assigned because the compression middleware writes Vary after the route returns.

Cache isolation was only covered between internal and public callers. A second synthetic embargoed model on the same provider lets one partner token's view be checked against another's on the single endpoint that caches. Weakening that key on purpose fails both tests.

Query keys carry no access identity, so swapping or clearing a token left the previous caller's rows on screen until the next refetch. Capture now reports whether it changed a stored value, and the cache is dropped from an effect rather than during render.