### PR TITLE
Exclusive access

### DIFF
--- a/runner/src/coval_bench/api/clerk.py
+++ b/runner/src/coval_bench/api/clerk.py
@@ -4,8 +4,8 @@
 """Resolve a Clerk session token to the embargoed models its holder may see.
 
 Verified against the instance JWKS (public — no secret involved). A mapped
-``org_id`` scopes the caller to its provider — even for coval.dev emails, so
-switching into a partner org previews exactly their view. Outside a mapped
+``org_id`` scopes the caller to what its entry names — even for coval.dev emails,
+so switching into a partner org previews exactly their view. Outside a mapped
 org, a coval.dev ``email`` sees everything.
 """
 
@@ -31,27 +31,123 @@ def _jwks(issuer: str) -> jwt.PyJWKClient:
     return jwt.PyJWKClient(f"{issuer}/.well-known/jwks.json")
 
 
-@functools.lru_cache(maxsize=1)
-def _parse_org_providers(raw: str) -> Mapping[str, str]:
-    """Parse the ``{org_id: provider}`` settings blob; a malformed blob maps nothing."""
+@functools.lru_cache(maxsize=2)
+def _parse_org_entries(raw: str) -> Mapping[str, tuple[str, ...]]:
+    """Parse the ``{org_id: "provider" | ["provider/model", ...]}`` settings blob.
+
+    A malformed entry is dropped rather than guessed at, so a bad deploy narrows a
+    view instead of widening one.
+    """
     try:
         parsed = json.loads(raw)
     except json.JSONDecodeError:
         logger.error("clerk_org_providers_unparsable")
         return {}
-    if not isinstance(parsed, dict) or not all(
-        isinstance(key, str) and isinstance(value, str) for key, value in parsed.items()
-    ):
+    if not isinstance(parsed, dict):
         logger.error("clerk_org_providers_malformed")
         return {}
-    return parsed
+    table: dict[str, tuple[str, ...]] = {}
+    for org_id, value in parsed.items():
+        entries = [value] if isinstance(value, str) else value
+        if (
+            not isinstance(org_id, str)
+            or not isinstance(entries, list)
+            or not all(isinstance(entry, str) and entry for entry in entries)
+        ):
+            logger.error("clerk_org_providers_malformed")
+            if isinstance(org_id, str):
+                table[org_id] = ()
+            continue
+        table[org_id] = tuple(entries)
+    return table
 
 
-def _org_provider(claims: dict[str, Any], settings: Settings) -> str | None:
+@functools.lru_cache(maxsize=2)
+def _parse_exclusive(raw: str) -> Mapping[str, tuple[str, ...]] | None:
+    """As ``_parse_org_entries``, but ``None`` when the blob itself is unusable."""
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        logger.error("clerk_org_exclusive_unparsable")
+        return None
+    if not isinstance(parsed, dict):
+        logger.error("clerk_org_exclusive_malformed")
+        return None
+    return _parse_org_entries(raw)
+
+
+def _org_unlocked(
+    claims: dict[str, Any], settings: Settings, embargoed: frozenset[tuple[str, str]]
+) -> frozenset[tuple[str, str]] | None:
+    """The pairs this token's org unlocks, or ``None`` when its org is unmapped.
+
+    An entry is a whole provider, or one ``provider/model`` pair. A mapped org that
+    names nothing unlocks nothing, which is distinct from being unmapped.
+    """
     org_id = claims.get("org_id")
     if not isinstance(org_id, str) or settings.clerk_org_providers is None:
         return None
