### PR TITLE
Cale/bench 712 move the model and tag registries to postgres with admin

### DIFF
--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -31,7 +31,7 @@ ENV UV_COMPILE_BYTECODE=1 \
 COPY pyproject.toml uv.lock README.md ./
 
 # Install production dependencies (no dev) into /app/.venv
-RUN uv sync --frozen --no-dev --extra google-stt --extra google-tts
+RUN uv sync --frozen --no-dev --extra google-stt --extra google-tts --extra hume-tts
 
 # Copy source tree + alembic config (db/cli.py reads /app/alembic.ini)
 COPY src/ ./src/

--- a/runner/pyproject.toml
+++ b/runner/pyproject.toml
@@ -94,6 +94,7 @@ extend-select = ["E", "F", "I", "B", "UP", "SIM", "S", "ANN"]
 # FastAPI uses Depends/Query in function argument defaults by design
 "src/coval_bench/api/routers/*.py" = ["B008"]
 "src/coval_bench/api/internal.py" = ["B008"]
+"src/coval_bench/api/deps.py" = ["B008"]
 # One prompt sample per source line, even past 100 chars
 "src/coval_bench/arena/prompts.py" = ["E501"]
 

--- a/runner/src/coval_bench/api/app.py
+++ b/runner/src/coval_bench/api/app.py
@@ -43,6 +43,7 @@ from coval_bench.api.internal import never_shared
 from coval_bench.api.ratelimit import _rate_limit_handler, limiter
 from coval_bench.api.request_logging import RequestLoggingMiddleware
 from coval_bench.api.routers import (
+    admin_models,
     aggregates,
     arena,
     health,
@@ -52,6 +53,7 @@ from coval_bench.api.routers import (
     robots,
     runs,
     s2s_samples,
+    tags,
 )
 from coval_bench.config import Settings, get_settings
 from coval_bench.db.conn import lifespan_pool
@@ -140,8 +142,8 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         allow_origins=resolved.cors_origins,
         allow_origin_regex=resolved.cors_origin_regex,
         allow_credentials=False,
-        allow_methods=["GET", "OPTIONS"],
-        allow_headers=["Authorization"],
+        allow_methods=["GET", "POST", "PATCH", "OPTIONS"],
+        allow_headers=["Authorization", "Content-Type", "If-Unmodified-Since"],
         max_age=600,
     )
 
@@ -170,8 +172,10 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     app.include_router(aggregates.router, prefix="/v1")
     app.include_router(leaderboard.router, prefix="/v1")
     app.include_router(providers.router, prefix="/v1")
+    app.include_router(tags.router, prefix="/v1")
     app.include_router(s2s_samples.router, prefix="/v1")
     app.include_router(arena.router, prefix="/v1")
+    app.include_router(admin_models.router, prefix="/v1")
 
     # Serve locally-generated arena clips when no external audio host is set
     # (prod sets arena_gcs_bucket for GCS, or arena_audio_base_url for a CDN origin).

--- a/runner/src/coval_bench/api/app.py
+++ b/runner/src/coval_bench/api/app.py
@@ -143,7 +143,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         allow_origin_regex=resolved.cors_origin_regex,
         allow_credentials=False,
         allow_methods=["GET", "POST", "PATCH", "OPTIONS"],
-        allow_headers=["Authorization", "Content-Type", "If-Unmodified-Since"],
+        allow_headers=["Authorization", "Content-Type", "If-Match"],
         max_age=600,
     )
 

--- a/runner/src/coval_bench/api/clerk.py
+++ b/runner/src/coval_bench/api/clerk.py
@@ -27,10 +27,13 @@ logger = structlog.get_logger("coval_bench.api.clerk")
 
 @dataclass(frozen=True)
 class CovalAdmin:
-    """The verified caller behind an admin request, as stamped into model history."""
+    """The verified caller behind an admin request, as stamped into model history.
+
+    Carries no org: admin callers are coval staff by construction, and history
+    records staff as ``changed_by_org_id = NULL``.
+    """
 
     user_id: str
-    org_id: str
     email: str | None
 
 

--- a/runner/src/coval_bench/api/clerk.py
+++ b/runner/src/coval_bench/api/clerk.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import functools
 import json
 from collections.abc import Mapping
+from dataclasses import dataclass
 from typing import Any
 
 import jwt
@@ -22,6 +23,15 @@ import structlog
 from coval_bench.config import Settings
 
 logger = structlog.get_logger("coval_bench.api.clerk")
+
+
+@dataclass(frozen=True)
+class CovalAdmin:
+    """The verified caller behind an admin request, as stamped into model history."""
+
+    user_id: str
+    org_id: str
+    email: str | None
 
 
 @functools.lru_cache(maxsize=4)
