### PR TITLE
Give the dental appointment runs their own S2S family

### DIFF
--- a/runner/src/coval_bench/config.py
+++ b/runner/src/coval_bench/config.py
@@ -165,6 +165,10 @@ class Settings(BaseSettings):
     # Test set for agents evaluated on the happy-path scenarios instead of the
     # shared one above. Opaque id, not secret.
     coval_s2s_happypath_test_set_id: str | None = None
+    # Test set for agents evaluated on the dental-appointment scenarios. Its own
+    # field, not a repoint of the happy-path one: the two are different domains
+    # and different populations. Opaque id, not secret.
+    coval_s2s_dental_test_set_id: str | None = None
     # The caller persona whose audio carries background noise; its runs land
     # under their own dataset instead of pooling into the clean numbers. Unset
     # means every persona is clean. Superseded by coval_s2s_condition_personas.

--- a/runner/src/coval_bench/s2s/conditions.py
+++ b/runner/src/coval_bench/s2s/conditions.py
@@ -153,9 +153,12 @@ CONDITIONS: dict[str, DatasetMetrics] = {
         required=Metric.INSTRUCTION_FOLLOWING,
         optional=frozenset({Metric.INTERRUPTION_RATE}),
     ),
+    # Anchored like its happy-path sibling: the same accented persona's runs are
+    # scored without V2V there, and anchoring on a metric the runs lack would
+    # skip every one of them and leave the condition silently empty.
     DATASET_ID_DENTAL_ACCENTED: DatasetMetrics(
-        required=Metric.V2V,
-        optional=frozenset({Metric.INSTRUCTION_FOLLOWING, Metric.INTERRUPTION_RATE}),
+        required=Metric.INSTRUCTION_FOLLOWING,
+        optional=frozenset({Metric.INTERRUPTION_RATE}),
     ),
 }
 

