### PR TITLE
Store the S2S interruption rate unrounded

### DIFF
--- a/runner/src/coval_bench/s2s/fetch_v2v.py
+++ b/runner/src/coval_bench/s2s/fetch_v2v.py
@@ -520,9 +520,9 @@ def _expected_behavior_value(raw: object) -> tuple[float | None, ResultStatus] |
 
 
 def _interruption_value(raw: object) -> tuple[float | None, ResultStatus] | None:
-    """Interruptions per minute, stored as-is; a clip with no numeric value becomes a FAILED row."""
+    """Interruptions per minute, unrounded; a clip with no numeric value becomes a FAILED row."""
     if isinstance(raw, (int, float)) and not isinstance(raw, bool):
-        return round(float(raw), 2), ResultStatus.SUCCESS
+        return float(raw), ResultStatus.SUCCESS
     return None, ResultStatus.FAILED
 
 

--- a/runner/tests/unit/test_s2s_fetch.py
+++ b/runner/tests/unit/test_s2s_fetch.py
@@ -1649,7 +1649,11 @@ async def test_fetch_and_write_rejects_a_metric_with_no_row_builder(
 
 
 def test_interruption_value_maps() -> None:
-    assert fetch_v2v._interruption_value(1.1666666666666632) == (1.17, ResultStatus.SUCCESS)
+    assert fetch_v2v._interruption_value(1.1666666666666632) == (
+        1.1666666666666632,
+        ResultStatus.SUCCESS,
+    )
+    assert fetch_v2v._interruption_value(0.0041) == (0.0041, ResultStatus.SUCCESS)
     assert fetch_v2v._interruption_value(0) == (0.0, ResultStatus.SUCCESS)
     assert fetch_v2v._interruption_value(None) == (None, ResultStatus.FAILED)
     assert fetch_v2v._interruption_value("1.5") == (None, ResultStatus.FAILED)


### PR DESCRIPTION
Each conversation's interruptions-per-minute value was rounded to two decimals in the fetch mapper before it reached the results table. Per-model means sit around 0.004 to 0.016 per minute, so the dashboard showed 0.00 or 0.02 and the bars looked empty. Coval's API already delivers the full float; this stores it as-is.

Rows already stored stay rounded. The bias that introduces on the mean is under 0.0002 per minute, so no backfill. The matching display change to three decimals is in benchmarks-web.