### PR TITLE
[BENCH-861] Generic OpenAI-compatible client for the LLM proxy

### DIFF
--- a/runner/src/coval_bench/llm/dental.py
+++ b/runner/src/coval_bench/llm/dental.py
@@ -1,0 +1,32 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""The dental agent as a prompt and tool list, for models we drive ourselves."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from functools import cache
+from typing import Any
+
+from coval_bench.contracts import read_contract_file
+
+SUITE = "dental"
+PROMPT_FILE = "_source/coval-prompt.txt"
+TOOLS_FILE = "tool-definitions.json"
+
+
+@dataclass(frozen=True)
+class DentalAgent:
+    system_prompt: str
+    tools: tuple[dict[str, Any], ...]
+
+
+@cache
+def load_dental_agent() -> DentalAgent:
+    definitions = json.loads(read_contract_file(SUITE, TOOLS_FILE))
+    return DentalAgent(
+        system_prompt=read_contract_file(SUITE, PROMPT_FILE),
+        tools=tuple({"type": "function", "function": d} for d in definitions),
+    )

--- a/runner/src/coval_bench/llm/openai_compat.py
+++ b/runner/src/coval_bench/llm/openai_compat.py
@@ -1,0 +1,210 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Streamed chat-completions turns against any OpenAI-compatible endpoint."""
+
+from __future__ import annotations
+
+import json
+import time
+import uuid
+from typing import Any
+
+import httpx
+
+from coval_bench.llm.turn import Session, TurnError, TurnResult
+
+# Turns are seconds apart; a 5s keepalive would put a TLS handshake inside most TTFTs.
+LIMITS = httpx.Limits(max_connections=20, max_keepalive_connections=8, keepalive_expiry=300.0)
+
+
+class UpstreamError(TurnError):
+    """The endpoint failed to produce a usable completion."""
+
+
+class AuthError(UpstreamError):
+    """The configured API key was rejected."""
+
+
+class TurnAccumulator:
+    """Reassemble OpenAI SSE chunks while measuring the first meaningful delta."""
+
+    def __init__(self, started_at: float) -> None:
+        self._started_at = started_at
+        self._first_token_at: float | None = None
+        self._content: list[str] = []
+        self._tool_calls: dict[int, dict[str, Any]] = {}
+        self._finish_reason: str | None = None
+        self._complete = False
+        self._output_tokens: int | None = None
+
+    def _stamp_first_token(self, now: float) -> None:
+        if self._first_token_at is None:
+            self._first_token_at = now
+
+    def feed(self, line: str, now: float) -> None:
+        """Consume one SSE line; irrelevant or malformed lines are ignored."""
+        line = line.strip()
+        if not line.startswith("data:"):
+            return
+        payload = line.removeprefix("data:").strip()
+        if not payload:
+            return
+        if payload == "[DONE]":
+            self._complete = True
+            return
+        try:
+            event = json.loads(payload)
+        except json.JSONDecodeError:
+            return
+        if not isinstance(event, dict):
+            return
+        error = event.get("error")
+        if error is not None:
+            message = error.get("message", error) if isinstance(error, dict) else error
+            raise UpstreamError(f"stream error: {message}")
+
+        usage = event.get("usage")
+        if isinstance(usage, dict):
+            output_tokens = usage.get("completion_tokens")
+            if isinstance(output_tokens, int) and not isinstance(output_tokens, bool):
+                self._output_tokens = output_tokens
+
+        choices = event.get("choices")
+        if not isinstance(choices, list) or not choices or not isinstance(choices[0], dict):
+            return
+        choice = choices[0]
+        delta = choice.get("delta")
+        if isinstance(delta, dict):
+            content = delta.get("content")
+            if isinstance(content, str) and content:
+                self._stamp_first_token(now)
+                self._content.append(content)
+            raw_tool_calls = delta.get("tool_calls")
+            if isinstance(raw_tool_calls, list) and raw_tool_calls:
+                self._stamp_first_token(now)
+                self._feed_tool_calls(raw_tool_calls)
+        finish_reason = choice.get("finish_reason")
+        if isinstance(finish_reason, str) and finish_reason:
+            self._finish_reason = finish_reason
+            self._complete = True
+
+    def _feed_tool_calls(self, chunks: list[Any]) -> None:
+        for chunk in chunks:
+            if not isinstance(chunk, dict):
+                continue
+            index = chunk.get("index", 0)
+            if not isinstance(index, int) or isinstance(index, bool):
+                index = 0
+            slot = self._tool_calls.setdefault(
+                index, {"id": "", "type": "function", "name": "", "arguments": ""}
+            )
+            call_id = chunk.get("id")
+            if isinstance(call_id, str) and call_id:
+                slot["id"] = call_id
+            call_type = chunk.get("type")
+            if isinstance(call_type, str) and call_type:
+                slot["type"] = call_type
+            function = chunk.get("function")
+            if not isinstance(function, dict):
+                continue
+            name = function.get("name")
+            if isinstance(name, str):
+                slot["name"] += name
+            arguments = function.get("arguments")
+            if isinstance(arguments, str):
+                slot["arguments"] += arguments
+
+    def result(self, now: float) -> TurnResult:
+        """Return the completed turn, rejecting an empty or truncated stream."""
+        if self._first_token_at is None:
+            raise UpstreamError("the endpoint returned an empty completion")
+        if not self._complete:
+            raise UpstreamError("the stream ended before the completion finished")
+        tool_calls = tuple(
+            {
+                "id": slot["id"],
+                "type": slot["type"],
+                "function": {"name": slot["name"], "arguments": slot["arguments"]},
+            }
+            for _, slot in sorted(self._tool_calls.items())
+        )
+        finish_reason = self._finish_reason or "stop"
+        if tool_calls and finish_reason == "stop":
+            finish_reason = "tool_calls"
+        return TurnResult(
+            content="".join(self._content),
+            tool_calls=tool_calls,
+            finish_reason=finish_reason,
+            ttft_ms=(self._first_token_at - self._started_at) * 1000,
+            total_ms=(now - self._started_at) * 1000,
+            output_tokens=self._output_tokens,
+        )
+
+
+class OpenAICompatClient:
+    """A model we prompt ourselves, over the chat-completions wire format.
+
+    Unlike a hosted agent there is no server-side session, so the session id is
+    minted here and only threads Coval's turns together.
+    """
+
+    def __init__(
+        self,
+        api_key: str,
+        base_url: str,
+        model: str,
+        system_prompt: str,
+        tools: list[dict[str, Any]],
+        extra_body: dict[str, Any] | None = None,
+        transport: httpx.AsyncBaseTransport | None = None,
+    ) -> None:
+        self._api_key = api_key
+        self._model = model
+        self._system_prompt = system_prompt
+        self._tools = tools
+        self._extra_body = extra_body or {}
+        self._client = httpx.AsyncClient(
+            base_url=base_url.rstrip("/"),
+            timeout=httpx.Timeout(30.0, read=None),
+            transport=transport or httpx.AsyncHTTPTransport(http2=True, limits=LIMITS),
+        )
+
+    def __repr__(self) -> str:
+        return f"OpenAICompatClient(model={self._model!r})"
+
+    async def aclose(self) -> None:
+        await self._client.aclose()
+
+    async def create_session(self) -> Session:
+        return Session(call_id=uuid.uuid4().hex, expires_at=None)
+
+    async def stream_turn(self, call_id: str, messages: list[dict[str, Any]]) -> TurnResult:
+        body: dict[str, Any] = {
+            "model": self._model,
+            "messages": [{"role": "system", "content": self._system_prompt}, *messages],
+            "stream": True,
+            "stream_options": {"include_usage": True},
+            **self._extra_body,
+        }
+        # OpenAI rejects an empty tools array outright.
+        if self._tools:
+            body["tools"] = self._tools
+        started_at = time.perf_counter()
+        accumulator = TurnAccumulator(started_at)
+        try:
+            async with self._client.stream(
+                "POST",
+                "/chat/completions",
+                headers={"Authorization": f"Bearer {self._api_key}"},
+                json=body,
+            ) as response:
+                if response.status_code in {401, 403}:
+                    raise AuthError(f"{self._model} rejected the API key ({response.status_code})")
+                if response.status_code >= 400:
+                    raise UpstreamError(f"{self._model} request failed ({response.status_code})")
+                async for line in response.aiter_lines():
+                    accumulator.feed(line, time.perf_counter())
+        except httpx.RequestError as exc:
+            raise UpstreamError(f"{self._model} endpoint is unreachable") from exc
+        return accumulator.result(time.perf_counter())

--- a/runner/src/coval_bench/llm/phonely.py
+++ b/runner/src/coval_bench/llm/phonely.py
@@ -1,16 +1,16 @@
 # Copyright 2026 The Coval Benchmarks Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Phonely Programmatic Calls client and streamed-turn accumulator."""
