### PR TITLE
[BENCH-593] Fix comparison table overflow and pin its header

### DIFF
--- a/web/components/dashboard/ModelComparisonTable.tsx
+++ b/web/components/dashboard/ModelComparisonTable.tsx
@@ -186,10 +186,10 @@ const ModelComparisonTable: React.FC<ModelComparisonTableProps> = ({
           Swipe table for more →
         </p>
         <div className="overflow-x-auto">
-        <table className="w-full min-w-[560px] border-collapse text-sm">
+        <table className="w-full border-collapse text-sm">
           <thead>
             <tr className="border-b border-border-primary text-text-tertiary">
-              <th className="sticky left-0 z-10 bg-surface-elevated py-2 pr-4 text-left font-medium">Model</th>
+              <th className="w-px py-2 pr-4 text-left font-medium">Model</th>
               {columns.map((column) => (
                 <th
                   key={column.key}
@@ -233,8 +233,8 @@ const ModelComparisonTable: React.FC<ModelComparisonTableProps> = ({
                 key={row.model}
                 className="border-b border-border-secondary last:border-b-0 hover:bg-hover-bg"
               >
-                <td className="sticky left-0 z-[1] bg-surface-elevated py-3 pr-4 align-middle">
-                  <div className="flex items-center gap-1.5 font-medium text-text-primary">
+                <td className="py-3 pr-4 align-middle">
+                  <div className="flex items-center gap-1.5 whitespace-nowrap font-medium text-text-primary">
                     {normalizeModelName(row.model)}
                     {dedicatedModels?.has(row.model) && (
                       <button

--- a/web/components/dashboard/ModelComparisonTable.tsx
+++ b/web/components/dashboard/ModelComparisonTable.tsx
@@ -185,11 +185,11 @@ const ModelComparisonTable: React.FC<ModelComparisonTableProps> = ({
         <p className="mb-2 text-right text-xs text-text-tertiary sm:hidden">
           Swipe table for more →
         </p>
-        <div className="overflow-x-auto">
+        <div className="max-h-[70vh] overflow-auto">
         <table className="w-full border-collapse text-sm">
           <thead>
             <tr className="border-b border-border-primary text-text-tertiary">
-              <th className="w-px py-2 pr-4 text-left font-medium">Model</th>
+              <th className="sticky top-0 z-10 w-px bg-surface-elevated py-2 pr-4 text-left font-medium">Model</th>
               {columns.map((column) => (
                 <th
                   key={column.key}
@@ -200,7 +200,7 @@ const ModelComparisonTable: React.FC<ModelComparisonTableProps> = ({
                         : "descending"
                       : undefined
                   }
-                  className="px-3 py-2 text-right font-medium"
+                  className="sticky top-0 z-10 bg-surface-elevated px-3 py-2 text-right font-medium"
                 >
                   <button
                     type="button"


### PR DESCRIPTION
## Summary
- Unpin the model column so the comparison table scrolls its full width: model names render whole on one line, the column hugs the longest name (`w-px`), and the artificial `min-w-[560px]` floor is gone, so the horizontal scroll range always matches the real sum of column widths. Previously the un-capped sticky column ate most of the mobile viewport and its opaque cell covered the data columns even at max scroll (values clipped to "2 ms", headers cut mid-word).
- Pin the header row while scrolling rows: the table body scrolls vertically inside a `max-h-[70vh]` container with sticky header cells, so the column labels stay visible on the long TTS/STT tables. The short S2S table fits under the cap and renders as before.

Both changes are in `ModelComparisonTable`, shared by the TTS, S2S, and STT dashboards.

## Testing
- Verified in the browser at 375px and desktop widths on /tts, /stt, /s2s: full model names, latency values visible without swiping on S2S, every column fully readable within the swipe range, header pinned through simultaneous horizontal + vertical scroll.
- `tsc --noEmit` and `eslint` clean; no console errors.