### PR TITLE
Wire up per-industry instruction-adherence S2S fetch

### DIFF
--- a/runner/src/coval_bench/config.py
+++ b/runner/src/coval_bench/config.py
@@ -218,6 +218,26 @@ class Settings(BaseSettings):
     # Exhaustive: a persona absent from this map faults its provider rather than
     # counting as clean, which would be invisible in the data and the logs.
     coval_s2s_condition_personas: dict[str, str] = Field(default_factory=dict)
+    # --- Instruction-adherence-by-industry (separate Coval workspace) ---
+    # These agents, test sets and this metric live in a workspace other than the
+    # one coval_api_key defaults to, so every request for them must carry this
+    # header. Opaque id, not secret.
+    coval_s2s_industry_workspace_id: str | None = None
+    # Shared across all three industries: reads test_case.expected_behaviors, so
+    # one metric id scores every industry's test set. Opaque id, not secret.
+    coval_s2s_industry_instruction_metric_id: str | None = None
+    coval_s2s_health_test_set_id: str | None = None
+    coval_s2s_health_openai_agent_id: str | None = None
+    coval_s2s_health_grok_agent_id: str | None = None
+    coval_s2s_health_violet_agent_id: str | None = None
+    coval_s2s_home_service_test_set_id: str | None = None
+    coval_s2s_home_service_openai_agent_id: str | None = None
+    coval_s2s_home_service_grok_agent_id: str | None = None
+    coval_s2s_home_service_violet_agent_id: str | None = None
+    coval_s2s_cust_service_test_set_id: str | None = None
+    coval_s2s_cust_service_openai_agent_id: str | None = None
+    coval_s2s_cust_service_grok_agent_id: str | None = None
+    coval_s2s_cust_service_violet_agent_id: str | None = None
     # Fetch grid, in seconds, shared by the s2s-fetch and llm-fetch jobs; each job
     # sets S2S_FETCH_PERIOD_SECONDS to match its own trigger cron in benchmark-infra.
     # The 3h default is far below a daily trigger, so an unset job reads stale.

