### PR TITLE
Add Atlas TTS provider over the WebSocket API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -63,3 +63,4 @@ ZOOM_API_SECRET=
 # --- Azure AI Speech STT + TTS (subscription key + region of the Speech resource) ---
 # AZURE_API_KEY=
 # AZURE_REGION=eastus
+ATLAS_API_KEY=

--- a/runner/src/coval_bench/config.py
+++ b/runner/src/coval_bench/config.py
@@ -89,6 +89,7 @@ class Settings(BaseSettings):
     # --- Provider API keys (all optional; loaded from Secret Manager at runtime) ---
     openai_api_key: SecretStr | None = None
     elevenlabs_api_key: SecretStr | None = None
+    atlas_api_key: SecretStr | None = None
     cartesia_api_key: SecretStr | None = None
     deepgram_api_key: SecretStr | None = None
     assemblyai_api_key: SecretStr | None = None

--- a/runner/src/coval_bench/providers/tts/__init__.py
+++ b/runner/src/coval_bench/providers/tts/__init__.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 from coval_bench.providers.base import TTSProvider
 from coval_bench.providers.tts.alibaba import AlibabaTTSProvider
+from coval_bench.providers.tts.atlas import AtlasTTSProvider
 from coval_bench.providers.tts.azure import AzureTTSProvider
 from coval_bench.providers.tts.baseten import BasetenTTSProvider
 from coval_bench.providers.tts.cartesia import CartesiaTTSProvider
