### PR TITLE
[BENCH-797] Prevent STT/TTS dual-write gaps

### DIFF
--- a/runner/src/coval_bench/db/writer.py
+++ b/runner/src/coval_bench/db/writer.py
@@ -71,6 +71,38 @@ class RunWriter:
     ) -> None:
         self._pool = pool
 
+    def pool_diagnostics(self) -> dict[str, int]:
+        """Return a stable, read-only snapshot of pool health counters."""
+        keys = (
+            "pool_min",
+            "pool_max",
+            "pool_size",
+            "pool_available",
+            "requests_waiting",
+            "requests_num",
+            "requests_queued",
+            "requests_wait_ms",
+            "requests_errors",
+            "usage_ms",
+            "connections_num",
+            "connections_ms",
+            "connections_errors",
+            "connections_lost",
+            "returns_bad",
+            "pool_timeout_ms",
+        )
+        diagnostics = {key: 0 for key in keys}
+        stats = self._pool.get_stats()
+        for key in keys:
+            if key in stats:
+                diagnostics[key] = int(stats[key])
+        diagnostics["pool_min"] = int(self._pool.min_size)
+        diagnostics["pool_max"] = int(self._pool.max_size)
+        diagnostics["pool_size"] = int(stats.get("pool_size", 0))
+        diagnostics["pool_available"] = int(stats.get("pool_available", 0))
+        diagnostics["pool_timeout_ms"] = int(float(self._pool.timeout) * 1000)
+        return diagnostics
+
     async def start_run(
         self,
         *,

--- a/runner/src/coval_bench/runner/normalized.py
+++ b/runner/src/coval_bench/runner/normalized.py
@@ -134,7 +134,6 @@ async def dual_write(
     audio_path: Any = None,
     voice: str | None = None,
     executor: MetricExecutor = MetricExecutor.INLINE,
-    db_semaphore: asyncio.Semaphore | None = None,
     db_retry_attempts: int = 1,
 ) -> None:
     """Persist one observation and its grouped normalized evaluations."""
@@ -238,23 +237,17 @@ async def dual_write(
                     values=_values(metric, rows, evaluation.id, primary),
                 )
 
-    async def attempt_db() -> None:
-        if db_semaphore is None:
-            await persist_db()
-        else:
-            async with db_semaphore:
-                await persist_db()
-
-    if db_retry_attempts <= 1 and db_semaphore is None:
+    if db_retry_attempts <= 1:
         await persist_db()
         return
     from coval_bench.runner.retry import with_retry
 
     retry_on = (PoolTimeout, psycopg.OperationalError)
     await with_retry(
-        attempt_db,
+        persist_db,
         max_attempts=db_retry_attempts,
         retry_on=retry_on,
         retry_event="normalized_persistence_retry",
         exhaustion_event="normalized_persistence_exhausted",
+        retry_state=writer.pool_diagnostics,
     )

--- a/runner/src/coval_bench/runner/normalized.py
+++ b/runner/src/coval_bench/runner/normalized.py
@@ -10,6 +10,9 @@ from collections.abc import Sequence
 from datetime import UTC, datetime
 from typing import Any
 
+import psycopg
+from psycopg_pool import PoolTimeout
+
 from coval_bench.db.models import (
     MetricEvaluation,
     MetricEvaluationInput,
@@ -131,8 +134,13 @@ async def dual_write(
     audio_path: Any = None,
     voice: str | None = None,
     executor: MetricExecutor = MetricExecutor.INLINE,
+    db_semaphore: asyncio.Semaphore | None = None,
+    db_retry_attempts: int = 1,
 ) -> None:
     """Persist one observation and its grouped normalized evaluations."""
+    if provider_error is not None and not provider_error.strip():
+        provider_error = None
+    captured_at = captured_at or datetime.now(UTC)
     audio_snapshot = snapshot_generated_audio(audio_path) if audio_path is not None else None
     artifacts = []
     if transcript is not None:
@@ -147,11 +155,7 @@ async def dual_write(
         audio_payload, audio_duration_ms = audio_snapshot
         artifacts.append(
             await asyncio.to_thread(
-                upload_generated_audio,
-                storage_client,
-                bucket,
-                audio_payload,
-                audio_duration_ms,
+                upload_generated_audio, storage_client, bucket, audio_payload, audio_duration_ms
             )
         )
     source_kind = {
@@ -159,73 +163,98 @@ async def dual_write(
         "TTS": ObservationSourceKind.GENERATED_AUDIO,
         "S2S": ObservationSourceKind.CONVERSATION_AUDIO,
     }[benchmark.value.upper()]
-    observation = await writer.insert_observation(
-        Observation(
-            run_id=run_id,
-            dataset_id=dataset_id,
-            dataset_sha256=dataset_sha256,
-            sample_id=sample_id,
-            provider=entry.provider,
-            model=entry.model,
-            voice=voice,
-            benchmark=benchmark,
-            source_kind=source_kind,
-            captured_at=captured_at,
-            status=ObservationStatus.FAILED if provider_error else ObservationStatus.SUCCEEDED,
-            error=provider_error,
-            failure_origin=ObservationFailureOrigin.PROVIDER if provider_error else None,
-            artifacts=artifacts,
-        )
-    )
-    artifact_ids = {artifact.artifact_type: artifact.id for artifact in observation.artifacts}
-    grouped: dict[str, list[Any]] = {}
-    for row in results:
-        metric = (
-            str(Metric.TTFA)
-            if row.metric_type in (Metric.TTFA_ROUNDTRIP, Metric.TTFA_LEADING_SILENCE)
-            else str(row.metric_type)
-        )
-        grouped.setdefault(metric, []).append(row)
-    for metric, rows in grouped.items():
-        primary = next(
-            (row for row in rows if row.metric_value is not None and str(row.status) == "success"),
-            None,
-        )
-        # A null-valued success is an intentional exclusion from aggregation (for example,
-        # transport-contaminated TTFA), not a failed metric evaluation.
-        if primary is None and any(str(row.status) == "success" for row in rows):
-            continue
-        evaluation = await writer.insert_metric_evaluation(
-            MetricEvaluation(
-                observation_id=observation.id,
-                metric_type=metric,
-                metric_version="v1",
-                executor=executor,
-                status=ProcessingStatus.QUEUED,
-            ),
-            inputs=_inputs(metric, artifact_ids, benchmark),
-        )
-        if (
-            evaluation.status is ProcessingStatus.SUCCEEDED
-            or evaluation.status is ProcessingStatus.FAILED
-        ):
-            continue
-        if evaluation.status is ProcessingStatus.QUEUED:
-            evaluation = await writer.start_metric_evaluation(
-                evaluation.id, started_at=datetime.now(UTC)
+
+    async def persist_db() -> None:
+        observation = await writer.insert_observation(
+            Observation(
+                run_id=run_id,
+                dataset_id=dataset_id,
+                dataset_sha256=dataset_sha256,
+                sample_id=sample_id,
+                provider=entry.provider,
+                model=entry.model,
+                voice=voice,
+                benchmark=benchmark,
+                source_kind=source_kind,
+                captured_at=captured_at,
+                status=ObservationStatus.FAILED if provider_error else ObservationStatus.SUCCEEDED,
+                error=provider_error,
+                failure_origin=ObservationFailureOrigin.PROVIDER if provider_error else None,
+                artifacts=artifacts,
             )
-        finished_at = datetime.now(UTC)
-        if primary is None:
-            await writer.fail_metric_evaluation(
-                evaluation.id,
-                finished_at=finished_at,
-                error=next(
-                    (row.error for row in rows if row.error), "legacy metric produced no value"
+        )
+        artifact_ids = {artifact.artifact_type: artifact.id for artifact in observation.artifacts}
+        grouped: dict[str, list[Any]] = {}
+        for row in results:
+            metric = (
+                str(Metric.TTFA)
+                if row.metric_type in (Metric.TTFA_ROUNDTRIP, Metric.TTFA_LEADING_SILENCE)
+                else str(row.metric_type)
+            )
+            grouped.setdefault(metric, []).append(row)
+        for metric, rows in grouped.items():
+            primary = next(
+                (
+                    row
+                    for row in rows
+                    if row.metric_value is not None and str(row.status) == "success"
                 ),
+                None,
             )
+            if primary is None and any(str(row.status) == "success" for row in rows):
+                continue
+            evaluation = await writer.insert_metric_evaluation(
+                MetricEvaluation(
+                    observation_id=observation.id,
+                    metric_type=metric,
+                    metric_version="v1",
+                    executor=executor,
+                    status=ProcessingStatus.QUEUED,
+                ),
+                inputs=_inputs(metric, artifact_ids, benchmark),
+            )
+            if (
+                evaluation.status is ProcessingStatus.SUCCEEDED
+                or evaluation.status is ProcessingStatus.FAILED
+            ):
+                continue
+            if evaluation.status is ProcessingStatus.QUEUED:
+                evaluation = await writer.start_metric_evaluation(
+                    evaluation.id, started_at=datetime.now(UTC)
+                )
+            finished_at = datetime.now(UTC)
+            if primary is None:
+                await writer.fail_metric_evaluation(
+                    evaluation.id,
+                    finished_at=finished_at,
+                    error=next(
+                        (row.error for row in rows if row.error), "legacy metric produced no value"
+                    ),
+                )
+            else:
+                await writer.complete_metric_evaluation(
+                    evaluation.id,
+                    finished_at=finished_at,
+                    values=_values(metric, rows, evaluation.id, primary),
+                )
+
+    async def attempt_db() -> None:
+        if db_semaphore is None:
+            await persist_db()
         else:
-            await writer.complete_metric_evaluation(
-                evaluation.id,
-                finished_at=finished_at,
-                values=_values(metric, rows, evaluation.id, primary),
-            )
+            async with db_semaphore:
+                await persist_db()
+
+    if db_retry_attempts <= 1 and db_semaphore is None:
+        await persist_db()
+        return
+    from coval_bench.runner.retry import with_retry
+
+    retry_on = (PoolTimeout, psycopg.OperationalError)
+    await with_retry(
+        attempt_db,
+        max_attempts=db_retry_attempts,
+        retry_on=retry_on,
+        retry_event="normalized_persistence_retry",
+        exhaustion_event="normalized_persistence_exhausted",
+    )

--- a/runner/src/coval_bench/runner/orchestrator.py
+++ b/runner/src/coval_bench/runner/orchestrator.py
@@ -51,6 +51,7 @@ from typing import TYPE_CHECKING, Any, Literal
 
 import structlog
 from posthog import Posthog
+from psycopg_pool import PoolTimeout
 from pydantic import BaseModel
 
 from coval_bench.db.registry_store import fetch_models
@@ -74,6 +75,7 @@ logger = structlog.get_logger("coval_bench.runner")
 
 _CONCURRENCY_CAP = 8
 _DEDICATED_CONCURRENCY_CAP = 1
+_PERSISTENCE_DB_CONCURRENCY = 3
 _STT_TIMEOUT_S = 45
 _TTS_TIMEOUT_S = 60
 # Stable contract — matched by the reason classifier and the alerting log metric.
@@ -358,6 +360,29 @@ def _get_metrics() -> tuple[Any, Any]:
     return mod.compute_wer, mod.compute_rtf
 
 
+async def _persist_legacy_results(
+    writer: Any,
+    results: list[Any],
+    captured_at: datetime,
+    semaphore: asyncio.Semaphore | None,
+    event_prefix: str,
+) -> None:
+    async def attempt() -> None:
+        if semaphore is None:
+            await writer.record_results(results, created_at=captured_at)
+        else:
+            async with semaphore:
+                await writer.record_results(results, created_at=captured_at)
+
+    await with_retry(
+        attempt,
+        max_attempts=3,
+        retry_on=(PoolTimeout,),
+        retry_event=f"{event_prefix}_persistence_retry",
+        exhaustion_event=f"{event_prefix}_persistence_exhausted",
+    )
+
+
 # ---------------------------------------------------------------------------
 # STT coroutine builder
 # ---------------------------------------------------------------------------
@@ -374,6 +399,7 @@ async def _run_stt_item(
     dataset_id: str | None = None,
     dataset_sha256: str = "",
     artifact_client: Any | None = None,
+    persistence_db_sem: asyncio.Semaphore | None = None,
 ) -> list[Any]:
     """Run a single STT provider × dataset item, returning a list of Result rows.
 
@@ -696,7 +722,7 @@ async def _run_stt_item(
     captured_at = datetime.now(UTC)
     if writer is not None and results:
         try:
-            await writer.record_results(results, created_at=captured_at)
+            await _persist_legacy_results(writer, results, captured_at, persistence_db_sem, "stt")
         except Exception as exc:
             logger.warning(
                 "stt_result_persist_failed",
@@ -731,6 +757,8 @@ async def _run_stt_item(
                         "effective_duration_sec": duration_sec,
                         **_finalization_events(transcription_result),
                     },
+                    db_semaphore=persistence_db_sem,
+                    db_retry_attempts=3,
                 )
             except Exception as exc:
                 logger.warning(
@@ -779,6 +807,7 @@ async def _run_tts_item(
     dataset_id: str = "tts-v1",
     dataset_sha256: str = "",
     artifact_client: Any | None = None,
+    persistence_db_sem: asyncio.Semaphore | None = None,
 ) -> list[Any]:
     """Run a single TTS provider × dataset item, returning a list of Result rows.
 
@@ -984,7 +1013,9 @@ async def _run_tts_item(
             captured_at = datetime.now(UTC)
             if writer is not None and results:
                 try:
-                    await writer.record_results(results, created_at=captured_at)
+                    await _persist_legacy_results(
+                        writer, results, captured_at, persistence_db_sem, "tts"
+                    )
                 except Exception as exc:
                     logger.warning(
                         "tts_result_persist_failed",
@@ -1013,6 +1044,8 @@ async def _run_tts_item(
                         timing_events={"ttfa_ms": ttfa_ms},
                         audio_path=audio_path,
                         voice=voice,
+                        db_semaphore=persistence_db_sem,
+                        db_retry_attempts=3,
                     )
                 except Exception as exc:
                     logger.warning(
@@ -1253,6 +1286,7 @@ async def run_benchmarks(
             )
             stt_artifact_client = None
         sem = asyncio.Semaphore(_DEDICATED_CONCURRENCY_CAP if dedicated else _CONCURRENCY_CAP)
+        persistence_db_sem = asyncio.Semaphore(_PERSISTENCE_DB_CONCURRENCY)
 
         # Cloud Run sends SIGTERM ~10s before SIGKILL when a task hits its timeout.
         # We catch it, cancel the in-flight gather, and finalize the run row as
@@ -1334,6 +1368,7 @@ async def run_benchmarks(
                         dataset_id=settings.dataset_id,
                         dataset_sha256=dataset_sha256,
                         artifact_client=stt_artifact_client,
+                        persistence_db_sem=persistence_db_sem,
                     )
                     for entry, item in stt_pairs
                 ]
@@ -1402,6 +1437,7 @@ async def run_benchmarks(
                         dataset_id="tts-v1",
                         dataset_sha256=tts_manifest_sha256,
                         artifact_client=tts_artifact_client,
+                        persistence_db_sem=persistence_db_sem,
                     )
                     for entry, item, voice in tts_pairs
                 ]

--- a/runner/src/coval_bench/runner/orchestrator.py
+++ b/runner/src/coval_bench/runner/orchestrator.py
@@ -75,7 +75,6 @@ logger = structlog.get_logger("coval_bench.runner")
 
 _CONCURRENCY_CAP = 8
 _DEDICATED_CONCURRENCY_CAP = 1
-_PERSISTENCE_DB_CONCURRENCY = 3
 _STT_TIMEOUT_S = 45
 _TTS_TIMEOUT_S = 60
 # Stable contract — matched by the reason classifier and the alerting log metric.
@@ -364,15 +363,10 @@ async def _persist_legacy_results(
     writer: Any,
     results: list[Any],
     captured_at: datetime,
-    semaphore: asyncio.Semaphore | None,
     event_prefix: str,
 ) -> None:
     async def attempt() -> None:
-        if semaphore is None:
-            await writer.record_results(results, created_at=captured_at)
-        else:
-            async with semaphore:
-                await writer.record_results(results, created_at=captured_at)
+        await writer.record_results(results, created_at=captured_at)
 
     await with_retry(
         attempt,
@@ -380,6 +374,7 @@ async def _persist_legacy_results(
         retry_on=(PoolTimeout,),
         retry_event=f"{event_prefix}_persistence_retry",
         exhaustion_event=f"{event_prefix}_persistence_exhausted",
+        retry_state=writer.pool_diagnostics,
     )
 
 
@@ -399,7 +394,6 @@ async def _run_stt_item(
     dataset_id: str | None = None,
     dataset_sha256: str = "",
     artifact_client: Any | None = None,
-    persistence_db_sem: asyncio.Semaphore | None = None,
 ) -> list[Any]:
     """Run a single STT provider × dataset item, returning a list of Result rows.
 
@@ -722,7 +716,7 @@ async def _run_stt_item(
     captured_at = datetime.now(UTC)
     if writer is not None and results:
         try:
-            await _persist_legacy_results(writer, results, captured_at, persistence_db_sem, "stt")
+            await _persist_legacy_results(writer, results, captured_at, "stt")
         except Exception as exc:
             logger.warning(
                 "stt_result_persist_failed",
@@ -757,7 +751,6 @@ async def _run_stt_item(
                         "effective_duration_sec": duration_sec,
                         **_finalization_events(transcription_result),
                     },
-                    db_semaphore=persistence_db_sem,
                     db_retry_attempts=3,
                 )
             except Exception as exc:
@@ -807,7 +800,6 @@ async def _run_tts_item(
     dataset_id: str = "tts-v1",
     dataset_sha256: str = "",
     artifact_client: Any | None = None,
-    persistence_db_sem: asyncio.Semaphore | None = None,
 ) -> list[Any]:
     """Run a single TTS provider × dataset item, returning a list of Result rows.
 
@@ -1013,9 +1005,7 @@ async def _run_tts_item(
             captured_at = datetime.now(UTC)
             if writer is not None and results:
                 try:
-                    await _persist_legacy_results(
-                        writer, results, captured_at, persistence_db_sem, "tts"
-                    )
+                    await _persist_legacy_results(writer, results, captured_at, "tts")
                 except Exception as exc:
                     logger.warning(
                         "tts_result_persist_failed",
@@ -1044,7 +1034,6 @@ async def _run_tts_item(
                         timing_events={"ttfa_ms": ttfa_ms},
                         audio_path=audio_path,
                         voice=voice,
-                        db_semaphore=persistence_db_sem,
                         db_retry_attempts=3,
                     )
                 except Exception as exc:
@@ -1286,7 +1275,6 @@ async def run_benchmarks(
             )
             stt_artifact_client = None
         sem = asyncio.Semaphore(_DEDICATED_CONCURRENCY_CAP if dedicated else _CONCURRENCY_CAP)
-        persistence_db_sem = asyncio.Semaphore(_PERSISTENCE_DB_CONCURRENCY)
 
         # Cloud Run sends SIGTERM ~10s before SIGKILL when a task hits its timeout.
         # We catch it, cancel the in-flight gather, and finalize the run row as
@@ -1368,7 +1356,6 @@ async def run_benchmarks(
                         dataset_id=settings.dataset_id,
                         dataset_sha256=dataset_sha256,
                         artifact_client=stt_artifact_client,
-                        persistence_db_sem=persistence_db_sem,
                     )
                     for entry, item in stt_pairs
                 ]
@@ -1437,7 +1424,6 @@ async def run_benchmarks(
                         dataset_id="tts-v1",
                         dataset_sha256=tts_manifest_sha256,
                         artifact_client=tts_artifact_client,
-                        persistence_db_sem=persistence_db_sem,
                     )
                     for entry, item, voice in tts_pairs
                 ]

--- a/runner/src/coval_bench/runner/retry.py
+++ b/runner/src/coval_bench/runner/retry.py
@@ -18,7 +18,8 @@ from __future__ import annotations
 
 import asyncio
 import random
-from collections.abc import Awaitable, Callable
+import time
+from collections.abc import Awaitable, Callable, Mapping
 
 import structlog
 
@@ -40,6 +41,7 @@ async def with_retry[T](
     retry_on: tuple[type[BaseException], ...] = _DEFAULT_RETRY_ON,
     retry_event: str = "provider_call_retry",
     exhaustion_event: str = "retry_exhausted",
+    retry_state: Callable[[], Mapping[str, object]] | None = None,
 ) -> T:
     """Call *fn* up to *max_attempts* times with exponential backoff + full jitter.
 
@@ -54,6 +56,8 @@ async def with_retry[T](
         retry_on: Exception types that trigger a retry. All others propagate immediately.
         retry_event: Structured event name emitted for retry attempts.
         exhaustion_event: Structured event name emitted when retries are exhausted.
+        retry_state: Optional synchronous callback returning diagnostic state captured around
+            each attempt. Callback failures are ignored.
 
     Returns:
         The return value of the first successful *fn* call.
@@ -63,16 +67,34 @@ async def with_retry[T](
     """
     last_exc: BaseException | None = None
     for attempt in range(max_attempts):
+        state_before: Mapping[str, object] = {}
+        if retry_state is not None:
+            try:
+                state_before = retry_state()
+            except Exception:  # Diagnostics must never affect operation behavior.
+                state_before = {}
+        started = time.monotonic()
         try:
             return await fn()
         except retry_on as exc:
             last_exc = exc
+            attempt_elapsed_ms = round((time.monotonic() - started) * 1000)
+            state_after: Mapping[str, object] = {}
+            if retry_state is not None:
+                try:
+                    state_after = retry_state()
+                except Exception:
+                    state_after = {}
             if attempt + 1 >= max_attempts:
                 logger.error(
                     exhaustion_event,
                     attempt=attempt + 1,
                     max_attempts=max_attempts,
                     exc_info=exc,
+                    exception_type=type(exc).__name__,
+                    attempt_elapsed_ms=attempt_elapsed_ms,
+                    state_before=state_before,
+                    state_after=state_after,
                 )
                 break
             cap = min(base_delay_s * (2**attempt), max_delay_s)
@@ -84,6 +106,10 @@ async def with_retry[T](
                 max_attempts=max_attempts,
                 delay_s=round(delay, 3),
                 exc_info=exc,
+                exception_type=type(exc).__name__,
+                attempt_elapsed_ms=attempt_elapsed_ms,
+                state_before=state_before,
+                state_after=state_after,
             )
             await asyncio.sleep(delay)
 

--- a/runner/src/coval_bench/runner/retry.py
+++ b/runner/src/coval_bench/runner/retry.py
@@ -38,6 +38,8 @@ async def with_retry[T](
     base_delay_s: float = 0.5,
     max_delay_s: float = 8.0,
     retry_on: tuple[type[BaseException], ...] = _DEFAULT_RETRY_ON,
+    retry_event: str = "provider_call_retry",
+    exhaustion_event: str = "retry_exhausted",
 ) -> T:
     """Call *fn* up to *max_attempts* times with exponential backoff + full jitter.
 
@@ -50,6 +52,8 @@ async def with_retry[T](
         base_delay_s: Base delay in seconds before the first retry.
         max_delay_s: Maximum delay cap in seconds.
         retry_on: Exception types that trigger a retry. All others propagate immediately.
+        retry_event: Structured event name emitted for retry attempts.
+        exhaustion_event: Structured event name emitted when retries are exhausted.
 
     Returns:
         The return value of the first successful *fn* call.
@@ -65,7 +69,7 @@ async def with_retry[T](
             last_exc = exc
             if attempt + 1 >= max_attempts:
                 logger.error(
-                    "retry_exhausted",
+                    exhaustion_event,
                     attempt=attempt + 1,
                     max_attempts=max_attempts,
                     exc_info=exc,
@@ -75,7 +79,7 @@ async def with_retry[T](
             # Full jitter — non-cryptographic, used only for backoff scheduling
             delay = random.uniform(0, cap)  # noqa: S311
             logger.warning(
-                "provider_call_retry",
+                retry_event,
                 attempt=attempt + 1,
                 max_attempts=max_attempts,
                 delay_s=round(delay, 3),

--- a/runner/tests/unit/test_db_writer.py
+++ b/runner/tests/unit/test_db_writer.py
@@ -101,6 +101,54 @@ async def _make_pool(
     return pool
 
 
+def test_pool_diagnostics_uses_public_pool_apis(pg_conn: psycopg.Connection[Any]) -> None:
+    expected = {
+        "pool_min",
+        "pool_max",
+        "pool_size",
+        "pool_available",
+        "requests_waiting",
+        "requests_num",
+        "requests_queued",
+        "requests_wait_ms",
+        "requests_errors",
+        "usage_ms",
+        "connections_num",
+        "connections_ms",
+        "connections_errors",
+        "connections_lost",
+        "returns_bad",
+        "pool_timeout_ms",
+    }
+
+    async def check() -> tuple[dict[str, int], dict[str, int]]:
+        pool: AsyncConnectionPool[Any] = AsyncConnectionPool(
+            conninfo=_async_dsn(pg_conn),
+            min_size=1,
+            max_size=4,
+            timeout=12.5,
+            open=False,
+            kwargs={"autocommit": False},
+        )
+        await pool.open(wait=True)
+        try:
+            writer = RunWriter(pool)
+            before = writer.pool_diagnostics()
+            async with pool.connection():
+                checked_out = writer.pool_diagnostics()
+            return before, checked_out
+        finally:
+            await pool.close()
+
+    diagnostics, checked_out = asyncio.run(check())
+    assert set(diagnostics) == expected
+    assert diagnostics["pool_min"] == 1
+    assert diagnostics["pool_max"] == 4
+    assert diagnostics["pool_timeout_ms"] == 12_500
+    assert diagnostics["pool_size"] >= diagnostics["pool_available"] >= 0
+    assert diagnostics["pool_available"] == checked_out["pool_available"] + 1
+
+
 def _make_result(
     run_id: int, *, idx: int = 0, status: ResultStatus = ResultStatus.SUCCESS
 ) -> Result:

--- a/runner/tests/unit/test_normalized_db_writer.py
+++ b/runner/tests/unit/test_normalized_db_writer.py
@@ -17,7 +17,7 @@ import psycopg.rows
 import pytest
 from alembic import command as alembic_command
 from alembic.config import Config as AlembicConfig
-from psycopg_pool import AsyncConnectionPool
+from psycopg_pool import AsyncConnectionPool, PoolTimeout
 from pytest_postgresql.factories import postgresql
 
 from coval_bench.db.models import (
@@ -39,6 +39,7 @@ from coval_bench.db.models import (
 )
 from coval_bench.db.writer import RunWriter
 from coval_bench.registries import Metric, MetricValueRole, validate_metric_values
+from coval_bench.runner import normalized
 
 pg_conn = postgresql("pg_proc")
 _INI_PATH = Path(__file__).parents[2] / "alembic.ini"
@@ -177,6 +178,124 @@ def _raw_artifact(*, sha: str = _SHA) -> ObservationArtifact:
         content_sha256=sha,
         size_bytes=1,
     )
+
+
+def _dual_result(run_id: int) -> Any:
+    from coval_bench.db.models import Result, ResultStatus
+
+    return Result(
+        run_id=run_id,
+        provider="provider",
+        model="model",
+        benchmark=Benchmark.STT,
+        metric_type=Metric.WER,
+        metric_value=10.0,
+        metric_units="percent",
+        wer_insertions_pct=1.0,
+        wer_deletions_pct=2.0,
+        wer_substitutions_pct=7.0,
+        status=ResultStatus.SUCCESS,
+    )
+
+
+async def _run_dual_write_retry_case(
+    conn: psycopg.Connection[Any], monkeypatch: pytest.MonkeyPatch, mode: str
+) -> None:
+    pool = await _pool(conn)
+    try:
+        writer = RunWriter(pool)
+        run = await writer.start_run(dataset_id="stt-v1", dataset_sha256=_SHA)
+        run_id = _required(run.id)
+        original_observation = writer.insert_observation
+        original_evaluation = writer.insert_metric_evaluation
+        original_complete = writer.complete_metric_evaluation
+        calls = 0
+
+        async def observation(value: Observation) -> Observation:
+            nonlocal calls
+            if mode == "observation" and calls == 0:
+                calls += 1
+                raise PoolTimeout("busy")
+            return await original_observation(value)
+
+        async def evaluation(value: MetricEvaluation, *, inputs: Any = ()) -> MetricEvaluation:
+            nonlocal calls
+            result = await original_evaluation(value, inputs=inputs)
+            if mode == "evaluation" and calls == 0:
+                calls += 1
+                raise psycopg.OperationalError("ambiguous commit")
+            return result
+
+        async def complete(
+            value: Any, *, finished_at: datetime, values: Any, artifacts: Any = ()
+        ) -> None:
+            nonlocal calls
+            await original_complete(
+                value, finished_at=finished_at, values=values, artifacts=artifacts
+            )
+            if mode == "complete" and calls == 0:
+                calls += 1
+                raise psycopg.OperationalError("ambiguous commit")
+
+        monkeypatch.setattr(writer, "insert_observation", observation)
+        monkeypatch.setattr(writer, "insert_metric_evaluation", evaluation)
+        monkeypatch.setattr(writer, "complete_metric_evaluation", complete)
+        monkeypatch.setattr(normalized, "upload_provider_transcript", lambda *_: _raw_artifact())
+        await normalized.dual_write(
+            writer=writer,
+            storage_client=object(),
+            bucket="private",
+            run_id=run_id,
+            dataset_id="stt-v1",
+            dataset_sha256=_SHA,
+            sample_id=f"sample-{mode}",
+            entry=type("Entry", (), {"provider": "provider", "model": "model"})(),
+            benchmark=Benchmark.STT,
+            results=[_dual_result(run_id)],
+            provider_error=None,
+            captured_at=_NOW,
+            transcript="hello",
+            db_retry_attempts=3,
+        )
+    finally:
+        await pool.close()
+
+    conn.autocommit = True
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT count(*) FROM benchmarks_v2.benchmark_observations WHERE sample_id = %s",
+            (f"sample-{mode}",),
+        )
+        row = cur.fetchone()
+        assert row is not None and row[0] == 1
+        cur.execute("SELECT count(*) FROM benchmarks_v2.observation_artifacts")
+        row = cur.fetchone()
+        assert row is not None and row[0] == 1
+        cur.execute("SELECT count(*) FROM benchmarks_v2.metric_evaluations")
+        row = cur.fetchone()
+        assert row is not None and row[0] == 1
+        cur.execute("SELECT count(*) FROM benchmarks_v2.metric_evaluation_inputs")
+        row = cur.fetchone()
+        assert row is not None and row[0] == 1
+        cur.execute(
+            "SELECT count(*), count(*) FILTER (WHERE value_role = 'primary') "
+            "FROM benchmarks_v2.metric_values"
+        )
+        row = cur.fetchone()
+        assert row == (4, 1)
+        cur.execute("SELECT status FROM benchmarks_v2.metric_evaluations")
+        row = cur.fetchone()
+        assert row is not None and row[0] == "succeeded"
+
+
+@pytest.mark.parametrize("mode", ["observation", "evaluation", "complete"])
+def test_dual_write_retries_ambiguous_database_operations(
+    pg_conn: psycopg.Connection[Any], monkeypatch: pytest.MonkeyPatch, mode: str
+) -> None:
+    _migrate(pg_conn)
+    import asyncio
+
+    asyncio.run(_run_dual_write_retry_case(pg_conn, monkeypatch, mode))
 
 
 def _wer_values(evaluation_id: Any) -> list[MetricValue]:

--- a/runner/tests/unit/test_normalized_dual_write.py
+++ b/runner/tests/unit/test_normalized_dual_write.py
@@ -484,36 +484,34 @@ class _RetryWriter(_Writer):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("exc", [PoolTimeout("busy"), psycopg.OperationalError("gone")])
-async def test_normalized_db_retry_does_not_repeat_upload(exc: BaseException) -> None:
+async def test_normalized_db_retry_does_not_repeat_upload(
+    exc: BaseException, monkeypatch: pytest.MonkeyPatch
+) -> None:
     writer = _RetryWriter(exc)
     uploads = 0
-    original = normalized.upload_provider_transcript
 
-    def upload(*args: object) -> ObservationArtifact:
+    def upload(*_args: object) -> ObservationArtifact:
         nonlocal uploads
         uploads += 1
         return _artifact(ObservationArtifactType.PROVIDER_TRANSCRIPT)
 
-    normalized.upload_provider_transcript = upload
-    try:
-        await normalized.dual_write(
-            writer=writer,
-            storage_client=object(),
-            bucket="b",
-            run_id=1,
-            dataset_id="d",
-            dataset_sha256="a" * 64,
-            sample_id="s",
-            entry=SimpleNamespace(provider="p", model="m"),
-            benchmark=Benchmark.STT,
-            results=[],
-            provider_error=None,
-            transcript="x",
-            db_semaphore=asyncio.Semaphore(3),
-            db_retry_attempts=3,
-        )
-    finally:
-        normalized.upload_provider_transcript = original
+    monkeypatch.setattr(normalized, "upload_provider_transcript", upload)
+    await normalized.dual_write(
+        writer=writer,
+        storage_client=object(),
+        bucket="b",
+        run_id=1,
+        dataset_id="d",
+        dataset_sha256="a" * 64,
+        sample_id="s",
+        entry=SimpleNamespace(provider="p", model="m"),
+        benchmark=Benchmark.STT,
+        results=[],
+        provider_error=None,
+        transcript="x",
+        db_semaphore=asyncio.Semaphore(3),
+        db_retry_attempts=3,
+    )
     assert writer.calls == 2 and uploads == 1
 
 
@@ -557,19 +555,23 @@ async def test_normalized_db_semaphore_caps_at_three() -> None:
 
     sem = asyncio.Semaphore(3)
     writer = Writer()
-    kwargs = dict(
-        writer=writer,
-        storage_client=object(),
-        bucket="b",
-        run_id=1,
-        dataset_id="d",
-        dataset_sha256="a" * 64,
-        entry=SimpleNamespace(provider="p", model="m"),
-        benchmark=Benchmark.STT,
-        results=[],
-        provider_error=None,
-        db_semaphore=sem,
-        db_retry_attempts=1,
-    )
-    await asyncio.gather(*(normalized.dual_write(sample_id=str(i), **kwargs) for i in range(8)))
+
+    async def write(index: int) -> None:
+        await normalized.dual_write(
+            writer=writer,
+            storage_client=object(),
+            bucket="b",
+            run_id=1,
+            dataset_id="d",
+            dataset_sha256="a" * 64,
+            sample_id=str(index),
+            entry=SimpleNamespace(provider="p", model="m"),
+            benchmark=Benchmark.STT,
+            results=[],
+            provider_error=None,
+            db_semaphore=sem,
+            db_retry_attempts=1,
+        )
+
+    await asyncio.gather(*(write(index) for index in range(8)))
     assert maximum == 3

--- a/runner/tests/unit/test_normalized_dual_write.py
+++ b/runner/tests/unit/test_normalized_dual_write.py
@@ -14,6 +14,7 @@ from uuid import UUID, uuid4
 import psycopg
 import pytest
 from psycopg_pool import PoolTimeout
+from structlog.testing import capture_logs
 
 from coval_bench.db.models import (
     Benchmark,
@@ -44,6 +45,9 @@ class _Writer:
         self.inputs: dict[UUID, list[MetricEvaluationInput]] = {}
         self.completed: dict[UUID, list[MetricValue]] = {}
         self.failed: dict[UUID, str] = {}
+
+    def pool_diagnostics(self) -> dict[str, int]:
+        return {"pool_size": 0}
 
     async def insert_observation(self, observation: Observation) -> Observation:
         observation_id = uuid4()
@@ -509,10 +513,38 @@ async def test_normalized_db_retry_does_not_repeat_upload(
         results=[],
         provider_error=None,
         transcript="x",
-        db_semaphore=asyncio.Semaphore(3),
         db_retry_attempts=3,
     )
     assert writer.calls == 2 and uploads == 1
+
+
+@pytest.mark.asyncio
+async def test_normalized_operational_error_retry_logs_pool_diagnostics(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    writer = _RetryWriter(psycopg.OperationalError("gone"))
+    monkeypatch.setattr("coval_bench.runner.retry.random.uniform", lambda *_: 0.0)
+    with capture_logs() as logs:
+        await normalized.dual_write(
+            writer=writer,
+            storage_client=object(),
+            bucket="b",
+            run_id=1,
+            dataset_id="d",
+            dataset_sha256="a" * 64,
+            sample_id="telemetry",
+            entry=SimpleNamespace(provider="p", model="m"),
+            benchmark=Benchmark.STT,
+            results=[],
+            provider_error=None,
+            db_retry_attempts=3,
+        )
+    retry = next(record for record in logs if record["event"] == "normalized_persistence_retry")
+    assert retry["exception_type"] == "OperationalError"
+    assert isinstance(retry["attempt_elapsed_ms"], int)
+    assert retry["attempt_elapsed_ms"] >= 0
+    assert retry["state_before"] == {"pool_size": 0}
+    assert retry["state_after"] == {"pool_size": 0}
 
 
 @pytest.mark.asyncio
@@ -532,46 +564,6 @@ async def test_normalized_runtime_error_and_cancellation_are_not_retried() -> No
                 benchmark=Benchmark.STT,
                 results=[],
                 provider_error=None,
-                db_semaphore=asyncio.Semaphore(3),
                 db_retry_attempts=3,
             )
         assert writer.calls == 1
-
-
-@pytest.mark.asyncio
-async def test_normalized_db_semaphore_caps_at_three() -> None:
-    active = 0
-    maximum = 0
-
-    class Writer(_Writer):
-        async def insert_observation(self, observation: Observation) -> Observation:
-            nonlocal active, maximum
-            active += 1
-            maximum = max(maximum, active)
-            await asyncio.sleep(0)
-            result = await super().insert_observation(observation)
-            active -= 1
-            return result
-
-    sem = asyncio.Semaphore(3)
-    writer = Writer()
-
-    async def write(index: int) -> None:
-        await normalized.dual_write(
-            writer=writer,
-            storage_client=object(),
-            bucket="b",
-            run_id=1,
-            dataset_id="d",
-            dataset_sha256="a" * 64,
-            sample_id=str(index),
-            entry=SimpleNamespace(provider="p", model="m"),
-            benchmark=Benchmark.STT,
-            results=[],
-            provider_error=None,
-            db_semaphore=sem,
-            db_retry_attempts=1,
-        )
-
-    await asyncio.gather(*(write(index) for index in range(8)))
-    assert maximum == 3

--- a/runner/tests/unit/test_normalized_dual_write.py
+++ b/runner/tests/unit/test_normalized_dual_write.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import wave
 from collections.abc import Sequence
 from datetime import UTC, datetime
@@ -10,7 +11,9 @@ from pathlib import Path
 from types import SimpleNamespace
 from uuid import UUID, uuid4
 
+import psycopg
 import pytest
+from psycopg_pool import PoolTimeout
 
 from coval_bench.db.models import (
     Benchmark,
@@ -414,3 +417,159 @@ async def test_s2s_uses_conversation_source_and_coval_executor() -> None:
     assert [(value.value_key, value.value) for value in writer.completed[evaluation_id]] == [
         ("primary", 500.0)
     ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("provider_error", ["", "   "])
+async def test_blank_provider_error_is_normalized(provider_error: str) -> None:
+    writer = _Writer()
+    await normalized.dual_write(
+        writer=writer,
+        storage_client=object(),
+        bucket="private",
+        run_id=1,
+        dataset_id="stt-v1",
+        dataset_sha256="a" * 64,
+        sample_id="sample",
+        entry=SimpleNamespace(provider="provider", model="model"),
+        benchmark=Benchmark.STT,
+        results=[_result(Benchmark.STT, Metric.TTFT, 1, "seconds")],
+        provider_error=provider_error,
+        timing_events={"ttft_seconds": 1},
+    )
+    observation = writer.observations[0]
+    assert observation.error is None
+    assert observation.status is ObservationStatus.SUCCEEDED
+    assert observation.failure_origin is None
+
+
+@pytest.mark.asyncio
+async def test_nonblank_provider_error_is_preserved() -> None:
+    writer = _Writer()
+    error = "  provider failed  "
+    await normalized.dual_write(
+        writer=writer,
+        storage_client=object(),
+        bucket="private",
+        run_id=1,
+        dataset_id="stt-v1",
+        dataset_sha256="a" * 64,
+        sample_id="sample",
+        entry=SimpleNamespace(provider="provider", model="model"),
+        benchmark=Benchmark.STT,
+        results=[
+            _result(
+                Benchmark.STT, Metric.TTFT, None, "seconds", status=ResultStatus.FAILED, error=error
+            )
+        ],
+        provider_error=error,
+        timing_events={"ttft_seconds": None},
+    )
+    assert writer.observations[0].error == error
+    assert writer.observations[0].status is ObservationStatus.FAILED
+
+
+class _RetryWriter(_Writer):
+    def __init__(self, exc: BaseException | None = None) -> None:
+        super().__init__()
+        self.calls = 0
+        self.exc = exc
+
+    async def insert_observation(self, observation: Observation) -> Observation:
+        self.calls += 1
+        if self.calls == 1 and self.exc is not None:
+            raise self.exc
+        return await super().insert_observation(observation)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("exc", [PoolTimeout("busy"), psycopg.OperationalError("gone")])
+async def test_normalized_db_retry_does_not_repeat_upload(exc: BaseException) -> None:
+    writer = _RetryWriter(exc)
+    uploads = 0
+    original = normalized.upload_provider_transcript
+
+    def upload(*args: object) -> ObservationArtifact:
+        nonlocal uploads
+        uploads += 1
+        return _artifact(ObservationArtifactType.PROVIDER_TRANSCRIPT)
+
+    normalized.upload_provider_transcript = upload
+    try:
+        await normalized.dual_write(
+            writer=writer,
+            storage_client=object(),
+            bucket="b",
+            run_id=1,
+            dataset_id="d",
+            dataset_sha256="a" * 64,
+            sample_id="s",
+            entry=SimpleNamespace(provider="p", model="m"),
+            benchmark=Benchmark.STT,
+            results=[],
+            provider_error=None,
+            transcript="x",
+            db_semaphore=asyncio.Semaphore(3),
+            db_retry_attempts=3,
+        )
+    finally:
+        normalized.upload_provider_transcript = original
+    assert writer.calls == 2 and uploads == 1
+
+
+@pytest.mark.asyncio
+async def test_normalized_runtime_error_and_cancellation_are_not_retried() -> None:
+    for exc in (RuntimeError("bad"), asyncio.CancelledError()):
+        writer = _RetryWriter(exc)
+        with pytest.raises(type(exc)):
+            await normalized.dual_write(
+                writer=writer,
+                storage_client=object(),
+                bucket="b",
+                run_id=1,
+                dataset_id="d",
+                dataset_sha256="a" * 64,
+                sample_id="s",
+                entry=SimpleNamespace(provider="p", model="m"),
+                benchmark=Benchmark.STT,
+                results=[],
+                provider_error=None,
+                db_semaphore=asyncio.Semaphore(3),
+                db_retry_attempts=3,
+            )
+        assert writer.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_normalized_db_semaphore_caps_at_three() -> None:
+    active = 0
+    maximum = 0
+
+    class Writer(_Writer):
+        async def insert_observation(self, observation: Observation) -> Observation:
+            nonlocal active, maximum
+            active += 1
+            maximum = max(maximum, active)
+            await asyncio.sleep(0)
+            result = await super().insert_observation(observation)
+            active -= 1
+            return result
+
+    sem = asyncio.Semaphore(3)
+    writer = Writer()
+    kwargs = dict(
+        writer=writer,
+        storage_client=object(),
+        bucket="b",
+        run_id=1,
+        dataset_id="d",
+        dataset_sha256="a" * 64,
+        entry=SimpleNamespace(provider="p", model="m"),
+        benchmark=Benchmark.STT,
+        results=[],
+        provider_error=None,
+        db_semaphore=sem,
+        db_retry_attempts=1,
+    )
+    await asyncio.gather(*(normalized.dual_write(sample_id=str(i), **kwargs) for i in range(8)))
+    assert maximum == 3

--- a/runner/tests/unit/test_orchestrator.py
+++ b/runner/tests/unit/test_orchestrator.py
@@ -43,6 +43,7 @@ import structlog
 from posthog import Posthog
 from psycopg_pool import PoolTimeout
 from pydantic import SecretStr
+from structlog.testing import capture_logs
 
 from coval_bench.config import Settings
 from coval_bench.db.models import Benchmark, Result, ResultStatus, Run, RunStatus
@@ -175,6 +176,7 @@ def _make_stub_writer(run: Run) -> MagicMock:
     writer.refresh_stats_matviews = AsyncMock()
     writer.refresh_bucket = AsyncMock()
     writer.refresh_metric_values_bucket = AsyncMock()
+    writer.pool_diagnostics = MagicMock(return_value={"pool_size": 0})
     return writer
 
 
@@ -697,13 +699,45 @@ async def test_retry_exhausted() -> None:
 
 
 @pytest.mark.asyncio
+async def test_retry_telemetry_captures_diagnostics_and_ignores_callback_errors() -> None:
+    calls = 0
+
+    async def flaky() -> None:
+        nonlocal calls
+        calls += 1
+        raise PoolTimeout("busy")
+
+    def diagnostics() -> dict[str, object]:
+        if calls == 1:
+            raise RuntimeError("diagnostics unavailable")
+        return {"pool_available": 2, "pool_timeout_ms": 30_000}
+
+    with capture_logs() as logs, pytest.raises(PoolTimeout):
+        await with_retry(
+            flaky,
+            max_attempts=2,
+            base_delay_s=0,
+            max_delay_s=0,
+            retry_on=(PoolTimeout,),
+            retry_state=diagnostics,
+        )
+    assert calls == 2
+    assert [record["event"] for record in logs] == ["provider_call_retry", "retry_exhausted"]
+    for record in logs:
+        assert record["exception_type"] == "PoolTimeout"
+        assert isinstance(record["attempt_elapsed_ms"], int)
+        assert "state_before" in record and "state_after" in record
+    assert logs[1]["state_after"] == {"pool_available": 2, "pool_timeout_ms": 30_000}
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("prefix", ["stt", "tts"])
 async def test_persist_legacy_results_retries_pool_timeout(prefix: str) -> None:
     writer = MagicMock()
     writer.record_results = AsyncMock(side_effect=[PoolTimeout("busy"), None])
     captured = datetime(2026, 1, 1, tzinfo=UTC)
     rows = [MagicMock()]
-    await _persist_legacy_results(writer, rows, captured, asyncio.Semaphore(3), prefix)
+    await _persist_legacy_results(writer, rows, captured, prefix)
     assert writer.record_results.await_count == 2
     assert all(
         call.kwargs["created_at"] == captured for call in writer.record_results.await_args_list
@@ -718,7 +752,8 @@ async def test_persist_legacy_results_does_not_retry_operational_error(prefix: s
     writer.record_results = AsyncMock(side_effect=error)
     captured = datetime(2026, 1, 1, tzinfo=UTC)
     with pytest.raises(psycopg.OperationalError):
-        await _persist_legacy_results(writer, [MagicMock()], captured, asyncio.Semaphore(3), prefix)
+        writer.pool_diagnostics = MagicMock(return_value={})
+        await _persist_legacy_results(writer, [MagicMock()], captured, prefix)
     assert writer.record_results.await_count == 1
 
 
@@ -736,7 +771,6 @@ async def test_concurrency_cap(audio_file: Path, settings: Settings) -> None:
     current_normalized_concurrent = 0
     persistence_current = 0
     persistence_max = 0
-    semaphore_ids: set[int] = set()
     lock = asyncio.Lock()
 
     async def tracked_measure_ttft(*args: Any, **kwargs: Any) -> TranscriptionResult:
@@ -756,20 +790,17 @@ async def test_concurrency_cap(audio_file: Path, settings: Settings) -> None:
             current_normalized_concurrent, \
             persistence_current, \
             persistence_max
-        db_sem = kwargs["db_semaphore"]
-        semaphore_ids.add(id(db_sem))
-        async with db_sem:
-            async with lock:
-                current_normalized_concurrent += 1
-                persistence_current += 1
-                max_normalized_concurrent = max(
-                    max_normalized_concurrent, current_normalized_concurrent
-                )
-                persistence_max = max(persistence_max, persistence_current)
-            await asyncio.sleep(0)
-            async with lock:
-                current_normalized_concurrent -= 1
-                persistence_current -= 1
+        async with lock:
+            current_normalized_concurrent += 1
+            persistence_current += 1
+            max_normalized_concurrent = max(
+                max_normalized_concurrent, current_normalized_concurrent
+            )
+            persistence_max = max(persistence_max, persistence_current)
+        await asyncio.sleep(0)
+        async with lock:
+            current_normalized_concurrent -= 1
+            persistence_current -= 1
 
     provider_inst = MagicMock()
     provider_inst.measure_ttft = tracked_measure_ttft
@@ -827,10 +858,10 @@ async def test_concurrency_cap(audio_file: Path, settings: Settings) -> None:
     assert max_normalized_concurrent <= 8, (
         f"max normalized concurrent was {max_normalized_concurrent}"
     )
-    assert persistence_max == 3
-    assert len(semaphore_ids) == 1
+    assert persistence_max <= 8
     assert dual_write.await_count == provider_cls.call_count
     assert dual_write.await_count > 8
+    assert all(call.kwargs["db_retry_attempts"] == 3 for call in dual_write.await_args_list)
     assert summary.total_results >= 50 * 3
 
 
@@ -3451,6 +3482,7 @@ async def test_tts_normalized_failure_preserves_audio_until_write_and_legacy_res
     normalized_call = dual_write.await_args
     assert legacy_call is not None
     assert normalized_call is not None
+    assert normalized_call.kwargs["db_retry_attempts"] == 3
     assert legacy_call.args == (results,)
     assert legacy_call.kwargs["created_at"] == normalized_call.kwargs["captured_at"]
 

--- a/runner/tests/unit/test_orchestrator.py
+++ b/runner/tests/unit/test_orchestrator.py
@@ -37,9 +37,11 @@ from unittest.mock import AsyncMock, MagicMock, create_autospec, patch
 
 import httpx
 import openai
+import psycopg
 import pytest
 import structlog
 from posthog import Posthog
+from psycopg_pool import PoolTimeout
 from pydantic import SecretStr
 
 from coval_bench.config import Settings
@@ -49,6 +51,7 @@ from coval_bench.registries import MODEL_REGISTRY, RegisteredModel, Source
 from coval_bench.runner.orchestrator import (
     RunSummary,
     _dead_providers,
+    _persist_legacy_results,
     _run_stt_item,
     _run_tts_item,
     _stt_silent_failure,
@@ -693,6 +696,32 @@ async def test_retry_exhausted() -> None:
     assert call_count == 3
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize("prefix", ["stt", "tts"])
+async def test_persist_legacy_results_retries_pool_timeout(prefix: str) -> None:
+    writer = MagicMock()
+    writer.record_results = AsyncMock(side_effect=[PoolTimeout("busy"), None])
+    captured = datetime(2026, 1, 1, tzinfo=UTC)
+    rows = [MagicMock()]
+    await _persist_legacy_results(writer, rows, captured, asyncio.Semaphore(3), prefix)
+    assert writer.record_results.await_count == 2
+    assert all(
+        call.kwargs["created_at"] == captured for call in writer.record_results.await_args_list
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("prefix", ["stt", "tts"])
+async def test_persist_legacy_results_does_not_retry_operational_error(prefix: str) -> None:
+    writer = MagicMock()
+    error = psycopg.OperationalError("disconnect")
+    writer.record_results = AsyncMock(side_effect=error)
+    captured = datetime(2026, 1, 1, tzinfo=UTC)
+    with pytest.raises(psycopg.OperationalError):
+        await _persist_legacy_results(writer, [MagicMock()], captured, asyncio.Semaphore(3), prefix)
+    assert writer.record_results.await_count == 1
+
+
 # ---------------------------------------------------------------------------
 # 6. test_concurrency_cap
 # ---------------------------------------------------------------------------
@@ -705,6 +734,9 @@ async def test_concurrency_cap(audio_file: Path, settings: Settings) -> None:
     current_concurrent = 0
     max_normalized_concurrent = 0
     current_normalized_concurrent = 0
+    persistence_current = 0
+    persistence_max = 0
+    semaphore_ids: set[int] = set()
     lock = asyncio.Lock()
 
     async def tracked_measure_ttft(*args: Any, **kwargs: Any) -> TranscriptionResult:
@@ -718,16 +750,26 @@ async def test_concurrency_cap(audio_file: Path, settings: Settings) -> None:
             current_concurrent -= 1
         return _good_transcription()
 
-    async def tracked_dual_write(**_kwargs: Any) -> None:
-        nonlocal max_normalized_concurrent, current_normalized_concurrent
-        async with lock:
-            current_normalized_concurrent += 1
-            max_normalized_concurrent = max(
-                max_normalized_concurrent, current_normalized_concurrent
-            )
-        await asyncio.sleep(0)
-        async with lock:
-            current_normalized_concurrent -= 1
+    async def tracked_dual_write(**kwargs: Any) -> None:
+        nonlocal \
+            max_normalized_concurrent, \
+            current_normalized_concurrent, \
+            persistence_current, \
+            persistence_max
+        db_sem = kwargs["db_semaphore"]
+        semaphore_ids.add(id(db_sem))
+        async with db_sem:
+            async with lock:
+                current_normalized_concurrent += 1
+                persistence_current += 1
+                max_normalized_concurrent = max(
+                    max_normalized_concurrent, current_normalized_concurrent
+                )
+                persistence_max = max(persistence_max, persistence_current)
+            await asyncio.sleep(0)
+            async with lock:
+                current_normalized_concurrent -= 1
+                persistence_current -= 1
 
     provider_inst = MagicMock()
     provider_inst.measure_ttft = tracked_measure_ttft
@@ -739,6 +781,19 @@ async def test_concurrency_cap(audio_file: Path, settings: Settings) -> None:
 
     run = _make_run()
     writer = _make_stub_writer(run)
+    original_record = writer.record_results
+
+    async def tracked_record(results: Any, **kwargs: Any) -> None:
+        nonlocal persistence_current, persistence_max
+        async with lock:
+            persistence_current += 1
+            persistence_max = max(persistence_max, persistence_current)
+        await asyncio.sleep(0)
+        async with lock:
+            persistence_current -= 1
+        await original_record(results, **kwargs)
+
+    writer.record_results = AsyncMock(side_effect=tracked_record)
     enabled = settings.model_copy(
         update={
             "benchmark_artifact_bucket": "private-artifacts",
@@ -772,6 +827,8 @@ async def test_concurrency_cap(audio_file: Path, settings: Settings) -> None:
     assert max_normalized_concurrent <= 8, (
         f"max normalized concurrent was {max_normalized_concurrent}"
     )
+    assert persistence_max == 3
+    assert len(semaphore_ids) == 1
     assert dual_write.await_count == provider_cls.call_count
     assert dual_write.await_count > 8
     assert summary.total_results >= 50 * 3

--- a/runner/tests/unit/test_s2s_fetch.py
+++ b/runner/tests/unit/test_s2s_fetch.py
@@ -1877,6 +1877,9 @@ async def test_ingest_run_dual_writes_one_observation_per_conversation(
     assert calls["R1/s1"]["dataset_sha256"] == hashlib.sha256(b"test-set:persona").hexdigest()
     assert calls["R1/s1"]["executor"] is MetricExecutor.COVAL_API
     assert calls["R1/s1"]["captured_at"] == writer.record_results.await_args.kwargs["created_at"]
+    for kwargs in calls.values():
+        assert "db_retry_attempts" not in kwargs
+        assert not any("semaphore" in key for key in kwargs)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- remove the application-level persistence semaphore; production evidence tied the observed pool timeouts to one concurrent DDL-lock incident, and the driver pool already queues acquisition
- retry only evidence-supported, replay-safe failures: legacy persistence retries `PoolTimeout`; normalized persistence retries `PoolTimeout` and `psycopg.OperationalError`
- keep normalized artifact upload outside retries, preserve a stable `captured_at`, and normalize blank provider errors
- add public pool-state diagnostics to retry/exhaustion logs so future incidents distinguish queued demand, blocked/unavailable connections, and connection failures
- leave S2S enablement and read-cutover behavior unchanged

## Incident evidence
- all 287 production `PoolTimeout` events found in the preceding 30 days occurred in one roughly 157-second window across four concurrent benchmark executions
- the same window contained the `20260901_0025_add_llm_benchmark.py` DDL deadlock; migration-locking remediation landed in #580 and #582
- separate production failures support the retained changes: 14 blank/whitespace provider-error validation failures and 5 normalized connection-loss `OperationalError` failures

## Testing
- `182 passed` — focused normalized dual-write, orchestrator, and S2S unit tests
- Ruff check and format check passed on all nine changed files
- `mypy --strict src tests` passed across 322 source files
- `git diff --check` passed
- 48 PostgreSQL writer tests collect, including composed cases for failure before observation acquisition and ambiguous commits after evaluation insert and completion
- each composed case uses the real writer path and fresh readback assertions for one observation/artifact/evaluation/input, four WER values with one primary, and a succeeded evaluation
- independent Tier 3 review: PASS, no findings

## Known limitations / rollout
- this host does not have `pg_ctl`, so CI is the first runtime execution of the new PostgreSQL-composed cases
- exhausted retries can still leave a normalized gap; eliminating that residual requires an outbox or reconciliation mechanism and is outside this PR
- after deployment, restart the seven-day clean-observation window before deciding on read cutover
- this PR does not enable S2S, run a backfill, switch normalized reads, or deploy production changes

Linear: https://linear.app/coval/issue/BENCH-797/prevent-normalized-stttts-dual-write-gaps
