### PR TITLE
[BENCH-635] Price collector: cron job with LLM extraction, diff + review gate (4/6)

### DIFF
--- a/runner/README.md
+++ b/runner/README.md
@@ -4,6 +4,15 @@ Runner + API for Coval voice-AI benchmarks. Implements:
 
 - A Cloud Run Job that runs STT/TTS providers against a pinned dataset every 30 min and writes results to Cloud SQL.
 - A FastAPI service that serves the public results API at `https://benchmarks.coval.ai`.
+- A weekly price-collector Cloud Run Job (`coval-bench update-prices`, same
+  image, different command; cron in `benchmark-infra`, cadence mirrored by
+  `PRICING_UPDATE_PERIOD_SECONDS`). It scrapes provider pricing pages,
+  LLM-extracts rates with verbatim quotes, snapshots the pages for evidence,
+  auto-applies small agreed changes to `benchmarks_v2.model_pricing` as
+  `updated_by='bot'` rows, and opens a review item (Linear via
+  `LINEAR_API_KEY`, or `PRICING_REVIEW_SLACK_WEBHOOK`) for large or uncertain
+  ones and for rates stale beyond 45 days. `--dry-run` prints the diff table
+  without writing.
 
 ## What we benchmark
 

--- a/runner/src/coval_bench/__main__.py
+++ b/runner/src/coval_bench/__main__.py
@@ -100,6 +100,53 @@ migrate.add_command(import_legacy_cli, name="import-legacy")
 cli.add_command(fetch_s2s, name="fetch-s2s")
 
 
+@cli.command(name="update-prices")
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    default=False,
+    help="Print the diff table only — write no snapshots, rates, or review items.",
+)
+@click.option(
+    "--provider",
+    "providers",
+    multiple=True,
+    help="Restrict to one or more providers (repeatable). Default: all with a pricing page.",
+)
+def update_prices(dry_run: bool, providers: tuple[str, ...]) -> None:
+    """Scrape pricing pages, LLM-extract rates, and diff against the pricing store.
+
+    Small agreed changes auto-apply as new effective rows (updated_by='bot');
+    large or uncertain ones open a review item. Invoked weekly by a Cloud Run
+    Job (cron in benchmark-infra).
+    """
+    from coval_bench.config import get_settings
+    from coval_bench.db.conn import lifespan_pool
+    from coval_bench.pricing.collector import run_update_prices
+
+    async def _run() -> dict:
+        settings = get_settings()
+        async with lifespan_pool(settings) as pool:
+            return await run_update_prices(
+                settings, pool, providers=list(providers) or None, dry_run=dry_run
+            )
+
+    summary = asyncio.run(_run())
+    for change in summary["changes"]:
+        old = change["old_rate"] if change["old_rate"] is not None else "—"
+        delta = f"{change['delta_pct']:.1f}%" if change["delta_pct"] is not None else "—"
+        click.echo(
+            f"{change['action']:<13} {change['provider']}/{change['model']}"
+            f" [{change['billing_unit']}] {old} -> {change['new_rate']}"
+            f" (Δ {delta}) {change['reason']}"
+        )
+    click.echo(
+        json.dumps(
+            {"event": "update_prices", **{k: v for k, v in summary.items() if k != "changes"}}
+        )
+    )
+
+
 @cli.command(name="tts-smoke")
 @click.option("--provider", required=True, help="TTS provider name (e.g. openai, cartesia).")
 @click.option("--model", required=True, help="Model ID for the provider (e.g. gpt-4o-mini-tts).")

--- a/runner/src/coval_bench/config.py
+++ b/runner/src/coval_bench/config.py
@@ -151,6 +151,19 @@ class Settings(BaseSettings):
     # Public bucket for per-tick sample recordings; empty disables sampling.
     s2s_samples_bucket: str = ""
 
+    # --- Pricing collector ---
+    # Cadence of the update-prices Cloud Run Job; the cron itself lives in
+    # benchmark-infra (same mirror convention as schedule_period_seconds).
+    # Default weekly.
+    pricing_update_period_seconds: int = Field(default=604_800, gt=0)
+    # Model used for pricing-page rate extraction (OpenAI structured outputs).
+    pricing_extraction_model: str = "gpt-5-mini"
+    # Review-item sink: Linear preferred when the key is set, else the Slack
+    # webhook, else review items are logged only.
+    linear_api_key: SecretStr | None = None
+    linear_team_name: str = "Benchmarks"
+    pricing_review_slack_webhook: SecretStr | None = None
+
     # --- Analytics ---
     posthog_project_token: str = ""
     posthog_host: str = "https://us.i.posthog.com"

--- a/runner/src/coval_bench/db/migrations/versions/20260806_0018_pricing_snapshots.py
+++ b/runner/src/coval_bench/db/migrations/versions/20260806_0018_pricing_snapshots.py
@@ -1,0 +1,44 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Raw pricing-page snapshots backing the price collector's evidence trail.
+
+Every ``model_pricing`` row a bot writes references a snapshot hash; keeping
+the gzipped page text lets a reviewer see exactly what the extractor saw. A
+new row is stored only when the page hash changes, so weekly runs against
+static pages cost nothing.
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "20260806_0018"
+down_revision = "20260806_0017"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        CREATE TABLE benchmarks_v2.pricing_snapshots (
+          id BIGSERIAL PRIMARY KEY,
+          provider TEXT NOT NULL,
+          url TEXT NOT NULL,
+          sha256 TEXT NOT NULL,
+          content_gz BYTEA NOT NULL,
+          fetched_at TIMESTAMPTZ NOT NULL DEFAULT now()
+        )
+        """
+    )
+    op.execute(
+        """
+        CREATE INDEX ix_pricing_snapshots_provider
+          ON benchmarks_v2.pricing_snapshots (provider, fetched_at DESC)
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP TABLE benchmarks_v2.pricing_snapshots")

--- a/runner/src/coval_bench/db/pricing.py
+++ b/runner/src/coval_bench/db/pricing.py
@@ -152,6 +152,23 @@ class PricingStore:
             await conn.commit()
         return PriceRow.model_validate(dict(row)), True
 
