### PR TITLE
[BENCH-592] Keep previous conversation samples visible while paging dates

### DIFF
--- a/web/app/s2s/components/SampleOutputs.tsx
+++ b/web/app/s2s/components/SampleOutputs.tsx
@@ -285,7 +285,7 @@ export function SampleOutputs({
             const turns = item.turns ?? [];
             return (
               <div
-                key={item.provider}
+                key={item.audioPath}
                 role="listitem"
                 className={`flex w-[300px] min-w-[300px] shrink-0 snap-start flex-col gap-2 rounded-xl border bg-surface-elevated p-3 ${
                   active ? "" : "border-border-secondary"

--- a/web/app/s2s/components/SamplesCard.tsx
+++ b/web/app/s2s/components/SamplesCard.tsx
@@ -210,12 +210,18 @@ export function SamplesCard() {
     [displayedTick, selectS2SSample]
   );
 
-  // Hold the skeleton until every signed URL is in: a pane whose URL is still in
-  // flight would hand the shared audio element an empty src.
+  // Hold the previous panes until every signed URL is in: a pane whose URL is
+  // still in flight would hand the shared audio element an empty src.
+  const pendingUrls = recordings.length > 0 && audioUrls.isPending;
+  const lastReadyItems = useRef<SampleOutputItem[]>([]);
+  if (!pendingUrls) lastReadyItems.current = items;
+  const displayItems = pendingUrls ? lastReadyItems.current : items;
+  const transitioning = manifestQuery.isPlaceholderData || pendingUrls;
+
   const loading =
     indexQuery.isLoading ||
     (effectiveTick != null && manifestQuery.isLoading) ||
-    (recordings.length > 0 && audioUrls.isPending);
+    (pendingUrls && displayItems.length === 0);
 
   useEffect(() => {
     if (s2sPlayRequest?.source === "timeline") {
@@ -283,27 +289,32 @@ export function SamplesCard() {
         <p className="py-8 text-center text-sm text-text-tertiary">
           Samples are temporarily unavailable.
         </p>
-      ) : items.length === 0 ? (
+      ) : displayItems.length === 0 ? (
         <p className="py-8 text-center text-sm text-text-tertiary">
           {!manifest && s2sPlayRequest
             ? "No sample recorded for this point."
             : "Samples appear here after the next benchmark run."}
         </p>
       ) : (
-        <div className="flex flex-1 flex-col gap-4">
+        <div
+          aria-busy={transitioning}
+          className={`flex flex-1 flex-col gap-4 transition-opacity ${
+            transitioning ? "pointer-events-none opacity-50" : ""
+          }`}
+        >
           {requestedProviderMissing && requestedProvider ? (
             <p className="text-[11px] text-text-tertiary">
               No recording for {normalizeProviderName(requestedProvider)} at this point.
             </p>
           ) : null}
           <SampleOutputs
-            items={items}
+            items={displayItems}
             normalizeProvider={normalizeProviderName}
             onPlay={handlePlay}
             onSeeked={handleSeeked}
             onPlaybackEnded={handlePlaybackEnded}
             playRequest={
-              requestedItem && !manifestQuery.isPlaceholderData
+              requestedItem && !transitioning
                 ? { provider: requestedItem.provider, nonce: s2sPlayRequest!.nonce }
                 : null
             }


### PR DESCRIPTION
## Summary
- Paging the Conversation samples date arrows collapsed the card area to an empty grey block. The manifest query already keeps previous data, so the flash came one stage later: once the new manifest landed, the signed audio-URL queries went pending and the loading check swapped the whole list for the fixed `h-40` skeleton.
- The card now holds the last fully-ready panes on screen while the next tick's URLs are in flight, dimming the list to 50% with `pointer-events-none` and `aria-busy` during any transition (placeholder manifest or pending URLs). The skeleton only appears on true cold load, so height and surrounding layout never jump. Same path covers `Return to latest`.
- `playRequest` is now gated on the transition ending rather than only `isPlaceholderData`: with stale panes kept mounted, a timeline click landing in the URL-fetch window would otherwise match the previous tick's items and play the wrong day's audio.
- Sample panes are now keyed by `audioPath` instead of `provider`. xAI ships two S2S models, so keying by provider produced duplicate React keys, which corrupted list reconciliation: every filter click minted another identical `grok-realtime` card, `grok-voice-think-fast-2.0` never rendered as itself, and provider filtering appeared broken. The playback hook was already safe (its track identity includes `audioPath`).

## Testing
- Sampled the section every 100ms in the browser while paging `<` against live API data: height held at 614px throughout, no skeleton mounted, opacity animated 1 → 0.5 → 1, and the day label swapped in place. `Return to latest` swaps instantly from cache with zero layout shift.
- With all four live recordings (google, openai, xai ×2): six rapid filter clicks leave exactly 4 panes — no duplicates; selecting the OpenAI creator facet filters to `gpt-realtime` alone and clearing restores each model exactly once, including `grok-voice-think-fast-2.0` rendering as its own card.
- Playback after paging still works (audio gets a real signed URL and plays); console clean.
- `tsc --noEmit` passes.

Closes BENCH-592.