### PR TITLE
Let callers ask the example bank for a specific domain

### DIFF
--- a/runner/src/coval_bench/api/routers/arena.py
+++ b/runner/src/coval_bench/api/routers/arena.py
@@ -203,10 +203,19 @@ async def get_battle(
 @limiter.limit("60/minute", key_func=_client_key)
 async def get_example_prompt(
     request: Request,  # required by slowapi
+    domain: ArenaDomain | None = Query(
+        None,
+        description="Draw only from this domain's bank. Omitted -> a random domain.",
+    ),
 ) -> ExamplePromptOut:
-    """Return a random prompt from the per-domain seed bank, tagged with its domain."""
-    domain = secrets.choice(list(EXAMPLE_PROMPTS))
-    return ExamplePromptOut(prompt=secrets.choice(EXAMPLE_PROMPTS[domain]), domain=domain)
+    """Return a random prompt from the seed bank, tagged with the domain it came from.
+
+    Callers that already know the domain pass it, so the prompt and the domain a battle
+    is filed under always agree; an unfiltered draw would hand back a prompt from some
+    other domain and mislabel every per-domain board built from it.
+    """
+    chosen = domain if domain is not None else secrets.choice(list(EXAMPLE_PROMPTS))
+    return ExamplePromptOut(prompt=secrets.choice(EXAMPLE_PROMPTS[chosen]), domain=chosen)
 
 
 @router.get(

--- a/runner/tests/api/test_arena.py
+++ b/runner/tests/api/test_arena.py
@@ -213,6 +213,35 @@ async def test_example_prompt_served_from_bank(client: AsyncClient, postgresql: 
     assert data["prompt"] in EXAMPLE_PROMPTS[data["domain"]]
 
 
+async def test_example_prompt_honours_requested_domain(
+    client: AsyncClient, postgresql: Any
+) -> None:
+    """?domain= draws from that bank only, so the prompt and its domain always agree."""
+    await _apply_arena_schema(_make_db_url(postgresql))
+    for domain in EXAMPLE_PROMPTS:
+        response = await client.get(
+            "/v1/arena/example-prompt",
+            params={"domain": domain},
+            headers=_LABELER_HEADERS,
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["domain"] == domain
+        assert data["prompt"] in EXAMPLE_PROMPTS[domain]
+
+
+async def test_example_prompt_rejects_unknown_domain(client: AsyncClient, postgresql: Any) -> None:
+    """A domain outside the closed set is a 422, including the reserved "all" board key."""
+    await _apply_arena_schema(_make_db_url(postgresql))
+    for domain in ("all", "not-a-domain"):
+        response = await client.get(
+            "/v1/arena/example-prompt",
+            params={"domain": domain},
+            headers=_LABELER_HEADERS,
+        )
+        assert response.status_code == 422
+
+
 async def test_example_prompt_hidden_without_labeler_key(
     client: AsyncClient, postgresql: Any
 ) -> None:


### PR DESCRIPTION
`GET /v1/arena/example-prompt` picked a random domain, so a caller that already knew the domain got a prompt from a different one — and the battle was filed under a domain its text never belonged to, which pollutes every per-domain board built from those rows.

It now takes an optional `?domain=`, typed as `ArenaDomain` so anything outside the closed set — including the reserved `all` board key — is a 422.

Omitting the parameter keeps the old random draw, so existing callers are unaffected and this deploys safely before or after the web side.

Web counterpart: coval-ai/benchmarks-web#23

`ruff check`, `ruff format --check`, `mypy --strict src tests` (256 files) and `pytest tests/api/test_arena.py` (51 passed) pass.
