### PR TITLE
Request 24 kHz audio from Fish Audio, MiniMax, and Groq TTS

### DIFF
--- a/runner/src/coval_bench/providers/tts/fishaudio.py
+++ b/runner/src/coval_bench/providers/tts/fishaudio.py
@@ -25,7 +25,7 @@ logger: structlog.BoundLogger = structlog.get_logger(__name__)
 
 _VALID_MODELS = ("s1", "s2.1-pro", "s2.1-pro-free")
 _WS_URL = "wss://api.fish.audio/v1/tts/live"
-_SAMPLE_RATE = 44100
+_SAMPLE_RATE = 24000
 _MAX_WS_SIZE = 16 * 1024 * 1024
 
 

--- a/runner/src/coval_bench/providers/tts/groq.py
+++ b/runner/src/coval_bench/providers/tts/groq.py
@@ -37,7 +37,7 @@ _MAX_INPUT_CHARS = 200
 
 _API_BASE_URL = "https://api.groq.com/openai/v1"
 _HOST_BASE_URL = "https://api.groq.com"
-_FALLBACK_SAMPLE_RATE = 24000
+_SAMPLE_RATE = 24000
 
 
 class GroqTTSProvider(TTSProvider):
@@ -93,7 +93,7 @@ class GroqTTSProvider(TTSProvider):
                 model=self._model,
                 voice=self._voice,
                 pcm=b"",
-                sample_rate=_FALLBACK_SAMPLE_RATE,
+                sample_rate=_SAMPLE_RATE,
                 audio_synthesis_start=None,
                 first_audio_chunk_at=None,
                 error=(
@@ -116,6 +116,8 @@ class GroqTTSProvider(TTSProvider):
                 voice=self._voice,
                 input=text,
                 response_format="wav",
+                # Groq extension; the WAV header stays authoritative at decode.
+                extra_body={"sample_rate": _SAMPLE_RATE},
             ) as response:
                 http_version = response.http_version
                 setup_ms = submit_to_headers_ms(response.http_response.request)
@@ -132,7 +134,7 @@ class GroqTTSProvider(TTSProvider):
                 model=self._model,
                 voice=self._voice,
                 pcm=b"",
-                sample_rate=_FALLBACK_SAMPLE_RATE,
+                sample_rate=_SAMPLE_RATE,
                 audio_synthesis_start=start,
                 first_audio_chunk_at=first_chunk_at,
                 error=str(exc),
@@ -159,7 +161,7 @@ class GroqTTSProvider(TTSProvider):
 
 def _wav_to_pcm(data: bytes) -> tuple[bytes, int, str | None]:
     if not data:
-        return b"", _FALLBACK_SAMPLE_RATE, "no audio bytes received from Groq"
+        return b"", _SAMPLE_RATE, "no audio bytes received from Groq"
     try:
         with wave.open(io.BytesIO(data), "rb") as wf:
             sample_rate = wf.getframerate()
@@ -167,7 +169,7 @@ def _wav_to_pcm(data: bytes) -> tuple[bytes, int, str | None]:
             n_channels = wf.getnchannels()
             pcm = wf.readframes(wf.getnframes())
     except (wave.Error, EOFError) as exc:
-        return b"", _FALLBACK_SAMPLE_RATE, f"Groq returned non-WAV audio: {exc}"
+        return b"", _SAMPLE_RATE, f"Groq returned non-WAV audio: {exc}"
     if n_channels != 1 or sampwidth != 2:
         return (
             b"",

--- a/runner/src/coval_bench/providers/tts/minimax.py
+++ b/runner/src/coval_bench/providers/tts/minimax.py
@@ -30,7 +30,7 @@ logger: structlog.BoundLogger = structlog.get_logger(__name__)
 
 _VALID_MODELS = ("speech-2.8-hd", "speech-2.8-turbo")
 _WS_URL = "wss://api.minimax.io/ws/v1/t2a_v2"
-_SAMPLE_RATE = 44100
+_SAMPLE_RATE = 24000
 _MAX_WS_SIZE = 16 * 1024 * 1024
 
 

--- a/runner/tests/providers/tts/test_fishaudio.py
+++ b/runner/tests/providers/tts/test_fishaudio.py
@@ -104,7 +104,7 @@ async def test_fishaudio_tts_sends_start_text_stop(fishaudio_settings: Settings)
     assert sent[0]["event"] == "start"
     request = sent[0]["request"]
     assert request["format"] == "pcm"
-    assert request["sample_rate"] == 44100
+    assert request["sample_rate"] == 24000
     assert request["reference_id"] == _VOICE
     assert request["latency"] == "balanced"
     assert request["features"] == ["quality-guard"]

--- a/runner/tests/providers/tts/test_groq.py
+++ b/runner/tests/providers/tts/test_groq.py
@@ -95,6 +95,7 @@ async def test_groq_request_uses_wav_format(fake_settings: Settings) -> None:
     assert kwargs["voice"] == "daniel"
     assert kwargs["input"] == "Hello from Orpheus"
     assert kwargs["response_format"] == "wav"
+    assert kwargs["extra_body"] == {"sample_rate": 24000}
     if result.audio_path:
         result.audio_path.unlink()
 

--- a/runner/tests/providers/tts/test_minimax.py
+++ b/runner/tests/providers/tts/test_minimax.py
@@ -106,7 +106,7 @@ async def test_minimax_tts_sends_start_continue_finish(minimax_settings: Setting
     assert sent[0]["event"] == "task_start"
     assert sent[0]["model"] == "speech-2.8-hd"
     assert sent[0]["voice_setting"] == {"voice_id": _VOICE}
-    assert sent[0]["audio_setting"] == {"format": "pcm", "sample_rate": 44100, "channel": 1}
+    assert sent[0]["audio_setting"] == {"format": "pcm", "sample_rate": 24000, "channel": 1}
     assert sent[1] == {"event": "task_continue", "text": "Hello world"}
     assert sent[2] == {"event": "task_finish"}
     if result.audio_path is not None:


### PR DESCRIPTION
Aligns their delivery with the 24 kHz the rest of the TTS fleet uses; Gradium (fixed 48 kHz) and Rime mistv3 (22.05 kHz native) remain exceptions.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR aligns Fish Audio, MiniMax, and Groq TTS requests with the fleet’s 24 kHz audio convention.
- Changes Fish Audio and MiniMax WebSocket request and PCM-finalization rates from 44.1 kHz to 24 kHz.
- Adds a 24 kHz sample-rate extension to Groq’s streaming speech request while retaining WAV-header-based decoding.
- Updates Fish Audio and MiniMax request-shape tests for the new rate.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with the non-blocking omission that Groq’s newly added sample-rate request field is not covered by its request-shape test.

Fish Audio and MiniMax consistently use 24 kHz in their requests and PCM finalization, while Groq continues to decode according to the returned WAV header; only regression coverage for Groq’s new request option is missing.

**Files Needing Attention:** runner/src/coval_bench/providers/tts/groq.py and runner/tests/providers/tts/test_groq.py

<sub>Reviews (1): Last reviewed commit: ["Request 24 kHz audio from Fish Audio, Mi..."](https://github.com/coval-ai/benchmarks/commit/9bb8406aa0da23676d0193c9d61847ced16eb442) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54422039)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Runner Orchestration](https://app.greptile.com/coval/-/custom-context/knowledge-base/coval-ai/benchmarks/-/docs/runner-orchestration.md)

<!-- /greptile_comment -->