### PR TITLE
Tag every model with its serving region

### DIFF
--- a/runner/src/coval_bench/registries/models.py
+++ b/runner/src/coval_bench/registries/models.py
@@ -92,7 +92,10 @@ class RegisteredModel(BaseModel, frozen=True, extra="forbid"):
     source: Source = Source.OFFICIAL_API
     licensing: Licensing = Licensing.PROPRIETARY
     on_prem: bool = False  # provider offers on-prem/customer-infra deployment
-    # Provider's serving region in ``us-east-1`` form; set only when confirmed.
+    # Serving region behind the endpoint we benchmark, normalized to
+    # ``us-east-1``-style codes regardless of cloud; broad ``us``/``eu``/
+    # ``global`` when the provider doesn't disclose or pin one. Unset means
+    # unknown. Geo-routed endpoints record where our runner's traffic lands.
     region: str | None = None
     status: ModelStatus
     arena_enabled: bool = True  # in the arena roster? independent of dashboard `status`
@@ -130,6 +133,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         model="nova-2",
         tags=(_STREAMING, _MULTI, _VAD, _DIAR, _CODESW, _KEYTERM),
         on_prem=True,
+        region="us",
         status=_ACTIVE,
     ),
     RegisteredModel(
@@ -138,6 +142,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         model="nova-3",
         tags=(_STREAMING, _MULTI, _VAD, _DIAR, _CODESW, _KEYTERM),
         on_prem=True,
+        region="us",
         status=_ACTIVE,
     ),
     RegisteredModel(
@@ -146,6 +151,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         model="flux-general-en",
         tags=(_STREAMING, _VAD, _KEYTERM),
         on_prem=True,
+        region="us",
         status=_ACTIVE,
     ),
     RegisteredModel(
@@ -154,6 +160,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         model="flux-general-multi",
         tags=(_STREAMING, _MULTI, _VAD, _CODESW, _KEYTERM),
         on_prem=True,
+        region="us",
         status=_ACTIVE,
     ),
     RegisteredModel(
@@ -161,6 +168,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         provider="elevenlabs",
         model="scribe_v2_realtime",
         tags=(_STREAMING, _MULTI, _VAD, _KEYTERM),
+        region="us",
         status=_ACTIVE,
     ),
     RegisteredModel(
@@ -168,6 +176,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         provider="openai",
         model="gpt-realtime-whisper",
         tags=(_STREAMING, _MULTI),
+        region="us",
         status=_ACTIVE,
     ),
     RegisteredModel(
@@ -175,6 +184,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         provider="openai",
         model="gpt-4o-transcribe",
         tags=(_STREAMING, _MULTI, _VAD, _KEYTERM),
+        region="us",
         status=_ACTIVE,
     ),
     RegisteredModel(
@@ -182,6 +192,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         provider="openai",
         model="gpt-4o-mini-transcribe",
         tags=(_STREAMING, _MULTI, _VAD, _KEYTERM),
+        region="us",
         status=_ACTIVE,
     ),
     RegisteredModel(
@@ -190,6 +201,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         model="universal-streaming",
         tags=(_STREAMING, _VAD, _DIAR, _KEYTERM),
         on_prem=True,
+        region="us-east-1",
         status=_ACTIVE,
     ),
     RegisteredModel(
@@ -198,6 +210,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         model="universal-streaming-multilingual",
         tags=(_STREAMING, _MULTI, _VAD, _DIAR, _CODESW, _KEYTERM),
         on_prem=True,
+        region="us-east-1",
         status=_ACTIVE,
     ),
     # No longer offered on AssemblyAI's streaming API (u3-rt-pro); superseded by
@@ -208,6 +221,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         model="universal-3-pro",
         tags=(_STREAMING, _MULTI, _VAD, _DIAR, _CODESW, _KEYTERM),
         on_prem=True,
