### PR TITLE
[BENCH-854] Record each model's series color in the registry

### DIFF
--- a/runner/src/coval_bench/api/routers/admin_models.py
+++ b/runner/src/coval_bench/api/routers/admin_models.py
@@ -50,7 +50,7 @@ from coval_bench.registries.provider_keys import provider_names
 router = APIRouter(tags=["admin"], dependencies=[Depends(require_coval_admin)])
 
 # PATCH fields where null is a value, not an omission.
-_NULLABLE_FIELDS = frozenset({"voice", "creator", "region"})
+_NULLABLE_FIELDS = frozenset({"voice", "creator", "region", "color"})
 
 
 def _model_out(record: ModelRecord, history: list[ModelChange]) -> AdminModelOut:

--- a/runner/src/coval_bench/api/routers/providers.py
+++ b/runner/src/coval_bench/api/routers/providers.py
@@ -114,6 +114,7 @@ def _build_provider_map(
                 disabled=not m.collected,
                 early_access=not m.published,
                 tags=_model_tags(m, vocabulary),
+                color=m.color,
             )
         )
     return result

--- a/runner/src/coval_bench/api/schemas.py
+++ b/runner/src/coval_bench/api/schemas.py
@@ -19,7 +19,7 @@ from pydantic import BaseModel, ConfigDict, Field
 
 from coval_bench.api.common import BenchmarkLiteral, WindowLiteral
 from coval_bench.arena.domains import ArenaDomain
-from coval_bench.registries import Benchmark, Licensing, Source, TagCategory, Voice
+from coval_bench.registries import Benchmark, HexColor, Licensing, Source, TagCategory, Voice
 
 
 class RunOut(BaseModel):
@@ -103,6 +103,9 @@ class ModelInfo(BaseModel):
     disabled: bool = False
     early_access: bool = False
     tags: list[ModelTagOut] = []
+    # The series color the registry records for the model, as lowercase
+    # ``#rrggbb``. None means the site picks one from its built-in palette.
+    color: str | None = None
 
 
 class ProviderInfo(BaseModel):
@@ -478,6 +481,7 @@ class AdminModelOut(BaseModel):
     collected: bool
     published: bool
     tags: list[str] = []
+    color: str | None = None
     updated_by_user_id: str
     updated_by_email: str | None = None
     updated_at: datetime
@@ -507,10 +511,14 @@ class AdminModelCreate(BaseModel):
     collected: bool = True
     published: bool = False
     tags: list[str] = []
+    color: HexColor = None
 
 
 class AdminModelPatch(BaseModel):
-    """PATCH body for /v1/admin/models/{id}; absent fields stay unchanged."""
+    """PATCH body for /v1/admin/models/{id}; absent fields stay unchanged.
+
+    ``color`` null returns the model to the site's built-in palette.
+    """
 
     provider: str | None = Field(default=None, min_length=1)
     model: str | None = Field(default=None, min_length=1)
@@ -525,6 +533,7 @@ class AdminModelPatch(BaseModel):
     collected: bool | None = None
     published: bool | None = None
     tags: list[str] | None = None
+    color: HexColor = None
 
 
 class AdminModelUpdateResponse(BaseModel):

