### PR TITLE
Remove the WER sort and dataset controls from TTS charts

### DIFF
--- a/web/components/dashboard/ModelComparisonTable.tsx
+++ b/web/components/dashboard/ModelComparisonTable.tsx
@@ -227,7 +227,7 @@ const ModelComparisonTable: React.FC<ModelComparisonTableProps> = ({
         {percentile.hint && (
           <span className="text-xs text-text-tertiary">{percentile.hint}</span>
         )}
-        {hasWER && <WerDatasetSelect className="ml-auto" />}
+        {hasWER && activeTab === "stt" && <WerDatasetSelect className="ml-auto" />}
       </div>
 
       <div ref={tableWrapRef} className="relative">

--- a/web/components/dashboard/QualityBarSection.tsx
+++ b/web/components/dashboard/QualityBarSection.tsx
@@ -303,17 +303,19 @@ const QualityBarSection: React.FC = () => {
               value={werBarDataset}
               onChange={changeWerBarDataset}
             />
-            <SelectControl
-              label="Sort"
-              value={barSort}
-              onChange={(v) => setBarSort(v as typeof barSort)}
-            >
-              {BAR_SORTS.map(({ key, label }) => (
-                <option key={key} value={key}>
-                  {label}
-                </option>
-              ))}
-            </SelectControl>
+            {mode === "stt" && (
+              <SelectControl
+                label="Sort"
+                value={barSort}
+                onChange={(v) => setBarSort(v as typeof barSort)}
+              >
+                {BAR_SORTS.map(({ key, label }) => (
+                  <option key={key} value={key}>
+                    {label}
+                  </option>
+                ))}
+              </SelectControl>
+            )}
           </div>
         )}
         {!isS2S && selectedBars.length > 0 && (

--- a/web/components/dashboard/QualityBarSection.tsx
+++ b/web/components/dashboard/QualityBarSection.tsx
@@ -296,26 +296,24 @@ const QualityBarSection: React.FC = () => {
             }}
           />
         )}
-        {!isS2S && (
+        {mode === "stt" && (
           <div className="mb-4 flex flex-wrap items-center gap-x-4 gap-y-2">
             <WerDatasetSelect
               label="Chart dataset"
               value={werBarDataset}
               onChange={changeWerBarDataset}
             />
-            {mode === "stt" && (
-              <SelectControl
-                label="Sort"
-                value={barSort}
-                onChange={(v) => setBarSort(v as typeof barSort)}
-              >
-                {BAR_SORTS.map(({ key, label }) => (
-                  <option key={key} value={key}>
-                    {label}
-                  </option>
-                ))}
-              </SelectControl>
-            )}
+            <SelectControl
+              label="Sort"
+              value={barSort}
+              onChange={(v) => setBarSort(v as typeof barSort)}
+            >
+              {BAR_SORTS.map(({ key, label }) => (
+                <option key={key} value={key}>
+                  {label}
+                </option>
+              ))}
+            </SelectControl>
           </div>
         )}
         {!isS2S && selectedBars.length > 0 && (


### PR DESCRIPTION
## Summary

<img width="1064" height="1248" alt="image" src="https://github.com/user-attachments/assets/a4891fca-8e41-4c83-91f6-d7b95d2699e2" />

The Sort dropdown ("Lowest WER" / "Most substitutions" / …) and the WER dataset selectors only carry meaning on STT, where multiple evaluation sets and error-type splits exist. On TTS they showed a redundant single-dataset choice ("Text prompts") and sort options that don't apply. Both are now rendered only when the active tab is STT:

- `QualityBarSection`: the Chart dataset + Sort controls row above the Accuracy by Model chart is gated on the STT tab. With the controls unmounted, `barSort` and the chart dataset stay at their defaults, so the TTS chart keeps its best-first pooled view.
- `ModelComparisonTable`: the "WER dataset" pin next to the latency-percentile slider is gated the same way.

S2S is unaffected (it never rendered these controls).

## Testing
- `tsc --noEmit`, `eslint --max-warnings 0`, `vitest` (107 passed) all green.
- Verified in the browser against the prod API: `/tts` shows no Sort or dataset selects on the WER chart or comparison table; `/stt` retains Chart dataset, Sort, and WER dataset controls with unchanged behavior.

Closes BENCH-613

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR removes STT-specific WER controls from TTS while preserving their behavior on STT.

- Gates the QualityBarSection dataset and sort controls on STT mode.
- Gates the ModelComparisonTable WER dataset selector on the STT tab.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the controls removed from TTS and retained on supported STT routes as intended.

The changed render guards affect only the visibility of STT-specific controls; dashboard and chart state initialize independently for each modality, so hiding the TTS controls does not leave stale user selections affecting its charts.

<sub>Reviews (1): Last reviewed commit: ["Hide the WER dataset selectors outside S..."](https://github.com/coval-ai/benchmarks/commit/e0fe1ba0241401913e6ec7438f60e0324ebf84b4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50176596)</sub>

**Context used:**

- Knowledge Base — [Web Dashboard (STT/TTS/S2S + Overview)](https://app.greptile.com/coval/-/custom-context/knowledge-base/coval-ai/benchmarks/-/docs/web-dashboard.md)

<!-- /greptile_comment -->