--- a/runner/src/coval_bench/s2s/conditions.py
+++ b/runner/src/coval_bench/s2s/conditions.py
@@ -21,12 +21,16 @@ from coval_bench.registries import Metric
 
 __all__ = [
     "DATASET_ID",
+    "DATASET_ID_DENTAL",
+    "DATASET_ID_DENTAL_ACCENTED",
+    "DATASET_ID_DENTAL_NOISY",
     "DATASET_ID_HAPPYPATH",
     "DATASET_ID_HAPPYPATH_ACCENTED",
     "DATASET_ID_HAPPYPATH_NOISY",
     "DATASET_ID_MULTITURN",
     "DATASET_ID_MULTITURN_NOISY",
     "DEFAULT_CONDITION",
+    "FAMILY_DENTAL",
     "FAMILY_HAPPYPATH",
     "FAMILY_MULTITURN",
     "Condition",
@@ -56,6 +60,10 @@ class Condition(StrEnum):
 # same 30 conversations either way.
 FAMILY_MULTITURN = "s2s-multiturn"  # customer-service, the shared board
 FAMILY_HAPPYPATH = "s2s-happypath"
+# Dental appointment booking, its own domain and its own 50 cases. Separate from
+# happy-path on purpose: pooling two populations under one dataset id would break
+# the one-dataset-id = one-condition = one-population anchor the metrics rest on.
+FAMILY_DENTAL = "s2s-dental"
 
 # Single-turn SLURP manifest (legacy, latency only) and the multi-turn Coval test
 # set, split by caller condition so background noise never pools into the clean
@@ -68,6 +76,10 @@ DATASET_ID_HAPPYPATH = "s2s-happypath-v1"
 DATASET_ID_HAPPYPATH_NOISY = "s2s-happypath-noisy-v1"
 DATASET_ID_HAPPYPATH_ACCENTED = "s2s-happypath-accented-v1"
 
+DATASET_ID_DENTAL = "s2s-dental-v1"
+DATASET_ID_DENTAL_NOISY = "s2s-dental-noisy-v1"
+DATASET_ID_DENTAL_ACCENTED = "s2s-dental-accented-v1"
+
 # Unlisted pairs are a configuration error, not a silent skip.
 DATASET_IDS: dict[tuple[str, Condition], str] = {
     (FAMILY_MULTITURN, Condition.CLEAN): DATASET_ID_MULTITURN,
@@ -75,6 +87,9 @@ DATASET_IDS: dict[tuple[str, Condition], str] = {
     (FAMILY_HAPPYPATH, Condition.CLEAN): DATASET_ID_HAPPYPATH,
     (FAMILY_HAPPYPATH, Condition.NOISY): DATASET_ID_HAPPYPATH_NOISY,
     (FAMILY_HAPPYPATH, Condition.ACCENTED): DATASET_ID_HAPPYPATH_ACCENTED,
+    (FAMILY_DENTAL, Condition.CLEAN): DATASET_ID_DENTAL,
+    (FAMILY_DENTAL, Condition.NOISY): DATASET_ID_DENTAL_NOISY,
+    (FAMILY_DENTAL, Condition.ACCENTED): DATASET_ID_DENTAL_ACCENTED,
 }
 
 
@@ -129,6 +144,18 @@ CONDITIONS: dict[str, DatasetMetrics] = {
     DATASET_ID_HAPPYPATH_ACCENTED: DatasetMetrics(
         required=Metric.INSTRUCTION_FOLLOWING,
         optional=frozenset({Metric.INTERRUPTION_RATE}),
+    ),
+    DATASET_ID_DENTAL: DatasetMetrics(
+        required=Metric.V2V,
+        optional=frozenset({Metric.INSTRUCTION_FOLLOWING, Metric.INTERRUPTION_RATE}),
+    ),
+    DATASET_ID_DENTAL_NOISY: DatasetMetrics(
+        required=Metric.INSTRUCTION_FOLLOWING,
+        optional=frozenset({Metric.INTERRUPTION_RATE}),
+    ),
+    DATASET_ID_DENTAL_ACCENTED: DatasetMetrics(
+        required=Metric.V2V,
+        optional=frozenset({Metric.INSTRUCTION_FOLLOWING, Metric.INTERRUPTION_RATE}),
     ),
 }
 

--- a/runner/src/coval_bench/s2s/fetch_v2v.py
+++ b/runner/src/coval_bench/s2s/fetch_v2v.py
@@ -903,6 +903,16 @@ async def fetch_and_write_v2v(
     raw_dental = settings.coval_s2s_dental_test_set_id
     if raw_dental is not None and not raw_dental.strip():
         raise RuntimeError("coval_s2s_dental_test_set_id must not be blank")
+    # A family's test set is required once one of its agents is configured;
+    # unset would otherwise skip the agent with a warning that reads the same
+    # as never having configured it.
+    for spec in AGENTS:
+        if not spec.test_set_id_attr or not getattr(settings, spec.agent_id_attr):
+            continue
+        if not (getattr(settings, spec.test_set_id_attr) or "").strip():
+            raise RuntimeError(
+                f"{spec.test_set_id_attr} is required when {spec.agent_id_attr} is set"
+            )
     # The noisy persona only separates conditions within a test set, so without
     # one it would silently never take effect.
     raw_noisy = settings.coval_s2s_noisy_persona_id

--- a/runner/src/coval_bench/s2s/fetch_v2v.py
+++ b/runner/src/coval_bench/s2s/fetch_v2v.py
@@ -32,7 +32,7 @@ from coval_bench.registries.benchmarks import Benchmark
 from coval_bench.s2s.conditions import (
     DATASET_ID,
     DEFAULT_CONDITION,
-    FAMILY_HAPPYPATH,
+    FAMILY_DENTAL,
     FAMILY_MULTITURN,
     Condition,
     DatasetMetrics,
@@ -96,16 +96,16 @@ AGENTS: tuple[AgentSpec, ...] = (
         agent_id_attr="coval_s2s_gray_agent_id",
         provider="colors",
         model="gray",
-        test_set_id_attr="coval_s2s_happypath_test_set_id",
-        family=FAMILY_HAPPYPATH,
+        test_set_id_attr="coval_s2s_dental_test_set_id",
+        family=FAMILY_DENTAL,
         publish_samples=False,
     ),
     AgentSpec(
         agent_id_attr="coval_s2s_red_agent_id",
         provider="colors",
         model="red",
-        test_set_id_attr="coval_s2s_happypath_test_set_id",
-        family=FAMILY_HAPPYPATH,
+        test_set_id_attr="coval_s2s_dental_test_set_id",
+        family=FAMILY_DENTAL,
         publish_samples=False,
     ),
 )
@@ -900,6 +900,9 @@ async def fetch_and_write_v2v(
     raw_happypath = settings.coval_s2s_happypath_test_set_id
     if raw_happypath is not None and not raw_happypath.strip():
         raise RuntimeError("coval_s2s_happypath_test_set_id must not be blank")
+    raw_dental = settings.coval_s2s_dental_test_set_id
+    if raw_dental is not None and not raw_dental.strip():
+        raise RuntimeError("coval_s2s_dental_test_set_id must not be blank")
     # The noisy persona only separates conditions within a test set, so without
     # one it would silently never take effect.
     raw_noisy = settings.coval_s2s_noisy_persona_id

--- a/runner/tests/unit/test_s2s_fetch.py
+++ b/runner/tests/unit/test_s2s_fetch.py
@@ -1075,6 +1075,18 @@ async def test_fetch_and_write_rejects_a_blank_dental_test_set() -> None:
 
 
 @pytest.mark.asyncio
+async def test_fetch_and_write_requires_a_dental_test_set_for_a_dental_agent() -> None:
+    # Unset skipped the agent with only a warning, which is how gray and red
+    # went five days without ingesting a row.
+    settings = Settings(
+        coval_s2s_latency_metric_id="MID",
+        coval_s2s_gray_agent_id="a2",
+    )
+    with pytest.raises(RuntimeError, match="coval_s2s_dental_test_set_id is required"):
+        await fetch_v2v.fetch_and_write_v2v(settings)
+
+
+@pytest.mark.asyncio
 async def test_fetch_and_write_rejects_a_metric_with_no_row_builder(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/runner/tests/unit/test_s2s_fetch.py
+++ b/runner/tests/unit/test_s2s_fetch.py
@@ -1063,6 +1063,18 @@ async def test_fetch_and_write_rejects_a_blank_happypath_test_set() -> None:
 
 
 @pytest.mark.asyncio
+async def test_fetch_and_write_rejects_a_blank_dental_test_set() -> None:
+    # gray/red read this one, so blank would strand both with only a warning.
+    settings = Settings(
+        coval_s2s_latency_metric_id="MID",
+        coval_s2s_openai_agent_id="a1",
+        coval_s2s_dental_test_set_id="   ",
+    )
+    with pytest.raises(RuntimeError, match="coval_s2s_dental_test_set_id must not be blank"):
+        await fetch_v2v.fetch_and_write_v2v(settings)
+
+
+@pytest.mark.asyncio
 async def test_fetch_and_write_rejects_a_metric_with_no_row_builder(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
The gray and red agents moved to the dental appointment test set on 08-20, but the fetch still filtered on the happy-path one. `_list_runs` returned zero rows, so `newest_data_at` stayed None and both providers went `provider_stale` → `failed` on every tick — no exception, exit 0. Nothing has ingested for them since.

Repointing `coval_s2s_happypath_test_set_id` would fix the symptom and break the data: dental is a different domain with 50 cases against happy-path's 30, and filing both under `s2s-happypath-*` pools two populations under one dataset id, which is the anchor every optional metric matches against. So dental gets its own family, dataset ids, and setting.

Clean anchors on V2V; noisy and accented anchor on instruction following. Noisy because background noise sits in the lane the turn boundaries come from, accented to match its happy-path sibling — the same persona's runs are scored without the latency metric there, and anchoring on a metric the runs lack would skip every one and leave the condition silently empty.

Also makes a missing test set fail loudly once one of the family's agents is configured. Unset previously skipped the agent with a warning indistinguishable from never having configured it, which is the exact failure mode above.

Paired with coval-ai/benchmark-infra#136, which supplies `COVAL_S2S_DENTAL_TEST_SET_ID`. **Apply #136 first, then ship this.** `extra="ignore"` means the deployed image ignores the unknown var, so applying early is a no-op; shipping this image first with the var unset leaves both agents producing no rows until the apply lands.

Happy-path is deliberately left in place — no `AgentSpec` references it after this change, but the family, its dataset ids, and its setting stay for now.
