### PR TITLE
[BENCH-713] Add Speechmatics STT

### DIFF
--- a/runner/src/coval_bench/providers/stt/speechmatics.py
+++ b/runner/src/coval_bench/providers/stt/speechmatics.py
@@ -3,7 +3,7 @@
 
 """Speechmatics real-time STT provider.
 
-Supports models: default, enhanced, broadcast.
+Supports models: default, enhanced, broadcast, linden-1 (Agent STT preview).
 Wire protocol: WebSocket, wss://eu2.rt.speechmatics.com/v2
 Auth: Authorization: Bearer <key>
 Start: {"message": "StartRecognition", ...}
@@ -27,12 +27,13 @@ from coval_bench.providers.stt._pacing import paced_chunks
 logger = structlog.get_logger(__name__)
 
 _WS_URL = "wss://eu2.rt.speechmatics.com/v2"
+_AGENT_WS_URL = "wss://preview.rt.speechmatics.com/v2/agent"
 
 
 class SpeechmaticsProvider(STTProvider):
     """Speechmatics real-time STT provider."""
 
-    _VALID_MODELS = frozenset({"default", "enhanced", "broadcast"})
+    _VALID_MODELS = frozenset({"default", "enhanced", "broadcast", "linden-1"})
 
     def __init__(self, api_key: SecretStr, model: str = "default") -> None:
         if not self._model_supported(model):
@@ -41,6 +42,7 @@ class SpeechmaticsProvider(STTProvider):
             )
         self._api_key = api_key
         self._model = model
+        self._is_agent = model == "linden-1"
 
     @property
     def name(self) -> str:
@@ -61,6 +63,9 @@ class SpeechmaticsProvider(STTProvider):
             transcription_config["operating_point"] = "enhanced"
         elif self._model == "broadcast":
             transcription_config["domain"] = "broadcast"
+        elif self._is_agent:
+            # Required: without it the /agent endpoint falls back to the RT API.
+            transcription_config["model"] = self._model
 
         return {
             "message": "StartRecognition",
@@ -85,7 +90,8 @@ class SpeechmaticsProvider(STTProvider):
 
         try:
             headers = {"Authorization": f"Bearer {self._api_key.get_secret_value()}"}
-            async with ws_client.connect(_WS_URL, additional_headers=headers) as ws:
+            ws_url = _AGENT_WS_URL if self._is_agent else _WS_URL
+            async with ws_client.connect(ws_url, additional_headers=headers) as ws:
                 # Send StartRecognition before streaming audio
                 start_config = self._build_start_recognition_config(sample_rate)
                 await ws.send(json.dumps(start_config))
@@ -199,7 +205,8 @@ class SpeechmaticsProvider(STTProvider):
                         result.first_token_content = transcript
                     result.partial_transcripts.append(transcript)
 
-                if msg_type == "AddTranscript":
+                final_type = "AddSegment" if self._is_agent else "AddTranscript"
+                if msg_type == final_type:
                     final_transcripts.append(transcript)
                     last_final_time = now
 
@@ -224,6 +231,9 @@ class SpeechmaticsProvider(STTProvider):
 
     def _extract_transcript(self, msg: dict[str, Any]) -> str:
         msg_type: str = msg.get("message", "")
+        if msg_type in ("AddSegment", "AddPartialSegment"):
+            segment: dict[str, Any] = msg.get("segment", {})
+            return str(segment.get("transcript", "")).strip()
         if msg_type not in ("AddTranscript", "AddPartialTranscript"):
             return ""
         # Prefer the pre-formatted transcript field — it handles punctuation

--- a/runner/src/coval_bench/registries/models.py
+++ b/runner/src/coval_bench/registries/models.py
@@ -253,6 +253,14 @@ MODEL_REGISTRY: list[RegisteredModel] = [
     ),
     RegisteredModel(
         benchmark=_STT,
+        provider="speechmatics",
+        model="linden-1",
+        tags=(_STREAMING, _MULTI, _VAD, _DIAR),
+        region="eu",
+        status=_EARLY_ACCESS,
+    ),
+    RegisteredModel(
+        benchmark=_STT,
         provider="gradium",
         model="default",
         tags=(_STREAMING, _MULTI, _VAD),

--- a/runner/tests/providers/stt/fixtures/speechmatics/events-agent-success.json
+++ b/runner/tests/providers/stt/fixtures/speechmatics/events-agent-success.json
@@ -1,0 +1,28 @@
+[
+  {"message": "RecognitionStarted", "id": "test-session-agent-001"},
+  {"message": "SpeechStarted", "metadata": {"start_time": 0.1}},
+  {"message": "StartOfTurn", "metadata": {"start_time": 0.1}},
+  {
+    "message": "AddPartialSegment",
+    "segment": {"transcript": "hello", "speaker": "S1"},
+    "metadata": {"start_time": 0.1, "end_time": 0.4}
+  },
+  {
+    "message": "AddPartialSegment",
+    "segment": {"transcript": "hello world", "speaker": "S1"},
+    "metadata": {"start_time": 0.1, "end_time": 0.8}
+  },
+  {
+    "message": "AddSegment",
+    "segment": {"transcript": "hello world", "speaker": "S1"},
+    "metadata": {"start_time": 0.1, "end_time": 0.8}
+  },
+  {
+    "message": "AddSegment",
+    "segment": {"transcript": "how are you", "speaker": "S1"},
+    "metadata": {"start_time": 1.0, "end_time": 1.8}
+  },
+  {"message": "SpeechEnded", "metadata": {"end_time": 1.8}},
+  {"message": "EndOfTurn", "metadata": {"end_time": 2.0}},
+  {"message": "EndOfTranscript"}
+]

--- a/runner/tests/providers/stt/test_speechmatics.py
+++ b/runner/tests/providers/stt/test_speechmatics.py
@@ -87,6 +87,36 @@ async def test_speechmatics_enhanced(fake_api_key: SecretStr, audio_pcm_bytes: b
 
 
 # ---------------------------------------------------------------------------
+# Happy path — linden-1 (Agent STT)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_speechmatics_linden_success(fake_api_key: SecretStr, audio_pcm_bytes: bytes) -> None:
+    events = load_fixture_events("speechmatics", "events-agent-success")
+    provider = SpeechmaticsProvider(api_key=fake_api_key, model="linden-1")
+
+    with patch(
+        "coval_bench.providers.stt.speechmatics.ws_client.connect",
+        return_value=_fake_connect(events),
+    ):
+        result = await provider.measure_ttft(
+            audio_data=audio_pcm_bytes,
+            channels=1,
+            sample_width=2,
+            sample_rate=16000,
+            realtime_resolution=0.5,
+        )
+
+    assert result.error is None
+    assert result.ttft_seconds is not None
+    assert result.first_token_content == "hello"  # noqa: S105 - transcript fixture text
+    assert result.audio_to_final_seconds is not None
+    assert result.complete_transcript == "hello world how are you"
+    assert result.word_count == 5
+
+
+# ---------------------------------------------------------------------------
 # Transcript field — punctuation spacing
 # ---------------------------------------------------------------------------
 
@@ -133,6 +163,19 @@ def test_extract_transcript_fallback_without_transcript_field() -> None:
     assert p._extract_transcript(msg) == "hello world"
 
 
+def test_extract_transcript_segment_messages() -> None:
+    p = make_provider("linden-1")
+    for msg_type in ("AddSegment", "AddPartialSegment"):
+        msg = {
+            "message": msg_type,
+            "segment": {"transcript": "Hello, world.", "speaker": "S1"},
+            "metadata": {"start_time": 0.1, "end_time": 0.8},
+        }
+        assert p._extract_transcript(msg) == "Hello, world."
+    assert p._extract_transcript({"message": "AddSegment", "segment": {}}) == ""
+    assert p._extract_transcript({"message": "EndOfTurn", "metadata": {"end_time": 2.0}}) == ""
+
+
 # ---------------------------------------------------------------------------
 # StartRecognition config
 # ---------------------------------------------------------------------------
@@ -152,6 +195,14 @@ def test_start_recognition_config_enhanced() -> None:
     assert cfg["transcription_config"]["operating_point"] == "enhanced"
 
 
+def test_start_recognition_config_linden() -> None:
+    p = make_provider("linden-1")
+    cfg = p._build_start_recognition_config(16000)
+    assert cfg["transcription_config"]["model"] == "linden-1"
+    assert "operating_point" not in cfg["transcription_config"]
+    assert "domain" not in cfg["transcription_config"]
+
+
 # ---------------------------------------------------------------------------
 # Provider name
 # ---------------------------------------------------------------------------
@@ -165,6 +216,11 @@ def test_provider_name_default() -> None:
 def test_provider_name_enhanced() -> None:
     p = make_provider("enhanced")
     assert p.name == "speechmatics-enhanced"
+
+
+def test_provider_name_linden() -> None:
+    p = make_provider("linden-1")
+    assert p.name == "speechmatics-linden-1"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds Speechmatics Linden-1 Agent STT as an early-access streaming model.
- Routes Linden-1 sessions through Speechmatics’ preview agent WebSocket endpoint.
- Adds Agent STT segment-event transcript and finalization handling.
- Registers the model and adds focused configuration, parsing, and success-path tests.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable defects identified.

Linden-1 is consistently registered, constructed, routed to its agent endpoint, configured with its model identifier, and handled through dedicated segment-event parsing and tests.

<sub>Reviews (1): Last reviewed commit: ["\[BENCH-713\] Add Speechmatics Agent STT (..."](https://github.com/coval-ai/benchmarks/commit/9c1f988f030286fa9f1aa175be3a0df97c3dbb97) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55650566)</sub>

**Context used:**

- Knowledge Base — [Runner Orchestration](https://app.greptile.com/coval/-/custom-context/knowledge-base/coval-ai/benchmarks/-/docs/runner-orchestration.md)

<!-- /greptile_comment -->