### PR TITLE
[BENCH-634] Cost computation: COST_USD per result + per-run rollups (3/6)

### DIFF
--- a/docs/cost-tracking.md
+++ b/docs/cost-tracking.md
@@ -1,0 +1,66 @@
+# Internal cost tracking
+
+Every benchmark item with a resolvable rate writes a sibling `COST_USD` row to
+`benchmarks_v2.results` (metric-as-a-row, so spend rides the existing
+`results → results_by_bucket → matviews` pipeline), and every run rolls up to
+`runs.total_cost_usd` / `runs.judge_cost_usd` at `finish_run`.
+
+How the number is computed (`coval_bench/metrics/cost.py`):
+
+- rates come from `benchmarks_v2.model_pricing` (append-only; the rate
+  effective at run time), loaded once per run;
+- resolution order: token rates × token counts → duration rates ×
+  `billable_seconds` (falling back to measured audio duration) → per-1M-chars
+  × `characters_in`;
+- no rate or no quantity → **no row** (never a zero). Failed items write no
+  cost row either — whether a provider bills a failed call is unknowable, so
+  the rollup undercounts by failed calls; treat it as a lower bound.
+
+`COST_USD` is internal: the API filters it out of `/v1/results` and both
+aggregates endpoints (`INTERNAL_METRICS` in `registries/metrics.py`). Public
+price display uses list prices from `model_pricing`, not measured spend.
+
+## Canonical queries
+
+Spend per model per run (the "one GROUP BY away" query):
+
+```sql
+SELECT run_id, provider, model, SUM(metric_value) AS cost_usd
+FROM benchmarks_v2.results
+WHERE metric_type = 'COST_USD' AND status = 'success'
+GROUP BY 1, 2, 3
+ORDER BY run_id DESC, cost_usd DESC;
+```
+
+Run totals (items + judge, stamped at finish):
+
+```sql
+SELECT id, started_at, dataset_id, status, total_cost_usd, judge_cost_usd
+FROM benchmarks_v2.runs
+WHERE total_cost_usd IS NOT NULL
+ORDER BY started_at DESC;
+```
+
+Daily spend by provider (from the series rollup — `value_sum` is the bucket's
+total spend; the pooled `__all__` bucket rows would double-count, so filter):
+
+```sql
+SELECT date_trunc('day', bucket_at) AS day, provider,
+       SUM(value_sum) AS cost_usd
+FROM benchmarks_v2.results_by_bucket
+WHERE metric_type = 'COST_USD' AND dataset_id = '__all__'
+GROUP BY 1, 2
+ORDER BY 1 DESC, cost_usd DESC;
+```
+
+Judge spend over time:
+
+```sql
+SELECT date_trunc('day', started_at) AS day, SUM(judge_cost_usd)
+FROM benchmarks_v2.runs
+GROUP BY 1 ORDER BY 1 DESC;
+```
+
+Per-run spend also lands in PostHog (project `public-benchmarks`) as one
+`benchmark_run_cost` event per run: `total_cost_usd`, `judge_cost_usd`, and
+the top-5 model costs.

--- a/runner/src/coval_bench/api/routers/aggregates.py
+++ b/runner/src/coval_bench/api/routers/aggregates.py
@@ -60,7 +60,7 @@ from coval_bench.api.schemas import (
     SeriesPoint,
 )
 from coval_bench.config import DATASET_ALL
-from coval_bench.registries import is_metric_excluded
+from coval_bench.registries import INTERNAL_METRICS, is_metric_excluded
 
 logger = structlog.get_logger("coval_bench.api")
 
