### PR TITLE
Warn instead of failing when an opted-out provider still has its key

### DIFF
--- a/runner/scripts/check_arena_keys.py
+++ b/runner/scripts/check_arena_keys.py
@@ -8,10 +8,11 @@ benchmarks-api from Secret Manager. Two infra layouts are understood:
 ``envs/prod/provider_keys.tf`` (one map entry per key; ``api = true`` marks
 the mount) and the older ``modules/cloud_run_service/main.tf`` (inline env
 blocks with ``secret_key_ref``). Fails if any provider the arena would
-synthesize lacks its key on the service (the cross-repo parity gate), and also
-fails when an ACTIVE provider is opted out with ``arena_enabled=False`` even
-though its key IS mounted — a stale opt-out that silently keeps the provider
-off the arena. Opted-out providers without a ``PROVIDER_ENV`` mapping (e.g.
+synthesize lacks its key on the service — the cross-repo parity gate, and the
+only failing condition. An ACTIVE provider opted out with
+``arena_enabled=False`` while its key IS mounted only warns: the registry owns
+arena membership, so a deliberate exclusion must not need an infra change to
+keep CI green. Opted-out providers without a ``PROVIDER_ENV`` mapping (e.g.
 ADC-authenticated ones) are skipped: there is no key mount to check them
 against.
 
@@ -109,7 +110,7 @@ def main(tf_path: str) -> int:
         )
         return 1
 
-    stale_opt_outs = sorted(
+    mounted_opt_outs = sorted(
         {
             m.provider
             for m in MODEL_REGISTRY
@@ -119,14 +120,13 @@ def main(tf_path: str) -> int:
             and PROVIDER_ENV.get(m.provider) in mounted
         }
     )
-    if stale_opt_outs:
+    if mounted_opt_outs:
         print(
-            f"ERROR: key mounted on benchmarks-api but arena_enabled=False: {stale_opt_outs}\n"
-            "The opt-out is stale — remove arena_enabled=False from these providers' "
-            "ACTIVE models in registries/models.py (or unmount the key if the "
-            "exclusion is intentional)."
+            f"::warning::key mounted on benchmarks-api but arena_enabled=False: "
+            f"{mounted_opt_outs}. Fine if the exclusion is deliberate. If it is not, "
+            "drop arena_enabled=False in registries/models.py, or unmount the key "
+            "to free the slot."
         )
-        return 1
 
     print(f"OK: all {len(required)} arena provider keys are mounted on benchmarks-api")
     return 0


### PR DESCRIPTION
The arena key parity check fails when an ACTIVE provider carries `arena_enabled=False` while its key is still mounted on benchmarks-api, on the theory that the opt-out is stale.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR makes mounted keys for explicitly arena-disabled providers produce a GitHub Actions warning rather than fail the parity check, while preserving hard failures for missing keys required by the arena.
- Renames the stale-opt-out collection to reflect the new intended semantics.
- Emits a workflow warning with remediation guidance for mounted, opted-out providers.
- Allows the check to exit successfully after that warning.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because the warning-only behavior matches the stated registry-ownership policy and leaves required-key failures intact.

The only behavior change removes the nonzero exit for mounted keys belonging to explicitly opted-out providers; required arena providers with missing mappings or mounts continue to fail the check.

<sub>Reviews (1): Last reviewed commit: ["Warn instead of failing when an opted-ou..."](https://github.com/coval-ai/benchmarks/commit/2fc3177c11241e06c57b50b013a645cc5f4810f6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51950187)</sub>

**Context used:**

- Knowledge Base — [Arena subsystem](https://app.greptile.com/coval/-/custom-context/knowledge-base/coval-ai/benchmarks/-/docs/arena-subsystem.md)

<!-- /greptile_comment -->