### PR TITLE
Restore the runner image's full CMD so scheduled jobs boot

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@
 #   docker compose up -d db     # bring up Postgres only
 #   docker compose run --rm migrate
 #   docker compose up api       # FastAPI on http://localhost:8000
-#   docker compose run --rm runner run --smoke --kind tts
+#   docker compose run --rm runner coval-bench run --smoke --kind tts
 #
 # The `runner` and `migrate` services have profiles so `docker compose up` only
 # starts long-running services (db, api). One-shot commands are invoked via
@@ -36,7 +36,7 @@ services:
     env_file: .env
     environment:
       DATABASE_URL: postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@db:5432/${POSTGRES_DB:-benchmarks}
-    command: ["db", "migrate"]
+    command: ["coval-bench", "db", "migrate"]
     depends_on:
       db:
         condition: service_healthy

--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -74,5 +74,4 @@ COPY --from=build --chown=65532:65532 /app /app
 
 USER 65532:65532
 
-ENTRYPOINT ["python", "-m", "coval_bench"]
-CMD ["run"]
+CMD ["python", "-m", "coval_bench", "run"]

--- a/runner/README.md
+++ b/runner/README.md
@@ -44,10 +44,10 @@ docker compose run --rm migrate  # alembic upgrade head
 docker compose up -d api         # FastAPI on http://localhost:8000
 
 # Trigger a single-item benchmark run (writes to the local Postgres):
-docker compose run --rm runner run --smoke --kind tts
+docker compose run --rm runner coval-bench run --smoke --kind tts
 
 # Probe one TTS provider without DB writes:
-docker compose run --rm runner tts-smoke \
+docker compose run --rm runner coval-bench tts-smoke \
   --provider cartesia --model sonic-3 --voice <voice-id> --text "hello"
 ```
 

--- a/runner/tests/unit/test_normalized_storage_backfill.py
+++ b/runner/tests/unit/test_normalized_storage_backfill.py
@@ -594,9 +594,10 @@ def test_repository_owned_container_overrides_spell_the_whole_command() -> None:
     compose = (root / ".." / "docker-compose.yml").read_text()
     assert 'command: ["coval-bench", "db", "migrate"]' in compose
     assert "docker compose run --rm runner coval-bench run" in (root / "README.md").read_text()
-    assert "docker compose run --rm runner coval-bench arena snapshot" in (
-        root / ".." / "scripts" / "arena-local.sh"
-    ).read_text()
+    assert (
+        "docker compose run --rm runner coval-bench arena snapshot"
+        in (root / ".." / "scripts" / "arena-local.sh").read_text()
+    )
 
 
 def test_apply_reconciles_artifacts_inputs_values_and_rollups(

--- a/runner/tests/unit/test_normalized_storage_backfill.py
+++ b/runner/tests/unit/test_normalized_storage_backfill.py
@@ -583,22 +583,20 @@ def test_mismatch_details_are_capped_but_counts_remain_exact() -> None:
     assert not report["cutover_ready"]
 
 
-def test_runner_image_allows_cloud_run_to_override_the_default_command() -> None:
+def test_runner_image_has_no_entrypoint_so_args_overrides_are_whole_commands() -> None:
     dockerfile = (Path(__file__).parents[2] / "Dockerfile").read_text()
-    assert 'ENTRYPOINT ["python", "-m", "coval_bench"]' in dockerfile
-    assert 'CMD ["run"]' in dockerfile
+    assert "ENTRYPOINT" not in dockerfile
+    assert 'CMD ["python", "-m", "coval_bench", "run"]' in dockerfile
 
 
-def test_repository_owned_container_overrides_use_the_image_entrypoint() -> None:
+def test_repository_owned_container_overrides_spell_the_whole_command() -> None:
     root = Path(__file__).parents[2]
-    overrides = {
-        "docker-compose.yml": root / ".." / "docker-compose.yml",
-        "runner README": root / "README.md",
-        "arena snapshot": root / ".." / "scripts" / "arena-local.sh",
-    }
-    for name, path in overrides.items():
-        assert "docker compose run --rm runner coval-bench" not in path.read_text(), name
-    assert 'command: ["coval-bench"' not in overrides["docker-compose.yml"].read_text()
+    compose = (root / ".." / "docker-compose.yml").read_text()
+    assert 'command: ["coval-bench", "db", "migrate"]' in compose
+    assert "docker compose run --rm runner coval-bench run" in (root / "README.md").read_text()
+    assert "docker compose run --rm runner coval-bench arena snapshot" in (
+        root / ".." / "scripts" / "arena-local.sh"
+    ).read_text()
 
 
 def test_apply_reconciles_artifacts_inputs_values_and_rollups(

--- a/scripts/arena-local.sh
+++ b/scripts/arena-local.sh
@@ -92,7 +92,7 @@ cmd_up() {
   wait_for_api
 }
 
-cmd_snapshot() { docker compose run --rm runner arena snapshot; }
+cmd_snapshot() { docker compose run --rm runner coval-bench arena snapshot; }
 
 cmd_status() {
   # Match how compose resolves these: shell env wins, then .env, then default.


### PR DESCRIPTION
The ENTRYPOINT/CMD split in #560 breaks every Cloud Run job: the scheduler triggers and job specs in benchmark-infra pass the full python -m coval_bench command as container args, which Cloud Run appends after the new ENTRYPOINT. Click receives 'python' as its subcommand and exits 2 before a single log line, so all benchmark runs have been down since the 1320487 release on Aug 28 ~22:00 UTC.

Reverting the image to a bare CMD makes the existing args overrides whole commands again. Re-landing the split needs a coordinated args change in benchmark-infra first.