### PR TITLE
Name the xAI S2S board key after its model version

### DIFF
--- a/runner/src/coval_bench/api/internal.py
+++ b/runner/src/coval_bench/api/internal.py
@@ -52,25 +52,33 @@ def never_shared(response: Response) -> None:
     response.headers["Cache-Control"] = "private, no-store"
 
 
-# Board keys an embargoed model used to be published under. Sample manifests
-# and result rows written before a rename still carry the old key, and the
-# embargo matches on the stored string, so dropping an entry here re-exposes
-# every recording and row published under that name. Retire one only once no
-# stored artefact can still name it.
-_RETIRED_EMBARGOED_KEYS: frozenset[tuple[str, str]] = frozenset(
-    {
-        ("xai", "grok-realtime"),
-    }
-)
+# Board keys an embargoed model used to be published under, mapped to the key it
+# uses now. Sample manifests and result rows written before a rename still carry
+# the old string and the embargo matches on what is stored, so a retired key stays
+# embargoed -- dropping an entry here re-exposes every artefact published under
+# that name. Retire one only once nothing stored can still name it.
+_RETIRED_BOARD_KEYS: dict[tuple[str, str], tuple[str, str]] = {
+    ("xai", "grok-realtime"): ("xai", "grok-voice-think-fast-1.0"),
+}
 
 
 def embargoed_pairs() -> frozenset[tuple[str, str]]:
     """Every ``(provider, model)`` pair currently under embargo."""
