### PR TITLE
[BENCH-872] Load the private tts-v2 manifest from GCS and score WER against the spoken reference

### DIFF
--- a/runner/src/coval_bench/datasets/loader.py
+++ b/runner/src/coval_bench/datasets/loader.py
@@ -136,11 +136,8 @@ class Dataset(BaseModel):
     items: list[DatasetItem]
 
 
-class TTSDatasetItem(BaseModel):
+class TTSDatasetItem(TTSManifestItem):
     """A single TTS benchmark item (text-only, no audio to fetch)."""
-
-    testcase_id: str = Field(min_length=1)
-    transcript: str
 
 
 class TTSDataset(BaseModel):
@@ -256,6 +253,34 @@ def _fetch_blob(
     blob.download_to_filename(str(dest))
 
 
+def _fetch_verified(
+    *,
+    client: storage.Client,
+    bucket: str,
+    object_path: str,
+    sha256: str,
+    local_path: Path,
+) -> Path:
+    """Return *local_path* holding *object_path*, downloading from GCS if needed.
+
+    If the cached file already has the correct SHA256, the download is skipped.
+    On SHA256 mismatch after download, raises :class:`DatasetIntegrityError`.
+    """
+    if local_path.exists():
+        if _sha256_file(local_path) == sha256:
+            logger.debug("cache_hit", path=object_path)
+            return local_path
+        logger.warning("cached_file_hash_mismatch", path=str(local_path))
+
+    logger.info("fetching_dataset_object", bucket=bucket, object=object_path)
+    _fetch_blob(client, bucket, object_path, local_path)
+
+    actual = _sha256_file(local_path)
+    if actual != sha256:
+        raise DatasetIntegrityError(object_path, sha256, actual)
+    return local_path
+
+
 def _fetch_and_verify(
     *,
     client: storage.Client,
@@ -264,31 +289,42 @@ def _fetch_and_verify(
     item: STTManifestItem,
     cache_dir: Path,
 ) -> Path:
-    """Return local path for *item*, downloading from GCS if needed.
+    """Return local path for *item*, downloading from GCS if needed."""
+    return _fetch_verified(
+        client=client,
+        bucket=bucket,
+        object_path=f"{dataset_id}/{item.path}",
+        sha256=item.sha256,
+        local_path=cache_dir / dataset_id / item.path,
+    )
 
-    If the cached file already has the correct SHA256, the download is skipped.
-    On SHA256 mismatch after download, raises :class:`DatasetIntegrityError`.
-    """
-    local_path = cache_dir / dataset_id / item.path
 
-    # Cache hit check
-    if local_path.exists():
-        if _sha256_file(local_path) == item.sha256:
-            logger.debug("cache_hit", path=str(item.path))
-            return local_path
-        logger.warning("cached_file_hash_mismatch", path=str(local_path))
-
-    # Download
-    gcs_object = f"{dataset_id}/{item.path}"
-    logger.info("fetching_dataset_object", bucket=bucket, object=gcs_object)
-    _fetch_blob(client, bucket, gcs_object, local_path)
-
-    # Post-download integrity check
-    actual = _sha256_file(local_path)
-    if actual != item.sha256:
-        raise DatasetIntegrityError(item.path, item.sha256, actual)
-
-    return local_path
+def _resolve_manifest(
+    dataset_id: str,
+    *,
+    cache_dir: Path | None,
+    storage_client: storage.Client | None,
+) -> Manifest:
+    """Load the packaged manifest, following a private ``remote`` pointer if present."""
+    packaged = _load_manifest(dataset_id)
+    if packaged.remote is None:
+        return packaged
+    # A private bucket needs real credentials; the anonymous public-bucket client cannot read it.
+    client = storage_client if storage_client is not None else storage.Client()
+    resolved_cache = cache_dir if cache_dir is not None else _default_cache_dir()
+    local_path = _fetch_verified(
+        client=client,
+        bucket=packaged.remote.bucket,
+        object_path=packaged.remote.path,
+        sha256=packaged.remote.sha256,
+        local_path=resolved_cache / dataset_id / "manifest.json",
+    )
+    manifest = Manifest.model_validate_json(local_path.read_text(encoding="utf-8"))
+    if manifest.id != dataset_id or manifest.remote is not None:
+        raise ManifestAlignmentError(
+            f"remote manifest for '{dataset_id}' is not a full manifest with that id"
+        )
+    return manifest
 
 
 # ---------------------------------------------------------------------------
@@ -327,7 +363,7 @@ def load_stt_dataset(
     Dataset
         Fully-verified dataset with local file paths.
     """
-    manifest = _load_manifest(dataset_id)
+    manifest = _resolve_manifest(dataset_id, cache_dir=cache_dir, storage_client=storage_client)
     if dataset_id in WILDASR_ENV_FAMILY:
         _assert_family_alignment(dataset_id, manifest)
     resolved_cache = cache_dir if cache_dir is not None else _default_cache_dir()
@@ -371,24 +407,24 @@ def load_stt_dataset(
 def load_tts_dataset(
     dataset_id: str,
     *,
-    settings: Settings,  # noqa: ARG001 – kept for uniform call signature
-    cache_dir: Path | None = None,  # noqa: ARG001 – no files to cache for TTS
-    storage_client: storage.Client | None = None,  # noqa: ARG001 – no GCS needed
+    settings: Settings,
+    cache_dir: Path | None = None,
+    storage_client: storage.Client | None = None,
     sample_size: int | None = None,
     rng: random.Random | None = None,
 ) -> TTSDataset:
-    """Load a TTS dataset (text prompts only; no GCS fetch required).
+    """Load a TTS dataset (text prompts only; GCS is touched only for a private manifest).
 
     Parameters
     ----------
     dataset_id:
         Manifest identifier, e.g. ``"tts-v1"``.
     settings:
-        Accepted for call-signature symmetry; not used for TTS.
+        Runner settings; used to build a GCS client for private manifests.
     cache_dir:
-        Accepted for call-signature symmetry; not used for TTS.
+        Override the local cache directory for a fetched private manifest.
     storage_client:
-        Accepted for call-signature symmetry; not used for TTS.
+        Injectable GCS client (for tests; production passes ``None``).
     sample_size:
         Draw this many prompts at random; ``None`` uses all.
     rng:
@@ -399,7 +435,7 @@ def load_tts_dataset(
     TTSDataset
         Dataset with text-only items.
     """
-    manifest = _load_manifest(dataset_id)
+    manifest = _resolve_manifest(dataset_id, cache_dir=cache_dir, storage_client=storage_client)
 
     tts_items: list[TTSDatasetItem] = []
     for raw_item in _sample_items(list(manifest.items), sample_size, rng):
@@ -407,12 +443,7 @@ def load_tts_dataset(
             raise TypeError(
                 f"Dataset '{dataset_id}' contains non-TTS items; use load_stt_dataset instead."
             )
-        tts_items.append(
-            TTSDatasetItem(
-                testcase_id=raw_item.testcase_id,
-                transcript=raw_item.transcript,
-            )
-        )
+        tts_items.append(TTSDatasetItem.model_validate(raw_item.model_dump()))
 
     return TTSDataset(id=manifest.id, version=manifest.version, items=tts_items)
 
@@ -431,7 +462,7 @@ def load_dataset(
     Prefer the explicit ``load_stt_dataset`` / ``load_tts_dataset`` functions
     when the caller knows the dataset type ahead of time.
     """
-    manifest = _load_manifest(dataset_id)
+    manifest = _resolve_manifest(dataset_id, cache_dir=cache_dir, storage_client=storage_client)
     if manifest.items and isinstance(manifest.items[0], STTManifestItem):
         return load_stt_dataset(
             dataset_id,

--- a/runner/src/coval_bench/datasets/loader.py
+++ b/runner/src/coval_bench/datasets/loader.py
@@ -420,7 +420,8 @@ def load_tts_dataset(
     dataset_id:
         Manifest identifier, e.g. ``"tts-v1"``.
     settings:
-        Runner settings; used to build a GCS client for private manifests.
+        Accepted for call-signature symmetry; not consulted. The private-manifest
+        client comes from ``storage_client`` or application-default credentials.
     cache_dir:
         Override the local cache directory for a fetched private manifest.
     storage_client:

--- a/runner/src/coval_bench/datasets/manifest.py
+++ b/runner/src/coval_bench/datasets/manifest.py
@@ -84,6 +84,13 @@ class RemoteManifest(BaseModel):
     path: str = Field(min_length=1)
     sha256: str = Field(pattern=r"^[a-f0-9]{64}$")
 
+    @model_validator(mode="after")
+    def path_is_content_addressed(self) -> RemoteManifest:
+        """A bank update is a new object, so a pinned runner never sees overwritten bytes."""
+        if self.sha256 not in self.path:
+            raise ValueError(f"remote path {self.path!r} must contain its sha256")
+        return self
+
 
 class Manifest(BaseModel):
     """Top-level manifest object for a dataset version.

--- a/runner/src/coval_bench/datasets/manifest.py
+++ b/runner/src/coval_bench/datasets/manifest.py
@@ -13,6 +13,8 @@ Schema matches ARCHITECTURE.md § "GCS dataset bucket — manifest.json schema".
 
 from __future__ import annotations
 
+from typing import Literal
+
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 
@@ -39,13 +41,48 @@ class STTManifestItem(BaseModel):
         return value
 
 
+class PhoneticControl(BaseModel):
+    """Speech-sound coverage metadata for a tts-v2 phonetic control sentence."""
+
+    model_config = ConfigDict(frozen=True)
+
+    block: int = Field(ge=1)
+    mode: str
+    focus: str
+    phones: list[str]
+    evidence: list[str]
+
+
 class TTSManifestItem(BaseModel):
-    """A single TTS prompt entry in the manifest."""
+    """A single TTS prompt entry in the manifest.
+
+    ``spoken_reference`` is the transcript written the way it sounds and is the
+    WER reference when present; tts-v1 items have none and fall back to
+    ``transcript``.
+    """
 
     model_config = ConfigDict(frozen=True)
 
     testcase_id: str = Field(min_length=1)
     transcript: str
+    spoken_reference: str | None = None
+    kind: Literal["vertical", "phonetic", "legacy"] | None = None
+    vertical: str | None = None
+    difficulty: Literal["easy", "medium", "hard"] | None = None
+    family: str | None = None
+    length_bucket: Literal["L1", "L2", "L3", "L4"] | None = None
+    tags: list[str] = Field(default_factory=list)
+    phonetic: PhoneticControl | None = None
+
+
+class RemoteManifest(BaseModel):
+    """Where a private manifest lives; the packaged file is only this pointer."""
+
+    model_config = ConfigDict(frozen=True)
+
+    bucket: str = Field(min_length=1)
+    path: str = Field(min_length=1)
+    sha256: str = Field(pattern=r"^[a-f0-9]{64}$")
 
 
 class Manifest(BaseModel):
@@ -54,6 +91,9 @@ class Manifest(BaseModel):
     The ``items`` field is either a homogeneous list of
     :class:`STTManifestItem` or :class:`TTSManifestItem`.
     Mixed lists are rejected by the ``items_consistent`` validator.
+
+    A private dataset ships no items in the wheel; its packaged file carries
+    ``remote`` instead and the loader fetches the full manifest at run time.
     """
 
     model_config = ConfigDict(frozen=True)
@@ -62,11 +102,14 @@ class Manifest(BaseModel):
     version: str = Field(pattern=r"^\d+\.\d+\.\d+$")
     license: str  # "CC-BY-4.0" for STT, internal for TTS
     source: str  # e.g. "LibriSpeech test-clean"
-    items: list[STTManifestItem | TTSManifestItem]
+    items: list[STTManifestItem | TTSManifestItem] = Field(default_factory=list)
+    remote: RemoteManifest | None = None
 
     @model_validator(mode="after")
     def items_consistent(self) -> Manifest:
         """Ensure items are homogeneous and have distinct effective identities."""
+        if self.items and self.remote is not None:
+            raise ValueError(f"Manifest '{self.id}' cannot carry both items and a remote pointer")
         if not self.items:
             return self
         first_type = type(self.items[0])

--- a/runner/src/coval_bench/datasets/manifest.py
+++ b/runner/src/coval_bench/datasets/manifest.py
@@ -115,6 +115,8 @@ class Manifest(BaseModel):
     @model_validator(mode="after")
     def items_consistent(self) -> Manifest:
         """Ensure items are homogeneous and have distinct effective identities."""
+        if not self.items and self.remote is None:
+            raise ValueError(f"Manifest '{self.id}' must carry either items or a remote pointer")
         if self.items and self.remote is not None:
             raise ValueError(f"Manifest '{self.id}' cannot carry both items and a remote pointer")
         if not self.items:

--- a/runner/src/coval_bench/datasets/manifests/README.md
+++ b/runner/src/coval_bench/datasets/manifests/README.md
@@ -346,6 +346,39 @@ print(json.dumps(manifest, indent=2, ensure_ascii=False))
 
 License: `Apache-2.0`.
 
+### `tts-v2.json` (private; pointer only)
+
+**What we benchmark.** The TTS v2 authoring bank: 240 original agent-to-customer
+passages (five verticals × easy/medium/hard × four scenario families × four
+spoken-word length buckets, L1 10–20 words up to L4 200–300), 60 phonetic
+control sentences with declared ARPAbet coverage, and the 30 `tts-v1` prompts
+imported unchanged. Every new item carries a `spoken_reference`, the transcript
+written the way it sounds (`$12` → `twelve dollars`,
+`ID-42` → `i d forty two`), which is the WER reference; legacy items have
+none and fall back to `transcript`. Item metadata (`kind`, `vertical`,
+`difficulty`, `family`, `length_bucket`, `tags`, `phonetic`) rides along for
+per-slice reporting.
+
+**The prompts are not in this repo.** The bank is private and this repo is
+public, so the packaged `tts-v2.json` is a pointer: `remote.bucket`,
+`remote.path`, and the `sha256` of the full manifest. The loader fetches the
+manifest from that bucket at run time, verifies the hash, and caches it under
+`<cache>/tts-v2/manifest.json`. The bucket has public-access prevention
+enforced; the runner service account can read it, contributors without GCP
+credentials cannot, and no test depends on it.
+
+**Updating the bank.** Reshape the bank compiler's `corpus.json` to this
+manifest schema (items with `testcase_id`, `transcript`, `spoken_reference`,
+`kind`, and the per-kind metadata), then upload and re-pin:
+
+```sh
+gcloud storage cp manifest.json gs://coval-benchmarks-datasets-private/datasets/tts-v2/manifest.json
+shasum -a 256 manifest.json   # paste into remote.sha256 in tts-v2.json, bump version
+```
+
+Never commit the full manifest here. `tts-v1.json` is never edited either: its
+byte hash is what ties historical runs to their items.
+
 ### `s2s-v1.json`
 
 **What we benchmark.** Speech-to-speech (S2S) providers are scored on a frozen

--- a/runner/src/coval_bench/datasets/manifests/README.md
+++ b/runner/src/coval_bench/datasets/manifests/README.md
@@ -369,11 +369,14 @@ credentials cannot, and no test depends on it.
 
 **Updating the bank.** Reshape the bank compiler's `corpus.json` to this
 manifest schema (items with `testcase_id`, `transcript`, `spoken_reference`,
-`kind`, and the per-kind metadata), then upload and re-pin:
+`kind`, and the per-kind metadata). The object name is the file's sha256, so a
+new revision is a new object and every pinned runner keeps resolving the bytes
+it was released with:
 
 ```sh
-gcloud storage cp manifest.json gs://coval-benchmarks-datasets-private/datasets/tts-v2/manifest.json
-shasum -a 256 manifest.json   # paste into remote.sha256 in tts-v2.json, bump version
+SHA=$(shasum -a 256 manifest.json | cut -c1-64)
+gcloud storage cp manifest.json gs://coval-benchmarks-datasets-private/datasets/tts-v2/$SHA.json
+# then set remote.path and remote.sha256 in tts-v2.json to $SHA and bump version
 ```
 
 Never commit the full manifest here. `tts-v1.json` is never edited either: its

--- a/runner/src/coval_bench/datasets/manifests/tts-v2.json
+++ b/runner/src/coval_bench/datasets/manifests/tts-v2.json
@@ -5,7 +5,7 @@
   "source": "Coval TTS v2 authoring bank (private); remote manifest also carries the tts-v1 prompts",
   "remote": {
     "bucket": "coval-benchmarks-datasets-private",
-    "path": "datasets/tts-v2/manifest.json",
+    "path": "datasets/tts-v2/4aa2aa77fdfa18fb62ea5ee932dd15feaa035e8d9c740f3e199e1fbd2178271f.json",
     "sha256": "4aa2aa77fdfa18fb62ea5ee932dd15feaa035e8d9c740f3e199e1fbd2178271f"
   }
 }

--- a/runner/src/coval_bench/datasets/manifests/tts-v2.json
+++ b/runner/src/coval_bench/datasets/manifests/tts-v2.json
@@ -1,0 +1,11 @@
+{
+  "id": "tts-v2",
+  "version": "2.0.0",
+  "license": "Proprietary",
+  "source": "Coval TTS v2 authoring bank (private); remote manifest also carries the tts-v1 prompts",
+  "remote": {
+    "bucket": "coval-benchmarks-datasets-private",
+    "path": "datasets/tts-v2/manifest.json",
+    "sha256": "4aa2aa77fdfa18fb62ea5ee932dd15feaa035e8d9c740f3e199e1fbd2178271f"
+  }
+}

--- a/runner/src/coval_bench/runner/orchestrator.py
+++ b/runner/src/coval_bench/runner/orchestrator.py
@@ -429,6 +429,9 @@ async def _run_stt_item(
             kwargs["project_id"] = settings.google_project_id
         elif entry.provider == "baseten":
             kwargs["ws_url"] = _get_baseten_stt_url()(settings, entry.model)
+        elif entry.provider == "guava":
+            kwargs["base_url"] = settings.guava_base_url
+            kwargs["domain"] = settings.guava_stt_domain
         elif entry.provider == "azure":
             kwargs["region"] = settings.azure_region
         elif entry.provider == "zoom":

--- a/runner/src/coval_bench/runner/orchestrator.py
+++ b/runner/src/coval_bench/runner/orchestrator.py
@@ -429,9 +429,6 @@ async def _run_stt_item(
             kwargs["project_id"] = settings.google_project_id
         elif entry.provider == "baseten":
             kwargs["ws_url"] = _get_baseten_stt_url()(settings, entry.model)
-        elif entry.provider == "guava":
-            kwargs["base_url"] = settings.guava_base_url
-            kwargs["domain"] = settings.guava_stt_domain
         elif entry.provider == "azure":
             kwargs["region"] = settings.azure_region
         elif entry.provider == "zoom":
@@ -956,7 +953,8 @@ async def _run_tts_item(
                 # genuine failure worth surfacing as a FAILED row rather than silently dropping.
                 if whisper_transcript is not None:
                     try:
-                        wer_result = compute_wer(transcript, whisper_transcript)
+                        reference = item.spoken_reference or transcript
+                        wer_result = compute_wer(reference, whisper_transcript)
                         results.append(
                             Result(
                                 run_id=run_id,

--- a/runner/tests/unit/test_dataset_loader.py
+++ b/runner/tests/unit/test_dataset_loader.py
@@ -561,7 +561,7 @@ def _remote(tmp_path: Path, body: str) -> tuple[Manifest, MagicMock]:
     ],
 )
 def test_manifest_shape_guards(patch_fields: dict[str, Any], message: str) -> None:
-    base = {"id": "tts-v2", "version": "2.0.0", "license": "l", "source": "s"}
+    base: dict[str, Any] = {"id": "tts-v2", "version": "2.0.0", "license": "l", "source": "s"}
     if "items" in patch_fields:
         base["remote"] = {"bucket": "b", "path": "tts-v2/" + "0" * 64, "sha256": "0" * 64}
     with pytest.raises(ValidationError, match=message):

--- a/runner/tests/unit/test_dataset_loader.py
+++ b/runner/tests/unit/test_dataset_loader.py
@@ -558,17 +558,14 @@ def _remote(tmp_path: Path, body: str) -> tuple[Manifest, MagicMock]:
     """A pointer to *body* served by a fake bucket, pinned to the body's real hash."""
     remote_dir = tmp_path / "remote"
     remote_dir.mkdir()
-    (remote_dir / "manifest.json").write_text(body)
+    sha = hashlib.sha256(body.encode()).hexdigest()
+    (remote_dir / f"{sha}.json").write_text(body)
     pointer = Manifest(
         id="tts-v2",
         version="2.0.0",
         license="proprietary",
         source="test",
-        remote={
-            "bucket": "private",
-            "path": "tts-v2/manifest.json",
-            "sha256": hashlib.sha256(body.encode()).hexdigest(),
-        },
+        remote={"bucket": "private", "path": f"tts-v2/{sha}.json", "sha256": sha},
     )
     return pointer, _make_fake_storage_client(remote_dir)
 
@@ -595,7 +592,8 @@ def test_remote_tts_manifest_is_fetched_and_verified(
 
 def test_remote_manifest_hash_mismatch_raises(test_settings: Settings, tmp_path: Path) -> None:
     pointer, client = _remote(tmp_path, "{}")
-    (tmp_path / "remote" / "manifest.json").write_text("tampered")
+    assert pointer.remote is not None
+    (tmp_path / "remote" / pointer.remote.path.rsplit("/", 1)[1]).write_text("tampered")
 
     with (
         patch("coval_bench.datasets.loader._load_manifest", return_value=pointer),

--- a/runner/tests/unit/test_dataset_loader.py
+++ b/runner/tests/unit/test_dataset_loader.py
@@ -548,6 +548,64 @@ def test_load_manifest_reads_packaged_tts_manifest() -> None:
     assert len(manifest.items) == 30  # 30 curated TTS prompts
 
 
+def test_packaged_tts_v2_is_a_private_pointer() -> None:
+    """The prompts never live in the wheel."""
+    manifest = _load_manifest("tts-v2")
+    assert manifest.items == [] and manifest.remote is not None
+
+
+def _remote(tmp_path: Path, body: str) -> tuple[Manifest, MagicMock]:
+    """A pointer to *body* served by a fake bucket, pinned to the body's real hash."""
+    remote_dir = tmp_path / "remote"
+    remote_dir.mkdir()
+    (remote_dir / "manifest.json").write_text(body)
+    pointer = Manifest(
+        id="tts-v2",
+        version="2.0.0",
+        license="proprietary",
+        source="test",
+        remote={
+            "bucket": "private",
+            "path": "tts-v2/manifest.json",
+            "sha256": hashlib.sha256(body.encode()).hexdigest(),
+        },
+    )
+    return pointer, _make_fake_storage_client(remote_dir)
+
+
+def test_remote_tts_manifest_is_fetched_and_verified(
+    test_settings: Settings, tmp_path: Path
+) -> None:
+    full = Manifest(
+        id="tts-v2",
+        version="2.0.0",
+        license="proprietary",
+        source="test",
+        items=[TTSManifestItem(testcase_id="x", transcript="LT-507", spoken_reference="l t")],
+    )
+    pointer, client = _remote(tmp_path, full.model_dump_json())
+
+    with patch("coval_bench.datasets.loader._load_manifest", return_value=pointer):
+        result = load_tts_dataset(
+            "tts-v2", settings=test_settings, cache_dir=tmp_path, storage_client=client
+        )
+
+    assert [i.spoken_reference for i in result.items] == ["l t"]
+
+
+def test_remote_manifest_hash_mismatch_raises(test_settings: Settings, tmp_path: Path) -> None:
+    pointer, client = _remote(tmp_path, "{}")
+    (tmp_path / "remote" / "manifest.json").write_text("tampered")
+
+    with (
+        patch("coval_bench.datasets.loader._load_manifest", return_value=pointer),
+        pytest.raises(DatasetIntegrityError),
+    ):
+        load_tts_dataset(
+            "tts-v2", settings=test_settings, cache_dir=tmp_path, storage_client=client
+        )
+
+
 def test_load_manifest_reads_packaged_stt_manifest() -> None:
     """_load_manifest round-trips the packaged stt-v1.json manifest."""
     from coval_bench.datasets.loader import _load_manifest

--- a/runner/tests/unit/test_dataset_loader.py
+++ b/runner/tests/unit/test_dataset_loader.py
@@ -33,6 +33,7 @@ import random
 import shutil
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -337,28 +338,6 @@ def test_gcs_path_resolution(test_settings: Settings, tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_empty_manifest_items(test_settings: Settings, tmp_path: Path) -> None:
-    """Manifest with items: [] → Dataset with empty items list; no exception."""
-    empty_manifest = Manifest(
-        id="stt-v1",
-        version="1.0.0",
-        license="CC-BY-4.0",
-        source="test",
-        items=[],
-    )
-
-    with patch("coval_bench.datasets.loader._load_manifest", return_value=empty_manifest):
-        result = load_stt_dataset(
-            "stt-v1",
-            settings=test_settings,
-            cache_dir=tmp_path,
-            storage_client=MagicMock(),
-        )
-
-    assert result.items == []
-    assert result.id == "stt-v1"
-
-
 def test_manifest_allows_unique_effective_stt_identities() -> None:
     """Explicit and fallback STT identities may coexist when they are distinct."""
     manifest = Manifest(
@@ -570,6 +549,47 @@ def _remote(tmp_path: Path, body: str) -> tuple[Manifest, MagicMock]:
     return pointer, _make_fake_storage_client(remote_dir)
 
 
+@pytest.mark.parametrize(
+    ("patch_fields", "message"),
+    [
+        ({}, "either items or a remote pointer"),
+        ({"items": [{"testcase_id": "a", "transcript": "b"}]}, "both items and a remote pointer"),
+        (
+            {"remote": {"bucket": "b", "path": "tts-v2/manifest.json", "sha256": "0" * 64}},
+            "must contain its sha256",
+        ),
+    ],
+)
+def test_manifest_shape_guards(patch_fields: dict[str, Any], message: str) -> None:
+    base = {"id": "tts-v2", "version": "2.0.0", "license": "l", "source": "s"}
+    if "items" in patch_fields:
+        base["remote"] = {"bucket": "b", "path": "tts-v2/" + "0" * 64, "sha256": "0" * 64}
+    with pytest.raises(ValidationError, match=message):
+        Manifest.model_validate(base | patch_fields)
+
+
+@pytest.mark.parametrize(
+    "served",
+    [
+        {"id": "tts-v1", "items": [{"testcase_id": "a", "transcript": "b"}]},
+        {"id": "tts-v2", "remote": {"bucket": "b", "path": "x/" + "1" * 64, "sha256": "1" * 64}},
+    ],
+)
+def test_resolved_manifest_must_match_id_and_carry_items(
+    test_settings: Settings, tmp_path: Path, served: dict[str, Any]
+) -> None:
+    body = json.dumps(served | {"version": "2.0.0", "license": "l", "source": "s"})
+    pointer, client = _remote(tmp_path, body)
+
+    with (
+        patch("coval_bench.datasets.loader._load_manifest", return_value=pointer),
+        pytest.raises(ManifestAlignmentError),
+    ):
+        load_tts_dataset(
+            "tts-v2", settings=test_settings, cache_dir=tmp_path, storage_client=client
+        )
+
+
 def test_remote_tts_manifest_is_fetched_and_verified(
     test_settings: Settings, tmp_path: Path
 ) -> None:
@@ -654,30 +674,6 @@ def test_load_dataset_dispatcher_tts(test_settings: Settings, tmp_path: Path) ->
         )
 
     assert isinstance(result, TTSDataset)
-
-
-def test_load_dataset_dispatcher_empty(test_settings: Settings, tmp_path: Path) -> None:
-    """load_dataset with empty items falls through to TTS path without error."""
-    from coval_bench.datasets.loader import TTSDataset, load_dataset
-
-    empty_manifest = Manifest(
-        id="tts-v1",
-        version="1.0.0",
-        license="proprietary",
-        source="test",
-        items=[],
-    )
-
-    with patch("coval_bench.datasets.loader._load_manifest", return_value=empty_manifest):
-        result = load_dataset(
-            "tts-v1",
-            settings=test_settings,
-            cache_dir=tmp_path,
-            storage_client=MagicMock(),
-        )
-
-    assert isinstance(result, TTSDataset)
-    assert result.items == []
 
 
 def test_stale_cache_redownloads(test_settings: Settings, tmp_path: Path) -> None:

--- a/runner/tests/unit/test_orchestrator.py
+++ b/runner/tests/unit/test_orchestrator.py
@@ -159,6 +159,7 @@ def _make_tts_item(transcript: str = "hello world") -> Any:
     item = MagicMock()
     item.testcase_id = "tts-0001"
     item.transcript = transcript
+    item.spoken_reference = None
     return item
 
 
@@ -3649,3 +3650,43 @@ async def test_transcribe_does_not_retry_other_errors(tmp_path: Path) -> None:
     ):
         await _transcribe_with_whisper(audio, _TEST_SETTINGS)
     assert client.audio.transcriptions.create.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_tts_wer_scores_against_spoken_reference(
+    audio_file: Path, settings: Settings
+) -> None:
+    """When an item carries a spoken reference, WER is measured against it, not the prompt."""
+    provider = MagicMock()
+    provider.synthesize = AsyncMock(
+        return_value=TTSResult(
+            provider="elevenlabs",
+            model="eleven_flash_v2_5",
+            voice="voice",
+            ttfa_ms=120.0,
+            audio_path=audio_file,
+            error=None,
+        )
+    )
+    item = _make_tts_item("Your reference is LT-507.")
+    item.spoken_reference = "your reference is l t five oh seven"
+
+    async with _orchestrator_env(
+        audio_path=audio_file, tts_providers={"elevenlabs": MagicMock(return_value=provider)}
+    ):
+        with patch(
+            "coval_bench.runner.orchestrator._transcribe_with_whisper",
+            new_callable=AsyncMock,
+            return_value="your reference is l t five oh seven",
+        ):
+            results = await _run_tts_item(
+                entry=_tts_entry("elevenlabs", "eleven_flash_v2_5", "voice"),
+                item=item,
+                run_id=1,
+                sem=asyncio.Semaphore(1),
+                settings=settings,
+            )
+
+    wer_rows = [r for r in results if r.metric_type == "WER"]
+    assert len(wer_rows) == 1
+    assert wer_rows[0].metric_value == 0.0

--- a/runner/tests/unit/test_orchestrator.py
+++ b/runner/tests/unit/test_orchestrator.py
@@ -32,6 +32,7 @@ import wave
 from collections.abc import AsyncIterator, MutableMapping
 from datetime import UTC, datetime
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, create_autospec, patch
 
@@ -3690,3 +3691,47 @@ async def test_tts_wer_scores_against_spoken_reference(
     wer_rows = [r for r in results if r.metric_type == "WER"]
     assert len(wer_rows) == 1
     assert wer_rows[0].metric_value == 0.0
+
+
+@pytest.mark.asyncio
+async def test_stt_guava_receives_base_url_and_domain(audio_file: Path, settings: Settings) -> None:
+    """The orchestrator wires Guava's endpoint settings into the provider constructor."""
+    seen: dict[str, Any] = {}
+
+    class _Capture:
+        def __init__(self, **kwargs: Any) -> None:
+            seen.update(kwargs)
+            raise RuntimeError("stop here")
+
+    entry = RegisteredModel(
+        benchmark=Benchmark.STT,
+        provider="guava",
+        model="daytona-stt",
+        source=Source.OFFICIAL_API,
+        collected=True,
+        published=False,
+    )
+    item = SimpleNamespace(
+        path=audio_file,
+        transcript="hello",
+        duration_sec=0.032,
+        speech_end_offset_ms=None,
+        sample_id=None,
+    )
+    cfg = settings.model_copy(
+        update={
+            "guava_api_key": SecretStr("k"),
+            "guava_base_url": "https://guava.test",
+            "guava_stt_domain": "healthcare",
+        }
+    )
+
+    with patch(
+        "coval_bench.runner.orchestrator._get_stt_providers", return_value={"guava": _Capture}
+    ):
+        await _run_stt_item(
+            entry=entry, item=item, run_id=0, sem=asyncio.Semaphore(1), settings=cfg, writer=None
+        )
+
+    assert seen["base_url"] == "https://guava.test"
+    assert seen["domain"] == "healthcare"


### PR DESCRIPTION
## What

- `tts-v2.json` ships as a pointer only: bucket, object path, and sha256 of the manifest.
- `Manifest` gains an optional `remote` block; a file may carry items or a pointer, never both.
- The loader resolves a pointer by fetching the manifest from `coval-benchmarks-datasets-private` (coval-ai/benchmark-infra#188), verifying the hash, and caching it. The download-and-verify step is shared with STT audio. Private fetches use real credentials rather than the anonymous public-bucket client.
- `TTSManifestItem` / `TTSDatasetItem` gain optional `spoken_reference`, `kind`, `vertical`, `difficulty`, `family`, `length_bucket`, `tags`, and `phonetic`. tts-v1 items are unchanged.
- The orchestrator scores WER against `spoken_reference` when present, falling back to `transcript`.

## Why

The TTS v2 authoring bank (BENCH-759) is proprietary.

## Reviewer notes

- Nothing loads tts-v2 in production yet; the orchestrator still hardcodes tts-v1. BENCH-873 makes the dataset id a setting and adds stratified sampling.
- The manifest is uploaded and its hash matches the pointer. I loaded it end to end against the real bucket with the runner code.
- tts-v2 rows keep their own dataset id, so the existing per-dataset aggregates apply. Do not add a cross-dataset TTS blend: v1 scores against normalized written text, v2 against an authored spoken form, and the two are not comparable.
- `tts-v1.json` is untouched; its byte hash ties historical runs to their items.

Linear: https://linear.app/coval/issue/BENCH-872
