### PR TITLE
[BENCH-766] Model pricing in Postgres: admin-recorded rates with history

### DIFF
--- a/runner/src/coval_bench/api/app.py
+++ b/runner/src/coval_bench/api/app.py
@@ -44,12 +44,14 @@ from coval_bench.api.ratelimit import _rate_limit_handler, limiter
 from coval_bench.api.request_logging import RequestLoggingMiddleware
 from coval_bench.api.routers import (
     admin_models,
+    admin_pricing,
     aggregates,
     arena,
     health,
     leaderboard,
     llm_phonely,
     mocktools,
+    pricing,
     providers,
     results,
     robots,
@@ -210,9 +212,11 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     app.include_router(leaderboard.router, prefix="/v1")
     app.include_router(providers.router, prefix="/v1")
     app.include_router(tags.router, prefix="/v1")
+    app.include_router(pricing.router, prefix="/v1")
     app.include_router(s2s_samples.router, prefix="/v1")
     app.include_router(arena.router, prefix="/v1")
     app.include_router(admin_models.router, prefix="/v1")
+    app.include_router(admin_pricing.router, prefix="/v1")
     # Not under /v1 and not rate limited: an appliance the agents call, not
     # public read API. slowapi carries no default limit, so /mock and /llm are exempt
     # by construction — a 429 mid-conversation would be graded as the agent failing.

--- a/runner/src/coval_bench/api/routers/admin_models.py
+++ b/runner/src/coval_bench/api/routers/admin_models.py
@@ -34,6 +34,7 @@ from coval_bench.api.schemas import (
     AdminModelsResponse,
     AdminModelUpdateResponse,
 )
+from coval_bench.db.pricing_store import PricingStore
 from coval_bench.db.registry_store import (
     DuplicateKey,
     ModelChange,
@@ -226,6 +227,22 @@ async def update_admin_model(
     before, after = result
     response.headers["ETag"] = _etag(after)
     history = await store.history(model_id)
-    return AdminModelUpdateResponse(
-        model=_model_out(after, history), warnings=_rename_warnings(before, after)
-    )
+    warnings = _rename_warnings(before, after)
+    warnings.extend(await _pricing_rename_warnings(before, after, pool))
+    return AdminModelUpdateResponse(model=_model_out(after, history), warnings=warnings)
+
+
+async def _pricing_rename_warnings(
+    before: ModelRecord, after: ModelRecord, pool: AsyncConnectionPool[Any]
+) -> list[str]:
+    """The pricing log keys on the natural name, so a rename leaves its rates behind."""
+    old = (before.provider, before.model)
+    if old == (after.provider, after.model):
+        return []
+    count = await PricingStore(pool).count_for((before.modality, before.provider, before.model))
+    if count == 0:
+        return []
+    return [
+        f"{count} pricing recording(s) are filed under {old[0]}/{old[1]}; "
+        f"{after.provider}/{after.model} has no price until one is recorded under its new name"
+    ]

--- a/runner/src/coval_bench/api/routers/admin_pricing.py
+++ b/runner/src/coval_bench/api/routers/admin_pricing.py
@@ -1,0 +1,138 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Admin pricing endpoints: read the whole pricing log, append to it.
+
+Coval-org only (``require_coval_admin``) and every response is private: the log
+names staff and may price models still under embargo. There is no PATCH and no
+DELETE — a mistake is corrected by recording the right value for the same
+effective date, which the log keeps beside the wrong one and marks superseded.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable
+from datetime import UTC, date, datetime, timedelta
+from typing import Any
+
+import psycopg
+from fastapi import APIRouter, Depends, HTTPException, Response
+from psycopg_pool import AsyncConnectionPool
+from pydantic import ValidationError
+
+from coval_bench.api.clerk import CovalAdmin
+from coval_bench.api.deps import get_pool, require_coval_admin
+from coval_bench.api.internal import never_shared
+from coval_bench.api.routers.pricing import PRICING_LOG_UNAVAILABLE, span_fields
+from coval_bench.api.schemas import (
+    AdminModelPricingOut,
+    AdminPricingResponse,
+    AdminRateCreate,
+    AdminRateRecordingOut,
+)
+from coval_bench.db.pricing_store import PricingStore
+from coval_bench.registries.pricing import (
+    NewRate,
+    RateKey,
+    RateRecording,
+    RateTimeline,
+    timelines,
+)
+
+router = APIRouter(tags=["admin"], dependencies=[Depends(require_coval_admin)])
+
+MAX_SCHEDULE_AHEAD = timedelta(days=366)
+EARLIEST_EFFECTIVE = date(2020, 1, 1)
+
+
+async def _guarded[T](call: Awaitable[T]) -> T:
+    """Run a store call; a missing table or grant is a 503, not a traceback."""
+    try:
+        return await call
+    except psycopg.Error as exc:
+        raise PRICING_LOG_UNAVAILABLE from exc
+
+
+def _recording_out(recording: RateRecording, superseded: bool) -> AdminRateRecordingOut:
+    return AdminRateRecordingOut(
+        **span_fields(recording),
+        id=recording.id,
+        notes=recording.notes,
+        recorded_by_user_id=recording.recorded_by_user_id,
+        recorded_by_email=recording.recorded_by_email,
+        recorded_at=recording.recorded_at,
+        superseded=superseded,
+    )
+
+
+def _model_out(
+    timeline: RateTimeline, recordings: list[RateRecording], today: date
+) -> AdminModelPricingOut:
+    superseded = {r.id for r in timeline.superseded}
+    current = timeline.in_force(today)
+    return AdminModelPricingOut(
+        benchmark=timeline.key[0],
+        provider=timeline.key[1],
+        model=timeline.key[2],
+        current=None if current is None else _recording_out(current.recording, False),
+        scheduled=[_recording_out(s.recording, False) for s in timeline.scheduled(today)],
+        recordings=[
+            _recording_out(r, r.id in superseded)
+            for r in sorted(recordings, key=lambda r: (r.recorded_at, r.id), reverse=True)
+        ],
+    )
+
+
+@router.get("/admin/pricing", response_model=AdminPricingResponse)
+async def list_admin_pricing(
+    response: Response, pool: AsyncConnectionPool[Any] = Depends(get_pool)
+) -> AdminPricingResponse:
+    """Every model with a pricing log entry: current, scheduled, and the full audit trail."""
+    never_shared(response)
+    today = datetime.now(UTC).date()
+    recordings = await _guarded(PricingStore(pool).recordings())
+    by_key: dict[RateKey, list[RateRecording]] = {}
+    for recording in recordings:
+        by_key.setdefault(recording.key, []).append(recording)
+    return AdminPricingResponse(
+        as_of=today,
+        models=[
+            _model_out(timeline, by_key[key], today)
+            for key, timeline in sorted(timelines(recordings).items())
+        ],
+    )
+
+
+@router.post("/admin/pricing", response_model=AdminModelPricingOut, status_code=201)
+async def record_admin_rate(
+    body: AdminRateCreate,
+    response: Response,
+    admin: CovalAdmin = Depends(require_coval_admin),
+    pool: AsyncConnectionPool[Any] = Depends(get_pool),
+) -> AdminModelPricingOut:
+    """Append a recording; 201 when it wrote, 200 when the date already said exactly this."""
+    never_shared(response)
+    today = datetime.now(UTC).date()
+    try:
+        new = NewRate.model_validate(
+            {**body.model_dump(), "effective_from": body.effective_from or today}
+        )
+    except ValidationError as exc:
+        messages = (str(e["msg"]).removeprefix("Value error, ") for e in exc.errors())
+        raise HTTPException(422, "; ".join(messages)) from exc
+    if new.effective_from > today + MAX_SCHEDULE_AHEAD:
+        raise HTTPException(422, "effective_from may be at most a year ahead")
+    if new.effective_from < EARLIEST_EFFECTIVE:
+        raise HTTPException(422, f"effective_from may not precede {EARLIEST_EFFECTIVE.isoformat()}")
+    store = PricingStore(pool)
+    if not await _guarded(store.model_exists(new.key)):
+        raise HTTPException(
+            422,
+            f"no registered model {new.benchmark}/{new.provider}/{new.model}; "
+            "add it to the registry before pricing it",
+        )
+    _, inserted = await _guarded(store.record(new, user_id=admin.user_id, email=admin.email))
+    if not inserted:
+        response.status_code = 200
+    recordings = await _guarded(store.recordings_for(new.key))
+    return _model_out(timelines(recordings)[new.key], recordings, today)

--- a/runner/src/coval_bench/api/routers/pricing.py
+++ b/runner/src/coval_bench/api/routers/pricing.py
@@ -1,0 +1,112 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""GET /v1/pricing — each listed model's rate in force on a day, with its history.
+
+Rates live in ``benchmarks_v2.pricing_rates`` and change through the admin API
+(``admin_pricing.py``), never by deploy; ``registries.pricing`` is the one rule
+for which recording describes which day. ``as_of`` defaults to today (UTC) and
+may not be later: a change scheduled for a future day is not public until then,
+its date included. Visibility follows the model roster and the same early-access
+embargo every other data endpoint applies.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from datetime import UTC, date, datetime
+from typing import Any
+
+import psycopg
+import structlog
+from fastapi import APIRouter, Depends, HTTPException, Query
+from posthog import Posthog
+from psycopg_pool import AsyncConnectionPool
+from starlette.requests import Request
+
+from coval_bench.api.deps import capture_api_event, get_models, get_pool, get_posthog
+from coval_bench.api.internal import hidden_early_access
+from coval_bench.api.ratelimit import limiter
+from coval_bench.api.schemas import PricingRateOut, PricingRateSpanOut, PricingRegistryResponse
+from coval_bench.db.pricing_store import PricingStore
+from coval_bench.registries import RegisteredModel
+from coval_bench.registries.pricing import RateRecording, RateSpan, timelines
+
+logger = structlog.get_logger("coval_bench.api")
+router = APIRouter(tags=["pricing"])
+
+PRICING_LOG_UNAVAILABLE = HTTPException(503, "the pricing log is unavailable")
+
+
+def span_fields(recording: RateRecording, effective_to: date | None = None) -> dict[str, Any]:
+    """The ``PricingRateSpanOut`` fields of a recording, shared with the admin router."""
+    chars, minutes = recording.price_per_1m_chars, recording.price_per_1k_minutes
+    return {
+        "unit": None if recording.unit is None else str(recording.unit),
+        "price_usd": recording.price_usd,
+        "price_per_1m_chars": None if chars is None else float(chars),
+        "price_per_1k_minutes": None if minutes is None else float(minutes),
+        "effective_from": recording.effective_from,
+        "effective_to": effective_to,
+        "source_url": recording.source_url,
+    }
+
+
+def _public_span(span: RateSpan, today: date) -> dict[str, Any]:
+    # A span closed by a scheduled change is still open as far as the public knows.
+    to = span.effective_to
+    return span_fields(span.recording, None if to is not None and to > today else to)
+
+
+@router.get("/pricing", response_model=PricingRegistryResponse)
+@limiter.limit("60/minute")
+async def get_pricing_registry(
+    request: Request,
+    as_of: date | None = Query(
+        default=None,
+        description="The day to price as of (UTC); defaults to today and may not be later.",
+    ),
+    posthog_client: Posthog | None = Depends(get_posthog),
+    hidden: frozenset[tuple[str, str]] = Depends(hidden_early_access),
+    models: Sequence[RegisteredModel] = Depends(get_models),
+    pool: AsyncConnectionPool[Any] = Depends(get_pool),
+) -> PricingRegistryResponse:
+    """Return every rate in force on ``as_of``, with the earlier spans as history."""
+    today = datetime.now(UTC).date()
+    day = as_of or today
+    if day > today:
+        raise HTTPException(422, f"as_of may not be later than today ({today.isoformat()} UTC)")
+    try:
+        recordings = await PricingStore(pool).recordings()
+    except psycopg.Error as exc:
+        logger.warning("pricing_log_unavailable", error=str(exc))
+        raise PRICING_LOG_UNAVAILABLE from exc
+    roster = {(m.benchmark, m.provider, m.model) for m in models}
+    rates: list[PricingRateOut] = []
+    for key, timeline in sorted(timelines(recordings).items()):
+        span = timeline.in_force(day)
+        if span is None or key not in roster or (key[1], key[2]) in hidden:
+            continue
+        rates.append(
+            PricingRateOut(
+                **_public_span(span, today),
+                benchmark=key[0],
+                provider=key[1],
+                model=key[2],
+                notes=span.recording.notes,
+                recorded_at=span.recording.recorded_at,
+                history=[
+                    PricingRateSpanOut(**_public_span(s, today)) for s in timeline.before(span)
+                ],
+            )
+        )
+    capture_api_event(
+        posthog_client,
+        "pricing_listed",
+        {
+            "rate_count": len(rates),
+            "as_of_requested": as_of is not None,
+            "$process_person_profile": False,
+        },
+    )
+    return PricingRegistryResponse(as_of=day, rates=rates)

--- a/runner/src/coval_bench/api/schemas.py
+++ b/runner/src/coval_bench/api/schemas.py
@@ -11,7 +11,8 @@ added later if needed.
 from __future__ import annotations
 
 import uuid
-from datetime import datetime
+from datetime import date, datetime
+from decimal import Decimal
 from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field
@@ -121,6 +122,42 @@ class ProvidersResponse(BaseModel):
     llm: list[ProviderInfo]
     # Facet vocabulary in display order, shared across every benchmark.
     tag_categories: list[TagCategoryOut]
+
+
+class PricingRateSpanOut(BaseModel):
+    """One stretch of a model's price history.
+
+    ``price_usd`` is the provider's native figure in ``unit`` as the exact decimal
+    string it was recorded as; the normalized fields are None where no conversion
+    exists without assuming a speaking rate, and all three are None over a span
+    with no known public rate. ``effective_to`` is exclusive, None while open.
+    """
+
+    unit: str | None = None
+    price_usd: Decimal | None = None
+    price_per_1m_chars: float | None = None
+    price_per_1k_minutes: float | None = None
+    effective_from: date
+    effective_to: date | None = None
+    source_url: str | None = None
+
+
+class PricingRateOut(PricingRateSpanOut):
+    """One model's rate in force on the requested day, with the earlier spans oldest first."""
+
+    benchmark: Benchmark
+    provider: str
+    model: str
+    notes: str | None = None
+    recorded_at: datetime
+    history: list[PricingRateSpanOut] = []
+
+
+class PricingRegistryResponse(BaseModel):
+    """Response schema for GET /v1/pricing: the rates in force on ``as_of``."""
+
+    as_of: date
+    rates: list[PricingRateOut]
 
 
 class ResultsResponse(BaseModel):
@@ -483,3 +520,46 @@ class AdminModelUpdateResponse(BaseModel):
 
     model: AdminModelOut
     warnings: list[str] = []
+
+
+class AdminRateRecordingOut(PricingRateSpanOut):
+    """One row of the pricing log as the admin sees it; ``superseded`` marks a corrected entry."""
+
+    id: int
+    notes: str | None = None
+    recorded_by_user_id: str
+    recorded_by_email: str | None = None
+    recorded_at: datetime
+    superseded: bool
+
+
+class AdminModelPricingOut(BaseModel):
+    """One model's pricing log: in force today, scheduled, and every recording newest first."""
+
+    benchmark: Benchmark
+    provider: str
+    model: str
+    current: AdminRateRecordingOut | None = None
+    scheduled: list[AdminRateRecordingOut] = []
+    recordings: list[AdminRateRecordingOut] = []
+
+
+class AdminPricingResponse(BaseModel):
+    """Response schema for GET /v1/admin/pricing."""
+
+    as_of: date
+    models: list[AdminModelPricingOut]
+
+
+class AdminRateCreate(BaseModel):
+    """POST body for /v1/admin/pricing: ``unit`` + ``price_usd`` (decimal string) for a
+    published rate, neither for a delisting; ``effective_from`` defaults to today (UTC)."""
+
+    benchmark: Benchmark
+    provider: str = Field(min_length=1)
+    model: str = Field(min_length=1)
+    unit: str | None = None
+    price_usd: str | None = None
+    effective_from: date | None = None
+    source_url: str | None = None
+    notes: str | None = None

--- a/runner/src/coval_bench/db/migrations/versions/20260903_0027_pricing_rates.py
+++ b/runner/src/coval_bench/db/migrations/versions/20260903_0027_pricing_rates.py
@@ -1,0 +1,153 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+# ruff: noqa: E501  # Seed rows are one line each so the log reads as a table.
+
+"""The pricing log: pricing_rates, seeded with the published rates as of this revision.
+
+Revision ID: 20260903_0027
+Revises:     20260902_0026
+Create Date: 2026-09-03
+
+Append-only (see ``registries.pricing`` for the reading rule); no FK to ``models`` so
+the log outlives renames. The seed is every rate verified against the providers'
+public pricing pages as of this revision, a literal so the migration never drifts
+with the code beside it. GRANTs are Terraform's: the ``api`` role needs SELECT and
+INSERT (identity column, so no sequence grant).
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "20260903_0027"
+down_revision = "20260902_0026"
+branch_labels = None
+depends_on = None
+
+_RECORDED_BY = f"migration:{revision}"
+
+# fmt: off
+# (benchmark, provider, model, unit, price_usd, effective_from, source_url, notes)
+SEED_ROWS: tuple[tuple[str, str, str, str, str, str, str, str | None], ...] = (
+    ('STT', 'assemblyai', 'universal-3.5-pro', 'per_hour', '0.45', '2026-08-24', 'https://www.assemblyai.com/pricing', "AssemblyAI sells three separate APIs and prices Universal-3.5 Pro differently on each. This is the Realtime Speech-to-Text API rate, listed as 'Universal-3.5 Pro Realtime' at $0.45/hr — the endpoint we benchmark, over wss://streaming.assemblyai.com/v3/ws. The similarly named async model on the Pre-recorded API is $0.21/hr and the Sync API is $0.45/hr; neither is what we measure. Billed on session duration like the Universal-Streaming rate above."),
+    ('STT', 'assemblyai', 'universal-streaming', 'per_hour', '0.15', '2026-08-24', 'https://www.assemblyai.com/pricing', "Pay-as-you-go rate for Universal-Streaming on the Realtime Speech-to-Text API (English and Multilingual both $0.15/hr). AssemblyAI bills streaming on session duration — WebSocket open time, not audio sent — and we stream each clip in real time and close, so a benchmarked session is one clip's audio plus a brief wait for the final transcript."),
+    ('STT', 'assemblyai', 'universal-streaming-multilingual', 'per_hour', '0.15', '2026-08-31', 'https://www.assemblyai.com/pricing', "'Universal-Streaming Multilingual' row on the Realtime Speech-to-Text API, same $0.15/hr as the English tier. Billed on session duration like the rates above."),
+    ('STT', 'azure', 'default', 'per_hour', '1', '2026-08-31', 'https://azure.microsoft.com/en-us/pricing/details/cognitive-services/speech-services/', "Pay-as-you-go 'S1 Speech To Text' standard real-time meter, $1.00 per hour in East US (the pricing page renders after region selection; figure verified via the Azure retail prices API). Batch and commitment tiers are cheaper."),
+    ('STT', 'deepgram', 'flux-general-en', 'per_minute', '0.0065', '2026-08-24', 'https://deepgram.com/pricing', 'Pay As You Go streaming rate, listed as a limited-time promotional price; regular price $0.0077/min.'),
+    ('STT', 'deepgram', 'flux-general-multi', 'per_minute', '0.0078', '2026-08-24', 'https://deepgram.com/pricing', 'Pay As You Go streaming rate.'),
+    ('STT', 'deepgram', 'nova-2', 'per_hour', '0.35', '2026-08-31', 'https://deepgram.com/pricing', "FAQ rate: 'Nova-2 streaming at $0.35/hour', kept unchanged for existing deployments; Nova-2 no longer appears in the main rate tables. Growth plan rates are about 12.5% lower."),
+    ('STT', 'deepgram', 'nova-3', 'per_minute', '0.0048', '2026-08-24', 'https://deepgram.com/pricing', 'Pay As You Go monolingual (English) streaming rate, listed as a limited-time promotional price; regular price $0.0077/min. Multilingual streaming is $0.0058/min (regular $0.0092).'),
+    ('STT', 'elevenlabs', 'scribe_v2_realtime', 'per_hour', '0.39', '2026-08-24', 'https://elevenlabs.io/pricing/api', 'Pay-as-you-go API rate for Scribe v2 Realtime; subscription tiers change only the included hours, not the rate.'),
+    ('STT', 'gladia', 'solaria-1', 'per_hour', '0.75', '2026-08-24', 'https://www.gladia.io/pricing', 'Starter pay-as-you-go real-time rate; Gladia prices real-time generically and Solaria is its real-time model.'),
+    ('STT', 'google', 'chirp_2', 'per_minute', '0.016', '2026-08-24', 'https://cloud.google.com/speech-to-text/pricing', 'Speech-to-Text V2 Recognition standard rate, first volume tier (0-500k min/month); V2 prices all standard models, Chirp included, at this one rate. Volume tiers drop to $0.004/min above 2M.'),
+    ('STT', 'google', 'chirp_3', 'per_minute', '0.016', '2026-08-24', 'https://cloud.google.com/speech-to-text/pricing', 'Speech-to-Text V2 Recognition standard rate, first volume tier (0-500k min/month); same single V2 SKU as chirp_2.'),
+    ('STT', 'gradium', 'default', 'per_second_audio_in', '0.000207', '2026-08-24', 'https://gradium.ai/pricing', "Entry (XS) plan add-on credit rate — the marginal price of usage: 3 credits per second of audio at $6.9 per 100k credits, exact conversion. Gradium has no standalone pay-as-you-go tier; larger plans publish lower add-on rates, and usage inside the XS plan's own 225k-credit allowance works out to about $0.000173 per second."),
+    ('STT', 'inworld', 'inworld-stt-1', 'per_hour', '0.15', '2026-08-24', 'https://inworld.ai/pricing', 'On-Demand pay-as-you-go base rate; paid subscription tiers discount to $0.10/hr.'),
+    ('STT', 'mistral', 'voxtral-mini-transcribe-realtime-2602', 'per_minute', '0.006', '2026-08-24', 'https://mistral.ai/pricing/api', 'La Plateforme pay-as-you-go audio-input rate for Voxtral Mini Transcribe Realtime; the batch Transcribe tier is $0.003/min.'),
+    ('STT', 'modulate', 'english-fast-transcription-streaming', 'per_hour', '0.05', '2026-08-31', 'https://www.modulate.ai/api-pricing', "'English Fast Speech-to-Text' streaming (real-time WebSocket) rate; the batch REST tier is $0.025/hr."),
+    ('STT', 'modulate', 'multilingual-transcription-streaming', 'per_hour', '0.06', '2026-08-31', 'https://www.modulate.ai/api-pricing', "'Multilingual Speech-to-Text' streaming (real-time WebSocket) rate; batch is $0.03/hr, and emotion, accent, and PII tagging bill as separate add-ons. Modulate's page prices these two products only — the velma-2 model ids have no printed row and stay unpriced."),
+    ('STT', 'openai', 'gpt-4o-mini-transcribe', 'per_minute', '0.003', '2026-08-24', 'https://developers.openai.com/api/docs/pricing', "OpenAI's published estimated per-minute cost; underlying token rates are $1.25/1M input tokens and $5.00/1M output tokens."),
+    ('STT', 'openai', 'gpt-4o-transcribe', 'per_minute', '0.006', '2026-08-24', 'https://developers.openai.com/api/docs/pricing', "OpenAI's published estimated per-minute cost; underlying token rates are $2.50/1M input tokens and $10.00/1M output tokens."),
+    ('STT', 'openai', 'gpt-realtime-whisper', 'per_minute', '0.017', '2026-08-24', 'https://developers.openai.com/api/docs/pricing', 'Published per-minute live-transcription rate; OpenAI lists no token pricing for this model.'),
+    ('STT', 'revai', 'reverb', 'per_hour', '0.20', '2026-08-31', 'https://www.rev.ai/pricing', "'Reverb Transcription $0.20 per hour' — Rev AI publishes one rate per product with no streaming/async split; usage is rounded up to the nearest second with a 15-second minimum. Reverb Turbo is $0.10/hr and foreign-language transcription $0.30/hr."),
+    ('STT', 'smallest', 'pulse', 'per_minute', '0.008', '2026-08-24', 'https://docs.smallest.ai/models/model-cards/speech-to-text/pulse', 'Standard Plan realtime rate from the official Pulse model card; batch is $0.005/min. Marketing pages print only approximate figures.'),
+    ('STT', 'soniox', 'stt-rt-v5', 'per_hour', '0.12', '2026-08-24', 'https://soniox.com/pricing', "Soniox's page-printed per-hour rate for real-time streaming, which is the all-in figure: canonical billing is token-based, and the page's own conversions add up to it — ~30,000 input audio tokens per hour at $2.00 per 1M ($0.06) plus ~15,000 output text tokens per hour at $4.00 per 1M ($0.06)."),
+    ('STT', 'speechmatics', 'default', 'per_hour', '0.24', '2026-08-24', 'https://www.speechmatics.com/pricing', 'Pro pay-as-you-go rate for real-time transcription, Standard operating point.'),
+    ('STT', 'speechmatics', 'enhanced', 'per_hour', '0.43', '2026-08-24', 'https://www.speechmatics.com/pricing', 'Pro pay-as-you-go rate for real-time transcription, Enhanced operating point.'),
+    ('STT', 'together', 'nemotron-3-asr-streaming-0.6b', 'per_minute', '0.0015', '2026-08-31', 'https://www.together.ai/pricing', "'NVIDIA Nemotron 3 ASR Streaming 0.6B' row in the Transcribe per-audio-minute table; no separate batch discount is listed for it. Distinct from the newer Nemotron 3.5 model above at $0.0045/min."),
+    ('STT', 'together', 'nemotron-3.5-asr-streaming-0.6b', 'per_minute', '0.0045', '2026-08-24', 'https://www.together.ai/models/nvidia-nemotron-35-asr', "Serverless pay-as-you-go per-audio-minute rate; the model page prints this price against the API string nvidia/nemotron-3.5-asr-streaming-0.6b (the pricing page's 'NVIDIA Nemotron 3.5 ASR' row). Not the older 'Nemotron 3 ASR Streaming 0.6B' row at $0.0015/min."),
+    ('STT', 'together', 'parakeet-tdt-0.6b-v3', 'per_minute', '0.0015', '2026-08-24', 'https://www.together.ai/pricing', "Serverless per-audio-minute rate for NVIDIA Parakeet TDT 0.6B v3. Together's per-audio-minute table is headed 'Batch API price' and carries no realtime row for this model, unlike Whisper Large v3 which has a separate (Streaming) row — so this is the only per-minute figure published for it, and it may understate the realtime endpoint we benchmark. The 'Parakeet TDT 0.6B V3 Realtime $0.0035' row sits in the per-1M-characters table beside the TTS models, so it is not a per-minute audio rate."),
+    ('STT', 'together', 'whisper-large-v3', 'per_minute', '0.0035', '2026-08-24', 'https://www.together.ai/pricing', "Whisper Large v3 (Streaming) rate — we benchmark over Together's realtime API; the non-streaming Transcribe tier is $0.0015/min."),
+    ('STT', 'xai', 'grok-stt', 'per_hour', '0.20', '2026-08-24', 'https://docs.x.ai/developers/pricing', 'Streaming speech-to-text rate — the endpoint we benchmark; the REST tier is $0.10/hr. Published as a generic Speech to Text row, not by model id.'),
+    ('TTS', 'alibaba', 'qwen3-tts-flash-realtime', 'per_1m_chars', '13', '2026-09-01', 'https://www.alibabacloud.com/help/en/model-studio/model-pricing', "Qwen3-TTS-Flash-Realtime table, Singapore region ('International' deployment scope — the dashscope-intl endpoint we benchmark): $0.13 per 10,000 input text characters, output audio free. The Chinese-mainland (Beijing) table lists $0.143353 per 10,000."),
+    ('TTS', 'azure', 'dragon-hd-latest', 'per_1m_chars', '22', '2026-08-10', 'https://azure.microsoft.com/en-us/pricing/details/cognitive-services/speech-services/', 'Pay-as-you-go Neural HD rate in East US; HD voices are region-limited.'),
+    ('TTS', 'azure', 'neural', 'per_1m_chars', '15', '2026-08-10', 'https://azure.microsoft.com/en-us/pricing/details/cognitive-services/speech-services/', 'Pay-as-you-go standard neural voice rate (US regions); commitment tiers are cheaper.'),
+    ('TTS', 'deepgram', 'aura-2-thalia-en', 'per_1k_chars', '0.030', '2026-08-10', 'https://deepgram.com/pricing', 'Aura-2 Pay As You Go rate.'),
+    ('TTS', 'elevenlabs', 'eleven_flash_v2_5', 'per_1k_chars', '0.05', '2026-08-10', 'https://elevenlabs.io/pricing/api', "API pricing 'Flash / Turbo' row; same rate across tiers."),
+    ('TTS', 'elevenlabs', 'eleven_multilingual_v2', 'per_1k_chars', '0.10', '2026-08-31', 'https://elevenlabs.io/pricing/api', "API pricing 'v2 Multilingual' row. Same rate across tiers."),
+    ('TTS', 'elevenlabs', 'eleven_turbo_v2_5', 'per_1k_chars', '0.05', '2026-08-31', 'https://elevenlabs.io/pricing/api', "API pricing 'Flash / Turbo' row; the page's tooltip states the row covers Flash/Turbo V2 and V2.5. Same rate across tiers."),
+    ('TTS', 'elevenlabs', 'eleven_v3', 'per_1k_chars', '0.10', '2026-08-31', 'https://elevenlabs.io/pricing/api', "API pricing 'v3' row — twice the v3 Conversational rate below. Same rate across tiers."),
+    ('TTS', 'elevenlabs', 'eleven_v3_conversational', 'per_1k_chars', '0.05', '2026-08-28', 'https://elevenlabs.io/pricing/api', "API pricing 'v3 Conversational' row — a distinct model from plain v3, which is $0.10 per 1K characters. Same rate across tiers."),
+    ('TTS', 'fishaudio', 's1', 'per_1m_chars', '15', '2026-08-31', 'https://docs.fish.audio/developer-guide/models-pricing/pricing-and-rate-limits', "Printed as '$15.00 / M UTF-8 bytes' — one byte per character for the English text we benchmark. s2.1-pro-free is listed at $0.00 and stays unpriced here (the registry cannot carry a zero rate)."),
+    ('TTS', 'fishaudio', 's2.1-pro', 'per_1m_chars', '15', '2026-08-31', 'https://docs.fish.audio/developer-guide/models-pricing/pricing-and-rate-limits', "Printed as '$15.00 / M UTF-8 bytes', same as s1; billed pay-as-you-go from the first call."),
+    ('TTS', 'fluxions', 'vui', 'per_1m_chars', '10', '2026-08-10', 'https://fluxions.ai/pricing', 'Pay-as-you-go rate for expressive VUI text-to-speech.'),
+    ('TTS', 'google', 'chirp-3-hd', 'per_1m_chars', '30', '2026-08-10', 'https://cloud.google.com/text-to-speech/pricing', 'Pay-as-you-go rate for Chirp 3: HD voices, billed per character sent for synthesis.'),
+    ('TTS', 'gradium', 'default', 'per_1m_chars', '69', '2026-08-10', 'https://gradium.ai/pricing', "Entry (XS) plan add-on credit rate — the marginal price of usage: $6.9 per 100k credits at 1 credit per character. Gradium has no standalone pay-as-you-go tier; larger plans publish lower add-on rates, and usage inside the XS plan's own 225k-credit allowance works out to about $57.78 per 1M."),
+    ('TTS', 'gradium', 'gradium-tts-beta', 'per_1m_chars', '69', '2026-08-31', 'https://gradium.ai/pricing', "Gradium prices TTS generically — '1 credit / character' with no model named on the page — so the new default model bills like the entry (XS) plan's marginal add-on rate recorded for gradium/default: $6.9 per 100k add-on credits = $69/1M characters. Larger plans publish $50/$40/$38."),
+    ('TTS', 'hume', 'octave-2', 'per_1k_chars', '0.15', '2026-08-31', 'https://www.hume.ai/pricing', "Same Creator-plan overage rate as octave-tts above; the pricing page covers 'Octave 1 | Octave 2' with one set of figures."),
+    ('TTS', 'hume', 'octave-tts', 'per_1k_chars', '0.15', '2026-08-31', 'https://www.hume.ai/pricing', "Creator plan ($7/mo) 'Additional characters cost' overage rate — the entry tier that prints one; Hume publishes no pay-as-you-go tier, and larger plans overage at $0.12/$0.10/$0.05 per 1K. Octave 1 and Octave 2 are priced jointly."),
+    ('TTS', 'inworld', 'inworld-tts-2', 'per_1m_chars', '25', '2026-08-10', 'https://inworld.ai/pricing', 'On-demand (pay-as-you-go) rate; subscription plans publish lower rates.'),
+    ('TTS', 'inworld', 'inworld-tts-2-flash', 'per_1m_chars', '15', '2026-08-24', 'https://inworld.ai/pricing', 'On-demand (pay-as-you-go) rate; subscription plans publish lower rates. TTS 1.5 Max/Mini are no longer published on the page, so the retired models carry no rate.'),
+    ('TTS', 'lmnt', 'blizzard', 'per_1k_chars', '0.05', '2026-08-10', 'https://www.lmnt.com/pricing', "Overage rate past the entry Indie plan's included characters; plan-based, not per-model."),
+    ('TTS', 'minimax', 'speech-2.8-hd', 'per_1m_chars', '100', '2026-08-10', 'https://platform.minimax.io/docs/guides/pricing-paygo.md', 'International-platform pay-as-you-go rate.'),
+    ('TTS', 'minimax', 'speech-2.8-turbo', 'per_1m_chars', '60', '2026-08-10', 'https://platform.minimax.io/docs/guides/pricing-paygo.md', 'International-platform pay-as-you-go rate.'),
+    ('TTS', 'murf', 'falcon-2', 'per_1k_chars', '0.01', '2026-08-31', 'https://murf.ai/pricing', "API tab of the pricing page, the realtime Text to Speech row ('Optimized for conversational AI and real-time voice agents with time-to-first-audio under 130ms', i.e. Falcon): $0.01 / 1000 characters. The $0.03 row beside it is the studio synthesis model, not this one. The page renders client-side; the old murf.ai/api/pricing route 404s since early Sep 2026."),
+    ('TTS', 'openai', 'tts-1', 'per_1m_chars', '15', '2026-08-31', 'https://developers.openai.com/api/docs/pricing', "Printed as '$15.00 / 1M characters' in the audio-generation pricing table (the row is collapsed behind the table's expander). gpt-4o-mini-tts and the realtime models bill in tokens only and stay unpriced here."),
+    ('TTS', 'openai', 'tts-1-hd', 'per_1m_chars', '30', '2026-08-31', 'https://developers.openai.com/api/docs/pricing', "Printed as '$30.00 / 1M characters' in the audio-generation pricing table (collapsed row), twice the tts-1 rate."),
+    ('TTS', 'palabra', 'palabra-tts-v1', 'per_1k_chars', '0.03', '2026-08-10', 'https://www.palabra.ai/pricing', 'TTS API pay-as-you-go rate.'),
+    ('TTS', 'rime', 'coda', 'per_1k_chars', '0.05', '2026-08-10', 'https://www.rime.ai/pricing', 'Pay-as-you-go Starter rate. Arcana has no published rate and is deliberately absent.'),
+    ('TTS', 'rime', 'mistv3', 'per_1k_chars', '0.03', '2026-08-10', 'https://www.rime.ai/pricing', 'Pay-as-you-go Starter rate.'),
+    ('TTS', 'speechify', 'simba-3.0', 'per_1m_chars', '10', '2026-08-10', 'https://speechify.ai/pricing', "Starter plan's rate past its 1M included characters — the entry published rate; Pro is $8 and Scale $6 per 1M. Billed per character at the same rate for every Simba model. The per-minute figure Speechify also publishes prices their bundled voice-agent product, not the TTS API."),
+    ('TTS', 'speechify', 'simba-3.2', 'per_1m_chars', '10', '2026-08-10', 'https://speechify.ai/pricing', "Starter plan's rate past its 1M included characters — the entry published rate; Pro is $8 and Scale $6 per 1M. Billed per character at the same rate for every Simba model. The per-minute figure Speechify also publishes prices their bundled voice-agent product, not the TTS API."),
+    ('TTS', 'xai', 'grok-tts', 'per_1m_chars', '15', '2026-08-10', 'https://docs.x.ai/developers/pricing', "Voice pricing 'Text to Speech' rate; xAI prices the service, not model variants."),
+)
+# fmt: on
+
+
+def upgrade() -> None:
+    """Create the pricing log and seed it."""
+    op.execute(
+        """
+        CREATE TABLE benchmarks_v2.pricing_rates (
+            id                  BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+            benchmark           TEXT NOT NULL CHECK (benchmark IN ('STT', 'TTS', 'S2S')),
+            provider            TEXT NOT NULL CHECK (provider <> ''),
+            model               TEXT NOT NULL CHECK (model <> ''),
+            unit                TEXT CHECK (unit IS NULL OR unit <> ''),
+            price_usd           NUMERIC CHECK (price_usd IS NULL OR price_usd > 0),  -- keeps the quoted scale: 0.20 stays 0.20
+            effective_from      DATE NOT NULL,
+            source_url          TEXT CHECK (source_url IS NULL OR source_url <> ''),
+            notes               TEXT CHECK (notes IS NULL OR notes <> ''),
+            recorded_by_user_id TEXT NOT NULL CHECK (recorded_by_user_id <> ''),  -- Clerk sub, or migration:<revision>
+            recorded_by_email   TEXT CHECK (recorded_by_email IS NULL OR recorded_by_email <> ''),
+            recorded_at         TIMESTAMPTZ NOT NULL DEFAULT now(),
+            CHECK ((unit IS NULL) = (price_usd IS NULL)),
+            CHECK (price_usd IS NULL OR source_url IS NOT NULL)
+        );
+        CREATE INDEX pricing_rates_key_effective
+            ON benchmarks_v2.pricing_rates (benchmark, provider, model, effective_from DESC, recorded_at DESC);
+        """
+    )
+    bind = op.get_bind()
+    for row in SEED_ROWS:
+        # Parameters, not literals: URLs and notes carry colons and percent signs.
+        bind.exec_driver_sql(
+            "INSERT INTO benchmarks_v2.pricing_rates"
+            " (benchmark, provider, model, unit, price_usd, effective_from, source_url, notes, recorded_by_user_id)"
+            " VALUES (%s, %s, %s, %s, %s::numeric, %s::date, %s, %s, %s)",
+            (*row, _RECORDED_BY),
+        )
+
+
+def downgrade() -> None:
+    """Drop the log, but only while it holds nothing beyond this seed.
+
+    Rates recorded through the admin page exist nowhere else; back them up first.
+    """
+    recorded = (
+        op.get_bind()
+        .execute(
+            sa.text(
+                "SELECT count(*) FROM benchmarks_v2.pricing_rates WHERE recorded_by_user_id <> :seed"
+            ),
+            {"seed": _RECORDED_BY},
+        )
+        .scalar_one()
+    )
+    if recorded:
+        raise RuntimeError(
+            f"refusing to drop benchmarks_v2.pricing_rates: it holds {recorded} recording(s) "
+            "made after the seed and they exist nowhere else; back them up before downgrading"
+        )
+    op.execute("DROP TABLE IF EXISTS benchmarks_v2.pricing_rates;")

--- a/runner/src/coval_bench/db/pricing_store.py
+++ b/runner/src/coval_bench/db/pricing_store.py
@@ -1,0 +1,110 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""``PricingStore``: parameterised reads of the pricing log and its one append door."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import psycopg
+import psycopg.rows
+from psycopg_pool import AsyncConnectionPool
+
+from coval_bench.registries.pricing import NewRate, RateKey, RateRecording
+
+PricingPool = AsyncConnectionPool[psycopg.AsyncConnection[psycopg.rows.DictRow]]
+
+_COLUMNS = (
+    "id, benchmark, provider, model, unit, price_usd, effective_from, source_url, notes,"
+    " recorded_by_user_id, recorded_by_email, recorded_at"
+)
+_SELECT = f"SELECT {_COLUMNS} FROM benchmarks_v2.pricing_rates"  # noqa: S608 — constant columns
+_BY_KEY = " WHERE benchmark = %s AND provider = %s AND model = %s"
+_ORDER = " ORDER BY benchmark, provider, model, effective_from, recorded_at, id"
+_INSERT = f"""
+    INSERT INTO benchmarks_v2.pricing_rates
+        (benchmark, provider, model, unit, price_usd, effective_from, source_url, notes,
+         recorded_by_user_id, recorded_by_email)
+    VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+    RETURNING {_COLUMNS}
+"""  # noqa: S608 — constant columns
+
+
+def _key_params(key: RateKey) -> tuple[str, str, str]:
+    return (key[0].value, key[1], key[2])
+
+
+class PricingStore:
+    """Per-pool persistence helper for the pricing log."""
+
+    def __init__(self, pool: PricingPool) -> None:
+        self._pool = pool
+
+    async def _fetch(self, sql: str, params: tuple[Any, ...] = ()) -> list[RateRecording]:
+        async with self._pool.connection() as conn:
+            rows = await (await conn.execute(sql, params)).fetchall()
+        return [RateRecording.model_validate(dict(row)) for row in rows]
+
+    async def recordings(self) -> list[RateRecording]:
+        """Every recording ever made, in key then chronological order."""
+        return await self._fetch(_SELECT + _ORDER)
+
+    async def recordings_for(self, key: RateKey) -> list[RateRecording]:
+        return await self._fetch(_SELECT + _BY_KEY + _ORDER, _key_params(key))
+
+    async def count_for(self, key: RateKey) -> int:
+        sql = "SELECT count(*) AS n FROM benchmarks_v2.pricing_rates" + _BY_KEY  # noqa: S608
+        async with self._pool.connection() as conn:
+            row = await (await conn.execute(sql, _key_params(key))).fetchone()
+        return 0 if row is None else int(row["n"])
+
+    async def model_exists(self, key: RateKey) -> bool:
+        """Whether the registry lists the model in any state — hidden ones may be priced."""
+        sql = "SELECT 1 FROM benchmarks_v2.models" + _BY_KEY.replace(  # noqa: S608
+            "benchmark =", "modality ="
+        )
+        async with self._pool.connection() as conn:
+            row = await (await conn.execute(sql, _key_params(key))).fetchone()
+        return row is not None
+
+    async def record(
+        self, new: NewRate, *, user_id: str, email: str | None
+    ) -> tuple[RateRecording, bool]:
+        """Append *new* unless it repeats what already describes that date.
+
+        Returns the recording now describing ``new.effective_from`` and whether this
+        call wrote it. Writers for one model serialise on an advisory lock so two
+        admins saving at once cannot both see an empty date and both append.
+        """
+        latest_sql = (
+            _SELECT
+            + _BY_KEY
+            + " AND effective_from = %s ORDER BY recorded_at DESC, id DESC LIMIT 1"
+        )
+        async with self._pool.connection() as conn, conn.transaction():
+            await conn.execute(
+                "SELECT pg_advisory_xact_lock(hashtext(%s))",
+                (f"pricing:{'/'.join(_key_params(new.key))}",),
+            )
+            latest = await (
+                await conn.execute(latest_sql, (*_key_params(new.key), new.effective_from))
+            ).fetchone()
+            if latest is not None and new.matches(
+                existing := RateRecording.model_validate(dict(latest))
+            ):
+                return existing, False
+            params = (
+                *_key_params(new.key),
+                None if new.unit is None else str(new.unit),
+                new.price_usd,
+                new.effective_from,
+                None if new.source_url is None else str(new.source_url),
+                new.notes,
+                user_id,
+                email,
+            )
+            row = await (await conn.execute(_INSERT, params)).fetchone()
+            if row is None:  # pragma: no cover — unreachable after INSERT RETURNING
+                raise RuntimeError("INSERT INTO benchmarks_v2.pricing_rates returned no row")
+            return RateRecording.model_validate(dict(row)), True

--- a/runner/src/coval_bench/registries/pricing.py
+++ b/runner/src/coval_bench/registries/pricing.py
@@ -1,0 +1,242 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""The pricing log's rules: units, normalization, and which recording prices which day.
+
+``benchmarks_v2.pricing_rates`` is append-only. A row is a *recording*: on
+``recorded_at`` someone said that from ``effective_from`` a model costs
+``price_usd`` per ``unit`` — or, with both null, that no public rate is known
+from that day. For one effective date the latest recording wins (that is how a
+mistake is corrected); the rate in force on a day is the winning recording with
+the greatest effective date at or before it, so a future-dated recording is
+scheduled and prices nothing until its day arrives.
+"""
+
+from __future__ import annotations
+
+from bisect import bisect_right
+from collections import defaultdict
+from collections.abc import Iterable
+from datetime import UTC, date, datetime
+from decimal import ROUND_HALF_UP, Decimal
+from enum import StrEnum
+from typing import Annotated
+
+from pydantic import BaseModel, Field, HttpUrl, field_validator, model_validator
+
+from coval_bench.registries.benchmarks import Benchmark
+
+RateKey = tuple[Benchmark, str, str]
+
+
+class PricingUnit(StrEnum):
+    """The native unit a provider publishes in.
+
+    Character units bill TTS input, duration units bill STT input. Each normalizes
+    within its own denominator; nothing converts across the two, which would take
+    an assumed speaking rate.
+    """
+
+    PER_1M_CHARS = "per_1m_chars"
+    PER_1K_CHARS = "per_1k_chars"
+    PER_CHAR = "per_char"
+    PER_SECOND_AUDIO_OUT = "per_second_audio_out"
+    PER_MINUTE = "per_minute"
+    PER_HOUR = "per_hour"
+    PER_SECOND_AUDIO_IN = "per_second_audio_in"
+
+
+UNITS_BY_BENCHMARK: dict[Benchmark, frozenset[PricingUnit]] = {
+    Benchmark.TTS: frozenset(
+        {
+            PricingUnit.PER_1M_CHARS,
+            PricingUnit.PER_1K_CHARS,
+            PricingUnit.PER_CHAR,
+            PricingUnit.PER_SECOND_AUDIO_OUT,
+        }
+    ),
+    Benchmark.STT: frozenset(
+        {PricingUnit.PER_MINUTE, PricingUnit.PER_HOUR, PricingUnit.PER_SECOND_AUDIO_IN}
+    ),
+}
+
+# Exact multipliers to the site's two figures. per_hour divides, so it rounds
+# half-up to a millionth; per_second_audio_out has no equivalent in either.
+_TO_1M_CHARS = {
+    PricingUnit.PER_1M_CHARS: 1,
+    PricingUnit.PER_1K_CHARS: 1000,
+    PricingUnit.PER_CHAR: 1_000_000,
+}
+_TO_1K_MINUTES = {PricingUnit.PER_MINUTE: 1000, PricingUnit.PER_SECOND_AUDIO_IN: 60_000}
+
+
+def per_1m_chars(unit: PricingUnit, price_usd: Decimal) -> Decimal | None:
+    """USD per 1M characters, or None when the unit is not character-billed."""
+    factor = _TO_1M_CHARS.get(unit)
+    return None if factor is None else price_usd * factor
+
+
+def per_1k_minutes(unit: PricingUnit, price_usd: Decimal) -> Decimal | None:
+    """USD per 1,000 minutes of input audio, or None when the unit does not bill audio in."""
+    if unit is PricingUnit.PER_HOUR:
+        return (price_usd * 1000 / 60).quantize(Decimal("0.000001"), rounding=ROUND_HALF_UP)
+    factor = _TO_1K_MINUTES.get(unit)
+    return None if factor is None else price_usd * factor
+
+
+class RateRecording(BaseModel, frozen=True):
+    """One row of ``benchmarks_v2.pricing_rates``."""
+
+    id: int
+    benchmark: Benchmark
+    provider: str
+    model: str
+    unit: PricingUnit | None
+    price_usd: Decimal | None
+    effective_from: date
+    source_url: str | None
+    notes: str | None
+    recorded_by_user_id: str
+    recorded_by_email: str | None
+    recorded_at: datetime
+
+    @field_validator("recorded_at")
+    @classmethod
+    def _in_utc(cls, value: datetime) -> datetime:
+        return value.astimezone(UTC) if value.tzinfo is not None else value.replace(tzinfo=UTC)
+
+    @property
+    def key(self) -> RateKey:
+        return (self.benchmark, self.provider, self.model)
+
+    @property
+    def priced(self) -> bool:
+        return self.price_usd is not None
+
+    @property
+    def price_per_1m_chars(self) -> Decimal | None:
+        if self.unit is None or self.price_usd is None:
+            return None
+        return per_1m_chars(self.unit, self.price_usd)
+
+    @property
+    def price_per_1k_minutes(self) -> Decimal | None:
+        if self.unit is None or self.price_usd is None:
+            return None
+        return per_1k_minutes(self.unit, self.price_usd)
+
+
+class RateSpan(BaseModel, frozen=True):
+    """A winning recording and the day the next one takes over (exclusive)."""
+
+    recording: RateRecording
+    effective_to: date | None
+
+    @property
+    def effective_from(self) -> date:
+        return self.recording.effective_from
+
+
+class RateTimeline(BaseModel, frozen=True):
+    """One model's spans, ascending by effective date, plus the recordings they replaced."""
+
+    key: RateKey
+    spans: tuple[RateSpan, ...]
+    superseded: tuple[RateRecording, ...]
+
+    def in_force(self, day: date) -> RateSpan | None:
+        """The span covering *day*, or None before the first recording."""
+        index = bisect_right([span.effective_from for span in self.spans], day) - 1
+        return self.spans[index] if index >= 0 else None
+
+    def before(self, span: RateSpan) -> tuple[RateSpan, ...]:
+        """Every span that ended before *span* began: the public history."""
+        return tuple(s for s in self.spans if s.effective_from < span.effective_from)
+
+    def scheduled(self, day: date) -> tuple[RateSpan, ...]:
+        return tuple(s for s in self.spans if s.effective_from > day)
+
+
+def timelines(recordings: Iterable[RateRecording]) -> dict[RateKey, RateTimeline]:
+    """Resolve every recording into per-model timelines."""
+    by_key: dict[RateKey, list[RateRecording]] = defaultdict(list)
+    for recording in recordings:
+        by_key[recording.key].append(recording)
+    return {key: _timeline(key, rows) for key, rows in by_key.items()}
+
+
+def _timeline(key: RateKey, rows: list[RateRecording]) -> RateTimeline:
+    winners: dict[date, RateRecording] = {}
+    superseded: list[RateRecording] = []
+    for row in sorted(rows, key=lambda r: (r.recorded_at, r.id)):
+        if (loser := winners.get(row.effective_from)) is not None:
+            superseded.append(loser)
+        winners[row.effective_from] = row
+    ordered = [winners[day] for day in sorted(winners)]
+    spans = tuple(
+        RateSpan(
+            recording=recording,
+            effective_to=ordered[i + 1].effective_from if i + 1 < len(ordered) else None,
+        )
+        for i, recording in enumerate(ordered)
+    )
+    return RateTimeline(key=key, spans=spans, superseded=tuple(superseded))
+
+
+class NewRate(BaseModel, frozen=True, extra="forbid"):
+    """A rate as an admin states it, before the log assigns identity and time.
+
+    ``unit`` and ``price_usd`` come together (a published rate, which must cite the
+    page that prints it) or not at all (no known public rate from ``effective_from``).
+    The price is a decimal string so the quoted figure survives exactly.
+    """
+
+    benchmark: Benchmark
+    provider: str = Field(min_length=1)
+    model: str = Field(min_length=1)
+    unit: PricingUnit | None = None
+    price_usd: Annotated[Decimal, Field(gt=0)] | None = None
+    effective_from: date
+    source_url: HttpUrl | None = None
+    notes: str | None = None
+
+    @field_validator("price_usd", mode="before")
+    @classmethod
+    def _price_written_as_string(cls, value: object) -> object:
+        if isinstance(value, float | int) or (isinstance(value, str) and "e" in value.lower()):
+            raise ValueError('write price_usd as a plain decimal string, e.g. "0.20"')
+        return value
+
+    @field_validator("notes", mode="before")
+    @classmethod
+    def _blank_notes_are_none(cls, value: object) -> object:
+        return (value.strip() or None) if isinstance(value, str) else value
+
+    @model_validator(mode="after")
+    def _priced_or_delisted(self) -> NewRate:
+        if (self.unit is None) != (self.price_usd is None):
+            raise ValueError(
+                "a rate needs both a unit and a price; "
+                "a delisting (no known public rate) has neither"
+            )
+        if self.unit is not None:
+            if self.unit not in UNITS_BY_BENCHMARK.get(self.benchmark, frozenset()):
+                raise ValueError(f"{self.unit} does not bill {self.benchmark} input")
+            if self.source_url is None:
+                raise ValueError("a priced rate must cite the public page that prints the figure")
+        return self
+
+    @property
+    def key(self) -> RateKey:
+        return (self.benchmark, self.provider, self.model)
+
+    def matches(self, recording: RateRecording) -> bool:
+        """Whether *recording* already states this rate for this date, quote for quote."""
+        return (
+            self.key == recording.key
+            and self.effective_from == recording.effective_from
+            and self.unit == recording.unit
+            and str(self.price_usd) == str(recording.price_usd)
+            and (self.source_url and str(self.source_url) or None) == recording.source_url
+            and self.notes == recording.notes
+        )

--- a/runner/tests/api/conftest.py
+++ b/runner/tests/api/conftest.py
@@ -347,6 +347,26 @@ def _load_schema(**connect_kwargs: Any) -> None:
             CREATE INDEX IF NOT EXISTS model_history_model_id_changed_at
                 ON benchmarks_v2.model_history (model_id, changed_at DESC)
         """)
+        # Pricing log (mirrors migration 20260903_0027).
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS benchmarks_v2.pricing_rates (
+                id                  bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+                benchmark           text NOT NULL CHECK (benchmark IN ('STT','TTS','S2S')),
+                provider            text NOT NULL CHECK (provider <> ''),
+                model               text NOT NULL CHECK (model <> ''),
+                unit                text CHECK (unit IS NULL OR unit <> ''),
+                price_usd           numeric CHECK (price_usd IS NULL OR price_usd > 0),
+                effective_from      date NOT NULL,
+                source_url          text CHECK (source_url IS NULL OR source_url <> ''),
+                notes               text CHECK (notes IS NULL OR notes <> ''),
+                recorded_by_user_id text NOT NULL CHECK (recorded_by_user_id <> ''),
+                recorded_by_email   text
+                    CHECK (recorded_by_email IS NULL OR recorded_by_email <> ''),
+                recorded_at         timestamptz NOT NULL DEFAULT now(),
+                CHECK ((unit IS NULL) = (price_usd IS NULL)),
+                CHECK (price_usd IS NULL OR source_url IS NOT NULL)
+            )
+        """)
 
 
 def _seed_registry(**connect_kwargs: Any) -> None:
@@ -363,6 +383,7 @@ def _seed_registry(**connect_kwargs: Any) -> None:
                 (str(tag), category.value, tag_value_label(category, str(tag))),
             )
         _insert_models(conn, TEST_ROSTER)
+        _insert_rates(conn, SEED_RATES)
         conn.commit()
 
 
@@ -399,6 +420,43 @@ def _insert_models(conn: psycopg.Connection[Any], models: Sequence[RegisteredMod
                 "INSERT INTO benchmarks_v2.model_tags (model_id, tag) VALUES (%s, %s)",
                 (row[0], str(tag)),
             )
+
+
+# One published rate per priced benchmark, on the test roster, keyed like the
+# migration's seed rows: (benchmark, provider, model, unit, price, from, source, notes).
+SEED_RATES: tuple[tuple[str, ...], ...] = (
+    (
+        "STT",
+        "seed",
+        "stt",
+        "per_minute",
+        "0.0048",
+        "2026-08-24",
+        "https://seed.example/pricing",
+        "Pay as you go.",
+    ),
+    (
+        "TTS",
+        "seed",
+        "tts-a",
+        "per_1k_chars",
+        "0.030",
+        "2026-08-10",
+        "https://seed.example/pricing",
+        "Pay as you go.",
+    ),
+)
+
+
+def _insert_rates(conn: psycopg.Connection[Any], rows: Sequence[Sequence[str]]) -> None:
+    """Record rates into the pricing log, as the seed migration does."""
+    for row in rows:
+        conn.execute(
+            "INSERT INTO benchmarks_v2.pricing_rates (benchmark, provider, model, unit, price_usd,"
+            " effective_from, source_url, notes, recorded_by_user_id)"
+            " VALUES (%s, %s, %s, %s, %s::numeric, %s::date, %s, %s, 'tests')",
+            tuple(row),
+        )
 
 
 def add_models(postgresql: Any, *models: RegisteredModel) -> None:

--- a/runner/tests/api/test_admin_pricing.py
+++ b/runner/tests/api/test_admin_pricing.py
@@ -1,0 +1,172 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""The admin pricing endpoints over HTTP."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import psycopg
+import pytest
+from fastapi import FastAPI
+from httpx import AsyncClient
+
+from coval_bench.api import deps
+from coval_bench.registries import Benchmark, RegisteredModel
+from tests.api.conftest import (
+    COVAL_ORG,
+    EA_MODEL,
+    EA_ORG,
+    EA_PROVIDER,
+    _make_db_url,
+    add_models,
+    bearer,
+)
+from tests.roster import TEST_ROSTER
+
+TODAY = datetime.now(UTC).date()
+SEEDED = {"benchmark": "STT", "provider": "seed", "model": "stt"}
+ADMIN = bearer(sub="user_admin", org_id=COVAL_ORG, email="admin@coval.dev")
+
+
+def _body(**overrides: Any) -> dict[str, Any]:
+    body: dict[str, Any] = {
+        **SEEDED,
+        "unit": "per_minute",
+        "price_usd": "0.0050",
+        "source_url": "https://seed.example/pricing",
+    }
+    return {**body, **overrides}
+
+
+async def _post(client: AsyncClient, **overrides: Any) -> Any:
+    return await client.post("/v1/admin/pricing", json=_body(**overrides), headers=ADMIN)
+
+
+def _model(payload: dict[str, Any], provider: str = "seed", model: str = "stt") -> dict[str, Any]:
+    return next(m for m in payload["models"] if (m["provider"], m["model"]) == (provider, model))
+
+
+async def test_admin_routes_require_a_coval_token(client: AsyncClient) -> None:
+    assert (await client.get("/v1/admin/pricing")).status_code == 401
+    assert (
+        await client.get("/v1/admin/pricing", headers=bearer(sub="u", org_id=EA_ORG))
+    ).status_code == 403
+    assert (await client.post("/v1/admin/pricing", json=_body())).status_code == 401
+
+
+async def test_list_resolves_the_seeded_log_and_is_private(client: AsyncClient) -> None:
+    response = await client.get("/v1/admin/pricing", headers=ADMIN)
+    assert response.status_code == 200
+    assert response.headers["Cache-Control"] == "private, no-store"
+    model = _model(response.json())
+    assert (model["current"]["price_usd"], model["scheduled"]) == ("0.0048", [])
+    assert [r["superseded"] for r in model["recordings"]] == [False]
+
+
+async def test_recording_takes_effect_names_the_admin_and_ignores_a_repeat(
+    client: AsyncClient,
+) -> None:
+    response = await _post(client)
+    assert response.status_code == 201
+    model = response.json()
+    current = model["current"]
+    assert (current["price_usd"], current["effective_from"]) == ("0.0050", TODAY.isoformat())
+    assert (current["recorded_by_user_id"], current["recorded_by_email"]) == (
+        "user_admin",
+        "admin@coval.dev",
+    )
+    newest, seeded = model["recordings"]
+    assert newest["price_usd"] == "0.0050" and seeded["recorded_by_user_id"] == "tests"
+    assert not newest["superseded"] and not seeded["superseded"]
+
+    served = next(
+        r for r in (await client.get("/v1/pricing")).json()["rates"] if r["model"] == "stt"
+    )
+    assert served["price_usd"] == "0.0050"
+    assert served["price_per_1k_minutes"] == current["price_per_1k_minutes"] == 5.0
+    assert served["history"][0]["price_usd"] == "0.0048"
+
+    repeat = await _post(client)
+    assert repeat.status_code == 200 and len(repeat.json()["recordings"]) == 2
+
+
+async def test_corrections_supersede_and_future_dates_schedule(client: AsyncClient) -> None:
+    await _post(client)
+    fix = await _post(client, price_usd="0.0055")
+    assert fix.status_code == 201 and fix.json()["current"]["price_usd"] == "0.0055"
+    assert [r["superseded"] for r in fix.json()["recordings"]] == [False, True, False]
+
+    ahead = (TODAY + timedelta(days=30)).isoformat()
+    scheduled = await _post(
+        client, unit=None, price_usd=None, source_url=None, effective_from=ahead
+    )
+    assert scheduled.status_code == 201
+    assert scheduled.json()["current"]["price_usd"] == "0.0055"
+    assert [(s["effective_from"], s["price_usd"]) for s in scheduled.json()["scheduled"]] == [
+        (ahead, None)
+    ]
+    served = next(
+        r for r in (await client.get("/v1/pricing")).json()["rates"] if r["model"] == "stt"
+    )
+    assert (served["price_usd"], served["effective_to"]) == ("0.0055", None)
+
+
+async def test_a_hidden_model_may_be_priced_ahead_of_launch(
+    client: AsyncClient, app: FastAPI, postgresql: Any
+) -> None:
+    hidden = RegisteredModel(
+        benchmark=Benchmark.STT,
+        provider=EA_PROVIDER,
+        model=EA_MODEL,
+        collected=True,
+        published=False,
+    )
+    add_models(postgresql, hidden)
+    app.dependency_overrides[deps.get_models] = lambda: [*TEST_ROSTER, hidden]
+    response = await _post(
+        client,
+        provider=EA_PROVIDER,
+        model=EA_MODEL,
+        price_usd="0.006",
+        source_url="https://acme.example.com/p",
+    )
+    assert response.status_code == 201
+    listed = await client.get("/v1/admin/pricing", headers=ADMIN)
+    assert _model(listed.json(), EA_PROVIDER, EA_MODEL)["current"]["price_usd"] == "0.006"
+    assert all(r["model"] != EA_MODEL for r in (await client.get("/v1/pricing")).json()["rates"])
+    cleared = await client.get("/v1/pricing", headers=bearer(org_id=EA_ORG))
+    assert any(r["model"] == EA_MODEL for r in cleared.json()["rates"])
+
+
+@pytest.mark.parametrize(
+    ("overrides", "detail"),
+    [
+        ({"model": "nova-99"}, "no registered model"),
+        ({"price_usd": None}, "both a unit and a price"),
+        ({"price_usd": 0.005}, "valid string"),  # a JSON number would drop trailing zeros
+        ({"unit": "per_1k_chars"}, "does not bill"),
+        ({"source_url": None}, "cite"),
+        ({"source_url": "not a url"}, ""),
+        ({"price_usd": "0"}, ""),
+        ({"effective_from": (TODAY + timedelta(days=400)).isoformat()}, "a year ahead"),
+        ({"effective_from": "2019-12-31"}, "may not precede"),
+        ({"effective_from": "someday"}, ""),
+    ],
+)
+async def test_writes_are_validated(
+    client: AsyncClient, overrides: dict[str, Any], detail: str
+) -> None:
+    response = await _post(client, **overrides)
+    assert response.status_code == 422
+    assert detail in str(response.json()["detail"])
+
+
+async def test_a_missing_log_is_a_503_for_admins_too(client: AsyncClient, postgresql: Any) -> None:
+    with psycopg.connect(_make_db_url(postgresql)) as conn:
+        conn.execute("DROP TABLE benchmarks_v2.pricing_rates")
+        conn.commit()
+    assert (await client.get("/v1/admin/pricing", headers=ADMIN)).status_code == 503
+    assert (await _post(client)).status_code == 503

--- a/runner/tests/api/test_pricing.py
+++ b/runner/tests/api/test_pricing.py
@@ -1,0 +1,171 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""GET /v1/pricing: the rate in force on a day, its history, and model visibility."""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime, timedelta
+from typing import Any
+
+import psycopg
+from fastapi import FastAPI
+from httpx import AsyncClient
+
+from coval_bench.api import deps
+from coval_bench.registries import Benchmark, RegisteredModel
+from tests.api.conftest import (
+    COVAL_ORG,
+    EA_MODEL,
+    EA_ORG,
+    EA_ORG_OTHER,
+    EA_PROVIDER,
+    SEED_RATES,
+    _make_db_url,
+    bearer,
+)
+from tests.roster import TEST_ROSTER
+
+TODAY = datetime.now(UTC).date()
+EA_KEY = ("STT", EA_PROVIDER, EA_MODEL)
+SEED_KEY = ("STT", "seed", "stt")
+
+
+def _record(
+    postgresql: Any,
+    *,
+    provider: str = EA_PROVIDER,
+    model: str = EA_MODEL,
+    price: str | None = "0.006",
+    effective_from: date = TODAY,
+    recorded_at: datetime | None = None,
+) -> None:
+    """Append one STT recording straight into the log, as the admin API would."""
+    with psycopg.connect(_make_db_url(postgresql)) as conn:
+        conn.execute(
+            "INSERT INTO benchmarks_v2.pricing_rates (benchmark, provider, model, unit, price_usd,"
+            " effective_from, source_url, recorded_by_user_id, recorded_at)"
+            " VALUES ('STT', %s, %s, %s, %s::numeric, %s, %s, 'tests', COALESCE(%s, now()))",
+            (
+                provider,
+                model,
+                None if price is None else "per_minute",
+                price,
+                effective_from,
+                None if price is None else "https://acme.example.com/pricing",
+                recorded_at,
+            ),
+        )
+        conn.commit()
+
+
+def _serve_model(app: FastAPI, *, collected: bool = True, published: bool = True) -> None:
+    """Extend the served roster with the early-access fixture model."""
+    model = RegisteredModel(
+        benchmark=Benchmark.STT,
+        provider=EA_PROVIDER,
+        model=EA_MODEL,
+        collected=collected,
+        published=published,
+    )
+    app.dependency_overrides[deps.get_models] = lambda: [*TEST_ROSTER, model]
+
+
+async def _rates(client: AsyncClient, **params: str) -> dict[tuple[str, str, str], dict[str, Any]]:
+    response = await client.get("/v1/pricing", params=params)
+    assert response.status_code == 200
+    return {(r["benchmark"], r["provider"], r["model"]): r for r in response.json()["rates"]}
+
+
+async def test_the_seeded_log_serves_exact_quotes_with_no_history_yet(client: AsyncClient) -> None:
+    response = await client.get("/v1/pricing")
+    assert response.json()["as_of"] == TODAY.isoformat()
+    rates = await _rates(client)
+    assert set(rates) == {(row[0], row[1], row[2]) for row in SEED_RATES}
+    stt = rates[SEED_KEY]
+    assert (stt["price_usd"], stt["price_per_1k_minutes"], stt["price_per_1m_chars"]) == (
+        "0.0048",
+        4.8,
+        None,
+    )
+    assert (stt["history"], stt["effective_to"], stt["unit"]) == ([], None, "per_minute")
+    assert rates[("TTS", "seed", "tts-a")]["price_per_1m_chars"] == 30.0
+    tomorrow = (TODAY + timedelta(days=1)).isoformat()
+    assert (await client.get("/v1/pricing", params={"as_of": tomorrow})).status_code == 422
+
+
+async def test_embargoed_rate_stays_hidden_from_public(
+    client: AsyncClient, app: FastAPI, postgresql: Any
+) -> None:
+    """A rate on an unpublished model shows only to callers cleared for the model."""
+    _serve_model(app, published=False)
+    _record(postgresql)
+    public = await client.get("/v1/pricing")
+    assert EA_KEY not in await _rates(client)
+    assert public.headers["X-EA-Token-Status"] == "absent"
+    cleared = await client.get("/v1/pricing", headers=bearer(org_id=EA_ORG))
+    assert cleared.headers["X-EA-Token-Status"] == "accepted"
+    assert cleared.headers["Cache-Control"] == "private, no-store"
+    rate = next(r for r in cleared.json()["rates"] if r["model"] == EA_MODEL)
+    assert (rate["price_per_1k_minutes"], rate["price_per_1m_chars"]) == (6.0, None)
+    # A partner org cleared for a different model on the same provider is scoped by model.
+    other = await client.get("/v1/pricing", headers=bearer(org_id=EA_ORG_OTHER))
+    assert all(r["model"] != EA_MODEL for r in other.json()["rates"])
+    staff = await client.get("/v1/pricing", headers=bearer(org_id=COVAL_ORG))
+    assert any(r["model"] == EA_MODEL for r in staff.json()["rates"])
+
+
+async def test_the_roster_decides_what_serves(
+    client: AsyncClient, app: FastAPI, postgresql: Any
+) -> None:
+    """Uncollected models still serve (the site lists them greyed out); unlisted ones never do."""
+    _serve_model(app, collected=False)
+    _record(postgresql)
+    _record(postgresql, provider="ghost", model="nobody")
+    rates = await _rates(client)
+    assert rates[EA_KEY]["price_per_1k_minutes"] == 6.0
+    assert ("STT", "ghost", "nobody") not in rates
+
+
+async def test_as_of_reads_the_rate_in_force_that_day_with_its_history(
+    client: AsyncClient, app: FastAPI, postgresql: Any
+) -> None:
+    _serve_model(app)
+    day0, day1 = TODAY - timedelta(days=30), TODAY - timedelta(days=10)
+    _record(postgresql, price="0.004", effective_from=day0)
+    _record(
+        postgresql, price="0.005", effective_from=day1, recorded_at=datetime(2026, 9, 1, tzinfo=UTC)
+    )
+    _record(
+        postgresql, price="0.006", effective_from=day1, recorded_at=datetime(2026, 9, 2, tzinfo=UTC)
+    )
+    _record(
+        postgresql, price=None, effective_from=TODAY + timedelta(days=5)
+    )  # a scheduled delisting
+    _record(postgresql, provider="seed", model="stt", price=None)  # a delisting in force today
+
+    rate = (await _rates(client))[EA_KEY]
+    assert (rate["price_usd"], rate["effective_from"]) == ("0.006", day1.isoformat())
+    assert rate["effective_to"] is None  # the scheduled change is not public, its date included
+    assert [(h["price_usd"], h["effective_to"]) for h in rate["history"]] == [
+        ("0.004", day1.isoformat())
+    ]
+
+    delisted = (await _rates(client))[SEED_KEY]
+    assert (delisted["unit"], delisted["price_usd"], delisted["source_url"]) == (None, None, None)
+    assert [(h["price_usd"], h["effective_to"]) for h in delisted["history"]] == [
+        ("0.0048", TODAY.isoformat())
+    ]
+
+    earlier = (await _rates(client, as_of=day0.isoformat()))[EA_KEY]
+    assert (earlier["price_usd"], earlier["history"]) == ("0.004", [])
+    assert EA_KEY not in await _rates(client, as_of=(day0 - timedelta(days=1)).isoformat())
+
+
+async def test_a_missing_log_is_a_503(client: AsyncClient, postgresql: Any) -> None:
+    with psycopg.connect(_make_db_url(postgresql)) as conn:
+        conn.execute("DROP TABLE benchmarks_v2.pricing_rates")
+        conn.commit()
+    response = await client.get("/v1/pricing")
+    assert response.status_code == 503
+    assert response.json()["detail"] == "the pricing log is unavailable"

--- a/runner/tests/unit/test_pricing_rules.py
+++ b/runner/tests/unit/test_pricing_rules.py
@@ -1,0 +1,143 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""The pricing rules: normalization, which recording prices which day, what a NewRate accepts."""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime, timedelta
+from decimal import Decimal
+from typing import Any
+
+import pytest
+from pydantic import ValidationError
+
+from coval_bench.registries import Benchmark
+from coval_bench.registries.pricing import (
+    NewRate,
+    PricingUnit,
+    RateRecording,
+    RateSpan,
+    RateTimeline,
+    per_1k_minutes,
+    per_1m_chars,
+    timelines,
+)
+
+KEY = (Benchmark.STT, "acme", "stt-1")
+D = date
+
+
+def _rec(
+    id: int, effective_from: date, price: str | None = "0.0050", recorded_at: datetime | None = None
+) -> RateRecording:
+    return RateRecording(
+        id=id,
+        benchmark=KEY[0],
+        provider=KEY[1],
+        model=KEY[2],
+        unit=None if price is None else PricingUnit.PER_MINUTE,
+        price_usd=None if price is None else Decimal(price),
+        effective_from=effective_from,
+        source_url=None if price is None else "https://acme.example/pricing",
+        notes=None,
+        recorded_by_user_id="tests",
+        recorded_by_email=None,
+        recorded_at=recorded_at or datetime(2026, 9, 1, tzinfo=UTC) + timedelta(seconds=id),
+    )
+
+
+def _in_force(timeline: RateTimeline, day: date) -> RateSpan:
+    span = timeline.in_force(day)
+    assert span is not None
+    return span
+
+
+def test_normalization_scales_within_one_denominator_only() -> None:
+    assert per_1m_chars(PricingUnit.PER_1K_CHARS, Decimal("0.030")) == Decimal("30.000")
+    assert per_1m_chars(PricingUnit.PER_CHAR, Decimal("0.00003")) == Decimal("30.00000")
+    assert per_1k_minutes(PricingUnit.PER_MINUTE, Decimal("0.0048")) == Decimal("4.8000")
+    assert per_1k_minutes(PricingUnit.PER_HOUR, Decimal("0.45")) == Decimal("7.500000")
+    assert per_1k_minutes(PricingUnit.PER_SECOND_AUDIO_IN, Decimal("0.0001")) == Decimal("6.0000")
+    # Seconds of audio out and character units never convert into the other denominator.
+    assert per_1m_chars(PricingUnit.PER_MINUTE, Decimal("1")) is None
+    assert per_1k_minutes(PricingUnit.PER_1K_CHARS, Decimal("1")) is None
+    assert per_1m_chars(PricingUnit.PER_SECOND_AUDIO_OUT, Decimal("1")) is None
+    assert per_1k_minutes(PricingUnit.PER_SECOND_AUDIO_OUT, Decimal("1")) is None
+
+
+def test_latest_recording_wins_spans_close_and_the_future_is_scheduled() -> None:
+    rows = [
+        _rec(1, D(2026, 8, 1), "0.0048"),
+        _rec(2, D(2026, 9, 1), "0.0050"),
+        _rec(3, D(2026, 9, 1), "0.0055"),  # a correction, recorded later
+        _rec(4, D(2026, 10, 1), None),  # a delisting, still ahead
+        _rec(5, D(2026, 8, 1), "1.00", recorded_at=datetime(2026, 8, 1, tzinfo=UTC)),  # earlier say
+    ]
+    timeline = timelines(rows)[KEY]
+    assert [s.recording.id for s in timeline.spans] == [1, 3, 4]
+    assert [r.id for r in timeline.superseded] == [5, 2]
+    assert [s.effective_to for s in timeline.spans] == [D(2026, 9, 1), D(2026, 10, 1), None]
+    assert timeline.in_force(D(2026, 7, 31)) is None
+    assert _in_force(timeline, D(2026, 8, 31)).recording.id == 1
+    today = _in_force(timeline, D(2026, 9, 15))
+    assert today.recording.id == 3
+    assert [s.recording.id for s in timeline.before(today)] == [1]
+    assert [s.recording.id for s in timeline.scheduled(D(2026, 9, 15))] == [4]
+    assert not _in_force(timeline, D(2026, 10, 1)).recording.priced
+    assert _in_force(timeline, D(2026, 9, 15)).recording.price_per_1k_minutes == Decimal("5.5000")
+
+
+def test_a_same_instant_tie_falls_to_the_later_row_and_keys_stay_apart() -> None:
+    at = datetime(2026, 9, 1, tzinfo=UTC)
+    other = _rec(9, D(2026, 9, 1)).model_copy(update={"model": "stt-2"})
+    resolved = timelines(
+        [
+            _rec(2, D(2026, 9, 1), "0.2", recorded_at=at),
+            _rec(1, D(2026, 9, 1), "0.1", recorded_at=at),
+            other,
+        ]
+    )
+    assert resolved[KEY].spans[0].recording.id == 2
+    assert resolved[(Benchmark.STT, "acme", "stt-2")].spans[0].recording.id == 9
+
+
+def _new(**overrides: Any) -> NewRate:
+    fields: dict[str, Any] = {
+        "benchmark": KEY[0],
+        "provider": KEY[1],
+        "model": KEY[2],
+        "unit": "per_minute",
+        "price_usd": "0.0050",
+        "effective_from": D(2026, 9, 1),
+        "source_url": "https://acme.example/pricing",
+    }
+    return NewRate.model_validate({**fields, **overrides})
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"price_usd": None},  # unit without a price
+        {"unit": None},  # price without a unit
+        {"price_usd": 0.005},  # a bare number would drop trailing zeros
+        {"price_usd": "1E+2"},  # exponent form would defeat the quote-for-quote repeat check
+        {"price_usd": "0"},
+        {"unit": "per_1k_chars"},  # a character unit cannot bill STT
+        {"source_url": None},  # a priced rate must cite its page
+        {"source_url": "not a url"},
+        {"provider": ""},
+    ],
+)
+def test_new_rate_rejects_half_rates_floats_and_wrong_units(overrides: dict[str, Any]) -> None:
+    with pytest.raises(ValidationError):
+        _new(**overrides)
+
+
+def test_new_rate_keeps_the_quote_and_knows_a_repeat() -> None:
+    rate = _new(notes="   ")
+    assert rate.notes is None and str(rate.price_usd) == "0.0050"
+    assert rate.matches(_rec(1, D(2026, 9, 1), "0.0050"))
+    assert not rate.matches(_rec(1, D(2026, 9, 1), "0.005"))  # same amount, different quote
+    delisting = _new(unit=None, price_usd=None, source_url=None)
+    assert delisting.price_usd is None and delisting.key == KEY