+"""Phonely Programmatic Calls client."""
 
 from __future__ import annotations
 
-import json
 import time
 from typing import TYPE_CHECKING, Any
 
 import httpx
 
+from coval_bench.llm.openai_compat import LIMITS, TurnAccumulator
 from coval_bench.llm.turn import Session as PhonelySession
 from coval_bench.llm.turn import TurnError, TurnResult
 
@@ -18,8 +18,6 @@ if TYPE_CHECKING:
     from coval_bench.config import Settings
 
 _SESSION_TIMEOUT = httpx.Timeout(30.0)
-# Turns are seconds apart; a 5s keepalive would put a TLS handshake inside most TTFTs.
-_LIMITS = httpx.Limits(max_connections=20, max_keepalive_connections=8, keepalive_expiry=300.0)
 
 
 class PhonelyError(TurnError):
@@ -38,122 +36,6 @@ class PhonelyUpstreamError(PhonelyError):
     """Phonely failed to produce a usable completion."""
 
 
-class TurnAccumulator:
-    """Reassemble OpenAI SSE chunks while measuring the first meaningful delta."""
-
-    def __init__(self, started_at: float) -> None:
-        self._started_at = started_at
-        self._first_token_at: float | None = None
-        self._content: list[str] = []
-        self._tool_calls: dict[int, dict[str, Any]] = {}
-        self._finish_reason: str | None = None
-        self._complete = False
-        self._output_tokens: int | None = None
-
-    def _stamp_first_token(self, now: float) -> None:
-        if self._first_token_at is None:
-            self._first_token_at = now
-
-    def feed(self, line: str, now: float) -> None:
-        """Consume one SSE line; irrelevant or malformed lines are ignored."""
-        line = line.strip()
-        if not line.startswith("data:"):
-            return
-        payload = line.removeprefix("data:").strip()
-        if not payload:
-            return
-        if payload == "[DONE]":
-            self._complete = True
-            return
-        try:
-            event = json.loads(payload)
-        except json.JSONDecodeError:
-            return
-        if not isinstance(event, dict):
-            return
-        error = event.get("error")
-        if error is not None:
-            message = error.get("message", error) if isinstance(error, dict) else error
-            raise PhonelyUpstreamError(f"Phonely stream error: {message}")
-
-        usage = event.get("usage")
-        if isinstance(usage, dict):
-            output_tokens = usage.get("completion_tokens")
-            if isinstance(output_tokens, int) and not isinstance(output_tokens, bool):
-                self._output_tokens = output_tokens
-
-        choices = event.get("choices")
-        if not isinstance(choices, list) or not choices or not isinstance(choices[0], dict):
-            return
-        choice = choices[0]
-        delta = choice.get("delta")
-        if isinstance(delta, dict):
-            content = delta.get("content")
-            if isinstance(content, str) and content:
-                self._stamp_first_token(now)
-                self._content.append(content)
-            raw_tool_calls = delta.get("tool_calls")
-            if isinstance(raw_tool_calls, list) and raw_tool_calls:
-                self._stamp_first_token(now)
-                self._feed_tool_calls(raw_tool_calls)
-        finish_reason = choice.get("finish_reason")
-        if isinstance(finish_reason, str) and finish_reason:
-            self._finish_reason = finish_reason
-            self._complete = True
-
-    def _feed_tool_calls(self, chunks: list[Any]) -> None:
-        for chunk in chunks:
-            if not isinstance(chunk, dict):
-                continue
-            index = chunk.get("index", 0)
-            if not isinstance(index, int) or isinstance(index, bool):
-                index = 0
-            slot = self._tool_calls.setdefault(
-                index, {"id": "", "type": "function", "name": "", "arguments": ""}
-            )
-            call_id = chunk.get("id")
-            if isinstance(call_id, str) and call_id:
-                slot["id"] = call_id
-            call_type = chunk.get("type")
-            if isinstance(call_type, str) and call_type:
-                slot["type"] = call_type
-            function = chunk.get("function")
-            if not isinstance(function, dict):
-                continue
-            name = function.get("name")
-            if isinstance(name, str):
-                slot["name"] += name
-            arguments = function.get("arguments")
-            if isinstance(arguments, str):
-                slot["arguments"] += arguments
-
-    def result(self, now: float) -> TurnResult:
-        """Return the completed turn, rejecting an empty or truncated stream."""
-        if self._first_token_at is None:
-            raise PhonelyUpstreamError("Phonely returned an empty completion")
-        if not self._complete:
-            raise PhonelyUpstreamError("Phonely stream ended before the completion finished")
-        tool_calls = tuple(
-            {
-                "id": slot["id"],
-                "type": slot["type"],
-                "function": {"name": slot["name"], "arguments": slot["arguments"]},
-            }
-            for _, slot in sorted(self._tool_calls.items())
-        )
-        finish_reason = self._finish_reason or "stop"
-        if tool_calls and finish_reason == "stop":
-            finish_reason = "tool_calls"
-        return TurnResult(
-            content="".join(self._content),
-            tool_calls=tool_calls,
-            finish_reason=finish_reason,
-            ttft_ms=(self._first_token_at - self._started_at) * 1000,
-            total_ms=(now - self._started_at) * 1000,
-            output_tokens=self._output_tokens,
-        )
-
-
 class PhonelyClient:
     """Async client for Phonely's session and streaming chat endpoints."""
 
