### PR TITLE
[BENCH-755] Stream production normalized backfill

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@
 #   docker compose up -d db     # bring up Postgres only
 #   docker compose run --rm migrate
 #   docker compose up api       # FastAPI on http://localhost:8000
-#   docker compose run --rm runner coval-bench run --smoke --kind tts
+#   docker compose run --rm runner run --smoke --kind tts
 #
 # The `runner` and `migrate` services have profiles so `docker compose up` only
 # starts long-running services (db, api). One-shot commands are invoked via
@@ -36,7 +36,7 @@ services:
     env_file: .env
     environment:
       DATABASE_URL: postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@db:5432/${POSTGRES_DB:-benchmarks}
-    command: ["coval-bench", "db", "migrate"]
+    command: ["db", "migrate"]
     depends_on:
       db:
         condition: service_healthy

--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -74,4 +74,5 @@ COPY --from=build --chown=65532:65532 /app /app
 
 USER 65532:65532
 
-CMD ["python", "-m", "coval_bench", "run"]
+ENTRYPOINT ["python", "-m", "coval_bench"]
+CMD ["run"]

--- a/runner/README.md
+++ b/runner/README.md
@@ -44,10 +44,10 @@ docker compose run --rm migrate  # alembic upgrade head
 docker compose up -d api         # FastAPI on http://localhost:8000
 
 # Trigger a single-item benchmark run (writes to the local Postgres):
-docker compose run --rm runner coval-bench run --smoke --kind tts
+docker compose run --rm runner run --smoke --kind tts
 
 # Probe one TTS provider without DB writes:
-docker compose run --rm runner coval-bench tts-smoke \
+docker compose run --rm runner tts-smoke \
   --provider cartesia --model sonic-3 --voice <voice-id> --text "hello"
 ```
 

--- a/runner/src/coval_bench/migrations/backfill_normalized_storage.py
+++ b/runner/src/coval_bench/migrations/backfill_normalized_storage.py
@@ -174,6 +174,7 @@ def _report() -> dict[str, Any]:
         "artifacts": 0,
         "buckets": 0,
         "skipped_by_reason": Counter(),
+        "verification_skipped_by_reason": Counter(),
         "parity_mismatches": [],
         "parity_mismatch_count": 0,
         "parity_mismatches_truncated": False,
@@ -1053,11 +1054,13 @@ def _preflight_artifact_bucket(client: storage.Client, bucket_name: str) -> None
 
 def _set_ready(report: dict[str, Any], *, dry_run: bool) -> None:
     report["skipped_by_reason"] = dict(report["skipped_by_reason"])
+    report["verification_skipped_by_reason"] = dict(report["verification_skipped_by_reason"])
     report["cutover_ready"] = (
         (not dry_run or not report["eligible"])
         and report["parity_mismatch_count"] == 0
         and report["rollup_mismatch_count"] == 0
         and not report["skipped_by_reason"]
+        and not report["verification_skipped_by_reason"]
     )
 
 
@@ -1138,12 +1141,13 @@ def backfill(
                             _refresh_bucket(cur, bucket_at)
                         report["buckets"] += 1
         # Re-plan from a fresh bounded pass; never retain first-pass plans.
-        verification_skipped: Counter[str] = Counter()
+        verification_skipped: Counter[str] = report["verification_skipped_by_reason"]
         for _, complete in _complete_pages(
             conn, min_result_id, max_result_id, batch_size, verification_skipped
         ):
             for plan in _page_plans(complete, verification_skipped):
                 if plan.first.scheduled_at is None:
+                    verification_skipped["scheduled_at_missing"] += 1
                     continue
                 with conn.cursor() as cur:
                     cur.execute(

--- a/runner/src/coval_bench/migrations/backfill_normalized_storage.py
+++ b/runner/src/coval_bench/migrations/backfill_normalized_storage.py
@@ -17,16 +17,16 @@ from collections import Counter, defaultdict
 from collections.abc import Iterable
 from dataclasses import dataclass
 from datetime import datetime
+from functools import lru_cache
 from importlib.resources import files
 from typing import Any
 
 import click
 import psycopg
+from google.api_core.exceptions import GoogleAPIError
 from google.cloud import storage
 
 from coval_bench.config import get_settings
-from coval_bench.datasets.loader import _load_manifest
-from coval_bench.datasets.manifest import STTManifestItem, TTSManifestItem
 from coval_bench.observation_artifacts import (
     prepare_provider_transcript,
     prepare_timing_events,
@@ -40,6 +40,7 @@ _OBS_NAMESPACE = uuid.UUID("6edc052c-4d05-5b64-9621-cc6f6343b6cd")
 _EVAL_NAMESPACE = uuid.UUID("e7f9ce4b-8f66-572c-bf9e-4f67b044422e")
 _ARTIFACT_NAMESPACE = uuid.UUID("64478df1-0d13-5996-a3ca-96c421f772c9")
 _LOCK = "normalized_storage_backfill"
+_MISMATCH_DETAIL_LIMIT = 100
 
 
 @dataclass(frozen=True)
@@ -99,12 +100,34 @@ def _valid_sha(value: str) -> bool:
     return len(value) == 64 and all(char in "0123456789abcdef" for char in value)
 
 
-def _manifest_sha(dataset_id: str) -> str | None:
+@dataclass(frozen=True)
+class _PackagedManifest:
+    sha256: str
+    stt_samples: dict[str, tuple[str, ...]]
+    tts_samples: dict[str, tuple[str, ...]]
+
+
+@lru_cache(maxsize=64)
+def _packaged_manifest(dataset_id: str) -> _PackagedManifest | None:
+    """Index packaged bytes once per dataset; never cache historical observations."""
     try:
         raw = files("coval_bench.datasets.manifests").joinpath(f"{dataset_id}.json").read_bytes()
     except FileNotFoundError:
         return None
-    return hashlib.sha256(raw).hexdigest()
+    payload = json.loads(raw)
+    stt: dict[str, list[str]] = defaultdict(list)
+    tts: dict[str, list[str]] = defaultdict(list)
+    for item in payload.get("items", []):
+        if "path" in item:
+            identity = item.get("sample_id") or item["path"]
+            stt[item["path"].rsplit("/", 1)[-1]].append(identity)
+        if "transcript" in item and "testcase_id" in item:
+            tts[item["transcript"]].append(item["testcase_id"])
+    return _PackagedManifest(
+        hashlib.sha256(raw).hexdigest(),
+        {key: tuple(value) for key, value in stt.items()},
+        {key: tuple(value) for key, value in tts.items()},
+    )
 
 
 def _legacy_sample(dataset_id: str, filename: str) -> str:
@@ -114,38 +137,27 @@ def _legacy_sample(dataset_id: str, filename: str) -> str:
 def _stt_sample(dataset_id: str, dataset_sha256: str, filename: str) -> str | None:
     if not filename:
         return None
-    try:
-        manifest = _load_manifest(dataset_id)
-    except FileNotFoundError:
+    manifest = _packaged_manifest(dataset_id)
+    if manifest is None:
         return _legacy_sample(dataset_id, filename)
     # A filename alone is not provenance.  Packaged identities are valid only
     # when the historical run pins these exact manifest bytes.
-    if _manifest_sha(dataset_id) != dataset_sha256:
+    if manifest.sha256 != dataset_sha256:
         return _legacy_sample(dataset_id, filename)
-    matches = [
-        x
-        for x in manifest.items
-        if isinstance(x, STTManifestItem) and x.path.rsplit("/", 1)[-1] == filename
-    ]
+    matches = manifest.stt_samples.get(filename, ())
     if len(matches) != 1:
         return _legacy_sample(dataset_id, filename)
-    item = matches[0]
-    return item.sample_id or item.path
+    return matches[0]
 
 
 def _tts_sample(dataset_id: str, sha: str, prompt: str) -> str | None:
     # A current tts-v1 prompt is usable only if the historical run proves it
     # used the exact packaged manifest bytes.
-    if dataset_id != "tts-v1" or _manifest_sha(dataset_id) != sha:
+    manifest = _packaged_manifest(dataset_id)
+    if dataset_id != "tts-v1" or manifest is None or manifest.sha256 != sha:
         return None
-    try:
-        manifest = _load_manifest(dataset_id)
-    except FileNotFoundError:
-        return None
-    matches = [
-        x for x in manifest.items if isinstance(x, TTSManifestItem) and x.transcript == prompt
-    ]
-    return matches[0].testcase_id if len(matches) == 1 else None
+    matches = manifest.tts_samples.get(prompt, ())
+    return matches[0] if len(matches) == 1 else None
 
 
 def _report() -> dict[str, Any]:
@@ -163,24 +175,44 @@ def _report() -> dict[str, Any]:
         "buckets": 0,
         "skipped_by_reason": Counter(),
         "parity_mismatches": [],
+        "parity_mismatch_count": 0,
+        "parity_mismatches_truncated": False,
         "rollup_mismatches": [],
+        "rollup_mismatch_count": 0,
+        "rollup_mismatches_truncated": False,
         "cutover_ready": False,
     }
 
 
-_ROWS_SQL = """
+_PAGE_RUN_IDS_SQL = """
+SELECT DISTINCT r.run_id
+FROM benchmarks_v2.results r
+WHERE r.id BETWEEN %s AND %s AND r.benchmark IN ('STT','TTS') AND r.run_id > %s
+ORDER BY r.run_id
+LIMIT %s
+"""
+
+_RUN_ROWS_SQL = """
 SELECT r.id,r.run_id,n.dataset_id,n.dataset_sha256,n.scheduled_at,r.provider,r.model,r.voice,
  r.benchmark,r.metric_type,r.metric_value,r.metric_units,r.audio_filename,r.transcript,r.status,
  r.error,r.http_version,r.submit_to_headers_ms,r.created_at,r.wer_insertions_pct,r.wer_deletions_pct,r.wer_substitutions_pct
 FROM benchmarks_v2.results r JOIN benchmarks_v2.runs n ON n.id=r.run_id
-WHERE r.id BETWEEN %s AND %s AND r.benchmark IN ('STT','TTS') ORDER BY r.id
+WHERE r.run_id=ANY(%s) AND r.id BETWEEN %s AND %s AND r.benchmark IN ('STT','TTS')
+ORDER BY r.run_id,r.id
 """
 
 
-def _rows(conn: psycopg.Connection, low: int, high: int) -> list[LegacyRow]:
+def _run_page(
+    conn: psycopg.Connection, low: int, high: int, after_run_id: int, batch_size: int
+) -> tuple[list[int], list[LegacyRow]]:
+    """Read one bounded, run-keyset page from the frozen result-id window."""
     with conn.cursor() as cur:
-        cur.execute(_ROWS_SQL, (low, high))
-        return [LegacyRow(*row) for row in cur.fetchall()]
+        cur.execute(_PAGE_RUN_IDS_SQL, (low, high, after_run_id, batch_size))
+        run_ids = [int(row[0]) for row in cur.fetchall()]
+        if not run_ids:
+            return [], []
+        cur.execute(_RUN_ROWS_SQL, (run_ids, low, high))
+        return run_ids, [LegacyRow(*row) for row in cur.fetchall()]
 
 
 def _complete_window_rows(
@@ -206,6 +238,28 @@ def _complete_window_rows(
                 skipped["run_not_terminal"] += 1
                 bad.add(run_id)
     return [row for row in rows if row.run_id not in bad]
+
+
+def _page_plans(rows: list[LegacyRow], skipped: Counter[str]) -> list[Planned]:
+    """Plan complete runs independently so TTS attachment scans stay page-bounded."""
+    by_run: dict[int, list[LegacyRow]] = defaultdict(list)
+    for row in rows:
+        by_run[row.run_id].append(row)
+    plans: list[Planned] = []
+    for run_rows in by_run.values():
+        plans.extend(_stt_plans((r for r in run_rows if r.benchmark == "STT"), skipped))
+        plans.extend(_tts_plans((r for r in run_rows if r.benchmark == "TTS"), skipped))
+    return plans
+
+
+def _append_mismatch(report: dict[str, Any], kind: str, detail: dict[str, Any]) -> None:
+    """Retain bounded diagnostics while reporting the exact mismatch total."""
+    count_key = "parity_mismatch_count" if kind == "parity_mismatches" else "rollup_mismatch_count"
+    report[count_key] += 1
+    if len(report[kind]) < _MISMATCH_DETAIL_LIMIT:
+        report[kind].append(detail)
+    else:
+        report[f"{kind}_truncated"] = True
 
 
 def _stt_plans(rows: Iterable[LegacyRow], skipped: Counter[str]) -> list[Planned]:
@@ -683,6 +737,8 @@ def _insert_plan(
     bucket: str | None,
     client: storage.Client | None,
     report: dict[str, Any],
+    *,
+    report_mismatch: bool = True,
 ) -> None:
     r = plan.first
     with conn.cursor() as cur:
@@ -697,17 +753,21 @@ def _insert_plan(
             report["live_owned"] += 1
             if _stored_plan_matches(cur, plan, found[0]):
                 report["reconciled"] += 1
-            else:
-                report["parity_mismatches"].append(
-                    {"natural_key": list(plan.natural), "reason": "live_owned_payload_mismatch"}
+            elif report_mismatch:
+                _append_mismatch(
+                    report,
+                    "parity_mismatches",
+                    {"natural_key": list(plan.natural), "reason": "live_owned_payload_mismatch"},
                 )
             return
         if found:
             if _stored_plan_matches(cur, plan, found[0]):
                 report["reconciled"] += 1
-            else:
-                report["parity_mismatches"].append(
-                    {"natural_key": list(plan.natural), "reason": "backfill_payload_mismatch"}
+            elif report_mismatch:
+                _append_mismatch(
+                    report,
+                    "parity_mismatches",
+                    {"natural_key": list(plan.natural), "reason": "backfill_payload_mismatch"},
                 )
             return
         report["eligible"] += 1
@@ -890,27 +950,115 @@ WHERE bucket_at=%(bucket)s
 
 
 def _rollup_mismatches(
-    conn: psycopg.Connection, buckets: Iterable[datetime]
-) -> list[dict[str, Any]]:
+    conn: psycopg.Connection, buckets: Iterable[datetime], report: dict[str, Any]
+) -> None:
     """Compare materialized rollups with a fresh aggregate over immutable values."""
-    mismatches: list[dict[str, Any]] = []
     with conn.cursor() as cur:
-        for bucket_at in sorted(set(buckets)):
+        for bucket_at in buckets:
             params = {"bucket": bucket_at}
             cur.execute(_ROLLUP_PAYLOAD_SQL, params)
             expected = sorted((tuple(row) for row in cur.fetchall()), key=repr)
             cur.execute(_STORED_ROLLUP_SQL, params)
             actual = sorted((tuple(row) for row in cur.fetchall()), key=repr)
             if actual != expected:
-                mismatches.append(
+                _append_mismatch(
+                    report,
+                    "rollup_mismatches",
                     {
                         "bucket_at": bucket_at.isoformat(),
                         "expected_rows": len(expected),
                         "actual_rows": len(actual),
                         "reason": "stored_bucket_payload_mismatch",
-                    }
+                    },
                 )
-    return mismatches
+
+
+_BUCKET_PAGE_SQL = """
+WITH buckets AS (
+  SELECT n.scheduled_at, min(n.id) AS first_run_id
+  FROM benchmarks_v2.runs n
+  WHERE n.status IN ('succeeded','partial','failed') AND n.scheduled_at IS NOT NULL
+    AND EXISTS (
+      SELECT 1 FROM benchmarks_v2.results r
+      WHERE r.run_id=n.id AND r.id BETWEEN %s AND %s AND r.benchmark IN ('STT','TTS')
+    )
+    AND NOT EXISTS (
+      SELECT 1 FROM benchmarks_v2.results r WHERE r.run_id=n.id AND (r.id < %s OR r.id > %s)
+    )
+  GROUP BY n.scheduled_at
+)
+SELECT scheduled_at,first_run_id FROM buckets
+WHERE (%s::timestamptz IS NULL OR (scheduled_at,first_run_id) > (%s,%s))
+ORDER BY scheduled_at,first_run_id LIMIT %s
+"""
+
+
+def _complete_pages(
+    conn: psycopg.Connection, low: int, high: int, batch_size: int, skipped: Counter[str]
+) -> Iterable[tuple[list[LegacyRow], list[LegacyRow]]]:
+    """Yield raw and complete bounded run pages, ending each read transaction."""
+    after_run_id = 0
+    while True:
+        run_ids, rows = _run_page(conn, low, high, after_run_id, batch_size)
+        if not run_ids:
+            conn.commit()
+            return
+        after_run_id = run_ids[-1]
+        complete = _complete_window_rows(conn, rows, low, high, skipped)
+        conn.commit()
+        yield rows, complete
+
+
+def _scheduled_buckets(
+    conn: psycopg.Connection, low: int, high: int, batch_size: int
+) -> Iterable[datetime]:
+    """Keyset distinct buckets by timestamp and a stable representative run id."""
+    after: tuple[datetime, int] | None = None
+    while True:
+        conn.commit()
+        with conn.cursor() as cur:
+            cur.execute(
+                _BUCKET_PAGE_SQL,
+                (
+                    low,
+                    high,
+                    low,
+                    high,
+                    after[0] if after else None,
+                    *(after or (None, 0)),
+                    batch_size,
+                ),
+            )
+            page = [(row[0], int(row[1])) for row in cur.fetchall()]
+        conn.commit()
+        if not page:
+            return
+        for bucket, _ in page:
+            yield bucket
+        after = page[-1]
+
+
+def _preflight_artifact_bucket(client: storage.Client, bucket_name: str) -> None:
+    """Prove the configured bucket permits the recoverable artifact contract."""
+    required = {"storage.objects.create", "storage.objects.get"}
+    try:
+        granted = set(client.bucket(bucket_name).test_iam_permissions(list(required)))
+    except GoogleAPIError as exc:
+        raise click.ClickException("cannot validate BENCHMARK_ARTIFACT_BUCKET access") from exc
+    if not required.issubset(granted):
+        raise click.ClickException(
+            "BENCHMARK_ARTIFACT_BUCKET requires storage.objects.create and storage.objects.get"
+        )
+
+
+def _set_ready(report: dict[str, Any], *, dry_run: bool) -> None:
+    report["skipped_by_reason"] = dict(report["skipped_by_reason"])
+    report["cutover_ready"] = (
+        (not dry_run or not report["eligible"])
+        and report["parity_mismatch_count"] == 0
+        and report["rollup_mismatch_count"] == 0
+        and not report["skipped_by_reason"]
+    )
 
 
 def backfill(
@@ -930,90 +1078,103 @@ def backfill(
         "max_result_id": max_result_id,
         "batch_size": batch_size,
     }
-    rows = _rows(conn, min_result_id, max_result_id)
-    report["source_rows"] = len(rows)
-    rows = _complete_window_rows(
-        conn, rows, min_result_id, max_result_id, report["skipped_by_reason"]
-    )
-    plans = _stt_plans(
-        (r for r in rows if r.benchmark == "STT"), report["skipped_by_reason"]
-    ) + _tts_plans((r for r in rows if r.benchmark == "TTS"), report["skipped_by_reason"])
-    report["source_groups"] = len(plans)
-    missing_schedule = sum(plan.first.scheduled_at is None for plan in plans)
-    if missing_schedule:
-        report["skipped_by_reason"]["scheduled_at_missing"] += missing_schedule
-        plans = [plan for plan in plans if plan.first.scheduled_at is not None]
-    buckets = {plan.first.scheduled_at for plan in plans}
-    scheduled_buckets = {bucket for bucket in buckets if bucket is not None}
-    if not apply:
-        for p in plans:
-            _insert_plan(conn, p, False, artifact_bucket, None, report)
-        report["rollup_mismatches"] = _rollup_mismatches(conn, scheduled_buckets)
-        report["skipped_by_reason"] = dict(report["skipped_by_reason"])
-        report["cutover_ready"] = (
-            not report["eligible"]
-            and not report["parity_mismatches"]
-            and not report["rollup_mismatches"]
-            and not report["skipped_by_reason"]
-        )
-        return report
-    # End planning's implicit transaction before taking a *session* lock.  Each
-    # transaction below is now a real commit boundary, not a savepoint.
+    if apply and not artifact_bucket:
+        raise click.ClickException("BENCHMARK_ARTIFACT_BUCKET is required for --apply")
+    # Fail GCS setup before the first committed page, even if this prefix happens
+    # not to contain an artifact-bearing observation.
+    client = storage.Client() if apply else None
+    if client is not None and artifact_bucket is not None:
+        _preflight_artifact_bucket(client, artifact_bucket)
     conn.commit()
-    needs_artifacts = any(p.artifacts for p in plans)
-    if needs_artifacts and not artifact_bucket:
-        raise click.ClickException(
-            "BENCHMARK_ARTIFACT_BUCKET is required for recoverable artifacts"
+    if not apply:
+        for rows, complete in _complete_pages(
+            conn, min_result_id, max_result_id, batch_size, report["skipped_by_reason"]
+        ):
+            report["source_rows"] += len(rows)
+            plans = _page_plans(complete, report["skipped_by_reason"])
+            report["source_groups"] += len(plans)
+            for plan in plans:
+                if plan.first.scheduled_at is None:
+                    report["skipped_by_reason"]["scheduled_at_missing"] += 1
+                else:
+                    _insert_plan(conn, plan, False, artifact_bucket, None, report)
+        _rollup_mismatches(
+            conn,
+            _scheduled_buckets(conn, min_result_id, max_result_id, batch_size),
+            report,
         )
-    client = storage.Client() if needs_artifacts else None
+        _set_ready(report, dry_run=True)
+        return report
     with conn.cursor() as cur:
         cur.execute("SELECT pg_advisory_lock(hashtextextended(%s,0))", (_LOCK,))
     # ``pg_advisory_lock`` is session scoped.  Commit the implicit SELECT
     # transaction now so each following ``conn.transaction`` is top-level.
     conn.commit()
     try:
-        for start in range(0, len(plans), batch_size):
-            with conn.transaction():
-                for p in plans[start : start + batch_size]:
-                    _insert_plan(conn, p, True, artifact_bucket, client, report)
-                buckets = {p.first.scheduled_at for p in plans[start : start + batch_size]}
-                for bucket_at in buckets:
-                    if bucket_at is None:  # guarded by the pre-write plan filter above.
-                        raise RuntimeError("scheduled_at changed during immutable plan execution")
-                    with conn.cursor() as cur:
-                        _refresh_bucket(cur, bucket_at)
-                    report["buckets"] += 1
-        # The decision is based on a fresh immutable snapshot, not optimistic
-        # INSERT success.  This also detects trigger/DB representation drift.
-        with conn.cursor() as cur:
-            for plan in plans:
-                cur.execute(
-                    """SELECT id FROM benchmarks_v2.benchmark_observations
-                       WHERE run_id=%s AND sample_id=%s AND provider=%s AND model=%s
-                         AND voice IS NOT DISTINCT FROM %s""",
-                    plan.natural,
-                )
-                found = cur.fetchone()
-                reason = (
-                    "post_write_observation_missing"
-                    if found is None
-                    else "post_write_payload_mismatch"
-                    if not _stored_plan_matches(cur, plan, found[0])
-                    else None
-                )
-                if reason is not None:
-                    report["parity_mismatches"].append(
-                        {"natural_key": list(plan.natural), "reason": reason}
+        for rows, complete in _complete_pages(
+            conn, min_result_id, max_result_id, batch_size, report["skipped_by_reason"]
+        ):
+            report["source_rows"] += len(rows)
+            plans = _page_plans(complete, report["skipped_by_reason"])
+            report["source_groups"] += len(plans)
+            missing_schedule = [plan for plan in plans if plan.first.scheduled_at is None]
+            if missing_schedule:
+                report["skipped_by_reason"]["scheduled_at_missing"] += len(missing_schedule)
+            plans = [plan for plan in plans if plan.first.scheduled_at is not None]
+            for start in range(0, len(plans), batch_size):
+                batch = plans[start : start + batch_size]
+                with conn.transaction():
+                    for p in batch:
+                        _insert_plan(
+                            conn, p, True, artifact_bucket, client, report, report_mismatch=False
+                        )
+                    buckets = {p.first.scheduled_at for p in batch}
+                    for bucket_at in buckets:
+                        if bucket_at is None:
+                            raise RuntimeError(
+                                "scheduled_at changed during immutable plan execution"
+                            )
+                        with conn.cursor() as cur:
+                            _refresh_bucket(cur, bucket_at)
+                        report["buckets"] += 1
+        # Re-plan from a fresh bounded pass; never retain first-pass plans.
+        verification_skipped: Counter[str] = Counter()
+        for _, complete in _complete_pages(
+            conn, min_result_id, max_result_id, batch_size, verification_skipped
+        ):
+            for plan in _page_plans(complete, verification_skipped):
+                if plan.first.scheduled_at is None:
+                    continue
+                with conn.cursor() as cur:
+                    cur.execute(
+                        """SELECT id FROM benchmarks_v2.benchmark_observations
+                           WHERE run_id=%s AND sample_id=%s AND provider=%s AND model=%s
+                             AND voice IS NOT DISTINCT FROM %s""",
+                        plan.natural,
                     )
-        report["rollup_mismatches"] = _rollup_mismatches(conn, scheduled_buckets)
-        report["skipped_by_reason"] = dict(report["skipped_by_reason"])
-        report["cutover_ready"] = (
-            not report["parity_mismatches"]
-            and not report["rollup_mismatches"]
-            and not report["skipped_by_reason"]
+                    found = cur.fetchone()
+                    reason = (
+                        "post_write_observation_missing"
+                        if found is None
+                        else "post_write_payload_mismatch"
+                        if not _stored_plan_matches(cur, plan, found[0])
+                        else None
+                    )
+                    if reason is not None:
+                        _append_mismatch(
+                            report,
+                            "parity_mismatches",
+                            {"natural_key": list(plan.natural), "reason": reason},
+                        )
+        _rollup_mismatches(
+            conn,
+            _scheduled_buckets(conn, min_result_id, max_result_id, batch_size),
+            report,
         )
+        _set_ready(report, dry_run=False)
         return report
     finally:
+        conn.rollback()
         with conn.cursor() as cur:
             cur.execute("SELECT pg_advisory_unlock(hashtextextended(%s,0))", (_LOCK,))
         conn.commit()
@@ -1031,6 +1192,10 @@ def backfill_normalized_storage_cli(
     if apply and max_result_id is None:
         raise click.UsageError("--apply requires an explicit --max-result-id")
     url = str(get_settings().database_url)
+    if url == "postgresql://unused:unused@127.0.0.1:5432/unused":
+        raise click.ClickException(
+            "DATABASE_URL is required for this production migration; set a non-local production URL"
+        )
     with psycopg.connect(url) as conn:
         if max_result_id is None:
             with conn.cursor() as cur:

--- a/runner/tests/unit/test_normalized_storage_backfill.py
+++ b/runner/tests/unit/test_normalized_storage_backfill.py
@@ -245,7 +245,7 @@ def test_cli_rejects_the_local_placeholder_before_connecting(
 
     monkeypatch.setattr(migration, "get_settings", lambda: Settings())
     monkeypatch.setattr(
-        migration.psycopg, "connect", lambda *_: pytest.fail("must not connect to placeholder")
+        psycopg, "connect", lambda *_: pytest.fail("must not connect to placeholder")
     )
     result = CliRunner().invoke(backfill_normalized_storage_cli, ["--max-result-id", "1"])
     assert result.exit_code == 1
@@ -390,7 +390,7 @@ def test_apply_replans_for_fresh_verification_without_retaining_pages(
 
     monkeypatch.setattr(migration, "_complete_pages", pages)
     monkeypatch.setattr(migration, "_page_plans", lambda *_: [plan])
-    monkeypatch.setattr(migration.storage, "Client", lambda: object())
+    monkeypatch.setattr(gcs_storage, "Client", lambda: object())
     monkeypatch.setattr(migration, "_preflight_artifact_bucket", lambda *_: None)
 
     def insert(*_args: Any, **kwargs: Any) -> None:
@@ -401,12 +401,12 @@ def test_apply_replans_for_fresh_verification_without_retaining_pages(
     monkeypatch.setattr(migration, "_stored_plan_matches", lambda *_: False)
     monkeypatch.setattr(migration, "_scheduled_buckets", lambda *_: iter(()))
     report = migration.backfill(
-        Conn(),
+        Conn(),  # type: ignore[arg-type]
         min_result_id=1,
         max_result_id=1,
         batch_size=1,
         apply=True,
-        artifact_bucket="bucket",  # type: ignore[arg-type]
+        artifact_bucket="bucket",
     )
     assert len(passes) == 2
     assert mismatch_flags == [False]
@@ -435,15 +435,15 @@ def test_apply_bucket_preflight_fails_before_lock_page_or_write(
             events.append("lock")
             return nullcontext()
 
-    monkeypatch.setattr(migration.storage, "Client", lambda: Storage())
+    monkeypatch.setattr(gcs_storage, "Client", lambda: Storage())
     with pytest.raises(click.ClickException, match="storage.objects.create"):
         migration.backfill(
-            Conn(),
+            Conn(),  # type: ignore[arg-type]
             min_result_id=1,
             max_result_id=1,
             batch_size=1,
             apply=True,
-            artifact_bucket="bucket",  # type: ignore[arg-type]
+            artifact_bucket="bucket",
         )
     assert events == ["preflight"]
 

--- a/runner/tests/unit/test_normalized_storage_backfill.py
+++ b/runner/tests/unit/test_normalized_storage_backfill.py
@@ -6,12 +6,14 @@ from __future__ import annotations
 
 import hashlib
 from collections import Counter
-from dataclasses import replace
-from datetime import UTC, datetime
+from contextlib import nullcontext
+from dataclasses import astuple, replace
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 from uuid import uuid4
 
+import click
 import psycopg
 import pytest
 from alembic import command as alembic_command
@@ -107,6 +109,9 @@ class _Bucket:
 
     def blob(self, key: str) -> _Blob:
         return self.blobs.setdefault(key, _Blob(key))
+
+    def test_iam_permissions(self, permissions: list[str]) -> list[str]:
+        return permissions
 
 
 class _Storage:
@@ -230,6 +235,263 @@ def test_cli_apply_requires_explicit_frozen_maximum() -> None:
     result = CliRunner().invoke(backfill_normalized_storage_cli, ["--apply"])
     assert result.exit_code == 2
     assert "--apply requires an explicit --max-result-id" in result.output
+
+
+def test_cli_rejects_the_local_placeholder_before_connecting(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class Settings:
+        database_url = "postgresql://unused:unused@127.0.0.1:5432/unused"
+
+    monkeypatch.setattr(migration, "get_settings", lambda: Settings())
+    monkeypatch.setattr(
+        migration.psycopg, "connect", lambda *_: pytest.fail("must not connect to placeholder")
+    )
+    result = CliRunner().invoke(backfill_normalized_storage_cli, ["--max-result-id", "1"])
+    assert result.exit_code == 1
+    assert "DATABASE_URL is required" in result.output
+
+
+def test_run_pages_keyset_by_run_id_not_interleaved_result_ids() -> None:
+    first = replace(_row("WER", 1.0), id=1, run_id=10, benchmark="STT")
+    second = replace(_row("WER", 2.0), id=2, run_id=20, benchmark="STT")
+
+    class Cursor:
+        def __init__(self) -> None:
+            self.result: list[tuple[Any, ...]] = []
+            self.calls: list[tuple[str, tuple[Any, ...]]] = []
+
+        def __enter__(self) -> Cursor:
+            return self
+
+        def __exit__(self, *_: Any) -> None:
+            return None
+
+        def execute(self, sql: str, params: tuple[Any, ...]) -> None:
+            self.calls.append((sql, params))
+            if sql == migration._PAGE_RUN_IDS_SQL:
+                after = int(params[2])
+                self.result = [(run_id,) for run_id in (10, 20) if run_id > after][: int(params[3])]
+            else:
+                self.result = [astuple(first) if params[0] == [10] else astuple(second)]
+
+        def fetchall(self) -> list[tuple[Any, ...]]:
+            return self.result
+
+    class Conn:
+        def __init__(self) -> None:
+            self.value = Cursor()
+
+        def cursor(self) -> Cursor:
+            return self.value
+
+    conn = Conn()
+    ids, rows = migration._run_page(conn, 1, 99, 0, 1)  # type: ignore[arg-type]
+    next_ids, next_rows = migration._run_page(conn, 1, 99, ids[-1], 1)  # type: ignore[arg-type]
+    assert (ids, [row.run_id for row in rows]) == ([10], [10])
+    assert (next_ids, [row.run_id for row in next_rows]) == ([20], [20])
+    assert [call[1][2] for call in conn.value.calls if call[0] == migration._PAGE_RUN_IDS_SQL] == [
+        0,
+        10,
+    ]
+
+
+def test_scheduled_buckets_uses_nullable_timestamp_keyset_across_pages() -> None:
+    later = _NOW + timedelta(hours=1)
+
+    class Cursor:
+        def __init__(self) -> None:
+            self.calls: list[tuple[Any, ...]] = []
+            self.result: list[tuple[datetime, int]] = []
+
+        def __enter__(self) -> Cursor:
+            return self
+
+        def __exit__(self, *_: Any) -> None:
+            return None
+
+        def execute(self, _: str, params: tuple[Any, ...]) -> None:
+            self.calls.append(params)
+            cursor = params[4]
+            self.result = (
+                [(_NOW, 10)] if cursor is None else [(later, 20)] if cursor == _NOW else []
+            )
+
+        def fetchall(self) -> list[tuple[datetime, int]]:
+            return self.result
+
+    class Conn:
+        def __init__(self) -> None:
+            self.value = Cursor()
+
+        def commit(self) -> None:
+            return None
+
+        def cursor(self) -> Cursor:
+            return self.value
+
+    conn = Conn()
+    assert list(migration._scheduled_buckets(conn, 1, 99, 1)) == [_NOW, later]  # type: ignore[arg-type]
+    assert conn.value.calls == [
+        (1, 99, 1, 99, None, None, 0, 1),
+        (1, 99, 1, 99, _NOW, _NOW, 10, 1),
+        (1, 99, 1, 99, later, later, 20, 1),
+    ]
+
+
+def test_apply_replans_for_fresh_verification_without_retaining_pages(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    row = replace(_row("WER", 1.0), benchmark="STT")
+    plan = migration.Planned(
+        [row],
+        "sample",
+        row.dataset_id,
+        row.dataset_sha256,
+        "STT",
+        "dataset_audio",
+        "succeeded",
+        None,
+        None,
+        [],
+    )
+    passes: list[int] = []
+    mismatch_flags: list[bool] = []
+
+    def pages(*_: Any) -> Any:
+        passes.append(1)
+        yield [row], [row]
+
+    class Cursor:
+        def __enter__(self) -> Cursor:
+            return self
+
+        def __exit__(self, *_: Any) -> None:
+            return None
+
+        def execute(self, *_: Any) -> None:
+            return None
+
+        def fetchone(self) -> tuple[Any, ...]:
+            return (plan.id,)
+
+    class Conn:
+        def commit(self) -> None:
+            return None
+
+        def rollback(self) -> None:
+            return None
+
+        def cursor(self) -> Cursor:
+            return Cursor()
+
+        def transaction(self) -> Any:
+            return nullcontext()
+
+    monkeypatch.setattr(migration, "_complete_pages", pages)
+    monkeypatch.setattr(migration, "_page_plans", lambda *_: [plan])
+    monkeypatch.setattr(migration.storage, "Client", lambda: object())
+    monkeypatch.setattr(migration, "_preflight_artifact_bucket", lambda *_: None)
+
+    def insert(*_args: Any, **kwargs: Any) -> None:
+        mismatch_flags.append(kwargs["report_mismatch"])
+
+    monkeypatch.setattr(migration, "_insert_plan", insert)
+    monkeypatch.setattr(migration, "_refresh_bucket", lambda *_: None)
+    monkeypatch.setattr(migration, "_stored_plan_matches", lambda *_: False)
+    monkeypatch.setattr(migration, "_scheduled_buckets", lambda *_: iter(()))
+    report = migration.backfill(
+        Conn(),
+        min_result_id=1,
+        max_result_id=1,
+        batch_size=1,
+        apply=True,
+        artifact_bucket="bucket",  # type: ignore[arg-type]
+    )
+    assert len(passes) == 2
+    assert mismatch_flags == [False]
+    assert report["parity_mismatch_count"] == 1
+
+
+def test_apply_bucket_preflight_fails_before_lock_page_or_write(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[str] = []
+
+    class Bucket:
+        def test_iam_permissions(self, _: list[str]) -> list[str]:
+            events.append("preflight")
+            return []
+
+    class Storage:
+        def bucket(self, _: str) -> Bucket:
+            return Bucket()
+
+    class Conn:
+        def commit(self) -> None:
+            events.append("commit")
+
+        def cursor(self) -> Any:
+            events.append("lock")
+            return nullcontext()
+
+    monkeypatch.setattr(migration.storage, "Client", lambda: Storage())
+    with pytest.raises(click.ClickException, match="storage.objects.create"):
+        migration.backfill(
+            Conn(),
+            min_result_id=1,
+            max_result_id=1,
+            batch_size=1,
+            apply=True,
+            artifact_bucket="bucket",  # type: ignore[arg-type]
+        )
+    assert events == ["preflight"]
+
+
+def test_packaged_manifest_index_preserves_ambiguity_and_is_bounded(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    migration._packaged_manifest.cache_clear()
+    reads = 0
+
+    class Resource:
+        def read_bytes(self) -> bytes:
+            nonlocal reads
+            reads += 1
+            return (
+                b'{"items":[{"path":"audio/a.wav","sample_id":"sample"},'
+                b'{"testcase_id":"T1","transcript":"prompt"},'
+                b'{"testcase_id":"T2","transcript":"prompt"}]}'
+            )
+
+    class Package:
+        def joinpath(self, _: str) -> Resource:
+            return Resource()
+
+    monkeypatch.setattr(migration, "files", lambda _: Package())
+    index = migration._packaged_manifest("tts-v1")
+    assert index is not None
+    assert migration._stt_sample("tts-v1", index.sha256, "a.wav") == "sample"
+    assert migration._tts_sample("tts-v1", index.sha256, "prompt") is None
+    assert reads == 1
+    migration._packaged_manifest.cache_clear()
+
+
+def test_mismatch_details_are_capped_but_counts_remain_exact() -> None:
+    report = migration._report()
+    for index in range(101):
+        migration._append_mismatch(report, "parity_mismatches", {"index": index})
+    migration._set_ready(report, dry_run=False)
+    assert report["parity_mismatch_count"] == 101
+    assert len(report["parity_mismatches"]) == 100
+    assert report["parity_mismatches_truncated"]
+    assert not report["cutover_ready"]
+
+
+def test_runner_image_allows_cloud_run_to_override_the_default_command() -> None:
+    dockerfile = (Path(__file__).parents[2] / "Dockerfile").read_text()
+    assert 'ENTRYPOINT ["python", "-m", "coval_bench"]' in dockerfile
+    assert 'CMD ["run"]' in dockerfile
 
 
 def test_apply_reconciles_artifacts_inputs_values_and_rollups(

--- a/runner/tests/unit/test_normalized_storage_backfill.py
+++ b/runner/tests/unit/test_normalized_storage_backfill.py
@@ -411,6 +411,101 @@ def test_apply_replans_for_fresh_verification_without_retaining_pages(
     assert len(passes) == 2
     assert mismatch_flags == [False]
     assert report["parity_mismatch_count"] == 1
+    assert report["verification_skipped_by_reason"] == {}
+
+
+@pytest.mark.parametrize("verification_reason", ["split_window_run", "scheduled_at_missing"])
+def test_apply_verification_skips_are_reported_and_block_readiness(
+    monkeypatch: pytest.MonkeyPatch, verification_reason: str
+) -> None:
+    row = replace(_row("WER", 1.0), benchmark="STT")
+    verification_row = replace(row, scheduled_at=None)
+    plan = migration.Planned(
+        [row],
+        "sample",
+        row.dataset_id,
+        row.dataset_sha256,
+        "STT",
+        "dataset_audio",
+        "succeeded",
+        None,
+        None,
+        [],
+    )
+    verification_plan = replace(plan, rows=[verification_row])
+    page_calls = 0
+
+    def pages(
+        _conn: Any,
+        _low: int,
+        _high: int,
+        _batch_size: int,
+        skipped: Counter[str],
+    ) -> Any:
+        nonlocal page_calls
+        page_calls += 1
+        if page_calls == 1:
+            yield [row], [row]
+        elif verification_reason == "split_window_run":
+            skipped[verification_reason] += 1
+        else:
+            yield [verification_row], [verification_row]
+
+    def plans(rows: list[LegacyRow], _: Counter[str]) -> list[migration.Planned]:
+        return [verification_plan if rows[0].scheduled_at is None else plan]
+
+    class Cursor:
+        def __enter__(self) -> Cursor:
+            return self
+
+        def __exit__(self, *_: Any) -> None:
+            return None
+
+        def execute(self, *_: Any) -> None:
+            return None
+
+    class Conn:
+        def commit(self) -> None:
+            return None
+
+        def rollback(self) -> None:
+            return None
+
+        def cursor(self) -> Cursor:
+            return Cursor()
+
+        def transaction(self) -> Any:
+            return nullcontext()
+
+    monkeypatch.setattr(migration, "_complete_pages", pages)
+    monkeypatch.setattr(migration, "_page_plans", plans)
+    monkeypatch.setattr(gcs_storage, "Client", lambda: object())
+    monkeypatch.setattr(migration, "_preflight_artifact_bucket", lambda *_: None)
+    monkeypatch.setattr(migration, "_insert_plan", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(migration, "_refresh_bucket", lambda *_: None)
+    monkeypatch.setattr(migration, "_scheduled_buckets", lambda *_: iter(()))
+
+    report = migration.backfill(
+        Conn(),  # type: ignore[arg-type]
+        min_result_id=1,
+        max_result_id=1,
+        batch_size=1,
+        apply=True,
+        artifact_bucket="bucket",
+    )
+
+    assert report["skipped_by_reason"] == {}
+    assert report["verification_skipped_by_reason"] == {verification_reason: 1}
+    assert report["parity_mismatch_count"] == 0
+    assert not report["cutover_ready"]
+
+
+def test_dry_run_report_has_no_verification_skips() -> None:
+    report = migration._report()
+    report["eligible"] = 1
+    migration._set_ready(report, dry_run=True)
+    assert report["verification_skipped_by_reason"] == {}
+    assert not report["cutover_ready"]
 
 
 def test_apply_bucket_preflight_fails_before_lock_page_or_write(
@@ -492,6 +587,18 @@ def test_runner_image_allows_cloud_run_to_override_the_default_command() -> None
     dockerfile = (Path(__file__).parents[2] / "Dockerfile").read_text()
     assert 'ENTRYPOINT ["python", "-m", "coval_bench"]' in dockerfile
     assert 'CMD ["run"]' in dockerfile
+
+
+def test_repository_owned_container_overrides_use_the_image_entrypoint() -> None:
+    root = Path(__file__).parents[2]
+    overrides = {
+        "docker-compose.yml": root / ".." / "docker-compose.yml",
+        "runner README": root / "README.md",
+        "arena snapshot": root / ".." / "scripts" / "arena-local.sh",
+    }
+    for name, path in overrides.items():
+        assert "docker compose run --rm runner coval-bench" not in path.read_text(), name
+    assert 'command: ["coval-bench"' not in overrides["docker-compose.yml"].read_text()
 
 
 def test_apply_reconciles_artifacts_inputs_values_and_rollups(

--- a/scripts/arena-local.sh
+++ b/scripts/arena-local.sh
@@ -92,7 +92,7 @@ cmd_up() {
   wait_for_api
 }
 
-cmd_snapshot() { docker compose run --rm runner coval-bench arena snapshot; }
+cmd_snapshot() { docker compose run --rm runner arena snapshot; }
 
 cmd_status() {
   # Match how compose resolves these: shell env wins, then .env, then default.


### PR DESCRIPTION
## Summary

- stream the frozen legacy result window by complete run-id pages instead of materializing all 16.7M rows
- add bounded manifest indexes, bounded reconciliation diagnostics, stable rollup keyset paging, and fresh post-write verification
- preflight artifact-bucket permissions before the advisory lock or any database commit
- split the runner image ENTRYPOINT and CMD so Cloud Run can invoke the one-shot migration safely
- reject the local placeholder DATABASE_URL with an actionable error

## Validation

- Ruff format/check
- strict mypy for the migration
- 17 focused unit tests passed
- independent Tier 3 review: PASS

Three real-PostgreSQL tests were not runnable locally because pg_config is unavailable. No production database, GCS object, deployment, or Cloud Run job was changed.