### PR TITLE
[BENCH-582] Track S2S sample engagement in PostHog

### DIFF
--- a/web/app/s2s/components/ConversationTurns.tsx
+++ b/web/app/s2s/components/ConversationTurns.tsx
@@ -32,7 +32,7 @@ export function ConversationTurns({
   turns: S2STurn[];
   accentColor: string;
   currentTime?: number;
-  onSeek?: (seconds: number) => void;
+  onSeek?: (seconds: number, turn: { index: number; role: "caller" | "agent" }) => void;
 }) {
   const active = onSeek ? activeTurnIndex(turns, currentTime) : -1;
   // Only fade the others once something is genuinely highlighted. Without
@@ -68,7 +68,12 @@ export function ConversationTurns({
           <button
             key={t.index}
             type="button"
-            onClick={() => onSeek(t.start_offset as number)}
+            onClick={() =>
+              onSeek(t.start_offset as number, {
+                index: t.index,
+                role: agent ? "agent" : "caller",
+              })
+            }
             aria-current={isActive ? "true" : undefined}
             className={`${className} block w-full cursor-pointer text-left hover:opacity-100`}
             style={style}

--- a/web/app/s2s/components/SampleOutputs.tsx
+++ b/web/app/s2s/components/SampleOutputs.tsx
@@ -4,7 +4,7 @@
 "use client";
 
 import { ChevronLeft, ChevronRight, Pause, Play } from "lucide-react";
-import { type RefObject, useEffect, useMemo, useRef, useState } from "react";
+import { type RefObject, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   useSequencedPlayback,
   type PlaybackCoordinator,
@@ -12,6 +12,7 @@ import {
 } from "@/hooks/useSequencedPlayback";
 import { getModelColor } from "@/lib/utils/colors";
 import { toModelKey } from "@/lib/utils/formatters";
+import type { S2SPlayTrigger, S2SSeekMethod } from "@/lib/posthog/events";
 import type { S2STurn } from "@/lib/audioSamples/s2sFeed";
 import { ConversationTurns } from "./ConversationTurns";
 
@@ -21,6 +22,21 @@ export interface SampleOutputItem {
   url: string;
   // Multi-turn (v2) only: this provider's own conversation transcript.
   turns?: S2STurn[];
+}
+
+export interface SampleSeekInfo {
+  method: S2SSeekMethod;
+  toSeconds: number;
+  // "turn" method only: which transcript turn was clicked.
+  turnIndex?: number;
+  turnRole?: "caller" | "agent";
+}
+
+export interface SampleListenInfo {
+  trigger: S2SPlayTrigger;
+  listenPct: number;
+  durationSeconds: number;
+  completed: boolean;
 }
 
 // Elapsed position as m:ss. The existing formatTime helpers render wall-clock
@@ -66,12 +82,16 @@ export function SampleOutputs({
   items,
   normalizeProvider,
   onPlay,
+  onSeeked,
+  onPlaybackEnded,
   playRequest,
   coordinator,
 }: {
   items: SampleOutputItem[];
   normalizeProvider: (provider: string) => string;
-  onPlay?: (provider: string) => void;
+  onPlay?: (provider: string, trigger: S2SPlayTrigger) => void;
+  onSeeked?: (provider: string, seek: SampleSeekInfo) => void;
+  onPlaybackEnded?: (provider: string, listen: SampleListenInfo) => void;
   playRequest?: { provider: string; nonce: number } | null;
   coordinator?: PlaybackCoordinator;
 }) {
@@ -84,8 +104,108 @@ export function SampleOutputs({
   const conversation = items.some((i) => (i.turns?.length ?? 0) > 0);
   const viewportRef = useRef<HTMLDivElement>(null);
 
+  // How the next playFrom was initiated: the Play buttons and the timeline
+  // effect each set this just before calling it. Panes never auto-advance
+  // (the <audio> stops on end), so no third path exists.
+  const triggerRef = useRef<S2SPlayTrigger>("button");
+
+  // One listen session per activation, flushed from cleanup paths that would
+  // otherwise capture a stale callback prop.
+  const callbacksRef = useRef({ onPlaybackEnded });
+  useEffect(() => {
+    callbacksRef.current = { onPlaybackEnded };
+  });
+  const listenRef = useRef<{
+    provider: string;
+    trigger: S2SPlayTrigger;
+    maxTime: number;
+    duration: number;
+    completed: boolean;
+  } | null>(null);
+
+  const flushListen = useCallback(() => {
+    const session = listenRef.current;
+    listenRef.current = null;
+    // duration 0 means metadata never loaded (or play() was rejected):
+    // nothing was heard, so there is no listen to report.
+    if (!session || session.duration <= 0) return;
+    callbacksRef.current.onPlaybackEnded?.(session.provider, {
+      trigger: session.trigger,
+      listenPct: session.completed
+        ? 100
+        : Math.min(100, Math.round((session.maxTime / session.duration) * 100)),
+      durationSeconds: Math.round(session.duration),
+      completed: session.completed,
+    });
+  }, []);
+
   const { audioRef, activeIndex, isPlaying, toggle, playFrom, stop, currentTime, duration, seek } =
-    useSequencedPlayback(tracks, (track) => onPlay?.(track.key), coordinator);
+    useSequencedPlayback(
+      tracks,
+      (track) => {
+        flushListen();
+        listenRef.current = {
+          provider: track.key,
+          trigger: triggerRef.current,
+          maxTime: 0,
+          duration: 0,
+          completed: false,
+        };
+        onPlay?.(track.key, triggerRef.current);
+      },
+      coordinator
+    );
+
+  // Mirror playhead progress into the session; maxTime survives backward seeks.
+  useEffect(() => {
+    const session = listenRef.current;
+    if (!session) return;
+    if (duration > 0) session.duration = duration;
+    if (currentTime > session.maxTime) session.maxTime = currentTime;
+  }, [currentTime, duration]);
+
+  // Pause, stop (including a track-list swap under playback), and play()
+  // rejection all land here; a pane-to-pane switch flushes in onActivate above.
+  useEffect(() => {
+    if (!isPlaying) flushListen();
+  }, [isPlaying, flushListen]);
+
+  useEffect(() => () => flushListen(), [flushListen]);
+
+  // The slider's onChange fires for every step of a drag; report one seek per
+  // burst, at its final position. Each input captures its own emit closure so
+  // a burst that outlives a tick swap still reports the manifest it scrubbed.
+  const seekBurstRef = useRef<{
+    provider: string;
+    emit: () => void;
+    timer: ReturnType<typeof setTimeout>;
+  } | null>(null);
+  const flushSeekBurst = useCallback(() => {
+    const burst = seekBurstRef.current;
+    if (!burst) return;
+    seekBurstRef.current = null;
+    clearTimeout(burst.timer);
+    burst.emit();
+  }, []);
+  const reportSliderSeek = useCallback(
+    (provider: string, emit: () => void) => {
+      const burst = seekBurstRef.current;
+      // Another pane's pending seek is a separate gesture: emit it now rather
+      // than coalescing across providers.
+      if (burst && burst.provider !== provider) flushSeekBurst();
+      else if (burst) clearTimeout(burst.timer);
+      seekBurstRef.current = {
+        provider,
+        emit,
+        timer: setTimeout(() => {
+          seekBurstRef.current = null;
+          emit();
+        }, 1000),
+      };
+    },
+    [flushSeekBurst]
+  );
+  useEffect(() => () => flushSeekBurst(), [flushSeekBurst]);
 
   // A timeline-tooltip click plays a specific provider. Wait until that tick's
   // items have loaded (provider present) before playing, then mark the request
@@ -96,6 +216,7 @@ export function SampleOutputs({
     const idx = items.findIndex((i) => i.provider === playRequest.provider);
     if (idx < 0) return;
     consumedNonce.current = playRequest.nonce;
+    triggerRef.current = "timeline";
     playFrom(idx);
     viewportRef.current?.children.item(idx)?.scrollIntoView({
       behavior: "smooth",
@@ -176,7 +297,11 @@ export function SampleOutputs({
                 </span>
                 <button
                   type="button"
-                  onClick={() => (playingThis ? toggle() : playFrom(i))}
+                  onClick={() => {
+                    triggerRef.current = "button";
+                    if (playingThis) toggle();
+                    else playFrom(i);
+                  }}
                   className={`flex items-center gap-1 self-start rounded-full border border-border-primary px-2 py-0.5 text-[11px] text-text-secondary transition-colors hover:text-text-primary ${
                     turns.length ? "" : "mt-auto"
                   }`}
@@ -195,7 +320,16 @@ export function SampleOutputs({
                       max={duration}
                       step={0.1}
                       value={Math.min(currentTime, duration)}
-                      onChange={(e) => seek(Number(e.target.value))}
+                      onChange={(e) => {
+                        const target = Number(e.target.value);
+                        seek(target);
+                        reportSliderSeek(item.provider, () =>
+                          onSeeked?.(item.provider, {
+                            method: "slider",
+                            toSeconds: target,
+                          })
+                        );
+                      }}
                       aria-label={`Seek ${normalizeProvider(item.provider)} recording`}
                       className="h-1 w-full cursor-pointer"
                       style={{ accentColor: color }}
@@ -210,7 +344,19 @@ export function SampleOutputs({
                     turns={turns}
                     accentColor={color}
                     currentTime={active ? currentTime : 0}
-                    onSeek={active ? seek : undefined}
+                    onSeek={
+                      active
+                        ? (seconds, turn) => {
+                            seek(seconds);
+                            onSeeked?.(item.provider, {
+                              method: "turn",
+                              toSeconds: seconds,
+                              turnIndex: turn.index,
+                              turnRole: turn.role,
+                            });
+                          }
+                        : undefined
+                    }
                   />
                 ) : null}
               </div>
@@ -219,7 +365,20 @@ export function SampleOutputs({
         </div>
       </div>
 
-      <audio ref={audioRef} onEnded={stop} hidden />
+      <audio
+        ref={audioRef}
+        onEnded={() => {
+          // Mark completion before stop() flushes: the last timeupdate can
+          // land short of the full duration.
+          const session = listenRef.current;
+          if (session) {
+            session.completed = true;
+            if (session.duration > 0) session.maxTime = session.duration;
+          }
+          stop();
+        }}
+        hidden
+      />
     </div>
   );
 }

--- a/web/app/s2s/components/SamplesCard.tsx
+++ b/web/app/s2s/components/SamplesCard.tsx
@@ -3,16 +3,25 @@
 
 "use client";
 
-import { useCallback, useEffect, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 import { ChevronLeft, ChevronRight } from "lucide-react";
 import Card from "@/components/shared/Card";
 import { useDashboard } from "@/contexts/DashboardContext";
 import { SampleFetchError } from "@/lib/audioSamples/createSampleFeed";
 import { s2sSampleFeed, visibleRecordings } from "@/lib/audioSamples/s2sFeed";
 import { capturePostHogEvent } from "@/lib/posthog/client";
-import { POSTHOG_EVENTS } from "@/lib/posthog/events";
+import {
+  POSTHOG_EVENTS,
+  type S2SPlayTrigger,
+  type S2STickDirection,
+} from "@/lib/posthog/events";
 import { usePlaybackCoordinator } from "@/hooks/useSequencedPlayback";
-import { SampleOutputs, type SampleOutputItem } from "./SampleOutputs";
+import {
+  SampleOutputs,
+  type SampleListenInfo,
+  type SampleOutputItem,
+  type SampleSeekInfo,
+} from "./SampleOutputs";
 
 // Which failure case fired, for the console — network/http/parse vs an
 // unclassified error, with the status when we have one.
@@ -113,16 +122,77 @@ export function SamplesCard() {
     !manifestQuery.isPlaceholderData &&
     requestedItem === undefined;
 
+  // Bucket/model of the last activation: the listen-ended flush can arrive
+  // after a tick swap has already replaced the manifest, and must attribute to
+  // what actually played.
+  const playContextRef = useRef<{ bucket?: string; model?: string }>({});
+
   const handlePlay = useCallback(
-    (provider: string) => {
+    (provider: string, trigger: S2SPlayTrigger) => {
+      const position = items.findIndex((item) => item.provider === provider);
+      const item = position >= 0 ? items[position] : undefined;
+      playContextRef.current = { bucket: manifest?.bucket_at, model: item?.model };
       capturePostHogEvent(POSTHOG_EVENTS.s2sSamplePlayRequested, {
         surface: "s2s_dashboard",
         mode: "s2s",
         provider,
+        model_id: item?.model,
+        position: position >= 0 ? position : undefined,
+        has_transcript: (item?.turns?.length ?? 0) > 0,
+        trigger,
         bucket_at: manifest?.bucket_at,
       });
     },
-    [manifest?.bucket_at]
+    [items, manifest?.bucket_at]
+  );
+
+  const handlePlaybackEnded = useCallback(
+    (provider: string, listen: SampleListenInfo) => {
+      capturePostHogEvent(POSTHOG_EVENTS.s2sSamplePlaybackEnded, {
+        surface: "s2s_dashboard",
+        mode: "s2s",
+        provider,
+        model_id: playContextRef.current.model,
+        bucket_at: playContextRef.current.bucket,
+        trigger: listen.trigger,
+        listen_pct: listen.listenPct,
+        duration_seconds: listen.durationSeconds,
+        completed: listen.completed,
+      });
+    },
+    []
+  );
+
+  const handleSeeked = useCallback(
+    (provider: string, seek: SampleSeekInfo) => {
+      const item = items.find((i) => i.provider === provider);
+      capturePostHogEvent(POSTHOG_EVENTS.s2sSampleSeeked, {
+        surface: "s2s_dashboard",
+        mode: "s2s",
+        provider,
+        model_id: item?.model,
+        bucket_at: manifest?.bucket_at,
+        method: seek.method,
+        to_seconds: Math.round(seek.toSeconds),
+        turn_index: seek.turnIndex,
+        turn_role: seek.turnRole,
+      });
+    },
+    [items, manifest?.bucket_at]
+  );
+
+  const handleTickSelect = useCallback(
+    (direction: S2STickDirection, toTick: string) => {
+      capturePostHogEvent(POSTHOG_EVENTS.s2sSampleTickChanged, {
+        surface: "s2s_dashboard",
+        mode: "s2s",
+        direction,
+        from_bucket: displayedTick,
+        to_bucket: toTick,
+      });
+      selectS2SSample(toTick);
+    },
+    [displayedTick, selectS2SSample]
   );
 
   const loading =
@@ -149,7 +219,7 @@ export function SamplesCard() {
               type="button"
               aria-label="Show older conversation sample"
               disabled={!olderTick}
-              onClick={() => olderTick && selectS2SSample(olderTick)}
+              onClick={() => olderTick && handleTickSelect("older", olderTick)}
               className="flex size-11 items-center justify-center rounded-md border border-border-secondary text-text-secondary transition-colors hover:bg-surface-tertiary hover:text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-text-tertiary/40 disabled:cursor-default disabled:text-text-tertiary disabled:opacity-30 lg:size-8"
             >
               <ChevronLeft className="size-4" />
@@ -162,7 +232,7 @@ export function SamplesCard() {
               type="button"
               aria-label="Show newer conversation sample"
               disabled={!newerTick}
-              onClick={() => newerTick && selectS2SSample(newerTick)}
+              onClick={() => newerTick && handleTickSelect("newer", newerTick)}
               className="flex size-11 items-center justify-center rounded-md border border-border-secondary text-text-secondary transition-colors hover:bg-surface-tertiary hover:text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-text-tertiary/40 disabled:cursor-default disabled:text-text-tertiary disabled:opacity-30 lg:size-8"
             >
               <ChevronRight className="size-4" />
@@ -171,7 +241,7 @@ export function SamplesCard() {
           {effectiveTick !== latestTick ? (
             <button
               type="button"
-              onClick={() => latestTick && selectS2SSample(latestTick)}
+              onClick={() => latestTick && handleTickSelect("latest", latestTick)}
               className="min-h-11 rounded-full border border-border-primary px-3 text-xs text-text-secondary transition-colors hover:text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-text-tertiary/40 lg:min-h-8"
             >
               Return to latest
@@ -203,6 +273,8 @@ export function SamplesCard() {
             items={items}
             normalizeProvider={normalizeProviderName}
             onPlay={handlePlay}
+            onSeeked={handleSeeked}
+            onPlaybackEnded={handlePlaybackEnded}
             playRequest={
               requestedItem && !manifestQuery.isPlaceholderData
                 ? { provider: requestedItem.provider, nonce: s2sPlayRequest!.nonce }

--- a/web/components/dashboard/QualityBarSection.tsx
+++ b/web/components/dashboard/QualityBarSection.tsx
@@ -18,7 +18,7 @@ import { useThemeColors } from "@/hooks/useThemeColors";
 import { useActiveTab } from "@/hooks/useActiveTab";
 import { useChartHoverTracking } from "@/hooks/useChartHoverTracking";
 import { capturePostHogEvent } from "@/lib/posthog/client";
-import { POSTHOG_EVENTS } from "@/lib/posthog/events";
+import { POSTHOG_EVENTS, type QualityBarMetric } from "@/lib/posthog/events";
 
 const INSTRUCTION_DESCRIPTION = {
   short: "Instruction adherence (%)",
@@ -68,6 +68,7 @@ const QualityBarSection: React.FC = () => {
         surface: `${mode}_dashboard`,
         mode,
         model_id: data.model,
+        metric: (isS2S ? "instruction" : "wer") satisfies QualityBarMetric,
       });
     }
     handleWERBarClick(data);

--- a/web/lib/posthog/events.ts
+++ b/web/lib/posthog/events.ts
@@ -22,6 +22,9 @@ export const POSTHOG_EVENTS = {
   dashboardWerDatasetChanged: "dashboard_wer_dataset_changed",
   dashboardWerBarViewChanged: "dashboard_wer_bar_view_changed",
   s2sSamplePlayRequested: "s2s_sample_play_requested",
+  s2sSamplePlaybackEnded: "s2s_sample_playback_ended",
+  s2sSampleTickChanged: "s2s_sample_tick_changed",
+  s2sSampleSeeked: "s2s_sample_seeked",
   headerCovalLinkClicked: "header_coval_link_clicked"
 } as const;
 
@@ -43,3 +46,13 @@ export type DashboardChartId =
   | "performance_delta";
 export type PlaygroundRunTrigger = "button" | "keyboard";
 export type PlaygroundModeSwitchTrigger = "tab" | "keyboard";
+// The quality bar plots WER on STT/TTS and instruction adherence on S2S; the
+// dashboard_wer_bar_clicked event name predates S2S, so `metric` says which
+// was plotted. Only "wer" can fire today — S2S instruction bars aren't
+// clickable — but the tag keeps the event honest if they ever become so.
+export type QualityBarMetric = "wer" | "instruction";
+// Sample panes never auto-advance (their <audio> stops on end), so a play can
+// only start from the pane's Play button or a timeline-tooltip click.
+export type S2SPlayTrigger = "button" | "timeline";
+export type S2SSeekMethod = "slider" | "turn";
+export type S2STickDirection = "older" | "newer" | "latest";


### PR DESCRIPTION
## Summary

Adds PostHog tracking for the new speech-to-speech section's unique surface — the conversation-samples player. The shared dashboard chrome (time window, facets, chart hover/share, scroll depth, heatmap sort) already reports with `surface: "s2s_dashboard"` for free, so this PR covers what's S2S-specific:

- **`s2s_sample_play_requested` enriched** with `trigger` (`button` | `timeline`), `model_id`, `position`, and `has_transcript`. Previously a timeline-tooltip autoplay and a deliberate Play press were indistinguishable.
- **`s2s_sample_playback_ended`** (new): one listen session per activation, reporting `listen_pct` (furthest playhead), `duration_seconds`, `completed`, and the starting `trigger`. Flushed on pause, stop, track swap, end, and unmount — answers "did they actually listen or bail?"
- **`s2s_sample_seeked`** (new): transcript-turn clicks (`method: "turn"`, with `turn_index`/`turn_role`) and scrub-slider gestures (`method: "slider"`, debounced to one event per burst at its final position).
- **`s2s_sample_tick_changed`** (new): the older/newer chevrons and "Return to latest", with `direction` and `from_bucket`/`to_bucket`.
- **`dashboard_wer_bar_clicked` tagged with `metric`** (`wer` | `instruction`). Note: S2S instruction bars aren't clickable today, so only `"wer"` can fire — the tag keeps the shared section honest if they ever become clickable.

Attribution is snapshot-based: `playback_ended` and deferred slider seeks capture bucket/model at interaction time, so flushes that outlive a tick swap attribute to what was actually heard, not the manifest that replaced it.

## Test plan

- `pnpm typecheck`, `pnpm lint`, `pnpm test` (124 tests) all green.
- Verified live against the dev server with a `posthog.capture` spy (dummy token, nothing sent to the real project):
  - Play → `trigger: "button"`, `model_id`, `position`, `has_transcript` correct
  - Pause at ~18s of 80s → `listen_pct: 22`, `completed: false`
  - Seek near end, play out → `listen_pct: 100`, `completed: true`
  - Transcript turn click → `method: "turn"`, `turn_index: 1`, `turn_role: "agent"`
  - Slider drag → single debounced event at final position
  - Chevron/latest navigation → `direction: "older"` / `"latest"` with correct buckets
  - Scrub then tick-swap within the debounce window → seek still attributed to the scrubbed manifest
  - TTS WER bar click → `metric: "wer"`
- Not exercised live: `trigger: "timeline"` (recharts tooltip resists automation) — it's a one-line ref set inside the pre-existing autoplay effect.