### PR TITLE
Unlock early access from clerk session tokens

### DIFF
--- a/runner/src/coval_bench/api/app.py
+++ b/runner/src/coval_bench/api/app.py
@@ -133,13 +133,15 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     )
 
     # CORS — allowlist read from settings; never hard-coded (ADR-015).
+    # Proof headers are listed explicitly: the `*` wildcard never covers
+    # Authorization, so bearer preflights would fail under it.
     app.add_middleware(
         CORSMiddleware,
         allow_origins=resolved.cors_origins,
         allow_origin_regex=resolved.cors_origin_regex,
         allow_credentials=False,
         allow_methods=["GET", "OPTIONS"],
-        allow_headers=["*"],
+        allow_headers=["Authorization", "X-Internal-Key", "X-EA-Token"],
         max_age=600,
     )
 

--- a/runner/src/coval_bench/api/app.py
+++ b/runner/src/coval_bench/api/app.py
@@ -133,8 +133,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     )
 
     # CORS — allowlist read from settings; never hard-coded (ADR-015).
-    # Proof headers are listed explicitly: the `*` wildcard never covers
-    # Authorization, so bearer preflights would fail under it.
+    # Headers are explicit: the `*` wildcard never covers Authorization.
     app.add_middleware(
         CORSMiddleware,
         allow_origins=resolved.cors_origins,

--- a/runner/src/coval_bench/api/clerk.py
+++ b/runner/src/coval_bench/api/clerk.py
@@ -3,9 +3,10 @@
 
 """Resolve a Clerk session token to the embargoed models its holder may see.
 
-Verified against the instance JWKS (public — no secret involved). A coval.dev
-``email`` sees everything; an org sees the provider its ``org_id`` is mapped to
-in settings.
+Verified against the instance JWKS (public — no secret involved). A mapped
+``org_id`` scopes the caller to its provider — even for coval.dev emails, so
+switching into a partner org previews exactly their view. Outside a mapped
+org, a coval.dev ``email`` sees everything.
 """
 
 from __future__ import annotations
@@ -89,10 +90,10 @@ def allowed_pairs(
     claims = _claims(token.strip(), settings)
     if claims is None:
         return None
+    provider = _org_provider(claims, settings)
+    if provider is not None:
+        return frozenset(pair for pair in embargoed if pair[0] == provider)
     email = claims.get("email")
     if isinstance(email, str) and email.endswith(_INTERNAL_EMAIL_SUFFIX):
         return embargoed
-    provider = _org_provider(claims, settings)
-    if provider is None:
-        return frozenset()
-    return frozenset(pair for pair in embargoed if pair[0] == provider)
+    return frozenset()

--- a/runner/src/coval_bench/api/clerk.py
+++ b/runner/src/coval_bench/api/clerk.py
@@ -4,13 +4,15 @@
 """Resolve a Clerk session token to the embargoed models its holder may see.
 
 Verified against the instance JWKS (public — no secret involved). A coval.dev
-``email`` sees everything; an org sees its own provider's models (org slugs
-equal provider ids).
+``email`` sees everything; an org sees the provider its ``org_id`` is mapped to
+in settings.
 """
 
 from __future__ import annotations
 
 import functools
+import json
+from collections.abc import Mapping
 from typing import Any
 
 import jwt
@@ -26,6 +28,29 @@ _INTERNAL_EMAIL_SUFFIX = "@coval.dev"
 @functools.lru_cache(maxsize=4)
 def _jwks(issuer: str) -> jwt.PyJWKClient:
     return jwt.PyJWKClient(f"{issuer}/.well-known/jwks.json")
+
+
+@functools.lru_cache(maxsize=1)
+def _parse_org_providers(raw: str) -> Mapping[str, str]:
+    """Parse the ``{org_id: provider}`` settings blob; a malformed blob maps nothing."""
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        logger.error("clerk_org_providers_unparsable")
+        return {}
+    if not isinstance(parsed, dict) or not all(
+        isinstance(key, str) and isinstance(value, str) for key, value in parsed.items()
+    ):
+        logger.error("clerk_org_providers_malformed")
+        return {}
+    return parsed
+
+
+def _org_provider(claims: dict[str, Any], settings: Settings) -> str | None:
+    org_id = claims.get("org_id")
+    if not isinstance(org_id, str) or settings.clerk_org_providers is None:
+        return None
+    return _parse_org_providers(settings.clerk_org_providers).get(org_id)
 
 
 def _claims(token: str, settings: Settings) -> dict[str, Any] | None:
@@ -67,7 +92,7 @@ def allowed_pairs(
     email = claims.get("email")
     if isinstance(email, str) and email.endswith(_INTERNAL_EMAIL_SUFFIX):
         return embargoed
-    org_slug = claims.get("org_slug")
-    if not isinstance(org_slug, str) or not org_slug:
+    provider = _org_provider(claims, settings)
+    if provider is None:
         return frozenset()
-    return frozenset(pair for pair in embargoed if pair[0] == org_slug)
+    return frozenset(pair for pair in embargoed if pair[0] == provider)

--- a/runner/src/coval_bench/api/clerk.py
+++ b/runner/src/coval_bench/api/clerk.py
@@ -3,10 +3,9 @@
 
 """Resolve a Clerk session token to the embargoed models its holder may see.
 
-Verified against the instance JWKS (public — no secret involved). The token
-carries the user's verified ``email`` and active org's ``org_slug``: a coval.dev
-email sees everything, an org sees its own provider's models (org slugs equal
-provider ids), and a valid token matching neither keeps the public view.
+Verified against the instance JWKS (public — no secret involved). A coval.dev
+``email`` sees everything; an org sees its own provider's models (org slugs
+equal provider ids).
 """
 
 from __future__ import annotations
@@ -21,7 +20,6 @@ from coval_bench.config import Settings
 
 logger = structlog.get_logger("coval_bench.api.clerk")
 
-# Benchmarking-team domain; Clerk only exposes verified primary emails.
 _INTERNAL_EMAIL_SUFFIX = "@coval.dev"
 
 

--- a/runner/src/coval_bench/api/clerk.py
+++ b/runner/src/coval_bench/api/clerk.py
@@ -1,10 +1,12 @@
 # Copyright 2026 The Coval Benchmarks Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Resolve a Clerk session token to the embargoed models its org may see.
+"""Resolve a Clerk session token to the embargoed models its holder may see.
 
-Verified against the instance JWKS (public — no secret involved). The
-``benchmark_providers`` claim names the org's providers, or ``"*"`` for all.
+Verified against the instance JWKS (public — no secret involved). The token
+carries the user's verified ``email`` and active org's ``org_slug``: a coval.dev
+email sees everything, an org sees its own provider's models (org slugs equal
+provider ids), and a valid token matching neither keeps the public view.
 """
 
 from __future__ import annotations
@@ -18,6 +20,9 @@ import structlog
 from coval_bench.config import Settings
 
 logger = structlog.get_logger("coval_bench.api.clerk")
+
+# Benchmarking-team domain; Clerk only exposes verified primary emails.
+_INTERNAL_EMAIL_SUFFIX = "@coval.dev"
 
 
 @functools.lru_cache(maxsize=4)
@@ -61,9 +66,10 @@ def allowed_pairs(
     claims = _claims(token.strip(), settings)
     if claims is None:
         return None
-    providers = claims.get("benchmark_providers")
-    if providers == "*":
+    email = claims.get("email")
+    if isinstance(email, str) and email.endswith(_INTERNAL_EMAIL_SUFFIX):
         return embargoed
-    if not isinstance(providers, list):
+    org_slug = claims.get("org_slug")
+    if not isinstance(org_slug, str) or not org_slug:
         return frozenset()
-    return frozenset(pair for pair in embargoed if pair[0] in providers)
+    return frozenset(pair for pair in embargoed if pair[0] == org_slug)

--- a/runner/src/coval_bench/api/internal.py
+++ b/runner/src/coval_bench/api/internal.py
@@ -168,8 +168,9 @@ def hidden_early_access(
     """The pairs this caller's responses must not contain.
 
     Sets the cache headers here rather than per route, so no endpoint can serve
-    embargoed rows without them. Only a presented-but-unknown token is logged; an
-    absent one is ordinary public traffic. Subtracting the allowlist means an entry
+    embargoed rows without them. A caller presenting several proofs gets the union
+    of what they unlock. Only a presented-but-unknown token is logged; an absent
+    one is ordinary public traffic. Subtracting the allowlist means an entry
     naming a model that is no longer embargoed is inert, and no token reveals what
     the registry does not currently embargo.
     """
@@ -183,26 +184,29 @@ def hidden_early_access(
         return frozenset()
 
     embargoed = embargoed_pairs()
-    if x_ea_token is None and authorization is not None and settings.clerk_issuer is not None:
-        allowed = clerk.allowed_pairs(authorization, settings, embargoed)
-        if allowed is None:
-            response.headers[EA_STATUS_HEADER] = "unknown"
-            return embargoed
-        response.headers[EA_STATUS_HEADER] = "accepted"
-        response.headers["Cache-Control"] = "private, no-store"
-        return embargoed - with_retired_keys(allowed)
+    bearer_presented = authorization is not None and settings.clerk_issuer is not None
 
-    if x_ea_token is None:
+    # None means no proof was accepted, distinct from accepted-but-unlocks-nothing.
+    unlocked: frozenset[tuple[str, str]] | None = None
+    if x_ea_token is not None:
+        allowed = _allowed_for(x_ea_token, _allowlists(settings))
+        if allowed is None:
+            # The one case worth alerting on: a link that should work and doesn't.
+            logger.warning("early_access_token_unknown", token=_fingerprint(x_ea_token))
+        else:
+            unlocked = with_retired_keys(allowed)
+    if authorization is not None and settings.clerk_issuer is not None:
+        allowed = clerk.allowed_pairs(authorization, settings, embargoed)
+        if allowed is not None:
+            unlocked = (unlocked or frozenset()) | with_retired_keys(allowed)
+
+    if x_ea_token is None and not bearer_presented:
         response.headers[EA_STATUS_HEADER] = "absent"
         return embargoed
-
-    allowed = _allowed_for(x_ea_token, _allowlists(settings))
-    if allowed is None:
-        # The one case worth alerting on: a link that should work and doesn't.
-        logger.warning("early_access_token_unknown", token=_fingerprint(x_ea_token))
+    if unlocked is None:
         response.headers[EA_STATUS_HEADER] = "unknown"
         return embargoed
 
     response.headers[EA_STATUS_HEADER] = "accepted"
     response.headers["Cache-Control"] = "private, no-store"
-    return embargoed - with_retired_keys(allowed)
+    return embargoed - unlocked

--- a/runner/src/coval_bench/api/internal.py
+++ b/runner/src/coval_bench/api/internal.py
@@ -167,12 +167,9 @@ def hidden_early_access(
 ) -> frozenset[tuple[str, str]]:
     """The pairs this caller's responses must not contain.
 
-    Sets the cache headers here rather than per route, so no endpoint can serve
-    embargoed rows without them. A caller presenting several proofs gets the union
-    of what they unlock. Only a presented-but-unknown token is logged; an absent
-    one is ordinary public traffic. Subtracting the allowlist means an entry
-    naming a model that is no longer embargoed is inert, and no token reveals what
-    the registry does not currently embargo.
+    Cache headers are set here rather than per route, so no endpoint can serve
+    embargoed rows without them. Several proofs may be presented at once; the
+    caller gets the union of what they unlock.
     """
     # Appended, not assigned: SelectiveGZipMiddleware adds Accept-Encoding after
     # the route returns, and assignment here would be overwritten.
@@ -184,25 +181,22 @@ def hidden_early_access(
         return frozenset()
 
     embargoed = embargoed_pairs()
-    bearer_presented = authorization is not None and settings.clerk_issuer is not None
-
-    # None means no proof was accepted, distinct from accepted-but-unlocks-nothing.
     unlocked: frozenset[tuple[str, str]] | None = None
     if x_ea_token is not None:
         allowed = _allowed_for(x_ea_token, _allowlists(settings))
         if allowed is None:
-            # The one case worth alerting on: a link that should work and doesn't.
             logger.warning("early_access_token_unknown", token=_fingerprint(x_ea_token))
         else:
             unlocked = with_retired_keys(allowed)
-    if authorization is not None and settings.clerk_issuer is not None:
-        allowed = clerk.allowed_pairs(authorization, settings, embargoed)
-        if allowed is not None:
-            unlocked = (unlocked or frozenset()) | with_retired_keys(allowed)
 
-    if x_ea_token is None and not bearer_presented:
+    if authorization is not None and settings.clerk_issuer is not None:
+        bearer = clerk.allowed_pairs(authorization, settings, embargoed)
+        if bearer is not None:
+            unlocked = (unlocked or frozenset()) | with_retired_keys(bearer)
+    elif x_ea_token is None:
         response.headers[EA_STATUS_HEADER] = "absent"
         return embargoed
+
     if unlocked is None:
         response.headers[EA_STATUS_HEADER] = "unknown"
         return embargoed

--- a/runner/src/coval_bench/config.py
+++ b/runner/src/coval_bench/config.py
@@ -187,6 +187,10 @@ class Settings(BaseSettings):
     clerk_issuer: str | None = None
     # Allowed azp claim values; bearer tokens are rejected while empty.
     clerk_authorized_parties: list[str] = []
+    # Clerk org id -> provider id, as a JSON object: {"org_abc123": "deepgram"}.
+    # Keyed by the immutable org id, not the slug, which org admins can rename.
+    # An org missing from the map unlocks nothing.
+    clerk_org_providers: str | None = None
 
     # --- Arena ---
     arena_labeler_key: SecretStr | None = None

--- a/runner/tests/api/test_clerk_scope.py
+++ b/runner/tests/api/test_clerk_scope.py
@@ -40,6 +40,7 @@ _PUBLIC_PEM = _PRIVATE_KEY.public_key().public_bytes(
 )
 
 _INTERNAL_EMAIL = "someone@coval.dev"
+_ORG_ID = "org_2abc123"
 
 
 @pytest.fixture(autouse=True)
@@ -54,6 +55,7 @@ def _settings(
     issuer: str | None = _ISSUER,
     parties: str | None = f'["{_PARTY}"]',
     ea_tokens: str | None = None,
+    org_providers: str | None = None,
 ) -> Settings:
     monkeypatch.setenv("DATABASE_URL", "postgresql://runner:password@localhost:5432/benchmarks")
     monkeypatch.setenv("DATASET_BUCKET", "test-bucket")
@@ -64,6 +66,10 @@ def _settings(
         monkeypatch.delenv("EARLY_ACCESS_TOKENS", raising=False)
     else:
         monkeypatch.setenv("EARLY_ACCESS_TOKENS", ea_tokens)
+    if org_providers is None:
+        monkeypatch.delenv("CLERK_ORG_PROVIDERS", raising=False)
+    else:
+        monkeypatch.setenv("CLERK_ORG_PROVIDERS", org_providers)
     if issuer is None:
         monkeypatch.delenv("CLERK_ISSUER", raising=False)
     else:
@@ -118,8 +124,8 @@ def test_org_sees_its_own_providers_models_and_no_others(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     mine, theirs = _two_embargoed_providers()
-    settings = _settings(monkeypatch)
-    token = _mint({"org_slug": mine})
+    settings = _settings(monkeypatch, org_providers=json.dumps({_ORG_ID: mine}))
+    token = _mint({"org_id": _ORG_ID})
     hidden, status = _resolve(settings, f"Bearer {token}")
     assert status == "accepted"
     assert hidden == frozenset(pair for pair in embargoed_pairs() if pair[0] != mine)
@@ -138,8 +144,8 @@ def test_coval_email_sees_everything(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_coval_email_wins_over_the_org(monkeypatch: pytest.MonkeyPatch) -> None:
     """A coval.dev user browsing under a provider org still sees everything."""
     provider = _embargoed_provider()
-    settings = _settings(monkeypatch)
-    token = _mint({"email": _INTERNAL_EMAIL, "org_slug": provider})
+    settings = _settings(monkeypatch, org_providers=json.dumps({_ORG_ID: provider}))
+    token = _mint({"email": _INTERNAL_EMAIL, "org_id": _ORG_ID})
     hidden, status = _resolve(settings, f"Bearer {token}")
     assert status == "accepted"
     assert hidden == frozenset()
@@ -168,7 +174,27 @@ def test_signed_in_user_without_an_org_keeps_the_public_view(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     settings = _settings(monkeypatch)
-    token = _mint({"email": "user@example.com", "org_slug": None})
+    token = _mint({"email": "user@example.com", "org_id": None})
+    hidden, status = _resolve(settings, f"Bearer {token}")
+    assert status == "accepted"
+    assert hidden == embargoed_pairs()
+
+
+def test_unmapped_org_keeps_the_public_view(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A real org unlocks nothing until settings say which provider it is."""
+    provider = _embargoed_provider()
+    settings = _settings(monkeypatch, org_providers=json.dumps({_ORG_ID: provider}))
+    token = _mint({"org_id": "org_2someoneelse"})
+    hidden, status = _resolve(settings, f"Bearer {token}")
+    assert status == "accepted"
+    assert hidden == embargoed_pairs()
+
+
+def test_org_without_a_configured_map_keeps_the_public_view(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    settings = _settings(monkeypatch)
+    token = _mint({"org_id": _ORG_ID})
     hidden, status = _resolve(settings, f"Bearer {token}")
     assert status == "accepted"
     assert hidden == embargoed_pairs()
@@ -176,8 +202,8 @@ def test_signed_in_user_without_an_org_keeps_the_public_view(
 
 def test_claims_of_the_wrong_shape_unlock_nothing(monkeypatch: pytest.MonkeyPatch) -> None:
     provider = _embargoed_provider()
-    settings = _settings(monkeypatch)
-    token = _mint({"email": [_INTERNAL_EMAIL], "org_slug": [provider]})
+    settings = _settings(monkeypatch, org_providers=json.dumps({_ORG_ID: provider}))
+    token = _mint({"email": [_INTERNAL_EMAIL], "org_id": [_ORG_ID]})
     hidden, status = _resolve(settings, f"Bearer {token}")
     assert status == "accepted"
     assert hidden == embargoed_pairs()
@@ -292,8 +318,9 @@ def test_partner_token_and_bearer_unlock_the_union(monkeypatch: pytest.MonkeyPat
     settings = _settings(
         monkeypatch,
         ea_tokens=json.dumps({"partner-token": [f"{their_pair[0]}/{their_pair[1]}"]}),
+        org_providers=json.dumps({_ORG_ID: mine}),
     )
-    token = _mint({"org_slug": mine})
+    token = _mint({"org_id": _ORG_ID})
     hidden, status = _resolve(settings, f"Bearer {token}", x_ea_token="partner-token")  # noqa: S106 - fake token
     assert status == "accepted"
     unlocked = with_retired_keys(
@@ -320,7 +347,7 @@ def test_valid_partner_token_survives_a_bad_bearer(monkeypatch: pytest.MonkeyPat
         ea_tokens=json.dumps({"partner-token": [f"{pair[0]}/{pair[1]}"]}),
     )
     now = int(time.time())
-    expired = _mint({"org_slug": provider}, iat=now - 120, exp=now - 60)
+    expired = _mint({"org_id": _ORG_ID}, iat=now - 120, exp=now - 60)
     hidden, status = _resolve(settings, f"Bearer {expired}", x_ea_token="partner-token")  # noqa: S106 - fake token
     assert status == "accepted"
     assert hidden == embargoed_pairs() - with_retired_keys(frozenset({pair}))

--- a/runner/tests/api/test_clerk_scope.py
+++ b/runner/tests/api/test_clerk_scope.py
@@ -9,6 +9,7 @@ as the roster changes status.
 
 from __future__ import annotations
 
+import json
 import time
 from types import SimpleNamespace
 from typing import Any
@@ -20,7 +21,12 @@ from cryptography.hazmat.primitives.asymmetric import rsa
 from fastapi import Response
 
 from coval_bench.api import clerk
-from coval_bench.api.internal import EA_STATUS_HEADER, embargoed_pairs, hidden_early_access
+from coval_bench.api.internal import (
+    EA_STATUS_HEADER,
+    embargoed_pairs,
+    hidden_early_access,
+    with_retired_keys,
+)
 from coval_bench.config import Settings
 
 _ISSUER = "https://clerk.example.com"
@@ -32,6 +38,8 @@ _PUBLIC_PEM = _PRIVATE_KEY.public_key().public_bytes(
     encoding=serialization.Encoding.PEM,
     format=serialization.PublicFormat.SubjectPublicKeyInfo,
 )
+
+_INTERNAL_EMAIL = "someone@coval.dev"
 
 
 @pytest.fixture(autouse=True)
@@ -45,13 +53,17 @@ def _settings(
     monkeypatch: pytest.MonkeyPatch,
     issuer: str | None = _ISSUER,
     parties: str | None = f'["{_PARTY}"]',
+    ea_tokens: str | None = None,
 ) -> Settings:
     monkeypatch.setenv("DATABASE_URL", "postgresql://runner:password@localhost:5432/benchmarks")
     monkeypatch.setenv("DATASET_BUCKET", "test-bucket")
     monkeypatch.setenv("DATASET_ID", "stt-v1")
     monkeypatch.setenv("RUNNER_SHA", "test-sha")
     monkeypatch.delenv("INTERNAL_API_KEY", raising=False)
-    monkeypatch.delenv("EARLY_ACCESS_TOKENS", raising=False)
+    if ea_tokens is None:
+        monkeypatch.delenv("EARLY_ACCESS_TOKENS", raising=False)
+    else:
+        monkeypatch.setenv("EARLY_ACCESS_TOKENS", ea_tokens)
     if issuer is None:
         monkeypatch.delenv("CLERK_ISSUER", raising=False)
     else:
@@ -107,7 +119,7 @@ def test_org_sees_its_own_providers_models_and_no_others(
 ) -> None:
     mine, theirs = _two_embargoed_providers()
     settings = _settings(monkeypatch)
-    token = _mint({"benchmark_providers": [mine]})
+    token = _mint({"org_slug": mine})
     hidden, status = _resolve(settings, f"Bearer {token}")
     assert status == "accepted"
     assert hidden == frozenset(pair for pair in embargoed_pairs() if pair[0] != mine)
@@ -115,15 +127,34 @@ def test_org_sees_its_own_providers_models_and_no_others(
     assert any(provider == theirs for provider, _ in hidden)
 
 
-def test_star_claim_sees_everything(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_coval_email_sees_everything(monkeypatch: pytest.MonkeyPatch) -> None:
     settings = _settings(monkeypatch)
-    token = _mint({"benchmark_providers": "*"})
+    token = _mint({"email": _INTERNAL_EMAIL})
     hidden, status = _resolve(settings, f"Bearer {token}")
     assert status == "accepted"
     assert hidden == frozenset()
 
 
-def test_session_without_the_claim_keeps_the_public_view(
+def test_coval_email_wins_over_the_org(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A coval.dev user browsing under a provider org still sees everything."""
+    provider = _embargoed_provider()
+    settings = _settings(monkeypatch)
+    token = _mint({"email": _INTERNAL_EMAIL, "org_slug": provider})
+    hidden, status = _resolve(settings, f"Bearer {token}")
+    assert status == "accepted"
+    assert hidden == frozenset()
+
+
+def test_lookalike_email_domain_unlocks_nothing(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Only the exact @coval.dev suffix is internal, not a domain ending in it."""
+    settings = _settings(monkeypatch)
+    token = _mint({"email": "someone@notcoval.dev"})
+    hidden, status = _resolve(settings, f"Bearer {token}")
+    assert status == "accepted"
+    assert hidden == embargoed_pairs()
+
+
+def test_session_without_the_claims_keeps_the_public_view(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     settings = _settings(monkeypatch)
@@ -133,10 +164,20 @@ def test_session_without_the_claim_keeps_the_public_view(
     assert hidden == embargoed_pairs()
 
 
-def test_claim_of_the_wrong_shape_unlocks_nothing(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_signed_in_user_without_an_org_keeps_the_public_view(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    settings = _settings(monkeypatch)
+    token = _mint({"email": "user@example.com", "org_slug": None})
+    hidden, status = _resolve(settings, f"Bearer {token}")
+    assert status == "accepted"
+    assert hidden == embargoed_pairs()
+
+
+def test_claims_of_the_wrong_shape_unlock_nothing(monkeypatch: pytest.MonkeyPatch) -> None:
     provider = _embargoed_provider()
     settings = _settings(monkeypatch)
-    token = _mint({"benchmark_providers": provider})
+    token = _mint({"email": [_INTERNAL_EMAIL], "org_slug": [provider]})
     hidden, status = _resolve(settings, f"Bearer {token}")
     assert status == "accepted"
     assert hidden == embargoed_pairs()
@@ -145,7 +186,7 @@ def test_claim_of_the_wrong_shape_unlocks_nothing(monkeypatch: pytest.MonkeyPatc
 def test_expired_token_keeps_the_public_view(monkeypatch: pytest.MonkeyPatch) -> None:
     settings = _settings(monkeypatch)
     now = int(time.time())
-    token = _mint({"benchmark_providers": "*"}, iat=now - 120, exp=now - 60)
+    token = _mint({"email": _INTERNAL_EMAIL}, iat=now - 120, exp=now - 60)
     hidden, status = _resolve(settings, f"Bearer {token}")
     assert status == "unknown"
     assert hidden == embargoed_pairs()
@@ -155,7 +196,7 @@ def test_token_signed_by_another_key_keeps_the_public_view(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     settings = _settings(monkeypatch)
-    token = _mint({"benchmark_providers": "*"}, key=_OTHER_KEY)
+    token = _mint({"email": _INTERNAL_EMAIL}, key=_OTHER_KEY)
     hidden, status = _resolve(settings, f"Bearer {token}")
     assert status == "unknown"
     assert hidden == embargoed_pairs()
@@ -165,7 +206,7 @@ def test_token_from_another_issuer_keeps_the_public_view(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     settings = _settings(monkeypatch)
-    token = _mint({"benchmark_providers": "*"}, iss="https://not-clerk.example.com")
+    token = _mint({"email": _INTERNAL_EMAIL}, iss="https://not-clerk.example.com")
     hidden, status = _resolve(settings, f"Bearer {token}")
     assert status == "unknown"
     assert hidden == embargoed_pairs()
@@ -175,7 +216,7 @@ def test_azp_outside_the_allowlist_keeps_the_public_view(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     settings = _settings(monkeypatch, parties=f'["{_PARTY}"]')
-    token = _mint({"benchmark_providers": "*"}, azp="https://elsewhere.example.com")
+    token = _mint({"email": _INTERNAL_EMAIL}, azp="https://elsewhere.example.com")
     hidden, status = _resolve(settings, f"Bearer {token}")
     assert status == "unknown"
     assert hidden == embargoed_pairs()
@@ -183,7 +224,7 @@ def test_azp_outside_the_allowlist_keeps_the_public_view(
 
 def test_azp_in_the_allowlist_is_accepted(monkeypatch: pytest.MonkeyPatch) -> None:
     settings = _settings(monkeypatch, parties=f'["{_PARTY}"]')
-    token = _mint({"benchmark_providers": "*"})
+    token = _mint({"email": _INTERNAL_EMAIL})
     hidden, status = _resolve(settings, f"Bearer {token}")
     assert status == "accepted"
     assert hidden == frozenset()
@@ -191,7 +232,7 @@ def test_azp_in_the_allowlist_is_accepted(monkeypatch: pytest.MonkeyPatch) -> No
 
 def test_unset_authorized_parties_rejects_every_token(monkeypatch: pytest.MonkeyPatch) -> None:
     settings = _settings(monkeypatch, parties=None)
-    token = _mint({"benchmark_providers": "*"})
+    token = _mint({"email": _INTERNAL_EMAIL})
     hidden, status = _resolve(settings, f"Bearer {token}")
     assert status == "unknown"
     assert hidden == embargoed_pairs()
@@ -213,14 +254,14 @@ def test_accepted_bearer_response_is_never_stored_shared(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     settings = _settings(monkeypatch)
-    token = _mint({"benchmark_providers": "*"})
+    token = _mint({"email": _INTERNAL_EMAIL})
     headers = _headers(settings, f"Bearer {token}")
     assert headers["cache-control"] == "private, no-store"
 
 
 def test_bearer_responses_vary_on_authorization(monkeypatch: pytest.MonkeyPatch) -> None:
     settings = _settings(monkeypatch)
-    token = _mint({"benchmark_providers": "*"})
+    token = _mint({"email": _INTERNAL_EMAIL})
     headers = _headers(settings, f"Bearer {token}")
     assert "Authorization" in headers["vary"]
 
@@ -229,7 +270,7 @@ def test_bearer_is_ignored_when_clerk_is_not_configured(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     settings = _settings(monkeypatch, issuer=None)
-    token = _mint({"benchmark_providers": "*"})
+    token = _mint({"email": _INTERNAL_EMAIL})
     hidden, status = _resolve(settings, f"Bearer {token}")
     assert status == "absent"
     assert hidden == embargoed_pairs()
@@ -244,13 +285,51 @@ def test_non_bearer_authorization_keeps_the_public_view(
     assert hidden == embargoed_pairs()
 
 
-def test_partner_token_takes_precedence_over_bearer(monkeypatch: pytest.MonkeyPatch) -> None:
-    settings = _settings(monkeypatch)
-    token = _mint({"benchmark_providers": "*"})
-    hidden, status = _resolve(
-        settings,
-        f"Bearer {token}",
-        x_ea_token="not-a-configured-token",  # noqa: S106 - fake token
+def test_partner_token_and_bearer_unlock_the_union(monkeypatch: pytest.MonkeyPatch) -> None:
+    """One request may carry both proofs, say an embargo link opened while signed in."""
+    mine, theirs = _two_embargoed_providers()
+    their_pair = min(pair for pair in embargoed_pairs() if pair[0] == theirs)
+    settings = _settings(
+        monkeypatch,
+        ea_tokens=json.dumps({"partner-token": [f"{their_pair[0]}/{their_pair[1]}"]}),
     )
+    token = _mint({"org_slug": mine})
+    hidden, status = _resolve(settings, f"Bearer {token}", x_ea_token="partner-token")  # noqa: S106 - fake token
+    assert status == "accepted"
+    unlocked = with_retired_keys(
+        frozenset({their_pair}) | frozenset(pair for pair in embargoed_pairs() if pair[0] == mine)
+    )
+    assert hidden == embargoed_pairs() - unlocked
+
+
+def test_valid_bearer_rescues_an_unknown_partner_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    settings = _settings(monkeypatch)
+    token = _mint({"email": _INTERNAL_EMAIL})
+    hidden, status = _resolve(settings, f"Bearer {token}", x_ea_token="not-a-configured-token")  # noqa: S106 - fake token
+    assert status == "accepted"
+    assert hidden == frozenset()
+
+
+def test_valid_partner_token_survives_a_bad_bearer(monkeypatch: pytest.MonkeyPatch) -> None:
+    provider = _embargoed_provider()
+    pair = min(p for p in embargoed_pairs() if p[0] == provider)
+    settings = _settings(
+        monkeypatch,
+        ea_tokens=json.dumps({"partner-token": [f"{pair[0]}/{pair[1]}"]}),
+    )
+    now = int(time.time())
+    expired = _mint({"org_slug": provider}, iat=now - 120, exp=now - 60)
+    hidden, status = _resolve(settings, f"Bearer {expired}", x_ea_token="partner-token")  # noqa: S106 - fake token
+    assert status == "accepted"
+    assert hidden == embargoed_pairs() - with_retired_keys(frozenset({pair}))
+
+
+def test_two_bad_proofs_stay_unknown(monkeypatch: pytest.MonkeyPatch) -> None:
+    settings = _settings(monkeypatch)
+    now = int(time.time())
+    expired = _mint({"email": _INTERNAL_EMAIL}, iat=now - 120, exp=now - 60)
+    hidden, status = _resolve(settings, f"Bearer {expired}", x_ea_token="not-a-configured-token")  # noqa: S106 - fake token
     assert status == "unknown"
     assert hidden == embargoed_pairs()

--- a/runner/tests/api/test_clerk_scope.py
+++ b/runner/tests/api/test_clerk_scope.py
@@ -141,11 +141,23 @@ def test_coval_email_sees_everything(monkeypatch: pytest.MonkeyPatch) -> None:
     assert hidden == frozenset()
 
 
-def test_coval_email_wins_over_the_org(monkeypatch: pytest.MonkeyPatch) -> None:
-    """A coval.dev user browsing under a provider org still sees everything."""
+def test_mapped_org_scopes_even_a_coval_email(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Switching into a partner org previews exactly that org's view."""
     provider = _embargoed_provider()
     settings = _settings(monkeypatch, org_providers=json.dumps({_ORG_ID: provider}))
     token = _mint({"email": _INTERNAL_EMAIL, "org_id": _ORG_ID})
+    hidden, status = _resolve(settings, f"Bearer {token}")
+    assert status == "accepted"
+    assert hidden == frozenset(pair for pair in embargoed_pairs() if pair[0] != provider)
+
+
+def test_coval_email_in_an_unmapped_org_still_sees_everything(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Only a mapped org narrows the view; an unmapped one must not demote to public."""
+    provider = _embargoed_provider()
+    settings = _settings(monkeypatch, org_providers=json.dumps({_ORG_ID: provider}))
+    token = _mint({"email": _INTERNAL_EMAIL, "org_id": "org_2someoneelse"})
     hidden, status = _resolve(settings, f"Bearer {token}")
     assert status == "accepted"
     assert hidden == frozenset()

--- a/runner/tests/api/test_cors.py
+++ b/runner/tests/api/test_cors.py
@@ -61,6 +61,26 @@ async def test_cors_methods_include_get_options(client: AsyncClient) -> None:
     assert "GET" in methods_header
 
 
+async def test_cors_preflight_allows_the_proof_headers(client: AsyncClient) -> None:
+    """Preflight passes for every embargo proof header, Authorization included.
+
+    Authorization is the header the `*` wildcard never covers, so this pins the
+    explicit allowlist.
+    """
+    response = await client.options(
+        "/v1/results",
+        headers={
+            "Origin": "https://benchmarks.coval.ai",
+            "Access-Control-Request-Method": "GET",
+            "Access-Control-Request-Headers": "authorization, x-ea-token, x-internal-key",
+        },
+    )
+    assert response.status_code in (200, 204)
+    allowed = response.headers.get("access-control-allow-headers", "").lower()
+    for header in ("authorization", "x-ea-token", "x-internal-key"):
+        assert header in allowed, f"{header} missing from {allowed!r}"
+
+
 async def test_cors_vercel_canonical_allowed(client: AsyncClient) -> None:
     """The canonical Vercel project URL is in the static allowlist."""
     response = await client.options(

--- a/runner/tests/api/test_cors.py
+++ b/runner/tests/api/test_cors.py
@@ -62,11 +62,7 @@ async def test_cors_methods_include_get_options(client: AsyncClient) -> None:
 
 
 async def test_cors_preflight_allows_the_proof_headers(client: AsyncClient) -> None:
-    """Preflight passes for every embargo proof header, Authorization included.
-
-    Authorization is the header the `*` wildcard never covers, so this pins the
-    explicit allowlist.
-    """
+    """Preflight passes for the proof headers; `*` never covers Authorization."""
     response = await client.options(
         "/v1/results",
         headers={


### PR DESCRIPTION
Second half of adding clerk auth to the frontend.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR changes early-access authorization to derive access from Clerk email and organization claims, combines Clerk and opaque-token entitlements, and explicitly limits CORS request headers.

- Grants full embargo access to `@coval.dev` session holders and provider-scoped access from `org_slug`
- Unions entitlements when both Clerk and `X-EA-Token` proofs are supplied
- Adds coverage for claim scoping, combined proofs, invalid proofs, caching headers, and CORS preflights

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because no concrete, currently reachable failure was established.

The changed authorization paths preserve the public view for invalid proofs, union valid entitlements, and keep authenticated responses private, while the explicit CORS list covers the request headers used by the current API clients.

<sub>Reviews (1): Last reviewed commit: ["Trim comments in the embargo gate"](https://github.com/coval-ai/benchmarks/commit/f0e501b16456ee981331b7234dc6391919c26e8c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52002671)</sub>

**Context used:**

- Knowledge Base — [API service](https://app.greptile.com/coval/-/custom-context/knowledge-base/coval-ai/benchmarks/-/docs/api-service.md)

<!-- /greptile_comment -->