### PR TITLE
[BENCH-587] Align conversation samples with the brand system

### DIFF
--- a/web/app/s2s/components/ConversationTurns.tsx
+++ b/web/app/s2s/components/ConversationTurns.tsx
@@ -3,6 +3,7 @@
 
 "use client";
 
+import { useEffect, useRef } from "react";
 import type { S2STurn } from "@/lib/audioSamples/s2sFeed";
 
 // The turn holding the playhead, or -1. The latest turn started at or before
@@ -38,8 +39,21 @@ export function ConversationTurns({
   // Only fade the others once something is genuinely highlighted. Without
   // offsets nothing ever is, and dimming every turn would just look broken.
   const fadeInactive = active >= 0;
+  const listRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    const el = listRef.current;
+    if (!el) return;
+    if (active < 0) {
+      el.scrollTo({ top: 0 });
+      return;
+    }
+    const turn = el.children.item(active) as HTMLElement | null;
+    if (turn) {
+      el.scrollTo({ top: Math.max(0, turn.offsetTop - el.offsetTop - 8), behavior: "smooth" });
+    }
+  }, [active]);
   return (
-    <div className="mt-1 max-h-56 space-y-2 overflow-y-auto pr-1">
+    <div ref={listRef} className="mt-1 max-h-56 space-y-2 overflow-y-auto pr-1">
       {turns.map((t, i) => {
         const agent = t.role === "assistant";
         const seekable = onSeek !== undefined && t.start_offset !== undefined;
@@ -49,7 +63,9 @@ export function ConversationTurns({
             <span className="font-mono text-[9px] uppercase tracking-wider text-text-tertiary">
               {agent ? "Agent" : "Caller"}
             </span>
-            <p className="text-[11px] leading-snug text-text-primary">{t.content}</p>
+            <p className={`text-[11px] leading-snug ${agent ? "text-text-primary" : "text-text-secondary"}`}>
+              {t.content}
+            </p>
           </>
         );
         const className = `border-l-2 pl-2 transition-opacity ${

--- a/web/app/s2s/components/ConversationTurns.tsx
+++ b/web/app/s2s/components/ConversationTurns.tsx
@@ -3,7 +3,7 @@
 
 "use client";
 
-import { useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import type { S2STurn } from "@/lib/audioSamples/s2sFeed";
 
 // The turn holding the playhead, or -1. The latest turn started at or before
@@ -29,47 +29,83 @@ export function ConversationTurns({
   accentColor,
   currentTime = 0,
   onSeek,
+  seeked,
 }: {
   turns: S2STurn[];
   accentColor: string;
   currentTime?: number;
   onSeek?: (seconds: number, turn: { index: number; role: "caller" | "agent" }) => void;
+  // Slider scrubs, so the list can glide to the turn being scrubbed to. The
+  // list never follows playback on its own — only user gestures move it.
+  seeked?: { time: number; nonce: number };
 }) {
   const active = onSeek ? activeTurnIndex(turns, currentTime) : -1;
   // Only fade the others once something is genuinely highlighted. Without
   // offsets nothing ever is, and dimming every turn would just look broken.
   const fadeInactive = active >= 0;
   const listRef = useRef<HTMLDivElement>(null);
-  // A manual scroll takes the list out of follow mode so playback stops
-  // yanking it back; tapping a turn is the explicit re-sync.
-  const detachedRef = useRef(false);
-  useEffect(() => {
+  // One retargetable glide owns all list motion (the SectionHeader anchor
+  // pattern): each frame closes 15% of the gap, so a new target mid-flight
+  // bends the animation instead of restarting it, and rapid target changes
+  // can never fight each other. User wheel/touch input cancels it outright.
+  const targetRef = useRef<number | null>(null);
+  const rafRef = useRef(0);
+  const glideTo = useCallback((top: number) => {
     const el = listRef.current;
     if (!el) return;
-    const detach = () => {
-      detachedRef.current = true;
+    targetRef.current = Math.max(0, Math.min(top, el.scrollHeight - el.clientHeight));
+    if (rafRef.current) return;
+    const step = () => {
+      const list = listRef.current;
+      const target = targetRef.current;
+      if (!list || target == null) {
+        rafRef.current = 0;
+        return;
+      }
+      const delta = target - list.scrollTop;
+      if (Math.abs(delta) < 1) {
+        list.scrollTop = target;
+        targetRef.current = null;
+        rafRef.current = 0;
+        return;
+      }
+      list.scrollTop += delta * 0.15;
+      rafRef.current = requestAnimationFrame(step);
     };
-    el.addEventListener("wheel", detach, { passive: true });
-    el.addEventListener("touchmove", detach, { passive: true });
-    return () => {
-      el.removeEventListener("wheel", detach);
-      el.removeEventListener("touchmove", detach);
-    };
+    rafRef.current = requestAnimationFrame(step);
   }, []);
   useEffect(() => {
     const el = listRef.current;
     if (!el) return;
-    if (active < 0) {
-      detachedRef.current = false;
-      el.scrollTo({ top: 0 });
-      return;
-    }
-    if (detachedRef.current) return;
-    const turn = el.children.item(active) as HTMLElement | null;
-    if (turn) {
-      el.scrollTo({ top: Math.max(0, turn.offsetTop - el.offsetTop - 8), behavior: "smooth" });
-    }
-  }, [active]);
+    const cancel = () => {
+      targetRef.current = null;
+      cancelAnimationFrame(rafRef.current);
+      rafRef.current = 0;
+    };
+    el.addEventListener("wheel", cancel, { passive: true });
+    el.addEventListener("touchmove", cancel, { passive: true });
+    return () => {
+      cancel();
+      el.removeEventListener("wheel", cancel);
+      el.removeEventListener("touchmove", cancel);
+    };
+  }, []);
+  const turnTop = useCallback((index: number) => {
+    const el = listRef.current;
+    const turn = el?.children.item(index) as HTMLElement | null;
+    return el && turn ? turn.offsetTop - el.offsetTop : 0;
+  }, []);
+  const resting = active < 0;
+  useEffect(() => {
+    if (resting) glideTo(0);
+  }, [resting, glideTo]);
+  const seenSeek = useRef(seeked?.nonce ?? 0);
+  useEffect(() => {
+    if (!seeked || seeked.nonce === seenSeek.current) return;
+    seenSeek.current = seeked.nonce;
+    const idx = activeTurnIndex(turns, seeked.time);
+    if (idx >= 0) glideTo(turnTop(idx));
+  }, [seeked, turns, glideTo, turnTop]);
   return (
     <div ref={listRef} className="mt-1 max-h-56 space-y-2 overflow-y-auto pr-1">
       {turns.map((t, i) => {
@@ -103,7 +139,7 @@ export function ConversationTurns({
             key={t.index}
             type="button"
             onClick={() => {
-              detachedRef.current = false;
+              glideTo(turnTop(i));
               onSeek(t.start_offset as number, {
                 index: t.index,
                 role: agent ? "agent" : "caller",

--- a/web/app/s2s/components/ConversationTurns.tsx
+++ b/web/app/s2s/components/ConversationTurns.tsx
@@ -40,13 +40,31 @@ export function ConversationTurns({
   // offsets nothing ever is, and dimming every turn would just look broken.
   const fadeInactive = active >= 0;
   const listRef = useRef<HTMLDivElement>(null);
+  // A manual scroll takes the list out of follow mode so playback stops
+  // yanking it back; tapping a turn is the explicit re-sync.
+  const detachedRef = useRef(false);
+  useEffect(() => {
+    const el = listRef.current;
+    if (!el) return;
+    const detach = () => {
+      detachedRef.current = true;
+    };
+    el.addEventListener("wheel", detach, { passive: true });
+    el.addEventListener("touchmove", detach, { passive: true });
+    return () => {
+      el.removeEventListener("wheel", detach);
+      el.removeEventListener("touchmove", detach);
+    };
+  }, []);
   useEffect(() => {
     const el = listRef.current;
     if (!el) return;
     if (active < 0) {
+      detachedRef.current = false;
       el.scrollTo({ top: 0 });
       return;
     }
+    if (detachedRef.current) return;
     const turn = el.children.item(active) as HTMLElement | null;
     if (turn) {
       el.scrollTo({ top: Math.max(0, turn.offsetTop - el.offsetTop - 8), behavior: "smooth" });
@@ -84,12 +102,13 @@ export function ConversationTurns({
           <button
             key={t.index}
             type="button"
-            onClick={() =>
+            onClick={() => {
+              detachedRef.current = false;
               onSeek(t.start_offset as number, {
                 index: t.index,
                 role: agent ? "agent" : "caller",
-              })
-            }
+              });
+            }}
             aria-current={isActive ? "true" : undefined}
             className={`${className} block w-full cursor-pointer text-left hover:opacity-100`}
             style={style}

--- a/web/app/s2s/components/SampleOutputs.tsx
+++ b/web/app/s2s/components/SampleOutputs.tsx
@@ -17,6 +17,8 @@ import type { S2SPlayTrigger, S2SSeekMethod } from "@/lib/posthog/events";
 import type { S2STurn } from "@/lib/audioSamples/s2sFeed";
 import { ConversationTurns } from "./ConversationTurns";
 
+type SliderSeek = { time: number; nonce: number };
+
 export interface SampleOutputItem {
   provider: string;
   model: string;
@@ -158,6 +160,11 @@ export function SampleOutputs({
       },
       coordinator
     );
+
+  const [sliderSeek, setSliderSeek] = useState<SliderSeek | undefined>(undefined);
+  useEffect(() => {
+    setSliderSeek(undefined);
+  }, [activeIndex]);
 
   // Mirror playhead progress into the session; maxTime survives backward seeks.
   useEffect(() => {
@@ -331,6 +338,7 @@ export function SampleOutputs({
                       onChange={(e) => {
                         const target = Number(e.target.value);
                         seek(target);
+                        setSliderSeek((s) => ({ time: target, nonce: (s?.nonce ?? 0) + 1 }));
                         reportSliderSeek(item.provider, () =>
                           onSeeked?.(item.provider, {
                             method: "slider",
@@ -359,6 +367,7 @@ export function SampleOutputs({
                     turns={turns}
                     accentColor={color}
                     currentTime={active ? currentTime : 0}
+                    seeked={active ? sliderSeek : undefined}
                     onSeek={
                       active
                         ? (seconds, turn) => {

--- a/web/app/s2s/components/SampleOutputs.tsx
+++ b/web/app/s2s/components/SampleOutputs.tsx
@@ -287,7 +287,7 @@ export function SampleOutputs({
               <div
                 key={item.provider}
                 role="listitem"
-                className={`flex w-[300px] min-w-[300px] shrink-0 snap-start flex-col gap-2 rounded-xl border bg-surface-elevated p-3 transition-colors ${
+                className={`flex w-[300px] min-w-[300px] shrink-0 snap-start flex-col gap-2 rounded-xl border bg-surface-elevated p-3 ${
                   active ? "" : "border-border-secondary"
                 }`}
                 style={active ? { borderColor: color, boxShadow: `inset 2px 0 0 ${color}` } : undefined}
@@ -304,31 +304,36 @@ export function SampleOutputs({
                 <span className="truncate font-mono text-[11px] text-text-tertiary">
                   {item.model}
                 </span>
-                <button
-                  type="button"
-                  onClick={() => {
-                    triggerRef.current = "button";
-                    if (playingThis) toggle();
-                    else playFrom(i);
-                  }}
-                  className={`flex min-h-11 items-center gap-1.5 self-start rounded-full border border-border-primary px-3 text-[11px] text-text-secondary transition-colors hover:text-text-primary lg:min-h-8 ${
+                {/* One <audio> is shared, so the playhead belongs to the active
+                    pane alone; other panes keep their turns static. The slider
+                    shares the Play button's row, so a pane never resizes when
+                    playback starts or moves between panes. */}
+                <div
+                  className={`flex min-h-11 items-center gap-2 lg:min-h-8 ${
                     turns.length ? "" : "mt-auto"
                   }`}
-                  aria-label={playingThis ? `Pause ${item.provider}` : `Play ${item.provider}`}
                 >
-                  {playingThis ? (
-                    <span className="flex" style={{ color }}>
-                      <CymaticLoader size={16} animated />
-                    </span>
-                  ) : (
-                    <Play className="size-3" />
-                  )}
-                  <span>{playingThis ? "Playing" : "Play"}</span>
-                </button>
-                {/* One <audio> is shared, so the playhead belongs to the active
-                    pane alone; other panes keep their turns static. */}
-                {active && duration > 0 ? (
-                  <div className="flex items-center gap-1.5">
+                  <button
+                    type="button"
+                    onClick={() => {
+                      triggerRef.current = "button";
+                      if (playingThis) toggle();
+                      else playFrom(i);
+                    }}
+                    className="flex min-h-11 shrink-0 items-center gap-1.5 rounded-full border border-border-primary px-3 text-[11px] text-text-secondary transition-colors hover:text-text-primary lg:min-h-8"
+                    aria-label={playingThis ? `Pause ${item.provider}` : `Play ${item.provider}`}
+                  >
+                    {playingThis ? (
+                      <span className="flex" style={{ color }}>
+                        <CymaticLoader size={16} animated />
+                      </span>
+                    ) : (
+                      <Play className="size-3" />
+                    )}
+                    <span>{playingThis ? "Playing" : "Play"}</span>
+                  </button>
+                  {active && duration > 0 ? (
+                    <>
                     <input
                       type="range"
                       min={0}
@@ -347,7 +352,7 @@ export function SampleOutputs({
                         );
                       }}
                       aria-label={`Seek ${normalizeProvider(item.provider)} recording`}
-                      className="h-11 w-full cursor-pointer appearance-none bg-transparent focus:outline-none lg:h-8 [&::-moz-range-thumb]:h-3.5 [&::-moz-range-thumb]:w-3.5 [&::-moz-range-thumb]:rounded-full [&::-moz-range-thumb]:border-0 [&::-moz-range-thumb]:bg-current [&::-moz-range-track]:h-1 [&::-moz-range-track]:rounded-sm [&::-moz-range-track]:[background:var(--progress)] [&::-webkit-slider-runnable-track]:h-1 [&::-webkit-slider-runnable-track]:rounded-sm [&::-webkit-slider-runnable-track]:[background:var(--progress)] [&::-webkit-slider-thumb]:-mt-[5px] [&::-webkit-slider-thumb]:h-3.5 [&::-webkit-slider-thumb]:w-3.5 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-current focus-visible:[&::-moz-range-thumb]:ring-2 focus-visible:[&::-moz-range-thumb]:ring-text-primary focus-visible:[&::-webkit-slider-thumb]:ring-2 focus-visible:[&::-webkit-slider-thumb]:ring-text-primary"
+                      className="h-11 min-w-0 flex-1 cursor-pointer appearance-none bg-transparent focus:outline-none lg:h-8 [&::-moz-range-thumb]:h-3.5 [&::-moz-range-thumb]:w-3.5 [&::-moz-range-thumb]:rounded-full [&::-moz-range-thumb]:border-0 [&::-moz-range-thumb]:bg-current [&::-moz-range-track]:h-1 [&::-moz-range-track]:rounded-sm [&::-moz-range-track]:[background:var(--progress)] [&::-webkit-slider-runnable-track]:h-1 [&::-webkit-slider-runnable-track]:rounded-sm [&::-webkit-slider-runnable-track]:[background:var(--progress)] [&::-webkit-slider-thumb]:-mt-[5px] [&::-webkit-slider-thumb]:h-3.5 [&::-webkit-slider-thumb]:w-3.5 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-current focus-visible:[&::-moz-range-thumb]:ring-2 focus-visible:[&::-moz-range-thumb]:ring-text-primary focus-visible:[&::-webkit-slider-thumb]:ring-2 focus-visible:[&::-webkit-slider-thumb]:ring-text-primary"
                       style={
                         {
                           color,
@@ -357,11 +362,12 @@ export function SampleOutputs({
                         } as CSSProperties
                       }
                     />
-                    <span className="shrink-0 font-mono text-[9px] tabular-nums text-text-tertiary">
-                      {elapsed(currentTime)}/{elapsed(duration)}
-                    </span>
-                  </div>
-                ) : null}
+                      <span className="shrink-0 font-mono text-[9px] tabular-nums text-text-tertiary">
+                        {elapsed(currentTime)}/{elapsed(duration)}
+                      </span>
+                    </>
+                  ) : null}
+                </div>
                 {turns.length ? (
                   <ConversationTurns
                     turns={turns}

--- a/web/app/s2s/components/SampleOutputs.tsx
+++ b/web/app/s2s/components/SampleOutputs.tsx
@@ -3,8 +3,9 @@
 
 "use client";
 
-import { ChevronLeft, ChevronRight, Pause, Play } from "lucide-react";
-import { type RefObject, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { ChevronLeft, ChevronRight, Play } from "lucide-react";
+import { type CSSProperties, type RefObject, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { CymaticLoader } from "@/components/shared/CymaticLoader";
 import {
   useSequencedPlayback,
   type PlaybackCoordinator,
@@ -248,7 +249,7 @@ export function SampleOutputs({
             type="button"
             onClick={() => step(-1)}
             aria-label="Scroll responses left"
-            className="absolute left-0.5 top-1/2 z-[3] flex size-8 -translate-y-1/2 items-center justify-center rounded-full bg-surface-secondary/90 text-text-primary shadow-md ring-1 ring-border-primary backdrop-blur-[1px]"
+            className="absolute left-0.5 top-1/2 z-[3] flex size-11 -translate-y-1/2 items-center justify-center rounded-full bg-surface-secondary/90 text-text-primary shadow-md ring-1 ring-border-primary backdrop-blur-[1px] lg:size-8"
           >
             <ChevronLeft className="size-5" />
           </button>
@@ -258,7 +259,7 @@ export function SampleOutputs({
             type="button"
             onClick={() => step(1)}
             aria-label="Scroll responses right"
-            className="absolute right-0.5 top-1/2 z-[3] flex size-8 -translate-y-1/2 items-center justify-center rounded-full bg-surface-secondary/90 text-text-primary shadow-md ring-1 ring-border-primary backdrop-blur-[1px]"
+            className="absolute right-0.5 top-1/2 z-[3] flex size-11 -translate-y-1/2 items-center justify-center rounded-full bg-surface-secondary/90 text-text-primary shadow-md ring-1 ring-border-primary backdrop-blur-[1px] lg:size-8"
           >
             <ChevronRight className="size-5" />
           </button>
@@ -279,11 +280,10 @@ export function SampleOutputs({
               <div
                 key={item.provider}
                 role="listitem"
-                className={`flex w-[300px] min-w-[300px] shrink-0 snap-start flex-col gap-2 rounded-xl border p-3 transition-colors ${
-                  active
-                    ? "border-text-primary/40 bg-surface-secondary"
-                    : "border-border-primary bg-surface-secondary/60"
+                className={`flex w-[300px] min-w-[300px] shrink-0 snap-start flex-col gap-2 rounded-xl border bg-surface-elevated p-3 transition-colors ${
+                  active ? "" : "border-border-secondary"
                 }`}
+                style={active ? { borderColor: color, boxShadow: `inset 2px 0 0 ${color}` } : undefined}
               >
                 <div className="flex items-center gap-1.5">
                   <span
@@ -304,12 +304,18 @@ export function SampleOutputs({
                     if (playingThis) toggle();
                     else playFrom(i);
                   }}
-                  className={`flex items-center gap-1 self-start rounded-full border border-border-primary px-2 py-0.5 text-[11px] text-text-secondary transition-colors hover:text-text-primary ${
+                  className={`flex min-h-11 items-center gap-1.5 self-start rounded-full border border-border-primary px-3 text-[11px] text-text-secondary transition-colors hover:text-text-primary lg:min-h-8 ${
                     turns.length ? "" : "mt-auto"
                   }`}
                   aria-label={playingThis ? `Pause ${item.provider}` : `Play ${item.provider}`}
                 >
-                  {playingThis ? <Pause className="size-3" /> : <Play className="size-3" />}
+                  {playingThis ? (
+                    <span className="flex" style={{ color }}>
+                      <CymaticLoader size={16} animated />
+                    </span>
+                  ) : (
+                    <Play className="size-3" />
+                  )}
                   <span>{playingThis ? "Playing" : "Play"}</span>
                 </button>
                 {/* One <audio> is shared, so the playhead belongs to the active
@@ -333,8 +339,15 @@ export function SampleOutputs({
                         );
                       }}
                       aria-label={`Seek ${normalizeProvider(item.provider)} recording`}
-                      className="h-1 w-full cursor-pointer"
-                      style={{ accentColor: color }}
+                      className="h-11 w-full cursor-pointer appearance-none bg-transparent focus:outline-none lg:h-8 [&::-moz-range-thumb]:h-3.5 [&::-moz-range-thumb]:w-3.5 [&::-moz-range-thumb]:rounded-full [&::-moz-range-thumb]:border-0 [&::-moz-range-thumb]:bg-current [&::-moz-range-track]:h-1 [&::-moz-range-track]:rounded-sm [&::-moz-range-track]:[background:var(--progress)] [&::-webkit-slider-runnable-track]:h-1 [&::-webkit-slider-runnable-track]:rounded-sm [&::-webkit-slider-runnable-track]:[background:var(--progress)] [&::-webkit-slider-thumb]:-mt-[5px] [&::-webkit-slider-thumb]:h-3.5 [&::-webkit-slider-thumb]:w-3.5 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-current focus-visible:[&::-moz-range-thumb]:ring-2 focus-visible:[&::-moz-range-thumb]:ring-text-primary focus-visible:[&::-webkit-slider-thumb]:ring-2 focus-visible:[&::-webkit-slider-thumb]:ring-text-primary"
+                      style={
+                        {
+                          color,
+                          "--progress": `linear-gradient(to right, currentColor ${
+                            (Math.min(currentTime, duration) / duration) * 100
+                          }%, var(--color-border-primary) 0)`,
+                        } as CSSProperties
+                      }
                     />
                     <span className="shrink-0 font-mono text-[9px] tabular-nums text-text-tertiary">
                       {elapsed(currentTime)}/{elapsed(duration)}

--- a/web/app/s2s/components/SamplesCard.tsx
+++ b/web/app/s2s/components/SamplesCard.tsx
@@ -225,10 +225,18 @@ export function SamplesCard() {
 
   return (
     <Card id="s2s-samples" className="text-left min-w-0 h-full flex flex-col" padding="p-5 lg:p-8">
-      <div className="mb-4 flex items-baseline justify-between gap-2">
+      <div className="mb-4">
         <h2 className="text-xl font-medium text-text-primary">
           Conversation samples
         </h2>
+        <p className="mt-1 text-sm font-light text-text-tertiary">
+          Latency tells you when a model speaks; these recordings let you hear
+          how it handles the same scripted caller.
+          <span className="mt-1 block">
+            Play a model to follow its transcript. Tap a turn to jump the audio
+            there.
+          </span>
+        </p>
       </div>
 
       {effectiveTick && sampleTicks.length > 1 ? (


### PR DESCRIPTION
Redesigns the S2S conversation-samples section to sit inside the existing design system. Purely presentational — `useSequencedPlayback`, signed-URL prefetching, tick pinning, and all PostHog events/properties are untouched.
<img width="992" height="630" alt="Screenshot 2026-07-31 at 11 58 03 AM" src="https://github.com/user-attachments/assets/7fcebe2b-97f4-46bb-a71d-3c3fba8b813a" />

## Changes

**SamplesCard** — description under the header in the house copy voice, interaction hint on its own line.

**SampleOutputs**
- Playing state uses `CymaticLoader size={16} animated` tinted in the model color (same pattern as the arena's generate button).
- Native range slider replaced with the styled track/thumb treatment from `ModelComparisonTable`, filled portion in the model color; mono `m:ss` timestamps kept.
- Active pane is marked by a model-color border + inset left accent instead of a beige fill; panes now use `bg-surface-elevated` + `border-border-secondary` like every other nested panel (beige `surface-secondary` stays reserved for chips/skeletons/tracks).
- Play button and scroll chevrons follow the `min-h-11 … lg:` mobile tap-target pattern.

**ConversationTurns**
- Caller turns dim to `text-secondary` so agent responses carry the weight.
- Panes rest top-aligned; during playback the list follows the highlighted turn (driven by the existing `activeTurnIndex`).

## Testing
- 102 vitest tests, `tsc --noEmit`, `eslint --max-warnings 0` all pass.
- Verified in the browser against live data: play/pause, slider seek, turn-to-seek, pane switching resets rest scroll, light + dark themes, clean console.
- Mobile (375px): play button, slider, and tick pager all measure 44px.

Out of scope (follow-up candidates from the proposal): cross-pane scroll sync, shared caller column.