### PR TITLE
Split the noisy S2S caller into its own dataset

### DIFF
--- a/runner/src/coval_bench/api/routers/leaderboard.py
+++ b/runner/src/coval_bench/api/routers/leaderboard.py
@@ -52,6 +52,11 @@ _VALID_COMBOS: set[tuple[str, str]] = {
     ("V2V", "S2S"),
 }
 
+# The headline S2S board is the clean multi-turn condition.  ``__all__`` remains
+# available to aggregate callers that explicitly want every S2S condition pooled,
+# including robustness datasets such as the noisy persona.
+_PRIMARY_DATASET_BY_BENCHMARK = {"S2S": "s2s-multiturn-v1"}
+
 _MV_SQL_TEMPLATE = """
     SELECT provider, model,
            avg_value AS avg,
@@ -97,7 +102,11 @@ async def get_leaderboard(
             f"Valid combinations: WER+STT, TTFT+STT, TTFS+STT, TTFA+TTS, V2V+S2S.",
         )
 
-    params: dict[str, Any] = {"metric": metric, "benchmark": benchmark, "dataset": DATASET_ALL}
+    params: dict[str, Any] = {
+        "metric": metric,
+        "benchmark": benchmark,
+        "dataset": _PRIMARY_DATASET_BY_BENCHMARK.get(benchmark, DATASET_ALL),
+    }
     sql = _MV_SQL_TEMPLATE.format(view=WINDOW_VIEWS[window])
 
     async with pool.connection() as conn:

--- a/runner/src/coval_bench/config.py
+++ b/runner/src/coval_bench/config.py
@@ -145,6 +145,11 @@ class Settings(BaseSettings):
     # other sims on the same agents (e.g. the single-turn set) would be ingested
     # and pooled into the same provider. Opaque id, not secret.
     coval_s2s_test_set_id: str | None = None
+    # The caller persona whose audio carries background noise; its runs land
+    # under their own dataset instead of pooling into the clean numbers. Unset
+    # means every persona is clean. Temporary: personas belong in stored
+    # settings, not one id here, once there is more than one condition.
+    coval_s2s_noisy_persona_id: str | None = None
     # Fetch grid, in seconds; kept in sync with the s2s-fetch-trigger cron in
     # benchmark-infra (override via S2S_FETCH_PERIOD_SECONDS). Default = 3h.
     s2s_fetch_period_seconds: int = Field(default=10_800, gt=0)

--- a/runner/src/coval_bench/db/migrations/versions/20260812_0017_runs_persona_id.py
+++ b/runner/src/coval_bench/db/migrations/versions/20260812_0017_runs_persona_id.py
@@ -1,0 +1,33 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Record the Coval caller persona on the run row.
+
+Provenance only: nothing groups, filters or aggregates by it, so the stats
+matviews and results_by_bucket are untouched. The caller condition the dashboard
+slices on rides on ``dataset_id`` instead, because the two clean personas are
+deliberately pooled and only the noisy one is a separate condition. Storing the
+id anyway means per-persona history exists if that slicing is ever wanted.
+
+Nullable, no backfill: pre-migration runs keep NULL, and non-S2S runs have no
+persona at all.
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "20260812_0017"
+down_revision = "20260810_0016"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Add the nullable persona_id column to runs."""
+    op.execute("ALTER TABLE benchmarks_v2.runs ADD COLUMN persona_id TEXT")
+
+
+def downgrade() -> None:
+    """Drop the persona_id column."""
+    op.execute("ALTER TABLE benchmarks_v2.runs DROP COLUMN persona_id")

--- a/runner/src/coval_bench/db/models.py
+++ b/runner/src/coval_bench/db/models.py
@@ -63,6 +63,7 @@ class Run(BaseModel):
     dataset_sha256: str
     status: RunStatus
     error: str | None = None
+    persona_id: str | None = None  # S2S caller persona; provenance only, never aggregated
 
 
 class Result(BaseModel):

