### PR TITLE
[BENCH-668] Add timestamp preprocessing contracts and batching foundation

### DIFF
--- a/runner/src/coval_bench/preprocessing/__init__.py
+++ b/runner/src/coval_bench/preprocessing/__init__.py
@@ -1,0 +1,48 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""CPU-only timestamp preprocessing contracts and deterministic utilities."""
+
+from coval_bench.preprocessing.artifacts import (
+    artifact_content_fingerprint,
+    canonical_json_bytes,
+    canonical_json_sha256,
+    generator_fingerprint,
+    immutable_artifact_key,
+)
+from coval_bench.preprocessing.batching import (
+    DEFAULT_MAX_BATCH_CLIPS,
+    DEFAULT_MAX_BATCH_DURATION_MS,
+    batch_by_duration,
+)
+from coval_bench.preprocessing.contracts import (
+    PhonemeProcessorProvenanceV1,
+    PhonemeTimestampsV1,
+    PhonemeTimestampV1,
+    TimestampArtifactV1,
+    TimestampWarningCode,
+    TimestampWarningV1,
+    WordProcessorProvenanceV1,
+    WordTimestampsV1,
+    WordTimestampV1,
+)
+
+__all__ = [
+    "DEFAULT_MAX_BATCH_CLIPS",
+    "DEFAULT_MAX_BATCH_DURATION_MS",
+    "PhonemeProcessorProvenanceV1",
+    "PhonemeTimestampV1",
+    "PhonemeTimestampsV1",
+    "TimestampArtifactV1",
+    "TimestampWarningCode",
+    "TimestampWarningV1",
+    "WordProcessorProvenanceV1",
+    "WordTimestampV1",
+    "WordTimestampsV1",
+    "artifact_content_fingerprint",
+    "batch_by_duration",
+    "canonical_json_bytes",
+    "canonical_json_sha256",
+    "generator_fingerprint",
+    "immutable_artifact_key",
+]

--- a/runner/src/coval_bench/preprocessing/artifacts.py
+++ b/runner/src/coval_bench/preprocessing/artifacts.py
@@ -1,0 +1,62 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Canonical bytes and immutable identities for timestamp artifacts."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+
+from pydantic import BaseModel
+
+from coval_bench.preprocessing.contracts import (
+    PhonemeProcessorProvenanceV1,
+    PhonemeTimestampsV1,
+    WordProcessorProvenanceV1,
+    WordTimestampsV1,
+)
+
+TimestampArtifact = WordTimestampsV1 | PhonemeTimestampsV1
+ProcessorProvenance = WordProcessorProvenanceV1 | PhonemeProcessorProvenanceV1
+
+
+def canonical_json_bytes(value: object) -> bytes:
+    """Serialize a JSON-compatible value to deterministic UTF-8 bytes."""
+    if isinstance(value, BaseModel):
+        value = value.model_dump(mode="json")
+    try:
+        return json.dumps(
+            value,
+            allow_nan=False,
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode("utf-8")
+    except (TypeError, ValueError) as exc:
+        raise ValueError("value must be JSON-compatible and contain no NaN values") from exc
+
+
+def canonical_json_sha256(value: object) -> str:
+    """Hash the exact bytes returned by :func:`canonical_json_bytes`."""
+    return hashlib.sha256(canonical_json_bytes(value)).hexdigest()
+
+
+def generator_fingerprint(processor: ProcessorProvenance) -> str:
+    """Hash one validated, fully typed processor identity."""
+    return canonical_json_sha256(processor)
+
+
+def artifact_content_fingerprint(artifact: TimestampArtifact) -> str:
+    """Return the SHA-256 of the artifact's canonical serialized bytes."""
+    return canonical_json_sha256(artifact)
+
+
+def immutable_artifact_key(artifact: TimestampArtifact) -> str:
+    """Return a content-addressed key whose final digest hashes canonical bytes."""
+    processor_fingerprint = generator_fingerprint(artifact.processor)
+    return (
+        f"timestamp-artifacts/{artifact.schema_version}/"
+        f"{artifact.audio_sha256}/{processor_fingerprint}/"
+        f"{artifact_content_fingerprint(artifact)}.json"
+    )

