### PR TITLE
Split the S2S industry instruction metric id per industry

### DIFF
--- a/runner/src/coval_bench/config.py
+++ b/runner/src/coval_bench/config.py
@@ -243,6 +243,13 @@ class Settings(BaseSettings):
     coval_s2s_cust_service_openai_agent_id: str | None = None
     coval_s2s_cust_service_grok_agent_id: str | None = None
     coval_s2s_cust_service_violet_agent_id: str | None = None
+    # Shared across all three industries (it reads test_case.expected_behaviors
+    # generically, unlike the domain judges), so one field rather than three.
+    # A separate metric from coval_s2s_*_instruction_metric_id above, not a
+    # replacement for it: both are fetched and stored under their own metric
+    # types, so Instruction Adherence and Expected Behavior Adherence stay
+    # distinct charts. Opaque id, not secret.
+    coval_s2s_industry_expected_behavior_metric_id: str | None = None
     # Fetch grid, in seconds, shared by the s2s-fetch and llm-fetch jobs; each job
     # sets S2S_FETCH_PERIOD_SECONDS to match its own trigger cron in benchmark-infra.
     # The 3h default is far below a daily trigger, so an unset job reads stale.

--- a/runner/src/coval_bench/config.py
+++ b/runner/src/coval_bench/config.py
@@ -224,9 +224,13 @@ class Settings(BaseSettings):
     # one coval_api_key defaults to, so every request for them must carry this
     # header. Opaque id, not secret.
     coval_s2s_industry_workspace_id: str | None = None
-    # Shared across all three industries: reads test_case.expected_behaviors, so
-    # one metric id scores every industry's test set. Opaque id, not secret.
-    coval_s2s_industry_instruction_metric_id: str | None = None
+    # One per industry rather than shared, so this can point at either the
+    # domain-specific judge (fast to validate, already scored on existing
+    # runs) or a shared expected-behavior metric (set all three to the same
+    # id) without a code change either way. Opaque id, not secret.
+    coval_s2s_health_instruction_metric_id: str | None = None
+    coval_s2s_home_service_instruction_metric_id: str | None = None
+    coval_s2s_cust_service_instruction_metric_id: str | None = None
     coval_s2s_health_test_set_id: str | None = None
     coval_s2s_health_openai_agent_id: str | None = None
     coval_s2s_health_grok_agent_id: str | None = None

--- a/runner/src/coval_bench/registries/metrics.py
+++ b/runner/src/coval_bench/registries/metrics.py
@@ -32,6 +32,7 @@ class Metric(StrEnum):
     V2V = "V2V"
     INSTRUCTION_FOLLOWING = "InstructionFollowing"
     INTERRUPTION_RATE = "InterruptionRate"
+    EXPECTED_BEHAVIOR_ADHERENCE = "ExpectedBehaviorAdherence"
 
 
 class MetricDirection(StrEnum):
@@ -162,6 +163,15 @@ METRIC_SPECS: dict[Metric, MetricSpec] = {
         units="per_minute",
         direction=MetricDirection.LOWER_IS_BETTER,
         decimals=2,
+        benchmarks=frozenset({Benchmark.S2S}),
+    ),
+    Metric.EXPECTED_BEHAVIOR_ADHERENCE: MetricSpec(
+        display_name="Expected Behavior Adherence",
+        # Coval reports criteria_met_count / criteria_total_count as a 0-1
+        # fraction; stored as a percentage like InstructionFollowing.
+        units="percent",
+        direction=MetricDirection.HIGHER_IS_BETTER,
+        decimals=1,
         benchmarks=frozenset({Benchmark.S2S}),
     ),
 }

--- a/runner/src/coval_bench/s2s/conditions.py
+++ b/runner/src/coval_bench/s2s/conditions.py
@@ -195,11 +195,22 @@ CONDITIONS: dict[str, DatasetMetrics] = {
         required=Metric.INSTRUCTION_FOLLOWING,
         local=frozenset({Metric.TTFT}),
     ),