--- a/runner/src/coval_bench/db/writer.py
+++ b/runner/src/coval_bench/db/writer.py
@@ -59,6 +59,7 @@ class RunWriter:
         dataset_id: str,
         dataset_sha256: str,
         scheduled_at: datetime | None = None,
+        persona_id: str | None = None,
     ) -> Run:
         """Insert a ``running`` row into ``benchmarks_v2.runs``.
 
@@ -66,16 +67,23 @@ class RunWriter:
         """
         sql = """
             INSERT INTO benchmarks_v2.runs
-                (runner_sha, dataset_id, dataset_sha256, status, scheduled_at)
-            VALUES (%s, %s, %s, %s, %s)
+                (runner_sha, dataset_id, dataset_sha256, status, scheduled_at, persona_id)
+            VALUES (%s, %s, %s, %s, %s, %s)
             RETURNING id, started_at, finished_at, scheduled_at, runner_sha,
-                      dataset_id, dataset_sha256, status, error
+                      dataset_id, dataset_sha256, status, error, persona_id
         """
         async with self._pool.connection() as conn:
             async with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
                 await cur.execute(
                     sql,
-                    (runner_sha, dataset_id, dataset_sha256, RunStatus.RUNNING, scheduled_at),
+                    (
+                        runner_sha,
+                        dataset_id,
+                        dataset_sha256,
+                        RunStatus.RUNNING,
+                        scheduled_at,
+                        persona_id,
+                    ),
                 )
                 row = await cur.fetchone()
                 if row is None:  # pragma: no cover — unreachable after INSERT RETURNING

--- a/runner/src/coval_bench/s2s/fetch_v2v.py
+++ b/runner/src/coval_bench/s2s/fetch_v2v.py
@@ -37,6 +37,9 @@ DATASET_ID = "s2s-v1"
 # Multi-turn runs have no local manifest -- they're keyed to the Coval test set --
 # so they use a distinct dataset id and never pool with single-turn s2s-v1.
 DATASET_ID_MULTITURN = "s2s-multiturn-v1"
+# The same test set run by the noisy caller persona, kept apart so background
+# noise never pools into the clean numbers.
+DATASET_ID_MULTITURN_NOISY = "s2s-multiturn-noisy-v1"
 
 # Ingest window: how far back one tick looks for not-yet-ingested runs, and
 # how many list results that scan reads. Two periods (with a one-day floor)
@@ -106,15 +109,24 @@ def _dataset_sha256() -> str:
         return "unknown"
 
 
-def _dataset_identity(test_set_id: str | None) -> tuple[str, str]:
-    """Dataset id + provenance for the fetched rows.
+def _dataset_identity(
+    test_set_id: str | None,
+    persona_id: str = "",
+    noisy_persona_id: str | None = None,
+) -> tuple[str, str]:
+    """Dataset id + provenance for one run's rows.
 
     Multi-turn runs are keyed to their Coval test set, not the single-turn SLURP
     manifest, so they get their own dataset id (never pooling with s2s-v1) and
     record the test-set id as provenance. Without a test set (legacy latency-only
     mode) the rows stay under the packaged s2s-v1 manifest.
