### PR TITLE
Manage the Vapi assistant's tools from the repo

### DIFF
--- a/runner/src/coval_bench/__main__.py
+++ b/runner/src/coval_bench/__main__.py
@@ -23,6 +23,7 @@ from coval_bench.db.cli import db_check, db_migrate
 from coval_bench.migrations.backfill_normalized_storage import backfill_normalized_storage_cli
 from coval_bench.migrations.backfill_wer_breakdown import backfill_wer_breakdown_cli
 from coval_bench.migrations.import_legacy import import_legacy_cli
+from coval_bench.platform_assets import platform_assets
 from coval_bench.s2s.fetch_v2v import fetch_s2s
 from coval_bench.variants.pull import pull_contract
 
@@ -111,6 +112,7 @@ migrate.add_command(import_legacy_cli, name="import-legacy")
 # S2S is fetch-only, so a standalone command rather than a `run --kind` value.
 cli.add_command(fetch_s2s, name="fetch-s2s")
 cli.add_command(pull_contract, name="pull-contract")
+cli.add_command(platform_assets, name="platform-assets")
 
 
 @cli.command(name="tts-smoke")

--- a/runner/src/coval_bench/assets/__init__.py
+++ b/runner/src/coval_bench/assets/__init__.py
@@ -1,0 +1,19 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import os
+
+from pydantic import BaseModel
+
+
+class SecretRef(BaseModel, frozen=True, extra="forbid"):
+    name: str
+    purpose: str
+
+    def resolve(self) -> str:
+        value = os.environ.get(self.name)
+        if not value:
+            raise RuntimeError(f"{self.name} is unset. It holds {self.purpose}.")
+        return value

