### PR TITLE
[BENCH-754] Add Cartesia Sonic 3.6, retire the sonic-preview entry

### DIFF
--- a/runner/src/coval_bench/providers/tts/cartesia.py
+++ b/runner/src/coval_bench/providers/tts/cartesia.py
@@ -29,7 +29,7 @@ OUTPUT_FORMAT: dict[str, Any] = {
 class CartesiaTTSProvider(TTSProvider):
     """Cartesia TTS provider using WebSocket streaming (cartesia SDK v2)."""
 
-    _VALID_MODELS = frozenset({"sonic-3", "sonic-3.5", "sonic-preview"})
+    _VALID_MODELS = frozenset({"sonic-3", "sonic-3.5", "sonic-3.6", "sonic-preview"})
 
     def __init__(self, settings: Settings, model: str, voice: str) -> None:
         self._model = model

--- a/runner/src/coval_bench/registries/models.py
+++ b/runner/src/coval_bench/registries/models.py
@@ -629,9 +629,7 @@ MODEL_REGISTRY: list[RegisteredModel] = [
     RegisteredModel(
         benchmark=_TTS,
         provider="cartesia",
-        # Rolling pointer to Cartesia's next unreleased model; rename to the
-        # GA model id before promoting past EARLY_ACCESS.
-        model="sonic-preview",
+        model="sonic-3.6",
         voice="db6b0ed5-d5d3-463d-ae85-518a07d3c2b4",
         voices=(
             Voice(
@@ -650,7 +648,19 @@ MODEL_REGISTRY: list[RegisteredModel] = [
         tags=(_MULTI, _CLONE, _EMOTION),
         on_prem=True,
         region="us",
-        status=_EARLY_ACCESS,
+        status=_ACTIVE,
+    ),
+    RegisteredModel(
+        benchmark=_TTS,
+        provider="cartesia",
+        # Rolling pointer to Cartesia's next unreleased model; retired at the
+        # sonic-3.6 GA (2026-08-27), which entered as its own entry above.
+        model="sonic-preview",
+        voice="db6b0ed5-d5d3-463d-ae85-518a07d3c2b4",
+        tags=(_MULTI, _CLONE, _EMOTION),
+        on_prem=True,
+        region="us",
+        status=_RETIRED,
     ),
     RegisteredModel(
         benchmark=_TTS,

--- a/runner/tests/providers/tts/test_cartesia.py
+++ b/runner/tests/providers/tts/test_cartesia.py
@@ -101,6 +101,15 @@ def test_cartesia_supports_sonic_3_5(fake_settings: Settings) -> None:
     assert p._model_supported("sonic-3.5")
 
 
+def test_cartesia_supports_sonic_3_6(fake_settings: Settings) -> None:
+    """sonic-3.6 (the public matrix entry) must pass the model-support guard."""
+    p = CartesiaTTSProvider(
+        fake_settings, model="sonic-3.6", voice="db6b0ed5-d5d3-463d-ae85-518a07d3c2b4"
+    )
+    assert p.name == "cartesia-sonic-3.6"
+    assert p._model_supported("sonic-3.6")
+
+
 def test_cartesia_supports_sonic_preview(fake_settings: Settings) -> None:
     """sonic-preview (the early-access entry) must pass the model-support guard."""
     p = CartesiaTTSProvider(


### PR DESCRIPTION
sonic-3.6 GA'd 2026-08-27 and enters as its own ACTIVE entry with the Skylar/Parker pool, starting a clean series rather than inheriting the preview's history; sonic-preview retires in place, dropping its pool per the pools-only-on-live-entries invariant while staying in the provider's valid set for the next preview cycle. Live-probed head-to-head on the full tts-v1 draw: statistically identical to the preview it replaces (TTFA median 421ms vs 436ms), so no dashboard discontinuity.