+        region="us-east-1",
         status=_RETIRED,
     ),
     RegisteredModel(
@@ -216,6 +230,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         model="universal-3.5-pro",
         tags=(_STREAMING, _MULTI, _VAD, _DIAR, _CODESW, _KEYTERM, _CONVCTX),
         on_prem=True,
+        region="us-east-1",
         status=_ACTIVE,
     ),
     RegisteredModel(
@@ -224,6 +239,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         model="default",
         tags=(_STREAMING, _MULTI, _VAD, _DIAR, _TRANS, _CODESW, _KEYTERM),
         on_prem=True,
+        region="eu-west-3",
         status=_ACTIVE,
     ),
     RegisteredModel(
@@ -232,6 +248,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         model="enhanced",
         tags=(_STREAMING, _MULTI, _VAD, _DIAR, _TRANS, _CODESW, _KEYTERM),
         on_prem=True,
+        region="eu-west-3",
         status=_ACTIVE,
     ),
     RegisteredModel(
@@ -239,6 +256,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         provider="gradium",
         model="default",
         tags=(_STREAMING, _MULTI, _VAD),
+        region="us-east-1",
         status=_ACTIVE,
     ),
     RegisteredModel(
@@ -246,6 +264,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         provider="gladia",
         model="solaria-1",
         tags=(_STREAMING, _MULTI, _VAD, _TRANS, _CODESW, _KEYTERM),
+        region="eu-west",
         status=_ACTIVE,
     ),
     RegisteredModel(
@@ -253,6 +272,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         provider="soniox",
         model="stt-rt-v4",
         tags=(_STREAMING, _MULTI, _VAD, _DIAR, _TRANS, _CODESW, _KEYTERM),
+        region="us",
         status=_RETIRED,
     ),
     RegisteredModel(
@@ -260,6 +280,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         provider="soniox",
         model="stt-rt-v5",
         tags=(_STREAMING, _MULTI, _VAD, _DIAR, _TRANS, _CODESW, _KEYTERM),
+        region="us",
         status=_ACTIVE,
     ),
     RegisteredModel(
@@ -267,6 +288,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         provider="inworld",
         model="inworld-stt-1",
         tags=(_STREAMING, _MULTI, _VAD, _KEYTERM),
+        region="us-east-1",
         status=_ACTIVE,
     ),
     RegisteredModel(
@@ -274,6 +296,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         provider="xai",
         model="grok-stt",
         tags=(_STREAMING, _MULTI, _VAD, _DIAR, _KEYTERM),
+        region="us-east-1",
         status=_ACTIVE,
     ),
     RegisteredModel(
@@ -281,6 +304,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         provider="smallest",
         model="pulse",
         tags=(_STREAMING, _MULTI, _DIAR, _CODESW),
+        region="us-west-2",
         status=_ACTIVE,
     ),
     RegisteredModel(
@@ -289,6 +313,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         model="ink-2",
         tags=(_STREAMING, _VAD),
         on_prem=True,
+        region="us",
         status=_ACTIVE,
     ),
     RegisteredModel(
@@ -297,6 +322,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         model="voxtral-mini-transcribe-realtime-2602",
         tags=(_STREAMING, _MULTI),
         licensing=_OPEN,
+        region="eu",
         status=_ACTIVE,
     ),
     # Baseten dedicated endpoint (Whisper Large V3). Benchmarked nightly by the
@@ -321,6 +347,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         creator="microsoft",
         tags=(_STREAMING, _MULTI, _VAD, _DIAR, _KEYTERM),
         on_prem=True,
+        region="us-east-1",
         status=_PAUSED,
     ),
     RegisteredModel(
@@ -329,6 +356,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         model="chirp_2",
         tags=(_STREAMING, _MULTI, _VAD, _KEYTERM),
         on_prem=True,
+        region="us-central-1",
         status=_ACTIVE,
     ),
     RegisteredModel(
@@ -337,6 +365,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         model="chirp_3",
         tags=(_STREAMING, _MULTI, _VAD, _KEYTERM),
         on_prem=True,
+        region="us",
         status=_ACTIVE,
     ),
     RegisteredModel(
@@ -346,6 +375,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         creator="rev",
         tags=(_STREAMING, _KEYTERM),
         on_prem=True,
+        region="us-west-2",
         status=_ACTIVE,
     ),
     # Together AI serverless realtime endpoints (open-weight models).