-    return (
-        frozenset(
-            (m.provider, m.model) for m in MODEL_REGISTRY if m.status is ModelStatus.EARLY_ACCESS
-        )
-        | _RETIRED_EMBARGOED_KEYS
+    return frozenset(
+        (m.provider, m.model) for m in MODEL_REGISTRY if m.status is ModelStatus.EARLY_ACCESS
+    ) | frozenset(_RETIRED_BOARD_KEYS)
+
+
+def with_retired_keys(allowed: frozenset[tuple[str, str]]) -> frozenset[tuple[str, str]]:
+    """Extend an allowlist to the retired keys of the models it already names.
+
+    An allowlist names models, not the strings they were once published under, so
+    clearing a caller for a model clears them for its history too. Without this a
+    rename would silently narrow every partner's view to artefacts written after
+    it, and each operator would have to know to list both keys by hand.
+    """
+    return allowed | frozenset(
+        retired for retired, current in _RETIRED_BOARD_KEYS.items() if current in allowed
     )
 
 
@@ -182,7 +190,7 @@ def hidden_early_access(
             return embargoed
         response.headers[EA_STATUS_HEADER] = "accepted"
         response.headers["Cache-Control"] = "private, no-store"
-        return embargoed - allowed
+        return embargoed - with_retired_keys(allowed)
 
     if x_ea_token is None:
         response.headers[EA_STATUS_HEADER] = "absent"
@@ -197,4 +205,4 @@ def hidden_early_access(
 
     response.headers[EA_STATUS_HEADER] = "accepted"
     response.headers["Cache-Control"] = "private, no-store"
-    return embargoed - allowed
+    return embargoed - with_retired_keys(allowed)

--- a/runner/src/coval_bench/api/internal.py
+++ b/runner/src/coval_bench/api/internal.py
@@ -52,10 +52,25 @@ def never_shared(response: Response) -> None:
     response.headers["Cache-Control"] = "private, no-store"
 
 
+# Board keys an embargoed model used to be published under. Sample manifests
+# and result rows written before a rename still carry the old key, and the
+# embargo matches on the stored string, so dropping an entry here re-exposes
+# every recording and row published under that name. Retire one only once no
+# stored artefact can still name it.
+_RETIRED_EMBARGOED_KEYS: frozenset[tuple[str, str]] = frozenset(
+    {
+        ("xai", "grok-realtime"),
+    }
+)
+
+
 def embargoed_pairs() -> frozenset[tuple[str, str]]:
     """Every ``(provider, model)`` pair currently under embargo."""
-    return frozenset(
-        (m.provider, m.model) for m in MODEL_REGISTRY if m.status is ModelStatus.EARLY_ACCESS
+    return (
+        frozenset(
+            (m.provider, m.model) for m in MODEL_REGISTRY if m.status is ModelStatus.EARLY_ACCESS
+        )
+        | _RETIRED_EMBARGOED_KEYS
     )
 
 

--- a/runner/src/coval_bench/config.py
+++ b/runner/src/coval_bench/config.py
@@ -173,8 +173,9 @@ class Settings(BaseSettings):
     internal_api_key: SecretStr | None = None
     # Partner early-access tokens (X-EA-Token header), as a JSON object mapping
     # each token to the "provider/model" entries that token may see under embargo:
-    # {"<token>": ["xai/grok-realtime"]}. The allowlist lives here, server-side,
-    # so a request carries only an opaque token and can never widen its own view.
+    # {"<token>": ["xai/grok-voice-think-fast-1.0"]}. The allowlist lives here,
+    # server-side, so a request carries only an opaque token and can never
+    # widen its own view.
     # Unset means no token unlocks anything.
     early_access_tokens: SecretStr | None = None
     # Clerk instance whose JWKS verifies provider-org session tokens.

--- a/runner/src/coval_bench/db/migrations/versions/20260803_0013_rename_xai_s2s_board_key.py
+++ b/runner/src/coval_bench/db/migrations/versions/20260803_0013_rename_xai_s2s_board_key.py
@@ -1,0 +1,55 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Rename the xAI S2S board key to name its model version.
+
+``grok-realtime`` carried no version while its sibling entry names one
+explicitly, so the two xAI rows read as unrelated products rather than as
+1.0 and 2.0 of the same one.
+
+``model`` is stored on every results row and is part of the
+``results_by_bucket`` primary key, so both tables are rewritten here.
+Rewriting only one would split the S2S timeline into two half-series, with
+the leaderboard and the timeline disagreeing about which key is live.
+
+The per-window matviews are deliberately not refreshed here: the runner
+refreshes them at the end of each benchmark run (see ``migrations/env.py``),
+and ``REFRESH ... CONCURRENTLY`` cannot run inside a migration's transaction.
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "20260803_0013"
+down_revision = "20260727_0012"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Point historical xAI S2S rows at the versioned key."""
+    op.execute(
+        "UPDATE benchmarks_v2.results "
+        "SET model = 'grok-voice-think-fast-1.0' "
+        "WHERE provider = 'xai' AND model = 'grok-realtime'"
+    )
+    op.execute(
+        "UPDATE benchmarks_v2.results_by_bucket "
+        "SET model = 'grok-voice-think-fast-1.0' "
+        "WHERE provider = 'xai' AND model = 'grok-realtime'"
+    )
+
+
+def downgrade() -> None:
+    """Restore the version-less key."""
+    op.execute(
+        "UPDATE benchmarks_v2.results "
+        "SET model = 'grok-realtime' "
+        "WHERE provider = 'xai' AND model = 'grok-voice-think-fast-1.0'"
+    )
+    op.execute(
+        "UPDATE benchmarks_v2.results_by_bucket "
+        "SET model = 'grok-realtime' "
+        "WHERE provider = 'xai' AND model = 'grok-voice-think-fast-1.0'"
+    )

--- a/runner/src/coval_bench/registries/models.py
+++ b/runner/src/coval_bench/registries/models.py
@@ -831,7 +831,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
     RegisteredModel(
         benchmark=_S2S,
         provider="xai",
-        model="grok-realtime",
+        model="grok-voice-think-fast-1.0",
         tags=(_STREAMING, _MULTI),
         status=_EARLY_ACCESS,
     ),

--- a/runner/src/coval_bench/s2s/fetch_v2v.py
+++ b/runner/src/coval_bench/s2s/fetch_v2v.py
@@ -69,7 +69,11 @@ class CovalRun:
 AGENTS: tuple[AgentSpec, ...] = (
     AgentSpec(agent_id_attr="coval_s2s_openai_agent_id", provider="openai", model="gpt-realtime"),
     AgentSpec(agent_id_attr="coval_s2s_gemini_agent_id", provider="google", model="gemini-live"),
-    AgentSpec(agent_id_attr="coval_s2s_xai_agent_id", provider="xai", model="grok-realtime"),
+    AgentSpec(
+        agent_id_attr="coval_s2s_xai_agent_id",
+        provider="xai",
+        model="grok-voice-think-fast-1.0",
+    ),
     AgentSpec(
         agent_id_attr="coval_s2s_xai_think_fast_2_agent_id",
         provider="xai",

--- a/runner/tests/api/test_early_access_scope.py
+++ b/runner/tests/api/test_early_access_scope.py
@@ -110,6 +110,21 @@ def test_retired_board_keys_stay_embargoed() -> None:
     assert ("xai", "grok-voice-think-fast-1.0") in embargoed_pairs()
 
 
+def test_token_for_a_renamed_model_also_sees_its_history(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Clearing a partner for a model clears them for its pre-rename artefacts.
+
+    An allowlist names models, not the strings they were once published under, so
+    a token listing only the current key must still reach the manifests that name
+    the old one -- otherwise a rename silently narrows what that partner can see.
+    """
+    settings = _settings(monkeypatch, {_TOKEN: ["xai/grok-voice-think-fast-1.0"]})
+    hidden = _hidden(settings, token=_TOKEN)
+    assert ("xai", "grok-voice-think-fast-1.0") not in hidden
+    assert ("xai", "grok-realtime") not in hidden
+
+
 def test_no_token_hides_every_embargoed_model(monkeypatch: pytest.MonkeyPatch) -> None:
     settings = _settings(monkeypatch, {_TOKEN: []})
     hidden, status = _resolve(settings, token=None)

--- a/runner/tests/api/test_early_access_scope.py
+++ b/runner/tests/api/test_early_access_scope.py
@@ -99,6 +99,17 @@ def _entry(pair: tuple[str, str]) -> str:
     return f"{pair[0]}/{pair[1]}"
 
 
+def test_retired_board_keys_stay_embargoed() -> None:
+    """A renamed embargoed model keeps hiding artefacts stored under its old key.
+
+    Sample manifests and result rows written before the rename still carry the
+    old string, and the embargo matches on what is stored -- so losing the old
+    key would publish every recording and row published under that name.
+    """
+    assert ("xai", "grok-realtime") in embargoed_pairs()
+    assert ("xai", "grok-voice-think-fast-1.0") in embargoed_pairs()
+
+
 def test_no_token_hides_every_embargoed_model(monkeypatch: pytest.MonkeyPatch) -> None:
     settings = _settings(monkeypatch, {_TOKEN: []})
     hidden, status = _resolve(settings, token=None)

--- a/runner/tests/unit/test_s2s_sample_store.py
+++ b/runner/tests/unit/test_s2s_sample_store.py
@@ -16,7 +16,7 @@ from coval_bench.s2s.samples import audio_object_key, load_sample, load_sample_i
 _BUCKET = "coval-benchmarks-s2s-samples"
 _SAMPLE = "2026-07-30T00:00:00Z"
 _MANIFEST_KEY = f"s2s-samples/{_SAMPLE}/manifest.json"
-_HIDDEN = frozenset({("xai", "grok-realtime")})
+_HIDDEN = frozenset({("xai", "grok-voice-think-fast-1.0")})
 
 
 def _recording(provider: str, model: str) -> dict[str, Any]:
@@ -64,7 +64,7 @@ def test_load_sample_strips_hidden_recordings() -> None:
     client = _FakeClient(
         {
             _MANIFEST_KEY: _manifest(
-                _recording("openai", "gpt-realtime"), _recording("xai", "grok-realtime")
+                _recording("openai", "gpt-realtime"), _recording("xai", "grok-voice-think-fast-1.0")
             )
         }
     )
@@ -78,7 +78,7 @@ def test_load_sample_strips_hidden_recordings() -> None:
 
 
 def test_load_sample_hidden_recording_takes_its_transcript_with_it() -> None:
-    client = _FakeClient({_MANIFEST_KEY: _manifest(_recording("xai", "grok-realtime"))})
+    client = _FakeClient({_MANIFEST_KEY: _manifest(_recording("xai", "grok-voice-think-fast-1.0"))})
 
     sample = load_sample(_BUCKET, _SAMPLE, hidden=_HIDDEN, storage_client=client)
 
@@ -91,7 +91,7 @@ def test_load_sample_keeps_everything_for_an_unrestricted_caller() -> None:
     client = _FakeClient(
         {
             _MANIFEST_KEY: _manifest(
-                _recording("openai", "gpt-realtime"), _recording("xai", "grok-realtime")
+                _recording("openai", "gpt-realtime"), _recording("xai", "grok-voice-think-fast-1.0")
             )
         }
     )
@@ -189,10 +189,10 @@ def test_audio_object_key_returns_the_stored_path() -> None:
 
 
 def test_audio_object_key_refuses_a_hidden_model() -> None:
-    client = _FakeClient({_MANIFEST_KEY: _manifest(_recording("xai", "grok-realtime"))})
+    client = _FakeClient({_MANIFEST_KEY: _manifest(_recording("xai", "grok-voice-think-fast-1.0"))})
 
     key = audio_object_key(
-        _BUCKET, _SAMPLE, "xai", "grok-realtime", hidden=_HIDDEN, storage_client=client
+        _BUCKET, _SAMPLE, "xai", "grok-voice-think-fast-1.0", hidden=_HIDDEN, storage_client=client
     )
 
     assert key is None

--- a/web/lib/utils/formatters.ts
+++ b/web/lib/utils/formatters.ts
@@ -141,7 +141,7 @@ export function normalizeModelName(modelKey: string): string {
     // S2S
     "gpt-realtime": "GPT Realtime 2",
     "gemini-live": "Gemini 3.1 Flash Live (Preview)",
-    "grok-realtime": "Grok Realtime",
+    "grok-voice-think-fast-1.0": "Grok Voice Think Fast 1.0",
     "grok-voice-think-fast-2.0": "Grok Voice Think Fast 2.0",
     default: "Default",
     enhanced: "Enhanced"


### PR DESCRIPTION
`grok-realtime` carried no version while its sibling xAI entry names one, so the two S2S rows read as unrelated products rather than 1.0 and 2.0 of the same one.

`model` lives on every results row and in the `results_by_bucket` primary key, so migration 0013 rewrites both — rewriting one would split the timeline into two half-series.

The embargo matches on the stored string, and manifests already in the bucket still carry the old key, so the old key stays in the embargoed set. Without that, every xAI recording published so far would have gone public on deploy. Both xAI models remain `EARLY_ACCESS`.

Before merging: add the new key to any partner EA token listing `xai/grok-realtime` (Secret Manager, via gcloud), and confirm that agent is really pinned to think-fast-1.0 — if it is on `grok-voice-latest` it became 2.0 on Aug 5 and this would relabel those rows wrongly. `db migrate` is manual, so the rename and the data rewrite need running together.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR renames the xAI S2S 1.0 board key while preserving the retired key’s embargo.
- Updates the model registry, S2S agent mapping, frontend label, and affected tests.
- Adds a migration rewriting historical result and bucket rows to the versioned key.
- Retains the old key in the embargo set for unmigrated stored artifacts.

<h3>Confidence Score: 4/5</h3>

The early-access token guidance should be corrected before merging because following it removes partner access to historical xAI recordings.

Authorization matches stored model keys exactly, but the revised example grants only the new key even though old sample manifests remain embargoed under grok-realtime.

**Files Needing Attention:** runner/src/coval_bench/config.py

<sub>Reviews (1): Last reviewed commit: ["Name the xAI S2S board key after its mod..."](https://github.com/coval-ai/benchmarks/commit/3efc935542ada5eb4a69eee3a28f2ff1705f9fb9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49860637)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->