### PR TITLE
Pause RevAI

### DIFF
--- a/runner/src/coval_bench/registries/models.py
+++ b/runner/src/coval_bench/registries/models.py
@@ -377,7 +377,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         tags=(_STREAMING, _KEYTERM),
         on_prem=True,
         region="us",
-        status=_ACTIVE,
+        status=_PAUSED,
     ),
     # Together AI serverless realtime endpoints (open-weight models).
     RegisteredModel(


### PR DESCRIPTION
We don't have the credits.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Marks RevAI Reverb as paused because provider credits are unavailable.
- Changes the RevAI Reverb registry status from active to paused.
- Prevents the scheduled benchmark runner from selecting this model while preserving its registry metadata and historical results.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because it makes the intended status-only change without introducing a functional defect.

RevAI Reverb remains registered but is no longer selected for scheduled benchmark runs, which directly addresses the unavailable-credit condition while preserving existing model identity and data.

<sub>Reviews (1): Last reviewed commit: ["Pause RevAI"](https://github.com/coval-ai/benchmarks/commit/e9a528d1e965d36f56713f1227b78af78bc7cfb6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54845131)</sub>

**Context used:**

- Knowledge Base — [Runner Orchestration](https://app.greptile.com/coval/-/custom-context/knowledge-base/coval-ai/benchmarks/-/docs/runner-orchestration.md)

<!-- /greptile_comment -->