-    return _parse_org_providers(settings.clerk_org_providers).get(org_id)
+    entries = _parse_org_entries(settings.clerk_org_providers).get(org_id)
+    if entries is None:
+        return None
+    return _expand(entries, embargoed, org_id=org_id, scope="providers")
+
+
+def _expand(
+    entries: tuple[str, ...],
+    universe: frozenset[tuple[str, str]],
+    *,
+    org_id: str,
+    scope: str,
+) -> frozenset[tuple[str, str]]:
+    """The pairs of *universe* that *entries* name, by provider or provider/model.
+
+    An entry naming nothing is a typo or a retired model, and silently grants zero,
+    so it is logged with the org it came from. Never log the token itself.
+    """
+    named: set[tuple[str, str]] = set()
+    for entry in entries:
+        provider, sep, model = entry.partition("/")
+        matched = {
+            pair for pair in universe if (pair == (provider, model) if sep else pair[0] == provider)
+        }
+        if not matched:
+            logger.warning("clerk_org_entry_unmatched", org_id=org_id, entry=entry, scope=scope)
+        named |= matched
+    return frozenset(named)
+
+
+def exclusive_pairs(
+    authorization: str, settings: Settings, universe: frozenset[tuple[str, str]]
+) -> frozenset[tuple[str, str]] | None:
+    """The only pairs this token's org may see, or ``None`` when it is not exclusive.
+
+    An exclusive org sees nothing else at all, public models included, so this is
+    resolved against every known pair rather than against the embargoed ones.
+    """
+    if settings.clerk_org_exclusive is None:
+        return None
+    scheme, _, token = authorization.partition(" ")
+    if scheme.lower() != "bearer" or not token.strip():
+        return None
+    claims = _claims(token.strip(), settings)
+    if claims is None:
+        return None
+    org_id = claims.get("org_id")
+    if not isinstance(org_id, str):
+        return None
+    table = _parse_exclusive(settings.clerk_org_exclusive)
+    if table is None:
+        # Configured but unusable. Denying every org-bearing token is deliberate: the
+        # blob is what says who is restricted, so without it we cannot tell, and
+        # serving ordinary visibility would be the one unrecoverable answer. Startup
+        # validation in Settings should make this unreachable.
+        logger.error("clerk_org_exclusive_denied_all")
+        return frozenset()
+    entries = table.get(org_id)
+    if entries is None:
+        return None
+    return _expand(entries, universe, org_id=org_id, scope="exclusive")
 
 
 def _claims(token: str, settings: Settings) -> dict[str, Any] | None:
@@ -90,9 +186,9 @@ def allowed_pairs(
     claims = _claims(token.strip(), settings)
     if claims is None:
         return None
-    provider = _org_provider(claims, settings)
-    if provider is not None:
-        return frozenset(pair for pair in embargoed if pair[0] == provider)
+    org_unlocked = _org_unlocked(claims, settings, embargoed)
+    if org_unlocked is not None:
+        return org_unlocked
     email = claims.get("email")
     if isinstance(email, str) and email.endswith(_INTERNAL_EMAIL_SUFFIX):
         return embargoed

--- a/runner/src/coval_bench/api/internal.py
+++ b/runner/src/coval_bench/api/internal.py
@@ -82,6 +82,15 @@ def with_retired_keys(allowed: frozenset[tuple[str, str]]) -> frozenset[tuple[st
     )
 
 
+def all_registered_pairs() -> frozenset[tuple[str, str]]:
+    """Every pair the registry knows, embargoed or not, plus the retired keys.
+
+    The universe an exclusive org's view is subtracted from. A pair that was never
+    registered cannot be subtracted, so it stays visible.
+    """
+    return frozenset((m.provider, m.model) for m in MODEL_REGISTRY) | frozenset(_RETIRED_BOARD_KEYS)
+
+
 def hidden_models() -> frozenset[tuple[str, str]]:
     """The pairs public API responses must not contain."""
     return embargoed_pairs()
@@ -181,6 +190,17 @@ def hidden_early_access(
         return frozenset()
 
     embargoed = embargoed_pairs()
+
+    # Exclusive orgs are resolved first and never widened: an X-EA-Token must not
+    # add to a view whose whole point is what it leaves out.
+    if authorization is not None and settings.clerk_issuer is not None:
+        universe = all_registered_pairs()
+        only = clerk.exclusive_pairs(authorization, settings, universe)
+        if only is not None:
+            response.headers[EA_STATUS_HEADER] = "accepted"
+            response.headers["Cache-Control"] = "private, no-store"
+            return universe - with_retired_keys(only)
+
     unlocked: frozenset[tuple[str, str]] | None = None
     if x_ea_token is not None:
         allowed = _allowed_for(x_ea_token, _allowlists(settings))

--- a/runner/src/coval_bench/config.py
+++ b/runner/src/coval_bench/config.py
@@ -11,6 +11,7 @@ Every other module that needs configuration imports from here:
 from __future__ import annotations
 
 import functools
+import json
 from pathlib import Path
 from typing import Literal, get_args
 
@@ -203,10 +204,49 @@ class Settings(BaseSettings):
     clerk_issuer: str | None = None
     # Allowed azp claim values; bearer tokens are rejected while empty.
     clerk_authorized_parties: list[str] = []
-    # Clerk org id -> provider id, as a JSON object: {"org_abc123": "deepgram"}.
-    # Keyed by the immutable org id, not the slug, which org admins can rename.
-    # An org missing from the map unlocks nothing.
+    # Clerk org id -> what it unlocks, as a JSON object. A value is a provider or a
+    # list of providers and provider/model pairs: {"org_abc": "deepgram"},
+    # {"org_def": ["colors/gray", "colors/red"]}. Keyed by the immutable org id, not
+    # the slug, which org admins can rename. An org missing from the map unlocks
+    # nothing.
     clerk_org_providers: str | None = None
+    # Clerk org id -> the ONLY models it may see, as a JSON object:
+    # {"org_abc": ["colors"]} or {"org_abc": ["colors/gray"]}. Same entry grammar as
+    # clerk_org_providers, but exclusive: everything else, public models included, is
+    # hidden from that org. Overrides clerk_org_providers for the same org.
+    clerk_org_exclusive: str | None = None
+
+    @field_validator("clerk_org_exclusive")
+    @classmethod
+    def _exclusive_map_is_usable(cls, value: str | None) -> str | None:
+        """Refuse to start on an unusable exclusive map.
+
+        The additive maps fall back to the public view when malformed, which is safe
+        because they only ever widen. This one only ever narrows, so a broken blob
+        must not boot into ordinary visibility for the orgs it was meant to restrict.
+        """
+        if value is None:
+            return None
+        try:
+            parsed = json.loads(value)
+        except json.JSONDecodeError as exc:
+            raise ValueError("clerk_org_exclusive is not valid JSON") from exc
+        if not isinstance(parsed, dict) or not all(
+            isinstance(org_id, str)
+            and org_id
+            and (
+                (isinstance(entries, str) and entries)
+                or (
+                    isinstance(entries, list)
+                    and all(isinstance(entry, str) and entry for entry in entries)
+                )
+            )
+            for org_id, entries in parsed.items()
+        ):
+            raise ValueError(
+                'clerk_org_exclusive must be {"org_id": "provider" | ["provider/model", ...]}'
+            )
+        return value
 
     # --- Arena ---
     arena_labeler_key: SecretStr | None = None

--- a/runner/tests/api/test_clerk_scope.py
+++ b/runner/tests/api/test_clerk_scope.py
@@ -19,10 +19,13 @@ import pytest
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 from fastapi import Response
+from pydantic import ValidationError
+from structlog.testing import capture_logs
 
 from coval_bench.api import clerk
 from coval_bench.api.internal import (
     EA_STATUS_HEADER,
+    all_registered_pairs,
     embargoed_pairs,
     hidden_early_access,
     with_retired_keys,
@@ -56,6 +59,7 @@ def _settings(
     parties: str | None = f'["{_PARTY}"]',
     ea_tokens: str | None = None,
     org_providers: str | None = None,
+    org_exclusive: str | None = None,
 ) -> Settings:
     monkeypatch.setenv("DATABASE_URL", "postgresql://runner:password@localhost:5432/benchmarks")
     monkeypatch.setenv("DATASET_BUCKET", "test-bucket")
@@ -70,6 +74,10 @@ def _settings(
         monkeypatch.delenv("CLERK_ORG_PROVIDERS", raising=False)
     else:
         monkeypatch.setenv("CLERK_ORG_PROVIDERS", org_providers)
+    if org_exclusive is None:
+        monkeypatch.delenv("CLERK_ORG_EXCLUSIVE", raising=False)
+    else:
+        monkeypatch.setenv("CLERK_ORG_EXCLUSIVE", org_exclusive)
     if issuer is None:
         monkeypatch.delenv("CLERK_ISSUER", raising=False)
     else:
@@ -131,6 +139,195 @@ def test_org_sees_its_own_providers_models_and_no_others(
     assert hidden == frozenset(pair for pair in embargoed_pairs() if pair[0] != mine)
     assert all(provider != mine for provider, _ in hidden)
     assert any(provider == theirs for provider, _ in hidden)
+
+
+def test_org_entry_can_name_one_model(monkeypatch: pytest.MonkeyPatch) -> None:
+    pair = sorted(embargoed_pairs())[0]
+    provider, model = pair
+    siblings = {p for p in embargoed_pairs() if p[0] == provider and p != pair}
+    if not siblings:
+        pytest.skip("no embargoed provider has two models")
+    settings = _settings(monkeypatch, org_providers=json.dumps({_ORG_ID: [f"{provider}/{model}"]}))
+    token = _mint({"org_id": _ORG_ID})
+    hidden, status = _resolve(settings, f"Bearer {token}")
+    assert status == "accepted"
+    assert pair not in hidden
+    assert siblings <= hidden
+
+
+def test_org_entry_list_of_one_provider_unlocks_all_its_models(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider = _embargoed_provider()
+    settings = _settings(monkeypatch, org_providers=json.dumps({_ORG_ID: [provider]}))
+    token = _mint({"org_id": _ORG_ID})
+    hidden, _ = _resolve(settings, f"Bearer {token}")
+    assert all(p != provider for p, _ in hidden)
+
+
+def test_mapped_org_naming_nothing_unlocks_nothing(monkeypatch: pytest.MonkeyPatch) -> None:
+    settings = _settings(monkeypatch, org_providers=json.dumps({_ORG_ID: []}))
+    token = _mint({"org_id": _ORG_ID, "email": _INTERNAL_EMAIL})
+    hidden, status = _resolve(settings, f"Bearer {token}")
+    assert status == "accepted"
+    assert hidden == with_retired_keys(embargoed_pairs())
+
+
+def test_malformed_org_entry_is_dropped(monkeypatch: pytest.MonkeyPatch) -> None:
+    provider = _embargoed_provider()
+    settings = _settings(monkeypatch, org_providers=json.dumps({_ORG_ID: [provider, 7]}))
+    token = _mint({"org_id": _ORG_ID, "email": "partner@example.com"})
+    hidden, _ = _resolve(settings, f"Bearer {token}")
+    assert hidden == with_retired_keys(embargoed_pairs())
+
+
+def _public_pair() -> tuple[str, str]:
+    """Any registered pair that is not embargoed, or skip."""
+    public = sorted(all_registered_pairs() - embargoed_pairs())
+    if not public:
+        pytest.skip("every registered model is embargoed")
+    return public[0]
+
+
+def test_exclusive_org_sees_only_its_own_provider(monkeypatch: pytest.MonkeyPatch) -> None:
+    provider = _embargoed_provider()
+    mine = {pair for pair in embargoed_pairs() if pair[0] == provider}
+    settings = _settings(monkeypatch, org_exclusive=json.dumps({_ORG_ID: [provider]}))
+    token = _mint({"org_id": _ORG_ID})
+    hidden, status = _resolve(settings, f"Bearer {token}")
+
+    assert status == "accepted"
+    assert not (mine & hidden)
+    assert _public_pair() in hidden
+    assert hidden == all_registered_pairs() - with_retired_keys(frozenset(mine))
+
+
+def test_exclusive_org_can_name_one_model(monkeypatch: pytest.MonkeyPatch) -> None:
+    provider, model = sorted(embargoed_pairs())[0]
+    settings = _settings(monkeypatch, org_exclusive=json.dumps({_ORG_ID: [f"{provider}/{model}"]}))
+    token = _mint({"org_id": _ORG_ID})
+    hidden, _ = _resolve(settings, f"Bearer {token}")
+
+    assert (provider, model) not in hidden
+    assert len(all_registered_pairs() - hidden) == 1
+
+
+def test_exclusive_wins_over_additive_for_the_same_org(monkeypatch: pytest.MonkeyPatch) -> None:
+    provider = _embargoed_provider()
+    settings = _settings(
+        monkeypatch,
+        org_providers=json.dumps({_ORG_ID: [provider]}),
+        org_exclusive=json.dumps({_ORG_ID: [provider]}),
+    )
+    token = _mint({"org_id": _ORG_ID})
+    hidden, _ = _resolve(settings, f"Bearer {token}")
+
+    assert _public_pair() in hidden
+
+
+def test_exclusive_overrides_a_coval_email(monkeypatch: pytest.MonkeyPatch) -> None:
+    provider = _embargoed_provider()
+    settings = _settings(monkeypatch, org_exclusive=json.dumps({_ORG_ID: [provider]}))
+    token = _mint({"org_id": _ORG_ID, "email": _INTERNAL_EMAIL})
+    hidden, _ = _resolve(settings, f"Bearer {token}")
+
+    assert _public_pair() in hidden
+
+
+def test_ea_token_cannot_widen_an_exclusive_org(monkeypatch: pytest.MonkeyPatch) -> None:
+    provider, model = sorted(embargoed_pairs())[0]
+    other = sorted(embargoed_pairs() - {(provider, model)})
+    if not other:
+        pytest.skip("only one embargoed model in the registry")
+    settings = _settings(
+        monkeypatch,
+        ea_tokens=json.dumps({"tok": [f"{other[0][0]}/{other[0][1]}"]}),
+        org_exclusive=json.dumps({_ORG_ID: [f"{provider}/{model}"]}),
+    )
+    token = _mint({"org_id": _ORG_ID})
+    hidden, _ = _resolve(settings, f"Bearer {token}", x_ea_token="tok")  # noqa: S106 - fake token
+
+    assert other[0] in hidden
+    assert (provider, model) not in hidden
+
+
+def test_unmapped_org_is_unaffected_by_the_exclusive_map(monkeypatch: pytest.MonkeyPatch) -> None:
+    provider = _embargoed_provider()
+    settings = _settings(monkeypatch, org_exclusive=json.dumps({"org_someone_else": [provider]}))
+    token = _mint({"email": _INTERNAL_EMAIL})
+    hidden, _ = _resolve(settings, f"Bearer {token}")
+
+    assert hidden == frozenset()
+
+
+@pytest.mark.parametrize(
+    "blob",
+    [
+        '{"org_x": ["colors"]',
+        '{"org_x": 7}',
+        '{"org_x": [""]}',
+        '{"org_x": ""}',
+        '{"": ["colors"]}',
+        '["colors"]',
+    ],
+)
+def test_unusable_exclusive_map_refuses_to_start(
+    monkeypatch: pytest.MonkeyPatch, blob: str
+) -> None:
+    with pytest.raises(ValidationError):
+        _settings(monkeypatch, org_exclusive=blob)
+
+
+def _unvalidated_settings(exclusive: str) -> Settings:
+    """Settings carrying a blob the field validator would have rejected."""
+    return Settings.model_construct(
+        clerk_issuer=_ISSUER,
+        clerk_authorized_parties=[_PARTY],
+        clerk_org_providers=None,
+        clerk_org_exclusive=exclusive,
+        early_access_tokens=None,
+    )
+
+
+def test_unparsable_exclusive_map_denies_instead_of_falling_back() -> None:
+    settings = _unvalidated_settings('{"org_x": ["colors"]')
+    token = _mint({"org_id": _ORG_ID, "email": _INTERNAL_EMAIL})
+    hidden, status = _resolve(settings, f"Bearer {token}")
+
+    assert status == "accepted"
+    assert hidden == all_registered_pairs()
+    assert _public_pair() in hidden
+
+
+def test_malformed_org_entry_in_exclusive_map_denies() -> None:
+    settings = _unvalidated_settings(json.dumps({_ORG_ID: [7]}))
+    token = _mint({"org_id": _ORG_ID})
+    hidden, _ = _resolve(settings, f"Bearer {token}")
+
+    assert hidden == all_registered_pairs()
+
+
+def test_unknown_exclusive_entry_grants_nothing_and_warns(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    settings = _settings(monkeypatch, org_exclusive=json.dumps({_ORG_ID: ["colours/gray"]}))
+    token = _mint({"org_id": _ORG_ID})
+    response = Response()
+    with capture_logs() as logs:
+        hidden = hidden_early_access(
+            response=response,
+            internal=False,
+            x_ea_token=None,
+            authorization=f"Bearer {token}",
+            settings=settings,
+        )
+
+    assert hidden == all_registered_pairs()
+    warned = [entry for entry in logs if entry["event"] == "clerk_org_entry_unmatched"]
+    assert [(entry["org_id"], entry["entry"], entry["scope"]) for entry in warned] == [
+        (_ORG_ID, "colours/gray", "exclusive")
+    ]
+    assert not any("Bearer" in str(entry) for entry in logs)
 
 
 def test_coval_email_sees_everything(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
Exclusive org access gated by specific models in the allowlist, no public visibility by default
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR extends Clerk organization early-access configuration from whole-provider grants to lists containing providers or individual provider/model pairs while retaining bare-provider compatibility.
- Adds fail-closed parsing for per-organization entry lists.
- Resolves each mapped organization to its exact embargoed model set.
- Adds tests for model-level grants, provider grants, empty mappings, and malformed entries.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no concrete blocking or non-blocking defects identified.

The new organization-entry parser fails closed for malformed entries, preserves mapped-versus-unmapped semantics, restricts model grants to existing embargoed pairs, and the request path continues expanding renamed-model aliases.

<sub>Reviews (1): Last reviewed commit: ["Let an org&#39;s early access name single mo..."](https://github.com/coval-ai/benchmarks/commit/9aba457cbe1ef3b9f221c259d4960f16c3a6352b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54522428)</sub>

<!-- /greptile_comment -->