+
+    The noisy caller shares that test set, so only the persona separates the two
+    conditions; its provenance names the persona to keep the rows self-describing.
     """
     if test_set_id:
+        if noisy_persona_id and persona_id == noisy_persona_id:
+            return DATASET_ID_MULTITURN_NOISY, f"{test_set_id}:{persona_id}"
         return DATASET_ID_MULTITURN, test_set_id
     return DATASET_ID, _dataset_sha256()
 
@@ -403,6 +415,7 @@ async def _ingest_run(
             dataset_id=dataset_id,
             dataset_sha256=dataset_sha256 or _dataset_sha256(),
             scheduled_at=scheduled_at,
+            persona_id=coval_run.persona_id or None,
         )
         if run_row.id is None:  # pragma: no cover -- start_run always returns an id
             raise RuntimeError("start_run returned a run with no id")
@@ -475,6 +488,7 @@ async def _fetch_one_provider(
     metric_id: str,
     instruction_metric_id: str | None = None,
     test_set_id: str | None = None,
+    noisy_persona_id: str | None = None,
     runner_sha: str,
     period_seconds: int,
     stale_grace_seconds: int,
@@ -500,6 +514,10 @@ async def _fetch_one_provider(
         # yesterday's before the sampler ever saw it. Staggered arrivals must not
         # shrink the sample; committed only after the staleness check so a stale
         # provider's old recording never ships today.
+        # The noisy caller is under embargo, so its recordings never reach the
+        # public samples card.
+        if noisy_persona_id and coval_run.persona_id == noisy_persona_id:
+            return
         bucket_at = _bucket_start(coval_run.create_time or datetime.now(tz=UTC), period_seconds)
         key = (bucket_at, coval_run.persona_id)
         if key in candidates:
@@ -517,8 +535,6 @@ async def _fetch_one_provider(
         runs = await recent_completed_runs(
             client, agent_id, period_seconds=period_seconds, test_set_id=test_set_id
         )
-        dataset_id, dataset_sha256 = _dataset_identity(test_set_id)
-
         data_seen = False
         newest_data_at: datetime | None = None
         for coval_run in runs:
@@ -549,6 +565,9 @@ async def _fetch_one_provider(
                     "run_already_ingested", provider=spec.provider, coval_run_id=coval_run.run_id
                 )
                 continue
+            dataset_id, dataset_sha256 = _dataset_identity(
+                test_set_id, coval_run.persona_id, noisy_persona_id
+            )
             status = await _ingest_run(
                 client,
                 writer,
@@ -633,6 +652,14 @@ async def fetch_and_write_v2v(settings: Settings | None = None) -> dict[str, Run
         raise RuntimeError(
             "coval_s2s_instruction_metric_id and coval_s2s_test_set_id must be set together"
         )
+    # The noisy persona only separates conditions within a test set, so without
+    # one it would silently never take effect.
+    raw_noisy = settings.coval_s2s_noisy_persona_id
+    if raw_noisy is not None and not raw_noisy.strip():
+        raise RuntimeError("coval_s2s_noisy_persona_id must not be blank")
+    noisy_persona_id = raw_noisy or None
+    if noisy_persona_id and not test_set_id:
+        raise RuntimeError("coval_s2s_noisy_persona_id requires coval_s2s_test_set_id")
 
     async with _client(settings) as client, lifespan_pool(settings) as pool:
         writer = RunWriter(pool)
@@ -652,6 +679,7 @@ async def fetch_and_write_v2v(settings: Settings | None = None) -> dict[str, Run
                 metric_id=metric_id,
                 instruction_metric_id=instruction_metric_id,
                 test_set_id=test_set_id,
+                noisy_persona_id=noisy_persona_id,
                 runner_sha=settings.runner_sha,
                 period_seconds=settings.s2s_fetch_period_seconds,
                 stale_grace_seconds=settings.s2s_stale_grace_seconds,

--- a/runner/tests/api/conftest.py
+++ b/runner/tests/api/conftest.py
@@ -106,7 +106,7 @@ def _load_schema(**connect_kwargs: Any) -> None:
                 provider       text NOT NULL,
                 model          text NOT NULL,
                 voice          text,
-                benchmark      text NOT NULL CHECK (benchmark IN ('STT','TTS')),
+                benchmark      text NOT NULL CHECK (benchmark IN ('STT','TTS','S2S')),
                 metric_type    text NOT NULL,
                 metric_value   double precision,
                 metric_units   text,

--- a/runner/tests/api/test_leaderboard.py
+++ b/runner/tests/api/test_leaderboard.py
@@ -157,6 +157,44 @@ async def test_excluded_metric_rows_hidden(client: AsyncClient, postgresql: Any)
     assert [(e["provider"], e["model"]) for e in entries] == [("deepgram", "nova-3")]
 
 
+async def test_s2s_leaderboard_uses_clean_multiturn_dataset(
+    client: AsyncClient, postgresql: Any
+) -> None:
+    """The headline S2S board excludes robustness conditions such as noisy speech."""
+    clean_run = await _insert_run(postgresql, dataset_id="s2s-multiturn-v1")
+    noisy_run = await _insert_run(postgresql, dataset_id="s2s-multiturn-noisy-v1")
+    await _insert_result(
+        postgresql,
+        clean_run,
+        provider="openai",
+        model="gpt-realtime",
+        metric_type="V2V",
+        metric_value=1200.0,
+        metric_units="ms",
+        benchmark="S2S",
+    )
+    await _insert_result(
+        postgresql,
+        noisy_run,
+        provider="google",
+        model="gemini-live",
+        metric_type="V2V",
+        metric_value=900.0,
+        metric_units="ms",
+        benchmark="S2S",
+    )
+    await _refresh_mv(postgresql)
+
+    response = await client.get(
+        "/v1/leaderboard", params={"metric": "V2V", "benchmark": "S2S"}
+    )
+
+    assert response.status_code == 200
+    assert [(e["provider"], e["model"]) for e in response.json()["entries"]] == [
+        ("openai", "gpt-realtime")
+    ]
+
+
 async def test_thin_entry_flagged_and_sunk_below_ranked(
     client: AsyncClient, postgresql: Any
 ) -> None:

--- a/runner/tests/api/test_leaderboard.py
+++ b/runner/tests/api/test_leaderboard.py
@@ -185,9 +185,7 @@ async def test_s2s_leaderboard_uses_clean_multiturn_dataset(
     )
     await _refresh_mv(postgresql)
 
-    response = await client.get(
-        "/v1/leaderboard", params={"metric": "V2V", "benchmark": "S2S"}
-    )
+    response = await client.get("/v1/leaderboard", params={"metric": "V2V", "benchmark": "S2S"})
 
     assert response.status_code == 200
     assert [(e["provider"], e["model"]) for e in response.json()["entries"]] == [

--- a/runner/tests/unit/test_arena_snapshot.py
+++ b/runner/tests/unit/test_arena_snapshot.py
@@ -403,7 +403,9 @@ def test_battle_voice_migration_reverses(snap_pg: psycopg.Connection[Any]) -> No
     after_upgrade = _battle_columns(snap_pg)
     assert added <= after_upgrade
 
-    alembic_command.downgrade(cfg, "-1")
+    # Named, not "-1": relative to head this stopped testing 0016 the moment a
+    # later migration landed.
+    alembic_command.downgrade(cfg, "20260807_0015")
     after_downgrade = _battle_columns(snap_pg)
     assert added.isdisjoint(after_downgrade)
     assert after_downgrade == after_upgrade - added

--- a/runner/tests/unit/test_s2s_fetch.py
+++ b/runner/tests/unit/test_s2s_fetch.py
@@ -576,6 +576,92 @@ def test_dataset_identity() -> None:
     assert dataset_id == "s2s-v1"
 
 
+def test_dataset_identity_splits_the_noisy_caller() -> None:
+    """The noisy persona shares the test set but gets its own dataset."""
+    assert fetch_v2v._dataset_identity("TS1", "PN", "PN") == (
+        "s2s-multiturn-noisy-v1",
+        "TS1:PN",
+    )
+    # Every other persona in that test set stays pooled as the clean condition.
+    assert fetch_v2v._dataset_identity("TS1", "PCLEAN", "PN") == ("s2s-multiturn-v1", "TS1")
+    # Unset setting: no persona is noisy, so nothing splits.
+    assert fetch_v2v._dataset_identity("TS1", "PN", None) == ("s2s-multiturn-v1", "TS1")
+    # Single-turn has no test set, so it keeps the packaged manifest.
+    single_turn, _sha = fetch_v2v._dataset_identity(None, "PN", "PN")
+    assert single_turn == "s2s-v1"
+
+
+@pytest.mark.asyncio
+async def test_noisy_and_clean_runs_land_in_different_datasets() -> None:
+    """One scan, two personas: the dataset is chosen per run, not per tick."""
+    writer = _stub_writer()
+    list_json = _list_json(
+        {"run_id": "RNOISY", "create_time": _iso(timedelta(hours=1)), "persona_id": "PN"},
+        {"run_id": "RCLEAN", "create_time": _iso(timedelta(hours=1)), "persona_id": "PCLEAN"},
+    )
+    values = [{"simulation_output_id": "s1", "value": 0.5}]
+    async with _fake_client(list_json, _run_json(values)) as client:
+        await fetch_v2v._fetch_one_provider(
+            client,
+            writer,
+            spec=SPEC,
+            agent_id="a1",
+            metric_id="MID",
+            test_set_id="TS1",
+            noisy_persona_id="PN",
+            runner_sha="test",
+            period_seconds=10_800,
+            stale_grace_seconds=5_400,
+        )
+    datasets = [c.kwargs["dataset_id"] for c in writer.start_run.await_args_list]
+    assert datasets == ["s2s-multiturn-noisy-v1", "s2s-multiturn-v1"]
+    # Provenance rides along so a row says which persona produced it.
+    personas = [c.kwargs["persona_id"] for c in writer.start_run.await_args_list]
+    assert personas == ["PN", "PCLEAN"]
+
+
+@pytest.mark.asyncio
+async def test_noisy_caller_never_becomes_a_sample_candidate() -> None:
+    """Embargoed audio must not reach the public samples card."""
+    from coval_bench.s2s.samples import SampleRun
+
+    writer = _stub_writer()
+    list_json = _list_json(
+        {"run_id": "RNOISY", "create_time": _iso(timedelta(hours=1)), "persona_id": "PN"},
+        {"run_id": "RCLEAN", "create_time": _iso(timedelta(hours=1)), "persona_id": "PCLEAN"},
+    )
+    values = [{"simulation_output_id": "s1", "value": 0.5}]
+    sampled: list[SampleRun] = []
+    async with _fake_client(list_json, _run_json(values)) as client:
+        await fetch_v2v._fetch_one_provider(
+            client,
+            writer,
+            spec=SPEC,
+            agent_id="a1",
+            metric_id="MID",
+            test_set_id="TS1",
+            noisy_persona_id="PN",
+            runner_sha="test",
+            period_seconds=10_800,
+            stale_grace_seconds=5_400,
+            sampled_runs=sampled,
+        )
+    assert [r.coval_run_id for r in sampled] == ["RCLEAN"]
+
+
+@pytest.mark.asyncio
+async def test_fetch_and_write_rejects_noisy_persona_without_a_test_set() -> None:
+    # Without a test set the persona split can never fire, so fail loudly.
+    settings = Settings(
+        runner_sha="test",
+        coval_s2s_latency_metric_id="MID",
+        coval_s2s_openai_agent_id="a1",
+        coval_s2s_noisy_persona_id="PN",
+    )
+    with pytest.raises(RuntimeError, match="requires coval_s2s_test_set_id"):
+        await fetch_v2v.fetch_and_write_v2v(settings)
+
+
 @pytest.mark.asyncio
 async def test_ingest_run_writes_instruction_rows() -> None:
     writer = _stub_writer()


### PR DESCRIPTION
Only the persona tells the noisy and clean conditions apart, so its runs now land under s2s-multiturn-noisy-v1 rather than pooling into the clean numbers, and the run row records which persona produced it. Unset, nothing changes  this needs to be live before we wire up the data wit high background noise speaker.
Note: more of a temp solution tbh