### PR TITLE
BENCH-768: Bound normalized readiness checks

### DIFF
--- a/runner/scripts/check_normalized_readiness.py
+++ b/runner/scripts/check_normalized_readiness.py
@@ -3,10 +3,10 @@
 
 """Read-only readiness gate for normalized dashboard reads.
 
-The checker takes one repeatable-read, read-only snapshot, fixes an ``as_of``
+The checker takes one repeatable-read, read-only snapshot, fixes an as_of
 cutoff, and reports whether eligible legacy data spans at least seven days and
 the latest seven-day window has exact raw public-row and materialized-rollup
-parity. It never writes.
+parity. Every parity query is time-bounded and the checker never writes.
 """
 
 from __future__ import annotations
@@ -14,15 +14,20 @@ from __future__ import annotations
 import argparse
 import json
 import os
-import sys
+import time
+from collections import Counter
 from collections.abc import Iterable, Mapping, Sequence
 from datetime import datetime, timedelta
-from typing import Any, Protocol
+from typing import Any, NoReturn, Protocol
 
 import psycopg
 
 MINIMUM_HOURS = 168
 DETAIL_LIMIT = 50
+DEFAULT_CHUNK_HOURS = 1
+DEFAULT_STATEMENT_TIMEOUT_SECONDS = 30
+DEFAULT_TOTAL_TIMEOUT_SECONDS = 600
+_BENCHMARKS = ("STT", "TTS", "S2S")
 
 
 class Cursor(Protocol):
@@ -35,89 +40,275 @@ class Connection(Protocol):
     def execute(self, query: str, params: Mapping[str, Any] | None = None) -> Cursor: ...
 
 
-_ELIGIBLE_BUCKETS_SQL = """
-SELECT DISTINCT date_trunc('hour', COALESCE(run.scheduled_at, result.created_at)) AS bucket_at
-FROM benchmarks_v2.results result JOIN benchmarks_v2.runs run ON run.id = result.run_id
-WHERE result.status = 'success' AND result.metric_value IS NOT NULL
-  AND run.status IN ('succeeded', 'partial') AND result.created_at < %(as_of)s
-ORDER BY bucket_at
+class ReadinessOperationalError(RuntimeError):
+    """A bounded readiness check could not complete."""
+
+    def __init__(self, stage: str, message: str) -> None:
+        super().__init__(message)
+        self.stage = stage
+
+
+_LATEST_ELIGIBLE_BUCKET_SQL = """
+SELECT date_trunc('hour', COALESCE(run.scheduled_at, result.created_at)) AS bucket_at
+FROM benchmarks_v2.results result
+JOIN benchmarks_v2.runs run ON run.id = result.run_id
+WHERE result.status = 'success'
+  AND result.metric_value IS NOT NULL
+  AND run.status IN ('succeeded', 'partial')
+  AND result.benchmark = %(benchmark)s
+  AND result.created_at < %(as_of)s
+ORDER BY result.created_at DESC
+LIMIT 1
+"""
+
+_HISTORICAL_COVERAGE_BUCKET_SQL = """
+SELECT date_trunc('hour', COALESCE(run.scheduled_at, result.created_at)) AS bucket_at
+FROM benchmarks_v2.results result
+JOIN benchmarks_v2.runs run ON run.id = result.run_id
+WHERE result.status = 'success'
+  AND result.metric_value IS NOT NULL
+  AND run.status IN ('succeeded', 'partial')
+  AND result.benchmark = %(benchmark)s
+  AND result.created_at < %(as_of)s
+  AND result.created_at <= %(cutoff)s
+  AND date_trunc('hour', COALESCE(run.scheduled_at, result.created_at)) <= %(cutoff)s
+ORDER BY result.created_at DESC
+LIMIT 1
+"""
+
+_NORMALIZED_DATASETS_SQL = """
+SELECT DISTINCT observation.dataset_id
+FROM benchmarks_v2.benchmark_observations observation
+WHERE observation.status = 'succeeded'
+  AND observation.benchmark = %(benchmark)s
+  AND observation.captured_at >= %(start)s
+  AND observation.captured_at < %(end)s
+ORDER BY observation.dataset_id
+"""
+
+_ROLLUP_DATASETS_SQL = """
+SELECT dataset_id
+FROM benchmarks_v2.results_by_bucket
+WHERE benchmark = %(benchmark)s
+  AND bucket_at >= %(start)s
+  AND bucket_at < %(end)s
+GROUP BY dataset_id
+UNION
+SELECT dataset_id
+FROM benchmarks_v2.metric_values_by_bucket
+WHERE benchmark = %(benchmark)s
+  AND metric_version = 'v1'
+  AND evaluation_variant = 'default'
+  AND value_key = 'primary'
+  AND bucket_at >= %(start)s
+  AND bucket_at < %(end)s
+GROUP BY dataset_id
+ORDER BY dataset_id
 """
 
 # Both projections intentionally use the dashboard's public rows rather than
-# normalized internals: WER components are omitted and TTFA components regain
-# their legacy public metric names.
-_RAW_MISMATCH_SQL = """
-WITH legacy AS (
- SELECT result.provider, result.model, result.benchmark,
-        CASE WHEN result.benchmark = 'TTS' THEN 'tts-v1' ELSE run.dataset_id END AS dataset_id,
-        result.metric_type, result.metric_value AS value, result.wer_insertions_pct,
-        result.wer_deletions_pct, result.wer_substitutions_pct
- FROM benchmarks_v2.results result JOIN benchmarks_v2.runs run ON run.id = result.run_id
- WHERE result.status = 'success' AND result.metric_value IS NOT NULL
-   AND run.status IN ('succeeded', 'partial') AND result.created_at >= %(start)s
-   AND result.created_at < %(as_of)s
-), normalized AS (
- SELECT observation.provider, observation.model, observation.benchmark, observation.dataset_id,
-        CASE WHEN evaluation.metric_type = 'TTFA' AND value.value_key = 'roundtrip'
-                  THEN 'TTFARoundtrip'
-             WHEN evaluation.metric_type = 'TTFA' AND value.value_key = 'leading_silence'
-                  THEN 'TTFALeadingSilence'
-             WHEN value.value_role = 'primary' THEN evaluation.metric_type END AS metric_type,
-        value.value, insertion.value AS wer_insertions_pct,
-        deletion.value AS wer_deletions_pct, substitution.value AS wer_substitutions_pct
- FROM benchmarks_v2.metric_values value
- JOIN benchmarks_v2.metric_evaluations evaluation ON evaluation.id = value.metric_evaluation_id
- JOIN benchmarks_v2.benchmark_observations observation ON observation.id = evaluation.observation_id
- JOIN benchmarks_v2.runs run ON run.id = observation.run_id
- LEFT JOIN benchmarks_v2.metric_values insertion
-   ON insertion.metric_evaluation_id = evaluation.id AND insertion.value_key = 'insertions'
- LEFT JOIN benchmarks_v2.metric_values deletion
-   ON deletion.metric_evaluation_id = evaluation.id AND deletion.value_key = 'deletions'
- LEFT JOIN benchmarks_v2.metric_values substitution
-   ON substitution.metric_evaluation_id = evaluation.id AND substitution.value_key = 'substitutions'
- WHERE observation.status = 'succeeded' AND evaluation.status = 'succeeded'
-   AND run.status IN ('succeeded', 'partial') AND evaluation.metric_version = 'v1'
-   AND evaluation.evaluation_variant = 'default' AND observation.captured_at >= %(start)s
-   AND observation.captured_at < %(as_of)s AND (value.value_role = 'primary'
-        OR (evaluation.metric_type = 'TTFA'
-            AND value.value_key IN ('roundtrip', 'leading_silence')))
-), mismatches AS (
- (SELECT 'legacy_only' AS side, * FROM legacy
-  EXCEPT ALL
-  SELECT 'legacy_only', provider, model, benchmark, dataset_id, metric_type, value,
-         wer_insertions_pct, wer_deletions_pct, wer_substitutions_pct
-  FROM normalized WHERE metric_type IS NOT NULL)
- UNION ALL
- (SELECT 'normalized_only', provider, model, benchmark, dataset_id, metric_type, value,
-         wer_insertions_pct, wer_deletions_pct, wer_substitutions_pct
-  FROM normalized WHERE metric_type IS NOT NULL
-  EXCEPT ALL
-  SELECT 'normalized_only', * FROM legacy)
-) SELECT * FROM mismatches
-ORDER BY side, benchmark, dataset_id, provider, model, metric_type, value
+# normalized internals: WER components are attached to the public WER row and
+# TTFA components regain their legacy public metric names.
+_LEGACY_RAW_COUNTS_SQL = """
+SELECT result.provider,
+       result.model,
+       result.benchmark,
+       CASE WHEN result.benchmark = 'TTS' THEN 'tts-v1' ELSE run.dataset_id END AS dataset_id,
+       result.metric_type,
+       result.metric_value AS value,
+       result.wer_insertions_pct,
+       result.wer_deletions_pct,
+       result.wer_substitutions_pct,
+       COUNT(*) AS multiplicity
+FROM benchmarks_v2.results result
+JOIN benchmarks_v2.runs run ON run.id = result.run_id
+WHERE result.status = 'success'
+  AND result.metric_value IS NOT NULL
+  AND run.status IN ('succeeded', 'partial')
+  AND result.benchmark = %(benchmark)s
+  AND result.created_at >= %(start)s
+  AND result.created_at < %(end)s
+GROUP BY result.provider,
+         result.model,
+         result.benchmark,
+         CASE WHEN result.benchmark = 'TTS' THEN 'tts-v1' ELSE run.dataset_id END,
+         result.metric_type,
+         result.metric_value,
+         result.wer_insertions_pct,
+         result.wer_deletions_pct,
+         result.wer_substitutions_pct
 """
 