@@ -169,7 +51,7 @@ class PhonelyClient:
         self._client = httpx.AsyncClient(
             base_url=base_url.rstrip("/"),
             timeout=httpx.Timeout(30.0, read=None),
-            transport=transport or httpx.AsyncHTTPTransport(http2=True, limits=_LIMITS),
+            transport=transport or httpx.AsyncHTTPTransport(http2=True, limits=LIMITS),
         )
 
     @classmethod

--- a/runner/tests/unit/test_openai_compat.py
+++ b/runner/tests/unit/test_openai_compat.py
@@ -1,0 +1,129 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Chat-completions accumulator, generic client, and dental agent tests."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import httpx
+import pytest
+
+from coval_bench.llm.dental import load_dental_agent
+from coval_bench.llm.openai_compat import (
+    AuthError,
+    OpenAICompatClient,
+    TurnAccumulator,
+    UpstreamError,
+)
+
+
+def _chunk(delta: dict[str, Any], finish_reason: str | None = None) -> str:
+    return "data: " + json.dumps({"choices": [{"delta": delta, "finish_reason": finish_reason}]})
+
+
+def test_accumulator_times_the_first_meaningful_delta() -> None:
+    turn = TurnAccumulator(10.0)
+    turn.feed(_chunk({"role": "assistant"}), 10.1)
+    turn.feed(_chunk({"content": "Hello"}), 10.25)
+    turn.feed(_chunk({"content": " there"}, "stop"), 10.4)
+    result = turn.result(10.5)
+
+    assert result.content == "Hello there"
+    assert result.finish_reason == "stop"
+    assert result.ttft_ms == pytest.approx(250.0)
+    assert result.total_ms == pytest.approx(500.0)
+
+
+def test_accumulator_reassembles_tool_calls_and_keeps_truncation() -> None:
+    turn = TurnAccumulator(5.0)
+    first = {"index": 0, "id": "call-1", "function": {"name": "end", "arguments": '{"reason":'}}
+    turn.feed(_chunk({"tool_calls": [first]}), 5.2)
+    rest = {"index": 0, "function": {"name": "Call", "arguments": '"done"}'}}
+    turn.feed(_chunk({"tool_calls": [rest]}, "tool_calls"), 5.3)
+    result = turn.result(5.4)
+
+    assert result.finish_reason == "tool_calls"
+    assert result.ttft_ms == pytest.approx(200.0)
+    assert result.tool_calls == (
+        {
+            "id": "call-1",
+            "type": "function",
+            "function": {"name": "endCall", "arguments": '{"reason":"done"}'},
+        },
+    )
+
+    cut = TurnAccumulator(0)
+    cut.feed(_chunk({"tool_calls": [first]}, "length"), 0.1)
+    assert cut.result(0.2).finish_reason == "length"
+
+
+def test_accumulator_rejects_errors_empty_and_unfinished_streams() -> None:
+    with pytest.raises(UpstreamError, match="generation failed"):
+        TurnAccumulator(0).feed('data: {"error":{"message":"generation failed"}}', 0.1)
+    with pytest.raises(UpstreamError, match="empty completion"):
+        TurnAccumulator(0).result(1)
+
+    turn = TurnAccumulator(0)
+    turn.feed(_chunk({"content": "partial"}), 0.1)
+    with pytest.raises(UpstreamError, match="before the completion finished"):
+        turn.result(0.2)
+    turn.feed("data: [DONE]", 0.3)
+    assert turn.result(0.4).content == "partial"
+
+
+@pytest.mark.asyncio
+async def test_client_prompts_and_arms_the_model_itself() -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(200, content=_chunk({"content": "Hi"}, "stop"))
+
+    tools = [{"type": "function", "function": {"name": "book", "parameters": {}}}]
+    client = OpenAICompatClient(
+        "secret-key",
+        "https://llm.test/v1/",
+        "gpt-test",
+        "Be brief.",
+        tools,
+        extra_body={"reasoning_effort": "none"},
+        transport=httpx.MockTransport(handler),
+    )
+    try:
+        session = await client.create_session()
+        result = await client.stream_turn(session.call_id, [{"role": "user", "content": "Hi"}])
+    finally:
+        await client.aclose()
+
+    assert session.call_id and result.content == "Hi"
+    (request,) = requests
+    assert request.url == "https://llm.test/v1/chat/completions"
+    assert request.headers["Authorization"] == "Bearer secret-key"
+    body = json.loads(request.content)
+    assert body["model"] == "gpt-test"
+    assert body["messages"][0] == {"role": "system", "content": "Be brief."}
+    assert body["tools"] == tools
+    assert body["stream"] is True
+    assert body["reasoning_effort"] == "none"
+    assert "secret-key" not in repr(client)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(("status", "error"), [(401, AuthError), (500, UpstreamError)])
+async def test_client_classifies_http_errors(status: int, error: type[Exception]) -> None:
+    transport = httpx.MockTransport(lambda _request: httpx.Response(status))
+    client = OpenAICompatClient("key", "https://llm.test", "m", "", [], transport=transport)
+    try:
+        with pytest.raises(error):
+            await client.stream_turn("call", [])
+    finally:
+        await client.aclose()
+
+
+def test_dental_agent_carries_the_contract_prompt_and_tools() -> None:
+    agent = load_dental_agent()
+    assert "BrightSmile Dental" in agent.system_prompt
+    assert "lookup_patient" in {tool["function"]["name"] for tool in agent.tools}

