### PR TITLE
[BENCH-633] Pricing store: append-only model_pricing table + seed ratesheet (2/6)

### DIFF
--- a/runner/scripts/check_pricing_coverage.py
+++ b/runner/scripts/check_pricing_coverage.py
@@ -28,10 +28,7 @@ async def _unpriced() -> list[str]:
             f"{m.benchmark}:{m.provider}/{m.model}"
             for m in MODEL_REGISTRY
             if m.status in (ModelStatus.ACTIVE, ModelStatus.EARLY_ACCESS)
-            and not any(
-                r.benchmark is m.benchmark
-                for r in store.effective_rates_cached(m.provider, m.model)
-            )
+            and not store.effective_rates_cached(m.provider, m.model, m.benchmark)
         ]
 
 

--- a/runner/scripts/check_pricing_coverage.py
+++ b/runner/scripts/check_pricing_coverage.py
@@ -1,0 +1,53 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+"""Report ACTIVE / EARLY_ACCESS models missing an effective ``model_pricing`` rate.
+
+Mirrors ``check_arena_keys.py``: exits non-zero with the offending list so it
+can gate CI or be run manually after registry changes. Known-unpriced models
+(no published rate anywhere — the seed script's gap list) still fail here:
+the failure IS the staleness signal to re-research them.
+
+Usage: DATABASE_URL=... uv run python scripts/check_pricing_coverage.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from coval_bench.config import get_settings
+from coval_bench.db.conn import lifespan_pool
+from coval_bench.db.pricing import PricingStore
+from coval_bench.registries.models import MODEL_REGISTRY, ModelStatus
+
+
+async def _unpriced() -> list[str]:
+    async with lifespan_pool(get_settings()) as pool:
+        store = PricingStore(pool)
+        await store.load_cache()
+        return [
+            f"{m.benchmark}:{m.provider}/{m.model}"
+            for m in MODEL_REGISTRY
+            if m.status in (ModelStatus.ACTIVE, ModelStatus.EARLY_ACCESS)
+            and not any(
+                r.benchmark is m.benchmark
+                for r in store.effective_rates_cached(m.provider, m.model)
+            )
+        ]
+
+
+def main() -> int:
+    missing = asyncio.run(_unpriced())
+    if missing:
+        print(
+            f"ERROR: {len(missing)} active models have no effective pricing row:\n  "
+            + "\n  ".join(missing)
+            + "\nAdd rates via scripts/seed_pricing.py (with source_url + as_of), "
+            "or pause the model."
+        )
+        return 1
+    print("OK: every active model has an effective pricing row")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/runner/scripts/seed_pricing.py
+++ b/runner/scripts/seed_pricing.py
@@ -1,0 +1,708 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+"""Seed ``benchmarks_v2.model_pricing`` with researched published list rates.
+
+One entry per ACTIVE / EARLY_ACCESS model in ``registries/models.py``, each in
+the provider's native billing unit with the provider's public pricing page as
+provenance. Subscription/credit providers are converted to an effective
+per-unit rate under the Artificial-Analysis-style assumption recorded in
+``plan_assumption``: the lowest-upfront plan that realistically supports
+1,000 min/month (STT) or 1M chars/month (TTS).
+
+Models whose price could not be verified on an official page get NO row —
+they are printed as an explicit gap list instead (never guessed). The gap
+list is enforced by ``scripts/check_pricing_coverage.py``.
+
+Idempotent: re-running upserts nothing when the effective rates are unchanged
+(``PricingStore.upsert_rate`` is a no-op on identical rate + plan). A changed
+rate supersedes the old row, preserving history.
+
+Run against a LOCAL/dev database only::
+
+    DATABASE_URL=postgresql://postgres:postgres@localhost:5432/benchmarks \\
+        uv run python scripts/seed_pricing.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import date
+from decimal import Decimal
+from typing import NamedTuple
+from urllib.parse import urlsplit
+
+from coval_bench.config import get_settings
+from coval_bench.db.conn import lifespan_pool
+from coval_bench.db.models import Benchmark, BillingUnit
+from coval_bench.db.pricing import PricingStore
+from coval_bench.registries.models import MODEL_REGISTRY, ModelStatus
+
+_LOCAL_HOSTS = frozenset({"localhost", "127.0.0.1", "::1"})
+
+#: Date the rates below were verified against the linked pricing pages.
+AS_OF = date(2026, 8, 6)
+
+
+class Rate(NamedTuple):
+    """One published rate in the provider's native billing unit."""
+
+    unit: BillingUnit
+    rate_usd: str  # exact decimal string, e.g. "0.0059"
+    source_url: str
+    evidence: str
+    plan_assumption: str | None = None
+
+
+# Keyed by (benchmark, provider, model) — matching registries/models.py
+# identifiers. Token-billed models carry two Rate entries (input + output).
+# Every rate was verified on the linked page on AS_OF; unpriced models
+# (enterprise/unpublished) are deliberately absent and surface as gaps.
+RATESHEET: dict[tuple[Benchmark, str, str], tuple[Rate, ...]] = {
+    # ------------------------------------------------------------------ STT
+    (Benchmark.STT, "cartesia", "ink-2"): (
+        Rate(
+            BillingUnit.PER_MINUTE,
+            "0.049",
+            "https://cartesia.ai/pricing",
+            'Startup $49/mo includes "~115h 44m" STT; Pro $5/mo covers only ~9h16m',
+            "Cartesia Startup plan $49/mo (1.25M credits, STT 3 credits/s); "
+            "lowest plan supporting 1,000 min/mo: $49 / 1,000 min",
+        ),
+    ),
+    (Benchmark.STT, "elevenlabs", "scribe_v2_realtime"): (
+        Rate(
+            BillingUnit.PER_HOUR,
+            "0.39",
+            "https://elevenlabs.io/pricing/api",
+            'Scribe v2 Realtime — "$0.39 / Price per hour" (API billed in USD, not credits)',
+        ),
+    ),
+    (Benchmark.STT, "soniox", "stt-rt-v5"): (
+        Rate(
+            BillingUnit.PER_HOUR,
+            "0.12",
+            "https://soniox.com/pricing",
+            'stt-rt-v5 — "$0.12/hr" real-time transcription '
+            "(underlying token billing: $2/1M audio-in + $4/1M text-out)",
+        ),
+    ),
+    (Benchmark.STT, "smallest", "pulse"): (
+        Rate(
+            BillingUnit.PER_MINUTE,
+            "0.008",
+            "https://docs.smallest.ai/models/model-cards/speech-to-text/pulse",
+            'Pulse model card: "Realtime: $0.008/min" (batch $0.005/min)',
+        ),
+    ),
+    (Benchmark.STT, "inworld", "inworld-stt-1"): (
+        Rate(
+            BillingUnit.PER_HOUR,
+            "0.15",
+            "https://inworld.ai/pricing",
+            'STT On-Demand "$0.15/hr" (paid tiers discount to $0.10/hr)',
+        ),
+    ),
+    (Benchmark.STT, "gradium", "default"): (
+        Rate(
+            BillingUnit.PER_MINUTE,
+            "0.013",
+            "https://gradium.ai/pricing",
+            '"Speech-to-Text: 3 credits / second"; XS $13/mo = 225k credits',
+            "Gradium XS plan $13/mo (225k credits); 1,000 min = 180k credits "
+            "fits in XS: $13 / 1,000 min",
+        ),
+    ),
+    (Benchmark.STT, "openai", "gpt-4o-transcribe"): (
+        Rate(
+            BillingUnit.PER_1M_TOKENS_INPUT,
+            "2.50",
+            "https://developers.openai.com/api/docs/pricing",
+            'audio input tokens: "gpt-4o-transcribe Transcription $2.50 $10.00 $0.006/minute"',
+        ),
+        Rate(
+            BillingUnit.PER_1M_TOKENS_OUTPUT,
+            "10.00",
+            "https://developers.openai.com/api/docs/pricing",
+            "text output tokens: gpt-4o-transcribe $10.00 per 1M",
+        ),
+    ),
+    (Benchmark.STT, "openai", "gpt-4o-mini-transcribe"): (
+        Rate(
+            BillingUnit.PER_1M_TOKENS_INPUT,
+            "1.25",
+            "https://developers.openai.com/api/docs/pricing",
+            'audio input tokens: "gpt-4o-mini-transcribe Transcription $1.25 $5.00 $0.003/minute"',
+        ),
+        Rate(
+            BillingUnit.PER_1M_TOKENS_OUTPUT,
+            "5.00",
+            "https://developers.openai.com/api/docs/pricing",
+            "text output tokens: gpt-4o-mini-transcribe $5.00 per 1M",
+        ),
+    ),
+    (Benchmark.STT, "openai", "gpt-realtime-whisper"): (
+        Rate(
+            BillingUnit.PER_MINUTE,
+            "0.017",
+            "https://developers.openai.com/api/docs/pricing",
+            'Realtime models table: "gpt-realtime-whisper Audio - - $0.017 / minute"',
+        ),
+    ),
+    (Benchmark.STT, "mistral", "voxtral-mini-transcribe-realtime-2602"): (
+        Rate(
+            BillingUnit.PER_MINUTE,
+            "0.006",
+            "https://mistral.ai/news/voxtral-transcribe-2/",
+            '"voxtral-mini-transcribe-realtime-2602 ... $0.006 per minute" '
+            "(batch voxtral-mini-transcribe is $0.003/min)",
+        ),
+    ),
+    (Benchmark.STT, "google", "chirp_2"): (
+        Rate(
+            BillingUnit.PER_MINUTE,
+            "0.016",
+            "https://cloud.google.com/speech-to-text/pricing",
+            "Speech-to-Text V2 Recognition (sku 3099-B70F-0949) Standard, "
+            "0-500,000 min tier: $0.016/min; chirp models bill as Standard V2",
+        ),
+    ),
+    (Benchmark.STT, "google", "chirp_3"): (
+        Rate(
+            BillingUnit.PER_MINUTE,
+            "0.016",
+            "https://cloud.google.com/speech-to-text/pricing",
+            "Speech-to-Text V2 Recognition Standard 0-500,000 min tier: $0.016/min",
+        ),
+    ),
+    (Benchmark.STT, "together", "nemotron-3.5-asr-streaming-0.6b"): (
+        Rate(
+            BillingUnit.PER_MINUTE,
+            "0.0045",
+            "https://www.together.ai/pricing",
+            'per audio minute: "NVIDIA Nemotron 3.5 ASR $0.0045/min" (streaming)',
+        ),
+    ),
+    (Benchmark.STT, "together", "parakeet-tdt-0.6b-v3"): (
+        Rate(
+            BillingUnit.PER_MINUTE,
+            "0.0015",
+            "https://www.together.ai/pricing",
+            'per audio minute: "NVIDIA Parakeet TDT 0.6B v3 $0.0015"',
+        ),
+    ),
+    (Benchmark.STT, "together", "whisper-large-v3"): (
+        Rate(
+            BillingUnit.PER_MINUTE,
+            "0.0035",
+            "https://www.together.ai/pricing",
+            '"Whisper Large v3 (Streaming) $0.0035/min" (batch is $0.0015/min)',
+        ),
+    ),
+    (Benchmark.STT, "xai", "grok-stt"): (
+        Rate(
+            BillingUnit.PER_HOUR,
+            "0.20",
+            "https://docs.x.ai/docs/models",
+            'Voice pricing: "Speech to Text | $0.10/hr (REST), $0.20/hr (Streaming)" — streaming',
+        ),
+    ),
+    (Benchmark.STT, "modulate", "velma-2-stt-streaming"): (
+        Rate(
+            BillingUnit.PER_HOUR,
+            "0.06",
+            "https://www.modulate.ai/api-pricing",
+            '"Multilingual Speech-to-Text ... Streaming $0.06" per hour of audio',
+        ),
+    ),
+    (Benchmark.STT, "modulate", "velma-2-stt-streaming-english-v2"): (
+        Rate(
+            BillingUnit.PER_HOUR,
+            "0.05",
+            "https://www.modulate.ai/api-pricing",
+            '"English Fast Speech-to-Text ... Streaming $0.05" per hour of audio',
+        ),
+    ),
+    (Benchmark.STT, "deepgram", "nova-2"): (
+        Rate(
+            BillingUnit.PER_HOUR,
+            "0.35",
+            "https://deepgram.com/pricing",
+            'FAQ: "Nova-2 streaming at $0.35/hour" (legacy rate for existing deployments)',
+        ),
+    ),
+    (Benchmark.STT, "deepgram", "nova-3"): (
+        Rate(
+            BillingUnit.PER_MINUTE,
+            "0.0048",
+            "https://deepgram.com/pricing",
+            'Nova-3 Monolingual streaming "$0.0048/min" (limited-time promo; regular list '
+            "$0.0077/min shown struck through)",
+        ),
+    ),
+    (Benchmark.STT, "deepgram", "flux-general-en"): (
+        Rate(
+            BillingUnit.PER_MINUTE,
+            "0.0065",
+            "https://deepgram.com/pricing",
+            'Flux English streaming "$0.0065/min" (promo; regular list $0.0077/min)',
+        ),
+    ),
+    (Benchmark.STT, "deepgram", "flux-general-multi"): (
+        Rate(
+            BillingUnit.PER_MINUTE,
+            "0.0078",
+            "https://deepgram.com/pricing",
+            'Flux Multilingual streaming "$0.0078/min"',
+        ),
+    ),
+    (Benchmark.STT, "assemblyai", "universal-streaming"): (
+        Rate(
+            BillingUnit.PER_HOUR,
+            "0.15",
+            "https://www.assemblyai.com/pricing",
+            'Universal-Streaming English "$0.15/hr — billed on WebSocket session duration"',
+        ),
+    ),
+    (Benchmark.STT, "assemblyai", "universal-streaming-multilingual"): (
+        Rate(
+            BillingUnit.PER_HOUR,
+            "0.15",
+            "https://www.assemblyai.com/pricing",
+            'Universal-Streaming Multilingual "$0.15/hr" (session-duration billing)',
+        ),
+    ),
+    (Benchmark.STT, "assemblyai", "universal-3.5-pro"): (
+        Rate(
+            BillingUnit.PER_HOUR,
+            "0.45",
+            "https://www.assemblyai.com/pricing",
+            'Universal-3.5 Pro Realtime (u3-rt-pro) "$0.45/hr base" (session-duration billing)',
+        ),
+    ),
+    (Benchmark.STT, "speechmatics", "default"): (
+        Rate(
+            BillingUnit.PER_HOUR,
+            "0.45",
+            "https://www.speechmatics.com/pricing",
+            'Real-time Standard $0.45/hr, "billed to the second, based on the cost per hour"',
+        ),
+    ),
+    (Benchmark.STT, "speechmatics", "enhanced"): (
+        Rate(
+            BillingUnit.PER_HOUR,
+            "0.80",
+            "https://www.speechmatics.com/pricing",
+            "Real-time Enhanced $0.80/hr (billed to the second)",
+        ),
+    ),
+    (Benchmark.STT, "revai", "reverb"): (
+        Rate(
+            BillingUnit.PER_HOUR,
+            "0.20",
+            "https://www.rev.ai/pricing",
+            '"Reverb Transcription $0.20 per hour" (streaming billed on stream duration, '
+            "15s minimum)",
+        ),
+    ),
+    (Benchmark.STT, "gladia", "solaria-1"): (
+        Rate(
+            BillingUnit.PER_HOUR,
+            "0.75",
+            "https://www.gladia.io/pricing",
+            'Starter (pay-as-you-go): "Real-time at $0.75/hr" (flat real-time rate, '
+            "no per-model split)",
+            "Gladia Starter prepaid PAYG plan; commit plans go as low as $0.25/hr",
+        ),
+    ),
+    # ------------------------------------------------------------------ TTS
+    (Benchmark.TTS, "inworld", "inworld-tts-2"): (
+        Rate(
+            BillingUnit.PER_1M_CHARS,
+            "25.00",
+            "https://inworld.ai/pricing",
+            "On-demand: Realtime TTS-2 $25 per 1M characters",
+        ),
+    ),
+    (Benchmark.TTS, "inworld", "inworld-tts-1.5-max"): (
+        Rate(
+            BillingUnit.PER_1M_CHARS,
+            "35.00",
+            "https://inworld.ai/pricing",
+            "On-demand: Realtime TTS 1.5 Max $35 per 1M characters",
+        ),
+    ),
+    (Benchmark.TTS, "inworld", "inworld-tts-1.5-mini"): (
+        Rate(
+            BillingUnit.PER_1M_CHARS,
+            "15.00",
+            "https://inworld.ai/pricing",
+            "On-demand: Realtime TTS 1.5 Mini $15 per 1M characters",
+        ),
+    ),
+    (Benchmark.TTS, "minimax", "speech-2.8-hd"): (
+        Rate(
+            BillingUnit.PER_1M_CHARS,
+            "100.00",
+            "https://platform.minimax.io/docs/guides/pricing-paygo",
+            "Pay-as-you-go table: T2A speech-2.8-hd $100/M characters",
+        ),
+    ),
+    (Benchmark.TTS, "minimax", "speech-2.8-turbo"): (
+        Rate(
+            BillingUnit.PER_1M_CHARS,
+            "60.00",
+            "https://platform.minimax.io/docs/guides/pricing-paygo",
+            "Pay-as-you-go table: T2A speech-2.8-turbo $60/M characters",
+        ),
+    ),
+    (Benchmark.TTS, "rime", "coda"): (
+        Rate(
+            BillingUnit.PER_1M_CHARS,
+            "50.00",
+            "https://www.rime.ai/pricing",
+            'Coda "$0.05 / 1K characters" ×1000',
+        ),
+    ),
+    (Benchmark.TTS, "rime", "arcana"): (
+        Rate(
+            BillingUnit.PER_1M_CHARS,
+            "40.00",
+            "https://www.rime.ai/resources/introducing-new-pricing",
+            'Starter plan: "Arcana $40 / million characters" (Rime pricing announcement; '
+            "current /pricing page lists only Coda and Mist v3)",
+        ),
+    ),
+    (Benchmark.TTS, "rime", "mistv3"): (
+        Rate(
+            BillingUnit.PER_1M_CHARS,
+            "30.00",
+            "https://www.rime.ai/pricing",
+            'Mist v3 "$0.03 / 1K characters" ×1000',
+        ),
+    ),
+    (Benchmark.TTS, "lmnt", "blizzard"): (
+        Rate(
+            BillingUnit.PER_1M_CHARS,
+            "49.00",
+            "https://www.lmnt.com/pricing",
+            "Pro: $49/mo, 1.25M characters included, $0.045 per 1K after "
+            "(plan-level pricing, no PAYG or per-model rates)",
+            "LMNT Pro plan $49/mo includes 1.25M chars; 1M chars/month fits the "
+            "quota: $49 / 1M chars",
+        ),
+    ),
+    (Benchmark.TTS, "smallest", "lightning_v3.1_pro"): (
+        Rate(
+            BillingUnit.PER_1M_CHARS,
+            "19.50",
+            "https://smallest.ai/pricing/models",
+            "Lightning V3.1 Pro $0.195/10K characters ×100 (pay-as-you-go)",
+        ),
+    ),
+    (Benchmark.TTS, "speechify", "simba-3.2"): (
+        Rate(
+            BillingUnit.PER_1M_CHARS,
+            "10.00",
+            "https://speechify.ai/pricing",
+            "Starter: $10/mo with 1M chars included, then $10/1M; rates uniform across "
+            "Simba models",
+            "Speechify Starter plan $10/mo includes 1M chars ($10/1M overage): $10 / 1M chars",
+        ),
+    ),
+    (Benchmark.TTS, "speechify", "simba-3.0"): (
+        Rate(
+            BillingUnit.PER_1M_CHARS,
+            "10.00",
+            "https://speechify.ai/pricing",
+            "Starter: $10/mo with 1M chars included, then $10/1M; rates uniform across "
+            "Simba models",
+            "Speechify Starter plan $10/mo includes 1M chars ($10/1M overage): $10 / 1M chars",
+        ),
+    ),
+    (Benchmark.TTS, "fishaudio", "s1"): (
+        Rate(
+            BillingUnit.PER_1M_CHARS,
+            "15.00",
+            "https://docs.fish.audio/developer-guide/models-pricing/pricing-and-rate-limits",
+            "s1: $15.00 / M UTF-8 bytes (1 byte = 1 char for English)",
+        ),
+    ),
+    (Benchmark.TTS, "fishaudio", "s2.1-pro"): (
+        Rate(
+            BillingUnit.PER_1M_CHARS,
+            "15.00",
+            "https://docs.fish.audio/developer-guide/models-pricing/pricing-and-rate-limits",
+            "s2.1-pro: $15.00 / M UTF-8 bytes",
+        ),
+    ),
+    (Benchmark.TTS, "fishaudio", "s2.1-pro-free"): (
+        Rate(
+            BillingUnit.PER_1M_CHARS,
+            "0.00",
+            "https://docs.fish.audio/developer-guide/models-pricing/pricing-and-rate-limits",
+            "s2.1-pro-free: $0.00 / M UTF-8 bytes (genuinely listed at $0.00)",
+        ),
+    ),
+    (Benchmark.TTS, "elevenlabs", "eleven_flash_v2_5"): (
+        Rate(
+            BillingUnit.PER_1M_CHARS,
+            "50.00",
+            "https://elevenlabs.io/pricing/api",
+            'Flash/Turbo TTS "$0.05 per 1K characters" ×1000; API billed in USD, not credits',
+        ),
+    ),
+    (Benchmark.TTS, "elevenlabs", "eleven_multilingual_v2"): (
+        Rate(
+            BillingUnit.PER_1M_CHARS,
+            "100.00",
+            "https://elevenlabs.io/pricing/api",
+            'Multilingual v2/v3 TTS "$0.10 per 1K characters" ×1000',
+        ),
+    ),
+    (Benchmark.TTS, "elevenlabs", "eleven_v3"): (
+        Rate(
+            BillingUnit.PER_1M_CHARS,
+            "100.00",
+            "https://elevenlabs.io/pricing/api",
+            "v3 priced identically to Multilingual v2 on the PAYG API page: $0.10/1k ×1000",
+        ),
+    ),
+    (Benchmark.TTS, "cartesia", "sonic-3.5"): (
+        Rate(
+            BillingUnit.PER_1M_CHARS,
+            "39.20",
+            "https://cartesia.ai/pricing",
+            '"Startup $49 ... 1.25M TTS credits"; docs: standard TTS ≈ 1 credit/char',
+            "Cartesia Startup plan $49/mo (1.25M credits, ~1 credit/char): $49 / 1.25M × 1M chars",
+        ),
+    ),
+    (Benchmark.TTS, "deepgram", "aura-2-thalia-en"): (
+        Rate(
+            BillingUnit.PER_1M_CHARS,
+            "30.00",
+            "https://deepgram.com/pricing",
+            'Aura-2 TTS pay-as-you-go "$0.030/1k characters" ×1000',
+        ),
+    ),
+    (Benchmark.TTS, "openai", "gpt-4o-mini-tts"): (
+        Rate(
+            BillingUnit.PER_1M_TOKENS_INPUT,
+            "0.60",
+            "https://developers.openai.com/api/docs/pricing",
+            "gpt-4o-mini-tts text input tokens: $0.60 per 1M",
+        ),
+        Rate(
+            BillingUnit.PER_1M_TOKENS_OUTPUT,
+            "12.00",
+            "https://developers.openai.com/api/docs/pricing",
+            "gpt-4o-mini-tts audio output tokens: $12.00 per 1M",
+        ),
+    ),
+    (Benchmark.TTS, "google", "chirp-3-hd"): (
+        Rate(
+            BillingUnit.PER_1M_CHARS,
+            "30.00",
+            "https://cloud.google.com/text-to-speech/pricing",
+            '"Chirp 3: HD voices (sku F977-2280-6F1B) US$0.00003 per character '
+            '(US$30 per 1 million characters)"',
+        ),
+    ),
+    (Benchmark.TTS, "hume", "octave-tts"): (
+        Rate(
+            BillingUnit.PER_1M_CHARS,
+            "70.00",
+            "https://www.hume.ai/pricing",
+            'Pro "$70/month ... 1,000,000 (~1,000 minutes)" included characters',
+            "Hume Pro plan $70/mo includes exactly 1M characters: $70 / 1M chars",
+        ),
+    ),
+    (Benchmark.TTS, "hume", "octave-2"): (
+        Rate(
+            BillingUnit.PER_1M_CHARS,
+            "70.00",
+            "https://www.hume.ai/pricing",
+            'characters billed identically for "Octave 1 / Octave 2" on the pricing page',
+            "Hume Pro plan $70/mo includes exactly 1M characters: $70 / 1M chars",
+        ),
+    ),
+    (Benchmark.TTS, "murf", "falcon-2"): (
+        Rate(
+            BillingUnit.PER_1M_CHARS,
+            "10.00",
+            "https://help.murf.ai/murf-api-pay-as-you-go",
+            '"Falcon model: $0.01/1000 characters" ×1000 (PAYG, $10 minimum purchase)',
+        ),
+    ),
+    (Benchmark.TTS, "palabra", "palabra-tts-v1"): (
+        Rate(
+            BillingUnit.PER_1M_CHARS,
+            "30.00",
+            "https://www.palabra.ai/pricing",
+            'TTS pay-as-you-go "$0.03 / 1,000 CHARACTERS" ×1000',
+        ),
+    ),
+    (Benchmark.TTS, "soniox", "tts-rt-v1"): (
+        Rate(
+            BillingUnit.PER_1M_TOKENS_INPUT,
+            "4.00",
+            "https://soniox.com/pricing",
+            'real-time TTS "Input text tokens: $4.00 per 1M tokens"',
+        ),
+        Rate(
+            BillingUnit.PER_1M_TOKENS_OUTPUT,
+            "21.50",
+            "https://soniox.com/pricing",
+            '"Output audio tokens: $21.50 per 1M tokens" (~30k tokens ≈ 1h of speech)',
+        ),
+    ),
+    (Benchmark.TTS, "gradium", "default"): (
+        Rate(
+            BillingUnit.PER_1M_CHARS,
+            "48.00",
+            "https://gradium.ai/pricing",
+            '"Text-to-Speech: 1 credit / character"; plans XS $13/225k, S $43/900k credits',
+            "Gradium S plan $43/mo (900k credits, 1 credit/char) + 100k add-on "
+            "credits at $5.00: $48 for 1M chars/month",
+        ),
+    ),
+    (Benchmark.TTS, "xai", "grok-tts"): (
+        Rate(
+            BillingUnit.PER_1M_CHARS,
+            "15.00",
+            "https://docs.x.ai/docs/models",
+            'Voice pricing table: "Text to Speech ... $15.00 / 1M chars"',
+        ),
+    ),
+    # ------------------------------------------------------------------ S2S
+    (Benchmark.S2S, "openai", "gpt-realtime"): (
+        Rate(
+            BillingUnit.PER_1M_TOKENS_INPUT,
+            "32.00",
+            "https://developers.openai.com/api/docs/pricing",
+            "gpt-realtime audio input tokens: $32.00 per 1M (cached audio input $0.40)",
+        ),
+        Rate(
+            BillingUnit.PER_1M_TOKENS_OUTPUT,
+            "64.00",
+            "https://developers.openai.com/api/docs/pricing",
+            "gpt-realtime audio output tokens: $64.00 per 1M",
+        ),
+    ),
+    (Benchmark.S2S, "google", "gemini-live"): (
+        Rate(
+            BillingUnit.PER_1M_TOKENS_INPUT,
+            "3.00",
+            "https://ai.google.dev/gemini-api/docs/pricing",
+            "gemini-2.5-flash-native-audio-preview-12-2025 (Live API): "
+            "audio input $3.00 per 1M tokens",
+        ),
+        Rate(
+            BillingUnit.PER_1M_TOKENS_OUTPUT,
+            "12.00",
+            "https://ai.google.dev/gemini-api/docs/pricing",
+            "gemini-2.5-flash-native-audio-preview-12-2025 (Live API): "
+            "audio output $12.00 per 1M tokens",
+        ),
+    ),
+    (Benchmark.S2S, "xai", "grok-voice-think-fast-1.0"): (
+        Rate(
+            BillingUnit.PER_MINUTE,
+            "0.05",
+            "https://docs.x.ai/docs/models",
+            '"grok-voice-think-fast-1.0 ... $0.05 / min ($3.00 / hr) audio"',
+        ),
+    ),
+    (Benchmark.S2S, "xai", "grok-voice-think-fast-2.0"): (
+        Rate(
+            BillingUnit.PER_MINUTE,
+            "0.08",
+            "https://docs.x.ai/docs/models",
+            '"grok-voice-think-fast-2.0 ... $0.08 / min ($4.80 / hr) audio"',
+        ),
+    ),
+}
+
+
+# Rates for measurement instruments that are not benchmarked models themselves
+# and so live outside the registry — the whisper-1 TTS judge. Same provenance
+# rules; applied unconditionally by apply_ratesheet.
+JUDGE_RATESHEET: dict[tuple[Benchmark, str, str], tuple[Rate, ...]] = {
+    (Benchmark.TTS, "openai", "whisper-1-judge"): (
+        Rate(
+            BillingUnit.PER_MINUTE,
+            "0.006",
+            "https://developers.openai.com/api/docs/pricing",
+            'Transcription table: "Whisper $0.006 / minute" (whisper-1 API model, '
+            "used as the TTS WER judge)",
+        ),
+    ),
+}
+
+
+async def apply_ratesheet(store: PricingStore) -> tuple[int, int, list[str]]:
+    """Upsert every ratesheet entry for the active roster, plus judge rates.
+
+    Returns ``(inserted, unchanged, gaps)`` where *gaps* lists active models
+    with no ratesheet entry.
+    """
+    inserted = 0
+    unchanged = 0
+    gaps: list[str] = []
+    active = [
+        m for m in MODEL_REGISTRY if m.status in (ModelStatus.ACTIVE, ModelStatus.EARLY_ACCESS)
+    ]
+    work: list[tuple[Benchmark, str, str, tuple[Rate, ...]]] = []
+    for m in active:
+        rates = RATESHEET.get((m.benchmark, m.provider, m.model))
+        if not rates:
+            gaps.append(f"{m.benchmark}:{m.provider}/{m.model}")
+            continue
+        work.append((m.benchmark, m.provider, m.model, rates))
+    work.extend((b, p, mod, rates) for (b, p, mod), rates in JUDGE_RATESHEET.items())
+
+    for benchmark, provider, model, rates in work:
+        for r in rates:
+            _, created = await store.upsert_rate(
+                provider=provider,
+                model=model,
+                benchmark=benchmark,
+                billing_unit=r.unit,
+                rate_usd=Decimal(r.rate_usd),
+                source_url=r.source_url,
+                as_of=AS_OF,
+                evidence=r.evidence,
+                plan_assumption=r.plan_assumption,
+                updated_by="human",
+            )
+            if created:
+                inserted += 1
+            else:
+                unchanged += 1
+    return inserted, unchanged, gaps
+
+
+def _assert_local(database_url: str) -> None:
+    """Refuse to seed against anything but a local DB (same guard as seed_arena)."""
+    host = urlsplit(database_url).hostname
+    if host not in _LOCAL_HOSTS:
+        raise SystemExit(
+            f"refusing to seed pricing: DB host {host!r} is not local "
+            f"({sorted(_LOCAL_HOSTS)}). This script is dev-only."
+        )
+
+
+async def run_seed() -> None:
+    settings = get_settings()
+    _assert_local(settings.database_url)
+    async with lifespan_pool(settings) as pool:
+        store = PricingStore(pool)
+        inserted, unchanged, gaps = await apply_ratesheet(store)
+    print(f"pricing seed: {inserted} rates inserted, {unchanged} unchanged")
+    if gaps:
+        print(f"NO PUBLISHED PRICE ({len(gaps)} models — no row written, never guessed):")
+        for gap in gaps:
+            print(f"  - {gap}")
+
+
+if __name__ == "__main__":
+    asyncio.run(run_seed())

