### PR TITLE
[BENCH-737] Add Zoom Scribe live STT as an early-access entry

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,6 +45,8 @@ FLUXIONS_API_KEY=
 DEEPDUB_API_KEY=
 MURFAI_API_KEY=
 HAKIMAI_API_KEY=
+ZOOM_API_KEY=
+ZOOM_API_SECRET=
 
 # --- API (optional) ---
 # Clerk instance for provider-org logins — the one early-access proof. The

--- a/runner/src/coval_bench/config.py
+++ b/runner/src/coval_bench/config.py
@@ -120,6 +120,8 @@ class Settings(BaseSettings):
     speechify_api_key: SecretStr | None = None
     fluxions_api_key: SecretStr | None = None
     deepdub_api_key: SecretStr | None = None
+    zoom_api_key: SecretStr | None = None
+    zoom_api_secret: SecretStr | None = None
 
     # Azure region hosting the Speech resource (e.g. "eastus"). Determines the
     # region-scoped WebSocket host; required only when the Azure STT provider runs.

--- a/runner/src/coval_bench/providers/stt/__init__.py
+++ b/runner/src/coval_bench/providers/stt/__init__.py
@@ -34,6 +34,7 @@ from coval_bench.providers.stt.soniox import SonioxSTTProvider
 from coval_bench.providers.stt.speechmatics import SpeechmaticsProvider
 from coval_bench.providers.stt.together import TogetherSTTProvider
 from coval_bench.providers.stt.xai import XaiSTTProvider
+from coval_bench.providers.stt.zoom import ZoomSTTProvider
 
 # Google is optional — gated on the ``google-stt`` extra
 try:
@@ -64,6 +65,7 @@ STT_PROVIDERS: dict[str, type[STTProvider]] = {
     "speechmatics": SpeechmaticsProvider,
     "together": TogetherSTTProvider,
     "xai": XaiSTTProvider,
+    "zoom": ZoomSTTProvider,
 }
 
 if GoogleSTTProvider is not None:
@@ -91,5 +93,6 @@ __all__ = [
     "SpeechmaticsProvider",
     "TogetherSTTProvider",
     "XaiSTTProvider",
+    "ZoomSTTProvider",
     "GoogleSTTProvider",
 ]

