### PR TITLE
[BENCH-794] Refresh stats matviews once per scheduled window

### DIFF
--- a/runner/src/coval_bench/db/migrations/env.py
+++ b/runner/src/coval_bench/db/migrations/env.py
@@ -15,9 +15,9 @@ Notes
 -----
 - DB roles and GRANTs are managed by Terraform, not Alembic.
 - The per-window materialized views (``results_24h``/``results_7d``/
-  ``results_30d``) are refreshed by the runner at the end of each benchmark
-  run (REFRESH MATERIALIZED VIEW CONCURRENTLY); Alembic only creates the
-  initial definitions.
+  ``results_30d``) are refreshed by the runner once per scheduled window, by
+  the slot's last run to finish (REFRESH MATERIALIZED VIEW CONCURRENTLY);
+  Alembic only creates the initial definitions.
 - ``alembic_version`` is stored in the public schema (default) so that
   Alembic can create it before ``benchmarks_v2`` is created.
 - We connect via psycopg3 sync connection + SQLAlchemy ``create_engine``

--- a/runner/src/coval_bench/db/writer.py
+++ b/runner/src/coval_bench/db/writer.py
@@ -961,16 +961,35 @@ class RunWriter:
             await conn.commit()
         return row is not None
 
-    async def refresh_stats_matviews(self) -> None:
-        """Concurrently refresh the per-window stats materialized views.
-
-        ``CONCURRENTLY`` relies on each view's unique group-key index and does
-        not block API reads. Raises on error like the rest of ``RunWriter``.
-        """
+    async def refresh_stats_matviews(self, run_id: int | None = None) -> bool:
+        """Only the slot's last finisher refreshes; False means skipped, not failed."""
         async with self._pool.connection() as conn:
-            async with conn.cursor() as cur:
+            async with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+                if run_id is not None:
+                    await cur.execute(
+                        """SELECT EXISTS (
+                               SELECT 1 FROM benchmarks_v2.runs sibling
+                               JOIN benchmarks_v2.runs own ON own.id = %s
+                               WHERE sibling.scheduled_at = own.scheduled_at
+                                 AND sibling.id <> own.id
+                                 AND sibling.status = 'running') AS siblings_running""",
+                        (run_id,),
+                    )
+                    row = await cur.fetchone()
+                    if row is not None and row["siblings_running"]:
+                        await conn.rollback()
+                        return False
+                await cur.execute(
+                    "SELECT pg_try_advisory_xact_lock(hashtextextended('stats_matviews', 0))"
+                    " AS acquired"
+                )
+                row = await cur.fetchone()
+                if row is None or not row["acquired"]:
+                    await conn.rollback()
+                    return False
                 for view in STATS_MATVIEWS:
                     await cur.execute(  # noqa: S608 — view names are constants
                         f"REFRESH MATERIALIZED VIEW CONCURRENTLY benchmarks_v2.{view}"
                     )
             await conn.commit()
+        return True

