### PR TITLE
[BENCH-858] Dual-write LLM results to the normalized tables

### DIFF
--- a/runner/src/coval_bench/db/migrations/versions/20260910_0031_conversation_text_source_kind.py
+++ b/runner/src/coval_bench/db/migrations/versions/20260910_0031_conversation_text_source_kind.py
@@ -1,0 +1,68 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Admit ``conversation_text`` as an observation source kind.
+
+LLM conversations have no audio, so the normalized store needs a text source
+kind before the LLM fetch can dual-write. The benchmark CHECKs already admit
+'LLM' since 20260901_0025; this widens the one remaining constraint.
+"""
+
+from __future__ import annotations
+
+import time
+
+import psycopg.errors
+import sqlalchemy.exc
+from alembic import op
+
+revision = "20260910_0031"
+down_revision = "20260910_0030"
+branch_labels = None
+depends_on = None
+
+_CONSTRAINT = "benchmark_observations_source_kind_check"
+_WIDE = "'dataset_audio','generated_audio','conversation_audio','conversation_text'"
+_NARROW = "'dataset_audio','generated_audio','conversation_audio'"
+
+_LOCK_TIMEOUT = "10s"
+_LOCK_ATTEMPTS = 12
+_RETRY_PAUSE_SECONDS = 5.0
+
+
+def _execute_retrying_locks(sql: str) -> None:
+    for attempt in range(1, _LOCK_ATTEMPTS + 1):
+        try:
+            op.execute(sql)
+            return
+        except sqlalchemy.exc.OperationalError as exc:
+            lock_timeout = isinstance(exc.orig, psycopg.errors.LockNotAvailable)
+            if not lock_timeout or attempt == _LOCK_ATTEMPTS:
+                raise
+            time.sleep(_RETRY_PAUSE_SECONDS)
+
+
+def _swap_constraint(values: str) -> None:
+    with op.get_context().autocommit_block():
+        op.execute(f"SET lock_timeout = '{_LOCK_TIMEOUT}'")
+        _execute_retrying_locks(
+            f"ALTER TABLE benchmarks_v2.benchmark_observations"
+            f" DROP CONSTRAINT IF EXISTS {_CONSTRAINT}"
+        )
+        _execute_retrying_locks(
+            f"ALTER TABLE benchmarks_v2.benchmark_observations"
+            f" ADD CONSTRAINT {_CONSTRAINT} CHECK (source_kind IN ({values})) NOT VALID"
+        )
+        _execute_retrying_locks(
+            f"ALTER TABLE benchmarks_v2.benchmark_observations VALIDATE CONSTRAINT {_CONSTRAINT}"
+        )
+        op.execute("RESET lock_timeout")
+
+
+def upgrade() -> None:
+    _swap_constraint(_WIDE)
+
+
+def downgrade() -> None:
+    """Re-narrow; fails while conversation_text rows remain."""
+    _swap_constraint(_NARROW)

--- a/runner/src/coval_bench/db/migrations/versions/20260910_0032_conversation_text_source_kind.py
+++ b/runner/src/coval_bench/db/migrations/versions/20260910_0032_conversation_text_source_kind.py
@@ -16,8 +16,8 @@ import psycopg.errors
 import sqlalchemy.exc
 from alembic import op
 
-revision = "20260910_0031"
-down_revision = "20260910_0030"
+revision = "20260910_0032"
+down_revision = "20260910_0031"
 branch_labels = None
 depends_on = None
 

--- a/runner/src/coval_bench/db/models.py
+++ b/runner/src/coval_bench/db/models.py
@@ -77,6 +77,7 @@ class ObservationSourceKind(StrEnum):
     DATASET_AUDIO = "dataset_audio"
     GENERATED_AUDIO = "generated_audio"
     CONVERSATION_AUDIO = "conversation_audio"
+    CONVERSATION_TEXT = "conversation_text"
 
 
 class ObservationFailureOrigin(StrEnum):

--- a/runner/src/coval_bench/runner/normalized.py
+++ b/runner/src/coval_bench/runner/normalized.py
@@ -174,6 +174,7 @@ async def dual_write(
         "STT": ObservationSourceKind.DATASET_AUDIO,
         "TTS": ObservationSourceKind.GENERATED_AUDIO,
         "S2S": ObservationSourceKind.CONVERSATION_AUDIO,
+        "LLM": ObservationSourceKind.CONVERSATION_TEXT,
     }[benchmark.value.upper()]
 
     async def persist_db() -> None:

--- a/runner/src/coval_bench/s2s/fetch_v2v.py
+++ b/runner/src/coval_bench/s2s/fetch_v2v.py
@@ -889,7 +889,7 @@ async def _ingest_run(
         if all_rows:
             captured_at = datetime.now(UTC)
             await writer.record_results(all_rows, created_at=captured_at)
-            if normalized_dual_write_enabled and spec.benchmark is Benchmark.S2S:
+            if normalized_dual_write_enabled and spec.benchmark in (Benchmark.S2S, Benchmark.LLM):
                 from coval_bench.runner.normalized import dual_write
 
                 grouped: dict[str, list[Result]] = {}
@@ -920,7 +920,7 @@ async def _ingest_run(
                             dataset_sha256=normalized_sha256,
                             sample_id=sample_id,
                             entry=spec,
-                            benchmark=Benchmark.S2S,
+                            benchmark=spec.benchmark,
                             results=sample_rows,
                             provider_error=provider_error,
                             captured_at=captured_at,

--- a/runner/tests/unit/test_normalized_dual_write.py
+++ b/runner/tests/unit/test_normalized_dual_write.py
@@ -403,7 +403,16 @@ async def test_null_success_metric_is_excluded_instead_of_failed() -> None:
 
 
 @pytest.mark.asyncio
-async def test_s2s_uses_conversation_source_and_coval_executor() -> None:
+@pytest.mark.parametrize(
+    ("benchmark", "metric", "unit", "source_kind"),
+    [
+        (Benchmark.S2S, Metric.V2V, "milliseconds", ObservationSourceKind.CONVERSATION_AUDIO),
+        (Benchmark.LLM, Metric.TTFT, "seconds", ObservationSourceKind.CONVERSATION_TEXT),
+    ],
+)
+async def test_conversation_benchmarks_use_their_source_kind_and_coval_executor(
+    benchmark: Benchmark, metric: Metric, unit: str, source_kind: ObservationSourceKind
+) -> None:
     writer = _Writer()
 
     await normalized.dual_write(
@@ -411,23 +420,23 @@ async def test_s2s_uses_conversation_source_and_coval_executor() -> None:
         storage_client=None,
         bucket="",
         run_id=1,
-        dataset_id="s2s-multiturn-v1",
+        dataset_id="dental-v1",
         dataset_sha256="e" * 64,
         sample_id="R1/s1",
         entry=SimpleNamespace(provider="provider", model="model"),
-        benchmark=Benchmark.S2S,
-        results=[_result(Benchmark.S2S, Metric.V2V, 500, "milliseconds")],
+        benchmark=benchmark,
+        results=[_result(benchmark, metric, 0.5, unit)],
         provider_error=None,
         executor=MetricExecutor.COVAL_API,
     )
 
     observation = writer.observations[0]
-    assert observation.source_kind is ObservationSourceKind.CONVERSATION_AUDIO
-    evaluation_id, evaluation = _evaluation_by_metric(writer, Metric.V2V)
+    assert observation.source_kind is source_kind
+    evaluation_id, evaluation = _evaluation_by_metric(writer, metric)
     assert evaluation.executor is MetricExecutor.COVAL_API
     assert writer.inputs[evaluation_id] == []
     assert [(value.value_key, value.value) for value in writer.completed[evaluation_id]] == [
-        ("primary", 500.0)
+        ("primary", 0.5)
     ]
 
 

--- a/runner/tests/unit/test_s2s_fetch.py
+++ b/runner/tests/unit/test_s2s_fetch.py
@@ -2284,7 +2284,7 @@ async def test_ingest_run_dual_writes_llm_rows(
     assert len(rows) == 1
     assert rows[0].benchmark is Benchmark.LLM
     dual_write.assert_awaited_once()
-    kwargs = dual_write.await_args.kwargs
+    kwargs = dual_write.await_args_list[0].kwargs
     assert (kwargs["benchmark"], kwargs["sample_id"]) == (Benchmark.LLM, "R1/s1")
 
 

--- a/runner/tests/unit/test_s2s_fetch.py
+++ b/runner/tests/unit/test_s2s_fetch.py
@@ -2252,7 +2252,7 @@ async def test_ingest_run_dual_writes_one_observation_per_conversation(
 
 
 @pytest.mark.asyncio
-async def test_ingest_run_does_not_dual_write_llm_rows(
+async def test_ingest_run_dual_writes_llm_rows(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     writer = _stub_writer()
@@ -2283,7 +2283,9 @@ async def test_ingest_run_does_not_dual_write_llm_rows(
     rows = writer.record_results.await_args.args[0]
     assert len(rows) == 1
     assert rows[0].benchmark is Benchmark.LLM
-    dual_write.assert_not_awaited()
+    dual_write.assert_awaited_once()
+    kwargs = dual_write.await_args.kwargs
+    assert (kwargs["benchmark"], kwargs["sample_id"]) == (Benchmark.LLM, "R1/s1")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Migration 0031 admits conversation_text as an observation source kind, the enum and normalized writer map LLM to it, and the Coval fetch's dual-write branch now runs for LLM as well as S2S with the spec's benchmark passed through. The benchmark CHECKs were already widened by 0025.