### PR TITLE
[BENCH-593] Preserve the query string on the root redirect

### DIFF
--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -3,6 +3,21 @@
 
 import { redirect } from "next/navigation";
 
-export default function Home() {
-  redirect("/overview");
+// The query string must survive this hop: shared links carry access tokens
+// (?ea=<token>, ?internal=<key>) that unlock early-access models, and a bare
+// redirect("/overview") would strip them before the client ever stores them.
+export default async function Home({
+  searchParams,
+}: {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const params = new URLSearchParams();
+  for (const [key, values] of Object.entries(await searchParams)) {
+    if (values === undefined) continue;
+    for (const value of Array.isArray(values) ? values : [values]) {
+      params.append(key, value);
+    }
+  }
+  const qs = params.toString();
+  redirect(qs ? `/overview?${qs}` : "/overview");
 }


### PR DESCRIPTION
## Why

Early-access links are shared pointing at the site root, e.g. `benchmarks.coval.ai/?ea=<token>`. The root page redirects to `/overview` with a bare `redirect("/overview")`, which drops the query string — so the token never reaches the client-side capture (`applyTokensFromUrl`), nothing lands in localStorage, and the partner sees only the public models. This is why Damien saw just GPT Realtime and Gemini Live instead of the embargoed xAI S2S models (BENCH-593).

## What

Forward all query params through the `/` → `/overview` redirect. The arena redirects in `next.config.ts` already keep their query strings for exactly this reason; this brings the root redirect in line.

## Verification

- `curl -sI 'localhost:3100/?ea=abc123&foo=bar'` → `307` with `location: /overview?ea=abc123&foo=bar` (previously `location: /overview`).
- In the browser: landing on `/?ea=<token>` ends at `/overview` with the param stripped from the URL and the token stored under `coval-ea-token`, which every API request then sends as `X-EA-Token`.
- `tsc --noEmit`, eslint, and `runner/tests/api/test_early_access_scope.py` (18 passed) are green.

## Note for rollout

The fix only unlocks what the token is allowed to see: prod `EARLY_ACCESS_TOKENS` must map Damien's token to both `xai/grok-realtime` and `xai/grok-voice-think-fast-2.0`. After deploy he just re-opens the same link — nothing was stored on his first visit.