### PR TITLE
Record a reason when a provider stream ends with no output

### DIFF
--- a/runner/src/coval_bench/providers/tts/_common.py
+++ b/runner/src/coval_bench/providers/tts/_common.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import os
 import tempfile
 import wave
+from collections.abc import Sequence
 from pathlib import Path
 
 import structlog
@@ -19,6 +20,10 @@ logger: structlog.BoundLogger = structlog.get_logger(__name__)
 
 # Mono signed 16-bit PCM: 2 bytes per sample.
 _PCM16_FRAME_BYTES = 2
+
+# Stable contract — matched by the reason classifier and the alerting log metric.
+_SILENT_FAILURE_PREFIX = "provider closed the stream without sending audio or an error"
+_LAST_FRAMES_MAX_CHARS = 400
 
 
 def finalize_tts_result(
@@ -34,6 +39,7 @@ def finalize_tts_result(
     http_version: str | None = None,
     submit_to_headers_ms: float | None = None,
     connection_reused: bool | None = None,
+    last_frames: Sequence[str] | None = None,
 ) -> TTSResult:
     """Build a TTSResult with perceived TTFA from assembled PCM and timing.
 
@@ -47,6 +53,16 @@ def finalize_tts_result(
     the final stream frame) is dropped, and any failure in offset detection is
     swallowed and degrades TTFA to arrival-only — the WAV is still written either
     way.
+
+    Empty ``pcm`` with no ``error`` is never a success: it means the receive loop
+    ended without synthesising anything and without recognising why. Every provider
+    reaches its final ``finalize_tts_result`` by falling out of that loop, so
+    without this guard an error frame the provider *did* send but the integration
+    failed to match is discarded, and the row lands on the orchestrator's generic
+    "no TTFA produced". Naming the state here is what keeps it diagnosable, for
+    every provider at once. ``last_frames`` carries the last non-audio frames seen,
+    when the caller retains them, so the provider's own wording survives even
+    though its schema was never matched.
     """
     # Drop a dangling partial sample so neither offset detection (which rejects
     # frame-misaligned PCM) nor the WAV header chokes on a split final frame.
@@ -70,6 +86,9 @@ def finalize_tts_result(
         )
 
     audio_path = _write_wav(pcm, sample_rate) if pcm else None
+    if not pcm and error is None:
+        error = _silent_failure_error(last_frames)
+        logger.warning("tts_silent_failure", provider=provider, model=model, error=error)
     return TTSResult(
         provider=provider,
         model=model,
@@ -81,6 +100,22 @@ def finalize_tts_result(
         submit_to_headers_ms=submit_to_headers_ms,
         connection_reused=connection_reused,
     )
+
+
+def _silent_failure_error(last_frames: Sequence[str] | None) -> str:
+    """Diagnostic for a stream that ended with no audio and no reported error.
+
+    The prefix is a stable contract: the reason classifier and the Cloud Logging
+    metric both match on it, so it must not be reworded casually. When the caller
+    retained trailing frames they are appended verbatim — that text is the
+    provider's own explanation, which is exactly what an unmatched schema loses.
+    """
+    if not last_frames:
+        return _SILENT_FAILURE_PREFIX
+    tail = " | ".join(frame.strip() for frame in last_frames if frame.strip())
+    if not tail:
+        return _SILENT_FAILURE_PREFIX
+    return f"{_SILENT_FAILURE_PREFIX}; last frames: {tail[:_LAST_FRAMES_MAX_CHARS]}"
 
 
 def _safe_offset_ms(pcm: bytes, sample_rate: int, provider: str, model: str) -> float | None:

--- a/runner/src/coval_bench/providers/tts/hume.py
+++ b/runner/src/coval_bench/providers/tts/hume.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import asyncio
 import json
 import time
+from typing import Any
 from urllib.parse import urlencode
 
 import structlog
@@ -29,6 +30,31 @@ _WS_SESSION_TIMEOUT_S = 30.0
 _MODEL_TO_VERSION: dict[str, str] = {"octave-tts": "1", "octave-2": "2"}
 
 _DEFAULT_VOICE_ID = "176a55b1-4468-4736-8878-db82729667c1"
+
+# How many trailing text frames to retain for the silent-stream diagnostic.
+_LAST_FRAMES_KEPT = 3
+
+
+def _frame_error(msg: dict[str, Any]) -> str | None:
+    """Hume's error text for an error frame, or ``None`` when the frame is benign.
+
+    Hume nests the discriminator under ``details`` and sends no top-level ``type``,
+    so the original top-level check never matched and every error frame was dropped —
+    including "Exhausted credit balance", stated on every request for four and a half
+    days. ``status_code`` is checked too so an error shape we haven't seen still
+    registers rather than being silently ignored.
+    """
+    details = msg.get("details")
+    nested_type = details.get("type") if isinstance(details, dict) else None
+    status_code = msg.get("status_code")
+    is_error = (
+        msg.get("type") == "error"
+        or nested_type == "error"
+        or (isinstance(status_code, int) and status_code >= 400)
+    )
+    if not is_error:
+        return None
+    return str(msg.get("message") or msg)
 
 
 class HumeTTSProvider(TTSProvider):
@@ -72,6 +98,7 @@ class HumeTTSProvider(TTSProvider):
         version = _MODEL_TO_VERSION[self._model]
 
         audio_chunks: list[bytes] = []
+        last_frames: list[str] = []
         start: float | None = None
         first_chunk_at: float | None = None
 
@@ -111,12 +138,15 @@ class HumeTTSProvider(TTSProvider):
                                 first_chunk_at = time.monotonic()
                             audio_chunks.append(raw)
                         elif isinstance(raw, str):
+                            last_frames.append(raw)
+                            del last_frames[:-_LAST_FRAMES_KEPT]
                             try:
                                 msg = json.loads(raw)
-                                if msg.get("type") == "error":
-                                    raise RuntimeError(str(msg.get("message", msg)))
-                            except (json.JSONDecodeError, KeyError):
-                                pass
+                            except json.JSONDecodeError:
+                                continue
+                            failure = _frame_error(msg)
+                            if failure is not None:
+                                raise RuntimeError(failure)
 
         except TimeoutError:
             logger.warning(
@@ -133,6 +163,7 @@ class HumeTTSProvider(TTSProvider):
                 sample_rate=SAMPLE_RATE,
                 audio_synthesis_start=start,
                 first_audio_chunk_at=first_chunk_at,
+                last_frames=last_frames,
                 error=f"Hume WebSocket session timed out after {_WS_SESSION_TIMEOUT_S}s",
             )
 
@@ -146,6 +177,7 @@ class HumeTTSProvider(TTSProvider):
                 sample_rate=SAMPLE_RATE,
                 audio_synthesis_start=start,
                 first_audio_chunk_at=first_chunk_at,
+                last_frames=last_frames,
                 error=str(exc),
             )
 
@@ -157,4 +189,5 @@ class HumeTTSProvider(TTSProvider):
             sample_rate=SAMPLE_RATE,
             audio_synthesis_start=start,
             first_audio_chunk_at=first_chunk_at,
+            last_frames=last_frames,
         )