-_ROLLUP_MISMATCH_SQL = """
-WITH legacy AS (
- SELECT provider, model, benchmark, dataset_id, metric_type, bucket_at,
-        min_value, p25, p50, p75, max_value, value_sum, sample_count
- FROM benchmarks_v2.results_by_bucket WHERE bucket_at >= %(start)s AND bucket_at < %(as_of)s
-), normalized AS (
- SELECT provider, model, benchmark, dataset_id, metric_type, bucket_at,
-        min_value, p25, p50, p75, max_value, value_sum, sample_count
- FROM benchmarks_v2.metric_values_by_bucket
- WHERE metric_version = 'v1' AND evaluation_variant = 'default'
-   AND value_key = 'primary'
-   AND bucket_at >= %(start)s AND bucket_at < %(as_of)s
-), mismatches AS (
- (SELECT 'legacy_only' AS side, * FROM legacy
-  EXCEPT ALL SELECT 'legacy_only', * FROM normalized)
- UNION ALL
- (SELECT 'normalized_only' AS side, * FROM normalized
-  EXCEPT ALL SELECT 'normalized_only', * FROM legacy)
-) SELECT * FROM mismatches
-ORDER BY side, benchmark, dataset_id, provider, model, metric_type, bucket_at
+_NORMALIZED_RAW_COUNTS_SQL = """
+SELECT observation.provider,
+       observation.model,
+       observation.benchmark,
+       observation.dataset_id,
+       CASE
+         WHEN evaluation.metric_type = 'TTFA' AND value.value_key = 'roundtrip'
+           THEN 'TTFARoundtrip'
+         WHEN evaluation.metric_type = 'TTFA' AND value.value_key = 'leading_silence'
+           THEN 'TTFALeadingSilence'
+         WHEN value.value_role = 'primary'
+           THEN evaluation.metric_type
+       END AS metric_type,
+       value.value,
+       components.wer_insertions_pct,
+       components.wer_deletions_pct,
+       components.wer_substitutions_pct,
+       COUNT(*) AS multiplicity
+FROM benchmarks_v2.benchmark_observations observation
+JOIN benchmarks_v2.runs run ON run.id = observation.run_id
+JOIN benchmarks_v2.metric_evaluations evaluation
+  ON evaluation.observation_id = observation.id
+JOIN benchmarks_v2.metric_values value
+  ON value.metric_evaluation_id = evaluation.id
+LEFT JOIN LATERAL (
+  SELECT MAX(component.value) FILTER (
+           WHERE component.value_key = 'insertions'
+         ) AS wer_insertions_pct,
+         MAX(component.value) FILTER (
+           WHERE component.value_key = 'deletions'
+         ) AS wer_deletions_pct,
+         MAX(component.value) FILTER (
+           WHERE component.value_key = 'substitutions'
+         ) AS wer_substitutions_pct
+  FROM benchmarks_v2.metric_values component
+  WHERE component.metric_evaluation_id = evaluation.id
+) components ON TRUE
+WHERE observation.status = 'succeeded'
+  AND evaluation.status = 'succeeded'
+  AND run.status IN ('succeeded', 'partial')
+  AND evaluation.metric_version = 'v1'
+  AND evaluation.evaluation_variant = 'default'
+  AND observation.benchmark = %(benchmark)s
+  AND observation.dataset_id = %(dataset_id)s
+  AND observation.captured_at >= %(start)s
+  AND observation.captured_at < %(end)s
+  AND (
+    value.value_role = 'primary'
+    OR (
+      evaluation.metric_type = 'TTFA'
+      AND value.value_key IN ('roundtrip', 'leading_silence')
+    )
+  )
+GROUP BY observation.provider,
+         observation.model,
+         observation.benchmark,
+         observation.dataset_id,
+         CASE
+           WHEN evaluation.metric_type = 'TTFA' AND value.value_key = 'roundtrip'
+             THEN 'TTFARoundtrip'
+           WHEN evaluation.metric_type = 'TTFA' AND value.value_key = 'leading_silence'
+             THEN 'TTFALeadingSilence'
+           WHEN value.value_role = 'primary'
+             THEN evaluation.metric_type
+         END,
+         value.value,
+         components.wer_insertions_pct,
+         components.wer_deletions_pct,
+         components.wer_substitutions_pct
 """
+
+_LEGACY_ROLLUP_COUNTS_SQL = """
+SELECT provider,
+       model,
+       benchmark,
+       dataset_id,
+       metric_type,
+       bucket_at,
+       min_value,
+       p25,
+       p50,
+       p75,
+       max_value,
+       value_sum,
+       sample_count,
+       COUNT(*) AS multiplicity
+FROM benchmarks_v2.results_by_bucket
+WHERE benchmark = %(benchmark)s
+  AND dataset_id = %(dataset_id)s
+  AND bucket_at >= %(start)s
+  AND bucket_at < %(end)s
+GROUP BY provider,
+         model,
+         benchmark,
+         dataset_id,
+         metric_type,
+         bucket_at,
+         min_value,
+         p25,
+         p50,
+         p75,
+         max_value,
+         value_sum,
+         sample_count
+"""
+
+_NORMALIZED_ROLLUP_COUNTS_SQL = """
+SELECT provider,
+       model,
+       benchmark,
+       dataset_id,
+       metric_type,
+       bucket_at,
+       min_value,
+       p25,
+       p50,
+       p75,
+       max_value,
+       value_sum,
+       sample_count,
+       COUNT(*) AS multiplicity
+FROM benchmarks_v2.metric_values_by_bucket
+WHERE benchmark = %(benchmark)s
+  AND dataset_id = %(dataset_id)s
+  AND metric_version = 'v1'
+  AND evaluation_variant = 'default'
+  AND value_key = 'primary'
+  AND bucket_at >= %(start)s
+  AND bucket_at < %(end)s
+GROUP BY provider,
+         model,
+         benchmark,
+         dataset_id,
+         metric_type,
+         bucket_at,
+         min_value,
+         p25,
+         p50,
+         p75,
+         max_value,
+         value_sum,
+         sample_count
+"""
+
+
+class _QueryRunner:
+    def __init__(
+        self,
+        conn: Connection,
+        *,
+        statement_timeout_seconds: int,
+        total_timeout_seconds: int,
+    ) -> None:
+        self._conn = conn
+        self._statement_timeout_ms = statement_timeout_seconds * 1000
+        self._deadline = time.monotonic() + total_timeout_seconds
+
+    def execute(self, stage: str, query: str, params: Mapping[str, Any] | None = None) -> Cursor:
+        remaining_ms = int((self._deadline - time.monotonic()) * 1000)
+        if remaining_ms <= 0:
+            raise ReadinessOperationalError(stage, "total readiness-check timeout exceeded")
+        timeout_ms = max(1, min(self._statement_timeout_ms, remaining_ms))
+        try:
+            self._conn.execute(
+                "SELECT set_config('statement_timeout', %(timeout)s, true)",
+                {"timeout": f"{timeout_ms}ms"},
+            )
+            return self._conn.execute(query, params)
+        except psycopg.Error as error:
+            raise ReadinessOperationalError(stage, f"database statement failed: {error}") from error
 
 
 def _coverage(buckets: Iterable[datetime]) -> tuple[float, datetime | None, datetime | None]:
@@ -129,6 +320,54 @@ def _coverage(buckets: Iterable[datetime]) -> tuple[float, datetime | None, date
     return (last - first).total_seconds() / 3600, first, last
 
 
+def _time_slices(
+    start: datetime, end: datetime, chunk_hours: int
+) -> Iterable[tuple[datetime, datetime]]:
+    cursor = start
+    delta = timedelta(hours=chunk_hours)
+    while cursor < end:
+        next_cursor = min(cursor + delta, end)
+        yield cursor, next_cursor
+        cursor = next_cursor
+
+
+def _apply_grouped_counts(
+    counter: Counter[tuple[Any, ...]],
+    rows: Iterable[Sequence[Any]],
+    *,
+    sign: int,
+) -> None:
+    for row in rows:
+        if not row:
+            raise ReadinessOperationalError("parity", "count query returned an empty row")
+        *public_row, multiplicity = row
+        counter[tuple(public_row)] += sign * int(multiplicity)
+
+
+def _row_sort_key(row: tuple[Any, ...]) -> tuple[tuple[str, str], ...]:
+    return tuple((type(value).__name__, "" if value is None else str(value)) for value in row)
+
+
+def _summarize_counter(
+    counter: Counter[tuple[Any, ...]],
+) -> tuple[int, list[tuple[Any, ...]]]:
+    mismatch_count = sum(abs(count) for count in counter.values())
+    details: list[tuple[Any, ...]] = []
+    residuals = [
+        ("legacy_only" if count > 0 else "normalized_only", row, abs(count))
+        for row, count in counter.items()
+        if count
+    ]
+    for side, row, multiplicity in sorted(
+        residuals, key=lambda item: (item[0], _row_sort_key(item[1]))
+    ):
+        remaining = DETAIL_LIMIT - len(details)
+        if remaining <= 0:
+            break
+        details.extend((side, *row) for _ in range(min(multiplicity, remaining)))
+    return mismatch_count, details
+
+
 def evaluate_readiness(
     *,
     as_of: datetime,
@@ -136,10 +375,17 @@ def evaluate_readiness(
     raw_mismatches: Sequence[Sequence[Any]],
     rollup_mismatches: Sequence[Sequence[Any]],
     required_hours: int = MINIMUM_HOURS,
+    raw_mismatch_count: int | None = None,
+    rollup_mismatch_count: int | None = None,
 ) -> dict[str, Any]:
     """Evaluate snapshot rows without database access; used by focused tests."""
     coverage_hours, coverage_start, coverage_end = _coverage(buckets)
-    raw_count, rollup_count = len(raw_mismatches), len(rollup_mismatches)
+    raw_details = [list(row) for row in raw_mismatches[:DETAIL_LIMIT]]
+    rollup_details = [list(row) for row in rollup_mismatches[:DETAIL_LIMIT]]
+    raw_count = len(raw_mismatches) if raw_mismatch_count is None else raw_mismatch_count
+    rollup_count = (
+        len(rollup_mismatches) if rollup_mismatch_count is None else rollup_mismatch_count
+    )
     report = {
         "as_of": as_of.isoformat(),
         "required_hours": required_hours,
@@ -147,50 +393,231 @@ def evaluate_readiness(
         "coverage_start": coverage_start.isoformat() if coverage_start else None,
         "coverage_end": coverage_end.isoformat() if coverage_end else None,
         "raw_mismatch_count": raw_count,
-        "raw_mismatches": [list(row) for row in raw_mismatches[:DETAIL_LIMIT]],
-        "raw_mismatches_truncated": raw_count > DETAIL_LIMIT,
+        "raw_mismatches": raw_details,
+        "raw_mismatches_truncated": raw_count > len(raw_details),
         "rollup_mismatch_count": rollup_count,
-        "rollup_mismatches": [list(row) for row in rollup_mismatches[:DETAIL_LIMIT]],
-        "rollup_mismatches_truncated": rollup_count > DETAIL_LIMIT,
+        "rollup_mismatches": rollup_details,
+        "rollup_mismatches_truncated": rollup_count > len(rollup_details),
     }
     report["ready"] = coverage_hours >= required_hours and not raw_count and not rollup_count
     return report
 
 
-def check(conn: Connection, *, required_hours: int = MINIMUM_HOURS) -> dict[str, Any]:
-    """Run every read in exactly one repeatable-read read-only transaction."""
-    conn.execute("BEGIN ISOLATION LEVEL REPEATABLE READ READ ONLY")
-    as_of_row = conn.execute("SELECT now()").fetchone()
+def _datasets_by_benchmark(
+    runner: _QueryRunner,
+    *,
+    query: str,
+    stage_prefix: str,
+    start: datetime,
+    end: datetime,
+) -> dict[str, list[str]]:
+    datasets: dict[str, list[str]] = {}
+    for benchmark in _BENCHMARKS:
+        rows = runner.execute(
+            f"{stage_prefix}_datasets_{benchmark.lower()}",
+            query,
+            {"benchmark": benchmark, "start": start, "end": end},
+        ).fetchall()
+        datasets[benchmark] = [str(row[0]) for row in rows]
+    return datasets
+
+
+def check(
+    conn: Connection,
+    *,
+    required_hours: int = MINIMUM_HOURS,
+    chunk_hours: int = DEFAULT_CHUNK_HOURS,
+    statement_timeout_seconds: int = DEFAULT_STATEMENT_TIMEOUT_SECONDS,
+    total_timeout_seconds: int = DEFAULT_TOTAL_TIMEOUT_SECONDS,
+) -> dict[str, Any]:
+    """Run every bounded read in one repeatable-read, read-only transaction."""
+    if required_hours <= 0:
+        raise ValueError("required_hours must be positive")
+    if chunk_hours <= 0:
+        raise ValueError("chunk_hours must be positive")
+    if statement_timeout_seconds <= 0:
+        raise ValueError("statement_timeout_seconds must be positive")
+    if total_timeout_seconds <= 0:
+        raise ValueError("total_timeout_seconds must be positive")
+
+    try:
+        conn.execute("BEGIN ISOLATION LEVEL REPEATABLE READ READ ONLY")
+    except psycopg.Error as error:
+        raise ReadinessOperationalError(
+            "transaction", f"could not begin snapshot: {error}"
+        ) from error
+
+    runner = _QueryRunner(
+        conn,
+        statement_timeout_seconds=statement_timeout_seconds,
+        total_timeout_seconds=total_timeout_seconds,
+    )
+    as_of_row = runner.execute("snapshot", "SELECT now()").fetchone()
     if as_of_row is None:
-        raise RuntimeError("SELECT now() returned no row")
+        raise ReadinessOperationalError("snapshot", "SELECT now() returned no row")
     as_of = as_of_row[0]
     start = as_of - timedelta(hours=required_hours)
-    params = {"start": start, "as_of": as_of}
-    buckets = [row[0] for row in conn.execute(_ELIGIBLE_BUCKETS_SQL, params).fetchall()]
-    raw = conn.execute(_RAW_MISMATCH_SQL, params).fetchall()
-    rollups = conn.execute(_ROLLUP_MISMATCH_SQL, params).fetchall()
+
+    latest_candidates: list[datetime] = []
+    for benchmark in _BENCHMARKS:
+        latest_row = runner.execute(
+            f"coverage_latest_{benchmark.lower()}",
+            _LATEST_ELIGIBLE_BUCKET_SQL,
+            {"benchmark": benchmark, "as_of": as_of},
+        ).fetchone()
+        if latest_row is not None:
+            latest_candidates.append(latest_row[0])
+
+    buckets: list[datetime] = []
+    if latest_candidates:
+        latest_bucket = max(latest_candidates)
+        cutoff = latest_bucket - timedelta(hours=required_hours)
+        historical_candidates: list[datetime] = []
+        for benchmark in _BENCHMARKS:
+            historical_row = runner.execute(
+                f"coverage_historical_{benchmark.lower()}",
+                _HISTORICAL_COVERAGE_BUCKET_SQL,
+                {"benchmark": benchmark, "as_of": as_of, "cutoff": cutoff},
+            ).fetchone()
+            if historical_row is not None:
+                historical_candidates.append(historical_row[0])
+        buckets = [latest_bucket]
+        if historical_candidates:
+            buckets.insert(0, min(historical_candidates))
+
+    normalized_datasets = _datasets_by_benchmark(
+        runner,
+        query=_NORMALIZED_DATASETS_SQL,
+        stage_prefix="raw",
+        start=start,
+        end=as_of,
+    )
+    rollup_datasets = _datasets_by_benchmark(
+        runner,
+        query=_ROLLUP_DATASETS_SQL,
+        stage_prefix="rollup",
+        start=start,
+        end=as_of,
+    )
+
+    raw_counter: Counter[tuple[Any, ...]] = Counter()
+    rollup_counter: Counter[tuple[Any, ...]] = Counter()
+    for slice_start, slice_end in _time_slices(start, as_of, chunk_hours):
+        window = {"start": slice_start, "end": slice_end}
+        slice_label = slice_start.isoformat()
+        for benchmark in _BENCHMARKS:
+            _apply_grouped_counts(
+                raw_counter,
+                runner.execute(
+                    f"raw_legacy_{benchmark.lower()}_{slice_label}",
+                    _LEGACY_RAW_COUNTS_SQL,
+                    {**window, "benchmark": benchmark},
+                ).fetchall(),
+                sign=1,
+            )
+            for dataset_id in normalized_datasets[benchmark]:
+                _apply_grouped_counts(
+                    raw_counter,
+                    runner.execute(
+                        f"raw_normalized_{benchmark.lower()}_{slice_label}",
+                        _NORMALIZED_RAW_COUNTS_SQL,
+                        {**window, "benchmark": benchmark, "dataset_id": dataset_id},
+                    ).fetchall(),
+                    sign=-1,
+                )
+
+            for dataset_id in rollup_datasets[benchmark]:
+                cohort = {**window, "benchmark": benchmark, "dataset_id": dataset_id}
+                _apply_grouped_counts(
+                    rollup_counter,
+                    runner.execute(
+                        f"rollup_legacy_{benchmark.lower()}_{slice_label}",
+                        _LEGACY_ROLLUP_COUNTS_SQL,
+                        cohort,
+                    ).fetchall(),
+                    sign=1,
+                )
+                _apply_grouped_counts(
+                    rollup_counter,
+                    runner.execute(
+                        f"rollup_normalized_{benchmark.lower()}_{slice_label}",
+                        _NORMALIZED_ROLLUP_COUNTS_SQL,
+                        cohort,
+                    ).fetchall(),
+                    sign=-1,
+                )
+
+    raw_count, raw_details = _summarize_counter(raw_counter)
+    rollup_count, rollup_details = _summarize_counter(rollup_counter)
     return evaluate_readiness(
         as_of=as_of,
         buckets=buckets,
-        raw_mismatches=raw,
-        rollup_mismatches=rollups,
+        raw_mismatches=raw_details,
+        rollup_mismatches=rollup_details,
         required_hours=required_hours,
+        raw_mismatch_count=raw_count,
+        rollup_mismatch_count=rollup_count,
     )
 
 
-def _args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description=__doc__)
+class _JsonArgumentParser(argparse.ArgumentParser):
+    def error(self, message: str) -> NoReturn:
+        raise ReadinessOperationalError("configuration", message)
+
+
+def _positive_int(value: str) -> int:
+    parsed = int(value)
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("must be a positive integer")
+    return parsed
+
+
+def _args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = _JsonArgumentParser(description=__doc__)
     parser.add_argument("--database-url", default=os.environ.get("DATABASE_URL"))
-    return parser.parse_args()
+    parser.add_argument("--chunk-hours", type=_positive_int, default=DEFAULT_CHUNK_HOURS)
+    parser.add_argument(
+        "--statement-timeout-seconds",
+        type=_positive_int,
+        default=DEFAULT_STATEMENT_TIMEOUT_SECONDS,
+    )
+    parser.add_argument(
+        "--total-timeout-seconds",
+        type=_positive_int,
+        default=DEFAULT_TOTAL_TIMEOUT_SECONDS,
+    )
+    return parser.parse_args(argv)
 
 
-def main() -> int:
-    args = _args()
-    if not args.database_url:
-        print("DATABASE_URL or --database-url is required", file=sys.stderr)
+def _error_report(stage: str, error: object) -> dict[str, Any]:
+    return {"ready": False, "stage": stage, "error": str(error)}
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    try:
+        args = _args(argv)
+    except ReadinessOperationalError as error:
+        print(json.dumps(_error_report(error.stage, error), sort_keys=True))
         return 2
-    with psycopg.connect(args.database_url, autocommit=False) as conn:
-        report = check(conn)
+    if not args.database_url:
+        print(
+            json.dumps(_error_report("configuration", "DATABASE_URL or --database-url is required"))
+        )
+        return 2
+    try:
+        with psycopg.connect(args.database_url, autocommit=False) as conn:
+            report = check(
+                conn,
+                chunk_hours=args.chunk_hours,
+                statement_timeout_seconds=args.statement_timeout_seconds,
+                total_timeout_seconds=args.total_timeout_seconds,
+            )
+    except ReadinessOperationalError as error:
+        print(json.dumps(_error_report(error.stage, error), sort_keys=True))
+        return 2
+    except psycopg.Error as error:
+        print(json.dumps(_error_report("connection", error), sort_keys=True))
+        return 2
     print(json.dumps(report, sort_keys=True, default=str))
     return 0 if report["ready"] else 1
 

--- a/runner/scripts/check_normalized_readiness.py
+++ b/runner/scripts/check_normalized_readiness.py
@@ -341,7 +341,10 @@ def _apply_grouped_counts(
         if not row:
             raise ReadinessOperationalError("parity", "count query returned an empty row")
         *public_row, multiplicity = row
-        counter[tuple(public_row)] += sign * int(multiplicity)
+        key = tuple(public_row)
+        counter[key] += sign * int(multiplicity)
+        if counter[key] == 0:
+            del counter[key]
 
 
 def _row_sort_key(row: tuple[Any, ...]) -> tuple[tuple[str, str], ...]:

--- a/runner/tests/test_check_normalized_readiness.py
+++ b/runner/tests/test_check_normalized_readiness.py
@@ -1,16 +1,56 @@
 # Copyright 2026 The Coval Benchmarks Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Unit tests for the read-only normalized dashboard readiness gate."""