--- a/runner/src/coval_bench/preprocessing/batching.py
+++ b/runner/src/coval_bench/preprocessing/batching.py
@@ -1,0 +1,64 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Deterministic, integer-millisecond batching for preprocessing workers."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable
+
+DEFAULT_MAX_BATCH_CLIPS = 32
+DEFAULT_MAX_BATCH_DURATION_MS = 300_000
+
+
+def batch_by_duration[Item](
+    items: Iterable[Item],
+    *,
+    duration_ms_of: Callable[[Item], int],
+    max_clips: int = DEFAULT_MAX_BATCH_CLIPS,
+    max_duration_ms: int = DEFAULT_MAX_BATCH_DURATION_MS,
+) -> tuple[tuple[Item, ...], ...]:
+    """Batch in input order under clip-count and total-duration bounds.
+
+    A clip longer than ``max_duration_ms`` is retained as a singleton. Integer
+    milliseconds make exact-boundary behavior independent of float arithmetic.
+    """
+    if isinstance(max_clips, bool) or not isinstance(max_clips, int) or max_clips < 1:
+        raise ValueError("max_clips must be a positive integer")
+    if (
+        isinstance(max_duration_ms, bool)
+        or not isinstance(max_duration_ms, int)
+        or max_duration_ms < 1
+    ):
+        raise ValueError("max_duration_ms must be a positive integer")
+
+    batches: list[tuple[Item, ...]] = []
+    current: list[Item] = []
+    current_duration_ms = 0
+
+    for item in items:
+        duration_ms = duration_ms_of(item)
+        if isinstance(duration_ms, bool) or not isinstance(duration_ms, int) or duration_ms < 1:
+            raise ValueError("item duration must be a positive integer number of milliseconds")
+
+        if duration_ms > max_duration_ms:
+            if current:
+                batches.append(tuple(current))
+                current = []
+                current_duration_ms = 0
+            batches.append((item,))
+            continue
+
+        if current and (
+            len(current) >= max_clips or current_duration_ms + duration_ms > max_duration_ms
+        ):
+            batches.append(tuple(current))
+            current = []
+            current_duration_ms = 0
+
+        current.append(item)
+        current_duration_ms += duration_ms
+
+    if current:
+        batches.append(tuple(current))
+    return tuple(batches)

--- a/runner/src/coval_bench/preprocessing/contracts.py
+++ b/runner/src/coval_bench/preprocessing/contracts.py
@@ -113,8 +113,11 @@ class PhonemeTimestampV1(_FrozenContract):
 class _TimestampSpan(Protocol):
     """Structural type shared by word and phoneme timestamp spans."""
 
