### PR TITLE
Trim an optional metric to the anchor instead of discarding it

### DIFF
--- a/runner/src/coval_bench/s2s/fetch_v2v.py
+++ b/runner/src/coval_bench/s2s/fetch_v2v.py
@@ -312,11 +312,13 @@ def _population_mismatch(
 ) -> dict[str, object] | None:
     """None if *other_values* covers the same conversations as the anchor.
 
-    Ids, not counts: equal counts can be different conversations. The caller trims
-    to the overlap; only duplicates skip the metric for the run.
+    Ids, not counts: equal counts can be different conversations. Values with no id
+    are excluded from both sides — two of them are not the same conversation, so
+    matching them would invent an overlap. The caller trims to the overlap; only
+    duplicates skip the metric for the run.
     """
-    other_set = {v.get("simulation_output_id") for v in other_values}
-    anchor_set = {v.get("simulation_output_id") for v in anchor_values}
+    other_set = {sid for v in other_values if (sid := v.get("simulation_output_id"))}
+    anchor_set = {sid for v in anchor_values if (sid := v.get("simulation_output_id"))}
     missing = sorted(str(x) for x in anchor_set - other_set)
     extra = sorted(str(x) for x in other_set - anchor_set)
     duplicate = _has_duplicate_ids(other_values)
@@ -534,6 +536,10 @@ async def _ingest_run(
                     metric=metric.value,
                 )
                 continue