--- a/runner/src/coval_bench/runner/orchestrator.py
+++ b/runner/src/coval_bench/runner/orchestrator.py
@@ -73,6 +73,10 @@ _CONCURRENCY_CAP = 8
 _DEDICATED_CONCURRENCY_CAP = 1
 _STT_TIMEOUT_S = 45
 _TTS_TIMEOUT_S = 60
+# Stable contract — matched by the reason classifier and the alerting log metric.
+# Mirrors _SILENT_FAILURE_PREFIX in providers/tts/_common.py.
+_STT_SILENT_FAILURE = "provider closed the stream without sending a transcript or an error"
+
 _MAX_ERROR_LEN = 4000  # truncate error messages stored in DB (Postgres text is unbounded
 # but huge stack traces choke log pipelines)
 
@@ -126,6 +130,26 @@ def _metric_outcome(
     if metric_value is None:
         return result_status.FAILED, f"no {metric_label} produced"
     return result_status.SUCCESS, None
+
+
+def _stt_silent_failure(result: Any) -> str | None:  # noqa: ANN401 — TranscriptionResult
+    """Diagnostic when a provider returned nothing at all and reported no reason.
+
+    The STT mirror of the TTS guard in ``providers/tts/_common.py``: every streaming
+    provider reaches its return by falling out of the receive loop, so an error frame
+    whose schema the integration failed to match leaves ``error`` unset and the row
+    lands on a generic "no <METRIC> produced".
+
+    Deliberately narrower than the TTS guard. A provider can deliver a final segment
+    with empty text, which still yields a legitimate TTFT/AudioToFinal measurement —
+    failing the item on an empty transcript alone would discard real latency data and
+    shrink sample counts. So this fires only when nothing whatsoever was produced.
+    """
+    if result.complete_transcript or result.partial_transcripts:
+        return None
+    if result.ttft_seconds is not None or result.audio_to_final_seconds is not None:
+        return None
+    return _STT_SILENT_FAILURE
 
 
 def _log_item_failures(
@@ -318,6 +342,8 @@ async def _run_stt_item(
         item_error = item_error or (
             transcription_result.error if transcription_result is not None else None
         )
+        if transcription_result is not None and item_error is None:
+            item_error = _stt_silent_failure(transcription_result)
         ttft_seconds = transcription_result.ttft_seconds if transcription_result else None
         audio_to_final = (
             transcription_result.audio_to_final_seconds if transcription_result else None

--- a/runner/tests/providers/tts/test_azure.py
+++ b/runner/tests/providers/tts/test_azure.py
@@ -201,7 +201,7 @@ async def test_azure_tts_skips_empty_audio_frames(fake_settings: Settings) -> No
     with patch("coval_bench.providers.tts.azure.ws_client.connect", return_value=ws):
         result = await provider.synthesize("Hello")
 
-    assert result.error is None
+    assert result.error == ("provider closed the stream without sending audio or an error")
     assert result.audio_path is None
     assert result.ttfa_ms is None
 

--- a/runner/tests/providers/tts/test_cartesia.py
+++ b/runner/tests/providers/tts/test_cartesia.py
@@ -76,7 +76,7 @@ async def test_cartesia_no_audio_chunks(fake_settings: Settings) -> None:
     with patch("coval_bench.providers.tts.cartesia.AsyncCartesia", return_value=fake_client):
         result = await provider.synthesize("silence test")
 
-    assert result.error is None
+    assert result.error == ("provider closed the stream without sending audio or an error")
     assert result.audio_path is None
     assert result.ttfa_ms is None
 

--- a/runner/tests/providers/tts/test_deepgram.py
+++ b/runner/tests/providers/tts/test_deepgram.py
@@ -131,7 +131,7 @@ async def test_deepgram_no_audio_chunks(fake_settings: Settings) -> None:
     ):
         result = await provider.synthesize("silent test")
 
-    assert result.error is None
+    assert result.error == ("provider closed the stream without sending audio or an error")
     assert result.audio_path is None
     assert result.ttfa_ms is None
 

--- a/runner/tests/providers/tts/test_elevenlabs.py
+++ b/runner/tests/providers/tts/test_elevenlabs.py
@@ -149,7 +149,7 @@ async def test_elevenlabs_empty_response(fake_settings: Settings) -> None:
     provider = ElevenLabsTTSProvider(fake_settings, model="eleven_flash_v2_5", voice="v")
     result = await provider.synthesize("silence")
 
-    assert result.error is None
+    assert result.error == ("provider closed the stream without sending audio or an error")
     assert result.audio_path is None
     assert result.ttfa_ms is None
 

--- a/runner/tests/providers/tts/test_gradium.py
+++ b/runner/tests/providers/tts/test_gradium.py
@@ -192,7 +192,7 @@ async def test_gradium_empty_response(fake_settings: Settings) -> None:
     ):
         result = await provider.synthesize("silence")
 
-    assert result.error is None
+    assert result.error == ("provider closed the stream without sending audio or an error")
     assert result.audio_path is None
     assert result.ttfa_ms is None
 

--- a/runner/tests/providers/tts/test_hume.py
+++ b/runner/tests/providers/tts/test_hume.py
@@ -177,7 +177,7 @@ async def test_hume_empty_response(fake_settings: Settings) -> None:
     with patch("coval_bench.providers.tts.hume.ws_client.connect", return_value=ws):
         result = await provider.synthesize("silence")
 
-    assert result.error is None
+    assert result.error == ("provider closed the stream without sending audio or an error")
     assert result.audio_path is None
     assert result.ttfa_ms is None
 
@@ -216,7 +216,7 @@ async def test_hume_empty_chunk_not_counted(fake_settings: Settings) -> None:
     with patch("coval_bench.providers.tts.hume.ws_client.connect", return_value=ws):
         result = await provider.synthesize("empty chunk")
 
-    assert result.error is None
+    assert result.error == ("provider closed the stream without sending audio or an error")
     assert result.audio_path is None
     assert result.ttfa_ms is None
 

--- a/runner/tests/providers/tts/test_hume.py
+++ b/runner/tests/providers/tts/test_hume.py
@@ -305,3 +305,58 @@ def test_hume_missing_api_key() -> None:
     )
     with pytest.raises(ValueError, match="hume_api_key"):
         HumeTTSProvider(settings_no_key, model="octave-tts", voice="v")
+
+
+# ---------------------------------------------------------------------------
+# Error-frame recognition (BENCH-589)
+# ---------------------------------------------------------------------------
+
+_ZERO_CREDITS_FRAME = json.dumps(
+    {
+        "status_code": 400,
+        "message": (
+            "Exhausted credit balance. Visit platform.hume.ai/billing to manage your account."
+        ),
+        "details": {"type": "error", "code": "E0300", "slug": "zero_credits"},
+    }
+)
+
+
+@pytest.mark.asyncio
+async def test_hume_zero_credits_frame_surfaces_its_message(fake_settings: Settings) -> None:
+    """Hume's real error frame reaches ``result.error`` verbatim.
+
+    The live frame nests the discriminator under ``details`` and carries no top-level
+    ``type``, so the original check never matched and this message — stated on every
+    request for four and a half days — was discarded on every one of them.
+    """
+    ws = FakeWebSocket([_ZERO_CREDITS_FRAME])
+    provider = HumeTTSProvider(fake_settings, model="octave-2", voice="v")
+
+    with patch("coval_bench.providers.tts.hume.ws_client.connect", return_value=ws):
+        result = await provider.synthesize("hello")
+
+    assert result.error is not None
+    assert "Exhausted credit balance" in result.error
+    assert result.ttfa_ms is None
+    assert result.audio_path is None
+
+
+@pytest.mark.asyncio
+async def test_hume_unrecognised_frame_is_quoted_in_the_silent_reason(
+    fake_settings: Settings,
+) -> None:
+    """A shape we don't classify still survives, via the retained trailing frames.
+
+    The safety net for the next schema change: even with no matching rule, the
+    provider's own words reach the row instead of a bare generic reason.
+    """
+    ws = FakeWebSocket([json.dumps({"somethingNew": "quota drained, contact billing"})])
+    provider = HumeTTSProvider(fake_settings, model="octave-2", voice="v")
+
+    with patch("coval_bench.providers.tts.hume.ws_client.connect", return_value=ws):
+        result = await provider.synthesize("hello")
+
+    assert result.error is not None
+    assert result.error.startswith("provider closed the stream without sending audio or an error")
+    assert "quota drained, contact billing" in result.error

--- a/runner/tests/providers/tts/test_inworld.py
+++ b/runner/tests/providers/tts/test_inworld.py
@@ -189,7 +189,7 @@ async def test_inworld_empty_audio(fake_settings: Settings) -> None:
         provider = InworldTTSProvider(fake_settings, model="inworld-tts-1.5-max", voice="Ashley")
         result = await provider.synthesize("silence")
 
-    assert result.error is None
+    assert result.error == ("provider closed the stream without sending audio or an error")
     assert result.audio_path is None
     assert result.ttfa_ms is None
 

--- a/runner/tests/providers/tts/test_rime.py
+++ b/runner/tests/providers/tts/test_rime.py
@@ -266,7 +266,7 @@ async def test_rime_empty_response(fake_settings: Settings) -> None:
     ):
         result = await provider.synthesize("silent test")
 
