### PR TITLE
[BENCH-639] Fix Latency vs Accuracy tooltip close overlap

### DIFF
--- a/web/components/dashboard/LatencyAccuracySection.tsx
+++ b/web/components/dashboard/LatencyAccuracySection.tsx
@@ -343,7 +343,7 @@ const LatencyAccuracySection: React.FC = () => {
         >
           {activePoint && (
             <div
-              className={`absolute top-2 z-10 max-w-[40%] text-xs ${
+              className={`absolute top-2 z-10 max-w-[calc(40%+2.75rem)] pr-11 text-xs md:max-w-[calc(40%+1.75rem)] md:pr-7 ${
                 activePoint.x > xMax / 2 ? "left-12" : "right-2"
               }`}
               onPointerDown={(e) => e.stopPropagation()}
@@ -352,7 +352,7 @@ const LatencyAccuracySection: React.FC = () => {
                 type="button"
                 aria-label="Close model details"
                 onClick={() => setActiveIdx(-1)}
-                className="absolute -right-2 -top-2 z-10 flex h-11 w-11 items-center justify-center rounded-full bg-surface-toggle-inactive text-lg text-text-secondary"
+                className="absolute right-0 top-0 z-10 flex h-11 w-11 items-center justify-center rounded-full bg-surface-toggle-inactive text-lg leading-none text-text-secondary hover:text-text-primary md:right-2 md:top-2 md:h-5 md:w-5 md:text-xs"
               >
                 ×
               </button>


### PR DESCRIPTION
## Summary
<img width="248" height="232" alt="Screenshot 2026-08-07 at 9 34 59 AM" src="https://github.com/user-attachments/assets/fa6533ca-d69c-4126-b101-dee617c3a5e2" />
<img width="137" height="80" alt="Screenshot 2026-08-07 at 9 35 15 AM" src="https://github.com/user-attachments/assets/e7a6284b-48fe-4a13-8515-a3639e7d50b8" />

- keep the pinned tooltip close control outside the tooltip text
- use a compact close button on desktop while preserving a 44×44 touch target on mobile
- retain the tooltip’s usable content width without covering the selected chart point

## Root cause

The 44×44 close button was absolutely positioned over a tooltip that reserved no space for it, obscuring the model and provider lines.

## Validation

- `pnpm exec eslint components/dashboard/LatencyAccuracySection.tsx`
- `pnpm exec tsc --noEmit`
- `pnpm test` — 111 tests passed
- visually verified at desktop and 390px mobile widths

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adjusts the pinned Latency vs Accuracy tooltip layout so its close control no longer overlaps tooltip text.
- Reserves responsive horizontal space for the close control while preserving the tooltip’s prior content-width allowance.
- Keeps a 44×44 mobile touch target and switches to a compact 20×20 desktop control.
- Adds responsive positioning, line-height, and hover styling for the close button.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable defects identified.

The wrapper’s added maximum width matches its new responsive right padding, preserving the previous usable content width while placing the mobile and desktop close controls inside the reserved area.

<sub>Reviews (1): Last reviewed commit: ["Fix scatter tooltip close button overlap"](https://github.com/coval-ai/benchmarks/commit/915347e99a1f55e348f1eaeefed8fc1a5fcbd1ff) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51228067)</sub>

<!-- /greptile_comment -->