@@ -357,6 +387,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         source=Source.SHARED_INFERENCE,
         tags=(_STREAMING,),
         licensing=_OPEN,
+        region="us",
         status=_RETIRED,
     ),
     RegisteredModel(
@@ -367,6 +398,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         source=Source.SHARED_INFERENCE,
         tags=(_STREAMING, _MULTI),
         licensing=_OPEN,
+        region="us",
         status=_ACTIVE,
     ),
     RegisteredModel(
@@ -377,6 +409,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         source=Source.SHARED_INFERENCE,
         tags=(_STREAMING, _MULTI),
         licensing=_OPEN,
+        region="us",
         status=_ACTIVE,
     ),
     RegisteredModel(
@@ -387,6 +420,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         source=Source.SHARED_INFERENCE,
         tags=(_STREAMING, _MULTI, _VAD),
         licensing=_OPEN,
+        region="us",
         status=_ACTIVE,
     ),
     # Reson8's realtime endpoint takes no model id, so the slug names the endpoint
@@ -398,6 +432,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         provider="reson8",
         model="realtime",
         tags=(_STREAMING, _MULTI, _DIAR, _KEYTERM),
+        region="eu",
         status=_EARLY_ACCESS,
     ),
     # Modulate Velma-2 real-time streaming; ids are the endpoint path segments.
@@ -409,6 +444,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         provider="modulate",
         model="velma-2-stt-streaming-english-v2",
         tags=(_STREAMING,),
+        region="us-east-1",
         status=_EARLY_ACCESS,
     ),
     RegisteredModel(
@@ -416,6 +452,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         provider="modulate",
         model="velma-2-stt-streaming",
         tags=(_STREAMING, _MULTI, _DIAR),
+        region="us-east-1",
         status=_ACTIVE,
     ),
     # Pre-Velma-2 ids; retired so their orphaned result rows stay off the site.
@@ -424,6 +461,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         provider="modulate",
         model="english-fast-transcription-streaming",
         tags=(_STREAMING,),
+        region="us-east-1",
         status=_RETIRED,
     ),
     RegisteredModel(
@@ -431,6 +469,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         provider="modulate",
         model="multilingual-transcription-streaming",
         tags=(_STREAMING, _MULTI, _DIAR),
+        region="us-east-1",
         status=_RETIRED,
     ),
     #######
@@ -446,6 +485,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
             Voice(id="29vD33N1CtxCmqQRPOHJ", gender=Gender.MALE, name="Drew"),
         ),
         tags=(_STREAMING, _MULTI, _CLONE, _STREAM),
+        region="us",
         status=_ACTIVE,
     ),
     RegisteredModel(
@@ -458,6 +498,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
             Voice(id="29vD33N1CtxCmqQRPOHJ", gender=Gender.MALE, name="Drew"),
         ),
         tags=(_STREAMING, _MULTI, _CLONE, _STREAM),
+        region="us",
         status=_ACTIVE,
     ),
     RegisteredModel(
@@ -466,6 +507,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         model="eleven_turbo_v2_5",
         voice="IKne3meq5aSn9XLyUdCD",
         tags=(_STREAMING, _MULTI),
+        region="us",
         status=_RETIRED,
     ),
     RegisteredModel(
@@ -478,6 +520,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
             Voice(id="29vD33N1CtxCmqQRPOHJ", gender=Gender.MALE, name="Drew"),
         ),
         tags=(_STREAMING, _MULTI, _CLONE, _EMOTION),
