### PR TITLE
[BENCH-766] Model pricing in Postgres: admin-recorded rates with history

### DIFF
--- a/runner/src/coval_bench/api/app.py
+++ b/runner/src/coval_bench/api/app.py
@@ -44,12 +44,14 @@ from coval_bench.api.ratelimit import _rate_limit_handler, limiter
 from coval_bench.api.request_logging import RequestLoggingMiddleware
 from coval_bench.api.routers import (
     admin_models,
+    admin_pricing,
     aggregates,
     arena,
     health,
     leaderboard,
     llm_phonely,
     mocktools,
+    pricing,
     providers,
     results,
     robots,
@@ -210,9 +212,11 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     app.include_router(leaderboard.router, prefix="/v1")
     app.include_router(providers.router, prefix="/v1")
     app.include_router(tags.router, prefix="/v1")
+    app.include_router(pricing.router, prefix="/v1")
     app.include_router(s2s_samples.router, prefix="/v1")
     app.include_router(arena.router, prefix="/v1")
     app.include_router(admin_models.router, prefix="/v1")
+    app.include_router(admin_pricing.router, prefix="/v1")
     # Not under /v1 and not rate limited: an appliance the agents call, not
     # public read API. slowapi carries no default limit, so /mock and /llm are exempt
     # by construction — a 429 mid-conversation would be graded as the agent failing.

--- a/runner/src/coval_bench/api/routers/admin_models.py
+++ b/runner/src/coval_bench/api/routers/admin_models.py
@@ -34,6 +34,7 @@ from coval_bench.api.schemas import (
     AdminModelsResponse,
     AdminModelUpdateResponse,
 )
+from coval_bench.db.pricing_store import PricingStore
 from coval_bench.db.registry_store import (
     DuplicateKey,
     ModelChange,
@@ -226,6 +227,22 @@ async def update_admin_model(
     before, after = result
     response.headers["ETag"] = _etag(after)
     history = await store.history(model_id)
-    return AdminModelUpdateResponse(
-        model=_model_out(after, history), warnings=_rename_warnings(before, after)
-    )
+    warnings = _rename_warnings(before, after)
+    warnings.extend(await _pricing_rename_warnings(before, after, pool))
+    return AdminModelUpdateResponse(model=_model_out(after, history), warnings=warnings)
+
+
+async def _pricing_rename_warnings(
+    before: ModelRecord, after: ModelRecord, pool: AsyncConnectionPool[Any]
+) -> list[str]:
+    """The pricing log keys on the natural name, so a rename leaves its rates behind."""
+    old = (before.provider, before.model)
+    if old == (after.provider, after.model):
+        return []
+    count = await PricingStore(pool).count_for((before.modality, before.provider, before.model))
+    if count == 0:
+        return []
+    return [
+        f"{count} pricing recording(s) are filed under {old[0]}/{old[1]}; "
+        f"{after.provider}/{after.model} has no price until one is recorded under its new name"
+    ]

--- a/runner/src/coval_bench/api/routers/admin_pricing.py
+++ b/runner/src/coval_bench/api/routers/admin_pricing.py
@@ -1,0 +1,151 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Admin pricing endpoints: read the whole pricing log, append to it.
+
+Every route requires a coval-org Clerk session (``require_coval_admin``) and
+every response is marked private: the log names staff and may price models
+that are still embargoed. There is no PATCH and no DELETE — a price is changed
+by recording a new one, and a mistake is corrected by recording the right
+value for the same effective date, which the log keeps beside the wrong one.
+
+Writes accept exactly what a ratesheet entry may say (``NewRate`` runs the
+entry through ``PricingEntry``), for a model the registry lists in any state —
+pricing a hidden model ahead of its launch is expected — dated no more than a
+year ahead, so a slipped keystroke cannot schedule a rate for 2062.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime, timedelta
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Response
+from psycopg_pool import AsyncConnectionPool
+from pydantic import ValidationError
+
+from coval_bench.api.clerk import CovalAdmin
+from coval_bench.api.deps import get_pool, require_coval_admin
+from coval_bench.api.internal import never_shared
+from coval_bench.api.schemas import (
+    AdminModelPricingOut,
+    AdminPricingResponse,
+    AdminRateCreate,
+    AdminRateRecordingOut,
+)
+from coval_bench.db.pricing_store import NewRate, PricingStore
+from coval_bench.registries.pricing.resolve import (
+    RateKey,
+    RateRecording,
+    RateTimeline,
+    timelines,
+)
+
+router = APIRouter(tags=["admin"], dependencies=[Depends(require_coval_admin)])
+
+# How far ahead a rate may be scheduled. Providers announce changes weeks out,
+# not years; anything further is far more likely a typo than a plan.
+MAX_SCHEDULE_AHEAD = timedelta(days=366)
+# And how far back one may be dated: the oldest model we benchmark postdates this.
+EARLIEST_EFFECTIVE = date(2020, 1, 1)
+
+
+def _recording_out(recording: RateRecording, superseded: bool) -> AdminRateRecordingOut:
+    per_chars = recording.price_per_1m_chars
+    per_minutes = recording.price_per_1k_minutes
+    return AdminRateRecordingOut(
+        id=recording.id,
+        unit=None if recording.unit is None else str(recording.unit),
+        price_usd=recording.price_usd,
+        price_per_1m_chars=float(per_chars) if per_chars is not None else None,
+        price_per_1k_minutes=float(per_minutes) if per_minutes is not None else None,
+        effective_from=recording.effective_from,
+        source_url=recording.source_url,
+        notes=recording.notes,
+        recorded_by_user_id=recording.recorded_by_user_id,
+        recorded_by_email=recording.recorded_by_email,
+        recorded_at=recording.recorded_at,
+        superseded=superseded,
+    )
+
+
+def _model_out(
+    timeline: RateTimeline, recordings: list[RateRecording], today: date
+) -> AdminModelPricingOut:
+    superseded = {r.id for r in timeline.superseded}
+    current = timeline.in_force(today)
+    return AdminModelPricingOut(
+        benchmark=timeline.key[0],
+        provider=timeline.key[1],
+        model=timeline.key[2],
+        current=None if current is None else _recording_out(current.recording, False),
+        scheduled=[_recording_out(s.recording, False) for s in timeline.scheduled(today)],
+        recordings=[
+            _recording_out(r, r.id in superseded)
+            for r in sorted(recordings, key=lambda r: (r.recorded_at, r.id), reverse=True)
+        ],
+    )
+
+
+def _today() -> date:
+    return datetime.now(UTC).date()
+
+
+@router.get("/admin/pricing", response_model=AdminPricingResponse)
+async def list_admin_pricing(
+    response: Response,
+    pool: AsyncConnectionPool[Any] = Depends(get_pool),
+) -> AdminPricingResponse:
+    """Every model with a pricing log entry: current, scheduled, and the full audit trail."""
+    never_shared(response)
+    today = _today()
+    recordings = await PricingStore(pool).recordings()
+    by_key: dict[RateKey, list[RateRecording]] = {}
+    for recording in recordings:
+        by_key.setdefault(recording.key, []).append(recording)
+    return AdminPricingResponse(
+        as_of=today,
+        models=[
+            _model_out(timeline, by_key[key], today)
+            for key, timeline in sorted(timelines(recordings).items())
+        ],
+    )
+
+
+def _messages(exc: ValidationError) -> str:
+    return "; ".join(str(error["msg"]).removeprefix("Value error, ") for error in exc.errors())
+
+
+@router.post("/admin/pricing", response_model=AdminModelPricingOut, status_code=201)
+async def record_admin_rate(
+    body: AdminRateCreate,
+    response: Response,
+    admin: CovalAdmin = Depends(require_coval_admin),
+    pool: AsyncConnectionPool[Any] = Depends(get_pool),
+) -> AdminModelPricingOut:
+    """Append a recording; 201 when it wrote, 200 when the date already said exactly this."""
+    never_shared(response)
+    today = _today()
+    try:
+        new = NewRate.model_validate(
+            {**body.model_dump(), "effective_from": body.effective_from or today}
+        )
+    except ValidationError as exc:
+        raise HTTPException(422, _messages(exc)) from exc
+    if new.effective_from > today + MAX_SCHEDULE_AHEAD:
+        raise HTTPException(422, "effective_from may be at most a year ahead")
+    if new.effective_from < EARLIEST_EFFECTIVE:
+        raise HTTPException(422, f"effective_from may not precede {EARLIEST_EFFECTIVE.isoformat()}")
+
+    store = PricingStore(pool)
+    if not await store.model_exists(new.key):
+        raise HTTPException(
+            422,
+            f"no registered model {new.benchmark}/{new.provider}/{new.model}; "
+            "add it to the registry before pricing it",
+        )
+    _, inserted = await store.record(new, user_id=admin.user_id, email=admin.email)
+    if not inserted:
+        response.status_code = 200
+    recordings = await store.recordings_for(new.key)
+    return _model_out(timelines(recordings)[new.key], recordings, today)

--- a/runner/src/coval_bench/api/routers/pricing.py
+++ b/runner/src/coval_bench/api/routers/pricing.py
@@ -1,0 +1,130 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""GET /v1/pricing — the rates in force on a day, with their history.
+
+The response carries one entry per listed model that has ever had a rate
+recorded: the rate in force on ``as_of`` (today by default), the earlier rates
+it succeeded, and the packaged datasets' usage (minutes of audio in,
+characters spoken), so a client can turn a rate into a benchmark-pass cost by
+pure arithmetic — against the datasets the site currently reports, since the
+usage list also keeps retired datasets whose artifacts still reference them.
+
+Rates live in ``benchmarks_v2.pricing_rates`` and change through the admin
+API (see ``admin_pricing.py``), never by deploy; ``registries.pricing.resolve``
+is the one rule for which recording describes which day. A rate scheduled for
+a future day prices nothing until then, and ``as_of`` may not be in the future
+either — the site never shows a price that is not yet in force.
+
+Visibility follows the model roster: a rate serves only while the roster
+lists its model — uncollected models included, since the site shows them
+greyed out — and unpublished models are hidden unless the caller's bearer
+token clears them, the same embargo every other data endpoint applies.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from datetime import UTC, date, datetime
+from typing import Any
+
+import structlog
+from fastapi import APIRouter, Depends, HTTPException, Query
+from posthog import Posthog
+from psycopg_pool import AsyncConnectionPool
+from starlette.requests import Request
+
+from coval_bench.api.deps import capture_api_event, get_models, get_pool, get_posthog
+from coval_bench.api.internal import hidden_early_access
+from coval_bench.api.ratelimit import limiter
+from coval_bench.api.schemas import (
+    PricingRateOut,
+    PricingRateSpanOut,
+    PricingRegistryResponse,
+)
+from coval_bench.db.pricing_store import PricingStore
+from coval_bench.registries import RegisteredModel
+from coval_bench.registries.pricing.resolve import RateSpan, RateTimeline, timelines
+
+logger = structlog.get_logger("coval_bench.api")
+
+router = APIRouter(tags=["pricing"])
+
+
+def _span_out(span: RateSpan, today: date) -> PricingRateSpanOut:
+    r = span.recording
+    per_chars = r.price_per_1m_chars
+    per_minutes = r.price_per_1k_minutes
+    # A span closed by a *scheduled* recording is served open: the public read
+    # never shows a rate before its day, so it must not name that day either.
+    effective_to = span.effective_to
+    if effective_to is not None and effective_to > today:
+        effective_to = None
+    return PricingRateSpanOut(
+        unit=None if r.unit is None else str(r.unit),
+        price_usd=r.price_usd,
+        price_per_1m_chars=float(per_chars) if per_chars is not None else None,
+        price_per_1k_minutes=float(per_minutes) if per_minutes is not None else None,
+        effective_from=span.effective_from,
+        effective_to=effective_to,
+        source_url=r.source_url,
+    )
+
+
+def _rate_out(timeline: RateTimeline, span: RateSpan, today: date) -> PricingRateOut:
+    r = span.recording
+    return PricingRateOut(
+        **_span_out(span, today).model_dump(),
+        benchmark=r.benchmark,
+        provider=r.provider,
+        model=r.model,
+        notes=r.notes,
+        recorded_at=r.recorded_at,
+        history=[_span_out(s, today) for s in timeline.before(span)],
+    )
+
+
+@router.get("/pricing", response_model=PricingRegistryResponse)
+@limiter.limit("60/minute")
+async def get_pricing_registry(
+    request: Request,
+    as_of: date | None = Query(
+        default=None,
+        description="The day to price as of (UTC); defaults to today and may not be later.",
+    ),
+    posthog_client: Posthog | None = Depends(get_posthog),
+    hidden: frozenset[tuple[str, str]] = Depends(hidden_early_access),
+    models: Sequence[RegisteredModel] = Depends(get_models),
+    pool: AsyncConnectionPool[Any] = Depends(get_pool),
+) -> PricingRegistryResponse:
+    """Return every rate in force on ``as_of``, with the earlier spans as history."""
+    today = datetime.now(UTC).date()
+    day = today if as_of is None else as_of
+    if day > today:
+        raise HTTPException(422, f"as_of may not be later than today ({today.isoformat()} UTC)")
+    try:
+        recordings = await PricingStore(pool).recordings()
+    except Exception as exc:
+        logger.error("pricing_log_unavailable", exc_info=True)
+        raise HTTPException(503, "the pricing log is unavailable") from exc
+
+    roster = {(m.benchmark, m.provider, m.model) for m in models}
+    rates: list[PricingRateOut] = []
+    for key, timeline in sorted(timelines(recordings).items()):
+        if key not in roster or (key[1], key[2]) in hidden:
+            continue
+        span = timeline.in_force(day)
+        if span is None:
+            continue
+        rates.append(_rate_out(timeline, span, today))
+
+    capture_api_event(
+        posthog_client,
+        "pricing_listed",
+        {
+            "rate_count": len(rates),
+            "as_of_requested": as_of is not None,
+            "$process_person_profile": False,
+        },
+    )
+    return PricingRegistryResponse(as_of=day, rates=rates)

--- a/runner/src/coval_bench/api/schemas.py
+++ b/runner/src/coval_bench/api/schemas.py
@@ -11,7 +11,8 @@ added later if needed.
 from __future__ import annotations
 
 import uuid
-from datetime import datetime
+from datetime import date, datetime
+from decimal import Decimal
 from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field
@@ -121,6 +122,54 @@ class ProvidersResponse(BaseModel):
     llm: list[ProviderInfo]
     # Facet vocabulary in display order, shared across every benchmark.
     tag_categories: list[TagCategoryOut]
+
+
+class PricingRateSpanOut(BaseModel):
+    """One stretch of a model's price history: a rate and the days it covered.
+
+    ``price_usd`` is the provider's native figure in ``unit``, served as the
+    exact decimal it was recorded as (a JSON string — floats would strip
+    trailing zeros and misquote the printed price, e.g. $0.20 → $0.2). The two
+    normalized fields scale it exactly, except hourly rates, whose ÷60 rounds
+    half-up to a millionth; both are ``None`` where no conversion exists
+    without assuming a speaking rate. ``unit``, ``price_usd`` and
+    ``source_url`` are all ``None`` over a span in which the model had no
+    known public rate. ``effective_to`` is exclusive, and ``None`` unless the
+    span was closed by a rate already in force — a change scheduled for a
+    future day is not public until then, its date included.
+    """
+
+    unit: str | None = None
+    price_usd: Decimal | None = None
+    price_per_1m_chars: float | None = None
+    price_per_1k_minutes: float | None = None
+    effective_from: date
+    effective_to: date | None = None
+    source_url: str | None = None
+
+
+class PricingRateOut(PricingRateSpanOut):
+    """One model's rate in force on the requested day, with what came before.
+
+    ``history`` lists the earlier spans oldest first, so a client can read the
+    price on any past day without a second request; ``recorded_at`` is when
+    the current figure was entered. Rates scheduled for a future day are not
+    served.
+    """
+
+    benchmark: BenchmarkLiteral
+    provider: str
+    model: str
+    notes: str | None = None
+    recorded_at: datetime
+    history: list[PricingRateSpanOut] = []
+
+
+class PricingRegistryResponse(BaseModel):
+    """Response schema for GET /v1/pricing: the rates in force on ``as_of``."""
+
+    as_of: date
+    rates: list[PricingRateOut]
 
 
 class ResultsResponse(BaseModel):
@@ -483,3 +532,68 @@ class AdminModelUpdateResponse(BaseModel):
 
     model: AdminModelOut
     warnings: list[str] = []
+
+
+class AdminRateRecordingOut(BaseModel):
+    """One row of the pricing log, as the admin sees it: who said what, when.
+
+    ``superseded`` marks a recording a later one replaced for the same
+    effective date — a corrected entry, kept for the audit trail but no longer
+    describing any day.
+    """
+
+    id: int
+    unit: str | None = None
+    price_usd: Decimal | None = None
+    price_per_1m_chars: float | None = None
+    price_per_1k_minutes: float | None = None
+    effective_from: date
+    source_url: str | None = None
+    notes: str | None = None
+    recorded_by_user_id: str
+    recorded_by_email: str | None = None
+    recorded_at: datetime
+    superseded: bool
+
+
+class AdminModelPricingOut(BaseModel):
+    """One model's pricing log, resolved for the admin page.
+
+    ``current`` is the recording in force today (None before the first
+    effective date), ``scheduled`` the ones whose day has not yet come, and
+    ``recordings`` every row ever written for the model, newest first.
+    """
+
+    benchmark: Benchmark
+    provider: str
+    model: str
+    current: AdminRateRecordingOut | None = None
+    scheduled: list[AdminRateRecordingOut] = []
+    recordings: list[AdminRateRecordingOut] = []
+
+
+class AdminPricingResponse(BaseModel):
+    """Response schema for GET /v1/admin/pricing."""
+
+    as_of: date
+    models: list[AdminModelPricingOut]
+
+
+class AdminRateCreate(BaseModel):
+    """POST body for /v1/admin/pricing: one new recording.
+
+    Send ``unit`` and ``price_usd`` together for a published rate, or leave
+    both out to record that the model has no known public rate from
+    ``effective_from``. ``price_usd`` is a decimal string so the quoted figure
+    survives exactly; ``effective_from`` defaults to today (UTC) and may be a
+    future day to schedule an announced change.
+    """
+
+    benchmark: Benchmark
+    provider: str = Field(min_length=1)
+    model: str = Field(min_length=1)
+    unit: str | None = None
+    price_usd: str | None = None
+    effective_from: date | None = None
+    source_url: str | None = None
+    notes: str | None = None

--- a/runner/src/coval_bench/db/migrations/versions/20260903_0027_pricing_rates.py
+++ b/runner/src/coval_bench/db/migrations/versions/20260903_0027_pricing_rates.py
@@ -1,0 +1,733 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+# ruff: noqa: E501  # Embedded SQL is formatted as executable migration text.
+
+"""The pricing log: pricing_rates, seeded with the published rates as of this revision.
+
+Revision ID: 20260903_0027
+Revises:     20260902_0026
+Create Date: 2026-09-03
+
+Prices live here, so a price changes through the admin API instead of a deploy,
+and every price ever served stays on record. Append-only: a row is a
+*recording* — on ``recorded_at`` someone said that from ``effective_from`` the
+model costs ``price_usd`` per ``unit``, or (both NULL) that no public rate is
+known from that day. Nothing is ever updated or deleted;
+``registries.pricing.resolve`` reads the log (latest recording wins per
+effective date; the rate in force on a day is the winning recording with the
+greatest effective date at or before it).
+
+No FK to ``models``: like ``model_history``, the log must outlive anything it
+references. No uniqueness on the rate itself, on purpose — recording a value
+again after a correction is a real change, and the store decides what counts
+as a repeat.
+
+The seed (``SEED_ROWS`` below) is every rate verified against the providers'
+public pricing pages as of this revision, with the page cited and the tier
+named in ``notes``, written as a literal the way 20260825_0021 seeded the
+model registry: a migration's effect must not drift with the code that later
+ships beside it. ``recorded_by_user_id`` names this migration; the first admin
+recording is the first human row.
+
+Notes
+-----
+DB roles (``runner``, ``api``) and GRANTs are managed by Terraform. Admin
+writes happen in the API process, so the ``api`` role needs SELECT and INSERT
+on ``pricing_rates``. Nothing is ever updated or deleted.
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "20260903_0027"
+down_revision = "20260902_0026"
+branch_labels = None
+depends_on = None
+
+_RECORDED_BY = f"migration:{revision}"
+
+# (benchmark, provider, model, unit, price_usd, effective_from, source_url, notes)
+SEED_ROWS: tuple[tuple[str, str, str, str, str, str, str, str | None], ...] = (
+    (
+        "STT",
+        "assemblyai",
+        "universal-3.5-pro",
+        "per_hour",
+        "0.45",
+        "2026-08-24",
+        "https://www.assemblyai.com/pricing",
+        "AssemblyAI sells three separate APIs and prices Universal-3.5 Pro differently on each. This is the Realtime Speech-to-Text API rate, listed as 'Universal-3.5 Pro Realtime' at $0.45/hr — the endpoint we benchmark, over wss://streaming.assemblyai.com/v3/ws. The similarly named async model on the Pre-recorded API is $0.21/hr and the Sync API is $0.45/hr; neither is what we measure. Billed on session duration like the Universal-Streaming rate above.",
+    ),
+    (
+        "STT",
+        "assemblyai",
+        "universal-streaming",
+        "per_hour",
+        "0.15",
+        "2026-08-24",
+        "https://www.assemblyai.com/pricing",
+        "Pay-as-you-go rate for Universal-Streaming on the Realtime Speech-to-Text API (English and Multilingual both $0.15/hr). AssemblyAI bills streaming on session duration — WebSocket open time, not audio sent — and we stream each clip in real time and close, so a benchmarked session is one clip's audio plus a brief wait for the final transcript.",
+    ),
+    (
+        "STT",
+        "assemblyai",
+        "universal-streaming-multilingual",
+        "per_hour",
+        "0.15",
+        "2026-08-31",
+        "https://www.assemblyai.com/pricing",
+        "'Universal-Streaming Multilingual' row on the Realtime Speech-to-Text API, same $0.15/hr as the English tier. Billed on session duration like the rates above.",
+    ),
+    (
+        "STT",
+        "azure",
+        "default",
+        "per_hour",
+        "1",
+        "2026-08-31",
+        "https://azure.microsoft.com/en-us/pricing/details/cognitive-services/speech-services/",
+        "Pay-as-you-go 'S1 Speech To Text' standard real-time meter, $1.00 per hour in East US (the pricing page renders after region selection; figure verified via the Azure retail prices API). Batch and commitment tiers are cheaper.",
+    ),
+    (
+        "STT",
+        "deepgram",
+        "flux-general-en",
+        "per_minute",
+        "0.0065",
+        "2026-08-24",
+        "https://deepgram.com/pricing",
+        "Pay As You Go streaming rate, listed as a limited-time promotional price; regular price $0.0077/min.",
+    ),
+    (
+        "STT",
+        "deepgram",
+        "flux-general-multi",
+        "per_minute",
+        "0.0078",
+        "2026-08-24",
+        "https://deepgram.com/pricing",
+        "Pay As You Go streaming rate.",
+    ),
+    (
+        "STT",
+        "deepgram",
+        "nova-2",
+        "per_hour",
+        "0.35",
+        "2026-08-31",
+        "https://deepgram.com/pricing",
+        "FAQ rate: 'Nova-2 streaming at $0.35/hour', kept unchanged for existing deployments; Nova-2 no longer appears in the main rate tables. Growth plan rates are about 12.5% lower.",
+    ),
+    (
+        "STT",
+        "deepgram",
+        "nova-3",
+        "per_minute",
+        "0.0048",
+        "2026-08-24",
+        "https://deepgram.com/pricing",
+        "Pay As You Go monolingual (English) streaming rate, listed as a limited-time promotional price; regular price $0.0077/min. Multilingual streaming is $0.0058/min (regular $0.0092).",
+    ),
+    (
+        "STT",
+        "elevenlabs",
+        "scribe_v2_realtime",
+        "per_hour",
+        "0.39",
+        "2026-08-24",
+        "https://elevenlabs.io/pricing/api",
+        "Pay-as-you-go API rate for Scribe v2 Realtime; subscription tiers change only the included hours, not the rate.",
+    ),
+    (
+        "STT",
+        "gladia",
+        "solaria-1",
+        "per_hour",
+        "0.75",
+        "2026-08-24",
+        "https://www.gladia.io/pricing",
+        "Starter pay-as-you-go real-time rate; Gladia prices real-time generically and Solaria is its real-time model.",
+    ),
+    (
+        "STT",
+        "google",
+        "chirp_2",
+        "per_minute",
+        "0.016",
+        "2026-08-24",
+        "https://cloud.google.com/speech-to-text/pricing",
+        "Speech-to-Text V2 Recognition standard rate, first volume tier (0-500k min/month); V2 prices all standard models, Chirp included, at this one rate. Volume tiers drop to $0.004/min above 2M.",
+    ),
+    (
+        "STT",
+        "google",
+        "chirp_3",
+        "per_minute",
+        "0.016",
+        "2026-08-24",
+        "https://cloud.google.com/speech-to-text/pricing",
+        "Speech-to-Text V2 Recognition standard rate, first volume tier (0-500k min/month); same single V2 SKU as chirp_2.",
+    ),
+    (
+        "STT",
+        "gradium",
+        "default",
+        "per_second_audio_in",
+        "0.000207",
+        "2026-08-24",
+        "https://gradium.ai/pricing",
+        "Entry (XS) plan add-on credit rate — the marginal price of usage: 3 credits per second of audio at $6.9 per 100k credits, exact conversion. Gradium has no standalone pay-as-you-go tier; larger plans publish lower add-on rates, and usage inside the XS plan's own 225k-credit allowance works out to about $0.000173 per second.",
+    ),
+    (
+        "STT",
+        "inworld",
+        "inworld-stt-1",
+        "per_hour",
+        "0.15",
+        "2026-08-24",
+        "https://inworld.ai/pricing",
+        "On-Demand pay-as-you-go base rate; paid subscription tiers discount to $0.10/hr.",
+    ),
+    (
+        "STT",
+        "mistral",
+        "voxtral-mini-transcribe-realtime-2602",
+        "per_minute",
+        "0.006",
+        "2026-08-24",
+        "https://mistral.ai/pricing/api",
+        "La Plateforme pay-as-you-go audio-input rate for Voxtral Mini Transcribe Realtime; the batch Transcribe tier is $0.003/min.",
+    ),
+    (
+        "STT",
+        "modulate",
+        "english-fast-transcription-streaming",
+        "per_hour",
+        "0.05",
+        "2026-08-31",
+        "https://www.modulate.ai/api-pricing",
+        "'English Fast Speech-to-Text' streaming (real-time WebSocket) rate; the batch REST tier is $0.025/hr.",
+    ),
+    (
+        "STT",
+        "modulate",
+        "multilingual-transcription-streaming",
+        "per_hour",
+        "0.06",
+        "2026-08-31",
+        "https://www.modulate.ai/api-pricing",
+        "'Multilingual Speech-to-Text' streaming (real-time WebSocket) rate; batch is $0.03/hr, and emotion, accent, and PII tagging bill as separate add-ons. Modulate's page prices these two products only — the velma-2 model ids have no printed row and stay unpriced.",
+    ),
+    (
+        "STT",
+        "openai",
+        "gpt-4o-mini-transcribe",
+        "per_minute",
+        "0.003",
+        "2026-08-24",
+        "https://developers.openai.com/api/docs/pricing",
+        "OpenAI's published estimated per-minute cost; underlying token rates are $1.25/1M input tokens and $5.00/1M output tokens.",
+    ),
+    (
+        "STT",
+        "openai",
+        "gpt-4o-transcribe",
+        "per_minute",
+        "0.006",
+        "2026-08-24",
+        "https://developers.openai.com/api/docs/pricing",
+        "OpenAI's published estimated per-minute cost; underlying token rates are $2.50/1M input tokens and $10.00/1M output tokens.",
+    ),
+    (
+        "STT",
+        "openai",
+        "gpt-realtime-whisper",
+        "per_minute",
+        "0.017",
+        "2026-08-24",
+        "https://developers.openai.com/api/docs/pricing",
+        "Published per-minute live-transcription rate; OpenAI lists no token pricing for this model.",
+    ),
+    (
+        "STT",
+        "revai",
+        "reverb",
+        "per_hour",
+        "0.20",
+        "2026-08-31",
+        "https://www.rev.ai/pricing",
+        "'Reverb Transcription $0.20 per hour' — Rev AI publishes one rate per product with no streaming/async split; usage is rounded up to the nearest second with a 15-second minimum. Reverb Turbo is $0.10/hr and foreign-language transcription $0.30/hr.",
+    ),
+    (
+        "STT",
+        "smallest",
+        "pulse",
+        "per_minute",
+        "0.008",
+        "2026-08-24",
+        "https://docs.smallest.ai/models/model-cards/speech-to-text/pulse",
+        "Standard Plan realtime rate from the official Pulse model card; batch is $0.005/min. Marketing pages print only approximate figures.",
+    ),
+    (
+        "STT",
+        "soniox",
+        "stt-rt-v5",
+        "per_hour",
+        "0.12",
+        "2026-08-24",
+        "https://soniox.com/pricing",
+        "Soniox's page-printed per-hour rate for real-time streaming, which is the all-in figure: canonical billing is token-based, and the page's own conversions add up to it — ~30,000 input audio tokens per hour at $2.00 per 1M ($0.06) plus ~15,000 output text tokens per hour at $4.00 per 1M ($0.06).",
+    ),
+    (
+        "STT",
+        "speechmatics",
+        "default",
+        "per_hour",
+        "0.24",
+        "2026-08-24",
+        "https://www.speechmatics.com/pricing",
+        "Pro pay-as-you-go rate for real-time transcription, Standard operating point.",
+    ),
+    (
+        "STT",
+        "speechmatics",
+        "enhanced",
+        "per_hour",
+        "0.43",
+        "2026-08-24",
+        "https://www.speechmatics.com/pricing",
+        "Pro pay-as-you-go rate for real-time transcription, Enhanced operating point.",
+    ),
+    (
+        "STT",
+        "together",
+        "nemotron-3-asr-streaming-0.6b",
+        "per_minute",
+        "0.0015",
+        "2026-08-31",
+        "https://www.together.ai/pricing",
+        "'NVIDIA Nemotron 3 ASR Streaming 0.6B' row in the Transcribe per-audio-minute table; no separate batch discount is listed for it. Distinct from the newer Nemotron 3.5 model above at $0.0045/min.",
+    ),
+    (
+        "STT",
+        "together",
+        "nemotron-3.5-asr-streaming-0.6b",
+        "per_minute",
+        "0.0045",
+        "2026-08-24",
+        "https://www.together.ai/models/nvidia-nemotron-35-asr",
+        "Serverless pay-as-you-go per-audio-minute rate; the model page prints this price against the API string nvidia/nemotron-3.5-asr-streaming-0.6b (the pricing page's 'NVIDIA Nemotron 3.5 ASR' row). Not the older 'Nemotron 3 ASR Streaming 0.6B' row at $0.0015/min.",
+    ),
+    (
+        "STT",
+        "together",
+        "parakeet-tdt-0.6b-v3",
+        "per_minute",
+        "0.0015",
+        "2026-08-24",
+        "https://www.together.ai/pricing",
+        "Serverless per-audio-minute rate for NVIDIA Parakeet TDT 0.6B v3. Together's per-audio-minute table is headed 'Batch API price' and carries no realtime row for this model, unlike Whisper Large v3 which has a separate (Streaming) row — so this is the only per-minute figure published for it, and it may understate the realtime endpoint we benchmark. The 'Parakeet TDT 0.6B V3 Realtime $0.0035' row sits in the per-1M-characters table beside the TTS models, so it is not a per-minute audio rate.",
+    ),
+    (
+        "STT",
+        "together",
+        "whisper-large-v3",
+        "per_minute",
+        "0.0035",
+        "2026-08-24",
+        "https://www.together.ai/pricing",
+        "Whisper Large v3 (Streaming) rate — we benchmark over Together's realtime API; the non-streaming Transcribe tier is $0.0015/min.",
+    ),
+    (
+        "STT",
+        "xai",
+        "grok-stt",
+        "per_hour",
+        "0.20",
+        "2026-08-24",
+        "https://docs.x.ai/developers/pricing",
+        "Streaming speech-to-text rate — the endpoint we benchmark; the REST tier is $0.10/hr. Published as a generic Speech to Text row, not by model id.",
+    ),
+    (
+        "TTS",
+        "alibaba",
+        "qwen3-tts-flash-realtime",
+        "per_1m_chars",
+        "13",
+        "2026-09-01",
+        "https://www.alibabacloud.com/help/en/model-studio/model-pricing",
+        "Qwen3-TTS-Flash-Realtime table, Singapore region ('International' deployment scope — the dashscope-intl endpoint we benchmark): $0.13 per 10,000 input text characters, output audio free. The Chinese-mainland (Beijing) table lists $0.143353 per 10,000.",
+    ),
+    (
+        "TTS",
+        "azure",
+        "dragon-hd-latest",
+        "per_1m_chars",
+        "22",
+        "2026-08-10",
+        "https://azure.microsoft.com/en-us/pricing/details/cognitive-services/speech-services/",
+        "Pay-as-you-go Neural HD rate in East US; HD voices are region-limited.",
+    ),
+    (
+        "TTS",
+        "azure",
+        "neural",
+        "per_1m_chars",
+        "15",
+        "2026-08-10",
+        "https://azure.microsoft.com/en-us/pricing/details/cognitive-services/speech-services/",
+        "Pay-as-you-go standard neural voice rate (US regions); commitment tiers are cheaper.",
+    ),
+    (
+        "TTS",
+        "deepgram",
+        "aura-2-thalia-en",
+        "per_1k_chars",
+        "0.030",
+        "2026-08-10",
+        "https://deepgram.com/pricing",
+        "Aura-2 Pay As You Go rate.",
+    ),
+    (
+        "TTS",
+        "elevenlabs",
+        "eleven_flash_v2_5",
+        "per_1k_chars",
+        "0.05",
+        "2026-08-10",
+        "https://elevenlabs.io/pricing/api",
+        "API pricing 'Flash / Turbo' row; same rate across tiers.",
+    ),
+    (
+        "TTS",
+        "elevenlabs",
+        "eleven_multilingual_v2",
+        "per_1k_chars",
+        "0.10",
+        "2026-08-31",
+        "https://elevenlabs.io/pricing/api",
+        "API pricing 'v2 Multilingual' row. Same rate across tiers.",
+    ),
+    (
+        "TTS",
+        "elevenlabs",
+        "eleven_turbo_v2_5",
+        "per_1k_chars",
+        "0.05",
+        "2026-08-31",
+        "https://elevenlabs.io/pricing/api",
+        "API pricing 'Flash / Turbo' row; the page's tooltip states the row covers Flash/Turbo V2 and V2.5. Same rate across tiers.",
+    ),
+    (
+        "TTS",
+        "elevenlabs",
+        "eleven_v3",
+        "per_1k_chars",
+        "0.10",
+        "2026-08-31",
+        "https://elevenlabs.io/pricing/api",
+        "API pricing 'v3' row — twice the v3 Conversational rate below. Same rate across tiers.",
+    ),
+    (
+        "TTS",
+        "elevenlabs",
+        "eleven_v3_conversational",
+        "per_1k_chars",
+        "0.05",
+        "2026-08-28",
+        "https://elevenlabs.io/pricing/api",
+        "API pricing 'v3 Conversational' row — a distinct model from plain v3, which is $0.10 per 1K characters. Same rate across tiers.",
+    ),
+    (
+        "TTS",
+        "fishaudio",
+        "s1",
+        "per_1m_chars",
+        "15",
+        "2026-08-31",
+        "https://docs.fish.audio/developer-guide/models-pricing/pricing-and-rate-limits",
+        "Printed as '$15.00 / M UTF-8 bytes' — one byte per character for the English text we benchmark. s2.1-pro-free is listed at $0.00 and stays unpriced here (the registry cannot carry a zero rate).",
+    ),
+    (
+        "TTS",
+        "fishaudio",
+        "s2.1-pro",
+        "per_1m_chars",
+        "15",
+        "2026-08-31",
+        "https://docs.fish.audio/developer-guide/models-pricing/pricing-and-rate-limits",
+        "Printed as '$15.00 / M UTF-8 bytes', same as s1; billed pay-as-you-go from the first call.",
+    ),
+    (
+        "TTS",
+        "fluxions",
+        "vui",
+        "per_1m_chars",
+        "10",
+        "2026-08-10",
+        "https://fluxions.ai/pricing",
+        "Pay-as-you-go rate for expressive VUI text-to-speech.",
+    ),
+    (
+        "TTS",
+        "google",
+        "chirp-3-hd",
+        "per_1m_chars",
+        "30",
+        "2026-08-10",
+        "https://cloud.google.com/text-to-speech/pricing",
+        "Pay-as-you-go rate for Chirp 3: HD voices, billed per character sent for synthesis.",
+    ),
+    (
+        "TTS",
+        "gradium",
+        "default",
+        "per_1m_chars",
+        "69",
+        "2026-08-10",
+        "https://gradium.ai/pricing",
+        "Entry (XS) plan add-on credit rate — the marginal price of usage: $6.9 per 100k credits at 1 credit per character. Gradium has no standalone pay-as-you-go tier; larger plans publish lower add-on rates, and usage inside the XS plan's own 225k-credit allowance works out to about $57.78 per 1M.",
+    ),
+    (
+        "TTS",
+        "gradium",
+        "gradium-tts-beta",
+        "per_1m_chars",
+        "69",
+        "2026-08-31",
+        "https://gradium.ai/pricing",
+        "Gradium prices TTS generically — '1 credit / character' with no model named on the page — so the new default model bills like the entry (XS) plan's marginal add-on rate recorded for gradium/default: $6.9 per 100k add-on credits = $69/1M characters. Larger plans publish $50/$40/$38.",
+    ),
+    (
+        "TTS",
+        "hume",
+        "octave-2",
+        "per_1k_chars",
+        "0.15",
+        "2026-08-31",
+        "https://www.hume.ai/pricing",
+        "Same Creator-plan overage rate as octave-tts above; the pricing page covers 'Octave 1 | Octave 2' with one set of figures.",
+    ),
+    (
+        "TTS",
+        "hume",
+        "octave-tts",
+        "per_1k_chars",
+        "0.15",
+        "2026-08-31",
+        "https://www.hume.ai/pricing",
+        "Creator plan ($7/mo) 'Additional characters cost' overage rate — the entry tier that prints one; Hume publishes no pay-as-you-go tier, and larger plans overage at $0.12/$0.10/$0.05 per 1K. Octave 1 and Octave 2 are priced jointly.",
+    ),
+    (
+        "TTS",
+        "inworld",
+        "inworld-tts-2",
+        "per_1m_chars",
+        "25",
+        "2026-08-10",
+        "https://inworld.ai/pricing",
+        "On-demand (pay-as-you-go) rate; subscription plans publish lower rates.",
+    ),
+    (
+        "TTS",
+        "inworld",
+        "inworld-tts-2-flash",
+        "per_1m_chars",
+        "15",
+        "2026-08-24",
+        "https://inworld.ai/pricing",
+        "On-demand (pay-as-you-go) rate; subscription plans publish lower rates. TTS 1.5 Max/Mini are no longer published on the page, so the retired models carry no rate.",
+    ),
+    (
+        "TTS",
+        "lmnt",
+        "blizzard",
+        "per_1k_chars",
+        "0.05",
+        "2026-08-10",
+        "https://www.lmnt.com/pricing",
+        "Overage rate past the entry Indie plan's included characters; plan-based, not per-model.",
+    ),
+    (
+        "TTS",
+        "minimax",
+        "speech-2.8-hd",
+        "per_1m_chars",
+        "100",
+        "2026-08-10",
+        "https://platform.minimax.io/docs/guides/pricing-paygo.md",
+        "International-platform pay-as-you-go rate.",
+    ),
+    (
+        "TTS",
+        "minimax",
+        "speech-2.8-turbo",
+        "per_1m_chars",
+        "60",
+        "2026-08-10",
+        "https://platform.minimax.io/docs/guides/pricing-paygo.md",
+        "International-platform pay-as-you-go rate.",
+    ),
+    (
+        "TTS",
+        "murf",
+        "falcon-2",
+        "per_1k_chars",
+        "0.01",
+        "2026-08-31",
+        "https://murf.ai/pricing",
+        "API tab of the pricing page, the realtime Text to Speech row ('Optimized for conversational AI and real-time voice agents with time-to-first-audio under 130ms', i.e. Falcon): $0.01 / 1000 characters. The $0.03 row beside it is the studio synthesis model, not this one. The page renders client-side; the old murf.ai/api/pricing route 404s since early Sep 2026.",
+    ),
+    (
+        "TTS",
+        "openai",
+        "tts-1",
+        "per_1m_chars",
+        "15",
+        "2026-08-31",
+        "https://developers.openai.com/api/docs/pricing",
+        "Printed as '$15.00 / 1M characters' in the audio-generation pricing table (the row is collapsed behind the table's expander). gpt-4o-mini-tts and the realtime models bill in tokens only and stay unpriced here.",
+    ),
+    (
+        "TTS",
+        "openai",
+        "tts-1-hd",
+        "per_1m_chars",
+        "30",
+        "2026-08-31",
+        "https://developers.openai.com/api/docs/pricing",
+        "Printed as '$30.00 / 1M characters' in the audio-generation pricing table (collapsed row), twice the tts-1 rate.",
+    ),
+    (
+        "TTS",
+        "palabra",
+        "palabra-tts-v1",
+        "per_1k_chars",
+        "0.03",
+        "2026-08-10",
+        "https://www.palabra.ai/pricing",
+        "TTS API pay-as-you-go rate.",
+    ),
+    (
+        "TTS",
+        "rime",
+        "coda",
+        "per_1k_chars",
+        "0.05",
+        "2026-08-10",
+        "https://www.rime.ai/pricing",
+        "Pay-as-you-go Starter rate. Arcana has no published rate and is deliberately absent.",
+    ),
+    (
+        "TTS",
+        "rime",
+        "mistv3",
+        "per_1k_chars",
+        "0.03",
+        "2026-08-10",
+        "https://www.rime.ai/pricing",
+        "Pay-as-you-go Starter rate.",
+    ),
+    (
+        "TTS",
+        "speechify",
+        "simba-3.0",
+        "per_1m_chars",
+        "10",
+        "2026-08-10",
+        "https://speechify.ai/pricing",
+        "Starter plan's rate past its 1M included characters — the entry published rate; Pro is $8 and Scale $6 per 1M. Billed per character at the same rate for every Simba model. The per-minute figure Speechify also publishes prices their bundled voice-agent product, not the TTS API.",
+    ),
+    (
+        "TTS",
+        "speechify",
+        "simba-3.2",
+        "per_1m_chars",
+        "10",
+        "2026-08-10",
+        "https://speechify.ai/pricing",
+        "Starter plan's rate past its 1M included characters — the entry published rate; Pro is $8 and Scale $6 per 1M. Billed per character at the same rate for every Simba model. The per-minute figure Speechify also publishes prices their bundled voice-agent product, not the TTS API.",
+    ),
+    (
+        "TTS",
+        "xai",
+        "grok-tts",
+        "per_1m_chars",
+        "15",
+        "2026-08-10",
+        "https://docs.x.ai/developers/pricing",
+        "Voice pricing 'Text to Speech' rate; xAI prices the service, not model variants.",
+    ),
+)
+
+
+def upgrade() -> None:
+    """Create the pricing log and seed it with the packaged rates."""
+    op.execute(
+        """
+        CREATE TABLE benchmarks_v2.pricing_rates (
+            id                  BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+            benchmark           TEXT NOT NULL CHECK (benchmark IN ('STT', 'TTS', 'S2S')),
+            provider            TEXT NOT NULL CHECK (provider <> ''),
+            model               TEXT NOT NULL CHECK (model <> ''),
+            -- Both set: a published rate in the provider's native unit. Both NULL:
+            -- no public rate is known from effective_from (a delisting).
+            unit                TEXT CHECK (unit IS NULL OR unit <> ''),
+            -- NUMERIC keeps the quoted scale: 0.20 stays 0.20, never 0.2 — the
+            -- same exact-decimal contract /v1/pricing serves.
+            price_usd           NUMERIC CHECK (price_usd IS NULL OR price_usd > 0),
+            effective_from      DATE NOT NULL,
+            source_url          TEXT CHECK (source_url IS NULL OR source_url <> ''),
+            notes               TEXT CHECK (notes IS NULL OR notes <> ''),
+            recorded_by_user_id TEXT NOT NULL CHECK (recorded_by_user_id <> ''),   -- Clerk sub, or migration:<revision>
+            recorded_by_email   TEXT CHECK (recorded_by_email IS NULL OR recorded_by_email <> ''), -- label at write time; scrubbable
+            recorded_at         TIMESTAMPTZ NOT NULL DEFAULT now(),
+            CHECK ((unit IS NULL) = (price_usd IS NULL)),
+            CHECK (price_usd IS NULL OR source_url IS NOT NULL)
+        );
+        CREATE INDEX pricing_rates_key_effective
+            ON benchmarks_v2.pricing_rates (benchmark, provider, model, effective_from DESC, recorded_at DESC);
+        """
+    )
+    bind = op.get_bind()
+    for row in SEED_ROWS:
+        # exec_driver_sql with parameters, not op.execute with literals: URLs and
+        # notes carry colons and percent signs that text() and format() would eat.
+        bind.exec_driver_sql(
+            """
+            INSERT INTO benchmarks_v2.pricing_rates
+                (benchmark, provider, model, unit, price_usd, effective_from, source_url, notes,
+                 recorded_by_user_id)
+            VALUES (%s, %s, %s, %s, %s::numeric, %s::date, %s, %s, %s)
+            """,
+            (*row, _RECORDED_BY),
+        )
+
+
+def downgrade() -> None:
+    """Drop the pricing log — but only while it holds nothing beyond this seed.
+
+    Rates recorded through the admin page have no other home: the seed below
+    is a snapshot, not a mirror of later changes. Dropping them would silently
+    forget every price change since launch, so the downgrade refuses while any
+    such recording exists. Export or copy them first.
+    """
+    recorded = (
+        op.get_bind()
+        .execute(
+            sa.text(
+                "SELECT count(*) FROM benchmarks_v2.pricing_rates "
+                "WHERE recorded_by_user_id <> :seed"
+            ),
+            {"seed": f"migration:{revision}"},
+        )
+        .scalar_one()
+    )
+    if recorded:
+        raise RuntimeError(
+            f"refusing to drop benchmarks_v2.pricing_rates: it holds {recorded} recording(s) "
+            "made after the seed and they exist nowhere else; back them up before downgrading"
+        )
+    op.execute("DROP TABLE IF EXISTS benchmarks_v2.pricing_rates;")

--- a/runner/src/coval_bench/db/pricing_store.py
+++ b/runner/src/coval_bench/db/pricing_store.py
@@ -1,0 +1,230 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""``PricingStore`` — the append-only pricing log.
+
+Mirrors ``db/registry_store.py``: async, the shared psycopg pool, every
+statement parameterised. Nothing here updates or deletes; a rate is changed by
+recording a new one, and ``registries.pricing.resolve`` decides which recording
+describes which day. :meth:`PricingStore.record` is the one door: a recording
+identical to the one currently describing that effective date is a no-op (a
+double-submit writes nothing), while re-recording a value that lost to a later
+correction is a real change and appends.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from datetime import date
+from decimal import Decimal
+from typing import Any
+
+import psycopg
+import psycopg.rows
+from psycopg_pool import AsyncConnectionPool
+from pydantic import BaseModel, Field, HttpUrl, field_validator, model_validator
+
+from coval_bench.registries.benchmarks import Benchmark
+from coval_bench.registries.pricing.resolve import RateKey, RateRecording
+from coval_bench.registries.pricing.schema import PricingEntry, PricingUnit
+
+PricingPool = AsyncConnectionPool[psycopg.AsyncConnection[psycopg.rows.DictRow]]
+
+
+class NewRate(BaseModel, frozen=True, extra="forbid"):
+    """A rate as an admin states it, before the log assigns identity and time.
+
+    A priced rate passes through :class:`PricingEntry`, so it obeys exactly the
+    rules a ratesheet entry does — unit bills the benchmark, price above zero
+    and written as a decimal string, a real URL. An unpriced one (``unit`` and
+    ``price_usd`` both None) says the model has no known public rate from
+    ``effective_from``; it may cite where that was checked but need not.
+    """
+
+    benchmark: Benchmark
+    provider: str = Field(min_length=1)
+    model: str = Field(min_length=1)
+    unit: PricingUnit | None = None
+    price_usd: Decimal | None = None
+    effective_from: date
+    source_url: HttpUrl | None = None
+    notes: str | None = None
+
+    @field_validator("price_usd", mode="before")
+    @classmethod
+    def _price_written_as_string(cls, value: object) -> object:
+        if isinstance(value, float | int):
+            raise ValueError('write price_usd as a string so the decimal is exact, e.g. "0.20"')
+        return value
+
+    @field_validator("notes", mode="before")
+    @classmethod
+    def _blank_notes_are_none(cls, value: object) -> object:
+        if isinstance(value, str) and not value.strip():
+            return None
+        return value.strip() if isinstance(value, str) else value
+
+    @model_validator(mode="after")
+    def _priced_or_delisted(self) -> NewRate:
+        if (self.unit is None) != (self.price_usd is None):
+            raise ValueError(
+                "a rate needs both a unit and a price; "
+                "a delisting (no known public rate) has neither"
+            )
+        if self.price_usd is not None:
+            if self.source_url is None:
+                raise ValueError("a priced rate must cite the public page that prints the figure")
+            # The ratesheet rules, applied to the admin's entry verbatim.
+            PricingEntry(
+                benchmark=self.benchmark,
+                provider=self.provider,
+                model=self.model,
+                unit=self.unit,
+                price_usd=self.price_usd,
+                effective_from=self.effective_from,
+                source_url=self.source_url,
+                notes=self.notes,
+            )
+        return self
+
+    @property
+    def key(self) -> RateKey:
+        return (self.benchmark, self.provider, self.model)
+
+    def matches(self, recording: RateRecording) -> bool:
+        """Whether *recording* already states this rate for this date.
+
+        Prices compare as written, not as numbers: ``0.20`` and ``0.2`` are the
+        same amount but not the same quote, and the site prints the quote.
+        """
+        return (
+            self.key == recording.key
+            and self.effective_from == recording.effective_from
+            and self.unit == recording.unit
+            and _as_written(self.price_usd) == _as_written(recording.price_usd)
+            and (None if self.source_url is None else str(self.source_url)) == recording.source_url
+            and self.notes == recording.notes
+        )
+
+
+def _as_written(price: Decimal | None) -> str | None:
+    return None if price is None else str(price)
+
+
+_COLUMNS = (
+    "id, benchmark, provider, model, unit, price_usd, effective_from, source_url, notes,"
+    " recorded_by_user_id, recorded_by_email, recorded_at"
+)
+_SELECT = f"SELECT {_COLUMNS} FROM benchmarks_v2.pricing_rates"  # noqa: S608 — column list is a constant
+_ORDER = " ORDER BY benchmark, provider, model, effective_from, recorded_at, id"
+
+_INSERT = f"""
+    INSERT INTO benchmarks_v2.pricing_rates
+        (benchmark, provider, model, unit, price_usd, effective_from, source_url, notes,
+         recorded_by_user_id, recorded_by_email)
+    VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+    RETURNING {_COLUMNS}
+"""  # noqa: S608 — column list is a constant
+
+# A recording already in the log with exactly these values, at any time.
+_EXISTS_EVER = """
+    SELECT 1 FROM benchmarks_v2.pricing_rates
+    WHERE benchmark = %s AND provider = %s AND model = %s AND effective_from = %s
+      AND unit IS NOT DISTINCT FROM %s
+      AND price_usd::text IS NOT DISTINCT FROM %s
+      AND source_url IS NOT DISTINCT FROM %s
+      AND notes IS NOT DISTINCT FROM %s
+    LIMIT 1
+"""
+
+
+def _recording(row: Mapping[str, Any]) -> RateRecording:
+    return RateRecording.model_validate(dict(row))
+
+
+def _insert_params(new: NewRate, user_id: str, email: str | None) -> tuple[Any, ...]:
+    return (
+        new.benchmark.value,
+        new.provider,
+        new.model,
+        None if new.unit is None else str(new.unit),
+        new.price_usd,
+        new.effective_from,
+        None if new.source_url is None else str(new.source_url),
+        new.notes,
+        user_id,
+        email,
+    )
+
+
+class PricingStore:
+    """Per-pool persistence helper for the pricing log."""
+
+    def __init__(self, pool: PricingPool) -> None:
+        self._pool = pool
+
+    async def recordings(self) -> list[RateRecording]:
+        """Every recording ever made, in key then chronological order."""
+        async with self._pool.connection() as conn:
+            rows = await (await conn.execute(_SELECT + _ORDER)).fetchall()
+        return [_recording(row) for row in rows]
+
+    async def recordings_for(self, key: RateKey) -> list[RateRecording]:
+        sql = _SELECT + " WHERE benchmark = %s AND provider = %s AND model = %s" + _ORDER
+        async with self._pool.connection() as conn:
+            rows = await (await conn.execute(sql, (key[0].value, key[1], key[2]))).fetchall()
+        return [_recording(row) for row in rows]
+
+    async def count_for(self, key: RateKey) -> int:
+        sql = (
+            "SELECT count(*) AS n FROM benchmarks_v2.pricing_rates"
+            " WHERE benchmark = %s AND provider = %s AND model = %s"
+        )
+        async with self._pool.connection() as conn:
+            row = await (await conn.execute(sql, (key[0].value, key[1], key[2]))).fetchone()
+        return 0 if row is None else int(row["n"])
+
+    async def model_exists(self, key: RateKey) -> bool:
+        """Whether the registry lists the model, in any state — hidden ones may be priced."""
+        sql = (
+            "SELECT 1 FROM benchmarks_v2.models"
+            " WHERE modality = %s AND provider = %s AND model = %s"
+        )
+        async with self._pool.connection() as conn:
+            row = await (await conn.execute(sql, (key[0].value, key[1], key[2]))).fetchone()
+        return row is not None
+
+    async def record(
+        self, new: NewRate, *, user_id: str, email: str | None
+    ) -> tuple[RateRecording, bool]:
+        """Append *new* unless it repeats what already describes that date.
+
+        Returns the recording now describing ``new.effective_from`` and whether
+        this call wrote it. Writers for one model are serialised on an advisory
+        lock so two admins saving at once cannot both see an empty date and
+        both append.
+        """
+        lock_key = f"pricing:{new.benchmark.value}:{new.provider}:{new.model}"
+        latest_sql = (
+            _SELECT
+            + " WHERE benchmark = %s AND provider = %s AND model = %s AND effective_from = %s"
+            + " ORDER BY recorded_at DESC, id DESC LIMIT 1"
+        )
+        async with self._pool.connection() as conn, conn.transaction():
+            await conn.execute("SELECT pg_advisory_xact_lock(hashtext(%s))", (lock_key,))
+            latest = await (
+                await conn.execute(
+                    latest_sql,
+                    (new.benchmark.value, new.provider, new.model, new.effective_from),
+                )
+            ).fetchone()
+            if latest is not None:
+                existing = _recording(latest)
+                if new.matches(existing):
+                    return existing, False
+            row = await (
+                await conn.execute(_INSERT, _insert_params(new, user_id, email))
+            ).fetchone()
+            if row is None:  # pragma: no cover — unreachable after INSERT RETURNING
+                raise RuntimeError("INSERT INTO benchmarks_v2.pricing_rates returned no row")
+            return _recording(row), True

--- a/runner/src/coval_bench/registries/pricing/__init__.py
+++ b/runner/src/coval_bench/registries/pricing/__init__.py
@@ -1,0 +1,7 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+"""Pricing rules and resolution. Rates themselves live in Postgres (pricing_rates)."""
+
+from coval_bench.registries.pricing.schema import PricingEntry, PricingUnit
+
+__all__ = ["PricingEntry", "PricingUnit"]

--- a/runner/src/coval_bench/registries/pricing/resolve.py
+++ b/runner/src/coval_bench/registries/pricing/resolve.py
@@ -1,0 +1,151 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+"""Which rate was in force when: the one place the pricing log is interpreted.
+
+``benchmarks_v2.pricing_rates`` is append-only. Every row is a *recording*: on
+``recorded_at`` someone (an admin, a migration, the ratesheet sync) said that
+from ``effective_from`` a model costs ``price_usd`` per ``unit`` — or, with both
+null, that no public rate is known from that day. Rows are never updated or
+deleted, so the table is the full history and this module is the rule that
+reads it. Two facts fall out of the rule, and everything that serves a price
+must go through here so they hold everywhere:
+
+* **For one effective date, the latest recording wins.** Recording a rate again
+  for a date that already has one is how a mistake is corrected — the earlier
+  recording stays in the log but stops describing that date.
+* **The rate in force on a day is the winning recording with the greatest
+  effective date at or before it.** A recording dated in the future is
+  scheduled: it prices nothing until its day arrives, and a public read never
+  sees it.
+
+Per key the winning recordings form a *timeline* of spans, each closed by the
+next span's effective date. A span whose recording is unpriced is a delisting:
+the model is known to have no public rate over that span.
+"""
+
+from __future__ import annotations
+
+from bisect import bisect_right
+from collections import defaultdict
+from collections.abc import Iterable
+from datetime import UTC, date, datetime
+from decimal import Decimal
+
+from pydantic import BaseModel, field_validator
+
+from coval_bench.registries.benchmarks import Benchmark
+from coval_bench.registries.pricing.schema import PricingUnit, per_1k_minutes, per_1m_chars
+
+RateKey = tuple[Benchmark, str, str]
+
+
+class RateRecording(BaseModel, frozen=True):
+    """One row of ``benchmarks_v2.pricing_rates``."""
+
+    id: int
+    benchmark: Benchmark
+    provider: str
+    model: str
+    # Both set (a published rate) or both None (no public rate from this date).
+    unit: PricingUnit | None
+    price_usd: Decimal | None
+    effective_from: date
+    source_url: str | None
+    notes: str | None
+    recorded_by_user_id: str
+    recorded_by_email: str | None
+    recorded_at: datetime
+
+    @field_validator("recorded_at")
+    @classmethod
+    def _in_utc(cls, value: datetime) -> datetime:
+        # The driver hands back timestamptz in the session's zone; serve one
+        # zone everywhere so two API instances never disagree on the stamp.
+        return value.astimezone(UTC) if value.tzinfo is not None else value.replace(tzinfo=UTC)
+
+    @property
+    def key(self) -> RateKey:
+        return (self.benchmark, self.provider, self.model)
+
+    @property
+    def priced(self) -> bool:
+        return self.price_usd is not None
+
+    @property
+    def price_per_1m_chars(self) -> Decimal | None:
+        if self.unit is None or self.price_usd is None:
+            return None
+        return per_1m_chars(self.unit, self.price_usd)
+
+    @property
+    def price_per_1k_minutes(self) -> Decimal | None:
+        if self.unit is None or self.price_usd is None:
+            return None
+        return per_1k_minutes(self.unit, self.price_usd)
+
+
+class RateSpan(BaseModel, frozen=True):
+    """A winning recording and the day the next one takes over (exclusive)."""
+
+    recording: RateRecording
+    effective_to: date | None
+
+    @property
+    def effective_from(self) -> date:
+        return self.recording.effective_from
+
+    def covers(self, day: date) -> bool:
+        return self.effective_from <= day and (self.effective_to is None or day < self.effective_to)
+
+
+class RateTimeline(BaseModel, frozen=True):
+    """One model's spans, ascending by effective date, gapless from the first."""
+
+    key: RateKey
+    spans: tuple[RateSpan, ...]
+    # Recordings that lost to a later one for the same date: kept for the
+    # admin's audit view, invisible to the public reads.
+    superseded: tuple[RateRecording, ...]
+
+    def in_force(self, day: date) -> RateSpan | None:
+        """The span covering *day*, or None before the first recording."""
+        starts = [span.effective_from for span in self.spans]
+        index = bisect_right(starts, day) - 1
+        return self.spans[index] if index >= 0 else None
+
+    def before(self, span: RateSpan) -> tuple[RateSpan, ...]:
+        """Every span that ended before *span* began — the public history."""
+        return tuple(s for s in self.spans if s.effective_from < span.effective_from)
+
+    def scheduled(self, day: date) -> tuple[RateSpan, ...]:
+        """Spans whose effective date is still ahead of *day*."""
+        return tuple(s for s in self.spans if s.effective_from > day)
+
+
+def timelines(recordings: Iterable[RateRecording]) -> dict[RateKey, RateTimeline]:
+    """Resolve every recording into per-model timelines."""
+    by_key: dict[RateKey, list[RateRecording]] = defaultdict(list)
+    for recording in recordings:
+        by_key[recording.key].append(recording)
+    return {key: _timeline(key, rows) for key, rows in by_key.items()}
+
+
+def _timeline(key: RateKey, rows: list[RateRecording]) -> RateTimeline:
+    winners: dict[date, RateRecording] = {}
+    superseded: list[RateRecording] = []
+    # Later recordings win; the id breaks a same-instant tie the way the
+    # identity column already ordered them.
+    for row in sorted(rows, key=lambda r: (r.recorded_at, r.id)):
+        loser = winners.get(row.effective_from)
+        if loser is not None:
+            superseded.append(loser)
+        winners[row.effective_from] = row
+    ordered = [winners[day] for day in sorted(winners)]
+    spans = tuple(
+        RateSpan(
+            recording=recording,
+            effective_to=ordered[i + 1].effective_from if i + 1 < len(ordered) else None,
+        )
+        for i, recording in enumerate(ordered)
+    )
+    return RateTimeline(key=key, spans=spans, superseded=tuple(superseded))

--- a/runner/src/coval_bench/registries/pricing/schema.py
+++ b/runner/src/coval_bench/registries/pricing/schema.py
@@ -1,0 +1,158 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+"""Schema for the provider-editable pricing registry.
+
+Entries live in per-provider JSON files under ``pricing/data/<benchmark>/``
+and carry the provider's *native* published unit; normalization to the two
+figures the API serves ($ per 1M characters for TTS, $ per 1,000 minutes for
+STT) happens here, never in the files.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import ROUND_HALF_UP, Decimal
+from enum import StrEnum
+
+from pydantic import BaseModel, Field, HttpUrl, field_validator, model_validator
+
+from coval_bench.registries.benchmarks import Benchmark
+
+# Scale for the one normalization that divides ($/hour → $/1,000 minutes, which
+# is × 1000 ÷ 60 and rarely terminates). Rounding it deliberately beats letting
+# the ambient Decimal context decide where the tail falls: a millionth of a
+# dollar per 1,000 minutes is finer than any published rate's own precision, and
+# the served figure is then identical everywhere. Every other unit scales by a
+# power of ten and stays exact.
+_DIVIDED_SCALE = Decimal("0.000001")
+
+
+class PricingUnit(StrEnum):
+    """The native unit a provider publishes its rate in.
+
+    Character units bill TTS input, duration units bill STT input. Each
+    normalizes within its own denominator; nothing converts across the two,
+    which would take an assumed speaking rate.
+    """
+
+    PER_1M_CHARS = "per_1m_chars"
+    PER_1K_CHARS = "per_1k_chars"
+    PER_CHAR = "per_char"
+    PER_SECOND_AUDIO_OUT = "per_second_audio_out"
+    PER_MINUTE = "per_minute"
+    PER_HOUR = "per_hour"
+    PER_SECOND_AUDIO_IN = "per_second_audio_in"
+
+
+# Which units bill which benchmark's input — the pairing CONTRIBUTING's table
+# states, enforced here so a mismatched entry fails at import with the entry
+# named, not later as a bare assert in a data test.
+_UNITS_BY_BENCHMARK: dict[Benchmark, frozenset[PricingUnit]] = {
+    Benchmark.TTS: frozenset(
+        {
+            PricingUnit.PER_1M_CHARS,
+            PricingUnit.PER_1K_CHARS,
+            PricingUnit.PER_CHAR,
+            PricingUnit.PER_SECOND_AUDIO_OUT,
+        }
+    ),
+    Benchmark.STT: frozenset(
+        {
+            PricingUnit.PER_MINUTE,
+            PricingUnit.PER_HOUR,
+            PricingUnit.PER_SECOND_AUDIO_IN,
+        }
+    ),
+}
+
+
+def units_for(benchmark: Benchmark) -> frozenset[PricingUnit]:
+    """The units that bill *benchmark*'s input; empty for a benchmark we do not price."""
+    return _UNITS_BY_BENCHMARK.get(benchmark, frozenset())
+
+
+def per_1m_chars(unit: PricingUnit, price_usd: Decimal) -> Decimal | None:
+    """A native rate normalized to USD per 1M characters.
+
+    Pure arithmetic per unit — ``per_1m_chars`` is served as-is,
+    ``per_1k_chars`` scales by 1000, ``per_char`` by 1,000,000.
+    ``per_second_audio_out`` returns None: seconds of audio have no
+    character equivalence without assuming a speaking rate, and we never
+    serve estimated figures.
+    """
+    if unit is PricingUnit.PER_1M_CHARS:
+        return price_usd
+    if unit is PricingUnit.PER_1K_CHARS:
+        return price_usd * 1000
+    if unit is PricingUnit.PER_CHAR:
+        return price_usd * 1_000_000
+    return None
+
+
+def per_1k_minutes(unit: PricingUnit, price_usd: Decimal) -> Decimal | None:
+    """A native rate normalized to USD per 1,000 minutes of input audio.
+
+    Defined only for the duration units that bill audio *in*.
+    ``per_second_audio_out`` measures synthesized output against a
+    different denominator, and character units have no duration
+    equivalence without assuming a speaking rate — both return None
+    rather than an estimate.
+
+    Per-minute and per-second rates scale exactly; the hourly conversion
+    divides and so rounds to ``_DIVIDED_SCALE``.
+    """
+    if unit is PricingUnit.PER_MINUTE:
+        return price_usd * 1000
+    if unit is PricingUnit.PER_HOUR:
+        return (price_usd * 1000 / 60).quantize(_DIVIDED_SCALE, rounding=ROUND_HALF_UP)
+    if unit is PricingUnit.PER_SECOND_AUDIO_IN:
+        return price_usd * 60_000
+    return None
+
+
+class PricingEntry(BaseModel, frozen=True, extra="forbid"):
+    """One model's published rate, keyed like the model registry.
+
+    The shape of a ratesheet entry. Since the rates moved into Postgres these
+    files are the seed and the open, reviewable mirror of the table, and this
+    class is what validates both them and every rate recorded through the
+    admin API — one set of rules, whichever door a rate comes in by.
+    """
+
+    benchmark: Benchmark
+    provider: str
+    model: str
+    unit: PricingUnit
+    price_usd: Decimal = Field(gt=0)
+    effective_from: date
+    source_url: HttpUrl
+    notes: str | None = None
+
+    @field_validator("price_usd", mode="before")
+    @classmethod
+    def _price_written_as_string(cls, value: object) -> object:
+        # A bare JSON number silently drops trailing zeros (0.20 → 0.2) — the
+        # exact misquote the decimal-string convention exists to prevent.
+        # Decimal itself stays accepted for entries built in code.
+        if isinstance(value, float | int):
+            raise ValueError('write price_usd as a string so the decimal is exact, e.g. "0.20"')
+        return value
+
+    @model_validator(mode="after")
+    def _unit_bills_this_benchmark(self) -> PricingEntry:
+        if self.unit not in _UNITS_BY_BENCHMARK.get(self.benchmark, frozenset()):
+            raise ValueError(
+                f"{self.unit} does not bill {self.benchmark} input; "
+                "see the unit table in CONTRIBUTING.md"
+            )
+        return self
+
+    @property
+    def price_per_1m_chars(self) -> Decimal | None:
+        """The native rate normalized to USD per 1M characters; see :func:`per_1m_chars`."""
+        return per_1m_chars(self.unit, self.price_usd)
+
+    @property
+    def price_per_1k_minutes(self) -> Decimal | None:
+        """The native rate normalized to USD per 1,000 minutes; see :func:`per_1k_minutes`."""
+        return per_1k_minutes(self.unit, self.price_usd)

--- a/runner/tests/api/conftest.py
+++ b/runner/tests/api/conftest.py
@@ -22,9 +22,10 @@ from __future__ import annotations
 
 import json
 import time
-from collections.abc import AsyncIterator, Awaitable, Callable, Sequence
+from collections.abc import AsyncIterator, Awaitable, Callable, Iterable, Sequence
 from contextlib import asynccontextmanager
-from datetime import datetime
+from datetime import date, datetime
+from decimal import Decimal
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
@@ -54,6 +55,8 @@ from coval_bench.registries import (
     RegisteredModel,
     tag_value_label,
 )
+from coval_bench.registries import Benchmark as _Benchmark
+from coval_bench.registries.pricing import PricingEntry, PricingUnit
 from coval_bench.registries.provider_keys import PROVIDER_ENV
 
 ARENA_LABELER_KEY = "test-labeler-key"
@@ -348,6 +351,31 @@ def _load_schema(**connect_kwargs: Any) -> None:
             CREATE INDEX IF NOT EXISTS model_history_model_id_changed_at
                 ON benchmarks_v2.model_history (model_id, changed_at DESC)
         """)
+        # Pricing log (mirrors migration 20260903_0027).
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS benchmarks_v2.pricing_rates (
+                id                  bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+                benchmark           text NOT NULL CHECK (benchmark IN ('STT','TTS','S2S')),
+                provider            text NOT NULL CHECK (provider <> ''),
+                model               text NOT NULL CHECK (model <> ''),
+                unit                text CHECK (unit IS NULL OR unit <> ''),
+                price_usd           numeric CHECK (price_usd IS NULL OR price_usd > 0),
+                effective_from      date NOT NULL,
+                source_url          text CHECK (source_url IS NULL OR source_url <> ''),
+                notes               text CHECK (notes IS NULL OR notes <> ''),
+                recorded_by_user_id text NOT NULL CHECK (recorded_by_user_id <> ''),
+                recorded_by_email   text
+                    CHECK (recorded_by_email IS NULL OR recorded_by_email <> ''),
+                recorded_at         timestamptz NOT NULL DEFAULT now(),
+                CHECK ((unit IS NULL) = (price_usd IS NULL)),
+                CHECK (price_usd IS NULL OR source_url IS NOT NULL)
+            )
+        """)
+        conn.execute("""
+            CREATE INDEX IF NOT EXISTS pricing_rates_key_effective
+                ON benchmarks_v2.pricing_rates
+                (benchmark, provider, model, effective_from DESC, recorded_at DESC)
+        """)
 
 
 def _seed_registry(**connect_kwargs: Any) -> None:
@@ -364,6 +392,7 @@ def _seed_registry(**connect_kwargs: Any) -> None:
                 (str(tag), category.value, tag_value_label(category, str(tag))),
             )
         _insert_models(conn, MODEL_REGISTRY)
