### PR TITLE
Hand back the audio URL instead of redirecting to it

### DIFF
--- a/runner/src/coval_bench/api/routers/s2s_samples.py
+++ b/runner/src/coval_bench/api/routers/s2s_samples.py
@@ -6,8 +6,12 @@
 The bucket allows no anonymous read. The API reads each manifest as its own
 service account, drops the recordings this caller may not see (their transcripts
 go with them, since both live in the same object), and hands back an API route
-per surviving recording. Playing one redirects to a short-lived signed URL minted
-at that moment, so no signature is ever stored or cached.
+per surviving recording. Asking for one returns a short-lived signed URL minted at
+that moment, so no signature is ever stored or cached.
+
+The URL comes back as a body rather than a redirect: a browser cannot carry its
+early-access header through a cross-origin redirect to storage, so a redirect
+would be unplayable for exactly the callers the embargo exists to serve.
 
 Every route resolves visibility through the same ``hidden_early_access``
 dependency: the audio route re-checks rather than trusting that the caller got
@@ -17,18 +21,18 @@ its path from a filtered manifest.
 from __future__ import annotations
 
 import asyncio
+from datetime import UTC, datetime
 from urllib.parse import quote
 
 import structlog
 from fastapi import APIRouter, Depends, HTTPException, Path, Response
-from fastapi.responses import RedirectResponse
 from posthog import Posthog
 from starlette.requests import Request
 
 from coval_bench.api.deps import capture_api_event, get_posthog, get_settings
-from coval_bench.api.internal import EA_STATUS_HEADER, hidden_early_access, never_shared
+from coval_bench.api.internal import hidden_early_access, never_shared
 from coval_bench.api.ratelimit import limiter
-from coval_bench.api.schemas import S2SSampleOut, S2SSampleRecordingOut
+from coval_bench.api.schemas import S2SSampleAudioOut, S2SSampleOut, S2SSampleRecordingOut
 from coval_bench.config import Settings
 from coval_bench.gcs import signed_url
 from coval_bench.registries import MODEL_REGISTRY, Benchmark
