### PR TITLE
[BENCH-769] Move the FEATURES tag vocabulary into Postgres

### DIFF
--- a/runner/src/coval_bench/api/deps.py
+++ b/runner/src/coval_bench/api/deps.py
@@ -25,7 +25,7 @@ from starlette.requests import Request
 
 from coval_bench.api import clerk
 from coval_bench.config import Settings
-from coval_bench.db.registry_store import fetch_models
+from coval_bench.db.registry_store import RegistryStore, TagRecord, fetch_models
 from coval_bench.llm.benchmark import ProxiedModel, llm_models
 from coval_bench.llm.turn import TurnClient
 from coval_bench.registries import RegisteredModel
@@ -148,6 +148,17 @@ async def get_proxied_model(
     if client is None:
         raise HTTPException(503, f"{provider} proxy is not configured")
     return ProxiedModel(provider=provider, model=registered.model, client=client)
+
+
+async def get_tag_vocabulary(
+    pool: AsyncConnectionPool[Any] = Depends(get_pool),
+) -> dict[str, TagRecord]:
+    """The FEATURES vocabulary by value, read fresh on every request like the roster."""
+    try:
+        return {record.value: record for record in await RegistryStore(pool).list_tags()}
+    except Exception as exc:
+        logger.error("tag_vocabulary_unavailable", exc_info=True)
+        raise HTTPException(503, "the tag vocabulary is unavailable") from exc
 
 
 def get_cache_locks(request: Request) -> defaultdict[Any, asyncio.Lock]:

--- a/runner/src/coval_bench/api/routers/providers.py
+++ b/runner/src/coval_bench/api/routers/providers.py
@@ -12,14 +12,19 @@ existence) and included for callers entitled to them.
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 
 import structlog
 from fastapi import APIRouter, Depends
 from posthog import Posthog
 from starlette.requests import Request
 