--- a/runner/src/coval_bench/db/migrations/versions/20260909_0029_model_colors.py
+++ b/runner/src/coval_bench/db/migrations/versions/20260909_0029_model_colors.py
@@ -1,0 +1,159 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+# ruff: noqa: E501  # Seed rows are one line each so the palette reads as a table.
+
+"""Per-model series colors: models.color, seeded with what the site draws today.
+
+Revision ID: 20260909_0029
+Revises:     20260909_0028
+Create Date: 2026-09-09
+
+The site used to pick every model's color from a palette compiled into the frontend;
+recoloring a model meant a deploy. The color now lives on the model row, edited from
+the admin registry like any other field, and ``/v1/providers`` carries it so the
+frontend draws what the registry says.
+
+The seed is the color the site was drawing each registered model in as of this
+revision — read off the live palette and pasted here as a literal, so the public
+pages look exactly the same the day the column lands and the registry, not the
+site's code, is the source of truth from then on.
+NULL means the site still picks: a model registered after this seed keeps the
+compiled palette until someone records a color for it.
+
+``color`` is nullable text constrained to lowercase ``#rrggbb``; case is normalized
+at the API boundary. The ``api`` role's existing GRANTs on ``models`` cover it.
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "20260909_0029"
+down_revision = "20260909_0028"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Add the color column and seed it with the palette the site draws today."""
+    op.execute(
+        """
+        ALTER TABLE benchmarks_v2.models
+            ADD COLUMN color TEXT CHECK (color IS NULL OR color ~ '^#[0-9a-f]{6}$');
+        """
+    )
+    op.get_bind().exec_driver_sql(
+        """
+        UPDATE benchmarks_v2.models m
+        SET color = v.color
+        FROM (VALUES
+            ('LLM', 'phonely', 'phonely-agent', '#c6668d'),
+            ('S2S', 'colors', 'gray', '#4b9ac0'),
+            ('S2S', 'colors', 'red', '#4b9ac0'),
+            ('S2S', 'google', 'gemini-live', '#53b0de'),
+            ('S2S', 'openai', 'gpt-realtime', '#c35483'),
+            ('S2S', 'xai', 'grok-voice-think-fast-1.0', '#a879c5'),
+            ('S2S', 'xai', 'grok-voice-think-fast-2.0', '#c890ea'),
+            ('STT', 'assemblyai', 'universal-3-pro', '#a871c9'),
+            ('STT', 'assemblyai', 'universal-3.5-pro', '#bf86e0'),
+            ('STT', 'assemblyai', 'universal-streaming', '#965fb6'),
+            ('STT', 'assemblyai', 'universal-streaming-multilingual', '#d299f5'),
+            ('STT', 'azure', 'default', '#3d7fd1'),
+            ('STT', 'baseten', 'qwen3-asr-1.7b', '#15c25c'),
+            ('STT', 'baseten', 'whisper-large-v3', '#19e76e'),
+            ('STT', 'cartesia', 'ink-2', '#3b6eb9'),
+            ('STT', 'deepgram', 'flux-general-en', '#039580'),
+            ('STT', 'deepgram', 'flux-general-multi', '#007b69'),
+            ('STT', 'deepgram', 'nova-2', '#49cdb4'),
+            ('STT', 'deepgram', 'nova-3', '#1db098'),
+            ('STT', 'elevenlabs', 'scribe_v2_realtime', '#e67e54'),
+            ('STT', 'gemini', 'gemini-3.5-transcribe-live', '#3cc3ab'),
+            ('STT', 'gladia', 'solaria-1', '#6a9fee'),
+            ('STT', 'google', 'chirp_2', '#53b0de'),
+            ('STT', 'google', 'chirp_3', '#1d85b0'),
+            ('STT', 'gradium', 'default', '#74c16c'),
+            ('STT', 'inworld', 'inworld-stt-1', '#736dc3'),
+            ('STT', 'mistral', 'voxtral-mini-transcribe-realtime-2602', '#835a01'),
+            ('STT', 'modulate', 'english-fast-transcription-streaming', '#3cc3ab'),
+            ('STT', 'modulate', 'multilingual-transcription-streaming', '#5bcdb8'),
+            ('STT', 'modulate', 'velma-2-stt-streaming', '#5bcdb8'),
+            ('STT', 'modulate', 'velma-2-stt-streaming-english-v2', '#32a490'),
+            ('STT', 'openai', 'gpt-4o-mini-transcribe', '#d1608f'),
+            ('STT', 'openai', 'gpt-4o-transcribe', '#f782b1'),
+            ('STT', 'openai', 'gpt-realtime-whisper', '#b24574'),
+            ('STT', 'reson8', 'realtime', '#8e9f36'),
+            ('STT', 'revai', 'reverb', '#7f7bc6'),
+            ('STT', 'smallest', 'pulse', '#b07b05'),
+            ('STT', 'soniox', 'stt-rt-v4', '#707f03'),
+            ('STT', 'soniox', 'stt-rt-v5', '#697800'),
+            ('STT', 'speechmatics', 'default', '#a24112'),
+            ('STT', 'speechmatics', 'enhanced', '#c35f36'),
+            ('STT', 'speechmatics', 'linden-1', '#cd7956'),
+            ('STT', 'together', 'nemotron-3-asr-streaming-0.6b', '#4a9243'),
+            ('STT', 'together', 'nemotron-3.5-asr-streaming-0.6b', '#4a9243'),
+            ('STT', 'together', 'parakeet-tdt-0.6b-v3', '#33792c'),
+            ('STT', 'together', 'whisper-large-v3', '#8f3055'),
+            ('STT', 'xai', 'grok-stt', '#844da2'),
+            ('STT', 'zoom', 'scribe', '#5bcdb8'),
+            ('TTS', 'alibaba', 'qwen3-tts-flash-realtime', '#9c6c03'),
+            ('TTS', 'atlas', 'atlas-tts', '#3cc3ab'),
+            ('TTS', 'azure', 'dragon-hd-latest', '#3d7fd1'),
+            ('TTS', 'azure', 'neural', '#5c93d8'),
+            ('TTS', 'baseten', 'qwen3-tts-1.7b', '#19e76e'),
+            ('TTS', 'cartesia', 'sonic', '#4f7bbd'),
+            ('TTS', 'cartesia', 'sonic-3', '#5e93e1'),
+            ('TTS', 'cartesia', 'sonic-3.5', '#5e93e1'),
+            ('TTS', 'cartesia', 'sonic-3.6', '#5e93e1'),
+            ('TTS', 'cartesia', 'sonic-preview', '#4f7bbd'),
+            ('TTS', 'deepdub', 'dd-etts-3.3', '#5bcdb8'),
+            ('TTS', 'deepgram', 'aura-2-thalia-en', '#29b69e'),
+            ('TTS', 'deepgram', 'flux-haley-en', '#189480'),
+            ('TTS', 'elevenlabs', 'eleven_flash_v2_5', '#d87248'),
+            ('TTS', 'elevenlabs', 'eleven_multilingual_v2', '#fb9167'),
+            ('TTS', 'elevenlabs', 'eleven_turbo_v2_5', '#bd592f'),
+            ('TTS', 'elevenlabs', 'eleven_v3', '#b04d20'),
+            ('TTS', 'elevenlabs', 'eleven_v3_conversational', '#c16a47'),
+            ('TTS', 'fishaudio', 's1', '#ef8eb6'),
+            ('TTS', 'fishaudio', 's2.1-pro', '#c6668d'),
+            ('TTS', 'fishaudio', 's2.1-pro-free', '#ec79a8'),
+            ('TTS', 'fluxions', 'vui', '#f78e64'),
+            ('TTS', 'google', 'chirp-3-hd', '#4694ba'),
+            ('TTS', 'google', 'gemini-2.5-flash-tts', '#53b0de'),
+            ('TTS', 'gradium', 'default', '#74c16c'),
+            ('TTS', 'gradium', 'gradium-tts-beta', '#74c16c'),
+            ('TTS', 'groq', 'canopylabs/orpheus-v1-english', '#dea645'),
+            ('TTS', 'hakim', 'hakim-fast-v1', '#cc9ce8'),
+            ('TTS', 'hume', 'octave-2', '#59b7e4'),
+            ('TTS', 'hume', 'octave-tts', '#268bb6'),
+            ('TTS', 'inworld', 'inworld-tts-1.5-max', '#8b85de'),
+            ('TTS', 'inworld', 'inworld-tts-1.5-mini', '#a9a5ff'),
+            ('TTS', 'inworld', 'inworld-tts-2', '#5b55a9'),
+            ('TTS', 'inworld', 'inworld-tts-2-flash', '#4c4294'),
+            ('TTS', 'lmnt', 'blizzard', '#3cc3ab'),
+            ('TTS', 'minimax', 'speech-2.8-hd', '#3cc3ab'),
+            ('TTS', 'minimax', 'speech-2.8-turbo', '#32a490'),
+            ('TTS', 'murf', 'falcon-2', '#a373c0'),
+            ('TTS', 'openai', 'gpt-4o-mini-tts', '#de6d9b'),
+            ('TTS', 'openai', 'gpt-realtime-2025-08-28', '#d1608f'),
+            ('TTS', 'openai', 'tts-1', '#b05178'),
+            ('TTS', 'openai', 'tts-1-hd', '#b05178'),
+            ('TTS', 'palabra', 'palabra-tts-v1', '#ba8b3a'),
+            ('TTS', 'rime', 'arcana', '#55a14e'),
+            ('TTS', 'rime', 'coda', '#3c8836'),
+            ('TTS', 'rime', 'mistv2', '#32722d'),
+            ('TTS', 'rime', 'mistv3', '#22701c'),
+            ('TTS', 'smallest', 'lightning_v3.1_pro', '#d7a03d'),
+            ('TTS', 'soniox', 'tts-rt-v1', '#9db030'),
+            ('TTS', 'soniox', 'tts-rt-v2', '#859704'),
+            ('TTS', 'speechify', 'simba-3.0', '#64a55d'),
+            ('TTS', 'speechify', 'simba-3.2', '#8dcd86'),
+            ('TTS', 'xai', 'grok-tts', '#c890ea')
+        ) AS v (modality, provider, model, color)
+        WHERE m.modality = v.modality AND m.provider = v.provider AND m.model = v.model;
+        """
+    )
+
+
+def downgrade() -> None:
+    """Drop the color column; the site falls back to its compiled palette."""
+    op.execute("ALTER TABLE benchmarks_v2.models DROP COLUMN color;")

