### PR TITLE
[BENCH-637] Web: price column, price-vs-quality Pareto chart, price history (6/6)

### DIFF
--- a/docs/pricing-go-live.md
+++ b/docs/pricing-go-live.md
@@ -5,28 +5,38 @@ Merge order: the six branches are stacked and must merge in ticket order
 
 ## Deploy sequence
 
-1. **Migrate prod FIRST** — migrations `0015`–`0018` must be applied before
-   the new runner/API images go live: the writer's INSERT names the new usage
-   columns and `finish_run` names the judge/cost columns, so old-schema +
-   new-code fails every run. All four migrations are plain
-   `CREATE TABLE`/`ADD COLUMN` (no matview drop/recreate, no lock-order
-   hazard, no backfill). Apply via cloud-sql-proxy the usual way:
+Prod auto-deploys main on a frequent weekday cron, so steps 1–2 run
+**before merging** — both are purely additive and invisible to the currently
+deployed code, which removes the merge→deploy race entirely.
+
+1. **Migrate prod BEFORE merging** — migrations `0015`–`0018` must be in
+   place before the new runner/API images go live: the new writer's INSERT
+   names the new usage columns and `finish_run` names the judge/cost columns,
+   so old-schema + new-code fails every run. (Old code + new schema is fine —
+   all four migrations are plain `CREATE TABLE`/`ADD COLUMN`, no matview
+   drop/recreate, no lock-order hazard, no backfill.) Apply via
+   cloud-sql-proxy the usual way, from the 637 branch checkout:
    `coval-bench db migrate` against the proxied DSN.
-2. **Seed the ratesheet** — `uv run python scripts/seed_pricing.py` against
-   the proxied DSN (the local-host guard passes through the proxy; the script
-   is idempotent and only ever supersedes). Expect ~69 rows inserted and a
-   6-model gap list (baseten ×2 dedicated, alibaba console-only, deepdub
-   enterprise, fluxions + deepgram flux TTS unreleased) — those are known and
-   deliberate; `scripts/check_pricing_coverage.py` will keep flagging them
-   until they're priced or paused.
-3. **Deploy runner + API**, then verify `GET /v1/pricing?benchmark=STT|TTS|S2S`
-   returns entries with `as_of` + `source_url` and that early-access models
-   (murf falcon-2, xai grok-voice, modulate english-v2) are absent without an
-   EA token.
-4. **Web deploys any time** — order does not matter. Verified against a live
-   API serving 404 on `/v1/pricing`: every pricing surface (column, toggle,
-   history card, overview cards) hides itself and the dashboards render
-   normally.
+2. **Seed the ratesheet (also pre-merge)** — `uv run python
+   scripts/seed_pricing.py` against the proxied DSN (the local-host guard
+   passes through the proxy; the script is idempotent and only ever
+   supersedes). Expect 69 rows inserted and a 6-model gap list (baseten ×2
+   dedicated, alibaba console-only, deepdub enterprise, fluxions + deepgram
+   flux TTS unreleased) — those are known and deliberate;
+   `scripts/check_pricing_coverage.py` will keep flagging them until they're
+   priced or paused.
+3. **Merge the six PRs in order** — the scheduled deploy (or a manual
+   ci-cd-switchboard "Deploy Service" run) rolls out runner + API. Then
+   verify `GET /v1/pricing?benchmark=STT|TTS|S2S` returns entries with
+   `as_of` + `source_url` and that early-access models (murf falcon-2, xai
+   grok-voice, modulate english-v2) are absent without an EA token.
+4. **Web deploys AFTER the API is live** — `vercel-build` runs `pnpm codegen`
+   against the live API's `/openapi.json` at build time, and the new
+   components reference the pricing types, so a web build that runs before
+   the new API is live fails its typecheck (safe: the site stays on the
+   previous version — just redeploy once step 3 is verified). At runtime the
+   ordering is free either way: against an API without `/v1/pricing` every
+   pricing surface hides itself (verified live).
 
 ## Day-one expectations
 

--- a/docs/pricing-go-live.md
+++ b/docs/pricing-go-live.md
@@ -1,0 +1,65 @@
+# Pricing go-live runbook (BENCH-631 epic)
+
+Merge order: the six branches are stacked and must merge in ticket order
+(632 → 633 → 634 → 635 → 636 → 637); each PR contains only its own commit.
+
+## Deploy sequence
+
+1. **Migrate prod FIRST** — migrations `0015`–`0018` must be applied before
+   the new runner/API images go live: the writer's INSERT names the new usage
+   columns and `finish_run` names the judge/cost columns, so old-schema +
+   new-code fails every run. All four migrations are plain
+   `CREATE TABLE`/`ADD COLUMN` (no matview drop/recreate, no lock-order
+   hazard, no backfill). Apply via cloud-sql-proxy the usual way:
+   `coval-bench db migrate` against the proxied DSN.
+2. **Seed the ratesheet** — `uv run python scripts/seed_pricing.py` against
+   the proxied DSN (the local-host guard passes through the proxy; the script
+   is idempotent and only ever supersedes). Expect ~69 rows inserted and a
+   6-model gap list (baseten ×2 dedicated, alibaba console-only, deepdub
+   enterprise, fluxions + deepgram flux TTS unreleased) — those are known and
+   deliberate; `scripts/check_pricing_coverage.py` will keep flagging them
+   until they're priced or paused.
+3. **Deploy runner + API**, then verify `GET /v1/pricing?benchmark=STT|TTS|S2S`
+   returns entries with `as_of` + `source_url` and that early-access models
+   (murf falcon-2, xai grok-voice, modulate english-v2) are absent without an
+   EA token.
+4. **Web deploys any time** — order does not matter. Verified against a live
+   API serving 404 on `/v1/pricing`: every pricing surface (column, toggle,
+   history card, overview cards) hides itself and the dashboards render
+   normally.
+
+## Day-one expectations
+
+- Duration- and character-billed models show normalized prices immediately
+  after the seed.
+- **Token-billed models (openai gpt-4o-transcribe/mini) show "—" until the
+  runner has captured ≥50 usage samples in the trailing 7 days** — the
+  measured conversion needs BENCH-632's usage columns populated. At the
+  30-minute cadence that's within the first day. gpt-4o-mini-tts and soniox
+  tts-rt-v1 stay "—" longer: their providers don't report token usage yet.
+- `runs.total_cost_usd` starts populating on the first post-deploy run;
+  internal spend queries are in `docs/cost-tracking.md`.
+
+## Infra follow-ups (benchmark-infra, not this repo)
+
+- New weekly Cloud Run Job: same image, command `coval-bench update-prices`;
+  cadence mirrored by `PRICING_UPDATE_PERIOD_SECONDS` (default 604800).
+- Secrets on that job: `OPENAI_API_KEY` (extraction), `LINEAR_API_KEY`
+  (review items; Slack webhook `PRICING_REVIEW_SLACK_WEBHOOK` is the
+  fallback, log-only without either).
+- Confirm `PRICING_EXTRACTION_MODEL` (default `gpt-5-mini`) is a valid model
+  id on the account before the first scheduled run: `coval-bench
+  update-prices --dry-run --provider deepgram` exercises the whole path
+  without writing.
+- Optional: wire `scripts/check_pricing_coverage.py` into CI once the six
+  known gaps are priced or the models paused (it exits non-zero today by
+  design).
+
+## Data provenance
+
+Every seeded rate was verified against the provider's public pricing page on
+2026-08-06 (see each row's `source_url`/`evidence`); deepgram, elevenlabs,
+openai, and assemblyai were independently re-verified against the live pages
+before this runbook was written. Plan-based rates (cartesia, hume, gradium,
+lmnt, speechify, gladia) carry their plan assumption on the row and in the
+price tooltip.

--- a/runner/scripts/seed_pricing.py
+++ b/runner/scripts/seed_pricing.py
@@ -26,7 +26,7 @@ Run against a LOCAL/dev database only::
 from __future__ import annotations
 
 import asyncio
-from datetime import date
+from datetime import UTC, date, datetime
 from decimal import Decimal
 from typing import NamedTuple
 from urllib.parse import urlsplit
@@ -648,6 +648,9 @@ async def apply_ratesheet(store: PricingStore) -> tuple[int, int, list[str]]:
     inserted = 0
     unchanged = 0
     gaps: list[str] = []
+    # One shared timestamp per invocation: a token-billed model's input+output
+    # rows land as a single effective period, not two breakpoints ms apart.
+    effective_at = datetime.now(tz=UTC)
     active = [
         m for m in MODEL_REGISTRY if m.status in (ModelStatus.ACTIVE, ModelStatus.EARLY_ACCESS)
     ]
@@ -673,6 +676,7 @@ async def apply_ratesheet(store: PricingStore) -> tuple[int, int, list[str]]:
                 evidence=r.evidence,
                 plan_assumption=r.plan_assumption,
                 updated_by="human",
+                effective_at=effective_at,
             )
             if created:
                 inserted += 1

--- a/web/app/s2s/s2s-dashboard.tsx
+++ b/web/app/s2s/s2s-dashboard.tsx
@@ -34,6 +34,11 @@ const ModelComparisonSection = dynamic(
   { ssr: false, loading: () => <ChartSkeleton /> }
 );
 
