### PR TITLE
Accept a composite judge's numeric fraction in the instruction mapper

### DIFF
--- a/runner/src/coval_bench/s2s/fetch_v2v.py
+++ b/runner/src/coval_bench/s2s/fetch_v2v.py
@@ -490,8 +490,16 @@ def _population_mismatch(
 def _instruction_value(raw: object) -> tuple[float | None, ResultStatus] | None:
     """YES -> 100.0, NO -> 0.0, UNKNOWN -> no row, so the mean is YES / (YES + NO).
 
-    Raises InvalidInstructionVerdict on any value outside the contract.
+    A numeric raw value is a composite judge's own already-computed fraction of
+    criteria met (e.g. Expected Behavior Adherence's 0-1 "percentage_of_criteria_met"),
+    not a YES/NO verdict, and is scaled to a percentage directly. Coval's binary
+    judges and composite judges report through the same metric id shape, so this
+    mapper must accept either.
+
+    Raises InvalidInstructionVerdict on a string outside YES/NO/UNKNOWN.
     """
+    if isinstance(raw, (int, float)) and not isinstance(raw, bool):
+        return round(float(raw) * 100, 2), ResultStatus.SUCCESS
     verdict = _instruction_verdict(raw)
     if verdict is None:
         return None

--- a/runner/tests/unit/test_s2s_fetch.py
+++ b/runner/tests/unit/test_s2s_fetch.py
@@ -1319,6 +1319,29 @@ def test_instruction_verdict_raises_on_unexpected() -> None:
         fetch_v2v._instruction_verdict(None)
 
 
+def test_instruction_value_scales_a_composite_judge_fraction() -> None:
+    # A composite judge (e.g. Expected Behavior Adherence) reports its own
+    # 0-1 "percentage of criteria met" through the same metric id a binary
+    # judge's YES/NO/UNKNOWN comes through, so the mapper must accept both.
+    assert fetch_v2v._instruction_value(0.4) == (40.0, ResultStatus.SUCCESS)
+    assert fetch_v2v._instruction_value(0.75) == (75.0, ResultStatus.SUCCESS)
+    assert fetch_v2v._instruction_value(1.0) == (100.0, ResultStatus.SUCCESS)
+    assert fetch_v2v._instruction_value(0) == (0.0, ResultStatus.SUCCESS)
+
+
+def test_instruction_rows_maps_a_composite_judge_fraction() -> None:
+    values: list[dict[str, Any]] = [
+        {"simulation_output_id": "s1", "value": 0.4},
+        {"simulation_output_id": "s2", "value": 0.75},
+        {"simulation_output_id": "s3", "value": 1.0},
+    ]
+    rows = fetch_v2v._s2s_rows(
+        values, metric=Metric.INSTRUCTION_FOLLOWING, run_pk=1, coval_run_id="R1", spec=SPEC
+    )
+    assert [r.metric_value for r in rows] == [40.0, 75.0, 100.0]
+    assert [r.status for r in rows] == [ResultStatus.SUCCESS] * 3
+
+
 def test_population_mismatch() -> None:
     anchor = [{"simulation_output_id": "s1"}, {"simulation_output_id": "s2"}]
     assert fetch_v2v._population_mismatch(anchor, anchor) is None


### PR DESCRIPTION
Traced real Coval data while checking alignment with a report Brooke's running: the three domain-specific instruction-following judges (Healthcare/Home Service/Customer Service) report literal `YES`/`NO`/`UNKNOWN` strings per conversation, which the existing mapper already handles correctly. Expected Behavior Adherence reports something different — its own already-computed `0-1` "percentage of criteria met" as a numeric value, through the same metric id shape. The mapper only understood the string verdict, so a numeric value raised `InvalidInstructionVerdict` on every conversation and silently discarded the whole metric for that run — as shipped in #623, wiring the industry pipeline to EBA would have ingested zero rows, with only a warning log to show for it.

Numeric raw values are now scaled directly to a percentage (`0.75` -> `75.0`) instead of being run through verdict classification; string values still go through the existing YES/NO/UNKNOWN path unchanged. Added two tests exercising the numeric branch directly and through `_s2s_rows`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)