### PR TITLE
Set Deepgram flux-haley-en to active

### DIFF
--- a/runner/src/coval_bench/registries/models.py
+++ b/runner/src/coval_bench/registries/models.py
@@ -547,7 +547,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         voice="flux-haley-en",
         tags=(_STREAMING, _STREAM),
         on_prem=True,
-        status=_EARLY_ACCESS,
+        status=_ACTIVE,
     ),
     RegisteredModel(
         benchmark=_TTS,

--- a/runner/src/coval_bench/registries/models.py
+++ b/runner/src/coval_bench/registries/models.py
@@ -595,6 +595,10 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         provider="deepgram",
         model="flux-haley-en",
         voice="flux-haley-en",
+        voices=(
+            Voice(id="flux-haley-en", gender=Gender.FEMALE, name="Haley", accent="en-US"),
+            Voice(id="flux-cole-en", gender=Gender.MALE, name="Cole", accent="en-US"),
+        ),
         tags=(_STREAMING, _STREAM),
         on_prem=True,
         region="us",


### PR DESCRIPTION
Promotes the model out of early access so its results are public.