### PR TITLE
[BENCH-742] Add Gemini 3.5 Transcribe Live to the STT benchmark

### DIFF
--- a/runner/src/coval_bench/config.py
+++ b/runner/src/coval_bench/config.py
@@ -96,6 +96,7 @@ class Settings(BaseSettings):
     hume_api_key: SecretStr | None = None
     rime_api_key: SecretStr | None = None
     gladia_api_key: SecretStr | None = None
+    gemini_api_key: SecretStr | None = None
     gradium_api_key: SecretStr | None = None
     gradium_tts_api_key: SecretStr | None = None
     mistral_api_key: SecretStr | None = None

--- a/runner/src/coval_bench/providers/stt/__init__.py
+++ b/runner/src/coval_bench/providers/stt/__init__.py
@@ -21,6 +21,7 @@ from coval_bench.providers.stt.baseten import BasetenSTTProvider
 from coval_bench.providers.stt.cartesia import CartesiaSTTProvider
 from coval_bench.providers.stt.deepgram import DeepgramProvider
 from coval_bench.providers.stt.elevenlabs import ElevenLabsSTTProvider
+from coval_bench.providers.stt.gemini import GeminiSTTProvider
 from coval_bench.providers.stt.gladia import GladiaSTTProvider
 from coval_bench.providers.stt.gradium import GradiumSTTProvider
 from coval_bench.providers.stt.inworld import InworldSTTProvider