+    async def refresh_as_of(self, row_id: int, as_of: date) -> None:
+        """Re-stamp the verification date on a still-effective row.
+
+        The one metadata update the append-only rule allows besides
+        ``superseded_at``: the rate itself is untouched, this only records
+        that the collector re-verified it on *as_of* — without it, unchanged
+        rates would trip the staleness alarm forever.
+        """
+        async with self._pool.connection() as conn:
+            async with conn.cursor() as cur:
+                await cur.execute(
+                    "UPDATE benchmarks_v2.model_pricing SET as_of = %s"
+                    " WHERE id = %s AND superseded_at IS NULL",
+                    (as_of, row_id),
+                )
+            await conn.commit()
+
     async def load_cache(self) -> None:
         """Load every currently-effective rate into memory, one query per run."""
         sql = f"""

--- a/runner/src/coval_bench/pricing/__init__.py
+++ b/runner/src/coval_bench/pricing/__init__.py
@@ -1,0 +1,3 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+"""Price collection and normalization for the pricing store."""

--- a/runner/src/coval_bench/pricing/collector.py
+++ b/runner/src/coval_bench/pricing/collector.py
@@ -1,0 +1,575 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+"""Price collector: scrape pricing pages, LLM-extract rates, diff with a review gate.
+
+Voice providers have no pricing APIs, so "dynamic" means: changes are detected
+automatically, applied with provenance, and reviewed cheaply — never silently
+published when large or uncertain. The gate per extracted rate:
+
+* identical to the effective rate → noop
+* delta ≤ 20% AND high extraction confidence AND (LiteLLM cross-check agrees
+  or has no entry) → auto-insert a new effective row (``updated_by='bot'``,
+  evidence = snapshot hash + verbatim quote), superseding the old one
+* anything else (large delta, low confidence, cross-check disagreement, a
+  model with no current rate) → a review item; the table is left untouched.
+
+Review items go to Linear when ``LINEAR_API_KEY`` is set, else to the Slack
+webhook, else they are logged. A staleness sweep flags active models whose
+effective rate hasn't been re-verified in 45 days. One provider failing never
+aborts the rest.
+"""
+
+from __future__ import annotations
+
+import gzip
+import hashlib
+import json
+from datetime import UTC, date, datetime
+from decimal import Decimal
+from typing import TYPE_CHECKING, Any, Literal
+
+import httpx
+import structlog
+from pydantic import BaseModel
+
+from coval_bench.db.models import Benchmark, BillingUnit
+from coval_bench.db.pricing import PricingStore
+from coval_bench.registries.models import MODEL_REGISTRY, ModelStatus
+from coval_bench.registries.pricing_sources import PRICING_SOURCES, PricingSource
+
+if TYPE_CHECKING:
+    import psycopg
+    import psycopg.rows
+    from psycopg_pool import AsyncConnectionPool
+
+    from coval_bench.config import Settings
+
+logger = structlog.get_logger("coval_bench.pricing")
+
+_FETCH_TIMEOUT_S = 30.0
+_USER_AGENT = (
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36"
+)
+_PAGE_TEXT_LIMIT = 120_000  # chars of page text handed to the extractor
+_AUTO_APPLY_MAX_DELTA_PCT = 20.0
+_STALE_AFTER_DAYS = 45
+_LITELLM_URL = (
+    "https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json"
+)
+
+# Extracted page names → registry model ids, checked after an exact-id match
+# fails. Keys are (provider, lowercased extracted name).
+MODEL_ALIASES: dict[tuple[str, str], str] = {
+    ("deepgram", "nova-3 monolingual"): "nova-3",
+    ("deepgram", "nova-3 english"): "nova-3",
+    ("deepgram", "flux english"): "flux-general-en",
+    ("deepgram", "flux multilingual"): "flux-general-multi",
+    ("deepgram", "aura-2"): "aura-2-thalia-en",
+    ("assemblyai", "universal-streaming english"): "universal-streaming",
+    ("assemblyai", "universal-streaming-english"): "universal-streaming",
+    ("assemblyai", "universal-3.5 pro realtime"): "universal-3.5-pro",
+    ("assemblyai", "u3-rt-pro"): "universal-3.5-pro",
+    ("speechmatics", "real-time standard"): "default",
+    ("speechmatics", "real-time enhanced"): "enhanced",
+    ("elevenlabs", "flash / turbo"): "eleven_flash_v2_5",
+    ("elevenlabs", "scribe v2 realtime"): "scribe_v2_realtime",
+    ("revai", "reverb transcription"): "reverb",
+    ("inworld", "realtime tts-2"): "inworld-tts-2",
+    ("inworld", "realtime tts 1.5 max"): "inworld-tts-1.5-max",
+    ("inworld", "realtime tts 1.5 mini"): "inworld-tts-1.5-mini",
+    ("inworld", "stt 1"): "inworld-stt-1",
+    ("rime", "mist v3"): "mistv3",
+    ("together", "whisper large v3 (streaming)"): "whisper-large-v3",
+    ("together", "nvidia nemotron 3.5 asr"): "nemotron-3.5-asr-streaming-0.6b",
+    ("together", "nvidia parakeet tdt 0.6b v3"): "parakeet-tdt-0.6b-v3",
+    ("xai", "speech to text"): "grok-stt",
+    ("xai", "text to speech"): "grok-tts",
+    ("modulate", "multilingual speech-to-text"): "velma-2-stt-streaming",
+    ("modulate", "english fast speech-to-text"): "velma-2-stt-streaming-english-v2",
+    ("smallest", "lightning v3.1 pro"): "lightning_v3.1_pro",
+    ("smallest", "pulse realtime"): "pulse",
+    ("mistral", "voxtral mini transcribe realtime"): "voxtral-mini-transcribe-realtime-2602",
+}
+
+
+class ExtractedRate(BaseModel):
+    """One rate the LLM extracted, with its verbatim supporting quote."""
+
+    model: str
+    billing_unit: BillingUnit
+    rate_usd: float
+    plan: str | None = None
+    confidence: Literal["high", "medium", "low"]
+    quote: str
+
+
+class _Extraction(BaseModel):
+    rates: list[ExtractedRate]
+
+
+class Change(BaseModel):
+    """Outcome of diffing one extracted rate against the effective rate."""
+
+    provider: str
+    model: str
+    benchmark: Benchmark | None = None
+    billing_unit: BillingUnit
+    old_rate: Decimal | None = None
+    new_rate: Decimal
+    delta_pct: float | None = None
+    action: Literal["noop", "auto_applied", "review", "unmatched"]
+    reason: str = ""
+    confidence: str = ""
+    quote: str = ""
+    snapshot_sha: str = ""
+    source_url: str = ""
+
+
+_EXTRACTION_PROMPT = """You extract published API list prices from a pricing page.
+
+Rules — follow them exactly:
+- Extract ONLY rates literally stated on the page. NEVER infer, estimate, or \
+compute a rate that is not written there (converting a stated per-1k rate to \
+per-1M by x1000 is allowed and must be noted in the quote).
+- For each rate include `quote`: the verbatim page text stating it.
+- billing_unit is the provider's native unit. Token-billed models produce two \
+entries (input and output).
+- When a promotional price shows a struck-through regular price, extract the \
+current charged (promotional) price.
+- confidence: "high" only when the model name and rate are unambiguous on the \
+page; "medium" when the mapping needs interpretation; "low" otherwise.
+- Speech/audio models only (STT, TTS, speech-to-speech); skip chat/LLM rates.
+
+Provider: {provider}
+Hints: {hints}
+"""
+
+
+async def _fetch_page(url: str) -> str:
+    async with httpx.AsyncClient(
+        timeout=_FETCH_TIMEOUT_S, headers={"User-Agent": _USER_AGENT}, follow_redirects=True
+    ) as client:
+        response = await client.get(url)
+        response.raise_for_status()
+        return response.text
+
+
+async def _store_snapshot(
+    pool: AsyncConnectionPool[psycopg.AsyncConnection[psycopg.rows.DictRow]],
+    provider: str,
+    url: str,
+    text: str,
+) -> tuple[str, bool]:
+    """Persist the page (gzipped) unless its hash matches the latest snapshot.
+
+    Returns ``(sha256, changed)`` — *changed* is False when the page is
+    byte-identical to the previous fetch.
+    """
+    sha = hashlib.sha256(text.encode()).hexdigest()
+    async with pool.connection() as conn:
+        async with conn.cursor() as cur:
+            await cur.execute(
+                "SELECT sha256 FROM benchmarks_v2.pricing_snapshots"
+                " WHERE provider = %s ORDER BY fetched_at DESC LIMIT 1",
+                (provider,),
+            )
+            row = await cur.fetchone()
+            if row is not None and row["sha256"] == sha:
+                await conn.commit()
+                return sha, False
+            await cur.execute(
+                "INSERT INTO benchmarks_v2.pricing_snapshots (provider, url, sha256, content_gz)"
+                " VALUES (%s, %s, %s, %s)",
+                (provider, url, sha, gzip.compress(text.encode())),
+            )
+        await conn.commit()
+    return sha, row is not None  # first-ever snapshot is not a "change"
+
+
+async def _extract_rates(
+    settings: Settings, provider: str, page_text: str, source: PricingSource
+) -> list[ExtractedRate]:
+    """LLM extraction with a strict JSON schema; quotes are mandatory."""
+    import openai
+
+    if settings.openai_api_key is None:
+        raise RuntimeError("openai_api_key is required for price extraction")
+    client = openai.AsyncOpenAI(api_key=settings.openai_api_key.get_secret_value())
+    completion = await client.chat.completions.parse(
+        model=settings.pricing_extraction_model,
+        messages=[
+            {
+                "role": "system",
+                "content": _EXTRACTION_PROMPT.format(
+                    provider=provider, hints=source.parse_hints or "none"
+                ),
+            },
+            {"role": "user", "content": page_text[:_PAGE_TEXT_LIMIT]},
+        ],
+        response_format=_Extraction,
+    )
+    parsed = completion.choices[0].message.parsed
+    return parsed.rates if parsed is not None else []
+
+
+def _match_model(provider: str, extracted_name: str) -> tuple[str, Benchmark] | None:
+    """Extracted page name → (registry model id, benchmark), or None.
+
+    Exact id match first, then the alias map. A name matching a model id that
+    the provider registers under more than one benchmark is ambiguous and
+    treated as unmatched.
+    """
+    name = extracted_name.strip()
+    model_id = MODEL_ALIASES.get((provider, name.lower()), name)
+    entries = [m for m in MODEL_REGISTRY if m.provider == provider and m.model == model_id]
+    benchmarks = {m.benchmark for m in entries}
+    if len(benchmarks) != 1:
+        return None
+    return model_id, next(iter(benchmarks))
+
+
+async def _litellm_prices() -> dict[str, Any]:
+    """LiteLLM's community price file, or {} when unreachable (never fatal)."""
+    try:
+        async with httpx.AsyncClient(timeout=_FETCH_TIMEOUT_S) as client:
+            response = await client.get(_LITELLM_URL)
+            response.raise_for_status()
+            data: dict[str, Any] = response.json()
+            return data
+    except Exception:
+        logger.warning("litellm_fetch_failed", exc_info=True)
+        return {}
+
+
+def _cross_check(
+    provider: str,
+    model: str,
+    unit: BillingUnit,
+    rate: Decimal,
+    litellm: dict[str, Any],
+) -> Literal["agree", "disagree", "unavailable"]:
+    """Second-witness check against LiteLLM entries, where one exists.
+
+    LiteLLM keys per-second audio as ``input_cost_per_second`` and token rates
+    as ``*_cost_per_token``; entries are keyed ``model`` or ``provider/model``.
+    """
+    entry = litellm.get(f"{provider}/{model}") or litellm.get(model)
+    if not isinstance(entry, dict):
+        return "unavailable"
+    ours_per_second: Decimal | None = None
+    if unit is BillingUnit.PER_SECOND:
+        ours_per_second = rate
+    elif unit is BillingUnit.PER_MINUTE:
+        ours_per_second = rate / 60
+    elif unit is BillingUnit.PER_HOUR:
+        ours_per_second = rate / 3600
+    theirs: Any = None
+    if ours_per_second is not None:
+        theirs = entry.get("input_cost_per_second")
+        ours: Decimal | None = ours_per_second
+    elif unit is BillingUnit.PER_1M_TOKENS_INPUT:
+        theirs = entry.get("input_cost_per_token")
+        ours = rate / 1_000_000
+    elif unit is BillingUnit.PER_1M_TOKENS_OUTPUT:
+        theirs = entry.get("output_cost_per_token")
+        ours = rate / 1_000_000
+    else:
+        return "unavailable"
+    if theirs is None:
+        return "unavailable"
+    try:
+        theirs_dec = Decimal(str(theirs))
+    except ArithmeticError:
+        return "unavailable"
+    if theirs_dec == 0:
+        return "unavailable"
+    delta = abs(ours - theirs_dec) / theirs_dec * 100
+    return "agree" if delta <= Decimal("5") else "disagree"
+
+
+def _delta_pct(old: Decimal, new: Decimal) -> float:
+    if old == 0:
+        return float("inf") if new != 0 else 0.0
+    return float(abs(new - old) / old * 100)
+
+
+async def _diff_and_gate(
+    store: PricingStore,
+    extracted: ExtractedRate,
+    *,
+    provider: str,
+    model: str,
+    benchmark: Benchmark,
+    source_url: str,
+    snapshot_sha: str,
+    litellm: dict[str, Any],
+    dry_run: bool,
+) -> Change:
+    new_rate = Decimal(str(extracted.rate_usd))
+    effective = [
+        r
+        for r in await store.get_effective_rates(provider, model, datetime.now(tz=UTC))
+        if r.benchmark is benchmark and r.billing_unit is extracted.billing_unit
+    ]
+    current = effective[0] if effective else None
+    change = Change(
+        provider=provider,
+        model=model,
+        benchmark=benchmark,
+        billing_unit=extracted.billing_unit,
+        old_rate=current.rate_usd if current else None,
+        new_rate=new_rate,
+        confidence=extracted.confidence,
+        quote=extracted.quote,
+        snapshot_sha=snapshot_sha,
+        source_url=source_url,
+        action="noop",
+    )
+    if current is not None and current.rate_usd == new_rate:
+        return change
+
+    delta = _delta_pct(current.rate_usd, new_rate) if current is not None else None
+    change.delta_pct = delta
+    witness = _cross_check(provider, model, extracted.billing_unit, new_rate, litellm)
+
+    if current is None:
+        change.action = "review"
+        change.reason = "no current effective rate — new rates always go to review"
+        return change
+    if delta is not None and delta > _AUTO_APPLY_MAX_DELTA_PCT:
+        change.action = "review"
+        change.reason = f"delta {delta:.1f}% exceeds {_AUTO_APPLY_MAX_DELTA_PCT:.0f}%"
+        return change
+    if extracted.confidence != "high":
+        change.action = "review"
+        change.reason = f"extraction confidence {extracted.confidence!r}"
+        return change
+    if witness == "disagree":
+        change.action = "review"
+        change.reason = "LiteLLM cross-check disagrees"
+        return change
+
+    change.action = "auto_applied"
+    change.reason = f"delta {delta:.1f}%, high confidence, cross-check {witness}"
+    if not dry_run:
+        await store.upsert_rate(
+            provider=provider,
+            model=model,
+            benchmark=benchmark,
+            billing_unit=extracted.billing_unit,
+            rate_usd=new_rate,
+            source_url=source_url,
+            as_of=date.today(),  # noqa: DTZ011 — as_of is a calendar date
+            evidence=f"snapshot sha256={snapshot_sha}; quote: {extracted.quote}",
+            plan_assumption=extracted.plan,
+            updated_by="bot",
+        )
+    return change
+
+
+async def _stale_rates(store: PricingStore) -> list[str]:
+    """Active models whose effective rate was last verified > 45 days ago."""
+    await store.load_cache()
+    today = date.today()  # noqa: DTZ011 — calendar-date comparison
+    stale: list[str] = []
+    for m in MODEL_REGISTRY:
+        if m.status not in (ModelStatus.ACTIVE, ModelStatus.EARLY_ACCESS):
+            continue
+        for rate in store.effective_rates_cached(m.provider, m.model):
+            if rate.benchmark is m.benchmark and (today - rate.as_of).days > _STALE_AFTER_DAYS:
+                stale.append(
+                    f"{m.benchmark}:{m.provider}/{m.model} [{rate.billing_unit}] "
+                    f"as_of {rate.as_of} ({(today - rate.as_of).days}d old)"
+                )
+    return stale
+
+
+async def _open_review(settings: Settings, title: str, body: str) -> None:
+    """File one review item: Linear when configured, else Slack, else a log line."""
+    if settings.linear_api_key is not None:
+        query = """
+        mutation IssueCreate($teamId: String!, $title: String!, $description: String!) {
+          issueCreate(input: {teamId: $teamId, title: $title, description: $description}) {
+            success
+          }
+        }
+        """
+        async with httpx.AsyncClient(timeout=_FETCH_TIMEOUT_S) as client:
+            teams = await client.post(
+                "https://api.linear.app/graphql",
+                headers={"Authorization": settings.linear_api_key.get_secret_value()},
+                json={
+                    "query": (
+                        "query Teams($name: String!) "
+                        "{ teams(filter: {name: {eq: $name}}) { nodes { id } } }"
+                    ),
+                    "variables": {"name": settings.linear_team_name},
+                },
+            )
+            teams.raise_for_status()
+            nodes = teams.json()["data"]["teams"]["nodes"]
+            if not nodes:
+                raise RuntimeError(f"Linear team {settings.linear_team_name!r} not found")
+            issue = await client.post(
+                "https://api.linear.app/graphql",
+                headers={"Authorization": settings.linear_api_key.get_secret_value()},
+                json={
+                    "query": query,
+                    "variables": {"teamId": nodes[0]["id"], "title": title, "description": body},
+                },
+            )
+            issue.raise_for_status()
+        return
+    if settings.pricing_review_slack_webhook is not None:
+        async with httpx.AsyncClient(timeout=_FETCH_TIMEOUT_S) as client:
+            response = await client.post(
+                settings.pricing_review_slack_webhook.get_secret_value(),
+                json={"text": f"*{title}*\n{body}"},
+            )
+            response.raise_for_status()
+        return
+    logger.warning("pricing_review_item", title=title, body=body)
+
+
+def _review_body(change: Change) -> str:
+    return (
+        f"provider/model: {change.provider}/{change.model} ({change.benchmark})\n"
+        f"billing unit: {change.billing_unit}\n"
+        f"current rate: {change.old_rate}\n"
+        f"candidate rate: {change.new_rate}\n"
+        f"delta: {f'{change.delta_pct:.1f}%' if change.delta_pct is not None else 'n/a (new)'}\n"
+        f"reason: {change.reason}\n"
+        f"confidence: {change.confidence}\n"
+        f"quote: {change.quote}\n"
+        f"snapshot: sha256={change.snapshot_sha}\n"
+        f"source: {change.source_url}"
+    )
+
+
+async def collect_provider(
+    settings: Settings,
+    pool: AsyncConnectionPool[psycopg.AsyncConnection[psycopg.rows.DictRow]],
+    store: PricingStore,
+    provider: str,
+    source: PricingSource,
+    litellm: dict[str, Any],
+    *,
+    dry_run: bool,
+) -> list[Change]:
+    """Fetch → snapshot → extract → match → diff one provider. Raises on failure."""
+    page = await _fetch_page(source.url)
+    sha, _ = await _store_snapshot(pool, provider, source.url, page)
+    extracted = await _extract_rates(settings, provider, page, source)
+
+    changes: list[Change] = []
+    for rate in extracted:
+        matched = _match_model(provider, rate.model)
+        if matched is None:
+            logger.info("pricing_unmatched_model", provider=provider, extracted=rate.model)
+            changes.append(
+                Change(
+                    provider=provider,
+                    model=rate.model,
+                    billing_unit=rate.billing_unit,
+                    new_rate=Decimal(str(rate.rate_usd)),
+                    action="unmatched",
+                    reason="no registry model matches the extracted name",
+                    confidence=rate.confidence,
+                    quote=rate.quote,
+                    snapshot_sha=sha,
+                    source_url=source.url,
+                )
+            )
+            continue
+        model_id, benchmark = matched
+        changes.append(
+            await _diff_and_gate(
+                store,
+                rate,
+                provider=provider,
+                model=model_id,
+                benchmark=benchmark,
+                source_url=source.url,
+                snapshot_sha=sha,
+                litellm=litellm,
+                dry_run=dry_run,
+            )
+        )
+    return changes
+
+
+async def run_update_prices(
+    settings: Settings,
+    pool: AsyncConnectionPool[psycopg.AsyncConnection[psycopg.rows.DictRow]],
+    *,
+    providers: list[str] | None = None,
+    dry_run: bool = False,
+) -> dict[str, Any]:
+    """Run the collector across providers; one failure never aborts the rest."""
+    store = PricingStore(pool)
+    litellm = await _litellm_prices()
+    selected = {
+        name: source
+        for name, source in PRICING_SOURCES.items()
+        if source is not None and (providers is None or name in providers)
+    }
+    skipped = sorted(
+        name
+        for name, source in PRICING_SOURCES.items()
+        if source is None and (providers is None or name in providers)
+    )
+
+    all_changes: list[Change] = []
+    failed: list[str] = []
+    for name, source in sorted(selected.items()):
+        try:
+            all_changes.extend(
+                await collect_provider(
+                    settings, pool, store, name, source, litellm, dry_run=dry_run
+                )
+            )
+        except Exception:
+            logger.warning("pricing_provider_failed", provider=name, exc_info=True)
+            failed.append(name)
+
+    reviews = [c for c in all_changes if c.action == "review"]
+    if not dry_run:
+        for change in reviews:
+            try:
+                await _open_review(
+                    settings,
+                    f"Price change review: {change.provider}/{change.model}",
+                    _review_body(change),
+                )
+            except Exception:
+                logger.warning(
+                    "pricing_review_open_failed",
+                    provider=change.provider,
+                    model=change.model,
+                    exc_info=True,
+                )
+
+    stale = await _stale_rates(store)
+    alerts: list[str] = []
+    if failed:
+        alerts.append("page fetch/extract failed: " + ", ".join(failed))
+    if stale:
+        alerts.append("stale rates (>45d): " + "; ".join(stale))
+    if alerts and not dry_run:
+        try:
+            await _open_review(settings, "Pricing collector alerts", "\n".join(alerts))
+        except Exception:
+            logger.warning("pricing_alert_open_failed", exc_info=True)
+
+    return {
+        "changes": [json.loads(c.model_dump_json()) for c in all_changes],
+        "counts": {
+            action: sum(1 for c in all_changes if c.action == action)
+            for action in ("noop", "auto_applied", "review", "unmatched")
+        },
+        "skipped_no_source": skipped,
+        "failed_providers": failed,
+        "stale_rates": stale,
+        "dry_run": dry_run,
+    }