--- a/runner/tests/unit/test_phonely_client.py
+++ b/runner/tests/unit/test_phonely_client.py
@@ -1,7 +1,7 @@
 # Copyright 2026 The Coval Benchmarks Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Phonely streaming client and accumulator tests."""
+"""Phonely streaming client tests."""
 
 from __future__ import annotations
 
@@ -16,7 +16,6 @@ from coval_bench.llm.phonely import (
     PhonelyClient,
     PhonelySessionExpired,
     PhonelyUpstreamError,
-    TurnAccumulator,
 )
 
 
@@ -28,81 +27,6 @@ def _chunk(delta: dict[str, Any], finish_reason: str | None = None) -> str:
             "choices": [{"delta": delta, "finish_reason": finish_reason}],
         }
     )
-
-
-def test_accumulator_stamps_the_first_meaningful_content_chunk() -> None:
-    turn = TurnAccumulator(10.0)
-    turn.feed(_chunk({"role": "assistant"}), 10.1)
-    turn.feed(_chunk({"content": "Hello"}), 10.25)
-    turn.feed(_chunk({"content": " there"}, "stop"), 10.4)
-    result = turn.result(10.5)
-
-    assert result.content == "Hello there"
-    assert result.tool_calls == ()
-    assert result.finish_reason == "stop"
-    assert result.ttft_ms == pytest.approx(250.0)
-    assert result.total_ms == pytest.approx(500.0)
-
-
-def test_accumulator_reassembles_tool_calls_by_index() -> None:
-    turn = TurnAccumulator(5.0)
-    turn.feed(
-        _chunk(
-            {
-                "tool_calls": [
-                    {
-                        "index": 0,
-                        "id": "call-1",
-                        "type": "function",
-                        "function": {"name": "end", "arguments": '{"reason":'},
-                    }
-                ]
-            }
-        ),
-        5.2,
-    )
-    turn.feed(
-        _chunk(
-            {"tool_calls": [{"index": 0, "function": {"name": "Call", "arguments": '"done"}'}}]},
-            "tool_calls",
-        ),
-        5.3,
-    )
-    result = turn.result(5.4)
-
-    assert result.content == ""
-    assert result.finish_reason == "tool_calls"
-    assert result.ttft_ms == pytest.approx(200.0)
-    assert result.tool_calls == (
-        {
-            "id": "call-1",
-            "type": "function",
-            "function": {"name": "endCall", "arguments": '{"reason":"done"}'},
-        },
-    )
-
-
-def test_accumulator_rejects_stream_errors_and_empty_completions() -> None:
-    with pytest.raises(PhonelyUpstreamError, match="generation failed"):
-        TurnAccumulator(0).feed('data: {"error":{"message":"generation failed"}}', 0.1)
-    with pytest.raises(PhonelyUpstreamError, match="empty completion"):
-        TurnAccumulator(0).result(1)
-
-
-def test_accumulator_rejects_a_stream_that_ends_before_completion() -> None:
-    turn = TurnAccumulator(0)
-    turn.feed('data: {"error":null,"choices":[{"delta":{"content":"partial"}}]}', 0.1)
-    with pytest.raises(PhonelyUpstreamError, match="before the completion finished"):
-        turn.result(0.2)
-    turn.feed("data: [DONE]", 0.3)
-    assert turn.result(0.4).content == "partial"
-
-
-def test_accumulator_keeps_a_length_finish_reason_on_truncated_tool_calls() -> None:
-    turn = TurnAccumulator(0)
-    call = {"index": 0, "id": "c", "function": {"name": "book", "arguments": '{"date": "2026-'}}
-    turn.feed(_chunk({"tool_calls": [call]}, "length"), 0.1)
-    assert turn.result(0.2).finish_reason == "length"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Prep for adding gpt-4.1 (BENCH-847) and gemini-2.5-flash (BENCH-848) to the LLM benchmark.

- Move `TurnAccumulator` out of `llm/phonely.py` into `llm/openai_compat.py`; it parses the chat-completions SSE format every OpenAI-compatible endpoint emits.
- Add `OpenAICompatClient` for models we prompt ourselves. Takes base URL, key, model, system prompt, tools, and an optional `extra_body` for per-provider switches (thinking off). Sessions are minted locally.
- Add `llm/dental.py`, which loads the dental contract prompt and the five tool definitions once in OpenAI function-tool shape.
- Phonely keeps its own client since it hosts the agent and owns a real session.

No new providers in this PR. Each new model becomes a `CLIENT_FACTORIES` entry plus its settings fields.

Linear: https://linear.app/coval/issue/BENCH-861