--- a/runner/src/coval_bench/platform_assets.py
+++ b/runner/src/coval_bench/platform_assets.py
@@ -1,0 +1,286 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import copy
+import json
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any, Protocol
+
+import click
+import httpx
+from pydantic import BaseModel, Field
+
+from coval_bench.assets import SecretRef
+from coval_bench.contracts import contract_sha256, read_contract_file
+from coval_bench.variants.platforms import redact
+
+TOOL_TIMEOUT_SECONDS = 20
+SIMULATION_HEADER_TEMPLATE = "{{coval-simulation-id}}"
+TOOLS_PATH = "model.tools"
+_TIMEOUT = httpx.Timeout(30.0, connect=10.0)
+
+
+class SyncError(RuntimeError):
+    pass
+
+
+class PlatformAgentSpec(BaseModel, frozen=True, extra="forbid"):
+    key: str = Field(min_length=1)
+    platform: str
+    suite: str
+    agent_id: SecretRef
+    api_key: SecretRef
+    mock_secret: SecretRef
+
+
+class AgentClient(Protocol):
+    def __enter__(self) -> AgentClient: ...
+    def __exit__(self, *exc: object) -> None: ...
+    def get_agent(self, agent_id: str) -> dict[str, Any]: ...
+    def update_agent(self, agent_id: str, body: dict[str, Any]) -> dict[str, Any]: ...
+
+
+Renderer = Callable[[PlatformAgentSpec, str, str], dict[str, Any]]
+ClientFactory = Callable[[str, str], AgentClient]
+
+
+@dataclass(frozen=True)
+class Platform:
+    name: str
+    api_base: str
+    render: Renderer
+    client: ClientFactory
+
+
+@dataclass
+class Plan:
+    update: dict[str, tuple[Any, Any]] = field(default_factory=dict)
+    unchanged: list[str] = field(default_factory=list)
+
+    def summary(self) -> str:
+        return f"update={sorted(self.update)} unchanged={sorted(self.unchanged)}"
+
+
+def render_vapi_tools(
+    definitions: list[dict[str, Any]], mock_base_url: str, secret: str
+) -> list[dict[str, Any]]:
+    server = {
+        "url": f"{mock_base_url.rstrip('/')}/mock/vapi",
+        "timeoutSeconds": TOOL_TIMEOUT_SECONDS,
+        "headers": {
+            "X-Mock-Tools-Key": secret,
+            "X-Coval-Simulation-Id": SIMULATION_HEADER_TEMPLATE,
+        },
+    }
+    return [
+        {
+            "type": "function",
+            "async": False,
+            "function": {
+                "name": definition["name"],
+                "description": definition["description"],
+                "parameters": definition["parameters"],
+            },
+            "server": server,
+        }
+        for definition in definitions
+    ]
+
+
+def render_vapi(spec: PlatformAgentSpec, mock_base_url: str, secret: str) -> dict[str, Any]:
+    definitions = json.loads(read_contract_file(spec.suite, "tool-definitions.json"))
+    return {TOOLS_PATH: render_vapi_tools(definitions, mock_base_url, secret)}
+
+
+class VapiClient:
+    def __init__(
+        self, api_key: str, base_url: str, transport: httpx.BaseTransport | None = None
+    ) -> None:
+        self._client = httpx.Client(
+            base_url=base_url,
+            headers={"Authorization": f"Bearer {api_key}"},
+            timeout=_TIMEOUT,
+            transport=transport,
+        )
+
+    def __enter__(self) -> VapiClient:
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self._client.close()
+
+    def _request(
+        self, method: str, path: str, payload: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
+        response = self._client.request(method, path, json=payload)
+        if response.status_code >= 400:
+            raise SyncError(f"{method} {path} -> {response.status_code}: {response.text[:400]}")
+        parsed: dict[str, Any] = response.json()
+        return parsed
+
+    def get_agent(self, agent_id: str) -> dict[str, Any]:
+        return self._request("GET", f"/assistant/{agent_id}")
+
+    def update_agent(self, agent_id: str, body: dict[str, Any]) -> dict[str, Any]:
+        return self._request("PATCH", f"/assistant/{agent_id}", body)
+
+
+PLATFORMS: dict[str, Platform] = {
+    "vapi": Platform(
+        name="vapi", api_base="https://api.vapi.ai", render=render_vapi, client=VapiClient
+    ),
+}
+
+AGENTS: tuple[PlatformAgentSpec, ...] = (
+    PlatformAgentSpec(
+        key="vapi-dental",
+        platform="vapi",
+        suite="dental",
+        agent_id=SecretRef(
+            name="VAPI_DENTAL_ASSISTANT_ID",
+            purpose="the Vapi assistant id for the dental suite",
+        ),
+        api_key=SecretRef(name="VAPI_API_KEY", purpose="the Vapi API key for the dental org"),
+        mock_secret=SecretRef(
+            name="MOCK_TOOLS_SECRET",
+            purpose="the shared secret the mock tool endpoint requires on X-Mock-Tools-Key",
+        ),
+    ),
+)
+
+
+def spec_for(key: str) -> PlatformAgentSpec:
+    for spec in AGENTS:
+        if spec.key == key:
+            return spec
+    known = ", ".join(sorted(s.key for s in AGENTS))
+    raise KeyError(f"unknown platform agent {key!r}; known: {known}")
+
+
+def platform_for(spec: PlatformAgentSpec) -> Platform:
+    platform = PLATFORMS.get(spec.platform)
+    if platform is None:
+        known = ", ".join(sorted(PLATFORMS))
+        raise SyncError(f"unknown platform {spec.platform!r}; known: {known}")
+    return platform
+
+
+def _get_path(body: dict[str, Any], path: str) -> Any:  # noqa: ANN401
+    node: Any = body
+    for part in path.split("."):
+        if not isinstance(node, dict):
+            return None
+        node = node.get(part)
+    return node
+
+
+def _set_path(body: dict[str, Any], path: str, value: Any) -> None:  # noqa: ANN401
+    parts = path.split(".")
+    node = body
+    for part in parts[:-1]:
+        child = node.get(part)
+        if not isinstance(child, dict):
+            child = {}
+            node[part] = child
+        node = child
+    node[parts[-1]] = value
+
+
+def desired(spec: PlatformAgentSpec, mock_base_url: str) -> dict[str, Any]:
+    return platform_for(spec).render(spec, mock_base_url, spec.mock_secret.resolve())
+
+
+def plan(live: dict[str, Any], wanted: dict[str, Any]) -> Plan:
+    result = Plan()
+    for path, value in wanted.items():
+        current = _get_path(live, path)
+        if current == value:
+            result.unchanged.append(path)
+        else:
+            result.update[path] = (current, value)
+    return result
+
+
+def patch_body(live: dict[str, Any], wanted: dict[str, Any]) -> dict[str, Any]:
+    body: dict[str, Any] = {}
+    for path, value in wanted.items():
+        top = path.split(".")[0]
+        if top not in body:
+            body[top] = copy.deepcopy(live.get(top)) if isinstance(live.get(top), dict) else {}
+        if "." in path:
+            _set_path(body, path, value)
+        else:
+            body[top] = value
+    return body
+
+
+def apply(client: AgentClient, spec: PlatformAgentSpec, wanted: dict[str, Any]) -> Plan:
+    agent_id = spec.agent_id.resolve()
+    live = client.get_agent(agent_id)
+    result = plan(live, wanted)
+    if result.update:
+        client.update_agent(agent_id, patch_body(live, wanted))
+    return result
+
+
+_agent_option = click.option(
+    "--agent", "agent_key", type=click.Choice(sorted(s.key for s in AGENTS)), required=True
+)
+_mock_base_url_option = click.option(
+    "--mock-base-url",
+    envvar="MOCK_TOOLS_BASE_URL",
+    required=True,
+    help="Where the mock tool service is reachable, e.g. https://api.example.com",
+)
+_api_base_option = click.option(
+    "--api-base", default=None, help="Override the platform's API base URL."
+)
+
+
+@click.group()
+def platform_assets() -> None:
+    """Platform agents managed as code."""
+
+
+@platform_assets.command(name="plan")
+@_agent_option
+@_mock_base_url_option
+@_api_base_option
+def assets_plan(agent_key: str, mock_base_url: str, api_base: str | None) -> None:
+    """Show what apply would change; writes nothing."""
+    spec = spec_for(agent_key)
+    platform = platform_for(spec)
+    wanted = desired(spec, mock_base_url)
+    with platform.client(spec.api_key.resolve(), api_base or platform.api_base) as client:
+        result = plan(client.get_agent(spec.agent_id.resolve()), wanted)
+    click.echo(result.summary())
+    for path, (current, value) in result.update.items():
+        found: list[str] = []
+        click.echo(f"\n{path}:")
+        click.echo(f"  live:    {json.dumps(redact(current, found), sort_keys=True)[:400]}")
+        click.echo(f"  desired: {json.dumps(redact(value, found), sort_keys=True)[:400]}")
+
+
+@platform_assets.command(name="apply")
+@_agent_option
+@_mock_base_url_option
+@_api_base_option
+@click.option("--yes", is_flag=True, default=False, help="Skip the confirmation prompt.")
+def assets_apply(agent_key: str, mock_base_url: str, api_base: str | None, yes: bool) -> None:
+    """Patch the managed fields on the live agent."""
+    spec = spec_for(agent_key)
+    platform = platform_for(spec)
+    wanted = desired(spec, mock_base_url)
+    with platform.client(spec.api_key.resolve(), api_base or platform.api_base) as client:
+        preview = plan(client.get_agent(spec.agent_id.resolve()), wanted)
+        click.echo(preview.summary())
+        if not preview.update:
+            return
+        if not yes and not click.confirm(f"Patch {sorted(preview.update)} on {agent_key}?"):
+            raise click.ClickException("aborted")
+        result = apply(client, spec, wanted)
+    click.echo(f"patched {sorted(result.update)}")
+    click.echo(f"contract sha256 ({spec.suite}): {contract_sha256(spec.suite)}")

--- a/runner/src/coval_bench/platform_assets.py
+++ b/runner/src/coval_bench/platform_assets.py
@@ -14,7 +14,7 @@ import httpx
 from pydantic import BaseModel, Field
 
 from coval_bench.assets import SecretRef
-from coval_bench.contracts import contract_sha256, read_contract_file
+from coval_bench.contracts import public_contract_sha256, read_contract_file
 from coval_bench.variants.platforms import redact
 
 TOOL_TIMEOUT_SECONDS = 20
@@ -283,4 +283,4 @@ def assets_apply(agent_key: str, mock_base_url: str, api_base: str | None, yes: 
             raise click.ClickException("aborted")
         result = apply(client, spec, wanted)
     click.echo(f"patched {sorted(result.update)}")
-    click.echo(f"contract sha256 ({spec.suite}): {contract_sha256(spec.suite)}")
+    click.echo(f"public contract sha256 ({spec.suite}): {public_contract_sha256(spec.suite)}")

--- a/runner/src/coval_bench/variants/platforms.py
+++ b/runner/src/coval_bench/variants/platforms.py
@@ -27,7 +27,7 @@ TIMEOUT_SECONDS = 30.0
 
 # Keys whose value is a live secret. `credentialIds` is deliberately absent: it
 # is an account-scoped reference that `apply` needs, and carries no key material.
-SECRET_KEY = re.compile(r"(api[_-]?key|secret|token|password|bearer|authorization)", re.I)
+SECRET_KEY = re.compile(r"(api[_-]?key|[_-]key$|secret|token|password|bearer|authorization)", re.I)
 
 
 # Keys whose value names a live object in someone's account. These are not

--- a/runner/tests/test_contracts.py
+++ b/runner/tests/test_contracts.py
@@ -213,3 +213,24 @@ def test_the_published_hash_is_the_same_whichever_source_supplied_the_bytes(
     register_fixture_provider(lambda suite: seeded)
     assert contract_sha256("dental") == from_disk
     assert contract_sha256("dental") != public_contract_sha256("dental")
+
+
+def test_redact_catches_the_mock_tools_header_but_not_the_correlation_one() -> None:
+    from coval_bench.variants.platforms import redact
+
+    found: list[str] = []
+    out = redact(
+        {
+            "server": {
+                "headers": {"X-Mock-Tools-Key": "s3cr3t", "X-Coval-Simulation-Id": "{{x}}"},
+            },
+            "credentialIds": ["cred_1"],
+        },
+        found,
+    )
+    assert out["server"]["headers"] == {
+        "X-Mock-Tools-Key": "[REDACTED]",
+        "X-Coval-Simulation-Id": "{{x}}",
+    }
+    assert out["credentialIds"] == ["cred_1"]
+    assert found == ["server.headers.X-Mock-Tools-Key"]

--- a/runner/tests/unit/test_platform_assets.py
+++ b/runner/tests/unit/test_platform_assets.py
@@ -1,0 +1,242 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import httpx
+import pytest
+
+from coval_bench.assets import SecretRef
+from coval_bench.contracts import read_contract_file
+from coval_bench.platform_assets import (
+    AGENTS,
+    TOOL_TIMEOUT_SECONDS,
+    SyncError,
+    VapiClient,
+    apply,
+    desired,
+    patch_body,
+    plan,
+    platform_for,
+    render_vapi_tools,
+    spec_for,
+)
+from coval_bench.variants.platforms import redact
+
+BASE = "https://mock.example.com/"
+SECRET = "s3cr3t-value"  # noqa: S105
+CONTRACT = json.loads(read_contract_file("dental", "tool-definitions.json"))
+DENTAL = spec_for("vapi-dental")
+
+LIVE: dict[str, Any] = {
+    "id": "asst_1",
+    "orgId": "org_1",
+    "name": "Vapi Dental",
+    "model": {
+        "provider": "openai",
+        "model": "gpt-4.1",
+        "temperature": 0,
+        "messages": [{"role": "system", "content": "You are the front desk."}],
+        "tools": [],
+    },
+    "voice": {"provider": "vapi", "voiceId": "Elliot"},
+}
+
+
+@pytest.fixture
+def env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("VAPI_DENTAL_ASSISTANT_ID", "asst_1")
+    monkeypatch.setenv("VAPI_API_KEY", "vapi-key")
+    monkeypatch.setenv("MOCK_TOOLS_SECRET", SECRET)
+
+
+def _client(handler: Any) -> VapiClient:  # noqa: ANN401
+    return VapiClient("vapi-key", "https://api.vapi.ai", transport=httpx.MockTransport(handler))
+
+
+# --- SecretRef -------------------------------------------------------------
+
+
+def test_secret_ref_names_what_is_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("NOPE_KEY", raising=False)
+    with pytest.raises(RuntimeError, match="NOPE_KEY is unset. It holds the thing"):
+        SecretRef(name="NOPE_KEY", purpose="the thing").resolve()
+
+
+def test_spec_for_names_the_known_set() -> None:
+    with pytest.raises(KeyError, match="known: vapi-dental"):
+        spec_for("telnyx-dental")
+    assert {s.key for s in AGENTS} == {"vapi-dental"}
+
+
+# --- render ----------------------------------------------------------------
+
+
+def test_render_emits_one_function_tool_per_contract_entry() -> None:
+    tools = render_vapi_tools(CONTRACT, BASE, SECRET)
+    assert len(tools) == len(CONTRACT) == 5
+    assert [t["function"]["name"] for t in tools] == [d["name"] for d in CONTRACT]
+    assert all(t["type"] == "function" and t["async"] is False for t in tools)
+
+
+def test_render_copies_parameters_verbatim() -> None:
+    tools = render_vapi_tools(CONTRACT, BASE, SECRET)
+    for tool, definition in zip(tools, CONTRACT, strict=True):
+        assert tool["function"]["parameters"] == definition["parameters"]
+        assert tool["function"]["description"] == definition["description"]
+
+
+def test_render_points_every_tool_at_the_vapi_codec_with_both_headers() -> None:
+    (tool, *_) = render_vapi_tools(CONTRACT, BASE, SECRET)
+    assert tool["server"]["url"] == "https://mock.example.com/mock/vapi"
+    assert tool["server"]["timeoutSeconds"] == TOOL_TIMEOUT_SECONDS
+    assert tool["server"]["headers"] == {
+        "X-Mock-Tools-Key": SECRET,
+        "X-Coval-Simulation-Id": "{{coval-simulation-id}}",
+    }
+
+
+def test_render_never_speaks_filler_messages() -> None:
+    assert all("messages" not in t for t in render_vapi_tools(CONTRACT, BASE, SECRET))
+
+
+def test_render_is_pure() -> None:
+    assert render_vapi_tools(CONTRACT, BASE, SECRET) == render_vapi_tools(CONTRACT, BASE, SECRET)
+
+
+def test_desired_resolves_the_secret_and_targets_model_tools(env: None) -> None:
+    wanted = desired(DENTAL, BASE)
+    assert list(wanted) == ["model.tools"]
+    assert wanted["model.tools"][0]["server"]["headers"]["X-Mock-Tools-Key"] == SECRET
+
+
+def test_desired_refuses_an_unknown_platform(env: None) -> None:
+    stranger = DENTAL.model_copy(update={"platform": "telnyx"})
+    with pytest.raises(SyncError, match="unknown platform 'telnyx'; known: vapi"):
+        desired(stranger, BASE)
+
+
+def test_the_platform_table_supplies_render_and_client_together() -> None:
+    platform = platform_for(DENTAL)
+    assert platform.name == "vapi"
+    assert platform.api_base == "https://api.vapi.ai"
+    assert platform.client is VapiClient
+
+
+def test_apply_accepts_any_client_with_the_two_methods(env: None) -> None:
+    class Fake:
+        def __init__(self) -> None:
+            self.patched: dict[str, Any] | None = None
+
+        def __enter__(self) -> Fake:
+            return self
+
+        def __exit__(self, *exc: object) -> None:
+            pass
+
+        def get_agent(self, agent_id: str) -> dict[str, Any]:
+            return LIVE
+
+        def update_agent(self, agent_id: str, body: dict[str, Any]) -> dict[str, Any]:
+            self.patched = body
+            return body
+
+    fake = Fake()
+    apply(fake, DENTAL, desired(DENTAL, BASE))
+    assert fake.patched is not None and len(fake.patched["model"]["tools"]) == 5
+
+
+# --- plan ------------------------------------------------------------------
+
+
+def test_plan_reports_tools_as_the_one_update(env: None) -> None:
+    result = plan(LIVE, desired(DENTAL, BASE))
+    assert list(result.update) == ["model.tools"]
+    assert result.unchanged == []
+    before, after = result.update["model.tools"]
+    assert before == []
+    assert len(after) == 5
+
+
+def test_plan_is_unchanged_when_live_already_matches(env: None) -> None:
+    wanted = desired(DENTAL, BASE)
+    live = {**LIVE, "model": {**LIVE["model"], "tools": wanted["model.tools"]}}
+    result = plan(live, wanted)
+    assert result.update == {}
+    assert result.unchanged == ["model.tools"]
+
+
+def test_plan_output_is_safe_to_print(env: None) -> None:
+    (_, after) = plan(LIVE, desired(DENTAL, BASE)).update["model.tools"]
+    found: list[str] = []
+    printed = json.dumps(redact(after, found))
+    assert SECRET not in printed
+    assert "{{coval-simulation-id}}" in printed
+    assert any(path.endswith("X-Mock-Tools-Key") for path in found)
+
+
+# --- apply -----------------------------------------------------------------
+
+
+def test_patch_body_carries_the_whole_live_model_with_tools_replaced(env: None) -> None:
+    body = patch_body(LIVE, desired(DENTAL, BASE))
+    assert list(body) == ["model"]
+    assert body["model"]["messages"] == LIVE["model"]["messages"]
+    assert body["model"]["provider"] == "openai"
+    assert body["model"]["temperature"] == 0
+    assert len(body["model"]["tools"]) == 5
+    assert LIVE["model"]["tools"] == []
+
+
+def test_apply_gets_then_patches_only_the_model(env: None) -> None:
+    calls: list[tuple[str, str, Any]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        payload = json.loads(request.content) if request.content else None
+        calls.append((request.method, request.url.path, payload))
+        return httpx.Response(200, json=LIVE)
+
+    with _client(handler) as client:
+        result = apply(client, DENTAL, desired(DENTAL, BASE))
+
+    assert [(m, p) for m, p, _ in calls] == [
+        ("GET", "/assistant/asst_1"),
+        ("PATCH", "/assistant/asst_1"),
+    ]
+    patched = calls[1][2]
+    assert set(patched) == {"model"}
+    assert "id" not in patched and "orgId" not in patched
+    assert patched["model"]["messages"] == LIVE["model"]["messages"]
+    assert len(patched["model"]["tools"]) == 5
+    assert list(result.update) == ["model.tools"]
+
+
+def test_apply_skips_the_patch_when_nothing_changed(env: None) -> None:
+    wanted = desired(DENTAL, BASE)
+    live = {**LIVE, "model": {**LIVE["model"], "tools": wanted["model.tools"]}}
+    methods: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        methods.append(request.method)
+        return httpx.Response(200, json=live)
+
+    with _client(handler) as client:
+        result = apply(client, DENTAL, wanted)
+    assert methods == ["GET"]
+    assert result.update == {}
+
+
+def test_apply_surfaces_vendor_errors(env: None) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "GET":
+            return httpx.Response(200, json=LIVE)
+        return httpx.Response(400, text="voiceId must be a string")
+
+    with (
+        _client(handler) as client,
+        pytest.raises(SyncError, match="PATCH /assistant/asst_1 -> 400"),
+    ):
+        apply(client, DENTAL, desired(DENTAL, BASE))


### PR DESCRIPTION
The Vapi dental assistant had no tools. This puts them there from the repo.

- `platform-assets plan|apply --agent vapi-dental --mock-base-url …` — `plan` diffs, `apply` confirms then PATCHes
- Five tools rendered from `tool-definitions.json`: `server.url` → `/mock/vapi`, headers carry `X-Mock-Tools-Key` and `X-Coval-Simulation-Id: {{coval-simulation-id}}`, no `messages[]` so no filler speech
- Only `model.tools` is managed. PATCH sends the whole live `model` with tools replaced, so prompt and temperature are untouched
- One `Platform` row per vendor (renderer + client behind a two-method protocol); Telnyx is one more row
- `SecretRef` lands in a committed module; redactor now catches `X-Mock-Tools-Key`

Needs `VAPI_API_KEY`, `VAPI_DENTAL_ASSISTANT_ID`, `MOCK_TOOLS_SECRET` in env.