-    assert result.error is None
+    assert result.error == ("provider closed the stream without sending audio or an error")
     assert result.audio_path is None
     assert result.ttfa_ms is None
 
@@ -332,7 +332,7 @@ async def test_rime_empty_chunk_not_counted(fake_settings: Settings) -> None:
     with patch("coval_bench.providers.tts.rime.ws_client.connect", return_value=_fake_connect(ws)):
         result = await provider.synthesize("test")
 
-    assert result.error is None
+    assert result.error == ("provider closed the stream without sending audio or an error")
     # If the `if audio_bytes:` guard is removed, first_chunk_at gets stamped on the
     # empty chunk, so ttfa_ms is computed (non-None) — the assertion below would fail.
     assert result.ttfa_ms is None

--- a/runner/tests/providers/tts/test_smallest.py
+++ b/runner/tests/providers/tts/test_smallest.py
@@ -96,7 +96,7 @@ async def test_smallest_empty_audio(fake_settings: Settings) -> None:
         provider = SmallestTTSProvider(fake_settings, model="lightning_v3.1_pro", voice="kaitlyn")
         result = await provider.synthesize("silence")
 
-    assert result.error is None
+    assert result.error == ("provider closed the stream without sending audio or an error")
     assert result.audio_path is None
     assert result.ttfa_ms is None
 

