### PR TITLE
[BENCH-848] Add gemini-2.5-flash to the LLM benchmark

### DIFF
--- a/runner/src/coval_bench/config.py
+++ b/runner/src/coval_bench/config.py
@@ -193,6 +193,7 @@ class Settings(BaseSettings):
     # Coval agent id for the Phonely text agent (opaque, not secret); unset skips it.
     coval_llm_phonely_agent_id: str | None = None
     coval_llm_openai_agent_id: str | None = None
+    coval_llm_google_agent_id: str | None = None
     # The S2S instruction-adherence metric id (opaque, not secret). Optional: the
     # fetch pulls its per-conversation scores only when set, so latency still
     # ingests without it.

--- a/runner/src/coval_bench/llm/benchmark.py
+++ b/runner/src/coval_bench/llm/benchmark.py
@@ -36,9 +36,29 @@ def openai_client(settings: Settings) -> TurnClient | None:
     )
 
 
+GEMINI_BASE_URL = "https://generativelanguage.googleapis.com/v1beta/openai"
+GEMINI_MODEL = "gemini-2.5-flash"
+
+
+def gemini_client(settings: Settings) -> TurnClient | None:
+    key = settings.gemini_api_key
+    if not (key and key.get_secret_value()):
+        return None
+    agent = load_dental_agent()
+    return OpenAICompatClient(
+        key.get_secret_value(),
+        GEMINI_BASE_URL,
+        GEMINI_MODEL,
+        agent.system_prompt,
+        list(agent.tools),
+        extra_body={"reasoning_effort": "none"},
+    )
+
+
 CLIENT_FACTORIES: dict[str, Callable[[Settings], TurnClient | None]] = {
     "phonely": PhonelyClient.from_settings,
     "openai": openai_client,
+    "google": gemini_client,
 }
 DEFAULT_PERSONA_ID = "PN3xgmsqeLDjsNNEA2e55e"
 ITERATION_COUNT = 1

--- a/runner/tests/unit/test_llm_clients.py
+++ b/runner/tests/unit/test_llm_clients.py
@@ -12,7 +12,7 @@ from coval_bench.llm.openai_compat import OpenAICompatClient
 
 @pytest.mark.parametrize(
     ("provider", "key_env", "model"),
-    [("openai", "OPENAI_API_KEY", "gpt-4.1")],
+    [("openai", "OPENAI_API_KEY", "gpt-4.1"), ("google", "GEMINI_API_KEY", "gemini-2.5-flash")],
 )
 def test_compat_clients_need_their_key(
     provider: str, key_env: str, model: str, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
Registers an `OpenAICompatClient` for gemini-2.5-flash under the `google` provider through Gemini's OpenAI-compatible endpoint with `reasoning_effort: none` so thinking is off, and adds the `coval_llm_google_agent_id` setting. The factory returns nothing when `GEMINI_API_KEY` is unset.

After release: flip collected on for registry row 103, `LLM / google / gemini-2.5-flash` (distinct from the existing `gemini-2.5-flash-tts` TTS row). The first sync-llm run prints the Coval agent id, which goes into benchmark-infra env.

Linear: https://linear.app/coval/issue/BENCH-848
