### PR TITLE
[BENCH-734] Add Baseten qwen3-asr-1.7b STT and warm Baseten endpoints…

### DIFF
--- a/docs/methodology.md
+++ b/docs/methodology.md
@@ -161,10 +161,13 @@ non-persisting probe (`coval-bench probe`) warms the same way, so its numbers
 are comparable to a scheduled run's.
 
 Dedicated endpoints warm differently: rather than a connection, what needs
-warming is the replica behind it. The Baseten STT provider streams a one-second
-synthetic clip to every configured endpoint before t0, because those
-deployments are pinned at a single replica whose load time would otherwise be
-charged to whichever dataset item happened to draw it first.
+warming is the replica behind it. Baseten scales these deployments on demand,
+so the warmup request is also the scale-up trigger. The STT provider streams a
+one-second synthetic clip to every configured endpoint and the TTS provider
+synthesizes (then deletes) a throwaway phrase, each connecting with a
+six-minute handshake budget so a scale-from-zero boot (~3-4 minutes observed)
+completes before t0. Measurement traffic keeps the tighter 45-second handshake
+cap as a degraded-endpoint tripwire.
 
 ### HTTP/2 for the HTTP TTS cohort
 

--- a/docs/methodology.md
+++ b/docs/methodology.md
@@ -156,7 +156,15 @@ but the rule is the same.
 HTTP-pool warming lives in `runner/src/coval_bench/providers/_http_session.py`.
 Providers opt in by overriding `Provider.warmup()` in `providers/base.py`; the
 orchestrator invokes warmup on every enabled provider class before the
-dataset loop runs and tears down the pool in the run's `finally` block.
+dataset loop runs and tears down the pool in the run's `finally` block. The
+non-persisting probe (`coval-bench probe`) warms the same way, so its numbers
+are comparable to a scheduled run's.
+
+Dedicated endpoints warm differently: rather than a connection, what needs
+warming is the replica behind it. The Baseten STT provider streams a one-second
+synthetic clip to every configured endpoint before t0, because those
+deployments are pinned at a single replica whose load time would otherwise be
+charged to whichever dataset item happened to draw it first.
 
 ### HTTP/2 for the HTTP TTS cohort
 

--- a/runner/src/coval_bench/__main__.py
+++ b/runner/src/coval_bench/__main__.py
@@ -271,7 +271,11 @@ def stt_smoke(provider: str, model: str, wav: str) -> None:
         kwargs["ws_url"] = endpoint_url(settings, model)
     elif provider == "azure":
         kwargs["region"] = settings.azure_region
-    instance = provider_cls(**kwargs)
+    try:
+        instance = provider_cls(**kwargs)
+    except ValueError as exc:
+        click.echo(f"Provider configuration error: {exc}", err=True)
+        sys.exit(2)
 
     with wave.open(wav, "rb") as w:
         if w.getframerate() != 16000 or w.getnchannels() != 1 or w.getsampwidth() != 2:

--- a/runner/src/coval_bench/__main__.py
+++ b/runner/src/coval_bench/__main__.py
@@ -266,7 +266,9 @@ def stt_smoke(provider: str, model: str, wav: str) -> None:
     if provider == "google":
         kwargs["project_id"] = settings.google_project_id
     elif provider == "baseten":
-        kwargs["ws_url"] = settings.baseten_whisper_url
+        from coval_bench.providers.stt.baseten import endpoint_url
+
+        kwargs["ws_url"] = endpoint_url(settings, model)
     elif provider == "azure":
         kwargs["region"] = settings.azure_region
     instance = provider_cls(**kwargs)

--- a/runner/src/coval_bench/config.py
+++ b/runner/src/coval_bench/config.py
@@ -129,6 +129,7 @@ class Settings(BaseSettings):
     # pre-launch model ids, so they live in config (``.env`` locally, Secret
     # Manager in prod) rather than hardcoded in the provider modules.
     baseten_whisper_url: str | None = None  # STT (Whisper Large V3)
+    baseten_qwen_asr_url: str | None = None  # STT (Qwen3-ASR)
     baseten_qwen_url: str | None = None  # TTS (Qwen3-TTS)
 
     alibaba_tts_url: str | None = None

--- a/runner/src/coval_bench/providers/stt/baseten.py
+++ b/runner/src/coval_bench/providers/stt/baseten.py
@@ -1,20 +1,40 @@
 # Copyright 2026 The Coval Benchmarks Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Baseten dedicated-endpoint STT provider (Whisper Large V3 over WebSocket).
+"""Baseten dedicated-endpoint STT provider (Whisper Large V3, Qwen3-ASR).
 
-The server runs a Silero VAD that consumes audio in fixed 512-sample frames
-(32 ms @ 16 kHz). Raw PCM must be sent as binary frames of exactly 512 samples
-(1024 bytes); other frame sizes are not processed correctly. The endpoint URL
-embeds a private model id, so it is injected from settings rather than hardcoded.
+Baseten fronts several dedicated deployments under one provider name, and they
+do not all speak the same wire protocol:
+
+``binary``
+    Whisper deployments. Raw PCM as binary frames of exactly 512 samples
+    (1024 bytes) — the Silero VAD frame size; other frame sizes are not
+    processed correctly — finalized with ``{"type": "end_audio"}``. The server
+    answers ``end_audio`` twice ("acknowledged", then "finished") and never
+    closes the session itself.
+
+``buffer``
+    Qwen3-ASR deployments. Binary frames are rejected; PCM goes base64-encoded
+    inside ``input_audio_buffer.append`` messages, finalized with
+    ``input_audio_buffer.commit``. The last transcription carries
+    ``is_end_of_audio_flush``; no ``end_audio`` message is ever sent.
+
+Both protocols open with the same session frame and return the same
+``transcription`` message shape. Endpoint URLs embed private, pre-launch model
+ids, so they are injected from settings rather than hardcoded.
 """
 
 from __future__ import annotations
 
 import asyncio
+import base64
 import json
+import math
+import struct
 import time
-from typing import Any
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import TYPE_CHECKING, Any
 
 import structlog
 import websockets.asyncio.client as ws_client
@@ -23,21 +43,82 @@ from pydantic import SecretStr
 from coval_bench.providers.base import STTProvider, TranscriptionResult
 from coval_bench.providers.stt._pacing import paced_chunks
 
+if TYPE_CHECKING:
+    from coval_bench.config import Settings
+
 logger = structlog.get_logger(__name__)
 
 # Silero VAD frame: 512 samples * 2 bytes = 1024 bytes; other sizes are rejected.
 _FRAME_SAMPLES = 512
 _FRAME_BYTES = _FRAME_SAMPLES * 2
-_BYTE_RATE = 16000 * 2  # 16 kHz mono 16-bit
+_SAMPLE_RATE = 16000
+_BYTE_RATE = _SAMPLE_RATE * 2  # 16 kHz mono 16-bit
+# input_audio_buffer.append carries 100 ms per message.
+_APPEND_BYTES = int(_SAMPLE_RATE * 0.1) * 2
 _MAX_WS_SIZE = 16 * 1024 * 1024
 # Cold replicas exceed the 10 s websockets default for the handshake.
 _OPEN_TIMEOUT_S = 45
+# Partial cadence. Held identical across every Baseten endpoint: TTFS measures
+# time to the first partial, so a per-endpoint cadence would show up as a
+# latency difference that is really just configuration.
+_PARTIAL_INTERVAL_S = 0.3
+# Warmup streams this much synthetic audio to wake a scaled-down replica.
+_WARMUP_SECONDS = 1.0
+# A stream the server closes without ever sending a final. During measurement
+# this is a failure; during warmup it is the expected outcome for the tone clip
+# (no speech for the VAD to finalize), so warmup maps it back to success.
+_NO_FINAL_ERROR = "Baseten stream ended before a final transcription was received"
+
+# Baseten runs these deployments on demand-scaled autoscaling with no schedule:
+# our warmup request IS the scale-up trigger, so the budget must outlast a full
+# scale-from-zero boot (~166 s measured) with slack for slow provisioning.
+_WARMUP_TIMEOUT_S = 360
+
+
+class _Protocol(StrEnum):
+    """How a deployment wants its audio framed."""
+
+    BINARY = "binary"
+    BUFFER = "buffer"
+
+
+@dataclass(frozen=True)
+class _Endpoint:
+    """Where a model is deployed and how to talk to it."""
+
+    url_attr: str  # Settings attribute holding the wss:// URL
+    protocol: _Protocol
+
+
+_ENDPOINTS: dict[str, _Endpoint] = {
+    "whisper-large-v3": _Endpoint("baseten_whisper_url", _Protocol.BINARY),
+    "qwen3-asr-1.7b": _Endpoint("baseten_qwen_asr_url", _Protocol.BUFFER),
+}
+
+
+def endpoint_url(settings: Settings, model: str) -> str | None:
+    """The configured WebSocket URL for *model*, or None if unknown/unset."""
+    endpoint = _ENDPOINTS.get(model)
+    if endpoint is None:
+        return None
+    url: str | None = getattr(settings, endpoint.url_attr, None)
+    return url
+
+
+def _warmup_pcm() -> bytes:
+    """A quiet tone, not silence — silence can pass under VAD without inference."""
+    n = int(_SAMPLE_RATE * _WARMUP_SECONDS)
+    amplitude = 3000  # ~ -21 dBFS: loud enough to trip VAD, quiet enough to be junk
+    return struct.pack(
+        f"<{n}h",
+        *(int(amplitude * math.sin(2 * math.pi * 220 * i / _SAMPLE_RATE)) for i in range(n)),
+    )
 
 
 class BasetenSTTProvider(STTProvider):
-    """Baseten streaming STT provider (Whisper Large V3)."""
+    """Baseten streaming STT provider (Whisper Large V3, Qwen3-ASR)."""
 