+            # An id-less value cannot be reconciled against the anchor or deduped,
+            # and its positional key is not stable across metrics, so it is
+            # rejected before the populations are compared.
+            values = [v for v in values if v.get("simulation_output_id")]
             mismatch = _population_mismatch(anchor_values, values)
             if mismatch is not None:
                 logger.warning(
@@ -551,7 +557,7 @@ async def _ingest_run(
                 # corrupt: one conversation would carry twice its weight.
                 if mismatch["duplicate_ids"]:
                     continue
-                anchor_ids = {v.get("simulation_output_id") for v in anchor_values}
+                anchor_ids = {sid for v in anchor_values if (sid := v.get("simulation_output_id"))}
                 values = [v for v in values if v.get("simulation_output_id") in anchor_ids]
                 if not values:
                     continue

--- a/runner/src/coval_bench/s2s/fetch_v2v.py
+++ b/runner/src/coval_bench/s2s/fetch_v2v.py
@@ -312,8 +312,8 @@ def _population_mismatch(
 ) -> dict[str, object] | None:
     """None if *other_values* covers the same conversations as the anchor.
 
-    Ids, not counts: equal counts can be different conversations. A mismatch skips
-    that metric for the run.
+    Ids, not counts: equal counts can be different conversations. The caller trims
+    to the overlap; only duplicates skip the metric for the run.
     """
     other_set = {v.get("simulation_output_id") for v in other_values}
     anchor_set = {v.get("simulation_output_id") for v in anchor_values}
@@ -536,8 +536,6 @@ async def _ingest_run(
                 continue
             mismatch = _population_mismatch(anchor_values, values)
             if mismatch is not None:
-                # A different conversation population than the anchor would make
-                # the rate incomparable, so drop this metric and keep the anchor.
                 logger.warning(
                     "metric_population_mismatch",
                     provider=spec.provider,
@@ -545,7 +543,18 @@ async def _ingest_run(
                     metric=metric.value,
                     **mismatch,
                 )
-                continue
+                # Trim to the conversations both cover rather than discarding the
+                # metric for the whole run: one unmeasured call should cost that
+                # call, not the other forty-nine. Row-level parity with the anchor
+                # was never exact anyway — an UNKNOWN verdict writes no row — so a
+                # coverage gap is thinner data, not corrupt data. Duplicates are
+                # corrupt: one conversation would carry twice its weight.
+                if mismatch["duplicate_ids"]:
+                    continue
+                anchor_ids = {v.get("simulation_output_id") for v in anchor_values}
+                values = [v for v in values if v.get("simulation_output_id") in anchor_ids]
+                if not values:
+                    continue
             writable[metric] = values
         # Same mapper the rows are built from, so "would this write anything?"
         # cannot drift from what actually gets written.

--- a/runner/tests/unit/test_s2s_fetch.py
+++ b/runner/tests/unit/test_s2s_fetch.py
@@ -1261,6 +1261,35 @@ async def test_ingest_run_extra_ids_are_trimmed_not_dropped() -> None:
 
 
 @pytest.mark.asyncio
+async def test_ingest_run_drops_id_less_values_before_trimming() -> None:
+    # Two values with no simulation_output_id are not the same conversation, so
+    # neither may be matched against the other.
+    writer = _stub_writer()
+    latency: list[dict[str, Any]] = [
+        {"simulation_output_id": "s0", "value": 0.5},
+        {"value": 0.5},
+    ]
+    instruction: list[dict[str, Any]] = [
+        {"simulation_output_id": "s0", "value": "YES"},
+        {"value": "NO"},
+    ]
+    async with _fake_client({}, _multi_metric_run(latency, instruction)) as client:
+        status = await fetch_v2v._ingest_run(
+            client,
+            writer,
+            spec=SPEC,
+            coval_run=CovalRun(run_id="R1", create_time=None),
+            metric_ids=IDS,
+            period_seconds=10_800,
+        )
+    assert status is RunStatus.SUCCEEDED
+    rows = writer.record_results.await_args.args[0]
+    instruction_rows = [r for r in rows if r.metric_type == Metric.INSTRUCTION_FOLLOWING]
+    assert len(instruction_rows) == 1
+    assert instruction_rows[0].audio_filename.endswith("s0")
+
+
+@pytest.mark.asyncio
 async def test_ingest_run_duplicate_ids_still_drop_the_metric() -> None:
     writer = _stub_writer()
     latency = [

--- a/runner/tests/unit/test_s2s_fetch.py
+++ b/runner/tests/unit/test_s2s_fetch.py
@@ -1224,7 +1224,66 @@ async def test_ingest_run_id_mismatch_keeps_latency() -> None:
         )
     assert status is RunStatus.SUCCEEDED  # latency intact
     rows = writer.record_results.await_args.args[0]
-    assert all(r.metric_type == Metric.V2V for r in rows)  # instruction skipped on mismatch
+    # s1 is unscored and s2 unmeasured, so only s0 is covered by both.
+    instruction_rows = [r for r in rows if r.metric_type == Metric.INSTRUCTION_FOLLOWING]
+    assert len(instruction_rows) == 1
+    assert instruction_rows[0].audio_filename.endswith("s0")
+
+
+@pytest.mark.asyncio
+async def test_ingest_run_extra_ids_are_trimmed_not_dropped() -> None:
+    # A call the anchor never measured (agent silent, so no turn gap) still gets a
+    # judge verdict. That one conversation is trimmed; the rest are kept.
+    writer = _stub_writer()
+    latency = [
+        {"simulation_output_id": "s0", "value": 0.5},
+        {"simulation_output_id": "s1", "value": 0.5},
+    ]
+    instruction = [
+        {"simulation_output_id": "s0", "value": "YES"},
+        {"simulation_output_id": "s1", "value": "NO"},
+        {"simulation_output_id": "s2", "value": "YES"},  # unmeasured by the anchor
+    ]
+    async with _fake_client({}, _multi_metric_run(latency, instruction)) as client:
+        status = await fetch_v2v._ingest_run(
+            client,
+            writer,
+            spec=SPEC,
+            coval_run=CovalRun(run_id="R1", create_time=None),
+            metric_ids=IDS,
+            period_seconds=10_800,
+        )
+    assert status is RunStatus.SUCCEEDED
+    rows = writer.record_results.await_args.args[0]
+    instruction_rows = [r for r in rows if r.metric_type == Metric.INSTRUCTION_FOLLOWING]
+    assert len(instruction_rows) == 2
+    assert not any(r.audio_filename.endswith("s2") for r in instruction_rows)
+
+
+@pytest.mark.asyncio
+async def test_ingest_run_duplicate_ids_still_drop_the_metric() -> None:
+    writer = _stub_writer()
+    latency = [
+        {"simulation_output_id": "s0", "value": 0.5},
+        {"simulation_output_id": "s1", "value": 0.5},
+    ]
+    instruction = [
+        {"simulation_output_id": "s0", "value": "YES"},
+        {"simulation_output_id": "s0", "value": "NO"},
+        {"simulation_output_id": "s1", "value": "YES"},
+    ]
+    async with _fake_client({}, _multi_metric_run(latency, instruction)) as client:
+        status = await fetch_v2v._ingest_run(
+            client,
+            writer,
+            spec=SPEC,
+            coval_run=CovalRun(run_id="R1", create_time=None),
+            metric_ids=IDS,
+            period_seconds=10_800,
+        )
+    assert status is RunStatus.SUCCEEDED
+    rows = writer.record_results.await_args.args[0]
+    assert all(r.metric_type == Metric.V2V for r in rows)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
A conversation the latency anchor never measured still gets a judge verdict, so the id sets differ and the whole metric was discarded for that run. Over 30 days it has hit 9 runs across google, openai, xai others.

The metric is now trimmed to the conversations both cover. Row-level parity with the anchor was never exact anyway, since an `UNKNOWN` verdict writes no row, so a coverage gap is thinner data rather than corrupt data. Duplicate ids still discard the metric: one conversation carrying twice its weight is corrupt, not incomplete.

Neither duplicates nor missing ids have occurred in 30 days of logs; every mismatch was a single extra id.