### PR TITLE
Telnyx assistant manage from the repo

### DIFF
--- a/runner/src/coval_bench/mocktools/codecs.py
+++ b/runner/src/coval_bench/mocktools/codecs.py
@@ -20,6 +20,7 @@ __all__ = [
     "PRESET_PREFIX",
     "Codec",
     "Correlation",
+    "Request",
     "ToolCall",
     "codec_for",
 ]
@@ -50,12 +51,31 @@ class Correlation:
 
 
 @dataclass(frozen=True)
+class Request:
+    """One tool call as the platform would put it on the wire, minus the shared secret."""
+
+    path: str
+    headers: dict[str, str]
+    body: Any
+
+
+@dataclass(frozen=True)
 class Codec:
     name: str
     tool_in_path: bool
     decode: Callable[[Body, Mapping[str, str], str | None], list[ToolCall]]
     correlate: Callable[[Body, Mapping[str, str]], Correlation]
     encode: Callable[[list[ToolCall], list[Outcome]], tuple[Any, int]]
+    encode_request: Callable[[str, dict[str, Any], Correlation], Request]
+
+
+def _coval_header_values(correlation: Correlation) -> dict[str, str]:
+    headers: dict[str, str] = {}
+    if correlation.simulation_id:
+        headers[SIMULATION_HEADER] = correlation.simulation_id
+    if correlation.caller_number:
+        headers[CALLER_HEADER] = correlation.caller_number
+    return headers
 
 
 def _coval_headers(headers: Mapping[str, str]) -> Correlation:
@@ -80,12 +100,17 @@ def _generic_encode(_calls: list[ToolCall], outcomes: list[Outcome]) -> tuple[An
     return outcomes[0].response, 200
 
 
+def _generic_request(tool: str, args: dict[str, Any], correlation: Correlation) -> Request:
+    return Request(f"/mock/generic/{tool}", _coval_header_values(correlation), dict(args))
+
+
 GENERIC = Codec(
     name="generic",
     tool_in_path=True,
     decode=_generic_decode,
     correlate=lambda _body, headers: _coval_headers(headers),
     encode=_generic_encode,
+    encode_request=_generic_request,
 )
 
 
@@ -116,12 +141,22 @@ def _telnyx_correlate(body: Body, headers: Mapping[str, str]) -> Correlation:
     return Correlation()
 
 
+def _telnyx_request(tool: str, args: dict[str, Any], correlation: Correlation) -> Request:
+    body = dict(args)
+    if correlation.simulation_id:
+        body[PRESET_SIMULATION] = correlation.simulation_id
+    if correlation.caller_number:
+        body[PRESET_CALLER] = correlation.caller_number
+    return Request(f"/mock/telnyx/{tool}", {}, body)
+
+
 TELNYX = Codec(
     name="telnyx",
     tool_in_path=True,
     decode=_telnyx_decode,
     correlate=_telnyx_correlate,
     encode=_generic_encode,
+    encode_request=_telnyx_request,
 )
 
 
@@ -185,12 +220,30 @@ def _vapi_encode(calls: list[ToolCall], outcomes: list[Outcome]) -> tuple[Any, i
     }, 200
 
 
+def _vapi_request(tool: str, args: dict[str, Any], correlation: Correlation) -> Request:
+    call_id = f"{correlation.simulation_id or 'call'}-1"
+    body = {
+        "message": {
+            "type": "tool-calls",
+            "toolCallList": [
+                {
+                    "id": call_id,
+                    "type": "function",
+                    "function": {"name": tool, "arguments": json.dumps(args)},
+                }
+            ],
+        }
+    }
+    return Request("/mock/vapi", _coval_header_values(correlation), body)
+
+
 VAPI = Codec(
     name="vapi",
     tool_in_path=False,
     decode=_vapi_decode,
     correlate=_vapi_correlate,
     encode=_vapi_encode,
+    encode_request=_vapi_request,
 )
 
 

--- a/runner/src/coval_bench/platform_assets.py
+++ b/runner/src/coval_bench/platform_assets.py
@@ -31,6 +31,7 @@ TOOL_TIMEOUT_SECONDS = 20
 SIMULATION_HEADER_TEMPLATE = "{{coval-simulation-id}}"
 TOOLS_PATH = "model.tools"
 TELNYX_SIP_SUFFIX = ".sip.telnyx.com"
+TELNYX_SIP_RECEIVE = "from_anyone"
 COVAL_API_BASE = "https://api.coval.dev/v1"
 COVAL_MODEL_TYPE = "MODEL_TYPE_VOICE"
 COVAL_PROMPT_FILE = "_source/coval-prompt.txt"
@@ -288,7 +289,7 @@ class TelnyxClient(_JsonClient):
             {
                 "inbound": {
                     "sip_subdomain": subdomain,
-                    "sip_subdomain_receive_settings": "from_anyone",
+                    "sip_subdomain_receive_settings": TELNYX_SIP_RECEIVE,
                 }
             },
         )
@@ -311,9 +312,10 @@ def prepare_telnyx(client: AgentClient, spec: PlatformAgentSpec, dry_run: bool) 
     app_id = str(_get_path(live, "telephony_settings.default_texml_app_id") or "")
     if not app_id:
         raise SyncError("the assistant has no telephony_settings.default_texml_app_id")
-    current = _get_path(client.get_texml_app(app_id), "inbound.sip_subdomain")
-    if current != wanted:
-        pending.append(f"sip_subdomain:{app_id}={wanted}")
+    inbound = _get_path(client.get_texml_app(app_id), "inbound") or {}
+    current = (inbound.get("sip_subdomain"), inbound.get("sip_subdomain_receive_settings"))
+    if current != (wanted, TELNYX_SIP_RECEIVE):
+        pending.append(f"sip_subdomain:{app_id}={wanted}:{TELNYX_SIP_RECEIVE}")
         if not dry_run:
             client.set_sip_subdomain(app_id, wanted)
     return pending