+        _insert_rates(conn, SEED_RATES)
         conn.commit()
 
 
@@ -400,6 +429,55 @@ def _insert_models(conn: psycopg.Connection[Any], models: Sequence[RegisteredMod
                 "INSERT INTO benchmarks_v2.model_tags (model_id, tag) VALUES (%s, %s)",
                 (row[0], str(tag)),
             )
+
+
+# Two real published rates the fixture log starts with (the production seed is
+# the migration's own literal); one per priced benchmark.
+SEED_RATES: tuple[PricingEntry, ...] = (
+    PricingEntry(
+        benchmark=_Benchmark.STT,
+        provider="deepgram",
+        model="nova-3",
+        unit=PricingUnit.PER_MINUTE,
+        price_usd=Decimal("0.0048"),
+        effective_from=date(2026, 8, 24),
+        source_url="https://deepgram.com/pricing",
+        notes="Pay As You Go streaming rate.",
+    ),
+    PricingEntry(
+        benchmark=_Benchmark.TTS,
+        provider="deepgram",
+        model="aura-2-thalia-en",
+        unit=PricingUnit.PER_1K_CHARS,
+        price_usd=Decimal("0.030"),
+        effective_from=date(2026, 8, 10),
+        source_url="https://deepgram.com/pricing",
+        notes="Aura-2 Pay As You Go rate.",
+    ),
+)
+
+
+def _insert_rates(conn: psycopg.Connection[Any], entries: Iterable[PricingEntry]) -> None:
+    """Record ratesheet entries into the pricing log, as the seed migration does."""
+    for entry in entries:
+        conn.execute(
+            """
+            INSERT INTO benchmarks_v2.pricing_rates
+                (benchmark, provider, model, unit, price_usd, effective_from, source_url, notes,
+                 recorded_by_user_id)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, 'tests')
+            """,
+            (
+                str(entry.benchmark),
+                entry.provider,
+                entry.model,
+                str(entry.unit),
+                entry.price_usd,
+                entry.effective_from,
+                str(entry.source_url),
+                entry.notes,
+            ),
+        )
 
 
 def add_models(postgresql: Any, *models: RegisteredModel) -> None:

--- a/runner/tests/api/test_admin_pricing.py
+++ b/runner/tests/api/test_admin_pricing.py
@@ -1,0 +1,211 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""The admin pricing endpoints over HTTP."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from fastapi import FastAPI
+from httpx import AsyncClient
+
+from coval_bench.api import deps
+from coval_bench.registries import MODEL_REGISTRY, Benchmark, RegisteredModel
+from tests.api.conftest import (
+    COVAL_ORG,
+    EA_MODEL,
+    EA_ORG,
+    EA_PROVIDER,
+    SEED_RATES,
+    add_models,
+    bearer,
+)
+
+TODAY = datetime.now(UTC).date()
+SEEDED = {"benchmark": "STT", "provider": "deepgram", "model": "nova-3"}
+
+
+def _admin_headers() -> dict[str, str]:
+    return bearer(sub="user_admin", org_id=COVAL_ORG, email="admin@coval.dev")
+
+
+def _body(**overrides: Any) -> dict[str, Any]:
+    body: dict[str, Any] = {
+        **SEEDED,
+        "unit": "per_minute",
+        "price_usd": "0.0050",
+        "source_url": "https://deepgram.com/pricing",
+    }
+    body.update(overrides)
+    return body
+
+
+async def _post(client: AsyncClient, **overrides: Any) -> Any:
+    return await client.post("/v1/admin/pricing", json=_body(**overrides), headers=_admin_headers())
+
+
+def _model(payload: dict[str, Any], **key: str) -> dict[str, Any]:
+    wanted = {**SEEDED, **key}
+    return next(
+        m
+        for m in payload["models"]
+        if (m["benchmark"], m["provider"], m["model"])
+        == (wanted["benchmark"], wanted["provider"], wanted["model"])
+    )
+
+
+async def test_reads_require_a_coval_token(client: AsyncClient) -> None:
+    assert (await client.get("/v1/admin/pricing")).status_code == 401
+    partner = bearer(sub="user_partner", org_id=EA_ORG)
+    assert (await client.get("/v1/admin/pricing", headers=partner)).status_code == 403
+    assert (await client.post("/v1/admin/pricing", json=_body())).status_code == 401
+    assert (
+        await client.post("/v1/admin/pricing", json=_body(), headers=partner)
+    ).status_code == 403
+
+
+async def test_list_resolves_the_seeded_log_and_is_private(client: AsyncClient) -> None:
+    response = await client.get("/v1/admin/pricing", headers=_admin_headers())
+    assert response.status_code == 200
+    assert response.headers["Cache-Control"] == "private, no-store"
+    payload = response.json()
+    assert payload["as_of"] == TODAY.isoformat()
+    assert len(payload["models"]) == len(SEED_RATES)
+    nova = _model(payload)
+    assert nova["current"]["price_usd"] == "0.0048"
+    assert nova["current"]["price_per_1k_minutes"] == 4.8
+    assert nova["scheduled"] == []
+    (recording,) = nova["recordings"]
+    assert recording["superseded"] is False
+    assert recording["recorded_by_user_id"] == "tests"
+
+
+async def test_recording_a_rate_takes_effect_and_names_the_admin(client: AsyncClient) -> None:
+    response = await _post(client)
+    assert response.status_code == 201
+    model = response.json()
+    assert model["current"]["price_usd"] == "0.0050"
+    assert model["current"]["effective_from"] == TODAY.isoformat()
+    assert model["current"]["recorded_by_email"] == "admin@coval.dev"
+    assert model["current"]["recorded_by_user_id"] == "user_admin"
+    newest, seeded = model["recordings"]
+    assert newest["price_usd"] == "0.0050" and newest["superseded"] is False
+    assert seeded["recorded_by_user_id"] == "tests" and seeded["superseded"] is False
+
+    public = await client.get("/v1/pricing")
+    served = next(r for r in public.json()["rates"] if r["model"] == "nova-3")
+    assert served["price_usd"] == "0.0050"
+    # The panel prints the admin figure; the public page prints the served one.
+    assert served["price_per_1k_minutes"] == model["current"]["price_per_1k_minutes"] == 5.0
+    assert served["history"][0]["price_usd"] == "0.0048"
+
+
+async def test_repeating_the_current_recording_writes_nothing(client: AsyncClient) -> None:
+    assert (await _post(client)).status_code == 201
+    repeat = await _post(client)
+    assert repeat.status_code == 200
+    assert len(repeat.json()["recordings"]) == 2  # the seed plus the one recording
+
+
+async def test_a_correction_supersedes_the_same_day(client: AsyncClient) -> None:
+    await _post(client, price_usd="0.0500")  # slipped a zero
+    fixed = await _post(client, price_usd="0.0050")
+    assert fixed.status_code == 201
+    model = fixed.json()
+    assert model["current"]["price_usd"] == "0.0050"
+    by_price = {r["price_usd"]: r["superseded"] for r in model["recordings"]}
+    assert by_price == {"0.0050": False, "0.0500": True, "0.0048": False}
+
+
+async def test_a_future_date_schedules_without_changing_today(client: AsyncClient) -> None:
+    ahead = (TODAY + timedelta(days=14)).isoformat()
+    response = await _post(client, price_usd="0.0077", effective_from=ahead)
+    assert response.status_code == 201
+    model = response.json()
+    assert model["current"]["price_usd"] == "0.0048"
+    (scheduled,) = model["scheduled"]
+    assert (scheduled["price_usd"], scheduled["effective_from"]) == ("0.0077", ahead)
+    public = next(
+        r for r in (await client.get("/v1/pricing")).json()["rates"] if r["model"] == "nova-3"
+    )
+    # The scheduled change is not public until its day — not even its date.
+    assert public["price_usd"] == "0.0048" and public["effective_to"] is None
+
+
+async def test_a_delisting_records_no_public_rate(client: AsyncClient) -> None:
+    response = await _post(
+        client, unit=None, price_usd=None, source_url=None, notes="No longer on the pricing page."
+    )
+    assert response.status_code == 201
+    current = response.json()["current"]
+    assert current["unit"] is None and current["price_usd"] is None
+    assert current["notes"] == "No longer on the pricing page."
+    public = next(
+        r for r in (await client.get("/v1/pricing")).json()["rates"] if r["model"] == "nova-3"
+    )
+    assert public["price_usd"] is None and public["history"][0]["price_usd"] == "0.0048"
+
+
+async def test_a_hidden_model_may_be_priced_ahead_of_launch(
+    client: AsyncClient, app: FastAPI, postgresql: Any
+) -> None:
+    hidden = RegisteredModel(
+        benchmark=Benchmark.STT,
+        provider=EA_PROVIDER,
+        model=EA_MODEL,
+        collected=True,
+        published=False,
+    )
+    add_models(postgresql, hidden)
+    app.dependency_overrides[deps.get_models] = lambda: [*MODEL_REGISTRY, hidden]
+    response = await _post(
+        client,
+        provider=EA_PROVIDER,
+        model=EA_MODEL,
+        price_usd="0.006",
+        source_url="https://acme.example.com/pricing",
+    )
+    assert response.status_code == 201
+    listed = await client.get("/v1/admin/pricing", headers=_admin_headers())
+    assert (
+        _model(listed.json(), provider=EA_PROVIDER, model=EA_MODEL)["current"]["price_usd"]
+        == "0.006"
+    )
+    public = await client.get("/v1/pricing")
+    assert all(r["model"] != EA_MODEL for r in public.json()["rates"])
+    cleared = await client.get("/v1/pricing", headers=bearer(org_id=EA_ORG))
+    assert any(r["model"] == EA_MODEL for r in cleared.json()["rates"])
+
+
+async def test_effective_from_defaults_to_today(client: AsyncClient) -> None:
+    body = _body()
+    del body["source_url"]
+    body["source_url"] = "https://deepgram.com/pricing"
+    response = await client.post("/v1/admin/pricing", json=body, headers=_admin_headers())
+    assert response.json()["current"]["effective_from"] == TODAY.isoformat()
+
+
+async def test_writes_are_validated_like_ratesheet_entries(client: AsyncClient) -> None:
+    unknown = await _post(client, model="nova-99")
+    assert unknown.status_code == 422 and "no registered model" in unknown.json()["detail"]
+
+    half = await _post(client, price_usd=None)
+    assert half.status_code == 422 and "both a unit and a price" in half.json()["detail"]
+
+    assert (await _post(client, price_usd=0.005)).status_code == 422  # a JSON number
+
+    wrong_unit = await _post(client, unit="per_1k_chars")
+    assert wrong_unit.status_code == 422 and "does not bill" in wrong_unit.json()["detail"]
+
+    unsourced = await _post(client, source_url=None)
+    assert unsourced.status_code == 422 and "cite" in unsourced.json()["detail"]
+
+    assert (await _post(client, source_url="not a url")).status_code == 422
+    assert (await _post(client, price_usd="0")).status_code == 422
+
+    too_far = await _post(client, effective_from=(TODAY + timedelta(days=400)).isoformat())
+    assert too_far.status_code == 422 and "a year ahead" in too_far.json()["detail"]
+    assert (await _post(client, effective_from="2019-12-31")).status_code == 422
+    assert (await _post(client, effective_from="someday")).status_code == 422

--- a/runner/tests/api/test_pricing.py
+++ b/runner/tests/api/test_pricing.py
@@ -1,0 +1,232 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""GET /v1/pricing: the rate in force on a day, its history, and model visibility."""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime, timedelta
+from typing import Any
+
+import psycopg
+from fastapi import FastAPI
+from httpx import AsyncClient
+
+from coval_bench.api import deps
+from coval_bench.registries import MODEL_REGISTRY, Benchmark, RegisteredModel
+from tests.api.conftest import (
+    COVAL_ORG,
+    EA_MODEL,
+    EA_ORG,
+    EA_ORG_OTHER,
+    EA_PROVIDER,
+    SEED_RATES,
+    _make_db_url,
+    bearer,
+)
+
+TODAY = datetime.now(UTC).date()
+EA_KEY = ("STT", EA_PROVIDER, EA_MODEL)
+
+
+def _record(
+    postgresql: Any,
+    *,
+    benchmark: str = "STT",
+    provider: str = EA_PROVIDER,
+    model: str = EA_MODEL,
+    price: str | None = "0.006",
+    unit: str | None = "per_minute",
+    effective_from: date = TODAY,
+    recorded_at: datetime | None = None,
+    source_url: str | None = "https://acme.example.com/pricing",
+) -> None:
+    """Append one recording straight into the log, as the admin API would."""
+    with psycopg.connect(_make_db_url(postgresql)) as conn:
+        conn.execute(
+            """
+            INSERT INTO benchmarks_v2.pricing_rates
+                (benchmark, provider, model, unit, price_usd, effective_from, source_url,
+                 recorded_by_user_id, recorded_at)
+            VALUES (%s, %s, %s, %s, %s::numeric, %s, %s, 'tests', COALESCE(%s, now()))
+            """,
+            (
+                benchmark,
+                provider,
+                model,
+                None if price is None else unit,
+                price,
+                effective_from,
+                None if price is None else source_url,
+                recorded_at,
+            ),
+        )
+        conn.commit()
+
+
+def _serve_model(app: FastAPI, *, collected: bool = True, published: bool = True) -> None:
+    """Extend the served roster with the early-access fixture model."""
+    model = RegisteredModel(
+        benchmark=Benchmark.STT,
+        provider=EA_PROVIDER,
+        model=EA_MODEL,
+        collected=collected,
+        published=published,
+    )
+    app.dependency_overrides[deps.get_models] = lambda: [*MODEL_REGISTRY, model]
+
+
+def _seeded() -> dict[tuple[str, str, str], Any]:
+    """The fixture's seeded rates by key: all sit on published models."""
+    return {(e.benchmark.value, e.provider, e.model): e for e in SEED_RATES}
+
+
+def _rates_by_key(payload: dict[str, Any]) -> dict[tuple[str, str, str], dict[str, Any]]:
+    return {(r["benchmark"], r["provider"], r["model"]): r for r in payload["rates"]}
+
+
+async def test_get_serves_the_seeded_log(client: AsyncClient) -> None:
+    """The public read is the seeded log: each rate in force today, no history yet."""
+    response = await client.get("/v1/pricing")
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["as_of"] == TODAY.isoformat()
+    rates = _rates_by_key(payload)
+    assert set(rates) == set(_seeded())
+    for rate in rates.values():
+        assert rate["history"] == []
+        assert rate["effective_to"] is None
+        assert rate["recorded_at"]
+
+
+async def test_price_usd_is_the_exact_decimal_string(client: AsyncClient) -> None:
+    """The native figure round-trips verbatim — a float would misquote $0.20 as $0.2."""
+    served = _rates_by_key((await client.get("/v1/pricing")).json())
+    for key, entry in _seeded().items():
+        assert served[key]["price_usd"] == str(entry.price_usd)
+        assert served[key]["unit"] == str(entry.unit)
+
+
+async def test_future_rate_is_scheduled_not_current(
+    client: AsyncClient, app: FastAPI, postgresql: Any
+) -> None:
+    """A rate dated tomorrow is in the log but prices nothing today."""
+    _serve_model(app)
+    _record(postgresql, effective_from=TODAY + timedelta(days=1))
+    response = await client.get("/v1/pricing", headers=bearer(org_id=EA_ORG))
+    assert EA_KEY not in _rates_by_key(response.json())
+
+
+async def test_as_of_may_not_be_in_the_future(client: AsyncClient) -> None:
+    tomorrow = (TODAY + timedelta(days=1)).isoformat()
+    assert (await client.get(f"/v1/pricing?as_of={tomorrow}")).status_code == 422
+    assert (await client.get("/v1/pricing?as_of=yesterday")).status_code == 422
+    today = await client.get(f"/v1/pricing?as_of={TODAY.isoformat()}")
+    assert today.status_code == 200 and today.json()["as_of"] == TODAY.isoformat()
+
+
+async def test_embargoed_rate_stays_hidden_from_public(
+    client: AsyncClient, app: FastAPI, postgresql: Any
+) -> None:
+    """A rate on an unpublished model shows only to callers cleared for the model."""
+    _serve_model(app, published=False)
+    _record(postgresql)
+    public = await client.get("/v1/pricing")
+    assert EA_KEY not in _rates_by_key(public.json())
+    assert public.headers["X-EA-Token-Status"] == "absent"
+    cleared = await client.get("/v1/pricing", headers=bearer(org_id=EA_ORG))
+    assert cleared.headers["X-EA-Token-Status"] == "accepted"
+    assert cleared.headers["Cache-Control"] == "private, no-store"
+    rate = _rates_by_key(cleared.json())[EA_KEY]
+    assert rate["price_per_1k_minutes"] == 6.0
+    assert rate["price_per_1m_chars"] is None
+    # Another partner org — cleared for a *different* model on the same provider —
+    # is scoped by model, not vendor: this rate stays hidden from it.
+    other = await client.get("/v1/pricing", headers=bearer(org_id=EA_ORG_OTHER))
+    assert other.headers["X-EA-Token-Status"] == "accepted"
+    assert EA_KEY not in _rates_by_key(other.json())
+    # And the coval org sees everything, as it does on every other data endpoint.
+    staff = await client.get("/v1/pricing", headers=bearer(org_id=COVAL_ORG))
+    assert EA_KEY in _rates_by_key(staff.json())
+
+
+async def test_uncollected_model_rate_serves_to_everyone(
+    client: AsyncClient, app: FastAPI, postgresql: Any
+) -> None:
+    """A rate on a model the runner no longer collects still serves publicly.
+
+    The site lists uncollected models greyed out, so their price stays readable.
+    """
+    _serve_model(app, collected=False)
+    _record(postgresql)
+    rate = _rates_by_key((await client.get("/v1/pricing")).json())[EA_KEY]
+    assert rate["price_per_1k_minutes"] == 6.0
+
+
+async def test_a_rate_on_a_model_off_the_roster_is_not_served(
+    client: AsyncClient, postgresql: Any
+) -> None:
+    """The log may outlive a model; the read serves only what the roster lists."""
+    _record(postgresql, provider="ghost", model="nobody")
+    assert ("STT", "ghost", "nobody") not in _rates_by_key((await client.get("/v1/pricing")).json())
+
+
+async def test_as_of_serves_the_rate_in_force_that_day_with_its_history(
+    client: AsyncClient, app: FastAPI, postgresql: Any
+) -> None:
+    """A price change mid-timeline: each day reads the rate that held on it."""
+    _serve_model(app)
+    _record(postgresql, price="0.006", effective_from=date(2026, 1, 1))
+    _record(postgresql, price="0.009", effective_from=TODAY)
+
+    now = _rates_by_key((await client.get("/v1/pricing")).json())[EA_KEY]
+    assert (now["price_usd"], now["effective_from"], now["effective_to"]) == (
+        "0.009",
+        TODAY.isoformat(),
+        None,
+    )
+    (old,) = now["history"]
+    assert (old["price_usd"], old["effective_from"], old["effective_to"]) == (
+        "0.006",
+        "2026-01-01",
+        TODAY.isoformat(),
+    )
+    assert old["price_per_1k_minutes"] == 6.0
+
+    yesterday = (TODAY - timedelta(days=1)).isoformat()
+    then = _rates_by_key((await client.get(f"/v1/pricing?as_of={yesterday}")).json())[EA_KEY]
+    assert (then["price_usd"], then["effective_to"], then["history"]) == (
+        "0.006",
+        TODAY.isoformat(),
+        [],
+    )
+
+
+async def test_a_correction_supersedes_and_stays_out_of_public_history(
+    client: AsyncClient, app: FastAPI, postgresql: Any
+) -> None:
+    """Re-recording a date replaces the earlier figure; the typo never described a day."""
+    _serve_model(app)
+    base = datetime(2026, 9, 1, 9, 0, tzinfo=UTC)
+    _record(postgresql, price="0.060", recorded_at=base)
+    _record(postgresql, price="0.006", recorded_at=base + timedelta(minutes=5))
+    rate = _rates_by_key((await client.get("/v1/pricing")).json())[EA_KEY]
+    assert rate["price_usd"] == "0.006"
+    assert rate["history"] == []
+    assert rate["recorded_at"].startswith("2026-09-01T09:05:00")
+
+
+async def test_a_delisted_model_serves_null_fields_with_its_history(
+    client: AsyncClient, app: FastAPI, postgresql: Any
+) -> None:
+    """A model whose provider stopped printing a rate keeps its row and its past."""
+    _serve_model(app)
+    _record(postgresql, price="0.006", effective_from=date(2026, 1, 1))
+    _record(postgresql, price=None, effective_from=TODAY)
+    rate = _rates_by_key((await client.get("/v1/pricing")).json())[EA_KEY]
+    assert rate["unit"] is None
+    assert rate["price_usd"] is None
+    assert rate["source_url"] is None
+    assert rate["price_per_1k_minutes"] is None
+    (old,) = rate["history"]
+    assert old["price_usd"] == "0.006" and old["effective_to"] == TODAY.isoformat()

--- a/runner/tests/unit/test_pricing_resolve.py
+++ b/runner/tests/unit/test_pricing_resolve.py
@@ -1,0 +1,120 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""The one rule for reading the pricing log: which recording describes which day."""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime, timedelta
+from decimal import Decimal
+
+from coval_bench.registries import Benchmark
+from coval_bench.registries.pricing.resolve import RateRecording, timelines
+from coval_bench.registries.pricing.schema import PricingUnit
+
+TODAY = date(2026, 9, 2)
+KEY = (Benchmark.STT, "acme", "stt-1")
+
+
+def _rec(
+    id: int,
+    effective_from: date,
+    price: str | None = "0.006",
+    *,
+    unit: PricingUnit | None = PricingUnit.PER_MINUTE,
+    recorded_at: datetime | None = None,
+    key: tuple[Benchmark, str, str] = KEY,
+) -> RateRecording:
+    priced = price is not None
+    return RateRecording(
+        id=id,
+        benchmark=key[0],
+        provider=key[1],
+        model=key[2],
+        unit=unit if priced else None,
+        price_usd=None if price is None else Decimal(price),
+        effective_from=effective_from,
+        source_url="https://acme.example.com/pricing" if priced else None,
+        notes=None,
+        recorded_by_user_id="user_test",
+        recorded_by_email=None,
+        recorded_at=recorded_at or datetime(2026, 9, 1, 12, 0, tzinfo=UTC) + timedelta(seconds=id),
+    )
+
+
+def test_no_recordings_means_no_timelines() -> None:
+    assert timelines([]) == {}
+
+
+def test_a_single_recording_is_an_open_span_from_its_day() -> None:
+    (timeline,) = timelines([_rec(1, TODAY)]).values()
+    (span,) = timeline.spans
+    assert span.effective_to is None
+    assert timeline.in_force(TODAY - timedelta(days=1)) is None
+    assert timeline.in_force(TODAY) is span
+    assert timeline.in_force(TODAY + timedelta(days=400)) is span
+    assert timeline.before(span) == ()
+    assert timeline.superseded == ()
+
+
+def test_a_later_effective_date_closes_the_earlier_span() -> None:
+    old, new = _rec(1, date(2026, 1, 1), "0.006"), _rec(2, TODAY, "0.009")
+    timeline = timelines([new, old])[KEY]
+    first, second = timeline.spans
+    assert first.recording is old and first.effective_to == TODAY
+    assert second.recording is new and second.effective_to is None
+    assert timeline.in_force(date(2026, 6, 1)) is first
+    assert timeline.in_force(TODAY) is second
+    assert timeline.before(second) == (first,)
+
+
+def test_the_latest_recording_wins_a_shared_effective_date() -> None:
+    typo = _rec(1, TODAY, "0.060", recorded_at=datetime(2026, 9, 2, 9, 0, tzinfo=UTC))
+    fix = _rec(2, TODAY, "0.006", recorded_at=datetime(2026, 9, 2, 9, 5, tzinfo=UTC))
+    timeline = timelines([fix, typo])[KEY]
+    assert [span.recording for span in timeline.spans] == [fix]
+    assert timeline.superseded == (typo,)
+    # The correction is not "history": the typo never described a day.
+    assert timeline.before(timeline.spans[0]) == ()
+
+
+def test_a_same_instant_tie_falls_to_the_later_row() -> None:
+    at = datetime(2026, 9, 2, 9, 0, tzinfo=UTC)
+    a, b = _rec(1, TODAY, "0.006", recorded_at=at), _rec(2, TODAY, "0.007", recorded_at=at)
+    timeline = timelines([b, a])[KEY]
+    assert timeline.spans[0].recording is b
+
+
+def test_a_future_recording_is_scheduled_not_in_force() -> None:
+    current, ahead = _rec(1, date(2026, 1, 1)), _rec(2, TODAY + timedelta(days=30), "0.009")
+    timeline = timelines([current, ahead])[KEY]
+    assert timeline.in_force(TODAY) is timeline.spans[0]
+    assert timeline.in_force(TODAY).effective_to == ahead.effective_from  # type: ignore[union-attr]
+    assert timeline.scheduled(TODAY) == (timeline.spans[1],)
+    assert timeline.scheduled(TODAY + timedelta(days=30)) == ()
+
+
+def test_a_delisting_is_an_unpriced_span() -> None:
+    priced, gone = _rec(1, date(2026, 1, 1)), _rec(2, TODAY, None, unit=None)
+    timeline = timelines([priced, gone])[KEY]
+    span = timeline.in_force(TODAY)
+    assert span is not None and not span.recording.priced
+    assert span.recording.price_per_1k_minutes is None
+    assert timeline.before(span)[0].recording.priced
+
+
+def test_recordings_normalize_like_ratesheet_entries() -> None:
+    hourly = _rec(1, TODAY, "0.45", unit=PricingUnit.PER_HOUR)
+    assert hourly.price_per_1k_minutes == Decimal("7.5")
+    assert hourly.price_per_1m_chars is None
+    chars = _rec(2, TODAY, "0.030", unit=PricingUnit.PER_1K_CHARS, key=(Benchmark.TTS, "a", "m"))
+    assert chars.price_per_1m_chars == Decimal("30")
+
+
+def test_keys_are_kept_apart() -> None:
+    other = (Benchmark.TTS, "acme", "tts-1")
+    result = timelines(
+        [_rec(1, TODAY), _rec(2, TODAY, "15", unit=PricingUnit.PER_1M_CHARS, key=other)]
+    )
+    assert set(result) == {KEY, other}
+    assert result[other].spans[0].recording.price_per_1m_chars == Decimal("15")

--- a/runner/tests/unit/test_pricing_store.py
+++ b/runner/tests/unit/test_pricing_store.py
@@ -1,0 +1,207 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""The pricing log's two doors, against a real Postgres brought up by the migrations.
+
+Running the migrations here is the seed's parity test: after ``upgrade head``
+the log must hold exactly the packaged ratesheets, so a ratesheet edit that
+forgets the ``SEED_ROWS`` literal (or the reverse) fails right here.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+from typing import Any
+
+import psycopg
+import pytest
+from alembic import command as alembic_command
+from alembic.config import Config as AlembicConfig
+from pydantic import ValidationError
+from pytest_postgresql.factories import postgresql
+
+from coval_bench.db.pricing_store import NewRate, PricingStore
+from coval_bench.registries import Benchmark
+from coval_bench.registries.pricing.resolve import timelines
+from coval_bench.registries.pricing.schema import PricingUnit
+
+from .conftest import _INI_PATH, apply_migrations, async_dsn, open_pool
+
+pricing_pg = postgresql("pg_proc")  # shared server from conftest, own per-test DB
+
+_ADMIN = {"user_id": "user_cale", "email": "cale@coval.dev"}
+SEEDED_KEY = (Benchmark.STT, "deepgram", "nova-3")
+TODAY = datetime.now(UTC).date()
+
+
+def _with_store(
+    conn: psycopg.Connection[Any],
+    scenario: Callable[[PricingStore, psycopg.Connection[Any]], Awaitable[None]],
+) -> None:
+    apply_migrations(conn)
+
+    async def _run() -> None:
+        pool = await open_pool(conn)
+        try:
+            await scenario(PricingStore(pool), conn)
+        finally:
+            await pool.close()
+
+    asyncio.run(_run())
+
+
+def _rate(price: str | None = "0.0050", **overrides: Any) -> NewRate:
+    fields: dict[str, Any] = {
+        "benchmark": SEEDED_KEY[0],
+        "provider": SEEDED_KEY[1],
+        "model": SEEDED_KEY[2],
+        "unit": None if price is None else PricingUnit.PER_MINUTE,
+        "price_usd": price,
+        "effective_from": TODAY,
+        "source_url": None if price is None else "https://deepgram.com/pricing",
+    }
+    fields.update(overrides)
+    return NewRate.model_validate(fields)
+
+
+def test_the_migration_seeds_valid_rates_on_registered_models(
+    pricing_pg: psycopg.Connection[Any],
+) -> None:
+    """Every seeded row passes the same rules an admin write must, and prices a real model."""
+
+    async def scenario(store: PricingStore, conn: psycopg.Connection[Any]) -> None:
+        recordings = await store.recordings()
+        assert len(recordings) == 61
+        assert len({r.key for r in recordings}) == 61  # one rate per model
+        for recording in recordings:
+            NewRate(
+                benchmark=recording.key[0],
+                provider=recording.key[1],
+                model=recording.key[2],
+                unit=recording.unit,
+                price_usd=recording.price_usd,
+                effective_from=recording.effective_from,
+                source_url=recording.source_url,
+                notes=recording.notes,
+            )
+            assert recording.priced, recording.key
+            assert recording.recorded_by_user_id == "migration:20260903_0027"
+            assert recording.recorded_by_email is None
+            assert await store.model_exists(recording.key), recording.key
+        # The scale of the quoted figure survives the round trip (0.030, not 0.03).
+        aura = next(
+            r for r in recordings if r.key == (Benchmark.TTS, "deepgram", "aura-2-thalia-en")
+        )
+        assert str(aura.price_usd) == "0.030"
+        nova = next(r for r in recordings if r.key == SEEDED_KEY)
+        assert str(nova.price_usd) == "0.0048"
+
+    _with_store(pricing_pg, scenario)
+
+
+def test_record_appends_ignores_repeats_and_keeps_corrections(
+    pricing_pg: psycopg.Connection[Any],
+) -> None:
+    async def scenario(store: PricingStore, conn: psycopg.Connection[Any]) -> None:
+        first, inserted = await store.record(_rate("0.0050"), **_ADMIN)
+        assert inserted
+        assert (first.recorded_by_user_id, first.recorded_by_email) == (
+            "user_cale",
+            "cale@coval.dev",
+        )
+
+        again, inserted = await store.record(_rate("0.0050"), **_ADMIN)
+        assert not inserted and again.id == first.id
+
+        fix, inserted = await store.record(_rate("0.0055"), **_ADMIN)
+        assert inserted and fix.id != first.id
+        timeline = timelines(await store.recordings_for(SEEDED_KEY))[SEEDED_KEY]
+        current = timeline.in_force(TODAY)
+        assert current is not None and current.recording.id == fix.id
+        assert [r.id for r in timeline.superseded] == [first.id]
+        # Yesterday still reads the seeded rate.
+        seeded = timeline.in_force(TODAY - timedelta(days=1))
+        assert seeded is not None and str(seeded.recording.price_usd) == "0.0048"
+
+        # Going back to a value that lost is a real change, not a repeat.
+        revert, inserted = await store.record(_rate("0.0050"), **_ADMIN)
+        assert inserted and revert.id not in {first.id, fix.id}
+        assert await store.count_for(SEEDED_KEY) == 4
+
+    _with_store(pricing_pg, scenario)
+
+
+def test_a_delisting_records_no_price(pricing_pg: psycopg.Connection[Any]) -> None:
+    async def scenario(store: PricingStore, conn: psycopg.Connection[Any]) -> None:
+        gone, inserted = await store.record(
+            _rate(None, notes="Page no longer prints a rate."), **_ADMIN
+        )
+        assert inserted and not gone.priced
+        assert gone.unit is None and gone.source_url is None
+        timeline = timelines(await store.recordings_for(SEEDED_KEY))[SEEDED_KEY]
+        current = timeline.in_force(TODAY)
+        assert current is not None and not current.recording.priced
+        assert not await store.model_exists((Benchmark.STT, "ghost", "nobody"))
+
+    _with_store(pricing_pg, scenario)
+
+
+def _downgrade_one(conn: psycopg.Connection[Any]) -> None:
+    """Step the per-test database back one revision, off the pricing log."""
+    cfg = AlembicConfig(str(_INI_PATH))
+    cfg.set_main_option(
+        "sqlalchemy.url", async_dsn(conn).replace("postgresql://", "postgresql+psycopg://")
+    )
+    alembic_command.downgrade(cfg, "-1")
+
+
+def test_downgrade_refuses_to_forget_admin_recordings(pricing_pg: psycopg.Connection[Any]) -> None:
+    """The log is the only home a recorded price has; a downgrade may not drop it."""
+
+    async def scenario(store: PricingStore, conn: psycopg.Connection[Any]) -> None:
+        await store.record(_rate("0.0061"), **_ADMIN)
+
+    _with_store(pricing_pg, scenario)
+    with pytest.raises(RuntimeError, match="refusing to drop"):
+        _downgrade_one(pricing_pg)
+    with pricing_pg.cursor() as cur:
+        cur.execute("SELECT count(*) FROM benchmarks_v2.pricing_rates WHERE price_usd = 0.0061")
+        assert cur.fetchone() == (1,)
+
+
+def test_downgrade_drops_a_log_that_holds_only_the_seed(
+    pricing_pg: psycopg.Connection[Any],
+) -> None:
+    apply_migrations(pricing_pg)
+    _downgrade_one(pricing_pg)
+    with pricing_pg.cursor() as cur:
+        cur.execute("SELECT to_regclass('benchmarks_v2.pricing_rates')")
+        assert cur.fetchone() == (None,)
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"price_usd": None},  # unit without a price
+        {"unit": None},  # price without a unit
+        {"price_usd": 0.005},  # a bare number would drop trailing zeros
+        {"price_usd": "0"},
+        {"unit": PricingUnit.PER_1K_CHARS},  # a character unit cannot bill STT
+        {"source_url": None},  # a priced rate must cite its page
+        {"source_url": "not a url"},
+        {"provider": ""},
+    ],
+)
+def test_new_rate_rejects_what_a_ratesheet_would(overrides: dict[str, Any]) -> None:
+    with pytest.raises(ValidationError):
+        _rate(**overrides)
+
+
+def test_new_rate_strips_blank_notes_and_matches_as_written() -> None:
+    rate = _rate(notes="   ")
+    assert rate.notes is None
+    assert _rate("0.20").price_usd == Decimal("0.20")
+    assert str(_rate("0.20").price_usd) == "0.20"


### PR DESCRIPTION
Linear: [BENCH-766](https://linear.app/coval/issue/BENCH-766/open-model-pricing-registry-on-get-v1pricing-static-no-db)

## What

- `benchmarks_v2.pricing_rates` (migration `20260903_0027`): append-only log, seeded with the 61 rates verified against providers' public pricing pages. Nothing updates or deletes a row; a correction appends and marks the earlier row superseded, a future date schedules a change, null unit + price records "no known public rate".
- `GET /v1/pricing?as_of=`: the rate in force on a day (default today) with earlier spans as `history`. Same roster and embargo filters as every other data endpoint.
- `GET` / `POST /v1/admin/pricing`: coval-org only via the existing `require_coval_admin`. Each recording is stamped with the caller's Clerk user id and email. Writes pass the ratesheet `PricingEntry` rules.
- Downgrade refuses to drop the table once admin recordings exist.

## Deploy

1. Merge. After the release deploys, run the migration the usual way:
   `gcloud run jobs execute benchmarks-runner --region=us-east1 --project=coval-benchmarks-prod --args="db,migrate"`
2. Grant: coval-ai/benchmark-infra#169 gives the api role SELECT + INSERT on `pricing_rates`, applied via Atlantis after the table exists.
3. Then the web PR: coval-ai/benchmarks-web#76.

Until the grant lands, `GET /v1/pricing` returns 503 and admin writes fail closed. Nothing else is affected.

## Verification

`cd runner && uv run ruff check . && uv run ruff format --check . && uv run mypy --strict src tests && uv run pytest -q --disable-socket --allow-unix-socket --allow-hosts=127.0.0.1,::1` — 2010 passed. Live on the local stack with a mock Clerk issuer: 401 no token, 403 other org, 422 bad unit / float price / bad URL / two years out, 201 stamped recording, repeat 200, public read serves the new rate with the old one in history, `?as_of=yesterday` serves the old one.