--- a/runner/src/coval_bench/pricing/collector.py
+++ b/runner/src/coval_bench/pricing/collector.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 import gzip
 import hashlib
 import json
+import re
 from datetime import UTC, date, datetime
 from decimal import Decimal
 from typing import TYPE_CHECKING, Any, Literal
@@ -102,6 +103,7 @@ class ExtractedRate(BaseModel):
     plan: str | None = None
     confidence: Literal["high", "medium", "low"]
     quote: str
+    note: str | None = None
 
 
 class _Extraction(BaseModel):
@@ -131,8 +133,10 @@ _EXTRACTION_PROMPT = """You extract published API list prices from a pricing pag
 Rules — follow them exactly:
 - Extract ONLY rates literally stated on the page. NEVER infer, estimate, or \
 compute a rate that is not written there (converting a stated per-1k rate to \
-per-1M by x1000 is allowed and must be noted in the quote).
-- For each rate include `quote`: the verbatim page text stating it.
+per-1M by x1000 is allowed and must be explained in `note`).
+- For each rate include `quote`: the EXACT verbatim page text stating it, \
+copied character-for-character — no paraphrase, no added notes. Auto-apply is \
+gated on this text being found in the page.
 - billing_unit is the provider's native unit. Token-billed models produce two \
 entries (input and output).
 - When a promotional price shows a struck-through regular price, extract the \
@@ -160,11 +164,14 @@ async def _store_snapshot(
     provider: str,
     url: str,
     text: str,
+    *,
+    dry_run: bool = False,
 ) -> tuple[str, bool]:
     """Persist the page (gzipped) unless its hash matches the latest snapshot.
 
     Returns ``(sha256, changed)`` — *changed* is False when the page is
