### PR TITLE
[BENCH-785] Make the Coval fetch benchmark-aware

### DIFF
--- a/runner/src/coval_bench/db/writer.py
+++ b/runner/src/coval_bench/db/writer.py
@@ -909,10 +909,12 @@ class RunWriter:
                 await cur.execute(sql, (status, error, run_id))
             await conn.commit()
 
-    async def coval_run_ingested(self, *, provider: str, coval_run_id: str) -> bool:
+    async def coval_run_ingested(
+        self, *, provider: str, coval_run_id: str, benchmark: str = "S2S"
+    ) -> bool:
         """True if a succeeded or partial run already holds rows for this Coval run.
 
-        S2S rows store ``audio_filename = '<coval_run_id>/<sim_id>'``. Lets the
+        Coval rows store ``audio_filename = '<coval_run_id>/<sim_id>'``. Lets the
         fetch job skip a re-pulled run so a retry or stale re-pull doesn't
         double-write the day's bucket. Rows from failed runs don't count: they
         never reach the bucket, so a retry must stay free to re-ingest the run.
@@ -922,20 +924,25 @@ class RunWriter:
             FROM benchmarks_v2.results r
             JOIN benchmarks_v2.runs rn ON rn.id = r.run_id
             WHERE r.provider = %s
-              AND r.benchmark = 'S2S'
+              AND r.benchmark = %s
               AND split_part(r.audio_filename, '/', 1) = %s
               AND rn.status IN ('succeeded', 'partial')
             LIMIT 1
         """
         async with self._pool.connection() as conn:
             async with conn.cursor() as cur:
-                await cur.execute(sql, (provider, coval_run_id))
+                await cur.execute(sql, (provider, benchmark, coval_run_id))
                 row = await cur.fetchone()
             await conn.commit()
         return row is not None
 
     async def coval_metric_ingested(
-        self, *, provider: str, coval_run_id: str, metric_type: str
+        self,
+        *,
+        provider: str,
+        coval_run_id: str,
+        metric_type: str,
+        benchmark: str = "S2S",
     ) -> bool:
         """True if a succeeded/partial run already holds this Coval run's ``metric_type`` rows.
 
@@ -948,7 +955,7 @@ class RunWriter:
             FROM benchmarks_v2.results r
             JOIN benchmarks_v2.runs rn ON rn.id = r.run_id
             WHERE r.provider = %s
-              AND r.benchmark = 'S2S'
+              AND r.benchmark = %s
               AND r.metric_type = %s
               AND split_part(r.audio_filename, '/', 1) = %s
               AND rn.status IN ('succeeded', 'partial')
@@ -956,7 +963,7 @@ class RunWriter:
         """
         async with self._pool.connection() as conn:
             async with conn.cursor() as cur:
-                await cur.execute(sql, (provider, metric_type, coval_run_id))
+                await cur.execute(sql, (provider, benchmark, metric_type, coval_run_id))
                 row = await cur.fetchone()
             await conn.commit()
         return row is not None

--- a/runner/src/coval_bench/s2s/conditions.py
+++ b/runner/src/coval_bench/s2s/conditions.py
@@ -1,6 +1,6 @@
 # Copyright 2026 The Coval Benchmarks Authors
 # SPDX-License-Identifier: Apache-2.0
-"""Which metrics each S2S caller condition carries.
+"""Which metrics each Coval caller condition carries.
 
 A condition is one dataset id. ``required`` must be on the run or the run is a
 fault; ``optional`` is written when present; anything named in neither is never
@@ -17,7 +17,7 @@ from enum import StrEnum
 
 from pydantic import BaseModel
 