--- a/runner/src/coval_bench/providers/stt/zoom.py
+++ b/runner/src/coval_bench/providers/stt/zoom.py
@@ -1,0 +1,223 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Zoom Scribe live STT provider (WebSocket)."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from typing import Any
+
+import jwt
+import structlog
+import websockets.asyncio.client as ws_client
+from pydantic import SecretStr
+from websockets.typing import Subprotocol
+
+from coval_bench.providers.base import STTProvider, TranscriptionResult
+from coval_bench.providers.stt._pacing import paced_chunks
+
+logger = structlog.get_logger(__name__)
+
+_WS_URL = "wss://api.zoom.us/v2/aiservices/scribe/live"
+_SUBPROTOCOL = Subprotocol("live-asr")
+_TOKEN_TTL_S = 7200
+_EOT_SILENCE_S = 2.0
+
+
+class ZoomSTTProvider(STTProvider):
+    """Zoom Scribe streaming STT provider."""
+
+    _VALID_MODELS = frozenset({"scribe"})
+
+    def __init__(
+        self,
+        api_key: SecretStr | None,
+        api_secret: SecretStr | None,
+        model: str = "scribe",
+    ) -> None:
+        if not self._model_supported(model):
+            raise ValueError(
+                f"Invalid Zoom STT model {model!r}. Valid: {sorted(self._VALID_MODELS)}"
+            )
+        if api_key is None:
+            raise ValueError("zoom_api_key is required for the Zoom STT provider")
+        if api_secret is None:
+            raise ValueError("zoom_api_secret is required for the Zoom STT provider")
+        self._api_key = api_key
+        self._api_secret = api_secret
+        self._model = model
+
+    @property
+    def name(self) -> str:
+        return "zoom"
+
+    @property
+    def model(self) -> str:
+        return self._model
+
+    def _auth_token(self) -> str:
+        # iat back-dated 30 s for clock skew
+        iat = int(time.time()) - 30
+        return jwt.encode(
+            {"iss": self._api_key.get_secret_value(), "iat": iat, "exp": iat + _TOKEN_TTL_S},
+            self._api_secret.get_secret_value(),
+            algorithm="HS256",
+        )
+
+    async def measure_ttft(
+        self,
+        audio_data: bytes,
+        channels: int,
+        sample_width: int,
+        sample_rate: int,
+        realtime_resolution: float = 0.1,
+    ) -> TranscriptionResult:
+        result = TranscriptionResult(provider=self.name)
+        if sample_rate != 16000:
+            result.error = f"Zoom Scribe requires 16 kHz PCM input; got {sample_rate} Hz"
+            return result
+        if channels != 1 or sample_width != 2:
+            result.error = (
+                "Zoom Scribe requires mono 16-bit PCM input; "
+                f"got channels={channels}, sample_width={sample_width}"
+            )
+            return result
+
+        total_start = time.monotonic()
+
+        try:
+            async with ws_client.connect(
+                _WS_URL,
+                subprotocols=[_SUBPROTOCOL],
+                additional_headers={"Authorization": f"Bearer {self._auth_token()}"},
+            ) as ws:
+                await ws.send(
+                    json.dumps(
+                        {
+                            "type": "session.update",
+                            "language": "en-US",
+                            "audio": {"format": "pcm16"},
+                        }
+                    )
+                )
+
+                final_event = asyncio.Event()
+                send_task = asyncio.create_task(
+                    self._send_audio(
+                        ws, audio_data, sample_rate, result, realtime_resolution, final_event
+                    )
+                )
+                recv_task = asyncio.create_task(self._receive(ws, result, final_event))
+                tasks = (send_task, recv_task)
+                done, pending = await asyncio.wait(tasks, return_when=asyncio.FIRST_EXCEPTION)
+                if any(not task.cancelled() and task.exception() is not None for task in done):
+                    for task in pending:
+                        task.cancel()
+                outcomes = await asyncio.gather(*tasks, return_exceptions=True)
+                if result.error is None and result.audio_to_final_seconds is None:
+                    for outcome in outcomes:
+                        if isinstance(outcome, Exception):
+                            result.error = str(outcome)
+                            break
+
+        except Exception as exc:
+            logger.warning(
+                "zoom_measure_ttft_failed", provider="zoom", model=self._model, exc_info=exc
+            )
+            result.error = str(exc)
+
+        result.total_time = time.monotonic() - total_start
+        return result
+
+    async def _send_audio(
+        self,
+        ws: Any,
+        audio_data: bytes,
+        sample_rate: int,
+        result: TranscriptionResult,
+        realtime_resolution: float,
+        final_event: asyncio.Event,
+    ) -> None:
+        bytes_per_second = sample_rate * 2  # 16-bit mono
+        chunk_size = int(bytes_per_second * realtime_resolution)
+        try:
+            async for chunk, start in paced_chunks(audio_data, chunk_size, bytes_per_second):
+                result.audio_start_time = start
+                await ws.send(chunk)
+            # Scribe has no force-finalize: session.close drops the pending turn, so
+            # feed trailing silence until the endpointer fires (cap; breaks early).
+            final_event.clear()
+            silence = bytes(int(bytes_per_second * _EOT_SILENCE_S))
+            async for chunk, _ in paced_chunks(silence, chunk_size, bytes_per_second):
+                if final_event.is_set():
+                    break
+                await ws.send(chunk)
+            await ws.send(json.dumps({"type": "session.close"}))
+        except Exception as exc:
+            logger.warning("zoom_send_error", provider="zoom", model=self._model, exc_info=exc)
+            raise
+
+    async def _receive(
+        self, ws: Any, result: TranscriptionResult, final_event: asyncio.Event
+    ) -> None:
+        final_parts: list[str] = []
+
+        try:
+            async for raw in ws:
+                if isinstance(raw, bytes):
+                    continue
+
+                msg: dict[str, Any] = json.loads(raw)
+                now = time.monotonic()
+                msg_type = msg.get("type")
+
+                if msg_type == "error":
+                    error: dict[str, Any] = msg.get("error") or {}
+                    if not error.get("fatal"):
+                        logger.warning(
+                            "zoom_stt_warning", provider="zoom", model=self._model, msg=msg
+                        )
+                        continue
+                    code = error.get("code")
+                    result.error = str(error.get("message") or f"Zoom Scribe error (code {code})")
+                    logger.warning("zoom_stt_error", provider="zoom", model=self._model, msg=msg)
+                    break
+
+                if msg_type == "transcription.delta":
+                    text = str(msg.get("delta", "")).strip()
+                    if text:
+                        self._mark_first_token(result, text, now)
+                        result.partial_transcripts.append(text)
+
+                elif msg_type == "transcription.completed":
+                    final_event.set()
+                    text = str(msg.get("transcript", "")).strip()
+                    if text:
+                        self._mark_first_token(result, text, now)
+                        final_parts.append(text)
+                        if result.audio_start_time is not None:
+                            result.audio_to_final_seconds = now - result.audio_start_time
+
+                elif msg_type == "session.closed":
+                    break
+
+        except Exception as exc:
+            logger.warning("zoom_receive_error", provider="zoom", model=self._model, exc_info=exc)
+            if result.error is None and result.audio_to_final_seconds is None:
+                result.error = str(exc)
+
+        if final_parts:
+            result.complete_transcript = " ".join(final_parts)
+
+        if result.complete_transcript:
+            result.transcript_length = len(result.complete_transcript)
+            result.word_count = len(result.complete_transcript.split())
+
+    @staticmethod
+    def _mark_first_token(result: TranscriptionResult, text: str, now: float) -> None:
+        if result.ttft_seconds is None and result.audio_start_time is not None:
+            result.ttft_seconds = now - result.audio_start_time
+            result.first_token_content = text[:30] + "..." if len(text) > 30 else text

