### PR TITLE
Bound benchmark dashboard API payloads

### DIFF
--- a/runner/src/coval_bench/api/routers/aggregates.py
+++ b/runner/src/coval_bench/api/routers/aggregates.py
@@ -59,6 +59,8 @@ from coval_bench.api.schemas import (
     DatasetAggregates,
     ModelStatEntry,
     SeriesPoint,
+    TimelinePoint,
+    TimelineResponse,
 )
 from coval_bench.config import DATASET_ALL
 from coval_bench.registries import is_metric_excluded
@@ -86,6 +88,50 @@ _SERIES_SQL = (
     " AND dataset_id = %(dataset)s"
     " AND bucket_at >= NOW() - %(interval)s::interval"
     " ORDER BY bucket_at, provider, model, metric_type"
+)
+
+_TIMELINE_SQL = (
+    "SELECT provider, model, metric_type, bucket_at AS scheduled_at,"
+    " CASE WHEN metric_type = 'WER'"
+    " THEN value_sum / NULLIF(sample_count, 0) ELSE p50 END AS value"
+    " FROM benchmarks_v2.results_by_bucket"
+    " WHERE benchmark = %(benchmark)s"
+    " AND dataset_id = %(dataset)s"
+    " AND bucket_at >= NOW() - %(interval)s::interval"
+    " ORDER BY bucket_at, provider, model, metric_type"
+)
+
+# Select a bounded, representative 30-day timeline in PostgreSQL.  Each exact
+# provider/model/metric group is split into 119 ordinal bins; retaining the min
+# and max plotted value in every bin plus the endpoints caps the result at 240
+# points per group while preserving endpoints and plotted extrema.  All tie
+# breaks include bucket_at so identical requests have identical ordering.
+_COMPACT_SERIES_SQL = (
+    "WITH base AS ("
+    " SELECT provider, model, metric_type, bucket_at AS scheduled_at,"
+    " min_value, p25, p50, p75, max_value, value_sum, sample_count,"
+    " CASE WHEN metric_type = 'WER'"
+    " THEN value_sum / NULLIF(sample_count, 0) ELSE p50 END AS value"
+    " FROM benchmarks_v2.results_by_bucket"
+    " WHERE benchmark = %(benchmark)s AND dataset_id = %(dataset)s"
+    " AND bucket_at >= NOW() - %(interval)s::interval"
+    "), ranked AS ("
+    " SELECT *, row_number() OVER grp AS ordinal,"
+    " count(*) OVER (PARTITION BY provider, model, metric_type) AS group_count"
+    " FROM base WINDOW grp AS (PARTITION BY provider, model, metric_type ORDER BY scheduled_at)"
+    "), binned AS ("
+    " SELECT *, floor((ordinal - 1) * 119.0 / group_count)::int AS bin"
+    " FROM ranked"
+    "), selected AS ("
+    " SELECT *, row_number() OVER (PARTITION BY provider, model, metric_type, bin"
+    " ORDER BY value ASC, scheduled_at ASC) AS min_rank,"
+    " row_number() OVER (PARTITION BY provider, model, metric_type, bin"
+    " ORDER BY value DESC, scheduled_at ASC) AS max_rank"
+    " FROM binned"
+    ") SELECT provider, model, metric_type, scheduled_at, min_value, p25, p50, p75,"
+    " max_value, value_sum, sample_count, value FROM selected"
+    " WHERE min_rank = 1 OR max_rank = 1 OR ordinal = 1 OR ordinal = group_count"
+    " ORDER BY scheduled_at, provider, model, metric_type"
 )
 
 _DATASETS_SQL_TEMPLATE = (
@@ -134,6 +180,9 @@ async def get_results_aggregates(
         default=None,
         description="Dataset id to aggregate over; omit for the pooled all-dataset blocks.",
     ),
+    include_series: bool = Query(
+        default=True, description="Whether to include the per-bucket chart series."
+    ),
     pool: AsyncConnectionPool[Any] = Depends(get_pool),
     posthog_client: Posthog | None = Depends(get_posthog),
     cache: TTLCache[Any, Any] = Depends(get_cache),
@@ -156,16 +205,22 @@ async def get_results_aggregates(
         stats_sql = _STATS_SQL_TEMPLATE.format(view=WINDOW_VIEWS[window])
         datasets_sql = _DATASETS_SQL_TEMPLATE.format(view=WINDOW_VIEWS[window])
         stats_params: dict[str, Any] = {"benchmark": benchmark, "dataset": dataset_key}
-        series_params: dict[str, Any] = {
-            "benchmark": benchmark,
-            "dataset": dataset_key,
-            "interval": WINDOW_INTERVALS[window],
-        }
-
         async with pool.connection() as conn:
             conn.row_factory = psycopg.rows.dict_row
             stat_rows = await (await conn.execute(stats_sql, stats_params)).fetchall()
-            series_rows = await (await conn.execute(_SERIES_SQL, series_params)).fetchall()
+            if include_series:
+                series_rows = await (
+                    await conn.execute(
+                        _COMPACT_SERIES_SQL if window == "30d" else _SERIES_SQL,
+                        {
+                            "benchmark": benchmark,
+                            "dataset": dataset_key,
+                            "interval": WINDOW_INTERVALS[window],
+                        },
+                    )
+                ).fetchall()
+            else:
+                series_rows = []
             dataset_rows = await (
                 await conn.execute(datasets_sql, {"benchmark": benchmark, "sentinel": DATASET_ALL})
             ).fetchall()
@@ -187,7 +242,14 @@ async def get_results_aggregates(
 
     # The hidden set is part of the key: two callers who can see different models
     # must never share a cache entry, or one would be served the other's rows.
-    cache_key = ("aggregates", benchmark, window, dataset_key, tuple(sorted(hidden)))
+    cache_key = (
+        "aggregates",
+        benchmark,
+        window,
+        dataset_key,
+        include_series,
+        tuple(sorted(hidden)),
+    )
     response, cache_status = await get_or_fill(cache, cache_locks, cache_key, fill)
 
     capture_api_event(
@@ -197,8 +259,77 @@ async def get_results_aggregates(
             "benchmark": benchmark,
             "window": window,
             "dataset": dataset_key,
+            "include_series": include_series,
             "model_stat_count": len(response.model_stats),
             "series_point_count": len(response.series),
+            "cache_hit": cache_status != "miss",
+            "cache_status": cache_status,
+            "$process_person_profile": False,
+        },
+    )
+    return response
+
+
+@router.get("/results/timeline", response_model=TimelineResponse)
+@limiter.limit("60/minute")
+async def get_results_timeline(
+    request: Request,
+    benchmark: BenchmarkLiteral = Query(...),
+    window: WindowLiteral = Query(default="24h"),
+    dataset: str | None = Query(
+        default=None,
+        description="Dataset id to aggregate over; omit for pooled all-dataset buckets.",
+    ),
+    pool: AsyncConnectionPool[Any] = Depends(get_pool),
+    posthog_client: Posthog | None = Depends(get_posthog),
+    cache: TTLCache[Any, Any] = Depends(get_cache),
+    cache_locks: defaultdict[Any, asyncio.Lock] = Depends(get_cache_locks),
+    hidden: frozenset[tuple[str, str]] = Depends(hidden_early_access),
+) -> TimelineResponse:
+    """Return chart points without the dashboard's aggregate-stat payload."""
+    dataset_key = dataset or DATASET_ALL
+
+    async def fill() -> TimelineResponse:
+        sql = _COMPACT_SERIES_SQL if window == "30d" else _TIMELINE_SQL
+        params = {
+            "benchmark": benchmark,
+            "dataset": dataset_key,
+            "interval": WINDOW_INTERVALS[window],
+        }
+        async with pool.connection() as conn:
+            conn.row_factory = psycopg.rows.dict_row
+            rows = await (await conn.execute(sql, params)).fetchall()
+        return TimelineResponse(
+            benchmark=benchmark,
+            window=window,
+            dataset=dataset_key,
+            points=[
+                TimelinePoint.model_validate(
+                    row
+                    if "value" in row
+                    else {
+                        **row,
+                        "value": row["value_sum"] / row["sample_count"]
+                        if row["metric_type"] == "WER"
+                        else row["p50"],
+                    }
+                )
+                for row in rows
+                if _visible(row, hidden)
+            ],
+        )
+
+    cache_key = ("timeline", benchmark, window, dataset_key, tuple(sorted(hidden)))
+    response, cache_status = await get_or_fill(cache, cache_locks, cache_key, fill)
+    capture_api_event(
+        posthog_client,
+        "results_timeline_queried",
+        {
+            "benchmark": benchmark,
+            "window": window,
+            "dataset": dataset_key,
+            "point_count": len(response.points),
+            "max_points_per_group": 240 if window == "30d" else None,
             "cache_hit": cache_status != "miss",
             "cache_status": cache_status,
             "$process_person_profile": False,

--- a/runner/src/coval_bench/api/schemas.py
+++ b/runner/src/coval_bench/api/schemas.py
@@ -196,6 +196,25 @@ class AggregatesResponse(BaseModel):
     series: list[SeriesPoint]
 
 
+class TimelinePoint(BaseModel):
+    """One compact chart point for a provider/model/metric bucket."""
+
+    provider: str
+    model: str
+    metric_type: str
+    scheduled_at: datetime
+    value: float
+
+
+class TimelineResponse(BaseModel):
+    """Response schema for GET /v1/results/timeline."""
+
+    benchmark: BenchmarkLiteral
+    window: WindowLiteral
+    dataset: str
+    points: list[TimelinePoint]
+
+
 class DatasetAggregates(BaseModel):
     """Per-model stats for one dataset — one block of the by-dataset response."""
 

--- a/runner/tests/api/test_aggregates.py
+++ b/runner/tests/api/test_aggregates.py
@@ -670,3 +670,142 @@ async def test_by_dataset_stats_carry_the_flag(client: AsyncClient, postgresql: 
     assert thin["model_stats"][0]["sample_count"] == 1
     assert full["model_stats"][0]["insufficient_samples"] is False
     assert full["model_stats"][0]["sample_count"] == MIN_SCORED_SAMPLES["STT"]
+
+
+async def test_include_series_false_keeps_stats_and_skips_series_sql(
+    client: AsyncClient, postgresql: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The lightweight aggregate path must not even prepare a series query."""
+    run_id = await _insert_run(postgresql, dataset_id="stt-v1")
+    await _insert_result(postgresql, run_id, metric_value=2.0)
+    await _refresh_mv(postgresql)
+
+    monkeypatch.setattr(
+        "coval_bench.api.routers.aggregates._SERIES_SQL", "SELECT invalid_series_sql"
+    )
+    monkeypatch.setattr(
+        "coval_bench.api.routers.aggregates._COMPACT_SERIES_SQL",
+        "SELECT invalid_compact_series_sql",
+    )
+    response = await client.get(
+        "/v1/results/aggregates",
+        params={"benchmark": "STT", "window": "30d", "include_series": "false"},
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["series"] == []
+    assert body["datasets"] == ["stt-v1"]
+    assert body["model_stats"][0]["avg_value"] == pytest.approx(2.0)
+
+
+async def test_include_series_cache_variants_do_not_cross_serve(
+    client: AsyncClient, postgresql: Any
+) -> None:
+    run_id = await _insert_run(postgresql)
+    await _insert_result(postgresql, run_id, metric_value=1.0)
+    await _refresh_mv(postgresql)
+    await _fill_buckets(postgresql)
+
+    no_series = await client.get(
+        "/v1/results/aggregates", params={"benchmark": "STT", "include_series": "false"}
+    )
+    with_series = await client.get("/v1/results/aggregates", params={"benchmark": "STT"})
+    assert no_series.json()["series"] == []
+    assert len(with_series.json()["series"]) == 1
+
+
+async def test_timeline_uses_weighted_wer_and_latency_p50(
+    client: AsyncClient, postgresql: Any
+) -> None:
+    scheduled = datetime.now(dt.UTC).replace(microsecond=0)
+    run_id = await _insert_run(postgresql, scheduled_at=scheduled)
+    await _insert_result(postgresql, run_id, metric_type="WER", metric_value=2.0)
+    await _insert_result(postgresql, run_id, metric_type="WER", metric_value=4.0)
+    await _insert_result(postgresql, run_id, metric_type="TTFS", metric_value=1.0)
+    await _insert_result(postgresql, run_id, metric_type="TTFS", metric_value=9.0)
+    await _fill_buckets(postgresql)
+
+    response = await client.get("/v1/results/timeline", params={"benchmark": "STT"})
+    assert response.status_code == 200
+    values = {point["metric_type"]: point["value"] for point in response.json()["points"]}
+    assert values["WER"] == pytest.approx(3.0)
+    assert values["TTFS"] == pytest.approx(5.0)
+
+
+async def test_timeline_short_windows_keep_all_buckets(
+    client: AsyncClient, postgresql: Any
+) -> None:
+    now = datetime.now(dt.UTC).replace(microsecond=0)
+    for hours_ago in (1, 24 * 3):
+        run_id = await _insert_run(postgresql, scheduled_at=now - timedelta(hours=hours_ago))
+        await _insert_result(postgresql, run_id, metric_value=float(hours_ago))
+    await _fill_buckets(postgresql)
+
+    seven_days = await client.get(
+        "/v1/results/timeline", params={"benchmark": "STT", "window": "7d"}
+    )
+    assert len(seven_days.json()["points"]) == 2
+    one_day = await client.get("/v1/results/timeline", params={"benchmark": "STT", "window": "24h"})
+    assert len(one_day.json()["points"]) == 1
+
+
+async def test_timeline_30d_caps_each_group_and_preserves_endpoints(
+    client: AsyncClient, postgresql: Any
+) -> None:
+    now = datetime.now(dt.UTC).replace(microsecond=0)
+    for index in range(241):
+        scheduled = now - timedelta(hours=index)
+        run_id = await _insert_run(postgresql, scheduled_at=scheduled)
+        deepgram_value = -100.0 if index == 80 else 1000.0 if index == 160 else float(index % 37)
+        await _insert_result(postgresql, run_id, metric_value=deepgram_value)
+        await _insert_result(
+            postgresql,
+            run_id,
+            provider="assemblyai",
+            model="best",
+            metric_value=float(index),
+        )
+    await _fill_buckets(postgresql)
+
+    response = await client.get(
+        "/v1/results/timeline", params={"benchmark": "STT", "window": "30d"}
+    )
+    assert response.status_code == 200
+    points = response.json()["points"]
+    assert points == sorted(
+        points,
+        key=lambda p: (p["scheduled_at"], p["provider"], p["model"], p["metric_type"]),
+    )
+    by_model: dict[tuple[str, str], list[dict[str, Any]]] = {}
+    for point in points:
+        by_model.setdefault((point["provider"], point["model"]), []).append(point)
+
+    assert set(by_model) == {("assemblyai", "best"), ("deepgram", "nova-3")}
+    for group in by_model.values():
+        assert len(group) <= 240
+        timestamps = {datetime.fromisoformat(point["scheduled_at"]) for point in group}
+        assert now in timestamps
+        assert now - timedelta(hours=240) in timestamps
+
+    deepgram_values = [point["value"] for point in by_model[("deepgram", "nova-3")]]
+    assert min(deepgram_values) == -100
+    assert max(deepgram_values) == 1000
+    assembly_values = [point["value"] for point in by_model[("assemblyai", "best")]]
+    assert min(assembly_values) == 0
+    assert max(assembly_values) == 240
+
+    repeated = await client.get(
+        "/v1/results/timeline", params={"benchmark": "STT", "window": "30d"}
+    )
+    assert repeated.json() == response.json()
+
+    legacy = await client.get(
+        "/v1/results/aggregates", params={"benchmark": "STT", "window": "30d"}
+    )
+    legacy_groups: dict[tuple[str, str], list[dict[str, Any]]] = {}
+    for point in legacy.json()["series"]:
+        legacy_groups.setdefault((point["provider"], point["model"]), []).append(point)
+    assert all(len(group) <= 240 for group in legacy_groups.values())
+    assert {"min_value", "p25", "p50", "p75", "max_value", "value_sum", "sample_count"} <= set(
+        legacy.json()["series"][0]
+    )

--- a/runner/tests/api/test_internal_access.py
+++ b/runner/tests/api/test_internal_access.py
@@ -165,6 +165,22 @@ async def test_aggregates_embargo_and_cache_isolation(client: AsyncClient, postg
 
 
 @pytest.mark.usefixtures("early_access_registry")
+async def test_timeline_embargo_and_cache_isolation(client: AsyncClient, postgresql: Any) -> None:
+    """Timeline cache entries keep the caller's embargo scope, like aggregates."""
+    await _seed_ea_and_public_rows(postgresql)
+    await _fill_buckets(postgresql)
+    params = {"benchmark": "STT", "window": "24h"}
+
+    internal = await client.get("/v1/results/timeline", params=params, headers=_internal_headers())
+    assert internal.status_code == 200
+    assert (_EA_PROVIDER, _EA_MODEL) in _models_in(internal.json()["points"])
+
+    public = await client.get("/v1/results/timeline", params=params)
+    assert public.status_code == 200
+    assert (_EA_PROVIDER, _EA_MODEL) not in _models_in(public.json()["points"])
+
+
+@pytest.mark.usefixtures("early_access_registry")
 async def test_aggregates_by_dataset_embargo_and_cache_isolation(
     client: AsyncClient, postgresql: Any
 ) -> None:
@@ -235,6 +251,7 @@ async def test_the_retired_x_headers_prove_nothing(client: AsyncClient) -> None:
         ("/v1/results", None),
         ("/v1/leaderboard", {"metric": "WER", "benchmark": "STT"}),
         ("/v1/results/aggregates", {"benchmark": "STT"}),
+        ("/v1/results/timeline", {"benchmark": "STT"}),
         ("/v1/results/aggregates/by-dataset", {"benchmark": "STT"}),
     ],
 )


### PR DESCRIPTION
## Summary

- add backward-compatible `include_series=false` support to aggregate requests and skip series SQL entirely on that path
- add a compact `/v1/results/timeline` response for dashboard charts
- keep 24h and 7d timelines at full bucket resolution
- bound 30d timelines in PostgreSQL to at most 240 representative points per provider/model/metric while preserving first, last, and plotted extrema
- apply the same 30d bound to the legacy aggregate series path
- keep internal-access visibility isolated in cache keys and add focused regression coverage

## Validation

- Ruff format and lint: PASS
- strict mypy on changed API source: PASS
- Python compile check: PASS
- `git diff --check`: PASS
- exact production SQL executed against PostgreSQL 16: two 241-point groups each returned 238 deterministic points, retaining endpoints and injected interior extrema; 7d returned every qualifying point with the compact projection
- independent Tier 3 review: PASS

Focused endpoint pytest was attempted, but the local host lacks the `pg_config` executable required by the pytest-postgresql fixture. The failure occurred during fixture setup rather than in a test assertion; the exact query received the PostgreSQL 16 smoke coverage described above.

## Rollout

Deploy this API change before the dependent benchmarks-web PR so `/v1/results/timeline` exists before the web client requests it.

Related: [infrastructure PR #138](https://github.com/coval-ai/benchmark-infra/pull/138) and [web PR #49](https://github.com/coval-ai/benchmarks-web/pull/49).