--- a/runner/src/coval_bench/runner/orchestrator.py
+++ b/runner/src/coval_bench/runner/orchestrator.py
@@ -1455,12 +1455,15 @@ async def run_benchmarks(
             # Refresh after finish_run: the view query only counts runs already
             # marked succeeded/partial. A failed refresh must not fail the run.
             try:
-                await writer.refresh_stats_matviews()
+                refreshed = await writer.refresh_stats_matviews(run_id)
             except Exception as refresh_exc:
                 logger.error(
                     "stats_matviews_refresh_failed",
                     exc_info=refresh_exc,
                 )
+            else:
+                if not refreshed:
+                    logger.info("stats_matviews_refresh_skipped")
 
             if final_status in (RunStatus.SUCCEEDED, RunStatus.PARTIAL):
                 await _refresh_series_bucket(writer, run_id, settings)

--- a/runner/tests/unit/test_db_writer.py
+++ b/runner/tests/unit/test_db_writer.py
@@ -436,19 +436,33 @@ def test_results_24h_view(pg_conn: psycopg.Connection[Any]) -> None:
     assert abs(float(row["p50"]) - 0.3) < 0.001
 
 
-def test_refresh_stats_matviews(pg_conn: psycopg.Connection[Any]) -> None:
-    """finish_run → refresh_stats_matviews populates all three per-window views."""
+def test_refresh_stats_matviews_once_per_window(pg_conn: psycopg.Connection[Any]) -> None:
+    """The slot's last finisher refreshes; a running sibling or a held lock skips."""
     _apply_migrations(pg_conn)
+    pg_conn.autocommit = True
+    slot = datetime(2026, 9, 2, 14, 30, tzinfo=UTC)
+
+    def _view_rows() -> int:
+        with pg_conn.cursor() as cur:
+            cur.execute("SELECT count(*) FROM benchmarks_v2.results_24h WHERE provider = 'openai'")
+            row = cur.fetchone()
+        assert row is not None
+        return int(row[0])
 
     async def _run() -> None:
         pool = await _make_pool(pg_conn)
         try:
             writer = RunWriter(pool)
-            run = await writer.start_run(dataset_id="stt-v1", dataset_sha256="deadbeef")
-            assert run.id is not None
+            first = await writer.start_run(
+                dataset_id="stt-v1", dataset_sha256="deadbeef", scheduled_at=slot
+            )
+            second = await writer.start_run(
+                dataset_id="stt-v1", dataset_sha256="deadbeef", scheduled_at=slot
+            )
+            assert first.id is not None and second.id is not None
             results = [
                 Result(
-                    run_id=run.id,
+                    run_id=first.id,
                     provider="openai",
                     model="whisper-1",
                     benchmark=Benchmark.STT,
@@ -460,14 +474,23 @@ def test_refresh_stats_matviews(pg_conn: psycopg.Connection[Any]) -> None:
                 for i in range(1, 6)
             ]
             await writer.record_results(results)
-            await writer.finish_run(run.id, status=RunStatus.SUCCEEDED)
-            await writer.refresh_stats_matviews()
+            await writer.finish_run(first.id, status=RunStatus.SUCCEEDED)
+            assert await writer.refresh_stats_matviews(first.id) is False
+            assert _view_rows() == 0
+
+            await writer.finish_run(second.id, status=RunStatus.SUCCEEDED)
+            with pg_conn.transaction():
+                pg_conn.execute(
+                    "SELECT pg_advisory_xact_lock(hashtextextended('stats_matviews', 0))"
+                )
+                assert await writer.refresh_stats_matviews(second.id) is False
+            assert _view_rows() == 0
+            assert await writer.refresh_stats_matviews(second.id) is True
         finally:
             await pool.close()
 
     asyncio.run(_run())
 
-    pg_conn.autocommit = True
     for view in ("results_24h", "results_7d", "results_30d"):
         with pg_conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
             cur.execute(

--- a/runner/tests/unit/test_orchestrator.py
+++ b/runner/tests/unit/test_orchestrator.py
@@ -345,7 +345,7 @@ async def test_smoke_run_stt(audio_file: Path, settings: Settings) -> None:
     # both deepgram and elevenlabs each fire multiple times via the same mock.
     assert writer.record_results.await_count >= 2
     writer.finish_run.assert_awaited_once_with(1, status=RunStatus.SUCCEEDED, error=None)
-    writer.refresh_stats_matviews.assert_awaited_once_with()
+    writer.refresh_stats_matviews.assert_awaited_once_with(1)
     writer.refresh_bucket.assert_awaited_once_with(
         1, period_seconds=settings.schedule_period_seconds
     )


### PR DESCRIPTION
Every run rebuilt all three stats views, so nine runs per tick queued on the view locks and rode the queue into the Cloud Run task timeout. Now only the slot's last finisher refreshes, with an advisory try-lock covering two runs finishing together. The s2s fetch keeps its unconditional refresh.