+        region="us",
         status=_ACTIVE,
     ),
     RegisteredModel(
@@ -487,6 +530,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         voice="alloy",
         voices=(Voice(id="shimmer", gender=Gender.FEMALE), Voice(id="onyx", gender=Gender.MALE)),
         tags=(_STREAMING, _MULTI, _EMOTION),
+        region="us",
         status=_ACTIVE,
     ),
     RegisteredModel(
@@ -495,6 +539,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         model="tts-1-hd",
         voice="alloy",
         tags=(_STREAMING, _MULTI),
+        region="us",
         status=_RETIRED,
     ),
     RegisteredModel(
@@ -503,6 +548,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         model="tts-1",
         voice="alloy",
         tags=(_STREAMING, _MULTI),
+        region="us",
         status=_RETIRED,
     ),
     RegisteredModel(
@@ -512,6 +558,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         voice="f786b574-daa5-4673-aa0c-cbe3e8534c02",
         tags=(_STREAMING, _MULTI, _CLONE, _EMOTION, _STREAM),
         on_prem=True,
+        region="us",
         status=_RETIRED,
     ),
     RegisteredModel(
@@ -525,6 +572,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         ),
         tags=(_STREAMING, _MULTI, _CLONE, _EMOTION, _STREAM),
         on_prem=True,
+        region="us",
         status=_ACTIVE,
     ),
     RegisteredModel(
@@ -538,6 +586,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         ),
         tags=(_STREAMING, _STREAM),
         on_prem=True,
+        region="us",
         status=_ACTIVE,
     ),
     RegisteredModel(
@@ -547,6 +596,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         voice="flux-haley-en",
         tags=(_STREAMING, _STREAM),
         on_prem=True,
+        region="us",
         status=_EARLY_ACCESS,
     ),
     RegisteredModel(
@@ -561,6 +611,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
             Voice(id="6MFfc37kq0sBjBjy", gender=Gender.MALE),
         ),
         tags=(_STREAMING, _MULTI, _CLONE, _STREAM),
+        region="us-east-1",
         status=_ACTIVE,
     ),
     RegisteredModel(
@@ -570,6 +621,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         voice="default_low",
         tags=(_STREAMING, _MULTI, _CLONE, _STREAM),
         on_prem=True,
+        region="us-central-1",
         status=_ACTIVE,
     ),
     # Rime — all three on /ws3 WebSocket.
@@ -582,6 +634,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         voices=(Voice(id="luna", gender=Gender.FEMALE), Voice(id="masonry", gender=Gender.MALE)),
         tags=(_STREAMING, _MULTI, _STREAM),
         on_prem=True,
+        region="us-west-2",
         status=_ACTIVE,
     ),
     RegisteredModel(
@@ -591,6 +644,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         voice="luna",
         tags=(_STREAMING, _MULTI, _EMOTION, _STREAM),
         on_prem=True,
+        region="us-west-2",
         status=_RETIRED,
     ),
     RegisteredModel(
@@ -601,6 +655,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         voices=(Voice(id="luna", gender=Gender.FEMALE), Voice(id="cedar", gender=Gender.MALE)),
         tags=(_STREAMING, _MULTI, _STREAM),
         on_prem=True,
+        region="us-west-2",
         status=_ACTIVE,
     ),
     RegisteredModel(
@@ -610,6 +665,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         voice="luna",
         tags=(_STREAMING, _MULTI),
         on_prem=True,
+        region="us-west-2",
         status=_RETIRED,
     ),
     RegisteredModel(
@@ -618,6 +674,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         model="octave-tts",
         voice="176a55b1-4468-4736-8878-db82729667c1",
         tags=(_STREAMING, _MULTI, _CLONE, _EMOTION, _STREAM),
+        region="us",
         status=_RETIRED,
     ),
     RegisteredModel(
@@ -626,6 +683,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         model="octave-2",
         voice="176a55b1-4468-4736-8878-db82729667c1",
         tags=(_STREAMING, _MULTI, _CLONE, _STREAM),
+        region="us",
         status=_RETIRED,
     ),
     RegisteredModel(
@@ -635,6 +693,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         voice="carina",
         voices=(Voice(id="carina", gender=Gender.FEMALE), Voice(id="altair", gender=Gender.MALE)),
         tags=(_STREAMING, _MULTI, _CLONE, _EMOTION, _STREAM),
+        region="us-east-1",
         status=_ACTIVE,
     ),
     RegisteredModel(
@@ -644,6 +703,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         voice="kelsey",
         voices=(Voice(id="kelsey", gender=Gender.FEMALE), Voice(id="spencer", gender=Gender.MALE)),
         tags=(_STREAMING, _MULTI, _CLONE, _STREAM),
+        region="us-west-2",
         status=_ACTIVE,
     ),
     RegisteredModel(
@@ -656,6 +716,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
             Voice(id="Jason", gender=Gender.MALE, accent="en-US"),
         ),
         tags=(_STREAMING, _MULTI, _CLONE, _EMOTION, _STREAM),
