### PR TITLE
[BENCH-583] Make leaderboard preview rows horizontally scrollable

### DIFF
--- a/web/components/overview/LeaderboardCard.tsx
+++ b/web/components/overview/LeaderboardCard.tsx
@@ -55,10 +55,14 @@ const LeaderboardCard: React.FC<LeaderboardCardProps> = ({
         </span>
       </div>
 
+      <div className="overflow-x-auto">
+      <div className="w-max min-w-full">
       <div className="grid grid-cols-[1.25rem_1fr_auto] items-center gap-x-2 gap-y-4 border-b border-border-secondary pb-2 text-[0.7rem] font-light tracking-wider text-text-secondary">
         <div>#</div>
         <div>Model</div>
-        <div className="text-right">{metricLabel}</div>
+        <div className="sticky right-0 bg-surface-elevated pl-2 text-right">
+          {metricLabel}
+        </div>
       </div>
 
       {loading && (
@@ -99,19 +103,19 @@ const LeaderboardCard: React.FC<LeaderboardCardProps> = ({
                 {index + 1}
               </span>
             </div>
-            <div className="min-w-0">
-              <div className="truncate text-sm font-medium">
-                {row.model}
-                <span className="ml-1 font-normal text-text-tertiary">
-                  {row.provider}
-                </span>
-              </div>
+            <div className="whitespace-nowrap text-sm font-medium">
+              {row.model}
+              <span className="ml-1 font-normal text-text-tertiary">
+                {row.provider}
+              </span>
             </div>
-            <div className="justify-self-end text-right font-mono text-lg">
+            <div className="sticky right-0 justify-self-end bg-surface-elevated pl-2 text-right font-mono text-lg">
               {row.value}
             </div>
           </div>
         ))}
+      </div>
+      </div>
 
       {!loading && !error && rows.length > 0 && (
         <Link


### PR DESCRIPTION
## Summary
- Long model/provider names on the overview leaderboard cards were truncated with an ellipsis (e.g. "Gemini 3.1 Flash Liv…", "Parakeet TDT 0.6B v3…").
- Card rows now scroll horizontally inside the card: the header + rows sit in an `overflow-x-auto` container with a `w-max min-w-full` wrapper so columns stay aligned, and the name cell uses `whitespace-nowrap` instead of `truncate`.
- The metric column (`ms` values and the metric header) is pinned with `sticky right-0` on the card background, so latency numbers stay visible while names scroll underneath.

## Testing
- Verified locally at mobile (375px) and desktop (1440px) widths against live prod data: full names reachable by scroll/swipe on STT and S2S cards, values pinned throughout, short-name cards unchanged.
- `tsc --noEmit` and ESLint clean.