@@ -125,10 +135,7 @@ def exclusive_pairs(
     """
     if settings.clerk_org_exclusive is None:
         return None
-    scheme, _, token = authorization.partition(" ")
-    if scheme.lower() != "bearer" or not token.strip():
-        return None
-    claims = _claims(token.strip(), settings)
+    claims = bearer_claims(authorization, settings)
     if claims is None:
         return None
     org_id = claims.get("org_id")
@@ -174,14 +181,21 @@ def _claims(token: str, settings: Settings) -> dict[str, Any] | None:
     return claims
 
 
+def bearer_claims(authorization: str | None, settings: Settings) -> dict[str, Any] | None:
+    """Verified claims behind a Bearer authorization header, or ``None``."""
+    if not authorization:
+        return None
+    scheme, _, token = authorization.partition(" ")
+    if scheme.lower() != "bearer" or not token.strip():
+        return None
+    return _claims(token.strip(), settings)
+
+
 def allowed_pairs(
     authorization: str, settings: Settings, embargoed: frozenset[tuple[str, str]]
 ) -> frozenset[tuple[str, str]] | None:
     """The embargoed pairs this bearer token unlocks, or ``None`` if it proves nothing."""
-    scheme, _, token = authorization.partition(" ")
-    if scheme.lower() != "bearer" or not token.strip():
-        return None
-    claims = _claims(token.strip(), settings)
+    claims = bearer_claims(authorization, settings)
     if claims is None:
         return None
     org_unlocked = _org_unlocked(claims, settings, embargoed)

--- a/runner/src/coval_bench/api/deps.py
+++ b/runner/src/coval_bench/api/deps.py
@@ -73,7 +73,6 @@ def require_coval_admin(
     email = claims.get("email")
     return clerk.CovalAdmin(
         user_id=user_id,
-        org_id=org_id,
         email=email if isinstance(email, str) and email else None,
     )
 

--- a/runner/src/coval_bench/api/deps.py
+++ b/runner/src/coval_bench/api/deps.py
@@ -16,11 +16,12 @@ from typing import Any, cast
 
 import structlog
 from cachetools import TTLCache
-from fastapi import HTTPException
+from fastapi import Depends, Header, HTTPException
 from posthog import Posthog
 from psycopg_pool import AsyncConnectionPool
 from starlette.requests import Request
 
+from coval_bench.api import clerk
 from coval_bench.config import Settings
 
 logger = structlog.get_logger("coval_bench.api")
@@ -41,6 +42,40 @@ def get_settings(request: Request) -> Settings:
     """Return the Settings instance from app state."""
     settings: Settings = request.app.state.settings
     return settings
+
+
+def require_coval_admin(
+    authorization: str | None = Header(default=None),
+    settings: Settings = Depends(get_settings),
+) -> clerk.CovalAdmin:
+    """The verified coval caller: 401 without a proven token, 403 outside the coval org."""
+    claims = clerk.bearer_claims(authorization, settings)
+    if claims is None:
+        raise HTTPException(
+            401,
+            "a valid Clerk session token is required",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    user_id = claims.get("sub")
+    if not isinstance(user_id, str) or not user_id:
+        raise HTTPException(
+            401,
+            "the session token names no subject",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    org_id = claims.get("org_id")
+    if (
+        not isinstance(org_id, str)
+        or not settings.clerk_coval_org
+        or org_id != settings.clerk_coval_org
+    ):
+        raise HTTPException(403, "the coval org must be active on the token")
+    email = claims.get("email")
+    return clerk.CovalAdmin(
+        user_id=user_id,
+        org_id=org_id,
+        email=email if isinstance(email, str) and email else None,
+    )
 
 
 def get_posthog(request: Request) -> Posthog | None:

--- a/runner/src/coval_bench/api/routers/admin_models.py
+++ b/runner/src/coval_bench/api/routers/admin_models.py
@@ -8,9 +8,10 @@ every response is marked private: rows carry unpublished models and staff
 emails, so a shared cache must never hold one. The tag vocabulary is public
 and lives in ``tags.py``.
 
-Writes enforce what the pydantic registry used to: the provider implementation
-must exist for the modality (S2S is exempt; its data is fetched, not
-synthesized here), tags must be in the vocabulary, a collected TTS model needs
+Writes enforce what the pydantic registry used to: a collected model's
+provider implementation must exist for the modality (S2S is exempt; its data
+is fetched, not synthesized here — and a Stopped row may outlive its
+provider's code), tags must be in the vocabulary, a collected TTS model needs
 a voice, and a non-empty voice pool is exactly one female and one male voice.
 """
 
@@ -72,9 +73,11 @@ def _implemented_providers(modality: Benchmark) -> frozenset[str] | None:
 async def _validate_model(candidate: NewModel | ModelRecord, store: RegistryStore) -> None:
     """The write-time rules the registry's review used to enforce; 422 on violation."""
     implemented = _implemented_providers(candidate.modality)
-    if implemented is not None and candidate.provider not in implemented:
+    if candidate.collected and implemented is not None and candidate.provider not in implemented:
         raise HTTPException(
-            422, f"no {candidate.modality} provider implementation named {candidate.provider!r}"
+            422,
+            f"no {candidate.modality} provider implementation named {candidate.provider!r}; "
+            "without one a model can only exist uncollected",
         )
     vocabulary = {tag.value for tag in await store.list_tags()}
     unknown = [tag for tag in candidate.tags if tag not in vocabulary]

--- a/runner/src/coval_bench/api/routers/admin_models.py
+++ b/runner/src/coval_bench/api/routers/admin_models.py
@@ -1,0 +1,223 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Admin registry endpoints: which models exist, their state, tags, and history.
+
+Every route requires a coval-org Clerk session (``require_coval_admin``), and
+every response is marked private: rows carry unpublished models and staff
+emails, so a shared cache must never hold one. The tag vocabulary is public
+and lives in ``tags.py``.
+
+Writes enforce what the pydantic registry used to: the provider implementation
+must exist for the modality (S2S is exempt; its data is fetched, not
+synthesized here), tags must be in the vocabulary, a collected TTS model needs
+a voice, and a non-empty voice pool is exactly one female and one male voice.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from fastapi import APIRouter, Depends, Header, HTTPException, Response
+from psycopg_pool import AsyncConnectionPool
+
+from coval_bench.api.clerk import CovalAdmin
+from coval_bench.api.deps import get_pool, require_coval_admin
+from coval_bench.api.internal import _RETIRED_BOARD_KEYS, never_shared
+from coval_bench.api.schemas import (
+    AdminChangeOut,
+    AdminModelCreate,
+    AdminModelOut,
+    AdminModelPatch,
+    AdminModelsResponse,
+    AdminModelUpdateResponse,
+)
+from coval_bench.db.registry_store import (
+    DuplicateKey,
+    ModelChange,
+    ModelRecord,
+    NewModel,
+    RegistryStore,
+    StaleEdit,
+)
+from coval_bench.registries import Benchmark, Gender
+from coval_bench.registries.metrics import METRIC_EXCLUSIONS
+from coval_bench.registries.provider_keys import provider_names
+
+router = APIRouter(tags=["admin"], dependencies=[Depends(require_coval_admin)])
+
+# PATCH fields where null is a value, not an omission.
+_NULLABLE_FIELDS = frozenset({"voice", "creator", "region"})
+
+
+def _model_out(record: ModelRecord, history: list[ModelChange]) -> AdminModelOut:
+    return AdminModelOut.model_validate(
+        {
+            **record.model_dump(),
+            "history": [AdminChangeOut.model_validate(change.model_dump()) for change in history],
+        }
+    )
+
+
+def _implemented_providers(modality: Benchmark) -> frozenset[str] | None:
+    """Provider names with code for *modality*, or ``None`` when any name is fine."""
+    if modality is Benchmark.STT:
+        return provider_names("stt")
+    if modality is Benchmark.TTS:
+        return provider_names("tts")
+    return None
+
+
+async def _validate_model(candidate: NewModel | ModelRecord, store: RegistryStore) -> None:
+    """The write-time rules the registry's review used to enforce; 422 on violation."""
+    implemented = _implemented_providers(candidate.modality)
+    if implemented is not None and candidate.provider not in implemented:
+        raise HTTPException(
+            422, f"no {candidate.modality} provider implementation named {candidate.provider!r}"
+        )
+    vocabulary = {tag.value for tag in await store.list_tags()}
+    unknown = [tag for tag in candidate.tags if tag not in vocabulary]
+    if unknown:
+        raise HTTPException(422, f"unknown tags: {unknown}")
+    if candidate.modality is not Benchmark.TTS and candidate.voice is not None:
+        raise HTTPException(422, "a synthesis voice is TTS-only")
+    if (
+        candidate.modality is Benchmark.TTS
+        and candidate.collected
+        and candidate.voice is None
+        and not candidate.voices
+    ):
+        raise HTTPException(422, "a collected TTS model needs a voice or a voice pool")
+    if candidate.voices:
+        if candidate.modality is not Benchmark.TTS:
+            raise HTTPException(422, "voice pools are TTS-only")
+        genders = sorted(voice.gender for voice in candidate.voices)
+        if genders != [Gender.FEMALE, Gender.MALE]:
+            raise HTTPException(422, "a voice pool holds exactly one female and one male voice")
+        if len({voice.id for voice in candidate.voices}) != len(candidate.voices):
+            raise HTTPException(422, "voice pool ids must be distinct")
+
+
+def _rename_warnings(before: ModelRecord, after: ModelRecord) -> list[str]:
+    """Code references a rename leaves pointing at the old or new key."""
+    old = (before.provider, before.model)
+    new = (after.provider, after.model)
+    if old == new:
+        return []
+    warnings = [
+        f"METRIC_EXCLUSIONS[{metric}] still names {old[0]}/{old[1]}; "
+        "the renamed model is no longer excluded"
+        for metric, pairs in METRIC_EXCLUSIONS.items()
+        if old in pairs
+    ]
+    for retired, current in _RETIRED_BOARD_KEYS.items():
+        if current == old:
+            warnings.append(
+                f"the retired board key {retired[0]}/{retired[1]} maps to {old[0]}/{old[1]}, "
+                "which no longer exists"
+            )
+        if retired == new:
+            warnings.append(
+                f"{new[0]}/{new[1]} is a retired board key; artefacts stored under it "
+                "are treated as embargoed history"
+            )
+    return warnings
+
+
+@router.get("/admin/models", response_model=AdminModelsResponse)
+async def list_admin_models(
+    response: Response,
+    pool: AsyncConnectionPool[Any] = Depends(get_pool),
+) -> AdminModelsResponse:
+    """Every registered model with its state, tags, and recent history."""
+    never_shared(response)
+    store = RegistryStore(pool)
+    models = await store.list_models()
+    history = await store.recent_history()
+    return AdminModelsResponse(
+        models=[_model_out(record, history.get(record.id, [])) for record in models]
+    )
+
+
+@router.post("/admin/models", response_model=AdminModelOut, status_code=201)
+async def create_admin_model(
+    body: AdminModelCreate,
+    response: Response,
+    admin: CovalAdmin = Depends(require_coval_admin),
+    pool: AsyncConnectionPool[Any] = Depends(get_pool),
+) -> AdminModelOut:
+    """Create a model. It starts collecting immediately; nothing is public yet."""
+    never_shared(response)
+    store = RegistryStore(pool)
+    new = NewModel.model_validate(body.model_dump())
+    await _validate_model(new, store)
+    try:
+        record = await store.insert_model(
+            new, user_id=admin.user_id, org_id=None, email=admin.email
+        )
+    except DuplicateKey as exc:
+        raise HTTPException(409, str(exc)) from exc
+    return _model_out(record, await store.history(record.id))
+
+
+@router.patch("/admin/models/{model_id}", response_model=AdminModelUpdateResponse)
+async def update_admin_model(
+    model_id: int,
+    body: AdminModelPatch,
+    response: Response,
+    if_unmodified_since: str | None = Header(default=None),
+    admin: CovalAdmin = Depends(require_coval_admin),
+    pool: AsyncConnectionPool[Any] = Depends(get_pool),
+) -> AdminModelUpdateResponse:
+    """Partially update a model; the history's ``old`` is what the editor saw."""
+    never_shared(response)
+    if if_unmodified_since is None:
+        raise HTTPException(
+            428, "If-Unmodified-Since is required: send the model's last-seen updated_at"
+        )
+    try:
+        expected = datetime.fromisoformat(if_unmodified_since)
+    except ValueError as exc:
+        raise HTTPException(
+            400, "If-Unmodified-Since must be the updated_at timestamp in ISO 8601"
+        ) from exc
+    if expected.tzinfo is None:
+        raise HTTPException(400, "If-Unmodified-Since must carry a timezone")
+
+    changes = body.model_dump(exclude_unset=True)
+    null_forbidden = [
+        field for field, value in changes.items() if value is None and field not in _NULLABLE_FIELDS
+    ]
+    if null_forbidden:
+        raise HTTPException(422, f"fields that cannot be null: {null_forbidden}")
+
+    store = RegistryStore(pool)
+    current = await store.get_model(model_id)
+    if current is None:
+        raise HTTPException(404, "no such model")
+    candidate = ModelRecord.model_validate({**current.model_dump(), **changes})
+    await _validate_model(candidate, store)
+    try:
+        result = await store.update_model(
+            model_id,
+            changes,
+            expected_updated_at=expected,
+            user_id=admin.user_id,
+            org_id=None,
+            email=admin.email,
+        )
+    except StaleEdit as exc:
+        raise HTTPException(
+            412,
+            f"the model changed at {exc.current.updated_at.isoformat()}; refetch and retry",
+        ) from exc
+    except DuplicateKey as exc:
+        raise HTTPException(409, str(exc)) from exc
+    if result is None:  # pragma: no cover — the row was read above
+        raise HTTPException(404, "no such model")
+    before, after = result
+    history = await store.history(model_id)
+    return AdminModelUpdateResponse(
+        model=_model_out(after, history), warnings=_rename_warnings(before, after)
+    )

--- a/runner/src/coval_bench/api/routers/admin_models.py
+++ b/runner/src/coval_bench/api/routers/admin_models.py
@@ -163,7 +163,9 @@ async def create_admin_model(
 
 
 def _etag(record: ModelRecord) -> str:
-    return f'"{record.updated_at.isoformat()}"'
+    """Quoted updated_at, via pydantic so it is byte-identical to the JSON body."""
+    stamp = record.model_dump(mode="json")["updated_at"]
+    return f'"{stamp}"'
 
 
 @router.patch("/admin/models/{model_id}", response_model=AdminModelUpdateResponse)

--- a/runner/src/coval_bench/api/routers/admin_models.py
+++ b/runner/src/coval_bench/api/routers/admin_models.py
@@ -158,7 +158,12 @@ async def create_admin_model(
         )
     except DuplicateKey as exc:
         raise HTTPException(409, str(exc)) from exc
+    response.headers["ETag"] = _etag(record)
     return _model_out(record, await store.history(record.id))
+
+
+def _etag(record: ModelRecord) -> str:
+    return f'"{record.updated_at.isoformat()}"'
 
 
 @router.patch("/admin/models/{model_id}", response_model=AdminModelUpdateResponse)
@@ -166,24 +171,21 @@ async def update_admin_model(
     model_id: int,
     body: AdminModelPatch,
     response: Response,
-    if_unmodified_since: str | None = Header(default=None),
+    if_match: str | None = Header(default=None),
     admin: CovalAdmin = Depends(require_coval_admin),
     pool: AsyncConnectionPool[Any] = Depends(get_pool),
 ) -> AdminModelUpdateResponse:
     """Partially update a model; the history's ``old`` is what the editor saw."""
     never_shared(response)
-    if if_unmodified_since is None:
-        raise HTTPException(
-            428, "If-Unmodified-Since is required: send the model's last-seen updated_at"
-        )
+    if if_match is None:
+        raise HTTPException(428, "If-Match is required: send the model's last-seen ETag")
+    if if_match.strip() == "*":
+        raise HTTPException(400, "If-Match must name the last-seen ETag, not *")
     try:
-        expected = datetime.fromisoformat(if_unmodified_since)
+        expected = datetime.fromisoformat(if_match.strip().removeprefix("W/").strip('"'))
     except ValueError as exc:
-        raise HTTPException(
-            400, "If-Unmodified-Since must be the updated_at timestamp in ISO 8601"
-        ) from exc
-    if expected.tzinfo is None:
-        raise HTTPException(400, "If-Unmodified-Since must carry a timezone")
+        # An unreadable tag matches nothing, exactly like a readable stale one.
+        raise HTTPException(412, "the If-Match tag matches no version of the model") from exc
 
     changes = body.model_dump(exclude_unset=True)
     null_forbidden = [
@@ -217,6 +219,7 @@ async def update_admin_model(
     if result is None:  # pragma: no cover — the row was read above
         raise HTTPException(404, "no such model")
     before, after = result
+    response.headers["ETag"] = _etag(after)
     history = await store.history(model_id)
     return AdminModelUpdateResponse(
         model=_model_out(after, history), warnings=_rename_warnings(before, after)

--- a/runner/src/coval_bench/api/routers/tags.py
+++ b/runner/src/coval_bench/api/routers/tags.py
@@ -1,0 +1,48 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""The tag vocabulary: public to read, coval-gated to extend.
+
+The site reads it to build per-table filters; the values are already public
+through ``/v1/providers``, so the read takes no token.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException
+from psycopg_pool import AsyncConnectionPool
+
+from coval_bench.api.deps import get_pool, require_coval_admin
+from coval_bench.api.schemas import TagOut, TagsResponse
+from coval_bench.db.registry_store import DuplicateKey, RegistryStore, TagRecord
+
+router = APIRouter(tags=["tags"])
+
+
+@router.get("/tags", response_model=TagsResponse)
+async def list_tags(
+    pool: AsyncConnectionPool[Any] = Depends(get_pool),
+) -> TagsResponse:
+    """The MODE and FEATURES tag vocabulary, ordered by value."""
+    records = await RegistryStore(pool).list_tags()
+    return TagsResponse(tags=[TagOut.model_validate(record.model_dump()) for record in records])
+
+
+@router.post(
+    "/tags",
+    response_model=TagOut,
+    status_code=201,
+    dependencies=[Depends(require_coval_admin)],
+)
+async def create_tag(
+    body: TagOut,
+    pool: AsyncConnectionPool[Any] = Depends(get_pool),
+) -> TagOut:
+    """Add a vocabulary entry. There is no delete: models reference tags."""
+    try:
+        await RegistryStore(pool).insert_tag(TagRecord.model_validate(body.model_dump()))
+    except DuplicateKey as exc:
+        raise HTTPException(409, str(exc)) from exc
+    return body

--- a/runner/src/coval_bench/api/schemas.py
+++ b/runner/src/coval_bench/api/schemas.py
@@ -12,13 +12,13 @@ from __future__ import annotations
 
 import uuid
 from datetime import datetime
-from typing import Literal
+from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
 from coval_bench.api.common import BenchmarkLiteral, WindowLiteral
 from coval_bench.arena.domains import ArenaDomain
-from coval_bench.registries import TagCategory
+from coval_bench.registries import Benchmark, Licensing, Source, TagCategory, Voice
 
 
 class RunOut(BaseModel):
@@ -363,3 +363,103 @@ class RevealOut(BaseModel):
 
     a: RevealModelOut
     b: RevealModelOut
+
+
+class TagOut(BaseModel):
+    """A MODE or FEATURES vocabulary entry."""
+
+    value: str = Field(min_length=1)
+    category: Literal["mode", "features"]
+    label: str = Field(min_length=1)
+
+
+class TagsResponse(BaseModel):
+    """Response schema for GET /v1/tags."""
+
+    tags: list[TagOut]
+
+
+class AdminChangeOut(BaseModel):
+    """One history row, embedded under its model. ``old`` is NULL on create."""
+
+    id: int
+    old: dict[str, Any] | None = None
+    new: dict[str, Any]
+    changed_by_user_id: str
+    changed_by_org_id: str | None = None
+    changed_by_email: str | None = None
+    changed_at: datetime
+
+
+class AdminModelOut(BaseModel):
+    """A registered model with full state, provenance, and recent history."""
+
+    id: int
+    modality: Benchmark
+    provider: str
+    model: str
+    voice: str | None = None
+    voices: list[Voice] = []
+    creator: str | None = None
+    source: Source
+    licensing: Licensing
+    on_prem: bool
+    region: Literal["us", "eu", "asia"] | None = None
+    arena_enabled: bool
+    collected: bool
+    published: bool
+    tags: list[str] = []
+    updated_by_user_id: str
+    updated_by_email: str | None = None
+    updated_at: datetime
+    history: list[AdminChangeOut] = []
+
+
+class AdminModelsResponse(BaseModel):
+    """Response schema for GET /v1/admin/models."""
+
+    models: list[AdminModelOut]
+
+
+class AdminModelCreate(BaseModel):
+    """POST body for /v1/admin/models. The defaults land the model Hidden."""
+
+    modality: Benchmark
+    provider: str = Field(min_length=1)
+    model: str = Field(min_length=1)
+    voice: str | None = Field(default=None, min_length=1)
+    voices: list[Voice] = []
+    creator: str | None = Field(default=None, min_length=1)
+    source: Source = Source.OFFICIAL_API
+    licensing: Licensing = Licensing.PROPRIETARY
+    on_prem: bool = False
+    region: Literal["us", "eu", "asia"] | None = None
+    arena_enabled: bool = True
+    collected: bool = True
+    published: bool = False
+    tags: list[str] = []
+
+
+class AdminModelPatch(BaseModel):
+    """PATCH body for /v1/admin/models/{id}; absent fields stay unchanged."""
+
+    provider: str | None = Field(default=None, min_length=1)
+    model: str | None = Field(default=None, min_length=1)
+    voice: str | None = Field(default=None, min_length=1)
+    voices: list[Voice] | None = None
+    creator: str | None = Field(default=None, min_length=1)
+    source: Source | None = None
+    licensing: Licensing | None = None
+    on_prem: bool | None = None
+    region: Literal["us", "eu", "asia"] | None = None
+    arena_enabled: bool | None = None
+    collected: bool | None = None
+    published: bool | None = None
+    tags: list[str] | None = None
+
+
+class AdminModelUpdateResponse(BaseModel):
+    """PATCH response: the updated model plus warnings a rename leaves behind."""
+
+    model: AdminModelOut
+    warnings: list[str] = []

--- a/runner/src/coval_bench/db/migrations/versions/20260824_0019_model_registry.py
+++ b/runner/src/coval_bench/db/migrations/versions/20260824_0019_model_registry.py
@@ -27,9 +27,10 @@ the API boundary; only modality, region and tag category are constrained here.
 
 Notes
 -----
-DB roles (``runner``, ``api``) and GRANTs are managed by Terraform. The ``api``
-role needs INSERT and UPDATE on these four tables: admin writes happen in the
-API process.
+DB roles (``runner``, ``api``) and GRANTs are managed by Terraform. Admin writes
+happen in the API process, so the ``api`` role needs SELECT and INSERT on all
+four tables, UPDATE on ``models``, and DELETE on ``model_tags`` — tag
+replacement rewrites the link rows. Nothing else is ever updated or deleted.
 """
 
 from __future__ import annotations

--- a/runner/src/coval_bench/db/migrations/versions/20260824_0019_model_registry.py
+++ b/runner/src/coval_bench/db/migrations/versions/20260824_0019_model_registry.py
@@ -1,0 +1,110 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+# ruff: noqa: E501  # Embedded SQL is formatted as executable migration text.
+
+"""Model and tag registry tables: models, tags, model_tags, model_history.
+
+Revision ID: 20260824_0019
+Revises:     20260818_0018
+Create Date: 2026-08-24
+
+The model registry (BENCH-710 design doc). No seed: rows are loaded through the
+admin API, which validates them.
+
+- ``models``         one row per benchmarked model. ``collected`` = the orchestrator
+                     schedules runs for it; ``published`` = the public site shows it.
+                     The surrogate ``id`` is the API resource id, so a rename does not
+                     orphan history; the natural key stays unique.
+- ``tags``           the MODE and FEATURES tag vocabulary. The other facet categories
+                     (type, host, creator, source, licensing, deployment, region) are
+                     derived from model columns at the API boundary.
+- ``model_tags``     which vocabulary tags each model carries.
+- ``model_history``  full before/after row snapshots per change. No FK to ``models``:
+                     history must outlive anything it references.
+
+Enum vocabularies (source, licensing, voice genders) are validated by pydantic at
+the API boundary; only modality, region and tag category are constrained here.
+
+Notes
+-----
+DB roles (``runner``, ``api``) and GRANTs are managed by Terraform. The ``api``
+role needs INSERT and UPDATE on these four tables: admin writes happen in the
+API process.
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "20260824_0019"
+down_revision = "20260818_0018"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Create the model and tag registry tables."""
+    op.execute(
+        """
+        CREATE TABLE benchmarks_v2.models (
+            id            BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+            modality      TEXT NOT NULL CHECK (modality IN ('STT', 'TTS', 'S2S')),
+            provider      TEXT NOT NULL CHECK (provider <> ''),
+            model         TEXT NOT NULL CHECK (model <> ''),
+            voice         TEXT CHECK (voice IS NULL OR voice <> ''),          -- TTS synthesis voice
+            voices        JSONB NOT NULL DEFAULT '[]' CHECK (jsonb_typeof(voices) = 'array'), -- gendered pool [{id, gender, name, accent}]
+            creator       TEXT CHECK (creator IS NULL OR creator <> ''),      -- NULL = same as provider
+            source        TEXT NOT NULL DEFAULT 'official-api' CHECK (source <> ''),
+            licensing     TEXT NOT NULL DEFAULT 'proprietary' CHECK (licensing <> ''),
+            on_prem       BOOLEAN NOT NULL DEFAULT false,
+            region        TEXT CHECK (region IN ('us', 'eu', 'asia')),        -- NULL = unknown
+            arena_enabled BOOLEAN NOT NULL DEFAULT true,
+            collected     BOOLEAN NOT NULL,
+            published     BOOLEAN NOT NULL,
+            updated_by_user_id TEXT NOT NULL CHECK (updated_by_user_id <> ''), -- Clerk sub
+            updated_by_email   TEXT CHECK (updated_by_email IS NULL OR updated_by_email <> ''), -- label at write time; scrubbable
+            updated_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+            UNIQUE (modality, provider, model)
+        );
+
+        CREATE TABLE benchmarks_v2.tags (
+            value    TEXT PRIMARY KEY CHECK (value <> ''),
+            category TEXT NOT NULL CHECK (category IN ('mode', 'features')),
+            label    TEXT NOT NULL CHECK (label <> '')
+        );
+
+        CREATE TABLE benchmarks_v2.model_tags (
+            model_id BIGINT NOT NULL REFERENCES benchmarks_v2.models(id) ON DELETE CASCADE,
+            tag      TEXT NOT NULL REFERENCES benchmarks_v2.tags(value),
+            PRIMARY KEY (model_id, tag)
+        );
+
+        CREATE TABLE benchmarks_v2.model_history (
+            id        BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+            model_id  BIGINT NOT NULL,
+            modality  TEXT NOT NULL CHECK (modality IN ('STT', 'TTS', 'S2S')),
+            provider  TEXT NOT NULL CHECK (provider <> ''),
+            model     TEXT NOT NULL CHECK (model <> ''),
+            old       JSONB CHECK (old IS NULL OR jsonb_typeof(old) = 'object'), -- NULL on create
+            new       JSONB NOT NULL CHECK (jsonb_typeof(new) = 'object'),
+            changed_by_user_id TEXT NOT NULL CHECK (changed_by_user_id <> ''),
+            changed_by_org_id  TEXT CHECK (changed_by_org_id IS NULL OR changed_by_org_id <> ''), -- NULL = coval staff
+            changed_by_email   TEXT CHECK (changed_by_email IS NULL OR changed_by_email <> ''),
+            changed_at TIMESTAMPTZ NOT NULL DEFAULT now()
+        );
+        CREATE INDEX model_history_model_id_changed_at
+            ON benchmarks_v2.model_history (model_id, changed_at DESC);
+        """
+    )
+
+
+def downgrade() -> None:
+    """Drop the registry tables."""
+    op.execute(
+        """
+        DROP TABLE IF EXISTS benchmarks_v2.model_tags;
+        DROP TABLE IF EXISTS benchmarks_v2.model_history;
+        DROP TABLE IF EXISTS benchmarks_v2.models;
+        DROP TABLE IF EXISTS benchmarks_v2.tags;
+        """
+    )

--- a/runner/src/coval_bench/db/migrations/versions/20260824_0020_model_registry.py
+++ b/runner/src/coval_bench/db/migrations/versions/20260824_0020_model_registry.py
@@ -4,8 +4,8 @@
 
 """Model and tag registry tables: models, tags, model_tags, model_history.
 
-Revision ID: 20260824_0019
-Revises:     20260818_0018
+Revision ID: 20260824_0020
+Revises:     20260824_0019
 Create Date: 2026-08-24
 
 The model registry (BENCH-710 design doc). No seed: rows are loaded through the
@@ -37,8 +37,8 @@ from __future__ import annotations
 
 from alembic import op
 
-revision = "20260824_0019"
-down_revision = "20260818_0018"
+revision = "20260824_0020"
+down_revision = "20260824_0019"
 branch_labels = None
 depends_on = None
 

--- a/runner/src/coval_bench/db/registry_store.py
+++ b/runner/src/coval_bench/db/registry_store.py
@@ -168,7 +168,8 @@ def _record(row: Mapping[str, Any]) -> ModelRecord:
 
 
 def _snapshot(record: ModelRecord) -> Jsonb:
-    return Jsonb(record.model_dump(mode="json"))
+    """The row minus the email label: scrubbing must not leave copies in history."""
+    return Jsonb(record.model_dump(mode="json", exclude={"updated_by_email"}))
 
 
 class RegistryStore:

--- a/runner/src/coval_bench/db/registry_store.py
+++ b/runner/src/coval_bench/db/registry_store.py
@@ -1,0 +1,398 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""``RegistryStore`` — typed read/write helpers for the model registry tables.
+
+Mirrors ``db/arena_store.py``: async, uses the shared psycopg pool, all SQL is
+parameterised (``%s``). Validation of what a row may say (tag vocabulary,
+voice pool rules, provider existence) lives at the API boundary; this layer is
+mechanical and enforces only atomicity, natural-key uniqueness, and the
+edit-from-stale-row check. Every write lands a full before/after snapshot in
+``model_history``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from datetime import datetime
+from typing import Any, Literal
+
+import psycopg
+import psycopg.errors
+import psycopg.rows
+from psycopg.types.json import Jsonb
+from psycopg_pool import AsyncConnectionPool
+from pydantic import BaseModel, field_validator
+
+from coval_bench.registries.benchmarks import Benchmark
+from coval_bench.registries.models import Licensing, Source, Voice
+
+RegistryPool = AsyncConnectionPool[psycopg.AsyncConnection[psycopg.rows.DictRow]]
+
+# Columns a PATCH may change. The modality is immutable: it selects the
+# pipeline, so a modality flip is a new model, not an edit.
+EDITABLE_FIELDS = frozenset(
+    {
+        "provider",
+        "model",
+        "voice",
+        "voices",
+        "creator",
+        "source",
+        "licensing",
+        "on_prem",
+        "region",
+        "arena_enabled",
+        "collected",
+        "published",
+        "tags",
+    }
+)
+
+
+class DuplicateKey(Exception):
+    """The write collided with an existing natural key or tag value."""
+
+
+class StaleEdit(Exception):
+    """The caller edited from a row that has since changed."""
+
+    def __init__(self, current: ModelRecord) -> None:
+        super().__init__(f"model {current.id} changed at {current.updated_at.isoformat()}")
+        self.current = current
+
+
+class TagRecord(BaseModel):
+    """A row in ``benchmarks_v2.tags``."""
+
+    value: str
+    category: Literal["mode", "features"]
+    label: str
+
+
+class NewModel(BaseModel):
+    """A model as POSTed, before the DB assigns identity and provenance."""
+
+    modality: Benchmark
+    provider: str
+    model: str
+    voice: str | None = None
+    voices: tuple[Voice, ...] = ()
+    creator: str | None = None
+    source: Source = Source.OFFICIAL_API
+    licensing: Licensing = Licensing.PROPRIETARY
+    on_prem: bool = False
+    region: Literal["us", "eu", "asia"] | None = None
+    arena_enabled: bool = True
+    collected: bool = True
+    published: bool = False
+    tags: tuple[str, ...] = ()
+
+    @field_validator("tags")
+    @classmethod
+    def _canonical_tags(cls, value: tuple[str, ...]) -> tuple[str, ...]:
+        """Tags are a set; reads alphabetize them, so writes must compare equal."""
+        return tuple(sorted(set(value)))
+
+
+class ModelRecord(NewModel):
+    """A row in ``benchmarks_v2.models`` with its tags."""
+
+    id: int
+    updated_by_user_id: str
+    updated_by_email: str | None = None
+    updated_at: datetime
+
+
+class ModelChange(BaseModel):
+    """A row in ``benchmarks_v2.model_history``."""
+
+    id: int
+    model_id: int
+    modality: Benchmark
+    provider: str
+    model: str
+    old: dict[str, Any] | None = None
+    new: dict[str, Any]
+    changed_by_user_id: str
+    changed_by_org_id: str | None = None
+    changed_by_email: str | None = None
+    changed_at: datetime
+
+
+_SELECT_MODELS = """
+    SELECT m.id, m.modality, m.provider, m.model, m.voice, m.voices, m.creator,
+           m.source, m.licensing, m.on_prem, m.region, m.arena_enabled,
+           m.collected, m.published, m.updated_by_user_id, m.updated_by_email,
+           m.updated_at, COALESCE(t.tags, '{}') AS tags
+    FROM benchmarks_v2.models m
+    LEFT JOIN (
+        SELECT model_id, array_agg(tag ORDER BY tag) AS tags
+        FROM benchmarks_v2.model_tags
+        GROUP BY model_id
+    ) t ON t.model_id = m.id
+"""
+
+_INSERT_MODEL = """
+    INSERT INTO benchmarks_v2.models
+        (modality, provider, model, voice, voices, creator, source, licensing,
+         on_prem, region, arena_enabled, collected, published,
+         updated_by_user_id, updated_by_email)
+    VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+    RETURNING id, updated_at
+"""
+
+_UPDATE_MODEL = """
+    UPDATE benchmarks_v2.models
+    SET provider = %s, model = %s, voice = %s, voices = %s, creator = %s,
+        source = %s, licensing = %s, on_prem = %s, region = %s,
+        arena_enabled = %s, collected = %s, published = %s,
+        updated_by_user_id = %s, updated_by_email = %s,
+        -- Strictly monotonic per row: the 412 stale check compares this exactly,
+        -- so same-microsecond updates must still produce a new value.
+        updated_at = GREATEST(now(), updated_at + interval '1 microsecond')
+    WHERE id = %s
+    RETURNING updated_at
+"""
+
+_INSERT_HISTORY = """
+    INSERT INTO benchmarks_v2.model_history
+        (model_id, modality, provider, model, old, new,
+         changed_by_user_id, changed_by_org_id, changed_by_email)
+    VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
+"""
+
+
+def _record(row: Mapping[str, Any]) -> ModelRecord:
+    return ModelRecord.model_validate({**row, "tags": tuple(row["tags"])})
+
+
+def _snapshot(record: ModelRecord) -> Jsonb:
+    return Jsonb(record.model_dump(mode="json"))
+
+
+class RegistryStore:
+    """Per-pool persistence helper for the model and tag registries."""
+
+    def __init__(self, pool: RegistryPool) -> None:
+        self._pool = pool
+
+    async def list_tags(self) -> list[TagRecord]:
+        sql = "SELECT value, category, label FROM benchmarks_v2.tags ORDER BY value"
+        async with self._pool.connection() as conn:
+            rows = await (await conn.execute(sql)).fetchall()
+        return [TagRecord.model_validate(dict(row)) for row in rows]
+
+    async def insert_tag(self, tag: TagRecord) -> TagRecord:
+        sql = """
+            INSERT INTO benchmarks_v2.tags (value, category, label)
+            VALUES (%s, %s, %s)
+        """
+        try:
+            async with self._pool.connection() as conn, conn.transaction():
+                await conn.execute(sql, (tag.value, tag.category, tag.label))
+        except psycopg.errors.UniqueViolation as exc:
+            raise DuplicateKey(f"tag {tag.value!r} already exists") from exc
+        return tag
+
+    async def list_models(self) -> list[ModelRecord]:
+        async with self._pool.connection() as conn:
+            rows = await (await conn.execute(f"{_SELECT_MODELS} ORDER BY m.id")).fetchall()
+        return [_record(row) for row in rows]
+
+    async def get_model(self, model_id: int) -> ModelRecord | None:
+        async with self._pool.connection() as conn:
+            row = await (
+                await conn.execute(f"{_SELECT_MODELS} WHERE m.id = %s", (model_id,))
+            ).fetchone()
+        return None if row is None else _record(row)
+
+    async def insert_model(
+        self,
+        new: NewModel,
+        *,
+        user_id: str,
+        org_id: str | None,
+        email: str | None,
+    ) -> ModelRecord:
+        """Insert a model with its tags and a creation history row, atomically."""
+        try:
+            async with self._pool.connection() as conn, conn.transaction():
+                row = await (
+                    await conn.execute(
+                        _INSERT_MODEL,
+                        (
+                            new.modality,
+                            new.provider,
+                            new.model,
+                            new.voice,
+                            Jsonb([voice.model_dump(mode="json") for voice in new.voices]),
+                            new.creator,
+                            new.source,
+                            new.licensing,
+                            new.on_prem,
+                            new.region,
+                            new.arena_enabled,
+                            new.collected,
+                            new.published,
+                            user_id,
+                            email,
+                        ),
+                    )
+                ).fetchone()
+                if row is None:  # pragma: no cover — unreachable after INSERT RETURNING
+                    raise RuntimeError("INSERT INTO benchmarks_v2.models returned no row")
+                record = ModelRecord.model_validate(
+                    {
+                        **new.model_dump(),
+                        "id": row["id"],
+                        "updated_by_user_id": user_id,
+                        "updated_by_email": email,
+                        "updated_at": row["updated_at"],
+                    }
+                )
+                await self._write_tags(conn, record.id, new.tags)
+                await conn.execute(
+                    _INSERT_HISTORY,
+                    (
+                        record.id,
+                        record.modality,
+                        record.provider,
+                        record.model,
+                        None,
+                        _snapshot(record),
+                        user_id,
+                        org_id,
+                        email,
+                    ),
+                )
+        except psycopg.errors.UniqueViolation as exc:
+            raise DuplicateKey(
+                f"model ({new.modality}, {new.provider}, {new.model}) already exists"
+            ) from exc
+        return record
+
+    async def update_model(
+        self,
+        model_id: int,
+        changes: Mapping[str, Any],
+        *,
+        expected_updated_at: datetime,
+        user_id: str,
+        org_id: str | None,
+        email: str | None,
+    ) -> tuple[ModelRecord, ModelRecord] | None:
+        """Apply *changes* to one model; return (before, after), or ``None`` if absent.
+
+        Raises ``StaleEdit`` when the row changed since *expected_updated_at*, and
+        ``DuplicateKey`` when a rename collides. A no-op returns before as after
+        and writes nothing, so history only ever records real differences.
+        """
+        unknown = set(changes) - EDITABLE_FIELDS
+        if unknown:
+            raise ValueError(f"uneditable fields: {sorted(unknown)}")
+        try:
+            async with self._pool.connection() as conn, conn.transaction():
+                row = await (
+                    await conn.execute(
+                        f"{_SELECT_MODELS} WHERE m.id = %s FOR UPDATE OF m", (model_id,)
+                    )
+                ).fetchone()
+                if row is None:
+                    return None
+                before = _record(row)
+                if before.updated_at != expected_updated_at:
+                    raise StaleEdit(before)
+                merged = ModelRecord.model_validate({**before.model_dump(), **dict(changes)})
+                if merged == before:
+                    return before, before
+                updated = await (
+                    await conn.execute(
+                        _UPDATE_MODEL,
+                        (
+                            merged.provider,
+                            merged.model,
+                            merged.voice,
+                            Jsonb([voice.model_dump(mode="json") for voice in merged.voices]),
+                            merged.creator,
+                            merged.source,
+                            merged.licensing,
+                            merged.on_prem,
+                            merged.region,
+                            merged.arena_enabled,
+                            merged.collected,
+                            merged.published,
+                            user_id,
+                            email,
+                            model_id,
+                        ),
+                    )
+                ).fetchone()
+                if updated is None:  # pragma: no cover — unreachable, the row is locked
+                    raise RuntimeError("UPDATE benchmarks_v2.models returned no row")
+                if merged.tags != before.tags:
+                    await conn.execute(
+                        "DELETE FROM benchmarks_v2.model_tags WHERE model_id = %s", (model_id,)
+                    )
+                    await self._write_tags(conn, model_id, merged.tags)
+                after = merged.model_copy(
+                    update={
+                        "updated_by_user_id": user_id,
+                        "updated_by_email": email,
+                        "updated_at": updated["updated_at"],
+                    }
+                )
+                await conn.execute(
+                    _INSERT_HISTORY,
+                    (
+                        model_id,
+                        after.modality,
+                        after.provider,
+                        after.model,
+                        _snapshot(before),
+                        _snapshot(after),
+                        user_id,
+                        org_id,
+                        email,
+                    ),
+                )
+        except psycopg.errors.UniqueViolation as exc:
+            raise DuplicateKey(
+                f"a model named ({before.modality}, {merged.provider}, {merged.model}) exists"
+            ) from exc
+        return before, after
+
+    async def recent_history(self, per_model: int = 5) -> dict[int, list[ModelChange]]:
+        """The newest *per_model* history rows for every model that has any."""
+        sql = """
+            SELECT * FROM (
+                SELECT h.*,
+                       row_number() OVER (
+                           PARTITION BY model_id ORDER BY changed_at DESC, id DESC
+                       ) AS rn
+                FROM benchmarks_v2.model_history h
+            ) numbered
+            WHERE rn <= %s
+            ORDER BY model_id, changed_at DESC, id DESC
+        """
+        async with self._pool.connection() as conn:
+            rows = await (await conn.execute(sql, (per_model,))).fetchall()
+        history: dict[int, list[ModelChange]] = {}
+        for row in rows:
+            change = ModelChange.model_validate(dict(row))
+            history.setdefault(change.model_id, []).append(change)
+        return history
+
+    @staticmethod
+    async def _write_tags(
+        conn: psycopg.AsyncConnection[psycopg.rows.DictRow],
+        model_id: int,
+        tags: tuple[str, ...],
+    ) -> None:
+        if not tags:
+            return
+        async with conn.cursor() as cur:
+            await cur.executemany(
+                "INSERT INTO benchmarks_v2.model_tags (model_id, tag) VALUES (%s, %s)",
+                [(model_id, tag) for tag in tags],
+            )

--- a/runner/src/coval_bench/db/registry_store.py
+++ b/runner/src/coval_bench/db/registry_store.py
@@ -362,6 +362,18 @@ class RegistryStore:
             ) from exc
         return before, after
 
+    async def history(self, model_id: int, limit: int = 5) -> list[ModelChange]:
+        """The newest *limit* history rows for one model, newest first."""
+        sql = """
+            SELECT * FROM benchmarks_v2.model_history
+            WHERE model_id = %s
+            ORDER BY changed_at DESC, id DESC
+            LIMIT %s
+        """
+        async with self._pool.connection() as conn:
+            rows = await (await conn.execute(sql, (model_id, limit))).fetchall()
+        return [ModelChange.model_validate(dict(row)) for row in rows]
+
     async def recent_history(self, per_model: int = 5) -> dict[int, list[ModelChange]]:
         """The newest *per_model* history rows for every model that has any."""
         sql = """

--- a/runner/src/coval_bench/registries/provider_keys.py
+++ b/runner/src/coval_bench/registries/provider_keys.py
@@ -18,6 +18,30 @@ separate ``gradium_api_key`` for the STT provider), so it maps to
 
 from __future__ import annotations
 
+import functools
+import importlib.util
+import pkgutil
+from typing import Literal
+
+
+@functools.cache
+def provider_names(kind: Literal["stt", "tts"]) -> frozenset[str]:
+    """Provider names for a modality, listed from the provider package's modules.
+
+    A provider module is named exactly its registry key; shared helpers start
+    with an underscore. Listing files skips the class imports, so the answer
+    does not depend on which optional SDK extras are installed.
+    """
+    spec = importlib.util.find_spec(f"coval_bench.providers.{kind}")
+    if spec is None or spec.submodule_search_locations is None:  # pragma: no cover
+        raise RuntimeError(f"provider package coval_bench.providers.{kind} not found")
+    return frozenset(
+        module.name
+        for module in pkgutil.iter_modules(spec.submodule_search_locations)
+        if not module.name.startswith("_")
+    )
+
+
 PROVIDER_ENV: dict[str, str] = {
     "openai": "OPENAI_API_KEY",
     "cartesia": "CARTESIA_API_KEY",

--- a/runner/tests/api/conftest.py
+++ b/runner/tests/api/conftest.py
@@ -220,7 +220,7 @@ def _load_schema(**connect_kwargs: Any) -> None:
                 PRIMARY KEY (provider, model, benchmark, dataset_id, metric_type, bucket_at)
             )
         """)
-        # Model/tag registry tables (mirrors migration 20260824_0019).
+        # Model/tag registry tables (mirrors migration 20260824_0020).
         conn.execute("""
             CREATE TABLE IF NOT EXISTS benchmarks_v2.models (
                 id            bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,

--- a/runner/tests/api/conftest.py
+++ b/runner/tests/api/conftest.py
@@ -220,6 +220,63 @@ def _load_schema(**connect_kwargs: Any) -> None:
                 PRIMARY KEY (provider, model, benchmark, dataset_id, metric_type, bucket_at)
             )
         """)
+        # Model/tag registry tables (mirrors migration 20260824_0019).
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS benchmarks_v2.models (
+                id            bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+                modality      text NOT NULL CHECK (modality IN ('STT','TTS','S2S')),
+                provider      text NOT NULL CHECK (provider <> ''),
+                model         text NOT NULL CHECK (model <> ''),
+                voice         text CHECK (voice IS NULL OR voice <> ''),
+                voices        jsonb NOT NULL DEFAULT '[]' CHECK (jsonb_typeof(voices) = 'array'),
+                creator       text CHECK (creator IS NULL OR creator <> ''),
+                source        text NOT NULL DEFAULT 'official-api' CHECK (source <> ''),
+                licensing     text NOT NULL DEFAULT 'proprietary' CHECK (licensing <> ''),
+                on_prem       boolean NOT NULL DEFAULT false,
+                region        text CHECK (region IN ('us','eu','asia')),
+                arena_enabled boolean NOT NULL DEFAULT true,
+                collected     boolean NOT NULL,
+                published     boolean NOT NULL,
+                updated_by_user_id text NOT NULL CHECK (updated_by_user_id <> ''),
+                updated_by_email   text CHECK (updated_by_email IS NULL OR updated_by_email <> ''),
+                updated_at    timestamptz NOT NULL DEFAULT now(),
+                UNIQUE (modality, provider, model)
+            )
+        """)
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS benchmarks_v2.tags (
+                value    text PRIMARY KEY CHECK (value <> ''),
+                category text NOT NULL CHECK (category IN ('mode','features')),
+                label    text NOT NULL CHECK (label <> '')
+            )
+        """)
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS benchmarks_v2.model_tags (
+                model_id bigint NOT NULL REFERENCES benchmarks_v2.models(id) ON DELETE CASCADE,
+                tag      text NOT NULL REFERENCES benchmarks_v2.tags(value),
+                PRIMARY KEY (model_id, tag)
+            )
+        """)
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS benchmarks_v2.model_history (
+                id        bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+                model_id  bigint NOT NULL,
+                modality  text NOT NULL CHECK (modality IN ('STT','TTS','S2S')),
+                provider  text NOT NULL CHECK (provider <> ''),
+                model     text NOT NULL CHECK (model <> ''),
+                old       jsonb CHECK (old IS NULL OR jsonb_typeof(old) = 'object'),
+                new       jsonb NOT NULL CHECK (jsonb_typeof(new) = 'object'),
+                changed_by_user_id text NOT NULL CHECK (changed_by_user_id <> ''),
+                changed_by_org_id  text
+                    CHECK (changed_by_org_id IS NULL OR changed_by_org_id <> ''),
+                changed_by_email   text CHECK (changed_by_email IS NULL OR changed_by_email <> ''),
+                changed_at timestamptz NOT NULL DEFAULT now()
+            )
+        """)
+        conn.execute("""
+            CREATE INDEX IF NOT EXISTS model_history_model_id_changed_at
+                ON benchmarks_v2.model_history (model_id, changed_at DESC)
+        """)
 
 
 postgresql_proc = factories.postgresql_proc(load=[_load_schema])

--- a/runner/tests/api/test_admin_auth.py
+++ b/runner/tests/api/test_admin_auth.py
@@ -1,0 +1,121 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""The admin auth dependency: 401 without a proven token, 403 outside the coval org."""
+
+from __future__ import annotations
+
+import json
+import time
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from fastapi import HTTPException
+
+from coval_bench.api import clerk
+from coval_bench.api.deps import require_coval_admin
+from coval_bench.config import Settings
+from tests.api.conftest import (
+    _CLERK_PUBLIC_PEM,
+    CLERK_ISSUER,
+    CLERK_PARTY,
+    COVAL_ORG,
+    mint_clerk_token,
+)
+
+
+@pytest.fixture(autouse=True)
+def _stub_jwks(monkeypatch: pytest.MonkeyPatch) -> None:
+    signing_key = SimpleNamespace(key=_CLERK_PUBLIC_PEM)
+    client = SimpleNamespace(get_signing_key_from_jwt=lambda token: signing_key)
+    monkeypatch.setattr(clerk, "_jwks", lambda issuer: client)
+
+
+def _settings(monkeypatch: pytest.MonkeyPatch, coval_org: str | None = COVAL_ORG) -> Settings:
+    monkeypatch.setenv("DATABASE_URL", "postgresql://runner:password@localhost:5432/benchmarks")
+    monkeypatch.setenv("DATASET_BUCKET", "test-bucket")
+    monkeypatch.setenv("DATASET_ID", "stt-v1")
+    monkeypatch.setenv("CLERK_ISSUER", CLERK_ISSUER)
+    monkeypatch.setenv("CLERK_AUTHORIZED_PARTIES", json.dumps([CLERK_PARTY]))
+    if coval_org is None:
+        monkeypatch.delenv("CLERK_COVAL_ORG", raising=False)
+    else:
+        monkeypatch.setenv("CLERK_COVAL_ORG", coval_org)
+    return Settings()
+
+
+def _admin(settings: Settings, authorization: str | None) -> clerk.CovalAdmin:
+    return require_coval_admin(authorization=authorization, settings=settings)
+
+
+def _bearer(**claims: Any) -> str:
+    return f"Bearer {mint_clerk_token(**claims)}"
+
+
+@pytest.mark.parametrize("authorization", [None, "", "Token abc", "Bearer ", "Bearer not-a-jwt"])
+def test_unproven_tokens_are_401(
+    monkeypatch: pytest.MonkeyPatch, authorization: str | None
+) -> None:
+    settings = _settings(monkeypatch)
+    with pytest.raises(HTTPException) as exc:
+        _admin(settings, authorization)
+    assert exc.value.status_code == 401
+    assert exc.value.headers is not None
+    assert exc.value.headers["WWW-Authenticate"] == "Bearer"
+
+
+def test_expired_token_is_401(monkeypatch: pytest.MonkeyPatch) -> None:
+    settings = _settings(monkeypatch)
+    now = int(time.time())
+    header = _bearer(sub="user_1", org_id=COVAL_ORG, iat=now - 120, exp=now - 60)
+    with pytest.raises(HTTPException) as exc:
+        _admin(settings, header)
+    assert exc.value.status_code == 401
+
+
+def test_token_without_a_subject_is_401(monkeypatch: pytest.MonkeyPatch) -> None:
+    settings = _settings(monkeypatch)
+    with pytest.raises(HTTPException) as exc:
+        _admin(settings, _bearer(org_id=COVAL_ORG))
+    assert exc.value.status_code == 401
+
+
+@pytest.mark.parametrize(
+    "claims",
+    [
+        {},
+        {"org_id": "org_test_first"},
+        {"org_id": COVAL_ORG + "x"},
+        {"org_id": [COVAL_ORG]},
+    ],
+)
+def test_tokens_outside_the_coval_org_are_403(
+    monkeypatch: pytest.MonkeyPatch, claims: dict[str, Any]
+) -> None:
+    settings = _settings(monkeypatch)
+    with pytest.raises(HTTPException) as exc:
+        _admin(settings, _bearer(sub="user_1", **claims))
+    assert exc.value.status_code == 403
+
+
+def test_unset_coval_org_is_403_for_everyone(monkeypatch: pytest.MonkeyPatch) -> None:
+    settings = _settings(monkeypatch, coval_org=None)
+    with pytest.raises(HTTPException) as exc:
+        _admin(settings, _bearer(sub="user_1", org_id=COVAL_ORG))
+    assert exc.value.status_code == 403
+
+
+def test_coval_org_token_yields_the_caller(monkeypatch: pytest.MonkeyPatch) -> None:
+    settings = _settings(monkeypatch)
+    admin = _admin(settings, _bearer(sub="user_1", org_id=COVAL_ORG, email="cale@coval.dev"))
+    assert admin == clerk.CovalAdmin(user_id="user_1", org_id=COVAL_ORG, email="cale@coval.dev")
+
+
+@pytest.mark.parametrize("claims", [{}, {"email": ""}, {"email": 7}])
+def test_a_missing_blank_or_malformed_email_is_none(
+    monkeypatch: pytest.MonkeyPatch, claims: dict[str, Any]
+) -> None:
+    settings = _settings(monkeypatch)
+    admin = _admin(settings, _bearer(sub="user_1", org_id=COVAL_ORG, **claims))
+    assert admin.email is None

--- a/runner/tests/api/test_admin_auth.py
+++ b/runner/tests/api/test_admin_auth.py
@@ -109,7 +109,7 @@ def test_unset_coval_org_is_403_for_everyone(monkeypatch: pytest.MonkeyPatch) ->
 def test_coval_org_token_yields_the_caller(monkeypatch: pytest.MonkeyPatch) -> None:
     settings = _settings(monkeypatch)
     admin = _admin(settings, _bearer(sub="user_1", org_id=COVAL_ORG, email="cale@coval.dev"))
-    assert admin == clerk.CovalAdmin(user_id="user_1", org_id=COVAL_ORG, email="cale@coval.dev")
+    assert admin == clerk.CovalAdmin(user_id="user_1", email="cale@coval.dev")
 
 
 @pytest.mark.parametrize("claims", [{}, {"email": ""}, {"email": 7}])

--- a/runner/tests/api/test_admin_models.py
+++ b/runner/tests/api/test_admin_models.py
@@ -1,0 +1,401 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""The admin registry endpoints over HTTP."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import psycopg
+import pytest
+from httpx import AsyncClient
+from psycopg.types.json import Jsonb
+
+from coval_bench.api.internal import _RETIRED_BOARD_KEYS
+from coval_bench.api.routers import admin_models
+from coval_bench.api.routers.admin_models import _implemented_providers as _real_implemented
+from coval_bench.registries import Benchmark
+from coval_bench.registries.metrics import METRIC_EXCLUSIONS
+from tests.api.conftest import COVAL_ORG, EA_ORG, _make_db_url, bearer
+
+_EXCLUDED_METRIC, _EXCLUDED_PAIRS = next(iter(METRIC_EXCLUSIONS.items()))
+_EXCLUDED_PROVIDER, _EXCLUDED_MODEL = sorted(_EXCLUDED_PAIRS)[0]
+_RETIRED_KEY, _CURRENT_KEY = next(iter(_RETIRED_BOARD_KEYS.items()))
+
+
+@pytest.fixture(autouse=True)
+def _fake_provider_registry(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Bypass the SDK-heavy provider imports; the real resolver has its own test."""
+    implemented = frozenset({"acme", _EXCLUDED_PROVIDER})
+    monkeypatch.setattr(
+        admin_models,
+        "_implemented_providers",
+        lambda modality: None if modality is Benchmark.S2S else implemented,
+    )
+
+
+_VOICES_JSON = [
+    {"id": "voice-f", "gender": "female", "name": "Ada", "accent": None},
+    {"id": "voice-m", "gender": "male", "name": None, "accent": None},
+]
+
+
+def _admin_headers() -> dict[str, str]:
+    return bearer(sub="user_admin", org_id=COVAL_ORG, email="admin@coval.dev")
+
+
+async def _exec(postgresql: Any, sql: str, params: tuple[Any, ...]) -> Any:
+    aconn = await psycopg.AsyncConnection.connect(_make_db_url(postgresql), autocommit=True)
+    try:
+        cur = await aconn.execute(sql, params)
+        return (await cur.fetchone()) if cur.description else None
+    finally:
+        await aconn.close()
+
+
+async def _seed_tag(postgresql: Any, value: str, category: str) -> None:
+    await _exec(
+        postgresql,
+        "INSERT INTO benchmarks_v2.tags (value, category, label) VALUES (%s, %s, %s)",
+        (value, category, value.capitalize()),
+    )
+
+
+async def _seed_model(postgresql: Any, **overrides: Any) -> int:
+    fields: dict[str, Any] = {
+        "modality": "STT",
+        "provider": "acme",
+        "model": "stt-1",
+        "voice": None,
+        "voices": Jsonb([]),
+        "region": None,
+        "collected": True,
+        "published": False,
+        "tags": (),
+    }
+    fields.update(overrides)
+    tags = fields.pop("tags")
+    row = await _exec(
+        postgresql,
+        """
+        INSERT INTO benchmarks_v2.models
+            (modality, provider, model, voice, voices, region, collected, published,
+             updated_by_user_id, updated_by_email)
+        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, 'user_seed', 'seed@coval.dev')
+        RETURNING id
+        """,
+        (
+            fields["modality"],
+            fields["provider"],
+            fields["model"],
+            fields["voice"],
+            fields["voices"],
+            fields["region"],
+            fields["collected"],
+            fields["published"],
+        ),
+    )
+    model_id = int(row[0])
+    for tag in tags:
+        await _exec(
+            postgresql,
+            "INSERT INTO benchmarks_v2.model_tags (model_id, tag) VALUES (%s, %s)",
+            (model_id, tag),
+        )
+    return model_id
+
+
+async def _seed_history(
+    postgresql: Any, model_id: int, *, old: dict[str, Any] | None, new: dict[str, Any]
+) -> None:
+    await _exec(
+        postgresql,
+        """
+        INSERT INTO benchmarks_v2.model_history
+            (model_id, modality, provider, model, old, new, changed_by_user_id)
+        VALUES (%s, 'STT', 'acme', 'stt-1', %s, %s, 'user_seed')
+        """,
+        (model_id, None if old is None else Jsonb(old), Jsonb(new)),
+    )
+
+
+async def test_admin_reads_require_a_token(client: AsyncClient) -> None:
+    response = await client.get("/v1/admin/models")
+    assert response.status_code == 401
+    assert response.headers["WWW-Authenticate"] == "Bearer"
+
+
+async def test_admin_reads_reject_partner_orgs(client: AsyncClient) -> None:
+    headers = bearer(sub="user_partner", org_id=EA_ORG)
+    assert (await client.get("/v1/admin/models", headers=headers)).status_code == 403
+
+
+async def test_empty_registry_reads_as_empty(client: AsyncClient) -> None:
+    response = await client.get("/v1/admin/models", headers=_admin_headers())
+    assert response.status_code == 200
+    assert response.json() == {"models": []}
+    assert response.headers["Cache-Control"] == "private, no-store"
+    assert "Authorization" in response.headers["Vary"]
+
+    response = await client.get("/v1/tags")
+    assert response.status_code == 200
+    assert response.json() == {"tags": []}
+
+
+async def test_models_list_state_tags_and_history(client: AsyncClient, postgresql: Any) -> None:
+    await _seed_tag(postgresql, "streaming", "mode")
+    await _seed_tag(postgresql, "vad", "features")
+    first = await _seed_model(
+        postgresql,
+        modality="TTS",
+        model="tts-1",
+        voice="voice-f",
+        voices=Jsonb(_VOICES_JSON),
+        region="eu",
+        tags=("vad", "streaming"),
+    )
+    second = await _seed_model(postgresql, model="stt-2", collected=False)
+    await _seed_history(postgresql, first, old=None, new={"published": False})
+    await _seed_history(postgresql, first, old={"published": False}, new={"published": True})
+
+    response = await client.get("/v1/admin/models", headers=_admin_headers())
+    assert response.status_code == 200
+    models = response.json()["models"]
+    assert [entry["id"] for entry in models] == [first, second]
+
+    tts = models[0]
+    assert (tts["modality"], tts["model"], tts["voice"]) == ("TTS", "tts-1", "voice-f")
+    assert (tts["source"], tts["licensing"], tts["region"]) == ("official-api", "proprietary", "eu")
+    assert (tts["collected"], tts["published"], tts["arena_enabled"]) == (True, False, True)
+    assert tts["voices"] == _VOICES_JSON
+    assert tts["tags"] == ["streaming", "vad"]
+    assert tts["updated_by_user_id"] == "user_seed"
+
+    newest, oldest = tts["history"]
+    assert (newest["old"], newest["new"]) == ({"published": False}, {"published": True})
+    assert (oldest["old"], oldest["new"]) == (None, {"published": False})
+    assert newest["changed_by_user_id"] == "user_seed"
+    assert newest["changed_by_org_id"] is None
+
+    assert models[1]["history"] == []
+    assert models[1]["collected"] is False
+
+
+async def test_the_tag_vocabulary_is_public(client: AsyncClient, postgresql: Any) -> None:
+    await _seed_tag(postgresql, "vad", "features")
+    await _seed_tag(postgresql, "streaming", "mode")
+
+    response = await client.get("/v1/tags")
+    assert response.status_code == 200
+    assert response.json() == {
+        "tags": [
+            {"value": "streaming", "category": "mode", "label": "Streaming"},
+            {"value": "vad", "category": "features", "label": "Vad"},
+        ]
+    }
+
+
+def _create_body(**overrides: Any) -> dict[str, Any]:
+    body: dict[str, Any] = {"modality": "STT", "provider": "acme", "model": "stt-new"}
+    body.update(overrides)
+    return body
+
+
+async def _post_model(client: AsyncClient, **overrides: Any) -> Any:
+    return await client.post(
+        "/v1/admin/models", json=_create_body(**overrides), headers=_admin_headers()
+    )
+
+
+def test_the_real_provider_registries_resolve() -> None:
+    stt = _real_implemented(Benchmark.STT)
+    tts = _real_implemented(Benchmark.TTS)
+    assert stt is not None and "deepgram" in stt
+    # Optional-SDK providers resolve even where their extras are not installed.
+    assert tts is not None and "google" in tts
+    assert _real_implemented(Benchmark.S2S) is None
+
+
+async def test_create_defaults_to_hidden(client: AsyncClient) -> None:
+    response = await _post_model(client)
+    assert response.status_code == 201
+    created = response.json()
+    assert (created["collected"], created["published"]) == (True, False)
+    assert (created["source"], created["licensing"]) == ("official-api", "proprietary")
+    assert created["updated_by_user_id"] == "user_admin"
+    assert created["updated_by_email"] == "admin@coval.dev"
+
+    (change,) = created["history"]  # the creation entry rides the POST response
+    assert change["old"] is None
+    assert change["new"]["model"] == "stt-new"
+
+    listed = (await client.get("/v1/admin/models", headers=_admin_headers())).json()["models"]
+    assert [entry["id"] for entry in listed] == [created["id"]]
+    (change,) = listed[0]["history"]
+    assert change["old"] is None
+    assert change["new"]["model"] == "stt-new"
+    assert change["changed_by_user_id"] == "user_admin"
+    assert change["changed_by_org_id"] is None
+
+
+async def test_create_requires_a_coval_token(client: AsyncClient) -> None:
+    assert (await client.post("/v1/admin/models", json=_create_body())).status_code == 401
+    partner = bearer(sub="user_partner", org_id=EA_ORG)
+    response = await client.post("/v1/admin/models", json=_create_body(), headers=partner)
+    assert response.status_code == 403
+
+
+async def test_create_rejects_duplicates_and_bad_input(client: AsyncClient) -> None:
+    assert (await _post_model(client)).status_code == 201
+    assert (await _post_model(client)).status_code == 409
+    assert (await _post_model(client, provider="nope")).status_code == 422
+    assert (await _post_model(client, model="tagged", tags=["mystery"])).status_code == 422
+
+
+async def test_create_s2s_skips_the_provider_check(client: AsyncClient) -> None:
+    response = await _post_model(client, modality="S2S", provider="anyone", model="s2s-1")
+    assert response.status_code == 201
+
+
+async def test_collected_tts_needs_a_voice(client: AsyncClient) -> None:
+    assert (await _post_model(client, modality="TTS", model="tts-1")).status_code == 422
+    ok = await _post_model(client, modality="TTS", model="tts-1", voice="v")
+    assert ok.status_code == 201
+    paused = await _post_model(client, modality="TTS", model="tts-2", collected=False)
+    assert paused.status_code == 201
+
+
+async def test_a_voice_pool_is_one_female_one_male(client: AsyncClient) -> None:
+    lopsided = [{"id": "a", "gender": "female"}, {"id": "b", "gender": "female"}]
+    response = await _post_model(client, modality="TTS", model="tts-1", voices=lopsided)
+    assert response.status_code == 422
+    shared_id = [{"id": "a", "gender": "female"}, {"id": "a", "gender": "male"}]
+    response = await _post_model(client, modality="TTS", model="tts-1", voices=shared_id)
+    assert response.status_code == 422
+    paired = [{"id": "a", "gender": "female"}, {"id": "b", "gender": "male"}]
+    response = await _post_model(client, modality="TTS", model="tts-1", voices=paired)
+    assert response.status_code == 201
+
+
+async def test_voices_are_tts_only(client: AsyncClient) -> None:
+    assert (await _post_model(client, voice="v")).status_code == 422
+    s2s = await _post_model(client, modality="S2S", provider="anyone", model="s2s-1", voice="v")
+    assert s2s.status_code == 422
+    pool = [{"id": "a", "gender": "female"}, {"id": "b", "gender": "male"}]
+    assert (await _post_model(client, voices=pool)).status_code == 422
+
+
+async def test_empty_strings_are_rejected_before_the_database(client: AsyncClient) -> None:
+    assert (await _post_model(client, modality="TTS", voice="")).status_code == 422
+    assert (await _post_model(client, creator="")).status_code == 422
+    created = (await _post_model(client)).json()
+    response = await _patch(client, created["id"], created["updated_at"], {"voice": ""})
+    assert response.status_code == 422
+    body = {"value": "", "category": "mode", "label": "Streaming"}
+    admin = _admin_headers()
+    assert (await client.post("/v1/tags", json=body, headers=admin)).status_code == 422
+    body = {"value": "streaming", "category": "mode", "label": ""}
+    assert (await client.post("/v1/tags", json=body, headers=admin)).status_code == 422
+
+
+async def _patch(
+    client: AsyncClient, model_id: int, stamp: str | None, body: dict[str, Any]
+) -> Any:
+    headers = _admin_headers()
+    if stamp is not None:
+        headers["If-Unmodified-Since"] = stamp
+    return await client.patch(f"/v1/admin/models/{model_id}", json=body, headers=headers)
+
+
+async def test_patch_flips_state_and_records_history(client: AsyncClient) -> None:
+    created = (await _post_model(client)).json()
+    response = await _patch(client, created["id"], created["updated_at"], {"published": True})
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["warnings"] == []
+    assert payload["model"]["published"] is True
+    assert payload["model"]["updated_at"] != created["updated_at"]
+    newest = payload["model"]["history"][0]
+    assert (newest["old"]["published"], newest["new"]["published"]) == (False, True)
+
+
+async def test_patch_requires_the_precondition_stamp(client: AsyncClient) -> None:
+    created = (await _post_model(client)).json()
+    assert (await _patch(client, created["id"], None, {"published": True})).status_code == 428
+    assert (await _patch(client, created["id"], "not-a-time", {})).status_code == 400
+    naive = "2026-01-01T00:00:00"
+    assert (await _patch(client, created["id"], naive, {})).status_code == 400
+
+
+async def test_patch_from_a_stale_stamp_is_412(client: AsyncClient) -> None:
+    created = (await _post_model(client)).json()
+    first = await _patch(client, created["id"], created["updated_at"], {"published": True})
+    assert first.status_code == 200
+    stale = await _patch(client, created["id"], created["updated_at"], {"collected": False})
+    assert stale.status_code == 412
+
+
+async def test_a_noop_patch_writes_no_history(client: AsyncClient) -> None:
+    created = (await _post_model(client)).json()
+    response = await _patch(client, created["id"], created["updated_at"], {"collected": True})
+    assert response.status_code == 200
+    assert len(response.json()["model"]["history"]) == 1  # the creation row only
+
+
+async def test_patch_null_rules(client: AsyncClient) -> None:
+    created = (await _post_model(client)).json()
+    rejected = await _patch(client, created["id"], created["updated_at"], {"provider": None})
+    assert rejected.status_code == 422
+    allowed = await _patch(client, created["id"], created["updated_at"], {"creator": None})
+    assert allowed.status_code == 200
+
+
+async def test_patch_unknown_model_is_404(client: AsyncClient) -> None:
+    created = (await _post_model(client)).json()
+    response = await _patch(client, created["id"] + 1, created["updated_at"], {})
+    assert response.status_code == 404
+
+
+async def test_patch_rename_collision_is_409(client: AsyncClient) -> None:
+    first = (await _post_model(client, model="stt-1")).json()
+    second = (await _post_model(client, model="stt-2")).json()
+    response = await _patch(client, second["id"], second["updated_at"], {"model": "stt-1"})
+    assert response.status_code == 409
+    assert first["model"] == "stt-1"
+
+
+async def test_a_rename_warns_about_code_references(client: AsyncClient) -> None:
+    created = (await _post_model(client, provider=_EXCLUDED_PROVIDER, model=_EXCLUDED_MODEL)).json()
+    response = await _patch(
+        client, created["id"], created["updated_at"], {"model": f"{_EXCLUDED_MODEL}-renamed"}
+    )
+    assert response.status_code == 200
+    warnings = response.json()["warnings"]
+    assert any("METRIC_EXCLUSIONS" in warning for warning in warnings)
+
+
+async def test_a_rename_warns_about_retired_board_keys(client: AsyncClient) -> None:
+    provider, model = _CURRENT_KEY
+    created = (await _post_model(client, modality="S2S", provider=provider, model=model)).json()
+    response = await _patch(
+        client, created["id"], created["updated_at"], {"model": _RETIRED_KEY[1]}
+    )
+    assert response.status_code == 200
+    warnings = "\n".join(response.json()["warnings"])
+    assert "no longer exists" in warnings
+    if _RETIRED_KEY[0] == provider:
+        assert "retired board key" in warnings
+
+
+async def test_tag_creation_is_coval_gated(client: AsyncClient) -> None:
+    body = {"value": "emotion-control", "category": "features", "label": "Emotion control"}
+    assert (await client.post("/v1/tags", json=body)).status_code == 401
+    partner = bearer(sub="user_partner", org_id=EA_ORG)
+    assert (await client.post("/v1/tags", json=body, headers=partner)).status_code == 403
+
+    created = await client.post("/v1/tags", json=body, headers=_admin_headers())
+    assert created.status_code == 201
+    assert created.json() == body
+    assert (await client.post("/v1/tags", json=body, headers=_admin_headers())).status_code == 409
+    assert (await client.get("/v1/tags")).json() == {"tags": [body]}

--- a/runner/tests/api/test_admin_models.py
+++ b/runner/tests/api/test_admin_models.py
@@ -253,6 +253,15 @@ async def test_create_rejects_duplicates_and_bad_input(client: AsyncClient) -> N
     assert (await _post_model(client, model="tagged", tags=["mystery"])).status_code == 422
 
 
+async def test_a_stopped_model_may_name_a_dead_provider(client: AsyncClient) -> None:
+    """History rows for providers whose code is gone stay importable, never collectable."""
+    created = await _post_model(client, provider="gone", collected=False, published=False)
+    assert created.status_code == 201
+    body = created.json()
+    revive = await _patch(client, body["id"], f'"{body["updated_at"]}"', {"collected": True})
+    assert revive.status_code == 422
+
+
 async def test_create_s2s_skips_the_provider_check(client: AsyncClient) -> None:
     response = await _post_model(client, modality="S2S", provider="anyone", model="s2s-1")
     assert response.status_code == 201

--- a/runner/tests/api/test_admin_models.py
+++ b/runner/tests/api/test_admin_models.py
@@ -304,7 +304,7 @@ async def _patch(
 ) -> Any:
     headers = _admin_headers()
     if stamp is not None:
-        headers["If-Unmodified-Since"] = stamp
+        headers["If-Match"] = stamp
     return await client.patch(f"/v1/admin/models/{model_id}", json=body, headers=headers)
 
 
@@ -320,12 +320,22 @@ async def test_patch_flips_state_and_records_history(client: AsyncClient) -> Non
     assert (newest["old"]["published"], newest["new"]["published"]) == (False, True)
 
 
-async def test_patch_requires_the_precondition_stamp(client: AsyncClient) -> None:
+async def test_patch_requires_the_precondition_tag(client: AsyncClient) -> None:
     created = (await _post_model(client)).json()
     assert (await _patch(client, created["id"], None, {"published": True})).status_code == 428
-    assert (await _patch(client, created["id"], "not-a-time", {})).status_code == 400
-    naive = "2026-01-01T00:00:00"
-    assert (await _patch(client, created["id"], naive, {})).status_code == 400
+    assert (await _patch(client, created["id"], "*", {})).status_code == 400
+    # An unreadable or foreign tag matches nothing, same as a stale one.
+    assert (await _patch(client, created["id"], "not-a-time", {})).status_code == 412
+    assert (await _patch(client, created["id"], "2026-01-01T00:00:00", {})).status_code == 412
+
+
+async def test_the_response_etag_round_trips(client: AsyncClient) -> None:
+    response = await _post_model(client)
+    etag = response.headers["ETag"]
+    assert etag == f'"{response.json()["updated_at"]}"'
+    patched = await _patch(client, response.json()["id"], etag, {"published": True})
+    assert patched.status_code == 200
+    assert patched.headers["ETag"] == f'"{patched.json()["model"]["updated_at"]}"'
 
 
 async def test_patch_from_a_stale_stamp_is_412(client: AsyncClient) -> None:

--- a/runner/tests/api/test_cors.py
+++ b/runner/tests/api/test_cors.py
@@ -131,3 +131,33 @@ async def test_cors_vercel_other_project_disallowed(client: AsyncClient) -> None
     )
     acao = response.headers.get("access-control-allow-origin", "")
     assert acao != "https://other-project-covalai.vercel.app"