-    byte-identical to the previous fetch.
+    byte-identical to the previous fetch. ``dry_run`` computes the hash and
+    compares, but never inserts.
     """
     sha = hashlib.sha256(text.encode()).hexdigest()
     async with pool.connection() as conn:
@@ -175,9 +182,9 @@ async def _store_snapshot(
                 (provider,),
             )
             row = await cur.fetchone()
-            if row is not None and row["sha256"] == sha:
+            if (row is not None and row["sha256"] == sha) or dry_run:
                 await conn.commit()
-                return sha, False
+                return sha, row is not None and row["sha256"] != sha
             await cur.execute(
                 "INSERT INTO benchmarks_v2.pricing_snapshots (provider, url, sha256, content_gz)"
                 " VALUES (%s, %s, %s, %s)",
@@ -288,6 +295,23 @@ def _cross_check(
     return "agree" if delta <= Decimal("5") else "disagree"
 
 
+_TAG_RE = re.compile(r"<[^>]+>")
+_WS_RE = re.compile(r"\s+")
+
+
+def _normalize_page_text(text: str) -> str:
+    return _WS_RE.sub(" ", _TAG_RE.sub(" ", text)).casefold().strip()
+
+
+def _quote_in_page(quote: str, page: str) -> bool:
+    """The auto-apply integrity gate: the extractor's verbatim quote must
+    actually appear in the fetched page (tag-stripped, whitespace-collapsed),
+    so a hallucinated or prompt-injected rate can never self-attest its way
+    into the pricing table."""
+    normalized_quote = _normalize_page_text(quote)
+    return bool(normalized_quote) and normalized_quote in _normalize_page_text(page)
+
+
 def _delta_pct(old: Decimal, new: Decimal) -> float:
     if old == 0:
         return float("inf") if new != 0 else 0.0
@@ -303,6 +327,7 @@ async def _diff_and_gate(
     benchmark: Benchmark,
     source_url: str,
     snapshot_sha: str,
+    page: str,
     litellm: dict[str, Any],
     dry_run: bool,
 ) -> Change:
@@ -327,6 +352,10 @@ async def _diff_and_gate(
         action="noop",
     )
     if current is not None and current.rate_usd == new_rate:
+        # Re-verified unchanged: stamp today's as_of so the rate never trips
+        # the staleness alarm right after a successful check.
+        if not dry_run and current.id is not None and current.as_of < date.today():  # noqa: DTZ011
+            await store.refresh_as_of(current.id, date.today())  # noqa: DTZ011
         return change
 
     delta = _delta_pct(current.rate_usd, new_rate) if current is not None else None
@@ -348,6 +377,10 @@ async def _diff_and_gate(
     if witness == "disagree":
         change.action = "review"
         change.reason = "LiteLLM cross-check disagrees"
+        return change
+    if not _quote_in_page(extracted.quote, page):
+        change.action = "review"
+        change.reason = "extractor's quote not found verbatim in the fetched page"
         return change
 
     change.action = "auto_applied"
@@ -459,7 +492,7 @@ async def collect_provider(
 ) -> list[Change]:
     """Fetch → snapshot → extract → match → diff one provider. Raises on failure."""
     page = await _fetch_page(source.url)
-    sha, _ = await _store_snapshot(pool, provider, source.url, page)
+    sha, _ = await _store_snapshot(pool, provider, source.url, page, dry_run=dry_run)
     extracted = await _extract_rates(settings, provider, page, source)
 
     changes: list[Change] = []
@@ -492,6 +525,7 @@ async def collect_provider(
                 benchmark=benchmark,
                 source_url=source.url,
                 snapshot_sha=sha,
+                page=page,
                 litellm=litellm,
                 dry_run=dry_run,
             )
@@ -554,6 +588,14 @@ async def run_update_prices(
     alerts: list[str] = []
     if failed:
         alerts.append("page fetch/extract failed: " + ", ".join(failed))
+    unmatched = [c for c in all_changes if c.action == "unmatched"]
+    if unmatched:
+        alerts.append(
+            "unmatched page rates (possible new/renamed models, never auto-written): "
+            + "; ".join(
+                f"{c.provider}: {c.model!r} @ {c.new_rate} [{c.billing_unit}]" for c in unmatched
+            )
+        )
     if stale:
         alerts.append("stale rates (>45d): " + "; ".join(stale))
     if alerts and not dry_run:

--- a/runner/src/coval_bench/registries/pricing_sources.py
+++ b/runner/src/coval_bench/registries/pricing_sources.py
@@ -1,0 +1,187 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+"""Registry of public pricing pages the price collector scrapes.
+
+One entry per provider in ``registries/models.py``. ``None`` documents that
+the provider has no public pricing page (dedicated infra, enterprise/contact
+sales, console-only, or unreleased) — the collector skips it and coverage is
+enforced by ``scripts/check_pricing_coverage.py`` instead. ``parse_hints``
+feed the LLM extraction prompt: how the page states rates, which sections
+matter, known traps.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class PricingSource(BaseModel, frozen=True):
+    """Where and how a provider publishes its list prices."""
+
+    url: str
+    notes: str = ""
+    parse_hints: str = ""
+
+
+PRICING_SOURCES: dict[str, PricingSource | None] = {
+    "assemblyai": PricingSource(
+        url="https://www.assemblyai.com/pricing",
+        parse_hints=(
+            "Streaming STT rates are per hour and billed on WebSocket session "
+            "duration; Universal-Streaming and Universal-3.5 Pro Realtime rows."
+        ),
+    ),
+    # Console-only pricing on international Model Studio; docs list models but no rates.
+    "alibaba": None,
+    "azure": PricingSource(
+        url="https://azure.microsoft.com/en-us/pricing/details/cognitive-services/speech-services/",
+        parse_hints="Speech service pay-as-you-go table; realtime STT per audio hour.",
+    ),
+    # Dedicated inference we host ourselves — spend is instance-hours, not list rates.
+    "baseten": None,
+    "cartesia": PricingSource(
+        url="https://cartesia.ai/pricing",
+        notes="Credit plans only; effective rates assume the Startup plan.",
+        parse_hints=(
+            "Plans are credit-based: TTS ~1 credit/char, STT 3 credits/sec. Extract "
+            "plan price + included credits, and any stated per-unit equivalents."
+        ),
+    ),
+    # Enterprise/contact-sales; only a free trial is public.
+    "deepdub": None,
+    "deepgram": PricingSource(
+        url="https://deepgram.com/pricing",
+        parse_hints=(
+            "Streaming STT per-minute rates (promo prices may show struck-through "
+            "regular rates — extract the current charged rate); Nova-2 legacy rate "
+            "lives in the FAQ; Aura-2 TTS is per 1k characters."
+        ),
+    ),
+    "elevenlabs": PricingSource(
+        url="https://elevenlabs.io/pricing/api",
+        parse_hints=(
+            "API pricing page billed in USD (not credits): TTS per 1k characters by "
+            "model family (Flash/Turbo vs Multilingual/v3), Scribe STT per hour."
+        ),
+    ),
+    "fishaudio": PricingSource(
+        url="https://docs.fish.audio/developer-guide/models-pricing/pricing-and-rate-limits",
+        parse_hints="Per-model rates in USD per 1M UTF-8 bytes.",
+    ),
+    # Early access; no published pricing.
+    "fluxions": None,
+    "gladia": PricingSource(
+        url="https://www.gladia.io/pricing",
+        parse_hints="Starter PAYG real-time rate per hour; no per-model split.",
+    ),
+    "google": PricingSource(
+        url="https://cloud.google.com/speech-to-text/pricing",
+        notes="STT only; TTS rates live on cloud.google.com/text-to-speech/pricing.",
+        parse_hints=(
+            "Speech-to-Text V2 Recognition table: Standard tier per-minute rate "
+            "(chirp models bill as Standard V2); first 500k min/month tier."
+        ),
+    ),
+    "gradium": PricingSource(
+        url="https://gradium.ai/pricing",
+        notes="Credit plans only; effective rates carry plan assumptions.",
+        parse_hints="Credits per second (STT) / per character (TTS) plus plan credit quotas.",
+    ),
+    "groq": PricingSource(
+        url="https://groq.com/pricing",
+        parse_hints="Audio models table; STT per hour of audio, TTS per 1M characters.",
+    ),
+    "hume": PricingSource(
+        url="https://www.hume.ai/pricing",
+        notes="Subscription plans; effective rates assume the Pro plan.",
+        parse_hints="Plan price and included characters for Octave TTS.",
+    ),
+    "inworld": PricingSource(
+        url="https://inworld.ai/pricing",
+        parse_hints="On-demand per-1M-characters rates per TTS tier; STT per hour.",
+    ),
+    "lmnt": PricingSource(
+        url="https://www.lmnt.com/pricing",
+        notes="Plan-level pricing, no per-model rates.",
+        parse_hints="Plan price, included characters, and per-1k overage rate.",
+    ),
+    "minimax": PricingSource(
+        url="https://platform.minimax.io/docs/guides/pricing-paygo",
+        parse_hints="Pay-as-you-go T2A table, USD per 1M characters per model.",
+    ),
+    "mistral": PricingSource(
+        url="https://mistral.ai/pricing",
+        notes=(
+            "Voxtral transcription rates have historically lived in announcement "
+            "posts rather than the main pricing page."
+        ),
+        parse_hints="Audio/transcription section; per-minute rates for Voxtral models.",
+    ),
+    "modulate": PricingSource(
+        url="https://www.modulate.ai/api-pricing",
+        parse_hints=("Per-hour streaming rates: Multilingual STT vs English Fast STT rows."),
+    ),
+    "murf": PricingSource(
+        url="https://help.murf.ai/murf-api-pay-as-you-go",
+        parse_hints="PAYG per-1k-character rates by model (Falcon vs Gen 2).",
+    ),
+    "openai": PricingSource(
+        url="https://developers.openai.com/api/docs/pricing",
+        parse_hints=(
+            "Transcription table (audio-in/text-out token rates per 1M plus per-minute "
+            "estimates), TTS token rates, and the Realtime models table "
+            "(gpt-realtime-whisper is per minute; gpt-realtime bills audio tokens)."
+        ),
+    ),
+    "palabra": PricingSource(
+        url="https://www.palabra.ai/pricing",
+        parse_hints="PAYG TTS per 1k characters; S2S per minute.",
+    ),
+    "revai": PricingSource(
+        url="https://www.rev.ai/pricing",
+        parse_hints="Reverb per-hour rate; streaming bills at the same model rate.",
+    ),
+    "rime": PricingSource(
+        url="https://www.rime.ai/pricing",
+        notes="Arcana rate last seen on rime.ai/resources/introducing-new-pricing.",
+        parse_hints="Per-1k-character rates per model (Coda, Mist v3, Arcana).",
+    ),
+    "smallest": PricingSource(
+        url="https://smallest.ai/pricing/models",
+        parse_hints=(
+            "Per-model PAYG rates: TTS per 10k characters, STT per minute "
+            "(Pulse realtime vs batch)."
+        ),
+    ),
+    "soniox": PricingSource(
+        url="https://soniox.com/pricing",
+        parse_hints=(
+            "stt-rt per-hour rate (token billing underneath); realtime TTS input/output "
+            "token rates per 1M."
+        ),
+    ),
+    "speechify": PricingSource(
+        url="https://speechify.ai/pricing",
+        notes="Plan-level pricing, uniform across Simba models.",
+        parse_hints="Plan price, included characters, per-1M overage.",
+    ),
+    "speechmatics": PricingSource(
+        url="https://www.speechmatics.com/pricing",
+        notes="Table is client-side rendered from a CSV the page loads.",
+        parse_hints="Real-time Standard vs Enhanced per-hour rates (Pro plan column).",
+    ),
+    "together": PricingSource(
+        url="https://www.together.ai/pricing",
+        parse_hints=(
+            "'Price per audio minute' table; prefer streaming variants "
+            "(Whisper Large v3 Streaming, Nemotron ASR, Parakeet)."
+        ),
+    ),
+    "xai": PricingSource(
+        url="https://docs.x.ai/docs/models",
+        parse_hints=(
+            "Voice pricing table: STT per hour (REST vs streaming — use streaming), "
+            "TTS per 1M chars, grok-voice per minute of audio."
+        ),
+    ),
+}

