### PR TITLE
[BENCH-725] Replace the coval email check with the coval org

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,11 +48,12 @@ MURFAI_API_KEY=
 HAKIMAI_API_KEY=
 
 # --- API (optional) ---
-# Clerk instance for provider-org logins — the one early-access proof. A
-# coval.dev session sees everything; a mapped org sees what its entry names.
-# Bearer tokens stay disabled until both are set.
+# Clerk instance for provider-org logins — the one early-access proof. The
+# coval org sees everything; a mapped org sees what its entry names.
+# Bearer tokens stay disabled until issuer and parties are set.
 # CLERK_ISSUER=https://clerk.example.com
 # CLERK_AUTHORIZED_PARTIES=["https://benchmarks.coval.ai"]
+# CLERK_COVAL_ORG=org_the_coval_staff_org
 
 # --- Google STT/TTS (optional; requires the `google-stt` / `google-tts` extras) ---
 # GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json

--- a/runner/src/coval_bench/api/clerk.py
+++ b/runner/src/coval_bench/api/clerk.py
@@ -4,9 +4,9 @@
 """Resolve a Clerk session token to the embargoed models its holder may see.
 
 Verified against the instance JWKS (public — no secret involved). A mapped
-``org_id`` scopes the caller to what its entry names — even for coval.dev emails,
-so switching into a partner org previews exactly their view. Outside a mapped
-org, a coval.dev ``email`` sees everything.
+``org_id`` scopes the caller to what its entry names — even for coval staff, so
+switching into a partner org previews exactly their view. The coval org
+(``clerk_coval_org``) sees everything.
 """
 
 from __future__ import annotations
@@ -22,8 +22,6 @@ import structlog
 from coval_bench.config import Settings
 
 logger = structlog.get_logger("coval_bench.api.clerk")
-
-_INTERNAL_EMAIL_SUFFIX = "@coval.dev"
 
 
 @functools.lru_cache(maxsize=4)
