### PR TITLE
fix(deploy): validate runner release environment

### DIFF
--- a/.github/workflows/runner-release.yml
+++ b/.github/workflows/runner-release.yml
@@ -40,6 +40,26 @@ jobs:
       api_image: ${{ steps.context.outputs.api_image }}
       skip: ${{ steps.context.outputs.skip }}
     steps:
+      - name: Validate release environment
+        env:
+          DISPATCH_ENVIRONMENT: ${{ github.event.client_payload.environment }}
+          RELEASE_EVENT_NAME: ${{ github.event_name }}
+        run: |
+          set -euo pipefail
+          case "$RELEASE_EVENT_NAME" in
+            repository_dispatch)
+              if [ "$DISPATCH_ENVIRONMENT" != "production" ]; then
+                echo "::error::Benchmarks runner release environment must be production."
+                exit 1
+              fi
+              ;;
+            workflow_dispatch) ;;
+            *)
+              echo "::error::Unsupported Benchmarks runner release event."
+              exit 1
+              ;;
+          esac
+
       - name: Resolve deploy ref
         id: input
         env:

--- a/runner/tests/unit/test_runner_release_workflow.py
+++ b/runner/tests/unit/test_runner_release_workflow.py
@@ -1,0 +1,51 @@
+import pathlib
+import textwrap
+
+_REPOSITORY_ROOT = pathlib.Path(__file__).resolve().parents[3]
+_WORKFLOW_PATH = _REPOSITORY_ROOT / ".github" / "workflows" / "runner-release.yml"
+
+
+def _step_script(workflow: str, step_name: str) -> str:
+    step_marker = f"      - name: {step_name}\n"
+    step_start = workflow.find(step_marker)
+    if step_start < 0:
+        raise AssertionError(f"Workflow step not found: {step_name}")
+
+    run_marker = "        run: |\n"
+    script_start = workflow.find(run_marker, step_start)
+    if script_start < 0:
+        raise AssertionError(f"Workflow script not found: {step_name}")
+
+    content_start = script_start + len(run_marker)
+    next_step = workflow.find("\n      - name:", content_start)
+    script = workflow[content_start:] if next_step < 0 else workflow[content_start:next_step]
+    return textwrap.dedent(script)
+
+
+def test_switchboard_dispatch_accepts_only_the_mapped_production_environment() -> None:
+    script = _step_script(_WORKFLOW_PATH.read_text(), "Validate release environment")
+
+    assert "repository_dispatch)" in script
+    assert 'if [ "$DISPATCH_ENVIRONMENT" != "production" ]; then' in script
+    assert "Benchmarks runner release environment must be production" in script
+
+
+def test_manual_production_release_remains_supported() -> None:
+    script = _step_script(_WORKFLOW_PATH.read_text(), "Validate release environment")
+
+    assert "workflow_dispatch) ;;" in script
+
+
+def test_unknown_release_event_fails_closed() -> None:
+    script = _step_script(_WORKFLOW_PATH.read_text(), "Validate release environment")
+
+    assert "*)" in script
+    assert "Unsupported Benchmarks runner release event" in script
+
+
+def test_environment_validation_precedes_checkout() -> None:
+    workflow = _WORKFLOW_PATH.read_text()
+
+    assert workflow.index("- name: Validate release environment") < workflow.index(
+        "- name: Checkout repository"
+    )


### PR DESCRIPTION
## Summary

- require the Switchboard-mapped production value for Benchmarks runner repository dispatches
- preserve the existing manual production-only workflow_dispatch path
- reject unknown events and validate before checkout, image builds, credentials, or infra dispatch

Follow-up consumer hardening for coval-ai/ci-cd-switchboard#485. The production-runner marker and production Artifact Registry resources are unchanged.

## Validation

- uv run --directory runner --frozen pytest tests/unit/test_runner_release_workflow.py -q — 4 passed
- uv run --directory runner --frozen ruff check tests/unit/test_runner_release_workflow.py
- uv run --directory runner --frozen ruff format --check tests/unit/test_runner_release_workflow.py
- actionlint .github/workflows/runner-release.yml
- git diff --check origin/main...HEAD

No release, image publication, or infra dispatch was triggered.