### PR TITLE
Scope S2S metrics per caller condition

### DIFF
--- a/runner/src/coval_bench/s2s/conditions.py
+++ b/runner/src/coval_bench/s2s/conditions.py
@@ -1,0 +1,71 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+"""Which metrics each S2S caller condition carries.
+
+A condition is one dataset id. ``required`` must be on the run or the run is a
+fault; ``optional`` is written when present; anything named in neither is never
+fetched, so its absence is silent rather than an alertable warning.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+from coval_bench.registries import Metric
+
+__all__ = [
+    "DATASET_ID",
+    "DATASET_ID_MULTITURN",
+    "DATASET_ID_MULTITURN_NOISY",
+    "DEFAULT_CONDITION",
+    "DatasetMetrics",
+    "condition_for",
+]
+
+# Single-turn SLURP manifest (legacy, latency only) and the multi-turn Coval test
+# set, split by caller condition so background noise never pools into the clean
+# numbers.
+DATASET_ID = "s2s-v1"
+DATASET_ID_MULTITURN = "s2s-multiturn-v1"
+DATASET_ID_MULTITURN_NOISY = "s2s-multiturn-noisy-v1"
+
+
+class DatasetMetrics(BaseModel, frozen=True):
+    """One condition's metric contract.
+
+    ``required`` is a single metric because it doubles as the population anchor:
+    every optional metric's conversation ids must match it to be written.
+    """
+
+    required: Metric
+    optional: frozenset[Metric] = frozenset()
+
+    @property
+    def fetched(self) -> frozenset[Metric]:
+        """Every metric worth asking Coval for; the rest are excluded."""
+        return self.optional | {self.required}
+
+
+# Background noise sits in the lane Silero VAD uses for turn boundaries, so V2V
+# is omitted for the noisy caller: not measured, not written, not warned about.
+CONDITIONS: dict[str, DatasetMetrics] = {
+    DATASET_ID_MULTITURN: DatasetMetrics(
+        required=Metric.V2V,
+        optional=frozenset({Metric.INSTRUCTION_FOLLOWING, Metric.INTERRUPTION_RATE}),
+    ),
+    DATASET_ID_MULTITURN_NOISY: DatasetMetrics(
+        required=Metric.INSTRUCTION_FOLLOWING,
+        optional=frozenset({Metric.INTERRUPTION_RATE}),
+    ),
+}
+
+# Pre-scoping behaviour, for any dataset without an entry above.
+DEFAULT_CONDITION = DatasetMetrics(
+    required=Metric.V2V,
+    optional=frozenset({Metric.INSTRUCTION_FOLLOWING}),
+)
+
+
+def condition_for(dataset_id: str) -> DatasetMetrics:
+    """The metric contract for *dataset_id*."""
+    return CONDITIONS.get(dataset_id, DEFAULT_CONDITION)

--- a/runner/src/coval_bench/s2s/fetch_v2v.py
+++ b/runner/src/coval_bench/s2s/fetch_v2v.py
@@ -720,6 +720,9 @@ async def fetch_and_write_v2v(settings: Settings | None = None) -> dict[str, Run
         metric_ids[Metric.INSTRUCTION_FOLLOWING] = instruction_metric_id
     if raw_interruption:
         metric_ids[Metric.INTERRUPTION_RATE] = raw_interruption
+    unmapped = sorted(m.value for m in metric_ids.keys() - _VALUE_MAPPERS.keys())
+    if unmapped:
+        raise RuntimeError(f"no _VALUE_MAPPERS entry for configured metrics: {', '.join(unmapped)}")
 
     async with _client(settings) as client, lifespan_pool(settings) as pool:
         writer = RunWriter(pool)

--- a/runner/src/coval_bench/s2s/fetch_v2v.py
+++ b/runner/src/coval_bench/s2s/fetch_v2v.py
@@ -14,6 +14,7 @@ import asyncio
 import hashlib
 import importlib.resources
 import random
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any, cast
@@ -26,20 +27,19 @@ from coval_bench.config import Settings, get_settings
 from coval_bench.db.conn import lifespan_pool
 from coval_bench.db.models import Result, ResultStatus, RunStatus
 from coval_bench.db.writer import RunWriter
-from coval_bench.registries import Metric
+from coval_bench.registries import METRIC_SPECS, Metric
 from coval_bench.registries.benchmarks import Benchmark
+from coval_bench.s2s.conditions import (
+    DATASET_ID,
+    DATASET_ID_MULTITURN,
+    DATASET_ID_MULTITURN_NOISY,
+    DEFAULT_CONDITION,
+    DatasetMetrics,
+    condition_for,
+)
 from coval_bench.s2s.samples import SampleRun, model_labels, publish_tick_sample
 
 logger = structlog.get_logger("coval_bench.s2s.fetch_v2v")
-
-# The dataset the S2S sims run against (matches the packaged manifest name).
-DATASET_ID = "s2s-v1"
-# Multi-turn runs have no local manifest -- they're keyed to the Coval test set --
-# so they use a distinct dataset id and never pool with single-turn s2s-v1.
-DATASET_ID_MULTITURN = "s2s-multiturn-v1"
-# The same test set run by the noisy caller persona, kept apart so background
-# noise never pools into the clean numbers.
-DATASET_ID_MULTITURN_NOISY = "s2s-multiturn-noisy-v1"
 
 # Ingest window: how far back one tick looks for not-yet-ingested runs, and
 # how many list results that scan reads. Two periods (with a one-day floor)
@@ -196,43 +196,11 @@ async def recent_completed_runs(
     return runs
 
 
-def _result_rows(
-    values: list[dict[str, Any]],
-    *,
-    run_pk: int,
-    coval_run_id: str,
-    spec: AgentSpec,
-) -> list[Result]:
-    """Map a Coval run's per-clip values to Result rows.
-
-    Values are seconds; convert to ms. A clip with no numeric value becomes a
-    FAILED row, so reliability = success/total.
-    """
-    rows: list[Result] = []
-    for i, v in enumerate(values):
-        raw = v.get("value")
-        if isinstance(raw, (int, float)) and not isinstance(raw, bool):
-            metric_value: float | None = round(float(raw) * 1000, 1)
-            status = ResultStatus.SUCCESS
-        else:
-            metric_value = None
-            status = ResultStatus.FAILED
-        sim_id = v.get("simulation_output_id")
-        clip_key = f"{coval_run_id}/{sim_id}" if sim_id else f"{coval_run_id}/{i}"
-        rows.append(
-            Result(
-                run_id=run_pk,
-                provider=spec.provider,
-                model=spec.model,
-                benchmark=Benchmark.S2S,
-                metric_type=Metric.V2V,
-                metric_units="milliseconds",
-                metric_value=metric_value,
-                audio_filename=clip_key,
-                status=status,
-            )
-        )
-    return rows
+def _v2v_value(raw: object) -> tuple[float | None, ResultStatus] | None:
+    """Seconds to ms; a clip with no numeric value becomes a FAILED row."""
+    if isinstance(raw, (int, float)) and not isinstance(raw, bool):
+        return round(float(raw) * 1000, 1), ResultStatus.SUCCESS
+    return None, ResultStatus.FAILED
 
 
 class InvalidInstructionVerdict(Exception):
@@ -256,67 +224,111 @@ def _instruction_verdict(raw: object) -> bool | None:
     raise InvalidInstructionVerdict(f"unexpected instruction verdict: {raw!r}")
 
 
-def _instruction_id_mismatch(
-    latency_values: list[dict[str, Any]] | None, instruction_values: list[dict[str, Any]]
-) -> dict[str, object] | None:
-    """None if instruction's sim-id set is sound; else the diff.
+def _has_duplicate_ids(values: list[dict[str, Any]]) -> bool:
+    """True if two of a metric's conversations share a simulation id."""
+    ids = [v.get("simulation_output_id") for v in values]
+    return len(ids) != len(set(ids))
 
