### PR TITLE
[BENCH-588] Replace generic AGENT/CALLER labels in conversation samples

### DIFF
--- a/web/app/s2s/components/ConversationTurns.tsx
+++ b/web/app/s2s/components/ConversationTurns.tsx
@@ -26,12 +26,16 @@ export function activeTurnIndex(turns: S2STurn[], currentTime: number): number {
 // When `onSeek` is given, a turn carrying an offset jumps the playhead to it.
 export function ConversationTurns({
   turns,
+  agentLabel,
   accentColor,
   currentTime = 0,
   onSeek,
   seeked,
 }: {
   turns: S2STurn[];
+  // Model id from the pane header, so each agent turn stays attributed to the
+  // model being compared. The caller side is always Coval's simulated caller.
+  agentLabel: string;
   accentColor: string;
   currentTime?: number;
   onSeek?: (seconds: number, turn: { index: number; role: "caller" | "agent" }) => void;
@@ -115,7 +119,7 @@ export function ConversationTurns({
         const body = (
           <>
             <span className="font-mono text-[9px] uppercase tracking-wider text-text-tertiary">
-              {agent ? "Agent" : "Caller"}
+              {agent ? agentLabel : "Caller (simulated)"}
             </span>
             <p className={`text-[11px] leading-snug ${agent ? "text-text-primary" : "text-text-secondary"}`}>
               {t.content}

--- a/web/app/s2s/components/SampleOutputs.tsx
+++ b/web/app/s2s/components/SampleOutputs.tsx
@@ -371,6 +371,7 @@ export function SampleOutputs({
                 {turns.length ? (
                   <ConversationTurns
                     turns={turns}
+                    agentLabel={item.model}
                     accentColor={color}
                     currentTime={active ? currentTime : 0}
                     seeked={active ? sliderSeek : undefined}


### PR DESCRIPTION
## Summary
- Label each agent turn with the model id (e.g. `gemini-live`, `gpt-realtime`) — the same value already shown in the pane header — so every turn stays attributed to the model being compared.
- Rename `CALLER` to `CALLER (SIMULATED)` so first-time visitors understand the caller side is Coval's simulated test caller.
- Copy/label change only: the mono tracking-label style, playback logic, and PostHog events are untouched. `ConversationTurns` gains an `agentLabel` prop; `SampleOutputs` passes `item.model`.

## Testing
- Verified in the browser on desktop and mobile viewports against live API data (both Google and OpenAI panes).
- `tsc --noEmit`, lint, and the ConversationTurns vitest suite (7 tests) pass.

Closes BENCH-588.