--- a/runner/src/coval_bench/providers/stt/zoom.py
+++ b/runner/src/coval_bench/providers/stt/zoom.py
@@ -184,19 +184,19 @@ class ZoomSTTProvider(STTProvider):
                     code = error.get("code")
                     result.error = str(error.get("message") or f"Zoom Scribe error (code {code})")
                     logger.warning("zoom_stt_error", provider="zoom", model=self._model, msg=msg)
+                    # Unblocks the send task: its next frame raises ConnectionClosed.
+                    await ws.close()
                     break
 
-                if msg_type == "transcription.delta":
-                    text = str(msg.get("delta", "")).strip()
-                    if text:
-                        self._mark_first_token(result, text, now)
-                        result.partial_transcripts.append(text)
-
-                elif msg_type == "transcription.completed":
+                if msg_type == "transcription.completed":
                     final_event.set()
                     text = str(msg.get("transcript", "")).strip()
                     if text:
-                        self._mark_first_token(result, text, now)
+                        if result.ttft_seconds is None and result.audio_start_time is not None:
+                            result.ttft_seconds = now - result.audio_start_time
+                            result.first_token_content = (
+                                text[:30] + "..." if len(text) > 30 else text
+                            )
                         final_parts.append(text)
                         if result.audio_start_time is not None:
                             result.audio_to_final_seconds = now - result.audio_start_time
@@ -215,9 +215,3 @@ class ZoomSTTProvider(STTProvider):
         if result.complete_transcript:
             result.transcript_length = len(result.complete_transcript)
             result.word_count = len(result.complete_transcript.split())
-
-    @staticmethod
-    def _mark_first_token(result: TranscriptionResult, text: str, now: float) -> None:
-        if result.ttft_seconds is None and result.audio_start_time is not None:
-            result.ttft_seconds = now - result.audio_start_time
-            result.first_token_content = text[:30] + "..." if len(text) > 30 else text

--- a/runner/src/coval_bench/registries/metrics.py
+++ b/runner/src/coval_bench/registries/metrics.py
@@ -308,6 +308,9 @@ METRIC_EXCLUSIONS: dict[Metric, frozenset[tuple[str, str]]] = {
             # Reson8 emits interims on a fixed ~1.1s grid, so first-token timing
             # tracks the emission interval.
             ("reson8", "realtime"),
+            # Scribe emits no partials — the first token is the turn-final, so
+            # first-token timing tracks utterance length.
+            ("zoom", "scribe"),
         }
     ),
     Metric.TTFS: frozenset(
@@ -325,6 +328,10 @@ METRIC_EXCLUSIONS: dict[Metric, frozenset[tuple[str, str]]] = {
             # tracks the pad length, not the engine.
             ("together", "nemotron-3-asr-streaming-0.6b"),
             ("together", "nemotron-3.5-asr-streaming-0.6b"),
+            # Scribe has no force-finalize (session.close drops the pending turn);
+            # the client pads trailing silence, so the final's timing bundles
+            # endpoint detection.
+            ("zoom", "scribe"),
         }
     ),
 }

--- a/runner/src/coval_bench/registries/models.py
+++ b/runner/src/coval_bench/registries/models.py
@@ -490,6 +490,14 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         region="us",
         status=_RETIRED,
     ),
