### PR TITLE
[BENCH-781] Productionize normalized storage backfill observability

### DIFF
--- a/runner/README.md
+++ b/runner/README.md
@@ -59,6 +59,37 @@ Normalized observation dual writes are additive, private, and disabled by defaul
 Set both `BENCHMARK_ARTIFACT_BUCKET` and `NORMALIZED_DUAL_WRITE_ENABLED=true` to
 enable the STT/TTS rollout; legacy result writes remain the source of truth.
 
+### Normalized-storage backfill operator runbook
+
+Run the production backfill as a dry run first. This command adds no `--apply`
+flag, so it makes no normalized-storage writes; the Cloud Run timeout override
+applies only to this execution.
+
+```bash
+gcloud run jobs execute benchmarks-runner \
+  --project=coval-benchmarks-prod \
+  --region=us-east1 \
+  --task-timeout=24h \
+  --wait \
+  --args='migrate,backfill-normalized-storage,--min-result-id=1,--batch-size=100'
+```
+
+The dry run freezes and reports its maximum result ID. Record that maximum for
+any separately authorized `--apply` run, which must pass it explicitly. Progress
+events are JSON on stderr; the final JSON report remains stdout's final line.
+
+`--batch-size` is a run-ID read page and also bounds apply-plan transaction
+batches. Larger pages reduce round trips, but increase memory, transaction
+duration, rollback and retry work, artifact exposure, and the spacing between
+safe checkpoints. A local PostgreSQL 16 dry-run comparison over 5,000 synthetic
+STT runs with one result each measured 1.15--1.26 s / 95.2 MB peak RSS at 25,
+1.03--1.06 s / 95.6 MB at 100, and 0.92--0.98 s / 97.6--97.8 MB at 400 after a
+warm-up run. The small synthetic gain does not model production row fanout,
+artifact handling, transaction duration, or rollback exposure, so the default
+remains 100. Compare candidate sizes in production only with sequential dry
+runs over the same frozen window, using each phase's elapsed time and throughput
+together with Cloud Run peak memory.
+
 ### Normalized read-index benchmark
 
 With Docker Postgres running, compare the baseline and the two candidate indexes

--- a/runner/src/coval_bench/migrations/backfill_normalized_storage.py
+++ b/runner/src/coval_bench/migrations/backfill_normalized_storage.py
@@ -12,14 +12,19 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import signal
+import sys
+import time
 import uuid
 from collections import Counter, defaultdict
-from collections.abc import Iterable
-from dataclasses import dataclass
+from collections.abc import Callable, Iterable, Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass, field
 from datetime import datetime
 from functools import lru_cache
 from importlib.resources import files
-from typing import Any
+from types import FrameType
+from typing import Any, TextIO
 
 import click
 import psycopg
@@ -41,6 +46,154 @@ _EVAL_NAMESPACE = uuid.UUID("e7f9ce4b-8f66-572c-bf9e-4f67b044422e")
 _ARTIFACT_NAMESPACE = uuid.UUID("64478df1-0d13-5996-a3ca-96c421f772c9")
 _LOCK = "normalized_storage_backfill"
 _MISMATCH_DETAIL_LIMIT = 100
