### PR TITLE
Add Inworld TTS 2 Flash under early access

### DIFF
--- a/runner/src/coval_bench/providers/tts/inworld.py
+++ b/runner/src/coval_bench/providers/tts/inworld.py
@@ -44,7 +44,14 @@ def _pcm_from_chunk(chunk: bytes) -> bytes:
 class InworldTTSProvider(TTSProvider):
     """Inworld AI TTS provider using WebSocket bidirectional streaming."""
 
-    _VALID_MODELS = frozenset({"inworld-tts-2", "inworld-tts-1.5-max", "inworld-tts-1.5-mini"})
+    _VALID_MODELS = frozenset(
+        {
+            "inworld-tts-2",
+            "inworld-tts-2-flash",
+            "inworld-tts-1.5-max",
+            "inworld-tts-1.5-mini",
+        }
+    )
 
     def __init__(self, settings: Settings, model: str, voice: str) -> None:
         if model not in self._VALID_MODELS:

--- a/runner/src/coval_bench/registries/models.py
+++ b/runner/src/coval_bench/registries/models.py
@@ -674,6 +674,18 @@ MODEL_REGISTRY: list[RegisteredModel] = [
     RegisteredModel(
         benchmark=_TTS,
         provider="inworld",
+        model="inworld-tts-2-flash",
+        voice="Brooke",
+        voices=(
+            Voice(id="Brooke", gender=Gender.FEMALE, accent="en-US"),
+            Voice(id="Jason", gender=Gender.MALE, accent="en-US"),
+        ),
+        tags=(_STREAMING, _MULTI, _CLONE, _EMOTION, _STREAM),
+        status=_EARLY_ACCESS,
+    ),
+    RegisteredModel(
+        benchmark=_TTS,
+        provider="inworld",
         model="inworld-tts-1.5-max",
         voice="Brooke",
         voices=(

--- a/runner/tests/providers/tts/test_inworld.py
+++ b/runner/tests/providers/tts/test_inworld.py
@@ -245,6 +245,12 @@ def test_inworld_accepts_tts_2(fake_settings: Settings) -> None:
     assert p.model == "inworld-tts-2"
 
 
+def test_inworld_accepts_tts_2_flash(fake_settings: Settings) -> None:
+    p = InworldTTSProvider(fake_settings, model="inworld-tts-2-flash", voice="Brooke")
+    assert p.name == "inworld-tts-2-flash"
+    assert p.model == "inworld-tts-2-flash"
+
+
 def test_inworld_rejects_unsupported_model(fake_settings: Settings) -> None:
     with pytest.raises(ValueError, match="Unsupported Inworld model"):
         InworldTTSProvider(fake_settings, model="not-a-real-model", voice="Brooke")


### PR DESCRIPTION
Adds `inworld-tts-2-flash`, Inworld's latency-tuned sibling to TTS 2, under early access 

Note:
- Inworld's docs also mark `inworld-tts-1.5-max` and `-mini` deprecated, but the automatic rerouting runs into the 1.5 family rather than out of it, so those entries stay active and keep reporting themselves. 
- Web side is in diff repo

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds Inworld TTS 2 Flash to the existing WebSocket provider and registers it as an early-access TTS model.
- Extends the Inworld provider model allowlist.
- Registers Brooke and Jason as the model's benchmark voices.
- Adds constructor-level coverage for the new model identifier.

<h3>Confidence Score: 4/5</h3>

The scheduling configuration should be corrected before merging because the new model will run on every normal shared benchmark rather than only nightly.

The early-access status makes the model schedulable, while its default shared source routes it into normal runs; repository nightly examples explicitly use the dedicated source.

**Files Needing Attention:** runner/src/coval_bench/registries/models.py

<sub>Reviews (1): Last reviewed commit: ["Add Inworld TTS 2 Flash under early acce..."](https://github.com/coval-ai/benchmarks/commit/b549a42efc1b2f0cb356436e70e4633803fabb0b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51976138)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Runner Orchestration](https://app.greptile.com/coval/-/custom-context/knowledge-base/coval-ai/benchmarks/-/docs/runner-orchestration.md)

<!-- /greptile_comment -->