-    start_ms: int
-    end_ms: int
+    @property
+    def start_ms(self) -> int: ...
+
+    @property
+    def end_ms(self) -> int: ...
 
 
 def _validate_timeline(

--- a/runner/src/coval_bench/preprocessing/contracts.py
+++ b/runner/src/coval_bench/preprocessing/contracts.py
@@ -6,7 +6,7 @@
 from __future__ import annotations
 
 from enum import StrEnum
-from typing import Annotated, Literal
+from typing import Annotated, Literal, Protocol
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
@@ -110,9 +110,16 @@ class PhonemeTimestampV1(_FrozenContract):
         return self
 
 
+class _TimestampSpan(Protocol):
+    """Structural type shared by word and phoneme timestamp spans."""
+
+    start_ms: int
+    end_ms: int
+
+
 def _validate_timeline(
     *,
-    spans: tuple[WordTimestampV1, ...] | tuple[PhonemeTimestampV1, ...],
+    spans: tuple[_TimestampSpan, ...],
     warnings: tuple[TimestampWarningV1, ...],
     duration_ms: int,
 ) -> None:

--- a/runner/src/coval_bench/preprocessing/contracts.py
+++ b/runner/src/coval_bench/preprocessing/contracts.py
@@ -1,0 +1,187 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Strict, versioned contracts for timestamp preprocessing artifacts."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import Annotated, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+SHA256_PATTERN = r"^[a-f0-9]{64}$"
+NONBLANK_PATTERN = r"^.*\S.*$"
+
+NonBlankStr = Annotated[str, Field(min_length=1, pattern=NONBLANK_PATTERN, strict=True)]
+NonNegativeMilliseconds = Annotated[int, Field(ge=0, strict=True)]
+PositiveMilliseconds = Annotated[int, Field(gt=0, strict=True)]
+Confidence = Annotated[float, Field(ge=0, le=1, allow_inf_nan=False, strict=True)]
+
+
+class _FrozenContract(BaseModel):
+    """Reject coercion and unknown fields, and prevent mutation after validation."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+
+
+class WordProcessorProvenanceV1(_FrozenContract):
+    """Exact word-alignment processor identity used to produce an artifact."""
+
+    aligner_name: NonBlankStr
+    aligner_revision: NonBlankStr
+    normalization_version: NonBlankStr
+
+
+class PhonemeProcessorProvenanceV1(_FrozenContract):
+    """Exact phoneme-alignment processor identity used to produce an artifact."""
+
+    model_name: NonBlankStr
+    model_revision: NonBlankStr
+    weights_sha256: str = Field(pattern=SHA256_PATTERN, strict=True)
+    phone_inventory: tuple[NonBlankStr, ...]
+    resampler: NonBlankStr
+    decoder: NonBlankStr
+
+    @model_validator(mode="after")
+    def validate_inventory(self) -> PhonemeProcessorProvenanceV1:
+        """Require a nonempty, unique inventory as part of the processor identity."""
+        if not self.phone_inventory:
+            raise ValueError("phone_inventory must not be empty")
+        if len(set(self.phone_inventory)) != len(self.phone_inventory):
+            raise ValueError("phone_inventory must not contain duplicate symbols")
+        return self
+
+
+class TimestampWarningCode(StrEnum):
+    """Closed initial registry of warnings accepted in v1 artifacts."""
+
+    EMPTY_SPANS = "EMPTY_SPANS"
+    PARTIAL_ALIGNMENT = "PARTIAL_ALIGNMENT"
+
+
+class TimestampWarningV1(_FrozenContract):
+    """A registered, machine-readable preprocessing warning."""
+
+    code: TimestampWarningCode
+    message: NonBlankStr
+    start_ms: NonNegativeMilliseconds | None = None
+    end_ms: PositiveMilliseconds | None = None
+
+    @model_validator(mode="after")
+    def validate_interval(self) -> TimestampWarningV1:
+        """Require warning bounds to be absent together or form a positive interval."""
+        if (self.start_ms is None) != (self.end_ms is None):
+            raise ValueError("warning start_ms and end_ms must be provided together")
+        if self.start_ms is not None and self.end_ms is not None and self.end_ms <= self.start_ms:
+            raise ValueError("warning end_ms must be greater than start_ms")
+        return self
+
+
+class WordTimestampV1(_FrozenContract):
+    """One word span. The wire shape is intentionally limited to these four fields."""
+
+    text: NonBlankStr
+    start_ms: NonNegativeMilliseconds
+    end_ms: PositiveMilliseconds
+    confidence: Confidence
+
+    @model_validator(mode="after")
+    def validate_interval(self) -> WordTimestampV1:
+        """Require a positive-duration span."""
+        if self.end_ms <= self.start_ms:
+            raise ValueError("end_ms must be greater than start_ms")
+        return self
+
+
+class PhonemeTimestampV1(_FrozenContract):
+    """One phone span. Word-index coupling is intentionally absent from this schema."""
+
+    symbol: NonBlankStr
+    start_ms: NonNegativeMilliseconds
+    end_ms: PositiveMilliseconds
+    confidence: Confidence
+
+    @model_validator(mode="after")
+    def validate_interval(self) -> PhonemeTimestampV1:
+        """Require a positive-duration span."""
+        if self.end_ms <= self.start_ms:
+            raise ValueError("end_ms must be greater than start_ms")
+        return self
+
+
+def _validate_timeline(
+    *,
+    spans: tuple[WordTimestampV1, ...] | tuple[PhonemeTimestampV1, ...],
+    warnings: tuple[TimestampWarningV1, ...],
+    duration_ms: int,
+) -> None:
+    """Validate top-level span/warning invariants common to both artifact schemas."""
+    previous_end_ms = 0
+    for index, span in enumerate(spans):
+        if span.end_ms > duration_ms:
+            raise ValueError(f"span {index} ends after duration_ms")
+        if index and span.start_ms < previous_end_ms:
+            raise ValueError(f"span {index} overlaps or is out of order")
+        previous_end_ms = span.end_ms
+
+    has_empty_warning = any(
+        warning.code is TimestampWarningCode.EMPTY_SPANS for warning in warnings
+    )
+    if not spans and not has_empty_warning:
+        raise ValueError("empty spans require an EMPTY_SPANS warning")
+
+    for index, warning in enumerate(warnings):
+        if warning.end_ms is not None and warning.end_ms > duration_ms:
+            raise ValueError(f"warning {index} ends after duration_ms")
+
+
+class WordTimestampsV1(_FrozenContract):
+    """Validated word timestamps for one source-audio sample."""
+
+    schema_version: Literal["WordTimestampsV1"]
+    analysis_id: NonBlankStr
+    audio_sha256: str = Field(pattern=SHA256_PATTERN, strict=True)
+    transcript_sha256: str = Field(pattern=SHA256_PATTERN, strict=True)
+    duration_ms: PositiveMilliseconds
+    processor: WordProcessorProvenanceV1
+    words: tuple[WordTimestampV1, ...]
+    warnings: tuple[TimestampWarningV1, ...]
+
+    @model_validator(mode="after")
+    def validate_timeline(self) -> WordTimestampsV1:
+        """Enforce ordering, non-overlap, bounds, and explicit empty output."""
+        _validate_timeline(spans=self.words, warnings=self.warnings, duration_ms=self.duration_ms)
+        return self
+
+
+class PhonemeTimestampsV1(_FrozenContract):
+    """Validated phoneme timestamps for one source-audio sample."""
+
+    schema_version: Literal["PhonemeTimestampsV1"]
+    analysis_id: NonBlankStr
+    audio_sha256: str = Field(pattern=SHA256_PATTERN, strict=True)
+    duration_ms: PositiveMilliseconds
+    processor: PhonemeProcessorProvenanceV1
+    phones: tuple[PhonemeTimestampV1, ...]
+    warnings: tuple[TimestampWarningV1, ...]
+
+    @model_validator(mode="after")
+    def validate_timeline_and_inventory(self) -> PhonemeTimestampsV1:
+        """Enforce timeline invariants and membership in a unique phone inventory."""
+        inventory = set(self.processor.phone_inventory)
+        for index, phone in enumerate(self.phones):
+            if phone.symbol not in inventory:
+                raise ValueError(f"phone {index} symbol is not in processor.phone_inventory")
+        _validate_timeline(
+            spans=self.phones,
+            warnings=self.warnings,
+            duration_ms=self.duration_ms,
+        )
+        return self
+
+
+type TimestampArtifactV1 = Annotated[
+    WordTimestampsV1 | PhonemeTimestampsV1,
+    Field(discriminator="schema_version"),
+]

--- a/runner/tests/unit/test_preprocessing.py
+++ b/runner/tests/unit/test_preprocessing.py
@@ -246,7 +246,7 @@ def test_empty_spans_require_registered_empty_warning() -> None:
 
 def test_warning_codes_and_intervals_are_strict_paired_and_bounded() -> None:
     with pytest.raises(ValidationError):
-        TimestampWarningV1(code="UNKNOWN", message="Unknown")
+        TimestampWarningV1(code="UNKNOWN", message="Unknown")  # type: ignore[arg-type]
     with pytest.raises(ValidationError, match="provided together"):
         TimestampWarningV1(
             code=TimestampWarningCode.PARTIAL_ALIGNMENT,

--- a/runner/tests/unit/test_preprocessing.py
+++ b/runner/tests/unit/test_preprocessing.py
@@ -1,0 +1,333 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Adversarial CPU-only tests for timestamp preprocessing contracts."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+from pydantic import BaseModel, ValidationError
+
+from coval_bench.preprocessing import (
+    DEFAULT_MAX_BATCH_CLIPS,
+    DEFAULT_MAX_BATCH_DURATION_MS,
+    PhonemeProcessorProvenanceV1,
+    PhonemeTimestampsV1,
+    PhonemeTimestampV1,
+    TimestampArtifactV1,
+    TimestampWarningCode,
+    TimestampWarningV1,
+    WordProcessorProvenanceV1,
+    WordTimestampsV1,
+    WordTimestampV1,
+    artifact_content_fingerprint,
+    batch_by_duration,
+    canonical_json_bytes,
+    generator_fingerprint,
+    immutable_artifact_key,
+)
+
+SOURCE_SHA = "a" * 64
+TRANSCRIPT_SHA = "b" * 64
+WEIGHTS_SHA = "c" * 64
+
+
+def _word_processor(**overrides: Any) -> WordProcessorProvenanceV1:
+    values: dict[str, Any] = {
+        "aligner_name": "word-aligner",
+        "aligner_revision": "revision-123",
+        "normalization_version": "normalization-v1",
+    }
+    values.update(overrides)
+    return WordProcessorProvenanceV1(**values)
+
+
+def _phoneme_processor(**overrides: Any) -> PhonemeProcessorProvenanceV1:
+    values: dict[str, Any] = {
+        "model_name": "phoneme-model",
+        "model_revision": "revision-456",
+        "weights_sha256": WEIGHTS_SHA,
+        "phone_inventory": ("HH", "AH"),
+        "resampler": "soxr-hq-v1",
+        "decoder": "ctc-greedy-v1",
+    }
+    values.update(overrides)
+    return PhonemeProcessorProvenanceV1(**values)
+
+
+def _word(text: str = "hello", start_ms: int = 0, end_ms: int = 250) -> WordTimestampV1:
+    return WordTimestampV1(text=text, start_ms=start_ms, end_ms=end_ms, confidence=0.95)
+
+
+def _phoneme(symbol: str = "HH", start_ms: int = 0, end_ms: int = 100) -> PhonemeTimestampV1:
+    return PhonemeTimestampV1(
+        symbol=symbol,
+        start_ms=start_ms,
+        end_ms=end_ms,
+        confidence=0.9,
+    )
+
+
+def _word_artifact(**overrides: Any) -> WordTimestampsV1:
+    values: dict[str, Any] = {
+        "schema_version": "WordTimestampsV1",
+        "analysis_id": "analysis-001",
+        "audio_sha256": SOURCE_SHA,
+        "transcript_sha256": TRANSCRIPT_SHA,
+        "processor": _word_processor(),
+        "duration_ms": 1_000,
+        "words": (_word(),),
+        "warnings": (),
+    }
+    values.update(overrides)
+    return WordTimestampsV1(**values)
+
+
+def _phoneme_artifact(**overrides: Any) -> PhonemeTimestampsV1:
+    values: dict[str, Any] = {
+        "schema_version": "PhonemeTimestampsV1",
+        "analysis_id": "analysis-001",
+        "audio_sha256": SOURCE_SHA,
+        "processor": _phoneme_processor(),
+        "duration_ms": 1_000,
+        "phones": (_phoneme(),),
+        "warnings": (),
+    }
+    values.update(overrides)
+    return PhonemeTimestampsV1(**values)
+
+
+def test_schema_versions_and_shapes_are_exact_and_independent() -> None:
+    word = _word_artifact()
+    phoneme = _phoneme_artifact()
+
+    assert word.schema_version == "WordTimestampsV1"
+    assert phoneme.schema_version == "PhonemeTimestampsV1"
+    assert set(word.words[0].model_dump()) == {"text", "start_ms", "end_ms", "confidence"}
+    assert set(phoneme.phones[0].model_dump()) == {
+        "symbol",
+        "start_ms",
+        "end_ms",
+        "confidence",
+    }
+    assert type(word.processor) is WordProcessorProvenanceV1
+    assert type(phoneme.processor) is PhonemeProcessorProvenanceV1
+    assert set(word.model_dump()) == {
+        "schema_version",
+        "analysis_id",
+        "audio_sha256",
+        "transcript_sha256",
+        "duration_ms",
+        "processor",
+        "words",
+        "warnings",
+    }
+    assert set(phoneme.model_dump()) == {
+        "schema_version",
+        "analysis_id",
+        "audio_sha256",
+        "duration_ms",
+        "processor",
+        "phones",
+        "warnings",
+    }
+    assert set(word.processor.model_dump()) == {
+        "aligner_name",
+        "aligner_revision",
+        "normalization_version",
+    }
+    assert set(phoneme.processor.model_dump()) == {
+        "model_name",
+        "model_revision",
+        "weights_sha256",
+        "phone_inventory",
+        "resampler",
+        "decoder",
+    }
+
+
+def test_discriminated_union_rejects_cross_schema_payloads() -> None:
+    class Envelope(BaseModel):
+        artifact: TimestampArtifactV1
+
+    payload = {"artifact": _word_artifact().model_dump(mode="json")}
+    parsed = Envelope.model_validate_json(json.dumps(payload))
+    assert type(parsed.artifact) is WordTimestampsV1
+
+    crossed = _word_artifact().model_dump(mode="json")
+    crossed["schema_version"] = "PhonemeTimestampsV1"
+    with pytest.raises(ValidationError):
+        Envelope.model_validate_json(json.dumps({"artifact": crossed}))
+
+    lowercase = _word_artifact().model_dump(mode="json")
+    lowercase["schema_version"] = "wordtimestampsv1"
+    with pytest.raises(ValidationError):
+        Envelope.model_validate_json(json.dumps({"artifact": lowercase}))
+
+
+def test_contracts_are_frozen_strict_and_forbid_extras() -> None:
+    artifact = _word_artifact()
+    with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+        WordTimestampV1.model_validate({**artifact.words[0].model_dump(), "word_index": 0})
+    with pytest.raises(ValidationError):
+        WordTimestampV1(text="hello", start_ms=0.0, end_ms=1, confidence=0.5)  # type: ignore[arg-type]
+    with pytest.raises(ValidationError):
+        artifact.duration_ms = 2_000  # type: ignore[misc]
+
+
+@pytest.mark.parametrize("field", ["schema_version", "warnings"])
+def test_required_top_level_fields_cannot_be_omitted(field: str) -> None:
+    payload = _word_artifact().model_dump(mode="json")
+    del payload[field]
+    with pytest.raises(ValidationError, match="Field required"):
+        WordTimestampsV1.model_validate_json(json.dumps(payload))
+
+
+@pytest.mark.parametrize("value", ["", "   ", 123])
+def test_analysis_id_is_strict_nonblank(value: object) -> None:
+    with pytest.raises(ValidationError):
+        _word_artifact(analysis_id=value)
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"start_ms": -1},
+        {"end_ms": 0},
+        {"start_ms": 2, "end_ms": 2},
+        {"confidence": -0.1},
+        {"confidence": 1.1},
+        {"confidence": float("nan")},
+    ],
+)
+def test_word_span_rejects_invalid_intervals_and_confidence(kwargs: dict[str, Any]) -> None:
+    values: dict[str, Any] = {"text": "hi", "start_ms": 0, "end_ms": 1, "confidence": 1.0}
+    values.update(kwargs)
+    with pytest.raises(ValidationError):
+        WordTimestampV1(**values)
+
+
+@pytest.mark.parametrize(
+    "words",
+    [
+        (_word("a", 100, 200), _word("b", 50, 90)),
+        (_word("a", 0, 200), _word("b", 199, 300)),
+        (_word("a", 0, 1_001),),
+    ],
+)
+def test_artifact_rejects_out_of_order_overlapping_or_unbounded_spans(
+    words: tuple[WordTimestampV1, ...],
+) -> None:
+    with pytest.raises(ValidationError):
+        _word_artifact(words=words)
+
+
+def test_adjacent_spans_are_valid() -> None:
+    artifact = _word_artifact(words=(_word("a", 0, 100), _word("b", 100, 200)))
+    assert len(artifact.words) == 2
+
+
+def test_empty_spans_require_registered_empty_warning() -> None:
+    with pytest.raises(ValidationError, match="EMPTY_SPANS"):
+        _word_artifact(words=())
+
+    warning = TimestampWarningV1(code=TimestampWarningCode.EMPTY_SPANS, message="No speech")
+    assert _word_artifact(words=(), warnings=(warning,)).words == ()
+    with pytest.raises(ValidationError, match="EMPTY_SPANS"):
+        _phoneme_artifact(phones=())
+    assert _phoneme_artifact(phones=(), warnings=(warning,)).phones == ()
+
+
+def test_warning_codes_and_intervals_are_strict_paired_and_bounded() -> None:
+    with pytest.raises(ValidationError):
+        TimestampWarningV1(code="UNKNOWN", message="Unknown")
+    with pytest.raises(ValidationError, match="provided together"):
+        TimestampWarningV1(
+            code=TimestampWarningCode.PARTIAL_ALIGNMENT,
+            message="Partial",
+            start_ms=100,
+        )
+    warning = TimestampWarningV1(
+        code=TimestampWarningCode.PARTIAL_ALIGNMENT,
+        message="Partial",
+        start_ms=900,
+        end_ms=1_001,
+    )
+    with pytest.raises(ValidationError, match="duration_ms"):
+        _word_artifact(warnings=(warning,))
+
+
+def test_processor_phone_inventory_is_unique_nonempty_and_contains_every_symbol() -> None:
+    with pytest.raises(ValidationError, match="must not be empty"):
+        _phoneme_processor(phone_inventory=())
+    with pytest.raises(ValidationError, match="duplicate"):
+        _phoneme_processor(phone_inventory=("HH", "HH"))
+    with pytest.raises(ValidationError, match="phone_inventory"):
+        _phoneme_artifact(phones=(_phoneme("ZZ"),))
+
+
+def test_canonical_bytes_and_key_use_the_same_content_sha() -> None:
+    artifact = _word_artifact()
+    encoded = canonical_json_bytes(artifact)
+    digest = hashlib.sha256(encoded).hexdigest()
+    key = immutable_artifact_key(artifact)
+
+    assert encoded == canonical_json_bytes(artifact.model_dump(mode="json"))
+    assert digest == artifact_content_fingerprint(artifact)
+    assert key.endswith(f"/{digest}.json")
+    assert "/WordTimestampsV1/" in key
+
+
+def test_generator_fingerprint_is_key_order_independent_and_config_sensitive() -> None:
+    first = generator_fingerprint(_word_processor())
+    same = generator_fingerprint(_word_processor())
+    changed = generator_fingerprint(_word_processor(aligner_revision="revision-789"))
+    assert first == same
+    assert first != changed
+
+
+def test_import_has_no_gpu_stack_side_effect() -> None:
+    assert not {"torch", "torchaudio", "whisperx"}.intersection(sys.modules)
+
+
+@dataclass(frozen=True)
+class _Clip:
+    identifier: str
+    duration_ms: int
+
+
+def _batch_ids(batches: tuple[tuple[_Clip, ...], ...]) -> list[list[str]]:
+    return [[clip.identifier for clip in batch] for batch in batches]
+
+
+def test_integer_batching_defaults_order_limits_and_exact_boundary() -> None:
+    assert DEFAULT_MAX_BATCH_CLIPS == 32
+    assert DEFAULT_MAX_BATCH_DURATION_MS == 300_000
+    clips = [_Clip("a", 200_000), _Clip("b", 100_000), _Clip("c", 1), _Clip("d", 99)]
+    batches = batch_by_duration(clips, duration_ms_of=lambda clip: clip.duration_ms)
+    assert _batch_ids(batches) == [["a", "b"], ["c", "d"]]
+
+
+def test_integer_batching_respects_clip_limit_and_oversized_singleton() -> None:
+    clips = [_Clip("a", 1), _Clip("large", 300_001), _Clip("b", 1), _Clip("c", 1)]
+    batches = batch_by_duration(
+        clips,
+        duration_ms_of=lambda clip: clip.duration_ms,
+        max_clips=1,
+    )
+    assert _batch_ids(batches) == [["a"], ["large"], ["b"], ["c"]]
+
+
+@pytest.mark.parametrize("duration", [0, -1, 1.0, True, "1"])
+def test_integer_batching_rejects_nonpositive_or_noninteger_duration(duration: object) -> None:
+    with pytest.raises(ValueError):
+        batch_by_duration(
+            [_Clip("bad", duration)],  # type: ignore[arg-type]
+            duration_ms_of=lambda clip: clip.duration_ms,
+        )


### PR DESCRIPTION
## Summary

- add strict, independently versioned word and phoneme timestamp artifact contracts
- add canonical serialization, hashes, processor fingerprints, and immutable artifact keys
- add deterministic CPU batching for the future GPU worker

## Scope

This is the first BENCH-668 implementation slice. It does not yet include manifest loading, task sharding, model loading, GPU inference, artifact upload, or Cloud Run deployment. It contains no pronunciation scoring logic, private dataset contents, provider credentials, or database writes.

## Validation

- ruff check
- ruff format --check
- 31 focused preprocessing tests

Linear: https://linear.app/coval/issue/BENCH-668/add-gpu-word-and-phoneme-timestamp-preprocessing