### PR TITLE
Read the mock fixtures from outside the checkout

### DIFF
--- a/runner/src/coval_bench/__main__.py
+++ b/runner/src/coval_bench/__main__.py
@@ -36,9 +36,17 @@ _SMOKE_TIMEOUT_S = 120
 def cli() -> None:
     """Coval voice-AI benchmarks runner."""
     from coval_bench.config import get_settings
+    from coval_bench.fixture_sources import install_fixture_providers
     from coval_bench.logging import configure_logging
 
-    configure_logging(level=get_settings().log_level)
+    settings = get_settings()
+    configure_logging(level=settings.log_level)
+    # Every command that reads or hashes a contract gets the same fixture sources
+    # the API has. `pull-contract` prints the hash today and the voice-agent
+    # ingest will write it onto result rows; a runner that could not see the
+    # fixtures would publish the hash of a run that had none, which is the one
+    # thing the hash exists to prevent.
+    install_fixture_providers(settings)
 
 
 @cli.command(name="run")

--- a/runner/src/coval_bench/api/app.py
+++ b/runner/src/coval_bench/api/app.py
@@ -58,6 +58,7 @@ from coval_bench.api.routers import (
 )
 from coval_bench.config import Settings, get_settings
 from coval_bench.db.conn import lifespan_pool
+from coval_bench.fixture_sources import install_fixture_providers
 from coval_bench.logging import configure_logging
 from coval_bench.mocktools.dispatch import build_dispatcher
 
@@ -119,6 +120,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         # fixtures inside a live call would put that cost on the agent's turn.
         # Absent fixtures are normal in CI and a fresh checkout, so the route
         # answers 503 rather than the service refusing to start.
+        install_fixture_providers(resolved)
         try:
             app.state.mock_dispatcher = build_dispatcher(resolved.mock_tools_suite)
         except (FileNotFoundError, NotADirectoryError):

--- a/runner/src/coval_bench/api/routers/mocktools.py
+++ b/runner/src/coval_bench/api/routers/mocktools.py
@@ -31,7 +31,7 @@ from starlette.responses import JSONResponse
 from coval_bench.api.deps import get_pool, get_settings
 from coval_bench.config import Settings
 from coval_bench.db.mock_tool_store import record_call
-from coval_bench.mocktools.dispatch import Dispatcher, build_dispatcher
+from coval_bench.mocktools.dispatch import Dispatcher
 
 logger = structlog.get_logger("coval_bench.mocktools")
 
