### PR TITLE
Swap Deepdub voice pool to Alice Sanders and Peter Jenkins

### DIFF
--- a/runner/src/coval_bench/registries/models.py
+++ b/runner/src/coval_bench/registries/models.py
@@ -1047,15 +1047,15 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         status=_ACTIVE,
     ),
     # Deepdub eTTS. Voices are preset voice-prompt ids from Deepdub's docs:
-    # the female sales-agent and male call-center-agent presets.
+    # Alice Sanders (female) and Peter Jenkins (male).
     RegisteredModel(
         benchmark=_TTS,
         provider="deepdub",
         model="dd-etts-3.3",
-        voice="02215cf5-04af-46f3-a061-48a4c81989bf",
+        voice="f60bad7d-1667-42ff-8410-e60b71d0cc34",
         voices=(
-            Voice(id="02215cf5-04af-46f3-a061-48a4c81989bf", gender=Gender.FEMALE),
-            Voice(id="b2abb241-ac92-48bf-a890-fec03f43e209", gender=Gender.MALE),
+            Voice(id="f60bad7d-1667-42ff-8410-e60b71d0cc34", gender=Gender.FEMALE),
+            Voice(id="2448b68c-b253-4243-88a5-38b7cc9a1f0d", gender=Gender.MALE),
         ),
         tags=(_STREAMING, _MULTI, _CLONE, _EMOTION, _STREAM),
         region="us",

--- a/runner/tests/providers/tts/test_deepdub.py
+++ b/runner/tests/providers/tts/test_deepdub.py
@@ -19,7 +19,7 @@ from coval_bench.providers.tts.deepdub import SAMPLE_RATE, DeepdubTTSProvider
 from .conftest import FakeWebSocket, make_pcm_bytes
 
 _MODEL = "dd-etts-3.3"
-_VOICE = "02215cf5-04af-46f3-a061-48a4c81989bf"
+_VOICE = "f60bad7d-1667-42ff-8410-e60b71d0cc34"
 
 
 def _settings(**overrides: object) -> Settings:


### PR DESCRIPTION
Deepdub asked us to replace the dd-etts-3.3 preset voices with Alice Sanders (female) and Peter Jenkins (male).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updates the Deepdub `dd-etts-3.3` voice pool to Alice Sanders and Peter Jenkins and aligns the provider test fixture with the new default female voice.
- Replaces the registry’s female and male Deepdub preset IDs.
- Changes the scalar fallback voice to Alice Sanders.
- Updates mocked Deepdub request expectations for the new default voice.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the registry and Deepdub provider test consistently updated for the requested voice-pool replacement.

The new voice IDs preserve the existing registry shape and flow unchanged through the established voice-assignment and Deepdub request paths, with no concrete changed-code failure established.

<sub>Reviews (1): Last reviewed commit: ["Swap Deepdub voice pool to Alice Sanders..."](https://github.com/coval-ai/benchmarks/commit/d67fae22cabfc3f1af75c6204b3951249351c116) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54407228)</sub>

<!-- /greptile_comment -->