-from coval_bench.api.deps import capture_api_event, get_models, get_posthog
+from coval_bench.api.deps import (
+    capture_api_event,
+    get_models,
+    get_posthog,
+    get_tag_vocabulary,
+)
 from coval_bench.api.internal import hidden_early_access
 from coval_bench.api.ratelimit import limiter
 from coval_bench.api.schemas import (
@@ -29,10 +34,10 @@ from coval_bench.api.schemas import (
     ProvidersResponse,
     TagCategoryOut,
 )
+from coval_bench.db.registry_store import TagRecord
 from coval_bench.registries import (
     CATEGORY_LABELS,
     PROVIDER_VALUED_CATEGORIES,
-    TAG_CATEGORIES,
     Benchmark,
     RegisteredModel,
     TagCategory,
@@ -45,11 +50,21 @@ router = APIRouter(tags=["providers"])
 
 
 def _tag(category: TagCategory, value: str) -> ModelTagOut:
-    """Build a facet tag with its display label resolved from the registry."""
+    """Build a derived facet tag, labelled from the category's own rules."""
     return ModelTagOut(category=category, value=value, label=tag_value_label(category, value))
 
 
-def _model_tags(m: RegisteredModel) -> list[ModelTagOut]:
+def _feature_tag(value: str, vocabulary: Mapping[str, TagRecord]) -> ModelTagOut:
+    """Build a curated tag, labelled from its vocabulary row."""
+    record = vocabulary.get(value)
+    if record is None:
+        return ModelTagOut(category=TagCategory.FEATURES, value=value, label=value)
+    return ModelTagOut(
+        category=TagCategory(record.category), value=record.value, label=record.label
+    )
+
+
+def _model_tags(m: RegisteredModel, vocabulary: Mapping[str, TagRecord]) -> list[ModelTagOut]:
     """Flatten a model's facets: derived columns/attributes plus curated tags."""
     deployment = "on-prem" if m.on_prem else "cloud"
     return [
@@ -60,7 +75,7 @@ def _model_tags(m: RegisteredModel) -> list[ModelTagOut]:
         _tag(TagCategory.LICENSING, m.licensing),
         _tag(TagCategory.DEPLOYMENT, deployment),
         *([_tag(TagCategory.REGION, m.region)] if m.region else []),
-        *(_tag(TAG_CATEGORIES[t], t) for t in m.tags),
+        *(_feature_tag(t, vocabulary) for t in m.tags),
     ]
 
 
@@ -80,6 +95,7 @@ def _build_provider_map(
     models: Sequence[RegisteredModel],
     benchmark: Benchmark,
     hidden: frozenset[tuple[str, str]],
+    vocabulary: Mapping[str, TagRecord],
 ) -> dict[str, list[ModelInfo]]:
     """Build an ordered {provider: [ModelInfo, ...]} map from the model registry.
 
@@ -97,19 +113,21 @@ def _build_provider_map(
                 model=m.model,
                 disabled=not m.collected,
                 early_access=not m.published,
-                tags=_model_tags(m),
+                tags=_model_tags(m, vocabulary),
             )
         )
     return result
 
 
 def _describe(
-    models: Sequence[RegisteredModel], hidden: frozenset[tuple[str, str]]
+    models: Sequence[RegisteredModel],
+    hidden: frozenset[tuple[str, str]],
+    vocabulary: Mapping[str, TagRecord],
 ) -> ProvidersResponse:
-    stt_map = _build_provider_map(models, Benchmark.STT, hidden)
-    tts_map = _build_provider_map(models, Benchmark.TTS, hidden)
-    s2s_map = _build_provider_map(models, Benchmark.S2S, hidden)
-    llm_map = _build_provider_map(models, Benchmark.LLM, hidden)
+    stt_map = _build_provider_map(models, Benchmark.STT, hidden, vocabulary)
+    tts_map = _build_provider_map(models, Benchmark.TTS, hidden, vocabulary)
+    s2s_map = _build_provider_map(models, Benchmark.S2S, hidden, vocabulary)
+    llm_map = _build_provider_map(models, Benchmark.LLM, hidden, vocabulary)
 
     return ProvidersResponse(
         stt=[ProviderInfo(provider=p, models=m) for p, m in sorted(stt_map.items())],
@@ -127,6 +145,7 @@ async def get_providers(
     posthog_client: Posthog | None = Depends(get_posthog),
     hidden: frozenset[tuple[str, str]] = Depends(hidden_early_access),
     models: Sequence[RegisteredModel] = Depends(get_models),
+    vocabulary: Mapping[str, TagRecord] = Depends(get_tag_vocabulary),
 ) -> ProvidersResponse:
     """Return the catalogue of benchmarked providers and models.
 
@@ -135,7 +154,7 @@ async def get_providers(
     hide or grey out models that are known but not actively benchmarked.
     An early-access model appears only for a caller whose allowlist names it.
     """
-    response = _describe(models, hidden)
+    response = _describe(models, hidden, vocabulary)
     capture_api_event(
         posthog_client,
         "providers_listed",

--- a/runner/src/coval_bench/api/routers/tags.py
+++ b/runner/src/coval_bench/api/routers/tags.py
@@ -25,7 +25,7 @@ router = APIRouter(tags=["tags"])
 async def list_tags(
     pool: AsyncConnectionPool[Any] = Depends(get_pool),
 ) -> TagsResponse:
-    """The MODE and FEATURES tag vocabulary, ordered by value."""
+    """The FEATURES tag vocabulary, ordered by value."""
     records = await RegistryStore(pool).list_tags()
     return TagsResponse(tags=[TagOut.model_validate(record.model_dump()) for record in records])
 

--- a/runner/src/coval_bench/db/migrations/versions/20260909_0028_features_only_tag_categories.py
+++ b/runner/src/coval_bench/db/migrations/versions/20260909_0028_features_only_tag_categories.py
@@ -1,0 +1,43 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Narrow the tag category check to the one category that exists.
+
+Revision ID: 20260909_0028
+Revises:     20260903_0027
+Create Date: 2026-09-09
+
+Nothing serves a second curated category: ``TagRecord`` pins the column to
+``features`` and no row has held anything else.
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "20260909_0028"
+down_revision = "20260903_0027"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Drop the two-value check for a features-only one."""
+    op.get_bind().exec_driver_sql(
+        """
+        ALTER TABLE benchmarks_v2.tags DROP CONSTRAINT tags_category_check;
+        ALTER TABLE benchmarks_v2.tags
+            ADD CONSTRAINT tags_category_check CHECK (category = 'features');
+        """
+    )
+
+
+def downgrade() -> None:
+    """Restore the check that also allowed 'mode'."""
+    op.get_bind().exec_driver_sql(
+        """
+        ALTER TABLE benchmarks_v2.tags DROP CONSTRAINT tags_category_check;
+        ALTER TABLE benchmarks_v2.tags
+            ADD CONSTRAINT tags_category_check CHECK (category IN ('mode', 'features'));
+        """
+    )

--- a/runner/src/coval_bench/db/registry_store.py
+++ b/runner/src/coval_bench/db/registry_store.py
@@ -20,7 +20,6 @@ from typing import Any, Literal
 import psycopg
 import psycopg.errors
 import psycopg.rows
-import structlog
 from psycopg.types.json import Jsonb
 from psycopg_pool import AsyncConnectionPool
 from pydantic import BaseModel, field_validator
@@ -32,11 +31,8 @@ from coval_bench.registries.models import (
     Source,
     Voice,
 )
-from coval_bench.registries.tags import ModelTag
 
 RegistryPool = AsyncConnectionPool[psycopg.AsyncConnection[psycopg.rows.DictRow]]
-
-logger = structlog.get_logger("coval_bench.db.registry_store")
 
 
 # Columns a PATCH may change. The modality is immutable: it selects the
@@ -422,23 +418,7 @@ class RegistryStore:
 
 
 def _registered(record: ModelRecord) -> RegisteredModel:
-    """One row as the frozen object every consumer already expects.
-
-    A tag the code vocabulary does not know is dropped rather than raised on: a
-    tag added through the admin API must not take the catalogue down, it just
-    does not surface until the vocabulary knows it.
-    """
-    tags: list[ModelTag] = []
-    for value in record.tags:
-        try:
-            tags.append(ModelTag(value))
-        except ValueError:
-            logger.warning(
-                "registry_unknown_tag",
-                provider=record.provider,
-                model=record.model,
-                tag=value,
-            )
+    """One row as the frozen object every consumer already expects."""
     return RegisteredModel(
         benchmark=record.modality,
         provider=record.provider,
@@ -446,7 +426,7 @@ def _registered(record: ModelRecord) -> RegisteredModel:
         voice=record.voice,
         voices=record.voices,
         creator=record.creator,
-        tags=tuple(tags),
+        tags=record.tags,
         source=record.source,
         licensing=record.licensing,
         on_prem=record.on_prem,

--- a/runner/src/coval_bench/registries/__init__.py
+++ b/runner/src/coval_bench/registries/__init__.py
@@ -36,8 +36,6 @@ from coval_bench.registries.preprocessing import (
 from coval_bench.registries.tags import (
     CATEGORY_LABELS,
     PROVIDER_VALUED_CATEGORIES,
-    TAG_CATEGORIES,
-    ModelTag,
     TagCategory,
     tag_value_label,
 )
@@ -62,8 +60,6 @@ __all__ = [
     "Voice",
     "CATEGORY_LABELS",
     "PROVIDER_VALUED_CATEGORIES",
-    "TAG_CATEGORIES",
-    "ModelTag",
     "TagCategory",
     "is_metric_excluded",
     "validate_metric_contract",

--- a/runner/src/coval_bench/registries/models.py
+++ b/runner/src/coval_bench/registries/models.py
@@ -16,7 +16,6 @@ from typing import Literal
 from pydantic import BaseModel
 
 from coval_bench.registries.benchmarks import Benchmark
-from coval_bench.registries.tags import ModelTag
 
 
 class Source(StrEnum):
@@ -76,7 +75,7 @@ class RegisteredModel(BaseModel, frozen=True, extra="forbid"):
     # see :class:`Voice` for why nothing pairs on it yet.
     voices: tuple[Voice, ...] = ()
     creator: str | None = None  # who makes the model; None means same as provider
-    tags: tuple[ModelTag, ...] = ()
+    tags: tuple[str, ...] = ()
     source: Source = Source.OFFICIAL_API
     licensing: Licensing = Licensing.PROPRIETARY
     on_prem: bool = False  # provider offers on-prem/customer-infra deployment

--- a/runner/src/coval_bench/registries/tags.py
+++ b/runner/src/coval_bench/registries/tags.py
@@ -1,6 +1,6 @@
 # Copyright 2026 The Coval Benchmarks Authors
 # SPDX-License-Identifier: Apache-2.0
-"""Model tag vocabulary surfaced as leaderboard filters."""
+"""Leaderboard facets derived from model columns; FEATURES lives in the tags table."""
 
 from __future__ import annotations
 
@@ -11,8 +11,8 @@ class TagCategory(StrEnum):
     """Faceted leaderboard filters. Within a facet tags OR; across facets they AND.
 
     TYPE/HOST/CREATOR are derived from registry columns and SOURCE/LICENSING/
-    DEPLOYMENT from model attributes, all at the API boundary; only FEATURES
-    draws its values from ``ModelTag``.
+    DEPLOYMENT from model attributes, all at the API boundary; FEATURES values
+    and labels come from ``benchmarks_v2.tags``.
     """
 
     TYPE = "type"
@@ -23,41 +23,6 @@ class TagCategory(StrEnum):
     LICENSING = "licensing"
     DEPLOYMENT = "deployment"
     REGION = "region"
-
-
-class ModelTag(StrEnum):
-    """Curated model attributes surfaced as FEATURES filter chips.
-
-    KEYTERM_BIASING means expected vocabulary or a static context prompt
-    supplied at session start biases recognition; CODE_SWITCHING means
-    intra-sentence language mixing in one stream — session-level language
-    identification or switching does not qualify.
-    """
-
-    MULTILINGUAL = "multilingual"
-    VAD = "vad"
-    DIARIZATION = "diarization"
-    TRANSLATION = "translation"
-    CODE_SWITCHING = "code-switching"
-    KEYTERM_BIASING = "keyterm-biasing"
-    VOICE_CLONING = "voice-cloning"
-    EMOTION_CONTROL = "emotion-control"
-
-
-TAG_CATEGORIES: dict[ModelTag, TagCategory] = {
-    ModelTag.MULTILINGUAL: TagCategory.FEATURES,
-    ModelTag.VAD: TagCategory.FEATURES,
-    ModelTag.DIARIZATION: TagCategory.FEATURES,
-    ModelTag.TRANSLATION: TagCategory.FEATURES,
-    ModelTag.CODE_SWITCHING: TagCategory.FEATURES,
-    ModelTag.KEYTERM_BIASING: TagCategory.FEATURES,
-    ModelTag.VOICE_CLONING: TagCategory.FEATURES,
-    ModelTag.EMOTION_CONTROL: TagCategory.FEATURES,
-}
-
-if TAG_CATEGORIES.keys() != set(ModelTag):
-    _missing = ", ".join(sorted(set(ModelTag) - TAG_CATEGORIES.keys()))
-    raise RuntimeError(f"TAG_CATEGORIES is missing categories for: {_missing}")
 
 
 # Display label per category.
@@ -92,16 +57,11 @@ _VALUE_LABELS: dict[str, str] = {
     "shared-inference": "Shared inference",
     "dedicated-inference": "Dedicated inference",
     "official-api": "Official API",
-    ModelTag.VAD.value: "VAD",
-    ModelTag.CODE_SWITCHING.value: "Code switching",
-    ModelTag.KEYTERM_BIASING.value: "Keyterm biasing",
-    ModelTag.VOICE_CLONING.value: "Voice cloning",
-    ModelTag.EMOTION_CONTROL.value: "Emotion control",
 }
 
 
 def tag_value_label(category: TagCategory, value: str) -> str:
-    """Display label for a tag value. Provider-valued categories keep the raw id."""
+    """Display label for a derived facet value. Provider-valued categories keep the raw id."""
     if category in PROVIDER_VALUED_CATEGORIES:
         return value
     if category is TagCategory.TYPE:

--- a/runner/tests/api/conftest.py
+++ b/runner/tests/api/conftest.py
@@ -47,11 +47,7 @@ from pytest_postgresql import factories
 from coval_bench.api.app import create_app
 from coval_bench.arena.moderation import ModerationResult
 from coval_bench.config import Settings
-from coval_bench.registries import (
-    TAG_CATEGORIES,
-    RegisteredModel,
-    tag_value_label,
-)
+from coval_bench.registries import RegisteredModel
 from coval_bench.registries.provider_keys import PROVIDER_ENV
 from tests.roster import TEST_ROSTER
 
@@ -316,7 +312,7 @@ def _load_schema(**connect_kwargs: Any) -> None:
         conn.execute("""
             CREATE TABLE IF NOT EXISTS benchmarks_v2.tags (
                 value    text PRIMARY KEY CHECK (value <> ''),
-                category text NOT NULL CHECK (category IN ('mode','features')),
+                category text NOT NULL CHECK (category = 'features'),
                 label    text NOT NULL CHECK (label <> '')
             )
         """)
@@ -369,6 +365,18 @@ def _load_schema(**connect_kwargs: Any) -> None:
         """)
 
 
+TAG_VOCABULARY: tuple[tuple[str, str], ...] = (
+    ("multilingual", "Multilingual"),
+    ("vad", "VAD"),
+    ("diarization", "Diarization"),
+    ("translation", "Translation"),
+    ("code-switching", "Code switching"),
+    ("keyterm-biasing", "Keyterm biasing"),
+    ("voice-cloning", "Voice cloning"),
+    ("emotion-control", "Emotion control"),
+)
+
+
 def _seed_registry(**connect_kwargs: Any) -> None:
     """Fill the registry tables from the code registry, as the seed migration does.
 
@@ -376,11 +384,11 @@ def _seed_registry(**connect_kwargs: Any) -> None:
     needs them populated. Loaded into the template database once.
     """
     with psycopg.connect(**connect_kwargs) as conn:
-        for tag, category in TAG_CATEGORIES.items():
+        for value, label in TAG_VOCABULARY:
             conn.execute(
                 "INSERT INTO benchmarks_v2.tags (value, category, label) VALUES (%s, %s, %s)"
                 " ON CONFLICT DO NOTHING",
-                (str(tag), category.value, tag_value_label(category, str(tag))),
+                (value, "features", label),
             )
         _insert_models(conn, TEST_ROSTER)
         _insert_rates(conn, SEED_RATES)

--- a/runner/tests/api/test_admin_models.py
+++ b/runner/tests/api/test_admin_models.py
@@ -209,6 +209,33 @@ async def test_the_tag_vocabulary_is_public(client: AsyncClient, postgresql: Any
     }
 
 
+async def test_a_tag_added_through_the_api_reaches_the_catalogue(
+    client: AsyncClient, postgresql: Any
+) -> None:
+    """A tag no Python file names still reaches the catalogue, labelled by its row."""
+    response = await client.post(
+        "/v1/tags",
+        json={"value": "turbo-mode", "category": "features", "label": "Turbo mode"},
+        headers=_admin_headers(),
+    )
+    assert response.status_code == 201
+    await _seed_tag(postgresql, "keyterm-biasing", "features")
+    await _seed_model(
+        postgresql,
+        provider="acme",
+        model="stt-tagged",
+        published=True,
+        tags=("turbo-mode", "keyterm-biasing"),
+    )
+
+    entry = next(
+        e for e in (await client.get("/v1/providers")).json()["stt"] if e["provider"] == "acme"
+    )
+    tags = {(t["category"], t["value"]): t["label"] for t in entry["models"][0]["tags"]}
+    assert tags[("features", "turbo-mode")] == "Turbo mode"
+    assert tags[("features", "keyterm-biasing")] == "Keyterm-biasing"
+
+
 def _create_body(**overrides: Any) -> dict[str, Any]:
     body: dict[str, Any] = {"modality": "STT", "provider": "acme", "model": "stt-new"}
     body.update(overrides)

--- a/runner/tests/api/test_providers.py
+++ b/runner/tests/api/test_providers.py
@@ -15,7 +15,7 @@ import pytest
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
 
-from coval_bench.registries import Benchmark, Licensing, ModelTag, RegisteredModel, Source
+from coval_bench.registries import Benchmark, Licensing, RegisteredModel, Source
 from tests.api.conftest import COVAL_ORG, add_models, bearer
 
 
@@ -196,7 +196,7 @@ async def test_feature_tags_and_on_prem_surface_as_facets(
             Benchmark.STT,
             "acme",
             "m",
-            tags=(ModelTag.DIARIZATION, ModelTag.TRANSLATION),
+            tags=("diarization", "translation"),
             on_prem=True,
         ),
     )

--- a/runner/tests/unit/test_pricing_store.py
+++ b/runner/tests/unit/test_pricing_store.py
@@ -87,12 +87,12 @@ def test_the_migration_seeds_valid_rates_on_registered_models(
     _run(pricing_pg, scenario)
 
 
-def _downgrade_one(conn: psycopg.Connection[Any]) -> None:
+def _downgrade_past_pricing(conn: psycopg.Connection[Any]) -> None:
     cfg = AlembicConfig(str(_INI_PATH))
     cfg.set_main_option(
         "sqlalchemy.url", async_dsn(conn).replace("postgresql://", "postgresql+psycopg://")
     )
-    alembic_command.downgrade(cfg, "-1")
+    alembic_command.downgrade(cfg, "20260902_0026")
 
 
 def test_downgrade_drops_only_a_log_that_holds_nothing_beyond_the_seed(
@@ -103,11 +103,11 @@ def test_downgrade_drops_only_a_log_that_holds_nothing_beyond_the_seed(
 
     _run(pricing_pg, scenario)
     with pytest.raises(RuntimeError, match="refusing to drop"):
-        _downgrade_one(pricing_pg)
+        _downgrade_past_pricing(pricing_pg)
     with pricing_pg.cursor() as cur:
         cur.execute("DELETE FROM benchmarks_v2.pricing_rates WHERE price_usd = 0.0061")
         pricing_pg.commit()
-    _downgrade_one(pricing_pg)
+    _downgrade_past_pricing(pricing_pg)
     with pricing_pg.cursor() as cur:
         cur.execute("SELECT to_regclass('benchmarks_v2.pricing_rates')")
         assert cur.fetchone() == (None,)

--- a/runner/tests/unit/test_provider_config.py
+++ b/runner/tests/unit/test_provider_config.py
@@ -1,6 +1,6 @@
 # Copyright 2026 The Coval Benchmarks Authors
 # SPDX-License-Identifier: Apache-2.0
-"""Unit tests for the model and tag types and the provider name map."""
+"""Unit tests for the model types and the provider name map."""
 
 from __future__ import annotations
 
@@ -9,18 +9,12 @@ import tomllib
 from pathlib import Path
 
 from coval_bench.registries import (
-    TAG_CATEGORIES,
     Benchmark,
     Licensing,
-    ModelTag,
     RegisteredModel,
     Source,
 )
 from coval_bench.registries.provider_keys import provider_names
-
-
-def test_every_tag_has_a_category() -> None:
-    assert TAG_CATEGORIES.keys() == set(ModelTag)
 
 
 def test_registered_model_defaults() -> None:


### PR DESCRIPTION
The tags table held the vocabulary but the API resolved a model's tags through the ModelTag enum, so a tag added by an admin was dropped before it reached /v1/providers. The table is now the only source: tag values are plain strings, and their category and label come from the row.

Narrow the tags.category check to 'features'. The second curated category the constraint allowed was never built.