### PR TITLE
[BENCH-871] Project normalized values for dashboard reads

### DIFF
--- a/runner/src/coval_bench/api/routers/aggregates.py
+++ b/runner/src/coval_bench/api/routers/aggregates.py
@@ -9,7 +9,9 @@ Serves the dashboard's chart data as pre-computed aggregates. Two blocks:
   (n-1 denominator, coalesced to 0 for n=1), p25/p50/p75/p90/p95/p99
   (percentile_cont), min, max, count. Read from the per-window materialized
   views (``results_24h``/``results_7d``/``results_30d``), refreshed by the
-  runner at the end of each benchmark run — read-only here.
+  runner at the end of each benchmark run — read-only here. Normalized reads
+  compute the same exact statistics from the transactional value projection,
+  with current observation/run eligibility and request-time window boundaries.
 * ``series`` — per (provider, model, metric_type, bucket_at) distribution
   (min/p25/p50/p75/max/value_sum/count), read from the ``results_by_bucket``
   rollup table, filled by the orchestrator's end-of-run hook.
@@ -181,42 +183,40 @@ def _mean_split(column: str) -> str:
 
 _POOLED_TOTAL = _pooled("substitution_count + deletion_count + insertion_count")
 
-# TTFA components have public metric names of their own, hence the UNION ALL.
+# Successful evaluations project their immutable values in the completion
+# transaction. Observation/run metadata and time boundaries remain live. TTFA
+# components expand once here, including evaluations without a literal primary key.
 _NORMALIZED_STATS_SQL = f"""
 WITH evaluations AS (
  SELECT o.provider, o.model, o.dataset_id, e.metric_type,
-        MAX(v.value) FILTER (WHERE v.value_key = 'primary') AS value,
-        MAX(v.value) FILTER (WHERE v.value_key = 'roundtrip') AS roundtrip,
-        MAX(v.value) FILTER (WHERE v.value_key = 'leading_silence') AS leading_silence,
-        MAX(v.value) FILTER (WHERE v.value_key = 'insertions') AS wer_insertions_pct,
-        MAX(v.value) FILTER (WHERE v.value_key = 'deletions') AS wer_deletions_pct,
-        MAX(v.value) FILTER (WHERE v.value_key = 'substitutions') AS wer_substitutions_pct,
-        MAX(v.value) FILTER (WHERE v.value_key = 'substitution_count') AS substitution_count,
-        MAX(v.value) FILTER (WHERE v.value_key = 'deletion_count') AS deletion_count,
-        MAX(v.value) FILTER (WHERE v.value_key = 'insertion_count') AS insertion_count,
-        MAX(v.value) FILTER (WHERE v.value_key = 'reference_words') AS reference_words
- FROM benchmarks_v2.metric_evaluations e
+        e.value, e.roundtrip, e.leading_silence,
+        e.wer_insertions_pct, e.wer_deletions_pct, e.wer_substitutions_pct,
+        e.substitution_count, e.deletion_count, e.insertion_count, e.reference_words
+ FROM benchmarks_v2.dashboard_metric_values e
  JOIN benchmarks_v2.benchmark_observations o ON o.id = e.observation_id
  JOIN benchmarks_v2.runs r ON r.id = o.run_id
- JOIN benchmarks_v2.metric_values v ON v.metric_evaluation_id = e.id
- WHERE o.status = 'succeeded' AND e.status = 'succeeded'
-   AND r.status IN ('succeeded', 'partial') AND e.metric_version = 'v1'
-   AND e.evaluation_variant = 'default' AND o.benchmark = %(benchmark)s
+ WHERE o.status = 'succeeded' AND r.status IN ('succeeded', 'partial')
+   AND e.metric_version = 'v1' AND e.evaluation_variant = 'default'
+   AND o.benchmark = %(benchmark)s
    AND o.captured_at >= NOW() - %(interval)s::interval
- GROUP BY e.id, o.provider, o.model, o.dataset_id, e.metric_type
+   AND (%(dataset)s = '__all__' OR o.dataset_id = %(dataset)s)
 ), public_values AS (
- SELECT provider, model, dataset_id, metric_type, value,
-        wer_insertions_pct, wer_deletions_pct, wer_substitutions_pct,
-        substitution_count, deletion_count, insertion_count, reference_words
- FROM evaluations WHERE value IS NOT NULL
- UNION ALL
- SELECT provider, model, dataset_id, 'TTFARoundtrip', roundtrip,
-        NULL, NULL, NULL, NULL, NULL, NULL, NULL
- FROM evaluations WHERE metric_type = 'TTFA' AND roundtrip IS NOT NULL
- UNION ALL
- SELECT provider, model, dataset_id, 'TTFALeadingSilence', leading_silence,
-        NULL, NULL, NULL, NULL, NULL, NULL, NULL
- FROM evaluations WHERE metric_type = 'TTFA' AND leading_silence IS NOT NULL
+ SELECT e.provider, e.model, e.dataset_id, p.metric_type, p.value,
+        p.wer_insertions_pct, p.wer_deletions_pct, p.wer_substitutions_pct,
+        p.substitution_count, p.deletion_count, p.insertion_count, p.reference_words
+ FROM evaluations e
+ CROSS JOIN LATERAL (VALUES
+   (e.metric_type, e.value, e.wer_insertions_pct, e.wer_deletions_pct,
+    e.wer_substitutions_pct, e.substitution_count, e.deletion_count,
+    e.insertion_count, e.reference_words),
+   ('TTFARoundtrip', CASE WHEN e.metric_type = 'TTFA' THEN e.roundtrip END,
+    NULL, NULL, NULL, NULL, NULL, NULL, NULL),
+   ('TTFALeadingSilence', CASE WHEN e.metric_type = 'TTFA' THEN e.leading_silence END,
+    NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+ ) AS p(metric_type, value, wer_insertions_pct, wer_deletions_pct,
+        wer_substitutions_pct, substitution_count, deletion_count,
+        insertion_count, reference_words)
+ WHERE p.value IS NOT NULL
 )
 SELECT provider, model, metric_type, AVG(value)::float8 AS mean_value,
  COALESCE({_POOLED_TOTAL}, AVG(value))::float8 AS avg_value,
@@ -237,25 +237,37 @@ SELECT provider, model, metric_type, AVG(value)::float8 AS mean_value,
  {_pooled("deletion_count")} AS pooled_deletions_pct,
  {_pooled("substitution_count")} AS pooled_substitutions_pct
 FROM public_values
- WHERE (%(dataset)s = '__all__' OR dataset_id = %(dataset)s)
 GROUP BY provider, model, metric_type ORDER BY provider, model, metric_type
 """  # noqa: S608
 
 _NORMALIZED_DATASETS_SQL = """
-SELECT DISTINCT o.dataset_id FROM benchmarks_v2.metric_values v
-JOIN benchmarks_v2.metric_evaluations e ON e.id = v.metric_evaluation_id
-JOIN benchmarks_v2.benchmark_observations o ON o.id = e.observation_id
-JOIN benchmarks_v2.runs r ON r.id = o.run_id
-WHERE o.status = 'succeeded' AND e.status = 'succeeded' AND r.status IN ('succeeded', 'partial')
- AND e.metric_version = 'v1' AND e.evaluation_variant = 'default' AND o.benchmark = %(benchmark)s
- AND o.captured_at >= NOW() - %(interval)s::interval AND v.value_role = 'primary'
- AND o.dataset_id <> %(sentinel)s
-ORDER BY o.dataset_id
+WITH candidate_datasets AS (
+ SELECT DISTINCT o.dataset_id
+ FROM benchmarks_v2.benchmark_observations o
+ WHERE o.status = 'succeeded' AND o.benchmark = %(benchmark)s
+   AND o.captured_at >= NOW() - %(interval)s::interval
+   AND o.dataset_id <> %(sentinel)s
+)
+SELECT d.dataset_id FROM candidate_datasets d
+CROSS JOIN LATERAL (
+ SELECT 1
+ FROM benchmarks_v2.benchmark_observations o
+ JOIN benchmarks_v2.runs r ON r.id = o.run_id
+ JOIN benchmarks_v2.dashboard_metric_values e ON e.observation_id = o.id
+ WHERE o.dataset_id = d.dataset_id AND o.status = 'succeeded'
+   AND o.benchmark = %(benchmark)s
+   AND o.captured_at >= NOW() - %(interval)s::interval
+   AND r.status IN ('succeeded', 'partial')
+   AND e.metric_version = 'v1' AND e.evaluation_variant = 'default'
+   AND e.has_primary_role
+ LIMIT 1
+) eligible
+ORDER BY d.dataset_id
 """
 
 _NORMALIZED_STATS_BY_DATASET_SQL = (
     _NORMALIZED_STATS_SQL.replace(
-        " WHERE (%(dataset)s = '__all__' OR dataset_id = %(dataset)s)", ""
+        "   AND (%(dataset)s = '__all__' OR o.dataset_id = %(dataset)s)\n", ""
     )
     .replace(
         "GROUP BY provider, model, metric_type ORDER BY provider, model, metric_type",

--- a/runner/src/coval_bench/db/migrations/versions/20260910_0031_dashboard_metric_values.py
+++ b/runner/src/coval_bench/db/migrations/versions/20260910_0031_dashboard_metric_values.py
@@ -1,0 +1,136 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+# ruff: noqa: E501, S608
+
+"""Cache the normalized evaluation payload used by dashboard reads."""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "20260910_0031"
+down_revision = "20260910_0030"
+branch_labels = None
+depends_on = None
+
+
+_PROJECTION_COLUMNS = """
+ evaluation_id UUID PRIMARY KEY REFERENCES benchmarks_v2.metric_evaluations(id) ON DELETE CASCADE,
+ observation_id UUID NOT NULL,
+ metric_type TEXT NOT NULL, metric_version TEXT NOT NULL, evaluation_variant TEXT NOT NULL,
+ has_primary_role BOOLEAN NOT NULL,
+ value DOUBLE PRECISION, roundtrip DOUBLE PRECISION, leading_silence DOUBLE PRECISION,
+ wer_insertions_pct DOUBLE PRECISION, wer_deletions_pct DOUBLE PRECISION,
+ wer_substitutions_pct DOUBLE PRECISION, substitution_count DOUBLE PRECISION,
+ deletion_count DOUBLE PRECISION, insertion_count DOUBLE PRECISION,
+ reference_words DOUBLE PRECISION
+"""
+
+
+def upgrade() -> None:
+    """Create the projection atomically; retry migration if a writer holds a lock."""
+    op.execute(  # noqa: S608
+        """
+        LOCK TABLE benchmarks_v2.metric_evaluations, benchmarks_v2.metric_values,
+                   benchmarks_v2.metric_artifacts IN SHARE ROW EXCLUSIVE MODE NOWAIT;
+        CREATE OR REPLACE FUNCTION benchmarks_v2.guard_terminal_metric_payload() RETURNS trigger AS $$
+        DECLARE parent_id UUID; old_parent_id UUID; parent_status TEXT;
+        BEGIN
+          IF TG_OP = 'DELETE' THEN parent_id := OLD.metric_evaluation_id;
+          ELSE parent_id := NEW.metric_evaluation_id; END IF;
+          IF TG_OP = 'UPDATE' AND OLD.metric_evaluation_id IS DISTINCT FROM NEW.metric_evaluation_id THEN
+            old_parent_id := OLD.metric_evaluation_id;
+          END IF;
+          FOR parent_id IN
+            SELECT DISTINCT id FROM unnest(ARRAY[parent_id, old_parent_id]) AS ids(id)
+            WHERE id IS NOT NULL ORDER BY id
+          LOOP
+            SELECT status INTO parent_status FROM benchmarks_v2.metric_evaluations
+              WHERE id = parent_id FOR UPDATE;
+            IF FOUND AND parent_status IN ('succeeded', 'failed')
+              THEN RAISE EXCEPTION 'terminal work payloads are immutable'; END IF;
+          END LOOP;
+          RETURN CASE WHEN TG_OP = 'DELETE' THEN OLD ELSE NEW END;
+        END; $$ LANGUAGE plpgsql;
+        CREATE TABLE benchmarks_v2.dashboard_metric_values (
+        """
+        + _PROJECTION_COLUMNS
+        + """
+        );
+        CREATE INDEX dashboard_metric_values_observation_id
+          ON benchmarks_v2.dashboard_metric_values (observation_id);
+        INSERT INTO benchmarks_v2.dashboard_metric_values
+          (evaluation_id, observation_id, metric_type, metric_version, evaluation_variant,
+           has_primary_role, value, roundtrip, leading_silence, wer_insertions_pct,
+           wer_deletions_pct, wer_substitutions_pct, substitution_count, deletion_count,
+           insertion_count, reference_words)
+        SELECT e.id, e.observation_id, e.metric_type, e.metric_version, e.evaluation_variant,
+               COALESCE(BOOL_OR(v.value_role = 'primary'), false),
+               MAX(v.value) FILTER (WHERE v.value_key = 'primary'),
+               MAX(v.value) FILTER (WHERE v.value_key = 'roundtrip'),
+               MAX(v.value) FILTER (WHERE v.value_key = 'leading_silence'),
+               MAX(v.value) FILTER (WHERE v.value_key = 'insertions'),
+               MAX(v.value) FILTER (WHERE v.value_key = 'deletions'),
+               MAX(v.value) FILTER (WHERE v.value_key = 'substitutions'),
+               MAX(v.value) FILTER (WHERE v.value_key = 'substitution_count'),
+               MAX(v.value) FILTER (WHERE v.value_key = 'deletion_count'),
+               MAX(v.value) FILTER (WHERE v.value_key = 'insertion_count'),
+               MAX(v.value) FILTER (WHERE v.value_key = 'reference_words')
+        FROM benchmarks_v2.metric_evaluations e
+        JOIN benchmarks_v2.metric_values v ON v.metric_evaluation_id = e.id
+        WHERE e.status = 'succeeded'
+        GROUP BY e.id;
+        CREATE FUNCTION benchmarks_v2.project_dashboard_metric_values() RETURNS trigger AS $$
+        BEGIN
+          INSERT INTO benchmarks_v2.dashboard_metric_values
+            (evaluation_id, observation_id, metric_type, metric_version, evaluation_variant,
+             has_primary_role, value, roundtrip, leading_silence, wer_insertions_pct,
+             wer_deletions_pct, wer_substitutions_pct, substitution_count, deletion_count,
+             insertion_count, reference_words)
+          SELECT e.id, e.observation_id, e.metric_type, e.metric_version, e.evaluation_variant,
+                 COALESCE(BOOL_OR(v.value_role = 'primary'), false),
+                 MAX(v.value) FILTER (WHERE v.value_key = 'primary'),
+                 MAX(v.value) FILTER (WHERE v.value_key = 'roundtrip'),
+                 MAX(v.value) FILTER (WHERE v.value_key = 'leading_silence'),
+                 MAX(v.value) FILTER (WHERE v.value_key = 'insertions'),
+                 MAX(v.value) FILTER (WHERE v.value_key = 'deletions'),
+                 MAX(v.value) FILTER (WHERE v.value_key = 'substitutions'),
+                 MAX(v.value) FILTER (WHERE v.value_key = 'substitution_count'),
+                 MAX(v.value) FILTER (WHERE v.value_key = 'deletion_count'),
+                 MAX(v.value) FILTER (WHERE v.value_key = 'insertion_count'),
+                 MAX(v.value) FILTER (WHERE v.value_key = 'reference_words')
+          FROM benchmarks_v2.metric_evaluations e
+          LEFT JOIN benchmarks_v2.metric_values v ON v.metric_evaluation_id = e.id
+          WHERE e.id = NEW.id GROUP BY e.id;
+          RETURN NEW;
+        END; $$ LANGUAGE plpgsql;
+        CREATE TRIGGER metric_evaluations_dashboard_projection
+          AFTER UPDATE OF status ON benchmarks_v2.metric_evaluations
+          FOR EACH ROW WHEN (NEW.status = 'succeeded')
+          EXECUTE FUNCTION benchmarks_v2.project_dashboard_metric_values();
+        DO $$ BEGIN
+          IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'api') THEN
+            REVOKE ALL PRIVILEGES ON TABLE benchmarks_v2.dashboard_metric_values FROM api;
+            GRANT SELECT ON TABLE benchmarks_v2.dashboard_metric_values TO api;
+          END IF;
+        END $$;
+        """
+    )
+
+
+def downgrade() -> None:
+    """Remove the projection and restore the pre projection payload guard."""
+    op.execute(
+        """
+        DROP TRIGGER IF EXISTS metric_evaluations_dashboard_projection ON benchmarks_v2.metric_evaluations;
+        DROP FUNCTION IF EXISTS benchmarks_v2.project_dashboard_metric_values();
+        CREATE OR REPLACE FUNCTION benchmarks_v2.guard_terminal_metric_payload() RETURNS trigger AS $$
+        DECLARE parent_status TEXT;
+        BEGIN
+            SELECT status INTO parent_status FROM benchmarks_v2.metric_evaluations WHERE id = CASE WHEN TG_OP = 'DELETE' THEN OLD.metric_evaluation_id ELSE NEW.metric_evaluation_id END;
+            IF FOUND AND parent_status IN ('succeeded', 'failed') THEN RAISE EXCEPTION 'terminal work payloads are immutable'; END IF;
+            RETURN CASE WHEN TG_OP = 'DELETE' THEN OLD ELSE NEW END;
+        END; $$ LANGUAGE plpgsql;
+        DROP TABLE IF EXISTS benchmarks_v2.dashboard_metric_values;
+        """
+    )

--- a/runner/tests/api/conftest.py
+++ b/runner/tests/api/conftest.py
@@ -25,10 +25,11 @@ import time
 from collections.abc import AsyncIterator, Awaitable, Callable, Sequence
 from contextlib import asynccontextmanager
 from datetime import datetime
+from importlib import import_module
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import jwt
 import psycopg
@@ -245,6 +246,10 @@ def _load_schema(**connect_kwargs: Any) -> None:
                 value_key text NOT NULL, unit text NOT NULL, value double precision NOT NULL,
                 value_role text NOT NULL, PRIMARY KEY (metric_evaluation_id, value_key)
             );
+            CREATE TABLE IF NOT EXISTS benchmarks_v2.metric_artifacts (
+                id uuid PRIMARY KEY,
+                metric_evaluation_id uuid NOT NULL REFERENCES benchmarks_v2.metric_evaluations(id)
+            );
             CREATE TABLE IF NOT EXISTS benchmarks_v2.metric_values_by_bucket (
                 provider text NOT NULL, model text NOT NULL, benchmark text NOT NULL,
                 dataset_id text NOT NULL, metric_type text NOT NULL, metric_version text NOT NULL,
@@ -256,6 +261,19 @@ def _load_schema(**connect_kwargs: Any) -> None:
                 sample_count integer NOT NULL
             )
         """)
+        # Exercise the actual projection migration over the small API schema.
+        # Full lifecycle constraints and migration rollback use the DB writer tests.
+        projection = import_module(
+            "coval_bench.db.migrations.versions.20260910_0031_dashboard_metric_values"
+        )
+        with patch.object(projection, "op", SimpleNamespace(execute=conn.execute)):
+            projection.upgrade()
+        for table in ("metric_values", "metric_artifacts"):
+            conn.execute(
+                f"CREATE TRIGGER {table}_guard_terminal BEFORE INSERT OR UPDATE OR DELETE "
+                f"ON benchmarks_v2.{table} FOR EACH ROW "
+                "EXECUTE FUNCTION benchmarks_v2.guard_terminal_metric_payload()"
+            )  # noqa: S608 — table names are fixed fixture constants.
         # Per-window stats materialized views (model_stats + leaderboard).
         # Mirrors migration 20260715_0010: per-dataset rows plus pooled rows
         # under the '__all__' sentinel, and 20260804_0014's WER breakdown.
@@ -583,6 +601,8 @@ async def app(
     monkeypatch.setattr("coval_bench.api.app.lifespan_pool", fresh_lifespan_pool)
 
     test_app = create_app(settings)
+    # The module-level limiter otherwise shares one quota across unrelated tests.
+    test_app.state.limiter.reset()
     async with LifespanManager(test_app):
         yield test_app
 

--- a/runner/tests/api/test_aggregates.py
+++ b/runner/tests/api/test_aggregates.py
@@ -39,6 +39,7 @@ async def _insert_normalized_metric(
     dataset_id: str,
     metric_type: str,
     values: dict[str, float],
+    primary_key: str = "primary",
     benchmark: str = "STT",
     observation_status: str = "succeeded",
     evaluation_status: str = "succeeded",
@@ -70,7 +71,7 @@ async def _insert_normalized_metric(
                 metric_type,
                 metric_version,
                 evaluation_variant,
-                evaluation_status,
+                "running",
             ),
         )
         for key, component in values.items():
@@ -83,9 +84,13 @@ async def _insert_normalized_metric(
                     key,
                     "count" if key in _WER_COUNT_KEYS else "percent",
                     component,
-                    "primary" if key == "primary" else "component",
+                    "primary" if key == primary_key else "component",
                 ),
             )
+        await conn.execute(
+            "UPDATE benchmarks_v2.metric_evaluations SET status = %s WHERE id = %s",
+            (evaluation_status, evaluation_id),
+        )
 
 
 _WER_COUNT_KEYS = ("substitution_count", "deletion_count", "insertion_count", "reference_words")
@@ -485,6 +490,284 @@ async def test_normalized_stats_expand_ttfa_and_filter_ineligible_rows(
     assert stats["TTFA"]["avg_value"] == pytest.approx(120.0)
     assert stats["TTFARoundtrip"]["avg_value"] == pytest.approx(75.0)
     assert stats["TTFALeadingSilence"]["avg_value"] == pytest.approx(45.0)
+
+
+async def test_normalized_component_only_ttfa_is_visible_and_discovers_dataset(
+    client: AsyncClient, postgresql: Any
+) -> None:
+    """TTFA components remain public when the primary role has another key."""
+    run_id = await _insert_run(postgresql, dataset_id="tts-components-v1")
+    await _insert_normalized_metric(
+        postgresql,
+        run_id,
+        dataset_id="tts-components-v1",
+        benchmark="TTS",
+        metric_type="TTFA",
+        values={"ttfa_ms": 120.0, "roundtrip": 75.0, "leading_silence": 45.0},
+        primary_key="ttfa_ms",
+    )
+
+    app = client._transport.app  # type: ignore[attr-defined]
+    app.state.settings.normalized_dashboard_reads_enabled = True
+    params = {"benchmark": "TTS", "include_series": "false"}
+
+    pooled = (await client.get("/v1/results/aggregates", params=params)).json()
+    pooled_stats = {row["metric_type"]: row for row in pooled["model_stats"]}
+    assert set(pooled_stats) == {"TTFARoundtrip", "TTFALeadingSilence"}
+    assert pooled["datasets"] == ["tts-components-v1"]
+
+    scoped = (
+        await client.get(
+            "/v1/results/aggregates",
+            params={**params, "dataset": "tts-components-v1"},
+        )
+    ).json()
+    assert {row["metric_type"] for row in scoped["model_stats"]} == {
+        "TTFARoundtrip",
+        "TTFALeadingSilence",
+    }
+
+    by_dataset = (
+        await client.get("/v1/results/aggregates/by-dataset", params={"benchmark": "TTS"})
+    ).json()["blocks"]
+    assert [block["dataset"] for block in by_dataset] == ["tts-components-v1"]
+    assert {row["metric_type"] for row in by_dataset[0]["model_stats"]} == {
+        "TTFARoundtrip",
+        "TTFALeadingSilence",
+    }
+
+
+async def test_normalized_stats_pool_scope_and_group_exact_distribution(
+    client: AsyncClient, postgresql: Any
+) -> None:
+    """Pooled and per dataset normalized stats preserve exact sample math."""
+    run_v1 = await _insert_run(postgresql, dataset_id="stt-v1")
+    run_v3 = await _insert_run(postgresql, dataset_id="stt-v3")
+    for run_id, dataset_id, values in (
+        (run_v1, "stt-v1", (1.0, 2.0)),
+        (run_v3, "stt-v3", (3.0, 4.0)),
+    ):
+        for value in values:
+            await _insert_normalized_metric(
+                postgresql,
+                run_id,
+                dataset_id=dataset_id,
+                metric_type="WER",
+                values={"primary": value},
+            )
+
+    app = client._transport.app  # type: ignore[attr-defined]
+    app.state.settings.normalized_dashboard_reads_enabled = True
+    params = {"benchmark": "STT", "include_series": "false"}
+
+    pooled = (await client.get("/v1/results/aggregates", params=params)).json()["model_stats"][0]
+    assert pooled["sample_count"] == 4
+    assert pooled["mean_value"] == pytest.approx(2.5)
+    assert pooled["avg_value"] == pytest.approx(2.5)
+    assert pooled["stddev_value"] == pytest.approx(1.2909944, rel=1e-6)
+    assert pooled["p25"] == pytest.approx(1.75)
+    assert pooled["p50"] == pytest.approx(2.5)
+    assert pooled["p75"] == pytest.approx(3.25)
+    assert pooled["p90"] == pytest.approx(3.7)
+    assert pooled["p95"] == pytest.approx(3.85)
+    assert pooled["p99"] == pytest.approx(3.97)
+    assert pooled["min_value"] == pytest.approx(1.0)
+    assert pooled["max_value"] == pytest.approx(4.0)
+
+    scoped = (
+        await client.get(
+            "/v1/results/aggregates",
+            params={**params, "dataset": "stt-v3"},
+        )
+    ).json()["model_stats"][0]
+    assert scoped["sample_count"] == 2
+    assert scoped["mean_value"] == pytest.approx(3.5)
+
+    by_dataset = (
+        await client.get("/v1/results/aggregates/by-dataset", params={"benchmark": "STT"})
+    ).json()["blocks"]
+    assert [block["dataset"] for block in by_dataset] == ["stt-v1", "stt-v3"]
+    assert [block["model_stats"][0]["mean_value"] for block in by_dataset] == pytest.approx(
+        [1.5, 3.5]
+    )
+
+
+async def test_projection_reads_current_metadata_eligibility_and_window(
+    client: AsyncClient, postgresql: Any
+) -> None:
+    """Persisted values never freeze live observation/run attributes or time bounds."""
+    import psycopg
+
+    from tests.api.conftest import _make_db_url
+
+    run_id = await _insert_run(postgresql, dataset_id="stt-v2")
+    await _insert_normalized_metric(
+        postgresql, run_id, dataset_id="stt-v2", metric_type="WER", values={"primary": 10.0}
+    )
+    app = client._transport.app  # type: ignore[attr-defined]
+    app.state.settings.normalized_dashboard_reads_enabled = True
+
+    async def read(window: str = "24h") -> dict[str, Any]:
+        app.state.response_cache.clear()
+        response = await client.get(
+            "/v1/results/aggregates",
+            params={"benchmark": "STT", "include_series": "false", "window": window},
+        )
+        assert response.status_code == 200
+        body: dict[str, Any] = response.json()
+        return body
+
+    assert (await read())["model_stats"][0]["avg_value"] == pytest.approx(10)
+    async with await psycopg.AsyncConnection.connect(
+        _make_db_url(postgresql), autocommit=True
+    ) as conn:
+        await conn.execute(
+            "UPDATE benchmarks_v2.benchmark_observations "
+            "SET dataset_id = 'stt-renamed', provider = 'Prövïder', model = 'Mödèl' "
+            "WHERE run_id = %s",
+            (run_id,),
+        )
+        body = await read()
+        assert body["datasets"] == ["stt-renamed"]
+        assert body["model_stats"][0]["provider"] == "Prövïder"
+        assert body["model_stats"][0]["model"] == "Mödèl"
+        await conn.execute(
+            "UPDATE benchmarks_v2.runs SET status = 'running' WHERE id = %s", (run_id,)
+        )
+        body = await read()
+        assert body["model_stats"] == []
+        assert body["datasets"] == []
+        await conn.execute(
+            "UPDATE benchmarks_v2.runs SET status = 'partial' WHERE id = %s", (run_id,)
+        )
+        assert (await read())["model_stats"][0]["avg_value"] == pytest.approx(10)
+        await conn.execute(
+            "UPDATE benchmarks_v2.benchmark_observations "
+            "SET captured_at = now() - interval '2 days' WHERE run_id = %s",
+            (run_id,),
+        )
+        assert (await read())["model_stats"] == []
+        assert (await read("7d"))["model_stats"][0]["avg_value"] == pytest.approx(10)
+        await conn.execute(
+            "UPDATE benchmarks_v2.benchmark_observations SET status = 'failed' WHERE run_id = %s",
+            (run_id,),
+        )
+        body = await read("7d")
+        assert body["model_stats"] == []
+        assert body["datasets"] == []
+
+
+async def test_normalized_wer_zero_reference_falls_back_to_mean(
+    client: AsyncClient, postgresql: Any
+) -> None:
+    """Complete count rows with no reference words cannot produce a ratio."""
+    run_id = await _insert_run(postgresql, dataset_id="stt-v2")
+    await _insert_normalized_metric(
+        postgresql,
+        run_id,
+        dataset_id="stt-v2",
+        metric_type="WER",
+        values={
+            "primary": 0.0,
+            "substitution_count": 0.0,
+            "deletion_count": 0.0,
+            "insertion_count": 0.0,
+            "reference_words": 0.0,
+        },
+    )
+
+    app = client._transport.app  # type: ignore[attr-defined]
+    app.state.settings.normalized_dashboard_reads_enabled = True
+    stat = (
+        await client.get(
+            "/v1/results/aggregates",
+            params={"benchmark": "STT", "include_series": "false"},
+        )
+    ).json()["model_stats"][0]
+    assert stat["sample_count"] == 1
+    assert stat["avg_value"] == pytest.approx(0.0)
+    assert stat["pooled_value"] is None
+
+
+async def test_normalized_wer_count_and_split_cohorts_fall_back_independently(
+    client: AsyncClient, postgresql: Any
+) -> None:
+    """Incomplete count or split cohorts cannot manufacture pooled breakdowns."""
+    run_id = await _insert_run(postgresql, dataset_id="stt-v2")
+    await _insert_normalized_metric(
+        postgresql,
+        run_id,
+        dataset_id="stt-v2",
+        metric_type="WER",
+        values={
+            "primary": 10.0,
+            "insertions": 1.0,
+            "deletions": 2.0,
+            "substitutions": 7.0,
+            "substitution_count": 1.0,
+            "deletion_count": 1.0,
+            "insertion_count": 0.0,
+            "reference_words": 10.0,
+        },
+    )
+    await _insert_normalized_metric(
+        postgresql,
+        run_id,
+        dataset_id="stt-v2",
+        metric_type="WER",
+        values={"primary": 20.0},
+    )
+
+    app = client._transport.app  # type: ignore[attr-defined]
+    app.state.settings.normalized_dashboard_reads_enabled = True
+    stat = (
+        await client.get(
+            "/v1/results/aggregates",
+            params={"benchmark": "STT", "include_series": "false"},
+        )
+    ).json()["model_stats"][0]
+    assert stat["sample_count"] == 2
+    assert stat["mean_value"] == pytest.approx(15.0)
+    assert stat["avg_value"] == pytest.approx(15.0)
+    assert stat["pooled_value"] is None
+    assert stat["wer_insertions_pct"] is None
+
+
+async def test_normalized_ttfa_derived_name_collision_keeps_public_count(
+    client: AsyncClient, postgresql: Any
+) -> None:
+    """A native metric sharing a TTFA component name joins the same final group."""
+    run_id = await _insert_run(postgresql, dataset_id="tts-v1")
+    await _insert_normalized_metric(
+        postgresql,
+        run_id,
+        dataset_id="tts-v1",
+        benchmark="TTS",
+        metric_type="TTFA",
+        values={"primary": 120.0, "roundtrip": 75.0, "leading_silence": 45.0},
+    )
+    await _insert_normalized_metric(
+        postgresql,
+        run_id,
+        dataset_id="tts-v1",
+        benchmark="TTS",
+        metric_type="TTFARoundtrip",
+        values={"primary": 90.0},
+    )
+
+    app = client._transport.app  # type: ignore[attr-defined]
+    app.state.settings.normalized_dashboard_reads_enabled = True
+    stats = {
+        row["metric_type"]: row
+        for row in (
+            await client.get(
+                "/v1/results/aggregates",
+                params={"benchmark": "TTS", "include_series": "false"},
+            )
+        ).json()["model_stats"]
+    }
+    assert stats["TTFARoundtrip"]["sample_count"] == 2
+    assert stats["TTFARoundtrip"]["mean_value"] == pytest.approx(82.5)
 
 
 async def test_normalized_pooled_wer_is_a_ratio_of_sums(

--- a/runner/tests/unit/test_dashboard_metric_values.py
+++ b/runner/tests/unit/test_dashboard_metric_values.py
@@ -1,0 +1,223 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Migration and transaction coverage for the dashboard value projection."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from typing import Any
+
+import psycopg
+import pytest
+from alembic import command as alembic_command
+from alembic.config import Config as AlembicConfig
+from pytest_postgresql.factories import postgresql
+from sqlalchemy.exc import OperationalError
+
+from coval_bench.db.writer import RunWriter
+from tests.unit import test_normalized_db_writer as storage
+
+pg_conn = postgresql("pg_proc")
+
+
+@pytest.mark.asyncio
+async def test_projection_seeds_existing_values_and_downgrades(
+    pg_conn: psycopg.Connection[Any],
+) -> None:
+    storage._migrate(pg_conn, "20260910_0030")
+    pool = await storage._pool(pg_conn)
+    try:
+        writer = RunWriter(pool)
+        _, observation = await storage._observation(writer)
+        evaluation = await storage._evaluation(writer, observation)
+        evaluation_id = storage._required(evaluation.id)
+        await writer.complete_metric_evaluation(
+            evaluation_id,
+            values=storage._wer_values(evaluation_id),
+            finished_at=storage._NOW + timedelta(seconds=1),
+        )
+    finally:
+        await pool.close()
+    storage._migrate(pg_conn)
+    pg_conn.autocommit = True
+    row = pg_conn.execute(
+        "SELECT value, wer_insertions_pct, wer_deletions_pct, wer_substitutions_pct, "
+        "reference_words, has_primary_role FROM benchmarks_v2.dashboard_metric_values "
+        "WHERE evaluation_id = %s",
+        (evaluation_id,),
+    ).fetchone()
+    assert row == (10, 1, 2, 7, None, True)
+    config = AlembicConfig(str(storage._INI_PATH))
+    config.set_main_option(
+        "sqlalchemy.url", storage._dsn(pg_conn).replace("postgresql://", "postgresql+psycopg://")
+    )
+    alembic_command.downgrade(config, "20260910_0030")
+    assert pg_conn.execute(
+        "SELECT to_regclass('benchmarks_v2.dashboard_metric_values')"
+    ).fetchone() == (None,)
+    assert pg_conn.execute(
+        "SELECT count(*) FROM benchmarks_v2.metric_values WHERE metric_evaluation_id = %s",
+        (evaluation_id,),
+    ).fetchone() == (4,)
+    with pytest.raises(psycopg.errors.RaiseException, match="payloads are immutable"):
+        pg_conn.execute(
+            "UPDATE benchmarks_v2.metric_values SET value = 0 "
+            "WHERE metric_evaluation_id = %s AND value_key = 'primary'",
+            (evaluation_id,),
+        )
+
+
+@pytest.mark.asyncio
+async def test_projection_cascades_and_evaluation_uuid_can_be_reused(
+    pg_conn: psycopg.Connection[Any],
+) -> None:
+    storage._migrate(pg_conn)
+    pool = await storage._pool(pg_conn)
+    try:
+        writer = RunWriter(pool)
+        _, observation = await storage._observation(writer)
+        evaluation = await storage._evaluation(writer, observation)
+        evaluation_id = storage._required(evaluation.id)
+        await writer.complete_metric_evaluation(
+            evaluation_id,
+            values=storage._wer_values(evaluation_id),
+            finished_at=storage._NOW + timedelta(seconds=1),
+        )
+        async with pool.connection() as conn:
+            await conn.execute(
+                "DELETE FROM benchmarks_v2.benchmark_observations WHERE id = %s",
+                (observation.id,),
+            )
+            row = await (
+                await conn.execute(
+                    "SELECT count(*) AS n FROM benchmarks_v2.dashboard_metric_values"
+                )
+            ).fetchone()
+            assert row == {"n": 0}
+        _, replacement = await storage._observation(writer, sample="replacement")
+        async with pool.connection() as conn:
+            await conn.execute(
+                "INSERT INTO benchmarks_v2.metric_evaluations "
+                "(id, observation_id, metric_type, metric_version, evaluation_variant, "
+                "executor, status) VALUES (%s, %s, 'WER', 'v1', 'default', 'inline', 'queued')",
+                (evaluation_id, replacement.id),
+            )
+        await writer.start_metric_evaluation(evaluation_id, started_at=storage._NOW)
+        values = storage._wer_values(evaluation_id)
+        values[0] = values[0].model_copy(update={"value": 11})
+        values[3] = values[3].model_copy(update={"value": 8})
+        await writer.complete_metric_evaluation(
+            evaluation_id, values=values, finished_at=storage._NOW + timedelta(seconds=1)
+        )
+        async with pool.connection() as conn:
+            row = await (
+                await conn.execute(
+                    "SELECT observation_id, value FROM benchmarks_v2.dashboard_metric_values "
+                    "WHERE evaluation_id = %s",
+                    (evaluation_id,),
+                )
+            ).fetchone()
+            assert row == {"observation_id": replacement.id, "value": 11}
+    finally:
+        await pool.close()
+
+
+@pytest.mark.asyncio
+async def test_deferred_validation_failure_rolls_back_projection(
+    pg_conn: psycopg.Connection[Any],
+) -> None:
+    storage._migrate(pg_conn)
+    pool = await storage._pool(pg_conn)
+    try:
+        writer = RunWriter(pool)
+        _, observation = await storage._observation(writer)
+        evaluation = await storage._evaluation(writer, observation)
+        evaluation_id = storage._required(evaluation.id)
+        async with pool.connection() as conn:
+            with pytest.raises(psycopg.errors.RaiseException, match="exactly one primary"):
+                async with conn.transaction():
+                    await conn.execute(
+                        "INSERT INTO benchmarks_v2.metric_values VALUES "
+                        "(%s, 'roundtrip', 'milliseconds', 42, 'component')",
+                        (evaluation_id,),
+                    )
+                    await conn.execute(
+                        "UPDATE benchmarks_v2.metric_evaluations "
+                        "SET status = 'succeeded', finished_at = %s, updated_at = now() "
+                        "WHERE id = %s",
+                        (storage._NOW + timedelta(seconds=1), evaluation_id),
+                    )
+                    row = await (
+                        await conn.execute(
+                            "SELECT roundtrip FROM benchmarks_v2.dashboard_metric_values "
+                            "WHERE evaluation_id = %s",
+                            (evaluation_id,),
+                        )
+                    ).fetchone()
+                    assert row == {"roundtrip": 42}
+            row = await (
+                await conn.execute(
+                    "SELECT status FROM benchmarks_v2.metric_evaluations WHERE id = %s",
+                    (evaluation_id,),
+                )
+            ).fetchone()
+            assert row == {"status": "running"}
+            row = await (
+                await conn.execute(
+                    "SELECT count(*) AS n FROM benchmarks_v2.dashboard_metric_values"
+                )
+            ).fetchone()
+            assert row == {"n": 0}
+    finally:
+        await pool.close()
+
+
+@pytest.mark.asyncio
+async def test_projection_upgrade_nowait_does_not_interrupt_completion(
+    pg_conn: psycopg.Connection[Any],
+) -> None:
+    """A partial lock set never makes migration and an active writer wait on each other."""
+    storage._migrate(pg_conn, "20260910_0030")
+    pool = await storage._pool(pg_conn)
+    try:
+        writer = RunWriter(pool)
+        _, observation = await storage._observation(writer)
+        evaluation = await storage._evaluation(writer, observation)
+        evaluation_id = storage._required(evaluation.id)
+        async with pool.connection() as conn:
+            await conn.execute(
+                "SELECT id FROM benchmarks_v2.metric_evaluations WHERE id = %s FOR UPDATE",
+                (evaluation_id,),
+            )
+            await conn.execute(
+                "INSERT INTO benchmarks_v2.metric_values VALUES "
+                "(%s, 'primary', 'percent', 10, 'primary')",
+                (evaluation_id,),
+            )
+            # The writer holds evaluations ROW SHARE and values ROW EXCLUSIVE.
+            # An ordered blocking migration lock could deadlock its final UPDATE.
+            with pytest.raises(OperationalError, match="could not obtain lock") as error:
+                storage._migrate(pg_conn)
+            assert isinstance(error.value.orig, psycopg.errors.LockNotAvailable)
+            await conn.execute(
+                "UPDATE benchmarks_v2.metric_evaluations "
+                "SET status = 'succeeded', finished_at = %s WHERE id = %s",
+                (storage._NOW + timedelta(seconds=1), evaluation_id),
+            )
+            await conn.commit()
+        storage._migrate(pg_conn)
+        async with pool.connection() as conn:
+            row = await (
+                await conn.execute(
+                    "SELECT d.value, v.value AS raw_value "
+                    "FROM benchmarks_v2.dashboard_metric_values d "
+                    "JOIN benchmarks_v2.metric_values v "
+                    "ON v.metric_evaluation_id = d.evaluation_id "
+                    "AND v.value_key = 'primary' WHERE d.evaluation_id = %s",
+                    (evaluation_id,),
+                )
+            ).fetchone()
+            assert row == {"value": 10, "raw_value": 10}
+    finally:
+        await pool.close()

--- a/runner/tests/unit/test_normalized_db_writer.py
+++ b/runner/tests/unit/test_normalized_db_writer.py
@@ -1323,6 +1323,21 @@ async def test_metric_completion_replay_and_rollback(pg_conn: psycopg.Connection
         await writer.complete_metric_evaluation(
             evaluation_id, values=values, artifacts=[artifact], finished_at=finished
         )
+        async with pool.connection() as conn, conn.cursor() as cur:
+            await cur.execute(
+                """SELECT has_primary_role, value, wer_insertions_pct,
+                          wer_deletions_pct, wer_substitutions_pct
+                   FROM benchmarks_v2.dashboard_metric_values
+                   WHERE evaluation_id = %s""",
+                (evaluation_id,),
+            )
+            assert await cur.fetchone() == {
+                "has_primary_role": True,
+                "value": 10.0,
+                "wer_insertions_pct": 1.0,
+                "wer_deletions_pct": 2.0,
+                "wer_substitutions_pct": 7.0,
+            }
         await writer.complete_metric_evaluation(
             evaluation_id, values=values, artifacts=[artifact], finished_at=finished
         )
@@ -1365,6 +1380,126 @@ async def test_metric_completion_replay_and_rollback(pg_conn: psycopg.Connection
                 (invalid_id,),
             )
             assert _required(await cur.fetchone())["count"] == 0
+            await cur.execute(
+                "SELECT count(*) AS count FROM benchmarks_v2.dashboard_metric_values "
+                "WHERE evaluation_id = %s",
+                (invalid_id,),
+            )
+            assert _required(await cur.fetchone())["count"] == 0
+    finally:
+        await pool.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("terminal_first", [True, False])
+async def test_metric_payload_reassignment_rejects_terminal_parents(
+    pg_conn: psycopg.Connection[Any], terminal_first: bool
+) -> None:
+    """Moving a payload to or from a terminal evaluation is rejected atomically."""
+    _migrate(pg_conn)
+    pool = await _pool(pg_conn)
+    try:
+        writer = RunWriter(pool)
+        _, observation = await _observation(writer, sample=f"reparent-{terminal_first}")
+        first = await _evaluation(writer, observation, metric=Metric.WER)
+        second = await _evaluation(writer, observation, metric=Metric.TTFA)
+        first_id, second_id = _required(first.id), _required(second.id)
+        terminal_id, running_id = (first_id, second_id) if terminal_first else (second_id, first_id)
+        if terminal_first:
+            await writer.complete_metric_evaluation(
+                terminal_id, values=_wer_values(terminal_id), finished_at=_NOW
+            )
+            payload_id, destination_id = terminal_id, running_id
+        else:
+            payload_id, destination_id = running_id, terminal_id
+            await writer.complete_metric_evaluation(
+                destination_id,
+                values=[
+                    MetricValue(
+                        metric_evaluation_id=destination_id,
+                        value_key="primary",
+                        unit="milliseconds",
+                        value=1,
+                        value_role=MetricValueRole.PRIMARY,
+                    )
+                ],
+                finished_at=_NOW,
+            )
+        async with pool.connection() as conn, conn.cursor() as cur:
+            if not terminal_first:
+                # Keep the running parent's temporary output in this transaction.
+                # It cannot commit until the parent succeeds.
+                await cur.execute(
+                    "INSERT INTO benchmarks_v2.metric_values "
+                    "(metric_evaluation_id, value_key, unit, value, value_role) "
+                    "VALUES (%s, 'primary', 'percent', 10, 'primary')",
+                    (payload_id,),
+                )
+            with pytest.raises(psycopg.errors.RaiseException, match="payloads are immutable"):
+                await cur.execute(
+                    "UPDATE benchmarks_v2.metric_values SET metric_evaluation_id = %s "
+                    "WHERE metric_evaluation_id = %s AND value_key = 'primary'",
+                    (destination_id, payload_id),
+                )
+            await conn.rollback()
+            await cur.execute(
+                "SELECT count(*) AS count FROM benchmarks_v2.dashboard_metric_values "
+                "WHERE evaluation_id IN (%s, %s)",
+                (terminal_id, running_id),
+            )
+            assert _required(await cur.fetchone())["count"] == 1
+    finally:
+        await pool.close()
+
+
+@pytest.mark.asyncio
+async def test_metric_payload_insert_waits_for_completion_then_rejects(
+    pg_conn: psycopg.Connection[Any],
+) -> None:
+    """A payload writer serializes behind completion and then sees terminal state."""
+    _migrate(pg_conn)
+    pool = await _pool(pg_conn)
+    try:
+        writer = RunWriter(pool)
+        _, observation = await _observation(writer, sample="payload-lock")
+        evaluation = await _evaluation(writer, observation)
+        evaluation_id = _required(evaluation.id)
+        async with pool.connection() as conn_a, conn_a.cursor() as cur_a:
+            await cur_a.execute(
+                "SELECT id FROM benchmarks_v2.metric_evaluations WHERE id = %s FOR UPDATE",
+                (evaluation_id,),
+            )
+            async with pool.connection() as conn_b, conn_b.cursor() as cur_b:
+                await cur_b.execute("SET LOCAL lock_timeout = '100ms'")
+                with pytest.raises(psycopg.errors.LockNotAvailable):
+                    await cur_b.execute(
+                        "INSERT INTO benchmarks_v2.metric_values "
+                        "(metric_evaluation_id, value_key, unit, value, value_role) "
+                        "VALUES (%s, 'primary', 'percent', 10, 'primary')",
+                        (evaluation_id,),
+                    )
+                await conn_b.rollback()
+            await cur_a.execute(
+                "INSERT INTO benchmarks_v2.metric_values "
+                "(metric_evaluation_id, value_key, unit, value, value_role) "
+                "VALUES (%s, 'primary', 'percent', 10, 'primary')",
+                (evaluation_id,),
+            )
+            await cur_a.execute(
+                "UPDATE benchmarks_v2.metric_evaluations SET status = 'succeeded', "
+                "finished_at = %s WHERE id = %s",
+                (_NOW + timedelta(seconds=1), evaluation_id),
+            )
+            await conn_a.commit()
+        async with pool.connection() as conn, conn.cursor() as cur:
+            with pytest.raises(psycopg.errors.RaiseException, match="payloads are immutable"):
+                await cur.execute(
+                    "INSERT INTO benchmarks_v2.metric_values "
+                    "(metric_evaluation_id, value_key, unit, value, value_role) "
+                    "VALUES (%s, 'insertions', 'percent', 1, 'component')",
+                    (evaluation_id,),
+                )
+            await conn.rollback()
     finally:
         await pool.close()
 


### PR DESCRIPTION
## Summary

Normalized dashboard requests currently pivot millions of metric-value rows; production STT 30-day probes still exceed the 20-second diagnostic limit. Persist the dashboard value projection in each successful evaluation's transaction, then compute exact statistics from it while joining current observation/run eligibility and request-time windows. This serves aggregates, by-dataset aggregates, dataset discovery, and the shared leaderboard query.

Migration `0031` seeds existing successful evaluations, adds the completion trigger and cascading projection table, and serializes payload changes with completion, including both parents on reassignment. Source-table locks use `NOWAIT`: an active writer makes migration fail cleanly for retry. TTFA components, complete-count pooled WER and fallbacks, literal-primary versus role-primary semantics, visibility, and exact distributions are preserved.

## Validation

- 94 focused PostgreSQL/API tests passed on current `main`; the four migration tests passed again after the lock repair.
- Real `0030 → 0031` migration and writer-to-HTTP smoke: 24 nonempty HTTP 200 responses and 18 exact SQL parity comparisons across STT/TTS and all windows. Forty completions per phase measured median 0.63ms before and 0.70ms after locally.
- Changed-file Ruff, formatting, and strict mypy passed. Independent Astra planning and Sol review completed.

Representative local PostgreSQL fixture: 800,000 observations, 2.4 million evaluations, 5.96 million values over nine days, `en_US.UTF-8`, 4MB work memory, one query worker. All 12 stats/by-dataset comparisons matched within `1e-9`; medians below use three executions.

| Stats window | STT before → after | TTS before → after |
|---|---:|---:|
| 24h | 1.020s → 0.468s | 1.981s → 0.608s |
| 7d | 4.509s → 2.295s | 6.144s → 3.356s |
| 30d | 5.451s → 3.008s | 7.707s → 4.272s |

By-dataset reads finished within 4.27s. Dataset discovery preserved all six result sets; the final projection-backed dataset reader took 0.043–0.130s in a subsequent local check.

## Rollout

Apply the migration before deploying these readers. The initial projection population holds write-conflicting source locks; retry migration when a writer prevents immediate acquisition. The actual migration took 40.5s for the local 2.4-million-evaluation fixture and created a 381MiB projection, so schedule an ingestion pause for initial population. Roll back the reader before dropping the projection. Projection writes commit atomically with completion and add no refresh job.

These are local performance measurements, not production after-change timings. The migration has not been applied in production, normalized reads have not been enabled by this change, and deployment/load validation remains pending. No history repair is included. The branch includes the merged BENCH-857 validator fix from current `main`.

[Linear BENCH-871](https://linear.app/coval/issue/BENCH-871/fix-slow-normalized-dashboard-queries)
