### PR TITLE
[BENCH-618] Dashboard freshness chip

### DIFF
--- a/web/components/dashboard/RunFreshness.tsx
+++ b/web/components/dashboard/RunFreshness.tsx
@@ -1,0 +1,75 @@
+// Copyright 2026 The Coval Benchmarks Authors
+// SPDX-License-Identifier: Apache-2.0
+
+"use client";
+
+import React, { useEffect, useState } from "react";
+import { useRunsQuery } from "@/lib/api/queries";
+import type { RunOut } from "@/lib/api/client";
+import MetricInfo from "@/components/shared/MetricInfo";
+
+function relativeTime(ms: number): string {
+  const min = Math.floor(ms / 60_000);
+  if (min < 1) return "just now";
+  if (min < 60) return `${min} min ago`;
+  const hours = Math.floor(min / 60);
+  if (hours < 24) return `${hours} hr ago`;
+  const days = Math.floor(hours / 24);
+  return `${days} day${days === 1 ? "" : "s"} ago`;
+}
+
+const DOT_CLASS = {
+  SUCCEEDED: "bg-accent-teal",
+  PARTIAL: "bg-accent-orange",
+  FAILED: "bg-accent-rust",
+} as const;
+
+const RunFreshness: React.FC = () => {
+  const { data } = useRunsQuery();
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    const id = setInterval(() => setNow(Date.now()), 30_000);
+    return () => clearInterval(id);
+  }, []);
+
+  const completed =
+    data?.runs.filter(
+      (run): run is RunOut & { status: keyof typeof DOT_CLASS } =>
+        run.status !== "RUNNING"
+    ) ?? [];
+  const lastGood = completed.find(
+    (run) => run.status === "SUCCEEDED" || run.status === "PARTIAL"
+  );
+  const latest = completed[0];
+  // Reserved height whether or not the chip has data, so the header never
+  // shifts when the runs query resolves (or silently fails).
+  if (!lastGood || !latest) return <div aria-hidden className="min-h-11 lg:min-h-7" />;
+
+  const updatedAt = Date.parse(lastGood.finished_at ?? lastGood.started_at);
+  const degraded = latest.status !== "SUCCEEDED";
+
+  return (
+    <div className="flex min-h-11 items-center lg:min-h-7">
+      <MetricInfo
+        align="left"
+        panelClassName="top-full mt-1.5 w-max"
+        content={`Last successful run finished ${new Date(updatedAt).toUTCString()}`}
+      >
+        <span className="inline-flex cursor-help items-center gap-1.5 rounded-full border border-border-primary px-2.5 py-1 font-mono text-[11px] text-text-tertiary">
+          <span
+            aria-hidden
+            className={`h-2 w-2 shrink-0 rounded-full ${DOT_CLASS[latest.status]}`}
+          />
+          Updated {relativeTime(now - updatedAt)}
+          {degraded && (
+            <span className="text-text-secondary">
+              · last run {latest.status.toLowerCase()}
+            </span>
+          )}
+        </span>
+      </MetricInfo>
+    </div>
+  );
+};
+
+export default RunFreshness;