--- a/runner/src/coval_bench/db/registry_store.py
+++ b/runner/src/coval_bench/db/registry_store.py
@@ -26,6 +26,7 @@ from pydantic import BaseModel, field_validator
 
 from coval_bench.registries.benchmarks import Benchmark
 from coval_bench.registries.models import (
+    HexColor,
     Licensing,
     RegisteredModel,
     Source,
@@ -52,6 +53,7 @@ EDITABLE_FIELDS = frozenset(
         "collected",
         "published",
         "tags",
+        "color",
     }
 )
 
@@ -93,6 +95,7 @@ class NewModel(BaseModel):
     collected: bool = True
     published: bool = False
     tags: tuple[str, ...] = ()
+    color: HexColor = None
 
     @field_validator("tags")
     @classmethod
@@ -129,7 +132,7 @@ class ModelChange(BaseModel):
 _SELECT_MODELS = """
     SELECT m.id, m.modality, m.provider, m.model, m.voice, m.voices, m.creator,
            m.source, m.licensing, m.on_prem, m.region, m.arena_enabled,
-           m.collected, m.published, m.updated_by_user_id, m.updated_by_email,
+           m.collected, m.published, m.color, m.updated_by_user_id, m.updated_by_email,
            m.updated_at, COALESCE(t.tags, '{}') AS tags
     FROM benchmarks_v2.models m
     LEFT JOIN (
@@ -142,9 +145,9 @@ _SELECT_MODELS = """
 _INSERT_MODEL = """
     INSERT INTO benchmarks_v2.models
         (modality, provider, model, voice, voices, creator, source, licensing,
-         on_prem, region, arena_enabled, collected, published,
+         on_prem, region, arena_enabled, collected, published, color,
          updated_by_user_id, updated_by_email)
-    VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+    VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
     RETURNING id, updated_at
 """
 
