### PR TITLE
[BENCH-787] Ingest Phonely into the LLM benchmark with a TTFT join

### DIFF
--- a/runner/src/coval_bench/__main__.py
+++ b/runner/src/coval_bench/__main__.py
@@ -27,7 +27,7 @@ from coval_bench.migrations.backfill_normalized_storage import backfill_normaliz
 from coval_bench.migrations.backfill_wer_breakdown import backfill_wer_breakdown_cli
 from coval_bench.migrations.import_legacy import import_legacy_cli
 from coval_bench.platform_assets import platform_assets
-from coval_bench.s2s.fetch_v2v import fetch_s2s
+from coval_bench.s2s.fetch_v2v import fetch_llm, fetch_s2s
 from coval_bench.variants.pull import pull_contract
 
 # Backstop so a stalled connection can't hang a smoke probe forever. Loose enough
@@ -113,8 +113,10 @@ migrate.add_command(backfill_normalized_storage_cli, name="backfill-normalized-s
 migrate.add_command(backfill_normalized_s2s_storage_cli, name="backfill-normalized-s2s-storage")
 migrate.add_command(import_legacy_cli, name="import-legacy")
 
-# S2S is fetch-only, so a standalone command rather than a `run --kind` value.
+# The Coval-fetched benchmarks are fetch-only, so each is a standalone command
+# backing its own Cloud Run job rather than a `run --kind` value.
 cli.add_command(fetch_s2s, name="fetch-s2s")
+cli.add_command(fetch_llm, name="fetch-llm")
 cli.add_command(pull_contract, name="pull-contract")
 cli.add_command(platform_assets, name="platform-assets")
 

--- a/runner/src/coval_bench/api/routers/llm_phonely.py
+++ b/runner/src/coval_bench/api/routers/llm_phonely.py
@@ -25,7 +25,7 @@ from coval_bench.api.deps import (
 )
 from coval_bench.config import Settings
 from coval_bench.db.llm_turns import insert_turn
-from coval_bench.llm.phonely import PhonelyClient, PhonelyError, TurnResult
+from coval_bench.llm.phonely import MODEL, PROVIDER, PhonelyClient, PhonelyError, TurnResult
 
 logger = structlog.get_logger("coval_bench.api.llm_phonely")
 
@@ -78,8 +78,8 @@ async def _record_turn(
             pool,
             simulation_id=simulation_id,
             turn_index=turn_index,
-            provider="phonely",
-            model="phonely-agent",
+            provider=PROVIDER,
+            model=MODEL,
             ttft_ms=result.ttft_ms,
             total_ms=result.total_ms,
             output_tokens=result.output_tokens,

--- a/runner/src/coval_bench/config.py
+++ b/runner/src/coval_bench/config.py
@@ -186,6 +186,8 @@ class Settings(BaseSettings):
     coval_s2s_xai_think_fast_2_agent_id: str | None = None
     coval_s2s_gray_agent_id: str | None = None
     coval_s2s_red_agent_id: str | None = None
+    # Coval agent id for the Phonely text agent (opaque, not secret); unset skips it.
+    coval_llm_phonely_agent_id: str | None = None
     # The S2S instruction-adherence metric id (opaque, not secret). Optional: the
     # fetch pulls its per-conversation scores only when set, so latency still
     # ingests without it.
@@ -211,8 +213,9 @@ class Settings(BaseSettings):
     # Exhaustive: a persona absent from this map faults its provider rather than
     # counting as clean, which would be invisible in the data and the logs.
     coval_s2s_condition_personas: dict[str, str] = Field(default_factory=dict)
-    # Fetch grid, in seconds; kept in sync with the s2s-fetch-trigger cron in
-    # benchmark-infra (override via S2S_FETCH_PERIOD_SECONDS). Default = 3h.
+    # Fetch grid, in seconds, shared by the s2s-fetch and llm-fetch jobs; each job
+    # sets S2S_FETCH_PERIOD_SECONDS to match its own trigger cron in benchmark-infra.
+    # The 3h default is far below a daily trigger, so an unset job reads stale.
     s2s_fetch_period_seconds: int = Field(default=10_800, gt=0)
     # Staleness threshold = fetch period + this grace.
     s2s_stale_grace_seconds: int = Field(default=0, ge=0)

--- a/runner/src/coval_bench/db/writer.py
+++ b/runner/src/coval_bench/db/writer.py
@@ -27,6 +27,7 @@ import psycopg.rows
 from psycopg.types.json import Jsonb
 from psycopg_pool import AsyncConnectionPool
 
+from coval_bench.db.llm_turns import fetch_conversation_ttft
 from coval_bench.db.models import (
     MetricArtifact,
     MetricEvaluation,
@@ -908,6 +909,10 @@ class RunWriter:
             async with conn.cursor() as cur:
                 await cur.execute(sql, (status, error, run_id))
             await conn.commit()
+
+    async def conversation_ttft(self, simulation_ids: Sequence[str]) -> dict[str, float]:
+        """Mean proxy-measured TTFT in seconds per Coval conversation that has turns."""
+        return await fetch_conversation_ttft(self._pool, simulation_ids)
 
     async def coval_run_ingested(
         self, *, provider: str, coval_run_id: str, benchmark: str = "S2S"

--- a/runner/src/coval_bench/llm/phonely.py
+++ b/runner/src/coval_bench/llm/phonely.py
@@ -12,6 +12,10 @@ from typing import Any
 
 import httpx
 
+# The (provider, model) identity seeded into benchmarks_v2.models by migration 0025.
+PROVIDER = "phonely"
+MODEL = "phonely-agent"
+
 _SESSION_TIMEOUT = httpx.Timeout(30.0)
 # Turns are seconds apart; a 5s keepalive would put a TLS handshake inside most TTFTs.
 _LIMITS = httpx.Limits(max_connections=20, max_keepalive_connections=8, keepalive_expiry=300.0)

--- a/runner/src/coval_bench/s2s/fetch_v2v.py
+++ b/runner/src/coval_bench/s2s/fetch_v2v.py
@@ -14,7 +14,7 @@ import asyncio
 import hashlib
 import importlib.resources
 import random
-from collections.abc import Callable, Mapping
+from collections.abc import Awaitable, Callable, Mapping, Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any, cast
@@ -27,12 +27,15 @@ from coval_bench.config import Settings, get_settings
 from coval_bench.db.conn import lifespan_pool
 from coval_bench.db.models import MetricExecutor, Result, ResultStatus, RunStatus
 from coval_bench.db.writer import RunWriter
+from coval_bench.llm.phonely import MODEL as PHONELY_MODEL
+from coval_bench.llm.phonely import PROVIDER as PHONELY_PROVIDER
 from coval_bench.registries import METRIC_SPECS, Metric
 from coval_bench.registries.benchmarks import Benchmark
 from coval_bench.s2s.conditions import (
     DATASET_ID,
     DEFAULT_CONDITION,
     FAMILY_DENTAL,
+    FAMILY_LLM_DENTAL,
     FAMILY_MULTITURN,
     Condition,
     DatasetMetrics,
@@ -126,6 +129,17 @@ AGENTS: tuple[AgentSpec, ...] = (
         test_set_id_attr="coval_s2s_dental_test_set_id",
         family=FAMILY_DENTAL,
         publish_samples=False,
+    ),
+    # The same dental set driven over text through the LLM proxy; TTFT comes from
+    # the proxy's own turn log rather than from Coval.
+    AgentSpec(
+        agent_id_attr="coval_llm_phonely_agent_id",
+        provider=PHONELY_PROVIDER,
+        model=PHONELY_MODEL,
+        test_set_id_attr="coval_s2s_dental_test_set_id",
+        family=FAMILY_LLM_DENTAL,
+        publish_samples=False,
+        benchmark=Benchmark.LLM,
     ),
 )
 
@@ -464,6 +478,41 @@ def _failed_conversation_rows(
     ]
 
 
+# Metrics a condition declares ``local`` are measured on our side and looked up
+# by the anchor's conversation ids instead of fetched from Coval. A local metric
+# is ingestable once it appears here, mirroring _VALUE_MAPPERS.
+_LOCAL_SOURCES: dict[
+    Metric, Callable[[RunWriter, Sequence[str]], Awaitable[Mapping[str, float]]]
+] = {
+    Metric.TTFT: lambda writer, sim_ids: writer.conversation_ttft(sim_ids),
+}
+
+
+def _local_rows(
+    values: Mapping[str, float],
+    *,
+    metric: Metric,
+    run_pk: int,
+    coval_run_id: str,
+    spec: AgentSpec,
+) -> list[Result]:
+    """One SUCCESS row per conversation measured locally, keyed like the anchor rows."""
+    return [
+        Result(
+            run_id=run_pk,
+            provider=spec.provider,
+            model=spec.model,
+            benchmark=spec.benchmark,
+            metric_type=metric,
+            metric_units=METRIC_SPECS[metric].units,
+            metric_value=round(value, 3),
+            audio_filename=f"{coval_run_id}/{sim_id}",
+            status=ResultStatus.SUCCESS,
+        )
+        for sim_id, value in values.items()
+    ]
+
+
 def _metric_values(metrics: dict[str, Any], metric_id: str | None) -> list[dict[str, Any]] | None:
     """The metric's per-conversation values, or None when it is not on the run."""
     payload = metrics.get(metric_id) if metric_id else None
@@ -477,7 +526,7 @@ def _ingestable(condition: DatasetMetrics, metric_ids: Mapping[Metric, str]) -> 
     fetched = frozenset(
         metric for metric in condition.fetched if metric in metric_ids and metric in _VALUE_MAPPERS
     )
-    return fetched | condition.local
+    return fetched | (condition.local & frozenset(_LOCAL_SOURCES))
 
 
 async def _pending_metrics(
@@ -526,7 +575,8 @@ async def _ingest_run(
     a single short call. A conversation with no anchor value becomes a FAILED
     row instead. SUCCEEDED = all clips numeric, PARTIAL = some failed, FAILED = all.
     """
-    pending = condition.fetched if pending is None else pending
+    if pending is None:
+        pending = condition.fetched | (condition.local & frozenset(_LOCAL_SOURCES))
     run_pk: int | None = None
     try:
         resp = await client.get(f"/runs/{coval_run.run_id}")
@@ -628,7 +678,27 @@ async def _ingest_run(
                     )
                     del writable[metric]
 
-        if not writable:
+        # Local metrics are looked up for the anchor's conversations. A metric with
+        # no values at all stays pending for a later scan; once any conversation
+        # has a value the run counts as ingested, and the ones still missing are a
+        # permanent coverage gap, as an UNKNOWN verdict is for instruction.
+        local: dict[Metric, Mapping[str, float]] = {}
+        sim_ids = [sid for v in anchor_values if (sid := v.get("simulation_output_id"))]
+        for metric in sorted(condition.local & pending):
+            measured = await _LOCAL_SOURCES[metric](writer, sim_ids)
+            if not measured:
+                continue
+            if len(measured) < len(sim_ids):
+                logger.warning(
+                    "local_metric_coverage_gap",
+                    provider=spec.provider,
+                    coval_run_id=coval_run.run_id,
+                    metric=metric.value,
+                    conversations=len(sim_ids) - len(measured),
+                )
+            local[metric] = measured
+
+        if not writable and not local:
             # Backfill with nothing to add; leave it retryable, write no run row.
             return None
 
@@ -651,6 +721,10 @@ async def _ingest_run(
             )
             for metric, values in writable.items()
         }
+        for metric, local_values in local.items():
+            by_metric[metric] = _local_rows(
+                local_values, metric=metric, run_pk=run_pk, coval_run_id=coval_run.run_id, spec=spec
+            )
         if condition.required is Metric.V2V and Metric.V2V in writable:
             output_ids = [
                 s
@@ -723,6 +797,7 @@ async def _ingest_run(
             slot=str(scheduled_at),
             clips=len(rows),
             instruction=len(by_metric.get(Metric.INSTRUCTION_FOLLOWING, [])),
+            ttft=len(by_metric.get(Metric.TTFT, [])),
             success=sum(1 for r in rows if r.status is ResultStatus.SUCCESS),
         )
         if Metric.V2V in writable:
@@ -1007,6 +1082,8 @@ async def fetch_and_write_v2v(
         )
     instruction_metric_id = raw_instr or None
     test_set_id = raw_test_set or None
+    if benchmark is Benchmark.LLM and not instruction_metric_id:
+        raise RuntimeError("coval_s2s_instruction_metric_id is not set")
     if benchmark is Benchmark.S2S and bool(instruction_metric_id) != bool(test_set_id):
         raise RuntimeError(
             "coval_s2s_instruction_metric_id and coval_s2s_test_set_id must be set together"
@@ -1140,36 +1217,40 @@ async def fetch_and_write_v2v(
         return statuses
 
 
-@click.command(name="fetch-s2s")
-@click.option(
-    "--coval-run-id",
-    "coval_run_ids",
-    multiple=True,
-    help="Ingest only these Coval runs, scanning beyond the scheduled window. Repeatable.",
-)
-@click.option(
-    "--window-hours",
-    type=click.IntRange(min=1),
-    default=720,
-    show_default=True,
-    help="How far back --coval-run-id searches. Ignored without it.",
-)
-@click.option(
-    "--page-size",
-    type=click.IntRange(min=1),
-    default=100,
-    show_default=True,
-    help="Runs listed per agent while searching for --coval-run-id. Ignored without it.",
-)
-def fetch_s2s(coval_run_ids: tuple[str, ...], window_hours: int, page_size: int) -> None:
-    """Fetch S2S latency from Coval and write per-clip rows (scheduled Cloud Run Job).
+def _fetch_options[Command: Callable[..., None]](command: Command) -> Command:
+    options = (
+        click.option(
+            "--coval-run-id",
+            "coval_run_ids",
+            multiple=True,
+            help="Ingest only these Coval runs, scanning beyond the scheduled window. Repeatable.",
+        ),
+        click.option(
+            "--window-hours",
+            type=click.IntRange(min=1),
+            default=720,
+            show_default=True,
+            help="How far back --coval-run-id searches. Ignored without it.",
+        ),
+        click.option(
+            "--page-size",
+            type=click.IntRange(min=1),
+            default=100,
+            show_default=True,
+            help="Runs listed per agent while searching for --coval-run-id. Ignored without it.",
+        ),
+    )
+    for option in reversed(options):
+        command = option(command)
+    return command
 
-    With --coval-run-id it becomes a targeted backfill instead: only the named runs
-    are ingested, no samples are published, and staleness is not judged, so an
-    operator can recover runs the scheduled window has already passed over.
-    """
+
+def _run_fetch(
+    benchmark: Benchmark, coval_run_ids: tuple[str, ...], window_hours: int, page_size: int
+) -> None:
     from coval_bench.logging import configure_logging, log_run_failed, log_run_partial
 
+    label = f"{benchmark.value.lower()} fetch"
     settings = get_settings()
     configure_logging(level=settings.log_level)
     # A setup crash fails the whole job.
@@ -1178,7 +1259,7 @@ def fetch_s2s(coval_run_ids: tuple[str, ...], window_hours: int, page_size: int)
         statuses = asyncio.run(
             fetch_and_write_v2v(
                 settings,
-                benchmark=Benchmark.S2S,
+                benchmark=benchmark,
                 only_run_ids=only_run_ids,
                 window_seconds=window_hours * 3600 if only_run_ids else None,
                 page_size=page_size if only_run_ids else WINDOW_PAGE_SIZE,
@@ -1193,12 +1274,35 @@ def fetch_s2s(coval_run_ids: tuple[str, ...], window_hours: int, page_size: int)
     failed = [p for p, s in statuses.items() if s is RunStatus.FAILED]
     if not statuses or all(s is RunStatus.FAILED for s in statuses.values()):
         if statuses:
-            log_run_failed(f"s2s fetch failed for all providers: {', '.join(failed)}")
+            log_run_failed(f"{label} failed for all providers: {', '.join(failed)}")
         else:
-            log_run_failed("s2s fetch ran no providers (none configured)")
-        raise click.ClickException("s2s fetch failed for all providers")
+            log_run_failed(f"{label} ran no providers (none configured)")
+        raise click.ClickException(f"{label} failed for all providers")
     if failed:
-        log_run_partial(f"s2s fetch has no fresh data from: {', '.join(failed)}")
+        log_run_partial(f"{label} has no fresh data from: {', '.join(failed)}")
+
+
+@click.command(name="fetch-s2s")
+@_fetch_options
+def fetch_s2s(coval_run_ids: tuple[str, ...], window_hours: int, page_size: int) -> None:
+    """Fetch S2S latency from Coval and write per-clip rows (scheduled Cloud Run Job).
+
+    With --coval-run-id it becomes a targeted backfill instead: only the named runs
+    are ingested, no samples are published, and staleness is not judged, so an
+    operator can recover runs the scheduled window has already passed over.
+    """
+    _run_fetch(Benchmark.S2S, coval_run_ids, window_hours, page_size)
+
+
+@click.command(name="fetch-llm")
+@_fetch_options
+def fetch_llm(coval_run_ids: tuple[str, ...], window_hours: int, page_size: int) -> None:
+    """Fetch LLM instruction scores from Coval and join the proxy's per-turn TTFT.
+
+    Same scan and backfill options as fetch-s2s; only agents on the LLM benchmark
+    are ingested, so the two jobs never see each other's runs.
+    """
+    _run_fetch(Benchmark.LLM, coval_run_ids, window_hours, page_size)
 
 
 if __name__ == "__main__":

--- a/runner/tests/unit/test_s2s_fetch.py
+++ b/runner/tests/unit/test_s2s_fetch.py
@@ -13,6 +13,7 @@ from datetime import UTC, datetime, timedelta
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
+import click
 import httpx
 import pytest
 from click.testing import CliRunner
@@ -24,6 +25,7 @@ from coval_bench.logging import log_run_failed, log_run_partial
 from coval_bench.registries import Benchmark, Metric
 from coval_bench.s2s import fetch_v2v
 from coval_bench.s2s.conditions import (
+    DATASET_ID_LLM_DENTAL,
     DATASET_ID_MULTITURN,
     DATASET_ID_MULTITURN_NOISY,
     FAMILY_HAPPYPATH,
@@ -117,6 +119,7 @@ def _stub_writer() -> MagicMock:
     )
     writer.coval_run_ingested = AsyncMock(return_value=False)
     writer.coval_metric_ingested = AsyncMock(return_value=False)
+    writer.conversation_ttft = AsyncMock(return_value={})
     writer.record_results = AsyncMock()
     writer.finish_run = AsyncMock()
     writer.refresh_bucket = AsyncMock()
@@ -301,12 +304,14 @@ def test_expected_sample_models_excludes_non_publishing_agents() -> None:
         coval_s2s_openai_agent_id="a1",
         coval_s2s_gray_agent_id="a2",
         coval_s2s_red_agent_id="a3",
+        coval_llm_phonely_agent_id="a4",
     )
     expected = fetch_v2v._expected_sample_models(settings)
 
     assert ("openai", "gpt-realtime") in expected
     assert ("colors", "gray") not in expected
     assert ("colors", "red") not in expected
+    assert ("phonely", "phonely-agent") not in expected
 
 
 def test_bucket_start_floors_to_grid() -> None:
@@ -795,6 +800,147 @@ async def test_fetch_and_write_filters_agents_and_allows_llm_without_v2v(
     assert fetch_one.await_args is not None
     assert fetch_one.await_args.kwargs["spec"] is LLM_SPEC
     assert fetch_one.await_args.kwargs["metric_ids"] == {Metric.INSTRUCTION_FOLLOWING: "IID"}
+
+
+def test_phonely_spec_is_the_llm_dental_text_agent() -> None:
+    spec = next(spec for spec in fetch_v2v.AGENTS if spec.provider == "phonely")
+    assert spec == AgentSpec(
+        agent_id_attr="coval_llm_phonely_agent_id",
+        provider="phonely",
+        model="phonely-agent",
+        test_set_id_attr="coval_s2s_dental_test_set_id",
+        family=FAMILY_LLM_DENTAL,
+        publish_samples=False,
+        benchmark=Benchmark.LLM,
+    )
+    assert condition_for(DATASET_ID_LLM_DENTAL) == DatasetMetrics(
+        benchmark=Benchmark.LLM,
+        required=Metric.INSTRUCTION_FOLLOWING,
+        local=frozenset({Metric.TTFT}),
+    )
+
+
+async def _fetch_llm(
+    writer: MagicMock,
+    values: list[dict[str, Any]],
+    *,
+    persona_conditions: dict[str, Condition] | None = None,
+) -> tuple[RunStatus, int]:
+    list_json = _list_json(
+        {"run_id": "R1", "create_time": _iso(timedelta(hours=1)), "persona_id": "P1"}
+    )
+    async with _fake_client(list_json, _run_json(values, metric_id="IID")) as client:
+        return await fetch_v2v._fetch_one_provider(
+            client,
+            writer,
+            spec=LLM_SPEC,
+            agent_id="a1",
+            metric_ids={Metric.INSTRUCTION_FOLLOWING: "IID"},
+            test_set_id="TSD",
+            persona_conditions=persona_conditions,
+            period_seconds=10_800,
+            stale_grace_seconds=5_400,
+        )
+
+
+@pytest.mark.asyncio
+async def test_text_agent_uses_instruction_as_the_clean_dental_anchor() -> None:
+    writer = _stub_writer()
+    writer.conversation_ttft = AsyncMock(return_value={"s1": 0.4126})
+    values = [
+        {"simulation_output_id": "s1", "value": "YES"},
+        {"simulation_output_id": "s2", "value": "NO"},
+    ]
+
+    with capture_logs() as logs:
+        status, ingested = await _fetch_llm(writer, values)
+
+    assert (status, ingested) == (RunStatus.SUCCEEDED, 1)
+    assert writer.start_run.await_args.kwargs["dataset_id"] == DATASET_ID_LLM_DENTAL
+    writer.conversation_ttft.assert_awaited_once_with(["s1", "s2"])
+    rows = writer.record_results.await_args.args[0]
+    assert {(r.metric_type, r.audio_filename, r.metric_value, r.metric_units) for r in rows} == {
+        (Metric.INSTRUCTION_FOLLOWING, "R1/s1", 100.0, "percent"),
+        (Metric.INSTRUCTION_FOLLOWING, "R1/s2", 0.0, "percent"),
+        (Metric.TTFT, "R1/s1", 0.413, "seconds"),
+    }
+    assert all(r.benchmark is Benchmark.LLM for r in rows)
+    gaps = [log for log in logs if log["event"] == "local_metric_coverage_gap"]
+    assert [(log["metric"], log["conversations"]) for log in gaps] == [("TTFT", 1)]
+
+
+def test_local_metrics_are_ingestable_only_with_a_source() -> None:
+    condition = DatasetMetrics(
+        required=Metric.INSTRUCTION_FOLLOWING, local=frozenset({Metric.TTFT, Metric.V2V})
+    )
+    assert fetch_v2v._ingestable(condition, {Metric.INSTRUCTION_FOLLOWING: "IID"}) == {
+        Metric.INSTRUCTION_FOLLOWING,
+        Metric.TTFT,
+    }
+
+
+@pytest.mark.asyncio
+async def test_ingest_run_defaults_to_writing_local_metrics() -> None:
+    writer = _stub_writer()
+    writer.conversation_ttft = AsyncMock(return_value={"s1": 0.25})
+    values = [{"simulation_output_id": "s1", "value": "YES"}]
+    async with _fake_client({}, _run_json(values, metric_id="IID")) as client:
+        status = await fetch_v2v._ingest_run(
+            client,
+            writer,
+            spec=LLM_SPEC,
+            coval_run=CovalRun(run_id="R1", create_time=None),
+            metric_ids={Metric.INSTRUCTION_FOLLOWING: "IID"},
+            condition=condition_for(DATASET_ID_LLM_DENTAL),
+            period_seconds=10_800,
+        )
+    assert status is RunStatus.SUCCEEDED
+    rows = writer.record_results.await_args.args[0]
+    assert {r.metric_type for r in rows} == {Metric.INSTRUCTION_FOLLOWING, Metric.TTFT}
+
+
+@pytest.mark.asyncio
+async def test_ttft_backfills_onto_an_ingested_run_once_turns_exist() -> None:
+    writer = _stub_writer()
+    writer.coval_metric_ingested = AsyncMock(
+        side_effect=lambda **kw: kw["metric_type"] is Metric.INSTRUCTION_FOLLOWING
+    )
+    values = [{"simulation_output_id": "s1", "value": "YES"}]
+
+    status, ingested = await _fetch_llm(writer, values)
+    assert (status, ingested) == (RunStatus.SUCCEEDED, 0)
+    writer.start_run.assert_not_awaited()
+
+    writer.conversation_ttft = AsyncMock(return_value={"s1": 0.2})
+    status, ingested = await _fetch_llm(writer, values)
+    assert (status, ingested) == (RunStatus.SUCCEEDED, 1)
+    rows = writer.record_results.await_args.args[0]
+    assert [(r.metric_type, r.metric_value) for r in rows] == [(Metric.TTFT, 0.2)]
+
+
+@pytest.mark.asyncio
+async def test_non_clean_text_personas_are_not_ingested() -> None:
+    writer = _stub_writer()
+    values = [{"simulation_output_id": "s1", "value": "YES"}]
+
+    status, ingested = await _fetch_llm(writer, values, persona_conditions={"P1": Condition.NOISY})
+
+    assert (status, ingested) == (RunStatus.FAILED, 0)
+    writer.coval_metric_ingested.assert_not_awaited()
+    writer.start_run.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_fetch_and_write_llm_requires_the_instruction_metric_and_dental_set() -> None:
+    with pytest.raises(RuntimeError, match="coval_s2s_instruction_metric_id is not set"):
+        await fetch_v2v.fetch_and_write_v2v(
+            Settings(coval_llm_phonely_agent_id="a1"), benchmark=Benchmark.LLM
+        )
+    with pytest.raises(RuntimeError, match="coval_s2s_dental_test_set_id is required"):
+        await fetch_v2v.fetch_and_write_v2v(
+            Settings(coval_llm_phonely_agent_id="a1", coval_s2s_instruction_metric_id="IID"),
+            benchmark=Benchmark.LLM,
+        )
 
 
 @pytest.mark.asyncio
@@ -1792,9 +1938,14 @@ def test_log_run_failed_emits_run_failed_event() -> None:
 
 
 def _run_fetch_cli(
-    monkeypatch: pytest.MonkeyPatch, statuses: dict[str, RunStatus]
+    monkeypatch: pytest.MonkeyPatch,
+    statuses: dict[str, RunStatus],
+    command: click.Command = fetch_v2v.fetch_s2s,
+    calls: list[dict[str, Any]] | None = None,
 ) -> tuple[int, list[str]]:
-    async def fake_fetch(_settings: Settings, **_kwargs: object) -> dict[str, RunStatus]:
+    async def fake_fetch(_settings: Settings, **kwargs: object) -> dict[str, RunStatus]:
+        if calls is not None:
+            calls.append(dict(kwargs))
         return statuses
 
     settings = Settings.model_construct(log_level="INFO")
@@ -1802,8 +1953,17 @@ def _run_fetch_cli(
     monkeypatch.setattr(fetch_v2v, "get_settings", lambda: settings)
     monkeypatch.setattr("coval_bench.logging.configure_logging", lambda level: None)
     with capture_logs() as logs:
-        result = CliRunner().invoke(fetch_v2v.fetch_s2s, [])
+        result = CliRunner().invoke(command, [])
     return result.exit_code, [str(entry.get("event")) for entry in logs]
+
+
+def test_fetch_llm_cli_selects_the_llm_benchmark(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[dict[str, Any]] = []
+    code, events = _run_fetch_cli(
+        monkeypatch, {"phonely:phonely-agent": RunStatus.SUCCEEDED}, fetch_v2v.fetch_llm, calls
+    )
+    assert (code, events) == (0, [])
+    assert calls[0]["benchmark"] is Benchmark.LLM
 
 
 def test_cli_mixed_alerts_partial_exit_zero(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
Register Phonely as an LLM-benchmark agent spec in the shared Coval fetch and join the proxy's per-turn timing onto the judged conversations. Local metrics are looked up through a source table beside the Coval value mappers; fetch-llm shares its options and body with fetch-s2s.