### PR TITLE
Authenticate the Fluxions websocket

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,6 +39,7 @@ TOGETHER_API_KEY=
 MINIMAX_API_KEY=
 MODULATE_API_KEY=
 LMNT_API_KEY=
+FLUXIONS_API_KEY=
 
 # --- API (optional) ---
 # Benchmarking-team key: requests with X-Internal-Key equal to this value see

--- a/runner/src/coval_bench/config.py
+++ b/runner/src/coval_bench/config.py
@@ -102,6 +102,7 @@ class Settings(BaseSettings):
     lmnt_api_key: SecretStr | None = None
     modulate_api_key: SecretStr | None = None
     speechify_api_key: SecretStr | None = None
+    fluxions_api_key: SecretStr | None = None
 
     # Azure region hosting the Speech resource (e.g. "eastus"). Determines the
     # region-scoped WebSocket host; required only when the Azure STT provider runs.

--- a/runner/src/coval_bench/providers/tts/fluxions.py
+++ b/runner/src/coval_bench/providers/tts/fluxions.py
@@ -7,11 +7,12 @@ Wire protocol on wss://api.fluxions.ai/vui/v1/tts/ws:
   connect → send speak(voice, input) → recv {"type": "start"}
   → recv binary s16le PCM @ 24 kHz frames → recv {"type": "done"}
 
-Built-in voices are public, so the render path takes no credential and there is
-no ``Settings`` key for this provider. ``verify_chunks`` is disabled: the
-server's STT re-render pass multiplies TTFA without improving WER. Voice ids
-are ``<name>.<catalog-hash>`` with a rotating hash, so the registry pins the
-bare name and this module resolves it against ``GET /vui/voices`` before t0.
+The websocket requires an API key, sent as a bearer ``Authorization`` header
+on the handshake; unauthenticated connects are closed 1008 by a bot gate. The
+voice catalog endpoint is public. ``verify_chunks`` is disabled: the server's
+STT re-render pass multiplies TTFA without improving WER. Voice ids are
+``<name>.<catalog-hash>`` with a rotating hash, so the registry pins the bare
+name and this module resolves it against ``GET /vui/voices`` before t0.
 """
 
 from __future__ import annotations
@@ -57,6 +58,10 @@ class FluxionsTTSProvider(TTSProvider):
             raise ValueError(f"Invalid Fluxions TTS model {model!r}. Valid: {_VALID_MODELS}")
         if not voice:
             raise ValueError("Fluxions TTS requires a voice")
+        api_key_secret = settings.fluxions_api_key
+        if api_key_secret is None:
+            raise ValueError("fluxions_api_key is required in Settings")
+        self._api_key = api_key_secret.get_secret_value()
         self._model = model
         self._voice = voice
 
@@ -107,7 +112,9 @@ class FluxionsTTSProvider(TTSProvider):
 
         try:
             voice_id = await self._resolve_voice()
-            async with ws_client.connect(_WS_URL) as ws:
+            async with ws_client.connect(
+                _WS_URL, additional_headers={"Authorization": f"Bearer {self._api_key}"}
+            ) as ws:
                 start = time.monotonic()
                 await ws.send(
                     json.dumps(

--- a/runner/src/coval_bench/registries/models.py
+++ b/runner/src/coval_bench/registries/models.py
@@ -756,7 +756,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         status=_EARLY_ACCESS,
     ),
     # No model id on the wire, only a voice, so "vui" is the bare surface name.
-    # Arena-disabled: keyless, so no env var for the key-parity gate to verify.
+    # Arena-disabled: FLUXIONS_API_KEY is not mounted on benchmarks-api yet.
     RegisteredModel(
         benchmark=_TTS,
         provider="fluxions",

--- a/runner/src/coval_bench/registries/provider_keys.py
+++ b/runner/src/coval_bench/registries/provider_keys.py
@@ -39,4 +39,5 @@ PROVIDER_ENV: dict[str, str] = {
     "palabra": "PALABRA_API_KEY",
     "speechify": "SPEECHIFY_API_KEY",
     "lmnt": "LMNT_API_KEY",
+    "fluxions": "FLUXIONS_API_KEY",
 }

--- a/runner/tests/providers/tts/test_fluxions.py
+++ b/runner/tests/providers/tts/test_fluxions.py
@@ -10,6 +10,7 @@ from collections.abc import Iterator
 from unittest.mock import patch
 
 import pytest
+from pydantic import SecretStr
 
 from coval_bench.config import Settings
 from coval_bench.providers.tts import fluxions as fluxions_module
@@ -29,6 +30,7 @@ def _settings() -> Settings:
         dataset_id="stt-v1",
         runner_sha="test",
         log_level="DEBUG",
+        fluxions_api_key=SecretStr("test-api-key"),
     )
 
 
@@ -83,6 +85,7 @@ async def test_fluxions_tts_url_and_speak_frame(fluxions_settings: Settings) -> 
 
     def connect_side_effect(url: str, **kwargs: object) -> FakeWebSocket:
         captured["url"] = url
+        captured["headers"] = kwargs.get("additional_headers")
         return ws
 
     provider = FluxionsTTSProvider(fluxions_settings, model="vui", voice=_VOICE)
@@ -95,6 +98,7 @@ async def test_fluxions_tts_url_and_speak_frame(fluxions_settings: Settings) -> 
 
     assert result.error is None
     assert captured["url"] == "wss://api.fluxions.ai/vui/v1/tts/ws"
+    assert captured["headers"] == {"Authorization": "Bearer test-api-key"}
     sent = [json.loads(m) for m in ws.sent if isinstance(m, str)]
     assert sent == [
         {
@@ -242,6 +246,12 @@ def test_fluxions_tts_invalid_model_raises(fluxions_settings: Settings) -> None:
 def test_fluxions_tts_missing_voice_raises(fluxions_settings: Settings) -> None:
     with pytest.raises(ValueError, match="requires a voice"):
         FluxionsTTSProvider(fluxions_settings, model="vui", voice="")
+
+
+def test_fluxions_tts_missing_api_key_raises(fluxions_settings: Settings) -> None:
+    fluxions_settings.fluxions_api_key = None
+    with pytest.raises(ValueError, match="fluxions_api_key"):
+        FluxionsTTSProvider(fluxions_settings, model="vui", voice=_VOICE)
 
 
 def test_fluxions_tts_provider_name(fluxions_settings: Settings) -> None:


### PR DESCRIPTION
Add an api key handshake to the fluxions client

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds API-key authentication to the Fluxions TTS WebSocket handshake.
- Adds `FLUXIONS_API_KEY` to settings, environment documentation, and the provider-key registry.
- Requires the credential when constructing the Fluxions provider and sends it as a Bearer authorization header.
- Updates Fluxions tests to cover authenticated handshakes and missing credentials.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete changed-code defect established.

The new credential follows the existing settings and provider-key conventions, and the supported WebSocket dependency accepts the authorization-header argument used by the handshake.

<sub>Reviews (1): Last reviewed commit: ["Authenticate the Fluxions websocket"](https://github.com/coval-ai/benchmarks/commit/e4479113fa56c35588e94841244f7273ee65a0c8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50485653)</sub>

**Context used:**

- Knowledge Base — [Runner Orchestration](https://app.greptile.com/coval/-/custom-context/knowledge-base/coval-ai/benchmarks/-/docs/runner-orchestration.md)

<!-- /greptile_comment -->