+"""Tests for the bounded normalized dashboard readiness gate."""
 
 from __future__ import annotations
 
+import json
+import time
+from collections import Counter
+from collections.abc import Mapping
 from datetime import UTC, datetime, timedelta
-from typing import Any
+from typing import Any, NoReturn
 
-from scripts.check_normalized_readiness import MINIMUM_HOURS, check, evaluate_readiness
+import psycopg
+import pytest
+
+import scripts.check_normalized_readiness as readiness
+from scripts.check_normalized_readiness import (
+    DETAIL_LIMIT,
+    MINIMUM_HOURS,
+    ReadinessOperationalError,
+    check,
+    evaluate_readiness,
+)
 
 AS_OF = datetime(2026, 8, 31, 12, tzinfo=UTC)
+RAW_ROW = (
+    "provider",
+    "model",
+    "STT",
+    "stt-v1",
+    "WER",
+    3.0,
+    1.0,
+    1.0,
+    1.0,
+)
+ROLLUP_ROW = (
+    "provider",
+    "model",
+    "STT",
+    "stt-v1",
+    "WER",
+    AS_OF - timedelta(hours=2),
+    1.0,
+    1.0,
+    1.0,
+    1.0,
+    1.0,
+    1.0,
+    1,
+)
 
 
 def _buckets(hours: int = MINIMUM_HOURS) -> list[datetime]:
@@ -45,7 +85,7 @@ def test_readiness_rejects_public_row_mismatch() -> None:
     report = evaluate_readiness(
         as_of=AS_OF,
         buckets=_buckets(),
-        raw_mismatches=[("legacy_only", "provider", "model", "STT", "stt-v1", "WER", 3.0)],
+        raw_mismatches=[("legacy_only", *RAW_ROW)],
         rollup_mismatches=[],
     )
     assert report["ready"] is False
@@ -57,43 +97,275 @@ def test_readiness_rejects_rollup_mismatch() -> None:
         as_of=AS_OF,
         buckets=_buckets(),
         raw_mismatches=[],
-        rollup_mismatches=[("normalized_only", "provider", "model")],
+        rollup_mismatches=[("normalized_only", *ROLLUP_ROW)],
     )
     assert report["ready"] is False
     assert report["rollup_mismatch_count"] == 1
+
+
+def test_grouped_counts_cancel_globally_across_slices() -> None:
+    counter: Counter[tuple[Any, ...]] = Counter()
+    readiness._apply_grouped_counts(counter, [(*RAW_ROW, 1)], sign=1)
+    readiness._apply_grouped_counts(counter, [(*RAW_ROW, 1)], sign=-1)
+    count, details = readiness._summarize_counter(counter)
+    assert count == 0
+    assert details == []
+
+
+def test_duplicate_residual_count_is_exact_while_details_are_bounded() -> None:
+    counter: Counter[tuple[Any, ...]] = Counter()
+    readiness._apply_grouped_counts(counter, [(*RAW_ROW, DETAIL_LIMIT + 7)], sign=1)
+    readiness._apply_grouped_counts(counter, [(*RAW_ROW, 2)], sign=-1)
+
+    count, details = readiness._summarize_counter(counter)
+    report = evaluate_readiness(
+        as_of=AS_OF,
+        buckets=_buckets(),
+        raw_mismatches=details,
+        rollup_mismatches=[],
+        raw_mismatch_count=count,
+    )
+
+    assert count == DETAIL_LIMIT + 5
+    assert len(details) == DETAIL_LIMIT
+    assert {row[0] for row in details} == {"legacy_only"}
+    assert report["raw_mismatch_count"] == DETAIL_LIMIT + 5
+    assert report["raw_mismatches_truncated"] is True
+
+
+def test_normalized_only_residual_has_the_correct_side() -> None:
+    counter: Counter[tuple[Any, ...]] = Counter()
+    readiness._apply_grouped_counts(counter, [(*RAW_ROW, 2)], sign=-1)
+    count, details = readiness._summarize_counter(counter)
+    assert count == 2
+    assert details == [("normalized_only", *RAW_ROW), ("normalized_only", *RAW_ROW)]
+
+
+def test_time_slices_are_half_open_and_cover_a_partial_final_chunk() -> None:
+    start = AS_OF - timedelta(hours=2, minutes=30)
+    slices = list(readiness._time_slices(start, AS_OF, 1))
+    assert slices == [
+        (start, start + timedelta(hours=1)),
+        (start + timedelta(hours=1), start + timedelta(hours=2)),
+        (start + timedelta(hours=2), AS_OF),
+    ]
+    assert all(left < right for left, right in slices)
+    assert all(slices[index][1] == slices[index + 1][0] for index in range(len(slices) - 1))
+
+
+def test_sql_preserves_public_mapping_and_uses_bounded_counts() -> None:
+    normalized = readiness._NORMALIZED_RAW_COUNTS_SQL
+    assert "TTFARoundtrip" in normalized
+    assert "TTFALeadingSilence" in normalized
+    assert "LEFT JOIN LATERAL" in normalized
+    assert "value_key = 'insertions'" in normalized
+    assert "observation.benchmark = %(benchmark)s" in normalized
+    assert "observation.dataset_id = %(dataset_id)s" in normalized
+    assert "observation.captured_at >= %(start)s" in normalized
+    assert "observation.captured_at < %(end)s" in normalized
+    assert "COUNT(*) AS multiplicity" in normalized
+    assert "EXCEPT ALL" not in normalized
+
+    legacy = readiness._LEGACY_RAW_COUNTS_SQL
+    assert "result.benchmark = %(benchmark)s" in legacy
+    assert "result.created_at >= %(start)s" in legacy
+    assert "result.created_at < %(end)s" in legacy
+
+    latest_coverage = readiness._LATEST_ELIGIBLE_BUCKET_SQL
+    assert "result.benchmark = %(benchmark)s" in latest_coverage
+    assert "ORDER BY result.created_at DESC" in latest_coverage
+    assert "LIMIT 1" in latest_coverage
+    assert "MIN(" not in latest_coverage
+    assert "MAX(" not in latest_coverage
+
+    historical_coverage = readiness._HISTORICAL_COVERAGE_BUCKET_SQL
+    assert "result.created_at <= %(cutoff)s" in historical_coverage
+    assert "COALESCE(run.scheduled_at, result.created_at)) <= %(cutoff)s" in historical_coverage
+    assert "LIMIT 1" in historical_coverage
 
 
 class _Cursor:
     def __init__(self, rows: list[tuple[Any, ...]]) -> None:
         self.rows = rows
 