--- a/runner/src/coval_bench/platform_assets.py
+++ b/runner/src/coval_bench/platform_assets.py
@@ -236,6 +236,8 @@ TELNYX_PINS: dict[str, Pin] = {
     "transcription.language": lambda _stack: "en",
     "voice_settings.voice": lambda stack: f"ElevenLabs.{stack.tts.model}.{stack.tts.voice_id}",
     "voice_settings.api_key_ref": lambda _stack: TELNYX_TTS_REF,
+    "voice_settings.expressive_mode": lambda _stack: False,
+    "tool_ids": lambda _stack: [],
     "telephony_settings.recording_settings.enabled": (
         lambda stack: stack.platform_behaviour.vendor_post_call_analysis
     ),

--- a/runner/src/coval_bench/platform_assets.py
+++ b/runner/src/coval_bench/platform_assets.py
@@ -81,6 +81,7 @@ class AgentClient(Protocol):
 
 ToolRenderer = Callable[[list[dict[str, Any]], str, str], list[dict[str, Any]]]
 Pin = Callable[[Stack], Any]
+Canon = Callable[[Any], Any]
 ClientFactory = Callable[[str, str], AgentClient]
 Prepare = Callable[[AgentClient, PlatformAgentSpec, bool], list[str]]
 
@@ -95,6 +96,7 @@ class Platform:
     tools_path: str
     render_tools: ToolRenderer
     pins: Mapping[str, Pin] = field(default_factory=dict)
+    canon: Mapping[str, Canon] = field(default_factory=dict)
     prepare: Prepare | None = None
 
 
@@ -247,6 +249,26 @@ TELNYX_PINS: dict[str, Pin] = {
 }
 
 
+TELNYX_SERVER_TOOL_KEYS = frozenset({"tool_id", "shared", "timeout_ms"})
+
+
+def _telnyx_canon_tools(live: Any) -> Any:  # noqa: ANN401
+    if not isinstance(live, list):
+        return live
+    return [
+        {k: v for k, v in tool.items() if k not in TELNYX_SERVER_TOOL_KEYS}
+        if isinstance(tool, dict)
+        else tool
+        for tool in live
+    ]
+
+
+TELNYX_CANON: dict[str, Canon] = {
+    "tools": _telnyx_canon_tools,
+    "tool_ids": lambda live: live or [],
+}
+
+
 def sip_subdomain(dial_target: str) -> str:
     """The Telnyx subdomain a ``sip:user@<sub>.sip.telnyx.com`` target names."""
     host = dial_target.split("@", 1)[-1].split(":", 1)[0].lower()
@@ -341,6 +363,7 @@ PLATFORMS: dict[str, Platform] = {
         tools_path="tools",
         render_tools=render_telnyx_tools,
         pins=TELNYX_PINS,
+        canon=TELNYX_CANON,
         prepare=prepare_telnyx,
     ),
 }
@@ -436,10 +459,15 @@ def desired(spec: PlatformAgentSpec, mock_base_url: str) -> dict[str, Any]:
     return wanted
 
 
-def plan(live: dict[str, Any], wanted: dict[str, Any]) -> Plan:
+def plan(
+    live: dict[str, Any], wanted: dict[str, Any], canon: Mapping[str, Canon] | None = None
+) -> Plan:
+    """Compare each managed path, after the platform's canonicaliser strips what the vendor adds."""
     result = Plan()
     for path, value in wanted.items():
         current = _get_path(live, path)
+        if canon and path in canon:
+            current = canon[path](current)
         if current == value:
             result.unchanged.append(path)
         else:
@@ -467,7 +495,7 @@ def apply(
     prepared = platform.prepare(client, spec, dry_run) if platform.prepare else []
     agent_id = spec.agent_id.resolve()
     live = client.get_agent(agent_id)
-    result = plan(live, wanted)
+    result = plan(live, wanted, platform.canon)
     result.prepared = prepared
     if result.update and not dry_run:
         client.update_agent(agent_id, patch_body(live, wanted))

--- a/runner/src/coval_bench/platform_assets.py
+++ b/runner/src/coval_bench/platform_assets.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import copy
 import json
 import time
-from collections.abc import Callable, Iterator
+from collections.abc import Callable, Iterator, Mapping
 from dataclasses import dataclass, field
 from typing import Any, Protocol
 
@@ -17,17 +17,20 @@ from pydantic import BaseModel, Field
 from coval_bench.assets import SecretRef
 from coval_bench.config import Settings
 from coval_bench.contracts import (
+    Stack,
     contract_sha256,
     has_private_contract,
     load_stack,
     read_contract_file,
 )
 from coval_bench.fixture_sources import install_fixture_providers
+from coval_bench.mocktools.codecs import PRESET_CALLER, PRESET_SIMULATION, Correlation, codec_for
 from coval_bench.variants.platforms import redact
 
 TOOL_TIMEOUT_SECONDS = 20
 SIMULATION_HEADER_TEMPLATE = "{{coval-simulation-id}}"
 TOOLS_PATH = "model.tools"
+TELNYX_SIP_SUFFIX = ".sip.telnyx.com"
 COVAL_API_BASE = "https://api.coval.dev/v1"
 COVAL_MODEL_TYPE = "MODEL_TYPE_VOICE"
 COVAL_PROMPT_FILE = "_source/coval-prompt.txt"
@@ -36,6 +39,22 @@ _TIMEOUT = httpx.Timeout(30.0, connect=10.0)
 COVAL_API_KEY = SecretRef(
     name="COVAL_API_KEY", purpose="the Coval API key for the benchmarking org"
 )
+
+
+TELNYX_SECRETS: dict[str, SecretRef] = {
+    "coval-bench-openai": SecretRef(
+        name="OPENAI_API_KEY", purpose="the OpenAI key Telnyx bills LLM calls to"
+    ),
+    "coval-bench-elevenlabs": SecretRef(
+        name="ELEVENLABS_API_KEY", purpose="the ElevenLabs key Telnyx synthesises with"
+    ),
+    "coval-bench-mock": SecretRef(
+        name="MOCK_TOOLS_SECRET", purpose="the shared secret the mock tool endpoint requires"
+    ),
+}
+TELNYX_LLM_REF = "coval-bench-openai"
+TELNYX_TTS_REF = "coval-bench-elevenlabs"
+TELNYX_MOCK_REF = "coval-bench-mock"
 
 
 class SyncError(RuntimeError):
@@ -59,19 +78,22 @@ class AgentClient(Protocol):
     def update_agent(self, agent_id: str, body: dict[str, Any]) -> dict[str, Any]: ...
 
 
-Renderer = Callable[[PlatformAgentSpec, str, str], dict[str, Any]]
+ToolRenderer = Callable[[list[dict[str, Any]], str, str], list[dict[str, Any]]]
+Pin = Callable[[Stack], Any]
 ClientFactory = Callable[[str, str], AgentClient]
 Prepare = Callable[[AgentClient, PlatformAgentSpec, bool], list[str]]
-Probe = Callable[[dict[str, Any], dict[str, Any], str, str], tuple[str, dict[str, str], Any]]
 
 
 @dataclass(frozen=True)
 class Platform:
+    """One vendor: where its API is, how a tool is spelled, and which paths carry the pin."""
+
     name: str
     api_base: str
-    render: Renderer
     client: ClientFactory
-    probe: Probe
+    tools_path: str
+    render_tools: ToolRenderer
+    pins: Mapping[str, Pin] = field(default_factory=dict)
     prepare: Prepare | None = None
 
 
@@ -155,30 +177,6 @@ def render_vapi_tools(
     ]
 
 
-def render_vapi(spec: PlatformAgentSpec, mock_base_url: str, secret: str) -> dict[str, Any]:
-    definitions = json.loads(read_contract_file(spec.suite, "tool-definitions.json"))
-    return {TOOLS_PATH: render_vapi_tools(definitions, mock_base_url, secret)}
-
-
-def probe_vapi(
-    tool: dict[str, Any], args: dict[str, Any], secret: str, simulation_id: str
-) -> tuple[str, dict[str, str], Any]:
-    headers = {"X-Mock-Tools-Key": secret, "X-Coval-Simulation-Id": simulation_id}
-    body = {
-        "message": {
-            "type": "tool-calls",
-            "toolCallList": [
-                {
-                    "id": f"{simulation_id}-1",
-                    "type": "function",
-                    "function": {"name": tool["function"]["name"], "arguments": json.dumps(args)},
-                }
-            ],
-        }
-    }
-    return str(tool["server"]["url"]), headers, body
-
-
 class VapiClient(_JsonClient):
     def __init__(
         self, api_key: str, base_url: str, transport: httpx.BaseTransport | None = None
@@ -195,6 +193,132 @@ class VapiClient(_JsonClient):
         return self._request("PATCH", f"/assistant/{agent_id}", body)
 
 
+# --- telnyx ----------------------------------------------------------------
+
+
+def _mustache_secret(identifier: str) -> str:
+    return f"{{{{#integration_secret}}}}{identifier}{{{{/integration_secret}}}}"
+
+
+def render_telnyx_tools(
+    definitions: list[dict[str, Any]], mock_base_url: str, _secret: str
+) -> list[dict[str, Any]]:
+    base = mock_base_url.rstrip("/")
+    return [
+        {
+            "type": "webhook",
+            "webhook": {
+                "name": definition["name"],
+                "description": definition["description"],
+                "url": f"{base}/mock/telnyx/{definition['name']}",
+                "method": "POST",
+                "headers": [
+                    {"name": "X-Mock-Tools-Key", "value": _mustache_secret(TELNYX_MOCK_REF)}
+                ],
+                "body_parameters": definition["parameters"],
+                "preset_body_fields": {
+                    PRESET_SIMULATION: "{{coval_simulation_id}}",
+                    PRESET_CALLER: "{{telnyx_end_user_target}}",
+                },
+                "timeout_ms": TOOL_TIMEOUT_SECONDS * 1000,
+                "async": False,
+            },
+        }
+        for definition in definitions
+    ]
+
+
+TELNYX_PINS: dict[str, Pin] = {
+    "model": lambda stack: f"{stack.llm.provider}/{stack.llm.model}",
+    "llm_api_key_ref": lambda _stack: TELNYX_LLM_REF,
+    "transcription.model": lambda stack: f"{stack.stt.provider}/{stack.stt.model}",
+    "transcription.language": lambda _stack: "en",
+    "voice_settings.voice": lambda stack: f"ElevenLabs.{stack.tts.model}.{stack.tts.voice_id}",
+    "voice_settings.api_key_ref": lambda _stack: TELNYX_TTS_REF,
+    "telephony_settings.recording_settings.enabled": (
+        lambda stack: stack.platform_behaviour.vendor_post_call_analysis
+    ),
+    "interruption_settings.start_speaking_plan.wait_seconds": (
+        lambda stack: stack.turn_taking.end_of_turn_target_ms / 1000
+    ),
+}
+
+
+def sip_subdomain(dial_target: str) -> str:
+    """The Telnyx subdomain a ``sip:user@<sub>.sip.telnyx.com`` target names."""
+    host = dial_target.split("@", 1)[-1].split(":", 1)[0].lower()
+    if not dial_target.lower().startswith("sip:") or not host.endswith(TELNYX_SIP_SUFFIX):
+        raise SyncError(f"{dial_target!r} is not a sip:...@<sub>{TELNYX_SIP_SUFFIX} target")
+    return host.removesuffix(TELNYX_SIP_SUFFIX)
+
+
+class TelnyxClient(_JsonClient):
+    def __init__(
+        self, api_key: str, base_url: str, transport: httpx.BaseTransport | None = None
+    ) -> None:
+        super().__init__(base_url, {"Authorization": f"Bearer {api_key}"}, transport)
+
+    def __enter__(self) -> TelnyxClient:
+        return self
+
+    def get_agent(self, agent_id: str) -> dict[str, Any]:
+        return _unwrap(self._request("GET", f"/ai/assistants/{agent_id}"))
+
+    def update_agent(self, agent_id: str, body: dict[str, Any]) -> dict[str, Any]:
+        return _unwrap(self._request("POST", f"/ai/assistants/{agent_id}", body))
+
+    def secret_identifiers(self) -> set[str]:
+        payload = self._request("GET", "/integration_secrets", params={"page[size]": 250})
+        return {str(item.get("identifier")) for item in payload.get("data", [])}
+
+    def create_secret(self, identifier: str, token: str) -> None:
+        self._request(
+            "POST",
+            "/integration_secrets",
+            {"identifier": identifier, "type": "bearer", "token": token},
+        )
+
+    def get_texml_app(self, app_id: str) -> dict[str, Any]:
+        return _unwrap(self._request("GET", f"/texml_applications/{app_id}"))
+
+    def set_sip_subdomain(self, app_id: str, subdomain: str) -> None:
+        self._request(
+            "PATCH",
+            f"/texml_applications/{app_id}",
+            {
+                "inbound": {
+                    "sip_subdomain": subdomain,
+                    "sip_subdomain_receive_settings": "from_anyone",
+                }
+            },
+        )
+
+
+def prepare_telnyx(client: AgentClient, spec: PlatformAgentSpec, dry_run: bool) -> list[str]:
+    """Ensure the integration secrets and SIP subdomain exist before the assistant is patched."""
+    if not isinstance(client, TelnyxClient):
+        raise SyncError("telnyx prepare needs a TelnyxClient")
+    pending: list[str] = []
+    present = client.secret_identifiers()
+    for identifier, ref in TELNYX_SECRETS.items():
+        if identifier in present:
+            continue
+        pending.append(f"integration_secret:{identifier}")
+        if not dry_run:
+            client.create_secret(identifier, ref.resolve())
+    wanted = sip_subdomain(spec.dial_target.resolve())
+    live = client.get_agent(spec.agent_id.resolve())
+    app_id = str(_get_path(live, "telephony_settings.default_texml_app_id") or "")
+    if not app_id:
+        raise SyncError("the assistant has no telephony_settings.default_texml_app_id")
+    current = _get_path(client.get_texml_app(app_id), "inbound.sip_subdomain")
+    if current != wanted:
+        pending.append(f"sip_subdomain:{app_id}={wanted}")
+        if not dry_run:
+            client.set_sip_subdomain(app_id, wanted)
+    return pending
+
+
 # --- the table -------------------------------------------------------------
 
 
@@ -202,9 +326,18 @@ PLATFORMS: dict[str, Platform] = {
     "vapi": Platform(
         name="vapi",
         api_base="https://api.vapi.ai",
-        render=render_vapi,
         client=VapiClient,
-        probe=probe_vapi,
+        tools_path=TOOLS_PATH,
+        render_tools=render_vapi_tools,
+    ),
+    "telnyx": Platform(
+        name="telnyx",
+        api_base="https://api.telnyx.com/v2",
+        client=TelnyxClient,
+        tools_path="tools",
+        render_tools=render_telnyx_tools,
+        pins=TELNYX_PINS,
+        prepare=prepare_telnyx,
     ),
 }
 
@@ -225,6 +358,26 @@ AGENTS: tuple[PlatformAgentSpec, ...] = (
         dial_target=SecretRef(
             name="VAPI_DENTAL_DIAL_TARGET",
             purpose="the sip: URI Coval dials to reach the Vapi dental assistant",
+        ),
+    ),
+    PlatformAgentSpec(
+        key="telnyx-dental",
+        platform="telnyx",
+        suite="dental",
+        agent_id=SecretRef(
+            name="TELNYX_DENTAL_ASSISTANT_ID",
+            purpose="the Telnyx assistant id for the dental suite",
+        ),
+        api_key=SecretRef(
+            name="TELNYX_API_KEY", purpose="the Telnyx v2 API key for the benchmark account"
+        ),
+        mock_secret=SecretRef(
+            name="MOCK_TOOLS_SECRET",
+            purpose="the shared secret the mock tool endpoint requires on X-Mock-Tools-Key",
+        ),
+        dial_target=SecretRef(
+            name="TELNYX_DENTAL_DIAL_TARGET",
+            purpose="the sip:...@<sub>.sip.telnyx.com URI Coval dials; names the subdomain",
         ),
     ),
 )
@@ -268,7 +421,15 @@ def _set_path(body: dict[str, Any], path: str, value: Any) -> None:  # noqa: ANN
 
 
 def desired(spec: PlatformAgentSpec, mock_base_url: str) -> dict[str, Any]:
-    return platform_for(spec).render(spec, mock_base_url, spec.mock_secret.resolve())
+    """Every managed path and the value the contract says it should hold."""
+    platform = platform_for(spec)
+    stack = load_stack()
+    definitions = json.loads(read_contract_file(spec.suite, "tool-definitions.json"))
+    wanted: dict[str, Any] = {path: pin(stack) for path, pin in platform.pins.items()}
+    wanted[platform.tools_path] = platform.render_tools(
+        definitions, mock_base_url, spec.mock_secret.resolve()
+    )
+    return wanted
 
 
 def plan(live: dict[str, Any], wanted: dict[str, Any]) -> Plan:
@@ -539,21 +700,18 @@ def assets_apply(agent_key: str, mock_base_url: str, api_base: str | None, yes: 
 def assets_smoke(agent_key: str, mock_base_url: str, tool: str, args: tuple[str, ...]) -> None:
     """Fire one tool call at /mock exactly as this platform would, and print the answer."""
     spec = spec_for(agent_key)
-    platform = platform_for(spec)
-    rendered = desired(spec, mock_base_url)
-    tools = rendered.get(TOOLS_PATH) or rendered.get("tools") or []
-    wanted = next(
-        (t for t in tools if (t.get("function") or t.get("webhook") or {}).get("name") == tool),
-        None,
-    )
-    if wanted is None:
+    codec = codec_for(spec.platform)
+    definitions = json.loads(read_contract_file(spec.suite, "tool-definitions.json"))
+    if tool not in {d["name"] for d in definitions}:
         raise click.ClickException(f"{tool!r} is not in the {spec.suite} contract")
     call_args = dict(item.split("=", 1) for item in args)
     simulation_id = f"smoke-{spec.key}-{int(time.time())}"
-    url, headers, body = platform.probe(
-        wanted, call_args, spec.mock_secret.resolve(), simulation_id
+    request = codec.encode_request(
+        tool, call_args, Correlation(simulation_id, "+15550100000", source="smoke")
     )
-    response = httpx.post(url, headers=headers, json=body, timeout=_TIMEOUT)
+    headers = {**request.headers, "X-Mock-Tools-Key": spec.mock_secret.resolve()}
+    url = f"{mock_base_url.rstrip('/')}{request.path}"
+    response = httpx.post(url, headers=headers, json=request.body, timeout=_TIMEOUT)
     click.echo(f"POST {url} -> {response.status_code}")
     click.echo(response.text[:800])
     click.echo(f"simulation_id sent: {simulation_id}")

--- a/runner/tests/unit/test_codecs.py
+++ b/runner/tests/unit/test_codecs.py
@@ -18,6 +18,7 @@ from coval_bench.mocktools.codecs import (
     PRESET_SIMULATION,
     TELNYX,
     VAPI,
+    Correlation,
     ToolCall,
     codec_for,
 )
@@ -295,3 +296,30 @@ def test_codec_for_names_the_known_set_on_a_miss() -> None:
 def test_each_codec_declares_where_the_tool_name_lives(name: str, tool_in_path: bool) -> None:
     assert codec_for(name).tool_in_path is tool_in_path
     assert CODECS[name].name == name
+
+
+# --- encode_request: the client side of every codec ------------------------
+
+
+@pytest.mark.parametrize("codec", list(CODECS.values()), ids=lambda c: c.name)
+def test_encode_request_round_trips_through_decode_and_correlate(codec: codecs.Codec) -> None:
+    request = codec.encode_request("lookup_patient", {"phone": PHONE}, Correlation(SIM, "+1404"))
+    tool = "lookup_patient" if codec.tool_in_path else None
+    (call,) = codec.decode(request.body, request.headers, tool)
+    assert (call.tool, call.args) == ("lookup_patient", {"phone": PHONE})
+    found = codec.correlate(request.body, request.headers)
+    assert (found.simulation_id, found.caller_number) == (SIM, "+1404")
+
+
+@pytest.mark.parametrize("codec", list(CODECS.values()), ids=lambda c: c.name)
+def test_encode_request_names_the_route_the_router_serves(codec: codecs.Codec) -> None:
+    path = codec.encode_request("lookup_patient", {}, Correlation()).path
+    assert path == (
+        f"/mock/{codec.name}/lookup_patient" if codec.tool_in_path else f"/mock/{codec.name}"
+    )
+
+
+def test_encode_request_never_carries_the_shared_secret() -> None:
+    for codec in CODECS.values():
+        request = codec.encode_request("lookup_patient", {}, Correlation(SIM))
+        assert "x-mock-tools-key" not in {k.lower() for k in request.headers}

--- a/runner/tests/unit/test_platform_assets.py
+++ b/runner/tests/unit/test_platform_assets.py
@@ -439,6 +439,7 @@ class Case:
     expected_drift: frozenset[str]
     pins: dict[str, Any]
     wraps_in_data: bool
+    echo: Any = None
 
 
 CASES = [
@@ -495,6 +496,14 @@ CASES = [
             "interruption_settings.start_speaking_plan.wait_seconds": 0.8,
         },
         wraps_in_data=True,
+        echo=lambda patched: {
+            **patched,
+            "tool_ids": None,
+            "tools": [
+                {**tool, "tool_id": f"tool-{i}", "shared": False, "timeout_ms": 5000}
+                for i, tool in enumerate(patched.get("tools", []))
+            ],
+        },
     ),
 ]
 
@@ -526,7 +535,9 @@ def _platform_client(case: Case, state: dict[str, Any]) -> Any:  # noqa: ANN401
             return httpx.Response(200, json=agent(state.get("live", case.live)))
         if request.url.path == case.agent_path:
             state["patched"] = json.loads(request.content)
-            return httpx.Response(200, json=agent(state["patched"]))
+            echoed = case.echo(state["patched"]) if case.echo else state["patched"]
+            state["live"] = {**case.live, **echoed}
+            return httpx.Response(200, json=agent(state["live"]))
         if request.url.path == "/v2/integration_secrets" and request.method == "GET":
             return httpx.Response(200, json={"data": [{"identifier": i} for i in state["secrets"]]})
         if request.url.path == "/v2/integration_secrets":
@@ -592,7 +603,8 @@ def test_every_platform_pins_what_its_row_declares(case: Case) -> None:
 
 
 def test_plan_flags_exactly_the_drift_on_the_live_agent(case: Case) -> None:
-    result = plan(case.live, desired(spec_for(case.key), BASE))
+    spec = spec_for(case.key)
+    result = plan(case.live, desired(spec, BASE), platform_for(spec).canon)
     assert set(result.update) == set(case.expected_drift)
 
 
@@ -607,7 +619,6 @@ def test_dry_run_reports_without_writing_then_apply_converges(case: Case) -> Non
         applied = apply(client, spec, wanted)
         assert (case.update_method, case.agent_path) in state["calls"]
         assert set(applied.update) == set(case.expected_drift)
-        state["live"] = {**case.live, **state["patched"]}
         assert drift(client, spec, BASE) == []
 
 
@@ -716,3 +727,13 @@ def test_telnyx_prepare_reopens_a_subdomain_locked_to_own_connections(telnyx_env
         prepare_telnyx(client, spec, False)
         assert prepare_telnyx(client, spec, False) == []
     assert state["recv"] == "from_anyone"
+
+
+def test_telnyx_canon_ignores_what_the_server_adds_to_tools(telnyx_env: Case) -> None:
+    from coval_bench.platform_assets import TELNYX_CANON
+
+    (tool, *_) = desired(spec_for("telnyx-dental"), BASE)["tools"]
+    echoed = [{**tool, "tool_id": "tool-1", "shared": False, "timeout_ms": 5000}]
+    assert TELNYX_CANON["tools"](echoed) == [tool]
+    assert TELNYX_CANON["tool_ids"](None) == []
+    assert TELNYX_CANON["tool_ids"](["t"]) == ["t"]

--- a/runner/tests/unit/test_platform_assets.py
+++ b/runner/tests/unit/test_platform_assets.py
@@ -414,13 +414,13 @@ TELNYX_LIVE: dict[str, Any] = {
     "model": "openai/gpt-4.1",
     "llm_api_key_ref": "",
     "transcription": {"model": "deepgram/nova-3-medical", "language": "en", "settings": {}},
-    "voice_settings": {"voice": "Telnyx.Ultra.abc", "api_key_ref": None},
+    "voice_settings": {"voice": "Telnyx.Ultra.abc", "api_key_ref": None, "expressive_mode": True},
     "telephony_settings": {
         "default_texml_app_id": "texml-1",
         "recording_settings": {"enabled": True, "channels": "dual"},
     },
     "interruption_settings": {"start_speaking_plan": {"wait_seconds": 0.1}},
-    "tools": [],
+    "tools": [{"type": "hangup", "shared": True, "tool_id": "tool-1"}],
 }
 
 
@@ -477,6 +477,8 @@ CASES = [
                 "transcription.model",
                 "voice_settings.voice",
                 "voice_settings.api_key_ref",
+                "voice_settings.expressive_mode",
+                "tool_ids",
                 "telephony_settings.recording_settings.enabled",
                 "interruption_settings.start_speaking_plan.wait_seconds",
             }
@@ -487,6 +489,8 @@ CASES = [
             "transcription.model": "deepgram/nova-3",
             "voice_settings.voice": "ElevenLabs.eleven_flash_v2.EXAVITQu4vr4xnSDxMaL",
             "voice_settings.api_key_ref": "coval-bench-elevenlabs",
+            "voice_settings.expressive_mode": False,
+            "tool_ids": [],
             "telephony_settings.recording_settings.enabled": False,
             "interruption_settings.start_speaking_plan.wait_seconds": 0.8,
         },

--- a/runner/tests/unit/test_platform_assets.py
+++ b/runner/tests/unit/test_platform_assets.py
@@ -14,7 +14,6 @@ from coval_bench.assets import SecretRef
 from coval_bench.contracts import read_contract_file
 from coval_bench.platform_assets import (
     AGENTS,
-    TOOL_TIMEOUT_SECONDS,
     CovalClient,
     Plan,
     SyncError,
@@ -27,9 +26,7 @@ from coval_bench.platform_assets import (
     patch_body,
     plan,
     platform_for,
-    probe_vapi,
     register,
-    render_vapi_tools,
     spec_for,
 )
 from coval_bench.variants.platforms import redact
@@ -77,44 +74,12 @@ def test_secret_ref_names_what_is_missing(monkeypatch: pytest.MonkeyPatch) -> No
 
 
 def test_spec_for_names_the_known_set() -> None:
-    with pytest.raises(KeyError, match="known: vapi-dental"):
-        spec_for("telnyx-dental")
-    assert {s.key for s in AGENTS} == {"vapi-dental"}
+    with pytest.raises(KeyError, match="known: telnyx-dental, vapi-dental"):
+        spec_for("retell-dental")
+    assert {s.key for s in AGENTS} == {"vapi-dental", "telnyx-dental"}
 
 
 # --- render ----------------------------------------------------------------
-
-
-def test_render_emits_one_function_tool_per_contract_entry() -> None:
-    tools = render_vapi_tools(CONTRACT, BASE, SECRET)
-    assert len(tools) == len(CONTRACT) == 5
-    assert [t["function"]["name"] for t in tools] == [d["name"] for d in CONTRACT]
-    assert all(t["type"] == "function" and t["async"] is False for t in tools)
-
-
-def test_render_copies_parameters_verbatim() -> None:
-    tools = render_vapi_tools(CONTRACT, BASE, SECRET)
-    for tool, definition in zip(tools, CONTRACT, strict=True):
-        assert tool["function"]["parameters"] == definition["parameters"]
-        assert tool["function"]["description"] == definition["description"]
-
-
-def test_render_points_every_tool_at_the_vapi_codec_with_both_headers() -> None:
-    (tool, *_) = render_vapi_tools(CONTRACT, BASE, SECRET)
-    assert tool["server"]["url"] == "https://mock.example.com/mock/vapi"
-    assert tool["server"]["timeoutSeconds"] == TOOL_TIMEOUT_SECONDS
-    assert tool["server"]["headers"] == {
-        "X-Mock-Tools-Key": SECRET,
-        "X-Coval-Simulation-Id": "{{coval-simulation-id}}",
-    }
-
-
-def test_render_never_speaks_filler_messages() -> None:
-    assert all("messages" not in t for t in render_vapi_tools(CONTRACT, BASE, SECRET))
-
-
-def test_render_is_pure() -> None:
-    assert render_vapi_tools(CONTRACT, BASE, SECRET) == render_vapi_tools(CONTRACT, BASE, SECRET)
 
 
 def test_desired_resolves_the_secret_and_targets_model_tools(env: None) -> None:
@@ -124,16 +89,9 @@ def test_desired_resolves_the_secret_and_targets_model_tools(env: None) -> None:
 
 
 def test_desired_refuses_an_unknown_platform(env: None) -> None:
-    stranger = DENTAL.model_copy(update={"platform": "telnyx"})
-    with pytest.raises(SyncError, match="unknown platform 'telnyx'; known: vapi"):
+    stranger = DENTAL.model_copy(update={"platform": "retell"})
+    with pytest.raises(SyncError, match="unknown platform 'retell'; known: telnyx, vapi"):
         desired(stranger, BASE)
-
-
-def test_the_platform_table_supplies_render_and_client_together() -> None:
-    platform = platform_for(DENTAL)
-    assert platform.name == "vapi"
-    assert platform.api_base == "https://api.vapi.ai"
-    assert platform.client is VapiClient
 
 
 def test_apply_accepts_any_client_with_the_two_methods(env: None) -> None:
@@ -281,16 +239,6 @@ def test_plan_summary_names_all_three_buckets() -> None:
 
 
 # --- probe -----------------------------------------------------------------
-
-
-def test_vapi_probe_sends_the_sdk_envelope_at_the_tool_url() -> None:
-    (tool, *_) = render_vapi_tools(CONTRACT, BASE, SECRET)
-    url, headers, body = probe_vapi(tool, {"phone": "6025550182"}, SECRET, "sim-1")
-    assert url == "https://mock.example.com/mock/vapi"
-    assert headers == {"X-Mock-Tools-Key": SECRET, "X-Coval-Simulation-Id": "sim-1"}
-    (call,) = body["message"]["toolCallList"]
-    assert call["id"] == "sim-1-1"
-    assert call["function"] == {"name": "lookup_patient", "arguments": '{"phone": "6025550182"}'}
 
 
 # --- coval side ------------------------------------------------------------
@@ -441,3 +389,305 @@ def test_contract_hash_refuses_to_label_without_the_fixtures(
         coval_agent_body(DENTAL)
     with pytest.raises(SyncError, match="seeded world"):
         launch_body("A" * 22, DENTAL, "P" * 22, "T" * 8, (), 1, 1)
+
+
+# --- every platform, one case each ------------------------------------------
+
+from dataclasses import dataclass  # noqa: E402
+
+from coval_bench.mocktools.codecs import (  # noqa: E402
+    PRESET_CALLER,
+    PRESET_SIMULATION,
+    Correlation,
+    codec_for,
+)
+from coval_bench.platform_assets import (  # noqa: E402
+    TELNYX_SECRETS,
+    TelnyxClient,
+    prepare_telnyx,
+    sip_subdomain,
+)
+
+TELNYX_LIVE: dict[str, Any] = {
+    "id": "assistant-1",
+    "name": "Telnyx Dental Assistant",
+    "model": "openai/gpt-4.1",
+    "llm_api_key_ref": "",
+    "transcription": {"model": "deepgram/nova-3-medical", "language": "en", "settings": {}},
+    "voice_settings": {"voice": "Telnyx.Ultra.abc", "api_key_ref": None},
+    "telephony_settings": {
+        "default_texml_app_id": "texml-1",
+        "recording_settings": {"enabled": True, "channels": "dual"},
+    },
+    "interruption_settings": {"start_speaking_plan": {"wait_seconds": 0.1}},
+    "tools": [],
+}
+
+
+@dataclass(frozen=True)
+class Case:
+    """What a platform row must satisfy, phrased without naming its envelope."""
+
+    key: str
+    env: dict[str, str]
+    live: dict[str, Any]
+    agent_path: str
+    update_method: str
+    tool_name: Any
+    tool_url: Any
+    secret_in_config: bool
+    expected_drift: frozenset[str]
+    pins: dict[str, Any]
+    wraps_in_data: bool
+
+
+CASES = [
+    Case(
+        key="vapi-dental",
+        env={"VAPI_DENTAL_ASSISTANT_ID": "asst_1", "VAPI_API_KEY": "vapi-key"},
+        live=LIVE,
+        agent_path="/assistant/asst_1",
+        update_method="PATCH",
+        tool_name=lambda t: t["function"]["name"],
+        tool_url=lambda t: t["server"]["url"],
+        secret_in_config=True,
+        expected_drift=frozenset({"model.tools"}),
+        pins={},
+        wraps_in_data=False,
+    ),
+    Case(
+        key="telnyx-dental",
+        env={
+            "TELNYX_DENTAL_ASSISTANT_ID": "assistant-1",
+            "TELNYX_API_KEY": "telnyx-key",
+            "TELNYX_DENTAL_DIAL_TARGET": "sip:dental@coval-bench-dental.sip.telnyx.com",
+            "OPENAI_API_KEY": "openai-key",
+            "ELEVENLABS_API_KEY": "eleven-key",
+        },
+        live=TELNYX_LIVE,
+        agent_path="/v2/ai/assistants/assistant-1",
+        update_method="POST",
+        tool_name=lambda t: t["webhook"]["name"],
+        tool_url=lambda t: t["webhook"]["url"],
+        secret_in_config=False,
+        expected_drift=frozenset(
+            {
+                "tools",
+                "llm_api_key_ref",
+                "transcription.model",
+                "voice_settings.voice",
+                "voice_settings.api_key_ref",
+                "telephony_settings.recording_settings.enabled",
+                "interruption_settings.start_speaking_plan.wait_seconds",
+            }
+        ),
+        pins={
+            "model": "openai/gpt-4.1",
+            "llm_api_key_ref": "coval-bench-openai",
+            "transcription.model": "deepgram/nova-3",
+            "voice_settings.voice": "ElevenLabs.eleven_flash_v2.EXAVITQu4vr4xnSDxMaL",
+            "voice_settings.api_key_ref": "coval-bench-elevenlabs",
+            "telephony_settings.recording_settings.enabled": False,
+            "interruption_settings.start_speaking_plan.wait_seconds": 0.8,
+        },
+        wraps_in_data=True,
+    ),
+]
+
+
+@pytest.fixture(params=CASES, ids=lambda c: c.key)
+def case(request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch) -> Case:
+    chosen: Case = request.param
+    for name, value in chosen.env.items():
+        monkeypatch.setenv(name, value)
+    monkeypatch.setenv("MOCK_TOOLS_SECRET", SECRET)
+    monkeypatch.setattr(platform_assets, "has_private_contract", lambda suite: True)
+    return chosen
+
+
+CLIENTS: dict[str, Any] = {"vapi": VapiClient, "telnyx": TelnyxClient}
+
+
+def _platform_client(case: Case, state: dict[str, Any]) -> Any:  # noqa: ANN401
+    """A fake vendor API: serves the live agent, records the patch, and answers Telnyx's extras."""
+    spec = spec_for(case.key)
+    platform = platform_for(spec)
+
+    def agent(payload: dict[str, Any]) -> dict[str, Any]:
+        return {"data": payload} if case.wraps_in_data else payload
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        state.setdefault("calls", []).append((request.method, request.url.path))
+        if request.url.path == case.agent_path and request.method == "GET":
+            return httpx.Response(200, json=agent(state.get("live", case.live)))
+        if request.url.path == case.agent_path:
+            state["patched"] = json.loads(request.content)
+            return httpx.Response(200, json=agent(state["patched"]))
+        if request.url.path == "/v2/integration_secrets" and request.method == "GET":
+            return httpx.Response(200, json={"data": [{"identifier": i} for i in state["secrets"]]})
+        if request.url.path == "/v2/integration_secrets":
+            state["secrets"].append(json.loads(request.content)["identifier"])
+            return httpx.Response(201, json={"data": {"id": "s", "identifier": "x"}})
+        if request.url.path == "/v2/texml_applications/texml-1" and request.method == "GET":
+            return httpx.Response(200, json={"data": {"inbound": {"sip_subdomain": state["sub"]}}})
+        if request.url.path == "/v2/texml_applications/texml-1":
+            state["sub"] = json.loads(request.content)["inbound"]["sip_subdomain"]
+            return httpx.Response(200, json={"data": {}})
+        return httpx.Response(404, text=request.url.path)
+
+    state.setdefault("secrets", list(TELNYX_SECRETS))
+    state.setdefault("sub", "coval-bench-dental")
+    return CLIENTS[spec.platform]("key", platform.api_base, transport=httpx.MockTransport(handler))
+
+
+def test_every_platform_renders_one_tool_per_contract_entry_in_order(case: Case) -> None:
+    spec = spec_for(case.key)
+    tools = desired(spec, BASE)[platform_for(spec).tools_path]
+    assert [case.tool_name(t) for t in tools] == [d["name"] for d in CONTRACT]
+    assert len(tools) == 5
+
+
+def test_every_platform_targets_the_route_its_codec_expects(case: Case) -> None:
+    spec = spec_for(case.key)
+    codec = codec_for(spec.platform)
+    for tool, definition in zip(
+        desired(spec, BASE)[platform_for(spec).tools_path], CONTRACT, strict=True
+    ):
+        expected = codec.encode_request(definition["name"], {}, Correlation()).path
+        assert case.tool_url(tool) == f"https://mock.example.com{expected}"
+
+
+def test_every_platform_carries_the_contract_parameters_verbatim(case: Case) -> None:
+    spec = spec_for(case.key)
+    tools = desired(spec, BASE)[platform_for(spec).tools_path]
+    for tool, definition in zip(tools, CONTRACT, strict=True):
+        blob = json.dumps(tool, sort_keys=True)
+        assert json.dumps(definition["parameters"], sort_keys=True) in blob
+        assert definition["description"] in blob
+
+
+def test_the_secret_is_a_value_or_a_reference_as_the_vendor_requires(case: Case) -> None:
+    spec = spec_for(case.key)
+    blob = json.dumps(desired(spec, BASE))
+    assert (SECRET in blob) is case.secret_in_config
+
+
+def test_every_platform_pins_what_its_row_declares(case: Case) -> None:
+    wanted = desired(spec_for(case.key), BASE)
+    for path, value in case.pins.items():
+        assert wanted[path] == value
+
+
+def test_plan_flags_exactly_the_drift_on_the_live_agent(case: Case) -> None:
+    result = plan(case.live, desired(spec_for(case.key), BASE))
+    assert set(result.update) == set(case.expected_drift)
+
+
+def test_dry_run_reports_without_writing_then_apply_converges(case: Case) -> None:
+    spec = spec_for(case.key)
+    wanted = desired(spec, BASE)
+    state: dict[str, Any] = {}
+    with _platform_client(case, state) as client:
+        preview = apply(client, spec, wanted, dry_run=True)
+        assert set(preview.update) == set(case.expected_drift)
+        assert all(method == "GET" for method, _ in state["calls"])
+        applied = apply(client, spec, wanted)
+        assert (case.update_method, case.agent_path) in state["calls"]
+        assert set(applied.update) == set(case.expected_drift)
+        state["live"] = {**case.live, **state["patched"]}
+        assert drift(client, spec, BASE) == []
+
+
+def test_smoke_request_round_trips_through_the_codec(case: Case) -> None:
+    codec = codec_for(spec_for(case.key).platform)
+    request = codec.encode_request(
+        "lookup_patient", {"phone": "6025550182"}, Correlation("sim-1", "+15550100000")
+    )
+    tool = "lookup_patient" if codec.tool_in_path else None
+    (call,) = codec.decode(request.body, request.headers, tool)
+    assert (call.tool, call.args) == ("lookup_patient", {"phone": "6025550182"})
+    found = codec.correlate(request.body, request.headers)
+    assert (found.simulation_id, found.caller_number) == ("sim-1", "+15550100000")
+
+
+# --- telnyx only: prerequisites Vapi does not have -------------------------
+
+
+@pytest.fixture
+def telnyx_env(monkeypatch: pytest.MonkeyPatch) -> Case:
+    chosen = next(c for c in CASES if c.key == "telnyx-dental")
+    for name, value in chosen.env.items():
+        monkeypatch.setenv(name, value)
+    monkeypatch.setenv("MOCK_TOOLS_SECRET", SECRET)
+    return chosen
+
+
+def test_telnyx_correlation_rides_in_preset_fields_the_model_cannot_see(telnyx_env: Case) -> None:
+    (tool, *_) = desired(spec_for("telnyx-dental"), BASE)["tools"]
+    assert tool["webhook"]["preset_body_fields"] == {
+        PRESET_SIMULATION: "{{coval_simulation_id}}",
+        PRESET_CALLER: "{{telnyx_end_user_target}}",
+    }
+    assert tool["webhook"]["headers"] == [
+        {
+            "name": "X-Mock-Tools-Key",
+            "value": "{{#integration_secret}}coval-bench-mock{{/integration_secret}}",
+        }
+    ]
+
+
+@pytest.mark.parametrize(
+    "target",
+    [
+        "sip:dental@coval-bench-dental.sip.telnyx.com",
+        "SIP:x@Coval-Bench-Dental.sip.telnyx.com:5060",
+    ],
+)
+def test_sip_subdomain_is_read_off_the_dial_target(target: str) -> None:
+    assert sip_subdomain(target) == "coval-bench-dental"
+
+
+@pytest.mark.parametrize(
+    "target", ["sip:dental@sip.vapi.ai", "+14045550710", "coval.sip.telnyx.com"]
+)
+def test_sip_subdomain_refuses_anything_else(target: str) -> None:
+    with pytest.raises(SyncError):
+        sip_subdomain(target)
+
+
+def test_telnyx_prepare_lists_missing_secrets_and_subdomain_then_creates_only_those(
+    telnyx_env: Case,
+) -> None:
+    spec = spec_for("telnyx-dental")
+    state: dict[str, Any] = {"secrets": ["coval", "coval-bench-openai"], "sub": None}
+    with _platform_client(telnyx_env, state) as client:
+        pending = prepare_telnyx(client, spec, True)
+        assert pending == [
+            "integration_secret:coval-bench-elevenlabs",
+            "integration_secret:coval-bench-mock",
+            "sip_subdomain:texml-1=coval-bench-dental",
+        ]
+        assert state["secrets"] == ["coval", "coval-bench-openai"] and state["sub"] is None
+        assert prepare_telnyx(client, spec, False) == pending
+        assert prepare_telnyx(client, spec, False) == []
+    assert set(state["secrets"]) == {"coval", *TELNYX_SECRETS}
+    assert state["sub"] == "coval-bench-dental"
+
+
+def test_telnyx_prepare_refuses_a_foreign_client(telnyx_env: Case) -> None:
+    with pytest.raises(SyncError), _client(lambda r: httpx.Response(200, json={})) as vapi:
+        prepare_telnyx(vapi, spec_for("telnyx-dental"), True)
+
+
+def test_telnyx_client_updates_with_post_as_the_reference_documents() -> None:
+    seen: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request.method)
+        return httpx.Response(200, json={"data": {}})
+
+    with TelnyxClient(
+        "k", "https://api.telnyx.com/v2", transport=httpx.MockTransport(handler)
+    ) as c:
+        c.update_agent("assistant-1", {})
+    assert seen == ["POST"]

--- a/runner/tests/unit/test_platform_assets.py
+++ b/runner/tests/unit/test_platform_assets.py
@@ -479,7 +479,6 @@ CASES = [
                 "voice_settings.voice",
                 "voice_settings.api_key_ref",
                 "voice_settings.expressive_mode",
-                "tool_ids",
                 "telephony_settings.recording_settings.enabled",
                 "interruption_settings.start_speaking_plan.wait_seconds",
             }

--- a/runner/tests/unit/test_platform_assets.py
+++ b/runner/tests/unit/test_platform_assets.py
@@ -529,14 +529,23 @@ def _platform_client(case: Case, state: dict[str, Any]) -> Any:  # noqa: ANN401
             state["secrets"].append(json.loads(request.content)["identifier"])
             return httpx.Response(201, json={"data": {"id": "s", "identifier": "x"}})
         if request.url.path == "/v2/texml_applications/texml-1" and request.method == "GET":
-            return httpx.Response(200, json={"data": {"inbound": {"sip_subdomain": state["sub"]}}})
+            inbound = {
+                "sip_subdomain": state["sub"],
+                "sip_subdomain_receive_settings": state["recv"],
+            }
+            return httpx.Response(200, json={"data": {"inbound": inbound}})
         if request.url.path == "/v2/texml_applications/texml-1":
-            state["sub"] = json.loads(request.content)["inbound"]["sip_subdomain"]
+            inbound = json.loads(request.content)["inbound"]
+            state["sub"], state["recv"] = (
+                inbound["sip_subdomain"],
+                inbound["sip_subdomain_receive_settings"],
+            )
             return httpx.Response(200, json={"data": {}})
         return httpx.Response(404, text=request.url.path)
 
     state.setdefault("secrets", list(TELNYX_SECRETS))
     state.setdefault("sub", "coval-bench-dental")
+    state.setdefault("recv", "from_anyone")
     return CLIENTS[spec.platform]("key", platform.api_base, transport=httpx.MockTransport(handler))
 
 
@@ -665,7 +674,7 @@ def test_telnyx_prepare_lists_missing_secrets_and_subdomain_then_creates_only_th
         assert pending == [
             "integration_secret:coval-bench-elevenlabs",
             "integration_secret:coval-bench-mock",
-            "sip_subdomain:texml-1=coval-bench-dental",
+            "sip_subdomain:texml-1=coval-bench-dental:from_anyone",
         ]
         assert state["secrets"] == ["coval", "coval-bench-openai"] and state["sub"] is None
         assert prepare_telnyx(client, spec, False) == pending
@@ -691,3 +700,15 @@ def test_telnyx_client_updates_with_post_as_the_reference_documents() -> None:
     ) as c:
         c.update_agent("assistant-1", {})
     assert seen == ["POST"]
+
+
+def test_telnyx_prepare_reopens_a_subdomain_locked_to_own_connections(telnyx_env: Case) -> None:
+    spec = spec_for("telnyx-dental")
+    state: dict[str, Any] = {"sub": "coval-bench-dental", "recv": "only_my_connections"}
+    with _platform_client(telnyx_env, state) as client:
+        assert prepare_telnyx(client, spec, True) == [
+            "sip_subdomain:texml-1=coval-bench-dental:from_anyone"
+        ]
+        prepare_telnyx(client, spec, False)
+        assert prepare_telnyx(client, spec, False) == []
+    assert state["recv"] == "from_anyone"


### PR DESCRIPTION
Before:
- each vendor has its own function that built the dict of fields to write into the vendor. hence adding a vendor meant writing a new function that did the same job with different field names

After: 
- each vendor is one platform dataclass instance in that dict. adding vendor means adding one instance. 
- shared desired() read the isntance and produces the fields.
- instance holds api base, client class info, tools location & name, which dotted paths carry the pin, 


