### PR TITLE
[BENCH-712] Pass the model roster into the registry's consumers

### DIFF
--- a/runner/scripts/check_arena_keys.py
+++ b/runner/scripts/check_arena_keys.py
@@ -86,7 +86,7 @@ def main(tf_path: str) -> int:
 
     required: set[str] = set()
     unmapped: set[str] = set()
-    for m in active_tts_models():
+    for m in active_tts_models(MODEL_REGISTRY):
         env_var = PROVIDER_ENV.get(m.provider)
         if env_var is None:
             unmapped.add(m.provider)

--- a/runner/src/coval_bench/api/internal.py
+++ b/runner/src/coval_bench/api/internal.py
@@ -15,12 +15,14 @@ either way, so there is nothing to 404 — and says so in ``X-EA-Token-Status``.
 
 from __future__ import annotations
 
+from collections.abc import Sequence
+
 from fastapi import Depends, Header, Response
 
 from coval_bench.api import clerk
 from coval_bench.api.deps import get_settings
 from coval_bench.config import Settings
-from coval_bench.registries import MODEL_REGISTRY, ModelStatus
+from coval_bench.registries import MODEL_REGISTRY, ModelStatus, RegisteredModel
 
 # Which proof the response honoured: accepted, unknown, or absent.
 EA_STATUS_HEADER = "X-EA-Token-Status"
@@ -50,10 +52,10 @@ _RETIRED_BOARD_KEYS: dict[tuple[str, str], tuple[str, str]] = {
 }
 
 
-def embargoed_pairs() -> frozenset[tuple[str, str]]:
+def embargoed_pairs(models: Sequence[RegisteredModel]) -> frozenset[tuple[str, str]]:
     """Every ``(provider, model)`` pair currently under embargo."""
     return frozenset(
-        (m.provider, m.model) for m in MODEL_REGISTRY if m.status is ModelStatus.EARLY_ACCESS
+        (m.provider, m.model) for m in models if m.status is ModelStatus.EARLY_ACCESS
     ) | frozenset(_RETIRED_BOARD_KEYS)
 
 