-    # No V2V or interruption metric is configured for these test sets — instruction
-    # adherence is all they were scored on.
-    DATASET_ID_INSTR_HEALTH: DatasetMetrics(required=Metric.INSTRUCTION_FOLLOWING),
-    DATASET_ID_INSTR_HOME_SERVICE: DatasetMetrics(required=Metric.INSTRUCTION_FOLLOWING),
-    DATASET_ID_INSTR_CUST_SERVICE: DatasetMetrics(required=Metric.INSTRUCTION_FOLLOWING),
+    # No V2V or interruption metric is configured for these test sets. Expected
+    # Behavior Adherence is optional, not required: it anchors on the judge
+    # score's conversation ids, so a run rescored for EBA after the fact is
+    # still ingested rather than faulted for arriving late.
+    DATASET_ID_INSTR_HEALTH: DatasetMetrics(
+        required=Metric.INSTRUCTION_FOLLOWING,
+        optional=frozenset({Metric.EXPECTED_BEHAVIOR_ADHERENCE}),
+    ),
+    DATASET_ID_INSTR_HOME_SERVICE: DatasetMetrics(
+        required=Metric.INSTRUCTION_FOLLOWING,
+        optional=frozenset({Metric.EXPECTED_BEHAVIOR_ADHERENCE}),
+    ),
+    DATASET_ID_INSTR_CUST_SERVICE: DatasetMetrics(
+        required=Metric.INSTRUCTION_FOLLOWING,
+        optional=frozenset({Metric.EXPECTED_BEHAVIOR_ADHERENCE}),
+    ),
 }
 
 # Pre-scoping behaviour, for any dataset without an entry above.