--- a/runner/tests/providers/tts/test_soniox.py
+++ b/runner/tests/providers/tts/test_soniox.py
@@ -206,7 +206,7 @@ async def test_soniox_tts_skips_empty_audio(fake_settings: Settings) -> None:
     ):
         result = await provider.synthesize("Hello")
 
-    assert result.error is None
+    assert result.error == ("provider closed the stream without sending audio or an error")
     assert result.audio_path is None
     assert result.ttfa_ms is None
 

--- a/runner/tests/providers/tts/test_speechify.py
+++ b/runner/tests/providers/tts/test_speechify.py
@@ -143,7 +143,7 @@ async def test_speechify_empty_response() -> None:
     provider = SpeechifyTTSProvider(_settings(), model="simba-3.2", voice=_VOICE)
     result = await provider.synthesize("silence")
 
-    assert result.error is None
+    assert result.error == ("provider closed the stream without sending audio or an error")
     assert result.audio_path is None
     assert result.ttfa_ms is None
 

--- a/runner/tests/providers/tts/test_xai.py
+++ b/runner/tests/providers/tts/test_xai.py
@@ -186,7 +186,7 @@ async def test_xai_tts_skips_empty_audio_delta(fake_settings: Settings) -> None:
     ):
         result = await provider.synthesize("Hello")
 