--- a/runner/tests/unit/test_pricing_store.py
+++ b/runner/tests/unit/test_pricing_store.py
@@ -1,0 +1,113 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""The seed migration against a real Postgres: every packaged rate valid, and the downgrade guard.
+
+Recording semantics are covered over HTTP in ``tests/api/test_admin_pricing.py``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from datetime import UTC, datetime
+from typing import Any
+
+import psycopg
+import pytest
+from alembic import command as alembic_command
+from alembic.config import Config as AlembicConfig
+from pytest_postgresql.factories import postgresql
+
+from coval_bench.db.pricing_store import PricingStore
+from coval_bench.registries import Benchmark
+from coval_bench.registries.pricing import NewRate
+
+from .conftest import _INI_PATH, apply_migrations, async_dsn, open_pool
+
+pricing_pg = postgresql("pg_proc")  # shared server from conftest, own per-test DB
+
+_ADMIN = {"user_id": "user_cale", "email": "cale@coval.dev"}
+KEY = (Benchmark.STT, "deepgram", "nova-3")
+TODAY = datetime.now(UTC).date()
+
+
+def _run(
+    conn: psycopg.Connection[Any], scenario: Callable[[PricingStore], Awaitable[None]]
+) -> None:
+    apply_migrations(conn)
+
+    async def go() -> None:
+        pool = await open_pool(conn)
+        try:
+            await scenario(PricingStore(pool))
+        finally:
+            await pool.close()
+
+    asyncio.run(go())
+
+
+def _rate(price: str | None = "0.0050", **overrides: Any) -> NewRate:
+    fields: dict[str, Any] = {
+        "benchmark": KEY[0],
+        "provider": KEY[1],
+        "model": KEY[2],
+        "unit": None if price is None else "per_minute",
+        "price_usd": price,
+        "effective_from": TODAY,
+        "source_url": None if price is None else "https://deepgram.com/pricing",
+    }
+    return NewRate.model_validate({**fields, **overrides})
+
+
+def test_the_migration_seeds_valid_rates_on_registered_models(
+    pricing_pg: psycopg.Connection[Any],
+) -> None:
+    async def scenario(store: PricingStore) -> None:
+        recordings = await store.recordings()
+        assert len(recordings) == 61 == len({r.key for r in recordings})
+        for r in recordings:
+            NewRate(
+                benchmark=r.benchmark,
+                provider=r.provider,
+                model=r.model,
+                unit=r.unit,
+                price_usd=r.price_usd,
+                effective_from=r.effective_from,
+                source_url=r.source_url,
+                notes=r.notes,
+            )
+            assert r.priced and r.recorded_by_user_id == "migration:20260903_0027"
+            assert await store.model_exists(r.key), r.key
+        by_key = {r.key: r for r in recordings}
+        # The quoted scale survives the round trip: 0.030, not 0.03.
+        assert str(by_key[KEY].price_usd) == "0.0048"
+        assert str(by_key[(Benchmark.TTS, "deepgram", "aura-2-thalia-en")].price_usd) == "0.030"
+
+    _run(pricing_pg, scenario)
+
+
+def _downgrade_one(conn: psycopg.Connection[Any]) -> None:
+    cfg = AlembicConfig(str(_INI_PATH))
+    cfg.set_main_option(
+        "sqlalchemy.url", async_dsn(conn).replace("postgresql://", "postgresql+psycopg://")
+    )
+    alembic_command.downgrade(cfg, "-1")
+
+
+def test_downgrade_drops_only_a_log_that_holds_nothing_beyond_the_seed(
+    pricing_pg: psycopg.Connection[Any],
+) -> None:
+    async def scenario(store: PricingStore) -> None:
+        await store.record(_rate("0.0061"), **_ADMIN)
+
+    _run(pricing_pg, scenario)
+    with pytest.raises(RuntimeError, match="refusing to drop"):
+        _downgrade_one(pricing_pg)
+    with pricing_pg.cursor() as cur:
+        cur.execute("DELETE FROM benchmarks_v2.pricing_rates WHERE price_usd = 0.0061")
+        pricing_pg.commit()
+    _downgrade_one(pricing_pg)
+    with pricing_pg.cursor() as cur:
+        cur.execute("SELECT to_regclass('benchmarks_v2.pricing_rates')")
+        assert cur.fetchone() == (None,)


