### PR TITLE
Give Deepgram a male voice alongside Thalia

### DIFF
--- a/runner/src/coval_bench/providers/tts/deepgram.py
+++ b/runner/src/coval_bench/providers/tts/deepgram.py
@@ -58,7 +58,10 @@ class DeepgramTTSProvider(TTSProvider):
 
     async def synthesize(self, text: str) -> TTSResult:
         """Synthesize speech via Deepgram WebSocket and return a TTSResult."""
-        if not self._model_supported(self._model):
+        # Deepgram addresses a speaker by model string, so the pooled voice — when
+        # one is assigned — selects the speaker and the endpoint family.
+        speaker = self._voice or self._model
+        if not self._model_supported(speaker):
             return TTSResult(
                 provider="deepgram",
                 model=self._model,
@@ -66,7 +69,7 @@ class DeepgramTTSProvider(TTSProvider):
                 ttfa_ms=None,
                 audio_path=None,
                 error=(
-                    f"Unsupported Deepgram TTS model: {self._model}. "
+                    f"Unsupported Deepgram TTS model: {speaker}. "
                     "Expected an 'aura-' or 'flux-' model."
                 ),
             )
@@ -74,11 +77,11 @@ class DeepgramTTSProvider(TTSProvider):
         start: float | None = None
         first_chunk_at: float | None = None
 
-        is_flux = self._model.startswith("flux-")
+        is_flux = speaker.startswith("flux-")
         base = _DEEPGRAM_FLUX_TTS_WS_BASE if is_flux else _DEEPGRAM_TTS_WS_BASE
         # Flux emits Flushed before the turn's audio; SpeechMetadata marks audio-complete.
         final_msg_type = "SpeechMetadata" if is_flux else "Flushed"
-        qs = urlencode({"encoding": "linear16", "sample_rate": SAMPLE_RATE, "model": self._model})
+        qs = urlencode({"encoding": "linear16", "sample_rate": SAMPLE_RATE, "model": speaker})
         url = f"{base}?{qs}"
         headers = {"Authorization": f"Token {self._api_key}"}
 

--- a/runner/src/coval_bench/registries/models.py
+++ b/runner/src/coval_bench/registries/models.py
@@ -521,6 +521,10 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         provider="deepgram",
         model="aura-2-thalia-en",
         voice="aura-2-thalia-en",
+        voices=(
+            Voice(id="aura-2-thalia-en", gender=Gender.FEMALE, name="Thalia", accent="en-US"),
+            Voice(id="aura-2-orion-en", gender=Gender.MALE, name="Orion", accent="en-US"),
+        ),
         tags=(_STREAMING, _STREAM),
         on_prem=True,
         status=_ACTIVE,

--- a/runner/tests/providers/tts/test_deepgram.py
+++ b/runner/tests/providers/tts/test_deepgram.py
@@ -136,6 +136,30 @@ async def test_deepgram_no_audio_chunks(fake_settings: Settings) -> None:
     assert result.ttfa_ms is None
 
 
+@pytest.mark.asyncio
+async def test_deepgram_voice_selects_the_speaker(fake_settings: Settings) -> None:
+    """A pooled voice addresses a speaker other than the entry's own model string."""
+    ws = FakeWebSocket(_speak_fixture_events([make_pcm_bytes(240)]))
+    provider = DeepgramTTSProvider(fake_settings, model="aura-2-thalia-en", voice="aura-2-orion-en")
+
+    captured: dict[str, str] = {}
+
+    def _capture(url: str, **_kwargs: object) -> Any:
+        captured["url"] = url
+        return _fake_connect(ws)
+
+    with patch("coval_bench.providers.tts.deepgram.ws_client.connect", side_effect=_capture):
+        result = await provider.synthesize("Hello from Orion")
+
+    assert urlparse(captured["url"]).path == "/v1/speak"
+    assert "model=aura-2-orion-en" in captured["url"]
+    assert result.error is None, f"Unexpected error: {result.error}"
+    assert result.voice == "aura-2-orion-en"
+    assert result.model == "aura-2-thalia-en"
+    assert result.audio_path is not None
+    result.audio_path.unlink()
+
+
 def test_deepgram_name_and_model(fake_settings: Settings) -> None:
     p = DeepgramTTSProvider(fake_settings, model="aura-2-thalia-en", voice="v")
     assert p.name == "deepgram-aura-2-thalia-en"

--- a/runner/tests/unit/test_tts_voice_assignment.py
+++ b/runner/tests/unit/test_tts_voice_assignment.py
@@ -87,14 +87,14 @@ def test_registry_pools_are_f_m_pairs() -> None:
 
 
 def test_active_tts_entries_have_pools() -> None:
-    """All ACTIVE TTS models split voices, except providers with no per-gender voices:
-    deepgram (voice IS the model string) and palabra (quality tiers only)."""
+    """All ACTIVE TTS models split voices, except palabra, whose voices are quality
+    tiers rather than speakers."""
     missing = [
         (m.provider, m.model)
         for m in MODEL_REGISTRY
         if m.benchmark is Benchmark.TTS
         and m.status is ModelStatus.ACTIVE
         and not m.voices
-        and m.provider not in ("deepgram", "palabra")
+        and m.provider != "palabra"
     ]
     assert missing == []


### PR DESCRIPTION
Deepgram addresses a speaker by model string, not a voice parameter, so it was the only ACTIVE TTS model not splitting runs across a female and a male voice. The provider now sends the assigned voice as the speaker and falls back to the model string when there's no pool.

Deferred : 
- Both voices were checked against the live API and return distinct audio. That row's TTFA and WER become a two-voice blend from here, so a methodology marker is owed. 
- Arena still synthesizes with the scalar `voice`, so this doesn't put Orion in battles on its own.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR enables balanced female/male speaker assignment for Deepgram Aura by treating the assigned voice as Deepgram’s speaker model while preserving the registry model as the benchmark identity.

- Adds Thalia and Orion as the voice pool for `aura-2-thalia-en`.
- Selects the Deepgram endpoint, protocol, and API model from the assigned speaker.
- Adds provider and assignment tests covering Orion selection and the active-model pool invariant.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no concrete changed-code defect identified.

The assigned Thalia and Orion values are valid Aura-family speaker models, and existing orchestration persists the selected voice separately while intentionally aggregating the balanced pool under the registry model.

<sub>Reviews (1): Last reviewed commit: ["Give Deepgram a male voice alongside Tha..."](https://github.com/coval-ai/benchmarks/commit/d3a532b4d601b820828a7dd89ee980a1bcb9e64b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51954637)</sub>

**Context used:**

- Knowledge Base — [Runner Orchestration](https://app.greptile.com/coval/-/custom-context/knowledge-base/coval-ai/benchmarks/-/docs/runner-orchestration.md)

<!-- /greptile_comment -->