+
+
+async def _admin_preflight(client: AsyncClient, method: str, headers: str) -> dict[str, str]:
+    response = await client.options(
+        "/v1/admin/models",
+        headers={
+            "Origin": "http://localhost:3000",
+            "Access-Control-Request-Method": method,
+            "Access-Control-Request-Headers": headers,
+        },
+    )
+    return dict(response.headers)
+
+
+async def test_admin_write_methods_preflight(client: AsyncClient) -> None:
+    for method in ("POST", "PATCH"):
+        headers = await _admin_preflight(client, method, "authorization,content-type")
+        assert headers["access-control-allow-origin"] == "http://localhost:3000"
+        assert method in headers["access-control-allow-methods"]
+        assert "content-type" in headers["access-control-allow-headers"].lower()
+
+
+async def test_the_precondition_header_preflights(client: AsyncClient) -> None:
+    headers = await _admin_preflight(client, "PATCH", "authorization,if-unmodified-since")
+    assert "if-unmodified-since" in headers["access-control-allow-headers"].lower()
+
+
+async def test_delete_stays_disallowed(client: AsyncClient) -> None:
+    headers = await _admin_preflight(client, "DELETE", "authorization")
+    assert "DELETE" not in headers.get("access-control-allow-methods", "")

--- a/runner/tests/api/test_cors.py
+++ b/runner/tests/api/test_cors.py
@@ -154,8 +154,8 @@ async def test_admin_write_methods_preflight(client: AsyncClient) -> None:
 
 
 async def test_the_precondition_header_preflights(client: AsyncClient) -> None:
-    headers = await _admin_preflight(client, "PATCH", "authorization,if-unmodified-since")
-    assert "if-unmodified-since" in headers["access-control-allow-headers"].lower()
+    headers = await _admin_preflight(client, "PATCH", "authorization,if-match")
+    assert "if-match" in headers["access-control-allow-headers"].lower()
 
 
 async def test_delete_stays_disallowed(client: AsyncClient) -> None:

--- a/runner/tests/unit/test_provider_config.py
+++ b/runner/tests/unit/test_provider_config.py
@@ -5,6 +5,8 @@
 from __future__ import annotations
 
 import importlib
+import tomllib
+from pathlib import Path
 
 from coval_bench.registries import (
     MODEL_REGISTRY,
@@ -77,3 +79,13 @@ def test_registry_models_use_implemented_providers() -> None:
             assert model.provider in provider_names("stt"), model.provider
         elif model.benchmark is Benchmark.TTS:
             assert model.provider in provider_names("tts"), model.provider
+
+
+def test_the_runner_image_installs_every_provider_extra() -> None:
+    """The API accepts any provider with a module, so the runner must load them all."""
+    runner_root = Path(__file__).parents[2]
+    pyproject = tomllib.loads((runner_root / "pyproject.toml").read_text())
+    extras = set(pyproject["project"]["optional-dependencies"]) - {"hf-parquet"}  # build-time only
+    dockerfile = (runner_root / "Dockerfile").read_text()
+    missing = sorted(extra for extra in extras if f"--extra {extra}" not in dockerfile)
+    assert not missing, f"provider extras absent from the runner image: {missing}"

--- a/runner/tests/unit/test_provider_config.py
+++ b/runner/tests/unit/test_provider_config.py
@@ -72,9 +72,15 @@ def test_provider_names_cover_the_class_registries() -> None:
     assert provider_names("tts") - tts_classes <= {"google", "hume"}
 
 
-def test_registry_models_use_implemented_providers() -> None:
-    """Every benchmarked model's provider resolves without SDK imports."""
+def test_scheduled_models_use_implemented_providers() -> None:
+    """Every model the orchestrator may schedule resolves without SDK imports.
+
+    Stopped models are exempt: their rows outlive their provider's code.
+    """
+    scheduled = (ModelStatus.ACTIVE, ModelStatus.EARLY_ACCESS)
     for model in MODEL_REGISTRY:
+        if model.status not in scheduled:
+            continue
         if model.benchmark is Benchmark.STT:
             assert model.provider in provider_names("stt"), model.provider
         elif model.benchmark is Benchmark.TTS:

--- a/runner/tests/unit/test_provider_config.py
+++ b/runner/tests/unit/test_provider_config.py
@@ -4,6 +4,8 @@
 
 from __future__ import annotations
 
+import importlib
+
 from coval_bench.registries import (
     MODEL_REGISTRY,
     TAG_CATEGORIES,
@@ -14,6 +16,7 @@ from coval_bench.registries import (
     RegisteredModel,
     Source,
 )
+from coval_bench.registries.provider_keys import provider_names
 
 
 def test_every_tag_has_a_category() -> None:
@@ -54,3 +57,23 @@ def test_stt_models_have_no_voice() -> None:
     for m in MODEL_REGISTRY:
         if m.benchmark is Benchmark.STT:
             assert m.voice is None
+
+
+def test_provider_names_cover_the_class_registries() -> None:
+    """Every loadable provider class is reachable by its module name."""
+    stt_classes = set(importlib.import_module("coval_bench.providers.stt").STT_PROVIDERS)
+    tts_classes = set(importlib.import_module("coval_bench.providers.tts").TTS_PROVIDERS)
+    assert stt_classes <= provider_names("stt")
+    assert tts_classes <= provider_names("tts")
+    # Names with no loadable class must be exactly the optional-SDK providers.
+    assert provider_names("stt") - stt_classes <= {"google"}
+    assert provider_names("tts") - tts_classes <= {"google", "hume"}
+
+
+def test_registry_models_use_implemented_providers() -> None:
+    """Every benchmarked model's provider resolves without SDK imports."""
+    for model in MODEL_REGISTRY:
+        if model.benchmark is Benchmark.STT:
+            assert model.provider in provider_names("stt"), model.provider
+        elif model.benchmark is Benchmark.TTS:
+            assert model.provider in provider_names("tts"), model.provider

--- a/runner/tests/unit/test_registry_store.py
+++ b/runner/tests/unit/test_registry_store.py
@@ -109,6 +109,7 @@ def test_insert_model_roundtrips_and_writes_history(
         (change,) = history[created.id]
         assert change.old is None
         assert change.new["provider"] == "acme"
+        assert "updated_by_email" not in change.new
         assert change.new["tags"] == ["streaming"]
         assert change.changed_by_user_id == "user_editor"
         assert change.changed_by_org_id is None

--- a/runner/tests/unit/test_registry_store.py
+++ b/runner/tests/unit/test_registry_store.py
@@ -1,0 +1,305 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for coval_bench.db.registry_store.
+
+Uses ``pytest-postgresql`` (embedded ``pg_ctl``, no Docker) to spin up a real
+Postgres. No remote DB is ever contacted.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from typing import Any, TypedDict
+
+import psycopg
+import pytest
+from pytest_postgresql.factories import postgresql
+
+from coval_bench.db.registry_store import (
+    DuplicateKey,
+    NewModel,
+    RegistryStore,
+    StaleEdit,
+    TagRecord,
+)
+from coval_bench.registries import Benchmark, Gender, Voice
+
+from .conftest import apply_migrations, open_pool
+
+registry_pg = postgresql("pg_proc")  # shared server from conftest, own per-test DB
+
+_VOICES = (
+    Voice(id="voice-f", gender=Gender.FEMALE, name="Ada"),
+    Voice(id="voice-m", gender=Gender.MALE),
+)
+
+
+class _Identity(TypedDict):
+    user_id: str
+    org_id: str | None
+    email: str | None
+
+
+_EDITOR: _Identity = {"user_id": "user_editor", "org_id": None, "email": "editor@coval.dev"}
+
+
+def _new_model(
+    provider: str = "acme", model: str = "stt-1", modality: Benchmark = Benchmark.STT
+) -> NewModel:
+    return NewModel(modality=modality, provider=provider, model=model)
+
+
+def _with_store(
+    conn: psycopg.Connection[Any], scenario: Callable[[RegistryStore], Awaitable[None]]
+) -> None:
+    apply_migrations(conn)
+
+    async def _run() -> None:
+        pool = await open_pool(conn)
+        try:
+            await scenario(RegistryStore(pool))
+        finally:
+            await pool.close()
+
+    asyncio.run(_run())
+
+
+def _streaming_tag() -> TagRecord:
+    return TagRecord(value="streaming", category="mode", label="Streaming")
+
+
+def test_tags_roundtrip_and_reject_duplicates(registry_pg: psycopg.Connection[Any]) -> None:
+    async def scenario(store: RegistryStore) -> None:
+        await store.insert_tag(TagRecord(value="vad", category="features", label="VAD"))
+        await store.insert_tag(_streaming_tag())
+        assert [tag.value for tag in await store.list_tags()] == ["streaming", "vad"]
+        with pytest.raises(DuplicateKey):
+            await store.insert_tag(_streaming_tag())
+
+    _with_store(registry_pg, scenario)
+
+
+def test_insert_model_roundtrips_and_writes_history(
+    registry_pg: psycopg.Connection[Any],
+) -> None:
+    async def scenario(store: RegistryStore) -> None:
+        await store.insert_tag(_streaming_tag())
+        new = NewModel(
+            modality=Benchmark.TTS,
+            provider="acme",
+            model="tts-1",
+            voice="voice-f",
+            voices=_VOICES,
+            region="eu",
+            tags=("streaming",),
+        )
+        created = await store.insert_model(new, **_EDITOR)
+
+        fetched = await store.get_model(created.id)
+        assert fetched == created
+        assert await store.list_models() == [created]
+        assert created.voices == _VOICES
+        assert created.tags == ("streaming",)
+        assert created.updated_by_user_id == "user_editor"
+        assert created.updated_by_email == "editor@coval.dev"
+
+        history = await store.recent_history()
+        (change,) = history[created.id]
+        assert change.old is None
+        assert change.new["provider"] == "acme"
+        assert change.new["tags"] == ["streaming"]
+        assert change.changed_by_user_id == "user_editor"
+        assert change.changed_by_org_id is None
+
+    _with_store(registry_pg, scenario)
+
+
+def test_insert_rejects_a_duplicate_natural_key(registry_pg: psycopg.Connection[Any]) -> None:
+    async def scenario(store: RegistryStore) -> None:
+        await store.insert_model(_new_model(), **_EDITOR)
+        with pytest.raises(DuplicateKey):
+            await store.insert_model(_new_model(), **_EDITOR)
+        # The same provider/model under another modality is a different model.
+        await store.insert_model(_new_model(modality=Benchmark.TTS), **_EDITOR)
+
+    _with_store(registry_pg, scenario)
+
+
+def test_models_list_in_id_order(registry_pg: psycopg.Connection[Any]) -> None:
+    async def scenario(store: RegistryStore) -> None:
+        first = await store.insert_model(_new_model(model="stt-1"), **_EDITOR)
+        second = await store.insert_model(_new_model(model="stt-2"), **_EDITOR)
+        assert [record.id for record in await store.list_models()] == [first.id, second.id]
+        assert await store.get_model(first.id + second.id + 1) is None
+
+    _with_store(registry_pg, scenario)
+
+
+def test_update_applies_changes_and_appends_history(
+    registry_pg: psycopg.Connection[Any],
+) -> None:
+    async def scenario(store: RegistryStore) -> None:
+        created = await store.insert_model(_new_model(), **_EDITOR)
+        result = await store.update_model(
+            created.id,
+            {"published": True, "region": "us"},
+            expected_updated_at=created.updated_at,
+            user_id="user_second",
+            org_id="org_partner",
+            email=None,
+        )
+        assert result is not None
+        before, after = result
+        assert before == created
+        assert (after.published, after.region) == (True, "us")
+        assert after.updated_at != before.updated_at
+        assert after.updated_by_user_id == "user_second"
+        assert after.updated_by_email is None
+        assert await store.get_model(created.id) == after
+
+        changes = (await store.recent_history())[created.id]
+        assert [change.old is None for change in changes] == [False, True]
+        assert changes[0].old is not None
+        assert changes[0].old["published"] is False
+        assert changes[0].new["published"] is True
+        assert changes[0].changed_by_org_id == "org_partner"
+
+    _with_store(registry_pg, scenario)
+
+
+def test_update_from_a_stale_row_raises(registry_pg: psycopg.Connection[Any]) -> None:
+    async def scenario(store: RegistryStore) -> None:
+        created = await store.insert_model(_new_model(), **_EDITOR)
+        result = await store.update_model(
+            created.id,
+            {"published": True},
+            expected_updated_at=created.updated_at,
+            **_EDITOR,
+        )
+        assert result is not None
+        _, after = result
+        with pytest.raises(StaleEdit) as exc:
+            await store.update_model(
+                created.id,
+                {"collected": False},
+                expected_updated_at=created.updated_at,
+                **_EDITOR,
+            )
+        assert exc.value.current == after
+        assert len((await store.recent_history())[created.id]) == 2
+
+    _with_store(registry_pg, scenario)
+
+
+def test_a_noop_update_writes_nothing(registry_pg: psycopg.Connection[Any]) -> None:
+    async def scenario(store: RegistryStore) -> None:
+        created = await store.insert_model(_new_model(), **_EDITOR)
+        result = await store.update_model(
+            created.id,
+            {"published": created.published, "provider": created.provider},
+            expected_updated_at=created.updated_at,
+            user_id="user_second",
+            org_id=None,
+            email=None,
+        )
+        assert result == (created, created)
+        assert await store.get_model(created.id) == created
+        assert len((await store.recent_history())[created.id]) == 1
+
+    _with_store(registry_pg, scenario)
+
+
+def test_update_replaces_the_tag_set(registry_pg: psycopg.Connection[Any]) -> None:
+    async def scenario(store: RegistryStore) -> None:
+        await store.insert_tag(_streaming_tag())
+        await store.insert_tag(TagRecord(value="vad", category="features", label="VAD"))
+        created = await store.insert_model(_new_model(), **_EDITOR)
+        result = await store.update_model(
+            created.id,
+            {"tags": ("streaming", "vad")},
+            expected_updated_at=created.updated_at,
+            **_EDITOR,
+        )
+        assert result is not None
+        assert result[1].tags == ("streaming", "vad")
+
+        second = await store.update_model(
+            created.id,
+            {"tags": ("vad",)},
+            expected_updated_at=result[1].updated_at,
+            **_EDITOR,
+        )
+        assert second is not None
+        assert second[1].tags == ("vad",)
+
+    _with_store(registry_pg, scenario)
+
+
+def test_tags_are_canonicalized(registry_pg: psycopg.Connection[Any]) -> None:
+    async def scenario(store: RegistryStore) -> None:
+        await store.insert_tag(_streaming_tag())
+        await store.insert_tag(TagRecord(value="vad", category="features", label="VAD"))
+        new = NewModel(
+            modality=Benchmark.STT, provider="acme", model="stt-1", tags=("vad", "streaming")
+        )
+        created = await store.insert_model(new, **_EDITOR)
+        assert created.tags == ("streaming", "vad")
+        assert await store.get_model(created.id) == created
+
+        result = await store.update_model(
+            created.id,
+            {"tags": ("vad", "streaming", "vad")},
+            expected_updated_at=created.updated_at,
+            **_EDITOR,
+        )
+        assert result == (created, created)
+        assert len((await store.recent_history())[created.id]) == 1
+
+    _with_store(registry_pg, scenario)
+
+
+def test_a_rename_onto_an_existing_key_raises(registry_pg: psycopg.Connection[Any]) -> None:
+    async def scenario(store: RegistryStore) -> None:
+        await store.insert_model(_new_model(model="stt-1"), **_EDITOR)
+        other = await store.insert_model(_new_model(model="stt-2"), **_EDITOR)
+        with pytest.raises(DuplicateKey):
+            await store.update_model(
+                other.id,
+                {"model": "stt-1"},
+                expected_updated_at=other.updated_at,
+                **_EDITOR,
+            )
+
+    _with_store(registry_pg, scenario)
+
+
+def test_update_of_a_missing_model_returns_none(registry_pg: psycopg.Connection[Any]) -> None:
+    async def scenario(store: RegistryStore) -> None:
+        created = await store.insert_model(_new_model(), **_EDITOR)
+        assert (
+            await store.update_model(
+                created.id + 1,
+                {"published": True},
+                expected_updated_at=created.updated_at,
+                **_EDITOR,
+            )
+            is None
+        )
+
+    _with_store(registry_pg, scenario)
+
+
+def test_the_modality_is_not_editable(registry_pg: psycopg.Connection[Any]) -> None:
+    async def scenario(store: RegistryStore) -> None:
+        created = await store.insert_model(_new_model(), **_EDITOR)
+        with pytest.raises(ValueError, match="uneditable"):
+            await store.update_model(
+                created.id,
+                {"modality": Benchmark.TTS},
+                expected_updated_at=created.updated_at,
+                **_EDITOR,
+            )
+
+    _with_store(registry_pg, scenario)


### PR DESCRIPTION
This ones a doozy but just adds a path that doesn't gets exercised yet. 

We're breaking out the model registry and tags into db tables. This pr adds those tables and the api routes for them but leaves the existing registries be and doesn't route anything to these endpoints yet.

After this I'll run the migration, make sure that all these routes work in prod, and fill it with the existing registry information.

Then I'll add a pr to switch the default from the registry routes to the db routes. Once we've confirmed this works I'll drop the registries.

Best way to review this is commit by commit. Quick overview of each commit
1. adds the tables.
2. better coval admin auth
3. adds all the functions that the api will need
4. adds the api

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces PostgreSQL-backed model and tag registries, admin-authenticated management routes, history and optimistic-concurrency support, and broader browser CORS permissions.

- Adds registry tables, typed persistence helpers, and model-change history.
- Adds public tag reads and Coval-admin tag/model writes.
- Adds Clerk organization authorization and provider-name discovery.
- Adds API and persistence tests for the new paths.

<h3>Confidence Score: 4/5</h3>

The provider validation defect should be fixed before merging because it permits persisted models that the runner cannot execute.

Provider module discovery includes optional provider files even when their implementations were not imported, while runner dispatch accepts only registered implementations; this lets admin writes create an unrunnable registry entry.

**Files Needing Attention:** runner/src/coval_bench/registries/provider_keys.py, runner/src/coval_bench/api/routers/admin_models.py

<sub>Reviews (1): Last reviewed commit: ["\[BENCH-712\] Add the admin registry API"](https://github.com/coval-ai/benchmarks/commit/060e39bed02c8919b876289fe488ddf455bb85eb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56446775)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (4)</h4></summary>

- Knowledge Base — [Benchmark API service](https://app.greptile.com/coval/-/custom-context/knowledge-base/coval-ai/benchmarks/-/docs/api-service.md)
- Knowledge Base — [API platform controls](https://app.greptile.com/coval/-/custom-context/knowledge-base/coval-ai/benchmarks/-/docs/api-platform-controls.md)
- Knowledge Base — [Data persistence](https://app.greptile.com/coval/-/custom-context/knowledge-base/coval-ai/benchmarks/-/docs/data-persistence.md)
- Knowledge Base — [Benchmark catalogs and configuration](https://app.greptile.com/coval/-/custom-context/knowledge-base/coval-ai/benchmarks/-/docs/benchmark-catalogs-and-configuration.md)
</details>


<!-- /greptile_comment -->