### PR TITLE
Set Fluxions VUI to active

### DIFF
--- a/runner/src/coval_bench/registries/models.py
+++ b/runner/src/coval_bench/registries/models.py
@@ -773,7 +773,6 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         status=_ACTIVE,
     ),
     # No model id on the wire, only a voice, so "vui" is the bare surface name.
-    # Arena-disabled: FLUXIONS_API_KEY is not mounted on benchmarks-api yet.
     RegisteredModel(
         benchmark=_TTS,
         provider="fluxions",
@@ -781,8 +780,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         voice="maeve",
         voices=("maeve", "abraham"),
         tags=(_STREAMING, _CLONE, _EMOTION),
-        status=_EARLY_ACCESS,
-        arena_enabled=False,
+        status=_ACTIVE,
     ),
     RegisteredModel(
         benchmark=_TTS,


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR publicly activates Fluxions VUI and enables it for arena selection.

- Changes Fluxions VUI from early access to active.
- Removes its explicit arena opt-out.
- Removes the note that its API key was not mounted on benchmarks-api.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge based on the available repository evidence.

The registry change intentionally exposes Fluxions VUI and enables arena selection, and no concrete blocking failure is established without assuming an unverified external credential state.

<sub>Reviews (1): Last reviewed commit: ["Set Fluxions VUI to active"](https://github.com/coval-ai/benchmarks/commit/42287a7260b06ee4f723936d5c28114d3d160517) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51870582)</sub>

**Context used:**

- Knowledge Base — [Runner Orchestration](https://app.greptile.com/coval/-/custom-context/knowledge-base/coval-ai/benchmarks/-/docs/runner-orchestration.md)

<!-- /greptile_comment -->