### PR TITLE
Pause the Azure models

### DIFF
--- a/runner/src/coval_bench/registries/models.py
+++ b/runner/src/coval_bench/registries/models.py
@@ -70,6 +70,7 @@ _STT = Benchmark.STT
 _TTS = Benchmark.TTS
 _S2S = Benchmark.S2S
 _ACTIVE = ModelStatus.ACTIVE
+_PAUSED = ModelStatus.PAUSED
 _RETIRED = ModelStatus.RETIRED
 _PENDING = ModelStatus.PENDING
 _EARLY_ACCESS = ModelStatus.EARLY_ACCESS
@@ -288,7 +289,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         creator="microsoft",
         tags=(_STREAMING, _MULTI, _VAD, _DIAR, _KEYTERM),
         on_prem=True,
-        status=_ACTIVE,
+        status=_PAUSED,
     ),
     RegisteredModel(
         benchmark=_STT,
@@ -634,7 +635,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         creator="microsoft",
         tags=(_STREAMING, _MULTI, _EMOTION, _STREAM),
         on_prem=True,
-        status=_ACTIVE,
+        status=_PAUSED,
     ),
     RegisteredModel(
         benchmark=_TTS,
@@ -644,7 +645,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         voices=("en-US-Ava:DragonHDLatestNeural", "en-US-Andrew:DragonHDLatestNeural"),
         creator="microsoft",
         tags=(_STREAMING, _MULTI, _STREAM),
-        status=_ACTIVE,
+        status=_PAUSED,
     ),
     RegisteredModel(
         benchmark=_TTS,

--- a/runner/tests/unit/test_tts_voice_assignment.py
+++ b/runner/tests/unit/test_tts_voice_assignment.py
@@ -64,13 +64,15 @@ def test_no_pool_falls_back_to_pin() -> None:
 
 
 def test_registry_pools_are_f_m_pairs() -> None:
-    """Every ``voices`` pool is a distinct (female, male) pair on a benchmarked TTS entry."""
-    benchmarked = (ModelStatus.ACTIVE, ModelStatus.EARLY_ACCESS)
+    """Every ``voices`` pool is a distinct (female, male) pair on a live TTS entry.
+
+    PAUSED entries keep their pool so resuming them needs no re-research."""
+    live = (ModelStatus.ACTIVE, ModelStatus.EARLY_ACCESS, ModelStatus.PAUSED)
     pooled = [m for m in MODEL_REGISTRY if m.voices]
     assert pooled, "expected voice pools in the registry"
     for m in pooled:
         assert m.benchmark is Benchmark.TTS, f"{m.provider}/{m.model}: pool on non-TTS entry"
-        assert m.status in benchmarked, f"{m.provider}/{m.model}: pool on unbenchmarked entry"
+        assert m.status in live, f"{m.provider}/{m.model}: pool on dead entry"
         assert len(m.voices) == 2, f"{m.provider}/{m.model}: pool must be a (female, male) pair"
         assert len(set(m.voices)) == 2, f"{m.provider}/{m.model}: duplicate voice in pool"
 


### PR DESCRIPTION
Sets all three Microsoft models (STT default, TTS neural, TTS dragon-hd-latest) to PAUSED: they stay visible on the site but drop out of scheduled runs and the arena roster. The voice-pool registry test now allows pools on paused entries so the pools survive for a later unpause.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR pauses all three Azure speech models while preserving their public catalogue entries and TTS voice pools for a later reactivation.
- Changes Azure STT `default` and TTS `neural`/`dragon-hd-latest` from active to paused.
- Expands the voice-pool registry invariant to accept paused entries.
- Existing status filters exclude the models from scheduled benchmarks and arena pairing.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the paused models excluded from scheduled runs and arena pairing while remaining publicly visible as intended.

The changed statuses match existing consumers: scheduled benchmarking accepts only active and early-access entries, arena pairing accepts only active TTS entries, and paused entries remain visible; the adjusted test preserves valid voice pools without weakening their shape checks.

<sub>Reviews (1): Last reviewed commit: ["Pause the Azure models"](https://github.com/coval-ai/benchmarks/commit/cac55928afa058cdb594afab9a4be2ddbd3dedd5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50260871)</sub>

**Context used:**

- Knowledge Base — [Runner Orchestration](https://app.greptile.com/coval/-/custom-context/knowledge-base/coval-ai/benchmarks/-/docs/runner-orchestration.md)

<!-- /greptile_comment -->