### PR TITLE
[BENCH-720] Reactivate the MiniMax Speech 2.8 TTS models

### DIFF
--- a/runner/src/coval_bench/registries/models.py
+++ b/runner/src/coval_bench/registries/models.py
@@ -978,7 +978,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         ),
         tags=(_STREAMING, _MULTI, _CLONE, _EMOTION, _STREAM),
         region="us",
-        status=_PAUSED,
+        status=_ACTIVE,
     ),
     RegisteredModel(
         benchmark=_TTS,
@@ -991,7 +991,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         ),
         tags=(_STREAMING, _MULTI, _CLONE, _EMOTION, _STREAM),
         region="us",
-        status=_PAUSED,
+        status=_ACTIVE,
     ),
     RegisteredModel(
         benchmark=_TTS,


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Reactivates the MiniMax Speech 2.8 HD and Turbo TTS models after their earlier operational pause.

- Changes both registry entries from `PAUSED` to `ACTIVE`.
- Restores their eligibility for scheduled benchmark execution and arena selection.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because the status-only reactivation introduces no concrete defect supported by the available repository evidence.

The changed statuses intentionally restore scheduling and arena eligibility for two existing models, and no evidence establishes that the provider remains unavailable or that the unchanged integration cannot serve them.

<sub>Reviews (1): Last reviewed commit: ["\[BENCH-720\] Reactivate the MiniMax Speec..."](https://github.com/coval-ai/benchmarks/commit/710f54aafed1bb14c26421a0905eb6acda6cd435) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56300187)</sub>

**Context used:**

- Knowledge Base — [Benchmark catalogs and configuration](https://app.greptile.com/coval/-/custom-context/knowledge-base/coval-ai/benchmarks/-/docs/benchmark-catalogs-and-configuration.md)
- Knowledge Base — [Pause MiniMax models after credit exhaustion](https://app.greptile.com/coval/-/custom-context/knowledge-base/coval-ai/benchmarks/-/reverts/incident-mitigation_524-20260821-pause-minimax-models-975b984.md)

<!-- /greptile_comment -->