### PR TITLE
[BENCH-709] Retire AssemblyAI multilingual, stop the Velma-2 models

### DIFF
--- a/runner/src/coval_bench/registries/models.py
+++ b/runner/src/coval_bench/registries/models.py
@@ -211,7 +211,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         tags=(_STREAMING, _MULTI, _VAD, _DIAR, _CODESW, _KEYTERM),
         on_prem=True,
         region="us",
-        status=_ACTIVE,
+        status=_RETIRED,
     ),
     # No longer offered on AssemblyAI's streaming API (u3-rt-pro); superseded by
     # universal-3.5-pro.
@@ -446,7 +446,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         model="velma-2-stt-streaming-english-v2",
         tags=(_STREAMING,),
         region="us",
-        status=_EARLY_ACCESS,
+        status=_RETIRED,
     ),
     RegisteredModel(
         benchmark=_STT,
@@ -454,7 +454,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         model="velma-2-stt-streaming",
         tags=(_STREAMING, _MULTI, _DIAR),
         region="us",
-        status=_ACTIVE,
+        status=_PAUSED,
     ),
     # Pre-Velma-2 ids; retired so their orphaned result rows stay off the site.
     RegisteredModel(


### PR DESCRIPTION
Hopefully this will fix the alerts

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR updates model lifecycle statuses to stop scheduled benchmarking for AssemblyAI multilingual and both Velma-2 models.

- Retires AssemblyAI multilingual and Velma-2 English, disabling their public catalog entries.
- Pauses Velma-2 multilingual, preserving its public visibility while removing it from scheduled runs.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because all three models are removed from scheduled benchmarking with visibility behavior consistent with their selected lifecycle statuses.

No concrete blocking or independently actionable non-blocking failure remains after checking how the orchestrator and API consume these statuses.

<sub>Reviews (1): Last reviewed commit: ["\[BENCH-709\] Retire AssemblyAI multilingu..."](https://github.com/coval-ai/benchmarks/commit/d598032c598abb6ae131e960c823e055d866a032) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55323443)</sub>

**Context used:**

- Knowledge Base — [Runner Orchestration](https://app.greptile.com/coval/-/custom-context/knowledge-base/coval-ai/benchmarks/-/docs/runner-orchestration.md)

<!-- /greptile_comment -->