@@ -106,8 +106,10 @@ _STATS_BY_DATASET_SQL_TEMPLATE = (
 
 
 def _visible(row: dict[str, Any], hidden: frozenset[tuple[str, str]]) -> bool:
-    return (row["provider"], row["model"]) not in hidden and not is_metric_excluded(
-        row["provider"], row["model"], row["metric_type"]
+    return (
+        row["metric_type"] not in INTERNAL_METRICS
+        and (row["provider"], row["model"]) not in hidden
+        and not is_metric_excluded(row["provider"], row["model"], row["metric_type"])
     )
 
 

--- a/runner/src/coval_bench/api/routers/results.py
+++ b/runner/src/coval_bench/api/routers/results.py
@@ -47,6 +47,7 @@ from coval_bench.api.internal import hidden_early_access
 from coval_bench.api.ratelimit import limiter
 from coval_bench.api.schemas import ResultOut, ResultsResponse
 from coval_bench.config import Settings
+from coval_bench.registries import INTERNAL_METRICS
 
 logger = structlog.get_logger("coval_bench.api")
 
@@ -176,10 +177,12 @@ async def list_results(
         resolved_metric = metric_type
 
     # Build WHERE clause dynamically — parameterised only, no f-string SQL injection.
-    conditions: list[str] = ["r.status = 'success'"]
+    # Internal metrics (measured spend) are never served publicly.
+    conditions: list[str] = ["r.status = 'success'", "r.metric_type <> ALL(%(internal_metrics)s)"]
     params: dict[str, Any] = {
         "limit": limit,
         "schedule_period": settings.schedule_period_seconds,
+        "internal_metrics": [str(m) for m in INTERNAL_METRICS],
     }
 
     if provider is not None:

--- a/runner/src/coval_bench/db/migrations/versions/20260806_0017_run_cost_rollup.py
+++ b/runner/src/coval_bench/db/migrations/versions/20260806_0017_run_cost_rollup.py
@@ -1,0 +1,31 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Per-run spend rollup columns.
+
+``total_cost_usd`` = the run's COST_USD result rows + the whisper judge's own
+spend (``judge_cost_usd``), computed at ``finish_run``. Nullable, no backfill:
+runs before cost capture stay NULL rather than reporting a fabricated zero.
+Plain ADD COLUMN on ``runs`` — no matview involvement.
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "20260806_0017"
+down_revision = "20260806_0016"
+branch_labels = None
+depends_on = None
+
+_COLUMNS: tuple[str, ...] = ("total_cost_usd", "judge_cost_usd")
+
+
+def upgrade() -> None:
+    for column in _COLUMNS:
+        op.execute(f"ALTER TABLE benchmarks_v2.runs ADD COLUMN {column} NUMERIC(12,4)")
+
+
+def downgrade() -> None:
+    for column in _COLUMNS:
+        op.execute(f"ALTER TABLE benchmarks_v2.runs DROP COLUMN {column}")

--- a/runner/src/coval_bench/db/models.py
+++ b/runner/src/coval_bench/db/models.py
@@ -68,6 +68,9 @@ class Run(BaseModel):
     judge_input_tokens: int | None = None
     judge_output_tokens: int | None = None
     judge_audio_seconds: float | None = None
+    # Spend rollup (migration 0017): COST_USD rows + judge cost, set at finish_run.
+    total_cost_usd: Decimal | None = None
+    judge_cost_usd: Decimal | None = None
 
 
 class Result(BaseModel):

--- a/runner/src/coval_bench/db/writer.py
+++ b/runner/src/coval_bench/db/writer.py
@@ -255,30 +255,51 @@ class RunWriter:
         judge_input_tokens: int | None = None,
         judge_output_tokens: int | None = None,
         judge_audio_seconds: float | None = None,
+        judge_cost_usd: float | None = None,
     ) -> None:
-        """Set ``finished_at = now()``, ``status`` / ``error``, and judge spend on a run row."""
+        """Set ``finished_at = now()``, ``status`` / ``error``, and spend on a run row.
+
+        ``total_cost_usd`` is summed from the run's persisted COST_USD rows in
+        SQL (not from memory) so a SIGTERM-cancelled run still rolls up every
+        row its tasks flushed, plus *judge_cost_usd*. Runs with neither stay
+        NULL — no fabricated zeros.
+        """
         sql = """
             UPDATE benchmarks_v2.runs
             SET finished_at = now(),
-                status = %s,
-                error  = %s,
-                judge_input_tokens = %s,
-                judge_output_tokens = %s,
-                judge_audio_seconds = %s
-            WHERE id = %s
+                status = %(status)s,
+                error  = %(error)s,
+                judge_input_tokens = %(judge_input_tokens)s,
+                judge_output_tokens = %(judge_output_tokens)s,
+                judge_audio_seconds = %(judge_audio_seconds)s,
+                judge_cost_usd = %(judge_cost_usd)s::numeric,
+                total_cost_usd = (
+                    SELECT CASE
+                        WHEN SUM(r.metric_value) IS NULL
+                             AND %(judge_cost_usd)s::numeric IS NULL THEN NULL
+                        ELSE COALESCE(SUM(r.metric_value), 0)::numeric
+                             + COALESCE(%(judge_cost_usd)s::numeric, 0)
+                    END
+                    FROM benchmarks_v2.results r
+                    WHERE r.run_id = %(run_id)s
+                      AND r.metric_type = 'COST_USD'
+                      AND r.status = 'success'
+                )
+            WHERE id = %(run_id)s
         """
         async with self._pool.connection() as conn:
             async with conn.cursor() as cur:
                 await cur.execute(
                     sql,
-                    (
-                        status,
-                        error,
-                        judge_input_tokens,
-                        judge_output_tokens,
-                        judge_audio_seconds,
-                        run_id,
-                    ),
+                    {
+                        "status": status,
+                        "error": error,
+                        "judge_input_tokens": judge_input_tokens,
+                        "judge_output_tokens": judge_output_tokens,
+                        "judge_audio_seconds": judge_audio_seconds,
+                        "judge_cost_usd": judge_cost_usd,
+                        "run_id": run_id,
+                    },
                 )
             await conn.commit()
 

--- a/runner/src/coval_bench/db/writer.py
+++ b/runner/src/coval_bench/db/writer.py
@@ -256,13 +256,15 @@ class RunWriter:
         judge_output_tokens: int | None = None,
         judge_audio_seconds: float | None = None,
         judge_cost_usd: float | None = None,
-    ) -> None:
+    ) -> float | None:
         """Set ``finished_at = now()``, ``status`` / ``error``, and spend on a run row.
 
         ``total_cost_usd`` is summed from the run's persisted COST_USD rows in
         SQL (not from memory) so a SIGTERM-cancelled run still rolls up every
         row its tasks flushed, plus *judge_cost_usd*. Runs with neither stay
-        NULL — no fabricated zeros.
+        NULL — no fabricated zeros. Returns the persisted total so telemetry
+        reports exactly what the DB recorded, never an in-memory sum that a
+        rolled-back batch could inflate.
         """
         sql = """
             UPDATE benchmarks_v2.runs
@@ -286,9 +288,10 @@ class RunWriter:
                       AND r.status = 'success'
                 )
             WHERE id = %(run_id)s
+            RETURNING total_cost_usd
         """
         async with self._pool.connection() as conn:
-            async with conn.cursor() as cur:
+            async with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
                 await cur.execute(
                     sql,
                     {
@@ -301,7 +304,10 @@ class RunWriter:
                         "run_id": run_id,
                     },
                 )
+                row = await cur.fetchone()
             await conn.commit()
