### PR TITLE
[BENCH-786] Add the Phonely proxy with per-turn timing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,6 +47,12 @@ MURFAI_API_KEY=
 HAKIMAI_API_KEY=
 ZOOM_API_KEY=
 ZOOM_API_SECRET=
+PHONELY_API_KEY=
+
+# --- Phonely LLM proxy (optional) ---
+PHONELY_BASE_URL=https://db.phonely.ai
+PHONELY_AGENT_ID=
+LLM_PROXY_SECRET=
 
 # --- API (optional) ---
 # Clerk instance for provider-org logins — the one early-access proof. The

--- a/runner/src/coval_bench/api/app.py
+++ b/runner/src/coval_bench/api/app.py
@@ -48,6 +48,7 @@ from coval_bench.api.routers import (
     arena,
     health,
     leaderboard,
+    llm_phonely,
     mocktools,
     providers,
     results,
@@ -59,6 +60,7 @@ from coval_bench.api.routers import (
 from coval_bench.config import Settings, get_settings
 from coval_bench.db.conn import lifespan_pool
 from coval_bench.fixture_sources import install_fixture_providers
+from coval_bench.llm.phonely import PhonelyClient
 from coval_bench.logging import configure_logging
 from coval_bench.mocktools.dispatch import build_dispatcher
 
@@ -116,6 +118,17 @@ def create_app(settings: Settings | None = None) -> FastAPI:
                 logger.warning("posthog_init_failed", exc_info=True)
                 posthog_client = None
         app.state.posthog = posthog_client
+        phonely_client: PhonelyClient | None = None
+        phonely_key = resolved.phonely_api_key
+        if phonely_key and phonely_key.get_secret_value() and resolved.phonely_agent_id:
+            phonely_client = PhonelyClient(
+                phonely_key.get_secret_value(),
+                resolved.phonely_agent_id,
+                resolved.phonely_base_url,
+            )
+        else:
+            logger.info("phonely_proxy_disabled")
+        app.state.phonely_client = phonely_client
         # Built here rather than on first request: loading and cross-checking the
         # fixtures inside a live call would put that cost on the agent's turn.
         # Absent fixtures are normal in CI and a fresh checkout, so the route
@@ -135,6 +148,8 @@ def create_app(settings: Settings | None = None) -> FastAPI:
                 app.state.settings = resolved
                 yield
         finally:
+            if phonely_client is not None:
+                await phonely_client.aclose()
             if posthog_client is not None:
                 try:
                     posthog_client.shutdown()  # type: ignore[no-untyped-call]
@@ -163,10 +178,12 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         max_age=600,
     )
 
-    # /mock is excluded alongside /clips: compressing a tool answer would add a
-    # variable cost to a response the suite deliberately holds to a fixed latency.
+    # /mock and /llm are excluded alongside /clips: compression would add jitter to
+    # a response whose latency is either held fixed (/mock) or measured (/llm).
     app.add_middleware(
-        SelectiveGZipMiddleware, minimum_size=1024, exclude_prefixes=("/clips", "/mock")
+        SelectiveGZipMiddleware,
+        minimum_size=1024,
+        exclude_prefixes=("/clips", "/mock", "/llm"),
     )
 
     app.state.response_cache = new_response_cache()
@@ -197,9 +214,10 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     app.include_router(arena.router, prefix="/v1")
     app.include_router(admin_models.router, prefix="/v1")
     # Not under /v1 and not rate limited: an appliance the agents call, not
-    # public read API. slowapi carries no default limit, so /mock is exempt by
-    # construction — a 429 mid-conversation would be graded as the agent failing.
+    # public read API. slowapi carries no default limit, so /mock and /llm are exempt
+    # by construction — a 429 mid-conversation would be graded as the agent failing.
     app.include_router(mocktools.router)
+    app.include_router(llm_phonely.router)
 
     # Serve locally-generated arena clips when no external audio host is set
     # (prod sets arena_gcs_bucket for GCS, or arena_audio_base_url for a CDN origin).

--- a/runner/src/coval_bench/api/deps.py
+++ b/runner/src/coval_bench/api/deps.py
@@ -11,6 +11,7 @@ populated during the FastAPI lifespan (see ``app.py``).
 from __future__ import annotations
 
 import asyncio
+import hmac
 from collections import defaultdict
 from typing import Any, cast
 
@@ -19,11 +20,13 @@ from cachetools import TTLCache
 from fastapi import Depends, Header, HTTPException
 from posthog import Posthog
 from psycopg_pool import AsyncConnectionPool
+from pydantic import SecretStr
 from starlette.requests import Request
 
 from coval_bench.api import clerk
 from coval_bench.config import Settings
 from coval_bench.db.registry_store import fetch_models
+from coval_bench.llm.phonely import PhonelyClient
 from coval_bench.registries import RegisteredModel
 
 logger = structlog.get_logger("coval_bench.api")
@@ -44,6 +47,33 @@ def get_settings(request: Request) -> Settings:
     """Return the Settings instance from app state."""
     settings: Settings = request.app.state.settings
     return settings
+
+
+def bearer_token(authorization: str | None) -> str | None:
+    """The token behind a Bearer authorization header, or ``None``."""
+    if not authorization:
+        return None
+    scheme, _, token = authorization.partition(" ")
+    token = token.strip()
+    if scheme.lower() != "bearer" or not token:
+        return None
+    return token
+
+
+def secret_matches(provided: str | None, expected: SecretStr | None) -> bool:
+    """Constant-time match; an unset or empty secret never matches anything."""
+    if provided is None or expected is None:
+        return False
+    value = expected.get_secret_value()
+    return bool(value) and hmac.compare_digest(provided.encode(), value.encode())
+
+
+def get_phonely_client(request: Request) -> PhonelyClient:
+    """Return the lifespan-owned Phonely client, or fail closed."""
+    client: PhonelyClient | None = getattr(request.app.state, "phonely_client", None)
+    if client is None:
+        raise HTTPException(503, "Phonely proxy is not configured")
+    return client
 
 
 def require_coval_admin(

--- a/runner/src/coval_bench/api/routers/arena.py
+++ b/runner/src/coval_bench/api/routers/arena.py
@@ -23,7 +23,6 @@ recorded.
 from __future__ import annotations
 
 import asyncio
-import hmac
 import secrets
 import uuid
 from collections.abc import Sequence
@@ -44,6 +43,7 @@ from coval_bench.api.deps import (
     get_pool,
     get_posthog,
     get_settings,
+    secret_matches,
 )
 from coval_bench.api.ratelimit import limiter
 from coval_bench.api.schemas import (
@@ -127,12 +127,7 @@ def _hidden_tts_models(models: Sequence[RegisteredModel]) -> frozenset[tuple[str
 
 def _is_authenticated_labeler(provided: str | None, settings: Settings) -> bool:
     """True only if a labeler key is configured and the presented key matches it."""
-    expected = settings.arena_labeler_key
-    if expected is None or provided is None:
-        return False
-    return hmac.compare_digest(
-        provided.encode("utf-8"), expected.get_secret_value().encode("utf-8")
-    )
+    return secret_matches(provided, settings.arena_labeler_key)
 
 
 def require_labeler(

--- a/runner/src/coval_bench/api/routers/llm_phonely.py
+++ b/runner/src/coval_bench/api/routers/llm_phonely.py
@@ -1,0 +1,172 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Authenticated OpenAI-compatible proxy for Phonely text-agent turns."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+import uuid
+from typing import Any
+
+import structlog
+from fastapi import APIRouter, BackgroundTasks, Depends, Header, HTTPException
+from psycopg_pool import AsyncConnectionPool
+from pydantic import BaseModel, Field
+from starlette.responses import JSONResponse
+
+from coval_bench.api.deps import (
+    bearer_token,
+    get_phonely_client,
+    get_pool,
+    get_settings,
+    secret_matches,
+)
+from coval_bench.config import Settings
+from coval_bench.db.llm_turns import insert_turn
+from coval_bench.llm.phonely import PhonelyClient, PhonelyError, TurnResult
+
+logger = structlog.get_logger("coval_bench.api.llm_phonely")
+
+router = APIRouter(prefix="/llm/phonely", tags=["llm-phonely"])
+
+_MESSAGE_KEYS = frozenset({"role", "content", "name", "tool_calls", "tool_call_id"})
+_TURN_TIMEOUT_S = 150.0
+
+
+# Only model (the Phonely callId) and messages reach Phonely; its agent owns tools and
+# sampling, so other OpenAI request fields are dropped.
+class ChatRequest(BaseModel):
+    model: str = Field(min_length=1)
+    messages: list[dict[str, Any]]
+    simulation_id: str | None = None
+    stream: bool | None = None
+
+
+def require_proxy_secret(
+    authorization: str | None = Header(default=None),
+    settings: Settings = Depends(get_settings),
+) -> None:
+    """Authenticate Coval with the proxy's shared bearer secret."""
+    if settings.llm_proxy_secret is None:
+        raise HTTPException(503, "LLM proxy is not configured")
+    if not secret_matches(bearer_token(authorization), settings.llm_proxy_secret):
+        raise HTTPException(
+            401,
+            "a valid proxy bearer token is required",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+
+def _messages(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [
+        {key: value for key, value in message.items() if key in _MESSAGE_KEYS}
+        for message in messages
+    ]
+
+
+async def _record_turn(
+    pool: AsyncConnectionPool[Any],
+    *,
+    simulation_id: str,
+    turn_index: int,
+    result: TurnResult,
+) -> None:
+    try:
+        await insert_turn(
+            pool,
+            simulation_id=simulation_id,
+            turn_index=turn_index,
+            provider="phonely",
+            model="phonely-agent",
+            ttft_ms=result.ttft_ms,
+            total_ms=result.total_ms,
+            output_tokens=result.output_tokens,
+        )
+    except Exception:
+        logger.error(
+            "llm_turn_not_recorded",
+            simulation_id=simulation_id,
+            turn_index=turn_index,
+            exc_info=True,
+        )
+    else:
+        logger.info("llm_turn_recorded", simulation_id=simulation_id, turn_index=turn_index)
+
+
+def _completion(call_id: str, result: TurnResult) -> dict[str, Any]:
+    message: dict[str, Any] = {"role": "assistant", "content": result.content}
+    if result.tool_calls:
+        message["tool_calls"] = list(result.tool_calls)
+    output_tokens = result.output_tokens or 0
+    return {
+        "id": f"chatcmpl-{uuid.uuid4().hex}",
+        "object": "chat.completion",
+        "created": int(time.time()),
+        "model": call_id,
+        "choices": [
+            {
+                "index": 0,
+                "message": message,
+                "finish_reason": result.finish_reason,
+            }
+        ],
+        "usage": {
+            "prompt_tokens": 0,
+            "completion_tokens": output_tokens,
+            "total_tokens": output_tokens,
+        },
+    }
+
+
+@router.post("/session", dependencies=[Depends(require_proxy_secret)])
+async def create_session(
+    client: PhonelyClient = Depends(get_phonely_client),
+) -> dict[str, str | None]:
+    try:
+        session = await client.create_session()
+    except PhonelyError as exc:
+        logger.warning("phonely_session_failed", error=str(exc))
+        raise HTTPException(502, "Phonely session creation failed") from exc
+    return {"sessionId": session.call_id, "expiresAt": session.expires_at}
+
+
+@router.post("/chat", dependencies=[Depends(require_proxy_secret)])
+async def chat(
+    body: ChatRequest,
+    background: BackgroundTasks,
+    client: PhonelyClient = Depends(get_phonely_client),
+    pool: AsyncConnectionPool[Any] = Depends(get_pool),
+) -> JSONResponse:
+    if body.stream:
+        raise HTTPException(400, "streaming responses are not supported")
+    messages = _messages(body.messages)
+    turn_index = sum(message.get("role") == "assistant" for message in messages)
+    try:
+        async with asyncio.timeout(_TURN_TIMEOUT_S):
+            result = await client.stream_turn(body.model, messages)
+    except TimeoutError as exc:
+        logger.warning("phonely_turn_timed_out", turn_index=turn_index)
+        raise HTTPException(504, "Phonely completion timed out") from exc
+    except PhonelyError as exc:
+        logger.warning("phonely_turn_failed", turn_index=turn_index, error=str(exc))
+        raise HTTPException(502, "Phonely completion failed") from exc
+
+    if body.simulation_id:
+        background.add_task(
+            _record_turn,
+            pool,
+            simulation_id=body.simulation_id,
+            turn_index=turn_index,
+            result=result,
+        )
+    else:
+        logger.warning("llm_turn_unattributed", turn_index=turn_index)
+    return JSONResponse(
+        _completion(body.model, result),
+        headers={
+            "X-Coval-Ttft-Ms": f"{result.ttft_ms:.3f}",
+            "X-Coval-Total-Ms": f"{result.total_ms:.3f}",
+        },
+    )

--- a/runner/src/coval_bench/api/routers/mocktools.py
+++ b/runner/src/coval_bench/api/routers/mocktools.py
@@ -19,7 +19,6 @@ mid-conversation would be graded as the agent breaking.
 from __future__ import annotations
 
 import asyncio
-import hmac
 import time
 from typing import Any
 
@@ -29,7 +28,7 @@ from psycopg_pool import AsyncConnectionPool
 from starlette.requests import Request
 from starlette.responses import JSONResponse
 
-from coval_bench.api.deps import get_pool, get_settings
+from coval_bench.api.deps import get_pool, get_settings, secret_matches
 from coval_bench.config import Settings
 from coval_bench.db.mock_tool_store import record_call
 from coval_bench.mocktools.codecs import Codec, codec_for
@@ -55,9 +54,7 @@ def require_mock_secret(
     expected = settings.mock_tools_secret
     if expected is None:
         raise HTTPException(503, "mock tools are not configured")
-    if x_mock_tools_key is None or not hmac.compare_digest(
-        x_mock_tools_key.encode("utf-8"), expected.get_secret_value().encode("utf-8")
-    ):
+    if not secret_matches(x_mock_tools_key, expected):
         raise HTTPException(401, f"a valid {SECRET_HEADER} is required")
 
 

--- a/runner/src/coval_bench/config.py
+++ b/runner/src/coval_bench/config.py
@@ -32,6 +32,7 @@ class Settings(BaseSettings):
     model_config = SettingsConfigDict(
         env_file=".env",
         env_file_encoding="utf-8",
+        env_ignore_empty=True,
         extra="ignore",
         case_sensitive=False,
     )
@@ -168,6 +169,14 @@ class Settings(BaseSettings):
     # built from a git checkout and `_private/` is never in one. Empty means
     # local-only, which is every developer machine.
     mock_fixtures_bucket: str = ""
+    # --- Phonely LLM proxy ---
+    # The client is only built when both the key and the agent id are set; the
+    # /llm/phonely routes answer 503 otherwise. Empty values count as unset.
+    phonely_api_key: SecretStr | None = None
+    phonely_base_url: str = "https://db.phonely.ai"
+    phonely_agent_id: str | None = None
+    # Bearer secret Coval presents to the proxy; unset fails closed with 503.
+    llm_proxy_secret: SecretStr | None = None
     coval_api_base: str = "https://api.coval.dev/v1"
     # The S2S latency metric id + per-provider Coval agent ids (opaque, not secret).
     coval_s2s_latency_metric_id: str | None = None

--- a/runner/src/coval_bench/db/llm_turns.py
+++ b/runner/src/coval_bench/db/llm_turns.py
@@ -1,0 +1,62 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Persistence for per-turn LLM timing measured by the proxy."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+
+import psycopg.rows
+from psycopg_pool import AsyncConnectionPool
+
+
+async def insert_turn(
+    pool: AsyncConnectionPool[Any],
+    *,
+    simulation_id: str,
+    turn_index: int,
+    provider: str,
+    model: str,
+    ttft_ms: float,
+    total_ms: float,
+    output_tokens: int | None = None,
+) -> None:
+    """Append one completed assistant turn; database failures propagate."""
+    async with pool.connection() as conn:
+        await conn.execute(
+            """
+            INSERT INTO benchmarks_v2.llm_turns
+                (simulation_id, turn_index, provider, model, ttft_ms, total_ms, output_tokens)
+            VALUES (%s, %s, %s, %s, %s, %s, %s)
+            """,
+            (simulation_id, turn_index, provider, model, ttft_ms, total_ms, output_tokens),
+        )
+
+
+async def fetch_conversation_ttft(
+    pool: AsyncConnectionPool[Any], simulation_ids: Sequence[str]
+) -> dict[str, float]:
+    """Return mean TTFT in seconds per conversation, counting a retried turn once."""
+    if not simulation_ids:
+        return {}
+    async with (
+        pool.connection() as conn,
+        conn.cursor(row_factory=psycopg.rows.dict_row) as cursor,
+    ):
+        await cursor.execute(
+            """
+            SELECT simulation_id, AVG(ttft_ms) / 1000.0 AS ttft_seconds
+            FROM (
+                SELECT DISTINCT ON (simulation_id, turn_index) simulation_id, ttft_ms
+                FROM benchmarks_v2.llm_turns
+                WHERE simulation_id = ANY(%s)
+                ORDER BY simulation_id, turn_index, created_at DESC, id DESC
+            ) latest
+            GROUP BY simulation_id
+            """,
+            (list(simulation_ids),),
+        )
+        rows = await cursor.fetchall()
+    return {row["simulation_id"]: row["ttft_seconds"] for row in rows}

--- a/runner/src/coval_bench/db/migrations/versions/20260902_0026_add_llm_turns.py
+++ b/runner/src/coval_bench/db/migrations/versions/20260902_0026_add_llm_turns.py
@@ -1,0 +1,41 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+# ruff: noqa: E501
+
+"""Add per-turn timing captured by the Phonely LLM proxy."""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "20260902_0026"
+down_revision = "20260901_0025"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        CREATE TABLE benchmarks_v2.llm_turns (
+            id            BIGSERIAL PRIMARY KEY,
+            simulation_id TEXT NOT NULL CHECK (simulation_id <> ''),
+            turn_index    INTEGER NOT NULL CHECK (turn_index >= 0),
+            provider      TEXT NOT NULL CHECK (provider <> ''),
+            model         TEXT NOT NULL CHECK (model <> ''),
+            ttft_ms       DOUBLE PRECISION NOT NULL CHECK (
+                ttft_ms >= 0 AND ttft_ms NOT IN (
+                    'NaN'::float8, 'Infinity'::float8, '-Infinity'::float8
+                )
+            ),
+            total_ms      DOUBLE PRECISION NOT NULL CHECK (total_ms >= ttft_ms),
+            output_tokens INTEGER CHECK (output_tokens IS NULL OR output_tokens >= 0),
+            created_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+        )
+        """
+    )
+    op.execute("CREATE INDEX llm_turns_simulation_id ON benchmarks_v2.llm_turns (simulation_id)")
+
+
+def downgrade() -> None:
+    op.execute("DROP TABLE IF EXISTS benchmarks_v2.llm_turns")

--- a/runner/src/coval_bench/llm/__init__.py
+++ b/runner/src/coval_bench/llm/__init__.py
@@ -1,0 +1,4 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""LLM benchmark integrations."""

--- a/runner/src/coval_bench/llm/phonely.py
+++ b/runner/src/coval_bench/llm/phonely.py
@@ -1,0 +1,241 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Phonely Programmatic Calls client and streamed-turn accumulator."""
+
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+
+_SESSION_TIMEOUT = httpx.Timeout(30.0)
+# Turns are seconds apart; a 5s keepalive would put a TLS handshake inside most TTFTs.
+_LIMITS = httpx.Limits(max_connections=20, max_keepalive_connections=8, keepalive_expiry=300.0)
+
+
+class PhonelyError(Exception):
+    """Base class for failures returned by the Phonely API."""
+
+
+class PhonelyAuthError(PhonelyError):
+    """The configured API key was rejected."""
+
+
+class PhonelySessionExpired(PhonelyError):
+    """The call session is missing or expired."""
+
+
+class PhonelyUpstreamError(PhonelyError):
+    """Phonely failed to produce a usable completion."""
+
+
+@dataclass(frozen=True)
+class PhonelySession:
+    call_id: str
+    expires_at: str | None
+
+
+@dataclass(frozen=True)
+class TurnResult:
+    content: str
+    tool_calls: tuple[dict[str, Any], ...]
+    finish_reason: str
+    ttft_ms: float
+    total_ms: float
+    output_tokens: int | None
+
+
+class TurnAccumulator:
+    """Reassemble OpenAI SSE chunks while measuring the first meaningful delta."""
+
+    def __init__(self, started_at: float) -> None:
+        self._started_at = started_at
+        self._first_token_at: float | None = None
+        self._content: list[str] = []
+        self._tool_calls: dict[int, dict[str, Any]] = {}
+        self._finish_reason: str | None = None
+        self._complete = False
+        self._output_tokens: int | None = None
+
+    def _stamp_first_token(self, now: float) -> None:
+        if self._first_token_at is None:
+            self._first_token_at = now
+
+    def feed(self, line: str, now: float) -> None:
+        """Consume one SSE line; irrelevant or malformed lines are ignored."""
+        line = line.strip()
+        if not line.startswith("data:"):
+            return
+        payload = line.removeprefix("data:").strip()
+        if not payload:
+            return
+        if payload == "[DONE]":
+            self._complete = True
+            return
+        try:
+            event = json.loads(payload)
+        except json.JSONDecodeError:
+            return
+        if not isinstance(event, dict):
+            return
+        error = event.get("error")
+        if error is not None:
+            message = error.get("message", error) if isinstance(error, dict) else error
+            raise PhonelyUpstreamError(f"Phonely stream error: {message}")
+
+        usage = event.get("usage")
+        if isinstance(usage, dict):
+            output_tokens = usage.get("completion_tokens")
+            if isinstance(output_tokens, int) and not isinstance(output_tokens, bool):
+                self._output_tokens = output_tokens
+
+        choices = event.get("choices")
+        if not isinstance(choices, list) or not choices or not isinstance(choices[0], dict):
+            return
+        choice = choices[0]
+        delta = choice.get("delta")
+        if isinstance(delta, dict):
+            content = delta.get("content")
+            if isinstance(content, str) and content:
+                self._stamp_first_token(now)
+                self._content.append(content)
+            raw_tool_calls = delta.get("tool_calls")
+            if isinstance(raw_tool_calls, list) and raw_tool_calls:
+                self._stamp_first_token(now)
+                self._feed_tool_calls(raw_tool_calls)
+        finish_reason = choice.get("finish_reason")
+        if isinstance(finish_reason, str) and finish_reason:
+            self._finish_reason = finish_reason
+            self._complete = True
+
+    def _feed_tool_calls(self, chunks: list[Any]) -> None:
+        for chunk in chunks:
+            if not isinstance(chunk, dict):
+                continue
+            index = chunk.get("index", 0)
+            if not isinstance(index, int) or isinstance(index, bool):
+                index = 0
+            slot = self._tool_calls.setdefault(
+                index, {"id": "", "type": "function", "name": "", "arguments": ""}
+            )
+            call_id = chunk.get("id")
+            if isinstance(call_id, str) and call_id:
+                slot["id"] = call_id
+            call_type = chunk.get("type")
+            if isinstance(call_type, str) and call_type:
+                slot["type"] = call_type
+            function = chunk.get("function")
+            if not isinstance(function, dict):
+                continue
+            name = function.get("name")
+            if isinstance(name, str):
+                slot["name"] += name
+            arguments = function.get("arguments")
+            if isinstance(arguments, str):
+                slot["arguments"] += arguments
+
+    def result(self, now: float) -> TurnResult:
+        """Return the completed turn, rejecting an empty or truncated stream."""
+        if self._first_token_at is None:
+            raise PhonelyUpstreamError("Phonely returned an empty completion")
+        if not self._complete:
+            raise PhonelyUpstreamError("Phonely stream ended before the completion finished")
+        tool_calls = tuple(
+            {
+                "id": slot["id"],
+                "type": slot["type"],
+                "function": {"name": slot["name"], "arguments": slot["arguments"]},
+            }
+            for _, slot in sorted(self._tool_calls.items())
+        )
+        finish_reason = self._finish_reason or "stop"
+        if tool_calls and finish_reason == "stop":
+            finish_reason = "tool_calls"
+        return TurnResult(
+            content="".join(self._content),
+            tool_calls=tool_calls,
+            finish_reason=finish_reason,
+            ttft_ms=(self._first_token_at - self._started_at) * 1000,
+            total_ms=(now - self._started_at) * 1000,
+            output_tokens=self._output_tokens,
+        )
+
+
+class PhonelyClient:
+    """Async client for Phonely's session and streaming chat endpoints."""
+
+    def __init__(
+        self,
+        api_key: str,
+        agent_id: str,
+        base_url: str = "https://db.phonely.ai",
+        transport: httpx.AsyncBaseTransport | None = None,
+    ) -> None:
+        self._api_key = api_key
+        self._agent_id = agent_id
+        self._client = httpx.AsyncClient(
+            base_url=base_url.rstrip("/"),
+            timeout=httpx.Timeout(30.0, read=None),
+            transport=transport or httpx.AsyncHTTPTransport(http2=True, limits=_LIMITS),
+        )
+
+    def __repr__(self) -> str:
+        return f"PhonelyClient(agent_id={self._agent_id!r})"
+
+    async def aclose(self) -> None:
+        await self._client.aclose()
+
+    async def create_session(self) -> PhonelySession:
+        try:
+            response = await self._client.post(
+                "/api/calls/session",
+                headers={"X-Authorization": self._api_key},
+                json={"agentId": self._agent_id},
+                timeout=_SESSION_TIMEOUT,
+            )
+        except httpx.RequestError as exc:
+            raise PhonelyUpstreamError("Phonely session endpoint is unreachable") from exc
+        self._raise_for_status(response)
+        try:
+            payload = response.json()
+        except ValueError as exc:
+            raise PhonelyUpstreamError("Phonely returned an invalid session response") from exc
+        call_id = payload.get("callId") if isinstance(payload, dict) else None
+        if not isinstance(call_id, str) or not call_id:
+            raise PhonelyUpstreamError("Phonely session response has no callId")
+        expires_at = payload.get("expiresAt")
+        return PhonelySession(
+            call_id=call_id,
+            expires_at=expires_at if isinstance(expires_at, str) else None,
+        )
+
+    async def stream_turn(self, call_id: str, messages: list[dict[str, Any]]) -> TurnResult:
+        started_at = time.perf_counter()
+        accumulator = TurnAccumulator(started_at)
+        try:
+            async with self._client.stream(
+                "POST",
+                "/api/v1/chat/completions",
+                headers={"Authorization": f"Bearer {self._api_key}"},
+                json={"model": call_id, "messages": messages, "stream": True},
+            ) as response:
+                self._raise_for_status(response)
+                async for line in response.aiter_lines():
+                    accumulator.feed(line, time.perf_counter())
+        except httpx.RequestError as exc:
+            raise PhonelyUpstreamError("Phonely chat endpoint is unreachable") from exc
+        return accumulator.result(time.perf_counter())
+
+    @staticmethod
+    def _raise_for_status(response: httpx.Response) -> None:
+        if response.status_code < 400:
+            return
+        if response.status_code in {401, 403}:
+            raise PhonelyAuthError(f"Phonely rejected the request ({response.status_code})")
+        if response.status_code == 404:
+            raise PhonelySessionExpired("Phonely session is missing or expired")
+        raise PhonelyUpstreamError(f"Phonely request failed ({response.status_code})")

--- a/runner/tests/api/conftest.py
+++ b/runner/tests/api/conftest.py
@@ -58,6 +58,7 @@ from coval_bench.registries.provider_keys import PROVIDER_ENV
 
 ARENA_LABELER_KEY = "test-labeler-key"
 MOCK_TOOLS_KEY = "test-mock-tools-key"  # noqa: S105 — a fixture value, not a credential
+LLM_PROXY_KEY = "test-llm-proxy-key"  # noqa: S105 — a fixture value, not a credential
 
 # The one early-access proof is a Clerk session token, so the app fixture wires a
 # whole stub instance: an issuer, an authorized party, a signing key the stubbed
@@ -173,6 +174,22 @@ def _load_schema(**connect_kwargs: Any) -> None:
                 latency_ms     double precision NOT NULL
                                CHECK (latency_ms >= 0 AND latency_ms NOT IN (
                                    'NaN'::float8, 'Infinity'::float8, '-Infinity'::float8)),
+                created_at     timestamptz NOT NULL DEFAULT now()
+            )
+        """)
+        # Per-turn LLM proxy timing (mirrors migration 20260902_0026).
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS benchmarks_v2.llm_turns (
+                id             bigserial PRIMARY KEY,
+                simulation_id  text NOT NULL CHECK (simulation_id <> ''),
+                turn_index     integer NOT NULL CHECK (turn_index >= 0),
+                provider       text NOT NULL CHECK (provider <> ''),
+                model          text NOT NULL CHECK (model <> ''),
+                ttft_ms        double precision NOT NULL CHECK (
+                    ttft_ms >= 0 AND ttft_ms NOT IN (
+                        'NaN'::float8, 'Infinity'::float8, '-Infinity'::float8)),
+                total_ms       double precision NOT NULL CHECK (total_ms >= ttft_ms),
+                output_tokens  integer CHECK (output_tokens IS NULL OR output_tokens >= 0),
                 created_at     timestamptz NOT NULL DEFAULT now()
             )
         """)
@@ -416,6 +433,10 @@ async def app(
     monkeypatch.setenv("POSTHOG_DISABLED", "true")
     monkeypatch.setenv("ARENA_LABELER_KEY", ARENA_LABELER_KEY)
     monkeypatch.setenv("MOCK_TOOLS_SECRET", MOCK_TOOLS_KEY)
+    monkeypatch.setenv("LLM_PROXY_SECRET", LLM_PROXY_KEY)
+    monkeypatch.setenv("PHONELY_API_KEY", "test-phonely-key")
+    monkeypatch.setenv("PHONELY_AGENT_ID", "test-phonely-agent")
+    monkeypatch.setenv("PHONELY_BASE_URL", "http://phonely.invalid")
     monkeypatch.setenv("CLERK_ISSUER", CLERK_ISSUER)
     monkeypatch.setenv("CLERK_AUTHORIZED_PARTIES", json.dumps([CLERK_PARTY]))
     monkeypatch.setenv("CLERK_ORG_PROVIDERS", json.dumps(CLERK_ORG_PROVIDERS))

--- a/runner/tests/api/test_llm_phonely.py
+++ b/runner/tests/api/test_llm_phonely.py
@@ -1,0 +1,285 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""The authenticated Phonely LLM proxy."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import AsyncIterator, Callable
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import psycopg
+import psycopg.rows
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import AsyncClient
+from pydantic import SecretStr
+
+from coval_bench.llm.phonely import PhonelyClient
+from tests.api.conftest import LLM_PROXY_KEY, _make_db_url
+
+AUTH = {"Authorization": f"Bearer {LLM_PROXY_KEY}"}
+Handler = Callable[[httpx.Request], httpx.Response]
+
+
+def _sse(*deltas: dict[str, Any]) -> bytes:
+    lines = [
+        "data: "
+        + json.dumps(
+            {
+                "id": "chatcmpl-test",
+                "created": 123,
+                "choices": [{"index": 0, "delta": delta, "finish_reason": None}],
+            }
+        )
+        for delta in deltas
+    ]
+    lines.extend(
+        [
+            'data: {"choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}',
+            "data: [DONE]",
+        ]
+    )
+    return "\n\n".join(lines).encode()
+
+
+@pytest_asyncio.fixture
+async def bind_phonely(app: FastAPI) -> AsyncIterator[Callable[[Handler], None]]:
+    handlers: list[Handler] = []
+    client = PhonelyClient(
+        "upstream-key",
+        "agent-1",
+        "https://phonely.test",
+        transport=httpx.MockTransport(lambda request: handlers[-1](request)),
+    )
+    app.state.phonely_client = client
+    yield handlers.append
+    await client.aclose()
+
+
+async def _turn_rows(postgresql: Any) -> list[dict[str, Any]]:
+    connection = await psycopg.AsyncConnection.connect(
+        _make_db_url(postgresql), autocommit=True, row_factory=psycopg.rows.dict_row
+    )
+    try:
+        cursor = await connection.execute(
+            "SELECT * FROM benchmarks_v2.llm_turns ORDER BY created_at, id"
+        )
+        return list(await cursor.fetchall())
+    finally:
+        await connection.close()
+
+
+async def test_proxy_auth_configuration_and_route_location(
+    client: AsyncClient, app: FastAPI
+) -> None:
+    configured_client = app.state.phonely_client
+    assert isinstance(configured_client, PhonelyClient)
+    assert (await client.post("/llm/phonely/session", json={})).status_code == 401
+    assert (
+        await client.post(
+            "/llm/phonely/session", json={}, headers={"Authorization": "Bearer wrong"}
+        )
+    ).status_code == 401
+    assert (await client.post("/v1/llm/phonely/session", json={}, headers=AUTH)).status_code == 404
+
+    app.state.phonely_client = None
+    assert (await client.post("/llm/phonely/session", json={}, headers=AUTH)).status_code == 503
+    lowercase = {"Authorization": f"bearer {LLM_PROXY_KEY}"}
+    lowercase_response = await client.post("/llm/phonely/session", json={}, headers=lowercase)
+    assert lowercase_response.status_code == 503
+    app.state.phonely_client = configured_client
+    settings = app.state.settings
+    app.state.settings = settings.model_copy(update={"llm_proxy_secret": SecretStr("")})
+    empty = {"Authorization": "Bearer "}
+    assert (await client.post("/llm/phonely/session", json={}, headers=empty)).status_code == 401
+    app.state.settings = settings.model_copy(update={"llm_proxy_secret": None})
+    assert (await client.post("/llm/phonely/session", json={}, headers=AUTH)).status_code == 503
+
+
+async def test_session_translates_the_phonely_shape(
+    client: AsyncClient,
+    bind_phonely: Callable[[Handler], None],
+) -> None:
+    captured: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return httpx.Response(200, json={"callId": "call-1", "expiresAt": "later"})
+
+    bind_phonely(handler)
+    response = await client.post("/llm/phonely/session", json={"ignored": True}, headers=AUTH)
+
+    assert response.status_code == 200
+    assert response.json() == {"sessionId": "call-1", "expiresAt": "later"}
+    assert captured[0].url.path == "/api/calls/session"
+
+
+async def test_chat_buffers_the_stream_strips_metadata_and_records_timing(
+    client: AsyncClient,
+    postgresql: Any,
+    bind_phonely: Callable[[Handler], None],
+) -> None:
+    captured: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return httpx.Response(200, content=_sse({"role": "assistant"}, {"content": "x" * 4096}))
+
+    bind_phonely(handler)
+    response = await client.post(
+        "/llm/phonely/chat",
+        headers={**AUTH, "Accept-Encoding": "gzip"},
+        json={
+            "model": "call-1",
+            "simulation_id": "sim-1",
+            "messages": [
+                {"role": "user", "content": "Hi", "timestamp": 1},
+                {"role": "assistant", "content": "Earlier"},
+                {"role": "user", "content": "Again"},
+            ],
+        },
+    )
+
+    assert response.status_code == 200
+    message = response.json()["choices"][0]["message"]
+    assert message == {"role": "assistant", "content": "x" * 4096}
+    assert "content-encoding" not in response.headers
+    assert float(response.headers["X-Coval-Ttft-Ms"]) >= 0
+    upstream = json.loads(captured[0].content)
+    assert upstream["stream"] is True
+    assert "timestamp" not in upstream["messages"][0]
+    rows = await _turn_rows(postgresql)
+    assert len(rows) == 1
+    assert (rows[0]["simulation_id"], rows[0]["turn_index"]) == ("sim-1", 1)
+    assert rows[0]["total_ms"] >= rows[0]["ttft_ms"] >= 0
+
+
+async def test_tool_only_turn_has_string_content_and_openai_tool_calls(
+    client: AsyncClient,
+    bind_phonely: Callable[[Handler], None],
+) -> None:
+    tool_delta = {
+        "tool_calls": [
+            {
+                "index": 0,
+                "id": "call-end",
+                "type": "function",
+                "function": {"name": "endCall", "arguments": "{}"},
+            }
+        ]
+    }
+    bind_phonely(lambda _request: httpx.Response(200, content=_sse(tool_delta)))
+    response = await client.post(
+        "/llm/phonely/chat",
+        headers=AUTH,
+        json={"model": "call-1", "messages": [{"role": "user", "content": "Bye"}]},
+    )
+
+    choice = response.json()["choices"][0]
+    assert choice["message"]["content"] == ""
+    assert choice["message"]["tool_calls"][0]["function"]["name"] == "endCall"
+    assert choice["finish_reason"] == "tool_calls"
+
+
+@pytest.mark.parametrize(
+    ("response", "expected"),
+    [
+        (httpx.Response(401), 502),
+        (httpx.Response(404), 502),
+        (httpx.Response(500), 502),
+        (httpx.Response(200, content=b'data: {"error":{"message":"failed"}}'), 502),
+        (httpx.Response(200, content=b"data: [DONE]"), 502),
+        (httpx.Response(200, content=b'data: {"choices":[{"delta":{"content":"partial"}}]}'), 502),
+    ],
+)
+async def test_upstream_failures_are_proxy_failures(
+    client: AsyncClient,
+    bind_phonely: Callable[[Handler], None],
+    response: httpx.Response,
+    expected: int,
+) -> None:
+    bind_phonely(lambda _request: response)
+    result = await client.post(
+        "/llm/phonely/chat", headers=AUTH, json={"model": "call-1", "messages": []}
+    )
+    assert result.status_code == expected
+
+
+async def test_streaming_requests_are_rejected(client: AsyncClient) -> None:
+    response = await client.post(
+        "/llm/phonely/chat",
+        headers=AUTH,
+        json={"model": "call-1", "messages": [], "stream": True},
+    )
+    assert response.status_code == 400
+
+
+async def test_session_failures_are_proxy_failures(
+    client: AsyncClient, bind_phonely: Callable[[Handler], None]
+) -> None:
+    bind_phonely(lambda _request: httpx.Response(500))
+    response = await client.post("/llm/phonely/session", json={}, headers=AUTH)
+    assert response.status_code == 502
+
+
+class _StalledStream(httpx.AsyncByteStream):
+    async def __aiter__(self) -> AsyncIterator[bytes]:
+        yield b'data: {"choices":[{"delta":{"content":"x"}}]}\n\n'
+        await asyncio.sleep(3600)
+
+
+async def test_a_stalled_turn_returns_504(
+    client: AsyncClient,
+    bind_phonely: Callable[[Handler], None],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("coval_bench.api.routers.llm_phonely._TURN_TIMEOUT_S", 0.2)
+    bind_phonely(lambda _request: httpx.Response(200, stream=_StalledStream()))
+    response = await client.post(
+        "/llm/phonely/chat", headers=AUTH, json={"model": "call-1", "messages": []}
+    )
+    assert response.status_code == 504
+
+
+async def test_failed_timing_insert_does_not_fail_the_turn(
+    client: AsyncClient,
+    bind_phonely: Callable[[Handler], None],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bind_phonely(lambda _request: httpx.Response(200, content=_sse({"content": "Hi"})))
+    monkeypatch.setattr(
+        "coval_bench.api.routers.llm_phonely.insert_turn",
+        AsyncMock(side_effect=RuntimeError("database unavailable")),
+    )
+    logger = MagicMock()
+    monkeypatch.setattr("coval_bench.api.routers.llm_phonely.logger", logger)
+
+    response = await client.post(
+        "/llm/phonely/chat",
+        headers=AUTH,
+        json={"model": "call-1", "messages": [], "simulation_id": "sim-1"},
+    )
+
+    assert response.status_code == 200
+    logger.error.assert_called_once()
+    assert logger.error.call_args.args[0] == "llm_turn_not_recorded"
+
+
+async def test_proxy_is_not_rate_limited(
+    client: AsyncClient,
+    bind_phonely: Callable[[Handler], None],
+) -> None:
+    bind_phonely(lambda _request: httpx.Response(200, content=_sse({"content": "Hi"})))
+    responses = await asyncio.gather(
+        *(
+            client.post("/llm/phonely/chat", headers=AUTH, json={"model": "call-1", "messages": []})
+            for _ in range(5)
+        )
+    )
+    assert {response.status_code for response in responses} == {200}

--- a/runner/tests/unit/test_db_writer.py
+++ b/runner/tests/unit/test_db_writer.py
@@ -150,6 +150,7 @@ def test_migration_up_down(pg_conn: psycopg.Connection[Any]) -> None:
     assert "runs" in tables
     assert "results" in tables
     assert "results_by_bucket" in tables
+    assert "llm_turns" in tables
 
     with pg_conn.cursor() as cur:
         cur.execute("SELECT matviewname FROM pg_matviews WHERE schemaname = 'benchmarks_v2'")

--- a/runner/tests/unit/test_llm_turns.py
+++ b/runner/tests/unit/test_llm_turns.py
@@ -1,0 +1,66 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Per-turn LLM timing persistence tests."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import psycopg
+import psycopg.errors
+import pytest
+from pytest_postgresql.factories import postgresql
+
+from coval_bench.db.llm_turns import fetch_conversation_ttft, insert_turn
+
+from .conftest import apply_migrations, open_pool
+
+llm_pg = postgresql("pg_proc")
+
+
+def test_turn_timings_average_the_latest_row_per_turn(
+    llm_pg: psycopg.Connection[Any],
+) -> None:
+    apply_migrations(llm_pg)
+
+    async def scenario() -> None:
+        pool = await open_pool(llm_pg)
+        try:
+            assert await fetch_conversation_ttft(pool, []) == {}
+            for simulation_id, turn_index, ttft_ms in (
+                ("sim-1", 0, 100.0),
+                ("sim-1", 1, 900.0),
+                ("sim-1", 1, 300.0),
+                ("sim-2", 0, 500.0),
+            ):
+                await insert_turn(
+                    pool,
+                    simulation_id=simulation_id,
+                    turn_index=turn_index,
+                    provider="phonely",
+                    model="phonely-agent",
+                    ttft_ms=ttft_ms,
+                    total_ms=ttft_ms + 50,
+                )
+            assert await fetch_conversation_ttft(pool, ["sim-1", "sim-2", "missing"]) == {
+                "sim-1": pytest.approx(0.2),
+                "sim-2": pytest.approx(0.5),
+            }
+        finally:
+            await pool.close()
+
+    asyncio.run(scenario())
+
+
+def test_turn_timing_constraints_reject_invalid_rows(llm_pg: psycopg.Connection[Any]) -> None:
+    apply_migrations(llm_pg)
+    with pytest.raises(psycopg.errors.CheckViolation), llm_pg.transaction():
+        llm_pg.execute(
+            """
+            INSERT INTO benchmarks_v2.llm_turns
+                (simulation_id, turn_index, provider, model, ttft_ms, total_ms)
+            VALUES ('sim-1', 0, 'phonely', 'phonely-agent', 200, 100)
+            """
+        )

--- a/runner/tests/unit/test_phonely_client.py
+++ b/runner/tests/unit/test_phonely_client.py
@@ -1,0 +1,177 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Phonely streaming client and accumulator tests."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import httpx
+import pytest
+
+from coval_bench.llm.phonely import (
+    PhonelyAuthError,
+    PhonelyClient,
+    PhonelySessionExpired,
+    PhonelyUpstreamError,
+    TurnAccumulator,
+)
+
+
+def _chunk(delta: dict[str, Any], finish_reason: str | None = None) -> str:
+    return "data: " + json.dumps(
+        {
+            "id": "chatcmpl-1",
+            "created": 123,
+            "choices": [{"delta": delta, "finish_reason": finish_reason}],
+        }
+    )
+
+
+def test_accumulator_stamps_the_first_meaningful_content_chunk() -> None:
+    turn = TurnAccumulator(10.0)
+    turn.feed(_chunk({"role": "assistant"}), 10.1)
+    turn.feed(_chunk({"content": "Hello"}), 10.25)
+    turn.feed(_chunk({"content": " there"}, "stop"), 10.4)
+    result = turn.result(10.5)
+
+    assert result.content == "Hello there"
+    assert result.tool_calls == ()
+    assert result.finish_reason == "stop"
+    assert result.ttft_ms == pytest.approx(250.0)
+    assert result.total_ms == pytest.approx(500.0)
+
+
+def test_accumulator_reassembles_tool_calls_by_index() -> None:
+    turn = TurnAccumulator(5.0)
+    turn.feed(
+        _chunk(
+            {
+                "tool_calls": [
+                    {
+                        "index": 0,
+                        "id": "call-1",
+                        "type": "function",
+                        "function": {"name": "end", "arguments": '{"reason":'},
+                    }
+                ]
+            }
+        ),
+        5.2,
+    )
+    turn.feed(
+        _chunk(
+            {"tool_calls": [{"index": 0, "function": {"name": "Call", "arguments": '"done"}'}}]},
+            "tool_calls",
+        ),
+        5.3,
+    )
+    result = turn.result(5.4)
+
+    assert result.content == ""
+    assert result.finish_reason == "tool_calls"
+    assert result.ttft_ms == pytest.approx(200.0)
+    assert result.tool_calls == (
+        {
+            "id": "call-1",
+            "type": "function",
+            "function": {"name": "endCall", "arguments": '{"reason":"done"}'},
+        },
+    )
+
+
+def test_accumulator_rejects_stream_errors_and_empty_completions() -> None:
+    with pytest.raises(PhonelyUpstreamError, match="generation failed"):
+        TurnAccumulator(0).feed('data: {"error":{"message":"generation failed"}}', 0.1)
+    with pytest.raises(PhonelyUpstreamError, match="empty completion"):
+        TurnAccumulator(0).result(1)
+
+
+def test_accumulator_rejects_a_stream_that_ends_before_completion() -> None:
+    turn = TurnAccumulator(0)
+    turn.feed('data: {"error":null,"choices":[{"delta":{"content":"partial"}}]}', 0.1)
+    with pytest.raises(PhonelyUpstreamError, match="before the completion finished"):
+        turn.result(0.2)
+    turn.feed("data: [DONE]", 0.3)
+    assert turn.result(0.4).content == "partial"
+
+
+def test_accumulator_keeps_a_length_finish_reason_on_truncated_tool_calls() -> None:
+    turn = TurnAccumulator(0)
+    call = {"index": 0, "id": "c", "function": {"name": "book", "arguments": '{"date": "2026-'}}
+    turn.feed(_chunk({"tool_calls": [call]}, "length"), 0.1)
+    assert turn.result(0.2).finish_reason == "length"
+
+
+@pytest.mark.asyncio
+async def test_client_uses_the_programmatic_calls_contract() -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        if request.url.path == "/api/calls/session":
+            return httpx.Response(200, json={"callId": "call-1", "expiresAt": "later"})
+        stream = "\n".join(
+            (_chunk({"role": "assistant"}), _chunk({"content": "Hi"}, "stop"), "data: [DONE]")
+        )
+        return httpx.Response(200, content=stream)
+
+    client = PhonelyClient(
+        "secret-key",
+        "agent-1",
+        "https://phonely.test",
+        transport=httpx.MockTransport(handler),
+    )
+    try:
+        session = await client.create_session()
+        result = await client.stream_turn(session.call_id, [{"role": "user", "content": "Hi"}])
+    finally:
+        await client.aclose()
+
+    assert session.call_id == "call-1"
+    assert session.expires_at == "later"
+    assert result.content == "Hi"
+    assert requests[0].headers["X-Authorization"] == "secret-key"
+    assert json.loads(requests[0].content) == {"agentId": "agent-1"}
+    assert requests[1].headers["Authorization"] == "Bearer secret-key"
+    assert requests[1].url.path == "/api/v1/chat/completions"
+    assert json.loads(requests[1].content)["stream"] is True
+    assert "secret-key" not in repr(client)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("status", "error"),
+    [
+        (401, PhonelyAuthError),
+        (403, PhonelyAuthError),
+        (404, PhonelySessionExpired),
+        (500, PhonelyUpstreamError),
+    ],
+)
+async def test_client_classifies_http_errors(status: int, error: type[Exception]) -> None:
+    client = PhonelyClient(
+        "key",
+        "agent",
+        transport=httpx.MockTransport(lambda _request: httpx.Response(status)),
+    )
+    try:
+        with pytest.raises(error):
+            await client.stream_turn("call", [])
+    finally:
+        await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_client_maps_network_failures_to_upstream_errors() -> None:
+    def unreachable(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("unreachable", request=request)
+
+    client = PhonelyClient("key", "agent", transport=httpx.MockTransport(unreachable))
+    try:
+        with pytest.raises(PhonelyUpstreamError, match="unreachable"):
+            await client.create_session()
+    finally:
+        await client.aclose()


### PR DESCRIPTION
Authenticated OpenAI-compatible proxy in front of Phonely's Programmatic Calls API. Buffers the upstream SSE stream, measures TTFT and total time per turn, and records the timing to a new benchmarks_v2.llm_turns table. Shared bearer-secret helpers replace the per-router copies.