### PR TITLE
[BENCH-585] Move chart share/export buttons next to the section label

### DIFF
--- a/web/components/shared/SectionHeader.tsx
+++ b/web/components/shared/SectionHeader.tsx
@@ -229,8 +229,8 @@ const SectionHeader: React.FC<SectionHeaderProps> = ({
   return (
     <div id={anchorId} className="flex flex-col sm:flex-row sm:justify-between sm:items-start gap-3 sm:gap-8 mb-4 scroll-mt-24">
       <div className="w-full sm:w-3/4 min-w-0">
-        <h2 className="mb-2 flex items-start gap-2 text-[0.9rem] font-light text-text-secondary">
-          <span className="min-w-0 flex-1 pt-3 lg:pt-1">{label}</span>
+        <h2 className="mb-2 flex items-center gap-2 text-[0.9rem] font-light text-text-secondary">
+          <span className="min-w-0">{label}</span>
           <button
             type="button"
             onClick={() => void copyLink()}


### PR DESCRIPTION
AFter
<img width="1023" height="589" alt="Screenshot 2026-07-30 at 5 20 59 PM" src="https://github.com/user-attachments/assets/0ae73b72-ec5e-46a8-9d7a-5d1bca35192c" />

Before 
<img width="1379" height="544" alt="Screenshot 2026-07-30 at 5 21 23 PM" src="https://github.com/user-attachments/assets/c1c06831-d7a5-44ce-bbc1-4bd47e25d241" />

The share/export icon buttons on chart cards floated to the middle of the header (the section label span was `flex-1`), where they crowded the headline stat and read as detached from anything. They now sit directly to the right of the section label (e.g. "Performance Consistency", "Latency vs Accuracy"), vertically centered on that row.

Two-line change in `SectionHeader.tsx`: drop `flex-1` (and the top-padding alignment hack) from the label span and switch the row to `items-center`. Applies to every chart card since they all render through `SectionHeader`. Verified on desktop and mobile widths — mobile keeps the 44px touch targets.