### PR TITLE
[BENCH-757] Demote per-persona sample degradations to warnings

### DIFF
--- a/runner/src/coval_bench/s2s/samples.py
+++ b/runner/src/coval_bench/s2s/samples.py
@@ -364,7 +364,7 @@ async def _publish_one_bucket(
     pool: list[tuple[str, str]] = []
     for persona_id, model_runs in runs_by_persona.items():
         if set(model_runs) != expected:
-            logger.error(
+            logger.warning(
                 "samples_persona_incomplete",
                 persona=persona_id,
                 missing=model_labels(expected - set(model_runs)),
@@ -380,7 +380,7 @@ async def _publish_one_bucket(
                     list_sims, provider=provider, what="sims_list"
                 )
             except Exception:
-                logger.error(
+                logger.warning(
                     "samples_provider_missing",
                     missing=model_labels({(provider, model)}),
                     exc_info=True,


### PR DESCRIPTION
samples_persona_incomplete and the per-persona samples_provider_missing fire the S2S Sample Failure pager even when the day's sample still publishes from another persona. The log metric behind the alert requires severity>=ERROR, so logging these at warning stops the false pages. Terminal conditions (samples_bucket_provider_absent, samples_no_shared_clip, samples_bucket_failed, and the window-level samples_provider_missing in fetch_v2v.py) stay ERROR and keep paging.