### PR TITLE
Send Murf's falcon-2 as FALCON on the wire

### DIFF
--- a/runner/src/coval_bench/providers/tts/murf.py
+++ b/runner/src/coval_bench/providers/tts/murf.py
@@ -21,7 +21,8 @@ from coval_bench.providers.tts._common import finalize_tts_result
 logger: structlog.BoundLogger = structlog.get_logger(__name__)
 
 _VALID_MODELS = ("falcon-2",)
-_WS_URL = "wss://global.api.murf.ai/v1/speech/stream-input"
+_WIRE_MODELS = {"falcon-2": "FALCON"}
+_WS_URL = "wss://us-east.api.murf.ai/v1/speech/stream-input"
 _SAMPLE_RATE = 24000
 
 
@@ -57,7 +58,7 @@ class MurfTTSProvider(TTSProvider):
         query = urlencode(
             {
                 "api-key": self._api_key,
-                "model": self._model,
+                "model": _WIRE_MODELS[self._model],
                 "sample_rate": _SAMPLE_RATE,
                 "channel_type": "MONO",
                 "format": "PCM",

--- a/runner/tests/providers/tts/test_murf.py
+++ b/runner/tests/providers/tts/test_murf.py
@@ -84,11 +84,11 @@ async def test_murf_tts_url_and_frames(murf_settings: Settings) -> None:
     assert result.error is None
     parts = urlsplit(captured["url"])
     assert parts.scheme == "wss"
-    assert parts.netloc == "global.api.murf.ai"
+    assert parts.netloc == "us-east.api.murf.ai"
     assert parts.path == "/v1/speech/stream-input"
     assert parse_qs(parts.query) == {
         "api-key": ["test-murf-key"],
-        "model": ["falcon-2"],
+        "model": ["FALCON"],
         "sample_rate": ["24000"],
         "channel_type": ["MONO"],
         "format": ["PCM"],


### PR DESCRIPTION
Murf's us-east cluster silently falls back to Gen2 on the docs' falcon-2 spelling, so the provider now sends the SDK's FALCON enum and pins us-east again.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR corrects Murf Falcon 2 requests by translating the repository model identifier to the provider’s `FALCON` wire value and restoring the `us-east` WebSocket endpoint.
- Adds an explicit internal-to-wire model mapping.
- Updates URL construction and focused tests for the regional host and wire model value.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the changed request values covered by focused tests and consistent with the provider’s existing model validation.

The only synthesis-reachable Murf model is `falcon-2`, its new wire mapping is complete, and the endpoint and query-string expectations are tested.

<sub>Reviews (1): Last reviewed commit: ["Send Murf&#39;s falcon-2 as FALCON on the wi..."](https://github.com/coval-ai/benchmarks/commit/4db6e94f38a75251bf66bf81eb710d4f93b7d744) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51279563)</sub>

**Context used:**

- Knowledge Base — [Runner Orchestration](https://app.greptile.com/coval/-/custom-context/knowledge-base/coval-ai/benchmarks/-/docs/runner-orchestration.md)
- Knowledge Base — [Methodology](https://app.greptile.com/coval/-/custom-context/knowledge-base/coval-ai/benchmarks/-/docs/methodology.md)

<!-- /greptile_comment -->