### PR TITLE
Fail a TTS result whose audio contains no audible speech

### DIFF
--- a/runner/src/coval_bench/providers/tts/_common.py
+++ b/runner/src/coval_bench/providers/tts/_common.py
@@ -5,12 +5,14 @@
 
 from __future__ import annotations
 
+import math
 import os
 import tempfile
 import wave
 from collections.abc import Sequence
 from pathlib import Path
 
+import numpy as np
 import structlog
 
 from coval_bench.metrics import compute_ttfa, first_audible_offset_ms
@@ -23,6 +25,7 @@ _PCM16_FRAME_BYTES = 2
 
 # Stable contract — matched by the reason classifier and the alerting log metric.
 _SILENT_FAILURE_PREFIX = "provider closed the stream without sending audio or an error"
+_INAUDIBLE_AUDIO_ERROR = "provider audio remained below the audibility threshold"
 _LAST_FRAMES_MAX_CHARS = 400
 
 
@@ -70,9 +73,18 @@ def finalize_tts_result(
     if remainder:
         pcm = pcm[: len(pcm) - remainder]
 
+    # Audibility is a property of the audio alone, so it is judged whenever there is
+    # audio — not only when both timestamps happen to be set. A provider that returned
+    # PCM but left a timestamp unset would otherwise skip the check entirely and fall
+    # through to the orchestrator's generic reason.
+    offset_ms: float | None = None
+    inaudible_audio = False
+    if pcm:
+        offset_ms, detection_ok = _safe_offset_ms(pcm, sample_rate, provider, model)
+        inaudible_audio = offset_ms is None and detection_ok
+
     ttfa_ms: float | None = None
     if audio_synthesis_start is not None and first_audio_chunk_at is not None:
-        offset_ms = _safe_offset_ms(pcm, sample_rate, provider, model) if pcm else None
         ttfa_ms = compute_ttfa(
             audio_synthesis_start, first_audio_chunk_at, offset_ms if offset_ms is not None else 0.0
         )
@@ -89,6 +101,26 @@ def finalize_tts_result(
     if not pcm and error is None:
         error = _silent_failure_error(last_frames)
         logger.warning("tts_silent_failure", provider=provider, model=model, error=error)
+    elif inaudible_audio and error is None:
+        # Audio arrived but no frame cleared the audibility threshold. Without this the
+        # null offset collapses into 0.0 and TTFA becomes pure arrival time — a
+        # plausible number measured off silence, which then enters the aggregates.
+        #
+        # The wording claims only what a fixed RMS threshold can support: the audio was
+        # below it, not definitively that speech is absent. Unusually quiet or whispered
+        # output would land here too, so the peak and RMS are logged to make that case
+        # recognisable rather than indistinguishable from true silence.
+        error = _INAUDIBLE_AUDIO_ERROR
+        ttfa_ms = None
+        peak, rms = _level_diagnostics(pcm)
+        logger.warning(
+            "tts_inaudible_audio",
+            provider=provider,
+            model=model,
+            bytes=len(pcm),
+            peak_dbfs=peak,
+            rms_dbfs=rms,
+        )
     return TTSResult(
         provider=provider,
         model=model,
@@ -118,17 +150,49 @@ def _silent_failure_error(last_frames: Sequence[str] | None) -> str:
     return f"{_SILENT_FAILURE_PREFIX}; last frames: {tail[:_LAST_FRAMES_MAX_CHARS]}"
 
 
-def _safe_offset_ms(pcm: bytes, sample_rate: int, provider: str, model: str) -> float | None:
-    """Leading-silence offset, swallowing any error to a ``None`` (arrival-only) result.
+def _level_diagnostics(pcm: bytes) -> tuple[float | None, float | None]:
+    """Peak and RMS of *pcm* in dBFS, or ``(None, None)`` when it can't be read.
+
+    Recorded alongside an inaudible-audio failure so quiet-but-real speech can be told
+    apart from true silence after the fact. Diagnostics only — never load-bearing, so
+    any failure degrades to ``None`` rather than propagating.
+    """
+    try:
+        samples = np.frombuffer(pcm, dtype="<i2").astype(np.float32) / 32768.0
+        if samples.size == 0:
+            return None, None
+        peak = float(np.max(np.abs(samples)))
+        rms = float(np.sqrt(np.mean(samples**2)))
+        return _to_dbfs(peak), _to_dbfs(rms)
+    except Exception:
+        return None, None
+
+
+def _to_dbfs(value: float) -> float | None:
+    """Linear amplitude in [0, 1] as dBFS, or ``None`` for digital silence."""
+    if value <= 0.0:
+        return None
+    return round(20.0 * math.log10(value), 1)
+
+
+def _safe_offset_ms(
+    pcm: bytes, sample_rate: int, provider: str, model: str
+) -> tuple[float | None, bool]:
+    """Leading-silence offset as ``(offset_ms, detection_ok)``.
 
     The offset is a latency metric, not load-bearing for the audio; a failure here
     must never propagate out of ``synthesize`` and discard the synthesized WAV.
+
+    ``detection_ok`` separates two states that both yield a ``None`` offset and must
+    not be conflated: detection ran and found no audible frame (the audio really is
+    silent — a synthesis failure), versus detection itself crashed (our problem, and
+    no reason to condemn the provider's audio).
     """
     try:
-        return first_audible_offset_ms(pcm, sample_rate)
+        return first_audible_offset_ms(pcm, sample_rate), True
     except Exception as exc:
         logger.warning("tts_offset_failed", provider=provider, model=model, exc_info=exc)
-        return None
+        return None, False
 
 
 def _write_wav(pcm: bytes, sample_rate: int) -> Path:

--- a/runner/tests/providers/tts/conftest.py
+++ b/runner/tests/providers/tts/conftest.py
@@ -10,6 +10,8 @@ monkeypatched fake SDKs.
 
 from __future__ import annotations
 
+import math
+import struct
 import wave as _wave
 from collections.abc import AsyncIterator, Sequence
 from io import BytesIO
@@ -277,12 +279,25 @@ class FakeAiohttpSession:
 
 
 def make_pcm_bytes(duration_frames: int = 480, sample_rate: int = 24000) -> bytes:
-    """Generate a block of silence PCM frames (16-bit, mono)."""
-    return b"\x00" * (duration_frames * 2)  # 2 bytes per sample, 16-bit
+    """Generate a block of audible PCM frames (16-bit mono sine).
+
+    Audible rather than silence: ``finalize_tts_result`` treats audio containing no
+    audible frame as a synthesis failure, so a silent fixture would drive every
+    provider's happy-path test down that failure branch instead. Amplitude 0.3 sits
+    well clear of the detector's RMS threshold.
+    """
+    amplitude = 0.3
+    return b"".join(
+        struct.pack(
+            "<h",
+            int(amplitude * 32767 * math.sin(2.0 * math.pi * 220.0 * n / sample_rate)),
+        )
+        for n in range(duration_frames)
+    )
 
 
 def make_wav_bytes(duration_frames: int = 480, sample_rate: int = 24000) -> bytes:
-    """Wrap PCM silence in a proper WAV container."""
+    """Wrap audible PCM in a proper WAV container."""
     buf = BytesIO()
     with _wave.open(buf, "wb") as wf:
         wf.setnchannels(1)

--- a/runner/tests/providers/tts/test_elevenlabs.py
+++ b/runner/tests/providers/tts/test_elevenlabs.py
@@ -48,7 +48,7 @@ async def test_elevenlabs_happy_path(
     fake_settings: Settings,
     tmp_path: Path,
 ) -> None:
-    pcm = make_pcm_bytes(480) * 4  # ~80 ms of silence
+    pcm = make_pcm_bytes(480) * 4  # ~80 ms of audible tone
     captured: dict[str, object] = {}
 
     def handler(request: httpx.Request) -> httpx.Response:

--- a/runner/tests/unit/test_tts_common.py
+++ b/runner/tests/unit/test_tts_common.py
@@ -240,3 +240,51 @@ def test_finalize_successful_audio_is_untouched() -> None:
 
     assert result.error is None
     assert result.audio_path is not None
+
+
+def test_finalize_inaudible_audio_fails_instead_of_reporting_ttfa() -> None:
+    """Silence-only audio is a synthesis failure, not a fast TTFA.
+
+    With no audible frame the offset is null, which used to collapse to 0.0 and make
+    TTFA pure arrival time — a plausible number measured off silence that then entered
+    the aggregates.
+    """
+    sr = 24000
+    result = finalize_tts_result(
+        provider="test",
+        model="m",
+        voice="v",
+        pcm=_silence_pcm(500, sr),
+        sample_rate=sr,
+        audio_synthesis_start=10.0,
+        first_audio_chunk_at=10.3,
+    )
+
+    assert result.error == "provider audio remained below the audibility threshold"
+    assert result.ttfa_ms is None
+
+
+def test_finalize_offset_detection_crash_does_not_condemn_the_audio() -> None:
+    """A crash in offset detection is our problem — keep the audio and the TTFA.
+
+    Distinct from genuine silence: both yield a null offset, and conflating them would
+    fail perfectly good audio whenever our own detection threw.
+    """
+    sr = 24000
+    with patch(
+        "coval_bench.providers.tts._common.first_audible_offset_ms",
+        side_effect=RuntimeError("detector exploded"),
+    ):
+        result = finalize_tts_result(
+            provider="test",
+            model="m",
+            voice="v",
+            pcm=_tone_pcm(300, sr),
+            sample_rate=sr,
+            audio_synthesis_start=10.0,
+            first_audio_chunk_at=10.3,
+        )
+
+    assert result.error is None
+    assert result.ttfa_ms == pytest.approx(300.0)
+    assert result.audio_path is not None

--- a/runner/tests/unit/test_tts_common.py
+++ b/runner/tests/unit/test_tts_common.py
@@ -288,3 +288,5 @@ def test_finalize_offset_detection_crash_does_not_condemn_the_audio() -> None:
     assert result.error is None
     assert result.ttfa_ms == pytest.approx(300.0)
     assert result.audio_path is not None
+    assert result.audio_path.exists()
+    result.audio_path.unlink()


### PR DESCRIPTION
This work was stranded. #440 was merged into `fix/surface-swallowed-provider-errors` rather than main, and that branch's only PR (#438) had already merged and closed — so the commit had no open PR and was never going to land. Cherry-picked onto current main instead of reopening the old branch, so nothing already in main gets re-proposed.

A TTS result whose audio contains no audible speech now fails instead of passing as a valid measurement. Silence still produces a WAV and a TTFA, so without this a provider that streams nothing but digital silence scores as healthy.

Only one commit was actually missing. The Hume error-frame fix from the same branch turned out to be in main already — it rode along inside #438's squash, under a different title.

1247 passed, 2 skipped; ruff, format and `mypy --strict src tests` clean.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR classifies nonempty TTS audio with no frame above the existing audibility threshold as a provider failure rather than reporting an arrival-only TTFA.

- Separates successful no-onset detection from detector exceptions.
- Clears TTFA and records bounded peak/RMS diagnostics for inaudible output.
- Changes shared provider-test PCM from silence to an audible tone and adds unit coverage for silence and detector failures.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with one non-blocking test-documentation inconsistency.

The audibility classification correctly distinguishes detector failure from successfully detected inaudibility, while the shared fixture's new audible semantics leave one call-site comment inaccurate.

**Files Needing Attention:** runner/tests/providers/tts/conftest.py and runner/tests/providers/tts/test_elevenlabs.py

<sub>Reviews (1): Last reviewed commit: ["Fail a TTS result whose audio contains n..."](https://github.com/coval-ai/benchmarks/commit/b5b0c42b32ce71ecec1683a2466ec079194a3458) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50196402)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Runner Orchestration](https://app.greptile.com/coval/-/custom-context/knowledge-base/coval-ai/benchmarks/-/docs/runner-orchestration.md)

<!-- /greptile_comment -->