### PR TITLE
[BENCH-783] Add normalized S2S storage backfill

### DIFF
--- a/runner/README.md
+++ b/runner/README.md
@@ -90,6 +90,69 @@ remains 100. Compare candidate sizes in production only with sequential dry
 runs over the same frozen window, using each phase's elapsed time and throughput
 together with Cloud Run peak memory.
 
+### Normalized S2S-storage backfill operator runbook
+
+S2S has a separate, database-only backfill: it never instantiates GCS and it
+never writes artifacts, preprocessing artifacts, evaluation inputs, or metric
+artifacts. Start with this read-only dry run; it freezes and reports the S2S
+maximum result ID only. Progress JSON is written to stderr and the final report
+is stdout's final line.
+
+```bash
+gcloud run jobs execute benchmarks-runner \
+  --project=coval-benchmarks-prod \
+  --region=us-east1 \
+  --task-timeout=24h \
+  --wait \
+  --args='migrate,backfill-normalized-s2s-storage,--min-result-id=1,--batch-size=100'
+```
+
+An apply requires explicit approval and the frozen maximum from the dry run:
+add `--max-result-id=N,--apply`. Progress phases are `qualifying_run_count`,
+`source_reconciliation`, `post_write_verification`, `public_parity`, and
+`rollup_verification`, bracketed by the `operation` phase. Events include both
+completed and durably committed run/result checkpoints. On failure, restart the
+same frozen window: deterministic backfill IDs and exact natural-key
+reconciliation make committed pages idempotent.
+
+The default is 100 run IDs/page. A page bounds planning memory and one top-level
+write transaction; a failed page rolls back its observations, evaluations,
+values, and bucket refreshes together while earlier pages remain committed.
+Larger pages reduce query and checkpoint overhead but increase memory,
+transaction duration, rollback work, and the distance between durable
+checkpoints. Each affected scheduled bucket is refreshed under the existing
+per-bucket advisory transaction lock.
+
+The final verification is independent of source-pass counters. It freshly
+re-plans the frozen complete-run cohort, compares the complete normalized S2S
+observation population, compares public legacy values with normalized primary
+values exactly, and compares every stored rollup field (including `value_sum`)
+with a fresh aggregate. Bounded mismatch details accompany exact mismatch
+counts. `backfill_complete` means this frozen migration window reconciles; it
+does not claim global cutover readiness.
+
+The local helper creates, migrates, seeds, benchmarks, and removes a uniquely
+named disposable database. Its default seed uses 450 runs, 50 conversations per
+run, and one to three metrics per conversation; each batch size runs in a fresh
+child process so peak RSS is comparable. Query duration is cumulative
+client-observed SQL execution time. The administrative URL must be loopback and
+its role must be allowed to create and drop databases.
+
+```bash
+uv run python scripts/benchmark_normalized_s2s_backfill.py \
+  --admin-database-url postgresql://postgres:postgres@127.0.0.1:5432/postgres \
+  --batch-sizes 25,100,400 \
+  --warmups 1 \
+  --iterations 1 \
+  --format markdown
+```
+
+No production-size measurement is recorded here yet, so 100 remains the
+conservative default. Roll out the read-only dry run, obtain explicit approval
+for the frozen apply, then use the separate readiness/cutover process. Do not
+enable normalized dashboard reads, broaden the STT/TTS backfill, or combine
+this runbook with the asynchronous-runner follow-up.
+
 ### Normalized read-index benchmark
 
 With Docker Postgres running, compare the baseline and the two candidate indexes

--- a/runner/scripts/benchmark_normalized_s2s_backfill.py
+++ b/runner/scripts/benchmark_normalized_s2s_backfill.py
@@ -1,0 +1,388 @@
+#!/usr/bin/env python3
+"""Benchmark the read-only S2S backfill on a disposable local database."""
+
+from __future__ import annotations
+
+import argparse
+import io
+import json
+import multiprocessing
+import platform
+import resource
+import time
+import traceback
+import uuid
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from multiprocessing.connection import Connection
+from pathlib import Path
+from typing import Any, Self, cast
+from urllib.parse import urlsplit, urlunsplit
+
+import psycopg
+from alembic import command as alembic_command
+from alembic.config import Config as AlembicConfig
+from psycopg import sql
+from psycopg.abc import Params, QueryNoTemplate
+
+from coval_bench.migrations.backfill_normalized_s2s_storage import (
+    ProgressReporter,
+    backfill,
+)
+
+_BATCH_SIZES = (25, 100, 400)
+_LOOPBACK_HOSTS = {"localhost", "127.0.0.1", "::1"}
+_INI_PATH = Path(__file__).parents[1] / "alembic.ini"
+_BASE_TIME = datetime(2026, 8, 27, tzinfo=UTC)
+
+
+@dataclass
+class _QueryTimer:
+    seconds: float = 0.0
+    count: int = 0
+
+    def reset(self) -> None:
+        self.seconds = 0.0
+        self.count = 0
+
+
+_QUERY_TIMER = _QueryTimer()
+
+
+class _TimingCursor(psycopg.Cursor[Any]):
+    """Measure client-observed execution duration for every SQL statement."""
+
+    def execute(  # type: ignore[override]  # Template queries are not used by this harness.
+        self,
+        query: QueryNoTemplate,
+        params: Params | None = None,
+        *,
+        prepare: bool | None = None,
+        binary: bool | None = None,
+    ) -> Self:
+        started = time.monotonic()
+        try:
+            return super().execute(query, params, prepare=prepare, binary=binary)
+        finally:
+            _QUERY_TIMER.seconds += time.monotonic() - started
+            _QUERY_TIMER.count += 1
+
+
+def _database_url(admin_url: str, database_name: str) -> str:
+    parts = urlsplit(admin_url)
+    return urlunsplit(parts._replace(path=f"/{database_name}"))
+
+
+def _validate_local_url(parser: argparse.ArgumentParser, url: str) -> None:
+    parsed = urlsplit(url)
+    if parsed.scheme not in {"postgresql", "postgres"}:
+        parser.error("--admin-database-url must be a PostgreSQL URL")
+    if parsed.hostname not in _LOOPBACK_HOSTS:
+        parser.error("benchmark refuses non-loopback database hosts")
+    if not parsed.path or parsed.path == "/":
+        parser.error("--admin-database-url must name an administrative database")
+    if parsed.query or parsed.fragment:
+        parser.error(
+            "--admin-database-url must not contain query parameters or a fragment; "
+            "libpq routing overrides are unsafe for a disposable benchmark"
+        )
+
+
+def _create_database(admin_url: str, database_name: str) -> None:
+    with psycopg.connect(admin_url, autocommit=True) as conn, conn.cursor() as cur:
+        cur.execute(sql.SQL("CREATE DATABASE {}").format(sql.Identifier(database_name)))
+
+
+def _drop_database(admin_url: str, database_name: str) -> None:
+    if not database_name.startswith("coval_s2s_backfill_bench_"):
+        raise RuntimeError("refusing to drop an unexpected database name")
+    with psycopg.connect(admin_url, autocommit=True) as conn, conn.cursor() as cur:
+        cur.execute(sql.SQL("DROP DATABASE {} WITH (FORCE)").format(sql.Identifier(database_name)))
+
+
+def _migrate(database_url: str) -> None:
+    config = AlembicConfig(str(_INI_PATH))
+    config.set_main_option(
+        "sqlalchemy.url", database_url.replace("postgresql://", "postgresql+psycopg://", 1)
+    )
+    alembic_command.upgrade(config, "head")
+
+
+def _seed(database_url: str, *, runs: int, conversations_per_run: int) -> dict[str, int]:
+    min_result_id: int | None = None
+    max_result_id: int | None = None
+    result_count = 0
+    with psycopg.connect(database_url) as conn, conn.cursor() as cur:
+        for run_index in range(runs):
+            captured_at = _BASE_TIME + timedelta(minutes=run_index)
+            scheduled_at = _BASE_TIME + timedelta(hours=run_index)
+            cur.execute(
+                """INSERT INTO benchmarks_v2.runs
+                   (started_at,finished_at,runner_sha,dataset_id,dataset_sha256,status,scheduled_at)
+                   VALUES (%s,%s,'benchmark-runner',%s,%s,%s,%s) RETURNING id""",
+                (
+                    captured_at,
+                    captured_at + timedelta(minutes=1),
+                    f"persona-{run_index % 12}",
+                    f"persona-source-{run_index % 12}",
+                    "partial" if run_index % 11 == 0 else "succeeded",
+                    scheduled_at,
+                ),
+            )
+            run_row = cur.fetchone()
+            if run_row is None:
+                raise RuntimeError("seed run insert returned no row")
+            run_id = int(run_row[0])
+            values: list[tuple[Any, ...]] = []
+            for conversation_index in range(conversations_per_run):
+                sample_id = f"coval-run-{run_index}/simulation-{conversation_index}"
+                provider = ("openai", "xai", "hume")[run_index % 3]
+                model = ("realtime", "grok-voice", "evi-3")[run_index % 3]
+                voice = None if run_index % 5 == 0 else f"voice-{run_index % 4}"
+                metric_count = 1 + conversation_index % 3
+                metric_payloads: list[tuple[str, float | None, str, str]] = [
+                    ("V2V", 180.0 + conversation_index, "milliseconds", "success")
+                ]
+                if metric_count >= 2:
+                    metric_payloads.append(
+                        (
+                            "InstructionFollowing",
+                            float((conversation_index % 2) * 100),
+                            "percent",
+                            "success",
+                        )
+                    )
+                if metric_count == 3:
+                    interrupted = conversation_index % 10 == 0
+                    metric_payloads.append(
+                        (
+                            "InterruptionRate",
+                            None if interrupted else round(conversation_index / 10, 2),
+                            "per_minute",
+                            "failed" if interrupted else "success",
+                        )
+                    )
+                for metric, value, unit, status in metric_payloads:
+                    values.append(
+                        (
+                            run_id,
+                            provider,
+                            model,
+                            voice,
+                            metric,
+                            value,
+                            unit,
+                            sample_id,
+                            status,
+                            captured_at,
+                        )
+                    )
+            cur.executemany(
+                """INSERT INTO benchmarks_v2.results
+                   (run_id,provider,model,voice,benchmark,metric_type,metric_value,
+                    metric_units,audio_filename,status,error,created_at)
+                   VALUES (%s,%s,%s,%s,'S2S',%s,%s,%s,%s,%s,NULL,%s)""",
+                values,
+            )
+            result_count += len(values)
+            if (run_index + 1) % 25 == 0:
+                conn.commit()
+        conn.commit()
+        cur.execute("SELECT min(id),max(id) FROM benchmarks_v2.results WHERE benchmark='S2S'")
+        bounds = cur.fetchone()
+        if bounds is not None:
+            min_result_id = int(bounds[0])
+            max_result_id = int(bounds[1])
+    if min_result_id is None or max_result_id is None:
+        raise RuntimeError("benchmark seed produced no S2S results")
+    return {
+        "runs": runs,
+        "conversations": runs * conversations_per_run,
+        "results": result_count,
+        "min_result_id": min_result_id,
+        "max_result_id": max_result_id,
+    }
+
+
+def _peak_rss_kib() -> int:
+    peak = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+    return int(peak / 1024) if platform.system() == "Darwin" else int(peak)
+
+
+def _worker(
+    send: Connection,
+    database_url: str,
+    low: int,
+    high: int,
+    batch_size: int,
+    warmups: int,
+    iterations: int,
+) -> None:
+    try:
+        measurements: list[dict[str, Any]] = []
+        with psycopg.connect(database_url, cursor_factory=_TimingCursor) as conn:
+            for _ in range(warmups):
+                backfill(
+                    conn,
+                    min_result_id=low,
+                    max_result_id=high,
+                    batch_size=batch_size,
+                    apply=False,
+                    reporter=ProgressReporter(
+                        "dry_run", low, high, batch_size, stream=io.StringIO()
+                    ),
+                )
+            for iteration in range(1, iterations + 1):
+                _QUERY_TIMER.reset()
+                started = time.monotonic()
+                report = backfill(
+                    conn,
+                    min_result_id=low,
+                    max_result_id=high,
+                    batch_size=batch_size,
+                    apply=False,
+                    reporter=ProgressReporter(
+                        "dry_run", low, high, batch_size, stream=io.StringIO()
+                    ),
+                )
+                runtime = time.monotonic() - started
+                measurements.append(
+                    {
+                        "batch_size": batch_size,
+                        "iteration": iteration,
+                        "pages": report["source_pages"],
+                        "runs": report["source_runs"],
+                        "results": report["source_rows"],
+                        "conversations": report["source_groups"],
+                        "runtime_seconds": round(runtime, 6),
+                        "query_duration_seconds": round(_QUERY_TIMER.seconds, 6),
+                        "query_count": _QUERY_TIMER.count,
+                        "throughput_runs_per_second": round(report["source_runs"] / runtime, 3),
+                        "throughput_results_per_second": round(report["source_rows"] / runtime, 3),
+                        "throughput_conversations_per_second": round(
+                            report["source_groups"] / runtime, 3
+                        ),
+                        "peak_rss_kib": _peak_rss_kib(),
+                    }
+                )
+        send.send({"measurements": measurements})
+    except BaseException:
+        send.send({"error": traceback.format_exc()})
+    finally:
+        send.close()
+
+
+def _run_batch_worker(
+    database_url: str,
+    low: int,
+    high: int,
+    batch_size: int,
+    warmups: int,
+    iterations: int,
+) -> list[dict[str, Any]]:
+    context = multiprocessing.get_context("spawn")
+    receive, send = context.Pipe(duplex=False)
+    process = context.Process(
+        target=_worker,
+        args=(send, database_url, low, high, batch_size, warmups, iterations),
+    )
+    process.start()
+    send.close()
+    process.join()
+    if not receive.poll():
+        raise RuntimeError(f"batch worker {batch_size} exited without a result")
+    payload = receive.recv()
+    receive.close()
+    if process.exitcode != 0:
+        raise RuntimeError(f"batch worker {batch_size} exited with {process.exitcode}")
+    if "error" in payload:
+        raise RuntimeError(payload["error"])
+    return cast("list[dict[str, Any]]", payload["measurements"])
+
+
+def _markdown(payload: dict[str, Any]) -> str:
+    seed = payload["seed"]
+    lines = [
+        "# Normalized S2S backfill benchmark",
+        "",
+        (
+            f"Seed: {seed['runs']} runs, {seed['conversations']} conversations, "
+            f"{seed['results']} results. Query duration is cumulative client-observed "
+            "SQL execution time."
+        ),
+        "",
+        "| batch | iter | pages | runs | results | conversations | runtime s | query s | "
+        "queries | runs/s | results/s | conversations/s | peak RSS KiB |",
+        "|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|",
+    ]
+    for row in payload["measurements"]:
+        lines.append(
+            "| {batch_size} | {iteration} | {pages} | {runs} | {results} | "
+            "{conversations} | {runtime_seconds} | {query_duration_seconds} | "
+            "{query_count} | {throughput_runs_per_second} | "
+            "{throughput_results_per_second} | {throughput_conversations_per_second} | "
+            "{peak_rss_kib} |".format(**row)
+        )
+    return "\n".join(lines)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--admin-database-url", required=True)
+    parser.add_argument("--runs", type=int, default=450)
+    parser.add_argument("--conversations-per-run", type=int, default=50)
+    parser.add_argument("--batch-sizes", default=",".join(map(str, _BATCH_SIZES)))
+    parser.add_argument("--warmups", type=int, default=1)
+    parser.add_argument("--iterations", type=int, default=1)
+    parser.add_argument("--format", choices=("json", "markdown"), default="json")
+    args = parser.parse_args()
+    _validate_local_url(parser, args.admin_database_url)
+    if args.runs < 1 or args.conversations_per_run < 1:
+        parser.error("--runs and --conversations-per-run must be positive")
+    if args.warmups < 0 or args.iterations < 1:
+        parser.error("--warmups must be non-negative and --iterations must be positive")
+    try:
+        batch_sizes = tuple(int(item) for item in args.batch_sizes.split(","))
+    except ValueError:
+        parser.error("--batch-sizes must be comma-separated integers")
+    if not batch_sizes or any(size < 1 for size in batch_sizes):
+        parser.error("--batch-sizes must contain positive integers")
+
+    database_name = f"coval_s2s_backfill_bench_{uuid.uuid4().hex}"
+    database_url = _database_url(args.admin_database_url, database_name)
+    created = False
+    try:
+        _create_database(args.admin_database_url, database_name)
+        created = True
+        _migrate(database_url)
+        seed = _seed(
+            database_url,
+            runs=args.runs,
+            conversations_per_run=args.conversations_per_run,
+        )
+        measurements = []
+        for batch_size in batch_sizes:
+            measurements.extend(
+                _run_batch_worker(
+                    database_url,
+                    seed["min_result_id"],
+                    seed["max_result_id"],
+                    batch_size,
+                    args.warmups,
+                    args.iterations,
+                )
+            )
+        payload = {
+            "seed": seed,
+            "warmups_per_batch": args.warmups,
+            "iterations_per_batch": args.iterations,
+            "measurements": measurements,
+        }
+        print(json.dumps(payload, sort_keys=True) if args.format == "json" else _markdown(payload))
+    finally:
+        if created:
+            _drop_database(args.admin_database_url, database_name)
+
+
+if __name__ == "__main__":
+    main()

