### PR TITLE
Close the loop from the CLI: dry run, smoke, register, launch

### DIFF
--- a/runner/src/coval_bench/platform_assets.py
+++ b/runner/src/coval_bench/platform_assets.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 
 import copy
 import json
-from collections.abc import Callable
+import time
+from collections.abc import Callable, Iterator
 from dataclasses import dataclass, field
 from typing import Any, Protocol
 
@@ -14,13 +15,20 @@ import httpx
 from pydantic import BaseModel, Field
 
 from coval_bench.assets import SecretRef
-from coval_bench.contracts import public_contract_sha256, read_contract_file
+from coval_bench.contracts import contract_sha256, load_stack, read_contract_file
 from coval_bench.variants.platforms import redact
 
 TOOL_TIMEOUT_SECONDS = 20
 SIMULATION_HEADER_TEMPLATE = "{{coval-simulation-id}}"
 TOOLS_PATH = "model.tools"
+COVAL_API_BASE = "https://api.coval.dev/v1"
+COVAL_MODEL_TYPE = "MODEL_TYPE_VOICE"
+COVAL_PROMPT_FILE = "_source/coval-prompt.txt"
 _TIMEOUT = httpx.Timeout(30.0, connect=10.0)
+
+COVAL_API_KEY = SecretRef(
+    name="COVAL_API_KEY", purpose="the Coval API key for the benchmarking org"
+)
 
 
 class SyncError(RuntimeError):
@@ -34,6 +42,7 @@ class PlatformAgentSpec(BaseModel, frozen=True, extra="forbid"):
     agent_id: SecretRef
     api_key: SecretRef
     mock_secret: SecretRef
+    dial_target: SecretRef
 
 
 class AgentClient(Protocol):
@@ -45,6 +54,8 @@ class AgentClient(Protocol):
 
 Renderer = Callable[[PlatformAgentSpec, str, str], dict[str, Any]]
 ClientFactory = Callable[[str, str], AgentClient]
+Prepare = Callable[[AgentClient, PlatformAgentSpec, bool], list[str]]
+Probe = Callable[[dict[str, Any], dict[str, Any], str, str], tuple[str, dict[str, str], Any]]
 
 
 @dataclass(frozen=True)
@@ -53,15 +64,62 @@ class Platform:
     api_base: str
     render: Renderer
     client: ClientFactory
+    probe: Probe
+    prepare: Prepare | None = None
 
 
 @dataclass
 class Plan:
     update: dict[str, tuple[Any, Any]] = field(default_factory=dict)
     unchanged: list[str] = field(default_factory=list)
+    prepared: list[str] = field(default_factory=list)
 
     def summary(self) -> str:
-        return f"update={sorted(self.update)} unchanged={sorted(self.unchanged)}"
+        return (
+            f"prepare={self.prepared} update={sorted(self.update)} "
+            f"unchanged={sorted(self.unchanged)}"
+        )
+
+
+def _unwrap(payload: dict[str, Any]) -> dict[str, Any]:
+    data = payload.get("data")
+    return data if isinstance(data, dict) else payload
+
+
+class _JsonClient:
+    def __init__(
+        self,
+        base_url: str,
+        headers: dict[str, str],
+        transport: httpx.BaseTransport | None = None,
+    ) -> None:
+        self._client = httpx.Client(
+            base_url=base_url, headers=headers, timeout=_TIMEOUT, transport=transport
+        )
+
+    def __enter__(self) -> _JsonClient:
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self._client.close()
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        payload: dict[str, Any] | None = None,
+        params: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        response = self._client.request(method, path, json=payload, params=params)
+        if response.status_code >= 400:
+            raise SyncError(f"{method} {path} -> {response.status_code}: {response.text[:400]}")
+        if not response.content:
+            return {}
+        parsed: dict[str, Any] = response.json()
+        return parsed
+
+
+# --- vapi ------------------------------------------------------------------
 
 
 def render_vapi_tools(
@@ -95,31 +153,33 @@ def render_vapi(spec: PlatformAgentSpec, mock_base_url: str, secret: str) -> dic
     return {TOOLS_PATH: render_vapi_tools(definitions, mock_base_url, secret)}
 
 
-class VapiClient:
+def probe_vapi(
+    tool: dict[str, Any], args: dict[str, Any], secret: str, simulation_id: str
+) -> tuple[str, dict[str, str], Any]:
+    headers = {"X-Mock-Tools-Key": secret, "X-Coval-Simulation-Id": simulation_id}
+    body = {
+        "message": {
+            "type": "tool-calls",
+            "toolCallList": [
+                {
+                    "id": f"{simulation_id}-1",
+                    "type": "function",
+                    "function": {"name": tool["function"]["name"], "arguments": json.dumps(args)},
+                }
+            ],
+        }
+    }
+    return str(tool["server"]["url"]), headers, body
+
+
+class VapiClient(_JsonClient):
     def __init__(
         self, api_key: str, base_url: str, transport: httpx.BaseTransport | None = None
     ) -> None:
-        self._client = httpx.Client(
-            base_url=base_url,
-            headers={"Authorization": f"Bearer {api_key}"},
-            timeout=_TIMEOUT,
-            transport=transport,
-        )
+        super().__init__(base_url, {"Authorization": f"Bearer {api_key}"}, transport)
 
     def __enter__(self) -> VapiClient:
         return self
-
-    def __exit__(self, *exc: object) -> None:
-        self._client.close()
-
-    def _request(
-        self, method: str, path: str, payload: dict[str, Any] | None = None
-    ) -> dict[str, Any]:
-        response = self._client.request(method, path, json=payload)
-        if response.status_code >= 400:
-            raise SyncError(f"{method} {path} -> {response.status_code}: {response.text[:400]}")
-        parsed: dict[str, Any] = response.json()
-        return parsed
 
     def get_agent(self, agent_id: str) -> dict[str, Any]:
         return self._request("GET", f"/assistant/{agent_id}")
@@ -128,9 +188,16 @@ class VapiClient:
         return self._request("PATCH", f"/assistant/{agent_id}", body)
 
 
+# --- the table -------------------------------------------------------------
+
+
 PLATFORMS: dict[str, Platform] = {
     "vapi": Platform(
-        name="vapi", api_base="https://api.vapi.ai", render=render_vapi, client=VapiClient
+        name="vapi",
+        api_base="https://api.vapi.ai",
+        render=render_vapi,
+        client=VapiClient,
+        probe=probe_vapi,
     ),
 }
 
@@ -147,6 +214,10 @@ AGENTS: tuple[PlatformAgentSpec, ...] = (
         mock_secret=SecretRef(
             name="MOCK_TOOLS_SECRET",
             purpose="the shared secret the mock tool endpoint requires on X-Mock-Tools-Key",
+        ),
+        dial_target=SecretRef(
+            name="VAPI_DENTAL_DIAL_TARGET",
+            purpose="the sip: URI Coval dials to reach the Vapi dental assistant",
         ),
     ),
 )
