### PR TITLE
Pause the MiniMax models

### DIFF
--- a/runner/src/coval_bench/registries/models.py
+++ b/runner/src/coval_bench/registries/models.py
@@ -978,7 +978,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         ),
         tags=(_STREAMING, _MULTI, _CLONE, _EMOTION, _STREAM),
         region="us",
-        status=_ACTIVE,
+        status=_PAUSED,
     ),
     RegisteredModel(
         benchmark=_TTS,
@@ -991,7 +991,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         ),
         tags=(_STREAMING, _MULTI, _CLONE, _EMOTION, _STREAM),
         region="us",
-        status=_ACTIVE,
+        status=_PAUSED,
     ),
     RegisteredModel(
         benchmark=_TTS,


### PR DESCRIPTION
The MiniMax account is out of credits: every item has failed with `[1008] insufficient balance` since 2026-07-18, and the last 20 prod runs (through run 19548 today) produced zero successes for either model.

Both models stay on the site but drop out of scheduled runs and the arena until the account is topped up.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR pauses both registered MiniMax TTS models because the provider account is out of credits.
- Excludes `speech-2.8-hd` and `speech-2.8-turbo` from scheduled benchmark runs.
- Excludes both models from new arena pairings while preserving their public registry presence and historical results.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because both intended MiniMax models are excluded from scheduled runs and new arena pairings while remaining publicly visible.

The registry status transition matches the established PAUSED contract and introduces no concrete blocking or non-blocking defect.

<sub>Reviews (1): Last reviewed commit: ["Pause the MiniMax models"](https://github.com/coval-ai/benchmarks/commit/1ab71d92df7fdcbbf4b9e51c28f5afa50856a82a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54850537)</sub>

**Context used:**

- Knowledge Base — [Runner Orchestration](https://app.greptile.com/coval/-/custom-context/knowledge-base/coval-ai/benchmarks/-/docs/runner-orchestration.md)

<!-- /greptile_comment -->