### PR TITLE
[BENCH-796] Retry normalized S2S persistence

### DIFF
--- a/runner/src/coval_bench/s2s/fetch_v2v.py
+++ b/runner/src/coval_bench/s2s/fetch_v2v.py
@@ -781,6 +781,7 @@ async def _ingest_run(
                             provider_error=provider_error,
                             captured_at=captured_at,
                             executor=MetricExecutor.COVAL_API,
+                            db_retry_attempts=3,
                         )
                     except Exception:
                         logger.warning(

--- a/runner/tests/unit/test_s2s_fetch.py
+++ b/runner/tests/unit/test_s2s_fetch.py
@@ -2038,7 +2038,7 @@ async def test_ingest_run_dual_writes_one_observation_per_conversation(
     assert calls["R1/s1"]["executor"] is MetricExecutor.COVAL_API
     assert calls["R1/s1"]["captured_at"] == writer.record_results.await_args.kwargs["created_at"]
     for kwargs in calls.values():
-        assert "db_retry_attempts" not in kwargs
+        assert kwargs["db_retry_attempts"] == 3
         assert not any("semaphore" in key for key in kwargs)
 
 


### PR DESCRIPTION
## Summary
- make S2S normalized persistence explicitly use the existing three-attempt database retry policy from BENCH-797
- keep retry classification, telemetry, idempotency, legacy-first persistence, and failure isolation unchanged
- leave the production S2S feature flag off; this PR only prepares the runner image

## Testing
- `2 passed` — focused S2S caller and legacy-preservation tests
- `4 passed` — existing normalized retry, telemetry, and non-retryable behavior tests
- Ruff check and format check passed on both changed files
- strict mypy passed on both changed files
- independent Tier 3 review: PASS, no findings

## Rollout
1. Merge this PR.
2. Build and deploy its runner image to `s2s-fetch`.
3. Verify the live job image contains BENCH-797 and this `db_retry_attempts=3` change.
4. Only then apply [coval-ai/benchmark-infra#170](https://github.com/coval-ai/benchmark-infra/pull/170), which stages the production flag.

No production job, scheduler, configuration, read path, or backfill is changed by this PR. Exhausted retries remain best-effort and still require reconciliation for a zero-gap guarantee.

Linear: https://linear.app/coval/issue/BENCH-796/safely-enable-production-s2s-normalized-dual-writes