### PR TITLE
[BENCH-883] Rebuild the shared pool after lifespan_pool closes it

### DIFF
--- a/runner/src/coval_bench/db/conn.py
+++ b/runner/src/coval_bench/db/conn.py
@@ -43,7 +43,8 @@ async def get_pool(
 ) -> AsyncConnectionPool[psycopg.AsyncConnection[psycopg.rows.DictRow]]:
     """Return the process-singleton async connection pool.
 
-    The pool is created once per process (first call wins).  Callers are
+    The pool lives until ``lifespan_pool`` closes it, after which the next call
+    builds a fresh one; psycopg refuses to reopen a closed pool.  Callers are
     responsible for calling ``.open()`` before use and ``.close()`` at shutdown.
     Prefer ``lifespan_pool`` for FastAPI; use this directly in the runner
     orchestrator's startup/shutdown hooks.
@@ -79,9 +80,12 @@ async def lifespan_pool(
                 app.state.pool = pool
                 yield
     """
+    global _pool
     pool = await get_pool(settings)
     await pool.open()
     try:
         yield pool
     finally:
         await pool.close()
+        if _pool is pool:
+            _pool = None

--- a/runner/tests/unit/test_db_conn.py
+++ b/runner/tests/unit/test_db_conn.py
@@ -1,0 +1,46 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the shared connection pool lifecycle."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from coval_bench.db import conn
+
+
+class _Pool:
+    instances: list[_Pool] = []
+
+    def __init__(self, **_: Any) -> None:
+        self.opened = 0
+        self.closed = True
+        self.instances.append(self)
+
+    async def open(self) -> None:
+        if self.opened:
+            raise RuntimeError("cannot reuse")
+        self.opened += 1
+        self.closed = False
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+@pytest.mark.asyncio
+async def test_lifespan_pool_can_be_entered_again_after_closing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(conn, "AsyncConnectionPool", _Pool)
+    monkeypatch.setattr(conn, "_pool", None)
+    settings = SimpleNamespace(database_url="postgresql://x@127.0.0.1:1/x")
+
+    async with conn.lifespan_pool(settings) as first:  # type: ignore[arg-type]
+        assert not first.closed
+    async with conn.lifespan_pool(settings) as second:  # type: ignore[arg-type]
+        assert not second.closed
+    assert first is not second
+    assert first.closed and second.closed


### PR DESCRIPTION
llm-sync reconciles the Coval agent inside one lifespan_pool and then runs the fetch inside another in the same process. psycopg refuses to reopen a closed pool, so the second entry raised PoolClosed and no LLM results were ingested. lifespan_pool now drops the process-wide reference when it closes the pool.