+    RegisteredModel(
+        benchmark=_STT,
+        provider="zoom",
+        model="scribe",
+        tags=(_MULTI, _VAD),
+        region="us",
+        status=_EARLY_ACCESS,
+    ),
     #######
     # TTS #
     #######

--- a/runner/src/coval_bench/runner/orchestrator.py
+++ b/runner/src/coval_bench/runner/orchestrator.py
@@ -378,6 +378,8 @@ async def _run_stt_item(
             kwargs["ws_url"] = _get_baseten_stt_url()(settings, entry.model)
         elif entry.provider == "azure":
             kwargs["region"] = settings.azure_region
+        elif entry.provider == "zoom":
+            kwargs["api_secret"] = settings.zoom_api_secret
 
         audio_path: Path = item.path
         transcript_ref: str = item.transcript

--- a/runner/tests/providers/stt/conftest.py
+++ b/runner/tests/providers/stt/conftest.py
@@ -84,6 +84,8 @@ class FakeWebSocket:
         self._events.clear()
 
     async def send(self, msg: bytes | str) -> None:
+        if self._closed.is_set():
+            raise ConnectionError("send on a closed FakeWebSocket")
         self._sent.append(msg)
         if self._on_send is not None:
             self._on_send(msg)

--- a/runner/tests/providers/stt/test_zoom.py
+++ b/runner/tests/providers/stt/test_zoom.py
@@ -1,0 +1,204 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for coval_bench.providers.stt.zoom (ZoomSTTProvider).
+
+All tests use FakeWebSocket — no live network calls are made. Events mirror
+the Scribe live wire protocol: interim ``transcription.delta``, turn-final
+``transcription.completed``, ``session.closed`` after ``session.close``.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import jwt
+import pytest
+from pydantic import SecretStr
+
+from coval_bench.providers.stt.zoom import ZoomSTTProvider
+from tests.providers.stt.conftest import FakeWebSocket
+
+_TEST_SECRET = "test-secret-zoom-0000000000000000"  # noqa: S105 - not a real credential
+
+
+def make_provider(api_key: SecretStr) -> ZoomSTTProvider:
+    return ZoomSTTProvider(api_key=api_key, api_secret=SecretStr(_TEST_SECRET))
+
+
+def _fake_connect(events: list[Any], sent: list[Any] | None = None) -> Any:
+    ws = FakeWebSocket(events, on_send=sent.append if sent is not None else None)
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=ws)
+    cm.__aexit__ = AsyncMock(return_value=False)
+    return cm
+
+
+_SUCCESS_EVENTS: list[Any] = [
+    {"type": "transcription.delta", "delta": "hello"},
+    {"type": "transcription.delta", "delta": "hello wor"},
+    {
+        "type": "transcription.completed",
+        "item_id": "item-1",
+        "transcript": "hello world",
+        "audio_start_ms": 0,
+        "audio_end_ms": 1400,
+        "transcription_latency_ms": 180,
+    },
+    {
+        "type": "transcription.completed",
+        "item_id": "item-2",
+        "transcript": "how are you",
+        "audio_start_ms": 1400,
+        "audio_end_ms": 2900,
+        "transcription_latency_ms": 165,
+    },
+    {"type": "session.closed"},
+]
+
+
+@pytest.mark.asyncio
+async def test_zoom_success(fake_api_key: SecretStr, audio_pcm_bytes: bytes) -> None:
+    sent: list[Any] = []
+    provider = make_provider(fake_api_key)
+
+    with patch(
+        "coval_bench.providers.stt.zoom.ws_client.connect",
+        return_value=_fake_connect(_SUCCESS_EVENTS, sent),
+    ):
+        result = await provider.measure_ttft(
+            audio_data=audio_pcm_bytes,
+            channels=1,
+            sample_width=2,
+            sample_rate=16000,
+            realtime_resolution=0.5,
+        )
+
+    assert result.error is None
+    assert result.ttft_seconds is not None
+    assert result.ttft_seconds >= 0
+    assert result.first_token_content == "hello"  # noqa: S105 - transcript fixture text
+    assert result.complete_transcript == "hello world how are you"
+    assert result.word_count == 5
+    assert result.audio_to_final_seconds is not None
+
+    assert json.loads(sent[0])["type"] == "session.update"
+    assert all(isinstance(frame, bytes) for frame in sent[1:-1])
+    assert json.loads(sent[-1]) == {"type": "session.close"}
+
+
+@pytest.mark.asyncio
+async def test_zoom_deltas_stay_out_of_the_transcript(
+    fake_api_key: SecretStr, audio_pcm_bytes: bytes
+) -> None:
+    events: list[Any] = [
+        {"type": "transcription.delta", "delta": "wrong guess"},
+        {"type": "transcription.completed", "transcript": "hello world"},
+        {"type": "session.closed"},
+    ]
+    provider = make_provider(fake_api_key)
+
+    with patch(
+        "coval_bench.providers.stt.zoom.ws_client.connect",
+        return_value=_fake_connect(events),
+    ):
+        result = await provider.measure_ttft(
+            audio_data=audio_pcm_bytes,
+            channels=1,
+            sample_width=2,
+            sample_rate=16000,
+            realtime_resolution=0.5,
+        )
+
+    assert result.error is None
+    assert result.complete_transcript == "hello world"
+    assert result.partial_transcripts == ["wrong guess"]
+    assert result.first_token_content == "wrong guess"  # noqa: S105 - transcript fixture text
+
+
+@pytest.mark.asyncio
+async def test_zoom_non_fatal_error_does_not_end_the_run(
+    fake_api_key: SecretStr, audio_pcm_bytes: bytes
+) -> None:
+    events: list[Any] = [
+        {"type": "error", "error": {"code": "some_hint", "message": "heads up", "fatal": False}},
+        {"type": "transcription.completed", "transcript": "hello world"},
+        {"type": "session.closed"},
+    ]
+    provider = make_provider(fake_api_key)
+
+    with patch(
+        "coval_bench.providers.stt.zoom.ws_client.connect",
+        return_value=_fake_connect(events),
+    ):
+        result = await provider.measure_ttft(
+            audio_data=audio_pcm_bytes,
+            channels=1,
+            sample_width=2,
+            sample_rate=16000,
+            realtime_resolution=0.5,
+        )
+
+    assert result.error is None
+    assert result.complete_transcript == "hello world"
+
+
+@pytest.mark.asyncio
+async def test_zoom_fatal_error_event(fake_api_key: SecretStr, audio_pcm_bytes: bytes) -> None:
+    events: list[Any] = [
+        {"type": "error", "error": {"code": "unauthorized", "message": "bad token", "fatal": True}}
+    ]
+    provider = make_provider(fake_api_key)
+
+    with patch(
+        "coval_bench.providers.stt.zoom.ws_client.connect",
+        return_value=_fake_connect(events),
+    ):
+        result = await provider.measure_ttft(
+            audio_data=audio_pcm_bytes,
+            channels=1,
+            sample_width=2,
+            sample_rate=16000,
+            realtime_resolution=0.5,
+        )
+
+    assert result.error == "bad token"
+    assert result.complete_transcript is None
+
+
+def test_zoom_requires_both_credentials(fake_api_key: SecretStr) -> None:
+    with pytest.raises(ValueError, match="zoom_api_key"):
+        ZoomSTTProvider(api_key=None, api_secret=SecretStr("s"))
+    with pytest.raises(ValueError, match="zoom_api_secret"):
+        ZoomSTTProvider(api_key=fake_api_key, api_secret=None)
+    with pytest.raises(ValueError, match="Invalid Zoom STT model"):
+        ZoomSTTProvider(api_key=fake_api_key, api_secret=SecretStr("s"), model="scribe-9000")
+
+
+@pytest.mark.asyncio
+async def test_zoom_rejects_non_16k_mono_pcm16(fake_api_key: SecretStr) -> None:
+    provider = make_provider(fake_api_key)
+
+    result = await provider.measure_ttft(
+        audio_data=b"\x00\x00", channels=1, sample_width=2, sample_rate=8000
+    )
+    assert result.error is not None and "16 kHz" in result.error
+
+    result = await provider.measure_ttft(
+        audio_data=b"\x00\x00", channels=2, sample_width=2, sample_rate=16000
+    )
+    assert result.error is not None and "mono" in result.error
+
+
+def test_zoom_jwt_claims(fake_api_key: SecretStr) -> None:
+    provider = make_provider(fake_api_key)
+
+    claims = jwt.decode(
+        provider._auth_token(),
+        _TEST_SECRET,
+        algorithms=["HS256"],
+        issuer=fake_api_key.get_secret_value(),
+    )
+    assert claims["exp"] - claims["iat"] == 7200