@@ -152,7 +155,7 @@ _UPDATE_MODEL = """
     UPDATE benchmarks_v2.models
     SET provider = %s, model = %s, voice = %s, voices = %s, creator = %s,
         source = %s, licensing = %s, on_prem = %s, region = %s,
-        arena_enabled = %s, collected = %s, published = %s,
+        arena_enabled = %s, collected = %s, published = %s, color = %s,
         updated_by_user_id = %s, updated_by_email = %s,
         -- Strictly monotonic per row: the 412 stale check compares this exactly,
         -- so same-microsecond updates must still produce a new value.
@@ -167,6 +170,13 @@ _INSERT_HISTORY = """
          changed_by_user_id, changed_by_org_id, changed_by_email)
     VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
 """
+
+
+# The same read for a database that migration 0029 has not reached yet. The API
+# deploys ahead of its migrations, and this is the read behind /v1/providers and
+# the orchestrator's roster — the whole site goes dark if it fails for the window
+# between the two. Every color reads as unset until the column exists.
+_SELECT_MODELS_BEFORE_COLOR = _SELECT_MODELS.replace("m.color,", "NULL AS color,")
 
 
 def _record(row: Mapping[str, Any]) -> ModelRecord:
@@ -204,15 +214,30 @@ class RegistryStore:
 
     async def list_models(self) -> list[ModelRecord]:
         async with self._pool.connection() as conn:
-            rows = await (await conn.execute(f"{_SELECT_MODELS} ORDER BY m.id")).fetchall()
+            rows = await self._select_models(conn, "ORDER BY m.id", ())
         return [_record(row) for row in rows]
 
     async def get_model(self, model_id: int) -> ModelRecord | None:
         async with self._pool.connection() as conn:
-            row = await (
-                await conn.execute(f"{_SELECT_MODELS} WHERE m.id = %s", (model_id,))
-            ).fetchone()
-        return None if row is None else _record(row)
+            rows = await self._select_models(conn, "WHERE m.id = %s", (model_id,))
+        return _record(rows[0]) if rows else None
+
+    @staticmethod
+    async def _select_models(
+        conn: psycopg.AsyncConnection[psycopg.rows.DictRow],
+        clause: str,
+        params: tuple[Any, ...],
+    ) -> list[psycopg.rows.DictRow]:
+        """Read model rows, falling back to the pre-0029 shape while the column is missing."""
+        try:
+            return await (await conn.execute(f"{_SELECT_MODELS} {clause}", params)).fetchall()
+        except psycopg.errors.UndefinedColumn:
+            # The failed statement aborted the connection's implicit transaction;
+            # clear it so the retry is not refused with InFailedSqlTransaction.
+            await conn.rollback()
+            return await (
+                await conn.execute(f"{_SELECT_MODELS_BEFORE_COLOR} {clause}", params)
+            ).fetchall()
 
     async def insert_model(
         self,
@@ -242,6 +267,7 @@ class RegistryStore:
                             new.arena_enabled,
                             new.collected,
                             new.published,
+                            new.color,
                             user_id,
                             email,
                         ),
@@ -329,6 +355,7 @@ class RegistryStore:
                             merged.arena_enabled,
                             merged.collected,
                             merged.published,
+                            merged.color,
                             user_id,
                             email,
                             model_id,
@@ -434,6 +461,7 @@ def _registered(record: ModelRecord) -> RegisteredModel:
         collected=record.collected,
         published=record.published,
         arena_enabled=record.arena_enabled,
+        color=record.color,
     )
 
 

--- a/runner/src/coval_bench/registries/__init__.py
+++ b/runner/src/coval_bench/registries/__init__.py
@@ -24,10 +24,12 @@ from coval_bench.registries.metrics import (
 )
 from coval_bench.registries.models import (
     Gender,
+    HexColor,
     Licensing,
     RegisteredModel,
     Source,
     Voice,
+    normalize_hex_color,
 )
 from coval_bench.registries.preprocessing import (
     SUPPORTED_PREPROCESSING_ARTIFACT_CONTRACTS,
@@ -51,6 +53,7 @@ __all__ = [
     "MetricDirection",
     "MetricSpec",
     "Gender",
+    "HexColor",
     "MetricValueContract",
     "MetricValueDefinition",
     "MetricValueRole",
@@ -58,6 +61,7 @@ __all__ = [
     "RegisteredModel",
     "Source",
     "Voice",
+    "normalize_hex_color",
     "CATEGORY_LABELS",
     "PROVIDER_VALUED_CATEGORIES",
     "TagCategory",

--- a/runner/src/coval_bench/registries/models.py
+++ b/runner/src/coval_bench/registries/models.py
@@ -10,10 +10,11 @@ the orchestrator runs every ``collected`` entry and the API serves only the
 
 from __future__ import annotations
 
+import re
 from enum import StrEnum
-from typing import Literal
+from typing import Annotated, Literal
 
-from pydantic import BaseModel
+from pydantic import AfterValidator, BaseModel
 
 from coval_bench.registries.benchmarks import Benchmark
 
@@ -43,6 +44,25 @@ class Gender(StrEnum):
 
     FEMALE = "female"
     MALE = "male"
+
+
+# What the site can draw: six hex digits, any case on the way in, lowercase at rest.
+_HEX_COLOR = re.compile(r"^#[0-9a-fA-F]{6}$")
+
+
+def normalize_hex_color(value: str | None) -> str | None:
+    """A ``#rrggbb`` color lowercased, ``None`` passed through; anything else is a ValueError."""
+    if value is None:
+        return None
+    candidate = value.strip()
+    if not _HEX_COLOR.match(candidate):
+        raise ValueError("a color is six hex digits behind a #, like #1db098")
+    return candidate.lower()
+
+
+# A model's series color as every writer accepts it: null, or #rrggbb in any case,
+# stored lowercase. One type so no body that carries a color can skip the rule.
+HexColor = Annotated[str | None, AfterValidator(normalize_hex_color)]
 
 
 class Voice(BaseModel, frozen=True, extra="forbid"):
