### PR TITLE
ci: avoid duplicate ready-for-review runs

### DIFF
--- a/.github/workflows/switchboard.yml
+++ b/.github/workflows/switchboard.yml
@@ -3,7 +3,7 @@ name: Switchboard
 on:
   pull_request:
     branches: [main]
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened]
   merge_group:
     types: [checks_requested]
   workflow_dispatch:


### PR DESCRIPTION
## Summary

Stop redispatching the Switchboard gate when a draft PR is marked ready.

## Why

Draft opened events and every synchronize event already run this workflow. Marking the PR ready does not change its head SHA, so the extra dispatch duplicates exact-head CI without adding coverage.

## Validation

- actionlint on the changed workflow