### PR TITLE
[BENCH-788] Add the sync-coval command for the Phonely Coval agent

### DIFF
--- a/runner/src/coval_bench/__main__.py
+++ b/runner/src/coval_bench/__main__.py
@@ -20,6 +20,7 @@ import click
 
 from coval_bench import __version__
 from coval_bench.db.cli import db_check, db_migrate
+from coval_bench.llm.coval_agent import sync_coval
 from coval_bench.migrations.backfill_normalized_s2s_storage import (
     backfill_normalized_s2s_storage_cli,
 )
@@ -117,6 +118,7 @@ migrate.add_command(import_legacy_cli, name="import-legacy")
 # backing its own Cloud Run job rather than a `run --kind` value.
 cli.add_command(fetch_s2s, name="fetch-s2s")
 cli.add_command(fetch_llm, name="fetch-llm")
+cli.add_command(sync_coval, name="sync-coval")
 cli.add_command(pull_contract, name="pull-contract")
 cli.add_command(platform_assets, name="platform-assets")
 

--- a/runner/src/coval_bench/config.py
+++ b/runner/src/coval_bench/config.py
@@ -177,6 +177,8 @@ class Settings(BaseSettings):
     phonely_agent_id: str | None = None
     # Bearer secret Coval presents to the proxy; unset fails closed with 503.
     llm_proxy_secret: SecretStr | None = None
+    # Public base URL of the API service, for sync-coval on a laptop; never deployed.
+    llm_proxy_public_url: str | None = None
     coval_api_base: str = "https://api.coval.dev/v1"
     # The S2S latency metric id + per-provider Coval agent ids (opaque, not secret).
     coval_s2s_latency_metric_id: str | None = None