-    def fetchone(self) -> tuple[Any, ...]:
-        return self.rows[0]
+    def fetchone(self) -> tuple[Any, ...] | None:
+        return self.rows[0] if self.rows else None
 
     def fetchall(self) -> list[tuple[Any, ...]]:
         return self.rows
 
 
 class _Connection:
-    def __init__(self) -> None:
-        self.calls: list[str] = []
-        self.responses = [
-            [(AS_OF,)],
-            [(bucket,) for bucket in _buckets()],
-            [],
-            [],
-        ]
+    def __init__(
+        self,
+        *,
+        legacy_raw_at: datetime | None = None,
+        normalized_raw_at: datetime | None = None,
+        legacy_rollup_at: datetime | None = None,
+        normalized_rollup_at: datetime | None = None,
+    ) -> None:
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+        self.legacy_raw_at = legacy_raw_at
+        self.normalized_raw_at = normalized_raw_at
+        self.legacy_rollup_at = legacy_rollup_at
+        self.normalized_rollup_at = normalized_rollup_at
 
-    def execute(self, query: str, params: Any = None) -> _Cursor:
-        self.calls.append(query)
-        if query.startswith("BEGIN"):
+    def execute(self, query: str, params: Mapping[str, Any] | None = None) -> _Cursor:
+        copied_params = dict(params or {})
+        self.calls.append((query, copied_params))
+        if query.startswith("BEGIN") or "set_config('statement_timeout'" in query:
             return _Cursor([])
