### PR TITLE
Keep ingesting S2S runs that have no latency metric

### DIFF
--- a/runner/src/coval_bench/s2s/fetch_v2v.py
+++ b/runner/src/coval_bench/s2s/fetch_v2v.py
@@ -245,20 +245,23 @@ def _instruction_verdict(raw: object) -> bool | None:
 
 
 def _instruction_id_mismatch(
-    latency_values: list[dict[str, Any]], instruction_values: list[dict[str, Any]]
+    latency_values: list[dict[str, Any]] | None, instruction_values: list[dict[str, Any]]
 ) -> dict[str, object] | None:
-    """None if instruction's sim-id set matches latency exactly; else the diff.
+    """None if instruction's sim-id set is sound; else the diff.
 
-    Equal counts can still be different conversations, so compare the id sets and
-    reject duplicates. A mismatch means the pass rate would not be over the same
-    population as latency, so instruction is skipped for the run.
+    Ids, not counts: equal counts can be different conversations. ``latency_values``
+    is None -- not empty -- when the run has no latency metric, and then only
+    duplicate ids are checked. A mismatch skips instruction for the run.
     """
-    lat_ids = [v.get("simulation_output_id") for v in latency_values]
     ins_ids = [v.get("simulation_output_id") for v in instruction_values]
-    lat_set, ins_set = set(lat_ids), set(ins_ids)
+    ins_set = set(ins_ids)
     duplicate = len(ins_ids) != len(ins_set)
-    missing = sorted(str(x) for x in lat_set - ins_set)
-    extra = sorted(str(x) for x in ins_set - lat_set)
+    missing: list[str] = []
+    extra: list[str] = []
+    if latency_values is not None:
+        lat_set = {v.get("simulation_output_id") for v in latency_values}
+        missing = sorted(str(x) for x in lat_set - ins_set)
+        extra = sorted(str(x) for x in ins_set - lat_set)
     if not duplicate and not missing and not extra:
         return None
     return {
@@ -322,8 +325,8 @@ async def _ingest_run(
     """Ingest one Coval run into its own run row; None = skipped, nothing written.
 
     Skips (before any DB write) runs finalized with an error_status — those
