### PR TITLE
[BENCH-632] Runner: capture native usage quantities per result (1/6)

### DIFF
--- a/runner/src/coval_bench/db/migrations/versions/20260806_0015_usage_quantities.py
+++ b/runner/src/coval_bench/db/migrations/versions/20260806_0015_usage_quantities.py
@@ -1,0 +1,54 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Capture raw usage quantities in native billing units.
+
+Per-result quantities land on ``results`` (tokens, provider-billed seconds,
+input characters, measured audio durations) and whisper-1 judge totals land on
+``runs``. All nullable, no backfill: providers report what they report, and
+cost math over these columns is a later migration's concern. The stats
+matviews don't select any of these columns, so unlike 0014 they are left
+untouched — a plain ADD COLUMN takes only the one lock and cannot deadlock
+against a concurrent matview refresh.
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "20260806_0015"
+down_revision = "20260804_0014"
+branch_labels = None
+depends_on = None
+
+_COLUMNS: dict[str, tuple[tuple[str, str], ...]] = {
+    "results": (
+        ("input_tokens", "BIGINT"),
+        ("output_tokens", "BIGINT"),
+        ("total_tokens", "BIGINT"),
+        ("billable_seconds", "DOUBLE PRECISION"),
+        ("characters_in", "INTEGER"),
+        ("audio_seconds_in", "DOUBLE PRECISION"),
+        ("audio_seconds_out", "DOUBLE PRECISION"),
+    ),
+    "runs": (
+        # whisper-1 bills by audio duration and reports duration-type usage, so
+        # the judge's real billing unit is seconds; the token columns cover a
+        # future token-billed judge model.
+        ("judge_input_tokens", "BIGINT"),
+        ("judge_output_tokens", "BIGINT"),
+        ("judge_audio_seconds", "DOUBLE PRECISION"),
+    ),
+}
+
+
+def upgrade() -> None:
+    for table, columns in _COLUMNS.items():
+        for name, sql_type in columns:
+            op.execute(f"ALTER TABLE benchmarks_v2.{table} ADD COLUMN {name} {sql_type}")
+
+
+def downgrade() -> None:
+    for table, columns in _COLUMNS.items():
+        for name, _ in columns:
+            op.execute(f"ALTER TABLE benchmarks_v2.{table} DROP COLUMN {name}")

--- a/runner/src/coval_bench/db/models.py
+++ b/runner/src/coval_bench/db/models.py
@@ -61,6 +61,10 @@ class Run(BaseModel):
     dataset_sha256: str
     status: RunStatus
     error: str | None = None
+    # whisper-1 judge spend for the run; null before migration 0015.
+    judge_input_tokens: int | None = None
+    judge_output_tokens: int | None = None
+    judge_audio_seconds: float | None = None
 
 
 class Result(BaseModel):
@@ -85,6 +89,15 @@ class Result(BaseModel):
     wer_insertions_pct: float | None = None
     wer_deletions_pct: float | None = None
     wer_substitutions_pct: float | None = None
+    # Raw usage in native billing units; null before migration 0015 or when
+    # the provider reports nothing.
+    input_tokens: int | None = None
+    output_tokens: int | None = None
+    total_tokens: int | None = None
+    billable_seconds: float | None = None
+    characters_in: int | None = None
+    audio_seconds_in: float | None = None
+    audio_seconds_out: float | None = None
 
 
 class VoteOutcome(StrEnum):

--- a/runner/src/coval_bench/db/writer.py
+++ b/runner/src/coval_bench/db/writer.py
@@ -114,9 +114,11 @@ class RunWriter:
                 (run_id, provider, model, voice, benchmark, metric_type,
                  metric_value, metric_units, audio_filename, transcript,
                  status, error, http_version, submit_to_headers_ms,
-                 wer_insertions_pct, wer_deletions_pct, wer_substitutions_pct)
+                 wer_insertions_pct, wer_deletions_pct, wer_substitutions_pct,
+                 input_tokens, output_tokens, total_tokens, billable_seconds,
+                 characters_in, audio_seconds_in, audio_seconds_out)
             VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s,
-                    %s, %s, %s)
+                    %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
         """
         params = [
             (
@@ -137,6 +139,13 @@ class RunWriter:
                 r.wer_insertions_pct,
                 r.wer_deletions_pct,
                 r.wer_substitutions_pct,
+                r.input_tokens,
+                r.output_tokens,
+                r.total_tokens,
+                r.billable_seconds,
+                r.characters_in,
+                r.audio_seconds_in,
+                r.audio_seconds_out,
             )
             for r in results
         ]
@@ -243,18 +252,34 @@ class RunWriter:
         *,
         status: RunStatus,
         error: str | None = None,
+        judge_input_tokens: int | None = None,
+        judge_output_tokens: int | None = None,
+        judge_audio_seconds: float | None = None,
     ) -> None:
-        """Set ``finished_at = now()`` and update ``status`` / ``error`` on a run row."""
+        """Set ``finished_at = now()``, ``status`` / ``error``, and judge spend on a run row."""
         sql = """
             UPDATE benchmarks_v2.runs
             SET finished_at = now(),
                 status = %s,