+const PriceHistorySection = dynamic(
+  () => import("@/components/dashboard/PriceHistorySection"),
+  { ssr: false, loading: () => <ChartSkeleton /> }
+);
+
 export function S2SDashboard() {
   return (
     <DashboardProvider page="s2s">
@@ -44,6 +49,7 @@ export function S2SDashboard() {
           <BoxPlotSection />
           <QualityBarSection />
           <ModelComparisonSection />
+          <PriceHistorySection />
         </DashboardLayout>
       </SidebarMenuProvider>
     </DashboardProvider>

--- a/web/app/stt/stt-dashboard.tsx
+++ b/web/app/stt/stt-dashboard.tsx
@@ -43,6 +43,11 @@ const ModelComparisonSection = dynamic(
   { ssr: false, loading: () => <ChartSkeleton /> }
 );
 
+const PriceHistorySection = dynamic(
+  () => import("@/components/dashboard/PriceHistorySection"),
+  { ssr: false, loading: () => <ChartSkeleton /> }
+);
+
 export function STTDashboard() {
   return (
     <DashboardProvider page="stt">
@@ -55,6 +60,7 @@ export function STTDashboard() {
           <LatencyAccuracySection />
           <WerRadarSection />
           <ModelComparisonSection />
+          <PriceHistorySection />
         </DashboardLayout>
       </SidebarMenuProvider>
     </DashboardProvider>

--- a/web/app/tts/tts-dashboard.tsx
+++ b/web/app/tts/tts-dashboard.tsx
@@ -38,6 +38,11 @@ const ModelComparisonSection = dynamic(
   { ssr: false, loading: () => <ChartSkeleton /> }
 );
 
+const PriceHistorySection = dynamic(
+  () => import("@/components/dashboard/PriceHistorySection"),
+  { ssr: false, loading: () => <ChartSkeleton /> }
+);
+
 export function TTSDashboard() {
   return (
     <DashboardProvider page="tts">
@@ -49,6 +54,7 @@ export function TTSDashboard() {
           <QualityBarSection />
           <LatencyAccuracySection />
           <ModelComparisonSection />
+          <PriceHistorySection />
         </DashboardLayout>
       </SidebarMenuProvider>
     </DashboardProvider>

--- a/web/components/charts/tooltips/ScatterTooltip.tsx
+++ b/web/components/charts/tooltips/ScatterTooltip.tsx
@@ -6,7 +6,8 @@ import type { TooltipContentProps } from "recharts";
 import type { ScatterDataPoint } from "@/types/benchmark.types";
 import { DedicatedBadge } from "@/components/shared/DedicatedInferenceInfo";
 import { RegionBadge } from "@/components/shared/InferenceRegionInfo";
-import { normalizeModelName, normalizeSTTProviderName, normalizeTTSProviderName } from "@/lib/utils/formatters";
+import { formatUsd, normalizeModelName, normalizeSTTProviderName, normalizeTTSProviderName } from "@/lib/utils/formatters";
+import { priceUnitShortLabel } from "@/lib/utils/pricing";
 
 interface ScatterTooltipProps extends Partial<Pick<
   TooltipContentProps<number, string>,
@@ -14,13 +15,15 @@ interface ScatterTooltipProps extends Partial<Pick<
 >> {
   activeTab: "tts" | "stt";
   metric: string;
+  /** What the x axis is plotting; "price" renders normalized USD instead of ms. */
+  xKind?: "latency" | "price";
   /** Dedicated-inference endpoints carry the server marker in their tooltip. */
   dedicatedModels?: Set<string>;
   /** Model key -> inference region, for models served outside our worker's region. */
   crossRegionModels?: Map<string, string>;
 }
 
-const CustomScatterTooltip: React.FC<ScatterTooltipProps> = ({ active, payload, activeTab, metric, dedicatedModels, crossRegionModels }) => {
+const CustomScatterTooltip: React.FC<ScatterTooltipProps> = ({ active, payload, activeTab, metric, xKind = "latency", dedicatedModels, crossRegionModels }) => {
   if (active && payload && payload.length > 0) {
     const item = payload[0];
     const point = item?.payload as ScatterDataPoint | undefined;
@@ -41,7 +44,11 @@ const CustomScatterTooltip: React.FC<ScatterTooltipProps> = ({ active, payload, 
         <p style={{ margin: 0 }}>{`Provider: ${activeTab === "stt" ? normalizeSTTProviderName(point.provider) : normalizeTTSProviderName(point.provider)}`}</p>
         {dedicatedModels?.has(point.model) && <DedicatedBadge />}
         <RegionBadge region={crossRegionModels?.get(point.model)} />
-        <p style={{ margin: 0 }}>{`Avg ${metric}: ${point.x.toFixed(0)}ms`}</p>
+        <p style={{ margin: 0 }}>
+          {xKind === "price"
+            ? `Price: ${formatUsd(point.x)} ${priceUnitShortLabel(activeTab)}`
+            : `Avg ${metric}: ${point.x.toFixed(0)}ms`}
+        </p>
         <p style={{ margin: 0 }}>{`Avg WER: ${point.y.toFixed(1)}%`}</p>
         <p style={{ margin: 0 }}>{`Samples: ${point.count}`}</p>
       </div>

--- a/web/components/dashboard/LatencyAccuracySection.tsx
+++ b/web/components/dashboard/LatencyAccuracySection.tsx
@@ -18,7 +18,10 @@ import {
 import { Info } from "lucide-react";
 import type { ScatterDataPoint } from "@/types/benchmark.types";
 import { getModelColor } from "@/lib/utils/colors";
-import { normalizeModelName, parseModelKey } from "@/lib/utils/formatters";
+import { formatUsd, normalizeModelName, parseModelKey } from "@/lib/utils/formatters";
+import { priceUnitShortLabel } from "@/lib/utils/pricing";
+import { capturePostHogEvent } from "@/lib/posthog/client";
+import { POSTHOG_EVENTS } from "@/lib/posthog/events";
 import { labelScatterDots } from "@/lib/utils/chartExport";
 import CustomScatterTooltip from "@/components/charts/tooltips/ScatterTooltip";
 import Card from "@/components/shared/Card";
@@ -66,6 +69,7 @@ const LatencyAccuracySection: React.FC = () => {
     activeMetric: metric,
     dedicatedModels,
     crossRegionModels,
+    pricingByModel,
   } = useDashboard();
 
   const activeTab = useActiveTab();
@@ -74,10 +78,49 @@ const LatencyAccuracySection: React.FC = () => {
   const metricTab = useMetricTab();
 
   const latencyLabel = metric;
-  const scatterData = useMemo(
+  const baseScatterData = useMemo(
     () => getScatterData(metric),
     [getScatterData, metric]
   );
+
+  // AA-style "value" view: x flips from latency to normalized list price.
+  const [xMode, setXMode] = useState<"latency" | "price">("latency");
+  const priceModeAvailable = useMemo(
+    () =>
+      baseScatterData.some(
+        (p) => pricingByModel.get(p.model)?.normalized_usd != null
+      ),
+    [baseScatterData, pricingByModel]
+  );
+  const priced = xMode === "price" && priceModeAvailable;
+  const changeXMode = (mode: "latency" | "price") => {
+    if (mode === xMode) return;
+    capturePostHogEvent(POSTHOG_EVENTS.priceQualityToggleChanged, {
+      surface: `${activeTab}_dashboard`,
+      mode: activeTab,
+      axis: mode,
+    });
+    setXMode(mode);
+  };
+
+  // Price mode keeps only priced models; unpriced ones have no x to plot.
+  const scatterData = useMemo(
+    () =>
+      priced
+        ? baseScatterData.flatMap((p) => {
+            const price = pricingByModel.get(p.model)?.normalized_usd;
+            return price != null ? [{ ...p, x: price }] : [];
+          })
+        : baseScatterData,
+    [baseScatterData, priced, pricingByModel]
+  );
+  const xLabel = priced
+    ? `Price (${priceUnitShortLabel(activeTab)})`
+    : `Average ${latencyLabel}`;
+  const formatX = (value: number) =>
+    priced
+      ? formatUsd(value)
+      : `${parseFloat((Number(value) / 1000).toFixed(2))}s`;
 
   const isMobile = useMobileDetection();
   const sortedData = useMemo(
@@ -137,11 +180,17 @@ const LatencyAccuracySection: React.FC = () => {
     };
   }, [activePoint]);
 
-  const description = {
-    short: `Average ${latencyLabel} and WER per model`,
-    detailed:
-      "Every voice AI system faces a fundamental trade-off between speed and accuracy. Faster models might sacrifice precision to deliver quick responses, while more accurate models may take additional processing time to ensure correct results. Choose the model that offers the best balance for your specific use case.",
-  };
+  const description = priced
+    ? {
+        short: `List price and WER per model`,
+        detailed:
+          "The value view: what each point of accuracy costs. Prices are normalized published list rates (see the comparison table's price column for provenance); models without a published price drop out of this view. The frontier traces the best WER available at each price point.",
+      }
+    : {
+        short: `Average ${latencyLabel} and WER per model`,
+        detailed:
+          "Every voice AI system faces a fundamental trade-off between speed and accuracy. Faster models might sacrifice precision to deliver quick responses, while more accurate models may take additional processing time to ensure correct results. Choose the model that offers the best balance for your specific use case.",
+      };
 
   // Overall run-weighted average, matching the mean over all raw measurements
   const avgLatency = useMemo(() => {
@@ -157,6 +206,11 @@ const LatencyAccuracySection: React.FC = () => {
     return sum / totalRuns;
   }, [scatterData]);
 
+  const cheapest = useMemo(
+    () => scatterData.reduce((min, p) => Math.min(min, p.x), Infinity),
+    [scatterData]
+  );
+
   // Y domain rounded up to the next 2% step, ticks every 2%
   const { yMax, yTicks } = useMemo(() => {
     const maxWER = scatterData.reduce(
@@ -169,21 +223,34 @@ const LatencyAccuracySection: React.FC = () => {
     return { yMax: max, yTicks: ticks };
   }, [scatterData]);
 
-  // X ticks at a "nice" step computed from the data, domain rounded up to the last tick
-  const { xMax, xTicks } = useMemo(() => {
-    const maxLatency = scatterData.reduce(
+  // X ticks at a "nice" step computed from the data, domain rounded up to the
+  // last tick. A wide price spread (>50x) switches to a log scale with
+  // powers-of-ten ticks, so a $1 model doesn't flatten against a $100 one.
+  const { xMin, xMax, xTicks, logScale } = useMemo(() => {
+    const maxX = scatterData.reduce(
       (acc: number, item: ScatterDataPoint) => Math.max(acc, item.x),
       0
     );
-    const raw = (maxLatency * 1.05) / 5;
+    if (priced) {
+      const positive = scatterData.map((p) => p.x).filter((v) => v > 0);
+      const minX = positive.length ? Math.min(...positive) : 0;
+      if (minX > 0 && maxX / minX > 50) {
+        const lo = Math.pow(10, Math.floor(Math.log10(minX)));
+        const hi = Math.pow(10, Math.ceil(Math.log10(maxX)));
+        const ticks = [];
+        for (let t = lo; t <= hi; t *= 10) ticks.push(t);
+        return { xMin: lo, xMax: hi, xTicks: ticks, logScale: true };
+      }
+    }
+    const raw = (maxX * 1.05) / 5;
     const pow = Math.pow(10, Math.floor(Math.log10(raw || 1)));
     const step =
       [1, 2, 2.5, 5, 10].map((m) => m * pow).find((s) => s >= raw) ?? pow;
-    const max = Math.ceil((maxLatency * 1.05) / step) * step;
+    const max = Math.ceil((maxX * 1.05) / step) * step;
     const ticks = [];
     for (let t = 0; t <= max; t += step) ticks.push(t);
-    return { xMax: max, xTicks: ticks };
-  }, [scatterData]);
+    return { xMin: 0, xMax: max, xTicks: ticks, logScale: false };
+  }, [scatterData, priced]);
 
   // The non-dominated set is rarely convex, so a curve through every one of
   // its points would dip and flatten between them. The drawn curve is its
@@ -232,11 +299,11 @@ const LatencyAccuracySection: React.FC = () => {
     <div className="mb-4">
       <Card padding="p-5 lg:p-8">
         <SectionHeader
-          label="Latency vs Accuracy"
+          label={priced ? "Price vs Accuracy" : "Latency vs Accuracy"}
           description={description}
           note={metricAboutNote(metric)}
-          exportNote={metricTab}
-          exportXLabel={`Average ${latencyLabel}`}
+          exportNote={priced ? "price" : metricTab}
+          exportXLabel={xLabel}
           exportAnnotate={(clone) => {
             // A tapped point leaves crosshairs, an enlarged dot and dimmed
             // neighbors in the SVG; the export is selection-neutral, so strip
@@ -287,21 +354,52 @@ const LatencyAccuracySection: React.FC = () => {
               model: parseModelKey(model).model,
               provider,
               benchmark,
-              [`avg_${metric}_ms`]: x,
+              [priced
+                ? activeTab === "tts"
+                  ? "price_usd_per_1m_chars"
+                  : "price_usd_per_1k_min"
+                : `avg_${metric}_ms`]: x,
               avg_wer_percent: y,
               runs: count,
             }))
           }
-          stat={{
-            label: (
-              <MetricInfo metric={metric} align="right">{`Avg ${latencyLabel}`}</MetricInfo>
-            ),
-            value: `${avgLatency.toFixed(0)} ms`,
-          }}
+          stat={
+            priced
+              ? {
+                  label: "Cheapest shown",
+                  value: Number.isFinite(cheapest) ? formatUsd(cheapest) : "—",
+                }
+              : {
+                  label: (
+                    <MetricInfo metric={metric} align="right">{`Avg ${latencyLabel}`}</MetricInfo>
+                  ),
+                  value: `${avgLatency.toFixed(0)} ms`,
+                }
+          }
         />
 
-        <div className="flex flex-wrap items-center">
+        <div className="flex flex-wrap items-center gap-x-3">
           <MetricToggle />
+          {priceModeAvailable && (
+            <div className="mb-4 inline-flex gap-0.5 rounded-lg bg-surface-toggle-inactive p-0.5">
+              {(["latency", "price"] as const).map((m) => (
+                <button
+                  key={m}
+                  type="button"
+                  aria-pressed={xMode === m}
+                  onClick={() => changeXMode(m)}
+                  className={
+                    "rounded-md px-4 py-3 text-sm sm:px-3 sm:py-1 sm:text-xs font-medium transition-colors " +
+                    (xMode === m
+                      ? "bg-surface-primary text-text-primary shadow-sm"
+                      : "text-text-secondary hover:text-text-primary")
+                  }
+                >
+                  {m === "latency" ? "Latency vs WER" : "Price vs WER"}
+                </button>
+              ))}
+            </div>
+          )}
           <ul data-chart-legend className="mb-4 ml-auto flex items-center gap-4">
             <li
               className="flex items-center gap-1.5 whitespace-nowrap text-xs"
@@ -325,7 +423,7 @@ const LatencyAccuracySection: React.FC = () => {
           data-export-frame
           className="relative h-64 select-none"
           role="listbox"
-          aria-label={`Models by ${latencyLabel} and WER; arrow keys move between points`}
+          aria-label={`Models by ${priced ? "price" : latencyLabel} and WER; arrow keys move between points`}
           tabIndex={0}
           aria-activedescendant={
             activeIdx >= 0 ? `latency-scatter-point-${activeIdx}` : undefined
@@ -367,6 +465,7 @@ const LatencyAccuracySection: React.FC = () => {
                 }]}
                 activeTab={activeTab}
                 metric={metric}
+                xKind={priced ? "price" : "latency"}
                 dedicatedModels={dedicatedModels}
                 crossRegionModels={crossRegionModels}
               />
@@ -387,13 +486,15 @@ const LatencyAccuracySection: React.FC = () => {
               <XAxis
                 dataKey="x"
                 type="number"
-                name={latencyLabel}
-                domain={[0, xMax]}
+                name={priced ? "Price" : latencyLabel}
+                scale={logScale ? "log" : "linear"}
+                domain={[xMin, xMax]}
                 ticks={xTicks}
+                allowDataOverflow={logScale}
                 axisLine={false}
                 tickLine={false}
                 tick={{ fill: themeColors.axisText, fontSize: 12 }}
-                tickFormatter={(value) => `${parseFloat((Number(value) / 1000).toFixed(2))}s`}
+                tickFormatter={(value) => formatX(Number(value))}
               />
               <YAxis
                 dataKey="y"
@@ -413,6 +514,7 @@ const LatencyAccuracySection: React.FC = () => {
                     <CustomScatterTooltip
                       activeTab={activeTab}
                       metric={metric}
+                      xKind={priced ? "price" : "latency"}
                       dedicatedModels={dedicatedModels}
                       crossRegionModels={crossRegionModels}
                     />
@@ -478,7 +580,7 @@ const LatencyAccuracySection: React.FC = () => {
                         strokeWidth={2}
                         role="option"
                         aria-selected={props.payload === activePoint}
-                        aria-label={`${normalizeModelName(props.payload!.model)}: ${props.payload!.x.toFixed(0)}ms ${metric}, ${props.payload!.y.toFixed(1)}% WER${paretoData.includes(props.payload!) ? ", on Pareto frontier" : ""}`}
+                        aria-label={`${normalizeModelName(props.payload!.model)}: ${priced ? formatUsd(props.payload!.x) : `${props.payload!.x.toFixed(0)}ms ${metric}`}, ${props.payload!.y.toFixed(1)}% WER${paretoData.includes(props.payload!) ? ", on Pareto frontier" : ""}`}
                         onClick={() => setActiveIdx(idx)}
                       />
                     );
@@ -492,7 +594,11 @@ const LatencyAccuracySection: React.FC = () => {
           className="mt-1 text-center font-mono text-sm"
           style={{ color: themeColors.axisText }}
         >
-          <MetricInfo metric={metric}>{latencyLabel}</MetricInfo>
+          {priced ? (
+            xLabel
+          ) : (
+            <MetricInfo metric={metric}>{latencyLabel}</MetricInfo>
+          )}
         </div>
       </Card>
     </div>

--- a/web/components/dashboard/ModelComparisonSection.tsx
+++ b/web/components/dashboard/ModelComparisonSection.tsx
@@ -26,6 +26,8 @@ const ModelComparisonSection: React.FC = () => {
     werDatasetLoading,
     dedicatedModels,
     crossRegionModels,
+    pricingByModel,
+    page,
   } = useDashboard();
   const trackChartHover = useChartHoverTracking("heatmap");
   const [percentileIdx, setPercentileIdx] = useState(DEFAULT_PERCENTILE_IDX);
@@ -43,19 +45,32 @@ const ModelComparisonSection: React.FC = () => {
           }}
           note={metricAboutNote(activeMetric)}
           exportRows={() =>
-            data.map(({ model, latency, avgWER, werStdDev, sampleCount }) => ({
-              model: parseModelKey(model).model,
-              provider: getProviderForModel(model),
-              metric: activeMetric,
-              ...(latency
-                ? { [`latency_${percentile}_ms`]: latency[percentile] }
-                : {}),
-              ...(avgWER !== undefined
-                ? { avg_wer_percent: avgWER, wer_std_dev_percent: werStdDev }
-                : {}),
-              ...(werServedDataset ? { wer_dataset: werServedDataset } : {}),
-              runs: sampleCount,
-            }))
+            data.map(({ model, latency, avgWER, werStdDev, sampleCount }) => {
+              const pricing = pricingByModel.get(model);
+              const priceKey =
+                page === "tts" ? "price_usd_per_1m_chars" : "price_usd_per_1k_min";
+              return {
+                model: parseModelKey(model).model,
+                provider: getProviderForModel(model),
+                metric: activeMetric,
+                ...(latency
+                  ? { [`latency_${percentile}_ms`]: latency[percentile] }
+                  : {}),
+                ...(avgWER !== undefined
+                  ? { avg_wer_percent: avgWER, wer_std_dev_percent: werStdDev }
+                  : {}),
+                ...(werServedDataset ? { wer_dataset: werServedDataset } : {}),
+                ...(pricing?.normalized_usd != null
+                  ? {
+                      [priceKey]: pricing.normalized_usd,
+                      price_basis: pricing.basis,
+                      price_as_of: pricing.as_of,
+                      price_source: pricing.source_url,
+                    }
+                  : {}),
+                runs: sampleCount,
+              };
+            })
           }
           exportImage={false}
         />
@@ -67,6 +82,7 @@ const ModelComparisonSection: React.FC = () => {
           getProviderForModel={getProviderForModel}
           dedicatedModels={dedicatedModels}
           crossRegionModels={crossRegionModels}
+          pricingByModel={pricingByModel}
           percentileIdx={percentileIdx}
           onPercentileChange={setPercentileIdx}
           werLabel={werServedDataset ? datasetLabel(werServedDataset) : undefined}

--- a/web/components/dashboard/ModelComparisonTable.tsx
+++ b/web/components/dashboard/ModelComparisonTable.tsx
@@ -8,12 +8,15 @@ import { Globe, Server } from "lucide-react";
 import { useDedicatedInfoTip } from "@/components/shared/DedicatedInferenceInfo";
 import { REGION_CONTENT } from "@/components/shared/InferenceRegionInfo";
 import { LatencyPercentile, ModelHeatmapData } from "@/types/benchmark.types";
-import { normalizeModelName } from "@/lib/utils/formatters";
+import { formatUsd, normalizeModelName } from "@/lib/utils/formatters";
+import { priceUnitShortLabel } from "@/lib/utils/pricing";
+import { priceTooltipContent } from "@/components/shared/PriceInfo";
 import WerDatasetSelect from "@/components/dashboard/WerDatasetSelect";
 import { WER_BREAKDOWN_LABELS } from "@/lib/utils/werBreakdown";
 import { useActiveTab } from "@/hooks/useActiveTab";
 import { capturePostHogEvent } from "@/lib/posthog/client";
 import { POSTHOG_EVENTS } from "@/lib/posthog/events";
+import type { PricingEntry } from "@/lib/api/client";
 
 interface ModelComparisonTableProps {
   data: ModelHeatmapData[];
@@ -22,13 +25,15 @@ interface ModelComparisonTableProps {
   dedicatedModels?: Set<string>;
   /** Model key -> inference region, for models served outside our worker's region. */
   crossRegionModels?: Map<string, string>;
+  /** Model key -> normalized list price; column hidden when absent/empty. */
+  pricingByModel?: Map<string, PricingEntry>;
   percentileIdx: number;
   onPercentileChange: (idx: number) => void;
   werLabel?: string;
   werLoading?: boolean;
 }
 
-type ColumnKey = "latency" | "avgWER" | "sampleCount";
+type ColumnKey = "latency" | "avgWER" | "price" | "sampleCount";
 
 export const PERCENTILES: { key: LatencyPercentile; hint?: string }[] = [
   { key: "p0", hint: "fastest run" },
@@ -51,8 +56,66 @@ const COLUMNS: {
 }[] = [
   { key: "latency", label: "Latency", bestDirection: "asc" },
   { key: "avgWER", label: "Word error rate", bestDirection: "asc" },
+  { key: "price", label: "Price", bestDirection: "asc" },
   { key: "sampleCount", label: "Samples", bestDirection: "desc" }
 ];
+
+// Normalized list price with full provenance on hover/tap; unpriced models
+// degrade to a dash that says why.
+const PriceValue: React.FC<{
+  model: string;
+  entry: PricingEntry | undefined;
+  tab: "tts" | "stt" | "s2s";
+  handlersFor: (content: React.ReactNode) => React.DOMAttributes<HTMLElement>;
+}> = ({ model, entry, tab, handlersFor }) => {
+  const handlers = handlersFor(
+    entry ? (
+      priceTooltipContent(entry, tab)
+    ) : (
+      <span>Pricing not published by the provider.</span>
+    )
+  );
+  const tracked: React.DOMAttributes<HTMLElement> = {
+    ...handlers,
+    onClick: (e) => {
+      capturePostHogEvent(POSTHOG_EVENTS.pricingTooltipOpened, {
+        surface: `${tab}_dashboard`,
+        mode: tab,
+        model,
+        priced: entry != null
+      });
+      handlers.onClick?.(e as React.MouseEvent<HTMLElement>);
+    }
+  };
+  return (
+    <button
+      type="button"
+      aria-label={
+        entry?.normalized_usd != null
+          ? `${normalizeModelName(model)}: ${formatUsd(entry.normalized_usd)} ${priceUnitShortLabel(tab)}, details`
+          : `${normalizeModelName(model)}: pricing details`
+      }
+      className="cursor-help rounded-md p-1 -m-1 underline decoration-border-primary decoration-dotted underline-offset-4 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-text-tertiary/40"
+      {...tracked}
+    >
+      {entry?.normalized_usd != null ? (
+        <span className="font-mono text-base text-text-primary">
+          {formatUsd(entry.normalized_usd)}
+          {entry.basis === "list_price_measured_conversion" && (
+            <span
+              className="text-xs text-text-tertiary"
+              title="Converted with rates measured from our runs"
+            >
+              *
+            </span>
+          )}
+        </span>
+      ) : (
+        <span className="text-text-tertiary">—</span>
+      )}
+    </button>
+  );
+};
 
 // WER value with the error-type split on hover/tap when the API serves one.
 const WerValue: React.FC<{
@@ -105,6 +168,7 @@ const ModelComparisonTable: React.FC<ModelComparisonTableProps> = ({
   getProviderForModel,
   dedicatedModels,
   crossRegionModels,
+  pricingByModel,
   percentileIdx,
   onPercentileChange,
   werLabel,
@@ -131,9 +195,16 @@ const ModelComparisonTable: React.FC<ModelComparisonTableProps> = ({
 
   // Latency-only benchmarks (S2S) ship rows without WER; hide that column.
   const hasWER = useMemo(() => data.some((d) => d.avgWER !== undefined), [data]);
+  // No pricing data at all (endpoint down or nothing seeded) hides the column
+  // rather than rendering a dash for every row.
+  const hasPricing = (pricingByModel?.size ?? 0) > 0;
   const columns = useMemo(
-    () => (hasWER ? COLUMNS : COLUMNS.filter((c) => c.key !== "avgWER")),
-    [hasWER]
+    () =>
+      COLUMNS.filter(
+        (c) =>
+          (hasWER || c.key !== "avgWER") && (hasPricing || c.key !== "price")
+      ),
+    [hasWER, hasPricing]
   );
 
   // One pass per (data, percentile, sort) change: pull the selected latency
@@ -148,15 +219,21 @@ const ModelComparisonTable: React.FC<ModelComparisonTableProps> = ({
       .filter((v): v is number => v !== undefined);
     const werMin = Math.min(...werValues);
 
+    const priceValues = data
+      .map((d) => pricingByModel?.get(d.model)?.normalized_usd)
+      .filter((v): v is number => v != null);
+    const priceMin = Math.min(...priceValues);
+
     const rows = data
       .map((d) => {
         const latency = d.latency?.[percentile.key];
-        return { ...d, latency };
+        const price = pricingByModel?.get(d.model)?.normalized_usd ?? undefined;
+        return { ...d, latency, price };
       })
       .sort((a, b) => {
         const [av, bv] = [a[sort.key], b[sort.key]];
-        if (av === undefined || bv === undefined)
-          return (av === undefined ? 1 : 0) - (bv === undefined ? 1 : 0);
+        if (av == null || bv == null)
+          return (av == null ? 1 : 0) - (bv == null ? 1 : 0);
         const delta = av - bv;
         return sort.direction === "asc" ? delta : -delta;
       });
@@ -166,10 +243,11 @@ const ModelComparisonTable: React.FC<ModelComparisonTableProps> = ({
       best: {
         latency: latencyMin,
         avgWER: werMin,
+        price: priceMin,
         sampleCount: Math.max(...data.map((d) => d.sampleCount))
       }
     };
-  }, [data, percentile.key, sort]);
+  }, [data, percentile.key, sort, pricingByModel]);
 
   type Row = (typeof rows)[number];
 
@@ -181,12 +259,17 @@ const ModelComparisonTable: React.FC<ModelComparisonTableProps> = ({
             ? "desc"
             : "asc"
           : column.bestDirection;
-      capturePostHogEvent(POSTHOG_EVENTS.dashboardHeatmapSorted, {
-        surface: `${activeTab}_dashboard`,
-        mode: activeTab,
-        metric: column.key,
-        direction
-      });
+      capturePostHogEvent(
+        column.key === "price"
+          ? POSTHOG_EVENTS.pricingColumnSorted
+          : POSTHOG_EVENTS.dashboardHeatmapSorted,
+        {
+          surface: `${activeTab}_dashboard`,
+          mode: activeTab,
+          metric: column.key,
+          direction
+        }
+      );
       setSort({ key: column.key, direction });
     },
     [activeTab, sort]
@@ -269,7 +352,9 @@ const ModelComparisonTable: React.FC<ModelComparisonTableProps> = ({
                   >
                     {column.key === "latency"
                       ? `Latency (${percentile.key})`
-                      : column.label}
+                      : column.key === "price"
+                        ? `Price (${priceUnitShortLabel(activeTab)})`
+                        : column.label}
                     {sort.key === column.key && (
                       <span className="text-xs">
                         {sort.direction === "asc" ? "↑" : "↓"}
@@ -348,6 +433,17 @@ const ModelComparisonTable: React.FC<ModelComparisonTableProps> = ({
                         <span className="text-text-tertiary">—</span>
                       )}
                     </div>
+                  )}
+                {hasPricing &&
+                  cell(
+                    row,
+                    "price",
+                    <PriceValue
+                      model={row.model}
+                      entry={pricingByModel?.get(row.model)}
+                      tab={activeTab}
+                      handlersFor={infoTipHandlersFor}
+                    />
                   )}
                 {cell(
                   row,

--- a/web/components/dashboard/PriceHistorySection.tsx
+++ b/web/components/dashboard/PriceHistorySection.tsx
@@ -1,0 +1,176 @@
+// Copyright 2026 The Coval Benchmarks Authors
+// SPDX-License-Identifier: Apache-2.0
+
+"use client";
+
+import React, { useEffect, useMemo, useRef } from "react";
+import {
+  CartesianGrid,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import Card from "@/components/shared/Card";
+import SectionHeader from "@/components/shared/SectionHeader";
+import { useDashboard } from "@/contexts/DashboardContext";
+import { useActiveTab } from "@/hooks/useActiveTab";
+import { useThemeColors } from "@/hooks/useThemeColors";
+import { useChartHoverTracking } from "@/hooks/useChartHoverTracking";
+import { getModelColor } from "@/lib/utils/colors";
+import { formatDate, formatUsd, normalizeModelName, parseModelKey } from "@/lib/utils/formatters";
+import { priceUnitShortLabel } from "@/lib/utils/pricing";
+import { capturePostHogEvent } from "@/lib/posthog/client";
+import { POSTHOG_EVENTS } from "@/lib/posthog/events";
+
+interface HistorySeries {
+  model: string;
+  provider: string;
+  /** Real recorded points, oldest first. */
+  points: { t: number; price: number }[];
+  /** points + a synthetic "still effective now" tail for the step line. */
+  plotted: { t: number; price: number }[];
+}
+
+// Prices come from the append-only pricing table, so a model's history is its
+// full life of list rates; a step line is the honest shape (a rate holds until
+// superseded, it never drifts).
+const PriceHistorySection: React.FC = () => {
+  const { selectedModels, pricingByModel, getProviderForModel } = useDashboard();
+  const activeTab = useActiveTab();
+  const themeColors = useThemeColors();
+  const trackChartHover = useChartHoverTracking("price_history");
+
+  const series = useMemo<HistorySeries[]>(() => {
+    const now = Date.now();
+    return selectedModels.flatMap((model) => {
+      const entry = pricingByModel.get(model);
+      if (!entry) return [];
+      const points = entry.history
+        .filter((h) => h.normalized_usd != null)
+        .map((h) => ({ t: Date.parse(h.effective_at), price: h.normalized_usd! }))
+        .filter((p) => Number.isFinite(p.t))
+        .sort((a, b) => a.t - b.t);
+      const last = points[points.length - 1];
+      if (!last) return [];
+      return [
+        {
+          model,
+          provider: getProviderForModel(model),
+          points,
+          plotted: [...points, { t: now, price: last.price }],
+        },
+      ];
+    });
+  }, [selectedModels, pricingByModel, getProviderForModel]);
+
+  const changed = useMemo(() => series.filter((s) => s.points.length >= 2), [series]);
+  const hasHistory = changed.length > 0;
+
+  const viewTracked = useRef(false);
+  useEffect(() => {
+    if (!hasHistory || viewTracked.current) return;
+    viewTracked.current = true;
+    capturePostHogEvent(POSTHOG_EVENTS.priceHistoryViewed, {
+      surface: `${activeTab}_dashboard`,
+      mode: activeTab,
+      models_with_changes: changed.length,
+    });
+  }, [hasHistory, changed.length, activeTab]);
+
+  // No pricing feature at all on this board — no card either.
+  if (pricingByModel.size === 0) return null;
+
+  const unit = priceUnitShortLabel(activeTab);
+
+  return (
+    <div className="mb-4">
+      <Card padding="p-5 lg:p-8" onMouseEnter={trackChartHover}>
+        <SectionHeader
+          label="Price History"
+          description={{
+            short: `List price over time (${unit})`,
+            detailed:
+              "Every published rate change we record, as a step line: a price holds until the provider supersedes it. Prices are normalized list rates with full provenance in the comparison table's price column.",
+          }}
+          exportXLabel="Effective date"
+          exportRows={() =>
+            changed.flatMap(({ model, provider, points }) =>
+              points.map((p) => ({
+                model: parseModelKey(model).model,
+                provider,
+                [activeTab === "tts" ? "price_usd_per_1m_chars" : "price_usd_per_1k_min"]:
+                  p.price,
+                effective_at: new Date(p.t).toISOString(),
+              }))
+            )
+          }
+          exportImage={hasHistory}
+        />
+        {hasHistory ? (
+          <div data-export-frame className="h-64">
+            <ResponsiveContainer width="100%" height="100%" debounce={200}>
+              <LineChart margin={{ top: 10, right: 8, left: 0, bottom: 0 }}>
+                <CartesianGrid stroke={themeColors.grid} strokeDasharray="2 2" />
+                <XAxis
+                  dataKey="t"
+                  type="number"
+                  scale="time"
+                  domain={["dataMin", "dataMax"]}
+                  axisLine={false}
+                  tickLine={false}
+                  tick={{ fill: themeColors.axisText, fontSize: 12 }}
+                  tickFormatter={(t) => formatDate(Number(t))}
+                />
+                <YAxis
+                  width={56}
+                  domain={[0, "auto"]}
+                  axisLine={false}
+                  tickLine={false}
+                  tick={{ fill: themeColors.axisText, fontSize: 12 }}
+                  tickFormatter={(v) => formatUsd(Number(v))}
+                />
+                <Tooltip
+                  isAnimationActive={false}
+                  labelFormatter={(t) => formatDate(Number(t))}
+                  formatter={(value, name) => [
+                    `${formatUsd(Number(value))} ${unit}`,
+                    normalizeModelName(String(name)),
+                  ]}
+                  contentStyle={{
+                    backgroundColor: "var(--color-surface-tooltip)",
+                    border: "1px solid var(--color-border-secondary)",
+                    borderRadius: "8px",
+                    color: "var(--color-text-on-tooltip)",
+                  }}
+                />
+                {changed.map(({ model, plotted }) => (
+                  <Line
+                    key={model}
+                    data={plotted}
+                    dataKey="price"
+                    name={model}
+                    type="stepAfter"
+                    stroke={getModelColor(model)}
+                    strokeWidth={2}
+                    dot={{ r: 3, fill: getModelColor(model) }}
+                    isAnimationActive={false}
+                  />
+                ))}
+              </LineChart>
+            </ResponsiveContainer>
+          </div>
+        ) : (
+          <p className="flex h-24 items-center justify-center text-sm text-text-tertiary">
+            No price changes recorded yet — every selected model has held its
+            current list rate.
+          </p>
+        )}
+      </Card>
+    </div>
+  );
+};
+
+export default PriceHistorySection;

--- a/web/components/overview/AboutMethodology.tsx
+++ b/web/components/overview/AboutMethodology.tsx
@@ -71,6 +71,21 @@ const SECTIONS: MethodologySection[] = [
       "The runner, the dataset manifests, and the methodology docs are all open source, and every audio file is checked against its SHA-256 hash on fetch. Every number on this site can be reproduced straight from the repository.",
     ],
   },
+  {
+    title: "Pricing",
+    summary:
+      "Published list prices, normalized to one unit per board so models are comparable at a glance — with the source linked on every number.",
+    terms: [
+      { code: "$/1k min", tag: "STT", name: "Normalized unit", def: "USD per 1,000 minutes of audio (also used for speech-to-speech)" },
+      { code: "$/1M chars", tag: "TTS", name: "Normalized unit", def: "USD per 1 million input characters" },
+      { code: "as of", name: "Provenance", def: "every price carries the date it was verified and a link to the provider's public pricing page" },
+      { code: "*", name: "Measured conversion", def: "token- and per-second-billed rates converted with usage rates measured from our own runs over the trailing 7 days" },
+    ],
+    details: [
+      "Every price on this site is the provider's published list rate, stored in its native billing unit — per minute, per hour, per character, or per token — and normalized for display to USD per 1,000 minutes of audio (speech-to-text, speech-to-speech) or USD per 1M characters (text-to-speech). Duration- and character-billed rates convert arithmetically. Token-billed models convert through how many tokens a minute of audio actually costs, measured continuously from our own benchmark runs rather than sampled once; prices derived this way carry a marker, and a model without enough recent samples shows its native rates with no normalized number instead of an estimate.",
+      "Providers that only sell subscriptions or credits are normalized under a stated plan assumption: the lowest-upfront plan that realistically supports 1,000 minutes per month (speech-to-text) or 1M characters per month (text-to-speech). The assumption is spelled out in the price tooltip. Models with no published price show a dash — we never guess. Price changes are detected automatically from providers' pricing pages, applied with a verbatim quote and page snapshot as evidence, and reviewed by a human when large or uncertain; the price history chart shows every recorded change.",
+    ],
+  },
 ];
 
 const MethodologyRow: React.FC<{ section: MethodologySection }> = ({ section }) => {

--- a/web/components/overview/OverviewLeaderboards.tsx
+++ b/web/components/overview/OverviewLeaderboards.tsx
@@ -4,15 +4,18 @@
 "use client";
 
 import React, { useMemo } from "react";
-import { useAggregatesQuery, useProvidersQuery } from "@/lib/api/queries";
+import { useAggregatesQuery, usePricingQuery, useProvidersQuery } from "@/lib/api/queries";
 import { buildTagIndex, dedicatedModelKeys } from "@/lib/utils/facets";
 import {
+  formatUsd,
   normalizeModelName,
   normalizeS2SProviderName,
   normalizeSTTProviderName,
   normalizeTTSProviderName,
   toModelKey,
 } from "@/lib/utils/formatters";
+import { priceUnitShortLabel } from "@/lib/utils/pricing";
+import type { PricingApiResponse } from "@/lib/api/client";
 import { S2S_MULTITURN_DATASET } from "@/lib/config/datasets";
 import type { ModelStatEntry, ProvidersApiResponse } from "@/lib/api/client";
 import { disabledModelKeys } from "@/lib/utils/modelsFromResults";
@@ -51,6 +54,24 @@ function toRows(
 
 const windowBadge = (window: TimeWindow): string => `Last ${WINDOW_LABELS[window]}`;
 
+// Cheapest normalized list price, ranked ascending. Prices are window-free
+// (list rates, not measurements), so the badge carries the unit instead.
+function toPriceRows(
+  pricing: PricingApiResponse | undefined,
+  normalizeProvider: (p: string) => string
+): LeaderboardRow[] {
+  return (pricing?.entries ?? [])
+    .filter((e) => e.normalized_usd != null)
+    .sort((a, b) => a.normalized_usd! - b.normalized_usd!)
+    .slice(0, TOP_N)
+    .map((e) => ({
+      key: toModelKey(e.provider, e.model),
+      model: normalizeModelName(toModelKey(e.provider, e.model)),
+      provider: normalizeProvider(e.provider),
+      value: formatUsd(e.normalized_usd!),
+    }));
+}
+
 // Dedicated-inference endpoints stay off these shared-latency rankings, and
 // disabled (retired/pending) models still present in the window's stats too.
 const excludedKeys = (
@@ -78,6 +99,9 @@ const OverviewLeaderboards: React.FC = () => {
     dataset: S2S_MULTITURN_DATASET,
   });
   const providersQuery = useProvidersQuery();
+  const ttsPricing = usePricingQuery("TTS");
+  const sttPricing = usePricingQuery("STT");
+  const s2sPricing = usePricingQuery("S2S");
   const windowDataStale =
     ttsQuery.isPlaceholderData ||
     sttQuery.isPlaceholderData ||
@@ -182,6 +206,42 @@ const OverviewLeaderboards: React.FC = () => {
           error={s2sQuery.isError || providersQuery.isError}
         />
       </div>
+      {/* Cheapest by normalized list price. Hidden entirely (never an error
+          card) while pricing has nothing to rank — the latency cards above
+          are the page's core. */}
+      {(toPriceRows(ttsPricing.data, normalizeTTSProviderName).length > 0 ||
+        toPriceRows(sttPricing.data, normalizeSTTProviderName).length > 0 ||
+        toPriceRows(s2sPricing.data, normalizeS2SProviderName).length > 0) && (
+        <div className="mt-4 grid grid-cols-1 gap-4 lg:grid-cols-3">
+          <LeaderboardCard
+            title="Cheapest Text-to-Speech"
+            metricLabel="List price"
+            windowLabel={priceUnitShortLabel("tts")}
+            rows={toPriceRows(ttsPricing.data, normalizeTTSProviderName)}
+            href="/tts"
+            loading={ttsPricing.isLoading}
+            error={ttsPricing.isError}
+          />
+          <LeaderboardCard
+            title="Cheapest Speech-to-Text"
+            metricLabel="List price"
+            windowLabel={priceUnitShortLabel("stt")}
+            rows={toPriceRows(sttPricing.data, normalizeSTTProviderName)}
+            href="/stt"
+            loading={sttPricing.isLoading}
+            error={sttPricing.isError}
+          />
+          <LeaderboardCard
+            title="Cheapest Speech-to-Speech"
+            metricLabel="List price"
+            windowLabel={priceUnitShortLabel("s2s")}
+            rows={toPriceRows(s2sPricing.data, normalizeS2SProviderName)}
+            href="/s2s"
+            loading={s2sPricing.isLoading}
+            error={s2sPricing.isError}
+          />
+        </div>
+      )}
     </div>
   );
 };

--- a/web/components/shared/PriceInfo.tsx
+++ b/web/components/shared/PriceInfo.tsx
@@ -6,6 +6,13 @@ import type { PricingEntry } from "@/lib/api/client";
 import { formatUsd, normalizeModelName, toModelKey } from "@/lib/utils/formatters";
 import { billingUnitLabel, priceUnitShortLabel } from "@/lib/utils/pricing";
 
+// Provenance URLs are provider-controlled data by way of the collector;
+// only http(s) may become a navigable link (defense-in-depth against a
+// malformed or malicious scheme ever reaching the table).
+function isHttpUrl(value: string): boolean {
+  return /^https?:\/\//i.test(value);
+}
+
 /**
  * The one provenance body every displayed price carries (AA convention):
  * native rate(s), derivation basis, plan assumption, as-of date, source link.
@@ -59,15 +66,19 @@ export function priceTooltipContent(
       )}
       <span className="block pt-1 opacity-80">
         as of {entry.as_of} ·{" "}
-        <a
-          href={entry.source_url}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="underline underline-offset-2"
-          onClick={(e) => e.stopPropagation()}
-        >
-          provider pricing page
-        </a>
+        {isHttpUrl(entry.source_url) ? (
+          <a
+            href={entry.source_url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline underline-offset-2"
+            onClick={(e) => e.stopPropagation()}
+          >
+            provider pricing page
+          </a>
+        ) : (
+          <span>{entry.source_url}</span>
+        )}
       </span>
     </>
   );

--- a/web/components/shared/PriceInfo.tsx
+++ b/web/components/shared/PriceInfo.tsx
@@ -1,0 +1,74 @@
+// Copyright 2026 The Coval Benchmarks Authors
+// SPDX-License-Identifier: Apache-2.0
+
+import React from "react";
+import type { PricingEntry } from "@/lib/api/client";
+import { formatUsd, normalizeModelName, toModelKey } from "@/lib/utils/formatters";
+import { billingUnitLabel, priceUnitShortLabel } from "@/lib/utils/pricing";
+
+/**
+ * The one provenance body every displayed price carries (AA convention):
+ * native rate(s), derivation basis, plan assumption, as-of date, source link.
+ * The link is reachable once the host tooltip is pinned (tap/click).
+ */
+export function priceTooltipContent(
+  entry: PricingEntry,
+  tab: "tts" | "stt" | "s2s"
+): React.ReactNode {
+  const conversion = entry.conversion;
+  const measured = entry.basis === "list_price_measured_conversion";
+  return (
+    <>
+      <span className="font-semibold">
+        {normalizeModelName(toModelKey(entry.provider, entry.model))}:{" "}
+        {entry.normalized_usd != null
+          ? `${formatUsd(entry.normalized_usd)} ${priceUnitShortLabel(tab)}`
+          : "no normalized price"}
+      </span>
+      {entry.native_rates.map((rate) => (
+        <span key={rate.billing_unit} className="block opacity-80">
+          List rate: {formatUsd(rate.rate_usd)} {billingUnitLabel(rate.billing_unit)}
+        </span>
+      ))}
+      {measured && (
+        <span className="block opacity-80">
+          * Converted with rates measured from our runs
+          {conversion
+            ? ` (${[
+                conversion.in_tokens_per_min != null &&
+                  `${Math.round(conversion.in_tokens_per_min)} in-tokens/min`,
+                conversion.out_tokens_per_min != null &&
+                  `${Math.round(conversion.out_tokens_per_min)} out-tokens/min`,
+                conversion.chars_per_sec != null &&
+                  `${conversion.chars_per_sec.toFixed(1)} chars/s`,
+              ]
+                .filter(Boolean)
+                .join(", ")}, ${conversion.window} window)`
+            : ""}
+        </span>
+      )}
+      {entry.normalized_usd == null && (
+        <span className="block opacity-80">
+          Normalizing needs usage measured from our runs; not enough samples yet.
+        </span>
+      )}
+      {entry.native_rates.some((r) => r.plan_assumption) && (
+        <span className="block opacity-80">
+          Plan assumption: {entry.native_rates.find((r) => r.plan_assumption)?.plan_assumption}
+        </span>
+      )}
+      <span className="block pt-1 opacity-80">
+        as of {entry.as_of} ·{" "}
+        <a
+          href={entry.source_url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="underline underline-offset-2"
+          onClick={(e) => e.stopPropagation()}
+        >
+          provider pricing page
+        </a>
+      </span>
+    </>
+  );
+}

--- a/web/hooks/useDashboardState.tsx
+++ b/web/hooks/useDashboardState.tsx
@@ -37,7 +37,8 @@ import { getModelColor } from "@/lib/utils/colors";
 import { werBreakdownOf } from "@/lib/utils/werBreakdown";
 import { metricDescriptions } from "@/lib/config/metrics";
 import { S2S_MULTITURN_DATASET } from "@/lib/config/datasets";
-import { useAggregatesQuery, useProvidersQuery } from "@/lib/api/queries";
+import { useAggregatesQuery, usePricingQuery, useProvidersQuery } from "@/lib/api/queries";
+import { buildPricingMap } from "@/lib/utils/pricing";
 import { useDatasetScopedWer } from "@/hooks/useDatasetScopedWer";
 import { useTimeWindow } from "@/hooks/useTimeWindow";
 import type { BarDataPoint, ModelStats } from "@/types/benchmark.types";
@@ -96,6 +97,14 @@ export function useDashboardState(page: "tts" | "stt" | "s2s") {
     dataset: page === "s2s" ? S2S_MULTITURN_DATASET : undefined,
   });
   const providersQuery = useProvidersQuery();
+
+  // List prices for the price column / value chart. A pricing outage never
+  // blocks the dashboard — surfaces just degrade to "—".
+  const pricingQuery = usePricingQuery(benchmarkParam);
+  const pricingByModel = useMemo(
+    () => buildPricingMap(pricingQuery.data?.entries),
+    [pricingQuery.data]
+  );
 
   // STT only: pin the WER column to one dataset (null = pooled across all).
   const [werDataset, setWerDataset] = useState<string | null>(null);
@@ -745,6 +754,9 @@ export function useDashboardState(page: "tts" | "stt" | "s2s") {
     toggleLegendModel,
     dedicatedModels,
     crossRegionModels,
+
+    // List prices (model key -> PricingEntry)
+    pricingByModel,
 
     // UI state
     isMobile,

--- a/web/lib/api/client.ts
+++ b/web/lib/api/client.ts
@@ -61,6 +61,9 @@ export type ModelStatEntry = components["schemas"]["ModelStatEntry"];
 export type SeriesPoint = components["schemas"]["SeriesPoint"];
 export type RunsApiResponse = components["schemas"]["RunsResponse"];
 export type RunOut = components["schemas"]["RunOut"];
+export type PricingApiResponse = components["schemas"]["PricingResponse"];
+export type PricingEntry = components["schemas"]["PricingEntry"];
+export type PriceHistoryPoint = components["schemas"]["PriceHistoryPoint"];
 
 // Query-param types from codegen
 export type AggregatesQueryParams = NonNullable<
@@ -143,6 +146,15 @@ export async function getAggregatesByDataset(
     `/v1/results/aggregates/by-dataset${qs}`,
     { signal: opts?.signal }
   );
+}
+
+export async function getPricing(
+  benchmark: "STT" | "TTS" | "S2S",
+  opts?: FetchOptions
+): Promise<PricingApiResponse> {
+  return request<PricingApiResponse>(`/v1/pricing?benchmark=${benchmark}`, {
+    signal: opts?.signal,
+  });
 }
 
 export async function getRuns(opts?: FetchOptions): Promise<RunsApiResponse> {

--- a/web/lib/api/queries.ts
+++ b/web/lib/api/queries.ts
@@ -8,6 +8,7 @@ import { keepPreviousData, useQueries, useQuery } from "@tanstack/react-query";
 import {
   getAggregates,
   getAggregatesByDataset,
+  getPricing,
   getProviders,
   getRuns,
   getS2SSample,
@@ -52,6 +53,19 @@ export function useProvidersQuery() {
     queryKey: ["providers"],
     queryFn: ({ signal }: { signal: AbortSignal }) =>
       getProviders({ signal } satisfies FetchOptions),
+  });
+}
+
+// Prices change on the weekly collector cadence at most; an hour of staleness
+// is invisible while sparing every navigation a refetch.
+const PRICING_STALE_MS = 60 * 60 * 1000;
+
+export function usePricingQuery(benchmark: "STT" | "TTS" | "S2S") {
+  return useQuery({
+    queryKey: ["pricing", benchmark],
+    queryFn: ({ signal }: { signal: AbortSignal }) =>
+      getPricing(benchmark, { signal } satisfies FetchOptions),
+    staleTime: PRICING_STALE_MS,
   });
 }
 

--- a/web/lib/config/metrics.ts
+++ b/web/lib/config/metrics.ts
@@ -51,9 +51,9 @@ export const metricDescriptions = {
   pareto: {
     short: "Pareto frontier",
     tooltip:
-      "The dashed line traces the best WER you can get at each latency budget. Bright dots earn their spot: nothing beats them on speed and accuracy at once. Every faded dot loses on both counts to some bright one.",
+      "The dashed line traces the best WER you can get at each budget on the x-axis — latency or price, whichever the toggle shows. Bright dots earn their spot: nothing beats them on both axes at once. Every faded dot loses on both counts to some bright one.",
     detailed:
-      "Speed and accuracy pull against each other, and the dashed line shows what the trade actually costs: follow it to read the best WER on offer at each latency budget. A straight stretch of the line is reachable too — split traffic between the models at its two ends. Bright models are the ones nothing beats on both axes at once, even where the line cuts below them. Faded models are beaten outright by a bright one, so picking them only makes sense for reasons this chart can't see, like price or language coverage."
+      "The two axes pull against each other, and the dashed line shows what the trade actually costs: follow it to read the best WER on offer at each latency or price budget. A straight stretch of the line is reachable too — split traffic between the models at its two ends. Bright models are the ones nothing beats on both axes at once, even where the line cuts below them. Faded models are beaten outright by a bright one on this pair of axes — flip the toggle to see whether they win on the other one, since a latency-dominated model can still be the value pick and vice versa. Only factors like language coverage stay off the chart entirely."
   },
   // Shared by the Latency Variation card's description and its headline tooltip.
   iqr: {

--- a/web/lib/posthog/events.ts
+++ b/web/lib/posthog/events.ts
@@ -25,7 +25,11 @@ export const POSTHOG_EVENTS = {
   s2sSamplePlaybackEnded: "s2s_sample_playback_ended",
   s2sSampleTickChanged: "s2s_sample_tick_changed",
   s2sSampleSeeked: "s2s_sample_seeked",
-  headerCovalLinkClicked: "header_coval_link_clicked"
+  headerCovalLinkClicked: "header_coval_link_clicked",
+  pricingColumnSorted: "pricing_column_sorted",
+  pricingTooltipOpened: "pricing_tooltip_opened",
+  priceQualityToggleChanged: "price_quality_toggle_changed",
+  priceHistoryViewed: "price_history_viewed"
 } as const;
 
 export type PostHogSurface =
@@ -43,7 +47,8 @@ export type DashboardChartId =
   | "wer_radar"
   | "box_plot"
   | "heatmap"
-  | "performance_delta";
+  | "performance_delta"
+  | "price_history";
 export type PlaygroundRunTrigger = "button" | "keyboard";
 export type PlaygroundModeSwitchTrigger = "tab" | "keyboard";
 // The quality bar plots WER on STT/TTS and instruction adherence on S2S; the

--- a/web/lib/utils/formatters.ts
+++ b/web/lib/utils/formatters.ts
@@ -12,6 +12,24 @@
  * `Intl.DateTimeFormat` defaults to the runtime timezone when none is given, so
  * axes reflect the viewer's local time unless a `timeZone` is supplied.
  */
+/**
+ * Format a USD amount with sensible significant figures and no trailing noise:
+ * $0.42, $12.50, $1,240. Sub-$10 keeps cents-level precision (3 sig figs for
+ * tiny normalized prices like $0.0048), $10-$1000 keeps cents, above that
+ * whole dollars with thousands separators.
+ */
+export function formatUsd(value: number): string {
+  const abs = Math.abs(value);
+  if (abs === 0) return "$0";
+  const opts: Intl.NumberFormatOptions =
+    abs >= 1000
+      ? { maximumFractionDigits: 0 }
+      : abs >= 0.1
+        ? { minimumFractionDigits: 2, maximumFractionDigits: 2 }
+        : { maximumSignificantDigits: 3 };
+  return `$${value.toLocaleString("en-US", opts)}`;
+}
+
 export function formatTime(timestamp: number, timeZone?: string): string {
   return new Date(timestamp).toLocaleTimeString(undefined, {
     hour: "2-digit",

--- a/web/lib/utils/pricing.test.ts
+++ b/web/lib/utils/pricing.test.ts
@@ -1,0 +1,50 @@
+// Copyright 2026 The Coval Benchmarks Authors
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+import { buildPricingMap, priceUnitShortLabel } from "./pricing";
+import { formatUsd } from "./formatters";
+import type { PricingEntry } from "@/lib/api/client";
+
+const entry = (provider: string, model: string): PricingEntry => ({
+  provider,
+  model,
+  normalized_usd: 6,
+  basis: "list_price",
+  native_rates: [{ billing_unit: "per_minute", rate_usd: 0.006 }],
+  as_of: "2026-08-06",
+  source_url: "https://example.com/pricing",
+  history: [],
+});
+
+describe("buildPricingMap", () => {
+  it("keys entries by the app-wide provider:model composite", () => {
+    const map = buildPricingMap([entry("deepgram", "nova-3")]);
+    expect(map.get("deepgram:nova-3")?.normalized_usd).toBe(6);
+    expect(map.size).toBe(1);
+  });
+
+  it("returns an empty map for undefined input", () => {
+    expect(buildPricingMap(undefined).size).toBe(0);
+  });
+});
+
+describe("priceUnitShortLabel", () => {
+  it("uses chars for TTS and minutes elsewhere", () => {
+    expect(priceUnitShortLabel("tts")).toBe("$/1M chars");
+    expect(priceUnitShortLabel("stt")).toBe("$/1k min");
+    expect(priceUnitShortLabel("s2s")).toBe("$/1k min");
+  });
+});
+
+describe("formatUsd", () => {
+  it("keeps sensible significant figures with no trailing noise", () => {
+    expect(formatUsd(0.42)).toBe("$0.42");
+    expect(formatUsd(12.5)).toBe("$12.50");
+    expect(formatUsd(1240)).toBe("$1,240");
+    expect(formatUsd(0.0048)).toBe("$0.0048");
+    expect(formatUsd(0.6)).toBe("$0.60");
+    expect(formatUsd(6)).toBe("$6.00");
+    expect(formatUsd(0)).toBe("$0");
+  });
+});

--- a/web/lib/utils/pricing.ts
+++ b/web/lib/utils/pricing.ts
@@ -1,0 +1,35 @@
+// Copyright 2026 The Coval Benchmarks Authors
+// SPDX-License-Identifier: Apache-2.0
+
+import type { PricingEntry } from "@/lib/api/client";
+import { toModelKey } from "@/lib/utils/formatters";
+
+/** O(1) price joins for chart/table hooks, keyed the app-wide "provider:model" way. */
+export function buildPricingMap(
+  entries: readonly PricingEntry[] | undefined
+): Map<string, PricingEntry> {
+  const map = new Map<string, PricingEntry>();
+  for (const entry of entries ?? []) {
+    map.set(toModelKey(entry.provider, entry.model), entry);
+  }
+  return map;
+}
+
+/** Column/axis label for the benchmark's display unit (AA convention). */
+export function priceUnitShortLabel(tab: "tts" | "stt" | "s2s"): string {
+  return tab === "tts" ? "$/1M chars" : "$/1k min";
+}
+
+/** Human wording of a native billing unit for tooltips. */
+export function billingUnitLabel(unit: string): string {
+  const labels: Record<string, string> = {
+    per_minute: "per minute",
+    per_second: "per second",
+    per_hour: "per hour",
+    per_1m_chars: "per 1M characters",
+    per_1m_tokens_input: "per 1M input tokens",
+    per_1m_tokens_output: "per 1M output tokens",
+    per_request: "per request",
+  };
+  return labels[unit] ?? unit;
+}

--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -13,6 +13,10 @@ const allowedDevOrigins = (process.env.NEXT_ALLOWED_DEV_ORIGINS ?? "")
   .filter(Boolean);
 
 const proxyApiTarget = process.env.BENCH_PROXY_API?.replace(/\/$/, "");
+// Optional split-target for /v1/pricing only: lets a dev preview serve live
+// production benchmark data while the pricing store (not yet deployed there)
+// comes from a local API. Rewrites are ordered, so the specific rule wins.
+const proxyPricingTarget = process.env.BENCH_PROXY_PRICING_API?.replace(/\/$/, "");
 
 const nextConfig: NextConfig = {
   reactStrictMode: true,
@@ -26,7 +30,17 @@ const nextConfig: NextConfig = {
   ...(proxyApiTarget
     ? {
         async rewrites() {
-          return [{ source: "/proxy-api/:path*", destination: `${proxyApiTarget}/:path*` }];
+          return [
+            ...(proxyPricingTarget
+              ? [
+                  {
+                    source: "/proxy-api/v1/pricing",
+                    destination: `${proxyPricingTarget}/v1/pricing`,
+                  },
+                ]
+              : []),
+            { source: "/proxy-api/:path*", destination: `${proxyApiTarget}/:path*` },
+          ];
         },
       }
     : {}),


### PR DESCRIPTION
Stacked on #463. Closes the BENCH-631 epic; go-live steps in docs/pricing-go-live.md (migrate+seed prod BEFORE merging — auto-deploy race; web deploys after the API — build-time codegen).

AA-style price display, joined by the provider:model key from the new `usePricing` hook (1h staleTime; a pricing outage degrades every surface to a dash — verified live against an API serving 404 on /v1/pricing). Comparison table gains a sortable Price column ($/1k min on STT/S2S, $/1M chars on TTS, nulls last) with full provenance in the tooltip (native rates, plan assumption, measured-conversion detail + * marker, as-of date, source link) and price columns in the CSV export. Latency-vs-Accuracy gains the Price-vs-WER toggle (frontier recomputed on the price axis, log scale past 50× spread); new PriceHistorySection step-lines recorded rate changes with a quiet empty state; /overview gains cheapest-model cards + a Pricing methodology accordion; four pricing PostHog events. Also: env-gated split-proxy dev mode (`BENCH_PROXY_PRICING_API`) used to verify the UI against live production benchmark data joined with the exact rows prod will be seeded with.

115 web tests + build + tsc green; verified live in both themes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds normalized pricing throughout the benchmark web experience and aligns seeded token-rate rows to a shared effective period.
- Adds sortable pricing and provenance to model comparisons and CSV exports.
- Adds price-versus-WER Pareto views, price-history charts, and overview cheapest-model cards.
- Adds pricing queries, model-key joins, formatting helpers, analytics events, and an optional development pricing proxy.
- Updates the pricing seed workflow and production go-live runbook.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with one non-blocking recommendation to restrict pricing provenance links to HTTP(S) URLs.

The pricing joins and history grouping are internally consistent, and current pricing writers provide static HTTPS source URLs; the remaining concern is hardening the new link against malformed or future dynamically sourced values.

**Files Needing Attention:** web/components/shared/PriceInfo.tsx

<details open><summary><h3>Security Review</h3></summary>

The new provenance link accepts an unrestricted API URL as its href. Current writers use static HTTPS literals, but validating the scheme would keep malformed or future dynamic pricing data from becoming an executable link.
</details>

<sub>Reviews (1): Last reviewed commit: ["\[BENCH-631\] Runbook: pre-merge migrate+s..."](https://github.com/coval-ai/benchmarks/commit/2f22171b00ee2c0f85b288eb7445ec42a32deea8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50943198)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Web Dashboard (STT/TTS/S2S + Overview)](https://app.greptile.com/coval/-/custom-context/knowledge-base/coval-ai/benchmarks/-/docs/web-dashboard.md)
- Knowledge Base — [Runner Orchestration](https://app.greptile.com/coval/-/custom-context/knowledge-base/coval-ai/benchmarks/-/docs/runner-orchestration.md)

<!-- /greptile_comment -->