### PR TITLE
Persist WER error and reference-word counts

### DIFF
--- a/runner/src/coval_bench/db/models.py
+++ b/runner/src/coval_bench/db/models.py
@@ -361,6 +361,12 @@ class Result(BaseModel):
     wer_insertions_pct: float | None = None
     wer_deletions_pct: float | None = None
     wer_substitutions_pct: float | None = None
+    # WER only: alignment counts behind the split. Not a legacy column; they ride
+    # the row to the normalized store so pooled WER can be aggregated.
+    wer_substitutions: int | None = None
+    wer_deletions: int | None = None
+    wer_insertions: int | None = None
+    wer_reference_words: int | None = None
     # The configuration arm that produced this row. `pinned` marks components Coval
     # chose for comparability; a vendor-submitted or otherwise-configured arm carries
     # its own id. Orchestration platforms are variants of S2S, not their own benchmark.

--- a/runner/src/coval_bench/metrics/wer.py
+++ b/runner/src/coval_bench/metrics/wer.py
@@ -44,7 +44,21 @@ class WERResult(BaseModel):
     incorrect_words: list[WordError]
     normalized_reference: str
     normalized_hypothesis: str
+    substitutions: int
+    deletions: int
+    insertions: int
+    reference_words: int
     norm_version: Literal["2"] = NORM_VERSION
+
+    @property
+    def error_counts(self) -> dict[str, int]:
+        """Raw alignment counts; pooled WER is sum(errors) / sum(reference_words)."""
+        return {
+            "wer_substitutions": self.substitutions,
+            "wer_deletions": self.deletions,
+            "wer_insertions": self.insertions,
+            "wer_reference_words": self.reference_words,
+        }
 
     @property
     def error_percentages(self) -> dict[str, float]:
@@ -175,6 +189,10 @@ def compute_wer(
             incorrect_words=[],
             normalized_reference=norm_ref,
             normalized_hypothesis=norm_hyp,
+            substitutions=0,
+            deletions=0,
+            insertions=0,
+            reference_words=0,
         )
 
     # Empty reference with non-empty hypothesis: jiwer would return inf.
@@ -190,10 +208,15 @@ def compute_wer(
             incorrect_words=errors,
             normalized_reference=norm_ref,
             normalized_hypothesis=norm_hyp,
+            substitutions=0,
+            deletions=0,
+            insertions=ins_count,
+            reference_words=0,
         )
 
     # Use jiwer for the WER ratio (fast, correctness-tested Levenshtein)
-    raw_wer: float = jiwer.wer(norm_ref, norm_hyp)
+    aligned = jiwer.process_words(norm_ref, norm_hyp)
+    raw_wer: float = aligned.wer
 
     incorrect = _build_word_errors(ref_words, hyp_words)
 
@@ -203,4 +226,8 @@ def compute_wer(
         incorrect_words=incorrect,
         normalized_reference=norm_ref,
         normalized_hypothesis=norm_hyp,
+        substitutions=aligned.substitutions,
+        deletions=aligned.deletions,
+        insertions=aligned.insertions,
+        reference_words=len(ref_words),
     )

--- a/runner/src/coval_bench/registries/metrics.py
+++ b/runner/src/coval_bench/registries/metrics.py
@@ -199,8 +199,15 @@ METRIC_VALUE_CONTRACTS[(Metric.WER, "v1")] = MetricValueContract(
         MetricValueDefinition(key="insertions", unit="percent", minimum=0.0),
         MetricValueDefinition(key="deletions", unit="percent", minimum=0.0),
         MetricValueDefinition(key="substitutions", unit="percent", minimum=0.0),
+        MetricValueDefinition(key="substitution_count", unit="count", minimum=0.0, required=False),
+        MetricValueDefinition(key="deletion_count", unit="count", minimum=0.0, required=False),
+        MetricValueDefinition(key="insertion_count", unit="count", minimum=0.0, required=False),
+        MetricValueDefinition(key="reference_words", unit="count", minimum=0.0, required=False),
     ),
     component_sum_tolerance=0.0001,