--- a/runner/src/coval_bench/llm/coval_agent.py
+++ b/runner/src/coval_bench/llm/coval_agent.py
@@ -1,0 +1,251 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""The Coval side of the Phonely text agent, defined in code and pushed idempotently."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any, Self
+
+import click
+import httpx
+from pydantic import BaseModel, SecretStr
+
+from coval_bench.config import Settings, get_settings
+from coval_bench.platform_assets import COVAL_API_BASE, COVAL_API_KEY, CovalClient, SyncError, plan
+from coval_bench.variants.platforms import redact
+
+CUSTOMER_AGENT_ID = "benchmarks-phonely-text"
+DISPLAY_NAME = "Benchmarks: Phonely text agent"
+# The public API rejects MODEL_TYPE_TEXT; CHAT is the HTTP text simulator.
+MODEL_TYPE = "MODEL_TYPE_CHAT"
+RUN_NAME = "benchmarks-phonely-text-daily"
+CLEAN_DENTAL_PERSONAS = ("PN3xgmsqeLDjsNNEA2e55e", "9ATy64zKXxSUaVWb5YnQtd")
+SCHEDULE_EXPRESSION = "cron(0 13 * * ? *)"
+SCHEDULE_TIMEZONE = "UTC"
+INPUT_TEMPLATE = (
+    '{"model": "{{session_id}}", "messages": {{messages}}, '
+    '"simulation_id": "{{simulation_output_id}}"}'
+)
+# PATCH replaces metadata wholesale, so it is reconciled as one value.
+MANAGED = ("display_name", "metadata", "test_set_ids")
+
+
+class CovalTextAgentDefinition(BaseModel, frozen=True):
+    proxy_url: str
+    proxy_secret: SecretStr
+    test_set_id: str
+    instruction_metric_id: str
+
+    @classmethod
+    def from_settings(cls, settings: Settings, *, test_set_id: str | None = None) -> Self:
+        proxy_url = settings.llm_proxy_public_url
+        proxy_secret = settings.llm_proxy_secret
+        dental = test_set_id or settings.coval_s2s_dental_test_set_id
+        metric = settings.coval_s2s_instruction_metric_id
+        missing = [
+            name
+            for name, value in (
+                ("llm_proxy_public_url", proxy_url),
+                ("llm_proxy_secret", proxy_secret),
+                ("coval_s2s_dental_test_set_id", dental),
+                ("coval_s2s_instruction_metric_id", metric),
+            )
+            if not value
+        ]
+        if missing or proxy_url is None or proxy_secret is None or not dental or not metric:
+            raise SyncError(f"sync-coval needs {', '.join(missing)} set")
+        return cls(
+            proxy_url=proxy_url.rstrip("/"),
+            proxy_secret=proxy_secret,
+            test_set_id=dental,
+            instruction_metric_id=metric,
+        )
+
+    def agent_body(self) -> dict[str, Any]:
+        return {
+            "display_name": DISPLAY_NAME,
+            "customer_agent_id": CUSTOMER_AGENT_ID,
+            "model_type": MODEL_TYPE,
+            "metadata": {
+                "chat_endpoint": f"{self.proxy_url}/llm/phonely/chat",
+                "initialization_endpoint": f"{self.proxy_url}/llm/phonely/session",
+                "initialization_payload": "{}",
+                "authorization_header": f"Bearer {self.proxy_secret.get_secret_value()}",
+                "input_template": INPUT_TEMPLATE,
+                "response_message_path": "choices[0].message.content",
+                "response_format": "chat_completions",
+                "response_stream_format": "none",
+                "strip_message_timestamps": True,
+                "tool_call_extraction": {
+                    "enabled": True,
+                    "tool_calls_path": "choices[].message.tool_calls[]",
+                    "tool_call_mappings": {
+                        "id": "id",
+                        "name": "function.name",
+                        "arguments": "function.arguments",
+                    },
+                },
+            },
+            "test_set_ids": [self.test_set_id],
+        }
+
+    def redacted_body(self) -> dict[str, Any]:
+        found: list[str] = []
+        redacted: dict[str, Any] = redact(self.agent_body(), found)
+        return redacted
+
+    def run_template_body(self, agent_id: str) -> dict[str, Any]:
+        return {
+            "display_name": RUN_NAME,
+            "agent_id": agent_id,
+            "persona_ids": list(CLEAN_DENTAL_PERSONAS),
+            "test_set_id": self.test_set_id,
+            "metric_ids": [self.instruction_metric_id],
+            "options": {"iteration_count": 1},
+        }
+
+
+def scheduled_run_body(run_template_id: str) -> dict[str, Any]:
+    return {
+        "display_name": RUN_NAME,
+        "run_template_id": run_template_id,
+        "schedule_expression": SCHEDULE_EXPRESSION,
+        "schedule_timezone": SCHEDULE_TIMEZONE,
+        "enabled": True,
+    }
+
+
+class CovalTextClient(CovalClient):
+    def __enter__(self) -> Self:
+        return self
+
+    def find_agent(self, customer_agent_id: str) -> dict[str, Any] | None:
+        by_name = None
+        for agent in self._pages("/agents", "agents"):
+            if agent.get("customer_agent_id") == customer_agent_id:
+                return agent
+            if by_name is None and agent.get("display_name") == DISPLAY_NAME:
+                by_name = agent
+        return by_name
+
+    def test_set_agent_ids(self, test_set_id: str) -> set[str]:
+        return {
+            str(agent["id"])
+            for agent in self._pages(f"/test-sets/{test_set_id}/agents", "agents")
+            if agent.get("id")
+        }
+
+    def add_test_set_agents(self, test_set_id: str, agent_ids: list[str]) -> None:
+        self._request("POST", f"/test-sets/{test_set_id}/agents:add", {"agent_ids": agent_ids})
+
+    def find_run_template(self, display_name: str) -> dict[str, Any] | None:
+        for template in self._pages("/run-templates", "run_templates"):
+            if template.get("display_name") == display_name:
+                return template
+        return None
+
+    def create_run_template(self, body: dict[str, Any]) -> dict[str, Any]:
+        payload = self._request("POST", "/run-templates", body)
+        template = payload.get("run_template")
+        return template if isinstance(template, dict) else payload
+
+    def find_scheduled_run(self, run_template_id: str) -> dict[str, Any] | None:
+        for scheduled in self._pages("/scheduled-runs", "scheduled_runs"):
+            if scheduled.get("run_template_id") == run_template_id:
+                return scheduled
+        return None
+
+    def create_scheduled_run(self, body: dict[str, Any]) -> dict[str, Any]:
+        payload = self._request("POST", "/scheduled-runs", body)
+        scheduled = payload.get("scheduled_run")
+        return scheduled if isinstance(scheduled, dict) else payload
+
+
+@dataclass
+class SyncResult:
+    agent_id: str = ""
+    actions: list[str] = field(default_factory=list)
+
+
+def sync(
+    client: CovalTextClient, definition: CovalTextAgentDefinition, *, dry_run: bool = False
+) -> SyncResult:
+    """Find-or-create the agent, its test-set link, run template, and schedule."""
+    result = SyncResult()
+    wanted = definition.agent_body()
+    live = client.find_agent(CUSTOMER_AGENT_ID)
+    if live is None:
+        result.actions.append("agent: create")
+        if dry_run:
+            result.actions.append("test set: attach")
+            result.actions.append("run template: create")
+            result.actions.append("scheduled run: create")
+            return result
+        result.agent_id = str(client.create_agent(wanted)["id"])
+    else:
+        if live.get("model_type") != MODEL_TYPE:
+            raise SyncError(
+                f"coval agent {live.get('id')} is {live.get('model_type')!r}, not {MODEL_TYPE}; "
+                "model_type cannot be patched, so this record is not ours to reconcile"
+            )
+        result.agent_id = str(live["id"])
+        drift = plan(live, {path: wanted[path] for path in MANAGED})
+        if drift.update:
+            result.actions.append(f"agent: patch {sorted(drift.update)}")
+            if not dry_run:
+                client.update_agent(result.agent_id, {path: wanted[path] for path in drift.update})
+        else:
+            result.actions.append("agent: unchanged")
+
+    if result.agent_id in client.test_set_agent_ids(definition.test_set_id):
+        result.actions.append("test set: attached")
+    else:
+        result.actions.append("test set: attach")
+        if not dry_run:
+            client.add_test_set_agents(definition.test_set_id, [result.agent_id])
+
+    template = client.find_run_template(RUN_NAME)
+    if template is None:
+        result.actions.append("run template: create")
+        if dry_run:
+            result.actions.append("scheduled run: create")
+            return result
+        template = client.create_run_template(definition.run_template_body(result.agent_id))
+    else:
+        result.actions.append("run template: exists")
+    template_id = str(template["id"])
+
+    if client.find_scheduled_run(template_id) is None:
+        result.actions.append("scheduled run: create")
+        if not dry_run:
+            client.create_scheduled_run(scheduled_run_body(template_id))
+    else:
+        result.actions.append("scheduled run: exists")
+    return result
+
+
+@click.command(name="sync-coval")
+@click.option(
+    "--dry-run", is_flag=True, default=False, help="Report what would change; write nothing."
+)
+@click.option("--test-set-id", default=None, help="Override coval_s2s_dental_test_set_id.")
+@click.option(
+    "--coval-api-base", envvar="COVAL_API_BASE", default=COVAL_API_BASE, show_default=True
+)
+def sync_coval(dry_run: bool, test_set_id: str | None, coval_api_base: str) -> None:
+    """Create or reconcile the Coval agent, test-set link, run template, and daily schedule
+    for the Phonely text agent. Laptop tool; prints the agent id the fetch job needs."""
+    try:
+        definition = CovalTextAgentDefinition.from_settings(get_settings(), test_set_id=test_set_id)
+        if dry_run:
+            click.echo(json.dumps(definition.redacted_body(), indent=2, sort_keys=True))
+        with CovalTextClient(COVAL_API_KEY.resolve(), coval_api_base) as client:
+            result = sync(client, definition, dry_run=dry_run)
+    except (SyncError, RuntimeError, httpx.HTTPError) as exc:
+        raise click.ClickException(str(exc)) from exc
+    for action in result.actions:
+        click.echo(action)
+    click.echo(f"COVAL_LLM_PHONELY_AGENT_ID={result.agent_id or '<created on apply>'}")

