### PR TITLE
[BENCH-703] Add normalized STT and TTS dual writes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,8 @@ POSTGRES_DB=benchmarks
 
 # --- Runner / dataset ---
 DATASET_BUCKET=coval-benchmarks-datasets
+BENCHMARK_ARTIFACT_BUCKET=
+NORMALIZED_DUAL_WRITE_ENABLED=false
 DATASET_ID=stt-v1
 RUNNER_SHA=local
 LOG_LEVEL=INFO

--- a/runner/README.md
+++ b/runner/README.md
@@ -55,4 +55,8 @@ The web FE lives in the private `coval-ai/benchmarks-web` repo — run it agains
 
 All env vars are documented in `src/coval_bench/config.py`. Provider keys are optional; tests don't need them.
 
+Normalized observation dual writes are additive, private, and disabled by default.
+Set both `BENCHMARK_ARTIFACT_BUCKET` and `NORMALIZED_DUAL_WRITE_ENABLED=true` to
+enable the STT/TTS rollout; legacy result writes remain the source of truth.
+
 Apache-2.0.

--- a/runner/src/coval_bench/config.py
+++ b/runner/src/coval_bench/config.py
@@ -51,6 +51,11 @@ class Settings(BaseSettings):
     # --- Dataset ---
     dataset_bucket: str = "coval-benchmarks-datasets"
     dataset_id: str = "stt-v1"
+    # Private bucket for additive normalized observation artifacts. The rollout
+    # is deliberately fail-closed: enabling writes without a destination is an
+    # invalid deployment rather than a silent partial capture.
+    benchmark_artifact_bucket: str = ""
+    normalized_dual_write_enabled: bool = False
 
     @field_validator("dataset_id")
     @classmethod
@@ -58,6 +63,14 @@ class Settings(BaseSettings):
         if value == DATASET_ALL:
             raise ValueError(f"dataset_id {DATASET_ALL!r} is reserved for pooled aggregates")
         return value
+
+    @model_validator(mode="after")
+    def _normalized_dual_write_requires_bucket(self) -> Settings:
+        if self.normalized_dual_write_enabled and not self.benchmark_artifact_bucket:
+            raise ValueError(
+                "benchmark_artifact_bucket is required when normalized dual write is enabled"
+            )
+        return self
 
     # Items drawn at random per run from each manifest, shared across all
     # models for parity. Set >= manifest size to run everything.

--- a/runner/src/coval_bench/datasets/loader.py
+++ b/runner/src/coval_bench/datasets/loader.py
@@ -120,6 +120,7 @@ class DatasetItem(BaseModel):
     """A single STT benchmark item, ready for a provider."""
 
     path: Path  # local on-disk path after fetch
+    sample_id: str = Field(min_length=1)
     transcript: str  # ground-truth transcript
     duration_sec: float
     sha256: str
@@ -138,7 +139,7 @@ class Dataset(BaseModel):
 class TTSDatasetItem(BaseModel):
     """A single TTS benchmark item (text-only, no audio to fetch)."""
 
-    testcase_id: str
+    testcase_id: str = Field(min_length=1)
     transcript: str
 
 