+        total = row["total_cost_usd"] if row else None
+        return float(total) if total is not None else None
 
     async def coval_run_ingested(self, *, provider: str, coval_run_id: str) -> bool:
         """True if a succeeded or partial run already holds rows for this Coval run.

--- a/runner/src/coval_bench/metrics/__init__.py
+++ b/runner/src/coval_bench/metrics/__init__.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """Public API for coval_bench metrics."""
 
+from coval_bench.metrics.cost import compute_cost_usd, judge_cost_usd
 from coval_bench.metrics.ttfa import compute_ttfa, first_audible_offset_ms
 from coval_bench.metrics.ttft import compute_rtf, compute_ttfs
 from coval_bench.metrics.wer import WERResult, WordError, compute_wer, normalize_text
@@ -9,7 +10,9 @@ from coval_bench.metrics.wer import WERResult, WordError, compute_wer, normalize
 __all__ = [
     "WERResult",
     "WordError",
+    "compute_cost_usd",
     "compute_wer",
+    "judge_cost_usd",
     "normalize_text",
     "compute_ttfa",
     "first_audible_offset_ms",

--- a/runner/src/coval_bench/metrics/cost.py
+++ b/runner/src/coval_bench/metrics/cost.py
@@ -1,0 +1,92 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+"""Per-item spend at the effective list rate, in USD.
+
+Resolution order mirrors how providers actually bill: token rates first (the
+only exact signal), then billed duration (provider-reported
+``billable_seconds``, falling back to the measured audio duration), then
+characters. No resolvable rate or no quantity → ``None`` — spend is never
+guessed.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from coval_bench.db.models import Benchmark, BillingUnit
+
+if TYPE_CHECKING:
+    from coval_bench.db.models import PriceRow, Result
+
+_SECONDS_PER_UNIT: dict[BillingUnit, float] = {
+    BillingUnit.PER_SECOND: 1.0,
+    BillingUnit.PER_MINUTE: 60.0,
+    BillingUnit.PER_HOUR: 3600.0,
+}
+
+
+def compute_cost_usd(result: Result, rates: list[PriceRow]) -> float | None:
+    """USD cost of one benchmark item given its usage and the effective rates.
+
+    *result* is any metric row of the item — usage quantities are stamped
+    identically on all of them. Rates for other benchmarks (gradium serves STT
+    and TTS under one model id) are ignored.
+    """
+    by_unit = {r.billing_unit: r for r in rates if r.benchmark is result.benchmark}
+
+    in_rate = by_unit.get(BillingUnit.PER_1M_TOKENS_INPUT)
+    out_rate = by_unit.get(BillingUnit.PER_1M_TOKENS_OUTPUT)
+    if in_rate is not None or out_rate is not None:
+        cost: float | None = None
+        if in_rate is not None and result.input_tokens is not None:
+            cost = (cost or 0.0) + result.input_tokens / 1e6 * float(in_rate.rate_usd)
+        if out_rate is not None and result.output_tokens is not None:
+            cost = (cost or 0.0) + result.output_tokens / 1e6 * float(out_rate.rate_usd)
+        if cost is not None:
+            return cost
+
+    for unit, seconds_per in _SECONDS_PER_UNIT.items():
+        rate = by_unit.get(unit)
+        if rate is None:
+            continue
+        seconds = result.billable_seconds
+        if seconds is None:
+            seconds = (
+                result.audio_seconds_out
+                if result.benchmark is Benchmark.TTS
+                else result.audio_seconds_in
+            )
+        if seconds is not None:
+            return seconds / seconds_per * float(rate.rate_usd)
+
+    chars_rate = by_unit.get(BillingUnit.PER_1M_CHARS)
+    if chars_rate is not None and result.characters_in is not None:
+        return result.characters_in / 1e6 * float(chars_rate.rate_usd)
+
+    return None
+
+
+def judge_cost_usd(judge_usage: dict[str, float], rates: list[PriceRow]) -> float | None:
+    """USD cost of the run's whisper-1 judge calls from the accumulated usage.
+
+    Handles both usage shapes the judge can report: duration seconds against a
+    per-duration rate, token counts against token rates.
+    """
+    by_unit = {r.billing_unit: r for r in rates}
+    cost: float | None = None
+    seconds = judge_usage.get("audio_seconds")
+    if seconds is not None:
+        for unit, seconds_per in _SECONDS_PER_UNIT.items():
+            rate = by_unit.get(unit)
+            if rate is not None:
+                cost = seconds / seconds_per * float(rate.rate_usd)
+                break
+    for key, unit in (
+        ("input_tokens", BillingUnit.PER_1M_TOKENS_INPUT),
+        ("output_tokens", BillingUnit.PER_1M_TOKENS_OUTPUT),
+    ):
+        tokens = judge_usage.get(key)
+        rate = by_unit.get(unit)
+        if tokens is not None and rate is not None:
+            cost = (cost or 0.0) + tokens / 1e6 * float(rate.rate_usd)
+    return cost

