### PR TITLE
Drop Soniox, Speechify, and Fluxions from the arena roster

### DIFF
--- a/runner/src/coval_bench/registries/models.py
+++ b/runner/src/coval_bench/registries/models.py
@@ -624,6 +624,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         voices=("Emma", "Daniel"),
         tags=(_STREAMING, _MULTI, _CLONE, _STREAM),
         status=_ACTIVE,
+        arena_enabled=False,
     ),
     RegisteredModel(
         benchmark=_TTS,
@@ -633,6 +634,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         voices=("Emma", "Daniel"),
         tags=(_STREAMING, _MULTI, _CLONE, _STREAM),
         status=_EARLY_ACCESS,
+        arena_enabled=False,
     ),
     # Azure AI Speech real-time (raw WebSocket). "neural" is the standard
     # neural-voice family; "dragon-hd-latest" pins the auto-updating
@@ -771,6 +773,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         voices=("beatrice_32", "hugh_32"),
         tags=(_STREAMING, _CLONE, _EMOTION),
         status=_ACTIVE,
+        arena_enabled=False,
     ),
     RegisteredModel(
         benchmark=_TTS,
@@ -780,6 +783,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         voices=("beatrice_32", "hugh_32"),
         tags=(_STREAMING, _MULTI, _CLONE, _EMOTION),
         status=_ACTIVE,
+        arena_enabled=False,
     ),
     # No model id on the wire, only a voice, so "vui" is the bare surface name.
     RegisteredModel(
@@ -790,6 +794,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         voices=("maeve", "abraham"),
         tags=(_STREAMING, _CLONE, _EMOTION),
         status=_ACTIVE,
+        arena_enabled=False,
     ),
     RegisteredModel(
         benchmark=_TTS,


### PR DESCRIPTION
Sets `arena_enabled=False` on Soniox `tts-rt-v1` and `tts-rt-v2`, Speechify `simba-3.2` and `simba-3.0`, and Fluxions `vui`. The flag is independent of dashboard `status`, so all five keep publishing latency and quality numbers exactly as before 

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Sets `arena_enabled=False` for five Soniox, Speechify, and Fluxions TTS registrations without changing their benchmark publication status.
- Removes four currently active models from arena pairings.
- Keeps Soniox `tts-rt-v2` excluded if it is later promoted from early access.
- Leaves scheduled benchmarks and dashboard publication unchanged.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge; the changed flags are scoped to arena eligibility, and the acknowledged key-parity failure requires the planned infrastructure alignment.

The targeted registrations are uniquely identified, arena roster construction honors the new flags, and normal benchmark scheduling and dashboard publication remain independently controlled by model status.

<sub>Reviews (1): Last reviewed commit: ["Drop Soniox, Speechify, and Fluxions fro..."](https://github.com/coval-ai/benchmarks/commit/e5c4fdc656e0d213a973a94082e9164abef2f87f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51943759)</sub>

**Context used:**

- Knowledge Base — [Runner Orchestration](https://app.greptile.com/coval/-/custom-context/knowledge-base/coval-ai/benchmarks/-/docs/runner-orchestration.md)

<!-- /greptile_comment -->