### PR TITLE
[BENCH-722] Use the global Speechmatics endpoint

### DIFF
--- a/runner/src/coval_bench/providers/stt/speechmatics.py
+++ b/runner/src/coval_bench/providers/stt/speechmatics.py
@@ -4,7 +4,7 @@
 """Speechmatics real-time STT provider.
 
 Supports models: default, enhanced, broadcast.
-Wire protocol: WebSocket, wss://eu2.rt.speechmatics.com/v2
+Wire protocol: WebSocket, wss://global.rt.speechmatics.com/v2
 Auth: Authorization: Bearer <key>
 Start: {"message": "StartRecognition", ...}
 Close: {"message": "EndOfStream", "last_seq_no": N}
@@ -26,7 +26,7 @@ from coval_bench.providers.stt._pacing import paced_chunks
 
 logger = structlog.get_logger(__name__)
 
-_WS_URL = "wss://eu2.rt.speechmatics.com/v2"
+_WS_URL = "wss://global.rt.speechmatics.com/v2"
 
 
 class SpeechmaticsProvider(STTProvider):


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updates the Speechmatics real-time STT integration to use the provider’s global WebSocket endpoint instead of the EU2 endpoint.
- Changes the fixed connection URL to `wss://global.rt.speechmatics.com/v2`.
- Updates the module’s wire-protocol documentation to match.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete changed-code failure identified.

The endpoint constant and its documentation are updated consistently, and the existing connection path continues to use the same authentication and WebSocket protocol.

<sub>Reviews (1): Last reviewed commit: ["\[BENCH-722\] Use the global Speechmatics ..."](https://github.com/coval-ai/benchmarks/commit/277b7f08ac660c192d0f93d98ef18b26641c1484) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56312966)</sub>

<!-- /greptile_comment -->