### PR TITLE
Add Hakim AI TTS provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,6 +42,7 @@ LMNT_API_KEY=
 FLUXIONS_API_KEY=
 DEEPDUB_API_KEY=
 MURFAI_API_KEY=
+HAKIMAI_API_KEY=
 
 # --- API (optional) ---
 # Benchmarking-team key: requests with X-Internal-Key equal to this value see

--- a/runner/src/coval_bench/config.py
+++ b/runner/src/coval_bench/config.py
@@ -101,6 +101,7 @@ class Settings(BaseSettings):
     palabra_api_key: SecretStr | None = None
     lmnt_api_key: SecretStr | None = None
     murfai_api_key: SecretStr | None = None
+    hakimai_api_key: SecretStr | None = None
     modulate_api_key: SecretStr | None = None
     speechify_api_key: SecretStr | None = None
     fluxions_api_key: SecretStr | None = None

--- a/runner/src/coval_bench/providers/tts/__init__.py
+++ b/runner/src/coval_bench/providers/tts/__init__.py
@@ -26,6 +26,7 @@ from coval_bench.providers.tts.fishaudio import FishAudioTTSProvider
 from coval_bench.providers.tts.fluxions import FluxionsTTSProvider
 from coval_bench.providers.tts.gradium import GradiumTTSProvider
 from coval_bench.providers.tts.groq import GroqTTSProvider
+from coval_bench.providers.tts.hakim import HakimTTSProvider
 from coval_bench.providers.tts.inworld import InworldTTSProvider
 from coval_bench.providers.tts.lmnt import LmntTTSProvider
 from coval_bench.providers.tts.minimax import MinimaxTTSProvider
@@ -75,6 +76,7 @@ TTS_PROVIDERS: dict[str, type[TTSProvider]] = {
     "lmnt": LmntTTSProvider,
     "deepdub": DeepdubTTSProvider,
     "murf": MurfTTSProvider,
+    "hakim": HakimTTSProvider,
 }
 
 if HumeTTSProvider is not None:
@@ -94,6 +96,7 @@ __all__ = [
     "FishAudioTTSProvider",
     "FluxionsTTSProvider",
     "GradiumTTSProvider",
+    "HakimTTSProvider",
     "LmntTTSProvider",
     "MinimaxTTSProvider",
     "MurfTTSProvider",

--- a/runner/src/coval_bench/providers/tts/hakim.py
+++ b/runner/src/coval_bench/providers/tts/hakim.py
@@ -1,15 +1,7 @@
 # Copyright 2026 The Coval Benchmarks Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Hakim AI TTS provider — WebSocket streaming via the realtime speech API.
-
-Wire protocol on wss://api.tryhakim.ai/v1/audio/speech/stream (Bearer auth at
-the handshake): send one ``speech.create`` → audio arrives as binary
-PCM-S16LE frames (24 kHz mono) between the matching ``speech.started`` /
-``speech.done`` JSON frames. Errors arrive as ``error`` frames with a stable
-``code``; lifecycle frames (``session.created``, ``session.usage``) interleave
-and carry no audio.
-"""
+"""Hakim AI TTS provider — WebSocket streaming via the realtime speech API."""
 
 from __future__ import annotations
 
@@ -30,7 +22,6 @@ _VALID_MODELS = ("hakim-fast-v1",)
 _WS_URL = "wss://api.tryhakim.ai/v1/audio/speech/stream"
 _SAMPLE_RATE = 24000
 
-# How many trailing non-audio frames to retain for the silent-stream diagnostic.
 _LAST_FRAMES_KEPT = 3
 
 
@@ -97,8 +88,6 @@ class HakimTTSProvider(TTSProvider):
                         done = True
                         break
 
-                # A clean close before ``speech.done`` is a truncated stream; audio
-                # collected so far must not be scored as a complete synthesis.
                 if not done:
                     raise RuntimeError("connection closed before the speech.done frame")
 

--- a/runner/src/coval_bench/providers/tts/hakim.py
+++ b/runner/src/coval_bench/providers/tts/hakim.py
@@ -1,0 +1,128 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Hakim AI TTS provider — WebSocket streaming via the realtime speech API.
+
+Wire protocol on wss://api.tryhakim.ai/v1/audio/speech/stream (Bearer auth at
+the handshake): send one ``speech.create`` → audio arrives as binary
+PCM-S16LE frames (24 kHz mono) between the matching ``speech.started`` /
+``speech.done`` JSON frames. Errors arrive as ``error`` frames with a stable
+``code``; lifecycle frames (``session.created``, ``session.usage``) interleave
+and carry no audio.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from typing import Any
+
+import structlog
+import websockets.asyncio.client as ws_client
+
+from coval_bench.config import Settings
+from coval_bench.providers.base import TTSProvider, TTSResult
+from coval_bench.providers.tts._common import finalize_tts_result
+
+logger: structlog.BoundLogger = structlog.get_logger(__name__)
+
+_VALID_MODELS = ("hakim-fast-v1",)
+_WS_URL = "wss://api.tryhakim.ai/v1/audio/speech/stream"
+_SAMPLE_RATE = 24000
+
+# How many trailing non-audio frames to retain for the silent-stream diagnostic.
+_LAST_FRAMES_KEPT = 3
+
+
+class HakimTTSProvider(TTSProvider):
+    """Hakim AI TTS provider using the realtime WebSocket API (binary PCM frames)."""
+
+    def __init__(self, settings: Settings, model: str, voice: str) -> None:
+        if model not in _VALID_MODELS:
+            raise ValueError(f"Invalid Hakim TTS model {model!r}. Valid: {_VALID_MODELS}")
+        if not voice:
+            raise ValueError("Hakim TTS requires a voice")
+        self._model = model
+        self._voice = voice
+
+        api_key_secret = settings.hakimai_api_key
+        if api_key_secret is None:
+            raise ValueError("hakimai_api_key is required in Settings")
+        self._api_key = api_key_secret.get_secret_value()
+
+    @property
+    def name(self) -> str:
+        return f"hakim-{self._model}"
+
+    @property
+    def model(self) -> str:
+        return self._model
+
+    async def synthesize(self, text: str) -> TTSResult:
+        audio_chunks: list[bytes] = []
+        last_frames: list[str] = []
+        start: float | None = None
+        first_chunk_at: float | None = None
+        done = False
+
+        request = {
+            "type": "speech.create",
+            "input": text,
+            "model": self._model,
+            "voice": self._voice,
+        }
+
+        try:
+            async with ws_client.connect(
+                _WS_URL, additional_headers={"Authorization": f"Bearer {self._api_key}"}
+            ) as ws:
+                start = time.monotonic()
+                await ws.send(json.dumps(request))
+
+                async for raw in ws:
+                    if isinstance(raw, bytes):
+                        if raw:
+                            if first_chunk_at is None:
+                                first_chunk_at = time.monotonic()
+                            audio_chunks.append(raw)
+                        continue
+
+                    frame: dict[str, Any] = json.loads(raw)
+                    if frame.get("type") == "error":
+                        code = frame.get("code") or "error"
+                        raise RuntimeError(f"hakim {code}: {frame.get('message')}")
+                    last_frames.append(raw)
+                    del last_frames[:-_LAST_FRAMES_KEPT]
+                    if frame.get("type") == "speech.done":
+                        done = True
+                        break
+
+                # A clean close before ``speech.done`` is a truncated stream; audio
+                # collected so far must not be scored as a complete synthesis.
+                if not done:
+                    raise RuntimeError("connection closed before the speech.done frame")
+
+        except Exception as exc:
+            logger.warning("hakim_tts_error", provider="hakim", model=self._model, exc_info=exc)
+            return finalize_tts_result(
+                provider="hakim",
+                model=self._model,
+                voice=self._voice,
+                pcm=b"",
+                sample_rate=_SAMPLE_RATE,
+                audio_synthesis_start=start,
+                first_audio_chunk_at=first_chunk_at,
+                last_frames=last_frames,
+                error=str(exc),
+            )
+
+        return finalize_tts_result(
+            provider="hakim",
+            model=self._model,
+            voice=self._voice,
+            pcm=b"".join(audio_chunks),
+            sample_rate=_SAMPLE_RATE,
+            audio_synthesis_start=start,
+            first_audio_chunk_at=first_chunk_at,
+            last_frames=last_frames,
+        )

--- a/runner/src/coval_bench/providers/tts/hakim.py
+++ b/runner/src/coval_bench/providers/tts/hakim.py
@@ -21,6 +21,7 @@ logger: structlog.BoundLogger = structlog.get_logger(__name__)
 _VALID_MODELS = ("hakim-fast-v1",)
 _WS_URL = "wss://api.tryhakim.ai/v1/audio/speech/stream"
 _SAMPLE_RATE = 24000
+_CFG = 3
 
 _LAST_FRAMES_KEPT = 3
 
@@ -37,7 +38,7 @@ class HakimTTSProvider(TTSProvider):
         self._voice = voice
 
         api_key_secret = settings.hakimai_api_key
-        if api_key_secret is None:
+        if api_key_secret is None or not api_key_secret.get_secret_value():
             raise ValueError("hakimai_api_key is required in Settings")
         self._api_key = api_key_secret.get_secret_value()
 
@@ -61,6 +62,7 @@ class HakimTTSProvider(TTSProvider):
             "input": text,
             "model": self._model,
             "voice": self._voice,
+            "cfg": _CFG,
         }
 
         try:

--- a/runner/src/coval_bench/registries/models.py
+++ b/runner/src/coval_bench/registries/models.py
@@ -817,8 +817,6 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         status=_EARLY_ACCESS,
         arena_enabled=False,
     ),
-    # Hakim AI (tryhakim.ai), Arabic-first realtime TTS. Voices are preset
-    # slugs from GET /v1/audio/voices: the en-US conversational pair.
     RegisteredModel(
         benchmark=_TTS,
         provider="hakim",

--- a/runner/src/coval_bench/registries/models.py
+++ b/runner/src/coval_bench/registries/models.py
@@ -817,6 +817,18 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         status=_EARLY_ACCESS,
         arena_enabled=False,
     ),
+    # Hakim AI (tryhakim.ai), Arabic-first realtime TTS. Voices are preset
+    # slugs from GET /v1/audio/voices: the en-US conversational pair.
+    RegisteredModel(
+        benchmark=_TTS,
+        provider="hakim",
+        model="hakim-fast-v1",
+        voice="amelia-en-us",
+        voices=("amelia-en-us", "noah-en-us"),
+        tags=(_STREAMING, _MULTI, _CLONE),
+        status=_EARLY_ACCESS,
+        arena_enabled=False,
+    ),
     # gpt-realtime is a speech-to-speech LLM, not a TTS provider: driving it
     # from a text "instructions" prompt folds LLM inference into TTFA and never
     # guarantees verbatim speech, so its metrics are incomparable here. Kept

--- a/runner/src/coval_bench/registries/provider_keys.py
+++ b/runner/src/coval_bench/registries/provider_keys.py
@@ -40,6 +40,7 @@ PROVIDER_ENV: dict[str, str] = {
     "speechify": "SPEECHIFY_API_KEY",
     "lmnt": "LMNT_API_KEY",
     "murf": "MURFAI_API_KEY",
+    "hakim": "HAKIMAI_API_KEY",
     "fluxions": "FLUXIONS_API_KEY",
     "deepdub": "DEEPDUB_API_KEY",
 }

--- a/runner/tests/providers/tts/test_hakim.py
+++ b/runner/tests/providers/tts/test_hakim.py
@@ -93,6 +93,7 @@ async def test_hakim_tts_url_auth_and_frames(hakim_settings: Settings) -> None:
             "input": "Hello world",
             "model": _MODEL,
             "voice": _VOICE,
+            "cfg": 3,
         }
     ]
     if result.audio_path is not None:
@@ -197,6 +198,19 @@ def test_hakim_tts_missing_key_raises() -> None:
         dataset_id="stt-v1",
         runner_sha="test",
         log_level="DEBUG",
+    )
+    with pytest.raises(ValueError, match="hakimai_api_key"):
+        HakimTTSProvider(settings, model=_MODEL, voice=_VOICE)
+
+
+def test_hakim_tts_empty_key_raises() -> None:
+    settings = Settings(
+        database_url="postgresql://runner:password@localhost:5432/benchmarks",
+        dataset_bucket="test-bucket",
+        dataset_id="stt-v1",
+        runner_sha="test",
+        log_level="DEBUG",
+        hakimai_api_key="",
     )
     with pytest.raises(ValueError, match="hakimai_api_key"):
         HakimTTSProvider(settings, model=_MODEL, voice=_VOICE)

--- a/runner/tests/providers/tts/test_hakim.py
+++ b/runner/tests/providers/tts/test_hakim.py
@@ -1,0 +1,208 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the Hakim AI WebSocket streaming TTS provider."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+from coval_bench.config import Settings
+from coval_bench.providers.tts.hakim import HakimTTSProvider
+
+from .conftest import FakeWebSocket, make_pcm_bytes
+
+_MODEL = "hakim-fast-v1"
+_VOICE = "amelia-en-us"
+
+
+def _settings() -> Settings:
+    return Settings(
+        database_url="postgresql://runner:password@localhost:5432/benchmarks",
+        dataset_bucket="test-bucket",
+        dataset_id="stt-v1",
+        runner_sha="test",
+        log_level="DEBUG",
+        hakimai_api_key="test-hakim-key",
+    )
+
+
+def _events(pcm_chunks: list[bytes]) -> list[str | bytes]:
+    events: list[str | bytes] = [
+        json.dumps({"type": "session.created", "session_id": "sess_1"}),
+        json.dumps({"type": "speech.started", "sample_rate": 24000, "channels": 1}),
+    ]
+    events.extend(pcm_chunks)
+    events.append(json.dumps({"type": "speech.done", "usage": {"units": 11}}))
+    return events
+
+
+@pytest.fixture()
+def hakim_settings() -> Settings:
+    return _settings()
+
+
+@pytest.mark.asyncio
+async def test_hakim_tts_happy_path(hakim_settings: Settings) -> None:
+    ws = FakeWebSocket(_events([make_pcm_bytes(240)]))
+    provider = HakimTTSProvider(hakim_settings, model=_MODEL, voice=_VOICE)
+
+    with patch("coval_bench.providers.tts.hakim.ws_client.connect", return_value=ws):
+        result = await provider.synthesize("Hello from Hakim")
+
+    assert result.error is None, f"Unexpected error: {result.error}"
+    assert result.ttfa_ms is not None
+    assert 0 < result.ttfa_ms < 60_000
+    assert result.audio_path is not None
+    assert result.audio_path.exists()
+    assert result.audio_path.read_bytes()[:4] == b"RIFF"
+    assert result.provider == "hakim"
+    assert result.model == _MODEL
+    assert result.voice == _VOICE
+    result.audio_path.unlink()
+
+
+@pytest.mark.asyncio
+async def test_hakim_tts_url_auth_and_frames(hakim_settings: Settings) -> None:
+    ws = FakeWebSocket(_events([make_pcm_bytes(240)]))
+    captured: dict[str, object] = {}
+
+    def connect_side_effect(url: str, **kwargs: object) -> FakeWebSocket:
+        captured["url"] = url
+        captured["headers"] = kwargs.get("additional_headers")
+        return ws
+
+    provider = HakimTTSProvider(hakim_settings, model=_MODEL, voice=_VOICE)
+
+    with patch(
+        "coval_bench.providers.tts.hakim.ws_client.connect",
+        side_effect=connect_side_effect,
+    ):
+        result = await provider.synthesize("Hello world")
+
+    assert result.error is None
+    assert captured["url"] == "wss://api.tryhakim.ai/v1/audio/speech/stream"
+    assert captured["headers"] == {"Authorization": "Bearer test-hakim-key"}
+    sent = [json.loads(m) for m in ws.sent if isinstance(m, str)]
+    assert sent == [
+        {
+            "type": "speech.create",
+            "input": "Hello world",
+            "model": _MODEL,
+            "voice": _VOICE,
+        }
+    ]
+    if result.audio_path is not None:
+        result.audio_path.unlink()
+
+
+@pytest.mark.asyncio
+async def test_hakim_tts_error_frame(hakim_settings: Settings) -> None:
+    events: list[str | bytes] = [
+        json.dumps({"type": "session.created", "session_id": "sess_1"}),
+        json.dumps({"type": "error", "code": "voice_not_found", "message": "no such voice"}),
+    ]
+    ws = FakeWebSocket(events)
+    provider = HakimTTSProvider(hakim_settings, model=_MODEL, voice=_VOICE)
+
+    with patch("coval_bench.providers.tts.hakim.ws_client.connect", return_value=ws):
+        result = await provider.synthesize("Hello")
+
+    assert result.error is not None
+    assert "voice_not_found" in result.error
+    assert result.audio_path is None
+    assert result.ttfa_ms is None
+
+
+@pytest.mark.asyncio
+async def test_hakim_tts_truncated_stream_is_error(hakim_settings: Settings) -> None:
+    events: list[str | bytes] = [
+        json.dumps({"type": "session.created", "session_id": "sess_1"}),
+        json.dumps({"type": "speech.started", "sample_rate": 24000, "channels": 1}),
+        make_pcm_bytes(240),
+    ]
+    ws = FakeWebSocket(events)
+    provider = HakimTTSProvider(hakim_settings, model=_MODEL, voice=_VOICE)
+
+    with patch("coval_bench.providers.tts.hakim.ws_client.connect", return_value=ws):
+        result = await provider.synthesize("Hello")
+
+    assert result.error is not None
+    assert "speech.done" in result.error
+    assert result.audio_path is None
+
+
+@pytest.mark.asyncio
+async def test_hakim_tts_ignores_lifecycle_frames(hakim_settings: Settings) -> None:
+    events: list[str | bytes] = [
+        json.dumps({"type": "session.created", "session_id": "sess_1"}),
+        json.dumps({"type": "speech.started", "sample_rate": 24000, "channels": 1}),
+        make_pcm_bytes(240),
+        json.dumps({"type": "session.usage", "session_characters": 5}),
+        make_pcm_bytes(240),
+        json.dumps({"type": "speech.done", "usage": {"units": 5}}),
+    ]
+    ws = FakeWebSocket(events)
+    provider = HakimTTSProvider(hakim_settings, model=_MODEL, voice=_VOICE)
+
+    with patch("coval_bench.providers.tts.hakim.ws_client.connect", return_value=ws):
+        result = await provider.synthesize("Hello")
+
+    assert result.error is None
+    assert result.ttfa_ms is not None
+    assert result.audio_path is not None
+    result.audio_path.unlink()
+
+
+@pytest.mark.asyncio
+async def test_hakim_tts_ttfa_on_first_binary_frame(hakim_settings: Settings) -> None:
+    chunks = [make_pcm_bytes(240), make_pcm_bytes(240), make_pcm_bytes(240)]
+    ws = FakeWebSocket(_events(chunks))
+    provider = HakimTTSProvider(hakim_settings, model=_MODEL, voice=_VOICE)
+
+    times = iter([0.0, 0.1])
+
+    with (
+        patch(
+            "coval_bench.providers.tts.hakim.time.monotonic",
+            side_effect=lambda: next(times, 10.0),
+        ),
+        patch("coval_bench.providers.tts.hakim.ws_client.connect", return_value=ws),
+    ):
+        result = await provider.synthesize("Hello")
+
+    assert result.error is None
+    assert result.ttfa_ms == pytest.approx(100.0)
+    assert result.audio_path is not None
+    result.audio_path.unlink()
+
+
+def test_hakim_tts_invalid_model_raises(hakim_settings: Settings) -> None:
+    with pytest.raises(ValueError, match="Invalid Hakim TTS model"):
+        HakimTTSProvider(hakim_settings, model="hakim-v2", voice=_VOICE)
+
+
+def test_hakim_tts_missing_voice_raises(hakim_settings: Settings) -> None:
+    with pytest.raises(ValueError, match="requires a voice"):
+        HakimTTSProvider(hakim_settings, model=_MODEL, voice="")
+
+
+def test_hakim_tts_missing_key_raises() -> None:
+    settings = Settings(
+        database_url="postgresql://runner:password@localhost:5432/benchmarks",
+        dataset_bucket="test-bucket",
+        dataset_id="stt-v1",
+        runner_sha="test",
+        log_level="DEBUG",
+    )
+    with pytest.raises(ValueError, match="hakimai_api_key"):
+        HakimTTSProvider(settings, model=_MODEL, voice=_VOICE)
+
+
+def test_hakim_tts_provider_name(hakim_settings: Settings) -> None:
+    provider = HakimTTSProvider(hakim_settings, model=_MODEL, voice=_VOICE)
+    assert provider.name == "hakim-hakim-fast-v1"
+    assert provider.model == _MODEL


### PR DESCRIPTION
Registers Hakim's hakim-fast-v1 streaming model as early access with an en-US voice pool, synthesized over their realtime WebSocket, hidden from the arena until HAKIMAI_API_KEY is mounted in infra.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds the Hakim AI realtime WebSocket TTS provider and registers its English voices as early access.
- Adds Hakim credential configuration and provider-key mapping.
- Implements PCM streaming, completion/error handling, and TTS result finalization.
- Registers `hakim-fast-v1` with two en-US voices and adds provider tests.

<h3>Confidence Score: 4/5</h3>

The scheduled-run failure caused by enabling Hakim before its credential is mounted should be fixed before merging.

EARLY_ACCESS entries participate in normal scheduled benchmarks, so an absent HAKIMAI_API_KEY makes every Hakim item fail during provider construction and turns otherwise healthy runs partial.

**Files Needing Attention:** runner/src/coval_bench/registries/models.py

<sub>Reviews (1): Last reviewed commit: ["Add Hakim AI TTS provider"](https://github.com/coval-ai/benchmarks/commit/df753dcfb8d61a70ce90ded5d54e401c0d374e27) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50965682)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Runner Orchestration](https://app.greptile.com/coval/-/custom-context/knowledge-base/coval-ai/benchmarks/-/docs/runner-orchestration.md)

<!-- /greptile_comment -->