@@ -90,3 +110,6 @@ class RegisteredModel(BaseModel, frozen=True, extra="forbid"):
     # the org its grant names, never to everyone.
     published: bool
     arena_enabled: bool = True  # in the arena roster? independent of `collected`
+    # The series color the site draws the model in, as lowercase ``#rrggbb``.
+    # None means the site picks one from its built-in palette.
+    color: HexColor = None

--- a/runner/tests/api/conftest.py
+++ b/runner/tests/api/conftest.py
@@ -341,6 +341,7 @@ def _load_schema(**connect_kwargs: Any) -> None:
                 arena_enabled boolean NOT NULL DEFAULT true,
                 collected     boolean NOT NULL,
                 published     boolean NOT NULL,
+                color         text CHECK (color IS NULL OR color ~ '^#[0-9a-f]{6}$'),
                 updated_by_user_id text NOT NULL CHECK (updated_by_user_id <> ''),
                 updated_by_email   text CHECK (updated_by_email IS NULL OR updated_by_email <> ''),
                 updated_at    timestamptz NOT NULL DEFAULT now(),
@@ -440,8 +441,9 @@ def _insert_models(conn: psycopg.Connection[Any], models: Sequence[RegisteredMod
             """
             INSERT INTO benchmarks_v2.models
                 (modality, provider, model, voice, voices, creator, source, licensing,
-                 on_prem, region, arena_enabled, collected, published, updated_by_user_id)
-            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, 'tests')
+                 on_prem, region, arena_enabled, collected, published, color,
+                 updated_by_user_id)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, 'tests')
             RETURNING id
             """,
             (
@@ -458,6 +460,7 @@ def _insert_models(conn: psycopg.Connection[Any], models: Sequence[RegisteredMod
                 model.arena_enabled,
                 model.collected,
                 model.published,
+                model.color,
             ),
         ).fetchone()
         assert row is not None

--- a/runner/tests/api/test_admin_models.py
+++ b/runner/tests/api/test_admin_models.py
@@ -410,6 +410,47 @@ async def test_patch_null_rules(client: AsyncClient) -> None:
     assert allowed.status_code == 200
 
 
+async def test_a_color_is_stored_lowercase_and_reaches_the_catalogue(
+    client: AsyncClient,
+) -> None:
+    """However it is typed, the row and the public roster say #rrggbb in lowercase."""
+    created = (await _post_model(client, published=True, color="#1DB098")).json()
+    assert created["color"] == "#1db098"
+    assert created["history"][0]["new"]["color"] == "#1db098"
+
+    public = (await client.get("/v1/providers")).json()
+    (entry,) = [m for e in public["stt"] for m in e["models"] if e["provider"] == "acme"]
+    assert entry["color"] == "#1db098"
+
+
+async def test_patch_sets_and_clears_the_color_with_history(client: AsyncClient) -> None:
+    created = (await _post_model(client)).json()
+    assert created["color"] is None
+
+    painted = await _patch(client, created["id"], created["updated_at"], {"color": "#FF8800"})
+    assert painted.status_code == 200
+    model = painted.json()["model"]
+    assert model["color"] == "#ff8800"
+    newest = model["history"][0]
+    assert (newest["old"]["color"], newest["new"]["color"]) == (None, "#ff8800")
+
+    # Null is a value here: the model goes back to the site's palette.
+    cleared = await _patch(client, created["id"], model["updated_at"], {"color": None})
+    assert cleared.status_code == 200
+    model = cleared.json()["model"]
+    assert model["color"] is None
+    assert model["history"][0]["old"]["color"] == "#ff8800"
+    assert len(model["history"]) == 3  # create, paint, clear
+
+
+@pytest.mark.parametrize("color", ["1db098", "#1db09", "#1db0988", "#gggggg", "", "teal"])
+async def test_a_color_is_six_hex_digits_or_nothing(client: AsyncClient, color: str) -> None:
+    assert (await _post_model(client, color=color)).status_code == 422
+    created = (await _post_model(client)).json()
+    response = await _patch(client, created["id"], created["updated_at"], {"color": color})
+    assert response.status_code == 422
+
+
 async def test_patch_unknown_model_is_404(client: AsyncClient) -> None:
     created = (await _post_model(client)).json()
     response = await _patch(client, created["id"] + 1, created["updated_at"], {})

--- a/runner/tests/api/test_providers.py
+++ b/runner/tests/api/test_providers.py
@@ -11,12 +11,13 @@ from __future__ import annotations
 
 from typing import Any, cast
 
+import psycopg
 import pytest
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
 
 from coval_bench.registries import Benchmark, Licensing, RegisteredModel, Source
-from tests.api.conftest import COVAL_ORG, add_models, bearer
+from tests.api.conftest import COVAL_ORG, _make_db_url, add_models, bearer
 
 
 def _model(
@@ -89,7 +90,21 @@ async def test_providers_shape(client: AsyncClient) -> None:
     for board in ("stt", "tts", "s2s", "llm"):
         assert isinstance(data[board], list)
     first_model = data["tts"][0]["models"][0]
-    assert set(first_model) == {"model", "disabled", "early_access", "tags"}
+    assert set(first_model) == {"model", "disabled", "early_access", "tags", "color"}
+
+
+async def test_a_recorded_color_rides_along_with_the_model(
+    client: AsyncClient, postgresql: Any
+) -> None:
+    """The site draws what the registry says; a model without a color says nothing."""
+    add_models(
+        postgresql,
+        _model(Benchmark.STT, "acme", "painted", color="#1db098"),
+        _model(Benchmark.STT, "acme", "plain"),
+    )
+    public = await _public(client)
+    assert _entry(public, "acme", "painted")["color"] == "#1db098"
+    assert _entry(public, "acme", "plain")["color"] is None
 
 
 async def test_publication_alone_decides_public_visibility(
@@ -282,3 +297,18 @@ async def test_providers_without_a_database_is_503(
         app.state.pool = original_pool
 
     assert response.status_code == 503
+
+
+async def test_the_catalogue_survives_a_database_without_the_color_column(
+    client: AsyncClient, postgresql: Any
+) -> None:
+    """The API deploys ahead of migration 0029; until it runs, every color reads as unset."""
+    add_models(postgresql, _model(Benchmark.STT, "acme", "m", color="#1db098"))
+    conn = psycopg.connect(_make_db_url(postgresql))
+    try:
+        conn.execute("ALTER TABLE benchmarks_v2.models DROP COLUMN color")
+        conn.commit()
+    finally:
+        conn.close()
+    public = await _public(client)
+    assert _entry(public, "acme", "m")["color"] is None

--- a/runner/tests/unit/test_registry_store.py
+++ b/runner/tests/unit/test_registry_store.py
@@ -309,3 +309,26 @@ def test_the_modality_is_not_editable(registry_pg: psycopg.Connection[Any]) -> N
             )
 
     _with_store(registry_pg, scenario)
+
+
+def test_color_roundtrips_and_clears(registry_pg: psycopg.Connection[Any]) -> None:
+    async def scenario(store: RegistryStore) -> None:
+        created = await store.insert_model(_new_model(), **_EDITOR)
+        assert created.color is None
+        result = await store.update_model(
+            created.id, {"color": "#1db098"}, expected_updated_at=created.updated_at, **_EDITOR
+        )
+        assert result is not None
+        _, painted = result
+        assert painted.color == "#1db098"
+        assert (await store.get_model(created.id)) == painted
+        result = await store.update_model(
+            created.id, {"color": None}, expected_updated_at=painted.updated_at, **_EDITOR
+        )
+        assert result is not None
+        _, cleared = result
+        assert cleared.color is None
+        changes = await store.history(created.id)
+        assert [change.new["color"] for change in changes] == [None, "#1db098", None]
+
+    _with_store(registry_pg, scenario)


### PR DESCRIPTION
## What
<img width="1134" height="149" alt="Screenshot 2026-09-09 at 4 16 14 PM" src="https://github.com/user-attachments/assets/592dad41-0607-4254-baa5-f7960e88e92f" />

A per-model series color in the model registry, so a model can be recolored on benchmarks.coval.ai from `/admin` without a deploy.

- `models.color`: nullable text, `CHECK` lowercase `#rrggbb`. Null means the site picks the color from its compiled palette.
- Migration `20260909_0029` adds the column and seeds every registered model (101 rows) with the color the site draws it in today, so nothing changes visually the day it lands and the registry is the source of truth from then on. A model registered after the seed reads null and keeps the palette until someone records a color.
- `POST /v1/admin/models` and `PATCH /v1/admin/models/{id}` accept `color` (any case, stored lowercase; `null` clears it). Every change lands in `model_history` with the rest of the row. One `HexColor` type on the domain model carries the rule, so no body that takes a color can skip it.
- `/v1/providers` carries `color` on each model.

## Deploy

- Code first, then migrate, as usual. The registry read tolerates the window in between: on `UndefinedColumn` it re-reads without the column and every color reads as unset, so `/v1/providers` and the orchestrator roster stay up. A test drops the column to prove it. Admin writes fail until the migration has run.
- No new grants. The `api` role's existing grants on `models` cover the column.
- Downgrade drops the column and any recorded colors with it. Re-upgrading reseeds the day-one palette.

## For review

The seed pastes the site's current palette values (hex strings) into this public repo. They are the colors already visible in every public page's HTML, but the workspace rule about anything from `benchmarks-web` landing here is why it is called out.

## Verification

- 1428 tests pass, `mypy --strict` and `ruff` clean.
- Companion frontend PR: coval-ai/benchmarks-web#88. Verified end to end against this API locally: an edit in `/admin` recolors the dashboards, the model, provider, benchmark and dataset pages, and a production build serves the new color on the very next request after a save.
