### PR TITLE
[BENCH-881] Lift the LLM legacy-read pin

### DIFF
--- a/runner/src/coval_bench/api/common.py
+++ b/runner/src/coval_bench/api/common.py
@@ -14,8 +14,7 @@ from typing import Literal
 BenchmarkLiteral = Literal["STT", "TTS", "S2S", "LLM"]
 WindowLiteral = Literal["24h", "7d", "30d"]
 
-# LLM results have no normalized writer yet, so its reads stay on legacy storage.
-NORMALIZED_BENCHMARKS: frozenset[str] = frozenset({"STT", "TTS", "S2S"})
+NORMALIZED_BENCHMARKS: frozenset[str] = frozenset({"STT", "TTS", "S2S", "LLM"})
 
 
 def reads_normalized(enabled: bool, benchmark: str) -> bool:

--- a/runner/tests/api/test_aggregates.py
+++ b/runner/tests/api/test_aggregates.py
@@ -45,6 +45,8 @@ async def _insert_normalized_metric(
     evaluation_status: str = "succeeded",
     metric_version: str = "v1",
     evaluation_variant: str = "default",
+    provider: str = "deepgram",
+    model: str = "nova-3",
 ) -> None:
     """Seed one normalized evaluation for cutover tests."""
     import psycopg
@@ -58,8 +60,8 @@ async def _insert_normalized_metric(
         await conn.execute(
             """INSERT INTO benchmarks_v2.benchmark_observations
                (id, run_id, dataset_id, provider, model, benchmark, captured_at, status)
-               VALUES (%s, %s, %s, 'deepgram', 'nova-3', %s, now(), %s)""",
-            (observation_id, run_id, dataset_id, benchmark, observation_status),
+               VALUES (%s, %s, %s, %s, %s, %s, now(), %s)""",
+            (observation_id, run_id, dataset_id, provider, model, benchmark, observation_status),
         )
         await conn.execute(
             """INSERT INTO benchmarks_v2.metric_evaluations
@@ -257,12 +259,28 @@ async def test_llm_instruction_following_is_served_by_aggregates(
     ]
     assert stats[0]["avg_value"] == pytest.approx(75.0)
 
+    normalized_run = await _insert_run(postgresql, dataset_id="llm-dental-v1")
+    for value in (100.0, 100.0, 0.0):
+        await _insert_normalized_metric(
+            postgresql,
+            normalized_run,
+            dataset_id="llm-dental-v1",
+            metric_type="InstructionFollowing",
+            values={"primary": value},
+            benchmark="LLM",
+            provider="phonely",
+            model="phonely-agent",
+        )
     app = client._transport.app  # type: ignore[attr-defined]
     app.state.settings.normalized_dashboard_reads_enabled = True
     response = await client.get(
         "/v1/results/aggregates", params={"benchmark": "LLM", "dataset": "llm-dental-v1"}
     )
-    assert response.json()["model_stats"] == stats
+    stats = response.json()["model_stats"]
+    assert [(s["provider"], s["metric_type"], s["sample_count"]) for s in stats] == [
+        ("phonely", "InstructionFollowing", 3)
+    ]
+    assert stats[0]["avg_value"] == pytest.approx(200 / 3)
 
 
 async def test_single_sample_stddev_is_zero(client: AsyncClient, postgresql: Any) -> None:

--- a/runner/tests/api/test_leaderboard.py
+++ b/runner/tests/api/test_leaderboard.py
@@ -11,6 +11,7 @@ from httpx import AsyncClient
 
 from coval_bench.api.common import MIN_SCORED_SAMPLES
 from tests.api.conftest import _insert_result, _insert_run, _refresh_mv
+from tests.api.test_aggregates import _insert_normalized_metric
 
 
 async def test_24h_window_sorted_ascending(client: AsyncClient, postgresql: Any) -> None:
@@ -227,10 +228,26 @@ async def test_ttft_llm_uses_the_dental_primary_dataset(
     assert response.status_code == 200
     assert [(e["provider"], e["model"]) for e in response.json()["entries"]] == expected
 
+    for run_id, dataset_id, provider in (
+        (dental_run, "llm-dental-v1", "phonely"),
+        (other_run, "llm-scratch-v1", "acme"),
+    ):
+        await _insert_normalized_metric(
+            postgresql,
+            run_id,
+            dataset_id=dataset_id,
+            metric_type="TTFT",
+            values={"primary": 0.42},
+            benchmark="LLM",
+            provider=provider,
+            model="normalized-model",
+        )
     app = client._transport.app  # type: ignore[attr-defined]
     app.state.settings.normalized_dashboard_reads_enabled = True
     response = await client.get("/v1/leaderboard", params=params)
-    assert [(e["provider"], e["model"]) for e in response.json()["entries"]] == expected
+    assert [(e["provider"], e["model"]) for e in response.json()["entries"]] == [
+        ("phonely", "normalized-model")
+    ]
 
 
 async def test_v2v_llm_incompatible(client: AsyncClient) -> None:


### PR DESCRIPTION
LLM results dual-write to the normalized tables since BENCH-858, so the reads flag now applies to LLM like every other benchmark. The LLM leaderboard and aggregates tests seed normalized rows under the flag and assert those are served.