### PR TITLE
[BENCH-780] Refresh normalized metric rollups after completed runs

### DIFF
--- a/runner/src/coval_bench/runner/orchestrator.py
+++ b/runner/src/coval_bench/runner/orchestrator.py
@@ -44,6 +44,7 @@ import random
 import signal
 import wave
 from collections import Counter, defaultdict
+from collections.abc import Awaitable, Callable
 from datetime import UTC, datetime  # noqa: UP017 — UTC alias requires 3.11+, target is 3.12
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
@@ -1028,23 +1029,34 @@ _BUCKET_REFRESH_RETRY_DELAY_S = 0.5
 
 
 async def _refresh_series_bucket(writer: Any, run_id: int, settings: Settings) -> None:  # noqa: ANN401 — RunWriter, lazy-imported by the caller
-    """Best-effort refresh of the run's series rollup bucket; never raises.
+    """Best-effort refresh of the run's legacy and normalized rollup bucket.
 
-    Transient failures are retried. A final failure leaves only this bucket
-    stale (a run sharing the slot recomputes it; the migration backfill is
-    the manual repair) — not worth failing the run.
+    Each rollup is retried independently so one stale table cannot suppress the
+    other. A run sharing the slot recomputes both tables; the migration backfill
+    is the manual repair after a final failure. Maintenance never fails the run.
     """
-    for attempt in range(1, _BUCKET_REFRESH_ATTEMPTS + 1):
-        try:
-            await writer.refresh_bucket(run_id, period_seconds=settings.schedule_period_seconds)
-        except Exception:
-            if attempt == _BUCKET_REFRESH_ATTEMPTS:
-                logger.warning("series_bucket_refresh_failed", exc_info=True)
-                return
-            logger.info("series_bucket_refresh_retry", attempt=attempt)
-            await asyncio.sleep(_BUCKET_REFRESH_RETRY_DELAY_S)
-        else:
-            return
+    refreshes: tuple[tuple[str, Callable[[], Awaitable[None]]], ...] = (
+        (
+            "series_bucket",
+            lambda: writer.refresh_bucket(run_id, period_seconds=settings.schedule_period_seconds),
+        ),
+        (
+            "normalized_series_bucket",
+            lambda: writer.refresh_metric_values_bucket(run_id),
+        ),
+    )
+    for event_prefix, refresh in refreshes:
+        for attempt in range(1, _BUCKET_REFRESH_ATTEMPTS + 1):
+            try:
+                await refresh()
+            except Exception:
+                if attempt == _BUCKET_REFRESH_ATTEMPTS:
+                    logger.warning(f"{event_prefix}_refresh_failed", exc_info=True)
+                    break
+                logger.info(f"{event_prefix}_refresh_retry", attempt=attempt)
+                await asyncio.sleep(_BUCKET_REFRESH_RETRY_DELAY_S)
+            else:
+                break
 
 
 async def run_benchmarks(

--- a/runner/src/coval_bench/s2s/fetch_v2v.py
+++ b/runner/src/coval_bench/s2s/fetch_v2v.py
@@ -676,6 +676,12 @@ async def _ingest_run(
                 await writer.refresh_bucket(run_pk, period_seconds=period_seconds)
             except Exception:
                 logger.warning("refresh_bucket_failed", provider=spec.provider, exc_info=True)
+            try:
+                await writer.refresh_metric_values_bucket(run_pk)
+            except Exception:
+                logger.warning(
+                    "normalized_bucket_refresh_failed", provider=spec.provider, exc_info=True
+                )
         return status
     except Exception as exc:
         if run_pk is not None:

--- a/runner/tests/unit/test_orchestrator.py
+++ b/runner/tests/unit/test_orchestrator.py
@@ -171,6 +171,7 @@ def _make_stub_writer(run: Run) -> MagicMock:
     writer.finish_run = AsyncMock()
     writer.refresh_stats_matviews = AsyncMock()
     writer.refresh_bucket = AsyncMock()
+    writer.refresh_metric_values_bucket = AsyncMock()
     return writer
 
 
@@ -348,6 +349,7 @@ async def test_smoke_run_stt(audio_file: Path, settings: Settings) -> None:
     writer.refresh_bucket.assert_awaited_once_with(
         1, period_seconds=settings.schedule_period_seconds
     )
+    writer.refresh_metric_values_bucket.assert_awaited_once_with(1)
 
 
 # ---------------------------------------------------------------------------
@@ -398,6 +400,7 @@ async def test_partial_run(audio_file: Path, settings: Settings) -> None:
     writer.refresh_bucket.assert_awaited_once_with(
         1, period_seconds=settings.schedule_period_seconds
     )
+    writer.refresh_metric_values_bucket.assert_awaited_once_with(1)
 
 
 # ---------------------------------------------------------------------------
@@ -446,38 +449,65 @@ async def test_full_failure(audio_file: Path, settings: Settings) -> None:
     assert all(r.status == ResultStatus.FAILED for r in rows)
     assert all("always fails" in (r.error or "") for r in rows)
     writer.refresh_bucket.assert_not_awaited()
+    writer.refresh_metric_values_bucket.assert_not_awaited()
 
 
 @pytest.mark.asyncio
 async def test_refresh_series_bucket_retries_transient_failure(
     settings: Settings, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """A transient refresh failure is retried; success stops the loop."""
+    """A transient normalized refresh failure is retried independently."""
     from coval_bench.runner import orchestrator
 
     monkeypatch.setattr(orchestrator, "_BUCKET_REFRESH_RETRY_DELAY_S", 0.0)
     writer = MagicMock()
-    writer.refresh_bucket = AsyncMock(side_effect=[RuntimeError("blip"), None])
+    writer.refresh_bucket = AsyncMock()
+    writer.refresh_metric_values_bucket = AsyncMock(side_effect=[RuntimeError("blip"), None])
 
     await orchestrator._refresh_series_bucket(writer, 1, settings)
 
-    assert writer.refresh_bucket.await_count == 2
+    writer.refresh_bucket.assert_awaited_once_with(
+        1, period_seconds=settings.schedule_period_seconds
+    )
+    assert writer.refresh_metric_values_bucket.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_refresh_series_bucket_continues_after_legacy_failure(
+    settings: Settings, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Exhausting the legacy refresh does not suppress the normalized refresh."""
+    from coval_bench.runner import orchestrator
+
+    monkeypatch.setattr(orchestrator, "_BUCKET_REFRESH_RETRY_DELAY_S", 0.0)
+    writer = MagicMock()
+    writer.refresh_bucket = AsyncMock(side_effect=RuntimeError("legacy db down"))
+    writer.refresh_metric_values_bucket = AsyncMock()
+
+    await orchestrator._refresh_series_bucket(writer, 1, settings)
+
+    assert writer.refresh_bucket.await_count == 3
+    writer.refresh_metric_values_bucket.assert_awaited_once_with(1)
 
 
 @pytest.mark.asyncio
 async def test_refresh_series_bucket_never_raises(
     settings: Settings, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Exhausting all attempts logs and returns instead of raising."""
+    """Exhausting normalized attempts logs and returns instead of raising."""
     from coval_bench.runner import orchestrator
 
     monkeypatch.setattr(orchestrator, "_BUCKET_REFRESH_RETRY_DELAY_S", 0.0)
     writer = MagicMock()
-    writer.refresh_bucket = AsyncMock(side_effect=RuntimeError("db down"))
+    writer.refresh_bucket = AsyncMock()
+    writer.refresh_metric_values_bucket = AsyncMock(side_effect=RuntimeError("db down"))
 
     await orchestrator._refresh_series_bucket(writer, 1, settings)
 
-    assert writer.refresh_bucket.await_count == 3
+    writer.refresh_bucket.assert_awaited_once_with(
+        1, period_seconds=settings.schedule_period_seconds
+    )
+    assert writer.refresh_metric_values_bucket.await_count == 3
 
 
 @pytest.mark.asyncio
@@ -1726,6 +1756,7 @@ async def test_sigterm_finalizes_run_as_partial(audio_file: Path, settings: Sett
     writer.refresh_bucket.assert_awaited_once_with(
         run.id, period_seconds=settings.schedule_period_seconds
     )
+    writer.refresh_metric_values_bucket.assert_awaited_once_with(run.id)
 
 
 # ---------------------------------------------------------------------------

--- a/runner/tests/unit/test_s2s_fetch.py
+++ b/runner/tests/unit/test_s2s_fetch.py
@@ -107,6 +107,7 @@ def _stub_writer() -> MagicMock:
     writer.record_results = AsyncMock()
     writer.finish_run = AsyncMock()
     writer.refresh_bucket = AsyncMock()
+    writer.refresh_metric_values_bucket = AsyncMock()
     writer.refresh_stats_matviews = AsyncMock()
     return writer
 
@@ -363,6 +364,7 @@ async def test_ingest_run_slots_by_create_time() -> None:
     assert writer.start_run.await_args.kwargs["scheduled_at"] == datetime(2026, 7, 7, 0, tzinfo=UTC)
     writer.record_results.assert_awaited_once()
     writer.refresh_bucket.assert_awaited_once()
+    writer.refresh_metric_values_bucket.assert_awaited_once_with(1)
     assert writer.finish_run.await_args.kwargs["status"] is RunStatus.SUCCEEDED
 
 
@@ -384,6 +386,8 @@ async def test_ingest_run_partial_and_failed() -> None:
             period_seconds=10_800,
         )
     assert status is RunStatus.PARTIAL
+    writer.refresh_bucket.assert_awaited_once()
+    writer.refresh_metric_values_bucket.assert_awaited_once_with(1)
 
     writer = _stub_writer()
     all_null: list[dict[str, Any]] = [{"simulation_output_id": "s1", "value": None}]
@@ -398,6 +402,33 @@ async def test_ingest_run_partial_and_failed() -> None:
         )
     assert status is RunStatus.FAILED
     writer.refresh_bucket.assert_not_awaited()
+    writer.refresh_metric_values_bucket.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failing_refresh", ["refresh_bucket", "refresh_metric_values_bucket"])
+async def test_ingest_run_rollup_refresh_failure_does_not_change_status(
+    failing_refresh: str,
+) -> None:
+    """Either best-effort rollup failure leaves the completed run succeeded."""
+    writer = _stub_writer()
+    getattr(writer, failing_refresh).side_effect = RuntimeError("db down")
+    values = [{"simulation_output_id": "s1", "value": 0.5}]
+
+    async with _fake_client({}, _run_json(values)) as client:
+        status = await fetch_v2v._ingest_run(
+            client,
+            writer,
+            spec=SPEC,
+            coval_run=CovalRun(run_id="R1", create_time=None),
+            metric_ids=LATENCY_IDS,
+            period_seconds=10_800,
+        )
+
+    assert status is RunStatus.SUCCEEDED
+    writer.finish_run.assert_awaited_once_with(1, status=RunStatus.SUCCEEDED)
+    writer.refresh_bucket.assert_awaited_once()
+    writer.refresh_metric_values_bucket.assert_awaited_once_with(1)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Refresh normalized metric rollups whenever the corresponding legacy series bucket is refreshed.
- Cover normal STT/TTS completion, shielded SIGTERM partial finalization, and S2S ingestion.
- Retry legacy and normalized refreshes independently so either table can recover without changing the run's terminal status.
- Add focused regression coverage for succeeded, partial, failed, retry, and failure-isolation paths.

## Why

Normalized observations and metric values were being written, but `metric_values_by_bucket` remained empty because `refresh_metric_values_bucket(run_id)` had no production call site. That prevents normalized dashboard reads from reaching rollup parity.

## Behavior

This does not change benchmark measurements or normalized dual-write behavior. It only maintains post-run rollups:

- succeeded and partial runs refresh both tables;
- failed runs refresh neither;
- rollup maintenance remains best-effort and cannot fail a completed benchmark run.

## Validation

- Disposable Postgres 16 smoke: applied all migrations, persisted matching legacy and normalized WER data, invoked the combined refresh twice, and verified matching/idempotent rollups.
- Orchestrator focused tests: 8 passed.
- S2S focused tests: 4 passed.
- Ruff lint and format checks passed.
- Mypy passed for both changed production files.
- Independent persistence review passed with no findings.

## Cutover sequencing

This PR can merge independently of BENCH-778 and BENCH-779. Cutover readiness still requires all three fixes to deploy, followed by the bounded historical backfill/rollup rebuild and another readiness check.