--- a/runner/src/coval_bench/db/migrations/versions/20260806_0016_model_pricing.py
+++ b/runner/src/coval_bench/db/migrations/versions/20260806_0016_model_pricing.py
@@ -1,0 +1,64 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Append-only ``model_pricing`` ratesheet.
+
+Rates live in the DB, not the code registry, because they change on their own
+schedule and history matters: a June run is costed at June rates. A rate is
+never UPDATEd — a new row is inserted and ``superseded_at`` is stamped on the
+old one, so the partial unique index keeps exactly one effective row per
+(provider, model, benchmark, billing_unit). Token-billed models legitimately
+hold two effective rows (input + output units). ``benchmark`` is part of the
+key because (provider, model) alone is not unique in the registry — gradium
+serves STT and TTS under the same model id. Rates are stored in the provider's
+native billing unit; normalization happens at read time.
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "20260806_0016"
+down_revision = "20260806_0015"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        CREATE TABLE benchmarks_v2.model_pricing (
+          id BIGSERIAL PRIMARY KEY,
+          provider TEXT NOT NULL,
+          model TEXT NOT NULL,
+          benchmark TEXT NOT NULL,
+          billing_unit TEXT NOT NULL,
+          rate_usd NUMERIC(14,8) NOT NULL,
+          plan_assumption TEXT NULL,
+          effective_at TIMESTAMPTZ NOT NULL,
+          superseded_at TIMESTAMPTZ NULL,
+          source_url TEXT NOT NULL,
+          as_of DATE NOT NULL,
+          evidence TEXT NULL,
+          updated_by TEXT NOT NULL,
+          created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+        )
+        """
+    )
+    op.execute(
+        """
+        CREATE UNIQUE INDEX ux_model_pricing_effective
+          ON benchmarks_v2.model_pricing (provider, model, benchmark, billing_unit)
+          WHERE superseded_at IS NULL
+        """
+    )
+    op.execute(
+        """
+        CREATE INDEX ix_model_pricing_lookup
+          ON benchmarks_v2.model_pricing (provider, model, effective_at)
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP TABLE benchmarks_v2.model_pricing")

