### PR TITLE
[BENCH-868] Pass LLM Coval agent ids from sync to fetch directly

### DIFF
--- a/runner/src/coval_bench/config.py
+++ b/runner/src/coval_bench/config.py
@@ -190,10 +190,6 @@ class Settings(BaseSettings):
     coval_s2s_xai_think_fast_2_agent_id: str | None = None
     coval_s2s_gray_agent_id: str | None = None
     coval_s2s_red_agent_id: str | None = None
-    # Coval agent id for the Phonely text agent (opaque, not secret); unset skips it.
-    coval_llm_phonely_agent_id: str | None = None
-    coval_llm_openai_agent_id: str | None = None
-    coval_llm_google_agent_id: str | None = None
     # The S2S instruction-adherence metric id (opaque, not secret). Optional: the
     # fetch pulls its per-conversation scores only when set, so latency still
     # ingests without it.

--- a/runner/src/coval_bench/llm/coval_agent.py
+++ b/runner/src/coval_bench/llm/coval_agent.py
@@ -330,12 +330,12 @@ def sync_llm(dry_run: bool, test_set_id: str | None, coval_api_base: str) -> Non
                 "llm_sync_fetch_deferred", provider=provider, reason="scheduled_run_created"
             )
         else:
-            fetchable[f"coval_llm_{provider}_agent_id"] = result.agent_id
+            fetchable[provider] = result.agent_id
     if fetchable:
         from coval_bench.registries.benchmarks import Benchmark
         from coval_bench.s2s.fetch_v2v import _run_fetch
 
