### PR TITLE
Scope S2S datasets to the test set that produced them

### DIFF
--- a/runner/src/coval_bench/config.py
+++ b/runner/src/coval_bench/config.py
@@ -137,6 +137,8 @@ class Settings(BaseSettings):
     coval_s2s_gemini_agent_id: str | None = None
     coval_s2s_xai_agent_id: str | None = None
     coval_s2s_xai_think_fast_2_agent_id: str | None = None
+    coval_s2s_gray_agent_id: str | None = None
+    coval_s2s_red_agent_id: str | None = None
     # The S2S instruction-adherence metric id (opaque, not secret). Optional: the
     # fetch pulls its per-conversation scores only when set, so latency still
     # ingests without it.
@@ -147,11 +149,17 @@ class Settings(BaseSettings):
     # other sims on the same agents (e.g. the single-turn set) would be ingested
     # and pooled into the same provider. Opaque id, not secret.
     coval_s2s_test_set_id: str | None = None
+    # Test set for agents evaluated on the happy-path scenarios instead of the
+    # shared one above. Opaque id, not secret.
+    coval_s2s_happypath_test_set_id: str | None = None
     # The caller persona whose audio carries background noise; its runs land
     # under their own dataset instead of pooling into the clean numbers. Unset
-    # means every persona is clean. Temporary: personas belong in stored
-    # settings, not one id here, once there is more than one condition.
+    # means every persona is clean. Superseded by coval_s2s_condition_personas.
     coval_s2s_noisy_persona_id: str | None = None
+    # Caller persona id -> condition name, e.g. {"<id>": "noisy", "<id>": "clean"}.
+    # Exhaustive: a persona absent from this map faults its provider rather than
+    # counting as clean, which would be invisible in the data and the logs.
+    coval_s2s_condition_personas: dict[str, str] = Field(default_factory=dict)
     # Fetch grid, in seconds; kept in sync with the s2s-fetch-trigger cron in
     # benchmark-infra (override via S2S_FETCH_PERIOD_SECONDS). Default = 3h.
     s2s_fetch_period_seconds: int = Field(default=10_800, gt=0)

--- a/runner/src/coval_bench/registries/models.py
+++ b/runner/src/coval_bench/registries/models.py
@@ -1108,6 +1108,24 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         region="us-east-1",
         status=_EARLY_ACCESS,
     ),
+    # Pre-launch models named by codename only: these strings reach the results
+    # table and every surface built on it, so they carry no vendor identity of
+    # their own. Leave `creator` unset — it falls back to the provider, which is
+    # the point.
+    RegisteredModel(
+        benchmark=_S2S,
+        provider="colors",
+        model="gray",
+        tags=(_STREAMING, _MULTI),
+        status=_EARLY_ACCESS,
+    ),
+    RegisteredModel(
+        benchmark=_S2S,
+        provider="colors",
+        model="red",
+        tags=(_STREAMING, _MULTI),
+        status=_EARLY_ACCESS,
+    ),
 ]
 
 _key_counts = Counter((m.benchmark, m.provider, m.model) for m in MODEL_REGISTRY)

--- a/runner/src/coval_bench/s2s/conditions.py
+++ b/runner/src/coval_bench/s2s/conditions.py
@@ -5,9 +5,15 @@
 A condition is one dataset id. ``required`` must be on the run or the run is a
 fault; ``optional`` is written when present; anything named in neither is never
 fetched, so its absence is silent rather than an alertable warning.
