### PR TITLE
Set Soniox tts-rt-v2 to active

### DIFF
--- a/runner/src/coval_bench/registries/models.py
+++ b/runner/src/coval_bench/registries/models.py
@@ -632,7 +632,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         voice="Adrian",
         voices=("Emma", "Daniel"),
         tags=(_STREAMING, _MULTI, _CLONE, _STREAM),
-        status=_EARLY_ACCESS,
+        status=_ACTIVE,
     ),
     # Azure AI Speech real-time (raw WebSocket). "neural" is the standard
     # neural-voice family; "dragon-hd-latest" pins the auto-updating


### PR DESCRIPTION
Promotes the model out of early access so its results are public.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Promotes Soniox `tts-rt-v2` from early access to active, making its benchmark results publicly visible while retaining normal scheduled benchmarking.

- Changes the model registry status from `_EARLY_ACCESS` to `_ACTIVE`.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

The status-only change intentionally removes early-access filtering for an existing model without changing its identity, provider configuration, or benchmark execution path.

<sub>Reviews (1): Last reviewed commit: ["Set Soniox tts-rt-v2 to active"](https://github.com/coval-ai/benchmarks/commit/2334cd90e19b4a89548aa453178d4c3110b1f452) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51906586)</sub>

**Context used:**

- Knowledge Base — [Runner Orchestration](https://app.greptile.com/coval/-/custom-context/knowledge-base/coval-ai/benchmarks/-/docs/runner-orchestration.md)

<!-- /greptile_comment -->