### PR TITLE
[BENCH-822] Fix Coval LLM run-template payload

### DIFF
--- a/runner/src/coval_bench/llm/coval_agent.py
+++ b/runner/src/coval_bench/llm/coval_agent.py
@@ -102,11 +102,11 @@ class CovalTextAgentDefinition(BaseModel, frozen=True):
     def run_template_body(self, agent_id: str) -> dict[str, Any]:
         return {
             "display_name": RUN_NAME,
-            "agent_id": agent_id,
+            "agent_ids": [agent_id],
             "persona_ids": list(CLEAN_DENTAL_PERSONAS),
-            "test_set_id": self.test_set_id,
+            "test_set_ids": [self.test_set_id],
             "metric_ids": [self.instruction_metric_id],
-            "options": {"iteration_count": 1},
+            "iteration_count": 1,
         }
 
 

--- a/runner/tests/unit/test_coval_agent_sync.py
+++ b/runner/tests/unit/test_coval_agent_sync.py
@@ -143,9 +143,12 @@ def test_sync_creates_everything_when_absent() -> None:
         "/scheduled-runs",
     ]
     template = state["writes"][2][1]
-    assert template["agent_id"] == "A" * 22
+    assert template["agent_ids"] == ["A" * 22]
     assert template["persona_ids"] == list(coval_agent.CLEAN_DENTAL_PERSONAS)
+    assert template["test_set_ids"] == ["TSDENTAL"]
     assert template["metric_ids"] == ["M" * 22]
+    assert template["iteration_count"] == 1
+    assert "options" not in template
     assert state["writes"][3][1]["schedule_expression"] == "cron(0 13 * * ? *)"
 
 


### PR DESCRIPTION
## Summary
- send Coval run-template `agent_ids` and `test_set_ids` as arrays
- send `iteration_count` at the top level
- assert the live payload contract in the sync test

## Production finding
The first `llm-sync` execution (`llm-sync-xch9w`) failed with Coval `INVALID_ARGUMENT` because the old singular fields were rejected. The scheduler is paused until this fix is released.

## Validation
- Ruff check and format
- strict mypy
- `tests/unit/test_coval_agent_sync.py`: 10 passed