--- a/runner/tests/pricing/conftest.py
+++ b/runner/tests/pricing/conftest.py
@@ -1,0 +1,10 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared fixtures for pricing-collector tests."""
+
+from pytest_postgresql.factories import postgresql_proc
+
+# Same convention as tests/unit: one embedded Postgres server for the package,
+# a clean per-test database per client fixture.
+pg_proc = postgresql_proc(port=None)

--- a/runner/tests/pricing/fixtures/deepgram-pricing.html
+++ b/runner/tests/pricing/fixtures/deepgram-pricing.html
@@ -1,0 +1,10 @@
+<html><body>
+<h1>Deepgram Pricing</h1>
+<table>
+  <tr><th>Model</th><th>Streaming</th></tr>
+  <tr><td>Nova-3 Monolingual</td><td>$0.0048/min <s>$0.0077/min</s></td></tr>
+  <tr><td>Flux English</td><td>$0.0065/min <s>$0.0077/min</s></td></tr>
+  <tr><td>Aura-2</td><td>$0.030/1k characters</td></tr>
+</table>
+<p>FAQ: These remain available at unchanged rates for existing deployments: Nova-2 streaming at $0.35/hour.</p>
+</body></html>

--- a/runner/tests/pricing/fixtures/elevenlabs-pricing.html
+++ b/runner/tests/pricing/fixtures/elevenlabs-pricing.html
@@ -1,0 +1,9 @@
+<html><body>
+<h1>ElevenLabs API Pricing</h1>
+<p>API usage is billed in US dollars, not credits.</p>
+<ul>
+  <li>Flash / Turbo Text to Speech — $0.05 per 1K characters</li>
+  <li>Multilingual v2 / v3 Text to Speech — $0.10 per 1K characters</li>
+  <li>Scribe v2 Realtime — $0.39 per hour</li>
+</ul>
+</body></html>

--- a/runner/tests/pricing/test_collector.py
+++ b/runner/tests/pricing/test_collector.py
@@ -94,13 +94,19 @@ async def _seed_nova3(store: PricingStore, rate: str = "0.0048") -> None:
     )
 
 
-def _extracted(rate: float, *, model: str = "Nova-3 Monolingual", confidence: str = "high") -> Any:
+def _extracted(
+    rate: float,
+    *,
+    model: str = "Nova-3 Monolingual",
+    confidence: str = "high",
+    quote: str | None = None,
+) -> Any:
     return ExtractedRate(
         model=model,
         billing_unit=BillingUnit.PER_MINUTE,
         rate_usd=rate,
         confidence=confidence,  # type: ignore[arg-type]
-        quote=f"Nova-3 Monolingual ${rate}/min",
+        quote=quote if quote is not None else f"Nova-3 Monolingual ${rate}/min",
     )
 
 
@@ -111,6 +117,7 @@ def _run_collector(
     seed_rate: str | None = "0.0048",
     dry_run: bool = False,
     fetch_side_effect: Any = None,
+    page: str | None = None,
 ) -> tuple[dict[str, Any], list[tuple[str, str]], PricingStore]:
     """Drive run_update_prices for deepgram only, LLM + fetch + reviews mocked."""
     reviews: list[tuple[str, str]] = []
@@ -129,7 +136,9 @@ def _run_collector(
                     "coval_bench.pricing.collector._fetch_page",
                     AsyncMock(
                         side_effect=fetch_side_effect,
-                        return_value=_fixture_page("deepgram-pricing.html"),
+                        return_value=page
+                        if page is not None
+                        else _fixture_page("deepgram-pricing.html"),
                     ),
                 ),
                 patch(
@@ -174,6 +183,15 @@ def test_noop_when_rate_unchanged(pg_conn: psycopg.Connection[Any]) -> None:
     _apply_migrations(pg_conn)
     summary, reviews, _ = _run_collector(pg_conn, [_extracted(0.0048)])
     assert summary["counts"] == {"noop": 1, "auto_applied": 0, "review": 0, "unmatched": 0}
+    pg_conn.autocommit = True
+    with pg_conn.cursor() as cur:
+        cur.execute(
+            "SELECT as_of FROM benchmarks_v2.model_pricing"
+            " WHERE provider = 'deepgram' AND superseded_at IS NULL"
+        )
+        row = cur.fetchone()
+    # A re-verified unchanged rate carries today's as_of, so it never goes stale.
+    assert row is not None and row[0] == date.today()
     assert reviews == []
     rows = _effective_nova3(pg_conn)
     assert len(rows) == 1  # nothing new written
@@ -181,7 +199,10 @@ def test_noop_when_rate_unchanged(pg_conn: psycopg.Connection[Any]) -> None:
 
 def test_small_delta_high_confidence_auto_applies(pg_conn: psycopg.Connection[Any]) -> None:
     _apply_migrations(pg_conn)
-    summary, reviews, _ = _run_collector(pg_conn, [_extracted(0.005)])  # +4.2%
+    page = _fixture_page("deepgram-pricing.html").replace("$0.0048/min", "$0.005/min")
+    summary, reviews, _ = _run_collector(
+        pg_conn, [_extracted(0.005, quote="Nova-3 Monolingual $0.005/min")], page=page
+    )  # +4.2%
     assert summary["counts"]["auto_applied"] == 1
     assert reviews == []
     rows = _effective_nova3(pg_conn)
@@ -224,7 +245,9 @@ def test_unmatched_model_logged_never_written(pg_conn: psycopg.Connection[Any]) 
     _apply_migrations(pg_conn)
     summary, reviews, _ = _run_collector(pg_conn, [_extracted(0.5, model="Totally Unknown Model")])
     assert summary["counts"]["unmatched"] == 1
-    assert reviews == []  # unmatched is a log line, not a review item
+    # Unmatched rates are never written, but they do reach the alert channel
+    # so a renamed/new page model can't rot unnoticed in the logs.
+    assert any("Totally Unknown Model" in body for _, body in reviews)
     assert len(_effective_nova3(pg_conn)) == 1
 
 
@@ -238,7 +261,13 @@ def test_fetch_failure_skips_provider_without_aborting(pg_conn: psycopg.Connecti
 
 def test_dry_run_writes_nothing(pg_conn: psycopg.Connection[Any]) -> None:
     _apply_migrations(pg_conn)
-    summary, reviews, _ = _run_collector(pg_conn, [_extracted(0.005)], dry_run=True)
+    page = _fixture_page("deepgram-pricing.html").replace("$0.0048/min", "$0.005/min")
+    summary, reviews, _ = _run_collector(
+        pg_conn,
+        [_extracted(0.005, quote="Nova-3 Monolingual $0.005/min")],
+        dry_run=True,
+        page=page,
+    )
     assert summary["counts"]["auto_applied"] == 1  # reported in the diff table
     assert reviews == []  # no review items filed on dry-run
     assert len(_effective_nova3(pg_conn)) == 1  # but nothing written
@@ -247,7 +276,7 @@ def test_dry_run_writes_nothing(pg_conn: psycopg.Connection[Any]) -> None:
     with pg_conn.cursor() as cur:
         cur.execute("SELECT count(*) FROM benchmarks_v2.pricing_snapshots")
         row = cur.fetchone()
-    assert row is not None and row[0] >= 0  # snapshot table exists either way
+    assert row is not None and row[0] == 0  # dry-run persists no snapshots either
 
 
 def test_snapshot_dedupes_on_hash(pg_conn: psycopg.Connection[Any]) -> None:
@@ -305,3 +334,15 @@ def test_match_model_exact_alias_and_ambiguous() -> None:
     assert _match_model("deepgram", "some-future-model") is None
     # gradium registers 'default' under STT and TTS — ambiguous, never guessed.
     assert _match_model("gradium", "default") is None
+
+
+def test_fabricated_quote_goes_to_review(pg_conn: psycopg.Connection[Any]) -> None:
+    """A small in-gate delta whose quote is not verbatim in the page never auto-applies."""
+    _apply_migrations(pg_conn)
+    summary, reviews, _ = _run_collector(
+        pg_conn, [_extracted(0.005, quote="Nova-3 Monolingual $0.005/min")]
+    )  # fetched page still says $0.0048 — the quote self-attests a rate the page doesn't show
+    assert summary["counts"]["auto_applied"] == 0
+    assert summary["counts"]["review"] == 1
+    assert any("quote not found" in body for _, body in reviews)
+    assert len(_effective_nova3(pg_conn)) == 1  # untouched

--- a/runner/tests/pricing/test_collector.py
+++ b/runner/tests/pricing/test_collector.py
@@ -1,0 +1,307 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Price-collector tests: fixture pages, mocked LLM, real Postgres gate checks."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, date, datetime, timedelta
+from decimal import Decimal
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import psycopg
+import psycopg.rows
+from alembic import command as alembic_command
+from alembic.config import Config as AlembicConfig
+from psycopg_pool import AsyncConnectionPool
+from pytest_postgresql.factories import postgresql
+
+from coval_bench.config import Settings
+from coval_bench.db.models import Benchmark, BillingUnit
+from coval_bench.db.pricing import PricingStore
+from coval_bench.pricing.collector import (
+    ExtractedRate,
+    _match_model,
+    _stale_rates,
+    _store_snapshot,
+    run_update_prices,
+)
+from coval_bench.registries.models import MODEL_REGISTRY
+from coval_bench.registries.pricing_sources import PRICING_SOURCES
+
+pg_conn = postgresql("pg_proc")
+
+_FIXTURES = Path(__file__).parent / "fixtures"
+_INI_PATH = Path(__file__).parents[2] / "alembic.ini"
+
+_SETTINGS = Settings(
+    database_url="postgresql://runner:password@localhost:5432/benchmarks",
+    dataset_bucket="test-bucket",
+    dataset_id="stt-v1",
+    runner_sha="test-sha",
+    posthog_disabled=True,
+)
+
+
+def _async_dsn(conn: psycopg.Connection[Any]) -> str:
+    info = conn.info
+    password = f":{info.password}" if info.password else ""
+    return (
+        f"postgresql://{info.user or ''}{password}@{info.host or 'localhost'}:"
+        f"{info.port or 5432}/{info.dbname or 'test'}"
+    )
+
+
+def _apply_migrations(conn: psycopg.Connection[Any]) -> None:
+    cfg = AlembicConfig(str(_INI_PATH))
+    cfg.set_main_option(
+        "sqlalchemy.url", _async_dsn(conn).replace("postgresql://", "postgresql+psycopg://")
+    )
+    alembic_command.upgrade(cfg, "head")
+
+
+async def _make_pool(
+    conn: psycopg.Connection[Any],
+) -> AsyncConnectionPool[psycopg.AsyncConnection[psycopg.rows.DictRow]]:
+    pool: AsyncConnectionPool[psycopg.AsyncConnection[psycopg.rows.DictRow]] = AsyncConnectionPool(
+        conninfo=_async_dsn(conn),
+        min_size=1,
+        max_size=4,
+        open=False,
+        kwargs={"autocommit": False, "row_factory": psycopg.rows.dict_row},
+    )
+    await pool.open()
+    return pool
+
+
+def _fixture_page(name: str) -> str:
+    return (_FIXTURES / name).read_text()
+
+
+async def _seed_nova3(store: PricingStore, rate: str = "0.0048") -> None:
+    await store.upsert_rate(
+        provider="deepgram",
+        model="nova-3",
+        benchmark=Benchmark.STT,
+        billing_unit=BillingUnit.PER_MINUTE,
+        rate_usd=Decimal(rate),
+        source_url="https://deepgram.com/pricing",
+        as_of=date(2026, 8, 6),
+        updated_by="human",
+    )
+
+
+def _extracted(rate: float, *, model: str = "Nova-3 Monolingual", confidence: str = "high") -> Any:
+    return ExtractedRate(
+        model=model,
+        billing_unit=BillingUnit.PER_MINUTE,
+        rate_usd=rate,
+        confidence=confidence,  # type: ignore[arg-type]
+        quote=f"Nova-3 Monolingual ${rate}/min",
+    )
+
+
+def _run_collector(
+    pg: psycopg.Connection[Any],
+    rates: list[Any],
+    *,
+    seed_rate: str | None = "0.0048",
+    dry_run: bool = False,
+    fetch_side_effect: Any = None,
+) -> tuple[dict[str, Any], list[tuple[str, str]], PricingStore]:
+    """Drive run_update_prices for deepgram only, LLM + fetch + reviews mocked."""
+    reviews: list[tuple[str, str]] = []
+
+    async def _capture_review(settings: Any, title: str, body: str) -> None:
+        reviews.append((title, body))
+
+    async def _run() -> tuple[dict[str, Any], PricingStore]:
+        pool = await _make_pool(pg)
+        try:
+            store = PricingStore(pool)
+            if seed_rate is not None:
+                await _seed_nova3(store, seed_rate)
+            with (
+                patch(
+                    "coval_bench.pricing.collector._fetch_page",
+                    AsyncMock(
+                        side_effect=fetch_side_effect,
+                        return_value=_fixture_page("deepgram-pricing.html"),
+                    ),
+                ),
+                patch(
+                    "coval_bench.pricing.collector._extract_rates",
+                    AsyncMock(return_value=rates),
+                ),
+                patch(
+                    "coval_bench.pricing.collector._litellm_prices",
+                    AsyncMock(return_value={}),
+                ),
+                patch("coval_bench.pricing.collector._open_review", _capture_review),
+            ):
+                summary = await run_update_prices(
+                    _SETTINGS, pool, providers=["deepgram"], dry_run=dry_run
+                )
+            return summary, store
+        finally:
+            await pool.close()
+
+    summary, store = asyncio.run(_run())
+    return summary, reviews, store
+
+
+def _effective_nova3(pg: psycopg.Connection[Any]) -> list[tuple[Any, ...]]:
+    pg.autocommit = True
+    with pg.cursor() as cur:
+        cur.execute(
+            "SELECT rate_usd, updated_by, superseded_at FROM benchmarks_v2.model_pricing "
+            "WHERE provider = 'deepgram' AND model = 'nova-3' ORDER BY id"
+        )
+        return cur.fetchall()
+
+
+def test_every_registry_provider_has_a_pricing_source_entry() -> None:
+    providers = {m.provider for m in MODEL_REGISTRY}
+    assert providers == set(PRICING_SOURCES), (
+        "PRICING_SOURCES must have an explicit entry (or None) for every provider"
+    )
+
+
+def test_noop_when_rate_unchanged(pg_conn: psycopg.Connection[Any]) -> None:
+    _apply_migrations(pg_conn)
+    summary, reviews, _ = _run_collector(pg_conn, [_extracted(0.0048)])
+    assert summary["counts"] == {"noop": 1, "auto_applied": 0, "review": 0, "unmatched": 0}
+    assert reviews == []
+    rows = _effective_nova3(pg_conn)
+    assert len(rows) == 1  # nothing new written
+
+
+def test_small_delta_high_confidence_auto_applies(pg_conn: psycopg.Connection[Any]) -> None:
+    _apply_migrations(pg_conn)
+    summary, reviews, _ = _run_collector(pg_conn, [_extracted(0.005)])  # +4.2%
+    assert summary["counts"]["auto_applied"] == 1
+    assert reviews == []
+    rows = _effective_nova3(pg_conn)
+    assert len(rows) == 2
+    old, new = rows
+    assert old[2] is not None  # superseded
+    assert new[1] == "bot"
+    assert new[0] == Decimal("0.00500000")
+
+
+def test_large_delta_goes_to_review_and_writes_nothing(pg_conn: psycopg.Connection[Any]) -> None:
+    _apply_migrations(pg_conn)
+    summary, reviews, _ = _run_collector(pg_conn, [_extracted(0.012)])  # +150%
+    assert summary["counts"]["review"] == 1
+    assert len(reviews) == 1
+    title, body = reviews[0]
+    assert title == "Price change review: deepgram/nova-3"
+    assert "0.012" in body and "0.0048" in body
+    assert len(_effective_nova3(pg_conn)) == 1  # untouched
+
+
+def test_low_confidence_goes_to_review(pg_conn: psycopg.Connection[Any]) -> None:
+    _apply_migrations(pg_conn)
+    summary, reviews, _ = _run_collector(pg_conn, [_extracted(0.005, confidence="medium")])
+    assert summary["counts"]["review"] == 1
+    assert len(reviews) == 1
+    assert len(_effective_nova3(pg_conn)) == 1
+
+
+def test_new_model_rate_goes_to_review(pg_conn: psycopg.Connection[Any]) -> None:
+    """A rate for a model with no current effective row is never auto-inserted."""
+    _apply_migrations(pg_conn)
+    summary, reviews, _ = _run_collector(pg_conn, [_extracted(0.0048)], seed_rate=None)
+    assert summary["counts"]["review"] == 1
+    assert len(reviews) == 1
+    assert _effective_nova3(pg_conn) == []
+
+
+def test_unmatched_model_logged_never_written(pg_conn: psycopg.Connection[Any]) -> None:
+    _apply_migrations(pg_conn)
+    summary, reviews, _ = _run_collector(pg_conn, [_extracted(0.5, model="Totally Unknown Model")])
+    assert summary["counts"]["unmatched"] == 1
+    assert reviews == []  # unmatched is a log line, not a review item
+    assert len(_effective_nova3(pg_conn)) == 1
+
+
+def test_fetch_failure_skips_provider_without_aborting(pg_conn: psycopg.Connection[Any]) -> None:
+    _apply_migrations(pg_conn)
+    summary, reviews, _ = _run_collector(pg_conn, [], fetch_side_effect=RuntimeError("boom"))
+    assert summary["failed_providers"] == ["deepgram"]
+    # The failure is surfaced through the alert channel.
+    assert any("fetch/extract failed" in body for _, body in reviews)
+
+
+def test_dry_run_writes_nothing(pg_conn: psycopg.Connection[Any]) -> None:
+    _apply_migrations(pg_conn)
+    summary, reviews, _ = _run_collector(pg_conn, [_extracted(0.005)], dry_run=True)
+    assert summary["counts"]["auto_applied"] == 1  # reported in the diff table
+    assert reviews == []  # no review items filed on dry-run
+    assert len(_effective_nova3(pg_conn)) == 1  # but nothing written
+
+    pg_conn.autocommit = True
+    with pg_conn.cursor() as cur:
+        cur.execute("SELECT count(*) FROM benchmarks_v2.pricing_snapshots")
+        row = cur.fetchone()
+    assert row is not None and row[0] >= 0  # snapshot table exists either way
+
+
+def test_snapshot_dedupes_on_hash(pg_conn: psycopg.Connection[Any]) -> None:
+    _apply_migrations(pg_conn)
+
+    async def _run() -> None:
+        pool = await _make_pool(pg_conn)
+        try:
+            sha1, changed1 = await _store_snapshot(pool, "deepgram", "https://x", "page-v1")
+            sha_same, changed_same = await _store_snapshot(pool, "deepgram", "https://x", "page-v1")
+            sha2, changed2 = await _store_snapshot(pool, "deepgram", "https://x", "page-v2")
+        finally:
+            await pool.close()
+        assert sha1 == sha_same and not changed1 and not changed_same
+        assert sha2 != sha1 and changed2
+
+    asyncio.run(_run())
+    pg_conn.autocommit = True
+    with pg_conn.cursor() as cur:
+        cur.execute("SELECT count(*) FROM benchmarks_v2.pricing_snapshots")
+        row = cur.fetchone()
+    assert row is not None and row[0] == 2
+
+
+def test_stale_rates_flagged(pg_conn: psycopg.Connection[Any]) -> None:
+    _apply_migrations(pg_conn)
+
+    async def _run() -> list[str]:
+        pool = await _make_pool(pg_conn)
+        try:
+            store = PricingStore(pool)
+            await store.upsert_rate(
+                provider="deepgram",
+                model="nova-3",
+                benchmark=Benchmark.STT,
+                billing_unit=BillingUnit.PER_MINUTE,
+                rate_usd=Decimal("0.0048"),
+                source_url="https://deepgram.com/pricing",
+                as_of=date.today() - timedelta(days=60),
+                updated_by="human",
+                effective_at=datetime.now(tz=UTC) - timedelta(days=60),
+            )
+            return await _stale_rates(store)
+        finally:
+            await pool.close()
+
+    stale = asyncio.run(_run())
+    assert len(stale) == 1
+    assert "deepgram/nova-3" in stale[0] and "60d old" in stale[0]
+
+
+def test_match_model_exact_alias_and_ambiguous() -> None:
+    assert _match_model("deepgram", "nova-3") == ("nova-3", Benchmark.STT)
+    assert _match_model("deepgram", "Nova-3 Monolingual") == ("nova-3", Benchmark.STT)
+    assert _match_model("deepgram", "some-future-model") is None
+    # gradium registers 'default' under STT and TTS — ambiguous, never guessed.
+    assert _match_model("gradium", "default") is None


### PR DESCRIPTION
Stacked on #461.

`coval-bench update-prices`: scrapes every provider page in the new `pricing_sources` registry (explicit None for the pageless), snapshots pages (gzipped, hash-deduped) so bot rows carry reviewable evidence, extracts rates via OpenAI structured outputs under an extract-only-never-infer prompt with mandatory verbatim quotes, matches to registry ids (exact + alias map; ambiguous ids never guessed), cross-checks LiteLLM as a second witness, and gates: identical → noop; ≤20% delta + high confidence + witness agrees-or-unavailable → auto-apply as `updated_by='bot'`; anything else (including brand-new rates) → exactly one review item via Linear or Slack webhook. Staleness sweep flags rates >45 days; one provider failing never aborts the rest; `--dry-run` prints the diff table and writes nothing. Weekly cadence mirrored as `PRICING_UPDATE_PERIOD_SECONDS` (cron lives in benchmark-infra).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds a weekly pricing collector that snapshots provider pages, uses structured LLM extraction, gates price changes against current rates and LiteLLM, writes approved rates, and sends uncertain or stale cases for review.

- Adds the `update-prices` CLI and collector workflow.
- Adds pricing-source and model-alias registries.
- Adds persisted, gzipped pricing-page snapshots.
- Adds configuration, documentation, fixtures, and integration tests for collection and review behavior.

<h3>Confidence Score: 0/5</h3>

The PR is not safe to merge until dry runs become read-only, successful unchanged checks refresh staleness, unverified LLM output cannot auto-apply pricing, and unmatched rates reach review.

The current workflow can write during dry runs, repeatedly flag freshly verified rates as stale, persist pricing based on self-attested extraction when the independent witness is absent, and omit newly discovered models from the review queue.

**Files Needing Attention:** runner/src/coval_bench/pricing/collector.py, runner/src/coval_bench/__main__.py, runner/tests/pricing/test_collector.py

<details open><summary><h3>Security Review</h3></summary>

The auto-apply path does not verify that the extractor's quote and rate are present in the fetched page, while an unavailable LiteLLM witness is accepted. Prompt-influenced page content can therefore satisfy the gate and alter effective pricing used for cost calculations. **How this was verified:** The parsed extraction flows directly to `upsert_rate`, and the only witness condition that blocks it is an explicit LiteLLM disagreement.
</details>

<sub>Reviews (1): Last reviewed commit: ["\[BENCH-635\] Price collector: cron job wi..."](https://github.com/coval-ai/benchmarks/commit/d0157d4d4e9395cbedff0f49c207946dc06d444c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50943174)</sub>

> Greptile also left **4 inline comments** on this PR.

**Context used:**

- Knowledge Base — [Runner Orchestration](https://app.greptile.com/coval/-/custom-context/knowledge-base/coval-ai/benchmarks/-/docs/runner-orchestration.md)
- Knowledge Base — [DB Layer](https://app.greptile.com/coval/-/custom-context/knowledge-base/coval-ai/benchmarks/-/docs/db-layer.md)

<!-- /greptile_comment -->