-        return _Cursor(self.responses.pop(0))
+        if query == "SELECT now()":
+            return _Cursor([(AS_OF,)])
+        if query == readiness._LATEST_ELIGIBLE_BUCKET_SQL:
+            return _Cursor([(AS_OF,)]) if copied_params["benchmark"] == "STT" else _Cursor([])
+        if query == readiness._HISTORICAL_COVERAGE_BUCKET_SQL:
+            return (
+                _Cursor([(AS_OF - timedelta(days=7),)])
+                if copied_params["benchmark"] == "STT"
+                else _Cursor([])
+            )
+        if query == readiness._NORMALIZED_DATASETS_SQL:
+            normalized_dataset_rows: list[tuple[Any, ...]] = (
+                [("stt-v1",)]
+                if copied_params["benchmark"] == "STT" and self.normalized_raw_at is not None
+                else []
+            )
+            return _Cursor(normalized_dataset_rows)
+        if query == readiness._ROLLUP_DATASETS_SQL:
+            rollup_dataset_rows: list[tuple[Any, ...]] = (
+                [("stt-v1",)]
+                if copied_params["benchmark"] == "STT"
+                and (self.legacy_rollup_at is not None or self.normalized_rollup_at is not None)
+                else []
+            )
+            return _Cursor(rollup_dataset_rows)
+        if query == readiness._LEGACY_RAW_COUNTS_SQL:
+            legacy_raw_rows: list[tuple[Any, ...]] = (
+                [(*RAW_ROW, 1)]
+                if copied_params["benchmark"] == "STT"
+                and copied_params["start"] == self.legacy_raw_at
+                else []
+            )
+            return _Cursor(legacy_raw_rows)
+        if query == readiness._NORMALIZED_RAW_COUNTS_SQL:
+            normalized_raw_rows = (
+                [(*RAW_ROW, 1)] if copied_params["start"] == self.normalized_raw_at else []
+            )
+            return _Cursor(normalized_raw_rows)
+        if query == readiness._LEGACY_ROLLUP_COUNTS_SQL:
+            legacy_rollup_rows = (
+                [(*ROLLUP_ROW, 1)] if copied_params["start"] == self.legacy_rollup_at else []
+            )
+            return _Cursor(legacy_rollup_rows)
+        if query == readiness._NORMALIZED_ROLLUP_COUNTS_SQL:
+            normalized_rollup_rows = (
+                [(*ROLLUP_ROW, 1)] if copied_params["start"] == self.normalized_rollup_at else []
+            )
+            return _Cursor(normalized_rollup_rows)
+        raise AssertionError(f"unexpected query: {query}")
 
 
-def test_checker_uses_one_repeatable_read_only_transaction() -> None:
-    conn = _Connection()
-    report = check(conn)
+def test_checker_uses_one_snapshot_and_cancels_cross_slice_raw_rows() -> None:
+    conn = _Connection(
+        legacy_raw_at=AS_OF - timedelta(hours=2),
+        normalized_raw_at=AS_OF - timedelta(hours=1),
+        legacy_rollup_at=AS_OF - timedelta(hours=2),
+        normalized_rollup_at=AS_OF - timedelta(hours=2),
+    )
+    report = check(conn, required_hours=2, chunk_hours=1)
+
     assert report["ready"] is True
