### PR TITLE
[BENCH-795] Scope normalized storage backfill to seven days

### DIFF
--- a/runner/README.md
+++ b/runner/README.md
@@ -69,14 +69,26 @@ applies only to this execution.
 gcloud run jobs execute benchmarks-runner \
   --project=coval-benchmarks-prod \
   --region=us-east1 \
-  --task-timeout=24h \
+  --task-timeout=48h \
   --wait \
   --args='migrate,backfill-normalized-storage,--min-result-id=1,--batch-size=100'
 ```
 
-The dry run freezes and reports its maximum result ID. Record that maximum for
-any separately authorized `--apply` run, which must pass it explicitly. Progress
-events are JSON on stderr; the final JSON report remains stdout's final line.
+The dry run resolves one database UTC timestamp, freezes the preceding inclusive
+start/exclusive end 168-hour window, and reports its exact UTC start, end, and
+maximum result ID. The 48-hour timeout leaves a safe margin beyond the observed
+17h31m48s dry run. Record all three values for any separately authorized apply:
+
+```bash
+gcloud run jobs execute benchmarks-runner \
+  --project=coval-benchmarks-prod \
+  --region=us-east1 \
+  --task-timeout=48h \
+  --wait \
+  --args='migrate,backfill-normalized-storage,--min-result-id=1,--window-start=2026-08-20T00:00:00Z,--window-end=2026-08-27T00:00:00Z,--max-result-id=N,--batch-size=100,--apply'
+```
+
+Progress events are JSON on stderr; the final JSON report remains stdout's final line.
 
 `--batch-size` is a run-ID read page and also bounds apply-plan transaction
 batches. Larger pages reduce round trips, but increase memory, transaction

--- a/runner/src/coval_bench/migrations/backfill_normalized_storage.py
+++ b/runner/src/coval_bench/migrations/backfill_normalized_storage.py
@@ -20,7 +20,7 @@ from collections import Counter, defaultdict
 from collections.abc import Callable, Iterable, Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import UTC, datetime, timedelta
 from functools import lru_cache
 from importlib.resources import files
 from types import FrameType
@@ -54,6 +54,28 @@ class _BackfillCancelled(Exception):
     """Raised by the CLI SIGTERM handler after the current DB work unwinds."""
 
 
+@dataclass(frozen=True)
+class FrozenWindow:
+    """The one, reproducible STT/TTS source cohort for an operator run."""
+
+    min_result_id: int
+    max_result_id: int
+    start: datetime
+    end: datetime
+
+    def __post_init__(self) -> None:
+        if self.min_result_id <= 0 or self.max_result_id < self.min_result_id:
+            raise ValueError("invalid frozen result-id bounds")
+        if self.start.tzinfo is None or self.end.tzinfo is None:
+            raise ValueError("window timestamps must be timezone-aware")
+        start = self.start.astimezone(UTC)
+        end = self.end.astimezone(UTC)
+        if end - start != timedelta(hours=168):
+            raise ValueError("window must be exactly 168 hours")
+        object.__setattr__(self, "start", start)
+        object.__setattr__(self, "end", end)
+
+
 @dataclass
 class ProgressReporter:
     """Write aggregate-only, machine-readable migration progress to stderr."""
@@ -62,6 +84,8 @@ class ProgressReporter:
     min_result_id: int
     max_result_id: int
     batch_size: int
+    window_start: datetime | None = None
+    window_end: datetime | None = None
     stream: TextIO = field(default_factory=lambda: sys.stderr)
     monotonic: Callable[[], float] = time.monotonic
     interval_seconds: float = _PROGRESS_INTERVAL_SECONDS
@@ -101,6 +125,8 @@ class ProgressReporter:
             "mode": self.mode,
             "min_result_id": self.min_result_id,
             "max_result_id": self.max_result_id,
+            "window_start": self.window_start.isoformat() if self.window_start else None,
+            "window_end": self.window_end.isoformat() if self.window_end else None,
             "batch_size": self.batch_size,
             "pages": self.pages,
             "runs": self.runs,
@@ -335,13 +361,15 @@ def _report() -> dict[str, Any]:
         "rollup_mismatch_count": 0,
         "rollup_mismatches_truncated": False,
         "cutover_ready": False,
+        "parity_mismatch_reasons": Counter(),
     }
 
 
 _PAGE_RUN_IDS_SQL = """
 SELECT DISTINCT r.run_id
 FROM benchmarks_v2.results r
-WHERE r.id BETWEEN %s AND %s AND r.benchmark IN ('STT','TTS') AND r.run_id > %s
+WHERE r.id BETWEEN %s AND %s AND r.created_at >= %s AND r.created_at < %s
+  AND r.benchmark IN ('STT','TTS') AND r.run_id > %s
 ORDER BY r.run_id
 LIMIT %s
 """
@@ -349,7 +377,8 @@ LIMIT %s
 _QUALIFYING_RUN_COUNT_SQL = """
 SELECT COUNT(DISTINCT r.run_id)
 FROM benchmarks_v2.results r
-WHERE r.id BETWEEN %s AND %s AND r.benchmark IN ('STT','TTS')
+WHERE r.id BETWEEN %s AND %s AND r.created_at >= %s AND r.created_at < %s
+  AND r.benchmark IN ('STT','TTS')
 """
 
 _RUN_ROWS_SQL = """
@@ -357,28 +386,45 @@ SELECT r.id,r.run_id,n.dataset_id,n.dataset_sha256,n.scheduled_at,r.provider,r.m
  r.benchmark,r.metric_type,r.metric_value,r.metric_units,r.audio_filename,r.transcript,r.status,
  r.error,r.http_version,r.submit_to_headers_ms,r.created_at,r.wer_insertions_pct,r.wer_deletions_pct,r.wer_substitutions_pct
 FROM benchmarks_v2.results r JOIN benchmarks_v2.runs n ON n.id=r.run_id
-WHERE r.run_id=ANY(%s) AND r.id BETWEEN %s AND %s AND r.benchmark IN ('STT','TTS')
+WHERE r.run_id=ANY(%s) AND r.id BETWEEN %s AND %s
+  AND r.created_at >= %s AND r.created_at < %s AND r.benchmark IN ('STT','TTS')
 ORDER BY r.run_id,r.id
 """
 
 
 def _run_page(
-    conn: psycopg.Connection, low: int, high: int, after_run_id: int, batch_size: int
+    conn: psycopg.Connection, window: FrozenWindow, after_run_id: int, batch_size: int
 ) -> tuple[list[int], list[LegacyRow]]:
     """Read one bounded, run-keyset page from the frozen result-id window."""
     with conn.cursor() as cur:
-        cur.execute(_PAGE_RUN_IDS_SQL, (low, high, after_run_id, batch_size))
+        cur.execute(
+            _PAGE_RUN_IDS_SQL,
+            (
+                window.min_result_id,
+                window.max_result_id,
+                window.start,
+                window.end,
+                after_run_id,
+                batch_size,
+            ),
+        )
         run_ids = [int(row[0]) for row in cur.fetchall()]
         if not run_ids:
             return [], []
-        cur.execute(_RUN_ROWS_SQL, (run_ids, low, high))
+        cur.execute(
+            _RUN_ROWS_SQL,
+            (run_ids, window.min_result_id, window.max_result_id, window.start, window.end),
+        )
         return run_ids, [LegacyRow(*row) for row in cur.fetchall()]
 
 
-def _qualifying_run_count(conn: psycopg.Connection, low: int, high: int) -> int:
+def _qualifying_run_count(conn: psycopg.Connection, window: FrozenWindow) -> int:
     """Count the same frozen run population used by keyset paging without loading IDs."""
     with conn.cursor() as cur:
-        cur.execute(_QUALIFYING_RUN_COUNT_SQL, (low, high))
+        cur.execute(
+            _QUALIFYING_RUN_COUNT_SQL,
+            (window.min_result_id, window.max_result_id, window.start, window.end),
+        )
         row = cur.fetchone()
     if row is None:  # pragma: no cover - aggregate SELECT always returns one row.
         raise RuntimeError("qualifying run count query returned no row")
@@ -386,7 +432,7 @@ def _qualifying_run_count(conn: psycopg.Connection, low: int, high: int) -> int:
 
 
 def _complete_window_rows(
-    conn: psycopg.Connection, rows: list[LegacyRow], low: int, high: int, skipped: Counter[str]
+    conn: psycopg.Connection, rows: list[LegacyRow], window: FrozenWindow, skipped: Counter[str]
 ) -> list[LegacyRow]:
     """A result window is safe only if each selected run is wholly present and terminal."""
     run_ids = sorted({row.run_id for row in rows})
@@ -394,14 +440,18 @@ def _complete_window_rows(
         return rows
     with conn.cursor() as cur:
         cur.execute(
-            """SELECT n.id, min(r.id), max(r.id), n.status FROM benchmarks_v2.runs n
-               JOIN benchmarks_v2.results r ON r.run_id=n.id WHERE n.id=ANY(%s)
+            """SELECT n.id,
+                      bool_or(r.benchmark IN ('STT','TTS') AND NOT (
+                        r.id BETWEEN %s AND %s AND r.created_at >= %s AND r.created_at < %s
+                      )), n.status
+               FROM benchmarks_v2.runs n JOIN benchmarks_v2.results r ON r.run_id=n.id
+               WHERE n.id=ANY(%s)
                GROUP BY n.id,n.status""",
-            (run_ids,),
+            (window.min_result_id, window.max_result_id, window.start, window.end, run_ids),
         )
         bad: set[int] = set()
-        for run_id, first_id, last_id, status in cur.fetchall():
-            if first_id < low or last_id > high:
+        for run_id, has_outside_stt_tts, status in cur.fetchall():
+            if has_outside_stt_tts:
                 skipped["split_window_run"] += 1
                 bad.add(run_id)
             elif status not in ("succeeded", "partial", "failed"):
@@ -426,6 +476,11 @@ def _append_mismatch(report: dict[str, Any], kind: str, detail: dict[str, Any]) 
     """Retain bounded diagnostics while reporting the exact mismatch total."""
     count_key = "parity_mismatch_count" if kind == "parity_mismatches" else "rollup_mismatch_count"
     report[count_key] += 1
+    if kind == "parity_mismatches":
+        report["parity_mismatch_reasons"][str(detail.get("reason", "unknown"))] += 1
+        # Parity spans private observations.  Keep its compatibility list useful
+        # without allowing a caller to leak identities or payloads into JSON.
+        detail = {"reason": str(detail.get("reason", "unknown"))}
     if len(report[kind]) < _MISMATCH_DETAIL_LIMIT:
         report[kind].append(detail)
     else:
@@ -737,7 +792,7 @@ def _metrics_are_valid(rows: list[LegacyRow], skipped: Counter[str]) -> bool:
     return True
 
 
-def _stored_plan_matches(
+def _strict_stored_plan_matches(
     cur: psycopg.Cursor[tuple[Any, ...]], plan: Planned, observation_id: uuid.UUID
 ) -> bool:
     """Compare the legacy-derived immutable payload, never merely its parent ID."""
@@ -900,6 +955,270 @@ def _stored_plan_matches(
     return [tuple(item) for item in cur.fetchall()] == sorted(expected_inputs, key=repr)
 
 
+def _expected_metric_payloads(
+    plan: Planned,
+) -> dict[str, tuple[str, str | None, list[tuple[str, str, float, str, str]]]]:
+    """Return the immutable metric identities and values reconstructed from legacy rows."""
+    values_by_metric: dict[str, list[tuple[str, str, float, str, str]]] = defaultdict(list)
+    for datum in _values(plan.rows):
+        values_by_metric[datum[0]].append(datum)
+    expected: dict[str, tuple[str, str | None, list[tuple[str, str, float, str, str]]]] = {
+        metric: ("succeeded", None, values) for metric, values in values_by_metric.items()
+    }
+    for metric, rows in _metric_groups(plan.rows).items():
+        if metric not in expected and rows and all(row.status == "failed" for row in rows):
+            expected[metric] = ("failed", next(row.error for row in rows if row.error), [])
+    return expected
+
+
+def _live_artifact_matches(
+    artifact_type: str,
+    schema_name: str,
+    schema_version: str,
+    gcs_uri: str,
+    digest: str,
+    size_bytes: int,
+    duration_ms: float | None,
+    *,
+    transcript: str | None,
+) -> bool:
+    """Validate dual-write descriptors without fetching private artifact payloads."""
+    if not _valid_sha(digest) or size_bytes <= 0 or schema_version != "v1":
+        return False
+    extension = {
+        "provider_transcript": "json",
+        "timing_events": "json",
+        "generated_audio": "wav",
+    }.get(artifact_type)
+    schema = {
+        "provider_transcript": "ProviderTranscript",
+        "timing_events": "TimingEvents",
+        "generated_audio": "GeneratedAudio",
+    }.get(artifact_type)
+    if extension is None or schema_name != schema:
+        return False
+    key = f"observation-artifacts/v1/{artifact_type}/{digest[:2]}/{digest}.{extension}"
+    parts = gcs_uri.split("/", 3)
+    if (
+        not gcs_uri.startswith("gs://")
+        or len(parts) != 4
+        or not parts[2]
+        or "?" in gcs_uri
+        or "#" in gcs_uri
+        or parts[3] != key
+    ):
+        return False
+    if artifact_type == "generated_audio":
+        return (
+            duration_ms is not None
+            and duration_ms > 0
+            and duration_ms != float("inf")
+            and duration_ms == duration_ms
+        )
+    if duration_ms is not None:
+        return False
+    if artifact_type == "provider_transcript":
+        if transcript is None:
+            return False
+        _, payload, _, _, _ = prepare_provider_transcript(transcript)
+        return digest == hashlib.sha256(payload).hexdigest() and size_bytes == len(payload)
+    return True
+
+
+def _live_stored_plan_matches(
+    cur: psycopg.Cursor[tuple[Any, ...]], plan: Planned, observation_id: uuid.UUID
+) -> bool:
+    """Accept only the current STT/TTS dual-write contract for a live-owned key."""
+    row = plan.first
+    cur.execute(
+        """SELECT run_id,dataset_id,dataset_sha256,sample_id,provider,model,voice,benchmark,
+                  source_kind,transport_protocol,submit_to_headers_ms,provider_extras,captured_at,status,error,failure_origin
+           FROM benchmarks_v2.benchmark_observations WHERE id=%s""",
+        (observation_id,),
+    )
+    actual = cur.fetchone()
+    expected = (
+        row.run_id,
+        plan.dataset_id,
+        plan.dataset_sha256,
+        plan.sample_id,
+        row.provider,
+        row.model,
+        row.voice,
+        plan.benchmark,
+        plan.source_kind,
+        None,
+        None,
+        None,
+        row.created_at,
+        plan.status,
+        plan.error,
+        plan.failure_origin,
+    )
+    if actual != expected:
+        return False
+    expected_metrics = _expected_metric_payloads(plan)
+    expected_tts_timing: tuple[str, int] | None = None
+    if plan.benchmark == "TTS":
+        anchor = next((candidate for candidate in plan.rows if candidate.metric == "TTFA"), None)
+        if anchor is None:
+            return False
+        if anchor.value is not None:
+            _, payload, _, _, _ = prepare_timing_events({"ttfa_ms": anchor.value})
+            expected_tts_timing = (hashlib.sha256(payload).hexdigest(), len(payload))
+        # Transport contamination nulls legacy TTFA while the private artifact
+        # retains the unrecoverable original measurement.
+    cur.execute(
+        """SELECT id,metric_type,metric_version,evaluation_variant,executor,external_request_id,status,started_at,finished_at,error
+           FROM benchmarks_v2.metric_evaluations WHERE observation_id=%s""",
+        (observation_id,),
+    )
+    evaluations = cur.fetchall()
+    if len(evaluations) != len(expected_metrics):
+        return False
+    evaluation_ids: dict[str, uuid.UUID] = {}
+    for (
+        eid,
+        metric,
+        version,
+        variant,
+        executor,
+        external_request_id,
+        status,
+        started,
+        finished,
+        error,
+    ) in evaluations:
+        expected_metric = expected_metrics.get(metric)
+        if metric in evaluation_ids or expected_metric is None:
+            return False
+        expected_status, expected_error, _ = expected_metric
+        if (version, variant, executor, external_request_id, status, error) != (
+            "v1",
+            "default",
+            "inline",
+            None,
+            expected_status,
+            expected_error,
+        ):
+            return False
+        if started is None or started < row.created_at or finished is None or finished < started:
+            return False
+        if status == "succeeded" and error is not None:
+            return False
+        if status == "failed" and not error:
+            return False
+        evaluation_ids[metric] = eid
+    cur.execute(
+        """SELECT e.metric_type,v.value_key,v.unit,v.value,v.value_role
+           FROM benchmarks_v2.metric_values v JOIN benchmarks_v2.metric_evaluations e ON e.id=v.metric_evaluation_id
+           WHERE e.observation_id=%s""",
+        (observation_id,),
+    )
+    actual_values = sorted((tuple(item) for item in cur.fetchall()), key=repr)
+    expected_values = sorted(
+        (metric, key, unit, value, role)
+        for metric, (_, _, values) in expected_metrics.items()
+        for _, key, value, unit, role in values
+    )
+    if actual_values != expected_values:
+        return False
+    cur.execute(
+        """SELECT id,artifact_type,schema_name,schema_version,gcs_uri,content_sha256,size_bytes,duration_ms
+           FROM benchmarks_v2.observation_artifacts WHERE observation_id=%s""",
+        (observation_id,),
+    )
+    artifacts = cur.fetchall()
+    allowed = (
+        {"provider_transcript", "timing_events"}
+        if plan.benchmark == "STT"
+        else {"timing_events", "generated_audio"}
+    )
+    by_type: dict[str, uuid.UUID] = {}
+    for aid, artifact_type, schema_name, schema_version, uri, digest, size, duration in artifacts:
+        if (
+            artifact_type in by_type
+            or artifact_type not in allowed
+            or not _live_artifact_matches(
+                artifact_type,
+                schema_name,
+                schema_version,
+                uri,
+                digest,
+                size,
+                duration,
+                transcript=row.transcript if artifact_type == "provider_transcript" else None,
+            )
+        ):
+            return False
+        if (
+            artifact_type == "timing_events"
+            and plan.benchmark == "TTS"
+            and expected_tts_timing is not None
+            and (digest, size) != expected_tts_timing
+        ):
+            return False
+        by_type[artifact_type] = aid
+    expected_emitted_artifact_types = (
+        {"timing_events", "generated_audio"}
+        if plan.benchmark == "TTS"
+        else {"timing_events"} | ({"provider_transcript"} if row.transcript is not None else set())
+    )
+    if set(by_type) != expected_emitted_artifact_types:
+        return False
+    expected_inputs: list[tuple[str, str, int, uuid.UUID]] = []
+    for metric in expected_metrics:
+        wanted = (
+            [("provider_transcript", "raw")]
+            if plan.benchmark == "STT" and metric == "WER"
+            else [("timing_events", "timing")]
+            if plan.benchmark == "STT"
+            else [("generated_audio", "raw")]
+            if metric == "WER"
+            else [("timing_events", "timing"), ("generated_audio", "raw")]
+            if metric == "TTFA"
+            else [("timing_events", "timing")]
+        )
+        for artifact_type, role in wanted:
+            aid = by_type.get(artifact_type)
+            if aid is None:
+                return False
+            expected_inputs.append((metric, role, 0, aid))
+    cur.execute(
+        """SELECT e.metric_type,i.input_role,i.input_order,i.observation_artifact_id
+           FROM benchmarks_v2.metric_evaluation_inputs i JOIN benchmarks_v2.metric_evaluations e ON e.id=i.metric_evaluation_id
+           WHERE e.observation_id=%s""",
+        (observation_id,),
+    )
+    if sorted((tuple(item) for item in cur.fetchall()), key=repr) != sorted(
+        expected_inputs, key=repr
+    ):
+        return False
+    cur.execute(
+        """SELECT EXISTS (
+             SELECT 1 FROM benchmarks_v2.preprocessing_artifacts WHERE observation_id=%s
+             UNION ALL
+             SELECT 1 FROM benchmarks_v2.metric_artifacts a
+             JOIN benchmarks_v2.metric_evaluations e ON e.id=a.metric_evaluation_id
+             WHERE e.observation_id=%s
+           )""",
+        (observation_id, observation_id),
+    )
+    exists_row = cur.fetchone()
+    return exists_row is not None and not bool(exists_row[0])
+
+
+def _stored_plan_matches(
+    cur: psycopg.Cursor[tuple[Any, ...]], plan: Planned, observation_id: uuid.UUID
+) -> bool:
+    """Dispatch exact backfill validation or the narrow live dual-write allowlist."""
+    return (
+        _strict_stored_plan_matches(cur, plan, observation_id)
+        if observation_id == plan.id
+        else _live_stored_plan_matches(cur, plan, observation_id)
+    )
+
+
 def _insert_plan(
     conn: psycopg.Connection,
     plan: Planned,
@@ -927,7 +1246,7 @@ def _insert_plan(
                 _append_mismatch(
                     report,
                     "parity_mismatches",
-                    {"natural_key": list(plan.natural), "reason": "live_owned_payload_mismatch"},
+                    {"reason": "live_owned_payload_mismatch"},
                 )
             return
         if found:
@@ -937,7 +1256,7 @@ def _insert_plan(
                 _append_mismatch(
                     report,
                     "parity_mismatches",
-                    {"natural_key": list(plan.natural), "reason": "backfill_payload_mismatch"},
+                    {"reason": "backfill_payload_mismatch"},
                 )
             return
         report["eligible"] += 1
@@ -1068,14 +1387,14 @@ def _insert_plan(
 
 
 def _refresh_bucket(cur: psycopg.Cursor[tuple[Any, ...]], bucket_at: datetime) -> None:
-    """Use the RunWriter delete/insert contract over every normalized row."""
+    """Refresh only STT/TTS rows; S2S owns its independent rollup population."""
     params = {"bucket": bucket_at}
     cur.execute(
         "SELECT pg_advisory_xact_lock(hashtextextended('metric_values_by_bucket', extract(epoch FROM %(bucket)s::timestamptz)::bigint))",
         params,
     )
     cur.execute(
-        "DELETE FROM benchmarks_v2.metric_values_by_bucket WHERE bucket_at=%(bucket)s",
+        "DELETE FROM benchmarks_v2.metric_values_by_bucket WHERE bucket_at=%(bucket)s AND benchmark IN ('STT','TTS')",
         params,
     )
     cur.execute(
@@ -1101,6 +1420,7 @@ JOIN benchmarks_v2.metric_evaluations e ON e.id=v.metric_evaluation_id
 JOIN benchmarks_v2.benchmark_observations o ON o.id=e.observation_id
 JOIN benchmarks_v2.runs r ON r.id=o.run_id
 WHERE o.status='succeeded' AND e.status='succeeded'
+  AND o.benchmark IN ('STT','TTS')
   AND r.status IN ('succeeded','partial')
   AND r.scheduled_at=%(bucket)s
 GROUP BY GROUPING SETS (
@@ -1116,7 +1436,7 @@ SELECT provider,model,benchmark,dataset_id,metric_type,metric_version,
        evaluation_variant,value_key,unit,bucket_at,min_value,p25,p50,p75,
        max_value,value_sum,sample_count
 FROM benchmarks_v2.metric_values_by_bucket
-WHERE bucket_at=%(bucket)s
+WHERE bucket_at=%(bucket)s AND benchmark IN ('STT','TTS')
 """
 
 
@@ -1156,10 +1476,14 @@ WITH buckets AS (
   WHERE n.status IN ('succeeded','partial','failed') AND n.scheduled_at IS NOT NULL
     AND EXISTS (
       SELECT 1 FROM benchmarks_v2.results r
-      WHERE r.run_id=n.id AND r.id BETWEEN %s AND %s AND r.benchmark IN ('STT','TTS')
+      WHERE r.run_id=n.id AND r.id BETWEEN %s AND %s AND r.created_at >= %s AND r.created_at < %s
+        AND r.benchmark IN ('STT','TTS')
     )
     AND NOT EXISTS (
-      SELECT 1 FROM benchmarks_v2.results r WHERE r.run_id=n.id AND (r.id < %s OR r.id > %s)
+      SELECT 1 FROM benchmarks_v2.results r
+      WHERE r.run_id=n.id AND r.benchmark IN ('STT','TTS') AND NOT (
+        r.id BETWEEN %s AND %s AND r.created_at >= %s AND r.created_at < %s
+      )
     )
   GROUP BY n.scheduled_at
 )
@@ -1170,23 +1494,23 @@ ORDER BY scheduled_at,first_run_id LIMIT %s
 
 
 def _complete_pages(
-    conn: psycopg.Connection, low: int, high: int, batch_size: int, skipped: Counter[str]
+    conn: psycopg.Connection, window: FrozenWindow, batch_size: int, skipped: Counter[str]
 ) -> Iterable[tuple[list[LegacyRow], list[LegacyRow]]]:
     """Yield raw and complete bounded run pages, ending each read transaction."""
     after_run_id = 0
     while True:
-        run_ids, rows = _run_page(conn, low, high, after_run_id, batch_size)
+        run_ids, rows = _run_page(conn, window, after_run_id, batch_size)
         if not run_ids:
             conn.commit()
             return
         after_run_id = run_ids[-1]
-        complete = _complete_window_rows(conn, rows, low, high, skipped)
+        complete = _complete_window_rows(conn, rows, window, skipped)
         conn.commit()
         yield rows, complete
 
 
 def _scheduled_buckets(
-    conn: psycopg.Connection, low: int, high: int, batch_size: int
+    conn: psycopg.Connection, window: FrozenWindow, batch_size: int
 ) -> Iterable[datetime]:
     """Keyset distinct buckets by timestamp and a stable representative run id."""
     after: tuple[datetime, int] | None = None
@@ -1196,10 +1520,14 @@ def _scheduled_buckets(
             cur.execute(
                 _BUCKET_PAGE_SQL,
                 (
-                    low,
-                    high,
-                    low,
-                    high,
+                    window.min_result_id,
+                    window.max_result_id,
+                    window.start,
+                    window.end,
+                    window.min_result_id,
+                    window.max_result_id,
+                    window.start,
+                    window.end,
                     after[0] if after else None,
                     *(after or (None, 0)),
                     batch_size,
@@ -1230,6 +1558,7 @@ def _preflight_artifact_bucket(client: storage.Client, bucket_name: str) -> None
 def _set_ready(report: dict[str, Any], *, dry_run: bool) -> None:
     report["skipped_by_reason"] = dict(report["skipped_by_reason"])
     report["verification_skipped_by_reason"] = dict(report["verification_skipped_by_reason"])
+    report["parity_mismatch_reasons"] = dict(report["parity_mismatch_reasons"])
     report["cutover_ready"] = (
         (not dry_run or not report["eligible"])
         and report["parity_mismatch_count"] == 0
@@ -1244,17 +1573,31 @@ def backfill(
     *,
     min_result_id: int,
     max_result_id: int,
+    window_start: datetime | None = None,
+    window_end: datetime | None = None,
     batch_size: int,
     apply: bool,
     artifact_bucket: str | None = None,
     reporter: ProgressReporter | None = None,
 ) -> dict[str, Any]:
-    if min_result_id <= 0 or max_result_id < min_result_id or batch_size <= 0:
+    if batch_size <= 0:
         raise ValueError("invalid id range or batch size")
+    if (window_start is None) != (window_end is None):
+        raise ValueError("window start and end must be provided together")
+    if apply and window_start is None:
+        raise ValueError("apply requires explicit window start and end")
+    # The command resolves this from the database exactly once.  This fallback
+    # retains a frozen cohort for programmatic callers used in focused tests.
+    end = window_end or datetime.now(UTC)
+    window = FrozenWindow(
+        min_result_id, max_result_id, window_start or end - timedelta(hours=168), end
+    )
     report = _report()
     report["window"] = {
         "min_result_id": min_result_id,
         "max_result_id": max_result_id,
+        "start": window.start.isoformat(),
+        "end": window.end.isoformat(),
         "batch_size": batch_size,
     }
     reporter = reporter or ProgressReporter(
@@ -1262,6 +1605,8 @@ def backfill(
         min_result_id=min_result_id,
         max_result_id=max_result_id,
         batch_size=batch_size,
+        window_start=window.start,
+        window_end=window.end,
     )
     phase = "operation"
     lock_acquired = False
@@ -1279,14 +1624,14 @@ def backfill(
             reporter.phase_completed(phase, report)
         phase = "qualifying_run_count"
         reporter.phase_started(phase, report)
-        reporter.total_runs = _qualifying_run_count(conn, min_result_id, max_result_id)
+        reporter.total_runs = _qualifying_run_count(conn, window)
         reporter.phase_completed(phase, report)
         conn.commit()
         phase = "source_reconciliation"
         reporter.phase_started(phase, report, total_runs=reporter.total_runs)
         if not apply:
             for rows, complete in _complete_pages(
-                conn, min_result_id, max_result_id, batch_size, report["skipped_by_reason"]
+                conn, window, batch_size, report["skipped_by_reason"]
             ):
                 report["source_rows"] += len(rows)
                 plans = _page_plans(complete, report["skipped_by_reason"])
@@ -1304,7 +1649,7 @@ def backfill(
             reporter.phase_started(phase, report)
             _rollup_mismatches(
                 conn,
-                _scheduled_buckets(conn, min_result_id, max_result_id, batch_size),
+                _scheduled_buckets(conn, window, batch_size),
                 report,
                 lambda: reporter.completed_unit(report, phase=phase),
             )
@@ -1319,7 +1664,7 @@ def backfill(
         # transaction now so each following ``conn.transaction`` is top-level.
         conn.commit()
         for rows, complete in _complete_pages(
-            conn, min_result_id, max_result_id, batch_size, report["skipped_by_reason"]
+            conn, window, batch_size, report["skipped_by_reason"]
         ):
             report["source_rows"] += len(rows)
             plans = _page_plans(complete, report["skipped_by_reason"])
@@ -1350,9 +1695,7 @@ def backfill(
         phase = "post_write_verification"
         reporter.phase_started(phase, report, total_runs=reporter.total_runs)
         verification_skipped: Counter[str] = report["verification_skipped_by_reason"]
-        for rows, complete in _complete_pages(
-            conn, min_result_id, max_result_id, batch_size, verification_skipped
-        ):
+        for rows, complete in _complete_pages(conn, window, batch_size, verification_skipped):
             for plan in _page_plans(complete, verification_skipped):
                 if plan.first.scheduled_at is None:
                     verification_skipped["scheduled_at_missing"] += 1
@@ -1376,7 +1719,7 @@ def backfill(
                         _append_mismatch(
                             report,
                             "parity_mismatches",
-                            {"natural_key": list(plan.natural), "reason": reason},
+                            {"reason": reason},
                         )
             reporter.completed_page(sorted({row.run_id for row in rows}), rows, report, phase=phase)
         reporter.phase_completed(phase, report)
@@ -1384,7 +1727,7 @@ def backfill(
         reporter.phase_started(phase, report)
         _rollup_mismatches(
             conn,
-            _scheduled_buckets(conn, min_result_id, max_result_id, batch_size),
+            _scheduled_buckets(conn, window, batch_size),
             report,
             lambda: reporter.completed_unit(report, phase=phase),
         )
@@ -1408,33 +1751,71 @@ def backfill(
 @click.command(name="backfill-normalized-storage")
 @click.option("--min-result-id", type=click.IntRange(1), default=1, show_default=True)
 @click.option("--max-result-id", type=click.IntRange(1))
+@click.option("--window-start", type=str)
+@click.option("--window-end", type=str)
 @click.option("--batch-size", type=click.IntRange(1), default=100, show_default=True)
 @click.option("--apply", is_flag=True, help="Write immutable normalized rows.")
 def backfill_normalized_storage_cli(
-    min_result_id: int, max_result_id: int | None, batch_size: int, apply: bool
+    min_result_id: int,
+    max_result_id: int | None,
+    window_start: str | None,
+    window_end: str | None,
+    batch_size: int,
+    apply: bool,
 ) -> None:
     """Reconcile a frozen inclusive legacy-result window into normalized tables."""
-    if apply and max_result_id is None:
-        raise click.UsageError("--apply requires an explicit --max-result-id")
+    if apply and (max_result_id is None or window_start is None or window_end is None):
+        raise click.UsageError(
+            "--apply requires explicit --window-start, --window-end, and --max-result-id"
+        )
+    if (window_start is None) != (window_end is None):
+        raise click.UsageError("--window-start and --window-end must be provided together")
+
+    def parse_window(value: str, option: str) -> datetime:
+        try:
+            parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError as exc:
+            raise click.UsageError(f"{option} must be an ISO-8601 timestamp") from exc
+        if parsed.tzinfo is None:
+            raise click.UsageError(f"{option} must include a timezone")
+        return parsed.astimezone(UTC)
+
+    explicit_start = parse_window(window_start, "--window-start") if window_start else None
+    explicit_end = parse_window(window_end, "--window-end") if window_end else None
     url = str(get_settings().database_url)
     if url == "postgresql://unused:unused@127.0.0.1:5432/unused":
         raise click.ClickException(
             "DATABASE_URL is required for this production migration; set a non-local production URL"
         )
     with _temporary_sigterm_cancellation(), psycopg.connect(url) as conn:
-        if max_result_id is None:
+        database_now: datetime | None = None
+        if max_result_id is None or explicit_end is None:
             with conn.cursor() as cur:
-                cur.execute("SELECT COALESCE(max(id),0) FROM benchmarks_v2.results")
+                cur.execute(
+                    "SELECT statement_timestamp(),COALESCE(max(id),0) FROM benchmarks_v2.results"
+                )
                 row = cur.fetchone()
                 if row is None:  # pragma: no cover - aggregate SELECT always returns one row.
-                    raise RuntimeError("max result id query returned no row")
-                max_result_id = row[0]
+                    raise RuntimeError("frozen window query returned no row")
+                database_now, resolved_max_result_id = row
+                if max_result_id is None:
+                    max_result_id = int(resolved_max_result_id)
+        end = explicit_end if explicit_end is not None else database_now
+        if end is None:  # pragma: no cover - query always returns statement_timestamp.
+            raise RuntimeError("database clock query returned no timestamp")
+        start = explicit_start if explicit_start is not None else end - timedelta(hours=168)
         if max_result_id < min_result_id:
             raise click.UsageError("--max-result-id must be >= --min-result-id")
+        try:
+            FrozenWindow(min_result_id, max_result_id, start, end)
+        except ValueError as exc:
+            raise click.UsageError(str(exc)) from exc
         report = backfill(
             conn,
             min_result_id=min_result_id,
             max_result_id=max_result_id,
+            window_start=start,
+            window_end=end,
             batch_size=batch_size,
             apply=apply,
             artifact_bucket=os.getenv("BENCHMARK_ARTIFACT_BUCKET"),

--- a/runner/tests/unit/test_normalized_storage_backfill.py
+++ b/runner/tests/unit/test_normalized_storage_backfill.py
@@ -13,7 +13,7 @@ from contextlib import nullcontext
 from dataclasses import astuple, replace
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 from uuid import uuid4
 
 import click
@@ -35,11 +35,17 @@ from coval_bench.migrations.backfill_normalized_storage import (
     backfill,
     backfill_normalized_storage_cli,
 )
+from coval_bench.observation_artifacts import (
+    prepare_provider_transcript,
+    prepare_timing_events,
+)
 
 backfill_pg = postgresql("pg_proc")
 _INI_PATH = Path(__file__).parents[2] / "alembic.ini"
 _NOW = datetime(2026, 8, 27, 10, 0, tzinfo=UTC)
 _SHA = "a" * 64
+_WINDOW_START = _NOW - timedelta(hours=167)
+_WINDOW_END = _NOW + timedelta(hours=1)
 
 
 def _dsn(conn: psycopg.Connection[Any]) -> str:
@@ -74,7 +80,12 @@ def _insert_run(conn: psycopg.Connection[Any]) -> int:
 
 
 def _insert_wer(
-    conn: psycopg.Connection[Any], run_id: int, filename: str, *, transcript: str = "words"
+    conn: psycopg.Connection[Any],
+    run_id: int,
+    filename: str,
+    *,
+    transcript: str = "words",
+    created_at: datetime = _NOW,
 ) -> int:
     with conn.cursor() as cur:
         cur.execute(
@@ -84,7 +95,7 @@ def _insert_wer(
                 wer_deletions_pct,wer_substitutions_pct)
                VALUES (%s,'provider','model','STT','WER',6,'percent',%s,%s,'success',
                        NULL,%s,1,2,3) RETURNING id""",
-            (run_id, filename, transcript, _NOW),
+            (run_id, filename, transcript, created_at),
         )
         row = cur.fetchone()
         assert row is not None
@@ -234,10 +245,466 @@ def test_ambiguous_tts_provider_failure_origin_is_skipped(
     assert skipped["observation_failure_origin_unrecoverable"] == 1
 
 
-def test_cli_apply_requires_explicit_frozen_maximum() -> None:
+def test_cli_apply_requires_explicit_frozen_window_and_maximum() -> None:
     result = CliRunner().invoke(backfill_normalized_storage_cli, ["--apply"])
     assert result.exit_code == 2
-    assert "--apply requires an explicit --max-result-id" in result.output
+    assert (
+        "--apply requires explicit --window-start, --window-end, and --max-result-id"
+        in result.output
+    )
+
+
+@pytest.mark.parametrize(
+    "missing",
+    ["--window-start", "--window-end", "--max-result-id"],
+)
+def test_cli_apply_rejects_each_missing_frozen_argument_before_connecting(missing: str) -> None:
+    arguments = {
+        "--window-start": "2026-08-20T00:00:00Z",
+        "--window-end": "2026-08-27T00:00:00Z",
+        "--max-result-id": "9",
+    }
+    command = ["--apply"] + [
+        item for pair in arguments.items() if pair[0] != missing for item in pair
+    ]
+    result = CliRunner().invoke(backfill_normalized_storage_cli, command)
+    assert result.exit_code == 2
+    assert "--apply requires explicit" in result.output
+
+
+def test_frozen_window_is_utc_and_exactly_seven_days() -> None:
+    start = datetime(2026, 8, 20, tzinfo=UTC)
+    window = migration.FrozenWindow(1, 9, start, start + timedelta(hours=168))
+    assert window.start == start
+    assert window.end == start + timedelta(days=7)
+    with pytest.raises(ValueError, match="exactly 168 hours"):
+        migration.FrozenWindow(1, 9, start, start + timedelta(days=7, seconds=1))
+
+
+def test_parity_mismatch_report_aggregates_safe_reasons() -> None:
+    report = migration._report()
+    migration._append_mismatch(
+        report,
+        "parity_mismatches",
+        {"reason": "live_owned_payload_mismatch", "natural_key": ["private"]},
+    )
+    assert report["parity_mismatch_count"] == 1
+    assert report["parity_mismatch_reasons"] == {"live_owned_payload_mismatch": 1}
+    assert report["parity_mismatches"] == [{"reason": "live_owned_payload_mismatch"}]
+
+
+def test_apply_core_requires_explicit_window_before_client_or_connection_setup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(gcs_storage, "Client", lambda: pytest.fail("must not create GCS client"))
+
+    class Conn:
+        def cursor(self) -> Any:
+            pytest.fail("must not touch the connection")
+
+    with pytest.raises(ValueError, match="apply requires explicit window"):
+        migration.backfill(
+            Conn(),  # type: ignore[arg-type]
+            min_result_id=1,
+            max_result_id=1,
+            batch_size=1,
+            apply=True,
+            artifact_bucket="bucket",
+        )
+
+
+def test_stt_tts_rollup_sql_never_deletes_or_verifies_s2s_rows() -> None:
+    assert "benchmark IN ('STT','TTS')" in migration._ROLLUP_PAYLOAD_SQL
+    assert "benchmark IN ('STT','TTS')" in migration._STORED_ROLLUP_SQL
+
+    class Cursor:
+        def __init__(self) -> None:
+            self.statements: list[str] = []
+
+        def execute(self, statement: str, _: Any) -> None:
+            self.statements.append(statement)
+
+    cursor = Cursor()
+    migration._refresh_bucket(cursor, _NOW)  # type: ignore[arg-type]
+    assert "benchmark IN ('STT','TTS')" in cursor.statements[1]
+
+
+def test_backfill_owned_row_keeps_strict_lifecycle_timestamp_comparison() -> None:
+    row = replace(_row("WER", 6.0), benchmark="STT")
+    plan = migration.Planned(
+        [row],
+        "sample",
+        row.dataset_id,
+        row.dataset_sha256,
+        "STT",
+        "dataset_audio",
+        "succeeded",
+        None,
+        None,
+        [("provider_transcript", row.transcript or "")],
+    )
+    parent = (
+        row.run_id,
+        plan.dataset_id,
+        plan.dataset_sha256,
+        plan.sample_id,
+        row.provider,
+        row.model,
+        row.voice,
+        plan.benchmark,
+        plan.source_kind,
+        row.http_version,
+        row.headers_ms,
+        row.created_at,
+        plan.status,
+        plan.error,
+        plan.failure_origin,
+    )
+    later = row.created_at + timedelta(seconds=1)
+    stored_values = [
+        (
+            metric,
+            "v1",
+            "default",
+            "inline",
+            "succeeded",
+            later,
+            later,
+            None,
+            key,
+            unit,
+            value,
+            role,
+        )
+        for metric, key, value, unit, role in migration._values(plan.rows)
+    ]
+
+    class Cursor:
+        def execute(self, *_: Any) -> None:
+            return None
+
+        def fetchone(self) -> tuple[Any, ...]:
+            return parent
+
+        def fetchall(self) -> list[tuple[Any, ...]]:
+            return stored_values
+
+    assert not migration._stored_plan_matches(Cursor(), plan, plan.id)  # type: ignore[arg-type]
+
+
+def test_live_tts_artifacts_inputs_and_lifecycle_are_exact_where_recoverable() -> None:
+    row = _row("TTFA", 12.0)
+    plan = migration.Planned(
+        [row],
+        "sample",
+        row.dataset_id,
+        row.dataset_sha256,
+        "TTS",
+        "generated_audio",
+        "succeeded",
+        None,
+        None,
+        [("timing_events", '{"ttfa_ms":12.0}')],
+    )
+    observation_id, timing_id, audio_id = uuid4(), uuid4(), uuid4()
+    _, timing_payload, _, _, _ = prepare_timing_events({"ttfa_ms": 12.0})
+    timing_digest = hashlib.sha256(timing_payload).hexdigest()
+    audio_digest = "b" * 64
+
+    def matches(
+        *,
+        timing: tuple[str, int],
+        started: datetime = _NOW + timedelta(seconds=1),
+        audio_duration: float = 1.0,
+    ) -> bool:
+        parent = (
+            row.run_id,
+            plan.dataset_id,
+            plan.dataset_sha256,
+            plan.sample_id,
+            row.provider,
+            row.model,
+            row.voice,
+            "TTS",
+            "generated_audio",
+            None,
+            None,
+            None,
+            _NOW,
+            "succeeded",
+            None,
+            None,
+        )
+        artifacts = [
+            (
+                timing_id,
+                "timing_events",
+                "TimingEvents",
+                "v1",
+                f"gs://private/observation-artifacts/v1/timing_events/{timing[0][:2]}/{timing[0]}.json",
+                timing[0],
+                timing[1],
+                None,
+            ),
+            (
+                audio_id,
+                "generated_audio",
+                "GeneratedAudio",
+                "v1",
+                f"gs://private/observation-artifacts/v1/generated_audio/bb/{audio_digest}.wav",
+                audio_digest,
+                10,
+                audio_duration,
+            ),
+        ]
+
+        class Cursor:
+            fetchone_calls = 0
+            fetchall_calls = 0
+
+            def execute(self, *_: Any) -> None:
+                return None
+
+            def fetchone(self) -> tuple[Any, ...]:
+                self.fetchone_calls += 1
+                return parent if self.fetchone_calls == 1 else (False,)
+
+            def fetchall(self) -> list[tuple[Any, ...]]:
+                self.fetchall_calls += 1
+                return cast(
+                    list[tuple[Any, ...]],
+                    {
+                        1: [
+                            (
+                                uuid4(),
+                                "TTFA",
+                                "v1",
+                                "default",
+                                "inline",
+                                None,
+                                "succeeded",
+                                started,
+                                started + timedelta(seconds=1),
+                                None,
+                            )
+                        ],
+                        2: [("TTFA", "primary", "milliseconds", 12.0, "primary")],
+                        3: artifacts,
+                        4: [("TTFA", "timing", 0, timing_id), ("TTFA", "raw", 0, audio_id)],
+                    }[self.fetchall_calls],
+                )
+
+        return migration._live_stored_plan_matches(Cursor(), plan, observation_id)  # type: ignore[arg-type]
+
+    assert matches(timing=(timing_digest, len(timing_payload)))
+    assert not matches(timing=("c" * 64, 9))
+    assert not matches(
+        timing=(timing_digest, len(timing_payload)), started=_NOW - timedelta(seconds=1)
+    )
+    assert not matches(timing=(timing_digest, len(timing_payload)), audio_duration=0)
+
+
+def test_live_tts_null_ttfa_keeps_unreferenced_timing_artifact_for_wer() -> None:
+    anchor = _row("TTFA", None)
+    wer = _row("WER", 6.0)
+    plan = migration.Planned(
+        [anchor, wer],
+        "sample",
+        anchor.dataset_id,
+        anchor.dataset_sha256,
+        "TTS",
+        "generated_audio",
+        "succeeded",
+        None,
+        None,
+        [],
+    )
+    observation_id, timing_id, audio_id = uuid4(), uuid4(), uuid4()
+    # The legacy transport-contaminated row is null; the private artifact kept
+    # the unrecoverable original provider timing.
+    _, timing_payload, _, _, _ = prepare_timing_events({"ttfa_ms": 47.25})
+    timing_digest = hashlib.sha256(timing_payload).hexdigest()
+    audio_digest = "b" * 64
+    parent = (
+        anchor.run_id,
+        plan.dataset_id,
+        plan.dataset_sha256,
+        plan.sample_id,
+        anchor.provider,
+        anchor.model,
+        anchor.voice,
+        "TTS",
+        "generated_audio",
+        None,
+        None,
+        None,
+        _NOW,
+        "succeeded",
+        None,
+        None,
+    )
+
+    class Cursor:
+        fetchone_calls = 0
+        fetchall_calls = 0
+
+        def execute(self, *_: Any) -> None:
+            return None
+
+        def fetchone(self) -> tuple[Any, ...]:
+            self.fetchone_calls += 1
+            return parent if self.fetchone_calls == 1 else (False,)
+
+        def fetchall(self) -> list[tuple[Any, ...]]:
+            self.fetchall_calls += 1
+            return cast(
+                list[tuple[Any, ...]],
+                {
+                    1: [
+                        (
+                            uuid4(),
+                            "WER",
+                            "v1",
+                            "default",
+                            "inline",
+                            None,
+                            "succeeded",
+                            _NOW,
+                            _NOW,
+                            None,
+                        )
+                    ],
+                    2: [
+                        ("WER", key, unit, value, role)
+                        for _, key, value, unit, role in migration._values(plan.rows)
+                    ],
+                    3: [
+                        (
+                            timing_id,
+                            "timing_events",
+                            "TimingEvents",
+                            "v1",
+                            f"gs://private/observation-artifacts/v1/timing_events/{timing_digest[:2]}/{timing_digest}.json",
+                            timing_digest,
+                            len(timing_payload),
+                            None,
+                        ),
+                        (
+                            audio_id,
+                            "generated_audio",
+                            "GeneratedAudio",
+                            "v1",
+                            f"gs://private/observation-artifacts/v1/generated_audio/bb/{audio_digest}.wav",
+                            audio_digest,
+                            10,
+                            1.0,
+                        ),
+                    ],
+                    4: [("WER", "raw", 0, audio_id)],
+                }[self.fetchall_calls],
+            )
+
+    assert migration._live_stored_plan_matches(Cursor(), plan, observation_id)  # type: ignore[arg-type]
+
+
+def test_live_stt_wer_allows_required_unreferenced_timing_artifact() -> None:
+    row = replace(_row("WER", 6.0), benchmark="STT")
+    plan = migration.Planned(
+        [row],
+        "sample",
+        row.dataset_id,
+        row.dataset_sha256,
+        "STT",
+        "dataset_audio",
+        "succeeded",
+        None,
+        None,
+        [("provider_transcript", row.transcript or "")],
+    )
+    observation_id, transcript_id, timing_id = uuid4(), uuid4(), uuid4()
+    _, transcript_payload, _, _, _ = prepare_provider_transcript(row.transcript or "")
+    transcript_digest = hashlib.sha256(transcript_payload).hexdigest()
+    timing_digest = "c" * 64
+    parent = (
+        row.run_id,
+        plan.dataset_id,
+        plan.dataset_sha256,
+        plan.sample_id,
+        row.provider,
+        row.model,
+        row.voice,
+        "STT",
+        "dataset_audio",
+        None,
+        None,
+        None,
+        _NOW,
+        "succeeded",
+        None,
+        None,
+    )
+
+    class Cursor:
+        fetchone_calls = 0
+        fetchall_calls = 0
+
+        def execute(self, *_: Any) -> None:
+            return None
+
+        def fetchone(self) -> tuple[Any, ...]:
+            self.fetchone_calls += 1
+            return parent if self.fetchone_calls == 1 else (False,)
+
+        def fetchall(self) -> list[tuple[Any, ...]]:
+            self.fetchall_calls += 1
+            return cast(
+                list[tuple[Any, ...]],
+                {
+                    1: [
+                        (
+                            uuid4(),
+                            "WER",
+                            "v1",
+                            "default",
+                            "inline",
+                            None,
+                            "succeeded",
+                            _NOW,
+                            _NOW,
+                            None,
+                        )
+                    ],
+                    2: [
+                        ("WER", key, unit, value, role)
+                        for _, key, value, unit, role in migration._values(plan.rows)
+                    ],
+                    3: [
+                        (
+                            transcript_id,
+                            "provider_transcript",
+                            "ProviderTranscript",
+                            "v1",
+                            f"gs://private/observation-artifacts/v1/provider_transcript/{transcript_digest[:2]}/{transcript_digest}.json",
+                            transcript_digest,
+                            len(transcript_payload),
+                            None,
+                        ),
+                        (
+                            timing_id,
+                            "timing_events",
+                            "TimingEvents",
+                            "v1",
+                            f"gs://private/observation-artifacts/v1/timing_events/{timing_digest[:2]}/{timing_digest}.json",
+                            timing_digest,
+                            1,
+                            None,
+                        ),
+                    ],
+                    4: [("WER", "raw", 0, transcript_id)],
+                }[self.fetchall_calls],
+            )
+
+    assert migration._live_stored_plan_matches(Cursor(), plan, observation_id)  # type: ignore[arg-type]
 
 
 def test_cli_rejects_the_local_placeholder_before_connecting(
@@ -408,12 +875,93 @@ def test_cli_keeps_progress_on_stderr_and_machine_report_as_final_stdout_line(
     monkeypatch.setattr(migration, "_scheduled_buckets", lambda *_: iter(()))
     monkeypatch.setattr(migration, "_rollup_mismatches", lambda *_args, **_kwargs: None)
 
-    result = CliRunner().invoke(backfill_normalized_storage_cli, ["--max-result-id", "9"])
+    result = CliRunner().invoke(
+        backfill_normalized_storage_cli,
+        [
+            "--max-result-id",
+            "9",
+            "--window-start",
+            "2026-08-20T00:00:00Z",
+            "--window-end",
+            "2026-08-27T00:00:00Z",
+        ],
+    )
 
     assert result.exit_code == 0
     assert "normalized_storage_backfill_progress" not in result.stdout
     assert "normalized_storage_backfill_progress" in result.stderr
-    assert json.loads(result.stdout.splitlines()[-1])["window"]["max_result_id"] == 9
+    window = json.loads(result.stdout.splitlines()[-1])["window"]
+    assert window == {
+        "batch_size": 100,
+        "end": "2026-08-27T00:00:00+00:00",
+        "max_result_id": 9,
+        "min_result_id": 1,
+        "start": "2026-08-20T00:00:00+00:00",
+    }
+
+
+def test_cli_dry_run_freezes_database_clock_and_maximum_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    database_now = datetime(2026, 8, 27, 12, 0, tzinfo=UTC)
+    captured: dict[str, Any] = {}
+
+    class Settings:
+        database_url = "postgresql://example"
+
+    class Cursor:
+        calls = 0
+
+        def __enter__(self) -> Cursor:
+            return self
+
+        def __exit__(self, *_: Any) -> None:
+            return None
+
+        def execute(self, statement: str) -> None:
+            assert "statement_timestamp" in statement
+            self.calls += 1
+
+        def fetchone(self) -> tuple[datetime, int]:
+            return database_now, 77
+
+    class Conn:
+        cursor_value = Cursor()
+
+        def __enter__(self) -> Conn:
+            return self
+
+        def __exit__(self, *_: Any) -> None:
+            return None
+
+        def cursor(self) -> Cursor:
+            return self.cursor_value
+
+    def fake_backfill(_: Any, **kwargs: Any) -> dict[str, Any]:
+        captured.update(kwargs)
+        return {
+            "window": {
+                "start": kwargs["window_start"].isoformat(),
+                "end": kwargs["window_end"].isoformat(),
+                "max_result_id": kwargs["max_result_id"],
+            }
+        }
+
+    monkeypatch.setattr(migration, "get_settings", lambda: Settings())
+    monkeypatch.setattr(psycopg, "connect", lambda _: Conn())
+    monkeypatch.setattr(migration, "backfill", fake_backfill)
+    result = CliRunner().invoke(backfill_normalized_storage_cli, [])
+
+    assert result.exit_code == 0
+    assert Conn.cursor_value.calls == 1
+    assert captured["window_start"] == database_now - timedelta(hours=168)
+    assert captured["window_end"] == database_now
+    assert captured["max_result_id"] == 77
+    assert json.loads(result.stdout.splitlines()[-1])["window"] == {
+        "start": "2026-08-20T12:00:00+00:00",
+        "end": "2026-08-27T12:00:00+00:00",
+        "max_result_id": 77,
+    }
 
 
 def test_sigterm_cancellation_handler_is_restored(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -451,6 +999,8 @@ def test_progress_failure_keeps_last_completed_checkpoint_without_detail_leakage
             Conn(),  # type: ignore[arg-type]
             min_result_id=1,
             max_result_id=9,
+            window_start=_WINDOW_START,
+            window_end=_WINDOW_END,
             batch_size=1,
             apply=False,
             reporter=reporter,
@@ -508,6 +1058,8 @@ def test_apply_cancellation_emits_checkpoint_then_unlocks(
             Conn(),  # type: ignore[arg-type]
             min_result_id=1,
             max_result_id=9,
+            window_start=_WINDOW_START,
+            window_end=_WINDOW_END,
             batch_size=1,
             apply=True,
             artifact_bucket="bucket",
@@ -538,8 +1090,8 @@ def test_run_pages_keyset_by_run_id_not_interleaved_result_ids() -> None:
         def execute(self, sql: str, params: tuple[Any, ...]) -> None:
             self.calls.append((sql, params))
             if sql == migration._PAGE_RUN_IDS_SQL:
-                after = int(params[2])
-                self.result = [(run_id,) for run_id in (10, 20) if run_id > after][: int(params[3])]
+                after = int(params[4])
+                self.result = [(run_id,) for run_id in (10, 20) if run_id > after][: int(params[5])]
             else:
                 self.result = [astuple(first) if params[0] == [10] else astuple(second)]
 
@@ -554,14 +1106,43 @@ def test_run_pages_keyset_by_run_id_not_interleaved_result_ids() -> None:
             return self.value
 
     conn = Conn()
-    ids, rows = migration._run_page(conn, 1, 99, 0, 1)  # type: ignore[arg-type]
-    next_ids, next_rows = migration._run_page(conn, 1, 99, ids[-1], 1)  # type: ignore[arg-type]
+    window = migration.FrozenWindow(1, 99, _NOW - timedelta(hours=168), _NOW)
+    ids, rows = migration._run_page(conn, window, 0, 1)  # type: ignore[arg-type]
+    next_ids, next_rows = migration._run_page(conn, window, ids[-1], 1)  # type: ignore[arg-type]
     assert (ids, [row.run_id for row in rows]) == ([10], [10])
     assert (next_ids, [row.run_id for row in next_rows]) == ([20], [20])
-    assert [call[1][2] for call in conn.value.calls if call[0] == migration._PAGE_RUN_IDS_SQL] == [
+    assert [call[1][4] for call in conn.value.calls if call[0] == migration._PAGE_RUN_IDS_SQL] == [
         0,
         10,
     ]
+
+
+def test_run_page_uses_start_inclusive_end_exclusive_and_frozen_max_id(
+    backfill_pg: psycopg.Connection[Any],
+) -> None:
+    _migrate(backfill_pg)
+    start = datetime(2026, 8, 20, tzinfo=UTC)
+    start_id = _insert_wer(backfill_pg, _insert_run(backfill_pg), "start.wav", created_at=start)
+    _insert_wer(
+        backfill_pg, _insert_run(backfill_pg), "end.wav", created_at=start + timedelta(hours=168)
+    )
+    max_id = _insert_wer(
+        backfill_pg, _insert_run(backfill_pg), "max.wav", created_at=start + timedelta(hours=1)
+    )
+    _insert_wer(
+        backfill_pg,
+        _insert_run(backfill_pg),
+        "after-max.wav",
+        created_at=start + timedelta(hours=1),
+    )
+
+    _, rows = migration._run_page(
+        backfill_pg,
+        migration.FrozenWindow(start_id, max_id, start, start + timedelta(hours=168)),
+        0,
+        100,
+    )
+    assert {row.id for row in rows} == {start_id, max_id}
 
 
 def test_scheduled_buckets_uses_nullable_timestamp_keyset_across_pages() -> None:
@@ -580,7 +1161,7 @@ def test_scheduled_buckets_uses_nullable_timestamp_keyset_across_pages() -> None
 
         def execute(self, _: str, params: tuple[Any, ...]) -> None:
             self.calls.append(params)
-            cursor = params[4]
+            cursor = params[8]
             self.result = (
                 [(_NOW, 10)] if cursor is None else [(later, 20)] if cursor == _NOW else []
             )
@@ -599,11 +1180,12 @@ def test_scheduled_buckets_uses_nullable_timestamp_keyset_across_pages() -> None
             return self.value
 
     conn = Conn()
-    assert list(migration._scheduled_buckets(conn, 1, 99, 1)) == [_NOW, later]  # type: ignore[arg-type]
+    window = migration.FrozenWindow(1, 99, _NOW - timedelta(hours=168), _NOW)
+    assert list(migration._scheduled_buckets(conn, window, 1)) == [_NOW, later]  # type: ignore[arg-type]
     assert conn.value.calls == [
-        (1, 99, 1, 99, None, None, 0, 1),
-        (1, 99, 1, 99, _NOW, _NOW, 10, 1),
-        (1, 99, 1, 99, later, later, 20, 1),
+        (1, 99, window.start, window.end, 1, 99, window.start, window.end, None, None, 0, 1),
+        (1, 99, window.start, window.end, 1, 99, window.start, window.end, _NOW, _NOW, 10, 1),
+        (1, 99, window.start, window.end, 1, 99, window.start, window.end, later, later, 20, 1),
     ]
 
 
@@ -673,6 +1255,8 @@ def test_apply_replans_for_fresh_verification_without_retaining_pages(
         Conn(),  # type: ignore[arg-type]
         min_result_id=1,
         max_result_id=1,
+        window_start=_WINDOW_START,
+        window_end=_WINDOW_END,
         batch_size=1,
         apply=True,
         artifact_bucket="bucket",
@@ -706,8 +1290,7 @@ def test_apply_verification_skips_are_reported_and_block_readiness(
 
     def pages(
         _conn: Any,
-        _low: int,
-        _high: int,
+        _window: migration.FrozenWindow,
         _batch_size: int,
         skipped: Counter[str],
     ) -> Any:
@@ -759,6 +1342,8 @@ def test_apply_verification_skips_are_reported_and_block_readiness(
         Conn(),  # type: ignore[arg-type]
         min_result_id=1,
         max_result_id=1,
+        window_start=_WINDOW_START,
+        window_end=_WINDOW_END,
         batch_size=1,
         apply=True,
         artifact_bucket="bucket",
@@ -806,6 +1391,8 @@ def test_apply_bucket_preflight_fails_before_lock_page_or_write(
             Conn(),  # type: ignore[arg-type]
             min_result_id=1,
             max_result_id=1,
+            window_start=_WINDOW_START,
+            window_end=_WINDOW_END,
             batch_size=1,
             apply=True,
             artifact_bucket="bucket",
@@ -884,6 +1471,8 @@ def test_apply_reconciles_artifacts_inputs_values_and_rollups(
         backfill_pg,
         min_result_id=result_id,
         max_result_id=result_id,
+        window_start=_WINDOW_START,
+        window_end=_WINDOW_END,
         batch_size=1,
         apply=False,
     )
@@ -898,6 +1487,8 @@ def test_apply_reconciles_artifacts_inputs_values_and_rollups(
         backfill_pg,
         min_result_id=result_id,
         max_result_id=result_id,
+        window_start=_WINDOW_START,
+        window_end=_WINDOW_END,
         batch_size=1,
         apply=True,
         artifact_bucket="backfill-artifacts",
@@ -919,6 +1510,8 @@ def test_apply_reconciles_artifacts_inputs_values_and_rollups(
         backfill_pg,
         min_result_id=result_id,
         max_result_id=result_id,
+        window_start=_WINDOW_START,
+        window_end=_WINDOW_END,
         batch_size=1,
         apply=True,
         artifact_bucket="backfill-artifacts",
@@ -950,6 +1543,8 @@ def test_live_owned_incomplete_child_payload_blocks_readiness(
         backfill_pg,
         min_result_id=result_id,
         max_result_id=result_id,
+        window_start=_WINDOW_START,
+        window_end=_WINDOW_END,
         batch_size=1,
         apply=False,
     )
@@ -984,6 +1579,8 @@ def test_batch_one_commits_when_batch_two_fails_then_rerun_resumes(
             backfill_pg,
             min_result_id=first,
             max_result_id=second,
+            window_start=_WINDOW_START,
+            window_end=_WINDOW_END,
             batch_size=1,
             apply=True,
             artifact_bucket="backfill-artifacts",
@@ -998,6 +1595,8 @@ def test_batch_one_commits_when_batch_two_fails_then_rerun_resumes(
         backfill_pg,
         min_result_id=first,
         max_result_id=second,
+        window_start=_WINDOW_START,
+        window_end=_WINDOW_END,
         batch_size=1,
         apply=True,
         artifact_bucket="backfill-artifacts",


### PR DESCRIPTION
## Summary

- freeze one inclusive-start/exclusive-end 168-hour UTC STT/TTS source window and require its explicit bounds plus maximum result ID for apply
- keep deterministic backfill-owned validation exact while accepting only the current allowlisted live dual-write contract, including semantic lifecycle timestamps and unrecoverable generated-audio descriptors
- apply the frozen scope throughout discovery, paging, verification, rollup selection, progress, and final reporting; document the 48-hour Cloud Run dry-run command
- keep S2S and floating-point rollup tolerance out of scope

## Testing

- `uv run pytest -q tests/unit/test_normalized_storage_backfill.py -k "not test_run_page_uses_start_inclusive_end_exclusive_and_frozen_max_id and not test_apply_reconciles_artifacts_inputs_values_and_rollups and not test_live_owned_incomplete_child_payload_blocks_readiness and not test_batch_one_commits_when_batch_two_fails_then_rerun_resumes"` — 41 passed, 4 deselected
- `uv run mypy --strict src tests` — passed across 322 source files
- `uv run ruff check tests/unit/test_normalized_storage_backfill.py` — passed
- `uv run ruff format --check tests/unit/test_normalized_storage_backfill.py` — passed
- `git diff --check` — passed

## Known limitations / rollout notes

- The four PostgreSQL-backed tests could not start locally because `pg_config` is unavailable; the PR Runner CI executes the full suite with its embedded PostgreSQL setup.
- No production apply, deployment, job execution, or normalized-read enablement was performed. Apply still requires separate explicit authorization and the frozen dry-run bounds.
- The existing floating-point rollup-tolerance issue remains separate.