+    optional_all_or_none=(
+        frozenset({"substitution_count", "deletion_count", "insertion_count", "reference_words"}),
+    ),
 )
 METRIC_VALUE_CONTRACTS[(Metric.TTFA, "v1")] = MetricValueContract(
     metric=Metric.TTFA,
@@ -273,7 +280,14 @@ def validate_metric_values(
             missing = ", ".join(sorted(optional_group - present))
             raise ValueError(f"optional metric value group is incomplete; missing: {missing}")
     if contract.component_sum_tolerance is not None:
-        components = [value for key, value in by_key.items() if key != "primary"]
+        primary_unit = next(
+            d.unit for d in contract.values if d.value_role is MetricValueRole.PRIMARY
+        )
+        components = [
+            value
+            for key, value in by_key.items()
+            if key != "primary" and definitions[key].unit == primary_unit
+        ]
         if (
             components
             and abs(sum(components) - by_key["primary"]) > contract.component_sum_tolerance

--- a/runner/src/coval_bench/runner/normalized.py
+++ b/runner/src/coval_bench/runner/normalized.py
@@ -86,6 +86,19 @@ def _values(
             for key, value in components
             if value is not None
         )
+        counts = (
+            ("substitution_count", primary.wer_substitutions),
+            ("deletion_count", primary.wer_deletions),
+            ("insertion_count", primary.wer_insertions),
+            ("reference_words", primary.wer_reference_words),
+        )
+        if all(count is not None for _, count in counts):
+            values.extend(
+                MetricValue(
+                    metric_evaluation_id=evaluation_id, value_key=key, unit="count", value=count
+                )
+                for key, count in counts
+            )
     if metric == Metric.TTFA:
         component_rows = {str(row.metric_type): row for row in rows}
         roundtrip = component_rows.get(str(Metric.TTFA_ROUNDTRIP))

--- a/runner/src/coval_bench/runner/orchestrator.py
+++ b/runner/src/coval_bench/runner/orchestrator.py
@@ -668,6 +668,7 @@ async def _run_stt_item(
                         status=ResultStatus.SUCCESS,
                         error=None,
                         **wer_result.error_percentages,
+                        **wer_result.error_counts,
                     )
                 )
                 logger.debug(
@@ -968,6 +969,7 @@ async def _run_tts_item(
                                 status=ResultStatus.SUCCESS,
                                 error=None,
                                 **wer_result.error_percentages,
+                                **wer_result.error_counts,
                             )
                         )
                         logger.debug(

--- a/runner/tests/unit/test_normalized_db_writer.py
+++ b/runner/tests/unit/test_normalized_db_writer.py
@@ -1381,6 +1381,32 @@ def test_metric_value_contracts_cover_wer_and_optional_ttfa_components() -> None
         ),
     )
     validate_metric_values(
+        Metric.WER,
+        "v1",
+        (
+            ("primary", "percent", 3, MetricValueRole.PRIMARY),
+            ("insertions", "percent", 1, MetricValueRole.COMPONENT),
+            ("deletions", "percent", 1, MetricValueRole.COMPONENT),
+            ("substitutions", "percent", 1, MetricValueRole.COMPONENT),
+            ("substitution_count", "count", 1, MetricValueRole.COMPONENT),
+            ("deletion_count", "count", 1, MetricValueRole.COMPONENT),
+            ("insertion_count", "count", 1, MetricValueRole.COMPONENT),
+            ("reference_words", "count", 100, MetricValueRole.COMPONENT),
+        ),
+    )
+    with pytest.raises(ValueError, match="optional metric value group"):
+        validate_metric_values(
+            Metric.WER,
+            "v1",
+            (
+                ("primary", "percent", 3, MetricValueRole.PRIMARY),
+                ("insertions", "percent", 1, MetricValueRole.COMPONENT),
+                ("deletions", "percent", 1, MetricValueRole.COMPONENT),
+                ("substitutions", "percent", 1, MetricValueRole.COMPONENT),
+                ("reference_words", "count", 100, MetricValueRole.COMPONENT),
+            ),
+        )
+    validate_metric_values(
         Metric.TTFA, "v1", (("primary", "milliseconds", 12, MetricValueRole.PRIMARY),)
     )
     validate_metric_values(

--- a/runner/tests/unit/test_normalized_dual_write.py
+++ b/runner/tests/unit/test_normalized_dual_write.py
@@ -203,6 +203,10 @@ async def test_stt_groups_wer_and_freezes_transcript_and_timing_lineage() -> Non
             wer_insertions_pct=2,
             wer_deletions_pct=3,
             wer_substitutions_pct=5,
+            wer_substitutions=5,
+            wer_deletions=3,
+            wer_insertions=2,
+            wer_reference_words=100,
         ),
     ]
 
@@ -236,6 +240,10 @@ async def test_stt_groups_wer_and_freezes_transcript_and_timing_lineage() -> Non
         "insertions",
         "deletions",
         "substitutions",
+        "substitution_count",
+        "deletion_count",
+        "insertion_count",
+        "reference_words",
     ]
     assert writer.inputs[wer_id] == [
         MetricEvaluationInput(

--- a/runner/tests/unit/test_wer.py
+++ b/runner/tests/unit/test_wer.py
@@ -197,6 +197,41 @@ def test_error_percentages_sum_to_wer(
 
 
 # ---------------------------------------------------------------------------
+# alignment counts
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(("case_id", "ref", "hyp", "expected_wer", "note"), _GOLDEN)
+def test_counts_reproduce_wer(
+    case_id: int, ref: str, hyp: str, expected_wer: float, note: str
+) -> None:
+    result = compute_wer(ref, hyp)
+    errors = result.substitutions + result.deletions + result.insertions
+    assert result.reference_words == len(result.normalized_reference.split())
+    if result.reference_words:
+        assert errors / result.reference_words == pytest.approx(result.wer)
+    else:
+        assert result.wer == float(errors)
+
+
+def test_counts_by_type() -> None:
+    result = compute_wer("a b c d", "a x c d e")
+    assert (result.substitutions, result.deletions, result.insertions) == (1, 0, 1)
+    assert result.error_counts == {
+        "wer_substitutions": 1,
+        "wer_deletions": 0,
+        "wer_insertions": 1,
+        "wer_reference_words": 4,
+    }
+
+
+def test_counts_empty_reference() -> None:
+    result = compute_wer("", "hello there")
+    assert result.reference_words == 0
+    assert result.insertions == 2
+
+
+# ---------------------------------------------------------------------------
 # WordError model
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Pooled WER needs per-clip error counts and reference word counts, and the store only carried the ratio and its percentage-point split. compute_wer now returns jiwer's substitution, deletion, and insertion counts plus the reference word count, the Result row carries them in memory, and the normalized writer emits them as an optional all-or-none group of count-unit components on the v1 WER contract. The component-sum check is scoped to components sharing the primary's unit so the percent split still reconciles.

Stays on v1 rather than minting v2 because aggregates, the readiness script, and the series SQL hardcode metric_version = 'v1'; a flip would blank WER on the dashboard until BENCH-844 lands.