-    assert conn.calls[0] == "BEGIN ISOLATION LEVEL REPEATABLE READ READ ONLY"
-    assert len(conn.calls) == 5
+    begin_calls = [query for query, _ in conn.calls if query.startswith("BEGIN")]
+    assert begin_calls == ["BEGIN ISOLATION LEVEL REPEATABLE READ READ ONLY"]
+
+    target_calls = [
+        query
+        for query, _ in conn.calls
+        if not query.startswith("BEGIN") and "set_config('statement_timeout'" not in query
+    ]
+    timeout_calls = [query for query, _ in conn.calls if "set_config('statement_timeout'" in query]
+    assert len(timeout_calls) == len(target_calls)
+
+    legacy_windows = [
+        params for query, params in conn.calls if query == readiness._LEGACY_RAW_COUNTS_SQL
+    ]
+    assert len(legacy_windows) == 6
+    assert all(params["end"] - params["start"] == timedelta(hours=1) for params in legacy_windows)
+    assert any(
+        query == readiness._NORMALIZED_RAW_COUNTS_SQL and params["dataset_id"] == "stt-v1"
+        for query, params in conn.calls
+    )
+
+
+def test_checker_detects_normalized_only_cohort() -> None:
+    conn = _Connection(normalized_raw_at=AS_OF - timedelta(hours=1))
+    report = check(conn, required_hours=2, chunk_hours=1)
+    assert report["ready"] is False
+    assert report["raw_mismatch_count"] == 1
+    assert report["raw_mismatches"][0][0] == "normalized_only"
+
+
+def test_checker_detects_rollup_only_mismatch() -> None:
+    conn = _Connection(legacy_rollup_at=AS_OF - timedelta(hours=2))
+    report = check(conn, required_hours=2, chunk_hours=1)
+    assert report["ready"] is False
+    assert report["rollup_mismatch_count"] == 1
+    assert report["rollup_mismatches"][0][0] == "legacy_only"
+
+
+def test_total_deadline_fails_before_an_unbounded_statement(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clock = iter([0.0, 1.0])
+    monkeypatch.setattr(time, "monotonic", lambda: next(clock))
+    conn = _Connection()
+    runner = readiness._QueryRunner(conn, statement_timeout_seconds=30, total_timeout_seconds=1)
+
+    with pytest.raises(ReadinessOperationalError, match="total readiness-check timeout") as raised:
+        runner.execute("raw_legacy_stt", readiness._LEGACY_RAW_COUNTS_SQL, {})
+    assert raised.value.stage == "raw_legacy_stt"
+    assert conn.calls == []
+
+
+@pytest.mark.parametrize(
+    "keyword",
+    ["required_hours", "chunk_hours", "statement_timeout_seconds", "total_timeout_seconds"],
+)
+def test_checker_rejects_non_positive_limits(keyword: str) -> None:
+    kwargs = {
+        "required_hours": 1,
+        "chunk_hours": 1,
+        "statement_timeout_seconds": 1,
+        "total_timeout_seconds": 1,
+    }
+    kwargs[keyword] = 0
+    with pytest.raises(ValueError, match="positive"):
+        check(_Connection(), **kwargs)
+
+
+def test_main_reports_connection_failure_as_json(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    def fail_connect(*args: Any, **kwargs: Any) -> NoReturn:
+        raise psycopg.OperationalError("database unavailable")
+
+    monkeypatch.setattr(psycopg, "connect", fail_connect)
+    assert readiness.main(["--database-url", "postgresql://invalid"]) == 2
+    report = json.loads(capsys.readouterr().out)
+    assert report == {
+        "error": "database unavailable",
+        "ready": False,
+        "stage": "connection",
+    }
+
+
+@pytest.mark.parametrize("value", ["0", "not-an-integer"])
+def test_cli_reports_invalid_chunk_size_as_json(
+    value: str, capsys: pytest.CaptureFixture[str]
+) -> None:
+    assert readiness.main(["--database-url", "postgresql://unused", "--chunk-hours", value]) == 2
+    report = json.loads(capsys.readouterr().out)
+    assert report["ready"] is False
+    assert report["stage"] == "configuration"
+    assert "chunk-hours" in report["error"]

--- a/runner/tests/test_check_normalized_readiness.py
+++ b/runner/tests/test_check_normalized_readiness.py
@@ -110,6 +110,7 @@ def test_grouped_counts_cancel_globally_across_slices() -> None:
     count, details = readiness._summarize_counter(counter)
     assert count == 0
     assert details == []
+    assert not counter
 
 
 def test_duplicate_residual_count_is_exact_while_details_are_bounded() -> None:

--- a/runner/tests/unit/test_check_normalized_readiness_db.py
+++ b/runner/tests/unit/test_check_normalized_readiness_db.py
@@ -1,0 +1,268 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Real-Postgres coverage for the normalized readiness checker SQL."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from datetime import datetime, timedelta
+from typing import Any
+from uuid import UUID
+
+import psycopg
+from pytest_postgresql.factories import postgresql
+
+from scripts.check_normalized_readiness import check
+
+from .conftest import apply_migrations
+
+readiness_pg = postgresql("pg_proc")
+_SHA = "a" * 64
+
+
+def _insert_observation(
+    cursor: psycopg.Cursor[Any],
+    *,
+    run_id: int,
+    sample_id: str,
+    benchmark: str,
+    dataset_id: str,
+    source_kind: str,
+    captured_at: datetime,
+) -> UUID:
+    cursor.execute(
+        """
+        INSERT INTO benchmarks_v2.benchmark_observations
+          (run_id, dataset_id, dataset_sha256, sample_id, provider, model,
+           benchmark, source_kind, captured_at, status)
+        VALUES
+          (%(run_id)s, %(dataset_id)s, %(_sha)s, %(sample_id)s, 'provider', 'model',
+           %(benchmark)s, %(source_kind)s, %(captured_at)s, 'succeeded')
+        RETURNING id
+        """,
+        {
+            "run_id": run_id,
+            "dataset_id": dataset_id,
+            "_sha": _SHA,
+            "sample_id": sample_id,
+            "benchmark": benchmark,
+            "source_kind": source_kind,
+            "captured_at": captured_at,
+        },
+    )
+    row = cursor.fetchone()
+    assert row is not None
+    return UUID(str(row[0]))
+
+
+def _insert_evaluation(
+    cursor: psycopg.Cursor[Any],
+    *,
+    observation_id: UUID,
+    metric_type: str,
+    unit: str,
+    values: Sequence[tuple[str, float, str]],
+    lifecycle_at: datetime,
+) -> None:
+    cursor.execute(
+        """
+        INSERT INTO benchmarks_v2.metric_evaluations
+          (observation_id, metric_type, metric_version, evaluation_variant,
+           executor, status)
+        VALUES (%s, %s, 'v1', 'default', 'test', 'queued')
+        RETURNING id
+        """,
+        (observation_id, metric_type),
+    )
+    row = cursor.fetchone()
+    assert row is not None
+    evaluation_id = UUID(str(row[0]))
+    cursor.execute(
+        """
+        UPDATE benchmarks_v2.metric_evaluations
+        SET status = 'running', started_at = %(at)s, updated_at = %(at)s
+        WHERE id = %(id)s
+        """,
+        {"id": evaluation_id, "at": lifecycle_at},
+    )
+    cursor.executemany(
+        """
+        INSERT INTO benchmarks_v2.metric_values
+          (metric_evaluation_id, value_key, unit, value, value_role)
+        VALUES (%s, %s, %s, %s, %s)
+        """,
+        [(evaluation_id, value_key, unit, value, role) for value_key, value, role in values],
+    )
+    cursor.execute(
+        """
+        UPDATE benchmarks_v2.metric_evaluations
+        SET status = 'succeeded', finished_at = %(at)s, updated_at = %(at)s
+        WHERE id = %(id)s
+        """,
+        {"id": evaluation_id, "at": lifecycle_at},
+    )
+
+
+def _insert_matching_rows(conn: psycopg.Connection[Any]) -> None:
+    with conn.cursor() as cursor:
+        cursor.execute("SELECT now()")
+        now_row = cursor.fetchone()
+        assert now_row is not None
+        now = now_row[0]
+        old_at = now - timedelta(hours=4)
+        legacy_at = now - timedelta(minutes=30)
+        normalized_at = now - timedelta(minutes=90)
+
+        cursor.execute(
+            """
+            INSERT INTO benchmarks_v2.runs
+              (started_at, finished_at, runner_sha, dataset_id, dataset_sha256,
+               status, scheduled_at)
+            VALUES
+              (%(old_at)s, %(old_at)s, 'runner-sha', 'stt-v1', %(_sha)s,
+               'succeeded', %(old_at)s),
+              (%(legacy_at)s, %(legacy_at)s, 'runner-sha', 'stt-v1', %(_sha)s,
+               'succeeded', %(legacy_at)s),
+              (%(legacy_at)s, %(legacy_at)s, 'runner-sha', 'source-tts', %(_sha)s,
+               'succeeded', %(legacy_at)s)
+            RETURNING id
+            """,
+            {"old_at": old_at, "legacy_at": legacy_at, "_sha": _SHA},
+        )
+        run_rows = cursor.fetchall()
+        assert len(run_rows) == 3
+        old_run_id, stt_run_id, tts_run_id = (int(row[0]) for row in run_rows)
+
+        cursor.executemany(
+            """
+            INSERT INTO benchmarks_v2.results
+              (run_id, provider, model, benchmark, metric_type, metric_value,
+               metric_units, status, created_at, wer_insertions_pct,
+               wer_deletions_pct, wer_substitutions_pct)
+            VALUES
+              (%s, 'provider', 'model', %s, %s, %s, %s, 'success', %s, %s, %s, %s)
+            """,
+            [
+                (old_run_id, "STT", "WER", 6.0, "percent", old_at, 1.0, 2.0, 3.0),
+                (stt_run_id, "STT", "WER", 6.0, "percent", legacy_at, 1.0, 2.0, 3.0),
+                (stt_run_id, "STT", "WER", 6.0, "percent", legacy_at, 1.0, 2.0, 3.0),
+                (tts_run_id, "TTS", "TTFA", 12.0, "milliseconds", legacy_at, None, None, None),
+                (
+                    tts_run_id,
+                    "TTS",
+                    "TTFARoundtrip",
+                    10.0,
+                    "milliseconds",
+                    legacy_at,
+                    None,
+                    None,
+                    None,
+                ),
+                (
+                    tts_run_id,
+                    "TTS",
+                    "TTFALeadingSilence",
+                    2.0,
+                    "milliseconds",
+                    legacy_at,
+                    None,
+                    None,
+                    None,
+                ),
+            ],
+        )
+
+        for sample_id in ("stt-sample-1", "stt-sample-2"):
+            observation_id = _insert_observation(
+                cursor,
+                run_id=stt_run_id,
+                sample_id=sample_id,
+                benchmark="STT",
+                dataset_id="stt-v1",
+                source_kind="dataset_audio",
+                captured_at=normalized_at,
+            )
+            _insert_evaluation(
+                cursor,
+                observation_id=observation_id,
+                metric_type="WER",
+                unit="percent",
+                values=[
+                    ("primary", 6.0, "primary"),
+                    ("insertions", 1.0, "component"),
+                    ("deletions", 2.0, "component"),
+                    ("substitutions", 3.0, "component"),
+                ],
+                lifecycle_at=now,
+            )
+
+        tts_observation_id = _insert_observation(
+            cursor,
+            run_id=tts_run_id,
+            sample_id="tts-sample",
+            benchmark="TTS",
+            dataset_id="tts-v1",
+            source_kind="generated_audio",
+            captured_at=normalized_at,
+        )
+        _insert_evaluation(
+            cursor,
+            observation_id=tts_observation_id,
+            metric_type="TTFA",
+            unit="milliseconds",
+            values=[
+                ("primary", 12.0, "primary"),
+                ("roundtrip", 10.0, "component"),
+                ("leading_silence", 2.0, "component"),
+            ],
+            lifecycle_at=now,
+        )
+
+        bucket_at = legacy_at.replace(minute=0, second=0, microsecond=0)
+        cursor.execute(
+            """
+            INSERT INTO benchmarks_v2.results_by_bucket
+              (provider, model, benchmark, dataset_id, metric_type, bucket_at,
+               min_value, p25, p50, p75, max_value, value_sum, sample_count)
+            VALUES
+              ('provider', 'model', 'STT', 'stt-v1', 'WER', %(bucket_at)s,
+               6, 6, 6, 6, 6, 12, 2)
+            """,
+            {"bucket_at": bucket_at},
+        )
+        cursor.execute(
+            """
+            INSERT INTO benchmarks_v2.metric_values_by_bucket
+              (provider, model, benchmark, dataset_id, metric_type,
+               metric_version, evaluation_variant, value_key, unit, bucket_at,
+               min_value, p25, p50, p75, max_value, value_sum, sample_count)
+            VALUES
+              ('provider', 'model', 'STT', 'stt-v1', 'WER',
+               'v1', 'default', 'primary', 'percent', %(bucket_at)s,
+               6, 6, 6, 6, 6, 12, 2)
+            """,
+            {"bucket_at": bucket_at},
+        )
+    conn.commit()
+
+
+def test_real_sql_matches_wer_duplicates_ttfa_components_and_rollups(
+    readiness_pg: psycopg.Connection[Any],
+) -> None:
+    apply_migrations(readiness_pg)
+    _insert_matching_rows(readiness_pg)
+
+    report = check(
+        readiness_pg,
+        required_hours=2,
+        chunk_hours=1,
+        statement_timeout_seconds=5,
+        total_timeout_seconds=30,
+    )
+    readiness_pg.rollback()
+
+    assert report["ready"] is True
+    assert report["coverage_hours"] >= 2
+    assert report["raw_mismatch_count"] == 0
+    assert report["rollup_mismatch_count"] == 0


### PR DESCRIPTION
## Summary
- replace the unbounded seven-day bidirectional EXCEPT ALL query with exact grouped-count comparisons over bounded time/cohort chunks
- accumulate signed multiplicities across the full snapshot so duplicates and cross-chunk matches retain exact whole-window semantics
- use benchmark/dataset-constrained reads, conservative index-seeking coverage proof, per-statement timeouts, and a total deadline
- preserve TTS dataset coercion, TTFA public metric names, WER components, rollup parity, and machine-readable 0/1/2 outcomes

## Validation
- 21 focused readiness tests pass
- Ruff formatting and lint pass for all changed files
- strict mypy passes with explicit package bases
- independent high-risk review approved with no remaining findings
- added embedded-Postgres coverage for duplicate WER rows across chunks, TTS/TTFA mapping, WER components, and rollups; local execution is blocked only because this host has no Postgres binaries, so CI must exercise it

## Rollout safety
- no schema migration and no read-path flag change
- normalized dashboard reads remain disabled
- after deployment, first run EXPLAIN without ANALYZE on representative chunks, then run the bounded checker once
- cut over only if the complete checker exits 0

Related: BENCH-768