### PR TITLE
[BENCH-803] Look up the Coval agent with a filter

### DIFF
--- a/runner/src/coval_bench/llm/coval_agent.py
+++ b/runner/src/coval_bench/llm/coval_agent.py
@@ -122,15 +122,6 @@ class CovalTextClient(CovalClient):
     def __enter__(self) -> Self:
         return self
 
-    def find_agent(self, customer_agent_id: str) -> dict[str, Any] | None:
-        by_name = None
-        for agent in self._pages("/agents", "agents"):
-            if agent.get("customer_agent_id") == customer_agent_id:
-                return agent
-            if by_name is None and agent.get("display_name") == DISPLAY_NAME:
-                by_name = agent
-        return by_name
-
     def test_set_agent_ids(self, test_set_id: str) -> set[str]:
         return {
             str(agent["id"])

--- a/runner/src/coval_bench/platform_assets.py
+++ b/runner/src/coval_bench/platform_assets.py
@@ -530,8 +530,13 @@ class CovalClient(_JsonClient):
                 return
 
     def find_agent(self, customer_agent_id: str) -> dict[str, Any] | None:
-        for agent in self._pages("/agents", "agents"):
-            if agent.get("customer_agent_id") == customer_agent_id:
+        payload = self._request(
+            "GET",
+            "/agents",
+            params={"filter": f'customer_agent_id="{customer_agent_id}"', "page_size": 1},
+        )
+        for agent in payload.get("agents") or []:
+            if isinstance(agent, dict) and agent.get("customer_agent_id") == customer_agent_id:
                 return agent
         return None
 

--- a/runner/tests/unit/test_coval_agent_sync.py
+++ b/runner/tests/unit/test_coval_agent_sync.py
@@ -41,6 +41,7 @@ def _state(**overrides: Any) -> dict[str, Any]:
         "run_templates": [],
         "scheduled_runs": [],
         "writes": [],
+        "filters": [],
     }
     state.update(overrides)
     return state
@@ -50,6 +51,11 @@ def _client(state: dict[str, Any]) -> CovalTextClient:
     def handler(request: httpx.Request) -> httpx.Response:
         path = request.url.path.removeprefix("/v1")
         body: dict[str, Any] = json.loads(request.content) if request.content else {}
+        if request.method == "GET" and path == "/agents":
+            state["filters"].append(dict(request.url.params))
+            wanted = request.url.params["filter"].split('"')[1]
+            agents = [a for a in state["agents"] if a.get("customer_agent_id") == wanted]
+            return httpx.Response(200, json={"agents": agents})
         if request.method == "GET":
             state_key, response_key = {
                 "/agents": ("agents", "agents"),
@@ -163,19 +169,16 @@ def test_sync_patches_drifted_metadata_wholesale_and_leaves_the_rest() -> None:
     assert state["writes"] == [("/agents/A", {"metadata": DEFINITION.agent_body()["metadata"]})]
 
 
-def test_sync_is_a_no_op_once_converged_and_matches_by_display_name_fallback() -> None:
-    live = {**DEFINITION.agent_body(), "id": "A", "customer_agent_id": ""}
-    state = _state(
-        agents=[live],
-        test_set_agents=[{"id": "A"}],
-        run_templates=[{"id": "T", "display_name": RUN_NAME}],
-        scheduled_runs=[{"id": "S", "run_template_id": "T"}],
-    )
+def test_sync_looks_up_by_customer_id_filter_and_never_adopts_a_name_only_match() -> None:
+    name_only = {**DEFINITION.agent_body(), "id": "B", "customer_agent_id": ""}
+    state = _state(agents=[name_only])
     with _client(state) as client:
         result = sync(client, DEFINITION)
-    assert result.agent_id == "A"
-    assert result.actions[0] == "agent: unchanged"
-    assert state["writes"] == []
+    assert state["filters"] == [
+        {"filter": f'customer_agent_id="{CUSTOMER_AGENT_ID}"', "page_size": "1"}
+    ]
+    assert result.agent_id == "A" * 22
+    assert state["writes"][0][0] == "/agents"
 
 
 def test_sync_dry_run_reports_and_writes_nothing() -> None:

--- a/runner/tests/unit/test_platform_assets.py
+++ b/runner/tests/unit/test_platform_assets.py
@@ -265,7 +265,9 @@ def _coval_client(state: dict[str, Any]) -> CovalClient:
     def handler(request: httpx.Request) -> httpx.Response:
         state.setdefault("calls", []).append((request.method, request.url.path))
         if request.url.path == "/v1/agents" and request.method == "GET":
-            return httpx.Response(200, json={"agents": state["agents"], "next_page_token": ""})
+            wanted = request.url.params["filter"].split('"')[1]
+            agents = [a for a in state["agents"] if a.get("customer_agent_id") == wanted]
+            return httpx.Response(200, json={"agents": agents, "next_page_token": ""})
         if request.url.path == "/v1/agents":
             created = {**json.loads(request.content), "id": "A" * 22}
             state["agents"].append(created)


### PR DESCRIPTION
The shared find_agent walked every page of /agents and compared in Python; sync-coval copied that and added a display-name fallback that walked them again. One filtered request replaces both, and a name-only match is no longer adopted.