### PR TITLE
[BENCH-718] Raise the Together realtime final wait to 15 s

### DIFF
--- a/runner/src/coval_bench/providers/stt/together.py
+++ b/runner/src/coval_bench/providers/stt/together.py
@@ -59,8 +59,10 @@ _LOOKAHEAD_FLUSH_MODELS = frozenset(
 _TAIL_SILENCE_S = 1.6
 
 # After commit, wait this long for the forced final before closing, so the
-# close can't race the final.
-_FINAL_WAIT_S = 5.0
+# close can't race the final. Elapses in full only when no final ever arrives;
+# 5 s proved too tight under serverless load and made slow finals read as
+# silent failures (nemotron especially).
+_FINAL_WAIT_S = 15.0
 
 
 class TogetherSTTProvider(STTProvider):

--- a/runner/src/coval_bench/providers/stt/together.py
+++ b/runner/src/coval_bench/providers/stt/together.py
@@ -59,9 +59,7 @@ _LOOKAHEAD_FLUSH_MODELS = frozenset(
 _TAIL_SILENCE_S = 1.6
 
 # After commit, wait this long for the forced final before closing, so the
-# close can't race the final. Elapses in full only when no final ever arrives;
-# 5 s proved too tight under serverless load and made slow finals read as
-# silent failures (nemotron especially).
+# close can't race the final.
 _FINAL_WAIT_S = 15.0
 
 


### PR DESCRIPTION
## Summary
- Raise `_FINAL_WAIT_S` in the Together STT provider from 5 s to 15 s.

The 5 s post-commit wait for the forced final proved too tight under serverless load: when the final took longer, the client closed the socket with no transcript and no error, and the orchestrator recorded "provider closed the stream without sending a transcript or an error". This silent-close mode caused 25 of nemotron-3.5's 48 item failures over the last 7 days (vs 6 parakeet, 3 whisper) and is the dominant trigger of the flapping Benchmark Partial Failure alert.

The wait only elapses in full when no final ever arrives, so successful items are unaffected; no timing metric is derived from this deadline.

Linear: BENCH-718

## Testing
- `uv run ruff check`, `uv run mypy --strict` on the touched file
- `uv run pytest tests/providers/stt/test_together.py` (13 passed)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Raises Together STT’s post-commit final-response wait from 5 seconds to 15 seconds so slow serverless finals are not misclassified as silent stream closures.
- Updates `_FINAL_WAIT_S` without changing successful-item latency or metric calculation.
- Documents the observed Nemotron failure mode motivating the larger deadline.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable correctness or security issues identified.

The longer final-response wait remains within the existing per-item timeout for current benchmark clips and preserves the provider’s established finalization behavior.

<sub>Reviews (1): Last reviewed commit: ["\[BENCH-718\] Raise the Together realtime ..."](https://github.com/coval-ai/benchmarks/commit/0ae207c058ffc3f921560b16af679d948e0778b9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55779430)</sub>

<!-- /greptile_comment -->