+
+Dataset ids pair a family with a condition. The family is the Coval test set the
+runs came from, so two sets' scenarios can never share a row key; the condition is
+the caller persona's character within it.
 """
 
 from __future__ import annotations
+
+from enum import StrEnum
 
 from pydantic import BaseModel
 
@@ -15,12 +21,41 @@ from coval_bench.registries import Metric
 
 __all__ = [
     "DATASET_ID",
+    "DATASET_ID_HAPPYPATH",
+    "DATASET_ID_HAPPYPATH_ACCENTED",
+    "DATASET_ID_HAPPYPATH_NOISY",
     "DATASET_ID_MULTITURN",
     "DATASET_ID_MULTITURN_NOISY",
     "DEFAULT_CONDITION",
+    "FAMILY_HAPPYPATH",
+    "FAMILY_MULTITURN",
+    "Condition",
     "DatasetMetrics",
     "condition_for",
+    "dataset_id_for",
 ]
+
+
+class Condition(StrEnum):
+    """One caller persona's character, independent of which test set ran it.
+
+    ``SKIP`` marks a persona we know about and deliberately do not ingest, so the
+    persona map can stay exhaustive — an *unmapped* persona faults instead of
+    silently counting as clean.
+    """
+
+    CLEAN = "clean"
+    NOISY = "noisy"
+    ACCENTED = "accented"
+    SKIP = "skip"
+
+
+# The Coval test sets we ingest, as dataset-id prefixes. Their case counts differ
+# by design: the shared set runs 15 cases across two clean voices and aggregates
+# them, the happy-path set runs 30 across one, so the clean condition carries the
+# same 30 conversations either way.
+FAMILY_MULTITURN = "s2s-multiturn"  # customer-service, the shared board
+FAMILY_HAPPYPATH = "s2s-happypath"
 
 # Single-turn SLURP manifest (legacy, latency only) and the multi-turn Coval test
 # set, split by caller condition so background noise never pools into the clean
@@ -28,6 +63,29 @@ __all__ = [
 DATASET_ID = "s2s-v1"
 DATASET_ID_MULTITURN = "s2s-multiturn-v1"
 DATASET_ID_MULTITURN_NOISY = "s2s-multiturn-noisy-v1"
+
+DATASET_ID_HAPPYPATH = "s2s-happypath-v1"
+DATASET_ID_HAPPYPATH_NOISY = "s2s-happypath-noisy-v1"
+DATASET_ID_HAPPYPATH_ACCENTED = "s2s-happypath-accented-v1"
+
+# Unlisted pairs are a configuration error, not a silent skip.
+DATASET_IDS: dict[tuple[str, Condition], str] = {
+    (FAMILY_MULTITURN, Condition.CLEAN): DATASET_ID_MULTITURN,
+    (FAMILY_MULTITURN, Condition.NOISY): DATASET_ID_MULTITURN_NOISY,
+    (FAMILY_HAPPYPATH, Condition.CLEAN): DATASET_ID_HAPPYPATH,
+    (FAMILY_HAPPYPATH, Condition.NOISY): DATASET_ID_HAPPYPATH_NOISY,
+    (FAMILY_HAPPYPATH, Condition.ACCENTED): DATASET_ID_HAPPYPATH_ACCENTED,
+}
+
+
+def dataset_id_for(family: str, condition: Condition) -> str | None:
+    """The dataset id for *condition* within *family*, or None when not ingested."""
+    if condition is Condition.SKIP:
+        return None
+    try:
+        return DATASET_IDS[(family, condition)]
+    except KeyError:
+        raise ValueError(f"no dataset id for family {family!r} condition {condition!r}") from None
 
 
 class DatasetMetrics(BaseModel, frozen=True):
@@ -54,6 +112,21 @@ CONDITIONS: dict[str, DatasetMetrics] = {
         optional=frozenset({Metric.INSTRUCTION_FOLLOWING, Metric.INTERRUPTION_RATE}),
     ),
     DATASET_ID_MULTITURN_NOISY: DatasetMetrics(
+        required=Metric.INSTRUCTION_FOLLOWING,
+        optional=frozenset({Metric.INTERRUPTION_RATE}),
+    ),
+    DATASET_ID_HAPPYPATH: DatasetMetrics(
+        required=Metric.V2V,
+        optional=frozenset({Metric.INSTRUCTION_FOLLOWING, Metric.INTERRUPTION_RATE}),
+    ),
+    DATASET_ID_HAPPYPATH_NOISY: DatasetMetrics(
+        required=Metric.INSTRUCTION_FOLLOWING,
+        optional=frozenset({Metric.INTERRUPTION_RATE}),
+    ),
+    # These runs were scored without V2V attached, so anchoring on it would skip
+    # every one with ``required_metric_absent``. Move the anchor back if they are
+    # ever re-scored with it.
+    DATASET_ID_HAPPYPATH_ACCENTED: DatasetMetrics(
         required=Metric.INSTRUCTION_FOLLOWING,
         optional=frozenset({Metric.INTERRUPTION_RATE}),
     ),

--- a/runner/src/coval_bench/s2s/fetch_v2v.py
+++ b/runner/src/coval_bench/s2s/fetch_v2v.py
@@ -31,11 +31,13 @@ from coval_bench.registries import METRIC_SPECS, Metric
 from coval_bench.registries.benchmarks import Benchmark
 from coval_bench.s2s.conditions import (
     DATASET_ID,
-    DATASET_ID_MULTITURN,
-    DATASET_ID_MULTITURN_NOISY,
     DEFAULT_CONDITION,
+    FAMILY_HAPPYPATH,
+    FAMILY_MULTITURN,
+    Condition,
     DatasetMetrics,
     condition_for,
+    dataset_id_for,
 )
 from coval_bench.s2s.samples import SampleRun, model_labels, publish_tick_sample
 
@@ -56,6 +58,13 @@ class AgentSpec:
     agent_id_attr: str
     provider: str
     model: str
+    # Settings attr holding this agent's own Coval test set id; None uses the
+    # shared ``coval_s2s_test_set_id``.
+    test_set_id_attr: str | None = None
+    # Dataset family for this agent's rows (see ``s2s.conditions``).
+    family: str = FAMILY_MULTITURN
+    # Whether this agent's recordings may reach the public samples card.
+    publish_samples: bool = True
 
 
 @dataclass(frozen=True)
@@ -81,6 +90,24 @@ AGENTS: tuple[AgentSpec, ...] = (
         agent_id_attr="coval_s2s_xai_think_fast_2_agent_id",
         provider="xai",
         model="grok-voice-think-fast-2.0",
+    ),
+    # Pre-launch models under codenames: the provider and model strings are what
+    # land in the results table, so they carry no vendor identity of their own.
+    AgentSpec(
+        agent_id_attr="coval_s2s_gray_agent_id",
+        provider="colors",
+        model="gray",
+        test_set_id_attr="coval_s2s_happypath_test_set_id",
+        family=FAMILY_HAPPYPATH,
+        publish_samples=False,
+    ),
+    AgentSpec(
+        agent_id_attr="coval_s2s_red_agent_id",
+        provider="colors",
+        model="red",
+        test_set_id_attr="coval_s2s_happypath_test_set_id",
+        family=FAMILY_HAPPYPATH,
+        publish_samples=False,
     ),
 )
 
@@ -109,26 +136,71 @@ def _dataset_sha256() -> str:
         return "unknown"
 
 
+def _condition_for_persona(
+    persona_id: str,
+    persona_conditions: Mapping[str, Condition] | None,
+    noisy_persona_id: str | None,
+) -> Condition:
+    """This run's caller condition.
+
+    An unmapped persona raises rather than counting as clean: that pooling would be
+    invisible in both the data and the logs. ``noisy_persona_id`` is the pre-map
+    setting, honoured only while the map is unset so the two can deploy in either
+    order.
+    """
+    if persona_conditions:
+        try:
+            return persona_conditions[persona_id]
+        except KeyError:
+            raise ValueError(f"persona {persona_id!r} has no condition mapped") from None
+    if noisy_persona_id and persona_id == noisy_persona_id:
+        return Condition.NOISY
+    return Condition.CLEAN
+
+
 def _dataset_identity(
     test_set_id: str | None,
     persona_id: str = "",
     noisy_persona_id: str | None = None,
-) -> tuple[str, str]:
-    """Dataset id + provenance for one run's rows.
+    *,
+    family: str = FAMILY_MULTITURN,
+    persona_conditions: Mapping[str, Condition] | None = None,
+) -> tuple[str, str] | None:
+    """Dataset id + provenance for one run's rows, or None when not ingested.
 
     Multi-turn runs are keyed to their Coval test set, not the single-turn SLURP
     manifest, so they get their own dataset id (never pooling with s2s-v1) and
     record the test-set id as provenance. Without a test set (legacy latency-only
     mode) the rows stay under the packaged s2s-v1 manifest.
 
-    The noisy caller shares that test set, so only the persona separates the two
-    conditions; its provenance names the persona to keep the rows self-describing.
+    Non-clean conditions name the persona in their provenance so the rows stay
+    self-describing.
     """