--- a/runner/src/coval_bench/__main__.py
+++ b/runner/src/coval_bench/__main__.py
@@ -20,6 +20,9 @@ import click
 
 from coval_bench import __version__
 from coval_bench.db.cli import db_check, db_migrate
+from coval_bench.migrations.backfill_normalized_s2s_storage import (
+    backfill_normalized_s2s_storage_cli,
+)
 from coval_bench.migrations.backfill_normalized_storage import backfill_normalized_storage_cli
 from coval_bench.migrations.backfill_wer_breakdown import backfill_wer_breakdown_cli
 from coval_bench.migrations.import_legacy import import_legacy_cli
@@ -106,6 +109,7 @@ def migrate() -> None:
 
 migrate.add_command(backfill_wer_breakdown_cli, name="backfill-wer-breakdown")
 migrate.add_command(backfill_normalized_storage_cli, name="backfill-normalized-storage")
+migrate.add_command(backfill_normalized_s2s_storage_cli, name="backfill-normalized-s2s-storage")
 migrate.add_command(import_legacy_cli, name="import-legacy")
 
 # S2S is fetch-only, so a standalone command rather than a `run --kind` value.

--- a/runner/src/coval_bench/migrations/backfill_normalized_s2s_storage.py
+++ b/runner/src/coval_bench/migrations/backfill_normalized_s2s_storage.py
@@ -39,6 +39,7 @@ _FALLBACK_EVALUATION_ERROR = "legacy metric produced no value"
 _MISMATCH_DETAIL_LIMIT = 100
 _PROGRESS_INTERVAL_SECONDS = 30.0
 _PROGRESS_MAX_UNITS = 10
