### PR TITLE
Set Soniox tts-rt-v2 to active

### DIFF
--- a/runner/src/coval_bench/registries/models.py
+++ b/runner/src/coval_bench/registries/models.py
@@ -737,7 +737,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         voice="Adrian",
         voices=(Voice(id="Emma", gender=Gender.FEMALE), Voice(id="Daniel", gender=Gender.MALE)),
         tags=(_STREAMING, _MULTI, _CLONE, _STREAM),
-        status=_EARLY_ACCESS,
+        status=_ACTIVE,
         arena_enabled=False,
     ),
     # Azure AI Speech real-time (raw WebSocket). "neural" is the standard


### PR DESCRIPTION
Promotes the model out of early access so its results are public.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Promotes Soniox `tts-rt-v2` from early access to active, making its existing benchmark results publicly visible while leaving scheduled benchmarking and arena participation unchanged.

- Changes the model registry status from `EARLY_ACCESS` to `ACTIVE`.
- Removes the model from early-access API filtering.
- Retains `arena_enabled=False`.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the status change consistently producing the intended public visibility behavior.

Both active and early-access models already follow the same benchmark schedule, while the status promotion automatically removes this model from early-access API filtering and does not enable arena participation.

<sub>Reviews (1): Last reviewed commit: ["Set Soniox tts-rt-v2 to active"](https://github.com/coval-ai/benchmarks/commit/3028f51f6d96f150589301f6d8439ab80c814daf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52255185)</sub>

**Context used:**

- Knowledge Base — [Runner Orchestration](https://app.greptile.com/coval/-/custom-context/knowledge-base/coval-ai/benchmarks/-/docs/runner-orchestration.md)

<!-- /greptile_comment -->