@@ -70,18 +72,13 @@ def with_retired_keys(allowed: frozenset[tuple[str, str]]) -> frozenset[tuple[st
     )
 
 
-def all_registered_pairs() -> frozenset[tuple[str, str]]:
+def all_registered_pairs(models: Sequence[RegisteredModel]) -> frozenset[tuple[str, str]]:
     """Every pair the registry knows, embargoed or not, plus the retired keys.
 
     The universe an exclusive org's view is subtracted from. A pair that was never
     registered cannot be subtracted, so it stays visible.
     """
-    return frozenset((m.provider, m.model) for m in MODEL_REGISTRY) | frozenset(_RETIRED_BOARD_KEYS)
-
-
-def hidden_models() -> frozenset[tuple[str, str]]:
-    """The pairs public API responses must not contain."""
-    return embargoed_pairs()
+    return frozenset((m.provider, m.model) for m in models) | frozenset(_RETIRED_BOARD_KEYS)
 
 
 def hidden_early_access(
@@ -98,14 +95,15 @@ def hidden_early_access(
     # the route returns, and assignment here would be overwritten.
     response.headers.append("Vary", VARY_HEADERS)
 
-    embargoed = embargoed_pairs()
+    models = MODEL_REGISTRY
+    embargoed = embargoed_pairs(models)
     if authorization is None or settings.clerk_issuer is None:
         response.headers[EA_STATUS_HEADER] = "absent"
         return embargoed
 
     # Exclusive orgs are resolved first and never widened: nothing may add to a
     # view whose whole point is what it leaves out.
-    universe = all_registered_pairs()
+    universe = all_registered_pairs(models)
     only = clerk.exclusive_pairs(authorization, settings, universe)
     if only is not None:
         response.headers[EA_STATUS_HEADER] = "accepted"

--- a/runner/src/coval_bench/api/routers/arena.py
+++ b/runner/src/coval_bench/api/routers/arena.py
@@ -26,6 +26,7 @@ import asyncio
 import hmac
 import secrets
 import uuid
+from collections.abc import Sequence
 from typing import Any
 
 import psycopg.rows
@@ -73,7 +74,7 @@ from coval_bench.arena.prompts import EXAMPLE_PROMPTS
 from coval_bench.config import Settings
 from coval_bench.db.arena_store import ArenaStore
 from coval_bench.db.models import VoteOutcome, VoterType
-from coval_bench.registries import MODEL_REGISTRY, Benchmark, ModelStatus
+from coval_bench.registries import MODEL_REGISTRY, Benchmark, ModelStatus, RegisteredModel
 
 logger = structlog.get_logger("coval_bench.api")
 
@@ -103,15 +104,19 @@ _LEADERBOARD_SQL = """
     ORDER BY s.rating_elo DESC
 """
 
-# TTS models the site hides (retired/pending/early-access). Their votes still
-# feed the rating fit, but boards computed before a retirement must not keep
-# showing them.
-_HIDDEN_TTS_MODELS = frozenset(
-    (m.provider, m.model)
-    for m in MODEL_REGISTRY
-    if m.benchmark is Benchmark.TTS
-    and m.status in (ModelStatus.RETIRED, ModelStatus.PENDING, ModelStatus.EARLY_ACCESS)
-)
+
+def _hidden_tts_models(models: Sequence[RegisteredModel]) -> frozenset[tuple[str, str]]:
+    """TTS models the site hides (retired/pending/early-access).
+
+    Their votes still feed the rating fit, but boards computed before a
+    retirement must not keep showing them.
+    """
+    return frozenset(
+        (m.provider, m.model)
+        for m in models
+        if m.benchmark is Benchmark.TTS
+        and m.status in (ModelStatus.RETIRED, ModelStatus.PENDING, ModelStatus.EARLY_ACCESS)
+    )
 
 
 def _is_authenticated_labeler(provided: str | None, settings: Settings) -> bool:
@@ -272,10 +277,11 @@ async def get_arena_leaderboard(
         rows = await conn.execute(_LEADERBOARD_SQL, {"metric": metric, "domain": domain})
         board = await rows.fetchall()
 
+    hidden = _hidden_tts_models(MODEL_REGISTRY)
     entries = [
         LeaderboardEntryOut.model_validate(r)
         for r in board
-        if (r["provider"], r["model"]) not in _HIDDEN_TTS_MODELS
+        if (r["provider"], r["model"]) not in hidden
     ]
     capture_api_event(
         posthog_client,
@@ -397,11 +403,11 @@ async def create_battle(
     # Providers with a dead key — named by the last TTS benchmark, or with no key
     # configured here — sit out until that changes. This call also raises the alert,
     # since nothing downstream ever sees a provider that was filtered out here.
-    roster = [m.provider for m in active_tts_models()]
+    roster = [m.provider for m in active_tts_models(MODEL_REGISTRY)]
     benched = provider_health.unconfigured_providers(
         settings, roster
     ) | await provider_health.benchmark_benched_providers(pool)
-    models = roster_for(gender, benched)
+    models = roster_for(MODEL_REGISTRY, gender, benched)
     if len(models) < 2:
         raise HTTPException(503, "not enough healthy TTS models to form a battle")
     ratings = await store.get_latest_ratings(metric_name=PAIRING_METRIC, domain=PAIRING_DOMAIN)

--- a/runner/src/coval_bench/api/routers/providers.py
+++ b/runner/src/coval_bench/api/routers/providers.py
@@ -15,6 +15,8 @@ No DB hit is made by this endpoint.
 
 from __future__ import annotations
 
+from collections.abc import Sequence
+
 import structlog
 from fastapi import APIRouter, Depends
 from posthog import Posthog
@@ -82,7 +84,9 @@ def _tag_categories() -> list[TagCategoryOut]:
 
 
 def _build_provider_map(
-    benchmark: Benchmark, hidden: frozenset[tuple[str, str]]
+    models: Sequence[RegisteredModel],
+    benchmark: Benchmark,
+    hidden: frozenset[tuple[str, str]],
 ) -> dict[str, list[ModelInfo]]:
     """Build an ordered {provider: [ModelInfo, ...]} map from the model registry.
 
@@ -90,7 +94,7 @@ def _build_provider_map(
     whose allowlist names it.
     """
     result: dict[str, list[ModelInfo]] = {}
-    for m in MODEL_REGISTRY:
+    for m in models:
         if m.benchmark is not benchmark:
             continue
         if (m.provider, m.model) in hidden:
@@ -106,10 +110,12 @@ def _build_provider_map(
     return result
 
 
-def _describe(hidden: frozenset[tuple[str, str]]) -> ProvidersResponse:
-    stt_map = _build_provider_map(Benchmark.STT, hidden)
-    tts_map = _build_provider_map(Benchmark.TTS, hidden)
-    s2s_map = _build_provider_map(Benchmark.S2S, hidden)
+def _describe(
+    models: Sequence[RegisteredModel], hidden: frozenset[tuple[str, str]]
+) -> ProvidersResponse:
+    stt_map = _build_provider_map(models, Benchmark.STT, hidden)
+    tts_map = _build_provider_map(models, Benchmark.TTS, hidden)
+    s2s_map = _build_provider_map(models, Benchmark.S2S, hidden)
 
     return ProvidersResponse(
         stt=[ProviderInfo(provider=p, models=m) for p, m in sorted(stt_map.items())],
@@ -133,7 +139,7 @@ async def get_providers(
     hide or grey out models that are known but not actively benchmarked.
     An early-access model appears only for a caller whose allowlist names it.
     """
-    response = _describe(hidden)
+    response = _describe(MODEL_REGISTRY, hidden)
     capture_api_event(
         posthog_client,
         "providers_listed",

--- a/runner/src/coval_bench/api/routers/s2s_samples.py
+++ b/runner/src/coval_bench/api/routers/s2s_samples.py
@@ -21,6 +21,7 @@ its path from a filtered manifest.
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Sequence
 from datetime import UTC, datetime
 from urllib.parse import quote
 
@@ -35,7 +36,7 @@ from coval_bench.api.ratelimit import limiter
 from coval_bench.api.schemas import S2SSampleAudioOut, S2SSampleOut, S2SSampleRecordingOut
 from coval_bench.config import Settings
 from coval_bench.gcs import signed_url
-from coval_bench.registries import MODEL_REGISTRY, Benchmark
+from coval_bench.registries import MODEL_REGISTRY, Benchmark, RegisteredModel
 from coval_bench.s2s.samples import (
     AUDIO_URL_TTL,
     audio_object_key,
@@ -50,10 +51,10 @@ router = APIRouter(tags=["s2s"])
 _SAMPLE_ID = r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$"
 
 
-def _sees_any_s2s_model(hidden: frozenset[tuple[str, str]]) -> bool:
-    return any(
-        m.benchmark is Benchmark.S2S and (m.provider, m.model) not in hidden for m in MODEL_REGISTRY
-    )
+def _sees_any_s2s_model(
+    models: Sequence[RegisteredModel], hidden: frozenset[tuple[str, str]]
+) -> bool:
+    return any(m.benchmark is Benchmark.S2S and (m.provider, m.model) not in hidden for m in models)
 
 
 def _audio_path(sample_id: str, provider: str, model: str) -> str:
@@ -73,7 +74,7 @@ async def list_s2s_samples(
 ) -> list[str]:
     """Sample ids newest-first, empty when the caller may see no S2S model at all."""
     never_shared(response)
-    if not settings.s2s_samples_bucket or not _sees_any_s2s_model(hidden):
+    if not settings.s2s_samples_bucket or not _sees_any_s2s_model(MODEL_REGISTRY, hidden):
         return []
     return await asyncio.to_thread(load_sample_ids, settings.s2s_samples_bucket)
 

--- a/runner/src/coval_bench/arena/pairing.py
+++ b/runner/src/coval_bench/arena/pairing.py
@@ -18,7 +18,6 @@ from collections.abc import Mapping, Sequence
 from coval_bench.db.models import PairingRating
 from coval_bench.registries.benchmarks import Benchmark
 from coval_bench.registries.models import (
-    MODEL_REGISTRY,
     Gender,
     ModelStatus,
     RegisteredModel,
@@ -36,16 +35,20 @@ PAIRING_METRIC = "naturalness"
 PAIRING_DOMAIN = "all"
 
 
-def active_tts_models() -> list[RegisteredModel]:
+def active_tts_models(models: Sequence[RegisteredModel]) -> list[RegisteredModel]:
     """The arena roster: every ACTIVE, arena-enabled TTS model in the registry."""
     return [
         m
-        for m in MODEL_REGISTRY
+        for m in models
         if m.benchmark is Benchmark.TTS and m.status is ModelStatus.ACTIVE and m.arena_enabled
     ]
 
 
-def roster_for(gender: Gender, benched: frozenset[str] = frozenset()) -> list[RegisteredModel]:
+def roster_for(
+    models: Sequence[RegisteredModel],
+    gender: Gender,
+    benched: frozenset[str] = frozenset(),
+) -> list[RegisteredModel]:
     """The arena roster restricted to models that can render a *gender* battle.
 
     A model without a voice of that gender cannot take a side, so it sits the
@@ -56,7 +59,7 @@ def roster_for(gender: Gender, benched: frozenset[str] = frozenset()) -> list[Re
     call on a key already known to be dead and hand the voter an error anyway; the caller
     reports the arena as unavailable instead.
     """
-    eligible = [m for m in active_tts_models() if any(v.gender is gender for v in m.voices)]
+    eligible = [m for m in active_tts_models(models) if any(v.gender is gender for v in m.voices)]
     if not benched:
         return eligible
     return [m for m in eligible if m.provider not in benched]

--- a/runner/src/coval_bench/arena/seed.py
+++ b/runner/src/coval_bench/arena/seed.py
@@ -20,6 +20,7 @@ from coval_bench.arena.prompts import EXAMPLE_PROMPTS
 from coval_bench.config import Settings
 from coval_bench.db.arena_store import ArenaStore
 from coval_bench.db.models import Battle
+from coval_bench.registries import MODEL_REGISTRY
 from coval_bench.registries.models import Gender
 
 logger: structlog.BoundLogger = structlog.get_logger(__name__)
@@ -46,7 +47,7 @@ async def seed_demo_battles(
     for domain, prompts in EXAMPLE_PROMPTS.items():
         for prompt in prompts[:per_domain]:
             gender = gender_for_next_battle(counts, rng=picker)
-            pair = select_pair(roster_for(gender), {}, rng=picker)
+            pair = select_pair(roster_for(MODEL_REGISTRY, gender), {}, rng=picker)
             battle = await generate_battle(
                 settings,
                 store,

--- a/runner/src/coval_bench/arena/tune_scale.py
+++ b/runner/src/coval_bench/arena/tune_scale.py
@@ -41,6 +41,7 @@ from coval_bench.arena.rating import (
     compute_ratings,
 )
 from coval_bench.db.models import PairingRating
+from coval_bench.registries import MODEL_REGISTRY
 from coval_bench.registries.models import Gender, RegisteredModel
 
 _EPS = 1e-12
@@ -194,7 +195,7 @@ def tune_scale(
     # the union. Both genders currently field the same models, so either stands
     # in for the regime; simulating the union would model a larger pool than any
     # real battle draws from.
-    roster = roster_for(Gender.FEMALE)
+    roster = roster_for(MODEL_REGISTRY, Gender.FEMALE)
     if len(roster) < 2:
         raise ValueError("need at least two active TTS models to simulate")
 

--- a/runner/src/coval_bench/runner/orchestrator.py
+++ b/runner/src/coval_bench/runner/orchestrator.py
@@ -1079,8 +1079,9 @@ async def run_benchmarks(
     # ------------------------------------------------------------------
     # 1. Resolve + filter the model registry
     # ------------------------------------------------------------------
-    stt_matrix = [m for m in MODEL_REGISTRY if m.benchmark is Benchmark.STT]
-    tts_matrix = [m for m in MODEL_REGISTRY if m.benchmark is Benchmark.TTS]
+    models = MODEL_REGISTRY
+    stt_matrix = [m for m in models if m.benchmark is Benchmark.STT]
+    tts_matrix = [m for m in models if m.benchmark is Benchmark.TTS]
 
     if matrix_overrides:
         override_map: dict[tuple[Benchmark, str, str], RegisteredModel] = {

--- a/runner/tests/api/conftest.py
+++ b/runner/tests/api/conftest.py
@@ -47,6 +47,7 @@ from coval_bench.api.app import create_app
 from coval_bench.arena.moderation import ModerationResult
 from coval_bench.arena.pairing import active_tts_models
 from coval_bench.config import Settings
+from coval_bench.registries import MODEL_REGISTRY
 from coval_bench.registries.provider_keys import PROVIDER_ENV
 
 ARENA_LABELER_KEY = "test-labeler-key"
@@ -320,7 +321,7 @@ async def app(
     # keys has no roster and every battle is a 503. Prod mounts all of them — CI's
     # check_arena_keys.py enforces it — so the fixture models that. OPENAI_API_KEY stays
     # unset on purpose above, which simply leaves openai out of the roster.
-    for model in active_tts_models():
+    for model in active_tts_models(MODEL_REGISTRY):
         env_var = PROVIDER_ENV.get(model.provider)
         if env_var is not None and env_var != "OPENAI_API_KEY":
             monkeypatch.setenv(env_var, "test-provider-key")

--- a/runner/tests/api/test_arena.py
+++ b/runner/tests/api/test_arena.py
@@ -19,6 +19,7 @@ from coval_bench.arena.moderation import ModerationResult
 from coval_bench.arena.pairing import active_tts_models
 from coval_bench.arena.prompts import EXAMPLE_PROMPTS
 from coval_bench.providers.base import TTSResult
+from coval_bench.registries import MODEL_REGISTRY
 from tests.api.conftest import ARENA_LABELER_KEY, _make_db_url
 
 _LABELER_HEADERS = {"X-Labeler-Key": ARENA_LABELER_KEY}
@@ -709,7 +710,7 @@ def _fake_tts_providers(fail_models: set[str]) -> dict[str, type]:
                 error=None,
             )
 
-    return {m.provider: _FakeTTS for m in active_tts_models()}
+    return {m.provider: _FakeTTS for m in active_tts_models(MODEL_REGISTRY)}
 
 
 async def test_create_battle_returns_blind_battle(
@@ -763,7 +764,7 @@ async def test_create_battle_502_when_synthesis_fails(
 ) -> None:
     """If synthesis fails, no battle is persisted and the endpoint returns 502."""
     await _apply_arena_schema(_make_db_url(postgresql))
-    every_model = {m.model for m in active_tts_models()}
+    every_model = {m.model for m in active_tts_models(MODEL_REGISTRY)}
     monkeypatch.setattr(
         "coval_bench.arena.generate.TTS_PROVIDERS", _fake_tts_providers(every_model)
     )

--- a/runner/tests/api/test_clerk_scope.py
+++ b/runner/tests/api/test_clerk_scope.py
@@ -31,6 +31,7 @@ from coval_bench.api.internal import (
     with_retired_keys,
 )
 from coval_bench.config import Settings
+from coval_bench.registries import MODEL_REGISTRY
 
 _ISSUER = "https://clerk.example.com"
 _PARTY = "https://benchmarks.example.com"
@@ -110,7 +111,7 @@ def _resolve(
 
 def _embargoed_provider() -> str:
     """Any provider with an embargoed model, or skip."""
-    providers = sorted({provider for provider, _ in embargoed_pairs()})
+    providers = sorted({provider for provider, _ in embargoed_pairs(MODEL_REGISTRY)})
     if not providers:
         pytest.skip("no embargoed models in the registry")
     return providers[0]
@@ -118,7 +119,7 @@ def _embargoed_provider() -> str:
 
 def _two_embargoed_providers() -> tuple[str, str]:
     """Two distinct providers with embargoed models, or skip."""
-    providers = sorted({provider for provider, _ in embargoed_pairs()})
+    providers = sorted({provider for provider, _ in embargoed_pairs(MODEL_REGISTRY)})
     if len(providers) < 2:
         pytest.skip("fewer than two providers have embargoed models")
     return providers[0], providers[1]
@@ -132,15 +133,15 @@ def test_org_sees_its_own_providers_models_and_no_others(
     token = _mint({"org_id": _ORG_ID})
     hidden, status = _resolve(settings, f"Bearer {token}")
     assert status == "accepted"
-    assert hidden == frozenset(pair for pair in embargoed_pairs() if pair[0] != mine)
+    assert hidden == frozenset(pair for pair in embargoed_pairs(MODEL_REGISTRY) if pair[0] != mine)
     assert all(provider != mine for provider, _ in hidden)
     assert any(provider == theirs for provider, _ in hidden)
 
 
 def test_org_entry_can_name_one_model(monkeypatch: pytest.MonkeyPatch) -> None:
-    pair = sorted(embargoed_pairs())[0]
+    pair = sorted(embargoed_pairs(MODEL_REGISTRY))[0]
     provider, model = pair
-    siblings = {p for p in embargoed_pairs() if p[0] == provider and p != pair}
+    siblings = {p for p in embargoed_pairs(MODEL_REGISTRY) if p[0] == provider and p != pair}
     if not siblings:
         pytest.skip("no embargoed provider has two models")
     settings = _settings(monkeypatch, org_providers=json.dumps({_ORG_ID: [f"{provider}/{model}"]}))
@@ -166,7 +167,7 @@ def test_mapped_org_naming_nothing_unlocks_nothing(monkeypatch: pytest.MonkeyPat
     token = _mint({"org_id": _ORG_ID})
     hidden, status = _resolve(settings, f"Bearer {token}")
     assert status == "accepted"
-    assert hidden == with_retired_keys(embargoed_pairs())
+    assert hidden == with_retired_keys(embargoed_pairs(MODEL_REGISTRY))
 
 
 def test_malformed_org_entry_is_dropped(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -174,12 +175,12 @@ def test_malformed_org_entry_is_dropped(monkeypatch: pytest.MonkeyPatch) -> None
     settings = _settings(monkeypatch, org_providers=json.dumps({_ORG_ID: [provider, 7]}))
     token = _mint({"org_id": _ORG_ID, "email": "partner@example.com"})
     hidden, _ = _resolve(settings, f"Bearer {token}")
-    assert hidden == with_retired_keys(embargoed_pairs())
+    assert hidden == with_retired_keys(embargoed_pairs(MODEL_REGISTRY))
 
 
 def _public_pair() -> tuple[str, str]:
     """Any registered pair that is not embargoed, or skip."""
-    public = sorted(all_registered_pairs() - embargoed_pairs())
+    public = sorted(all_registered_pairs(MODEL_REGISTRY) - embargoed_pairs(MODEL_REGISTRY))
     if not public:
         pytest.skip("every registered model is embargoed")
     return public[0]
@@ -187,7 +188,7 @@ def _public_pair() -> tuple[str, str]:
 
 def test_exclusive_org_sees_only_its_own_provider(monkeypatch: pytest.MonkeyPatch) -> None:
     provider = _embargoed_provider()
-    mine = {pair for pair in embargoed_pairs() if pair[0] == provider}
+    mine = {pair for pair in embargoed_pairs(MODEL_REGISTRY) if pair[0] == provider}
     settings = _settings(monkeypatch, org_exclusive=json.dumps({_ORG_ID: [provider]}))
     token = _mint({"org_id": _ORG_ID})
     hidden, status = _resolve(settings, f"Bearer {token}")
@@ -195,17 +196,17 @@ def test_exclusive_org_sees_only_its_own_provider(monkeypatch: pytest.MonkeyPatc
     assert status == "accepted"
     assert not (mine & hidden)
     assert _public_pair() in hidden
-    assert hidden == all_registered_pairs() - with_retired_keys(frozenset(mine))
+    assert hidden == all_registered_pairs(MODEL_REGISTRY) - with_retired_keys(frozenset(mine))
 
 
 def test_exclusive_org_can_name_one_model(monkeypatch: pytest.MonkeyPatch) -> None:
-    provider, model = sorted(embargoed_pairs())[0]
+    provider, model = sorted(embargoed_pairs(MODEL_REGISTRY))[0]
     settings = _settings(monkeypatch, org_exclusive=json.dumps({_ORG_ID: [f"{provider}/{model}"]}))
     token = _mint({"org_id": _ORG_ID})
     hidden, _ = _resolve(settings, f"Bearer {token}")
 
     assert (provider, model) not in hidden
-    assert len(all_registered_pairs() - hidden) == 1
+    assert len(all_registered_pairs(MODEL_REGISTRY) - hidden) == 1
 
 
 def test_exclusive_wins_over_additive_for_the_same_org(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -273,7 +274,7 @@ def test_unparsable_exclusive_map_denies_instead_of_falling_back() -> None:
     hidden, status = _resolve(settings, f"Bearer {token}")
 
     assert status == "accepted"
-    assert hidden == all_registered_pairs()
+    assert hidden == all_registered_pairs(MODEL_REGISTRY)
     assert _public_pair() in hidden
 
 
@@ -282,7 +283,7 @@ def test_malformed_org_entry_in_exclusive_map_denies() -> None:
     token = _mint({"org_id": _ORG_ID})
     hidden, _ = _resolve(settings, f"Bearer {token}")
 
-    assert hidden == all_registered_pairs()
+    assert hidden == all_registered_pairs(MODEL_REGISTRY)
 
 
 def test_unknown_exclusive_entry_grants_nothing_and_warns(
@@ -298,7 +299,7 @@ def test_unknown_exclusive_entry_grants_nothing_and_warns(
             settings=settings,
         )
 
-    assert hidden == all_registered_pairs()
+    assert hidden == all_registered_pairs(MODEL_REGISTRY)
     warned = [entry for entry in logs if entry["event"] == "clerk_org_entry_unmatched"]
     assert [(entry["org_id"], entry["entry"], entry["scope"]) for entry in warned] == [
         (_ORG_ID, "colours/gray", "exclusive")
@@ -319,7 +320,7 @@ def test_unset_coval_org_grants_nothing(monkeypatch: pytest.MonkeyPatch) -> None
     token = _mint({"org_id": _COVAL_ORG})
     hidden, status = _resolve(settings, f"Bearer {token}")
     assert status == "accepted"
-    assert hidden == embargoed_pairs()
+    assert hidden == embargoed_pairs(MODEL_REGISTRY)
 
 
 def test_a_mapped_coval_org_gets_only_its_entry(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -329,7 +330,9 @@ def test_a_mapped_coval_org_gets_only_its_entry(monkeypatch: pytest.MonkeyPatch)
     token = _mint({"org_id": _COVAL_ORG})
     hidden, status = _resolve(settings, f"Bearer {token}")
     assert status == "accepted"
-    assert hidden == frozenset(pair for pair in embargoed_pairs() if pair[0] != provider)
+    assert hidden == frozenset(
+        pair for pair in embargoed_pairs(MODEL_REGISTRY) if pair[0] != provider
+    )
 
 
 def test_a_coval_email_alone_unlocks_nothing(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -338,7 +341,7 @@ def test_a_coval_email_alone_unlocks_nothing(monkeypatch: pytest.MonkeyPatch) ->
     token = _mint({"email": "someone@coval.dev"})
     hidden, status = _resolve(settings, f"Bearer {token}")
     assert status == "accepted"
-    assert hidden == embargoed_pairs()
+    assert hidden == embargoed_pairs(MODEL_REGISTRY)
 
 
 def test_a_coval_email_in_another_org_unlocks_nothing(
@@ -350,7 +353,7 @@ def test_a_coval_email_in_another_org_unlocks_nothing(
     token = _mint({"email": "someone@coval.dev", "org_id": "org_2someoneelse"})
     hidden, status = _resolve(settings, f"Bearer {token}")
     assert status == "accepted"
-    assert hidden == embargoed_pairs()
+    assert hidden == embargoed_pairs(MODEL_REGISTRY)
 
 
 def test_a_lookalike_org_id_unlocks_nothing(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -359,7 +362,7 @@ def test_a_lookalike_org_id_unlocks_nothing(monkeypatch: pytest.MonkeyPatch) -> 
     token = _mint({"org_id": f"{_COVAL_ORG}x"})
     hidden, status = _resolve(settings, f"Bearer {token}")
     assert status == "accepted"
-    assert hidden == embargoed_pairs()
+    assert hidden == embargoed_pairs(MODEL_REGISTRY)
 
 
 def test_session_without_the_claims_keeps_the_public_view(
@@ -369,7 +372,7 @@ def test_session_without_the_claims_keeps_the_public_view(
     token = _mint({})
     hidden, status = _resolve(settings, f"Bearer {token}")
     assert status == "accepted"
-    assert hidden == embargoed_pairs()
+    assert hidden == embargoed_pairs(MODEL_REGISTRY)
 
 
 def test_signed_in_user_without_an_org_keeps_the_public_view(
@@ -379,7 +382,7 @@ def test_signed_in_user_without_an_org_keeps_the_public_view(
     token = _mint({"email": "user@example.com", "org_id": None})
     hidden, status = _resolve(settings, f"Bearer {token}")
     assert status == "accepted"
-    assert hidden == embargoed_pairs()
+    assert hidden == embargoed_pairs(MODEL_REGISTRY)
 
 
 def test_unmapped_org_keeps_the_public_view(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -389,7 +392,7 @@ def test_unmapped_org_keeps_the_public_view(monkeypatch: pytest.MonkeyPatch) -> 
     token = _mint({"org_id": "org_2someoneelse"})
     hidden, status = _resolve(settings, f"Bearer {token}")
     assert status == "accepted"
-    assert hidden == embargoed_pairs()
+    assert hidden == embargoed_pairs(MODEL_REGISTRY)
 
 
 def test_org_without_a_configured_map_keeps_the_public_view(
@@ -399,7 +402,7 @@ def test_org_without_a_configured_map_keeps_the_public_view(
     token = _mint({"org_id": _ORG_ID})
     hidden, status = _resolve(settings, f"Bearer {token}")
     assert status == "accepted"
-    assert hidden == embargoed_pairs()
+    assert hidden == embargoed_pairs(MODEL_REGISTRY)
 
 
 def test_claims_of_the_wrong_shape_unlock_nothing(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -408,7 +411,7 @@ def test_claims_of_the_wrong_shape_unlock_nothing(monkeypatch: pytest.MonkeyPatc
     token = _mint({"org_id": [_COVAL_ORG]})
     hidden, status = _resolve(settings, f"Bearer {token}")
     assert status == "accepted"
-    assert hidden == embargoed_pairs()
+    assert hidden == embargoed_pairs(MODEL_REGISTRY)
 
 
 def test_expired_token_keeps_the_public_view(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -417,7 +420,7 @@ def test_expired_token_keeps_the_public_view(monkeypatch: pytest.MonkeyPatch) ->
     token = _mint({"org_id": _COVAL_ORG}, iat=now - 120, exp=now - 60)
     hidden, status = _resolve(settings, f"Bearer {token}")
     assert status == "unknown"
-    assert hidden == embargoed_pairs()
+    assert hidden == embargoed_pairs(MODEL_REGISTRY)
 
 
 def test_token_signed_by_another_key_keeps_the_public_view(
@@ -427,7 +430,7 @@ def test_token_signed_by_another_key_keeps_the_public_view(
     token = _mint({"org_id": _COVAL_ORG}, key=_OTHER_KEY)
     hidden, status = _resolve(settings, f"Bearer {token}")
     assert status == "unknown"
-    assert hidden == embargoed_pairs()
+    assert hidden == embargoed_pairs(MODEL_REGISTRY)
 
 
 def test_token_from_another_issuer_keeps_the_public_view(
@@ -437,7 +440,7 @@ def test_token_from_another_issuer_keeps_the_public_view(
     token = _mint({"org_id": _COVAL_ORG}, iss="https://not-clerk.example.com")
     hidden, status = _resolve(settings, f"Bearer {token}")
     assert status == "unknown"
-    assert hidden == embargoed_pairs()
+    assert hidden == embargoed_pairs(MODEL_REGISTRY)
 
 
 def test_azp_outside_the_allowlist_keeps_the_public_view(
@@ -447,7 +450,7 @@ def test_azp_outside_the_allowlist_keeps_the_public_view(
     token = _mint({"org_id": _COVAL_ORG}, azp="https://elsewhere.example.com")
     hidden, status = _resolve(settings, f"Bearer {token}")
     assert status == "unknown"
-    assert hidden == embargoed_pairs()
+    assert hidden == embargoed_pairs(MODEL_REGISTRY)
 
 
 def test_azp_in_the_allowlist_is_accepted(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -463,7 +466,7 @@ def test_unset_authorized_parties_rejects_every_token(monkeypatch: pytest.Monkey
     token = _mint({"org_id": _COVAL_ORG})
     hidden, status = _resolve(settings, f"Bearer {token}")
     assert status == "unknown"
-    assert hidden == embargoed_pairs()
+    assert hidden == embargoed_pairs(MODEL_REGISTRY)
 
 
 def _headers(settings: Settings, authorization: str) -> dict[str, str]:
@@ -495,7 +498,7 @@ def test_bearer_is_ignored_when_clerk_is_not_configured(
     token = _mint({"org_id": _COVAL_ORG})
     hidden, status = _resolve(settings, f"Bearer {token}")
     assert status == "absent"
-    assert hidden == embargoed_pairs()
+    assert hidden == embargoed_pairs(MODEL_REGISTRY)
 
 
 def test_non_bearer_authorization_keeps_the_public_view(
@@ -504,7 +507,7 @@ def test_non_bearer_authorization_keeps_the_public_view(
     settings = _settings(monkeypatch)
     hidden, status = _resolve(settings, "Basic dXNlcjpwYXNz")
     assert status == "unknown"
-    assert hidden == embargoed_pairs()
+    assert hidden == embargoed_pairs(MODEL_REGISTRY)
 
 
 def test_retired_board_keys_stay_embargoed() -> None:
@@ -514,8 +517,8 @@ def test_retired_board_keys_stay_embargoed() -> None:
     old string, and the embargo matches on what is stored -- so losing the old
     key would publish every recording and row published under that name.
     """
-    assert ("xai", "grok-realtime") in embargoed_pairs()
-    assert ("xai", "grok-voice-think-fast-1.0") in embargoed_pairs()
+    assert ("xai", "grok-realtime") in embargoed_pairs(MODEL_REGISTRY)
+    assert ("xai", "grok-voice-think-fast-1.0") in embargoed_pairs(MODEL_REGISTRY)
 
 
 def test_org_grant_for_a_renamed_model_also_sees_its_history(

--- a/runner/tests/api/test_providers.py
+++ b/runner/tests/api/test_providers.py
@@ -174,7 +174,7 @@ async def test_early_access_flag_marks_only_embargoed_rows(client: AsyncClient) 
         for m in entry["models"]
         if m["early_access"]
     }
-    # Registry-derived, not embargoed_pairs(): retired board keys stay embargoed
+    # Registry-derived, not embargoed_pairs(MODEL_REGISTRY): retired board keys stay embargoed
     # for stored artefacts but are not registry entries, so they never appear here.
     assert flagged == {
         (m.provider, m.model) for m in MODEL_REGISTRY if m.status is ModelStatus.EARLY_ACCESS

--- a/runner/tests/unit/test_arena_pairing.py
+++ b/runner/tests/unit/test_arena_pairing.py
@@ -19,6 +19,7 @@ from coval_bench.arena.pairing import (
 )
 from coval_bench.config import Settings
 from coval_bench.db.models import PairingRating
+from coval_bench.registries import MODEL_REGISTRY
 from coval_bench.registries.benchmarks import Benchmark
 from coval_bench.registries.models import Gender, ModelStatus, RegisteredModel, Voice
 from coval_bench.registries.provider_keys import PROVIDER_ENV
@@ -158,19 +159,19 @@ def test_select_pair_rejects_non_positive_scale() -> None:
 
 
 def test_active_tts_models_are_tts_and_active() -> None:
-    roster = active_tts_models()
+    roster = active_tts_models(MODEL_REGISTRY)
     assert len(roster) >= 2
     assert all(m.benchmark is Benchmark.TTS and m.status is ModelStatus.ACTIVE for m in roster)
 
 
 def test_active_tts_models_excludes_arena_disabled() -> None:
-    assert all(m.arena_enabled for m in active_tts_models())
+    assert all(m.arena_enabled for m in active_tts_models(MODEL_REGISTRY))
 
 
 def test_provider_env_covers_arena_providers() -> None:
     # Only providers the arena can actually synthesize with (ACTIVE + arena_enabled),
-    # matching active_tts_models() and the parity script — not every non-retired one.
-    providers = {m.provider for m in active_tts_models()}
+    # matching active_tts_models(MODEL_REGISTRY) and the parity script — not every non-retired one.
+    providers = {m.provider for m in active_tts_models(MODEL_REGISTRY)}
     missing = providers - PROVIDER_ENV.keys()
     assert not missing, f"arena providers with no PROVIDER_ENV entry: {sorted(missing)}"
 
@@ -189,7 +190,7 @@ def test_every_arena_model_can_field_both_genders() -> None:
     """
     incomplete = [
         f"{m.provider}/{m.model}"
-        for m in active_tts_models()
+        for m in active_tts_models(MODEL_REGISTRY)
         if {v.gender for v in m.voices} != {Gender.FEMALE, Gender.MALE} and m.provider != "palabra"
     ]
     assert incomplete == [], f"arena models missing a gendered voice: {incomplete}"
@@ -197,10 +198,10 @@ def test_every_arena_model_can_field_both_genders() -> None:
 
 def test_roster_for_keeps_only_models_with_that_gender() -> None:
     for gender in (Gender.FEMALE, Gender.MALE):
-        roster = roster_for(gender)
+        roster = roster_for(MODEL_REGISTRY, gender)
         assert len(roster) >= 2
         assert all(any(v.gender is gender for v in m.voices) for m in roster)
-    assert {m.provider for m in roster_for(Gender.FEMALE)}.isdisjoint({"palabra"})
+    assert {m.provider for m in roster_for(MODEL_REGISTRY, Gender.FEMALE)}.isdisjoint({"palabra"})
 
 
 def test_voice_for_returns_the_matching_half() -> None:
@@ -263,9 +264,7 @@ class TestBenchedProviders:
             _gendered_model("beta", "m-beta"),
             _gendered_model("gamma", "m-gamma"),
         ]
-        monkeypatch.setattr("coval_bench.arena.pairing.active_tts_models", lambda: roster)
-
-        remaining = roster_for(Gender.FEMALE, frozenset({"beta"}))
+        remaining = roster_for(roster, Gender.FEMALE, frozenset({"beta"}))
 
         assert [m.provider for m in remaining] == ["alpha", "gamma"]
 
@@ -275,8 +274,6 @@ class TestBenchedProviders:
         # Too few to pair is the caller's problem to report; pairing a key already known
         # to be dead spends a paid call and fails the voter anyway.
         roster = [_gendered_model("alpha", "m-alpha"), _gendered_model("beta", "m-beta")]
-        monkeypatch.setattr("coval_bench.arena.pairing.active_tts_models", lambda: roster)
-
-        remaining = roster_for(Gender.FEMALE, frozenset({"beta"}))
+        remaining = roster_for(roster, Gender.FEMALE, frozenset({"beta"}))
 
         assert [m.provider for m in remaining] == ["alpha"]

--- a/runner/tests/unit/test_arena_tune_scale.py
+++ b/runner/tests/unit/test_arena_tune_scale.py
@@ -21,6 +21,7 @@ from coval_bench.arena.tune_scale import (
     _true_strengths,
     tune_scale,
 )
+from coval_bench.registries import MODEL_REGISTRY
 
 
 def _fast(seed: int) -> list[ScaleResult]:
@@ -75,7 +76,7 @@ def test_davidson_is_symmetric_under_swap() -> None:
 
 
 def test_true_strengths_span_the_requested_elo_spread() -> None:
-    roster = active_tts_models()
+    roster = active_tts_models(MODEL_REGISTRY)
     theta = _true_strengths(roster, elo_spread=800.0, rng=random.Random(0))
     elo_range = (max(theta.values()) - min(theta.values())) * _ELO_SCALE
     assert math.isclose(elo_range, 800.0, rel_tol=1e-9)


### PR DESCRIPTION
Switch everything from using global model variables to being passed a list of models. Prep for grabbing all the models from the db.