@@ -51,6 +52,7 @@ STT_PROVIDERS: dict[str, type[STTProvider]] = {
     "azure": AzureSTTProvider,
     "baseten": BasetenSTTProvider,
     "elevenlabs": ElevenLabsSTTProvider,
+    "gemini": GeminiSTTProvider,
     "gladia": GladiaSTTProvider,
     "gradium": GradiumSTTProvider,
     "inworld": InworldSTTProvider,
@@ -78,6 +80,7 @@ __all__ = [
     "AzureSTTProvider",
     "BasetenSTTProvider",
     "ElevenLabsSTTProvider",
+    "GeminiSTTProvider",
     "GladiaSTTProvider",
     "GradiumSTTProvider",
     "InworldSTTProvider",

--- a/runner/src/coval_bench/providers/stt/gemini.py
+++ b/runner/src/coval_bench/providers/stt/gemini.py
@@ -1,0 +1,246 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Gemini Live API STT provider (WebSocket) for ``gemini-3.5-transcribe-live``.
+
+Distinct from the ``google`` provider, which speaks Cloud Speech v2 with
+service-account auth; the Live API is plain JSON-over-WebSocket with API-key
+auth. VERBATIM mode is pinned: SMART cleans disfluencies, which would skew WER
+against our verbatim references.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import contextlib
+import json
+import time
+from typing import Any
+
+import structlog
+import websockets.asyncio.client as ws_client
+from pydantic import SecretStr
+
+from coval_bench.providers.base import STTProvider, TranscriptionResult
+from coval_bench.providers.stt._pacing import paced_chunks
+from coval_bench.providers.stt._transcript_utils import (
+    add_partial_transcript,
+    finalize_transcript,
+    set_first_token,
+)
+
+logger = structlog.get_logger(__name__)
+
+_WS_URL = (
+    "wss://generativelanguage.googleapis.com/ws/"
+    "google.ai.generativelanguage.v1beta.GenerativeService.BidiGenerateContent"
+)
+_SETUP_TIMEOUT_S = 30.0
+
+# The server never ends the session itself (verified live 2026-08): it holds the
+# socket open after ``audioStreamEnd``, and ``generationComplete`` fires per
+# utterance, not per session. The sender waits this long for the post-stream-end
+# completion before closing, so the close can't race the last final.
+_FINAL_WAIT_S = 5.0
+
+
+def _decode_event(raw: str | bytes) -> dict[str, Any]:
+    """The Live API sends JSON in binary frames; accept text frames too."""
+    text = raw.decode("utf-8") if isinstance(raw, bytes) else raw
+    event: dict[str, Any] = json.loads(text)
+    return event
+
+
+class GeminiSTTProvider(STTProvider):
+    """Gemini Live API streaming transcription provider."""
+
+    _VALID_MODELS = frozenset({"gemini-3.5-transcribe-live"})
+
+    def __init__(
+        self, api_key: SecretStr | None, model: str = "gemini-3.5-transcribe-live"
+    ) -> None:
+        if not self._model_supported(model):
+            raise ValueError(
+                f"Invalid Gemini STT model {model!r}. Valid: {sorted(self._VALID_MODELS)}"
+            )
+        if api_key is None:
+            raise ValueError("gemini_api_key is required for the Gemini STT provider")
+        self._api_key = api_key
+        self._model = model
+
+    @property
+    def name(self) -> str:
+        return "gemini"
+
+    @property
+    def model(self) -> str:
+        return self._model
+
+    def _build_setup(self) -> dict[str, Any]:
+        return {
+            "setup": {
+                "model": f"models/{self._model}",
+                "generationConfig": {"responseModalities": ["TEXT"]},
+                "inputAudioTranscription": {
+                    "languageCodes": ["en-US"],
+                    "mode": "VERBATIM",
+                },
+            }
+        }
+
+    async def measure_ttft(
+        self,
+        audio_data: bytes,
+        channels: int,
+        sample_width: int,
+        sample_rate: int,
+        realtime_resolution: float = 0.1,
+    ) -> TranscriptionResult:
+        result = TranscriptionResult(provider=self.name)
+        if sample_rate != 16000:
+            result.error = f"Gemini Live requires 16 kHz PCM input; got {sample_rate} Hz"
+            return result
+        if channels != 1 or sample_width != 2:
+            result.error = (
+                "Gemini Live requires mono 16-bit PCM input; "
+                f"got channels={channels}, sample_width={sample_width}"
+            )
+            return result
+
+        total_start = time.monotonic()
+
+        try:
+            url = f"{_WS_URL}?key={self._api_key.get_secret_value()}"
+            async with ws_client.connect(url) as ws:
+                await self._wait_for_setup_complete(ws)
+
+                final_event = asyncio.Event()
+                send_task = asyncio.create_task(
+                    self._send_audio(
+                        ws, audio_data, sample_rate, result, realtime_resolution, final_event
+                    )
+                )
+                recv_task = asyncio.create_task(self._receive(ws, result, final_event))
+                tasks = (send_task, recv_task)
+                done, pending = await asyncio.wait(tasks, return_when=asyncio.FIRST_EXCEPTION)
+                if any(not task.cancelled() and task.exception() is not None for task in done):
+                    for task in pending:
+                        task.cancel()
+                outcomes = await asyncio.gather(*tasks, return_exceptions=True)
+                if result.error is None and result.audio_to_final_seconds is None:
+                    for outcome in outcomes:
+                        if isinstance(outcome, Exception):
+                            result.error = str(outcome)
+                            break
+
+        except Exception as exc:
+            logger.warning(
+                "gemini_measure_ttft_failed", provider="gemini", model=self._model, exc_info=exc
+            )
+            if result.error is None:
+                result.error = str(exc)
+
+        result.total_time = time.monotonic() - total_start
+        return result
+
+    async def _wait_for_setup_complete(self, ws: Any) -> None:
+        await ws.send(json.dumps(self._build_setup()))
+        try:
+            async with asyncio.timeout(_SETUP_TIMEOUT_S):
+                while True:
+                    try:
+                        raw = await ws.recv()
+                    except StopAsyncIteration as exc:
+                        raise RuntimeError(
+                            f"Did not receive setupComplete within {_SETUP_TIMEOUT_S}s"
+                        ) from exc
+                    event = _decode_event(raw)
+                    if "setupComplete" in event:
+                        return
+                    if "error" in event:
+                        message = event["error"].get("message", "Unknown Gemini error")
+                        raise RuntimeError(f"Gemini error during setup: {message}")
+        except TimeoutError as exc:
+            raise RuntimeError(f"Did not receive setupComplete within {_SETUP_TIMEOUT_S}s") from exc
+
+    async def _send_audio(
+        self,
+        ws: Any,
+        audio_data: bytes,
+        sample_rate: int,
+        result: TranscriptionResult,
+        realtime_resolution: float,
+        final_event: asyncio.Event,
+    ) -> None:
+        bytes_per_second = sample_rate * 2  # 16-bit mono
+        chunk_size = int(bytes_per_second * realtime_resolution)
+        try:
+            async for chunk, start in paced_chunks(audio_data, chunk_size, bytes_per_second):
+                result.audio_start_time = start
+                await ws.send(
+                    json.dumps(
+                        {
+                            "realtimeInput": {
+                                "audio": {
+                                    "data": base64.b64encode(chunk).decode("ascii"),
+                                    "mimeType": f"audio/pcm;rate={sample_rate}",
+                                }
+                            }
+                        }
+                    )
+                )
+            # Completions seen mid-audio belong to earlier utterances; only one
+            # arriving after this clear can be the stream-end flush.
+            final_event.clear()
+            await ws.send(json.dumps({"realtimeInput": {"audioStreamEnd": True}}))
+            with contextlib.suppress(TimeoutError):
+                await asyncio.wait_for(final_event.wait(), timeout=_FINAL_WAIT_S)
+            await ws.close()
+        except Exception as exc:
+            logger.warning("gemini_send_error", provider="gemini", model=self._model, exc_info=exc)
+            raise
+
+    async def _receive(
+        self, ws: Any, result: TranscriptionResult, final_event: asyncio.Event
+    ) -> None:
+        final_parts: list[str] = []
+
+        try:
+            async for raw in ws:
+                msg = _decode_event(raw)
+                now = time.monotonic()
+
+                if "error" in msg:
+                    result.error = str(msg["error"].get("message", "Gemini error"))
+                    logger.warning(
+                        "gemini_stt_error", provider="gemini", model=self._model, msg=msg
+                    )
+                    break
+
+                server_content: dict[str, Any] = msg.get("serverContent") or {}
+
+                interim_event = server_content.get("interimInputTranscription") or {}
+                interim = str(interim_event.get("text", ""))
+                if interim.strip():
+                    set_first_token(result, interim, now=now)
+                    add_partial_transcript(result, interim)
+
+                final = str((server_content.get("inputTranscription") or {}).get("text", ""))
+                if final.strip():
+                    set_first_token(result, final, now=now)
+                    final_parts.append(final)
+                    if result.audio_start_time is not None:
+                        result.audio_to_final_seconds = now - result.audio_start_time
+
+                if server_content.get("generationComplete"):
+                    final_event.set()
+
+        except Exception as exc:
+            logger.warning(
+                "gemini_receive_error", provider="gemini", model=self._model, exc_info=exc
+            )
+            if result.error is None and result.audio_to_final_seconds is None:
+                result.error = str(exc)
+
+        finalize_transcript(result, final_segments=final_parts, partial_fallback="longest")

--- a/runner/src/coval_bench/providers/stt/gemini.py
+++ b/runner/src/coval_bench/providers/stt/gemini.py
@@ -40,8 +40,10 @@ _SETUP_TIMEOUT_S = 30.0
 
 # The server never ends the session itself (verified live 2026-08): it holds the
 # socket open after ``audioStreamEnd``, and ``generationComplete`` fires per
-# utterance, not per session. The sender waits this long for the post-stream-end
-# completion before closing, so the close can't race the last final.
+# utterance, not per session. Transcriptions also stream independently of other
+# server content with no ordering guarantee, so the sender waits this long for
+# BOTH the post-stream-end final and its completion before closing — a close on
+# the completion alone could race a reordered final and truncate the transcript.
 _FINAL_WAIT_S = 5.0
 
 
@@ -115,13 +117,22 @@ class GeminiSTTProvider(STTProvider):
             async with ws_client.connect(url) as ws:
                 await self._wait_for_setup_complete(ws)
 
-                final_event = asyncio.Event()
+                final_seen = asyncio.Event()
+                complete_seen = asyncio.Event()
                 send_task = asyncio.create_task(
                     self._send_audio(
-                        ws, audio_data, sample_rate, result, realtime_resolution, final_event
+                        ws,
+                        audio_data,
+                        sample_rate,
+                        result,
+                        realtime_resolution,
+                        final_seen,
+                        complete_seen,
                     )
                 )
-                recv_task = asyncio.create_task(self._receive(ws, result, final_event))
+                recv_task = asyncio.create_task(
+                    self._receive(ws, result, final_seen, complete_seen)
+                )
                 tasks = (send_task, recv_task)
                 done, pending = await asyncio.wait(tasks, return_when=asyncio.FIRST_EXCEPTION)
                 if any(not task.cancelled() and task.exception() is not None for task in done):
@@ -171,7 +182,8 @@ class GeminiSTTProvider(STTProvider):
         sample_rate: int,
         result: TranscriptionResult,
         realtime_resolution: float,
-        final_event: asyncio.Event,
+        final_seen: asyncio.Event,
+        complete_seen: asyncio.Event,
     ) -> None:
         bytes_per_second = sample_rate * 2  # 16-bit mono
         chunk_size = int(bytes_per_second * realtime_resolution)
@@ -190,19 +202,26 @@ class GeminiSTTProvider(STTProvider):
                         }
                     )
                 )
