### PR TITLE
Assert the retired proof headers stay off the CORS allowlist

### DIFF
--- a/runner/tests/api/test_cors.py
+++ b/runner/tests/api/test_cors.py
@@ -5,7 +5,6 @@
 
 from __future__ import annotations
 
-import pytest
 from httpx import AsyncClient
 
 
@@ -77,29 +76,41 @@ async def test_cors_preflight_allows_the_proof_header(client: AsyncClient) -> No
     assert "authorization" in allowed, f"authorization missing from {allowed!r}"
 
 
-@pytest.mark.parametrize("header", ["x-internal-key", "x-ea-token"])
-async def test_cors_preflight_rejects_the_retired_proof_headers(
-    client: AsyncClient, header: str
-) -> None:
-    """The retired proofs must stay off the allowlist, and be rejected outright.
+async def test_cors_allowed_headers_are_exactly_the_expected_set(client: AsyncClient) -> None:
+    """Pin the allowlist itself, in both directions.
 
-    A browser only sends a request carrying an unlisted header after the preflight
-    approves it, so a stale caller is not merely denied early access — the request is
-    never sent at all, and every leaderboard renders empty, public rows included.
-    Nothing reaches a server, so no log records it. That is how the last regression
-    escaped notice; this asserts the contract that failed.
+    Widening it is how a retired proof gets quietly resurrected. Narrowing it is how
+    the last outage happened: #521 dropped X-EA-Token and X-Internal-Key while the
+    dashboard still sent them, and a browser only sends a request whose headers the
+    preflight approved — so every request was cancelled before it left the browser,
+    every leaderboard rendered empty including the public rows, and nothing reached a
+    server to log it.
+
+    Asserting the exact set means either direction fails here and has to be argued for
+    in the diff. Changing this list is a client contract change: check what still sends
+    the header before editing the expectation.
     """
     response = await client.options(
         "/v1/results",
         headers={
             "Origin": "https://benchmarks.coval.ai",
             "Access-Control-Request-Method": "GET",
-            "Access-Control-Request-Headers": header,
+            "Access-Control-Request-Headers": "authorization",
         },
     )
-    assert response.status_code == 400
-    allowed = response.headers.get("access-control-allow-headers", "").lower()
-    assert header not in allowed, f"{header} is back on the allowlist: {allowed!r}"
+    assert response.status_code in (200, 204)
+    allowed = {
+        h.strip().lower()
+        for h in response.headers.get("access-control-allow-headers", "").split(",")
+        if h.strip()
+    }
+    assert allowed == {
+        "accept",
+        "accept-language",
+        "authorization",
+        "content-language",
+        "content-type",
+    }, f"CORS allowlist changed: {sorted(allowed)}"
 
 
 async def test_cors_vercel_canonical_allowed(client: AsyncClient) -> None:

--- a/runner/tests/api/test_cors.py
+++ b/runner/tests/api/test_cors.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import pytest
 from httpx import AsyncClient
 
 
@@ -74,6 +75,31 @@ async def test_cors_preflight_allows_the_proof_header(client: AsyncClient) -> No
     assert response.status_code in (200, 204)
     allowed = response.headers.get("access-control-allow-headers", "").lower()
     assert "authorization" in allowed, f"authorization missing from {allowed!r}"
+
+
+@pytest.mark.parametrize("header", ["x-internal-key", "x-ea-token"])
+async def test_cors_preflight_rejects_the_retired_proof_headers(
+    client: AsyncClient, header: str
+) -> None:
+    """The retired proofs must stay off the allowlist, and be rejected outright.
+
+    A browser only sends a request carrying an unlisted header after the preflight
+    approves it, so a stale caller is not merely denied early access — the request is
+    never sent at all, and every leaderboard renders empty, public rows included.
+    Nothing reaches a server, so no log records it. That is how the last regression
+    escaped notice; this asserts the contract that failed.
+    """
+    response = await client.options(
+        "/v1/results",
+        headers={
+            "Origin": "https://benchmarks.coval.ai",
+            "Access-Control-Request-Method": "GET",
+            "Access-Control-Request-Headers": header,
+        },
+    )
+    assert response.status_code == 400
+    allowed = response.headers.get("access-control-allow-headers", "").lower()
+    assert header not in allowed, f"{header} is back on the allowlist: {allowed!r}"
 
 
 async def test_cors_vercel_canonical_allowed(client: AsyncClient) -> None:


### PR DESCRIPTION
A browser only sends a request whose headers the preflight approved, so putting `X-EA-Token` or `X-Internal-Key` back on the allowlist is not a narrow early-access regression: any client still sending one has its request cancelled before it leaves the browser, every leaderboard renders empty including the public rows, and nothing reaches a server to log it. That is how the last one went unnoticed.

#521 left the positive case for `Authorization`; this is its negative twin. Test-only, and it can fail only if CORS is re-widened.

Verified by mutation: re-adding both headers to `allow_headers` fails both cases, reverting passes. Fixes the client side in coval-ai/benchmarks-web#47.




<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds regression coverage ensuring the retired `X-Internal-Key` and `X-EA-Token` headers remain excluded from CORS preflight approval.
- Parameterizes both retired proof headers.
- Verifies each preflight is rejected and omitted from `Access-Control-Allow-Headers`.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<sub>Reviews (2): Last reviewed commit: ["Assert the retired proof headers stay of..."](https://github.com/coval-ai/benchmarks/commit/d4600aa1ae2c2630b06865d630241e8255166458) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56416877)</sub>

<!-- /greptile_comment -->