--- a/runner/tests/unit/test_coval_agent_sync.py
+++ b/runner/tests/unit/test_coval_agent_sync.py
@@ -1,0 +1,229 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""The sync-coval command and the Phonely text agent it defines."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import httpx
+import pytest
+from click.testing import CliRunner
+from pydantic import SecretStr
+
+from coval_bench.config import Settings
+from coval_bench.llm import coval_agent
+from coval_bench.llm.coval_agent import (
+    CUSTOMER_AGENT_ID,
+    RUN_NAME,
+    CovalTextAgentDefinition,
+    CovalTextClient,
+    sync,
+    sync_coval,
+)
+from coval_bench.platform_assets import SyncError
+
+SECRET = "proxy-secret-value"  # noqa: S105
+DEFINITION = CovalTextAgentDefinition(
+    proxy_url="https://api.example.com",
+    proxy_secret=SecretStr(SECRET),
+    test_set_id="TSDENTAL",
+    instruction_metric_id="M" * 22,
+)
+
+
+def _state(**overrides: Any) -> dict[str, Any]:
+    state: dict[str, Any] = {
+        "agents": [],
+        "test_set_agents": [],
+        "run_templates": [],
+        "scheduled_runs": [],
+        "writes": [],
+    }
+    state.update(overrides)
+    return state
+
+
+def _client(state: dict[str, Any]) -> CovalTextClient:
+    def handler(request: httpx.Request) -> httpx.Response:
+        path = request.url.path.removeprefix("/v1")
+        body: dict[str, Any] = json.loads(request.content) if request.content else {}
+        if request.method == "GET":
+            state_key, response_key = {
+                "/agents": ("agents", "agents"),
+                "/test-sets/TSDENTAL/agents": ("test_set_agents", "agents"),
+                "/run-templates": ("run_templates", "run_templates"),
+                "/scheduled-runs": ("scheduled_runs", "scheduled_runs"),
+            }[path]
+            return httpx.Response(200, json={response_key: state[state_key]})
+        state["writes"].append((path, body))
+        if path == "/agents":
+            created = {**body, "id": "A" * 22}
+            state["agents"].append(created)
+            return httpx.Response(200, json={"agent": created})
+        if path.startswith("/agents/"):
+            return httpx.Response(200, json={"agent": {**state["agents"][0], **body}})
+        if path == "/test-sets/TSDENTAL/agents:add":
+            state["test_set_agents"].extend({"id": i} for i in body["agent_ids"])
+            return httpx.Response(200, json={})
+        if path == "/run-templates":
+            created = {**body, "id": "T" * 22}
+            state["run_templates"].append(created)
+            return httpx.Response(200, json={"run_template": created})
+        if path == "/scheduled-runs":
+            return httpx.Response(200, json={"scheduled_run": {**body, "id": "S" * 22}})
+        return httpx.Response(
+            400, json={"error": {"code": 400, "status": "INVALID_ARGUMENT", "message": path}}
+        )
+
+    return CovalTextClient("coval-key", "https://api.coval.dev/v1", httpx.MockTransport(handler))
+
+
+def test_body_renders_the_proxy_contract_and_survives_covals_substitution() -> None:
+    body = DEFINITION.agent_body()
+    assert body["customer_agent_id"] == CUSTOMER_AGENT_ID
+    assert body["model_type"] == "MODEL_TYPE_CHAT"
+    assert body["metadata"]["chat_endpoint"] == "https://api.example.com/llm/phonely/chat"
+    assert body["metadata"]["authorization_header"] == f"Bearer {SECRET}"
+    substituted = (
+        body["metadata"]["input_template"]
+        .replace("{{session_id}}", "call-1")
+        .replace("{{messages}}", '[{"role": "user", "content": "hi"}]')
+        .replace("{{simulation_output_id}}", "sim-1")
+    )
+    assert json.loads(substituted) == {
+        "model": "call-1",
+        "messages": [{"role": "user", "content": "hi"}],
+        "simulation_id": "sim-1",
+    }
+    assert SECRET not in json.dumps(DEFINITION.redacted_body())
+
+
+def test_from_settings_names_every_missing_setting() -> None:
+    with pytest.raises(SyncError, match="llm_proxy_public_url, llm_proxy_secret"):
+        CovalTextAgentDefinition.from_settings(
+            Settings(coval_s2s_dental_test_set_id="T", coval_s2s_instruction_metric_id="M")
+        )
+    definition = CovalTextAgentDefinition.from_settings(
+        Settings(
+            llm_proxy_public_url="https://api.example.com/",
+            llm_proxy_secret=SecretStr(SECRET),
+            coval_s2s_instruction_metric_id="M",
+        ),
+        test_set_id="T",
+    )
+    assert (definition.proxy_url, definition.test_set_id) == ("https://api.example.com", "T")
+
+
+def test_sync_creates_everything_when_absent() -> None:
+    state = _state()
+    with _client(state) as client:
+        result = sync(client, DEFINITION)
+
+    assert result.agent_id == "A" * 22
+    assert result.actions == [
+        "agent: create",
+        "test set: attach",
+        "run template: create",
+        "scheduled run: create",
+    ]
+    assert [path for path, _ in state["writes"]] == [
+        "/agents",
+        "/test-sets/TSDENTAL/agents:add",
+        "/run-templates",
+        "/scheduled-runs",
+    ]
+    template = state["writes"][2][1]
+    assert template["agent_id"] == "A" * 22
+    assert template["persona_ids"] == list(coval_agent.CLEAN_DENTAL_PERSONAS)
+    assert template["metric_ids"] == ["M" * 22]
+    assert state["writes"][3][1]["schedule_expression"] == "cron(0 13 * * ? *)"
+
+
+def test_sync_patches_drifted_metadata_wholesale_and_leaves_the_rest() -> None:
+    live = {**DEFINITION.agent_body(), "id": "A"}
+    live["metadata"] = {**live["metadata"], "authorization_header": "Bearer stale"}
+    state = _state(
+        agents=[live],
+        test_set_agents=[{"id": "A"}],
+        run_templates=[{"id": "T", "display_name": RUN_NAME}],
+        scheduled_runs=[{"id": "S", "run_template_id": "T"}],
+    )
+    with _client(state) as client:
+        result = sync(client, DEFINITION)
+
+    assert result.actions == [
+        "agent: patch ['metadata']",
+        "test set: attached",
+        "run template: exists",
+        "scheduled run: exists",
+    ]
+    assert state["writes"] == [("/agents/A", {"metadata": DEFINITION.agent_body()["metadata"]})]
+
+
+def test_sync_is_a_no_op_once_converged_and_matches_by_display_name_fallback() -> None:
+    live = {**DEFINITION.agent_body(), "id": "A", "customer_agent_id": ""}
+    state = _state(
+        agents=[live],
+        test_set_agents=[{"id": "A"}],
+        run_templates=[{"id": "T", "display_name": RUN_NAME}],
+        scheduled_runs=[{"id": "S", "run_template_id": "T"}],
+    )
+    with _client(state) as client:
+        result = sync(client, DEFINITION)
+    assert result.agent_id == "A"
+    assert result.actions[0] == "agent: unchanged"
+    assert state["writes"] == []
+
+
+def test_sync_dry_run_reports_and_writes_nothing() -> None:
+    state = _state()
+    with _client(state) as client:
+        result = sync(client, DEFINITION, dry_run=True)
+    assert result.agent_id == ""
+    assert result.actions[0] == "agent: create"
+    assert state["writes"] == []
+
+
+def test_sync_refuses_a_foreign_model_type_and_surfaces_api_errors() -> None:
+    live = {**DEFINITION.agent_body(), "id": "A", "model_type": "MODEL_TYPE_VOICE"}
+    with (
+        _client(_state(agents=[live])) as client,
+        pytest.raises(SyncError, match="MODEL_TYPE_VOICE"),
+    ):
+        sync(client, DEFINITION)
+
+    with (
+        _client(_state(test_set_agents=None)) as client,
+        pytest.raises(SyncError, match="INVALID_ARGUMENT") as failure,
+    ):
+        client.add_test_set_agents("OTHER", ["A"])
+    assert "agents:add" in str(failure.value)
+
+
+def test_cli_prints_the_agent_id_and_never_the_secret(monkeypatch: pytest.MonkeyPatch) -> None:
+    state = _state()
+    monkeypatch.setenv("COVAL_API_KEY", "coval-key")
+    monkeypatch.setattr(
+        coval_agent,
+        "get_settings",
+        lambda: Settings(
+            llm_proxy_public_url="https://api.example.com",
+            llm_proxy_secret=SecretStr(SECRET),
+            coval_s2s_dental_test_set_id="TSDENTAL",
+            coval_s2s_instruction_metric_id="M" * 22,
+        ),
+    )
+    monkeypatch.setattr(coval_agent, "CovalTextClient", lambda *_args: _client(state))
+
+    dry = CliRunner().invoke(sync_coval, ["--dry-run"])
+    assert dry.exit_code == 0, dry.output
+    assert "COVAL_LLM_PHONELY_AGENT_ID=<created on apply>" in dry.output
+    assert state["writes"] == []
+
+    applied = CliRunner().invoke(sync_coval, [])
+    assert applied.exit_code == 0, applied.output
+    assert f"COVAL_LLM_PHONELY_AGENT_ID={'A' * 22}" in applied.output
+    assert SECRET not in dry.output + applied.output


### PR DESCRIPTION
Define the Coval side of the Phonely text agent in code and push it idempotently: the agent, its test-set link, a run template with the clean dental personas, and the daily schedule. Dry run prints the redacted body and writes nothing; every run prints the agent id the fetch job needs.