-            # Completions seen mid-audio belong to earlier utterances; only one
+            # Events seen mid-audio belong to earlier utterances; only ones
             # arriving after this clear can be the stream-end flush.
-            final_event.clear()
+            final_seen.clear()
+            complete_seen.clear()
             await ws.send(json.dumps({"realtimeInput": {"audioStreamEnd": True}}))
             with contextlib.suppress(TimeoutError):
-                await asyncio.wait_for(final_event.wait(), timeout=_FINAL_WAIT_S)
+                async with asyncio.timeout(_FINAL_WAIT_S):
+                    await final_seen.wait()
+                    await complete_seen.wait()
             await ws.close()
         except Exception as exc:
             logger.warning("gemini_send_error", provider="gemini", model=self._model, exc_info=exc)
             raise
 
     async def _receive(
-        self, ws: Any, result: TranscriptionResult, final_event: asyncio.Event
+        self,
+        ws: Any,
+        result: TranscriptionResult,
+        final_seen: asyncio.Event,
+        complete_seen: asyncio.Event,
     ) -> None:
         final_parts: list[str] = []
 
@@ -232,9 +251,10 @@ class GeminiSTTProvider(STTProvider):
                     final_parts.append(final)
                     if result.audio_start_time is not None:
                         result.audio_to_final_seconds = now - result.audio_start_time