+        region="us-east-1",
         status=_ACTIVE,
     ),
     RegisteredModel(
@@ -668,6 +729,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
             Voice(id="Jason", gender=Gender.MALE, accent="en-US"),
         ),
         tags=(_STREAMING, _MULTI, _CLONE, _EMOTION, _STREAM),
+        region="us-east-1",
         status=_EARLY_ACCESS,
     ),
     RegisteredModel(
@@ -681,6 +743,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         ),
         tags=(_STREAMING, _MULTI, _CLONE, _EMOTION, _STREAM),
         on_prem=True,
+        region="us-east-1",
         status=_ACTIVE,
     ),
     RegisteredModel(
@@ -694,6 +757,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         ),
         tags=(_STREAMING, _MULTI, _CLONE, _EMOTION, _STREAM),
         on_prem=True,
+        region="us-east-1",
         status=_ACTIVE,
     ),
     RegisteredModel(
@@ -703,6 +767,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         voice="Adrian",
         voices=(Voice(id="Emma", gender=Gender.FEMALE), Voice(id="Daniel", gender=Gender.MALE)),
         tags=(_STREAMING, _MULTI, _CLONE, _STREAM),
+        region="us",
         status=_ACTIVE,
         arena_enabled=False,
     ),
@@ -713,6 +778,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         voice="Adrian",
         voices=(Voice(id="Emma", gender=Gender.FEMALE), Voice(id="Daniel", gender=Gender.MALE)),
         tags=(_STREAMING, _MULTI, _CLONE, _STREAM),
+        region="us",
         status=_ACTIVE,
         arena_enabled=False,
     ),
@@ -731,6 +797,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         creator="microsoft",
         tags=(_STREAMING, _MULTI, _EMOTION, _STREAM),
         on_prem=True,
+        region="us-east-1",
         status=_PAUSED,
     ),
     RegisteredModel(
@@ -754,6 +821,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         ),
         creator="microsoft",
         tags=(_STREAMING, _MULTI, _STREAM),
+        region="us-east-1",
         status=_PAUSED,
     ),
     RegisteredModel(
@@ -764,6 +832,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         creator="canopylabs",
         source=Source.SHARED_INFERENCE,
         tags=(_STREAMING, _EMOTION),
+        region="us",
         status=_PENDING,
         arena_enabled=False,
     ),
@@ -784,6 +853,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
             ),
         ),
         tags=(_STREAMING, _MULTI, _STREAM),
+        region="global",
         status=_ACTIVE,
         arena_enabled=False,
     ),
@@ -793,6 +863,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         model="gemini-2.5-flash-tts",
         voice="Kore",
         tags=(_STREAMING, _MULTI, _EMOTION),
+        region="global",
         status=_PENDING,
         arena_enabled=False,
     ),
@@ -817,6 +888,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         voice="Cherry",
         voices=(Voice(id="Cherry", gender=Gender.FEMALE), Voice(id="Ethan", gender=Gender.MALE)),
         tags=(_STREAMING, _MULTI, _STREAM),
+        region="ap-southeast-1",
         status=_ACTIVE,
     ),
     # Fish Audio. Voice ids are library reference_ids, not names.
@@ -870,6 +942,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
             Voice(id="English_magnetic_voiced_man", gender=Gender.MALE),
         ),
         tags=(_STREAMING, _MULTI, _CLONE, _EMOTION, _STREAM),
+        region="us-east-1",
         status=_ACTIVE,
     ),
     RegisteredModel(
@@ -882,6 +955,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
             Voice(id="English_magnetic_voiced_man", gender=Gender.MALE),
         ),
         tags=(_STREAMING, _MULTI, _CLONE, _EMOTION, _STREAM),