+_PROGRESS_INTERVAL_SECONDS = 30.0
+_PROGRESS_MAX_UNITS = 10
+
+
+class _BackfillCancelled(Exception):
+    """Raised by the CLI SIGTERM handler after the current DB work unwinds."""
+
+
+@dataclass
+class ProgressReporter:
+    """Write aggregate-only, machine-readable migration progress to stderr."""
+
+    mode: str
+    min_result_id: int
+    max_result_id: int
+    batch_size: int
+    stream: TextIO = field(default_factory=lambda: sys.stderr)
+    monotonic: Callable[[], float] = time.monotonic
+    interval_seconds: float = _PROGRESS_INTERVAL_SECONDS
+    max_units: int = _PROGRESS_MAX_UNITS
+    started_at: float = 0.0
+    last_emitted_at: float = 0.0
+    units_since_emit: int = 0
+    pages: int = 0
+    runs: int = 0
+    results: int = 0
+    last_completed_run_id: int | None = None
+    last_completed_result_id: int | None = None
+    total_runs: int | None = None
+    phase_started_at: float = 0.0
+    phase_pages: int = 0
+    phase_runs: int = 0
+    phase_results: int = 0
+    phase_units_completed: int = 0
+    phase_last_completed_run_id: int | None = None
+    phase_last_completed_result_id: int | None = None
+    phase_total_runs: int | None = None
+
+    def __post_init__(self) -> None:
+        self.started_at = self.monotonic()
+        self.last_emitted_at = self.started_at
+        self.phase_started_at = self.started_at
+
+    def _payload(self, *, phase: str, status: str, report: dict[str, Any]) -> dict[str, Any]:
+        elapsed = max(0.0, self.monotonic() - self.started_at)
+        phase_elapsed = max(0.0, self.monotonic() - self.phase_started_at)
+        phase_run_throughput = self.phase_runs / phase_elapsed if phase_elapsed else 0.0
+        phase_result_throughput = self.phase_results / phase_elapsed if phase_elapsed else 0.0
+        payload: dict[str, Any] = {
+            "event": "normalized_storage_backfill_progress",
+            "status": status,
+            "phase": phase,
+            "mode": self.mode,
+            "min_result_id": self.min_result_id,
+            "max_result_id": self.max_result_id,
+            "batch_size": self.batch_size,
+            "pages": self.pages,
+            "runs": self.runs,
+            "results": self.results,
+            "last_completed_run_id": self.last_completed_run_id,
+            "last_completed_result_id": self.last_completed_result_id,
+            "elapsed_seconds": round(elapsed, 3),
+            "phase_elapsed_seconds": round(phase_elapsed, 3),
+            "throughput_runs_per_second": round(phase_run_throughput, 6),
+            "throughput_results_per_second": round(phase_result_throughput, 6),
+            "phase_pages": self.phase_pages,
+            "phase_runs": self.phase_runs,
+            "phase_results": self.phase_results,
+            "phase_units_completed": self.phase_units_completed,
+            "phase_last_completed_run_id": self.phase_last_completed_run_id,
+            "phase_last_completed_result_id": self.phase_last_completed_result_id,
+            "skipped": sum(report["skipped_by_reason"].values())
+            + sum(report["verification_skipped_by_reason"].values()),
+            "conflicts": report["parity_mismatch_count"] + report["rollup_mismatch_count"],
+        }
+        if self.phase_total_runs is not None:
+            payload["total_runs"] = self.phase_total_runs
+            payload["eta_seconds"] = (
+                round(max(0, self.phase_total_runs - self.phase_runs) / phase_run_throughput, 3)
+                if phase_run_throughput
+                else None
+            )
+        return payload
+
+    def emit(self, *, phase: str, status: str, report: dict[str, Any]) -> None:
+        self.stream.write(
+            json.dumps(self._payload(phase=phase, status=status, report=report), sort_keys=True)
+            + "\n"
+        )
+        self.stream.flush()
+        self.last_emitted_at = self.monotonic()
+        self.units_since_emit = 0
+
+    def phase_started(
+        self, phase: str, report: dict[str, Any], *, total_runs: int | None = None
+    ) -> None:
+        self.phase_started_at = self.monotonic()
+        self.phase_pages = 0
+        self.phase_runs = 0
+        self.phase_results = 0
+        self.phase_units_completed = 0
+        self.phase_last_completed_run_id = None
+        self.phase_last_completed_result_id = None
+        self.phase_total_runs = total_runs
+        self.emit(phase=phase, status="started", report=report)
+
+    def phase_completed(self, phase: str, report: dict[str, Any]) -> None:
+        self.emit(phase=phase, status="completed", report=report)
+
+    def completed_page(
+        self, run_ids: list[int], rows: list[LegacyRow], report: dict[str, Any], *, phase: str
+    ) -> None:
+        self.pages += 1
+        self.runs += len(run_ids)
+        self.results += len(rows)
+        self.phase_pages += 1
+        self.phase_runs += len(run_ids)
+        self.phase_results += len(rows)
+        self.last_completed_run_id = run_ids[-1]
+        self.last_completed_result_id = max(row.id for row in rows) if rows else None
+        self.phase_last_completed_run_id = self.last_completed_run_id
+        self.phase_last_completed_result_id = self.last_completed_result_id
+        self.completed_unit(report, phase=phase)
+
+    def completed_unit(self, report: dict[str, Any], *, phase: str) -> None:
+        self.units_since_emit += 1
+        self.phase_units_completed += 1
+        if (
+            self.units_since_emit >= self.max_units
+            or self.monotonic() - self.last_emitted_at >= self.interval_seconds
+        ):
+            self.emit(phase=phase, status="progress", report=report)
+
+
+@contextmanager
+def _temporary_sigterm_cancellation() -> Iterator[None]:
+    """Turn Cloud Run SIGTERM into an exception so cleanup finally blocks run."""
+
+    previous = signal.getsignal(signal.SIGTERM)
+
+    def cancel(_: int, __: FrameType | None) -> None:
+        raise _BackfillCancelled()
+
+    signal.signal(signal.SIGTERM, cancel)
+    try:
+        yield
+    finally:
+        signal.signal(signal.SIGTERM, previous)
 
 
 @dataclass(frozen=True)