-        _run_fetch(Benchmark.LLM, (), 720, 100, settings=settings.model_copy(update=fetchable))
+        _run_fetch(Benchmark.LLM, (), 720, 100, settings=settings, llm_agent_ids=fetchable)
     for provider, result in results.items():
         run_logger.info(
             "llm_sync_completed",

--- a/runner/src/coval_bench/s2s/fetch_v2v.py
+++ b/runner/src/coval_bench/s2s/fetch_v2v.py
@@ -59,11 +59,12 @@ WINDOW_PAGE_SIZE = 10
 
 @dataclass(frozen=True)
 class AgentSpec:
-    """One provider: the Settings attr holding its Coval agent id + display strings."""
+    """One provider: its Coval agent id + display strings."""
 
-    agent_id_attr: str
     provider: str
     model: str
+    # None means the agent is not configured and is skipped.
+    agent_id: str | None = None
     # Settings attr holding this agent's own Coval test set id; None uses the
     # shared ``coval_s2s_test_set_id``.
     test_set_id_attr: str | None = None
@@ -95,169 +96,173 @@ class CovalRun:
     persona_id: str = ""
 
 
-# Agent ids resolved from Settings; model strings are display labels. Every agent
-# now runs the dental test set: the shared multi-turn set stays queryable but is
-# no longer written to, so a spec left on it would go stale rather than idle.
-AGENTS: tuple[AgentSpec, ...] = (
-    AgentSpec(
-        agent_id_attr="coval_s2s_openai_agent_id",
-        provider="openai",
-        model="gpt-realtime",
-        test_set_id_attr="coval_s2s_dental_test_set_id",
-        family=FAMILY_DENTAL,
-    ),
-    AgentSpec(
-        agent_id_attr="coval_s2s_gemini_agent_id",
-        provider="google",
-        model="gemini-live",
-        test_set_id_attr="coval_s2s_dental_test_set_id",
-        family=FAMILY_DENTAL,
-    ),
-    AgentSpec(
-        agent_id_attr="coval_s2s_xai_agent_id",
-        provider="xai",
-        model="grok-voice-think-fast-1.0",
-        test_set_id_attr="coval_s2s_dental_test_set_id",
-        family=FAMILY_DENTAL,
-    ),
-    AgentSpec(
-        agent_id_attr="coval_s2s_xai_think_fast_2_agent_id",
-        provider="xai",
-        model="grok-voice-think-fast-2.0",
-        test_set_id_attr="coval_s2s_dental_test_set_id",
-        family=FAMILY_DENTAL,
-    ),
-    # Pre-launch models under codenames: the provider and model strings are what
-    # land in the results table, so they carry no vendor identity of their own.
-    AgentSpec(
-        agent_id_attr="coval_s2s_gray_agent_id",
-        provider="colors",
-        model="gray",
-        test_set_id_attr="coval_s2s_dental_test_set_id",
-        family=FAMILY_DENTAL,
-        publish_samples=False,
-    ),
-    AgentSpec(
-        agent_id_attr="coval_s2s_red_agent_id",
-        provider="colors",
-        model="red",
-        test_set_id_attr="coval_s2s_dental_test_set_id",
-        family=FAMILY_DENTAL,
-        publish_samples=False,
-    ),
-    # Instruction adherence by industry: a separate Coval workspace, one family
-    # per industry so they're never pooled together on the dashboard. No V2V is
-    # measured here, so these never reach the public samples card.
-    AgentSpec(
-        agent_id_attr="coval_s2s_health_openai_agent_id",
-        provider="openai",
-        model="gpt-realtime",
-        test_set_id_attr="coval_s2s_health_test_set_id",
-        family=FAMILY_INSTR_HEALTH,
-        publish_samples=False,
-        workspace_id_attr="coval_s2s_industry_workspace_id",
-        instruction_metric_id_attr="coval_s2s_health_instruction_metric_id",
-        expected_behavior_metric_id_attr="coval_s2s_industry_expected_behavior_metric_id",
-    ),
-    AgentSpec(
-        agent_id_attr="coval_s2s_health_grok_agent_id",
-        provider="xai",
-        model="grok-voice",
-        test_set_id_attr="coval_s2s_health_test_set_id",
-        family=FAMILY_INSTR_HEALTH,
-        publish_samples=False,
-        workspace_id_attr="coval_s2s_industry_workspace_id",
-        instruction_metric_id_attr="coval_s2s_health_instruction_metric_id",
-        expected_behavior_metric_id_attr="coval_s2s_industry_expected_behavior_metric_id",
-    ),
-    AgentSpec(
-        agent_id_attr="coval_s2s_health_violet_agent_id",
-        provider="openai",
-        model="violet",
-        test_set_id_attr="coval_s2s_health_test_set_id",
-        family=FAMILY_INSTR_HEALTH,
-        publish_samples=False,
-        workspace_id_attr="coval_s2s_industry_workspace_id",
-        instruction_metric_id_attr="coval_s2s_health_instruction_metric_id",
-        expected_behavior_metric_id_attr="coval_s2s_industry_expected_behavior_metric_id",
-    ),
-    AgentSpec(
-        agent_id_attr="coval_s2s_home_service_openai_agent_id",
-        provider="openai",
-        model="gpt-realtime",
-        test_set_id_attr="coval_s2s_home_service_test_set_id",
-        family=FAMILY_INSTR_HOME_SERVICE,
-        publish_samples=False,
-        workspace_id_attr="coval_s2s_industry_workspace_id",
-        instruction_metric_id_attr="coval_s2s_home_service_instruction_metric_id",
-        expected_behavior_metric_id_attr="coval_s2s_industry_expected_behavior_metric_id",
-    ),
-    AgentSpec(
-        agent_id_attr="coval_s2s_home_service_grok_agent_id",
-        provider="xai",
-        model="grok-voice",
-        test_set_id_attr="coval_s2s_home_service_test_set_id",
-        family=FAMILY_INSTR_HOME_SERVICE,
-        publish_samples=False,
-        workspace_id_attr="coval_s2s_industry_workspace_id",
-        instruction_metric_id_attr="coval_s2s_home_service_instruction_metric_id",
-        expected_behavior_metric_id_attr="coval_s2s_industry_expected_behavior_metric_id",
-    ),
-    AgentSpec(
-        agent_id_attr="coval_s2s_home_service_violet_agent_id",
-        provider="openai",
-        model="violet",
-        test_set_id_attr="coval_s2s_home_service_test_set_id",
-        family=FAMILY_INSTR_HOME_SERVICE,
-        publish_samples=False,
-        workspace_id_attr="coval_s2s_industry_workspace_id",
-        instruction_metric_id_attr="coval_s2s_home_service_instruction_metric_id",
-        expected_behavior_metric_id_attr="coval_s2s_industry_expected_behavior_metric_id",
-    ),
-    AgentSpec(
-        agent_id_attr="coval_s2s_cust_service_openai_agent_id",
-        provider="openai",
-        model="gpt-realtime",
-        test_set_id_attr="coval_s2s_cust_service_test_set_id",
-        family=FAMILY_INSTR_CUST_SERVICE,
-        publish_samples=False,
-        workspace_id_attr="coval_s2s_industry_workspace_id",
-        instruction_metric_id_attr="coval_s2s_cust_service_instruction_metric_id",
-        expected_behavior_metric_id_attr="coval_s2s_industry_expected_behavior_metric_id",
-    ),
-    AgentSpec(
-        agent_id_attr="coval_s2s_cust_service_grok_agent_id",
-        provider="xai",
-        model="grok-voice",
-        test_set_id_attr="coval_s2s_cust_service_test_set_id",
-        family=FAMILY_INSTR_CUST_SERVICE,
-        publish_samples=False,
-        workspace_id_attr="coval_s2s_industry_workspace_id",
-        instruction_metric_id_attr="coval_s2s_cust_service_instruction_metric_id",
-        expected_behavior_metric_id_attr="coval_s2s_industry_expected_behavior_metric_id",
-    ),
-    AgentSpec(
-        agent_id_attr="coval_s2s_cust_service_violet_agent_id",
-        provider="openai",
-        model="violet",
-        test_set_id_attr="coval_s2s_cust_service_test_set_id",
-        family=FAMILY_INSTR_CUST_SERVICE,
-        publish_samples=False,
-        workspace_id_attr="coval_s2s_industry_workspace_id",
-        instruction_metric_id_attr="coval_s2s_cust_service_instruction_metric_id",
-        expected_behavior_metric_id_attr="coval_s2s_industry_expected_behavior_metric_id",
-    ),
-)
+# Model strings are display labels. Every agent runs the dental test set: the
+# shared multi-turn set stays queryable but is no longer written to, so a spec
+# left on it would go stale rather than idle.
+def s2s_specs(settings: Settings) -> tuple[AgentSpec, ...]:
+    return (
+        AgentSpec(
+            agent_id=settings.coval_s2s_openai_agent_id,
+            provider="openai",
+            model="gpt-realtime",
+            test_set_id_attr="coval_s2s_dental_test_set_id",
+            family=FAMILY_DENTAL,
+        ),
+        AgentSpec(
+            agent_id=settings.coval_s2s_gemini_agent_id,
+            provider="google",
+            model="gemini-live",
+            test_set_id_attr="coval_s2s_dental_test_set_id",
+            family=FAMILY_DENTAL,
+        ),
+        AgentSpec(
+            agent_id=settings.coval_s2s_xai_agent_id,
+            provider="xai",
+            model="grok-voice-think-fast-1.0",
+            test_set_id_attr="coval_s2s_dental_test_set_id",
+            family=FAMILY_DENTAL,
+        ),
+        AgentSpec(
+            agent_id=settings.coval_s2s_xai_think_fast_2_agent_id,
+            provider="xai",
+            model="grok-voice-think-fast-2.0",
+            test_set_id_attr="coval_s2s_dental_test_set_id",
+            family=FAMILY_DENTAL,
+        ),
+        # Pre-launch models under codenames: the provider and model strings are what
+        # land in the results table, so they carry no vendor identity of their own.
+        AgentSpec(
+            agent_id=settings.coval_s2s_gray_agent_id,
+            provider="colors",
+            model="gray",
+            test_set_id_attr="coval_s2s_dental_test_set_id",
+            family=FAMILY_DENTAL,
+            publish_samples=False,
+        ),
+        AgentSpec(
+            agent_id=settings.coval_s2s_red_agent_id,
+            provider="colors",
+            model="red",
+            test_set_id_attr="coval_s2s_dental_test_set_id",
+            family=FAMILY_DENTAL,
+            publish_samples=False,
+        ),
+        # Instruction adherence by industry: a separate Coval workspace, one family
+        # per industry so they're never pooled together on the dashboard. No V2V is
+        # measured here, so these never reach the public samples card.
+        AgentSpec(
+            agent_id=settings.coval_s2s_health_openai_agent_id,
+            provider="openai",
+            model="gpt-realtime",
+            test_set_id_attr="coval_s2s_health_test_set_id",
+            family=FAMILY_INSTR_HEALTH,
+            publish_samples=False,
+            workspace_id_attr="coval_s2s_industry_workspace_id",
+            instruction_metric_id_attr="coval_s2s_health_instruction_metric_id",
+            expected_behavior_metric_id_attr="coval_s2s_industry_expected_behavior_metric_id",
+        ),
+        AgentSpec(
+            agent_id=settings.coval_s2s_health_grok_agent_id,
+            provider="xai",
+            model="grok-voice",
+            test_set_id_attr="coval_s2s_health_test_set_id",
+            family=FAMILY_INSTR_HEALTH,
+            publish_samples=False,
+            workspace_id_attr="coval_s2s_industry_workspace_id",
+            instruction_metric_id_attr="coval_s2s_health_instruction_metric_id",
+            expected_behavior_metric_id_attr="coval_s2s_industry_expected_behavior_metric_id",
+        ),
+        AgentSpec(
+            agent_id=settings.coval_s2s_health_violet_agent_id,
+            provider="openai",
+            model="violet",
+            test_set_id_attr="coval_s2s_health_test_set_id",
+            family=FAMILY_INSTR_HEALTH,
+            publish_samples=False,
+            workspace_id_attr="coval_s2s_industry_workspace_id",
+            instruction_metric_id_attr="coval_s2s_health_instruction_metric_id",
+            expected_behavior_metric_id_attr="coval_s2s_industry_expected_behavior_metric_id",
+        ),
+        AgentSpec(
+            agent_id=settings.coval_s2s_home_service_openai_agent_id,
+            provider="openai",
+            model="gpt-realtime",
+            test_set_id_attr="coval_s2s_home_service_test_set_id",
+            family=FAMILY_INSTR_HOME_SERVICE,
+            publish_samples=False,
+            workspace_id_attr="coval_s2s_industry_workspace_id",
+            instruction_metric_id_attr="coval_s2s_home_service_instruction_metric_id",
+            expected_behavior_metric_id_attr="coval_s2s_industry_expected_behavior_metric_id",
+        ),
+        AgentSpec(
+            agent_id=settings.coval_s2s_home_service_grok_agent_id,
+            provider="xai",
+            model="grok-voice",
+            test_set_id_attr="coval_s2s_home_service_test_set_id",
+            family=FAMILY_INSTR_HOME_SERVICE,
+            publish_samples=False,
+            workspace_id_attr="coval_s2s_industry_workspace_id",
+            instruction_metric_id_attr="coval_s2s_home_service_instruction_metric_id",
+            expected_behavior_metric_id_attr="coval_s2s_industry_expected_behavior_metric_id",
+        ),
+        AgentSpec(
+            agent_id=settings.coval_s2s_home_service_violet_agent_id,
+            provider="openai",
+            model="violet",
+            test_set_id_attr="coval_s2s_home_service_test_set_id",
+            family=FAMILY_INSTR_HOME_SERVICE,
+            publish_samples=False,
+            workspace_id_attr="coval_s2s_industry_workspace_id",
+            instruction_metric_id_attr="coval_s2s_home_service_instruction_metric_id",
+            expected_behavior_metric_id_attr="coval_s2s_industry_expected_behavior_metric_id",
+        ),
+        AgentSpec(
+            agent_id=settings.coval_s2s_cust_service_openai_agent_id,
+            provider="openai",
+            model="gpt-realtime",
+            test_set_id_attr="coval_s2s_cust_service_test_set_id",
+            family=FAMILY_INSTR_CUST_SERVICE,
+            publish_samples=False,
+            workspace_id_attr="coval_s2s_industry_workspace_id",
+            instruction_metric_id_attr="coval_s2s_cust_service_instruction_metric_id",
+            expected_behavior_metric_id_attr="coval_s2s_industry_expected_behavior_metric_id",
+        ),
+        AgentSpec(
+            agent_id=settings.coval_s2s_cust_service_grok_agent_id,
+            provider="xai",
+            model="grok-voice",
+            test_set_id_attr="coval_s2s_cust_service_test_set_id",
+            family=FAMILY_INSTR_CUST_SERVICE,
+            publish_samples=False,
+            workspace_id_attr="coval_s2s_industry_workspace_id",
+            instruction_metric_id_attr="coval_s2s_cust_service_instruction_metric_id",
+            expected_behavior_metric_id_attr="coval_s2s_industry_expected_behavior_metric_id",
+        ),
+        AgentSpec(
+            agent_id=settings.coval_s2s_cust_service_violet_agent_id,
+            provider="openai",
+            model="violet",
+            test_set_id_attr="coval_s2s_cust_service_test_set_id",
+            family=FAMILY_INSTR_CUST_SERVICE,
+            publish_samples=False,
+            workspace_id_attr="coval_s2s_industry_workspace_id",
+            instruction_metric_id_attr="coval_s2s_cust_service_instruction_metric_id",
+            expected_behavior_metric_id_attr="coval_s2s_industry_expected_behavior_metric_id",
+        ),
+    )
 
 
-def llm_specs(models: Iterable[RegisteredModel]) -> tuple[AgentSpec, ...]:
+def llm_specs(
+    models: Iterable[RegisteredModel], agent_ids: Mapping[str, str] | None = None
+) -> tuple[AgentSpec, ...]:
     """Every collected LLM model, driven over the same dental set through the proxy.
 
     TTFT comes from the proxy's own turn log rather than from Coval.
     """
+    agent_ids = agent_ids or {}
     return tuple(
         AgentSpec(
-            agent_id_attr=f"coval_llm_{model.provider}_agent_id",
+            agent_id=agent_ids.get(model.provider),
             provider=model.provider,
             model=model.model,
             test_set_id_attr="coval_s2s_dental_test_set_id",
@@ -1001,8 +1006,8 @@ def _expected_sample_models(settings: Settings) -> set[tuple[str, str]]:
     """The pairs a sample must cover; a bucket short one publishes nothing."""
     return {
         (spec.provider, spec.model)
-        for spec in AGENTS
-        if getattr(settings, spec.agent_id_attr) and spec.publish_samples
+        for spec in s2s_specs(settings)
+        if spec.agent_id and spec.publish_samples
     }
 
 
@@ -1197,11 +1202,11 @@ def _require_family_test_sets(settings: Settings, specs: Sequence[AgentSpec]) ->
     never having configured it.
     """
     for spec in specs:
-        if not spec.test_set_id_attr or not getattr(settings, spec.agent_id_attr, None):
+        if not spec.test_set_id_attr or not spec.agent_id:
             continue
         if not (getattr(settings, spec.test_set_id_attr) or "").strip():
             raise RuntimeError(
-                f"{spec.test_set_id_attr} is required when {spec.agent_id_attr} is set"
+                f"{spec.test_set_id_attr} is required when the {spec.provider} agent is set"
             )
 
 
@@ -1212,6 +1217,7 @@ async def fetch_and_write_v2v(
     only_run_ids: frozenset[str] | None = None,
     window_seconds: int | None = None,
     page_size: int = WINDOW_PAGE_SIZE,
+    llm_agent_ids: Mapping[str, str] | None = None,
 ) -> dict[str, RunStatus]:
     """Ingest the selected benchmark's providers; return per-provider status.
 
@@ -1221,15 +1227,14 @@ async def fetch_and_write_v2v(
     run more often than the sims.
     """
     settings = settings or get_settings()
-    specs = tuple(spec for spec in AGENTS if spec.benchmark is benchmark)
+    specs = s2s_specs(settings) if benchmark is Benchmark.S2S else ()
 
     metric_id = settings.coval_s2s_latency_metric_id
     if benchmark is Benchmark.S2S and not metric_id:
         # Industry specs fetch instruction adherence only (see conditions.py);
         # only a spec still relying on the shared V2V metric makes it required.
         v2v_spec_configured = any(
-            not spec.instruction_metric_id_attr and getattr(settings, spec.agent_id_attr, None)
-            for spec in specs
+            not spec.instruction_metric_id_attr and spec.agent_id for spec in specs
         )
         if v2v_spec_configured:
             raise RuntimeError("coval_s2s_latency_metric_id is not set")
@@ -1295,7 +1300,7 @@ async def fetch_and_write_v2v(
 
     async with _client(settings) as client, lifespan_pool(settings) as pool:
         if benchmark is Benchmark.LLM:
-            specs = llm_specs(await fetch_models(pool))
+            specs = llm_specs(await fetch_models(pool), llm_agent_ids)
             _require_family_test_sets(settings, specs)
         writer = RunWriter(pool)
         statuses: dict[str, RunStatus] = {}
@@ -1303,9 +1308,9 @@ async def fetch_and_write_v2v(
         matched_run_ids: set[str] = set()
         sampled_runs: list[SampleRun] = []
         for spec in specs:
-            agent_id = getattr(settings, spec.agent_id_attr, None)
+            agent_id = spec.agent_id
             if not agent_id:
-                logger.warning("agent_id_unset", provider=spec.provider, attr=spec.agent_id_attr)
+                logger.warning("agent_id_unset", provider=spec.provider, model=spec.model)
                 continue
             # An agent on its own test set is skipped when that id is missing rather
             # than falling back to the shared one, which would file its runs under
@@ -1456,6 +1461,7 @@ def _run_fetch(
     page_size: int,
     *,
     settings: Settings | None = None,
+    llm_agent_ids: Mapping[str, str] | None = None,
 ) -> None:
     from coval_bench.logging import configure_logging, log_run_failed, log_run_partial
 
@@ -1472,6 +1478,7 @@ def _run_fetch(
                 only_run_ids=only_run_ids,
                 window_seconds=window_hours * 3600 if only_run_ids else None,
                 page_size=page_size if only_run_ids else WINDOW_PAGE_SIZE,
+                llm_agent_ids=llm_agent_ids,
             )
         )
     except Exception as exc:

--- a/runner/tests/unit/test_coval_agent_sync.py
+++ b/runner/tests/unit/test_coval_agent_sync.py
@@ -328,7 +328,7 @@ def test_cli_syncs_completed_runs_into_the_database(monkeypatch: pytest.MonkeyPa
 
     assert applied.exit_code == 0, applied.output
     fetch.assert_called_once()
-    assert fetch.call_args.kwargs["settings"].coval_llm_phonely_agent_id == agent_id
+    assert fetch.call_args.kwargs["llm_agent_ids"] == {"phonely": agent_id}
 
     paused = PHONELY.model_copy(update={"collected": False})
     monkeypatch.setattr(coval_agent, "load_llm_models", lambda _settings: [paused])

--- a/runner/tests/unit/test_s2s_fetch.py
+++ b/runner/tests/unit/test_s2s_fetch.py
@@ -29,6 +29,7 @@ from coval_bench.s2s.conditions import (
     DATASET_ID_MULTITURN,
     DATASET_ID_MULTITURN_NOISY,
     FAMILY_HAPPYPATH,
+    FAMILY_INSTR_HEALTH,
     FAMILY_LLM_DENTAL,
     FAMILY_MULTITURN,
     Condition,
@@ -41,7 +42,7 @@ IDS = {Metric.V2V: "MID", Metric.INSTRUCTION_FOLLOWING: "IID"}
 LATENCY_IDS = {Metric.V2V: "MID"}
 ALL_IDS = {**IDS, Metric.INTERRUPTION_RATE: "RID"}
 
-SPEC = AgentSpec(agent_id_attr="coval_s2s_openai_agent_id", provider="openai", model="gpt-realtime")
+SPEC = AgentSpec(agent_id="a1", provider="openai", model="gpt-realtime")
 PHONELY = RegisteredModel(
     benchmark=Benchmark.LLM,
     provider="phonely",
@@ -50,7 +51,7 @@ PHONELY = RegisteredModel(
     published=False,
 )
 LLM_SPEC = AgentSpec(
-    agent_id_attr="coval_s2s_openai_agent_id",
+    agent_id="a1",
     provider="phonely",
     model="phonely-agent",
     test_set_id_attr="coval_s2s_dental_test_set_id",
@@ -311,7 +312,6 @@ def test_expected_sample_models_excludes_non_publishing_agents() -> None:
         coval_s2s_openai_agent_id="a1",
         coval_s2s_gray_agent_id="a2",
         coval_s2s_red_agent_id="a3",
-        coval_llm_phonely_agent_id="a4",
     )
     expected = fetch_v2v._expected_sample_models(settings)
 
@@ -784,7 +784,6 @@ async def test_fetch_and_write_filters_agents_and_allows_llm_without_v2v(
     settings = Settings(
         coval_s2s_instruction_metric_id="IID",
         coval_s2s_openai_agent_id="s2s-agent",
-        coval_llm_phonely_agent_id="llm-agent",
         coval_s2s_dental_test_set_id="TSD",
     )
     client = _fake_client({}, {})
@@ -802,26 +801,31 @@ async def test_fetch_and_write_filters_agents_and_allows_llm_without_v2v(
         collected=False,
         published=False,
     )
-    monkeypatch.setattr(fetch_v2v, "AGENTS", (SPEC,))
+    monkeypatch.setattr(fetch_v2v, "s2s_specs", lambda _s: (SPEC,))
     monkeypatch.setattr(fetch_v2v, "fetch_models", AsyncMock(return_value=[PHONELY, paused]))
     monkeypatch.setattr(fetch_v2v, "_client", lambda _settings: client)
     monkeypatch.setattr(fetch_v2v, "lifespan_pool", _fake_pool)
     monkeypatch.setattr(fetch_v2v, "RunWriter", lambda _pool: writer)
     monkeypatch.setattr(fetch_v2v, "_fetch_one_provider", fetch_one)
 
-    statuses = await fetch_v2v.fetch_and_write_v2v(settings, benchmark=Benchmark.LLM)
+    statuses = await fetch_v2v.fetch_and_write_v2v(
+        settings, benchmark=Benchmark.LLM, llm_agent_ids={"phonely": "llm-agent"}
+    )
 
     assert statuses == {"llm-dental:phonely:phonely-agent": RunStatus.SUCCEEDED}
     fetch_one.assert_awaited_once()
     assert fetch_one.await_args is not None
-    assert fetch_one.await_args.kwargs["spec"] == fetch_v2v.llm_specs([PHONELY])[0]
+    assert fetch_one.await_args.kwargs["spec"].agent_id == "llm-agent"
+    assert fetch_one.await_args.kwargs["agent_id"] == "llm-agent"
     assert fetch_one.await_args.kwargs["metric_ids"] == {Metric.INSTRUCTION_FOLLOWING: "IID"}
 
 
 def test_phonely_spec_is_the_llm_dental_text_agent() -> None:
-    (spec,) = fetch_v2v.llm_specs([PHONELY, PHONELY.model_copy(update={"collected": False})])
+    (spec,) = fetch_v2v.llm_specs(
+        [PHONELY, PHONELY.model_copy(update={"collected": False})], {"phonely": "A1"}
+    )
     assert spec == AgentSpec(
-        agent_id_attr="coval_llm_phonely_agent_id",
+        agent_id="A1",
         provider="phonely",
         model="phonely-agent",
         test_set_id_attr="coval_s2s_dental_test_set_id",
@@ -950,12 +954,13 @@ async def test_non_clean_text_personas_are_not_ingested() -> None:
 async def test_fetch_and_write_llm_requires_the_instruction_metric_and_dental_set() -> None:
     with pytest.raises(RuntimeError, match="coval_s2s_instruction_metric_id is not set"):
         await fetch_v2v.fetch_and_write_v2v(
-            Settings(coval_llm_phonely_agent_id="a1"), benchmark=Benchmark.LLM
+            Settings(), benchmark=Benchmark.LLM, llm_agent_ids={"phonely": "a1"}
         )
     with pytest.raises(RuntimeError, match="coval_s2s_dental_test_set_id is required"):
         await fetch_v2v.fetch_and_write_v2v(
-            Settings(coval_llm_phonely_agent_id="a1", coval_s2s_instruction_metric_id="IID"),
+            Settings(coval_s2s_instruction_metric_id="IID"),
             benchmark=Benchmark.LLM,
+            llm_agent_ids={"phonely": "a1"},
         )
 
 
@@ -968,16 +973,16 @@ async def test_industry_only_deployment_does_not_require_the_latency_metric(
     ``coval_s2s_latency_metric_id`` would otherwise block ingestion for a
     workspace that only ever asks Coval for instruction adherence.
     """
-    industry_spec = next(
-        spec
-        for spec in fetch_v2v.AGENTS
-        if spec.agent_id_attr == "coval_s2s_health_openai_agent_id"
-    )
     settings = Settings(
         coval_s2s_health_openai_agent_id="a1",
         coval_s2s_health_test_set_id="TS1",
         coval_s2s_industry_workspace_id="W1",
         coval_s2s_health_instruction_metric_id="IID",
+    )
+    industry_spec = next(
+        spec
+        for spec in fetch_v2v.s2s_specs(settings)
+        if spec.family == FAMILY_INSTR_HEALTH and spec.provider == "openai"
     )
 
     list_json = _list_json({"run_id": "R1", "create_time": _iso(timedelta(hours=1))})
@@ -989,7 +994,7 @@ async def test_industry_only_deployment_does_not_require_the_latency_metric(
     async def _fake_pool(_settings: Any) -> AsyncIterator[MagicMock]:
         yield MagicMock()
 
-    monkeypatch.setattr(fetch_v2v, "AGENTS", (industry_spec,))
+    monkeypatch.setattr(fetch_v2v, "s2s_specs", lambda _s: (industry_spec,))
     monkeypatch.setattr(fetch_v2v, "_client", lambda _s: client)
     monkeypatch.setattr(fetch_v2v, "lifespan_pool", _fake_pool)
     monkeypatch.setattr(fetch_v2v, "RunWriter", lambda _pool: writer)
@@ -1021,16 +1026,16 @@ async def test_blank_industry_workspace_and_instruction_metric_ids_skip_the_spec
     blank-vs-unset risk applies to it individually, instead of the clear
     "*_unset" warning + skip.
     """
-    industry_spec = next(
-        spec
-        for spec in fetch_v2v.AGENTS
-        if spec.agent_id_attr == "coval_s2s_health_openai_agent_id"
-    )
     settings = Settings(
         coval_s2s_health_openai_agent_id="a1",
         coval_s2s_health_test_set_id="TS1",
         coval_s2s_industry_workspace_id="   ",
         coval_s2s_health_instruction_metric_id="   ",
+    )
+    industry_spec = next(
+        spec
+        for spec in fetch_v2v.s2s_specs(settings)
+        if spec.family == FAMILY_INSTR_HEALTH and spec.provider == "openai"
     )
 
     fetch_one = AsyncMock(return_value=(RunStatus.SUCCEEDED, 0))
@@ -1039,7 +1044,7 @@ async def test_blank_industry_workspace_and_instruction_metric_ids_skip_the_spec
     async def _fake_pool(_settings: Any) -> AsyncIterator[MagicMock]:
         yield MagicMock()
 
-    monkeypatch.setattr(fetch_v2v, "AGENTS", (industry_spec,))
+    monkeypatch.setattr(fetch_v2v, "s2s_specs", lambda _s: (industry_spec,))
     monkeypatch.setattr(fetch_v2v, "_client", lambda _s: _fake_client({}, {}))
     monkeypatch.setattr(fetch_v2v, "lifespan_pool", _fake_pool)
     monkeypatch.setattr(fetch_v2v, "RunWriter", lambda _pool: _stub_writer())
@@ -1058,17 +1063,17 @@ async def test_expected_behavior_metric_id_merged_into_spec_metric_ids(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Set alongside the domain judge, EBA is fetched too, not instead of it."""
-    industry_spec = next(
-        spec
-        for spec in fetch_v2v.AGENTS
-        if spec.agent_id_attr == "coval_s2s_health_openai_agent_id"
-    )
     settings = Settings(
         coval_s2s_health_openai_agent_id="a1",
         coval_s2s_health_test_set_id="TS1",
         coval_s2s_industry_workspace_id="WS1",
         coval_s2s_health_instruction_metric_id="JUDGE1",
         coval_s2s_industry_expected_behavior_metric_id="EBA1",
+    )
+    industry_spec = next(
+        spec
+        for spec in fetch_v2v.s2s_specs(settings)
+        if spec.family == FAMILY_INSTR_HEALTH and spec.provider == "openai"
     )
 
     fetch_one = AsyncMock(return_value=(RunStatus.SUCCEEDED, 0))
@@ -1077,7 +1082,7 @@ async def test_expected_behavior_metric_id_merged_into_spec_metric_ids(
     async def _fake_pool(_settings: Any) -> AsyncIterator[MagicMock]:
         yield MagicMock()
 
-    monkeypatch.setattr(fetch_v2v, "AGENTS", (industry_spec,))
+    monkeypatch.setattr(fetch_v2v, "s2s_specs", lambda _s: (industry_spec,))
     monkeypatch.setattr(fetch_v2v, "_client", lambda _s: _fake_client({}, {}))
     monkeypatch.setattr(fetch_v2v, "lifespan_pool", _fake_pool)
     monkeypatch.setattr(fetch_v2v, "RunWriter", lambda _pool: _stub_writer())
@@ -1096,16 +1101,16 @@ async def test_blank_expected_behavior_metric_id_warns_but_does_not_skip_the_spe
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Unlike the domain judge, EBA is optional: its absence logs, not skips."""
-    industry_spec = next(
-        spec
-        for spec in fetch_v2v.AGENTS
-        if spec.agent_id_attr == "coval_s2s_health_openai_agent_id"
-    )
     settings = Settings(
         coval_s2s_health_openai_agent_id="a1",
         coval_s2s_health_test_set_id="TS1",
         coval_s2s_industry_workspace_id="WS1",
         coval_s2s_health_instruction_metric_id="JUDGE1",
+    )
+    industry_spec = next(
+        spec
+        for spec in fetch_v2v.s2s_specs(settings)
+        if spec.family == FAMILY_INSTR_HEALTH and spec.provider == "openai"
     )
 
     fetch_one = AsyncMock(return_value=(RunStatus.SUCCEEDED, 0))
@@ -1114,7 +1119,7 @@ async def test_blank_expected_behavior_metric_id_warns_but_does_not_skip_the_spe
     async def _fake_pool(_settings: Any) -> AsyncIterator[MagicMock]:
         yield MagicMock()
 
-    monkeypatch.setattr(fetch_v2v, "AGENTS", (industry_spec,))
+    monkeypatch.setattr(fetch_v2v, "s2s_specs", lambda _s: (industry_spec,))
     monkeypatch.setattr(fetch_v2v, "_client", lambda _s: _fake_client({}, {}))
     monkeypatch.setattr(fetch_v2v, "lifespan_pool", _fake_pool)
     monkeypatch.setattr(fetch_v2v, "RunWriter", lambda _pool: _stub_writer())
@@ -1263,7 +1268,7 @@ async def test_embargoed_agent_never_becomes_a_sample_candidate() -> None:
         {"run_id": "R1", "create_time": _iso(timedelta(hours=1)), "error_status": "SUCCESS"}
     )
     embargoed = AgentSpec(
-        agent_id_attr="coval_s2s_gray_agent_id",
+        agent_id="g1",
         provider="colors",
         model="gray",
         publish_samples=False,


### PR DESCRIPTION
`AgentSpec` now carries the Coval agent id rather than the name of a Settings field that holds it. Both benchmarks build the same shape and the fetch reads `spec.agent_id` everywhere.

- S2S: the module-level table becomes `s2s_specs(settings)`, with each entry reading its id as a typed field (`settings.coval_s2s_openai_agent_id`). Same env vars, same behavior; a misspelled field now fails mypy instead of skipping an agent at runtime.
- LLM: `llm_specs(models, agent_ids)` takes the provider-to-id map the sync reconciled, passed through `_run_fetch` / `fetch_and_write_v2v` as `llm_agent_ids`. The three `coval_llm_*_agent_id` settings and the `model_copy(update=...)` hand-off are gone.

No runtime change: an unset id still warns and skips. Adding an LLM provider no longer needs a settings field.

Follow-up in benchmark-infra: drop the unused `coval_llm_phonely_agent_id` variable.

Makes sure that LLM and S2S models have the same AgentSpec shape. Makes it easy to, down the line, move the S2S model info into the db.