@@ -55,6 +56,7 @@ except ImportError:
 
 TTS_PROVIDERS: dict[str, type[TTSProvider]] = {
     "openai": OpenAITTSProvider,
+    "atlas": AtlasTTSProvider,
     "cartesia": CartesiaTTSProvider,
     "elevenlabs": ElevenLabsTTSProvider,
     "gradium": GradiumTTSProvider,
@@ -90,6 +92,7 @@ __all__ = [
     "HUME_AVAILABLE",
     "GOOGLE_TTS_AVAILABLE",
     "AlibabaTTSProvider",
+    "AtlasTTSProvider",
     "AzureTTSProvider",
     "BasetenTTSProvider",
     "DeepdubTTSProvider",

--- a/runner/src/coval_bench/providers/tts/atlas.py
+++ b/runner/src/coval_bench/providers/tts/atlas.py
@@ -1,0 +1,205 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Atlas TTS provider — WebSocket streaming.
+
+TTFA is measured from the text submit to the first PCM frame; session setup
+(connect, the ``start`` frame, and the server's ``ready`` ack) stays out of the
+measurement, matching every other WebSocket TTS provider here. Minimax is the
+closest analogue: it waits for ``task_started`` before starting its clock, as
+this waits for ``ready``.
+
+Audio is requested as raw PCM. The container formats only complete at end of
+synthesis, so a first frame under ``wav`` would fold the whole synthesis into
+TTFA.
+
+Atlas is a gateway in front of a third-party synthesiser rather than a
+first-party model: on the HTTP surface it returns ``x-upstream-ms`` and a
+``server-timing`` breakdown attributing the bulk of each request to
+``upstream``, and its error envelope is typed ``proxy_error``. The upstream is
+undisclosed, so a row here may not be independent of another provider already on
+the board. That is why the registry entry is early-access, off the arena, and
+marked shared-inference; it belongs in the parity ledger beside the number.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from typing import Any
+
+import structlog
+import websockets.asyncio.client as ws_client
+
+from coval_bench.config import Settings
+from coval_bench.providers.base import TTSProvider, TTSResult
+from coval_bench.providers.tts._common import finalize_tts_result
+
+logger: structlog.BoundLogger = structlog.get_logger(__name__)
+
+HTTP_MODELS = {"atlas-tts"}
+
+# From GET /v1/models. All report owned_by "sabi"; none are per-account clones,
+# so the benchmarked voice is the same class of object as every other provider's
+# stock voice rather than something tuned for this key.
+VALID_VOICES = [
+    "capella",
+    "dax",
+    "enzo",
+    "sena",
+    "marlow",
+    "elin",
+    "corin",
+    "orin",
+    "isla",
+    "talia",
+    "serin",
+    "reeve",
+    "ember",
+    "maitri",
+]
+
+# Pinned per provider, as everywhere else in this package. Atlas declares a rate
+# on ``ready`` and ``audio.start``; that value is checked against this constant
+# and a mismatch is logged rather than silently honoured, so a vendor-side change
+# surfaces as a warning instead of quietly rescaling every duration and
+# leading-silence offset we publish.
+SAMPLE_RATE = 24000
+
+_WS_URL = "wss://api.tts.runatlas.com/v1/audio/speech/stream"
+_MAX_WS_SIZE = 16 * 1024 * 1024
+_LAST_FRAMES_KEPT = 3
+
+
+class AtlasTTSProvider(TTSProvider):
+    """Atlas TTS provider using the streaming WebSocket API (binary PCM frames)."""
+
+    _VALID_MODELS = frozenset(HTTP_MODELS)
+
+    def __init__(self, settings: Settings, model: str, voice: str) -> None:
+        if not self._model_supported(model):
+            raise ValueError(
+                f"Invalid Atlas TTS model {model!r}. Valid: {sorted(self._VALID_MODELS)}"
+            )
+        self._model = model
+        self._voice = voice
+
+        if self._voice not in VALID_VOICES:
+            logger.warning("unknown_atlas_voice", voice=self._voice, fallback="dax")
+            self._voice = "dax"
+
+        api_key_secret = settings.atlas_api_key
+        if api_key_secret is None or not api_key_secret.get_secret_value():
+            raise ValueError("atlas_api_key is required in Settings")
+        self._api_key = api_key_secret.get_secret_value()
+
+    @property
+    def name(self) -> str:
+        return f"atlas-{self._model}"
+
+    @property
+    def model(self) -> str:
+        return self._model
+
+    async def synthesize(self, text: str) -> TTSResult:
+        audio_chunks: list[bytes] = []
+        last_frames: list[str] = []
+        start: float | None = None
+        first_chunk_at: float | None = None
+        done = False
+
+        try:
+            async with ws_client.connect(
+                _WS_URL,
+                additional_headers={"Authorization": f"Bearer {self._api_key}"},
+                max_size=_MAX_WS_SIZE,
+            ) as ws:
+                await ws.send(
+                    json.dumps({"type": "start", "voice": self._voice, "response_format": "pcm"})
+                )
+
+                async for raw in ws:
+                    if isinstance(raw, (bytes, bytearray)):
+                        if raw:
+                            if first_chunk_at is None:
+                                first_chunk_at = time.monotonic()
+                            audio_chunks.append(bytes(raw))
+                        continue
+
+                    frame: dict[str, Any] = json.loads(raw)
+                    frame_type = frame.get("type")
+
+                    if frame_type == "error":
+                        raise RuntimeError(f"atlas error: {frame.get('message', frame)}")
+
+                    last_frames.append(raw)
+                    del last_frames[:-_LAST_FRAMES_KEPT]
+
+                    if frame_type == "ready":
+                        self._check_declared_rate(frame, frame_type)
+                        # t0 — immediately before the text submit, so connect, the
+                        # start frame and this ack all stay out of TTFA.
+                        start = time.monotonic()
+                        await ws.send(json.dumps({"type": "text", "text": text}))
+                        await ws.send(json.dumps({"type": "done"}))
+                    elif frame_type == "audio.start":
+                        self._check_declared_rate(frame, frame_type)
+                    elif frame_type == "audio.done":
+                        # audio.done carries a per-sentence error flag. Unchecked, a
+                        # partial clip would be scored against the full prompt and
+                        # read as a fast, fluent result.
+                        if frame.get("error"):
+                            index = frame.get("sentence_index")
+                            raise RuntimeError(f"atlas sentence {index} failed to synthesize")
+                    elif frame_type == "session.done":
+                        done = True
+                        break
+
+                if not done:
+                    raise RuntimeError("connection closed before the session.done frame")
+
+        except Exception as exc:
+            logger.warning("atlas_tts_error", provider="atlas", model=self._model, exc_info=exc)
+            return finalize_tts_result(
+                provider="atlas",
+                model=self._model,
+                voice=self._voice,
+                pcm=b"",
+                sample_rate=SAMPLE_RATE,
+                audio_synthesis_start=start,
+                first_audio_chunk_at=first_chunk_at,
+                last_frames=last_frames,
+                error=str(exc),
+            )
+
+        return finalize_tts_result(
+            provider="atlas",
+            model=self._model,
+            voice=self._voice,
+            pcm=b"".join(audio_chunks),
+            sample_rate=SAMPLE_RATE,
+            audio_synthesis_start=start,
+            first_audio_chunk_at=first_chunk_at,
+            last_frames=last_frames,
+        )
+
+    def _check_declared_rate(self, frame: dict[str, Any], frame_type: str | None) -> None:
+        """Warn when Atlas declares a rate other than the pinned one.
+
+        The declared value is deliberately not honoured: the rate is pinned per
+        provider here as it is for every other one, so a silent vendor-side change
+        would otherwise rescale published durations without anyone noticing.
+        """
+        declared = frame.get("sample_rate")
+        if isinstance(declared, bool) or not isinstance(declared, int):
+            return
+        if declared != SAMPLE_RATE:
+            logger.warning(
+                "atlas_sample_rate_mismatch",
+                provider="atlas",
+                model=self._model,
+                voice=self._voice,
+                frame=frame_type,
+                declared=declared,
+                pinned=SAMPLE_RATE,
+            )

--- a/runner/src/coval_bench/registries/models.py
+++ b/runner/src/coval_bench/registries/models.py
@@ -1148,6 +1148,27 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         region="us",
         status=_RETIRED,
     ),
+    # Atlas exposes no model id of its own: /v1/models returns voices, not models,
+    # and a model field in the request body is accepted and ignored, so "atlas-tts"
+    # is our name for the single synthesiser behind it. Early-access rather than
+    # active on purpose - Atlas is a gateway over an undisclosed third-party
+    # synthesiser (its server-timing attributes each request to "upstream", and
+    # its error envelope is typed "proxy_error"), so a row here may not be
+    # independent of another provider already on the board. Benchmark it, but do
+    # not publish it beside first-party models until the upstream is named.
+    RegisteredModel(
+        benchmark=_TTS,
+        provider="atlas",
+        model="atlas-tts",
+        voice="dax",
+        source=Source.SHARED_INFERENCE,
+        region="us",
+        status=_EARLY_ACCESS,
+        # Out of the voice arena: an arena entry needs a gendered voice pool, and
+        # pitting an undisclosed proxy against first-party models in a blind A/B
+        # would attribute the upstream's quality to Atlas.
+        arena_enabled=False,
+    ),
     #######
     # S2S #
     #######

--- a/runner/src/coval_bench/registries/provider_keys.py
+++ b/runner/src/coval_bench/registries/provider_keys.py
@@ -67,4 +67,5 @@ PROVIDER_ENV: dict[str, str] = {
     "hakim": "HAKIMAI_API_KEY",
     "fluxions": "FLUXIONS_API_KEY",
     "deepdub": "DEEPDUB_API_KEY",
+    "atlas": "ATLAS_API_KEY",
 }

--- a/runner/tests/providers/tts/conftest.py
+++ b/runner/tests/providers/tts/conftest.py
@@ -55,6 +55,7 @@ def fake_settings(tmp_path: Path) -> Settings:
         openai_api_key=SecretStr("sk-test-openai"),
         cartesia_api_key=SecretStr("test-cartesia-key"),
         elevenlabs_api_key=SecretStr("test-elevenlabs-key"),
+        atlas_api_key=SecretStr("test-atlas-key"),
         deepgram_api_key=SecretStr("test-deepgram-key"),
         hume_api_key=SecretStr("test-hume-key"),
         rime_api_key=SecretStr("test-rime-key"),

--- a/runner/tests/providers/tts/test_atlas.py
+++ b/runner/tests/providers/tts/test_atlas.py
@@ -1,0 +1,337 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the Atlas WebSocket streaming TTS provider.
+
+The interesting cases are not the happy path but the ways an Atlas row could be
+flattered: a TTFA clock that starts somewhere other than the text submit, leading
+silence hiding inside a bare arrival time, a partial clip scored against a full
+prompt, and a vendor-side sample-rate change rescaling every published duration.
+"""
+
+from __future__ import annotations
+
+import json
+import struct
+import wave
+from unittest.mock import patch
+
+import pytest
+
+from coval_bench.config import Settings
+from coval_bench.providers.tts.atlas import SAMPLE_RATE, VALID_VOICES, AtlasTTSProvider
+
+from .conftest import FakeWebSocket, make_pcm_bytes
+
+_MODEL = "atlas-tts"
+_VOICE = "dax"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _provider(fake_settings: Settings, voice: str = _VOICE) -> AtlasTTSProvider:
+    return AtlasTTSProvider(fake_settings, model=_MODEL, voice=voice)
+
+
+def _frame(frame_type: str, **fields: object) -> str:
+    return json.dumps({"type": frame_type, **fields})
+
+
+def _session(
+    audio: list[bytes],
+    *,
+    ready_rate: int | None = SAMPLE_RATE,
+    audio_done: dict[str, object] | None = None,
+    closed_early: bool = False,
+) -> list[str | bytes]:
+    """A well-formed Atlas session: ready -> audio.start -> pcm -> done."""
+    ready: dict[str, object] = {}
+    if ready_rate is not None:
+        ready["sample_rate"] = ready_rate
+    messages: list[str | bytes] = [
+        _frame("ready", **ready),
+        _frame("audio.start", sample_rate=ready_rate) if ready_rate else _frame("audio.start"),
+        *audio,
+        _frame("audio.done", **(audio_done or {})),
+    ]
+    if not closed_early:
+        messages.append(_frame("session.done"))
+    return messages
+
+
+def _silence(frames: int) -> bytes:
+    return struct.pack("<h", 0) * frames
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_atlas_happy_path(fake_settings: Settings) -> None:
+    provider = _provider(fake_settings)
+    ws = FakeWebSocket(_session([make_pcm_bytes()]))
+
+    with patch("websockets.asyncio.client.connect", return_value=ws):
+        result = await provider.synthesize("Hello world")
+
+    assert result.error is None
+    assert result.provider == "atlas"
+    assert result.model == _MODEL
+    assert result.voice == _VOICE
+    assert result.ttfa_ms is not None
+    assert result.audio_path is not None
+
+
+@pytest.mark.asyncio
+async def test_requests_pcm_and_the_configured_voice(fake_settings: Settings) -> None:
+    """Containers only complete at end of synthesis, so PCM is required for TTFA."""
+    provider = _provider(fake_settings)
+    ws = FakeWebSocket(_session([make_pcm_bytes()]))
+
+    with patch("websockets.asyncio.client.connect", return_value=ws):
+        await provider.synthesize("Hello world")
+
+    start = json.loads(ws.sent[0])
+    assert start["type"] == "start"
+    assert start["response_format"] == "pcm"
+    assert start["voice"] == _VOICE
+
+
+@pytest.mark.asyncio
+async def test_text_is_submitted_only_after_ready(fake_settings: Settings) -> None:
+    """The frame order the TTFA boundary depends on: start, then text on ready."""
+    provider = _provider(fake_settings)
+    ws = FakeWebSocket(_session([make_pcm_bytes()]))
+
+    with patch("websockets.asyncio.client.connect", return_value=ws):
+        await provider.synthesize("Hello world")
+
+    assert [json.loads(frame)["type"] for frame in ws.sent] == ["start", "text", "done"]
+
+
+# ---------------------------------------------------------------------------
+# TTFA boundary — parity with the other WebSocket TTS providers
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ttfa_excludes_session_setup(fake_settings: Settings) -> None:
+    """t0 is the text submit, so setup before ``ready`` cannot inflate TTFA.
+
+    Every WebSocket TTS provider here starts its clock immediately before the text
+    submit - minimax waits for ``task_started``, elevenlabs sends its setup frame
+    first - so connect, the ``start`` frame and the ``ready`` ack all stay out.
+    Five seconds burned during setup must therefore not reach TTFA.
+    """
+    provider = _provider(fake_settings)
+    ws = FakeWebSocket(_session([make_pcm_bytes()]))
+    clock = {"t": 1000.0}
+    original_send = ws.send
+
+    async def send(data: str | bytes) -> None:
+        if isinstance(data, str) and json.loads(data).get("type") == "start":
+            clock["t"] += 5.0
+        await original_send(data)
+
+    ws.send = send  # type: ignore[method-assign]
+
+    with (
+        patch("websockets.asyncio.client.connect", return_value=ws),
+        patch("coval_bench.providers.tts.atlas.time.monotonic", lambda: clock["t"]),
+    ):
+        result = await provider.synthesize("Hello world")
+
+    assert result.ttfa_ms is not None
+    assert result.ttfa_ms < 5000.0
+
+
+@pytest.mark.asyncio
+async def test_leading_silence_is_split_out_not_swallowed(fake_settings: Settings) -> None:
+    """An instant chunk of silence is the cheapest way to win a TTFA benchmark."""
+    provider = _provider(fake_settings)
+    ws = FakeWebSocket(_session([_silence(SAMPLE_RATE // 10) + make_pcm_bytes()]))
+
+    with patch("websockets.asyncio.client.connect", return_value=ws):
+        result = await provider.synthesize("Hello world")
+
+    # The detector uses a 10 ms RMS window, so the reported onset is the start of
+    # the frame straddling the boundary - up to one frame early, never late.
+    assert result.leading_silence_ms is not None
+    assert 90.0 <= result.leading_silence_ms <= 100.0
+    assert result.ttfa_ms is not None
+    assert result.ttfa_ms >= result.leading_silence_ms
+
+
+@pytest.mark.asyncio
+async def test_all_silence_is_a_failure_not_a_fast_ttfa(fake_settings: Settings) -> None:
+    provider = _provider(fake_settings)
+    ws = FakeWebSocket(_session([_silence(SAMPLE_RATE // 2)]))
+
+    with patch("websockets.asyncio.client.connect", return_value=ws):
+        result = await provider.synthesize("Hello world")
+
+    assert result.error is not None
+    assert result.ttfa_ms is None
+
+
+# ---------------------------------------------------------------------------
+# Sample rate — pinned per provider, mismatch surfaced
+# ---------------------------------------------------------------------------
+
+
+def test_sample_rate_is_pinned() -> None:
+    """Pinned per provider as everywhere else in this package; 24 kHz measured."""
+    assert SAMPLE_RATE == 24000
+
+
+@pytest.mark.asyncio
+async def test_declared_rate_mismatch_does_not_rescale(fake_settings: Settings) -> None:
+    """A vendor-side rate change must surface, not silently rescale durations."""
+    provider = _provider(fake_settings)
+    ws = FakeWebSocket(_session([make_pcm_bytes()], ready_rate=48000))
+
+    with patch("websockets.asyncio.client.connect", return_value=ws):
+        result = await provider.synthesize("Hello world")
+
+    assert result.error is None
+    assert result.audio_path is not None
+    # The WAV is written at the pinned rate regardless of what Atlas declared.
+    with wave.open(str(result.audio_path)) as handle:
+        assert handle.getframerate() == SAMPLE_RATE
+
+
+@pytest.mark.asyncio
+async def test_missing_declared_rate_is_tolerated(fake_settings: Settings) -> None:
+    provider = _provider(fake_settings)
+    ws = FakeWebSocket(_session([make_pcm_bytes()], ready_rate=None))
+
+    with patch("websockets.asyncio.client.connect", return_value=ws):
+        result = await provider.synthesize("Hello world")
+
+    assert result.error is None
+    assert result.ttfa_ms is not None
+
+
+# ---------------------------------------------------------------------------
+# Failure modes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_per_sentence_error_flag_fails_the_result(fake_settings: Settings) -> None:
+    """A truncated clip must not be scored against the full prompt."""
+    provider = _provider(fake_settings)
+    ws = FakeWebSocket(
+        _session([make_pcm_bytes()], audio_done={"error": True, "sentence_index": 2})
+    )
+
+    with patch("websockets.asyncio.client.connect", return_value=ws):
+        result = await provider.synthesize("Hello world")
+
+    assert result.error is not None
+    assert "sentence 2" in result.error
+
+
+@pytest.mark.asyncio
+async def test_error_frame_fails_the_result(fake_settings: Settings) -> None:
+    provider = _provider(fake_settings)
+    ws = FakeWebSocket([_frame("ready", sample_rate=SAMPLE_RATE), _frame("error", message="boom")])
+
+    with patch("websockets.asyncio.client.connect", return_value=ws):
+        result = await provider.synthesize("Hello world")
+
+    assert result.error is not None
+    assert "boom" in result.error
+
+
+@pytest.mark.asyncio
+async def test_stream_closed_before_session_done_fails(fake_settings: Settings) -> None:
+    """Silent truncation would otherwise score a partial clip as a success."""
+    provider = _provider(fake_settings)
+    ws = FakeWebSocket(_session([make_pcm_bytes()], closed_early=True))
+
+    with patch("websockets.asyncio.client.connect", return_value=ws):
+        result = await provider.synthesize("Hello world")
+
+    assert result.error is not None
+    assert "session.done" in result.error
+
+
+@pytest.mark.asyncio
+async def test_unknown_frames_are_ignored(fake_settings: Settings) -> None:
+    provider = _provider(fake_settings)
+    messages = _session([make_pcm_bytes()])
+    messages.insert(1, _frame("some.future.frame", detail="ignored"))
+    ws = FakeWebSocket(messages)
+
+    with patch("websockets.asyncio.client.connect", return_value=ws):
+        result = await provider.synthesize("Hello world")
+
+    assert result.error is None
+    assert result.ttfa_ms is not None
+
+
+# ---------------------------------------------------------------------------
+# Construction and registration
+# ---------------------------------------------------------------------------
+
+
+def test_dax_is_a_listed_voice() -> None:
+    """``dax`` is a stock voice from /v1/models, not a per-account clone."""
+    assert "dax" in VALID_VOICES
+
+
+def test_valid_voices_match_the_published_list() -> None:
+    assert VALID_VOICES[:3] == ["capella", "dax", "enzo"]
+    assert len(VALID_VOICES) == 14
+
+
+@pytest.mark.asyncio
+async def test_unknown_voice_falls_back_to_dax(fake_settings: Settings) -> None:
+    assert _provider(fake_settings, voice="not-a-voice")._voice == "dax"
+
+
+def test_invalid_model_is_rejected(fake_settings: Settings) -> None:
+    with pytest.raises(ValueError, match="Invalid Atlas TTS model"):
+        AtlasTTSProvider(fake_settings, model="not-a-model", voice=_VOICE)
+
+
+def test_missing_key_is_rejected() -> None:
+    settings = Settings(
+        database_url="postgresql://runner:password@localhost:5432/benchmarks",
+        dataset_bucket="test-bucket",
+        atlas_api_key=None,
+    )
+    with pytest.raises(ValueError, match="atlas_api_key"):
+        AtlasTTSProvider(settings, model=_MODEL, voice=_VOICE)
+
+
+def test_registry_entry_is_early_access_off_arena_and_shared_inference() -> None:
+    """Atlas proxies an undisclosed upstream, so it is not published as first-party.
+
+    Pinned as a test because these three fields are the only thing keeping a
+    possibly non-independent row off the public board and out of the blind
+    voice-quality A/B.
+    """
+    from coval_bench.registries import MODEL_REGISTRY
+    from coval_bench.registries.models import ModelStatus, Source
+
+    rows = [m for m in MODEL_REGISTRY if m.provider == "atlas"]
+    assert len(rows) == 1
+    assert rows[0].model == _MODEL
+    assert rows[0].voice == _VOICE
+    assert rows[0].status is ModelStatus.EARLY_ACCESS
+    assert rows[0].source is Source.SHARED_INFERENCE
+    assert rows[0].arena_enabled is False
+
+
+def test_atlas_has_a_provider_env_entry() -> None:
+    """Without this, promoting Atlas to ACTIVE breaks the arena key parity check."""
+    from coval_bench.registries.provider_keys import PROVIDER_ENV
+
+    assert PROVIDER_ENV["atlas"] == "ATLAS_API_KEY"


### PR DESCRIPTION
Adds Atlas as a TTS provider over its streaming WebSocket
Four consecutive live runs, same sentence, same voice:

| arrival | leading silence | perceived TTFA |
|--------:|----------------:|---------------:|
| 166.5 | 479.0 | 645.5 |
| 159.8 | 585.0 | 744.8 |
| 163.2 | 380.0 | 543.2 |
| 161.0 | 600.0 | 761.0 |
| **median 162.1** | **median 532.0** | **median 695.2** |

`PROVIDER_ENV` gains an `atlas` entry so promoting to `ACTIVE` is a one-line status change rather than a `check_arena_keys.py` failure to debug.