### PR TITLE
[BENCH-846] Make pooled WER the headline with a mean fallback

### DIFF
--- a/docs/methodology.md
+++ b/docs/methodology.md
@@ -49,7 +49,7 @@ retired manifests (`stt-v2.json`) stay for historical reproducibility.
 **Aggregation across datasets.** Each dataset runs as its own run (one
 `DATASET_ID` per execution), and a result's dataset is derived from its parent
 run. The aggregation layer pools every result in the window regardless of
-dataset, so headline stats (e.g. average WER) blend all datasets that ran.
+dataset, so headline stats (e.g. pooled WER) blend all datasets that ran.
 `/v1/results` exposes each row's `dataset_id` and takes a `dataset` filter for
 per-dataset inspection. See ADR-023.
 
@@ -103,6 +103,27 @@ with `EnglishTextNormalizer` per [ADR-021](#adr-references). WER values
 before and after the change are **not comparable**. Because result rows do not
 carry a normalization-version marker, historical rows cannot be reliably
 segmented by normalization pipeline version.
+
+### Aggregation
+
+The headline WER for a model is corpus-level: the sum of substitutions,
+deletions, and insertions across every clip in the window, divided by the sum
+of reference words. Each per-clip row carries those four counts, so the figure
+is exact rather than an average of ratios. The per-clip distribution (median,
+percentiles, spread) is still reported from the per-clip ratios.
+
+The two disagree by design. Reference clips run from 4 to 41 words, so a mean
+of per-clip ratios lets one miss on a 4-word clip weigh the same as a perfect
+41-word clip, and the empty-reference convention above turns a clip with no
+reference into a raw insertion count. Pooling weights every word equally and
+absorbs both.
+
+**Methodology change (2026-09).** WER was previously the mean of per-clip
+ratios. Counts are recorded from this point forward and were not backfilled,
+so a window reports the pooled figure only once every clip in it carries
+counts; until then it falls back to the mean and says so (`pooled_value` is
+null, `mean_value` is always present). Headline numbers before and after are
+**not comparable**. See [ADR-024](#adr-references).
 
 ## 4. Latency metrics (TTFA)
 
@@ -255,6 +276,10 @@ exact source reproduction for those rows is unsupported.
 - ADR-023 — Multi-dataset benchmarking: one run per dataset, dataset identity
   derived from the parent run (no dataset column on `results`); headline
   aggregates pool across datasets.
+- ADR-024 — Corpus-level WER as the headline: per-clip S/I/D and reference-word
+  counts persisted as WER components; aggregates report sum(errors) /
+  sum(reference words), falling back to the per-clip mean until a window is
+  fully counted; no backfill.
 
 ADR rationale is referenced inline in the relevant source files and READMEs
 where the decision context is load-bearing.

--- a/runner/src/coval_bench/api/common.py
+++ b/runner/src/coval_bench/api/common.py
@@ -14,6 +14,14 @@ from typing import Literal
 BenchmarkLiteral = Literal["STT", "TTS", "S2S", "LLM"]
 WindowLiteral = Literal["24h", "7d", "30d"]
 
+# LLM results have no normalized writer yet, so its reads stay on legacy storage.
+NORMALIZED_BENCHMARKS: frozenset[str] = frozenset({"STT", "TTS", "S2S"})
+
+
+def reads_normalized(enabled: bool, benchmark: str) -> bool:
+    return enabled and benchmark in NORMALIZED_BENCHMARKS
+
+
 # Fixed interval strings — looked up by Python, never user-interpolated into
 # SQL. Used by live queries (the aggregates series block).
 WINDOW_INTERVALS: dict[str, str] = {

--- a/runner/src/coval_bench/api/routers/aggregates.py
+++ b/runner/src/coval_bench/api/routers/aggregates.py
@@ -43,6 +43,7 @@ from coval_bench.api.common import (
     BenchmarkLiteral,
     WindowLiteral,
     has_enough_samples,
+    reads_normalized,
 )
 from coval_bench.api.deps import (
     capture_api_event,
@@ -122,7 +123,8 @@ _COMPACT_SERIES_TAIL = (
     " ORDER BY value DESC, scheduled_at ASC) AS max_rank"
     " FROM binned"
     ") SELECT provider, model, metric_type, scheduled_at, min_value, p25, p50, p75,"
-    " max_value, value_sum, sample_count, value, pooled_value FROM selected"
+    " max_value, value_sum, sample_count, value, error_sum, reference_word_sum, pooled_value"
+    " FROM selected"
     " WHERE min_rank = 1 OR max_rank = 1 OR ordinal = 1 OR ordinal = group_count"
     " ORDER BY scheduled_at, provider, model, metric_type"
 )
@@ -133,7 +135,7 @@ _COMPACT_SERIES_SQL = (
     " min_value, p25, p50, p75, max_value, value_sum, sample_count,"
     " CASE WHEN metric_type = 'WER'"
     " THEN value_sum / NULLIF(sample_count, 0) ELSE p50 END AS value,"
-    " NULL::float8 AS pooled_value"
+    " NULL::float8 AS error_sum, NULL::float8 AS reference_word_sum, NULL::float8 AS pooled_value"
     " FROM benchmarks_v2.results_by_bucket"
     " WHERE benchmark = %(benchmark)s AND dataset_id = %(dataset)s"
     " AND bucket_at >= NOW() - %(interval)s::interval" + _COMPACT_SERIES_TAIL
@@ -377,7 +379,7 @@ async def get_results_aggregates(
     dataset_key = dataset or DATASET_ALL
 
     async def fill() -> AggregatesResponse:
-        normalized = settings.normalized_dashboard_reads_enabled
+        normalized = reads_normalized(settings.normalized_dashboard_reads_enabled, benchmark)
         stats_sql = (
             _NORMALIZED_STATS_SQL
             if normalized
@@ -495,7 +497,7 @@ async def get_results_timeline(
     async def fill() -> TimelineResponse:
         sql = (
             (_NORMALIZED_COMPACT_SERIES_SQL if window == "30d" else _NORMALIZED_TIMELINE_SQL)
-            if settings.normalized_dashboard_reads_enabled
+            if reads_normalized(settings.normalized_dashboard_reads_enabled, benchmark)
             else (_COMPACT_SERIES_SQL if window == "30d" else _TIMELINE_SQL)
         )
         params = {
@@ -573,7 +575,7 @@ async def get_results_aggregates_by_dataset(
     """
 
     async def fill() -> AggregatesByDatasetResponse:
-        normalized = settings.normalized_dashboard_reads_enabled
+        normalized = reads_normalized(settings.normalized_dashboard_reads_enabled, benchmark)
         stats_sql = (
             _NORMALIZED_STATS_BY_DATASET_SQL
             if normalized

--- a/runner/src/coval_bench/api/routers/aggregates.py
+++ b/runner/src/coval_bench/api/routers/aggregates.py
@@ -105,8 +105,7 @@ _TIMELINE_SQL = (
 # Select a bounded, representative 30-day timeline in PostgreSQL.  Each exact
 # provider/model/metric group is split into 119 ordinal bins; retaining the min
 # and max plotted value in every bin plus the endpoints caps the result at 240
-# points per group (480 when pooled WER extrema are kept too) while preserving
-# endpoints and plotted extrema.  All tie
+# points per group while preserving endpoints and plotted extrema.  All tie
 # breaks include bucket_at so identical requests have identical ordering.
 _COMPACT_SERIES_TAIL = (
     "), ranked AS ("
@@ -120,16 +119,11 @@ _COMPACT_SERIES_TAIL = (
     " SELECT *, row_number() OVER (PARTITION BY provider, model, metric_type, bin"
     " ORDER BY value ASC, scheduled_at ASC) AS min_rank,"
     " row_number() OVER (PARTITION BY provider, model, metric_type, bin"
-    " ORDER BY value DESC, scheduled_at ASC) AS max_rank,"
-    " row_number() OVER (PARTITION BY provider, model, metric_type, bin"
-    " ORDER BY pooled_value ASC NULLS LAST, scheduled_at ASC) AS pooled_min_rank,"
-    " row_number() OVER (PARTITION BY provider, model, metric_type, bin"
-    " ORDER BY pooled_value DESC NULLS LAST, scheduled_at ASC) AS pooled_max_rank"
+    " ORDER BY value DESC, scheduled_at ASC) AS max_rank"
     " FROM binned"
     ") SELECT provider, model, metric_type, scheduled_at, min_value, p25, p50, p75,"
     " max_value, value_sum, sample_count, value, pooled_value FROM selected"
     " WHERE min_rank = 1 OR max_rank = 1 OR ordinal = 1 OR ordinal = group_count"
-    " OR (pooled_value IS NOT NULL AND (pooled_min_rank = 1 OR pooled_max_rank = 1))"
     " ORDER BY scheduled_at, provider, model, metric_type"
 )
 
@@ -170,7 +164,20 @@ _WER_COUNTS_COMPLETE = (
     "COUNT(reference_words) = COUNT(*) AND COUNT(substitution_count) = COUNT(*)"
     " AND COUNT(deletion_count) = COUNT(*) AND COUNT(insertion_count) = COUNT(*)"
 )
-_POOLED = "100 * SUM({key}) / NULLIF(SUM(reference_words), 0)"
+
+
+def _pooled(counts: str) -> str:
+    return (
+        f"CASE WHEN {_WER_COUNTS_COMPLETE}"
+        f" THEN (100 * SUM({counts}) / NULLIF(SUM(reference_words), 0))::float8 END"
+    )
+
+
+def _mean_split(column: str) -> str:
+    return f"CASE WHEN {_WER_SPLIT_COMPLETE} THEN AVG({column})::float8 END"
+
+
+_POOLED_TOTAL = _pooled("substitution_count + deletion_count + insertion_count")
 
 # TTFA components have public metric names of their own, hence the UNION ALL.
 _NORMALIZED_STATS_SQL = f"""
@@ -209,7 +216,8 @@ WITH evaluations AS (
         NULL, NULL, NULL, NULL, NULL, NULL, NULL
  FROM evaluations WHERE metric_type = 'TTFA' AND leading_silence IS NOT NULL
 )
-SELECT provider, model, metric_type, AVG(value)::float8 AS avg_value,
+SELECT provider, model, metric_type, AVG(value)::float8 AS mean_value,
+ COALESCE({_POOLED_TOTAL}, AVG(value))::float8 AS avg_value,
  COALESCE(STDDEV_SAMP(value), 0)::float8 AS stddev_value,
  PERCENTILE_CONT(.25) WITHIN GROUP (ORDER BY value)::float8 AS p25,
  PERCENTILE_CONT(.5) WITHIN GROUP (ORDER BY value)::float8 AS p50,
@@ -218,19 +226,14 @@ SELECT provider, model, metric_type, AVG(value)::float8 AS avg_value,
  PERCENTILE_CONT(.95) WITHIN GROUP (ORDER BY value)::float8 AS p95,
  PERCENTILE_CONT(.99) WITHIN GROUP (ORDER BY value)::float8 AS p99,
  MIN(value)::float8 AS min_value, MAX(value)::float8 AS max_value, COUNT(*)::int AS sample_count,
- CASE WHEN {_WER_SPLIT_COMPLETE} THEN AVG(wer_insertions_pct)::float8 END AS wer_insertions_pct,
- CASE WHEN {_WER_SPLIT_COMPLETE} THEN AVG(wer_deletions_pct)::float8 END AS wer_deletions_pct,
- CASE WHEN {_WER_SPLIT_COMPLETE}
-      THEN AVG(wer_substitutions_pct)::float8 END AS wer_substitutions_pct,
- CASE WHEN {_WER_COUNTS_COMPLETE}
-      THEN ({_POOLED.format(key="substitution_count + deletion_count + insertion_count")})::float8
-      END AS pooled_value,
- CASE WHEN {_WER_COUNTS_COMPLETE}
-      THEN ({_POOLED.format(key="insertion_count")})::float8 END AS pooled_insertions_pct,
- CASE WHEN {_WER_COUNTS_COMPLETE}
-      THEN ({_POOLED.format(key="deletion_count")})::float8 END AS pooled_deletions_pct,
- CASE WHEN {_WER_COUNTS_COMPLETE}
-      THEN ({_POOLED.format(key="substitution_count")})::float8 END AS pooled_substitutions_pct
+ COALESCE({_pooled("insertion_count")}, {_mean_split("wer_insertions_pct")}) AS wer_insertions_pct,
+ COALESCE({_pooled("deletion_count")}, {_mean_split("wer_deletions_pct")}) AS wer_deletions_pct,
+ COALESCE({_pooled("substitution_count")}, {_mean_split("wer_substitutions_pct")})
+   AS wer_substitutions_pct,
+ {_POOLED_TOTAL} AS pooled_value,
+ {_pooled("insertion_count")} AS pooled_insertions_pct,
+ {_pooled("deletion_count")} AS pooled_deletions_pct,
+ {_pooled("substitution_count")} AS pooled_substitutions_pct
 FROM public_values
  WHERE (%(dataset)s = '__all__' OR dataset_id = %(dataset)s)
 GROUP BY provider, model, metric_type ORDER BY provider, model, metric_type
@@ -258,13 +261,20 @@ _NORMALIZED_STATS_BY_DATASET_SQL = (
         "ORDER BY dataset_id, provider, model, metric_type",
     )
     .replace(
-        "SELECT provider, model, metric_type, AVG(value)",
-        "SELECT dataset_id, provider, model, metric_type, AVG(value)",
+        "SELECT provider, model, metric_type, AVG(value)::float8 AS mean_value",
+        "SELECT dataset_id, provider, model, metric_type, AVG(value)::float8 AS mean_value",
     )
 )
 
 # Pooled WER needs all four count rows covering the same clips as the primary row.
-_NORMALIZED_BUCKETS_SQL = """
+_BUCKET_COUNTS_COMPLETE = "COUNT(*) = 5 AND MIN(sample_count) = MAX(sample_count)"
+_BUCKET_ERROR_SUM = (
+    "SUM(value_sum) FILTER (WHERE value_key IN"
+    " ('substitution_count', 'deletion_count', 'insertion_count'))"
+)
+_BUCKET_REFERENCE_SUM = "SUM(value_sum) FILTER (WHERE value_key = 'reference_words')"
+
+_NORMALIZED_BUCKETS_SQL = f"""
 SELECT provider, model, metric_type, bucket_at AS scheduled_at,
  MAX(min_value) FILTER (WHERE value_key = 'primary') AS min_value,
  MAX(p25) FILTER (WHERE value_key = 'primary') AS p25,
@@ -273,11 +283,10 @@ SELECT provider, model, metric_type, bucket_at AS scheduled_at,
  MAX(max_value) FILTER (WHERE value_key = 'primary') AS max_value,
  MAX(value_sum) FILTER (WHERE value_key = 'primary') AS value_sum,
  MAX(sample_count) FILTER (WHERE value_key = 'primary') AS sample_count,
- CASE WHEN COUNT(*) = 5 AND MIN(sample_count) = MAX(sample_count)
-      THEN 100 * SUM(value_sum) FILTER (WHERE value_key IN
-             ('substitution_count', 'deletion_count', 'insertion_count'))
-           / NULLIF(SUM(value_sum) FILTER (WHERE value_key = 'reference_words'), 0)
-      END AS pooled_value
+ CASE WHEN {_BUCKET_COUNTS_COMPLETE} THEN {_BUCKET_ERROR_SUM} END AS error_sum,
+ CASE WHEN {_BUCKET_COUNTS_COMPLETE} THEN {_BUCKET_REFERENCE_SUM} END AS reference_word_sum,
+ CASE WHEN {_BUCKET_COUNTS_COMPLETE}
+      THEN 100 * {_BUCKET_ERROR_SUM} / NULLIF({_BUCKET_REFERENCE_SUM}, 0) END AS pooled_value
 FROM benchmarks_v2.metric_values_by_bucket
 WHERE metric_version = 'v1' AND evaluation_variant = 'default'
  AND value_key IN ('primary', 'substitution_count', 'deletion_count',
@@ -286,10 +295,11 @@ WHERE metric_version = 'v1' AND evaluation_variant = 'default'
  AND bucket_at >= NOW() - %(interval)s::interval
 GROUP BY provider, model, metric_type, bucket_at
 HAVING COUNT(*) FILTER (WHERE value_key = 'primary') = 1
-"""
+"""  # noqa: S608
 
 _BUCKET_VALUE = (
-    " CASE WHEN metric_type = 'WER' THEN value_sum / NULLIF(sample_count, 0) ELSE p50 END AS value"
+    " CASE WHEN metric_type = 'WER'"
+    " THEN COALESCE(pooled_value, value_sum / NULLIF(sample_count, 0)) ELSE p50 END AS value"
 )
 
 _NORMALIZED_SERIES_SQL = (

--- a/runner/src/coval_bench/api/routers/leaderboard.py
+++ b/runner/src/coval_bench/api/routers/leaderboard.py
@@ -34,6 +34,7 @@ from coval_bench.api.common import (
     BenchmarkLiteral,
     WindowLiteral,
     has_enough_samples,
+    reads_normalized,
 )
 from coval_bench.api.deps import capture_api_event, get_pool, get_posthog, get_settings
 from coval_bench.api.internal import hidden_early_access
@@ -119,7 +120,7 @@ async def get_leaderboard(
         "dataset": _PRIMARY_DATASET_BY_BENCHMARK.get(benchmark, DATASET_ALL),
         "interval": WINDOW_INTERVALS[window],
     }
-    normalized = settings.normalized_dashboard_reads_enabled
+    normalized = reads_normalized(settings.normalized_dashboard_reads_enabled, benchmark)
     sql = (
         _NORMALIZED_STATS_SQL if normalized else _MV_SQL_TEMPLATE.format(view=WINDOW_VIEWS[window])
     )

--- a/runner/src/coval_bench/api/routers/leaderboard.py
+++ b/runner/src/coval_bench/api/routers/leaderboard.py
@@ -13,7 +13,8 @@ Metric/benchmark compatibility:
 
 Every window queries its materialized view (``benchmarks_v2.results_24h``/
 ``results_7d``/``results_30d``), refreshed by the runner at the end of each
-benchmark run — read-only here.
+benchmark run — read-only here. With normalized reads enabled it ranks on the
+aggregates' headline value.
 """
 
 from __future__ import annotations
@@ -28,16 +29,18 @@ from psycopg_pool import AsyncConnectionPool
 from starlette.requests import Request
 
 from coval_bench.api.common import (
+    WINDOW_INTERVALS,
     WINDOW_VIEWS,
     BenchmarkLiteral,
     WindowLiteral,
     has_enough_samples,
 )
-from coval_bench.api.deps import capture_api_event, get_pool, get_posthog
+from coval_bench.api.deps import capture_api_event, get_pool, get_posthog, get_settings
 from coval_bench.api.internal import hidden_early_access
 from coval_bench.api.ratelimit import limiter
+from coval_bench.api.routers.aggregates import _NORMALIZED_STATS_SQL
 from coval_bench.api.schemas import LeaderboardEntry, LeaderboardResponse
-from coval_bench.config import DATASET_ALL
+from coval_bench.config import DATASET_ALL, Settings
 from coval_bench.registries import is_metric_excluded
 from coval_bench.s2s.conditions import DATASET_ID_DENTAL, DATASET_ID_LLM_DENTAL
 
@@ -88,6 +91,7 @@ async def get_leaderboard(
     pool: AsyncConnectionPool[Any] = Depends(get_pool),
     posthog_client: Posthog | None = Depends(get_posthog),
     hidden: frozenset[tuple[str, str]] = Depends(hidden_early_access),
+    settings: Settings = Depends(get_settings),
 ) -> LeaderboardResponse:
     """Return leaderboard entries sorted ascending by average metric value.
 
@@ -113,13 +117,26 @@ async def get_leaderboard(
         "metric": metric,
         "benchmark": benchmark,
         "dataset": _PRIMARY_DATASET_BY_BENCHMARK.get(benchmark, DATASET_ALL),
+        "interval": WINDOW_INTERVALS[window],
     }
-    sql = _MV_SQL_TEMPLATE.format(view=WINDOW_VIEWS[window])
+    normalized = settings.normalized_dashboard_reads_enabled
+    sql = (
+        _NORMALIZED_STATS_SQL if normalized else _MV_SQL_TEMPLATE.format(view=WINDOW_VIEWS[window])
+    )
 
     async with pool.connection() as conn:
         conn.row_factory = psycopg.rows.dict_row
         rows = await conn.execute(sql, params)
         entry_rows = await rows.fetchall()
+    if normalized:
+        entry_rows = sorted(
+            (
+                {**r, "avg": r["avg_value"], "n": r["sample_count"]}
+                for r in entry_rows
+                if r["metric_type"] == metric
+            ),
+            key=lambda r: r["avg"],
+        )
 
     entries = [
         LeaderboardEntry.model_validate(r)

--- a/runner/src/coval_bench/api/schemas.py
+++ b/runner/src/coval_bench/api/schemas.py
@@ -175,7 +175,9 @@ class ModelStatEntry(BaseModel):
     provider: str
     model: str
     metric_type: str
+    # WER: corpus-level (pooled) when every clip carries counts, else the per-clip mean.
     avg_value: float
+    mean_value: float | None = None
     stddev_value: float
     p25: float
     p50: float
@@ -206,7 +208,8 @@ class ModelStatEntry(BaseModel):
 class SeriesPoint(BaseModel):
     """Per-(provider, model, metric_type) distribution for one scheduled_at bucket.
 
-    Latency timelines render p50; WER renders value_sum / sample_count.
+    Latency timelines render p50. WER renders error_sum / reference_word_sum when
+    present, else value_sum / sample_count; both pairs sum across buckets.
     """
 
     provider: str
@@ -220,6 +223,8 @@ class SeriesPoint(BaseModel):
     max_value: float
     value_sum: float
     sample_count: int
+    error_sum: float | None = None
+    reference_word_sum: float | None = None
     pooled_value: float | None = None
 
 

--- a/runner/tests/api/test_aggregates.py
+++ b/runner/tests/api/test_aggregates.py
@@ -496,19 +496,18 @@ async def test_normalized_pooled_wer_is_a_ratio_of_sums(
     app.state.settings.normalized_dashboard_reads_enabled = True
     s = (await client.get("/v1/results/aggregates", params={"benchmark": "STT"})).json()
     s = s["model_stats"][0]
-    assert s["avg_value"] == pytest.approx(12.5)
-    assert s["pooled_value"] == pytest.approx(2.5)
-    assert s["pooled_substitutions_pct"] == pytest.approx(2.5)
-    assert s["pooled_deletions_pct"] == 0.0
-    assert s["pooled_insertions_pct"] == 0.0
+    keys = ("mean_value", "avg_value", "pooled_value", "wer_substitutions_pct")
+    assert [s[k] for k in keys] == pytest.approx([12.5, 2.5, 2.5, 2.5])
+    assert (s["pooled_deletions_pct"], s["pooled_insertions_pct"]) == (0, 0)
+    board = await client.get("/v1/leaderboard", params={"metric": "WER", "benchmark": "STT"})
+    assert board.json()["entries"][0]["avg"] == pytest.approx(2.5)
 
     await _insert_normalized_wer(postgresql, run_id, dataset_id="stt-v2", value=6.0)
     app.state.response_cache.clear()
     s = (await client.get("/v1/results/aggregates", params={"benchmark": "STT"})).json()
     s = s["model_stats"][0]
-    assert s["sample_count"] == 3
     assert s["pooled_value"] is None
-    assert s["pooled_substitutions_pct"] is None
+    assert s["avg_value"] == pytest.approx(s["mean_value"]) == pytest.approx(31 / 3)
 
 
 async def test_normalized_bucket_pooled_wer_requires_complete_count_rows(
@@ -533,16 +532,15 @@ async def test_normalized_bucket_pooled_wer_requires_complete_count_rows(
     app.state.settings.normalized_dashboard_reads_enabled = True
 
     pooled = await client.get("/v1/results/aggregates", params={"benchmark": "STT"})
-    assert len(pooled.json()["series"]) == 1
-    assert pooled.json()["series"][0]["pooled_value"] == pytest.approx(5.0)
+    [point] = pooled.json()["series"]
+    assert (point["pooled_value"], point["error_sum"], point["reference_word_sum"]) == (5.0, 2, 40)
     timeline = await client.get("/v1/results/timeline", params={"benchmark": "STT"})
-    assert timeline.json()["points"][0]["pooled_value"] == pytest.approx(5.0)
+    assert timeline.json()["points"][0]["value"] == pytest.approx(5.0)
 
-    partial = await client.get(
-        "/v1/results/aggregates", params={"benchmark": "STT", "dataset": "stt-v2"}
+    timeline = await client.get(
+        "/v1/results/timeline", params={"benchmark": "STT", "dataset": "stt-v2"}
     )
-    assert len(partial.json()["series"]) == 1
-    assert partial.json()["series"][0]["pooled_value"] is None
+    assert timeline.json()["points"][0]["value"] == pytest.approx(3.0)
 
 
 async def test_compact_series_keeps_pooled_wer_extrema(
@@ -588,7 +586,7 @@ async def test_compact_series_keeps_pooled_wer_extrema(
     )
     points = response.json()["points"]
     assert len(points) < 360
-    assert max(p["pooled_value"] for p in points) == pytest.approx(90.0)
+    assert max(p["value"] for p in points) == pytest.approx(90.0)
 
 
 async def test_normalized_series_and_timeline_use_primary_v1_default_buckets(

--- a/runner/tests/api/test_aggregates.py
+++ b/runner/tests/api/test_aggregates.py
@@ -252,6 +252,13 @@ async def test_llm_instruction_following_is_served_by_aggregates(
     ]
     assert stats[0]["avg_value"] == pytest.approx(75.0)
 
+    app = client._transport.app  # type: ignore[attr-defined]
+    app.state.settings.normalized_dashboard_reads_enabled = True
+    response = await client.get(
+        "/v1/results/aggregates", params={"benchmark": "LLM", "dataset": "llm-dental-v1"}
+    )
+    assert response.json()["model_stats"] == stats
+
 
 async def test_single_sample_stddev_is_zero(client: AsyncClient, postgresql: Any) -> None:
     """STDDEV_SAMP is NULL for n=1 — must be coalesced to 0 like the client did."""
@@ -536,6 +543,11 @@ async def test_normalized_bucket_pooled_wer_requires_complete_count_rows(
     assert (point["pooled_value"], point["error_sum"], point["reference_word_sum"]) == (5.0, 2, 40)
     timeline = await client.get("/v1/results/timeline", params={"benchmark": "STT"})
     assert timeline.json()["points"][0]["value"] == pytest.approx(5.0)
+    compact = await client.get(
+        "/v1/results/aggregates", params={"benchmark": "STT", "window": "30d"}
+    )
+    [point] = compact.json()["series"]
+    assert (point["error_sum"], point["reference_word_sum"]) == (2, 40)
 
     timeline = await client.get(
         "/v1/results/timeline", params={"benchmark": "STT", "dataset": "stt-v2"}

--- a/runner/tests/api/test_leaderboard.py
+++ b/runner/tests/api/test_leaderboard.py
@@ -221,12 +221,16 @@ async def test_ttft_llm_uses_the_dental_primary_dataset(
     )
     await _refresh_mv(postgresql)
 
-    response = await client.get("/v1/leaderboard", params={"metric": "TTFT", "benchmark": "LLM"})
-
+    params = {"metric": "TTFT", "benchmark": "LLM"}
+    expected = [("phonely", "phonely-agent")]
+    response = await client.get("/v1/leaderboard", params=params)
     assert response.status_code == 200
-    assert [(e["provider"], e["model"]) for e in response.json()["entries"]] == [
-        ("phonely", "phonely-agent")
-    ]
+    assert [(e["provider"], e["model"]) for e in response.json()["entries"]] == expected
+
+    app = client._transport.app  # type: ignore[attr-defined]
+    app.state.settings.normalized_dashboard_reads_enabled = True
+    response = await client.get("/v1/leaderboard", params=params)
+    assert [(e["provider"], e["model"]) for e in response.json()["entries"]] == expected
 
 
 async def test_v2v_llm_incompatible(client: AsyncClient) -> None:


### PR DESCRIPTION
On the normalized path avg_value for WER is the pooled ratio when every clip in the window carries counts and the per-clip mean otherwise, with the mean always on mean_value; the S/I/D split and series value follow the same rule. Series points expose error_sum and reference_word_sum so consumers can pool across buckets. /v1/leaderboard gains a normalized path behind the reads flag and ranks on the same headline. Methodology doc gains the aggregation section, a dated not-comparable note, and ADR-024.