### PR TITLE
Flag a metric that rests on too few samples

### DIFF
--- a/runner/src/coval_bench/api/common.py
+++ b/runner/src/coval_bench/api/common.py
@@ -30,6 +30,34 @@ WINDOW_VIEWS: dict[str, str] = {
     "30d": "benchmarks_v2.results_30d",
 }
 
+# Fewest scored samples a headline stat may rest on, per modality. Below this a
+# stat is still returned but flagged insufficient, so the frontend shows "n/a"
+# rather than presenting one lucky sample as a provider's real number.
+#
+# Deliberately low. The floors sit just under the smallest legitimate cohort we
+# serve: a per-run breakdown metric lands 10 samples at a time, and S2S runs a
+# single ~30-item batch a day. A stricter floor would blank those. It is set to
+# catch collapse (a provider that scored 1 of 480 attempts), not thin-but-real
+# data, so a model failing most of its items still reports — see the
+# success/attempt ratio work for that case.
+#
+# Read-side only: every row stays in the database exactly as written.
+MIN_SCORED_SAMPLES: dict[str, int] = {
+    "STT": 5,
+    "TTS": 5,
+    "S2S": 5,
+}
+
+
+def has_enough_samples(benchmark: str, sample_count: int) -> bool:
+    """Whether *sample_count* clears the modality's floor for a headline stat.
+
+    An unknown benchmark passes: a new modality should surface its numbers
+    rather than silently read as "n/a" until someone adds a floor for it.
+    """
+    return sample_count >= MIN_SCORED_SAMPLES.get(benchmark, 0)
+
+
 # Bucket expression for chart timestamps: the run's cron trigger time,
 # falling back to created_at floored to the scheduler period for legacy rows.
 # Shared by /results and /results/aggregates so both bucket identically.

