### PR TITLE
Add the result variant dimensions and the mock tool-call log

### DIFF
--- a/runner/src/coval_bench/db/migrations/versions/20260826_0022_result_variant_dimensions.py
+++ b/runner/src/coval_bench/db/migrations/versions/20260826_0022_result_variant_dimensions.py
@@ -16,6 +16,10 @@ bug. Every existing row is Coval-pinned, so the default is also the backfill.
 ``transport``, ``test_case_id`` and ``iteration`` stay nullable and cannot be
 backfilled, which is why this lands before the first row worth keeping.
 
+Replay order within one simulation is ``(created_at, id)``, never ``created_at``
+alone: ``now()`` is constant across a transaction, so a batch of calls shares one
+timestamp and only the serial id separates them.
+
 ``mock_tool_calls`` is deliberately its own table rather than rows in ``results``:
 a tool call is an event carrying arguments and a response, not a numeric metric,
 and ``results.metric_value`` is DOUBLE PRECISION with the rollups filtering on it
@@ -64,10 +68,14 @@ def upgrade() -> None:
         )
         """
     )
-    # The ingest join: every tool call for one simulation, in order.
+    # The ingest join: every tool call for one simulation, in order. `now()` is the
+    # transaction start time, so calls written in one transaction share a
+    # `created_at` and the timestamp alone cannot recover the order they fired in.
+    # `id` is the tiebreak, and the index carries it so `(created_at, id)` — the
+    # order replay must use — is served without a sort.
     op.execute(
         "CREATE INDEX mock_tool_calls_simulation_idx "
-        "ON benchmarks_v2.mock_tool_calls (simulation_id, created_at)"
+        "ON benchmarks_v2.mock_tool_calls (simulation_id, created_at, id)"
     )
     # Correlation fallback for platforms that drop unknown SIP headers.
     op.execute(

--- a/runner/src/coval_bench/db/migrations/versions/20260826_0022_result_variant_dimensions.py
+++ b/runner/src/coval_bench/db/migrations/versions/20260826_0022_result_variant_dimensions.py
@@ -1,0 +1,91 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Add the result variant dimensions and the mock tool-call log.
+
+Orchestration platforms are measured under the existing ``S2S`` benchmark rather
+than one of their own: they carry the same turn-latency and interruption metrics,
+read from the same stereo recording, so the platform is a dimension of a row and
+not a different experiment. ``variant_id`` is that dimension.
+
+``variant_id`` is NOT NULL and defaults to ``pinned`` — the arm whose components
+Coval fixed for comparability. Nullable would leave "unset" ambiguous between a
+row predating variants and one somebody forgot to tag, and only the second is a
+bug. Every existing row is Coval-pinned, so the default is also the backfill.
+
+``transport``, ``test_case_id`` and ``iteration`` stay nullable and cannot be
+backfilled, which is why this lands before the first row worth keeping.
+
+``mock_tool_calls`` is deliberately its own table rather than rows in ``results``:
+a tool call is an event carrying arguments and a response, not a numeric metric,
+and ``results.metric_value`` is DOUBLE PRECISION with the rollups filtering on it
+being non-null. Metrics *derived* from these rows still land in ``results``.
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "20260826_0022"
+down_revision = "20260825_0021"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Add the result dimensions and the tool-call log."""
+    # The default is also the backfill: every row written before variants existed
+    # ran the components Coval pinned. A platform arm must set the column at write
+    # time rather than lean on this.
+    op.execute(
+        """
+        ALTER TABLE benchmarks_v2.results
+            ADD COLUMN variant_id   TEXT NOT NULL DEFAULT 'pinned',
+            ADD COLUMN transport    TEXT,
+            ADD COLUMN test_case_id TEXT,
+            ADD COLUMN iteration    INTEGER
+        """
+    )
+
+    op.execute(
+        """
+        CREATE TABLE benchmarks_v2.mock_tool_calls (
+            id             BIGSERIAL PRIMARY KEY,
+            simulation_id  TEXT,
+            caller_number  TEXT,
+            tool           TEXT NOT NULL CHECK (tool <> ''),
+            args           JSONB NOT NULL CHECK (jsonb_typeof(args) = 'object'),
+            matched_seed   TEXT,
+            response       JSONB NOT NULL,
+            latency_ms     DOUBLE PRECISION NOT NULL
+                           CHECK (latency_ms >= 0 AND latency_ms NOT IN (
+                               'NaN'::float8, 'Infinity'::float8, '-Infinity'::float8)),
+            created_at     TIMESTAMPTZ NOT NULL DEFAULT now()
+        )
+        """
+    )
+    # The ingest join: every tool call for one simulation, in order.
+    op.execute(
+        "CREATE INDEX mock_tool_calls_simulation_idx "
+        "ON benchmarks_v2.mock_tool_calls (simulation_id, created_at)"
+    )
+    # Correlation fallback for platforms that drop unknown SIP headers.
+    op.execute(
+        "CREATE INDEX mock_tool_calls_caller_idx "
+        "ON benchmarks_v2.mock_tool_calls (caller_number, created_at) "
+        "WHERE caller_number IS NOT NULL"
+    )
+
+
+def downgrade() -> None:
+    """Drop the tool-call log and the result dimensions."""
+    op.execute("DROP TABLE IF EXISTS benchmarks_v2.mock_tool_calls")
+    op.execute(
+        """
+        ALTER TABLE benchmarks_v2.results
+            DROP COLUMN IF EXISTS iteration,
+            DROP COLUMN IF EXISTS test_case_id,
+            DROP COLUMN IF EXISTS transport,
+            DROP COLUMN IF EXISTS variant_id
+        """
+    )