--- a/runner/tests/providers/stt/test_zoom.py
+++ b/runner/tests/providers/stt/test_zoom.py
@@ -37,8 +37,6 @@ def _fake_connect(events: list[Any], sent: list[Any] | None = None) -> Any:
 
 
 _SUCCESS_EVENTS: list[Any] = [
-    {"type": "transcription.delta", "delta": "hello"},
-    {"type": "transcription.delta", "delta": "hello wor"},
     {
         "type": "transcription.completed",
         "item_id": "item-1",
@@ -79,7 +77,7 @@ async def test_zoom_success(fake_api_key: SecretStr, audio_pcm_bytes: bytes) -> 
     assert result.error is None
     assert result.ttft_seconds is not None
     assert result.ttft_seconds >= 0
-    assert result.first_token_content == "hello"  # noqa: S105 - transcript fixture text
+    assert result.first_token_content == "hello world"  # noqa: S105 - transcript fixture text
     assert result.complete_transcript == "hello world how are you"
     assert result.word_count == 5
     assert result.audio_to_final_seconds is not None
@@ -90,9 +88,9 @@ async def test_zoom_success(fake_api_key: SecretStr, audio_pcm_bytes: bytes) -> 
 
 
 @pytest.mark.asyncio
-async def test_zoom_deltas_stay_out_of_the_transcript(
-    fake_api_key: SecretStr, audio_pcm_bytes: bytes
-) -> None:
+async def test_zoom_ignores_delta_events(fake_api_key: SecretStr, audio_pcm_bytes: bytes) -> None:
+    """Deltas never arrive under the working config; if one does, it must not
+    count as a first token — a set TTFT would mask a missing-final failure."""
     events: list[Any] = [
         {"type": "transcription.delta", "delta": "wrong guess"},
         {"type": "transcription.completed", "transcript": "hello world"},
@@ -114,8 +112,8 @@ async def test_zoom_deltas_stay_out_of_the_transcript(
 
     assert result.error is None
     assert result.complete_transcript == "hello world"
-    assert result.partial_transcripts == ["wrong guess"]
-    assert result.first_token_content == "wrong guess"  # noqa: S105 - transcript fixture text
+    assert result.partial_transcripts == []
+    assert result.first_token_content == "hello world"  # noqa: S105 - transcript fixture text
 
 
 @pytest.mark.asyncio
@@ -146,7 +144,12 @@ async def test_zoom_non_fatal_error_does_not_end_the_run(
 
 
 @pytest.mark.asyncio
-async def test_zoom_fatal_error_event(fake_api_key: SecretStr, audio_pcm_bytes: bytes) -> None:
+async def test_zoom_fatal_error_stops_the_send(
+    fake_api_key: SecretStr, audio_pcm_bytes: bytes
+) -> None:
+    """A fatal error closes the socket, so the sender stops instead of pacing
+    out the rest of the clip; the fatal message survives the send failure."""
+    sent: list[Any] = []
     events: list[Any] = [
         {"type": "error", "error": {"code": "unauthorized", "message": "bad token", "fatal": True}}
     ]
@@ -154,7 +157,7 @@ async def test_zoom_fatal_error_event(fake_api_key: SecretStr, audio_pcm_bytes: 
 
     with patch(
         "coval_bench.providers.stt.zoom.ws_client.connect",
-        return_value=_fake_connect(events),
+        return_value=_fake_connect(events, sent),
     ):
         result = await provider.measure_ttft(
             audio_data=audio_pcm_bytes,
@@ -166,6 +169,7 @@ async def test_zoom_fatal_error_event(fake_api_key: SecretStr, audio_pcm_bytes: 
 
     assert result.error == "bad token"
     assert result.complete_transcript is None
+    assert json.dumps({"type": "session.close"}) not in sent
 
 
 def test_zoom_requires_both_credentials(fake_api_key: SecretStr) -> None:


### PR DESCRIPTION
Scribe live is a WebSocket session (subprotocol live-asr) authenticated with a per-connection HS256 JWT signed from the Zoom Build key/secret pair, so the provider takes two credentials and the orchestrator passes the secret alongside the conventional api_key.

The wire protocol emits only turn-final transcription.completed events: the documented enable_partial_results flag silently disables transcription (verified live), and session.close drops a pending turn instead of flushing it, so the client pads up to 2 s of trailing silence until the endpointer fires, as revai and together already do. TTFT and TTFS are excluded accordingly: the first token is the turn-final, and final timing bundles endpoint detection. WER, AudioToFinal, and RTF publish; a 5-item live probe measured 2.1% mean WER.

Non-fatal error events are logged and skipped since Zoom uses them as warnings (e.g. config hints); only errors flagged fatal end a run.