+        region="us-east-1",
         status=_ACTIVE,
     ),
     RegisteredModel(
@@ -894,6 +968,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
             Voice(id="hugh_32", gender=Gender.MALE),
         ),
         tags=(_STREAMING, _CLONE, _EMOTION),
+        region="us-east",
         status=_ACTIVE,
         arena_enabled=False,
     ),
@@ -907,6 +982,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
             Voice(id="hugh_32", gender=Gender.MALE),
         ),
         tags=(_STREAMING, _MULTI, _CLONE, _EMOTION),
+        region="us-east",
         status=_ACTIVE,
         arena_enabled=False,
     ),
@@ -928,6 +1004,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         voice="leah",
         voices=(Voice(id="leah", gender=Gender.FEMALE), Voice(id="caleb", gender=Gender.MALE)),
         tags=(_STREAMING, _MULTI, _CLONE, _STREAM),
+        region="us",
         status=_ACTIVE,
     ),
     # Deepdub eTTS. Voices are preset voice-prompt ids from Deepdub's docs:
@@ -942,6 +1019,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
             Voice(id="b2abb241-ac92-48bf-a890-fec03f43e209", gender=Gender.MALE),
         ),
         tags=(_STREAMING, _MULTI, _CLONE, _EMOTION, _STREAM),
+        region="us-east-1",
         status=_EARLY_ACCESS,
     ),
     RegisteredModel(
@@ -951,6 +1029,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         voice="Amara",
         voices=(Voice(id="Amara", gender=Gender.FEMALE), Voice(id="Gordon", gender=Gender.MALE)),
         tags=(_STREAMING, _MULTI, _STREAM),
+        region="us-east-2",
         status=_EARLY_ACCESS,
         arena_enabled=False,
     ),
@@ -964,6 +1043,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
             Voice(id="noah-en-us", gender=Gender.MALE, name="Noah", accent="en-US"),
         ),
         tags=(_STREAMING, _MULTI, _CLONE),
+        region="eu-central-1",
         status=_EARLY_ACCESS,
         arena_enabled=False,
     ),
@@ -976,6 +1056,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         provider="openai",
         model="gpt-realtime-2025-08-28",
         tags=(_STREAMING, _MULTI),
+        region="us",
         status=_RETIRED,
     ),
     RegisteredModel(
@@ -983,6 +1064,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         provider="cartesia",
         model="sonic",
         tags=(_STREAMING, _MULTI),
+        region="us",
         status=_RETIRED,
     ),
     #######
@@ -995,6 +1077,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         provider="openai",
         model="gpt-realtime",
         tags=(_STREAMING, _MULTI),
+        region="us",
         status=_ACTIVE,
     ),
     RegisteredModel(
@@ -1002,6 +1085,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         provider="google",
         model="gemini-live",
         tags=(_STREAMING, _MULTI),
+        region="global",
         status=_ACTIVE,
     ),
     # xAI stays under the early-access embargo while they are unresponsive to
@@ -1013,6 +1097,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         provider="xai",
         model="grok-voice-think-fast-1.0",
         tags=(_STREAMING, _MULTI),
+        region="us-east-1",
         status=_EARLY_ACCESS,
     ),
     RegisteredModel(
@@ -1020,6 +1105,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         provider="xai",
         model="grok-voice-think-fast-2.0",
         tags=(_STREAMING, _MULTI),
+        region="us-east-1",
         status=_EARLY_ACCESS,
     ),
 ]

--- a/runner/src/coval_bench/registries/models.py
+++ b/runner/src/coval_bench/registries/models.py
@@ -93,9 +93,10 @@ class RegisteredModel(BaseModel, frozen=True, extra="forbid"):
     licensing: Licensing = Licensing.PROPRIETARY
     on_prem: bool = False  # provider offers on-prem/customer-infra deployment
     # Serving region behind the endpoint we benchmark, normalized to
