### PR TITLE
Resolve early access from a Clerk session token

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,7 +48,7 @@ LMNT_API_KEY=
 # models that key lists. Unset means no token unlocks anything.
 # EARLY_ACCESS_TOKENS={"some-token":["xai/grok-realtime"]}
 # Clerk instance for provider-org logins; the org's benchmark_providers claim
-# scopes early access. Unset disables bearer tokens.
+# scopes early access. Bearer tokens stay disabled until both are set.
 # CLERK_ISSUER=https://clerk.example.com
 # CLERK_AUTHORIZED_PARTIES=["https://benchmarks.coval.ai"]
 

--- a/.env.example
+++ b/.env.example
@@ -47,6 +47,10 @@ LMNT_API_KEY=
 # Partner tokens: a request with X-EA-Token equal to a key below sees only the
 # models that key lists. Unset means no token unlocks anything.
 # EARLY_ACCESS_TOKENS={"some-token":["xai/grok-realtime"]}
+# Clerk instance for provider-org logins; the org's benchmark_providers claim
+# scopes early access. Unset disables bearer tokens.
+# CLERK_ISSUER=https://clerk.example.com
+# CLERK_AUTHORIZED_PARTIES=["https://benchmarks.coval.ai"]
 
 # --- Google STT/TTS (optional; requires the `google-stt` / `google-tts` extras) ---
 # GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json

--- a/runner/pyproject.toml
+++ b/runner/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "uvicorn[standard]>=0.30",
     "slowapi>=0.1.9",
     "cachetools>=5.3",
+    "pyjwt[crypto]>=2.9",
     # WebSocket clients (STT providers)
     "websockets>=13,<14",
     # Fish Audio WS protocol serialization

--- a/runner/src/coval_bench/api/clerk.py
+++ b/runner/src/coval_bench/api/clerk.py
@@ -1,0 +1,68 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Resolve a Clerk session token to the embargoed models its org may see.
+
+Verified against the instance JWKS (public — no secret involved). The
+``benchmark_providers`` claim names the org's providers, or ``"*"`` for all.
+"""
+
+from __future__ import annotations
+
+import functools
+from typing import Any
+
+import jwt
+import structlog
+
+from coval_bench.config import Settings
+
+logger = structlog.get_logger("coval_bench.api.clerk")
+
+
+@functools.lru_cache(maxsize=4)
+def _jwks(issuer: str) -> jwt.PyJWKClient:
+    return jwt.PyJWKClient(f"{issuer}/.well-known/jwks.json")
+
+
+def _claims(token: str, settings: Settings) -> dict[str, Any] | None:
+    """Verified claims, or ``None`` if the token proves nothing."""
+    issuer = settings.clerk_issuer
+    if issuer is None:
+        return None
+    try:
+        key = _jwks(issuer).get_signing_key_from_jwt(token).key
+        claims: dict[str, Any] = jwt.decode(
+            token,
+            key,
+            algorithms=["RS256"],
+            issuer=issuer,
+            leeway=5,
+            options={"require": ["exp"]},
+        )
+    except jwt.PyJWTError as exc:
+        logger.warning("clerk_token_rejected", error=str(exc))
+        return None
+    parties = settings.clerk_authorized_parties
+    if parties and claims.get("azp") not in parties:
+        logger.warning("clerk_token_rejected", error="azp not in clerk_authorized_parties")
+        return None
+    return claims
+
+
+def allowed_pairs(
+    authorization: str, settings: Settings, embargoed: frozenset[tuple[str, str]]
+) -> frozenset[tuple[str, str]] | None:
+    """The embargoed pairs this bearer token unlocks, or ``None`` if it proves nothing."""
+    scheme, _, token = authorization.partition(" ")
+    if scheme.lower() != "bearer" or not token.strip():
+        return None
+    claims = _claims(token.strip(), settings)
+    if claims is None:
+        return None
+    providers = claims.get("benchmark_providers")
+    if providers == "*":
+        return embargoed
+    if not isinstance(providers, list):
+        return frozenset()
+    return frozenset(pair for pair in embargoed if pair[0] in providers)

--- a/runner/src/coval_bench/api/clerk.py
+++ b/runner/src/coval_bench/api/clerk.py
@@ -28,7 +28,9 @@ def _jwks(issuer: str) -> jwt.PyJWKClient:
 def _claims(token: str, settings: Settings) -> dict[str, Any] | None:
     """Verified claims, or ``None`` if the token proves nothing."""
     issuer = settings.clerk_issuer
-    if issuer is None:
+    parties = settings.clerk_authorized_parties
+    if issuer is None or not parties:
+        logger.warning("clerk_token_rejected", error="clerk_authorized_parties unset")
         return None
     try:
         key = _jwks(issuer).get_signing_key_from_jwt(token).key
@@ -43,8 +45,7 @@ def _claims(token: str, settings: Settings) -> dict[str, Any] | None:
     except jwt.PyJWTError as exc:
         logger.warning("clerk_token_rejected", error=str(exc))
         return None
-    parties = settings.clerk_authorized_parties
-    if parties and claims.get("azp") not in parties:
+    if claims.get("azp") not in parties:
         logger.warning("clerk_token_rejected", error="azp not in clerk_authorized_parties")
         return None
     return claims

--- a/runner/src/coval_bench/api/internal.py
+++ b/runner/src/coval_bench/api/internal.py
@@ -36,9 +36,9 @@ logger = structlog.get_logger("coval_bench.api.internal")
 # Which proof the response honoured: internal, accepted, unknown, or absent.
 EA_STATUS_HEADER = "X-EA-Token-Status"
 
-# Both proof headers. Listing one is worse than listing none: a cached internal
-# response carries no X-EA-Token, so it would match a public request.
-VARY_HEADERS = "X-Internal-Key, X-EA-Token"
+# Every proof header. Listing a subset is worse than listing none: a cached
+# internal response carries no X-EA-Token, so it would match a public request.
+VARY_HEADERS = "X-Internal-Key, X-EA-Token, Authorization"
 
 
 def never_shared(response: Response) -> None:
@@ -48,7 +48,7 @@ def never_shared(response: Response) -> None:
     included: the same URL is a 404 for the public and a redirect for a partner,
     so a shared cache must never hand one caller's answer to another.
     """
