### PR TITLE
Move the daily S2S board to the Ultra Bank set

### DIFF
--- a/runner/src/coval_bench/api/internal.py
+++ b/runner/src/coval_bench/api/internal.py
@@ -49,6 +49,7 @@ def never_shared(response: Response) -> None:
 # that name. Retire one only once nothing stored can still name it.
 _RETIRED_BOARD_KEYS: dict[tuple[str, str], tuple[str, str]] = {
     ("xai", "grok-realtime"): ("xai", "grok-voice-think-fast-1.0"),
+    ("openai", "violet"): ("openai", "gpt-live-1"),
 }
 
 

--- a/runner/src/coval_bench/api/routers/leaderboard.py
+++ b/runner/src/coval_bench/api/routers/leaderboard.py
@@ -43,7 +43,7 @@ from coval_bench.api.routers.aggregates import _NORMALIZED_STATS_SQL
 from coval_bench.api.schemas import LeaderboardEntry, LeaderboardResponse
 from coval_bench.config import DATASET_ALL, Settings
 from coval_bench.registries import is_metric_excluded
-from coval_bench.s2s.conditions import DATASET_ID_DENTAL, DATASET_ID_LLM_DENTAL
+from coval_bench.s2s.conditions import DATASET_ID_BANK, DATASET_ID_LLM_DENTAL
 
 logger = structlog.get_logger("coval_bench.api")
 
@@ -61,12 +61,12 @@ _VALID_COMBOS: set[tuple[str, str]] = {
     ("TTFT", "LLM"),
 }
 
-# The headline S2S board is the clean dental condition, which every agent now runs.
-# The multi-turn set is frozen rather than retired: no agent writes to it, but it
-# stays reachable through the aggregates ``dataset`` param, as does ``__all__`` for
-# callers that want every S2S condition pooled. LLM runs the same dental scenario
-# over text.
-_PRIMARY_DATASET_BY_BENCHMARK = {"S2S": DATASET_ID_DENTAL, "LLM": DATASET_ID_LLM_DENTAL}
+# The headline S2S board is the Ultra Bank instruction-following set, which every
+# S2S agent runs daily. Dental and the multi-turn set are frozen rather than
+# retired: nothing writes to them, but they stay reachable through the aggregates
+# ``dataset`` param, as does ``__all__`` for callers that want every S2S condition
+# pooled. LLM still runs the dental scenario over text.
+_PRIMARY_DATASET_BY_BENCHMARK = {"S2S": DATASET_ID_BANK, "LLM": DATASET_ID_LLM_DENTAL}
 
 _MV_SQL_TEMPLATE = """
     SELECT provider, model,

--- a/runner/src/coval_bench/api/routers/s2s_samples.py
+++ b/runner/src/coval_bench/api/routers/s2s_samples.py
@@ -3,6 +3,11 @@
 
 """GET /v1/s2s/samples — conversation samples from the private samples bucket.
 
+Samples are partitioned by dataset id, one industry per partition, and every
+route takes the partition as ``?dataset=``. Without it the routes read the
+pre-partition root layout, so a dashboard that predates the split keeps working
+until those ticks age out.
+
 The bucket allows no anonymous read. The API reads each manifest as its own
 service account, drops the recordings this caller may not see (their transcripts
 go with them, since both live in the same object), and hands back an API route
@@ -26,7 +31,7 @@ from datetime import UTC, datetime
 from urllib.parse import quote
 
 import structlog
-from fastapi import APIRouter, Depends, HTTPException, Path, Response
+from fastapi import APIRouter, Depends, HTTPException, Path, Query, Response
 from posthog import Posthog
 from starlette.requests import Request
 
@@ -49,6 +54,8 @@ logger = structlog.get_logger("coval_bench.api.s2s_samples")
 router = APIRouter(tags=["s2s"])
 
 _SAMPLE_ID = r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$"