@@ -61,18 +61,18 @@ def require_mock_secret(
         raise HTTPException(401, f"a valid {SECRET_HEADER} is required")
 
 
-def get_dispatcher(request: Request, settings: Settings = Depends(get_settings)) -> Dispatcher:
-    """The suite's dispatcher, built once per process from the contract and fixtures."""
-    existing: Dispatcher | None = getattr(request.app.state, "mock_dispatcher", None)
-    if existing is not None:
-        return existing
-    try:
-        dispatcher = build_dispatcher(settings.mock_tools_suite)
-    except (FileNotFoundError, NotADirectoryError) as exc:
-        raise HTTPException(503, "mock tool fixtures are not installed") from exc
-    except ValueError as exc:
-        raise HTTPException(503, f"mock tool fixtures are unusable: {exc}") from exc
-    request.app.state.mock_dispatcher = dispatcher
+def get_dispatcher(request: Request) -> Dispatcher:
+    """The dispatcher the lifespan built, or 503.
+
+    Deliberately does not build one here. Loading the fixtures can mean a call
+    out to object storage, and a service that failed to load them at startup will
+    not succeed on request four hundred — retrying per request would put a round
+    trip in front of every tool call, in the middle of a live conversation, and a
+    miss is not something a cache prevents. Startup has already logged why.
+    """
+    dispatcher: Dispatcher | None = getattr(request.app.state, "mock_dispatcher", None)
+    if dispatcher is None:
+        raise HTTPException(503, "mock tool fixtures are not loaded")
     return dispatcher
 
 

--- a/runner/src/coval_bench/config.py
+++ b/runner/src/coval_bench/config.py
@@ -162,6 +162,10 @@ class Settings(BaseSettings):
     # constant across variants instead of a property of the seed that answered.
     mock_tools_latency_ms: float = Field(default=50.0, ge=0)
     mock_tools_suite: str = "dental"
+    # Where the deployed service reads the seeded world, since the image is
+    # built from a git checkout and `_private/` is never in one. Empty means
+    # local-only, which is every developer machine.
+    mock_fixtures_bucket: str = ""
     coval_api_base: str = "https://api.coval.dev/v1"
     # The S2S latency metric id + per-provider Coval agent ids (opaque, not secret).
     coval_s2s_latency_metric_id: str | None = None

--- a/runner/src/coval_bench/contracts/__init__.py
+++ b/runner/src/coval_bench/contracts/__init__.py
@@ -43,9 +43,11 @@ vendor rejecting it at apply time; a mistyped key would silently drop the pin.
 
 from __future__ import annotations
 
+import contextlib
 import hashlib
 import importlib.resources
 import json
+from collections.abc import Callable
 from typing import Any, Literal, cast
 
 from pydantic import BaseModel, ConfigDict, model_validator
@@ -58,6 +60,8 @@ __all__ = [
     "read_contract_file",
     "has_private_contract",
     "read_private_fixture",
+    "FixtureProvider",
+    "register_fixture_provider",
     "AnnotatedModel",
 ]
 
@@ -168,8 +172,13 @@ def read_contract_file(suite: str, filename: str) -> str:
     return _read_bytes(suite, filename).decode()
 
 
-def _digest(suite: str, filenames: tuple[str, ...]) -> str:
-    """SHA-256 over the pinned stack plus the named suite files, skipping absentees."""
+def _digest(suite: str, filenames: tuple[str, ...], extra: bytes | None = None) -> str:
+    """SHA-256 over the pinned stack, the named suite files, and any trailing bytes.
+
+    ``extra`` carries the private fixtures, which do not come from ``_read_bytes``
+    on a deployment that fetched them from a provider. Appending them last keeps
+    the digest byte-order identical to reading them as the final filename.
+    """
     digest = hashlib.sha256()
     digest.update(_read_bytes("stack.json"))
     for filename in filenames:
@@ -177,6 +186,8 @@ def _digest(suite: str, filenames: tuple[str, ...]) -> str:
             digest.update(_read_bytes(suite, *filename.split("/")))
         except (FileNotFoundError, NotADirectoryError):
             continue
+    if extra is not None:
+        digest.update(extra)
     return digest.hexdigest()
 
 
@@ -199,7 +210,14 @@ def contract_sha256(suite: str) -> str:
     ``stack.json`` too, because changing a pin changes what the agent is just
     as surely as changing its prompt.
     """
-    return _digest(suite, (*PUBLIC_CONTRACT_FILES, *PRIVATE_CONTRACT_FILES))
+    # The private half goes through `read_private_fixture`, not `_read_bytes`, so
+    # the hash covers whatever the service actually loaded. Reading the checkout
+    # directly here would make a deployment that fetched its fixtures from a
+    # provider publish the fixture-less hash while serving the fixtures.
+    private: bytes | None = None
+    with contextlib.suppress(FileNotFoundError, NotADirectoryError):
+        private = read_private_fixture(suite)
+    return _digest(suite, PUBLIC_CONTRACT_FILES, extra=private)
 
 
 def has_private_contract(suite: str) -> bool:
@@ -215,14 +233,50 @@ def has_private_contract(suite: str) -> bool:
     return True
 
 
-def read_private_fixture(suite: str) -> bytes:
-    """Read the suite's uncommitted mock fixtures.
+# A source of fixtures that is not the local checkout. The deployed image cannot
+# carry `_private/` — it is gitignored, and the build context is a git checkout —
+# so production reads the seeded world from somewhere else. That somewhere
+# registers itself here rather than being imported, because this module is
+# deliberately dependency-light and has no business knowing about object storage.
+FixtureProvider = Callable[[str], bytes]
 
-    Raises ``FileNotFoundError`` in a fresh checkout and in CI, where
-    ``_private/`` does not exist. Callers that can run without the seeded world
-    should ask ``has_private_contract`` first.
+_FIXTURE_PROVIDERS: list[FixtureProvider] = []
+
+
+def register_fixture_provider(provider: FixtureProvider) -> None:
+    """Add a fallback source, consulted in registration order when local is absent.
+
+    A provider raises ``FileNotFoundError`` for a suite it does not carry, and
+    the chain moves on.
     """
-    return _read_bytes(suite, "_private", "mock-tools.json")
+    _FIXTURE_PROVIDERS.append(provider)
+
+
+def read_private_fixture(suite: str) -> bytes:
+    """Read the suite's uncommitted mock fixtures: local checkout, then providers.
+
+    Local wins, so that editing the file is what a developer sees take effect.
+
+    **Every reader goes through here, `contract_sha256` included, and that is the
+    point.** The hash covers the seeded world, so a fallback wired only into the
+    mock service would leave production serving the right fixtures while
+    publishing a hash computed as though it had none — a different "what ran"
+    number on every result, with nothing to notice it.
+
+    Raises ``FileNotFoundError`` when neither the checkout nor any provider has
+    it. Callers that can run without the seeded world should ask
+    ``has_private_contract`` first.
+    """
+    try:
+        return _read_bytes(suite, "_private", "mock-tools.json")
+    except (FileNotFoundError, NotADirectoryError):
+        pass
+    for provider in _FIXTURE_PROVIDERS:
+        try:
+            return provider(suite)
+        except (FileNotFoundError, NotADirectoryError):
+            continue
+    raise FileNotFoundError(f"no mock fixtures for suite {suite!r}, locally or from a provider")
 
 
 def stack_as_dict(stack: Stack) -> dict[str, Any]:

--- a/runner/src/coval_bench/fixture_sources.py
+++ b/runner/src/coval_bench/fixture_sources.py
@@ -1,0 +1,71 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Where the seeded world comes from when it is not in the checkout.
+
+``contracts`` deliberately knows nothing about storage; it exposes a seam and
+this module fills it. Keeping the two apart is what lets the fixtures move to a
+different store later without touching the contract or the published hash.
+
+The object path mirrors the layout on disk, so it is a mechanical function of
+the suite name and nothing has to be remembered:
+
+    disk  contracts/<suite>/_private/mock-tools.json
+    gcs   gs://<bucket>/contracts/<suite>/mock-tools.json
+"""
+
+from __future__ import annotations
+
+import functools
+from typing import TYPE_CHECKING
+
+import structlog
+
+from coval_bench import gcs
+from coval_bench.contracts import FixtureProvider, register_fixture_provider
+
+if TYPE_CHECKING:
+    from google.cloud import storage
+
+    from coval_bench.config import Settings
+
+logger = structlog.get_logger("coval_bench.fixtures")
+
+FIXTURE_OBJECT = "contracts/{suite}/mock-tools.json"
+
+
+def gcs_fixture_provider(
+    bucket: str, *, storage_client: storage.Client | None = None
+) -> FixtureProvider:
+    """A provider reading each suite's fixtures from *bucket*, fetched once.
+
+    Memoised on purpose, and not for the round trip — on the happy path there is
+    exactly one fetch, at startup. The seeded world must not change under a
+    running benchmark: the contract hash is computed over these bytes and
+    published beside every result, so an object edited mid-run would leave some
+    results citing a hash that no longer describes what they ran against. A
+    fixture update takes effect on the next start, which is also when the hash is
+    next computed.
+    """
+
+    @functools.cache
+    def provider(suite: str) -> bytes:
+        key = FIXTURE_OBJECT.format(suite=suite)
+        data = gcs.read_bytes(bucket, key, storage_client=storage_client)
+        if data is None:
+            # Not an error: the chain moves on to the next provider.
+            raise FileNotFoundError(f"gs://{bucket}/{key}")
+        logger.info("mock_fixtures_loaded", suite=suite, bucket=bucket, bytes=len(data))
+        return data
+
+    return provider
+
+
+def install_fixture_providers(settings: Settings) -> None:
+    """Register whatever sources this deployment is configured for.
+
+    Called once per process, by each entry point that reads fixtures: the API
+    serves them, and the runner hashes them.
+    """
+    if settings.mock_fixtures_bucket:
+        register_fixture_provider(gcs_fixture_provider(settings.mock_fixtures_bucket))

--- a/runner/src/coval_bench/gcs.py
+++ b/runner/src/coval_bench/gcs.py
@@ -41,6 +41,20 @@ def read_json(
     return decoded
 
 
+def read_bytes(
+    bucket_name: str,
+    key: str,
+    *,
+    storage_client: storage.Client | None = None,
+) -> bytes | None:
+    """The object's bytes, or ``None`` when it is not there."""
+    gcs = storage_client if storage_client is not None else client()
+    try:
+        return bytes(gcs.bucket(bucket_name).blob(key).download_as_bytes())
+    except NotFound:
+        return None
+
+
 def signed_url(
     bucket_name: str,
     key: str,

--- a/runner/tests/api/test_mocktools.py
+++ b/runner/tests/api/test_mocktools.py
@@ -16,6 +16,7 @@ import pytest_asyncio
 from fastapi import FastAPI
 from httpx import AsyncClient
 
+import coval_bench.contracts as contracts_module
 from coval_bench.mocktools.dispatch import Dispatcher, load_tool_specs
 from coval_bench.mocktools.fixtures import MockFixtures, Seed, ToolFixture
 from tests.api.conftest import MOCK_TOOLS_KEY, _make_db_url
@@ -107,6 +108,32 @@ async def test_an_unconfigured_secret_closes_the_appliance(
     mock_app.state.settings = mock_app.state.settings.model_copy(update={"mock_tools_secret": None})
     response = await client.post("/mock/lookup_patient", json={"phone": PHONE}, headers=AUTH)
     assert response.status_code == 503
+
+
+async def test_unloaded_fixtures_answer_503_without_reaching_storage(
+    client: AsyncClient, app: FastAPI
+) -> None:
+    """Startup owns the build, so a request never retries it.
+
+    Retrying per request would put a round trip in front of every tool call, in
+    the middle of a live conversation, and a miss is not something a cache
+    prevents. A provider registered here must never be consulted.
+    """
+    app.state.mock_dispatcher = None
+    consulted = False
+
+    def never(suite: str) -> bytes:
+        nonlocal consulted
+        consulted = True
+        raise FileNotFoundError(suite)
+
+    contracts_module._FIXTURE_PROVIDERS.append(never)
+    try:
+        response = await client.post("/mock/lookup_patient", json={"phone": PHONE}, headers=AUTH)
+    finally:
+        contracts_module._FIXTURE_PROVIDERS.remove(never)
+    assert response.status_code == 503
+    assert not consulted
 
 
 # --- answers ---------------------------------------------------------------

--- a/runner/tests/test_contracts.py
+++ b/runner/tests/test_contracts.py
@@ -10,6 +10,7 @@ import json
 import pytest
 from pydantic import ValidationError
 
+import coval_bench.contracts as contracts_module
 from coval_bench.contracts import (
     LlmPin,
     Stack,
@@ -18,6 +19,8 @@ from coval_bench.contracts import (
     load_stack,
     public_contract_sha256,
     read_contract_file,
+    read_private_fixture,
+    register_fixture_provider,
     stack_as_dict,
 )
 from coval_bench.variants.platforms import redact_identifiers
@@ -123,3 +126,90 @@ def test_redact_identifiers_leaves_methodology_alone() -> None:
         "nested": [{"phone_number": "[REDACTED]"}],
     }
     assert found == ["id", "nested[0].phone_number"]
+
+
+# --- the fixture fallback chain ---------------------------------------------
+#
+# `_private/` is gitignored and the image is built from a git checkout, so the
+# deployed service can never carry the seeded world. It reads it from elsewhere,
+# and that elsewhere registers itself here.
+
+SEEDED = b'{"tools": {}}'
+
+
+@pytest.fixture
+def no_providers(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An empty chain, so one test cannot leak a provider into the next."""
+    monkeypatch.setattr(contracts_module, "_FIXTURE_PROVIDERS", [])
+
+
+@pytest.fixture
+def checkout_without_fixtures(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A checkout where only `_private/` is missing, as in CI and in the image."""
+    real = contracts_module._read_bytes
+
+    def missing_private(*parts: str) -> bytes:
+        if "_private" in parts:
+            raise FileNotFoundError("/".join(parts))
+        return real(*parts)
+
+    monkeypatch.setattr(contracts_module, "_read_bytes", missing_private)
+
+
+def test_a_provider_answers_when_the_checkout_has_none(
+    no_providers: None, checkout_without_fixtures: None
+) -> None:
+    register_fixture_provider(lambda suite: SEEDED)
+    assert read_private_fixture("dental") == SEEDED
+
+
+def test_the_local_checkout_wins_over_a_provider(no_providers: None) -> None:
+    """Editing the file is what a developer expects to take effect."""
+    if not has_private_contract("dental"):
+        pytest.skip("local fixtures are not installed")
+    register_fixture_provider(lambda suite: SEEDED)
+    assert read_private_fixture("dental") != SEEDED
+
+
+def test_a_provider_without_the_suite_falls_through(
+    no_providers: None, checkout_without_fixtures: None
+) -> None:
+    def absent(suite: str) -> bytes:
+        raise FileNotFoundError(suite)
+
+    register_fixture_provider(absent)
+    register_fixture_provider(lambda suite: SEEDED)
+    assert read_private_fixture("dental") == SEEDED
+
+
+def test_an_empty_chain_still_raises(no_providers: None, checkout_without_fixtures: None) -> None:
+    with pytest.raises(FileNotFoundError):
+        read_private_fixture("dental")
+
+
+def test_the_published_hash_is_the_same_whichever_source_supplied_the_bytes(
+    no_providers: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The reason the fallback lives in the reader and not in the mock service.
+
+    `contract_sha256` reads through the same function. A fallback wired only into
+    dispatch would leave production serving the right fixtures while publishing a
+    hash computed as though it had none — a different "what ran" number on every
+    result, and nothing to notice it.
+    """
+    if not has_private_contract("dental"):
+        pytest.skip("local fixtures are not installed")
+    from_disk = contract_sha256("dental")
+    seeded = read_private_fixture("dental")
+
+    real = contracts_module._read_bytes
+
+    def missing_private(*parts: str) -> bytes:
+        if "_private" in parts:
+            raise FileNotFoundError("/".join(parts))
+        return real(*parts)
+
+    monkeypatch.setattr(contracts_module, "_read_bytes", missing_private)
+    register_fixture_provider(lambda suite: seeded)
+    assert contract_sha256("dental") == from_disk
+    assert contract_sha256("dental") != public_contract_sha256("dental")

--- a/runner/tests/unit/test_fixture_sources.py
+++ b/runner/tests/unit/test_fixture_sources.py
@@ -103,3 +103,36 @@ def test_nothing_is_registered_without_a_bucket(no_providers: None) -> None:
 def test_a_configured_bucket_registers_one_provider(no_providers: None) -> None:
     install_fixture_providers(Settings(mock_fixtures_bucket=BUCKET))
     assert len(contracts_module._FIXTURE_PROVIDERS) == 1
+
+
+# --- every entry point, not just the API ------------------------------------
+
+
+def test_the_cli_installs_the_same_providers_the_api_does(
+    no_providers: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The runner hashes contracts too.
+
+    `pull-contract` prints the hash today and the voice-agent ingest will write
+    it onto result rows. A runner that could not see the fixtures would publish
+    the hash of a run that had none — the one thing the hash exists to prevent.
+    """
+    from click.testing import CliRunner
+
+    from coval_bench.__main__ import cli
+    from coval_bench.config import get_settings
+
+    monkeypatch.setenv("MOCK_FIXTURES_BUCKET", BUCKET)
+    monkeypatch.setenv("DATABASE_URL", "postgresql://u:p@localhost:5432/db")
+    monkeypatch.setenv("DATASET_BUCKET", "b")
+    monkeypatch.setenv("DATASET_ID", "d")
+    get_settings.cache_clear()
+    try:
+        # A subcommand's help runs the group callback first, then exits before
+        # the subcommand does anything. `--help` on the *group* would not: click
+        # handles that eagerly and never reaches the callback.
+        result = CliRunner().invoke(cli, ["pull-contract", "--help"])
+        assert result.exit_code == 0, result.output
+        assert len(contracts_module._FIXTURE_PROVIDERS) == 1
+    finally:
+        get_settings.cache_clear()

--- a/runner/tests/unit/test_fixture_sources.py
+++ b/runner/tests/unit/test_fixture_sources.py
@@ -1,0 +1,105 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""The GCS source that fills the fixture seam on a deployment."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from google.api_core.exceptions import NotFound
+
+import coval_bench.contracts as contracts_module
+from coval_bench.config import Settings
+from coval_bench.fixture_sources import (
+    FIXTURE_OBJECT,
+    gcs_fixture_provider,
+    install_fixture_providers,
+)
+
+SEEDED = b'{"tools": {}}'
+BUCKET = "coval-benchmarks-contracts"
+
+
+class _Blob:
+    def __init__(self, store: dict[str, bytes], key: str) -> None:
+        self._store = store
+        self._key = key
+        self.downloads = 0
+
+    def download_as_bytes(self) -> bytes:
+        if self._key not in self._store:
+            raise NotFound(self._key)  # type: ignore[no-untyped-call]
+        self.downloads += 1
+        return self._store[self._key]
+
+
+class _FakeClient:
+    """Just enough of storage.Client, and it counts round trips."""
+
+    def __init__(self, objects: dict[str, bytes]) -> None:
+        self._objects = objects
+        self.blobs: list[_Blob] = []
+
+    def bucket(self, name: str) -> _FakeClient:
+        assert name == BUCKET
+        return self
+
+    def blob(self, key: str) -> _Blob:
+        blob = _Blob(self._objects, key)
+        self.blobs.append(blob)
+        return blob
+
+    @property
+    def downloads(self) -> int:
+        return sum(b.downloads for b in self.blobs)
+
+
+@pytest.fixture
+def no_providers(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(contracts_module, "_FIXTURE_PROVIDERS", [])
+
+
+def _client(**objects: bytes) -> Any:
+    return _FakeClient({FIXTURE_OBJECT.format(suite=s): b for s, b in objects.items()})
+
+
+def test_the_object_path_mirrors_the_layout_on_disk() -> None:
+    assert FIXTURE_OBJECT.format(suite="dental") == "contracts/dental/mock-tools.json"
+
+
+def test_a_seeded_suite_is_returned() -> None:
+    provider = gcs_fixture_provider(BUCKET, storage_client=_client(dental=SEEDED))
+    assert provider("dental") == SEEDED
+
+
+def test_a_missing_object_raises_file_not_found_so_the_chain_continues() -> None:
+    """Not an error: another provider may carry the suite."""
+    provider = gcs_fixture_provider(BUCKET, storage_client=_client(dental=SEEDED))
+    with pytest.raises(FileNotFoundError):
+        provider("insurance")
+
+
+def test_the_fetch_is_memoised() -> None:
+    """The seeded world must not change under a running benchmark.
+
+    The contract hash is computed over these bytes and published beside every
+    result, so a mid-run change would silently invalidate it.
+    """
+    client = _client(dental=SEEDED)
+    provider = gcs_fixture_provider(BUCKET, storage_client=client)
+    for _ in range(3):
+        assert provider("dental") == SEEDED
+    assert client.downloads == 1
+
+
+def test_nothing_is_registered_without_a_bucket(no_providers: None) -> None:
+    """Every developer machine: local fixtures only, no cloud call attempted."""
+    install_fixture_providers(Settings(mock_fixtures_bucket=""))
+    assert contracts_module._FIXTURE_PROVIDERS == []
+
+
+def test_a_configured_bucket_registers_one_provider(no_providers: None) -> None:
+    install_fixture_providers(Settings(mock_fixtures_bucket=BUCKET))
+    assert len(contracts_module._FIXTURE_PROVIDERS) == 1


### PR DESCRIPTION
`_private/mock-tools.json` is gitignored and the image is built from a git checkout, so the deployed service can never carry the seeded world. Today that means the mock deploys correctly and answers 503 to everything. This gives it a source.

`contracts` exposes a seam — a `FixtureProvider` callable registered at startup — and knows nothing about storage; `fixture_sources` fills it from the bucket in benchmark-infra#148. Keeping them apart is what lets the fixtures move to a different store later without touching the contract or the published hash. The object path mirrors the layout on disk, so it is a mechanical function of the suite name: `contracts/<suite>/mock-tools.json`.

The hash reads through the same seam, and that is the point. `contract_sha256` had been reading the private half directly, so a deployment that fetched its fixtures from a provider would have served them while publishing the hash of a run that had none — a different "what ran" number on every result, with nothing to notice it. `_digest` now takes the fixtures as trailing bytes, which keeps the digest byte-order and leaves both published hashes unchanged: `146ac237…` public, `7c91811e…` full.

The provider is memoised, not for the round trip — on the happy path there is one fetch, at startup — but because the hash is published beside every result, so an object edited mid-run would leave some results citing a hash that no longer describes what they ran against.

One change here is to already-merged code and is worth calling out. The mock router used to rebuild the dispatcher on any request that arrived without one. That retry was free when the fixtures were a local file and is not once they are an object: it would put a round trip in front of every tool call, mid-conversation, and a miss is not something a cache prevents. Startup now owns the build and has already logged any failure; a request gets a clean 503 and reaches no storage at all. A test asserts a registered provider is never consulted on that path.

Needs benchmark-infra#148 for the bucket. Without `MOCK_FIXTURES_BUCKET` set, nothing is registered and behaviour is exactly as before — which is every developer machine.