--- a/runner/src/coval_bench/db/migrations/versions/20260826_0022_result_variant_dimensions.py
+++ b/runner/src/coval_bench/db/migrations/versions/20260826_0022_result_variant_dimensions.py
@@ -13,8 +13,12 @@ Coval fixed for comparability. Nullable would leave "unset" ambiguous between a
 row predating variants and one somebody forgot to tag, and only the second is a
 bug. Every existing row is Coval-pinned, so the default is also the backfill.
 
-``transport``, ``test_case_id`` and ``iteration`` stay nullable and cannot be
-backfilled, which is why this lands before the first row worth keeping.
+``transport`` and ``test_case_id`` stay nullable and cannot be backfilled, which
+is why this lands before the first row worth keeping. The repeat index within a run
+is deliberately not a column: unlike those two it is recoverable after the fact, as
+``row_number() over (partition by run_id, variant_id, test_case_id order by
+created_at, id)``, so storing it would buy only the ability to tell a skipped
+attempt from a short run.
 
 Replay order within one simulation is ``(created_at, id)``, never ``created_at``
 alone: ``now()`` is constant across a transaction, so a batch of calls shares one
@@ -46,8 +50,7 @@ def upgrade() -> None:
         ALTER TABLE benchmarks_v2.results
             ADD COLUMN variant_id   TEXT NOT NULL DEFAULT 'pinned',
             ADD COLUMN transport    TEXT,
-            ADD COLUMN test_case_id TEXT,
-            ADD COLUMN iteration    INTEGER
+            ADD COLUMN test_case_id TEXT
         """
     )
 
@@ -91,7 +94,6 @@ def downgrade() -> None:
     op.execute(
         """
         ALTER TABLE benchmarks_v2.results
-            DROP COLUMN IF EXISTS iteration,
             DROP COLUMN IF EXISTS test_case_id,
             DROP COLUMN IF EXISTS transport,
             DROP COLUMN IF EXISTS variant_id

--- a/runner/src/coval_bench/db/models.py
+++ b/runner/src/coval_bench/db/models.py
@@ -361,6 +361,16 @@ class Result(BaseModel):
     wer_insertions_pct: float | None = None
     wer_deletions_pct: float | None = None
     wer_substitutions_pct: float | None = None
+    # The configuration arm that produced this row. `pinned` marks components Coval
+    # chose for comparability; a vendor-submitted or otherwise-configured arm carries
+    # its own id. Orchestration platforms are variants of S2S, not their own benchmark.
+    variant_id: str = "pinned"
+    # Call-shape dimensions, null outside the orchestration runs that set them:
+    # `transport` the carrier path, `test_case_id` the scenario, `iteration` the
+    # repeat within one run.
+    transport: str | None = None
+    test_case_id: str | None = None
+    iteration: int | None = None
 
 
 class VoteOutcome(StrEnum):

--- a/runner/src/coval_bench/db/models.py
+++ b/runner/src/coval_bench/db/models.py
@@ -366,11 +366,11 @@ class Result(BaseModel):
     # its own id. Orchestration platforms are variants of S2S, not their own benchmark.
     variant_id: str = "pinned"
     # Call-shape dimensions, null outside the orchestration runs that set them:
-    # `transport` the carrier path, `test_case_id` the scenario, `iteration` the
-    # repeat within one run.
+    # `transport` the carrier path, `test_case_id` the scenario. Neither survives
+    # the run it was measured in, so both are stored rather than derived. The repeat
+    # index within a run is not: it falls out of (created_at, id) when it is wanted.
     transport: str | None = None
     test_case_id: str | None = None
-    iteration: int | None = None
 
 
 class VoteOutcome(StrEnum):

--- a/runner/src/coval_bench/db/writer.py
+++ b/runner/src/coval_bench/db/writer.py
@@ -139,9 +139,10 @@ class RunWriter:
                 (run_id, provider, model, voice, benchmark, metric_type,
                  metric_value, metric_units, audio_filename, transcript,
                  status, error, http_version, submit_to_headers_ms,
-                 wer_insertions_pct, wer_deletions_pct, wer_substitutions_pct)
+                 wer_insertions_pct, wer_deletions_pct, wer_substitutions_pct,
+                 variant_id, transport, test_case_id, iteration)
             VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s,