--- a/web/components/dashboard/RunFreshness.tsx
+++ b/web/components/dashboard/RunFreshness.tsx
@@ -31,24 +31,29 @@ const RunFreshness: React.FC = () => {
   // shifts as queries resolve (or silently fail).
   if (!latestDataBucket) return <div aria-hidden className="min-h-11 lg:min-h-7" />;
 
-  // Runs are per-dataset with modality-prefixed ids. PARTIAL is the norm with
-  // flaky providers — only FAILED matters.
-  const runs =
-    runsData?.runs.filter(
-      (run) => run.dataset_id.startsWith(`${page}-`) && run.status !== "RUNNING"
-    ) ?? [];
+  // Only runs from the datasets this board's aggregates actually cover (the
+  // pinned S2S board must ignore legacy s2s-v1 runs). Sorted locally rather
+  // than trusting response order. PARTIAL is the norm with flaky providers —
+  // only FAILED matters.
+  const runs = (runsData?.runs ?? [])
+    .filter(
+      (run) =>
+        latestDataBucket.datasets.includes(run.dataset_id) &&
+        run.status !== "RUNNING"
+    )
+    .sort((a, b) => Date.parse(b.started_at) - Date.parse(a.started_at));
   const failed = runs[0]?.status === "FAILED";
 
-  // "Updated" = the newest run the charts already include: runs finishing after
-  // the served bucket ends are materialized later, and the bucket start alone
-  // undersells daily-bucketed boards. Shown as the run's start (its schedule
-  // slot — what the chart's newest point is labeled with), not its finish.
-  // Chart bucket as fallback if runs fail.
-  const included = runs.find(
-    (run) =>
-      run.status !== "FAILED" &&
-      Date.parse(run.finished_at ?? run.started_at) <= latestDataBucket.end
-  );
+  // "Updated" = the newest run the charts already include: one finishing inside
+  // the served bucket (later runs are materialized later, and the bucket start
+  // alone undersells daily-bucketed boards). Shown as the run's start (its
+  // schedule slot — what the chart's newest point is labeled with), not its
+  // finish. Chart bucket as fallback if runs fail.
+  const included = runs.find((run) => {
+    if (run.status === "FAILED") return false;
+    const finished = Date.parse(run.finished_at ?? run.started_at);
+    return finished >= latestDataBucket.start && finished <= latestDataBucket.end;
+  });
   const updatedAt = included
     ? Date.parse(included.started_at)
     : latestDataBucket.start;

--- a/web/components/dashboard/RunFreshness.tsx
+++ b/web/components/dashboard/RunFreshness.tsx
@@ -41,14 +41,16 @@ const RunFreshness: React.FC = () => {
 
   // "Updated" = the newest run the charts already include: runs finishing after
   // the served bucket ends are materialized later, and the bucket start alone
-  // undersells daily-bucketed boards. Chart bucket as fallback if runs fail.
+  // undersells daily-bucketed boards. Shown as the run's start (its schedule
+  // slot — what the chart's newest point is labeled with), not its finish.
+  // Chart bucket as fallback if runs fail.
   const included = runs.find(
     (run) =>
       run.status !== "FAILED" &&
       Date.parse(run.finished_at ?? run.started_at) <= latestDataBucket.end
   );
   const updatedAt = included
-    ? Date.parse(included.finished_at ?? included.started_at)
+    ? Date.parse(included.started_at)
     : latestDataBucket.start;
 
   return (

--- a/web/components/dashboard/RunFreshness.tsx
+++ b/web/components/dashboard/RunFreshness.tsx
@@ -4,8 +4,8 @@
 "use client";
 
 import React, { useEffect, useState } from "react";
+import { useDashboard } from "@/contexts/DashboardContext";
 import { useRunsQuery } from "@/lib/api/queries";
-import type { RunOut } from "@/lib/api/client";
 import MetricInfo from "@/components/shared/MetricInfo";
 
 function relativeTime(ms: number): string {
@@ -18,13 +18,8 @@ function relativeTime(ms: number): string {
   return `${days} day${days === 1 ? "" : "s"} ago`;
 }
 
-const DOT_CLASS = {
-  SUCCEEDED: "bg-accent-teal",
-  PARTIAL: "bg-accent-orange",
-  FAILED: "bg-accent-rust",
-} as const;
-
 const RunFreshness: React.FC = () => {
+  const { page } = useDashboard();
   const { data } = useRunsQuery();
   const [now, setNow] = useState(() => Date.now());
   useEffect(() => {
@@ -32,40 +27,36 @@ const RunFreshness: React.FC = () => {
     return () => clearInterval(id);
   }, []);
 
-  const completed =
-    data?.runs.filter(
-      (run): run is RunOut & { status: keyof typeof DOT_CLASS } =>
-        run.status !== "RUNNING"
-    ) ?? [];
-  const lastGood = completed.find(
+  // Runs are per-dataset; dataset ids are prefixed with their modality, so this
+  // scopes freshness to the benchmark type being viewed.
+  const runs =
+    data?.runs.filter((run) => run.dataset_id.startsWith(`${page}-`)) ?? [];
+  // PARTIAL still produced data — with flaky providers nearly every run is
+  // PARTIAL, so only FAILED is worth surfacing.
+  const lastGood = runs.find(
     (run) => run.status === "SUCCEEDED" || run.status === "PARTIAL"
   );
-  const latest = completed[0];
+  const failed = runs.find((run) => run.status !== "RUNNING")?.status === "FAILED";
   // Reserved height whether or not the chip has data, so the header never
   // shifts when the runs query resolves (or silently fails).
-  if (!lastGood || !latest) return <div aria-hidden className="min-h-11 lg:min-h-7" />;
+  if (!lastGood) return <div aria-hidden className="min-h-11 lg:min-h-7" />;
 
   const updatedAt = Date.parse(lastGood.finished_at ?? lastGood.started_at);
-  const degraded = latest.status !== "SUCCEEDED";
 
   return (
     <div className="flex min-h-11 items-center lg:min-h-7">
       <MetricInfo
         align="left"
         panelClassName="top-full mt-1.5 w-max"
-        content={`Last successful run finished ${new Date(updatedAt).toUTCString()}`}
+        content={`Last ${page.toUpperCase()} run finished ${new Date(updatedAt).toUTCString()}`}
       >
         <span className="inline-flex cursor-help items-center gap-1.5 rounded-full border border-border-primary px-2.5 py-1 font-mono text-[11px] text-text-tertiary">
           <span
             aria-hidden
-            className={`h-2 w-2 shrink-0 rounded-full ${DOT_CLASS[latest.status]}`}
+            className={`h-2 w-2 shrink-0 rounded-full ${failed ? "bg-accent-rust" : "bg-accent-teal"}`}
           />
           Updated {relativeTime(now - updatedAt)}
-          {degraded && (
-            <span className="text-text-secondary">
-              · last run {latest.status.toLowerCase()}
-            </span>
-          )}
+          {failed && <span className="text-text-secondary">· last run failed</span>}
         </span>
       </MetricInfo>
     </div>

--- a/web/components/dashboard/RunFreshness.tsx
+++ b/web/components/dashboard/RunFreshness.tsx
@@ -19,36 +19,44 @@ function relativeTime(ms: number): string {
 }
 
 const RunFreshness: React.FC = () => {
-  const { page } = useDashboard();
-  const { data } = useRunsQuery();
+  const { page, latestDataBucket } = useDashboard();
+  const { data: runsData } = useRunsQuery();
   const [now, setNow] = useState(() => Date.now());
   useEffect(() => {
     const id = setInterval(() => setNow(Date.now()), 30_000);
     return () => clearInterval(id);
   }, []);
 
-  // Runs are per-dataset; dataset ids are prefixed with their modality, so this
-  // scopes freshness to the benchmark type being viewed.
-  const runs =
-    data?.runs.filter((run) => run.dataset_id.startsWith(`${page}-`)) ?? [];
-  // PARTIAL still produced data — with flaky providers nearly every run is
-  // PARTIAL, so only FAILED is worth surfacing.
-  const lastGood = runs.find(
-    (run) => run.status === "SUCCEEDED" || run.status === "PARTIAL"
-  );
-  const failed = runs.find((run) => run.status !== "RUNNING")?.status === "FAILED";
   // Reserved height whether or not the chip has data, so the header never
-  // shifts when the runs query resolves (or silently fails).
-  if (!lastGood) return <div aria-hidden className="min-h-11 lg:min-h-7" />;
+  // shifts as queries resolve (or silently fail).
+  if (!latestDataBucket) return <div aria-hidden className="min-h-11 lg:min-h-7" />;
 
-  const updatedAt = Date.parse(lastGood.finished_at ?? lastGood.started_at);
+  // Runs are per-dataset with modality-prefixed ids. PARTIAL is the norm with
+  // flaky providers — only FAILED matters.
+  const runs =
+    runsData?.runs.filter(
+      (run) => run.dataset_id.startsWith(`${page}-`) && run.status !== "RUNNING"
+    ) ?? [];
+  const failed = runs[0]?.status === "FAILED";
+
+  // "Updated" = the newest run the charts already include: runs finishing after
+  // the served bucket ends are materialized later, and the bucket start alone
+  // undersells daily-bucketed boards. Chart bucket as fallback if runs fail.
+  const included = runs.find(
+    (run) =>
+      run.status !== "FAILED" &&
+      Date.parse(run.finished_at ?? run.started_at) <= latestDataBucket.end
+  );
+  const updatedAt = included
+    ? Date.parse(included.finished_at ?? included.started_at)
+    : latestDataBucket.start;
 
   return (
     <div className="flex min-h-11 items-center lg:min-h-7">
       <MetricInfo
         align="left"
         panelClassName="top-full mt-1.5 w-max"
-        content={`Last ${page.toUpperCase()} run finished ${new Date(updatedAt).toUTCString()}`}
+        content={`Newest ${page.toUpperCase()} data: ${new Date(updatedAt).toUTCString()}`}
       >
         <span className="inline-flex cursor-help items-center gap-1.5 rounded-full border border-border-primary px-2.5 py-1 font-mono text-[11px] text-text-tertiary">
           <span

--- a/web/components/layout/DashboardLayout.tsx
+++ b/web/components/layout/DashboardLayout.tsx
@@ -13,6 +13,7 @@ import DashboardFooter from "@/components/dashboard/DashboardFooter";
 import MobileModelSheet from "@/components/layout/MobileModelSheet";
 import ModelSidebar from "@/components/layout/ModelSidebar";
 import DashboardSkeleton from "@/components/dashboard/DashboardSkeleton";
+import RunFreshness from "@/components/dashboard/RunFreshness";
 
 const DashboardLayout: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const { loading, loadError, benchmarkTitle, windowDataStale } =
@@ -57,9 +58,12 @@ const DashboardLayout: React.FC<{ children: React.ReactNode }> = ({ children }) 
       <div className="relative z-10 flex flex-1">
         <ModelSidebar />
         <div className="pt-20 px-3 py-8 sm:px-8 pb-24 lg:pb-8 overflow-x-hidden flex-1 min-w-0">
-          <h1 className="mb-6 text-2xl font-bold tracking-tight text-text-primary">
-            {benchmarkTitle}
-          </h1>
+          <div className="mb-6">
+            <h1 className="mb-1 text-2xl font-bold tracking-tight text-text-primary">
+              {benchmarkTitle}
+            </h1>
+            <RunFreshness />
+          </div>
 
           <div
             className={`transition-opacity duration-200 ${

--- a/web/hooks/useDashboardState.tsx
+++ b/web/hooks/useDashboardState.tsx
@@ -158,20 +158,26 @@ export function useDashboardState(page: "tts" | "stt" | "s2s") {
   }, [availableWerDatasets, werDataset, werBarDatasetId]);
 
   // Freshness as the charts see it: the newest series bucket actually served
-  // (start, and end inferred from the bucket spacing). Deliberately not the
-  // runs table alone — a finished run can precede its aggregates.
+  // (start, end inferred from the bucket spacing, and the dataset scope the
+  // response covers). Deliberately not the runs table alone — a finished run
+  // can precede its aggregates.
   const latestDataBucket = useMemo(() => {
+    const data = aggregatesQuery.data;
     const times = [
-      ...new Set(
-        (aggregatesQuery.data?.series ?? []).map((point) =>
-          Date.parse(point.scheduled_at)
-        )
-      ),
+      ...new Set((data?.series ?? []).map((point) => Date.parse(point.scheduled_at))),
     ].sort((a, b) => a - b);
     if (times.length === 0) return null;
     const start = times[times.length - 1]!;
-    const period = times.length > 1 ? start - times[times.length - 2]! : 0;
-    return { start, end: start + period };
+    // Minimum spacing, not last spacing: a gap from a missed run would inflate
+    // the bucket and admit runs the charts don't serve yet. A single-point
+    // series degenerates to end === start, which only ever falls back to the
+    // bucket time itself.
+    let period = 0;
+    for (let i = 1; i < times.length; i++) {
+      const diff = times[i]! - times[i - 1]!;
+      if (period === 0 || diff < period) period = diff;
+    }
+    return { start, end: start + period, datasets: data?.datasets ?? [] };
   }, [aggregatesQuery.data]);
 
   // The charts keep showing the prior window's data while a new one loads,

--- a/web/hooks/useDashboardState.tsx
+++ b/web/hooks/useDashboardState.tsx
@@ -157,6 +157,23 @@ export function useDashboardState(page: "tts" | "stt" | "s2s") {
     }
   }, [availableWerDatasets, werDataset, werBarDatasetId]);
 
+  // Freshness as the charts see it: the newest series bucket actually served
+  // (start, and end inferred from the bucket spacing). Deliberately not the
+  // runs table alone — a finished run can precede its aggregates.
+  const latestDataBucket = useMemo(() => {
+    const times = [
+      ...new Set(
+        (aggregatesQuery.data?.series ?? []).map((point) =>
+          Date.parse(point.scheduled_at)
+        )
+      ),
+    ].sort((a, b) => a - b);
+    if (times.length === 0) return null;
+    const start = times[times.length - 1]!;
+    const period = times.length > 1 ? start - times[times.length - 2]! : 0;
+    return { start, end: start + period };
+  }, [aggregatesQuery.data]);
+
   // The charts keep showing the prior window's data while a new one loads,
   // so window-derived rendering must follow the data, not the toggle.
   const dataTimeWindow = aggregatesQuery.data?.window ?? timeWindow;
@@ -703,6 +720,7 @@ export function useDashboardState(page: "tts" | "stt" | "s2s") {
     // Data loading
     loading,
     loadError,
+    latestDataBucket,
 
     // Model state
     selectedModels,

--- a/web/lib/api/client.ts
+++ b/web/lib/api/client.ts
@@ -146,7 +146,9 @@ export async function getAggregatesByDataset(
 }
 
 export async function getRuns(opts?: FetchOptions): Promise<RunsApiResponse> {
-  return request<RunsApiResponse>("/v1/runs", { signal: opts?.signal });
+  // Max page size: one page must reach back past a full day of per-dataset
+  // runs so every modality still has a completed run on it.
+  return request<RunsApiResponse>("/v1/runs?limit=200", { signal: opts?.signal });
 }
 
 export async function getProviders(

--- a/web/lib/api/client.ts
+++ b/web/lib/api/client.ts
@@ -59,6 +59,8 @@ export type AggregatesByDatasetApiResponse =
   components["schemas"]["AggregatesByDatasetResponse"];
 export type ModelStatEntry = components["schemas"]["ModelStatEntry"];
 export type SeriesPoint = components["schemas"]["SeriesPoint"];
+export type RunsApiResponse = components["schemas"]["RunsResponse"];
+export type RunOut = components["schemas"]["RunOut"];
 
 // Query-param types from codegen
 export type AggregatesQueryParams = NonNullable<
@@ -141,6 +143,10 @@ export async function getAggregatesByDataset(
     `/v1/results/aggregates/by-dataset${qs}`,
     { signal: opts?.signal }
   );
+}
+
+export async function getRuns(opts?: FetchOptions): Promise<RunsApiResponse> {
+  return request<RunsApiResponse>("/v1/runs", { signal: opts?.signal });
 }
 
 export async function getProviders(

--- a/web/lib/api/queries.ts
+++ b/web/lib/api/queries.ts
@@ -9,6 +9,7 @@ import {
   getAggregates,
   getAggregatesByDataset,
   getProviders,
+  getRuns,
   getS2SSample,
   getS2SSampleAudio,
   getS2SSampleIds,
@@ -51,6 +52,14 @@ export function useProvidersQuery() {
     queryKey: ["providers"],
     queryFn: ({ signal }: { signal: AbortSignal }) =>
       getProviders({ signal } satisfies FetchOptions),
+  });
+}
+
+export function useRunsQuery() {
+  return useQuery({
+    queryKey: ["runs"],
+    queryFn: ({ signal }: { signal: AbortSignal }) =>
+      getRuns({ signal } satisfies FetchOptions),
   });
 }
 


### PR DESCRIPTION
## What
<img width="527" height="99" alt="Screenshot 2026-08-04 at 4 59 40 PM" src="https://github.com/user-attachments/assets/ad266544-28b3-40cf-89f4-78f8d3e40236" />

Adds an \"Updated X ago\" chip under the title on /tts, /stt, and /s2s, per benchmark type, with the absolute UTC timestamp in a tap/hover tooltip (reuses `MetricInfo`) and a rust dot + \"last run failed\" when the newest completed run for that board failed. Frontend only — no API or DB changes.

## How freshness is computed

Naively using `/v1/runs` alone is wrong in both directions, so the chip crosses the two sources the app already has:

- The dashboard's existing aggregates response gives the newest series bucket the charts actually serve (a finished run can precede its aggregates by ~30 min, so the runs table alone would claim updates the charts don't show yet).
- `/v1/runs` (filtered by the `dataset_id` modality prefix) gives the newest completed run whose finish falls inside that bucket, and the chip shows that run's **start** — its schedule slot, which matches the chart's newest point label (bucket start alone would make S2S's daily 00:00Z buckets undersell a 9 AM run by ~16 hr).

PARTIAL runs count as data (nearly every run is PARTIAL with flaky providers); only FAILED is surfaced.

## Notes

- Runs query rides the app-wide React Query defaults (5 min refetch); the relative text re-renders every 30 s.
- If the runs query fails, the chip falls back to the bucket time; if aggregates are empty, a fixed-height placeholder renders instead, so the header never shifts and failures degrade silently.
- Verified live against prod data on all three boards, mobile + desktop, both themes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a dashboard freshness chip backed by aggregate-series timestamps and the runs endpoint.
- Derives the latest served data bucket from aggregate series points.
- Fetches recent runs to display relative/absolute update time and the latest failure state.
- Integrates the chip into the shared STT, TTS, and S2S dashboard header.

<h3>Confidence Score: 4/5</h3>

The freshness chip needs correction before merging because it can disagree with the aggregate data shown by the dashboards.

Bucket boundaries are inferred from potentially sparse aggregate points, and S2S run matching includes a legacy dataset that the corresponding charts explicitly exclude.

**Files Needing Attention:** web/hooks/useDashboardState.tsx, web/components/dashboard/RunFreshness.tsx

<sub>Reviews (1): Last reviewed commit: ["Show the run&#39;s schedule slot, not its fi..."](https://github.com/coval-ai/benchmarks/commit/a113103e46786b7a6a6e966a881f402174789ea3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50271683)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Knowledge Base — [Web Dashboard (STT/TTS/S2S + Overview)](https://app.greptile.com/coval/-/custom-context/knowledge-base/coval-ai/benchmarks/-/docs/web-dashboard.md)

<!-- /greptile_comment -->