-                error  = %s
+                error  = %s,
+                judge_input_tokens = %s,
+                judge_output_tokens = %s,
+                judge_audio_seconds = %s
             WHERE id = %s
         """
         async with self._pool.connection() as conn:
             async with conn.cursor() as cur:
-                await cur.execute(sql, (status, error, run_id))
+                await cur.execute(
+                    sql,
+                    (
+                        status,
+                        error,
+                        judge_input_tokens,
+                        judge_output_tokens,
+                        judge_audio_seconds,
+                        run_id,
+                    ),
+                )
             await conn.commit()
 
     async def coval_run_ingested(self, *, provider: str, coval_run_id: str) -> bool:

--- a/runner/src/coval_bench/providers/base.py
+++ b/runner/src/coval_bench/providers/base.py
@@ -53,6 +53,12 @@ class TranscriptionResult:
     vad_events_count: int | None = None
     vad_first_event_content: str | None = None
 
+    # Native billing units as reported by the provider (never derived)
+    input_tokens: int | None = None
+    output_tokens: int | None = None
+    total_tokens: int | None = None
+    billable_seconds: float | None = None
+
 
 @dataclass
 class TTSResult:
@@ -70,6 +76,12 @@ class TTSResult:
     # The leading-silence part of ttfa_ms; None when offset detection didn't
     # run or failed, in which case ttfa_ms is arrival-only and has no split.
     leading_silence_ms: float | None = None
+    # Native billing units as reported by the provider (never derived)
+    input_tokens: int | None = None
+    output_tokens: int | None = None
+    total_tokens: int | None = None
+    characters_in: int | None = None
+    billable_seconds: float | None = None
 
 
 # ---------------------------------------------------------------------------

--- a/runner/src/coval_bench/providers/stt/cartesia.py
+++ b/runner/src/coval_bench/providers/stt/cartesia.py
@@ -156,6 +156,10 @@ class CartesiaSTTProvider(STTProvider):
                 if msg_type != "transcript":
                     continue
 
+                # Cumulative processed-audio duration; the last frame carries the total.
+                if isinstance(msg.get("duration"), (int, float)):
+                    result.billable_seconds = float(msg["duration"])
+
                 # Keep the raw text: Cartesia deltas carry their own leading spaces,
                 # which are the word separators. Strip only for the empty check + display.
                 text = str(msg.get("text", ""))

--- a/runner/src/coval_bench/providers/stt/deepgram.py
+++ b/runner/src/coval_bench/providers/stt/deepgram.py
@@ -261,6 +261,14 @@ class DeepgramProvider(STTProvider):
                         final_event.set()
                     continue
 
+                # is_final Results frames partition the audio, so their durations
+                # sum to the billed total — accumulate before the empty-transcript
+                # skip, which would drop silent tail segments.
+                if msg.get("is_final") and isinstance(msg.get("duration"), (int, float)):
+                    result.billable_seconds = (result.billable_seconds or 0.0) + float(
+                        msg["duration"]
+                    )
+
                 transcript = self._extract_transcript(msg)
                 if not transcript:
                     continue

--- a/runner/src/coval_bench/providers/stt/gradium.py
+++ b/runner/src/coval_bench/providers/stt/gradium.py
@@ -165,6 +165,9 @@ class GradiumSTTProvider(STTProvider):
                 msg_type: str = msg.get("type", "")
 
                 if msg_type == "step":
+                    # Cumulative processed-audio duration; the last step carries the total.
+                    if isinstance(msg.get("total_duration_s"), (int, float)):
+                        result.billable_seconds = float(msg["total_duration_s"])
                     result.vad_events_count = (result.vad_events_count or 0) + 1
                     if result.vad_first_detected is None and result.audio_start_time is not None:
                         result.vad_first_detected = now - result.audio_start_time

--- a/runner/src/coval_bench/providers/stt/inworld.py
+++ b/runner/src/coval_bench/providers/stt/inworld.py
@@ -186,6 +186,10 @@ class InworldSTTProvider(STTProvider):
                     break
 
                 if "usage" in msg:
+                    if isinstance(msg["usage"], dict):
+                        duration = msg["usage"].get("durationSeconds")
+                        if isinstance(duration, (int, float)):
+                            result.billable_seconds = float(duration)
                     break
 
                 transcription = msg.get("result", {}).get("transcription")

--- a/runner/src/coval_bench/providers/stt/mistral.py
+++ b/runner/src/coval_bench/providers/stt/mistral.py
@@ -217,6 +217,11 @@ class MistralSTTProvider(STTProvider):
                         delta_texts.append(text)
                         result.partial_transcripts.append(text)
                 elif msg_type == "transcription.done":
+                    usage = msg.get("usage")
+                    if isinstance(usage, dict):
+                        result.input_tokens = usage.get("prompt_tokens")
+                        result.output_tokens = usage.get("completion_tokens")
+                        result.total_tokens = usage.get("total_tokens")
                     text = str(msg.get("text", "")).strip()
                     result.complete_transcript = text or None
                     # A done with no text after a delta-less session is a dead

--- a/runner/src/coval_bench/providers/stt/modulate.py
+++ b/runner/src/coval_bench/providers/stt/modulate.py
@@ -191,6 +191,8 @@ class ModulateSTTProvider(STTProvider):
                     break
 
                 if msg_type == "done":
+                    if isinstance(msg.get("duration_ms"), (int, float)):
+                        result.billable_seconds = float(msg["duration_ms"]) / 1000.0
                     break
 
                 payload = msg.get(msg_type)

--- a/runner/src/coval_bench/providers/stt/openai.py
+++ b/runner/src/coval_bench/providers/stt/openai.py
@@ -240,6 +240,11 @@ class OpenAISTTProvider(STTProvider):
                     continue
 
                 if event_type == "conversation.item.input_audio_transcription.completed":
+                    usage = event.get("usage")
+                    if isinstance(usage, dict):
+                        result.input_tokens = usage.get("input_tokens")
+                        result.output_tokens = usage.get("output_tokens")
+                        result.total_tokens = usage.get("total_tokens")
                     transcript = str(event.get("transcript", "")).strip()
                     if not transcript:
                         continue

--- a/runner/src/coval_bench/providers/stt/xai.py
+++ b/runner/src/coval_bench/providers/stt/xai.py
@@ -213,6 +213,8 @@ class XaiSTTProvider(STTProvider):
 
                 if event_type == "transcript.done":
                     done_received = True
+                    if isinstance(event.get("duration"), (int, float)):
+                        result.billable_seconds = float(event["duration"])
                     done_transcript = str(event.get("text", "")).strip() or None
                     if done_transcript:
                         set_first_token(result, done_transcript, now=now)

--- a/runner/src/coval_bench/runner/orchestrator.py
+++ b/runner/src/coval_bench/runner/orchestrator.py
@@ -250,11 +250,18 @@ def _log_run_outcome(
         log_run_partial(f"providers failed every item: {'; '.join(dead)}")
 
 
-async def _transcribe_with_whisper(audio_path: Path, settings: Settings) -> str:
+async def _transcribe_with_whisper(
+    audio_path: Path, settings: Settings, judge_usage: dict[str, float] | None = None
+) -> str:
     """Transcribe *audio_path* with OpenAI ``whisper-1`` and return the text.
 
     Used by the TTS path to compute WER against the synthesized audio.
     Raises on API error — caller handles and records as a failed Result.