--- a/runner/src/coval_bench/db/models.py
+++ b/runner/src/coval_bench/db/models.py
@@ -9,7 +9,8 @@ These are **persistence-layer** models only. The API layer has its own
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import date, datetime
+from decimal import Decimal
 from enum import StrEnum
 from uuid import UUID
 
@@ -20,8 +21,10 @@ from coval_bench.registries.benchmarks import Benchmark
 __all__ = [
     "Battle",
     "Benchmark",
+    "BillingUnit",
     "LeaderboardSnapshot",
     "PairingRating",
+    "PriceRow",
     "Result",
     "ResultStatus",
     "Run",
@@ -98,6 +101,45 @@ class Result(BaseModel):
     characters_in: int | None = None
     audio_seconds_in: float | None = None
     audio_seconds_out: float | None = None
+
+
+class BillingUnit(StrEnum):
+    """Native billing unit a provider publishes its rate in.
+
+    Rates are stored raw in these units; normalization to $/1k min or
+    $/1M chars happens at read time.
+    """
+
+    PER_MINUTE = "per_minute"
+    PER_SECOND = "per_second"
+    PER_HOUR = "per_hour"
+    PER_1M_CHARS = "per_1m_chars"
+    PER_1M_TOKENS_INPUT = "per_1m_tokens_input"
+    PER_1M_TOKENS_OUTPUT = "per_1m_tokens_output"
+    PER_REQUEST = "per_request"
+
+
+class PriceRow(BaseModel):
+    """Domain model for a row in ``benchmarks_v2.model_pricing`` (append-only).
+
+    ``superseded_at IS NULL`` marks the currently effective rate; token-billed
+    models hold two effective rows (input + output units).
+    """
+
+    id: int | None = None  # set by DB (bigserial)
+    provider: str
+    model: str
+    benchmark: Benchmark
+    billing_unit: BillingUnit
+    rate_usd: Decimal
+    plan_assumption: str | None = None
+    effective_at: datetime
+    superseded_at: datetime | None = None
+    source_url: str
+    as_of: date
+    evidence: str | None = None
+    updated_by: str  # 'human' | 'bot'
+    created_at: datetime | None = None  # set by DB default (now())
 
 
 class VoteOutcome(StrEnum):

--- a/runner/src/coval_bench/db/pricing.py
+++ b/runner/src/coval_bench/db/pricing.py
@@ -41,22 +41,35 @@ class PricingStore:
         self._pool = pool
         self._cache: dict[tuple[str, str], list[PriceRow]] | None = None
 
-    async def get_effective_rates(self, provider: str, model: str, at: datetime) -> list[PriceRow]:
+    async def get_effective_rates(
+        self,
+        provider: str,
+        model: str,
+        at: datetime,
+        benchmark: Benchmark | None = None,
+    ) -> list[PriceRow]:
         """Rates in force at *at*: ``effective_at <= at < coalesce(superseded_at, ∞)``.
 
-        Token-billed models return two rows (input + output units).
+        Token-billed models return two rows (input + output units). Pass
+        *benchmark* whenever the caller knows it: (provider, model) alone is
+        not unique — gradium serves STT and TTS under one model id, and an
+        unfiltered read would hand back incompatible rates together.
         """
         sql = f"""
             SELECT {_COLUMNS}
             FROM benchmarks_v2.model_pricing
             WHERE provider = %(provider)s AND model = %(model)s
+              AND (%(benchmark)s::text IS NULL OR benchmark = %(benchmark)s)
               AND effective_at <= %(at)s
               AND (superseded_at IS NULL OR superseded_at > %(at)s)
             ORDER BY billing_unit
         """  # noqa: S608 — column list is a module constant
         async with self._pool.connection() as conn:
             async with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
-                await cur.execute(sql, {"provider": provider, "model": model, "at": at})
+                await cur.execute(
+                    sql,
+                    {"provider": provider, "model": model, "at": at, "benchmark": benchmark},
+                )
                 rows = await cur.fetchall()
             await conn.commit()
         return [PriceRow.model_validate(dict(r)) for r in rows]
@@ -157,8 +170,16 @@ class PricingStore:
             cache.setdefault((price.provider, price.model), []).append(price)
         self._cache = cache
 
-    def effective_rates_cached(self, provider: str, model: str) -> list[PriceRow]:
-        """Currently-effective rates from the in-process cache ([] = unpriced model)."""
+    def effective_rates_cached(
+        self, provider: str, model: str, benchmark: Benchmark | None = None
+    ) -> list[PriceRow]:
+        """Currently-effective rates from the in-process cache ([] = unpriced model).
+
+        Same *benchmark* rule as :meth:`get_effective_rates` — pass it when known.
+        """
         if self._cache is None:
             raise RuntimeError("PricingStore cache not loaded — call load_cache() first")
-        return self._cache.get((provider, model), [])
+        rates = self._cache.get((provider, model), [])
+        if benchmark is None:
+            return rates
+        return [r for r in rates if r.benchmark is benchmark]

--- a/runner/src/coval_bench/db/pricing.py
+++ b/runner/src/coval_bench/db/pricing.py
@@ -1,0 +1,164 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""``PricingStore`` — access to the append-only ``model_pricing`` ratesheet.
+
+A rate is never UPDATEd: ``upsert_rate`` inserts a new row and stamps
+``superseded_at`` on the previous effective one, in a single transaction. That
+keeps price history intact and makes historical cost attribution a range query
+(``get_effective_rates`` with the run's timestamp).
+
+The orchestrator resolves rates once per result row, so ``load_cache`` pulls
+every currently-effective row in one query at run start and
+``effective_rates_cached`` serves lookups from memory.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+from decimal import Decimal
+from typing import Literal
+
+import psycopg
+import psycopg.rows
+from psycopg_pool import AsyncConnectionPool
+
+from coval_bench.db.models import Benchmark, BillingUnit, PriceRow
+
+_COLUMNS = (
+    "id, provider, model, benchmark, billing_unit, rate_usd, plan_assumption, "
+    "effective_at, superseded_at, source_url, as_of, evidence, updated_by, created_at"
+)
+
+
+class PricingStore:
+    """Typed helpers over ``benchmarks_v2.model_pricing``."""
+
+    def __init__(
+        self,
+        pool: AsyncConnectionPool[psycopg.AsyncConnection[psycopg.rows.DictRow]],
+    ) -> None:
+        self._pool = pool
+        self._cache: dict[tuple[str, str], list[PriceRow]] | None = None
+
+    async def get_effective_rates(self, provider: str, model: str, at: datetime) -> list[PriceRow]:
+        """Rates in force at *at*: ``effective_at <= at < coalesce(superseded_at, ∞)``.
+
+        Token-billed models return two rows (input + output units).
+        """
+        sql = f"""
+            SELECT {_COLUMNS}
+            FROM benchmarks_v2.model_pricing
+            WHERE provider = %(provider)s AND model = %(model)s
+              AND effective_at <= %(at)s
+              AND (superseded_at IS NULL OR superseded_at > %(at)s)
+            ORDER BY billing_unit
+        """  # noqa: S608 — column list is a module constant
+        async with self._pool.connection() as conn:
+            async with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+                await cur.execute(sql, {"provider": provider, "model": model, "at": at})
+                rows = await cur.fetchall()
+            await conn.commit()
+        return [PriceRow.model_validate(dict(r)) for r in rows]
+
+    async def upsert_rate(
+        self,
+        *,
+        provider: str,
+        model: str,
+        benchmark: Benchmark,
+        billing_unit: BillingUnit,
+        rate_usd: Decimal,
+        source_url: str,
+        as_of: date,
+        updated_by: Literal["human", "bot"],
+        plan_assumption: str | None = None,
+        evidence: str | None = None,
+        effective_at: datetime | None = None,
+    ) -> tuple[PriceRow, bool]:
+        """Insert a new effective rate, superseding the previous one, atomically.
+
+        Idempotent: when the currently effective row already carries the same
+        ``rate_usd`` and ``plan_assumption``, nothing is written and the
+        existing row is returned with ``created=False``. Otherwise the old row
+        gets ``superseded_at = effective_at`` (contiguous history) and the new
+        row is inserted.
+        """
+        effective_at = effective_at or datetime.now(tz=UTC)
+        async with self._pool.connection() as conn:
+            async with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+                await cur.execute(
+                    f"""
+                    SELECT {_COLUMNS}
+                    FROM benchmarks_v2.model_pricing
+                    WHERE provider = %s AND model = %s AND benchmark = %s
+                      AND billing_unit = %s AND superseded_at IS NULL
+                    FOR UPDATE
+                    """,  # noqa: S608 — column list is a module constant
+                    (provider, model, benchmark, billing_unit),
+                )
+                current = await cur.fetchone()
+                if (
+                    current is not None
+                    and current["rate_usd"] == rate_usd
+                    and current["plan_assumption"] == plan_assumption
+                ):
+                    await conn.commit()
+                    return PriceRow.model_validate(dict(current)), False
+
+                if current is not None:
+                    await cur.execute(
+                        "UPDATE benchmarks_v2.model_pricing SET superseded_at = %s WHERE id = %s",
+                        (effective_at, current["id"]),
+                    )
+                await cur.execute(
+                    f"""
+                    INSERT INTO benchmarks_v2.model_pricing
+                        (provider, model, benchmark, billing_unit, rate_usd, plan_assumption,
+                         effective_at, source_url, as_of, evidence, updated_by)
+                    VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                    RETURNING {_COLUMNS}
+                    """,  # noqa: S608 — column list is a module constant
+                    (
+                        provider,
+                        model,
+                        benchmark,
+                        billing_unit,
+                        rate_usd,
+                        plan_assumption,
+                        effective_at,
+                        source_url,
+                        as_of,
+                        evidence,
+                        updated_by,
+                    ),
+                )
+                row = await cur.fetchone()
+                if row is None:  # pragma: no cover — unreachable after INSERT RETURNING
+                    raise RuntimeError("INSERT INTO model_pricing returned no row")
+            await conn.commit()
+        return PriceRow.model_validate(dict(row)), True
+
+    async def load_cache(self) -> None:
+        """Load every currently-effective rate into memory, one query per run."""
+        sql = f"""
+            SELECT {_COLUMNS}
+            FROM benchmarks_v2.model_pricing
+            WHERE superseded_at IS NULL
+        """  # noqa: S608 — column list is a module constant
+        cache: dict[tuple[str, str], list[PriceRow]] = {}
+        async with self._pool.connection() as conn:
+            async with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+                await cur.execute(sql)
+                rows = await cur.fetchall()
+            await conn.commit()
+        for r in rows:
+            price = PriceRow.model_validate(dict(r))
+            cache.setdefault((price.provider, price.model), []).append(price)
+        self._cache = cache
+
+    def effective_rates_cached(self, provider: str, model: str) -> list[PriceRow]:
+        """Currently-effective rates from the in-process cache ([] = unpriced model)."""
+        if self._cache is None:
+            raise RuntimeError("PricingStore cache not loaded — call load_cache() first")
+        return self._cache.get((provider, model), [])

--- a/runner/tests/unit/test_db_pricing.py
+++ b/runner/tests/unit/test_db_pricing.py
@@ -169,6 +169,29 @@ def test_token_billed_model_holds_two_effective_rows(pg_conn: psycopg.Connection
             cached = store.effective_rates_cached("openai", "gpt-4o-transcribe")
             assert len(cached) == 2
             assert store.effective_rates_cached("openai", "unknown") == []
+
+            # The benchmark filter keeps shared model ids apart (gradium
+            # serves STT and TTS under "default").
+            await _upsert(store, "0.013", at=_T0, provider="gradium", model="default")
+            await _upsert(
+                store,
+                "48.0",
+                at=_T0,
+                provider="gradium",
+                model="default",
+                benchmark=Benchmark.TTS,
+                billing_unit=BillingUnit.PER_1M_CHARS,
+            )
+            both = await store.get_effective_rates("gradium", "default", _T0)
+            assert len(both) == 2
+            stt_only = await store.get_effective_rates(
+                "gradium", "default", _T0, benchmark=Benchmark.STT
+            )
+            assert [r.benchmark for r in stt_only] == [Benchmark.STT]
+            await store.load_cache()
+            assert len(store.effective_rates_cached("gradium", "default")) == 2
+            tts_only = store.effective_rates_cached("gradium", "default", Benchmark.TTS)
+            assert [r.benchmark for r in tts_only] == [Benchmark.TTS]
         finally:
             await pool.close()
 

--- a/runner/tests/unit/test_db_pricing.py
+++ b/runner/tests/unit/test_db_pricing.py
@@ -1,0 +1,213 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the append-only ``model_pricing`` store.
+
+Same embedded-Postgres harness as ``test_db_writer``: real DB, migrations
+applied per test, no remote connections.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, date, datetime, timedelta
+from decimal import Decimal
+from pathlib import Path
+from typing import Any
+
+import psycopg
+import psycopg.errors
+import psycopg.rows
+import pytest
+from alembic import command as alembic_command
+from alembic.config import Config as AlembicConfig
+from psycopg_pool import AsyncConnectionPool
+from pytest_postgresql.factories import postgresql
+
+from coval_bench.db.models import Benchmark, BillingUnit
+from coval_bench.db.pricing import PricingStore
+from coval_bench.registries.models import MODEL_REGISTRY, ModelStatus
+from scripts.seed_pricing import RATESHEET, apply_ratesheet
+
+pg_conn = postgresql("pg_proc")  # function-scoped clean DB per test
+
+_INI_PATH = Path(__file__).parents[2] / "alembic.ini"
+
+
+def _async_dsn(conn: psycopg.Connection[Any]) -> str:
+    info = conn.info
+    host = info.host or "localhost"
+    port = info.port or 5432
+    user = info.user or ""
+    password = f":{info.password}" if info.password else ""
+    return f"postgresql://{user}{password}@{host}:{port}/{info.dbname or 'test'}"
+
+
+def _apply_migrations(conn: psycopg.Connection[Any]) -> None:
+    cfg = AlembicConfig(str(_INI_PATH))
+    cfg.set_main_option(
+        "sqlalchemy.url", _async_dsn(conn).replace("postgresql://", "postgresql+psycopg://")
+    )
+    alembic_command.upgrade(cfg, "head")
+
+
+async def _make_pool(
+    conn: psycopg.Connection[Any],
+) -> AsyncConnectionPool[psycopg.AsyncConnection[psycopg.rows.DictRow]]:
+    pool: AsyncConnectionPool[psycopg.AsyncConnection[psycopg.rows.DictRow]] = AsyncConnectionPool(
+        conninfo=_async_dsn(conn),
+        min_size=1,
+        max_size=4,
+        open=False,
+        kwargs={"autocommit": False, "row_factory": psycopg.rows.dict_row},
+    )
+    await pool.open()
+    return pool
+
+
+_T0 = datetime(2026, 8, 1, tzinfo=UTC)
+
+
+async def _upsert(store: PricingStore, rate: str, *, at: datetime, **overrides: Any) -> Any:
+    kwargs: dict[str, Any] = {
+        "provider": "deepgram",
+        "model": "nova-3",
+        "benchmark": Benchmark.STT,
+        "billing_unit": BillingUnit.PER_MINUTE,
+        "rate_usd": Decimal(rate),
+        "source_url": "https://deepgram.com/pricing",
+        "as_of": date(2026, 8, 6),
+        "updated_by": "human",
+        "effective_at": at,
+    }
+    kwargs.update(overrides)
+    return await store.upsert_rate(**kwargs)
+
+
+def test_unique_effective_rate_enforced(pg_conn: psycopg.Connection[Any]) -> None:
+    """The partial unique index rejects a second effective row for one unit."""
+    _apply_migrations(pg_conn)
+    pg_conn.autocommit = True
+    insert = (
+        "INSERT INTO benchmarks_v2.model_pricing "
+        "(provider, model, benchmark, billing_unit, rate_usd, effective_at, "
+        " source_url, as_of, updated_by) "
+        "VALUES ('deepgram', 'nova-3', 'STT', 'per_minute', %s, now(), "
+        " 'https://deepgram.com/pricing', current_date, 'human')"
+    )
+    with pg_conn.cursor() as cur:
+        cur.execute(insert, ("0.0059",))
+        with pytest.raises(psycopg.errors.UniqueViolation):
+            cur.execute(insert, ("0.0077",))
+
+
+def test_supersede_flow_keeps_history(pg_conn: psycopg.Connection[Any]) -> None:
+    """upsert supersedes atomically; a backdated query returns the old rate."""
+    _apply_migrations(pg_conn)
+
+    async def _run() -> None:
+        pool = await _make_pool(pg_conn)
+        try:
+            store = PricingStore(pool)
+            row_a, created_a = await _upsert(store, "0.0059", at=_T0)
+            assert created_a and row_a.superseded_at is None
+
+            # Identical re-upsert is a no-op (seed idempotency).
+            row_same, created_same = await _upsert(store, "0.0059", at=_T0 + timedelta(days=1))
+            assert not created_same
+            assert row_same.id == row_a.id
+
+            t1 = _T0 + timedelta(days=2)
+            row_b, created_b = await _upsert(store, "0.0077", at=t1)
+            assert created_b
+
+            # History: before the change the old rate is effective, after it the new.
+            old = await store.get_effective_rates("deepgram", "nova-3", _T0 + timedelta(days=1))
+            assert [r.rate_usd for r in old] == [Decimal("0.0059")]
+            assert old[0].superseded_at == t1
+            new = await store.get_effective_rates("deepgram", "nova-3", t1)
+            assert [r.id for r in new] == [row_b.id]
+            # Before the first rate existed: nothing.
+            before = await store.get_effective_rates("deepgram", "nova-3", _T0 - timedelta(days=1))
+            assert before == []
+        finally:
+            await pool.close()
+
+    asyncio.run(_run())
+
+
+def test_token_billed_model_holds_two_effective_rows(pg_conn: psycopg.Connection[Any]) -> None:
+    _apply_migrations(pg_conn)
+
+    async def _run() -> None:
+        pool = await _make_pool(pg_conn)
+        try:
+            store = PricingStore(pool)
+            await _upsert(
+                store,
+                "6.0",
+                at=_T0,
+                model="gpt-4o-transcribe",
+                billing_unit=BillingUnit.PER_1M_TOKENS_INPUT,
+                provider="openai",
+            )
+            await _upsert(
+                store,
+                "10.0",
+                at=_T0,
+                model="gpt-4o-transcribe",
+                billing_unit=BillingUnit.PER_1M_TOKENS_OUTPUT,
+                provider="openai",
+            )
+            rates = await store.get_effective_rates("openai", "gpt-4o-transcribe", _T0)
+            assert {r.billing_unit for r in rates} == {
+                BillingUnit.PER_1M_TOKENS_INPUT,
+                BillingUnit.PER_1M_TOKENS_OUTPUT,
+            }
+
+            await store.load_cache()
+            cached = store.effective_rates_cached("openai", "gpt-4o-transcribe")
+            assert len(cached) == 2
+            assert store.effective_rates_cached("openai", "unknown") == []
+        finally:
+            await pool.close()
+
+    asyncio.run(_run())
+
+
+def test_cache_requires_explicit_load() -> None:
+    store = PricingStore(pool=None)  # type: ignore[arg-type] — never touched before load
+    with pytest.raises(RuntimeError, match="load_cache"):
+        store.effective_rates_cached("deepgram", "nova-3")
+
+
+def test_ratesheet_keys_match_registry() -> None:
+    """Every ratesheet entry maps to a real active model — no orphan prices."""
+    active = {
+        (m.benchmark, m.provider, m.model)
+        for m in MODEL_REGISTRY
+        if m.status in (ModelStatus.ACTIVE, ModelStatus.EARLY_ACCESS)
+    }
+    orphans = set(RATESHEET) - active
+    assert not orphans, f"ratesheet entries for unknown/inactive models: {sorted(orphans)}"
+
+
+def test_seed_is_idempotent(pg_conn: psycopg.Connection[Any]) -> None:
+    """Second apply_ratesheet run writes nothing new."""
+    _apply_migrations(pg_conn)
+
+    async def _run() -> None:
+        pool = await _make_pool(pg_conn)
+        try:
+            store = PricingStore(pool)
+            inserted, unchanged, gaps = await apply_ratesheet(store)
+            assert inserted > 0
+            assert unchanged == 0
+            inserted2, unchanged2, gaps2 = await apply_ratesheet(store)
+            assert inserted2 == 0
+            assert unchanged2 == inserted
+            assert gaps2 == gaps
+        finally:
+            await pool.close()
+
+    asyncio.run(_run())


### PR DESCRIPTION
Stacked on #459.

Append-only `model_pricing`: one effective rate per (provider, model, benchmark, billing_unit) enforced by a partial unique index — benchmark is in the key because gradium serves STT and TTS under one model id. `PricingStore` does the supersede dance atomically, is idempotent on unchanged rates, and serves a run-scoped cache. The seed prices 62/68 active models with per-page provenance (source_url, as_of, verbatim evidence, AA-style plan assumptions) plus the whisper-1 judge; the 6 unpriced models are an explicit gap list that `check_pricing_coverage.py` reports. Every rate was verified against the provider's public pricing page on 2026-08-06; deepgram/elevenlabs/openai/assemblyai independently re-verified before opening this PR.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds an append-only model-pricing table, typed pricing store, local seed ratesheet, coverage checker, and database-backed tests.

- Adds historical rate supersession and current-rate caching.
- Seeds published pricing with provenance and explicit unpriced-model gaps.
- Adds migration and tests for uniqueness, history, token-billed rates, caching, and seed idempotency.

<h3>Confidence Score: 4/5</h3>

The benchmark-unscoped pricing reads need to be fixed before merging because shared provider/model identities return rates from multiple benchmarks.

The seeded data already contains `gradium/default` under both STT and TTS, while both database and cached reads omit benchmark and therefore return incompatible rates together.

**Files Needing Attention:** runner/src/coval_bench/db/pricing.py

<sub>Reviews (1): Last reviewed commit: ["\[BENCH-633\] Pricing store: append-only m..."](https://github.com/coval-ai/benchmarks/commit/d06594aa189ec869960a543283ffab706eac9f90) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50943004)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [DB Layer](https://app.greptile.com/coval/-/custom-context/knowledge-base/coval-ai/benchmarks/-/docs/db-layer.md)
- Knowledge Base — [Runner Orchestration](https://app.greptile.com/coval/-/custom-context/knowledge-base/coval-ai/benchmarks/-/docs/runner-orchestration.md)

<!-- /greptile_comment -->