### PR TITLE
[BENCH-779] Add normalized writes for S2S ingestion

### DIFF
--- a/runner/src/coval_bench/runner/normalized.py
+++ b/runner/src/coval_bench/runner/normalized.py
@@ -1,7 +1,7 @@
 # Copyright 2026 The Coval Benchmarks Authors
 # SPDX-License-Identifier: Apache-2.0
 # ruff: noqa: ANN401 -- adapter composes lazy runtime collaborators from orchestrator.
-"""Best-effort additive persistence of legacy STT/TTS results."""
+"""Best-effort additive persistence of legacy STT/TTS/S2S results."""
 
 from __future__ import annotations
 
@@ -130,6 +130,7 @@ async def dual_write(
     timing_events: dict[str, Any] | None = None,
     audio_path: Any = None,
     voice: str | None = None,
+    executor: MetricExecutor = MetricExecutor.INLINE,
 ) -> None:
     """Persist one observation and its grouped normalized evaluations."""
     audio_snapshot = snapshot_generated_audio(audio_path) if audio_path is not None else None
@@ -153,11 +154,11 @@ async def dual_write(
                 audio_duration_ms,
             )
         )
-    source_kind = (
-        ObservationSourceKind.DATASET_AUDIO
-        if benchmark.value.upper() == "STT"
-        else ObservationSourceKind.GENERATED_AUDIO
-    )
+    source_kind = {
+        "STT": ObservationSourceKind.DATASET_AUDIO,
+        "TTS": ObservationSourceKind.GENERATED_AUDIO,
+        "S2S": ObservationSourceKind.CONVERSATION_AUDIO,
+    }[benchmark.value.upper()]
     observation = await writer.insert_observation(
         Observation(
             run_id=run_id,
@@ -199,7 +200,7 @@ async def dual_write(
                 observation_id=observation.id,
                 metric_type=metric,
                 metric_version="v1",
-                executor=MetricExecutor.INLINE,
+                executor=executor,
                 status=ProcessingStatus.QUEUED,
             ),
             inputs=_inputs(metric, artifact_ids, benchmark),

--- a/runner/src/coval_bench/s2s/fetch_v2v.py
+++ b/runner/src/coval_bench/s2s/fetch_v2v.py
@@ -25,7 +25,7 @@ import structlog
 
 from coval_bench.config import Settings, get_settings
 from coval_bench.db.conn import lifespan_pool
-from coval_bench.db.models import Result, ResultStatus, RunStatus
+from coval_bench.db.models import MetricExecutor, Result, ResultStatus, RunStatus
 from coval_bench.db.writer import RunWriter
 from coval_bench.registries import METRIC_SPECS, Metric
 from coval_bench.registries.benchmarks import Benchmark
@@ -151,6 +151,18 @@ def _dataset_sha256() -> str:
     except Exception:
         logger.warning("dataset_sha256_failed", dataset_id=DATASET_ID, exc_info=True)
         return "unknown"
+
+
+def _normalized_dataset_sha256(provenance: str) -> str:
+    """Return the normalized schema stable 64-hex dataset fingerprint.
+
+    Packaged datasets already carry a content SHA. Coval-hosted S2S datasets
+    carry immutable test-set/persona provenance in the legacy run column, so
+    fingerprint that identifier without changing the legacy representation.
+    """
+    if len(provenance) == 64 and all(character in "0123456789abcdef" for character in provenance):
+        return provenance
+    return hashlib.sha256(provenance.encode()).hexdigest()
 
 
 def _condition_for_persona(
@@ -494,6 +506,7 @@ async def _ingest_run(
     dataset_id: str = DATASET_ID,
     dataset_sha256: str = "",
     period_seconds: int,
+    normalized_dual_write_enabled: bool = False,
 ) -> RunStatus | None:
     """Ingest one Coval run into its own run row; None = skipped, nothing written.
 
@@ -648,7 +661,53 @@ async def _ingest_run(
         all_rows = [row for rows in by_metric.values() for row in rows]
         rows = by_metric.get(Metric.V2V, [])
         if all_rows:
-            await writer.record_results(all_rows)
+            captured_at = datetime.now(UTC)
+            await writer.record_results(all_rows, created_at=captured_at)
+            if normalized_dual_write_enabled:
+                from coval_bench.runner.normalized import dual_write
+
+                grouped: dict[str, list[Result]] = {}
+                for row in all_rows:
+                    if row.audio_filename is None:  # pragma: no cover -- S2S rows set it
+                        logger.warning(
+                            "normalized_s2s_sample_id_missing",
+                            provider=spec.provider,
+                            coval_run_id=coval_run.run_id,
+                        )
+                        continue
+                    grouped.setdefault(row.audio_filename, []).append(row)
+                normalized_sha256 = _normalized_dataset_sha256(dataset_sha256 or _dataset_sha256())
+                for sample_id, sample_rows in grouped.items():
+                    provider_error = None
+                    if not any(row.status is ResultStatus.SUCCESS for row in sample_rows):
+                        provider_error = next(
+                            (row.error for row in sample_rows if row.error),
+                            "Coval conversation produced no successful metric value",
+                        )
+                    try:
+                        await dual_write(
+                            writer=writer,
+                            storage_client=None,
+                            bucket="",
+                            run_id=run_pk,
+                            dataset_id=dataset_id,
+                            dataset_sha256=normalized_sha256,
+                            sample_id=sample_id,
+                            entry=spec,
+                            benchmark=Benchmark.S2S,
+                            results=sample_rows,
+                            provider_error=provider_error,
+                            captured_at=captured_at,
+                            executor=MetricExecutor.COVAL_API,
+                        )
+                    except Exception:
+                        logger.warning(
+                            "normalized_s2s_dual_write_failed",
+                            provider=spec.provider,
+                            coval_run_id=coval_run.run_id,
+                            sample_id=sample_id,
+                            exc_info=True,
+                        )
         logger.info(
             "fetched_clips",
             provider=spec.provider,
@@ -735,6 +794,7 @@ async def _fetch_one_provider(
     window_seconds: int | None = None,
     page_size: int = WINDOW_PAGE_SIZE,
     matched_run_ids: set[str] | None = None,
+    normalized_dual_write_enabled: bool = False,
 ) -> tuple[RunStatus, int]:
     """Scan the window and ingest every clean, not-yet-ingested run.
 
@@ -843,6 +903,7 @@ async def _fetch_one_provider(
                 dataset_id=dataset_id,
                 dataset_sha256=dataset_sha256,
                 period_seconds=period_seconds,
+                normalized_dual_write_enabled=normalized_dual_write_enabled,
             )
             if status is None:
                 continue
@@ -1010,6 +1071,7 @@ async def fetch_and_write_v2v(
                 window_seconds=window_seconds,
                 page_size=page_size,
                 matched_run_ids=matched_run_ids,
+                normalized_dual_write_enabled=settings.normalized_dual_write_enabled,
             )
             total_ingested += ingested
 

--- a/runner/tests/unit/test_normalized_dual_write.py
+++ b/runner/tests/unit/test_normalized_dual_write.py
@@ -17,6 +17,7 @@ from coval_bench.db.models import (
     MetricArtifact,
     MetricEvaluation,
     MetricEvaluationInput,
+    MetricExecutor,
     MetricValue,
     Observation,
     ObservationArtifact,
@@ -384,3 +385,32 @@ async def test_null_success_metric_is_excluded_instead_of_failed() -> None:
     assert not writer.evaluations
     assert not writer.completed
     assert not writer.failed
+
+
+@pytest.mark.asyncio
+async def test_s2s_uses_conversation_source_and_coval_executor() -> None:
+    writer = _Writer()
+
+    await normalized.dual_write(
+        writer=writer,
+        storage_client=None,
+        bucket="",
+        run_id=1,
+        dataset_id="s2s-multiturn-v1",
+        dataset_sha256="e" * 64,
+        sample_id="R1/s1",
+        entry=SimpleNamespace(provider="provider", model="model"),
+        benchmark=Benchmark.S2S,
+        results=[_result(Benchmark.S2S, Metric.V2V, 500, "milliseconds")],
+        provider_error=None,
+        executor=MetricExecutor.COVAL_API,
+    )
+
+    observation = writer.observations[0]
+    assert observation.source_kind is ObservationSourceKind.CONVERSATION_AUDIO
+    evaluation_id, evaluation = _evaluation_by_metric(writer, Metric.V2V)
+    assert evaluation.executor is MetricExecutor.COVAL_API
+    assert writer.inputs[evaluation_id] == []
+    assert [(value.value_key, value.value) for value in writer.completed[evaluation_id]] == [
+        ("primary", 500.0)
+    ]

--- a/runner/tests/unit/test_s2s_fetch.py
+++ b/runner/tests/unit/test_s2s_fetch.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import contextlib
+import hashlib
 from collections.abc import AsyncIterator
 from datetime import UTC, datetime, timedelta
 from typing import Any
@@ -17,7 +18,7 @@ from click.testing import CliRunner
 from structlog.testing import capture_logs
 
 from coval_bench.config import Settings
-from coval_bench.db.models import ResultStatus, Run, RunStatus
+from coval_bench.db.models import MetricExecutor, ResultStatus, Run, RunStatus
 from coval_bench.logging import log_run_failed, log_run_partial
 from coval_bench.registries import Metric
 from coval_bench.s2s import fetch_v2v
@@ -1694,3 +1695,110 @@ def test_cli_no_providers_alerts_failed_exit_nonzero(monkeypatch: pytest.MonkeyP
     assert code != 0
     assert "RUN_FAILED" in events
     assert "RUN_PARTIAL" not in events
+
+
+@pytest.mark.asyncio
+async def test_ingest_run_dual_writes_one_observation_per_conversation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    writer = _stub_writer()
+    dual_write = AsyncMock()
+    monkeypatch.setattr("coval_bench.runner.normalized.dual_write", dual_write)
+    latency = [
+        {"simulation_output_id": "s1", "value": 0.5},
+        {"simulation_output_id": "s2", "value": 0.6},
+    ]
+    instruction = [
+        {"simulation_output_id": "s1", "value": "YES"},
+        {"simulation_output_id": "s2", "value": "NO"},
+    ]
+    fixture = {
+        "run": {
+            "results": {"metrics": {"MID": {"values": latency}, "IID": {"values": instruction}}}
+        }
+    }
+
+    async with _fake_client({}, fixture) as client:
+        status = await fetch_v2v._ingest_run(
+            client,
+            writer,
+            spec=SPEC,
+            coval_run=CovalRun(run_id="R1", create_time=None),
+            metric_ids=IDS,
+            condition=condition_for(DATASET_ID_MULTITURN),
+            dataset_id=DATASET_ID_MULTITURN,
+            dataset_sha256="test-set:persona",
+            period_seconds=10_800,
+            normalized_dual_write_enabled=True,
+        )
+
+    assert status is RunStatus.SUCCEEDED
+    assert dual_write.await_count == 2
+    calls = {call.kwargs["sample_id"]: call.kwargs for call in dual_write.await_args_list}
+    assert set(calls) == {"R1/s1", "R1/s2"}
+    assert {row.metric_type for row in calls["R1/s1"]["results"]} == {
+        Metric.V2V,
+        Metric.INSTRUCTION_FOLLOWING,
+    }
+    assert calls["R1/s1"]["dataset_sha256"] == hashlib.sha256(b"test-set:persona").hexdigest()
+    assert calls["R1/s1"]["executor"] is MetricExecutor.COVAL_API
+    assert calls["R1/s1"]["captured_at"] == writer.record_results.await_args.kwargs["created_at"]
+
+
+@pytest.mark.asyncio
+async def test_ingest_run_normalized_failure_does_not_lose_legacy_rows(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    writer = _stub_writer()
+    dual_write = AsyncMock(side_effect=RuntimeError("normalized unavailable"))
+    monkeypatch.setattr("coval_bench.runner.normalized.dual_write", dual_write)
+    values = [{"simulation_output_id": "s1", "value": 0.5}]
+
+    async with _fake_client({}, _run_json(values)) as client:
+        status = await fetch_v2v._ingest_run(
+            client,
+            writer,
+            spec=SPEC,
+            coval_run=CovalRun(run_id="R1", create_time=None),
+            metric_ids=LATENCY_IDS,
+            dataset_sha256="f" * 64,
+            period_seconds=10_800,
+            normalized_dual_write_enabled=True,
+        )
+
+    assert status is RunStatus.SUCCEEDED
+    writer.record_results.assert_awaited_once()
+    writer.finish_run.assert_awaited_once()
+    dual_write.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_fetch_and_write_v2v_propagates_normalized_gate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("COVAL_S2S_GEMINI_AGENT_ID", raising=False)
+    settings = Settings(
+        coval_s2s_latency_metric_id="MID",
+        coval_s2s_openai_agent_id="a1",
+        coval_s2s_dental_test_set_id="TSD",
+        normalized_dual_write_enabled=True,
+        benchmark_artifact_bucket="private-artifacts",
+    )
+    client = _fake_client({}, {})
+    writer = _stub_writer()
+
+    @contextlib.asynccontextmanager
+    async def _fake_pool(_settings: Any) -> AsyncIterator[MagicMock]:
+        yield MagicMock()
+
+    fetch_one = AsyncMock(return_value=(RunStatus.SUCCEEDED, 0))
+    monkeypatch.setattr(fetch_v2v, "_client", lambda _settings: client)
+    monkeypatch.setattr(fetch_v2v, "lifespan_pool", _fake_pool)
+    monkeypatch.setattr(fetch_v2v, "RunWriter", lambda _pool: writer)
+    monkeypatch.setattr(fetch_v2v, "_fetch_one_provider", fetch_one)
+
+    statuses = await fetch_v2v.fetch_and_write_v2v(settings)
+
+    assert statuses == {"openai:gpt-realtime": RunStatus.SUCCEEDED}
+    assert fetch_one.await_args is not None
+    assert fetch_one.await_args.kwargs["normalized_dual_write_enabled"] is True


### PR DESCRIPTION
## Summary

- add feature-gated normalized observation, evaluation, and value writes to S2S ingestion
- group legacy metric rows into one normalized observation per Coval conversation
- preserve S2S provenance, use the Coval API executor, and share capture timestamps across legacy and normalized rows
- keep normalized failures best-effort so legacy ingestion still completes

## Validation

- `pytest -q tests/unit/test_normalized_dual_write.py tests/unit/test_s2s_fetch.py` — 84 passed
- `ruff check` on the four changed files
- `ruff format --check` on the four changed files
- `mypy --strict` on the four changed files

## Follow-up

This enables new S2S writes when the existing normalized dual-write flag is enabled. Historical backfill and normalized rollup refresh remain separate cutover work.