### PR TITLE
Keep non-publishing agents out of sample completeness

### DIFF
--- a/runner/src/coval_bench/s2s/fetch_v2v.py
+++ b/runner/src/coval_bench/s2s/fetch_v2v.py
@@ -603,6 +603,15 @@ async def _ingest_run(
         return RunStatus.FAILED
 
 
+def _expected_sample_models(settings: Settings) -> set[tuple[str, str]]:
+    """The pairs a sample must cover; a bucket short one publishes nothing."""
+    return {
+        (spec.provider, spec.model)
+        for spec in AGENTS
+        if getattr(settings, spec.agent_id_attr) and spec.publish_samples
+    }
+
+
 async def _fetch_one_provider(
     client: httpx.AsyncClient,
     writer: RunWriter,
@@ -866,11 +875,7 @@ async def fetch_and_write_v2v(settings: Settings | None = None) -> dict[str, Run
                 logger.warning("refresh_stats_matviews_failed", exc_info=True)
 
         if settings.s2s_samples_bucket and sampled_runs and test_set_id:
-            expected = {
-                (spec.provider, spec.model)
-                for spec in AGENTS
-                if getattr(settings, spec.agent_id_attr)
-            }
+            expected = _expected_sample_models(settings)
             missing = expected - {r.key for r in sampled_runs}
             if missing:
                 # Error level on purpose: this is the alert that a model is

--- a/runner/tests/unit/test_s2s_fetch.py
+++ b/runner/tests/unit/test_s2s_fetch.py
@@ -114,6 +114,19 @@ async def _fetch(client: httpx.AsyncClient, writer: MagicMock) -> tuple[RunStatu
     )
 
 
+def test_expected_sample_models_excludes_non_publishing_agents() -> None:
+    settings = Settings.model_construct(
+        coval_s2s_openai_agent_id="a1",
+        coval_s2s_gray_agent_id="a2",
+        coval_s2s_red_agent_id="a3",
+    )
+    expected = fetch_v2v._expected_sample_models(settings)
+
+    assert ("openai", "gpt-realtime") in expected
+    assert ("colors", "gray") not in expected
+    assert ("colors", "red") not in expected
+
+
 def test_bucket_start_floors_to_grid() -> None:
     at = datetime(2026, 7, 7, 4, 59, 59, tzinfo=UTC)
     assert fetch_v2v._bucket_start(at, 10_800) == datetime(2026, 7, 7, 3, tzinfo=UTC)


### PR DESCRIPTION
A bucket short a model publishes nothing, and the pre-launch agents never appear in a sample by design, so counting them would have stopped the samples card the moment their ids were configured.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR aligns S2S sample-completeness checks with sample eligibility so configured pre-launch agents cannot block publication.
- Adds a helper that includes only configured agents marked `publish_samples=True` in the expected model set.
- Adds unit coverage confirming non-publishing color agents are excluded.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

Non-publishing agents are consistently excluded both when collecting sample candidates and when checking model completeness.

<sub>Reviews (1): Last reviewed commit: ["Keep non-publishing agents out of sample..."](https://github.com/coval-ai/benchmarks/commit/0a590ec42f2c3a3b39e38ae3813c00d3ec7de738) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54522374)</sub>

**Context used:**

- Knowledge Base — [Runner Orchestration](https://app.greptile.com/coval/-/custom-context/knowledge-base/coval-ai/benchmarks/-/docs/runner-orchestration.md)

<!-- /greptile_comment -->