### PR TITLE
Pin the contract hash over committed files only

### DIFF
--- a/runner/src/coval_bench/contracts/__init__.py
+++ b/runner/src/coval_bench/contracts/__init__.py
@@ -54,6 +54,7 @@ __all__ = [
     "Stack",
     "load_stack",
     "contract_sha256",
+    "public_contract_sha256",
     "read_contract_file",
     "has_private_contract",
 ]
@@ -159,6 +160,29 @@ def read_contract_file(suite: str, filename: str) -> str:
     return _read_bytes(suite, filename).decode()
 
 
+def _digest(suite: str, filenames: tuple[str, ...]) -> str:
+    """SHA-256 over the pinned stack plus the named suite files, skipping absentees."""
+    digest = hashlib.sha256()
+    digest.update(_read_bytes("stack.json"))
+    for filename in filenames:
+        try:
+            digest.update(_read_bytes(suite, *filename.split("/")))
+        except (FileNotFoundError, NotADirectoryError):
+            continue
+    return digest.hexdigest()
+
+
+def public_contract_sha256(suite: str) -> str:
+    """The hash over committed files only, so every checkout agrees on it.
+
+    This is the one a test can pin. ``contract_sha256`` covers the uncommitted
+    fixtures too, so its value legitimately differs between a machine holding the
+    answer key and CI, which never does — pinning *that* would fail for exactly
+    the people doing the work while guarding nothing where it runs.
+    """
+    return _digest(suite, PUBLIC_CONTRACT_FILES)
+
+
 def contract_sha256(suite: str) -> str:
     """One SHA-256 over the pinned stack, the public suite files, and the fixtures.
 
@@ -167,14 +191,7 @@ def contract_sha256(suite: str) -> str:
     ``stack.json`` too, because changing a pin changes what the agent is just
     as surely as changing its prompt.
     """
-    digest = hashlib.sha256()
-    digest.update(_read_bytes("stack.json"))
-    for filename in (*PUBLIC_CONTRACT_FILES, *PRIVATE_CONTRACT_FILES):
-        try:
-            digest.update(_read_bytes(suite, *filename.split("/")))
-        except (FileNotFoundError, NotADirectoryError):
-            continue
-    return digest.hexdigest()
+    return _digest(suite, (*PUBLIC_CONTRACT_FILES, *PRIVATE_CONTRACT_FILES))
 
 
 def has_private_contract(suite: str) -> bool:

--- a/runner/tests/test_contracts.py
+++ b/runner/tests/test_contracts.py
@@ -14,16 +14,23 @@ from coval_bench.contracts import (
     LlmPin,
     Stack,
     contract_sha256,
+    has_private_contract,
     load_stack,
+    public_contract_sha256,
     read_contract_file,
     stack_as_dict,
 )
 from coval_bench.variants.platforms import redact_identifiers
 
-# Bump deliberately, in the same commit that changes a contract file or a pin.
-# A failure here means someone edited the contract without versioning it, which
-# would silently repoint every published number at a different agent.
-EXPECTED_CONTRACT_SHA = "146ac237d7ef007c"
+# Bump deliberately, in the same commit that changes a committed contract file or
+# a pin. A failure here means someone edited the contract without versioning it,
+# which would silently repoint every published number at a different agent.
+#
+# This pins the *public* hash. The full hash also covers `_private/`, which is
+# never committed, so its value differs between a machine holding the fixtures
+# and CI, which never does — pinning that would be red for exactly the people
+# doing the work and vacuous everywhere else.
+EXPECTED_PUBLIC_CONTRACT_SHA = "146ac237d7ef007c"
 
 
 def test_stack_loads_and_pins_are_what_the_design_doc_says() -> None:
@@ -43,11 +50,21 @@ def test_stack_loads_and_pins_are_what_the_design_doc_says() -> None:
     assert stack.platform_behaviour.vendor_post_call_analysis is False
 
 
-def test_contract_hash_is_pinned() -> None:
-    assert contract_sha256("dental").startswith(EXPECTED_CONTRACT_SHA), (
+def test_public_contract_hash_is_pinned() -> None:
+    assert public_contract_sha256("dental").startswith(EXPECTED_PUBLIC_CONTRACT_SHA), (
         "The dental contract or the pinned stack changed. If that was deliberate, "
-        "update EXPECTED_CONTRACT_SHA in the same commit."
+        "update EXPECTED_PUBLIC_CONTRACT_SHA in the same commit."
     )
+
+
+def test_the_published_hash_also_covers_the_private_fixtures() -> None:
+    """What ran is identified by the fixtures too, not just the committed files.
+
+    Skips in CI and a fresh checkout, where `_private/` does not exist.
+    """
+    if not has_private_contract("dental"):
+        pytest.skip("private fixtures are not installed")
+    assert contract_sha256("dental") != public_contract_sha256("dental")
 
 
 def test_rationale_keys_are_allowed_and_survive_load() -> None:


### PR DESCRIPTION
The published contract hash covers the private fixtures as well as the committed contract. That is right for identifying what ran, and wrong for a test to assert: `_private/` never exists in CI, so the pin passed there while never seeing half of what it hashed, and failed on any machine that actually holds the fixtures. It was red for the people doing the work and vacuous where it ran.

`public_contract_sha256` covers the committed files and is what the test pins. The value is unchanged — `146ac237d7ef007c` was always what was being computed. `contract_sha256` still covers everything and stays the number published beside results.

A second test asserts the published hash still differs when the fixtures are present, and skips when they are not.