### PR TITLE
[BENCH-727] Open model pricing registry served on GET /v1/pricing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,29 @@
 # Contributing
 
 Contributions are welcome. Please open an issue first to discuss significant changes. All code must pass `ruff`, `mypy --strict`, and `pytest` before merging. By submitting a pull request you agree your contribution is licensed under Apache-2.0.
+
+## Updating your model's price
+
+The prices shown on [benchmarks.coval.ai](https://benchmarks.coval.ai) live in this repo, one JSON file per provider per benchmark under [`runner/src/coval_bench/registries/pricing/data/<benchmark>/`](runner/src/coval_bench/registries/pricing/data/) (`tts/`, `stt/`). Providers are encouraged to keep their own rates current:
+
+1. Edit (or add) `<benchmark>/<your-provider>.json` — the file may only contain entries for your own provider on that benchmark, keyed by the same `(benchmark, provider, model)` as [`registries/models.py`](runner/src/coval_bench/registries/models.py):
+
+   ```json
+   [
+     {
+       "benchmark": "STT",
+       "provider": "deepgram",
+       "model": "nova-3",
+       "unit": "per_minute",
+       "price_usd": "0.0048",
+       "effective_from": "2026-08-24",
+       "source_url": "https://deepgram.com/pricing",
+       "notes": "Pay As You Go streaming rate."
+     }
+   ]
+   ```
+
+2. Use your *native* published unit — characters for TTS (`per_1m_chars`, `per_1k_chars`, `per_char`, `per_second_audio_out`), duration of input audio for STT (`per_minute`, `per_hour`, `per_second_audio_in`). The API normalizes server-side to the figure the site shows: $ per 1M characters for TTS, $ per 1,000 minutes for STT — never across the two, which would take an assumed speaking rate. Write `price_usd` as a string so the decimal is exact. `source_url` must point at your public pricing page, and `effective_from` is the date the rate took effect. For STT, use the rate of the tier we benchmark: streaming/real-time pay-as-you-go, and say so in `notes`.
+3. Open a PR. CI validates the schema and that every entry matches a registered model; a model without a pricing entry simply shows no price on the site — never submit an estimated rate.
+
+The new price appears on the site with the next deploy — no code change needed.

--- a/runner/src/coval_bench/__main__.py
+++ b/runner/src/coval_bench/__main__.py
@@ -19,6 +19,7 @@ import click
 
 from coval_bench import __version__
 from coval_bench.db.cli import db_check, db_migrate
+from coval_bench.db.pricing_log import pricing_sync
 from coval_bench.migrations.backfill_wer_breakdown import backfill_wer_breakdown_cli
 from coval_bench.migrations.import_legacy import import_legacy_cli
 from coval_bench.s2s.fetch_v2v import fetch_s2s
@@ -96,6 +97,14 @@ def migrate() -> None:
 
 migrate.add_command(backfill_wer_breakdown_cli, name="backfill-wer-breakdown")
 migrate.add_command(import_legacy_cli, name="import-legacy")
+
+
+@cli.group()
+def pricing() -> None:
+    """Pricing registry commands."""
+
+
+pricing.add_command(pricing_sync, name="sync")
 
 # S2S is fetch-only, so a standalone command rather than a `run --kind` value.
 cli.add_command(fetch_s2s, name="fetch-s2s")

--- a/runner/src/coval_bench/api/app.py
+++ b/runner/src/coval_bench/api/app.py
@@ -48,6 +48,7 @@ from coval_bench.api.routers import (
     arena,
     health,
     leaderboard,
+    pricing,
     providers,
     results,
     robots,
@@ -173,6 +174,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     app.include_router(leaderboard.router, prefix="/v1")
     app.include_router(providers.router, prefix="/v1")
     app.include_router(tags.router, prefix="/v1")
+    app.include_router(pricing.router, prefix="/v1")
     app.include_router(s2s_samples.router, prefix="/v1")
     app.include_router(arena.router, prefix="/v1")
     app.include_router(admin_models.router, prefix="/v1")

--- a/runner/src/coval_bench/api/routers/pricing.py
+++ b/runner/src/coval_bench/api/routers/pricing.py
@@ -1,0 +1,84 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""GET /v1/pricing — the packaged pricing registry, served for the public page.
+
+The response carries every rate in force today plus the packaged datasets'
+usage (minutes of audio in, characters spoken), so a client can turn a rate
+into a benchmark-pass cost by pure arithmetic. Rates change by pull request
+against the JSON ratesheets (see CONTRIBUTING.md), never at runtime, and a
+rate whose ``effective_from`` is still ahead prices nothing until that day.
+
+Visibility follows the model registry: a rate serves only while the site
+shows its model. RETIRED and PENDING models are hidden from everyone — a
+unit test keeps the shipped ratesheets free of them, and this filter covers
+the window where a status flips before its ratesheet catches up — and
+EARLY_ACCESS models are hidden unless the caller's bearer token clears them,
+the same embargo every other data endpoint applies. No DB hit is made by
+this endpoint.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+from fastapi import APIRouter, Depends
+from starlette.requests import Request
+
+from coval_bench.api.internal import hidden_early_access
+from coval_bench.api.ratelimit import limiter
+from coval_bench.api.schemas import DatasetUsageOut, PricingRateOut, PricingRegistryResponse
+from coval_bench.datasets.usage import dataset_usage
+from coval_bench.registries import MODEL_REGISTRY, Benchmark, ModelStatus
+from coval_bench.registries.pricing import PRICING, PricingEntry
+
+router = APIRouter(tags=["pricing"])
+
+# Statuses the site does not list at all, mirroring the providers router's
+# hidden set. Unlike the per-caller EA embargo, no proof reveals these.
+_UNLISTED_STATUSES = frozenset({ModelStatus.RETIRED, ModelStatus.PENDING})
+
+
+def _unlisted_keys() -> frozenset[tuple[Benchmark, str, str]]:
+    return frozenset(
+        (m.benchmark, m.provider, m.model) for m in MODEL_REGISTRY if m.status in _UNLISTED_STATUSES
+    )
+
+
+def _rate_out(entry: PricingEntry) -> PricingRateOut:
+    per_chars = entry.price_per_1m_chars
+    per_minutes = entry.price_per_1k_minutes
+    return PricingRateOut(
+        benchmark=entry.benchmark,
+        provider=entry.provider,
+        model=entry.model,
+        unit=entry.unit,
+        price_usd=entry.price_usd,
+        price_per_1m_chars=float(per_chars) if per_chars is not None else None,
+        price_per_1k_minutes=float(per_minutes) if per_minutes is not None else None,
+        effective_from=entry.effective_from,
+        source_url=str(entry.source_url),
+        notes=entry.notes,
+    )
+
+
+@router.get("/pricing", response_model=PricingRegistryResponse)
+@limiter.limit("60/minute")
+async def get_pricing_registry(
+    request: Request,
+    hidden: frozenset[tuple[str, str]] = Depends(hidden_early_access),
+) -> PricingRegistryResponse:
+    """Return every rate in force today plus per-dataset usage figures."""
+    today = date.today()
+    unlisted = _unlisted_keys()
+    return PricingRegistryResponse(
+        as_of=today,
+        rates=[
+            _rate_out(entry)
+            for key, entry in sorted(PRICING.items())
+            if entry.effective_from <= today
+            and key not in unlisted
+            and (key[1], key[2]) not in hidden
+        ],
+        usage=[DatasetUsageOut.model_validate(u, from_attributes=True) for u in dataset_usage()],
+    )

--- a/runner/src/coval_bench/api/schemas.py
+++ b/runner/src/coval_bench/api/schemas.py
@@ -11,7 +11,8 @@ added later if needed.
 from __future__ import annotations
 
 import uuid
-from datetime import datetime
+from datetime import date, datetime
+from decimal import Decimal
 from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field
@@ -120,6 +121,50 @@ class ProvidersResponse(BaseModel):
     s2s: list[ProviderInfo]
     # Facet vocabulary in display order, shared across STT, TTS, and S2S.
     tag_categories: list[TagCategoryOut]
+
+
+class PricingRateOut(BaseModel):
+    """One model's rate as recorded in the pricing registry.
+
+    ``price_usd`` is the provider's native figure in ``unit``, served as the
+    registry's exact decimal (a JSON string — floats would strip trailing
+    zeros and misquote the printed price, e.g. $0.20 → $0.2); the two
+    normalized fields are exact arithmetic from it and ``None`` where no
+    conversion exists without assuming a speaking rate.
+    """
+
+    benchmark: BenchmarkLiteral
+    provider: str
+    model: str
+    unit: str
+    price_usd: Decimal
+    price_per_1m_chars: float | None = None
+    price_per_1k_minutes: float | None = None
+    effective_from: date
+    source_url: str
+    notes: str | None = None
+
+
+class DatasetUsageOut(BaseModel):
+    """What one full pass of a packaged dataset consumes, from its manifest.
+
+    Exactly one of ``audio_minutes``/``characters`` is set: STT datasets are
+    billed on audio in, TTS datasets on characters spoken.
+    """
+
+    dataset_id: str
+    benchmark: BenchmarkLiteral
+    items: int
+    audio_minutes: float | None = None
+    characters: int | None = None
+
+
+class PricingRegistryResponse(BaseModel):
+    """Response schema for GET /v1/pricing: rates in force plus fixture usage."""
+
+    as_of: date
+    rates: list[PricingRateOut]
+    usage: list[DatasetUsageOut]
 
 
 class ResultsResponse(BaseModel):

--- a/runner/src/coval_bench/datasets/usage.py
+++ b/runner/src/coval_bench/datasets/usage.py
@@ -1,0 +1,67 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+"""What one pass of a dataset consumes, read straight from its packaged manifest.
+
+A rate is only half of a cost. The other half is usage, and the manifests
+already pin it exactly: the audio an STT dataset feeds a model, and the
+characters a TTS dataset asks it to speak. Both are SHA-pinned and identical
+for every model, which is what makes a cost comparison between two models fair
+— and neither is estimated, so nothing here assumes a speaking rate.
+"""
+
+from __future__ import annotations
+
+from functools import cache
+from importlib.resources import files
+
+from pydantic import BaseModel
+
+from coval_bench.datasets.loader import _load_manifest
+from coval_bench.datasets.manifest import STTManifestItem
+from coval_bench.registries.benchmarks import Benchmark
+
+
+class DatasetUsage(BaseModel, frozen=True):
+    """One full pass of a dataset, in the units providers bill in."""
+
+    dataset_id: str
+    benchmark: Benchmark
+    items: int
+    # Exactly one is populated: STT datasets are audio, TTS datasets are text.
+    audio_minutes: float | None = None
+    characters: int | None = None
+
+
+def _usage_of(dataset_id: str) -> DatasetUsage:
+    items = _load_manifest(dataset_id).items
+    benchmark = (
+        Benchmark.S2S
+        if dataset_id.startswith("s2s")
+        else Benchmark.STT
+        if dataset_id.startswith("stt")
+        else Benchmark.TTS
+    )
+    if items and isinstance(items[0], STTManifestItem):
+        seconds = sum(i.duration_sec for i in items if isinstance(i, STTManifestItem))
+        return DatasetUsage(
+            dataset_id=dataset_id,
+            benchmark=benchmark,
+            items=len(items),
+            audio_minutes=seconds / 60,
+        )
+    return DatasetUsage(
+        dataset_id=dataset_id,
+        benchmark=benchmark,
+        items=len(items),
+        characters=sum(len(i.transcript) for i in items),
+    )
+
+
+@cache
+def dataset_usage() -> tuple[DatasetUsage, ...]:
+    """Usage for every packaged dataset, by id. Manifests are immutable, so cache."""
+    manifests = files("coval_bench.datasets.manifests")
+    ids = sorted(
+        r.name.removesuffix(".json") for r in manifests.iterdir() if r.name.endswith(".json")
+    )
+    return tuple(_usage_of(dataset_id) for dataset_id in ids)

--- a/runner/src/coval_bench/db/migrations/versions/20260826_0022_pricing_rates.py
+++ b/runner/src/coval_bench/db/migrations/versions/20260826_0022_pricing_rates.py
@@ -1,0 +1,70 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+# ruff: noqa: E501  # Embedded SQL is formatted as executable migration text.
+
+"""Pricing rate change-log: pricing_rates.
+
+Revision ID: 20260826_0022
+Revises:     20260825_0021
+Create Date: 2026-08-26
+
+Append-only record of every published rate the pricing registry has carried,
+so cost is trackable over time rather than a snapshot. ``coval-bench pricing
+sync`` records the packaged ratesheets into it and is idempotent: the unique
+key makes re-recording an unchanged registry a no-op, while a new price or a
+new effective date appends. Notes/source edits alone do not re-record — this
+tracks prices, not prose.
+
+No FK to ``models``: like ``model_history``, history must outlive anything it
+references. No seed migration: the first sync run is the seed, and stays the
+ongoing mechanism.
+
+Notes
+-----
+DB roles (``runner``, ``api``) and GRANTs are managed by Terraform. The sync
+runs inside the runner job, so the ``runner`` role needs SELECT and INSERT.
+Nothing is ever updated or deleted.
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "20260826_0022"
+down_revision = "20260825_0021"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Create the pricing rate change-log."""
+    op.execute(
+        """
+        CREATE TABLE benchmarks_v2.pricing_rates (
+            id             BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+            benchmark      TEXT NOT NULL CHECK (benchmark IN ('STT', 'TTS', 'S2S')),
+            provider       TEXT NOT NULL CHECK (provider <> ''),
+            model          TEXT NOT NULL CHECK (model <> ''),
+            unit           TEXT NOT NULL CHECK (unit <> ''),
+            -- NUMERIC keeps the registry's printed scale: 0.20 stays 0.20,
+            -- never 0.2 — the same exact-decimal contract /v1/pricing serves.
+            price_usd      NUMERIC NOT NULL CHECK (price_usd > 0),
+            effective_from DATE NOT NULL,
+            source_url     TEXT NOT NULL CHECK (source_url <> ''),
+            notes          TEXT CHECK (notes IS NULL OR notes <> ''),
+            recorded_by    TEXT NOT NULL CHECK (recorded_by <> ''),
+            recorded_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+            -- One row per distinct rate. A price revert carries a new
+            -- effective_from (the day it took effect again), so round trips
+            -- still append; only a byte-identical rate is skipped.
+            UNIQUE (benchmark, provider, model, unit, price_usd, effective_from)
+        );
+        CREATE INDEX pricing_rates_key_recorded_at
+            ON benchmarks_v2.pricing_rates (benchmark, provider, model, recorded_at DESC);
+        """
+    )
+
+
+def downgrade() -> None:
+    """Drop the pricing rate change-log."""
+    op.execute("DROP TABLE IF EXISTS benchmarks_v2.pricing_rates;")

--- a/runner/src/coval_bench/db/pricing_log.py
+++ b/runner/src/coval_bench/db/pricing_log.py
@@ -1,0 +1,61 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Record the packaged pricing registry into the ``pricing_rates`` change-log.
+
+The registry files are the source of truth for what a model costs today; this
+log is how cost stays trackable over time. Each sync inserts every packaged
+rate and lets the table's unique key drop the ones already recorded, so an
+unchanged registry is a no-op and a rate change (new price or new effective
+date) appends exactly one row. Append-only: nothing here updates or deletes.
+"""
+
+from __future__ import annotations
+
+import click
+import psycopg
+
+from coval_bench.registries.pricing import PRICING
+
+_INSERT_SQL = """
+    INSERT INTO benchmarks_v2.pricing_rates
+        (benchmark, provider, model, unit, price_usd, effective_from,
+         source_url, notes, recorded_by)
+    VALUES
+        (%(benchmark)s, %(provider)s, %(model)s, %(unit)s, %(price_usd)s,
+         %(effective_from)s, %(source_url)s, %(notes)s, %(recorded_by)s)
+    ON CONFLICT (benchmark, provider, model, unit, price_usd, effective_from)
+        DO NOTHING
+"""
+
+
+def sync_pricing_log(conn: psycopg.Connection, recorded_by: str = "pricing-sync") -> int:
+    """Append every packaged rate not already recorded; return the rows added."""
+    inserted = 0
+    for entry in (PRICING[key] for key in sorted(PRICING)):
+        cursor = conn.execute(
+            _INSERT_SQL,
+            {
+                "benchmark": entry.benchmark.value,
+                "provider": entry.provider,
+                "model": entry.model,
+                "unit": str(entry.unit),
+                "price_usd": entry.price_usd,
+                "effective_from": entry.effective_from,
+                "source_url": str(entry.source_url),
+                "notes": entry.notes,
+                "recorded_by": recorded_by,
+            },
+        )
+        inserted += cursor.rowcount
+    return inserted
+
+
+@click.command(name="sync")
+def pricing_sync() -> None:
+    """Record the packaged ratesheets into the pricing_rates change-log."""
+    from coval_bench.config import get_settings
+
+    with psycopg.connect(str(get_settings().database_url)) as conn:
+        inserted = sync_pricing_log(conn)
+    click.echo(f"pricing sync: {inserted} new rate(s) recorded")

--- a/runner/src/coval_bench/registries/pricing/__init__.py
+++ b/runner/src/coval_bench/registries/pricing/__init__.py
@@ -1,0 +1,8 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+"""Open, provider-editable pricing registry. See CONTRIBUTING.md to update a rate."""
+
+from coval_bench.registries.pricing.loader import PRICING, index_pricing
+from coval_bench.registries.pricing.schema import PricingEntry, PricingUnit
+
+__all__ = ["PRICING", "PricingEntry", "PricingUnit", "index_pricing"]

--- a/runner/src/coval_bench/registries/pricing/data/stt/assemblyai.json
+++ b/runner/src/coval_bench/registries/pricing/data/stt/assemblyai.json
@@ -1,0 +1,22 @@
+[
+  {
+    "benchmark": "STT",
+    "provider": "assemblyai",
+    "model": "universal-streaming",
+    "unit": "per_hour",
+    "price_usd": "0.15",
+    "effective_from": "2026-08-24",
+    "source_url": "https://www.assemblyai.com/pricing",
+    "notes": "Pay-as-you-go Universal-Streaming rate (English and Multilingual both $0.15/hr); AssemblyAI bills streaming on session duration, not audio duration."
+  },
+  {
+    "benchmark": "STT",
+    "provider": "assemblyai",
+    "model": "universal-3.5-pro",
+    "unit": "per_hour",
+    "price_usd": "0.45",
+    "effective_from": "2026-08-24",
+    "source_url": "https://www.assemblyai.com/pricing",
+    "notes": "Pay-as-you-go Universal-3.5 Pro Realtime base streaming rate — the endpoint we benchmark; the async pre-recorded tier is $0.21/hr."
+  }
+]

--- a/runner/src/coval_bench/registries/pricing/data/stt/cartesia.json
+++ b/runner/src/coval_bench/registries/pricing/data/stt/cartesia.json
@@ -1,0 +1,12 @@
+[
+  {
+    "benchmark": "STT",
+    "provider": "cartesia",
+    "model": "ink-2",
+    "unit": "per_hour",
+    "price_usd": "0.39",
+    "effective_from": "2026-08-24",
+    "source_url": "https://www.cartesia.ai/pricing",
+    "notes": "Scale plan rate as printed ('one hour of audio is only $0.39'); billing is credit-based at 3 credits per second of audio, and cheaper tiers work out higher per hour. No standalone pay-as-you-go tier."
+  }
+]

--- a/runner/src/coval_bench/registries/pricing/data/stt/deepgram.json
+++ b/runner/src/coval_bench/registries/pricing/data/stt/deepgram.json
@@ -1,0 +1,32 @@
+[
+  {
+    "benchmark": "STT",
+    "provider": "deepgram",
+    "model": "nova-3",
+    "unit": "per_minute",
+    "price_usd": "0.0048",
+    "effective_from": "2026-08-24",
+    "source_url": "https://deepgram.com/pricing",
+    "notes": "Pay As You Go monolingual (English) streaming rate, listed as a limited-time promotional price; regular price $0.0077/min. Multilingual streaming is $0.0058/min (regular $0.0092)."
+  },
+  {
+    "benchmark": "STT",
+    "provider": "deepgram",
+    "model": "flux-general-en",
+    "unit": "per_minute",
+    "price_usd": "0.0065",
+    "effective_from": "2026-08-24",
+    "source_url": "https://deepgram.com/pricing",
+    "notes": "Pay As You Go streaming rate, listed as a limited-time promotional price; regular price $0.0077/min."
+  },
+  {
+    "benchmark": "STT",
+    "provider": "deepgram",
+    "model": "flux-general-multi",
+    "unit": "per_minute",
+    "price_usd": "0.0078",
+    "effective_from": "2026-08-24",
+    "source_url": "https://deepgram.com/pricing",
+    "notes": "Pay As You Go streaming rate."
+  }
+]

--- a/runner/src/coval_bench/registries/pricing/data/stt/elevenlabs.json
+++ b/runner/src/coval_bench/registries/pricing/data/stt/elevenlabs.json
@@ -1,0 +1,12 @@
+[
+  {
+    "benchmark": "STT",
+    "provider": "elevenlabs",
+    "model": "scribe_v2_realtime",
+    "unit": "per_hour",
+    "price_usd": "0.39",
+    "effective_from": "2026-08-24",
+    "source_url": "https://elevenlabs.io/pricing/api",
+    "notes": "Pay-as-you-go API rate for Scribe v2 Realtime; subscription tiers change only the included hours, not the rate."
+  }
+]

--- a/runner/src/coval_bench/registries/pricing/data/stt/gladia.json
+++ b/runner/src/coval_bench/registries/pricing/data/stt/gladia.json
@@ -1,0 +1,12 @@
+[
+  {
+    "benchmark": "STT",
+    "provider": "gladia",
+    "model": "solaria-1",
+    "unit": "per_hour",
+    "price_usd": "0.75",
+    "effective_from": "2026-08-24",
+    "source_url": "https://www.gladia.io/pricing",
+    "notes": "Starter pay-as-you-go real-time rate; Gladia prices real-time generically and Solaria is its real-time model."
+  }
+]

--- a/runner/src/coval_bench/registries/pricing/data/stt/google.json
+++ b/runner/src/coval_bench/registries/pricing/data/stt/google.json
@@ -1,0 +1,22 @@
+[
+  {
+    "benchmark": "STT",
+    "provider": "google",
+    "model": "chirp_2",
+    "unit": "per_minute",
+    "price_usd": "0.016",
+    "effective_from": "2026-08-24",
+    "source_url": "https://cloud.google.com/speech-to-text/pricing",
+    "notes": "Speech-to-Text V2 Recognition standard rate, first volume tier (0-500k min/month); V2 prices all standard models, Chirp included, at this one rate. Volume tiers drop to $0.004/min above 2M."
+  },
+  {
+    "benchmark": "STT",
+    "provider": "google",
+    "model": "chirp_3",
+    "unit": "per_minute",
+    "price_usd": "0.016",
+    "effective_from": "2026-08-24",
+    "source_url": "https://cloud.google.com/speech-to-text/pricing",
+    "notes": "Speech-to-Text V2 Recognition standard rate, first volume tier (0-500k min/month); same single V2 SKU as chirp_2."
+  }
+]

--- a/runner/src/coval_bench/registries/pricing/data/stt/gradium.json
+++ b/runner/src/coval_bench/registries/pricing/data/stt/gradium.json
@@ -1,0 +1,12 @@
+[
+  {
+    "benchmark": "STT",
+    "provider": "gradium",
+    "model": "default",
+    "unit": "per_second_audio_in",
+    "price_usd": "0.000207",
+    "effective_from": "2026-08-24",
+    "source_url": "https://gradium.ai/pricing",
+    "notes": "Entry (XS) plan add-on credit rate: 3 credits per second of audio at $6.9 per 100k credits, exact conversion; larger plans publish lower credit rates. No standalone pay-as-you-go tier."
+  }
+]

--- a/runner/src/coval_bench/registries/pricing/data/stt/inworld.json
+++ b/runner/src/coval_bench/registries/pricing/data/stt/inworld.json
@@ -1,0 +1,12 @@
+[
+  {
+    "benchmark": "STT",
+    "provider": "inworld",
+    "model": "inworld-stt-1",
+    "unit": "per_hour",
+    "price_usd": "0.15",
+    "effective_from": "2026-08-24",
+    "source_url": "https://inworld.ai/pricing",
+    "notes": "On-Demand pay-as-you-go base rate; paid subscription tiers discount to $0.10/hr."
+  }
+]

--- a/runner/src/coval_bench/registries/pricing/data/stt/mistral.json
+++ b/runner/src/coval_bench/registries/pricing/data/stt/mistral.json
@@ -1,0 +1,12 @@
+[
+  {
+    "benchmark": "STT",
+    "provider": "mistral",
+    "model": "voxtral-mini-transcribe-realtime-2602",
+    "unit": "per_minute",
+    "price_usd": "0.006",
+    "effective_from": "2026-08-24",
+    "source_url": "https://mistral.ai/pricing/api",
+    "notes": "La Plateforme pay-as-you-go audio-input rate for Voxtral Mini Transcribe Realtime; the batch Transcribe tier is $0.003/min."
+  }
+]

--- a/runner/src/coval_bench/registries/pricing/data/stt/openai.json
+++ b/runner/src/coval_bench/registries/pricing/data/stt/openai.json
@@ -1,0 +1,32 @@
+[
+  {
+    "benchmark": "STT",
+    "provider": "openai",
+    "model": "gpt-4o-mini-transcribe",
+    "unit": "per_minute",
+    "price_usd": "0.003",
+    "effective_from": "2026-08-24",
+    "source_url": "https://developers.openai.com/api/docs/pricing",
+    "notes": "OpenAI's published estimated per-minute cost; underlying token rates are $1.25/1M input tokens and $5.00/1M output tokens."
+  },
+  {
+    "benchmark": "STT",
+    "provider": "openai",
+    "model": "gpt-4o-transcribe",
+    "unit": "per_minute",
+    "price_usd": "0.006",
+    "effective_from": "2026-08-24",
+    "source_url": "https://developers.openai.com/api/docs/pricing",
+    "notes": "OpenAI's published estimated per-minute cost; underlying token rates are $2.50/1M input tokens and $10.00/1M output tokens."
+  },
+  {
+    "benchmark": "STT",
+    "provider": "openai",
+    "model": "gpt-realtime-whisper",
+    "unit": "per_minute",
+    "price_usd": "0.017",
+    "effective_from": "2026-08-24",
+    "source_url": "https://developers.openai.com/api/docs/pricing",
+    "notes": "Published per-minute live-transcription rate; OpenAI lists no token pricing for this model."
+  }
+]

--- a/runner/src/coval_bench/registries/pricing/data/stt/smallest.json
+++ b/runner/src/coval_bench/registries/pricing/data/stt/smallest.json
@@ -1,0 +1,12 @@
+[
+  {
+    "benchmark": "STT",
+    "provider": "smallest",
+    "model": "pulse",
+    "unit": "per_minute",
+    "price_usd": "0.008",
+    "effective_from": "2026-08-24",
+    "source_url": "https://docs.smallest.ai/models/model-cards/speech-to-text/pulse",
+    "notes": "Standard Plan realtime rate from the official Pulse model card; batch is $0.005/min. Marketing pages print only approximate figures."
+  }
+]

--- a/runner/src/coval_bench/registries/pricing/data/stt/soniox.json
+++ b/runner/src/coval_bench/registries/pricing/data/stt/soniox.json
@@ -1,0 +1,12 @@
+[
+  {
+    "benchmark": "STT",
+    "provider": "soniox",
+    "model": "stt-rt-v5",
+    "unit": "per_hour",
+    "price_usd": "0.12",
+    "effective_from": "2026-08-24",
+    "source_url": "https://soniox.com/pricing",
+    "notes": "Soniox's page-printed per-hour equivalent for real-time streaming; canonical billing is $2.00 per 1M input audio tokens (~30,000 tokens per hour of audio)."
+  }
+]

--- a/runner/src/coval_bench/registries/pricing/data/stt/speechmatics.json
+++ b/runner/src/coval_bench/registries/pricing/data/stt/speechmatics.json
@@ -1,0 +1,22 @@
+[
+  {
+    "benchmark": "STT",
+    "provider": "speechmatics",
+    "model": "default",
+    "unit": "per_hour",
+    "price_usd": "0.24",
+    "effective_from": "2026-08-24",
+    "source_url": "https://www.speechmatics.com/pricing",
+    "notes": "Pro pay-as-you-go rate for real-time transcription, Standard operating point."
+  },
+  {
+    "benchmark": "STT",
+    "provider": "speechmatics",
+    "model": "enhanced",
+    "unit": "per_hour",
+    "price_usd": "0.43",
+    "effective_from": "2026-08-24",
+    "source_url": "https://www.speechmatics.com/pricing",
+    "notes": "Pro pay-as-you-go rate for real-time transcription, Enhanced operating point."
+  }
+]

--- a/runner/src/coval_bench/registries/pricing/data/stt/together.json
+++ b/runner/src/coval_bench/registries/pricing/data/stt/together.json
@@ -1,0 +1,32 @@
+[
+  {
+    "benchmark": "STT",
+    "provider": "together",
+    "model": "nemotron-3.5-asr-streaming-0.6b",
+    "unit": "per_minute",
+    "price_usd": "0.0045",
+    "effective_from": "2026-08-24",
+    "source_url": "https://www.together.ai/models/nvidia-nemotron-35-asr",
+    "notes": "Serverless pay-as-you-go per-audio-minute rate; the model page prints this price against the API string nvidia/nemotron-3.5-asr-streaming-0.6b (the pricing page's 'NVIDIA Nemotron 3.5 ASR' row). Not the older 'Nemotron 3 ASR Streaming 0.6B' row at $0.0015/min."
+  },
+  {
+    "benchmark": "STT",
+    "provider": "together",
+    "model": "parakeet-tdt-0.6b-v3",
+    "unit": "per_minute",
+    "price_usd": "0.0015",
+    "effective_from": "2026-08-24",
+    "source_url": "https://www.together.ai/pricing",
+    "notes": "Serverless pay-as-you-go per-audio-minute rate for NVIDIA Parakeet TDT 0.6B v3."
+  },
+  {
+    "benchmark": "STT",
+    "provider": "together",
+    "model": "whisper-large-v3",
+    "unit": "per_minute",
+    "price_usd": "0.0035",
+    "effective_from": "2026-08-24",
+    "source_url": "https://www.together.ai/pricing",
+    "notes": "Whisper Large v3 (Streaming) rate — we benchmark over Together's realtime API; the non-streaming Transcribe tier is $0.0015/min."
+  }
+]

--- a/runner/src/coval_bench/registries/pricing/data/stt/xai.json
+++ b/runner/src/coval_bench/registries/pricing/data/stt/xai.json
@@ -1,0 +1,12 @@
+[
+  {
+    "benchmark": "STT",
+    "provider": "xai",
+    "model": "grok-stt",
+    "unit": "per_hour",
+    "price_usd": "0.20",
+    "effective_from": "2026-08-24",
+    "source_url": "https://docs.x.ai/developers/pricing",
+    "notes": "Streaming speech-to-text rate — the endpoint we benchmark; the REST tier is $0.10/hr. Published as a generic Speech to Text row, not by model id."
+  }
+]

--- a/runner/src/coval_bench/registries/pricing/data/tts/alibaba.json
+++ b/runner/src/coval_bench/registries/pricing/data/tts/alibaba.json
@@ -1,0 +1,12 @@
+[
+  {
+    "benchmark": "TTS",
+    "provider": "alibaba",
+    "model": "qwen3-tts-flash-realtime",
+    "unit": "per_1m_chars",
+    "price_usd": "13",
+    "effective_from": "2026-08-10",
+    "source_url": "https://www.alibabacloud.com/help/en/model-studio/model-pricing",
+    "notes": "International deployment, published as $0.13 per 10k input characters (output free); exact conversion."
+  }
+]

--- a/runner/src/coval_bench/registries/pricing/data/tts/azure.json
+++ b/runner/src/coval_bench/registries/pricing/data/tts/azure.json
@@ -1,0 +1,22 @@
+[
+  {
+    "benchmark": "TTS",
+    "provider": "azure",
+    "model": "neural",
+    "unit": "per_1m_chars",
+    "price_usd": "15",
+    "effective_from": "2026-08-10",
+    "source_url": "https://azure.microsoft.com/en-us/pricing/details/cognitive-services/speech-services/",
+    "notes": "Pay-as-you-go standard neural voice rate (US regions); commitment tiers are cheaper."
+  },
+  {
+    "benchmark": "TTS",
+    "provider": "azure",
+    "model": "dragon-hd-latest",
+    "unit": "per_1m_chars",
+    "price_usd": "22",
+    "effective_from": "2026-08-10",
+    "source_url": "https://azure.microsoft.com/en-us/pricing/details/cognitive-services/speech-services/",
+    "notes": "Pay-as-you-go Neural HD rate in East US; HD voices are region-limited."
+  }
+]

--- a/runner/src/coval_bench/registries/pricing/data/tts/cartesia.json
+++ b/runner/src/coval_bench/registries/pricing/data/tts/cartesia.json
@@ -1,0 +1,12 @@
+[
+  {
+    "benchmark": "TTS",
+    "provider": "cartesia",
+    "model": "sonic-3.5",
+    "unit": "per_1m_chars",
+    "price_usd": "65",
+    "effective_from": "2026-08-10",
+    "source_url": "https://cartesia.ai/pricing",
+    "notes": "Entry paid (Pro) overage rate; 1 credit = 1 character, $65 per 1M credits. Higher tiers publish lower rates. The page's FAQ carries the rate; its TTS model is now labeled Sonic-3.6, same per-credit price."
+  }
+]

--- a/runner/src/coval_bench/registries/pricing/data/tts/deepgram.json
+++ b/runner/src/coval_bench/registries/pricing/data/tts/deepgram.json
@@ -1,0 +1,12 @@
+[
+  {
+    "benchmark": "TTS",
+    "provider": "deepgram",
+    "model": "aura-2-thalia-en",
+    "unit": "per_1k_chars",
+    "price_usd": "0.030",
+    "effective_from": "2026-08-10",
+    "source_url": "https://deepgram.com/pricing",
+    "notes": "Aura-2 Pay As You Go rate."
+  }
+]

--- a/runner/src/coval_bench/registries/pricing/data/tts/elevenlabs.json
+++ b/runner/src/coval_bench/registries/pricing/data/tts/elevenlabs.json
@@ -1,0 +1,12 @@
+[
+  {
+    "benchmark": "TTS",
+    "provider": "elevenlabs",
+    "model": "eleven_flash_v2_5",
+    "unit": "per_1k_chars",
+    "price_usd": "0.05",
+    "effective_from": "2026-08-10",
+    "source_url": "https://elevenlabs.io/pricing/api",
+    "notes": "API pricing 'Flash / Turbo' row; same rate across tiers."
+  }
+]

--- a/runner/src/coval_bench/registries/pricing/data/tts/fluxions.json
+++ b/runner/src/coval_bench/registries/pricing/data/tts/fluxions.json
@@ -1,0 +1,12 @@
+[
+  {
+    "benchmark": "TTS",
+    "provider": "fluxions",
+    "model": "vui",
+    "unit": "per_1m_chars",
+    "price_usd": "10",
+    "effective_from": "2026-08-10",
+    "source_url": "https://fluxions.ai/pricing",
+    "notes": "Pay-as-you-go rate for expressive VUI text-to-speech."
+  }
+]

--- a/runner/src/coval_bench/registries/pricing/data/tts/google.json
+++ b/runner/src/coval_bench/registries/pricing/data/tts/google.json
@@ -1,0 +1,12 @@
+[
+  {
+    "benchmark": "TTS",
+    "provider": "google",
+    "model": "chirp-3-hd",
+    "unit": "per_1m_chars",
+    "price_usd": "30",
+    "effective_from": "2026-08-10",
+    "source_url": "https://cloud.google.com/text-to-speech/pricing",
+    "notes": "Pay-as-you-go rate for Chirp 3: HD voices, billed per character sent for synthesis."
+  }
+]

--- a/runner/src/coval_bench/registries/pricing/data/tts/gradium.json
+++ b/runner/src/coval_bench/registries/pricing/data/tts/gradium.json
@@ -1,0 +1,12 @@
+[
+  {
+    "benchmark": "TTS",
+    "provider": "gradium",
+    "model": "default",
+    "unit": "per_1m_chars",
+    "price_usd": "69",
+    "effective_from": "2026-08-10",
+    "source_url": "https://gradium.ai/pricing",
+    "notes": "Entry (XS) plan add-on credit rate, 1 credit = 1 character; larger plans publish lower rates. No standalone pay-as-you-go tier."
+  }
+]

--- a/runner/src/coval_bench/registries/pricing/data/tts/inworld.json
+++ b/runner/src/coval_bench/registries/pricing/data/tts/inworld.json
@@ -1,0 +1,22 @@
+[
+  {
+    "benchmark": "TTS",
+    "provider": "inworld",
+    "model": "inworld-tts-2",
+    "unit": "per_1m_chars",
+    "price_usd": "25",
+    "effective_from": "2026-08-10",
+    "source_url": "https://inworld.ai/pricing",
+    "notes": "On-demand (pay-as-you-go) rate; subscription plans publish lower rates."
+  },
+  {
+    "benchmark": "TTS",
+    "provider": "inworld",
+    "model": "inworld-tts-2-flash",
+    "unit": "per_1m_chars",
+    "price_usd": "15",
+    "effective_from": "2026-08-24",
+    "source_url": "https://inworld.ai/pricing",
+    "notes": "On-demand (pay-as-you-go) rate; subscription plans publish lower rates. TTS 1.5 Max/Mini are no longer published on the page, so the retired models carry no rate."
+  }
+]

--- a/runner/src/coval_bench/registries/pricing/data/tts/lmnt.json
+++ b/runner/src/coval_bench/registries/pricing/data/tts/lmnt.json
@@ -1,0 +1,12 @@
+[
+  {
+    "benchmark": "TTS",
+    "provider": "lmnt",
+    "model": "blizzard",
+    "unit": "per_1k_chars",
+    "price_usd": "0.05",
+    "effective_from": "2026-08-10",
+    "source_url": "https://www.lmnt.com/pricing",
+    "notes": "Overage rate past the entry Indie plan's included characters; plan-based, not per-model."
+  }
+]

--- a/runner/src/coval_bench/registries/pricing/data/tts/minimax.json
+++ b/runner/src/coval_bench/registries/pricing/data/tts/minimax.json
@@ -1,0 +1,22 @@
+[
+  {
+    "benchmark": "TTS",
+    "provider": "minimax",
+    "model": "speech-2.8-hd",
+    "unit": "per_1m_chars",
+    "price_usd": "100",
+    "effective_from": "2026-08-10",
+    "source_url": "https://platform.minimax.io/docs/guides/pricing-paygo.md",
+    "notes": "International-platform pay-as-you-go rate."
+  },
+  {
+    "benchmark": "TTS",
+    "provider": "minimax",
+    "model": "speech-2.8-turbo",
+    "unit": "per_1m_chars",
+    "price_usd": "60",
+    "effective_from": "2026-08-10",
+    "source_url": "https://platform.minimax.io/docs/guides/pricing-paygo.md",
+    "notes": "International-platform pay-as-you-go rate."
+  }
+]

--- a/runner/src/coval_bench/registries/pricing/data/tts/palabra.json
+++ b/runner/src/coval_bench/registries/pricing/data/tts/palabra.json
@@ -1,0 +1,12 @@
+[
+  {
+    "benchmark": "TTS",
+    "provider": "palabra",
+    "model": "palabra-tts-v1",
+    "unit": "per_1k_chars",
+    "price_usd": "0.03",
+    "effective_from": "2026-08-10",
+    "source_url": "https://www.palabra.ai/pricing",
+    "notes": "TTS API pay-as-you-go rate."
+  }
+]

--- a/runner/src/coval_bench/registries/pricing/data/tts/rime.json
+++ b/runner/src/coval_bench/registries/pricing/data/tts/rime.json
@@ -1,0 +1,22 @@
+[
+  {
+    "benchmark": "TTS",
+    "provider": "rime",
+    "model": "coda",
+    "unit": "per_1k_chars",
+    "price_usd": "0.05",
+    "effective_from": "2026-08-10",
+    "source_url": "https://www.rime.ai/pricing",
+    "notes": "Pay-as-you-go Starter rate. Arcana has no published rate and is deliberately absent."
+  },
+  {
+    "benchmark": "TTS",
+    "provider": "rime",
+    "model": "mistv3",
+    "unit": "per_1k_chars",
+    "price_usd": "0.03",
+    "effective_from": "2026-08-10",
+    "source_url": "https://www.rime.ai/pricing",
+    "notes": "Pay-as-you-go Starter rate."
+  }
+]

--- a/runner/src/coval_bench/registries/pricing/data/tts/speechify.json
+++ b/runner/src/coval_bench/registries/pricing/data/tts/speechify.json
@@ -1,0 +1,22 @@
+[
+  {
+    "benchmark": "TTS",
+    "provider": "speechify",
+    "model": "simba-3.2",
+    "unit": "per_1m_chars",
+    "price_usd": "10",
+    "effective_from": "2026-08-10",
+    "source_url": "https://speechify.ai/pricing",
+    "notes": "Entry (Starter) plan rate; no per-model rate variation, larger plans publish lower rates."
+  },
+  {
+    "benchmark": "TTS",
+    "provider": "speechify",
+    "model": "simba-3.0",
+    "unit": "per_1m_chars",
+    "price_usd": "10",
+    "effective_from": "2026-08-10",
+    "source_url": "https://speechify.ai/pricing",
+    "notes": "Entry (Starter) plan rate; no per-model rate variation, larger plans publish lower rates."
+  }
+]

--- a/runner/src/coval_bench/registries/pricing/data/tts/xai.json
+++ b/runner/src/coval_bench/registries/pricing/data/tts/xai.json
@@ -1,0 +1,12 @@
+[
+  {
+    "benchmark": "TTS",
+    "provider": "xai",
+    "model": "grok-tts",
+    "unit": "per_1m_chars",
+    "price_usd": "15",
+    "effective_from": "2026-08-10",
+    "source_url": "https://docs.x.ai/developers/pricing",
+    "notes": "Voice pricing 'Text to Speech' rate; xAI prices the service, not model variants."
+  }
+]

--- a/runner/src/coval_bench/registries/pricing/loader.py
+++ b/runner/src/coval_bench/registries/pricing/loader.py
@@ -1,0 +1,74 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+"""Loader for the pricing registry: per-provider JSON, validated on import.
+
+Files ship inside the wheel under ``pricing/data/<benchmark>/<provider>.json``
+and are loaded via ``importlib.resources``, mirroring the dataset manifests. A
+file may only price its own provider's models on its own benchmark, every entry
+must match a ``MODEL_REGISTRY`` row, and duplicate ``(benchmark, provider,
+model)`` keys raise — all at import time, so a bad PR can never reach the API. Missing
+pricing for a model is fine: it renders as absent, never $0.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from importlib.resources import files
+
+from pydantic import TypeAdapter
+
+from coval_bench.registries.benchmarks import Benchmark
+from coval_bench.registries.models import MODEL_REGISTRY
+from coval_bench.registries.pricing.schema import PricingEntry
+
+_ENTRIES = TypeAdapter(list[PricingEntry])
+
+
+def _load_entries() -> list[PricingEntry]:
+    root = files("coval_bench.registries.pricing") / "data"
+    entries: list[PricingEntry] = []
+    for bench_dir in sorted(root.iterdir(), key=lambda r: r.name):
+        if not bench_dir.is_dir():
+            continue
+        benchmark = Benchmark(bench_dir.name.upper())
+        for resource in sorted(bench_dir.iterdir(), key=lambda r: r.name):
+            if not resource.name.endswith(".json"):
+                continue
+            provider = resource.name.removesuffix(".json")
+            loaded = _ENTRIES.validate_json(resource.read_bytes())
+            strays = sorted(
+                f"{e.benchmark}:{e.provider}"
+                for e in loaded
+                if e.provider != provider or e.benchmark is not benchmark
+            )
+            if strays:
+                raise RuntimeError(
+                    f"pricing/data/{bench_dir.name}/{resource.name} prices entries "
+                    f"belonging elsewhere: {', '.join(strays)}"
+                )
+            entries.extend(loaded)
+    return entries
+
+
+def index_pricing(
+    entries: list[PricingEntry],
+) -> dict[tuple[Benchmark, str, str], PricingEntry]:
+    """Index entries by registry key, rejecting duplicates and unknown models."""
+    key_counts = Counter((e.benchmark, e.provider, e.model) for e in entries)
+    dupes = sorted(f"{b}:{p}/{m}" for (b, p, m), n in key_counts.items() if n > 1)
+    if dupes:
+        raise RuntimeError(f"pricing registry contains duplicate entries: {', '.join(dupes)}")
+    registered = {(m.benchmark, m.provider, m.model) for m in MODEL_REGISTRY}
+    unknown = sorted(
+        f"{e.benchmark}:{e.provider}/{e.model}"
+        for e in entries
+        if (e.benchmark, e.provider, e.model) not in registered
+    )
+    if unknown:
+        raise RuntimeError(
+            f"pricing registry entries match no MODEL_REGISTRY row: {', '.join(unknown)}"
+        )
+    return {(e.benchmark, e.provider, e.model): e for e in entries}
+
+
+PRICING: dict[tuple[Benchmark, str, str], PricingEntry] = index_pricing(_load_entries())

--- a/runner/src/coval_bench/registries/pricing/schema.py
+++ b/runner/src/coval_bench/registries/pricing/schema.py
@@ -1,0 +1,85 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+"""Schema for the provider-editable pricing registry.
+
+Entries live in per-provider JSON files under ``pricing/data/<benchmark>/``
+and carry the provider's *native* published unit; normalization to the two
+figures the API serves ($ per 1M characters for TTS, $ per 1,000 minutes for
+STT) happens here, never in the files.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+from enum import StrEnum
+
+from pydantic import BaseModel, Field, HttpUrl
+
+from coval_bench.registries.benchmarks import Benchmark
+
+
+class PricingUnit(StrEnum):
+    """The native unit a provider publishes its rate in.
+
+    Character units bill TTS input, duration units bill STT input. Both
+    normalize by exact arithmetic within their own denominator; nothing
+    converts across the two, which would take an assumed speaking rate.
+    """
+
+    PER_1M_CHARS = "per_1m_chars"
+    PER_1K_CHARS = "per_1k_chars"
+    PER_CHAR = "per_char"
+    PER_SECOND_AUDIO_OUT = "per_second_audio_out"
+    PER_MINUTE = "per_minute"
+    PER_HOUR = "per_hour"
+    PER_SECOND_AUDIO_IN = "per_second_audio_in"
+
+
+class PricingEntry(BaseModel, frozen=True, extra="forbid"):
+    """One model's published rate, keyed like the model registry."""
+
+    benchmark: Benchmark
+    provider: str
+    model: str
+    unit: PricingUnit
+    price_usd: Decimal = Field(gt=0)
+    effective_from: date
+    source_url: HttpUrl
+    notes: str | None = None
+
+    @property
+    def price_per_1m_chars(self) -> Decimal | None:
+        """The native rate normalized to USD per 1M characters.
+
+        Pure arithmetic per unit — ``per_1m_chars`` is served as-is,
+        ``per_1k_chars`` scales by 1000, ``per_char`` by 1,000,000.
+        ``per_second_audio_out`` returns None: seconds of audio have no
+        character equivalence without assuming a speaking rate, and we never
+        serve estimated figures.
+        """
+        if self.unit is PricingUnit.PER_1M_CHARS:
+            return self.price_usd
+        if self.unit is PricingUnit.PER_1K_CHARS:
+            return self.price_usd * 1000
+        if self.unit is PricingUnit.PER_CHAR:
+            return self.price_usd * 1_000_000
+        return None
+
+    @property
+    def price_per_1k_minutes(self) -> Decimal | None:
+        """The native rate normalized to USD per 1,000 minutes of input audio.
+
+        Defined only for the duration units that bill audio *in*.
+        ``per_second_audio_out`` measures synthesized output against a
+        different denominator, and character units have no duration
+        equivalence without assuming a speaking rate — both return None
+        rather than an estimate.
+        """
+        if self.unit is PricingUnit.PER_MINUTE:
+            return self.price_usd * 1000
+        if self.unit is PricingUnit.PER_HOUR:
+            return self.price_usd * 1000 / 60
+        if self.unit is PricingUnit.PER_SECOND_AUDIO_IN:
+            return self.price_usd * 60_000
+        return None

--- a/runner/tests/api/test_pricing.py
+++ b/runner/tests/api/test_pricing.py
@@ -1,0 +1,154 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""GET /v1/pricing: packaged rates, manifest usage, and model-visibility rules."""
+
+from __future__ import annotations
+
+import json
+from datetime import date, timedelta
+from decimal import Decimal
+from importlib.resources import files
+from typing import Any
+
+import pytest
+from httpx import AsyncClient
+
+from coval_bench.registries import MODEL_REGISTRY, Benchmark, ModelStatus, RegisteredModel
+from coval_bench.registries.pricing import PRICING, PricingEntry
+from tests.api.conftest import EA_MODEL, EA_ORG, EA_PROVIDER, bearer
+
+
+def _entry(**overrides: Any) -> PricingEntry:
+    fields: dict[str, Any] = {
+        "benchmark": Benchmark.STT,
+        "provider": EA_PROVIDER,
+        "model": EA_MODEL,
+        "unit": "per_minute",
+        "price_usd": Decimal("0.006"),
+        "effective_from": date.today(),
+        "source_url": "https://acme.example.com/pricing",
+    }
+    fields.update(overrides)
+    return PricingEntry(**fields)
+
+
+def _patch_registry(
+    monkeypatch: pytest.MonkeyPatch, entry: PricingEntry, status: ModelStatus
+) -> None:
+    """Extend the model registry with a model of the given status and price it."""
+    patched = [
+        *MODEL_REGISTRY,
+        RegisteredModel(
+            benchmark=entry.benchmark,
+            provider=entry.provider,
+            model=entry.model,
+            status=status,
+        ),
+    ]
+    for module in ("internal", "routers.providers", "routers.pricing"):
+        monkeypatch.setattr(f"coval_bench.api.{module}.MODEL_REGISTRY", patched)
+    priced = {**PRICING, (entry.benchmark, entry.provider, entry.model): entry}
+    monkeypatch.setattr("coval_bench.api.routers.pricing.PRICING", priced)
+
+
+def _listed_keys() -> set[tuple[str, str, str]]:
+    """The packaged rates the public read serves: everything on a listed model."""
+    unlisted = {
+        (m.benchmark, m.provider, m.model)
+        for m in MODEL_REGISTRY
+        if m.status in (ModelStatus.RETIRED, ModelStatus.PENDING)
+    }
+    return {(b.value, p, m) for b, p, m in PRICING if (b, p, m) not in unlisted}
+
+
+def _rates_by_key(payload: dict[str, Any]) -> dict[tuple[str, str, str], dict[str, Any]]:
+    return {(r["benchmark"], r["provider"], r["model"]): r for r in payload["rates"]}
+
+
+async def test_get_serves_packaged_rates_and_manifest_usage(client: AsyncClient) -> None:
+    """The public read is the packaged registry plus usage recomputed here."""
+    response = await client.get("/v1/pricing")
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["as_of"] == date.today().isoformat()
+    keys = set(_rates_by_key(payload))
+    assert keys == _listed_keys()
+
+    usage = {u["dataset_id"]: u for u in payload["usage"]}
+    manifest = json.loads(
+        (files("coval_bench.datasets.manifests") / "tts-v1.json").read_text("utf-8")
+    )
+    assert usage["tts-v1"]["benchmark"] == "TTS"
+    assert usage["tts-v1"]["items"] == len(manifest["items"])
+    assert usage["tts-v1"]["characters"] == sum(len(i["transcript"]) for i in manifest["items"])
+    assert usage["tts-v1"]["audio_minutes"] is None
+    assert usage["stt-v3"]["audio_minutes"] is not None
+    assert usage["stt-v3"]["characters"] is None
+
+
+async def test_price_usd_is_the_exact_decimal_string(client: AsyncClient) -> None:
+    """The native figure round-trips verbatim — a float would misquote $0.20 as $0.2."""
+    response = await client.get("/v1/pricing")
+    served = _rates_by_key(response.json())
+    for key in _listed_keys():
+        entry = PRICING[(Benchmark(key[0]), key[1], key[2])]
+        assert served[key]["price_usd"] == str(entry.price_usd)
+
+
+async def test_future_rate_is_scheduled_not_current(
+    client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A rate dated tomorrow is in the registry but prices nothing today."""
+    entry = _entry(effective_from=date.today() + timedelta(days=1))
+    _patch_registry(monkeypatch, entry, ModelStatus.ACTIVE)
+    response = await client.get("/v1/pricing", headers=bearer(org_id=EA_ORG))
+    assert ("STT", EA_PROVIDER, EA_MODEL) not in _rates_by_key(response.json())
+
+
+async def test_embargoed_rate_stays_hidden_from_public(
+    client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A rate on an EARLY_ACCESS model shows only to callers cleared for the model."""
+    _patch_registry(monkeypatch, _entry(), ModelStatus.EARLY_ACCESS)
+    key = ("STT", EA_PROVIDER, EA_MODEL)
+    public = await client.get("/v1/pricing")
+    assert key not in _rates_by_key(public.json())
+    assert public.headers["X-EA-Token-Status"] == "absent"
+    cleared = await client.get("/v1/pricing", headers=bearer(org_id=EA_ORG))
+    assert cleared.headers["X-EA-Token-Status"] == "accepted"
+    rate = _rates_by_key(cleared.json())[key]
+    assert rate["price_per_1k_minutes"] == 6.0
+    assert rate["price_per_1m_chars"] is None
+
+
+@pytest.mark.parametrize("status", [ModelStatus.RETIRED, ModelStatus.PENDING])
+async def test_unlisted_model_rate_serves_to_no_one(
+    client: AsyncClient, monkeypatch: pytest.MonkeyPatch, status: ModelStatus
+) -> None:
+    """A rate on a retired or pending model is hidden even from cleared callers.
+
+    The site hides these models everywhere; no bearer token re-lists them. The
+    ratesheet stays in the repo so the rate returns with the model.
+    """
+    _patch_registry(monkeypatch, _entry(), status)
+    key = ("STT", EA_PROVIDER, EA_MODEL)
+    assert key not in _rates_by_key((await client.get("/v1/pricing")).json())
+    cleared = await client.get("/v1/pricing", headers=bearer(org_id=EA_ORG))
+    assert key not in _rates_by_key(cleared.json())
+
+
+async def test_no_packaged_rate_prices_an_unlisted_or_unknown_model() -> None:
+    """Every shipped ratesheet entry belongs to a model the site currently lists.
+
+    Guards the data, not the route: a rate for a RETIRED or PENDING model would
+    silently serve to no one, which is either a stale ratesheet or a status
+    change that forgot its pricing. Delist deliberately or re-list the model.
+    """
+    by_key = {(m.benchmark, m.provider, m.model): m.status for m in MODEL_REGISTRY}
+    unlisted = sorted(
+        f"{b}:{p}/{m}"
+        for (b, p, m) in PRICING
+        if by_key[(b, p, m)] in (ModelStatus.RETIRED, ModelStatus.PENDING)
+    )
+    assert unlisted == [], f"ratesheets price unlisted models: {', '.join(unlisted)}"

--- a/runner/tests/api/test_pricing_log.py
+++ b/runner/tests/api/test_pricing_log.py
@@ -1,0 +1,97 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""The pricing_rates change-log: idempotent sync, appended changes, exact scale."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from datetime import date, timedelta
+from decimal import Decimal
+from typing import Any
+
+import psycopg
+import pytest
+
+from coval_bench.db.pricing_log import sync_pricing_log
+from coval_bench.registries.pricing import PRICING
+from tests.api.conftest import _make_db_url
+
+# Mirrors migration 20260826_0022, the way this conftest mirrors the matview
+# migrations.
+_TABLE_SQL = """
+    CREATE TABLE benchmarks_v2.pricing_rates (
+        id             BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+        benchmark      TEXT NOT NULL CHECK (benchmark IN ('STT', 'TTS', 'S2S')),
+        provider       TEXT NOT NULL CHECK (provider <> ''),
+        model          TEXT NOT NULL CHECK (model <> ''),
+        unit           TEXT NOT NULL CHECK (unit <> ''),
+        price_usd      NUMERIC NOT NULL CHECK (price_usd > 0),
+        effective_from DATE NOT NULL,
+        source_url     TEXT NOT NULL CHECK (source_url <> ''),
+        notes          TEXT CHECK (notes IS NULL OR notes <> ''),
+        recorded_by    TEXT NOT NULL CHECK (recorded_by <> ''),
+        recorded_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+        UNIQUE (benchmark, provider, model, unit, price_usd, effective_from)
+    );
+    CREATE INDEX pricing_rates_key_recorded_at
+        ON benchmarks_v2.pricing_rates (benchmark, provider, model, recorded_at DESC);
+"""
+
+
+@pytest.fixture
+def conn(postgresql: Any) -> Iterator[psycopg.Connection]:
+    with psycopg.connect(_make_db_url(postgresql), autocommit=True) as connection:
+        connection.execute(_TABLE_SQL)
+        yield connection
+
+
+def test_sync_records_every_packaged_rate_exactly_once(conn: psycopg.Connection) -> None:
+    """The first run seeds the log; re-syncing an unchanged registry is a no-op."""
+    assert sync_pricing_log(conn) == len(PRICING)
+    assert sync_pricing_log(conn) == 0
+    row = conn.execute("SELECT count(*) FROM benchmarks_v2.pricing_rates").fetchone()
+    assert row is not None and row[0] == len(PRICING)
+
+
+def test_rate_change_appends_without_rewriting_history(
+    conn: psycopg.Connection, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A new price with a new effective date lands one new row; the old row stays."""
+    sync_pricing_log(conn)
+    key = sorted(PRICING)[0]
+    old = PRICING[key]
+    changed = old.model_copy(
+        update={
+            "price_usd": old.price_usd + Decimal("0.001"),
+            "effective_from": date.today() + timedelta(days=1),
+        }
+    )
+    monkeypatch.setattr("coval_bench.db.pricing_log.PRICING", {**PRICING, key: changed})
+    assert sync_pricing_log(conn) == 1
+    rows = conn.execute(
+        """
+        SELECT price_usd, effective_from FROM benchmarks_v2.pricing_rates
+        WHERE benchmark = %s AND provider = %s AND model = %s
+        ORDER BY recorded_at, id
+        """,
+        (key[0].value, key[1], key[2]),
+    ).fetchall()
+    assert [r[0] for r in rows] == [old.price_usd, changed.price_usd]
+    assert rows[0][1] == old.effective_from
+
+
+def test_price_scale_survives_verbatim(conn: psycopg.Connection) -> None:
+    """NUMERIC keeps the printed decimal: $0.20 must never become $0.2."""
+    sync_pricing_log(conn)
+    trailing_zero = [key for key in PRICING if str(PRICING[key].price_usd).endswith("0")]
+    assert trailing_zero, "registry should carry at least one trailing-zero rate"
+    for key in trailing_zero:
+        row = conn.execute(
+            """
+            SELECT price_usd::text FROM benchmarks_v2.pricing_rates
+            WHERE benchmark = %s AND provider = %s AND model = %s
+            """,
+            (key[0].value, key[1], key[2]),
+        ).fetchone()
+        assert row is not None and row[0] == str(PRICING[key].price_usd)

--- a/runner/tests/unit/test_pricing_registry.py
+++ b/runner/tests/unit/test_pricing_registry.py
@@ -1,0 +1,111 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Pricing registry: schema validation, normalization, and MODEL_REGISTRY parity."""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+import pytest
+from pydantic import ValidationError
+
+from coval_bench.registries.benchmarks import Benchmark
+from coval_bench.registries.models import MODEL_REGISTRY
+from coval_bench.registries.pricing import PRICING, PricingEntry, PricingUnit, index_pricing
+
+
+def _entry(**overrides: object) -> PricingEntry:
+    fields: dict[str, object] = {
+        "benchmark": Benchmark.TTS,
+        "provider": "deepgram",
+        "model": "aura-2-thalia-en",
+        "unit": PricingUnit.PER_1K_CHARS,
+        "price_usd": Decimal("0.030"),
+        "effective_from": date(2026, 8, 10),
+        "source_url": "https://deepgram.com/pricing",
+    }
+    fields.update(overrides)
+    return PricingEntry.model_validate(fields)
+
+
+def test_shipped_registry_matches_model_registry() -> None:
+    """Every shipped entry keys to a registered model; both benchmarks are priced."""
+    assert PRICING
+    registered = {(m.benchmark, m.provider, m.model) for m in MODEL_REGISTRY}
+    assert set(PRICING) <= registered
+    assert {k[0] for k in PRICING} == {Benchmark.TTS, Benchmark.STT}
+
+
+def test_every_shipped_entry_serves_its_benchmark_figure() -> None:
+    """Each STT rate normalizes to $/1k minutes; TTS rates that can, to $/1M chars.
+
+    ``per_second_audio_out`` is the one TTS unit allowed to serve nothing —
+    output seconds have no character equivalence without a speaking rate.
+    """
+    for (benchmark, _, _), entry in PRICING.items():
+        if benchmark is Benchmark.STT:
+            assert entry.price_per_1k_minutes is not None
+            assert entry.price_per_1m_chars is None
+        elif entry.unit is not PricingUnit.PER_SECOND_AUDIO_OUT:
+            assert entry.price_per_1m_chars is not None
+
+
+@pytest.mark.parametrize(
+    ("unit", "price", "normalized"),
+    [
+        (PricingUnit.PER_1M_CHARS, Decimal("15"), Decimal("15")),
+        (PricingUnit.PER_1K_CHARS, Decimal("0.030"), Decimal("30")),
+        (PricingUnit.PER_CHAR, Decimal("0.00003"), Decimal("30")),
+        (PricingUnit.PER_SECOND_AUDIO_OUT, Decimal("0.001"), None),
+    ],
+)
+def test_normalization(unit: PricingUnit, price: Decimal, normalized: Decimal | None) -> None:
+    """Native units normalize to $/1M chars; audio-out seconds never estimate one."""
+    assert _entry(unit=unit, price_usd=price).price_per_1m_chars == normalized
+
+
+@pytest.mark.parametrize(
+    ("unit", "price", "normalized"),
+    [
+        (PricingUnit.PER_MINUTE, Decimal("0.0043"), Decimal("4.3")),
+        (PricingUnit.PER_HOUR, Decimal("0.36"), Decimal("6")),
+        (PricingUnit.PER_SECOND_AUDIO_IN, Decimal("0.0001"), Decimal("6")),
+        (PricingUnit.PER_1K_CHARS, Decimal("0.030"), None),
+        (PricingUnit.PER_SECOND_AUDIO_OUT, Decimal("0.001"), None),
+    ],
+)
+def test_minutes_normalization(
+    unit: PricingUnit, price: Decimal, normalized: Decimal | None
+) -> None:
+    """Duration units normalize to $/1k minutes; character units never estimate one."""
+    assert _entry(unit=unit, price_usd=price).price_per_1k_minutes == normalized
+
+
+def test_duplicate_key_raises() -> None:
+    entry = _entry()
+    with pytest.raises(RuntimeError, match="duplicate"):
+        index_pricing([entry, _entry(notes="same key, different rate")])
+    assert index_pricing([entry]) == {(entry.benchmark, entry.provider, entry.model): entry}
+
+
+def test_unregistered_model_raises() -> None:
+    with pytest.raises(RuntimeError, match="no MODEL_REGISTRY row"):
+        index_pricing([_entry(model="aura-99")])
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"price_usd": Decimal("0")},
+        {"price_usd": Decimal("-1")},
+        {"source_url": "not a url"},
+        {"unit": "per_word"},
+        {"currency": "EUR"},
+    ],
+)
+def test_schema_rejects_invalid_entries(overrides: dict[str, object]) -> None:
+    """Zero/negative rates, bad URLs, unknown units, and stray fields all fail validation."""
+    with pytest.raises(ValidationError):
+        _entry(**overrides)


### PR DESCRIPTION
## What

- **Open pricing registry**: per-provider JSON ratesheets (48 rates across 29 providers) under `runner/src/coval_bench/registries/pricing/data/{stt,tts}/`, validated at import. Rates are amended by PR — contributor instructions added to `CONTRIBUTING.md`.
- **`GET /v1/pricing`**: serves the registry with rates normalized server-side by exact arithmetic — $/1M characters for TTS, $/1k minutes for STT — plus manifest-pinned dataset usage. Early-access models are excluded from the public read.
- **`pricing_rates` change-log** (migration `0022`): append-only history seeded and maintained by `coval-bench pricing sync`. Every packaged rate inserts once (NUMERIC preserves the printed scale, `0.20` stays `0.20`); an unchanged registry is a no-op via the unique key; a new price or effective date appends one dated row. Follows the `model_history` conventions: no FK, nothing updated or deleted.

Serving rate history through the API/site is future work — this is the recording half.

## Notes

- The API endpoint reads only the in-memory registry, so it runs DB-less; the `pricing_rates` table is written only by the sync command.
- Migration merges first, runs on prod after (per our migration workflow).
- Counterpart web change (public `/pricing` page) lands separately in benchmarks-web.

## Testing

- `pytest tests/api -k pricing` — 10 passed (registry validation, normalization, endpoint shape, sync idempotency/append behavior).