### PR TITLE
Alert when a run fails outright or a provider fails everything it runs

### DIFF
--- a/runner/src/coval_bench/runner/orchestrator.py
+++ b/runner/src/coval_bench/runner/orchestrator.py
@@ -41,6 +41,7 @@ import importlib
 import random
 import signal
 import wave
+from collections import Counter, defaultdict
 from datetime import UTC, datetime  # noqa: UP017 — UTC alias requires 3.11+, target is 3.12
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
@@ -49,7 +50,7 @@ import structlog
 from posthog import Posthog
 from pydantic import BaseModel
 
-from coval_bench.logging import log_run_failed
+from coval_bench.logging import log_run_failed, log_run_partial
 from coval_bench.providers._http_session import close_all as _close_http_clients
 from coval_bench.providers.base import Provider
 from coval_bench.registries import (
@@ -153,6 +154,69 @@ def _log_item_failures(
     }
     if reasons:
         logger.warning(event, provider=provider, model=model, item=item, reasons=reasons)
+
+
+def _dead_providers(
+    results: list[Any],
+    result_status: Any,  # noqa: ANN401 — ResultStatus enum, lazy-imported by callers
+) -> list[str]:
+    """``benchmark:provider/model (reason)`` for each provider whose every row failed.
+
+    Keyed by benchmark as well as provider and model: openai and xai are registered
+    under both TTS and STT, so keying on the provider alone would let a dead TTS model
+    be masked by the same provider's healthy STT rows. The reason is the most common
+    error across that provider's rows, so the alert names a cause and not just a name.
+    """
+    rows: dict[tuple[str, str, str], list[Any]] = defaultdict(list)
+    for r in results:
+        rows[(str(r.benchmark), r.provider, r.model)].append(r)
+
+    dead: list[str] = []
+    for (benchmark, provider, model), group in sorted(rows.items()):
+        if not all(row.status == result_status.FAILED for row in group):
+            continue
+        ranked = Counter(row.error for row in group if row.error).most_common(1)
+        reason = ranked[0][0] if ranked else "no reason reported"
+        dead.append(f"{benchmark}:{provider}/{model} ({_truncate(reason)})")
+    return dead
+
+
+def _log_run_outcome(
+    final_status: Any,  # noqa: ANN401 — RunStatus enum, lazy-imported by callers
+    results: list[Any],
+    fail_count: int,
+    *,
+    result_status: Any,  # noqa: ANN401 — ResultStatus enum, lazy-imported by callers
+    run_status: Any,  # noqa: ANN401 — RunStatus enum, lazy-imported by callers
+) -> None:
+    """Emit the run-level event that the infra alert metrics filter on.
+
+    Storing the status on the run row is not enough to notify anyone: the Cloud
+    Logging metrics in benchmark-infra match on the literal ``RUN_FAILED`` /
+    ``RUN_PARTIAL`` event strings, so a run that ends badly and logs nothing is
+    invisible in Slack.
+
+    Deliberately log-only — it never raises. The runner job sets ``max_retries = 1``,
+    so exiting non-zero would re-run the whole benchmark, re-spending on every
+    provider and writing a duplicate run. Alerting keys off the log event, not the
+    exit code, so the page fires either way.
+
+    A total failure reports only ``RUN_FAILED``; the per-provider breakdown is
+    skipped there because every provider is in it, and one incident must not page
+    twice.
+    """
+    if final_status is run_status.FAILED:
+        log_run_failed(
+            f"all {fail_count} result rows failed"
+            if results
+            else "benchmark produced no results (no providers configured or dataset empty)"
+        )
+        return
+    if final_status is not run_status.PARTIAL:
+        return
+    dead = _dead_providers(results, result_status)
+    if dead:
+        log_run_partial(f"providers failed every item: {'; '.join(dead)}")
 
 
 async def _transcribe_with_whisper(audio_path: Path, settings: Settings) -> str:
@@ -1114,6 +1178,14 @@ async def run_benchmarks(
                 final_status = RunStatus.SUCCEEDED
             else:
                 final_status = RunStatus.PARTIAL
+
+            _log_run_outcome(
+                final_status,
+                typed_results,
+                fail_count,
+                result_status=ResultStatus,
+                run_status=RunStatus,
+            )
 
             await writer.finish_run(run_id, status=final_status, error=None)
 

--- a/runner/src/coval_bench/runner/orchestrator.py
+++ b/runner/src/coval_bench/runner/orchestrator.py
@@ -186,10 +186,10 @@ def _dead_providers(
 ) -> list[str]:
     """``benchmark:provider/model (reason)`` for each provider whose every row failed.
 
-    Keyed by benchmark as well as provider and model: openai and xai are registered
-    under both TTS and STT, so keying on the provider alone would let a dead TTS model
-    be masked by the same provider's healthy STT rows. The reason is the most common
-    error across that provider's rows, so the alert names a cause and not just a name.
+    Keyed by benchmark as well as provider and model, because a provider may be
+    registered under more than one modality; keying on the provider alone would let a
+    dead model be masked by that provider's healthy rows in the other benchmark. The
+    reason is the most common error across the rows, so the alert names a cause.
     """
     rows: dict[tuple[str, str, str], list[Any]] = defaultdict(list)
     for r in results:
@@ -228,6 +228,13 @@ def _log_run_outcome(
     A total failure reports only ``RUN_FAILED``; the per-provider breakdown is
     skipped there because every provider is in it, and one incident must not page
     twice.
+
+    A partial run reports ``RUN_PARTIAL`` **only when some provider failed every one
+    of its items**, not on every partial run. Scattered item failures are normal —
+    providers routinely lose one clip out of thirty — so paging on those would bury
+    the signal and the alert would be muted. The consequence is deliberate: a run
+    where many providers fail most of their items without any single one being fully
+    dead stays silent here, and is caught only by the run's own metrics.
     """
     if final_status is run_status.FAILED:
         log_run_failed(
@@ -1205,6 +1212,12 @@ async def run_benchmarks(
             else:
                 final_status = RunStatus.PARTIAL
 
+            await writer.finish_run(run_id, status=final_status, error=None)
+
+            # After the row is stored, never before: if finish_run raises, the outer
+            # handler is the only thing that should report, otherwise a partial run
+            # pages RUN_PARTIAL and then RUN_FAILED for one incident. Everything
+            # below this point is best-effort and cannot raise.
             _log_run_outcome(
                 final_status,
                 typed_results,
@@ -1212,8 +1225,6 @@ async def run_benchmarks(
                 result_status=ResultStatus,
                 run_status=RunStatus,
             )
-
-            await writer.finish_run(run_id, status=final_status, error=None)
 
             # Refresh after finish_run: the view query only counts runs already
             # marked succeeded/partial. A failed refresh must not fail the run.
@@ -1292,6 +1303,19 @@ async def run_benchmarks(
             else:
                 # Run row is PARTIAL, so its bucket qualifies.
                 await asyncio.shield(_refresh_series_bucket(writer, run_id, settings))
+                # A truncated run still alerts on any provider that failed everything
+                # it managed to run. Reach is limited: ``all_results`` is only extended
+                # after a phase's gather returns, so the cancelled phase contributes
+                # nothing and a single-kind run reports no dead providers at all. Only
+                # an earlier completed phase (kind="both") can be named here. Rows are
+                # already durable either way — each task persists its own.
+                _log_run_outcome(
+                    RunStatus.PARTIAL,
+                    typed_results,
+                    fail_count,
+                    result_status=ResultStatus,
+                    run_status=RunStatus,
+                )
             finished_at = datetime.now(tz=UTC)
             sigterm_duration_s = (finished_at - started_at).total_seconds()
             logger.warning(

--- a/runner/src/coval_bench/runner/orchestrator.py
+++ b/runner/src/coval_bench/runner/orchestrator.py
@@ -1301,14 +1301,13 @@ async def run_benchmarks(
                     exc_info=write_exc,
                 )
             else:
-                # Run row is PARTIAL, so its bucket qualifies.
-                await asyncio.shield(_refresh_series_bucket(writer, run_id, settings))
-                # A truncated run still alerts on any provider that failed everything
-                # it managed to run. Reach is limited: ``all_results`` is only extended
-                # after a phase's gather returns, so the cancelled phase contributes
-                # nothing and a single-kind run reports no dead providers at all. Only
-                # an earlier completed phase (kind="both") can be named here. Rows are
-                # already durable either way — each task persists its own.
+                # Report before the bucket refresh, not after: SIGTERM gives ~10s
+                # before SIGKILL, and losing the page to a slow maintenance call is
+                # worse than losing the rollup. Reach is limited — ``all_results`` is
+                # only extended after a phase's gather returns, so the cancelled phase
+                # contributes nothing and a single-kind run names no dead provider.
+                # Only an earlier completed phase (kind="both") can be named here.
+                # Rows are durable either way; each task persists its own.
                 _log_run_outcome(
                     RunStatus.PARTIAL,
                     typed_results,
@@ -1316,6 +1315,8 @@ async def run_benchmarks(
                     result_status=ResultStatus,
                     run_status=RunStatus,
                 )
+                # Run row is PARTIAL, so its bucket qualifies.
+                await asyncio.shield(_refresh_series_bucket(writer, run_id, settings))
             finished_at = datetime.now(tz=UTC)
             sigterm_duration_s = (finished_at - started_at).total_seconds()
             logger.warning(

--- a/runner/tests/unit/test_orchestrator.py
+++ b/runner/tests/unit/test_orchestrator.py
@@ -44,7 +44,7 @@ from coval_bench.config import Settings
 from coval_bench.db.models import Benchmark, Result, ResultStatus, Run, RunStatus
 from coval_bench.providers.base import TranscriptionResult, TTSResult
 from coval_bench.registries import MODEL_REGISTRY, ModelStatus, RegisteredModel, Source
-from coval_bench.runner.orchestrator import RunSummary, run_benchmarks
+from coval_bench.runner.orchestrator import RunSummary, _dead_providers, run_benchmarks
 from coval_bench.runner.retry import with_retry
 
 # ---------------------------------------------------------------------------
@@ -2449,3 +2449,179 @@ async def test_posthog_capture_failure_does_not_fail_run(
 
     assert summary.status == str(RunStatus.SUCCEEDED)
     fake.capture.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Run-level alert events — RUN_FAILED / RUN_PARTIAL
+#
+# These literal event strings are what the Cloud Logging metrics in
+# benchmark-infra filter on, so the assertions below are a contract with the
+# alerting stack, not just internal logging detail.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_total_failure_emits_run_failed(audio_file: Path, settings: Settings) -> None:
+    """Every row failing logs RUN_FAILED, so a silent wipeout still pages."""
+    provider_inst = MagicMock()
+    provider_inst.measure_ttft = AsyncMock(side_effect=RuntimeError("boom"))
+
+    run = _make_run()
+    writer = _make_stub_writer(run)
+
+    async with _orchestrator_env(
+        audio_path=audio_file,
+        stt_items=[_make_dataset_item(audio_file)],
+        stt_providers={"deepgram": MagicMock(return_value=provider_inst)},
+        run=run,
+        writer=writer,
+    ) as _:
+        with structlog.testing.capture_logs() as captured:
+            summary = await run_benchmarks(
+                settings=settings,
+                benchmark_kind="stt",
+                smoke=True,
+                matrix_overrides=_only_stt_matrix("deepgram", "nova-2"),
+            )
+
+    assert summary.status == str(RunStatus.FAILED)
+    failed = _events(captured, "RUN_FAILED")
+    assert len(failed) == 1, "exactly one run-level event per run"
+    assert "result rows failed" in failed[0]["error"]
+    # A total loss is already covered by RUN_FAILED; paging twice is the bug
+    # the s2s metric comment warns about.
+    assert _events(captured, "RUN_PARTIAL") == []
+
+
+@pytest.mark.asyncio
+async def test_partial_run_emits_run_partial_with_cause(
+    audio_file: Path, settings: Settings
+) -> None:
+    """A provider failing every item is named, with its reason, in RUN_PARTIAL."""
+    provider_ok = MagicMock()
+    provider_ok.measure_ttft = AsyncMock(return_value=_good_transcription())
+
+    provider_bad = MagicMock()
+    provider_bad.measure_ttft = AsyncMock(side_effect=RuntimeError("boom"))
+
+    run = _make_run()
+    writer = _make_stub_writer(run)
+
+    async with _orchestrator_env(
+        audio_path=audio_file,
+        stt_items=[_make_dataset_item(audio_file)],
+        stt_providers={
+            "deepgram": MagicMock(return_value=provider_ok),
+            "elevenlabs": MagicMock(return_value=provider_bad),
+        },
+        run=run,
+        writer=writer,
+    ) as _:
+        with structlog.testing.capture_logs() as captured:
+            summary = await run_benchmarks(
+                settings=settings,
+                benchmark_kind="stt",
+                smoke=True,
+                matrix_overrides=[
+                    _stt_entry("deepgram", "nova-2"),
+                    _stt_entry("elevenlabs", "scribe_v2_realtime"),
+                ],
+            )
+
+    assert summary.status == str(RunStatus.PARTIAL)
+    partial = _events(captured, "RUN_PARTIAL")
+    assert len(partial) == 1
+    message = partial[0]["error"]
+    # The dead provider is named and its cause carried, so Slack's Logs link
+    # lands on an actionable line.
+    assert "elevenlabs/scribe_v2_realtime" in message
+    assert "boom" in message
+    # The healthy provider must never appear in the failure list.
+    assert "deepgram" not in message
+    assert _events(captured, "RUN_FAILED") == []
+
+
+@pytest.mark.asyncio
+async def test_healthy_run_emits_no_run_event(audio_file: Path, settings: Settings) -> None:
+    """A fully successful run stays quiet — no alert event of either kind."""
+    provider_inst = MagicMock()
+    provider_inst.measure_ttft = AsyncMock(return_value=_good_transcription())
+
+    run = _make_run()
+    writer = _make_stub_writer(run)
+
+    async with _orchestrator_env(
+        audio_path=audio_file,
+        stt_items=[_make_dataset_item(audio_file)],
+        stt_providers={"deepgram": MagicMock(return_value=provider_inst)},
+        run=run,
+        writer=writer,
+    ) as _:
+        with structlog.testing.capture_logs() as captured:
+            summary = await run_benchmarks(
+                settings=settings,
+                benchmark_kind="stt",
+                smoke=True,
+                matrix_overrides=_only_stt_matrix("deepgram", "nova-2"),
+            )
+
+    assert summary.status == str(RunStatus.SUCCEEDED)
+    assert _events(captured, "RUN_FAILED") == []
+    assert _events(captured, "RUN_PARTIAL") == []
+
+
+def _result(provider: str, benchmark: Benchmark, status: ResultStatus, error: str | None) -> Result:
+    return Result(
+        run_id=1,
+        provider=provider,
+        model="m1",
+        benchmark=benchmark,
+        metric_type="TTFT",
+        metric_value=None if status is ResultStatus.FAILED else 1.0,
+        metric_units="ms",
+        status=status,
+        error=error,
+    )
+
+
+def test_dead_providers_keyed_by_benchmark() -> None:
+    """A dead TTS model is not masked by the same provider's healthy STT rows."""
+    results = [
+        _result("openai", Benchmark.TTS, ResultStatus.FAILED, "no audio"),
+        _result("openai", Benchmark.TTS, ResultStatus.FAILED, "no audio"),
+        _result("openai", Benchmark.STT, ResultStatus.SUCCESS, None),
+    ]
+
+    dead = _dead_providers(results, ResultStatus)
+
+    assert dead == ["TTS:openai/m1 (no audio)"]
+
+
+def test_dead_providers_reports_most_common_reason() -> None:
+    """The reason carried is the dominant one, not whichever row came first."""
+    results = [
+        _result("hume", Benchmark.TTS, ResultStatus.FAILED, "one-off blip"),
+        _result("hume", Benchmark.TTS, ResultStatus.FAILED, "stream closed"),
+        _result("hume", Benchmark.TTS, ResultStatus.FAILED, "stream closed"),
+    ]
+
+    dead = _dead_providers(results, ResultStatus)
+
+    assert dead == ["TTS:hume/m1 (stream closed)"]
+
+
+def test_dead_providers_skips_partly_healthy_provider() -> None:
+    """One flaky item is not a dead provider — that threshold is what avoids noise."""
+    results = [
+        _result("deepgram", Benchmark.STT, ResultStatus.FAILED, "timeout"),
+        _result("deepgram", Benchmark.STT, ResultStatus.SUCCESS, None),
+    ]
+
+    assert _dead_providers(results, ResultStatus) == []
+
+
+def test_dead_providers_handles_missing_reason() -> None:
+    """A failed row with no error still names the provider rather than crashing."""
+    results = [_result("rime", Benchmark.TTS, ResultStatus.FAILED, None)]
+
+    assert _dead_providers(results, ResultStatus) == ["TTS:rime/m1 (no reason reported)"]

--- a/runner/tests/unit/test_orchestrator.py
+++ b/runner/tests/unit/test_orchestrator.py
@@ -2779,3 +2779,70 @@ async def test_sigterm_partial_does_not_report_a_dead_provider(
     assert summary.status == str(RunStatus.PARTIAL)
     assert _events(captured, "RUN_PARTIAL") == []
     assert _events(captured, "RUN_FAILED") == []
+
+
+@pytest.mark.asyncio
+async def test_sigterm_reports_dead_provider_from_a_completed_phase(
+    audio_file: Path, settings: Settings
+) -> None:
+    """A phase that finished before SIGTERM still gets its dead provider reported.
+
+    kind="both" runs STT then TTS. STT completes with a provider that failed every
+    item, then TTS hangs until SIGTERM cancels it. The STT rows are already in
+    ``all_results``, so the truncated run can still name what died.
+    """
+    import os
+    import signal
+
+    stt_bad = MagicMock()
+    stt_bad.measure_ttft = AsyncMock(side_effect=RuntimeError("boom"))
+
+    started = asyncio.Event()
+
+    async def _hang(*args: Any, **kwargs: Any) -> TTSResult:
+        started.set()
+        await asyncio.sleep(60)
+        raise AssertionError("unreachable — SIGTERM cancels this")
+
+    tts_slow = MagicMock()
+    tts_slow.synthesize = _hang
+
+    run = _make_run()
+    writer = _make_stub_writer(run)
+
+    async def _send_sigterm_after_tts_starts() -> None:
+        await started.wait()
+        await asyncio.sleep(0.01)
+        os.kill(os.getpid(), signal.SIGTERM)
+
+    sigterm_task = asyncio.create_task(_send_sigterm_after_tts_starts())
+
+    async with _orchestrator_env(
+        audio_path=audio_file,
+        stt_items=[_make_dataset_item(audio_file)],
+        tts_items=[_make_tts_item("hello world")],
+        stt_providers={"elevenlabs": MagicMock(return_value=stt_bad)},
+        tts_providers={"cartesia": MagicMock(return_value=tts_slow)},
+        run=run,
+        writer=writer,
+    ) as _:
+        with structlog.testing.capture_logs() as captured:
+            summary = await run_benchmarks(
+                settings=settings,
+                benchmark_kind="both",
+                smoke=True,
+                matrix_overrides=[
+                    *_paused_registry(Benchmark.STT),
+                    *_paused_registry(Benchmark.TTS),
+                    _stt_entry("elevenlabs", "scribe_v2_realtime"),
+                    _tts_entry("cartesia", "sonic-3", "luna"),
+                ],
+            )
+
+    await sigterm_task
+
+    assert summary.status == str(RunStatus.PARTIAL)
+    partial = _events(captured, "RUN_PARTIAL")
+    assert len(partial) == 1, "the completed phase's dead provider must still report"
+    assert "elevenlabs/scribe_v2_realtime" in partial[0]["error"]
+    assert "boom" in partial[0]["error"]


### PR DESCRIPTION
The orchestrator stored a run's status without ever emitting the `RUN_FAILED` / `RUN_PARTIAL` strings the alert metrics match on, so a run that completed and produced nothing paged nobody. Eight `ACTIVE` models across five providers have been failing every item since 29 July, unnoticed.

A total failure now reports `RUN_FAILED`. A partial run reports `RUN_PARTIAL` only when some provider failed **every one of its items**, named with its cause  `TTS:hume/octave-2 (server rejected WebSocket connection: HTTP 429)`. That threshold is deliberate: gladia and assemblyai each lost one clip in three days, and paging on those would get the alert muted. Neither path raises, since `max_retries = 1` means a non-zero exit re-runs the whole benchmark and re-spends on every provider.

Reported after `finish_run`, otherwise a failed write pages twice for one incident. The SIGTERM path reports too, limited to providers from a phase that finished before the cancellation.

Needs coval-ai/benchmark-infra#87 applied first so the events have a metric to land in.