### PR TITLE
Add interruption rate to the metric registry

### DIFF
--- a/runner/src/coval_bench/config.py
+++ b/runner/src/coval_bench/config.py
@@ -141,6 +141,8 @@ class Settings(BaseSettings):
     # fetch pulls its per-conversation scores only when set, so latency still
     # ingests without it.
     coval_s2s_instruction_metric_id: str | None = None
+    # The S2S interruption-rate metric id (opaque, not secret). Optional.
+    coval_s2s_interruption_metric_id: str | None = None
     # Restrict the fetch to one Coval test set (the multi-turn set). Without it,
     # other sims on the same agents (e.g. the single-turn set) would be ingested
     # and pooled into the same provider. Opaque id, not secret.

--- a/runner/src/coval_bench/registries/metrics.py
+++ b/runner/src/coval_bench/registries/metrics.py
@@ -130,9 +130,9 @@ METRIC_SPECS: dict[Metric, MetricSpec] = {
     ),
     Metric.INTERRUPTION_RATE: MetricSpec(
         display_name="Interruption Rate",
-        units="percent",
+        units="per_minute",
         direction=MetricDirection.LOWER_IS_BETTER,
-        decimals=1,
+        decimals=2,
         benchmarks=frozenset({Benchmark.S2S}),
     ),
 }

--- a/runner/src/coval_bench/registries/metrics.py
+++ b/runner/src/coval_bench/registries/metrics.py
@@ -30,6 +30,7 @@ class Metric(StrEnum):
     AUDIO_TO_FINAL = "AudioToFinal"
     V2V = "V2V"
     INSTRUCTION_FOLLOWING = "InstructionFollowing"
+    INTERRUPTION_RATE = "InterruptionRate"
 
 
 class MetricDirection(StrEnum):
@@ -124,6 +125,13 @@ METRIC_SPECS: dict[Metric, MetricSpec] = {
         # average is the pass rate as a percentage, like WER.
         units="percent",
         direction=MetricDirection.HIGHER_IS_BETTER,
+        decimals=1,
+        benchmarks=frozenset({Benchmark.S2S}),
+    ),
+    Metric.INTERRUPTION_RATE: MetricSpec(
+        display_name="Interruption Rate",
+        units="percent",
+        direction=MetricDirection.LOWER_IS_BETTER,
         decimals=1,
         benchmarks=frozenset({Benchmark.S2S}),
     ),

--- a/runner/tests/unit/test_metric_registry.py
+++ b/runner/tests/unit/test_metric_registry.py
@@ -25,6 +25,7 @@ def test_metric_values_match_stored_strings() -> None:
         "AudioToFinal",
         "V2V",
         "InstructionFollowing",
+        "InterruptionRate",
     }
 
 
@@ -41,6 +42,7 @@ def test_units_match_stored_strings() -> None:
         Metric.AUDIO_TO_FINAL: "seconds",
         Metric.V2V: "milliseconds",
         Metric.INSTRUCTION_FOLLOWING: "percent",
+        Metric.INTERRUPTION_RATE: "percent",
     }
     assert {m: spec.units for m, spec in METRIC_SPECS.items()} == expected
 

--- a/runner/tests/unit/test_metric_registry.py
+++ b/runner/tests/unit/test_metric_registry.py
@@ -42,7 +42,7 @@ def test_units_match_stored_strings() -> None:
         Metric.AUDIO_TO_FINAL: "seconds",
         Metric.V2V: "milliseconds",
         Metric.INSTRUCTION_FOLLOWING: "percent",
-        Metric.INTERRUPTION_RATE: "percent",
+        Metric.INTERRUPTION_RATE: "per_minute",
     }
     assert {m: spec.units for m, spec in METRIC_SPECS.items()} == expected
 


### PR DESCRIPTION
Declares the S2S interruption rate metric — percent, lower is better — and the setting that holds its Coval metric id. Coval computes the metric itself, so ingesting it later needs no turn parsing.

Nothing reads either yet: this is the declaration the per-dataset metric scoping will name, split out so that change stays small. No migration, since results.metric_type is a plain text column.