-    assert result.error is None
+    assert result.error == ("provider closed the stream without sending audio or an error")
     assert result.audio_path is None
     assert result.ttfa_ms is None
 

--- a/runner/tests/unit/test_orchestrator.py
+++ b/runner/tests/unit/test_orchestrator.py
@@ -44,7 +44,7 @@ from coval_bench.config import Settings
 from coval_bench.db.models import Benchmark, Result, ResultStatus, Run, RunStatus
 from coval_bench.providers.base import TranscriptionResult, TTSResult
 from coval_bench.registries import MODEL_REGISTRY, ModelStatus, RegisteredModel, Source
-from coval_bench.runner.orchestrator import RunSummary, run_benchmarks
+from coval_bench.runner.orchestrator import RunSummary, _stt_silent_failure, run_benchmarks
 from coval_bench.runner.retry import with_retry
 
 # ---------------------------------------------------------------------------
@@ -1633,7 +1633,9 @@ async def test_stt_empty_result_marked_failed(audio_file: Path, settings: Settin
     for mt in ("TTFT", "AudioToFinal", "RTF"):
         assert by_metric[mt].status == ResultStatus.FAILED
         error = by_metric[mt].error
-        assert error is not None and "produced" in error
+        # A silent return is diagnosed as such, not left on the generic
+        # "no <METRIC> produced" fallback that hides an unmatched error frame.
+        assert error == "provider closed the stream without sending a transcript or an error"
     assert "WER" not in by_metric  # no transcript → no WER row
     assert summary.success_count == 0
     assert summary.status == str(RunStatus.FAILED)
@@ -2098,7 +2100,10 @@ async def test_stt_empty_result_logs_item_failure(audio_file: Path, settings: Se
     assert event["item"] == "0001.wav"
     # Every silent FAILED metric is carried with its reason.
     assert {"TTFT", "AudioToFinal", "RTF"} <= set(event["reasons"])
-    assert all("produced" in reason for reason in event["reasons"].values())
+    assert all(
+        reason == "provider closed the stream without sending a transcript or an error"
+        for reason in event["reasons"].values()
+    )
 
 
 @pytest.mark.asyncio
@@ -2449,3 +2454,46 @@ async def test_posthog_capture_failure_does_not_fail_run(
 
     assert summary.status == str(RunStatus.SUCCEEDED)
     fake.capture.assert_called_once()
+
+
+def test_stt_silent_failure_stamps_a_reason_when_nothing_was_produced() -> None:
+    """Nothing at all returned and no reason given → a diagnostic replaces the generic row.
+
+    The STT mirror of the TTS guard: an error frame whose schema the integration failed
+    to match leaves ``error`` unset, and the row would otherwise read "no TTFS produced".
+    """
+    result = TranscriptionResult(provider="assemblyai")
+
+    assert (
+        _stt_silent_failure(result)
+        == "provider closed the stream without sending a transcript or an error"
+    )
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("ttft_seconds", 0.4),
+        ("audio_to_final_seconds", 1.2),
+        ("complete_transcript", "hello"),
+    ],
+)
+def test_stt_silent_failure_ignores_a_result_that_produced_something(
+    field: str, value: object
+) -> None:
+    """Any real measurement means the item is not a silent failure.
+
+    Deliberately narrow: a provider can send a final segment with empty text, which
+    still yields a valid TTFT/AudioToFinal. Failing the item on an empty transcript
+    alone would discard real latency data and shrink sample counts.
+    """
+    result = TranscriptionResult(provider="deepgram", **{field: value})  # type: ignore[arg-type]
+
+    assert _stt_silent_failure(result) is None
+
+
+def test_stt_silent_failure_ignores_partials_only() -> None:
+    """Partial transcripts arrived, so the stream was not silent."""
+    result = TranscriptionResult(provider="together", partial_transcripts=["par"])
+
+    assert _stt_silent_failure(result) is None

--- a/runner/tests/unit/test_tts_common.py
+++ b/runner/tests/unit/test_tts_common.py
@@ -162,7 +162,11 @@ def test_finalize_offset_failure_falls_back_and_writes_wav() -> None:
 
 
 def test_finalize_no_audio_returns_none() -> None:
-    """No audio (first_audio_chunk_at unset) → ttfa None, no WAV."""
+    """No audio (first_audio_chunk_at unset) → ttfa None, no WAV, and a stamped reason.
+
+    Empty pcm with no error is a silent failure, not a success: the provider's receive
+    loop ended without synthesising anything and without recognising why.
+    """
     result = finalize_tts_result(
         provider="test",
         model="m",
@@ -175,4 +179,64 @@ def test_finalize_no_audio_returns_none() -> None:
 
     assert result.ttfa_ms is None
     assert result.audio_path is None
+    assert result.error == "provider closed the stream without sending audio or an error"
+
+
+def test_finalize_silent_failure_quotes_last_frames() -> None:
+    """Retained frames are appended verbatim, so an unmatched schema still explains itself.
+
+    This is the Hume case: it sent a plain-English billing message under a key the
+    integration didn't match. The wording must survive without provider-specific code.
+    """
+    hume_frame = (
+        '{"status_code":400,"message":"Exhausted credit balance.",'
+        '"details":{"type":"error","code":"E0300","slug":"zero_credits"}}'
+    )
+    result = finalize_tts_result(
+        provider="hume",
+        model="octave-2",
+        voice="v",
+        pcm=b"",
+        sample_rate=24000,
+        audio_synthesis_start=10.0,
+        first_audio_chunk_at=None,
+        last_frames=[hume_frame],
+    )
+
+    assert result.error is not None
+    assert result.error.startswith("provider closed the stream without sending audio or an error")
+    assert "Exhausted credit balance." in result.error
+
+
+def test_finalize_does_not_override_a_reported_error() -> None:
+    """A provider that did report a reason keeps its own wording."""
+    result = finalize_tts_result(
+        provider="test",
+        model="m",
+        voice="v",
+        pcm=b"",
+        sample_rate=24000,
+        audio_synthesis_start=None,
+        first_audio_chunk_at=None,
+        error="rate limited",
+        last_frames=["ignored"],
+    )
+
+    assert result.error == "rate limited"
+
+
+def test_finalize_successful_audio_is_untouched() -> None:
+    """Audio present → the guard stays out of the way."""
+    sr = 24000
+    result = finalize_tts_result(
+        provider="test",
+        model="m",
+        voice="v",
+        pcm=_tone_pcm(200, sr),
+        sample_rate=sr,
+        audio_synthesis_start=10.0,
+        first_audio_chunk_at=10.2,
+    )
+
     assert result.error is None
+    assert result.audio_path is not None


### PR DESCRIPTION
Every streaming provider reached its success path by falling out of the receive loop, so an error frame we failed to match was dropped and the row read `no TTFA produced`. All 21 TTS providers passed no error argument there, and 14 test suites asserted that as correct.

Guards both modalities at their shared finalize point rather than per provider. The STT mirror is narrower — it fires only when nothing at all was produced, since a final with empty text still yields a valid latency point.

Also fixes Hume itself, which is the case that exposed this: it nests the discriminator under `details` and sends no top-level `type`, so `hume.py` never matched and "Exhausted credit balance" was discarded on every request for four and a half days. It now matches the real shape, falls back to `status_code` for shapes we have not seen, and retains its trailing frames so an unrecognised frame still reaches the row. Two provider-level tests assert the message survives end to end.

Clean closes that arrive as exceptions (`received 1000 (OK)`) are a separate follow-up.