+
+    *judge_usage* is a run-scoped accumulator for the judge's own billed
+    quantities: whisper-1 reports duration-type usage (its billing unit), a
+    token-billed judge model would report token-type. Single-threaded asyncio
+    makes the read-modify-write safe without a lock.
     """
     import openai
 
@@ -268,6 +275,13 @@ async def _transcribe_with_whisper(audio_path: Path, settings: Settings) -> str:
             model="whisper-1",
             file=fh,
         )
+    usage = getattr(response, "usage", None)
+    if judge_usage is not None and usage is not None:
+        if usage.type == "tokens":
+            judge_usage["input_tokens"] = judge_usage.get("input_tokens", 0) + usage.input_tokens
+            judge_usage["output_tokens"] = judge_usage.get("output_tokens", 0) + usage.output_tokens
+        elif usage.type == "duration":
+            judge_usage["audio_seconds"] = judge_usage.get("audio_seconds", 0.0) + usage.seconds
     return str(response.text)
 
 
@@ -422,6 +436,16 @@ async def _run_stt_item(
         complete_transcript = (
             transcription_result.complete_transcript if transcription_result else None
         )
+        # Raw usage in native billing units, identical on every row of this item;
+        # duration_sec reflects the trimmed audio actually sent.
+        tr = transcription_result
+        usage_fields = {
+            "input_tokens": tr.input_tokens if tr else None,
+            "output_tokens": tr.output_tokens if tr else None,
+            "total_tokens": tr.total_tokens if tr else None,
+            "billable_seconds": tr.billable_seconds if tr else None,
+            "audio_seconds_in": duration_sec,
+        }
 
         # 1. TTFT — time-to-first-partial from first audio.
         ttft_status, ttft_error = _metric_outcome(
@@ -442,6 +466,7 @@ async def _run_stt_item(
                     transcript=complete_transcript,
                     status=ttft_status,
                     error=ttft_error,
+                    **usage_fields,
                 )
             )
             if ttft_status is ResultStatus.SUCCESS:
@@ -469,6 +494,7 @@ async def _run_stt_item(
                 transcript=complete_transcript,
                 status=atf_status,
                 error=atf_error,
+                **usage_fields,
             )
         )
         if atf_status is ResultStatus.SUCCESS:
@@ -514,6 +540,7 @@ async def _run_stt_item(
                     transcript=complete_transcript,
                     status=ttfs_status,
                     error=ttfs_error,
+                    **usage_fields,
                 )
             )
             if ttfs_status is ResultStatus.SUCCESS:
@@ -555,6 +582,7 @@ async def _run_stt_item(
                 transcript=complete_transcript,
                 status=rtf_status,
                 error=rtf_error,
+                **usage_fields,
             )
         )
         if rtf_status is ResultStatus.SUCCESS and rtf_value is not None:
@@ -584,6 +612,7 @@ async def _run_stt_item(
                         status=ResultStatus.SUCCESS,
                         error=None,
                         **wer_result.error_percentages,
+                        **usage_fields,
                     )
                 )
                 logger.debug(
@@ -616,6 +645,7 @@ async def _run_stt_item(
                         transcript=complete_transcript,
                         status=ResultStatus.FAILED,
                         error=_truncate(str(exc)),
+                        **usage_fields,
                     )
                 )
 
@@ -674,6 +704,7 @@ async def _run_tts_item(
     settings: Settings,
     voice: str | None = None,
     writer: Any | None = None,  # noqa: ANN401 — RunWriter, lazy-imported in caller
+    judge_usage: dict[str, float] | None = None,
 ) -> list[Any]:
     """Run a single TTS provider × dataset item, returning a list of Result rows.
 