--- a/runner/src/coval_bench/api/routers/aggregates.py
+++ b/runner/src/coval_bench/api/routers/aggregates.py
@@ -237,7 +237,9 @@ async def get_results_aggregates_by_dataset(
         grouped: dict[str, list[ModelStatEntry]] = {}
         for row in rows:
             if _visible(row, hidden):
-                grouped.setdefault(row["dataset_id"], []).append(ModelStatEntry.model_validate(row))
+                grouped.setdefault(row["dataset_id"], []).append(
+                    _flag_thin(ModelStatEntry.model_validate(row), benchmark)
+                )
 
         return AggregatesByDatasetResponse(
             benchmark=benchmark,

--- a/runner/src/coval_bench/api/routers/aggregates.py
+++ b/runner/src/coval_bench/api/routers/aggregates.py
@@ -42,6 +42,7 @@ from coval_bench.api.common import (
     WINDOW_VIEWS,
     BenchmarkLiteral,
     WindowLiteral,
+    has_enough_samples,
 )
 from coval_bench.api.deps import (
     capture_api_event,
@@ -111,6 +112,18 @@ def _visible(row: dict[str, Any], hidden: frozenset[tuple[str, str]]) -> bool:
     )
 
 
+def _flag_thin(stat: ModelStatEntry, benchmark: str) -> ModelStatEntry:
+    """Mark a stat that rests on too few samples to present as a real number.
+
+    The values are left intact — a collapsed provider's one measurement is a real
+    measurement, and callers that want it still get it. Only the flag changes, so
+    the frontend can show "n/a" instead of ranking a lucky sample.
+    """
+    if has_enough_samples(benchmark, stat.sample_count):
+        return stat
+    return stat.model_copy(update={"insufficient_samples": True})
+
+
 @router.get("/results/aggregates", response_model=AggregatesResponse)
 @limiter.limit("60/minute")
 async def get_results_aggregates(
@@ -163,8 +176,12 @@ async def get_results_aggregates(
             dataset=dataset_key,
             datasets=[r["dataset_id"] for r in dataset_rows],
             model_stats=[
-                ModelStatEntry.model_validate(r) for r in stat_rows if _visible(r, hidden)
+                _flag_thin(ModelStatEntry.model_validate(r), benchmark)
+                for r in stat_rows
+                if _visible(r, hidden)
             ],
+            # Series points are deliberately unflagged: one bucket holds a single
+            # run's samples, so every point sits under the floor by design.
             series=[SeriesPoint.model_validate(r) for r in series_rows if _visible(r, hidden)],
         )
 

--- a/runner/src/coval_bench/api/routers/leaderboard.py
+++ b/runner/src/coval_bench/api/routers/leaderboard.py
@@ -24,7 +24,12 @@ from posthog import Posthog
 from psycopg_pool import AsyncConnectionPool
 from starlette.requests import Request
 
-from coval_bench.api.common import WINDOW_VIEWS, BenchmarkLiteral, WindowLiteral
+from coval_bench.api.common import (
+    WINDOW_VIEWS,
+    BenchmarkLiteral,
+    WindowLiteral,
+    has_enough_samples,
+)
 from coval_bench.api.deps import capture_api_event, get_pool, get_posthog
 from coval_bench.api.internal import hidden_early_access
 from coval_bench.api.ratelimit import limiter
@@ -106,6 +111,16 @@ async def get_leaderboard(
         if (r["provider"], r["model"]) not in hidden
         and not is_metric_excluded(r["provider"], r["model"], metric)
     ]
+    entries = [
+        e
+        if has_enough_samples(benchmark, e.n)
+        else e.model_copy(update={"insufficient_samples": True})
+        for e in entries
+    ]
+    # The view ranks by value alone, so a model that scored once with a fast time
+    # would lead the board. Thin entries sink below every ranked one; ORDER BY
+    # already sorted within each group, and a stable sort preserves it.
+    entries.sort(key=lambda e: e.insufficient_samples)
     capture_api_event(
         posthog_client,
         "leaderboard_queried",

--- a/runner/src/coval_bench/api/schemas.py
+++ b/runner/src/coval_bench/api/schemas.py
@@ -72,6 +72,11 @@ class LeaderboardEntry(BaseModel):
     p50: float
     p95: float
     n: int
+    # True when ``n`` is under the modality's floor: the values are real but rest
+    # on too few samples to rank on, so clients render "n/a". Sent alongside the
+    # numbers rather than in place of them, so a caller that wants the raw
+    # measurement still has it.
+    insufficient_samples: bool = False
 
 
 class ModelTagOut(BaseModel):
@@ -143,6 +148,11 @@ class ModelStatEntry(BaseModel):
     min_value: float
     max_value: float
     sample_count: int
+    # True when sample_count is under the modality's floor: the values are real
+    # but rest on too few samples to present, so clients render "n/a". Sent
+    # alongside the numbers rather than in place of them, so a caller that wants
+    # the raw measurement still has it.
+    insufficient_samples: bool = False
     # WER only, percentage points summing to avg_value; null pre-0014 rows —
     # clients fall back to the total alone.
     wer_insertions_pct: float | None = None

--- a/runner/tests/api/test_aggregates.py
+++ b/runner/tests/api/test_aggregates.py
@@ -667,4 +667,6 @@ async def test_by_dataset_stats_carry_the_flag(client: AsyncClient, postgresql: 
     assert thin["model_stats"][0]["insufficient_samples"] is True
     # The value survives the flag — nothing is dropped or nulled.
     assert thin["model_stats"][0]["avg_value"] == 0.0
+    assert thin["model_stats"][0]["sample_count"] == 1
     assert full["model_stats"][0]["insufficient_samples"] is False
+    assert full["model_stats"][0]["sample_count"] == MIN_SCORED_SAMPLES["STT"]

--- a/runner/tests/api/test_aggregates.py
+++ b/runner/tests/api/test_aggregates.py
@@ -15,7 +15,12 @@ import pytest
 from fastapi import FastAPI
 from httpx import AsyncClient
 
-from coval_bench.api.common import WINDOW_INTERVALS, WINDOW_VIEWS, WindowLiteral
+from coval_bench.api.common import (
+    MIN_SCORED_SAMPLES,
+    WINDOW_INTERVALS,
+    WINDOW_VIEWS,
+    WindowLiteral,
+)
 from tests.api.conftest import _fill_buckets, _insert_result, _insert_run, _refresh_mv
 
 
@@ -580,3 +585,61 @@ async def test_excluded_metric_rows_hidden(client: AsyncClient, postgresql: Any)
     assert stat_keys == [("assemblyai", "universal-streaming", "WER")]
     series_keys = {(p["provider"], p["model"], p["metric_type"]) for p in body["series"]}
     assert series_keys == {("assemblyai", "universal-streaming", "WER")}
+
+
+async def test_thin_stat_flagged_but_series_untouched(client: AsyncClient, postgresql: Any) -> None:
+    """A thin model stat is flagged; its series points are not.
+
+    One bucket holds a single run's samples, so every point sits under the floor
+    by design — flagging them would blank every timeline.
+    """
+    run_id = await _insert_run(postgresql)
+    await _insert_result(
+        postgresql,
+        run_id,
+        provider="hume",
+        model="octave-2",
+        metric_type="WER",
+        metric_value=0.0,
+        benchmark="TTS",
+    )
+    await _refresh_mv(postgresql)
+    await _fill_buckets(postgresql)
+
+    response = await client.get(
+        "/v1/results/aggregates", params={"benchmark": "TTS", "window": "24h"}
+    )
+    assert response.status_code == 200
+    data = response.json()
+
+    stats = [s for s in data["model_stats"] if s["model"] == "octave-2"]
+    assert [s["insufficient_samples"] for s in stats] == [True]
+    # The value survives the flag — nothing is dropped or nulled.
+    assert stats[0]["sample_count"] == 1
+    assert stats[0]["avg_value"] == 0.0
+
+    points = [p for p in data["series"] if p["model"] == "octave-2"]
+    assert points, "expected the thin model to still draw a timeline"
+    assert all("insufficient_samples" not in p for p in points)
+
+
+async def test_well_sampled_stat_not_flagged(client: AsyncClient, postgresql: Any) -> None:
+    """A model above its modality's floor reports normally."""
+    run_id = await _insert_run(postgresql)
+    for _ in range(MIN_SCORED_SAMPLES["TTS"] + 1):
+        await _insert_result(
+            postgresql,
+            run_id,
+            provider="elevenlabs",
+            model="eleven_v3",
+            metric_type="WER",
+            metric_value=3.0,
+            benchmark="TTS",
+        )
+    await _refresh_mv(postgresql)
+
+    response = await client.get(
+        "/v1/results/aggregates", params={"benchmark": "TTS", "window": "24h"}
+    )
+    stats = [s for s in response.json()["model_stats"] if s["model"] == "eleven_v3"]
+    assert [s["insufficient_samples"] for s in stats] == [False]

--- a/runner/tests/api/test_aggregates.py
+++ b/runner/tests/api/test_aggregates.py
@@ -643,3 +643,28 @@ async def test_well_sampled_stat_not_flagged(client: AsyncClient, postgresql: An
     )
     stats = [s for s in response.json()["model_stats"] if s["model"] == "eleven_v3"]
     assert [s["insufficient_samples"] for s in stats] == [False]
+
+
+async def test_by_dataset_stats_carry_the_flag(client: AsyncClient, postgresql: Any) -> None:
+    """Per-dataset blocks flag thin stats the same way the pooled ones do.
+
+    The same statistic must not read as trustworthy on one endpoint and thin on
+    the other.
+    """
+    thin_run = await _insert_run(postgresql, dataset_id="stt-v1")
+    await _insert_result(postgresql, thin_run, metric_value=0.0)
+    full_run = await _insert_run(postgresql, dataset_id="stt-v3")
+    for _ in range(MIN_SCORED_SAMPLES["STT"]):
+        await _insert_result(postgresql, full_run, metric_value=9.0)
+    await _refresh_mv(postgresql)
+
+    response = await client.get("/v1/results/aggregates/by-dataset", params={"benchmark": "STT"})
+    assert response.status_code == 200
+    blocks = response.json()["blocks"]
+    assert [b["dataset"] for b in blocks] == ["stt-v1", "stt-v3"]
+
+    thin, full = blocks
+    assert thin["model_stats"][0]["insufficient_samples"] is True
+    # The value survives the flag — nothing is dropped or nulled.
+    assert thin["model_stats"][0]["avg_value"] == 0.0
+    assert full["model_stats"][0]["insufficient_samples"] is False

--- a/runner/tests/api/test_leaderboard.py
+++ b/runner/tests/api/test_leaderboard.py
@@ -9,6 +9,7 @@ from typing import Any
 
 from httpx import AsyncClient
 
+from coval_bench.api.common import MIN_SCORED_SAMPLES
 from tests.api.conftest import _insert_result, _insert_run, _refresh_mv
 
 
@@ -154,3 +155,74 @@ async def test_excluded_metric_rows_hidden(client: AsyncClient, postgresql: Any)
     assert response.status_code == 200
     entries = response.json()["entries"]
     assert [(e["provider"], e["model"]) for e in entries] == [("deepgram", "nova-3")]
+
+
+async def test_thin_entry_flagged_and_sunk_below_ranked(
+    client: AsyncClient, postgresql: Any
+) -> None:
+    """A model scored fewer times than the floor can't outrank a well-sampled one.
+
+    The view orders by value alone, so a single fast measurement would otherwise
+    lead the board.
+    """
+    run_id = await _insert_run(postgresql)
+    # One lucky, very fast sample — would sort first on value.
+    await _insert_result(
+        postgresql,
+        run_id,
+        provider="fishaudio",
+        model="s1",
+        metric_type="WER",
+        metric_value=0.0,
+        benchmark="STT",
+    )
+    for _ in range(MIN_SCORED_SAMPLES["STT"]):
+        await _insert_result(
+            postgresql,
+            run_id,
+            provider="deepgram",
+            model="nova-3",
+            metric_type="WER",
+            metric_value=9.0,
+            benchmark="STT",
+        )
+    await _refresh_mv(postgresql)
+
+    response = await client.get(
+        "/v1/leaderboard", params={"metric": "WER", "benchmark": "STT", "window": "24h"}
+    )
+    assert response.status_code == 200
+    entries = response.json()["entries"]
+
+    assert [(e["model"], e["insufficient_samples"]) for e in entries] == [
+        ("nova-3", False),
+        ("s1", True),
+    ]
+    # The measurement is still reported, just not presented as rankable.
+    thin = entries[1]
+    assert thin["avg"] == 0.0
+    assert thin["n"] == 1
+
+
+async def test_entry_at_the_floor_is_not_flagged(client: AsyncClient, postgresql: Any) -> None:
+    """Exactly the floor's worth of samples counts as enough."""
+    run_id = await _insert_run(postgresql)
+    for _ in range(MIN_SCORED_SAMPLES["STT"]):
+        await _insert_result(
+            postgresql,
+            run_id,
+            provider="deepgram",
+            model="nova-3",
+            metric_type="WER",
+            metric_value=4.0,
+            benchmark="STT",
+        )
+    await _refresh_mv(postgresql)
+
+    response = await client.get(
+        "/v1/leaderboard", params={"metric": "WER", "benchmark": "STT", "window": "24h"}
+    )
+    entries = response.json()["entries"]
+    assert [(e["n"], e["insufficient_samples"]) for e in entries] == [
+        (MIN_SCORED_SAMPLES["STT"], False)
+    ]


### PR DESCRIPTION
A provider that failed almost everything it ran still published the few measurements that survived. `fishaudio/s1` scored 1 of ~480 attempts and read as 0.0% WER; Hume and Minimax did the same on 1–2 samples.

Stats under the modality's floor now carry `insufficient_samples` so the frontend can show "n/a", and a flagged entry sinks below every ranked one — the view orders by value alone, so one fast measurement would otherwise lead the board.

Values stay in the payload and no rows change. Series points are exempt: one bucket holds a single run's samples, so flagging them would blank every timeline.

Against prod this flags exactly the 8 affected rows and nothing else. The frontend half lands in benchmarks-web once this ships and codegen picks up the field.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds a modality-specific minimum sample floor and exposes an `insufficient_samples` response field while retaining raw metric values. It also moves flagged leaderboard entries behind sufficiently sampled entries, but the by-dataset aggregate path does not apply the new flag.

- Adds shared minimum-sample thresholds for STT, TTS, and S2S
- Flags thin pooled aggregate and leaderboard statistics
- Preserves timeline series points without flags
- Adds boundary and ordering tests for pooled aggregates and leaderboards

<h3>Confidence Score: 4/5</h3>

The by-dataset aggregates path must apply the same insufficient-sample rule before this is safe to merge.

Thin per-dataset ModelStatEntry values retain the schema default of false because that endpoint bypasses the newly introduced flagging helper, producing inconsistent API behavior for the same statistic type.

**Files Needing Attention:** runner/src/coval_bench/api/routers/aggregates.py

<sub>Reviews (1): Last reviewed commit: ["Flag a metric that rests on too few samp..."](https://github.com/coval-ai/benchmarks/commit/e1089f7ada77ac19649c9a645816b00efbc96d61) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50646809)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [API service](https://app.greptile.com/coval/-/custom-context/knowledge-base/coval-ai/benchmarks/-/docs/api-service.md)

<!-- /greptile_comment -->