--- a/runner/src/coval_bench/registries/__init__.py
+++ b/runner/src/coval_bench/registries/__init__.py
@@ -8,6 +8,7 @@ and the orchestrator without pulling in metric-computation dependencies.
 
 from coval_bench.registries.benchmarks import Benchmark
 from coval_bench.registries.metrics import (
+    INTERNAL_METRICS,
     METRIC_EXCLUSIONS,
     METRIC_SPECS,
     SERIES_EXCLUDED_METRICS,
@@ -34,6 +35,7 @@ from coval_bench.registries.tags import (
 
 __all__ = [
     "Benchmark",
+    "INTERNAL_METRICS",
     "METRIC_EXCLUSIONS",
     "METRIC_SPECS",
     "SERIES_EXCLUDED_METRICS",

--- a/runner/src/coval_bench/registries/metrics.py
+++ b/runner/src/coval_bench/registries/metrics.py
@@ -30,6 +30,7 @@ class Metric(StrEnum):
     AUDIO_TO_FINAL = "AudioToFinal"
     V2V = "V2V"
     INSTRUCTION_FOLLOWING = "InstructionFollowing"
+    COST_USD = "COST_USD"
 
 
 class MetricDirection(StrEnum):
@@ -127,6 +128,16 @@ METRIC_SPECS: dict[Metric, MetricSpec] = {
         decimals=1,
         benchmarks=frozenset({Benchmark.S2S}),
     ),
+    # Measured spend per benchmark item at the effective list rate — internal
+    # only (see INTERNAL_METRICS); the public site shows list prices, not our
+    # measured spend.
+    Metric.COST_USD: MetricSpec(
+        display_name="Cost",
+        units="usd",
+        direction=MetricDirection.LOWER_IS_BETTER,
+        decimals=4,
+        benchmarks=frozenset({Benchmark.STT, Benchmark.TTS, Benchmark.S2S}),
+    ),
 }
 
 if METRIC_SPECS.keys() != set(Metric):
@@ -143,6 +154,13 @@ if METRIC_SPECS.keys() != set(Metric):
 SERIES_EXCLUDED_METRICS: frozenset[Metric] = frozenset(
     {Metric.TTFA_ROUNDTRIP, Metric.TTFA_LEADING_SILENCE}
 )
+
+
+# Metrics the public API never serves: they ride the results pipeline (rows,
+# buckets, matviews) for internal spend tracking but are filtered out of every
+# /v1 response. Keep COST_USD out of SERIES_EXCLUDED_METRICS — the per-bucket
+# spend series is exactly what internal dashboards query.
+INTERNAL_METRICS: frozenset[Metric] = frozenset({Metric.COST_USD})
 
 
 # (provider, model) pairs whose metric is not comparable with the cohort:

--- a/runner/src/coval_bench/runner/orchestrator.py
+++ b/runner/src/coval_bench/runner/orchestrator.py
@@ -338,6 +338,57 @@ def _get_metrics() -> tuple[Any, Any]:
     return mod.compute_wer, mod.compute_rtf
 
 
+def _append_cost_row(
+    results: list[Any],
+    pricing: Any,  # noqa: ANN401 — PricingStore, lazy-imported by the caller
+    unpriced_logged: set[tuple[str, str]],
+    *,
+    result_status: Any,  # noqa: ANN401 — ResultStatus enum, lazy-imported by the caller
+) -> None:
+    """Append the item's COST_USD sibling row, or log the unpriced model once per run.
+
+    Usage quantities ride every row of the item identically, so any row (the
+    first) carries what the calculator needs. No effective rate or no usable
+    quantity → no row, never a zero.
+    """
+    first = results[0]
+    rates = pricing.effective_rates_cached(first.provider, first.model)
+    cost = importlib.import_module("coval_bench.metrics").compute_cost_usd(first, rates)
+    if cost is None:
+        key = (first.provider, first.model)
+        if key not in unpriced_logged:
+            unpriced_logged.add(key)
+            logger.info(
+                "cost_unpriced",
+                provider=first.provider,
+                model=first.model,
+                benchmark=str(first.benchmark),
+            )
+        return
+    results.append(
+        type(first)(
+            run_id=first.run_id,
+            provider=first.provider,
+            model=first.model,
+            voice=first.voice,
+            benchmark=first.benchmark,
+            metric_type=Metric.COST_USD,
+            metric_value=cost,
+            metric_units=METRIC_SPECS[Metric.COST_USD].units,
+            audio_filename=first.audio_filename,
+            status=result_status.SUCCESS,
+            error=None,
+            input_tokens=first.input_tokens,
+            output_tokens=first.output_tokens,
+            total_tokens=first.total_tokens,
+            billable_seconds=first.billable_seconds,
+            characters_in=first.characters_in,
+            audio_seconds_in=first.audio_seconds_in,
+            audio_seconds_out=first.audio_seconds_out,
+        )
+    )
+
+
 # ---------------------------------------------------------------------------
 # STT coroutine builder
 # ---------------------------------------------------------------------------
@@ -351,6 +402,8 @@ async def _run_stt_item(
     sem: asyncio.Semaphore,
     settings: Settings,
     writer: Any | None = None,  # noqa: ANN401 — RunWriter, lazy-imported in caller
+    pricing: Any | None = None,  # noqa: ANN401 — PricingStore, lazy-imported in caller
+    unpriced_logged: set[tuple[str, str]] | None = None,
 ) -> list[Any]:
     """Run a single STT provider × dataset item, returning a list of Result rows.
 
@@ -659,6 +712,14 @@ async def _run_stt_item(
                     )
                 )
 
+        if pricing is not None and results and item_error is None:
+            _append_cost_row(
+                results,
+                pricing,
+                unpriced_logged if unpriced_logged is not None else set(),
+                result_status=ResultStatus,
+            )
+
     _log_item_failures(
         "stt_item_failed",
         results,
@@ -715,6 +776,8 @@ async def _run_tts_item(
     voice: str | None = None,
     writer: Any | None = None,  # noqa: ANN401 — RunWriter, lazy-imported in caller
     judge_usage: dict[str, float] | None = None,
+    pricing: Any | None = None,  # noqa: ANN401 — PricingStore, lazy-imported in caller
+    unpriced_logged: set[tuple[str, str]] | None = None,
 ) -> list[Any]:
     """Run a single TTS provider × dataset item, returning a list of Result rows.
 
@@ -948,6 +1011,14 @@ async def _run_tts_item(
                         exc_info=exc,
                     )
 
+        if pricing is not None and results and item_error is None:
+            _append_cost_row(
+                results,
+                pricing,
+                unpriced_logged if unpriced_logged is not None else set(),
+                result_status=ResultStatus,
+            )
+
     _log_item_failures(
         "tts_item_failed",
         results,
@@ -1145,15 +1216,35 @@ async def run_benchmarks(
         all_results: list[Any] = []
         sem = asyncio.Semaphore(_DEDICATED_CONCURRENCY_CAP if dedicated else _CONCURRENCY_CAP)
 
+        # Run-scoped pricing cache (one DB read per run) for COST_USD rows.
+        # Cost capture is best-effort: a failed load means no cost rows this
+        # run, never a failed run.
+        pricing: Any = None
+        unpriced_logged: set[tuple[str, str]] = set()
+        try:
+            pricing = importlib.import_module("coval_bench.db.pricing").PricingStore(pool)
+            await pricing.load_cache()
+        except Exception:
+            logger.warning("pricing_cache_load_failed", exc_info=True)
+            pricing = None
+
         # Run-scoped whisper-judge spend, filled by _transcribe_with_whisper.
         # Empty keys stay NULL on the run row rather than fabricating zeros.
         judge_usage: dict[str, float] = {}
+
+        def _judge_cost() -> float | None:
+            if pricing is None or not judge_usage:
+                return None
+            rates = pricing.effective_rates_cached("openai", "whisper-1-judge")
+            judge_cost_fn = importlib.import_module("coval_bench.metrics").judge_cost_usd
+            return judge_cost_fn(judge_usage, rates)
 
         def _judge_totals() -> dict[str, Any]:
             return {
                 "judge_input_tokens": judge_usage.get("input_tokens"),
                 "judge_output_tokens": judge_usage.get("output_tokens"),
                 "judge_audio_seconds": judge_usage.get("audio_seconds"),
+                "judge_cost_usd": _judge_cost(),
             }
 
         # Cloud Run sends SIGTERM ~10s before SIGKILL when a task hits its timeout.
@@ -1233,6 +1324,8 @@ async def run_benchmarks(
                         sem=sem,
                         settings=settings,
                         writer=writer,
+                        pricing=pricing,
+                        unpriced_logged=unpriced_logged,
                     )
                     for entry, item in stt_pairs
                 ]
@@ -1283,6 +1376,8 @@ async def run_benchmarks(
                         voice=voice,
                         writer=writer,
                         judge_usage=judge_usage,
+                        pricing=pricing,
+                        unpriced_logged=unpriced_logged,
                     )
                     for entry, item, voice in tts_pairs
                 ]
@@ -1380,6 +1475,30 @@ async def run_benchmarks(
                     "$process_person_profile": False,
                 },
             )
+
+            # Internal spend telemetry — one event per run so PostHog can chart
+            # spend with no UI work. Best-effort like every _emit_posthog call.
+            model_costs: dict[str, float] = defaultdict(float)
+            for r in typed_results:
+                if r.metric_type == Metric.COST_USD and r.metric_value is not None:
+                    model_costs[f"{r.provider}/{r.model}"] += r.metric_value
+            judge_cost = _judge_cost()
+            if model_costs or judge_cost is not None:
+                run_cost = sum(model_costs.values()) + (judge_cost or 0.0)
+                _emit_posthog(
+                    posthog_client,
+                    "benchmark_run_cost",
+                    {
+                        "run_id": run_id,
+                        "benchmark_kind": benchmark_kind,
+                        "total_cost_usd": run_cost,
+                        "judge_cost_usd": judge_cost,
+                        "top_model_costs": dict(
+                            sorted(model_costs.items(), key=lambda kv: kv[1], reverse=True)[:5]
+                        ),
+                        "$process_person_profile": False,
+                    },
+                )
             return summary
 
         except asyncio.CancelledError:

--- a/runner/src/coval_bench/runner/orchestrator.py
+++ b/runner/src/coval_bench/runner/orchestrator.py
@@ -352,7 +352,7 @@ def _append_cost_row(
     quantity → no row, never a zero.
     """
     first = results[0]
-    rates = pricing.effective_rates_cached(first.provider, first.model)
+    rates = pricing.effective_rates_cached(first.provider, first.model, first.benchmark)
     cost = importlib.import_module("coval_bench.metrics").compute_cost_usd(first, rates)
     if cost is None:
         key = (first.provider, first.model)
@@ -1061,6 +1061,47 @@ def _emit_posthog(client: Posthog | None, event: str, properties: dict[str, Any]
         logger.warning("posthog_emit_failed", event_name=event, exc_info=True)
 
 
+def _emit_run_cost_event(
+    posthog_client: Posthog | None,
+    *,
+    run_id: int,
+    benchmark_kind: str,
+    persisted_total: Any,  # noqa: ANN401 — float from RunWriter; mocks pass through
+    judge_cost: float | None,
+    typed_results: list[Any],
+    sigterm: bool = False,
+) -> None:
+    """Internal spend telemetry — one event per run so PostHog can chart spend.
+
+    ``total_cost_usd`` is the DB-persisted rollup returned by ``finish_run``,
+    never an in-memory sum that a rolled-back batch could inflate; the top-5
+    breakdown is in-memory and therefore approximate on persist failures.
+    Best-effort like every ``_emit_posthog`` call.
+    """
+    total = persisted_total if isinstance(persisted_total, (int, float)) else None
+    model_costs: dict[str, float] = defaultdict(float)
+    for r in typed_results:
+        if r.metric_type == Metric.COST_USD and r.metric_value is not None:
+            model_costs[f"{r.provider}/{r.model}"] += r.metric_value
+    if total is None and not model_costs and judge_cost is None:
+        return
+    _emit_posthog(
+        posthog_client,
+        "benchmark_run_cost",
+        {
+            "run_id": run_id,
+            "benchmark_kind": benchmark_kind,
+            "total_cost_usd": total,
+            "judge_cost_usd": judge_cost,
+            "top_model_costs": dict(
+                sorted(model_costs.items(), key=lambda kv: kv[1], reverse=True)[:5]
+            ),
+            "sigterm": sigterm,
+            "$process_person_profile": False,
+        },
+    )
+
+
 # Transient-failure retry for the end-of-run bucket refresh.
 _BUCKET_REFRESH_ATTEMPTS = 3
 _BUCKET_REFRESH_RETRY_DELAY_S = 0.5
@@ -1414,7 +1455,9 @@ async def run_benchmarks(
             else:
                 final_status = RunStatus.PARTIAL
 
-            await writer.finish_run(run_id, status=final_status, error=None, **_judge_totals())
+            persisted_cost = await writer.finish_run(
+                run_id, status=final_status, error=None, **_judge_totals()
+            )
 
             # After the row is stored, never before: if finish_run raises, the outer
             # handler is the only thing that should report, otherwise a partial run
@@ -1476,29 +1519,14 @@ async def run_benchmarks(
                 },
             )
 
-            # Internal spend telemetry — one event per run so PostHog can chart
-            # spend with no UI work. Best-effort like every _emit_posthog call.
-            model_costs: dict[str, float] = defaultdict(float)
-            for r in typed_results:
-                if r.metric_type == Metric.COST_USD and r.metric_value is not None:
-                    model_costs[f"{r.provider}/{r.model}"] += r.metric_value
-            judge_cost = _judge_cost()
-            if model_costs or judge_cost is not None:
-                run_cost = sum(model_costs.values()) + (judge_cost or 0.0)
-                _emit_posthog(
-                    posthog_client,
-                    "benchmark_run_cost",
-                    {
-                        "run_id": run_id,
-                        "benchmark_kind": benchmark_kind,
-                        "total_cost_usd": run_cost,
-                        "judge_cost_usd": judge_cost,
-                        "top_model_costs": dict(
-                            sorted(model_costs.items(), key=lambda kv: kv[1], reverse=True)[:5]
-                        ),
-                        "$process_person_profile": False,
-                    },
-                )
+            _emit_run_cost_event(
+                posthog_client,
+                run_id=run_id,
+                benchmark_kind=benchmark_kind,
+                persisted_total=persisted_cost,
+                judge_cost=_judge_cost(),
+                typed_results=typed_results,
+            )
             return summary
 
         except asyncio.CancelledError:
@@ -1513,8 +1541,9 @@ async def run_benchmarks(
             success_count = sum(1 for r in typed_results if r.status == ResultStatus.SUCCESS)
             fail_count = sum(1 for r in typed_results if r.status == ResultStatus.FAILED)
             total_results = len(typed_results)
+            sigterm_cost: Any = None
             try:
-                await asyncio.shield(
+                sigterm_cost = await asyncio.shield(
                     writer.finish_run(
                         run_id,
                         status=RunStatus.PARTIAL,
@@ -1544,6 +1573,17 @@ async def run_benchmarks(
                 )
                 # Run row is PARTIAL, so its bucket qualifies.
                 await asyncio.shield(_refresh_series_bucket(writer, run_id, settings))
+                # Spend persisted by the incremental flush must reach the
+                # PostHog charts too, not just the run row.
+                _emit_run_cost_event(
+                    posthog_client,
+                    run_id=run_id,
+                    benchmark_kind=benchmark_kind,
+                    persisted_total=sigterm_cost,
+                    judge_cost=_judge_cost(),
+                    typed_results=typed_results,
+                    sigterm=True,
+                )
             finished_at = datetime.now(tz=UTC)
             sigterm_duration_s = (finished_at - started_at).total_seconds()
             logger.warning(

--- a/runner/tests/api/test_aggregates.py
+++ b/runner/tests/api/test_aggregates.py
@@ -71,6 +71,25 @@ async def test_model_stats_math(client: AsyncClient, postgresql: Any) -> None:
     assert s["sample_count"] == 4
 
 
+async def test_internal_cost_metric_never_served(client: AsyncClient, postgresql: Any) -> None:
+    """COST_USD rides the pipeline for internal spend tracking but never leaves the API."""
+    run_id = await _insert_run(postgresql)
+    await _insert_result(postgresql, run_id, metric_type="WER", metric_value=5.0)
+    await _insert_result(postgresql, run_id, metric_type="COST_USD", metric_value=0.01)
+    await _refresh_mv(postgresql)
+    await _fill_buckets(postgresql)
+
+    response = await client.get("/v1/results/aggregates", params={"benchmark": "STT"})
+    assert response.status_code == 200
+    body = response.json()
+    assert {s["metric_type"] for s in body["model_stats"]} == {"WER"}
+    assert all(p["metric_type"] != "COST_USD" for p in body["series"])
+
+    raw = await client.get("/v1/results", params={"benchmark": "STT"})
+    assert raw.status_code == 200
+    assert all(r["metric_type"] != "COST_USD" for r in raw.json()["results"])
+
+
 async def test_single_sample_stddev_is_zero(client: AsyncClient, postgresql: Any) -> None:
     """STDDEV_SAMP is NULL for n=1 — must be coalesced to 0 like the client did."""
     run_id = await _insert_run(postgresql)

--- a/runner/tests/unit/test_cost.py
+++ b/runner/tests/unit/test_cost.py
@@ -1,0 +1,126 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the per-item cost calculator and the judge-cost helper."""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+from decimal import Decimal
+
+import pytest
+
+from coval_bench.db.models import Benchmark, BillingUnit, PriceRow, Result, ResultStatus
+from coval_bench.metrics import compute_cost_usd, judge_cost_usd
+
+
+def _rate(unit: BillingUnit, rate: str, benchmark: Benchmark = Benchmark.STT) -> PriceRow:
+    return PriceRow(
+        provider="p",
+        model="m",
+        benchmark=benchmark,
+        billing_unit=unit,
+        rate_usd=Decimal(rate),
+        effective_at=datetime(2026, 8, 1, tzinfo=UTC),
+        source_url="https://example.com/pricing",
+        as_of=date(2026, 8, 6),
+        updated_by="human",
+    )
+
+
+def _result(benchmark: Benchmark = Benchmark.STT, **usage: object) -> Result:
+    return Result(
+        run_id=1,
+        provider="p",
+        model="m",
+        benchmark=benchmark,
+        metric_type="WER",
+        metric_value=1.0,
+        metric_units="percent",
+        status=ResultStatus.SUCCESS,
+        **usage,  # type: ignore[arg-type]
+    )
+
+
+def test_token_rates_use_token_counts() -> None:
+    rates = [
+        _rate(BillingUnit.PER_1M_TOKENS_INPUT, "2.50"),
+        _rate(BillingUnit.PER_1M_TOKENS_OUTPUT, "10.00"),
+    ]
+    result = _result(input_tokens=1_000_000, output_tokens=500_000)
+    assert compute_cost_usd(result, rates) == pytest.approx(2.50 + 5.00)
+
+
+def test_token_rates_partial_counts_still_price_available_side() -> None:
+    rates = [
+        _rate(BillingUnit.PER_1M_TOKENS_INPUT, "2.50"),
+        _rate(BillingUnit.PER_1M_TOKENS_OUTPUT, "10.00"),
+    ]
+    result = _result(output_tokens=100_000)  # provider reported only output
+    assert compute_cost_usd(result, rates) == pytest.approx(1.00)
+
+
+def test_duration_rate_prefers_billable_seconds() -> None:
+    rates = [_rate(BillingUnit.PER_MINUTE, "0.006")]
+    result = _result(billable_seconds=120.0, audio_seconds_in=999.0)
+    assert compute_cost_usd(result, rates) == pytest.approx(0.012)
+
+
+def test_duration_rate_falls_back_to_audio_seconds_in_for_stt() -> None:
+    rates = [_rate(BillingUnit.PER_HOUR, "0.36")]
+    result = _result(audio_seconds_in=600.0)  # 1/6 hour
+    assert compute_cost_usd(result, rates) == pytest.approx(0.06)
+
+
+def test_duration_rate_falls_back_to_audio_seconds_out_for_tts() -> None:
+    rates = [_rate(BillingUnit.PER_SECOND, "0.001", benchmark=Benchmark.TTS)]
+    result = _result(benchmark=Benchmark.TTS, audio_seconds_out=30.0, audio_seconds_in=999.0)
+    assert compute_cost_usd(result, rates) == pytest.approx(0.03)
+
+
+def test_chars_rate_uses_characters_in() -> None:
+    rates = [_rate(BillingUnit.PER_1M_CHARS, "50.00", benchmark=Benchmark.TTS)]
+    result = _result(benchmark=Benchmark.TTS, characters_in=2_000)
+    assert compute_cost_usd(result, rates) == pytest.approx(0.10)
+
+
+def test_token_rates_without_counts_fall_through_to_duration() -> None:
+    rates = [
+        _rate(BillingUnit.PER_1M_TOKENS_INPUT, "2.50"),
+        _rate(BillingUnit.PER_MINUTE, "0.006"),
+    ]
+    result = _result(billable_seconds=60.0)  # no tokens reported
+    assert compute_cost_usd(result, rates) == pytest.approx(0.006)
+
+
+def test_rates_from_other_benchmark_are_ignored() -> None:
+    # gradium serves STT and TTS under one model id — the TTS chars rate must
+    # not price an STT row.
+    rates = [_rate(BillingUnit.PER_1M_CHARS, "48.00", benchmark=Benchmark.TTS)]
+    result = _result(benchmark=Benchmark.STT, characters_in=1_000)
+    assert compute_cost_usd(result, rates) is None
+
+
+def test_no_rate_or_no_quantity_returns_none() -> None:
+    assert compute_cost_usd(_result(billable_seconds=60.0), []) is None
+    assert compute_cost_usd(_result(), [_rate(BillingUnit.PER_MINUTE, "0.006")]) is None
+    assert compute_cost_usd(_result(), [_rate(BillingUnit.PER_REQUEST, "0.01")]) is None
+
+
+def test_judge_cost_duration_usage() -> None:
+    rates = [_rate(BillingUnit.PER_MINUTE, "0.006", benchmark=Benchmark.TTS)]
+    assert judge_cost_usd({"audio_seconds": 300.0}, rates) == pytest.approx(0.03)
+
+
+def test_judge_cost_token_usage() -> None:
+    rates = [
+        _rate(BillingUnit.PER_1M_TOKENS_INPUT, "2.00", benchmark=Benchmark.TTS),
+        _rate(BillingUnit.PER_1M_TOKENS_OUTPUT, "4.00", benchmark=Benchmark.TTS),
+    ]
+    usage = {"input_tokens": 500_000.0, "output_tokens": 250_000.0}
+    assert judge_cost_usd(usage, rates) == pytest.approx(1.00 + 1.00)
+
+
+def test_judge_cost_empty_usage_or_rates_is_none() -> None:
+    assert judge_cost_usd({}, [_rate(BillingUnit.PER_MINUTE, "0.006")]) is None
+    assert judge_cost_usd({"audio_seconds": 300.0}, []) is None

--- a/runner/tests/unit/test_db_pricing.py
+++ b/runner/tests/unit/test_db_pricing.py
@@ -215,6 +215,88 @@ def test_ratesheet_keys_match_registry() -> None:
     assert not orphans, f"ratesheet entries for unknown/inactive models: {sorted(orphans)}"
 
 
+def test_cost_rollup_and_bucket_flow(pg_conn: psycopg.Connection[Any]) -> None:
+    """COST_USD rows roll up onto the run row and flow into bucket + matviews."""
+    from datetime import timedelta as _td
+
+    from coval_bench.db.models import Result, ResultStatus, RunStatus
+    from coval_bench.db.writer import RunWriter
+
+    _apply_migrations(pg_conn)
+
+    def _cost_row(run_id: int, value: float) -> Result:
+        return Result(
+            run_id=run_id,
+            provider="deepgram",
+            model="nova-3",
+            benchmark=Benchmark.STT,
+            metric_type="COST_USD",
+            metric_value=value,
+            metric_units="usd",
+            status=ResultStatus.SUCCESS,
+        )
+
+    async def _run() -> None:
+        pool = await _make_pool(pg_conn)
+        try:
+            writer = RunWriter(pool)
+            scheduled = datetime(2026, 8, 6, 12, 0, tzinfo=UTC)
+            run = await writer.start_run(
+                runner_sha="s", dataset_id="stt-v1", dataset_sha256="h", scheduled_at=scheduled
+            )
+            assert run.id is not None
+            await writer.record_results([_cost_row(run.id, 0.01), _cost_row(run.id, 0.02)])
+            await writer.finish_run(run.id, status=RunStatus.SUCCEEDED, judge_cost_usd=0.5)
+            await writer.refresh_bucket(run.id, period_seconds=1800)
+            await writer.refresh_stats_matviews()
+
+            # A run with no cost rows and no judge cost stays NULL — no zeros.
+            run2 = await writer.start_run(
+                runner_sha="s",
+                dataset_id="stt-v1",
+                dataset_sha256="h",
+                scheduled_at=scheduled + _td(hours=1),
+            )
+            assert run2.id is not None
+            await writer.finish_run(run2.id, status=RunStatus.FAILED, error="boom")
+        finally:
+            await pool.close()
+
+        pg_conn.autocommit = True
+        with pg_conn.cursor() as cur:
+            cur.execute(
+                "SELECT total_cost_usd, judge_cost_usd FROM benchmarks_v2.runs WHERE id = %s",
+                (run.id,),
+            )
+            totals = cur.fetchone()
+            assert totals is not None
+            assert float(totals[0]) == pytest.approx(0.53)
+            assert float(totals[1]) == pytest.approx(0.5)
+
+            cur.execute("SELECT total_cost_usd FROM benchmarks_v2.runs WHERE id = %s", (run2.id,))
+            row2 = cur.fetchone()
+            assert row2 is not None and row2[0] is None
+
+            cur.execute(
+                "SELECT value_sum, sample_count FROM benchmarks_v2.results_by_bucket "
+                "WHERE metric_type = 'COST_USD' AND dataset_id = '__all__'"
+            )
+            bucket = cur.fetchone()
+            assert bucket is not None
+            assert float(bucket[0]) == pytest.approx(0.03)
+            assert bucket[1] == 2
+
+            cur.execute(
+                "SELECT avg_value, sample_count FROM benchmarks_v2.results_24h "
+                "WHERE metric_type = 'COST_USD'"
+            )
+            stat = cur.fetchone()
+            assert stat is not None
+            assert float(stat[0]) == pytest.approx(0.015)
+
+    asyncio.run(_run())
+
+
 def test_seed_is_idempotent(pg_conn: psycopg.Connection[Any]) -> None:
     """Second apply_ratesheet run writes nothing new."""
     _apply_migrations(pg_conn)

--- a/runner/tests/unit/test_metric_registry.py
+++ b/runner/tests/unit/test_metric_registry.py
@@ -25,6 +25,7 @@ def test_metric_values_match_stored_strings() -> None:
         "AudioToFinal",
         "V2V",
         "InstructionFollowing",
+        "COST_USD",
     }
 
 
@@ -41,6 +42,7 @@ def test_units_match_stored_strings() -> None:
         Metric.AUDIO_TO_FINAL: "seconds",
         Metric.V2V: "milliseconds",
         Metric.INSTRUCTION_FOLLOWING: "percent",
+        Metric.COST_USD: "usd",
     }
     assert {m: spec.units for m, spec in METRIC_SPECS.items()} == expected
 