### PR DESCRIPTION
Linear: [BENCH-766](https://linear.app/coval/issue/BENCH-766/open-model-pricing-registry-on-get-v1pricing-static-no-db)
Replaces #594: same change, rebased onto current main and cut from 2,549 to 1,517 lines.

## What

- `benchmarks_v2.pricing_rates` (migration `20260903_0027`): append-only log seeded with the 61 rates verified against providers' public pricing pages. A correction appends and marks the earlier row superseded, a future date schedules a change, null unit + price records "no known public rate". Nothing updates or deletes a row.
- `GET /v1/pricing?as_of=`: the rate in force on a day (default today) with earlier spans as `history`. Same roster and embargo filters as every other data endpoint.
- `GET` / `POST /v1/admin/pricing`: coval-org only via `require_coval_admin`; each recording is stamped with the caller's Clerk user id and email.
- A missing table or grant is a 503 on every pricing route, admin included. Downgrade refuses to drop the table once admin recordings exist.

## Deploy

1. Merge. Wait for the Switchboard runner release for this SHA (`production-runner` must equal it), then run the migration:
   `gcloud run jobs execute benchmarks-runner --region=us-east1 --project=coval-benchmarks-prod --args="db,migrate"`
2. Grant: coval-ai/benchmark-infra#169 gives the api role SELECT + INSERT on `pricing_rates`. Plan and apply it only after the table exists.
3. Then the web PR on `cooper/bench-766-pricing-postgres` in coval-ai/benchmarks-web.

Until the grant lands, `GET /v1/pricing` and the admin routes return 503. Nothing else is affected.

## Verification

`cd runner && uv run ruff check . && uv run ruff format --check . && uv run mypy --strict src tests && uv run pytest -q --disable-socket --allow-unix-socket --allow-hosts=127.0.0.1,::1` — 2006 passed. Live on the local stack with a mock Clerk issuer: 401 no token, 403 other org, 422 bad unit / float price / bad URL / two years out, 201 stamped recording, repeat 200, hidden model priced ahead of launch stays off the public read.
