### PR TITLE
[BENCH-872] Add the tts-v2 manifest

### DIFF
--- a/runner/src/coval_bench/datasets/loader.py
+++ b/runner/src/coval_bench/datasets/loader.py
@@ -136,11 +136,8 @@ class Dataset(BaseModel):
     items: list[DatasetItem]
 
 
-class TTSDatasetItem(BaseModel):
+class TTSDatasetItem(TTSManifestItem):
     """A single TTS benchmark item (text-only, no audio to fetch)."""
-
-    testcase_id: str = Field(min_length=1)
-    transcript: str
 
 
 class TTSDataset(BaseModel):
@@ -407,12 +404,7 @@ def load_tts_dataset(
             raise TypeError(
                 f"Dataset '{dataset_id}' contains non-TTS items; use load_stt_dataset instead."
             )
-        tts_items.append(
-            TTSDatasetItem(
-                testcase_id=raw_item.testcase_id,
-                transcript=raw_item.transcript,
-            )
-        )
+        tts_items.append(TTSDatasetItem.model_validate(raw_item.model_dump()))
 
     return TTSDataset(id=manifest.id, version=manifest.version, items=tts_items)
 

--- a/runner/src/coval_bench/datasets/manifest.py
+++ b/runner/src/coval_bench/datasets/manifest.py
@@ -13,6 +13,8 @@ Schema matches ARCHITECTURE.md § "GCS dataset bucket — manifest.json schema".
 
 from __future__ import annotations
 
+from typing import Literal
+
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 
@@ -39,13 +41,38 @@ class STTManifestItem(BaseModel):
         return value
 
 
+class PhoneticControl(BaseModel):
+    """Speech-sound coverage metadata for a tts-v2 phonetic control sentence."""
+
+    model_config = ConfigDict(frozen=True)
+
+    block: int = Field(ge=1)
+    mode: str
+    focus: str
+    phones: list[str]
+    evidence: list[str]
+
+
 class TTSManifestItem(BaseModel):
-    """A single TTS prompt entry in the manifest."""
+    """A single TTS prompt entry in the manifest.
+
+    ``spoken_reference`` is the transcript written the way it sounds and is the
+    WER reference when present; tts-v1 items have none and fall back to
+    ``transcript``.
+    """
 
     model_config = ConfigDict(frozen=True)
 
     testcase_id: str = Field(min_length=1)
     transcript: str
+    spoken_reference: str | None = None
+    kind: Literal["vertical", "phonetic", "legacy"] | None = None
+    vertical: str | None = None
+    difficulty: Literal["easy", "medium", "hard"] | None = None
+    family: str | None = None
+    length_bucket: Literal["L1", "L2", "L3", "L4"] | None = None
+    tags: list[str] = Field(default_factory=list)
+    phonetic: PhoneticControl | None = None
 
 
 class Manifest(BaseModel):

--- a/runner/src/coval_bench/datasets/manifests/README.md
+++ b/runner/src/coval_bench/datasets/manifests/README.md
@@ -346,6 +346,54 @@ print(json.dumps(manifest, indent=2, ensure_ascii=False))
 
 License: `Apache-2.0`.
 
+### `tts-v2.json`
+
+**What we benchmark.** The TTS v2 authoring bank: 240 original agent-to-customer
+passages (five verticals × easy/medium/hard × four scenario families × four
+spoken-word length buckets, L1 10–20 words up to L4 200–300), 60 phonetic
+control sentences with declared ARPAbet coverage, and the 30 `tts-v1` prompts
+imported unchanged. Every new item carries a `spoken_reference`, the transcript
+written the way it sounds (`$24.50` → `twenty four dollars and fifty cents`,
+`LT-507` → `l t five oh seven`), which is the WER reference; legacy items have
+none and fall back to `transcript`. Item metadata (`kind`, `vertical`,
+`difficulty`, `family`, `length_bucket`, `tags`, `phonetic`) rides along for
+per-slice reporting.
+
+**How it is built.** The bank is authored privately as segments (literal text
+plus `{"written", "spoken"}` pairs); its own compiler joins them and emits a
+`corpus.json`. The shipped manifest is that file re-shaped to our schema, from
+the 2026-09-08 draft:
+
+```sh
+python3 -c "
+import json, sys
+records = json.load(open('corpus.json'))['records']
+items = []
+for r in records:
+    item = {'testcase_id': r['id'], 'transcript': r['text'], 'kind': r['kind']}
+    if r['spoken_reference'] is not None:
+        item['spoken_reference'] = r['spoken_reference']
+    if r['kind'] == 'vertical':
+        item.update({k: r[k] for k in ('vertical', 'difficulty', 'family', 'length_bucket', 'tags')})
+    elif r['kind'] == 'phonetic':
+        item['phonetic'] = {k: r[k] for k in ('block', 'mode', 'focus', 'phones', 'evidence')}
+    items.append(item)
+manifest = {
+    'id': 'tts-v2',
+    'version': '2.0.0',
+    'license': 'Apache-2.0',
+    'source': 'Coval TTS v2 authoring bank plus tts-v1',
+    'items': items,
+}
+print(json.dumps(manifest, indent=2, ensure_ascii=False))
+" > runner/src/coval_bench/datasets/manifests/tts-v2.json
+```
+
+`tts-v1.json` is never edited: its byte hash is what ties historical runs to
+their items.
+
+License: `Apache-2.0`.
+
 ### `s2s-v1.json`
 
 **What we benchmark.** Speech-to-speech (S2S) providers are scored on a frozen

--- a/runner/src/coval_bench/datasets/manifests/tts-v2.json
+++ b/runner/src/coval_bench/datasets/manifests/tts-v2.json
@@ -1,0 +1,5441 @@
+{
+  "id": "tts-v2",
+  "version": "2.0.0",
+  "license": "Apache-2.0",
+  "source": "Coval TTS v2 authoring bank plus tts-v1",
+  "items": [
+    {
+      "testcase_id": "tts2-hc-e-f01-L1",
+      "transcript": "I can hold the morning visit while you check your ride to the clinic.",
+      "kind": "vertical",
+      "spoken_reference": "i can hold the morning visit while you check your ride to the clinic",
+      "vertical": "healthcare",
+      "difficulty": "easy",
+      "family": "appointment",
+      "length_bucket": "L1",
+      "tags": []
+    },
+    {
+      "testcase_id": "tts2-hc-e-f01-L2",
+      "transcript": "A later visit may suit your work hours better. I can check the afternoon openings while leaving the current booking in place. Once you choose a time, the desk will send a new notice for you to keep.",
+      "kind": "vertical",
+      "spoken_reference": "a later visit may suit your work hours better i can check the afternoon openings while leaving the current booking in place once you choose a time the desk will send a new notice for you to keep",
+      "vertical": "healthcare",
+      "difficulty": "easy",
+      "family": "appointment",
+      "length_bucket": "L2",
+      "tags": [
+        "conditional"
+      ]
+    },
+    {
+      "testcase_id": "tts2-hc-e-f01-L3",
+      "transcript": "The room listed in your message has changed, but the visit time has not. You should now check in at the desk beside the main lift. From there, a staff member can show you the new room. If stairs are difficult for you, tell the desk when you arrive so they can help you find the lift entrance. I can send these directions using your usual contact method. That way, you have the new room details with you instead of relying on the earlier message.",
+      "kind": "vertical",
+      "spoken_reference": "the room listed in your message has changed but the visit time has not you should now check in at the desk beside the main lift from there a staff member can show you the new room if stairs are difficult for you tell the desk when you arrive so they can help you find the lift entrance i can send these directions using your usual contact method that way you have the new room details with you instead of relying on the earlier message",
+      "vertical": "healthcare",
+      "difficulty": "easy",
+      "family": "appointment",
+      "length_bucket": "L3",
+      "tags": [
+        "conditional",
+        "contrast"
+      ]
+    },
+    {
+      "testcase_id": "tts2-hc-e-f01-L4",
+      "transcript": "Because you're bringing someone with you, let's make the visit easier to plan. The clinic can note that a support person will attend, and the front desk can explain where you should meet. Your guest does not need a separate visit time. If you need help getting from the entrance to the desk, tell us before you travel so the staff can check what help is available.\n\nThere are two ways into this building. The main doors face the bus stop, while the side doors open toward the car park. Both lead to the same waiting room, but the walk from the side doors is shorter. Tell the desk which entrance you expect to use. That detail will appear in the visit note alongside your request for a chair near the door.\n\nYou mentioned that the early bus can be late. We can ask about a later opening, or keep the current booking while you check your ride. Nothing will change until you choose. If your guest arrives after you, the desk can point them to the waiting area once you have checked in. I can read back the travel and access notes before we finish, so you can correct anything I have misunderstood. The clinic will handle any questions about the care itself.",
+      "kind": "vertical",
+      "spoken_reference": "because you're bringing someone with you let's make the visit easier to plan the clinic can note that a support person will attend and the front desk can explain where you should meet your guest does not need a separate visit time if you need help getting from the entrance to the desk tell us before you travel so the staff can check what help is available there are two ways into this building the main doors face the bus stop while the side doors open toward the car park both lead to the same waiting room but the walk from the side doors is shorter tell the desk which entrance you expect to use that detail will appear in the visit note alongside your request for a chair near the door you mentioned that the early bus can be late we can ask about a later opening or keep the current booking while you check your ride nothing will change until you choose if your guest arrives after you the desk can point them to the waiting area once you have checked in i can read back the travel and access notes before we finish so you can correct anything i have misunderstood the clinic will handle any questions about the care itself",
+      "vertical": "healthcare",
+      "difficulty": "easy",
+      "family": "appointment",
+      "length_bucket": "L4",
+      "tags": [
+        "conditional",
+        "list"
+      ]
+    },
+    {
+      "testcase_id": "tts2-hc-e-f02-L1",
+      "transcript": "The pharmacy has your pickup ready; would you prefer directions or the store hours?",
+      "kind": "vertical",
+      "spoken_reference": "the pharmacy has your pickup ready would you prefer directions or the store hours",
+      "vertical": "healthcare",
+      "difficulty": "easy",
+      "family": "pharmacy",
+      "length_bucket": "L1",
+      "tags": []
+    },
+    {
+      "testcase_id": "tts2-hc-e-f02-L2",
+      "transcript": "I found the metformin request you asked about, but it does not show a pickup time yet. The pharmacy can check the order and contact you when it has an update. Would a phone call be easiest for you?",
+      "kind": "vertical",
+      "spoken_reference": "i found the metformin request you asked about but it does not show a pickup time yet the pharmacy can check the order and contact you when it has an update would a phone call be easiest for you",
+      "vertical": "healthcare",
+      "difficulty": "easy",
+      "family": "pharmacy",
+      "length_bucket": "L2",
+      "tags": [
+        "medication_name"
+      ]
+    },
+    {
+      "testcase_id": "tts2-hc-e-f02-L3",
+      "transcript": "Someone else may be collecting your metformin request, so the pharmacy needs to explain its pickup process before they travel. I can connect you to that branch and note that you are asking about collection by another person. The pharmacy will tell you what permission or identification it needs; I cannot confirm those requirements from this screen. It would help to have the current pickup message nearby when the team answers. They can use its store name and request details to find the right record.",
+      "kind": "vertical",
+      "spoken_reference": "someone else may be collecting your metformin request so the pharmacy needs to explain its pickup process before they travel i can connect you to that branch and note that you are asking about collection by another person the pharmacy will tell you what permission or identification it needs i cannot confirm those requirements from this screen it would help to have the current pickup message nearby when the team answers they can use its store name and request details to find the right record",
+      "vertical": "healthcare",
+      "difficulty": "easy",
+      "family": "pharmacy",
+      "length_bucket": "L3",
+      "tags": [
+        "medication_name",
+        "conditional"
+      ]
+    },
+    {
+      "testcase_id": "tts2-hc-e-f02-L4",
+      "transcript": "The two pickup messages you received refer to different orders, so you do not need to guess which one is ready. The newer message concerns metformin at the pharmacy inside the grocery store. The other message belongs to a separate request that has not been marked ready. I can help you keep those records apart while the pharmacy checks the second request.\n\nOpen the newer message and look for the store name near the top. Below it, you should see the pickup status and a way to contact that location. The grocery store and its pharmacy may close at different times, so use the pharmacy hours when planning your trip. You can ask the counter whether another person may collect the order for you and what they would need to bring.\n\nIf you want to collect both orders together, the pharmacy can tell you whether that is possible. I cannot estimate when the other request will be ready from this screen. You also mentioned that messages sometimes reach your old phone. After this call, the account team can help check the contact details used for pickup notices. Keep both messages until the records have been matched; deleting one now might make the comparison harder. Any questions about taking either medicine should go to the pharmacist, who has the information needed to discuss them with you.",
+      "kind": "vertical",
+      "spoken_reference": "the two pickup messages you received refer to different orders so you do not need to guess which one is ready the newer message concerns metformin at the pharmacy inside the grocery store the other message belongs to a separate request that has not been marked ready i can help you keep those records apart while the pharmacy checks the second request open the newer message and look for the store name near the top below it you should see the pickup status and a way to contact that location the grocery store and its pharmacy may close at different times so use the pharmacy hours when planning your trip you can ask the counter whether another person may collect the order for you and what they would need to bring if you want to collect both orders together the pharmacy can tell you whether that is possible i cannot estimate when the other request will be ready from this screen you also mentioned that messages sometimes reach your old phone after this call the account team can help check the contact details used for pickup notices keep both messages until the records have been matched deleting one now might make the comparison harder any questions about taking either medicine should go to the pharmacist who has the information needed to discuss them with you",
+      "vertical": "healthcare",
+      "difficulty": "easy",
+      "family": "pharmacy",
+      "length_bucket": "L4",
+      "tags": [
+        "medication_name",
+        "contrast",
+        "conditional"
+      ]
+    },
+    {
+      "testcase_id": "tts2-hc-e-f03-L1",
+      "transcript": "Let's check which office should receive your paperwork before I send the referral.",
+      "kind": "vertical",
+      "spoken_reference": "let's check which office should receive your paperwork before i send the referral",
+      "vertical": "healthcare",
+      "difficulty": "easy",
+      "family": "referral",
+      "length_bucket": "L1",
+      "tags": []
+    },
+    {
+      "testcase_id": "tts2-hc-e-f03-L2",
+      "transcript": "The office tried to reach you while you were at work. I can note a better time for a callback and ask the referral desk to try again. You do not need to send the paperwork a second time.",
+      "kind": "vertical",
+      "spoken_reference": "the office tried to reach you while you were at work i can note a better time for a callback and ask the referral desk to try again you do not need to send the paperwork a second time",
+      "vertical": "healthcare",
+      "difficulty": "easy",
+      "family": "referral",
+      "length_bucket": "L2",
+      "tags": [
+        "conditional"
+      ]
+    },
+    {
+      "testcase_id": "tts2-hc-e-f03-L3",
+      "transcript": "The receiving office found the first page of your referral, but the remaining pages did not come through clearly. You do not need to rewrite them. I can ask the clinic that sent the packet to send a clearer copy and confirm when it has arrived. The note will explain that this is a replacement for an unreadable copy, not a new referral. Keep the current message until the office responds, so you can compare the office name and follow the progress of the same request.",
+      "kind": "vertical",
+      "spoken_reference": "the receiving office found the first page of your referral but the remaining pages did not come through clearly you do not need to rewrite them i can ask the clinic that sent the packet to send a clearer copy and confirm when it has arrived the note will explain that this is a replacement for an unreadable copy not a new referral keep the current message until the office responds so you can compare the office name and follow the progress of the same request",
+      "vertical": "healthcare",
+      "difficulty": "easy",
+      "family": "referral",
+      "length_bucket": "L3",
+      "tags": [
+        "contrast"
+      ]
+    },
+    {
+      "testcase_id": "tts2-hc-e-f03-L4",
+      "transcript": "The specialist office has your referral, but a visit has not been booked yet. Receiving the paperwork and setting a visit time are separate steps. You can still choose how you would like the office to contact you when it is ready to offer a time. I can add a note that phone calls are easier for you than messages in the online account.\n\nYou said your work hours change from week to week. Instead of listing a time that might be wrong later, we can ask the booking team to call before placing a visit on the calendar. They can explain the openings they have and let you check your work schedule. If they leave a message, use the callback details in that message to reach the same team.\n\nThere is also a note about the location. The office has moved, and the address on the old leaflet is no longer the one shown in your referral record. I can send the current location details through your usual contact method. Before you arrange a ride, compare those details with the place named in the booking notice. If the two do not match, call the booking team so they can sort it out. We can finish by checking your contact preference and the location note together. Neither step changes the care described in the referral.",
+      "kind": "vertical",
+      "spoken_reference": "the specialist office has your referral but a visit has not been booked yet receiving the paperwork and setting a visit time are separate steps you can still choose how you would like the office to contact you when it is ready to offer a time i can add a note that phone calls are easier for you than messages in the online account you said your work hours change from week to week instead of listing a time that might be wrong later we can ask the booking team to call before placing a visit on the calendar they can explain the openings they have and let you check your work schedule if they leave a message use the callback details in that message to reach the same team there is also a note about the location the office has moved and the address on the old leaflet is no longer the one shown in your referral record i can send the current location details through your usual contact method before you arrange a ride compare those details with the place named in the booking notice if the two do not match call the booking team so they can sort it out we can finish by checking your contact preference and the location note together neither step changes the care described in the referral",
+      "vertical": "healthcare",
+      "difficulty": "easy",
+      "family": "referral",
+      "length_bucket": "L4",
+      "tags": [
+        "conditional",
+        "contrast",
+        "list"
+      ]
+    },
+    {
+      "testcase_id": "tts2-hc-e-f04-L1",
+      "transcript": "I found the payment you mentioned and can ask the clinic to check it.",
+      "kind": "vertical",
+      "spoken_reference": "i found the payment you mentioned and can ask the clinic to check it",
+      "vertical": "healthcare",
+      "difficulty": "easy",
+      "family": "billing",
+      "length_bucket": "L1",
+      "tags": []
+    },
+    {
+      "testcase_id": "tts2-hc-e-f04-L2",
+      "transcript": "That letter was sent before your payment arrived. I can ask billing to check the receipt and tell you whether another statement is needed. Please keep both papers together until the team finishes comparing the records.",
+      "kind": "vertical",
+      "spoken_reference": "that letter was sent before your payment arrived i can ask billing to check the receipt and tell you whether another statement is needed please keep both papers together until the team finishes comparing the records",
+      "vertical": "healthcare",
+      "difficulty": "easy",
+      "family": "billing",
+      "length_bucket": "L2",
+      "tags": [
+        "contrast"
+      ]
+    },
+    {
+      "testcase_id": "tts2-hc-e-f04-L3",
+      "transcript": "Your receipt and the paper bill show the same visit, but the receipt is more recent. Let's ask the billing team to check whether the payment has been matched to that bill. I can record the visit date and the receipt date without collecting your full payment details here. If the team needs a copy, it can explain how to send it through the clinic's usual secure method. We should wait for that comparison before treating the older paper balance as the current amount.",
+      "kind": "vertical",
+      "spoken_reference": "your receipt and the paper bill show the same visit but the receipt is more recent let's ask the billing team to check whether the payment has been matched to that bill i can record the visit date and the receipt date without collecting your full payment details here if the team needs a copy it can explain how to send it through the clinic's usual secure method we should wait for that comparison before treating the older paper balance as the current amount",
+      "vertical": "healthcare",
+      "difficulty": "easy",
+      "family": "billing",
+      "length_bucket": "L3",
+      "tags": [
+        "money",
+        "contrast"
+      ]
+    },
+    {
+      "testcase_id": "tts2-hc-e-f04-L4",
+      "transcript": "I can see why the letters were confusing: one is a bill from the clinic, and the other explains how your insurer handled the same visit. The second letter is not another request to pay the clinic. We can compare the date of the visit and the office name to make sure both letters concern the same event.\n\nYour clinic bill was printed before a recent payment reached the account. That timing can leave the paper copy showing more than the current record. I will ask the billing team to check the payment before sending an updated statement. Keep the payment receipt available, but you do not need to read your full card details to me. The billing team can explain which part of the receipt helps them match the payment.\n\nYou also asked why the office name looks different on the two letters. One uses the name of the clinic, while the other lists the group that sent the claim. We should confirm that connection rather than assume the names refer to different visits. If a line still does not match after the review, it can be listed as a separate question for the team. The next step is to compare the records, check the payment, and give you a clear account of any amount that remains. No new payment is being taken during this call.",
+      "kind": "vertical",
+      "spoken_reference": "i can see why the letters were confusing one is a bill from the clinic and the other explains how your insurer handled the same visit the second letter is not another request to pay the clinic we can compare the date of the visit and the office name to make sure both letters concern the same event your clinic bill was printed before a recent payment reached the account that timing can leave the paper copy showing more than the current record i will ask the billing team to check the payment before sending an updated statement keep the payment receipt available but you do not need to read your full card details to me the billing team can explain which part of the receipt helps them match the payment you also asked why the office name looks different on the two letters one uses the name of the clinic while the other lists the group that sent the claim we should confirm that connection rather than assume the names refer to different visits if a line still does not match after the review it can be listed as a separate question for the team the next step is to compare the records check the payment and give you a clear account of any amount that remains no new payment is being taken during this call",
+      "vertical": "healthcare",
+      "difficulty": "easy",
+      "family": "billing",
+      "length_bucket": "L4",
+      "tags": [
+        "money",
+        "contrast",
+        "conditional"
+      ]
+    },
+    {
+      "testcase_id": "tts2-hc-m-f01-L1",
+      "transcript": "Please confirm the neurology visit on October 12 before I update your calendar.",
+      "kind": "vertical",
+      "spoken_reference": "please confirm the neurology visit on october twelfth before i update your calendar",
+      "vertical": "healthcare",
+      "difficulty": "medium",
+      "family": "appointment",
+      "length_bucket": "L1",
+      "tags": [
+        "domain_term",
+        "date"
+      ]
+    },
+    {
+      "testcase_id": "tts2-hc-m-f01-L2",
+      "transcript": "An interpreter request can be added to your neurology booking at 2:15 PM. The coordinator will confirm availability separately. Shall I record your preferred language and ask for a callback before any appointment changes are made?",
+      "kind": "vertical",
+      "spoken_reference": "an interpreter request can be added to your neurology booking at two fifteen p m the coordinator will confirm availability separately shall i record your preferred language and ask for a callback before any appointment changes are made",
+      "vertical": "healthcare",
+      "difficulty": "medium",
+      "family": "appointment",
+      "length_bucket": "L2",
+      "tags": [
+        "time",
+        "domain_term",
+        "conditional"
+      ]
+    },
+    {
+      "testcase_id": "tts2-hc-m-f01-L3",
+      "transcript": "The dermatology desk can offer a cancellation opening at 3:20 PM, but it has not moved your existing appointment. You asked whether the same clinician would see you, and the booking screen does not answer that question. I can ask the coordinator to confirm the clinician and location before you decide. If the opening is taken while those details are checked, your current booking will remain in place. The coordinator should send one clear confirmation after you choose, so you are not left with conflicting reminders.",
+      "kind": "vertical",
+      "spoken_reference": "the dermatology desk can offer a cancellation opening at three twenty p m but it has not moved your existing appointment you asked whether the same clinician would see you and the booking screen does not answer that question i can ask the coordinator to confirm the clinician and location before you decide if the opening is taken while those details are checked your current booking will remain in place the coordinator should send one clear confirmation after you choose so you are not left with conflicting reminders",
+      "vertical": "healthcare",
+      "difficulty": "medium",
+      "family": "appointment",
+      "length_bucket": "L3",
+      "tags": [
+        "domain_term",
+        "time",
+        "conditional"
+      ]
+    },
+    {
+      "testcase_id": "tts2-hc-m-f01-L4",
+      "transcript": "The time inside your video link does not match the appointment notice, so let's resolve that before you rearrange your day. The neurology booking shows 10:30 AM on November 14, while the older link belongs to a visit that was moved. I can ask the booking desk to send a replacement link tied to the current appointment.\n\nYou do not need to test the camera with me during this call. The new message should explain where to find the connection check and who to contact if it fails. If you plan to use a different device, open the message on that device when you are ready to check it. A successful connection check does not mean you have joined the visit itself.\n\nWe should also confirm which contact method receives the replacement. You told me that reminders go to your phone but longer messages are easier to read on your computer. The booking desk can review those preferences without changing the visit time. If the replacement still shows a different date, leave the booking unchanged and ask the desk to compare the two notices. I will include that mismatch in the note so you do not have to explain it again. Once the desk confirms the correct link, you can use its instructions to prepare for the connection.",
+      "kind": "vertical",
+      "spoken_reference": "the time inside your video link does not match the appointment notice so let's resolve that before you rearrange your day the neurology booking shows ten thirty a m on november fourteenth while the older link belongs to a visit that was moved i can ask the booking desk to send a replacement link tied to the current appointment you do not need to test the camera with me during this call the new message should explain where to find the connection check and who to contact if it fails if you plan to use a different device open the message on that device when you are ready to check it a successful connection check does not mean you have joined the visit itself we should also confirm which contact method receives the replacement you told me that reminders go to your phone but longer messages are easier to read on your computer the booking desk can review those preferences without changing the visit time if the replacement still shows a different date leave the booking unchanged and ask the desk to compare the two notices i will include that mismatch in the note so you do not have to explain it again once the desk confirms the correct link you can use its instructions to prepare for the connection",
+      "vertical": "healthcare",
+      "difficulty": "medium",
+      "family": "appointment",
+      "length_bucket": "L4",
+      "tags": [
+        "time",
+        "date",
+        "domain_term",
+        "contrast",
+        "conditional"
+      ]
+    },
+    {
+      "testcase_id": "tts2-hc-m-f02-L1",
+      "transcript": "Would you like the pharmacy to send your atorvastatin pickup notice by text?",
+      "kind": "vertical",
+      "spoken_reference": "would you like the pharmacy to send your atorvastatin pickup notice by text",
+      "vertical": "healthcare",
+      "difficulty": "medium",
+      "family": "pharmacy",
+      "length_bucket": "L1",
+      "tags": [
+        "medication_name"
+      ]
+    },
+    {
+      "testcase_id": "tts2-hc-m-f02-L2",
+      "transcript": "The atorvastatin notice names the airport branch, while your amoxicillin message names the town center. I can ask the pharmacy to confirm those locations. Please keep the notices separate until the staff has matched each one to its request.",
+      "kind": "vertical",
+      "spoken_reference": "the atorvastatin notice names the airport branch while your amoxicillin message names the town center i can ask the pharmacy to confirm those locations please keep the notices separate until the staff has matched each one to its request",
+      "vertical": "healthcare",
+      "difficulty": "medium",
+      "family": "pharmacy",
+      "length_bucket": "L2",
+      "tags": [
+        "medication_name",
+        "contrast"
+      ]
+    },
+    {
+      "testcase_id": "tts2-hc-m-f02-L3",
+      "transcript": "The pharmacy found your amoxicillin request under a previous surname, which may explain why it did not appear in the first search. I can ask the account team to check how the two profile entries are linked. That is a record-matching request, not a change to the prescription. Keep the pickup notice available when the pharmacy calls, and explain which surname appears on it. The staff can tell you how to verify the correct profile and which contact details will receive future notices.",
+      "kind": "vertical",
+      "spoken_reference": "the pharmacy found your amoxicillin request under a previous surname which may explain why it did not appear in the first search i can ask the account team to check how the two profile entries are linked that is a record matching request not a change to the prescription keep the pickup notice available when the pharmacy calls and explain which surname appears on it the staff can tell you how to verify the correct profile and which contact details will receive future notices",
+      "vertical": "healthcare",
+      "difficulty": "medium",
+      "family": "pharmacy",
+      "length_bucket": "L3",
+      "tags": [
+        "medication_name",
+        "domain_term",
+        "contrast"
+      ]
+    },
+    {
+      "testcase_id": "tts2-hc-m-f02-L4",
+      "transcript": "Since you have moved, the pickup location on the atorvastatin notice needs attention. The notice still names the original branch, and choosing a new address in your account does not automatically move a pharmacy request. I can connect you with the pharmacy team to check whether that request can be transferred to the branch you selected.\n\nThere is already a note under reference RX-26, so please mention that reference when the team answers. It records the location question, not a promise that the transfer has been completed. The pharmacist may need to check the request before the destination branch can confirm a pickup. You should wait for that confirmation before traveling to the new location.\n\nYou also have a separate message about amoxicillin. We should leave that message attached to its own request, because the pharmacy must check each record rather than assume both have moved together. I can note that you would prefer a single callback covering both location questions. That may save you from repeating the address details to different teams.\n\nBefore I transfer the call, I will read the two branch names back to you. If either is wrong, we can correct the note now. The pharmacy team will handle any clinical questions and explain what happens next with each request.",
+      "kind": "vertical",
+      "spoken_reference": "since you have moved the pickup location on the atorvastatin notice needs attention the notice still names the original branch and choosing a new address in your account does not automatically move a pharmacy request i can connect you with the pharmacy team to check whether that request can be transferred to the branch you selected there is already a note under reference r x twenty six so please mention that reference when the team answers it records the location question not a promise that the transfer has been completed the pharmacist may need to check the request before the destination branch can confirm a pickup you should wait for that confirmation before traveling to the new location you also have a separate message about amoxicillin we should leave that message attached to its own request because the pharmacy must check each record rather than assume both have moved together i can note that you would prefer a single callback covering both location questions that may save you from repeating the address details to different teams before i transfer the call i will read the two branch names back to you if either is wrong we can correct the note now the pharmacy team will handle any clinical questions and explain what happens next with each request",
+      "vertical": "healthcare",
+      "difficulty": "medium",
+      "family": "pharmacy",
+      "length_bucket": "L4",
+      "tags": [
+        "medication_name",
+        "identifier",
+        "conditional",
+        "contrast",
+        "domain_term"
+      ]
+    },
+    {
+      "testcase_id": "tts2-hc-m-f03-L1",
+      "transcript": "I can track your cardiology referral once the receiving office confirms the fax.",
+      "kind": "vertical",
+      "spoken_reference": "i can track your cardiology referral once the receiving office confirms the fax",
+      "vertical": "healthcare",
+      "difficulty": "medium",
+      "family": "referral",
+      "length_bucket": "L1",
+      "tags": [
+        "domain_term"
+      ]
+    },
+    {
+      "testcase_id": "tts2-hc-m-f03-L2",
+      "transcript": "To trace your rheumatology referral, the coordinator needs reference RH-28 and the name of the sending clinic. I can include both in a status request, then ask whether the receiving office needs another attachment.",
+      "kind": "vertical",
+      "spoken_reference": "to trace your rheumatology referral the coordinator needs reference r h twenty eight and the name of the sending clinic i can include both in a status request then ask whether the receiving office needs another attachment",
+      "vertical": "healthcare",
+      "difficulty": "medium",
+      "family": "referral",
+      "length_bucket": "L2",
+      "tags": [
+        "domain_term",
+        "identifier"
+      ]
+    },
+    {
+      "testcase_id": "tts2-hc-m-f03-L3",
+      "transcript": "The cardiology office received your referral but cannot open the attached image file. Its acknowledgment uses reference CD-91. I will send that reference to the originating clinic and ask whether it can supply the attachment in a format the receiving office accepts. You do not need to alter the image yourself. When the clinic responds, check whether the reply confirms both transmission and readability; a message saying the file was sent does not necessarily mean the other office could view it.",
+      "kind": "vertical",
+      "spoken_reference": "the cardiology office received your referral but cannot open the attached image file its acknowledgment uses reference c d ninety one i will send that reference to the originating clinic and ask whether it can supply the attachment in a format the receiving office accepts you do not need to alter the image yourself when the clinic responds check whether the reply confirms both transmission and readability a message saying the file was sent does not necessarily mean the other office could view it",
+      "vertical": "healthcare",
+      "difficulty": "medium",
+      "family": "referral",
+      "length_bucket": "L3",
+      "tags": [
+        "domain_term",
+        "identifier",
+        "conditional"
+      ]
+    },
+    {
+      "testcase_id": "tts2-hc-m-f03-L4",
+      "transcript": "Two receiving offices are listed in your referral history, but they are handling different requests. The cardiology office acknowledged its packet on March 6. The dermatology office is still waiting for an attachment. I can help you identify which office needs a callback instead of sending the same paperwork to both.\n\nThe missing attachment is described as the referral cover sheet. That is the page containing the sending office and contact information; it is not a request for you to rewrite any medical details. The clinic that sent the packet can supply another copy. I will route a message to its referral coordinator and note that the receiving office has the rest of the documents.\n\nYour online account currently groups both requests under the same heading, which makes the status harder to follow. The acknowledgment from cardiology does not confirm that dermatology received its missing page. Keep the two notices together for now, and compare the office names when responding to either one. If a message offers a visit time, check that it names the office you intended to contact.\n\nYou asked whether you should start another referral request. We can first ask the coordinator to correct the existing packet, so the receiving office has a clear record to review. Any decision about the care described in that packet remains with your care team.",
+      "kind": "vertical",
+      "spoken_reference": "two receiving offices are listed in your referral history but they are handling different requests the cardiology office acknowledged its packet on march sixth the dermatology office is still waiting for an attachment i can help you identify which office needs a callback instead of sending the same paperwork to both the missing attachment is described as the referral cover sheet that is the page containing the sending office and contact information it is not a request for you to rewrite any medical details the clinic that sent the packet can supply another copy i will route a message to its referral coordinator and note that the receiving office has the rest of the documents your online account currently groups both requests under the same heading which makes the status harder to follow the acknowledgment from cardiology does not confirm that dermatology received its missing page keep the two notices together for now and compare the office names when responding to either one if a message offers a visit time check that it names the office you intended to contact you asked whether you should start another referral request we can first ask the coordinator to correct the existing packet so the receiving office has a clear record to review any decision about the care described in that packet remains with your care team",
+      "vertical": "healthcare",
+      "difficulty": "medium",
+      "family": "referral",
+      "length_bucket": "L4",
+      "tags": [
+        "domain_term",
+        "date",
+        "contrast",
+        "conditional"
+      ]
+    },
+    {
+      "testcase_id": "tts2-hc-m-f04-L1",
+      "transcript": "The copayment on your statement is $64.20; shall I request an itemized copy?",
+      "kind": "vertical",
+      "spoken_reference": "the copayment on your statement is sixty four dollars and twenty cents shall i request an itemized copy",
+      "vertical": "healthcare",
+      "difficulty": "medium",
+      "family": "billing",
+      "length_bucket": "L1",
+      "tags": [
+        "money",
+        "domain_term"
+      ]
+    },
+    {
+      "testcase_id": "tts2-hc-m-f04-L2",
+      "transcript": "The EOB in your account explains the insurer's claim response; it is not a second clinic invoice. I can request an itemized statement from billing so you can compare the service descriptions and ask about any mismatch.",
+      "kind": "vertical",
+      "spoken_reference": "the e o b in your account explains the insurer's claim response it is not a second clinic invoice i can request an itemized statement from billing so you can compare the service descriptions and ask about any mismatch",
+      "vertical": "healthcare",
+      "difficulty": "medium",
+      "family": "billing",
+      "length_bucket": "L2",
+      "tags": [
+        "initialism",
+        "domain_term",
+        "contrast"
+      ]
+    },
+    {
+      "testcase_id": "tts2-hc-m-f04-L3",
+      "transcript": "The $73.60 entry on your statement is labeled as an adjustment rather than a payment. I can ask the billing analyst to explain how it affects the displayed balance. You also mentioned an itemized copy from the insurer. Please keep that document separate from the clinic statement while the analyst compares the service descriptions. If the dates match but the descriptions do not, I will include that difference in the request instead of assuming the two lines mean the same thing.",
+      "kind": "vertical",
+      "spoken_reference": "the seventy three dollars and sixty cents entry on your statement is labeled as an adjustment rather than a payment i can ask the billing analyst to explain how it affects the displayed balance you also mentioned an itemized copy from the insurer please keep that document separate from the clinic statement while the analyst compares the service descriptions if the dates match but the descriptions do not i will include that difference in the request instead of assuming the two lines mean the same thing",
+      "vertical": "healthcare",
+      "difficulty": "medium",
+      "family": "billing",
+      "length_bucket": "L3",
+      "tags": [
+        "money",
+        "domain_term",
+        "contrast"
+      ]
+    },
+    {
+      "testcase_id": "tts2-hc-m-f04-L4",
+      "transcript": "The itemized copy explains why your statement has two lines for the same date. One line records the office visit, and another records a payment adjustment. They are not both new charges. I can ask the billing specialist to compare those lines with the receipt you saved from June 18.\n\nThe receipt shows a copayment of $35. The statement also has an adjustment of $12.40, but its description does not say whether that adjustment has already been applied to the displayed balance. Rather than subtracting it ourselves, we should have the specialist check how it was posted. That review can establish whether an updated statement is needed.\n\nThere is a separate question about where the copy should be sent. You requested an itemized statement for your own records, not a new claim submission. I will make that distinction in the request so the team knows which document you need. Please use the clinic's usual secure contact method if the specialist asks you to send the receipt; you do not need to share full payment details here.\n\nThe review note will list the service date, the copayment, and the adjustment description as separate points. Once the specialist responds, you can compare their explanation with both documents and ask about any line that still does not match.",
+      "kind": "vertical",
+      "spoken_reference": "the itemized copy explains why your statement has two lines for the same date one line records the office visit and another records a payment adjustment they are not both new charges i can ask the billing specialist to compare those lines with the receipt you saved from june eighteenth the receipt shows a copayment of thirty five dollars the statement also has an adjustment of twelve dollars and forty cents but its description does not say whether that adjustment has already been applied to the displayed balance rather than subtracting it ourselves we should have the specialist check how it was posted that review can establish whether an updated statement is needed there is a separate question about where the copy should be sent you requested an itemized statement for your own records not a new claim submission i will make that distinction in the request so the team knows which document you need please use the clinic's usual secure contact method if the specialist asks you to send the receipt you do not need to share full payment details here the review note will list the service date the copayment and the adjustment description as separate points once the specialist responds you can compare their explanation with both documents and ask about any line that still does not match",
+      "vertical": "healthcare",
+      "difficulty": "medium",
+      "family": "billing",
+      "length_bucket": "L4",
+      "tags": [
+        "money",
+        "domain_term",
+        "contrast",
+        "date",
+        "conditional"
+      ]
+    },
+    {
+      "testcase_id": "tts2-hc-h-f01-L1",
+      "transcript": "Before your echocardiography visit, I'll check whether the hydrochlorothiazide entry reached the intake team.",
+      "kind": "vertical",
+      "spoken_reference": "before your echocardiography visit i'll check whether the hydrochlorothiazide entry reached the intake team",
+      "vertical": "healthcare",
+      "difficulty": "hard",
+      "family": "appointment",
+      "length_bucket": "L1",
+      "tags": [
+        "medication_name",
+        "domain_term"
+      ]
+    },
+    {
+      "testcase_id": "tts2-hc-h-f01-L2",
+      "transcript": "Your ophthalmology preregistration note lists a preauthorization query beside the 8:35 AM booking. I can send that query to the coordinator and ask for confirmation of the appointment status without interpreting the clinical information in the referral.",
+      "kind": "vertical",
+      "spoken_reference": "your ophthalmology preregistration note lists a preauthorization query beside the eight thirty five a m booking i can send that query to the coordinator and ask for confirmation of the appointment status without interpreting the clinical information in the referral",
+      "vertical": "healthcare",
+      "difficulty": "hard",
+      "family": "appointment",
+      "length_bucket": "L2",
+      "tags": [
+        "domain_term",
+        "time"
+      ]
+    },
+    {
+      "testcase_id": "tts2-hc-h-f01-L3",
+      "transcript": "An endocrinology questionnaire was attached to your echocardiography booking under reference EC-640. I can ask preregistration to confirm whether the attachment belongs to that appointment. The questionnaire includes hydroxychloroquine in its medication section, but the scheduling desk should not reinterpret that entry. Your care team can verify the clinical details after the documents are matched. I will describe the attachment title and booking reference in the request, then ask which questionnaire you should receive if a replacement is necessary.",
+      "kind": "vertical",
+      "spoken_reference": "an endocrinology questionnaire was attached to your echocardiography booking under reference e c six forty i can ask preregistration to confirm whether the attachment belongs to that appointment the questionnaire includes hydroxychloroquine in its medication section but the scheduling desk should not reinterpret that entry your care team can verify the clinical details after the documents are matched i will describe the attachment title and booking reference in the request then ask which questionnaire you should receive if a replacement is necessary",
+      "vertical": "healthcare",
+      "difficulty": "hard",
+      "family": "appointment",
+      "length_bucket": "L3",
+      "tags": [
+        "domain_term",
+        "medication_name",
+        "identifier"
+      ]
+    },
+    {
+      "testcase_id": "tts2-hc-h-f01-L4",
+      "transcript": "Before your endocrinology appointment, the preregistration team needs to reconcile two versions of the intake packet. The version marked EN-47 contains your interpreter request, but the appointment screen still links to an earlier version without that note. I can flag the mismatch for the coordinator without changing anything in the clinical history.\n\nYou requested an interpreter for the conversation beginning at 1:45 PM. The coordinator must confirm that arrangement separately from the appointment itself. A reminder message showing the visit time does not establish that an interpreter has been assigned. I will ask for a clear response about both the booking and the language support request.\n\nThe packet also lists hydrochlorothiazide in the medication section. You said the spelling on your printed copy is difficult to read. Please show that copy to the care team so they can verify the entry against their records; I will not replace or interpret it from the scheduling screen. The same distinction applies to the note about a previous consultation: we can identify which document contains it, but the clinician handles its meaning.\n\nFor now, you can keep the two packet versions together and mark which one contains the interpreter request. The coordinator's reply should identify the version the office will use and explain whether any further preregistration information is needed.",
+      "kind": "vertical",
+      "spoken_reference": "before your endocrinology appointment the preregistration team needs to reconcile two versions of the intake packet the version marked e n forty seven contains your interpreter request but the appointment screen still links to an earlier version without that note i can flag the mismatch for the coordinator without changing anything in the clinical history you requested an interpreter for the conversation beginning at one forty five p m the coordinator must confirm that arrangement separately from the appointment itself a reminder message showing the visit time does not establish that an interpreter has been assigned i will ask for a clear response about both the booking and the language support request the packet also lists hydrochlorothiazide in the medication section you said the spelling on your printed copy is difficult to read please show that copy to the care team so they can verify the entry against their records i will not replace or interpret it from the scheduling screen the same distinction applies to the note about a previous consultation we can identify which document contains it but the clinician handles its meaning for now you can keep the two packet versions together and mark which one contains the interpreter request the coordinator's reply should identify the version the office will use and explain whether any further preregistration information is needed",
+      "vertical": "healthcare",
+      "difficulty": "hard",
+      "family": "appointment",
+      "length_bucket": "L4",
+      "tags": [
+        "medication_name",
+        "domain_term",
+        "time",
+        "identifier",
+        "conditional",
+        "contrast"
+      ]
+    },
+    {
+      "testcase_id": "tts2-hc-h-f02-L1",
+      "transcript": "I've located your hydroxychloroquine request; the pharmacy will verify the dispensing record before arranging pickup.",
+      "kind": "vertical",
+      "spoken_reference": "i've located your hydroxychloroquine request the pharmacy will verify the dispensing record before arranging pickup",
+      "vertical": "healthcare",
+      "difficulty": "hard",
+      "family": "pharmacy",
+      "length_bucket": "L1",
+      "tags": [
+        "medication_name",
+        "domain_term"
+      ]
+    },
+    {
+      "testcase_id": "tts2-hc-h-f02-L2",
+      "transcript": "The levothyroxine request carries reference LT-507 in your dispensing history. A separate lisinopril notification appears underneath it. I will ask the pharmacy to reconcile those entries and identify which notice describes the current pickup status.",
+      "kind": "vertical",
+      "spoken_reference": "the levothyroxine request carries reference l t five oh seven in your dispensing history a separate lisinopril notification appears underneath it i will ask the pharmacy to reconcile those entries and identify which notice describes the current pickup status",
+      "vertical": "healthcare",
+      "difficulty": "hard",
+      "family": "pharmacy",
+      "length_bucket": "L2",
+      "tags": [
+        "medication_name",
+        "identifier",
+        "domain_term"
+      ]
+    },
+    {
+      "testcase_id": "tts2-hc-h-f02-L3",
+      "transcript": "Your pharmacy callback concerns two differently dated records: an azithromycin notification from February 18 and a dexamethasone acknowledgment from March 1. The portal's combined heading does not show whether either notice has been superseded. I can ask the pharmacist to reconcile the notification history and identify the active request. Please keep the individual notices available for that conversation. I will not infer a dispensing status from the medication names or combine the entries merely because they appear under the same heading.",
+      "kind": "vertical",
+      "spoken_reference": "your pharmacy callback concerns two differently dated records an azithromycin notification from february eighteenth and a dexamethasone acknowledgment from march first the portal's combined heading does not show whether either notice has been superseded i can ask the pharmacist to reconcile the notification history and identify the active request please keep the individual notices available for that conversation i will not infer a dispensing status from the medication names or combine the entries merely because they appear under the same heading",
+      "vertical": "healthcare",
+      "difficulty": "hard",
+      "family": "pharmacy",
+      "length_bucket": "L3",
+      "tags": [
+        "medication_name",
+        "domain_term",
+        "date",
+        "contrast"
+      ]
+    },
+    {
+      "testcase_id": "tts2-hc-h-f02-L4",
+      "transcript": "I found the source of the conflicting pharmacy notices: the portal combines a hydroxychloroquine request with a separate azithromycin message under one conversation heading. The heading does not mean the requests share a status. We need the pharmacy to identify each dispensing record before you can rely on either pickup notice.\n\nThe first message carries reference HQ-318, while the second carries AZ-604. I can include both references in the callback request so the pharmacist can inspect the right entries. Please keep the messages in their current order; the date sequence may help distinguish an active request from a superseded notice. You do not need to decide which notice is correct yourself.\n\nThere is another detail worth separating. A note about insurance verification appears beneath the conversation, but this screen does not identify which request it belongs to. I will ask the pharmacy to clarify that association instead of treating the note as a result for both medicines. Neither the conversation heading nor a message preview can answer a clinical question about the medicines themselves.\n\nYou can tell the pharmacy whether a phone call or a secure message is easier for you to receive. I will record that preference alongside the two references. The callback should explain the status of each record and which branch, if any, has a confirmed pickup available.",
+      "kind": "vertical",
+      "spoken_reference": "i found the source of the conflicting pharmacy notices the portal combines a hydroxychloroquine request with a separate azithromycin message under one conversation heading the heading does not mean the requests share a status we need the pharmacy to identify each dispensing record before you can rely on either pickup notice the first message carries reference h q three eighteen while the second carries a z six oh four i can include both references in the callback request so the pharmacist can inspect the right entries please keep the messages in their current order the date sequence may help distinguish an active request from a superseded notice you do not need to decide which notice is correct yourself there is another detail worth separating a note about insurance verification appears beneath the conversation but this screen does not identify which request it belongs to i will ask the pharmacy to clarify that association instead of treating the note as a result for both medicines neither the conversation heading nor a message preview can answer a clinical question about the medicines themselves you can tell the pharmacy whether a phone call or a secure message is easier for you to receive i will record that preference alongside the two references the callback should explain the status of each record and which branch if any has a confirmed pickup available",
+      "vertical": "healthcare",
+      "difficulty": "hard",
+      "family": "pharmacy",
+      "length_bucket": "L4",
+      "tags": [
+        "medication_name",
+        "identifier",
+        "domain_term",
+        "contrast",
+        "conditional"
+      ]
+    },
+    {
+      "testcase_id": "tts2-hc-h-f03-L1",
+      "transcript": "Should I attach the otolaryngology referral to your existing endocrinology file, or route it separately?",
+      "kind": "vertical",
+      "spoken_reference": "should i attach the otolaryngology referral to your existing endocrinology file or route it separately",
+      "vertical": "healthcare",
+      "difficulty": "hard",
+      "family": "referral",
+      "length_bucket": "L1",
+      "tags": [
+        "domain_term",
+        "contrast"
+      ]
+    },
+    {
+      "testcase_id": "tts2-hc-h-f03-L2",
+      "transcript": "The gastroenterology acknowledgment and the otolaryngology cover sheet appear together in your referral record. Before another packet is dispatched, I can ask the originating clinic to verify the destination and explain whether either document has been superseded.",
+      "kind": "vertical",
+      "spoken_reference": "the gastroenterology acknowledgment and the otolaryngology cover sheet appear together in your referral record before another packet is dispatched i can ask the originating clinic to verify the destination and explain whether either document has been superseded",
+      "vertical": "healthcare",
+      "difficulty": "hard",
+      "family": "referral",
+      "length_bucket": "L2",
+      "tags": [
+        "domain_term",
+        "contrast"
+      ]
+    },
+    {
+      "testcase_id": "tts2-hc-h-f03-L3",
+      "transcript": "The otolaryngology packet reached the central referral queue, but your acknowledgment names the gastroenterology scheduling team. I can request a routing review using tracking code MI-7309. The coordinator should compare the originating department, destination label, and receipt acknowledgment before resending anything. You do not need to select a specialty based on the conflicting labels. If the packet is redirected, ask for a confirmation identifying the receiving office and whether the existing tracking record still applies to the corrected route.",
+      "kind": "vertical",
+      "spoken_reference": "the otolaryngology packet reached the central referral queue but your acknowledgment names the gastroenterology scheduling team i can request a routing review using tracking code m i seven three oh nine the coordinator should compare the originating department destination label and receipt acknowledgment before resending anything you do not need to select a specialty based on the conflicting labels if the packet is redirected ask for a confirmation identifying the receiving office and whether the existing tracking record still applies to the corrected route",
+      "vertical": "healthcare",
+      "difficulty": "hard",
+      "family": "referral",
+      "length_bucket": "L3",
+      "tags": [
+        "domain_term",
+        "identifier",
+        "contrast"
+      ]
+    },
+    {
+      "testcase_id": "tts2-hc-h-f03-L4",
+      "transcript": "The referral index and the scanned attachment disagree about the receiving department. The index names otolaryngology, but the attachment is labeled gastroenterology. I can route this discrepancy to the referring office so it can identify the intended destination before the receiving team relies on the packet.\n\nYour request is filed under RF-572 and was acknowledged on September 19. That acknowledgment confirms a document was received; it does not establish that the destination or every attachment is correct. The coordinator should compare the cover sheet, department label, and acknowledgment together. You do not need to choose between the departments based on these labels.\n\nYou also pointed out a dexamethasone entry in a page that appears to belong to an older consultation. I will describe it as a possible attachment mismatch, without changing the medication entry or deciding whether it belongs in the current referral. The care team can review the clinical content after the records are matched correctly.\n\nTo keep the request clear, I will list the department discrepancy first and the possible older attachment second. If the referring office sends a corrected packet, ask which version replaces the earlier copy and whether the receiving office has acknowledged it. That lets you track the document correction without opening another referral unnecessarily or losing the history of the existing request.",
+      "kind": "vertical",
+      "spoken_reference": "the referral index and the scanned attachment disagree about the receiving department the index names otolaryngology but the attachment is labeled gastroenterology i can route this discrepancy to the referring office so it can identify the intended destination before the receiving team relies on the packet your request is filed under r f five seventy two and was acknowledged on september nineteenth that acknowledgment confirms a document was received it does not establish that the destination or every attachment is correct the coordinator should compare the cover sheet department label and acknowledgment together you do not need to choose between the departments based on these labels you also pointed out a dexamethasone entry in a page that appears to belong to an older consultation i will describe it as a possible attachment mismatch without changing the medication entry or deciding whether it belongs in the current referral the care team can review the clinical content after the records are matched correctly to keep the request clear i will list the department discrepancy first and the possible older attachment second if the referring office sends a corrected packet ask which version replaces the earlier copy and whether the receiving office has acknowledged it that lets you track the document correction without opening another referral unnecessarily or losing the history of the existing request",
+      "vertical": "healthcare",
+      "difficulty": "hard",
+      "family": "referral",
+      "length_bucket": "L4",
+      "tags": [
+        "medication_name",
+        "domain_term",
+        "identifier",
+        "date",
+        "contrast",
+        "conditional"
+      ]
+    },
+    {
+      "testcase_id": "tts2-hc-h-f04-L1",
+      "transcript": "I'll reconcile your $309.07 adjustment with the remittance advice.",
+      "kind": "vertical",
+      "spoken_reference": "i'll reconcile your three hundred nine dollars and seven cents adjustment with the remittance advice",
+      "vertical": "healthcare",
+      "difficulty": "hard",
+      "family": "billing",
+      "length_bucket": "L1",
+      "tags": [
+        "money",
+        "domain_term"
+      ]
+    },
+    {
+      "testcase_id": "tts2-hc-h-f04-L2",
+      "transcript": "Under reconciliation reference RC-83, your ledger shows $1,234.56 beside a reimbursement adjustment. I'll ask billing to distinguish the original charge from the adjusted entry before explaining the remaining balance.",
+      "kind": "vertical",
+      "spoken_reference": "under reconciliation reference r c eighty three your ledger shows one thousand two hundred thirty four dollars and fifty six cents beside a reimbursement adjustment i'll ask billing to distinguish the original charge from the adjusted entry before explaining the remaining balance",
+      "vertical": "healthcare",
+      "difficulty": "hard",
+      "family": "billing",
+      "length_bucket": "L2",
+      "tags": [
+        "money",
+        "domain_term",
+        "identifier"
+      ]
+    },
+    {
+      "testcase_id": "tts2-hc-h-f04-L3",
+      "transcript": "The reimbursement narrative does not explain why your ledger associates $97.18 with reference B-581. I can request a reconciliation showing the original posting and any subsequent adjustment separately. The specialist should also compare the remittance date with the clinic's transaction date, since those fields describe different events. Until that comparison is complete, I will record your question without treating the unexplained entry as a new payment obligation or changing the balance displayed in the account.",
+      "kind": "vertical",
+      "spoken_reference": "the reimbursement narrative does not explain why your ledger associates ninety seven dollars and eighteen cents with reference b five eighty one i can request a reconciliation showing the original posting and any subsequent adjustment separately the specialist should also compare the remittance date with the clinic's transaction date since those fields describe different events until that comparison is complete i will record your question without treating the unexplained entry as a new payment obligation or changing the balance displayed in the account",
+      "vertical": "healthcare",
+      "difficulty": "hard",
+      "family": "billing",
+      "length_bucket": "L3",
+      "tags": [
+        "domain_term",
+        "money",
+        "identifier"
+      ]
+    },
+    {
+      "testcase_id": "tts2-hc-h-f04-L4",
+      "transcript": "Your remittance advice and the clinic ledger show different descriptions for the same adjustment, so I am sending this for reconciliation. The remittance labels $186.42 as an adjustment, while the ledger places that amount beside an outpatient reimbursement entry. The description alone is not enough to establish the remaining balance.\n\nThe document marked EOB is the insurer's explanation of benefits. It is separate from the clinic's payment request, even when both display the same service date. The billing specialist should compare the adjustment code, the posted payment, and the amount shown as patient responsibility. I will ask for an explanation of the difference, not simply another copy of the same statement.\n\nThere is also a pharmacy-related line naming levothyroxine in an attachment. Because that line came from a different submitting office, I will identify it separately in the review request. We should not combine it with the outpatient entry unless the specialist confirms how the records relate. You can leave the documents as they are; no handwritten recalculation is needed.\n\nPlease use reference BR-209 when you contact billing about this comparison. The reply should distinguish any corrected posting from an unresolved question and state whether a replacement statement will be issued. No conclusion about coverage or a new payment is being made during this call.",
+      "kind": "vertical",
+      "spoken_reference": "your remittance advice and the clinic ledger show different descriptions for the same adjustment so i am sending this for reconciliation the remittance labels one hundred eighty six dollars and forty two cents as an adjustment while the ledger places that amount beside an outpatient reimbursement entry the description alone is not enough to establish the remaining balance the document marked e o b is the insurer's explanation of benefits it is separate from the clinic's payment request even when both display the same service date the billing specialist should compare the adjustment code the posted payment and the amount shown as patient responsibility i will ask for an explanation of the difference not simply another copy of the same statement there is also a pharmacy related line naming levothyroxine in an attachment because that line came from a different submitting office i will identify it separately in the review request we should not combine it with the outpatient entry unless the specialist confirms how the records relate you can leave the documents as they are no handwritten recalculation is needed please use reference b r two oh nine when you contact billing about this comparison the reply should distinguish any corrected posting from an unresolved question and state whether a replacement statement will be issued no conclusion about coverage or a new payment is being made during this call",
+      "vertical": "healthcare",
+      "difficulty": "hard",
+      "family": "billing",
+      "length_bucket": "L4",
+      "tags": [
+        "medication_name",
+        "money",
+        "domain_term",
+        "initialism",
+        "identifier",
+        "contrast",
+        "conditional"
+      ]
+    },
+    {
+      "testcase_id": "tts2-bk-e-f01-L1",
+      "transcript": "Your payment went through today, and the updated balance is visible now.",
+      "kind": "vertical",
+      "spoken_reference": "your payment went through today and the updated balance is visible now",
+      "vertical": "banking",
+      "difficulty": "easy",
+      "family": "transaction",
+      "length_bucket": "L1",
+      "tags": []
+    },
+    {
+      "testcase_id": "tts2-bk-e-f01-L2",
+      "transcript": "I found your grocery payment in the activity list. It is complete, and the amount has already left your balance. The merchant name and posting date are shown together clearly.",
+      "kind": "vertical",
+      "spoken_reference": "i found your grocery payment in the activity list it is complete and the amount has already left your balance the merchant name and posting date are shown together clearly",
+      "vertical": "banking",
+      "difficulty": "easy",
+      "family": "transaction",
+      "length_bucket": "L2",
+      "tags": []
+    },
+    {
+      "testcase_id": "tts2-bk-e-f01-L3",
+      "transcript": "Your rent transfer reached the landlord this morning. The transfer appears as complete in your history, and the recipient name matches the one you selected. You can open its details to see the amount, date, source account, and confirmation record. Keep that record with your rent receipt if you need to check the payment later. The completed status means the transfer is no longer waiting in the outgoing list. You can also download its confirmation for your records.",
+      "kind": "vertical",
+      "spoken_reference": "your rent transfer reached the landlord this morning the transfer appears as complete in your history and the recipient name matches the one you selected you can open its details to see the amount date source account and confirmation record keep that record with your rent receipt if you need to check the payment later the completed status means the transfer is no longer waiting in the outgoing list you can also download its confirmation for your records",
+      "vertical": "banking",
+      "difficulty": "easy",
+      "family": "transaction",
+      "length_bucket": "L3",
+      "tags": []
+    },
+    {
+      "testcase_id": "tts2-bk-e-f01-L4",
+      "transcript": "I reviewed your recent activity and found three completed payments: a water bill, a phone bill, and a bookstore purchase. Each entry has a merchant name, a posting date, and a final amount. Your available balance already includes these withdrawals, so the amount shown in the app is ready for your next purchase. Open a transaction to see whether it came from your card, a transfer, or a biller. That source label helps you compare the entry with a receipt. A pending purchase can change before it settles, while a completed purchase will stay in your history. If one entry does not look familiar, note the merchant name, date, and amount before you contact us. You can download the statement, compare it with your receipts, and keep the confirmation for your records. Do not count a pending hold and its later settlement as two separate payments. The activity screen also separates refunds from purchases, so a credit should not be mistaken for a new deposit. Review the balance after each item posts, and save the receipt when the payment is important. If the merchant name is shortened, open the detail view for its full description and payment method before deciding. Check the final status afterward.",
+      "kind": "vertical",
+      "spoken_reference": "i reviewed your recent activity and found three completed payments a water bill a phone bill and a bookstore purchase each entry has a merchant name a posting date and a final amount your available balance already includes these withdrawals so the amount shown in the app is ready for your next purchase open a transaction to see whether it came from your card a transfer or a biller that source label helps you compare the entry with a receipt a pending purchase can change before it settles while a completed purchase will stay in your history if one entry does not look familiar note the merchant name date and amount before you contact us you can download the statement compare it with your receipts and keep the confirmation for your records do not count a pending hold and its later settlement as two separate payments the activity screen also separates refunds from purchases so a credit should not be mistaken for a new deposit review the balance after each item posts and save the receipt when the payment is important if the merchant name is shortened open the detail view for its full description and payment method before deciding check the final status afterward",
+      "vertical": "banking",
+      "difficulty": "easy",
+      "family": "transaction",
+      "length_bucket": "L4",
+      "tags": [
+        "conditional"
+      ]
+    },
+    {
+      "testcase_id": "tts2-bk-e-f02-L1",
+      "transcript": "Your new card should arrive this week. Please sign it when it comes.",
+      "kind": "vertical",
+      "spoken_reference": "your new card should arrive this week please sign it when it comes",
+      "vertical": "banking",
+      "difficulty": "easy",
+      "family": "card",
+      "length_bucket": "L1",
+      "tags": []
+    },
+    {
+      "testcase_id": "tts2-bk-e-f02-L2",
+      "transcript": "I blocked the card you reported missing. Your replacement has a new number, and the old card will no longer work. Keep the envelope until you can compare the printed name with your account and activate the replacement safely.",
+      "kind": "vertical",
+      "spoken_reference": "i blocked the card you reported missing your replacement has a new number and the old card will no longer work keep the envelope until you can compare the printed name with your account and activate the replacement safely",
+      "vertical": "banking",
+      "difficulty": "easy",
+      "family": "card",
+      "length_bucket": "L2",
+      "tags": []
+    },
+    {
+      "testcase_id": "tts2-bk-e-f02-L3",
+      "transcript": "Your replacement debit card was mailed yesterday and usually arrives within five business days. When it arrives, compare the name and address, then activate it in the app. Choose your personal identification number only after the physical card is in your hands. The app will show the new status after activation, and merchants can then receive the new card details when you update them. Keep the delivery notice nearby if you need to compare the shipping status later. Keep the delivery notice with your account records.",
+      "kind": "vertical",
+      "spoken_reference": "your replacement debit card was mailed yesterday and usually arrives within five business days when it arrives compare the name and address then activate it in the app choose your personal identification number only after the physical card is in your hands the app will show the new status after activation and merchants can then receive the new card details when you update them keep the delivery notice nearby if you need to compare the shipping status later keep the delivery notice with your account records",
+      "vertical": "banking",
+      "difficulty": "easy",
+      "family": "card",
+      "length_bucket": "L3",
+      "tags": []
+    },
+    {
+      "testcase_id": "tts2-bk-e-f02-L4",
+      "transcript": "The card in your wallet is active, but the temporary number you saw online is not. You may use the physical card for ordinary purchases while the replacement travels to you. When the envelope arrives, compare the printed name with your account and activate the card in the app. After activation, use it at stores, for online orders, and for recurring charges that used the old number. Remove the old number from shopping profiles, but do not share your card details in a text or email. A merchant may decline the new card before activation, so wait until the app confirms activation and then try again. Keep the delivery notice and confirmation together. If your app shows two replacement requests, choose the one with the newest delivery status and leave the earlier request inactive. The security page can show recent card activity and help you identify the current card. When you replace a saved card, review subscriptions, travel reservations, and delivery accounts separately. Some merchants update automatically, while others require the new details. Check the recent activity after activation and keep any decline notice with the delivery record. If the card is still missing after the expected date, review the tracking message before requesting another replacement.",
+      "kind": "vertical",
+      "spoken_reference": "the card in your wallet is active but the temporary number you saw online is not you may use the physical card for ordinary purchases while the replacement travels to you when the envelope arrives compare the printed name with your account and activate the card in the app after activation use it at stores for online orders and for recurring charges that used the old number remove the old number from shopping profiles but do not share your card details in a text or email a merchant may decline the new card before activation so wait until the app confirms activation and then try again keep the delivery notice and confirmation together if your app shows two replacement requests choose the one with the newest delivery status and leave the earlier request inactive the security page can show recent card activity and help you identify the current card when you replace a saved card review subscriptions travel reservations and delivery accounts separately some merchants update automatically while others require the new details check the recent activity after activation and keep any decline notice with the delivery record if the card is still missing after the expected date review the tracking message before requesting another replacement",
+      "vertical": "banking",
+      "difficulty": "easy",
+      "family": "card",
+      "length_bucket": "L4",
+      "tags": [
+        "conditional"
+      ]
+    },
+    {
+      "testcase_id": "tts2-bk-e-f03-L1",
+      "transcript": "Your savings account is open, and you can make a deposit today.",
+      "kind": "vertical",
+      "spoken_reference": "your savings account is open and you can make a deposit today",
+      "vertical": "banking",
+      "difficulty": "easy",
+      "family": "account",
+      "length_bucket": "L1",
+      "tags": []
+    },
+    {
+      "testcase_id": "tts2-bk-e-f03-L2",
+      "transcript": "Your account balance is ready to view. You can move money between checking and savings in the app. Review the receiving account name before confirming a transfer, then save the confirmation shown in your activity list.",
+      "kind": "vertical",
+      "spoken_reference": "your account balance is ready to view you can move money between checking and savings in the app review the receiving account name before confirming a transfer then save the confirmation shown in your activity list",
+      "vertical": "banking",
+      "difficulty": "easy",
+      "family": "account",
+      "length_bucket": "L2",
+      "tags": []
+    },
+    {
+      "testcase_id": "tts2-bk-e-f03-L3",
+      "transcript": "Your new checking account is ready for deposits, bill payments, and transfers. You can find the account and routing details in the information screen. Recent activity will list each deposit and withdrawal separately, so you can compare the balance with your receipts. The confirmation screen identifies the account you selected before any transfer is submitted. You can save that information for later reference. The account screen also identifies the current balance and recent status. Save the confirmation after you make a change, then check the activity list to ensure the entry appears correctly.",
+      "kind": "vertical",
+      "spoken_reference": "your new checking account is ready for deposits bill payments and transfers you can find the account and routing details in the information screen recent activity will list each deposit and withdrawal separately so you can compare the balance with your receipts the confirmation screen identifies the account you selected before any transfer is submitted you can save that information for later reference the account screen also identifies the current balance and recent status save the confirmation after you make a change then check the activity list to ensure the entry appears correctly",
+      "vertical": "banking",
+      "difficulty": "easy",
+      "family": "account",
+      "length_bucket": "L3",
+      "tags": []
+    },
+    {
+      "testcase_id": "tts2-bk-e-f03-L4",
+      "transcript": "Your checking account is ready for everyday use. You can receive a paycheck, pay a bill, move money to savings, or start a transfer in the app. The balance and recent activity appear on separate screens, and pending entries may not be available yet. Choose the account name carefully before confirming a transfer because checking and savings have different numbers. You can download a statement listing deposits, withdrawals, and fees. The account information screen shows routing details, while the activity screen shows dates and descriptions. Read the confirmation page before pressing submit, then save the receipt when a transfer matters to a bill or deposit. If you need to update your mailing address, use the profile section first because statements are sent to the saved address. If you notice an unfamiliar fee, open its detail line to see its description rather than relying only on the total balance. The profile section handles your address and contact details, while the account section handles money movement. Review the destination account before sending funds, and read the confirmation page carefully. If a transfer is pending, its amount may not be available yet. Save the receipt, compare the posting date with your statement, and open the detail line if a fee needs explanation. This makes it easier to distinguish an account change from a transaction.",
+      "kind": "vertical",
+      "spoken_reference": "your checking account is ready for everyday use you can receive a paycheck pay a bill move money to savings or start a transfer in the app the balance and recent activity appear on separate screens and pending entries may not be available yet choose the account name carefully before confirming a transfer because checking and savings have different numbers you can download a statement listing deposits withdrawals and fees the account information screen shows routing details while the activity screen shows dates and descriptions read the confirmation page before pressing submit then save the receipt when a transfer matters to a bill or deposit if you need to update your mailing address use the profile section first because statements are sent to the saved address if you notice an unfamiliar fee open its detail line to see its description rather than relying only on the total balance the profile section handles your address and contact details while the account section handles money movement review the destination account before sending funds and read the confirmation page carefully if a transfer is pending its amount may not be available yet save the receipt compare the posting date with your statement and open the detail line if a fee needs explanation this makes it easier to distinguish an account change from a transaction",
+      "vertical": "banking",
+      "difficulty": "easy",
+      "family": "account",
+      "length_bucket": "L4",
+      "tags": [
+        "conditional"
+      ]
+    },
+    {
+      "testcase_id": "tts2-bk-e-f04-L1",
+      "transcript": "Your payment is scheduled for tomorrow. Please keep enough money in the account.",
+      "kind": "vertical",
+      "spoken_reference": "your payment is scheduled for tomorrow please keep enough money in the account",
+      "vertical": "banking",
+      "difficulty": "easy",
+      "family": "scheduled_payment",
+      "length_bucket": "L1",
+      "tags": []
+    },
+    {
+      "testcase_id": "tts2-bk-e-f04-L2",
+      "transcript": "Your electricity payment is set for next week. The schedule shows the biller name and next date. You can review the amount and funding account in the app before processing begins.",
+      "kind": "vertical",
+      "spoken_reference": "your electricity payment is set for next week the schedule shows the biller name and next date you can review the amount and funding account in the app before processing begins",
+      "vertical": "banking",
+      "difficulty": "easy",
+      "family": "scheduled_payment",
+      "length_bucket": "L2",
+      "tags": []
+    },
+    {
+      "testcase_id": "tts2-bk-e-f04-L3",
+      "transcript": "Your monthly payment is active and will leave the selected account on the date shown. You can open the schedule to review the amount, recipient, funding account, and payment history. If you cancel before processing, the upcoming payment will disappear from the list. The history will retain earlier completed payments so you can distinguish them from the canceled occurrence. The revised schedule appears in your upcoming list. The app will show the revised date and amount after you save the change.",
+      "kind": "vertical",
+      "spoken_reference": "your monthly payment is active and will leave the selected account on the date shown you can open the schedule to review the amount recipient funding account and payment history if you cancel before processing the upcoming payment will disappear from the list the history will retain earlier completed payments so you can distinguish them from the canceled occurrence the revised schedule appears in your upcoming list the app will show the revised date and amount after you save the change",
+      "vertical": "banking",
+      "difficulty": "easy",
+      "family": "scheduled_payment",
+      "length_bucket": "L3",
+      "tags": []
+    },
+    {
+      "testcase_id": "tts2-bk-e-f04-L4",
+      "transcript": "Your scheduled rent payment is active and will be sent on the date you selected each month. The schedule shows the recipient, amount, funding account, and next date separately. We will show the payment as pending after processing begins, then mark it complete when the recipient receives it. If your balance is too low, the payment may not go through, so check the account beforehand. To change the amount or date, edit the existing payment instead of creating a second one. A duplicate could send money twice, while a canceled payment will no longer appear in the upcoming list. After saving an edit, read the confirmation and check the updated history. The history distinguishes an edited schedule, a canceled occurrence, and a completed debit. Keep the confirmation until the payment appears as completed, especially when the recipient expects the money on a particular day. You can open the detail view to see the biller name, source account, amount, and next processing date. After an edit, confirm that the upcoming list shows only one payment. The payment history separates canceled entries from completed debits, which helps you avoid creating a duplicate. If the biller changes its amount, review the notice before deciding whether to edit the schedule. Keep the confirmation until the final posting appears, especially when the recipient expects money on a particular day. A pending status means processing has started, not that the payment has finished.",
+      "kind": "vertical",
+      "spoken_reference": "your scheduled rent payment is active and will be sent on the date you selected each month the schedule shows the recipient amount funding account and next date separately we will show the payment as pending after processing begins then mark it complete when the recipient receives it if your balance is too low the payment may not go through so check the account beforehand to change the amount or date edit the existing payment instead of creating a second one a duplicate could send money twice while a canceled payment will no longer appear in the upcoming list after saving an edit read the confirmation and check the updated history the history distinguishes an edited schedule a canceled occurrence and a completed debit keep the confirmation until the payment appears as completed especially when the recipient expects the money on a particular day you can open the detail view to see the biller name source account amount and next processing date after an edit confirm that the upcoming list shows only one payment the payment history separates canceled entries from completed debits which helps you avoid creating a duplicate if the biller changes its amount review the notice before deciding whether to edit the schedule keep the confirmation until the final posting appears especially when the recipient expects money on a particular day a pending status means processing has started not that the payment has finished",
+      "vertical": "banking",
+      "difficulty": "easy",
+      "family": "scheduled_payment",
+      "length_bucket": "L4",
+      "tags": [
+        "conditional"
+      ]
+    },
+    {
+      "testcase_id": "tts2-bk-m-f01-L1",
+      "transcript": "Your transfer of $314.27 is complete; reference BX-19 is listed.",
+      "kind": "vertical",
+      "spoken_reference": "your transfer of three hundred fourteen dollars and twenty seven cents is complete reference b x nineteen is listed",
+      "vertical": "banking",
+      "difficulty": "medium",
+      "family": "transaction",
+      "length_bucket": "L1",
+      "tags": [
+        "money",
+        "identifier"
+      ]
+    },
+    {
+      "testcase_id": "tts2-bk-m-f01-L2",
+      "transcript": "A payment to Harbor Market for $116.08 posted on September 9. Your available balance reflects it, while the receipt remains available in transaction history. The merchant name and final posting date are easy to compare with your receipt.",
+      "kind": "vertical",
+      "spoken_reference": "a payment to harbor market for one hundred sixteen dollars and eight cents posted on september ninth your available balance reflects it while the receipt remains available in transaction history the merchant name and final posting date are easy to compare with your receipt",
+      "vertical": "banking",
+      "difficulty": "medium",
+      "family": "transaction",
+      "length_bucket": "L2",
+      "tags": [
+        "money",
+        "date",
+        "proper_name"
+      ]
+    },
+    {
+      "testcase_id": "tts2-bk-m-f01-L3",
+      "transcript": "Your international purchase from Luma Books was $47.60 plus a 2% conversion charge. It settled under reference K4R8-PL, so the original pending amount has disappeared. Your statement keeps the settled amount separate from the earlier authorization. Open the detail row to compare the merchant name, posting date, and funding account before you decide whether the entry is familiar. This record remains available in your history.",
+      "kind": "vertical",
+      "spoken_reference": "your international purchase from luma books was forty seven dollars and sixty cents plus a two percent conversion charge it settled under reference k four r eight p l so the original pending amount has disappeared your statement keeps the settled amount separate from the earlier authorization open the detail row to compare the merchant name posting date and funding account before you decide whether the entry is familiar this record remains available in your history",
+      "vertical": "banking",
+      "difficulty": "medium",
+      "family": "transaction",
+      "length_bucket": "L3",
+      "tags": [
+        "money",
+        "percentage",
+        "identifier"
+      ]
+    },
+    {
+      "testcase_id": "tts2-bk-m-f01-L4",
+      "transcript": "I compared the ledger with your downloadable statement and found four entries from the weekend. On Friday, Cedar Taxi posted $28.40; on Saturday, Northline Grocers posted $203.17; and on Sunday, an online payment to Mira Patel posted $75.00. A fourth entry for $12.99 is still pending at Bright Desk. Pending amounts can change before settlement, so your available balance may differ from your ledger balance for a short time. If Bright Desk completes the charge, it will receive a posting date automatically; if it disappears, the authorization was released without a final withdrawal. The detail page lists the payment method and each status change in order. A pending entry can reduce the available amount temporarily, while a released authorization returns without becoming a completed withdrawal. Compare the final posted amount with the receipt, then save the statement line and confirmation for your records. If the merchant sends a refund, it will appear as a separate credit rather than changing the original purchase. Reviewing those entries together makes the weekend activity easier to explain. The receipt and statement should show the same final amount after settlement.",
+      "kind": "vertical",
+      "spoken_reference": "i compared the ledger with your downloadable statement and found four entries from the weekend on friday cedar taxi posted twenty eight dollars and forty cents on saturday northline grocers posted two hundred three dollars and seventeen cents and on sunday an online payment to mira patel posted seventy five dollars a fourth entry for twelve dollars and ninety nine cents is still pending at bright desk pending amounts can change before settlement so your available balance may differ from your ledger balance for a short time if bright desk completes the charge it will receive a posting date automatically if it disappears the authorization was released without a final withdrawal the detail page lists the payment method and each status change in order a pending entry can reduce the available amount temporarily while a released authorization returns without becoming a completed withdrawal compare the final posted amount with the receipt then save the statement line and confirmation for your records if the merchant sends a refund it will appear as a separate credit rather than changing the original purchase reviewing those entries together makes the weekend activity easier to explain the receipt and statement should show the same final amount after settlement",
+      "vertical": "banking",
+      "difficulty": "medium",
+      "family": "transaction",
+      "length_bucket": "L4",
+      "tags": [
+        "money",
+        "date",
+        "list",
+        "conditional",
+        "proper_name"
+      ]
+    },
+    {
+      "testcase_id": "tts2-bk-m-f02-L1",
+      "transcript": "Your replacement card shipped on October 11; tracking begins with TR-62. Activate it only after delivery.",
+      "kind": "vertical",
+      "spoken_reference": "your replacement card shipped on october eleventh tracking begins with t r sixty two activate it only after delivery",
+      "vertical": "banking",
+      "difficulty": "medium",
+      "family": "card",
+      "length_bucket": "L1",
+      "tags": [
+        "date",
+        "identifier"
+      ]
+    },
+    {
+      "testcase_id": "tts2-bk-m-f02-L2",
+      "transcript": "The cash withdrawal was declined because your card has a daily limit. You can try a smaller amount, or use a teller after showing identification. Keep the decline notice with your receipt so the amount and time are easy to compare.",
+      "kind": "vertical",
+      "spoken_reference": "the cash withdrawal was declined because your card has a daily limit you can try a smaller amount or use a teller after showing identification keep the decline notice with your receipt so the amount and time are easy to compare",
+      "vertical": "banking",
+      "difficulty": "medium",
+      "family": "card",
+      "length_bucket": "L2",
+      "tags": [
+        "number",
+        "conditional"
+      ]
+    },
+    {
+      "testcase_id": "tts2-bk-m-f02-L3",
+      "transcript": "Your new card supports contactless payments and ATM withdrawals. The envelope includes activation steps, a customer service number, and a notice explaining the ATM limit. After activation, update merchants that charge your old card automatically. The activation page also shows the card status and last four digits. Review those details before updating a merchant, and keep the notice with your delivery record in case an order retries the old number. Review the saved card details before you use the card.",
+      "kind": "vertical",
+      "spoken_reference": "your new card supports contactless payments and a t m withdrawals the envelope includes activation steps a customer service number and a notice explaining the a t m limit after activation update merchants that charge your old card automatically the activation page also shows the card status and last four digits review those details before updating a merchant and keep the notice with your delivery record in case an order retries the old number review the saved card details before you use the card",
+      "vertical": "banking",
+      "difficulty": "medium",
+      "family": "card",
+      "length_bucket": "L3",
+      "tags": [
+        "initialism",
+        "time",
+        "list"
+      ]
+    },
+    {
+      "testcase_id": "tts2-bk-m-f02-L4",
+      "transcript": "The card dispute you opened for a Riverstone Hotel charge is now under review. The purchase date was November 2, the amount was $187.30, and the case number is D-58104. We have paused that card number for online use while the review is active, but your replacement card remains available for ordinary purchases. Save the hotel receipt, cancellation email, and any message showing the merchant promised a refund. Those documents help us compare the requested refund with the final card entry. If Riverstone sends a credit, it can appear separately from the dispute outcome, so check both your recent activity and your monthly statement. The case timeline records the purchase, review, and any credit separately. Keep the merchant receipt with the cancellation message, then compare the final statement entry with the disputed amount. If the merchant credit arrives first, it may close part of the issue without changing the original case number. You can review the card status and recent activity in the app while the review remains open. Keep the case number unchanged when you send additional documents, and check the activity list for any separate merchant credit.",
+      "kind": "vertical",
+      "spoken_reference": "the card dispute you opened for a riverstone hotel charge is now under review the purchase date was november second the amount was one hundred eighty seven dollars and thirty cents and the case number is d five eight one zero four we have paused that card number for online use while the review is active but your replacement card remains available for ordinary purchases save the hotel receipt cancellation email and any message showing the merchant promised a refund those documents help us compare the requested refund with the final card entry if riverstone sends a credit it can appear separately from the dispute outcome so check both your recent activity and your monthly statement the case timeline records the purchase review and any credit separately keep the merchant receipt with the cancellation message then compare the final statement entry with the disputed amount if the merchant credit arrives first it may close part of the issue without changing the original case number you can review the card status and recent activity in the app while the review remains open keep the case number unchanged when you send additional documents and check the activity list for any separate merchant credit",
+      "vertical": "banking",
+      "difficulty": "medium",
+      "family": "card",
+      "length_bucket": "L4",
+      "tags": [
+        "date",
+        "identifier",
+        "conditional",
+        "list"
+      ]
+    },
+    {
+      "testcase_id": "tts2-bk-m-f03-L1",
+      "transcript": "Your account profile was updated on May 6. The new contact method is marked SMS.",
+      "kind": "vertical",
+      "spoken_reference": "your account profile was updated on may sixth the new contact method is marked s m s",
+      "vertical": "banking",
+      "difficulty": "medium",
+      "family": "account",
+      "length_bucket": "L1",
+      "tags": [
+        "date",
+        "initialism"
+      ]
+    },
+    {
+      "testcase_id": "tts2-bk-m-f03-L2",
+      "transcript": "Your savings balance is $4,275, and the current interest rate is 1.25%. The rate shown is for this fictional account plan.",
+      "kind": "vertical",
+      "spoken_reference": "your savings balance is four thousand two hundred seventy five dollars and the current interest rate is one point two five percent the rate shown is for this fictional account plan",
+      "vertical": "banking",
+      "difficulty": "medium",
+      "family": "account",
+      "length_bucket": "L2",
+      "tags": [
+        "money",
+        "percentage"
+      ]
+    },
+    {
+      "testcase_id": "tts2-bk-m-f03-L3",
+      "transcript": "Your account ending in 9026 received a direct deposit on December 15. The entry lists your employer, payroll, and the net amount, while taxes are not shown as separate deposits. The account detail identifies the posting date, source, and current status. Check those fields against your payroll record, then save the confirmation so you can distinguish the deposit from a later adjustment. A profile change does not alter the deposit entry; keep the confirmation with your payroll records.",
+      "kind": "vertical",
+      "spoken_reference": "your account ending in nine zero two six received a direct deposit on december fifteenth the entry lists your employer payroll and the net amount while taxes are not shown as separate deposits the account detail identifies the posting date source and current status check those fields against your payroll record then save the confirmation so you can distinguish the deposit from a later adjustment a profile change does not alter the deposit entry keep the confirmation with your payroll records",
+      "vertical": "banking",
+      "difficulty": "medium",
+      "family": "account",
+      "length_bucket": "L3",
+      "tags": [
+        "identifier",
+        "date",
+        "list"
+      ]
+    },
+    {
+      "testcase_id": "tts2-bk-m-f03-L4",
+      "transcript": "I found why your statement total differs from the balance on screen. The statement closed on January 31 and includes a monthly service charge of $8.00, while the live balance includes a deposit of $240.00 made yesterday. Your account ending in 7731 is the account that received it. The statement also identifies the routing transfer as ACH and shows its posting date separately from the date you initiated it. Download the statement, open the transaction detail, and compare the dates line by line. If a deposit is missing after its posted date, give us the employer name and trace code shown in your payroll record so we can locate the entry. The statement view separates the service charge, live deposit, and routing information into different rows. Check your account ending and posting dates before comparing totals. A pending deposit can be visible without being available, while a completed deposit changes the available amount. Save the trace code and payroll description if you need to explain the difference later. Reviewing the statement and live activity together prevents a recent deposit from being counted twice. Your statement and live activity should agree after the deposit is complete.",
+      "kind": "vertical",
+      "spoken_reference": "i found why your statement total differs from the balance on screen the statement closed on january thirty first and includes a monthly service charge of eight dollars while the live balance includes a deposit of two hundred forty dollars made yesterday your account ending in seven seven three one is the account that received it the statement also identifies the routing transfer as a c h and shows its posting date separately from the date you initiated it download the statement open the transaction detail and compare the dates line by line if a deposit is missing after its posted date give us the employer name and trace code shown in your payroll record so we can locate the entry the statement view separates the service charge live deposit and routing information into different rows check your account ending and posting dates before comparing totals a pending deposit can be visible without being available while a completed deposit changes the available amount save the trace code and payroll description if you need to explain the difference later reviewing the statement and live activity together prevents a recent deposit from being counted twice your statement and live activity should agree after the deposit is complete",
+      "vertical": "banking",
+      "difficulty": "medium",
+      "family": "account",
+      "length_bucket": "L4",
+      "tags": [
+        "money",
+        "date",
+        "initialism",
+        "conditional"
+      ]
+    },
+    {
+      "testcase_id": "tts2-bk-m-f04-L1",
+      "transcript": "Your water bill for $58.42 will be paid on February 18.",
+      "kind": "vertical",
+      "spoken_reference": "your water bill for fifty eight dollars and forty two cents will be paid on february eighteenth",
+      "vertical": "banking",
+      "difficulty": "medium",
+      "family": "scheduled_payment",
+      "length_bucket": "L1",
+      "tags": [
+        "money",
+        "date"
+      ]
+    },
+    {
+      "testcase_id": "tts2-bk-m-f04-L2",
+      "transcript": "The recurring payment to Pine Wireless is set at $64.99 each month. It will pause if you turn off the schedule before the next processing date. You can open the schedule to see the next date, source account, and biller name.",
+      "kind": "vertical",
+      "spoken_reference": "the recurring payment to pine wireless is set at sixty four dollars and ninety nine cents each month it will pause if you turn off the schedule before the next processing date you can open the schedule to see the next date source account and biller name",
+      "vertical": "banking",
+      "difficulty": "medium",
+      "family": "scheduled_payment",
+      "length_bucket": "L2",
+      "tags": [
+        "money",
+        "date",
+        "conditional"
+      ]
+    },
+    {
+      "testcase_id": "tts2-bk-m-f04-L3",
+      "transcript": "Your mortgage reminder is not a withdrawal; the scheduled payment is the separate entry for $1,875.50 on March 27. Its schedule code is SP-440. The payment detail shows the biller, source account, and schedule code separately. Review each field after saving, then check the upcoming list to confirm that only the revised payment remains. A reminder is not itself a withdrawal; use the payment history to verify the actual debit.",
+      "kind": "vertical",
+      "spoken_reference": "your mortgage reminder is not a withdrawal the scheduled payment is the separate entry for one thousand eight hundred seventy five dollars and fifty cents on march twenty seventh its schedule code is s p four forty the payment detail shows the biller source account and schedule code separately review each field after saving then check the upcoming list to confirm that only the revised payment remains a reminder is not itself a withdrawal use the payment history to verify the actual debit",
+      "vertical": "banking",
+      "difficulty": "medium",
+      "family": "scheduled_payment",
+      "length_bucket": "L3",
+      "tags": [
+        "money",
+        "date",
+        "identifier"
+      ]
+    },
+    {
+      "testcase_id": "tts2-bk-m-f04-L4",
+      "transcript": "Your recurring payment to Willow Utilities has two parts because the provider accepts a base charge and a seasonal adjustment separately. The base amount is $74.00 on the fifteenth, and the adjustment currently listed is $18.63 on the twentieth. Both entries use your checking account ending in 1182 and both can be edited from the schedule page. The provider name, Willow Utilities, must remain unchanged for the payment to match its biller record. If you cancel only the adjustment, the base payment will continue; if you cancel the base schedule, the adjustment will also be removed because it has no independent bill reference. Review the next processing dates before saving, then look for a confirmation banner and the updated entries in your payment history. The schedule detail distinguishes the base charge from the seasonal adjustment and shows each next date. Review the account ending and provider name before saving an edit. If the biller changes the adjustment, the payment history will show that change separately from the base amount. Keep the confirmation until both entries have posted, and compare them with the bill details rather than adding a pending estimate to a settled debit. This makes it easier to tell whether a schedule was edited, paused, or completed.",
+      "kind": "vertical",
+      "spoken_reference": "your recurring payment to willow utilities has two parts because the provider accepts a base charge and a seasonal adjustment separately the base amount is seventy four dollars on the fifteenth and the adjustment currently listed is eighteen dollars and sixty three cents on the twentieth both entries use your checking account ending in one one eight two and both can be edited from the schedule page the provider name willow utilities must remain unchanged for the payment to match its biller record if you cancel only the adjustment the base payment will continue if you cancel the base schedule the adjustment will also be removed because it has no independent bill reference review the next processing dates before saving then look for a confirmation banner and the updated entries in your payment history the schedule detail distinguishes the base charge from the seasonal adjustment and shows each next date review the account ending and provider name before saving an edit if the biller changes the adjustment the payment history will show that change separately from the base amount keep the confirmation until both entries have posted and compare them with the bill details rather than adding a pending estimate to a settled debit this makes it easier to tell whether a schedule was edited paused or completed",
+      "vertical": "banking",
+      "difficulty": "medium",
+      "family": "scheduled_payment",
+      "length_bucket": "L4",
+      "tags": [
+        "money",
+        "date",
+        "conditional",
+        "list",
+        "proper_name"
+      ]
+    },
+    {
+      "testcase_id": "tts2-bk-h-f01-L1",
+      "transcript": "Your $2,019.07 transfer cleared under QX-8.",
+      "kind": "vertical",
+      "spoken_reference": "your two thousand nineteen dollars and seven cents transfer cleared under q x eight",
+      "vertical": "banking",
+      "difficulty": "hard",
+      "family": "transaction",
+      "length_bucket": "L1",
+      "tags": [
+        "money",
+        "identifier"
+      ]
+    },
+    {
+      "testcase_id": "tts2-bk-h-f01-L2",
+      "transcript": "Your $905.44 wire settled on October 31; the SWIFT trace is attached. The trace detail identifies the sending bank, settlement date, and final status. Compare those fields with your transfer record before treating the wire as complete.",
+      "kind": "vertical",
+      "spoken_reference": "your nine hundred five dollars and forty four cents wire settled on october thirty first the s w i f t trace is attached the trace detail identifies the sending bank settlement date and final status compare those fields with your transfer record before treating the wire as complete",
+      "vertical": "banking",
+      "difficulty": "hard",
+      "family": "transaction",
+      "length_bucket": "L2",
+      "tags": [
+        "money",
+        "date",
+        "initialism"
+      ]
+    },
+    {
+      "testcase_id": "tts2-bk-h-f01-L3",
+      "transcript": "The reversed $63.17 authorization was replaced by a settled debit with trace R9-VK-204. Your ledger now shows only the final posting. Open the trace detail to compare the merchant, posting date, and original authorization. Your statement should show the release and final debit as related entries rather than one combined amount. Keep that comparison with the related entries for later review. The release and settlement stay linked in your history.",
+      "kind": "vertical",
+      "spoken_reference": "the reversed sixty three dollars and seventeen cents authorization was replaced by a settled debit with trace r nine v k two zero four your ledger now shows only the final posting open the trace detail to compare the merchant posting date and original authorization your statement should show the release and final debit as related entries rather than one combined amount keep that comparison with the related entries for later review the release and settlement stay linked in your history",
+      "vertical": "banking",
+      "difficulty": "hard",
+      "family": "transaction",
+      "length_bucket": "L3",
+      "tags": [
+        "money",
+        "identifier",
+        "domain_term"
+      ]
+    },
+    {
+      "testcase_id": "tts2-bk-h-f01-L4",
+      "transcript": "I reconciled the three entries that made your balance look inconsistent: a preauthorization from Oriole Air, a partial reversal from the same merchant, and the final settlement from its payment processor. The original hold was $486.90 on March 4; the reversal released $112.00 two days later; and the settled charge was $374.90 under trace A7K-00931. The statement labels the processor as ISO and the original hold as pending, which is why the app displayed both amounts temporarily. Your available balance should recover the released portion after the reversal posts. If the settled amount differs from the receipt, compare the merchant's final total with the processor trace rather than adding the hold and settlement together. The ledger detail preserves the authorization, reversal, and settlement as linked events. Review the posting dates in order, then compare the final debit with the merchant receipt. A released hold should not be added to the settled amount. Save the trace and statement line together so you can explain the balance change without exposing your full account number. Keep the final receipt nearby.",
+      "kind": "vertical",
+      "spoken_reference": "i reconciled the three entries that made your balance look inconsistent a preauthorization from oriole air a partial reversal from the same merchant and the final settlement from its payment processor the original hold was four hundred eighty six dollars and ninety cents on march fourth the reversal released one hundred twelve dollars two days later and the settled charge was three hundred seventy four dollars and ninety cents under trace a seven k zero zero nine three one the statement labels the processor as i s o and the original hold as pending which is why the app displayed both amounts temporarily your available balance should recover the released portion after the reversal posts if the settled amount differs from the receipt compare the merchant's final total with the processor trace rather than adding the hold and settlement together the ledger detail preserves the authorization reversal and settlement as linked events review the posting dates in order then compare the final debit with the merchant receipt a released hold should not be added to the settled amount save the trace and statement line together so you can explain the balance change without exposing your full account number keep the final receipt nearby",
+      "vertical": "banking",
+      "difficulty": "hard",
+      "family": "transaction",
+      "length_bucket": "L4",
+      "tags": [
+        "money",
+        "date",
+        "initialism",
+        "identifier",
+        "conditional",
+        "list"
+      ]
+    },
+    {
+      "testcase_id": "tts2-bk-h-f02-L1",
+      "transcript": "Your EMV card is active; the CVV is never stored in chat.",
+      "kind": "vertical",
+      "spoken_reference": "your e m v card is active the c v v is never stored in chat",
+      "vertical": "banking",
+      "difficulty": "hard",
+      "family": "card",
+      "length_bucket": "L1",
+      "tags": [
+        "identifier",
+        "initialism"
+      ]
+    },
+    {
+      "testcase_id": "tts2-bk-h-f02-L2",
+      "transcript": "Your card's tap-to-pay feature is disabled after several failed reads. Insert the chip once, then follow the terminal prompts; contactless use can return after a successful chip transaction.",
+      "kind": "vertical",
+      "spoken_reference": "your card's tap to pay feature is disabled after several failed reads insert the chip once then follow the terminal prompts contactless use can return after a successful chip transaction",
+      "vertical": "banking",
+      "difficulty": "hard",
+      "family": "card",
+      "length_bucket": "L2",
+      "tags": [
+        "number",
+        "conditional",
+        "hyphenated_word"
+      ]
+    },
+    {
+      "testcase_id": "tts2-bk-h-f02-L3",
+      "transcript": "The POS dispute for terminal N-4407 was opened on May 22. Your physical card remains usable, but its tokenized wallet version is paused pending review. The wallet record and physical-card record have separate statuses. Review the terminal, date, and token details before deciding which card activity you recognize. Save the event details with your card records, and check the wallet status again after the review is complete.",
+      "kind": "vertical",
+      "spoken_reference": "the p o s dispute for terminal n four four zero seven was opened on may twenty second your physical card remains usable but its tokenized wallet version is paused pending review the wallet record and physical card record have separate statuses review the terminal date and token details before deciding which card activity you recognize save the event details with your card records and check the wallet status again after the review is complete",
+      "vertical": "banking",
+      "difficulty": "hard",
+      "family": "card",
+      "length_bucket": "L3",
+      "tags": [
+        "initialism",
+        "identifier",
+        "date"
+      ]
+    },
+    {
+      "testcase_id": "tts2-bk-h-f02-L4",
+      "transcript": "Your card security review concerns a wallet token, not the physical card itself. On June 7, an online merchant submitted a CNP authorization against token TKN-8842-Z for $219.80. The authorization was declined, then a second request from the same merchant arrived with a different MCC classification. We paused that wallet token while retaining the physical card's chip and magnetic-stripe settings. Review the merchant name, device nickname, and timestamp in your wallet activity; do not remove the card from every device until you have saved those details. If you recognize the purchase, re-enable the token from the security screen. If you do not, leave it paused and use the secure dispute form, which links the token event to the card record without exposing the full card number. The wallet activity page records the token event separately from the physical-card history. Review the merchant, device, timestamp, and token status in that order. If you recognize the purchase, follow the re-enable action; if you do not, preserve the paused status and use the secure form. Keep the case confirmation with your saved event details, because a later authorization from the same merchant may receive a different classification.",
+      "kind": "vertical",
+      "spoken_reference": "your card security review concerns a wallet token not the physical card itself on june seventh an online merchant submitted a c n p authorization against token t k n eight eight four two z for two hundred nineteen dollars and eighty cents the authorization was declined then a second request from the same merchant arrived with a different m c c classification we paused that wallet token while retaining the physical card's chip and magnetic stripe settings review the merchant name device nickname and timestamp in your wallet activity do not remove the card from every device until you have saved those details if you recognize the purchase re enable the token from the security screen if you do not leave it paused and use the secure dispute form which links the token event to the card record without exposing the full card number the wallet activity page records the token event separately from the physical card history review the merchant device timestamp and token status in that order if you recognize the purchase follow the re enable action if you do not preserve the paused status and use the secure form keep the case confirmation with your saved event details because a later authorization from the same merchant may receive a different classification",
+      "vertical": "banking",
+      "difficulty": "hard",
+      "family": "card",
+      "length_bucket": "L4",
+      "tags": [
+        "initialism",
+        "identifier",
+        "date",
+        "conditional",
+        "list",
+        "domain_term"
+      ]
+    },
+    {
+      "testcase_id": "tts2-bk-h-f03-L1",
+      "transcript": "Your IBAN ending 6021 is active, while your BIC remains unchanged.",
+      "kind": "vertical",
+      "spoken_reference": "your i b a n ending six zero two one is active while your b i c remains unchanged",
+      "vertical": "banking",
+      "difficulty": "hard",
+      "family": "account",
+      "length_bucket": "L1",
+      "tags": [
+        "identifier",
+        "initialism"
+      ]
+    },
+    {
+      "testcase_id": "tts2-bk-h-f03-L2",
+      "transcript": "Your $7,500 balance crossed the 3.05% tier, and the ledger labels the change as an interest accrual, not a deposit. The account detail shows whether the accrual is pending or posted, and your available amount can differ while the ledger updates.",
+      "kind": "vertical",
+      "spoken_reference": "your seven thousand five hundred dollars balance crossed the three point zero five percent tier and the ledger labels the change as an interest accrual not a deposit the account detail shows whether the accrual is pending or posted and your available amount can differ while the ledger updates",
+      "vertical": "banking",
+      "difficulty": "hard",
+      "family": "account",
+      "length_bucket": "L2",
+      "tags": [
+        "money",
+        "percentage",
+        "domain_term"
+      ]
+    },
+    {
+      "testcase_id": "tts2-bk-h-f03-L3",
+      "transcript": "The dormant account review for Northstar Design concerns account 0084-7719. It began on August 1 after a KYC profile mismatch; your deposit account itself has not been closed. The review page separates your profile task from account activity. Save the mismatch notice, then check the account status again after the requested document is recorded. The account history will retain the review note for your reference, so you can compare it with the updated profile.",
+      "kind": "vertical",
+      "spoken_reference": "the dormant account review for northstar design concerns account zero zero eight four seven seven one nine it began on august first after a k y c profile mismatch your deposit account itself has not been closed the review page separates your profile task from account activity save the mismatch notice then check the account status again after the requested document is recorded the account history will retain the review note for your reference so you can compare it with the updated profile",
+      "vertical": "banking",
+      "difficulty": "hard",
+      "family": "account",
+      "length_bucket": "L3",
+      "tags": [
+        "identifier",
+        "date",
+        "initialism",
+        "proper_name"
+      ]
+    },
+    {
+      "testcase_id": "tts2-bk-h-f03-L4",
+      "transcript": "Your account review has two separate tracks, and combining them would produce the wrong result. The first track is a profile correction for account 7740-26 because your postal address does not match the address on a recent KYC document. The second track is a $3,820.16 incoming transfer dated September 18 that is visible in the ledger but not yet available. The transfer carries ACH trace 0097716 and is pending sender-bank confirmation. Updating your address can correct the profile mismatch, but it cannot accelerate that transfer. Conversely, a completed transfer will not update your profile. Open the profile task to submit the address document, then return to the transfer detail after its expected posting window. If the trace remains pending, provide it to the sending institution; our team can search the receiving ledger once the sender marks it released. The profile task and transfer task have independent statuses, so completing one does not complete the other. Review the account ending, trace, posting date, and available amount separately. A pending transfer can be visible without being spendable. Save the address-document confirmation, then check the ledger again after the sender releases the funds. If the trace stays pending, give the sender its reference and retain the receiving account details for comparison.",
+      "kind": "vertical",
+      "spoken_reference": "your account review has two separate tracks and combining them would produce the wrong result the first track is a profile correction for account seven seven four zero two six because your postal address does not match the address on a recent k y c document the second track is a three thousand eight hundred twenty dollars and sixteen cents incoming transfer dated september eighteenth that is visible in the ledger but not yet available the transfer carries a c h trace zero zero nine seven seven one six and is pending sender bank confirmation updating your address can correct the profile mismatch but it cannot accelerate that transfer conversely a completed transfer will not update your profile open the profile task to submit the address document then return to the transfer detail after its expected posting window if the trace remains pending provide it to the sending institution our team can search the receiving ledger once the sender marks it released the profile task and transfer task have independent statuses so completing one does not complete the other review the account ending trace posting date and available amount separately a pending transfer can be visible without being spendable save the address document confirmation then check the ledger again after the sender releases the funds if the trace stays pending give the sender its reference and retain the receiving account details for comparison",
+      "vertical": "banking",
+      "difficulty": "hard",
+      "family": "account",
+      "length_bucket": "L4",
+      "tags": [
+        "money",
+        "date",
+        "identifier",
+        "initialism",
+        "conditional",
+        "contrast"
+      ]
+    },
+    {
+      "testcase_id": "tts2-bk-h-f04-L1",
+      "transcript": "Your $2,004.06 payment runs on April 29 through the ACH network.",
+      "kind": "vertical",
+      "spoken_reference": "your two thousand four dollars and six cents payment runs on april twenty ninth through the a c h network",
+      "vertical": "banking",
+      "difficulty": "hard",
+      "family": "scheduled_payment",
+      "length_bucket": "L1",
+      "tags": [
+        "money",
+        "date",
+        "initialism"
+      ]
+    },
+    {
+      "testcase_id": "tts2-bk-h-f04-L2",
+      "transcript": "Your split payment sends $318.75 on May 30 and carries schedule key SP-7Q. If that date is a weekend, processing begins on the next business day.",
+      "kind": "vertical",
+      "spoken_reference": "your split payment sends three hundred eighteen dollars and seventy five cents on may thirtieth and carries schedule key s p seven q if that date is a weekend processing begins on the next business day",
+      "vertical": "banking",
+      "difficulty": "hard",
+      "family": "scheduled_payment",
+      "length_bucket": "L2",
+      "tags": [
+        "money",
+        "date",
+        "identifier",
+        "conditional"
+      ]
+    },
+    {
+      "testcase_id": "tts2-bk-h-f04-L3",
+      "transcript": "Your variable-rate installment is scheduled at $1,042.18 on July 31. The APR field changed to 4.75%, but this month's scheduled amount remains the amount already displayed. The schedule detail shows the rate field, next date, source account, and current amount separately. Compare those fields with the notice before editing the upcoming payment. Save the updated schedule with your payment records.",
+      "kind": "vertical",
+      "spoken_reference": "your variable rate installment is scheduled at one thousand forty two dollars and eighteen cents on july thirty first the a p r field changed to four point seven five percent but this month's scheduled amount remains the amount already displayed the schedule detail shows the rate field next date source account and current amount separately compare those fields with the notice before editing the upcoming payment save the updated schedule with your payment records",
+      "vertical": "banking",
+      "difficulty": "hard",
+      "family": "scheduled_payment",
+      "length_bucket": "L3",
+      "tags": [
+        "money",
+        "date",
+        "percentage",
+        "initialism"
+      ]
+    },
+    {
+      "testcase_id": "tts2-bk-h-f04-L4",
+      "transcript": "Your scheduled payment to Meridian Equipment contains a principal transfer, a service fee, and a separately recorded tax adjustment. The principal is $1,286.40 on October 3; the service fee is $14.25; and the tax adjustment is 0.8% of the principal, rounded by the biller. The schedule identifier is ME-APR-611, and the funding account ends in 4300. Because the biller sends a prenotification before the debit, the visible amount can briefly show an estimate rather than the settled total. If the prenotification changes, the payment record will display the new estimate without creating another schedule. Do not cancel the principal merely because the fee appears separately; canceling it would stop the main installment. Instead, open the detail view, compare the biller's tax line with the estimated adjustment, and save the confirmation after you approve or reject the revised amount. The prenotification, schedule, and final debit are distinct records. Review the biller name, account ending, dates, estimated amount, and settled amount in that order. If the adjustment changes, the schedule history should show the revision without creating a second payment. Keep the saved notice after you accept or decline the estimate, and compare the final posting with the biller notice. A canceled edit should leave the prior schedule unchanged, while an approved edit should change only the intended field.",
+      "kind": "vertical",
+      "spoken_reference": "your scheduled payment to meridian equipment contains a principal transfer a service fee and a separately recorded tax adjustment the principal is one thousand two hundred eighty six dollars and forty cents on october third the service fee is fourteen dollars and twenty five cents and the tax adjustment is zero point eight percent of the principal rounded by the biller the schedule identifier is m e a p r six one one and the funding account ends in four three zero zero because the biller sends a prenotification before the debit the visible amount can briefly show an estimate rather than the settled total if the prenotification changes the payment record will display the new estimate without creating another schedule do not cancel the principal merely because the fee appears separately canceling it would stop the main installment instead open the detail view compare the biller's tax line with the estimated adjustment and save the confirmation after you approve or reject the revised amount the prenotification schedule and final debit are distinct records review the biller name account ending dates estimated amount and settled amount in that order if the adjustment changes the schedule history should show the revision without creating a second payment keep the saved notice after you accept or decline the estimate and compare the final posting with the biller notice a canceled edit should leave the prior schedule unchanged while an approved edit should change only the intended field",
+      "vertical": "banking",
+      "difficulty": "hard",
+      "family": "scheduled_payment",
+      "length_bucket": "L4",
+      "tags": [
+        "money",
+        "date",
+        "percentage",
+        "identifier",
+        "initialism",
+        "conditional",
+        "list",
+        "domain_term"
+      ]
+    },
+    {
+      "testcase_id": "tts2-ln-e-f01-L1",
+      "transcript": "Your loan file needs one signed document before review can begin.",
+      "kind": "vertical",
+      "spoken_reference": "your loan file needs one signed document before review can begin",
+      "vertical": "loans",
+      "difficulty": "easy",
+      "family": "documents",
+      "length_bucket": "L1",
+      "tags": [
+        "list"
+      ]
+    },
+    {
+      "testcase_id": "tts2-ln-e-f01-L2",
+      "transcript": "I received your income form and address page. Please upload the missing signature page by May 18. Your document list will update after the file is checked. Save the receipt.",
+      "kind": "vertical",
+      "spoken_reference": "i received your income form and address page please upload the missing signature page by may eighteenth your document list will update after the file is checked save the receipt",
+      "vertical": "loans",
+      "difficulty": "easy",
+      "family": "documents",
+      "length_bucket": "L2",
+      "tags": [
+        "date",
+        "list"
+      ]
+    },
+    {
+      "testcase_id": "tts2-ln-e-f01-L3",
+      "transcript": "The documents in your loan folder are a signed application, an income statement, and a copy of your identification. We still need the page showing your current address. Upload it through the secure document list by June 12. After the page arrives, our review team will match the name and file number before marking the folder complete. Keep the confirmation message for your records, and do not send private documents through ordinary email. You can view the status of each page in the same portal.",
+      "kind": "vertical",
+      "spoken_reference": "the documents in your loan folder are a signed application an income statement and a copy of your identification we still need the page showing your current address upload it through the secure document list by june twelfth after the page arrives our review team will match the name and file number before marking the folder complete keep the confirmation message for your records and do not send private documents through ordinary email you can view the status of each page in the same portal",
+      "vertical": "loans",
+      "difficulty": "easy",
+      "family": "documents",
+      "length_bucket": "L3",
+      "tags": [
+        "date",
+        "list",
+        "identifier"
+      ]
+    },
+    {
+      "testcase_id": "tts2-ln-e-f01-L4",
+      "transcript": "Your application folder currently contains the signed request, proof of income, identification, and the address page. The review team has matched the names on those files, but the employer section is still marked incomplete. Open the document checklist and upload the missing page through the secure portal. If your file has more than one page, combine them in the order shown so the reviewer can read the form without gaps. Use the same name and loan reference when you label the upload, then wait for the confirmation screen before closing the portal. A successful upload appears in your checklist with its received date. If the page is rejected because it is hard to read, replace only that page and keep the earlier confirmation for comparison. You can review the folder at any time to see which documents are received, under review, or still needed. The service team can explain document status and routing, but it cannot provide individualized financial advice. Once every item is marked received, the file moves to the next administrative review step. Save the completed checklist with your other loan records. Keep the confirmation number with the checklist so the team can find the upload quickly online.",
+      "kind": "vertical",
+      "spoken_reference": "your application folder currently contains the signed request proof of income identification and the address page the review team has matched the names on those files but the employer section is still marked incomplete open the document checklist and upload the missing page through the secure portal if your file has more than one page combine them in the order shown so the reviewer can read the form without gaps use the same name and loan reference when you label the upload then wait for the confirmation screen before closing the portal a successful upload appears in your checklist with its received date if the page is rejected because it is hard to read replace only that page and keep the earlier confirmation for comparison you can review the folder at any time to see which documents are received under review or still needed the service team can explain document status and routing but it cannot provide individualized financial advice once every item is marked received the file moves to the next administrative review step save the completed checklist with your other loan records keep the confirmation number with the checklist so the team can find the upload quickly online",
+      "vertical": "loans",
+      "difficulty": "easy",
+      "family": "documents",
+      "length_bucket": "L4",
+      "tags": [
+        "date",
+        "list",
+        "identifier",
+        "conditional"
+      ]
+    },
+    {
+      "testcase_id": "tts2-ln-e-f02-L1",
+      "transcript": "Your loan application is still under review as of today.",
+      "kind": "vertical",
+      "spoken_reference": "your loan application is still under review as of today",
+      "vertical": "loans",
+      "difficulty": "easy",
+      "family": "status",
+      "length_bucket": "L1",
+      "tags": [
+        "date"
+      ]
+    },
+    {
+      "testcase_id": "tts2-ln-e-f02-L2",
+      "transcript": "Your application reached the review queue on April 4. The current status is pending review, and your confirmation code appears in the account message. You can check for updates in the portal.",
+      "kind": "vertical",
+      "spoken_reference": "your application reached the review queue on april fourth the current status is pending review and your confirmation code appears in the account message you can check for updates in the portal",
+      "vertical": "loans",
+      "difficulty": "easy",
+      "family": "status",
+      "length_bucket": "L2",
+      "tags": [
+        "date",
+        "identifier"
+      ]
+    },
+    {
+      "testcase_id": "tts2-ln-e-f02-L3",
+      "transcript": "Your loan request is in the verification stage, and the latest update was posted on July 7. The file reference ends in 4821. No new document is listed as needed right now. Check the portal for the next status message, and keep the reference nearby if you contact the service team. If the review team requests another page, the checklist will show its title and received date. Save each notice with its date.",
+      "kind": "vertical",
+      "spoken_reference": "your loan request is in the verification stage and the latest update was posted on july seventh the file reference ends in four eight two one no new document is listed as needed right now check the portal for the next status message and keep the reference nearby if you contact the service team if the review team requests another page the checklist will show its title and received date save each notice with its date",
+      "vertical": "loans",
+      "difficulty": "easy",
+      "family": "status",
+      "length_bucket": "L3",
+      "tags": [
+        "date",
+        "identifier",
+        "conditional"
+      ]
+    },
+    {
+      "testcase_id": "tts2-ln-e-f02-L4",
+      "transcript": "You have not missed a new request from the review team. The message you received this morning was a reminder to check your application, not a notice that another document is needed. I can help you tell those two kinds of messages apart so you do not spend time looking for a form that has not been requested.\n\nOn the account page, the list of received documents is complete for the current step. That does not mean a decision has been made. It means the file is waiting for the team to review what is already there. If a reviewer needs more information, the request should name what is missing and explain how to send it.\n\nYou said you are about to be away from home for a few days. We can note a contact method that you can use while traveling. The team may still need time to respond, so I cannot offer a decision date from this screen. What I can do now is check that notices are reaching the contact method you chose.\n\nThere is no need to start a second application because of this reminder. We can keep the existing file and ask the team to explain any new request that is unclear. Before we finish, I will confirm the current stage and whether a specific action is listed for you today.",
+      "kind": "vertical",
+      "spoken_reference": "you have not missed a new request from the review team the message you received this morning was a reminder to check your application not a notice that another document is needed i can help you tell those two kinds of messages apart so you do not spend time looking for a form that has not been requested on the account page the list of received documents is complete for the current step that does not mean a decision has been made it means the file is waiting for the team to review what is already there if a reviewer needs more information the request should name what is missing and explain how to send it you said you are about to be away from home for a few days we can note a contact method that you can use while traveling the team may still need time to respond so i cannot offer a decision date from this screen what i can do now is check that notices are reaching the contact method you chose there is no need to start a second application because of this reminder we can keep the existing file and ask the team to explain any new request that is unclear before we finish i will confirm the current stage and whether a specific action is listed for you today",
+      "vertical": "loans",
+      "difficulty": "easy",
+      "family": "status",
+      "length_bucket": "L4",
+      "tags": [
+        "contrast",
+        "conditional"
+      ]
+    },
+    {
+      "testcase_id": "tts2-ln-e-f03-L1",
+      "transcript": "Your loan service record is open, and the account page is ready.",
+      "kind": "vertical",
+      "spoken_reference": "your loan service record is open and the account page is ready",
+      "vertical": "loans",
+      "difficulty": "easy",
+      "family": "servicing",
+      "length_bucket": "L1",
+      "tags": [
+        "time"
+      ]
+    },
+    {
+      "testcase_id": "tts2-ln-e-f03-L2",
+      "transcript": "Your servicing account shows the next scheduled amount as $425 due on June 1. The payment history and mailing details are available in your account. Review them there.",
+      "kind": "vertical",
+      "spoken_reference": "your servicing account shows the next scheduled amount as four hundred twenty five dollars due on june first the payment history and mailing details are available in your account review them there",
+      "vertical": "loans",
+      "difficulty": "easy",
+      "family": "servicing",
+      "length_bucket": "L2",
+      "tags": [
+        "money",
+        "date"
+      ]
+    },
+    {
+      "testcase_id": "tts2-ln-e-f03-L3",
+      "transcript": "The servicing page for your loan shows a posted payment of $580.25 dated September 3. It also lists the next due date, the account address, and the current contact preference. Review those fields before saving any profile change. If you have a receipt, compare its date and amount with the payment history line. The service team can explain how the account record is displayed and can note a question for review.",
+      "kind": "vertical",
+      "spoken_reference": "the servicing page for your loan shows a posted payment of five hundred eighty dollars and twenty five cents dated september third it also lists the next due date the account address and the current contact preference review those fields before saving any profile change if you have a receipt compare its date and amount with the payment history line the service team can explain how the account record is displayed and can note a question for review",
+      "vertical": "loans",
+      "difficulty": "easy",
+      "family": "servicing",
+      "length_bucket": "L3",
+      "tags": [
+        "money",
+        "date",
+        "list"
+      ]
+    },
+    {
+      "testcase_id": "tts2-ln-e-f03-L4",
+      "transcript": "Your loan servicing page brings together the payment history, next due date, mailing address, contact preference, and account notices. The latest posted payment is $740.60 from October 2. Open the payment line to see its received date, posting date, and reference number rather than relying only on the account total. If your receipt shows a different amount or date, keep both records and contact the service team with the exact line details. A profile update should be saved only after you review the confirmation page, because the account may display the new address on a later notice. The page also separates completed payments from scheduled items, so check the status label before assuming a payment has posted. You can download a statement, review recent notices, and save a copy of the current contact details. If the account shows an item you do not recognize, identify its date and description so the team can investigate the record. The servicing desk can explain account history and document routing, but it does not provide individualized financial advice. Keep payment receipts with your statements and use the account reference whenever you call. The next notice will show any later changes to the record.",
+      "kind": "vertical",
+      "spoken_reference": "your loan servicing page brings together the payment history next due date mailing address contact preference and account notices the latest posted payment is seven hundred forty dollars and sixty cents from october second open the payment line to see its received date posting date and reference number rather than relying only on the account total if your receipt shows a different amount or date keep both records and contact the service team with the exact line details a profile update should be saved only after you review the confirmation page because the account may display the new address on a later notice the page also separates completed payments from scheduled items so check the status label before assuming a payment has posted you can download a statement review recent notices and save a copy of the current contact details if the account shows an item you do not recognize identify its date and description so the team can investigate the record the servicing desk can explain account history and document routing but it does not provide individualized financial advice keep payment receipts with your statements and use the account reference whenever you call the next notice will show any later changes to the record",
+      "vertical": "loans",
+      "difficulty": "easy",
+      "family": "servicing",
+      "length_bucket": "L4",
+      "tags": [
+        "money",
+        "date",
+        "list",
+        "conditional"
+      ]
+    },
+    {
+      "testcase_id": "tts2-ln-e-f04-L1",
+      "transcript": "Your payoff statement shows a current amount of $8,200.",
+      "kind": "vertical",
+      "spoken_reference": "your payoff statement shows a current amount of eight thousand two hundred dollars",
+      "vertical": "loans",
+      "difficulty": "easy",
+      "family": "payoff",
+      "length_bucket": "L1",
+      "tags": [
+        "money"
+      ]
+    },
+    {
+      "testcase_id": "tts2-ln-e-f04-L2",
+      "transcript": "Your requested payoff letter is dated March 20 and lists $12,480 as the stated amount. Review the expiration date and account reference in the letter.",
+      "kind": "vertical",
+      "spoken_reference": "your requested payoff letter is dated march twentieth and lists twelve thousand four hundred eighty dollars as the stated amount review the expiration date and account reference in the letter",
+      "vertical": "loans",
+      "difficulty": "easy",
+      "family": "payoff",
+      "length_bucket": "L2",
+      "tags": [
+        "money",
+        "date"
+      ]
+    },
+    {
+      "testcase_id": "tts2-ln-e-f04-L3",
+      "transcript": "Your payoff request produced a statement dated November 10. The amount shown is $19,775.40, and the letter references account PL-208. Check the valid-through date before using the statement. If the date has passed, request a new letter rather than relying on the earlier amount. Keep the statement with your account records while the service team processes any follow-up. Save a copy for reference.",
+      "kind": "vertical",
+      "spoken_reference": "your payoff request produced a statement dated november tenth the amount shown is nineteen thousand seven hundred seventy five dollars and forty cents and the letter references account p l two zero eight check the valid through date before using the statement if the date has passed request a new letter rather than relying on the earlier amount keep the statement with your account records while the service team processes any follow up save a copy for reference",
+      "vertical": "loans",
+      "difficulty": "easy",
+      "family": "payoff",
+      "length_bucket": "L3",
+      "tags": [
+        "money",
+        "date",
+        "identifier"
+      ]
+    },
+    {
+      "testcase_id": "tts2-ln-e-f04-L4",
+      "transcript": "Your payoff statement for account LN-7742 was prepared on December 9 and remains valid through the date printed in the letter. It lists the stated payoff amount, the account reference, the receiving instructions, and the contact details for the servicing team. Review every page before taking action, especially the amount, expiration date, and reference number. A later payment or account change may require a new statement, so do not assume an older letter still shows the current figure. If your records contain two letters, compare their preparation dates and keep the newer one clearly marked. The service team can explain which statement is active, confirm whether a payment has been posted, and record a request for another letter. Use the secure portal or the contact method printed on the statement when sending account documents. Save any receipt or confirmation with the statement that it belongs to. If the letter lists a missing page or unclear instruction, tell the team the page title and reference instead of sending a partial copy. The payoff desk can explain administrative records and routing; it cannot give individualized financial advice or interpret your personal decision. Once the account record is updated, download the current statement and retain it with your loan documents. Check the portal later for the next account notice.",
+      "kind": "vertical",
+      "spoken_reference": "your payoff statement for account l n seven seven four two was prepared on december ninth and remains valid through the date printed in the letter it lists the stated payoff amount the account reference the receiving instructions and the contact details for the servicing team review every page before taking action especially the amount expiration date and reference number a later payment or account change may require a new statement so do not assume an older letter still shows the current figure if your records contain two letters compare their preparation dates and keep the newer one clearly marked the service team can explain which statement is active confirm whether a payment has been posted and record a request for another letter use the secure portal or the contact method printed on the statement when sending account documents save any receipt or confirmation with the statement that it belongs to if the letter lists a missing page or unclear instruction tell the team the page title and reference instead of sending a partial copy the payoff desk can explain administrative records and routing it cannot give individualized financial advice or interpret your personal decision once the account record is updated download the current statement and retain it with your loan documents check the portal later for the next account notice",
+      "vertical": "loans",
+      "difficulty": "easy",
+      "family": "payoff",
+      "length_bucket": "L4",
+      "tags": [
+        "money",
+        "date",
+        "identifier",
+        "list",
+        "conditional"
+      ]
+    },
+    {
+      "testcase_id": "tts2-ln-m-f01-L1",
+      "transcript": "Your self-employment file needs one quarterly statement before review can continue.",
+      "kind": "vertical",
+      "spoken_reference": "your self employment file needs one quarterly statement before review can continue",
+      "vertical": "loans",
+      "difficulty": "medium",
+      "family": "documents",
+      "length_bucket": "L1",
+      "tags": [
+        "list"
+      ]
+    },
+    {
+      "testcase_id": "tts2-ln-m-f01-L2",
+      "transcript": "I matched your business registration and income summary. Please add the missing quarterly statement by June 16. Label it with loan reference LM-204 so the document team can place it correctly.",
+      "kind": "vertical",
+      "spoken_reference": "i matched your business registration and income summary please add the missing quarterly statement by june sixteenth label it with loan reference l m two zero four so the document team can place it correctly",
+      "vertical": "loans",
+      "difficulty": "medium",
+      "family": "documents",
+      "length_bucket": "L2",
+      "tags": [
+        "date",
+        "list",
+        "identifier"
+      ]
+    },
+    {
+      "testcase_id": "tts2-ln-m-f01-L3",
+      "transcript": "Your self-employed documentation includes the business license, two quarterly statements, and the signed application. The reviewer still needs the statement covering the latest quarter, which you can upload through the secure checklist by September 9. Use reference SE-814 in the filename and wait for the portal receipt. If the file has multiple pages, place them in order and keep the original confirmation. The document team will mark the page received before the application moves to the next review step. You can view the checklist to see the received date and any replacement request.",
+      "kind": "vertical",
+      "spoken_reference": "your self employed documentation includes the business license two quarterly statements and the signed application the reviewer still needs the statement covering the latest quarter which you can upload through the secure checklist by september ninth use reference s e eight one four in the filename and wait for the portal receipt if the file has multiple pages place them in order and keep the original confirmation the document team will mark the page received before the application moves to the next review step you can view the checklist to see the received date and any replacement request",
+      "vertical": "loans",
+      "difficulty": "medium",
+      "family": "documents",
+      "length_bucket": "L3",
+      "tags": [
+        "date",
+        "list",
+        "identifier",
+        "domain_term"
+      ]
+    },
+    {
+      "testcase_id": "tts2-ln-m-f01-L4",
+      "transcript": "For the self-employed portion of your application, the document team has matched the business registration, signed request, tax summary, and two quarterly statements. The latest checklist still marks one income statement as missing. Upload that statement through the secure portal under reference SE-4816 and wait for the receipt showing its received date. If the statement contains several pages, keep the pages in their original order and make sure every page is readable. The reviewer compares the business name and reporting period with the application, so do not combine this statement with a different company file. When the upload is accepted, the checklist changes from missing to received; a later message may still mark it under review. If the file is rejected, read the reason in the portal and replace the requested page rather than sending a second copy with a different label. Save each receipt with the corresponding statement. The service desk can explain the checklist, naming convention, and routing history, but it cannot provide individualized financial advice. Once the final statement is matched, the folder moves to the next administrative review. Keep the completed checklist and all receipts together in your loan records.",
+      "kind": "vertical",
+      "spoken_reference": "for the self employed portion of your application the document team has matched the business registration signed request tax summary and two quarterly statements the latest checklist still marks one income statement as missing upload that statement through the secure portal under reference s e four eight one six and wait for the receipt showing its received date if the statement contains several pages keep the pages in their original order and make sure every page is readable the reviewer compares the business name and reporting period with the application so do not combine this statement with a different company file when the upload is accepted the checklist changes from missing to received a later message may still mark it under review if the file is rejected read the reason in the portal and replace the requested page rather than sending a second copy with a different label save each receipt with the corresponding statement the service desk can explain the checklist naming convention and routing history but it cannot provide individualized financial advice once the final statement is matched the folder moves to the next administrative review keep the completed checklist and all receipts together in your loan records",
+      "vertical": "loans",
+      "difficulty": "medium",
+      "family": "documents",
+      "length_bucket": "L4",
+      "tags": [
+        "date",
+        "list",
+        "identifier",
+        "conditional",
+        "domain_term"
+      ]
+    },
+    {
+      "testcase_id": "tts2-ln-m-f02-L1",
+      "transcript": "Your appraisal review is waiting in the queue as of today.",
+      "kind": "vertical",
+      "spoken_reference": "your appraisal review is waiting in the queue as of today",
+      "vertical": "loans",
+      "difficulty": "medium",
+      "family": "status",
+      "length_bucket": "L1",
+      "tags": [
+        "date"
+      ]
+    },
+    {
+      "testcase_id": "tts2-ln-m-f02-L2",
+      "transcript": "The appraisal request entered review on March 11. Your file reference is AP-772, and the portal currently shows waiting for review. Check the status page for the next update.",
+      "kind": "vertical",
+      "spoken_reference": "the appraisal request entered review on march eleventh your file reference is a p seven seven two and the portal currently shows waiting for review check the status page for the next update",
+      "vertical": "loans",
+      "difficulty": "medium",
+      "family": "status",
+      "length_bucket": "L2",
+      "tags": [
+        "date",
+        "identifier"
+      ]
+    },
+    {
+      "testcase_id": "tts2-ln-m-f02-L3",
+      "transcript": "Your appraisal is assigned to the review queue, with the latest status posted on October 3. The request reference ends in 5906. The portal shows the property file received and the appraisal report pending review. If the reviewer needs a clearer document, the status page will list its title and upload date. Save the current notice before replacing any page, and use the same reference when you contact the service team. The desk can explain the queue label and record a follow-up note.",
+      "kind": "vertical",
+      "spoken_reference": "your appraisal is assigned to the review queue with the latest status posted on october third the request reference ends in five nine zero six the portal shows the property file received and the appraisal report pending review if the reviewer needs a clearer document the status page will list its title and upload date save the current notice before replacing any page and use the same reference when you contact the service team the desk can explain the queue label and record a follow up note",
+      "vertical": "loans",
+      "difficulty": "medium",
+      "family": "status",
+      "length_bucket": "L3",
+      "tags": [
+        "date",
+        "identifier",
+        "domain_term",
+        "conditional"
+      ]
+    },
+    {
+      "testcase_id": "tts2-ln-m-f02-L4",
+      "transcript": "The appraisal visit was rescheduled, but your portal still displays the date from the original arrangement. That mismatch does not tell us whether the appraiser has completed the report. I can ask the processing team to confirm the appointment history and distinguish the inspection date from the report-received date.\n\nThe status note carries reference AR-6610 and was posted on November 22. You told me the property visit happened after that note appeared. I will include that sequence in the question so the team can check whether the portal is showing an older event. The review status may remain unchanged until the report is received and logged.\n\nYour other question concerns the contact listed for the property. The file names the person who arranged access, which may be different from the person receiving application updates. I can ask whether that distinction explains why one notice reached the property contact before it appeared in your account.\n\nFor now, the useful next step is to clarify which event each date represents. If the team confirms that the report has arrived, its reply should identify the current review stage. If it has not arrived, the reply should explain who is following up. Neither answer should be read as a lending decision by itself.",
+      "kind": "vertical",
+      "spoken_reference": "the appraisal visit was rescheduled but your portal still displays the date from the original arrangement that mismatch does not tell us whether the appraiser has completed the report i can ask the processing team to confirm the appointment history and distinguish the inspection date from the report received date the status note carries reference a r six six one oh and was posted on november twenty second you told me the property visit happened after that note appeared i will include that sequence in the question so the team can check whether the portal is showing an older event the review status may remain unchanged until the report is received and logged your other question concerns the contact listed for the property the file names the person who arranged access which may be different from the person receiving application updates i can ask whether that distinction explains why one notice reached the property contact before it appeared in your account for now the useful next step is to clarify which event each date represents if the team confirms that the report has arrived its reply should identify the current review stage if it has not arrived the reply should explain who is following up neither answer should be read as a lending decision by itself",
+      "vertical": "loans",
+      "difficulty": "medium",
+      "family": "status",
+      "length_bucket": "L4",
+      "tags": [
+        "domain_term",
+        "identifier",
+        "date",
+        "contrast"
+      ]
+    },
+    {
+      "testcase_id": "tts2-ln-m-f03-L1",
+      "transcript": "Your automatic payment change is recorded for the next billing cycle.",
+      "kind": "vertical",
+      "spoken_reference": "your automatic payment change is recorded for the next billing cycle",
+      "vertical": "loans",
+      "difficulty": "medium",
+      "family": "servicing",
+      "length_bucket": "L1",
+      "tags": [
+        "money"
+      ]
+    },
+    {
+      "testcase_id": "tts2-ln-m-f03-L2",
+      "transcript": "The servicing account shows your automatic payment updated to $615 beginning July 1. Review the funding account name and keep the confirmation page for your records carefully.",
+      "kind": "vertical",
+      "spoken_reference": "the servicing account shows your automatic payment updated to six hundred fifteen dollars beginning july first review the funding account name and keep the confirmation page for your records carefully",
+      "vertical": "loans",
+      "difficulty": "medium",
+      "family": "servicing",
+      "length_bucket": "L2",
+      "tags": [
+        "money",
+        "date"
+      ]
+    },
+    {
+      "testcase_id": "tts2-ln-m-f03-L3",
+      "transcript": "Your automatic payment request was saved on May 27 under confirmation PM-318. The next scheduled amount is $492.80. Check the funding account and effective date in the confirmation. If the old amount still appears in a notice, compare its posting date with the change record before contacting servicing. The team can explain how the account displays scheduled and completed payments, and can record a correction request when the records disagree.",
+      "kind": "vertical",
+      "spoken_reference": "your automatic payment request was saved on may twenty seventh under confirmation p m three one eight the next scheduled amount is four hundred ninety two dollars and eighty cents check the funding account and effective date in the confirmation if the old amount still appears in a notice compare its posting date with the change record before contacting servicing the team can explain how the account displays scheduled and completed payments and can record a correction request when the records disagree",
+      "vertical": "loans",
+      "difficulty": "medium",
+      "family": "servicing",
+      "length_bucket": "L3",
+      "tags": [
+        "money",
+        "date",
+        "identifier",
+        "conditional"
+      ]
+    },
+    {
+      "testcase_id": "tts2-ln-m-f03-L4",
+      "transcript": "Your servicing history shows one returned payment and a later automatic payment change. The returned item is dated September 6 and references RP-2408. The updated automatic payment is scheduled for $688.15 on October 1. Open the two entries separately to see their dates, statuses, and account notes. The returned item remains in history even after a later payment is recorded. The change confirmation identifies the funding account and the date it becomes active, so compare those fields with your current notice. If your receipt differs from the history, keep both records and provide the reference numbers to servicing. The team can review whether a payment is returned, pending, or posted and can add a note for follow-up. It cannot give individualized financial advice or promise a future posting result. Save the returned-payment notice, the new confirmation, and any updated statement together. When a later statement arrives, compare its status labels with this history rather than relying on memory. Use the newest account notice when contacting the desk and keep older copies marked with their dates. Keep the confirmation visible for later account calls. Store all notices together safely.",
+      "kind": "vertical",
+      "spoken_reference": "your servicing history shows one returned payment and a later automatic payment change the returned item is dated september sixth and references r p two four zero eight the updated automatic payment is scheduled for six hundred eighty eight dollars and fifteen cents on october first open the two entries separately to see their dates statuses and account notes the returned item remains in history even after a later payment is recorded the change confirmation identifies the funding account and the date it becomes active so compare those fields with your current notice if your receipt differs from the history keep both records and provide the reference numbers to servicing the team can review whether a payment is returned pending or posted and can add a note for follow up it cannot give individualized financial advice or promise a future posting result save the returned payment notice the new confirmation and any updated statement together when a later statement arrives compare its status labels with this history rather than relying on memory use the newest account notice when contacting the desk and keep older copies marked with their dates keep the confirmation visible for later account calls store all notices together safely",
+      "vertical": "loans",
+      "difficulty": "medium",
+      "family": "servicing",
+      "length_bucket": "L4",
+      "tags": [
+        "money",
+        "date",
+        "identifier",
+        "list",
+        "conditional"
+      ]
+    },
+    {
+      "testcase_id": "tts2-ln-m-f04-L1",
+      "transcript": "Your payoff quote expires on October 31 and lists $14,600.",
+      "kind": "vertical",
+      "spoken_reference": "your payoff quote expires on october thirty first and lists fourteen thousand six hundred dollars",
+      "vertical": "loans",
+      "difficulty": "medium",
+      "family": "payoff",
+      "length_bucket": "L1",
+      "tags": [
+        "money",
+        "date"
+      ]
+    },
+    {
+      "testcase_id": "tts2-ln-m-f04-L2",
+      "transcript": "Your payoff quote issued on February 2 lists $27,410.75. It is tied to reference PQ-903. Check its expiration date before using the letter.",
+      "kind": "vertical",
+      "spoken_reference": "your payoff quote issued on february second lists twenty seven thousand four hundred ten dollars and seventy five cents it is tied to reference p q nine zero three check its expiration date before using the letter",
+      "vertical": "loans",
+      "difficulty": "medium",
+      "family": "payoff",
+      "length_bucket": "L2",
+      "tags": [
+        "money",
+        "date",
+        "identifier"
+      ]
+    },
+    {
+      "testcase_id": "tts2-ln-m-f04-L3",
+      "transcript": "Your payoff quote for reference QT-6142 was issued on August 8 and lists $31,905.10. The letter is valid only through the date printed in its header. If you need a quote after that date, request a new letter rather than relying on the earlier amount. Keep the quote and any delivery receipt together while the service team checks the account record. The payoff desk can explain expiration and document delivery, but it cannot provide individualized financial advice.",
+      "kind": "vertical",
+      "spoken_reference": "your payoff quote for reference q t six one four two was issued on august eighth and lists thirty one thousand nine hundred five dollars and ten cents the letter is valid only through the date printed in its header if you need a quote after that date request a new letter rather than relying on the earlier amount keep the quote and any delivery receipt together while the service team checks the account record the payoff desk can explain expiration and document delivery but it cannot provide individualized financial advice",
+      "vertical": "loans",
+      "difficulty": "medium",
+      "family": "payoff",
+      "length_bucket": "L3",
+      "tags": [
+        "money",
+        "date",
+        "identifier",
+        "conditional"
+      ]
+    },
+    {
+      "testcase_id": "tts2-ln-m-f04-L4",
+      "transcript": "Your payoff quote was prepared under reference QF-1807 on December 14. It lists the quoted amount, valid-through date, receiving instructions, and delivery contact for the servicing team. The account portal shows that the letter was delivered, but it does not show a completed payoff payment. Keep the quote, delivery receipt, and any later statement together so the dates can be compared. If the valid-through date passes before the account record changes, request a new quote because a replacement may contain a different amount. When you receive a new letter, mark the earlier version as expired rather than combining pages from both. The payoff desk can confirm which reference is current, whether a document was delivered, and whether a payment has posted. It can also record that you need another receipt or a copy of the delivery notice. Review the account number and receiving instructions on every version before sending documents. The service team handles administrative records and routing; it cannot advise you on a personal financial decision. Save the final quote and confirmation in your loan folder, then check the portal for the next account update. If a message appears incomplete, provide the reference and page title so the desk can locate the correct file.",
+      "kind": "vertical",
+      "spoken_reference": "your payoff quote was prepared under reference q f one eight zero seven on december fourteenth it lists the quoted amount valid through date receiving instructions and delivery contact for the servicing team the account portal shows that the letter was delivered but it does not show a completed payoff payment keep the quote delivery receipt and any later statement together so the dates can be compared if the valid through date passes before the account record changes request a new quote because a replacement may contain a different amount when you receive a new letter mark the earlier version as expired rather than combining pages from both the payoff desk can confirm which reference is current whether a document was delivered and whether a payment has posted it can also record that you need another receipt or a copy of the delivery notice review the account number and receiving instructions on every version before sending documents the service team handles administrative records and routing it cannot advise you on a personal financial decision save the final quote and confirmation in your loan folder then check the portal for the next account update if a message appears incomplete provide the reference and page title so the desk can locate the correct file",
+      "vertical": "loans",
+      "difficulty": "medium",
+      "family": "payoff",
+      "length_bucket": "L4",
+      "tags": [
+        "money",
+        "date",
+        "identifier",
+        "list",
+        "conditional"
+      ]
+    },
+    {
+      "testcase_id": "tts2-ln-h-f01-L1",
+      "transcript": "Your loan packet is missing the signed disbursement authorization page.",
+      "kind": "vertical",
+      "spoken_reference": "your loan packet is missing the signed disbursement authorization page",
+      "vertical": "loans",
+      "difficulty": "hard",
+      "family": "documents",
+      "length_bucket": "L1",
+      "tags": [
+        "domain_term"
+      ]
+    },
+    {
+      "testcase_id": "tts2-ln-h-f01-L2",
+      "transcript": "The disbursement file needs your signed authorization and the closing checklist. Upload both by October 21 under reference DS-418. The document team will confirm receipt in the portal.",
+      "kind": "vertical",
+      "spoken_reference": "the disbursement file needs your signed authorization and the closing checklist upload both by october twenty first under reference d s four one eight the document team will confirm receipt in the portal",
+      "vertical": "loans",
+      "difficulty": "hard",
+      "family": "documents",
+      "length_bucket": "L2",
+      "tags": [
+        "date",
+        "identifier",
+        "domain_term"
+      ]
+    },
+    {
+      "testcase_id": "tts2-ln-h-f01-L3",
+      "transcript": "Your closing packet contains the executed note, disbursement schedule, escrow worksheet, and identification page. The review team still needs the signed authorization that permits the file to move into administrative disbursement review. Upload that page by November 12 under reference CL-7094. Keep the signature page separate from the worksheet so the reviewer can match its title. After upload, wait for the portal receipt and check that the page is marked received rather than merely saved. If the team rejects the image, replace the requested page and keep the original receipt. The document desk can explain the checklist and routing history, but not provide individualized financial advice.",
+      "kind": "vertical",
+      "spoken_reference": "your closing packet contains the executed note disbursement schedule escrow worksheet and identification page the review team still needs the signed authorization that permits the file to move into administrative disbursement review upload that page by november twelfth under reference c l seven zero nine four keep the signature page separate from the worksheet so the reviewer can match its title after upload wait for the portal receipt and check that the page is marked received rather than merely saved if the team rejects the image replace the requested page and keep the original receipt the document desk can explain the checklist and routing history but not provide individualized financial advice",
+      "vertical": "loans",
+      "difficulty": "hard",
+      "family": "documents",
+      "length_bucket": "L3",
+      "tags": [
+        "date",
+        "identifier",
+        "domain_term",
+        "list"
+      ]
+    },
+    {
+      "testcase_id": "tts2-ln-h-f01-L4",
+      "transcript": "Your loan packet is in document review for disbursement, and the checklist currently shows the executed note, closing disclosure, escrow worksheet, identification page, and signed authorization as received. The reviewer has flagged one missing page from the subordinated lien acknowledgment. Upload the page through the secure portal under reference DL-5820 and preserve the page order shown in the checklist. The document team compares the lien name, account reference, and signature block with the rest of the packet, so do not merge it with an unrelated version. If the acknowledgment contains a percentage such as 2.5% keep that notation in the written copy and let the portal record the original page. After submission, wait for a receipt containing the received date and page title. If the page is rejected as incomplete, read the exact reason and replace only the requested section. A corrected upload should retain the same reference so the team can connect it to the packet. The desk can explain document status, naming, and routing, but it cannot interpret lien priority or give individualized financial advice. Keep the checklist, receipts, and corrected pages together. Once every required item is received, the packet proceeds to the next administrative review. Save the final confirmation with your other closing records and use the packet reference for later calls.",
+      "kind": "vertical",
+      "spoken_reference": "your loan packet is in document review for disbursement and the checklist currently shows the executed note closing disclosure escrow worksheet identification page and signed authorization as received the reviewer has flagged one missing page from the subordinated lien acknowledgment upload the page through the secure portal under reference d l five eight two zero and preserve the page order shown in the checklist the document team compares the lien name account reference and signature block with the rest of the packet so do not merge it with an unrelated version if the acknowledgment contains a percentage such as two point five percent keep that notation in the written copy and let the portal record the original page after submission wait for a receipt containing the received date and page title if the page is rejected as incomplete read the exact reason and replace only the requested section a corrected upload should retain the same reference so the team can connect it to the packet the desk can explain document status naming and routing but it cannot interpret lien priority or give individualized financial advice keep the checklist receipts and corrected pages together once every required item is received the packet proceeds to the next administrative review save the final confirmation with your other closing records and use the packet reference for later calls",
+      "vertical": "loans",
+      "difficulty": "hard",
+      "family": "documents",
+      "length_bucket": "L4",
+      "tags": [
+        "date",
+        "identifier",
+        "domain_term",
+        "list",
+        "conditional",
+        "percentage"
+      ]
+    },
+    {
+      "testcase_id": "tts2-ln-h-f02-L1",
+      "transcript": "The amortization review is pending, and your portal shows the file in queue.",
+      "kind": "vertical",
+      "spoken_reference": "the amortization review is pending and your portal shows the file in queue",
+      "vertical": "loans",
+      "difficulty": "hard",
+      "family": "status",
+      "length_bucket": "L1",
+      "tags": [
+        "domain_term"
+      ]
+    },
+    {
+      "testcase_id": "tts2-ln-h-f02-L2",
+      "transcript": "Your amortization schedule is waiting for a verification pass dated July 18. The file reference is AM-640. Open the status page to see whether the payment history and schedule are marked received.",
+      "kind": "vertical",
+      "spoken_reference": "your amortization schedule is waiting for a verification pass dated july eighteenth the file reference is a m six four zero open the status page to see whether the payment history and schedule are marked received",
+      "vertical": "loans",
+      "difficulty": "hard",
+      "family": "status",
+      "length_bucket": "L2",
+      "tags": [
+        "date",
+        "identifier",
+        "domain_term"
+      ]
+    },
+    {
+      "testcase_id": "tts2-ln-h-f02-L3",
+      "transcript": "Your application is in the amortization verification queue, with the latest status posted on January 29 under reference AV-3118. The portal lists the payment history and original schedule as received, while the revised schedule remains under review. Open each line separately because the received date and status label may differ. If the reviewer requests a clearer statement, the checklist will name the exact page and upload date. Keep the current notice and receipt together, and use the reference when contacting servicing. The desk can explain queue labels and document routing, not the terms of a personal loan.",
+      "kind": "vertical",
+      "spoken_reference": "your application is in the amortization verification queue with the latest status posted on january twenty ninth under reference a v three one one eight the portal lists the payment history and original schedule as received while the revised schedule remains under review open each line separately because the received date and status label may differ if the reviewer requests a clearer statement the checklist will name the exact page and upload date keep the current notice and receipt together and use the reference when contacting servicing the desk can explain queue labels and document routing not the terms of a personal loan",
+      "vertical": "loans",
+      "difficulty": "hard",
+      "family": "status",
+      "length_bucket": "L3",
+      "tags": [
+        "date",
+        "identifier",
+        "domain_term",
+        "list"
+      ]
+    },
+    {
+      "testcase_id": "tts2-ln-h-f02-L4",
+      "transcript": "A conditional approval notice and a disbursement hold appear together in your file, and they refer to different stages. The approval notice records the review outcome subject to its stated conditions. The hold means the funds have not been released. I can ask the closing coordinator to identify the unresolved condition without treating either status as a replacement for the other.\n\nThe outstanding entry is labeled lien-priority verification under reference LP-408. A payoff statement has been received, but the status note does not establish whether the coordinator has matched it to the required release documentation. I will request a clarification of that association rather than ask you to send every document again.\n\nYou also noticed an amortization schedule in the closing packet with a different preparation date. That date may identify the document version, not the planned disbursement date. The coordinator should explain which schedule belongs to the current packet and whether a replacement is expected before the hold can be resolved.\n\nMy follow-up will separate those two questions: the lien-priority entry and the schedule version. You can then compare the coordinator's response with the condition listed in your notice. If additional documentation is required, the request should name it clearly and specify where it belongs. I cannot confirm a release time while this hold remains unresolved, but I can make sure the status question reaches the closing team handling your file.",
+      "kind": "vertical",
+      "spoken_reference": "a conditional approval notice and a disbursement hold appear together in your file and they refer to different stages the approval notice records the review outcome subject to its stated conditions the hold means the funds have not been released i can ask the closing coordinator to identify the unresolved condition without treating either status as a replacement for the other the outstanding entry is labeled lien priority verification under reference l p four oh eight a payoff statement has been received but the status note does not establish whether the coordinator has matched it to the required release documentation i will request a clarification of that association rather than ask you to send every document again you also noticed an amortization schedule in the closing packet with a different preparation date that date may identify the document version not the planned disbursement date the coordinator should explain which schedule belongs to the current packet and whether a replacement is expected before the hold can be resolved my follow up will separate those two questions the lien priority entry and the schedule version you can then compare the coordinator's response with the condition listed in your notice if additional documentation is required the request should name it clearly and specify where it belongs i cannot confirm a release time while this hold remains unresolved but i can make sure the status question reaches the closing team handling your file",
+      "vertical": "loans",
+      "difficulty": "hard",
+      "family": "status",
+      "length_bucket": "L4",
+      "tags": [
+        "domain_term",
+        "identifier",
+        "contrast",
+        "conditional"
+      ]
+    },
+    {
+      "testcase_id": "tts2-ln-h-f03-L1",
+      "transcript": "Your escrow reconciliation shows a recorded balance of $1,240.",
+      "kind": "vertical",
+      "spoken_reference": "your escrow reconciliation shows a recorded balance of one thousand two hundred forty dollars",
+      "vertical": "loans",
+      "difficulty": "hard",
+      "family": "servicing",
+      "length_bucket": "L1",
+      "tags": [
+        "money",
+        "domain_term"
+      ]
+    },
+    {
+      "testcase_id": "tts2-ln-h-f03-L2",
+      "transcript": "The servicing record lists an escrow adjustment of $86.40 dated May 6. The worksheet shows a reserve percentage of 10%. Review the reconciliation line and keep the statement for your records.",
+      "kind": "vertical",
+      "spoken_reference": "the servicing record lists an escrow adjustment of eighty six dollars and forty cents dated may sixth the worksheet shows a reserve percentage of ten percent review the reconciliation line and keep the statement for your records",
+      "vertical": "loans",
+      "difficulty": "hard",
+      "family": "servicing",
+      "length_bucket": "L2",
+      "tags": [
+        "money",
+        "percentage",
+        "date",
+        "domain_term"
+      ]
+    },
+    {
+      "testcase_id": "tts2-ln-h-f03-L3",
+      "transcript": "Your escrow reconciliation dated September 30 references ER-2195 and lists the projected tax entry, insurance entry, prior reserve, and recorded disbursement. The current worksheet shows a difference of $143.22. Open each line to compare its posting date with the statement you received. If your receipt uses a different description, keep both copies and provide the reference to servicing. The desk can explain how the administrative worksheet is organized, while personal financial advice is outside this service.",
+      "kind": "vertical",
+      "spoken_reference": "your escrow reconciliation dated september thirtieth references e r two one nine five and lists the projected tax entry insurance entry prior reserve and recorded disbursement the current worksheet shows a difference of one hundred forty three dollars and twenty two cents open each line to compare its posting date with the statement you received if your receipt uses a different description keep both copies and provide the reference to servicing the desk can explain how the administrative worksheet is organized while personal financial advice is outside this service",
+      "vertical": "loans",
+      "difficulty": "hard",
+      "family": "servicing",
+      "length_bucket": "L3",
+      "tags": [
+        "money",
+        "date",
+        "identifier",
+        "domain_term",
+        "list"
+      ]
+    },
+    {
+      "testcase_id": "tts2-ln-h-f03-L4",
+      "transcript": "Your servicing account contains an escrow reconciliation prepared on October 18 under reference ES-7740. The worksheet separates projected taxes, insurance, prior reserve, recorded disbursements, and the current account balance. It shows a reconciliation difference of $267.35 and a reserve percentage of 12%. Open each line to see its source date and description instead of relying on the worksheet total. If a statement from an outside office uses a different date, retain both documents and tell servicing which line you want matched. The team can compare the administrative entries, record a correction request, and explain when an updated worksheet is posted. It cannot interpret a personal financial choice or promise a future account result. Keep the original worksheet marked with its preparation date, and save each revised copy separately. The account may show a projected item beside a completed disbursement, so check the status label before treating both as posted. Use the reference when contacting the desk and include the page title if the question concerns one line. After review, download the current reconciliation and keep it with your statements and payment records. The next notice will show any later change to the account history.",
+      "kind": "vertical",
+      "spoken_reference": "your servicing account contains an escrow reconciliation prepared on october eighteenth under reference e s seven seven four zero the worksheet separates projected taxes insurance prior reserve recorded disbursements and the current account balance it shows a reconciliation difference of two hundred sixty seven dollars and thirty five cents and a reserve percentage of twelve percent open each line to see its source date and description instead of relying on the worksheet total if a statement from an outside office uses a different date retain both documents and tell servicing which line you want matched the team can compare the administrative entries record a correction request and explain when an updated worksheet is posted it cannot interpret a personal financial choice or promise a future account result keep the original worksheet marked with its preparation date and save each revised copy separately the account may show a projected item beside a completed disbursement so check the status label before treating both as posted use the reference when contacting the desk and include the page title if the question concerns one line after review download the current reconciliation and keep it with your statements and payment records the next notice will show any later change to the account history",
+      "vertical": "loans",
+      "difficulty": "hard",
+      "family": "servicing",
+      "length_bucket": "L4",
+      "tags": [
+        "money",
+        "date",
+        "identifier",
+        "domain_term",
+        "list",
+        "conditional",
+        "percentage"
+      ]
+    },
+    {
+      "testcase_id": "tts2-ln-h-f04-L1",
+      "transcript": "Your payoff quote includes per diem interest of $48.25.",
+      "kind": "vertical",
+      "spoken_reference": "your payoff quote includes per diem interest of forty eight dollars and twenty five cents",
+      "vertical": "loans",
+      "difficulty": "hard",
+      "family": "payoff",
+      "length_bucket": "L1",
+      "tags": [
+        "money",
+        "domain_term"
+      ]
+    },
+    {
+      "testcase_id": "tts2-ln-h-f04-L2",
+      "transcript": "Your payoff letter dated June 5 lists $22,840 plus per diem interest of $37.10. Reference PD-417 appears in the header; check the expiration date before using the letter.",
+      "kind": "vertical",
+      "spoken_reference": "your payoff letter dated june fifth lists twenty two thousand eight hundred forty dollars plus per diem interest of thirty seven dollars and ten cents reference p d four one seven appears in the header check the expiration date before using the letter",
+      "vertical": "loans",
+      "difficulty": "hard",
+      "family": "payoff",
+      "length_bucket": "L2",
+      "tags": [
+        "money",
+        "date",
+        "identifier",
+        "domain_term"
+      ]
+    },
+    {
+      "testcase_id": "tts2-ln-h-f04-L3",
+      "transcript": "Your payoff quote for account reference PO-6912 was prepared on August 12. It lists a principal balance of $41,280 and per diem interest of $42.75. The letter is valid through its printed date, so request a new quote if delivery or processing extends beyond that date. Keep the quote and delivery confirmation together while the service team checks the account record. The payoff desk can explain the letter, reference, and receipt status, but it cannot provide individualized financial advice.",
+      "kind": "vertical",
+      "spoken_reference": "your payoff quote for account reference p o six nine one two was prepared on august twelfth it lists a principal balance of forty one thousand two hundred eighty dollars and per diem interest of forty two dollars and seventy five cents the letter is valid through its printed date so request a new quote if delivery or processing extends beyond that date keep the quote and delivery confirmation together while the service team checks the account record the payoff desk can explain the letter reference and receipt status but it cannot provide individualized financial advice",
+      "vertical": "loans",
+      "difficulty": "hard",
+      "family": "payoff",
+      "length_bucket": "L3",
+      "tags": [
+        "money",
+        "date",
+        "identifier",
+        "domain_term",
+        "conditional"
+      ]
+    },
+    {
+      "testcase_id": "tts2-ln-h-f04-L4",
+      "transcript": "The title company's message asks for a payoff quotation, but the attachment you forwarded is a payment-history summary. Those documents serve different purposes. I can help you request the quotation the closing team needs and clarify where the authorized copy should be delivered.\n\nYour portal has a draft request under PL-604. It identifies the loan, but it does not yet name the intended recipient. Before the servicing team sends account information outside your portal, it should confirm the delivery authorization associated with that request. You do not need to paste account credentials into a message to establish that authorization.\n\nThe summary also shows a recent credit of $480.25. I will flag that posting for the payoff specialist so it can determine whether the quotation already reflects the credit. We should not subtract the amount from another document ourselves, because the specialist must reconcile the transaction timing and any per diem interest entry.\n\nYou asked whether receiving the quotation means a lien release has been completed. It does not establish that outcome; the quotation and the release record are separate documents. The servicing team can explain what is available in your file and what confirmation the closing team still needs. My request will focus on the correct document, its authorized recipient, and the recent credit, so those questions reach the payoff specialist together.",
+      "kind": "vertical",
+      "spoken_reference": "the title company's message asks for a payoff quotation but the attachment you forwarded is a payment history summary those documents serve different purposes i can help you request the quotation the closing team needs and clarify where the authorized copy should be delivered your portal has a draft request under p l six oh four it identifies the loan but it does not yet name the intended recipient before the servicing team sends account information outside your portal it should confirm the delivery authorization associated with that request you do not need to paste account credentials into a message to establish that authorization the summary also shows a recent credit of four hundred eighty dollars and twenty five cents i will flag that posting for the payoff specialist so it can determine whether the quotation already reflects the credit we should not subtract the amount from another document ourselves because the specialist must reconcile the transaction timing and any per diem interest entry you asked whether receiving the quotation means a lien release has been completed it does not establish that outcome the quotation and the release record are separate documents the servicing team can explain what is available in your file and what confirmation the closing team still needs my request will focus on the correct document its authorized recipient and the recent credit so those questions reach the payoff specialist together",
+      "vertical": "loans",
+      "difficulty": "hard",
+      "family": "payoff",
+      "length_bucket": "L4",
+      "tags": [
+        "domain_term",
+        "money",
+        "identifier",
+        "contrast",
+        "conditional"
+      ]
+    },
+    {
+      "testcase_id": "tts2-cs-e-f01-L1",
+      "transcript": "Your connection is working again, so you can return to the page now.",
+      "kind": "vertical",
+      "spoken_reference": "your connection is working again so you can return to the page now",
+      "vertical": "customer_service",
+      "difficulty": "easy",
+      "family": "troubleshooting",
+      "length_bucket": "L1",
+      "tags": []
+    },
+    {
+      "testcase_id": "tts2-cs-e-f01-L2",
+      "transcript": "I restarted your connection session. Please close the app, open it again, and try the same page. Your saved settings will remain in place.  The home page should open normally now.",
+      "kind": "vertical",
+      "spoken_reference": "i restarted your connection session please close the app open it again and try the same page your saved settings will remain in place the home page should open normally now",
+      "vertical": "customer_service",
+      "difficulty": "easy",
+      "family": "troubleshooting",
+      "length_bucket": "L2",
+      "tags": [
+        "conditional"
+      ]
+    },
+    {
+      "testcase_id": "tts2-cs-e-f01-L3",
+      "transcript": "The sign-in page is responding again after I refreshed your account session. Close the app completely, reopen it, and try the page once more. If the page loads, you can continue where you stopped. If it still appears blank, switch from wireless data to your home connection and check whether other pages open. Do not enter the same request repeatedly while the first one is loading, because that can create duplicate attempts. Your recent activity will show whether the original request finished.",
+      "kind": "vertical",
+      "spoken_reference": "the sign in page is responding again after i refreshed your account session close the app completely reopen it and try the page once more if the page loads you can continue where you stopped if it still appears blank switch from wireless data to your home connection and check whether other pages open do not enter the same request repeatedly while the first one is loading because that can create duplicate attempts your recent activity will show whether the original request finished",
+      "vertical": "customer_service",
+      "difficulty": "easy",
+      "family": "troubleshooting",
+      "length_bucket": "L3",
+      "tags": [
+        "conditional"
+      ]
+    },
+    {
+      "testcase_id": "tts2-cs-e-f01-L4",
+      "transcript": "Your service is reachable, but the page is failing during the final loading step. I cleared the temporary session and kept your saved preferences unchanged. Start by closing the app rather than pressing the button repeatedly. Reopen it, wait for the home screen, and select the affected feature once. If it loads, review the last confirmation before trying anything new. If the screen remains blank, test another page so we can tell whether the issue affects one feature or the whole service. A different connection can also reveal whether the problem is local to your network. Do not remove the app or erase your saved data while we check this. Your recent activity can show whether the earlier request completed even if the screen did not refresh. If it did complete, use that existing result instead of submitting another request. If it did not, the feature can be tried again after the connection is stable.  Your activity record can confirm whether the first request finished.  If the same page fails again, note whether the home screen and another feature still work. That comparison tells us whether the problem is limited to one function or affects the whole service. Keep the successful result in your activity list instead of submitting another request immediately.",
+      "kind": "vertical",
+      "spoken_reference": "your service is reachable but the page is failing during the final loading step i cleared the temporary session and kept your saved preferences unchanged start by closing the app rather than pressing the button repeatedly reopen it wait for the home screen and select the affected feature once if it loads review the last confirmation before trying anything new if the screen remains blank test another page so we can tell whether the issue affects one feature or the whole service a different connection can also reveal whether the problem is local to your network do not remove the app or erase your saved data while we check this your recent activity can show whether the earlier request completed even if the screen did not refresh if it did complete use that existing result instead of submitting another request if it did not the feature can be tried again after the connection is stable your activity record can confirm whether the first request finished if the same page fails again note whether the home screen and another feature still work that comparison tells us whether the problem is limited to one function or affects the whole service keep the successful result in your activity list instead of submitting another request immediately",
+      "vertical": "customer_service",
+      "difficulty": "easy",
+      "family": "troubleshooting",
+      "length_bucket": "L4",
+      "tags": [
+        "conditional"
+      ]
+    },
+    {
+      "testcase_id": "tts2-cs-e-f02-L1",
+      "transcript": "Your subscription is active, and the next service period is ready to use.",
+      "kind": "vertical",
+      "spoken_reference": "your subscription is active and the next service period is ready to use",
+      "vertical": "customer_service",
+      "difficulty": "easy",
+      "family": "subscription",
+      "length_bucket": "L1",
+      "tags": []
+    },
+    {
+      "testcase_id": "tts2-cs-e-f02-L2",
+      "transcript": "I found your subscription and confirmed that it is active. You can use the included features today, and your account page shows the next renewal date.  Your included features remain available during this period.",
+      "kind": "vertical",
+      "spoken_reference": "i found your subscription and confirmed that it is active you can use the included features today and your account page shows the next renewal date your included features remain available during this period",
+      "vertical": "customer_service",
+      "difficulty": "easy",
+      "family": "subscription",
+      "length_bucket": "L2",
+      "tags": [
+        "conditional"
+      ]
+    },
+    {
+      "testcase_id": "tts2-cs-e-f02-L3",
+      "transcript": "Your monthly plan is active through the current service period. The account page lists the included features and the next renewal date. You can change the plan from that page, and the new choice will be shown before you confirm. If you turn off renewal, access remains available through the period already shown. A canceled renewal will not create another charge after that date. Your current settings are unchanged while you review the options.  The renewal setting and current access are shown on separate lines, so you can check both before making a change.",
+      "kind": "vertical",
+      "spoken_reference": "your monthly plan is active through the current service period the account page lists the included features and the next renewal date you can change the plan from that page and the new choice will be shown before you confirm if you turn off renewal access remains available through the period already shown a canceled renewal will not create another charge after that date your current settings are unchanged while you review the options the renewal setting and current access are shown on separate lines so you can check both before making a change",
+      "vertical": "customer_service",
+      "difficulty": "easy",
+      "family": "subscription",
+      "length_bucket": "L3",
+      "tags": [
+        "conditional"
+      ]
+    },
+    {
+      "testcase_id": "tts2-cs-e-f02-L4",
+      "transcript": "Your subscription has an active period and a separate renewal setting, so those two labels can look different. The active period shows what you can use now; the renewal setting shows whether another period will begin afterward. Open your account page to compare the plan name, included features, next renewal date, and payment status. If you choose a different plan, read the summary before saving because the feature list may change. If you turn off renewal, the current period stays available until its displayed end date, but a new period will not begin afterward. You can return to the page later and enable renewal again before that date. A confirmation banner appears after each saved change, and the subscription history keeps the earlier setting. If you see an old plan name in a separate device, refresh that device rather than changing the subscription twice. Your account page is the best place to verify the current plan and its next action.  Your subscription history keeps each saved choice, so you can compare the current plan with the earlier setting.  The active period is not shortened when you change the renewal setting. If you switch plans, the summary identifies what changes now and what begins later. Check the confirmation after saving, and refresh another device only after the account page shows the new status.",
+      "kind": "vertical",
+      "spoken_reference": "your subscription has an active period and a separate renewal setting so those two labels can look different the active period shows what you can use now the renewal setting shows whether another period will begin afterward open your account page to compare the plan name included features next renewal date and payment status if you choose a different plan read the summary before saving because the feature list may change if you turn off renewal the current period stays available until its displayed end date but a new period will not begin afterward you can return to the page later and enable renewal again before that date a confirmation banner appears after each saved change and the subscription history keeps the earlier setting if you see an old plan name in a separate device refresh that device rather than changing the subscription twice your account page is the best place to verify the current plan and its next action your subscription history keeps each saved choice so you can compare the current plan with the earlier setting the active period is not shortened when you change the renewal setting if you switch plans the summary identifies what changes now and what begins later check the confirmation after saving and refresh another device only after the account page shows the new status",
+      "vertical": "customer_service",
+      "difficulty": "easy",
+      "family": "subscription",
+      "length_bucket": "L4",
+      "tags": [
+        "conditional"
+      ]
+    },
+    {
+      "testcase_id": "tts2-cs-e-f03-L1",
+      "transcript": "Your corrected charge is now visible, and the account total has been updated.",
+      "kind": "vertical",
+      "spoken_reference": "your corrected charge is now visible and the account total has been updated",
+      "vertical": "customer_service",
+      "difficulty": "easy",
+      "family": "billing_correction",
+      "length_bucket": "L1",
+      "tags": []
+    },
+    {
+      "testcase_id": "tts2-cs-e-f03-L2",
+      "transcript": "I adjusted your duplicate charge. Your billing page now shows one completed payment and one matching credit, so the total reflects the correction.  The credit is listed in your billing history.",
+      "kind": "vertical",
+      "spoken_reference": "i adjusted your duplicate charge your billing page now shows one completed payment and one matching credit so the total reflects the correction the credit is listed in your billing history",
+      "vertical": "customer_service",
+      "difficulty": "easy",
+      "family": "billing_correction",
+      "length_bucket": "L2",
+      "tags": [
+        "conditional"
+      ]
+    },
+    {
+      "testcase_id": "tts2-cs-e-f03-L3",
+      "transcript": "Your billing history showed the same order twice, so I applied a correction to the extra entry. The original payment remains listed, and the matching credit appears separately. Open the order details to compare the item name, date, and final total. Your account total includes the credit, although it may take a short time for the updated balance to appear on another device. Keep the receipt and correction notice together. If the original charge is still pending, it can disappear rather than receive a second credit.",
+      "kind": "vertical",
+      "spoken_reference": "your billing history showed the same order twice so i applied a correction to the extra entry the original payment remains listed and the matching credit appears separately open the order details to compare the item name date and final total your account total includes the credit although it may take a short time for the updated balance to appear on another device keep the receipt and correction notice together if the original charge is still pending it can disappear rather than receive a second credit",
+      "vertical": "customer_service",
+      "difficulty": "easy",
+      "family": "billing_correction",
+      "length_bucket": "L3",
+      "tags": [
+        "conditional"
+      ]
+    },
+    {
+      "testcase_id": "tts2-cs-e-f03-L4",
+      "transcript": "Your billing page contained two entries for one order, and the correction process keeps those records linked. The original completed payment remains in the history, while the duplicate line now has a matching credit. Open each detail row to compare the order name, date, payment status, and final total. The account total includes the correction, but a second device may need a refresh before it displays the same amount. Do not submit another refund request for the duplicate while this correction is processing, because that could create a second adjustment. Keep your receipt and the correction notice together until the credit appears as completed. When the first charge remains pending, it may disappear when the authorization expires instead of receiving a separate credit. If the corrected total still looks wrong, compare the itemized order with the two history rows and note which line is completed. Your billing page will retain the correction record so the result can be checked later.  The correction entry remains linked to the original order, making the final total easier to verify.  A credit can be pending before it becomes part of the available total. Check the correction status and the original payment status separately, then compare both with the itemized receipt. If the duplicate disappears without a credit, the authorization may have expired instead.",
+      "kind": "vertical",
+      "spoken_reference": "your billing page contained two entries for one order and the correction process keeps those records linked the original completed payment remains in the history while the duplicate line now has a matching credit open each detail row to compare the order name date payment status and final total the account total includes the correction but a second device may need a refresh before it displays the same amount do not submit another refund request for the duplicate while this correction is processing because that could create a second adjustment keep your receipt and the correction notice together until the credit appears as completed when the first charge remains pending it may disappear when the authorization expires instead of receiving a separate credit if the corrected total still looks wrong compare the itemized order with the two history rows and note which line is completed your billing page will retain the correction record so the result can be checked later the correction entry remains linked to the original order making the final total easier to verify a credit can be pending before it becomes part of the available total check the correction status and the original payment status separately then compare both with the itemized receipt if the duplicate disappears without a credit the authorization may have expired instead",
+      "vertical": "customer_service",
+      "difficulty": "easy",
+      "family": "billing_correction",
+      "length_bucket": "L4",
+      "tags": [
+        "conditional"
+      ]
+    },
+    {
+      "testcase_id": "tts2-cs-e-f04-L1",
+      "transcript": "Your issue is now with our review team, and you will receive the next update there.",
+      "kind": "vertical",
+      "spoken_reference": "your issue is now with our review team and you will receive the next update there",
+      "vertical": "customer_service",
+      "difficulty": "easy",
+      "family": "escalation",
+      "length_bucket": "L1",
+      "tags": []
+    },
+    {
+      "testcase_id": "tts2-cs-e-f04-L2",
+      "transcript": "I sent your service issue to the review team with the details already in your account. You do not need to repeat the same explanation when the team contacts you.",
+      "kind": "vertical",
+      "spoken_reference": "i sent your service issue to the review team with the details already in your account you do not need to repeat the same explanation when the team contacts you",
+      "vertical": "customer_service",
+      "difficulty": "easy",
+      "family": "escalation",
+      "length_bucket": "L2",
+      "tags": [
+        "conditional"
+      ]
+    },
+    {
+      "testcase_id": "tts2-cs-e-f04-L3",
+      "transcript": "Your request needs a review team because the earlier service attempt did not resolve it. I included the account history and the steps already tried, so you should not need to repeat the same explanation. The team will review the record and post its next update in your account messages. Keep the reference shown in your confirmation, and check that message area for the response. You can continue using unrelated account features while the review is open. If a new error appears, save its wording and time so the team can distinguish it from the original issue.",
+      "kind": "vertical",
+      "spoken_reference": "your request needs a review team because the earlier service attempt did not resolve it i included the account history and the steps already tried so you should not need to repeat the same explanation the team will review the record and post its next update in your account messages keep the reference shown in your confirmation and check that message area for the response you can continue using unrelated account features while the review is open if a new error appears save its wording and time so the team can distinguish it from the original issue",
+      "vertical": "customer_service",
+      "difficulty": "easy",
+      "family": "escalation",
+      "length_bucket": "L3",
+      "tags": [
+        "conditional"
+      ]
+    },
+    {
+      "testcase_id": "tts2-cs-e-f04-L4",
+      "transcript": "A specialist review is now open because the first service attempt did not resolve your problem. I attached the existing account history and the actions already recorded, so the reviewing team can begin with the same information instead of asking you to rebuild the case. Open the confirmation message to see the reference and current status, then use that thread for any new detail about this issue. You can continue using unrelated features while the review is open, but avoid starting another request for the same problem because separate records can split the evidence and create conflicting updates. If a new error appears, save its exact wording, the page where it appeared, and the time you saw it. Those details help the team decide whether the event is a continuation or a separate issue. When the review is complete, the message will describe the next available action and preserve the earlier notes. The reference remains attached to the original review, so a later agent can follow the history without asking you to repeat every step. Check the message thread for the response rather than relying on a general notification, and keep the confirmation until the issue is resolved for follow-up.",
+      "kind": "vertical",
+      "spoken_reference": "a specialist review is now open because the first service attempt did not resolve your problem i attached the existing account history and the actions already recorded so the reviewing team can begin with the same information instead of asking you to rebuild the case open the confirmation message to see the reference and current status then use that thread for any new detail about this issue you can continue using unrelated features while the review is open but avoid starting another request for the same problem because separate records can split the evidence and create conflicting updates if a new error appears save its exact wording the page where it appeared and the time you saw it those details help the team decide whether the event is a continuation or a separate issue when the review is complete the message will describe the next available action and preserve the earlier notes the reference remains attached to the original review so a later agent can follow the history without asking you to repeat every step check the message thread for the response rather than relying on a general notification and keep the confirmation until the issue is resolved for follow up",
+      "vertical": "customer_service",
+      "difficulty": "easy",
+      "family": "escalation",
+      "length_bucket": "L4",
+      "tags": [
+        "conditional"
+      ]
+    },
+    {
+      "testcase_id": "tts2-cs-m-f01-L1",
+      "transcript": "Your paired device is visible again, and the permission request is ready.",
+      "kind": "vertical",
+      "spoken_reference": "your paired device is visible again and the permission request is ready",
+      "vertical": "customer_service",
+      "difficulty": "medium",
+      "family": "troubleshooting",
+      "length_bucket": "L1",
+      "tags": [
+        "domain_term"
+      ]
+    },
+    {
+      "testcase_id": "tts2-cs-m-f01-L2",
+      "transcript": "The app can see your device, but notification permission is off. Open the system settings, allow notifications for this app, then return and select the device once. Your pairing record will remain saved.",
+      "kind": "vertical",
+      "spoken_reference": "the app can see your device but notification permission is off open the system settings allow notifications for this app then return and select the device once your pairing record will remain saved",
+      "vertical": "customer_service",
+      "difficulty": "medium",
+      "family": "troubleshooting",
+      "length_bucket": "L2",
+      "tags": [
+        "conditional",
+        "domain_term"
+      ]
+    },
+    {
+      "testcase_id": "tts2-cs-m-f01-L3",
+      "transcript": "The device pairing is present, but your app cannot use the microphone permission required for calls. Open the system settings, find this app, and allow microphone access without changing other permissions. Return to the app and select the paired device from the call screen. If the device appears twice, choose the entry marked connected and remove only the stale entry. Your account history will retain the pairing attempt, so you can tell whether the next call reached the device. A restart is unnecessary unless the permission screen reports that the setting could not be saved.",
+      "kind": "vertical",
+      "spoken_reference": "the device pairing is present but your app cannot use the microphone permission required for calls open the system settings find this app and allow microphone access without changing other permissions return to the app and select the paired device from the call screen if the device appears twice choose the entry marked connected and remove only the stale entry your account history will retain the pairing attempt so you can tell whether the next call reached the device a restart is unnecessary unless the permission screen reports that the setting could not be saved",
+      "vertical": "customer_service",
+      "difficulty": "medium",
+      "family": "troubleshooting",
+      "length_bucket": "L3",
+      "tags": [
+        "conditional",
+        "domain_term"
+      ]
+    },
+    {
+      "testcase_id": "tts2-cs-m-f01-L4",
+      "transcript": "Your account is paired with the speaker, but the app is stopping at the operating system permission check. The pairing record and the permission are separate, so removing the device would not fix an access setting. Open system settings, locate the app permissions, and allow microphone access for calls. Leave unrelated permissions unchanged. Return to the call screen, select the connected speaker, and listen for the connection tone. If two device names appear, compare their last activity and choose the current entry rather than pairing a third copy. If the permission toggle is unavailable, close the app once and reopen the settings page; do not erase app data while the pairing record is useful. A successful call should appear in your recent activity. If it does not, note whether the device connected, whether audio reached it, and whether the app displayed an error. Those details separate a permission issue from a Bluetooth connection issue and give the next support review a clear starting point.  If the permission toggle remains unavailable, record the setting name and the message shown by the system. That wording tells support whether the operating system is blocking access or the app is failing to request it. The pairing itself should remain saved while you check this.",
+      "kind": "vertical",
+      "spoken_reference": "your account is paired with the speaker but the app is stopping at the operating system permission check the pairing record and the permission are separate so removing the device would not fix an access setting open system settings locate the app permissions and allow microphone access for calls leave unrelated permissions unchanged return to the call screen select the connected speaker and listen for the connection tone if two device names appear compare their last activity and choose the current entry rather than pairing a third copy if the permission toggle is unavailable close the app once and reopen the settings page do not erase app data while the pairing record is useful a successful call should appear in your recent activity if it does not note whether the device connected whether audio reached it and whether the app displayed an error those details separate a permission issue from a bluetooth connection issue and give the next support review a clear starting point if the permission toggle remains unavailable record the setting name and the message shown by the system that wording tells support whether the operating system is blocking access or the app is failing to request it the pairing itself should remain saved while you check this",
+      "vertical": "customer_service",
+      "difficulty": "medium",
+      "family": "troubleshooting",
+      "length_bucket": "L4",
+      "tags": [
+        "conditional",
+        "domain_term"
+      ]
+    },
+    {
+      "testcase_id": "tts2-cs-m-f02-L1",
+      "transcript": "Your member access is active, even though the renewal notice is still pending.",
+      "kind": "vertical",
+      "spoken_reference": "your member access is active even though the renewal notice is still pending",
+      "vertical": "customer_service",
+      "difficulty": "medium",
+      "family": "subscription",
+      "length_bucket": "L1",
+      "tags": [
+        "domain_term"
+      ]
+    },
+    {
+      "testcase_id": "tts2-cs-m-f02-L2",
+      "transcript": "Your family membership includes the shared library, but your renewal notice has not posted yet. The access page shows what you can use now, while billing shows the next renewal separately.",
+      "kind": "vertical",
+      "spoken_reference": "your family membership includes the shared library but your renewal notice has not posted yet the access page shows what you can use now while billing shows the next renewal separately",
+      "vertical": "customer_service",
+      "difficulty": "medium",
+      "family": "subscription",
+      "length_bucket": "L2",
+      "tags": [
+        "conditional",
+        "domain_term"
+      ]
+    },
+    {
+      "testcase_id": "tts2-cs-m-f02-L3",
+      "transcript": "Your member profile can open the shared library, but the renewal notice is delayed. Access and renewal are separate records, so the missing notice does not remove your current features. Open the membership page to check your role and included library. Then open billing to review the next renewal date and payment status. If another member cannot enter, confirm that their invitation is accepted before changing the plan. A plan change affects future access details, while the active period stays visible until its end. Save the membership summary if you need to compare it with the notice later.",
+      "kind": "vertical",
+      "spoken_reference": "your member profile can open the shared library but the renewal notice is delayed access and renewal are separate records so the missing notice does not remove your current features open the membership page to check your role and included library then open billing to review the next renewal date and payment status if another member cannot enter confirm that their invitation is accepted before changing the plan a plan change affects future access details while the active period stays visible until its end save the membership summary if you need to compare it with the notice later",
+      "vertical": "customer_service",
+      "difficulty": "medium",
+      "family": "subscription",
+      "length_bucket": "L3",
+      "tags": [
+        "conditional",
+        "domain_term"
+      ]
+    },
+    {
+      "testcase_id": "tts2-cs-m-f02-L4",
+      "transcript": "Your shared membership has two records that can update at different times: the member-access record and the renewal notice. The access record currently lists you as an active household member with permission to use the shared library. The billing page, however, is still preparing the next renewal notice, so it may not show the same status yet. Open the membership page first to check your role, library access, and invited members. Then open billing to review the renewal date, payment status, and any pending notice. If a household member cannot enter, confirm that the invitation was accepted and that the person is using the intended account. Do not remove and re-add the membership while the notice is pending, because that can create a second invitation and make the history harder to read. A plan change affects future access details; it does not erase the active period already displayed. When the notice appears, compare its plan name and next date with the membership summary, then save the confirmation. Your account history will retain the earlier access record so a support review can distinguish a membership problem from a delayed billing message.  The renewal notice may arrive after access has already been updated. Compare the member page and billing page again before changing anything, and save the later confirmation with the membership record.",
+      "kind": "vertical",
+      "spoken_reference": "your shared membership has two records that can update at different times the member access record and the renewal notice the access record currently lists you as an active household member with permission to use the shared library the billing page however is still preparing the next renewal notice so it may not show the same status yet open the membership page first to check your role library access and invited members then open billing to review the renewal date payment status and any pending notice if a household member cannot enter confirm that the invitation was accepted and that the person is using the intended account do not remove and re add the membership while the notice is pending because that can create a second invitation and make the history harder to read a plan change affects future access details it does not erase the active period already displayed when the notice appears compare its plan name and next date with the membership summary then save the confirmation your account history will retain the earlier access record so a support review can distinguish a membership problem from a delayed billing message the renewal notice may arrive after access has already been updated compare the member page and billing page again before changing anything and save the later confirmation with the membership record",
+      "vertical": "customer_service",
+      "difficulty": "medium",
+      "family": "subscription",
+      "length_bucket": "L4",
+      "tags": [
+        "conditional",
+        "domain_term"
+      ]
+    },
+    {
+      "testcase_id": "tts2-cs-m-f03-L1",
+      "transcript": "Your duplicate invoice is marked for correction, and the original order remains active.",
+      "kind": "vertical",
+      "spoken_reference": "your duplicate invoice is marked for correction and the original order remains active",
+      "vertical": "customer_service",
+      "difficulty": "medium",
+      "family": "billing_correction",
+      "length_bucket": "L1",
+      "tags": [
+        "domain_term"
+      ]
+    },
+    {
+      "testcase_id": "tts2-cs-m-f03-L2",
+      "transcript": "I found two invoices for your single order. Your original invoice remains attached to the order, while the duplicate is marked for review. The correction will appear separately from any prorated credit.",
+      "kind": "vertical",
+      "spoken_reference": "i found two invoices for your single order your original invoice remains attached to the order while the duplicate is marked for review the correction will appear separately from any prorated credit",
+      "vertical": "customer_service",
+      "difficulty": "medium",
+      "family": "billing_correction",
+      "length_bucket": "L2",
+      "tags": [
+        "conditional",
+        "domain_term"
+      ]
+    },
+    {
+      "testcase_id": "tts2-cs-m-f03-L3",
+      "transcript": "Your order has one valid invoice and a second invoice with the same items. I marked the duplicate for correction without changing the original order. The billing page will show the invoice numbers, item dates, and current status separately. If a prorated credit applies to a changed service period, it will appear as its own credit rather than replacing the original invoice. Keep both notices while the correction is processing, and compare the final total with your order summary. Your account total may update before the downloadable statement refreshes.",
+      "kind": "vertical",
+      "spoken_reference": "your order has one valid invoice and a second invoice with the same items i marked the duplicate for correction without changing the original order the billing page will show the invoice numbers item dates and current status separately if a prorated credit applies to a changed service period it will appear as its own credit rather than replacing the original invoice keep both notices while the correction is processing and compare the final total with your order summary your account total may update before the downloadable statement refreshes",
+      "vertical": "customer_service",
+      "difficulty": "medium",
+      "family": "billing_correction",
+      "length_bucket": "L3",
+      "tags": [
+        "conditional",
+        "domain_term"
+      ]
+    },
+    {
+      "testcase_id": "tts2-cs-m-f03-L4",
+      "transcript": "Your billing history contains two invoices for one order, but they represent different records in the correction workflow. The original invoice remains linked to the order and keeps its itemized charges. The duplicate invoice is flagged for correction, so it can be reversed without deleting the original history. Open both invoice details to compare the invoice identifier, service period, item list, tax line, and current status. A prorated credit for a shortened service period is a separate adjustment; it should not be treated as evidence that the duplicate invoice was accepted. Keep the original invoice, duplicate notice, and order summary together while the review is pending. Your account total may change before the downloadable statement reflects the same correction, so check the billing page and statement separately. Do not request another adjustment for the same duplicate while this record is open. When the correction posts, verify that the original invoice remains payable or completed as appropriate, the duplicate is marked reversed, and any prorated credit has its own date and description. The correction history stays attached to your order for later review.  A correction can post before the statement refreshes. Compare the invoice details, account total, and statement date rather than assuming the first visible total is final.",
+      "kind": "vertical",
+      "spoken_reference": "your billing history contains two invoices for one order but they represent different records in the correction workflow the original invoice remains linked to the order and keeps its itemized charges the duplicate invoice is flagged for correction so it can be reversed without deleting the original history open both invoice details to compare the invoice identifier service period item list tax line and current status a prorated credit for a shortened service period is a separate adjustment it should not be treated as evidence that the duplicate invoice was accepted keep the original invoice duplicate notice and order summary together while the review is pending your account total may change before the downloadable statement reflects the same correction so check the billing page and statement separately do not request another adjustment for the same duplicate while this record is open when the correction posts verify that the original invoice remains payable or completed as appropriate the duplicate is marked reversed and any prorated credit has its own date and description the correction history stays attached to your order for later review a correction can post before the statement refreshes compare the invoice details account total and statement date rather than assuming the first visible total is final",
+      "vertical": "customer_service",
+      "difficulty": "medium",
+      "family": "billing_correction",
+      "length_bucket": "L4",
+      "tags": [
+        "conditional",
+        "domain_term"
+      ]
+    },
+    {
+      "testcase_id": "tts2-cs-m-f04-L1",
+      "transcript": "Your unresolved ticket is assigned to a callback team, and the handoff is recorded.",
+      "kind": "vertical",
+      "spoken_reference": "your unresolved ticket is assigned to a callback team and the handoff is recorded",
+      "vertical": "customer_service",
+      "difficulty": "medium",
+      "family": "escalation",
+      "length_bucket": "L1",
+      "tags": [
+        "domain_term"
+      ]
+    },
+    {
+      "testcase_id": "tts2-cs-m-f04-L2",
+      "transcript": "Your ticket was handed to the callback team because the earlier troubleshooting did not resolve the issue. The team has your existing notes, so keep the ticket reference for the next update.",
+      "kind": "vertical",
+      "spoken_reference": "your ticket was handed to the callback team because the earlier troubleshooting did not resolve the issue the team has your existing notes so keep the ticket reference for the next update",
+      "vertical": "customer_service",
+      "difficulty": "medium",
+      "family": "escalation",
+      "length_bucket": "L2",
+      "tags": [
+        "conditional",
+        "domain_term"
+      ]
+    },
+    {
+      "testcase_id": "tts2-cs-m-f04-L3",
+      "transcript": "Your unresolved ticket is now with a callback team. I included the steps already recorded and the device details from your earlier contact, so you do not need to repeat the whole history. The handoff status appears in your messages, along with the ticket reference and callback window. Keep your phone available during that window, but do not open a second ticket for the same problem. If the issue changes, add the new error and time to the existing thread. The callback team will see those additions with the earlier notes.",
+      "kind": "vertical",
+      "spoken_reference": "your unresolved ticket is now with a callback team i included the steps already recorded and the device details from your earlier contact so you do not need to repeat the whole history the handoff status appears in your messages along with the ticket reference and callback window keep your phone available during that window but do not open a second ticket for the same problem if the issue changes add the new error and time to the existing thread the callback team will see those additions with the earlier notes",
+      "vertical": "customer_service",
+      "difficulty": "medium",
+      "family": "escalation",
+      "length_bucket": "L3",
+      "tags": [
+        "conditional",
+        "domain_term"
+      ]
+    },
+    {
+      "testcase_id": "tts2-cs-m-f04-L4",
+      "transcript": "Your ticket is moving to a callback team because the first support path did not resolve the issue. The handoff record includes your earlier description, the troubleshooting steps, and the latest error, so the next agent can start from the existing history. Open the message thread to verify the ticket reference, callback window, and current owner. Keep your contact method available during that window, but avoid creating a second ticket for the same problem because separate records can split the evidence. If the issue changes before the callback, add the new error, page name, and time to the existing thread. Do not repeat a failed setup step unless the callback team asks you to; the earlier result is already attached. The team can return the ticket to the original queue if the callback is unnecessary, and that status change will remain visible. When the callback is complete, read the summary carefully and check whether the ticket is resolved, waiting for your action, or still under review. Your message history preserves the handoff and later notes for any follow-up.  Keep the existing thread open until the callback summary is posted. That keeps the handoff, response, and final status together for you.",
+      "kind": "vertical",
+      "spoken_reference": "your ticket is moving to a callback team because the first support path did not resolve the issue the handoff record includes your earlier description the troubleshooting steps and the latest error so the next agent can start from the existing history open the message thread to verify the ticket reference callback window and current owner keep your contact method available during that window but avoid creating a second ticket for the same problem because separate records can split the evidence if the issue changes before the callback add the new error page name and time to the existing thread do not repeat a failed setup step unless the callback team asks you to the earlier result is already attached the team can return the ticket to the original queue if the callback is unnecessary and that status change will remain visible when the callback is complete read the summary carefully and check whether the ticket is resolved waiting for your action or still under review your message history preserves the handoff and later notes for any follow up keep the existing thread open until the callback summary is posted that keeps the handoff response and final status together for you",
+      "vertical": "customer_service",
+      "difficulty": "medium",
+      "family": "escalation",
+      "length_bucket": "L4",
+      "tags": [
+        "conditional",
+        "domain_term"
+      ]
+    },
+    {
+      "testcase_id": "tts2-cs-h-f01-L1",
+      "transcript": "Your paired hub is online, but its clock is out of sync with the app.",
+      "kind": "vertical",
+      "spoken_reference": "your paired hub is online but its clock is out of sync with the app",
+      "vertical": "customer_service",
+      "difficulty": "hard",
+      "family": "troubleshooting",
+      "length_bucket": "L1",
+      "tags": [
+        "identifier"
+      ]
+    },
+    {
+      "testcase_id": "tts2-cs-h-f01-L2",
+      "transcript": "The app sees your device intermittently because its local clock differs from the service clock. Reopen the pairing screen, wait for synchronization, and select the hub once; do not create a second device record.",
+      "kind": "vertical",
+      "spoken_reference": "the app sees your device intermittently because its local clock differs from the service clock reopen the pairing screen wait for synchronization and select the hub once do not create a second device record",
+      "vertical": "customer_service",
+      "difficulty": "hard",
+      "family": "troubleshooting",
+      "length_bucket": "L2",
+      "tags": [
+        "initialism",
+        "identifier",
+        "conditional"
+      ]
+    },
+    {
+      "testcase_id": "tts2-cs-h-f01-L3",
+      "transcript": "Your device alternates between connected and unavailable because the app is receiving stale synchronization data. The pairing record is valid, but the hub clock and the service clock disagree. Open the device details, wait for the synchronization timestamp to refresh, then select the existing hub rather than adding another copy. If the status flips again, note whether the change happens when the screen locks or when your network changes. That distinction separates a local sleep setting from intermittent connectivity. Your saved configuration remains intact while we compare those events.",
+      "kind": "vertical",
+      "spoken_reference": "your device alternates between connected and unavailable because the app is receiving stale synchronization data the pairing record is valid but the hub clock and the service clock disagree open the device details wait for the synchronization timestamp to refresh then select the existing hub rather than adding another copy if the status flips again note whether the change happens when the screen locks or when your network changes that distinction separates a local sleep setting from intermittent connectivity your saved configuration remains intact while we compare those events",
+      "vertical": "customer_service",
+      "difficulty": "hard",
+      "family": "troubleshooting",
+      "length_bucket": "L3",
+      "tags": [
+        "initialism",
+        "identifier",
+        "conditional"
+      ]
+    },
+    {
+      "testcase_id": "tts2-cs-h-f01-L4",
+      "transcript": "Your hub is paired, yet the app is cycling between connected, waiting, and unavailable because three signals arrive out of order. The device record is valid; the difficult part is synchronization between the hub clock, the app session, and the service timestamp. Open the existing device detail and wait for its last-synced time to change before selecting the hub. Do not delete the record or create a duplicate while the status is moving. If the connection drops when your screen locks, note that event; if it drops only when your network changes, note that instead. A stable local network with an old service timestamp points to a synchronization delay, while changing network addresses can produce a different pairing event. Your saved configuration should remain untouched. Review recent activity after the next successful connection so you can tell whether a request completed during an intermittent outage. If the app shows two records, use the one with the latest synchronization time and leave the older record alone for support review. The synchronization history can show whether the device, app, or network changed first. Compare those timestamps before trying another pairing action, and tell support which device or app reported each inconsistent time.",
+      "kind": "vertical",
+      "spoken_reference": "your hub is paired yet the app is cycling between connected waiting and unavailable because three signals arrive out of order the device record is valid the difficult part is synchronization between the hub clock the app session and the service timestamp open the existing device detail and wait for its last synced time to change before selecting the hub do not delete the record or create a duplicate while the status is moving if the connection drops when your screen locks note that event if it drops only when your network changes note that instead a stable local network with an old service timestamp points to a synchronization delay while changing network addresses can produce a different pairing event your saved configuration should remain untouched review recent activity after the next successful connection so you can tell whether a request completed during an intermittent outage if the app shows two records use the one with the latest synchronization time and leave the older record alone for support review the synchronization history can show whether the device app or network changed first compare those timestamps before trying another pairing action and tell support which device or app reported each inconsistent time",
+      "vertical": "customer_service",
+      "difficulty": "hard",
+      "family": "troubleshooting",
+      "length_bucket": "L4",
+      "tags": [
+        "initialism",
+        "identifier",
+        "conditional"
+      ]
+    },
+    {
+      "testcase_id": "tts2-cs-h-f02-L1",
+      "transcript": "Your member access is active, but the renewal notice references a different plan version.",
+      "kind": "vertical",
+      "spoken_reference": "your member access is active but the renewal notice references a different plan version",
+      "vertical": "customer_service",
+      "difficulty": "hard",
+      "family": "subscription",
+      "length_bucket": "L1",
+      "tags": [
+        "identifier"
+      ]
+    },
+    {
+      "testcase_id": "tts2-cs-h-f02-L2",
+      "transcript": "The renewal notice names version four of your plan, while your member page still shows version three. Your current access remains visible; compare the plan records before changing renewal. The member page lists the features available to your household now.",
+      "kind": "vertical",
+      "spoken_reference": "the renewal notice names version four of your plan while your member page still shows version three your current access remains visible compare the plan records before changing renewal the member page lists the features available to your household now",
+      "vertical": "customer_service",
+      "difficulty": "hard",
+      "family": "subscription",
+      "length_bucket": "L2",
+      "tags": [
+        "initialism",
+        "identifier",
+        "conditional"
+      ]
+    },
+    {
+      "testcase_id": "tts2-cs-h-f02-L3",
+      "transcript": "Your subscription has a plan-version mismatch: the member page lists the current feature set, while the renewal notice names a newer version. Access and renewal are separate records, so do not infer that the notice has already changed your current features. Open the plan history and compare the version label, renewal date, and included members. If a household member loses access, check the member record before editing the renewal. Save the notice and the membership summary so support can see which record changed first.",
+      "kind": "vertical",
+      "spoken_reference": "your subscription has a plan version mismatch the member page lists the current feature set while the renewal notice names a newer version access and renewal are separate records so do not infer that the notice has already changed your current features open the plan history and compare the version label renewal date and included members if a household member loses access check the member record before editing the renewal save the notice and the membership summary so support can see which record changed first",
+      "vertical": "customer_service",
+      "difficulty": "hard",
+      "family": "subscription",
+      "length_bucket": "L3",
+      "tags": [
+        "initialism",
+        "identifier",
+        "conditional"
+      ]
+    },
+    {
+      "testcase_id": "tts2-cs-h-f02-L4",
+      "transcript": "Your membership is active, but the renewal notice and access record are out of sequence. The member page lists your current feature set under plan version three, while the notice refers to plan version four and a later renewal date. That mismatch does not by itself change the access already displayed. Open plan history and compare the version label, included members, renewal date, and payment status line by line. If a household member cannot use the shared feature, inspect the member record and invitation status rather than changing the renewal immediately. A renewal notice can be prepared before the access record updates, and a saved plan change can appear before a later billing message. Keep both records together, including the timestamps shown in each view. If you choose a new plan, read the feature summary and next date before confirming. Do not remove and re-add members while the records are being synchronized. After the next update, verify that the member page and renewal notice refer to the intended version. Your account history preserves the earlier version so a review can distinguish a delayed notice from an unintended access change. The plan history keeps the earlier version visible, which helps separate a delayed renewal notice from a feature change.",
+      "kind": "vertical",
+      "spoken_reference": "your membership is active but the renewal notice and access record are out of sequence the member page lists your current feature set under plan version three while the notice refers to plan version four and a later renewal date that mismatch does not by itself change the access already displayed open plan history and compare the version label included members renewal date and payment status line by line if a household member cannot use the shared feature inspect the member record and invitation status rather than changing the renewal immediately a renewal notice can be prepared before the access record updates and a saved plan change can appear before a later billing message keep both records together including the timestamps shown in each view if you choose a new plan read the feature summary and next date before confirming do not remove and re add members while the records are being synchronized after the next update verify that the member page and renewal notice refer to the intended version your account history preserves the earlier version so a review can distinguish a delayed notice from an unintended access change the plan history keeps the earlier version visible which helps separate a delayed renewal notice from a feature change",
+      "vertical": "customer_service",
+      "difficulty": "hard",
+      "family": "subscription",
+      "length_bucket": "L4",
+      "tags": [
+        "initialism",
+        "identifier",
+        "conditional"
+      ]
+    },
+    {
+      "testcase_id": "tts2-cs-h-f03-L1",
+      "transcript": "Your prorated reimbursement is calculated separately from the duplicate invoice correction.",
+      "kind": "vertical",
+      "spoken_reference": "your prorated reimbursement is calculated separately from the duplicate invoice correction",
+      "vertical": "customer_service",
+      "difficulty": "hard",
+      "family": "billing_correction",
+      "length_bucket": "L1",
+      "tags": [
+        "identifier"
+      ]
+    },
+    {
+      "testcase_id": "tts2-cs-h-f03-L2",
+      "transcript": "The duplicate invoice is being reversed, while your prorated reimbursement covers unused service time. The two credits will have separate descriptions and posting dates in billing. Keep the invoice notice with the plan-change record while the adjustment is pending.",
+      "kind": "vertical",
+      "spoken_reference": "the duplicate invoice is being reversed while your prorated reimbursement covers unused service time the two credits will have separate descriptions and posting dates in billing keep the invoice notice with the plan change record while the adjustment is pending",
+      "vertical": "customer_service",
+      "difficulty": "hard",
+      "family": "billing_correction",
+      "length_bucket": "L2",
+      "tags": [
+        "initialism",
+        "identifier",
+        "conditional"
+      ]
+    },
+    {
+      "testcase_id": "tts2-cs-h-f03-L3",
+      "transcript": "Your billing record has two adjustments with different purposes. One reverses the duplicate invoice, and the other reimburses unused service time after your plan changed. The invoice correction should link to the duplicate line, while the prorated reimbursement should show the service period and calculation. Compare the descriptions, dates, and amounts before deciding that one credit is missing. Your account total may change before the statement refreshes, and a pending adjustment can later be replaced by its final posting. Keep the invoice, plan-change notice, and credit entries together.",
+      "kind": "vertical",
+      "spoken_reference": "your billing record has two adjustments with different purposes one reverses the duplicate invoice and the other reimburses unused service time after your plan changed the invoice correction should link to the duplicate line while the prorated reimbursement should show the service period and calculation compare the descriptions dates and amounts before deciding that one credit is missing your account total may change before the statement refreshes and a pending adjustment can later be replaced by its final posting keep the invoice plan change notice and credit entries together",
+      "vertical": "customer_service",
+      "difficulty": "hard",
+      "family": "billing_correction",
+      "length_bucket": "L3",
+      "tags": [
+        "initialism",
+        "identifier",
+        "conditional"
+      ]
+    },
+    {
+      "testcase_id": "tts2-cs-h-f03-L4",
+      "transcript": "Your billing correction contains a duplicate-invoice reversal and a prorated reimbursement, and those entries should not be combined. The reversal addresses the extra invoice line; the reimbursement covers unused service time between the old plan period and the change date. Open each detail record and compare its invoice reference, service dates, description, amount, and status. A reversal should point back to the duplicate invoice, while the prorated entry should identify the covered period and its calculation. The two credits can post on different days, and the account total may update before the downloadable statement reflects both. Keep the original invoice, duplicate notice, plan-change confirmation, and both credit records together. Do not submit a second correction while either adjustment is pending. If one entry remains pending, compare its status with the statement date rather than treating the visible estimate as final. When both entries are complete, verify that the original invoice remains linked to the order, the duplicate is reversed, and the reimbursement description matches the unused period. Your billing history retains the adjustment links for later review. The statement can lag behind the account total, so use the posting status to decide which amount is final. Keep both confirmations together.",
+      "kind": "vertical",
+      "spoken_reference": "your billing correction contains a duplicate invoice reversal and a prorated reimbursement and those entries should not be combined the reversal addresses the extra invoice line the reimbursement covers unused service time between the old plan period and the change date open each detail record and compare its invoice reference service dates description amount and status a reversal should point back to the duplicate invoice while the prorated entry should identify the covered period and its calculation the two credits can post on different days and the account total may update before the downloadable statement reflects both keep the original invoice duplicate notice plan change confirmation and both credit records together do not submit a second correction while either adjustment is pending if one entry remains pending compare its status with the statement date rather than treating the visible estimate as final when both entries are complete verify that the original invoice remains linked to the order the duplicate is reversed and the reimbursement description matches the unused period your billing history retains the adjustment links for later review the statement can lag behind the account total so use the posting status to decide which amount is final keep both confirmations together",
+      "vertical": "customer_service",
+      "difficulty": "hard",
+      "family": "billing_correction",
+      "length_bucket": "L4",
+      "tags": [
+        "initialism",
+        "identifier",
+        "conditional"
+      ]
+    },
+    {
+      "testcase_id": "tts2-cs-h-f04-L1",
+      "transcript": "Your escalation is linked to reference code KX-7, and the callback handoff is recorded.",
+      "kind": "vertical",
+      "spoken_reference": "your escalation is linked to reference code k x seven and the callback handoff is recorded",
+      "vertical": "customer_service",
+      "difficulty": "hard",
+      "family": "escalation",
+      "length_bucket": "L1",
+      "tags": [
+        "identifier"
+      ]
+    },
+    {
+      "testcase_id": "tts2-cs-h-f04-L2",
+      "transcript": "Your unresolved case moved to the specialist queue under reference code R Q forty two. The handoff notes are attached, so keep that code for the callback team and check the message thread for its next update.",
+      "kind": "vertical",
+      "spoken_reference": "your unresolved case moved to the specialist queue under reference code r q forty two the handoff notes are attached so keep that code for the callback team and check the message thread for its next update",
+      "vertical": "customer_service",
+      "difficulty": "hard",
+      "family": "escalation",
+      "length_bucket": "L2",
+      "tags": [
+        "initialism",
+        "identifier",
+        "conditional"
+      ]
+    },
+    {
+      "testcase_id": "tts2-cs-h-f04-L3",
+      "transcript": "The specialist's reply assumes you can receive a verification call, but your case concerns an inaccessible phone line. I can return that mismatch for review under reference ES-714. The request will explain why repeating the same callback instruction cannot resolve this particular access problem. I will ask whether an approved written verification route is available, without bypassing authentication requirements. You should not send passwords or recovery codes in response to the earlier message. The specialist can explain which authorized route applies to your account.",
+      "kind": "vertical",
+      "spoken_reference": "the specialist's reply assumes you can receive a verification call but your case concerns an inaccessible phone line i can return that mismatch for review under reference e s seven fourteen the request will explain why repeating the same callback instruction cannot resolve this particular access problem i will ask whether an approved written verification route is available without bypassing authentication requirements you should not send passwords or recovery codes in response to the earlier message the specialist can explain which authorized route applies to your account",
+      "vertical": "customer_service",
+      "difficulty": "hard",
+      "family": "escalation",
+      "length_bucket": "L3",
+      "tags": [
+        "domain_term",
+        "identifier",
+        "contrast"
+      ]
+    },
+    {
+      "testcase_id": "tts2-cs-h-f04-L4",
+      "transcript": "You are right to question the closure notice: connectivity has been restored, but the exported report still has missing rows. The ticket appears to have been closed against the connection symptom alone. I can request a review of that closure and identify the report problem as the unresolved part of your original request.\n\nThe latest export failed at 2:07 PM with message SYN-409. You described a CSV file whose preview looks complete even though the downloaded copy is truncated. I will include that distinction so the specialist does not assume that a successful preview proves the export is intact. There is no need to attach customer records to establish the discrepancy; the team can first ask for a privacy-safe reproduction using sample data.\n\nAnother detail is the encoding option. You selected UTF-8, while the closure response discussed connection settings. Those are different parts of the workflow, and the specialist should explain whether the encoding choice is relevant rather than repeat the network instructions.\n\nThe review request will ask whether the existing ticket should be reopened or linked to a separate export investigation. Either way, you should receive a clear explanation of what remains unresolved. I will not mark the report problem fixed just because the connection is working again. Before sending the request, I can read back the missing-row symptom and error message to confirm I captured them accurately.",
+      "kind": "vertical",
+      "spoken_reference": "you are right to question the closure notice connectivity has been restored but the exported report still has missing rows the ticket appears to have been closed against the connection symptom alone i can request a review of that closure and identify the report problem as the unresolved part of your original request the latest export failed at two oh seven p m with message s y n four oh nine you described a c s v file whose preview looks complete even though the downloaded copy is truncated i will include that distinction so the specialist does not assume that a successful preview proves the export is intact there is no need to attach customer records to establish the discrepancy the team can first ask for a privacy safe reproduction using sample data another detail is the encoding option you selected u t f eight while the closure response discussed connection settings those are different parts of the workflow and the specialist should explain whether the encoding choice is relevant rather than repeat the network instructions the review request will ask whether the existing ticket should be reopened or linked to a separate export investigation either way you should receive a clear explanation of what remains unresolved i will not mark the report problem fixed just because the connection is working again before sending the request i can read back the missing row symptom and error message to confirm i captured them accurately",
+      "vertical": "customer_service",
+      "difficulty": "hard",
+      "family": "escalation",
+      "length_bucket": "L4",
+      "tags": [
+        "domain_term",
+        "initialism",
+        "identifier",
+        "time",
+        "contrast",
+        "conditional"
+      ]
+    },
+    {
+      "testcase_id": "tts2-rt-e-f01-L1",
+      "transcript": "Your blue travel mug is in stock at our downtown store.",
+      "kind": "vertical",
+      "spoken_reference": "your blue travel mug is in stock at our downtown store",
+      "vertical": "retail",
+      "difficulty": "easy",
+      "family": "availability",
+      "length_bucket": "L1",
+      "tags": [
+        "domain_term"
+      ]
+    },
+    {
+      "testcase_id": "tts2-rt-e-f01-L2",
+      "transcript": "Good news: your requested garden hose is available today. We have three on the shelf, and you can collect it before closing. The associate can place one aside while you finish shopping, so your item will be ready at the front desk.",
+      "kind": "vertical",
+      "spoken_reference": "good news your requested garden hose is available today we have three on the shelf and you can collect it before closing the associate can place one aside while you finish shopping so your item will be ready at the front desk",
+      "vertical": "retail",
+      "difficulty": "easy",
+      "family": "availability",
+      "length_bucket": "L2",
+      "tags": [
+        "number"
+      ]
+    },
+    {
+      "testcase_id": "tts2-rt-e-f01-L3",
+      "transcript": "I checked your kitchen order against our store list. The white toaster is ready in the north aisle, but the matching kettle is not there yet. You can reserve the toaster for pickup, or choose the black set that is available now. Our stock changes during the day, so the team will hold your choice at the service desk once you select it. The associate can also check another store and explain the next available option.",
+      "kind": "vertical",
+      "spoken_reference": "i checked your kitchen order against our store list the white toaster is ready in the north aisle but the matching kettle is not there yet you can reserve the toaster for pickup or choose the black set that is available now our stock changes during the day so the team will hold your choice at the service desk once you select it the associate can also check another store and explain the next available option",
+      "vertical": "retail",
+      "difficulty": "easy",
+      "family": "availability",
+      "length_bucket": "L3",
+      "tags": [
+        "number",
+        "contrast"
+      ]
+    },
+    {
+      "testcase_id": "tts2-rt-e-f01-L4",
+      "transcript": "Your home office chair is currently available, and I can help you choose the most useful pickup option. The display model is on the second floor near the desk lamps, while boxed chairs are kept in back. If you visit the store today, bring the item name or show the listing on your phone so the associate can match the color and size. You may inspect the chair, ask about assembly, and place it on hold while you shop. We have two gray chairs ready, but the green version needs a new delivery. If gray works for you, the associate can print a pickup slip and guide you to the collection counter. If you prefer green, we can check another nearby store and explain the expected arrival without promising a date. Your choice remains yours, and we will confirm the exact box before you leave. The desk team can answer questions about pickup hours, the box dimensions, and whether your vehicle has enough room. You can change your mind before the hold is completed, and the associate will explain which color is ready. Please inspect the chair carefully before taking it home, especially the wheels and height lever, so any concern is noticed while the store can help.",
+      "kind": "vertical",
+      "spoken_reference": "your home office chair is currently available and i can help you choose the most useful pickup option the display model is on the second floor near the desk lamps while boxed chairs are kept in back if you visit the store today bring the item name or show the listing on your phone so the associate can match the color and size you may inspect the chair ask about assembly and place it on hold while you shop we have two gray chairs ready but the green version needs a new delivery if gray works for you the associate can print a pickup slip and guide you to the collection counter if you prefer green we can check another nearby store and explain the expected arrival without promising a date your choice remains yours and we will confirm the exact box before you leave the desk team can answer questions about pickup hours the box dimensions and whether your vehicle has enough room you can change your mind before the hold is completed and the associate will explain which color is ready please inspect the chair carefully before taking it home especially the wheels and height lever so any concern is noticed while the store can help",
+      "vertical": "retail",
+      "difficulty": "easy",
+      "family": "availability",
+      "length_bucket": "L4",
+      "tags": [
+        "number",
+        "conditional",
+        "list"
+      ]
+    },
+    {
+      "testcase_id": "tts2-rt-e-f02-L1",
+      "transcript": "Your order is packed and moving to our pickup counter.",
+      "kind": "vertical",
+      "spoken_reference": "your order is packed and moving to our pickup counter",
+      "vertical": "retail",
+      "difficulty": "easy",
+      "family": "fulfillment",
+      "length_bucket": "L1",
+      "tags": [
+        "domain_term"
+      ]
+    },
+    {
+      "testcase_id": "tts2-rt-e-f02-L2",
+      "transcript": "Your parcel has left our warehouse. You will receive a pickup message when it reaches the store, usually later today. The counter will keep it ready, and you can bring the message when you arrive.",
+      "kind": "vertical",
+      "spoken_reference": "your parcel has left our warehouse you will receive a pickup message when it reaches the store usually later today the counter will keep it ready and you can bring the message when you arrive",
+      "vertical": "retail",
+      "difficulty": "easy",
+      "family": "fulfillment",
+      "length_bucket": "L2",
+      "tags": [
+        "time"
+      ]
+    },
+    {
+      "testcase_id": "tts2-rt-e-f02-L3",
+      "transcript": "Your camping order is moving in two separate boxes. The lantern is already at the store, while the sleeping bag is still traveling. We will keep both items together for pickup when the second box arrives. Please bring your order message and a photo identification card to the counter. The associate can check both labels before handing over the complete order. You can inspect the boxes at the desk before taking them with you. The counter can answer questions about the remaining package.",
+      "kind": "vertical",
+      "spoken_reference": "your camping order is moving in two separate boxes the lantern is already at the store while the sleeping bag is still traveling we will keep both items together for pickup when the second box arrives please bring your order message and a photo identification card to the counter the associate can check both labels before handing over the complete order you can inspect the boxes at the desk before taking them with you the counter can answer questions about the remaining package",
+      "vertical": "retail",
+      "difficulty": "easy",
+      "family": "fulfillment",
+      "length_bucket": "L3",
+      "tags": [
+        "number",
+        "list"
+      ]
+    },
+    {
+      "testcase_id": "tts2-rt-e-f02-L4",
+      "transcript": "Your order contains a coffee grinder, filters, and a small storage jar, so it is being packed in two cartons. The first carton reached our local store this morning; the second is still moving from the regional warehouse. You do not need to make two trips. When the final carton is scanned, the store will send your pickup notice and keep the complete order at the counter. Bring the order message when you arrive, and tell the associate if someone else is collecting it for you. The team can check the package labels, open a carton if an item seems damaged, and explain the next step before you leave. If the second carton misses today's transfer, the notice will wait until tomorrow's scan. You can also choose delivery instead, but that changes the handoff and may add a fee. Your current pickup request stays active while the boxes are traveling. Before leaving home, clear enough space for the carton and keep the message easy to find. The associate can explain store hours, identify which box contains each product, and note a visible problem on the pickup record. If one item is missing, do not take a partial order unless you choose that option after hearing the available solution. Once every box is present, the counter will close the handoff and give you a receipt for the items collected.",
+      "kind": "vertical",
+      "spoken_reference": "your order contains a coffee grinder filters and a small storage jar so it is being packed in two cartons the first carton reached our local store this morning the second is still moving from the regional warehouse you do not need to make two trips when the final carton is scanned the store will send your pickup notice and keep the complete order at the counter bring the order message when you arrive and tell the associate if someone else is collecting it for you the team can check the package labels open a carton if an item seems damaged and explain the next step before you leave if the second carton misses today's transfer the notice will wait until tomorrow's scan you can also choose delivery instead but that changes the handoff and may add a fee your current pickup request stays active while the boxes are traveling before leaving home clear enough space for the carton and keep the message easy to find the associate can explain store hours identify which box contains each product and note a visible problem on the pickup record if one item is missing do not take a partial order unless you choose that option after hearing the available solution once every box is present the counter will close the handoff and give you a receipt for the items collected",
+      "vertical": "retail",
+      "difficulty": "easy",
+      "family": "fulfillment",
+      "length_bucket": "L4",
+      "tags": [
+        "time",
+        "conditional",
+        "contrast"
+      ]
+    },
+    {
+      "testcase_id": "tts2-rt-e-f03-L1",
+      "transcript": "Your return can be brought to the service desk today.",
+      "kind": "vertical",
+      "spoken_reference": "your return can be brought to the service desk today",
+      "vertical": "retail",
+      "difficulty": "easy",
+      "family": "returns",
+      "length_bucket": "L1",
+      "tags": [
+        "domain_term"
+      ]
+    },
+    {
+      "testcase_id": "tts2-rt-e-f03-L2",
+      "transcript": "Your unopened candle set is eligible for a store return. Bring the item and order message, and we can refund the original payment after inspection. Keep the packaging together so the associate can finish the check quickly.",
+      "kind": "vertical",
+      "spoken_reference": "your unopened candle set is eligible for a store return bring the item and order message and we can refund the original payment after inspection keep the packaging together so the associate can finish the check quickly",
+      "vertical": "retail",
+      "difficulty": "easy",
+      "family": "returns",
+      "length_bucket": "L2",
+      "tags": [
+        "list",
+        "contrast"
+      ]
+    },
+    {
+      "testcase_id": "tts2-rt-e-f03-L3",
+      "transcript": "I can help with your return at the service desk. Please bring the shoes, their box, and your order message. If the shoes are unworn, the associate can inspect them and send the refund to the original payment method. If the box is missing, the team will explain the available option before processing anything. Keep the laces and inserts with the pair so the inspection is easier. The team will confirm the choice before the return is completed.",
+      "kind": "vertical",
+      "spoken_reference": "i can help with your return at the service desk please bring the shoes their box and your order message if the shoes are unworn the associate can inspect them and send the refund to the original payment method if the box is missing the team will explain the available option before processing anything keep the laces and inserts with the pair so the inspection is easier the team will confirm the choice before the return is completed",
+      "vertical": "retail",
+      "difficulty": "easy",
+      "family": "returns",
+      "length_bucket": "L3",
+      "tags": [
+        "conditional",
+        "money"
+      ]
+    },
+    {
+      "testcase_id": "tts2-rt-e-f03-L4",
+      "transcript": "Your return for the electric kettle can be handled at the service desk, and the steps are simple. Bring the kettle, its cord, the package if you still have it, and your order message. The associate will check that the model matches the order and look for visible damage before accepting the return. If the kettle is unused, the refund can be sent to the original payment method after the inspection is complete. If it has been used, the team will review its condition and tell you which return option is available. You do not need to explain the whole purchase history at the counter; the order message gives the associate the basic details. Keep any accessories together so the inspection is quick. A refund may appear after the store finishes processing, depending on the payment provider. If you prefer store credit, ask before the transaction is completed so the associate can describe that choice. Your receipt is helpful, but the order message can also help locate the purchase. Wipe away any loose packaging, but do not alter the appliance before bringing it in. The associate can record a missing cord, compare the model label, and tell you whether another option is possible. If you decide against a return after the inspection begins, ask the team before the refund is finalized. The service desk will give you a receipt showing what was accepted and which payment route was selected.",
+      "kind": "vertical",
+      "spoken_reference": "your return for the electric kettle can be handled at the service desk and the steps are simple bring the kettle its cord the package if you still have it and your order message the associate will check that the model matches the order and look for visible damage before accepting the return if the kettle is unused the refund can be sent to the original payment method after the inspection is complete if it has been used the team will review its condition and tell you which return option is available you do not need to explain the whole purchase history at the counter the order message gives the associate the basic details keep any accessories together so the inspection is quick a refund may appear after the store finishes processing depending on the payment provider if you prefer store credit ask before the transaction is completed so the associate can describe that choice your receipt is helpful but the order message can also help locate the purchase wipe away any loose packaging but do not alter the appliance before bringing it in the associate can record a missing cord compare the model label and tell you whether another option is possible if you decide against a return after the inspection begins ask the team before the refund is finalized the service desk will give you a receipt showing what was accepted and which payment route was selected",
+      "vertical": "retail",
+      "difficulty": "easy",
+      "family": "returns",
+      "length_bucket": "L4",
+      "tags": [
+        "list",
+        "conditional",
+        "contrast"
+      ]
+    },
+    {
+      "testcase_id": "tts2-rt-e-f04-L1",
+      "transcript": "Your jacket can be exchanged for another size at the service desk.",
+      "kind": "vertical",
+      "spoken_reference": "your jacket can be exchanged for another size at the service desk",
+      "vertical": "retail",
+      "difficulty": "easy",
+      "family": "exchange",
+      "length_bucket": "L1",
+      "tags": [
+        "contrast"
+      ]
+    },
+    {
+      "testcase_id": "tts2-rt-e-f04-L2",
+      "transcript": "Your shirt exchange is available in the store today. Bring the shirt and order message, and we can check a different size or color before completing the exchange. Keep the tags attached if you still have them.",
+      "kind": "vertical",
+      "spoken_reference": "your shirt exchange is available in the store today bring the shirt and order message and we can check a different size or color before completing the exchange keep the tags attached if you still have them",
+      "vertical": "retail",
+      "difficulty": "easy",
+      "family": "exchange",
+      "length_bucket": "L2",
+      "tags": [
+        "list",
+        "number"
+      ]
+    },
+    {
+      "testcase_id": "tts2-rt-e-f04-L3",
+      "transcript": "Your headphones can be exchanged if the replacement is in stock. Bring the headphones, charging cable, and order message. The associate will compare the model, then check available colors. If the new pair costs more, the team will explain the difference before finishing the exchange. Please include the case and any included adapters. You can approve the replacement after the team shows you the available pair. The service desk will print a receipt for the completed exchange.",
+      "kind": "vertical",
+      "spoken_reference": "your headphones can be exchanged if the replacement is in stock bring the headphones charging cable and order message the associate will compare the model then check available colors if the new pair costs more the team will explain the difference before finishing the exchange please include the case and any included adapters you can approve the replacement after the team shows you the available pair the service desk will print a receipt for the completed exchange",
+      "vertical": "retail",
+      "difficulty": "easy",
+      "family": "exchange",
+      "length_bucket": "L3",
+      "tags": [
+        "conditional",
+        "number"
+      ]
+    },
+    {
+      "testcase_id": "tts2-rt-e-f04-L4",
+      "transcript": "Your raincoat exchange can be completed at the service desk, and you may choose another size or a different color. Bring the coat, its tags if they remain attached, and your order message. The associate will compare the item with the purchase record and check the replacement stock. If your preferred size is on the rack, the team can hold it while the original coat is inspected. If that size is unavailable, the associate can look at another nearby store or describe a delivery option. A different color may have a different price, so the team will show the amount before confirming the exchange. You can keep the original coat until the replacement choice is settled. Please bring all included accessories, such as the belt, because missing pieces may change which option is offered. The exchange is finished only after you approve the replacement and the associate prints an updated receipt. Your order message makes the lookup faster, but the store can explain what is needed if you cannot find it. Before the counter starts, check the new coat for sleeve length, pocket placement, and the hood style. The associate can compare those details with the item on the rack and place the selected coat beside the counter. If you change color after the comparison, the team can repeat the stock check without opening a second exchange record. Any price difference will be explained plainly, and you can stop before accepting the replacement. Once you approve the size and color, the associate will finish the handoff and give you the updated receipt.",
+      "kind": "vertical",
+      "spoken_reference": "your raincoat exchange can be completed at the service desk and you may choose another size or a different color bring the coat its tags if they remain attached and your order message the associate will compare the item with the purchase record and check the replacement stock if your preferred size is on the rack the team can hold it while the original coat is inspected if that size is unavailable the associate can look at another nearby store or describe a delivery option a different color may have a different price so the team will show the amount before confirming the exchange you can keep the original coat until the replacement choice is settled please bring all included accessories such as the belt because missing pieces may change which option is offered the exchange is finished only after you approve the replacement and the associate prints an updated receipt your order message makes the lookup faster but the store can explain what is needed if you cannot find it before the counter starts check the new coat for sleeve length pocket placement and the hood style the associate can compare those details with the item on the rack and place the selected coat beside the counter if you change color after the comparison the team can repeat the stock check without opening a second exchange record any price difference will be explained plainly and you can stop before accepting the replacement once you approve the size and color the associate will finish the handoff and give you the updated receipt",
+      "vertical": "retail",
+      "difficulty": "easy",
+      "family": "exchange",
+      "length_bucket": "L4",
+      "tags": [
+        "contrast",
+        "conditional",
+        "list"
+      ]
+    },
+    {
+      "testcase_id": "tts2-rt-m-f01-L1",
+      "transcript": "Your Harborline rain boots are available in our west store today.",
+      "kind": "vertical",
+      "spoken_reference": "your harborline rain boots are available in our west store today",
+      "vertical": "retail",
+      "difficulty": "medium",
+      "family": "availability",
+      "length_bucket": "L1",
+      "tags": [
+        "proper_name"
+      ]
+    },
+    {
+      "testcase_id": "tts2-rt-m-f01-L2",
+      "transcript": "Your replacement filter is available in aisle fourteen. We have five units on hand, and the associate can place one on hold while you travel to the store. Bring the product name so the team can match the correct size at the counter.",
+      "kind": "vertical",
+      "spoken_reference": "your replacement filter is available in aisle fourteen we have five units on hand and the associate can place one on hold while you travel to the store bring the product name so the team can match the correct size at the counter",
+      "vertical": "retail",
+      "difficulty": "medium",
+      "family": "availability",
+      "length_bucket": "L2",
+      "tags": [
+        "number",
+        "domain_term"
+      ]
+    },
+    {
+      "testcase_id": "tts2-rt-m-f01-L3",
+      "transcript": "Your Solara desk lamp is available in brass, but the green finish is still on the incoming list. We have four brass lamps in the display area and one sealed box in back. The listed price is $38.00, and the associate can confirm the current shelf label before you decide. If brass works, we can hold it until closing; otherwise, the team can check a nearby location. Please compare the shade, base, and switch before choosing the display piece.",
+      "kind": "vertical",
+      "spoken_reference": "your solara desk lamp is available in brass but the green finish is still on the incoming list we have four brass lamps in the display area and one sealed box in back the listed price is thirty eight dollars and the associate can confirm the current shelf label before you decide if brass works we can hold it until closing otherwise the team can check a nearby location please compare the shade base and switch before choosing the display piece",
+      "vertical": "retail",
+      "difficulty": "medium",
+      "family": "availability",
+      "length_bucket": "L3",
+      "tags": [
+        "number",
+        "money",
+        "contrast"
+      ]
+    },
+    {
+      "testcase_id": "tts2-rt-m-f01-L4",
+      "transcript": "I reviewed the store inventory for your Northstar folding table and found two useful choices. The oak finish is available at the Lakeside branch, while the walnut finish is showing limited stock at our central shop. Because display and boxed inventory are counted separately, the associate will confirm the exact condition when you select a location. If you want to see the table first, the floor sample is near seasonal storage and can be measured with you. If you prefer an unopened box, ask the desk team to verify the carton before placing a hold. The listing shows a price of $76.50, but the store will read the shelf label and explain any current promotion before checkout. You can hold the oak table for pickup, request a transfer from Lakeside, or choose walnut if its stock remains available. A hold is not a completed purchase, so the team will tell you how long it can remain aside. Bring the product name and finish when you arrive; similar tables have nearly identical labels. Your preferred branch can also check the tabletop, legs, hardware packet, and carton condition before handing it over. Before confirming the branch, consider whether you need the table folded for transport or assembled for viewing. The associate can explain the box dimensions and keep the hold attached to the exact finish you selected.",
+      "kind": "vertical",
+      "spoken_reference": "i reviewed the store inventory for your northstar folding table and found two useful choices the oak finish is available at the lakeside branch while the walnut finish is showing limited stock at our central shop because display and boxed inventory are counted separately the associate will confirm the exact condition when you select a location if you want to see the table first the floor sample is near seasonal storage and can be measured with you if you prefer an unopened box ask the desk team to verify the carton before placing a hold the listing shows a price of seventy six dollars and fifty cents but the store will read the shelf label and explain any current promotion before checkout you can hold the oak table for pickup request a transfer from lakeside or choose walnut if its stock remains available a hold is not a completed purchase so the team will tell you how long it can remain aside bring the product name and finish when you arrive similar tables have nearly identical labels your preferred branch can also check the tabletop legs hardware packet and carton condition before handing it over before confirming the branch consider whether you need the table folded for transport or assembled for viewing the associate can explain the box dimensions and keep the hold attached to the exact finish you selected",
+      "vertical": "retail",
+      "difficulty": "medium",
+      "family": "availability",
+      "length_bucket": "L4",
+      "tags": [
+        "number",
+        "proper_name",
+        "conditional",
+        "list"
+      ]
+    },
+    {
+      "testcase_id": "tts2-rt-m-f02-L1",
+      "transcript": "Your parcel is at the regional hub and should reach the store tomorrow morning.",
+      "kind": "vertical",
+      "spoken_reference": "your parcel is at the regional hub and should reach the store tomorrow morning",
+      "vertical": "retail",
+      "difficulty": "medium",
+      "family": "fulfillment",
+      "length_bucket": "L1",
+      "tags": [
+        "time"
+      ]
+    },
+    {
+      "testcase_id": "tts2-rt-m-f02-L2",
+      "transcript": "Your cookware order is traveling in three cartons. Two have reached the store, while the lid set is still moving. We will send one pickup notice after the final scan.",
+      "kind": "vertical",
+      "spoken_reference": "your cookware order is traveling in three cartons two have reached the store while the lid set is still moving we will send one pickup notice after the final scan",
+      "vertical": "retail",
+      "difficulty": "medium",
+      "family": "fulfillment",
+      "length_bucket": "L2",
+      "tags": [
+        "number",
+        "list"
+      ]
+    },
+    {
+      "testcase_id": "tts2-rt-m-f02-L3",
+      "transcript": "Your order is moving under the store reference RT-4827. The mixer arrived with its bowl, but the whisk attachment is in a second carton. Once that carton receives an arrival scan, the counter will send a complete pickup notice. If the attachment misses today's transfer, the notice will wait for the next scan rather than asking you to collect an incomplete set. Keep the reference ready so the associate can distinguish this carton from another kitchen order.",
+      "kind": "vertical",
+      "spoken_reference": "your order is moving under the store reference r t four eight two seven the mixer arrived with its bowl but the whisk attachment is in a second carton once that carton receives an arrival scan the counter will send a complete pickup notice if the attachment misses today's transfer the notice will wait for the next scan rather than asking you to collect an incomplete set keep the reference ready so the associate can distinguish this carton from another kitchen order",
+      "vertical": "retail",
+      "difficulty": "medium",
+      "family": "fulfillment",
+      "length_bucket": "L3",
+      "tags": [
+        "identifier",
+        "number",
+        "conditional"
+      ]
+    },
+    {
+      "testcase_id": "tts2-rt-m-f02-L4",
+      "transcript": "Your home lighting order is being fulfilled from two warehouses, which explains why the tracking view has several entries. The pendant shade and ceiling plate left our eastern facility together, while the dimmer switch is coming from the local distribution center. The store cannot close the pickup handoff until every carton is scanned into the same order. When the last scan appears, you will receive a notice with the counter location and collection hours. Bring that notice, the order reference RT-7314, and a photo identification card if the associate requests a matching check. You can inspect carton corners and labels before accepting the boxes. If a carton looks crushed, tell the team immediately so they can record the condition and explain the available next step. A partial pickup is possible only if the desk confirms which pieces you are taking and which remain open. Delivery is another option, but changing the handoff can alter the fee and timing. The current pickup request stays active while the dimmer travels. If the scan remains unchanged through tomorrow afternoon, the store can search the carrier view and tell you what movement is visible, without guessing at an arrival time. Once all three pieces are ready, the associate will reconcile the labels and print one receipt for the completed collection.",
+      "kind": "vertical",
+      "spoken_reference": "your home lighting order is being fulfilled from two warehouses which explains why the tracking view has several entries the pendant shade and ceiling plate left our eastern facility together while the dimmer switch is coming from the local distribution center the store cannot close the pickup handoff until every carton is scanned into the same order when the last scan appears you will receive a notice with the counter location and collection hours bring that notice the order reference r t seven three one four and a photo identification card if the associate requests a matching check you can inspect carton corners and labels before accepting the boxes if a carton looks crushed tell the team immediately so they can record the condition and explain the available next step a partial pickup is possible only if the desk confirms which pieces you are taking and which remain open delivery is another option but changing the handoff can alter the fee and timing the current pickup request stays active while the dimmer travels if the scan remains unchanged through tomorrow afternoon the store can search the carrier view and tell you what movement is visible without guessing at an arrival time once all three pieces are ready the associate will reconcile the labels and print one receipt for the completed collection",
+      "vertical": "retail",
+      "difficulty": "medium",
+      "family": "fulfillment",
+      "length_bucket": "L4",
+      "tags": [
+        "identifier",
+        "time",
+        "list",
+        "contrast"
+      ]
+    },
+    {
+      "testcase_id": "tts2-rt-m-f03-L1",
+      "transcript": "Your return is ready for inspection, and the refund will follow the original payment route.",
+      "kind": "vertical",
+      "spoken_reference": "your return is ready for inspection and the refund will follow the original payment route",
+      "vertical": "retail",
+      "difficulty": "medium",
+      "family": "returns",
+      "length_bucket": "L1",
+      "tags": [
+        "money"
+      ]
+    },
+    {
+      "testcase_id": "tts2-rt-m-f03-L2",
+      "transcript": "Your unopened speaker can come to the service desk within thirty days. Bring the speaker, cable, and order message; the associate will inspect the set before discussing the refund route.",
+      "kind": "vertical",
+      "spoken_reference": "your unopened speaker can come to the service desk within thirty days bring the speaker cable and order message the associate will inspect the set before discussing the refund route",
+      "vertical": "retail",
+      "difficulty": "medium",
+      "family": "returns",
+      "length_bucket": "L2",
+      "tags": [
+        "number",
+        "conditional"
+      ]
+    },
+    {
+      "testcase_id": "tts2-rt-m-f03-L3",
+      "transcript": "Your return for the ceramic pan can be reviewed at the service desk. Bring the pan, lid, package insert, and order message. The associate will compare the item with the purchase record and inspect the cooking surface. If it is unused, the refund can follow the original payment method; if it has been used, the team will explain the condition-based option before completing anything. Keep the handle and lid together so the inspection reflects the full set.",
+      "kind": "vertical",
+      "spoken_reference": "your return for the ceramic pan can be reviewed at the service desk bring the pan lid package insert and order message the associate will compare the item with the purchase record and inspect the cooking surface if it is unused the refund can follow the original payment method if it has been used the team will explain the condition based option before completing anything keep the handle and lid together so the inspection reflects the full set",
+      "vertical": "retail",
+      "difficulty": "medium",
+      "family": "returns",
+      "length_bucket": "L3",
+      "tags": [
+        "money",
+        "list",
+        "conditional"
+      ]
+    },
+    {
+      "testcase_id": "tts2-rt-m-f03-L4",
+      "transcript": "Your return for the AeroPress brewer can be started at the service desk under reference RT-9052. Please bring the brewer, filter cap, scoop, and any package insert, because the associate will compare the parts with the original order. The team will inspect the seal, chamber, and visible surfaces, then tell you which return route matches the condition. If the set is unused and complete, the refund can be directed to the original payment method after the inspection. If a piece is missing or the brewer has been used, the associate will explain the available alternative before processing the record. You may choose to pause while the team checks the package rather than accepting a result you have not heard. The receipt or order message helps locate the purchase, but do not share unrelated account details at the counter. Store credit may be available in the fictional store scenario, and the associate will describe it before selecting that route. A refund can take time to appear after the store submits it, depending on the payment provider. Keep the reference visible so the team can distinguish this brewer from another item in the same order. When the inspection is finished, the associate will state what was accepted, what payment route was chosen, and which receipt you should keep.",
+      "kind": "vertical",
+      "spoken_reference": "your return for the aeropress brewer can be started at the service desk under reference r t nine zero five two please bring the brewer filter cap scoop and any package insert because the associate will compare the parts with the original order the team will inspect the seal chamber and visible surfaces then tell you which return route matches the condition if the set is unused and complete the refund can be directed to the original payment method after the inspection if a piece is missing or the brewer has been used the associate will explain the available alternative before processing the record you may choose to pause while the team checks the package rather than accepting a result you have not heard the receipt or order message helps locate the purchase but do not share unrelated account details at the counter store credit may be available in the fictional store scenario and the associate will describe it before selecting that route a refund can take time to appear after the store submits it depending on the payment provider keep the reference visible so the team can distinguish this brewer from another item in the same order when the inspection is finished the associate will state what was accepted what payment route was chosen and which receipt you should keep",
+      "vertical": "retail",
+      "difficulty": "medium",
+      "family": "returns",
+      "length_bucket": "L4",
+      "tags": [
+        "identifier",
+        "money",
+        "conditional",
+        "list"
+      ]
+    },
+    {
+      "testcase_id": "tts2-rt-m-f04-L1",
+      "transcript": "Your Trailmark fleece can be exchanged for the next size if that color remains available.",
+      "kind": "vertical",
+      "spoken_reference": "your trailmark fleece can be exchanged for the next size if that color remains available",
+      "vertical": "retail",
+      "difficulty": "medium",
+      "family": "exchange",
+      "length_bucket": "L1",
+      "tags": [
+        "contrast"
+      ]
+    },
+    {
+      "testcase_id": "tts2-rt-m-f04-L2",
+      "transcript": "Your kettle exchange can be checked at the counter. Bring the kettle, lid, and order message; we can compare two colors and explain any price difference before you approve the replacement.",
+      "kind": "vertical",
+      "spoken_reference": "your kettle exchange can be checked at the counter bring the kettle lid and order message we can compare two colors and explain any price difference before you approve the replacement",
+      "vertical": "retail",
+      "difficulty": "medium",
+      "family": "exchange",
+      "length_bucket": "L2",
+      "tags": [
+        "number",
+        "conditional"
+      ]
+    },
+    {
+      "testcase_id": "tts2-rt-m-f04-L3",
+      "transcript": "Your running shoe exchange can be handled after the associate checks the size, color, and sole condition. Bring both shoes, the box, and your order message. If the replacement is in stock, the team can hold it beside the counter while comparing the pair. A different model may have a different price, so you will hear the amount before approving the exchange. If no local pair matches, the associate can describe another store or delivery option.",
+      "kind": "vertical",
+      "spoken_reference": "your running shoe exchange can be handled after the associate checks the size color and sole condition bring both shoes the box and your order message if the replacement is in stock the team can hold it beside the counter while comparing the pair a different model may have a different price so you will hear the amount before approving the exchange if no local pair matches the associate can describe another store or delivery option",
+      "vertical": "retail",
+      "difficulty": "medium",
+      "family": "exchange",
+      "length_bucket": "L3",
+      "tags": [
+        "money",
+        "conditional",
+        "list"
+      ]
+    },
+    {
+      "testcase_id": "tts2-rt-m-f04-L4",
+      "transcript": "Your Willow Creek backpack exchange can be reviewed under reference RT-1168, and you may compare size, color, or a nearby model. Bring the backpack, detachable waist strap, rain cover, and order message so the associate can check every included part. The team will inspect the zippers, seams, and interior lining, then compare the bag with the purchase record. If the preferred replacement is on the rack, the associate can hold it while the original is reviewed. If that color is absent, another branch may show stock, but a transfer or delivery choice can change the timing. A different model may also change the price; the team will read the amount and identify any difference before you approve it. Keep the original backpack with you until the replacement is selected, because the exchange is not finished at the moment a new bag is found. You can ask to see the shoulder straps adjusted, check the laptop sleeve, and compare the pocket layout before accepting the substitute. If a part is missing, the associate will explain whether the exchange can continue or whether another route is more suitable. The order message helps match the reference, while the printed receipt confirms the final size and color. Once you approve the replacement, the desk will update the record and return any included accessories with the exchanged item.",
+      "kind": "vertical",
+      "spoken_reference": "your willow creek backpack exchange can be reviewed under reference r t one one six eight and you may compare size color or a nearby model bring the backpack detachable waist strap rain cover and order message so the associate can check every included part the team will inspect the zippers seams and interior lining then compare the bag with the purchase record if the preferred replacement is on the rack the associate can hold it while the original is reviewed if that color is absent another branch may show stock but a transfer or delivery choice can change the timing a different model may also change the price the team will read the amount and identify any difference before you approve it keep the original backpack with you until the replacement is selected because the exchange is not finished at the moment a new bag is found you can ask to see the shoulder straps adjusted check the laptop sleeve and compare the pocket layout before accepting the substitute if a part is missing the associate will explain whether the exchange can continue or whether another route is more suitable the order message helps match the reference while the printed receipt confirms the final size and color once you approve the replacement the desk will update the record and return any included accessories with the exchanged item",
+      "vertical": "retail",
+      "difficulty": "medium",
+      "family": "exchange",
+      "length_bucket": "L4",
+      "tags": [
+        "identifier",
+        "money",
+        "conditional",
+        "contrast"
+      ]
+    },
+    {
+      "testcase_id": "tts2-rt-h-f01-L1",
+      "transcript": "Your AeroWeave sectional is available, but only the left chaise configuration is on the showroom floor.",
+      "kind": "vertical",
+      "spoken_reference": "your aeroweave sectional is available but only the left chaise configuration is on the showroom floor",
+      "vertical": "retail",
+      "difficulty": "hard",
+      "family": "availability",
+      "length_bucket": "L1",
+      "tags": [
+        "domain_term"
+      ]
+    },
+    {
+      "testcase_id": "tts2-rt-h-f01-L2",
+      "transcript": "Your replacement cartridge, model KX-47B, is available at the service counter. We have six sealed units, but the compatible adapter is stocked in a separate aisle.",
+      "kind": "vertical",
+      "spoken_reference": "your replacement cartridge model k x forty seven b is available at the service counter we have six sealed units but the compatible adapter is stocked in a separate aisle",
+      "vertical": "retail",
+      "difficulty": "hard",
+      "family": "availability",
+      "length_bucket": "L2",
+      "tags": [
+        "identifier",
+        "number"
+      ]
+    },
+    {
+      "testcase_id": "tts2-rt-h-f01-L3",
+      "transcript": "Your LumenArc pendant is listed under code LA-208C, and the brushed nickel finish is available for inspection. The matte graphite version has no local shelf unit, although the catalog still displays it. The nickel price is $124.95, before any fictional store promotion. If you choose the displayed unit, the associate can verify the canopy, cord, and mounting hardware rather than relying on the photograph.",
+      "kind": "vertical",
+      "spoken_reference": "your lumenarc pendant is listed under code l a two zero eight c and the brushed nickel finish is available for inspection the matte graphite version has no local shelf unit although the catalog still displays it the nickel price is one hundred twenty four dollars and ninety five cents before any fictional store promotion if you choose the displayed unit the associate can verify the canopy cord and mounting hardware rather than relying on the photograph",
+      "vertical": "retail",
+      "difficulty": "hard",
+      "family": "availability",
+      "length_bucket": "L3",
+      "tags": [
+        "identifier",
+        "money",
+        "domain_term",
+        "contrast"
+      ]
+    },
+    {
+      "testcase_id": "tts2-rt-h-f01-L4",
+      "transcript": "Your Arcadia modular shelving search is complicated by finish, bay width, and packaging, so I checked each inventory record separately. The item code AR-9X-114 describes the sixty-inch oak bay; a nearly identical code describes the walnut bay with different brackets. The oak display is assembled beside the lighting wall, while unopened cartons are stacked in the receiving area and may not share the display label. We currently show three oak cartons and one display unit, but the associate must scan a carton before promising that every bracket packet is present. The listed amount is $219.40, and a shelf promotion may alter that amount only after the store confirms the label. If you need a same-day hold, specify oak, walnut, bay width, and whether you need one bay or a pair; saying merely “the shelf” could attach the wrong record. You can inspect the upright finish, shelf pins, back braces, and carton seals. If the oak cartons are all reserved, the team can check the walnut version or another branch, but a transfer changes the expected handoff. A hold is not payment, and the final availability depends on the scan at the selected store. The desk will read back the code and finish before setting anything aside, then explain how long the hold remains active. Your vehicle space matters as well, because a flat-packed carton may be long even when the display seems compact.",
+      "kind": "vertical",
+      "spoken_reference": "your arcadia modular shelving search is complicated by finish bay width and packaging so i checked each inventory record separately the item code a r nine x one one four describes the sixty inch oak bay a nearly identical code describes the walnut bay with different brackets the oak display is assembled beside the lighting wall while unopened cartons are stacked in the receiving area and may not share the display label we currently show three oak cartons and one display unit but the associate must scan a carton before promising that every bracket packet is present the listed amount is two hundred nineteen dollars and forty cents and a shelf promotion may alter that amount only after the store confirms the label if you need a same day hold specify oak walnut bay width and whether you need one bay or a pair saying merely the shelf could attach the wrong record you can inspect the upright finish shelf pins back braces and carton seals if the oak cartons are all reserved the team can check the walnut version or another branch but a transfer changes the expected handoff a hold is not payment and the final availability depends on the scan at the selected store the desk will read back the code and finish before setting anything aside then explain how long the hold remains active your vehicle space matters as well because a flat packed carton may be long even when the display seems compact",
+      "vertical": "retail",
+      "difficulty": "hard",
+      "family": "availability",
+      "length_bucket": "L4",
+      "tags": [
+        "identifier",
+        "number",
+        "money",
+        "conditional",
+        "list"
+      ]
+    },
+    {
+      "testcase_id": "tts2-rt-h-f02-L1",
+      "transcript": "Your order is moving under reference PX-8841, and the glassware carton has its carrier scan.",
+      "kind": "vertical",
+      "spoken_reference": "your order is moving under reference p x eight eight four one and the glassware carton has its carrier scan",
+      "vertical": "retail",
+      "difficulty": "hard",
+      "family": "fulfillment",
+      "length_bucket": "L1",
+      "tags": [
+        "identifier"
+      ]
+    },
+    {
+      "testcase_id": "tts2-rt-h-f02-L2",
+      "transcript": "Your fulfillment record shows an ETA of Friday for the ceramic set. The DC scan is complete, but the last-mile carrier has not checked in the insulated packing sleeve.",
+      "kind": "vertical",
+      "spoken_reference": "your fulfillment record shows an e t a of friday for the ceramic set the d c scan is complete but the last mile carrier has not checked in the insulated packing sleeve",
+      "vertical": "retail",
+      "difficulty": "hard",
+      "family": "fulfillment",
+      "length_bucket": "L2",
+      "tags": [
+        "initialism",
+        "identifier",
+        "number"
+      ]
+    },
+    {
+      "testcase_id": "tts2-rt-h-f02-L3",
+      "transcript": "Your espresso shipment carries reference PX-5916-Q, with the machine in carton one and the portafilter in carton two. The first carton reached the regional hub, while the second is awaiting a departure scan. If both scans reconcile at the store, the desk will send one complete pickup message; if they do not, the team will describe whether a partial handoff is sensible. Please compare the seals before accepting anything.",
+      "kind": "vertical",
+      "spoken_reference": "your espresso shipment carries reference p x five nine one six q with the machine in carton one and the portafilter in carton two the first carton reached the regional hub while the second is awaiting a departure scan if both scans reconcile at the store the desk will send one complete pickup message if they do not the team will describe whether a partial handoff is sensible please compare the seals before accepting anything",
+      "vertical": "retail",
+      "difficulty": "hard",
+      "family": "fulfillment",
+      "length_bucket": "L3",
+      "tags": [
+        "identifier",
+        "number",
+        "conditional",
+        "contrast"
+      ]
+    },
+    {
+      "testcase_id": "tts2-rt-h-f02-L4",
+      "transcript": "Your fulfillment record has not stalled; it has split across a vendor-direct carton and our local stock, which makes the tracking language look more dramatic than the physical movement. The order reference is PX-7740-R, and the store is waiting for the vendor carton containing the replacement filter and the mounting ring. The main purifier arrived at the distribution center, but its carton remains in a quality-control lane marked QC, so the pickup notice cannot close until that review releases the box. A carrier estimate shows Friday, yet that estimate is not a promise of a store scan. When the cartons arrive, the associate will compare the purifier serial label, accessory packet, filter sleeve, and ring against the order record. If a carton is visibly crushed, ask the desk to note the condition before accepting a partial handoff. You may collect the purifier alone only if the team explains which pieces remain open and you agree to that split; otherwise, the complete set will wait. Delivery can be discussed, but changing from pickup to delivery may alter handling and timing. Keep the reference available, because product names such as “air cleaner” and “purifier” can point to different records. If no scan appears by the next review window, the store can read the carrier event, identify the last physical location shown, and explain the available follow-up without inventing an arrival. Once the quality check clears, the desk will reconcile every label and print the final collection receipt.",
+      "kind": "vertical",
+      "spoken_reference": "your fulfillment record has not stalled it has split across a vendor direct carton and our local stock which makes the tracking language look more dramatic than the physical movement the order reference is p x seven seven four zero r and the store is waiting for the vendor carton containing the replacement filter and the mounting ring the main purifier arrived at the distribution center but its carton remains in a quality control lane marked q c so the pickup notice cannot close until that review releases the box a carrier estimate shows friday yet that estimate is not a promise of a store scan when the cartons arrive the associate will compare the purifier serial label accessory packet filter sleeve and ring against the order record if a carton is visibly crushed ask the desk to note the condition before accepting a partial handoff you may collect the purifier alone only if the team explains which pieces remain open and you agree to that split otherwise the complete set will wait delivery can be discussed but changing from pickup to delivery may alter handling and timing keep the reference available because product names such as air cleaner and purifier can point to different records if no scan appears by the next review window the store can read the carrier event identify the last physical location shown and explain the available follow up without inventing an arrival once the quality check clears the desk will reconcile every label and print the final collection receipt",
+      "vertical": "retail",
+      "difficulty": "hard",
+      "family": "fulfillment",
+      "length_bucket": "L4",
+      "tags": [
+        "identifier",
+        "initialism",
+        "number",
+        "conditional",
+        "list"
+      ]
+    },
+    {
+      "testcase_id": "tts2-rt-h-f03-L1",
+      "transcript": "Your return needs a complete accessory check, because the dock and power brick are separate pieces of the original bundle.",
+      "kind": "vertical",
+      "spoken_reference": "your return needs a complete accessory check because the dock and power brick are separate pieces of the original bundle",
+      "vertical": "retail",
+      "difficulty": "hard",
+      "family": "returns",
+      "length_bucket": "L1",
+      "tags": [
+        "domain_term",
+        "conditional"
+      ]
+    },
+    {
+      "testcase_id": "tts2-rt-h-f03-L2",
+      "transcript": "Your return for model Vela-3 can start at the service desk. Bring the speaker, charging base, cable, and order message so the associate can compare the bundle before choosing a return route.",
+      "kind": "vertical",
+      "spoken_reference": "your return for model vela three can start at the service desk bring the speaker charging base cable and order message so the associate can compare the bundle before choosing a return route",
+      "vertical": "retail",
+      "difficulty": "hard",
+      "family": "returns",
+      "length_bucket": "L2",
+      "tags": [
+        "identifier",
+        "conditional",
+        "list"
+      ]
+    },
+    {
+      "testcase_id": "tts2-rt-h-f03-L3",
+      "transcript": "Your return concerns the Nimbus air fryer, reference RF-2408, and the basket, divider, and recipe booklet should travel with it. The associate will compare the model label, inspect the nonstick surface, and check whether the power cord is present. If the appliance is unused and complete, the refund can follow the original payment route after inspection. If it has been heated or a part is absent, the team will describe the available option instead of silently changing the record. A receipt helps, but the order message can locate this fictional purchase. Keep unrelated account information private while the associate verifies only the item details.",
+      "kind": "vertical",
+      "spoken_reference": "your return concerns the nimbus air fryer reference r f two four zero eight and the basket divider and recipe booklet should travel with it the associate will compare the model label inspect the nonstick surface and check whether the power cord is present if the appliance is unused and complete the refund can follow the original payment route after inspection if it has been heated or a part is absent the team will describe the available option instead of silently changing the record a receipt helps but the order message can locate this fictional purchase keep unrelated account information private while the associate verifies only the item details",
+      "vertical": "retail",
+      "difficulty": "hard",
+      "family": "returns",
+      "length_bucket": "L3",
+      "tags": [
+        "identifier",
+        "money",
+        "conditional",
+        "contrast"
+      ]
+    },
+    {
+      "testcase_id": "tts2-rt-h-f03-L4",
+      "transcript": "Your return for the Kestrel induction hob can be reviewed under RF-6382-N, but the desk must distinguish the hob from the separate cookware bundle in the same purchase. Bring the glass surface, control dial, power lead, protective pad, and any insert that arrived in the carton. The associate will compare the serial label, inspect the surface for chips or scratches, and check whether the connector is included. If the hob is unused and all listed components are present, the store can submit the refund to the original payment route after its inspection. If it has been powered on, the team will record that condition and explain the next available route before you approve anything. A missing pad does not automatically identify which item was purchased, so the order message and product code matter. You can wait while the team checks the contents, ask which pieces were recorded, and request a receipt describing the accepted set. Do not provide unrelated account secrets; the fictional desk needs only the purchase record and item details. A refund may take time to appear after submission, and the payment provider controls that posting step. Store credit is a separate choice if offered, so hear its description before selecting it. If you decide to keep the hob after the inspection starts, tell the associate before the record is finalized. The final receipt should state whether the complete kit was accepted, whether an accessory was missing, and which payment route the team submitted.",
+      "kind": "vertical",
+      "spoken_reference": "your return for the kestrel induction hob can be reviewed under r f six three eight two n but the desk must distinguish the hob from the separate cookware bundle in the same purchase bring the glass surface control dial power lead protective pad and any insert that arrived in the carton the associate will compare the serial label inspect the surface for chips or scratches and check whether the connector is included if the hob is unused and all listed components are present the store can submit the refund to the original payment route after its inspection if it has been powered on the team will record that condition and explain the next available route before you approve anything a missing pad does not automatically identify which item was purchased so the order message and product code matter you can wait while the team checks the contents ask which pieces were recorded and request a receipt describing the accepted set do not provide unrelated account secrets the fictional desk needs only the purchase record and item details a refund may take time to appear after submission and the payment provider controls that posting step store credit is a separate choice if offered so hear its description before selecting it if you decide to keep the hob after the inspection starts tell the associate before the record is finalized the final receipt should state whether the complete kit was accepted whether an accessory was missing and which payment route the team submitted",
+      "vertical": "retail",
+      "difficulty": "hard",
+      "family": "returns",
+      "length_bucket": "L4",
+      "tags": [
+        "identifier",
+        "money",
+        "conditional",
+        "list",
+        "contrast"
+      ]
+    },
+    {
+      "testcase_id": "tts2-rt-h-f04-L1",
+      "transcript": "Your Meridian parka can be exchanged, but the insulated liner and shell must remain matched to the replacement size.",
+      "kind": "vertical",
+      "spoken_reference": "your meridian parka can be exchanged but the insulated liner and shell must remain matched to the replacement size",
+      "vertical": "retail",
+      "difficulty": "hard",
+      "family": "exchange",
+      "length_bucket": "L1",
+      "tags": [
+        "domain_term",
+        "contrast"
+      ]
+    },
+    {
+      "testcase_id": "tts2-rt-h-f04-L2",
+      "transcript": "Your exchange request names the Oriole-2 headphones, and the desk can compare that model with the Oriole-2S. Bring the case and cable; the newer version may carry a different price, which the associate will state before you approve the change.",
+      "kind": "vertical",
+      "spoken_reference": "your exchange request names the oriole two headphones and the desk can compare that model with the oriole two s bring the case and cable the newer version may carry a different price which the associate will state before you approve the change",
+      "vertical": "retail",
+      "difficulty": "hard",
+      "family": "exchange",
+      "length_bucket": "L2",
+      "tags": [
+        "identifier",
+        "money",
+        "conditional"
+      ]
+    },
+    {
+      "testcase_id": "tts2-rt-h-f04-L3",
+      "transcript": "Your exchange for the Ridgetrail boots is attached to reference EX-3179-M. Bring both boots, the molded insoles, and the box so the associate can compare the size code and tread. If the next size is available, the team can let you inspect the heel counter and lacing before you approve it. A different width may come from another store, while a different model can change the price. The desk will explain that distinction before closing the exchange record.",
+      "kind": "vertical",
+      "spoken_reference": "your exchange for the ridgetrail boots is attached to reference e x three one seven nine m bring both boots the molded insoles and the box so the associate can compare the size code and tread if the next size is available the team can let you inspect the heel counter and lacing before you approve it a different width may come from another store while a different model can change the price the desk will explain that distinction before closing the exchange record",
+      "vertical": "retail",
+      "difficulty": "hard",
+      "family": "exchange",
+      "length_bucket": "L3",
+      "tags": [
+        "identifier",
+        "number",
+        "conditional",
+        "list"
+      ]
+    },
+    {
+      "testcase_id": "tts2-rt-h-f04-L4",
+      "transcript": "Your exchange involves a Vantage modular stroller, reference EX-4820-T, and the configuration matters more than the color name alone. Bring the frame, seat shell, canopy, rain shield, and storage basket so the associate can compare the included components with the original record. The graphite frame with the compact seat is on the local rack, but the graphite frame with the extended seat is listed at another branch, and those configurations use different harness pads. The team will inspect wheel release, brake engagement, folding latch, and fabric seams before accepting the original. If the local configuration matches your needs, you can compare the harness height and basket clearance at the counter. If it does not, the associate can check a transfer or discuss a delivery path; neither option should be treated as an immediate handoff until the stock scan is confirmed. A premium canopy may alter the amount, so the desk will read the difference before you approve the substitute. You may keep the original stroller beside you while the comparison happens, and you can stop before the exchange record is finalized. If an accessory is missing, the team will identify whether the replacement is complete or whether another route is needed. Do not rely on a similar product label, because the frame code and seat configuration determine compatibility. Once you approve the exact frame, seat, and accessory set, the associate will update the record, return the original pieces that belong with the exchange, and print a receipt describing the final configuration.",
+      "kind": "vertical",
+      "spoken_reference": "your exchange involves a vantage modular stroller reference e x four eight two zero t and the configuration matters more than the color name alone bring the frame seat shell canopy rain shield and storage basket so the associate can compare the included components with the original record the graphite frame with the compact seat is on the local rack but the graphite frame with the extended seat is listed at another branch and those configurations use different harness pads the team will inspect wheel release brake engagement folding latch and fabric seams before accepting the original if the local configuration matches your needs you can compare the harness height and basket clearance at the counter if it does not the associate can check a transfer or discuss a delivery path neither option should be treated as an immediate handoff until the stock scan is confirmed a premium canopy may alter the amount so the desk will read the difference before you approve the substitute you may keep the original stroller beside you while the comparison happens and you can stop before the exchange record is finalized if an accessory is missing the team will identify whether the replacement is complete or whether another route is needed do not rely on a similar product label because the frame code and seat configuration determine compatibility once you approve the exact frame seat and accessory set the associate will update the record return the original pieces that belong with the exchange and print a receipt describing the final configuration",
+      "vertical": "retail",
+      "difficulty": "hard",
+      "family": "exchange",
+      "length_bucket": "L4",
+      "tags": [
+        "identifier",
+        "money",
+        "conditional",
+        "contrast",
+        "list"
+      ]
+    },
+    {
+      "testcase_id": "tts2-p-b01-i01",
+      "transcript": "Pat packed the big red pot before the guests arrived this evening.",
+      "kind": "phonetic",
+      "spoken_reference": "pat packed the big red pot before the guests arrived this evening",
+      "phonetic": {
+        "block": 1,
+        "mode": "statement",
+        "focus": "stops",
+        "phones": [
+          "AA",
+          "AE",
+          "B",
+          "D",
+          "EH",
+          "G",
+          "IH",
+          "K",
+          "P",
+          "R",
+          "T"
+        ],
+        "evidence": [
+          "packed",
+          "big",
+          "red",
+          "pot"
+        ]
+      }
+    },
+    {
+      "testcase_id": "tts2-p-b01-i02",
+      "transcript": "Those thieves left a beige vase beside the sofa upstairs.",
+      "kind": "phonetic",
+      "spoken_reference": "those thieves left a beige vase beside the sofa upstairs",
+      "phonetic": {
+        "block": 1,
+        "mode": "statement",
+        "focus": "fricatives",
+        "phones": [
+          "AH",
+          "B",
+          "DH",
+          "EY",
+          "F",
+          "IY",
+          "OW",
+          "S",
+          "TH",
+          "V",
+          "Z",
+          "ZH"
+        ],
+        "evidence": [
+          "those",
+          "thieves",
+          "beige",
+          "sofa"
+        ]
+      }
+    },
+    {
+      "testcase_id": "tts2-p-b01-i03",
+      "transcript": "A cheerful judge chose fresh peaches from the market stall.",
+      "kind": "phonetic",
+      "spoken_reference": "a cheerful judge chose fresh peaches from the market stall",
+      "phonetic": {
+        "block": 1,
+        "mode": "statement",
+        "focus": "affricates",
+        "phones": [
+          "AH",
+          "CH",
+          "EH",
+          "F",
+          "IH",
+          "IY",
+          "JH",
+          "L",
+          "P",
+          "R",
+          "SH",
+          "Z"
+        ],
+        "evidence": [
+          "cheerful",
+          "judge",
+          "peaches",
+          "fresh"
+        ]
+      }
+    },
+    {
+      "testcase_id": "tts2-p-b01-i04",
+      "transcript": "Morning rain brought humming birds back to the quiet meadow.",
+      "kind": "phonetic",
+      "spoken_reference": "morning rain brought humming birds back to the quiet meadow",
+      "phonetic": {
+        "block": 1,
+        "mode": "statement",
+        "focus": "nasals",
+        "phones": [
+          "AH",
+          "AO",
+          "B",
+          "D",
+          "ER",
+          "EY",
+          "HH",
+          "IH",
+          "M",
+          "N",
+          "NG",
+          "R",
+          "Z"
+        ],
+        "evidence": [
+          "morning",
+          "rain",
+          "humming",
+          "birds"
+        ]
+      }
+    },
+    {
+      "testcase_id": "tts2-p-b01-i05",
+      "transcript": "We watched yellow sails drift slowly around the harbor wall.",
+      "kind": "phonetic",
+      "spoken_reference": "we watched yellow sails drift slowly around the harbor wall",
+      "phonetic": {
+        "block": 1,
+        "mode": "statement",
+        "focus": "liquids_glides",
+        "phones": [
+          "AA",
+          "AO",
+          "CH",
+          "EH",
+          "EY",
+          "L",
+          "OW",
+          "S",
+          "T",
+          "W",
+          "Y",
+          "Z"
+        ],
+        "evidence": [
+          "watched",
+          "yellow",
+          "sails",
+          "wall"
+        ]
+      }
+    },
+    {
+      "testcase_id": "tts2-p-b01-i06",
+      "transcript": "Could the strong breeze scatter clouds across the narrow bridge?",
+      "kind": "phonetic",
+      "spoken_reference": "could the strong breeze scatter clouds across the narrow bridge",
+      "phonetic": {
+        "block": 1,
+        "mode": "question",
+        "focus": "clusters",
+        "phones": [
+          "AO",
+          "AW",
+          "B",
+          "D",
+          "IH",
+          "IY",
+          "JH",
+          "K",
+          "L",
+          "NG",
+          "R",
+          "S",
+          "T",
+          "Z"
+        ],
+        "evidence": [
+          "strong",
+          "breeze",
+          "clouds",
+          "bridge"
+        ]
+      }
+    },
+    {
+      "testcase_id": "tts2-p-b01-i07",
+      "transcript": "Did the green hen leave her eggs beneath that tree?",
+      "kind": "phonetic",
+      "spoken_reference": "did the green hen leave her eggs beneath that tree",
+      "phonetic": {
+        "block": 1,
+        "mode": "question",
+        "focus": "front_vowels",
+        "phones": [
+          "EH",
+          "G",
+          "HH",
+          "IY",
+          "N",
+          "R",
+          "T",
+          "Z"
+        ],
+        "evidence": [
+          "green",
+          "hen",
+          "eggs",
+          "tree"
+        ]
+      }
+    },
+    {
+      "testcase_id": "tts2-p-b01-i08",
+      "transcript": "Put the blue toy beside the wooden bowl before lunch.",
+      "kind": "phonetic",
+      "spoken_reference": "put the blue toy beside the wooden bowl before lunch",
+      "phonetic": {
+        "block": 1,
+        "mode": "imperative",
+        "focus": "back_vowels",
+        "phones": [
+          "AH",
+          "B",
+          "D",
+          "L",
+          "N",
+          "OW",
+          "OY",
+          "T",
+          "UH",
+          "UW",
+          "W"
+        ],
+        "evidence": [
+          "blue",
+          "toy",
+          "wooden",
+          "bowl"
+        ]
+      }
+    },
+    {
+      "testcase_id": "tts2-p-b01-i09",
+      "transcript": "Record the bright sunrise without disturbing the sleeping family.",
+      "kind": "phonetic",
+      "spoken_reference": "record the bright sunrise without disturbing the sleeping family",
+      "phonetic": {
+        "block": 1,
+        "mode": "imperative",
+        "focus": "stress",
+        "phones": [
+          "AH",
+          "AO",
+          "AY",
+          "B",
+          "D",
+          "IH",
+          "K",
+          "N",
+          "R",
+          "S",
+          "T",
+          "Z"
+        ],
+        "evidence": [
+          "record",
+          "bright",
+          "sunrise"
+        ]
+      }
+    },
+    {
+      "testcase_id": "tts2-p-b01-i10",
+      "transcript": "What a huge brown owl swooping over the quiet field!",
+      "kind": "phonetic",
+      "spoken_reference": "what a huge brown owl swooping over the quiet field",
+      "phonetic": {
+        "block": 1,
+        "mode": "exclamation",
+        "focus": "prosody",
+        "phones": [
+          "AW",
+          "B",
+          "HH",
+          "JH",
+          "L",
+          "N",
+          "R",
+          "UW",
+          "Y"
+        ],
+        "evidence": [
+          "huge",
+          "brown",
+          "owl"
+        ]
+      }
+    },
+    {
+      "testcase_id": "tts2-p-b02-i01",
+      "transcript": "Beth kept a damp ticket tucked inside her coat pocket.",
+      "kind": "phonetic",
+      "spoken_reference": "beth kept a damp ticket tucked inside her coat pocket",
+      "phonetic": {
+        "block": 2,
+        "mode": "statement",
+        "focus": "stops",
+        "phones": [
+          "AE",
+          "AH",
+          "B",
+          "D",
+          "EH",
+          "IH",
+          "K",
+          "M",
+          "P",
+          "T",
+          "TH"
+        ],
+        "evidence": [
+          "Beth",
+          "kept",
+          "damp",
+          "ticket"
+        ]
+      }
+    },
+    {
+      "testcase_id": "tts2-p-b02-i02",
+      "transcript": "Their vision of a safe village survived the fierce storm.",
+      "kind": "phonetic",
+      "spoken_reference": "their vision of a safe village survived the fierce storm",
+      "phonetic": {
+        "block": 2,
+        "mode": "statement",
+        "focus": "fricatives",
+        "phones": [
+          "AH",
+          "DH",
+          "EH",
+          "EY",
+          "F",
+          "IH",
+          "N",
+          "R",
+          "S",
+          "V",
+          "ZH"
+        ],
+        "evidence": [
+          "their",
+          "vision",
+          "safe",
+          "fierce"
+        ]
+      }
+    },
+    {
+      "testcase_id": "tts2-p-b02-i03",
+      "transcript": "The cheerful coach gently nudged a chair toward the doorway.",
+      "kind": "phonetic",
+      "spoken_reference": "the cheerful coach gently nudged a chair toward the doorway",
+      "phonetic": {
+        "block": 2,
+        "mode": "statement",
+        "focus": "affricates",
+        "phones": [
+          "AH",
+          "CH",
+          "EH",
+          "F",
+          "IH",
+          "IY",
+          "JH",
+          "K",
+          "L",
+          "N",
+          "OW",
+          "R",
+          "T"
+        ],
+        "evidence": [
+          "cheerful",
+          "coach",
+          "gently",
+          "chair"
+        ]
+      }
+    },
+    {
+      "testcase_id": "tts2-p-b02-i04",
+      "transcript": "Humming men carried long wooden beams into the narrow hall.",
+      "kind": "phonetic",
+      "spoken_reference": "humming men carried long wooden beams into the narrow hall",
+      "phonetic": {
+        "block": 2,
+        "mode": "statement",
+        "focus": "nasals",
+        "phones": [
+          "AH",
+          "AO",
+          "EH",
+          "HH",
+          "IH",
+          "L",
+          "M",
+          "N",
+          "NG"
+        ],
+        "evidence": [
+          "humming",
+          "men",
+          "long",
+          "hall"
+        ]
+      }
+    },
+    {
+      "testcase_id": "tts2-p-b02-i05",
+      "transcript": "Warm yellow light washed over the little lake at dusk.",
+      "kind": "phonetic",
+      "spoken_reference": "warm yellow light washed over the little lake at dusk",
+      "phonetic": {
+        "block": 2,
+        "mode": "statement",
+        "focus": "liquids_glides",
+        "phones": [
+          "AO",
+          "AY",
+          "EH",
+          "EY",
+          "K",
+          "L",
+          "M",
+          "OW",
+          "R",
+          "T",
+          "W",
+          "Y"
+        ],
+        "evidence": [
+          "warm",
+          "yellow",
+          "light",
+          "lake"
+        ]
+      }
+    },
+    {
+      "testcase_id": "tts2-p-b02-i06",
+      "transcript": "Will three small trucks cross the bridge before the rain?",
+      "kind": "phonetic",
+      "spoken_reference": "will three small trucks cross the bridge before the rain",
+      "phonetic": {
+        "block": 2,
+        "mode": "question",
+        "focus": "clusters",
+        "phones": [
+          "AH",
+          "AO",
+          "B",
+          "IH",
+          "IY",
+          "JH",
+          "K",
+          "L",
+          "M",
+          "R",
+          "S",
+          "T",
+          "TH"
+        ],
+        "evidence": [
+          "three",
+          "small",
+          "trucks",
+          "bridge"
+        ]
+      }
+    },
+    {
+      "testcase_id": "tts2-p-b02-i07",
+      "transcript": "Are these red sheets clean enough for the guest bed?",
+      "kind": "phonetic",
+      "spoken_reference": "are these red sheets clean enough for the guest bed",
+      "phonetic": {
+        "block": 2,
+        "mode": "question",
+        "focus": "front_vowels",
+        "phones": [
+          "B",
+          "D",
+          "DH",
+          "EH",
+          "IY",
+          "R",
+          "S",
+          "SH",
+          "T",
+          "Z"
+        ],
+        "evidence": [
+          "these",
+          "red",
+          "sheets",
+          "bed"
+        ]
+      }
+    },
+    {
+      "testcase_id": "tts2-p-b02-i08",
+      "transcript": "Move the good blue stool closer to the toy box.",
+      "kind": "phonetic",
+      "spoken_reference": "move the good blue stool closer to the toy box",
+      "phonetic": {
+        "block": 2,
+        "mode": "imperative",
+        "focus": "back_vowels",
+        "phones": [
+          "AA",
+          "B",
+          "D",
+          "G",
+          "K",
+          "L",
+          "OY",
+          "S",
+          "T",
+          "UH",
+          "UW"
+        ],
+        "evidence": [
+          "good",
+          "blue",
+          "toy",
+          "box"
+        ]
+      }
+    },
+    {
+      "testcase_id": "tts2-p-b02-i09",
+      "transcript": "Present the artist's sketch after the curtains have been lowered.",
+      "kind": "phonetic",
+      "spoken_reference": "present the artist's sketch after the curtains have been lowered",
+      "phonetic": {
+        "block": 2,
+        "mode": "imperative",
+        "focus": "stress",
+        "phones": [
+          "AA",
+          "AH",
+          "CH",
+          "EH",
+          "ER",
+          "IH",
+          "K",
+          "N",
+          "P",
+          "R",
+          "S",
+          "T",
+          "Z"
+        ],
+        "evidence": [
+          "present",
+          "artist's",
+          "sketch",
+          "curtains"
+        ]
+      }
+    },
+    {
+      "testcase_id": "tts2-p-b02-i10",
+      "transcript": "How loudly that brown hound howls beside the open gate!",
+      "kind": "phonetic",
+      "spoken_reference": "how loudly that brown hound howls beside the open gate",
+      "phonetic": {
+        "block": 2,
+        "mode": "exclamation",
+        "focus": "prosody",
+        "phones": [
+          "AW",
+          "B",
+          "D",
+          "HH",
+          "IY",
+          "L",
+          "N",
+          "R",
+          "Z"
+        ],
+        "evidence": [
+          "loudly",
+          "brown",
+          "hound",
+          "howls"
+        ]
+      }
+    },
+    {
+      "testcase_id": "tts2-p-b03-i01",
+      "transcript": "A black goat bumped the gate while Pat stacked empty buckets.",
+      "kind": "phonetic",
+      "spoken_reference": "a black goat bumped the gate while pat stacked empty buckets",
+      "phonetic": {
+        "block": 3,
+        "mode": "statement",
+        "focus": "stops",
+        "phones": [
+          "AE",
+          "AH",
+          "B",
+          "G",
+          "K",
+          "L",
+          "M",
+          "OW",
+          "P",
+          "S",
+          "T"
+        ],
+        "evidence": [
+          "black",
+          "goat",
+          "bumped",
+          "buckets"
+        ]
+      }
+    },
+    {
+      "testcase_id": "tts2-p-b03-i02",
+      "transcript": "These thin shelves display unusual treasures from distant shores.",
+      "kind": "phonetic",
+      "spoken_reference": "these thin shelves display unusual treasures from distant shores",
+      "phonetic": {
+        "block": 3,
+        "mode": "statement",
+        "focus": "fricatives",
+        "phones": [
+          "AH",
+          "AO",
+          "DH",
+          "IH",
+          "IY",
+          "L",
+          "N",
+          "R",
+          "SH",
+          "TH",
+          "UW",
+          "Y",
+          "Z",
+          "ZH"
+        ],
+        "evidence": [
+          "these",
+          "thin",
+          "unusual",
+          "shores"
+        ]
+      }
+    },
+    {
+      "testcase_id": "tts2-p-b03-i03",
+      "transcript": "Ginger chose a cheap jacket with bright orange buttons.",
+      "kind": "phonetic",
+      "spoken_reference": "ginger chose a cheap jacket with bright orange buttons",
+      "phonetic": {
+        "block": 3,
+        "mode": "statement",
+        "focus": "affricates",
+        "phones": [
+          "AE",
+          "AH",
+          "CH",
+          "ER",
+          "IH",
+          "IY",
+          "JH",
+          "K",
+          "N",
+          "OW",
+          "P",
+          "T",
+          "Z"
+        ],
+        "evidence": [
+          "Ginger",
+          "chose",
+          "cheap",
+          "jacket"
+        ]
+      }
+    },
+    {
+      "testcase_id": "tts2-p-b03-i04",
+      "transcript": "The hungry singer hummed softly near a row of new homes.",
+      "kind": "phonetic",
+      "spoken_reference": "the hungry singer hummed softly near a row of new homes",
+      "phonetic": {
+        "block": 3,
+        "mode": "statement",
+        "focus": "nasals",
+        "phones": [
+          "AH",
+          "D",
+          "ER",
+          "G",
+          "HH",
+          "IH",
+          "IY",
+          "M",
+          "NG",
+          "OW",
+          "R",
+          "S",
+          "Z"
+        ],
+        "evidence": [
+          "hungry",
+          "singer",
+          "hummed",
+          "homes"
+        ]
+      }
+    },
+    {
+      "testcase_id": "tts2-p-b03-i05",
+      "transcript": "Your little yellow wagon rolled smoothly down the winding lane.",
+      "kind": "phonetic",
+      "spoken_reference": "your little yellow wagon rolled smoothly down the winding lane",
+      "phonetic": {
+        "block": 3,
+        "mode": "statement",
+        "focus": "liquids_glides",
+        "phones": [
+          "AE",
+          "AH",
+          "AO",
+          "EH",
+          "EY",
+          "G",
+          "L",
+          "N",
+          "OW",
+          "R",
+          "W",
+          "Y"
+        ],
+        "evidence": [
+          "your",
+          "yellow",
+          "wagon",
+          "lane"
+        ]
+      }
+    },
+    {
+      "testcase_id": "tts2-p-b03-i06",
+      "transcript": "Can fresh spring water flow through cracks in the stone?",
+      "kind": "phonetic",
+      "spoken_reference": "can fresh spring water flow through cracks in the stone",
+      "phonetic": {
+        "block": 3,
+        "mode": "question",
+        "focus": "clusters",
+        "phones": [
+          "AE",
+          "EH",
+          "F",
+          "IH",
+          "K",
+          "N",
+          "NG",
+          "OW",
+          "P",
+          "R",
+          "S",
+          "SH",
+          "T"
+        ],
+        "evidence": [
+          "fresh",
+          "spring",
+          "cracks",
+          "stone"
+        ]
+      }
+    },
+    {
+      "testcase_id": "tts2-p-b03-i07",
+      "transcript": "Has the busy cook kept enough bread for the visitors?",
+      "kind": "phonetic",
+      "spoken_reference": "has the busy cook kept enough bread for the visitors",
+      "phonetic": {
+        "block": 3,
+        "mode": "question",
+        "focus": "front_vowels",
+        "phones": [
+          "B",
+          "D",
+          "EH",
+          "ER",
+          "IH",
+          "IY",
+          "K",
+          "P",
+          "R",
+          "T",
+          "UH",
+          "V",
+          "Z"
+        ],
+        "evidence": [
+          "busy",
+          "cook",
+          "visitors",
+          "bread"
+        ]
+      }
+    },
+    {
+      "testcase_id": "tts2-p-b03-i08",
+      "transcript": "Set the small blue bowl beside the noisy toy train.",
+      "kind": "phonetic",
+      "spoken_reference": "set the small blue bowl beside the noisy toy train",
+      "phonetic": {
+        "block": 3,
+        "mode": "imperative",
+        "focus": "back_vowels",
+        "phones": [
+          "AO",
+          "B",
+          "IY",
+          "L",
+          "M",
+          "N",
+          "OY",
+          "S",
+          "T",
+          "UW",
+          "Z"
+        ],
+        "evidence": [
+          "small",
+          "blue",
+          "toy",
+          "noisy"
+        ]
+      }
+    },
+    {
+      "testcase_id": "tts2-p-b03-i09",
+      "transcript": "Permit the artist to draw both a fern and a palm.",
+      "kind": "phonetic",
+      "spoken_reference": "permit the artist to draw both a fern and a palm",
+      "phonetic": {
+        "block": 3,
+        "mode": "imperative",
+        "focus": "stress",
+        "phones": [
+          "AA",
+          "ER",
+          "F",
+          "IH",
+          "M",
+          "N",
+          "P",
+          "R",
+          "S",
+          "T"
+        ],
+        "evidence": [
+          "permit",
+          "artist",
+          "fern",
+          "palm"
+        ]
+      }
+    },
+    {
+      "testcase_id": "tts2-p-b03-i10",
+      "transcript": "What bright clouds hover above the cows in that field!",
+      "kind": "phonetic",
+      "spoken_reference": "what bright clouds hover above the cows in that field",
+      "phonetic": {
+        "block": 3,
+        "mode": "exclamation",
+        "focus": "prosody",
+        "phones": [
+          "AW",
+          "AY",
+          "B",
+          "D",
+          "F",
+          "IY",
+          "K",
+          "L",
+          "R",
+          "T",
+          "Z"
+        ],
+        "evidence": [
+          "bright",
+          "clouds",
+          "cows",
+          "field"
+        ]
+      }
+    },
+    {
+      "testcase_id": "tts2-p-b04-i01",
+      "transcript": "The baker dropped a thick crust beside the cracked cup.",
+      "kind": "phonetic",
+      "spoken_reference": "the baker dropped a thick crust beside the cracked cup",
+      "phonetic": {
+        "block": 4,
+        "mode": "statement",
+        "focus": "stops",
+        "phones": [
+          "AA",
+          "AE",
+          "AH",
+          "B",
+          "D",
+          "ER",
+          "EY",
+          "K",
+          "P",
+          "R",
+          "T"
+        ],
+        "evidence": [
+          "baker",
+          "dropped",
+          "cracked",
+          "cup"
+        ]
+      }
+    },
+    {
+      "testcase_id": "tts2-p-b04-i02",
+      "transcript": "Though the path was rough, their leisurely walk felt peaceful.",
+      "kind": "phonetic",
+      "spoken_reference": "though the path was rough their leisurely walk felt peaceful",
+      "phonetic": {
+        "block": 4,
+        "mode": "statement",
+        "focus": "fricatives",
+        "phones": [
+          "AE",
+          "AH",
+          "DH",
+          "ER",
+          "F",
+          "IY",
+          "L",
+          "OW",
+          "P",
+          "R",
+          "TH",
+          "ZH"
+        ],
+        "evidence": [
+          "Though",
+          "path",
+          "rough",
+          "leisurely"
+        ]
+      }
+    },
+    {
+      "testcase_id": "tts2-p-b04-i03",
+      "transcript": "A young judge checked each page before closing the ledger.",
+      "kind": "phonetic",
+      "spoken_reference": "a young judge checked each page before closing the ledger",
+      "phonetic": {
+        "block": 4,
+        "mode": "statement",
+        "focus": "affricates",
+        "phones": [
+          "AH",
+          "CH",
+          "EH",
+          "EY",
+          "JH",
+          "K",
+          "NG",
+          "P",
+          "T",
+          "Y"
+        ],
+        "evidence": [
+          "young",
+          "judge",
+          "checked",
+          "page"
+        ]
+      }
+    },
+    {
+      "testcase_id": "tts2-p-b04-i04",
+      "transcript": "Nine men sang softly while carrying the long wooden bench.",
+      "kind": "phonetic",
+      "spoken_reference": "nine men sang softly while carrying the long wooden bench",
+      "phonetic": {
+        "block": 4,
+        "mode": "statement",
+        "focus": "nasals",
+        "phones": [
+          "AE",
+          "AH",
+          "AY",
+          "D",
+          "EH",
+          "M",
+          "N",
+          "NG",
+          "S",
+          "UH",
+          "W"
+        ],
+        "evidence": [
+          "nine",
+          "men",
+          "sang",
+          "wooden"
+        ]
+      }
+    },
+    {
+      "testcase_id": "tts2-p-b04-i05",
+      "transcript": "We heard a yellow wren calling from the leafy hedge.",
+      "kind": "phonetic",
+      "spoken_reference": "we heard a yellow wren calling from the leafy hedge",
+      "phonetic": {
+        "block": 4,
+        "mode": "statement",
+        "focus": "liquids_glides",
+        "phones": [
+          "D",
+          "EH",
+          "ER",
+          "HH",
+          "JH",
+          "L",
+          "N",
+          "OW",
+          "R",
+          "Y"
+        ],
+        "evidence": [
+          "heard",
+          "yellow",
+          "wren",
+          "hedge"
+        ]
+      }
+    },
+    {
+      "testcase_id": "tts2-p-b04-i06",
+      "transcript": "Should the swift train stop before it reaches the bridge?",
+      "kind": "phonetic",
+      "spoken_reference": "should the swift train stop before it reaches the bridge",
+      "phonetic": {
+        "block": 4,
+        "mode": "question",
+        "focus": "clusters",
+        "phones": [
+          "B",
+          "D",
+          "EY",
+          "F",
+          "IH",
+          "JH",
+          "N",
+          "R",
+          "S",
+          "SH",
+          "T",
+          "UH",
+          "W"
+        ],
+        "evidence": [
+          "Should",
+          "swift",
+          "train",
+          "bridge"
+        ]
+      }
+    },
+    {
+      "testcase_id": "tts2-p-b04-i07",
+      "transcript": "Have these pink roses lost their scent in the heat?",
+      "kind": "phonetic",
+      "spoken_reference": "have these pink roses lost their scent in the heat",
+      "phonetic": {
+        "block": 4,
+        "mode": "question",
+        "focus": "front_vowels",
+        "phones": [
+          "AE",
+          "DH",
+          "HH",
+          "IH",
+          "IY",
+          "OW",
+          "R",
+          "T",
+          "V",
+          "Z"
+        ],
+        "evidence": [
+          "Have",
+          "these",
+          "roses",
+          "heat"
+        ]
+      }
+    },
+    {
+      "testcase_id": "tts2-p-b04-i08",
+      "transcript": "Choose the small blue book with the boy on its cover.",
+      "kind": "phonetic",
+      "spoken_reference": "choose the small blue book with the boy on its cover",
+      "phonetic": {
+        "block": 4,
+        "mode": "imperative",
+        "focus": "back_vowels",
+        "phones": [
+          "AO",
+          "B",
+          "K",
+          "L",
+          "M",
+          "OY",
+          "S",
+          "UH",
+          "UW"
+        ],
+        "evidence": [
+          "small",
+          "blue",
+          "book",
+          "boy"
+        ]
+      }
+    },
+    {
+      "testcase_id": "tts2-p-b04-i09",
+      "transcript": "Contrast the two drawings while the artist adjusts the light.",
+      "kind": "phonetic",
+      "spoken_reference": "contrast the two drawings while the artist adjusts the light",
+      "phonetic": {
+        "block": 4,
+        "mode": "imperative",
+        "focus": "stress",
+        "phones": [
+          "AA",
+          "AE",
+          "AH",
+          "AO",
+          "AY",
+          "D",
+          "IH",
+          "K",
+          "L",
+          "N",
+          "NG",
+          "R",
+          "S",
+          "T",
+          "Z"
+        ],
+        "evidence": [
+          "contrast",
+          "drawings",
+          "artist",
+          "light"
+        ]
+      }
+    },
+    {
+      "testcase_id": "tts2-p-b04-i10",
+      "transcript": "Look at that proud hound racing around the garden!",
+      "kind": "phonetic",
+      "spoken_reference": "look at that proud hound racing around the garden",
+      "phonetic": {
+        "block": 4,
+        "mode": "exclamation",
+        "focus": "prosody",
+        "phones": [
+          "AA",
+          "AH",
+          "AW",
+          "D",
+          "G",
+          "HH",
+          "N",
+          "P",
+          "R"
+        ],
+        "evidence": [
+          "proud",
+          "hound",
+          "around",
+          "garden"
+        ]
+      }
+    },
+    {
+      "testcase_id": "tts2-p-b05-i01",
+      "transcript": "The porter tucked the tan bag behind the heavy garden gate.",
+      "kind": "phonetic",
+      "spoken_reference": "the porter tucked the tan bag behind the heavy garden gate",
+      "phonetic": {
+        "block": 5,
+        "mode": "statement",
+        "focus": "stops",
+        "phones": [
+          "AE",
+          "AH",
+          "B",
+          "EH",
+          "EY",
+          "G",
+          "HH",
+          "IY",
+          "K",
+          "T",
+          "V"
+        ],
+        "evidence": [
+          "tucked",
+          "bag",
+          "heavy",
+          "gate"
+        ]
+      }
+    },
+    {
+      "testcase_id": "tts2-p-b05-i02",
+      "transcript": "Those fresh flowers fill the beige room with a sweet scent.",
+      "kind": "phonetic",
+      "spoken_reference": "those fresh flowers fill the beige room with a sweet scent",
+      "phonetic": {
+        "block": 5,
+        "mode": "statement",
+        "focus": "fricatives",
+        "phones": [
+          "AW",
+          "B",
+          "DH",
+          "EH",
+          "ER",
+          "EY",
+          "F",
+          "L",
+          "OW",
+          "R",
+          "SH",
+          "Z",
+          "ZH"
+        ],
+        "evidence": [
+          "those",
+          "fresh",
+          "flowers",
+          "beige"
+        ]
+      }
+    },
+    {
+      "testcase_id": "tts2-p-b05-i03",
+      "transcript": "A cheerful child joined the judge near the chess table.",
+      "kind": "phonetic",
+      "spoken_reference": "a cheerful child joined the judge near the chess table",
+      "phonetic": {
+        "block": 5,
+        "mode": "statement",
+        "focus": "affricates",
+        "phones": [
+          "AH",
+          "AY",
+          "CH",
+          "D",
+          "EH",
+          "JH",
+          "L",
+          "N",
+          "OY",
+          "S"
+        ],
+        "evidence": [
+          "child",
+          "joined",
+          "judge",
+          "chess"
+        ]
+      }
+    },
+    {
+      "testcase_id": "tts2-p-b05-i04",
+      "transcript": "Many neighbors hummed along as the evening bells began ringing.",
+      "kind": "phonetic",
+      "spoken_reference": "many neighbors hummed along as the evening bells began ringing",
+      "phonetic": {
+        "block": 5,
+        "mode": "statement",
+        "focus": "nasals",
+        "phones": [
+          "AH",
+          "B",
+          "D",
+          "EH",
+          "ER",
+          "EY",
+          "HH",
+          "IH",
+          "IY",
+          "M",
+          "N",
+          "NG",
+          "R",
+          "Z"
+        ],
+        "evidence": [
+          "many",
+          "neighbors",
+          "hummed",
+          "ringing"
+        ]
+      }
+    },
+    {
+      "testcase_id": "tts2-p-b05-i05",
+      "transcript": "Yellow leaves drifted over the wide lawn toward the river.",
+      "kind": "phonetic",
+      "spoken_reference": "yellow leaves drifted over the wide lawn toward the river",
+      "phonetic": {
+        "block": 5,
+        "mode": "statement",
+        "focus": "liquids_glides",
+        "phones": [
+          "AO",
+          "AY",
+          "D",
+          "EH",
+          "IY",
+          "L",
+          "N",
+          "OW",
+          "V",
+          "W",
+          "Y",
+          "Z"
+        ],
+        "evidence": [
+          "Yellow",
+          "leaves",
+          "wide",
+          "lawn"
+        ]
+      }
+    },
+    {
+      "testcase_id": "tts2-p-b05-i06",
+      "transcript": "Could three bright sparks leap from the stacked logs?",
+      "kind": "phonetic",
+      "spoken_reference": "could three bright sparks leap from the stacked logs",
+      "phonetic": {
+        "block": 5,
+        "mode": "question",
+        "focus": "clusters",
+        "phones": [
+          "AA",
+          "AO",
+          "AY",
+          "B",
+          "G",
+          "IY",
+          "K",
+          "L",
+          "P",
+          "R",
+          "S",
+          "T",
+          "TH",
+          "Z"
+        ],
+        "evidence": [
+          "three",
+          "bright",
+          "sparks",
+          "logs"
+        ]
+      }
+    },
+    {
+      "testcase_id": "tts2-p-b05-i07",
+      "transcript": "Is the little green fish hiding beneath the red bridge?",
+      "kind": "phonetic",
+      "spoken_reference": "is the little green fish hiding beneath the red bridge",
+      "phonetic": {
+        "block": 5,
+        "mode": "question",
+        "focus": "front_vowels",
+        "phones": [
+          "AH",
+          "B",
+          "F",
+          "G",
+          "IH",
+          "IY",
+          "JH",
+          "L",
+          "N",
+          "R",
+          "SH",
+          "T"
+        ],
+        "evidence": [
+          "little",
+          "green",
+          "fish",
+          "bridge"
+        ]
+      }
+    },
+    {
+      "testcase_id": "tts2-p-b05-i08",
+      "transcript": "Pull the blue hood forward before you enter the cool room.",
+      "kind": "phonetic",
+      "spoken_reference": "pull the blue hood forward before you enter the cool room",
+      "phonetic": {
+        "block": 5,
+        "mode": "imperative",
+        "focus": "back_vowels",
+        "phones": [
+          "B",
+          "D",
+          "HH",
+          "K",
+          "L",
+          "P",
+          "UH",
+          "UW"
+        ],
+        "evidence": [
+          "Pull",
+          "blue",
+          "hood",
+          "cool"
+        ]
+      }
+    },
+    {
+      "testcase_id": "tts2-p-b05-i09",
+      "transcript": "Address the group after the drummer finishes the quiet introduction.",
+      "kind": "phonetic",
+      "spoken_reference": "address the group after the drummer finishes the quiet introduction",
+      "phonetic": {
+        "block": 5,
+        "mode": "imperative",
+        "focus": "stress",
+        "phones": [
+          "AH",
+          "D",
+          "EH",
+          "ER",
+          "G",
+          "IH",
+          "K",
+          "M",
+          "N",
+          "P",
+          "R",
+          "S",
+          "SH",
+          "T",
+          "UW"
+        ],
+        "evidence": [
+          "Address",
+          "group",
+          "drummer",
+          "introduction"
+        ]
+      }
+    },
+    {
+      "testcase_id": "tts2-p-b05-i10",
+      "transcript": "What a marvelous view of those clouds above the valley!",
+      "kind": "phonetic",
+      "spoken_reference": "what a marvelous view of those clouds above the valley",
+      "phonetic": {
+        "block": 5,
+        "mode": "exclamation",
+        "focus": "prosody",
+        "phones": [
+          "AA",
+          "AE",
+          "AH",
+          "AW",
+          "D",
+          "IY",
+          "K",
+          "L",
+          "M",
+          "R",
+          "S",
+          "UW",
+          "V",
+          "Y",
+          "Z"
+        ],
+        "evidence": [
+          "marvelous",
+          "view",
+          "clouds",
+          "valley"
+        ]
+      }
+    },
+    {
+      "testcase_id": "tts2-p-b06-i01",
+      "transcript": "The cook packed a ripe peach beside the dark bread.",
+      "kind": "phonetic",
+      "spoken_reference": "the cook packed a ripe peach beside the dark bread",
+      "phonetic": {
+        "block": 6,
+        "mode": "statement",
+        "focus": "stops",
+        "phones": [
+          "AE",
+          "AY",
+          "B",
+          "D",
+          "EH",
+          "K",
+          "P",
+          "R",
+          "T",
+          "UH"
+        ],
+        "evidence": [
+          "cook",
+          "packed",
+          "ripe",
+          "bread"
+        ]
+      }
+    },
+    {
+      "testcase_id": "tts2-p-b06-i02",
+      "transcript": "Their smooth voices rose above the usual rush of traffic.",
+      "kind": "phonetic",
+      "spoken_reference": "their smooth voices rose above the usual rush of traffic",
+      "phonetic": {
+        "block": 6,
+        "mode": "statement",
+        "focus": "fricatives",
+        "phones": [
+          "AH",
+          "DH",
+          "EH",
+          "IH",
+          "L",
+          "M",
+          "OY",
+          "R",
+          "S",
+          "UW",
+          "V",
+          "Y",
+          "Z",
+          "ZH"
+        ],
+        "evidence": [
+          "Their",
+          "smooth",
+          "voices",
+          "usual"
+        ]
+      }
+    },
+    {
+      "testcase_id": "tts2-p-b06-i03",
+      "transcript": "Jean watched the cheerful child juggle bright red beanbags.",
+      "kind": "phonetic",
+      "spoken_reference": "jean watched the cheerful child juggle bright red beanbags",
+      "phonetic": {
+        "block": 6,
+        "mode": "statement",
+        "focus": "affricates",
+        "phones": [
+          "AA",
+          "AH",
+          "AY",
+          "CH",
+          "D",
+          "G",
+          "IY",
+          "JH",
+          "L",
+          "N",
+          "T",
+          "W"
+        ],
+        "evidence": [
+          "Jean",
+          "watched",
+          "child",
+          "juggle"
+        ]
+      }
+    },
+    {
+      "testcase_id": "tts2-p-b06-i04",
+      "transcript": "Rain drummed on the roof while a young singer warmed up.",
+      "kind": "phonetic",
+      "spoken_reference": "rain drummed on the roof while a young singer warmed up",
+      "phonetic": {
+        "block": 6,
+        "mode": "statement",
+        "focus": "nasals",
+        "phones": [
+          "AH",
+          "D",
+          "ER",
+          "EY",
+          "IH",
+          "M",
+          "N",
+          "NG",
+          "R",
+          "S",
+          "Y"
+        ],
+        "evidence": [
+          "Rain",
+          "drummed",
+          "young",
+          "singer"
+        ]
+      }
+    },
+    {
+      "testcase_id": "tts2-p-b06-i05",
+      "transcript": "We left the yellow wheel leaning against a low wall.",
+      "kind": "phonetic",
+      "spoken_reference": "we left the yellow wheel leaning against a low wall",
+      "phonetic": {
+        "block": 6,
+        "mode": "statement",
+        "focus": "liquids_glides",
+        "phones": [
+          "AO",
+          "EH",
+          "IY",
+          "L",
+          "OW",
+          "W",
+          "Y"
+        ],
+        "evidence": [
+          "yellow",
+          "wheel",
+          "low",
+          "wall"
+        ]
+      }
+    },
+    {
+      "testcase_id": "tts2-p-b06-i06",
+      "transcript": "Will that strong gust sweep three thick branches onto the path?",
+      "kind": "phonetic",
+      "spoken_reference": "will that strong gust sweep three thick branches onto the path",
+      "phonetic": {
+        "block": 6,
+        "mode": "question",
+        "focus": "clusters",
+        "phones": [
+          "AE",
+          "AH",
+          "AO",
+          "B",
+          "CH",
+          "G",
+          "IH",
+          "IY",
+          "N",
+          "NG",
+          "R",
+          "S",
+          "T",
+          "TH",
+          "Z"
+        ],
+        "evidence": [
+          "strong",
+          "gust",
+          "three",
+          "branches"
+        ]
+      }
+    },
+    {
+      "testcase_id": "tts2-p-b06-i07",
+      "transcript": "Has the shy hen found a fresh green leaf yet?",
+      "kind": "phonetic",
+      "spoken_reference": "has the shy hen found a fresh green leaf yet",
+      "phonetic": {
+        "block": 6,
+        "mode": "question",
+        "focus": "front_vowels",
+        "phones": [
+          "AY",
+          "EH",
+          "F",
+          "HH",
+          "IY",
+          "L",
+          "N",
+          "R",
+          "SH"
+        ],
+        "evidence": [
+          "shy",
+          "hen",
+          "fresh",
+          "leaf"
+        ]
+      }
+    },
+    {
+      "testcase_id": "tts2-p-b06-i08",
+      "transcript": "Push the blue toy boat slowly across the shallow pool.",
+      "kind": "phonetic",
+      "spoken_reference": "push the blue toy boat slowly across the shallow pool",
+      "phonetic": {
+        "block": 6,
+        "mode": "imperative",
+        "focus": "back_vowels",
+        "phones": [
+          "B",
+          "L",
+          "OW",
+          "OY",
+          "P",
+          "SH",
+          "T",
+          "UH",
+          "UW"
+        ],
+        "evidence": [
+          "Push",
+          "blue",
+          "toy",
+          "boat"
+        ]
+      }
+    },
+    {
+      "testcase_id": "tts2-p-b06-i09",
+      "transcript": "Object politely if the speaker forgets to describe the final scene.",
+      "kind": "phonetic",
+      "spoken_reference": "object politely if the speaker forgets to describe the final scene",
+      "phonetic": {
+        "block": 6,
+        "mode": "imperative",
+        "focus": "stress",
+        "phones": [
+          "AH",
+          "AY",
+          "B",
+          "EH",
+          "ER",
+          "F",
+          "IY",
+          "JH",
+          "K",
+          "L",
+          "N",
+          "P",
+          "S",
+          "T"
+        ],
+        "evidence": [
+          "Object",
+          "politely",
+          "speaker",
+          "final"
+        ]
+      }
+    },
+    {
+      "testcase_id": "tts2-p-b06-i10",
+      "transcript": "How that brown owl glides beyond the house at twilight!",
+      "kind": "phonetic",
+      "spoken_reference": "how that brown owl glides beyond the house at twilight",
+      "phonetic": {
+        "block": 6,
+        "mode": "exclamation",
+        "focus": "prosody",
+        "phones": [
+          "AW",
+          "AY",
+          "B",
+          "HH",
+          "L",
+          "N",
+          "R",
+          "S",
+          "T",
+          "W"
+        ],
+        "evidence": [
+          "brown",
+          "owl",
+          "house",
+          "twilight"
+        ]
+      }
+    },
+    {
+      "testcase_id": "A1",
+      "transcript": "Your order #ORD-24589 shipped via UPS tracking 1Z999AA1234567890 and will arrive between 2:30 PM and 4:45 PM tomorrow.",
+      "kind": "legacy"
+    },
+    {
+      "testcase_id": "A2",
+      "transcript": "There's a slight delay with your $347.89 order, but we expect it to ship by Friday afternoon.",
+      "kind": "legacy"
+    },
+    {
+      "testcase_id": "A3",
+      "transcript": "Order status update: your items are now in \"Quality Check\" and should ship within 24-48 hours.",
+      "kind": "legacy"
+    },
+    {
+      "testcase_id": "A4",
+      "transcript": "Hi Ms. Garcia, your appointment with Dr. Peterson is scheduled for Tuesday, March 5th at 10:30 AM.",
+      "kind": "legacy"
+    },
+    {
+      "testcase_id": "A5",
+      "transcript": "I can reschedule you to either 11:15 AM on Wednesday or, let me check, 2:45 PM on Thursday.",
+      "kind": "legacy"
+    },
+    {
+      "testcase_id": "A6",
+      "transcript": "Please arrive 10 minutes early and bring your insurance card and a photo ID.",
+      "kind": "legacy"
+    },
+    {
+      "testcase_id": "A7",
+      "transcript": "Let's fix your Wi-Fi: unplug your router for exactly 30 seconds, then wait for the green light.",
+      "kind": "legacy"
+    },
+    {
+      "testcase_id": "A8",
+      "transcript": "Your device is downloading update version 12.4.1, about 250 MB remaining, roughly 8 minutes left.",
+      "kind": "legacy"
+    },
+    {
+      "testcase_id": "A9",
+      "transcript": "I'm seeing error code E-1047 here, which usually means, actually, let me guide you through the solution.",
+      "kind": "legacy"
+    },
+    {
+      "testcase_id": "A10",
+      "transcript": "For security, please confirm the last 4 digits of the card ending in 8429 used for your recent purchase.",
+      "kind": "legacy"
+    },
+    {
+      "testcase_id": "A11",
+      "transcript": "I need to verify your account: what's the ZIP code we have on file? Please take your time.",
+      "kind": "legacy"
+    },
+    {
+      "testcase_id": "A12",
+      "transcript": "We detected 2 unusual login attempts from Chicago, Illinois yesterday around 11:30 PM.",
+      "kind": "legacy"
+    },
+    {
+      "testcase_id": "A13",
+      "transcript": "Hi David, your premium subscription renews in 5 days at $29.99, would you like to continue or explore other options?",
+      "kind": "legacy"
+    },
+    {
+      "testcase_id": "A14",
+      "transcript": "Based on your purchase history, you might like our flash sale: 30% off electronics through Sunday.",
+      "kind": "legacy"
+    },
+    {
+      "testcase_id": "A15",
+      "transcript": "I noticed you haven't logged in since January 15th, is there anything we can help you with?",
+      "kind": "legacy"
+    },
+    {
+      "testcase_id": "A16",
+      "transcript": "Your invoice shows a balance of $187.50, including the monthly fee plus tax.",
+      "kind": "legacy"
+    },
+    {
+      "testcase_id": "A17",
+      "transcript": "The $24.99 charge is for the premium support package you activated on January 22nd.",
+      "kind": "legacy"
+    },
+    {
+      "testcase_id": "A18",
+      "transcript": "Your auto-payment of $67.50 failed due to an expired card, would you like to update your payment method?",
+      "kind": "legacy"
+    },
+    {
+      "testcase_id": "A19",
+      "transcript": "Thanks for your interest in our software, companies your size typically see 20-25% efficiency gains.",
+      "kind": "legacy"
+    },
+    {
+      "testcase_id": "A20",
+      "transcript": "For a 50-person team, I'd recommend our Business plan at $149 per month rather than Basic.",
+      "kind": "legacy"
+    },
+    {
+      "testcase_id": "A21",
+      "transcript": "Great timing! We're offering 20% off annual plans, that saves you $359.88 for the first year.",
+      "kind": "legacy"
+    },
+    {
+      "testcase_id": "A22",
+      "transcript": "On a scale of 1 to 10, how would you rate your current pain level?",
+      "kind": "legacy"
+    },
+    {
+      "testcase_id": "A23",
+      "transcript": "Have you taken any medications today? Please include prescription drugs and over-the-counter items.",
+      "kind": "legacy"
+    },
+    {
+      "testcase_id": "A24",
+      "transcript": "Your symptoms sound manageable, but I'd recommend seeing Dr. Martinez within 48 hours to be safe.",
+      "kind": "legacy"
+    },
+    {
+      "testcase_id": "A25",
+      "transcript": "Your PTO request for December 20th through 24th has been approved, that's 3 business days.",
+      "kind": "legacy"
+    },
+    {
+      "testcase_id": "A26",
+      "transcript": "Password reset complete: your temporary password was sent to your email. Please change it within 24 hours.",
+      "kind": "legacy"
+    },
+    {
+      "testcase_id": "A27",
+      "transcript": "IT ticket about your printer issue has been assigned to technician Lisa Chen.",
+      "kind": "legacy"
+    },
+    {
+      "testcase_id": "A28",
+      "transcript": "Your wire transfer of $1,247.50 to account ending in 5691 was processed at 2:15 PM.",
+      "kind": "legacy"
+    },
+    {
+      "testcase_id": "A29",
+      "transcript": "Hi Mr. O'Connor, I'm calling about your consultation, are you available for 20 minutes between 9 AM and noon?",
+      "kind": "legacy"
+    },
+    {
+      "testcase_id": "A30",
+      "transcript": "System alert: your server usage hit 87% at 3:42 AM, but it's back to normal levels now.",
+      "kind": "legacy"
+    }
+  ]
+}

--- a/runner/src/coval_bench/runner/orchestrator.py
+++ b/runner/src/coval_bench/runner/orchestrator.py
@@ -953,7 +953,8 @@ async def _run_tts_item(
                 # genuine failure worth surfacing as a FAILED row rather than silently dropping.
                 if whisper_transcript is not None:
                     try:
-                        wer_result = compute_wer(transcript, whisper_transcript)
+                        reference = item.spoken_reference or transcript
+                        wer_result = compute_wer(reference, whisper_transcript)
                         results.append(
                             Result(
                                 run_id=run_id,

--- a/runner/tests/unit/test_dataset_loader.py
+++ b/runner/tests/unit/test_dataset_loader.py
@@ -548,6 +548,20 @@ def test_load_manifest_reads_packaged_tts_manifest() -> None:
     assert len(manifest.items) == 30  # 30 curated TTS prompts
 
 
+def test_load_manifest_reads_packaged_tts_v2_manifest() -> None:
+    """tts-v2 carries the v1 prompts unchanged plus the annotated v2 bank."""
+    from coval_bench.datasets.loader import _load_manifest
+
+    manifest = _load_manifest("tts-v2")
+    items = [item for item in manifest.items if isinstance(item, TTSManifestItem)]
+    assert len(items) == 330
+    kinds = {item.kind for item in items}
+    assert kinds == {"vertical", "phonetic", "legacy"}
+    assert all(item.spoken_reference for item in items if item.kind != "legacy")
+    v1 = {item.testcase_id: item.transcript for item in _load_manifest("tts-v1").items}
+    assert {i.testcase_id: i.transcript for i in items if i.kind == "legacy"} == v1
+
+
 def test_load_manifest_reads_packaged_stt_manifest() -> None:
     """_load_manifest round-trips the packaged stt-v1.json manifest."""
     from coval_bench.datasets.loader import _load_manifest

--- a/runner/tests/unit/test_dataset_loader.py
+++ b/runner/tests/unit/test_dataset_loader.py
@@ -558,7 +558,11 @@ def test_load_manifest_reads_packaged_tts_v2_manifest() -> None:
     kinds = {item.kind for item in items}
     assert kinds == {"vertical", "phonetic", "legacy"}
     assert all(item.spoken_reference for item in items if item.kind != "legacy")
-    v1 = {item.testcase_id: item.transcript for item in _load_manifest("tts-v1").items}
+    v1 = {
+        item.testcase_id: item.transcript
+        for item in _load_manifest("tts-v1").items
+        if isinstance(item, TTSManifestItem)
+    }
     assert {i.testcase_id: i.transcript for i in items if i.kind == "legacy"} == v1
 
 

--- a/runner/tests/unit/test_orchestrator.py
+++ b/runner/tests/unit/test_orchestrator.py
@@ -159,6 +159,7 @@ def _make_tts_item(transcript: str = "hello world") -> Any:
     item = MagicMock()
     item.testcase_id = "tts-0001"
     item.transcript = transcript
+    item.spoken_reference = None
     return item
 
 
@@ -3649,3 +3650,43 @@ async def test_transcribe_does_not_retry_other_errors(tmp_path: Path) -> None:
     ):
         await _transcribe_with_whisper(audio, _TEST_SETTINGS)
     assert client.audio.transcriptions.create.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_tts_wer_scores_against_spoken_reference(
+    audio_file: Path, settings: Settings
+) -> None:
+    """When an item carries a spoken reference, WER is measured against it, not the prompt."""
+    provider = MagicMock()
+    provider.synthesize = AsyncMock(
+        return_value=TTSResult(
+            provider="elevenlabs",
+            model="eleven_flash_v2_5",
+            voice="voice",
+            ttfa_ms=120.0,
+            audio_path=audio_file,
+            error=None,
+        )
+    )
+    item = _make_tts_item("Your reference is LT-507.")
+    item.spoken_reference = "your reference is l t five oh seven"
+
+    async with _orchestrator_env(
+        audio_path=audio_file, tts_providers={"elevenlabs": MagicMock(return_value=provider)}
+    ):
+        with patch(
+            "coval_bench.runner.orchestrator._transcribe_with_whisper",
+            new_callable=AsyncMock,
+            return_value="your reference is l t five oh seven",
+        ):
+            results = await _run_tts_item(
+                entry=_tts_entry("elevenlabs", "eleven_flash_v2_5", "voice"),
+                item=item,
+                run_id=1,
+                sem=asyncio.Semaphore(1),
+                settings=settings,
+            )
+
+    wer_rows = [r for r in results if r.metric_type == "WER"]
+    assert len(wer_rows) == 1
+    assert wer_rows[0].metric_value == 0.0


### PR DESCRIPTION
Ship the 330-item TTS v2 bank as tts-v2.json next to the untouched tts-v1. TTS manifest and dataset items gain optional metadata and a spoken reference, which the orchestrator now uses as the WER reference when present. Nothing loads tts-v2 in production yet.