@@ -732,6 +763,21 @@ async def _run_tts_item(
         item_error = item_error or (tts_result.error if tts_result is not None else None)
         ttfa_ms = tts_result.ttfa_ms if tts_result else None
 
+        audio_seconds_out: float | None = None
+        if audio_path is not None and audio_path.exists():
+            with contextlib.suppress(Exception), wave.open(str(audio_path), "rb") as wav_file:
+                audio_seconds_out = wav_file.getnframes() / wav_file.getframerate()
+
+        # Raw usage in native billing units, identical on every row of this item.
+        usage_fields = {
+            "input_tokens": tts_result.input_tokens if tts_result else None,
+            "output_tokens": tts_result.output_tokens if tts_result else None,
+            "total_tokens": tts_result.total_tokens if tts_result else None,
+            "billable_seconds": tts_result.billable_seconds if tts_result else None,
+            "characters_in": len(transcript),
+            "audio_seconds_out": audio_seconds_out,
+        }
+
         try:
             # 1. TTFA
             ttfa_status, ttfa_error = _metric_outcome(
@@ -772,6 +818,7 @@ async def _run_tts_item(
                     error=ttfa_error,
                     http_version=tts_result.http_version if tts_result else None,
                     submit_to_headers_ms=tts_result.submit_to_headers_ms if tts_result else None,
+                    **usage_fields,
                 )
             )
 
@@ -803,6 +850,7 @@ async def _run_tts_item(
                             transcript=transcript,
                             status=ResultStatus.SUCCESS,
                             error=None,
+                            **usage_fields,
                         )
                     )
 