-    Ids, not counts: equal counts can be different conversations. ``latency_values``
-    is None -- not empty -- when the run has no latency metric, and then only
-    duplicate ids are checked. A mismatch skips instruction for the run.
+
+def _population_mismatch(
+    anchor_values: list[dict[str, Any]], other_values: list[dict[str, Any]]
+) -> dict[str, object] | None:
+    """None if *other_values* covers the same conversations as the anchor.
+
+    Ids, not counts: equal counts can be different conversations. A mismatch skips
+    that metric for the run.
     """
-    ins_ids = [v.get("simulation_output_id") for v in instruction_values]
-    ins_set = set(ins_ids)
-    duplicate = len(ins_ids) != len(ins_set)
-    missing: list[str] = []
-    extra: list[str] = []
-    if latency_values is not None:
-        lat_set = {v.get("simulation_output_id") for v in latency_values}
-        missing = sorted(str(x) for x in lat_set - ins_set)
-        extra = sorted(str(x) for x in ins_set - lat_set)
+    other_set = {v.get("simulation_output_id") for v in other_values}
+    anchor_set = {v.get("simulation_output_id") for v in anchor_values}
+    missing = sorted(str(x) for x in anchor_set - other_set)
+    extra = sorted(str(x) for x in other_set - anchor_set)
+    duplicate = _has_duplicate_ids(other_values)
     if not duplicate and not missing and not extra:
         return None
