### PR TITLE
Delete mislabeled Murf Gen2 results

### DIFF
--- a/runner/src/coval_bench/db/migrations/versions/20260807_0015_delete_murf_gen2_rows.py
+++ b/runner/src/coval_bench/db/migrations/versions/20260807_0015_delete_murf_gen2_rows.py
@@ -1,0 +1,47 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Delete Murf rows recorded before falcon-2 was actually served.
+
+Murf's us-east cluster silently substitutes Gen2 when it does not recognise
+the requested model value, so every ``murf/falcon-2`` row scheduled before
+2026-08-07 20:00 UTC measured Gen2 under falcon-2's key. They misstate the
+model's latency several-fold and would pollute its aggregates, so they are
+removed rather than annotated.
+
+``results`` carries no timestamp of its own; the cutoff is applied through
+the owning run's ``scheduled_at``. ``results_by_bucket`` is keyed by
+``bucket_at`` directly. The per-window matviews are deliberately not
+refreshed here: the runner refreshes them at the end of each benchmark run
+(see ``migrations/env.py``), and ``REFRESH ... CONCURRENTLY`` cannot run
+inside a migration's transaction.
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "20260807_0015"
+down_revision = "20260804_0014"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Remove the mislabeled Gen2 rows from both results tables."""
+    op.execute(
+        "DELETE FROM benchmarks_v2.results r "
+        "USING benchmarks_v2.runs ru "
+        "WHERE r.run_id = ru.id "
+        "AND r.provider = 'murf' AND r.model = 'falcon-2' "
+        "AND ru.scheduled_at < '2026-08-07 20:00:00+00'"
+    )
+    op.execute(
+        "DELETE FROM benchmarks_v2.results_by_bucket "
+        "WHERE provider = 'murf' AND model = 'falcon-2' "
+        "AND bucket_at < '2026-08-07 20:00:00+00'"
+    )
+
+
+def downgrade() -> None:
+    """The deleted rows are unrecoverable; nothing to restore."""


### PR DESCRIPTION
Murf served Gen2 under the falcon-2 key until 2026-08-07 20:00 UTC, so those rows misstate falcon-2's latency and are removed from both results tables.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Deletes Murf `falcon-2` benchmark data recorded before the provider began serving that model, preventing substituted Gen2 measurements from affecting published results.
- Removes matching raw results based on their owning run’s scheduled time.
- Removes corresponding historical time-series bucket rows.
- Leaves the irreversible downgrade intentionally empty.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with its intentionally deferred materialized-view refresh clearly documented.

The migration targets the intended provider, model, and cutoff across both raw and bucketed results, uses the current Alembic head and compatible schema fields, and introduces no blocking failure.

<sub>Reviews (1): Last reviewed commit: ["Delete mislabeled Murf Gen2 results"](https://github.com/coval-ai/benchmarks/commit/be39323fa1a4542c1f622f4d3f2e161262044eb4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51332873)</sub>

**Context used:**

- Knowledge Base — [DB Layer](https://app.greptile.com/coval/-/custom-context/knowledge-base/coval-ai/benchmarks/-/docs/db-layer.md)

<!-- /greptile_comment -->