### PR TITLE
[BENCH-636] API: /v1/pricing — normalized prices, measured conversions, history (5/6)

### DIFF
--- a/docs/methodology.md
+++ b/docs/methodology.md
@@ -196,6 +196,40 @@ filtered out of analysis rather than silently inflating the published TTFA.
   Deferred — pool reuse achieves the same end result by construction, and the
   recorded interval is sufficient to detect and filter pool eviction.
 
+## Pricing normalization
+
+Model prices are published list prices, normalized the way Artificial
+Analysis does it: **USD per 1,000 minutes of audio** for STT and
+speech-to-speech, **USD per 1M characters** for TTS. Served by
+`GET /v1/pricing`.
+
+- **Rates are stored raw** in the provider's native billing unit in an
+  append-only table (`benchmarks_v2.model_pricing`); every rate carries the
+  provider's public pricing page (`source_url`), the date it was verified
+  (`as_of`), and evidence (page-snapshot hash / verbatim quote). A price
+  change supersedes the old row rather than replacing it, which is what makes
+  price history and historically-correct cost attribution possible.
+- **Duration- and character-billed rates** convert arithmetically
+  (`basis: "list_price"`): per-minute × 1,000, per-second × 60,000,
+  per-hour ÷ 60 × 1,000; per-1M-characters passes through.
+- **Token- and per-second-billed models** convert through conversion rates
+  measured from our own benchmark runs over the trailing 7 days
+  (`basis: "list_price_measured_conversion"`): tokens per minute of audio for
+  token-billed STT/S2S, characters per second of synthesized audio for
+  duration-billed TTS. This mirrors how AA converts token billing, but the
+  conversion is re-measured continuously rather than sampled once; the
+  response includes the measured rates, sample count, and window. A model
+  needs at least 50 sampled items in the window; below that (or when the
+  usage signal isn't reported) the model serves its native rates with
+  `normalized_usd: null` — nothing is estimated.
+- **Subscription/credit providers** (no pay-as-you-go list price) are
+  normalized under the assumption recorded in `plan_assumption`: the
+  lowest-upfront plan that realistically supports 1,000 minutes/month (STT)
+  or 1M characters/month (TTS) — the AA convention.
+- **Price history** normalizes each superseded rate at *today's* measured
+  conversion rates. Historical token prices at historical conversion rates
+  are not reconstructed; the approximation is noted on the response schema.
+
 ## Reproducing a result
 
 To reproduce a single `(provider, model, voice, metric)` cell:

--- a/runner/src/coval_bench/api/app.py
+++ b/runner/src/coval_bench/api/app.py
@@ -46,6 +46,7 @@ from coval_bench.api.routers import (
     arena,
     health,
     leaderboard,
+    pricing,
     providers,
     results,
     robots,
@@ -168,6 +169,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     app.include_router(aggregates.router, prefix="/v1")
     app.include_router(leaderboard.router, prefix="/v1")
     app.include_router(providers.router, prefix="/v1")
+    app.include_router(pricing.router, prefix="/v1")
     app.include_router(s2s_samples.router, prefix="/v1")
     app.include_router(arena.router, prefix="/v1")
 

--- a/runner/src/coval_bench/api/routers/pricing.py
+++ b/runner/src/coval_bench/api/routers/pricing.py
@@ -133,18 +133,18 @@ async def get_pricing(
 
         now = datetime.now(tz=UTC)
         entries: list[PricingEntry] = []
-        for (provider, model), model_rows in sorted(by_model.items()):
+        for (provider, model), all_rows in sorted(by_model.items()):
             if (provider, model) not in visible:
                 continue
-            effective = [
-                r
-                for r in model_rows
-                if r.effective_at <= now and (r.superseded_at is None or r.superseded_at > now)
-            ]
+            # A scheduled future-effective row is neither current nor history
+            # yet — it must not leak into either surface before its time.
+            model_rows = [r for r in all_rows if r.effective_at <= now]
+            effective = [r for r in model_rows if r.superseded_at is None or r.superseded_at > now]
             if not effective:
                 continue
             conversion = conversions.get((provider, model, bench))
             normalized = normalized_price(bench, effective, conversion)
+            latest = max(effective, key=lambda r: (r.as_of, r.id or 0))
             entries.append(
                 PricingEntry(
                     provider=provider,
@@ -170,8 +170,10 @@ async def get_pricing(
                         if conversion
                         else None
                     ),
-                    as_of=max(r.as_of for r in effective),
-                    source_url=effective[0].source_url,
+                    # Provenance from ONE row (the most recently verified),
+                    # never a max-date paired with another row's URL.
+                    as_of=latest.as_of,
+                    source_url=latest.source_url,
                     history=_history(bench, model_rows, conversion),
                 )
             )

--- a/runner/src/coval_bench/api/routers/pricing.py
+++ b/runner/src/coval_bench/api/routers/pricing.py
@@ -1,0 +1,184 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""GET /v1/pricing — normalized model prices with provenance and history.
+
+Normalization targets follow Artificial Analysis: USD per 1,000 minutes of
+audio (STT, S2S) and USD per 1M characters (TTS). Token- and per-second-billed
+models convert through conversion rates measured from our own runs (7-day
+window); a model whose conversion isn't measurable serves its native rates
+with ``normalized_usd: null`` — nothing is fabricated. History normalizes
+every effective period of the append-only ``model_pricing`` table at today's
+measured conversion (documented approximation on ``PriceHistoryPoint``).
+Models without an effective rate are simply absent.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections import defaultdict
+from datetime import UTC, datetime
+from typing import Any
+
+import psycopg.rows
+import structlog
+from cachetools import TTLCache
+from fastapi import APIRouter, Depends, Query, Request
+from psycopg_pool import AsyncConnectionPool
+
+from coval_bench.api.cache import get_or_fill
+from coval_bench.api.common import BenchmarkLiteral
+from coval_bench.api.deps import get_cache, get_cache_locks, get_pool
+from coval_bench.api.internal import hidden_early_access
+from coval_bench.api.ratelimit import limiter
+from coval_bench.api.schemas import (
+    ConversionOut,
+    NativeRateOut,
+    PriceHistoryPoint,
+    PricingEntry,
+    PricingResponse,
+)
+from coval_bench.db.models import Benchmark, PriceRow
+from coval_bench.pricing.normalize import Conversion, load_conversions, normalized_price
+from coval_bench.registries import MODEL_REGISTRY, ModelStatus
+
+logger = structlog.get_logger("coval_bench.api")
+
+router = APIRouter(tags=["pricing"])
+
+_UNIT_LABELS: dict[str, str] = {
+    "STT": "USD per 1,000 minutes",
+    "TTS": "USD per 1M characters",
+    "S2S": "USD per 1,000 minutes",
+}
+
+_PRICING_SQL = """
+    SELECT id, provider, model, benchmark, billing_unit, rate_usd, plan_assumption,
+           effective_at, superseded_at, source_url, as_of, evidence, updated_by, created_at
+    FROM benchmarks_v2.model_pricing
+    WHERE benchmark = %(benchmark)s
+    ORDER BY provider, model, effective_at
+"""
+
+
+def _history(
+    benchmark: Benchmark, rows: list[PriceRow], conversion: Conversion | None
+) -> list[PriceHistoryPoint]:
+    """One point per effective period, normalized at today's conversion.
+
+    Breakpoints are the distinct ``effective_at`` stamps; the rates in force at
+    each breakpoint are normalized together, so token models (two rows per
+    period) produce one combined point per period. By construction each period
+    ends where the next begins, so ``superseded_at`` chains contiguously even
+    when the units of a token pair changed at different times; only the final
+    period can be open-ended.
+    """
+    starts = sorted({r.effective_at for r in rows})
+    points: list[PriceHistoryPoint] = []
+    for i, start in enumerate(starts):
+        active = [
+            r
+            for r in rows
+            if r.effective_at <= start and (r.superseded_at is None or r.superseded_at > start)
+        ]
+        if not active:
+            continue
+        if i + 1 < len(starts):
+            superseded_at = starts[i + 1]
+        else:
+            ends = [r.superseded_at for r in active]
+            superseded_at = None if any(e is None for e in ends) else max(ends)  # type: ignore[type-var, arg-type]
+        normalized = normalized_price(benchmark, active, conversion)
+        points.append(
+            PriceHistoryPoint(
+                normalized_usd=normalized.value if normalized else None,
+                effective_at=start,
+                superseded_at=superseded_at,
+            )
+        )
+    return points
+
+
+@router.get("/pricing", response_model=PricingResponse)
+@limiter.limit("60/minute")
+async def get_pricing(
+    request: Request,  # required by slowapi
+    benchmark: BenchmarkLiteral = Query(...),
+    pool: AsyncConnectionPool[Any] = Depends(get_pool),
+    cache: TTLCache[Any, Any] = Depends(get_cache),
+    cache_locks: defaultdict[Any, asyncio.Lock] = Depends(get_cache_locks),
+    hidden: frozenset[tuple[str, str]] = Depends(hidden_early_access),
+) -> PricingResponse:
+    """Normalized list prices for every active priced model of one benchmark."""
+
+    async def fill() -> PricingResponse:
+        async with pool.connection() as conn:
+            conn.row_factory = psycopg.rows.dict_row
+            rows = await (await conn.execute(_PRICING_SQL, {"benchmark": benchmark})).fetchall()
+        conversions = await load_conversions(pool)
+
+        by_model: dict[tuple[str, str], list[PriceRow]] = defaultdict(list)
+        for r in rows:
+            price = PriceRow.model_validate(dict(r))
+            by_model[(price.provider, price.model)].append(price)
+
+        bench = Benchmark(benchmark)
+        visible = {
+            (m.provider, m.model)
+            for m in MODEL_REGISTRY
+            if m.benchmark is bench
+            and m.status in (ModelStatus.ACTIVE, ModelStatus.EARLY_ACCESS)
+            and (m.provider, m.model) not in hidden
+        }
+
+        now = datetime.now(tz=UTC)
+        entries: list[PricingEntry] = []
+        for (provider, model), model_rows in sorted(by_model.items()):
+            if (provider, model) not in visible:
+                continue
+            effective = [
+                r
+                for r in model_rows
+                if r.effective_at <= now and (r.superseded_at is None or r.superseded_at > now)
+            ]
+            if not effective:
+                continue
+            conversion = conversions.get((provider, model, bench))
+            normalized = normalized_price(bench, effective, conversion)
+            entries.append(
+                PricingEntry(
+                    provider=provider,
+                    model=model,
+                    normalized_usd=normalized.value if normalized else None,
+                    basis=normalized.basis if normalized else None,
+                    native_rates=[
+                        NativeRateOut(
+                            billing_unit=str(r.billing_unit),
+                            rate_usd=float(r.rate_usd),
+                            plan_assumption=r.plan_assumption,
+                        )
+                        for r in effective
+                    ],
+                    conversion=(
+                        ConversionOut(
+                            in_tokens_per_min=conversion.in_tokens_per_min,
+                            out_tokens_per_min=conversion.out_tokens_per_min,
+                            chars_per_sec=conversion.chars_per_sec,
+                            sample_count=conversion.sample_count,
+                            window=conversion.window,
+                        )
+                        if conversion
+                        else None
+                    ),
+                    as_of=max(r.as_of for r in effective),
+                    source_url=effective[0].source_url,
+                    history=_history(bench, model_rows, conversion),
+                )
+            )
+        return PricingResponse(
+            benchmark=benchmark, unit_label=_UNIT_LABELS[benchmark], entries=entries
+        )
+
+    cache_key = ("pricing", benchmark, tuple(sorted(hidden)))
+    response, _ = await get_or_fill(cache, cache_locks, cache_key, fill)
+    return response

--- a/runner/src/coval_bench/api/schemas.py
+++ b/runner/src/coval_bench/api/schemas.py
@@ -11,7 +11,7 @@ added later if needed.
 from __future__ import annotations
 
 import uuid
-from datetime import datetime
+from datetime import date, datetime
 from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field
@@ -220,6 +220,59 @@ class LeaderboardResponse(BaseModel):
     metric: Literal["WER", "TTFA", "TTFT", "TTFS", "V2V"]
     window: Literal["24h", "7d", "30d"]
     entries: list[LeaderboardEntry]
+
+
+class NativeRateOut(BaseModel):
+    """One published rate in the provider's native billing unit."""
+
+    billing_unit: str
+    rate_usd: float
+    plan_assumption: str | None = None
+
+
+class ConversionOut(BaseModel):
+    """Measured unit-conversion rates from our own runs (7-day window)."""
+
+    in_tokens_per_min: float | None = None
+    out_tokens_per_min: float | None = None
+    chars_per_sec: float | None = None
+    sample_count: int
+    window: str
+
+
+class PriceHistoryPoint(BaseModel):
+    """One effective-rate period, normalized with today's measured conversion.
+
+    Historical token rates are normalized at today's conversion rates (not the
+    conversion measured back then) — the approximation keeps history a pure
+    function of the append-only pricing table.
+    """
+
+    normalized_usd: float | None = None
+    effective_at: datetime
+    superseded_at: datetime | None = None
+
+
+class PricingEntry(BaseModel):
+    """Normalized display price + provenance for one model."""
+
+    provider: str
+    model: str
+    normalized_usd: float | None = None
+    basis: Literal["list_price", "list_price_measured_conversion"] | None = None
+    native_rates: list[NativeRateOut]
+    conversion: ConversionOut | None = None
+    as_of: date
+    source_url: str
+    history: list[PriceHistoryPoint]
+
+
+class PricingResponse(BaseModel):
+    """Response schema for GET /v1/pricing."""
+
+    benchmark: BenchmarkLiteral
+    unit_label: Literal["USD per 1,000 minutes", "USD per 1M characters"]
+    entries: list[PricingEntry]
 
 
 class S2SSampleTurnOut(BaseModel):

--- a/runner/src/coval_bench/pricing/normalize.py
+++ b/runner/src/coval_bench/pricing/normalize.py
@@ -40,14 +40,42 @@ _SECONDS_PER_UNIT: dict[BillingUnit, float] = {
 # One anchor metric per benchmark (AudioToFinal / TTFA / V2V): exactly one row
 # per item carries the item's usage quantities, so summing over anchors never
 # double-counts the usage columns duplicated across an item's metric rows.
+# Each ratio is computed strictly over rows where BOTH its numerator and
+# denominator are present (FILTER pairs), and each carries its own sample
+# count — COUNT(*) over the anchor rows would overstate the population when
+# providers report usage on only some rows, biasing the published conversion.
 _CONVERSIONS_SQL = """
     SELECT provider, model, benchmark,
-           SUM(input_tokens)::float8    AS in_tokens,
-           SUM(output_tokens)::float8   AS out_tokens,
-           SUM(audio_seconds_in)::float8  AS seconds_in,
-           SUM(audio_seconds_out)::float8 AS seconds_out,
-           SUM(characters_in)::float8   AS chars_in,
-           COUNT(*)::int                AS sample_count
+           COUNT(*) FILTER (WHERE input_tokens IS NOT NULL
+                              AND audio_seconds_in > 0)::int AS in_tpm_n,
+           SUM(input_tokens)     FILTER (WHERE input_tokens IS NOT NULL
+                              AND audio_seconds_in > 0)::float8 AS in_tpm_tokens,
+           SUM(audio_seconds_in) FILTER (WHERE input_tokens IS NOT NULL
+                              AND audio_seconds_in > 0)::float8 AS in_tpm_seconds,
+           COUNT(*) FILTER (WHERE output_tokens IS NOT NULL
+                              AND audio_seconds_in > 0)::int AS out_tpm_n,
+           SUM(output_tokens)    FILTER (WHERE output_tokens IS NOT NULL
+                              AND audio_seconds_in > 0)::float8 AS out_tpm_tokens,
+           SUM(audio_seconds_in) FILTER (WHERE output_tokens IS NOT NULL
+                              AND audio_seconds_in > 0)::float8 AS out_tpm_seconds,
+           COUNT(*) FILTER (WHERE characters_in IS NOT NULL
+                              AND audio_seconds_out > 0)::int AS cps_n,
+           SUM(characters_in)     FILTER (WHERE characters_in IS NOT NULL
+                              AND audio_seconds_out > 0)::float8 AS cps_chars,
+           SUM(audio_seconds_out) FILTER (WHERE characters_in IS NOT NULL
+                              AND audio_seconds_out > 0)::float8 AS cps_seconds,
+           COUNT(*) FILTER (WHERE input_tokens IS NOT NULL
+                              AND characters_in > 0)::int AS in_tpc_n,
+           SUM(input_tokens)  FILTER (WHERE input_tokens IS NOT NULL
+                              AND characters_in > 0)::float8 AS in_tpc_tokens,
+           SUM(characters_in) FILTER (WHERE input_tokens IS NOT NULL
+                              AND characters_in > 0)::float8 AS in_tpc_chars,
+           COUNT(*) FILTER (WHERE output_tokens IS NOT NULL
+                              AND characters_in > 0)::int AS out_tpc_n,
+           SUM(output_tokens) FILTER (WHERE output_tokens IS NOT NULL
+                              AND characters_in > 0)::float8 AS out_tpc_tokens,
+           SUM(characters_in) FILTER (WHERE output_tokens IS NOT NULL
+                              AND characters_in > 0)::float8 AS out_tpc_chars
     FROM benchmarks_v2.results
     WHERE status = 'success'
       AND created_at >= now() - INTERVAL '7 days'
@@ -101,16 +129,37 @@ async def load_conversions(
 
     conversions: dict[tuple[str, str, Benchmark], Conversion] = {}
     for r in rows:
-        if r["sample_count"] < MIN_CONVERSION_SAMPLES:
+
+        def _pair(n_key: str, num_key: str, den_key: str, scale: float = 1.0) -> float | None:
+            # A ratio exists only when its own paired population clears the
+            # floor; each pair's numerator and denominator come from the same
+            # rows by construction of the FILTER clauses.
+            if r[n_key] < MIN_CONVERSION_SAMPLES:  # noqa: B023 — consumed within the iteration
+                return None
+            return _ratio(r[num_key], (r[den_key] or 0) / scale)  # noqa: B023
+
+        fields = {
+            "in_tokens_per_min": _pair("in_tpm_n", "in_tpm_tokens", "in_tpm_seconds", 60),
+            "out_tokens_per_min": _pair("out_tpm_n", "out_tpm_tokens", "out_tpm_seconds", 60),
+            "chars_per_sec": _pair("cps_n", "cps_chars", "cps_seconds"),
+            "in_tokens_per_char": _pair("in_tpc_n", "in_tpc_tokens", "in_tpc_chars"),
+            "out_tokens_per_char": _pair("out_tpc_n", "out_tpc_tokens", "out_tpc_chars"),
+        }
+        counts = {
+            "in_tokens_per_min": r["in_tpm_n"],
+            "out_tokens_per_min": r["out_tpm_n"],
+            "chars_per_sec": r["cps_n"],
+            "in_tokens_per_char": r["in_tpc_n"],
+            "out_tokens_per_char": r["out_tpc_n"],
+        }
+        present = {k: v for k, v in fields.items() if v is not None}
+        if not present:
             continue
-        minutes_in = r["seconds_in"] / 60 if r["seconds_in"] else None
         conversions[(r["provider"], r["model"], Benchmark(r["benchmark"]))] = Conversion(
-            in_tokens_per_min=_ratio(r["in_tokens"], minutes_in),
-            out_tokens_per_min=_ratio(r["out_tokens"], minutes_in),
-            chars_per_sec=_ratio(r["chars_in"], r["seconds_out"]),
-            in_tokens_per_char=_ratio(r["in_tokens"], r["chars_in"]),
-            out_tokens_per_char=_ratio(r["out_tokens"], r["chars_in"]),
-            sample_count=r["sample_count"],
+            **fields,
+            # The smallest population among the ratios actually served — the
+            # conservative honest answer to "how many samples back this".
+            sample_count=min(counts[k] for k in present),
         )
     return conversions
 

--- a/runner/src/coval_bench/pricing/normalize.py
+++ b/runner/src/coval_bench/pricing/normalize.py
@@ -1,0 +1,179 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+"""Normalize native billing rates to display units, AA-style.
+
+Targets: USD per 1,000 minutes of audio (STT, S2S) and USD per 1M characters
+(TTS). Duration- and character-billed rates convert arithmetically
+(``basis="list_price"``). Token- and per-second-billed models convert through
+conversion rates measured from our own runs over the last 7 days
+(``basis="list_price_measured_conversion"``) — the same idea Artificial
+Analysis applies to token billing, but re-measured continuously instead of
+one-off. No measured conversion (or too few samples) → no normalized value,
+never an estimate.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Literal
+
+from pydantic import BaseModel
+
+from coval_bench.db.models import Benchmark, BillingUnit
+
+if TYPE_CHECKING:
+    import psycopg
+    import psycopg.rows
+    from psycopg_pool import AsyncConnectionPool
+
+    from coval_bench.db.models import PriceRow
+
+#: Minimum anchor rows in the window before a measured conversion is trusted.
+MIN_CONVERSION_SAMPLES = 50
+CONVERSION_WINDOW = "7d"
+
+_SECONDS_PER_UNIT: dict[BillingUnit, float] = {
+    BillingUnit.PER_SECOND: 1.0,
+    BillingUnit.PER_MINUTE: 60.0,
+    BillingUnit.PER_HOUR: 3600.0,
+}
+
+# One anchor metric per benchmark (AudioToFinal / TTFA / V2V): exactly one row
+# per item carries the item's usage quantities, so summing over anchors never
+# double-counts the usage columns duplicated across an item's metric rows.
+_CONVERSIONS_SQL = """
+    SELECT provider, model, benchmark,
+           SUM(input_tokens)::float8    AS in_tokens,
+           SUM(output_tokens)::float8   AS out_tokens,
+           SUM(audio_seconds_in)::float8  AS seconds_in,
+           SUM(audio_seconds_out)::float8 AS seconds_out,
+           SUM(characters_in)::float8   AS chars_in,
+           COUNT(*)::int                AS sample_count
+    FROM benchmarks_v2.results
+    WHERE status = 'success'
+      AND created_at >= now() - INTERVAL '7 days'
+      AND ((benchmark = 'STT' AND metric_type = 'AudioToFinal')
+        OR (benchmark = 'TTS' AND metric_type = 'TTFA')
+        OR (benchmark = 'S2S' AND metric_type = 'V2V'))
+    GROUP BY provider, model, benchmark
+"""
+
+
+class Conversion(BaseModel):
+    """Measured unit-conversion rates for one (provider, model, benchmark)."""
+
+    in_tokens_per_min: float | None = None
+    out_tokens_per_min: float | None = None
+    chars_per_sec: float | None = None
+    in_tokens_per_char: float | None = None
+    out_tokens_per_char: float | None = None
+    sample_count: int
+    window: str = CONVERSION_WINDOW
+
+
+class NormalizedPrice(BaseModel):
+    """A display price in the benchmark's target unit, with its derivation basis."""
+
+    value: float
+    basis: Literal["list_price", "list_price_measured_conversion"]
+
+
+def _ratio(numerator: float | None, denominator: float | None) -> float | None:
+    if numerator is None or denominator is None or denominator <= 0:
+        return None
+    return numerator / denominator
+
+
+async def load_conversions(
+    pool: AsyncConnectionPool[psycopg.AsyncConnection[psycopg.rows.DictRow]],
+) -> dict[tuple[str, str, Benchmark], Conversion]:
+    """Measured conversion rates for every model with enough recent samples.
+
+    One grouped query over the 7-day window; models under
+    ``MIN_CONVERSION_SAMPLES`` anchor rows are omitted entirely.
+    """
+    import psycopg.rows as _rows
+
+    async with pool.connection() as conn:
+        async with conn.cursor(row_factory=_rows.dict_row) as cur:
+            await cur.execute(_CONVERSIONS_SQL)
+            rows = await cur.fetchall()
+        await conn.commit()
+
+    conversions: dict[tuple[str, str, Benchmark], Conversion] = {}
+    for r in rows:
+        if r["sample_count"] < MIN_CONVERSION_SAMPLES:
+            continue
+        minutes_in = r["seconds_in"] / 60 if r["seconds_in"] else None
+        conversions[(r["provider"], r["model"], Benchmark(r["benchmark"]))] = Conversion(
+            in_tokens_per_min=_ratio(r["in_tokens"], minutes_in),
+            out_tokens_per_min=_ratio(r["out_tokens"], minutes_in),
+            chars_per_sec=_ratio(r["chars_in"], r["seconds_out"]),
+            in_tokens_per_char=_ratio(r["in_tokens"], r["chars_in"]),
+            out_tokens_per_char=_ratio(r["out_tokens"], r["chars_in"]),
+            sample_count=r["sample_count"],
+        )
+    return conversions
+
+
+def normalized_price(
+    benchmark: Benchmark,
+    rates: list[PriceRow],
+    conversion: Conversion | None,
+) -> NormalizedPrice | None:
+    """Normalize one model's effective rates to the benchmark's display unit.
+
+    STT/S2S → USD per 1,000 minutes; TTS → USD per 1M characters. Returns
+    ``None`` when the native unit needs a measured conversion that isn't
+    available — the caller shows native rates with a null normalized value.
+    """
+    by_unit = {r.billing_unit: r for r in rates if r.benchmark is benchmark}
+    duration_rate = next(((u, r) for u, r in by_unit.items() if u in _SECONDS_PER_UNIT), None)
+    in_rate = by_unit.get(BillingUnit.PER_1M_TOKENS_INPUT)
+    out_rate = by_unit.get(BillingUnit.PER_1M_TOKENS_OUTPUT)
+
+    if benchmark is Benchmark.TTS:
+        chars_rate = by_unit.get(BillingUnit.PER_1M_CHARS)
+        if chars_rate is not None:
+            return NormalizedPrice(value=float(chars_rate.rate_usd), basis="list_price")
+        if duration_rate is not None:
+            unit, rate = duration_rate
+            chars_per_sec = conversion.chars_per_sec if conversion else None
+            if chars_per_sec is None:
+                return None
+            per_second = float(rate.rate_usd) / _SECONDS_PER_UNIT[unit]
+            return NormalizedPrice(
+                value=per_second * (1e6 / chars_per_sec),
+                basis="list_price_measured_conversion",
+            )
+        if in_rate is not None or out_rate is not None:
+            in_tpc = conversion.in_tokens_per_char if conversion else None
+            out_tpc = conversion.out_tokens_per_char if conversion else None
+            if (in_rate is not None and in_tpc is None) or (
+                out_rate is not None and out_tpc is None
+            ):
+                return None
+            value = 0.0
+            if in_rate is not None and in_tpc is not None:
+                value += float(in_rate.rate_usd) / 1e6 * in_tpc * 1e6
+            if out_rate is not None and out_tpc is not None:
+                value += float(out_rate.rate_usd) / 1e6 * out_tpc * 1e6
+            return NormalizedPrice(value=value, basis="list_price_measured_conversion")
+        return None
+
+    # STT / S2S → USD per 1,000 minutes
+    if duration_rate is not None:
+        unit, rate = duration_rate
+        per_minute = float(rate.rate_usd) * 60 / _SECONDS_PER_UNIT[unit]
+        return NormalizedPrice(value=per_minute * 1000, basis="list_price")
+    if in_rate is not None or out_rate is not None:
+        in_tpm = conversion.in_tokens_per_min if conversion else None
+        out_tpm = conversion.out_tokens_per_min if conversion else None
+        if (in_rate is not None and in_tpm is None) or (out_rate is not None and out_tpm is None):
+            return None
+        per_minute = 0.0
+        if in_rate is not None and in_tpm is not None:
+            per_minute += float(in_rate.rate_usd) / 1e6 * in_tpm
+        if out_rate is not None and out_tpm is not None:
+            per_minute += float(out_rate.rate_usd) / 1e6 * out_tpm
+        return NormalizedPrice(value=per_minute * 1000, basis="list_price_measured_conversion")
+    return None

--- a/runner/tests/api/conftest.py
+++ b/runner/tests/api/conftest.py
@@ -117,7 +117,33 @@ def _load_schema(**connect_kwargs: Any) -> None:
                 created_at     timestamptz NOT NULL DEFAULT now(),
                 wer_insertions_pct    double precision,
                 wer_deletions_pct     double precision,
-                wer_substitutions_pct double precision
+                wer_substitutions_pct double precision,
+                input_tokens     bigint,
+                output_tokens    bigint,
+                total_tokens     bigint,
+                billable_seconds double precision,
+                characters_in    integer,
+                audio_seconds_in  double precision,
+                audio_seconds_out double precision
+            )
+        """)
+        # Append-only pricing store (mirrors migration 20260806_0016).
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS benchmarks_v2.model_pricing (
+                id BIGSERIAL PRIMARY KEY,
+                provider TEXT NOT NULL,
+                model TEXT NOT NULL,
+                benchmark TEXT NOT NULL,
+                billing_unit TEXT NOT NULL,
+                rate_usd NUMERIC(14,8) NOT NULL,
+                plan_assumption TEXT NULL,
+                effective_at TIMESTAMPTZ NOT NULL,
+                superseded_at TIMESTAMPTZ NULL,
+                source_url TEXT NOT NULL,
+                as_of DATE NOT NULL,
+                evidence TEXT NULL,
+                updated_by TEXT NOT NULL,
+                created_at TIMESTAMPTZ NOT NULL DEFAULT now()
             )
         """)
         # Per-window stats materialized views (model_stats + leaderboard).

--- a/runner/tests/api/test_pricing.py
+++ b/runner/tests/api/test_pricing.py
@@ -224,3 +224,33 @@ async def test_unregistered_model_absent(client: AsyncClient, postgresql: Any) -
     )
     response = await client.get("/v1/pricing", params={"benchmark": "TTS"})
     assert response.json()["entries"] == []
+
+
+async def test_future_effective_rate_absent_from_current_and_history(
+    client: AsyncClient, postgresql: Any
+) -> None:
+    """A scheduled future rate leaks into neither native_rates nor history."""
+    now = datetime.now(tz=UTC)
+    await _insert_price(
+        postgresql,
+        provider="mistral",
+        model="voxtral-mini-transcribe-realtime-2602",
+        benchmark="STT",
+        billing_unit="per_minute",
+        rate_usd="0.006",
+        effective_at=now - timedelta(days=10),
+    )
+    await _insert_price(
+        postgresql,
+        provider="mistral",
+        model="voxtral-mini-transcribe-realtime-2602",
+        benchmark="STT",
+        billing_unit="per_second",
+        rate_usd="0.001",
+        effective_at=now + timedelta(days=10),  # scheduled, not yet effective
+    )
+    response = await client.get("/v1/pricing", params={"benchmark": "STT"})
+    entry = response.json()["entries"][0]
+    assert [r["billing_unit"] for r in entry["native_rates"]] == ["per_minute"]
+    assert len(entry["history"]) == 1
+    assert entry["normalized_usd"] == pytest.approx(6.0)

--- a/runner/tests/api/test_pricing.py
+++ b/runner/tests/api/test_pricing.py
@@ -1,0 +1,226 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for GET /v1/pricing."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import psycopg
+import pytest
+from httpx import AsyncClient
+
+from tests.api.conftest import _insert_result, _insert_run, _make_db_url
+
+
+async def _insert_price(
+    postgresql: Any,
+    *,
+    provider: str,
+    model: str,
+    benchmark: str,
+    billing_unit: str,
+    rate_usd: str,
+    effective_at: datetime,
+    superseded_at: datetime | None = None,
+    plan_assumption: str | None = None,
+) -> None:
+    aconn = await psycopg.AsyncConnection.connect(_make_db_url(postgresql), autocommit=True)
+    try:
+        await aconn.execute(
+            "INSERT INTO benchmarks_v2.model_pricing"
+            " (provider, model, benchmark, billing_unit, rate_usd, plan_assumption,"
+            "  effective_at, superseded_at, source_url, as_of, updated_by)"
+            " VALUES (%s, %s, %s, %s, %s, %s, %s, %s,"
+            "  'https://example.com/pricing', '2026-08-06', 'human')",
+            (
+                provider,
+                model,
+                benchmark,
+                billing_unit,
+                rate_usd,
+                plan_assumption,
+                effective_at,
+                superseded_at,
+            ),
+        )
+    finally:
+        await aconn.close()
+
+
+async def test_benchmark_required(client: AsyncClient) -> None:
+    assert (await client.get("/v1/pricing")).status_code == 422
+
+
+async def test_empty_db_returns_no_entries(client: AsyncClient) -> None:
+    response = await client.get("/v1/pricing", params={"benchmark": "TTS"})
+    assert response.status_code == 200
+    body = response.json()
+    assert body["unit_label"] == "USD per 1M characters"
+    assert body["entries"] == []
+
+
+async def test_duration_billed_model_normalizes_from_list_price(
+    client: AsyncClient, postgresql: Any
+) -> None:
+    t0 = datetime(2026, 7, 1, tzinfo=UTC)
+    t1 = datetime(2026, 8, 1, tzinfo=UTC)
+    # Superseded history row (was $0.004/min) then the current $0.006/min.
+    await _insert_price(
+        postgresql,
+        provider="mistral",
+        model="voxtral-mini-transcribe-realtime-2602",
+        benchmark="STT",
+        billing_unit="per_minute",
+        rate_usd="0.004",
+        effective_at=t0,
+        superseded_at=t1,
+    )
+    await _insert_price(
+        postgresql,
+        provider="mistral",
+        model="voxtral-mini-transcribe-realtime-2602",
+        benchmark="STT",
+        billing_unit="per_minute",
+        rate_usd="0.006",
+        effective_at=t1,
+    )
+
+    response = await client.get("/v1/pricing", params={"benchmark": "STT"})
+    assert response.status_code == 200
+    body = response.json()
+    assert body["unit_label"] == "USD per 1,000 minutes"
+    assert len(body["entries"]) == 1
+    entry = body["entries"][0]
+    assert entry["provider"] == "mistral"
+    assert entry["normalized_usd"] == pytest.approx(6.0)
+    assert entry["basis"] == "list_price"
+    assert entry["as_of"] == "2026-08-06"
+    assert entry["source_url"] == "https://example.com/pricing"
+    assert entry["native_rates"] == [
+        {"billing_unit": "per_minute", "rate_usd": 0.006, "plan_assumption": None}
+    ]
+    # History: the old rate normalized too, oldest first.
+    history = entry["history"]
+    assert len(history) == 2
+    assert history[0]["normalized_usd"] == pytest.approx(4.0)
+    assert history[0]["superseded_at"] is not None
+    assert history[1]["normalized_usd"] == pytest.approx(6.0)
+    assert history[1]["superseded_at"] is None
+
+
+async def test_token_billed_model_uses_measured_conversion(
+    client: AsyncClient, postgresql: Any
+) -> None:
+    now = datetime.now(tz=UTC)
+    for unit, rate in (("per_1m_tokens_input", "2.50"), ("per_1m_tokens_output", "10.00")):
+        await _insert_price(
+            postgresql,
+            provider="openai",
+            model="gpt-4o-transcribe",
+            benchmark="STT",
+            billing_unit=unit,
+            rate_usd=rate,
+            effective_at=now - timedelta(days=30),
+        )
+    # 50 anchor rows in the 7d window: 1000 in-tokens + 100 out-tokens per
+    # 60s item → 1000 in-tokens/min, 100 out-tokens/min measured.
+    run_id = await _insert_run(postgresql)
+    for _ in range(50):
+        await _insert_result(
+            postgresql,
+            run_id,
+            provider="openai",
+            model="gpt-4o-transcribe",
+            metric_type="AudioToFinal",
+            metric_value=1.0,
+            input_tokens=1000,
+            output_tokens=100,
+            audio_seconds_in=60.0,
+        )
+
+    response = await client.get("/v1/pricing", params={"benchmark": "STT"})
+    assert response.status_code == 200
+    entries = response.json()["entries"]
+    assert len(entries) == 1
+    entry = entries[0]
+    # (2.5/1e6 * 1000 + 10/1e6 * 100) * 1000 = $3.50 per 1k min
+    assert entry["normalized_usd"] == pytest.approx(3.5)
+    assert entry["basis"] == "list_price_measured_conversion"
+    assert entry["conversion"]["in_tokens_per_min"] == pytest.approx(1000.0)
+    assert entry["conversion"]["out_tokens_per_min"] == pytest.approx(100.0)
+    assert entry["conversion"]["sample_count"] == 50
+    assert entry["conversion"]["window"] == "7d"
+    assert {r["billing_unit"] for r in entry["native_rates"]} == {
+        "per_1m_tokens_input",
+        "per_1m_tokens_output",
+    }
+
+
+async def test_token_billed_model_without_conversion_serves_native_only(
+    client: AsyncClient, postgresql: Any
+) -> None:
+    await _insert_price(
+        postgresql,
+        provider="openai",
+        model="gpt-4o-transcribe",
+        benchmark="STT",
+        billing_unit="per_1m_tokens_input",
+        rate_usd="2.50",
+        effective_at=datetime.now(tz=UTC) - timedelta(days=1),
+    )
+    response = await client.get("/v1/pricing", params={"benchmark": "STT"})
+    entries = response.json()["entries"]
+    assert len(entries) == 1
+    assert entries[0]["normalized_usd"] is None
+    assert entries[0]["basis"] is None
+    assert entries[0]["conversion"] is None
+    assert entries[0]["native_rates"][0]["rate_usd"] == pytest.approx(2.5)
+
+
+async def test_history_periods_chain_when_token_pair_staggers(
+    client: AsyncClient, postgresql: Any
+) -> None:
+    """A pair whose units changed at different times still yields contiguous periods."""
+    t0 = datetime(2026, 7, 1, tzinfo=UTC)
+    t1 = datetime(2026, 8, 1, tzinfo=UTC)
+    await _insert_price(
+        postgresql,
+        provider="openai",
+        model="gpt-4o-transcribe",
+        benchmark="STT",
+        billing_unit="per_1m_tokens_input",
+        rate_usd="2.50",
+        effective_at=t0,
+    )
+    await _insert_price(
+        postgresql,
+        provider="openai",
+        model="gpt-4o-transcribe",
+        benchmark="STT",
+        billing_unit="per_1m_tokens_output",
+        rate_usd="10.00",
+        effective_at=t1,
+    )
+    response = await client.get("/v1/pricing", params={"benchmark": "STT"})
+    history = response.json()["entries"][0]["history"]
+    assert len(history) == 2
+    assert history[0]["superseded_at"] == history[1]["effective_at"]
+    assert history[1]["superseded_at"] is None
+
+
+async def test_unregistered_model_absent(client: AsyncClient, postgresql: Any) -> None:
+    """Rows for models not in the active registry never surface."""
+    await _insert_price(
+        postgresql,
+        provider="openai",
+        model="whisper-1-judge",
+        benchmark="TTS",
+        billing_unit="per_minute",
+        rate_usd="0.006",
+        effective_at=datetime.now(tz=UTC) - timedelta(days=1),
+    )
+    response = await client.get("/v1/pricing", params={"benchmark": "TTS"})
+    assert response.json()["entries"] == []

--- a/runner/tests/pricing/test_normalize.py
+++ b/runner/tests/pricing/test_normalize.py
@@ -1,0 +1,137 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for every price-normalization branch."""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+from decimal import Decimal
+
+import pytest
+
+from coval_bench.db.models import Benchmark, BillingUnit, PriceRow
+from coval_bench.pricing.normalize import Conversion, normalized_price
+
+
+def _rate(unit: BillingUnit, rate: str, benchmark: Benchmark) -> PriceRow:
+    return PriceRow(
+        provider="p",
+        model="m",
+        benchmark=benchmark,
+        billing_unit=unit,
+        rate_usd=Decimal(rate),
+        effective_at=datetime(2026, 8, 1, tzinfo=UTC),
+        source_url="https://example.com/pricing",
+        as_of=date(2026, 8, 6),
+        updated_by="human",
+    )
+
+
+def test_stt_per_minute() -> None:
+    result = normalized_price(
+        Benchmark.STT, [_rate(BillingUnit.PER_MINUTE, "0.006", Benchmark.STT)], None
+    )
+    assert result is not None
+    assert result.value == pytest.approx(6.0)  # $/1k min
+    assert result.basis == "list_price"
+
+
+def test_stt_per_second() -> None:
+    result = normalized_price(
+        Benchmark.STT, [_rate(BillingUnit.PER_SECOND, "0.0001", Benchmark.STT)], None
+    )
+    assert result is not None
+    assert result.value == pytest.approx(6.0)
+    assert result.basis == "list_price"
+
+
+def test_stt_per_hour() -> None:
+    result = normalized_price(
+        Benchmark.STT, [_rate(BillingUnit.PER_HOUR, "0.36", Benchmark.STT)], None
+    )
+    assert result is not None
+    assert result.value == pytest.approx(6.0)
+    assert result.basis == "list_price"
+
+
+def test_stt_token_rates_with_measured_conversion() -> None:
+    rates = [
+        _rate(BillingUnit.PER_1M_TOKENS_INPUT, "2.50", Benchmark.STT),
+        _rate(BillingUnit.PER_1M_TOKENS_OUTPUT, "10.00", Benchmark.STT),
+    ]
+    conversion = Conversion(in_tokens_per_min=600.0, out_tokens_per_min=100.0, sample_count=100)
+    result = normalized_price(Benchmark.STT, rates, conversion)
+    assert result is not None
+    # (2.5/1e6*600 + 10/1e6*100) * 1000 = 1.5 + 1.0
+    assert result.value == pytest.approx(2.5)
+    assert result.basis == "list_price_measured_conversion"
+
+
+def test_stt_token_rates_without_conversion_is_none() -> None:
+    rates = [_rate(BillingUnit.PER_1M_TOKENS_INPUT, "2.50", Benchmark.STT)]
+    assert normalized_price(Benchmark.STT, rates, None) is None
+    assert normalized_price(Benchmark.STT, rates, Conversion(sample_count=100)) is None
+
+
+def test_tts_per_1m_chars_passthrough() -> None:
+    result = normalized_price(
+        Benchmark.TTS, [_rate(BillingUnit.PER_1M_CHARS, "50.00", Benchmark.TTS)], None
+    )
+    assert result is not None
+    assert result.value == pytest.approx(50.0)
+    assert result.basis == "list_price"
+
+
+def test_tts_per_second_with_measured_chars_per_sec() -> None:
+    conversion = Conversion(chars_per_sec=16.0, sample_count=100)
+    result = normalized_price(
+        Benchmark.TTS, [_rate(BillingUnit.PER_SECOND, "0.001", Benchmark.TTS)], conversion
+    )
+    assert result is not None
+    # $0.001/s of audio; 1M chars at 16 chars/s of audio = 62,500s → $62.50
+    assert result.value == pytest.approx(62.5)
+    assert result.basis == "list_price_measured_conversion"
+
+
+def test_tts_per_second_without_conversion_is_none() -> None:
+    rates = [_rate(BillingUnit.PER_SECOND, "0.001", Benchmark.TTS)]
+    assert normalized_price(Benchmark.TTS, rates, None) is None
+
+
+def test_tts_token_rates_with_measured_tokens_per_char() -> None:
+    rates = [
+        _rate(BillingUnit.PER_1M_TOKENS_INPUT, "0.60", Benchmark.TTS),
+        _rate(BillingUnit.PER_1M_TOKENS_OUTPUT, "12.00", Benchmark.TTS),
+    ]
+    conversion = Conversion(in_tokens_per_char=0.25, out_tokens_per_char=5.0, sample_count=100)
+    result = normalized_price(Benchmark.TTS, rates, conversion)
+    assert result is not None
+    # per char: 0.6/1e6*0.25 + 12/1e6*5 → ×1e6 chars = 0.15 + 60
+    assert result.value == pytest.approx(60.15)
+    assert result.basis == "list_price_measured_conversion"
+
+
+def test_tts_token_rates_without_conversion_is_none() -> None:
+    rates = [_rate(BillingUnit.PER_1M_TOKENS_OUTPUT, "12.00", Benchmark.TTS)]
+    assert normalized_price(Benchmark.TTS, rates, None) is None
+
+
+def test_s2s_per_minute() -> None:
+    result = normalized_price(
+        Benchmark.S2S, [_rate(BillingUnit.PER_MINUTE, "0.05", Benchmark.S2S)], None
+    )
+    assert result is not None
+    assert result.value == pytest.approx(50.0)
+    assert result.basis == "list_price"
+
+
+def test_rates_from_other_benchmark_ignored() -> None:
+    # gradium serves STT and TTS under one model id.
+    rates = [_rate(BillingUnit.PER_1M_CHARS, "48.00", Benchmark.TTS)]
+    assert normalized_price(Benchmark.STT, rates, None) is None
+
+
+def test_per_request_rate_never_normalized() -> None:
+    rates = [_rate(BillingUnit.PER_REQUEST, "0.01", Benchmark.STT)]
+    assert normalized_price(Benchmark.STT, rates, None) is None

--- a/web/lib/api/generated/schema.ts
+++ b/web/lib/api/generated/schema.ts
@@ -40,6 +40,22 @@ export interface paths {
       };
     };
   };
+  "/v1/pricing": {
+    get: {
+      parameters: {
+        query: {
+          benchmark: components["schemas"]["BenchmarkLiteral"];
+        };
+      };
+      responses: {
+        200: {
+          content: {
+            "application/json": components["schemas"]["PricingResponse"];
+          };
+        };
+      };
+    };
+  };
 }
 
 export interface components {
@@ -106,6 +122,39 @@ export interface components {
       category: components["schemas"]["TagCategory"];
       value: string;
       label: string;
+    };
+    ConversionOut: {
+      in_tokens_per_min?: number | null;
+      out_tokens_per_min?: number | null;
+      chars_per_sec?: number | null;
+      sample_count: number;
+      window: string;
+    };
+    NativeRateOut: {
+      billing_unit: string;
+      rate_usd: number;
+      plan_assumption?: string | null;
+    };
+    PriceHistoryPoint: {
+      normalized_usd?: number | null;
+      effective_at: string;
+      superseded_at?: string | null;
+    };
+    PricingEntry: {
+      provider: string;
+      model: string;
+      normalized_usd?: number | null;
+      basis?: ("list_price" | "list_price_measured_conversion") | null;
+      native_rates: components["schemas"]["NativeRateOut"][];
+      conversion?: components["schemas"]["ConversionOut"] | null;
+      as_of: string;
+      source_url: string;
+      history: components["schemas"]["PriceHistoryPoint"][];
+    };
+    PricingResponse: {
+      benchmark: components["schemas"]["BenchmarkLiteral"];
+      unit_label: "USD per 1,000 minutes" | "USD per 1M characters";
+      entries: components["schemas"]["PricingEntry"][];
     };
     ProviderInfo: {
       provider: string;


### PR DESCRIPTION
Stacked on #462.

`GET /v1/pricing` serves AA-style display prices: USD per 1k minutes (STT/S2S), USD per 1M chars (TTS). Duration/char rates normalize arithmetically (`basis=list_price`); token- and per-second-billed models convert through conversion rates measured from our own runs over the trailing 7 days (`basis=list_price_measured_conversion`, one grouped SQL query over per-item anchor rows, ≥50-sample floor — below it the model serves native rates with `normalized_usd: null`, never an estimate). Entries carry provenance (as_of, source_url, plan assumptions), conversion metadata, and price history from the append-only table normalized at today's conversion (approximation documented on the schema; periods chain contiguously even when a token pair's units changed at different times). Same TTL cache + early-access hiding as the other read endpoints. Web types added to the curated schema.ts mirror; methodology doc gains the pricing section.

Verified: all 58 served entries recompute exactly from DB rows via an independent audit; EA models absent for public callers.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds the public `/v1/pricing` endpoint with normalized STT, TTS, and S2S prices, measured conversions, provenance, caching, early-access filtering, and normalized price history.

- Introduces conversion SQL and arithmetic for native duration, character, and token billing units.
- Adds API schemas, frontend schema types, methodology documentation, and endpoint/normalization tests.
- The conversion sample population and combined provenance handling can currently publish misleading normalized prices or metadata.

<h3>Confidence Score: 3/5</h3>

The PR should not merge until conversion sampling and multi-rate provenance are corrected so the API cannot publish biased prices or mismatched source metadata.

Nullable usage fields are aggregated over populations that can differ from the reported sample count, and combined token-rate entries can pair a source URL with an unrelated verification date; future-effective history exposure is an additional non-blocking concern.

**Files Needing Attention:** runner/src/coval_bench/pricing/normalize.py, runner/src/coval_bench/api/routers/pricing.py

<sub>Reviews (1): Last reviewed commit: ["\[BENCH-636\] API: /v1/pricing — normalize..."](https://github.com/coval-ai/benchmarks/commit/365c1fdaa0f781dd5a8eafb0d38c142a00fad406) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50943183)</sub>

> Greptile also left **3 inline comments** on this PR.

**Context used:**

- Knowledge Base — [API service](https://app.greptile.com/coval/-/custom-context/knowledge-base/coval-ai/benchmarks/-/docs/api-service.md)
- Knowledge Base — [Methodology](https://app.greptile.com/coval/-/custom-context/knowledge-base/coval-ai/benchmarks/-/docs/methodology.md)

<!-- /greptile_comment -->