@@ -217,13 +288,153 @@ def patch_body(live: dict[str, Any], wanted: dict[str, Any]) -> dict[str, Any]:
     return body
 
 
-def apply(client: AgentClient, spec: PlatformAgentSpec, wanted: dict[str, Any]) -> Plan:
+def apply(
+    client: AgentClient, spec: PlatformAgentSpec, wanted: dict[str, Any], *, dry_run: bool = False
+) -> Plan:
+    platform = platform_for(spec)
+    prepared = platform.prepare(client, spec, dry_run) if platform.prepare else []
     agent_id = spec.agent_id.resolve()
     live = client.get_agent(agent_id)
     result = plan(live, wanted)
-    if result.update:
+    result.prepared = prepared
+    if result.update and not dry_run:
         client.update_agent(agent_id, patch_body(live, wanted))
     return result
+
+
+# --- coval side ------------------------------------------------------------
+
+
+class CovalClient(_JsonClient):
+    def __init__(
+        self,
+        api_key: str,
+        base_url: str = COVAL_API_BASE,
+        transport: httpx.BaseTransport | None = None,
+    ) -> None:
+        super().__init__(base_url, {"X-API-Key": api_key}, transport)
+
+    def __enter__(self) -> CovalClient:
+        return self
+
+    def _pages(self, path: str, key: str) -> Iterator[dict[str, Any]]:
+        token: str | None = None
+        while True:
+            params: dict[str, Any] = {"page_size": 100}
+            if token:
+                params["page_token"] = token
+            payload = self._request("GET", path, params=params)
+            yield from payload.get(key, [])
+            token = payload.get("next_page_token") or None
+            if not token:
+                return
+
+    def find_agent(self, customer_agent_id: str) -> dict[str, Any] | None:
+        for agent in self._pages("/agents", "agents"):
+            if agent.get("customer_agent_id") == customer_agent_id:
+                return agent
+        return None
+
+    def create_agent(self, body: dict[str, Any]) -> dict[str, Any]:
+        payload = self._request("POST", "/agents", body)
+        agent = payload.get("agent")
+        return agent if isinstance(agent, dict) else payload
+
+    def update_agent(self, agent_id: str, body: dict[str, Any]) -> dict[str, Any]:
+        payload = self._request("PATCH", f"/agents/{agent_id}", body)
+        agent = payload.get("agent")
+        return agent if isinstance(agent, dict) else payload
+
+    def launch_run(self, body: dict[str, Any]) -> dict[str, Any]:
+        payload = self._request("POST", "/runs", body)
+        run = payload.get("run")
+        return run if isinstance(run, dict) else payload
+
+    def get_run(self, run_id: str) -> dict[str, Any]:
+        payload = self._request("GET", f"/runs/{run_id}")
+        run = payload.get("run")
+        return run if isinstance(run, dict) else payload
+
+
+COVAL_MANAGED = ("phone_number", "prompt", "metadata", "attributes")
+
+
+def coval_agent_body(spec: PlatformAgentSpec) -> dict[str, Any]:
+    """The Coval-side agent every variant registers: same call, only the dial target differs."""
+    stack = load_stack()
+    return {
+        "display_name": spec.key,
+        "customer_agent_id": spec.key,
+        "model_type": COVAL_MODEL_TYPE,
+        "phone_number": spec.dial_target.resolve(),
+        "prompt": read_contract_file(spec.suite, COVAL_PROMPT_FILE),
+        "language": "en",
+        "metadata": {"audio_codec": stack.media.codec},
+        "attributes": {
+            "platform": spec.platform,
+            "suite": spec.suite,
+            "contract_sha256": contract_sha256(spec.suite),
+        },
+        "tags": ["orchestration", spec.suite, spec.platform],
+    }
+
+
+def register(
+    client: CovalClient, spec: PlatformAgentSpec, *, dry_run: bool = False
+) -> tuple[str, Plan]:
+    """Create or reconcile the Coval agent that dials this variant; returns its id."""
+    wanted = coval_agent_body(spec)
+    live = client.find_agent(spec.key)
+    if live is None:
+        result = Plan(update={path: (None, wanted[path]) for path in COVAL_MANAGED})
+        if dry_run:
+            return "", result
+        return str(client.create_agent(wanted)["id"]), result
+    result = plan(live, {path: wanted[path] for path in COVAL_MANAGED})
+    if result.update and not dry_run:
+        client.update_agent(str(live["id"]), {path: wanted[path] for path in result.update})
+    return str(live["id"]), result
+
+
+def drift(client: AgentClient, spec: PlatformAgentSpec, mock_base_url: str) -> list[str]:
+    """What the live platform agent still differs from the contract by; empty means in sync."""
+    result = apply(client, spec, desired(spec, mock_base_url), dry_run=True)
+    return sorted(result.update) + result.prepared
+
+
+def launch_body(
+    agent_id: str,
+    spec: PlatformAgentSpec,
+    persona_id: str,
+    test_set_id: str,
+    metric_ids: tuple[str, ...],
+    sample: int,
+    seed: int,
+) -> dict[str, Any]:
+    sha = contract_sha256(spec.suite)
+    return {
+        "agent_id": agent_id,
+        "persona_id": persona_id,
+        "test_set_id": test_set_id,
+        "metric_ids": list(metric_ids),
+        "options": {
+            "iteration_count": 1,
+            "concurrency": 1,
+            "sub_sample_size": sample,
+            "sub_sample_seed": seed,
+        },
+        "metadata": {
+            "display_name": f"{spec.key} e2e {sha[:8]}",
+            "customer_metadata": {
+                "arm": spec.key,
+                "platform": spec.platform,
+                "contract_sha256": sha,
+            },
+        },
+    }
+
+
+# --- cli -------------------------------------------------------------------
 
 
 _agent_option = click.option(
@@ -238,6 +449,18 @@ _mock_base_url_option = click.option(
 _api_base_option = click.option(
     "--api-base", default=None, help="Override the platform's API base URL."
 )
+_coval_base_option = click.option(
+    "--coval-api-base", envvar="COVAL_API_BASE", default=COVAL_API_BASE, show_default=True
+)
+
+
+def _echo_plan(result: Plan) -> None:
+    click.echo(result.summary())
+    for path, (current, value) in result.update.items():
+        found: list[str] = []
+        click.echo(f"\n{path}:")
+        click.echo(f"  live:    {json.dumps(redact(current, found), sort_keys=True)[:400]}")
+        click.echo(f"  desired: {json.dumps(redact(value, found), sort_keys=True)[:400]}")
 
 
 @click.group()
@@ -250,18 +473,12 @@ def platform_assets() -> None:
 @_mock_base_url_option
 @_api_base_option
 def assets_plan(agent_key: str, mock_base_url: str, api_base: str | None) -> None:
-    """Show what apply would change; writes nothing."""
+    """Show what apply would change on the platform; writes nothing."""
     spec = spec_for(agent_key)
     platform = platform_for(spec)
     wanted = desired(spec, mock_base_url)
     with platform.client(spec.api_key.resolve(), api_base or platform.api_base) as client:
-        result = plan(client.get_agent(spec.agent_id.resolve()), wanted)
-    click.echo(result.summary())
-    for path, (current, value) in result.update.items():
-        found: list[str] = []
-        click.echo(f"\n{path}:")
-        click.echo(f"  live:    {json.dumps(redact(current, found), sort_keys=True)[:400]}")
-        click.echo(f"  desired: {json.dumps(redact(value, found), sort_keys=True)[:400]}")
+        _echo_plan(apply(client, spec, wanted, dry_run=True))
 
 
 @platform_assets.command(name="apply")
@@ -270,17 +487,121 @@ def assets_plan(agent_key: str, mock_base_url: str, api_base: str | None) -> Non
 @_api_base_option
 @click.option("--yes", is_flag=True, default=False, help="Skip the confirmation prompt.")
 def assets_apply(agent_key: str, mock_base_url: str, api_base: str | None, yes: bool) -> None:
-    """Patch the managed fields on the live agent."""
+    """Prepare the platform's prerequisites, then patch the managed fields on the live agent."""
     spec = spec_for(agent_key)
     platform = platform_for(spec)
     wanted = desired(spec, mock_base_url)
     with platform.client(spec.api_key.resolve(), api_base or platform.api_base) as client:
-        preview = plan(client.get_agent(spec.agent_id.resolve()), wanted)
+        preview = apply(client, spec, wanted, dry_run=True)
         click.echo(preview.summary())
-        if not preview.update:
+        if not preview.update and not preview.prepared:
             return
-        if not yes and not click.confirm(f"Patch {sorted(preview.update)} on {agent_key}?"):
+        pending = sorted(preview.update) + preview.prepared
+        if not yes and not click.confirm(f"Apply {pending} on {agent_key}?"):
             raise click.ClickException("aborted")
         result = apply(client, spec, wanted)
+    click.echo(f"prepared {result.prepared}")
     click.echo(f"patched {sorted(result.update)}")
-    click.echo(f"public contract sha256 ({spec.suite}): {public_contract_sha256(spec.suite)}")
+    click.echo(f"contract sha256 ({spec.suite}): {contract_sha256(spec.suite)}")
+
+
+@platform_assets.command(name="smoke")
+@_agent_option
+@_mock_base_url_option
+@click.option("--tool", default="lookup_patient", show_default=True)
+@click.option("--arg", "args", multiple=True, help="key=value, repeatable.")
+def assets_smoke(agent_key: str, mock_base_url: str, tool: str, args: tuple[str, ...]) -> None:
+    """Fire one tool call at /mock exactly as this platform would, and print the answer."""
+    spec = spec_for(agent_key)
+    platform = platform_for(spec)
+    rendered = desired(spec, mock_base_url)
+    tools = rendered.get(TOOLS_PATH) or rendered.get("tools") or []
+    wanted = next(
+        (t for t in tools if (t.get("function") or t.get("webhook") or {}).get("name") == tool),
+        None,
+    )
+    if wanted is None:
+        raise click.ClickException(f"{tool!r} is not in the {spec.suite} contract")
+    call_args = dict(item.split("=", 1) for item in args)
+    simulation_id = f"smoke-{spec.key}-{int(time.time())}"
+    url, headers, body = platform.probe(
+        wanted, call_args, spec.mock_secret.resolve(), simulation_id
+    )
+    response = httpx.post(url, headers=headers, json=body, timeout=_TIMEOUT)
+    click.echo(f"POST {url} -> {response.status_code}")
+    click.echo(response.text[:800])
+    click.echo(f"simulation_id sent: {simulation_id}")
+
+
+@platform_assets.command(name="register")
+@_agent_option
+@_coval_base_option
+@click.option("--yes", is_flag=True, default=False, help="Skip the confirmation prompt.")
+def assets_register(agent_key: str, coval_api_base: str, yes: bool) -> None:
+    """Create or reconcile the Coval agent that dials this variant."""
+    spec = spec_for(agent_key)
+    with CovalClient(COVAL_API_KEY.resolve(), coval_api_base) as client:
+        agent_id, preview = register(client, spec, dry_run=True)
+        _echo_plan(preview)
+        if not preview.update:
+            click.echo(f"coval agent {agent_id} already matches")
+            return
+        if not yes and not click.confirm(
+            f"Write {sorted(preview.update)} to Coval for {agent_key}?"
+        ):
+            raise click.ClickException("aborted")
+        agent_id, _ = register(client, spec)
+    click.echo(f"coval agent id: {agent_id}")
+
+
+@platform_assets.command(name="launch")
+@_agent_option
+@_mock_base_url_option
+@_api_base_option
+@_coval_base_option
+@click.option("--persona-id", envvar="COVAL_DENTAL_PERSONA_ID", required=True)
+@click.option("--test-set-id", envvar="COVAL_DENTAL_TEST_SET_ID", required=True)
+@click.option("--metric-id", "metric_ids", multiple=True, envvar="COVAL_DENTAL_METRIC_IDS")
+@click.option("--sample", default=1, show_default=True, help="Test cases to run; 0 = all.")
+@click.option("--seed", default=847293, show_default=True)
+@click.option("--wait/--no-wait", default=False, help="Poll until the run is terminal.")
+@click.option(
+    "--allow-drift", is_flag=True, default=False, help="Launch even if the platform agent drifts."
+)
+def assets_launch(
+    agent_key: str,
+    mock_base_url: str,
+    api_base: str | None,
+    coval_api_base: str,
+    persona_id: str,
+    test_set_id: str,
+    metric_ids: tuple[str, ...],
+    sample: int,
+    seed: int,
+    wait: bool,
+    allow_drift: bool,
+) -> None:
+    """Launch one Coval run against this variant's registered agent, once the platform matches."""
+    spec = spec_for(agent_key)
+    platform = platform_for(spec)
+    with platform.client(spec.api_key.resolve(), api_base or platform.api_base) as client:
+        pending = drift(client, spec, mock_base_url)
+    if pending:
+        message = f"{agent_key} drifts from the contract: {pending}; run apply first"
+        if not allow_drift:
+            raise click.ClickException(message)
+        click.echo(f"warning: {message}")
+    with CovalClient(COVAL_API_KEY.resolve(), coval_api_base) as client:
+        agent = client.find_agent(spec.key)
+        if agent is None:
+            raise click.ClickException(f"no Coval agent for {agent_key}; run register first")
+        run = client.launch_run(
+            launch_body(str(agent["id"]), spec, persona_id, test_set_id, metric_ids, sample, seed)
+        )
+        run_id = str(run.get("run_id") or run.get("id"))
+        click.echo(f"run_id: {run_id} status: {run.get('status')}")
+        click.echo("open this run id in the Coval UI to watch the simulation")
+        while wait and run.get("status") not in {"COMPLETED", "FAILED", "CANCELLED", "DELETED"}:
+            time.sleep(30)
+            run = client.get_run(run_id)
+            click.echo(f"status: {run.get('status')} progress: {run.get('progress')}")

--- a/runner/src/coval_bench/platform_assets.py
+++ b/runner/src/coval_bench/platform_assets.py
@@ -15,7 +15,14 @@ import httpx
 from pydantic import BaseModel, Field
 
 from coval_bench.assets import SecretRef
-from coval_bench.contracts import contract_sha256, load_stack, read_contract_file
+from coval_bench.config import Settings
+from coval_bench.contracts import (
+    contract_sha256,
+    has_private_contract,
+    load_stack,
+    read_contract_file,
+)
+from coval_bench.fixture_sources import install_fixture_providers
 from coval_bench.variants.platforms import redact
 
 TOOL_TIMEOUT_SECONDS = 20
@@ -356,7 +363,21 @@ class CovalClient(_JsonClient):
         return run if isinstance(run, dict) else payload
 
 
-COVAL_MANAGED = ("phone_number", "prompt", "metadata", "attributes")
+COVAL_MANAGED = ("phone_number", "prompt", "metadata", "attributes", "display_name", "tags")
+
+
+def published_contract_sha256(suite: str) -> str:
+    """The hash a run or agent may be labelled with; refuses when the fixtures are unreadable here.
+
+    ``contract_sha256`` falls back to the public files alone, which would label the
+    run with a number that does not describe the seeded world the mock answered from.
+    """
+    if not has_private_contract(suite):
+        raise SyncError(
+            f"no mock fixtures for {suite!r} here (checkout or MOCK_FIXTURES_BUCKET); "
+            "the contract hash would omit the seeded world"
+        )
+    return contract_sha256(suite)
 
 
 def coval_agent_body(spec: PlatformAgentSpec) -> dict[str, Any]:
@@ -373,7 +394,7 @@ def coval_agent_body(spec: PlatformAgentSpec) -> dict[str, Any]:
         "attributes": {
             "platform": spec.platform,
             "suite": spec.suite,
-            "contract_sha256": contract_sha256(spec.suite),
+            "contract_sha256": published_contract_sha256(spec.suite),
         },
         "tags": ["orchestration", spec.suite, spec.platform],
     }
@@ -390,6 +411,11 @@ def register(
         if dry_run:
             return "", result
         return str(client.create_agent(wanted)["id"]), result
+    if live.get("model_type") != COVAL_MODEL_TYPE:
+        raise SyncError(
+            f"coval agent {live.get('id')} is {live.get('model_type')!r}, not {COVAL_MODEL_TYPE}; "
+            "model_type cannot be patched, so this record is not ours to reconcile"
+        )
     result = plan(live, {path: wanted[path] for path in COVAL_MANAGED})
     if result.update and not dry_run:
         client.update_agent(str(live["id"]), {path: wanted[path] for path in result.update})
@@ -411,7 +437,7 @@ def launch_body(
     sample: int,
     seed: int,
 ) -> dict[str, Any]:
-    sha = contract_sha256(spec.suite)
+    sha = published_contract_sha256(spec.suite)
     return {
         "agent_id": agent_id,
         "persona_id": persona_id,
@@ -540,6 +566,7 @@ def assets_smoke(agent_key: str, mock_base_url: str, tool: str, args: tuple[str,
 def assets_register(agent_key: str, coval_api_base: str, yes: bool) -> None:
     """Create or reconcile the Coval agent that dials this variant."""
     spec = spec_for(agent_key)
+    install_fixture_providers(Settings())
     with CovalClient(COVAL_API_KEY.resolve(), coval_api_base) as client:
         agent_id, preview = register(client, spec, dry_run=True)
         _echo_plan(preview)
@@ -581,27 +608,31 @@ def assets_launch(
     wait: bool,
     allow_drift: bool,
 ) -> None:
-    """Launch one Coval run against this variant's registered agent, once the platform matches."""
+    """Launch one Coval run against this variant, once both the platform and Coval agent match."""
     spec = spec_for(agent_key)
+    install_fixture_providers(Settings())
     platform = platform_for(spec)
     with platform.client(spec.api_key.resolve(), api_base or platform.api_base) as client:
         pending = drift(client, spec, mock_base_url)
-    if pending:
-        message = f"{agent_key} drifts from the contract: {pending}; run apply first"
-        if not allow_drift:
-            raise click.ClickException(message)
-        click.echo(f"warning: {message}")
-    with CovalClient(COVAL_API_KEY.resolve(), coval_api_base) as client:
-        agent = client.find_agent(spec.key)
-        if agent is None:
+    with CovalClient(COVAL_API_KEY.resolve(), coval_api_base) as coval:
+        agent_id, coval_plan = register(coval, spec, dry_run=True)
+        if not agent_id:
             raise click.ClickException(f"no Coval agent for {agent_key}; run register first")
-        run = client.launch_run(
-            launch_body(str(agent["id"]), spec, persona_id, test_set_id, metric_ids, sample, seed)
+        pending += [f"coval:{path}" for path in sorted(coval_plan.update)]
+        if pending:
+            message = (
+                f"{agent_key} drifts from the contract: {pending}; run apply and register first"
+            )
+            if not allow_drift:
+                raise click.ClickException(message)
+            click.echo(f"warning: {message}")
+        run = coval.launch_run(
+            launch_body(agent_id, spec, persona_id, test_set_id, metric_ids, sample, seed)
         )
         run_id = str(run.get("run_id") or run.get("id"))
         click.echo(f"run_id: {run_id} status: {run.get('status')}")
         click.echo("open this run id in the Coval UI to watch the simulation")
         while wait and run.get("status") not in {"COMPLETED", "FAILED", "CANCELLED", "DELETED"}:
             time.sleep(30)
-            run = client.get_run(run_id)
+            run = coval.get_run(run_id)
             click.echo(f"status: {run.get('status')} progress: {run.get('progress')}")

--- a/runner/tests/unit/test_platform_assets.py
+++ b/runner/tests/unit/test_platform_assets.py
@@ -14,13 +14,20 @@ from coval_bench.contracts import read_contract_file
 from coval_bench.platform_assets import (
     AGENTS,
     TOOL_TIMEOUT_SECONDS,
+    CovalClient,
+    Plan,
     SyncError,
     VapiClient,
     apply,
+    coval_agent_body,
     desired,
+    drift,
+    launch_body,
     patch_body,
     plan,
     platform_for,
+    probe_vapi,
+    register,
     render_vapi_tools,
     spec_for,
 )
@@ -51,6 +58,7 @@ def env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("VAPI_DENTAL_ASSISTANT_ID", "asst_1")
     monkeypatch.setenv("VAPI_API_KEY", "vapi-key")
     monkeypatch.setenv("MOCK_TOOLS_SECRET", SECRET)
+    monkeypatch.setenv("VAPI_DENTAL_DIAL_TARGET", "sip:appointment-dental@sip.vapi.ai")
 
 
 def _client(handler: Any) -> VapiClient:  # noqa: ANN401
@@ -240,3 +248,163 @@ def test_apply_surfaces_vendor_errors(env: None) -> None:
         pytest.raises(SyncError, match="PATCH /assistant/asst_1 -> 400"),
     ):
         apply(client, DENTAL, desired(DENTAL, BASE))
+
+
+# --- dry run ---------------------------------------------------------------
+
+
+def test_apply_dry_run_plans_but_never_patches(env: None) -> None:
+    seen: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request.method)
+        return httpx.Response(200, json=LIVE)
+
+    with _client(handler) as client:
+        result = apply(client, DENTAL, desired(DENTAL, BASE), dry_run=True)
+    assert list(result.update) == ["model.tools"]
+    assert result.prepared == []
+    assert seen == ["GET"]
+
+
+def test_platform_without_prepare_reports_nothing_prepared(env: None) -> None:
+    assert platform_for(DENTAL).prepare is None
+    with _client(lambda r: httpx.Response(200, json=LIVE)) as client:
+        assert apply(client, DENTAL, desired(DENTAL, BASE)).prepared == []
+
+
+def test_plan_summary_names_all_three_buckets() -> None:
+    result = Plan(update={"a": (1, 2)}, unchanged=["b"], prepared=["secret:x"])
+    assert result.summary() == "prepare=['secret:x'] update=['a'] unchanged=['b']"
+
+
+# --- probe -----------------------------------------------------------------
+
+
+def test_vapi_probe_sends_the_sdk_envelope_at_the_tool_url() -> None:
+    (tool, *_) = render_vapi_tools(CONTRACT, BASE, SECRET)
+    url, headers, body = probe_vapi(tool, {"phone": "6025550182"}, SECRET, "sim-1")
+    assert url == "https://mock.example.com/mock/vapi"
+    assert headers == {"X-Mock-Tools-Key": SECRET, "X-Coval-Simulation-Id": "sim-1"}
+    (call,) = body["message"]["toolCallList"]
+    assert call["id"] == "sim-1-1"
+    assert call["function"] == {"name": "lookup_patient", "arguments": '{"phone": "6025550182"}'}
+
+
+# --- coval side ------------------------------------------------------------
+
+
+def test_coval_agent_body_dials_the_target_with_the_pinned_codec(env: None) -> None:
+    body = coval_agent_body(DENTAL)
+    assert body["model_type"] == "MODEL_TYPE_VOICE"
+    assert body["phone_number"] == "sip:appointment-dental@sip.vapi.ai"
+    assert body["metadata"] == {"audio_codec": "PCMU"}
+    assert body["customer_agent_id"] == "vapi-dental"
+    assert body["attributes"]["platform"] == "vapi"
+    assert body["tags"] == ["orchestration", "dental", "vapi"]
+    assert body["prompt"].startswith("BrightSmile Dental")
+
+
+def test_dial_target_is_required_and_named_when_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("VAPI_DENTAL_DIAL_TARGET", raising=False)
+    with pytest.raises(RuntimeError, match="VAPI_DENTAL_DIAL_TARGET is unset"):
+        coval_agent_body(DENTAL)
+
+
+def _coval_client(state: dict[str, Any]) -> CovalClient:
+    def handler(request: httpx.Request) -> httpx.Response:
+        state.setdefault("calls", []).append((request.method, request.url.path))
+        if request.url.path == "/v1/agents" and request.method == "GET":
+            return httpx.Response(200, json={"agents": state["agents"], "next_page_token": ""})
+        if request.url.path == "/v1/agents":
+            created = {**json.loads(request.content), "id": "A" * 22}
+            state["agents"].append(created)
+            return httpx.Response(200, json={"agent": created})
+        if request.url.path.startswith("/v1/agents/"):
+            state["patched"] = json.loads(request.content)
+            return httpx.Response(200, json={"agent": state["agents"][0]})
+        if request.url.path == "/v1/runs":
+            state["launched"] = json.loads(request.content)
+            return httpx.Response(200, json={"run": {"run_id": "R" * 22, "status": "PENDING"}})
+        return httpx.Response(404, text=request.url.path)
+
+    return CovalClient(
+        "coval-key", "https://api.coval.dev/v1", transport=httpx.MockTransport(handler)
+    )
+
+
+def test_register_creates_the_coval_agent_when_absent(env: None) -> None:
+    state: dict[str, Any] = {"agents": []}
+    with _coval_client(state) as client:
+        agent_id, result = register(client, DENTAL)
+    assert agent_id == "A" * 22
+    assert set(result.update) == {"phone_number", "prompt", "metadata", "attributes"}
+    assert state["agents"][0]["phone_number"] == "sip:appointment-dental@sip.vapi.ai"
+
+
+def test_register_patches_only_the_drifted_fields(env: None) -> None:
+    live = {**coval_agent_body(DENTAL), "id": "A", "phone_number": "sip:old@sip.vapi.ai"}
+    state: dict[str, Any] = {"agents": [live]}
+    with _coval_client(state) as client:
+        agent_id, result = register(client, DENTAL)
+    assert agent_id == "A"
+    assert list(result.update) == ["phone_number"]
+    assert state["patched"] == {"phone_number": "sip:appointment-dental@sip.vapi.ai"}
+
+
+def test_register_matches_on_customer_agent_id_not_display_name(env: None) -> None:
+    other = {**coval_agent_body(DENTAL), "id": "B", "customer_agent_id": "someone-else"}
+    state: dict[str, Any] = {"agents": [other]}
+    with _coval_client(state) as client:
+        agent_id, _ = register(client, DENTAL)
+    assert agent_id == "A" * 22
+    assert len(state["agents"]) == 2
+
+
+def test_register_dry_run_writes_nothing(env: None) -> None:
+    state: dict[str, Any] = {"agents": []}
+    with _coval_client(state) as client:
+        agent_id, result = register(client, DENTAL, dry_run=True)
+    assert agent_id == ""
+    assert len(result.update) == 4
+    assert all(method == "GET" for method, _ in state["calls"])
+
+
+def test_launch_body_is_reproducible_and_tagged_with_the_arm(env: None) -> None:
+    body = launch_body("A" * 22, DENTAL, "P" * 22, "T" * 8, ("M" * 22,), 3, 42)
+    assert body["agent_id"] == "A" * 22
+    assert body["options"] == {
+        "iteration_count": 1,
+        "concurrency": 1,
+        "sub_sample_size": 3,
+        "sub_sample_seed": 42,
+    }
+    assert body["metric_ids"] == ["M" * 22]
+    assert body["metadata"]["customer_metadata"]["arm"] == "vapi-dental"
+    assert body["metadata"]["display_name"].startswith("vapi-dental e2e ")
+
+
+def test_launch_run_unwraps_the_run(env: None) -> None:
+    state: dict[str, Any] = {"agents": []}
+    with _coval_client(state) as client:
+        run = client.launch_run(launch_body("A" * 22, DENTAL, "P" * 22, "T" * 8, (), 1, 1))
+    assert run == {"run_id": "R" * 22, "status": "PENDING"}
+    assert state["launched"]["options"]["sub_sample_size"] == 1
+
+
+def test_drift_lists_what_apply_would_still_change_without_writing(env: None) -> None:
+    seen: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request.method)
+        return httpx.Response(200, json=LIVE)
+
+    with _client(handler) as client:
+        assert drift(client, DENTAL, BASE) == ["model.tools"]
+    assert seen == ["GET"]
+
+
+def test_drift_is_empty_once_the_platform_matches(env: None) -> None:
+    synced = {**LIVE, "model": {**LIVE["model"], "tools": desired(DENTAL, BASE)["model.tools"]}}
+    with _client(lambda r: httpx.Response(200, json=synced)) as client:
+        assert drift(client, DENTAL, BASE) == []

--- a/runner/tests/unit/test_platform_assets.py
+++ b/runner/tests/unit/test_platform_assets.py
@@ -9,6 +9,7 @@ from typing import Any
 import httpx
 import pytest
 
+import coval_bench.platform_assets as platform_assets
 from coval_bench.assets import SecretRef
 from coval_bench.contracts import read_contract_file
 from coval_bench.platform_assets import (
@@ -59,6 +60,7 @@ def env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("VAPI_API_KEY", "vapi-key")
     monkeypatch.setenv("MOCK_TOOLS_SECRET", SECRET)
     monkeypatch.setenv("VAPI_DENTAL_DIAL_TARGET", "sip:appointment-dental@sip.vapi.ai")
+    monkeypatch.setattr(platform_assets, "has_private_contract", lambda suite: True)
 
 
 def _client(handler: Any) -> VapiClient:  # noqa: ANN401
@@ -338,7 +340,7 @@ def test_register_creates_the_coval_agent_when_absent(env: None) -> None:
     with _coval_client(state) as client:
         agent_id, result = register(client, DENTAL)
     assert agent_id == "A" * 22
-    assert set(result.update) == {"phone_number", "prompt", "metadata", "attributes"}
+    assert set(result.update) == set(platform_assets.COVAL_MANAGED)
     assert state["agents"][0]["phone_number"] == "sip:appointment-dental@sip.vapi.ai"
 
 
@@ -366,7 +368,7 @@ def test_register_dry_run_writes_nothing(env: None) -> None:
     with _coval_client(state) as client:
         agent_id, result = register(client, DENTAL, dry_run=True)
     assert agent_id == ""
-    assert len(result.update) == 4
+    assert len(result.update) == len(platform_assets.COVAL_MANAGED) == 6
     assert all(method == "GET" for method, _ in state["calls"])
 
 
@@ -408,3 +410,34 @@ def test_drift_is_empty_once_the_platform_matches(env: None) -> None:
     synced = {**LIVE, "model": {**LIVE["model"], "tools": desired(DENTAL, BASE)["model.tools"]}}
     with _client(lambda r: httpx.Response(200, json=synced)) as client:
         assert drift(client, DENTAL, BASE) == []
+
+
+def test_register_reconciles_display_name_and_tags_too(env: None) -> None:
+    live = {**coval_agent_body(DENTAL), "id": "A", "display_name": "old name", "tags": []}
+    state: dict[str, Any] = {"agents": [live]}
+    with _coval_client(state) as client:
+        _, result = register(client, DENTAL)
+    assert sorted(result.update) == ["display_name", "tags"]
+    assert state["patched"] == {
+        "display_name": "vapi-dental",
+        "tags": ["orchestration", "dental", "vapi"],
+    }
+
+
+def test_register_refuses_a_non_voice_agent_with_our_customer_id(env: None) -> None:
+    live = {**coval_agent_body(DENTAL), "id": "A", "model_type": "MODEL_TYPE_SMS"}
+    with (
+        _coval_client({"agents": [live]}) as client,
+        pytest.raises(SyncError, match="MODEL_TYPE_SMS"),
+    ):
+        register(client, DENTAL)
+
+
+def test_contract_hash_refuses_to_label_without_the_fixtures(
+    env: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(platform_assets, "has_private_contract", lambda suite: False)
+    with pytest.raises(SyncError, match="seeded world"):
+        coval_agent_body(DENTAL)
+    with pytest.raises(SyncError, match="seeded world"):
+        launch_body("A" * 22, DENTAL, "P" * 22, "T" * 8, (), 1, 1)


### PR DESCRIPTION

No vendor is added here, first pass at running things from this repo more natively. PR 584 makes sure the Vapi side, Coval side, and mock-tool contract are aligned before spending benchmark quota.

High level:
1. apply
   - Reads the desired Vapi configuration from the repo and private contract files.
   - Compares it with the live Vapi assistant.
   - Patches only managed fields that differ.
2. register
   - Creates or updates the matching Coval voice agent.
   - Sets the SIP dial target, prompt, codec metadata, tags, and contract hash.
   - Refuses to patch an existing agent if its model type is not voice.
3. launch
   - Checks that the Vapi assistant has no drift.
   - Checks that the Coval agent has no drift.
   - Refuses to launch if either side differs, unless --allow-drift is used.
   - Launches a deterministic sampled run with a fixed seed.
4. smoke
   - Sends one synthetic tool call directly to the mock tool endpoint.
   - Confirms the tool URL, payload, authentication, and response work.

teh flow: apply -> register -> smoke -> launch
 note: The Telnyx codec and fetcher are in #583; the Telnyx assistant row follows once this lands.
