### PR TITLE
Draft: dispatch immutable Benchmarks release images

### DIFF
--- a/.github/workflows/runner-release.yml
+++ b/.github/workflows/runner-release.yml
@@ -129,6 +129,7 @@ jobs:
         uses: docker/setup-buildx-action@v4
 
       - name: Build and push ${{ matrix.image }} image
+        id: build
         uses: docker/build-push-action@v7
         with:
           context: runner
@@ -140,10 +141,67 @@ jobs:
           cache-to: type=gha,mode=max
           provenance: true
 
+      - name: Retain immutable ${{ matrix.image }} digest
+        env:
+          IMAGE_DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          set -euo pipefail
+          if ! [[ "$IMAGE_DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+            echo "::error::Build did not produce a valid immutable image digest."
+            exit 1
+          fi
+          mkdir -p image-digest
+          printf '%s\n' "$IMAGE_DIGEST" > "image-digest/${{ matrix.image }}"
+
+      - name: Upload ${{ matrix.image }} digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmarks-image-digest-${{ matrix.image }}
+          path: image-digest/${{ matrix.image }}
+          if-no-files-found: error
+          retention-days: 1
+
+  resolve_images:
+    name: Resolve immutable image references
+    needs: build_and_push
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      runner_image: ${{ steps.images.outputs.runner_image }}
+      api_image: ${{ steps.images.outputs.api_image }}
+    steps:
+      - name: Download runner digest
+        uses: actions/download-artifact@v4
+        with:
+          name: benchmarks-image-digest-runner
+          path: image-digests/runner
+
+      - name: Download API digest
+        uses: actions/download-artifact@v4
+        with:
+          name: benchmarks-image-digest-api
+          path: image-digests/api
+
+      - name: Build immutable image references
+        id: images
+        run: |
+          set -euo pipefail
+          runner_digest="$(tr -d '\r\n' < image-digests/runner/runner)"
+          api_digest="$(tr -d '\r\n' < image-digests/api/api)"
+          for digest in "$runner_digest" "$api_digest"; do
+            if ! [[ "$digest" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+              echo "::error::Invalid retained image digest."
+              exit 1
+            fi
+          done
+          echo "runner_image=us-east1-docker.pkg.dev/coval-benchmarks-prod/runner/coval-bench-runner@${runner_digest}" >> "$GITHUB_OUTPUT"
+          echo "api_image=us-east1-docker.pkg.dev/coval-benchmarks-prod/runner/coval-bench-api@${api_digest}" >> "$GITHUB_OUTPUT"
+
   dispatch_infra:
     name: Dispatch and watch benchmark-infra rollout
-    needs: [context, build_and_push]
-    if: always() && needs.context.outputs.skip != 'true' && needs.build_and_push.result == 'success'
+    needs: [context, resolve_images]
+    if: always() && needs.context.outputs.skip != 'true' && needs.resolve_images.result == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 45
     outputs:
@@ -153,11 +211,11 @@ jobs:
       - name: Dispatch image-bump
         id: dispatch
         env:
-          API_IMAGE: ${{ needs.context.outputs.api_image }}
+          API_IMAGE: ${{ needs.resolve_images.outputs.api_image }}
           DEPLOY_REF: ${{ needs.context.outputs.deploy_ref }}
           DEPLOY_SHA: ${{ needs.context.outputs.deploy_sha }}
           GH_TOKEN: ${{ secrets.INFRA_DISPATCH_TOKEN }}
-          RUNNER_IMAGE: ${{ needs.context.outputs.runner_image }}
+          RUNNER_IMAGE: ${{ needs.resolve_images.outputs.runner_image }}
           SWITCHBOARD_CORRELATION_ID: ${{ github.event.client_payload.switchboard_correlation_id }}
         run: |
           set -euo pipefail
@@ -242,7 +300,7 @@ jobs:
 
   summarize:
     name: Summarize release
-    needs: [context, build_and_push, dispatch_infra, promote_marker]
+    needs: [context, build_and_push, resolve_images, dispatch_infra, promote_marker]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -253,6 +311,7 @@ jobs:
             echo ""
             echo "- Skipped: \`${{ needs.context.outputs.skip || 'false' }}\`"
             echo "- Build: \`${{ needs.build_and_push.result }}\`"
+            echo "- Immutable image resolution: \`${{ needs.resolve_images.result }}\`"
             echo "- Infra rollout: \`${{ needs.dispatch_infra.result }}\`"
             echo "- Marker promote: \`${{ needs.promote_marker.result }}\`"
             echo "- Infra run: ${{ needs.dispatch_infra.outputs.infra_url || 'n/a' }}"

--- a/.github/workflows/runner-release.yml
+++ b/.github/workflows/runner-release.yml
@@ -244,32 +244,18 @@ jobs:
           gh api repos/coval-ai/benchmark-infra/dispatches --method POST --input - <<< "$payload"
 
           run_id=""
-          fallback_run_id=""
-          for attempt in $(seq 1 30); do
+          for _ in $(seq 1 30); do
             candidates="$(gh run list --repo coval-ai/benchmark-infra --workflow bump-images.yml --event repository_dispatch --limit 30 --json databaseId,createdAt,displayTitle \
               | jq -c --arg started "$started_at" 'map(select(.createdAt >= $started)) | sort_by(.createdAt) | reverse')"
-            fallback_run_id="$(jq -r '.[0].databaseId // ""' <<<"$candidates")"
-            run_id="$(jq -r --arg correlation "$correlation_id" '.[] | select((.displayTitle // "") | contains($correlation)) | .databaseId' <<<"$candidates" | head -n 1)"
-            if [ -z "$run_id" ]; then
-              while IFS= read -r candidate_id; do
-                [ -z "$candidate_id" ] && continue
-                if gh run view "$candidate_id" --repo coval-ai/benchmark-infra --log 2>/dev/null | grep -Fq "$correlation_id"; then
-                  run_id="$candidate_id"
-                  break
-                fi
-              done < <(jq -r '.[].databaseId' <<<"$candidates")
-            fi
+            run_id="$(jq -r --arg correlation "$correlation_id" \
+              '.[] | select((.displayTitle // "") | endswith(" " + $correlation)) | .databaseId' \
+              <<<"$candidates" | head -n 1)"
             [ -n "$run_id" ] && break
-            if [ "$attempt" -ge 6 ] && [ -n "$fallback_run_id" ]; then
-              echo "::notice::Could not find benchmark-infra run with correlation ${correlation_id}; using newest repository_dispatch run after ${started_at}: ${fallback_run_id}."
-              run_id="$fallback_run_id"
-              break
-            fi
             sleep 5
           done
 
           if [ -z "$run_id" ]; then
-            echo "::error::Could not find dispatched benchmark-infra bump-images run."
+            echo "::error::Could not find the benchmark-infra bump-images run for correlation ${correlation_id}."
             exit 1
           fi
 

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -6,8 +6,9 @@
 #        :<ref_name>  (e.g. :v0.1.0)
 #        :latest
 #        :<sha>       (keeps sha↔tag mapping recoverable)
-#   2. Fire repository_dispatch to coval-ai/benchmark-infra with the tag-named
-#      image refs so bump-images.yml deploys the named release, not the raw SHA.
+#   2. Retain the exact digests produced by both builds.
+#   3. Fire repository_dispatch to coval-ai/benchmark-infra with the immutable
+#      image refs while preserving the version tag as release metadata.
 #
 # :latest is ONLY pushed from this workflow (not from release.yml).
 
@@ -63,6 +64,7 @@ jobs:
         uses: docker/setup-buildx-action@v4
 
       - name: Build and push ${{ matrix.image }} image
+        id: build
         uses: docker/build-push-action@v7
         with:
           context: runner
@@ -77,16 +79,73 @@ jobs:
           cache-to: type=gha,mode=max
           provenance: true
 
+      - name: Retain immutable ${{ matrix.image }} digest
+        env:
+          IMAGE_DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          set -euo pipefail
+          if ! [[ "$IMAGE_DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+            echo "::error::Build did not produce a valid immutable image digest."
+            exit 1
+          fi
+          mkdir -p image-digest
+          printf '%s\n' "$IMAGE_DIGEST" > "image-digest/${{ matrix.image }}"
+
+      - name: Upload ${{ matrix.image }} digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmarks-tag-image-digest-${{ matrix.image }}
+          path: image-digest/${{ matrix.image }}
+          if-no-files-found: error
+          retention-days: 1
+
+  resolve-images:
+    name: Resolve immutable image references
+    needs: build-and-push
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      runner_image: ${{ steps.images.outputs.runner_image }}
+      api_image: ${{ steps.images.outputs.api_image }}
+    steps:
+      - name: Download runner digest
+        uses: actions/download-artifact@v4
+        with:
+          name: benchmarks-tag-image-digest-runner
+          path: image-digests/runner
+
+      - name: Download API digest
+        uses: actions/download-artifact@v4
+        with:
+          name: benchmarks-tag-image-digest-api
+          path: image-digests/api
+
+      - name: Build immutable image references
+        id: images
+        run: |
+          set -euo pipefail
+          runner_digest="$(tr -d '\r\n' < image-digests/runner/runner)"
+          api_digest="$(tr -d '\r\n' < image-digests/api/api)"
+          for digest in "$runner_digest" "$api_digest"; do
+            if ! [[ "$digest" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+              echo "::error::Invalid retained image digest."
+              exit 1
+            fi
+          done
+          echo "runner_image=us-east1-docker.pkg.dev/coval-benchmarks-prod/runner/coval-bench-runner@${runner_digest}" >> "$GITHUB_OUTPUT"
+          echo "api_image=us-east1-docker.pkg.dev/coval-benchmarks-prod/runner/coval-bench-api@${api_digest}" >> "$GITHUB_OUTPUT"
+
   dispatch-infra:
     name: Dispatch image-bump to benchmark-infra
     runs-on: ubuntu-latest
-    needs: build-and-push
+    needs: resolve-images
 
     permissions:
       contents: read
 
     steps:
-      # Dispatch uses the tag-named image refs so infra deploys the named release.
+      # The tag remains release metadata; deployment uses the exact built digest.
       - name: Fire repository_dispatch → coval-ai/benchmark-infra
         uses: peter-evans/repository-dispatch@v4
         with:
@@ -97,6 +156,6 @@ jobs:
             {
               "sha": "${{ github.sha }}",
               "ref": "${{ github.ref }}",
-              "runner_image": "us-east1-docker.pkg.dev/coval-benchmarks-prod/runner/coval-bench-runner:${{ github.ref_name }}",
-              "api_image": "us-east1-docker.pkg.dev/coval-benchmarks-prod/runner/coval-bench-api:${{ github.ref_name }}"
+              "runner_image": "${{ needs.resolve-images.outputs.runner_image }}",
+              "api_image": "${{ needs.resolve-images.outputs.api_image }}"
             }

--- a/runner/tests/unit/test_release_workflow_contracts.py
+++ b/runner/tests/unit/test_release_workflow_contracts.py
@@ -1,0 +1,25 @@
+import pathlib
+
+REPOSITORY_ROOT = pathlib.Path(__file__).parents[3]
+
+
+def test_switchboard_release_dispatches_built_image_digests() -> None:
+    workflow = (REPOSITORY_ROOT / ".github" / "workflows" / "runner-release.yml").read_text()
+
+    assert "IMAGE_DIGEST: ${{ steps.build.outputs.digest }}" in workflow
+    assert "needs: [context, resolve_images]" in workflow
+    assert "RUNNER_IMAGE: ${{ needs.resolve_images.outputs.runner_image }}" in workflow
+    assert "API_IMAGE: ${{ needs.resolve_images.outputs.api_image }}" in workflow
+    assert "coval-bench-runner@${runner_digest}" in workflow
+    assert "coval-bench-api@${api_digest}" in workflow
+
+
+def test_tag_release_preserves_tags_but_dispatches_built_digests() -> None:
+    workflow = (REPOSITORY_ROOT / ".github" / "workflows" / "tag.yml").read_text()
+
+    assert "coval-bench-${{ matrix.image }}:${{ github.ref_name }}" in workflow
+    assert "IMAGE_DIGEST: ${{ steps.build.outputs.digest }}" in workflow
+    assert '"runner_image": "${{ needs.resolve-images.outputs.runner_image }}"' in workflow
+    assert '"api_image": "${{ needs.resolve-images.outputs.api_image }}"' in workflow
+    assert "coval-bench-runner@${runner_digest}" in workflow
+    assert "coval-bench-api@${api_digest}" in workflow

--- a/runner/tests/unit/test_release_workflow_contracts.py
+++ b/runner/tests/unit/test_release_workflow_contracts.py
@@ -14,6 +14,17 @@ def test_switchboard_release_dispatches_built_image_digests() -> None:
     assert "coval-bench-api@${api_digest}" in workflow
 
 
+def test_switchboard_release_watches_only_its_correlated_infra_run() -> None:
+    workflow = (REPOSITORY_ROOT / ".github" / "workflows" / "runner-release.yml").read_text()
+
+    assert 'endswith(" " + $correlation)' in workflow
+    assert "for _ in $(seq 1 30)" in workflow
+    assert 'gh run view "$candidate_id"' not in workflow
+    assert "newest repository_dispatch run" not in workflow
+    assert "fallback_run_id" not in workflow
+    assert "for correlation ${correlation_id}" in workflow
+
+
 def test_tag_release_preserves_tags_but_dispatches_built_digests() -> None:
     workflow = (REPOSITORY_ROOT / ".github" / "workflows" / "tag.yml").read_text()
 


### PR DESCRIPTION
## Summary

Retain the exact runner and API digests emitted by each build and dispatch those immutable `@sha256:` references to Benchmark Infra. Release/version tags remain metadata only.

The caller discovers the infra run by the exact release correlation and fails closed if that run is absent; it cannot treat an unrelated recent success as this transaction.

## Dependency

Consumer cutover and backwards-compatible tag-to-digest resolution are consolidated in coval-ai/benchmark-infra#91. The combined Infra draft safely accepts the current tag caller until this PR lands, then uses the already-retained digests directly.

## Safety and validation

- no build, image push, dispatch, deployment, or marker update was triggered during validation;
- focused release workflow contracts, Ruff, mypy, actionlint, and prior hosted CodeQL/Switchboard checks are green;
- exact-head workflow-dispatch run 31285901223 passed three consecutive complete attempts; the PR remains draft and no release path was invoked.