### PR TITLE
Keep a recording's signed URL out of the failure log

### DIFF
--- a/runner/src/coval_bench/s2s/samples.py
+++ b/runner/src/coval_bench/s2s/samples.py
@@ -161,14 +161,35 @@ async def _sims_by_test_case(client: httpx.AsyncClient, coval_run_id: str) -> di
 async def _download_recording(
     client: httpx.AsyncClient, download_client: httpx.AsyncClient, sim_id: str
 ) -> bytes | None:
-    """Recording bytes via the presigned URL; None when the object is gone."""
+    """Recording bytes via the presigned URL; None when the object is gone.
+
+    The download failure is raised by hand rather than through
+    ``blob.raise_for_status()``: that message embeds the whole URL, and the
+    signature in the query string is the credential granting read access to the
+    recording. The caller logs the failure with ``exc_info``, so the message
+    reaches Cloud Logging verbatim. Only the query is dropped — host and object
+    path say which backend refused which recording, and neither is secret.
+    Still an ``HTTPStatusError``: the retry in ``_fetch_retry`` keys on
+    ``httpx.HTTPError``.
+
+    Assumes Coval signs ``audio_url`` the way GCS and S3 do, with the signature
+    in the query string. A CDN that signs by path token instead would put the
+    credential in a path segment, which this keeps — revisit if the recordings
+    ever move off object storage.
+    """
     url_resp = await client.get(f"/simulations/{sim_id}/audio")
     if url_resp.status_code == 404:
         return None
     url_resp.raise_for_status()
     audio_url = cast("str", url_resp.json()["audio_url"])
     blob = await download_client.get(audio_url)
-    blob.raise_for_status()
+    if blob.is_error:
+        raise httpx.HTTPStatusError(
+            f"recording download for {sim_id} failed: HTTP {blob.status_code} "
+            f"from {blob.request.url.copy_with(query=None, userinfo=b'')}",
+            request=blob.request,
+            response=blob,
+        )
     return blob.content
 
 

--- a/runner/src/coval_bench/s2s/samples.py
+++ b/runner/src/coval_bench/s2s/samples.py
@@ -183,7 +183,7 @@ async def _download_recording(
     url_resp.raise_for_status()
     audio_url = cast("str", url_resp.json()["audio_url"])
     blob = await download_client.get(audio_url)
-    if blob.is_error:
+    if not blob.is_success:
         raise httpx.HTTPStatusError(
             f"recording download for {sim_id} failed: HTTP {blob.status_code} "
             f"from {blob.request.url.copy_with(query=None, userinfo=b'')}",

--- a/runner/tests/unit/test_s2s_samples.py
+++ b/runner/tests/unit/test_s2s_samples.py
@@ -464,8 +464,13 @@ def test_conversation_turns_coerces_offsets() -> None:
     ]
 
 
+# 302 as well as 502: the download client does not follow redirects, so an
+# unfollowed 3xx carries an empty body that would otherwise publish as audio.
+@pytest.mark.parametrize("status", [502, 302])
 @pytest.mark.asyncio
-async def test_failed_recording_download_keeps_the_signature_out_of_the_error() -> None:
+async def test_failed_recording_download_keeps_the_signature_out_of_the_error(
+    status: int,
+) -> None:
     """The error names the object but not the signature — the caller logs it verbatim."""
     signature = "3a9fSECRETSIGNATURE"
     signed = f"https://blobs.test/recordings/sim-1.wav?X-Goog-Signature={signature}"
@@ -474,7 +479,7 @@ async def test_failed_recording_download_keeps_the_signature_out_of_the_error() 
         return httpx.Response(200, json={"audio_url": signed})
 
     def blobs(request: httpx.Request) -> httpx.Response:
-        return httpx.Response(502, text="upstream unavailable")
+        return httpx.Response(status, headers={"Location": "https://elsewhere.test/x.wav"})
 
     async with (
         httpx.AsyncClient(
@@ -489,5 +494,5 @@ async def test_failed_recording_download_keeps_the_signature_out_of_the_error() 
     assert signature not in message
     assert "?" not in message
     assert "https://blobs.test/recordings/sim-1.wav" in message
-    assert "502" in message
+    assert str(status) in message
     assert "sim-1" in message

--- a/runner/tests/unit/test_s2s_samples.py
+++ b/runner/tests/unit/test_s2s_samples.py
@@ -462,3 +462,32 @@ def test_conversation_turns_coerces_offsets() -> None:
         (None, None),
         (None, None),
     ]
+
+
+@pytest.mark.asyncio
+async def test_failed_recording_download_keeps_the_signature_out_of_the_error() -> None:
+    """The error names the object but not the signature — the caller logs it verbatim."""
+    signature = "3a9fSECRETSIGNATURE"
+    signed = f"https://blobs.test/recordings/sim-1.wav?X-Goog-Signature={signature}"
+
+    def api(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"audio_url": signed})
+
+    def blobs(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(502, text="upstream unavailable")
+
+    async with (
+        httpx.AsyncClient(
+            base_url="https://api.test/v1", transport=httpx.MockTransport(api)
+        ) as client,
+        httpx.AsyncClient(transport=httpx.MockTransport(blobs)) as download_client,
+    ):
+        with pytest.raises(httpx.HTTPStatusError) as caught:
+            await samples._download_recording(client, download_client, "sim-1")
+
+    message = str(caught.value)
+    assert signature not in message
+    assert "?" not in message
+    assert "https://blobs.test/recordings/sim-1.wav" in message
+    assert "502" in message
+    assert "sim-1" in message


### PR DESCRIPTION
Context: a failed recording download raised httpx's own error, whose message embeds the full URL. That URL is presigned,the query-string signature grants read access to the recording,  and the caller logs with `exc_info`, so it reached Cloud Logging.

Now raised by hand with the query stripped: `recording download for sim-1 failed: HTTP 502 from https://blobs.test/recordings/sim-1.wav`. Simulation, status, backend and object all survive, and it stays an `HTTPStatusError` so the retry is unchanged.


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR replaces HTTPX's default recording-download status error with a manually constructed `HTTPStatusError` whose message omits URL query credentials while retaining useful diagnostics and existing retry semantics.

- Sanitizes query strings and user information in failed recording-download messages.
- Preserves the original request and response on the raised exception.
- Adds a unit test covering signature removal, status, simulation ID, and object URL diagnostics.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no blocking or non-blocking issues identified.

The manually raised exception retains the original HTTP error type, request, response, status, and diagnostic URL path while its logged message excludes the presigned query credential.

<sub>Reviews (1): Last reviewed commit: ["Keep a recording&#39;s signed URL out of the..."](https://github.com/coval-ai/benchmarks/commit/27a16b31bfae385fa07b4eb80c3ca143f36673ca) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51258473)</sub>

**Context used:**

- Knowledge Base — [Runner Orchestration](https://app.greptile.com/coval/-/custom-context/knowledge-base/coval-ai/benchmarks/-/docs/runner-orchestration.md)

<!-- /greptile_comment -->