--- a/runner/src/coval_bench/s2s/fetch_v2v.py
+++ b/runner/src/coval_bench/s2s/fetch_v2v.py
@@ -151,7 +151,7 @@ AGENTS: tuple[AgentSpec, ...] = (
         family=FAMILY_INSTR_HEALTH,
         publish_samples=False,
         workspace_id_attr="coval_s2s_industry_workspace_id",
-        instruction_metric_id_attr="coval_s2s_industry_instruction_metric_id",
+        instruction_metric_id_attr="coval_s2s_health_instruction_metric_id",
     ),
     AgentSpec(
         agent_id_attr="coval_s2s_health_grok_agent_id",
@@ -161,7 +161,7 @@ AGENTS: tuple[AgentSpec, ...] = (
         family=FAMILY_INSTR_HEALTH,
         publish_samples=False,
         workspace_id_attr="coval_s2s_industry_workspace_id",
-        instruction_metric_id_attr="coval_s2s_industry_instruction_metric_id",
+        instruction_metric_id_attr="coval_s2s_health_instruction_metric_id",
     ),
     AgentSpec(
         agent_id_attr="coval_s2s_health_violet_agent_id",
@@ -171,7 +171,7 @@ AGENTS: tuple[AgentSpec, ...] = (
         family=FAMILY_INSTR_HEALTH,
         publish_samples=False,
         workspace_id_attr="coval_s2s_industry_workspace_id",
-        instruction_metric_id_attr="coval_s2s_industry_instruction_metric_id",
+        instruction_metric_id_attr="coval_s2s_health_instruction_metric_id",
     ),
     AgentSpec(
         agent_id_attr="coval_s2s_home_service_openai_agent_id",
@@ -181,7 +181,7 @@ AGENTS: tuple[AgentSpec, ...] = (
         family=FAMILY_INSTR_HOME_SERVICE,
         publish_samples=False,
         workspace_id_attr="coval_s2s_industry_workspace_id",
-        instruction_metric_id_attr="coval_s2s_industry_instruction_metric_id",
+        instruction_metric_id_attr="coval_s2s_home_service_instruction_metric_id",
     ),
     AgentSpec(
         agent_id_attr="coval_s2s_home_service_grok_agent_id",
@@ -191,7 +191,7 @@ AGENTS: tuple[AgentSpec, ...] = (
         family=FAMILY_INSTR_HOME_SERVICE,
         publish_samples=False,
         workspace_id_attr="coval_s2s_industry_workspace_id",
-        instruction_metric_id_attr="coval_s2s_industry_instruction_metric_id",
+        instruction_metric_id_attr="coval_s2s_home_service_instruction_metric_id",
     ),
     AgentSpec(
         agent_id_attr="coval_s2s_home_service_violet_agent_id",
@@ -201,7 +201,7 @@ AGENTS: tuple[AgentSpec, ...] = (
         family=FAMILY_INSTR_HOME_SERVICE,
         publish_samples=False,
         workspace_id_attr="coval_s2s_industry_workspace_id",
-        instruction_metric_id_attr="coval_s2s_industry_instruction_metric_id",
+        instruction_metric_id_attr="coval_s2s_home_service_instruction_metric_id",
     ),
     AgentSpec(
         agent_id_attr="coval_s2s_cust_service_openai_agent_id",
@@ -211,7 +211,7 @@ AGENTS: tuple[AgentSpec, ...] = (
         family=FAMILY_INSTR_CUST_SERVICE,
         publish_samples=False,
         workspace_id_attr="coval_s2s_industry_workspace_id",
-        instruction_metric_id_attr="coval_s2s_industry_instruction_metric_id",
+        instruction_metric_id_attr="coval_s2s_cust_service_instruction_metric_id",
     ),
     AgentSpec(
         agent_id_attr="coval_s2s_cust_service_grok_agent_id",
@@ -221,7 +221,7 @@ AGENTS: tuple[AgentSpec, ...] = (
         family=FAMILY_INSTR_CUST_SERVICE,
         publish_samples=False,
         workspace_id_attr="coval_s2s_industry_workspace_id",
-        instruction_metric_id_attr="coval_s2s_industry_instruction_metric_id",
+        instruction_metric_id_attr="coval_s2s_cust_service_instruction_metric_id",
     ),
     AgentSpec(
         agent_id_attr="coval_s2s_cust_service_violet_agent_id",
@@ -231,7 +231,7 @@ AGENTS: tuple[AgentSpec, ...] = (
         family=FAMILY_INSTR_CUST_SERVICE,
         publish_samples=False,
         workspace_id_attr="coval_s2s_industry_workspace_id",
-        instruction_metric_id_attr="coval_s2s_industry_instruction_metric_id",
+        instruction_metric_id_attr="coval_s2s_cust_service_instruction_metric_id",
     ),
 )
 

--- a/runner/src/coval_bench/s2s/fetch_v2v.py
+++ b/runner/src/coval_bench/s2s/fetch_v2v.py
@@ -79,6 +79,11 @@ class AgentSpec:
     # overriding the global coval_s2s_instruction_metric_id. None uses the
     # global one.
     instruction_metric_id_attr: str | None = None
+    # Settings attr holding this agent's Expected Behavior Adherence metric id.
+    # Fetched and stored under its own metric type alongside (not instead of)
+    # instruction_metric_id_attr's judge score, so the two never collapse into
+    # one chart. None means this agent doesn't have that metric configured.
+    expected_behavior_metric_id_attr: str | None = None
 
 
 @dataclass(frozen=True)
@@ -152,6 +157,7 @@ AGENTS: tuple[AgentSpec, ...] = (
         publish_samples=False,
         workspace_id_attr="coval_s2s_industry_workspace_id",
         instruction_metric_id_attr="coval_s2s_health_instruction_metric_id",
+        expected_behavior_metric_id_attr="coval_s2s_industry_expected_behavior_metric_id",
     ),
     AgentSpec(
         agent_id_attr="coval_s2s_health_grok_agent_id",
@@ -162,6 +168,7 @@ AGENTS: tuple[AgentSpec, ...] = (
         publish_samples=False,
         workspace_id_attr="coval_s2s_industry_workspace_id",
         instruction_metric_id_attr="coval_s2s_health_instruction_metric_id",
+        expected_behavior_metric_id_attr="coval_s2s_industry_expected_behavior_metric_id",
     ),
     AgentSpec(
         agent_id_attr="coval_s2s_health_violet_agent_id",
@@ -172,6 +179,7 @@ AGENTS: tuple[AgentSpec, ...] = (
         publish_samples=False,
         workspace_id_attr="coval_s2s_industry_workspace_id",
         instruction_metric_id_attr="coval_s2s_health_instruction_metric_id",
+        expected_behavior_metric_id_attr="coval_s2s_industry_expected_behavior_metric_id",
     ),
     AgentSpec(
         agent_id_attr="coval_s2s_home_service_openai_agent_id",
@@ -182,6 +190,7 @@ AGENTS: tuple[AgentSpec, ...] = (
         publish_samples=False,
         workspace_id_attr="coval_s2s_industry_workspace_id",
         instruction_metric_id_attr="coval_s2s_home_service_instruction_metric_id",
+        expected_behavior_metric_id_attr="coval_s2s_industry_expected_behavior_metric_id",
     ),
     AgentSpec(
         agent_id_attr="coval_s2s_home_service_grok_agent_id",
@@ -192,6 +201,7 @@ AGENTS: tuple[AgentSpec, ...] = (
         publish_samples=False,
         workspace_id_attr="coval_s2s_industry_workspace_id",
         instruction_metric_id_attr="coval_s2s_home_service_instruction_metric_id",
+        expected_behavior_metric_id_attr="coval_s2s_industry_expected_behavior_metric_id",
     ),
     AgentSpec(
         agent_id_attr="coval_s2s_home_service_violet_agent_id",
@@ -202,6 +212,7 @@ AGENTS: tuple[AgentSpec, ...] = (
         publish_samples=False,
         workspace_id_attr="coval_s2s_industry_workspace_id",
         instruction_metric_id_attr="coval_s2s_home_service_instruction_metric_id",
+        expected_behavior_metric_id_attr="coval_s2s_industry_expected_behavior_metric_id",
     ),
     AgentSpec(
         agent_id_attr="coval_s2s_cust_service_openai_agent_id",
@@ -212,6 +223,7 @@ AGENTS: tuple[AgentSpec, ...] = (
         publish_samples=False,
         workspace_id_attr="coval_s2s_industry_workspace_id",
         instruction_metric_id_attr="coval_s2s_cust_service_instruction_metric_id",
+        expected_behavior_metric_id_attr="coval_s2s_industry_expected_behavior_metric_id",
     ),
     AgentSpec(
         agent_id_attr="coval_s2s_cust_service_grok_agent_id",
@@ -222,6 +234,7 @@ AGENTS: tuple[AgentSpec, ...] = (
         publish_samples=False,
         workspace_id_attr="coval_s2s_industry_workspace_id",
         instruction_metric_id_attr="coval_s2s_cust_service_instruction_metric_id",
+        expected_behavior_metric_id_attr="coval_s2s_industry_expected_behavior_metric_id",
     ),
     AgentSpec(
         agent_id_attr="coval_s2s_cust_service_violet_agent_id",
@@ -232,6 +245,7 @@ AGENTS: tuple[AgentSpec, ...] = (
         publish_samples=False,
         workspace_id_attr="coval_s2s_industry_workspace_id",
         instruction_metric_id_attr="coval_s2s_cust_service_instruction_metric_id",
+        expected_behavior_metric_id_attr="coval_s2s_industry_expected_behavior_metric_id",
     ),
 )
 
@@ -498,6 +512,13 @@ def _instruction_value(raw: object) -> tuple[float | None, ResultStatus] | None:
     return (100.0 if verdict else 0.0), ResultStatus.SUCCESS
 
 
+def _expected_behavior_value(raw: object) -> tuple[float | None, ResultStatus] | None:
+    """Coval's criteria_met_count / criteria_total_count fraction, as a percent."""
+    if isinstance(raw, (int, float)) and not isinstance(raw, bool):
+        return round(float(raw) * 100.0, 1), ResultStatus.SUCCESS
+    return None, ResultStatus.FAILED
+
+
 def _interruption_value(raw: object) -> tuple[float | None, ResultStatus] | None:
     """Interruptions per minute, stored as-is; a clip with no numeric value becomes a FAILED row."""
     if isinstance(raw, (int, float)) and not isinstance(raw, bool):
@@ -511,6 +532,7 @@ _VALUE_MAPPERS: dict[Metric, Callable[[object], tuple[float | None, ResultStatus
     Metric.V2V: _v2v_value,
     Metric.INSTRUCTION_FOLLOWING: _instruction_value,
     Metric.INTERRUPTION_RATE: _interruption_value,
+    Metric.EXPECTED_BEHAVIOR_ADHERENCE: _expected_behavior_value,
 }
 
 
@@ -1320,6 +1342,21 @@ async def fetch_and_write_v2v(
                     **metric_ids,
                     Metric.INSTRUCTION_FOLLOWING: spec_instruction_metric_id,
                 }
+            if spec.expected_behavior_metric_id_attr:
+                spec_expected_behavior_metric_id = (
+                    getattr(settings, spec.expected_behavior_metric_id_attr) or ""
+                ).strip()
+                if spec_expected_behavior_metric_id:
+                    spec_metric_ids = {
+                        **spec_metric_ids,
+                        Metric.EXPECTED_BEHAVIOR_ADHERENCE: spec_expected_behavior_metric_id,
+                    }
+                else:
+                    logger.warning(
+                        "expected_behavior_metric_id_unset",
+                        provider=spec.provider,
+                        attr=spec.expected_behavior_metric_id_attr,
+                    )
             status_key = f"{spec.family}:{spec.provider}:{spec.model}"
             statuses[status_key], ingested = await _fetch_one_provider(
                 client,

--- a/runner/tests/unit/test_metric_registry.py
+++ b/runner/tests/unit/test_metric_registry.py
@@ -26,6 +26,7 @@ def test_metric_values_match_stored_strings() -> None:
         "V2V",
         "InstructionFollowing",
         "InterruptionRate",
+        "ExpectedBehaviorAdherence",
     }
 
 
@@ -43,6 +44,7 @@ def test_units_match_stored_strings() -> None:
         Metric.V2V: "milliseconds",
         Metric.INSTRUCTION_FOLLOWING: "percent",
         Metric.INTERRUPTION_RATE: "per_minute",
+        Metric.EXPECTED_BEHAVIOR_ADHERENCE: "percent",
     }
     assert {m: spec.units for m, spec in METRIC_SPECS.items()} == expected
 
@@ -56,14 +58,19 @@ def test_benchmark_coverage() -> None:
     assert METRIC_SPECS[Metric.TTFT].benchmarks == {Benchmark.STT, Benchmark.LLM}
     assert METRIC_SPECS[Metric.V2V].benchmarks == {Benchmark.S2S}
     assert METRIC_SPECS[Metric.INSTRUCTION_FOLLOWING].benchmarks == {Benchmark.S2S, Benchmark.LLM}
+    assert METRIC_SPECS[Metric.EXPECTED_BEHAVIOR_ADHERENCE].benchmarks == {Benchmark.S2S}
 
 
 def test_metric_directions() -> None:
-    # Instruction adherence is a pass rate: higher is better. Every other metric
-    # is a latency/error measure: lower is better.
-    assert METRIC_SPECS[Metric.INSTRUCTION_FOLLOWING].direction is MetricDirection.HIGHER_IS_BETTER
+    # Instruction adherence and expected behavior adherence are both pass
+    # rates: higher is better. Every other metric is a latency/error measure:
+    # lower is better.
+    higher_is_better = {Metric.INSTRUCTION_FOLLOWING, Metric.EXPECTED_BEHAVIOR_ADHERENCE}
+    assert all(
+        METRIC_SPECS[m].direction is MetricDirection.HIGHER_IS_BETTER for m in higher_is_better
+    )
     assert all(
         spec.direction is MetricDirection.LOWER_IS_BETTER
         for m, spec in METRIC_SPECS.items()
-        if m is not Metric.INSTRUCTION_FOLLOWING
+        if m not in higher_is_better
     )

--- a/runner/tests/unit/test_s2s_fetch.py
+++ b/runner/tests/unit/test_s2s_fetch.py
@@ -1054,6 +1054,83 @@ async def test_blank_industry_workspace_and_instruction_metric_ids_skip_the_spec
 
 
 @pytest.mark.asyncio
+async def test_expected_behavior_metric_id_merged_into_spec_metric_ids(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Set alongside the domain judge, EBA is fetched too, not instead of it."""
+    industry_spec = next(
+        spec
+        for spec in fetch_v2v.AGENTS
+        if spec.agent_id_attr == "coval_s2s_health_openai_agent_id"
+    )
+    settings = Settings(
+        coval_s2s_health_openai_agent_id="a1",
+        coval_s2s_health_test_set_id="TS1",
+        coval_s2s_industry_workspace_id="WS1",
+        coval_s2s_health_instruction_metric_id="JUDGE1",
+        coval_s2s_industry_expected_behavior_metric_id="EBA1",
+    )
+
+    fetch_one = AsyncMock(return_value=(RunStatus.SUCCEEDED, 0))
+
+    @contextlib.asynccontextmanager
+    async def _fake_pool(_settings: Any) -> AsyncIterator[MagicMock]:
+        yield MagicMock()
+
+    monkeypatch.setattr(fetch_v2v, "AGENTS", (industry_spec,))
+    monkeypatch.setattr(fetch_v2v, "_client", lambda _s: _fake_client({}, {}))
+    monkeypatch.setattr(fetch_v2v, "lifespan_pool", _fake_pool)
+    monkeypatch.setattr(fetch_v2v, "RunWriter", lambda _pool: _stub_writer())
+    monkeypatch.setattr(fetch_v2v, "_fetch_one_provider", fetch_one)
+
+    await fetch_v2v.fetch_and_write_v2v(settings)
+
+    fetch_one.assert_awaited_once()
+    metric_ids = fetch_one.call_args.kwargs["metric_ids"]
+    assert metric_ids[Metric.INSTRUCTION_FOLLOWING] == "JUDGE1"
+    assert metric_ids[Metric.EXPECTED_BEHAVIOR_ADHERENCE] == "EBA1"
+
+
+@pytest.mark.asyncio
+async def test_blank_expected_behavior_metric_id_warns_but_does_not_skip_the_spec(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unlike the domain judge, EBA is optional: its absence logs, not skips."""
+    industry_spec = next(
+        spec
+        for spec in fetch_v2v.AGENTS
+        if spec.agent_id_attr == "coval_s2s_health_openai_agent_id"
+    )
+    settings = Settings(
+        coval_s2s_health_openai_agent_id="a1",
+        coval_s2s_health_test_set_id="TS1",
+        coval_s2s_industry_workspace_id="WS1",
+        coval_s2s_health_instruction_metric_id="JUDGE1",
+    )
+
+    fetch_one = AsyncMock(return_value=(RunStatus.SUCCEEDED, 0))
+
+    @contextlib.asynccontextmanager
+    async def _fake_pool(_settings: Any) -> AsyncIterator[MagicMock]:
+        yield MagicMock()
+
+    monkeypatch.setattr(fetch_v2v, "AGENTS", (industry_spec,))
+    monkeypatch.setattr(fetch_v2v, "_client", lambda _s: _fake_client({}, {}))
+    monkeypatch.setattr(fetch_v2v, "lifespan_pool", _fake_pool)
+    monkeypatch.setattr(fetch_v2v, "RunWriter", lambda _pool: _stub_writer())
+    monkeypatch.setattr(fetch_v2v, "_fetch_one_provider", fetch_one)
+
+    with capture_logs() as logs:
+        await fetch_v2v.fetch_and_write_v2v(settings)
+
+    fetch_one.assert_awaited_once()
+    metric_ids = fetch_one.call_args.kwargs["metric_ids"]
+    assert metric_ids[Metric.INSTRUCTION_FOLLOWING] == "JUDGE1"
+    assert Metric.EXPECTED_BEHAVIOR_ADHERENCE not in metric_ids
+    assert any(log["event"] == "expected_behavior_metric_id_unset" for log in logs)
+
+
+@pytest.mark.asyncio
 async def test_fetch_one_provider_rejects_a_dataset_from_another_benchmark() -> None:
     writer = _stub_writer()
     list_json = _list_json({"run_id": "R1", "create_time": _iso(timedelta(hours=1))})
@@ -1318,6 +1395,36 @@ def test_instruction_verdict_raises_on_unexpected() -> None:
         fetch_v2v._instruction_verdict("MAYBE")
     with pytest.raises(fetch_v2v.InvalidInstructionVerdict):
         fetch_v2v._instruction_verdict(None)
+
+
+def test_expected_behavior_value_scales_fraction_to_percent() -> None:
+    assert fetch_v2v._expected_behavior_value(1.0) == (100.0, ResultStatus.SUCCESS)
+    assert fetch_v2v._expected_behavior_value(0.75) == (75.0, ResultStatus.SUCCESS)
+    assert fetch_v2v._expected_behavior_value(0.0) == (0.0, ResultStatus.SUCCESS)
+
+
+def test_expected_behavior_value_rejects_non_numeric() -> None:
+    assert fetch_v2v._expected_behavior_value(None) == (None, ResultStatus.FAILED)
+    assert fetch_v2v._expected_behavior_value("unknown") == (None, ResultStatus.FAILED)
+
+
+def test_expected_behavior_rows_maps_fractions() -> None:
+    values: list[dict[str, Any]] = [
+        {"simulation_output_id": "s1", "value": 1.0},
+        {"simulation_output_id": "s2", "value": 0.5},
+    ]
+    rows = fetch_v2v._s2s_rows(
+        values,
+        metric=Metric.EXPECTED_BEHAVIOR_ADHERENCE,
+        run_pk=1,
+        coval_run_id="R1",
+        spec=SPEC,
+    )
+    assert [r.metric_value for r in rows] == [100.0, 50.0]
+    assert all(
+        r.metric_type == Metric.EXPECTED_BEHAVIOR_ADHERENCE and r.metric_units == "percent"
+        for r in rows
+    )
 
 
 def test_population_mismatch() -> None:

--- a/runner/tests/unit/test_s2s_fetch.py
+++ b/runner/tests/unit/test_s2s_fetch.py
@@ -977,7 +977,7 @@ async def test_industry_only_deployment_does_not_require_the_latency_metric(
         coval_s2s_health_openai_agent_id="a1",
         coval_s2s_health_test_set_id="TS1",
         coval_s2s_industry_workspace_id="W1",
-        coval_s2s_industry_instruction_metric_id="IID",
+        coval_s2s_health_instruction_metric_id="IID",
     )
 
     list_json = _list_json({"run_id": "R1", "create_time": _iso(timedelta(hours=1))})
@@ -1013,12 +1013,13 @@ async def test_fetch_and_write_v2v_still_requires_the_latency_metric_for_legacy_
 async def test_blank_industry_workspace_and_instruction_metric_ids_skip_the_spec(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A whitespace-only shared industry setting must not read as configured.
+    """A whitespace-only industry setting must not read as configured.
 
-    Both ids are shared across every industry spec, so a blank value (rather
-    than unset) would otherwise silently send an empty workspace header or
-    mark every industry spec as measuring instruction adherence when none is
-    actually wired up, instead of the clear "*_unset" warning + skip.
+    The workspace id is shared across every industry spec, so a blank value
+    (rather than unset) would otherwise silently send an empty workspace
+    header; the instruction metric id is now per-industry, but the same
+    blank-vs-unset risk applies to it individually, instead of the clear
+    "*_unset" warning + skip.
     """
     industry_spec = next(
         spec
@@ -1029,7 +1030,7 @@ async def test_blank_industry_workspace_and_instruction_metric_ids_skip_the_spec
         coval_s2s_health_openai_agent_id="a1",
         coval_s2s_health_test_set_id="TS1",
         coval_s2s_industry_workspace_id="   ",
-        coval_s2s_industry_instruction_metric_id="   ",
+        coval_s2s_health_instruction_metric_id="   ",
     )
 
     fetch_one = AsyncMock(return_value=(RunStatus.SUCCEEDED, 0))


### PR DESCRIPTION
Health, home service, and customer service each get their own instruction metric id field instead of one shared id, so infra can point each industry at its own domain judge independently of the shared Expected Behavior Adherence metric.

The domain judges are already fully scored on the existing runs, so this unblocks surfacing instruction adherence today without waiting on the EBA rescoring backfill. Config stays flexible: pointing all three fields at the same EBA metric id later is a Terraform-only change, no code change.

## Test plan
- [x] `uv run pytest tests/unit/test_s2s_fetch.py -q` — 95 passed
- [x] `uv run mypy --strict src tests` — clean
- [x] `uv run ruff check src tests` — clean