+                    final_seen.set()
 
                 if server_content.get("generationComplete"):
-                    final_event.set()
+                    complete_seen.set()
 
         except Exception as exc:
             logger.warning(

--- a/runner/src/coval_bench/registries/models.py
+++ b/runner/src/coval_bench/registries/models.py
@@ -386,6 +386,16 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         region="us",
         status=_ACTIVE,
     ),
+    # Gemini Live API (API-key auth), not Cloud Speech v2 like the `google` provider.
+    RegisteredModel(
+        benchmark=_STT,
+        provider="gemini",
+        model="gemini-3.5-transcribe-live",
+        creator="google",
+        tags=(_MULTI, _VAD, _KEYTERM),
+        region="us",
+        status=_EARLY_ACCESS,
+    ),
     RegisteredModel(
         benchmark=_STT,
         provider="revai",

--- a/runner/tests/providers/stt/conftest.py
+++ b/runner/tests/providers/stt/conftest.py
@@ -142,6 +142,7 @@ _WAIT_PATCHES = (
     "coval_bench.providers.stt.deepgram._FLUX_EOT_SILENCE_S",
     "coval_bench.providers.stt.revai._EOT_SILENCE_S",
     "coval_bench.providers.stt.xai._FINAL_WAIT_S",
+    "coval_bench.providers.stt.gemini._FINAL_WAIT_S",
     "coval_bench.providers.stt.gradium._FLUSH_WAIT_S",
     "coval_bench.providers.stt.reson8._FLUSH_WAIT_S",
     "coval_bench.providers.stt.inworld._CLOSE_WAIT_S",

--- a/runner/tests/providers/stt/fixtures/gemini/events-success.json
+++ b/runner/tests/providers/stt/fixtures/gemini/events-success.json
@@ -1,0 +1,13 @@
+[
+  {"setupComplete": {}},
+  {"serverContent": {}},
+  {"serverContent": {"interimInputTranscription": {"text": "hello"}}},
+  {"serverContent": {"interimInputTranscription": {"text": "hello world"}}},
+  {"serverContent": {"inputTranscription": {"text": "hello world"}}},
+  {"serverContent": {"generationComplete": true}},
+  {"serverContent": {}},
+  {"serverContent": {"interimInputTranscription": {"text": "how are"}}},
+  {"serverContent": {"inputTranscription": {"text": "how are you"}}},
+  {"serverContent": {"generationComplete": true}},
+  {"serverContent": {}}
+]

--- a/runner/tests/providers/stt/test_gemini.py
+++ b/runner/tests/providers/stt/test_gemini.py
@@ -1,0 +1,120 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for coval_bench.providers.stt.gemini (GeminiSTTProvider).
+
+All tests use FakeWebSocket — no live network calls are made. The event
+fixtures mirror the Gemini Live API wire protocol as observed live: a
+``setupComplete`` handshake, then ``serverContent`` frames carrying
+``interimInputTranscription`` (speculative) and ``inputTranscription`` (final)
+segments, with ``generationComplete`` per utterance — the server never ends
+the session, so the client closes after the post-stream-end completion. The
+live API delivers JSON in binary frames, so decoding ``bytes`` events is
+pinned explicitly.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pydantic import SecretStr
+
+from coval_bench.metrics.wer import compute_wer
+from coval_bench.providers.stt.gemini import GeminiSTTProvider
+from tests.providers.stt.conftest import FakeWebSocket, load_fixture_events
+
+_CONNECT = "coval_bench.providers.stt.gemini.ws_client.connect"
+
+
+def _fake_connect(events: list[Any]) -> tuple[Any, FakeWebSocket]:
+    ws = FakeWebSocket(events)
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=ws)
+    cm.__aexit__ = AsyncMock(return_value=False)
+    return cm, ws
+
+
+async def _measure(
+    provider: GeminiSTTProvider, events: list[Any], audio: bytes
+) -> tuple[Any, FakeWebSocket]:
+    cm, ws = _fake_connect(events)
+    with patch(_CONNECT, return_value=cm):
+        result = await provider.measure_ttft(
+            audio_data=audio,
+            channels=1,
+            sample_width=2,
+            sample_rate=16000,
+            realtime_resolution=0.5,
+        )
+    return result, ws
+
+
+@pytest.mark.asyncio
+async def test_gemini_success(fake_api_key: SecretStr, audio_pcm_bytes: bytes) -> None:
+    events = load_fixture_events("gemini", "events-success")
+    provider = GeminiSTTProvider(api_key=fake_api_key)
+
+    result, ws = await _measure(provider, events, audio_pcm_bytes)
+
+    assert result.error is None
+    assert result.ttft_seconds is not None
+    assert result.ttft_seconds >= 0
+    assert result.first_token_content is not None
+    assert result.complete_transcript == "hello world how are you"
+    assert result.word_count == 5
+    assert result.audio_to_final_seconds is not None
+    wer = compute_wer("hello world how are you", result.complete_transcript)
+    assert wer.wer_percentage == pytest.approx(0.0)
+
+    setup = json.loads(ws._sent[0])["setup"]
+    assert setup["model"] == "models/gemini-3.5-transcribe-live"
+    # SMART mode cleans disfluencies, which would skew WER against verbatim references.
+    assert setup["inputAudioTranscription"]["mode"] == "VERBATIM"
+    assert json.loads(ws._sent[-1]) == {"realtimeInput": {"audioStreamEnd": True}}
+
+
+@pytest.mark.asyncio
+async def test_gemini_decodes_binary_frames(
+    fake_api_key: SecretStr, audio_pcm_bytes: bytes
+) -> None:
+    """The live API sends JSON in binary frames; they must decode, not be skipped."""
+    events: list[Any] = [
+        json.dumps(event).encode("utf-8")
+        for event in load_fixture_events("gemini", "events-success")
+    ]
+    provider = GeminiSTTProvider(api_key=fake_api_key)
+
+    result, _ = await _measure(provider, events, audio_pcm_bytes)
+
+    assert result.error is None
+    assert result.complete_transcript == "hello world how are you"
+    assert result.ttft_seconds is not None
+
+
+@pytest.mark.asyncio
+async def test_gemini_stream_error(fake_api_key: SecretStr, audio_pcm_bytes: bytes) -> None:
+    events: list[Any] = [
+        {"setupComplete": {}},
+        {"error": {"message": "quota exceeded"}},
+    ]
+    provider = GeminiSTTProvider(api_key=fake_api_key)
+
+    result, _ = await _measure(provider, events, audio_pcm_bytes)
+
+    assert result.error == "quota exceeded"
+    assert result.complete_transcript is None
+
+
+@pytest.mark.asyncio
+async def test_gemini_setup_error(fake_api_key: SecretStr, audio_pcm_bytes: bytes) -> None:
+    events: list[Any] = [{"error": {"message": "invalid model"}}]
+    provider = GeminiSTTProvider(api_key=fake_api_key)
+
+    result, _ = await _measure(provider, events, audio_pcm_bytes)
+
+    assert result.error is not None
+    assert "invalid model" in result.error
+    assert result.ttft_seconds is None

--- a/runner/tests/providers/stt/test_gemini.py
+++ b/runner/tests/providers/stt/test_gemini.py
@@ -95,6 +95,28 @@ async def test_gemini_decodes_binary_frames(
 
 
 @pytest.mark.asyncio
+async def test_gemini_completion_before_final(
+    fake_api_key: SecretStr, audio_pcm_bytes: bytes
+) -> None:
+    """Transcriptions have no ordering guarantee vs other server content: a
+    ``generationComplete`` arriving ahead of its final must not end the session
+    early or drop the reordered final segment."""
+    events: list[Any] = [
+        {"setupComplete": {}},
+        {"serverContent": {"interimInputTranscription": {"text": "hello"}}},
+        {"serverContent": {"generationComplete": True}},
+        {"serverContent": {"inputTranscription": {"text": "hello world"}}},
+    ]
+    provider = GeminiSTTProvider(api_key=fake_api_key)
+
+    result, _ = await _measure(provider, events, audio_pcm_bytes)
+
+    assert result.error is None
+    assert result.complete_transcript == "hello world"
+    assert result.audio_to_final_seconds is not None
+
+
+@pytest.mark.asyncio
 async def test_gemini_stream_error(fake_api_key: SecretStr, audio_pcm_bytes: bytes) -> None:
     events: list[Any] = [
         {"setupComplete": {}},


### PR DESCRIPTION
gemini-3.5-transcribe-live joins as a new gemini provider speaking the Live API WebSocket protocol (JSON setup, base64 PCM realtime input), registered early-access with creator google. The provider name derives gemini_api_key generically, so the orchestrator and smoke CLI need no special-casing. VERBATIM mode is pinned: SMART cleans disfluencies, which would skew WER against verbatim references.

Two wire behaviors diverge from the docs, verified live: JSON arrives in binary frames (decoded, where other providers skip bytes), and generationComplete fires per utterance with the server never ending the session — so the sender close-gates like Deepgram, waiting up to 5s after audioStreamEnd for the flush completion before closing. audioStreamEnd is a genuine force-finalize (final ~0.25-0.28s after stream end vs 1-2s endpointer wait mid-stream), keeping TTFS comparable. Smoke runs: word-perfect transcripts, TTFT ~0.75s.