### PR TITLE
Add Cartesia sonic-preview in early access

### DIFF
--- a/runner/src/coval_bench/providers/tts/cartesia.py
+++ b/runner/src/coval_bench/providers/tts/cartesia.py
@@ -29,7 +29,7 @@ OUTPUT_FORMAT: dict[str, Any] = {
 class CartesiaTTSProvider(TTSProvider):
     """Cartesia TTS provider using WebSocket streaming (cartesia SDK v2)."""
 
-    _VALID_MODELS = frozenset({"sonic-3", "sonic-3.5"})
+    _VALID_MODELS = frozenset({"sonic-3", "sonic-3.5", "sonic-preview"})
 
     def __init__(self, settings: Settings, model: str, voice: str) -> None:
         self._model = model

--- a/runner/src/coval_bench/registries/models.py
+++ b/runner/src/coval_bench/registries/models.py
@@ -589,6 +589,32 @@ MODEL_REGISTRY: list[RegisteredModel] = [
     ),
     RegisteredModel(
         benchmark=_TTS,
+        provider="cartesia",
+        # Rolling pointer to Cartesia's next unreleased model; rename to the
+        # GA model id before promoting past EARLY_ACCESS.
+        model="sonic-preview",
+        voice="db6b0ed5-d5d3-463d-ae85-518a07d3c2b4",
+        voices=(
+            Voice(
+                id="db6b0ed5-d5d3-463d-ae85-518a07d3c2b4",
+                gender=Gender.FEMALE,
+                name="Skylar",
+                accent="en-US",
+            ),
+            Voice(
+                id="30894953-bcce-41fe-892c-15ce19c843ff",
+                gender=Gender.MALE,
+                name="Parker",
+                accent="en-US",
+            ),
+        ),
+        tags=(_STREAMING, _MULTI, _CLONE, _EMOTION, _STREAM),
+        on_prem=True,
+        region="us",
+        status=_EARLY_ACCESS,
+    ),
+    RegisteredModel(
+        benchmark=_TTS,
         provider="deepgram",
         model="aura-2-thalia-en",
         voice="aura-2-thalia-en",

--- a/runner/tests/providers/tts/test_cartesia.py
+++ b/runner/tests/providers/tts/test_cartesia.py
@@ -101,6 +101,15 @@ def test_cartesia_supports_sonic_3_5(fake_settings: Settings) -> None:
     assert p._model_supported("sonic-3.5")
 
 
+def test_cartesia_supports_sonic_preview(fake_settings: Settings) -> None:
+    """sonic-preview (the early-access entry) must pass the model-support guard."""
+    p = CartesiaTTSProvider(
+        fake_settings, model="sonic-preview", voice="db6b0ed5-d5d3-463d-ae85-518a07d3c2b4"
+    )
+    assert p.name == "cartesia-sonic-preview"
+    assert p._model_supported("sonic-preview")
+
+
 # ---------------------------------------------------------------------------
 # Missing API key
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Add cartesias preview in early access

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds Cartesia’s rolling `sonic-preview` model as an early-access TTS benchmark.
- Registers the model with the existing Skylar and Parker voice pool and Cartesia capability metadata.
- Allows the provider to send `sonic-preview` as the Cartesia model identifier.
- Adds a unit test covering model support and provider naming.

<h3>Confidence Score: 5/5</h3>

The pull request appears safe to merge with no actionable defects identified.

The model registration, provider allowlist, voice assignment, and early-access behavior are consistent with existing Cartesia and registry contracts.

<sub>Reviews (1): Last reviewed commit: ["Add Cartesia sonic-preview in early acce..."](https://github.com/coval-ai/benchmarks/commit/f1fadc0c9087b753cad0518202f806fcd7a12c85) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54113636)</sub>

**Context used:**

- Knowledge Base — [Runner Orchestration](https://app.greptile.com/coval/-/custom-context/knowledge-base/coval-ai/benchmarks/-/docs/runner-orchestration.md)

<!-- /greptile_comment -->