@@ -193,6 +346,12 @@ ORDER BY r.run_id
 LIMIT %s
 """
 
+_QUALIFYING_RUN_COUNT_SQL = """
+SELECT COUNT(DISTINCT r.run_id)
+FROM benchmarks_v2.results r
+WHERE r.id BETWEEN %s AND %s AND r.benchmark IN ('STT','TTS')
+"""
+
 _RUN_ROWS_SQL = """
 SELECT r.id,r.run_id,n.dataset_id,n.dataset_sha256,n.scheduled_at,r.provider,r.model,r.voice,
  r.benchmark,r.metric_type,r.metric_value,r.metric_units,r.audio_filename,r.transcript,r.status,
@@ -214,6 +373,16 @@ def _run_page(
             return [], []
         cur.execute(_RUN_ROWS_SQL, (run_ids, low, high))
         return run_ids, [LegacyRow(*row) for row in cur.fetchall()]
+
+
+def _qualifying_run_count(conn: psycopg.Connection, low: int, high: int) -> int:
+    """Count the same frozen run population used by keyset paging without loading IDs."""
+    with conn.cursor() as cur:
+        cur.execute(_QUALIFYING_RUN_COUNT_SQL, (low, high))
+        row = cur.fetchone()
+    if row is None:  # pragma: no cover - aggregate SELECT always returns one row.
+        raise RuntimeError("qualifying run count query returned no row")
+    return int(row[0])
 
 
 def _complete_window_rows(
@@ -952,7 +1121,10 @@ WHERE bucket_at=%(bucket)s
 
 
 def _rollup_mismatches(
-    conn: psycopg.Connection, buckets: Iterable[datetime], report: dict[str, Any]
+    conn: psycopg.Connection,
+    buckets: Iterable[datetime],
+    report: dict[str, Any],
+    on_bucket_completed: Callable[[], None] | None = None,
 ) -> None:
     """Compare materialized rollups with a fresh aggregate over immutable values."""
     with conn.cursor() as cur:
@@ -973,6 +1145,8 @@ def _rollup_mismatches(
                         "reason": "stored_bucket_payload_mismatch",
                     },
                 )
+            if on_bucket_completed is not None:
+                on_bucket_completed()
 
 
 _BUCKET_PAGE_SQL = """
@@ -1073,6 +1247,7 @@ def backfill(
     batch_size: int,
     apply: bool,
     artifact_bucket: str | None = None,
+    reporter: ProgressReporter | None = None,
 ) -> dict[str, Any]:
     if min_result_id <= 0 or max_result_id < min_result_id or batch_size <= 0:
         raise ValueError("invalid id range or batch size")
@@ -1082,39 +1257,67 @@ def backfill(
         "max_result_id": max_result_id,
         "batch_size": batch_size,
     }
-    if apply and not artifact_bucket:
-        raise click.ClickException("BENCHMARK_ARTIFACT_BUCKET is required for --apply")
-    # Fail GCS setup before the first committed page, even if this prefix happens
-    # not to contain an artifact-bearing observation.
-    client = storage.Client() if apply else None
-    if client is not None and artifact_bucket is not None:
-        _preflight_artifact_bucket(client, artifact_bucket)
-    conn.commit()
-    if not apply:
-        for rows, complete in _complete_pages(
-            conn, min_result_id, max_result_id, batch_size, report["skipped_by_reason"]
-        ):
-            report["source_rows"] += len(rows)
-            plans = _page_plans(complete, report["skipped_by_reason"])
-            report["source_groups"] += len(plans)
-            for plan in plans:
-                if plan.first.scheduled_at is None:
-                    report["skipped_by_reason"]["scheduled_at_missing"] += 1
-                else:
-                    _insert_plan(conn, plan, False, artifact_bucket, None, report)
-        _rollup_mismatches(
-            conn,
-            _scheduled_buckets(conn, min_result_id, max_result_id, batch_size),
-            report,
-        )
-        _set_ready(report, dry_run=True)
-        return report
-    with conn.cursor() as cur:
-        cur.execute("SELECT pg_advisory_lock(hashtextextended(%s,0))", (_LOCK,))
-    # ``pg_advisory_lock`` is session scoped.  Commit the implicit SELECT
-    # transaction now so each following ``conn.transaction`` is top-level.
-    conn.commit()
+    reporter = reporter or ProgressReporter(
+        mode="apply" if apply else "dry_run",
+        min_result_id=min_result_id,
+        max_result_id=max_result_id,
+        batch_size=batch_size,
+    )
+    phase = "operation"
+    lock_acquired = False
+    reporter.phase_started(phase, report)
     try:
+        if apply and not artifact_bucket:
+            raise click.ClickException("BENCHMARK_ARTIFACT_BUCKET is required for --apply")
+        # Fail GCS setup before the first committed page, even if this prefix happens
+        # not to contain an artifact-bearing observation.
+        client = storage.Client() if apply else None
+        if client is not None and artifact_bucket is not None:
+            phase = "artifact_preflight"
+            reporter.phase_started(phase, report)
+            _preflight_artifact_bucket(client, artifact_bucket)
+            reporter.phase_completed(phase, report)
+        phase = "qualifying_run_count"
+        reporter.phase_started(phase, report)
+        reporter.total_runs = _qualifying_run_count(conn, min_result_id, max_result_id)
+        reporter.phase_completed(phase, report)
+        conn.commit()
+        phase = "source_reconciliation"
+        reporter.phase_started(phase, report, total_runs=reporter.total_runs)
+        if not apply:
+            for rows, complete in _complete_pages(
+                conn, min_result_id, max_result_id, batch_size, report["skipped_by_reason"]
+            ):
+                report["source_rows"] += len(rows)
+                plans = _page_plans(complete, report["skipped_by_reason"])
+                report["source_groups"] += len(plans)
+                for plan in plans:
+                    if plan.first.scheduled_at is None:
+                        report["skipped_by_reason"]["scheduled_at_missing"] += 1
+                    else:
+                        _insert_plan(conn, plan, False, artifact_bucket, None, report)
+                reporter.completed_page(
+                    sorted({row.run_id for row in rows}), rows, report, phase=phase
+                )
+            reporter.phase_completed(phase, report)
+            phase = "rollup_verification"
+            reporter.phase_started(phase, report)
+            _rollup_mismatches(
+                conn,
+                _scheduled_buckets(conn, min_result_id, max_result_id, batch_size),
+                report,
+                lambda: reporter.completed_unit(report, phase=phase),
+            )
+            reporter.phase_completed(phase, report)
+            _set_ready(report, dry_run=True)
+            reporter.phase_completed("operation", report)
+            return report
+        with conn.cursor() as cur:
+            cur.execute("SELECT pg_advisory_lock(hashtextextended(%s,0))", (_LOCK,))
+        lock_acquired = True
+        # ``pg_advisory_lock`` is session scoped.  Commit the implicit SELECT
+        # transaction now so each following ``conn.transaction`` is top-level.
+        conn.commit()
         for rows, complete in _complete_pages(
             conn, min_result_id, max_result_id, batch_size, report["skipped_by_reason"]
         ):
@@ -1141,9 +1344,13 @@ def backfill(
                         with conn.cursor() as cur:
                             _refresh_bucket(cur, bucket_at)
                         report["buckets"] += 1
+            reporter.completed_page(sorted({row.run_id for row in rows}), rows, report, phase=phase)
+        reporter.phase_completed(phase, report)
         # Re-plan from a fresh bounded pass; never retain first-pass plans.
+        phase = "post_write_verification"
+        reporter.phase_started(phase, report, total_runs=reporter.total_runs)
         verification_skipped: Counter[str] = report["verification_skipped_by_reason"]
-        for _, complete in _complete_pages(
+        for rows, complete in _complete_pages(
             conn, min_result_id, max_result_id, batch_size, verification_skipped
         ):
             for plan in _page_plans(complete, verification_skipped):
@@ -1171,18 +1378,31 @@ def backfill(
                             "parity_mismatches",
                             {"natural_key": list(plan.natural), "reason": reason},
                         )
+            reporter.completed_page(sorted({row.run_id for row in rows}), rows, report, phase=phase)
+        reporter.phase_completed(phase, report)
+        phase = "rollup_verification"
+        reporter.phase_started(phase, report)
         _rollup_mismatches(
             conn,
             _scheduled_buckets(conn, min_result_id, max_result_id, batch_size),
             report,
+            lambda: reporter.completed_unit(report, phase=phase),
         )
+        reporter.phase_completed(phase, report)
         _set_ready(report, dry_run=False)
+        reporter.phase_completed("operation", report)
         return report
+    except BaseException:
+        status = "cancelled" if isinstance(sys.exception(), _BackfillCancelled) else "failed"
+        reporter.emit(phase=phase, status=status, report=report)
+        reporter.emit(phase="operation", status=status, report=report)
+        raise
     finally:
-        conn.rollback()
-        with conn.cursor() as cur:
-            cur.execute("SELECT pg_advisory_unlock(hashtextextended(%s,0))", (_LOCK,))
-        conn.commit()
+        if lock_acquired:
+            conn.rollback()
+            with conn.cursor() as cur:
+                cur.execute("SELECT pg_advisory_unlock(hashtextextended(%s,0))", (_LOCK,))
+            conn.commit()
 
 
 @click.command(name="backfill-normalized-storage")
@@ -1201,7 +1421,7 @@ def backfill_normalized_storage_cli(
         raise click.ClickException(
             "DATABASE_URL is required for this production migration; set a non-local production URL"
         )
-    with psycopg.connect(url) as conn:
+    with _temporary_sigterm_cancellation(), psycopg.connect(url) as conn:
         if max_result_id is None:
             with conn.cursor() as cur:
                 cur.execute("SELECT COALESCE(max(id),0) FROM benchmarks_v2.results")

--- a/runner/tests/unit/test_normalized_storage_backfill.py
+++ b/runner/tests/unit/test_normalized_storage_backfill.py
@@ -5,6 +5,9 @@
 from __future__ import annotations
 
 import hashlib
+import io
+import json
+import signal
 from collections import Counter
 from contextlib import nullcontext
 from dataclasses import astuple, replace
@@ -252,6 +255,271 @@ def test_cli_rejects_the_local_placeholder_before_connecting(
     assert "DATABASE_URL is required" in result.output
 
 
+class _Clock:
+    def __init__(self) -> None:
+        self.value = 0.0
+
+    def __call__(self) -> float:
+        return self.value
+
+
+def _progress_events(stream: io.StringIO) -> list[dict[str, Any]]:
+    return [json.loads(line) for line in stream.getvalue().splitlines()]
+
+
+def test_progress_reporter_emits_periodically_with_checkpoint_throughput_and_eta() -> None:
+    clock = _Clock()
+    stream = io.StringIO()
+    report = migration._report()
+    reporter = migration.ProgressReporter(
+        "dry_run", 1, 99, 100, stream=stream, monotonic=clock, max_units=10
+    )
+    reporter.total_runs = 4
+    reporter.phase_started("source_reconciliation", report, total_runs=4)
+    clock.value = 31
+    row = replace(_row("WER", 1.0), id=9, run_id=7, benchmark="STT")
+    reporter.completed_page([7], [row], report, phase="source_reconciliation")
+
+    event = _progress_events(stream)[-1]
+    assert event["status"] == "progress"
+    assert event["last_completed_run_id"] == 7
+    assert event["last_completed_result_id"] == 9
+    assert event["throughput_runs_per_second"] == pytest.approx(1 / 31, rel=1e-5)
+    assert event["throughput_results_per_second"] == pytest.approx(1 / 31, rel=1e-5)
+    assert event["eta_seconds"] == pytest.approx(93)
+    assert event["phase_elapsed_seconds"] == 31
+    assert event["mode"] == "dry_run"
+
+
+def test_progress_reporter_uses_bounded_unit_fallback_before_time_interval() -> None:
+    clock = _Clock()
+    stream = io.StringIO()
+    report = migration._report()
+    reporter = migration.ProgressReporter(
+        "dry_run", 1, 99, 100, stream=stream, monotonic=clock, max_units=2
+    )
+    reporter.phase_started("source_reconciliation", report)
+    row = replace(_row("WER", 1.0), benchmark="STT")
+    reporter.completed_page([1], [row], report, phase="source_reconciliation")
+    reporter.completed_page(
+        [2], [replace(row, id=2, run_id=2)], report, phase="source_reconciliation"
+    )
+
+    assert _progress_events(stream)[-1]["status"] == "progress"
+
+
+def test_progress_reporter_tracks_verification_pages_and_rollup_units() -> None:
+    clock = _Clock()
+    stream = io.StringIO()
+    report = migration._report()
+    reporter = migration.ProgressReporter("apply", 1, 99, 100, stream=stream, monotonic=clock)
+    row = replace(_row("WER", 1.0), id=9, run_id=7, benchmark="STT")
+
+    reporter.phase_started("post_write_verification", report, total_runs=4)
+    clock.value = 10
+    reporter.completed_page([7], [row], report, phase="post_write_verification")
+    reporter.phase_completed("post_write_verification", report)
+    verification = _progress_events(stream)[-1]
+    assert verification["phase_pages"] == 1
+    assert verification["phase_runs"] == 1
+    assert verification["phase_results"] == 1
+    assert verification["eta_seconds"] == pytest.approx(30)
+
+    reporter.phase_started("rollup_verification", report)
+    reporter.completed_unit(report, phase="rollup_verification")
+    reporter.phase_completed("rollup_verification", report)
+    rollup = _progress_events(stream)[-1]
+    assert rollup["phase_units_completed"] == 1
+    assert "eta_seconds" not in rollup
+
+
+def test_dry_run_progress_is_stderr_only_and_forces_phase_completion(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    row = replace(_row("WER", 1.0), id=9, run_id=7, benchmark="STT", transcript="private")
+    stream = io.StringIO()
+    reporter = migration.ProgressReporter("dry_run", 1, 9, 1, stream=stream, monotonic=_Clock())
+    writes: list[bool] = []
+    plan = migration.Planned(
+        [row],
+        "sample",
+        row.dataset_id,
+        row.dataset_sha256,
+        "STT",
+        "dataset_audio",
+        "succeeded",
+        None,
+        None,
+        [],
+    )
+
+    class Conn:
+        def commit(self) -> None:
+            return None
+
+    monkeypatch.setattr(migration, "_qualifying_run_count", lambda *_: 1)
+    monkeypatch.setattr(migration, "_complete_pages", lambda *_: iter([([row], [row])]))
+    monkeypatch.setattr(migration, "_page_plans", lambda *_: [plan])
+    monkeypatch.setattr(migration, "_scheduled_buckets", lambda *_: iter(()))
+    monkeypatch.setattr(migration, "_rollup_mismatches", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        migration, "_insert_plan", lambda _conn, _plan, apply, *_args: writes.append(apply)
+    )
+
+    report = migration.backfill(
+        Conn(),  # type: ignore[arg-type]
+        min_result_id=1,
+        max_result_id=9,
+        batch_size=1,
+        apply=False,
+        reporter=reporter,
+    )
+
+    events = _progress_events(stream)
+    assert writes == [False]
+    assert report["source_rows"] == 1
+    assert events[-1]["phase"] == "operation"
+    assert events[-1]["status"] == "completed"
+    assert "private" not in stream.getvalue()
+
+
+def test_cli_keeps_progress_on_stderr_and_machine_report_as_final_stdout_line(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class Settings:
+        database_url = "postgresql://example"
+
+    class Conn:
+        def __enter__(self) -> Conn:
+            return self
+
+        def __exit__(self, *_: Any) -> None:
+            return None
+
+        def commit(self) -> None:
+            return None
+
+    row = replace(_row("WER", 1.0), id=9, run_id=7, benchmark="STT")
+    monkeypatch.setattr(migration, "get_settings", lambda: Settings())
+    monkeypatch.setattr(psycopg, "connect", lambda _: Conn())
+    monkeypatch.setattr(migration, "_qualifying_run_count", lambda *_: 1)
+    monkeypatch.setattr(migration, "_complete_pages", lambda *_: iter([([row], [row])]))
+    monkeypatch.setattr(migration, "_page_plans", lambda *_: [])
+    monkeypatch.setattr(migration, "_scheduled_buckets", lambda *_: iter(()))
+    monkeypatch.setattr(migration, "_rollup_mismatches", lambda *_args, **_kwargs: None)
+
+    result = CliRunner().invoke(backfill_normalized_storage_cli, ["--max-result-id", "9"])
+
+    assert result.exit_code == 0
+    assert "normalized_storage_backfill_progress" not in result.stdout
+    assert "normalized_storage_backfill_progress" in result.stderr
+    assert json.loads(result.stdout.splitlines()[-1])["window"]["max_result_id"] == 9
+
+
+def test_sigterm_cancellation_handler_is_restored(monkeypatch: pytest.MonkeyPatch) -> None:
+    previous = object()
+    handlers: list[Any] = []
+    monkeypatch.setattr(signal, "getsignal", lambda _: previous)
+    monkeypatch.setattr(signal, "signal", lambda _, handler: handlers.append(handler))
+
+    with migration._temporary_sigterm_cancellation(), pytest.raises(migration._BackfillCancelled):
+        handlers[-1](signal.SIGTERM, None)
+
+    assert handlers[-1] is previous
+
+
+def test_progress_failure_keeps_last_completed_checkpoint_without_detail_leakage(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    row = replace(_row("WER", 1.0), id=9, run_id=7, benchmark="STT")
+    stream = io.StringIO()
+    reporter = migration.ProgressReporter("dry_run", 1, 9, 1, stream=stream, monotonic=_Clock())
+
+    def pages(*_: Any) -> Any:
+        yield [row], [row]
+        raise RuntimeError("private transcript and exception detail")
+
+    class Conn:
+        def commit(self) -> None:
+            return None
+
+    monkeypatch.setattr(migration, "_qualifying_run_count", lambda *_: 1)
+    monkeypatch.setattr(migration, "_complete_pages", pages)
+    monkeypatch.setattr(migration, "_page_plans", lambda *_: [])
+    with pytest.raises(RuntimeError, match="private transcript"):
+        migration.backfill(
+            Conn(),  # type: ignore[arg-type]
+            min_result_id=1,
+            max_result_id=9,
+            batch_size=1,
+            apply=False,
+            reporter=reporter,
+        )
+
+    events = _progress_events(stream)
+    assert events[-1]["status"] == "failed"
+    assert events[-1]["last_completed_run_id"] == 7
+    assert events[-1]["last_completed_result_id"] == 9
+    assert "private" not in stream.getvalue()
+
+
+def test_apply_cancellation_emits_checkpoint_then_unlocks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    row = replace(_row("WER", 1.0), id=9, run_id=7, benchmark="STT")
+    stream = io.StringIO()
+    reporter = migration.ProgressReporter("apply", 1, 9, 1, stream=stream, monotonic=_Clock())
+    events: list[str] = []
+
+    def pages(*_: Any) -> Any:
+        yield [row], []
+        raise migration._BackfillCancelled()
+
+    class Cursor:
+        def __enter__(self) -> Cursor:
+            return self
+
+        def __exit__(self, *_: Any) -> None:
+            return None
+
+        def execute(self, statement: str, *_: Any) -> None:
+            events.append("unlock" if "pg_advisory_unlock" in statement else "lock")
+
+    class Conn:
+        def commit(self) -> None:
+            events.append("commit")
+
+        def rollback(self) -> None:
+            events.append("rollback")
+
+        def cursor(self) -> Cursor:
+            return Cursor()
+
+        def transaction(self) -> Any:
+            return nullcontext()
+
+    monkeypatch.setattr(migration, "_qualifying_run_count", lambda *_: 1)
+    monkeypatch.setattr(migration, "_complete_pages", pages)
+    monkeypatch.setattr(migration, "_page_plans", lambda *_: [])
+    monkeypatch.setattr(gcs_storage, "Client", lambda: object())
+    monkeypatch.setattr(migration, "_preflight_artifact_bucket", lambda *_: None)
+    with pytest.raises(migration._BackfillCancelled):
+        migration.backfill(
+            Conn(),  # type: ignore[arg-type]
+            min_result_id=1,
+            max_result_id=9,
+            batch_size=1,
+            apply=True,
+            artifact_bucket="bucket",
+            reporter=reporter,
+        )
+
+    progress = _progress_events(stream)
+    assert progress[-1]["status"] == "cancelled"
+    assert progress[-1]["last_completed_run_id"] == 7
+    assert events[-3:] == ["rollback", "unlock", "commit"]
+
+
 def test_run_pages_keyset_by_run_id_not_interleaved_result_ids() -> None:
     first = replace(_row("WER", 1.0), id=1, run_id=10, benchmark="STT")
     second = replace(_row("WER", 2.0), id=2, run_id=20, benchmark="STT")
@@ -389,6 +657,7 @@ def test_apply_replans_for_fresh_verification_without_retaining_pages(
             return nullcontext()
 
     monkeypatch.setattr(migration, "_complete_pages", pages)
+    monkeypatch.setattr(migration, "_qualifying_run_count", lambda *_: 1)
     monkeypatch.setattr(migration, "_page_plans", lambda *_: [plan])
     monkeypatch.setattr(gcs_storage, "Client", lambda: object())
     monkeypatch.setattr(migration, "_preflight_artifact_bucket", lambda *_: None)
@@ -478,6 +747,7 @@ def test_apply_verification_skips_are_reported_and_block_readiness(
             return nullcontext()
 
     monkeypatch.setattr(migration, "_complete_pages", pages)
+    monkeypatch.setattr(migration, "_qualifying_run_count", lambda *_: 1)
     monkeypatch.setattr(migration, "_page_plans", plans)
     monkeypatch.setattr(gcs_storage, "Client", lambda: object())
     monkeypatch.setattr(migration, "_preflight_artifact_bucket", lambda *_: None)


### PR DESCRIPTION
## Summary

- emit migration-local structured JSON progress on stderr for every phase, every 30 seconds or 10 completed units, and terminal completion/failure/cancellation
- report frozen bounds, batch size, phase/cumulative pages-runs-results, conservative checkpoints, elapsed time, throughput, ETA, and aggregate skip/conflict counts while preserving the final stdout JSON contract
- unwind SIGTERM through the existing rollback/advisory-unlock cleanup and add controlled-clock, CLI stream-separation, failure, and cancellation coverage
- document the exact one-off 24-hour Cloud Run dry-run command and retain batch size 100 based on a local 5,000-run comparison plus production tradeoffs

## Validation

- 29 focused normalized-backfill tests passed
- all 3 PostgreSQL-backed correctness test functions passed against fresh isolated PostgreSQL 16 databases
- Ruff check and format check passed
- strict mypy passed
- git diff --check passed
- independent Tier 3 Sol re-review: PASS

## Safety

No production apply, deployment, normalized-read flag, S2S backfill, readiness-tolerance, Docker command, or infra command change was performed.