-    if test_set_id:
-        if noisy_persona_id and persona_id == noisy_persona_id:
-            return DATASET_ID_MULTITURN_NOISY, f"{test_set_id}:{persona_id}"
-        return DATASET_ID_MULTITURN, test_set_id
-    return DATASET_ID, _dataset_sha256()
+    if not test_set_id:
+        return DATASET_ID, _dataset_sha256()
+    condition = _condition_for_persona(persona_id, persona_conditions, noisy_persona_id)
+    dataset_id = dataset_id_for(family, condition)
+    if dataset_id is None:
+        return None
+    if condition is Condition.CLEAN:
+        return dataset_id, test_set_id
+    return dataset_id, f"{test_set_id}:{persona_id}"
+
+
+def _persona_conditions(raw: Mapping[str, str]) -> dict[str, Condition] | None:
+    """Parse the persona -> condition setting, rejecting unknown condition names."""
+    if not raw:
+        return None
+    parsed: dict[str, Condition] = {}
+    for persona_id, name in raw.items():
+        try:
+            parsed[persona_id] = Condition(name)
+        except ValueError:
+            valid = ", ".join(c.value for c in Condition)
+            raise RuntimeError(
+                f"coval_s2s_condition_personas[{persona_id!r}] is {name!r}; expected one of {valid}"
+            ) from None
+    return parsed
 
 
 def _parse_time(raw: object) -> datetime | None:
@@ -532,6 +604,7 @@ async def _fetch_one_provider(
     metric_ids: Mapping[Metric, str],
     test_set_id: str | None = None,
     noisy_persona_id: str | None = None,
+    persona_conditions: Mapping[str, Condition] | None = None,
     runner_sha: str,
     period_seconds: int,
     stale_grace_seconds: int,
@@ -547,8 +620,10 @@ async def _fetch_one_provider(
     """
     statuses: list[RunStatus] = []
     candidates: dict[tuple[datetime, str], SampleRun] = {}
+    # The clean caller, plus the legacy single-turn manifest which has no conditions.
+    publishable = {DATASET_ID, dataset_id_for(spec.family, Condition.CLEAN)}
 
-    def note_sample_candidate(coval_run: CovalRun) -> None:
+    def note_sample_candidate(coval_run: CovalRun, dataset_id: str) -> None:
         # Newest-first scan: keep the newest eligible run PER (BUCKET, PERSONA).
         # Multi-turn runs the same test set once per persona, so a provider yields
         # one candidate per persona per day (single-turn has no persona -> a "" key).
@@ -557,9 +632,9 @@ async def _fetch_one_provider(
         # yesterday's before the sampler ever saw it. Staggered arrivals must not
         # shrink the sample; committed only after the staleness check so a stale
         # provider's old recording never ships today.
-        # The noisy caller is under embargo, so its recordings never reach the
-        # public samples card.
-        if noisy_persona_id and coval_run.persona_id == noisy_persona_id:
+        # Every other condition's recording stays internal, as does every recording
+        # from an agent under embargo.
+        if not spec.publish_samples or dataset_id not in publishable:
             return
         bucket_at = _bucket_start(coval_run.create_time or datetime.now(tz=UTC), period_seconds)
         key = (bucket_at, coval_run.persona_id)
@@ -589,9 +664,16 @@ async def _fetch_one_provider(
                     error_status=coval_run.error_status,
                 )
                 continue
-            dataset_id, dataset_sha256 = _dataset_identity(
-                test_set_id, coval_run.persona_id, noisy_persona_id
+            identity = _dataset_identity(
+                test_set_id,
+                coval_run.persona_id,
+                noisy_persona_id,
+                family=spec.family,
+                persona_conditions=persona_conditions,
             )
+            if identity is None:
+                continue
+            dataset_id, dataset_sha256 = identity
             condition = condition_for(dataset_id)
             if condition.required not in metric_ids:
                 logger.warning(
@@ -611,7 +693,7 @@ async def _fetch_one_provider(
             )
             persisted = ingestable - pending
             if persisted:
-                note_sample_candidate(coval_run)
+                note_sample_candidate(coval_run, dataset_id)
             if condition.required in persisted and not data_seen:
                 data_seen, newest_data_at = True, coval_run.create_time
             if not pending:
@@ -635,7 +717,7 @@ async def _fetch_one_provider(
             if status is None:
                 continue
             if status is not RunStatus.FAILED:
-                note_sample_candidate(coval_run)
+                note_sample_candidate(coval_run, dataset_id)
                 if not data_seen:
                     data_seen, newest_data_at = True, coval_run.create_time
             statuses.append(status)
@@ -710,6 +792,11 @@ async def fetch_and_write_v2v(settings: Settings | None = None) -> dict[str, Run
     noisy_persona_id = raw_noisy or None
     if noisy_persona_id and not test_set_id:
         raise RuntimeError("coval_s2s_noisy_persona_id requires coval_s2s_test_set_id")
+    # Supersedes coval_s2s_noisy_persona_id once set, so the two can deploy in
+    # either order.
+    persona_conditions = _persona_conditions(settings.coval_s2s_condition_personas)
+    if persona_conditions and not test_set_id:
+        raise RuntimeError("coval_s2s_condition_personas requires coval_s2s_test_set_id")
     raw_interruption = settings.coval_s2s_interruption_metric_id
     if raw_interruption is not None and not raw_interruption.strip():
         raise RuntimeError("coval_s2s_interruption_metric_id must not be blank")
@@ -734,14 +821,24 @@ async def fetch_and_write_v2v(settings: Settings | None = None) -> dict[str, Run
             if not agent_id:
                 logger.warning("agent_id_unset", provider=spec.provider, attr=spec.agent_id_attr)
                 continue
+            # An agent on its own test set is skipped when that id is missing rather
+            # than falling back to the shared one, which would file its runs under
+            # the wrong family.
+            spec_test_set = (
+                getattr(settings, spec.test_set_id_attr) if spec.test_set_id_attr else test_set_id
+            ) or None
+            if spec.test_set_id_attr and not spec_test_set:
+                logger.warning("test_set_unset", provider=spec.provider, attr=spec.test_set_id_attr)
+                continue
             statuses[f"{spec.provider}:{spec.model}"], ingested = await _fetch_one_provider(
                 client,
                 writer,
                 spec=spec,
                 agent_id=agent_id,
                 metric_ids=metric_ids,
-                test_set_id=test_set_id,
+                test_set_id=spec_test_set,
                 noisy_persona_id=noisy_persona_id,
+                persona_conditions=persona_conditions,
                 runner_sha=settings.runner_sha,
                 period_seconds=settings.s2s_fetch_period_seconds,
                 stale_grace_seconds=settings.s2s_stale_grace_seconds,

--- a/runner/src/coval_bench/s2s/fetch_v2v.py
+++ b/runner/src/coval_bench/s2s/fetch_v2v.py
@@ -784,6 +784,11 @@ async def fetch_and_write_v2v(settings: Settings | None = None) -> dict[str, Run
         raise RuntimeError(
             "coval_s2s_instruction_metric_id and coval_s2s_test_set_id must be set together"
         )
+    # Blank rather than unset would skip its agents with only a warning, which
+    # reads the same as never having configured them.
+    raw_happypath = settings.coval_s2s_happypath_test_set_id
+    if raw_happypath is not None and not raw_happypath.strip():
+        raise RuntimeError("coval_s2s_happypath_test_set_id must not be blank")
     # The noisy persona only separates conditions within a test set, so without
     # one it would silently never take effect.
     raw_noisy = settings.coval_s2s_noisy_persona_id

--- a/runner/tests/unit/test_s2s_fetch.py
+++ b/runner/tests/unit/test_s2s_fetch.py
@@ -797,6 +797,19 @@ async def test_fetch_and_write_rejects_noisy_persona_without_a_test_set() -> Non
 
 
 @pytest.mark.asyncio
+async def test_fetch_and_write_rejects_a_blank_happypath_test_set() -> None:
+    # Blank would skip its agents with only a warning, indistinguishable from unset.
+    settings = Settings(
+        runner_sha="test",
+        coval_s2s_latency_metric_id="MID",
+        coval_s2s_openai_agent_id="a1",
+        coval_s2s_happypath_test_set_id="   ",
+    )
+    with pytest.raises(RuntimeError, match="coval_s2s_happypath_test_set_id must not be blank"):
+        await fetch_v2v.fetch_and_write_v2v(settings)
+
+
+@pytest.mark.asyncio
 async def test_fetch_and_write_rejects_a_metric_with_no_row_builder() -> None:
     settings = Settings(
         runner_sha="test",

--- a/runner/tests/unit/test_s2s_fetch.py
+++ b/runner/tests/unit/test_s2s_fetch.py
@@ -24,6 +24,9 @@ from coval_bench.s2s import fetch_v2v
 from coval_bench.s2s.conditions import (
     DATASET_ID_MULTITURN,
     DATASET_ID_MULTITURN_NOISY,
+    FAMILY_HAPPYPATH,
+    FAMILY_MULTITURN,
+    Condition,
     condition_for,
 )
 from coval_bench.s2s.fetch_v2v import AgentSpec, CovalRun
@@ -478,6 +481,38 @@ async def test_already_ingested_run_still_becomes_sample_candidate() -> None:
 
 
 @pytest.mark.asyncio
+async def test_embargoed_agent_never_becomes_a_sample_candidate() -> None:
+    """An embargoed agent's recordings must never reach the public samples card."""
+    from coval_bench.s2s.samples import SampleRun
+
+    writer = _stub_writer()
+    writer.coval_metric_ingested = AsyncMock(return_value=True)
+    list_json = _list_json(
+        {"run_id": "R1", "create_time": _iso(timedelta(hours=1)), "error_status": "SUCCESS"}
+    )
+    embargoed = AgentSpec(
+        agent_id_attr="coval_s2s_gray_agent_id",
+        provider="colors",
+        model="gray",
+        publish_samples=False,
+    )
+    sampled: list[SampleRun] = []
+    async with _fake_client(list_json, {}) as client:
+        await fetch_v2v._fetch_one_provider(
+            client,
+            writer,
+            spec=embargoed,
+            agent_id="a1",
+            metric_ids=LATENCY_IDS,
+            runner_sha="test",
+            period_seconds=10_800,
+            stale_grace_seconds=5_400,
+            sampled_runs=sampled,
+        )
+    assert sampled == []
+
+
+@pytest.mark.asyncio
 async def test_each_bucket_contributes_its_own_sample_candidate() -> None:
     """Runs in different buckets are both candidates — this is what recovers a missed day."""
     from coval_bench.s2s.samples import SampleRun
@@ -620,12 +655,13 @@ def test_has_duplicate_ids_guards_the_anchor() -> None:
 
 def test_dataset_identity() -> None:
     assert fetch_v2v._dataset_identity("TS1") == ("s2s-multiturn-v1", "TS1")
-    dataset_id, _sha = fetch_v2v._dataset_identity(None)
-    assert dataset_id == "s2s-v1"
+    single_turn = fetch_v2v._dataset_identity(None)
+    assert single_turn is not None
+    assert single_turn[0] == "s2s-v1"
 
 
 def test_dataset_identity_splits_the_noisy_caller() -> None:
-    """The noisy persona shares the test set but gets its own dataset."""
+    """The pre-map setting still splits the noisy persona while the map is unset."""
     assert fetch_v2v._dataset_identity("TS1", "PN", "PN") == (
         "s2s-multiturn-noisy-v1",
         "TS1:PN",
@@ -635,8 +671,50 @@ def test_dataset_identity_splits_the_noisy_caller() -> None:
     # Unset setting: no persona is noisy, so nothing splits.
     assert fetch_v2v._dataset_identity("TS1", "PN", None) == ("s2s-multiturn-v1", "TS1")
     # Single-turn has no test set, so it keeps the packaged manifest.
-    single_turn, _sha = fetch_v2v._dataset_identity(None, "PN", "PN")
-    assert single_turn == "s2s-v1"
+    single_turn = fetch_v2v._dataset_identity(None, "PN", "PN")
+    assert single_turn is not None
+    assert single_turn[0] == "s2s-v1"
+
+
+def test_dataset_identity_keeps_families_apart() -> None:
+    """The same persona lands in a different dataset per test-set family."""
+    personas = {"PC": Condition.CLEAN, "PN": Condition.NOISY, "PA": Condition.ACCENTED}
+    assert fetch_v2v._dataset_identity(
+        "TS1", "PC", family=FAMILY_MULTITURN, persona_conditions=personas
+    ) == ("s2s-multiturn-v1", "TS1")
+    assert fetch_v2v._dataset_identity(
+        "TS2", "PC", family=FAMILY_HAPPYPATH, persona_conditions=personas
+    ) == ("s2s-happypath-v1", "TS2")
+    assert fetch_v2v._dataset_identity(
+        "TS2", "PN", family=FAMILY_HAPPYPATH, persona_conditions=personas
+    ) == ("s2s-happypath-noisy-v1", "TS2:PN")
+    assert fetch_v2v._dataset_identity(
+        "TS2", "PA", family=FAMILY_HAPPYPATH, persona_conditions=personas
+    ) == ("s2s-happypath-accented-v1", "TS2:PA")
+
+
+def test_dataset_identity_skips_known_and_faults_unknown_personas() -> None:
+    personas = {"PSKIP": Condition.SKIP}
+    # Known but deliberately not ingested.
+    assert fetch_v2v._dataset_identity("TS1", "PSKIP", persona_conditions=personas) is None
+    # Unmapped: loud, because counting it as clean would be invisible.
+    with pytest.raises(ValueError, match="no condition mapped"):
+        fetch_v2v._dataset_identity("TS1", "PUNKNOWN", persona_conditions=personas)
+
+
+def test_dataset_identity_map_supersedes_the_noisy_setting() -> None:
+    """Once the map is set the single-persona setting no longer applies."""
+    assert fetch_v2v._dataset_identity(
+        "TS1", "PN", "PN", persona_conditions={"PN": Condition.CLEAN}
+    ) == ("s2s-multiturn-v1", "TS1")
+
+
+def test_dataset_identity_rejects_a_condition_its_family_lacks() -> None:
+    """A persona mapped to a condition the shared set never runs is a config error."""
+    with pytest.raises(ValueError, match="no dataset id"):
+        fetch_v2v._dataset_identity(
+            "TS1", "PA", family=FAMILY_MULTITURN, persona_conditions={"PA": Condition.ACCENTED}
+        )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Groundwork only — every switch is off by default, so merging changes nothing in production.

- `AgentSpec` takes an optional test set and dataset family. Agents that set neither keep today's shared set and `s2s-multiturn-*` ids; ones that do file under `s2s-happypath-*` and can never share a row key with the shared board.
- `coval_s2s_condition_personas` replaces `coval_s2s_noisy_persona_id`. The old setting expressed "one persona is noisy, everything else is clean", and that fallback is how a new persona silently pools into the clean numbers. The map is exhaustive — unmapped personas now fail loudly, with an explicit `skip` for ones we deliberately don't ingest. Old setting still honoured while the map is unset, so the two can deploy in either order.
- Accented anchors on instruction adherence, not latency — those runs were scored without V2V attached, so anchoring on it would skip every one.
- Sampling publishes the clean caller only, and agents can opt out entirely. Two pre-launch models registered under codenames with `creator` unset.
- No migration; `dataset_id` has been a grouped column since the aggregates gained the dataset dimension.

Turning it on is a separate infra change, and the persona map should land on its own tick first so a missing persona is caught while only the four known-good agents are exposed to it.