@@ -355,6 +356,7 @@ def load_stt_dataset(
         items.append(
             DatasetItem(
                 path=local_path,
+                sample_id=raw_item.sample_id or raw_item.path,
                 transcript=raw_item.transcript,
                 duration_sec=raw_item.duration_sec,
                 sha256=raw_item.sha256,

--- a/runner/src/coval_bench/datasets/manifest.py
+++ b/runner/src/coval_bench/datasets/manifest.py
@@ -66,7 +66,7 @@ class Manifest(BaseModel):
 
     @model_validator(mode="after")
     def items_consistent(self) -> Manifest:
-        """Ensure all items are the same concrete type."""
+        """Ensure items are homogeneous and have distinct effective identities."""
         if not self.items:
             return self
         first_type = type(self.items[0])
@@ -77,4 +77,17 @@ class Manifest(BaseModel):
                     f"expected all {first_type.__name__}, "
                     f"found {type(item).__name__}"
                 )
+
+        identities: set[str] = set()
+        for item in self.items:
+            if isinstance(item, STTManifestItem):
+                identity = item.sample_id or item.path
+            else:
+                identity = item.testcase_id
+            if identity in identities:
+                raise ValueError(
+                    f"Manifest '{self.id}' contains duplicate effective sample identity: "
+                    f"{identity!r}"
+                )
+            identities.add(identity)
         return self

--- a/runner/src/coval_bench/datasets/manifest.py
+++ b/runner/src/coval_bench/datasets/manifest.py
@@ -13,7 +13,7 @@ Schema matches ARCHITECTURE.md § "GCS dataset bucket — manifest.json schema".
 
 from __future__ import annotations
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 
 class STTManifestItem(BaseModel):
@@ -21,7 +21,8 @@ class STTManifestItem(BaseModel):
 
     model_config = ConfigDict(frozen=True)
 
-    path: str  # relative path, e.g. "audio/0001.wav"
+    path: str = Field(min_length=1)  # relative path, e.g. "audio/0001.wav"
+    sample_id: str | None = Field(default=None, min_length=1)
     sha256: str = Field(pattern=r"^[a-f0-9]{64}$")
     transcript: str
     duration_sec: float = Field(gt=0)
@@ -30,13 +31,20 @@ class STTManifestItem(BaseModel):
     utterance_id: str | None = None
     speech_end_offset_ms: float | None = Field(default=None, ge=0)
 
+    @field_validator("sample_id")
+    @classmethod
+    def _sample_id_not_empty(cls, value: str | None) -> str | None:
+        if value is not None and not value:
+            raise ValueError("sample_id must be non-empty when provided")
+        return value
+
 
 class TTSManifestItem(BaseModel):
     """A single TTS prompt entry in the manifest."""
 
     model_config = ConfigDict(frozen=True)
 
-    testcase_id: str
+    testcase_id: str = Field(min_length=1)
     transcript: str
 
 

--- a/runner/src/coval_bench/observation_artifacts.py
+++ b/runner/src/coval_bench/observation_artifacts.py
@@ -1,0 +1,117 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+"""Immutable private GCS artifacts for normalized benchmark observations."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import wave
+from pathlib import Path
+from typing import Any
+
+from google.api_core.exceptions import PreconditionFailed
+from google.cloud import storage
+
+from coval_bench.db.models import ObservationArtifact, ObservationArtifactType
+
+
+def _canonical_json(value: object) -> bytes:
+    return json.dumps(
+        value, sort_keys=True, separators=(",", ":"), ensure_ascii=False, allow_nan=False
+    ).encode()
+
+
+def _artifact_key(artifact_type: ObservationArtifactType, digest: str, extension: str) -> str:
+    return f"observation-artifacts/v1/{artifact_type}/{digest[:2]}/{digest}.{extension}"
+
+
+def _upload(
+    client: storage.Client,
+    bucket_name: str,
+    artifact_type: ObservationArtifactType,
+    payload: bytes,
+    *,
+    extension: str,
+    content_type: str,
+    schema_name: str,
+    duration_ms: float | None = None,
+) -> ObservationArtifact:
+    digest = hashlib.sha256(payload).hexdigest()
+    key = _artifact_key(artifact_type, digest, extension)
+    blob = client.bucket(bucket_name).blob(key)
+    blob.metadata = {"sha256": digest}
+    try:
+        blob.upload_from_string(payload, content_type=content_type, if_generation_match=0)
+    except PreconditionFailed:
+        blob.reload()
+        remote = blob.download_as_bytes()
+        if (
+            remote != payload
+            or blob.size != len(payload)
+            or blob.content_type != content_type
+            or (blob.metadata or {}).get("sha256") != digest
+        ):
+            raise ValueError(
+                "immutable artifact collision does not match expected content"
+            ) from None
+    return ObservationArtifact(
+        artifact_type=artifact_type,
+        schema_name=schema_name,
+        schema_version="v1",
+        gcs_uri=f"gs://{bucket_name}/{key}",
+        content_sha256=digest,
+        size_bytes=len(payload),
+        duration_ms=duration_ms,
+    )
+
+
+def upload_provider_transcript(
+    client: storage.Client, bucket_name: str, transcript: str
+) -> ObservationArtifact:
+    return _upload(
+        client,
+        bucket_name,
+        ObservationArtifactType.PROVIDER_TRANSCRIPT,
+        _canonical_json({"schema_version": "v1", "transcript": transcript}),
+        extension="json",
+        content_type="application/json",
+        schema_name="ProviderTranscript",
+    )
+
+
+def upload_timing_events(
+    client: storage.Client, bucket_name: str, events: dict[str, Any]
+) -> ObservationArtifact:
+    return _upload(
+        client,
+        bucket_name,
+        ObservationArtifactType.TIMING_EVENTS,
+        _canonical_json({"schema_version": "v1", "events": events}),
+        extension="json",
+        content_type="application/json",
+        schema_name="TimingEvents",
+    )
+
+
+def snapshot_generated_audio(path: Path) -> tuple[bytes, float]:
+    """Read a temporary WAV before yielding to asynchronous persistence work."""
+    payload = path.read_bytes()
+    with wave.open(str(path), "rb") as wav:
+        duration_ms = wav.getnframes() / wav.getframerate() * 1000
+    return payload, duration_ms
+
+
+def upload_generated_audio(
+    client: storage.Client, bucket_name: str, payload: bytes, duration_ms: float
+) -> ObservationArtifact:
+    return _upload(
+        client,
+        bucket_name,
+        ObservationArtifactType.GENERATED_AUDIO,
+        payload,
+        extension="wav",
+        content_type="audio/wav",
+        schema_name="GeneratedAudio",
+        duration_ms=duration_ms,
+    )

--- a/runner/src/coval_bench/runner/normalized.py
+++ b/runner/src/coval_bench/runner/normalized.py
@@ -1,0 +1,223 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+# ruff: noqa: ANN401 -- adapter composes lazy runtime collaborators from orchestrator.
+"""Best-effort additive persistence of legacy STT/TTS results."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Sequence
+from datetime import UTC, datetime
+from typing import Any
+
+from coval_bench.db.models import (
+    MetricEvaluation,
+    MetricEvaluationInput,
+    MetricExecutor,
+    MetricValue,
+    Observation,
+    ObservationArtifactType,
+    ObservationFailureOrigin,
+    ObservationSourceKind,
+    ObservationStatus,
+    ProcessingStatus,
+)
+from coval_bench.observation_artifacts import (
+    snapshot_generated_audio,
+    upload_generated_audio,
+    upload_provider_transcript,
+    upload_timing_events,
+)
+from coval_bench.registries import Metric
+
+
+def _inputs(metric: str, artifacts: dict[Any, Any], benchmark: Any) -> list[MetricEvaluationInput]:
+    """Freeze the raw artifact lineage used for one legacy metric."""
+    wanted: list[tuple[Any, str]]
+    if benchmark.value.upper() == "STT":
+        wanted = (
+            [(ObservationArtifactType.PROVIDER_TRANSCRIPT, "raw")]
+            if metric == Metric.WER
+            else [(ObservationArtifactType.TIMING_EVENTS, "timing")]
+        )
+    elif metric == Metric.WER:
+        wanted = [(ObservationArtifactType.GENERATED_AUDIO, "raw")]
+    elif metric == Metric.TTFA:
+        wanted = [
+            (ObservationArtifactType.TIMING_EVENTS, "timing"),
+            (ObservationArtifactType.GENERATED_AUDIO, "raw"),
+        ]
+    else:
+        wanted = [(ObservationArtifactType.TIMING_EVENTS, "timing")]
+    return [
+        MetricEvaluationInput(
+            observation_artifact_id=artifacts[kind], input_role=role, input_order=0
+        )
+        for kind, role in wanted
+        if artifacts.get(kind) is not None
+    ]
+
+
+def _values(metric: str, rows: Sequence[Any], evaluation_id: Any) -> list[MetricValue]:
+    primary = next(
+        row for row in rows if row.metric_value is not None and str(row.status) == "success"
+    )
+    values = [
+        MetricValue(
+            metric_evaluation_id=evaluation_id,
+            value_key="primary",
+            unit=primary.metric_units,
+            value=primary.metric_value,
+            value_role="primary",
+        )
+    ]
+    if metric == Metric.WER:
+        components = (
+            ("insertions", primary.wer_insertions_pct),
+            ("deletions", primary.wer_deletions_pct),
+            ("substitutions", primary.wer_substitutions_pct),
+        )
+        values.extend(
+            MetricValue(
+                metric_evaluation_id=evaluation_id, value_key=key, unit="percent", value=value
+            )
+            for key, value in components
+            if value is not None
+        )
+    if metric == Metric.TTFA:
+        component_rows = {str(row.metric_type): row for row in rows}
+        roundtrip = component_rows.get(str(Metric.TTFA_ROUNDTRIP))
+        silence = component_rows.get(str(Metric.TTFA_LEADING_SILENCE))
+        if (
+            roundtrip is not None
+            and silence is not None
+            and roundtrip.metric_value is not None
+            and silence.metric_value is not None
+        ):
+            values.extend(
+                (
+                    MetricValue(
+                        metric_evaluation_id=evaluation_id,
+                        value_key="roundtrip",
+                        unit="milliseconds",
+                        value=roundtrip.metric_value,
+                    ),
+                    MetricValue(
+                        metric_evaluation_id=evaluation_id,
+                        value_key="leading_silence",
+                        unit="milliseconds",
+                        value=silence.metric_value,
+                    ),
+                )
+            )
+    return values
+
+
+async def dual_write(
+    *,
+    writer: Any,
+    storage_client: Any,
+    bucket: str,
+    run_id: int,
+    dataset_id: str,
+    dataset_sha256: str,
+    sample_id: str,
+    entry: Any,
+    benchmark: Any,
+    results: Sequence[Any],
+    provider_error: str | None,
+    transcript: str | None = None,
+    timing_events: dict[str, Any] | None = None,
+    audio_path: Any = None,
+    voice: str | None = None,
+) -> None:
+    """Persist one observation and its grouped normalized evaluations."""
+    audio_snapshot = snapshot_generated_audio(audio_path) if audio_path is not None else None
+    artifacts = []
+    if transcript is not None:
+        artifacts.append(
+            await asyncio.to_thread(upload_provider_transcript, storage_client, bucket, transcript)
+        )
+    if timing_events:
+        artifacts.append(
+            await asyncio.to_thread(upload_timing_events, storage_client, bucket, timing_events)
+        )
+    if audio_snapshot is not None:
+        audio_payload, audio_duration_ms = audio_snapshot
+        artifacts.append(
+            await asyncio.to_thread(
+                upload_generated_audio,
+                storage_client,
+                bucket,
+                audio_payload,
+                audio_duration_ms,
+            )
+        )
+    source_kind = (
+        ObservationSourceKind.DATASET_AUDIO
+        if benchmark.value.upper() == "STT"
+        else ObservationSourceKind.GENERATED_AUDIO
+    )
+    observation = await writer.insert_observation(
+        Observation(
+            run_id=run_id,
+            dataset_id=dataset_id,
+            dataset_sha256=dataset_sha256,
+            sample_id=sample_id,
+            provider=entry.provider,
+            model=entry.model,
+            voice=voice,
+            benchmark=benchmark,
+            source_kind=source_kind,
+            status=ObservationStatus.FAILED if provider_error else ObservationStatus.SUCCEEDED,
+            error=provider_error,
+            failure_origin=ObservationFailureOrigin.PROVIDER if provider_error else None,
+            artifacts=artifacts,
+        )
+    )
+    artifact_ids = {artifact.artifact_type: artifact.id for artifact in observation.artifacts}
+    grouped: dict[str, list[Any]] = {}
+    for row in results:
+        metric = (
+            str(Metric.TTFA)
+            if row.metric_type in (Metric.TTFA_ROUNDTRIP, Metric.TTFA_LEADING_SILENCE)
+            else str(row.metric_type)
+        )
+        grouped.setdefault(metric, []).append(row)
+    for metric, rows in grouped.items():
+        evaluation = await writer.insert_metric_evaluation(
+            MetricEvaluation(
+                observation_id=observation.id,
+                metric_type=metric,
+                metric_version="v1",
+                executor=MetricExecutor.INLINE,
+                status=ProcessingStatus.QUEUED,
+            ),
+            inputs=_inputs(metric, artifact_ids, benchmark),
+        )
+        if (
+            evaluation.status is ProcessingStatus.SUCCEEDED
+            or evaluation.status is ProcessingStatus.FAILED
+        ):
+            continue
+        if evaluation.status is ProcessingStatus.QUEUED:
+            evaluation = await writer.start_metric_evaluation(
+                evaluation.id, started_at=datetime.now(UTC)
+            )
+        primary = next(
+            (row for row in rows if row.metric_value is not None and str(row.status) == "success"),
+            None,
+        )
+        finished_at = datetime.now(UTC)
+        if primary is None:
+            await writer.fail_metric_evaluation(
+                evaluation.id,
+                finished_at=finished_at,
+                error=next(
+                    (row.error for row in rows if row.error), "legacy metric produced no value"
+                ),
+            )
+        else:
+            await writer.complete_metric_evaluation(
+                evaluation.id, finished_at=finished_at, values=_values(metric, rows, evaluation.id)
+            )

--- a/runner/src/coval_bench/runner/normalized.py
+++ b/runner/src/coval_bench/runner/normalized.py
@@ -58,10 +58,9 @@ def _inputs(metric: str, artifacts: dict[Any, Any], benchmark: Any) -> list[Metr
     ]
 
 
-def _values(metric: str, rows: Sequence[Any], evaluation_id: Any) -> list[MetricValue]:
-    primary = next(
-        row for row in rows if row.metric_value is not None and str(row.status) == "success"
-    )
+def _values(
+    metric: str, rows: Sequence[Any], evaluation_id: Any, primary: Any
+) -> list[MetricValue]:
     values = [
         MetricValue(
             metric_evaluation_id=evaluation_id,
@@ -185,6 +184,14 @@ async def dual_write(
         )
         grouped.setdefault(metric, []).append(row)
     for metric, rows in grouped.items():
+        primary = next(
+            (row for row in rows if row.metric_value is not None and str(row.status) == "success"),
+            None,
+        )
+        # A null-valued success is an intentional exclusion from aggregation (for example,
+        # transport-contaminated TTFA), not a failed metric evaluation.
+        if primary is None and any(str(row.status) == "success" for row in rows):
+            continue
         evaluation = await writer.insert_metric_evaluation(
             MetricEvaluation(
                 observation_id=observation.id,
@@ -204,10 +211,6 @@ async def dual_write(
             evaluation = await writer.start_metric_evaluation(
                 evaluation.id, started_at=datetime.now(UTC)
             )
-        primary = next(
-            (row for row in rows if row.metric_value is not None and str(row.status) == "success"),
-            None,
-        )
         finished_at = datetime.now(UTC)
         if primary is None:
             await writer.fail_metric_evaluation(
@@ -219,5 +222,7 @@ async def dual_write(
             )
         else:
             await writer.complete_metric_evaluation(
-                evaluation.id, finished_at=finished_at, values=_values(metric, rows, evaluation.id)
+                evaluation.id,
+                finished_at=finished_at,
+                values=_values(metric, rows, evaluation.id, primary),
             )

--- a/runner/src/coval_bench/runner/orchestrator.py
+++ b/runner/src/coval_bench/runner/orchestrator.py
@@ -39,6 +39,7 @@ import atexit
 import contextlib
 import hashlib
 import importlib
+import importlib.resources
 import random
 import signal
 import wave
@@ -645,36 +646,37 @@ async def _run_stt_item(
             )
 
     if writer is not None and artifact_client is not None:
-        try:
-            from coval_bench.runner.normalized import dual_write
+        async with sem:
+            try:
+                from coval_bench.runner.normalized import dual_write
 
-            await dual_write(
-                writer=writer,
-                storage_client=artifact_client,
-                bucket=settings.benchmark_artifact_bucket,
-                run_id=run_id,
-                dataset_id=dataset_id or settings.dataset_id,
-                dataset_sha256=dataset_sha256,
-                sample_id=item.sample_id or audio_path.name,
-                entry=entry,
-                benchmark=Benchmark.STT,
-                results=results,
-                provider_error=item_error,
-                transcript=complete_transcript,
-                timing_events={
-                    "ttft_seconds": ttft_seconds,
-                    "audio_to_final_seconds": audio_to_final,
-                    "speech_end_offset_ms": speech_end_offset_ms,
-                    "effective_duration_sec": duration_sec,
-                },
-            )
-        except Exception as exc:
-            logger.warning(
-                "normalized_stt_dual_write_failed",
-                provider=entry.provider,
-                model=entry.model,
-                exc_info=exc,
-            )
+                await dual_write(
+                    writer=writer,
+                    storage_client=artifact_client,
+                    bucket=settings.benchmark_artifact_bucket,
+                    run_id=run_id,
+                    dataset_id=dataset_id or settings.dataset_id,
+                    dataset_sha256=dataset_sha256,
+                    sample_id=item.sample_id or audio_path.name,
+                    entry=entry,
+                    benchmark=Benchmark.STT,
+                    results=results,
+                    provider_error=item_error,
+                    transcript=complete_transcript,
+                    timing_events={
+                        "ttft_seconds": ttft_seconds,
+                        "audio_to_final_seconds": audio_to_final,
+                        "speech_end_offset_ms": speech_end_offset_ms,
+                        "effective_duration_sec": duration_sec,
+                    },
+                )
+            except Exception as exc:
+                logger.warning(
+                    "normalized_stt_dual_write_failed",
+                    provider=entry.provider,
+                    model=entry.model,
+                    exc_info=exc,
+                )
 
     return results
 
@@ -915,6 +917,19 @@ async def _run_tts_item(
                                 error=_truncate(str(exc)),
                             )
                         )
+            # The legacy rows remain the source of truth. Persist them before the optional
+            # normalized path so cancellation during artifact upload cannot drop completed work.
+            if writer is not None and results:
+                try:
+                    await writer.record_results(results)
+                except Exception as exc:
+                    logger.warning(
+                        "tts_result_persist_failed",
+                        provider=entry.provider,
+                        model=entry.model,
+                        exc_info=exc,
+                    )
+
             if writer is not None and artifact_client is not None:
                 try:
                     from coval_bench.runner.normalized import dual_write
@@ -963,17 +978,6 @@ async def _run_tts_item(
         model=entry.model,
         item=item.testcase_id,
     )
-
-    if writer is not None and results:
-        try:
-            await writer.record_results(results)
-        except Exception as exc:
-            logger.warning(
-                "tts_result_persist_failed",
-                provider=entry.provider,
-                model=entry.model,
-                exc_info=exc,
-            )
 
     return results
 
@@ -1115,9 +1119,7 @@ async def run_benchmarks(
 
         # Dataset SHA256 for the run record (computed from the packaged manifest)
         try:
-            import importlib.resources as _importlib_resources
-
-            manifest_ref = _importlib_resources.files("coval_bench.datasets.manifests").joinpath(
+            manifest_ref = importlib.resources.files("coval_bench.datasets.manifests").joinpath(
                 f"{run_dataset_id}.json"
             )
             manifest_bytes = manifest_ref.read_bytes()

--- a/runner/src/coval_bench/runner/orchestrator.py
+++ b/runner/src/coval_bench/runner/orchestrator.py
@@ -1,5 +1,6 @@
 # Copyright 2026 The Coval Benchmarks Authors
 # SPDX-License-Identifier: Apache-2.0
+# ruff: noqa: ANN401 -- lazy runtime collaborators intentionally use Any in this module.
 
 """Main benchmark run loop.
 
@@ -327,6 +328,9 @@ async def _run_stt_item(
     sem: asyncio.Semaphore,
     settings: Settings,
     writer: Any | None = None,  # noqa: ANN401 — RunWriter, lazy-imported in caller
+    dataset_id: str | None = None,
+    dataset_sha256: str = "",
+    artifact_client: Any | None = None,
 ) -> list[Any]:
     """Run a single STT provider × dataset item, returning a list of Result rows.
 
@@ -640,6 +644,38 @@ async def _run_stt_item(
                 exc_info=exc,
             )
 
+    if writer is not None and artifact_client is not None:
+        try:
+            from coval_bench.runner.normalized import dual_write
+
+            await dual_write(
+                writer=writer,
+                storage_client=artifact_client,
+                bucket=settings.benchmark_artifact_bucket,
+                run_id=run_id,
+                dataset_id=dataset_id or settings.dataset_id,
+                dataset_sha256=dataset_sha256,
+                sample_id=item.sample_id or audio_path.name,
+                entry=entry,
+                benchmark=Benchmark.STT,
+                results=results,
+                provider_error=item_error,
+                transcript=complete_transcript,
+                timing_events={
+                    "ttft_seconds": ttft_seconds,
+                    "audio_to_final_seconds": audio_to_final,
+                    "speech_end_offset_ms": speech_end_offset_ms,
+                    "effective_duration_sec": duration_sec,
+                },
+            )
+        except Exception as exc:
+            logger.warning(
+                "normalized_stt_dual_write_failed",
+                provider=entry.provider,
+                model=entry.model,
+                exc_info=exc,
+            )
+
     return results
 
 
@@ -676,6 +712,9 @@ async def _run_tts_item(
     settings: Settings,
     voice: str | None = None,
     writer: Any | None = None,  # noqa: ANN401 — RunWriter, lazy-imported in caller
+    dataset_id: str = "tts-v1",
+    dataset_sha256: str = "",
+    artifact_client: Any | None = None,
 ) -> list[Any]:
     """Run a single TTS provider × dataset item, returning a list of Result rows.
 
@@ -876,6 +915,33 @@ async def _run_tts_item(
                                 error=_truncate(str(exc)),
                             )
                         )
+            if writer is not None and artifact_client is not None:
+                try:
+                    from coval_bench.runner.normalized import dual_write
+
+                    await dual_write(
+                        writer=writer,
+                        storage_client=artifact_client,
+                        bucket=settings.benchmark_artifact_bucket,
+                        run_id=run_id,
+                        dataset_id=dataset_id,
+                        dataset_sha256=dataset_sha256,
+                        sample_id=item.testcase_id,
+                        entry=entry,
+                        benchmark=Benchmark.TTS,
+                        results=results,
+                        provider_error=item_error,
+                        timing_events={"ttfa_ms": ttfa_ms},
+                        audio_path=audio_path,
+                        voice=voice,
+                    )
+                except Exception as exc:
+                    logger.warning(
+                        "normalized_tts_dual_write_failed",
+                        provider=entry.provider,
+                        model=entry.model,
+                        exc_info=exc,
+                    )
         finally:
             # Orchestrator owns audio cleanup — always delete in finally block
             if audio_path is not None and audio_path.exists():
@@ -1083,6 +1149,29 @@ async def run_benchmarks(
         )
 
         all_results: list[Any] = []
+        artifact_client: Any | None = None
+        if settings.normalized_dual_write_enabled:
+            try:
+                from google.cloud import storage
+
+                artifact_client = storage.Client()
+            except Exception as exc:
+                logger.warning("normalized_artifact_client_failed", exc_info=exc)
+
+        stt_artifact_client = artifact_client
+        if (
+            stt_artifact_client is not None
+            and benchmark_kind in ("stt", "both")
+            and (
+                len(dataset_sha256) != 64
+                or any(character not in "0123456789abcdef" for character in dataset_sha256)
+            )
+        ):
+            logger.warning(
+                "normalized_stt_manifest_sha_unavailable",
+                dataset_id=settings.dataset_id,
+            )
+            stt_artifact_client = None
         sem = asyncio.Semaphore(_DEDICATED_CONCURRENCY_CAP if dedicated else _CONCURRENCY_CAP)
 
         # Cloud Run sends SIGTERM ~10s before SIGKILL when a task hits its timeout.
@@ -1162,6 +1251,9 @@ async def run_benchmarks(
                         sem=sem,
                         settings=settings,
                         writer=writer,
+                        dataset_id=settings.dataset_id,
+                        dataset_sha256=dataset_sha256,
+                        artifact_client=stt_artifact_client,
                     )
                     for entry, item in stt_pairs
                 ]
@@ -1202,6 +1294,22 @@ async def run_benchmarks(
                     for i, item in enumerate(tts_items)
                     for entry in enabled_tts
                 ]
+                tts_artifact_client = artifact_client
+                tts_manifest_sha256 = ""
+                if tts_artifact_client is not None:
+                    try:
+                        tts_manifest_sha256 = hashlib.sha256(
+                            importlib.resources.files("coval_bench.datasets.manifests")
+                            .joinpath("tts-v1.json")
+                            .read_bytes()
+                        ).hexdigest()
+                    except Exception as exc:
+                        logger.warning(
+                            "normalized_tts_manifest_sha_unavailable",
+                            dataset_id="tts-v1",
+                            exc_info=exc,
+                        )
+                        tts_artifact_client = None
                 tts_tasks = [
                     _run_tts_item(
                         entry=entry,
@@ -1211,6 +1319,9 @@ async def run_benchmarks(
                         settings=settings,
                         voice=voice,
                         writer=writer,
+                        dataset_id="tts-v1",
+                        dataset_sha256=tts_manifest_sha256,
+                        artifact_client=tts_artifact_client,
                     )
                     for entry, item, voice in tts_pairs
                 ]

--- a/runner/tests/unit/fixtures/datasets/manifest-valid.json
+++ b/runner/tests/unit/fixtures/datasets/manifest-valid.json
@@ -7,6 +7,7 @@
   "items": [
     {
       "path": "audio/0001.wav",
+      "sample_id": "fixture-sample-0001",
       "sha256": "61648b306c4b096538b83eafa50fea3a22ae49918d48430859d29725243fb1d4",
       "transcript": "hello world",
       "duration_sec": 1.0,
@@ -16,6 +17,7 @@
     },
     {
       "path": "audio/0001.wav",
+      "sample_id": "fixture-sample-0002",
       "sha256": "61648b306c4b096538b83eafa50fea3a22ae49918d48430859d29725243fb1d4",
       "transcript": "how are you today",
       "duration_sec": 1.0,

--- a/runner/tests/unit/test_config.py
+++ b/runner/tests/unit/test_config.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 from typing import Any
 
+import pytest
 import structlog
 
 from coval_bench.config import SECRET_PLACEHOLDER, Settings
@@ -37,3 +38,15 @@ def test_real_values_pass_through_silently() -> None:
     assert settings.openai_api_key.get_secret_value() == "sk-real"
     assert settings.baseten_whisper_url == "wss://example"
     assert not [entry for entry in logs if entry["event"] == "placeholder_secret"]
+
+
+def test_normalized_dual_write_is_default_off_and_requires_bucket() -> None:
+    assert _settings().normalized_dual_write_enabled is False
+    assert (
+        _settings(
+            normalized_dual_write_enabled="true", benchmark_artifact_bucket="private"
+        ).normalized_dual_write_enabled
+        is True
+    )
+    with pytest.raises(ValueError, match="benchmark_artifact_bucket"):
+        _settings(normalized_dual_write_enabled=True)

--- a/runner/tests/unit/test_dataset_loader.py
+++ b/runner/tests/unit/test_dataset_loader.py
@@ -42,8 +42,10 @@ from coval_bench.config import Settings
 from coval_bench.datasets.loader import (
     WILDASR_ENV_FAMILY,
     DatasetIntegrityError,
+    DatasetItem,
     ManifestAlignmentError,
     TTSDataset,
+    TTSDatasetItem,
     _assert_family_alignment,
     _load_manifest,
     family_rng,
@@ -355,6 +357,69 @@ def test_empty_manifest_items(test_settings: Settings, tmp_path: Path) -> None:
 
     assert result.items == []
     assert result.id == "stt-v1"
+
+
+@pytest.mark.parametrize(
+    ("sample_id", "expected"),
+    [("stable-sample-id", "stable-sample-id"), (None, "audio/0001.wav")],
+)
+def test_stt_sample_identity_is_explicit_or_manifest_path_fallback(
+    sample_id: str | None,
+    expected: str,
+    test_settings: Settings,
+    tmp_path: Path,
+) -> None:
+    """Normalized STT identity is stable without changing existing manifests."""
+    manifest = Manifest(
+        id="stt-v1",
+        version="1.0.0",
+        license="CC-BY-4.0",
+        source="test",
+        items=[
+            STTManifestItem(
+                path="audio/0001.wav",
+                sample_id=sample_id,
+                sha256=FIXTURE_SHA256,
+                transcript="test",
+                duration_sec=1.0,
+            )
+        ],
+    )
+
+    with patch("coval_bench.datasets.loader._load_manifest", return_value=manifest):
+        dataset = load_stt_dataset(
+            "stt-v1",
+            settings=test_settings,
+            cache_dir=tmp_path,
+            storage_client=_make_fake_storage_client(AUDIO_DIR),
+        )
+
+    assert dataset.items[0].sample_id == expected
+
+
+def test_empty_dataset_identities_are_rejected(tmp_path: Path) -> None:
+    """Every identity entering a normalized observation must be non-empty."""
+    stt_fields = {
+        "sha256": "a" * 64,
+        "transcript": "test",
+        "duration_sec": 1.0,
+    }
+    with pytest.raises(ValidationError):
+        STTManifestItem(path="", **stt_fields)
+    with pytest.raises(ValidationError):
+        STTManifestItem(path="audio/test.wav", sample_id="", **stt_fields)
+    with pytest.raises(ValidationError):
+        DatasetItem(
+            path=tmp_path / "test.wav",
+            sample_id="",
+            transcript="test",
+            duration_sec=1.0,
+            sha256="a" * 64,
+        )
+    with pytest.raises(ValidationError):
+        TTSManifestItem(testcase_id="", transcript="test")
+    with pytest.raises(ValidationError):
+        TTSDatasetItem(testcase_id="", transcript="test")
 
 
 # ---------------------------------------------------------------------------

--- a/runner/tests/unit/test_dataset_loader.py
+++ b/runner/tests/unit/test_dataset_loader.py
@@ -359,6 +359,103 @@ def test_empty_manifest_items(test_settings: Settings, tmp_path: Path) -> None:
     assert result.id == "stt-v1"
 
 
+def test_manifest_allows_unique_effective_stt_identities() -> None:
+    """Explicit and fallback STT identities may coexist when they are distinct."""
+    manifest = Manifest(
+        id="stt-v1",
+        version="1.0.0",
+        license="CC-BY-4.0",
+        source="test",
+        items=[
+            STTManifestItem(
+                path="audio/0001.wav",
+                sample_id="sample-0001",
+                sha256=FIXTURE_SHA256,
+                transcript="first",
+                duration_sec=1.0,
+            ),
+            STTManifestItem(
+                path="audio/0002.wav",
+                sha256=FIXTURE_SHA256,
+                transcript="second",
+                duration_sec=1.0,
+            ),
+        ],
+    )
+
+    assert len(manifest.items) == 2
+
+
+def test_manifest_rejects_duplicate_explicit_stt_sample_id() -> None:
+    """Repeated explicit STT sample IDs are rejected."""
+    with pytest.raises(ValidationError, match="duplicate effective sample identity: 'sample-0001'"):
+        Manifest(
+            id="stt-v1",
+            version="1.0.0",
+            license="CC-BY-4.0",
+            source="test",
+            items=[
+                STTManifestItem(
+                    path="audio/0001.wav",
+                    sample_id="sample-0001",
+                    sha256=FIXTURE_SHA256,
+                    transcript="first",
+                    duration_sec=1.0,
+                ),
+                STTManifestItem(
+                    path="audio/0002.wav",
+                    sample_id="sample-0001",
+                    sha256=FIXTURE_SHA256,
+                    transcript="second",
+                    duration_sec=1.0,
+                ),
+            ],
+        )
+
+
+def test_manifest_rejects_stt_path_fallback_and_sample_id_collision() -> None:
+    """An explicit STT sample ID cannot collide with another item's path fallback."""
+    with pytest.raises(
+        ValidationError, match="duplicate effective sample identity: 'audio/0001.wav'"
+    ):
+        Manifest(
+            id="stt-v1",
+            version="1.0.0",
+            license="CC-BY-4.0",
+            source="test",
+            items=[
+                STTManifestItem(
+                    path="audio/0001.wav",
+                    sha256=FIXTURE_SHA256,
+                    transcript="first",
+                    duration_sec=1.0,
+                ),
+                STTManifestItem(
+                    path="audio/0002.wav",
+                    sample_id="audio/0001.wav",
+                    sha256=FIXTURE_SHA256,
+                    transcript="second",
+                    duration_sec=1.0,
+                ),
+            ],
+        )
+
+
+def test_manifest_rejects_duplicate_tts_testcase_id() -> None:
+    """Repeated TTS testcase IDs are rejected."""
+    with pytest.raises(ValidationError, match="duplicate effective sample identity: 'TC001'"):
+        Manifest(
+            id="tts-v1",
+            version="1.0.0",
+            license="proprietary",
+            source="test",
+            items=[
+                TTSManifestItem(testcase_id="TC001", transcript="first"),
+                TTSManifestItem(testcase_id="TC001", transcript="second"),
+            ],
+        )
+
+
 @pytest.mark.parametrize(
     ("sample_id", "expected"),
     [("stable-sample-id", "stable-sample-id"), (None, "audio/0001.wav")],

--- a/runner/tests/unit/test_normalized_dual_write.py
+++ b/runner/tests/unit/test_normalized_dual_write.py
@@ -14,6 +14,7 @@ import pytest
 
 from coval_bench.db.models import (
     Benchmark,
+    MetricArtifact,
     MetricEvaluation,
     MetricEvaluationInput,
     MetricValue,
@@ -77,7 +78,9 @@ class _Writer:
         *,
         finished_at: datetime,
         values: Sequence[MetricValue],
-    ) -> MetricEvaluation:
+        artifacts: Sequence[MetricArtifact] = (),
+    ) -> None:
+        del artifacts
         validate_metric_values(
             self.evaluations[evaluation_id].metric_type,
             "v1",
@@ -91,7 +94,6 @@ class _Writer:
             }
         )
         self.evaluations[evaluation_id] = stored
-        return stored
 
     async def fail_metric_evaluation(
         self, evaluation_id: UUID, *, finished_at: datetime, error: str
@@ -347,3 +349,35 @@ async def test_provider_and_metric_failure_map_to_failed_normalized_rows() -> No
     assert observation.failure_origin is ObservationFailureOrigin.PROVIDER
     assert not writer.completed
     assert list(writer.failed.values()) == ["provider failed"]
+
+
+@pytest.mark.asyncio
+async def test_null_success_metric_is_excluded_instead_of_failed() -> None:
+    writer = _Writer()
+    await normalized.dual_write(
+        writer=writer,
+        storage_client=object(),
+        bucket="private",
+        run_id=1,
+        dataset_id="tts-v1",
+        dataset_sha256="d" * 64,
+        sample_id="tts-1",
+        entry=SimpleNamespace(provider="provider", model="model"),
+        benchmark=Benchmark.TTS,
+        results=[
+            _result(
+                Benchmark.TTS,
+                Metric.TTFA,
+                None,
+                "milliseconds",
+                error="TTFA measured over HTTP/1.1; not comparable",
+            )
+        ],
+        provider_error=None,
+        timing_events={"ttfa_ms": 120},
+    )
+
+    assert writer.observations[0].status is ObservationStatus.SUCCEEDED
+    assert not writer.evaluations
+    assert not writer.completed
+    assert not writer.failed

--- a/runner/tests/unit/test_normalized_dual_write.py
+++ b/runner/tests/unit/test_normalized_dual_write.py
@@ -1,0 +1,349 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import wave
+from collections.abc import Sequence
+from datetime import datetime
+from pathlib import Path
+from types import SimpleNamespace
+from uuid import UUID, uuid4
+
+import pytest
+
+from coval_bench.db.models import (
+    Benchmark,
+    MetricEvaluation,
+    MetricEvaluationInput,
+    MetricValue,
+    Observation,
+    ObservationArtifact,
+    ObservationArtifactType,
+    ObservationFailureOrigin,
+    ObservationSourceKind,
+    ObservationStatus,
+    ProcessingStatus,
+    Result,
+    ResultStatus,
+)
+from coval_bench.registries import Metric
+from coval_bench.registries.metrics import validate_metric_values
+from coval_bench.runner import normalized
+
+
+class _Writer:
+    def __init__(self) -> None:
+        self.observations: list[Observation] = []
+        self.evaluations: dict[UUID, MetricEvaluation] = {}
+        self.inputs: dict[UUID, list[MetricEvaluationInput]] = {}
+        self.completed: dict[UUID, list[MetricValue]] = {}
+        self.failed: dict[UUID, str] = {}
+
+    async def insert_observation(self, observation: Observation) -> Observation:
+        observation_id = uuid4()
+        artifacts = [
+            artifact.model_copy(update={"id": uuid4(), "observation_id": observation_id})
+            for artifact in observation.artifacts
+        ]
+        stored = observation.model_copy(update={"id": observation_id, "artifacts": artifacts})
+        self.observations.append(stored)
+        return stored
+
+    async def insert_metric_evaluation(
+        self,
+        evaluation: MetricEvaluation,
+        *,
+        inputs: Sequence[MetricEvaluationInput] = (),
+    ) -> MetricEvaluation:
+        evaluation_id = uuid4()
+        stored = evaluation.model_copy(update={"id": evaluation_id})
+        self.evaluations[evaluation_id] = stored
+        self.inputs[evaluation_id] = list(inputs)
+        return stored
+
+    async def start_metric_evaluation(
+        self, evaluation_id: UUID, *, started_at: datetime
+    ) -> MetricEvaluation:
+        stored = self.evaluations[evaluation_id].model_copy(
+            update={"status": ProcessingStatus.RUNNING, "started_at": started_at}
+        )
+        self.evaluations[evaluation_id] = stored
+        return stored
+
+    async def complete_metric_evaluation(
+        self,
+        evaluation_id: UUID,
+        *,
+        finished_at: datetime,
+        values: Sequence[MetricValue],
+    ) -> MetricEvaluation:
+        validate_metric_values(
+            self.evaluations[evaluation_id].metric_type,
+            "v1",
+            tuple((value.value_key, value.unit, value.value, value.value_role) for value in values),
+        )
+        self.completed[evaluation_id] = list(values)
+        stored = self.evaluations[evaluation_id].model_copy(
+            update={
+                "status": ProcessingStatus.SUCCEEDED,
+                "finished_at": finished_at,
+            }
+        )
+        self.evaluations[evaluation_id] = stored
+        return stored
+
+    async def fail_metric_evaluation(
+        self, evaluation_id: UUID, *, finished_at: datetime, error: str
+    ) -> MetricEvaluation:
+        self.failed[evaluation_id] = error
+        stored = self.evaluations[evaluation_id].model_copy(
+            update={
+                "status": ProcessingStatus.FAILED,
+                "finished_at": finished_at,
+                "error": error,
+            }
+        )
+        self.evaluations[evaluation_id] = stored
+        return stored
+
+
+def _artifact(artifact_type: ObservationArtifactType) -> ObservationArtifact:
+    return ObservationArtifact(
+        artifact_type=artifact_type,
+        schema_name="TestArtifact",
+        schema_version="v1",
+        gcs_uri=f"gs://private/{artifact_type}.bin",
+        content_sha256="a" * 64,
+        size_bytes=1,
+        duration_ms=1 if artifact_type is ObservationArtifactType.GENERATED_AUDIO else None,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _fake_uploads(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        normalized,
+        "upload_provider_transcript",
+        lambda *_args: _artifact(ObservationArtifactType.PROVIDER_TRANSCRIPT),
+    )
+    monkeypatch.setattr(
+        normalized,
+        "upload_timing_events",
+        lambda *_args: _artifact(ObservationArtifactType.TIMING_EVENTS),
+    )
+    monkeypatch.setattr(
+        normalized,
+        "upload_generated_audio",
+        lambda *_args: _artifact(ObservationArtifactType.GENERATED_AUDIO),
+    )
+
+
+def _result(
+    benchmark: Benchmark,
+    metric: Metric,
+    value: float | None,
+    unit: str | None,
+    *,
+    status: ResultStatus = ResultStatus.SUCCESS,
+    error: str | None = None,
+    **components: float,
+) -> Result:
+    return Result(
+        run_id=1,
+        provider="provider",
+        model="model",
+        benchmark=benchmark,
+        metric_type=metric,
+        metric_value=value,
+        metric_units=unit,
+        status=status,
+        error=error,
+        **components,
+    )
+
+
+def _evaluation_by_metric(writer: _Writer, metric: Metric) -> tuple[UUID, MetricEvaluation]:
+    return next(
+        (evaluation_id, evaluation)
+        for evaluation_id, evaluation in writer.evaluations.items()
+        if evaluation.metric_type == metric
+    )
+
+
+def _artifact_ids(observation: Observation) -> dict[ObservationArtifactType, UUID]:
+    return {
+        artifact.artifact_type: artifact.id
+        for artifact in observation.artifacts
+        if artifact.id is not None
+    }
+
+
+@pytest.mark.asyncio
+async def test_stt_groups_wer_and_freezes_transcript_and_timing_lineage() -> None:
+    writer = _Writer()
+    results = [
+        _result(Benchmark.STT, Metric.TTFT, 0.25, "seconds"),
+        _result(
+            Benchmark.STT,
+            Metric.WER,
+            10,
+            "percent",
+            wer_insertions_pct=2,
+            wer_deletions_pct=3,
+            wer_substitutions_pct=5,
+        ),
+    ]
+
+    await normalized.dual_write(
+        writer=writer,
+        storage_client=object(),
+        bucket="private",
+        run_id=1,
+        dataset_id="stt-v1",
+        dataset_sha256="a" * 64,
+        sample_id="sample-1",
+        entry=SimpleNamespace(provider="provider", model="model"),
+        benchmark=Benchmark.STT,
+        results=results,
+        provider_error=None,
+        transcript="hello",
+        timing_events={"ttft_seconds": 0.25},
+    )
+
+    assert len(writer.observations) == 1
+    observation = writer.observations[0]
+    assert observation.source_kind is ObservationSourceKind.DATASET_AUDIO
+    artifacts = _artifact_ids(observation)
+
+    wer_id, _ = _evaluation_by_metric(writer, Metric.WER)
+    ttft_id, _ = _evaluation_by_metric(writer, Metric.TTFT)
+    assert [value.value_key for value in writer.completed[wer_id]] == [
+        "primary",
+        "insertions",
+        "deletions",
+        "substitutions",
+    ]
+    assert writer.inputs[wer_id] == [
+        MetricEvaluationInput(
+            observation_artifact_id=artifacts[ObservationArtifactType.PROVIDER_TRANSCRIPT],
+            input_role="raw",
+            input_order=0,
+        )
+    ]
+    assert writer.inputs[ttft_id] == [
+        MetricEvaluationInput(
+            observation_artifact_id=artifacts[ObservationArtifactType.TIMING_EVENTS],
+            input_role="timing",
+            input_order=0,
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_tts_groups_ttfa_components_and_audio_lineage(tmp_path: Path) -> None:
+    audio_path = tmp_path / "sample.wav"
+    with wave.open(str(audio_path), "wb") as wav:
+        wav.setparams((1, 2, 16_000, 160, "NONE", "not compressed"))
+        wav.writeframes(b"\0\0" * 160)
+
+    writer = _Writer()
+    results = [
+        _result(Benchmark.TTS, Metric.TTFA, 120, "milliseconds"),
+        _result(Benchmark.TTS, Metric.TTFA_ROUNDTRIP, 75, "milliseconds"),
+        _result(Benchmark.TTS, Metric.TTFA_LEADING_SILENCE, 45, "milliseconds"),
+        _result(
+            Benchmark.TTS,
+            Metric.WER,
+            10,
+            "percent",
+            wer_insertions_pct=2,
+            wer_deletions_pct=3,
+            wer_substitutions_pct=5,
+        ),
+    ]
+
+    await normalized.dual_write(
+        writer=writer,
+        storage_client=object(),
+        bucket="private",
+        run_id=1,
+        dataset_id="tts-v1",
+        dataset_sha256="b" * 64,
+        sample_id="tts-1",
+        entry=SimpleNamespace(provider="provider", model="model"),
+        benchmark=Benchmark.TTS,
+        results=results,
+        provider_error=None,
+        timing_events={"ttfa_ms": 120},
+        audio_path=audio_path,
+        voice="voice",
+    )
+
+    observation = writer.observations[0]
+    assert observation.source_kind is ObservationSourceKind.GENERATED_AUDIO
+    artifacts = _artifact_ids(observation)
+    ttfa_id, _ = _evaluation_by_metric(writer, Metric.TTFA)
+    wer_id, _ = _evaluation_by_metric(writer, Metric.WER)
+    assert {evaluation.metric_type for evaluation in writer.evaluations.values()} == {
+        Metric.TTFA,
+        Metric.WER,
+    }
+    assert [value.value_key for value in writer.completed[ttfa_id]] == [
+        "primary",
+        "roundtrip",
+        "leading_silence",
+    ]
+    assert writer.inputs[ttfa_id] == [
+        MetricEvaluationInput(
+            observation_artifact_id=artifacts[ObservationArtifactType.TIMING_EVENTS],
+            input_role="timing",
+            input_order=0,
+        ),
+        MetricEvaluationInput(
+            observation_artifact_id=artifacts[ObservationArtifactType.GENERATED_AUDIO],
+            input_role="raw",
+            input_order=0,
+        ),
+    ]
+    assert writer.inputs[wer_id] == [
+        MetricEvaluationInput(
+            observation_artifact_id=artifacts[ObservationArtifactType.GENERATED_AUDIO],
+            input_role="raw",
+            input_order=0,
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_provider_and_metric_failure_map_to_failed_normalized_rows() -> None:
+    writer = _Writer()
+    await normalized.dual_write(
+        writer=writer,
+        storage_client=object(),
+        bucket="private",
+        run_id=1,
+        dataset_id="stt-v1",
+        dataset_sha256="c" * 64,
+        sample_id="sample-1",
+        entry=SimpleNamespace(provider="provider", model="model"),
+        benchmark=Benchmark.STT,
+        results=[
+            _result(
+                Benchmark.STT,
+                Metric.TTFT,
+                None,
+                "seconds",
+                status=ResultStatus.FAILED,
+                error="provider failed",
+            )
+        ],
+        provider_error="provider failed",
+        timing_events={"ttft_seconds": None},
+    )
+
+    observation = writer.observations[0]
+    assert observation.status is ObservationStatus.FAILED
+    assert observation.failure_origin is ObservationFailureOrigin.PROVIDER
+    assert not writer.completed
+    assert list(writer.failed.values()) == ["provider failed"]

--- a/runner/tests/unit/test_observation_artifacts.py
+++ b/runner/tests/unit/test_observation_artifacts.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import hashlib
+import wave
+from pathlib import Path
+
+import pytest
+from google.api_core.exceptions import PreconditionFailed
+
+from coval_bench.observation_artifacts import (
+    snapshot_generated_audio,
+    upload_generated_audio,
+    upload_provider_transcript,
+)
+
+
+class Blob:
+    def __init__(self) -> None:
+        self.metadata: dict[str, str] | None = None
+        self.payload = b""
+        self.size = 0
+        self.content_type: str | None = None
+        self.kwargs: dict[str, object] = {}
+        self.conflict = False
+
+    def upload_from_string(self, payload: bytes, **kwargs: object) -> None:
+        self.kwargs = kwargs
+        if self.conflict:
+            raise PreconditionFailed("exists")
+        self.payload = payload
+        self.size = len(payload)
+        self.content_type = str(kwargs["content_type"])
+
+    def reload(self) -> None:
+        return None
+
+    def download_as_bytes(self) -> bytes:
+        return self.payload
+
+
+class Bucket:
+    def __init__(self, blob: Blob) -> None:
+        self._blob = blob
+
+    def blob(self, _key: str) -> Blob:
+        return self._blob
+
+
+class Client:
+    def __init__(self, blob: Blob) -> None:
+        self._bucket = Bucket(blob)
+
+    def bucket(self, _name: str) -> Bucket:
+        return self._bucket
+
+
+def test_transcript_upload_is_create_only_private_and_opaque() -> None:
+    blob = Blob()
+    artifact = upload_provider_transcript(Client(blob), "private", "secret transcript")  # type: ignore[arg-type]
+    assert blob.kwargs["if_generation_match"] == 0
+    assert artifact.gcs_uri.startswith("gs://private/observation-artifacts/v1/")
+    assert "secret" not in artifact.gcs_uri
+    assert artifact.content_sha256 == hashlib.sha256(blob.payload).hexdigest()
+    assert artifact.size_bytes == len(blob.payload)
+    assert blob.metadata == {"sha256": artifact.content_sha256}
+    assert blob.content_type == "application/json"
+
+
+def test_exact_collision_accepts_but_corruption_rejects() -> None:
+    blob = Blob()
+    client = Client(blob)
+    upload_provider_transcript(client, "private", "same")  # type: ignore[arg-type]
+    blob.conflict = True
+    upload_provider_transcript(client, "private", "same")  # type: ignore[arg-type]
+    blob.content_type = "text/plain"
+    with pytest.raises(ValueError, match="collision"):
+        upload_provider_transcript(client, "private", "same")  # type: ignore[arg-type]
+    blob.content_type = "application/json"
+    blob.payload = b"wrong"
+    blob.size = len(blob.payload)
+    with pytest.raises(ValueError, match="collision"):
+        upload_provider_transcript(client, "private", "same")  # type: ignore[arg-type]
+
+
+def test_wav_snapshot_keeps_bytes_and_duration(tmp_path: Path) -> None:
+    path = tmp_path / "sample.wav"
+    with wave.open(str(path), "wb") as wav:
+        wav.setparams((1, 2, 16_000, 160, "NONE", "not compressed"))
+        wav.writeframes(b"\0\0" * 160)
+    payload, duration_ms = snapshot_generated_audio(path)
+    assert payload == path.read_bytes()
+    assert duration_ms == 10
+
+    blob = Blob()
+    artifact = upload_generated_audio(  # type: ignore[arg-type]
+        Client(blob), "private", payload, duration_ms
+    )
+    assert blob.payload == payload
+    assert blob.content_type == "audio/wav"
+    assert artifact.duration_ms == duration_ms

--- a/runner/tests/unit/test_observation_artifacts.py
+++ b/runner/tests/unit/test_observation_artifacts.py
@@ -2,10 +2,13 @@ from __future__ import annotations
 
 import hashlib
 import wave
+from collections.abc import Callable
 from pathlib import Path
+from typing import cast
 
 import pytest
 from google.api_core.exceptions import PreconditionFailed
+from google.cloud import storage
 
 from coval_bench.observation_artifacts import (
     snapshot_generated_audio,
@@ -26,7 +29,7 @@ class Blob:
     def upload_from_string(self, payload: bytes, **kwargs: object) -> None:
         self.kwargs = kwargs
         if self.conflict:
-            raise PreconditionFailed("exists")
+            raise cast(Callable[[str], Exception], PreconditionFailed)("exists")
         self.payload = payload
         self.size = len(payload)
         self.content_type = str(kwargs["content_type"])
@@ -54,9 +57,13 @@ class Client:
         return self._bucket
 
 
+def _client(blob: Blob) -> storage.Client:
+    return cast(storage.Client, Client(blob))
+
+
 def test_transcript_upload_is_create_only_private_and_opaque() -> None:
     blob = Blob()
-    artifact = upload_provider_transcript(Client(blob), "private", "secret transcript")  # type: ignore[arg-type]
+    artifact = upload_provider_transcript(_client(blob), "private", "secret transcript")
     assert blob.kwargs["if_generation_match"] == 0
     assert artifact.gcs_uri.startswith("gs://private/observation-artifacts/v1/")
     assert "secret" not in artifact.gcs_uri
@@ -68,18 +75,18 @@ def test_transcript_upload_is_create_only_private_and_opaque() -> None:
 
 def test_exact_collision_accepts_but_corruption_rejects() -> None:
     blob = Blob()
-    client = Client(blob)
-    upload_provider_transcript(client, "private", "same")  # type: ignore[arg-type]
+    client = _client(blob)
+    upload_provider_transcript(client, "private", "same")
     blob.conflict = True
-    upload_provider_transcript(client, "private", "same")  # type: ignore[arg-type]
+    upload_provider_transcript(client, "private", "same")
     blob.content_type = "text/plain"
     with pytest.raises(ValueError, match="collision"):
-        upload_provider_transcript(client, "private", "same")  # type: ignore[arg-type]
+        upload_provider_transcript(client, "private", "same")
     blob.content_type = "application/json"
     blob.payload = b"wrong"
     blob.size = len(blob.payload)
     with pytest.raises(ValueError, match="collision"):
-        upload_provider_transcript(client, "private", "same")  # type: ignore[arg-type]
+        upload_provider_transcript(client, "private", "same")
 
 
 def test_wav_snapshot_keeps_bytes_and_duration(tmp_path: Path) -> None:
@@ -92,9 +99,7 @@ def test_wav_snapshot_keeps_bytes_and_duration(tmp_path: Path) -> None:
     assert duration_ms == 10
 
     blob = Blob()
-    artifact = upload_generated_audio(  # type: ignore[arg-type]
-        Client(blob), "private", payload, duration_ms
-    )
+    artifact = upload_generated_audio(_client(blob), "private", payload, duration_ms)
     assert blob.payload == payload
     assert blob.content_type == "audio/wav"
     assert artifact.duration_ms == duration_ms

--- a/runner/tests/unit/test_orchestrator.py
+++ b/runner/tests/unit/test_orchestrator.py
@@ -47,6 +47,7 @@ from coval_bench.registries import MODEL_REGISTRY, ModelStatus, RegisteredModel,
 from coval_bench.runner.orchestrator import (
     RunSummary,
     _dead_providers,
+    _run_tts_item,
     _stt_silent_failure,
     run_benchmarks,
 )
@@ -2961,3 +2962,252 @@ async def test_sigterm_reports_dead_provider_from_a_completed_phase(
     assert len(partial) == 1, "the completed phase's dead provider must still report"
     assert "elevenlabs/scribe_v2_realtime" in partial[0]["error"]
     assert "boom" in partial[0]["error"]
+
+
+# ---------------------------------------------------------------------------
+# Normalized dual-write lifecycle
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_normalized_dual_write_disabled_creates_no_gcs_client(
+    audio_file: Path, settings: Settings
+) -> None:
+    """The default-off flag must leave both GCS and normalized writes untouched."""
+    provider = MagicMock()
+    provider.measure_ttft = AsyncMock(return_value=_good_transcription())
+    matrix = [*_paused_registry(Benchmark.STT), _stt_entry("deepgram", "nova-2")]
+
+    async with _orchestrator_env(
+        audio_path=audio_file,
+        stt_items=[_make_dataset_item(audio_file)],
+        stt_providers={"deepgram": MagicMock(return_value=provider)},
+    ):
+        with (
+            patch("google.cloud.storage.Client") as storage_client,
+            patch("coval_bench.runner.normalized.dual_write", new_callable=AsyncMock) as dual_write,
+        ):
+            await run_benchmarks(
+                settings=settings,
+                benchmark_kind="stt",
+                smoke=True,
+                matrix_overrides=matrix,
+            )
+
+    storage_client.assert_not_called()
+    dual_write.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_stt_normalized_write_fails_closed_without_manifest_sha(
+    audio_file: Path, settings: Settings
+) -> None:
+    """An unknown STT manifest hash must disable only the normalized write path."""
+    enabled = settings.model_copy(
+        update={
+            "benchmark_artifact_bucket": "private-artifacts",
+            "normalized_dual_write_enabled": True,
+        }
+    )
+    provider = MagicMock()
+    provider.measure_ttft = AsyncMock(return_value=_good_transcription())
+    writer = _make_stub_writer(_make_run())
+    matrix = [*_paused_registry(Benchmark.STT), _stt_entry("deepgram", "nova-2")]
+
+    async with _orchestrator_env(
+        audio_path=audio_file,
+        stt_items=[_make_dataset_item(audio_file)],
+        stt_providers={"deepgram": MagicMock(return_value=provider)},
+        writer=writer,
+    ):
+        with (
+            patch("importlib.resources.files", side_effect=OSError("manifest unavailable")),
+            patch("google.cloud.storage.Client", return_value=object()) as storage_client,
+            patch("coval_bench.runner.normalized.dual_write", new_callable=AsyncMock) as dual_write,
+        ):
+            await run_benchmarks(
+                settings=enabled,
+                benchmark_kind="stt",
+                smoke=True,
+                matrix_overrides=matrix,
+            )
+
+    storage_client.assert_called_once_with()
+    dual_write.assert_not_awaited()
+    writer.record_results.assert_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("dual_write_enabled", [False, True])
+async def test_tts_manifest_sha_failure_never_breaks_legacy_writes(
+    dual_write_enabled: bool, audio_file: Path, settings: Settings
+) -> None:
+    """TTS provenance lookup is skipped or fail-closed without affecting legacy rows."""
+    configured = settings.model_copy(
+        update={
+            "benchmark_artifact_bucket": "private-artifacts" if dual_write_enabled else "",
+            "normalized_dual_write_enabled": dual_write_enabled,
+        }
+    )
+    provider = MagicMock()
+    provider.synthesize = AsyncMock(
+        return_value=TTSResult(
+            provider="elevenlabs",
+            model="eleven_flash_v2_5",
+            voice="voice",
+            ttfa_ms=120.0,
+            audio_path=audio_file,
+            error=None,
+        )
+    )
+    writer = _make_stub_writer(_make_run())
+    matrix = [
+        *_paused_registry(Benchmark.TTS),
+        _tts_entry("elevenlabs", "eleven_flash_v2_5", "voice"),
+    ]
+
+    async with _orchestrator_env(
+        audio_path=audio_file,
+        tts_items=[_make_tts_item()],
+        tts_providers={"elevenlabs": MagicMock(return_value=provider)},
+        writer=writer,
+    ):
+        with (
+            patch("importlib.resources.files", side_effect=OSError("manifest unavailable")),
+            patch("google.cloud.storage.Client", return_value=object()) as storage_client,
+            patch(
+                "coval_bench.runner.orchestrator._transcribe_with_whisper",
+                side_effect=RuntimeError("whisper unavailable"),
+            ),
+            patch("coval_bench.runner.normalized.dual_write", new_callable=AsyncMock) as dual_write,
+        ):
+            await run_benchmarks(
+                settings=configured,
+                benchmark_kind="tts",
+                smoke=True,
+                matrix_overrides=matrix,
+            )
+
+    assert storage_client.call_count == int(dual_write_enabled)
+    dual_write.assert_not_awaited()
+    writer.record_results.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_tts_normalized_failure_preserves_audio_until_write_and_legacy_results(
+    audio_file: Path, settings: Settings
+) -> None:
+    """An ordinary normalized failure is isolated after it snapshots live audio."""
+    enabled = settings.model_copy(
+        update={
+            "benchmark_artifact_bucket": "private-artifacts",
+            "normalized_dual_write_enabled": True,
+        }
+    )
+    provider = MagicMock()
+    provider.synthesize = AsyncMock(
+        return_value=TTSResult(
+            provider="elevenlabs",
+            model="eleven_flash_v2_5",
+            voice="voice",
+            ttfa_ms=120.0,
+            audio_path=audio_file,
+            error=None,
+        )
+    )
+    writer = _make_stub_writer(_make_run())
+
+    async def _fail_after_checking_audio(**kwargs: Any) -> None:
+        assert kwargs["audio_path"].exists()
+        raise RuntimeError("normalized unavailable")
+
+    async with _orchestrator_env(
+        audio_path=audio_file,
+        tts_providers={"elevenlabs": MagicMock(return_value=provider)},
+        writer=writer,
+    ):
+        with (
+            patch(
+                "coval_bench.runner.orchestrator._transcribe_with_whisper",
+                side_effect=RuntimeError("whisper unavailable"),
+            ),
+            patch(
+                "coval_bench.runner.normalized.dual_write",
+                new_callable=AsyncMock,
+                side_effect=_fail_after_checking_audio,
+            ) as dual_write,
+        ):
+            results = await _run_tts_item(
+                entry=_tts_entry("elevenlabs", "eleven_flash_v2_5", "voice"),
+                item=_make_tts_item(),
+                run_id=1,
+                sem=asyncio.Semaphore(1),
+                settings=enabled,
+                writer=writer,
+                dataset_sha256="a" * 64,
+                artifact_client=object(),
+            )
+
+    dual_write.assert_awaited_once()
+    assert not audio_file.exists()
+    writer.record_results.assert_awaited_once_with(results)
+
+
+@pytest.mark.asyncio
+async def test_tts_cancellation_propagates_after_audio_cleanup(
+    audio_file: Path, settings: Settings
+) -> None:
+    """Cancellation is never swallowed, but orchestrator-owned audio is removed."""
+    enabled = settings.model_copy(
+        update={
+            "benchmark_artifact_bucket": "private-artifacts",
+            "normalized_dual_write_enabled": True,
+        }
+    )
+    provider = MagicMock()
+    provider.synthesize = AsyncMock(
+        return_value=TTSResult(
+            provider="elevenlabs",
+            model="eleven_flash_v2_5",
+            voice="voice",
+            ttfa_ms=120.0,
+            audio_path=audio_file,
+            error=None,
+        )
+    )
+    writer = _make_stub_writer(_make_run())
+
+    async def _cancel_after_checking_audio(**kwargs: Any) -> None:
+        assert kwargs["audio_path"].exists()
+        raise asyncio.CancelledError
+
+    async with _orchestrator_env(
+        audio_path=audio_file,
+        tts_providers={"elevenlabs": MagicMock(return_value=provider)},
+        writer=writer,
+    ):
+        with (
+            patch(
+                "coval_bench.runner.orchestrator._transcribe_with_whisper",
+                side_effect=RuntimeError("whisper unavailable"),
+            ),
+            patch(
+                "coval_bench.runner.normalized.dual_write",
+                new_callable=AsyncMock,
+                side_effect=_cancel_after_checking_audio,
+            ),
+            pytest.raises(asyncio.CancelledError),
+        ):
+            await _run_tts_item(
+                entry=_tts_entry("elevenlabs", "eleven_flash_v2_5", "voice"),
+                item=_make_tts_item(),
+                run_id=1,
+                sem=asyncio.Semaphore(1),
+                settings=enabled,
+                writer=writer,
+                dataset_sha256="a" * 64,
+                artifact_client=object(),
+            )
+
+    assert not audio_file.exists()
+    writer.record_results.assert_not_awaited()

--- a/runner/tests/unit/test_orchestrator.py
+++ b/runner/tests/unit/test_orchestrator.py
@@ -631,9 +631,11 @@ async def test_retry_exhausted() -> None:
 
 @pytest.mark.asyncio
 async def test_concurrency_cap(audio_file: Path, settings: Settings) -> None:
-    """50 dataset items × 1 provider — at most 8 coroutines in flight at once."""
+    """Provider calls and normalized writes both stay within the eight-item cap."""
     max_concurrent = 0
     current_concurrent = 0
+    max_normalized_concurrent = 0
+    current_normalized_concurrent = 0
     lock = asyncio.Lock()
 
     async def tracked_measure_ttft(*args: Any, **kwargs: Any) -> TranscriptionResult:
@@ -647,6 +649,17 @@ async def test_concurrency_cap(audio_file: Path, settings: Settings) -> None:
             current_concurrent -= 1
         return _good_transcription()
 
+    async def tracked_dual_write(**_kwargs: Any) -> None:
+        nonlocal max_normalized_concurrent, current_normalized_concurrent
+        async with lock:
+            current_normalized_concurrent += 1
+            max_normalized_concurrent = max(
+                max_normalized_concurrent, current_normalized_concurrent
+            )
+        await asyncio.sleep(0)
+        async with lock:
+            current_normalized_concurrent -= 1
+
     provider_inst = MagicMock()
     provider_inst.measure_ttft = tracked_measure_ttft
     provider_cls = MagicMock(return_value=provider_inst)
@@ -657,6 +670,12 @@ async def test_concurrency_cap(audio_file: Path, settings: Settings) -> None:
 
     run = _make_run()
     writer = _make_stub_writer(run)
+    enabled = settings.model_copy(
+        update={
+            "benchmark_artifact_bucket": "private-artifacts",
+            "normalized_dual_write_enabled": True,
+        }
+    )
 
     async with _orchestrator_env(
         audio_path=audio_file,
@@ -665,14 +684,27 @@ async def test_concurrency_cap(audio_file: Path, settings: Settings) -> None:
         run=run,
         writer=writer,
     ) as _:
-        summary = await run_benchmarks(
-            settings=settings,
-            benchmark_kind="stt",
-            smoke=False,
-            matrix_overrides=matrix,
-        )
+        with (
+            patch("google.cloud.storage.Client", return_value=object()),
+            patch(
+                "coval_bench.runner.normalized.dual_write",
+                new_callable=AsyncMock,
+                side_effect=tracked_dual_write,
+            ) as dual_write,
+        ):
+            summary = await run_benchmarks(
+                settings=enabled,
+                benchmark_kind="stt",
+                smoke=False,
+                matrix_overrides=matrix,
+            )
 
     assert max_concurrent <= 8, f"max concurrent was {max_concurrent}"
+    assert max_normalized_concurrent <= 8, (
+        f"max normalized concurrent was {max_normalized_concurrent}"
+    )
+    assert dual_write.await_count == provider_cls.call_count
+    assert dual_write.await_count > 8
     assert summary.total_results >= 50 * 3
 
 
@@ -3117,8 +3149,10 @@ async def test_tts_normalized_failure_preserves_audio_until_write_and_legacy_res
     )
     writer = _make_stub_writer(_make_run())
 
+    audio_existed_during_write: list[bool] = []
+
     async def _fail_after_checking_audio(**kwargs: Any) -> None:
-        assert kwargs["audio_path"].exists()
+        audio_existed_during_write.append(kwargs["audio_path"].exists())
         raise RuntimeError("normalized unavailable")
 
     async with _orchestrator_env(
@@ -3149,6 +3183,7 @@ async def test_tts_normalized_failure_preserves_audio_until_write_and_legacy_res
             )
 
     dual_write.assert_awaited_once()
+    assert audio_existed_during_write == [True]
     assert not audio_file.exists()
     writer.record_results.assert_awaited_once_with(results)
 
@@ -3210,4 +3245,4 @@ async def test_tts_cancellation_propagates_after_audio_cleanup(
             )
 
     assert not audio_file.exists()
-    writer.record_results.assert_not_awaited()
+    writer.record_results.assert_awaited_once()


### PR DESCRIPTION
## Summary

- Add immutable, content-addressed private GCS artifacts for provider transcripts, timing events, and generated audio.
- Feature-flag additive normalized observations, metric evaluations, values, and frozen input lineage for STT and TTS while preserving legacy writes as the source of truth.
- Add stable dataset sample identities, fail-closed manifest provenance, TTS audio lifecycle protection, and failure/cancellation isolation.

## Scope

- Excludes S2S dual writes and normalized read cutover.
- Includes no Terraform changes.
- Defaults off until the private production bucket, runner IAM, and Cloud Run environment are configured.

## Validation

- Independent Tier 3 review: PASS
- Ruff format check: PASS
- Ruff lint: PASS
- Mypy on changed production modules: PASS
- Focused unit tests: 109 passed
- Live GCP smoke: not run; the target bucket is absent and the active account lacks bucket provisioning permissions.

Linear: https://linear.app/coval/issue/BENCH-703/implement-normalized-stttts-benchmark-dual-writes

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds feature-flagged normalized STT/TTS observations backed by immutable GCS artifacts while retaining legacy result writes.

- Adds stable dataset sample identities and manifest provenance.
- Uploads content-addressed transcript, timing, and generated-audio artifacts.
- Converts legacy STT/TTS results into normalized observations, evaluations, inputs, and values.
- Adds rollout configuration and focused unit coverage.

<h3>Confidence Score: 3/5</h3>

The PR should not merge until TTS legacy persistence is protected from normalized-write cancellation and intentional null-valued successes retain their non-failure semantics.

The enabled TTS path can lose completed source-of-truth results when cancellation occurs during optional normalized work, and the adapter records deliberately excluded legacy measurements as failed normalized evaluations.

**Files Needing Attention:** runner/src/coval_bench/runner/orchestrator.py, runner/src/coval_bench/runner/normalized.py

<sub>Reviews (1): Last reviewed commit: ["\[BENCH-703\] Add normalized STT and TTS d..."](https://github.com/coval-ai/benchmarks/commit/edc46d74ccfdae40d475c744cc05c7a862705da6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54910490)</sub>

> Greptile also left **2 inline comments** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Runner Orchestration](https://app.greptile.com/coval/-/custom-context/knowledge-base/coval-ai/benchmarks/-/docs/runner-orchestration.md)
- Knowledge Base — [DB Layer](https://app.greptile.com/coval/-/custom-context/knowledge-base/coval-ai/benchmarks/-/docs/db-layer.md)
- Knowledge Base — [Methodology](https://app.greptile.com/coval/-/custom-context/knowledge-base/coval-ai/benchmarks/-/docs/methodology.md)
</details>

<!-- /greptile_comment -->