### PR TITLE
[BENCH-719] Require a minimum item count before RUN_PARTIAL names a dead provider

### DIFF
--- a/runner/src/coval_bench/runner/orchestrator.py
+++ b/runner/src/coval_bench/runner/orchestrator.py
@@ -84,9 +84,6 @@ _MAX_ERROR_LEN = 4000  # truncate error messages stored in DB (Postgres text is 
 # but huge stack traces choke log pipelines)
 
 # Items a fully-failed provider must have run before RUN_PARTIAL calls it dead;
-# see _dead_providers. Sized to the scheduler's shard mix (1/4/10 items): small
-# enough that every multi-item shard can still page, large enough that the
-# dominant single-item shards never do.
 _MIN_DEAD_ITEMS = 3
 
 
@@ -200,13 +197,6 @@ def _dead_providers(
     reason is the most common error across the rows, so the alert names a cause.
 
     A provider only counts as dead when it failed at least ``_MIN_DEAD_ITEMS`` items.
-    Most scheduled runs shard the dataset down to a single item per model, so without
-    a floor one transient blip reads as "failed every item it ran" and pages. Each
-    item yields at most one row per metric, so the busiest metric counts the items
-    actually run — items can't be counted from rows directly because one item fans
-    out to several metric rows, nor from ``audio_filename``, which TTS render
-    failures leave unset. The deliberate consequence: a genuinely dead provider
-    stays silent on the single-item shards and pages via the next larger run.
     """
     rows: dict[tuple[str, str, str], list[Any]] = defaultdict(list)
     for r in results:
@@ -250,14 +240,7 @@ def _log_run_outcome(
     twice.
 
     A partial run reports ``RUN_PARTIAL`` **only when some provider failed every one
-    of at least ``_MIN_DEAD_ITEMS`` items**, not on every partial run. Scattered item
-    failures are normal — providers routinely lose one clip out of thirty — so paging
-    on those would bury the signal and the alert would be muted; the item floor keeps
-    the dominant single-item shards from paging on one transient blip. The consequence
-    is deliberate: a run where many providers fail most of their items without any
-    single one being fully dead stays silent here, and is caught only by the run's
-    own metrics.
-    """
+    of at least ``_MIN_DEAD_ITEMS`` items**, not on every partial run."""
     if final_status is run_status.FAILED:
         log_run_failed(
             f"all {fail_count} result rows failed"

--- a/runner/src/coval_bench/runner/orchestrator.py
+++ b/runner/src/coval_bench/runner/orchestrator.py
@@ -83,6 +83,12 @@ _STT_SILENT_FAILURE = "provider closed the stream without sending a transcript o
 _MAX_ERROR_LEN = 4000  # truncate error messages stored in DB (Postgres text is unbounded
 # but huge stack traces choke log pipelines)
 
+# Items a fully-failed provider must have run before RUN_PARTIAL calls it dead;
+# see _dead_providers. Sized to the scheduler's shard mix (1/4/10 items): small
+# enough that every multi-item shard can still page, large enough that the
+# dominant single-item shards never do.
+_MIN_DEAD_ITEMS = 3
+
 
 # ---------------------------------------------------------------------------
 # Public result type
@@ -192,6 +198,15 @@ def _dead_providers(
     registered under more than one modality; keying on the provider alone would let a
     dead model be masked by that provider's healthy rows in the other benchmark. The
     reason is the most common error across the rows, so the alert names a cause.
+
+    A provider only counts as dead when it failed at least ``_MIN_DEAD_ITEMS`` items.
+    Most scheduled runs shard the dataset down to a single item per model, so without
+    a floor one transient blip reads as "failed every item it ran" and pages. Each
+    item yields at most one row per metric, so the busiest metric counts the items
+    actually run — items can't be counted from rows directly because one item fans
+    out to several metric rows, nor from ``audio_filename``, which TTS render
+    failures leave unset. The deliberate consequence: a genuinely dead provider
+    stays silent on the single-item shards and pages via the next larger run.
     """
     rows: dict[tuple[str, str, str], list[Any]] = defaultdict(list)
     for r in results:
@@ -200,6 +215,9 @@ def _dead_providers(
     dead: list[str] = []
     for (benchmark, provider, model), group in sorted(rows.items()):
         if not all(row.status == result_status.FAILED for row in group):
+            continue
+        items_run = max(Counter(row.metric_type for row in group).values())
+        if items_run < _MIN_DEAD_ITEMS:
             continue
         ranked = Counter(row.error for row in group if row.error).most_common(1)
         reason = ranked[0][0] if ranked else "no reason reported"
@@ -232,11 +250,13 @@ def _log_run_outcome(
     twice.
 
     A partial run reports ``RUN_PARTIAL`` **only when some provider failed every one
-    of its items**, not on every partial run. Scattered item failures are normal —
-    providers routinely lose one clip out of thirty — so paging on those would bury
-    the signal and the alert would be muted. The consequence is deliberate: a run
-    where many providers fail most of their items without any single one being fully
-    dead stays silent here, and is caught only by the run's own metrics.
+    of at least ``_MIN_DEAD_ITEMS`` items**, not on every partial run. Scattered item
+    failures are normal — providers routinely lose one clip out of thirty — so paging
+    on those would bury the signal and the alert would be muted; the item floor keeps
+    the dominant single-item shards from paging on one transient blip. The consequence
+    is deliberate: a run where many providers fail most of their items without any
+    single one being fully dead stays silent here, and is caught only by the run's
+    own metrics.
     """
     if final_status is run_status.FAILED:
         log_run_failed(

--- a/runner/tests/unit/test_orchestrator.py
+++ b/runner/tests/unit/test_orchestrator.py
@@ -2667,7 +2667,8 @@ async def test_partial_run_emits_run_partial_with_cause(
 
     async with _orchestrator_env(
         audio_path=audio_file,
-        stt_items=[_make_dataset_item(audio_file)],
+        # Enough items to clear _MIN_DEAD_ITEMS — smaller shards never page.
+        stt_items=[_make_dataset_item(audio_file) for _ in range(3)],
         stt_providers={
             "deepgram": MagicMock(return_value=provider_ok),
             "elevenlabs": MagicMock(return_value=provider_bad),
@@ -2676,10 +2677,11 @@ async def test_partial_run_emits_run_partial_with_cause(
         writer=writer,
     ) as _:
         with structlog.testing.capture_logs() as captured:
+            # smoke=True would slice the dataset back down to one item.
             summary = await run_benchmarks(
                 settings=settings,
                 benchmark_kind="stt",
-                smoke=True,
+                smoke=False,
                 matrix_overrides=[
                     _stt_entry("deepgram", "nova-2"),
                     _stt_entry("elevenlabs", "scribe_v2_realtime"),
@@ -2728,13 +2730,19 @@ async def test_healthy_run_emits_no_run_event(audio_file: Path, settings: Settin
     assert _events(captured, "RUN_PARTIAL") == []
 
 
-def _result(provider: str, benchmark: Benchmark, status: ResultStatus, error: str | None) -> Result:
+def _result(
+    provider: str,
+    benchmark: Benchmark,
+    status: ResultStatus,
+    error: str | None,
+    metric_type: str = "TTFT",
+) -> Result:
     return Result(
         run_id=1,
         provider=provider,
         model="m1",
         benchmark=benchmark,
-        metric_type="TTFT",
+        metric_type=metric_type,
         metric_value=None if status is ResultStatus.FAILED else 1.0,
         metric_units="ms",
         status=status,
@@ -2745,6 +2753,7 @@ def _result(provider: str, benchmark: Benchmark, status: ResultStatus, error: st
 def test_dead_providers_keyed_by_benchmark() -> None:
     """A dead TTS model is not masked by the same provider's healthy STT rows."""
     results = [
+        _result("openai", Benchmark.TTS, ResultStatus.FAILED, "no audio"),
         _result("openai", Benchmark.TTS, ResultStatus.FAILED, "no audio"),
         _result("openai", Benchmark.TTS, ResultStatus.FAILED, "no audio"),
         _result("openai", Benchmark.STT, ResultStatus.SUCCESS, None),
@@ -2780,9 +2789,39 @@ def test_dead_providers_skips_partly_healthy_provider() -> None:
 
 def test_dead_providers_handles_missing_reason() -> None:
     """A failed row with no error still names the provider rather than crashing."""
-    results = [_result("rime", Benchmark.TTS, ResultStatus.FAILED, None)]
+    results = [_result("rime", Benchmark.TTS, ResultStatus.FAILED, None) for _ in range(3)]
 
     assert _dead_providers(results, ResultStatus) == ["TTS:rime/m1 (no reason reported)"]
+
+
+def test_dead_providers_ignores_small_shards() -> None:
+    """Failing every item of a sub-threshold shard is a blip, not a dead provider.
+
+    Most scheduled runs give each model a single item; one transient failure
+    there must not page. The metric fan-out is the trap: one failed item
+    produces several FAILED rows, which must count as one item, not many.
+    """
+    one_item_fanned_out = [
+        _result("together", Benchmark.STT, ResultStatus.FAILED, "503", metric_type=m)
+        for m in ("TTFT", "AudioToFinal", "RTF")
+    ]
+
+    assert _dead_providers(one_item_fanned_out, ResultStatus) == []
+
+
+def test_dead_providers_counts_items_by_busiest_metric() -> None:
+    """Threshold items are counted per metric, so fan-out doesn't inflate them.
+
+    Three items × two metrics is six FAILED rows but only three items — exactly
+    at the floor, so the provider is reported.
+    """
+    results = [
+        _result("together", Benchmark.STT, ResultStatus.FAILED, "503", metric_type=m)
+        for m in ("TTFT", "AudioToFinal")
+        for _ in range(3)
+    ]
+
+    assert _dead_providers(results, ResultStatus) == ["STT:together/m1 (503)"]
 
 
 def test_stt_silent_failure_stamps_a_reason_when_nothing_was_produced() -> None:
@@ -2967,7 +3006,8 @@ async def test_sigterm_reports_dead_provider_from_a_completed_phase(
 
     async with _orchestrator_env(
         audio_path=audio_file,
-        stt_items=[_make_dataset_item(audio_file)],
+        # Enough items to clear _MIN_DEAD_ITEMS — smaller shards never page.
+        stt_items=[_make_dataset_item(audio_file) for _ in range(3)],
         tts_items=[_make_tts_item("hello world")],
         stt_providers={"elevenlabs": MagicMock(return_value=stt_bad)},
         tts_providers={"cartesia": MagicMock(return_value=tts_slow)},
@@ -2975,10 +3015,11 @@ async def test_sigterm_reports_dead_provider_from_a_completed_phase(
         writer=writer,
     ) as _:
         with structlog.testing.capture_logs() as captured:
+            # smoke=True would slice the dataset back down to one item.
             summary = await run_benchmarks(
                 settings=settings,
                 benchmark_kind="both",
-                smoke=True,
+                smoke=False,
                 matrix_overrides=[
                     *_paused_registry(Benchmark.STT),
                     *_paused_registry(Benchmark.TTS),


### PR DESCRIPTION
## Summary
- A fully-failed provider now counts as dead in `_dead_providers` only when it ran at least `_MIN_DEAD_ITEMS = 3` items.

The Benchmark Partial Failure alert fires on `RUN_PARTIAL`, emitted when a provider fails every item it ran. 288 of the 388 runs in the last 24 h shard the dataset to a single item per model, so one transient blip satisfied "failed every item it ran" and paged several times a day (most recently together/nemotron-3.5 silent closes; earlier assemblyai multilingual, velma-2, mistral voxtral).

Items are counted as the busiest metric's row count: one item fans out to several metric rows, and TTS render failures leave `audio_filename` unset, so neither raw row count nor filenames measure items run. Deliberate consequence, documented in the docstrings: a genuinely dead provider stays silent on single-item shards and pages via the next 4- or 10-item run, still within the hour.

Linear: BENCH-719

## Testing
- New unit tests: sub-threshold shards are ignored; fan-out across metrics does not inflate the item count; at-threshold groups still report.
- Existing dead-provider and RUN_PARTIAL contract tests updated to run 3 items (`smoke=False`, since smoke mode slices to one item).
- `uv run pytest tests/unit` (640 passed), `uv run ruff check .`, `uv run mypy --strict` on the touched module.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR reduces noisy `RUN_PARTIAL` alerts by requiring a fully failed provider to have processed at least three items before it is classified as dead.

- Adds a three-item minimum and derives item count from the busiest metric’s row count.
- Documents the deliberate suppression of alerts for single-item shards.
- Updates alert-contract tests and adds coverage for sub-threshold shards, metric fan-out, and threshold behavior.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable correctness or security issues identified.

The item-count proxy remains complete for fully failed runs because every attempted STT item emits AudioToFinal and RTF rows and every attempted TTS item emits a TTFA row, while the added tests cover the threshold and metric fan-out behavior.

<sub>Reviews (1): Last reviewed commit: ["\[BENCH-719\] Require a minimum item count..."](https://github.com/coval-ai/benchmarks/commit/550c4ce17004bb813364e181d97d62719ea5df2d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55779464)</sub>

**Context used:**

- Knowledge Base — [Runner Orchestration](https://app.greptile.com/coval/-/custom-context/knowledge-base/coval-ai/benchmarks/-/docs/runner-orchestration.md)
- Knowledge Base — [Emit alerts for failed benchmark runs](https://app.greptile.com/coval/-/custom-context/knowledge-base/coval-ai/benchmarks/-/reverts/incident-mitigation_441-20260821-missing-run-alerts-6715a06.md)

<!-- /greptile_comment -->