### PR TITLE
Retire Rime Arcana

### DIFF
--- a/runner/src/coval_bench/registries/models.py
+++ b/runner/src/coval_bench/registries/models.py
@@ -578,10 +578,9 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         provider="rime",
         model="arcana",
         voice="luna",
-        voices=(Voice(id="luna", gender=Gender.FEMALE), Voice(id="masonry", gender=Gender.MALE)),
         tags=(_STREAMING, _MULTI, _EMOTION, _STREAM),
         on_prem=True,
-        status=_ACTIVE,
+        status=_RETIRED,
     ),
     RegisteredModel(
         benchmark=_TTS,


### PR DESCRIPTION
Arcana is getting retired on August 15. Will most likely forget to do it by that time, so retiring now.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR retires Rime Arcana while preserving its registry identity and default voice for historical results and replay.
- Changes Arcana's registry status from active to retired.
- Removes the voice-assignment pool that is no longer needed for scheduled runs.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge; no actionable defects were identified in the retirement change.

The status transition follows the registry's retirement behavior, and removing the voice pool does not affect a model that is no longer eligible for scheduled voice assignment.

<sub>Reviews (1): Last reviewed commit: ["Retire Rime Arcana"](https://github.com/coval-ai/benchmarks/commit/f8945cd62acc5c5a4d1abadb711b13d00919cea4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51962864)</sub>

**Context used:**

- Knowledge Base — [Runner Orchestration](https://app.greptile.com/coval/-/custom-context/knowledge-base/coval-ai/benchmarks/-/docs/runner-orchestration.md)

<!-- /greptile_comment -->