@@ -189,7 +187,7 @@ def allowed_pairs(
     org_unlocked = _org_unlocked(claims, settings, embargoed)
     if org_unlocked is not None:
         return org_unlocked
-    email = claims.get("email")
-    if isinstance(email, str) and email.endswith(_INTERNAL_EMAIL_SUFFIX):
+    org_id = claims.get("org_id")
+    if settings.clerk_coval_org and org_id == settings.clerk_coval_org:
         return embargoed
     return frozenset()

--- a/runner/src/coval_bench/api/internal.py
+++ b/runner/src/coval_bench/api/internal.py
@@ -5,9 +5,9 @@
 
 ``EARLY_ACCESS`` models run on the normal schedule but are under embargo: every
 data endpoint strips them unless the caller proves it may see them. The one
-proof is a bearer Clerk session token (see ``clerk.py``): a coval.dev email
-sees everything, and a mapped provider org sees what its entry names. The
-grants live in settings, so a request can never widen its own view.
+proof is a bearer Clerk session token (see ``clerk.py``): the coval org sees
+everything, and a mapped provider org sees what its entry names. The grants
+live in settings, so a request can never widen its own view.
 
 An absent or unknown proof yields the public view — the endpoints stay public
 either way, so there is nothing to 404 — and says so in ``X-EA-Token-Status``.

--- a/runner/src/coval_bench/config.py
+++ b/runner/src/coval_bench/config.py
@@ -208,8 +208,9 @@ class Settings(BaseSettings):
     # Allowed azp claim values; bearer tokens are rejected while empty.
     clerk_authorized_parties: list[str] = []
     # The coval staff org id: a token with this org active sees every embargoed
-    # model. Must never appear in clerk_org_providers, since a mapped org narrows
-    # the view. Unset means no org gets the staff view.
+    # model. A clerk_org_providers or clerk_org_exclusive entry for this org takes
+    # precedence and narrows it like any other org. Unset means no org gets the
+    # staff view.
     clerk_coval_org: str | None = None
     # Clerk org id -> what it unlocks, as a JSON object. A value is a provider or a
     # list of providers and provider/model pairs: {"org_abc": "deepgram"},

--- a/runner/src/coval_bench/config.py
+++ b/runner/src/coval_bench/config.py
@@ -207,6 +207,10 @@ class Settings(BaseSettings):
     clerk_issuer: str | None = None
     # Allowed azp claim values; bearer tokens are rejected while empty.
     clerk_authorized_parties: list[str] = []
+    # The coval staff org id: a token with this org active sees every embargoed
+    # model. Must never appear in clerk_org_providers, since a mapped org narrows
+    # the view. Unset means no org gets the staff view.
+    clerk_coval_org: str | None = None
     # Clerk org id -> what it unlocks, as a JSON object. A value is a provider or a
     # list of providers and provider/model pairs: {"org_abc": "deepgram"},
     # {"org_def": ["colors/gray", "colors/red"]}. Keyed by the immutable org id, not

--- a/runner/tests/api/conftest.py
+++ b/runner/tests/api/conftest.py
@@ -58,7 +58,7 @@ ARENA_LABELER_KEY = "test-labeler-key"
 # grants separate callers by model, not just by vendor.
 CLERK_ISSUER = "https://clerk.test.example.com"
 CLERK_PARTY = "https://benchmarks.test.example.com"
-INTERNAL_EMAIL = "tests@coval.dev"
+COVAL_ORG = "org_test_coval"
 
 EA_PROVIDER = "acme"
 EA_MODEL = "unreleased-stt"
@@ -249,6 +249,7 @@ async def app(
     monkeypatch.setenv("CLERK_ISSUER", CLERK_ISSUER)
     monkeypatch.setenv("CLERK_AUTHORIZED_PARTIES", json.dumps([CLERK_PARTY]))
     monkeypatch.setenv("CLERK_ORG_PROVIDERS", json.dumps(CLERK_ORG_PROVIDERS))
+    monkeypatch.setenv("CLERK_COVAL_ORG", COVAL_ORG)
     # Resolve token signatures against the fixture key instead of the network.
     signing_key = SimpleNamespace(key=_CLERK_PUBLIC_PEM)
     monkeypatch.setattr(

--- a/runner/tests/api/test_clerk_scope.py
+++ b/runner/tests/api/test_clerk_scope.py
@@ -42,7 +42,7 @@ _PUBLIC_PEM = _PRIVATE_KEY.public_key().public_bytes(
     format=serialization.PublicFormat.SubjectPublicKeyInfo,
 )
 
-_INTERNAL_EMAIL = "someone@coval.dev"
+_COVAL_ORG = "org_2coval"
 _ORG_ID = "org_2abc123"
 
 
@@ -59,6 +59,7 @@ def _settings(
     parties: str | None = f'["{_PARTY}"]',
     org_providers: str | None = None,
     org_exclusive: str | None = None,
+    coval_org: str | None = _COVAL_ORG,
 ) -> Settings:
     monkeypatch.setenv("DATABASE_URL", "postgresql://runner:password@localhost:5432/benchmarks")
     monkeypatch.setenv("DATASET_BUCKET", "test-bucket")
@@ -72,6 +73,10 @@ def _settings(
         monkeypatch.delenv("CLERK_ORG_EXCLUSIVE", raising=False)
     else:
         monkeypatch.setenv("CLERK_ORG_EXCLUSIVE", org_exclusive)
+    if coval_org is None:
+        monkeypatch.delenv("CLERK_COVAL_ORG", raising=False)
+    else:
+        monkeypatch.setenv("CLERK_COVAL_ORG", coval_org)
     if issuer is None:
         monkeypatch.delenv("CLERK_ISSUER", raising=False)
     else:
@@ -159,7 +164,7 @@ def test_org_entry_list_of_one_provider_unlocks_all_its_models(
 
 def test_mapped_org_naming_nothing_unlocks_nothing(monkeypatch: pytest.MonkeyPatch) -> None:
     settings = _settings(monkeypatch, org_providers=json.dumps({_ORG_ID: []}))
-    token = _mint({"org_id": _ORG_ID, "email": _INTERNAL_EMAIL})
+    token = _mint({"org_id": _ORG_ID})
     hidden, status = _resolve(settings, f"Bearer {token}")
     assert status == "accepted"
     assert hidden == with_retired_keys(embargoed_pairs())
@@ -217,10 +222,10 @@ def test_exclusive_wins_over_additive_for_the_same_org(monkeypatch: pytest.Monke
     assert _public_pair() in hidden
 
 
-def test_exclusive_overrides_a_coval_email(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_exclusive_overrides_the_coval_org(monkeypatch: pytest.MonkeyPatch) -> None:
     provider = _embargoed_provider()
-    settings = _settings(monkeypatch, org_exclusive=json.dumps({_ORG_ID: [provider]}))
-    token = _mint({"org_id": _ORG_ID, "email": _INTERNAL_EMAIL})
+    settings = _settings(monkeypatch, org_exclusive=json.dumps({_COVAL_ORG: [provider]}))
+    token = _mint({"org_id": _COVAL_ORG})
     hidden, _ = _resolve(settings, f"Bearer {token}")
 
     assert _public_pair() in hidden
@@ -229,7 +234,7 @@ def test_exclusive_overrides_a_coval_email(monkeypatch: pytest.MonkeyPatch) -> N
 def test_unmapped_org_is_unaffected_by_the_exclusive_map(monkeypatch: pytest.MonkeyPatch) -> None:
     provider = _embargoed_provider()
     settings = _settings(monkeypatch, org_exclusive=json.dumps({"org_someone_else": [provider]}))
-    token = _mint({"email": _INTERNAL_EMAIL})
+    token = _mint({"org_id": _COVAL_ORG})
     hidden, _ = _resolve(settings, f"Bearer {token}")
 
     assert hidden == frozenset()
@@ -265,7 +270,7 @@ def _unvalidated_settings(exclusive: str) -> Settings:
 
 def test_unparsable_exclusive_map_denies_instead_of_falling_back() -> None:
     settings = _unvalidated_settings('{"org_x": ["colors"]')
-    token = _mint({"org_id": _ORG_ID, "email": _INTERNAL_EMAIL})
+    token = _mint({"org_id": _ORG_ID})
     hidden, status = _resolve(settings, f"Bearer {token}")
 
     assert status == "accepted"
@@ -302,40 +307,57 @@ def test_unknown_exclusive_entry_grants_nothing_and_warns(
     assert not any("Bearer" in str(entry) for entry in logs)
 
 
-def test_coval_email_sees_everything(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_coval_org_sees_everything(monkeypatch: pytest.MonkeyPatch) -> None:
     settings = _settings(monkeypatch)
-    token = _mint({"email": _INTERNAL_EMAIL})
+    token = _mint({"org_id": _COVAL_ORG})
     hidden, status = _resolve(settings, f"Bearer {token}")
     assert status == "accepted"
     assert hidden == frozenset()
 
 
-def test_mapped_org_scopes_even_a_coval_email(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Switching into a partner org previews exactly that org's view."""
+def test_unset_coval_org_grants_nothing(monkeypatch: pytest.MonkeyPatch) -> None:
+    settings = _settings(monkeypatch, coval_org=None)
+    token = _mint({"org_id": _COVAL_ORG})
+    hidden, status = _resolve(settings, f"Bearer {token}")
+    assert status == "accepted"
+    assert hidden == embargoed_pairs()
+
+
+def test_a_mapped_coval_org_gets_only_its_entry(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Mapping the coval org in clerk_org_providers narrows it like any other org."""
     provider = _embargoed_provider()
-    settings = _settings(monkeypatch, org_providers=json.dumps({_ORG_ID: provider}))
-    token = _mint({"email": _INTERNAL_EMAIL, "org_id": _ORG_ID})
+    settings = _settings(monkeypatch, org_providers=json.dumps({_COVAL_ORG: provider}))
+    token = _mint({"org_id": _COVAL_ORG})
     hidden, status = _resolve(settings, f"Bearer {token}")
     assert status == "accepted"
     assert hidden == frozenset(pair for pair in embargoed_pairs() if pair[0] != provider)
 
 
-def test_coval_email_in_an_unmapped_org_still_sees_everything(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Only a mapped org narrows the view; an unmapped one must not demote to public."""
-    provider = _embargoed_provider()
-    settings = _settings(monkeypatch, org_providers=json.dumps({_ORG_ID: provider}))
-    token = _mint({"email": _INTERNAL_EMAIL, "org_id": "org_2someoneelse"})
+def test_a_coval_email_alone_unlocks_nothing(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Staff identity is the coval org, not the mailbox domain."""
+    settings = _settings(monkeypatch)
+    token = _mint({"email": "someone@coval.dev"})
     hidden, status = _resolve(settings, f"Bearer {token}")
     assert status == "accepted"
-    assert hidden == frozenset()
+    assert hidden == embargoed_pairs()
 
 
-def test_lookalike_email_domain_unlocks_nothing(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Only the exact @coval.dev suffix is internal, not a domain ending in it."""
+def test_a_coval_email_in_another_org_unlocks_nothing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The staff view requires the coval org active, whatever the email says."""
+    provider = _embargoed_provider()
+    settings = _settings(monkeypatch, org_providers=json.dumps({_ORG_ID: provider}))
+    token = _mint({"email": "someone@coval.dev", "org_id": "org_2someoneelse"})
+    hidden, status = _resolve(settings, f"Bearer {token}")
+    assert status == "accepted"
+    assert hidden == embargoed_pairs()
+
+
+def test_a_lookalike_org_id_unlocks_nothing(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Only the exact coval org id is staff, not a superstring of it."""
     settings = _settings(monkeypatch)
-    token = _mint({"email": "someone@notcoval.dev"})
+    token = _mint({"org_id": f"{_COVAL_ORG}x"})
     hidden, status = _resolve(settings, f"Bearer {token}")
     assert status == "accepted"
     assert hidden == embargoed_pairs()
@@ -384,7 +406,7 @@ def test_org_without_a_configured_map_keeps_the_public_view(
 def test_claims_of_the_wrong_shape_unlock_nothing(monkeypatch: pytest.MonkeyPatch) -> None:
     provider = _embargoed_provider()
     settings = _settings(monkeypatch, org_providers=json.dumps({_ORG_ID: provider}))
-    token = _mint({"email": [_INTERNAL_EMAIL], "org_id": [_ORG_ID]})
+    token = _mint({"org_id": [_COVAL_ORG]})
     hidden, status = _resolve(settings, f"Bearer {token}")
     assert status == "accepted"
     assert hidden == embargoed_pairs()
@@ -393,7 +415,7 @@ def test_claims_of_the_wrong_shape_unlock_nothing(monkeypatch: pytest.MonkeyPatc
 def test_expired_token_keeps_the_public_view(monkeypatch: pytest.MonkeyPatch) -> None:
     settings = _settings(monkeypatch)
     now = int(time.time())
-    token = _mint({"email": _INTERNAL_EMAIL}, iat=now - 120, exp=now - 60)
+    token = _mint({"org_id": _COVAL_ORG}, iat=now - 120, exp=now - 60)
     hidden, status = _resolve(settings, f"Bearer {token}")
     assert status == "unknown"
     assert hidden == embargoed_pairs()
@@ -403,7 +425,7 @@ def test_token_signed_by_another_key_keeps_the_public_view(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     settings = _settings(monkeypatch)
-    token = _mint({"email": _INTERNAL_EMAIL}, key=_OTHER_KEY)
+    token = _mint({"org_id": _COVAL_ORG}, key=_OTHER_KEY)
     hidden, status = _resolve(settings, f"Bearer {token}")
     assert status == "unknown"
     assert hidden == embargoed_pairs()
@@ -413,7 +435,7 @@ def test_token_from_another_issuer_keeps_the_public_view(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     settings = _settings(monkeypatch)
-    token = _mint({"email": _INTERNAL_EMAIL}, iss="https://not-clerk.example.com")
+    token = _mint({"org_id": _COVAL_ORG}, iss="https://not-clerk.example.com")
     hidden, status = _resolve(settings, f"Bearer {token}")
     assert status == "unknown"
     assert hidden == embargoed_pairs()
@@ -423,7 +445,7 @@ def test_azp_outside_the_allowlist_keeps_the_public_view(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     settings = _settings(monkeypatch, parties=f'["{_PARTY}"]')
-    token = _mint({"email": _INTERNAL_EMAIL}, azp="https://elsewhere.example.com")
+    token = _mint({"org_id": _COVAL_ORG}, azp="https://elsewhere.example.com")
     hidden, status = _resolve(settings, f"Bearer {token}")
     assert status == "unknown"
     assert hidden == embargoed_pairs()
@@ -431,7 +453,7 @@ def test_azp_outside_the_allowlist_keeps_the_public_view(
 
 def test_azp_in_the_allowlist_is_accepted(monkeypatch: pytest.MonkeyPatch) -> None:
     settings = _settings(monkeypatch, parties=f'["{_PARTY}"]')
-    token = _mint({"email": _INTERNAL_EMAIL})
+    token = _mint({"org_id": _COVAL_ORG})
     hidden, status = _resolve(settings, f"Bearer {token}")
     assert status == "accepted"
     assert hidden == frozenset()
@@ -439,7 +461,7 @@ def test_azp_in_the_allowlist_is_accepted(monkeypatch: pytest.MonkeyPatch) -> No
 
 def test_unset_authorized_parties_rejects_every_token(monkeypatch: pytest.MonkeyPatch) -> None:
     settings = _settings(monkeypatch, parties=None)
-    token = _mint({"email": _INTERNAL_EMAIL})
+    token = _mint({"org_id": _COVAL_ORG})
     hidden, status = _resolve(settings, f"Bearer {token}")
     assert status == "unknown"
     assert hidden == embargoed_pairs()
@@ -455,14 +477,14 @@ def test_accepted_bearer_response_is_never_stored_shared(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     settings = _settings(monkeypatch)
-    token = _mint({"email": _INTERNAL_EMAIL})
+    token = _mint({"org_id": _COVAL_ORG})
     headers = _headers(settings, f"Bearer {token}")
     assert headers["cache-control"] == "private, no-store"
 
 
 def test_bearer_responses_vary_on_authorization(monkeypatch: pytest.MonkeyPatch) -> None:
     settings = _settings(monkeypatch)
-    token = _mint({"email": _INTERNAL_EMAIL})
+    token = _mint({"org_id": _COVAL_ORG})
     headers = _headers(settings, f"Bearer {token}")
     assert "Authorization" in headers["vary"]
 
@@ -471,7 +493,7 @@ def test_bearer_is_ignored_when_clerk_is_not_configured(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     settings = _settings(monkeypatch, issuer=None)
-    token = _mint({"email": _INTERNAL_EMAIL})
+    token = _mint({"org_id": _COVAL_ORG})
     hidden, status = _resolve(settings, f"Bearer {token}")
     assert status == "absent"
     assert hidden == embargoed_pairs()

--- a/runner/tests/api/test_internal_access.py
+++ b/runner/tests/api/test_internal_access.py
@@ -4,8 +4,8 @@
 """Tests for the early-access embargo over HTTP.
 
 EARLY_ACCESS models must never appear in public responses of the data
-endpoints. The one proof is a Clerk bearer session token: a coval.dev email
-sees them everywhere, and a mapped provider org sees what its grant names.
+endpoints. The one proof is a Clerk bearer session token: the coval org sees
+them everywhere, and a mapped provider org sees what its grant names.
 """
 
 from __future__ import annotations
@@ -18,12 +18,12 @@ from httpx import AsyncClient
 from coval_bench.api.internal import VARY_HEADERS
 from coval_bench.registries import MODEL_REGISTRY, Benchmark, ModelStatus, RegisteredModel
 from tests.api.conftest import (
+    COVAL_ORG,
     EA_MODEL,
     EA_MODEL_OTHER,
     EA_ORG,
     EA_ORG_OTHER,
     EA_PROVIDER,
-    INTERNAL_EMAIL,
     _fill_buckets,
     _insert_result,
     _insert_run,
@@ -39,7 +39,7 @@ _EA_MODEL = EA_MODEL
 
 
 def _internal_headers() -> dict[str, str]:
-    return bearer(email=INTERNAL_EMAIL)
+    return bearer(org_id=COVAL_ORG)
 
 
 @pytest.fixture
@@ -92,7 +92,7 @@ async def test_results_hides_early_access_from_public(client: AsyncClient, postg
 async def test_results_serves_early_access_to_internal(
     client: AsyncClient, postgresql: Any
 ) -> None:
-    """A coval.dev session unlocks EARLY_ACCESS rows on /v1/results."""
+    """A coval org session unlocks EARLY_ACCESS rows on /v1/results."""
     await _seed_ea_and_public_rows(postgresql)
 
     response = await client.get("/v1/results", headers=_internal_headers())

--- a/runner/tests/api/test_providers.py
+++ b/runner/tests/api/test_providers.py
@@ -10,7 +10,7 @@ from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
 
 from coval_bench.registries.models import MODEL_REGISTRY, ModelStatus
-from tests.api.conftest import INTERNAL_EMAIL, bearer
+from tests.api.conftest import COVAL_ORG, bearer
 
 
 async def test_providers_200(client: AsyncClient) -> None:
@@ -145,7 +145,7 @@ async def test_capability_and_licensing_facets(client: AsyncClient) -> None:
 
     # Baseten's dedicated endpoints are EARLY_ACCESS, so their facets are only
     # visible on the internal view.
-    internal = await client.get("/v1/providers", headers=bearer(email=INTERNAL_EMAIL))
+    internal = await client.get("/v1/providers", headers=bearer(org_id=COVAL_ORG))
     internal_data = internal.json()
     baseten = next(e for e in internal_data["tts"] if e["provider"] == "baseten")
     qwen = next(m for m in baseten["models"] if m["model"] == "qwen3-tts-1.7b")
@@ -165,7 +165,7 @@ async def test_early_access_flag_marks_only_embargoed_rows(client: AsyncClient) 
         for m in entry["models"]
     )
 
-    internal = await client.get("/v1/providers", headers=bearer(email=INTERNAL_EMAIL))
+    internal = await client.get("/v1/providers", headers=bearer(org_id=COVAL_ORG))
     internal_data = internal.json()
     flagged = {
         (entry["provider"], m["model"])

--- a/runner/tests/api/test_s2s_samples_api.py
+++ b/runner/tests/api/test_s2s_samples_api.py
@@ -22,7 +22,7 @@ from coval_bench.api.deps import get_settings
 from coval_bench.config import Settings
 from coval_bench.registries import MODEL_REGISTRY, Benchmark, ModelStatus, RegisteredModel
 from coval_bench.s2s.samples import AUDIO_URL_TTL
-from tests.api.conftest import INTERNAL_EMAIL, bearer
+from tests.api.conftest import COVAL_ORG, bearer
 
 _BUCKET = "test-s2s-samples"
 _SAMPLE = "2026-07-30T00:00:00Z"
@@ -34,7 +34,7 @@ _ORG_PROVIDERS = f'{{"{_PARTNER_ORG}": ["acme/secret-s2s"]}}'
 
 
 def _internal() -> dict[str, str]:
-    return bearer(email=INTERNAL_EMAIL)
+    return bearer(org_id=COVAL_ORG)
 
 
 def _partner() -> dict[str, str]:


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR replaces email-domain-based early-access authorization with an exact configured Clerk organization ID.

- Adds the optional `CLERK_COVAL_ORG` setting.
- Grants the full embargoed model view when that organization is active, while preserving mapped-organization precedence.
- Updates API tests to exercise organization-based staff access and email-only denial.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with a non-blocking configuration-documentation gap that could make the new staff-access setting easy to omit.

The authorization change is coherently covered by tests, but the new optional setting silently controls all staff visibility and is absent from the repository's environment template.

**Files Needing Attention:** runner/src/coval_bench/config.py and runner/.env.example

<sub>Reviews (1): Last reviewed commit: ["\[BENCH-725\] Replace the coval email chec..."](https://github.com/coval-ai/benchmarks/commit/c41923d6371694ed376e4ae9b0ef208c749f569d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56373492)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [API platform controls](https://app.greptile.com/coval/-/custom-context/knowledge-base/coval-ai/benchmarks/-/docs/api-platform-controls.md)
- Knowledge Base — [Benchmark API service](https://app.greptile.com/coval/-/custom-context/knowledge-base/coval-ai/benchmarks/-/docs/api-service.md)

<!-- /greptile_comment -->