### PR TITLE
Serve S2S samples through the API with signed URLs

### DIFF
--- a/runner/src/coval_bench/api/app.py
+++ b/runner/src/coval_bench/api/app.py
@@ -18,17 +18,27 @@ from __future__ import annotations
 import atexit
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
+from typing import cast
 
 import structlog
 from fastapi import FastAPI
+from fastapi.exception_handlers import (
+    http_exception_handler,
+    request_validation_exception_handler,
+)
+from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 from posthog import Posthog
 from slowapi.errors import RateLimitExceeded
 from slowapi.middleware import SlowAPIMiddleware
+from starlette.exceptions import HTTPException as StarletteHTTPException
+from starlette.requests import Request
+from starlette.responses import Response
 
 from coval_bench.api.cache import new_cache_locks, new_response_cache
 from coval_bench.api.compression import SelectiveGZipMiddleware
+from coval_bench.api.internal import never_shared
 from coval_bench.api.ratelimit import _rate_limit_handler, limiter
 from coval_bench.api.request_logging import RequestLoggingMiddleware
 from coval_bench.api.routers import (
@@ -47,6 +57,28 @@ from coval_bench.db.conn import lifespan_pool
 from coval_bench.logging import configure_logging
 
 logger = structlog.get_logger("coval_bench.api")
+
+
+async def _never_shared_http_error(request: Request, exc: Exception) -> Response:
+    """The stock HTTP error, marked as this caller's alone.
+
+    FastAPI builds an exception response from scratch, so the headers a route set
+    on its injected ``Response`` are gone by the time the error is rendered. An
+    embargoed recording answers 404 to the public and 302 to a partner at the very
+    same URL, and without this a shared cache could hand the 404 to the partner.
+    """
+    response = await http_exception_handler(request, cast("StarletteHTTPException", exc))
+    never_shared(response)
+    return response
+
+
+async def _never_shared_validation_error(request: Request, exc: Exception) -> Response:
+    """A rejected request parameter, under the same cache policy as every error."""
+    response = await request_validation_exception_handler(
+        request, cast("RequestValidationError", exc)
+    )
+    never_shared(response)
+    return response
 
 
 def create_app(settings: Settings | None = None) -> FastAPI:
@@ -115,6 +147,10 @@ def create_app(settings: Settings | None = None) -> FastAPI:
 
     app.state.response_cache = new_response_cache()
     app.state.cache_locks = new_cache_locks()
+
+    # Error responses carry the same caller-scoped cache policy as successful ones.
+    app.add_exception_handler(StarletteHTTPException, _never_shared_http_error)
+    app.add_exception_handler(RequestValidationError, _never_shared_validation_error)
 
     # Rate limiting (ADR-013) — in-memory per-instance; see ratelimit.py for caveat.
     app.state.limiter = limiter

--- a/runner/src/coval_bench/api/app.py
+++ b/runner/src/coval_bench/api/app.py
@@ -40,6 +40,7 @@ from coval_bench.api.routers import (
     results,
     robots,
     runs,
+    s2s_samples,
 )
 from coval_bench.config import Settings, get_settings
 from coval_bench.db.conn import lifespan_pool
@@ -131,6 +132,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     app.include_router(aggregates.router, prefix="/v1")
     app.include_router(leaderboard.router, prefix="/v1")
     app.include_router(providers.router, prefix="/v1")
+    app.include_router(s2s_samples.router, prefix="/v1")
     app.include_router(arena.router, prefix="/v1")
 
     # Serve locally-generated arena clips when no external audio host is set

--- a/runner/src/coval_bench/api/internal.py
+++ b/runner/src/coval_bench/api/internal.py
@@ -35,6 +35,17 @@ logger = structlog.get_logger("coval_bench.api.internal")
 EA_STATUS_HEADER = "X-EA-Token-Status"
 
 
+def never_shared(response: Response) -> None:
+    """Mark a response as belonging to this caller alone.
+
+    Any response whose content depends on the presented proof needs this, errors
+    included: the same URL is a 404 for the public and a redirect for a partner,
+    so a shared cache must never hand one caller's answer to another.
+    """
+    response.headers.append("Vary", "X-Internal-Key, X-EA-Token")
+    response.headers["Cache-Control"] = "private, no-store"
+
+
 def embargoed_pairs() -> frozenset[tuple[str, str]]:
     """Every ``(provider, model)`` pair currently under embargo."""
     return frozenset(

--- a/runner/src/coval_bench/api/routers/s2s_samples.py
+++ b/runner/src/coval_bench/api/routers/s2s_samples.py
@@ -26,7 +26,7 @@ from posthog import Posthog
 from starlette.requests import Request
 
 from coval_bench.api.deps import capture_api_event, get_posthog, get_settings
-from coval_bench.api.internal import EA_STATUS_HEADER, hidden_early_access
+from coval_bench.api.internal import EA_STATUS_HEADER, hidden_early_access, never_shared
 from coval_bench.api.ratelimit import limiter
 from coval_bench.api.schemas import S2SSampleOut, S2SSampleRecordingOut
 from coval_bench.config import Settings
@@ -44,11 +44,6 @@ logger = structlog.get_logger("coval_bench.api.s2s_samples")
 router = APIRouter(tags=["s2s"])
 
 _SAMPLE_ID = r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$"
-
-
-def _never_shared(response: Response) -> None:
-    response.headers.append("Vary", "X-Internal-Key, X-EA-Token")
-    response.headers["Cache-Control"] = "private, no-store"
 
 
 def _sees_any_s2s_model(hidden: frozenset[tuple[str, str]]) -> bool:
@@ -73,7 +68,7 @@ async def list_s2s_samples(
     hidden: frozenset[tuple[str, str]] = Depends(hidden_early_access),
 ) -> list[str]:
     """Sample ids newest-first, empty when the caller may see no S2S model at all."""
-    _never_shared(response)
+    never_shared(response)
     if not settings.s2s_samples_bucket or not _sees_any_s2s_model(hidden):
         return []
     return await asyncio.to_thread(load_sample_ids, settings.s2s_samples_bucket)
@@ -89,15 +84,20 @@ async def get_s2s_sample(
     hidden: frozenset[tuple[str, str]] = Depends(hidden_early_access),
     posthog_client: Posthog | None = Depends(get_posthog),
 ) -> S2SSampleOut:
-    """One sample's manifest, carrying only the recordings this caller may see."""
-    _never_shared(response)
+    """One sample's manifest, carrying only the recordings this caller may see.
+
+    A sample whose every recording is embargoed for this caller is a 404 rather
+    than an empty shell: the surrounding metadata would otherwise confirm that a
+    tick exists and name the scenario and persona behind it.
+    """
+    never_shared(response)
     if not settings.s2s_samples_bucket:
         raise HTTPException(404, "s2s samples are not configured")
 
     sample = await asyncio.to_thread(
         load_sample, settings.s2s_samples_bucket, sample_id, hidden=hidden
     )
-    if sample is None:
+    if sample is None or not sample["recordings"]:
         raise HTTPException(404, f"no s2s sample for {sample_id}")
 
     recordings = [
@@ -164,7 +164,7 @@ async def get_s2s_sample_audio(
 
     url = await asyncio.to_thread(signed_url, settings.s2s_samples_bucket, key, ttl=AUDIO_URL_TTL)
     redirect = RedirectResponse(url, status_code=302)
-    _never_shared(redirect)
+    never_shared(redirect)
     ea_status = response.headers.get(EA_STATUS_HEADER)
     if ea_status is not None:
         redirect.headers[EA_STATUS_HEADER] = ea_status

--- a/runner/src/coval_bench/api/routers/s2s_samples.py
+++ b/runner/src/coval_bench/api/routers/s2s_samples.py
@@ -1,0 +1,171 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""GET /v1/s2s/samples — conversation samples from the private samples bucket.
+
+The bucket allows no anonymous read. The API reads each manifest as its own
+service account, drops the recordings this caller may not see (their transcripts
+go with them, since both live in the same object), and hands back an API route
+per surviving recording. Playing one redirects to a short-lived signed URL minted
+at that moment, so no signature is ever stored or cached.
+
+Every route resolves visibility through the same ``hidden_early_access``
+dependency: the audio route re-checks rather than trusting that the caller got
+its path from a filtered manifest.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from urllib.parse import quote
+
+import structlog
+from fastapi import APIRouter, Depends, HTTPException, Path, Response
+from fastapi.responses import RedirectResponse
+from posthog import Posthog
+from starlette.requests import Request
+
+from coval_bench.api.deps import capture_api_event, get_posthog, get_settings
+from coval_bench.api.internal import EA_STATUS_HEADER, hidden_early_access
+from coval_bench.api.ratelimit import limiter
+from coval_bench.api.schemas import S2SSampleOut, S2SSampleRecordingOut
+from coval_bench.config import Settings
+from coval_bench.gcs import signed_url
+from coval_bench.registries import MODEL_REGISTRY, Benchmark
+from coval_bench.s2s.samples import (
+    AUDIO_URL_TTL,
+    audio_object_key,
+    load_sample,
+    load_sample_ids,
+)
+
+logger = structlog.get_logger("coval_bench.api.s2s_samples")
+
+router = APIRouter(tags=["s2s"])
+
+_SAMPLE_ID = r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$"
+
+
+def _never_shared(response: Response) -> None:
+    response.headers.append("Vary", "X-Internal-Key, X-EA-Token")
+    response.headers["Cache-Control"] = "private, no-store"
+
+
+def _sees_any_s2s_model(hidden: frozenset[tuple[str, str]]) -> bool:
+    return any(
+        m.benchmark is Benchmark.S2S and (m.provider, m.model) not in hidden for m in MODEL_REGISTRY
+    )
+
+
+def _audio_path(sample_id: str, provider: str, model: str) -> str:
+    return (
+        f"/v1/s2s/samples/{quote(sample_id, safe='')}"
+        f"/{quote(provider, safe='')}/{quote(model, safe='')}/audio"
+    )
+
+
+@router.get("/s2s/samples", response_model=list[str])
+@limiter.limit("60/minute")
+async def list_s2s_samples(
+    request: Request,
+    response: Response,
+    settings: Settings = Depends(get_settings),
+    hidden: frozenset[tuple[str, str]] = Depends(hidden_early_access),
+) -> list[str]:
+    """Sample ids newest-first, empty when the caller may see no S2S model at all."""
+    _never_shared(response)
+    if not settings.s2s_samples_bucket or not _sees_any_s2s_model(hidden):
+        return []
+    return await asyncio.to_thread(load_sample_ids, settings.s2s_samples_bucket)
+
+
+@router.get("/s2s/samples/{sample_id}", response_model=S2SSampleOut)
+@limiter.limit("60/minute")
+async def get_s2s_sample(
+    request: Request,
+    response: Response,
+    sample_id: str = Path(pattern=_SAMPLE_ID),
+    settings: Settings = Depends(get_settings),
+    hidden: frozenset[tuple[str, str]] = Depends(hidden_early_access),
+    posthog_client: Posthog | None = Depends(get_posthog),
+) -> S2SSampleOut:
+    """One sample's manifest, carrying only the recordings this caller may see."""
+    _never_shared(response)
+    if not settings.s2s_samples_bucket:
+        raise HTTPException(404, "s2s samples are not configured")
+
+    sample = await asyncio.to_thread(
+        load_sample, settings.s2s_samples_bucket, sample_id, hidden=hidden
+    )
+    if sample is None:
+        raise HTTPException(404, f"no s2s sample for {sample_id}")
+
+    recordings = [
+        S2SSampleRecordingOut(
+            provider=rec["provider"],
+            model=rec["model"],
+            audio_path=_audio_path(sample_id, rec["provider"], rec["model"]),
+            coval_run_id=rec["coval_run_id"],
+            sim_id=rec["sim_id"],
+            agent_id=rec.get("agent_id"),
+            turns=rec.get("turns", []),
+        )
+        for rec in sample["recordings"]
+    ]
+    out = S2SSampleOut(
+        schema_version=sample.get("schema_version"),
+        sample_id=sample_id,
+        test_case_id=sample["test_case_id"],
+        test_set_id=sample.get("test_set_id"),
+        persona_name=sample.get("persona_name"),
+        transcript=sample.get("transcript"),
+        recordings=recordings,
+    )
+    capture_api_event(
+        posthog_client,
+        "s2s_sample_served",
+        {
+            "sample_id": sample_id,
+            "recording_count": len(recordings),
+            "$process_person_profile": False,
+        },
+    )
+    return out
+
+
+@router.get(
+    "/s2s/samples/{sample_id}/{provider}/{model}/audio",
+    response_class=RedirectResponse,
+)
+@limiter.limit("120/minute")
+async def get_s2s_sample_audio(
+    request: Request,
+    response: Response,
+    provider: str,
+    model: str,
+    sample_id: str = Path(pattern=_SAMPLE_ID),
+    settings: Settings = Depends(get_settings),
+    hidden: frozenset[tuple[str, str]] = Depends(hidden_early_access),
+) -> RedirectResponse:
+    """Redirect to a freshly signed URL, minted only if this caller may hear it."""
+    if not settings.s2s_samples_bucket:
+        raise HTTPException(404, "s2s samples are not configured")
+
+    key = await asyncio.to_thread(
+        audio_object_key,
+        settings.s2s_samples_bucket,
+        sample_id,
+        provider,
+        model,
+        hidden=hidden,
+    )
+    if key is None:
+        raise HTTPException(404, "no such s2s sample recording")
+
+    url = await asyncio.to_thread(signed_url, settings.s2s_samples_bucket, key, ttl=AUDIO_URL_TTL)
+    redirect = RedirectResponse(url, status_code=302)
+    _never_shared(redirect)
+    ea_status = response.headers.get(EA_STATUS_HEADER)
+    if ea_status is not None:
+        redirect.headers[EA_STATUS_HEADER] = ea_status
+    return redirect

--- a/runner/src/coval_bench/api/schemas.py
+++ b/runner/src/coval_bench/api/schemas.py
@@ -196,6 +196,40 @@ class LeaderboardResponse(BaseModel):
     entries: list[LeaderboardEntry]
 
 
+class S2SSampleTurnOut(BaseModel):
+    """One spoken turn of a sampled conversation."""
+
+    index: int
+    role: str
+    content: str
+    start_offset: float | None = None
+    end_offset: float | None = None
+
+
+class S2SSampleRecordingOut(BaseModel):
+    """One model's recording. ``audio_path`` is an API route, not a storage URL."""
+
+    provider: str
+    model: str
+    audio_path: str
+    coval_run_id: str
+    sim_id: str
+    agent_id: str | None = None
+    turns: list[S2SSampleTurnOut] = Field(default_factory=list)
+
+
+class S2SSampleOut(BaseModel):
+    """One sample, filtered to the recordings this caller may see."""
+
+    schema_version: int | None = None
+    sample_id: str
+    test_case_id: str
+    test_set_id: str | None = None
+    persona_name: str | None = None
+    transcript: str | None = None
+    recordings: list[S2SSampleRecordingOut]
+
+
 class BattleOut(BaseModel):
     """A battle to vote on. Blind by design: no provider/model identities."""
 

--- a/runner/src/coval_bench/arena/audio_store.py
+++ b/runner/src/coval_bench/arena/audio_store.py
@@ -14,9 +14,10 @@ import shutil
 import uuid
 from datetime import timedelta
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from coval_bench.config import Settings
+from coval_bench.gcs import signed_url
 
 if TYPE_CHECKING:
     from google.cloud import storage
@@ -49,7 +50,12 @@ def clip_url(
 ) -> str:
     """Build a playable URL for a key at serve time: a fresh signed URL for GCS, else local."""
     if settings.arena_gcs_bucket:
-        return _signed_url(settings.arena_gcs_bucket, key, storage_client=storage_client)
+        return signed_url(
+            settings.arena_gcs_bucket,
+            key,
+            ttl=_SIGNED_URL_TTL,
+            storage_client=storage_client,
+        )
     base = settings.arena_audio_base_url.rstrip("/")
     return f"{base}/{key}" if base else f"/{key}"
 
@@ -67,37 +73,3 @@ def _upload_gcs(
     blob = client.bucket(bucket_name).blob(key)
     blob.upload_from_filename(str(src_path), content_type="audio/wav")
     src_path.unlink(missing_ok=True)
-
-
-def _signed_url(
-    bucket_name: str,
-    key: str,
-    *,
-    storage_client: storage.Client | None = None,
-) -> str:
-    """Fresh V4 signed GET URL via the SA's IAM SignBlob (no key file; needs tokenCreator)."""
-    import google.auth
-    import google.auth.transport.requests
-
-    if storage_client is None:
-        from google.cloud import storage
-
-        storage_client = storage.Client()
-    blob = storage_client.bucket(bucket_name).blob(key)
-
-    credentials, _ = google.auth.default()
-    signer: Any = credentials
-    if not hasattr(signer, "service_account_email"):
-        raise RuntimeError(
-            "Signing arena clip URLs requires service-account credentials with a "
-            "tokenCreator grant; got credentials without a service account."
-        )
-    signer.refresh(google.auth.transport.requests.Request())
-    url: str = blob.generate_signed_url(
-        version="v4",
-        expiration=_SIGNED_URL_TTL,
-        method="GET",
-        service_account_email=signer.service_account_email,
-        access_token=signer.token,
-    )
-    return url

--- a/runner/src/coval_bench/gcs.py
+++ b/runner/src/coval_bench/gcs.py
@@ -1,0 +1,72 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared access to private GCS buckets.
+
+Signing goes through the runtime service account's IAM SignBlob, so no key file
+is ever held: the service account needs tokenCreator on itself plus read access
+to the bucket. Callers pass their own TTL — arena clips and S2S samples want
+very different lifetimes.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import timedelta
+from typing import TYPE_CHECKING, Any
+
+from google.api_core.exceptions import NotFound
+
+if TYPE_CHECKING:
+    from google.cloud import storage
+
+
+def client() -> storage.Client:
+    from google.cloud import storage
+
+    return storage.Client()
+
+
+def read_json(
+    bucket_name: str,
+    key: str,
+    *,
+    storage_client: storage.Client | None = None,
+) -> object | None:
+    gcs = storage_client if storage_client is not None else client()
+    try:
+        decoded: object = json.loads(gcs.bucket(bucket_name).blob(key).download_as_bytes())
+    except NotFound:
+        return None
+    return decoded
+
+
+def signed_url(
+    bucket_name: str,
+    key: str,
+    *,
+    ttl: timedelta,
+    storage_client: storage.Client | None = None,
+) -> str:
+    import google.auth
+    import google.auth.transport.requests
+
+    gcs = storage_client if storage_client is not None else client()
+    blob = gcs.bucket(bucket_name).blob(key)
+
+    credentials, _ = google.auth.default()
+    signer: Any = credentials
+    if not hasattr(signer, "service_account_email"):
+        raise RuntimeError(
+            "Signing GCS URLs requires service-account credentials with a "
+            "tokenCreator grant; got credentials without a service account."
+        )
+    signer.refresh(google.auth.transport.requests.Request())
+    url: str = blob.generate_signed_url(
+        version="v4",
+        expiration=ttl,
+        method="GET",
+        service_account_email=signer.service_account_email,
+        access_token=signer.token,
+    )
+    return url

--- a/runner/src/coval_bench/s2s/samples.py
+++ b/runner/src/coval_bench/s2s/samples.py
@@ -19,13 +19,14 @@ from __future__ import annotations
 import json
 from collections.abc import Awaitable, Callable, Iterable
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Any, cast
 
 import httpx
 import structlog
 from google.api_core.exceptions import NotFound
 
+from coval_bench.gcs import read_json
 from coval_bench.runner.retry import with_retry
 
 if TYPE_CHECKING:
@@ -465,3 +466,59 @@ async def _publish_one_bucket(
         test_case_ids=sorted({tc for _, tc in pool}),
     )
     return 0
+
+
+AUDIO_URL_TTL = timedelta(minutes=30)
+
+
+def load_sample_ids(
+    bucket_name: str,
+    *,
+    storage_client: storage.Client | None = None,
+) -> list[str]:
+    raw = read_json(bucket_name, INDEX_KEY, storage_client=storage_client)
+    if not isinstance(raw, list):
+        return []
+    return sorted((s for s in raw if isinstance(s, str)), reverse=True)
+
+
+def load_sample(
+    bucket_name: str,
+    sample_id: str,
+    *,
+    hidden: frozenset[tuple[str, str]],
+    storage_client: storage.Client | None = None,
+) -> dict[str, Any] | None:
+    raw = read_json(
+        bucket_name,
+        f"{PREFIX}/{sample_id}/manifest.json",
+        storage_client=storage_client,
+    )
+    if not isinstance(raw, dict):
+        return None
+    recordings = [
+        rec
+        for rec in raw.get("recordings", [])
+        if isinstance(rec, dict)
+        and isinstance(rec.get("object"), str)
+        and (rec.get("provider"), rec.get("model")) not in hidden
+    ]
+    return {**raw, "recordings": recordings}
+
+
+def audio_object_key(
+    bucket_name: str,
+    sample_id: str,
+    provider: str,
+    model: str,
+    *,
+    hidden: frozenset[tuple[str, str]],
+    storage_client: storage.Client | None = None,
+) -> str | None:
+    sample = load_sample(bucket_name, sample_id, hidden=hidden, storage_client=storage_client)
+    if sample is None:
+        return None
+    for rec in sample["recordings"]:
+        if rec["provider"] == provider and rec["model"] == model:
+            return cast("str", rec["object"])
+    return None

--- a/runner/src/coval_bench/s2s/samples.py
+++ b/runner/src/coval_bench/s2s/samples.py
@@ -468,7 +468,7 @@ async def _publish_one_bucket(
     return 0
 
 
-AUDIO_URL_TTL = timedelta(minutes=30)
+AUDIO_URL_TTL = timedelta(minutes=10)
 
 
 def load_sample_ids(
@@ -480,6 +480,23 @@ def load_sample_ids(
     if not isinstance(raw, list):
         return []
     return sorted((s for s in raw if isinstance(s, str)), reverse=True)
+
+
+def _own_audio_object(key: object, sample_id: str) -> bool:
+    """True only for a recording key that lives inside this sample's own directory.
+
+    The manifest is ours, but a stale or malformed one must not be able to steer
+    signing at some other object in the bucket. The stored key is checked rather
+    than rebuilt from ``provider``/``model``: ticks published before the per-model
+    layout store ``{PREFIX}/{tick}/{provider}.wav``, and both layouts sit in the
+    bucket together until the older ticks age out.
+    """
+    return (
+        isinstance(key, str)
+        and key.startswith(f"{PREFIX}/{sample_id}/")
+        and key.endswith(".wav")
+        and ".." not in key
+    )
 
 
 def load_sample(
@@ -500,7 +517,7 @@ def load_sample(
         rec
         for rec in raw.get("recordings", [])
         if isinstance(rec, dict)
-        and isinstance(rec.get("object"), str)
+        and _own_audio_object(rec.get("object"), sample_id)
         and (rec.get("provider"), rec.get("model")) not in hidden
     ]
     return {**raw, "recordings": recordings}

--- a/runner/tests/api/test_s2s_samples_api.py
+++ b/runner/tests/api/test_s2s_samples_api.py
@@ -1,0 +1,255 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""The S2S samples endpoints: who sees which recording, and how audio is served.
+
+The bucket is private, so these routes are the only way in. A recording carries
+its own transcript, so an embargoed model must vanish from the manifest entirely
+rather than merely losing its audio link.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import AsyncClient
+
+from coval_bench.api.deps import get_settings
+from coval_bench.config import Settings
+from coval_bench.registries import MODEL_REGISTRY, Benchmark, ModelStatus, RegisteredModel
+from tests.api.conftest import INTERNAL_API_KEY
+
+_BUCKET = "test-s2s-samples"
+_SAMPLE = "2026-07-30T00:00:00Z"
+_OTHER_SAMPLE = "2026-07-29T00:00:00Z"
+_SIGNED = "https://storage.googleapis.com/signed-for-test"
+
+_PARTNER_TOKEN = "partner-token-value"  # noqa: S105 — fake token for the stubbed allowlist
+_TOKENS = f'{{"{_PARTNER_TOKEN}": ["acme/secret-s2s"]}}'
+
+_INTERNAL = {"X-Internal-Key": INTERNAL_API_KEY}
+_PARTNER = {"X-EA-Token": _PARTNER_TOKEN}
+
+_LIVE = ("openlab", "public-s2s")
+_EMBARGOED = ("acme", "secret-s2s")
+
+
+def _recording(provider: str, model: str) -> dict[str, Any]:
+    return {
+        "provider": provider,
+        "model": model,
+        "object": f"s2s-samples/{_SAMPLE}/{provider}/{model}.wav",
+        "coval_run_id": "run-1",
+        "sim_id": "sim-1",
+        "agent_id": "agent-1",
+        "turns": [{"index": 0, "role": "assistant", "content": f"{provider}-spoken-words"}],
+    }
+
+
+_OBJECTS: dict[str, Any] = {
+    "s2s-samples/index.json": [_OTHER_SAMPLE, _SAMPLE],
+    f"s2s-samples/{_SAMPLE}/manifest.json": {
+        "schema_version": 2,
+        "bucket_at": _SAMPLE,
+        "test_case_id": "tc-1",
+        "persona_name": "Standard Male",
+        "recordings": [_recording(*_LIVE), _recording(*_EMBARGOED)],
+    },
+}
+
+
+@pytest.fixture(autouse=True)
+def s2s_samples_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A two-model S2S roster — one live, one embargoed — over a stubbed bucket."""
+    patched = [
+        *MODEL_REGISTRY,
+        RegisteredModel(
+            benchmark=Benchmark.S2S,
+            provider=_LIVE[0],
+            model=_LIVE[1],
+            status=ModelStatus.ACTIVE,
+        ),
+        RegisteredModel(
+            benchmark=Benchmark.S2S,
+            provider=_EMBARGOED[0],
+            model=_EMBARGOED[1],
+            status=ModelStatus.EARLY_ACCESS,
+        ),
+    ]
+    monkeypatch.setattr("coval_bench.api.internal.MODEL_REGISTRY", patched)
+    monkeypatch.setattr("coval_bench.api.routers.s2s_samples.MODEL_REGISTRY", patched)
+
+    def _read_json(bucket_name: str, key: str, **_: Any) -> Any:
+        assert bucket_name == _BUCKET
+        return _OBJECTS.get(key)
+
+    monkeypatch.setattr("coval_bench.s2s.samples.read_json", _read_json)
+    monkeypatch.setattr(
+        "coval_bench.api.routers.s2s_samples.signed_url",
+        lambda bucket_name, key, **_: f"{_SIGNED}/{key}",
+    )
+
+
+@pytest_asyncio.fixture
+async def samples_client(app: FastAPI, client: AsyncClient) -> AsyncClient:
+    """The API client with the samples bucket configured."""
+    app.dependency_overrides[get_settings] = lambda: Settings(
+        s2s_samples_bucket=_BUCKET,
+        early_access_tokens=_TOKENS,
+    )
+    return client
+
+
+def _pairs(payload: dict[str, Any]) -> list[tuple[str, str]]:
+    return [(r["provider"], r["model"]) for r in payload["recordings"]]
+
+
+# --- the index --------------------------------------------------------------
+
+
+async def test_index_lists_samples_newest_first(samples_client: AsyncClient) -> None:
+    res = await samples_client.get("/v1/s2s/samples")
+
+    assert res.status_code == 200
+    assert res.json() == [_SAMPLE, _OTHER_SAMPLE]
+
+
+async def test_index_is_never_shared_between_callers(samples_client: AsyncClient) -> None:
+    res = await samples_client.get("/v1/s2s/samples")
+
+    assert res.headers["cache-control"] == "private, no-store"
+    assert "X-EA-Token" in res.headers["vary"]
+
+
+async def test_index_empty_when_no_bucket_is_configured(app: FastAPI, client: AsyncClient) -> None:
+    app.dependency_overrides[get_settings] = lambda: Settings(s2s_samples_bucket="")
+
+    res = await client.get("/v1/s2s/samples")
+
+    assert res.status_code == 200
+    assert res.json() == []
+
+
+# --- the manifest -----------------------------------------------------------
+
+
+async def test_public_caller_never_sees_the_embargoed_recording(
+    samples_client: AsyncClient,
+) -> None:
+    res = await samples_client.get(f"/v1/s2s/samples/{_SAMPLE}")
+
+    assert res.status_code == 200
+    assert _pairs(res.json()) == [_LIVE]
+
+
+async def test_embargoed_transcript_leaves_with_its_recording(
+    samples_client: AsyncClient,
+) -> None:
+    res = await samples_client.get(f"/v1/s2s/samples/{_SAMPLE}")
+
+    assert f"{_EMBARGOED[0]}-spoken-words" not in res.text
+    assert f"{_LIVE[0]}-spoken-words" in res.text
+
+
+async def test_internal_caller_sees_every_recording(samples_client: AsyncClient) -> None:
+    res = await samples_client.get(f"/v1/s2s/samples/{_SAMPLE}", headers=_INTERNAL)
+
+    assert _pairs(res.json()) == [_LIVE, _EMBARGOED]
+
+
+async def test_partner_token_unlocks_only_its_own_model(samples_client: AsyncClient) -> None:
+    res = await samples_client.get(f"/v1/s2s/samples/{_SAMPLE}", headers=_PARTNER)
+
+    assert _pairs(res.json()) == [_LIVE, _EMBARGOED]
+    assert res.headers["X-EA-Token-Status"] == "accepted"
+
+
+async def test_unknown_token_falls_back_to_the_public_view(samples_client: AsyncClient) -> None:
+    res = await samples_client.get(
+        f"/v1/s2s/samples/{_SAMPLE}", headers={"X-EA-Token": "not-a-real-token"}
+    )
+
+    assert _pairs(res.json()) == [_LIVE]
+    assert res.headers["X-EA-Token-Status"] == "unknown"
+
+
+async def test_manifest_hands_back_api_paths_not_storage_paths(
+    samples_client: AsyncClient,
+) -> None:
+    res = await samples_client.get(f"/v1/s2s/samples/{_SAMPLE}", headers=_INTERNAL)
+    body = res.json()
+
+    assert body["sample_id"] == _SAMPLE
+    for recording in body["recordings"]:
+        assert recording["audio_path"].startswith("/v1/s2s/samples/")
+        assert "object" not in recording
+    assert "storage.googleapis.com" not in res.text
+
+
+async def test_missing_sample_is_a_404(samples_client: AsyncClient) -> None:
+    res = await samples_client.get("/v1/s2s/samples/2020-01-01T00:00:00Z")
+
+    assert res.status_code == 404
+
+
+async def test_malformed_sample_id_is_rejected_before_any_read(
+    samples_client: AsyncClient,
+) -> None:
+    res = await samples_client.get("/v1/s2s/samples/banana")
+
+    assert res.status_code == 422
+
+
+# --- the audio redirect -----------------------------------------------------
+
+
+async def test_audio_redirects_to_a_signed_url(samples_client: AsyncClient) -> None:
+    res = await samples_client.get(
+        f"/v1/s2s/samples/{_SAMPLE}/{_LIVE[0]}/{_LIVE[1]}/audio", follow_redirects=False
+    )
+
+    assert res.status_code == 302
+    assert res.headers["location"].startswith(_SIGNED)
+
+
+async def test_audio_redirect_is_never_cached(samples_client: AsyncClient) -> None:
+    res = await samples_client.get(
+        f"/v1/s2s/samples/{_SAMPLE}/{_LIVE[0]}/{_LIVE[1]}/audio", follow_redirects=False
+    )
+
+    assert res.headers["cache-control"] == "private, no-store"
+    assert "X-EA-Token" in res.headers["vary"]
+    assert res.headers["X-EA-Token-Status"] == "absent"
+
+
+async def test_audio_for_an_embargoed_model_is_refused(samples_client: AsyncClient) -> None:
+    res = await samples_client.get(
+        f"/v1/s2s/samples/{_SAMPLE}/{_EMBARGOED[0]}/{_EMBARGOED[1]}/audio",
+        follow_redirects=False,
+    )
+
+    assert res.status_code == 404
+
+
+async def test_audio_for_an_embargoed_model_is_served_to_internal(
+    samples_client: AsyncClient,
+) -> None:
+    res = await samples_client.get(
+        f"/v1/s2s/samples/{_SAMPLE}/{_EMBARGOED[0]}/{_EMBARGOED[1]}/audio",
+        headers=_INTERNAL,
+        follow_redirects=False,
+    )
+
+    assert res.status_code == 302
+    assert res.headers["X-EA-Token-Status"] == "internal"
+
+
+async def test_audio_for_an_unknown_recording_is_a_404(samples_client: AsyncClient) -> None:
+    res = await samples_client.get(
+        f"/v1/s2s/samples/{_SAMPLE}/{_LIVE[0]}/no-such-model/audio", follow_redirects=False
+    )
+
+    assert res.status_code == 404

--- a/runner/tests/api/test_s2s_samples_api.py
+++ b/runner/tests/api/test_s2s_samples_api.py
@@ -37,11 +37,11 @@ _LIVE = ("openlab", "public-s2s")
 _EMBARGOED = ("acme", "secret-s2s")
 
 
-def _recording(provider: str, model: str) -> dict[str, Any]:
+def _recording(provider: str, model: str, sample_id: str = _SAMPLE) -> dict[str, Any]:
     return {
         "provider": provider,
         "model": model,
-        "object": f"s2s-samples/{_SAMPLE}/{provider}/{model}.wav",
+        "object": f"s2s-samples/{sample_id}/{provider}/{model}.wav",
         "coval_run_id": "run-1",
         "sim_id": "sim-1",
         "agent_id": "agent-1",
@@ -57,6 +57,14 @@ _OBJECTS: dict[str, Any] = {
         "test_case_id": "tc-1",
         "persona_name": "Standard Male",
         "recordings": [_recording(*_LIVE), _recording(*_EMBARGOED)],
+    },
+    # A tick whose only recording is embargoed: nothing about it may reach the public.
+    f"s2s-samples/{_OTHER_SAMPLE}/manifest.json": {
+        "schema_version": 2,
+        "bucket_at": _OTHER_SAMPLE,
+        "test_case_id": "tc-secret",
+        "persona_name": "Standard Female",
+        "recordings": [_recording(*_EMBARGOED, sample_id=_OTHER_SAMPLE)],
     },
 }
 
@@ -203,6 +211,25 @@ async def test_malformed_sample_id_is_rejected_before_any_read(
     assert res.status_code == 422
 
 
+async def test_a_wholly_embargoed_sample_is_a_404_not_an_empty_shell(
+    samples_client: AsyncClient,
+) -> None:
+    res = await samples_client.get(f"/v1/s2s/samples/{_OTHER_SAMPLE}")
+
+    assert res.status_code == 404
+    assert "tc-secret" not in res.text
+    assert "Standard Female" not in res.text
+
+
+async def test_the_same_sample_is_served_to_a_caller_who_may_hear_it(
+    samples_client: AsyncClient,
+) -> None:
+    res = await samples_client.get(f"/v1/s2s/samples/{_OTHER_SAMPLE}", headers=_PARTNER)
+
+    assert res.status_code == 200
+    assert _pairs(res.json()) == [_EMBARGOED]
+
+
 # --- the audio redirect -----------------------------------------------------
 
 
@@ -253,3 +280,34 @@ async def test_audio_for_an_unknown_recording_is_a_404(samples_client: AsyncClie
     )
 
     assert res.status_code == 404
+
+
+# --- errors are caller-scoped too -------------------------------------------
+
+
+async def test_a_refusal_is_never_cached(samples_client: AsyncClient) -> None:
+    """The public 404 and the partner's 302 share a URL, so no cache may reuse it."""
+    res = await samples_client.get(
+        f"/v1/s2s/samples/{_SAMPLE}/{_EMBARGOED[0]}/{_EMBARGOED[1]}/audio",
+        follow_redirects=False,
+    )
+
+    assert res.status_code == 404
+    assert res.headers["cache-control"] == "private, no-store"
+    assert "X-EA-Token" in res.headers["vary"]
+
+
+async def test_an_embargoed_manifest_404_is_never_cached(samples_client: AsyncClient) -> None:
+    res = await samples_client.get(f"/v1/s2s/samples/{_OTHER_SAMPLE}")
+
+    assert res.status_code == 404
+    assert res.headers["cache-control"] == "private, no-store"
+    assert "X-EA-Token" in res.headers["vary"]
+
+
+async def test_a_rejected_sample_id_is_never_cached(samples_client: AsyncClient) -> None:
+    res = await samples_client.get("/v1/s2s/samples/banana")
+
+    assert res.status_code == 422
+    assert res.headers["cache-control"] == "private, no-store"
+    assert "X-EA-Token" in res.headers["vary"]

--- a/runner/tests/unit/test_s2s_sample_store.py
+++ b/runner/tests/unit/test_s2s_sample_store.py
@@ -138,6 +138,39 @@ def test_load_sample_drops_recordings_without_an_object() -> None:
     assert sample["recordings"] == []
 
 
+def test_load_sample_drops_an_object_from_another_sample() -> None:
+    strayed = _manifest(_recording("openai", "gpt-realtime"))
+    strayed["recordings"][0]["object"] = "s2s-samples/2026-01-01T00:00:00Z/openai.wav"
+    client = _FakeClient({_MANIFEST_KEY: strayed})
+
+    sample = load_sample(_BUCKET, _SAMPLE, hidden=frozenset(), storage_client=client)
+
+    assert sample is not None
+    assert sample["recordings"] == []
+
+
+def test_load_sample_drops_an_object_that_is_not_audio() -> None:
+    strayed = _manifest(_recording("openai", "gpt-realtime"))
+    strayed["recordings"][0]["object"] = _MANIFEST_KEY
+    client = _FakeClient({_MANIFEST_KEY: strayed})
+
+    sample = load_sample(_BUCKET, _SAMPLE, hidden=frozenset(), storage_client=client)
+
+    assert sample is not None
+    assert sample["recordings"] == []
+
+
+def test_load_sample_drops_a_traversing_object() -> None:
+    strayed = _manifest(_recording("openai", "gpt-realtime"))
+    strayed["recordings"][0]["object"] = f"s2s-samples/{_SAMPLE}/../../secrets/leak.wav"
+    client = _FakeClient({_MANIFEST_KEY: strayed})
+
+    sample = load_sample(_BUCKET, _SAMPLE, hidden=frozenset(), storage_client=client)
+
+    assert sample is not None
+    assert sample["recordings"] == []
+
+
 def test_load_sample_missing_manifest_is_none() -> None:
     assert load_sample(_BUCKET, _SAMPLE, hidden=frozenset(), storage_client=_FakeClient({})) is None
 
@@ -160,6 +193,23 @@ def test_audio_object_key_refuses_a_hidden_model() -> None:
 
     key = audio_object_key(
         _BUCKET, _SAMPLE, "xai", "grok-realtime", hidden=_HIDDEN, storage_client=client
+    )
+
+    assert key is None
+
+
+def test_audio_object_key_refuses_an_object_outside_the_sample() -> None:
+    strayed = _manifest(_recording("openai", "gpt-realtime"))
+    strayed["recordings"][0]["object"] = "s2s-samples/2026-01-01T00:00:00Z/openai.wav"
+    client = _FakeClient({_MANIFEST_KEY: strayed})
+
+    key = audio_object_key(
+        _BUCKET,
+        _SAMPLE,
+        "openai",
+        "gpt-realtime",
+        hidden=frozenset(),
+        storage_client=client,
     )
 
     assert key is None

--- a/runner/tests/unit/test_s2s_sample_store.py
+++ b/runner/tests/unit/test_s2s_sample_store.py
@@ -1,0 +1,227 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Serve-time reads of the S2S samples bucket: index, filtering, object lookup."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+from google.api_core.exceptions import NotFound
+
+from coval_bench.s2s.samples import audio_object_key, load_sample, load_sample_ids
+
+_BUCKET = "coval-benchmarks-s2s-samples"
+_SAMPLE = "2026-07-30T00:00:00Z"
+_MANIFEST_KEY = f"s2s-samples/{_SAMPLE}/manifest.json"
+_HIDDEN = frozenset({("xai", "grok-realtime")})
+
+
+def _recording(provider: str, model: str) -> dict[str, Any]:
+    return {
+        "provider": provider,
+        "model": model,
+        "object": f"s2s-samples/{_SAMPLE}/{provider}/{model}.wav",
+        "coval_run_id": "run-1",
+        "sim_id": "sim-1",
+        "agent_id": "agent-1",
+        "turns": [{"index": 0, "role": "user", "content": "hi"}],
+    }
+
+
+def _manifest(*recordings: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "schema_version": 2,
+        "bucket_at": _SAMPLE,
+        "test_case_id": "tc-1",
+        "recordings": list(recordings),
+    }
+
+
+# --- load_sample_ids --------------------------------------------------------
+
+
+def test_load_sample_ids_newest_first() -> None:
+    client = _FakeClient({"s2s-samples/index.json": ["2026-07-28T00:00:00Z", _SAMPLE]})
+    assert load_sample_ids(_BUCKET, storage_client=client) == [_SAMPLE, "2026-07-28T00:00:00Z"]
+
+
+def test_load_sample_ids_missing_index_is_empty() -> None:
+    assert load_sample_ids(_BUCKET, storage_client=_FakeClient({})) == []
+
+
+def test_load_sample_ids_drops_non_strings() -> None:
+    client = _FakeClient({"s2s-samples/index.json": [_SAMPLE, 7, None]})
+    assert load_sample_ids(_BUCKET, storage_client=client) == [_SAMPLE]
+
+
+# --- load_sample: the embargo filter ----------------------------------------
+
+
+def test_load_sample_strips_hidden_recordings() -> None:
+    client = _FakeClient(
+        {
+            _MANIFEST_KEY: _manifest(
+                _recording("openai", "gpt-realtime"), _recording("xai", "grok-realtime")
+            )
+        }
+    )
+
+    sample = load_sample(_BUCKET, _SAMPLE, hidden=_HIDDEN, storage_client=client)
+
+    assert sample is not None
+    assert [(r["provider"], r["model"]) for r in sample["recordings"]] == [
+        ("openai", "gpt-realtime")
+    ]
+
+
+def test_load_sample_hidden_recording_takes_its_transcript_with_it() -> None:
+    client = _FakeClient({_MANIFEST_KEY: _manifest(_recording("xai", "grok-realtime"))})
+
+    sample = load_sample(_BUCKET, _SAMPLE, hidden=_HIDDEN, storage_client=client)
+
+    assert sample is not None
+    assert sample["recordings"] == []
+    assert "hi" not in json.dumps(sample)
+
+
+def test_load_sample_keeps_everything_for_an_unrestricted_caller() -> None:
+    client = _FakeClient(
+        {
+            _MANIFEST_KEY: _manifest(
+                _recording("openai", "gpt-realtime"), _recording("xai", "grok-realtime")
+            )
+        }
+    )
+
+    sample = load_sample(_BUCKET, _SAMPLE, hidden=frozenset(), storage_client=client)
+
+    assert sample is not None
+    assert len(sample["recordings"]) == 2
+
+
+def test_load_sample_tolerates_v1_manifests() -> None:
+    v1 = {
+        "bucket_at": _SAMPLE,
+        "test_case_id": "tc-1",
+        "transcript": None,
+        "input_audio_url": None,
+        "recordings": [
+            {
+                "provider": "openai",
+                "model": "gpt-realtime",
+                "object": f"s2s-samples/{_SAMPLE}/openai.wav",
+                "coval_run_id": "run-1",
+                "sim_id": "sim-1",
+            }
+        ],
+    }
+    client = _FakeClient({_MANIFEST_KEY: v1})
+
+    sample = load_sample(_BUCKET, _SAMPLE, hidden=_HIDDEN, storage_client=client)
+
+    assert sample is not None
+    assert len(sample["recordings"]) == 1
+    assert "turns" not in sample["recordings"][0]
+
+
+def test_load_sample_drops_recordings_without_an_object() -> None:
+    broken = _manifest(_recording("openai", "gpt-realtime"))
+    del broken["recordings"][0]["object"]
+    client = _FakeClient({_MANIFEST_KEY: broken})
+
+    sample = load_sample(_BUCKET, _SAMPLE, hidden=frozenset(), storage_client=client)
+
+    assert sample is not None
+    assert sample["recordings"] == []
+
+
+def test_load_sample_missing_manifest_is_none() -> None:
+    assert load_sample(_BUCKET, _SAMPLE, hidden=frozenset(), storage_client=_FakeClient({})) is None
+
+
+# --- audio_object_key: the check the redirect route relies on ---------------
+
+
+def test_audio_object_key_returns_the_stored_path() -> None:
+    client = _FakeClient({_MANIFEST_KEY: _manifest(_recording("openai", "gpt-realtime"))})
+
+    key = audio_object_key(
+        _BUCKET, _SAMPLE, "openai", "gpt-realtime", hidden=frozenset(), storage_client=client
+    )
+
+    assert key == f"s2s-samples/{_SAMPLE}/openai/gpt-realtime.wav"
+
+
+def test_audio_object_key_refuses_a_hidden_model() -> None:
+    client = _FakeClient({_MANIFEST_KEY: _manifest(_recording("xai", "grok-realtime"))})
+
+    key = audio_object_key(
+        _BUCKET, _SAMPLE, "xai", "grok-realtime", hidden=_HIDDEN, storage_client=client
+    )
+
+    assert key is None
+
+
+def test_audio_object_key_unknown_model_is_none() -> None:
+    client = _FakeClient({_MANIFEST_KEY: _manifest(_recording("openai", "gpt-realtime"))})
+
+    key = audio_object_key(
+        _BUCKET, _SAMPLE, "openai", "no-such-model", hidden=frozenset(), storage_client=client
+    )
+
+    assert key is None
+
+
+def test_audio_object_key_missing_manifest_is_none() -> None:
+    key = audio_object_key(
+        _BUCKET,
+        _SAMPLE,
+        "openai",
+        "gpt-realtime",
+        hidden=frozenset(),
+        storage_client=_FakeClient({}),
+    )
+
+    assert key is None
+
+
+# --- fakes ------------------------------------------------------------------
+
+
+class _FakeBlob:
+    def __init__(self, payload: object | None) -> None:
+        self._payload = payload
+
+    def download_as_bytes(self) -> bytes:
+        if self._payload is None:
+            raise NotFound("no such object")  # type: ignore[no-untyped-call]
+        return json.dumps(self._payload).encode()
+
+
+class _FakeBucket:
+    def __init__(self, objects: dict[str, object]) -> None:
+        self._objects = objects
+
+    def blob(self, key: str) -> _FakeBlob:
+        return _FakeBlob(self._objects.get(key))
+
+
+class _FakeClient:
+    def __init__(self, objects: dict[str, object]) -> None:
+        self._objects = objects
+        self.bucket_name: str | None = None
+
+    def bucket(self, name: str) -> _FakeBucket:
+        self.bucket_name = name
+        return _FakeBucket(self._objects)
+
+
+@pytest.fixture(autouse=True)
+def _no_real_gcs(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _explode() -> None:
+        raise AssertionError("test reached for a real GCS client")
+
+    monkeypatch.setattr("coval_bench.gcs.client", _explode)


### PR DESCRIPTION
The S2S samples bucket is world-readable, and `allUsers: objectViewer` includes `objects.list`, so anyone can enumerate every sample and read the manifests — full conversation transcripts — plus the recordings. Two of the four S2S models are still embargoed, so their audio sits in the open while the API hides their numbers.

These routes make the bucket privatisable. The API reads each manifest as the runtime service account and drops the recordings a caller may not see, transcripts included, since both live in the same object. What survives carries an API path instead of a storage URL, and playing it re-checks the embargo before redirecting to a signed URL minted at that moment — nothing is pre-signed, so no signature is stored or needs refreshing. All three routes share the `hidden_early_access` dependency the data endpoints already use.

Nothing changes for users yet: the dashboard still reads GCS directly, so these routes are unused until the web swap, and the bucket flip comes after that.