--- a/runner/src/coval_bench/s2s/conditions.py
+++ b/runner/src/coval_bench/s2s/conditions.py
@@ -27,12 +27,18 @@ __all__ = [
     "DATASET_ID_HAPPYPATH",
     "DATASET_ID_HAPPYPATH_ACCENTED",
     "DATASET_ID_HAPPYPATH_NOISY",
+    "DATASET_ID_INSTR_CUST_SERVICE",
+    "DATASET_ID_INSTR_HEALTH",
+    "DATASET_ID_INSTR_HOME_SERVICE",
     "DATASET_ID_LLM_DENTAL",
     "DATASET_ID_MULTITURN",
     "DATASET_ID_MULTITURN_NOISY",
     "DEFAULT_CONDITION",
     "FAMILY_DENTAL",
     "FAMILY_HAPPYPATH",
+    "FAMILY_INSTR_CUST_SERVICE",
+    "FAMILY_INSTR_HEALTH",
+    "FAMILY_INSTR_HOME_SERVICE",
     "FAMILY_LLM_DENTAL",
     "FAMILY_MULTITURN",
     "Condition",
@@ -67,6 +73,11 @@ FAMILY_HAPPYPATH = "s2s-happypath"
 # the one-dataset-id = one-condition = one-population anchor the metrics rest on.
 FAMILY_DENTAL = "s2s-dental"
 FAMILY_LLM_DENTAL = "llm-dental"
+# One family per industry so their instruction-adherence numbers are never
+# pooled together — each is its own board on the dashboard.
+FAMILY_INSTR_HEALTH = "instruction-adherence-health"
+FAMILY_INSTR_HOME_SERVICE = "instruction-adherence-home-service"
+FAMILY_INSTR_CUST_SERVICE = "instruction-adherence-cust-service"
 
 # Single-turn SLURP manifest (legacy, latency only) and the multi-turn Coval test
 # set, split by caller condition so background noise never pools into the clean
@@ -87,6 +98,10 @@ DATASET_ID_DENTAL_ACCENTED = "s2s-dental-accented-v1"
 # pooled with the voice rows.
 DATASET_ID_LLM_DENTAL = "llm-dental-v1"
 
+DATASET_ID_INSTR_HEALTH = "instruction-adherence-health-v1"
+DATASET_ID_INSTR_HOME_SERVICE = "instruction-adherence-home-service-v1"
+DATASET_ID_INSTR_CUST_SERVICE = "instruction-adherence-cust-service-v1"
+
 # Unlisted pairs are a configuration error, not a silent skip.
 DATASET_IDS: dict[tuple[str, Condition], str | None] = {
     (FAMILY_MULTITURN, Condition.CLEAN): DATASET_ID_MULTITURN,
@@ -100,6 +115,9 @@ DATASET_IDS: dict[tuple[str, Condition], str | None] = {
     (FAMILY_LLM_DENTAL, Condition.CLEAN): DATASET_ID_LLM_DENTAL,
     (FAMILY_LLM_DENTAL, Condition.NOISY): None,
     (FAMILY_LLM_DENTAL, Condition.ACCENTED): None,
+    (FAMILY_INSTR_HEALTH, Condition.CLEAN): DATASET_ID_INSTR_HEALTH,
+    (FAMILY_INSTR_HOME_SERVICE, Condition.CLEAN): DATASET_ID_INSTR_HOME_SERVICE,
+    (FAMILY_INSTR_CUST_SERVICE, Condition.CLEAN): DATASET_ID_INSTR_CUST_SERVICE,
 }
 
 
@@ -177,6 +195,11 @@ CONDITIONS: dict[str, DatasetMetrics] = {
         required=Metric.INSTRUCTION_FOLLOWING,
         local=frozenset({Metric.TTFT}),
     ),
+    # No V2V or interruption metric is configured for these test sets — instruction
+    # adherence is all they were scored on.
+    DATASET_ID_INSTR_HEALTH: DatasetMetrics(required=Metric.INSTRUCTION_FOLLOWING),
+    DATASET_ID_INSTR_HOME_SERVICE: DatasetMetrics(required=Metric.INSTRUCTION_FOLLOWING),
+    DATASET_ID_INSTR_CUST_SERVICE: DatasetMetrics(required=Metric.INSTRUCTION_FOLLOWING),
 }
 
 # Pre-scoping behaviour, for any dataset without an entry above.

--- a/runner/src/coval_bench/s2s/fetch_v2v.py
+++ b/runner/src/coval_bench/s2s/fetch_v2v.py
@@ -1203,7 +1203,14 @@ async def fetch_and_write_v2v(
 
     metric_id = settings.coval_s2s_latency_metric_id
     if benchmark is Benchmark.S2S and not metric_id:
-        raise RuntimeError("coval_s2s_latency_metric_id is not set")
+        # Industry specs fetch instruction adherence only (see conditions.py);
+        # only a spec still relying on the shared V2V metric makes it required.
+        v2v_spec_configured = any(
+            not spec.instruction_metric_id_attr and getattr(settings, spec.agent_id_attr, None)
+            for spec in specs
+        )
+        if v2v_spec_configured:
+            raise RuntimeError("coval_s2s_latency_metric_id is not set")
     # Instruction ingestion and the test-set filter go together: instruction
     # without the filter would pool other sims on the same agents into the S2S
     # rows. Reject a blank (misconfigured) value and require the pair; both
@@ -1288,7 +1295,9 @@ async def fetch_and_write_v2v(
                 logger.warning("test_set_unset", provider=spec.provider, attr=spec.test_set_id_attr)
                 continue
             spec_workspace_id = (
-                getattr(settings, spec.workspace_id_attr) if spec.workspace_id_attr else None
+                (getattr(settings, spec.workspace_id_attr) or "").strip() or None
+                if spec.workspace_id_attr
+                else None
             )
             if spec.workspace_id_attr and not spec_workspace_id:
                 logger.warning(
@@ -1297,7 +1306,9 @@ async def fetch_and_write_v2v(
                 continue
             spec_metric_ids = metric_ids
             if spec.instruction_metric_id_attr:
-                spec_instruction_metric_id = getattr(settings, spec.instruction_metric_id_attr)
+                spec_instruction_metric_id = (
+                    getattr(settings, spec.instruction_metric_id_attr) or ""
+                ).strip()
                 if not spec_instruction_metric_id:
                     logger.warning(
                         "instruction_metric_id_unset",

--- a/runner/src/coval_bench/s2s/fetch_v2v.py
+++ b/runner/src/coval_bench/s2s/fetch_v2v.py
@@ -35,6 +35,9 @@ from coval_bench.s2s.conditions import (
     DATASET_ID,
     DEFAULT_CONDITION,
     FAMILY_DENTAL,
+    FAMILY_INSTR_CUST_SERVICE,
+    FAMILY_INSTR_HEALTH,
+    FAMILY_INSTR_HOME_SERVICE,
     FAMILY_LLM_DENTAL,
     FAMILY_MULTITURN,
     Condition,
@@ -69,6 +72,13 @@ class AgentSpec:
     # Whether this agent's recordings may reach the public samples card.
     publish_samples: bool = True
     benchmark: Benchmark = Benchmark.S2S
+    # Settings attr holding the Coval workspace id this agent lives in. None
+    # means the workspace coval_api_key defaults to (the existing behavior).
+    workspace_id_attr: str | None = None
+    # Settings attr holding this agent's own instruction-adherence metric id,
+    # overriding the global coval_s2s_instruction_metric_id. None uses the
+    # global one.
+    instruction_metric_id_attr: str | None = None
 
 
 @dataclass(frozen=True)
@@ -129,6 +139,99 @@ AGENTS: tuple[AgentSpec, ...] = (
         test_set_id_attr="coval_s2s_dental_test_set_id",
         family=FAMILY_DENTAL,
         publish_samples=False,
+    ),
+    # Instruction adherence by industry: a separate Coval workspace, one family
+    # per industry so they're never pooled together on the dashboard. No V2V is
+    # measured here, so these never reach the public samples card.
+    AgentSpec(
+        agent_id_attr="coval_s2s_health_openai_agent_id",
+        provider="openai",
+        model="gpt-realtime",
+        test_set_id_attr="coval_s2s_health_test_set_id",
+        family=FAMILY_INSTR_HEALTH,
+        publish_samples=False,
+        workspace_id_attr="coval_s2s_industry_workspace_id",
+        instruction_metric_id_attr="coval_s2s_industry_instruction_metric_id",
+    ),
+    AgentSpec(
+        agent_id_attr="coval_s2s_health_grok_agent_id",
+        provider="xai",
+        model="grok-voice",
+        test_set_id_attr="coval_s2s_health_test_set_id",
+        family=FAMILY_INSTR_HEALTH,
+        publish_samples=False,
+        workspace_id_attr="coval_s2s_industry_workspace_id",
+        instruction_metric_id_attr="coval_s2s_industry_instruction_metric_id",
+    ),
+    AgentSpec(
+        agent_id_attr="coval_s2s_health_violet_agent_id",
+        provider="openai",
+        model="violet",
+        test_set_id_attr="coval_s2s_health_test_set_id",
+        family=FAMILY_INSTR_HEALTH,
+        publish_samples=False,
+        workspace_id_attr="coval_s2s_industry_workspace_id",
+        instruction_metric_id_attr="coval_s2s_industry_instruction_metric_id",
+    ),
+    AgentSpec(
+        agent_id_attr="coval_s2s_home_service_openai_agent_id",
+        provider="openai",
+        model="gpt-realtime",
+        test_set_id_attr="coval_s2s_home_service_test_set_id",
+        family=FAMILY_INSTR_HOME_SERVICE,
+        publish_samples=False,
+        workspace_id_attr="coval_s2s_industry_workspace_id",
+        instruction_metric_id_attr="coval_s2s_industry_instruction_metric_id",
+    ),
+    AgentSpec(
+        agent_id_attr="coval_s2s_home_service_grok_agent_id",
+        provider="xai",
+        model="grok-voice",
+        test_set_id_attr="coval_s2s_home_service_test_set_id",
+        family=FAMILY_INSTR_HOME_SERVICE,
+        publish_samples=False,
+        workspace_id_attr="coval_s2s_industry_workspace_id",
+        instruction_metric_id_attr="coval_s2s_industry_instruction_metric_id",
+    ),
+    AgentSpec(
+        agent_id_attr="coval_s2s_home_service_violet_agent_id",
+        provider="openai",
+        model="violet",
+        test_set_id_attr="coval_s2s_home_service_test_set_id",
+        family=FAMILY_INSTR_HOME_SERVICE,
+        publish_samples=False,
+        workspace_id_attr="coval_s2s_industry_workspace_id",
+        instruction_metric_id_attr="coval_s2s_industry_instruction_metric_id",
+    ),
+    AgentSpec(
+        agent_id_attr="coval_s2s_cust_service_openai_agent_id",
+        provider="openai",
+        model="gpt-realtime",
+        test_set_id_attr="coval_s2s_cust_service_test_set_id",
+        family=FAMILY_INSTR_CUST_SERVICE,
+        publish_samples=False,
+        workspace_id_attr="coval_s2s_industry_workspace_id",
+        instruction_metric_id_attr="coval_s2s_industry_instruction_metric_id",
+    ),
+    AgentSpec(
+        agent_id_attr="coval_s2s_cust_service_grok_agent_id",
+        provider="xai",
+        model="grok-voice",
+        test_set_id_attr="coval_s2s_cust_service_test_set_id",
+        family=FAMILY_INSTR_CUST_SERVICE,
+        publish_samples=False,
+        workspace_id_attr="coval_s2s_industry_workspace_id",
+        instruction_metric_id_attr="coval_s2s_industry_instruction_metric_id",
+    ),
+    AgentSpec(
+        agent_id_attr="coval_s2s_cust_service_violet_agent_id",
+        provider="openai",
+        model="violet",
+        test_set_id_attr="coval_s2s_cust_service_test_set_id",
+        family=FAMILY_INSTR_CUST_SERVICE,
+        publish_samples=False,
+        workspace_id_attr="coval_s2s_industry_workspace_id",
+        instruction_metric_id_attr="coval_s2s_industry_instruction_metric_id",
     ),
 )
 
@@ -280,6 +383,7 @@ async def recent_completed_runs(
     window_seconds: int | None = None,
     page_size: int = WINDOW_PAGE_SIZE,
     requested_run_ids: frozenset[str] | None = None,
+    workspace_id: str | None = None,
 ) -> list[CovalRun]:
     """Completed Coval runs for one agent within the ingest window, newest first.
 
@@ -287,7 +391,8 @@ async def recent_completed_runs(
     (tags are not filterable). ``test_set_id`` narrows to one test set so other
     sims on the same agents (e.g. the single-turn set) are not ingested. Runs
     without a parseable create_time are kept: better to ingest with a fetch-time
-    slot than to drop data.
+    slot than to drop data. ``workspace_id`` is required for an agent that does
+    not live in the workspace the client's API key defaults to.
     """
     window = window_seconds or max(WINDOW_FLOOR_SECONDS, 2 * period_seconds)
     filt = f'status="COMPLETED" AND agent_id="{agent_id}"'
@@ -297,6 +402,7 @@ async def recent_completed_runs(
     runs: list[CovalRun] = []
     page_token: str | None = None
     found_ids: set[str] = set()
+    headers = {"X-Coval-Workspace-Id": workspace_id} if workspace_id else None
     while True:
         params: dict[str, str | int] = {
             "filter": filt,
@@ -305,7 +411,7 @@ async def recent_completed_runs(
         }
         if page_token:
             params["page_token"] = page_token
-        resp = await client.get("/runs", params=params)
+        resp = await client.get("/runs", params=params, headers=headers)
         resp.raise_for_status()
         payload = cast("dict[str, Any]", resp.json())
         raw = cast("list[dict[str, Any]]", payload.get("runs", []))
@@ -573,6 +679,7 @@ async def _ingest_run(
     dataset_sha256: str = "",
     period_seconds: int,
     normalized_dual_write_enabled: bool = False,
+    workspace_id: str | None = None,
 ) -> RunStatus | None:
     """Ingest one Coval run into its own run row; None = skipped, nothing written.
 
@@ -587,8 +694,9 @@ async def _ingest_run(
     if pending is None:
         pending = condition.fetched | (condition.local & frozenset(_LOCAL_SOURCES))
     run_pk: int | None = None
+    headers = {"X-Coval-Workspace-Id": workspace_id} if workspace_id else None
     try:
-        resp = await client.get(f"/runs/{coval_run.run_id}")
+        resp = await client.get(f"/runs/{coval_run.run_id}", headers=headers)
         resp.raise_for_status()
         run = cast("dict[str, Any]", resp.json()["run"])
         metrics = cast("dict[str, Any]", (run.get("results") or {}).get("metrics") or {})
@@ -894,6 +1002,7 @@ async def _fetch_one_provider(
     page_size: int = WINDOW_PAGE_SIZE,
     matched_run_ids: set[str] | None = None,
     normalized_dual_write_enabled: bool = False,
+    workspace_id: str | None = None,
 ) -> tuple[RunStatus, int]:
     """Scan the window and ingest every clean, not-yet-ingested run.
 
@@ -946,6 +1055,7 @@ async def _fetch_one_provider(
             window_seconds=window_seconds,
             page_size=page_size,
             requested_run_ids=only_run_ids,
+            workspace_id=workspace_id,
         )
         data_seen = False
         newest_data_at: datetime | None = None
@@ -1008,6 +1118,7 @@ async def _fetch_one_provider(
                 dataset_sha256=dataset_sha256,
                 period_seconds=period_seconds,
                 normalized_dual_write_enabled=normalized_dual_write_enabled,
+                workspace_id=workspace_id,
             )
             if status is None:
                 continue
@@ -1176,12 +1287,35 @@ async def fetch_and_write_v2v(
             if spec.test_set_id_attr and not spec_test_set:
                 logger.warning("test_set_unset", provider=spec.provider, attr=spec.test_set_id_attr)
                 continue
-            statuses[f"{spec.provider}:{spec.model}"], ingested = await _fetch_one_provider(
+            spec_workspace_id = (
+                getattr(settings, spec.workspace_id_attr) if spec.workspace_id_attr else None
+            )
+            if spec.workspace_id_attr and not spec_workspace_id:
+                logger.warning(
+                    "workspace_id_unset", provider=spec.provider, attr=spec.workspace_id_attr
+                )
+                continue
+            spec_metric_ids = metric_ids
+            if spec.instruction_metric_id_attr:
+                spec_instruction_metric_id = getattr(settings, spec.instruction_metric_id_attr)
+                if not spec_instruction_metric_id:
+                    logger.warning(
+                        "instruction_metric_id_unset",
+                        provider=spec.provider,
+                        attr=spec.instruction_metric_id_attr,
+                    )
+                    continue
+                spec_metric_ids = {
+                    **metric_ids,
+                    Metric.INSTRUCTION_FOLLOWING: spec_instruction_metric_id,
+                }
+            status_key = f"{spec.family}:{spec.provider}:{spec.model}"
+            statuses[status_key], ingested = await _fetch_one_provider(
                 client,
                 writer,
                 spec=spec,
                 agent_id=agent_id,
-                metric_ids=metric_ids,
+                metric_ids=spec_metric_ids,
                 test_set_id=spec_test_set,
                 noisy_persona_id=noisy_persona_id,
                 persona_conditions=persona_conditions,
@@ -1193,6 +1327,7 @@ async def fetch_and_write_v2v(
                 page_size=page_size,
                 matched_run_ids=matched_run_ids,
                 normalized_dual_write_enabled=settings.normalized_dual_write_enabled,
+                workspace_id=spec_workspace_id,
             )
             total_ingested += ingested
 

--- a/runner/tests/unit/test_s2s_fetch.py
+++ b/runner/tests/unit/test_s2s_fetch.py
@@ -960,6 +960,99 @@ async def test_fetch_and_write_llm_requires_the_instruction_metric_and_dental_se
 
 
 @pytest.mark.asyncio
+async def test_industry_only_deployment_does_not_require_the_latency_metric(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An install with only industry agents configured never measures V2V.
+
+    ``coval_s2s_latency_metric_id`` would otherwise block ingestion for a
+    workspace that only ever asks Coval for instruction adherence.
+    """
+    industry_spec = next(
+        spec
+        for spec in fetch_v2v.AGENTS
+        if spec.agent_id_attr == "coval_s2s_health_openai_agent_id"
+    )
+    settings = Settings(
+        coval_s2s_health_openai_agent_id="a1",
+        coval_s2s_health_test_set_id="TS1",
+        coval_s2s_industry_workspace_id="W1",
+        coval_s2s_industry_instruction_metric_id="IID",
+    )
+
+    list_json = _list_json({"run_id": "R1", "create_time": _iso(timedelta(hours=1))})
+    values = [{"simulation_output_id": "s1", "value": "YES"}]
+    client = _fake_client(list_json, _run_json(values, metric_id="IID"))
+    writer = _stub_writer()
+
+    @contextlib.asynccontextmanager
+    async def _fake_pool(_settings: Any) -> AsyncIterator[MagicMock]:
+        yield MagicMock()
+
+    monkeypatch.setattr(fetch_v2v, "AGENTS", (industry_spec,))
+    monkeypatch.setattr(fetch_v2v, "_client", lambda _s: client)
+    monkeypatch.setattr(fetch_v2v, "lifespan_pool", _fake_pool)
+    monkeypatch.setattr(fetch_v2v, "RunWriter", lambda _pool: writer)
+
+    statuses = await fetch_v2v.fetch_and_write_v2v(settings)
+
+    key = f"{industry_spec.family}:{industry_spec.provider}:{industry_spec.model}"
+    assert statuses == {key: RunStatus.SUCCEEDED}
+    writer.record_results.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_fetch_and_write_v2v_still_requires_the_latency_metric_for_legacy_agents() -> None:
+    settings = Settings(coval_s2s_openai_agent_id="a1", coval_s2s_dental_test_set_id="TSD")
+
+    with pytest.raises(RuntimeError, match="coval_s2s_latency_metric_id is not set"):
+        await fetch_v2v.fetch_and_write_v2v(settings)
+
+
+@pytest.mark.asyncio
+async def test_blank_industry_workspace_and_instruction_metric_ids_skip_the_spec(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A whitespace-only shared industry setting must not read as configured.
+
+    Both ids are shared across every industry spec, so a blank value (rather
+    than unset) would otherwise silently send an empty workspace header or
+    mark every industry spec as measuring instruction adherence when none is
+    actually wired up, instead of the clear "*_unset" warning + skip.
+    """
+    industry_spec = next(
+        spec
+        for spec in fetch_v2v.AGENTS
+        if spec.agent_id_attr == "coval_s2s_health_openai_agent_id"
+    )
+    settings = Settings(
+        coval_s2s_health_openai_agent_id="a1",
+        coval_s2s_health_test_set_id="TS1",
+        coval_s2s_industry_workspace_id="   ",
+        coval_s2s_industry_instruction_metric_id="   ",
+    )
+
+    fetch_one = AsyncMock(return_value=(RunStatus.SUCCEEDED, 0))
+
+    @contextlib.asynccontextmanager
+    async def _fake_pool(_settings: Any) -> AsyncIterator[MagicMock]:
+        yield MagicMock()
+
+    monkeypatch.setattr(fetch_v2v, "AGENTS", (industry_spec,))
+    monkeypatch.setattr(fetch_v2v, "_client", lambda _s: _fake_client({}, {}))
+    monkeypatch.setattr(fetch_v2v, "lifespan_pool", _fake_pool)
+    monkeypatch.setattr(fetch_v2v, "RunWriter", lambda _pool: _stub_writer())
+    monkeypatch.setattr(fetch_v2v, "_fetch_one_provider", fetch_one)
+
+    with capture_logs() as logs:
+        statuses = await fetch_v2v.fetch_and_write_v2v(settings)
+
+    assert statuses == {}
+    fetch_one.assert_not_awaited()
+    assert any(log["event"] == "workspace_id_unset" for log in logs)
+
+
+@pytest.mark.asyncio
 async def test_fetch_one_provider_rejects_a_dataset_from_another_benchmark() -> None:
     writer = _stub_writer()
     list_json = _list_json({"run_id": "R1", "create_time": _iso(timedelta(hours=1))})

--- a/runner/tests/unit/test_s2s_fetch.py
+++ b/runner/tests/unit/test_s2s_fetch.py
@@ -773,7 +773,7 @@ async def test_fetch_and_write_v2v_per_provider(monkeypatch: pytest.MonkeyPatch)
     statuses = await fetch_v2v.fetch_and_write_v2v(settings)
 
     # only openai runs (gemini unset), and it fully succeeds.
-    assert statuses == {"openai:gpt-realtime": RunStatus.SUCCEEDED}
+    assert statuses == {"s2s-dental:openai:gpt-realtime": RunStatus.SUCCEEDED}
     writer.refresh_stats_matviews.assert_awaited_once()
 
 
@@ -811,7 +811,7 @@ async def test_fetch_and_write_filters_agents_and_allows_llm_without_v2v(
 
     statuses = await fetch_v2v.fetch_and_write_v2v(settings, benchmark=Benchmark.LLM)
 
-    assert statuses == {"phonely:phonely-agent": RunStatus.SUCCEEDED}
+    assert statuses == {"llm-dental:phonely:phonely-agent": RunStatus.SUCCEEDED}
     fetch_one.assert_awaited_once()
     assert fetch_one.await_args is not None
     assert fetch_one.await_args.kwargs["spec"] == fetch_v2v.llm_specs([PHONELY])[0]
@@ -1052,7 +1052,7 @@ async def test_fetch_and_write_v2v_noop_skips_matview_refresh(
 
     statuses = await fetch_v2v.fetch_and_write_v2v(settings)
 
-    assert statuses == {"openai:gpt-realtime": RunStatus.SUCCEEDED}
+    assert statuses == {"s2s-dental:openai:gpt-realtime": RunStatus.SUCCEEDED}
     writer.refresh_stats_matviews.assert_not_awaited()
 
 
@@ -2134,6 +2134,6 @@ async def test_fetch_and_write_v2v_propagates_normalized_gate(
 
     statuses = await fetch_v2v.fetch_and_write_v2v(settings)
 
-    assert statuses == {"openai:gpt-realtime": RunStatus.SUCCEEDED}
+    assert statuses == {"s2s-dental:openai:gpt-realtime": RunStatus.SUCCEEDED}
     assert fetch_one.await_args is not None
     assert fetch_one.await_args.kwargs["normalized_dual_write_enabled"] is True


### PR DESCRIPTION
Adds workspace-id support to the S2S fetch client and nine new AgentSpec entries (OpenAI RT, Grok Voice native, and anotehr agent , across healthcare, home-service, and change/cancel-order) plus three new dataset families/conditions, so instruction adherence for these three industries lands as its own board instead of pooling with the existing S2S data.

The agents, test sets, and instruction-adherence metric for these live in a separate Coval workspace (not the one the API key defaults to), so every request for them now carries an `X-Coval-Workspace-Id` header — the existing client never sent one. `AgentSpec` gained `workspace_id_attr` and `instruction_metric_id_attr`, mirroring the existing per-spec `test_set_id_attr` override pattern, so the default-workspace agents are unaffected.