-    # ``us-east-1``-style codes regardless of cloud; broad ``us``/``eu``/
-    # ``global`` when the provider doesn't disclose or pin one. Unset means
-    # unknown. Geo-routed endpoints record where our runner's traffic lands.
+    # ``us-east-1``-style codes regardless of cloud. Broad ``us``/``eu`` when
+    # only the geography is known; ``global`` when the provider documents
+    # globally routed serving. Unset means unknown. Geo-routed endpoints
+    # record where our runner's traffic lands.
     region: str | None = None
     status: ModelStatus
     arena_enabled: bool = True  # in the arena roster? independent of dashboard `status`

--- a/runner/src/coval_bench/registries/tags.py
+++ b/runner/src/coval_bench/registries/tags.py
@@ -91,6 +91,13 @@ PROVIDER_VALUED_CATEGORIES: frozenset[TagCategory] = frozenset(
     {TagCategory.HOST, TagCategory.CREATOR}
 )
 
+# Broad region values get a readable label; granular codes stay raw.
+_REGION_LABELS: dict[str, str] = {
+    "us": "US",
+    "eu": "Europe",
+    "global": "Global",
+}
+
 # Value labels that aren't a plain capitalization.
 _VALUE_LABELS: dict[str, str] = {
     "shared-inference": "Shared inference",
@@ -113,5 +120,5 @@ def tag_value_label(category: TagCategory, value: str) -> str:
     if category is TagCategory.TYPE:
         return value.upper()
     if category is TagCategory.REGION:
-        return value
+        return _REGION_LABELS.get(value, value)
     return _VALUE_LABELS.get(value, value.capitalize())

--- a/runner/tests/api/test_providers.py
+++ b/runner/tests/api/test_providers.py
@@ -155,7 +155,7 @@ async def test_capability_and_licensing_facets(client: AsyncClient) -> None:
 
 
 async def test_region_facet_rides_only_on_models_that_report_one(client: AsyncClient) -> None:
-    """Region is emitted only where a provider confirmed it, and the label stays raw."""
+    """Region is emitted only where known; granular labels stay raw, broad ones readable."""
     response = await client.get("/v1/providers")
     data = response.json()
 
@@ -167,7 +167,13 @@ async def test_region_facet_rides_only_on_models_that_report_one(client: AsyncCl
         assert region["label"] == "us-west-1"
 
     elevenlabs = next(e for e in data["tts"] if e["provider"] == "elevenlabs")
-    assert not [t for m in elevenlabs["models"] for t in m["tags"] if t["category"] == "region"]
+    for model in elevenlabs["models"]:
+        region = next(t for t in model["tags"] if t["category"] == "region")
+        assert region["value"] == "us"
+        assert region["label"] == "US"
+
+    fluxions = next(e for e in data["tts"] if e["provider"] == "fluxions")
+    assert not [t for m in fluxions["models"] for t in m["tags"] if t["category"] == "region"]
 
 
 async def test_tag_categories_metadata(client: AsyncClient) -> None:

--- a/runner/tests/api/test_providers.py
+++ b/runner/tests/api/test_providers.py
@@ -172,6 +172,18 @@ async def test_region_facet_rides_only_on_models_that_report_one(client: AsyncCl
         assert region["value"] == "us"
         assert region["label"] == "US"
 
+    reson8 = next(e for e in data["stt"] if e["provider"] == "reson8")
+    for model in reson8["models"]:
+        region = next(t for t in model["tags"] if t["category"] == "region")
+        assert region["value"] == "eu"
+        assert region["label"] == "Europe"
+
+    google = next(e for e in data["tts"] if e["provider"] == "google")
+    chirp = next(m for m in google["models"] if m["model"] == "chirp-3-hd")
+    region = next(t for t in chirp["tags"] if t["category"] == "region")
+    assert region["value"] == "global"
+    assert region["label"] == "Global"
+
     fluxions = next(e for e in data["tts"] if e["provider"] == "fluxions")
     assert not [t for m in fluxions["models"] for t in m["tags"] if t["category"] == "region"]
 


### PR DESCRIPTION
Populates the region facet for all providers, normalized to us-east-1 style codes with broad US/Europe/Global fallbacks where the provider does not pin one.