-    return {
-        "missing_instruction_ids": missing,
-        "extra_instruction_ids": extra,
-        "duplicate_instruction_ids": duplicate,
-    }
+    return {"missing_ids": missing, "extra_ids": extra, "duplicate_ids": duplicate}
 
 
-def _instruction_rows(
+def _instruction_value(raw: object) -> tuple[float | None, ResultStatus] | None:
+    """YES -> 100.0, NO -> 0.0, UNKNOWN -> no row, so the mean is YES / (YES + NO).
+
+    Raises InvalidInstructionVerdict on any value outside the contract.
+    """
+    verdict = _instruction_verdict(raw)
+    if verdict is None:
+        return None
+    return (100.0 if verdict else 0.0), ResultStatus.SUCCESS
+
+
+# The only per-metric part: one raw Coval value -> (row value, status), or None to
+# write no row. A metric is ingestable once it appears here.
+_VALUE_MAPPERS: dict[Metric, Callable[[object], tuple[float | None, ResultStatus] | None]] = {
+    Metric.V2V: _v2v_value,
+    Metric.INSTRUCTION_FOLLOWING: _instruction_value,
+}
+
+
+def _s2s_rows(
     values: list[dict[str, Any]],
     *,
+    metric: Metric,
     run_pk: int,
     coval_run_id: str,
     spec: AgentSpec,
 ) -> list[Result]:
-    """Map a run's per-conversation verdicts to instruction Result rows.
-
-    YES -> 100.0, NO -> 0.0 (both SUCCESS, both in the pool); UNKNOWN produces no
-    row (excluded), so the aggregate mean is YES / (YES + NO). Raises
-    InvalidInstructionVerdict on any value outside the contract.
-    """
+    """Map one metric's per-conversation values to Result rows."""
+    to_row = _VALUE_MAPPERS[metric]
     rows: list[Result] = []
     for i, v in enumerate(values):
-        verdict = _instruction_verdict(v.get("value"))
-        if verdict is None:  # UNKNOWN: excluded from the pool, no row written
+        mapped = to_row(v.get("value"))
+        if mapped is None:
             continue
+        metric_value, status = mapped
         sim_id = v.get("simulation_output_id")
-        clip_key = f"{coval_run_id}/{sim_id}" if sim_id else f"{coval_run_id}/{i}"
         rows.append(
             Result(
                 run_id=run_pk,
                 provider=spec.provider,
                 model=spec.model,
                 benchmark=Benchmark.S2S,
-                metric_type=Metric.INSTRUCTION_FOLLOWING,
-                metric_units="percent",
-                metric_value=100.0 if verdict else 0.0,
-                audio_filename=clip_key,
-                status=ResultStatus.SUCCESS,
+                metric_type=metric,
+                metric_units=METRIC_SPECS[metric].units,
+                metric_value=metric_value,
+                audio_filename=f"{coval_run_id}/{sim_id}" if sim_id else f"{coval_run_id}/{i}",
+                status=status,
             )
         )
     return rows
+
+
+def _metric_values(metrics: dict[str, Any], metric_id: str | None) -> list[dict[str, Any]] | None:
+    """The metric's per-conversation values, or None when it is not on the run."""
+    payload = metrics.get(metric_id) if metric_id else None
+    if payload is None:
+        return None
+    return cast("list[dict[str, Any]]", payload.get("values", []))
+
+
+def _ingestable(condition: DatasetMetrics, metric_ids: Mapping[Metric, str]) -> frozenset[Metric]:
+    """The condition's metrics that are configured and have a row builder."""
+    return frozenset(m for m in condition.fetched if m in metric_ids and m in _VALUE_MAPPERS)
+
+
+async def _pending_metrics(
+    writer: RunWriter,
+    *,
+    provider: str,
+    coval_run_id: str,
+    condition: DatasetMetrics,
+    metric_ids: Mapping[Metric, str],
+) -> frozenset[Metric]:
+    """The condition's ingestable metrics that are not yet stored."""
+    pending: set[Metric] = set()
+    for metric in _ingestable(condition, metric_ids):
+        if not await writer.coval_metric_ingested(
+            provider=provider, coval_run_id=coval_run_id, metric_type=metric
+        ):
+            pending.add(metric)
+    return frozenset(pending)
 
 
 async def _ingest_run(
@@ -325,22 +337,22 @@ async def _ingest_run(
     *,
     spec: AgentSpec,
     coval_run: CovalRun,
-    metric_id: str,
-    instruction_metric_id: str | None = None,
+    metric_ids: Mapping[Metric, str],
+    condition: DatasetMetrics = DEFAULT_CONDITION,
+    pending: frozenset[Metric] | None = None,
     dataset_id: str = DATASET_ID,
     dataset_sha256: str = "",
-    want_latency: bool = True,
-    want_instruction: bool = True,
     runner_sha: str,
     period_seconds: int,
 ) -> RunStatus | None:
     """Ingest one Coval run into its own run row; None = skipped, nothing written.
 
-    Skips (before any DB write) runs finalized with an error_status — those
-    failed upstream of the provider and must not dent its reliability — and runs
-    left with nothing to write. Otherwise SUCCEEDED = all clips numeric, PARTIAL =
-    some failed, FAILED = all failed.
+    Writes the metrics *condition* declares and *pending* still owes (default all
+    of them). Skips (before any DB write) runs finalized with an error_status,
+    runs missing the condition's required metric, and runs left with nothing to
+    write. SUCCEEDED = all clips numeric, PARTIAL = some failed, FAILED = all.
     """
+    pending = condition.fetched if pending is None else pending
     run_pk: int | None = None
     try:
         resp = await client.get(f"/runs/{coval_run.run_id}")
@@ -356,62 +368,89 @@ async def _ingest_run(
             )
             return None
         metrics = cast("dict[str, Any]", (run.get("results") or {}).get("metrics") or {})
-        metric = metrics.get(metric_id)
-        if metric is None:
-            # Conditions with unreliable turn boundaries run with latency off.
+        anchor = condition.required
+        anchor_values = _metric_values(metrics, metric_ids.get(anchor))
+        if anchor_values is None:
+            # The condition says this one must be here, so its absence is a fault
+            # rather than a quiet skip. Metrics the condition omits are never
+            # looked up, so they never reach this branch.
             logger.warning(
-                "metric_absent",
+                "required_metric_absent",
                 provider=spec.provider,
                 coval_run_id=coval_run.run_id,
-                metric_id=metric_id,
+                dataset_id=dataset_id,
+                metric=anchor.value,
             )
-        values = cast("list[dict[str, Any]]", metric.get("values", [])) if metric else []
-        write_latency = want_latency and metric is not None
+            return None
+        if _has_duplicate_ids(anchor_values):
+            # Nothing else checks the anchor's own population, and duplicate rows
+            # would double-count conversations in the aggregate.
+            logger.warning(
+                "anchor_duplicate_ids",
+                provider=spec.provider,
+                coval_run_id=coval_run.run_id,
+                metric=anchor.value,
+            )
+            return None
 
-        # Decide instruction writability up front (pure) so a backfill with
-        # nothing to add creates no run row and stays retryable.
-        instr_values: list[dict[str, Any]] = []
-        write_instruction = False
-        if want_instruction and instruction_metric_id:
-            instr = metrics.get(instruction_metric_id)
-            if instr is None:
-                # Latency still lands; instruction stays retryable on a later scan.
-                logger.warning(
-                    "instruction_metric_absent",
+        # Decide writability up front (pure) so a backfill with nothing to add
+        # creates no run row and stays retryable.
+        writable: dict[Metric, list[dict[str, Any]]] = {}
+        if anchor in pending:
+            writable[anchor] = anchor_values
+        for metric in sorted(condition.optional):
+            if metric not in pending:
+                continue
+            values = _metric_values(metrics, metric_ids.get(metric))
+            if values is None:
+                logger.info(
+                    "optional_metric_absent",
                     provider=spec.provider,
                     coval_run_id=coval_run.run_id,
-                    metric_id=instruction_metric_id,
+                    metric=metric.value,
                 )
+                continue
+            mismatch = _population_mismatch(anchor_values, values)
+            if mismatch is not None:
+                # A different conversation population than the anchor would make
+                # the rate incomparable, so drop this metric and keep the anchor.
+                logger.warning(
+                    "metric_population_mismatch",
+                    provider=spec.provider,
+                    coval_run_id=coval_run.run_id,
+                    metric=metric.value,
+                    **mismatch,
+                )
+                continue
+            writable[metric] = values
+        # Same mapper the rows are built from, so "would this write anything?"
+        # cannot drift from what actually gets written.
+        for metric in list(writable):
+            try:
+                mapped = [_VALUE_MAPPERS[metric](v.get("value")) for v in writable[metric]]
+            except InvalidInstructionVerdict as exc:
+                # Judge-contract violation: discard that metric for the whole run;
+                # retryable on a later scan.
+                logger.warning(
+                    "instruction_verdict_invalid",
+                    provider=spec.provider,
+                    coval_run_id=coval_run.run_id,
+                    metric=metric.value,
+                    error=str(exc),
+                )
+                del writable[metric]
             else:
-                instr_values = cast("list[dict[str, Any]]", instr.get("values", []))
-                mismatch = _instruction_id_mismatch(values if metric else None, instr_values)
-                if mismatch is not None:
-                    # Different conversation population than latency -> skip
-                    # instruction (keep latency) so the rate stays comparable.
-                    logger.warning(
-                        "instruction_id_mismatch",
+                if not any(m is not None for m in mapped):
+                    # Every value maps to no row (all UNKNOWN), so claim nothing.
+                    logger.info(
+                        "metric_yields_no_rows",
                         provider=spec.provider,
                         coval_run_id=coval_run.run_id,
-                        **mismatch,
+                        metric=metric.value,
                     )
-                else:
-                    try:
-                        has_instruction_row = False
-                        for v in instr_values:
-                            verdict = _instruction_verdict(v.get("value"))
-                            has_instruction_row |= verdict is not None
-                        write_instruction = has_instruction_row
-                    except InvalidInstructionVerdict as exc:
-                        # Judge-contract violation: discard instruction for the
-                        # whole run (keep latency); retryable on a later scan.
-                        logger.warning(
-                            "instruction_verdict_invalid",
-                            provider=spec.provider,
-                            coval_run_id=coval_run.run_id,
-                            error=str(exc),
-                        )
+                    del writable[metric]
 
-        if not write_latency and not write_instruction:
+        if not writable:
             # Backfill with nothing to add; leave it retryable, write no run row.
             return None
 
@@ -427,17 +466,16 @@ async def _ingest_run(
             raise RuntimeError("start_run returned a run with no id")
         run_pk = run_row.id
 
-        rows = (
-            _result_rows(values, run_pk=run_pk, coval_run_id=coval_run.run_id, spec=spec)
-            if write_latency
-            else []
-        )
-        instruction_rows = (
-            _instruction_rows(instr_values, run_pk=run_pk, coval_run_id=coval_run.run_id, spec=spec)
-            if write_instruction
-            else []
-        )
-        all_rows = rows + instruction_rows
+        # Grouped as built: metric_type is a plain str on Result, so filtering the
+        # flat list by enum identity would silently match nothing.
+        by_metric = {
+            metric: _s2s_rows(
+                values, metric=metric, run_pk=run_pk, coval_run_id=coval_run.run_id, spec=spec
+            )
+            for metric, values in writable.items()
+        }
+        all_rows = [row for rows in by_metric.values() for row in rows]
+        rows = by_metric.get(Metric.V2V, [])
         if all_rows:
             await writer.record_results(all_rows)
         logger.info(
@@ -446,11 +484,11 @@ async def _ingest_run(
             coval_run_id=coval_run.run_id,
             slot=str(scheduled_at),
             clips=len(rows),
-            instruction=len(instruction_rows),
+            instruction=len(by_metric.get(Metric.INSTRUCTION_FOLLOWING, [])),
             success=sum(1 for r in rows if r.status is ResultStatus.SUCCESS),
         )
-        if write_latency:
-            # Reliability is the latency signal (instruction lag never fails the run).
+        if Metric.V2V in writable:
+            # Reliability is the latency signal (other metrics never fail the run).
             failed = sum(1 for r in rows if r.status is ResultStatus.FAILED)
             if not rows or failed == len(rows):
                 status = RunStatus.FAILED
@@ -459,7 +497,7 @@ async def _ingest_run(
             else:
                 status = RunStatus.SUCCEEDED
         else:
-            # Instruction-only backfill onto an already-ingested run.
+            # This condition has no latency, or it landed on an earlier scan.
             status = RunStatus.SUCCEEDED
         await writer.finish_run(run_pk, status=status)
         if status in (RunStatus.SUCCEEDED, RunStatus.PARTIAL):
@@ -491,8 +529,7 @@ async def _fetch_one_provider(
     *,
     spec: AgentSpec,
     agent_id: str,
-    metric_id: str,
-    instruction_metric_id: str | None = None,
+    metric_ids: Mapping[Metric, str],
     test_set_id: str | None = None,
     noisy_persona_id: str | None = None,
     runner_sha: str,
@@ -552,42 +589,48 @@ async def _fetch_one_provider(
                     error_status=coval_run.error_status,
                 )
                 continue
-            latency_done = await writer.coval_metric_ingested(
-                provider=spec.provider, coval_run_id=coval_run.run_id, metric_type=Metric.V2V
+            dataset_id, dataset_sha256 = _dataset_identity(
+                test_set_id, coval_run.persona_id, noisy_persona_id
             )
-            instruction_done = instruction_metric_id is None or await writer.coval_metric_ingested(
+            condition = condition_for(dataset_id)
+            if condition.required not in metric_ids:
+                logger.warning(
+                    "required_metric_unconfigured",
+                    provider=spec.provider,
+                    dataset_id=dataset_id,
+                    metric=condition.required.value,
+                )
+                continue
+            ingestable = _ingestable(condition, metric_ids)
+            pending = await _pending_metrics(
+                writer,
                 provider=spec.provider,
                 coval_run_id=coval_run.run_id,
-                metric_type=Metric.INSTRUCTION_FOLLOWING,
+                condition=condition,
+                metric_ids=metric_ids,
             )
-            instruction_data_done = instruction_metric_id is not None and instruction_done
-            # Either persisted metric is fresh data + an eligible sample. This
-            # keeps intentionally instruction-only conditions healthy between
-            # fetches while an unconfigured instruction metric cannot mask
-            # missing latency.
-            if latency_done or instruction_data_done:
+            # Any persisted metric is fresh data + an eligible sample, so an
+            # instruction-only condition stays healthy between fetches while an
+            # unconfigured metric cannot mask a missing one.
+            if ingestable - pending:
                 note_sample_candidate(coval_run)
                 if not data_seen:
                     data_seen, newest_data_at = True, coval_run.create_time
-            if latency_done and instruction_done:
+            if not pending:
                 logger.info(
                     "run_already_ingested", provider=spec.provider, coval_run_id=coval_run.run_id
                 )
                 continue
-            dataset_id, dataset_sha256 = _dataset_identity(
-                test_set_id, coval_run.persona_id, noisy_persona_id
-            )
             status = await _ingest_run(
                 client,
                 writer,
                 spec=spec,
                 coval_run=coval_run,
-                metric_id=metric_id,
-                instruction_metric_id=instruction_metric_id,
+                metric_ids=metric_ids,
+                condition=condition,
+                pending=pending,
                 dataset_id=dataset_id,
                 dataset_sha256=dataset_sha256,
-                want_latency=not latency_done,
-                want_instruction=instruction_metric_id is not None and not instruction_done,
                 runner_sha=runner_sha,
                 period_seconds=period_seconds,
             )
@@ -669,6 +712,16 @@ async def fetch_and_write_v2v(settings: Settings | None = None) -> dict[str, Run
     noisy_persona_id = raw_noisy or None
     if noisy_persona_id and not test_set_id:
         raise RuntimeError("coval_s2s_noisy_persona_id requires coval_s2s_test_set_id")
+    raw_interruption = settings.coval_s2s_interruption_metric_id
+    if raw_interruption is not None and not raw_interruption.strip():
+        raise RuntimeError("coval_s2s_interruption_metric_id must not be blank")
+    # Only configured metrics are ever asked for, so an unset id simply means that
+    # metric is not ingested yet.
+    metric_ids: dict[Metric, str] = {Metric.V2V: metric_id}
+    if instruction_metric_id:
+        metric_ids[Metric.INSTRUCTION_FOLLOWING] = instruction_metric_id
+    if raw_interruption:
+        metric_ids[Metric.INTERRUPTION_RATE] = raw_interruption
 
     async with _client(settings) as client, lifespan_pool(settings) as pool:
         writer = RunWriter(pool)
@@ -685,8 +738,7 @@ async def fetch_and_write_v2v(settings: Settings | None = None) -> dict[str, Run
                 writer,
                 spec=spec,
                 agent_id=agent_id,
-                metric_id=metric_id,
-                instruction_metric_id=instruction_metric_id,
+                metric_ids=metric_ids,
                 test_set_id=test_set_id,
                 noisy_persona_id=noisy_persona_id,
                 runner_sha=settings.runner_sha,

--- a/runner/src/coval_bench/s2s/fetch_v2v.py
+++ b/runner/src/coval_bench/s2s/fetch_v2v.py
@@ -609,13 +609,11 @@ async def _fetch_one_provider(
                 condition=condition,
                 metric_ids=metric_ids,
             )
-            # Any persisted metric is fresh data + an eligible sample, so an
-            # instruction-only condition stays healthy between fetches while an
-            # unconfigured metric cannot mask a missing one.
-            if ingestable - pending:
+            persisted = ingestable - pending
+            if persisted:
                 note_sample_candidate(coval_run)
-                if not data_seen:
-                    data_seen, newest_data_at = True, coval_run.create_time
+            if condition.required in persisted and not data_seen:
+                data_seen, newest_data_at = True, coval_run.create_time
             if not pending:
                 logger.info(
                     "run_already_ingested", provider=spec.provider, coval_run_id=coval_run.run_id
@@ -638,9 +636,9 @@ async def _fetch_one_provider(
                 continue
             if status is not RunStatus.FAILED:
                 note_sample_candidate(coval_run)
+                if not data_seen:
+                    data_seen, newest_data_at = True, coval_run.create_time
             statuses.append(status)
-            if not data_seen:
-                data_seen, newest_data_at = True, coval_run.create_time
 
         threshold = period_seconds + stale_grace_seconds
         age = (

--- a/runner/tests/unit/test_s2s_conditions.py
+++ b/runner/tests/unit/test_s2s_conditions.py
@@ -1,0 +1,36 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the S2S caller-condition metric contracts."""
+
+from __future__ import annotations
+
+from coval_bench.registries import Metric
+from coval_bench.s2s import conditions
+
+
+def test_standard_caller_requires_latency() -> None:
+    standard = conditions.condition_for(conditions.DATASET_ID_MULTITURN)
+    assert standard.required is Metric.V2V
+    assert standard.optional == frozenset({Metric.INSTRUCTION_FOLLOWING, Metric.INTERRUPTION_RATE})
+
+
+def test_noise_condition_excludes_latency() -> None:
+    noisy = conditions.condition_for(conditions.DATASET_ID_MULTITURN_NOISY)
+    assert noisy.required is Metric.INSTRUCTION_FOLLOWING
+    assert noisy.optional == frozenset({Metric.INTERRUPTION_RATE})
+    # Excluded by omission: never asked for, so its absence is never a warning.
+    assert Metric.V2V not in noisy.fetched
+
+
+def test_unmapped_dataset_keeps_the_pre_scoping_contract() -> None:
+    legacy = conditions.condition_for(conditions.DATASET_ID)
+    assert legacy == conditions.DEFAULT_CONDITION
+    assert legacy.required is Metric.V2V
+
+
+def test_every_fetched_metric_is_an_s2s_metric() -> None:
+    from coval_bench.registries import METRIC_SPECS, Benchmark
+
+    for dataset_id, condition in conditions.CONDITIONS.items():
+        for metric in condition.fetched:
+            assert Benchmark.S2S in METRIC_SPECS[metric].benchmarks, (dataset_id, metric)

--- a/runner/tests/unit/test_s2s_fetch.py
+++ b/runner/tests/unit/test_s2s_fetch.py
@@ -21,7 +21,15 @@ from coval_bench.db.models import ResultStatus, Run, RunStatus
 from coval_bench.logging import log_run_failed, log_run_partial
 from coval_bench.registries import Metric
 from coval_bench.s2s import fetch_v2v
+from coval_bench.s2s.conditions import (
+    DATASET_ID_MULTITURN,
+    DATASET_ID_MULTITURN_NOISY,
+    condition_for,
+)
 from coval_bench.s2s.fetch_v2v import AgentSpec, CovalRun
+
+IDS = {Metric.V2V: "MID", Metric.INSTRUCTION_FOLLOWING: "IID"}
+LATENCY_IDS = {Metric.V2V: "MID"}
 
 SPEC = AgentSpec(agent_id_attr="coval_s2s_openai_agent_id", provider="openai", model="gpt-realtime")
 
@@ -95,7 +103,7 @@ async def _fetch(client: httpx.AsyncClient, writer: MagicMock) -> tuple[RunStatu
         writer,
         spec=SPEC,
         agent_id="a1",
-        metric_id="MID",
+        metric_ids=LATENCY_IDS,
         runner_sha="test",
         period_seconds=10_800,
         stale_grace_seconds=5_400,
@@ -115,7 +123,7 @@ def test_result_rows_maps_values() -> None:
         {"simulation_output_id": "s2", "value": None},
         {"value": 0.5},  # missing sim id -> index fallback in the clip key
     ]
-    rows = fetch_v2v._result_rows(values, run_pk=1, coval_run_id="R1", spec=SPEC)
+    rows = fetch_v2v._s2s_rows(values, metric=Metric.V2V, run_pk=1, coval_run_id="R1", spec=SPEC)
     assert [r.metric_value for r in rows] == [842.0, None, 500.0]
     assert [r.status for r in rows] == [
         ResultStatus.SUCCESS,
@@ -165,7 +173,7 @@ async def test_ingest_run_slots_by_create_time() -> None:
             writer,
             spec=SPEC,
             coval_run=CovalRun(run_id="R1", create_time=created, error_status=None),
-            metric_id="MID",
+            metric_ids=LATENCY_IDS,
             runner_sha="test",
             period_seconds=10_800,
         )
@@ -190,7 +198,7 @@ async def test_ingest_run_partial_and_failed() -> None:
             writer,
             spec=SPEC,
             coval_run=run,
-            metric_id="MID",
+            metric_ids=LATENCY_IDS,
             runner_sha="test",
             period_seconds=10_800,
         )
@@ -204,7 +212,7 @@ async def test_ingest_run_partial_and_failed() -> None:
             writer,
             spec=SPEC,
             coval_run=run,
-            metric_id="MID",
+            metric_ids=LATENCY_IDS,
             runner_sha="test",
             period_seconds=10_800,
         )
@@ -224,7 +232,7 @@ async def test_ingest_run_skips_before_any_write() -> None:
                 writer,
                 spec=SPEC,
                 coval_run=run,
-                metric_id="MID",
+                metric_ids=LATENCY_IDS,
                 runner_sha="test",
                 period_seconds=10_800,
             )
@@ -241,7 +249,7 @@ async def test_ingest_run_skips_before_any_write() -> None:
                 writer,
                 spec=SPEC,
                 coval_run=run,
-                metric_id="MID",
+                metric_ids=LATENCY_IDS,
                 runner_sha="test",
                 period_seconds=10_800,
             )
@@ -427,7 +435,7 @@ async def test_already_ingested_run_still_becomes_sample_candidate() -> None:
             writer,
             spec=SPEC,
             agent_id="a1",
-            metric_id="MID",
+            metric_ids=LATENCY_IDS,
             runner_sha="test",
             period_seconds=10_800,
             stale_grace_seconds=5_400,
@@ -456,7 +464,7 @@ async def test_each_bucket_contributes_its_own_sample_candidate() -> None:
             writer,
             spec=SPEC,
             agent_id="a1",
-            metric_id="MID",
+            metric_ids=LATENCY_IDS,
             runner_sha="test",
             period_seconds=10_800,
             stale_grace_seconds=5_400,
@@ -486,7 +494,7 @@ async def test_one_bucket_keeps_only_its_newest_candidate() -> None:
             writer,
             spec=SPEC,
             agent_id="a1",
-            metric_id="MID",
+            metric_ids=LATENCY_IDS,
             runner_sha="test",
             period_seconds=10_800,
             stale_grace_seconds=5_400,
@@ -511,7 +519,7 @@ async def test_stale_provider_lends_no_sample_candidate() -> None:
             writer,
             spec=SPEC,
             agent_id="a1",
-            metric_id="MID",
+            metric_ids=LATENCY_IDS,
             runner_sha="test",
             period_seconds=10_800,
             stale_grace_seconds=5_400,
@@ -535,7 +543,9 @@ def test_instruction_rows_maps_verdicts() -> None:
         {"simulation_output_id": "s2", "value": "NO"},
         {"simulation_output_id": "s3", "value": "UNKNOWN"},
     ]
-    rows = fetch_v2v._instruction_rows(values, run_pk=1, coval_run_id="R1", spec=SPEC)
+    rows = fetch_v2v._s2s_rows(
+        values, metric=Metric.INSTRUCTION_FOLLOWING, run_pk=1, coval_run_id="R1", spec=SPEC
+    )
     # UNKNOWN produces no row (excluded from the pool); only YES/NO are written.
     assert [r.metric_value for r in rows] == [100.0, 0.0]
     assert [r.status for r in rows] == [ResultStatus.SUCCESS, ResultStatus.SUCCESS]
@@ -552,27 +562,28 @@ def test_instruction_verdict_raises_on_unexpected() -> None:
         fetch_v2v._instruction_verdict(None)
 
 
-def test_instruction_id_mismatch() -> None:
-    lat = [{"simulation_output_id": "s1"}, {"simulation_output_id": "s2"}]
-    assert fetch_v2v._instruction_id_mismatch(lat, lat) is None
+def test_population_mismatch() -> None:
+    anchor = [{"simulation_output_id": "s1"}, {"simulation_output_id": "s2"}]
+    assert fetch_v2v._population_mismatch(anchor, anchor) is None
     # different population (same count) -> diff reported
-    ins = [{"simulation_output_id": "s1"}, {"simulation_output_id": "s3"}]
-    diff = fetch_v2v._instruction_id_mismatch(lat, ins)
-    assert diff == {
-        "missing_instruction_ids": ["s2"],
-        "extra_instruction_ids": ["s3"],
-        "duplicate_instruction_ids": False,
+    other = [{"simulation_output_id": "s1"}, {"simulation_output_id": "s3"}]
+    assert fetch_v2v._population_mismatch(anchor, other) == {
+        "missing_ids": ["s2"],
+        "extra_ids": ["s3"],
+        "duplicate_ids": False,
     }
-    # duplicate id
     dup = [{"simulation_output_id": "s1"}, {"simulation_output_id": "s1"}]
-    dup_diff = fetch_v2v._instruction_id_mismatch(lat, dup)
+    dup_diff = fetch_v2v._population_mismatch(anchor, dup)
     assert dup_diff is not None
-    assert dup_diff["duplicate_instruction_ids"] is True
-    # no latency metric: nothing to compare against, duplicates still rejected
-    assert fetch_v2v._instruction_id_mismatch(None, ins) is None
-    no_anchor = fetch_v2v._instruction_id_mismatch(None, dup)
-    assert no_anchor is not None
-    assert no_anchor["duplicate_instruction_ids"] is True
+    assert dup_diff["duplicate_ids"] is True
+
+
+def test_has_duplicate_ids_guards_the_anchor() -> None:
+    # The anchor has nothing to be compared against, so this is its only check.
+    assert not fetch_v2v._has_duplicate_ids([{"simulation_output_id": "s1"}])
+    assert fetch_v2v._has_duplicate_ids(
+        [{"simulation_output_id": "s1"}, {"simulation_output_id": "s1"}]
+    )
 
 
 def test_dataset_identity() -> None:
@@ -604,14 +615,15 @@ async def test_noisy_and_clean_runs_land_in_different_datasets() -> None:
         {"run_id": "RNOISY", "create_time": _iso(timedelta(hours=1)), "persona_id": "PN"},
         {"run_id": "RCLEAN", "create_time": _iso(timedelta(hours=1)), "persona_id": "PCLEAN"},
     )
-    values = [{"simulation_output_id": "s1", "value": 0.5}]
-    async with _fake_client(list_json, _run_json(values)) as client:
+    latency = [{"simulation_output_id": "s1", "value": 0.5}]
+    instruction = [{"simulation_output_id": "s1", "value": "YES"}]
+    async with _fake_client(list_json, _multi_metric_run(latency, instruction)) as client:
         await fetch_v2v._fetch_one_provider(
             client,
             writer,
             spec=SPEC,
             agent_id="a1",
-            metric_id="MID",
+            metric_ids=IDS,
             test_set_id="TS1",
             noisy_persona_id="PN",
             runner_sha="test",
@@ -620,6 +632,13 @@ async def test_noisy_and_clean_runs_land_in_different_datasets() -> None:
         )
     datasets = [c.kwargs["dataset_id"] for c in writer.start_run.await_args_list]
     assert datasets == ["s2s-multiturn-noisy-v1", "s2s-multiturn-v1"]
+    # Both runs carry latency, but the noise dataset excludes it: only the clean
+    # run writes V2V rows, and neither warns about the omission.
+    written = [c.args[0] for c in writer.record_results.await_args_list]
+    assert [{r.metric_type for r in rows} for rows in written] == [
+        {Metric.INSTRUCTION_FOLLOWING},
+        {Metric.V2V, Metric.INSTRUCTION_FOLLOWING},
+    ]
     # Provenance rides along so a row says which persona produced it.
     personas = [c.kwargs["persona_id"] for c in writer.start_run.await_args_list]
     assert personas == ["PN", "PCLEAN"]
@@ -643,7 +662,7 @@ async def test_noisy_caller_never_becomes_a_sample_candidate() -> None:
             writer,
             spec=SPEC,
             agent_id="a1",
-            metric_id="MID",
+            metric_ids=LATENCY_IDS,
             test_set_id="TS1",
             noisy_persona_id="PN",
             runner_sha="test",
@@ -688,8 +707,7 @@ async def test_ingest_run_writes_instruction_rows() -> None:
             writer,
             spec=SPEC,
             coval_run=CovalRun(run_id="R1", create_time=None, error_status=None),
-            metric_id="MID",
-            instruction_metric_id="IID",
+            metric_ids=IDS,
             runner_sha="test",
             period_seconds=10_800,
         )
@@ -734,8 +752,7 @@ async def test_ingest_run_id_mismatch_keeps_latency() -> None:
             writer,
             spec=SPEC,
             coval_run=CovalRun(run_id="R1", create_time=None, error_status=None),
-            metric_id="MID",
-            instruction_metric_id="IID",
+            metric_ids=IDS,
             runner_sha="test",
             period_seconds=10_800,
         )
@@ -755,8 +772,7 @@ async def test_ingest_run_invalid_verdict_discards_instruction() -> None:
             writer,
             spec=SPEC,
             coval_run=CovalRun(run_id="R1", create_time=None, error_status=None),
-            metric_id="MID",
-            instruction_metric_id="IID",
+            metric_ids=IDS,
             runner_sha="test",
             period_seconds=10_800,
         )
@@ -790,10 +806,8 @@ async def test_ingest_run_backfill_instruction_only() -> None:
             writer,
             spec=SPEC,
             coval_run=CovalRun(run_id="R1", create_time=None, error_status=None),
-            metric_id="MID",
-            instruction_metric_id="IID",
-            want_latency=False,
-            want_instruction=True,
+            metric_ids=IDS,
+            pending=frozenset({Metric.INSTRUCTION_FOLLOWING}),
             runner_sha="test",
             period_seconds=10_800,
         )
@@ -814,10 +828,8 @@ async def test_ingest_run_backfill_instruction_absent_is_noop() -> None:
             writer,
             spec=SPEC,
             coval_run=CovalRun(run_id="R1", create_time=None, error_status=None),
-            metric_id="MID",
-            instruction_metric_id="IID",
-            want_latency=False,
-            want_instruction=True,
+            metric_ids=IDS,
+            pending=frozenset({Metric.INSTRUCTION_FOLLOWING}),
             runner_sha="test",
             period_seconds=10_800,
         )
@@ -828,7 +840,8 @@ async def test_ingest_run_backfill_instruction_absent_is_noop() -> None:
 
 @pytest.mark.asyncio
 async def test_ingest_run_latency_absent_writes_instruction() -> None:
-    # Conditions that run with latency off must still yield instruction rows.
+    # The noise condition requires instruction, not latency, so a run with no V2V
+    # is normal there and its instruction rows must still land.
     writer = _stub_writer()
     instruction = [{"simulation_output_id": "s0", "value": "YES"}]
     async with _fake_client({}, _run_json(instruction, metric_id="IID")) as client:
@@ -837,8 +850,9 @@ async def test_ingest_run_latency_absent_writes_instruction() -> None:
             writer,
             spec=SPEC,
             coval_run=CovalRun(run_id="R1", create_time=None, error_status=None),
-            metric_id="MID",
-            instruction_metric_id="IID",
+            metric_ids=IDS,
+            condition=condition_for(DATASET_ID_MULTITURN_NOISY),
+            dataset_id=DATASET_ID_MULTITURN_NOISY,
             runner_sha="test",
             period_seconds=10_800,
         )
@@ -849,8 +863,32 @@ async def test_ingest_run_latency_absent_writes_instruction() -> None:
 
 
 @pytest.mark.asyncio
-async def test_ingest_run_latency_absent_rejects_duplicate_instruction_ids() -> None:
-    # The duplicate check is instruction-only, so it survives having no anchor.
+async def test_ingest_run_latency_required_on_the_standard_caller() -> None:
+    # Same payload under the standard condition: latency is a must, so this is a
+    # fault and nothing is written rather than instruction publishing on its own.
+    writer = _stub_writer()
+    instruction = [{"simulation_output_id": "s0", "value": "YES"}]
+    async with _fake_client({}, _run_json(instruction, metric_id="IID")) as client:
+        status = await fetch_v2v._ingest_run(
+            client,
+            writer,
+            spec=SPEC,
+            coval_run=CovalRun(run_id="R1", create_time=None, error_status=None),
+            metric_ids=IDS,
+            condition=condition_for(DATASET_ID_MULTITURN),
+            dataset_id=DATASET_ID_MULTITURN,
+            runner_sha="test",
+            period_seconds=10_800,
+        )
+    assert status is None
+    writer.start_run.assert_not_awaited()
+    writer.record_results.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_ingest_run_rejects_duplicate_ids_in_the_anchor() -> None:
+    # Noise condition, so instruction is the anchor and nothing compares it against
+    # another metric: this guard is the only thing stopping double-counted rows.
     writer = _stub_writer()
     instruction = [
         {"simulation_output_id": "s0", "value": "YES"},
@@ -862,8 +900,9 @@ async def test_ingest_run_latency_absent_rejects_duplicate_instruction_ids() -> 
             writer,
             spec=SPEC,
             coval_run=CovalRun(run_id="R1", create_time=None, error_status=None),
-            metric_id="MID",
-            instruction_metric_id="IID",
+            metric_ids=IDS,
+            condition=condition_for(DATASET_ID_MULTITURN_NOISY),
+            dataset_id=DATASET_ID_MULTITURN_NOISY,
             runner_sha="test",
             period_seconds=10_800,
         )
@@ -881,6 +920,8 @@ async def test_ingest_run_latency_absent_rejects_duplicate_instruction_ids() -> 
 async def test_ingest_run_latency_absent_instruction_without_rows_is_noop(
     instruction: list[dict[str, Any]],
 ) -> None:
+    # Noise condition: instruction is the anchor, so values mapping to no rows
+    # must not leave an empty run row behind.
     writer = _stub_writer()
     async with _fake_client({}, _run_json(instruction, metric_id="IID")) as client:
         status = await fetch_v2v._ingest_run(
@@ -888,8 +929,9 @@ async def test_ingest_run_latency_absent_instruction_without_rows_is_noop(
             writer,
             spec=SPEC,
             coval_run=CovalRun(run_id="R1", create_time=None, error_status=None),
-            metric_id="MID",
-            instruction_metric_id="IID",
+            metric_ids=IDS,
+            condition=condition_for(DATASET_ID_MULTITURN_NOISY),
+            dataset_id=DATASET_ID_MULTITURN_NOISY,
             runner_sha="test",
             period_seconds=10_800,
         )
@@ -900,6 +942,7 @@ async def test_ingest_run_latency_absent_instruction_without_rows_is_noop(
 
 @pytest.mark.asyncio
 async def test_already_ingested_instruction_only_run_is_fresh() -> None:
+    # Any persisted metric keeps the provider fresh, even with latency still owed.
     writer = _stub_writer()
 
     async def metric_ingested(*, metric_type: str, **_kwargs: Any) -> bool:
@@ -914,8 +957,7 @@ async def test_already_ingested_instruction_only_run_is_fresh() -> None:
             writer,
             spec=SPEC,
             agent_id="a1",
-            metric_id="MID",
-            instruction_metric_id="IID",
+            metric_ids=IDS,
             test_set_id="TS1",
             runner_sha="test",
             period_seconds=10_800,
@@ -924,6 +966,37 @@ async def test_already_ingested_instruction_only_run_is_fresh() -> None:
 
     assert (status, ingested) == (RunStatus.SUCCEEDED, 0)
     writer.start_run.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_run_skipped_when_the_required_metric_is_unconfigured() -> None:
+    # Noise requires instruction; without its id the run cannot be judged, so it is
+    # skipped and must not count as fresh data or a sample candidate.
+    from coval_bench.s2s.samples import SampleRun
+
+    writer = _stub_writer()
+    list_json = _list_json(
+        {"run_id": "RNOISY", "create_time": _iso(timedelta(hours=1)), "persona_id": "PN"}
+    )
+    sampled: list[SampleRun] = []
+    async with _fake_client(list_json, _run_json([{"simulation_output_id": "s1"}])) as client:
+        status, ingested = await fetch_v2v._fetch_one_provider(
+            client,
+            writer,
+            spec=SPEC,
+            agent_id="a1",
+            metric_ids=LATENCY_IDS,
+            test_set_id="TS1",
+            noisy_persona_id="PN",
+            runner_sha="test",
+            period_seconds=10_800,
+            stale_grace_seconds=5_400,
+            sampled_runs=sampled,
+        )
+    assert ingested == 0
+    assert sampled == []
+    writer.start_run.assert_not_awaited()
+    assert status is not RunStatus.SUCCEEDED
 
 
 @pytest.mark.asyncio
@@ -936,8 +1009,7 @@ async def test_ingest_run_no_metrics_present_is_noop() -> None:
             writer,
             spec=SPEC,
             coval_run=CovalRun(run_id="R1", create_time=None, error_status=None),
-            metric_id="MID",
-            instruction_metric_id="IID",
+            metric_ids=IDS,
             runner_sha="test",
             period_seconds=10_800,
         )
@@ -957,7 +1029,7 @@ async def test_ingest_run_without_instruction_metric_id() -> None:
             writer,
             spec=SPEC,
             coval_run=CovalRun(run_id="R1", create_time=None, error_status=None),
-            metric_id="MID",
+            metric_ids=LATENCY_IDS,
             runner_sha="test",
             period_seconds=10_800,
         )

--- a/runner/tests/unit/test_s2s_fetch.py
+++ b/runner/tests/unit/test_s2s_fetch.py
@@ -328,6 +328,38 @@ async def test_fetch_one_provider_stale_wins_over_backfill() -> None:
 
 
 @pytest.mark.asyncio
+async def test_optional_metric_alone_does_not_prove_freshness() -> None:
+    writer = _stub_writer()
+
+    async def ingested(*, provider: str, coval_run_id: str, metric_type: Metric) -> bool:
+        return metric_type is Metric.INSTRUCTION_FOLLOWING
+
+    writer.coval_metric_ingested = AsyncMock(side_effect=ingested)
+    list_json = _list_json({"run_id": "R1", "create_time": _iso(timedelta(hours=1))})
+    run_json = {
+        "run": {
+            "error_status": "SUCCESS",
+            "results": {
+                "metrics": {"IID": {"values": [{"simulation_output_id": "s1", "value": "YES"}]}}
+            },
+        }
+    }
+    async with _fake_client(list_json, run_json) as client:
+        status, _ = await fetch_v2v._fetch_one_provider(
+            client,
+            writer,
+            spec=SPEC,
+            agent_id="a1",
+            metric_ids=IDS,
+            test_set_id="TS1",
+            runner_sha="test",
+            period_seconds=10_800,
+            stale_grace_seconds=5_400,
+        )
+    assert status is RunStatus.FAILED
+
+
+@pytest.mark.asyncio
 async def test_fetch_one_provider_unknown_age_is_stale() -> None:
     # A usable run without a parseable create_time is no evidence of freshness.
     writer = _stub_writer()
@@ -942,14 +974,17 @@ async def test_ingest_run_latency_absent_instruction_without_rows_is_noop(
 
 @pytest.mark.asyncio
 async def test_already_ingested_instruction_only_run_is_fresh() -> None:
-    # Any persisted metric keeps the provider fresh, even with latency still owed.
+    # Noise requires instruction and never carries latency, so a persisted
+    # instruction run keeps the provider fresh between fetches.
     writer = _stub_writer()
 
     async def metric_ingested(*, metric_type: str, **_kwargs: Any) -> bool:
         return metric_type == Metric.INSTRUCTION_FOLLOWING
 
     writer.coval_metric_ingested = AsyncMock(side_effect=metric_ingested)
-    list_json = _list_json({"run_id": "R1", "create_time": _iso(timedelta(hours=1))})
+    list_json = _list_json(
+        {"run_id": "R1", "create_time": _iso(timedelta(hours=1)), "persona_id": "PN"}
+    )
     instruction = [{"simulation_output_id": "s0", "value": "YES"}]
     async with _fake_client(list_json, _run_json(instruction, metric_id="IID")) as client:
         status, ingested = await fetch_v2v._fetch_one_provider(
@@ -959,6 +994,7 @@ async def test_already_ingested_instruction_only_run_is_fresh() -> None:
             agent_id="a1",
             metric_ids=IDS,
             test_set_id="TS1",
+            noisy_persona_id="PN",
             runner_sha="test",
             period_seconds=10_800,
             stale_grace_seconds=5_400,

--- a/runner/tests/unit/test_s2s_fetch.py
+++ b/runner/tests/unit/test_s2s_fetch.py
@@ -719,6 +719,20 @@ async def test_fetch_and_write_rejects_noisy_persona_without_a_test_set() -> Non
 
 
 @pytest.mark.asyncio
+async def test_fetch_and_write_rejects_a_metric_with_no_row_builder() -> None:
+    settings = Settings(
+        runner_sha="test",
+        coval_s2s_latency_metric_id="MID",
+        coval_s2s_openai_agent_id="a1",
+        coval_s2s_test_set_id="TS1",
+        coval_s2s_instruction_metric_id="IID",
+        coval_s2s_interruption_metric_id="RID",
+    )
+    with pytest.raises(RuntimeError, match="no _VALUE_MAPPERS entry"):
+        await fetch_v2v.fetch_and_write_v2v(settings)
+
+
+@pytest.mark.asyncio
 async def test_ingest_run_writes_instruction_rows() -> None:
     writer = _stub_writer()
     latency = [{"simulation_output_id": f"s{i}", "value": 0.5} for i in range(3)]


### PR DESCRIPTION
Each S2S dataset now declares which metric it requires, which it may carry, and which it never writes: the noise caller requires instruction adherence and never asks for V2V, while the standard caller still faults if latency goes missing.

That one declaration replaces the want_latency/want_instruction flag pairs, so a run is skipped once its declared metrics land instead of being rescanned until the ingest window closes.

The two row builders collapse into one, leaving interruption rate a small mapper and a dict entry away.