### PR TITLE
Pair arena battles within one gender

### DIFF
--- a/runner/src/coval_bench/api/routers/arena.py
+++ b/runner/src/coval_bench/api/routers/arena.py
@@ -63,7 +63,8 @@ from coval_bench.arena.monitoring import (
 from coval_bench.arena.pairing import (
     PAIRING_DOMAIN,
     PAIRING_METRIC,
-    active_tts_models,
+    gender_for_next_battle,
+    roster_for,
     select_pair,
 )
 from coval_bench.arena.prompts import EXAMPLE_PROMPTS
@@ -376,7 +377,10 @@ async def create_battle(
         )
         raise HTTPException(429, "daily generation limit reached")
 
-    models = active_tts_models()
+    # Whichever gender has fewer battles goes next, so the two accrue votes at
+    # the same rate and neither board lags the other into significance.
+    gender = gender_for_next_battle(await store.count_battles_by_gender())
+    models = roster_for(gender)
     if len(models) < 2:
         raise HTTPException(503, "not enough active TTS models to form a battle")
     ratings = await store.get_latest_ratings(metric_name=PAIRING_METRIC, domain=PAIRING_DOMAIN)
@@ -387,6 +391,7 @@ async def create_battle(
         prompt=prompt,
         domain=body.domain,
         pair=pair,
+        gender=gender,
     )
     if battle is None:
         raise HTTPException(502, "audio synthesis failed for one or both models")

--- a/runner/src/coval_bench/api/routers/arena.py
+++ b/runner/src/coval_bench/api/routers/arena.py
@@ -165,7 +165,10 @@ async def get_battle(
     # Placeholder selection: a uniformly random battle. Adaptive pairing will
     # replace this to surface the most informative matchups. With GCS-backed
     # clips, skip battles older than the bucket retention — their audio is gone.
-    conditions = []
+    # Only gendered battles. Their votes still count, but serving a legacy
+    # cross-gender pairing would keep adding the very comparison this stopped
+    # making — the old share should shrink from here, not grow.
+    conditions = ["gender IS NOT NULL"]
     params: dict[str, Any] = {}
     if settings.arena_gcs_bucket:
         conditions.append("created_at >= now() - make_interval(days => %(days)s)")

--- a/runner/src/coval_bench/arena/generate.py
+++ b/runner/src/coval_bench/arena/generate.py
@@ -19,12 +19,13 @@ from typing import Any
 import structlog
 
 from coval_bench.arena.audio_store import store_clip
+from coval_bench.arena.pairing import voice_for
 from coval_bench.config import Settings
 from coval_bench.db.arena_store import ArenaStore
 from coval_bench.db.models import Battle
 from coval_bench.providers.base import TTSResult
 from coval_bench.providers.tts import TTS_PROVIDERS
-from coval_bench.registries.models import RegisteredModel
+from coval_bench.registries.models import Gender, RegisteredModel, Voice
 
 logger: structlog.BoundLogger = structlog.get_logger(__name__)
 
@@ -38,20 +39,28 @@ async def generate_battle(
     prompt: str,
     domain: str | None,
     pair: tuple[RegisteredModel, RegisteredModel],
+    gender: Gender,
     rng: random.Random | None = None,
 ) -> Battle | None:
     """Synthesize both sides of *pair* on *prompt*, store the clips, persist a battle.
 
-    Returns the inserted ``Battle``, or ``None`` if either synthesis fails (no row
-    is written). ``rng`` is injectable so the A/B assignment is deterministic in tests.
+    Both sides speak in *gender*, so a listener compares delivery rather than
+    register. Returns the inserted ``Battle``, or ``None`` if either synthesis
+    fails (no row is written). ``rng`` is injectable so the A/B assignment is
+    deterministic in tests.
     """
     picker = rng if rng is not None else random.Random()  # noqa: S311
     first, second = pair
     model_a, model_b = (first, second) if picker.random() < 0.5 else (second, first)
 
+    # Resolved before synthesis: a roster that cannot field this gender is a
+    # caller error, and it should surface without paying for any audio.
+    voice_a = voice_for(model_a, gender)
+    voice_b = voice_for(model_b, gender)
+
     path_a, path_b = await asyncio.gather(
-        _synthesize(settings, model_a, prompt),
-        _synthesize(settings, model_b, prompt),
+        _synthesize(settings, model_a, prompt, voice_a),
+        _synthesize(settings, model_b, prompt, voice_b),
     )
     if path_a is None or path_b is None:
         for path in (path_a, path_b):
@@ -85,6 +94,9 @@ async def generate_battle(
         prompt_text=prompt,
         audio_a_url=audio_a_url,
         audio_b_url=audio_b_url,
+        voice_a=voice_a.id,
+        voice_b=voice_b.id,
+        gender=gender,
     )
     inserted = await store.insert_battle(battle)
     logger.info(
@@ -97,18 +109,17 @@ async def generate_battle(
     return inserted
 
 
-async def _synthesize(settings: Settings, model: RegisteredModel, prompt: str) -> Path | None:
-    """Synthesize one side; return its WAV path, or ``None`` on any failure."""
+async def _synthesize(
+    settings: Settings, model: RegisteredModel, prompt: str, voice: Voice
+) -> Path | None:
+    """Synthesize one side in *voice*; return its WAV path, or ``None`` on any failure."""
     provider_cls: Any = TTS_PROVIDERS.get(model.provider)
     if provider_cls is None:
         logger.warning("arena_unknown_provider", provider=model.provider, model=model.model)
         return None
-    if model.voice is None:
-        logger.warning("arena_missing_voice", provider=model.provider, model=model.model)
-        return None
 
     try:
-        provider = provider_cls(settings=settings, model=model.model, voice=model.voice)
+        provider = provider_cls(settings=settings, model=model.model, voice=voice.id)
         result: TTSResult = await asyncio.wait_for(
             provider.synthesize(prompt), timeout=_SYNTH_TIMEOUT_S
         )

--- a/runner/src/coval_bench/arena/pairing.py
+++ b/runner/src/coval_bench/arena/pairing.py
@@ -17,7 +17,13 @@ from collections.abc import Mapping, Sequence
 
 from coval_bench.db.models import PairingRating
 from coval_bench.registries.benchmarks import Benchmark
-from coval_bench.registries.models import MODEL_REGISTRY, ModelStatus, RegisteredModel
+from coval_bench.registries.models import (
+    MODEL_REGISTRY,
+    Gender,
+    ModelStatus,
+    RegisteredModel,
+    Voice,
+)
 
 # Volume knob (Elo points): the rating gap at which a matchup's sampling priority
 # decays by 1/e. Tuned offline and committed — deliberately a constant, never an
@@ -37,6 +43,44 @@ def active_tts_models() -> list[RegisteredModel]:
         for m in MODEL_REGISTRY
         if m.benchmark is Benchmark.TTS and m.status is ModelStatus.ACTIVE and m.arena_enabled
     ]
+
+
+def roster_for(gender: Gender) -> list[RegisteredModel]:
+    """The arena roster restricted to models that can render a *gender* battle.
+
+    A model without a voice of that gender cannot take a side, so it sits the
+    round out — today that is only Palabra, whose voices are quality tiers.
+    """
+    return [m for m in active_tts_models() if any(v.gender is gender for v in m.voices)]
+
+
+def voice_for(model: RegisteredModel, gender: Gender) -> Voice:
+    """The model's pooled voice of *gender*.
+
+    Guards the caller contract, not the registry: ``roster_for`` selects on the
+    same predicate, so a miss means *model* came from an unfiltered roster.
+    """
+    for voice in model.voices:
+        if voice.gender is gender:
+            return voice
+    raise ValueError(f"{model.provider}/{model.model} has no {gender.value} voice")
+
+
+def gender_for_next_battle(
+    counts: Mapping[Gender, int], rng: random.Random | None = None
+) -> Gender:
+    """Pick the gender with fewer battles so both accrue votes at the same rate.
+
+    Chooses the deficit rather than alternating on a parity bit: two concurrent
+    picks can overshoot by one, and only a deficit rule pulls that back. Ties
+    break randomly, since a fixed winner would hand one gender a standing +1 at
+    every cold start.
+    """
+    female, male = counts.get(Gender.FEMALE, 0), counts.get(Gender.MALE, 0)
+    if female != male:
+        return Gender.FEMALE if female < male else Gender.MALE
+    picker = rng if rng is not None else random.Random()  # noqa: S311
+    return picker.choice([Gender.FEMALE, Gender.MALE])
 
 
 def select_pair(

--- a/runner/src/coval_bench/arena/rating.py
+++ b/runner/src/coval_bench/arena/rating.py
@@ -77,11 +77,15 @@ class ConvergenceError(RuntimeError):
 
 
 # Bump on any behavioural change to the rating math (model, Elo map, bootstrap,
-# status thresholds). Persisted on leaderboard snapshots so a stored rating can
-# be tied back to the method that produced it. The numeric suffix is zero-padded
-# so its lexicographic order (used as the leaderboard tiebreaker on equal
-# timestamps) still matches numeric order past version 9.
-METHODOLOGY_VERSION: Literal["davidson-bt-001"] = "davidson-bt-001"
+# status thresholds), or to which votes are eligible to feed it — a rating means
+# nothing without the regime that produced the battles behind it. Persisted on
+# leaderboard snapshots so a stored rating can be tied back to the method that
+# produced it. The numeric suffix is zero-padded so its lexicographic order (used
+# as the leaderboard tiebreaker on equal timestamps) still matches numeric order
+# past version 9.
+#
+# 002: battles pair same-gender voices, and only gendered battles are counted.
+METHODOLOGY_VERSION: Literal["davidson-bt-002"] = "davidson-bt-002"
 
 # Standard Bradley-Terry -> Elo scale: a difference of 400 Elo == 10:1 win odds.
 _ELO_BASE = 1500.0
@@ -131,7 +135,7 @@ class ModelRating(BaseModel):
 class RatingResult(BaseModel):
     """Full leaderboard fit: the tie parameter plus one entry per model."""
 
-    methodology_version: Literal["davidson-bt-001"] = METHODOLOGY_VERSION
+    methodology_version: Literal["davidson-bt-002"] = METHODOLOGY_VERSION
     tie_param: float
     models: list[ModelRating]
 

--- a/runner/src/coval_bench/arena/rating.py
+++ b/runner/src/coval_bench/arena/rating.py
@@ -84,7 +84,9 @@ class ConvergenceError(RuntimeError):
 # as the leaderboard tiebreaker on equal timestamps) still matches numeric order
 # past version 9.
 #
-# 002: battles pair same-gender voices, and only gendered battles are counted.
+# 002: battles pair same-gender voices. Votes carry over rather than reset, so a
+# board spans both regimes and the older cross-gender share dilutes as new votes
+# land — continuity was preferred to a clean break.
 METHODOLOGY_VERSION: Literal["davidson-bt-002"] = "davidson-bt-002"
 
 # Standard Bradley-Terry -> Elo scale: a difference of 400 Elo == 10:1 win odds.

--- a/runner/src/coval_bench/arena/seed.py
+++ b/runner/src/coval_bench/arena/seed.py
@@ -15,11 +15,12 @@ import random
 import structlog
 
 from coval_bench.arena.generate import generate_battle
-from coval_bench.arena.pairing import active_tts_models, select_pair
+from coval_bench.arena.pairing import gender_for_next_battle, roster_for, select_pair
 from coval_bench.arena.prompts import EXAMPLE_PROMPTS
 from coval_bench.config import Settings
 from coval_bench.db.arena_store import ArenaStore
 from coval_bench.db.models import Battle
+from coval_bench.registries.models import Gender
 
 logger: structlog.BoundLogger = structlog.get_logger(__name__)
 
@@ -37,23 +38,28 @@ async def seed_demo_battles(
     (logged), never inserted — so the result may be shorter than requested.
     """
     picker = rng if rng is not None else random.Random()  # noqa: S311
-    models = active_tts_models()
     created: list[Battle] = []
+    # Counted locally rather than read back from the table, so a seed run
+    # balances its own output without depending on what is already stored.
+    counts: dict[Gender, int] = {}
 
     for domain, prompts in EXAMPLE_PROMPTS.items():
         for prompt in prompts[:per_domain]:
-            pair = select_pair(models, {}, rng=picker)
+            gender = gender_for_next_battle(counts, rng=picker)
+            pair = select_pair(roster_for(gender), {}, rng=picker)
             battle = await generate_battle(
                 settings,
                 store,
                 prompt=prompt,
                 domain=domain,
                 pair=pair,
+                gender=gender,
                 rng=picker,
             )
             if battle is None:
                 logger.warning("arena_seed_skipped", domain=domain, prompt=prompt)
                 continue
+            counts[gender] = counts.get(gender, 0) + 1
             created.append(battle)
 
     return created

--- a/runner/src/coval_bench/arena/snapshot.py
+++ b/runner/src/coval_bench/arena/snapshot.py
@@ -39,6 +39,12 @@ async def _refit_and_persist(
         battle = battles.get(vote.battle_id)
         if battle is None:
             continue
+        # Battles predating same-gender pairing carry a NULL gender. They pitted
+        # a female voice against a male one, and several of those voices have
+        # since been replaced, so their votes are not evidence about the models
+        # as they sound today. They stay in the table, out of this board.
+        if battle.gender is None:
+            continue
         a_id = _model_id(battle.provider_a, battle.model_a)
         b_id = _model_id(battle.provider_b, battle.model_b)
         id_to_pm[a_id] = (battle.provider_a, battle.model_a)

--- a/runner/src/coval_bench/arena/snapshot.py
+++ b/runner/src/coval_bench/arena/snapshot.py
@@ -39,12 +39,6 @@ async def _refit_and_persist(
         battle = battles.get(vote.battle_id)
         if battle is None:
             continue
-        # Battles predating same-gender pairing carry a NULL gender. They pitted
-        # a female voice against a male one, and several of those voices have
-        # since been replaced, so their votes are not evidence about the models
-        # as they sound today. They stay in the table, out of this board.
-        if battle.gender is None:
-            continue
         a_id = _model_id(battle.provider_a, battle.model_a)
         b_id = _model_id(battle.provider_b, battle.model_b)
         id_to_pm[a_id] = (battle.provider_a, battle.model_a)

--- a/runner/src/coval_bench/arena/tune_scale.py
+++ b/runner/src/coval_bench/arena/tune_scale.py
@@ -33,7 +33,7 @@ import random
 from collections.abc import Sequence
 from dataclasses import dataclass
 
-from coval_bench.arena.pairing import SCALE, active_tts_models, select_pair
+from coval_bench.arena.pairing import SCALE, roster_for, select_pair
 from coval_bench.arena.rating import (
     _ELO_SCALE,
     BattleOutcome,
@@ -41,7 +41,7 @@ from coval_bench.arena.rating import (
     compute_ratings,
 )
 from coval_bench.db.models import PairingRating
-from coval_bench.registries.models import RegisteredModel
+from coval_bench.registries.models import Gender, RegisteredModel
 
 _EPS = 1e-12
 
@@ -190,7 +190,11 @@ def tune_scale(
         raise ValueError("replications must be > 0")
     if bootstrap_rounds < 0:
         raise ValueError("bootstrap_rounds must be >= 0")
-    roster = active_tts_models()
+    # One gender's roster, because that is what production pairs within — never
+    # the union. Both genders currently field the same models, so either stands
+    # in for the regime; simulating the union would model a larger pool than any
+    # real battle draws from.
+    roster = roster_for(Gender.FEMALE)
     if len(roster) < 2:
         raise ValueError("need at least two active TTS models to simulate")
 

--- a/runner/src/coval_bench/db/arena_store.py
+++ b/runner/src/coval_bench/db/arena_store.py
@@ -21,6 +21,7 @@ from psycopg_pool import AsyncConnectionPool
 
 from coval_bench.db.models import (
     Battle,
+    Gender,
     LeaderboardSnapshot,
     PairingRating,
     Vote,
@@ -48,10 +49,11 @@ class ArenaStore:
         sql = """
             INSERT INTO arena.battles
                 (provider_a, model_a, provider_b, model_b, domain,
-                 prompt_text, audio_a_url, audio_b_url)
-            VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+                 prompt_text, audio_a_url, audio_b_url, voice_a, voice_b, gender)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
             RETURNING id, provider_a, model_a, provider_b, model_b, domain,
-                      prompt_text, audio_a_url, audio_b_url, created_at
+                      prompt_text, audio_a_url, audio_b_url, voice_a, voice_b,
+                      gender, created_at
         """
         async with self._pool.connection() as conn:
             async with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
@@ -66,6 +68,9 @@ class ArenaStore:
                         battle.prompt_text,
                         battle.audio_a_url,
                         battle.audio_b_url,
+                        battle.voice_a,
+                        battle.voice_b,
+                        battle.gender,
                     ),
                 )
                 row = await cur.fetchone()
@@ -106,6 +111,23 @@ class ArenaStore:
             await conn.commit()
         return Vote.model_validate(dict(row))
 
+    async def count_battles_by_gender(self) -> dict[Gender, int]:
+        """Gendered battle counts, all time, for keeping generation balanced.
+
+        Only gendered rows are counted: pre-migration battles carry NULL and
+        belong to the retired cross-gender methodology, so including them would
+        skew the deficit the caller is trying to close. A gender absent from the
+        result has no battles yet, which the caller reads as zero.
+        """
+        sql = "SELECT gender, count(*) FROM arena.battles WHERE gender IS NOT NULL GROUP BY gender"
+        async with (
+            self._pool.connection() as conn,
+            conn.cursor(row_factory=psycopg.rows.tuple_row) as cur,
+        ):
+            await cur.execute(sql)
+            rows = await cur.fetchall()
+        return {Gender(gender): int(count) for gender, count in rows}
+
     async def count_battles_today(self) -> int:
         """Count battles created since the start of the current UTC day.
 
@@ -128,7 +150,8 @@ class ArenaStore:
         """Return the battle with this id, or ``None`` if it does not exist."""
         sql = """
             SELECT id, provider_a, model_a, provider_b, model_b, domain,
-                   prompt_text, audio_a_url, audio_b_url, created_at
+                   prompt_text, audio_a_url, audio_b_url, voice_a, voice_b,
+                   gender, created_at
             FROM arena.battles
             WHERE id = %s
         """
@@ -153,7 +176,8 @@ class ArenaStore:
         """
         clauses = [
             "SELECT id, provider_a, model_a, provider_b, model_b, domain,"
-            " prompt_text, audio_a_url, audio_b_url, created_at FROM arena.battles",
+            " prompt_text, audio_a_url, audio_b_url, voice_a, voice_b, gender,"
+            " created_at FROM arena.battles",
         ]
         params: list[object] = []
         if domain is not None:

--- a/runner/src/coval_bench/db/arena_store.py
+++ b/runner/src/coval_bench/db/arena_store.py
@@ -114,10 +114,10 @@ class ArenaStore:
     async def count_battles_by_gender(self) -> dict[Gender, int]:
         """Gendered battle counts, all time, for keeping generation balanced.
 
-        Only gendered rows are counted: pre-migration battles carry NULL and
-        belong to the retired cross-gender methodology, so including them would
-        skew the deficit the caller is trying to close. A gender absent from the
-        result has no battles yet, which the caller reads as zero.
+        Only gendered rows are counted: pre-migration battles carry NULL and had
+        no gender to balance, so including them would skew the deficit the caller
+        is trying to close. A gender absent from the result has no battles yet,
+        which the caller reads as zero.
         """
         sql = "SELECT gender, count(*) FROM arena.battles WHERE gender IS NOT NULL GROUP BY gender"
         async with (

--- a/runner/src/coval_bench/db/migrations/versions/20260810_0016_battle_voices.py
+++ b/runner/src/coval_bench/db/migrations/versions/20260810_0016_battle_voices.py
@@ -1,0 +1,37 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Record which voice sang each side of an arena battle, and the gender they share.
+
+Gender is stored on the row rather than derived from the voice ids at read time:
+voices get retired from the registry as providers change their catalogues, and a
+retired id would leave historical battles unattributable. Voice ids are kept
+alongside it for auditing which speaker a rating was earned with.
+
+Nullable with no backfill. Battles predating this migration were cross-gender by
+construction, so a NULL gender is exactly the marker the ``davidson-bt-002``
+rating methodology uses to exclude them — no date cutoff needed.
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "20260810_0016"
+down_revision = "20260807_0015"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE arena.battles ADD COLUMN voice_a TEXT")
+    op.execute("ALTER TABLE arena.battles ADD COLUMN voice_b TEXT")
+    op.execute(
+        "ALTER TABLE arena.battles ADD COLUMN gender TEXT CHECK (gender IN ('female', 'male'))"
+    )
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE arena.battles DROP COLUMN gender")
+    op.execute("ALTER TABLE arena.battles DROP COLUMN voice_b")
+    op.execute("ALTER TABLE arena.battles DROP COLUMN voice_a")

--- a/runner/src/coval_bench/db/models.py
+++ b/runner/src/coval_bench/db/models.py
@@ -16,10 +16,12 @@ from uuid import UUID
 from pydantic import BaseModel
 
 from coval_bench.registries.benchmarks import Benchmark
+from coval_bench.registries.models import Gender
 
 __all__ = [
     "Battle",
     "Benchmark",
+    "Gender",
     "LeaderboardSnapshot",
     "PairingRating",
     "Result",
@@ -114,6 +116,12 @@ class Battle(BaseModel):
     prompt_text: str
     audio_a_url: str
     audio_b_url: str
+    # Which voice sang each side, and the gender both share. Stored rather than
+    # derived from the registry: voices get retired, and a retired id would
+    # leave historical rows unreadable. NULL on pre-gendered battles.
+    voice_a: str | None = None
+    voice_b: str | None = None
+    gender: Gender | None = None
     created_at: datetime | None = None  # set by DB default (now())
 
 

--- a/runner/src/coval_bench/db/seed_arena.py
+++ b/runner/src/coval_bench/db/seed_arena.py
@@ -22,7 +22,7 @@ from urllib.parse import urlsplit
 from coval_bench.config import get_settings
 from coval_bench.db.arena_store import ArenaPool, ArenaStore
 from coval_bench.db.conn import lifespan_pool
-from coval_bench.db.models import Battle, VoteOutcome, VoterType
+from coval_bench.db.models import Battle, Gender, VoteOutcome, VoterType
 
 _LOCAL_HOSTS = frozenset({"localhost", "127.0.0.1", "::1"})
 
@@ -112,6 +112,12 @@ async def run_seed(*, reset: bool = False) -> None:
                     prompt_text=_PROMPTS[idx % len(_PROMPTS)],
                     audio_a_url=_sample_url(provider_a, model_a),
                     audio_b_url=_sample_url(provider_b, model_b),
+                    # Alternate so a seeded database exercises both, and give
+                    # every row a gender — an ungendered one is never served for
+                    # voting, so the seeded battles would be unreachable.
+                    gender=Gender.FEMALE if idx % 2 == 0 else Gender.MALE,
+                    voice_a=f"{model_a}-seed",
+                    voice_b=f"{model_b}-seed",
                 )
             )
             battle_count += 1

--- a/runner/tests/api/test_arena.py
+++ b/runner/tests/api/test_arena.py
@@ -116,9 +116,11 @@ async def _insert_battle(postgresql: Any, **kwargs: Any) -> str:
             "prompt_text": "Tell me about your refund policy.",
             "audio_a_url": "https://example.test/a.wav",
             "audio_b_url": "https://example.test/b.wav",
+            # Gendered by default: that is what generation now writes, and only
+            # gendered battles are served. Pass gender=None for a legacy row.
             "voice_a": None,
             "voice_b": None,
-            "gender": None,
+            "gender": "female",
         }
         defaults.update(kwargs)
         row = await aconn.execute(
@@ -1030,3 +1032,18 @@ async def test_reveal_never_exposes_voice_ids(client: AsyncClient, postgresql: A
     assert "sonic-english-male" not in body
     assert "voice_a" not in body and "voice_b" not in body
     assert await _stored_voice_a(postgresql, battle_id) == "aura-2-orion-en"
+
+
+@pytest.mark.asyncio
+async def test_ungendered_battles_are_never_served(client: AsyncClient, postgresql: Any) -> None:
+    """A vote on a pre-gender battle is discarded by the refit, so never offer one."""
+    await _apply_arena_schema(_make_db_url(postgresql))
+    await _insert_battle(postgresql, gender=None)
+
+    assert (await client.get("/v1/arena/battle", headers=_LABELER_HEADERS)).status_code == 404
+
+    gendered = await _insert_battle(postgresql, voice_a="a-f", voice_b="b-f", gender="female")
+    response = await client.get("/v1/arena/battle", headers=_LABELER_HEADERS)
+
+    assert response.status_code == 200
+    assert response.json()["id"] == gendered

--- a/runner/tests/api/test_arena.py
+++ b/runner/tests/api/test_arena.py
@@ -25,7 +25,11 @@ _LABELER_HEADERS = {"X-Labeler-Key": ARENA_LABELER_KEY}
 
 
 async def _apply_arena_schema(dsn: str) -> None:
-    """Create the arena tables read by the endpoints (mirrors migration 20260615_0007)."""
+    """Create the arena tables read by the endpoints.
+
+    Mirrors migrations 20260615_0007 and 20260810_0016 by hand — this fixture does
+    not run the migration chain, so a schema change has to be repeated here.
+    """
     aconn = await psycopg.AsyncConnection.connect(dsn, autocommit=True)
     try:
         await aconn.execute("CREATE SCHEMA IF NOT EXISTS arena")
@@ -40,6 +44,9 @@ async def _apply_arena_schema(dsn: str) -> None:
                 prompt_text TEXT NOT NULL,
                 audio_a_url TEXT NOT NULL,
                 audio_b_url TEXT NOT NULL,
+                voice_a     TEXT,
+                voice_b     TEXT,
+                gender      TEXT CHECK (gender IN ('female', 'male')),
                 created_at  TIMESTAMPTZ NOT NULL DEFAULT now()
             )
         """)
@@ -109,16 +116,20 @@ async def _insert_battle(postgresql: Any, **kwargs: Any) -> str:
             "prompt_text": "Tell me about your refund policy.",
             "audio_a_url": "https://example.test/a.wav",
             "audio_b_url": "https://example.test/b.wav",
+            "voice_a": None,
+            "voice_b": None,
+            "gender": None,
         }
         defaults.update(kwargs)
         row = await aconn.execute(
             """
             INSERT INTO arena.battles
                 (provider_a, model_a, provider_b, model_b, domain,
-                 prompt_text, audio_a_url, audio_b_url)
+                 prompt_text, audio_a_url, audio_b_url, voice_a, voice_b, gender)
             VALUES
                 (%(provider_a)s, %(model_a)s, %(provider_b)s, %(model_b)s, %(domain)s,
-                 %(prompt_text)s, %(audio_a_url)s, %(audio_b_url)s)
+                 %(prompt_text)s, %(audio_a_url)s, %(audio_b_url)s,
+                 %(voice_a)s, %(voice_b)s, %(gender)s)
             RETURNING id
             """,
             defaults,
@@ -126,6 +137,18 @@ async def _insert_battle(postgresql: Any, **kwargs: Any) -> str:
         result = await row.fetchone()
         assert result is not None
         return str(result[0])
+    finally:
+        await aconn.close()
+
+
+async def _stored_voice_a(postgresql: Any, battle_id: str) -> str | None:
+    """Read voice_a straight from the row, bypassing the API."""
+    aconn = await psycopg.AsyncConnection.connect(_make_db_url(postgresql), autocommit=True)
+    try:
+        cur = await aconn.execute("SELECT voice_a FROM arena.battles WHERE id = %s", (battle_id,))
+        row = await cur.fetchone()
+        assert row is not None
+        return str(row[0]) if row[0] is not None else None
     finally:
         await aconn.close()
 
@@ -953,3 +976,57 @@ async def test_admin_convergence_renders_history(client: AsyncClient, postgresql
     assert response.status_code == 200
     assert response.headers["content-type"].startswith("text/html")
     assert "elevenlabs/eleven_multilingual_v2" in response.text
+
+
+@pytest.mark.asyncio
+async def test_battle_never_exposes_voice_ids(client: AsyncClient, postgresql: Any) -> None:
+    """A voice id names its provider, so it would unblind the battle.
+
+    ``aura-2-orion-en`` gives Deepgram away on sight. The blind endpoints must
+    withhold the voice columns even though the row carries them.
+    """
+    await _apply_arena_schema(_make_db_url(postgresql))
+    battle_id = await _insert_battle(
+        postgresql,
+        voice_a="aura-2-orion-en",
+        voice_b="sonic-english-male",
+        gender="male",
+    )
+
+    response = await client.get(f"/v1/arena/battle/{battle_id}", headers=_LABELER_HEADERS)
+
+    assert response.status_code == 200
+    body = response.text
+    assert "aura-2-orion-en" not in body
+    assert "sonic-english-male" not in body
+    assert set(response.json()) == {"id", "prompt_text", "domain", "audio_a_url", "audio_b_url"}
+    # Guard against a vacuous pass: the row really does carry the voice ids.
+    assert await _stored_voice_a(postgresql, battle_id) == "aura-2-orion-en"
+
+
+@pytest.mark.asyncio
+async def test_reveal_never_exposes_voice_ids(client: AsyncClient, postgresql: Any) -> None:
+    """Reveal discloses provider and model by design — voices stay out of it."""
+    await _apply_arena_schema(_make_db_url(postgresql))
+    battle_id = await _insert_battle(
+        postgresql,
+        voice_a="aura-2-orion-en",
+        voice_b="sonic-english-male",
+        gender="male",
+    )
+    await client.post(
+        "/v1/arena/vote",
+        json={"battle_id": battle_id, "outcome": "A_WIN", "voter_id": "ann-1"},
+        headers=_LABELER_HEADERS,
+    )
+
+    response = await client.get(
+        f"/v1/arena/battle/{battle_id}/reveal?voter_id=ann-1", headers=_LABELER_HEADERS
+    )
+
+    assert response.status_code == 200
+    body = response.text
+    assert "aura-2-orion-en" not in body
+    assert "sonic-english-male" not in body
+    assert "voice_a" not in body and "voice_b" not in body
+    assert await _stored_voice_a(postgresql, battle_id) == "aura-2-orion-en"

--- a/runner/tests/unit/test_arena_generate.py
+++ b/runner/tests/unit/test_arena_generate.py
@@ -18,7 +18,7 @@ from coval_bench.config import Settings
 from coval_bench.db.models import Battle
 from coval_bench.providers.base import TTSResult
 from coval_bench.registries.benchmarks import Benchmark
-from coval_bench.registries.models import ModelStatus, RegisteredModel
+from coval_bench.registries.models import Gender, ModelStatus, RegisteredModel, Voice
 
 
 def _model(provider: str, model: str) -> RegisteredModel:
@@ -27,6 +27,10 @@ def _model(provider: str, model: str) -> RegisteredModel:
         provider=provider,
         model=model,
         voice="v",
+        voices=(
+            Voice(id=f"{model}-f", gender=Gender.FEMALE),
+            Voice(id=f"{model}-m", gender=Gender.MALE),
+        ),
         status=ModelStatus.ACTIVE,
     )
 
@@ -96,6 +100,7 @@ async def test_generate_battle_success(tmp_path: Path, monkeypatch: pytest.Monke
         prompt=prompt,
         domain="healthcare",
         pair=models,
+        gender=Gender.FEMALE,
         rng=random.Random(0),
     )
 
@@ -106,6 +111,13 @@ async def test_generate_battle_success(tmp_path: Path, monkeypatch: pytest.Monke
     assert {battle.model_a, battle.model_b} == {"model-a", "model-b"}
     for url in (battle.audio_a_url, battle.audio_b_url):
         assert (settings.arena_audio_dir / url.lstrip("/")).is_file()
+
+    # The pooled female voice sang, not the scalar ``voice="v"``, and the row
+    # records which one so the rating can be traced back to a speaker.
+    assert battle.gender is Gender.FEMALE
+    assert battle.voice_a is not None and battle.voice_a.endswith("-f")
+    assert battle.voice_b is not None and battle.voice_b.endswith("-f")
+    assert {battle.voice_a, battle.voice_b} == {"model-a-f", "model-b-f"}
 
 
 async def test_generate_battle_skips_when_a_side_fails(
@@ -123,8 +135,75 @@ async def test_generate_battle_skips_when_a_side_fails(
         prompt="Your claim has been approved and payment will arrive within five business days.",
         domain="insurance",
         pair=models,
+        gender=Gender.MALE,
         rng=random.Random(0),
     )
 
     assert battle is None
     assert store.inserted == []
+
+
+@pytest.mark.asyncio
+async def test_generate_battle_uses_the_requested_gender(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The male half of each pool sings when a male battle is asked for."""
+    models = (_model("provider-a", "model-a"), _model("provider-b", "model-b"))
+    provider = _fake_provider_cls(tmp_path, fail_models=set())
+    monkeypatch.setattr(generate_module, "TTS_PROVIDERS", {m.provider: provider for m in models})
+    settings = Settings(arena_audio_dir=tmp_path / "store")
+    store = _FakeStore()
+
+    battle = await generate_battle(
+        settings,
+        store,  # type: ignore[arg-type]
+        prompt="Your appointment has been moved to Thursday afternoon.",
+        domain="healthcare",
+        pair=models,
+        gender=Gender.MALE,
+        rng=random.Random(0),
+    )
+
+    assert battle is not None
+    assert battle.gender is Gender.MALE
+    assert {battle.voice_a, battle.voice_b} == {"model-a-m", "model-b-m"}
+
+
+@pytest.mark.asyncio
+async def test_generate_battle_refuses_a_model_without_that_gender(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An unfiltered roster is a caller bug, and it must not reach a provider.
+
+    The raise has to land before synthesis, otherwise the healthy side has
+    already been paid for by the time the broken one is noticed.
+    """
+    female_only = RegisteredModel(
+        benchmark=Benchmark.TTS,
+        provider="provider-b",
+        model="model-b",
+        voice="v",
+        voices=(Voice(id="model-b-f", gender=Gender.FEMALE),),
+        status=ModelStatus.ACTIVE,
+    )
+    models = (_model("provider-a", "model-a"), female_only)
+    provider = _fake_provider_cls(tmp_path, fail_models=set())
+    monkeypatch.setattr(generate_module, "TTS_PROVIDERS", {m.provider: provider for m in models})
+    settings = Settings(arena_audio_dir=tmp_path / "store")
+    store = _FakeStore()
+
+    with pytest.raises(ValueError, match="no male voice"):
+        await generate_battle(
+            settings,
+            store,  # type: ignore[arg-type]
+            prompt="This should never reach a provider.",
+            domain="healthcare",
+            pair=models,
+            gender=Gender.MALE,
+            rng=random.Random(0),
+        )
+
+    assert store.inserted == []
+    assert not (settings.arena_audio_dir).exists() or not any(
+        settings.arena_audio_dir.rglob("*.wav")
+    )

--- a/runner/tests/unit/test_arena_pairing.py
+++ b/runner/tests/unit/test_arena_pairing.py
@@ -10,11 +10,17 @@ from collections import Counter
 
 import pytest
 
-from coval_bench.arena.pairing import active_tts_models, select_pair
+from coval_bench.arena.pairing import (
+    active_tts_models,
+    gender_for_next_battle,
+    roster_for,
+    select_pair,
+    voice_for,
+)
 from coval_bench.config import Settings
 from coval_bench.db.models import PairingRating
 from coval_bench.registries.benchmarks import Benchmark
-from coval_bench.registries.models import ModelStatus, RegisteredModel
+from coval_bench.registries.models import Gender, ModelStatus, RegisteredModel, Voice
 from coval_bench.registries.provider_keys import PROVIDER_ENV
 
 
@@ -158,3 +164,75 @@ def test_provider_env_names_match_settings_fields() -> None:
     fields = Settings.model_fields
     bad = {env for env in PROVIDER_ENV.values() if env.lower() not in fields}
     assert not bad, f"PROVIDER_ENV names with no Settings field: {sorted(bad)}"
+
+
+def test_every_arena_model_can_field_both_genders() -> None:
+    """Any arena model must field both genders, or it silently sits out half the battles.
+
+    Palabra is the standing exception: its ``voices`` are quality tiers rather
+    than speakers, so it has no gendered pool to draw from.
+    """
+    incomplete = [
+        f"{m.provider}/{m.model}"
+        for m in active_tts_models()
+        if {v.gender for v in m.voices} != {Gender.FEMALE, Gender.MALE} and m.provider != "palabra"
+    ]
+    assert incomplete == [], f"arena models missing a gendered voice: {incomplete}"
+
+
+def test_roster_for_keeps_only_models_with_that_gender() -> None:
+    for gender in (Gender.FEMALE, Gender.MALE):
+        roster = roster_for(gender)
+        assert len(roster) >= 2
+        assert all(any(v.gender is gender for v in m.voices) for m in roster)
+    assert {m.provider for m in roster_for(Gender.FEMALE)}.isdisjoint({"palabra"})
+
+
+def test_voice_for_returns_the_matching_half() -> None:
+    model = RegisteredModel(
+        benchmark=Benchmark.TTS,
+        provider="p",
+        model="m",
+        voice="v",
+        voices=(Voice(id="她", gender=Gender.FEMALE), Voice(id="他", gender=Gender.MALE)),
+        status=ModelStatus.ACTIVE,
+    )
+    assert voice_for(model, Gender.FEMALE).id == "她"
+    assert voice_for(model, Gender.MALE).id == "他"
+
+
+def test_voice_for_raises_when_the_model_cannot_field_the_gender() -> None:
+    model = RegisteredModel(
+        benchmark=Benchmark.TTS,
+        provider="p",
+        model="m",
+        voice="v",
+        voices=(Voice(id="only-female", gender=Gender.FEMALE),),
+        status=ModelStatus.ACTIVE,
+    )
+    with pytest.raises(ValueError, match="no male voice"):
+        voice_for(model, Gender.MALE)
+
+
+def test_gender_for_next_battle_picks_the_deficit() -> None:
+    assert gender_for_next_battle({Gender.FEMALE: 6, Gender.MALE: 5}) is Gender.MALE
+    assert gender_for_next_battle({Gender.FEMALE: 5, Gender.MALE: 6}) is Gender.FEMALE
+    # A concurrent double-pick overshoots; the deficit rule pulls it back rather
+    # than latching, which a parity bit would not do.
+    assert gender_for_next_battle({Gender.FEMALE: 7, Gender.MALE: 5}) is Gender.MALE
+    # An absent gender counts as zero, so a cold start is not a special case.
+    assert gender_for_next_battle({Gender.FEMALE: 3}) is Gender.MALE
+
+
+def test_gender_for_next_battle_breaks_ties_both_ways() -> None:
+    """A fixed tie-break would hand one gender a standing +1 at every cold start."""
+    picks = {gender_for_next_battle({}, random.Random(seed)) for seed in range(20)}
+    assert picks == {Gender.FEMALE, Gender.MALE}
+
+
+def test_gender_alternates_over_a_run_of_battles() -> None:
+    counts: dict[Gender, int] = {}
+    for _ in range(20):
+        gender = gender_for_next_battle(counts, random.Random(0))
+        counts[gender] = counts.get(gender, 0) + 1
+    assert counts[Gender.FEMALE] == counts[Gender.MALE] == 10

--- a/runner/tests/unit/test_arena_snapshot.py
+++ b/runner/tests/unit/test_arena_snapshot.py
@@ -429,3 +429,51 @@ def test_gender_check_constraint_rejects_other_values(snap_pg: psycopg.Connectio
         else:  # pragma: no cover - the constraint is missing
             raise AssertionError("arena.battles accepted a gender outside the CHECK")
     snap_pg.rollback()
+
+
+def test_migration_preserves_existing_rows(snap_pg: psycopg.Connection[Any]) -> None:
+    """0016 adds columns to a populated table without touching a single row.
+
+    Runs the real chain to 0015, writes a battle and a vote, then upgrades. The
+    rows must survive untouched, with the new columns NULL rather than defaulted.
+    """
+    cfg = _alembic_cfg(_async_dsn(snap_pg))
+    alembic_command.upgrade(cfg, "20260807_0015")
+    snap_pg.rollback()
+
+    with snap_pg.cursor() as cur:
+        cur.execute(
+            "INSERT INTO arena.battles"
+            " (provider_a, model_a, provider_b, model_b, domain, prompt_text,"
+            "  audio_a_url, audio_b_url)"
+            " VALUES ('cartesia', 'sonic-3.5', 'openai', 'gpt-4o-mini-tts',"
+            "         'general', 'hello there', 'a.wav', 'b.wav')"
+            " RETURNING id"
+        )
+        inserted = cur.fetchone()
+        assert inserted is not None
+        battle_id = inserted[0]
+        cur.execute(
+            "INSERT INTO arena.votes (battle_id, outcome, voter_type, voter_id)"
+            " VALUES (%s, 'A_WIN', 'labeler', 'ann')",
+            (battle_id,),
+        )
+    snap_pg.commit()
+
+    alembic_command.upgrade(cfg, "head")
+    snap_pg.rollback()
+
+    with snap_pg.cursor() as cur:
+        cur.execute("SELECT count(*) FROM arena.battles")
+        battles = cur.fetchone()
+        cur.execute("SELECT count(*) FROM arena.votes")
+        votes = cur.fetchone()
+        cur.execute("SELECT id, prompt_text, voice_a, voice_b, gender FROM arena.battles")
+        row = cur.fetchone()
+
+    assert battles is not None and battles[0] == 1
+    assert votes is not None and votes[0] == 1
+    assert row is not None
+    assert row[0] == battle_id  # same row, not a replacement
+    assert row[1] == "hello there"
+    assert (row[2], row[3], row[4]) == (None, None, None)

--- a/runner/tests/unit/test_arena_snapshot.py
+++ b/runner/tests/unit/test_arena_snapshot.py
@@ -342,11 +342,12 @@ def test_count_battles_by_gender_ignores_ungendered_rows(
     asyncio.run(_run())
 
 
-def test_snapshot_excludes_pre_gender_battles(snap_pg: psycopg.Connection[Any]) -> None:
-    """Cross-gender votes from the retired methodology never reach a new board.
+def test_snapshot_counts_pre_gender_battles(snap_pg: psycopg.Connection[Any]) -> None:
+    """Votes carry across the methodology change instead of resetting.
 
-    Their voices have since been replaced, so they are not evidence about the
-    models as they sound now. The rows stay; only the board excludes them.
+    Ratings continue rather than starting fresh, so a battle from the
+    cross-gender era still feeds the board. Its share dilutes as same-gender
+    votes accumulate.
     """
     _apply_migrations(snap_pg)
 
@@ -370,12 +371,9 @@ def test_snapshot_excludes_pre_gender_battles(snap_pg: psycopg.Connection[Any]) 
 
             result = await run_snapshot(store, bootstrap_rounds=50, seed=0)
             assert result is not None
-            assert result.models == []
-            assert await _snapshot_row_count(pool) == 0
-
-            # The battle and its votes are still on disk, just not in the board.
-            assert len(await store.list_battles(limit=None)) == 1
-            assert len(await store.list_votes()) == len(_VOTES)
+            assert len(result.models) == 2
+            assert sum(m.votes_total for m in result.models) == 2 * len(_VOTES)
+            assert await _snapshot_row_count(pool) == 2
         finally:
             await pool.close()
 

--- a/runner/tests/unit/test_arena_snapshot.py
+++ b/runner/tests/unit/test_arena_snapshot.py
@@ -23,7 +23,7 @@ from pytest_postgresql.factories import postgresql
 
 from coval_bench.arena.snapshot import run_snapshot
 from coval_bench.db.arena_store import ArenaStore
-from coval_bench.db.models import Battle, VoteOutcome, VoterType
+from coval_bench.db.models import Battle, Gender, VoteOutcome, VoterType
 
 snap_pg = postgresql("pg_proc")  # shared server from conftest, own per-test DB
 
@@ -101,6 +101,9 @@ def _battle(provider_b: str, model_b: str) -> Battle:
         prompt_text="hello there",
         audio_a_url="https://example.test/a.wav",
         audio_b_url="https://example.test/b.wav",
+        voice_a="voice-a",
+        voice_b="voice-b",
+        gender=Gender.FEMALE,
     )
 
 
@@ -118,6 +121,9 @@ async def _seed_battle(store: ArenaStore, *, domain: str, provider_b: str, model
             prompt_text="hello there",
             audio_a_url="https://example.test/a.wav",
             audio_b_url="https://example.test/b.wav",
+            voice_a="voice-a",
+            voice_b="voice-b",
+            gender=Gender.FEMALE,
         )
     )
     assert battle.id is not None
@@ -162,7 +168,7 @@ def test_snapshot_persists_one_board(snap_pg: psycopg.Connection[Any]) -> None:
             assert len(rows) == 2
             assert {r["metric_name"] for r in rows} == {"naturalness"}
             assert {r["domain"] for r in rows} == {"all"}
-            assert {r["methodology_version"] for r in rows} == {"davidson-bt-001"}
+            assert {r["methodology_version"] for r in rows} == {"davidson-bt-002"}
             assert len({r["computed_at"] for r in rows}) == 1
             assert {(r["provider"], r["model"]) for r in rows} == {
                 ("cartesia", "sonic-3.5"),
@@ -274,3 +280,154 @@ def test_snapshot_scoped_to_domain_excludes_other_domains(snap_pg: psycopg.Conne
             await pool.close()
 
     asyncio.run(_run())
+
+
+def test_battle_voices_and_gender_survive_a_round_trip(snap_pg: psycopg.Connection[Any]) -> None:
+    """Written by ``insert_battle``, read back by both battle getters.
+
+    The INSERT and the two SELECTs carry independent column lists, so a column
+    added to one and forgotten in another reads back as ``None`` rather than
+    failing — this is the test that catches it.
+    """
+    _apply_migrations(snap_pg)
+
+    async def _run() -> None:
+        pool = await _make_pool(snap_pg)
+        try:
+            await _reset(pool)
+            store = ArenaStore(pool)
+            inserted = await store.insert_battle(_battle("openai", "gpt-4o-mini-tts"))
+
+            assert inserted.voice_a == "voice-a"
+            assert inserted.voice_b == "voice-b"
+            assert inserted.gender is Gender.FEMALE
+
+            assert inserted.id is not None
+            fetched = await store.get_battle(inserted.id)
+            assert fetched is not None
+            assert (fetched.voice_a, fetched.voice_b) == ("voice-a", "voice-b")
+            assert fetched.gender is Gender.FEMALE
+
+            listed = await store.list_battles(limit=None)
+            assert [b.gender for b in listed] == [Gender.FEMALE]
+            assert [b.voice_a for b in listed] == ["voice-a"]
+        finally:
+            await pool.close()
+
+    asyncio.run(_run())
+
+
+def test_count_battles_by_gender_ignores_ungendered_rows(
+    snap_pg: psycopg.Connection[Any],
+) -> None:
+    _apply_migrations(snap_pg)
+
+    async def _run() -> None:
+        pool = await _make_pool(snap_pg)
+        try:
+            await _reset(pool)
+            store = ArenaStore(pool)
+            assert await store.count_battles_by_gender() == {}
+
+            await store.insert_battle(_battle("openai", "gpt-4o-mini-tts"))
+            male = _battle("deepgram", "aura-2").model_copy(update={"gender": Gender.MALE})
+            await store.insert_battle(male)
+            legacy = _battle("rime", "mistv3").model_copy(update={"gender": None})
+            await store.insert_battle(legacy)
+
+            assert await store.count_battles_by_gender() == {Gender.FEMALE: 1, Gender.MALE: 1}
+        finally:
+            await pool.close()
+
+    asyncio.run(_run())
+
+
+def test_snapshot_excludes_pre_gender_battles(snap_pg: psycopg.Connection[Any]) -> None:
+    """Cross-gender votes from the retired methodology never reach a new board.
+
+    Their voices have since been replaced, so they are not evidence about the
+    models as they sound now. The rows stay; only the board excludes them.
+    """
+    _apply_migrations(snap_pg)
+
+    async def _run() -> None:
+        pool = await _make_pool(snap_pg)
+        try:
+            await _reset(pool)
+            store = ArenaStore(pool)
+
+            legacy = await store.insert_battle(
+                _battle("openai", "gpt-4o-mini-tts").model_copy(update={"gender": None})
+            )
+            assert legacy.id is not None
+            for idx, outcome in enumerate(_VOTES):
+                await store.upsert_vote(
+                    battle_id=legacy.id,
+                    outcome=outcome,
+                    voter_type=VoterType.LABELER,
+                    voter_id=f"labeler-{idx + 1}",
+                )
+
+            result = await run_snapshot(store, bootstrap_rounds=50, seed=0)
+            assert result is not None
+            assert result.models == []
+            assert await _snapshot_row_count(pool) == 0
+
+            # The battle and its votes are still on disk, just not in the board.
+            assert len(await store.list_battles(limit=None)) == 1
+            assert len(await store.list_votes()) == len(_VOTES)
+        finally:
+            await pool.close()
+
+    asyncio.run(_run())
+
+
+def _battle_columns(conn: psycopg.Connection[Any]) -> set[str]:
+    conn.rollback()  # see the catalog as alembic left it, not this session's snapshot
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT column_name FROM information_schema.columns"
+            " WHERE table_schema = 'arena' AND table_name = 'battles'"
+        )
+        return {str(row[0]) for row in cur.fetchall()}
+
+
+def test_battle_voice_migration_reverses(snap_pg: psycopg.Connection[Any]) -> None:
+    """0016 adds three columns and takes exactly those three back off.
+
+    A downgrade that leaves debris behind makes the migration unsafe to roll
+    back, which is the only thing standing between a bad deploy and a restore.
+    """
+    _apply_migrations(snap_pg)
+    cfg = _alembic_cfg(_async_dsn(snap_pg))
+    added = {"voice_a", "voice_b", "gender"}
+
+    after_upgrade = _battle_columns(snap_pg)
+    assert added <= after_upgrade
+
+    alembic_command.downgrade(cfg, "-1")
+    after_downgrade = _battle_columns(snap_pg)
+    assert added.isdisjoint(after_downgrade)
+    assert after_downgrade == after_upgrade - added
+
+    alembic_command.upgrade(cfg, "head")
+    assert _battle_columns(snap_pg) == after_upgrade
+
+
+def test_gender_check_constraint_rejects_other_values(snap_pg: psycopg.Connection[Any]) -> None:
+    """Postgres refuses a bad gender even when the write bypasses Pydantic."""
+    _apply_migrations(snap_pg)
+    snap_pg.rollback()
+    with snap_pg.cursor() as cur:
+        try:
+            cur.execute(
+                "INSERT INTO arena.battles"
+                " (provider_a, model_a, provider_b, model_b, prompt_text,"
+                "  audio_a_url, audio_b_url, gender)"
+                " VALUES ('a', 'm', 'b', 'n', 'p', 'x', 'y', 'nonbinary')"
+            )
+        except psycopg.errors.CheckViolation:
+            pass
+        else:  # pragma: no cover - the constraint is missing
+            raise AssertionError("arena.battles accepted a gender outside the CHECK")
+    snap_pg.rollback()


### PR DESCRIPTION
Both sides of a battle now speak the same gender, so a vote compares delivery rather than register. Whichever gender has fewer battles goes next, keeping the two vote counts even.

Battles record the voices that sang and the gender they shared, so a rating stays traceable to a speaker. Voice ids stay out of every API response including reveal — an id like `aura-2-orion-en` names its provider.

Ratings continue rather than restarting. Votes from the cross-gender era still count, so the board keeps its history and the older share dilutes as same-gender votes land. Legacy battles are no longer handed out for voting though — their votes count, but serving one would keep adding the comparison this change stopped making.

The methodology version moves to `davidson-bt-002` to mark the date pairing changed, not a reset. Palabra has no gendered voices, so it sits out until handled separately.