+_PUBLIC_PARITY_STATEMENT_TIMEOUT = "30s"
 _METRICS = {
     "V2V": "milliseconds",
     "InstructionFollowing": "percent",
@@ -747,7 +748,7 @@ FROM benchmarks_v2.metric_values v
 JOIN benchmarks_v2.metric_evaluations e ON e.id=v.metric_evaluation_id
 JOIN benchmarks_v2.benchmark_observations o ON o.id=e.observation_id
 JOIN benchmarks_v2.runs r ON r.id=o.run_id
-WHERE o.status='succeeded' AND e.status='succeeded'
+WHERE o.benchmark='S2S' AND o.status='succeeded' AND e.status='succeeded'
   AND r.status IN ('succeeded','partial') AND r.scheduled_at=%(bucket)s
 GROUP BY GROUPING SETS (
   (o.provider,o.model,o.benchmark,o.dataset_id,e.metric_type,e.metric_version,
@@ -760,7 +761,8 @@ _STORED_ROLLUP_SQL = """
 SELECT provider,model,benchmark,dataset_id,metric_type,metric_version,
        evaluation_variant,value_key,unit,bucket_at,min_value,p25,p50,p75,
        max_value,value_sum,sample_count
-FROM benchmarks_v2.metric_values_by_bucket WHERE bucket_at=%(bucket)s
+FROM benchmarks_v2.metric_values_by_bucket
+WHERE bucket_at=%(bucket)s AND benchmark='S2S'
 """
 
 
@@ -771,7 +773,9 @@ def _refresh(cur: psycopg.Cursor[Any], bucket: datetime) -> None:
         params,
     )
     cur.execute(
-        "DELETE FROM benchmarks_v2.metric_values_by_bucket WHERE bucket_at=%(bucket)s", params
+        "DELETE FROM benchmarks_v2.metric_values_by_bucket "
+        "WHERE bucket_at=%(bucket)s AND benchmark='S2S'",
+        params,
     )
     cur.execute(
         """INSERT INTO benchmarks_v2.metric_values_by_bucket
@@ -853,27 +857,15 @@ def _verify_population(
     _record_counter_diff(report, "observation_population_mismatches", expected, actual)
 
 
-_PUBLIC_PARITY_SQL = """
-WITH cohort AS (
-  SELECT n.id
-  FROM benchmarks_v2.runs n
-  WHERE n.status IN ('succeeded','partial','failed')
-    AND EXISTS (
-      SELECT 1 FROM benchmarks_v2.results r
-      WHERE r.run_id=n.id AND r.id BETWEEN %(low)s AND %(high)s AND r.benchmark='S2S'
-    )
-    AND NOT EXISTS (
-      SELECT 1 FROM benchmarks_v2.results r
-      WHERE r.run_id=n.id AND (r.id < %(low)s OR r.id > %(high)s)
-    )
-), legacy AS (
+_PUBLIC_PARITY_PAGE_SQL = """
+WITH legacy AS (
   SELECT jsonb_build_array(r.run_id,r.audio_filename,r.provider,r.model,r.voice,n.dataset_id,
                            r.metric_type,r.metric_units,r.metric_value) AS identity,
          count(*)::int AS row_count
   FROM benchmarks_v2.results r
   JOIN benchmarks_v2.runs n ON n.id=r.run_id
-  JOIN cohort c ON c.id=r.run_id
-  WHERE r.id BETWEEN %(low)s AND %(high)s AND r.benchmark='S2S'
+  WHERE r.run_id=ANY(%(run_ids)s) AND r.id BETWEEN %(low)s AND %(high)s
+    AND r.benchmark='S2S'
     AND r.status='success' AND r.metric_value IS NOT NULL
     AND n.status IN ('succeeded','partial')
   GROUP BY r.run_id,r.audio_filename,r.provider,r.model,r.voice,n.dataset_id,
@@ -883,11 +875,11 @@ WITH cohort AS (
                            e.metric_type,v.unit,v.value) AS identity,
          count(*)::int AS row_count
   FROM benchmarks_v2.benchmark_observations o
-  JOIN cohort c ON c.id=o.run_id
   JOIN benchmarks_v2.runs n ON n.id=o.run_id
   JOIN benchmarks_v2.metric_evaluations e ON e.observation_id=o.id
   JOIN benchmarks_v2.metric_values v ON v.metric_evaluation_id=e.id
-  WHERE o.benchmark='S2S' AND o.status='succeeded' AND e.status='succeeded'
+  WHERE o.run_id=ANY(%(run_ids)s) AND o.benchmark='S2S'
+    AND o.status='succeeded' AND e.status='succeeded'
     AND e.metric_version='v1' AND e.evaluation_variant='default'
     AND v.value_key='primary' AND v.value_role='primary'
     AND n.status IN ('succeeded','partial')
@@ -901,27 +893,35 @@ ORDER BY 1
 """
 
 
-def _verify_public_parity(
-    conn: psycopg.Connection, low: int, high: int, report: dict[str, Any]
+def _verify_public_parity_page(
+    cur: psycopg.Cursor[Any],
+    run_ids: list[int],
+    low: int,
+    high: int,
+    report: dict[str, Any],
 ) -> None:
-    with conn.transaction(), conn.cursor() as cur:
-        cur.execute("SET TRANSACTION READ ONLY")
-        cur.execute(_PUBLIC_PARITY_SQL, {"low": low, "high": high})
-        while rows := cur.fetchmany(100):
-            for row in rows:
-                identity = row[0]
-                legacy_count = int(row[1])
-                normalized_count = int(row[2])
-                _append_mismatch(
-                    report,
-                    "public_parity_mismatches",
-                    {
-                        "identity": identity,
-                        "legacy_count": legacy_count,
-                        "normalized_count": normalized_count,
-                    },
-                    count=abs(legacy_count - normalized_count),
-                )
+    cur.execute(
+        "SELECT set_config('statement_timeout', %s, true)",
+        (_PUBLIC_PARITY_STATEMENT_TIMEOUT,),
+    )
+    cur.execute(
+        _PUBLIC_PARITY_PAGE_SQL,
+        {"run_ids": run_ids, "low": low, "high": high},
+    )
+    for row in cur.fetchall():
+        identity = row[0]
+        legacy_count = int(row[1])
+        normalized_count = int(row[2])
+        _append_mismatch(
+            report,
+            "public_parity_mismatches",
+            {
+                "identity": identity,
+                "legacy_count": legacy_count,
+                "normalized_count": normalized_count,
+            },
+            count=abs(legacy_count - normalized_count),
+        )
 
 
 def _finalize_report(report: dict[str, Any], *, apply: bool) -> None:
@@ -1081,9 +1081,39 @@ def backfill(
         progress.phase_completed(phase, report)
 
         phase = "public_parity"
-        progress.phase_started(phase, report)
-        _verify_public_parity(conn, min_result_id, max_result_id, report)
-        progress.completed_unit(report, phase=phase)
+        progress.phase_started(phase, report, total_runs=progress.total_runs)
+        after = 0
+        while True:
+            parity_skips: Counter[str] = Counter()
+            run_ids, rows, complete = _read_complete_page(
+                conn,
+                min_result_id,
+                max_result_id,
+                after,
+                batch_size,
+                parity_skips,
+            )
+            if not run_ids:
+                break
+            after = run_ids[-1]
+            complete_run_ids = sorted({row.run_id for row in complete})
+            if complete_run_ids:
+                with conn.transaction(), conn.cursor() as cur:
+                    cur.execute("SET TRANSACTION READ ONLY")
+                    _verify_public_parity_page(
+                        cur,
+                        complete_run_ids,
+                        min_result_id,
+                        max_result_id,
+                        report,
+                    )
+            conversations = len(
+                {
+                    (row.run_id, row.sample_id, row.provider, row.model, row.voice)
+                    for row in complete
+                }
+            )
+            progress.completed_page(run_ids, rows, conversations, report, phase=phase)
         progress.phase_completed(phase, report)
 
         phase = "rollup_verification"

--- a/runner/src/coval_bench/migrations/backfill_normalized_s2s_storage.py
+++ b/runner/src/coval_bench/migrations/backfill_normalized_s2s_storage.py
@@ -1,0 +1,1153 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+# ruff: noqa: E501, S608  # Audited SQL is intentionally kept as complete statements.
+"""Backfill legacy S2S rows into normalized database-only storage.
+
+Historic S2S results retain metric outcomes, but not the underlying conversation
+artifact.  This standalone operator therefore writes observations, evaluations,
+values, and rollups only.  It never fabricates artifact lineage and never changes
+legacy rows.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import signal
+import sys
+import time
+import uuid
+from collections import Counter, defaultdict
+from collections.abc import Callable, Iterable, Iterator, Mapping
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from datetime import datetime
+from types import FrameType
+from typing import Any, TextIO
+
+import click
+import psycopg
+
+from coval_bench.config import get_settings
+from coval_bench.s2s.fetch_v2v import _normalized_dataset_sha256
+
+_OBS_NAMESPACE = uuid.UUID("0c43bb05-d3e4-5d07-b9d9-1e4e7e18f9f2")
+_EVAL_NAMESPACE = uuid.UUID("5bb93c92-caae-5f2b-a7c5-3a239e8d423d")
+_LOCK = "normalized_storage_backfill"
+_FALLBACK_OBSERVATION_ERROR = "Coval conversation produced no successful metric value"
+_FALLBACK_EVALUATION_ERROR = "legacy metric produced no value"
+_MISMATCH_DETAIL_LIMIT = 100
+_PROGRESS_INTERVAL_SECONDS = 30.0
+_PROGRESS_MAX_UNITS = 10
+_METRICS = {
+    "V2V": "milliseconds",
+    "InstructionFollowing": "percent",
+    "InterruptionRate": "per_minute",
+}
+_MISMATCH_KEYS = {
+    "payload_mismatches": "payload_mismatch_count",
+    "observation_population_mismatches": "observation_population_mismatch_count",
+    "public_parity_mismatches": "public_parity_mismatch_count",
+    "rollup_mismatches": "rollup_mismatch_count",
+}
+
+
+class _Cancelled(Exception):
+    """Raised by the CLI SIGTERM handler so cleanup finally blocks run."""
+
+
+@contextmanager
+def _sigterm() -> Iterator[None]:
+    previous = signal.getsignal(signal.SIGTERM)
+
+    def cancel(_: int, __: FrameType | None) -> None:
+        raise _Cancelled()
+
+    signal.signal(signal.SIGTERM, cancel)
+    try:
+        yield
+    finally:
+        signal.signal(signal.SIGTERM, previous)
+
+
+@dataclass(frozen=True)
+class LegacyS2SRow:
+    id: int
+    run_id: int
+    dataset_id: str
+    dataset_sha256: str
+    scheduled_at: datetime | None
+    provider: str
+    model: str
+    voice: str | None
+    metric: str
+    value: float | None
+    unit: str | None
+    sample_id: str | None
+    status: str
+    error: str | None
+    captured_at: datetime
+
+
+@dataclass(frozen=True)
+class Plan:
+    rows: tuple[LegacyS2SRow, ...]
+    status: str
+    error: str | None
+
+    @property
+    def first(self) -> LegacyS2SRow:
+        return self.rows[0]
+
+    @property
+    def natural(self) -> tuple[Any, ...]:
+        row = self.first
+        return row.run_id, row.sample_id, row.provider, row.model, row.voice
+
+    @property
+    def id(self) -> uuid.UUID:
+        return uuid.uuid5(_OBS_NAMESPACE, "|".join(map(str, self.natural)))
+
+    def evaluation_id(self, metric: str) -> uuid.UUID:
+        return uuid.uuid5(_EVAL_NAMESPACE, f"{self.id}|{metric}|v1|default")
+
+    @property
+    def dataset_sha256(self) -> str:
+        return _normalized_dataset_sha256(self.first.dataset_sha256)
+
+    @property
+    def population_key(self) -> tuple[Any, ...]:
+        row = self.first
+        return (*self.natural, row.dataset_id)
+
+    def evaluations(self) -> list[tuple[str, str, float | None, str | None]]:
+        evaluations: list[tuple[str, str, float | None, str | None]] = []
+        for row in sorted(self.rows, key=lambda candidate: candidate.metric):
+            succeeded = row.status == "success" and row.value is not None
+            legacy_error = row.error if row.error else None
+            evaluations.append(
+                (
+                    row.metric,
+                    "succeeded" if succeeded else "failed",
+                    float(row.value) if row.status == "success" and row.value is not None else None,
+                    None if succeeded else (legacy_error or _FALLBACK_EVALUATION_ERROR),
+                )
+            )
+        return evaluations
+
+
+@dataclass(frozen=True)
+class ReconcileResult:
+    disposition: str
+    reason: str | None = None
+    evaluations: int = 0
+    values: int = 0
+
+
+@dataclass
+class PageDelta:
+    eligible: int = 0
+    created: int = 0
+    reconciled: int = 0
+    live_owned: int = 0
+    evaluations: int = 0
+    values: int = 0
+    buckets: int = 0
+    conflicts: Counter[str] = field(default_factory=Counter)
+
+    def record(self, result: ReconcileResult) -> None:
+        if result.disposition == "eligible":
+            self.eligible += 1
+        elif result.disposition == "created":
+            self.eligible += 1
+            self.created += 1
+            self.evaluations += result.evaluations
+            self.values += result.values
+        elif result.disposition == "reconciled":
+            self.reconciled += 1
+        elif result.disposition == "live_owned":
+            self.reconciled += 1
+            self.live_owned += 1
+        else:
+            self.conflicts[result.reason or "stored_payload_conflict"] += 1
+
+
+@dataclass
+class ProgressReporter:
+    """Write aggregate-only, machine-readable progress events to stderr."""
+
+    mode: str
+    min_result_id: int
+    max_result_id: int
+    batch_size: int
+    stream: TextIO = field(default_factory=lambda: sys.stderr)
+    monotonic: Callable[[], float] = time.monotonic
+    interval_seconds: float = _PROGRESS_INTERVAL_SECONDS
+    max_units: int = _PROGRESS_MAX_UNITS
+    started_at: float = field(init=False)
+    last_emitted_at: float = field(init=False)
+    phase_started_at: float = field(init=False)
+    units_since_emit: int = 0
+    pages: int = 0
+    runs: int = 0
+    results: int = 0
+    conversations: int = 0
+    phase_pages: int = 0
+    phase_runs: int = 0
+    phase_results: int = 0
+    phase_conversations: int = 0
+    phase_units_completed: int = 0
+    total_runs: int | None = None
+    phase_total_runs: int | None = None
+    last_completed_run_id: int | None = None
+    last_completed_result_id: int | None = None
+    last_committed_run_id: int | None = None
+    last_committed_result_id: int | None = None
+    phase_last_completed_run_id: int | None = None
+    phase_last_completed_result_id: int | None = None
+
+    def __post_init__(self) -> None:
+        now = self.monotonic()
+        self.started_at = now
+        self.last_emitted_at = now
+        self.phase_started_at = now
+
+    def _payload(self, phase: str, status: str, report: Mapping[str, Any]) -> dict[str, Any]:
+        now = self.monotonic()
+        elapsed = max(now - self.started_at, 0.0)
+        phase_elapsed = max(now - self.phase_started_at, 0.0)
+        phase_run_rate = self.phase_runs / phase_elapsed if phase_elapsed else 0.0
+        mismatch_count = sum(int(report.get(key, 0)) for key in _MISMATCH_KEYS.values())
+        skipped = _counter_total(report.get("skipped_by_reason")) + _counter_total(
+            report.get("verification_skipped_by_reason")
+        )
+        conflicts = _counter_total(report.get("conflicts_by_reason")) + _counter_total(
+            report.get("verification_conflicts_by_reason")
+        )
+        payload: dict[str, Any] = {
+            "event": "normalized_s2s_storage_backfill_progress",
+            "phase": phase,
+            "status": status,
+            "mode": self.mode,
+            "min_result_id": self.min_result_id,
+            "max_result_id": self.max_result_id,
+            "batch_size": self.batch_size,
+            "pages": self.pages,
+            "runs": self.runs,
+            "results": self.results,
+            "conversations": self.conversations,
+            "phase_pages": self.phase_pages,
+            "phase_runs": self.phase_runs,
+            "phase_results": self.phase_results,
+            "phase_conversations": self.phase_conversations,
+            "phase_units_completed": self.phase_units_completed,
+            "total_runs": self.total_runs,
+            "phase_total_runs": self.phase_total_runs,
+            "last_completed_run_id": self.last_completed_run_id,
+            "last_completed_result_id": self.last_completed_result_id,
+            "last_committed_run_id": self.last_committed_run_id,
+            "last_committed_result_id": self.last_committed_result_id,
+            "phase_last_completed_run_id": self.phase_last_completed_run_id,
+            "phase_last_completed_result_id": self.phase_last_completed_result_id,
+            "elapsed_seconds": round(elapsed, 3),
+            "phase_elapsed_seconds": round(phase_elapsed, 3),
+            "throughput_runs_per_second": round(self.runs / elapsed, 6) if elapsed else 0.0,
+            "throughput_results_per_second": round(self.results / elapsed, 6) if elapsed else 0.0,
+            "throughput_conversations_per_second": round(self.conversations / elapsed, 6)
+            if elapsed
+            else 0.0,
+            "phase_throughput_runs_per_second": round(phase_run_rate, 6),
+            "phase_throughput_results_per_second": round(self.phase_results / phase_elapsed, 6)
+            if phase_elapsed
+            else 0.0,
+            "phase_throughput_conversations_per_second": round(
+                self.phase_conversations / phase_elapsed, 6
+            )
+            if phase_elapsed
+            else 0.0,
+            "skipped": skipped,
+            "conflicts": conflicts,
+            "mismatches": mismatch_count,
+        }
+        payload["eta_seconds"] = (
+            round(max(self.phase_total_runs - self.phase_runs, 0) / phase_run_rate, 3)
+            if self.phase_total_runs is not None and phase_run_rate
+            else None
+        )
+        return payload
+
+    def emit(self, phase: str, status: str, report: Mapping[str, Any]) -> None:
+        self.stream.write(json.dumps(self._payload(phase, status, report), sort_keys=True) + "\n")
+        self.stream.flush()
+        self.last_emitted_at = self.monotonic()
+        self.units_since_emit = 0
+
+    def phase_started(
+        self, phase: str, report: Mapping[str, Any], *, total_runs: int | None = None
+    ) -> None:
+        self.phase_started_at = self.monotonic()
+        self.phase_pages = 0
+        self.phase_runs = 0
+        self.phase_results = 0
+        self.phase_conversations = 0
+        self.phase_units_completed = 0
+        self.phase_last_completed_run_id = None
+        self.phase_last_completed_result_id = None
+        self.phase_total_runs = total_runs
+        self.emit(phase, "started", report)
+
+    def phase_completed(self, phase: str, report: Mapping[str, Any]) -> None:
+        self.emit(phase, "completed", report)
+
+    def completed_page(
+        self,
+        run_ids: list[int],
+        rows: list[LegacyS2SRow],
+        conversations: int,
+        report: Mapping[str, Any],
+        *,
+        phase: str,
+        committed: bool = False,
+    ) -> None:
+        self.pages += 1
+        self.runs += len(run_ids)
+        self.results += len(rows)
+        self.conversations += conversations
+        self.phase_pages += 1
+        self.phase_runs += len(run_ids)
+        self.phase_results += len(rows)
+        self.phase_conversations += conversations
+        self.last_completed_run_id = run_ids[-1]
+        self.last_completed_result_id = max((row.id for row in rows), default=None)
+        self.phase_last_completed_run_id = self.last_completed_run_id
+        self.phase_last_completed_result_id = self.last_completed_result_id
+        if committed:
+            self.last_committed_run_id = self.last_completed_run_id
+            self.last_committed_result_id = self.last_completed_result_id
+        self.completed_unit(report, phase=phase)
+
+    def completed_unit(self, report: Mapping[str, Any], *, phase: str) -> None:
+        self.units_since_emit += 1
+        self.phase_units_completed += 1
+        if (
+            self.units_since_emit >= self.max_units
+            or self.monotonic() - self.last_emitted_at >= self.interval_seconds
+        ):
+            self.emit(phase, "progress", report)
+
+
+def _counter_total(value: object) -> int:
+    return sum(int(count) for count in value.values()) if isinstance(value, Mapping) else 0
+
+
+def _report(low: int, high: int, batch: int) -> dict[str, Any]:
+    report: dict[str, Any] = {
+        "window": {"min_result_id": low, "max_result_id": high, "batch_size": batch},
+        "source_rows": 0,
+        "source_runs": 0,
+        "source_groups": 0,
+        "source_pages": 0,
+        "eligible": 0,
+        "created": 0,
+        "reconciled": 0,
+        "live_owned": 0,
+        "evaluations": 0,
+        "values": 0,
+        "buckets": 0,
+        "skipped_by_reason": Counter(),
+        "conflicts_by_reason": Counter(),
+        "verification_rows": 0,
+        "verification_runs": 0,
+        "verification_groups": 0,
+        "verification_pages": 0,
+        "verification_reconciled": 0,
+        "verification_live_owned": 0,
+        "verification_skipped_by_reason": Counter(),
+        "verification_conflicts_by_reason": Counter(),
+        "backfill_complete": False,
+    }
+    for details_key, count_key in _MISMATCH_KEYS.items():
+        report[details_key] = []
+        report[count_key] = 0
+        report[f"{details_key}_truncated"] = False
+    return report
+
+
+def _append_mismatch(
+    report: dict[str, Any], key: str, detail: dict[str, Any], *, count: int = 1
+) -> None:
+    count_key = _MISMATCH_KEYS[key]
+    report[count_key] += count
+    if len(report[key]) < _MISMATCH_DETAIL_LIMIT:
+        report[key].append(detail)
+    else:
+        report[f"{key}_truncated"] = True
+
+
+def _record_counter_diff(
+    report: dict[str, Any], key: str, expected: Counter[Any], actual: Counter[Any]
+) -> None:
+    for item in sorted(set(expected) | set(actual), key=repr):
+        expected_count = expected[item]
+        actual_count = actual[item]
+        if expected_count == actual_count:
+            continue
+        _append_mismatch(
+            report,
+            key,
+            {
+                "identity": list(item),
+                "expected_count": expected_count,
+                "actual_count": actual_count,
+            },
+            count=abs(expected_count - actual_count),
+        )
+
+
+_PAGE_SQL = """
+SELECT DISTINCT run_id
+FROM benchmarks_v2.results
+WHERE id BETWEEN %s AND %s AND benchmark='S2S' AND run_id>%s
+ORDER BY run_id LIMIT %s
+"""
+_ROWS_SQL = """
+SELECT r.id,r.run_id,n.dataset_id,n.dataset_sha256,n.scheduled_at,
+       r.provider,r.model,r.voice,r.metric_type,r.metric_value,r.metric_units,
+       r.audio_filename,r.status,r.error,r.created_at
+FROM benchmarks_v2.results r
+JOIN benchmarks_v2.runs n ON n.id=r.run_id
+WHERE r.run_id=ANY(%s) AND r.id BETWEEN %s AND %s AND r.benchmark='S2S'
+ORDER BY r.run_id,r.id
+"""
+
+
+def _read_complete_page(
+    conn: psycopg.Connection,
+    low: int,
+    high: int,
+    after: int,
+    size: int,
+    skipped: Counter[str],
+) -> tuple[list[int], list[LegacyS2SRow], list[LegacyS2SRow]]:
+    with conn.transaction(), conn.cursor() as cur:
+        cur.execute("SET TRANSACTION READ ONLY")
+        cur.execute(_PAGE_SQL, (low, high, after, size))
+        run_ids = [int(row[0]) for row in cur.fetchall()]
+        if not run_ids:
+            return [], [], []
+        cur.execute(_ROWS_SQL, (run_ids, low, high))
+        rows = [LegacyS2SRow(*row) for row in cur.fetchall()]
+        cur.execute(
+            """SELECT n.id,min(r.id),max(r.id),n.status
+               FROM benchmarks_v2.runs n
+               JOIN benchmarks_v2.results r ON r.run_id=n.id
+               WHERE n.id=ANY(%s)
+               GROUP BY n.id,n.status""",
+            (run_ids,),
+        )
+        excluded: set[int] = set()
+        for run_id, first_result, last_result, status in cur.fetchall():
+            if first_result < low or last_result > high:
+                skipped["split_window_run"] += 1
+                excluded.add(int(run_id))
+            elif status not in ("succeeded", "partial", "failed"):
+                skipped["run_not_terminal"] += 1
+                excluded.add(int(run_id))
+        complete = [row for row in rows if row.run_id not in excluded]
+        return run_ids, rows, complete
+
+
+def _qualifying_run_count(conn: psycopg.Connection, low: int, high: int) -> int:
+    with conn.transaction(), conn.cursor() as cur:
+        cur.execute("SET TRANSACTION READ ONLY")
+        cur.execute(
+            "SELECT count(DISTINCT run_id) FROM benchmarks_v2.results WHERE id BETWEEN %s AND %s AND benchmark='S2S'",
+            (low, high),
+        )
+        row = cur.fetchone()
+        if row is None:
+            raise RuntimeError("qualifying run count returned no row")
+        return int(row[0])
+
+
+def _plans(rows: list[LegacyS2SRow], skipped: Counter[str], conflicts: Counter[str]) -> list[Plan]:
+    grouped: dict[tuple[Any, ...], list[LegacyS2SRow]] = defaultdict(list)
+    for row in rows:
+        grouped[(row.run_id, row.provider, row.model, row.voice, row.sample_id)].append(row)
+    plans: list[Plan] = []
+    for key, group in grouped.items():
+        if not key[-1]:
+            skipped["audio_filename_missing"] += 1
+            continue
+        shared = {
+            (row.dataset_id, row.dataset_sha256, row.scheduled_at, row.captured_at) for row in group
+        }
+        metric_counts = Counter(row.metric for row in group)
+        if len(shared) != 1 or any(
+            metric not in _METRICS or count != 1 for metric, count in metric_counts.items()
+        ):
+            conflicts["conflicting_group"] += 1
+            continue
+        invalid = False
+        for row in group:
+            if row.status == "success":
+                invalid = (
+                    row.value is None
+                    or not math.isfinite(float(row.value))
+                    or row.unit != _METRICS[row.metric]
+                )
+            elif row.status != "failed" or row.value is not None:
+                invalid = True
+            if invalid:
+                break
+        if invalid:
+            conflicts["metric_payload_invalid"] += 1
+            continue
+        succeeded = any(row.status == "success" and row.value is not None for row in group)
+        legacy_error = next((row.error for row in group if row.error), None)
+        plans.append(
+            Plan(
+                tuple(group),
+                "succeeded" if succeeded else "failed",
+                None if succeeded else (legacy_error or _FALLBACK_OBSERVATION_ERROR),
+            )
+        )
+    return plans
+
+
+def _no_lineage(cur: psycopg.Cursor[Any], observation_id: uuid.UUID) -> bool:
+    for table in ("observation_artifacts", "preprocessing_artifacts"):
+        cur.execute(
+            f"SELECT EXISTS(SELECT 1 FROM benchmarks_v2.{table} WHERE observation_id=%s)",
+            (observation_id,),
+        )
+        found = cur.fetchone()
+        if found is None:
+            raise RuntimeError("lineage existence query returned no row")
+        if found[0]:
+            return False
+    cur.execute(
+        """SELECT EXISTS(
+               SELECT 1 FROM benchmarks_v2.metric_evaluation_inputs i
+               JOIN benchmarks_v2.metric_evaluations e ON e.id=i.metric_evaluation_id
+               WHERE e.observation_id=%s
+           ) OR EXISTS(
+               SELECT 1 FROM benchmarks_v2.metric_artifacts a
+               JOIN benchmarks_v2.metric_evaluations e ON e.id=a.metric_evaluation_id
+               WHERE e.observation_id=%s
+           )""",
+        (observation_id, observation_id),
+    )
+    found = cur.fetchone()
+    if found is None:
+        raise RuntimeError("metric lineage existence query returned no row")
+    return not found[0]
+
+
+def _match_reason(
+    cur: psycopg.Cursor[Any], plan: Plan, observation_id: uuid.UUID, *, live_owned: bool
+) -> str | None:
+    row = plan.first
+    cur.execute(
+        """SELECT run_id,dataset_id,dataset_sha256,sample_id,provider,model,voice,
+                  benchmark,source_kind,transport_protocol,submit_to_headers_ms,
+                  provider_extras,captured_at,status,error,failure_origin
+           FROM benchmarks_v2.benchmark_observations WHERE id=%s""",
+        (observation_id,),
+    )
+    expected_observation = (
+        row.run_id,
+        row.dataset_id,
+        plan.dataset_sha256,
+        row.sample_id,
+        row.provider,
+        row.model,
+        row.voice,
+        "S2S",
+        "conversation_audio",
+        None,
+        None,
+        None,
+        row.captured_at,
+        plan.status,
+        plan.error,
+        None if plan.status == "succeeded" else "provider",
+    )
+    if cur.fetchone() != expected_observation:
+        return "observation_payload_mismatch"
+    if not _no_lineage(cur, observation_id):
+        return "unexpected_artifact_lineage"
+    cur.execute(
+        """SELECT id,metric_type,metric_version,evaluation_variant,executor,
+                  external_request_id,status,started_at,finished_at,error
+           FROM benchmarks_v2.metric_evaluations
+           WHERE observation_id=%s ORDER BY metric_type""",
+        (observation_id,),
+    )
+    actual_evaluations = cur.fetchall()
+    expected = {
+        metric: (status, value, error) for metric, status, value, error in plan.evaluations()
+    }
+    if len(actual_evaluations) != len(expected):
+        return "evaluation_population_mismatch"
+    for (
+        evaluation_id,
+        metric,
+        version,
+        variant,
+        executor,
+        external_request_id,
+        status,
+        started_at,
+        finished_at,
+        error,
+    ) in actual_evaluations:
+        wanted = expected.get(metric)
+        if wanted is None:
+            return "unexpected_metric_evaluation"
+        if not live_owned and evaluation_id != plan.evaluation_id(metric):
+            return "backfill_evaluation_id_mismatch"
+        if (version, variant, executor, external_request_id, status, error) != (
+            "v1",
+            "default",
+            "coval_api",
+            None,
+            wanted[0],
+            wanted[2],
+        ):
+            return "evaluation_payload_mismatch"
+        if live_owned:
+            if (
+                started_at is None
+                or finished_at is None
+                or started_at < row.captured_at
+                or finished_at < started_at
+            ):
+                return "live_evaluation_timestamps_invalid"
+        elif started_at != row.captured_at or finished_at != row.captured_at:
+            return "backfill_evaluation_timestamps_mismatch"
+        cur.execute(
+            """SELECT value_key,unit,value,value_role
+               FROM benchmarks_v2.metric_values
+               WHERE metric_evaluation_id=%s ORDER BY value_key""",
+            (evaluation_id,),
+        )
+        values = cur.fetchall()
+        expected_values = (
+            [] if wanted[1] is None else [("primary", _METRICS[metric], wanted[1], "primary")]
+        )
+        if values != expected_values:
+            return "metric_value_payload_mismatch"
+    return None
+
+
+def _insert_plan(cur: psycopg.Cursor[Any], plan: Plan) -> tuple[int, int]:
+    row = plan.first
+    cur.execute(
+        """INSERT INTO benchmarks_v2.benchmark_observations
+           (id,run_id,dataset_id,dataset_sha256,sample_id,provider,model,voice,
+            benchmark,source_kind,captured_at,status,error,failure_origin)
+           VALUES (%s,%s,%s,%s,%s,%s,%s,%s,'S2S','conversation_audio',%s,%s,%s,%s)""",
+        (
+            plan.id,
+            row.run_id,
+            row.dataset_id,
+            plan.dataset_sha256,
+            row.sample_id,
+            row.provider,
+            row.model,
+            row.voice,
+            row.captured_at,
+            plan.status,
+            plan.error,
+            None if plan.status == "succeeded" else "provider",
+        ),
+    )
+    evaluations = 0
+    values = 0
+    for metric, status, value, error in plan.evaluations():
+        evaluation_id = plan.evaluation_id(metric)
+        cur.execute(
+            """INSERT INTO benchmarks_v2.metric_evaluations
+               (id,observation_id,metric_type,metric_version,evaluation_variant,executor,status)
+               VALUES (%s,%s,%s,'v1','default','coval_api','queued')""",
+            (evaluation_id, plan.id, metric),
+        )
+        cur.execute(
+            "UPDATE benchmarks_v2.metric_evaluations SET status='running',started_at=%s WHERE id=%s",
+            (row.captured_at, evaluation_id),
+        )
+        if value is not None:
+            cur.execute(
+                """INSERT INTO benchmarks_v2.metric_values
+                   (metric_evaluation_id,value_key,unit,value,value_role)
+                   VALUES (%s,'primary',%s,%s,'primary')""",
+                (evaluation_id, _METRICS[metric], value),
+            )
+            values += 1
+        cur.execute(
+            """UPDATE benchmarks_v2.metric_evaluations
+               SET status=%s,finished_at=%s,error=%s WHERE id=%s""",
+            (status, row.captured_at, error, evaluation_id),
+        )
+        evaluations += 1
+    return evaluations, values
+
+
+def _reconcile(cur: psycopg.Cursor[Any], plan: Plan, *, apply: bool) -> ReconcileResult:
+    cur.execute(
+        """SELECT id FROM benchmarks_v2.benchmark_observations
+           WHERE run_id=%s AND sample_id=%s AND provider=%s AND model=%s
+             AND voice IS NOT DISTINCT FROM %s""",
+        plan.natural,
+    )
+    found = cur.fetchone()
+    if found is None:
+        if not apply:
+            return ReconcileResult("eligible")
+        evaluations, values = _insert_plan(cur, plan)
+        return ReconcileResult("created", evaluations=evaluations, values=values)
+    observation_id = found[0]
+    live_owned = observation_id != plan.id
+    reason = _match_reason(cur, plan, observation_id, live_owned=live_owned)
+    if reason is not None:
+        return ReconcileResult("conflict", reason=reason)
+    return ReconcileResult("live_owned" if live_owned else "reconciled")
+
+
+def _merge_source_delta(report: dict[str, Any], delta: PageDelta) -> None:
+    for key in (
+        "eligible",
+        "created",
+        "reconciled",
+        "live_owned",
+        "evaluations",
+        "values",
+        "buckets",
+    ):
+        report[key] += getattr(delta, key)
+    report["conflicts_by_reason"].update(delta.conflicts)
+
+
+def _merge_verification_delta(report: dict[str, Any], delta: PageDelta) -> None:
+    report["verification_reconciled"] += delta.reconciled
+    report["verification_live_owned"] += delta.live_owned
+    report["verification_conflicts_by_reason"].update(delta.conflicts)
+
+
+_ROLLUP_PAYLOAD_SQL = """
+SELECT o.provider,o.model,o.benchmark,COALESCE(o.dataset_id,'__all__'),
+       e.metric_type,e.metric_version,e.evaluation_variant,v.value_key,v.unit,%(bucket)s,
+       MIN(v.value)::float8,
+       PERCENTILE_CONT(.25) WITHIN GROUP (ORDER BY v.value)::float8,
+       PERCENTILE_CONT(.5) WITHIN GROUP (ORDER BY v.value)::float8,
+       PERCENTILE_CONT(.75) WITHIN GROUP (ORDER BY v.value)::float8,
+       MAX(v.value)::float8,SUM(v.value)::float8,COUNT(*)::int
+FROM benchmarks_v2.metric_values v
+JOIN benchmarks_v2.metric_evaluations e ON e.id=v.metric_evaluation_id
+JOIN benchmarks_v2.benchmark_observations o ON o.id=e.observation_id
+JOIN benchmarks_v2.runs r ON r.id=o.run_id
+WHERE o.status='succeeded' AND e.status='succeeded'
+  AND r.status IN ('succeeded','partial') AND r.scheduled_at=%(bucket)s
+GROUP BY GROUPING SETS (
+  (o.provider,o.model,o.benchmark,o.dataset_id,e.metric_type,e.metric_version,
+   e.evaluation_variant,v.value_key,v.unit),
+  (o.provider,o.model,o.benchmark,e.metric_type,e.metric_version,
+   e.evaluation_variant,v.value_key,v.unit)
+)
+"""
+_STORED_ROLLUP_SQL = """
+SELECT provider,model,benchmark,dataset_id,metric_type,metric_version,
+       evaluation_variant,value_key,unit,bucket_at,min_value,p25,p50,p75,
+       max_value,value_sum,sample_count
+FROM benchmarks_v2.metric_values_by_bucket WHERE bucket_at=%(bucket)s
+"""
+
+
+def _refresh(cur: psycopg.Cursor[Any], bucket: datetime) -> None:
+    params = {"bucket": bucket}
+    cur.execute(
+        "SELECT pg_advisory_xact_lock(hashtextextended('metric_values_by_bucket',extract(epoch FROM %(bucket)s::timestamptz)::bigint))",
+        params,
+    )
+    cur.execute(
+        "DELETE FROM benchmarks_v2.metric_values_by_bucket WHERE bucket_at=%(bucket)s", params
+    )
+    cur.execute(
+        """INSERT INTO benchmarks_v2.metric_values_by_bucket
+           (provider,model,benchmark,dataset_id,metric_type,metric_version,evaluation_variant,
+            value_key,unit,bucket_at,min_value,p25,p50,p75,max_value,value_sum,sample_count)
+        """
+        + _ROLLUP_PAYLOAD_SQL,
+        params,
+    )
+
+
+_BUCKET_PAGE_SQL = """
+SELECT n.scheduled_at
+FROM benchmarks_v2.runs n
+WHERE n.status IN ('succeeded','partial','failed') AND n.scheduled_at IS NOT NULL
+  AND EXISTS (
+    SELECT 1 FROM benchmarks_v2.results r
+    WHERE r.run_id=n.id AND r.id BETWEEN %s AND %s AND r.benchmark='S2S'
+  )
+  AND NOT EXISTS (
+    SELECT 1 FROM benchmarks_v2.results r
+    WHERE r.run_id=n.id AND (r.id < %s OR r.id > %s)
+  )
+  AND (%s::timestamptz IS NULL OR n.scheduled_at > %s)
+GROUP BY n.scheduled_at ORDER BY n.scheduled_at LIMIT %s
+"""
+
+
+def _scheduled_bucket_pages(
+    conn: psycopg.Connection, low: int, high: int, batch_size: int
+) -> Iterable[list[datetime]]:
+    after: datetime | None = None
+    while True:
+        with conn.transaction(), conn.cursor() as cur:
+            cur.execute("SET TRANSACTION READ ONLY")
+            cur.execute(_BUCKET_PAGE_SQL, (low, high, low, high, after, after, batch_size))
+            page = [row[0] for row in cur.fetchall()]
+        if not page:
+            return
+        yield page
+        after = page[-1]
+
+
+def _verify_rollup_bucket(
+    cur: psycopg.Cursor[Any], bucket: datetime, report: dict[str, Any]
+) -> None:
+    params = {"bucket": bucket}
+    cur.execute(_ROLLUP_PAYLOAD_SQL, params)
+    expected = Counter(tuple(row) for row in cur.fetchall())
+    cur.execute(_STORED_ROLLUP_SQL, params)
+    actual = Counter(tuple(row) for row in cur.fetchall())
+    for item in sorted(set(expected) | set(actual), key=repr):
+        if expected[item] == actual[item]:
+            continue
+        _append_mismatch(
+            report,
+            "rollup_mismatches",
+            {
+                "bucket_at": bucket.isoformat(),
+                "payload": list(item),
+                "expected_count": expected[item],
+                "actual_count": actual[item],
+            },
+            count=abs(expected[item] - actual[item]),
+        )
+
+
+def _verify_population(
+    cur: psycopg.Cursor[Any], plans: list[Plan], run_ids: list[int], report: dict[str, Any]
+) -> None:
+    expected = Counter(plan.population_key for plan in plans)
+    cur.execute(
+        """SELECT run_id,sample_id,provider,model,voice,dataset_id
+           FROM benchmarks_v2.benchmark_observations
+           WHERE run_id=ANY(%s) AND benchmark='S2S'""",
+        (run_ids,),
+    )
+    actual = Counter(tuple(row) for row in cur.fetchall())
+    _record_counter_diff(report, "observation_population_mismatches", expected, actual)
+
+
+_PUBLIC_PARITY_SQL = """
+WITH cohort AS (
+  SELECT n.id
+  FROM benchmarks_v2.runs n
+  WHERE n.status IN ('succeeded','partial','failed')
+    AND EXISTS (
+      SELECT 1 FROM benchmarks_v2.results r
+      WHERE r.run_id=n.id AND r.id BETWEEN %(low)s AND %(high)s AND r.benchmark='S2S'
+    )
+    AND NOT EXISTS (
+      SELECT 1 FROM benchmarks_v2.results r
+      WHERE r.run_id=n.id AND (r.id < %(low)s OR r.id > %(high)s)
+    )
+), legacy AS (
+  SELECT jsonb_build_array(r.run_id,r.audio_filename,r.provider,r.model,r.voice,n.dataset_id,
+                           r.metric_type,r.metric_units,r.metric_value) AS identity,
+         count(*)::int AS row_count
+  FROM benchmarks_v2.results r
+  JOIN benchmarks_v2.runs n ON n.id=r.run_id
+  JOIN cohort c ON c.id=r.run_id
+  WHERE r.id BETWEEN %(low)s AND %(high)s AND r.benchmark='S2S'
+    AND r.status='success' AND r.metric_value IS NOT NULL
+    AND n.status IN ('succeeded','partial')
+  GROUP BY r.run_id,r.audio_filename,r.provider,r.model,r.voice,n.dataset_id,
+           r.metric_type,r.metric_units,r.metric_value
+), normalized AS (
+  SELECT jsonb_build_array(o.run_id,o.sample_id,o.provider,o.model,o.voice,o.dataset_id,
+                           e.metric_type,v.unit,v.value) AS identity,
+         count(*)::int AS row_count
+  FROM benchmarks_v2.benchmark_observations o
+  JOIN cohort c ON c.id=o.run_id
+  JOIN benchmarks_v2.runs n ON n.id=o.run_id
+  JOIN benchmarks_v2.metric_evaluations e ON e.observation_id=o.id
+  JOIN benchmarks_v2.metric_values v ON v.metric_evaluation_id=e.id
+  WHERE o.benchmark='S2S' AND o.status='succeeded' AND e.status='succeeded'
+    AND e.metric_version='v1' AND e.evaluation_variant='default'
+    AND v.value_key='primary' AND v.value_role='primary'
+    AND n.status IN ('succeeded','partial')
+  GROUP BY o.run_id,o.sample_id,o.provider,o.model,o.voice,o.dataset_id,
+           e.metric_type,v.unit,v.value
+)
+SELECT COALESCE(l.identity,n.identity),COALESCE(l.row_count,0),COALESCE(n.row_count,0)
+FROM legacy l FULL OUTER JOIN normalized n ON l.identity=n.identity
+WHERE COALESCE(l.row_count,0) <> COALESCE(n.row_count,0)
+ORDER BY 1
+"""
+
+
+def _verify_public_parity(
+    conn: psycopg.Connection, low: int, high: int, report: dict[str, Any]
+) -> None:
+    with conn.transaction(), conn.cursor() as cur:
+        cur.execute("SET TRANSACTION READ ONLY")
+        cur.execute(_PUBLIC_PARITY_SQL, {"low": low, "high": high})
+        while rows := cur.fetchmany(100):
+            for row in rows:
+                identity = row[0]
+                legacy_count = int(row[1])
+                normalized_count = int(row[2])
+                _append_mismatch(
+                    report,
+                    "public_parity_mismatches",
+                    {
+                        "identity": identity,
+                        "legacy_count": legacy_count,
+                        "normalized_count": normalized_count,
+                    },
+                    count=abs(legacy_count - normalized_count),
+                )
+
+
+def _finalize_report(report: dict[str, Any], *, apply: bool) -> None:
+    source_skips = _counter_total(report["skipped_by_reason"])
+    verification_skips = _counter_total(report["verification_skipped_by_reason"])
+    source_conflicts = _counter_total(report["conflicts_by_reason"])
+    verification_conflicts = _counter_total(report["verification_conflicts_by_reason"])
+    mismatches = sum(int(report[key]) for key in _MISMATCH_KEYS.values())
+    report["skip_count"] = source_skips + verification_skips
+    report["conflict_count"] = source_conflicts + verification_conflicts
+    report["mismatch_count"] = mismatches
+    report["backfill_complete"] = (
+        report["skip_count"] == 0
+        and report["conflict_count"] == 0
+        and mismatches == 0
+        and (apply or report["eligible"] == 0)
+    )
+    for key in (
+        "skipped_by_reason",
+        "conflicts_by_reason",
+        "verification_skipped_by_reason",
+        "verification_conflicts_by_reason",
+    ):
+        report[key] = {reason: count for reason, count in report[key].items() if count}
+
+
+def backfill(
+    conn: psycopg.Connection,
+    *,
+    min_result_id: int,
+    max_result_id: int,
+    batch_size: int = 100,
+    apply: bool = False,
+    reporter: ProgressReporter | None = None,
+) -> dict[str, Any]:
+    if min_result_id < 1 or max_result_id < min_result_id or batch_size < 1:
+        raise ValueError("invalid id range or batch size")
+    report = _report(min_result_id, max_result_id, batch_size)
+    progress = reporter or ProgressReporter(
+        "apply" if apply else "dry_run", min_result_id, max_result_id, batch_size
+    )
+    phase = "operation"
+    lock_acquired = False
+    progress.phase_started(phase, report)
+    try:
+        phase = "qualifying_run_count"
+        progress.phase_started(phase, report)
+        progress.total_runs = _qualifying_run_count(conn, min_result_id, max_result_id)
+        progress.phase_completed(phase, report)
+        if apply:
+            with conn.cursor() as cur:
+                cur.execute("SELECT pg_advisory_lock(hashtextextended(%s,0))", (_LOCK,))
+            conn.commit()
+            lock_acquired = True
+
+        phase = "source_reconciliation"
+        progress.phase_started(phase, report, total_runs=progress.total_runs)
+        after = 0
+        while True:
+            page_skips: Counter[str] = Counter()
+            run_ids, rows, complete = _read_complete_page(
+                conn,
+                min_result_id,
+                max_result_id,
+                after,
+                batch_size,
+                page_skips,
+            )
+            if not run_ids:
+                break
+            after = run_ids[-1]
+            page_conflicts: Counter[str] = Counter()
+            plans = _plans(complete, page_skips, page_conflicts)
+            missing_schedule = [plan for plan in plans if plan.first.scheduled_at is None]
+            page_skips["scheduled_at_missing"] += len(missing_schedule)
+            plans = [plan for plan in plans if plan.first.scheduled_at is not None]
+            report["source_rows"] += len(rows)
+            report["source_runs"] += len(run_ids)
+            report["source_groups"] += len(plans)
+            report["source_pages"] += 1
+            report["skipped_by_reason"].update(page_skips)
+            report["conflicts_by_reason"].update(page_conflicts)
+            delta = PageDelta()
+            if apply:
+                with conn.transaction(), conn.cursor() as cur:
+                    for plan in plans:
+                        delta.record(_reconcile(cur, plan, apply=True))
+                    for bucket in sorted(
+                        {plan.first.scheduled_at for plan in plans if plan.first.scheduled_at}
+                    ):
+                        _refresh(cur, bucket)
+                        delta.buckets += 1
+                _merge_source_delta(report, delta)
+            else:
+                with conn.transaction(), conn.cursor() as cur:
+                    cur.execute("SET TRANSACTION READ ONLY")
+                    for plan in plans:
+                        delta.record(_reconcile(cur, plan, apply=False))
+                _merge_source_delta(report, delta)
+            progress.completed_page(
+                run_ids,
+                rows,
+                len(plans),
+                report,
+                phase=phase,
+                committed=apply,
+            )
+        progress.phase_completed(phase, report)
+
+        phase = "post_write_verification"
+        progress.phase_started(phase, report, total_runs=progress.total_runs)
+        after = 0
+        while True:
+            page_skips = Counter()
+            run_ids, rows, complete = _read_complete_page(
+                conn,
+                min_result_id,
+                max_result_id,
+                after,
+                batch_size,
+                page_skips,
+            )
+            if not run_ids:
+                break
+            after = run_ids[-1]
+            page_conflicts = Counter()
+            plans = _plans(complete, page_skips, page_conflicts)
+            missing_schedule = [plan for plan in plans if plan.first.scheduled_at is None]
+            page_skips["scheduled_at_missing"] += len(missing_schedule)
+            plans = [plan for plan in plans if plan.first.scheduled_at is not None]
+            report["verification_rows"] += len(rows)
+            report["verification_runs"] += len(run_ids)
+            report["verification_groups"] += len(plans)
+            report["verification_pages"] += 1
+            report["verification_skipped_by_reason"].update(page_skips)
+            report["verification_conflicts_by_reason"].update(page_conflicts)
+            delta = PageDelta()
+            with conn.transaction(), conn.cursor() as cur:
+                cur.execute("SET TRANSACTION READ ONLY")
+                for plan in plans:
+                    result = _reconcile(cur, plan, apply=False)
+                    delta.record(result)
+                    if result.disposition in ("eligible", "conflict"):
+                        _append_mismatch(
+                            report,
+                            "payload_mismatches",
+                            {
+                                "natural_key": list(plan.natural),
+                                "reason": result.reason or "observation_missing",
+                            },
+                        )
+                complete_run_ids = sorted({row.run_id for row in complete})
+                if complete_run_ids:
+                    _verify_population(cur, plans, complete_run_ids, report)
+            _merge_verification_delta(report, delta)
+            progress.completed_page(run_ids, rows, len(plans), report, phase=phase)
+        progress.phase_completed(phase, report)
+
+        phase = "public_parity"
+        progress.phase_started(phase, report)
+        _verify_public_parity(conn, min_result_id, max_result_id, report)
+        progress.completed_unit(report, phase=phase)
+        progress.phase_completed(phase, report)
+
+        phase = "rollup_verification"
+        progress.phase_started(phase, report)
+        for buckets in _scheduled_bucket_pages(conn, min_result_id, max_result_id, batch_size):
+            with conn.transaction(), conn.cursor() as cur:
+                cur.execute("SET TRANSACTION READ ONLY")
+                for bucket in buckets:
+                    _verify_rollup_bucket(cur, bucket, report)
+                    progress.completed_unit(report, phase=phase)
+        progress.phase_completed(phase, report)
+
+        _finalize_report(report, apply=apply)
+        progress.phase_completed("operation", report)
+        return report
+    except BaseException:
+        status = "cancelled" if isinstance(sys.exception(), _Cancelled) else "failed"
+        progress.emit(phase, status, report)
+        progress.emit("operation", status, report)
+        raise
+    finally:
+        if lock_acquired:
+            conn.rollback()
+            with conn.cursor() as cur:
+                cur.execute("SELECT pg_advisory_unlock(hashtextextended(%s,0))", (_LOCK,))
+            conn.commit()
+
+
+@click.command(name="backfill-normalized-s2s-storage")
+@click.option("--min-result-id", type=click.IntRange(1), default=1, show_default=True)
+@click.option("--max-result-id", type=click.IntRange(1))
+@click.option("--batch-size", type=click.IntRange(1), default=100, show_default=True)
+@click.option("--apply", is_flag=True, help="Write immutable normalized rows.")
+def backfill_normalized_s2s_storage_cli(
+    min_result_id: int, max_result_id: int | None, batch_size: int, apply: bool
+) -> None:
+    """Reconcile a frozen inclusive legacy S2S result window."""
+    if apply and max_result_id is None:
+        raise click.UsageError("--apply requires an explicit --max-result-id")
+    url = str(get_settings().database_url)
+    if url == "postgresql://unused:unused@127.0.0.1:5432/unused":
+        raise click.ClickException(
+            "DATABASE_URL is required for this production migration; set a non-local production URL"
+        )
+    with _sigterm(), psycopg.connect(url) as conn:
+        if max_result_id is None:
+            with conn.transaction(), conn.cursor() as cur:
+                cur.execute("SET TRANSACTION READ ONLY")
+                cur.execute(
+                    "SELECT COALESCE(max(id),0) FROM benchmarks_v2.results WHERE benchmark='S2S'"
+                )
+                row = cur.fetchone()
+                if row is None:
+                    raise RuntimeError("S2S max result query returned no row")
+                max_result_id = int(row[0])
+        if max_result_id < min_result_id:
+            raise click.UsageError("--max-result-id must be >= --min-result-id")
+        report = backfill(
+            conn,
+            min_result_id=min_result_id,
+            max_result_id=max_result_id,
+            batch_size=batch_size,
+            apply=apply,
+        )
+    click.echo(json.dumps(report, sort_keys=True, default=str))
+    if apply and not report["backfill_complete"]:
+        raise click.ClickException("backfill incomplete or conflicting")

--- a/runner/tests/unit/test_normalized_s2s_storage_backfill.py
+++ b/runner/tests/unit/test_normalized_s2s_storage_backfill.py
@@ -1,0 +1,719 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+"""Safety and real-Postgres coverage for the normalized S2S backfill."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import io
+import json
+import os
+import uuid
+from collections import Counter
+from dataclasses import replace
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import psycopg
+import pytest
+from click.testing import CliRunner
+from pytest_postgresql.factories import postgresql
+
+from coval_bench.migrations import backfill_normalized_s2s_storage as migration
+from coval_bench.migrations.backfill_normalized_s2s_storage import (
+    LegacyS2SRow,
+    ProgressReporter,
+    _plans,
+    backfill,
+    backfill_normalized_s2s_storage_cli,
+)
+from scripts import benchmark_normalized_s2s_backfill as benchmark
+
+from .conftest import apply_migrations
+
+s2s_pg = postgresql("pg_proc")
+_NOW = datetime(2026, 8, 27, 10, 0, tzinfo=UTC)
+_SHA = "a" * 64
+_UNNORMALIZED_PROVENANCE = "persona/test-set-v1"
+
+
+def _dsn(conn: psycopg.Connection[Any]) -> str:
+    info = conn.info
+    auth = f"{info.user}:{info.password}@" if info.password else f"{info.user}@"
+    return (
+        f"postgresql://{auth}{info.host or 'localhost'}:{info.port or 5432}/{info.dbname or 'test'}"
+    )
+
+
+def _truncate(conn: psycopg.Connection[Any]) -> None:
+    with conn.cursor() as cur:
+        cur.execute(
+            "TRUNCATE benchmarks_v2.runs, benchmarks_v2.metric_values_by_bucket "
+            "RESTART IDENTITY CASCADE"
+        )
+    conn.commit()
+
+
+@pytest.fixture
+def s2s_db(request: pytest.FixtureRequest) -> Any:
+    external_url = os.environ.get("S2S_BACKFILL_TEST_DATABASE_URL")
+    if external_url:
+        conn = psycopg.connect(external_url)
+        _truncate(conn)
+        try:
+            yield conn
+        finally:
+            _truncate(conn)
+            conn.close()
+        return
+    conn = request.getfixturevalue("s2s_pg")
+    apply_migrations(conn)
+    yield conn
+
+
+def _row(
+    metric: str,
+    *,
+    value: float | None = 1.0,
+    status: str = "success",
+    error: str | None = None,
+    row_id: int = 1,
+    run_id: int = 4,
+    sample_id: str | None = "coval-run/simulation",
+    dataset_id: str = "s2s-v1",
+    dataset_sha256: str = _UNNORMALIZED_PROVENANCE,
+    scheduled_at: datetime | None = _NOW,
+    captured_at: datetime = _NOW,
+) -> LegacyS2SRow:
+    return LegacyS2SRow(
+        row_id,
+        run_id,
+        dataset_id,
+        dataset_sha256,
+        scheduled_at,
+        "provider",
+        "model",
+        "voice",
+        metric,
+        value,
+        {
+            "V2V": "milliseconds",
+            "InstructionFollowing": "percent",
+            "InterruptionRate": "per_minute",
+        }[metric],
+        sample_id,
+        status,
+        error,
+        captured_at,
+    )
+
+
+def _insert_run(
+    conn: psycopg.Connection[Any],
+    *,
+    status: str = "succeeded",
+    scheduled_at: datetime | None = _NOW,
+    dataset_id: str = "persona-v1",
+    dataset_sha256: str = _UNNORMALIZED_PROVENANCE,
+) -> int:
+    with conn.cursor() as cur:
+        cur.execute(
+            """INSERT INTO benchmarks_v2.runs
+               (started_at,finished_at,runner_sha,dataset_id,dataset_sha256,status,scheduled_at)
+               VALUES (%s,%s,'runner-sha',%s,%s,%s,%s) RETURNING id""",
+            (
+                _NOW,
+                None if status == "running" else _NOW + timedelta(minutes=1),
+                dataset_id,
+                dataset_sha256,
+                status,
+                scheduled_at,
+            ),
+        )
+        row = cur.fetchone()
+        assert row is not None
+    conn.commit()
+    return int(row[0])
+
+
+def _insert_result(
+    conn: psycopg.Connection[Any],
+    run_id: int,
+    metric: str,
+    *,
+    value: float | None = 1.0,
+    status: str = "success",
+    error: str | None = None,
+    sample_id: str = "coval-run/simulation",
+    provider: str = "provider",
+    model: str = "model",
+    voice: str | None = "voice",
+) -> int:
+    unit = {
+        "V2V": "milliseconds",
+        "InstructionFollowing": "percent",
+        "InterruptionRate": "per_minute",
+    }[metric]
+    with conn.cursor() as cur:
+        cur.execute(
+            """INSERT INTO benchmarks_v2.results
+               (run_id,provider,model,voice,benchmark,metric_type,metric_value,metric_units,
+                audio_filename,status,error,created_at)
+               VALUES (%s,%s,%s,%s,'S2S',%s,%s,%s,%s,%s,%s,%s) RETURNING id""",
+            (
+                run_id,
+                provider,
+                model,
+                voice,
+                metric,
+                value,
+                unit,
+                sample_id,
+                status,
+                error,
+                _NOW + timedelta(seconds=30),
+            ),
+        )
+        row = cur.fetchone()
+        assert row is not None
+    conn.commit()
+    return int(row[0])
+
+
+def _seed_conversation(
+    conn: psycopg.Connection[Any],
+    *,
+    run_status: str = "succeeded",
+    scheduled_at: datetime | None = _NOW,
+    sample_id: str = "coval-run/simulation",
+    metrics: tuple[tuple[str, float | None, str], ...] = (
+        ("V2V", 210.0, "success"),
+        ("InstructionFollowing", 91.0, "success"),
+        ("InterruptionRate", None, "failed"),
+    ),
+) -> tuple[int, int, int]:
+    run_id = _insert_run(conn, status=run_status, scheduled_at=scheduled_at)
+    ids = [
+        _insert_result(
+            conn,
+            run_id,
+            metric,
+            value=value,
+            status=status,
+            sample_id=sample_id,
+        )
+        for metric, value, status in metrics
+    ]
+    return run_id, min(ids), max(ids)
+
+
+def _events(stream: io.StringIO) -> list[dict[str, Any]]:
+    return [json.loads(line) for line in stream.getvalue().splitlines()]
+
+
+class _Clock:
+    def __init__(self) -> None:
+        self.value = 0.0
+
+    def __call__(self) -> float:
+        return self.value
+
+
+def test_groups_mixed_metrics_and_preserves_exact_recoverable_payload() -> None:
+    skipped: Counter[str] = Counter()
+    conflicts: Counter[str] = Counter()
+    plans = _plans(
+        [
+            _row("V2V"),
+            _row("InstructionFollowing"),
+            _row("InterruptionRate", value=None, status="failed", error=" exact error "),
+        ],
+        skipped,
+        conflicts,
+    )
+
+    assert len(plans) == 1
+    assert plans[0].status == "succeeded"
+    assert plans[0].error is None
+    assert plans[0].dataset_sha256 == hashlib.sha256(_UNNORMALIZED_PROVENANCE.encode()).hexdigest()
+    assert plans[0].evaluations()[-1] == (
+        "V2V",
+        "succeeded",
+        1.0,
+        None,
+    )
+    assert (
+        next(item for item in plans[0].evaluations() if item[0] == "InterruptionRate")[3]
+        == " exact error "
+    )
+    assert skipped == {}
+    assert conflicts == {}
+
+
+def test_all_failed_uses_canonical_fallbacks() -> None:
+    plans = _plans([_row("V2V", value=None, status="failed")], Counter(), Counter())
+    assert plans[0].status == "failed"
+    assert plans[0].error == "Coval conversation produced no successful metric value"
+    assert plans[0].evaluations()[0][3] == "legacy metric produced no value"
+
+
+def test_duplicate_metrics_and_conflicting_groups_fail_closed() -> None:
+    skipped: Counter[str] = Counter()
+    conflicts: Counter[str] = Counter()
+    assert _plans([_row("V2V"), _row("V2V", row_id=2)], skipped, conflicts) == []
+    assert conflicts == {"conflicting_group": 1}
+
+    conflicts.clear()
+    rows = [_row("V2V"), replace(_row("InstructionFollowing", row_id=2), dataset_id="other")]
+    assert _plans(rows, skipped, conflicts) == []
+    assert conflicts == {"conflicting_group": 1}
+
+
+def test_progress_cadence_throughput_eta_and_durable_checkpoint() -> None:
+    clock = _Clock()
+    stream = io.StringIO()
+    report = migration._report(1, 99, 1)
+    reporter = ProgressReporter(
+        "apply", 1, 99, 1, stream=stream, monotonic=clock, interval_seconds=30, max_units=10
+    )
+    reporter.total_runs = 4
+    reporter.phase_started("source_reconciliation", report, total_runs=4)
+    clock.value = 31
+    row = _row("V2V", row_id=9, run_id=7, sample_id="private/sample")
+    reporter.completed_page([7], [row], 1, report, phase="source_reconciliation", committed=True)
+
+    event = _events(stream)[-1]
+    assert event["status"] == "progress"
+    assert event["last_committed_run_id"] == 7
+    assert event["last_committed_result_id"] == 9
+    assert event["throughput_results_per_second"] == pytest.approx(1 / 31, rel=1e-5)
+    assert event["throughput_conversations_per_second"] == pytest.approx(1 / 31, rel=1e-5)
+    assert event["eta_seconds"] == pytest.approx(93)
+    assert "private/sample" not in stream.getvalue()
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "postgresql://postgres@127.0.0.1/postgres?hostaddr=203.0.113.1",
+        "postgresql://postgres@127.0.0.1/postgres?dbname=production",
+        "postgresql://postgres@127.0.0.1/postgres?service=remote",
+        "postgresql://postgres@127.0.0.1/postgres#dbname=production",
+    ],
+)
+def test_benchmark_rejects_libpq_routing_and_database_overrides(url: str) -> None:
+    with pytest.raises(SystemExit):
+        benchmark._validate_local_url(argparse.ArgumentParser(), url)
+
+    benchmark._validate_local_url(
+        argparse.ArgumentParser(), "postgresql://postgres@127.0.0.1/postgres"
+    )
+
+
+def test_apply_reconciles_payload_lineage_rollups_and_is_idempotent(
+    s2s_db: psycopg.Connection[Any],
+) -> None:
+    successful_metrics = (
+        ("V2V", 210.0, "success"),
+        ("InstructionFollowing", 91.0, "success"),
+        ("InterruptionRate", 0.2, "success"),
+    )
+    _, low, _ = _seed_conversation(
+        s2s_db,
+        sample_id="coval-run-one/simulation",
+        metrics=successful_metrics,
+    )
+    _, _, high = _seed_conversation(
+        s2s_db,
+        sample_id="coval-run-two/simulation",
+        metrics=successful_metrics,
+    )
+    stream = io.StringIO()
+    first = backfill(
+        s2s_db,
+        min_result_id=low,
+        max_result_id=high,
+        batch_size=1,
+        apply=True,
+        reporter=ProgressReporter("apply", low, high, 1, stream=stream),
+    )
+
+    assert first["backfill_complete"] is True
+    assert (first["created"], first["evaluations"], first["values"]) == (2, 6, 6)
+    assert first["verification_reconciled"] == 2
+    assert first["public_parity_mismatch_count"] == 0
+    assert first["rollup_mismatch_count"] == 0
+    with s2s_db.cursor() as cur:
+        cur.execute("SELECT dataset_sha256 FROM benchmarks_v2.benchmark_observations")
+        assert cur.fetchone() == (hashlib.sha256(_UNNORMALIZED_PROVENANCE.encode()).hexdigest(),)
+        cur.execute(
+            """SELECT
+                 (SELECT count(*) FROM benchmarks_v2.observation_artifacts),
+                 (SELECT count(*) FROM benchmarks_v2.preprocessing_artifacts),
+                 (SELECT count(*) FROM benchmarks_v2.metric_evaluation_inputs),
+                 (SELECT count(*) FROM benchmarks_v2.metric_artifacts)"""
+        )
+        assert cur.fetchone() == (0, 0, 0, 0)
+        cur.execute("SELECT count(*) FROM benchmarks_v2.metric_values_by_bucket")
+        assert cur.fetchone() == (6,)
+    s2s_db.commit()
+
+    second = backfill(
+        s2s_db,
+        min_result_id=low,
+        max_result_id=high,
+        batch_size=1,
+        apply=True,
+        reporter=ProgressReporter("apply", low, high, 1, stream=io.StringIO()),
+    )
+    assert second["backfill_complete"] is True
+    assert second["created"] == 0
+    assert second["reconciled"] == 2
+    phases = {(event["phase"], event["status"]) for event in _events(stream)}
+    for phase in (
+        "operation",
+        "qualifying_run_count",
+        "source_reconciliation",
+        "post_write_verification",
+        "public_parity",
+        "rollup_verification",
+    ):
+        assert (phase, "started") in phases
+        assert (phase, "completed") in phases
+
+
+def test_entirely_failed_conversation_persists_canonical_errors(
+    s2s_db: psycopg.Connection[Any],
+) -> None:
+    _, low, high = _seed_conversation(
+        s2s_db,
+        sample_id="coval-run/entirely-failed",
+        metrics=(("V2V", None, "failed"),),
+    )
+    report = backfill(
+        s2s_db,
+        min_result_id=low,
+        max_result_id=high,
+        apply=True,
+        reporter=ProgressReporter("apply", low, high, 100, stream=io.StringIO()),
+    )
+    assert report["backfill_complete"] is True
+    with s2s_db.cursor() as cur:
+        cur.execute(
+            """SELECT o.error,e.error
+               FROM benchmarks_v2.benchmark_observations o
+               JOIN benchmarks_v2.metric_evaluations e ON e.observation_id=o.id"""
+        )
+        assert cur.fetchone() == (
+            "Coval conversation produced no successful metric value",
+            "legacy metric produced no value",
+        )
+    s2s_db.commit()
+
+
+def test_extra_failed_normalized_observation_blocks_completion(
+    s2s_db: psycopg.Connection[Any],
+) -> None:
+    run_id, low, high = _seed_conversation(s2s_db)
+    backfill(
+        s2s_db,
+        min_result_id=low,
+        max_result_id=high,
+        apply=True,
+        reporter=ProgressReporter("apply", low, high, 100, stream=io.StringIO()),
+    )
+    with s2s_db.cursor() as cur:
+        cur.execute(
+            """INSERT INTO benchmarks_v2.benchmark_observations
+               (id,run_id,dataset_id,dataset_sha256,sample_id,provider,model,voice,
+                benchmark,source_kind,captured_at,status,error,failure_origin)
+               VALUES (%s,%s,'persona-v1',%s,'unexpected/sample','provider','model','voice',
+                       'S2S','conversation_audio',%s,'failed','extra normalized row','provider')""",
+            (uuid.uuid4(), run_id, _SHA, _NOW),
+        )
+    s2s_db.commit()
+
+    report = backfill(
+        s2s_db,
+        min_result_id=low,
+        max_result_id=high,
+        apply=True,
+        reporter=ProgressReporter("apply", low, high, 100, stream=io.StringIO()),
+    )
+    assert report["backfill_complete"] is False
+    assert report["observation_population_mismatch_count"] == 1
+    assert report["observation_population_mismatches"][0]["expected_count"] == 0
+
+
+def test_rollup_tamper_is_detected_exactly_by_read_only_dry_run(
+    s2s_db: psycopg.Connection[Any],
+) -> None:
+    _, low, high = _seed_conversation(s2s_db, metrics=(("V2V", 210.0, "success"),))
+    backfill(
+        s2s_db,
+        min_result_id=low,
+        max_result_id=high,
+        apply=True,
+        reporter=ProgressReporter("apply", low, high, 100, stream=io.StringIO()),
+    )
+    with s2s_db.cursor() as cur:
+        cur.execute("UPDATE benchmarks_v2.metric_values_by_bucket SET value_sum=value_sum+0.000001")
+    s2s_db.commit()
+
+    report = backfill(
+        s2s_db,
+        min_result_id=low,
+        max_result_id=high,
+        apply=False,
+        reporter=ProgressReporter("dry_run", low, high, 100, stream=io.StringIO()),
+    )
+    assert report["eligible"] == 0
+    assert report["backfill_complete"] is False
+    assert report["rollup_mismatch_count"] == 4
+
+
+def _insert_live_owned(
+    conn: psycopg.Connection[Any],
+    run_id: int,
+    *,
+    dataset_id: str = "persona-v1",
+) -> uuid.UUID:
+    observation_id = uuid.uuid4()
+    evaluation_id = uuid.uuid4()
+    normalized_sha = hashlib.sha256(_UNNORMALIZED_PROVENANCE.encode()).hexdigest()
+    with conn.cursor() as cur:
+        cur.execute(
+            """INSERT INTO benchmarks_v2.benchmark_observations
+               (id,run_id,dataset_id,dataset_sha256,sample_id,provider,model,voice,
+                benchmark,source_kind,captured_at,status)
+               VALUES (%s,%s,%s,%s,'coval-run/simulation','provider','model','voice',
+                       'S2S','conversation_audio',%s,'succeeded')""",
+            (observation_id, run_id, dataset_id, normalized_sha, _NOW + timedelta(seconds=30)),
+        )
+        cur.execute(
+            """INSERT INTO benchmarks_v2.metric_evaluations
+               (id,observation_id,metric_type,metric_version,evaluation_variant,executor,status)
+               VALUES (%s,%s,'V2V','v1','default','coval_api','queued')""",
+            (evaluation_id, observation_id),
+        )
+        cur.execute(
+            "UPDATE benchmarks_v2.metric_evaluations "
+            "SET status='running',started_at=%s WHERE id=%s",
+            (_NOW + timedelta(seconds=31), evaluation_id),
+        )
+        cur.execute(
+            """INSERT INTO benchmarks_v2.metric_values
+               (metric_evaluation_id,value_key,unit,value,value_role)
+               VALUES (%s,'primary','milliseconds',210,'primary')""",
+            (evaluation_id,),
+        )
+        cur.execute(
+            """UPDATE benchmarks_v2.metric_evaluations
+               SET status='succeeded',finished_at=%s WHERE id=%s""",
+            (_NOW + timedelta(seconds=32), evaluation_id),
+        )
+    conn.commit()
+    return observation_id
+
+
+def test_exact_live_owned_random_ids_reconcile(
+    s2s_db: psycopg.Connection[Any],
+) -> None:
+    run_id, low, high = _seed_conversation(s2s_db, metrics=(("V2V", 210.0, "success"),))
+    observation_id = _insert_live_owned(s2s_db, run_id)
+
+    report = backfill(
+        s2s_db,
+        min_result_id=low,
+        max_result_id=high,
+        apply=True,
+        reporter=ProgressReporter("apply", low, high, 100, stream=io.StringIO()),
+    )
+    assert report["backfill_complete"] is True
+    assert report["created"] == 0
+    assert report["live_owned"] == 1
+    assert report["verification_live_owned"] == 1
+    with s2s_db.cursor() as cur:
+        cur.execute("SELECT id FROM benchmarks_v2.benchmark_observations")
+        assert cur.fetchone() == (observation_id,)
+    s2s_db.commit()
+
+
+def test_conflicting_live_owned_payload_blocks_completion(
+    s2s_db: psycopg.Connection[Any],
+) -> None:
+    run_id, low, high = _seed_conversation(s2s_db, metrics=(("V2V", 210.0, "success"),))
+    _insert_live_owned(s2s_db, run_id, dataset_id="wrong-persona")
+
+    report = backfill(
+        s2s_db,
+        min_result_id=low,
+        max_result_id=high,
+        apply=True,
+        reporter=ProgressReporter("apply", low, high, 100, stream=io.StringIO()),
+    )
+    assert report["backfill_complete"] is False
+    assert report["conflicts_by_reason"] == {"observation_payload_mismatch": 1}
+    assert report["verification_conflicts_by_reason"] == {"observation_payload_mismatch": 1}
+    assert report["payload_mismatch_count"] == 1
+
+
+def test_split_window_nonterminal_and_dry_run_no_dml(
+    s2s_db: psycopg.Connection[Any],
+) -> None:
+    split_run = _insert_run(s2s_db)
+    first = _insert_result(s2s_db, split_run, "V2V", value=10)
+    running_run = _insert_run(s2s_db, status="running")
+    last_in_window = _insert_result(s2s_db, running_run, "V2V", value=11)
+    _insert_result(s2s_db, split_run, "InstructionFollowing", value=90)
+
+    with s2s_db.cursor() as cur:
+        cur.execute("SELECT count(*) FROM benchmarks_v2.benchmark_observations")
+        before = cur.fetchone()
+    s2s_db.commit()
+    report = backfill(
+        s2s_db,
+        min_result_id=first,
+        max_result_id=last_in_window,
+        batch_size=1,
+        apply=False,
+        reporter=ProgressReporter("dry_run", first, last_in_window, 1, stream=io.StringIO()),
+    )
+    with s2s_db.cursor() as cur:
+        cur.execute("SELECT count(*) FROM benchmarks_v2.benchmark_observations")
+        after = cur.fetchone()
+    s2s_db.commit()
+
+    assert before == after == (0,)
+    assert report["backfill_complete"] is False
+    assert report["skipped_by_reason"]["split_window_run"] == 1
+    assert report["skipped_by_reason"]["run_not_terminal"] == 1
+    assert report["verification_skipped_by_reason"]["split_window_run"] == 1
+    assert report["verification_skipped_by_reason"]["run_not_terminal"] == 1
+
+
+def test_page_failure_rolls_back_only_current_page_and_rerun_resumes(
+    s2s_db: psycopg.Connection[Any], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    first_run, low, _ = _seed_conversation(
+        s2s_db,
+        scheduled_at=_NOW,
+        sample_id="run-one/sample",
+        metrics=(("V2V", 10.0, "success"),),
+    )
+    second_run, _, high = _seed_conversation(
+        s2s_db,
+        scheduled_at=_NOW + timedelta(days=1),
+        sample_id="run-two/sample",
+        metrics=(("V2V", 20.0, "success"),),
+    )
+    original_refresh = migration._refresh
+    stream = io.StringIO()
+
+    def fail_second(cur: psycopg.Cursor[Any], bucket: datetime) -> None:
+        if bucket == _NOW + timedelta(days=1):
+            raise RuntimeError("forced second-page failure")
+        original_refresh(cur, bucket)
+
+    monkeypatch.setattr(migration, "_refresh", fail_second)
+    with pytest.raises(RuntimeError, match="second-page"):
+        backfill(
+            s2s_db,
+            min_result_id=low,
+            max_result_id=high,
+            batch_size=1,
+            apply=True,
+            reporter=ProgressReporter("apply", low, high, 1, stream=stream),
+        )
+    with s2s_db.cursor() as cur:
+        cur.execute(
+            "SELECT run_id,count(*) FROM benchmarks_v2.benchmark_observations GROUP BY run_id"
+        )
+        assert cur.fetchall() == [(first_run, 1)]
+    s2s_db.commit()
+    failed = _events(stream)[-1]
+    assert failed["status"] == "failed"
+    assert failed["last_committed_run_id"] == first_run
+
+    monkeypatch.setattr(migration, "_refresh", original_refresh)
+    resumed = backfill(
+        s2s_db,
+        min_result_id=low,
+        max_result_id=high,
+        batch_size=1,
+        apply=True,
+        reporter=ProgressReporter("apply", low, high, 1, stream=io.StringIO()),
+    )
+    assert resumed["backfill_complete"] is True
+    assert resumed["created"] == 1
+    assert resumed["reconciled"] == 1
+    with s2s_db.cursor() as cur:
+        cur.execute("SELECT count(*) FROM benchmarks_v2.benchmark_observations")
+        assert cur.fetchone() == (2,)
+    s2s_db.commit()
+    assert second_run != first_run
+
+
+def test_cancellation_emits_checkpoint_and_releases_global_lock(
+    s2s_db: psycopg.Connection[Any], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    run_id, low, high = _seed_conversation(s2s_db, metrics=(("V2V", 10.0, "success"),))
+    stream = io.StringIO()
+    monkeypatch.setattr(
+        migration,
+        "_verify_public_parity",
+        lambda *_: (_ for _ in ()).throw(migration._Cancelled()),
+    )
+    with pytest.raises(migration._Cancelled):
+        backfill(
+            s2s_db,
+            min_result_id=low,
+            max_result_id=high,
+            apply=True,
+            reporter=ProgressReporter("apply", low, high, 1, stream=stream),
+        )
+    events = _events(stream)
+    assert events[-2]["phase"] == "public_parity"
+    assert events[-2]["status"] == "cancelled"
+    assert events[-1]["phase"] == "operation"
+    assert events[-1]["last_committed_run_id"] == run_id
+    with s2s_db.cursor() as cur:
+        cur.execute("SELECT pg_try_advisory_lock(hashtextextended(%s,0))", (migration._LOCK,))
+        assert cur.fetchone() == (True,)
+        cur.execute("SELECT pg_advisory_unlock(hashtextextended(%s,0))", (migration._LOCK,))
+    s2s_db.commit()
+
+
+def test_cli_requires_frozen_apply_and_keeps_final_report_on_stdout(
+    s2s_db: psycopg.Connection[Any], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _, low, high = _seed_conversation(s2s_db, metrics=(("V2V", 10.0, "success"),))
+
+    class Settings:
+        database_url = _dsn(s2s_db)
+
+    monkeypatch.setattr(migration, "get_settings", lambda: Settings())
+    missing_max = CliRunner().invoke(backfill_normalized_s2s_storage_cli, ["--apply"])
+    assert missing_max.exit_code == 2
+    assert "--apply requires an explicit --max-result-id" in missing_max.output
+
+    result = CliRunner().invoke(
+        backfill_normalized_s2s_storage_cli,
+        ["--min-result-id", str(low), "--max-result-id", str(high)],
+    )
+    assert result.exit_code == 0
+    assert "normalized_s2s_storage_backfill_progress" not in result.stdout
+    assert "normalized_s2s_storage_backfill_progress" in result.stderr
+    final = json.loads(result.stdout.splitlines()[-1])
+    assert final["window"]["max_result_id"] == high
+    assert final["backfill_complete"] is False
+
+    auto_frozen = CliRunner().invoke(
+        backfill_normalized_s2s_storage_cli,
+        ["--min-result-id", str(low)],
+    )
+    assert auto_frozen.exit_code == 0
+    auto_final = json.loads(auto_frozen.stdout.splitlines()[-1])
+    assert auto_final["window"]["max_result_id"] == high
+    assert auto_final["backfill_complete"] is False

--- a/runner/tests/unit/test_normalized_s2s_storage_backfill.py
+++ b/runner/tests/unit/test_normalized_s2s_storage_backfill.py
@@ -383,6 +383,90 @@ def test_apply_reconciles_payload_lineage_rollups_and_is_idempotent(
         assert (phase, "completed") in phases
 
 
+def test_public_parity_is_bounded_to_complete_run_pages(
+    s2s_db: psycopg.Connection[Any], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    run_ids: list[int] = []
+    low = 0
+    high = 0
+    for index in range(3):
+        run_id, first, last = _seed_conversation(
+            s2s_db,
+            sample_id=f"coval-run-{index}/simulation",
+            metrics=(("V2V", 210.0 + index, "success"),),
+        )
+        run_ids.append(run_id)
+        low = first if low == 0 else min(low, first)
+        high = max(high, last)
+    initial = backfill(
+        s2s_db,
+        min_result_id=low,
+        max_result_id=high,
+        batch_size=1,
+        apply=True,
+        reporter=ProgressReporter("apply", low, high, 1, stream=io.StringIO()),
+    )
+    assert initial["backfill_complete"] is True
+
+    original_verify = migration._verify_public_parity_page
+    verified_pages: list[list[int]] = []
+
+    def record_page(
+        cur: psycopg.Cursor[Any],
+        page_run_ids: list[int],
+        page_low: int,
+        page_high: int,
+        report: dict[str, Any],
+    ) -> None:
+        verified_pages.append(list(page_run_ids))
+        original_verify(cur, page_run_ids, page_low, page_high, report)
+
+    monkeypatch.setattr(migration, "_verify_public_parity_page", record_page)
+    _insert_live_owned(s2s_db, run_ids[-1], sample_id="normalized-only/sample")
+    report = backfill(
+        s2s_db,
+        min_result_id=low,
+        max_result_id=high,
+        batch_size=1,
+        apply=True,
+        reporter=ProgressReporter("apply", low, high, 1, stream=io.StringIO()),
+    )
+
+    assert verified_pages == [[run_id] for run_id in run_ids]
+    assert report["public_parity_mismatch_count"] == 1
+    assert report["public_parity_mismatches"][0]["legacy_count"] == 0
+    assert report["public_parity_mismatches"][0]["normalized_count"] == 1
+    assert report["backfill_complete"] is False
+
+
+def test_public_parity_sets_transaction_local_timeout_before_page_query() -> None:
+    class RecordingCursor:
+        def __init__(self) -> None:
+            self.calls: list[tuple[str, object]] = []
+
+        def execute(self, query: str, params: object = None) -> None:
+            self.calls.append((query, params))
+
+        def fetchall(self) -> list[tuple[Any, ...]]:
+            return []
+
+    cursor = RecordingCursor()
+    report = migration._report(11, 29, 1)
+    migration._verify_public_parity_page(cursor, [17], 11, 29, report)  # type: ignore[arg-type]
+
+    assert cursor.calls == [
+        (
+            "SELECT set_config('statement_timeout', %s, true)",
+            (migration._PUBLIC_PARITY_STATEMENT_TIMEOUT,),
+        ),
+        (
+            migration._PUBLIC_PARITY_PAGE_SQL,
+            {"run_ids": [17], "low": 11, "high": 29},
+        ),
+    ]
+    assert migration._PUBLIC_PARITY_STATEMENT_TIMEOUT == "30s"
+
+
 def test_entirely_failed_conversation_persists_canonical_errors(
     s2s_db: psycopg.Connection[Any],
 ) -> None:
@@ -473,11 +557,90 @@ def test_rollup_tamper_is_detected_exactly_by_read_only_dry_run(
     assert report["rollup_mismatch_count"] == 4
 
 
+def test_s2s_refresh_preserves_and_ignores_same_bucket_non_s2s_rollups(
+    s2s_db: psycopg.Connection[Any],
+) -> None:
+    _, low, high = _seed_conversation(s2s_db, metrics=(("V2V", 210.0, "success"),))
+    with s2s_db.cursor() as cur:
+        cur.execute(
+            """INSERT INTO benchmarks_v2.metric_values_by_bucket
+                (provider,model,benchmark,dataset_id,metric_type,metric_version,
+                 evaluation_variant,value_key,unit,bucket_at,min_value,p25,p50,p75,
+                 max_value,value_sum,sample_count)
+                VALUES
+                ('stt-provider','stt-model','STT','stt-dataset','WER','v7','custom',
+                 'primary','percent',%s,11,12,13,14,15,123,7),
+                ('tts-provider','tts-model','TTS','__all__','MOS','v9','custom',
+                 'primary','score',%s,21,22,23,24,25,456,8)""",
+            (_NOW, _NOW),
+        )
+        cur.execute(
+            """SELECT provider,model,benchmark,dataset_id,metric_type,metric_version,
+                       evaluation_variant,value_key,unit,bucket_at,min_value,p25,p50,p75,
+                       max_value,value_sum,sample_count
+                FROM benchmarks_v2.metric_values_by_bucket
+                WHERE benchmark <> 'S2S' ORDER BY benchmark"""
+        )
+        before = cur.fetchall()
+    s2s_db.commit()
+
+    applied = backfill(
+        s2s_db,
+        min_result_id=low,
+        max_result_id=high,
+        apply=True,
+        reporter=ProgressReporter("apply", low, high, 100, stream=io.StringIO()),
+    )
+    assert applied["backfill_complete"] is True
+    assert applied["rollup_mismatch_count"] == 0
+    with s2s_db.cursor() as cur:
+        cur.execute(
+            """SELECT provider,model,benchmark,dataset_id,metric_type,metric_version,
+                       evaluation_variant,value_key,unit,bucket_at,min_value,p25,p50,p75,
+                       max_value,value_sum,sample_count
+                FROM benchmarks_v2.metric_values_by_bucket
+                WHERE benchmark <> 'S2S' ORDER BY benchmark"""
+        )
+        assert cur.fetchall() == before
+        cur.execute(
+            "UPDATE benchmarks_v2.metric_values_by_bucket "
+            "SET value_sum=value_sum+1 WHERE benchmark='STT'"
+        )
+    s2s_db.commit()
+
+    non_s2s_tamper = backfill(
+        s2s_db,
+        min_result_id=low,
+        max_result_id=high,
+        apply=False,
+        reporter=ProgressReporter("dry_run", low, high, 100, stream=io.StringIO()),
+    )
+    assert non_s2s_tamper["backfill_complete"] is True
+    assert non_s2s_tamper["rollup_mismatch_count"] == 0
+
+    with s2s_db.cursor() as cur:
+        cur.execute(
+            "UPDATE benchmarks_v2.metric_values_by_bucket "
+            "SET value_sum=value_sum+0.000001 WHERE benchmark='S2S'"
+        )
+    s2s_db.commit()
+    s2s_tamper = backfill(
+        s2s_db,
+        min_result_id=low,
+        max_result_id=high,
+        apply=False,
+        reporter=ProgressReporter("dry_run", low, high, 100, stream=io.StringIO()),
+    )
+    assert s2s_tamper["backfill_complete"] is False
+    assert s2s_tamper["rollup_mismatch_count"] == 4
+
+
 def _insert_live_owned(
     conn: psycopg.Connection[Any],
     run_id: int,
     *,
     dataset_id: str = "persona-v1",
+    sample_id: str = "coval-run/simulation",
 ) -> uuid.UUID:
     observation_id = uuid.uuid4()
     evaluation_id = uuid.uuid4()
@@ -487,9 +650,16 @@ def _insert_live_owned(
             """INSERT INTO benchmarks_v2.benchmark_observations
                (id,run_id,dataset_id,dataset_sha256,sample_id,provider,model,voice,
                 benchmark,source_kind,captured_at,status)
-               VALUES (%s,%s,%s,%s,'coval-run/simulation','provider','model','voice',
+               VALUES (%s,%s,%s,%s,%s,'provider','model','voice',
                        'S2S','conversation_audio',%s,'succeeded')""",
-            (observation_id, run_id, dataset_id, normalized_sha, _NOW + timedelta(seconds=30)),
+            (
+                observation_id,
+                run_id,
+                dataset_id,
+                normalized_sha,
+                sample_id,
+                _NOW + timedelta(seconds=30),
+            ),
         )
         cur.execute(
             """INSERT INTO benchmarks_v2.metric_evaluations
@@ -662,7 +832,7 @@ def test_cancellation_emits_checkpoint_and_releases_global_lock(
     stream = io.StringIO()
     monkeypatch.setattr(
         migration,
-        "_verify_public_parity",
+        "_verify_public_parity_page",
         lambda *_: (_ for _ in ()).throw(migration._Cancelled()),
     )
     with pytest.raises(migration._Cancelled):


### PR DESCRIPTION
## Summary
- add a standalone database-only normalized S2S storage backfill command
- reconcile deterministic backfill rows and random-ID live dual writes without fabricating artifact lineage
- verify fresh payloads, complete observation population, public primary-value parity, and exact rollups before reporting backfill_complete
- add structured phase/checkpoint progress, a disposable local benchmark harness, and the operator runbook

## Safety
- apply requires an explicit frozen maximum result ID
- dry run is read-only and can auto-freeze the S2S maximum
- writes commit one complete run-ID page at a time under the shared normalized-storage lock
- protected STT/TTS, live S2S dual-write, and readiness implementations are unchanged
- no production apply or dashboard-read rollout was performed

## Validation
- 18 focused S2S backfill tests passed against disposable PostgreSQL
- 86 existing normalized dual-write and S2S fetch tests passed
- 23 relevant sibling backfill tests passed
- Ruff format/check and mypy passed
- adversarial smoke confirmed an extra failed normalized observation blocks completion
- disposable benchmark smoke completed for multiple batch sizes and removed its database
- independent Tier 3 Sol review passed after one repair pass

Linear: https://linear.app/coval/issue/BENCH-783/implement-standalone-normalized-s2s-storage-backfill