-    failed upstream of the provider and must not dent its reliability — and
-    runs missing the metric. Otherwise SUCCEEDED = all clips numeric, PARTIAL =
+    failed upstream of the provider and must not dent its reliability — and runs
+    left with nothing to write. Otherwise SUCCEEDED = all clips numeric, PARTIAL =
     some failed, FAILED = all failed.
     """
     run_pk: int | None = None
@@ -343,14 +346,15 @@ async def _ingest_run(
         metrics = cast("dict[str, Any]", (run.get("results") or {}).get("metrics") or {})
         metric = metrics.get(metric_id)
         if metric is None:
+            # Conditions with unreliable turn boundaries run with latency off.
             logger.warning(
                 "metric_absent",
                 provider=spec.provider,
                 coval_run_id=coval_run.run_id,
                 metric_id=metric_id,
             )
-            return None
-        values = cast("list[dict[str, Any]]", metric.get("values", []))
+        values = cast("list[dict[str, Any]]", metric.get("values", [])) if metric else []
+        write_latency = want_latency and metric is not None
 
         # Decide instruction writability up front (pure) so a backfill with
         # nothing to add creates no run row and stays retryable.
@@ -368,7 +372,7 @@ async def _ingest_run(
                 )
             else:
                 instr_values = cast("list[dict[str, Any]]", instr.get("values", []))
-                mismatch = _instruction_id_mismatch(values, instr_values)
+                mismatch = _instruction_id_mismatch(values if metric else None, instr_values)
                 if mismatch is not None:
                     # Different conversation population than latency -> skip
                     # instruction (keep latency) so the rate stays comparable.
@@ -393,7 +397,7 @@ async def _ingest_run(
                             error=str(exc),
                         )
 
-        if not want_latency and not write_instruction:
+        if not write_latency and not write_instruction:
             # Backfill with nothing to add; leave it retryable, write no run row.
             return None
 
@@ -410,7 +414,7 @@ async def _ingest_run(
 
         rows = (
             _result_rows(values, run_pk=run_pk, coval_run_id=coval_run.run_id, spec=spec)
-            if want_latency
+            if write_latency
             else []
         )
         instruction_rows = (
@@ -430,7 +434,7 @@ async def _ingest_run(
             instruction=len(instruction_rows),
             success=sum(1 for r in rows if r.status is ResultStatus.SUCCESS),
         )
-        if want_latency:
+        if write_latency:
             # Reliability is the latency signal (instruction lag never fails the run).
             failed = sum(1 for r in rows if r.status is ResultStatus.FAILED)
             if not rows or failed == len(rows):

--- a/runner/src/coval_bench/s2s/fetch_v2v.py
+++ b/runner/src/coval_bench/s2s/fetch_v2v.py
@@ -384,9 +384,11 @@ async def _ingest_run(
                     )
                 else:
                     try:
+                        has_instruction_row = False
                         for v in instr_values:
-                            _instruction_verdict(v.get("value"))
-                        write_instruction = True
+                            verdict = _instruction_verdict(v.get("value"))
+                            has_instruction_row |= verdict is not None
+                        write_instruction = has_instruction_row
                     except InvalidInstructionVerdict as exc:
                         # Judge-contract violation: discard instruction for the
                         # whole run (keep latency); retryable on a later scan.
@@ -542,9 +544,12 @@ async def _fetch_one_provider(
                 coval_run_id=coval_run.run_id,
                 metric_type=Metric.INSTRUCTION_FOLLOWING,
             )
-            # A run whose latency already landed is fresh data + an eligible
-            # sample even if we still owe it an instruction backfill.
-            if latency_done:
+            instruction_data_done = instruction_metric_id is not None and instruction_done
+            # Either persisted metric is fresh data + an eligible sample. This
+            # keeps intentionally instruction-only conditions healthy between
+            # fetches while an unconfigured instruction metric cannot mask
+            # missing latency.
+            if latency_done or instruction_data_done:
                 note_sample_candidate(coval_run)
                 if not data_seen:
                     data_seen, newest_data_at = True, coval_run.create_time

--- a/runner/tests/unit/test_s2s_fetch.py
+++ b/runner/tests/unit/test_s2s_fetch.py
@@ -568,6 +568,11 @@ def test_instruction_id_mismatch() -> None:
     dup_diff = fetch_v2v._instruction_id_mismatch(lat, dup)
     assert dup_diff is not None
     assert dup_diff["duplicate_instruction_ids"] is True
+    # no latency metric: nothing to compare against, duplicates still rejected
+    assert fetch_v2v._instruction_id_mismatch(None, ins) is None
+    no_anchor = fetch_v2v._instruction_id_mismatch(None, dup)
+    assert no_anchor is not None
+    assert no_anchor["duplicate_instruction_ids"] is True
 
 
 def test_dataset_identity() -> None:
@@ -731,6 +736,72 @@ async def test_ingest_run_backfill_instruction_absent_is_noop() -> None:
             period_seconds=10_800,
         )
     assert status is None  # nothing to write -> no run row, stays retryable
+    writer.start_run.assert_not_awaited()
+    writer.record_results.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_ingest_run_latency_absent_writes_instruction() -> None:
+    # Conditions that run with latency off must still yield instruction rows.
+    writer = _stub_writer()
+    instruction = [{"simulation_output_id": "s0", "value": "YES"}]
+    async with _fake_client({}, _run_json(instruction, metric_id="IID")) as client:
+        status = await fetch_v2v._ingest_run(
+            client,
+            writer,
+            spec=SPEC,
+            coval_run=CovalRun(run_id="R1", create_time=None, error_status=None),
+            metric_id="MID",
+            instruction_metric_id="IID",
+            runner_sha="test",
+            period_seconds=10_800,
+        )
+    assert status is RunStatus.SUCCEEDED
+    rows = writer.record_results.await_args.args[0]
+    assert len(rows) == 1
+    assert all(r.metric_type == Metric.INSTRUCTION_FOLLOWING for r in rows)
+
+
+@pytest.mark.asyncio
+async def test_ingest_run_latency_absent_rejects_duplicate_instruction_ids() -> None:
+    # The duplicate check is instruction-only, so it survives having no anchor.
+    writer = _stub_writer()
+    instruction = [
+        {"simulation_output_id": "s0", "value": "YES"},
+        {"simulation_output_id": "s0", "value": "NO"},
+    ]
+    async with _fake_client({}, _run_json(instruction, metric_id="IID")) as client:
+        status = await fetch_v2v._ingest_run(
+            client,
+            writer,
+            spec=SPEC,
+            coval_run=CovalRun(run_id="R1", create_time=None, error_status=None),
+            metric_id="MID",
+            instruction_metric_id="IID",
+            runner_sha="test",
+            period_seconds=10_800,
+        )
+    assert status is None
+    writer.start_run.assert_not_awaited()
+    writer.record_results.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_ingest_run_no_metrics_present_is_noop() -> None:
+    # Neither metric on the run -> no run row, stays retryable.
+    writer = _stub_writer()
+    async with _fake_client({}, _run_json([], metric_id="OTHER")) as client:
+        status = await fetch_v2v._ingest_run(
+            client,
+            writer,
+            spec=SPEC,
+            coval_run=CovalRun(run_id="R1", create_time=None, error_status=None),
+            metric_id="MID",
+            instruction_metric_id="IID",
+            runner_sha="test",
+            period_seconds=10_800,
+        )
+    assert status is None
     writer.start_run.assert_not_awaited()
     writer.record_results.assert_not_awaited()
 

--- a/runner/tests/unit/test_s2s_fetch.py
+++ b/runner/tests/unit/test_s2s_fetch.py
@@ -787,6 +787,60 @@ async def test_ingest_run_latency_absent_rejects_duplicate_instruction_ids() -> 
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "instruction",
+    [[], [{"simulation_output_id": "s0", "value": "UNKNOWN"}]],
+    ids=["empty", "all-unknown"],
+)
+async def test_ingest_run_latency_absent_instruction_without_rows_is_noop(
+    instruction: list[dict[str, Any]],
+) -> None:
+    writer = _stub_writer()
+    async with _fake_client({}, _run_json(instruction, metric_id="IID")) as client:
+        status = await fetch_v2v._ingest_run(
+            client,
+            writer,
+            spec=SPEC,
+            coval_run=CovalRun(run_id="R1", create_time=None, error_status=None),
+            metric_id="MID",
+            instruction_metric_id="IID",
+            runner_sha="test",
+            period_seconds=10_800,
+        )
+    assert status is None
+    writer.start_run.assert_not_awaited()
+    writer.record_results.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_already_ingested_instruction_only_run_is_fresh() -> None:
+    writer = _stub_writer()
+
+    async def metric_ingested(*, metric_type: str, **_kwargs: Any) -> bool:
+        return metric_type == Metric.INSTRUCTION_FOLLOWING
+
+    writer.coval_metric_ingested = AsyncMock(side_effect=metric_ingested)
+    list_json = _list_json({"run_id": "R1", "create_time": _iso(timedelta(hours=1))})
+    instruction = [{"simulation_output_id": "s0", "value": "YES"}]
+    async with _fake_client(list_json, _run_json(instruction, metric_id="IID")) as client:
+        status, ingested = await fetch_v2v._fetch_one_provider(
+            client,
+            writer,
+            spec=SPEC,
+            agent_id="a1",
+            metric_id="MID",
+            instruction_metric_id="IID",
+            test_set_id="TS1",
+            runner_sha="test",
+            period_seconds=10_800,
+            stale_grace_seconds=5_400,
+        )
+
+    assert (status, ingested) == (RunStatus.SUCCEEDED, 0)
+    writer.start_run.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_ingest_run_no_metrics_present_is_noop() -> None:
     # Neither metric on the run -> no run row, stays retryable.
     writer = _stub_writer()


### PR DESCRIPTION
A caller whose background noise makes turn boundaries unreliable runs with latency off, and today that drops the whole run — the instruction adherence rows go with it, so the metric we most want under noise silently produces nothing.

Latency absence is now treated as just an absent metric: no latency rows, everything else still lands, and a run left with nothing to write creates no run row and stays retryable. The population check needed the same distinction, since it compared instruction's conversation ids against latency's — with no latency every id read as extra and instruction was skipped anyway. It now compares only when the run carries latency, and still rejects duplicate ids, which was always an instruction-only check.

Groundwork for scoping metrics per dataset, so each condition declares what it can measure.