### PR TITLE
[BENCH-652] Open-source TTS pricing registry + prices on /v1/providers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,7 @@
 # Everyone on the benchmarking team owns everything in this repo.
 * @coval-ai/coval-benchmarking
+
+# Pricing registry: providers own their own rates. As provider GitHub teams
+# get repo access, add a line per file so their PRs route to them, e.g.:
+#   /runner/src/coval_bench/registries/pricing/data/tts/<provider>.json @<provider-org>/<team>
+/runner/src/coval_bench/registries/pricing/data/ @coval-ai/coval-benchmarking

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,29 @@
 # Contributing
 
 Contributions are welcome. Please open an issue first to discuss significant changes. All code must pass `ruff`, `mypy --strict`, and `pytest` before merging. By submitting a pull request you agree your contribution is licensed under Apache-2.0.
+
+## Updating your model's price
+
+The prices shown on [benchmarks.coval.ai](https://benchmarks.coval.ai) live in this repo, one JSON file per provider under [`runner/src/coval_bench/registries/pricing/data/tts/`](runner/src/coval_bench/registries/pricing/data/tts/). Providers are encouraged to keep their own rates current:
+
+1. Edit (or add) `<your-provider>.json` — the file may only contain entries for your own provider, keyed by the same `(benchmark, provider, model)` as [`registries/models.py`](runner/src/coval_bench/registries/models.py):
+
+   ```json
+   [
+     {
+       "benchmark": "TTS",
+       "provider": "deepgram",
+       "model": "aura-2-thalia-en",
+       "unit": "per_1k_chars",
+       "price_usd": "0.030",
+       "effective_from": "2026-08-10",
+       "source_url": "https://deepgram.com/pricing",
+       "notes": "Pay As You Go rate."
+     }
+   ]
+   ```
+
+2. Use your *native* published unit (`per_1m_chars`, `per_1k_chars`, `per_char`, or `per_second_audio_out`); the API normalizes to $ per 1M characters server-side. Write `price_usd` as a string so the decimal is exact. `source_url` must point at your public pricing page, and `effective_from` is the date the rate took effect.
+3. Open a PR. CI validates the schema and that every entry matches a registered model; a model without a pricing entry simply shows no price on the site — never submit an estimated rate.
+
+The new price appears on the site with the next deploy — no code change needed.

--- a/runner/src/coval_bench/api/routers/providers.py
+++ b/runner/src/coval_bench/api/routers/providers.py
@@ -41,6 +41,7 @@ from coval_bench.registries import (
     TagCategory,
     tag_value_label,
 )
+from coval_bench.registries.pricing import PRICING
 
 logger = structlog.get_logger("coval_bench.api")
 
@@ -95,11 +96,15 @@ def _build_provider_map(
             continue
         if (m.provider, m.model) in hidden:
             continue
+        entry = PRICING.get((m.benchmark, m.provider, m.model))
+        price = entry.price_per_1m_chars if entry else None
         result.setdefault(m.provider, []).append(
             ModelInfo(
                 model=m.model,
                 disabled=m.status in _HIDDEN_STATUSES,
                 tags=_model_tags(m),
+                price_per_1m_chars=float(price) if price is not None else None,
+                price_effective_from=entry.effective_from if entry and price is not None else None,
             )
         )
     return result

--- a/runner/src/coval_bench/api/schemas.py
+++ b/runner/src/coval_bench/api/schemas.py
@@ -11,7 +11,7 @@ added later if needed.
 from __future__ import annotations
 
 import uuid
-from datetime import datetime
+from datetime import date, datetime
 from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field
@@ -102,6 +102,10 @@ class ModelInfo(BaseModel):
     model: str
     disabled: bool = False
     tags: list[ModelTagOut] = []
+    # From the pricing registry, normalized server-side to USD per 1M
+    # characters. None (never $0) for STT/S2S models and unpriced TTS models.
+    price_per_1m_chars: float | None = None
+    price_effective_from: date | None = None
 
 
 class ProviderInfo(BaseModel):

--- a/runner/src/coval_bench/registries/pricing/__init__.py
+++ b/runner/src/coval_bench/registries/pricing/__init__.py
@@ -1,0 +1,8 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+"""Open, provider-editable pricing registry. See CONTRIBUTING.md to update a rate."""
+
+from coval_bench.registries.pricing.loader import PRICING, index_pricing
+from coval_bench.registries.pricing.schema import PricingEntry, PricingUnit
+
+__all__ = ["PRICING", "PricingEntry", "PricingUnit", "index_pricing"]

--- a/runner/src/coval_bench/registries/pricing/data/tts/azure.json
+++ b/runner/src/coval_bench/registries/pricing/data/tts/azure.json
@@ -1,0 +1,22 @@
+[
+  {
+    "benchmark": "TTS",
+    "provider": "azure",
+    "model": "neural",
+    "unit": "per_1m_chars",
+    "price_usd": "15",
+    "effective_from": "2026-08-10",
+    "source_url": "https://azure.microsoft.com/en-us/pricing/details/cognitive-services/speech-services/",
+    "notes": "Pay-as-you-go standard neural voice rate (US regions); commitment tiers are cheaper."
+  },
+  {
+    "benchmark": "TTS",
+    "provider": "azure",
+    "model": "dragon-hd-latest",
+    "unit": "per_1m_chars",
+    "price_usd": "22",
+    "effective_from": "2026-08-10",
+    "source_url": "https://azure.microsoft.com/en-us/pricing/details/cognitive-services/speech-services/",
+    "notes": "Pay-as-you-go Neural HD rate in East US; HD voices are region-limited."
+  }
+]

--- a/runner/src/coval_bench/registries/pricing/data/tts/cartesia.json
+++ b/runner/src/coval_bench/registries/pricing/data/tts/cartesia.json
@@ -1,0 +1,12 @@
+[
+  {
+    "benchmark": "TTS",
+    "provider": "cartesia",
+    "model": "sonic-3.5",
+    "unit": "per_1m_chars",
+    "price_usd": "65",
+    "effective_from": "2026-08-10",
+    "source_url": "https://cartesia.ai/pricing",
+    "notes": "Entry paid (Pro) overage rate; 1 credit = 1 character, $65 per 1M credits. Higher tiers publish lower rates."
+  }
+]

--- a/runner/src/coval_bench/registries/pricing/data/tts/deepgram.json
+++ b/runner/src/coval_bench/registries/pricing/data/tts/deepgram.json
@@ -1,0 +1,12 @@
+[
+  {
+    "benchmark": "TTS",
+    "provider": "deepgram",
+    "model": "aura-2-thalia-en",
+    "unit": "per_1k_chars",
+    "price_usd": "0.030",
+    "effective_from": "2026-08-10",
+    "source_url": "https://deepgram.com/pricing",
+    "notes": "Aura-2 Pay As You Go rate."
+  }
+]

--- a/runner/src/coval_bench/registries/pricing/data/tts/elevenlabs.json
+++ b/runner/src/coval_bench/registries/pricing/data/tts/elevenlabs.json
@@ -1,0 +1,32 @@
+[
+  {
+    "benchmark": "TTS",
+    "provider": "elevenlabs",
+    "model": "eleven_flash_v2_5",
+    "unit": "per_1k_chars",
+    "price_usd": "0.05",
+    "effective_from": "2026-08-10",
+    "source_url": "https://elevenlabs.io/pricing/api",
+    "notes": "API pricing 'Flash / Turbo' row; same rate across tiers."
+  },
+  {
+    "benchmark": "TTS",
+    "provider": "elevenlabs",
+    "model": "eleven_multilingual_v2",
+    "unit": "per_1k_chars",
+    "price_usd": "0.10",
+    "effective_from": "2026-08-10",
+    "source_url": "https://elevenlabs.io/pricing/api",
+    "notes": "API pricing 'Multilingual v2/v3' row; same rate across tiers."
+  },
+  {
+    "benchmark": "TTS",
+    "provider": "elevenlabs",
+    "model": "eleven_v3",
+    "unit": "per_1k_chars",
+    "price_usd": "0.10",
+    "effective_from": "2026-08-10",
+    "source_url": "https://elevenlabs.io/pricing/api",
+    "notes": "API pricing 'Multilingual v2/v3' row; same rate across tiers."
+  }
+]

--- a/runner/src/coval_bench/registries/pricing/data/tts/google.json
+++ b/runner/src/coval_bench/registries/pricing/data/tts/google.json
@@ -1,0 +1,12 @@
+[
+  {
+    "benchmark": "TTS",
+    "provider": "google",
+    "model": "chirp-3-hd",
+    "unit": "per_1m_chars",
+    "price_usd": "30",
+    "effective_from": "2026-08-10",
+    "source_url": "https://cloud.google.com/text-to-speech/pricing",
+    "notes": "Pay-as-you-go rate for Chirp 3: HD voices, billed per character sent for synthesis."
+  }
+]

--- a/runner/src/coval_bench/registries/pricing/data/tts/hume.json
+++ b/runner/src/coval_bench/registries/pricing/data/tts/hume.json
@@ -1,0 +1,22 @@
+[
+  {
+    "benchmark": "TTS",
+    "provider": "hume",
+    "model": "octave-tts",
+    "unit": "per_1k_chars",
+    "price_usd": "0.15",
+    "effective_from": "2026-08-10",
+    "source_url": "https://www.hume.ai/pricing",
+    "notes": "Usage-based rate on the entry Starter/Creator plans; higher tiers publish lower rates. Octave 1 and 2 are priced together."
+  },
+  {
+    "benchmark": "TTS",
+    "provider": "hume",
+    "model": "octave-2",
+    "unit": "per_1k_chars",
+    "price_usd": "0.15",
+    "effective_from": "2026-08-10",
+    "source_url": "https://www.hume.ai/pricing",
+    "notes": "Usage-based rate on the entry Starter/Creator plans; higher tiers publish lower rates. Octave 1 and 2 are priced together."
+  }
+]

--- a/runner/src/coval_bench/registries/pricing/data/tts/lmnt.json
+++ b/runner/src/coval_bench/registries/pricing/data/tts/lmnt.json
@@ -1,0 +1,12 @@
+[
+  {
+    "benchmark": "TTS",
+    "provider": "lmnt",
+    "model": "blizzard",
+    "unit": "per_1k_chars",
+    "price_usd": "0.05",
+    "effective_from": "2026-08-10",
+    "source_url": "https://www.lmnt.com/pricing",
+    "notes": "Overage rate past the entry Indie plan's included characters; plan-based, not per-model."
+  }
+]

--- a/runner/src/coval_bench/registries/pricing/data/tts/rime.json
+++ b/runner/src/coval_bench/registries/pricing/data/tts/rime.json
@@ -1,0 +1,22 @@
+[
+  {
+    "benchmark": "TTS",
+    "provider": "rime",
+    "model": "coda",
+    "unit": "per_1k_chars",
+    "price_usd": "0.05",
+    "effective_from": "2026-08-10",
+    "source_url": "https://www.rime.ai/pricing",
+    "notes": "Pay-as-you-go Starter rate. Arcana has no published rate and is deliberately absent."
+  },
+  {
+    "benchmark": "TTS",
+    "provider": "rime",
+    "model": "mistv3",
+    "unit": "per_1k_chars",
+    "price_usd": "0.03",
+    "effective_from": "2026-08-10",
+    "source_url": "https://www.rime.ai/pricing",
+    "notes": "Pay-as-you-go Starter rate."
+  }
+]

--- a/runner/src/coval_bench/registries/pricing/loader.py
+++ b/runner/src/coval_bench/registries/pricing/loader.py
@@ -1,0 +1,65 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+"""Loader for the pricing registry: per-provider JSON, validated on import.
+
+Files ship inside the wheel under ``pricing/data/tts/<provider>.json`` and are
+loaded via ``importlib.resources``, mirroring the dataset manifests. A file
+may only price its own provider's models, every entry must match a
+``MODEL_REGISTRY`` row, and duplicate ``(benchmark, provider, model)`` keys
+raise — all at import time, so a bad PR can never reach the API. Missing
+pricing for a model is fine: it renders as absent, never $0.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from importlib.resources import files
+
+from pydantic import TypeAdapter
+
+from coval_bench.registries.benchmarks import Benchmark
+from coval_bench.registries.models import MODEL_REGISTRY
+from coval_bench.registries.pricing.schema import PricingEntry
+
+_ENTRIES = TypeAdapter(list[PricingEntry])
+
+
+def _load_entries() -> list[PricingEntry]:
+    data_dir = files("coval_bench.registries.pricing") / "data" / "tts"
+    entries: list[PricingEntry] = []
+    for resource in sorted(data_dir.iterdir(), key=lambda r: r.name):
+        if not resource.name.endswith(".json"):
+            continue
+        provider = resource.name.removesuffix(".json")
+        loaded = _ENTRIES.validate_json(resource.read_bytes())
+        strays = sorted({e.provider for e in loaded} - {provider})
+        if strays:
+            raise RuntimeError(
+                f"pricing/data/tts/{resource.name} prices other providers: {', '.join(strays)}"
+            )
+        entries.extend(loaded)
+    return entries
+
+
+def index_pricing(
+    entries: list[PricingEntry],
+) -> dict[tuple[Benchmark, str, str], PricingEntry]:
+    """Index entries by registry key, rejecting duplicates and unknown models."""
+    key_counts = Counter((e.benchmark, e.provider, e.model) for e in entries)
+    dupes = sorted(f"{b}:{p}/{m}" for (b, p, m), n in key_counts.items() if n > 1)
+    if dupes:
+        raise RuntimeError(f"pricing registry contains duplicate entries: {', '.join(dupes)}")
+    registered = {(m.benchmark, m.provider, m.model) for m in MODEL_REGISTRY}
+    unknown = sorted(
+        f"{e.benchmark}:{e.provider}/{e.model}"
+        for e in entries
+        if (e.benchmark, e.provider, e.model) not in registered
+    )
+    if unknown:
+        raise RuntimeError(
+            f"pricing registry entries match no MODEL_REGISTRY row: {', '.join(unknown)}"
+        )
+    return {(e.benchmark, e.provider, e.model): e for e in entries}
+
+
+PRICING: dict[tuple[Benchmark, str, str], PricingEntry] = index_pricing(_load_entries())

--- a/runner/src/coval_bench/registries/pricing/schema.py
+++ b/runner/src/coval_bench/registries/pricing/schema.py
@@ -1,0 +1,58 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+"""Schema for the provider-editable pricing registry.
+
+Entries live in per-provider JSON files under ``pricing/data/<benchmark>/``
+and carry the provider's *native* published unit; normalization to the one
+figure the API serves ($ per 1M characters) happens here, never in the files.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+from enum import StrEnum
+
+from pydantic import BaseModel, Field, HttpUrl
+
+from coval_bench.registries.benchmarks import Benchmark
+
+
+class PricingUnit(StrEnum):
+    """The native unit a TTS provider publishes its rate in."""
+
+    PER_1M_CHARS = "per_1m_chars"
+    PER_1K_CHARS = "per_1k_chars"
+    PER_CHAR = "per_char"
+    PER_SECOND_AUDIO_OUT = "per_second_audio_out"
+
+
+class PricingEntry(BaseModel, frozen=True, extra="forbid"):
+    """One model's published rate, keyed like the model registry."""
+
+    benchmark: Benchmark
+    provider: str
+    model: str
+    unit: PricingUnit
+    price_usd: Decimal = Field(gt=0)
+    effective_from: date
+    source_url: HttpUrl
+    notes: str | None = None
+
+    @property
+    def price_per_1m_chars(self) -> Decimal | None:
+        """The native rate normalized to USD per 1M characters.
+
+        Pure arithmetic per unit — ``per_1m_chars`` is served as-is,
+        ``per_1k_chars`` scales by 1000, ``per_char`` by 1,000,000.
+        ``per_second_audio_out`` returns None: seconds of audio have no
+        character equivalence without assuming a speaking rate, and we never
+        serve estimated figures.
+        """
+        if self.unit is PricingUnit.PER_1M_CHARS:
+            return self.price_usd
+        if self.unit is PricingUnit.PER_1K_CHARS:
+            return self.price_usd * 1000
+        if self.unit is PricingUnit.PER_CHAR:
+            return self.price_usd * 1_000_000
+        return None

--- a/runner/tests/api/test_providers.py
+++ b/runner/tests/api/test_providers.py
@@ -69,8 +69,9 @@ async def test_response_shape_breaking_change(client: AsyncClient) -> None:
     data = response.json()
     first_model = data["stt"][0]["models"][0]
     assert isinstance(first_model, dict), "models must be dicts, not strings"
-    assert set(first_model.keys()) == {"model", "disabled", "tags"}, (
-        f"ModelInfo keys must be model/disabled/tags, got {set(first_model.keys())}"
+    expected_keys = {"model", "disabled", "tags", "price_per_1m_chars", "price_effective_from"}
+    assert set(first_model.keys()) == expected_keys, (
+        f"ModelInfo keys must be {expected_keys}, got {set(first_model.keys())}"
     )
 
     openai_entry = next(e for e in data["tts"] if e["provider"] == "openai")
@@ -201,6 +202,27 @@ async def test_tag_categories_metadata(client: AsyncClient) -> None:
     assert ("host", "groq") in orpheus_facets
     assert ("creator", "canopylabs") in orpheus_facets
     assert ("source", "shared-inference") in orpheus_facets
+
+
+async def test_pricing_served_for_seeded_tts_models_only(client: AsyncClient) -> None:
+    """Registry prices ride TTS models normalized to $/1M chars; STT/S2S stay null."""
+    response = await client.get("/v1/providers")
+    data = response.json()
+
+    # Deepgram Aura-2 is seeded at $0.030/1k chars — served as $30/1M chars.
+    deepgram = next(e for e in data["tts"] if e["provider"] == "deepgram")
+    aura = next(m for m in deepgram["models"] if m["model"] == "aura-2-thalia-en")
+    assert aura["price_per_1m_chars"] == 30.0
+    assert aura["price_effective_from"] is not None
+
+    priced = [m for e in data["tts"] for m in e["models"] if m["price_per_1m_chars"] is not None]
+    assert len(priced) >= 2
+    # Unpriced models are absent, never $0 — and effective_from never rides alone.
+    assert all(m["price_per_1m_chars"] > 0 for m in priced)
+    for entry in [*data["stt"], *data["s2s"]]:
+        for m in entry["models"]:
+            assert m["price_per_1m_chars"] is None
+            assert m["price_effective_from"] is None
 
 
 async def test_providers_no_db_connection(app: FastAPI, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/runner/tests/unit/test_pricing_registry.py
+++ b/runner/tests/unit/test_pricing_registry.py
@@ -1,0 +1,80 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Pricing registry: schema validation, normalization, and MODEL_REGISTRY parity."""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+import pytest
+from pydantic import ValidationError
+
+from coval_bench.registries.benchmarks import Benchmark
+from coval_bench.registries.models import MODEL_REGISTRY
+from coval_bench.registries.pricing import PRICING, PricingEntry, PricingUnit, index_pricing
+
+
+def _entry(**overrides: object) -> PricingEntry:
+    fields: dict[str, object] = {
+        "benchmark": Benchmark.TTS,
+        "provider": "deepgram",
+        "model": "aura-2-thalia-en",
+        "unit": PricingUnit.PER_1K_CHARS,
+        "price_usd": Decimal("0.030"),
+        "effective_from": date(2026, 8, 10),
+        "source_url": "https://deepgram.com/pricing",
+    }
+    fields.update(overrides)
+    return PricingEntry.model_validate(fields)
+
+
+def test_shipped_registry_matches_model_registry() -> None:
+    """Every shipped entry keys to a registered model; the registry is non-empty."""
+    assert PRICING
+    registered = {(m.benchmark, m.provider, m.model) for m in MODEL_REGISTRY}
+    assert set(PRICING) <= registered
+    assert all(k[0] is Benchmark.TTS for k in PRICING)
+
+
+@pytest.mark.parametrize(
+    ("unit", "price", "normalized"),
+    [
+        (PricingUnit.PER_1M_CHARS, Decimal("15"), Decimal("15")),
+        (PricingUnit.PER_1K_CHARS, Decimal("0.030"), Decimal("30")),
+        (PricingUnit.PER_CHAR, Decimal("0.00003"), Decimal("30")),
+        (PricingUnit.PER_SECOND_AUDIO_OUT, Decimal("0.001"), None),
+    ],
+)
+def test_normalization(unit: PricingUnit, price: Decimal, normalized: Decimal | None) -> None:
+    """Native units normalize to $/1M chars; audio-out seconds never estimate one."""
+    assert _entry(unit=unit, price_usd=price).price_per_1m_chars == normalized
+
+
+def test_duplicate_key_raises() -> None:
+    entry = _entry()
+    with pytest.raises(RuntimeError, match="duplicate"):
+        index_pricing([entry, _entry(notes="same key, different rate")])
+    assert index_pricing([entry]) == {(entry.benchmark, entry.provider, entry.model): entry}
+
+
+def test_unregistered_model_raises() -> None:
+    with pytest.raises(RuntimeError, match="no MODEL_REGISTRY row"):
+        index_pricing([_entry(model="aura-99")])
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"price_usd": Decimal("0")},
+        {"price_usd": Decimal("-1")},
+        {"source_url": "not a url"},
+        {"unit": "per_word"},
+        {"currency": "EUR"},
+    ],
+)
+def test_schema_rejects_invalid_entries(overrides: dict[str, object]) -> None:
+    """Zero/negative rates, bad URLs, unknown units, and stray fields all fail validation."""
+    with pytest.raises(ValidationError):
+        _entry(**overrides)


### PR DESCRIPTION
Part of epic BENCH-631 (cost & pricing). Backend half of showing \$ per 1M characters for TTS models on benchmarks.coval.ai; frontend counterpart is the matching benchmarks-web PR.

## What

- **Pricing registry** at `runner/src/coval_bench/registries/pricing/`: one PR-editable JSON file per provider under `data/tts/`, Pydantic-validated (`frozen`, `extra="forbid"`, `price_usd > 0`, required `source_url` + `effective_from`). Native units (`per_1m_chars`, `per_1k_chars`, `per_char`, `per_second_audio_out`) normalize server-side via `PricingEntry.price_per_1m_chars`; audio-out seconds normalize to `None` rather than an estimated character rate.
- **Import-time validation** mirroring the `MODEL_REGISTRY` dup check: duplicate keys raise, entries that match no registered model raise, and a provider file that prices another provider's models raises — a bad PR can't reach the API.
- **API**: `ModelInfo` gains nullable `price_per_1m_chars` / `price_effective_from`, joined from the registry in `/v1/providers`. Additive only; the endpoint still makes **no DB queries** (covered by the existing no-pool test).
- **Contribution path**: CONTRIBUTING section for providers updating their own rate; CODEOWNERS default rule for the pricing data dir with a documented pattern for per-provider lines once provider teams have repo access.
- **Seeds** for 8 providers (13 models), each verified against the provider's public pricing page on 2026-08-10 with `source_url` and tier noted.

## Deliberately unpriced

Never estimated, rendered as absent (frontend shows "—"):
- **openai gpt-4o-mini-tts** — priced per token only (\$0.60/1M text in, \$12/1M audio out); no published per-character rate.
- **rime arcana** — no rate on Rime's current pricing page (Coda and Mist v3 are seeded).

## Testing

- `uv run ruff check` / `ruff format --check`: clean
- `uv run mypy --strict src tests`: clean
- `uv run pytest`: 1295 passed (new: schema validation, unit normalization, dup/unknown-model rejection, registry↔MODEL_REGISTRY parity, priced-TTS/null-STT API assertions)
- Verified locally end to end with the benchmarks-web branch: prices render, sort, and export on /tts; STT stays null.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR introduces a provider-editable TTS pricing registry and exposes normalized character prices through `/v1/providers`.
- Adds validated per-provider pricing resources and normalization for character-based units.
- Joins pricing metadata into the provider API while leaving unpriced models nullable.
- Adds contribution guidance, ownership rules, provider seeds, and registry/API tests.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with a non-blocking recommendation to enforce the TTS-directory benchmark invariant directly in the loader.

Current shipped data and API behavior are consistent, but the production loader accepts registered non-TTS entries from TTS pricing files even though the response contract requires those benchmarks to remain unpriced.

**Files Needing Attention:** runner/src/coval_bench/registries/pricing/loader.py

<sub>Reviews (1): Last reviewed commit: ["Add open-source TTS pricing registry ser..."](https://github.com/coval-ai/benchmarks/commit/41ec6ae32139fc449aefc9985126d2446d3f7d7b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51900213)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Runner Orchestration](https://app.greptile.com/coval/-/custom-context/knowledge-base/coval-ai/benchmarks/-/docs/runner-orchestration.md)
- Knowledge Base — [API service](https://app.greptile.com/coval/-/custom-context/knowledge-base/coval-ai/benchmarks/-/docs/api-service.md)

<!-- /greptile_comment -->