### PR TITLE
Add Soniox model

### DIFF
--- a/runner/src/coval_bench/providers/tts/soniox.py
+++ b/runner/src/coval_bench/providers/tts/soniox.py
@@ -20,7 +20,7 @@ from coval_bench.providers.tts._common import finalize_tts_result
 
 logger: structlog.BoundLogger = structlog.get_logger(__name__)
 
-_VALID_MODELS = ("tts-rt-v1",)
+_VALID_MODELS = ("tts-rt-v1", "tts-rt-v2")
 _VALID_VOICES = (
     "Maya",
     "Daniel",

--- a/runner/src/coval_bench/registries/models.py
+++ b/runner/src/coval_bench/registries/models.py
@@ -625,6 +625,15 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         tags=(_STREAMING, _MULTI, _CLONE, _STREAM),
         status=_ACTIVE,
     ),
+    RegisteredModel(
+        benchmark=_TTS,
+        provider="soniox",
+        model="tts-rt-v2",
+        voice="Adrian",
+        voices=("Emma", "Daniel"),
+        tags=(_STREAMING, _MULTI, _CLONE, _STREAM),
+        status=_EARLY_ACCESS,
+    ),
     # Azure AI Speech real-time (raw WebSocket). "neural" is the standard
     # neural-voice family; "dragon-hd-latest" pins the auto-updating
     # :DragonHDLatestNeural HD variant. The voice name selects the served model.

--- a/runner/tests/providers/tts/test_soniox.py
+++ b/runner/tests/providers/tts/test_soniox.py
@@ -234,7 +234,8 @@ def test_soniox_tts_missing_api_key_raises() -> None:
         SonioxTTSProvider(settings, model="tts-rt-v1", voice="Adrian")
 
 
-def test_soniox_tts_provider_name(fake_settings: Settings) -> None:
-    provider = SonioxTTSProvider(fake_settings, model="tts-rt-v1", voice="Adrian")
-    assert provider.name == "soniox-tts-rt-v1"
-    assert provider.model == "tts-rt-v1"
+@pytest.mark.parametrize("model", ["tts-rt-v1", "tts-rt-v2"])
+def test_soniox_tts_provider_name(fake_settings: Settings, model: str) -> None:
+    provider = SonioxTTSProvider(fake_settings, model=model, voice="Adrian")
+    assert provider.name == f"soniox-{model}"
+    assert provider.model == model


### PR DESCRIPTION
Registers the new model as early access.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR enables Soniox `tts-rt-v2` in the existing TTS adapter and registers it as an early-access model.
- Adds `tts-rt-v2` to the Soniox model allowlist.
- Registers the model with default and scheduled voice-pool settings.
- Extends provider metadata assertions to cover both Soniox model identifiers.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with a non-blocking gap in operational test coverage for the newly enabled model.

The registry and provider configuration are internally consistent, but the only new v2 test verifies constructor metadata and would not catch regressions in the WebSocket synthesis path.

**Files Needing Attention:** runner/tests/providers/tts/test_soniox.py

<sub>Reviews (1): Last reviewed commit: ["Add Soniox tts-rt-v2 TTS model"](https://github.com/coval-ai/benchmarks/commit/833034b9d5ac879e2eb6a0ce1c5a8f858b4b4e6b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51865911)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Runner Orchestration](https://app.greptile.com/coval/-/custom-context/knowledge-base/coval-ai/benchmarks/-/docs/runner-orchestration.md)

<!-- /greptile_comment -->