### PR TITLE
Move the S2S stack onto the dental test set

### DIFF
--- a/runner/src/coval_bench/api/routers/leaderboard.py
+++ b/runner/src/coval_bench/api/routers/leaderboard.py
@@ -52,10 +52,11 @@ _VALID_COMBOS: set[tuple[str, str]] = {
     ("V2V", "S2S"),
 }
 
-# The headline S2S board is the clean multi-turn condition.  ``__all__`` remains
-# available to aggregate callers that explicitly want every S2S condition pooled,
-# including robustness datasets such as the noisy persona.
-_PRIMARY_DATASET_BY_BENCHMARK = {"S2S": "s2s-multiturn-v1"}
+# The headline S2S board is the clean dental condition, which every agent now runs.
+# The multi-turn set is frozen rather than retired: no agent writes to it, but it
+# stays reachable through the aggregates ``dataset`` param, as does ``__all__`` for
+# callers that want every S2S condition pooled.
+_PRIMARY_DATASET_BY_BENCHMARK = {"S2S": "s2s-dental-v1"}
 
 _MV_SQL_TEMPLATE = """
     SELECT provider, model,

--- a/runner/src/coval_bench/s2s/fetch_v2v.py
+++ b/runner/src/coval_bench/s2s/fetch_v2v.py
@@ -1025,7 +1025,14 @@ async def fetch_and_write_v2v(
                 f"targeted backfill did not recover runs: {', '.join(sorted(unmatched))}"
             )
 
-        if settings.s2s_samples_bucket and sampled_runs and test_set_id:
+        # The set the sampled recordings actually came from, which is what labels
+        # the manifest. Gating on the shared ``coval_s2s_test_set_id`` instead would
+        # stop publishing entirely once every agent carries its own set, filling
+        # sampled_runs and then never shipping them.
+        sample_test_set_id = next(
+            (r.test_set_id for r in sampled_runs if r.test_set_id), test_set_id
+        )
+        if settings.s2s_samples_bucket and sampled_runs and sample_test_set_id:
             expected = _expected_sample_models(settings)
             missing = expected - {r.key for r in sampled_runs}
             if missing:
@@ -1035,7 +1042,7 @@ async def fetch_and_write_v2v(
             await publish_tick_sample(
                 client,
                 bucket_name=settings.s2s_samples_bucket,
-                test_set_id=test_set_id,
+                test_set_id=sample_test_set_id,
                 runs=sampled_runs,
                 rng=random.Random(),  # noqa: S311
                 expected_models=expected,

--- a/runner/src/coval_bench/s2s/fetch_v2v.py
+++ b/runner/src/coval_bench/s2s/fetch_v2v.py
@@ -76,19 +76,37 @@ class CovalRun:
     persona_id: str = ""
 
 
-# Agent ids resolved from Settings; model strings are display labels.
+# Agent ids resolved from Settings; model strings are display labels. Every agent
+# now runs the dental test set: the shared multi-turn set stays queryable but is
+# no longer written to, so a spec left on it would go stale rather than idle.
 AGENTS: tuple[AgentSpec, ...] = (
-    AgentSpec(agent_id_attr="coval_s2s_openai_agent_id", provider="openai", model="gpt-realtime"),
-    AgentSpec(agent_id_attr="coval_s2s_gemini_agent_id", provider="google", model="gemini-live"),
+    AgentSpec(
+        agent_id_attr="coval_s2s_openai_agent_id",
+        provider="openai",
+        model="gpt-realtime",
+        test_set_id_attr="coval_s2s_dental_test_set_id",
+        family=FAMILY_DENTAL,
+    ),
+    AgentSpec(
+        agent_id_attr="coval_s2s_gemini_agent_id",
+        provider="google",
+        model="gemini-live",
+        test_set_id_attr="coval_s2s_dental_test_set_id",
+        family=FAMILY_DENTAL,
+    ),
     AgentSpec(
         agent_id_attr="coval_s2s_xai_agent_id",
         provider="xai",
         model="grok-voice-think-fast-1.0",
+        test_set_id_attr="coval_s2s_dental_test_set_id",
+        family=FAMILY_DENTAL,
     ),
     AgentSpec(
         agent_id_attr="coval_s2s_xai_think_fast_2_agent_id",
         provider="xai",
         model="grok-voice-think-fast-2.0",
+        test_set_id_attr="coval_s2s_dental_test_set_id",
+        family=FAMILY_DENTAL,
     ),
     # Pre-launch models under codenames: the provider and model strings are what
     # land in the results table, so they carry no vendor identity of their own.

--- a/runner/src/coval_bench/s2s/fetch_v2v.py
+++ b/runner/src/coval_bench/s2s/fetch_v2v.py
@@ -775,6 +775,7 @@ async def _fetch_one_provider(
             bucket_at=bucket_at,
             persona_id=coval_run.persona_id,
             agent_id=agent_id,
+            test_set_id=test_set_id or "",
         )
 
     try:

--- a/runner/src/coval_bench/s2s/samples.py
+++ b/runner/src/coval_bench/s2s/samples.py
@@ -69,6 +69,9 @@ class SampleRun:
     bucket_at: datetime
     persona_id: str = ""
     agent_id: str = ""
+    # The set this run actually came from. Agents no longer share one, so the
+    # manifest cannot label a recording with the caller-wide configured id.
+    test_set_id: str = ""
 
     @property
     def key(self) -> tuple[str, str]:
@@ -468,7 +471,9 @@ async def _publish_one_bucket(
         manifest = {
             "schema_version": 2,
             "bucket_at": tick_key,
-            "test_set_id": test_set_id,
+            # The recordings' own set, falling back to the configured one only when
+            # a run predates the field.
+            "test_set_id": next((r.test_set_id for r in runs if r.test_set_id), test_set_id),
             "test_case_id": test_case_id,
             "persona_name": _persona_label(persona_id),
             "recordings": recordings,

--- a/runner/tests/api/test_leaderboard.py
+++ b/runner/tests/api/test_leaderboard.py
@@ -157,12 +157,12 @@ async def test_excluded_metric_rows_hidden(client: AsyncClient, postgresql: Any)
     assert [(e["provider"], e["model"]) for e in entries] == [("deepgram", "nova-3")]
 
 
-async def test_s2s_leaderboard_uses_clean_multiturn_dataset(
+async def test_s2s_leaderboard_uses_the_clean_primary_dataset(
     client: AsyncClient, postgresql: Any
 ) -> None:
     """The headline S2S board excludes robustness conditions such as noisy speech."""
-    clean_run = await _insert_run(postgresql, dataset_id="s2s-multiturn-v1")
-    noisy_run = await _insert_run(postgresql, dataset_id="s2s-multiturn-noisy-v1")
+    clean_run = await _insert_run(postgresql, dataset_id="s2s-dental-v1")
+    noisy_run = await _insert_run(postgresql, dataset_id="s2s-dental-noisy-v1")
     await _insert_result(
         postgresql,
         clean_run,

--- a/runner/tests/unit/test_s2s_fetch.py
+++ b/runner/tests/unit/test_s2s_fetch.py
@@ -689,6 +689,47 @@ async def test_fetch_and_write_v2v_per_provider(monkeypatch: pytest.MonkeyPatch)
 
 
 @pytest.mark.asyncio
+async def test_samples_publish_without_the_shared_test_set(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A dental-only deployment still publishes: the gate reads the run's own set.
+
+    ``coval_s2s_test_set_id`` is deliberately unset here. Gating publication on it
+    would fill ``sampled_runs`` and then silently never ship them, leaving the
+    public sample card frozen while ingestion looked healthy.
+    """
+    monkeypatch.delenv("COVAL_S2S_GEMINI_AGENT_ID", raising=False)
+    settings = Settings(
+        coval_s2s_latency_metric_id="MID",
+        coval_s2s_openai_agent_id="a1",
+        coval_s2s_dental_test_set_id="TSD",
+        s2s_samples_bucket="bucket",
+    )
+    assert settings.coval_s2s_test_set_id is None
+
+    writer = _stub_writer()
+    list_json = _list_json({"run_id": "R1", "create_time": _iso(timedelta(hours=1))})
+    values = [{"simulation_output_id": "s1", "value": 0.5}]
+    client = _fake_client(list_json, _run_json(values))
+
+    @contextlib.asynccontextmanager
+    async def _fake_pool(_settings: Any) -> AsyncIterator[MagicMock]:
+        yield MagicMock()
+
+    publish = AsyncMock(return_value=1)
+    monkeypatch.setattr(fetch_v2v, "_client", lambda _s: client)
+    monkeypatch.setattr(fetch_v2v, "lifespan_pool", _fake_pool)
+    monkeypatch.setattr(fetch_v2v, "RunWriter", lambda _pool: writer)
+    monkeypatch.setattr(fetch_v2v, "publish_tick_sample", publish)
+
+    await fetch_v2v.fetch_and_write_v2v(settings)
+
+    publish.assert_awaited_once()
+    assert publish.await_args is not None
+    assert publish.await_args.kwargs["test_set_id"] == "TSD"
+
+
+@pytest.mark.asyncio
 async def test_fetch_and_write_v2v_noop_skips_matview_refresh(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/runner/tests/unit/test_s2s_fetch.py
+++ b/runner/tests/unit/test_s2s_fetch.py
@@ -665,6 +665,7 @@ async def test_fetch_and_write_v2v_per_provider(monkeypatch: pytest.MonkeyPatch)
     settings = Settings(
         coval_s2s_latency_metric_id="MID",
         coval_s2s_openai_agent_id="a1",
+        coval_s2s_dental_test_set_id="TSD",
     )
 
     writer = _stub_writer()
@@ -695,6 +696,7 @@ async def test_fetch_and_write_v2v_noop_skips_matview_refresh(
     settings = Settings(
         coval_s2s_latency_metric_id="MID",
         coval_s2s_openai_agent_id="a1",
+        coval_s2s_dental_test_set_id="TSD",
     )
 
     writer = _stub_writer()
@@ -1044,6 +1046,7 @@ async def test_fetch_and_write_rejects_noisy_persona_without_a_test_set() -> Non
     settings = Settings(
         coval_s2s_latency_metric_id="MID",
         coval_s2s_openai_agent_id="a1",
+        coval_s2s_dental_test_set_id="TSD",
         coval_s2s_noisy_persona_id="PN",
     )
     with pytest.raises(RuntimeError, match="requires coval_s2s_test_set_id"):
@@ -1098,6 +1101,7 @@ async def test_fetch_and_write_rejects_a_metric_with_no_row_builder(
         coval_s2s_latency_metric_id="MID",
         coval_s2s_openai_agent_id="a1",
         coval_s2s_test_set_id="TS1",
+        coval_s2s_dental_test_set_id="TSD",
         coval_s2s_instruction_metric_id="IID",
         coval_s2s_interruption_metric_id="RID",
     )

--- a/runner/tests/unit/test_s2s_samples.py
+++ b/runner/tests/unit/test_s2s_samples.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import json
 import random
+from dataclasses import replace
 from datetime import UTC, datetime
 from typing import Any
 from unittest.mock import MagicMock
@@ -173,6 +174,20 @@ async def _publish(
         download_client=client,
         expected_models=expected_models,
     )
+
+
+@pytest.mark.asyncio
+async def test_manifest_labels_the_set_the_runs_came_from() -> None:
+    # Agents no longer share one test set, so the manifest must name the set the
+    # recordings came from rather than whatever the caller was configured with.
+    storage_client, bucket = _fake_storage()
+    runs = [replace(run, test_set_id="OWN_SET") for run in _runs()]
+    cases = {"RO_F": ["b", "c"], "RG_F": ["b", "c"], "RO_M": ["b", "c"], "RG_M": ["b", "c"]}
+    async with _fake_client(cases) as client:
+        await _publish(client, storage_client, runs)
+
+    manifest = json.loads(bucket.objects[f"{PREFIX}/{TICK}/manifest.json"])
+    assert manifest["test_set_id"] == "OWN_SET"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
The run template was switched at 20:46 UTC on 27 Aug, so openai, gemini and others now produce runs on dental comapred to generic custoemr service.Pointing all four at the dental family puts every S2S model on one test set, so the pre-launch pair becomes directly comparable to the rest instead of sitting on a two-model board. The headline leaderboard follows to `s2s-dental-v1`.

The multi-turn datasets are frozen rather than retired: nothing writes to them, and they stay reachable through the aggregates `dataset` param.

Persona coverage is unchanged — these four run the two clean personas on dental exactly as they did on multi-turn, so the noisy and accented dental conditions stay pre-launch-only for now.

Needs a paired web change: repin the overview card, and rank the dental ids above the multi-turn ones in `S2S_DATASET_PRIORITY` so the frozen multi-turn rows don't keep winning the clean condition for the next 30 days.