### PR TITLE
Add per-platform codecs in front of the mock tool dispatcher

### DIFF
--- a/runner/src/coval_bench/api/routers/mocktools.py
+++ b/runner/src/coval_bench/api/routers/mocktools.py
@@ -3,10 +3,11 @@
 
 """The mock tool endpoint the benchmarked agents call.
 
-``POST /mock/{tool}`` with the tool's arguments as a JSON object. The response
-is whichever seed the resolver picks, held to a fixed latency budget so that a
-tool call costs the same on every platform under test. Without that, a variant
-would be measured partly on how fast our mock happened to answer it.
+``POST /mock/{platform}/{tool}`` for platforms that name the tool in the URL and
+``POST /mock/{platform}`` for those that name it in the body. The platform's codec
+unwraps the request into tool calls, the dispatcher answers each from the seeded
+fixtures, and the codec wraps the answers back into that platform's reply shape.
+Nothing past the codec knows which platform asked.
 
 Mounted outside ``/v1``: this is not part of the public read API, it is an
 appliance the agents talk to. It carries a shared secret rather than Clerk —
@@ -31,14 +32,13 @@ from starlette.responses import JSONResponse
 from coval_bench.api.deps import get_pool, get_settings
 from coval_bench.config import Settings
 from coval_bench.db.mock_tool_store import record_call
+from coval_bench.mocktools.codecs import Codec, codec_for
 from coval_bench.mocktools.dispatch import Dispatcher
 
 logger = structlog.get_logger("coval_bench.mocktools")
 
 router = APIRouter(prefix="/mock", tags=["mock-tools"])
 
-SIMULATION_HEADER = "X-Coval-Simulation-Id"
-CALLER_HEADER = "X-Coval-Caller-Number"
 SECRET_HEADER = "X-Mock-Tools-Key"  # noqa: S105 — a header name, not a credential
 
 
@@ -76,49 +76,93 @@ def get_dispatcher(request: Request) -> Dispatcher:
     return dispatcher
 
 
-@router.post("/{tool}", dependencies=[Depends(require_mock_secret)])
-async def call_tool(
-    tool: str,
+def get_codec(platform: str) -> Codec:
+    try:
+        return codec_for(platform)
+    except KeyError as exc:
+        raise HTTPException(404, str(exc)) from exc
+
+
+async def _answer(
+    codec: Codec,
+    tool: str | None,
+    body: dict[str, Any] | None,
+    request: Request,
     background: BackgroundTasks,
-    args: dict[str, Any] = Body(default=None),
-    x_coval_simulation_id: str | None = Header(default=None),
-    x_coval_caller_number: str | None = Header(default=None),
+    dispatcher: Dispatcher,
+    settings: Settings,
+    pool: AsyncConnectionPool[Any],
+) -> JSONResponse:
+    started = time.perf_counter()
+    calls = codec.decode(body, request.headers, tool)
+    correlation = codec.correlate(body, request.headers)
+    outcomes = [dispatcher.call(call.tool, call.args) for call in calls]
+
+    budget_s = len(calls) * settings.mock_tools_latency_ms / 1000
+    remaining = budget_s - (time.perf_counter() - started)
+    if remaining > 0:
+        await asyncio.sleep(remaining)
+    latency_ms = (time.perf_counter() - started) * 1000 / max(len(calls), 1)
+
+    for call, outcome in zip(calls, outcomes, strict=True):
+        background.add_task(
+            record_call,
+            pool,
+            tool=call.tool,
+            args=call.args,
+            response=outcome.response,
+            latency_ms=latency_ms,
+            matched_seed=outcome.resolution.matched_seed if outcome.resolution else None,
+            simulation_id=correlation.simulation_id,
+            caller_number=correlation.caller_number,
+        )
+        logger.info(
+            "mock_tool_call",
+            platform=codec.name,
+            tool=call.tool,
+            status=outcome.http_status,
+            mode=outcome.resolution.mode if outcome.resolution else "rejected",
+            seed=outcome.resolution.matched_seed if outcome.resolution else None,
+            simulation_id=correlation.simulation_id,
+            correlation_source=correlation.source,
+        )
+    if not calls:
+        logger.warning("mock_tool_call_empty", platform=codec.name)
+
+    payload, status = codec.encode(calls, outcomes)
+    return JSONResponse(payload, status_code=status)
+
+
+@router.post("/{platform}", dependencies=[Depends(require_mock_secret)])
+async def call_tools(
+    platform: str,
+    request: Request,
+    background: BackgroundTasks,
+    body: dict[str, Any] | None = Body(default=None),
     dispatcher: Dispatcher = Depends(get_dispatcher),
     settings: Settings = Depends(get_settings),
     pool: AsyncConnectionPool[Any] = Depends(get_pool),
 ) -> JSONResponse:
-    """Answer one tool call, hold it to the latency budget, and log it."""
-    started = time.perf_counter()
-    call_args = args if args is not None else {}
-    outcome = dispatcher.call(tool, call_args)
+    codec = get_codec(platform)
+    if codec.tool_in_path:
+        raise HTTPException(
+            404, f"{platform} names the tool in the path: /mock/{platform}/{{tool}}"
+        )
+    return await _answer(codec, None, body, request, background, dispatcher, settings, pool)
 
-    # Hold every answer to the same budget so tool time is a constant across
-    # variants rather than a property of how much work this particular seed took.
-    budget_s = settings.mock_tools_latency_ms / 1000
-    remaining = budget_s - (time.perf_counter() - started)
-    if remaining > 0:
-        await asyncio.sleep(remaining)
-    latency_ms = (time.perf_counter() - started) * 1000
 
-    # Logged after the response goes out: the row is telemetry and must not be
-    # charged to the latency the platform observes.
-    background.add_task(
-        record_call,
-        pool,
-        tool=tool,
-        args=call_args,
-        response=outcome.response,
-        latency_ms=latency_ms,
-        matched_seed=outcome.resolution.matched_seed if outcome.resolution else None,
-        simulation_id=x_coval_simulation_id,
-        caller_number=x_coval_caller_number,
-    )
-    logger.info(
-        "mock_tool_call",
-        tool=tool,
-        status=outcome.http_status,
-        mode=outcome.resolution.mode if outcome.resolution else "rejected",
-        seed=outcome.resolution.matched_seed if outcome.resolution else None,
-        simulation_id=x_coval_simulation_id,
-    )
-    return JSONResponse(outcome.response, status_code=outcome.http_status)
+@router.post("/{platform}/{tool}", dependencies=[Depends(require_mock_secret)])
+async def call_tool(
+    platform: str,
+    tool: str,
+    request: Request,
+    background: BackgroundTasks,
+    body: dict[str, Any] | None = Body(default=None),
+    dispatcher: Dispatcher = Depends(get_dispatcher),
+    settings: Settings = Depends(get_settings),
+    pool: AsyncConnectionPool[Any] = Depends(get_pool),
+) -> JSONResponse:
+    codec = get_codec(platform)
+    if not codec.tool_in_path:
+        raise HTTPException(404, f"{platform} names the tool in the body: /mock/{platform}")
+    return await _answer(codec, tool, body, request, background, dispatcher, settings, pool)

--- a/runner/src/coval_bench/config.py
+++ b/runner/src/coval_bench/config.py
@@ -162,7 +162,7 @@ class Settings(BaseSettings):
     mock_tools_secret: SecretStr | None = None
     # The fixed latency every mock tool answer is held to, so tool time is a
     # constant across variants instead of a property of the seed that answered.
-    mock_tools_latency_ms: float = Field(default=50.0, ge=0)
+    mock_tools_latency_ms: float = Field(default=0.0, ge=0, le=10_000)
     mock_tools_suite: str = "dental"
     # Where the deployed service reads the seeded world, since the image is
     # built from a git checkout and `_private/` is never in one. Empty means

--- a/runner/src/coval_bench/mocktools/__init__.py
+++ b/runner/src/coval_bench/mocktools/__init__.py
@@ -18,6 +18,11 @@ The pieces:
 ``dispatch``
     Handlers built *from* ``tool-definitions.json``, so adding a tool to the
     contract adds a route, and no tool gets a hand-written one.
+``codecs``
+    Per-platform wire translation: each platform's request envelope in, its
+    reply shape out. The mirror of ``variants.platforms.FETCHERS`` — that is
+    how we talk to a platform, this is how a platform talks to us. Nothing past
+    a codec knows a vendor's name.
 ``keyterms``
     Domain vocabulary read back out of the fixtures for STT keyterm prompting.
 

--- a/runner/src/coval_bench/mocktools/codecs.py
+++ b/runner/src/coval_bench/mocktools/codecs.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import json
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from typing import Any
@@ -102,6 +103,15 @@ TELNYX = Codec(
 )
 
 
+def _vapi_arguments(raw: object) -> dict[str, Any]:
+    if isinstance(raw, str):
+        try:
+            raw = json.loads(raw or "{}")
+        except json.JSONDecodeError:
+            return {}
+    return _as_args(raw)
+
+
 def _vapi_decode(body: Body, _headers: Mapping[str, str], _tool: str | None) -> list[ToolCall]:
     message = body.get("message") if body else None
     raw_calls = message.get("toolCallList") if isinstance(message, dict) else None
@@ -111,11 +121,14 @@ def _vapi_decode(body: Body, _headers: Mapping[str, str], _tool: str | None) -> 
     for entry in raw_calls[:MAX_TOOL_CALLS]:
         if not isinstance(entry, dict):
             continue
-        raw = entry.get("arguments", entry.get("parameters"))
+        function = entry.get("function")
+        if not isinstance(function, dict):
+            function = {}
+        raw = entry.get("arguments", entry.get("parameters", function.get("arguments")))
         calls.append(
             ToolCall(
-                tool=str(entry.get("name") or ""),
-                args=_as_args(raw),
+                tool=str(entry.get("name") or function.get("name") or ""),
+                args=_vapi_arguments(raw),
                 call_id=str(entry["id"]) if entry.get("id") else None,
             )
         )
@@ -140,7 +153,11 @@ def _vapi_correlate(body: Body, headers: Mapping[str, str]) -> Correlation:
 def _vapi_encode(calls: list[ToolCall], outcomes: list[Outcome]) -> tuple[Any, int]:
     return {
         "results": [
-            {"toolCallId": call.call_id, "result": outcome.response}
+            {
+                "name": call.tool,
+                "toolCallId": call.call_id,
+                "result": json.dumps(outcome.response, separators=(",", ":")),
+            }
             for call, outcome in zip(calls, outcomes, strict=True)
         ]
     }, 200

--- a/runner/src/coval_bench/mocktools/codecs.py
+++ b/runner/src/coval_bench/mocktools/codecs.py
@@ -1,0 +1,170 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from typing import Any
+
+import structlog
+
+from coval_bench.mocktools.dispatch import Outcome
+
+logger = structlog.get_logger("coval_bench.mocktools")
+
+__all__ = [
+    "CODECS",
+    "MAX_TOOL_CALLS",
+    "Codec",
+    "Correlation",
+    "ToolCall",
+    "codec_for",
+]
+
+SIMULATION_HEADER = "x-coval-simulation-id"
+CALLER_HEADER = "x-coval-caller-number"
+TELNYX_CALL_HEADER = "x-telnyx-call-control-id"
+MAX_TOOL_CALLS = 32
+
+Body = dict[str, Any] | None
+
+
+@dataclass(frozen=True)
+class ToolCall:
+    tool: str
+    args: dict[str, Any]
+    call_id: str | None = None
+
+
+@dataclass(frozen=True)
+class Correlation:
+    simulation_id: str | None = None
+    caller_number: str | None = None
+    source: str = "none"
+
+
+@dataclass(frozen=True)
+class Codec:
+    name: str
+    tool_in_path: bool
+    decode: Callable[[Body, Mapping[str, str], str | None], list[ToolCall]]
+    correlate: Callable[[Body, Mapping[str, str]], Correlation]
+    encode: Callable[[list[ToolCall], list[Outcome]], tuple[Any, int]]
+
+
+def _coval_headers(headers: Mapping[str, str]) -> Correlation:
+    simulation_id = headers.get(SIMULATION_HEADER)
+    caller_number = headers.get(CALLER_HEADER)
+    if simulation_id:
+        return Correlation(simulation_id, caller_number, source="simulation_header")
+    if caller_number:
+        return Correlation(None, caller_number, source="caller_header")
+    return Correlation()
+
+
+def _as_args(body: object) -> dict[str, Any]:
+    return body if isinstance(body, dict) else {}
+
+
+def _generic_decode(body: Body, _headers: Mapping[str, str], tool: str | None) -> list[ToolCall]:
+    return [ToolCall(tool=tool or "", args=_as_args(body))]
+
+
+def _generic_encode(_calls: list[ToolCall], outcomes: list[Outcome]) -> tuple[Any, int]:
+    return outcomes[0].response, 200
+
+
+GENERIC = Codec(
+    name="generic",
+    tool_in_path=True,
+    decode=_generic_decode,
+    correlate=lambda _body, headers: _coval_headers(headers),
+    encode=_generic_encode,
+)
+
+
+def _telnyx_correlate(_body: Body, headers: Mapping[str, str]) -> Correlation:
+    found = _coval_headers(headers)
+    if found.source != "none":
+        return found
+    if headers.get(TELNYX_CALL_HEADER):
+        return Correlation(source="telnyx_call_control_id")
+    return Correlation()
+
+
+TELNYX = Codec(
+    name="telnyx",
+    tool_in_path=True,
+    decode=_generic_decode,
+    correlate=_telnyx_correlate,
+    encode=_generic_encode,
+)
+
+
+def _vapi_decode(body: Body, _headers: Mapping[str, str], _tool: str | None) -> list[ToolCall]:
+    message = body.get("message") if body else None
+    raw_calls = message.get("toolCallList") if isinstance(message, dict) else None
+    if not isinstance(raw_calls, list):
+        return []
+    calls: list[ToolCall] = []
+    for entry in raw_calls[:MAX_TOOL_CALLS]:
+        if not isinstance(entry, dict):
+            continue
+        raw = entry.get("arguments", entry.get("parameters"))
+        calls.append(
+            ToolCall(
+                tool=str(entry.get("name") or ""),
+                args=_as_args(raw),
+                call_id=str(entry["id"]) if entry.get("id") else None,
+            )
+        )
+    return calls
+
+
+def _vapi_correlate(body: Body, headers: Mapping[str, str]) -> Correlation:
+    found = _coval_headers(headers)
+    if found.source != "none":
+        return found
+    message = body.get("message") if body else None
+    call = message.get("call") if isinstance(message, dict) else None
+    logger.warning(
+        "mock_tool_call_uncorrelated",
+        codec="vapi",
+        message_keys=sorted(message) if isinstance(message, dict) else None,
+        call_keys=sorted(call) if isinstance(call, dict) else None,
+    )
+    return Correlation()
+
+
+def _vapi_encode(calls: list[ToolCall], outcomes: list[Outcome]) -> tuple[Any, int]:
+    return {
+        "results": [
+            {"toolCallId": call.call_id, "result": outcome.response}
+            for call, outcome in zip(calls, outcomes, strict=True)
+        ]
+    }, 200
+
+
+VAPI = Codec(
+    name="vapi",
+    tool_in_path=False,
+    decode=_vapi_decode,
+    correlate=_vapi_correlate,
+    encode=_vapi_encode,
+)
+
+
+CODECS: dict[str, Codec] = {
+    GENERIC.name: GENERIC,
+    TELNYX.name: TELNYX,
+    VAPI.name: VAPI,
+}
+
+
+def codec_for(platform: str) -> Codec:
+    codec = CODECS.get(platform)
+    if codec is None:
+        known = ", ".join(sorted(CODECS))
+        raise KeyError(f"unknown platform {platform!r}; known: {known}")
+    return codec

--- a/runner/tests/api/test_mocktools.py
+++ b/runner/tests/api/test_mocktools.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import time
 from typing import Any
 
@@ -333,9 +334,9 @@ async def test_vapi_gets_the_same_seed_wrapped_by_call_id(
     body = _vapi({"id": "tc_1", "name": "lookup_patient", "arguments": {"phone": PHONE}})
     response = await client.post("/mock/vapi", json=body, headers=AUTH)
     assert response.status_code == 200
-    assert response.json() == {
-        "results": [{"toolCallId": "tc_1", "result": BULKY}],
-    }
+    (result,) = response.json()["results"]
+    assert (result["name"], result["toolCallId"]) == ("lookup_patient", "tc_1")
+    assert json.loads(result["result"]) == BULKY
 
 
 async def test_vapi_batch_writes_one_row_per_call_in_order(
@@ -348,8 +349,8 @@ async def test_vapi_batch_writes_one_row_per_call_in_order(
     response = await client.post("/mock/vapi", json=body, headers=AUTH)
     results = response.json()["results"]
     assert [r["toolCallId"] for r in results] == ["tc_1", "tc_2"]
-    assert results[0]["result"] == BULKY
-    assert results[1]["result"] == {"found": False}
+    assert json.loads(results[0]["result"]) == BULKY
+    assert json.loads(results[1]["result"]) == {"found": False}
     rows = await _rows(postgresql)
     assert [row["args"]["phone"] for row in rows] == [PHONE, "5105550141"]
     assert [row["matched_seed"] for row in rows] == ["marcus_lee", None]
@@ -386,7 +387,7 @@ async def test_vapi_error_rides_inside_the_result(client: AsyncClient, mock_app:
     body = _vapi({"id": "tc_1", "name": "read_chart", "arguments": {}})
     response = await client.post("/mock/vapi", json=body, headers=AUTH)
     assert response.status_code == 200
-    assert response.json()["results"][0]["result"]["error"] == "unknown_tool"
+    assert json.loads(response.json()["results"][0]["result"])["error"] == "unknown_tool"
 
 
 # --- transport edge cases --------------------------------------------------
@@ -428,3 +429,17 @@ async def test_telnyx_control_id_never_lands_in_caller_number(
     assert len(rows) == 1
     assert rows[0]["caller_number"] is None
     assert rows[0]["simulation_id"] is None
+
+
+async def test_vapi_nested_function_shape_reaches_the_seed(
+    client: AsyncClient, mock_app: FastAPI
+) -> None:
+    body = _vapi(
+        {
+            "id": "tc_1",
+            "type": "function",
+            "function": {"name": "lookup_patient", "arguments": json.dumps({"phone": PHONE})},
+        }
+    )
+    response = await client.post("/mock/vapi", json=body, headers=AUTH)
+    assert json.loads(response.json()["results"][0]["result"]) == BULKY

--- a/runner/tests/api/test_mocktools.py
+++ b/runner/tests/api/test_mocktools.py
@@ -88,7 +88,7 @@ async def _rows(postgresql: Any) -> list[dict[str, Any]]:
 async def test_a_call_without_the_secret_is_rejected(
     client: AsyncClient, mock_app: FastAPI
 ) -> None:
-    response = await client.post("/mock/lookup_patient", json={"phone": PHONE})
+    response = await client.post("/mock/generic/lookup_patient", json={"phone": PHONE})
     assert response.status_code == 401
 
 
@@ -96,7 +96,7 @@ async def test_a_call_with_the_wrong_secret_is_rejected(
     client: AsyncClient, mock_app: FastAPI
 ) -> None:
     response = await client.post(
-        "/mock/lookup_patient", json={"phone": PHONE}, headers={"X-Mock-Tools-Key": "nope"}
+        "/mock/generic/lookup_patient", json={"phone": PHONE}, headers={"X-Mock-Tools-Key": "nope"}
     )
     assert response.status_code == 401
 
@@ -106,7 +106,9 @@ async def test_an_unconfigured_secret_closes_the_appliance(
 ) -> None:
     """Fails closed: an open mock would let anyone write into the tool-call log."""
     mock_app.state.settings = mock_app.state.settings.model_copy(update={"mock_tools_secret": None})
-    response = await client.post("/mock/lookup_patient", json={"phone": PHONE}, headers=AUTH)
+    response = await client.post(
+        "/mock/generic/lookup_patient", json={"phone": PHONE}, headers=AUTH
+    )
     assert response.status_code == 503
 
 
@@ -129,7 +131,9 @@ async def test_unloaded_fixtures_answer_503_without_reaching_storage(
 
     contracts_module._FIXTURE_PROVIDERS.append(never)
     try:
-        response = await client.post("/mock/lookup_patient", json={"phone": PHONE}, headers=AUTH)
+        response = await client.post(
+            "/mock/generic/lookup_patient", json={"phone": PHONE}, headers=AUTH
+        )
     finally:
         contracts_module._FIXTURE_PROVIDERS.remove(never)
     assert response.status_code == 503
@@ -140,7 +144,9 @@ async def test_unloaded_fixtures_answer_503_without_reaching_storage(
 
 
 async def test_a_seeded_call_returns_its_seed(client: AsyncClient, mock_app: FastAPI) -> None:
-    response = await client.post("/mock/lookup_patient", json={"phone": PHONE}, headers=AUTH)
+    response = await client.post(
+        "/mock/generic/lookup_patient", json={"phone": PHONE}, headers=AUTH
+    )
     assert response.status_code == 200
     assert response.json()["patient_name"] == "Marcus Lee"
 
@@ -148,28 +154,34 @@ async def test_a_seeded_call_returns_its_seed(client: AsyncClient, mock_app: Fas
 async def test_an_unseeded_call_returns_the_fallback(
     client: AsyncClient, mock_app: FastAPI
 ) -> None:
-    response = await client.post("/mock/lookup_patient", json={"phone": "5105550141"}, headers=AUTH)
+    response = await client.post(
+        "/mock/generic/lookup_patient", json={"phone": "5105550141"}, headers=AUTH
+    )
     assert response.status_code == 200
     assert response.json() == {"found": False}
 
 
 async def test_a_seeded_failure_reaches_the_caller(client: AsyncClient, mock_app: FastAPI) -> None:
-    response = await client.post("/mock/lookup_patient", json={"phone": "0000000000"}, headers=AUTH)
-    assert response.status_code == 500
+    response = await client.post(
+        "/mock/generic/lookup_patient", json={"phone": "0000000000"}, headers=AUTH
+    )
+    assert response.status_code == 200
     assert response.json()["error"] == "upstream_unavailable"
 
 
-async def test_an_unknown_tool_answers_404(client: AsyncClient, mock_app: FastAPI) -> None:
-    response = await client.post("/mock/read_chart", json={"phone": PHONE}, headers=AUTH)
-    assert response.status_code == 404
+async def test_an_unknown_tool_is_answered_not_refused(
+    client: AsyncClient, mock_app: FastAPI
+) -> None:
+    response = await client.post("/mock/generic/read_chart", json={"phone": PHONE}, headers=AUTH)
+    assert response.status_code == 200
     assert response.json()["error"] == "unknown_tool"
 
 
-async def test_a_missing_required_argument_answers_422(
+async def test_a_missing_required_argument_is_named_in_the_answer(
     client: AsyncClient, mock_app: FastAPI
 ) -> None:
-    response = await client.post("/mock/lookup_patient", json={}, headers=AUTH)
-    assert response.status_code == 422
+    response = await client.post("/mock/generic/lookup_patient", json={}, headers=AUTH)
+    assert response.status_code == 200
     assert response.json()["missing"] == ["phone"]
 
 
@@ -180,7 +192,7 @@ async def test_a_call_lands_a_row_carrying_the_simulation_id(
     client: AsyncClient, mock_app: FastAPI, postgresql: Any
 ) -> None:
     await client.post(
-        "/mock/lookup_patient",
+        "/mock/generic/lookup_patient",
         json={"phone": PHONE},
         headers={**AUTH, "X-Coval-Simulation-Id": SIMULATION_ID, "X-Coval-Caller-Number": PHONE},
     )
@@ -197,7 +209,7 @@ async def test_a_call_lands_a_row_carrying_the_simulation_id(
 async def test_a_fallback_row_names_no_seed(
     client: AsyncClient, mock_app: FastAPI, postgresql: Any
 ) -> None:
-    await client.post("/mock/lookup_patient", json={"phone": "5105550141"}, headers=AUTH)
+    await client.post("/mock/generic/lookup_patient", json={"phone": "5105550141"}, headers=AUTH)
     rows = await _rows(postgresql)
     assert rows[0]["matched_seed"] is None
 
@@ -206,7 +218,7 @@ async def test_a_rejected_call_is_still_recorded(
     client: AsyncClient, mock_app: FastAPI, postgresql: Any
 ) -> None:
     """An agent inventing a tool is evidence, not a reason to lose the row."""
-    await client.post("/mock/read_chart", json={"phone": PHONE}, headers=AUTH)
+    await client.post("/mock/generic/read_chart", json={"phone": PHONE}, headers=AUTH)
     rows = await _rows(postgresql)
     assert len(rows) == 1
     assert rows[0]["tool"] == "read_chart"
@@ -218,7 +230,9 @@ async def test_calls_are_recoverable_in_the_order_they_fired(
 ) -> None:
     """`now()` is constant within a transaction, so `id` is what orders a burst."""
     for _ in range(5):
-        await client.post("/mock/check_availability", json={"date": "2030-11-12"}, headers=AUTH)
+        await client.post(
+            "/mock/generic/check_availability", json={"date": "2030-11-12"}, headers=AUTH
+        )
     rows = await _rows(postgresql)
     assert [row["id"] for row in rows] == sorted(row["id"] for row in rows)
     assert len(rows) == 5
@@ -233,7 +247,9 @@ async def test_every_answer_is_held_to_the_latency_budget(
     app.state.mock_dispatcher = Dispatcher(load_tool_specs("dental"), _test_fixtures())
     app.state.settings = app.state.settings.model_copy(update={"mock_tools_latency_ms": 120.0})
     started = time.perf_counter()
-    response = await client.post("/mock/lookup_patient", json={"phone": PHONE}, headers=AUTH)
+    response = await client.post(
+        "/mock/generic/lookup_patient", json={"phone": PHONE}, headers=AUTH
+    )
     elapsed_ms = (time.perf_counter() - started) * 1000
     assert response.status_code == 200
     assert elapsed_ms >= 120.0
@@ -242,7 +258,7 @@ async def test_every_answer_is_held_to_the_latency_budget(
 async def test_the_budget_is_configurable(client: AsyncClient, mock_app: FastAPI) -> None:
     """Zeroed by the fixture: the budget is a setting, not a constant in the route."""
     started = time.perf_counter()
-    await client.post("/mock/lookup_patient", json={"phone": PHONE}, headers=AUTH)
+    await client.post("/mock/generic/lookup_patient", json={"phone": PHONE}, headers=AUTH)
     assert (time.perf_counter() - started) * 1000 < 120.0
 
 
@@ -250,7 +266,7 @@ async def test_the_appliance_is_never_rate_limited(client: AsyncClient, mock_app
     """A burst of tool calls is a scenario working; a 429 would be graded as the agent failing."""
     responses = await asyncio.gather(
         *(
-            client.post("/mock/lookup_patient", json={"phone": PHONE}, headers=AUTH)
+            client.post("/mock/generic/lookup_patient", json={"phone": PHONE}, headers=AUTH)
             for _ in range(80)
         )
     )
@@ -260,7 +276,7 @@ async def test_the_appliance_is_never_rate_limited(client: AsyncClient, mock_app
 async def test_answers_are_not_compressed(client: AsyncClient, mock_app: FastAPI) -> None:
     """Compression would add a variable cost to a deliberately fixed-latency response."""
     response = await client.post(
-        "/mock/lookup_patient",
+        "/mock/generic/lookup_patient",
         json={"phone": PHONE},
         headers={**AUTH, "Accept-Encoding": "gzip"},
     )
@@ -273,5 +289,142 @@ async def test_every_contract_tool_is_answerable(
     client: AsyncClient, mock_app: FastAPI, tool: str
 ) -> None:
     """Routes come from the contract, so no tool needs a hand-written one."""
-    response = await client.post(f"/mock/{tool}", json={}, headers=AUTH)
-    assert response.status_code in (200, 422)
+    response = await client.post(f"/mock/generic/{tool}", json={}, headers=AUTH)
+    assert response.status_code == 200
+
+
+# --- routing ---------------------------------------------------------------
+
+
+async def test_an_unknown_platform_names_the_known_set(
+    client: AsyncClient, mock_app: FastAPI
+) -> None:
+    response = await client.post("/mock/retell/lookup_patient", json={"phone": PHONE}, headers=AUTH)
+    assert response.status_code == 404
+    assert "known: generic, telnyx, vapi" in response.json()["detail"]
+
+
+async def test_a_body_platform_rejects_the_path_shape_with_a_hint(
+    client: AsyncClient, mock_app: FastAPI
+) -> None:
+    response = await client.post("/mock/vapi/lookup_patient", json={}, headers=AUTH)
+    assert response.status_code == 404
+    assert response.json()["detail"].endswith("/mock/vapi")
+
+
+async def test_a_path_platform_rejects_the_body_shape_with_a_hint(
+    client: AsyncClient, mock_app: FastAPI
+) -> None:
+    response = await client.post("/mock/generic", json={"phone": PHONE}, headers=AUTH)
+    assert response.status_code == 404
+    assert response.json()["detail"].endswith("/mock/generic/{tool}")
+
+
+# --- vapi ------------------------------------------------------------------
+
+
+def _vapi(*entries: dict[str, Any]) -> dict[str, Any]:
+    return {"message": {"type": "tool-calls", "toolCallList": list(entries)}}
+
+
+async def test_vapi_gets_the_same_seed_wrapped_by_call_id(
+    client: AsyncClient, mock_app: FastAPI
+) -> None:
+    body = _vapi({"id": "tc_1", "name": "lookup_patient", "arguments": {"phone": PHONE}})
+    response = await client.post("/mock/vapi", json=body, headers=AUTH)
+    assert response.status_code == 200
+    assert response.json() == {
+        "results": [{"toolCallId": "tc_1", "result": BULKY}],
+    }
+
+
+async def test_vapi_batch_writes_one_row_per_call_in_order(
+    client: AsyncClient, mock_app: FastAPI, postgresql: Any
+) -> None:
+    body = _vapi(
+        {"id": "tc_1", "name": "lookup_patient", "arguments": {"phone": PHONE}},
+        {"id": "tc_2", "name": "lookup_patient", "arguments": {"phone": "5105550141"}},
+    )
+    response = await client.post("/mock/vapi", json=body, headers=AUTH)
+    results = response.json()["results"]
+    assert [r["toolCallId"] for r in results] == ["tc_1", "tc_2"]
+    assert results[0]["result"] == BULKY
+    assert results[1]["result"] == {"found": False}
+    rows = await _rows(postgresql)
+    assert [row["args"]["phone"] for row in rows] == [PHONE, "5105550141"]
+    assert [row["matched_seed"] for row in rows] == ["marcus_lee", None]
+
+
+async def test_vapi_batch_is_held_to_the_budget_per_call(client: AsyncClient, app: FastAPI) -> None:
+    app.state.mock_dispatcher = Dispatcher(load_tool_specs("dental"), _test_fixtures())
+    app.state.settings = app.state.settings.model_copy(update={"mock_tools_latency_ms": 60.0})
+    body = _vapi(
+        {"id": "tc_1", "name": "lookup_patient", "arguments": {"phone": PHONE}},
+        {"id": "tc_2", "name": "lookup_patient", "arguments": {"phone": PHONE}},
+    )
+    started = time.perf_counter()
+    response = await client.post("/mock/vapi", json=body, headers=AUTH)
+    elapsed_ms = (time.perf_counter() - started) * 1000
+    assert response.status_code == 200
+    assert elapsed_ms >= 120.0
+
+
+async def test_vapi_with_no_calls_answers_empty_and_writes_nothing(
+    client: AsyncClient, app: FastAPI, postgresql: Any
+) -> None:
+    app.state.mock_dispatcher = Dispatcher(load_tool_specs("dental"), _test_fixtures())
+    app.state.settings = app.state.settings.model_copy(update={"mock_tools_latency_ms": 200.0})
+    started = time.perf_counter()
+    response = await client.post("/mock/vapi", json=_vapi(), headers=AUTH)
+    elapsed_ms = (time.perf_counter() - started) * 1000
+    assert response.json() == {"results": []}
+    assert elapsed_ms < 200.0
+    assert await _rows(postgresql) == []
+
+
+async def test_vapi_error_rides_inside_the_result(client: AsyncClient, mock_app: FastAPI) -> None:
+    body = _vapi({"id": "tc_1", "name": "read_chart", "arguments": {}})
+    response = await client.post("/mock/vapi", json=body, headers=AUTH)
+    assert response.status_code == 200
+    assert response.json()["results"][0]["result"]["error"] == "unknown_tool"
+
+
+# --- transport edge cases --------------------------------------------------
+
+
+async def test_an_empty_body_is_a_call_with_no_arguments(
+    client: AsyncClient, mock_app: FastAPI
+) -> None:
+    response = await client.post("/mock/generic/lookup_patient", headers=AUTH)
+    assert response.status_code == 200
+    assert response.json()["missing"] == ["phone"]
+
+
+async def test_invalid_json_is_refused_at_the_door(client: AsyncClient, mock_app: FastAPI) -> None:
+    response = await client.post(
+        "/mock/generic/lookup_patient",
+        content=b"{not json",
+        headers={**AUTH, "Content-Type": "application/json"},
+    )
+    assert response.status_code == 422
+
+
+async def test_a_non_object_body_is_refused_at_the_door(
+    client: AsyncClient, mock_app: FastAPI
+) -> None:
+    response = await client.post("/mock/generic/lookup_patient", json=[PHONE], headers=AUTH)
+    assert response.status_code == 422
+
+
+async def test_telnyx_control_id_never_lands_in_caller_number(
+    client: AsyncClient, mock_app: FastAPI, postgresql: Any
+) -> None:
+    await client.post(
+        "/mock/telnyx/lookup_patient",
+        json={"phone": PHONE},
+        headers={**AUTH, "x-telnyx-call-control-id": "v3:abc123"},
+    )
+    rows = await _rows(postgresql)
+    assert len(rows) == 1
+    assert rows[0]["caller_number"] is None
+    assert rows[0]["simulation_id"] is None

--- a/runner/tests/unit/test_codecs.py
+++ b/runner/tests/unit/test_codecs.py
@@ -3,11 +3,13 @@
 
 from __future__ import annotations
 
+import json
 from typing import Any
+from unittest.mock import MagicMock
 
 import pytest
-import structlog.testing
 
+import coval_bench.mocktools.codecs as codecs
 from coval_bench.mocktools.codecs import (
     CODECS,
     GENERIC,
@@ -132,7 +134,25 @@ def test_vapi_keeps_a_call_with_no_id() -> None:
     assert VAPI.decode(body, NO_HEADERS, None)[0].call_id is None
 
 
-def test_vapi_treats_non_object_arguments_as_none() -> None:
+def test_vapi_decodes_the_nested_function_shape_with_string_arguments() -> None:
+    body = _vapi_body(
+        {
+            "id": "tc_1",
+            "type": "function",
+            "function": {"name": "lookup_patient", "arguments": json.dumps({"phone": PHONE})},
+        }
+    )
+    assert VAPI.decode(body, NO_HEADERS, None) == [
+        ToolCall(tool="lookup_patient", args={"phone": PHONE}, call_id="tc_1")
+    ]
+
+
+def test_vapi_parses_string_arguments_on_the_flat_shape_too() -> None:
+    body = _vapi_body({"id": "tc_1", "name": "lookup_patient", "arguments": '{"phone": "1"}'})
+    assert VAPI.decode(body, NO_HEADERS, None)[0].args == {"phone": "1"}
+
+
+def test_vapi_treats_unparseable_arguments_as_none() -> None:
     body = _vapi_body({"id": "tc_1", "name": "lookup_patient", "arguments": "not json"})
     assert VAPI.decode(body, NO_HEADERS, None)[0].args == {}
 
@@ -167,12 +187,21 @@ def test_vapi_encodes_each_result_under_its_call_id_in_order() -> None:
     calls = [ToolCall("a", {}, "tc_1"), ToolCall("b", {}, "tc_2")]
     payload, status = VAPI.encode(calls, [FOUND, UNKNOWN])
     assert status == 200
-    assert payload == {
-        "results": [
-            {"toolCallId": "tc_1", "result": FOUND.response},
-            {"toolCallId": "tc_2", "result": UNKNOWN.response},
-        ]
-    }
+    assert [r["toolCallId"] for r in payload["results"]] == ["tc_1", "tc_2"]
+    assert [r["name"] for r in payload["results"]] == ["a", "b"]
+
+
+def test_vapi_encodes_the_result_as_a_json_string() -> None:
+    payload, _ = VAPI.encode([ToolCall("a", {}, "tc_1")], [FOUND])
+    result = payload["results"][0]["result"]
+    assert isinstance(result, str)
+    assert json.loads(result) == FOUND.response
+
+
+def test_vapi_encodes_an_error_inside_the_result_string() -> None:
+    payload, _ = VAPI.encode([ToolCall("read_chart", {}, "tc_1")], [UNKNOWN])
+    assert json.loads(payload["results"][0]["result"])["error"] == "unknown_tool"
+    assert "error" not in payload["results"][0]
 
 
 def test_vapi_encodes_a_missing_id_as_null() -> None:
@@ -197,20 +226,24 @@ def test_vapi_correlates_from_the_coval_header_when_present() -> None:
     assert (found.simulation_id, found.source) == (SIM, "simulation_header")
 
 
-def test_vapi_without_a_header_logs_the_envelope_shape_and_not_its_values() -> None:
+def test_vapi_without_a_header_logs_the_envelope_shape_and_not_its_values(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake = MagicMock()
+    monkeypatch.setattr(codecs, "logger", fake)
     body = _vapi_body(
         {"id": "tc_1", "name": "lookup_patient", "arguments": {"phone": PHONE}},
         call={"id": "call_9", "customer": {"number": PHONE}},
     )
-    with structlog.testing.capture_logs() as captured:
-        found = VAPI.correlate(body, NO_HEADERS)
+    found = VAPI.correlate(body, NO_HEADERS)
     assert found.source == "none"
-    events = [e for e in captured if e["event"] == "mock_tool_call_uncorrelated"]
-    assert len(events) == 1
-    assert events[0]["message_keys"] == ["call", "toolCallList", "type"]
-    assert events[0]["call_keys"] == ["customer", "id"]
-    assert PHONE not in repr(events[0])
-    assert "call_9" not in repr(events[0])
+    fake.warning.assert_called_once()
+    assert fake.warning.call_args.args == ("mock_tool_call_uncorrelated",)
+    kwargs = fake.warning.call_args.kwargs
+    assert kwargs["message_keys"] == ["call", "toolCallList", "type"]
+    assert kwargs["call_keys"] == ["customer", "id"]
+    assert PHONE not in repr(kwargs)
+    assert "call_9" not in repr(kwargs)
 
 
 # --- registry --------------------------------------------------------------

--- a/runner/tests/unit/test_codecs.py
+++ b/runner/tests/unit/test_codecs.py
@@ -1,0 +1,230 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+import structlog.testing
+
+from coval_bench.mocktools.codecs import (
+    CODECS,
+    GENERIC,
+    MAX_TOOL_CALLS,
+    TELNYX,
+    VAPI,
+    ToolCall,
+    codec_for,
+)
+from coval_bench.mocktools.dispatch import Outcome
+
+PHONE = "6025550182"
+SIM = "sim_abc123"
+NO_HEADERS: dict[str, str] = {}
+
+FOUND = Outcome(response={"found": True, "patient_id": "P-1041"}, http_status=200)
+UNKNOWN = Outcome(response={"error": "unknown_tool", "tool": "read_chart"}, http_status=404)
+
+
+def _vapi_body(*entries: dict[str, Any], call: dict[str, Any] | None = None) -> dict[str, Any]:
+    message: dict[str, Any] = {"type": "tool-calls", "toolCallList": list(entries)}
+    if call is not None:
+        message["call"] = call
+    return {"message": message}
+
+
+# --- generic ---------------------------------------------------------------
+
+
+def test_generic_decodes_bare_args_with_the_path_tool() -> None:
+    calls = GENERIC.decode({"phone": PHONE}, NO_HEADERS, "lookup_patient")
+    assert calls == [ToolCall(tool="lookup_patient", args={"phone": PHONE})]
+
+
+def test_generic_decodes_an_empty_body_as_no_args() -> None:
+    assert GENERIC.decode(None, NO_HEADERS, "lookup_patient")[0].args == {}
+
+
+def test_generic_encodes_the_bare_response_at_200() -> None:
+    payload, status = GENERIC.encode([ToolCall("lookup_patient", {})], [FOUND])
+    assert (payload, status) == (FOUND.response, 200)
+
+
+def test_generic_encodes_a_rejected_call_at_200_too() -> None:
+    payload, status = GENERIC.encode([ToolCall("read_chart", {})], [UNKNOWN])
+    assert status == 200
+    assert payload["error"] == "unknown_tool"
+
+
+def test_generic_correlates_from_the_coval_headers() -> None:
+    found = GENERIC.correlate({}, {"x-coval-simulation-id": SIM, "x-coval-caller-number": PHONE})
+    assert (found.simulation_id, found.caller_number, found.source) == (
+        SIM,
+        PHONE,
+        "simulation_header",
+    )
+
+
+def test_generic_correlates_from_the_caller_alone() -> None:
+    found = GENERIC.correlate({}, {"x-coval-caller-number": PHONE})
+    assert (found.simulation_id, found.caller_number, found.source) == (
+        None,
+        PHONE,
+        "caller_header",
+    )
+
+
+def test_generic_without_headers_is_uncorrelated() -> None:
+    assert GENERIC.correlate({}, NO_HEADERS).source == "none"
+
+
+# --- telnyx ----------------------------------------------------------------
+
+
+def test_telnyx_shares_the_generic_wire_shape() -> None:
+    assert TELNYX.decode is GENERIC.decode
+    assert TELNYX.encode is GENERIC.encode
+    assert TELNYX.tool_in_path
+
+
+def test_telnyx_prefers_the_coval_header() -> None:
+    found = TELNYX.correlate(
+        {}, {"x-coval-simulation-id": SIM, "x-telnyx-call-control-id": "v3:abc"}
+    )
+    assert (found.simulation_id, found.source) == (SIM, "simulation_header")
+
+
+def test_telnyx_control_id_is_noted_but_never_stored_as_a_number() -> None:
+    found = TELNYX.correlate({}, {"x-telnyx-call-control-id": "v3:abc"})
+    assert found.source == "telnyx_call_control_id"
+    assert found.caller_number is None
+    assert found.simulation_id is None
+
+
+# --- vapi decode -----------------------------------------------------------
+
+
+def test_vapi_decodes_one_call() -> None:
+    body = _vapi_body({"id": "tc_1", "name": "lookup_patient", "arguments": {"phone": PHONE}})
+    assert VAPI.decode(body, NO_HEADERS, None) == [
+        ToolCall(tool="lookup_patient", args={"phone": PHONE}, call_id="tc_1")
+    ]
+
+
+def test_vapi_accepts_parameters_as_the_arguments_key() -> None:
+    body = _vapi_body({"id": "tc_1", "name": "lookup_patient", "parameters": {"phone": PHONE}})
+    assert VAPI.decode(body, NO_HEADERS, None)[0].args == {"phone": PHONE}
+
+
+def test_vapi_decodes_a_batch_in_order() -> None:
+    body = _vapi_body(
+        {"id": "tc_1", "name": "check_availability", "arguments": {"date": "2030-04-04"}},
+        {"id": "tc_2", "name": "check_availability", "arguments": {"date": "2030-04-05"}},
+    )
+    calls = VAPI.decode(body, NO_HEADERS, None)
+    assert [c.call_id for c in calls] == ["tc_1", "tc_2"]
+    assert [c.args["date"] for c in calls] == ["2030-04-04", "2030-04-05"]
+
+
+def test_vapi_keeps_a_call_with_no_id() -> None:
+    body = _vapi_body({"name": "lookup_patient", "arguments": {"phone": PHONE}})
+    assert VAPI.decode(body, NO_HEADERS, None)[0].call_id is None
+
+
+def test_vapi_treats_non_object_arguments_as_none() -> None:
+    body = _vapi_body({"id": "tc_1", "name": "lookup_patient", "arguments": "not json"})
+    assert VAPI.decode(body, NO_HEADERS, None)[0].args == {}
+
+
+def test_vapi_skips_entries_that_are_not_objects() -> None:
+    body = _vapi_body({"id": "tc_1", "name": "lookup_patient", "arguments": {}})
+    body["message"]["toolCallList"].insert(0, "garbage")
+    calls = VAPI.decode(body, NO_HEADERS, None)
+    assert [c.call_id for c in calls] == ["tc_1"]
+
+
+@pytest.mark.parametrize(
+    "body",
+    [None, {}, {"message": {}}, {"message": {"toolCallList": "nope"}}, {"message": "x"}],
+)
+def test_vapi_decodes_a_missing_list_as_no_calls(body: dict[str, Any] | None) -> None:
+    assert VAPI.decode(body, NO_HEADERS, None) == []
+
+
+def test_vapi_caps_the_batch() -> None:
+    entries = [
+        {"id": f"tc_{i}", "name": "lookup_patient", "arguments": {}}
+        for i in range(MAX_TOOL_CALLS + 8)
+    ]
+    assert len(VAPI.decode(_vapi_body(*entries), NO_HEADERS, None)) == MAX_TOOL_CALLS
+
+
+# --- vapi encode -----------------------------------------------------------
+
+
+def test_vapi_encodes_each_result_under_its_call_id_in_order() -> None:
+    calls = [ToolCall("a", {}, "tc_1"), ToolCall("b", {}, "tc_2")]
+    payload, status = VAPI.encode(calls, [FOUND, UNKNOWN])
+    assert status == 200
+    assert payload == {
+        "results": [
+            {"toolCallId": "tc_1", "result": FOUND.response},
+            {"toolCallId": "tc_2", "result": UNKNOWN.response},
+        ]
+    }
+
+
+def test_vapi_encodes_a_missing_id_as_null() -> None:
+    payload, _ = VAPI.encode([ToolCall("a", {})], [FOUND])
+    assert payload["results"][0]["toolCallId"] is None
+
+
+def test_vapi_encodes_an_empty_batch() -> None:
+    assert VAPI.encode([], []) == ({"results": []}, 200)
+
+
+def test_vapi_encode_refuses_a_cardinality_mismatch() -> None:
+    with pytest.raises(ValueError):
+        VAPI.encode([ToolCall("a", {}, "tc_1")], [FOUND, UNKNOWN])
+
+
+# --- vapi correlate --------------------------------------------------------
+
+
+def test_vapi_correlates_from_the_coval_header_when_present() -> None:
+    found = VAPI.correlate(_vapi_body(), {"x-coval-simulation-id": SIM})
+    assert (found.simulation_id, found.source) == (SIM, "simulation_header")
+
+
+def test_vapi_without_a_header_logs_the_envelope_shape_and_not_its_values() -> None:
+    body = _vapi_body(
+        {"id": "tc_1", "name": "lookup_patient", "arguments": {"phone": PHONE}},
+        call={"id": "call_9", "customer": {"number": PHONE}},
+    )
+    with structlog.testing.capture_logs() as captured:
+        found = VAPI.correlate(body, NO_HEADERS)
+    assert found.source == "none"
+    events = [e for e in captured if e["event"] == "mock_tool_call_uncorrelated"]
+    assert len(events) == 1
+    assert events[0]["message_keys"] == ["call", "toolCallList", "type"]
+    assert events[0]["call_keys"] == ["customer", "id"]
+    assert PHONE not in repr(events[0])
+    assert "call_9" not in repr(events[0])
+
+
+# --- registry --------------------------------------------------------------
+
+
+def test_codec_for_names_the_known_set_on_a_miss() -> None:
+    with pytest.raises(KeyError, match="known: generic, telnyx, vapi"):
+        codec_for("retell")
+
+
+@pytest.mark.parametrize(
+    ("name", "tool_in_path"),
+    [("generic", True), ("telnyx", True), ("vapi", False)],
+)
+def test_each_codec_declares_where_the_tool_name_lives(name: str, tool_in_path: bool) -> None:
+    assert codec_for(name).tool_in_path is tool_in_path
+    assert CODECS[name].name == name


### PR DESCRIPTION
Vapi couldn't call the mock — it wraps tool calls in its own envelope and expects the answers wrapped back by id. This adds a translation layer so every platform reaches the same dispatcher.

- New `mocktools/codecs.py`: one codec per platform, registered by name. Same shape as `FETCHERS`.
- Only Vapi needs a real codec. Telnyx, Synthflow, Retell, LiveKit, Pipecat and Twilio CR all fit `generic`.
- Routes: `/mock/{platform}/{tool}` when the tool is in the URL, `/mock/{platform}` when it's in the body. Wrong shape or unknown platform → 404 with a hint.
- Always HTTP 200; the outcome is in the body. Batches force one status, and platforms treat non-2xx differently.
- Latency pad defaults to 0 and scales per call. Setting kept, capped at 10 s. Methodology doc's "fixed 50 ms" line needs updating.
- Telnyx's call control id is logged, not stored as a phone number.
- Vapi correlation reads HTTP headers only; on a miss it logs key names, never values. Whether Coval's SIP header reaches the tool webhook is what the first real call answers.
- Old `/mock/{tool}` route had no production callers, so nothing migrates.

Outside this PR: LiveKit and Pipecat need one shared HTTP client; the contract stays string-only while Synthflow is in the roster.