@@ -813,7 +861,9 @@ async def _run_tts_item(
                 # transient Whisper outage doesn't drag the provider's run to PARTIAL.
                 whisper_transcript: str | None = None
                 try:
-                    whisper_transcript = await _transcribe_with_whisper(audio_path, settings)
+                    whisper_transcript = await _transcribe_with_whisper(
+                        audio_path, settings, judge_usage
+                    )
                 except Exception as exc:
                     logger.warning(
                         "tts_wer_transcription_failed",
@@ -842,6 +892,7 @@ async def _run_tts_item(
                                 status=ResultStatus.SUCCESS,
                                 error=None,
                                 **wer_result.error_percentages,
+                                **usage_fields,
                             )
                         )
                         logger.debug(
@@ -872,6 +923,7 @@ async def _run_tts_item(
                                 transcript=whisper_transcript,
                                 status=ResultStatus.FAILED,
                                 error=_truncate(str(exc)),
+                                **usage_fields,
                             )
                         )
         finally:
@@ -1083,6 +1135,17 @@ async def run_benchmarks(
         all_results: list[Any] = []
         sem = asyncio.Semaphore(_DEDICATED_CONCURRENCY_CAP if dedicated else _CONCURRENCY_CAP)
 
+        # Run-scoped whisper-judge spend, filled by _transcribe_with_whisper.
+        # Empty keys stay NULL on the run row rather than fabricating zeros.
+        judge_usage: dict[str, float] = {}
+
+        def _judge_totals() -> dict[str, Any]:
+            return {
+                "judge_input_tokens": judge_usage.get("input_tokens"),
+                "judge_output_tokens": judge_usage.get("output_tokens"),
+                "judge_audio_seconds": judge_usage.get("audio_seconds"),
+            }
+
         # Cloud Run sends SIGTERM ~10s before SIGKILL when a task hits its timeout.
         # We catch it, cancel the in-flight gather, and finalize the run row as
         # PARTIAL so timed-out executions surface in /v1/results instead of
@@ -1209,6 +1272,7 @@ async def run_benchmarks(
                         settings=settings,
                         voice=voice,
                         writer=writer,
+                        judge_usage=judge_usage,
                     )
                     for entry, item, voice in tts_pairs
                 ]
@@ -1245,7 +1309,7 @@ async def run_benchmarks(
             else:
                 final_status = RunStatus.PARTIAL
 
-            await writer.finish_run(run_id, status=final_status, error=None)
+            await writer.finish_run(run_id, status=final_status, error=None, **_judge_totals())
 
             # After the row is stored, never before: if finish_run raises, the outer
             # handler is the only thing that should report, otherwise a partial run
@@ -1326,6 +1390,7 @@ async def run_benchmarks(
                         run_id,
                         status=RunStatus.PARTIAL,
                         error="sigterm-received (cloud-run-task-timeout)",
+                        **_judge_totals(),
                     )
                 )
             except Exception as write_exc:
@@ -1391,7 +1456,9 @@ async def run_benchmarks(
             err_msg = _truncate(str(exc))
             log_run_failed(err_msg, exc)
             try:
-                await writer.finish_run(run_id, status=RunStatus.FAILED, error=err_msg)
+                await writer.finish_run(
+                    run_id, status=RunStatus.FAILED, error=err_msg, **_judge_totals()
+                )
             except Exception as write_exc:
                 logger.error(
                     "run_row_update_failed_after_failure",

--- a/runner/src/coval_bench/runner/orchestrator.py
+++ b/runner/src/coval_bench/runner/orchestrator.py
@@ -274,14 +274,24 @@ async def _transcribe_with_whisper(
         response = await client.audio.transcriptions.create(
             model="whisper-1",
             file=fh,
+            # verbose_json always carries a `duration` field; the default json
+            # shape only sometimes attaches `usage`, which would leave the
+            # judge unmetered. The transcript text is identical either way.
+            response_format="verbose_json",
         )
-    usage = getattr(response, "usage", None)
-    if judge_usage is not None and usage is not None:
-        if usage.type == "tokens":
+    if judge_usage is not None:
+        usage = getattr(response, "usage", None)
+        if usage is not None and usage.type == "tokens":
             judge_usage["input_tokens"] = judge_usage.get("input_tokens", 0) + usage.input_tokens
             judge_usage["output_tokens"] = judge_usage.get("output_tokens", 0) + usage.output_tokens
-        elif usage.type == "duration":
+        elif usage is not None and usage.type == "duration":
             judge_usage["audio_seconds"] = judge_usage.get("audio_seconds", 0.0) + usage.seconds
+        else:
+            duration = getattr(response, "duration", None)
+            if isinstance(duration, (int, float)):
+                judge_usage["audio_seconds"] = judge_usage.get("audio_seconds", 0.0) + float(
+                    duration
+                )
     return str(response.text)
 
 

--- a/runner/tests/providers/stt/fixtures/openai/events-success.json
+++ b/runner/tests/providers/stt/fixtures/openai/events-success.json
@@ -17,6 +17,13 @@
     "type": "conversation.item.input_audio_transcription.completed",
     "item_id": "item_001",
     "content_index": 0,
-    "transcript": "hello world how are you"
+    "transcript": "hello world how are you",
+    "usage": {
+      "type": "tokens",
+      "input_tokens": 33,
+      "input_token_details": {"text_tokens": 0, "audio_tokens": 33},
+      "output_tokens": 11,
+      "total_tokens": 44
+    }
   }
 ]

--- a/runner/tests/providers/stt/test_cartesia.py
+++ b/runner/tests/providers/stt/test_cartesia.py
@@ -59,6 +59,8 @@ async def test_cartesia_success(fake_api_key: SecretStr, audio_pcm_bytes: bytes)
     assert result.first_token_content is not None
     assert "hello" in result.first_token_content.lower()
     assert result.complete_transcript == "hello world how are you"
+    # duration is cumulative; the last transcript frame carries the total
+    assert result.billable_seconds == 2.4
 
 
 # ---------------------------------------------------------------------------

--- a/runner/tests/providers/stt/test_deepgram.py
+++ b/runner/tests/providers/stt/test_deepgram.py
@@ -70,6 +70,8 @@ async def test_deepgram_nova3_success(fake_api_key: SecretStr, audio_pcm_bytes: 
     # VAD: 1 SpeechStarted in fixture
     assert result.vad_events_count == 1
     assert result.vad_first_detected is not None
+    # One is_final Results frame with duration 3.0
+    assert result.billable_seconds == 3.0
 
 
 # ---------------------------------------------------------------------------
@@ -474,6 +476,8 @@ async def test_deepgram_audio_to_final_uses_last_final(
     complete_lower = result.complete_transcript.lower()
     assert "hello world" in complete_lower
     assert "how are you" in complete_lower
+    # is_final durations (1.5 + 3.0) sum to the billed total
+    assert result.billable_seconds == 4.5
 
 
 # ---------------------------------------------------------------------------

--- a/runner/tests/providers/stt/test_gradium.py
+++ b/runner/tests/providers/stt/test_gradium.py
@@ -69,6 +69,7 @@ async def test_gradium_success(fake_api_key: SecretStr, audio_pcm_bytes: bytes) 
     assert result.complete_transcript == "hello world how are you"
     assert result.word_count == 5
     assert result.audio_to_final_seconds is not None
+    assert result.billable_seconds == 0.5
     wer = compute_wer("hello world how are you", result.complete_transcript)
     assert wer.wer_percentage == pytest.approx(0.0)
 

--- a/runner/tests/providers/stt/test_inworld.py
+++ b/runner/tests/providers/stt/test_inworld.py
@@ -65,6 +65,7 @@ async def test_inworld_success(fake_api_key: SecretStr, audio_pcm_bytes: bytes) 
     assert result.complete_transcript == "hello world how are you"
     assert result.word_count == 5
     assert result.audio_to_final_seconds is not None
+    assert result.billable_seconds == 3.0
     wer = compute_wer("hello world how are you", result.complete_transcript)
     assert wer.wer_percentage == pytest.approx(0.0)
 

--- a/runner/tests/providers/stt/test_mistral.py
+++ b/runner/tests/providers/stt/test_mistral.py
@@ -60,6 +60,9 @@ async def test_mistral_success(fake_api_key: SecretStr, audio_pcm_bytes: bytes) 
     assert result.first_token_content == "hello"  # noqa: S105 - transcript fixture text
     assert result.complete_transcript == "hello world how are you"
     assert result.audio_to_final_seconds is not None
+    assert result.input_tokens == 0
+    assert result.output_tokens == 12
+    assert result.total_tokens == 12
     wer = compute_wer("hello world how are you", result.complete_transcript)
     assert wer.wer_percentage == pytest.approx(0.0)
 

--- a/runner/tests/providers/stt/test_modulate.py
+++ b/runner/tests/providers/stt/test_modulate.py
@@ -65,6 +65,7 @@ async def test_modulate_success(fake_api_key: SecretStr, audio_pcm_bytes: bytes)
     assert result.complete_transcript == "hello world how are you"
     assert result.word_count == 5
     assert result.audio_to_final_seconds is not None
+    assert result.billable_seconds == 3.0
     wer = compute_wer("hello world how are you", result.complete_transcript)
     assert wer.wer_percentage == pytest.approx(0.0)
 

--- a/runner/tests/providers/stt/test_openai.py
+++ b/runner/tests/providers/stt/test_openai.py
@@ -58,6 +58,9 @@ async def test_openai_success(fake_api_key: SecretStr, audio_pcm_bytes: bytes) -
     assert result.ttft_seconds >= 0
     assert result.audio_to_final_seconds is not None
     assert result.complete_transcript == "hello world how are you"
+    assert result.input_tokens == 33
+    assert result.output_tokens == 11
+    assert result.total_tokens == 44
     wer = compute_wer("hello world how are you", result.complete_transcript)
     assert wer.wer_percentage == pytest.approx(0.0)
 

--- a/runner/tests/providers/stt/test_xai.py
+++ b/runner/tests/providers/stt/test_xai.py
@@ -59,6 +59,7 @@ async def test_xai_grok_stt_success(fake_api_key: SecretStr, audio_pcm_bytes: by
     assert result.first_token_content == "hello"  # noqa: S105 - transcript fixture text
     assert result.complete_transcript == "hello world how are you"
     assert result.audio_to_final_seconds is not None
+    assert result.billable_seconds == 3.0
     wer = compute_wer("hello world how are you", result.complete_transcript)
     assert wer.wer_percentage == pytest.approx(0.0)
 

--- a/runner/tests/unit/test_db_writer.py
+++ b/runner/tests/unit/test_db_writer.py
@@ -113,6 +113,9 @@ def _make_result(
         metric_value=0.05 + idx * 0.01,
         metric_units="ratio",
         status=status,
+        total_tokens=12,
+        billable_seconds=2.5,
+        audio_seconds_in=3.0,
     )
 
 
@@ -148,6 +151,23 @@ def test_migration_up_down(pg_conn: psycopg.Connection[Any]) -> None:
         )
         columns = {row[0] for row in cur.fetchall()}
     assert {"http_version", "submit_to_headers_ms"} <= columns
+    assert {
+        "input_tokens",
+        "output_tokens",
+        "total_tokens",
+        "billable_seconds",
+        "characters_in",
+        "audio_seconds_in",
+        "audio_seconds_out",
+    } <= columns
+
+    with pg_conn.cursor() as cur:
+        cur.execute(
+            "SELECT column_name FROM information_schema.columns "
+            "WHERE table_schema = 'benchmarks_v2' AND table_name = 'runs'"
+        )
+        run_columns = {row[0] for row in cur.fetchall()}
+    assert {"judge_input_tokens", "judge_output_tokens", "judge_audio_seconds"} <= run_columns
 
     _downgrade_migrations(pg_conn)
 
@@ -226,7 +246,11 @@ def test_run_lifecycle(pg_conn: psycopg.Connection[Any]) -> None:
             for i in range(3):
                 await writer.record_result(_make_result(run.id, idx=i))
 
-            await writer.finish_run(run.id, status=RunStatus.SUCCEEDED)
+            await writer.finish_run(
+                run.id,
+                status=RunStatus.SUCCEEDED,
+                judge_audio_seconds=8.4,
+            )
         finally:
             await pool.close()
 
@@ -234,22 +258,31 @@ def test_run_lifecycle(pg_conn: psycopg.Connection[Any]) -> None:
         pg_conn.autocommit = True
         with pg_conn.cursor() as cur:
             cur.execute(
-                "SELECT status, finished_at FROM benchmarks_v2.runs WHERE id = %s",
+                "SELECT status, finished_at, judge_input_tokens, judge_audio_seconds "
+                "FROM benchmarks_v2.runs WHERE id = %s",
                 (run.id,),
             )
             row = cur.fetchone()
         assert row is not None
         assert row[0] == "succeeded"
         assert row[1] is not None
+        assert row[2] is None
+        assert row[3] == pytest.approx(8.4)
 
         with pg_conn.cursor() as cur:
             cur.execute(
-                "SELECT count(*) FROM benchmarks_v2.results WHERE run_id = %s",
+                "SELECT count(*), min(total_tokens), min(billable_seconds), "
+                "min(audio_seconds_in), min(characters_in) "
+                "FROM benchmarks_v2.results WHERE run_id = %s",
                 (run.id,),
             )
             count_row = cur.fetchone()
         assert count_row is not None
         assert count_row[0] == 3
+        assert count_row[1] == 12
+        assert count_row[2] == pytest.approx(2.5)
+        assert count_row[3] == pytest.approx(3.0)
+        assert count_row[4] is None
 
     asyncio.run(_run())
 

--- a/runner/tests/unit/test_db_writer.py
+++ b/runner/tests/unit/test_db_writer.py
@@ -269,20 +269,26 @@ def test_run_lifecycle(pg_conn: psycopg.Connection[Any]) -> None:
         assert row[2] is None
         assert row[3] == pytest.approx(8.4)
 
+        # count(col) + min==max prove every row carries the value (min/max
+        # alone would pass with NULLs or strays mixed in).
         with pg_conn.cursor() as cur:
             cur.execute(
-                "SELECT count(*), min(total_tokens), min(billable_seconds), "
-                "min(audio_seconds_in), min(characters_in) "
+                "SELECT count(*), count(total_tokens), min(total_tokens), max(total_tokens), "
+                "count(billable_seconds), min(billable_seconds), max(billable_seconds), "
+                "count(audio_seconds_in), min(audio_seconds_in), max(audio_seconds_in), "
+                "count(characters_in) "
                 "FROM benchmarks_v2.results WHERE run_id = %s",
                 (run.id,),
             )
             count_row = cur.fetchone()
         assert count_row is not None
         assert count_row[0] == 3
-        assert count_row[1] == 12
-        assert count_row[2] == pytest.approx(2.5)
-        assert count_row[3] == pytest.approx(3.0)
-        assert count_row[4] is None
+        assert count_row[1] == 3 and count_row[2] == count_row[3] == 12
+        assert count_row[4] == 3
+        assert count_row[5] == pytest.approx(2.5) and count_row[6] == pytest.approx(2.5)
+        assert count_row[7] == 3
+        assert count_row[8] == pytest.approx(3.0) and count_row[9] == pytest.approx(3.0)
+        assert count_row[10] == 0  # STT-shaped rows: characters_in stays NULL
 
     asyncio.run(_run())
 

--- a/runner/tests/unit/test_orchestrator.py
+++ b/runner/tests/unit/test_orchestrator.py
@@ -2117,8 +2117,15 @@ async def test_transcribe_with_whisper_accumulates_judge_usage(
         assert await _transcribe_with_whisper(audio_file, settings, judge_usage) == "hello"
         response.usage = MagicMock(type="tokens", input_tokens=7, output_tokens=3)
         assert await _transcribe_with_whisper(audio_file, settings, judge_usage) == "hello"
+        # No usage object at all: verbose_json's duration field is the fallback.
+        response.usage = None
+        response.duration = 2.5
+        assert await _transcribe_with_whisper(audio_file, settings, judge_usage) == "hello"
 
-    assert judge_usage == {"audio_seconds": 4.0, "input_tokens": 7, "output_tokens": 3}
+    assert judge_usage == {"audio_seconds": 6.5, "input_tokens": 7, "output_tokens": 3}
+    # verbose_json is what guarantees the duration field exists.
+    call_kwargs = client.audio.transcriptions.create.await_args.kwargs
+    assert call_kwargs["response_format"] == "verbose_json"
 
 
 @pytest.mark.asyncio

--- a/runner/tests/unit/test_orchestrator.py
+++ b/runner/tests/unit/test_orchestrator.py
@@ -48,6 +48,7 @@ from coval_bench.runner.orchestrator import (
     RunSummary,
     _dead_providers,
     _stt_silent_failure,
+    _transcribe_with_whisper,
     run_benchmarks,
 )
 from coval_bench.runner.retry import with_retry
@@ -293,6 +294,10 @@ def settings() -> Settings:
 async def test_smoke_run_stt(audio_file: Path, settings: Settings) -> None:
     """1-item dataset, 2 STT providers, happy path → SUCCEEDED."""
     good = _good_transcription()
+    good.input_tokens = 5
+    good.output_tokens = 7
+    good.total_tokens = 12
+    good.billable_seconds = 2.5
 
     provider_a = MagicMock()
     provider_a.measure_ttft = AsyncMock(return_value=good)
@@ -338,7 +343,23 @@ async def test_smoke_run_stt(audio_file: Path, settings: Settings) -> None:
     # The default STT matrix has additional deepgram models (nova-3, flux), so
     # both deepgram and elevenlabs each fire multiple times via the same mock.
     assert writer.record_results.await_count >= 2
-    writer.finish_run.assert_awaited_once_with(1, status=RunStatus.SUCCEEDED, error=None)
+    writer.finish_run.assert_awaited_once_with(
+        1,
+        status=RunStatus.SUCCEEDED,
+        error=None,
+        judge_input_tokens=None,
+        judge_output_tokens=None,
+        judge_audio_seconds=None,
+    )
+    # Usage quantities ride every row of the item: the dataset item's audio
+    # duration plus whatever the provider reported.
+    rows = _recorded_rows(writer)
+    assert rows
+    assert all(r.audio_seconds_in == 1.0 for r in rows)
+    assert all(r.input_tokens == 5 for r in rows)
+    assert all(r.output_tokens == 7 for r in rows)
+    assert all(r.total_tokens == 12 for r in rows)
+    assert all(r.billable_seconds == 2.5 for r in rows)
     writer.refresh_stats_matviews.assert_awaited_once_with()
     writer.refresh_bucket.assert_awaited_once_with(
         1, period_seconds=settings.schedule_period_seconds
@@ -389,7 +410,14 @@ async def test_partial_run(audio_file: Path, settings: Settings) -> None:
     assert summary.status == str(RunStatus.PARTIAL)
     assert summary.fail_count >= 1
     assert summary.success_count >= 1
-    writer.finish_run.assert_awaited_once_with(1, status=RunStatus.PARTIAL, error=None)
+    writer.finish_run.assert_awaited_once_with(
+        1,
+        status=RunStatus.PARTIAL,
+        error=None,
+        judge_input_tokens=None,
+        judge_output_tokens=None,
+        judge_audio_seconds=None,
+    )
     writer.refresh_bucket.assert_awaited_once_with(
         1, period_seconds=settings.schedule_period_seconds
     )
@@ -2017,6 +2045,80 @@ async def test_tts_provider_error_wins_over_contamination(
     assert "TTFARoundtrip" not in by_metric
     assert "TTFALeadingSilence" not in by_metric
     assert summary.success_count == 0
+
+
+@pytest.mark.asyncio
+async def test_tts_usage_quantities_recorded(audio_file: Path, settings: Settings) -> None:
+    """Every TTS row carries characters_in, measured output duration, and provider usage."""
+    hume_entry = _registry_entry(Benchmark.TTS, "hume")
+    tts_result = TTSResult(
+        provider="hume",
+        model=hume_entry.model,
+        voice=hume_entry.voice or "v",
+        ttfa_ms=120.0,
+        audio_path=audio_file,
+        error=None,
+        http_version="HTTP/2",
+        billable_seconds=1.9,
+    )
+
+    provider_inst = MagicMock()
+    provider_inst.synthesize = AsyncMock(return_value=tts_result)
+    provider_cls = MagicMock(return_value=provider_inst)
+
+    matrix = [
+        *_paused_registry(Benchmark.TTS),
+        hume_entry.model_copy(update={"status": ModelStatus.ACTIVE}),
+    ]
+
+    run = _make_run()
+    writer = _make_stub_writer(run)
+
+    async with _orchestrator_env(
+        audio_path=audio_file,
+        tts_items=[_make_tts_item("hello world")],
+        tts_providers={"hume": provider_cls},
+        run=run,
+        writer=writer,
+    ) as _:
+        with patch(
+            "coval_bench.runner.orchestrator._transcribe_with_whisper",
+            return_value="hello world",
+        ):
+            await run_benchmarks(
+                settings=settings,
+                benchmark_kind="tts",
+                smoke=True,
+                matrix_overrides=matrix,
+            )
+
+    rows = _recorded_rows(writer)
+    assert {r.metric_type for r in rows} == {"TTFA", "WER"}
+    # audio_file is 512 PCM16 frames at 16 kHz.
+    assert all(r.characters_in == len("hello world") for r in rows)
+    assert all(r.audio_seconds_out == pytest.approx(512 / 16000) for r in rows)
+    assert all(r.billable_seconds == 1.9 for r in rows)
+
+
+@pytest.mark.asyncio
+async def test_transcribe_with_whisper_accumulates_judge_usage(
+    audio_file: Path, settings: Settings
+) -> None:
+    """Both whisper usage shapes accumulate: duration-type seconds, token-type tokens."""
+    response = MagicMock()
+    response.text = "hello"
+    response.usage = MagicMock(type="duration", seconds=2.0)
+    client = MagicMock()
+    client.audio.transcriptions.create = AsyncMock(return_value=response)
+
+    judge_usage: dict[str, float] = {}
+    with patch("openai.AsyncOpenAI", return_value=client):
+        assert await _transcribe_with_whisper(audio_file, settings, judge_usage) == "hello"
+        assert await _transcribe_with_whisper(audio_file, settings, judge_usage) == "hello"
+        response.usage = MagicMock(type="tokens", input_tokens=7, output_tokens=3)
+        assert await _transcribe_with_whisper(audio_file, settings, judge_usage) == "hello"
+
+    assert judge_usage == {"audio_seconds": 4.0, "input_tokens": 7, "output_tokens": 3}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
First of the six stacked BENCH-631 cost/pricing PRs — merge in ticket order; each PR diff is only its own commit.

Widens `TranscriptionResult`/`TTSResult` with raw usage fields and parses them where providers already report usage (Mistral + OpenAI Realtime tokens; Inworld/xAI/Deepgram/Cartesia/Modulate/Gradium billable duration — Deepgram sums is_final frame durations, Cartesia/Gradium are cumulative so last wins). The orchestrator stamps every result row with known quantities (STT `audio_seconds_in` from the trimmed item, TTS `characters_in` + measured `audio_seconds_out`) and meters the whisper-1 judge per run. Migration `0015` adds the nullable columns (plus `judge_audio_seconds` beyond the ticket DDL: whisper-1 reports duration-type usage, its actual billing unit). No behavior change to metrics; all fields nullable; providers that report nothing still work.

Tests: provider fixtures now assert parsed usage; real-Postgres migration up/down + writer roundtrip; judge accumulation covered for both usage shapes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds nullable native usage quantities to benchmark result and run records.
- Parses token or billed-duration usage reported by supported STT providers.
- Stamps STT and TTS metric rows with request-level input/output quantities.
- Accumulates Whisper judge usage and persists it when finalizing a run.
- Adds the corresponding migration, database writer support, fixtures, and tests.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge; no concrete changed-code failure remains supported by the available repository evidence.

The migration, persistence models, writer SQL, provider parsing, and orchestrator propagation are coordinated, while investigated edge cases either match the documented design or lack a reachable failing condition.

<sub>Reviews (1): Last reviewed commit: ["\[BENCH-632\] Runner: capture native usage..."](https://github.com/coval-ai/benchmarks/commit/2ce6c146dea2d3f0d8c40ac610f4b5d9f264d1f8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50942993)</sub>

**Context used:**

- Knowledge Base — [Runner Orchestration](https://app.greptile.com/coval/-/custom-context/knowledge-base/coval-ai/benchmarks/-/docs/runner-orchestration.md)
- Knowledge Base — [DB Layer](https://app.greptile.com/coval/-/custom-context/knowledge-base/coval-ai/benchmarks/-/docs/db-layer.md)

<!-- /greptile_comment -->