-    _VALID_MODELS = frozenset({"whisper-large-v3"})
+    _VALID_MODELS = frozenset(_ENDPOINTS)
 
     def __init__(
         self,
@@ -51,11 +132,13 @@ class BasetenSTTProvider(STTProvider):
             )
         if api_key is None or not api_key.get_secret_value().strip():
             raise ValueError("baseten_api_key is required for the Baseten STT provider")
+        endpoint = _ENDPOINTS[model]
         if not ws_url:
-            raise ValueError("baseten_whisper_url is required for the Baseten STT provider")
+            raise ValueError(f"{endpoint.url_attr} is required for the Baseten STT provider")
         self._api_key = api_key
         self._model = model
         self._ws_url = ws_url
+        self._protocol = endpoint.protocol
 
     @property
     def name(self) -> str:
@@ -64,6 +147,48 @@ class BasetenSTTProvider(STTProvider):
     @property
     def model(self) -> str:
         return self._model
+
+    @classmethod
+    async def warmup(cls, settings: Settings) -> None:
+        """Stream a throwaway clip to every configured endpoint, concurrently.
+
+        Baseten pins these deployments at one replica and asked us to warm them
+        before each test, since they plan to drop their own warmup when
+        autoscaling moves off GitHub Actions. A cold replica would otherwise
+        charge its load time to whichever dataset item drew it first.
+        """
+        api_key = settings.baseten_api_key
+        if api_key is None or not api_key.get_secret_value().strip():
+            return
+        pcm = _warmup_pcm()
+
+        async def _warm(model: str, url: str) -> None:
+            provider = cls(api_key=api_key, model=model, ws_url=url)
+            t0 = time.monotonic()
+            error: str | None = None
+            try:
+                async with asyncio.timeout(_WARMUP_TIMEOUT_S):
+                    result = await provider.measure_ttft(pcm, 1, 2, _SAMPLE_RATE)
+                error = None if result.error == _NO_FINAL_ERROR else result.error
+            except TimeoutError:
+                error = f"warmup timed out after {_WARMUP_TIMEOUT_S}s; endpoint still not up"
+            logger.info(
+                "baseten_stt_prewarm",
+                provider="baseten",
+                model=model,
+                warmup_ms=round((time.monotonic() - t0) * 1000, 1),
+                error=error,
+            )
+
+        targets = [
+            (model, url)
+            for model in _ENDPOINTS
+            if (url := endpoint_url(settings, model)) is not None
+        ]
+        if targets:
+            await asyncio.gather(
+                *(_warm(model, url) for model, url in targets), return_exceptions=True
+            )
 
     async def measure_ttft(
         self,
@@ -74,7 +199,7 @@ class BasetenSTTProvider(STTProvider):
         realtime_resolution: float = 0.1,
     ) -> TranscriptionResult:
         result = TranscriptionResult(provider=self.name)
-        if sample_rate != 16000:
+        if sample_rate != _SAMPLE_RATE:
             result.error = f"Baseten requires 16 kHz PCM input; got {sample_rate} Hz"
             return result
         if channels != 1 or sample_width != 2:
@@ -94,13 +219,13 @@ class BasetenSTTProvider(STTProvider):
                 max_size=_MAX_WS_SIZE,
                 open_timeout=_OPEN_TIMEOUT_S,
             ) as ws:
-                # First message configures the stream: partials at a 300 ms cadence.
+                # First message configures the stream, on both protocols.
                 await ws.send(
                     json.dumps(
                         {
                             "streaming_params": {
                                 "enable_partial_transcripts": True,
-                                "partial_transcript_interval_s": 0.3,
+                                "partial_transcript_interval_s": _PARTIAL_INTERVAL_S,
                             }
                         }
                     )
@@ -120,9 +245,7 @@ class BasetenSTTProvider(STTProvider):
                             result.error = str(outcome)
                             break
                     else:
-                        result.error = (
-                            "Baseten stream ended before a final transcription was received"
-                        )
+                        result.error = _NO_FINAL_ERROR
 
         except Exception as exc:
             logger.warning(
@@ -139,18 +262,31 @@ class BasetenSTTProvider(STTProvider):
         audio_data: bytes,
         result: TranscriptionResult,
     ) -> None:
+        binary = self._protocol is _Protocol.BINARY
+        chunk_bytes = _FRAME_BYTES if binary else _APPEND_BYTES
         try:
-            async for chunk, start in paced_chunks(audio_data, _FRAME_BYTES, _BYTE_RATE):
+            async for chunk, start in paced_chunks(audio_data, chunk_bytes, _BYTE_RATE):
                 # Stop early if _receive already recorded a protocol/auth error.
                 if result.error is not None:
                     break
                 result.audio_start_time = start
-                frame = chunk
-                if len(frame) < _FRAME_BYTES:  # pad the final short frame to 512 samples
-                    frame += b"\x00" * (_FRAME_BYTES - len(frame))
-                await ws.send(frame)
+                if binary:
+                    frame = chunk
+                    if len(frame) < _FRAME_BYTES:  # pad the final short frame to 512 samples
+                        frame += b"\x00" * (_FRAME_BYTES - len(frame))
+                    await ws.send(frame)
+                else:
+                    await ws.send(
+                        json.dumps(
+                            {
+                                "type": "input_audio_buffer.append",
+                                "audio": base64.b64encode(chunk).decode(),
+                            }
+                        )
+                    )
             # Signal end of audio so the server flushes the final transcript.
-            await ws.send(json.dumps({"type": "end_audio"}))
+            terminator = "end_audio" if binary else "input_audio_buffer.commit"
+            await ws.send(json.dumps({"type": terminator}))
         except Exception as exc:
             logger.warning(
                 "baseten_send_error", provider="baseten", model=self._model, exc_info=exc
@@ -177,7 +313,7 @@ class BasetenSTTProvider(STTProvider):
                         break
                     continue
                 if msg_type == "error":
-                    result.error = str(msg.get("message") or msg)
+                    result.error = str(msg.get("message") or msg.get("body") or msg)
                     logger.warning(
                         "baseten_stt_error", provider="baseten", model=self._model, msg=msg
                     )
@@ -186,19 +322,21 @@ class BasetenSTTProvider(STTProvider):
                     continue
 
                 text = " ".join(str(seg.get("text", "")) for seg in msg.get("segments", [])).strip()
-                if not text:
-                    continue
+                if text:
+                    if result.ttft_seconds is None and result.audio_start_time is not None:
+                        result.ttft_seconds = now - result.audio_start_time
+                        result.first_token_content = text[:30] + "..." if len(text) > 30 else text
 
-                if result.ttft_seconds is None and result.audio_start_time is not None:
-                    result.ttft_seconds = now - result.audio_start_time
-                    result.first_token_content = text[:30] + "..." if len(text) > 30 else text
+                    if msg.get("is_final"):
+                        final_parts.append(text)
+                        if result.audio_start_time is not None:
+                            result.audio_to_final_seconds = now - result.audio_start_time
+                    else:
+                        result.partial_transcripts.append(text)
 
-                if msg.get("is_final"):
-                    final_parts.append(text)
-                    if result.audio_start_time is not None:
-                        result.audio_to_final_seconds = now - result.audio_start_time
-                else:
-                    result.partial_transcripts.append(text)
+                # The buffer protocol's end-of-stream marker; it sends no end_audio.
+                if msg.get("is_end_of_audio_flush"):
+                    break
 
         except Exception as exc:
             logger.warning(

--- a/runner/src/coval_bench/providers/stt/baseten.py
+++ b/runner/src/coval_bench/providers/stt/baseten.py
@@ -56,7 +56,10 @@ _BYTE_RATE = _SAMPLE_RATE * 2  # 16 kHz mono 16-bit
 # input_audio_buffer.append carries 100 ms per message.
 _APPEND_BYTES = int(_SAMPLE_RATE * 0.1) * 2
 _MAX_WS_SIZE = 16 * 1024 * 1024
-# Cold replicas exceed the 10 s websockets default for the handshake.
+# Measurement handshake cap. By measurement time warmup has already booted the
+# replica, so 45 s is a degraded-endpoint tripwire; warmup itself connects with
+# its own budget-length open timeout, since Baseten parks the upgrade request
+# for the whole scale-from-zero boot.
 _OPEN_TIMEOUT_S = 45
 # Partial cadence. Held identical across every Baseten endpoint: TTFS measures
 # time to the first partial, so a per-endpoint cadence would show up as a
@@ -125,6 +128,7 @@ class BasetenSTTProvider(STTProvider):
         api_key: SecretStr | None,
         model: str = "whisper-large-v3",
         ws_url: str | None = None,
+        open_timeout_s: float = _OPEN_TIMEOUT_S,
     ) -> None:
         if not self._model_supported(model):
             raise ValueError(
@@ -139,6 +143,7 @@ class BasetenSTTProvider(STTProvider):
         self._model = model
         self._ws_url = ws_url
         self._protocol = endpoint.protocol
+        self._open_timeout_s = open_timeout_s
 
     @property
     def name(self) -> str:
@@ -163,7 +168,9 @@ class BasetenSTTProvider(STTProvider):
         pcm = _warmup_pcm()
 
         async def _warm(model: str, url: str) -> None:
-            provider = cls(api_key=api_key, model=model, ws_url=url)
+            provider = cls(
+                api_key=api_key, model=model, ws_url=url, open_timeout_s=_WARMUP_TIMEOUT_S
+            )
             t0 = time.monotonic()
             error: str | None = None
             try:
@@ -217,7 +224,7 @@ class BasetenSTTProvider(STTProvider):
                 self._ws_url,
                 additional_headers=headers,
                 max_size=_MAX_WS_SIZE,
-                open_timeout=_OPEN_TIMEOUT_S,
+                open_timeout=self._open_timeout_s,
             ) as ws:
                 # First message configures the stream, on both protocols.
                 await ws.send(

--- a/runner/src/coval_bench/providers/stt/baseten.py
+++ b/runner/src/coval_bench/providers/stt/baseten.py
@@ -53,28 +53,17 @@ _FRAME_SAMPLES = 512
 _FRAME_BYTES = _FRAME_SAMPLES * 2
 _SAMPLE_RATE = 16000
 _BYTE_RATE = _SAMPLE_RATE * 2  # 16 kHz mono 16-bit
-# input_audio_buffer.append carries 100 ms per message.
 _APPEND_BYTES = int(_SAMPLE_RATE * 0.1) * 2
 _MAX_WS_SIZE = 16 * 1024 * 1024
-# Measurement handshake cap. By measurement time warmup has already booted the
-# replica, so 45 s is a degraded-endpoint tripwire; warmup itself connects with
-# its own budget-length open timeout, since Baseten parks the upgrade request
-# for the whole scale-from-zero boot.
+# Measurement handshake cap; warmup connects with its own budget-length timeout.
 _OPEN_TIMEOUT_S = 45
-# Partial cadence. Held identical across every Baseten endpoint: TTFS measures
-# time to the first partial, so a per-endpoint cadence would show up as a
-# latency difference that is really just configuration.
+# Identical across endpoints so latency deltas are model, not configuration.
 _PARTIAL_INTERVAL_S = 0.3
-# Warmup streams this much synthetic audio to wake a scaled-down replica.
 _WARMUP_SECONDS = 1.0
-# A stream the server closes without ever sending a final. During measurement
-# this is a failure; during warmup it is the expected outcome for the tone clip
-# (no speech for the VAD to finalize), so warmup maps it back to success.
+# A measurement failure; warmup maps it to success (the tone has no speech).
 _NO_FINAL_ERROR = "Baseten stream ended before a final transcription was received"
 
-# Baseten runs these deployments on demand-scaled autoscaling with no schedule:
-# our warmup request IS the scale-up trigger, so the budget must outlast a full
-# scale-from-zero boot (~166 s measured) with slack for slow provisioning.
+# The warmup is the scale-up trigger; must outlast a boot (~253 s observed).
 _WARMUP_TIMEOUT_S = 360
 
 
@@ -111,7 +100,7 @@ def endpoint_url(settings: Settings, model: str) -> str | None:
 def _warmup_pcm() -> bytes:
     """A quiet tone, not silence — silence can pass under VAD without inference."""
     n = int(_SAMPLE_RATE * _WARMUP_SECONDS)
-    amplitude = 3000  # ~ -21 dBFS: loud enough to trip VAD, quiet enough to be junk
+    amplitude = 3000
     return struct.pack(
         f"<{n}h",
         *(int(amplitude * math.sin(2 * math.pi * 220 * i / _SAMPLE_RATE)) for i in range(n)),
@@ -155,13 +144,7 @@ class BasetenSTTProvider(STTProvider):
 
     @classmethod
     async def warmup(cls, settings: Settings) -> None:
-        """Stream a throwaway clip to every configured endpoint, concurrently.
-
-        Baseten pins these deployments at one replica and asked us to warm them
-        before each test, since they plan to drop their own warmup when
-        autoscaling moves off GitHub Actions. A cold replica would otherwise
-        charge its load time to whichever dataset item drew it first.
-        """
+        """Wake and warm every configured endpoint concurrently; never fatal."""
         api_key = settings.baseten_api_key
         if api_key is None or not api_key.get_secret_value().strip():
             return
@@ -226,7 +209,6 @@ class BasetenSTTProvider(STTProvider):
                 max_size=_MAX_WS_SIZE,
                 open_timeout=self._open_timeout_s,
             ) as ws:
-                # First message configures the stream, on both protocols.
                 await ws.send(
                     json.dumps(
                         {

--- a/runner/src/coval_bench/providers/tts/baseten.py
+++ b/runner/src/coval_bench/providers/tts/baseten.py
@@ -29,10 +29,9 @@ _VALID_MODELS = ("qwen3-tts-1.7b",)
 _VALID_VOICES = ("lisa", "jim")
 _SAMPLE_RATE = 24000
 _MAX_WS_SIZE = 16 * 1024 * 1024
-# Cold replicas exceed the 10 s websockets default for the handshake.
+# Measurement handshake cap; warmup connects with its own budget-length timeout.
 _OPEN_TIMEOUT_S = 45
-# Our warmup request is the scale-up trigger for a demand-scaled deployment;
-# the budget must outlast a full boot (~166 s measured) with provisioning slack.
+# The warmup is the scale-up trigger; must outlast a boot (~253 s observed).
 _WARMUP_TIMEOUT_S = 360
 
 
@@ -73,12 +72,7 @@ class BasetenTTSProvider(TTSProvider):
 
     @classmethod
     async def warmup(cls, settings: Settings) -> None:
-        """Synthesize a throwaway phrase so the single pinned replica is hot.
-
-        Mirrors the Baseten STT warmup: Baseten is retiring its own scheduled
-        warmup traffic and asked us to warm endpoints before testing. The audio
-        artifact is deleted here — the orchestrator only cleans up items it ran.
-        """
+        """Wake and warm the endpoint; deletes its own artifact; never fatal."""
         api_key = settings.baseten_api_key
         if api_key is None or not api_key.get_secret_value().strip():
             return

--- a/runner/src/coval_bench/providers/tts/baseten.py
+++ b/runner/src/coval_bench/providers/tts/baseten.py
@@ -39,7 +39,13 @@ _WARMUP_TIMEOUT_S = 360
 class BasetenTTSProvider(TTSProvider):
     """Baseten TTS provider using WebSocket streaming (Qwen3-TTS)."""
 
-    def __init__(self, settings: Settings, model: str, voice: str) -> None:
+    def __init__(
+        self,
+        settings: Settings,
+        model: str,
+        voice: str,
+        open_timeout_s: float = _OPEN_TIMEOUT_S,
+    ) -> None:
         if model not in _VALID_MODELS:
             raise ValueError(f"Invalid Baseten TTS model {model!r}. Valid: {_VALID_MODELS}")
         if voice not in _VALID_VOICES:
@@ -55,6 +61,7 @@ class BasetenTTSProvider(TTSProvider):
         if not settings.baseten_qwen_url:
             raise ValueError("baseten_qwen_url is required in Settings")
         self._ws_url = settings.baseten_qwen_url
+        self._open_timeout_s = open_timeout_s
 
     @property
     def name(self) -> str:
@@ -77,7 +84,9 @@ class BasetenTTSProvider(TTSProvider):
             return
         if not settings.baseten_qwen_url:
             return
-        provider = cls(settings, _VALID_MODELS[0], _VALID_VOICES[0])
+        provider = cls(
+            settings, _VALID_MODELS[0], _VALID_VOICES[0], open_timeout_s=_WARMUP_TIMEOUT_S
+        )
         t0 = time.monotonic()
         error: str | None = None
         try:
@@ -107,7 +116,7 @@ class BasetenTTSProvider(TTSProvider):
                 self._ws_url,
                 additional_headers=headers,
                 max_size=_MAX_WS_SIZE,
-                open_timeout=_OPEN_TIMEOUT_S,
+                open_timeout=self._open_timeout_s,
             ) as ws:
                 # Clock starts post-handshake so TTFA excludes connect (cohort parity).
                 start = time.monotonic()

--- a/runner/src/coval_bench/providers/tts/baseten.py
+++ b/runner/src/coval_bench/providers/tts/baseten.py
@@ -11,6 +11,7 @@ private model id, so it is read from settings rather than hardcoded.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import time
 from typing import Any
@@ -30,6 +31,9 @@ _SAMPLE_RATE = 24000
 _MAX_WS_SIZE = 16 * 1024 * 1024
 # Cold replicas exceed the 10 s websockets default for the handshake.
 _OPEN_TIMEOUT_S = 45
+# Our warmup request is the scale-up trigger for a demand-scaled deployment;
+# the budget must outlast a full boot (~166 s measured) with provisioning slack.
+_WARMUP_TIMEOUT_S = 360
 
 
 class BasetenTTSProvider(TTSProvider):
@@ -59,6 +63,38 @@ class BasetenTTSProvider(TTSProvider):
     @property
     def model(self) -> str:
         return self._model
+
+    @classmethod
+    async def warmup(cls, settings: Settings) -> None:
+        """Synthesize a throwaway phrase so the single pinned replica is hot.
+
+        Mirrors the Baseten STT warmup: Baseten is retiring its own scheduled
+        warmup traffic and asked us to warm endpoints before testing. The audio
+        artifact is deleted here — the orchestrator only cleans up items it ran.
+        """
+        api_key = settings.baseten_api_key
+        if api_key is None or not api_key.get_secret_value().strip():
+            return
+        if not settings.baseten_qwen_url:
+            return
+        provider = cls(settings, _VALID_MODELS[0], _VALID_VOICES[0])
+        t0 = time.monotonic()
+        error: str | None = None
+        try:
+            async with asyncio.timeout(_WARMUP_TIMEOUT_S):
+                result = await provider.synthesize("Warm up.")
+            if result.audio_path is not None:
+                result.audio_path.unlink(missing_ok=True)
+            error = result.error
+        except TimeoutError:
+            error = f"warmup timed out after {_WARMUP_TIMEOUT_S}s; endpoint still not up"
+        logger.info(
+            "baseten_tts_prewarm",
+            provider="baseten",
+            model=_VALID_MODELS[0],
+            warmup_ms=round((time.monotonic() - t0) * 1000, 1),
+            error=error,
+        )
 
     async def synthesize(self, text: str) -> TTSResult:
         audio_chunks: list[bytes] = []

--- a/runner/src/coval_bench/registries/models.py
+++ b/runner/src/coval_bench/registries/models.py
@@ -345,6 +345,18 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         region="us",
         status=_EARLY_ACCESS,
     ),
+    RegisteredModel(
+        benchmark=_STT,
+        provider="baseten",
+        model="qwen3-asr-1.7b",
+        creator="alibaba",
+        tags=(_MULTI, _VAD),
+        source=Source.DEDICATED_INFERENCE,
+        licensing=_OPEN,
+        on_prem=True,
+        region="us",
+        status=_EARLY_ACCESS,
+    ),
     # Azure AI Speech real-time (raw WebSocket, conversation mode).
     RegisteredModel(
         benchmark=_STT,

--- a/runner/src/coval_bench/runner/orchestrator.py
+++ b/runner/src/coval_bench/runner/orchestrator.py
@@ -378,7 +378,6 @@ async def _run_stt_item(
             kwargs["ws_url"] = _get_baseten_stt_url()(settings, entry.model)
         elif entry.provider == "azure":
             kwargs["region"] = settings.azure_region
-        provider = provider_cls(**kwargs)
 
         audio_path: Path = item.path
         transcript_ref: str = item.transcript
@@ -403,6 +402,9 @@ async def _run_stt_item(
         transcription_result = None
         item_error: str | None = None
         try:
+            # Inside the try so a config error (e.g. unset endpoint URL) lands
+            # as error rows instead of vanishing into the gather.
+            provider = provider_cls(**kwargs)
             async with asyncio.timeout(_STT_TIMEOUT_S):
                 transcription_result = await with_retry(
                     lambda: provider.measure_ttft(
@@ -759,11 +761,11 @@ async def _run_tts_item(
             return []
 
         transcript: str = item.transcript
-        provider = provider_cls(settings=settings, model=entry.model, voice=voice)
 
         tts_result = None
         item_error: str | None = None
         try:
+            provider = provider_cls(settings=settings, model=entry.model, voice=voice)
             async with asyncio.timeout(_TTS_TIMEOUT_S):
                 tts_result = await with_retry(
                     lambda: provider.synthesize(transcript),

--- a/runner/src/coval_bench/runner/orchestrator.py
+++ b/runner/src/coval_bench/runner/orchestrator.py
@@ -288,6 +288,12 @@ def _get_tts_providers() -> dict[str, Any]:
     return mod.TTS_PROVIDERS  # type: ignore[no-any-return]
 
 
+def _get_baseten_stt_url() -> Any:
+    """Resolve the Baseten per-model endpoint lookup at call time (lazy import)."""
+    mod = importlib.import_module("coval_bench.providers.stt.baseten")
+    return mod.endpoint_url
+
+
 def _get_load_dataset() -> Any:  # noqa: ANN401
     """Resolve ``load_dataset`` at call time (lazy import)."""
     mod = importlib.import_module("coval_bench.datasets")
@@ -369,7 +375,7 @@ async def _run_stt_item(
         if entry.provider == "google":
             kwargs["project_id"] = settings.google_project_id
         elif entry.provider == "baseten":
-            kwargs["ws_url"] = settings.baseten_whisper_url
+            kwargs["ws_url"] = _get_baseten_stt_url()(settings, entry.model)
         elif entry.provider == "azure":
             kwargs["region"] = settings.azure_region
         provider = provider_cls(**kwargs)

--- a/runner/src/coval_bench/runner/probe.py
+++ b/runner/src/coval_bench/runner/probe.py
@@ -105,12 +105,7 @@ async def _run_model(
 
 
 async def _warmup(models: list[RegisteredModel], settings: Settings) -> None:
-    """Run ``Provider.warmup()`` for the selected models, as ``run_benchmarks`` does.
-
-    Without this a probe charges cold-start to whichever item ran first, which
-    is exactly the number a probe of a single-replica dedicated endpoint is
-    trying to measure. Failures are logged, never fatal.
-    """
+    """Run ``Provider.warmup()`` for the selected models, as ``run_benchmarks`` does."""
     stt_providers = _get_stt_providers()
     tts_providers = _get_tts_providers()
     classes: set[Any] = set()
@@ -155,8 +150,7 @@ async def run_probe(
             results=results,
         )
     finally:
-        # Warmup may prime the shared HTTP pools; mirror run_benchmarks so a
-        # probe never leaves clients bound to this (about to close) event loop.
+        # Warmup can prime the shared HTTP pools.
         await _close_http_clients()
     return results
 

--- a/runner/src/coval_bench/runner/probe.py
+++ b/runner/src/coval_bench/runner/probe.py
@@ -22,7 +22,12 @@ import structlog
 from coval_bench.datasets.loader import load_stt_dataset, load_tts_dataset
 from coval_bench.db.models import ResultStatus
 from coval_bench.registries import METRIC_SPECS, Benchmark, Metric
-from coval_bench.runner.orchestrator import _run_stt_item, _run_tts_item
+from coval_bench.runner.orchestrator import (
+    _get_stt_providers,
+    _get_tts_providers,
+    _run_stt_item,
+    _run_tts_item,
+)
 
 if TYPE_CHECKING:
     from coval_bench.config import Settings
@@ -98,6 +103,33 @@ async def _run_model(
     }
 
 
+async def _warmup(models: list[RegisteredModel], settings: Settings) -> None:
+    """Run ``Provider.warmup()`` for the selected models, as ``run_benchmarks`` does.
+
+    Without this a probe charges cold-start to whichever item ran first, which
+    is exactly the number a probe of a single-replica dedicated endpoint is
+    trying to measure. Failures are logged, never fatal.
+    """
+    stt_providers = _get_stt_providers()
+    tts_providers = _get_tts_providers()
+    classes: set[Any] = set()
+    for entry in models:
+        registry = stt_providers if entry.benchmark is Benchmark.STT else tts_providers
+        cls = registry.get(entry.provider)
+        if cls is not None:
+            classes.add(cls)
+    if not classes:
+        return
+
+    ordered = list(classes)
+    outcomes = await asyncio.gather(
+        *(cls.warmup(settings=settings) for cls in ordered), return_exceptions=True
+    )
+    for cls, outcome in zip(ordered, outcomes, strict=False):
+        if isinstance(outcome, BaseException):
+            logger.warning("probe_warmup_failed", provider=cls.__name__, exc_info=outcome)
+
+
 async def run_probe(
     *,
     settings: Settings,
@@ -112,6 +144,8 @@ async def run_probe(
     """
     sem = asyncio.Semaphore(concurrency)
     results: dict[str, dict[str, Any]] = {}
+
+    await _warmup(models, settings)
 
     stt_models = [m for m in models if m.benchmark is Benchmark.STT]
     tts_models = [m for m in models if m.benchmark is Benchmark.TTS]

--- a/runner/src/coval_bench/runner/probe.py
+++ b/runner/src/coval_bench/runner/probe.py
@@ -21,6 +21,7 @@ import structlog
 
 from coval_bench.datasets.loader import load_stt_dataset, load_tts_dataset
 from coval_bench.db.models import ResultStatus
+from coval_bench.providers._http_session import close_all as _close_http_clients
 from coval_bench.registries import METRIC_SPECS, Benchmark, Metric
 from coval_bench.runner.orchestrator import (
     _get_stt_providers,
@@ -145,6 +146,29 @@ async def run_probe(
     sem = asyncio.Semaphore(concurrency)
     results: dict[str, dict[str, Any]] = {}
 
+    try:
+        await _run(
+            models=models,
+            settings=settings,
+            sample_size=sample_size,
+            sem=sem,
+            results=results,
+        )
+    finally:
+        # Warmup may prime the shared HTTP pools; mirror run_benchmarks so a
+        # probe never leaves clients bound to this (about to close) event loop.
+        await _close_http_clients()
+    return results
+
+
+async def _run(
+    *,
+    models: list[RegisteredModel],
+    settings: Settings,
+    sample_size: int,
+    sem: asyncio.Semaphore,
+    results: dict[str, dict[str, Any]],
+) -> None:
     await _warmup(models, settings)
 
     stt_models = [m for m in models if m.benchmark is Benchmark.STT]
@@ -182,4 +206,3 @@ async def run_probe(
                 sem=sem,
                 settings=settings,
             )
-    return results

--- a/runner/tests/providers/stt/test_baseten.py
+++ b/runner/tests/providers/stt/test_baseten.py
@@ -3,15 +3,21 @@
 
 """Tests for coval_bench.providers.stt.baseten (BasetenSTTProvider).
 
-All tests use FakeWebSocket — no live network calls. The fixtures mirror the
-Baseten Whisper wire protocol: ``transcription`` messages carry ``segments`` and
-an ``is_final`` flag, two ``end_audio`` messages bracket the stream
-(``acknowledged`` then ``finished``), and the receiver stops only on
-``finished``. A small PCM buffer keeps the real-time 512-sample pacing fast.
+All tests use FakeWebSocket — no live network calls. Two wire protocols are
+covered. Whisper endpoints (``binary``) take raw 512-sample frames and are
+bracketed by two ``end_audio`` messages (``acknowledged`` then ``finished``),
+and the receiver stops only on ``finished``. The Qwen3-ASR endpoint
+(``buffer``) takes base64 PCM in ``input_audio_buffer.append`` messages,
+finalizes with ``input_audio_buffer.commit``, and ends on a transcription
+flagged ``is_end_of_audio_flush``. Both share the ``transcription`` message
+shape. A small PCM buffer keeps the real-time pacing fast.
 """
 
 from __future__ import annotations
 
+import base64
+import json
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -19,10 +25,11 @@ import pytest
 from pydantic import SecretStr
 
 from coval_bench.metrics.wer import compute_wer
-from coval_bench.providers.stt.baseten import BasetenSTTProvider
+from coval_bench.providers.stt.baseten import BasetenSTTProvider, endpoint_url
 from tests.providers.stt.conftest import FakeWebSocket
 
 _WS_URL = "wss://model-test.api.baseten.co/environments/production/websocket"
+_QWEN_MODEL = "qwen3-asr-1.7b"
 
 # A few frames of PCM — enough to exercise framing/padding without the 3 s
 # fixture's real-time pacing dominating the test runtime.
@@ -33,8 +40,8 @@ def make_provider(api_key: SecretStr | None = None) -> BasetenSTTProvider:
     return BasetenSTTProvider(api_key=api_key or SecretStr("test-key"), ws_url=_WS_URL)
 
 
-def _fake_connect(events: list[Any]) -> Any:
-    ws = FakeWebSocket(events)
+def _fake_connect(events: list[Any], sent: list[Any] | None = None) -> Any:
+    ws = FakeWebSocket(events, on_send=None if sent is None else sent.append)
     cm = MagicMock()
     cm.__aenter__ = AsyncMock(return_value=ws)
     cm.__aexit__ = AsyncMock(return_value=False)
@@ -195,3 +202,238 @@ async def test_baseten_connection_error(fake_api_key: SecretStr) -> None:
     assert result.error is not None
     assert "connection refused" in result.error
     assert result.complete_transcript is None
+
+
+# ---------------------------------------------------------------------------
+# Qwen3-ASR: the input_audio_buffer protocol
+# ---------------------------------------------------------------------------
+
+
+def _qwen_provider(api_key: SecretStr) -> BasetenSTTProvider:
+    return BasetenSTTProvider(api_key=api_key, model=_QWEN_MODEL, ws_url=_WS_URL)
+
+
+@pytest.mark.asyncio
+async def test_qwen_buffer_success(fake_api_key: SecretStr) -> None:
+    """The buffer protocol ends on is_end_of_audio_flush, never on end_audio."""
+    events: list[Any] = [
+        {"type": "transcription", "segments": [{"text": "hello"}], "is_final": False},
+        {
+            "type": "transcription",
+            "segments": [{"text": "hello world"}],
+            "is_final": True,
+            "is_end_of_audio_flush": True,
+        },
+    ]
+    provider = _qwen_provider(fake_api_key)
+
+    with patch(
+        "coval_bench.providers.stt.baseten.ws_client.connect",
+        return_value=_fake_connect(events),
+    ):
+        result = await provider.measure_ttft(_SMALL_PCM, 1, 2, 16000, 0.1)
+
+    assert result.error is None
+    assert result.complete_transcript == "hello world"
+    assert result.partial_transcripts == ["hello"]
+    assert result.audio_to_final_seconds is not None
+    assert compute_wer("hello world", result.complete_transcript).wer_percentage == pytest.approx(
+        0.0
+    )
+
+
+@pytest.mark.asyncio
+async def test_qwen_flush_with_empty_segments_still_stops(fake_api_key: SecretStr) -> None:
+    """A flush carrying no text must end the stream rather than hang on it."""
+    events: list[Any] = [
+        {"type": "transcription", "segments": [{"text": "done"}], "is_final": True},
+        {"type": "transcription", "segments": [], "is_end_of_audio_flush": True},
+    ]
+    provider = _qwen_provider(fake_api_key)
+
+    with patch(
+        "coval_bench.providers.stt.baseten.ws_client.connect",
+        return_value=_fake_connect(events),
+    ):
+        result = await provider.measure_ttft(_SMALL_PCM, 1, 2, 16000, 0.1)
+
+    assert result.error is None
+    assert result.complete_transcript == "done"
+
+
+@pytest.mark.asyncio
+async def test_qwen_sends_base64_appends_then_commit(fake_api_key: SecretStr) -> None:
+    """Audio goes out base64 in JSON, never as binary frames, and commit finalizes."""
+    events: list[Any] = [
+        {
+            "type": "transcription",
+            "segments": [{"text": "ok"}],
+            "is_final": True,
+            "is_end_of_audio_flush": True,
+        },
+    ]
+    sent: list[Any] = []
+    provider = _qwen_provider(fake_api_key)
+
+    with patch(
+        "coval_bench.providers.stt.baseten.ws_client.connect",
+        return_value=_fake_connect(events, sent),
+    ):
+        await provider.measure_ttft(_SMALL_PCM, 1, 2, 16000, 0.1)
+
+    assert not any(isinstance(msg, (bytes, bytearray)) for msg in sent)
+    frames = [json.loads(msg) for msg in sent]
+    assert "streaming_params" in frames[0]
+    appends = [f for f in frames if f.get("type") == "input_audio_buffer.append"]
+    assert appends, "no audio was appended"
+    reassembled = b"".join(base64.b64decode(f["audio"]) for f in appends)
+    assert reassembled == _SMALL_PCM
+    assert frames[-1] == {"type": "input_audio_buffer.commit"}
+
+
+@pytest.mark.asyncio
+async def test_whisper_still_sends_binary_frames_and_end_audio(fake_api_key: SecretStr) -> None:
+    """Regression guard on the protocol split: Whisper must not get JSON audio."""
+    events: list[Any] = [
+        {"type": "transcription", "segments": [{"text": "ok"}], "is_final": True},
+        {"type": "end_audio", "body": {"status": "finished"}},
+    ]
+    sent: list[Any] = []
+    provider = BasetenSTTProvider(api_key=fake_api_key, ws_url=_WS_URL)
+
+    with patch(
+        "coval_bench.providers.stt.baseten.ws_client.connect",
+        return_value=_fake_connect(events, sent),
+    ):
+        await provider.measure_ttft(_SMALL_PCM, 1, 2, 16000, 0.1)
+
+    binary = [msg for msg in sent if isinstance(msg, (bytes, bytearray))]
+    assert binary, "no binary audio frames were sent"
+    assert {len(frame) for frame in binary} == {1024}
+    assert json.loads(sent[-1]) == {"type": "end_audio"}
+
+
+# ---------------------------------------------------------------------------
+# Per-model endpoint resolution
+# ---------------------------------------------------------------------------
+
+
+def _url_settings(**kwargs: Any) -> Any:
+    defaults = {
+        "baseten_api_key": SecretStr("test-key"),
+        "baseten_whisper_url": None,
+        "baseten_qwen_asr_url": None,
+    }
+    return SimpleNamespace(**{**defaults, **kwargs})
+
+
+def test_endpoint_url_is_per_model() -> None:
+    settings = _url_settings(
+        baseten_whisper_url="wss://whisper",
+        baseten_qwen_asr_url="wss://qwen",
+    )
+    assert endpoint_url(settings, "whisper-large-v3") == "wss://whisper"
+    assert endpoint_url(settings, _QWEN_MODEL) == "wss://qwen"
+
+
+def test_endpoint_url_unknown_model_is_none() -> None:
+    assert endpoint_url(_url_settings(), "whisper-tiny") is None
+
+
+def test_missing_url_error_names_the_models_setting() -> None:
+    with pytest.raises(ValueError, match="baseten_qwen_asr_url is required"):
+        BasetenSTTProvider(api_key=SecretStr("k"), model=_QWEN_MODEL, ws_url=None)
+
+
+# ---------------------------------------------------------------------------
+# Warmup
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_warmup_hits_every_configured_endpoint() -> None:
+    urls: list[str] = []
+
+    def _connect(url: str, **_: Any) -> Any:
+        urls.append(url)
+        return _fake_connect([{"type": "end_audio", "body": {"status": "finished"}}])
+
+    settings = _url_settings(baseten_whisper_url="wss://v1", baseten_qwen_asr_url="wss://qwen")
+
+    with (
+        patch("coval_bench.providers.stt.baseten._WARMUP_SECONDS", 0.02),
+        patch("coval_bench.providers.stt.baseten.ws_client.connect", side_effect=_connect),
+    ):
+        await BasetenSTTProvider.warmup(settings)
+
+    # v2 is unconfigured here, so it must not be dialled.
+    assert sorted(urls) == ["wss://qwen", "wss://v1"]
+
+
+@pytest.mark.asyncio
+async def test_warmup_without_api_key_is_a_noop() -> None:
+    settings = _url_settings(baseten_api_key=None, baseten_whisper_url="wss://v1")
+
+    with patch("coval_bench.providers.stt.baseten.ws_client.connect") as connect:
+        await BasetenSTTProvider.warmup(settings)
+
+    connect.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_warmup_survives_a_dead_endpoint() -> None:
+    """One endpoint failing must not stop the others from being warmed."""
+    settings = _url_settings(baseten_whisper_url="wss://v1", baseten_qwen_asr_url="wss://qwen")
+    seen: list[str] = []
+
+    def _connect(url: str, **_: Any) -> Any:
+        seen.append(url)
+        if url == "wss://v1":
+            raise OSError("connection refused")
+        return _fake_connect([{"type": "end_audio", "body": {"status": "finished"}}])
+
+    with (
+        patch("coval_bench.providers.stt.baseten._WARMUP_SECONDS", 0.02),
+        patch("coval_bench.providers.stt.baseten.ws_client.connect", side_effect=_connect),
+    ):
+        await BasetenSTTProvider.warmup(settings)
+
+    assert sorted(seen) == ["wss://qwen", "wss://v1"]
+
+
+@pytest.mark.asyncio
+async def test_warmup_treats_no_final_as_success() -> None:
+    """The tone clip has no speech, so a close without a final is a warm endpoint."""
+    settings = _url_settings(baseten_whisper_url="wss://whisper")
+
+    def _connect(url: str, **_: Any) -> Any:
+        return _fake_connect([{"type": "end_audio", "body": {"status": "finished"}}])
+
+    with (
+        patch("coval_bench.providers.stt.baseten._WARMUP_SECONDS", 0.02),
+        patch("coval_bench.providers.stt.baseten.ws_client.connect", side_effect=_connect),
+        patch("coval_bench.providers.stt.baseten.logger") as log,
+    ):
+        await BasetenSTTProvider.warmup(settings)
+
+    prewarms = [c.kwargs for c in log.info.call_args_list if c.args[0] == "baseten_stt_prewarm"]
+    assert prewarms and prewarms[0]["error"] is None
+
+
+@pytest.mark.asyncio
+async def test_warmup_still_reports_real_errors() -> None:
+    settings = _url_settings(baseten_whisper_url="wss://whisper")
+    events: list[Any] = [{"type": "error", "message": "Invalid or expired API key"}]
+
+    with (
+        patch("coval_bench.providers.stt.baseten._WARMUP_SECONDS", 0.02),
+        patch(
+            "coval_bench.providers.stt.baseten.ws_client.connect",
+            side_effect=lambda url, **_: _fake_connect(events),
+        ),
+        patch("coval_bench.providers.stt.baseten.logger") as log,
+    ):
+        await BasetenSTTProvider.warmup(settings)
+
+    prewarms = [c.kwargs for c in log.info.call_args_list if c.args[0] == "baseten_stt_prewarm"]
+    assert prewarms and "Invalid or expired API key" in prewarms[0]["error"]

--- a/runner/tests/providers/stt/test_baseten.py
+++ b/runner/tests/providers/stt/test_baseten.py
@@ -437,3 +437,44 @@ async def test_warmup_still_reports_real_errors() -> None:
 
     prewarms = [c.kwargs for c in log.info.call_args_list if c.args[0] == "baseten_stt_prewarm"]
     assert prewarms and "Invalid or expired API key" in prewarms[0]["error"]
+
+
+@pytest.mark.asyncio
+async def test_warmup_connects_with_boot_length_open_timeout() -> None:
+    """Baseten parks the WS upgrade for the whole scale-from-zero boot, so the
+    warmup handshake must be allowed the full warmup budget, not the 45 s
+    measurement cap."""
+    from coval_bench.providers.stt.baseten import _OPEN_TIMEOUT_S, _WARMUP_TIMEOUT_S
+
+    seen: list[float] = []
+
+    def _connect(url: str, **kwargs: Any) -> Any:
+        seen.append(kwargs["open_timeout"])
+        return _fake_connect([{"type": "end_audio", "body": {"status": "finished"}}])
+
+    settings = _url_settings(baseten_whisper_url="wss://whisper")
+    with (
+        patch("coval_bench.providers.stt.baseten._WARMUP_SECONDS", 0.02),
+        patch("coval_bench.providers.stt.baseten.ws_client.connect", side_effect=_connect),
+    ):
+        await BasetenSTTProvider.warmup(settings)
+
+    assert seen == [_WARMUP_TIMEOUT_S]
+    assert _WARMUP_TIMEOUT_S > _OPEN_TIMEOUT_S
+
+
+@pytest.mark.asyncio
+async def test_measurement_keeps_the_short_open_timeout(fake_api_key: SecretStr) -> None:
+    from coval_bench.providers.stt.baseten import _OPEN_TIMEOUT_S
+
+    seen: list[float] = []
+
+    def _connect(url: str, **kwargs: Any) -> Any:
+        seen.append(kwargs["open_timeout"])
+        return _fake_connect([{"type": "end_audio", "body": {"status": "finished"}}])
+
+    provider = BasetenSTTProvider(api_key=fake_api_key, ws_url=_WS_URL)
+    with patch("coval_bench.providers.stt.baseten.ws_client.connect", side_effect=_connect):
+        await provider.measure_ttft(_SMALL_PCM, 1, 2, 16000, 0.1)
+
+    assert seen == [_OPEN_TIMEOUT_S]

--- a/runner/tests/providers/stt/test_baseten.py
+++ b/runner/tests/providers/stt/test_baseten.py
@@ -25,7 +25,12 @@ import pytest
 from pydantic import SecretStr
 
 from coval_bench.metrics.wer import compute_wer
-from coval_bench.providers.stt.baseten import BasetenSTTProvider, endpoint_url
+from coval_bench.providers.stt.baseten import (
+    _OPEN_TIMEOUT_S,
+    _WARMUP_TIMEOUT_S,
+    BasetenSTTProvider,
+    endpoint_url,
+)
 from tests.providers.stt.conftest import FakeWebSocket
 
 _WS_URL = "wss://model-test.api.baseten.co/environments/production/websocket"
@@ -237,9 +242,6 @@ async def test_qwen_buffer_success(fake_api_key: SecretStr) -> None:
     assert result.complete_transcript == "hello world"
     assert result.partial_transcripts == ["hello"]
     assert result.audio_to_final_seconds is not None
-    assert compute_wer("hello world", result.complete_transcript).wer_percentage == pytest.approx(
-        0.0
-    )
 
 
 @pytest.mark.asyncio
@@ -285,7 +287,6 @@ async def test_qwen_sends_base64_appends_then_commit(fake_api_key: SecretStr) ->
     frames = [json.loads(msg) for msg in sent]
     assert "streaming_params" in frames[0]
     appends = [f for f in frames if f.get("type") == "input_audio_buffer.append"]
-    assert appends, "no audio was appended"
     reassembled = b"".join(base64.b64decode(f["audio"]) for f in appends)
     assert reassembled == _SMALL_PCM
     assert frames[-1] == {"type": "input_audio_buffer.commit"}
@@ -293,28 +294,30 @@ async def test_qwen_sends_base64_appends_then_commit(fake_api_key: SecretStr) ->
 
 @pytest.mark.asyncio
 async def test_whisper_still_sends_binary_frames_and_end_audio(fake_api_key: SecretStr) -> None:
-    """Regression guard on the protocol split: Whisper must not get JSON audio."""
+    """Protocol-split regression guard: whisper keeps binary frames and the 45 s handshake."""
     events: list[Any] = [
         {"type": "transcription", "segments": [{"text": "ok"}], "is_final": True},
         {"type": "end_audio", "body": {"status": "finished"}},
     ]
     sent: list[Any] = []
-    provider = BasetenSTTProvider(api_key=fake_api_key, ws_url=_WS_URL)
+    timeouts: list[float] = []
 
-    with patch(
-        "coval_bench.providers.stt.baseten.ws_client.connect",
-        return_value=_fake_connect(events, sent),
-    ):
+    def _connect(url: str, **kwargs: Any) -> Any:
+        timeouts.append(kwargs["open_timeout"])
+        return _fake_connect(events, sent)
+
+    provider = BasetenSTTProvider(api_key=fake_api_key, ws_url=_WS_URL)
+    with patch("coval_bench.providers.stt.baseten.ws_client.connect", side_effect=_connect):
         await provider.measure_ttft(_SMALL_PCM, 1, 2, 16000, 0.1)
 
     binary = [msg for msg in sent if isinstance(msg, (bytes, bytearray))]
-    assert binary, "no binary audio frames were sent"
     assert {len(frame) for frame in binary} == {1024}
     assert json.loads(sent[-1]) == {"type": "end_audio"}
+    assert timeouts == [_OPEN_TIMEOUT_S]
 
 
 # ---------------------------------------------------------------------------
-# Per-model endpoint resolution
+# Endpoint resolution and warmup
 # ---------------------------------------------------------------------------
 
 
@@ -327,88 +330,50 @@ def _url_settings(**kwargs: Any) -> Any:
     return SimpleNamespace(**{**defaults, **kwargs})
 
 
-def test_endpoint_url_is_per_model() -> None:
-    settings = _url_settings(
-        baseten_whisper_url="wss://whisper",
-        baseten_qwen_asr_url="wss://qwen",
-    )
+def test_endpoint_url_resolution() -> None:
+    settings = _url_settings(baseten_whisper_url="wss://whisper", baseten_qwen_asr_url="wss://qwen")
     assert endpoint_url(settings, "whisper-large-v3") == "wss://whisper"
     assert endpoint_url(settings, _QWEN_MODEL) == "wss://qwen"
-
-
-def test_endpoint_url_unknown_model_is_none() -> None:
-    assert endpoint_url(_url_settings(), "whisper-tiny") is None
-
-
-def test_missing_url_error_names_the_models_setting() -> None:
-    with pytest.raises(ValueError, match="baseten_qwen_asr_url is required"):
-        BasetenSTTProvider(api_key=SecretStr("k"), model=_QWEN_MODEL, ws_url=None)
-
-
-# ---------------------------------------------------------------------------
-# Warmup
-# ---------------------------------------------------------------------------
+    assert endpoint_url(settings, "whisper-tiny") is None
 
 
 @pytest.mark.asyncio
-async def test_warmup_hits_every_configured_endpoint() -> None:
-    urls: list[str] = []
+async def test_warmup_warms_every_configured_endpoint() -> None:
+    """Dials each configured URL with the boot-length handshake; tone no-final is success."""
+    calls: list[tuple[str, float]] = []
 
-    def _connect(url: str, **_: Any) -> Any:
-        urls.append(url)
+    def _connect(url: str, **kwargs: Any) -> Any:
+        calls.append((url, kwargs["open_timeout"]))
         return _fake_connect([{"type": "end_audio", "body": {"status": "finished"}}])
 
-    settings = _url_settings(baseten_whisper_url="wss://v1", baseten_qwen_asr_url="wss://qwen")
-
+    settings = _url_settings(baseten_whisper_url="wss://whisper", baseten_qwen_asr_url="wss://qwen")
     with (
         patch("coval_bench.providers.stt.baseten._WARMUP_SECONDS", 0.02),
         patch("coval_bench.providers.stt.baseten.ws_client.connect", side_effect=_connect),
+        patch("coval_bench.providers.stt.baseten.logger") as log,
     ):
         await BasetenSTTProvider.warmup(settings)
 
-    # v2 is unconfigured here, so it must not be dialled.
-    assert sorted(urls) == ["wss://qwen", "wss://v1"]
-
-
-@pytest.mark.asyncio
-async def test_warmup_without_api_key_is_a_noop() -> None:
-    settings = _url_settings(baseten_api_key=None, baseten_whisper_url="wss://v1")
-
-    with patch("coval_bench.providers.stt.baseten.ws_client.connect") as connect:
-        await BasetenSTTProvider.warmup(settings)
-
-    connect.assert_not_called()
+    assert sorted(calls) == [
+        ("wss://qwen", _WARMUP_TIMEOUT_S),
+        ("wss://whisper", _WARMUP_TIMEOUT_S),
+    ]
+    prewarms = [c.kwargs for c in log.info.call_args_list if c.args[0] == "baseten_stt_prewarm"]
+    assert [p["error"] for p in prewarms] == [None, None]
 
 
 @pytest.mark.asyncio
 async def test_warmup_survives_a_dead_endpoint() -> None:
-    """One endpoint failing must not stop the others from being warmed."""
-    settings = _url_settings(baseten_whisper_url="wss://v1", baseten_qwen_asr_url="wss://qwen")
+    """One endpoint failing must not stop the others, and its error must surface."""
     seen: list[str] = []
 
     def _connect(url: str, **_: Any) -> Any:
         seen.append(url)
-        if url == "wss://v1":
+        if url == "wss://whisper":
             raise OSError("connection refused")
         return _fake_connect([{"type": "end_audio", "body": {"status": "finished"}}])
 
-    with (
-        patch("coval_bench.providers.stt.baseten._WARMUP_SECONDS", 0.02),
-        patch("coval_bench.providers.stt.baseten.ws_client.connect", side_effect=_connect),
-    ):
-        await BasetenSTTProvider.warmup(settings)
-
-    assert sorted(seen) == ["wss://qwen", "wss://v1"]
-
-
-@pytest.mark.asyncio
-async def test_warmup_treats_no_final_as_success() -> None:
-    """The tone clip has no speech, so a close without a final is a warm endpoint."""
-    settings = _url_settings(baseten_whisper_url="wss://whisper")
-
-    def _connect(url: str, **_: Any) -> Any:
-        return _fake_connect([{"type": "end_audio", "body": {"status": "finished"}}])
-
+    settings = _url_settings(baseten_whisper_url="wss://whisper", baseten_qwen_asr_url="wss://qwen")
     with (
         patch("coval_bench.providers.stt.baseten._WARMUP_SECONDS", 0.02),
         patch("coval_bench.providers.stt.baseten.ws_client.connect", side_effect=_connect),
@@ -416,65 +381,11 @@ async def test_warmup_treats_no_final_as_success() -> None:
     ):
         await BasetenSTTProvider.warmup(settings)
 
-    prewarms = [c.kwargs for c in log.info.call_args_list if c.args[0] == "baseten_stt_prewarm"]
-    assert prewarms and prewarms[0]["error"] is None
-
-
-@pytest.mark.asyncio
-async def test_warmup_still_reports_real_errors() -> None:
-    settings = _url_settings(baseten_whisper_url="wss://whisper")
-    events: list[Any] = [{"type": "error", "message": "Invalid or expired API key"}]
-
-    with (
-        patch("coval_bench.providers.stt.baseten._WARMUP_SECONDS", 0.02),
-        patch(
-            "coval_bench.providers.stt.baseten.ws_client.connect",
-            side_effect=lambda url, **_: _fake_connect(events),
-        ),
-        patch("coval_bench.providers.stt.baseten.logger") as log,
-    ):
-        await BasetenSTTProvider.warmup(settings)
-
-    prewarms = [c.kwargs for c in log.info.call_args_list if c.args[0] == "baseten_stt_prewarm"]
-    assert prewarms and "Invalid or expired API key" in prewarms[0]["error"]
-
-
-@pytest.mark.asyncio
-async def test_warmup_connects_with_boot_length_open_timeout() -> None:
-    """Baseten parks the WS upgrade for the whole scale-from-zero boot, so the
-    warmup handshake must be allowed the full warmup budget, not the 45 s
-    measurement cap."""
-    from coval_bench.providers.stt.baseten import _OPEN_TIMEOUT_S, _WARMUP_TIMEOUT_S
-
-    seen: list[float] = []
-
-    def _connect(url: str, **kwargs: Any) -> Any:
-        seen.append(kwargs["open_timeout"])
-        return _fake_connect([{"type": "end_audio", "body": {"status": "finished"}}])
-
-    settings = _url_settings(baseten_whisper_url="wss://whisper")
-    with (
-        patch("coval_bench.providers.stt.baseten._WARMUP_SECONDS", 0.02),
-        patch("coval_bench.providers.stt.baseten.ws_client.connect", side_effect=_connect),
-    ):
-        await BasetenSTTProvider.warmup(settings)
-
-    assert seen == [_WARMUP_TIMEOUT_S]
-    assert _WARMUP_TIMEOUT_S > _OPEN_TIMEOUT_S
-
-
-@pytest.mark.asyncio
-async def test_measurement_keeps_the_short_open_timeout(fake_api_key: SecretStr) -> None:
-    from coval_bench.providers.stt.baseten import _OPEN_TIMEOUT_S
-
-    seen: list[float] = []
-
-    def _connect(url: str, **kwargs: Any) -> Any:
-        seen.append(kwargs["open_timeout"])
-        return _fake_connect([{"type": "end_audio", "body": {"status": "finished"}}])
-
-    provider = BasetenSTTProvider(api_key=fake_api_key, ws_url=_WS_URL)
-    with patch("coval_bench.providers.stt.baseten.ws_client.connect", side_effect=_connect):
-        await provider.measure_ttft(_SMALL_PCM, 1, 2, 16000, 0.1)
-
-    assert seen == [_OPEN_TIMEOUT_S]
+    assert sorted(seen) == ["wss://qwen", "wss://whisper"]
+    errors = {
+        c.kwargs["model"]: c.kwargs["error"]
+        for c in log.info.call_args_list
+        if c.args[0] == "baseten_stt_prewarm"
+    }
+    assert errors["qwen3-asr-1.7b"] is None
+    assert "connection refused" in errors["whisper-large-v3"]

--- a/runner/tests/providers/tts/test_baseten.py
+++ b/runner/tests/providers/tts/test_baseten.py
@@ -14,7 +14,11 @@ from pydantic import SecretStr
 
 from coval_bench.config import Settings
 from coval_bench.providers.tts import _common
-from coval_bench.providers.tts.baseten import BasetenTTSProvider
+from coval_bench.providers.tts.baseten import (
+    _OPEN_TIMEOUT_S,
+    _WARMUP_TIMEOUT_S,
+    BasetenTTSProvider,
+)
 
 from .conftest import FakeWebSocket, make_pcm_bytes
 
@@ -174,10 +178,12 @@ def test_baseten_tts_provider_name(baseten_settings: Settings) -> None:
 
 
 @pytest.mark.asyncio
-async def test_warmup_synthesizes_and_cleans_up(baseten_settings: Settings) -> None:
-    """Warmup hits the endpoint once and leaves no audio artifact behind."""
-    ws = FakeWebSocket(_done_events([make_pcm_bytes(240)]))
+async def test_warmup_synthesizes_with_boot_budget_and_cleans_up(
+    baseten_settings: Settings,
+) -> None:
+    """Warmup uses the boot-length handshake and leaves no audio artifact behind."""
     made: list[Path] = []
+    timeouts: list[float] = []
     real_write = _common._write_wav
 
     def _tracking_write(pcm: bytes, sample_rate: int) -> Path:
@@ -185,60 +191,28 @@ async def test_warmup_synthesizes_and_cleans_up(baseten_settings: Settings) -> N
         made.append(path)
         return path
 
+    def _connect(url: str, **kwargs: object) -> FakeWebSocket:
+        assert isinstance(kwargs["open_timeout"], (int, float))
+        timeouts.append(float(kwargs["open_timeout"]))
+        return FakeWebSocket(_done_events([make_pcm_bytes(240)]))
+
     with (
-        patch("coval_bench.providers.tts.baseten.ws_client.connect", return_value=ws),
+        patch("coval_bench.providers.tts.baseten.ws_client.connect", side_effect=_connect),
         patch.object(_common, "_write_wav", _tracking_write),
     ):
         await BasetenTTSProvider.warmup(baseten_settings)
 
-    assert made, "warmup never synthesized"
-    assert not made[0].exists(), "warmup left its audio artifact on disk"
-
-
-@pytest.mark.asyncio
-async def test_warmup_without_key_or_url_is_a_noop() -> None:
-    for settings in (_settings(baseten_api_key=None), _settings(baseten_qwen_url=None)):
-        with patch("coval_bench.providers.tts.baseten.ws_client.connect") as connect:
-            await BasetenTTSProvider.warmup(settings)
-        connect.assert_not_called()
-
-
-@pytest.mark.asyncio
-async def test_warmup_error_result_does_not_raise(baseten_settings: Settings) -> None:
-    """A refused endpoint surfaces in the result, and warmup stays non-fatal."""
-    ws = FakeWebSocket([json.dumps({"type": "error", "message": "no replicas"})])
-
-    with patch("coval_bench.providers.tts.baseten.ws_client.connect", return_value=ws):
-        await BasetenTTSProvider.warmup(baseten_settings)
-
-
-@pytest.mark.asyncio
-async def test_warmup_connects_with_boot_length_open_timeout(baseten_settings: Settings) -> None:
-    from coval_bench.providers.tts.baseten import _OPEN_TIMEOUT_S, _WARMUP_TIMEOUT_S
-
-    seen: list[float] = []
-
-    def _connect(url: str, **kwargs: object) -> FakeWebSocket:
-        assert isinstance(kwargs["open_timeout"], (int, float))
-        seen.append(float(kwargs["open_timeout"]))
-        return FakeWebSocket(_done_events([make_pcm_bytes(240)]))
-
-    with patch("coval_bench.providers.tts.baseten.ws_client.connect", side_effect=_connect):
-        await BasetenTTSProvider.warmup(baseten_settings)
-
-    assert seen == [float(_WARMUP_TIMEOUT_S)]
-    assert _WARMUP_TIMEOUT_S > _OPEN_TIMEOUT_S
+    assert timeouts == [float(_WARMUP_TIMEOUT_S)]
+    assert made and not made[0].exists()
 
 
 @pytest.mark.asyncio
 async def test_synthesize_keeps_the_short_open_timeout(baseten_settings: Settings) -> None:
-    from coval_bench.providers.tts.baseten import _OPEN_TIMEOUT_S
-
-    seen: list[float] = []
+    timeouts: list[float] = []
 
     def _connect(url: str, **kwargs: object) -> FakeWebSocket:
         assert isinstance(kwargs["open_timeout"], (int, float))
-        seen.append(float(kwargs["open_timeout"]))
+        timeouts.append(float(kwargs["open_timeout"]))
         return FakeWebSocket(_done_events([make_pcm_bytes(240)]))
 
     provider = BasetenTTSProvider(baseten_settings, model="qwen3-tts-1.7b", voice="lisa")
@@ -247,4 +221,4 @@ async def test_synthesize_keeps_the_short_open_timeout(baseten_settings: Setting
     if result.audio_path is not None:
         result.audio_path.unlink(missing_ok=True)
 
-    assert seen == [float(_OPEN_TIMEOUT_S)]
+    assert timeouts == [float(_OPEN_TIMEOUT_S)]

--- a/runner/tests/providers/tts/test_baseten.py
+++ b/runner/tests/providers/tts/test_baseten.py
@@ -210,3 +210,41 @@ async def test_warmup_error_result_does_not_raise(baseten_settings: Settings) ->
 
     with patch("coval_bench.providers.tts.baseten.ws_client.connect", return_value=ws):
         await BasetenTTSProvider.warmup(baseten_settings)
+
+
+@pytest.mark.asyncio
+async def test_warmup_connects_with_boot_length_open_timeout(baseten_settings: Settings) -> None:
+    from coval_bench.providers.tts.baseten import _OPEN_TIMEOUT_S, _WARMUP_TIMEOUT_S
+
+    seen: list[float] = []
+
+    def _connect(url: str, **kwargs: object) -> FakeWebSocket:
+        assert isinstance(kwargs["open_timeout"], (int, float))
+        seen.append(float(kwargs["open_timeout"]))
+        return FakeWebSocket(_done_events([make_pcm_bytes(240)]))
+
+    with patch("coval_bench.providers.tts.baseten.ws_client.connect", side_effect=_connect):
+        await BasetenTTSProvider.warmup(baseten_settings)
+
+    assert seen == [float(_WARMUP_TIMEOUT_S)]
+    assert _WARMUP_TIMEOUT_S > _OPEN_TIMEOUT_S
+
+
+@pytest.mark.asyncio
+async def test_synthesize_keeps_the_short_open_timeout(baseten_settings: Settings) -> None:
+    from coval_bench.providers.tts.baseten import _OPEN_TIMEOUT_S
+
+    seen: list[float] = []
+
+    def _connect(url: str, **kwargs: object) -> FakeWebSocket:
+        assert isinstance(kwargs["open_timeout"], (int, float))
+        seen.append(float(kwargs["open_timeout"]))
+        return FakeWebSocket(_done_events([make_pcm_bytes(240)]))
+
+    provider = BasetenTTSProvider(baseten_settings, model="qwen3-tts-1.7b", voice="lisa")
+    with patch("coval_bench.providers.tts.baseten.ws_client.connect", side_effect=_connect):
+        result = await provider.synthesize("hello")
+    if result.audio_path is not None:
+        result.audio_path.unlink(missing_ok=True)
+
+    assert seen == [float(_OPEN_TIMEOUT_S)]

--- a/runner/tests/providers/tts/test_baseten.py
+++ b/runner/tests/providers/tts/test_baseten.py
@@ -6,12 +6,14 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 from pydantic import SecretStr
 
 from coval_bench.config import Settings
+from coval_bench.providers.tts import _common
 from coval_bench.providers.tts.baseten import BasetenTTSProvider
 
 from .conftest import FakeWebSocket, make_pcm_bytes
@@ -169,3 +171,42 @@ def test_baseten_tts_provider_name(baseten_settings: Settings) -> None:
     provider = BasetenTTSProvider(baseten_settings, model="qwen3-tts-1.7b", voice="lisa")
     assert provider.name == "baseten-qwen3-tts-1.7b"
     assert provider.model == "qwen3-tts-1.7b"
+
+
+@pytest.mark.asyncio
+async def test_warmup_synthesizes_and_cleans_up(baseten_settings: Settings) -> None:
+    """Warmup hits the endpoint once and leaves no audio artifact behind."""
+    ws = FakeWebSocket(_done_events([make_pcm_bytes(240)]))
+    made: list[Path] = []
+    real_write = _common._write_wav
+
+    def _tracking_write(pcm: bytes, sample_rate: int) -> Path:
+        path = real_write(pcm, sample_rate)
+        made.append(path)
+        return path
+
+    with (
+        patch("coval_bench.providers.tts.baseten.ws_client.connect", return_value=ws),
+        patch.object(_common, "_write_wav", _tracking_write),
+    ):
+        await BasetenTTSProvider.warmup(baseten_settings)
+
+    assert made, "warmup never synthesized"
+    assert not made[0].exists(), "warmup left its audio artifact on disk"
+
+
+@pytest.mark.asyncio
+async def test_warmup_without_key_or_url_is_a_noop() -> None:
+    for settings in (_settings(baseten_api_key=None), _settings(baseten_qwen_url=None)):
+        with patch("coval_bench.providers.tts.baseten.ws_client.connect") as connect:
+            await BasetenTTSProvider.warmup(settings)
+        connect.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_warmup_error_result_does_not_raise(baseten_settings: Settings) -> None:
+    """A refused endpoint surfaces in the result, and warmup stays non-fatal."""
+    ws = FakeWebSocket([json.dumps({"type": "error", "message": "no replicas"})])
+
+    with patch("coval_bench.providers.tts.baseten.ws_client.connect", return_value=ws):
+        await BasetenTTSProvider.warmup(baseten_settings)

--- a/runner/tests/runner/test_probe.py
+++ b/runner/tests/runner/test_probe.py
@@ -95,3 +95,38 @@ async def test_run_probe_no_persist(monkeypatch: pytest.MonkeyPatch) -> None:
     assert stt["metrics"]["TTFS"]["median"] == pytest.approx(0.5)
     tts = results["baseten/qwen3-tts-1.7b"]
     assert tts["metrics"]["TTFA"]["mean"] == pytest.approx(300.0)
+
+
+@pytest.mark.asyncio
+async def test_run_probe_closes_http_pools_even_on_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The probe mirrors run_benchmarks: shared HTTP clients close in a finally."""
+    closed: list[bool] = []
+
+    async def fake_close() -> None:
+        closed.append(True)
+
+    def boom(*_: Any, **__: Any) -> Any:
+        raise RuntimeError("dataset unavailable")
+
+    monkeypatch.setattr(probe_mod, "_close_http_clients", fake_close)
+    monkeypatch.setattr(probe_mod, "load_stt_dataset", boom)
+
+    models = [
+        RegisteredModel(
+            benchmark=Benchmark.STT,
+            provider="baseten",
+            model="whisper-large-v3",
+            status=ModelStatus.PENDING,
+        ),
+    ]
+    with pytest.raises(RuntimeError, match="dataset unavailable"):
+        await probe_mod.run_probe(
+            settings=cast(Settings, SimpleNamespace(dataset_id="stt-v2")),
+            models=models,
+            sample_size=1,
+            concurrency=1,
+        )
+
+    assert closed == [True]

--- a/runner/tests/unit/test_orchestrator.py
+++ b/runner/tests/unit/test_orchestrator.py
@@ -47,6 +47,7 @@ from coval_bench.registries import MODEL_REGISTRY, ModelStatus, RegisteredModel,
 from coval_bench.runner.orchestrator import (
     RunSummary,
     _dead_providers,
+    _run_stt_item,
     _run_tts_item,
     _stt_silent_failure,
     run_benchmarks,
@@ -3285,3 +3286,37 @@ async def test_tts_cancellation_propagates_after_audio_cleanup(
 
     assert not audio_file.exists()
     writer.record_results.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_stt_missing_endpoint_url_yields_error_rows(
+    audio_file: Path, settings: Settings
+) -> None:
+    """A provider config hole must land as FAILED rows, not vanish into the gather."""
+    from types import SimpleNamespace
+
+    entry = RegisteredModel(
+        benchmark=Benchmark.STT,
+        provider="baseten",
+        model="qwen3-asr-1.7b",
+        source=Source.DEDICATED_INFERENCE,
+        status=ModelStatus.EARLY_ACCESS,
+    )
+    item = SimpleNamespace(
+        path=audio_file,
+        transcript="hello",
+        duration_sec=0.032,
+        speech_end_offset_ms=None,
+        sample_id=None,
+    )
+    cfg = settings.model_copy(
+        update={"baseten_api_key": SecretStr("test-key"), "baseten_qwen_asr_url": None}
+    )
+
+    rows = await _run_stt_item(
+        entry=entry, item=item, run_id=0, sem=asyncio.Semaphore(1), settings=cfg, writer=None
+    )
+
+    assert rows
+    assert all(r.status is ResultStatus.FAILED for r in rows)
+    assert "baseten_qwen_asr_url is required" in (rows[0].error or "")


### PR DESCRIPTION
… before runs

qwen3-asr-1.7b joins as an early-access dedicated entry speaking the input_audio_buffer wire protocol (base64 JSON appends, commit to finalize, is_end_of_audio_flush to end); the whisper deployments keep the binary 512-sample protocol, verified against all three endpoints. Endpoint URLs resolve per model, so whisper-large-v3's cutover to the v2 deployment is a secret rotation with no registry change.

Baseten is retiring its own warmup traffic in favor of demand autoscaling, making our warmup the scale-up trigger: both Baseten providers now warm every configured endpoint concurrently with a 6-minute budget (a scale-from-zero boot measured ~166 s), run_probe warms the same way run_benchmarks does, warmup timeouts are logged rather than swallowed, and the tone clip's expected close-without-final is not reported as an error.