### PR TITLE
Revert "Set Soniox tts-rt-v2 to active (#477)"

### DIFF
--- a/runner/src/coval_bench/registries/models.py
+++ b/runner/src/coval_bench/registries/models.py
@@ -632,7 +632,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         voice="Adrian",
         voices=("Emma", "Daniel"),
         tags=(_STREAMING, _MULTI, _CLONE, _STREAM),
-        status=_ACTIVE,
+        status=_EARLY_ACCESS,
     ),
     # Azure AI Speech real-time (raw WebSocket). "neural" is the standard
     # neural-voice family; "dragon-hd-latest" pins the auto-updating


### PR DESCRIPTION
This reverts commit ed557ab0e289a806a0467a8b81a782b9f01fd0fd.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Reverts Soniox `tts-rt-v2` from active to early-access status.
- Keeps the model on the normal benchmark schedule.
- Restricts its public visibility through the existing early-access gating.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable defects identified.

The changed status preserves scheduled benchmark execution and applies the repository's established early-access visibility controls.

<sub>Reviews (1): Last reviewed commit: ["Revert &quot;Set Soniox tts-rt-v2 to active (..."](https://github.com/coval-ai/benchmarks/commit/a144a59fd5cd2bfc2d8a6a83de0d3fbba2c5e3ad) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51931516)</sub>

**Context used:**

- Knowledge Base — [Runner Orchestration](https://app.greptile.com/coval/-/custom-context/knowledge-base/coval-ai/benchmarks/-/docs/runner-orchestration.md)

<!-- /greptile_comment -->