### PR TITLE
[BENCH-847] Add gpt-4.1 to the LLM benchmark

### DIFF
--- a/runner/src/coval_bench/config.py
+++ b/runner/src/coval_bench/config.py
@@ -192,6 +192,7 @@ class Settings(BaseSettings):
     coval_s2s_red_agent_id: str | None = None
     # Coval agent id for the Phonely text agent (opaque, not secret); unset skips it.
     coval_llm_phonely_agent_id: str | None = None
+    coval_llm_openai_agent_id: str | None = None
     # The S2S instruction-adherence metric id (opaque, not secret). Optional: the
     # fetch pulls its per-conversation scores only when set, so latency still
     # ingests without it.

--- a/runner/src/coval_bench/llm/benchmark.py
+++ b/runner/src/coval_bench/llm/benchmark.py
@@ -10,13 +10,35 @@ from dataclasses import dataclass
 from typing import Any
 
 from coval_bench.config import Settings
+from coval_bench.llm.dental import load_dental_agent
+from coval_bench.llm.openai_compat import OpenAICompatClient
 from coval_bench.llm.phonely import PhonelyClient
 from coval_bench.llm.turn import TurnClient
 from coval_bench.registries.benchmarks import Benchmark
 from coval_bench.registries.models import RegisteredModel
 
+OPENAI_BASE_URL = "https://api.openai.com/v1"
+# Must match the model column of the collected LLM row for this provider.
+OPENAI_MODEL = "gpt-4.1"
+
+
+def openai_client(settings: Settings) -> TurnClient | None:
+    key = settings.openai_api_key
+    if not (key and key.get_secret_value()):
+        return None
+    agent = load_dental_agent()
+    return OpenAICompatClient(
+        key.get_secret_value(),
+        OPENAI_BASE_URL,
+        OPENAI_MODEL,
+        agent.system_prompt,
+        list(agent.tools),
+    )
+
+
 CLIENT_FACTORIES: dict[str, Callable[[Settings], TurnClient | None]] = {
     "phonely": PhonelyClient.from_settings,
+    "openai": openai_client,
 }
 DEFAULT_PERSONA_ID = "PN3xgmsqeLDjsNNEA2e55e"
 ITERATION_COUNT = 1

--- a/runner/tests/unit/test_llm_clients.py
+++ b/runner/tests/unit/test_llm_clients.py
@@ -1,0 +1,25 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import pytest
+
+from coval_bench.config import Settings
+from coval_bench.llm.benchmark import make_clients
+from coval_bench.llm.openai_compat import OpenAICompatClient
+
+
+@pytest.mark.parametrize(
+    ("provider", "key_env", "model"),
+    [("openai", "OPENAI_API_KEY", "gpt-4.1")],
+)
+def test_compat_clients_need_their_key(
+    provider: str, key_env: str, model: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv(key_env, raising=False)
+    assert provider not in make_clients(Settings(_env_file=None))
+    monkeypatch.setenv(key_env, "k")
+    clients = make_clients(Settings(_env_file=None))
+    assert isinstance(clients[provider], OpenAICompatClient)
+    assert model in repr(clients[provider])


### PR DESCRIPTION
Registers an `OpenAICompatClient` for gpt-4.1 under the `openai` provider, armed with the dental prompt and tools, and adds the `coval_llm_openai_agent_id` setting the fetch reads for that provider. The factory returns nothing when `OPENAI_API_KEY` is unset.

After release: add the `LLM / openai / gpt-4.1` row on /admin with collected on. The first sync-llm run prints the Coval agent id, which goes into benchmark-infra env.

Linear: https://linear.app/coval/issue/BENCH-847