-from coval_bench.registries import Metric
+from coval_bench.registries import Benchmark, Metric
 
 __all__ = [
     "DATASET_ID",
@@ -33,6 +33,7 @@ __all__ = [
     "DEFAULT_CONDITION",
     "FAMILY_DENTAL",
     "FAMILY_HAPPYPATH",
+    "FAMILY_LLM_DENTAL",
     "FAMILY_MULTITURN",
     "Condition",
     "DatasetMetrics",
@@ -65,6 +66,7 @@ FAMILY_HAPPYPATH = "s2s-happypath"
 # happy-path on purpose: pooling two populations under one dataset id would break
 # the one-dataset-id = one-condition = one-population anchor the metrics rest on.
 FAMILY_DENTAL = "s2s-dental"
+FAMILY_LLM_DENTAL = "llm-dental"
 
 # Single-turn SLURP manifest (legacy, latency only) and the multi-turn Coval test
 # set, split by caller condition so background noise never pools into the clean
@@ -86,7 +88,7 @@ DATASET_ID_DENTAL_ACCENTED = "s2s-dental-accented-v1"
 DATASET_ID_LLM_DENTAL = "llm-dental-v1"
 
 # Unlisted pairs are a configuration error, not a silent skip.
-DATASET_IDS: dict[tuple[str, Condition], str] = {
+DATASET_IDS: dict[tuple[str, Condition], str | None] = {
     (FAMILY_MULTITURN, Condition.CLEAN): DATASET_ID_MULTITURN,
     (FAMILY_MULTITURN, Condition.NOISY): DATASET_ID_MULTITURN_NOISY,
     (FAMILY_HAPPYPATH, Condition.CLEAN): DATASET_ID_HAPPYPATH,
@@ -95,6 +97,9 @@ DATASET_IDS: dict[tuple[str, Condition], str] = {
     (FAMILY_DENTAL, Condition.CLEAN): DATASET_ID_DENTAL,
     (FAMILY_DENTAL, Condition.NOISY): DATASET_ID_DENTAL_NOISY,
     (FAMILY_DENTAL, Condition.ACCENTED): DATASET_ID_DENTAL_ACCENTED,
+    (FAMILY_LLM_DENTAL, Condition.CLEAN): DATASET_ID_LLM_DENTAL,
+    (FAMILY_LLM_DENTAL, Condition.NOISY): None,
+    (FAMILY_LLM_DENTAL, Condition.ACCENTED): None,
 }
 
 
@@ -115,8 +120,10 @@ class DatasetMetrics(BaseModel, frozen=True):
     every optional metric's conversation ids must match it to be written.
     """
 
+    benchmark: Benchmark = Benchmark.S2S
     required: Metric
     optional: frozenset[Metric] = frozenset()
+    local: frozenset[Metric] = frozenset()
 
     @property
     def fetched(self) -> frozenset[Metric]:
@@ -164,6 +171,11 @@ CONDITIONS: dict[str, DatasetMetrics] = {
     DATASET_ID_DENTAL_ACCENTED: DatasetMetrics(
         required=Metric.INSTRUCTION_FOLLOWING,
         optional=frozenset({Metric.INTERRUPTION_RATE}),
+    ),
+    DATASET_ID_LLM_DENTAL: DatasetMetrics(
+        benchmark=Benchmark.LLM,
+        required=Metric.INSTRUCTION_FOLLOWING,
+        local=frozenset({Metric.TTFT}),
     ),
 }
 

--- a/runner/src/coval_bench/s2s/fetch_v2v.py
+++ b/runner/src/coval_bench/s2s/fetch_v2v.py
@@ -1,7 +1,7 @@
 # Copyright 2026 The Coval Benchmarks Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Fetch S2S (voice-to-voice) latency from the Coval API and write per-clip rows.
+"""Fetch benchmark metrics from the Coval API and write per-conversation rows.
 
 Ingests each provider's recent completed runs not yet in the DB, slotted by
 run create_time, and flags providers with no fresh data. Agent ids, the
@@ -53,7 +53,7 @@ WINDOW_PAGE_SIZE = 10
 
 @dataclass(frozen=True)
 class AgentSpec:
-    """One S2S provider: the Settings attr holding its Coval agent id + display strings."""
+    """One provider: the Settings attr holding its Coval agent id + display strings."""
 
     agent_id_attr: str
     provider: str
@@ -65,6 +65,7 @@ class AgentSpec:
     family: str = FAMILY_MULTITURN
     # Whether this agent's recordings may reach the public samples card.
     publish_samples: bool = True
+    benchmark: Benchmark = Benchmark.S2S
 
 
 @dataclass(frozen=True)
@@ -406,7 +407,7 @@ def _s2s_rows(
                 run_id=run_pk,
                 provider=spec.provider,
                 model=spec.model,
-                benchmark=Benchmark.S2S,
+                benchmark=spec.benchmark,
                 metric_type=metric,
                 metric_units=METRIC_SPECS[metric].units,
                 metric_value=metric_value,
@@ -451,7 +452,7 @@ def _failed_conversation_rows(
             run_id=run_pk,
             provider=spec.provider,
             model=spec.model,
-            benchmark=Benchmark.S2S,
+            benchmark=spec.benchmark,
             metric_type=Metric.V2V,
             metric_units=METRIC_SPECS[Metric.V2V].units,
             metric_value=None,
@@ -473,12 +474,16 @@ def _metric_values(metrics: dict[str, Any], metric_id: str | None) -> list[dict[
 
 def _ingestable(condition: DatasetMetrics, metric_ids: Mapping[Metric, str]) -> frozenset[Metric]:
     """The condition's metrics that are configured and have a row builder."""
-    return frozenset(m for m in condition.fetched if m in metric_ids and m in _VALUE_MAPPERS)
+    fetched = frozenset(
+        metric for metric in condition.fetched if metric in metric_ids and metric in _VALUE_MAPPERS
+    )
+    return fetched | condition.local
 
 
 async def _pending_metrics(
     writer: RunWriter,
     *,
+    benchmark: Benchmark,
     provider: str,
     coval_run_id: str,
     condition: DatasetMetrics,
@@ -488,7 +493,10 @@ async def _pending_metrics(
     pending: set[Metric] = set()
     for metric in _ingestable(condition, metric_ids):
         if not await writer.coval_metric_ingested(
-            provider=provider, coval_run_id=coval_run_id, metric_type=metric
+            benchmark=benchmark,
+            provider=provider,
+            coval_run_id=coval_run_id,
+            metric_type=metric,
         ):
             pending.add(metric)
     return frozenset(pending)
@@ -663,7 +671,7 @@ async def _ingest_run(
         if all_rows:
             captured_at = datetime.now(UTC)
             await writer.record_results(all_rows, created_at=captured_at)
-            if normalized_dual_write_enabled:
+            if normalized_dual_write_enabled and spec.benchmark is Benchmark.S2S:
                 from coval_bench.runner.normalized import dual_write
 
                 grouped: dict[str, list[Result]] = {}
@@ -870,6 +878,10 @@ async def _fetch_one_provider(
                 continue
             dataset_id, dataset_sha256 = identity
             condition = condition_for(dataset_id)
+            if condition.benchmark is not spec.benchmark:
+                raise RuntimeError(
+                    f"dataset {dataset_id!r} belongs to {condition.benchmark}, not {spec.benchmark}"
+                )
             if condition.required not in metric_ids:
                 logger.warning(
                     "required_metric_unconfigured",
@@ -881,6 +893,7 @@ async def _fetch_one_provider(
             ingestable = _ingestable(condition, metric_ids)
             pending = await _pending_metrics(
                 writer,
+                benchmark=spec.benchmark,
                 provider=spec.provider,
                 coval_run_id=coval_run.run_id,
                 condition=condition,
@@ -962,11 +975,12 @@ async def _fetch_one_provider(
 async def fetch_and_write_v2v(
     settings: Settings | None = None,
     *,
+    benchmark: Benchmark = Benchmark.S2S,
     only_run_ids: frozenset[str] | None = None,
     window_seconds: int | None = None,
     page_size: int = WINDOW_PAGE_SIZE,
 ) -> dict[str, RunStatus]:
-    """Ingest every provider's recent runs; return per-provider status.
+    """Ingest the selected benchmark's providers; return per-provider status.
 
     Each ingested Coval run gets its own run row slotted by its create_time,
     and ``coval_run_ingested`` makes re-scans no-ops, so ticks are idempotent
@@ -974,9 +988,10 @@ async def fetch_and_write_v2v(
     run more often than the sims.
     """
     settings = settings or get_settings()
+    specs = tuple(spec for spec in AGENTS if spec.benchmark is benchmark)
 
     metric_id = settings.coval_s2s_latency_metric_id
-    if not metric_id:
+    if benchmark is Benchmark.S2S and not metric_id:
         raise RuntimeError("coval_s2s_latency_metric_id is not set")
     # Instruction ingestion and the test-set filter go together: instruction
     # without the filter would pool other sims on the same agents into the S2S
@@ -992,7 +1007,7 @@ async def fetch_and_write_v2v(
         )
     instruction_metric_id = raw_instr or None
     test_set_id = raw_test_set or None
-    if bool(instruction_metric_id) != bool(test_set_id):
+    if benchmark is Benchmark.S2S and bool(instruction_metric_id) != bool(test_set_id):
         raise RuntimeError(
             "coval_s2s_instruction_metric_id and coval_s2s_test_set_id must be set together"
         )
@@ -1007,7 +1022,7 @@ async def fetch_and_write_v2v(
     # A family's test set is required once one of its agents is configured;
     # unset would otherwise skip the agent with a warning that reads the same
     # as never having configured it.
-    for spec in AGENTS:
+    for spec in specs:
         if not spec.test_set_id_attr or not getattr(settings, spec.agent_id_attr):
             continue
         if not (getattr(settings, spec.test_set_id_attr) or "").strip():
@@ -1020,19 +1035,21 @@ async def fetch_and_write_v2v(
     if raw_noisy is not None and not raw_noisy.strip():
         raise RuntimeError("coval_s2s_noisy_persona_id must not be blank")
     noisy_persona_id = raw_noisy or None
-    if noisy_persona_id and not test_set_id:
+    if benchmark is Benchmark.S2S and noisy_persona_id and not test_set_id:
         raise RuntimeError("coval_s2s_noisy_persona_id requires coval_s2s_test_set_id")
     # Supersedes coval_s2s_noisy_persona_id once set, so the two can deploy in
     # either order.
     persona_conditions = _persona_conditions(settings.coval_s2s_condition_personas)
-    if persona_conditions and not test_set_id:
+    if benchmark is Benchmark.S2S and persona_conditions and not test_set_id:
         raise RuntimeError("coval_s2s_condition_personas requires coval_s2s_test_set_id")
     raw_interruption = settings.coval_s2s_interruption_metric_id
     if raw_interruption is not None and not raw_interruption.strip():
         raise RuntimeError("coval_s2s_interruption_metric_id must not be blank")
     # Only configured metrics are ever asked for, so an unset id simply means that
     # metric is not ingested yet.
-    metric_ids: dict[Metric, str] = {Metric.V2V: metric_id}
+    metric_ids: dict[Metric, str] = {}
+    if metric_id:
+        metric_ids[Metric.V2V] = metric_id
     if instruction_metric_id:
         metric_ids[Metric.INSTRUCTION_FOLLOWING] = instruction_metric_id
     if raw_interruption:
@@ -1047,7 +1064,7 @@ async def fetch_and_write_v2v(
         total_ingested = 0
         matched_run_ids: set[str] = set()
         sampled_runs: list[SampleRun] = []
-        for spec in AGENTS:
+        for spec in specs:
             agent_id = getattr(settings, spec.agent_id_attr)
             if not agent_id:
                 logger.warning("agent_id_unset", provider=spec.provider, attr=spec.agent_id_attr)
@@ -1161,6 +1178,7 @@ def fetch_s2s(coval_run_ids: tuple[str, ...], window_hours: int, page_size: int)
         statuses = asyncio.run(
             fetch_and_write_v2v(
                 settings,
+                benchmark=Benchmark.S2S,
                 only_run_ids=only_run_ids,
                 window_seconds=window_hours * 3600 if only_run_ids else None,
                 page_size=page_size if only_run_ids else WINDOW_PAGE_SIZE,

--- a/runner/tests/unit/test_db_writer.py
+++ b/runner/tests/unit/test_db_writer.py
@@ -31,6 +31,7 @@ from pytest_postgresql.factories import postgresql
 from coval_bench.db.conn import get_pool
 from coval_bench.db.models import Benchmark, Result, ResultStatus, Run, RunStatus
 from coval_bench.db.writer import RunWriter
+from coval_bench.registries import Metric
 
 # ---------------------------------------------------------------------------
 # pytest-postgresql fixtures — server shared via conftest ``pg_proc``
@@ -113,6 +114,20 @@ def _make_result(
         metric_value=0.05 + idx * 0.01,
         metric_units="ratio",
         status=status,
+    )
+
+
+def _coval_result(run_id: int, *, benchmark: Benchmark, coval_run_id: str) -> Result:
+    return Result(
+        run_id=run_id,
+        provider="test-provider",
+        model="test-model",
+        benchmark=benchmark,
+        metric_type=Metric.INSTRUCTION_FOLLOWING,
+        metric_value=100.0,
+        metric_units="percent",
+        audio_filename=f"{coval_run_id}/simulation-1",
+        status=ResultStatus.SUCCESS,
     )
 
 
@@ -970,3 +985,41 @@ def test_record_results_rejects_unknown_metric_type(pg_conn: psycopg.Connection[
         row = cur.fetchone()
     assert row is not None
     assert row[0] == 0
+
+
+def test_coval_ingestion_checks_are_scoped_by_benchmark(
+    pg_conn: psycopg.Connection[Any],
+) -> None:
+    _apply_migrations(pg_conn)
+
+    async def _run() -> tuple[bool, bool, bool, bool]:
+        pool = await _make_pool(pg_conn)
+        try:
+            writer = RunWriter(pool)
+            llm_run = await writer.start_run(dataset_id="llm-dental-v1", dataset_sha256="llm")
+            assert llm_run.id is not None
+            await writer.record_results(
+                [_coval_result(llm_run.id, benchmark=Benchmark.LLM, coval_run_id="RLLM")]
+            )
+            await writer.finish_run(llm_run.id, status=RunStatus.SUCCEEDED)
+            return (
+                await writer.coval_run_ingested(provider="test-provider", coval_run_id="RLLM"),
+                await writer.coval_run_ingested(
+                    provider="test-provider", coval_run_id="RLLM", benchmark="LLM"
+                ),
+                await writer.coval_metric_ingested(
+                    provider="test-provider",
+                    coval_run_id="RLLM",
+                    metric_type=Metric.INSTRUCTION_FOLLOWING,
+                ),
+                await writer.coval_metric_ingested(
+                    provider="test-provider",
+                    coval_run_id="RLLM",
+                    metric_type=Metric.INSTRUCTION_FOLLOWING,
+                    benchmark="LLM",
+                ),
+            )
+        finally:
+            await pool.close()
+
+    assert asyncio.run(_run()) == (False, True, False, True)

--- a/runner/tests/unit/test_s2s_conditions.py
+++ b/runner/tests/unit/test_s2s_conditions.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from coval_bench.registries import Metric
+from coval_bench.registries import Benchmark, Metric
 from coval_bench.s2s import conditions
 
 
@@ -28,9 +28,35 @@ def test_unmapped_dataset_keeps_the_pre_scoping_contract() -> None:
     assert legacy.required is Metric.V2V
 
 
-def test_every_fetched_metric_is_an_s2s_metric() -> None:
-    from coval_bench.registries import METRIC_SPECS, Benchmark
+def test_llm_dental_contract_uses_instruction_and_local_ttft() -> None:
+    llm = conditions.condition_for(conditions.DATASET_ID_LLM_DENTAL)
+    assert llm.benchmark is Benchmark.LLM
+    assert llm.required is Metric.INSTRUCTION_FOLLOWING
+    assert llm.optional == frozenset()
+    assert llm.local == frozenset({Metric.TTFT})
+    assert (
+        conditions.dataset_id_for(conditions.FAMILY_LLM_DENTAL, conditions.Condition.CLEAN)
+        == conditions.DATASET_ID_LLM_DENTAL
+    )
+    assert (
+        conditions.dataset_id_for(conditions.FAMILY_LLM_DENTAL, conditions.Condition.NOISY) is None
+    )
+    assert (
+        conditions.dataset_id_for(conditions.FAMILY_LLM_DENTAL, conditions.Condition.ACCENTED)
+        is None
+    )
+    existing = {
+        dataset_id: condition
+        for dataset_id, condition in conditions.CONDITIONS.items()
+        if dataset_id != conditions.DATASET_ID_LLM_DENTAL
+    }
+    assert all(condition.benchmark is Benchmark.S2S for condition in existing.values())
+    assert all(not condition.local for condition in existing.values())
+
+
+def test_every_condition_metric_supports_its_benchmark() -> None:
+    from coval_bench.registries import METRIC_SPECS
 
     for dataset_id, condition in conditions.CONDITIONS.items():
-        for metric in condition.fetched:
-            assert Benchmark.S2S in METRIC_SPECS[metric].benchmarks, (dataset_id, metric)
+        for metric in condition.fetched | condition.local:
+            assert condition.benchmark in METRIC_SPECS[metric].benchmarks, (dataset_id, metric)

--- a/runner/tests/unit/test_s2s_fetch.py
+++ b/runner/tests/unit/test_s2s_fetch.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import contextlib
 import hashlib
 from collections.abc import AsyncIterator
+from dataclasses import replace
 from datetime import UTC, datetime, timedelta
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
@@ -20,14 +21,16 @@ from structlog.testing import capture_logs
 from coval_bench.config import Settings
 from coval_bench.db.models import MetricExecutor, ResultStatus, Run, RunStatus
 from coval_bench.logging import log_run_failed, log_run_partial
-from coval_bench.registries import Metric
+from coval_bench.registries import Benchmark, Metric
 from coval_bench.s2s import fetch_v2v
 from coval_bench.s2s.conditions import (
     DATASET_ID_MULTITURN,
     DATASET_ID_MULTITURN_NOISY,
     FAMILY_HAPPYPATH,
+    FAMILY_LLM_DENTAL,
     FAMILY_MULTITURN,
     Condition,
+    DatasetMetrics,
     condition_for,
 )
 from coval_bench.s2s.fetch_v2v import AgentSpec, CovalRun
@@ -37,6 +40,15 @@ LATENCY_IDS = {Metric.V2V: "MID"}
 ALL_IDS = {**IDS, Metric.INTERRUPTION_RATE: "RID"}
 
 SPEC = AgentSpec(agent_id_attr="coval_s2s_openai_agent_id", provider="openai", model="gpt-realtime")
+LLM_SPEC = AgentSpec(
+    agent_id_attr="coval_s2s_openai_agent_id",
+    provider="phonely",
+    model="phonely-agent",
+    test_set_id_attr="coval_s2s_dental_test_set_id",
+    family=FAMILY_LLM_DENTAL,
+    publish_samples=False,
+    benchmark=Benchmark.LLM,
+)
 
 
 def _iso(age: timedelta) -> str:
@@ -584,6 +596,36 @@ async def test_fetch_one_provider_noop_when_fresh() -> None:
 
 
 @pytest.mark.asyncio
+async def test_pending_metrics_include_local_metrics_and_scope_dedupe_to_benchmark() -> None:
+    writer = _stub_writer()
+    condition = DatasetMetrics(
+        benchmark=Benchmark.LLM,
+        required=Metric.INSTRUCTION_FOLLOWING,
+        local=frozenset({Metric.TTFT}),
+    )
+
+    pending = await fetch_v2v._pending_metrics(
+        writer,
+        benchmark=Benchmark.LLM,
+        provider="phonely",
+        coval_run_id="R1",
+        condition=condition,
+        metric_ids={Metric.INSTRUCTION_FOLLOWING: "IID"},
+    )
+
+    assert pending == frozenset({Metric.INSTRUCTION_FOLLOWING, Metric.TTFT})
+    assert {call.kwargs["benchmark"] for call in writer.coval_metric_ingested.await_args_list} == {
+        Benchmark.LLM
+    }
+    assert {
+        call.kwargs["metric_type"] for call in writer.coval_metric_ingested.await_args_list
+    } == {
+        Metric.INSTRUCTION_FOLLOWING,
+        Metric.TTFT,
+    }
+
+
+@pytest.mark.asyncio
 async def test_fetch_one_provider_stale_fails() -> None:
     # Newest usable run is older than period + grace (4.5h) -> stale.
     writer = _stub_writer()
@@ -616,7 +658,10 @@ async def test_fetch_one_provider_stale_wins_over_backfill() -> None:
 async def test_optional_metric_alone_does_not_prove_freshness() -> None:
     writer = _stub_writer()
 
-    async def ingested(*, provider: str, coval_run_id: str, metric_type: Metric) -> bool:
+    async def ingested(
+        *, benchmark: Benchmark, provider: str, coval_run_id: str, metric_type: Metric
+    ) -> bool:
+        assert benchmark is Benchmark.S2S
         return metric_type is Metric.INSTRUCTION_FOLLOWING
 
     writer.coval_metric_ingested = AsyncMock(side_effect=ingested)
@@ -718,6 +763,64 @@ async def test_fetch_and_write_v2v_per_provider(monkeypatch: pytest.MonkeyPatch)
     # only openai runs (gemini unset), and it fully succeeds.
     assert statuses == {"openai:gpt-realtime": RunStatus.SUCCEEDED}
     writer.refresh_stats_matviews.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_fetch_and_write_filters_agents_and_allows_llm_without_v2v(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    settings = Settings(
+        coval_s2s_instruction_metric_id="IID",
+        coval_s2s_openai_agent_id="llm-agent",
+        coval_s2s_dental_test_set_id="TSD",
+    )
+    client = _fake_client({}, {})
+    writer = _stub_writer()
+
+    @contextlib.asynccontextmanager
+    async def _fake_pool(_settings: Any) -> AsyncIterator[MagicMock]:
+        yield MagicMock()
+
+    fetch_one = AsyncMock(return_value=(RunStatus.SUCCEEDED, 0))
+    monkeypatch.setattr(fetch_v2v, "AGENTS", (SPEC, LLM_SPEC))
+    monkeypatch.setattr(fetch_v2v, "_client", lambda _settings: client)
+    monkeypatch.setattr(fetch_v2v, "lifespan_pool", _fake_pool)
+    monkeypatch.setattr(fetch_v2v, "RunWriter", lambda _pool: writer)
+    monkeypatch.setattr(fetch_v2v, "_fetch_one_provider", fetch_one)
+
+    statuses = await fetch_v2v.fetch_and_write_v2v(settings, benchmark=Benchmark.LLM)
+
+    assert statuses == {"phonely:phonely-agent": RunStatus.SUCCEEDED}
+    fetch_one.assert_awaited_once()
+    assert fetch_one.await_args is not None
+    assert fetch_one.await_args.kwargs["spec"] is LLM_SPEC
+    assert fetch_one.await_args.kwargs["metric_ids"] == {Metric.INSTRUCTION_FOLLOWING: "IID"}
+
+
+@pytest.mark.asyncio
+async def test_fetch_one_provider_rejects_a_dataset_from_another_benchmark() -> None:
+    writer = _stub_writer()
+    list_json = _list_json({"run_id": "R1", "create_time": _iso(timedelta(hours=1))})
+
+    with capture_logs() as logs:
+        async with _fake_client(list_json, {}) as client:
+            status, ingested = await fetch_v2v._fetch_one_provider(
+                client,
+                writer,
+                spec=replace(LLM_SPEC, family=FAMILY_MULTITURN),
+                agent_id="a1",
+                metric_ids={Metric.INSTRUCTION_FOLLOWING: "IID"},
+                test_set_id="TS1",
+                period_seconds=10_800,
+                stale_grace_seconds=5_400,
+            )
+
+    assert (status, ingested) == (RunStatus.FAILED, 0)
+    assert any(
+        log["event"] == "provider_fetch_failed" and "belongs to S2S, not LLM" in log["error"]
+        for log in logs
+    )
+    writer.coval_metric_ingested.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -1774,6 +1877,41 @@ async def test_ingest_run_dual_writes_one_observation_per_conversation(
     assert calls["R1/s1"]["dataset_sha256"] == hashlib.sha256(b"test-set:persona").hexdigest()
     assert calls["R1/s1"]["executor"] is MetricExecutor.COVAL_API
     assert calls["R1/s1"]["captured_at"] == writer.record_results.await_args.kwargs["created_at"]
+
+
+@pytest.mark.asyncio
+async def test_ingest_run_does_not_dual_write_llm_rows(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    writer = _stub_writer()
+    dual_write = AsyncMock()
+    monkeypatch.setattr("coval_bench.runner.normalized.dual_write", dual_write)
+    condition = DatasetMetrics(
+        benchmark=Benchmark.LLM,
+        required=Metric.INSTRUCTION_FOLLOWING,
+    )
+
+    async with _fake_client(
+        {}, _run_json([{"simulation_output_id": "s1", "value": "YES"}], metric_id="IID")
+    ) as client:
+        status = await fetch_v2v._ingest_run(
+            client,
+            writer,
+            spec=LLM_SPEC,
+            coval_run=CovalRun(run_id="R1", create_time=None),
+            metric_ids={Metric.INSTRUCTION_FOLLOWING: "IID"},
+            condition=condition,
+            dataset_id="llm-dental-v1",
+            period_seconds=10_800,
+            normalized_dual_write_enabled=True,
+        )
+
+    assert status is RunStatus.SUCCEEDED
+    writer.record_results.assert_awaited_once()
+    rows = writer.record_results.await_args.args[0]
+    assert len(rows) == 1
+    assert rows[0].benchmark is Benchmark.LLM
+    dual_write.assert_not_awaited()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Basically takes the current coval fetch job and generalizes it to the LLM benchmark as well.