### PR TITLE
Teach the mock codec and the contract puller about Telnyx

### DIFF
--- a/runner/src/coval_bench/mocktools/codecs.py
+++ b/runner/src/coval_bench/mocktools/codecs.py
@@ -17,6 +17,7 @@ logger = structlog.get_logger("coval_bench.mocktools")
 __all__ = [
     "CODECS",
     "MAX_TOOL_CALLS",
+    "PRESET_PREFIX",
     "Codec",
     "Correlation",
     "ToolCall",
@@ -26,6 +27,9 @@ __all__ = [
 SIMULATION_HEADER = "x-coval-simulation-id"
 CALLER_HEADER = "x-coval-caller-number"
 TELNYX_CALL_HEADER = "x-telnyx-call-control-id"
+PRESET_PREFIX = "_coval_"
+PRESET_SIMULATION = f"{PRESET_PREFIX}simulation_id"
+PRESET_CALLER = f"{PRESET_PREFIX}caller_number"
 MAX_TOOL_CALLS = 32
 
 Body = dict[str, Any] | None
@@ -85,10 +89,28 @@ GENERIC = Codec(
 )
 
 
-def _telnyx_correlate(_body: Body, headers: Mapping[str, str]) -> Correlation:
+def _telnyx_decode(body: Body, _headers: Mapping[str, str], tool: str | None) -> list[ToolCall]:
+    args = {k: v for k, v in _as_args(body).items() if not k.startswith(PRESET_PREFIX)}
+    return [ToolCall(tool=tool or "", args=args)]
+
+
+def _rendered(value: object) -> str | None:
+    if not isinstance(value, str) or not value or "{{" in value:
+        return None
+    return value
+
+
+def _telnyx_correlate(body: Body, headers: Mapping[str, str]) -> Correlation:
     found = _coval_headers(headers)
     if found.source != "none":
         return found
+    preset = _as_args(body)
+    simulation_id = _rendered(preset.get(PRESET_SIMULATION))
+    caller_number = _rendered(preset.get(PRESET_CALLER))
+    if simulation_id:
+        return Correlation(simulation_id, caller_number, source="telnyx_preset_body")
+    if caller_number:
+        return Correlation(None, caller_number, source="telnyx_preset_caller")
     if headers.get(TELNYX_CALL_HEADER):
         return Correlation(source="telnyx_call_control_id")
     return Correlation()
@@ -97,7 +119,7 @@ def _telnyx_correlate(_body: Body, headers: Mapping[str, str]) -> Correlation:
 TELNYX = Codec(
     name="telnyx",
     tool_in_path=True,
-    decode=_generic_decode,
+    decode=_telnyx_decode,
     correlate=_telnyx_correlate,
     encode=_generic_encode,
 )

--- a/runner/src/coval_bench/variants/platforms.py
+++ b/runner/src/coval_bench/variants/platforms.py
@@ -115,6 +115,20 @@ def _vapi(client: httpx.Client, agent_id: str) -> PlatformConfig:
     )
 
 
+def _telnyx(client: httpx.Client, agent_id: str) -> PlatformConfig:
+    response = client.get(f"/ai/assistants/{agent_id}")
+    response.raise_for_status()
+    payload = cast("dict[str, Any]", response.json())
+    data = payload.get("data")
+    raw = data if isinstance(data, dict) else payload
+    return PlatformConfig(
+        raw=raw,
+        system_prompt=str(raw.get("instructions") or ""),
+        first_message=str(raw.get("greeting") or "").strip(),
+        tools=list(raw.get("tools") or []),
+    )
+
+
 FETCHERS: dict[str, Fetcher] = {
     "vapi": Fetcher(
         name="vapi",
@@ -122,6 +136,13 @@ FETCHERS: dict[str, Fetcher] = {
         key_env="VAPI_API_KEY",
         fetch=_vapi,
         id_help="Vapi assistant id (uuid)",
+    ),
+    "telnyx": Fetcher(
+        name="telnyx",
+        api_base="https://api.telnyx.com/v2",
+        key_env="TELNYX_API_KEY",
+        fetch=_telnyx,
+        id_help="Telnyx assistant id (assistant-<uuid>)",
     ),
 }
 

--- a/runner/tests/api/test_mocktools.py
+++ b/runner/tests/api/test_mocktools.py
@@ -431,6 +431,28 @@ async def test_telnyx_control_id_never_lands_in_caller_number(
     assert rows[0]["simulation_id"] is None
 
 
+async def test_telnyx_preset_body_fields_correlate_and_never_reach_the_args(
+    client: AsyncClient, mock_app: FastAPI, postgresql: Any
+) -> None:
+    response = await client.post(
+        "/mock/telnyx/lookup_patient",
+        json={
+            "phone": PHONE,
+            "_coval_simulation_id": SIMULATION_ID,
+            "_coval_caller_number": "+14045550710",
+        },
+        headers={**AUTH, "x-telnyx-call-control-id": "v3:abc123"},
+    )
+    assert response.status_code == 200
+    assert response.json() == BULKY
+    rows = await _rows(postgresql)
+    assert len(rows) == 1
+    assert rows[0]["simulation_id"] == SIMULATION_ID
+    assert rows[0]["caller_number"] == "+14045550710"
+    assert rows[0]["args"] == {"phone": PHONE}
+    assert rows[0]["matched_seed"] == "marcus_lee"
+
+
 async def test_vapi_nested_function_shape_reaches_the_seed(
     client: AsyncClient, mock_app: FastAPI
 ) -> None:

--- a/runner/tests/unit/test_codecs.py
+++ b/runner/tests/unit/test_codecs.py
@@ -14,6 +14,8 @@ from coval_bench.mocktools.codecs import (
     CODECS,
     GENERIC,
     MAX_TOOL_CALLS,
+    PRESET_CALLER,
+    PRESET_SIMULATION,
     TELNYX,
     VAPI,
     ToolCall,
@@ -84,17 +86,49 @@ def test_generic_without_headers_is_uncorrelated() -> None:
 # --- telnyx ----------------------------------------------------------------
 
 
-def test_telnyx_shares_the_generic_wire_shape() -> None:
-    assert TELNYX.decode is GENERIC.decode
+def test_telnyx_shares_the_generic_response_shape_but_not_decode() -> None:
+    assert TELNYX.decode is not GENERIC.decode
     assert TELNYX.encode is GENERIC.encode
     assert TELNYX.tool_in_path
 
 
+def test_telnyx_strips_preset_body_fields_before_dispatch() -> None:
+    body = {"phone": PHONE, PRESET_SIMULATION: SIM, PRESET_CALLER: "+14045550710"}
+    (call,) = TELNYX.decode(body, NO_HEADERS, "lookup_patient")
+    assert call == ToolCall(tool="lookup_patient", args={"phone": PHONE})
+
+
 def test_telnyx_prefers_the_coval_header() -> None:
     found = TELNYX.correlate(
-        {}, {"x-coval-simulation-id": SIM, "x-telnyx-call-control-id": "v3:abc"}
+        {PRESET_SIMULATION: "other"},
+        {"x-coval-simulation-id": SIM, "x-telnyx-call-control-id": "v3:abc"},
     )
     assert (found.simulation_id, found.source) == (SIM, "simulation_header")
+
+
+def test_telnyx_correlates_from_the_preset_body() -> None:
+    found = TELNYX.correlate({"phone": PHONE, PRESET_SIMULATION: SIM, PRESET_CALLER: "+1404"}, {})
+    assert (found.simulation_id, found.caller_number, found.source) == (
+        SIM,
+        "+1404",
+        "telnyx_preset_body",
+    )
+
+
+def test_telnyx_falls_back_to_the_preset_caller_alone() -> None:
+    found = TELNYX.correlate({PRESET_CALLER: "+1404"}, {})
+    assert (found.simulation_id, found.caller_number, found.source) == (
+        None,
+        "+1404",
+        "telnyx_preset_caller",
+    )
+
+
+def test_telnyx_treats_an_unrendered_template_as_absent() -> None:
+    found = TELNYX.correlate(
+        {PRESET_SIMULATION: "{{coval_simulation_id}}", PRESET_CALLER: "+1404"}, {}
+    )
+    assert (found.simulation_id, found.source) == (None, "telnyx_preset_caller")
 
 
 def test_telnyx_control_id_is_noted_but_never_stored_as_a_number() -> None:


### PR DESCRIPTION
Telnyx posts a flat body to `/mock/telnyx/{tool}` and, because its webhook headers only interpolate integration secrets, carries the correlation ids in `preset_body_fields` the model never sees. The Telnyx codec strips those `_coval_` fields before dispatch so they never reach the resolver or the `args` column, and reads them for correlation when the Coval headers are absent, treating an unrendered `{{template}}` as no value. Encode stays generic: bare response, always 200.

`pull-contract` gains the Telnyx fetcher, reading `instructions`, `greeting` and `tools` off `GET /v2/ai/assistants/{id}`.

The Telnyx assistant row for the asset manager (webhook-tool renderer, integration secrets, SIP subdomain, pinned fields) is held back until the platform-neutral seam changes in the sibling PR land, so nothing here is stacked. The Codex findings from the first revision are addressed there or, for temperature, recorded as a Telnyx parity gap since the assistant API exposes no LLM temperature field.