+# A dataset id is one path segment of the bucket layout; the pattern keeps it so.
+_DATASET_ID = r"^[a-z0-9][a-z0-9-]*$"
 
 
 def _sees_any_s2s_model(
@@ -57,11 +64,19 @@ def _sees_any_s2s_model(
     return any(m.benchmark is Benchmark.S2S and (m.provider, m.model) not in hidden for m in models)
 
 
-def _audio_path(sample_id: str, provider: str, model: str) -> str:
-    return (
+def _audio_path(dataset_id: str | None, sample_id: str, provider: str, model: str) -> str:
+    path = (
         f"/v1/s2s/samples/{quote(sample_id, safe='')}"
         f"/{quote(provider, safe='')}/{quote(model, safe='')}/audio"
     )
+    return f"{path}?dataset={quote(dataset_id, safe='')}" if dataset_id else path
+
+
+_DATASET_QUERY = Query(
+    default=None,
+    pattern=_DATASET_ID,
+    description="Samples partition (an S2S dataset id); omitted reads the legacy root layout.",
+)
 
 
 @router.get("/s2s/samples", response_model=list[str])
@@ -69,6 +84,7 @@ def _audio_path(sample_id: str, provider: str, model: str) -> str:
 async def list_s2s_samples(
     request: Request,
     response: Response,
+    dataset: str | None = _DATASET_QUERY,
     settings: Settings = Depends(get_settings),
     hidden: frozenset[tuple[str, str]] = Depends(hidden_early_access),
     models: Sequence[RegisteredModel] = Depends(get_models),
@@ -77,7 +93,7 @@ async def list_s2s_samples(
     never_shared(response)
     if not settings.s2s_samples_bucket or not _sees_any_s2s_model(models, hidden):
         return []
-    return await asyncio.to_thread(load_sample_ids, settings.s2s_samples_bucket)
+    return await asyncio.to_thread(load_sample_ids, settings.s2s_samples_bucket, dataset)
 
 
 @router.get("/s2s/samples/{sample_id}", response_model=S2SSampleOut)
@@ -86,6 +102,7 @@ async def get_s2s_sample(
     request: Request,
     response: Response,
     sample_id: str = Path(pattern=_SAMPLE_ID),
+    dataset: str | None = _DATASET_QUERY,
     settings: Settings = Depends(get_settings),
     hidden: frozenset[tuple[str, str]] = Depends(hidden_early_access),
     posthog_client: Posthog | None = Depends(get_posthog),
@@ -101,7 +118,7 @@ async def get_s2s_sample(
         raise HTTPException(404, "s2s samples are not configured")
 
     sample = await asyncio.to_thread(
-        load_sample, settings.s2s_samples_bucket, sample_id, hidden=hidden
+        load_sample, settings.s2s_samples_bucket, dataset, sample_id, hidden=hidden
     )
     if sample is None or not sample["recordings"]:
         raise HTTPException(404, f"no s2s sample for {sample_id}")
@@ -110,7 +127,7 @@ async def get_s2s_sample(
         S2SSampleRecordingOut(
             provider=rec["provider"],
             model=rec["model"],
-            audio_path=_audio_path(sample_id, rec["provider"], rec["model"]),
+            audio_path=_audio_path(dataset, sample_id, rec["provider"], rec["model"]),
             coval_run_id=rec["coval_run_id"],
             sim_id=rec["sim_id"],
             agent_id=rec.get("agent_id"),
@@ -121,6 +138,7 @@ async def get_s2s_sample(
     out = S2SSampleOut(
         schema_version=sample.get("schema_version"),
         sample_id=sample_id,
+        dataset_id=sample.get("dataset_id"),
         test_case_id=sample["test_case_id"],
         test_set_id=sample.get("test_set_id"),
         persona_name=sample.get("persona_name"),
@@ -150,6 +168,7 @@ async def get_s2s_sample_audio(
     provider: str,
     model: str,
     sample_id: str = Path(pattern=_SAMPLE_ID),
+    dataset: str | None = _DATASET_QUERY,
     settings: Settings = Depends(get_settings),
     hidden: frozenset[tuple[str, str]] = Depends(hidden_early_access),
 ) -> S2SSampleAudioOut:
@@ -161,6 +180,7 @@ async def get_s2s_sample_audio(
     key = await asyncio.to_thread(
         audio_object_key,
         settings.s2s_samples_bucket,
+        dataset,
         sample_id,
         provider,
         model,

--- a/runner/src/coval_bench/api/schemas.py
+++ b/runner/src/coval_bench/api/schemas.py
@@ -331,6 +331,7 @@ class S2SSampleOut(BaseModel):
 
     schema_version: int | None = None
     sample_id: str
+    dataset_id: str | None = None
     test_case_id: str
     test_set_id: str | None = None
     persona_name: str | None = None

--- a/runner/src/coval_bench/config.py
+++ b/runner/src/coval_bench/config.py
@@ -246,6 +246,16 @@ class Settings(BaseSettings):
     coval_s2s_cust_service_openai_agent_id: str | None = None
     coval_s2s_cust_service_grok_agent_id: str | None = None
     coval_s2s_cust_service_violet_agent_id: str | None = None
+    # --- Ultra Bank instruction following (default workspace, the daily board) ---
+    # The instruction metric is Coval's Validate Expected Behaviors composite: a
+    # 0-1 fraction of the case's expected behaviors met, not a YES/NO verdict.
+    # Opaque ids, not secrets.
+    coval_s2s_bank_test_set_id: str | None = None
+    coval_s2s_bank_instruction_metric_id: str | None = None
+    coval_s2s_bank_openai_agent_id: str | None = None
+    coval_s2s_bank_gpt_live_agent_id: str | None = None
+    coval_s2s_bank_gemini_agent_id: str | None = None
+    coval_s2s_bank_xai_agent_id: str | None = None
     # Shared across all three industries (it reads test_case.expected_behaviors
     # generically, unlike the domain judges), so one field rather than three.
     # A separate metric from coval_s2s_*_instruction_metric_id above, not a

--- a/runner/src/coval_bench/db/migrations/versions/20260911_0033_rename_violet_to_gpt_live_1.py
+++ b/runner/src/coval_bench/db/migrations/versions/20260911_0033_rename_violet_to_gpt_live_1.py
@@ -1,27 +1,7 @@
 # Copyright 2026 The Coval Benchmarks Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Rename ``violet`` to ``openai/gpt-live-1``; register it and ``xai/grok-voice`` as early access.
-
-``violet`` was the pre-launch label for the GPT-Live-1 agents on the three
-instruction-adherence industry boards. GPT-Live-1 launched publicly on
-2026-07-08, so the codename no longer protects anything and just reads as an
-unknown model on the dashboard.
-
-``model`` is stored on every results row and is part of the bucket tables'
-primary keys, so every table keyed by (provider, model) is rewritten together.
-Rewriting only some would split the industry series between two keys.
-
-Neither the codename nor ``xai/grok-voice`` was ever registered, so the industry
-boards served both to the public: an unregistered pair cannot be embargoed. Both
-get registry rows here as early access (``published = FALSE``), which is what
-pulls them back behind the gate while giving them a name and a color for the orgs
-that may see them.
-
-The per-window matviews are deliberately not refreshed here: the runner
-refreshes them at the end of each benchmark run (see ``migrations/env.py``),
-and ``REFRESH ... CONCURRENTLY`` cannot run inside a migration's transaction.
-"""
+"""Rename Violet to GPT-Live-1 and register GPT-Live-1 and Grok Voice as early access."""
 
 from __future__ import annotations
 
@@ -49,7 +29,6 @@ def _rename(old: str, new: str) -> None:
 
 
 def upgrade() -> None:
-    """Point every violet row at gpt-live-1 and register both models as early access."""
     _rename("violet", "gpt-live-1")
     op.execute(
         """
@@ -76,7 +55,6 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    """Restore the codename and drop both registry rows (tags cascade)."""
     op.execute(
         "DELETE FROM benchmarks_v2.models "
         "WHERE modality = 'S2S' AND updated_by_user_id = 'migration:20260911_0033' "

--- a/runner/src/coval_bench/db/migrations/versions/20260911_0033_rename_violet_to_gpt_live_1.py
+++ b/runner/src/coval_bench/db/migrations/versions/20260911_0033_rename_violet_to_gpt_live_1.py
@@ -1,0 +1,85 @@
+# Copyright 2026 The Coval Benchmarks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Rename ``violet`` to ``openai/gpt-live-1``; register it and ``xai/grok-voice`` as early access.
+
+``violet`` was the pre-launch label for the GPT-Live-1 agents on the three
+instruction-adherence industry boards. GPT-Live-1 launched publicly on
+2026-07-08, so the codename no longer protects anything and just reads as an
+unknown model on the dashboard.
+
+``model`` is stored on every results row and is part of the bucket tables'
+primary keys, so every table keyed by (provider, model) is rewritten together.
+Rewriting only some would split the industry series between two keys.
+
+Neither the codename nor ``xai/grok-voice`` was ever registered, so the industry
+boards served both to the public: an unregistered pair cannot be embargoed. Both
+get registry rows here as early access (``published = FALSE``), which is what
+pulls them back behind the gate while giving them a name and a color for the orgs
+that may see them.
+
+The per-window matviews are deliberately not refreshed here: the runner
+refreshes them at the end of each benchmark run (see ``migrations/env.py``),
+and ``REFRESH ... CONCURRENTLY`` cannot run inside a migration's transaction.
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "20260911_0033"
+down_revision = "20260910_0032"
+branch_labels = None
+depends_on = None
+
+_RENAME_ROWS = """
+UPDATE benchmarks_v2.results SET model = '{new}'
+    WHERE provider = 'openai' AND model = '{old}';
+UPDATE benchmarks_v2.results_by_bucket SET model = '{new}'
+    WHERE provider = 'openai' AND model = '{old}';
+UPDATE benchmarks_v2.metric_values_by_bucket SET model = '{new}'
+    WHERE provider = 'openai' AND model = '{old}';
+UPDATE benchmarks_v2.benchmark_observations SET model = '{new}'
+    WHERE provider = 'openai' AND model = '{old}';
+"""
+
+
+def _rename(old: str, new: str) -> None:
+    op.execute(_RENAME_ROWS.format(old=old, new=new))  # noqa: S608 — both values are literals above
+
+
+def upgrade() -> None:
+    """Point every violet row at gpt-live-1 and register both models as early access."""
+    _rename("violet", "gpt-live-1")
+    op.execute(
+        """
+        INSERT INTO benchmarks_v2.models
+            (modality, provider, model, voice, voices, creator, source, licensing,
+             on_prem, region, arena_enabled, collected, published, color, updated_by_user_id)
+        VALUES
+            ('S2S', 'openai', 'gpt-live-1', NULL, '[]'::jsonb, NULL, 'official-api', 'proprietary',
+             FALSE, 'us', TRUE, TRUE, FALSE, '#e08bb5', 'migration:20260911_0033'),
+            ('S2S', 'xai', 'grok-voice', NULL, '[]'::jsonb, NULL, 'official-api', 'proprietary',
+             FALSE, 'us', TRUE, TRUE, FALSE, '#9a6ad1', 'migration:20260911_0033')
+        ON CONFLICT (modality, provider, model) DO NOTHING
+        """
+    )
+    op.execute(
+        """
+        INSERT INTO benchmarks_v2.model_tags (model_id, tag)
+        SELECT m.id, 'multilingual'
+        FROM benchmarks_v2.models m
+        WHERE m.modality = 'S2S' AND m.provider = 'openai' AND m.model = 'gpt-live-1'
+        ON CONFLICT DO NOTHING
+        """
+    )
+
+
+def downgrade() -> None:
+    """Restore the codename and drop both registry rows (tags cascade)."""
+    op.execute(
+        "DELETE FROM benchmarks_v2.models "
+        "WHERE modality = 'S2S' AND updated_by_user_id = 'migration:20260911_0033' "
+        "AND (provider, model) IN (('openai', 'gpt-live-1'), ('xai', 'grok-voice'))"
+    )
+    _rename("gpt-live-1", "violet")

--- a/runner/src/coval_bench/s2s/conditions.py
+++ b/runner/src/coval_bench/s2s/conditions.py
@@ -21,6 +21,7 @@ from coval_bench.registries import Benchmark, Metric
 
 __all__ = [
     "DATASET_ID",
+    "DATASET_ID_BANK",
     "DATASET_ID_DENTAL",
     "DATASET_ID_DENTAL_ACCENTED",
     "DATASET_ID_DENTAL_NOISY",
@@ -34,6 +35,7 @@ __all__ = [
     "DATASET_ID_MULTITURN",
     "DATASET_ID_MULTITURN_NOISY",
     "DEFAULT_CONDITION",
+    "FAMILY_BANK",
     "FAMILY_DENTAL",
     "FAMILY_HAPPYPATH",
     "FAMILY_INSTR_CUST_SERVICE",
@@ -78,6 +80,10 @@ FAMILY_LLM_DENTAL = "llm-dental"
 FAMILY_INSTR_HEALTH = "instruction-adherence-health"
 FAMILY_INSTR_HOME_SERVICE = "instruction-adherence-home-service"
 FAMILY_INSTR_CUST_SERVICE = "instruction-adherence-cust-service"
+# Ultra Bank instruction following: two scenarios, run daily by every S2S agent in
+# the default workspace. Only the clean caller is scheduled; the harder personas
+# exist in Coval but are not ingested until they get a dataset id here.
+FAMILY_BANK = "s2s-bank"
 
 # Single-turn SLURP manifest (legacy, latency only) and the multi-turn Coval test
 # set, split by caller condition so background noise never pools into the clean
@@ -102,6 +108,8 @@ DATASET_ID_INSTR_HEALTH = "instruction-adherence-health-v1"
 DATASET_ID_INSTR_HOME_SERVICE = "instruction-adherence-home-service-v1"
 DATASET_ID_INSTR_CUST_SERVICE = "instruction-adherence-cust-service-v1"
 
+DATASET_ID_BANK = "s2s-bank-v1"
+
 # Unlisted pairs are a configuration error, not a silent skip.
 DATASET_IDS: dict[tuple[str, Condition], str | None] = {
     (FAMILY_MULTITURN, Condition.CLEAN): DATASET_ID_MULTITURN,
@@ -118,6 +126,9 @@ DATASET_IDS: dict[tuple[str, Condition], str | None] = {
     (FAMILY_INSTR_HEALTH, Condition.CLEAN): DATASET_ID_INSTR_HEALTH,
     (FAMILY_INSTR_HOME_SERVICE, Condition.CLEAN): DATASET_ID_INSTR_HOME_SERVICE,
     (FAMILY_INSTR_CUST_SERVICE, Condition.CLEAN): DATASET_ID_INSTR_CUST_SERVICE,
+    (FAMILY_BANK, Condition.CLEAN): DATASET_ID_BANK,
+    (FAMILY_BANK, Condition.NOISY): None,
+    (FAMILY_BANK, Condition.ACCENTED): None,
 }
 
 
@@ -210,6 +221,15 @@ CONDITIONS: dict[str, DatasetMetrics] = {
     DATASET_ID_INSTR_CUST_SERVICE: DatasetMetrics(
         required=Metric.INSTRUCTION_FOLLOWING,
         optional=frozenset({Metric.EXPECTED_BEHAVIOR_ADHERENCE}),
+    ),
+    # The Ultra Bank instruction-following set, the daily public board. Latency is
+    # the anchor because Coval's built-in metric is on every run; "instruction
+    # following" here is the Validate Expected Behaviors judge, a fraction of the
+    # case's expected behaviors met, stored as a percentage under the same metric
+    # the binary judges feed so the adherence chart needs no second series.
+    DATASET_ID_BANK: DatasetMetrics(
+        required=Metric.V2V,
+        optional=frozenset({Metric.INSTRUCTION_FOLLOWING, Metric.INTERRUPTION_RATE}),
     ),
 }
 

--- a/runner/src/coval_bench/s2s/fetch_v2v.py
+++ b/runner/src/coval_bench/s2s/fetch_v2v.py
@@ -34,6 +34,7 @@ from coval_bench.registries.models import RegisteredModel
 from coval_bench.s2s.conditions import (
     DATASET_ID,
     DEFAULT_CONDITION,
+    FAMILY_BANK,
     FAMILY_DENTAL,
     FAMILY_INSTR_CUST_SERVICE,
     FAMILY_INSTR_HEALTH,
@@ -175,7 +176,7 @@ def s2s_specs(settings: Settings) -> tuple[AgentSpec, ...]:
         AgentSpec(
             agent_id=settings.coval_s2s_health_violet_agent_id,
             provider="openai",
-            model="violet",
+            model="gpt-live-1",
             test_set_id_attr="coval_s2s_health_test_set_id",
             family=FAMILY_INSTR_HEALTH,
             publish_samples=False,
@@ -208,7 +209,7 @@ def s2s_specs(settings: Settings) -> tuple[AgentSpec, ...]:
         AgentSpec(
             agent_id=settings.coval_s2s_home_service_violet_agent_id,
             provider="openai",
-            model="violet",
+            model="gpt-live-1",
             test_set_id_attr="coval_s2s_home_service_test_set_id",
             family=FAMILY_INSTR_HOME_SERVICE,
             publish_samples=False,
@@ -241,13 +242,49 @@ def s2s_specs(settings: Settings) -> tuple[AgentSpec, ...]:
         AgentSpec(
             agent_id=settings.coval_s2s_cust_service_violet_agent_id,
             provider="openai",
-            model="violet",
+            model="gpt-live-1",
             test_set_id_attr="coval_s2s_cust_service_test_set_id",
             family=FAMILY_INSTR_CUST_SERVICE,
             publish_samples=False,
             workspace_id_attr="coval_s2s_industry_workspace_id",
             instruction_metric_id_attr="coval_s2s_cust_service_instruction_metric_id",
             expected_behavior_metric_id_attr="coval_s2s_industry_expected_behavior_metric_id",
+        ),
+        # The Ultra Bank set, the daily public board: four agents in the default
+        # workspace on one test set. Its instruction metric is the Validate
+        # Expected Behaviors judge, a fraction rather than a verdict, which the
+        # instruction mapper scales to a percentage.
+        AgentSpec(
+            agent_id=settings.coval_s2s_bank_openai_agent_id,
+            provider="openai",
+            model="gpt-realtime",
+            test_set_id_attr="coval_s2s_bank_test_set_id",
+            family=FAMILY_BANK,
+            instruction_metric_id_attr="coval_s2s_bank_instruction_metric_id",
+        ),
+        AgentSpec(
+            agent_id=settings.coval_s2s_bank_gpt_live_agent_id,
+            provider="openai",
+            model="gpt-live-1",
+            test_set_id_attr="coval_s2s_bank_test_set_id",
+            family=FAMILY_BANK,
+            instruction_metric_id_attr="coval_s2s_bank_instruction_metric_id",
+        ),
+        AgentSpec(
+            agent_id=settings.coval_s2s_bank_gemini_agent_id,
+            provider="google",
+            model="gemini-live",
+            test_set_id_attr="coval_s2s_bank_test_set_id",
+            family=FAMILY_BANK,
+            instruction_metric_id_attr="coval_s2s_bank_instruction_metric_id",
+        ),
+        AgentSpec(
+            agent_id=settings.coval_s2s_bank_xai_agent_id,
+            provider="xai",
+            model="grok-voice-think-fast-2.0",
+            test_set_id_attr="coval_s2s_bank_test_set_id",
+            family=FAMILY_BANK,
+            instruction_metric_id_attr="coval_s2s_bank_instruction_metric_id",
         ),
     )
 
@@ -360,6 +397,12 @@ def _dataset_identity(
     if condition is Condition.CLEAN:
         return dataset_id, test_set_id
     return dataset_id, f"{test_set_id}:{persona_id}"
+
+
+def _fetches_v2v(family: str) -> bool:
+    """Whether *family*'s clean condition asks Coval for V2V latency."""
+    dataset_id = dataset_id_for(family, Condition.CLEAN)
+    return dataset_id is not None and Metric.V2V in condition_for(dataset_id).fetched
 
 
 def _persona_conditions(raw: Mapping[str, str]) -> dict[str, Condition] | None:
@@ -509,8 +552,14 @@ def _population_mismatch(
 def _instruction_value(raw: object) -> tuple[float | None, ResultStatus] | None:
     """YES -> 100.0, NO -> 0.0, UNKNOWN -> no row, so the mean is YES / (YES + NO).
 
-    Raises InvalidInstructionVerdict on any value outside the contract.
+    A composite judge reports the fraction of expected behaviors met instead of a
+    verdict; that fraction becomes a percentage on the same scale, unrounded.
+    Raises InvalidInstructionVerdict on any value outside either contract.
     """
+    if isinstance(raw, (int, float)) and not isinstance(raw, bool):
+        if not 0.0 <= raw <= 1.0:
+            raise InvalidInstructionVerdict(f"instruction fraction out of range: {raw!r}")
+        return float(raw) * 100.0, ResultStatus.SUCCESS
     verdict = _instruction_verdict(raw)
     if verdict is None:
         return None
@@ -1002,12 +1051,18 @@ def _backfill_status(statuses: list[RunStatus]) -> RunStatus:
     return RunStatus.PARTIAL
 
 
-def _expected_sample_models(settings: Settings) -> set[tuple[str, str]]:
-    """The pairs a sample must cover; a bucket short one publishes nothing."""
+def _expected_sample_models(settings: Settings, dataset_id: str) -> set[tuple[str, str]]:
+    """The pairs a sample on *dataset_id* must cover; a bucket short one publishes nothing.
+
+    Each dataset is its own samples partition, so only the agents whose clean
+    condition lands there count; a model on another industry's set is not missing.
+    """
     return {
         (spec.provider, spec.model)
         for spec in s2s_specs(settings)
-        if spec.agent_id and spec.publish_samples
+        if spec.agent_id
+        and spec.publish_samples
+        and dataset_id_for(spec.family, Condition.CLEAN) == dataset_id
     }
 
 
@@ -1071,6 +1126,7 @@ async def _fetch_one_provider(
             persona_id=coval_run.persona_id,
             agent_id=agent_id,
             test_set_id=test_set_id or "",
+            dataset_id=dataset_id,
         )
 
     try:
@@ -1231,11 +1287,9 @@ async def fetch_and_write_v2v(
 
     metric_id = settings.coval_s2s_latency_metric_id
     if benchmark is Benchmark.S2S and not metric_id:
-        # Industry specs fetch instruction adherence only (see conditions.py);
-        # only a spec still relying on the shared V2V metric makes it required.
-        v2v_spec_configured = any(
-            not spec.instruction_metric_id_attr and spec.agent_id for spec in specs
-        )
+        # Only a configured spec whose clean condition fetches V2V (see
+        # conditions.py) makes the latency metric required; industry specs don't.
+        v2v_spec_configured = any(spec.agent_id and _fetches_v2v(spec.family) for spec in specs)
         if v2v_spec_configured:
             raise RuntimeError("coval_s2s_latency_metric_id is not set")
     # Instruction ingestion and the test-set filter go together: instruction
@@ -1396,25 +1450,34 @@ async def fetch_and_write_v2v(
                 f"targeted backfill did not recover runs: {', '.join(sorted(unmatched))}"
             )
 
-        # The set the sampled recordings actually came from, which is what labels
-        # the manifest. Gating on the shared ``coval_s2s_test_set_id`` instead would
-        # stop publishing entirely once every agent carries its own set, filling
-        # sampled_runs and then never shipping them.
-        sample_test_set_id = next(
-            (r.test_set_id for r in sampled_runs if r.test_set_id), test_set_id
-        )
-        if settings.s2s_samples_bucket and sampled_runs and sample_test_set_id:
-            expected = _expected_sample_models(settings)
-            missing = expected - {r.key for r in sampled_runs}
+        # One sample per dataset: each industry runs its own test set, so a tick
+        # that pooled them would never find a scenario shared by every model. The
+        # set the recordings actually came from labels the manifest; gating on the
+        # shared ``coval_s2s_test_set_id`` instead would stop publishing entirely
+        # once every agent carries its own set.
+        by_dataset: dict[str, list[SampleRun]] = {}
+        for run in sampled_runs:
+            by_dataset.setdefault(run.dataset_id, []).append(run)
+        for dataset_id, dataset_runs in sorted(by_dataset.items()):
+            sample_test_set_id = next(
+                (r.test_set_id for r in dataset_runs if r.test_set_id), test_set_id
+            )
+            if not (settings.s2s_samples_bucket and sample_test_set_id):
+                continue
+            expected = _expected_sample_models(settings, dataset_id)
+            missing = expected - {r.key for r in dataset_runs}
             if missing:
                 # Error level on purpose: this is the alert that a model is
                 # absent from the window, so no day in it can publish a sample.
-                logger.error("samples_provider_missing", missing=model_labels(missing))
+                logger.error(
+                    "samples_provider_missing", dataset=dataset_id, missing=model_labels(missing)
+                )
             await publish_tick_sample(
                 client,
                 bucket_name=settings.s2s_samples_bucket,
+                dataset_id=dataset_id,
                 test_set_id=sample_test_set_id,
-                runs=sampled_runs,
+                runs=dataset_runs,
                 rng=random.Random(),  # noqa: S311
                 expected_models=expected,
             )

--- a/runner/src/coval_bench/s2s/samples.py
+++ b/runner/src/coval_bench/s2s/samples.py
@@ -3,10 +3,12 @@
 
 """Publish one multi-turn conversation sample per fetch tick.
 
-Each tick picks ONE (scenario, persona) present for every benchmarked model,
-uploads each model's full-conversation recording plus its per-agent transcript
-into the public samples bucket, and writes a ``manifest.json`` keyed by the
-timeline bucket timestamp. Only a fully-complete sample (audio + transcript for
+Each dataset is its own partition under ``PREFIX``: a tick picks ONE (scenario,
+persona) present for every model benchmarked on that dataset, uploads each
+model's full-conversation recording plus its per-agent transcript into the
+samples bucket, and writes a ``manifest.json`` keyed by the timeline bucket
+timestamp. Ticks published before partitioning sit at the root and stay readable
+until the TTL prunes them. Only a fully-complete sample (audio + transcript for
 every model) is published; otherwise the tick is skipped. The dashboard reads the
 manifests directly (public bucket, no API hop); a rolling ``index.json`` lists
 the available ticks newest-first. The bucket's 30-day TTL prunes old ticks.
@@ -37,7 +39,6 @@ if TYPE_CHECKING:
 logger = structlog.get_logger("coval_bench.s2s.samples")
 
 PREFIX = "s2s-samples"
-INDEX_KEY = f"{PREFIX}/index.json"
 _TICK_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 _INDEX_MAX_ENTRIES = 60
 _DOWNLOAD_TIMEOUT = 120.0
@@ -48,11 +49,22 @@ _DOWNLOAD_TIMEOUT = 120.0
 _PERSONA_LABELS: dict[str, str] = {
     "PN3xgmsqeLDjsNNEA2e55e": "Standard Female",
     "9ATy64zKXxSUaVWb5YnQtd": "Standard Male",
+    "MUFJdYAHdBHU6UbRRu4ykM": "Standard Customer",
+    "NWTe6Q7B7WvhUfU52A3NY8": "Clean Speech Baseline",
 }
 
 
 def _persona_label(persona_id: str) -> str:
     return _PERSONA_LABELS.get(persona_id, persona_id)
+
+
+def sample_prefix(dataset_id: str | None) -> str:
+    """Where a dataset's ticks live; ``None`` is the pre-partition root layout."""
+    return f"{PREFIX}/{dataset_id}" if dataset_id else PREFIX
+
+
+def index_key(dataset_id: str | None) -> str:
+    return f"{sample_prefix(dataset_id)}/index.json"
 
 
 @dataclass(frozen=True)
@@ -72,6 +84,8 @@ class SampleRun:
     # The set this run actually came from. Agents no longer share one, so the
     # manifest cannot label a recording with the caller-wide configured id.
     test_set_id: str = ""
+    # The dataset the run's rows landed under, which is the samples partition.
+    dataset_id: str = ""
 
     @property
     def key(self) -> tuple[str, str]:
@@ -205,7 +219,7 @@ def _upload(bucket: storage.Bucket, key: str, data: bytes, content_type: str) ->
     bucket.blob(key).upload_from_string(data, content_type=content_type)
 
 
-def _update_index(bucket: storage.Bucket, tick_key: str) -> None:
+def _update_index(bucket: storage.Bucket, dataset_id: str | None, tick_key: str) -> None:
     """Add the tick to index.json, kept newest-first (single writer — no race to guard).
 
     Sorted rather than prepended because ticks are not always written in
@@ -219,7 +233,7 @@ def _update_index(bucket: storage.Bucket, tick_key: str) -> None:
     failure leaves the existing index untouched so a transient error can't
     erase the history.
     """
-    blob = bucket.blob(INDEX_KEY)
+    blob = bucket.blob(index_key(dataset_id))
     ticks: list[str]
     try:
         decoded = json.loads(blob.download_as_bytes())
@@ -232,13 +246,14 @@ def _update_index(bucket: storage.Bucket, tick_key: str) -> None:
         logger.error("samples_index_read_failed", tick=tick_key, exc_info=True)
         return
     ticks = sorted({tick_key, *ticks}, reverse=True)[:_INDEX_MAX_ENTRIES]
-    _upload(bucket, INDEX_KEY, json.dumps(ticks).encode(), "application/json")
+    _upload(bucket, index_key(dataset_id), json.dumps(ticks).encode(), "application/json")
 
 
 async def publish_tick_sample(
     client: httpx.AsyncClient,
     *,
     bucket_name: str,
+    dataset_id: str,
     test_set_id: str,
     runs: list[SampleRun],
     rng: Random,
@@ -247,6 +262,9 @@ async def publish_tick_sample(
     expected_models: set[tuple[str, str]] | None = None,
 ) -> int:
     """Copy one multi-turn conversation (every model, one persona) as a v2 sample.
+
+    ``dataset_id`` names the partition the tick lands in; every model in ``runs``
+    is expected to have been benchmarked on it.
 
     ``expected_models`` is the configured ``(provider, model)`` set a sample must
     cover. Pass it: without it completeness is judged against whichever models
@@ -262,6 +280,7 @@ async def publish_tick_sample(
                 client,
                 download_client or default_download,
                 bucket_name=bucket_name,
+                dataset_id=dataset_id,
                 test_set_id=test_set_id,
                 runs=runs,
                 rng=rng,
@@ -278,6 +297,7 @@ async def _publish_tick_sample(
     download_client: httpx.AsyncClient,
     *,
     bucket_name: str,
+    dataset_id: str,
     test_set_id: str,
     runs: list[SampleRun],
     rng: Random,
@@ -312,6 +332,7 @@ async def _publish_tick_sample(
                 client,
                 download_client,
                 bucket=bucket,
+                dataset_id=dataset_id,
                 test_set_id=test_set_id,
                 runs=by_bucket[bucket_at],
                 bucket_at=bucket_at,
@@ -332,6 +353,7 @@ async def _publish_one_bucket(
     download_client: httpx.AsyncClient,
     *,
     bucket: storage.Bucket,
+    dataset_id: str,
     test_set_id: str,
     runs: list[SampleRun],
     bucket_at: datetime,
@@ -339,14 +361,15 @@ async def _publish_one_bucket(
     expected_models: set[tuple[str, str]] | None,
 ) -> int:
     tick_key = bucket_at.strftime(_TICK_FORMAT)
-    manifest_key = f"{PREFIX}/{tick_key}/manifest.json"
+    tick_prefix = f"{sample_prefix(dataset_id)}/{tick_key}"
+    manifest_key = f"{tick_prefix}/manifest.json"
     # Ahead of every other gate: an already-published day needs no runs at all,
     # only its index entry restored if that write once failed. Gating this behind
     # the checks below would strand such a day for good — its runs age out of the
     # window, so no later fetch would revisit the bucket to repair it.
     if bucket.blob(manifest_key).exists():
-        _update_index(bucket, tick_key)
-        logger.info("samples_tick_exists", tick=tick_key)
+        _update_index(bucket, dataset_id, tick_key)
+        logger.info("samples_tick_exists", dataset=dataset_id, tick=tick_key)
         return 0
 
     expected = expected_models or {r.key for r in runs}
@@ -455,7 +478,7 @@ async def _publish_one_bucket(
 
         recordings: list[dict[str, Any]] = []
         for s_run, s_sim_id, s_audio, s_turns in staged:
-            key = f"{PREFIX}/{tick_key}/{s_run.provider}/{s_run.model}.wav"
+            key = f"{tick_prefix}/{s_run.provider}/{s_run.model}.wav"
             _upload(bucket, key, s_audio, "audio/wav")
             recordings.append(
                 {
@@ -471,6 +494,7 @@ async def _publish_one_bucket(
         manifest = {
             "schema_version": 2,
             "bucket_at": tick_key,
+            "dataset_id": dataset_id,
             # The recordings' own set, falling back to the configured one only when
             # a run predates the field.
             "test_set_id": next((r.test_set_id for r in runs if r.test_set_id), test_set_id),
@@ -479,9 +503,10 @@ async def _publish_one_bucket(
             "recordings": recordings,
         }
         _upload(bucket, manifest_key, json.dumps(manifest).encode(), "application/json")
-        _update_index(bucket, tick_key)
+        _update_index(bucket, dataset_id, tick_key)
         logger.info(
             "samples_tick_stored",
+            dataset=dataset_id,
             tick=tick_key,
             recordings=len(recordings),
             persona=persona_id,
@@ -504,16 +529,17 @@ AUDIO_URL_TTL = timedelta(minutes=10)
 
 def load_sample_ids(
     bucket_name: str,
+    dataset_id: str | None,
     *,
     storage_client: storage.Client | None = None,
 ) -> list[str]:
-    raw = read_json(bucket_name, INDEX_KEY, storage_client=storage_client)
+    raw = read_json(bucket_name, index_key(dataset_id), storage_client=storage_client)
     if not isinstance(raw, list):
         return []
     return sorted((s for s in raw if isinstance(s, str)), reverse=True)
 
 
-def _own_audio_object(key: object, sample_id: str) -> bool:
+def _own_audio_object(key: object, dataset_id: str | None, sample_id: str) -> bool:
     """True only for a recording key that lives inside this sample's own directory.
 
     The manifest is ours, but a stale or malformed one must not be able to steer
@@ -524,7 +550,7 @@ def _own_audio_object(key: object, sample_id: str) -> bool:
     """
     return (
         isinstance(key, str)
-        and key.startswith(f"{PREFIX}/{sample_id}/")
+        and key.startswith(f"{sample_prefix(dataset_id)}/{sample_id}/")
         and key.endswith(".wav")
         and ".." not in key
     )
@@ -532,6 +558,7 @@ def _own_audio_object(key: object, sample_id: str) -> bool:
 
 def load_sample(
     bucket_name: str,
+    dataset_id: str | None,
     sample_id: str,
     *,
     hidden: frozenset[tuple[str, str]],
@@ -539,7 +566,7 @@ def load_sample(
 ) -> dict[str, Any] | None:
     raw = read_json(
         bucket_name,
-        f"{PREFIX}/{sample_id}/manifest.json",
+        f"{sample_prefix(dataset_id)}/{sample_id}/manifest.json",
         storage_client=storage_client,
     )
     if not isinstance(raw, dict):
@@ -548,7 +575,7 @@ def load_sample(
         rec
         for rec in raw.get("recordings", [])
         if isinstance(rec, dict)
-        and _own_audio_object(rec.get("object"), sample_id)
+        and _own_audio_object(rec.get("object"), dataset_id, sample_id)
         and (rec.get("provider"), rec.get("model")) not in hidden
     ]
     return {**raw, "recordings": recordings}
@@ -556,6 +583,7 @@ def load_sample(
 
 def audio_object_key(
     bucket_name: str,
+    dataset_id: str | None,
     sample_id: str,
     provider: str,
     model: str,
@@ -563,7 +591,9 @@ def audio_object_key(
     hidden: frozenset[tuple[str, str]],
     storage_client: storage.Client | None = None,
 ) -> str | None:
-    sample = load_sample(bucket_name, sample_id, hidden=hidden, storage_client=storage_client)
+    sample = load_sample(
+        bucket_name, dataset_id, sample_id, hidden=hidden, storage_client=storage_client
+    )
     if sample is None:
         return None
     for rec in sample["recordings"]:

--- a/runner/tests/api/test_clerk_scope.py
+++ b/runner/tests/api/test_clerk_scope.py
@@ -61,8 +61,11 @@ COLORS = ("colors", "gray")
 # The board key grok-voice-think-fast-1.0 was published under before its rename.
 # Artefacts stored under it stay embargoed alongside the current key.
 XAI_RETIRED = ("xai", "grok-realtime")
+# The codename gpt-live-1 was published under on the industry boards before launch.
+OPENAI_RETIRED = ("openai", "violet")
+RETIRED = frozenset({XAI_RETIRED, OPENAI_RETIRED})
 
-EMBARGOED = frozenset({XAI_1, XAI_2, XAI_RETIRED, COLORS})
+EMBARGOED = frozenset({XAI_1, XAI_2, COLORS}) | RETIRED
 EVERYTHING = EMBARGOED | {PUBLIC}
 
 
@@ -136,7 +139,7 @@ def test_org_sees_its_own_providers_models_and_no_others(
     token = _mint({"org_id": _ORG_ID})
     hidden, status = _resolve(settings, f"Bearer {token}")
     assert status == "accepted"
-    assert hidden == {COLORS}
+    assert hidden == {COLORS, OPENAI_RETIRED}
 
 
 def test_org_entry_can_name_one_model(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -146,7 +149,7 @@ def test_org_entry_can_name_one_model(monkeypatch: pytest.MonkeyPatch) -> None:
     token = _mint({"org_id": _ORG_ID})
     hidden, status = _resolve(settings, f"Bearer {token}")
     assert status == "accepted"
-    assert hidden == {XAI_1, XAI_RETIRED, COLORS}
+    assert hidden == {XAI_1, XAI_RETIRED, COLORS, OPENAI_RETIRED}
 
 
 def test_org_entry_list_of_one_provider_unlocks_all_its_models(
@@ -155,7 +158,7 @@ def test_org_entry_list_of_one_provider_unlocks_all_its_models(
     settings = _settings(monkeypatch, org_providers=json.dumps({_ORG_ID: ["xai"]}))
     token = _mint({"org_id": _ORG_ID})
     hidden, _ = _resolve(settings, f"Bearer {token}")
-    assert hidden == {COLORS}
+    assert hidden == {COLORS, OPENAI_RETIRED}
 
 
 def test_mapped_org_naming_nothing_unlocks_nothing(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -180,7 +183,7 @@ def test_exclusive_org_sees_only_its_own_provider(monkeypatch: pytest.MonkeyPatc
 
     assert status == "accepted"
     # Public models are hidden too: an exclusive org sees nothing but its own.
-    assert hidden == {PUBLIC, COLORS}
+    assert hidden == {PUBLIC, COLORS, OPENAI_RETIRED}
 
 
 def test_exclusive_org_can_name_one_model(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -212,7 +215,7 @@ def test_exclusive_wins_over_additive_for_the_same_org(monkeypatch: pytest.Monke
     token = _mint({"org_id": _ORG_ID})
     hidden, _ = _resolve(settings, f"Bearer {token}")
 
-    assert hidden == {PUBLIC, COLORS}
+    assert hidden == {PUBLIC, COLORS, OPENAI_RETIRED}
 
 
 def test_exclusive_overrides_the_coval_org(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -220,7 +223,7 @@ def test_exclusive_overrides_the_coval_org(monkeypatch: pytest.MonkeyPatch) -> N
     token = _mint({"org_id": _COVAL_ORG})
     hidden, _ = _resolve(settings, f"Bearer {token}")
 
-    assert hidden == {PUBLIC, COLORS}
+    assert hidden == {PUBLIC, COLORS, OPENAI_RETIRED}
 
 
 def test_unmapped_org_is_unaffected_by_the_exclusive_map(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -320,7 +323,7 @@ def test_a_mapped_coval_org_gets_only_its_entry(monkeypatch: pytest.MonkeyPatch)
     token = _mint({"org_id": _COVAL_ORG})
     hidden, status = _resolve(settings, f"Bearer {token}")
     assert status == "accepted"
-    assert hidden == {COLORS}
+    assert hidden == {COLORS, OPENAI_RETIRED}
 
 
 def test_a_coval_email_alone_unlocks_nothing(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -508,7 +511,7 @@ def test_retired_board_keys_stay_embargoed() -> None:
     key would publish every recording and row published under that name. The
     retired key is embargoed even when no roster entry carries it.
     """
-    assert embargoed_pairs([]) == {XAI_RETIRED}
+    assert embargoed_pairs([]) == RETIRED
     assert embargoed_pairs(_MODELS) == EMBARGOED
 
 
@@ -527,4 +530,4 @@ def test_org_grant_for_a_renamed_model_also_sees_its_history(
     )
     token = _mint({"org_id": _ORG_ID})
     hidden, _ = _resolve(settings, f"Bearer {token}")
-    assert hidden == {XAI_2, COLORS}
+    assert hidden == {XAI_2, COLORS, OPENAI_RETIRED}

--- a/runner/tests/api/test_leaderboard.py
+++ b/runner/tests/api/test_leaderboard.py
@@ -157,15 +157,15 @@ async def test_excluded_metric_rows_hidden(client: AsyncClient, postgresql: Any)
     assert [(e["provider"], e["model"]) for e in entries] == [("deepgram", "nova-3")]
 
 
-async def test_s2s_leaderboard_uses_the_clean_primary_dataset(
+async def test_s2s_leaderboard_uses_the_bank_primary_dataset(
     client: AsyncClient, postgresql: Any
 ) -> None:
-    """The headline S2S board excludes robustness conditions such as noisy speech."""
-    clean_run = await _insert_run(postgresql, dataset_id="s2s-dental-v1")
-    noisy_run = await _insert_run(postgresql, dataset_id="s2s-dental-noisy-v1")
+    """The headline S2S board is the Ultra Bank set; the frozen dental rows stay out."""
+    primary_run = await _insert_run(postgresql, dataset_id="s2s-bank-v1")
+    dental_run = await _insert_run(postgresql, dataset_id="s2s-dental-v1")
     await _insert_result(
         postgresql,
-        clean_run,
+        primary_run,
         provider="openai",
         model="gpt-realtime",
         metric_type="V2V",
@@ -175,7 +175,7 @@ async def test_s2s_leaderboard_uses_the_clean_primary_dataset(
     )
     await _insert_result(
         postgresql,
-        noisy_run,
+        dental_run,
         provider="google",
         model="gemini-live",
         metric_type="V2V",

--- a/runner/tests/api/test_s2s_samples_api.py
+++ b/runner/tests/api/test_s2s_samples_api.py
@@ -27,6 +27,8 @@ from tests.api.conftest import COVAL_ORG, add_models, bearer
 _BUCKET = "test-s2s-samples"
 _SAMPLE = "2026-07-30T00:00:00Z"
 _OTHER_SAMPLE = "2026-07-29T00:00:00Z"
+_DATASET = "instruction-adherence-cust-service-v1"
+_PARTITIONED_SAMPLE = "2026-09-11T00:00:00Z"
 _SIGNED = "https://storage.googleapis.com/signed-for-test"
 
 _PARTNER_ORG = "org_s2s_partner"
@@ -45,11 +47,14 @@ _LIVE = ("openlab", "public-s2s")
 _EMBARGOED = ("acme", "secret-s2s")
 
 
-def _recording(provider: str, model: str, sample_id: str = _SAMPLE) -> dict[str, Any]:
+def _recording(
+    provider: str, model: str, sample_id: str = _SAMPLE, dataset_id: str | None = None
+) -> dict[str, Any]:
+    prefix = f"s2s-samples/{dataset_id}" if dataset_id else "s2s-samples"
     return {
         "provider": provider,
         "model": model,
-        "object": f"s2s-samples/{sample_id}/{provider}/{model}.wav",
+        "object": f"{prefix}/{sample_id}/{provider}/{model}.wav",
         "coval_run_id": "run-1",
         "sim_id": "sim-1",
         "agent_id": "agent-1",
@@ -73,6 +78,16 @@ _OBJECTS: dict[str, Any] = {
         "test_case_id": "tc-secret",
         "persona_name": "Standard Female",
         "recordings": [_recording(*_EMBARGOED, sample_id=_OTHER_SAMPLE)],
+    },
+    # One industry's partition, keyed by its dataset id, alongside the legacy root.
+    f"s2s-samples/{_DATASET}/index.json": [_PARTITIONED_SAMPLE],
+    f"s2s-samples/{_DATASET}/{_PARTITIONED_SAMPLE}/manifest.json": {
+        "schema_version": 2,
+        "bucket_at": _PARTITIONED_SAMPLE,
+        "dataset_id": _DATASET,
+        "test_case_id": "tc-cs",
+        "persona_name": "Standard Customer",
+        "recordings": [_recording(*_LIVE, sample_id=_PARTITIONED_SAMPLE, dataset_id=_DATASET)],
     },
 }
 
@@ -318,3 +333,63 @@ async def test_a_rejected_sample_id_is_never_cached(samples_client: AsyncClient)
     assert res.status_code == 422
     assert res.headers["cache-control"] == "private, no-store"
     assert "Authorization" in res.headers["vary"]
+
+
+# --- dataset partitions -----------------------------------------------------
+
+
+async def test_dataset_param_selects_that_partitions_index(samples_client: AsyncClient) -> None:
+    res = await samples_client.get("/v1/s2s/samples", params={"dataset": _DATASET})
+
+    assert res.status_code == 200
+    assert res.json() == [_PARTITIONED_SAMPLE]
+
+
+async def test_without_dataset_the_legacy_root_is_still_served(
+    samples_client: AsyncClient,
+) -> None:
+    """A dashboard that predates partitioning keeps its card until the root ages out."""
+    res = await samples_client.get("/v1/s2s/samples")
+
+    assert res.json() == [_SAMPLE, _OTHER_SAMPLE]
+    assert (await samples_client.get(f"/v1/s2s/samples/{_PARTITIONED_SAMPLE}")).status_code == 404
+
+
+async def test_partitioned_manifest_carries_its_dataset_into_the_audio_paths(
+    samples_client: AsyncClient,
+) -> None:
+    res = await samples_client.get(
+        f"/v1/s2s/samples/{_PARTITIONED_SAMPLE}", params={"dataset": _DATASET}
+    )
+
+    assert res.status_code == 200
+    body = res.json()
+    assert body["dataset_id"] == _DATASET
+    assert _pairs(body) == [_LIVE]
+    audio_path = body["recordings"][0]["audio_path"]
+    assert audio_path.endswith(f"?dataset={_DATASET}")
+
+    audio = await samples_client.get(audio_path)
+    assert audio.status_code == 200
+    assert (
+        audio.json()["url"]
+        == f"{_SIGNED}/s2s-samples/{_DATASET}/{_PARTITIONED_SAMPLE}/{_LIVE[0]}/{_LIVE[1]}.wav"
+    )
+
+
+async def test_a_recording_is_only_signed_inside_its_own_partition(
+    samples_client: AsyncClient,
+) -> None:
+    """The legacy sample's objects sit at the root, so asking for them under a
+    partition must refuse rather than sign a path outside that partition."""
+    res = await samples_client.get(
+        f"/v1/s2s/samples/{_SAMPLE}/{_LIVE[0]}/{_LIVE[1]}/audio", params={"dataset": _DATASET}
+    )
+
+    assert res.status_code == 404
+
+
+async def test_dataset_param_must_be_one_path_segment(samples_client: AsyncClient) -> None:
+    for bad in ("../other", "s2s/x", "Upper", ""):
+        res = await samples_client.get("/v1/s2s/samples", params={"dataset": bad})
+        assert res.status_code == 422, bad

--- a/runner/tests/unit/test_s2s_conditions.py
+++ b/runner/tests/unit/test_s2s_conditions.py
@@ -22,6 +22,22 @@ def test_noise_condition_excludes_latency() -> None:
     assert Metric.V2V not in noisy.fetched
 
 
+def test_bank_board_anchors_on_latency_and_carries_the_judge() -> None:
+    """Latency is on every Ultra Bank run; the expected-behaviors judge rides along
+    under the instruction metric so the adherence chart needs no second series."""
+    bank = conditions.condition_for(conditions.DATASET_ID_BANK)
+    assert bank.required is Metric.V2V
+    assert bank.optional == frozenset({Metric.INSTRUCTION_FOLLOWING, Metric.INTERRUPTION_RATE})
+    assert Metric.EXPECTED_BEHAVIOR_ADHERENCE not in bank.fetched
+    assert (
+        conditions.dataset_id_for(conditions.FAMILY_BANK, conditions.Condition.CLEAN)
+        == conditions.DATASET_ID_BANK
+    )
+    # The harder personas exist in Coval but are not ingested yet.
+    assert conditions.dataset_id_for(conditions.FAMILY_BANK, conditions.Condition.NOISY) is None
+    assert conditions.dataset_id_for(conditions.FAMILY_BANK, conditions.Condition.ACCENTED) is None
+
+
 def test_unmapped_dataset_keeps_the_pre_scoping_contract() -> None:
     legacy = conditions.condition_for(conditions.DATASET_ID)
     assert legacy == conditions.DEFAULT_CONDITION

--- a/runner/tests/unit/test_s2s_fetch.py
+++ b/runner/tests/unit/test_s2s_fetch.py
@@ -25,9 +25,14 @@ from coval_bench.registries import Benchmark, Metric
 from coval_bench.registries.models import RegisteredModel
 from coval_bench.s2s import fetch_v2v
 from coval_bench.s2s.conditions import (
+    DATASET_ID_BANK,
+    DATASET_ID_DENTAL,
+    DATASET_ID_INSTR_CUST_SERVICE,
     DATASET_ID_LLM_DENTAL,
     DATASET_ID_MULTITURN,
     DATASET_ID_MULTITURN_NOISY,
+    FAMILY_BANK,
+    FAMILY_DENTAL,
     FAMILY_HAPPYPATH,
     FAMILY_INSTR_HEALTH,
     FAMILY_LLM_DENTAL,
@@ -313,12 +318,36 @@ def test_expected_sample_models_excludes_non_publishing_agents() -> None:
         coval_s2s_gray_agent_id="a2",
         coval_s2s_red_agent_id="a3",
     )
-    expected = fetch_v2v._expected_sample_models(settings)
+    expected = fetch_v2v._expected_sample_models(settings, DATASET_ID_DENTAL)
 
     assert ("openai", "gpt-realtime") in expected
     assert ("colors", "gray") not in expected
     assert ("colors", "red") not in expected
     assert ("phonely", "phonely-agent") not in expected
+
+
+def test_expected_sample_models_are_scoped_to_the_dataset_partition() -> None:
+    """An agent counts only on its own dataset: a model absent from another set is
+    not a missing provider there, and industry agents never publish at all."""
+    settings = Settings.model_construct(
+        coval_s2s_openai_agent_id="a1",
+        coval_s2s_bank_openai_agent_id="b1",
+        coval_s2s_bank_gpt_live_agent_id="b2",
+        coval_s2s_bank_gemini_agent_id="b3",
+        coval_s2s_bank_xai_agent_id="b4",
+        coval_s2s_cust_service_openai_agent_id="c1",
+    )
+
+    assert fetch_v2v._expected_sample_models(settings, DATASET_ID_DENTAL) == {
+        ("openai", "gpt-realtime")
+    }
+    assert fetch_v2v._expected_sample_models(settings, DATASET_ID_BANK) == {
+        ("openai", "gpt-realtime"),
+        ("openai", "gpt-live-1"),
+        ("google", "gemini-live"),
+        ("xai", "grok-voice-think-fast-2.0"),
+    }
+    assert fetch_v2v._expected_sample_models(settings, DATASET_ID_INSTR_CUST_SERVICE) == set()
 
 
 def test_bucket_start_floors_to_grid() -> None:
@@ -1200,6 +1229,65 @@ async def test_samples_publish_without_the_shared_test_set(
     publish.assert_awaited_once()
     assert publish.await_args is not None
     assert publish.await_args.kwargs["test_set_id"] == "TSD"
+    assert publish.await_args.kwargs["dataset_id"] == DATASET_ID_DENTAL
+
+
+@pytest.mark.asyncio
+async def test_each_dataset_publishes_its_own_sample_tick(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Dental and the bank set never share a tick: each partition gets its own
+    publish with only its own runs and only its own expected models."""
+    monkeypatch.delenv("COVAL_S2S_GEMINI_AGENT_ID", raising=False)
+    settings = Settings(
+        coval_s2s_latency_metric_id="MID",
+        coval_s2s_openai_agent_id="a1",
+        coval_s2s_dental_test_set_id="TSD",
+        coval_s2s_bank_openai_agent_id="b1",
+        coval_s2s_bank_test_set_id="TSB",
+        coval_s2s_bank_instruction_metric_id="BIM",
+        s2s_samples_bucket="bucket",
+    )
+
+    writer = _stub_writer()
+    list_json = _list_json({"run_id": "R1", "create_time": _iso(timedelta(hours=1))})
+    run_json = {
+        "run": {
+            "error_status": "SUCCESS",
+            "results": {
+                "metrics": {
+                    "MID": {"values": [{"simulation_output_id": "s1", "value": 0.5}]},
+                    "BIM": {"values": [{"simulation_output_id": "s1", "value": 0.75}]},
+                }
+            },
+        }
+    }
+    client = _fake_client(list_json, run_json)
+
+    @contextlib.asynccontextmanager
+    async def _fake_pool(_settings: Any) -> AsyncIterator[MagicMock]:
+        yield MagicMock()
+
+    publish = AsyncMock(return_value=1)
+    monkeypatch.setattr(fetch_v2v, "_client", lambda _s: client)
+    monkeypatch.setattr(fetch_v2v, "lifespan_pool", _fake_pool)
+    monkeypatch.setattr(fetch_v2v, "RunWriter", lambda _pool: writer)
+    monkeypatch.setattr(fetch_v2v, "publish_tick_sample", publish)
+
+    await fetch_v2v.fetch_and_write_v2v(settings)
+
+    calls = {c.kwargs["dataset_id"]: c.kwargs for c in publish.await_args_list}
+    assert set(calls) == {DATASET_ID_DENTAL, DATASET_ID_BANK}
+    dental, bank = calls[DATASET_ID_DENTAL], calls[DATASET_ID_BANK]
+    assert dental["test_set_id"] == "TSD"
+    assert {r.key for r in dental["runs"]} == {("openai", "gpt-realtime")}
+    assert dental["expected_models"] == {("openai", "gpt-realtime")}
+    assert bank["test_set_id"] == "TSB"
+    assert all(r.dataset_id == DATASET_ID_BANK for r in bank["runs"])
+    assert bank["expected_models"] == {("openai", "gpt-realtime")}
+    # The bank run's judge fraction landed as a percentage under the instruction metric.
+    rows = [r for call in writer.record_results.await_args_list for r in call.args[0]]
+    assert [r.metric_value for r in rows if r.metric_type == "InstructionFollowing"] == [75.0]
 
 
 @pytest.mark.asyncio
@@ -1651,6 +1739,28 @@ async def test_fetch_and_write_rejects_a_metric_with_no_row_builder(
     )
     with pytest.raises(RuntimeError, match="no _VALUE_MAPPERS entry"):
         await fetch_v2v.fetch_and_write_v2v(settings)
+
+
+def test_instruction_value_scales_a_judge_fraction_to_percent() -> None:
+    assert fetch_v2v._instruction_value(0.75) == (75.0, ResultStatus.SUCCESS)
+    assert fetch_v2v._instruction_value(1) == (100.0, ResultStatus.SUCCESS)
+    assert fetch_v2v._instruction_value(0.0) == (0.0, ResultStatus.SUCCESS)
+    assert fetch_v2v._instruction_value(0.3333333333333333) == (
+        33.33333333333333,
+        ResultStatus.SUCCESS,
+    )
+    assert fetch_v2v._instruction_value("YES") == (100.0, ResultStatus.SUCCESS)
+    assert fetch_v2v._instruction_value("UNKNOWN") is None
+    with pytest.raises(fetch_v2v.InvalidInstructionVerdict):
+        fetch_v2v._instruction_value(1.5)
+    with pytest.raises(fetch_v2v.InvalidInstructionVerdict):
+        fetch_v2v._instruction_value(True)
+
+
+def test_latency_metric_is_required_only_for_a_family_that_fetches_it() -> None:
+    assert fetch_v2v._fetches_v2v(FAMILY_BANK)
+    assert fetch_v2v._fetches_v2v(FAMILY_DENTAL)
+    assert not fetch_v2v._fetches_v2v(FAMILY_INSTR_HEALTH)
 
 
 def test_interruption_value_maps() -> None:

--- a/runner/tests/unit/test_s2s_sample_store.py
+++ b/runner/tests/unit/test_s2s_sample_store.py
@@ -45,16 +45,19 @@ def _manifest(*recordings: dict[str, Any]) -> dict[str, Any]:
 
 def test_load_sample_ids_newest_first() -> None:
     client = _FakeClient({"s2s-samples/index.json": ["2026-07-28T00:00:00Z", _SAMPLE]})
-    assert load_sample_ids(_BUCKET, storage_client=client) == [_SAMPLE, "2026-07-28T00:00:00Z"]
+    assert load_sample_ids(_BUCKET, None, storage_client=client) == [
+        _SAMPLE,
+        "2026-07-28T00:00:00Z",
+    ]
 
 
 def test_load_sample_ids_missing_index_is_empty() -> None:
-    assert load_sample_ids(_BUCKET, storage_client=_FakeClient({})) == []
+    assert load_sample_ids(_BUCKET, None, storage_client=_FakeClient({})) == []
 
 
 def test_load_sample_ids_drops_non_strings() -> None:
     client = _FakeClient({"s2s-samples/index.json": [_SAMPLE, 7, None]})
-    assert load_sample_ids(_BUCKET, storage_client=client) == [_SAMPLE]
+    assert load_sample_ids(_BUCKET, None, storage_client=client) == [_SAMPLE]
 
 
 # --- load_sample: the embargo filter ----------------------------------------
@@ -69,7 +72,7 @@ def test_load_sample_strips_hidden_recordings() -> None:
         }
     )
 
-    sample = load_sample(_BUCKET, _SAMPLE, hidden=_HIDDEN, storage_client=client)
+    sample = load_sample(_BUCKET, None, _SAMPLE, hidden=_HIDDEN, storage_client=client)
 
     assert sample is not None
     assert [(r["provider"], r["model"]) for r in sample["recordings"]] == [
@@ -80,7 +83,7 @@ def test_load_sample_strips_hidden_recordings() -> None:
 def test_load_sample_hidden_recording_takes_its_transcript_with_it() -> None:
     client = _FakeClient({_MANIFEST_KEY: _manifest(_recording("xai", "grok-voice-think-fast-1.0"))})
 
-    sample = load_sample(_BUCKET, _SAMPLE, hidden=_HIDDEN, storage_client=client)
+    sample = load_sample(_BUCKET, None, _SAMPLE, hidden=_HIDDEN, storage_client=client)
 
     assert sample is not None
     assert sample["recordings"] == []
@@ -96,7 +99,7 @@ def test_load_sample_keeps_everything_for_an_unrestricted_caller() -> None:
         }
     )
 
-    sample = load_sample(_BUCKET, _SAMPLE, hidden=frozenset(), storage_client=client)
+    sample = load_sample(_BUCKET, None, _SAMPLE, hidden=frozenset(), storage_client=client)
 
     assert sample is not None
     assert len(sample["recordings"]) == 2
@@ -120,7 +123,7 @@ def test_load_sample_tolerates_v1_manifests() -> None:
     }
     client = _FakeClient({_MANIFEST_KEY: v1})
 
-    sample = load_sample(_BUCKET, _SAMPLE, hidden=_HIDDEN, storage_client=client)
+    sample = load_sample(_BUCKET, None, _SAMPLE, hidden=_HIDDEN, storage_client=client)
 
     assert sample is not None
     assert len(sample["recordings"]) == 1
@@ -132,7 +135,7 @@ def test_load_sample_drops_recordings_without_an_object() -> None:
     del broken["recordings"][0]["object"]
     client = _FakeClient({_MANIFEST_KEY: broken})
 
-    sample = load_sample(_BUCKET, _SAMPLE, hidden=frozenset(), storage_client=client)
+    sample = load_sample(_BUCKET, None, _SAMPLE, hidden=frozenset(), storage_client=client)
 
     assert sample is not None
     assert sample["recordings"] == []
@@ -143,7 +146,7 @@ def test_load_sample_drops_an_object_from_another_sample() -> None:
     strayed["recordings"][0]["object"] = "s2s-samples/2026-01-01T00:00:00Z/openai.wav"
     client = _FakeClient({_MANIFEST_KEY: strayed})
 
-    sample = load_sample(_BUCKET, _SAMPLE, hidden=frozenset(), storage_client=client)
+    sample = load_sample(_BUCKET, None, _SAMPLE, hidden=frozenset(), storage_client=client)
 
     assert sample is not None
     assert sample["recordings"] == []
@@ -154,7 +157,7 @@ def test_load_sample_drops_an_object_that_is_not_audio() -> None:
     strayed["recordings"][0]["object"] = _MANIFEST_KEY
     client = _FakeClient({_MANIFEST_KEY: strayed})
 
-    sample = load_sample(_BUCKET, _SAMPLE, hidden=frozenset(), storage_client=client)
+    sample = load_sample(_BUCKET, None, _SAMPLE, hidden=frozenset(), storage_client=client)
 
     assert sample is not None
     assert sample["recordings"] == []
@@ -165,14 +168,17 @@ def test_load_sample_drops_a_traversing_object() -> None:
     strayed["recordings"][0]["object"] = f"s2s-samples/{_SAMPLE}/../../secrets/leak.wav"
     client = _FakeClient({_MANIFEST_KEY: strayed})
 
-    sample = load_sample(_BUCKET, _SAMPLE, hidden=frozenset(), storage_client=client)
+    sample = load_sample(_BUCKET, None, _SAMPLE, hidden=frozenset(), storage_client=client)
 
     assert sample is not None
     assert sample["recordings"] == []
 
 
 def test_load_sample_missing_manifest_is_none() -> None:
-    assert load_sample(_BUCKET, _SAMPLE, hidden=frozenset(), storage_client=_FakeClient({})) is None
+    assert (
+        load_sample(_BUCKET, None, _SAMPLE, hidden=frozenset(), storage_client=_FakeClient({}))
+        is None
+    )
 
 
 # --- audio_object_key: the check the redirect route relies on ---------------
@@ -182,7 +188,7 @@ def test_audio_object_key_returns_the_stored_path() -> None:
     client = _FakeClient({_MANIFEST_KEY: _manifest(_recording("openai", "gpt-realtime"))})
 
     key = audio_object_key(
-        _BUCKET, _SAMPLE, "openai", "gpt-realtime", hidden=frozenset(), storage_client=client
+        _BUCKET, None, _SAMPLE, "openai", "gpt-realtime", hidden=frozenset(), storage_client=client
     )
 
     assert key == f"s2s-samples/{_SAMPLE}/openai/gpt-realtime.wav"
@@ -192,7 +198,13 @@ def test_audio_object_key_refuses_a_hidden_model() -> None:
     client = _FakeClient({_MANIFEST_KEY: _manifest(_recording("xai", "grok-voice-think-fast-1.0"))})
 
     key = audio_object_key(
-        _BUCKET, _SAMPLE, "xai", "grok-voice-think-fast-1.0", hidden=_HIDDEN, storage_client=client
+        _BUCKET,
+        None,
+        _SAMPLE,
+        "xai",
+        "grok-voice-think-fast-1.0",
+        hidden=_HIDDEN,
+        storage_client=client,
     )
 
     assert key is None
@@ -205,6 +217,7 @@ def test_audio_object_key_refuses_an_object_outside_the_sample() -> None:
 
     key = audio_object_key(
         _BUCKET,
+        None,
         _SAMPLE,
         "openai",
         "gpt-realtime",
@@ -219,7 +232,7 @@ def test_audio_object_key_unknown_model_is_none() -> None:
     client = _FakeClient({_MANIFEST_KEY: _manifest(_recording("openai", "gpt-realtime"))})
 
     key = audio_object_key(
-        _BUCKET, _SAMPLE, "openai", "no-such-model", hidden=frozenset(), storage_client=client
+        _BUCKET, None, _SAMPLE, "openai", "no-such-model", hidden=frozenset(), storage_client=client
     )
 
     assert key is None
@@ -228,6 +241,7 @@ def test_audio_object_key_unknown_model_is_none() -> None:
 def test_audio_object_key_missing_manifest_is_none() -> None:
     key = audio_object_key(
         _BUCKET,
+        None,
         _SAMPLE,
         "openai",
         "gpt-realtime",

--- a/runner/tests/unit/test_s2s_samples.py
+++ b/runner/tests/unit/test_s2s_samples.py
@@ -25,6 +25,8 @@ TICK = "2026-07-17T00:00:00Z"
 PREV_BUCKET_AT = datetime(2026, 7, 16, tzinfo=UTC)
 PREV_TICK = "2026-07-16T00:00:00Z"
 TEST_SET = "DvAqQ4md"
+DATASET = "s2s-dental-v1"
+PARTITION = f"{PREFIX}/{DATASET}"
 
 # Real bench persona ids so the label map is exercised too.
 FEMALE = "PN3xgmsqeLDjsNNEA2e55e"
@@ -46,6 +48,7 @@ def _run(
         bucket_at=bucket_at,
         persona_id=persona_id,
         agent_id=agent_id,
+        dataset_id=DATASET,
     )
 
 
@@ -167,6 +170,7 @@ async def _publish(
     return await publish_tick_sample(
         client,
         bucket_name="bkt",
+        dataset_id=DATASET,
         test_set_id=TEST_SET,
         runs=runs,
         rng=random.Random(rng_seed),
@@ -186,7 +190,7 @@ async def test_manifest_labels_the_set_the_runs_came_from() -> None:
     async with _fake_client(cases) as client:
         await _publish(client, storage_client, runs)
 
-    manifest = json.loads(bucket.objects[f"{PREFIX}/{TICK}/manifest.json"])
+    manifest = json.loads(bucket.objects[f"{PARTITION}/{TICK}/manifest.json"])
     assert manifest["test_set_id"] == "OWN_SET"
 
 
@@ -198,10 +202,10 @@ async def test_publishes_complete_conversation_for_all_providers() -> None:
         stored = await _publish(client, storage_client, _runs())
 
     assert stored == 2
-    assert f"{PREFIX}/{TICK}/openai/gpt-realtime.wav" in bucket.objects
-    assert f"{PREFIX}/{TICK}/google/gemini-live.wav" in bucket.objects
+    assert f"{PARTITION}/{TICK}/openai/gpt-realtime.wav" in bucket.objects
+    assert f"{PARTITION}/{TICK}/google/gemini-live.wav" in bucket.objects
 
-    manifest = json.loads(bucket.objects[f"{PREFIX}/{TICK}/manifest.json"])
+    manifest = json.loads(bucket.objects[f"{PARTITION}/{TICK}/manifest.json"])
     assert manifest["schema_version"] == 2
     assert manifest["bucket_at"] == TICK
     assert manifest["test_set_id"] == TEST_SET
@@ -217,7 +221,7 @@ async def test_publishes_complete_conversation_for_all_providers() -> None:
         assert [t["start_offset"] for t in rec["turns"]] == [1.5, 3.0]
         assert [t["end_offset"] for t in rec["turns"]] == [2.25, None]
 
-    assert json.loads(bucket.objects[samples.INDEX_KEY]) == [TICK]
+    assert json.loads(bucket.objects[samples.index_key(DATASET)]) == [TICK]
 
 
 @pytest.mark.asyncio
@@ -229,7 +233,7 @@ async def test_conversation_key_never_mixes_personas() -> None:
         stored = await _publish(client, storage_client, _runs())
 
     assert stored == 2
-    manifest = json.loads(bucket.objects[f"{PREFIX}/{TICK}/manifest.json"])
+    manifest = json.loads(bucket.objects[f"{PARTITION}/{TICK}/manifest.json"])
     assert (manifest["persona_name"], manifest["test_case_id"]) in {
         ("Standard Female", "b"),
         ("Standard Male", "d"),
@@ -245,7 +249,7 @@ async def test_incomplete_persona_is_skipped_and_other_is_published() -> None:
         stored = await _publish(client, storage_client, _runs())
 
     assert stored == 2
-    manifest = json.loads(bucket.objects[f"{PREFIX}/{TICK}/manifest.json"])
+    manifest = json.loads(bucket.objects[f"{PARTITION}/{TICK}/manifest.json"])
     assert manifest["persona_name"] == "Standard Male"
     assert manifest["test_case_id"] == "c"
     assert {r["provider"] for r in manifest["recordings"]} == {"openai", "google"}
@@ -265,7 +269,7 @@ async def test_failed_sim_drops_its_test_case_from_the_pool() -> None:
         stored = await _publish(client, storage_client, _runs())
 
     assert stored == 2
-    manifest = json.loads(bucket.objects[f"{PREFIX}/{TICK}/manifest.json"])
+    manifest = json.loads(bucket.objects[f"{PARTITION}/{TICK}/manifest.json"])
     assert (manifest["persona_name"], manifest["test_case_id"]) == ("Standard Male", "c")
 
 
@@ -278,7 +282,7 @@ async def test_no_complete_conversation_publishes_nothing() -> None:
         stored = await _publish(client, storage_client, _runs())
 
     assert stored == 0
-    assert f"{PREFIX}/{TICK}/manifest.json" not in bucket.objects
+    assert f"{PARTITION}/{TICK}/manifest.json" not in bucket.objects
 
 
 @pytest.mark.asyncio
@@ -307,7 +311,7 @@ async def test_persona_missing_a_provider_is_skipped() -> None:
         stored = await _publish(client, storage_client, _runs(include_google_male=False))
 
     assert stored == 2
-    manifest = json.loads(bucket.objects[f"{PREFIX}/{TICK}/manifest.json"])
+    manifest = json.loads(bucket.objects[f"{PARTITION}/{TICK}/manifest.json"])
     assert manifest["persona_name"] == "Standard Female"
 
 
@@ -325,25 +329,25 @@ async def test_no_shared_conversation_stores_nothing() -> None:
 @pytest.mark.asyncio
 async def test_existing_manifest_is_never_overwritten() -> None:
     storage_client, bucket = _fake_storage()
-    bucket.objects[f"{PREFIX}/{TICK}/manifest.json"] = b'{"sentinel": true}'
+    bucket.objects[f"{PARTITION}/{TICK}/manifest.json"] = b'{"sentinel": true}'
     cases = {"RO_F": ["b"], "RG_F": ["b"], "RO_M": ["b"], "RG_M": ["b"]}
     async with _fake_client(cases) as client:
         stored = await _publish(client, storage_client, _runs())
 
     assert stored == 0
-    assert bucket.objects[f"{PREFIX}/{TICK}/manifest.json"] == b'{"sentinel": true}'
-    assert json.loads(bucket.objects[samples.INDEX_KEY]) == [TICK]  # index repaired
+    assert bucket.objects[f"{PARTITION}/{TICK}/manifest.json"] == b'{"sentinel": true}'
+    assert json.loads(bucket.objects[samples.index_key(DATASET)]) == [TICK]  # index repaired
 
 
 @pytest.mark.asyncio
 async def test_index_keeps_existing_history() -> None:
     storage_client, bucket = _fake_storage()
-    bucket.objects[samples.INDEX_KEY] = json.dumps([PREV_TICK]).encode()
+    bucket.objects[samples.index_key(DATASET)] = json.dumps([PREV_TICK]).encode()
     cases = {"RO_F": ["b"], "RG_F": ["b"], "RO_M": ["b"], "RG_M": ["b"]}
     async with _fake_client(cases) as client:
         await _publish(client, storage_client, _runs())
 
-    assert json.loads(bucket.objects[samples.INDEX_KEY]) == [TICK, PREV_TICK]
+    assert json.loads(bucket.objects[samples.index_key(DATASET)]) == [TICK, PREV_TICK]
 
 
 @pytest.mark.asyncio
@@ -355,13 +359,13 @@ async def test_index_stays_newest_first_when_an_older_day_lands_later() -> None:
     """
     storage_client, bucket = _fake_storage()
     newer = ["2026-07-27T00:00:00Z", TICK]
-    bucket.objects[samples.INDEX_KEY] = json.dumps(newer).encode()
+    bucket.objects[samples.index_key(DATASET)] = json.dumps(newer).encode()
     runs = _runs_on(PREV_BUCKET_AT, "_Y")
     cases = {r.coval_run_id: ["b"] for r in runs}
     async with _fake_client(cases) as client:
         await _publish(client, storage_client, runs)
 
-    assert json.loads(bucket.objects[samples.INDEX_KEY]) == [*newer, PREV_TICK]
+    assert json.loads(bucket.objects[samples.index_key(DATASET)]) == [*newer, PREV_TICK]
 
 
 @pytest.mark.asyncio
@@ -390,13 +394,13 @@ async def test_missed_day_publishes_alongside_the_current_tick() -> None:
 
     assert stored == 4  # two providers x two days
     for tick in (PREV_TICK, TICK):
-        manifest = json.loads(bucket.objects[f"{PREFIX}/{tick}/manifest.json"])
+        manifest = json.loads(bucket.objects[f"{PARTITION}/{tick}/manifest.json"])
         assert manifest["bucket_at"] == tick
         assert {r["provider"] for r in manifest["recordings"]} == {"openai", "google"}
-        assert f"{PREFIX}/{tick}/openai/gpt-realtime.wav" in bucket.objects
-        assert f"{PREFIX}/{tick}/google/gemini-live.wav" in bucket.objects
+        assert f"{PARTITION}/{tick}/openai/gpt-realtime.wav" in bucket.objects
+        assert f"{PARTITION}/{tick}/google/gemini-live.wav" in bucket.objects
     # Published oldest-first, so the index ends up newest-first.
-    assert json.loads(bucket.objects[f"{PREFIX}/index.json"]) == [TICK, PREV_TICK]
+    assert json.loads(bucket.objects[samples.index_key(DATASET)]) == [TICK, PREV_TICK]
 
 
 @pytest.mark.asyncio
@@ -424,10 +428,10 @@ async def test_bucket_missing_an_expected_provider_publishes_nothing() -> None:
 
     # Today is complete and publishes; yesterday is refused outright.
     assert stored == 2
-    assert f"{PREFIX}/{TICK}/manifest.json" in bucket.objects
-    assert f"{PREFIX}/{PREV_TICK}/manifest.json" not in bucket.objects
-    assert f"{PREFIX}/{PREV_TICK}/openai/gpt-realtime.wav" not in bucket.objects
-    assert json.loads(bucket.objects[samples.INDEX_KEY]) == [TICK]
+    assert f"{PARTITION}/{TICK}/manifest.json" in bucket.objects
+    assert f"{PARTITION}/{PREV_TICK}/manifest.json" not in bucket.objects
+    assert f"{PARTITION}/{PREV_TICK}/openai/gpt-realtime.wav" not in bucket.objects
+    assert json.loads(bucket.objects[samples.index_key(DATASET)]) == [TICK]
 
 
 @pytest.mark.asyncio
@@ -441,7 +445,7 @@ async def test_published_day_is_reindexed_even_when_a_provider_is_absent() -> No
     """
     storage_client, bucket = _fake_storage()
     already_there = b'{"schema_version": 2, "bucket_at": "2026-07-16T00:00:00Z"}'
-    bucket.objects[f"{PREFIX}/{PREV_TICK}/manifest.json"] = already_there
+    bucket.objects[f"{PARTITION}/{PREV_TICK}/manifest.json"] = already_there
     # Only openai remains for that day, so the provider gate would otherwise fire.
     openai_only = [_run("openai", "gpt-realtime", "RO_F_Y", FEMALE, "AO", PREV_BUCKET_AT)]
     cases = {r.coval_run_id: ["b"] for r in openai_only}
@@ -454,26 +458,26 @@ async def test_published_day_is_reindexed_even_when_a_provider_is_absent() -> No
         )
 
     assert stored == 0
-    assert bucket.objects[f"{PREFIX}/{PREV_TICK}/manifest.json"] == already_there
-    assert json.loads(bucket.objects[samples.INDEX_KEY]) == [PREV_TICK]
+    assert bucket.objects[f"{PARTITION}/{PREV_TICK}/manifest.json"] == already_there
+    assert json.loads(bucket.objects[samples.index_key(DATASET)]) == [PREV_TICK]
 
 
 @pytest.mark.asyncio
 async def test_recovery_never_overwrites_an_existing_manifest() -> None:
     storage_client, bucket = _fake_storage()
     already_there = b'{"schema_version": 2, "bucket_at": "2026-07-16T00:00:00Z"}'
-    bucket.objects[f"{PREFIX}/{PREV_TICK}/manifest.json"] = already_there
+    bucket.objects[f"{PARTITION}/{PREV_TICK}/manifest.json"] = already_there
     runs = _runs_on(PREV_BUCKET_AT, "_Y") + _runs_on(BUCKET_AT, "_T")
     cases = {r.coval_run_id: ["b", "c"] for r in runs}
     async with _fake_client(cases) as client:
         stored = await _publish(client, storage_client, runs)
 
     assert stored == 2  # only the current tick
-    assert bucket.objects[f"{PREFIX}/{PREV_TICK}/manifest.json"] == already_there
-    assert f"{PREFIX}/{PREV_TICK}/openai/gpt-realtime.wav" not in bucket.objects
-    assert f"{PREFIX}/{TICK}/manifest.json" in bucket.objects
+    assert bucket.objects[f"{PARTITION}/{PREV_TICK}/manifest.json"] == already_there
+    assert f"{PARTITION}/{PREV_TICK}/openai/gpt-realtime.wav" not in bucket.objects
+    assert f"{PARTITION}/{TICK}/manifest.json" in bucket.objects
     # The existing day is still repaired into the index.
-    assert PREV_TICK in json.loads(bucket.objects[f"{PREFIX}/index.json"])
+    assert PREV_TICK in json.loads(bucket.objects[samples.index_key(DATASET)])
 
 
 @pytest.mark.asyncio
@@ -488,8 +492,8 @@ async def test_an_unusable_day_does_not_block_the_other() -> None:
         stored = await _publish(client, storage_client, runs)
 
     assert stored == 2
-    assert f"{PREFIX}/{PREV_TICK}/manifest.json" not in bucket.objects
-    assert f"{PREFIX}/{TICK}/manifest.json" in bucket.objects
+    assert f"{PARTITION}/{PREV_TICK}/manifest.json" not in bucket.objects
+    assert f"{PARTITION}/{TICK}/manifest.json" in bucket.objects
 
 
 def test_conversation_turns_coerces_offsets() -> None:
@@ -540,3 +544,32 @@ async def test_failed_recording_download_keeps_the_signature_out_of_the_error(
     assert "https://blobs.test/recordings/sim-1.wav" in message
     assert str(status) in message
     assert "sim-1" in message
+
+
+@pytest.mark.asyncio
+async def test_manifest_and_objects_live_in_the_dataset_partition() -> None:
+    """The dataset id is the partition: nothing lands at the pre-partition root."""
+    client = _fake_client({"RO_F": ["tc1"], "RO_M": ["tc1"], "RG_F": ["tc1"], "RG_M": ["tc1"]})
+    storage_client, bucket = _fake_storage()
+
+    await _publish(client, storage_client, _runs())
+
+    manifest = json.loads(bucket.objects[f"{PARTITION}/{TICK}/manifest.json"])
+    assert manifest["dataset_id"] == DATASET
+    assert f"{PREFIX}/{TICK}/manifest.json" not in bucket.objects
+    assert f"{PREFIX}/index.json" not in bucket.objects
+    assert all(key.startswith(f"{PARTITION}/") for key in bucket.objects)
+
+
+def test_readers_follow_the_partition_and_the_legacy_root() -> None:
+    assert samples.sample_prefix(None) == PREFIX
+    assert samples.index_key(None) == f"{PREFIX}/index.json"
+    assert samples.index_key("instruction-adherence-health-v1") == (
+        f"{PREFIX}/instruction-adherence-health-v1/index.json"
+    )
+    legacy = f"{PREFIX}/{TICK}/openai/gpt-realtime.wav"
+    partitioned = f"{PARTITION}/{TICK}/openai/gpt-realtime.wav"
+    assert samples._own_audio_object(legacy, None, TICK)
+    assert not samples._own_audio_object(legacy, DATASET, TICK)
+    assert samples._own_audio_object(partitioned, DATASET, TICK)
+    assert not samples._own_audio_object(partitioned, None, TICK)


### PR DESCRIPTION
test set( from dental to bank), 
metrics ( better instruction adherence metric),
 persona ( clean speech persona only for now) ,  
agent setup changes ( according to the per agent documentation prompting)  are wired up here for S2S.

 The leaderboard pins S2S to s2s-bank-v1; dental and the multi-turn set stay reachable through the aggregates dataset parameter.

there's also migration to put some models back to EA.

Settings added for Terraform include some id changes.I will get this cleaned up once I get to work a bit more on putting these as assets in the repo. please deal with it for now)