@@ -135,7 +139,7 @@ async def get_s2s_sample(
 
 @router.get(
     "/s2s/samples/{sample_id}/{provider}/{model}/audio",
-    response_class=RedirectResponse,
+    response_model=S2SSampleAudioOut,
 )
 @limiter.limit("120/minute")
 async def get_s2s_sample_audio(
@@ -146,8 +150,9 @@ async def get_s2s_sample_audio(
     sample_id: str = Path(pattern=_SAMPLE_ID),
     settings: Settings = Depends(get_settings),
     hidden: frozenset[tuple[str, str]] = Depends(hidden_early_access),
-) -> RedirectResponse:
-    """Redirect to a freshly signed URL, minted only if this caller may hear it."""
+) -> S2SSampleAudioOut:
+    """A freshly signed URL for one recording, minted only if this caller may hear it."""
+    never_shared(response)
     if not settings.s2s_samples_bucket:
         raise HTTPException(404, "s2s samples are not configured")
 
@@ -163,9 +168,4 @@ async def get_s2s_sample_audio(
         raise HTTPException(404, "no such s2s sample recording")
 
     url = await asyncio.to_thread(signed_url, settings.s2s_samples_bucket, key, ttl=AUDIO_URL_TTL)
-    redirect = RedirectResponse(url, status_code=302)
-    never_shared(redirect)
-    ea_status = response.headers.get(EA_STATUS_HEADER)
-    if ea_status is not None:
-        redirect.headers[EA_STATUS_HEADER] = ea_status
-    return redirect
+    return S2SSampleAudioOut(url=url, expires_at=datetime.now(UTC) + AUDIO_URL_TTL)

--- a/runner/src/coval_bench/api/schemas.py
+++ b/runner/src/coval_bench/api/schemas.py
@@ -230,6 +230,19 @@ class S2SSampleOut(BaseModel):
     recordings: list[S2SSampleRecordingOut]
 
 
+class S2SSampleAudioOut(BaseModel):
+    """A freshly signed URL for one recording, with the moment it stops working.
+
+    Handed over as a body rather than a redirect: a browser cannot carry its
+    early-access header through a cross-origin redirect to storage, so the caller
+    fetches this with its proof and then points an audio element at ``url``.
+    ``expires_at`` lets the caller re-ask before playing rather than after failing.
+    """
+
+    url: str
+    expires_at: datetime
+
+
 class BattleOut(BaseModel):
     """A battle to vote on. Blind by design: no provider/model identities."""
 

--- a/runner/tests/api/test_s2s_samples_api.py
+++ b/runner/tests/api/test_s2s_samples_api.py
@@ -10,6 +10,7 @@ rather than merely losing its audio link.
 
 from __future__ import annotations
 
+from datetime import UTC, datetime, timedelta
 from typing import Any
 
 import pytest
@@ -20,6 +21,7 @@ from httpx import AsyncClient
 from coval_bench.api.deps import get_settings
 from coval_bench.config import Settings
 from coval_bench.registries import MODEL_REGISTRY, Benchmark, ModelStatus, RegisteredModel
+from coval_bench.s2s.samples import AUDIO_URL_TTL
 from tests.api.conftest import INTERNAL_API_KEY
 
 _BUCKET = "test-s2s-samples"
@@ -230,22 +232,26 @@ async def test_the_same_sample_is_served_to_a_caller_who_may_hear_it(
     assert _pairs(res.json()) == [_EMBARGOED]
 
 
-# --- the audio redirect -----------------------------------------------------
+# --- the audio url ----------------------------------------------------------
 
 
-async def test_audio_redirects_to_a_signed_url(samples_client: AsyncClient) -> None:
-    res = await samples_client.get(
-        f"/v1/s2s/samples/{_SAMPLE}/{_LIVE[0]}/{_LIVE[1]}/audio", follow_redirects=False
-    )
+async def test_audio_hands_back_a_signed_url_in_the_body(samples_client: AsyncClient) -> None:
+    """A body, not a redirect: a browser cannot carry its token through one."""
+    res = await samples_client.get(f"/v1/s2s/samples/{_SAMPLE}/{_LIVE[0]}/{_LIVE[1]}/audio")
 
-    assert res.status_code == 302
-    assert res.headers["location"].startswith(_SIGNED)
+    assert res.status_code == 200
+    assert res.json()["url"].startswith(_SIGNED)
 
 
-async def test_audio_redirect_is_never_cached(samples_client: AsyncClient) -> None:
-    res = await samples_client.get(
-        f"/v1/s2s/samples/{_SAMPLE}/{_LIVE[0]}/{_LIVE[1]}/audio", follow_redirects=False
-    )
+async def test_audio_says_when_the_url_stops_working(samples_client: AsyncClient) -> None:
+    res = await samples_client.get(f"/v1/s2s/samples/{_SAMPLE}/{_LIVE[0]}/{_LIVE[1]}/audio")
+
+    expires_at = datetime.fromisoformat(res.json()["expires_at"])
+    assert timedelta() < expires_at - datetime.now(UTC) <= AUDIO_URL_TTL
+
+
+async def test_audio_url_is_never_cached(samples_client: AsyncClient) -> None:
+    res = await samples_client.get(f"/v1/s2s/samples/{_SAMPLE}/{_LIVE[0]}/{_LIVE[1]}/audio")
 
     assert res.headers["cache-control"] == "private, no-store"
     assert "X-EA-Token" in res.headers["vary"]
@@ -255,7 +261,6 @@ async def test_audio_redirect_is_never_cached(samples_client: AsyncClient) -> No
 async def test_audio_for_an_embargoed_model_is_refused(samples_client: AsyncClient) -> None:
     res = await samples_client.get(
         f"/v1/s2s/samples/{_SAMPLE}/{_EMBARGOED[0]}/{_EMBARGOED[1]}/audio",
-        follow_redirects=False,
     )
 
     assert res.status_code == 404
@@ -267,17 +272,14 @@ async def test_audio_for_an_embargoed_model_is_served_to_internal(
     res = await samples_client.get(
         f"/v1/s2s/samples/{_SAMPLE}/{_EMBARGOED[0]}/{_EMBARGOED[1]}/audio",
         headers=_INTERNAL,
-        follow_redirects=False,
     )
 
-    assert res.status_code == 302
+    assert res.status_code == 200
     assert res.headers["X-EA-Token-Status"] == "internal"
 
 
 async def test_audio_for_an_unknown_recording_is_a_404(samples_client: AsyncClient) -> None:
-    res = await samples_client.get(
-        f"/v1/s2s/samples/{_SAMPLE}/{_LIVE[0]}/no-such-model/audio", follow_redirects=False
-    )
+    res = await samples_client.get(f"/v1/s2s/samples/{_SAMPLE}/{_LIVE[0]}/no-such-model/audio")
 
     assert res.status_code == 404
 
@@ -286,10 +288,9 @@ async def test_audio_for_an_unknown_recording_is_a_404(samples_client: AsyncClie
 
 
 async def test_a_refusal_is_never_cached(samples_client: AsyncClient) -> None:
-    """The public 404 and the partner's 302 share a URL, so no cache may reuse it."""
+    """The public 404 and the partner's signed URL share a route, so no cache may reuse it."""
     res = await samples_client.get(
         f"/v1/s2s/samples/{_SAMPLE}/{_EMBARGOED[0]}/{_EMBARGOED[1]}/audio",
-        follow_redirects=False,
     )
 
     assert res.status_code == 404


### PR DESCRIPTION
A browser cannot carry its early-access header through a cross-origin redirect to storage, so a redirect was unplayable for exactly the partners the embargo exists to serve. The route now returns the signed URL with the moment it expires, and the caller points an audio element at it.