-    response.headers.append("Vary", "X-Internal-Key, X-EA-Token")
+    response.headers.append("Vary", VARY_HEADERS)
     response.headers["Cache-Control"] = "private, no-store"
 
 
@@ -166,6 +166,7 @@ def hidden_early_access(
             response.headers[EA_STATUS_HEADER] = "unknown"
             return embargoed
         response.headers[EA_STATUS_HEADER] = "accepted"
+        response.headers["Cache-Control"] = "private, no-store"
         return embargoed - allowed
 
     if x_ea_token is None:

--- a/runner/src/coval_bench/api/internal.py
+++ b/runner/src/coval_bench/api/internal.py
@@ -8,7 +8,8 @@ data endpoint strips them unless the caller proves it may see them. The
 benchmarking team presents ``X-Internal-Key`` and sees everything; a partner
 presents ``X-EA-Token``, which the server resolves to an allowlist of the models
 that token may see. The token is opaque and the allowlist lives in settings, so a
-request can never widen its own view.
+request can never widen its own view. A signed-in provider org presents a
+bearer Clerk session token instead (see ``clerk.py``).
 
 An absent or unknown proof yields the public view — the endpoints stay public
 either way, so there is nothing to 404 — and says so in ``X-EA-Token-Status``.
@@ -25,6 +26,7 @@ from collections.abc import Mapping
 import structlog
 from fastapi import Depends, Header, Response
 
+from coval_bench.api import clerk
 from coval_bench.api.deps import get_settings
 from coval_bench.config import Settings
 from coval_bench.registries import MODEL_REGISTRY, ModelStatus
@@ -122,6 +124,7 @@ def hidden_early_access(
     response: Response,
     internal: bool = Depends(is_internal),
     x_ea_token: str | None = Header(default=None),
+    authorization: str | None = Header(default=None),
     settings: Settings = Depends(get_settings),
 ) -> frozenset[tuple[str, str]]:
     """The pairs this caller's responses must not contain.
@@ -136,6 +139,14 @@ def hidden_early_access(
         return frozenset()
 
     embargoed = embargoed_pairs()
+    if x_ea_token is None and authorization is not None and settings.clerk_issuer is not None:
+        allowed = clerk.allowed_pairs(authorization, settings, embargoed)
+        if allowed is None:
+            response.headers[EA_STATUS_HEADER] = "unknown"
+            return embargoed
+        response.headers[EA_STATUS_HEADER] = "accepted"
+        return embargoed - allowed
+
     if x_ea_token is None:
         response.headers[EA_STATUS_HEADER] = "absent"
         return embargoed

--- a/runner/src/coval_bench/config.py
+++ b/runner/src/coval_bench/config.py
@@ -180,7 +180,7 @@ class Settings(BaseSettings):
     # Clerk instance whose JWKS verifies provider-org session tokens.
     # Unset means no bearer token unlocks anything.
     clerk_issuer: str | None = None
-    # Allowed azp claim values; empty skips the check.
+    # Allowed azp claim values; bearer tokens are rejected while empty.
     clerk_authorized_parties: list[str] = []
 
     # --- Arena ---

--- a/runner/src/coval_bench/config.py
+++ b/runner/src/coval_bench/config.py
@@ -177,6 +177,11 @@ class Settings(BaseSettings):
     # so a request carries only an opaque token and can never widen its own view.
     # Unset means no token unlocks anything.
     early_access_tokens: SecretStr | None = None
+    # Clerk instance whose JWKS verifies provider-org session tokens.
+    # Unset means no bearer token unlocks anything.
+    clerk_issuer: str | None = None
+    # Allowed azp claim values; empty skips the check.
+    clerk_authorized_parties: list[str] = []
 
     # --- Arena ---
     arena_labeler_key: SecretStr | None = None

--- a/runner/tests/api/test_clerk_scope.py
+++ b/runner/tests/api/test_clerk_scope.py
@@ -1,0 +1,220 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Provider-org early access via Clerk session tokens (JWKS stubbed).
+
+Assertions derive the embargoed set from the registry, so they keep holding
+as the roster changes status.
+"""
+
+from __future__ import annotations
+
+import time
+from types import SimpleNamespace
+from typing import Any
+
+import jwt
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from fastapi import Response
+
+from coval_bench.api import clerk
+from coval_bench.api.internal import EA_STATUS_HEADER, embargoed_pairs, hidden_early_access
+from coval_bench.config import Settings
+
+_ISSUER = "https://clerk.example.com"
+_PARTY = "https://benchmarks.example.com"
+
+_PRIVATE_KEY = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+_OTHER_KEY = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+_PUBLIC_PEM = _PRIVATE_KEY.public_key().public_bytes(
+    encoding=serialization.Encoding.PEM,
+    format=serialization.PublicFormat.SubjectPublicKeyInfo,
+)
+
+
+@pytest.fixture(autouse=True)
+def _stub_jwks(monkeypatch: pytest.MonkeyPatch) -> None:
+    signing_key = SimpleNamespace(key=_PUBLIC_PEM)
+    client = SimpleNamespace(get_signing_key_from_jwt=lambda token: signing_key)
+    monkeypatch.setattr(clerk, "_jwks", lambda issuer: client)
+
+
+def _settings(
+    monkeypatch: pytest.MonkeyPatch,
+    issuer: str | None = _ISSUER,
+    parties: str | None = None,
+) -> Settings:
+    monkeypatch.setenv("DATABASE_URL", "postgresql://runner:password@localhost:5432/benchmarks")
+    monkeypatch.setenv("DATASET_BUCKET", "test-bucket")
+    monkeypatch.setenv("DATASET_ID", "stt-v1")
+    monkeypatch.setenv("RUNNER_SHA", "test-sha")
+    monkeypatch.delenv("INTERNAL_API_KEY", raising=False)
+    monkeypatch.delenv("EARLY_ACCESS_TOKENS", raising=False)
+    if issuer is None:
+        monkeypatch.delenv("CLERK_ISSUER", raising=False)
+    else:
+        monkeypatch.setenv("CLERK_ISSUER", issuer)
+    if parties is None:
+        monkeypatch.delenv("CLERK_AUTHORIZED_PARTIES", raising=False)
+    else:
+        monkeypatch.setenv("CLERK_AUTHORIZED_PARTIES", parties)
+    return Settings()
+
+
+def _mint(claims: dict[str, Any], key: rsa.RSAPrivateKey = _PRIVATE_KEY, **overrides: Any) -> str:
+    now = int(time.time())
+    payload: dict[str, Any] = {"iss": _ISSUER, "iat": now, "exp": now + 60, "azp": _PARTY}
+    payload.update(claims)
+    payload.update(overrides)
+    return jwt.encode(payload, key, algorithm="RS256")
+
+
+def _resolve(
+    settings: Settings, authorization: str | None, x_ea_token: str | None = None
+) -> tuple[frozenset[tuple[str, str]], str]:
+    """This caller's hidden set and the status header it got."""
+    response = Response()
+    hidden = hidden_early_access(
+        response=response,
+        internal=False,
+        x_ea_token=x_ea_token,
+        authorization=authorization,
+        settings=settings,
+    )
+    return hidden, response.headers[EA_STATUS_HEADER]
+
+
+def _embargoed_provider() -> str:
+    """Any provider with an embargoed model, or skip."""
+    providers = sorted({provider for provider, _ in embargoed_pairs()})
+    if not providers:
+        pytest.skip("no embargoed models in the registry")
+    return providers[0]
+
+
+def _two_embargoed_providers() -> tuple[str, str]:
+    """Two distinct providers with embargoed models, or skip."""
+    providers = sorted({provider for provider, _ in embargoed_pairs()})
+    if len(providers) < 2:
+        pytest.skip("fewer than two providers have embargoed models")
+    return providers[0], providers[1]
+
+
+def test_org_sees_its_own_providers_models_and_no_others(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    mine, theirs = _two_embargoed_providers()
+    settings = _settings(monkeypatch)
+    token = _mint({"benchmark_providers": [mine]})
+    hidden, status = _resolve(settings, f"Bearer {token}")
+    assert status == "accepted"
+    assert hidden == frozenset(pair for pair in embargoed_pairs() if pair[0] != mine)
+    assert all(provider != mine for provider, _ in hidden)
+    assert any(provider == theirs for provider, _ in hidden)
+
+
+def test_star_claim_sees_everything(monkeypatch: pytest.MonkeyPatch) -> None:
+    settings = _settings(monkeypatch)
+    token = _mint({"benchmark_providers": "*"})
+    hidden, status = _resolve(settings, f"Bearer {token}")
+    assert status == "accepted"
+    assert hidden == frozenset()
+
+
+def test_session_without_the_claim_keeps_the_public_view(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    settings = _settings(monkeypatch)
+    token = _mint({})
+    hidden, status = _resolve(settings, f"Bearer {token}")
+    assert status == "accepted"
+    assert hidden == embargoed_pairs()
+
+
+def test_claim_of_the_wrong_shape_unlocks_nothing(monkeypatch: pytest.MonkeyPatch) -> None:
+    provider = _embargoed_provider()
+    settings = _settings(monkeypatch)
+    token = _mint({"benchmark_providers": provider})
+    hidden, status = _resolve(settings, f"Bearer {token}")
+    assert status == "accepted"
+    assert hidden == embargoed_pairs()
+
+
+def test_expired_token_keeps_the_public_view(monkeypatch: pytest.MonkeyPatch) -> None:
+    settings = _settings(monkeypatch)
+    now = int(time.time())
+    token = _mint({"benchmark_providers": "*"}, iat=now - 120, exp=now - 60)
+    hidden, status = _resolve(settings, f"Bearer {token}")
+    assert status == "unknown"
+    assert hidden == embargoed_pairs()
+
+
+def test_token_signed_by_another_key_keeps_the_public_view(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    settings = _settings(monkeypatch)
+    token = _mint({"benchmark_providers": "*"}, key=_OTHER_KEY)
+    hidden, status = _resolve(settings, f"Bearer {token}")
+    assert status == "unknown"
+    assert hidden == embargoed_pairs()
+
+
+def test_token_from_another_issuer_keeps_the_public_view(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    settings = _settings(monkeypatch)
+    token = _mint({"benchmark_providers": "*"}, iss="https://not-clerk.example.com")
+    hidden, status = _resolve(settings, f"Bearer {token}")
+    assert status == "unknown"
+    assert hidden == embargoed_pairs()
+
+
+def test_azp_outside_the_allowlist_keeps_the_public_view(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    settings = _settings(monkeypatch, parties=f'["{_PARTY}"]')
+    token = _mint({"benchmark_providers": "*"}, azp="https://elsewhere.example.com")
+    hidden, status = _resolve(settings, f"Bearer {token}")
+    assert status == "unknown"
+    assert hidden == embargoed_pairs()
+
+
+def test_azp_in_the_allowlist_is_accepted(monkeypatch: pytest.MonkeyPatch) -> None:
+    settings = _settings(monkeypatch, parties=f'["{_PARTY}"]')
+    token = _mint({"benchmark_providers": "*"})
+    hidden, status = _resolve(settings, f"Bearer {token}")
+    assert status == "accepted"
+    assert hidden == frozenset()
+
+
+def test_bearer_is_ignored_when_clerk_is_not_configured(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    settings = _settings(monkeypatch, issuer=None)
+    token = _mint({"benchmark_providers": "*"})
+    hidden, status = _resolve(settings, f"Bearer {token}")
+    assert status == "absent"
+    assert hidden == embargoed_pairs()
+
+
+def test_non_bearer_authorization_keeps_the_public_view(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    settings = _settings(monkeypatch)
+    hidden, status = _resolve(settings, "Basic dXNlcjpwYXNz")
+    assert status == "unknown"
+    assert hidden == embargoed_pairs()
+
+
+def test_partner_token_takes_precedence_over_bearer(monkeypatch: pytest.MonkeyPatch) -> None:
+    settings = _settings(monkeypatch)
+    token = _mint({"benchmark_providers": "*"})
+    hidden, status = _resolve(
+        settings,
+        f"Bearer {token}",
+        x_ea_token="not-a-configured-token",  # noqa: S106 - fake token
+    )
+    assert status == "unknown"
+    assert hidden == embargoed_pairs()

--- a/runner/tests/api/test_clerk_scope.py
+++ b/runner/tests/api/test_clerk_scope.py
@@ -44,7 +44,7 @@ def _stub_jwks(monkeypatch: pytest.MonkeyPatch) -> None:
 def _settings(
     monkeypatch: pytest.MonkeyPatch,
     issuer: str | None = _ISSUER,
-    parties: str | None = None,
+    parties: str | None = f'["{_PARTY}"]',
 ) -> Settings:
     monkeypatch.setenv("DATABASE_URL", "postgresql://runner:password@localhost:5432/benchmarks")
     monkeypatch.setenv("DATASET_BUCKET", "test-bucket")
@@ -187,6 +187,14 @@ def test_azp_in_the_allowlist_is_accepted(monkeypatch: pytest.MonkeyPatch) -> No
     hidden, status = _resolve(settings, f"Bearer {token}")
     assert status == "accepted"
     assert hidden == frozenset()
+
+
+def test_unset_authorized_parties_rejects_every_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    settings = _settings(monkeypatch, parties=None)
+    token = _mint({"benchmark_providers": "*"})
+    hidden, status = _resolve(settings, f"Bearer {token}")
+    assert status == "unknown"
+    assert hidden == embargoed_pairs()
 
 
 def test_bearer_is_ignored_when_clerk_is_not_configured(

--- a/runner/tests/api/test_clerk_scope.py
+++ b/runner/tests/api/test_clerk_scope.py
@@ -197,6 +197,34 @@ def test_unset_authorized_parties_rejects_every_token(monkeypatch: pytest.Monkey
     assert hidden == embargoed_pairs()
 
 
+def _headers(settings: Settings, authorization: str) -> dict[str, str]:
+    response = Response()
+    hidden_early_access(
+        response=response,
+        internal=False,
+        x_ea_token=None,
+        authorization=authorization,
+        settings=settings,
+    )
+    return dict(response.headers)
+
+
+def test_accepted_bearer_response_is_never_stored_shared(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    settings = _settings(monkeypatch)
+    token = _mint({"benchmark_providers": "*"})
+    headers = _headers(settings, f"Bearer {token}")
+    assert headers["cache-control"] == "private, no-store"
+
+
+def test_bearer_responses_vary_on_authorization(monkeypatch: pytest.MonkeyPatch) -> None:
+    settings = _settings(monkeypatch)
+    token = _mint({"benchmark_providers": "*"})
+    headers = _headers(settings, f"Bearer {token}")
+    assert "Authorization" in headers["vary"]
+
+
 def test_bearer_is_ignored_when_clerk_is_not_configured(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/runner/uv.lock
+++ b/runner/uv.lock
@@ -294,6 +294,7 @@ dependencies = [
     { name = "psycopg", extra = ["binary", "pool"] },
     { name = "pydantic" },
     { name = "pydantic-settings" },
+    { name = "pyjwt", extra = ["crypto"] },
     { name = "scipy" },
     { name = "slowapi" },
     { name = "soundfile" },
@@ -358,6 +359,7 @@ requires-dist = [
     { name = "pyarrow", marker = "extra == 'hf-parquet'", specifier = ">=17" },
     { name = "pydantic", specifier = ">=2.7" },
     { name = "pydantic-settings", specifier = ">=2.14.2" },
+    { name = "pyjwt", extras = ["crypto"], specifier = ">=2.9" },
     { name = "scipy", specifier = ">=1.11" },
     { name = "slowapi", specifier = ">=0.1.9" },
     { name = "soundfile", specifier = ">=0.12" },
@@ -1397,6 +1399,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pyjwt"
+version = "2.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
+]
+
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography" },
 ]
 
 [[package]]


### PR DESCRIPTION
A signed-in provider org's benchmark_providers claim names the providers whose embargoed models it may see; anything unverified keeps the public view, and nothing activates until clerk_issuer is set.

Prep for adding early access orgs.