-                    %s, %s, %s)
+                    %s, %s, %s, %s, %s, %s, %s)
         """
         params = [
             (
@@ -162,6 +163,10 @@ class RunWriter:
                 r.wer_insertions_pct,
                 r.wer_deletions_pct,
                 r.wer_substitutions_pct,
+                r.variant_id,
+                r.transport,
+                r.test_case_id,
+                r.iteration,
             )
             for r in results
         ]

--- a/runner/src/coval_bench/db/writer.py
+++ b/runner/src/coval_bench/db/writer.py
@@ -140,9 +140,9 @@ class RunWriter:
                  metric_value, metric_units, audio_filename, transcript,
                  status, error, http_version, submit_to_headers_ms,
                  wer_insertions_pct, wer_deletions_pct, wer_substitutions_pct,
-                 variant_id, transport, test_case_id, iteration)
+                 variant_id, transport, test_case_id)
             VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s,
-                    %s, %s, %s, %s, %s, %s, %s)
+                    %s, %s, %s, %s, %s, %s)
         """
         params = [
             (
@@ -166,7 +166,6 @@ class RunWriter:
                 r.variant_id,
                 r.transport,
                 r.test_case_id,
-                r.iteration,
             )
             for r in results
         ]

--- a/runner/tests/unit/test_db_writer.py
+++ b/runner/tests/unit/test_db_writer.py
@@ -283,6 +283,45 @@ def test_record_results_batch(pg_conn: psycopg.Connection[Any]) -> None:
     asyncio.run(_run())
 
 
+def test_record_results_persists_variant_dimensions(
+    pg_conn: psycopg.Connection[Any],
+) -> None:
+    """A non-default variant survives the insert; an unset one defaults to pinned."""
+    _apply_migrations(pg_conn)
+
+    async def _run() -> None:
+        pool = await _make_pool(pg_conn)
+        try:
+            writer = RunWriter(pool)
+            run = await writer.start_run(dataset_id="s2s-dental-v1", dataset_sha256="deadbeef")
+            assert run.id is not None
+            tagged = _make_result(run.id, idx=0)
+            tagged = tagged.model_copy(
+                update={
+                    "variant_id": "vapi-baseline-v1",
+                    "transport": "sip",
+                    "test_case_id": "TC1",
+                    "iteration": 2,
+                }
+            )
+            await writer.record_results([tagged, _make_result(run.id, idx=1)])
+            await writer.finish_run(run.id, status=RunStatus.SUCCEEDED)
+        finally:
+            await pool.close()
+
+        pg_conn.autocommit = True
+        with pg_conn.cursor() as cur:
+            cur.execute(
+                "SELECT variant_id, transport, test_case_id, iteration"
+                " FROM benchmarks_v2.results WHERE run_id = %s ORDER BY metric_value",
+                (run.id,),
+            )
+            rows = cur.fetchall()
+        assert rows == [("vapi-baseline-v1", "sip", "TC1", 2), ("pinned", None, None, None)]
+
+    asyncio.run(_run())
+
+
 def test_partial_run(pg_conn: psycopg.Connection[Any]) -> None:
     """1 success + 1 failed result → finish_run('partial') → status persists."""
     _apply_migrations(pg_conn)

--- a/runner/tests/unit/test_db_writer.py
+++ b/runner/tests/unit/test_db_writer.py
@@ -301,7 +301,6 @@ def test_record_results_persists_variant_dimensions(
                     "variant_id": "vapi-baseline-v1",
                     "transport": "sip",
                     "test_case_id": "TC1",
-                    "iteration": 2,
                 }
             )
             await writer.record_results([tagged, _make_result(run.id, idx=1)])
@@ -312,12 +311,12 @@ def test_record_results_persists_variant_dimensions(
         pg_conn.autocommit = True
         with pg_conn.cursor() as cur:
             cur.execute(
-                "SELECT variant_id, transport, test_case_id, iteration"
+                "SELECT variant_id, transport, test_case_id"
                 " FROM benchmarks_v2.results WHERE run_id = %s ORDER BY metric_value",
                 (run.id,),
             )
             rows = cur.fetchall()
-        assert rows == [("vapi-baseline-v1", "sip", "TC1", 2), ("pinned", None, None, None)]
+        assert rows == [("vapi-baseline-v1", "sip", "TC1"), ("pinned", None, None)]
 
     asyncio.run(_run())
 


### PR DESCRIPTION
Schema only, nothing runs yet.

Orchestration platforms measure under the existing `S2S` benchmark, not one of their own — same metrics off the same recording, so the platform is a dimension of a row. `variant_id` is that dimension, NOT NULL defaulting to `pinned`, which is also the backfill since every existing row is Coval-pinned. `transport` and `test_case_id` are nullable and can't be reconstructed once a run stops being queryable, so this wants to land before the first row worth keeping. No `iteration` column — it falls out of `row_number() over (partition by run_id, variant_id, test_case_id order by created_at, id)`.

`mock_tool_calls` is the tool-call ground truth, indexed on `(simulation_id, created_at, id)` for the ingest join and `(caller_number, created_at)` for when a platform drops the `X-Coval-Simulation-Id` SIP header. The trailing `id` matters: `now()` is transaction start, so one transaction's calls share a `created_at`. Separate table because a tool call is an event with arguments and a response, not a numeric metric, and the rollups filter on `metric_value` being non-null.