--- a/runner/tests/unit/test_orchestrator.py
+++ b/runner/tests/unit/test_orchestrator.py
@@ -350,6 +350,7 @@ async def test_smoke_run_stt(audio_file: Path, settings: Settings) -> None:
         judge_input_tokens=None,
         judge_output_tokens=None,
         judge_audio_seconds=None,
+        judge_cost_usd=None,
     )
     # Usage quantities ride every row of the item: the dataset item's audio
     # duration plus whatever the provider reported.
@@ -417,6 +418,7 @@ async def test_partial_run(audio_file: Path, settings: Settings) -> None:
         judge_input_tokens=None,
         judge_output_tokens=None,
         judge_audio_seconds=None,
+        judge_cost_usd=None,
     )
     writer.refresh_bucket.assert_awaited_once_with(
         1, period_seconds=settings.schedule_period_seconds
@@ -2098,6 +2100,82 @@ async def test_tts_usage_quantities_recorded(audio_file: Path, settings: Setting
     assert all(r.characters_in == len("hello world") for r in rows)
     assert all(r.audio_seconds_out == pytest.approx(512 / 16000) for r in rows)
     assert all(r.billable_seconds == 1.9 for r in rows)
+
+
+class _StubPricing:
+    """PricingStore stand-in: nova-2 priced per-minute, everything else unpriced."""
+
+    def __init__(self, pool: Any) -> None:
+        self.pool = pool
+
+    async def load_cache(self) -> None:
+        return None
+
+    def effective_rates_cached(self, provider: str, model: str) -> list[Any]:
+        from datetime import date
+        from decimal import Decimal
+
+        from coval_bench.db.models import BillingUnit, PriceRow
+
+        if (provider, model) != ("deepgram", "nova-2"):
+            return []
+        return [
+            PriceRow(
+                provider=provider,
+                model=model,
+                benchmark=Benchmark.STT,
+                billing_unit=BillingUnit.PER_MINUTE,
+                rate_usd=Decimal("0.006"),
+                effective_at=datetime(2026, 8, 1, tzinfo=UTC),
+                source_url="https://example.com/pricing",
+                as_of=date(2026, 8, 6),
+                updated_by="human",
+            )
+        ]
+
+
+@pytest.mark.asyncio
+async def test_stt_cost_rows_emitted_for_priced_models(
+    audio_file: Path, settings: Settings
+) -> None:
+    """Priced model gets one COST_USD sibling row per item; unpriced model gets none."""
+    good = _good_transcription()
+    good.billable_seconds = 120.0
+
+    provider_inst = MagicMock()
+    provider_inst.measure_ttft = AsyncMock(return_value=good)
+    provider_cls = MagicMock(return_value=provider_inst)
+
+    run = _make_run()
+    writer = _make_stub_writer(run)
+
+    async with _orchestrator_env(
+        audio_path=audio_file,
+        stt_items=[_make_dataset_item(audio_file)],
+        stt_providers={"deepgram": provider_cls, "elevenlabs": provider_cls},
+        run=run,
+        writer=writer,
+    ) as _:
+        with patch("coval_bench.db.pricing.PricingStore", _StubPricing):
+            await run_benchmarks(
+                settings=settings,
+                benchmark_kind="stt",
+                smoke=True,
+                matrix_overrides=[
+                    _stt_entry("deepgram", "nova-2"),
+                    _stt_entry("elevenlabs", "scribe_v2_realtime"),
+                ],
+            )
+
+    cost_rows = [r for r in _recorded_rows(writer) if r.metric_type == "COST_USD"]
+    assert len(cost_rows) == 1
+    row = cost_rows[0]
+    assert (row.provider, row.model) == ("deepgram", "nova-2")
+    # 120 billable seconds at $0.006/min
+    assert row.metric_value == pytest.approx(0.012)
+    assert row.metric_units == "usd"
+    assert row.status == ResultStatus.SUCCESS
+    assert row.billable_seconds == 120.0
 
 
 @pytest.mark.asyncio

--- a/runner/tests/unit/test_orchestrator.py
+++ b/runner/tests/unit/test_orchestrator.py
@@ -2111,7 +2111,7 @@ class _StubPricing:
     async def load_cache(self) -> None:
         return None
 
-    def effective_rates_cached(self, provider: str, model: str) -> list[Any]:
+    def effective_rates_cached(self, provider: str, model: str, benchmark: Any = None) -> list[Any]:
         from datetime import date
         from decimal import Decimal
 


### PR DESCRIPTION
Stacked on #460.

Cost as a metric: each succeeded item with a resolvable rate gets a sibling `COST_USD` row (token rates × counts → duration rates × billable/measured seconds → per-1M-chars; no rate or quantity → no row, logged once per model per run — never a zero). `finish_run` sums the run's persisted cost rows in SQL (correct even after SIGTERM) plus the whisper judge's cost into `runs.total_cost_usd`/`judge_cost_usd` (migration `0017`), and a fail-silent `benchmark_run_cost` PostHog event carries totals + top-5 model costs. `COST_USD` is internal-only: `INTERNAL_METRICS` filters it from `/v1/results` and both aggregates endpoints (API test proves it) while it deliberately stays in `results_by_bucket` for internal spend series. Canonical queries in `docs/cost-tracking.md`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds per-item `COST_USD` measurements, persisted per-run cost rollups, internal-only API filtering, and PostHog spend telemetry.

- Computes costs from effective token, duration, or character rates.
- Stores item and judge costs and rolls them into `runs.total_cost_usd`.
- Keeps cost metrics out of public result and aggregate responses while retaining internal bucket data.
- Adds cost calculation, persistence, API, registry, and orchestration tests.

<h3>Confidence Score: 3/5</h3>

The PR should not merge until PostHog cost telemetry uses persisted totals and covers SIGTERM-finalized runs.

The database rollup is authoritative, but normal telemetry can include rows whose persistence failed, while SIGTERM runs can persist spend without emitting any cost event.

**Files Needing Attention:** runner/src/coval_bench/runner/orchestrator.py

<sub>Reviews (1): Last reviewed commit: ["\[BENCH-634\] Cost computation: COST\_USD p..."](https://github.com/coval-ai/benchmarks/commit/37bb0a8dc8ae71f6e2fe79f754dd841bf56d132d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50943165)</sub>

> Greptile also left **2 inline comments** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Runner Orchestration](https://app.greptile.com/coval/-/custom-context/knowledge-base/coval-ai/benchmarks/-/docs/runner-orchestration.md)
- Knowledge Base — [DB Layer](https://app.greptile.com/coval/-/custom-context/knowledge-base/coval-ai/benchmarks/-/docs/db-layer.md)
- Knowledge Base — [API service](https://app.greptile.com/coval/-/custom-context/knowledge-base/coval-ai/benchmarks/-/docs/api-service.md)
</details>

<!-- /greptile_comment -->